### PR TITLE
Keep async scheduling samples GPU-resident

### DIFF
--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -2130,6 +2130,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         *,
         construct_graph_dimensions: Optional[InferenceBatchDimensions] = None,
         is_expert_parallel_dummy_cuda_graph_step: bool = False,
+        skip_token_input_ids_transfer: bool = False,
     ) -> None:
         """Initialize attention state so that every layer can use it.
 
@@ -2138,6 +2139,8 @@ class DynamicInferenceContext(BaseInferenceContext):
                 The graph config to use for constructing the cuda graphs.
             is_expert_parallel_dummy_cuda_graph_step (bool):
                 Whether this is a dummy expert model parallel step.
+            skip_token_input_ids_transfer (bool): If true, leave the GPU
+                token_to_input_ids field unchanged during bookkeeping transfer.
         Return:
             None.
         """
@@ -2377,12 +2380,11 @@ class DynamicInferenceContext(BaseInferenceContext):
         # No-op when the queue is already empty (regular non-warmup steps).
         self._execute_pending_mamba_ops()
 
-        # Run the H2D transfer here so callers that bypass the controller
-        # (e.g. unit tests that call `model.forward()` directly after
-        # `initialize_attention_state()`) see populated GPU bookkeeping. The
-        # text-generation controller still calls `transfer_bookkeeping_to_gpu`
-        # explicitly; that second call is a cheap idempotent re-copy.
-        self.transfer_bookkeeping_to_gpu()
+        # Run the H2D transfer here so every caller sees populated GPU
+        # bookkeeping immediately after initialize_attention_state().
+        self.transfer_bookkeeping_to_gpu(
+            skip_token_input_ids=skip_token_input_ids_transfer
+        )
 
     def _execute_pending_mamba_ops(self) -> None:
         """Execute Mamba GPU operations deferred from add_request() / update_requests().
@@ -2408,7 +2410,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             self.mamba_ssm_states[:, indices] = 0.0
             self._pending_mamba_zeros.clear()
 
-    def transfer_bookkeeping_to_gpu(self) -> None:
+    def transfer_bookkeeping_to_gpu(self, skip_token_input_ids: bool = False) -> None:
         """Batch transfer CPU bookkeeping state to GPU staging buffers.
 
         Called after initialize_attention_state() and before the forward pass.
@@ -2420,6 +2422,11 @@ class DynamicInferenceContext(BaseInferenceContext):
         Request-level staging slots are refreshed from the persistent CPU
         tensors immediately before the H2D (GPU reads them at `[:n_active]`
         while CPU bookkeeping keeps them at `[paused_count:total_count)`).
+
+        Args:
+            skip_token_input_ids (bool): If true, leave
+                `gpu_view.token_to_input_ids` unchanged while copying the rest
+                of the bookkeeping buffer.
         """
         n_active = self.total_request_count - self.paused_request_count
         active_slice = slice(self.paused_request_count, self.total_request_count)
@@ -2456,8 +2463,19 @@ class DynamicInferenceContext(BaseInferenceContext):
         # Coalesced H2D: one cudaMemcpyAsync for the entire bookkeeping buffer.
         # Copying the whole (max_tokens + max_requests)-sized buffer including
         # unused slots is cheap (~71 KB total, ~3-5 us on PCIe Gen4) and saves
-        # 8 redundant launch overheads vs. the prior per-field copies.
-        self.gpu_view._buf.copy_(self._cpu_bookkeeping_buf, non_blocking=True)
+        # redundant launch overheads vs. per-field copies. Async scheduling
+        # decode steps skip token_to_input_ids here because sampled tokens are
+        # already GPU-resident and copied directly into the GPU input buffer.
+        if skip_token_input_ids:
+            token_to_input_ids_offset = (
+                self.token_to_input_ids.numel() * self.token_to_input_ids.element_size()
+            )
+        else:
+            token_to_input_ids_offset = 0
+        self.gpu_view._buf[token_to_input_ids_offset:].copy_(
+            self._cpu_bookkeeping_buf[token_to_input_ids_offset:],
+            non_blocking=True,
+        )
 
         # MHA metadata GPU views were already bound to state_data in
         # initialize_attention_state(); the H2D above populates the underlying
@@ -2467,6 +2485,27 @@ class DynamicInferenceContext(BaseInferenceContext):
         if hasattr(self, '_pending_mamba_transfer') and self._pending_mamba_transfer is not None:
             self.mamba_metadata.load_from_cpu(self._pending_mamba_transfer)
             self._pending_mamba_transfer = None
+
+    def copy_async_sched_input_tokens_to_gpu(self, sampled_tokens_cuda: Tensor) -> None:
+        """Populate GPU input token IDs from sampled CUDA tokens for async scheduled decode.
+
+        Async scheduling keeps sampled tokens GPU-resident for the next decode
+        forward. CPU bookkeeping is still prepared normally, but forward input
+        IDs are patched directly from the sampled CUDA tensor.
+
+        Args:
+            sampled_tokens_cuda (Tensor): 1D CUDA tensor containing one sampled
+                token per active decode request.
+        """
+        active_request_count = self.total_request_count - self.paused_request_count
+
+        self.gpu_view.token_to_input_ids[:active_request_count].copy_(
+            sampled_tokens_cuda, non_blocking=True
+        )
+        if active_request_count < self.padded_active_token_count:
+            self.gpu_view.token_to_input_ids[
+                active_request_count : self.padded_active_token_count
+            ].zero_()
 
     def reset_tensors(self) -> None:
         """Fill all bookkeeping tensors with sentinel values."""

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -2141,8 +2141,6 @@ class DynamicInferenceContext(BaseInferenceContext):
                 Whether this is a dummy expert model parallel step.
             skip_token_input_ids_transfer (bool): If true, leave the GPU
                 token_to_input_ids field unchanged during bookkeeping transfer.
-        Return:
-            None.
         """
         # Launch deferred Mamba GPU ops first (state zeroing/restore) so they
         # overlap with the CPU work below.  These are non-blocking GPU kernels.

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -621,6 +621,7 @@ class TextGenerationController:
         self,
         construct_graph_dimensions: Optional[InferenceBatchDimensions] = None,
         is_dummy_forward: bool = False,
+        skip_token_input_ids_transfer: bool = False,
     ):
         """Initializes the inference context for dynamic batching.
 
@@ -628,6 +629,9 @@ class TextGenerationController:
             construct_graph_dimensions (Optional[InferenceBatchDimensions]): The graph config to use
                 for constructing the cuda graphs.
             is_dummy_forward (bool): Whether we are running an expert parallel dummy forward pass
+            skip_token_input_ids_transfer (bool): If true, do not copy CPU
+                token_to_input_ids into GPU bookkeeping. The caller must
+                populate GPU input token IDs before forward.
 
         Return:
             input_ids (Tensor): The active input IDs.
@@ -639,17 +643,13 @@ class TextGenerationController:
         unwrapped_model = unwrap_model(self.inference_wrapped_model.model)
         model_config = get_model_config(unwrapped_model)
 
-        # Initialize attention state (100% CPU computation).
+        # Initialize attention state and publish CPU bookkeeping to GPU.
         range_push("initialize_attention_state")
         context.initialize_attention_state(
             construct_graph_dimensions=construct_graph_dimensions,
             is_expert_parallel_dummy_cuda_graph_step=is_dummy_forward,
+            skip_token_input_ids_transfer=skip_token_input_ids_transfer,
         )
-        range_pop()
-
-        # Single batch CPU-to-GPU transfer of bookkeeping state.
-        range_push("transfer_bookkeeping_to_gpu")
-        context.transfer_bookkeeping_to_gpu()
         range_pop()
 
         set_moe_metadata_sync(unwrapped_model)
@@ -757,18 +757,26 @@ class TextGenerationController:
         else:
             self._all_logits_cuda = logits
 
-    def _run_async_sched_prepare(self, new_sample_copy: Tensor) -> Tuple[Tensor, Tensor]:
+    def _run_async_sched_prepare(
+        self, new_sample_copy: Tensor, sampled_tokens_cuda: Tensor
+    ) -> Tuple[Tensor, Tensor]:
         """Prepare decode requests and GPU-visible forward state for async scheduling.
 
         Args:
             new_sample_copy (Tensor): CPU copy of sampled tokens for active requests.
+            sampled_tokens_cuda (Tensor): GPU-resident sampled tokens to use as
+                input IDs for the speculative forward.
 
         Returns:
             Tuple[Tensor, Tensor]: Input token IDs and position IDs for the speculative forward.
         """
         context = self.inference_wrapped_model.inference_context
         context.prepare_requests(new_sample_copy)
-        return self._dynamic_step_context_init()
+        input_ids, position_ids = self._dynamic_step_context_init(
+            skip_token_input_ids_transfer=True
+        )
+        context.copy_async_sched_input_tokens_to_gpu(sampled_tokens_cuda)
+        return input_ids, position_ids
 
     def _run_async_sched_forward(self, input_ids: Tensor, position_ids: Tensor) -> Optional[int]:
         """Run one dynamic forward pass and cache logits for async scheduling.
@@ -2028,7 +2036,9 @@ class TextGenerationController:
             range_pop()
 
             range_push("prepare_requests")
-            input_ids, position_ids = self._run_async_sched_prepare(new_sample_copy)
+            input_ids, position_ids = self._run_async_sched_prepare(
+                new_sample_copy, sampled_tokens_cuda
+            )
             range_pop()
 
             range_push("async_sched_forward_pass")

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -758,24 +758,24 @@ class TextGenerationController:
             self._all_logits_cuda = logits
 
     def _run_async_sched_prepare(
-        self, new_sample_copy: Tensor, sampled_tokens_cuda: Tensor
+        self, sampled_tokens_cpu: Tensor, sampled_tokens_gpu: Tensor
     ) -> Tuple[Tensor, Tensor]:
         """Prepare decode requests and GPU-visible forward state for async scheduling.
 
         Args:
-            new_sample_copy (Tensor): CPU copy of sampled tokens for active requests.
-            sampled_tokens_cuda (Tensor): GPU-resident sampled tokens to use as
+            sampled_tokens_cpu (Tensor): CPU copy of sampled tokens for active requests.
+            sampled_tokens_gpu (Tensor): GPU-resident sampled tokens to use as
                 input IDs for the speculative forward.
 
         Returns:
             Tuple[Tensor, Tensor]: Input token IDs and position IDs for the speculative forward.
         """
         context = self.inference_wrapped_model.inference_context
-        context.prepare_requests(new_sample_copy)
+        context.prepare_requests(sampled_tokens_cpu)
         input_ids, position_ids = self._dynamic_step_context_init(
             skip_token_input_ids_transfer=True
         )
-        context.copy_async_sched_input_tokens_to_gpu(sampled_tokens_cuda)
+        context.copy_async_sched_input_tokens_to_gpu(sampled_tokens_gpu)
         return input_ids, position_ids
 
     def _run_async_sched_forward(self, input_ids: Tensor, position_ids: Tensor) -> Optional[int]:
@@ -2011,10 +2011,10 @@ class TextGenerationController:
             cached_cuda_graph_request_count = self._decode_forward_primer.cuda_graph_request_count
 
             range_push("sampling")
-            sampled_tokens_cuda = torch.argmax(
+            sampled_tokens_gpu = torch.argmax(
                 self._all_logits_cuda.squeeze(0)[:active_request_count].float(), dim=-1
             )
-            sampled_tokens_cpu = sampled_tokens_cuda.cpu()
+            sampled_tokens_cpu = sampled_tokens_gpu.cpu()
             range_pop()
 
             range_push("active_request_mask")
@@ -2032,12 +2032,11 @@ class TextGenerationController:
             )
             finished_request_ids = context.request_ids[finished_idxs].clone()
             survivor_idxs = torch.nonzero(active_request_mask == 1, as_tuple=True)[0]
-            new_sample_copy = sampled_tokens_cpu.clone()
             range_pop()
 
             range_push("prepare_requests")
             input_ids, position_ids = self._run_async_sched_prepare(
-                new_sample_copy, sampled_tokens_cuda
+                sampled_tokens_cpu, sampled_tokens_gpu
             )
             range_pop()
 

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -633,9 +633,8 @@ class TextGenerationController:
                 token_to_input_ids into GPU bookkeeping. The caller must
                 populate GPU input token IDs before forward.
 
-        Return:
-            input_ids (Tensor): The active input IDs.
-            position_ids (Tensor): The active position IDs.
+        Returns:
+            Tuple[Tensor, Tensor]: The active input IDs and position IDs.
         """
         context = self.inference_wrapped_model.inference_context
 

--- a/tests/unit_tests/inference/contexts/test_dynamic_context.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_context.py
@@ -300,6 +300,90 @@ class TestDynamicContext:
 
     @pytest.mark.internal
     @rounder_override(64)
+    def test_transfer_bookkeeping_to_gpu_can_skip_input_token_ids(self):
+        dynamic_context = self._get_dynamic_context(
+            params_dtype=torch.float32,
+            num_layers=2,
+            kv_channels=64,
+            num_attention_heads=8,
+            max_sequence_length=128,
+            buffer_size_gb=0.1,
+            block_size_tokens=128,
+            max_tokens=None,
+        )
+
+        num_tokens = 4
+        dynamic_context.total_request_count = 2
+        dynamic_context.paused_request_count = 0
+        dynamic_context.padded_active_request_count = 2
+        dynamic_context.token_to_input_ids[:num_tokens] = torch.tensor(
+            [11, 12, 13, 14], dtype=torch.int64
+        )
+        dynamic_context.token_to_pos_ids[:num_tokens] = torch.tensor(
+            [21, 22, 23, 24], dtype=torch.int64
+        )
+        existing_gpu_tokens = torch.tensor(
+            [91, 92, 93, 94],
+            dtype=torch.int64,
+            device=dynamic_context.gpu_view.token_to_input_ids.device,
+        )
+        dynamic_context.gpu_view.token_to_input_ids[:num_tokens] = existing_gpu_tokens
+
+        dynamic_context.transfer_bookkeeping_to_gpu(skip_token_input_ids=True)
+
+        assert torch.equal(
+            dynamic_context.gpu_view.token_to_input_ids[:num_tokens], existing_gpu_tokens
+        )
+        assert torch.equal(
+            dynamic_context.gpu_view.token_to_pos_ids[:num_tokens].cpu(),
+            torch.tensor([21, 22, 23, 24], dtype=torch.int64),
+        )
+
+        dynamic_context.token_to_input_ids[:num_tokens] = torch.tensor(
+            [31, 32, 33, 34], dtype=torch.int64
+        )
+        dynamic_context.transfer_bookkeeping_to_gpu()
+
+        assert torch.equal(
+            dynamic_context.gpu_view.token_to_input_ids[:num_tokens].cpu(),
+            torch.tensor([31, 32, 33, 34], dtype=torch.int64),
+        )
+
+    @pytest.mark.internal
+    @rounder_override(8)
+    def test_copy_async_sched_input_tokens_to_gpu_populates_active_and_clears_padding(self):
+        ctx = self._get_dynamic_context(
+            params_dtype=torch.float32,
+            num_layers=2,
+            kv_channels=8,
+            num_attention_heads=2,
+            max_sequence_length=32,
+            buffer_size_gb=0.01,
+            block_size_tokens=4,
+            max_tokens=32,
+            max_requests=8,
+        )
+
+        ctx.total_request_count = 3
+        ctx.paused_request_count = 0
+        ctx.num_prefill_requests = 0
+        ctx.active_token_count = 3
+        ctx.padded_active_token_count = 8
+        device = ctx.gpu_view.token_to_input_ids.device
+        ctx.gpu_view.token_to_input_ids[:8] = torch.full(
+            (8,), 777, dtype=torch.int64, device=device
+        )
+        sampled_tokens_cuda = torch.tensor([90, 91, 92], dtype=torch.int64, device=device)
+
+        ctx.copy_async_sched_input_tokens_to_gpu(sampled_tokens_cuda)
+
+        assert torch.equal(ctx.gpu_view.token_to_input_ids[:3], sampled_tokens_cuda)
+        assert torch.equal(
+            ctx.gpu_view.token_to_input_ids[3:8].cpu(), torch.zeros(5, dtype=torch.int64)
+        )
+
+    @pytest.mark.internal
+    @rounder_override(64)
     @pytest.mark.parametrize("is_hybrid_model", [False, True])
     def test_reset(self, is_hybrid_model: bool):
 

--- a/tests/unit_tests/inference/text_generation_controllers/test_text_generation_controller.py
+++ b/tests/unit_tests/inference/text_generation_controllers/test_text_generation_controller.py
@@ -346,16 +346,35 @@ def test_run_async_sched_prepare_updates_context_before_h2d_init():
 
     context.prepare_requests = mock.Mock(side_effect=lambda _: call_order.append("prepare"))
     controller._dynamic_step_context_init = mock.Mock(
-        side_effect=lambda: call_order.append("context_init") or (input_ids, position_ids)
+        side_effect=lambda *, skip_token_input_ids_transfer=False: call_order.append(
+            f"context_init:{skip_token_input_ids_transfer}"
+        )
+        or (input_ids, position_ids)
     )
-    sample = torch.tensor([3, 4])
 
-    returned_input_ids, returned_position_ids = controller._run_async_sched_prepare(sample)
+    def copy_async_sched_input_tokens_to_gpu(sampled_tokens_cuda):
+        call_order.append("copy_async_sched_input_tokens_to_gpu")
+        assert torch.equal(sampled_tokens_cuda, sample_cuda)
 
-    context.prepare_requests.assert_called_once_with(sample)
+    context.copy_async_sched_input_tokens_to_gpu = mock.Mock(
+        side_effect=copy_async_sched_input_tokens_to_gpu
+    )
+    sample_cpu = torch.tensor([3, 4])
+    sample_cuda = torch.tensor([3, 4])
+
+    returned_input_ids, returned_position_ids = controller._run_async_sched_prepare(
+        sample_cpu, sample_cuda
+    )
+
+    context.prepare_requests.assert_called_once()
+    assert context.prepare_requests.call_args.args[0] is sample_cpu
+    controller._dynamic_step_context_init.assert_called_once_with(
+        skip_token_input_ids_transfer=True
+    )
+    context.copy_async_sched_input_tokens_to_gpu.assert_called_once()
     assert torch.equal(returned_input_ids, input_ids)
     assert torch.equal(returned_position_ids, position_ids)
-    assert call_order == ["prepare", "context_init"]
+    assert call_order == ["prepare", "context_init:True", "copy_async_sched_input_tokens_to_gpu"]
 
 
 @pytest.mark.parametrize(
@@ -421,9 +440,6 @@ def test_async_sched_serial_step(
     sample_tokens = torch.tensor([1, 2, 3], dtype=torch.int64)
     context = _make_async_sched_context(total_request_count=3)
     context.request_metadata["termination_id"] = termination_ids
-    context.resolve_requests = mock.Mock(
-        return_value=torch.tensor(expected_finished_ids, dtype=torch.int32)
-    )
     controller = _make_async_sched_controller(context)
     controller._decode_forward_primer = DecodeForwardPrimer(
         is_primed=is_primed, cuda_graph_request_count=7 if is_primed else None
@@ -436,9 +452,10 @@ def test_async_sched_serial_step(
     input_ids = torch.tensor([[101, 102, 103]])
     position_ids = torch.tensor([[0, 1, 2]])
     call_order = []
-    controller._dynamic_step_context_init = mock.Mock(
-        side_effect=lambda: call_order.append("context_init") or (input_ids, position_ids)
-    )
+
+    def initialize_step_context(*, skip_token_input_ids_transfer=False):
+        call_order.append(f"context_init:{skip_token_input_ids_transfer}")
+        return input_ids, position_ids
 
     def forward_step(forward_input_ids, forward_position_ids):
         call_order.append("forward")
@@ -447,8 +464,27 @@ def test_async_sched_serial_step(
         controller._decode_forward_primer.mark_primed(5)
         return 5
 
+    def prepare_requests(new_sample_copy):
+        call_order.append("prepare")
+        assert torch.equal(new_sample_copy, sample_tokens)
+
+    def copy_async_sched_input_tokens_to_gpu(sampled_tokens_cuda):
+        call_order.append("copy_async_sched_input_tokens_to_gpu")
+        assert torch.equal(sampled_tokens_cuda, sample_tokens)
+
+    def resolve_requests(active_request_mask):
+        call_order.append("resolve")
+        expected_active_request_mask = (sample_tokens != termination_ids).byte()
+        assert torch.equal(active_request_mask, expected_active_request_mask)
+        return torch.tensor(expected_finished_ids, dtype=torch.int32)
+
+    controller._dynamic_step_context_init = mock.Mock(side_effect=initialize_step_context)
     controller._run_async_sched_forward = mock.Mock(side_effect=forward_step)
-    context.prepare_requests = mock.Mock(side_effect=lambda _: call_order.append("prepare"))
+    context.prepare_requests = mock.Mock(side_effect=prepare_requests)
+    context.copy_async_sched_input_tokens_to_gpu = mock.Mock(
+        side_effect=copy_async_sched_input_tokens_to_gpu
+    )
+    context.resolve_requests = mock.Mock(side_effect=resolve_requests)
 
     def compact_logits(survivor_idxs):
         assert context.async_sched_step_count == 0
@@ -472,9 +508,16 @@ def test_async_sched_serial_step(
     assert context.async_sched_compaction_step_count == expected_compaction_count
     context.prepare_requests.assert_called_once()
     context.resolve_requests.assert_called_once()
+    context.copy_async_sched_input_tokens_to_gpu.assert_called_once()
     controller._compact_async_sched_logits.assert_called_once()
-    expected_prefix = [] if is_primed else ["context_init", "forward"]
-    assert call_order == expected_prefix + ["prepare", "context_init", "forward"]
+    expected_prefix = [] if is_primed else ["context_init:False", "forward"]
+    assert call_order == expected_prefix + [
+        "prepare",
+        "context_init:True",
+        "copy_async_sched_input_tokens_to_gpu",
+        "forward",
+        "resolve",
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/inference/text_generation_controllers/test_text_generation_controller.py
+++ b/tests/unit_tests/inference/text_generation_controllers/test_text_generation_controller.py
@@ -352,9 +352,9 @@ def test_run_async_sched_prepare_updates_context_before_h2d_init():
         or (input_ids, position_ids)
     )
 
-    def copy_async_sched_input_tokens_to_gpu(sampled_tokens_cuda):
+    def copy_async_sched_input_tokens_to_gpu(sampled_tokens_gpu):
         call_order.append("copy_async_sched_input_tokens_to_gpu")
-        assert torch.equal(sampled_tokens_cuda, sample_cuda)
+        assert torch.equal(sampled_tokens_gpu, sample_cuda)
 
     context.copy_async_sched_input_tokens_to_gpu = mock.Mock(
         side_effect=copy_async_sched_input_tokens_to_gpu
@@ -464,13 +464,13 @@ def test_async_sched_serial_step(
         controller._decode_forward_primer.mark_primed(5)
         return 5
 
-    def prepare_requests(new_sample_copy):
+    def prepare_requests(sampled_tokens_cpu):
         call_order.append("prepare")
-        assert torch.equal(new_sample_copy, sample_tokens)
+        assert torch.equal(sampled_tokens_cpu, sample_tokens)
 
-    def copy_async_sched_input_tokens_to_gpu(sampled_tokens_cuda):
+    def copy_async_sched_input_tokens_to_gpu(sampled_tokens_gpu):
         call_order.append("copy_async_sched_input_tokens_to_gpu")
-        assert torch.equal(sampled_tokens_cuda, sample_tokens)
+        assert torch.equal(sampled_tokens_gpu, sample_tokens)
 
     def resolve_requests(active_request_mask):
         call_order.append("resolve")


### PR DESCRIPTION
## Summary
- skip CPU token-ID H2D for non-primer async scheduling decode forwards
- patch async scheduling forward input IDs directly from sampled CUDA tokens
- add focused context/controller tests for the skipped transfer path

## Tests
- git diff --check main/main...defer-req-res-sample-gpu-res
- python3 -m py_compile megatron/core/inference/contexts/dynamic_context.py megatron/core/inference/text_generation_controllers/text_generation_controller.py tests/unit_tests/inference/contexts/test_dynamic_context.py tests/unit_tests/inference/text_generation_controllers/test_text_generation_controller.py
- DFW job 13240924 on 0197747aacc2c17eb9078f11f585302910a4d994: uv run python -m torch.distributed.run --standalone --nproc-per-node=8 -m pytest -q tests/unit_tests/inference/test_inference_config.py tests/unit_tests/inference/engines/test_dynamic_engine_async_sched.py tests/unit_tests/inference/text_generation_controllers/test_text_generation_controller.py tests/unit_tests/inference/contexts/test_dynamic_context.py -k "async_sched or async_generate_output_tokens_dynamic_batch" --capture=fd --tb=short (69 passed, 138 deselected)