### PR TITLE
Add --ckpt-drop-redundant-extra-state to skip persisting redundant TE _extra_state

### DIFF
--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2893,6 +2893,17 @@ def _add_checkpointing_args(parser):
     group.add_argument('--ckpt-fully-parallel-save', action='store_true',
                        dest='ckpt_fully_parallel_save_deprecated',
                        help='Deprecated: see --no-ckpt-fully-parallel-save.')
+    group.add_argument('--drop-redundant-extra-state', action='store_true',
+                       default=False,
+                       help='Drop TE `_extra_state` artifacts that carry no '
+                       'irreplaceable state (no FP8, or block/current FP8 '
+                       'scaling) from the distributed checkpoint, keeping them '
+                       'local instead of writing them. Only delayed-scaling '
+                       '`_extra_state` (amax history + scale) is ever needed and '
+                       'it is always persisted regardless of this flag. By '
+                       'default (flag off) all `_extra_state` are persisted, '
+                       'preserving the previous behavior. Older checkpoints load '
+                       'unchanged either way.')
     return parser
 
 

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2893,6 +2893,17 @@ def _add_checkpointing_args(parser):
     group.add_argument('--ckpt-fully-parallel-save', action='store_true',
                        dest='ckpt_fully_parallel_save_deprecated',
                        help='Deprecated: see --no-ckpt-fully-parallel-save.')
+    group.add_argument('--ckpt-drop-redundant-extra-state', action='store_true',
+                       default=False,
+                       help='Drop TE `_extra_state` artifacts that carry no '
+                       'irreplaceable state (no FP8, or block/current FP8 '
+                       'scaling) from the distributed checkpoint, keeping them '
+                       'local instead of writing them. Only delayed-scaling '
+                       '`_extra_state` (amax history + scale) is ever needed and '
+                       'it is always persisted regardless of this flag. By '
+                       'default (flag off) all `_extra_state` are persisted, '
+                       'preserving the previous behavior. Older checkpoints load '
+                       'unchanged either way.')
     return parser
 
 

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -25,7 +25,8 @@ import torch
 from torch.distributed.checkpoint import FileSystemReader, default_planner
 
 from megatron.core import dist_checkpointing, mpu, tensor_parallel
-from megatron.core.dist_checkpointing.mapping import ShardedObject
+from megatron.core.dist_checkpointing.dict_utils import dict_list_map_inplace
+from megatron.core.dist_checkpointing.mapping import LocalNonpersistentObject, ShardedObject
 from megatron.core.dist_checkpointing.strategies.async_utils import _disable_gc
 from megatron.core.dist_checkpointing.strategies.fully_parallel import (
     FullyParallelLoadStrategyWrapper,
@@ -1426,7 +1427,97 @@ def generate_state_dict(
     if not args.no_save_rng and rng_state:
         state_dict['rng_state'] = rng_state
 
+    # Optionally avoid persisting TE `_extra_state` artifacts that carry no
+    # irreplaceable state (see `_localize_redundant_extra_states`). Opt-in via
+    # --ckpt-drop-redundant-extra-state (off by default, preserving prior behavior).
+    # Applied here so the SAME decision is used for both the save state dict and
+    # the load *request* (`generate_state_dict` is the shared chokepoint), which
+    # keeps the two symmetric and backward compatible.
+    if args.ckpt_format == "torch_dist" and getattr(
+        args, "ckpt_drop_redundant_extra_state", False
+    ):
+        _localize_redundant_extra_states(state_dict)
+
     return state_dict
+
+
+# Byte markers of the dict keys that TE `get_extra_state` writes ONLY under
+# `if recipe.delayed():` (see TransformerEngine `module/base.py`). Their presence
+# in the serialized payload is a robust, unpickle-free signal that the
+# `_extra_state` carries persistent delayed-scaling state (amax history + scale).
+_FP8_PERSISTENT_EXTRA_STATE_MARKERS = (b"amax_history_fwd", b"scale_fwd", b"scale_bwd")
+
+
+def _fp8_extra_state_is_persistent(data) -> bool:
+    """Whether a TE `_extra_state` payload must be checkpointed.
+
+    A `_extra_state` is worth persisting only when it carries state that cannot
+    be reconstructed from the run config at model-build time, i.e. the
+    delayed-scaling FP8 amax history + scale. Concretely:
+
+    * ``None`` / empty ``uint8`` tensor  -> FP8 disabled        -> NOT persistent
+    * non-empty, no delayed-scaling key  -> block/current scaling (NVFP4, MXFP8,
+      Float8CurrentScaling): recipe + scalars only, all config-derived
+                                                                  -> NOT persistent
+    * non-empty, has ``scale_fwd`` / ``amax_history_fwd`` / ``scale_bwd``
+                                          -> delayed scaling      -> persistent
+
+    The check operates on the raw serialized bytes (the uint8 tensor that
+    ``get_extra_state`` returns) so it needs no unpickling and no TE import.
+    Anything unrecognized defaults to persistent, so real state is never
+    silently dropped.
+    """
+    if data is None:
+        return False
+    if isinstance(data, torch.Tensor):
+        if data.numel() == 0:
+            return False
+        try:
+            raw = data.detach().cpu().contiguous().numpy().tobytes()
+        except Exception:
+            return True
+        return any(marker in raw for marker in _FP8_PERSISTENT_EXTRA_STATE_MARKERS)
+    # Unknown payload type: keep it persistent to be safe.
+    return True
+
+
+def _localize_redundant_extra_states(state_dict):
+    """Rewrite non-persistent TE `_extra_state` ShardedObjects as local objects.
+
+    For checkpoints with no FP8, or with block/current FP8 scaling (NVFP4,
+    MXFP8, Float8CurrentScaling), every `_extra_state` is either empty or a
+    recipe-only blob that the freshly-built model reproduces from config — see
+    `_fp8_extra_state_is_persistent`. Such artifacts are pure overhead: in a
+    large MoE model they account for the overwhelming majority of the
+    checkpoint's ShardedObjects (e.g. ~50k on the 55B hybrid-MoE run).
+
+    Wrapping them in ``LocalNonpersistentObject`` (instead of ``ShardedObject``)
+    means, via the dist-checkpointing pipeline:
+
+    * SAVE: ``save_preprocess`` drops them, so they are never written to disk.
+    * LOAD: ``load_preprocess`` unwraps them back into the loaded state dict with
+      the local (freshly-built) value, so the module's ``_extra_state`` key is
+      still present (strict ``load_state_dict`` stays happy) and
+      ``set_extra_state`` no-ops on the empty/recipe payload.
+
+    Because this runs in ``generate_state_dict`` (shared by save and the load
+    request), the decision is symmetric: dropped keys are never *requested*, so
+    loading an older checkpoint that still stores them simply does not read them
+    (they are neither "missing" nor "unexpected" in the request) — backward
+    compatible. Delayed-scaling `_extra_state` stays a ``ShardedObject`` and is
+    saved/loaded exactly as before.
+    """
+
+    def _maybe_localize(value):
+        if (
+            isinstance(value, ShardedObject)
+            and value.key.endswith("_extra_state")
+            and not _fp8_extra_state_is_persistent(value.data)
+        ):
+            return LocalNonpersistentObject(value.data)
+        return value
+
+    dict_list_map_inplace(_maybe_localize, state_dict)
 
 
 def preprocess_fsdp_dtensor_state_dict(args, raw_state_dict, model):

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -25,7 +25,8 @@ import torch
 from torch.distributed.checkpoint import FileSystemReader, default_planner
 
 from megatron.core import dist_checkpointing, mpu, tensor_parallel
-from megatron.core.dist_checkpointing.mapping import ShardedObject
+from megatron.core.dist_checkpointing.dict_utils import dict_list_map_inplace
+from megatron.core.dist_checkpointing.mapping import LocalNonpersistentObject, ShardedObject
 from megatron.core.dist_checkpointing.strategies.async_utils import _disable_gc
 from megatron.core.dist_checkpointing.strategies.fully_parallel import (
     FullyParallelLoadStrategyWrapper,
@@ -1414,7 +1415,97 @@ def generate_state_dict(
     if not args.no_save_rng and rng_state:
         state_dict['rng_state'] = rng_state
 
+    # Optionally avoid persisting TE `_extra_state` artifacts that carry no
+    # irreplaceable state (see `_localize_redundant_extra_states`). Opt-in via
+    # --drop-redundant-extra-state (off by default, preserving prior behavior).
+    # Applied here so the SAME decision is used for both the save state dict and
+    # the load *request* (`generate_state_dict` is the shared chokepoint), which
+    # keeps the two symmetric and backward compatible.
+    if args.ckpt_format == "torch_dist" and getattr(
+        args, "drop_redundant_extra_state", False
+    ):
+        _localize_redundant_extra_states(state_dict)
+
     return state_dict
+
+
+# Byte markers of the dict keys that TE `get_extra_state` writes ONLY under
+# `if recipe.delayed():` (see TransformerEngine `module/base.py`). Their presence
+# in the serialized payload is a robust, unpickle-free signal that the
+# `_extra_state` carries persistent delayed-scaling state (amax history + scale).
+_FP8_PERSISTENT_EXTRA_STATE_MARKERS = (b"amax_history_fwd", b"scale_fwd", b"scale_bwd")
+
+
+def _fp8_extra_state_is_persistent(data) -> bool:
+    """Whether a TE `_extra_state` payload must be checkpointed.
+
+    A `_extra_state` is worth persisting only when it carries state that cannot
+    be reconstructed from the run config at model-build time, i.e. the
+    delayed-scaling FP8 amax history + scale. Concretely:
+
+    * ``None`` / empty ``uint8`` tensor  -> FP8 disabled        -> NOT persistent
+    * non-empty, no delayed-scaling key  -> block/current scaling (NVFP4, MXFP8,
+      Float8CurrentScaling): recipe + scalars only, all config-derived
+                                                                  -> NOT persistent
+    * non-empty, has ``scale_fwd`` / ``amax_history_fwd`` / ``scale_bwd``
+                                          -> delayed scaling      -> persistent
+
+    The check operates on the raw serialized bytes (the uint8 tensor that
+    ``get_extra_state`` returns) so it needs no unpickling and no TE import.
+    Anything unrecognized defaults to persistent, so real state is never
+    silently dropped.
+    """
+    if data is None:
+        return False
+    if isinstance(data, torch.Tensor):
+        if data.numel() == 0:
+            return False
+        try:
+            raw = data.detach().cpu().contiguous().numpy().tobytes()
+        except Exception:
+            return True
+        return any(marker in raw for marker in _FP8_PERSISTENT_EXTRA_STATE_MARKERS)
+    # Unknown payload type: keep it persistent to be safe.
+    return True
+
+
+def _localize_redundant_extra_states(state_dict):
+    """Rewrite non-persistent TE `_extra_state` ShardedObjects as local objects.
+
+    For checkpoints with no FP8, or with block/current FP8 scaling (NVFP4,
+    MXFP8, Float8CurrentScaling), every `_extra_state` is either empty or a
+    recipe-only blob that the freshly-built model reproduces from config — see
+    `_fp8_extra_state_is_persistent`. Such artifacts are pure overhead: in a
+    large MoE model they account for the overwhelming majority of the
+    checkpoint's ShardedObjects (e.g. ~50k on the 55B hybrid-MoE run).
+
+    Wrapping them in ``LocalNonpersistentObject`` (instead of ``ShardedObject``)
+    means, via the dist-checkpointing pipeline:
+
+    * SAVE: ``save_preprocess`` drops them, so they are never written to disk.
+    * LOAD: ``load_preprocess`` unwraps them back into the loaded state dict with
+      the local (freshly-built) value, so the module's ``_extra_state`` key is
+      still present (strict ``load_state_dict`` stays happy) and
+      ``set_extra_state`` no-ops on the empty/recipe payload.
+
+    Because this runs in ``generate_state_dict`` (shared by save and the load
+    request), the decision is symmetric: dropped keys are never *requested*, so
+    loading an older checkpoint that still stores them simply does not read them
+    (they are neither "missing" nor "unexpected" in the request) — backward
+    compatible. Delayed-scaling `_extra_state` stays a ``ShardedObject`` and is
+    saved/loaded exactly as before.
+    """
+
+    def _maybe_localize(value):
+        if (
+            isinstance(value, ShardedObject)
+            and value.key.endswith("_extra_state")
+            and not _fp8_extra_state_is_persistent(value.data)
+        ):
+            return LocalNonpersistentObject(value.data)
+        return value
+
+    dict_list_map_inplace(_maybe_localize, state_dict)
 
 
 def preprocess_fsdp_dtensor_state_dict(args, raw_state_dict, model):

--- a/tests/unit_tests/dist_checkpointing/test_drop_redundant_extra_state.py
+++ b/tests/unit_tests/dist_checkpointing/test_drop_redundant_extra_state.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+
+"""Unit tests for the ``--drop-redundant-extra-state`` optimization.
+
+These cover the two pure-logic helpers that decide which TE ``_extra_state``
+artifacts are redundant and rewrite them as local (non-persistent) objects:
+``_fp8_extra_state_is_persistent`` and ``_localize_redundant_extra_states``.
+
+The logic operates on the raw serialized ``_extra_state`` bytes, so it is
+exercised here with TE-format payloads built the same way TE's
+``get_extra_state`` does (a ``torch.save`` of a small dict into a ``uint8``
+tensor). This needs no FP8 hardware, so it runs identically on FP8-capable CI
+(H100 / GB200) and elsewhere.
+"""
+
+import io
+
+import pytest
+import torch
+
+from megatron.core.dist_checkpointing.mapping import (
+    LocalNonpersistentObject,
+    ShardedObject,
+    ShardedTensor,
+)
+from megatron.training.checkpointing import (
+    _fp8_extra_state_is_persistent,
+    _localize_redundant_extra_states,
+)
+
+
+def _te_like_extra_state(payload: dict) -> torch.Tensor:
+    """Serialize ``payload`` the way TE's ``get_extra_state`` does: a
+    ``torch.save`` of a dict into a ``uint8`` byte tensor."""
+    buf = io.BytesIO()
+    torch.save(payload, buf)
+    return torch.frombuffer(bytearray(buf.getvalue()), dtype=torch.uint8)
+
+
+# A delayed-scaling FP8 payload carries amax history + scale buffers -> persistent.
+_DELAYED = {
+    "amax_history_fwd": torch.zeros(3),
+    "scale_fwd": torch.ones(1),
+    "scale_bwd": torch.ones(1),
+}
+# Block / current scaling (NVFP4, MXFP8, Float8CurrentScaling) only stores
+# recipe + config-derived scalars, none of the delayed-scaling markers.
+_RECIPE_ONLY = {"recipe": "Float8CurrentScaling", "global_steps": 7}
+
+
+class TestFp8ExtraStateIsPersistent:
+    def test_none_is_not_persistent(self):
+        assert _fp8_extra_state_is_persistent(None) is False
+
+    def test_empty_tensor_is_not_persistent(self):
+        # FP8 disabled: get_extra_state returns an empty uint8 tensor.
+        assert _fp8_extra_state_is_persistent(torch.empty(0, dtype=torch.uint8)) is False
+
+    def test_recipe_only_is_not_persistent(self):
+        # Block / current scaling: no delayed-scaling markers in the payload.
+        assert _fp8_extra_state_is_persistent(_te_like_extra_state(_RECIPE_ONLY)) is False
+
+    @pytest.mark.parametrize("marker", ["amax_history_fwd", "scale_fwd", "scale_bwd"])
+    def test_delayed_scaling_markers_are_persistent(self, marker):
+        # Any one delayed-scaling marker is enough to keep the payload.
+        assert (
+            _fp8_extra_state_is_persistent(_te_like_extra_state({marker: torch.zeros(2)})) is True
+        )
+
+    def test_full_delayed_payload_is_persistent(self):
+        assert _fp8_extra_state_is_persistent(_te_like_extra_state(_DELAYED)) is True
+
+    def test_unknown_payload_defaults_to_persistent(self):
+        # Anything that is not a tensor is kept, so real state is never dropped.
+        assert _fp8_extra_state_is_persistent({"not": "a tensor"}) is True
+
+
+class TestLocalizeRedundantExtraStates:
+    def _sharded_object(self, key, data):
+        return ShardedObject(key, data, (1,), (0,))
+
+    def test_localizes_only_redundant_extra_states(self):
+        empty_es = self._sharded_object("decoder.0.self_attention._extra_state", None)
+        recipe_es = self._sharded_object(
+            "decoder.0.mlp._extra_state", _te_like_extra_state(_RECIPE_ONLY)
+        )
+        delayed_es = self._sharded_object(
+            "decoder.1.mlp._extra_state", _te_like_extra_state(_DELAYED)
+        )
+        # A ShardedObject that is NOT an _extra_state must be left alone.
+        other_obj = self._sharded_object("decoder.0.metadata", {"foo": "bar"})
+        weight = ShardedTensor.from_rank_offsets("decoder.0.weight", torch.zeros(4), replica_id=0)
+
+        state_dict = {
+            "empty_es": empty_es,
+            "recipe_es": recipe_es,
+            "delayed_es": delayed_es,
+            "other_obj": other_obj,
+            "weight": weight,
+        }
+        _localize_redundant_extra_states(state_dict)
+
+        # Redundant (empty / recipe-only) _extra_state -> dropped on save.
+        assert isinstance(state_dict["empty_es"], LocalNonpersistentObject)
+        assert isinstance(state_dict["recipe_es"], LocalNonpersistentObject)
+        # The wrapped value is preserved so load can restore the key locally.
+        assert state_dict["recipe_es"].unwrap() is recipe_es.data
+        # Delayed-scaling _extra_state stays a ShardedObject (still checkpointed).
+        assert state_dict["delayed_es"] is delayed_es
+        # Non-_extra_state objects and tensors are untouched.
+        assert state_dict["other_obj"] is other_obj
+        assert state_dict["weight"] is weight
+
+    def test_noop_when_no_redundant_extra_states(self):
+        delayed_es = self._sharded_object(
+            "decoder.0.mlp._extra_state", _te_like_extra_state(_DELAYED)
+        )
+        state_dict = {"delayed_es": delayed_es}
+        _localize_redundant_extra_states(state_dict)
+        assert state_dict["delayed_es"] is delayed_es

--- a/tests/unit_tests/dist_checkpointing/test_drop_redundant_extra_state.py
+++ b/tests/unit_tests/dist_checkpointing/test_drop_redundant_extra_state.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+
+"""Unit tests for the ``--ckpt-drop-redundant-extra-state`` optimization.
+
+These cover the two pure-logic helpers that decide which TE ``_extra_state``
+artifacts are redundant and rewrite them as local (non-persistent) objects:
+``_fp8_extra_state_is_persistent`` and ``_localize_redundant_extra_states``.
+
+The logic operates on the raw serialized ``_extra_state`` bytes, so it is
+exercised here with TE-format payloads built the same way TE's
+``get_extra_state`` does (a ``torch.save`` of a small dict into a ``uint8``
+tensor). This needs no FP8 hardware, so it runs identically on FP8-capable CI
+(H100 / GB200) and elsewhere.
+"""
+
+import io
+
+import pytest
+import torch
+
+from megatron.core.dist_checkpointing.mapping import (
+    LocalNonpersistentObject,
+    ShardedObject,
+    ShardedTensor,
+)
+from megatron.training.checkpointing import (
+    _fp8_extra_state_is_persistent,
+    _localize_redundant_extra_states,
+)
+
+
+def _te_like_extra_state(payload: dict) -> torch.Tensor:
+    """Serialize ``payload`` the way TE's ``get_extra_state`` does: a
+    ``torch.save`` of a dict into a ``uint8`` byte tensor."""
+    buf = io.BytesIO()
+    torch.save(payload, buf)
+    return torch.frombuffer(bytearray(buf.getvalue()), dtype=torch.uint8)
+
+
+# A delayed-scaling FP8 payload carries amax history + scale buffers -> persistent.
+_DELAYED = {
+    "amax_history_fwd": torch.zeros(3),
+    "scale_fwd": torch.ones(1),
+    "scale_bwd": torch.ones(1),
+}
+# Block / current scaling (NVFP4, MXFP8, Float8CurrentScaling) only stores
+# recipe + config-derived scalars, none of the delayed-scaling markers.
+_RECIPE_ONLY = {"recipe": "Float8CurrentScaling", "global_steps": 7}
+
+
+class TestFp8ExtraStateIsPersistent:
+    def test_none_is_not_persistent(self):
+        assert _fp8_extra_state_is_persistent(None) is False
+
+    def test_empty_tensor_is_not_persistent(self):
+        # FP8 disabled: get_extra_state returns an empty uint8 tensor.
+        assert _fp8_extra_state_is_persistent(torch.empty(0, dtype=torch.uint8)) is False
+
+    def test_recipe_only_is_not_persistent(self):
+        # Block / current scaling: no delayed-scaling markers in the payload.
+        assert _fp8_extra_state_is_persistent(_te_like_extra_state(_RECIPE_ONLY)) is False
+
+    @pytest.mark.parametrize("marker", ["amax_history_fwd", "scale_fwd", "scale_bwd"])
+    def test_delayed_scaling_markers_are_persistent(self, marker):
+        # Any one delayed-scaling marker is enough to keep the payload.
+        assert (
+            _fp8_extra_state_is_persistent(_te_like_extra_state({marker: torch.zeros(2)})) is True
+        )
+
+    def test_full_delayed_payload_is_persistent(self):
+        assert _fp8_extra_state_is_persistent(_te_like_extra_state(_DELAYED)) is True
+
+    def test_unknown_payload_defaults_to_persistent(self):
+        # Anything that is not a tensor is kept, so real state is never dropped.
+        assert _fp8_extra_state_is_persistent({"not": "a tensor"}) is True
+
+
+class TestLocalizeRedundantExtraStates:
+    def _sharded_object(self, key, data):
+        return ShardedObject(key, data, (1,), (0,))
+
+    def test_localizes_only_redundant_extra_states(self):
+        empty_es = self._sharded_object("decoder.0.self_attention._extra_state", None)
+        recipe_es = self._sharded_object(
+            "decoder.0.mlp._extra_state", _te_like_extra_state(_RECIPE_ONLY)
+        )
+        delayed_es = self._sharded_object(
+            "decoder.1.mlp._extra_state", _te_like_extra_state(_DELAYED)
+        )
+        # A ShardedObject that is NOT an _extra_state must be left alone.
+        other_obj = self._sharded_object("decoder.0.metadata", {"foo": "bar"})
+        weight = ShardedTensor.from_rank_offsets("decoder.0.weight", torch.zeros(4), replica_id=0)
+
+        state_dict = {
+            "empty_es": empty_es,
+            "recipe_es": recipe_es,
+            "delayed_es": delayed_es,
+            "other_obj": other_obj,
+            "weight": weight,
+        }
+        _localize_redundant_extra_states(state_dict)
+
+        # Redundant (empty / recipe-only) _extra_state -> dropped on save.
+        assert isinstance(state_dict["empty_es"], LocalNonpersistentObject)
+        assert isinstance(state_dict["recipe_es"], LocalNonpersistentObject)
+        # The wrapped value is preserved so load can restore the key locally.
+        assert state_dict["recipe_es"].unwrap() is recipe_es.data
+        # Delayed-scaling _extra_state stays a ShardedObject (still checkpointed).
+        assert state_dict["delayed_es"] is delayed_es
+        # Non-_extra_state objects and tensors are untouched.
+        assert state_dict["other_obj"] is other_obj
+        assert state_dict["weight"] is weight
+
+    def test_noop_when_no_redundant_extra_states(self):
+        delayed_es = self._sharded_object(
+            "decoder.0.mlp._extra_state", _te_like_extra_state(_DELAYED)
+        )
+        state_dict = {"delayed_es": delayed_es}
+        _localize_redundant_extra_states(state_dict)
+        assert state_dict["delayed_es"] is delayed_es


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do ?

Add an opt-in `--drop-redundant-extra-state` flag that stops persisting TE `_extra_state` artifacts that carry no irreplaceable state (everything except delayed-scaling FP8).
 
## Issue tracking

Linked issue: <!-- TODO: open a feature-request issue and reference it here (required for new features) -->

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code
- [x] I have added relevant documentation
- [x] I have run the autoformatter.sh on my PR

---

# Don't persist redundant TransformerEngine `_extra_state` in distributed checkpoints

## Problem

Every TransformerEngine module (`Linear`, `LayerNormLinear`, `DotProductAttention`,
grouped/MoE experts, fused ops, …) contributes an `_extra_state` entry to the
checkpoint via `TransformerEngineBaseModule.get_extra_state`. In a large model
these dominate the checkpoint's object count — on a 55B hybrid-MoE run (512
experts) they are on the order of ~50k `ShardedObject`s, each saved (and its
metadata gathered/validated) on every checkpoint.

But that payload is only meaningful in one case. `get_extra_state` writes real
state **only under `if recipe.delayed():`** — the FP8 delayed-scaling amax
history and scale factors, which evolve during training and cannot be
reconstructed from config. In every other configuration the `_extra_state` is
either:

* **No FP8** → `None` / an empty `uint8` tensor, or
* **Block scaling (NVFP4, MXFP8) / current scaling (Float8CurrentScaling)** →
  a recipe + scalar blob that the freshly-built model reproduces from the run
  config at build time.

So unless you train with delayed-scaling FP8, these objects are pure overhead:
they bloat the checkpoint, inflate `.metadata`, and add tens of thousands of
items to the save-side metadata gathers and sharding validation — for data that
is either empty or trivially reconstructable. (Checkpoints are typically stored
in BF16 even when compute uses FP8/FP4, so this is the common case.)

## Solution

Add an opt-in `--drop-redundant-extra-state` flag (**off by default**, so the
prior behavior — persisting all `_extra_state` — is preserved) that stops
persisting the redundant `_extra_state` while keeping the genuinely useful
delayed-scaling ones, with no change to the load contract.

When enabled, in `generate_state_dict` (the shared chokepoint for both the save
state dict and the load *request*), for `torch_dist` checkpoints, every
non-persistent `_extra_state` `ShardedObject` is rewritten into a
`LocalNonpersistentObject`:

* **SAVE**: `save_preprocess` drops `LocalNonpersistentObject`s, so they are
  never written — fewer objects, smaller `.metadata`, lighter metadata gather
  and sharding validation.
* **LOAD**: `load_preprocess` unwraps them back into the loaded state dict with
  the local (freshly-built) value, so the module's `_extra_state` key is still
  present (strict `load_state_dict` stays satisfied) and `set_extra_state`
  no-ops on the empty/recipe payload.

Persistence is decided by `_fp8_extra_state_is_persistent`, which inspects the
**raw serialized bytes** of the `uint8` payload for the delayed-scaling key
markers (`amax_history_fwd` / `scale_fwd` / `scale_bwd`) — no unpickling, no TE
import. Anything unrecognized defaults to *persistent*, so real state is never
dropped silently. Delayed-scaling `_extra_state` remains a `ShardedObject` and
is saved/loaded exactly as before.

## Backward compatibility

* **Old checkpoints load unchanged.** Because the decision runs in
  `generate_state_dict`, the dropped keys are never *requested* at load time, so
  an older checkpoint that still stores those `_extra_state`s simply does not
  read them — they are neither "missing" nor "unexpected".
* **New checkpoints load on old code** the same way an empty `_extra_state`
  always has (`set_extra_state` no-ops).
* **Delayed-scaling FP8 runs are unaffected** — their `_extra_state` is detected
  as persistent and kept.

## Usage

The optimization is **opt-in**; by default all `_extra_state` are persisted, so
existing behavior is unchanged. Enable it to drop the redundant ones:

```
--drop-redundant-extra-state
```

## Files changed

* `megatron/training/checkpointing.py` — `_fp8_extra_state_is_persistent`,
  `_localize_redundant_extra_states`, and the gated call in `generate_state_dict`.
* `megatron/training/arguments.py` — `--drop-redundant-extra-state` flag.
* `tests/unit_tests/dist_checkpointing/test_drop_redundant_extra_state.py` — new
  unit tests (below).

## Testing notes

* **Unit tests** (`test_drop_redundant_extra_state.py`, no GPU/FP8 required, so
  they run identically on FP8-capable CI and elsewhere): exercise
  `_fp8_extra_state_is_persistent` on TE-format payloads — empty / `None` /
  recipe-only (block & current scaling) classify as non-persistent; the
  delayed-scaling markers (`amax_history_fwd` / `scale_fwd` / `scale_bwd`)
  classify as persistent — and `_localize_redundant_extra_states`, which must
  wrap only the redundant `_extra_state` objects as `LocalNonpersistentObject`
  while leaving delayed-scaling objects, non-`_extra_state` objects, and tensors
  untouched.
* No-FP8 / BF16 run: confirm a checkpoint saved with `--drop-redundant-extra-state`
  contains no `*_extra_state` data objects and the `.metadata` object count drops
  by the expected ~50k; train→save→load→resume is bit-exact vs the default
  (persist-all) baseline.
* Delayed-scaling FP8 run (H100 / GB200): confirm `_extra_state` is still
  persisted with `--drop-redundant-extra-state` and that amax history/scale
  survive a save/load round-trip.
* Cross-version: load a pre-change checkpoint with the new code (and vice versa)
  and verify resume works.
