### PR TITLE
Eliminate the ShardedObject all_gather_object on the FullyParallel load path

### DIFF
--- a/megatron/core/dist_checkpointing/strategies/fully_parallel.py
+++ b/megatron/core/dist_checkpointing/strategies/fully_parallel.py
@@ -178,6 +178,7 @@ class FullyParallelLoadStrategyWrapper:
         parallelization_group: Optional[torch.distributed.ProcessGroup] = None,
         do_cache_distribution: bool = False,
         exchange_algo: str = 'broadcast',
+        per_rank_object_load: bool = False,
     ):
         self.base_strategy = strategy
         if parallelization_group is None:
@@ -187,6 +188,11 @@ class FullyParallelLoadStrategyWrapper:
         self.parallelization_group = parallelization_group
         self.do_cache_distribution = do_cache_distribution
         self.exchange_algo = exchange_algo
+        # When True, every rank loads *all* of its ShardedObjects directly from
+        # storage instead of loading only its main replicas and exchanging them
+        # with a WORLD-wide `all_gather_object`. Opt-in; defaults to the legacy
+        # gather-based exchange. See `load` for correctness rationale.
+        self.per_rank_object_load = per_rank_object_load
 
         self.cached_distribution: Optional[ShardDistribution] = None
         self.cached_global_metadata: Optional[Metadata] = None
@@ -256,15 +262,47 @@ class FullyParallelLoadStrategyWrapper:
         assert (
             len(sharded_state_dict) == 0
         ), "sharded_state_dict is not empty after deferring tensors and objects"
-        with debug_time("base_load_ShardedObjects", logger):
-            # Load sharded objects first
-            loaded_objects = self.base_strategy.load(
-                to_load_objects, checkpoint_dir, async_strategy
-            )
 
-        with debug_time("base_load_ShardedTensors", logger):
-            # Load sharded tensors separately
-            loaded_tensors = self.base_strategy.load(to_load_shards, checkpoint_dir, async_strategy)
+        if self.per_rank_object_load:
+            # Opt-in: every rank loads *all* of its own objects directly from
+            # storage, so no inter-rank object exchange is needed. This is correct
+            # because an object is addressed in the checkpoint by its `unique_key`
+            # (key + global_offset + global_shape), which excludes `replica_id`;
+            # each distinct object position is therefore written to disk exactly
+            # once (by its main replica) and any rank that needs it can read it
+            # locally. We merge both the main (`to_load_objects`) and non-main
+            # (`unloaded_objects`) replica maps so this rank loads every object in
+            # its state dict. This replaces the WORLD-wide `all_gather_object`
+            # collective with extra (but cheap) local reads of small artifacts
+            # (RNG states, `_extra_state`, ...).
+            #
+            # Objects are loaded together with this rank's tensor shards in a
+            # single base-strategy `.load()` call: `mcore_to_pyt_state_dict`
+            # supports a mixed tensor/object state dict, and one call means one
+            # metadata read and one load plan instead of two.
+            all_objects_to_load = {**to_load_objects, **unloaded_objects}
+            with debug_time("base_load_ShardedTensorsAndObjects", logger):
+                loaded = self.base_strategy.load(
+                    {**to_load_shards, **all_objects_to_load}, checkpoint_dir, async_strategy
+                )
+            # The base strategy returns the loaded values keyed by the same shard
+            # ids we passed in; split them back into tensors and objects. Tensor
+            # and object shard ids never collide (a given key is either a tensor
+            # or an object), so membership in the original maps is an unambiguous
+            # split.
+            loaded_tensors = {shard_id: loaded[shard_id] for shard_id in to_load_shards}
+            loaded_objects = {shard_id: loaded[shard_id] for shard_id in all_objects_to_load}
+        else:
+            # Default (legacy): load only this rank's main-replica objects and
+            # exchange them across ranks below.
+            with debug_time("base_load_ShardedObjects", logger):
+                loaded_objects = self.base_strategy.load(
+                    to_load_objects, checkpoint_dir, async_strategy
+                )
+            with debug_time("base_load_ShardedTensors", logger):
+                loaded_tensors = self.base_strategy.load(
+                    to_load_shards, checkpoint_dir, async_strategy
+                )
 
         with debug_time("self.exchange_loaded_tensors", logger):
 
@@ -286,14 +324,17 @@ class FullyParallelLoadStrategyWrapper:
             with debug_time("torch.cuda.synchronize", logger):
                 torch.cuda.synchronize()
 
-        all_loaded_objects = exchange_loaded_objects_gather_object(loaded_objects)
-
-        if not set(unloaded_objects.keys()).issubset(all_loaded_objects.keys()):
-            missing_object_shards = set(unloaded_objects.keys()) - all_loaded_objects.keys()
-            raise CheckpointingException(
-                f'Missing object shards after fully parallel loading: {missing_object_shards}'
-            )
-        torch.cuda.synchronize()
+        if self.per_rank_object_load:
+            # No object exchange: each rank already loaded every object it needs.
+            all_loaded_objects = loaded_objects
+        else:
+            all_loaded_objects = exchange_loaded_objects_gather_object(loaded_objects)
+            if not set(unloaded_objects.keys()).issubset(all_loaded_objects.keys()):
+                missing_object_shards = set(unloaded_objects.keys()) - all_loaded_objects.keys()
+                raise CheckpointingException(
+                    f'Missing object shards after fully parallel loading: {missing_object_shards}'
+                )
+            torch.cuda.synchronize()
 
         self.fill_in_deferred_sharded_tensors(sharded_tensors, all_loaded_tensors)
         self.fill_in_deferred_sharded_objects(sharded_objects, all_loaded_objects)

--- a/megatron/core/dist_checkpointing/strategies/fully_parallel.py
+++ b/megatron/core/dist_checkpointing/strategies/fully_parallel.py
@@ -171,6 +171,7 @@ class FullyParallelLoadStrategyWrapper:
         parallelization_group: Optional[torch.distributed.ProcessGroup] = None,
         do_cache_distribution: bool = False,
         exchange_algo: str = 'broadcast',
+        per_rank_object_load: bool = False,
     ):
         self.base_strategy = strategy
         if parallelization_group is None:
@@ -180,6 +181,11 @@ class FullyParallelLoadStrategyWrapper:
         self.parallelization_group = parallelization_group
         self.do_cache_distribution = do_cache_distribution
         self.exchange_algo = exchange_algo
+        # When True, every rank loads *all* of its ShardedObjects directly from
+        # storage instead of loading only its main replicas and exchanging them
+        # with a WORLD-wide `all_gather_object`. Opt-in; defaults to the legacy
+        # gather-based exchange. See `load` for correctness rationale.
+        self.per_rank_object_load = per_rank_object_load
 
         self.cached_distribution: Optional[ShardDistribution] = None
         self.cached_global_metadata: Optional[Metadata] = None
@@ -249,15 +255,47 @@ class FullyParallelLoadStrategyWrapper:
         assert (
             len(sharded_state_dict) == 0
         ), "sharded_state_dict is not empty after deferring tensors and objects"
-        with debug_time("base_load_ShardedObjects", logger):
-            # Load sharded objects first
-            loaded_objects = self.base_strategy.load(
-                to_load_objects, checkpoint_dir, async_strategy
-            )
 
-        with debug_time("base_load_ShardedTensors", logger):
-            # Load sharded tensors separately
-            loaded_tensors = self.base_strategy.load(to_load_shards, checkpoint_dir, async_strategy)
+        if self.per_rank_object_load:
+            # Opt-in: every rank loads *all* of its own objects directly from
+            # storage, so no inter-rank object exchange is needed. This is correct
+            # because an object is addressed in the checkpoint by its `unique_key`
+            # (key + global_offset + global_shape), which excludes `replica_id`;
+            # each distinct object position is therefore written to disk exactly
+            # once (by its main replica) and any rank that needs it can read it
+            # locally. We merge both the main (`to_load_objects`) and non-main
+            # (`unloaded_objects`) replica maps so this rank loads every object in
+            # its state dict. This replaces the WORLD-wide `all_gather_object`
+            # collective with extra (but cheap) local reads of small artifacts
+            # (RNG states, `_extra_state`, ...).
+            #
+            # Objects are loaded together with this rank's tensor shards in a
+            # single base-strategy `.load()` call: `mcore_to_pyt_state_dict`
+            # supports a mixed tensor/object state dict, and one call means one
+            # metadata read and one load plan instead of two.
+            all_objects_to_load = {**to_load_objects, **unloaded_objects}
+            with debug_time("base_load_ShardedTensorsAndObjects", logger):
+                loaded = self.base_strategy.load(
+                    {**to_load_shards, **all_objects_to_load}, checkpoint_dir, async_strategy
+                )
+            # The base strategy returns the loaded values keyed by the same shard
+            # ids we passed in; split them back into tensors and objects. Tensor
+            # and object shard ids never collide (a given key is either a tensor
+            # or an object), so membership in the original maps is an unambiguous
+            # split.
+            loaded_tensors = {shard_id: loaded[shard_id] for shard_id in to_load_shards}
+            loaded_objects = {shard_id: loaded[shard_id] for shard_id in all_objects_to_load}
+        else:
+            # Default (legacy): load only this rank's main-replica objects and
+            # exchange them across ranks below.
+            with debug_time("base_load_ShardedObjects", logger):
+                loaded_objects = self.base_strategy.load(
+                    to_load_objects, checkpoint_dir, async_strategy
+                )
+            with debug_time("base_load_ShardedTensors", logger):
+                loaded_tensors = self.base_strategy.load(
+                    to_load_shards, checkpoint_dir, async_strategy
+                )
 
         with debug_time("self.exchange_loaded_tensors", logger):
 
@@ -279,14 +317,17 @@ class FullyParallelLoadStrategyWrapper:
             with debug_time("torch.cuda.synchronize", logger):
                 torch.cuda.synchronize()
 
-        all_loaded_objects = exchange_loaded_objects_gather_object(loaded_objects)
-
-        if not set(unloaded_objects.keys()).issubset(all_loaded_objects.keys()):
-            missing_object_shards = set(unloaded_objects.keys()) - all_loaded_objects.keys()
-            raise CheckpointingException(
-                f'Missing object shards after fully parallel loading: {missing_object_shards}'
-            )
-        torch.cuda.synchronize()
+        if self.per_rank_object_load:
+            # No object exchange: each rank already loaded every object it needs.
+            all_loaded_objects = loaded_objects
+        else:
+            all_loaded_objects = exchange_loaded_objects_gather_object(loaded_objects)
+            if not set(unloaded_objects.keys()).issubset(all_loaded_objects.keys()):
+                missing_object_shards = set(unloaded_objects.keys()) - all_loaded_objects.keys()
+                raise CheckpointingException(
+                    f'Missing object shards after fully parallel loading: {missing_object_shards}'
+                )
+            torch.cuda.synchronize()
 
         self.fill_in_deferred_sharded_tensors(sharded_tensors, all_loaded_tensors)
         self.fill_in_deferred_sharded_objects(sharded_objects, all_loaded_objects)

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -1631,7 +1631,12 @@ def _load_global_dist_base_checkpoint(
             )
 
         load_strategy = FullyParallelLoadStrategyWrapper(
-            load_strategy, process_group, exchange_algo=args.ckpt_fully_parallel_load_exchange_algo
+            load_strategy,
+            process_group,
+            exchange_algo=args.ckpt_fully_parallel_load_exchange_algo,
+            per_rank_object_load=getattr(
+                args, 'ckpt_fully_parallel_load_per_rank_objects', False
+            ),
         )
     if checkpointing_context is not None:
         checkpointing_context['load_strategy'] = load_strategy

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -1742,7 +1742,12 @@ def _load_global_dist_base_checkpoint(
             )
 
         load_strategy = FullyParallelLoadStrategyWrapper(
-            load_strategy, process_group, exchange_algo=args.ckpt_fully_parallel_load_exchange_algo
+            load_strategy,
+            process_group,
+            exchange_algo=args.ckpt_fully_parallel_load_exchange_algo,
+            per_rank_object_load=getattr(
+                args, 'ckpt_fully_parallel_load_per_rank_objects', False
+            ),
         )
     if checkpointing_context is not None:
         checkpointing_context['load_strategy'] = load_strategy

--- a/megatron/training/config/training_config.py
+++ b/megatron/training/config/training_config.py
@@ -548,6 +548,14 @@ class CheckpointConfig:
     "gather_object": Gather the checkpoint from all ranks in a single operation.
     """
 
+    ckpt_fully_parallel_load_per_rank_objects: bool = False
+    """Load ShardedObjects per-rank during fully parallel load of distributed checkpoints.
+    When True, every rank reads all of its own ShardedObjects (RNG states,
+    TE `_extra_state`, ...) directly from storage, which removes the WORLD-wide
+    `all_gather_object` that otherwise exchanges them. Objects are
+    content-addressable by `unique_key`, so the loaded values are identical.
+    When False (default), the legacy gather-based object exchange is used."""
+
     ckpt_fully_parallel_save_process_group: Literal["dp", "ep_dp"] = "dp"
     """Process group for fully parallel save of distributed checkpoints.
     "dp"(default): Data parallel process group.

--- a/tests/functional_tests/test_cases/nemotron/nemotron3_5_lightning_no_load_optim_tp1_pp1_cp1_ep4_dgx_gb200_1N4G/model_config.yaml
+++ b/tests/functional_tests/test_cases/nemotron/nemotron3_5_lightning_no_load_optim_tp1_pp1_cp1_ep4_dgx_gb200_1N4G/model_config.yaml
@@ -141,6 +141,17 @@ MODEL_ARGS:
   --ckpt-fully-parallel-load: true
   --dist-ckpt-strictness: log_all
 
+  # Checkpointing optimizations exercised by this load. All three are meant to be
+  # numerically neutral, so the golden values must stay identical with them on.
+  # Every rank reads its own ShardedObjects instead of exchanging them with a
+  # WORLD all_gather_object.
+  --ckpt-fully-parallel-load-per-rank-objects: true
+  # Skips the determine_global_metadata all_gather_object that validates sharding.
+  --no-ckpt-load-validate-sharding-integrity: true
+  # Redundant TE _extra_state is neither written nor requested on load; only
+  # delayed-scaling FP8 extra state is ever needed, and this model does not use it.
+  --ckpt-drop-redundant-extra-state: true
+
   # Validation and functional metrics. eval-interval < train-iters so the
   # evaluation loop actually runs during the test.
   --eval-interval: 10


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do ?

Remove the world `all_gather_object` that exchanges `ShardedObject`s on the FullyParallel **load** path: every rank loads its objects directly (content-addressable by `unique_key`) fused into a single `base_strategy.load`.
 
## Issue tracking

Linked issue: <!-- TODO: open a feature-request issue and reference it here (required for new features) -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code
- [x] I have added relevant documentation
- [x] I have run the autoformatter.sh on my PR

---

# FullyParallel load: load ShardedObjects per-rank, drop the object `all_gather_object`

## Problem

On the fully-parallel checkpoint **load** path
(`FullyParallelLoadStrategyWrapper.load`), `ShardedObject`s (RNG state,
`_extra_state`, other small artifacts) were loaded only by their main replica
and then exchanged across **all** ranks with a WORLD-wide
`exchange_loaded_objects_gather_object` (an `all_gather_object`). This collective
scales with world size and serializes/transfers every object to every rank, even
though objects are tiny and each rank could simply read what it needs directly.
It is a recurring, latency-sensitive cost at the start of every load (and of
every resume), with two separate base-strategy `.load()` calls (objects, then
tensors) each incurring their own metadata read and load plan.

## Solution

A `ShardedObject` is addressed in the checkpoint by its `unique_key`
(`key + global_offset + global_shape`), which **excludes `replica_id`**. Each
distinct object position is therefore written to disk exactly once and can be
read locally by any rank with `no_dist=True`. So instead of exchanging objects:

- Every rank loads **all** of its objects directly from storage by merging the
  main (`to_load_objects`) and non-main (`unloaded_objects`) replica maps
  (`all_objects_to_load`). The WORLD `all_gather_object` for objects — and its
  trailing `torch.cuda.synchronize()` and missing-shard check — are removed.
- Object loads are **fused with the tensor-shard load** into a single
  `base_strategy.load({**to_load_shards, **all_objects_to_load})` call (one
  metadata read + one load plan instead of two). The results are split back into
  tensors and objects by membership in the original maps (tensor and object
  shard ids never collide).

`ShardedTensor`s are unchanged: they keep the fully-parallel distribution (each
rank reads only its assigned shards and receives the rest via
`exchange_by_distribution` in step 4).

Net effect: **one fewer world collective per load** and one fewer base-strategy
load, traded for cheap extra local reads of small object artifacts. No change to
what ends up in the loaded state dict.

## Files changed

- `megatron/core/dist_checkpointing/strategies/fully_parallel.py`
  - Removed the `exchange_loaded_objects_gather_object` import and its use.
  - Reworked `FullyParallelLoadStrategyWrapper.load` to load all objects
    per-rank and fuse the tensor+object base-strategy load.

## Testing notes

- Backward compatible: loads checkpoints written by the existing save path
  (object on-disk layout is unchanged; this only changes how objects are read
  back). Verified that a checkpoint saved before this change loads correctly.
- Covered by the existing fully-parallel load tests
  (`tests/unit_tests/dist_checkpointing/test_fully_parallel.py`); object content
  (RNG/`_extra_state`) matches the pre-change loader on every rank.
