### PR TITLE
Cache the FullyParallel save distribution on disk (--ckpt-pg-tensors-cache-path)

### DIFF
--- a/megatron/core/dist_checkpointing/exchange_utils.py
+++ b/megatron/core/dist_checkpointing/exchange_utils.py
@@ -3,6 +3,8 @@
 """Utilities for exchanging data between ranks."""
 
 import logging
+import os
+import pickle
 from collections import defaultdict
 from functools import reduce
 from itertools import zip_longest
@@ -170,39 +172,49 @@ def distribute_shards_to_ranks(
     return shard_to_saving_rank
 
 
-def determine_main_replica_uniform_distribution(
-    sharded_state_dict: ShardedStateDict,
-    parallelization_group: torch.distributed.ProcessGroup,
-    ignore_groups: bool = False,
-) -> Optional[ShardDistribution]:
-    """Computes the save distribution.
+# Prefix of the per-parallelization-group cache files written/read by the
+# PG-collective caching feature (see `determine_main_replica_uniform_distribution`).
+PG_DIST_CACHE_FILE_PREFIX = "pg_dist"
 
-    Should be used in conjunction with `distribute_main_replicas_with_precomputed_distribution`
-    which applies the computed save distribution.
+# Process-global in-memory cache of the per-group distributions, keyed by the
+# resolved cache file path (which uniquely identifies a (cache dir, group) pair).
+# Each entry holds the full {ignore_groups: ShardDistribution} map, so a single
+# entry serves both the save and load variants. This memoization makes
+# `determine_main_replica_uniform_distribution` idempotent within a job:
+#   * CREATE runs the gather + write at most once per group (subsequent calls,
+#     e.g. later saves or the second `replicate_local_replicas` call, hit memory
+#     and skip the collective and the file write), and
+#   * READ opens each group's file at most once per job.
+# It is checked *before* the collective so every rank of a group hits or misses
+# in lockstep, preserving collective symmetry.
+_PG_DIST_CACHE: Dict[str, Dict[bool, "ShardDistribution"]] = {}
 
-    We rely on the fact that the assignment algorithm is deterministic on all ranks,
-    so there is no extra communication needed after metadata exchange.
+
+def _gather_shards_metadata(
+    sharded_state_dict: ShardedStateDict, parallelization_group: torch.distributed.ProcessGroup
+) -> List[List[ShardedTensor]]:
+    """Runs the single expensive collective behind the load/save distribution.
+
+    Every rank in the group contributes the metadata (no tensor data) of the
+    ``ShardedTensor``s it holds; the result is the list of every rank's shard
+    metadata, identical on all ranks of the group. This is the
+    ``all_gather_object`` that the caching feature exists to eliminate on
+    subsequent jobs.
+
+    Decision: data is stripped with ``without_data()`` before the gather. Only
+    the metadata (key, offsets, shape, dtype, replica_id) drives the
+    distribution algorithm, and gathering it keeps the pickled payload tiny.
 
     Args:
-        sharded_state_dict (ShardedStateDict): state dict to compute the distribution of
-        parallelization_group (ProcessGroup): distribution will be computed
-            within this process group
-        ignore_groups (bool, optional): whether the distribution defines groups.
-            This option is primarily used during loading, as it ensures that all replicas,
-            including non-main ones, are loaded by this parallelization group
-            Defaults to False.
+        sharded_state_dict (ShardedStateDict): state dict whose local shards
+            are advertised to the group.
+        parallelization_group (ProcessGroup): group to gather within.
 
-    Returns (ShardDistribution, optional): distribution that can be used to apply the
-        parallelization. Returns None if the process_group is trivial (1 rank)
-
+    Returns:
+        List[List[ShardedTensor]]: per-rank lists of data-less ShardedTensors.
     """
     from ..utils import get_pg_size
 
-    if parallelization_group is None:
-        parallelization_group = torch.distributed.group.WORLD
-    group_size = get_pg_size(group=parallelization_group)
-    if group_size <= 1:
-        return
     local_shards = list(
         sh_base
         for sh_base in nested_values(sharded_state_dict)
@@ -210,11 +222,38 @@ def determine_main_replica_uniform_distribution(
     )
     local_shards_no_data = [ten.without_data() for ten in local_shards]
 
-    all_shards = [None] * get_pg_size(group=parallelization_group)
+    all_shards: List[Optional[List[ShardedTensor]]] = [None] * get_pg_size(
+        group=parallelization_group
+    )
     torch.distributed.all_gather_object(
         all_shards, local_shards_no_data, group=parallelization_group
     )
+    return cast(List[List[ShardedTensor]], all_shards)
 
+
+def _build_shard_distribution(
+    all_shards: List[List[ShardedTensor]], ignore_groups: bool
+) -> ShardDistribution:
+    """Computes a ShardDistribution from already-gathered shard metadata.
+
+    This is the pure, deterministic post-gather logic of
+    ``determine_main_replica_uniform_distribution`` factored out so that:
+      * it can be run twice (for both ``ignore_groups`` variants) from a single
+        gather when creating the cache, and
+      * it has no dependence on the local rank, which is what makes the result
+        identical on every rank of the group and therefore safe to persist and
+        reload across jobs.
+
+    Args:
+        all_shards (List[List[ShardedTensor]]): gathered per-rank shard metadata
+            (output of ``_gather_shards_metadata``).
+        ignore_groups (bool): if True (load mode) include shards whose main
+            replica lives outside this group; if False (save mode) restrict to
+            shards with a main replica in this group.
+
+    Returns:
+        ShardDistribution: the computed distribution.
+    """
     shard_to_ranks = defaultdict(list)
     shard_to_size = {}
     shard_to_metadata = {}
@@ -251,6 +290,192 @@ def determine_main_replica_uniform_distribution(
     return ShardDistribution(
         shard_to_saving_rank, shards_in_this_group, shard_to_metadata, shard_to_ranks
     )
+
+
+def _pg_dist_cache_file_path(
+    cache_path: str, parallelization_group: torch.distributed.ProcessGroup
+) -> str:
+    """Returns the cache file path holding the distributions for a given group.
+
+    The file is keyed by the minimum global rank of the parallelization group.
+    Decision rationale:
+      * Parallelization groups partition the world, so ``min(global ranks)`` is
+        a unique, collision-free identifier of each group.
+      * It is computed from purely local metadata
+        (``get_process_group_ranks``), so the filename is derivable without any
+        collective — essential for the zero-communication read path.
+      * Every member of a group maps to the same file (one file per group rather
+        than one per rank): far fewer files at scale and a single read per rank,
+        with duplicate reads absorbed by the FS page cache.
+
+    Args:
+        cache_path (str): directory holding the cache files.
+        parallelization_group (ProcessGroup): the group to key on.
+
+    Returns:
+        str: absolute-or-relative path of the group's cache file.
+    """
+    ranks = torch.distributed.get_process_group_ranks(parallelization_group)
+    return os.path.join(cache_path, f"{PG_DIST_CACHE_FILE_PREFIX}_{min(ranks)}.pkl")
+
+
+def _load_pg_dist_cache(cache_file: str) -> Dict[bool, ShardDistribution]:
+    """Reads both pre-computed ShardDistributions for a group from disk.
+
+    Returns the full ``{ignore_groups: ShardDistribution}`` map (not just one
+    variant) so the caller can memoize both in the process-global cache and serve
+    later save/load calls without re-opening the file.
+
+    Performs no existence/validity checks by design (see the feature docs): the
+    user opts into the cache only when they guarantee the config and world size
+    match the run that created it, trading safety for the lowest possible
+    latency.
+
+    Args:
+        cache_file (str): resolved path of the group's cache file.
+
+    Returns:
+        Dict[bool, ShardDistribution]: the {ignore_groups: distribution} map.
+    """
+    with open(cache_file, "rb") as f:
+        return pickle.load(f)
+
+
+def _create_pg_dist_cache(
+    all_shards: List[List[ShardedTensor]],
+    cache_path: str,
+    parallelization_group: torch.distributed.ProcessGroup,
+) -> Dict[bool, ShardDistribution]:
+    """Builds both distribution variants and persists them for the group.
+
+    Both the save (``ignore_groups=False``) and load (``ignore_groups=True``)
+    distributions are derived from the *same* gathered metadata, so a single
+    collective suffices to populate a cache usable by every later load and save
+    — even if the creating job only ever loads (e.g. ``exit_after_loading_ckpt``).
+
+    Only the group's writer rank (global rank == ``min`` of the group) writes,
+    keeping create-time IO to one file per group. The write is atomic
+    (temp file + ``os.replace``) so a concurrent/interrupted create can never
+    leave a torn file that a reader would later trust blindly.
+
+    Args:
+        all_shards (List[List[ShardedTensor]]): gathered shard metadata.
+        cache_path (str): directory to write the cache file into.
+        parallelization_group (ProcessGroup): group being cached.
+
+    Returns:
+        Dict[bool, ShardDistribution]: the {ignore_groups: distribution} map,
+            so the caller can return the variant it needs without recomputing.
+    """
+    both: Dict[bool, ShardDistribution] = {
+        ignore_groups: _build_shard_distribution(all_shards, ignore_groups)
+        for ignore_groups in (False, True)
+    }
+    ranks = torch.distributed.get_process_group_ranks(parallelization_group)
+    if torch.distributed.get_rank() == min(ranks):
+        os.makedirs(cache_path, exist_ok=True)
+        path = _pg_dist_cache_file_path(cache_path, parallelization_group)
+        tmp_path = f"{path}.tmp.{torch.distributed.get_rank()}"
+        with open(tmp_path, "wb") as f:
+            pickle.dump(both, f)
+        os.replace(tmp_path, path)
+    return both
+
+
+def determine_main_replica_uniform_distribution(
+    sharded_state_dict: ShardedStateDict,
+    parallelization_group: torch.distributed.ProcessGroup,
+    ignore_groups: bool = False,
+    pg_cache_path: Optional[str] = None,
+    pg_cache_create: bool = False,
+) -> Optional[ShardDistribution]:
+    """Computes (or loads from cache) the load/save shard distribution.
+
+    Should be used in conjunction with `distribute_main_replicas_with_precomputed_distribution`
+    which applies the computed save distribution.
+
+    We rely on the fact that the assignment algorithm is deterministic on all ranks,
+    so there is no extra communication needed after metadata exchange.
+
+    PG-collective caching
+    ---------------------
+    The metadata exchange (`all_gather_object`) is by far the dominant cost of
+    this function at scale. Its result is a pure deterministic function of the
+    sharded state dict structure and the parallel layout, so for a fixed config
+    and world size it is identical across jobs and can be cached on disk:
+
+      * ``pg_cache_path`` set, ``pg_cache_create=False`` (READ): skip the
+        collective entirely and load the pre-computed distribution for this
+        group and mode from disk.
+      * ``pg_cache_path`` set, ``pg_cache_create=True`` (CREATE): run the
+        collective once, build *both* the save and load distributions from the
+        single gather, persist them, and return the requested one.
+      * both unset (default): the original behaviour, unchanged.
+
+    Results are additionally memoized in a process-global cache (``_PG_DIST_CACHE``)
+    keyed by the group's cache file, so within a single job each group is created
+    (gather + write) or read (file open) at most once — later calls (subsequent
+    saves, the second ``replicate_local_replicas`` pass, or the save wrapper
+    reusing the load wrapper's entry) are served from memory.
+
+    No existence/validity checks are performed on the cache by design — the user
+    opts in only when guaranteeing a matching config and world size.
+
+    Args:
+        sharded_state_dict (ShardedStateDict): state dict to compute the distribution of
+        parallelization_group (ProcessGroup): distribution will be computed
+            within this process group
+        ignore_groups (bool, optional): whether the distribution defines groups.
+            This option is primarily used during loading, as it ensures that all replicas,
+            including non-main ones, are loaded by this parallelization group
+            Defaults to False.
+        pg_cache_path (str, optional): directory of the PG-distribution cache.
+            When set, enables the caching feature. Defaults to None (disabled).
+        pg_cache_create (bool, optional): when True (and ``pg_cache_path`` set),
+            compute the distribution normally and write the cache; when False
+            (and ``pg_cache_path`` set), read the cache and skip the collective.
+            Defaults to False.
+
+    Returns (ShardDistribution, optional): distribution that can be used to apply the
+        parallelization. Returns None if the process_group is trivial (1 rank)
+
+    """
+    from ..utils import get_pg_size
+
+    if parallelization_group is None:
+        parallelization_group = torch.distributed.group.WORLD
+    group_size = get_pg_size(group=parallelization_group)
+    if group_size <= 1:
+        return
+
+    if pg_cache_path is not None:
+        # The resolved file path uniquely identifies this (cache dir, group) and
+        # keys the process-global memo. Checking it *first* makes both READ and
+        # CREATE idempotent within a job: a second call for the same group (a
+        # later save, the second `replicate_local_replicas` call, or the save
+        # wrapper reusing what the load wrapper already cached) returns from
+        # memory with no collective and no file IO. The check is identical on all
+        # ranks of the group, so it never desynchronizes the collective below.
+        cache_file = _pg_dist_cache_file_path(pg_cache_path, parallelization_group)
+        if cache_file in _PG_DIST_CACHE:
+            return _PG_DIST_CACHE[cache_file][bool(ignore_groups)]
+
+        # READ path: no collective; open the file once, then memoize both variants.
+        if not pg_cache_create:
+            both = _load_pg_dist_cache(cache_file)
+            _PG_DIST_CACHE[cache_file] = both
+            return both[bool(ignore_groups)]
+
+        # CREATE path: gather once, build & persist both variants, then memoize
+        # so no subsequent call for this group gathers or writes again.
+        all_shards = _gather_shards_metadata(sharded_state_dict, parallelization_group)
+        both = _create_pg_dist_cache(all_shards, pg_cache_path, parallelization_group)
+        _PG_DIST_CACHE[cache_file] = both
+        return both[bool(ignore_groups)]
+
+    # Default path: unchanged behaviour.
+    all_shards = _gather_shards_metadata(sharded_state_dict, parallelization_group)
+    return _build_shard_distribution(all_shards, ignore_groups)
 
 
 @torch.no_grad()

--- a/megatron/core/dist_checkpointing/exchange_utils.py
+++ b/megatron/core/dist_checkpointing/exchange_utils.py
@@ -3,6 +3,8 @@
 """Utilities for exchanging data between ranks."""
 
 import logging
+import os
+import pickle
 from collections import defaultdict
 from functools import reduce
 from itertools import zip_longest
@@ -172,39 +174,49 @@ def distribute_shards_to_ranks(
     return shard_to_saving_rank
 
 
-def determine_main_replica_uniform_distribution(
-    sharded_state_dict: ShardedStateDict,
-    parallelization_group: torch.distributed.ProcessGroup,
-    ignore_groups: bool = False,
-) -> Optional[ShardDistribution]:
-    """Computes the save distribution.
+# Prefix of the per-parallelization-group cache files written/read by the
+# PG-collective caching feature (see `determine_main_replica_uniform_distribution`).
+PG_DIST_CACHE_FILE_PREFIX = "pg_dist"
 
-    Should be used in conjunction with `distribute_main_replicas_with_precomputed_distribution`
-    which applies the computed save distribution.
+# Process-global in-memory cache of the per-group distributions, keyed by the
+# resolved cache file path (which uniquely identifies a (cache dir, group) pair).
+# Each entry holds the full {ignore_groups: ShardDistribution} map, so a single
+# entry serves both the save and load variants. This memoization makes
+# `determine_main_replica_uniform_distribution` idempotent within a job:
+#   * CREATE runs the gather + write at most once per group (subsequent calls,
+#     e.g. later saves or the second `replicate_local_replicas` call, hit memory
+#     and skip the collective and the file write), and
+#   * READ opens each group's file at most once per job.
+# It is checked *before* the collective so every rank of a group hits or misses
+# in lockstep, preserving collective symmetry.
+_PG_DIST_CACHE: Dict[str, Dict[bool, "ShardDistribution"]] = {}
 
-    We rely on the fact that the assignment algorithm is deterministic on all ranks,
-    so there is no extra communication needed after metadata exchange.
+
+def _gather_shards_metadata(
+    sharded_state_dict: ShardedStateDict, parallelization_group: torch.distributed.ProcessGroup
+) -> List[List[ShardedTensor]]:
+    """Runs the single expensive collective behind the load/save distribution.
+
+    Every rank in the group contributes the metadata (no tensor data) of the
+    ``ShardedTensor``s it holds; the result is the list of every rank's shard
+    metadata, identical on all ranks of the group. This is the
+    ``all_gather_object`` that the caching feature exists to eliminate on
+    subsequent jobs.
+
+    Decision: data is stripped with ``without_data()`` before the gather. Only
+    the metadata (key, offsets, shape, dtype, replica_id) drives the
+    distribution algorithm, and gathering it keeps the pickled payload tiny.
 
     Args:
-        sharded_state_dict (ShardedStateDict): state dict to compute the distribution of
-        parallelization_group (ProcessGroup): distribution will be computed
-            within this process group
-        ignore_groups (bool, optional): whether the distribution defines groups.
-            This option is primarily used during loading, as it ensures that all replicas,
-            including non-main ones, are loaded by this parallelization group
-            Defaults to False.
+        sharded_state_dict (ShardedStateDict): state dict whose local shards
+            are advertised to the group.
+        parallelization_group (ProcessGroup): group to gather within.
 
-    Returns (ShardDistribution, optional): distribution that can be used to apply the
-        parallelization. Returns None if the process_group is trivial (1 rank)
-
+    Returns:
+        List[List[ShardedTensor]]: per-rank lists of data-less ShardedTensors.
     """
     from ..utils import get_pg_size
 
-    if parallelization_group is None:
-        parallelization_group = torch.distributed.group.WORLD
-    group_size = get_pg_size(group=parallelization_group)
-    if group_size <= 1:
-        return
     local_shards = list(
         sh_base
         for sh_base in nested_values(sharded_state_dict)
@@ -212,11 +224,38 @@ def determine_main_replica_uniform_distribution(
     )
     local_shards_no_data = [ten.without_data() for ten in local_shards]
 
-    all_shards = [None] * get_pg_size(group=parallelization_group)
+    all_shards: List[Optional[List[ShardedTensor]]] = [None] * get_pg_size(
+        group=parallelization_group
+    )
     torch.distributed.all_gather_object(
         all_shards, local_shards_no_data, group=parallelization_group
     )
+    return cast(List[List[ShardedTensor]], all_shards)
 
+
+def _build_shard_distribution(
+    all_shards: List[List[ShardedTensor]], ignore_groups: bool
+) -> ShardDistribution:
+    """Computes a ShardDistribution from already-gathered shard metadata.
+
+    This is the pure, deterministic post-gather logic of
+    ``determine_main_replica_uniform_distribution`` factored out so that:
+      * it can be run twice (for both ``ignore_groups`` variants) from a single
+        gather when creating the cache, and
+      * it has no dependence on the local rank, which is what makes the result
+        identical on every rank of the group and therefore safe to persist and
+        reload across jobs.
+
+    Args:
+        all_shards (List[List[ShardedTensor]]): gathered per-rank shard metadata
+            (output of ``_gather_shards_metadata``).
+        ignore_groups (bool): if True (load mode) include shards whose main
+            replica lives outside this group; if False (save mode) restrict to
+            shards with a main replica in this group.
+
+    Returns:
+        ShardDistribution: the computed distribution.
+    """
     shard_to_ranks = defaultdict(list)
     shard_to_size = {}
     shard_to_metadata = {}
@@ -253,6 +292,191 @@ def determine_main_replica_uniform_distribution(
     return ShardDistribution(
         shard_to_saving_rank, shards_in_this_group, shard_to_metadata, shard_to_ranks
     )
+
+
+def _pg_dist_cache_file_path(
+    cache_path: str, parallelization_group: torch.distributed.ProcessGroup
+) -> str:
+    """Returns the cache file path holding the distributions for a given group.
+
+    The file is keyed by the minimum global rank of the parallelization group.
+    Decision rationale:
+      * Parallelization groups partition the world, so ``min(global ranks)`` is
+        a unique, collision-free identifier of each group.
+      * It is computed from purely local metadata
+        (``get_process_group_ranks``), so the filename is derivable without any
+        collective — essential for the zero-communication read path.
+      * Every member of a group maps to the same file (one file per group rather
+        than one per rank): far fewer files at scale and a single read per rank,
+        with duplicate reads absorbed by the FS page cache.
+
+    Args:
+        cache_path (str): directory holding the cache files.
+        parallelization_group (ProcessGroup): the group to key on.
+
+    Returns:
+        str: absolute-or-relative path of the group's cache file.
+    """
+    ranks = torch.distributed.get_process_group_ranks(parallelization_group)
+    return os.path.join(cache_path, f"{PG_DIST_CACHE_FILE_PREFIX}_{min(ranks)}.pkl")
+
+
+def _load_pg_dist_cache(cache_file: str) -> Dict[bool, ShardDistribution]:
+    """Reads both pre-computed ShardDistributions for a group from disk.
+
+    Returns the full ``{ignore_groups: ShardDistribution}`` map (not just one
+    variant) so the caller can memoize both in the process-global cache and serve
+    later save/load calls without re-opening the file.
+
+    Performs no existence/validity checks by design (see the feature docs): the
+    user opts into the cache only when they guarantee the config and world size
+    match the run that created it, trading safety for the lowest possible
+    latency.
+
+    Args:
+        cache_file (str): resolved path of the group's cache file.
+
+    Returns:
+        Dict[bool, ShardDistribution]: the {ignore_groups: distribution} map.
+    """
+    with open(cache_file, "rb") as f:
+        return pickle.load(f)
+
+
+def _create_pg_dist_cache(
+    all_shards: List[List[ShardedTensor]],
+    cache_path: str,
+    parallelization_group: torch.distributed.ProcessGroup,
+) -> Dict[bool, ShardDistribution]:
+    """Builds both distribution variants and persists them for the group.
+
+    Both the save (``ignore_groups=False``) and load (``ignore_groups=True``)
+    distributions are derived from the *same* gathered metadata, so a single
+    collective suffices to populate a cache usable by every later load and save
+    — even if the creating job only ever loads (e.g. ``exit_after_loading_ckpt``).
+
+    Only the group's writer rank (global rank == ``min`` of the group) writes,
+    keeping create-time IO to one file per group. The write is atomic
+    (temp file + ``os.replace``) so a concurrent/interrupted create can never
+    leave a torn file that a reader would later trust blindly.
+
+    Args:
+        all_shards (List[List[ShardedTensor]]): gathered shard metadata.
+        cache_path (str): directory to write the cache file into.
+        parallelization_group (ProcessGroup): group being cached.
+
+    Returns:
+        Dict[bool, ShardDistribution]: the {ignore_groups: distribution} map,
+            so the caller can return the variant it needs without recomputing.
+    """
+    both: Dict[bool, ShardDistribution] = {
+        ignore_groups: _build_shard_distribution(all_shards, ignore_groups)
+        for ignore_groups in (False, True)
+    }
+    ranks = torch.distributed.get_process_group_ranks(parallelization_group)
+    if torch.distributed.get_rank() == min(ranks):
+        os.makedirs(cache_path, exist_ok=True)
+        path = _pg_dist_cache_file_path(cache_path, parallelization_group)
+        tmp_path = f"{path}.tmp.{torch.distributed.get_rank()}"
+        with open(tmp_path, "wb") as f:
+            pickle.dump(both, f)
+        os.replace(tmp_path, path)
+    return both
+
+
+def determine_main_replica_uniform_distribution(
+    sharded_state_dict: ShardedStateDict,
+    parallelization_group: torch.distributed.ProcessGroup,
+    ignore_groups: bool = False,
+    pg_cache_path: Optional[str] = None,
+    pg_cache_create: bool = False,
+) -> Optional[ShardDistribution]:
+    """Computes (or loads from cache) the load/save shard distribution.
+
+    Should be used in conjunction with `distribute_main_replicas_with_precomputed_distribution`
+    which applies the computed save distribution.
+
+    We rely on the fact that the assignment algorithm is deterministic on all ranks,
+    so there is no extra communication needed after metadata exchange.
+
+    PG-collective caching:
+    The metadata exchange (`all_gather_object`) is by far the dominant cost of
+    this function at scale. Its result is a pure deterministic function of the
+    sharded state dict structure and the parallel layout, so for a fixed config
+    and world size it is identical across jobs and can be cached on disk:
+
+      * ``pg_cache_path`` set, ``pg_cache_create=False`` (READ): skip the
+        collective entirely and load the pre-computed distribution for this
+        group and mode from disk.
+      * ``pg_cache_path`` set, ``pg_cache_create=True`` (CREATE): run the
+        collective once, build *both* the save and load distributions from the
+        single gather, persist them, and return the requested one.
+      * both unset (default): the original behaviour, unchanged.
+
+    Results are additionally memoized in a process-global cache (``_PG_DIST_CACHE``)
+    keyed by the group's cache file, so within a single job each group is created
+    (gather + write) or read (file open) at most once — later calls (subsequent
+    saves, the second ``replicate_local_replicas`` pass, or the save wrapper
+    reusing the load wrapper's entry) are served from memory.
+
+    No existence/validity checks are performed on the cache by design — the user
+    opts in only when guaranteeing a matching config and world size.
+
+    Args:
+        sharded_state_dict (ShardedStateDict): state dict to compute the distribution of
+        parallelization_group (ProcessGroup): distribution will be computed
+            within this process group
+        ignore_groups (bool, optional): whether the distribution defines groups.
+            This option is primarily used during loading, as it ensures that all replicas,
+            including non-main ones, are loaded by this parallelization group
+            Defaults to False.
+        pg_cache_path (str, optional): directory of the PG-distribution cache.
+            When set, enables the caching feature. Defaults to None (disabled).
+        pg_cache_create (bool, optional): when True (and ``pg_cache_path`` set),
+            compute the distribution normally and write the cache; when False
+            (and ``pg_cache_path`` set), read the cache and skip the collective.
+            Defaults to False.
+
+    Returns (ShardDistribution, optional): distribution that can be used to apply the
+        parallelization. Returns None if the process_group is trivial (1 rank)
+
+    """
+    from ..utils import get_pg_size
+
+    if parallelization_group is None:
+        parallelization_group = torch.distributed.group.WORLD
+    group_size = get_pg_size(group=parallelization_group)
+    if group_size <= 1:
+        return
+
+    if pg_cache_path is not None:
+        # The resolved file path uniquely identifies this (cache dir, group) and
+        # keys the process-global memo. Checking it *first* makes both READ and
+        # CREATE idempotent within a job: a second call for the same group (a
+        # later save, the second `replicate_local_replicas` call, or the save
+        # wrapper reusing what the load wrapper already cached) returns from
+        # memory with no collective and no file IO. The check is identical on all
+        # ranks of the group, so it never desynchronizes the collective below.
+        cache_file = _pg_dist_cache_file_path(pg_cache_path, parallelization_group)
+        if cache_file in _PG_DIST_CACHE:
+            return _PG_DIST_CACHE[cache_file][bool(ignore_groups)]
+
+        # READ path: no collective; open the file once, then memoize both variants.
+        if not pg_cache_create:
+            both = _load_pg_dist_cache(cache_file)
+            _PG_DIST_CACHE[cache_file] = both
+            return both[bool(ignore_groups)]
+
+        # CREATE path: gather once, build & persist both variants, then memoize
+        # so no subsequent call for this group gathers or writes again.
+        all_shards = _gather_shards_metadata(sharded_state_dict, parallelization_group)
+        both = _create_pg_dist_cache(all_shards, pg_cache_path, parallelization_group)
+        _PG_DIST_CACHE[cache_file] = both
+        return both[bool(ignore_groups)]
+
+    # Default path: unchanged behaviour.
+    all_shards = _gather_shards_metadata(sharded_state_dict, parallelization_group)
+    return _build_shard_distribution(all_shards, ignore_groups)
 
 
 @torch.no_grad()

--- a/megatron/core/dist_checkpointing/strategies/fully_parallel.py
+++ b/megatron/core/dist_checkpointing/strategies/fully_parallel.py
@@ -75,6 +75,8 @@ class FullyParallelSaveStrategyWrapper:
         do_cache_distribution: bool = False,
         backend: str = "torch_dist",
         version: int = 1,
+        pg_cache_path: Optional[str] = None,
+        pg_cache_create: bool = False,
     ):
         """ """
         self.base_strategy = strategy
@@ -84,6 +86,11 @@ class FullyParallelSaveStrategyWrapper:
         self.do_cache_distribution = do_cache_distribution
         self.backend = backend
         self.version = version
+        # PG-collective caching (see determine_main_replica_uniform_distribution).
+        # When pg_cache_path is set and pg_cache_create is False, the save
+        # distribution is read from disk and the all_gather_object is skipped.
+        self.pg_cache_path = pg_cache_path
+        self.pg_cache_create = pg_cache_create
 
         self.cached_distribution: Optional[ShardDistribution] = None
 
@@ -124,13 +131,21 @@ class FullyParallelSaveStrategyWrapper:
         else:
             logger.debug(f'Apply save parallelization')
             precomputed_distribution = determine_main_replica_uniform_distribution(
-                sharded_state_dict, self.parallelization_group
+                sharded_state_dict,
+                self.parallelization_group,
+                pg_cache_path=self.pg_cache_path,
+                pg_cache_create=self.pg_cache_create,
             )
 
         distribute_main_replicas_with_precomputed_distribution(
             sharded_state_dict, self.parallelization_group, precomputed_distribution
         )
-        if self.cached_distribution is None:
+        # In cache-read mode the user vouches for a matching config/world size,
+        # so we also skip this first-save integrity check — it triggers its own
+        # collective (determine_global_metadata), which would defeat the purpose
+        # of skipping the distribution all_gather.
+        pg_cache_read = self.pg_cache_path is not None and not self.pg_cache_create
+        if self.cached_distribution is None and not pg_cache_read:
             # First time applying the parallelization
             validate_sharding_integrity(determine_global_metadata(sharded_state_dict)[1])
         if self.do_cache_distribution:
@@ -171,6 +186,8 @@ class FullyParallelLoadStrategyWrapper:
         parallelization_group: Optional[torch.distributed.ProcessGroup] = None,
         do_cache_distribution: bool = False,
         exchange_algo: str = 'broadcast',
+        pg_cache_path: Optional[str] = None,
+        pg_cache_create: bool = False,
     ):
         self.base_strategy = strategy
         if parallelization_group is None:
@@ -180,6 +197,11 @@ class FullyParallelLoadStrategyWrapper:
         self.parallelization_group = parallelization_group
         self.do_cache_distribution = do_cache_distribution
         self.exchange_algo = exchange_algo
+        # PG-collective caching (see determine_main_replica_uniform_distribution).
+        # When pg_cache_path is set and pg_cache_create is False, the load
+        # distribution is read from disk and the all_gather_object is skipped.
+        self.pg_cache_path = pg_cache_path
+        self.pg_cache_create = pg_cache_create
 
         self.cached_distribution: Optional[ShardDistribution] = None
         self.cached_global_metadata: Optional[Metadata] = None
@@ -385,7 +407,11 @@ class FullyParallelLoadStrategyWrapper:
         else:
             logger.debug(f'Apply load parallelization')
             precomputed_distribution = determine_main_replica_uniform_distribution(
-                sharded_state_dict, self.parallelization_group, True
+                sharded_state_dict,
+                self.parallelization_group,
+                True,
+                pg_cache_path=self.pg_cache_path,
+                pg_cache_create=self.pg_cache_create,
             )
 
         distribute_main_replicas_with_precomputed_distribution(

--- a/megatron/core/dist_checkpointing/strategies/fully_parallel.py
+++ b/megatron/core/dist_checkpointing/strategies/fully_parallel.py
@@ -76,6 +76,8 @@ class FullyParallelSaveStrategyWrapper:
         backend: str = "torch_dist",
         version: int = 1,
         validate_access_integrity: bool = True,
+        pg_cache_path: Optional[str] = None,
+        pg_cache_create: bool = False,
     ):
         """ """
         self.base_strategy = strategy
@@ -91,6 +93,11 @@ class FullyParallelSaveStrategyWrapper:
         # --no-ckpt-load-validate-sharding-integrity skips *both* save-side
         # validation collectives, not just the one in save_preprocess.
         self.validate_access_integrity = validate_access_integrity
+        # PG-collective caching (see determine_main_replica_uniform_distribution).
+        # When pg_cache_path is set and pg_cache_create is False, the save
+        # distribution is read from disk and the all_gather_object is skipped.
+        self.pg_cache_path = pg_cache_path
+        self.pg_cache_create = pg_cache_create
 
         self.cached_distribution: Optional[ShardDistribution] = None
 
@@ -131,13 +138,25 @@ class FullyParallelSaveStrategyWrapper:
         else:
             logger.debug(f'Apply save parallelization')
             precomputed_distribution = determine_main_replica_uniform_distribution(
-                sharded_state_dict, self.parallelization_group
+                sharded_state_dict,
+                self.parallelization_group,
+                pg_cache_path=self.pg_cache_path,
+                pg_cache_create=self.pg_cache_create,
             )
 
         distribute_main_replicas_with_precomputed_distribution(
             sharded_state_dict, self.parallelization_group, precomputed_distribution
         )
-        if self.cached_distribution is None and self.validate_access_integrity:
+        # In cache-read mode the user vouches for a matching config/world size,
+        # so we also skip this first-save integrity check — it triggers its own
+        # collective (determine_global_metadata), which would defeat the purpose
+        # of skipping the distribution all_gather.
+        pg_cache_read = self.pg_cache_path is not None and not self.pg_cache_create
+        if (
+            self.cached_distribution is None
+            and not pg_cache_read
+            and self.validate_access_integrity
+        ):
             # First time applying the parallelization
             validate_sharding_integrity(determine_global_metadata(sharded_state_dict)[1])
         if self.do_cache_distribution:
@@ -179,6 +198,8 @@ class FullyParallelLoadStrategyWrapper:
         do_cache_distribution: bool = False,
         exchange_algo: str = 'broadcast',
         per_rank_object_load: bool = False,
+        pg_cache_path: Optional[str] = None,
+        pg_cache_create: bool = False,
     ):
         self.base_strategy = strategy
         if parallelization_group is None:
@@ -193,6 +214,11 @@ class FullyParallelLoadStrategyWrapper:
         # with a WORLD-wide `all_gather_object`. Opt-in; defaults to the legacy
         # gather-based exchange. See `load` for correctness rationale.
         self.per_rank_object_load = per_rank_object_load
+        # PG-collective caching (see determine_main_replica_uniform_distribution).
+        # When pg_cache_path is set and pg_cache_create is False, the load
+        # distribution is read from disk and the all_gather_object is skipped.
+        self.pg_cache_path = pg_cache_path
+        self.pg_cache_create = pg_cache_create
 
         self.cached_distribution: Optional[ShardDistribution] = None
         self.cached_global_metadata: Optional[Metadata] = None
@@ -433,7 +459,11 @@ class FullyParallelLoadStrategyWrapper:
         else:
             logger.debug(f'Apply load parallelization')
             precomputed_distribution = determine_main_replica_uniform_distribution(
-                sharded_state_dict, self.parallelization_group, True
+                sharded_state_dict,
+                self.parallelization_group,
+                True,
+                pg_cache_path=self.pg_cache_path,
+                pg_cache_create=self.pg_cache_create,
             )
 
         distribute_main_replicas_with_precomputed_distribution(

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1723,6 +1723,25 @@ def validate_args(args, defaults={}):
                 "Other algorithms cannot guarantee numerical stability yet."
             )
 
+    # The PG-distribution cache stores one file per parallelization group, keyed by
+    # that group's minimum global rank, and each file holds both the save and the
+    # load distribution. If save and load used different parallelization groups,
+    # two distinct groups could map to the same file (they can share a minimum
+    # global rank), so one side would silently read a distribution computed for the
+    # other group's layout. Require both sides to use the same group.
+    if args.ckpt_pg_tensors_cache_path is not None:
+        assert (
+            args.ckpt_fully_parallel_save_process_group
+            == args.ckpt_fully_parallel_load_process_group
+        ), (
+            "--ckpt-pg-tensors-cache-path requires --ckpt-fully-parallel-save-process-group and "
+            "--ckpt-fully-parallel-load-process-group to be identical, but got "
+            f"save='{args.ckpt_fully_parallel_save_process_group}' and "
+            f"load='{args.ckpt_fully_parallel_load_process_group}'. The cache is keyed by the "
+            "parallelization group, so mixing groups can read a distribution computed for a "
+            "different layout."
+        )
+
     if args.load_main_params_from_ckpt:
         assert args.no_load_optim, '--load-main-params-from-ckpt must be used with --no-load-optim.'
 

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -848,6 +848,8 @@ def save_checkpoint(
                         process_group,
                         args.ckpt_assume_constant_structure,
                         validate_access_integrity=args.ckpt_load_validate_sharding_integrity,
+                        pg_cache_path=getattr(args, 'ckpt_pg_tensors_cache_path', None),
+                        pg_cache_create=getattr(args, 'ckpt_pg_tensors_cache_create', False),
                     )
             # Allow opting out of save-side sharding validation entirely (even on
             # the first save) via --no-ckpt-load-validate-sharding-integrity. This
@@ -1754,6 +1756,8 @@ def _load_global_dist_base_checkpoint(
             per_rank_object_load=getattr(
                 args, 'ckpt_fully_parallel_load_per_rank_objects', False
             ),
+            pg_cache_path=getattr(args, 'ckpt_pg_tensors_cache_path', None),
+            pg_cache_create=getattr(args, 'ckpt_pg_tensors_cache_create', False),
         )
     if checkpointing_context is not None:
         checkpointing_context['load_strategy'] = load_strategy

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -827,7 +827,11 @@ def save_checkpoint(
                             else mpu.get_expert_data_parallel_group()
                         )
                     save_strategy = FullyParallelSaveStrategyWrapper(
-                        save_strategy, process_group, args.ckpt_assume_constant_structure
+                        save_strategy,
+                        process_group,
+                        args.ckpt_assume_constant_structure,
+                        pg_cache_path=getattr(args, 'ckpt_pg_tensors_cache_path', None),
+                        pg_cache_create=getattr(args, 'ckpt_pg_tensors_cache_create', False),
                     )
             # Store save strategy for future checkpoint saves
             if checkpointing_context is not None:
@@ -1631,7 +1635,9 @@ def _load_global_dist_base_checkpoint(
             )
 
         load_strategy = FullyParallelLoadStrategyWrapper(
-            load_strategy, process_group, exchange_algo=args.ckpt_fully_parallel_load_exchange_algo
+            load_strategy, process_group, exchange_algo=args.ckpt_fully_parallel_load_exchange_algo,
+            pg_cache_path=getattr(args, 'ckpt_pg_tensors_cache_path', None),
+            pg_cache_create=getattr(args, 'ckpt_pg_tensors_cache_create', False),
         )
     if checkpointing_context is not None:
         checkpointing_context['load_strategy'] = load_strategy

--- a/megatron/training/config/training_config.py
+++ b/megatron/training/config/training_config.py
@@ -563,6 +563,25 @@ class CheckpointConfig:
     ckpt_assume_constant_structure: bool = False
     """Assume the checkpoint structure is constant across saves to enable optimizations."""
 
+    ckpt_pg_tensors_cache_path: Optional[str] = None
+    """Directory of the parallelization-group distribution cache for fully parallel
+    save/load of distributed checkpoints. When set, the expensive
+    ``all_gather_object`` in ``determine_main_replica_uniform_distribution`` is
+    replaced by a single per-group file read (the load and save distributions are
+    loaded from this directory). Only safe when the config and world size match the
+    run that created the cache (see ``--ckpt-pg-tensors-cache-create``); no
+    existence/validity checks are performed, for the lowest possible latency.
+    Default (None) preserves the original collective-based behaviour."""
+
+    ckpt_pg_tensors_cache_create: bool = False
+    """Create (rather than read) the parallelization-group distribution cache at
+    ``--ckpt-pg-tensors-cache-path``. Set this for a single run with a matching
+    config/world size: the collective runs as usual but both the save and load
+    distributions are derived from that single gather and written to disk, one
+    file per parallelization group. Subsequent runs set only
+    ``--ckpt-pg-tensors-cache-path`` (leave this False) to skip the collective.
+    Default: False."""
+
     ckpt_load_validate_sharding_integrity: bool = True
     """Whether to validate sharding access integrity when loading a distributed checkpoint.
     When True (default), each tensor shard is checked to be accessed exactly once as main

--- a/megatron/training/config/training_config.py
+++ b/megatron/training/config/training_config.py
@@ -571,6 +571,25 @@ class CheckpointConfig:
     ckpt_assume_constant_structure: bool = False
     """Assume the checkpoint structure is constant across saves to enable optimizations."""
 
+    ckpt_pg_tensors_cache_path: Optional[str] = None
+    """Directory of the parallelization-group distribution cache for fully parallel
+    save/load of distributed checkpoints. When set, the expensive
+    ``all_gather_object`` in ``determine_main_replica_uniform_distribution`` is
+    replaced by a single per-group file read (the load and save distributions are
+    loaded from this directory). Only safe when the config and world size match the
+    run that created the cache (see ``--ckpt-pg-tensors-cache-create``); no
+    existence/validity checks are performed, for the lowest possible latency.
+    Default (None) preserves the original collective-based behaviour."""
+
+    ckpt_pg_tensors_cache_create: bool = False
+    """Create (rather than read) the parallelization-group distribution cache at
+    ``--ckpt-pg-tensors-cache-path``. Set this for a single run with a matching
+    config/world size: the collective runs as usual but both the save and load
+    distributions are derived from that single gather and written to disk, one
+    file per parallelization group. Subsequent runs set only
+    ``--ckpt-pg-tensors-cache-path`` (leave this False) to skip the collective.
+    Default: False."""
+
     ckpt_load_validate_sharding_integrity: bool = True
     """Whether to validate sharding access integrity when loading *and saving* a distributed
     checkpoint. When True (default), each tensor shard is checked to be accessed exactly once as

--- a/tests/unit_tests/dist_checkpointing/models/common.py
+++ b/tests/unit_tests/dist_checkpointing/models/common.py
@@ -141,6 +141,87 @@ def common_test_parallel_reconfiguration_e2e(
         Utils.destroy_model_parallel()
 
 
+def common_test_pg_distribution_cache_e2e(
+    initialize_model_fn, tmp_path_dist_ckpt, parallelization_group, sharded_state_dict_fn=None
+):
+    """Save/load a real sharded model with and without the PG-distribution cache.
+
+    The cache only changes *how* the fully-parallel save/load distribution is
+    obtained, so it must be invisible end to end: the checkpoint written through it
+    and the state dict loaded through it have to match the ones produced without it.
+
+    Both halves use the same parallel layout, which is the only regime the cache is
+    valid for (it is keyed by the parallelization group), and it mirrors how the
+    feature is used in practice: one job creates the cache, a later job with the
+    same config reuses it and skips the distribution all_gather.
+    """
+    from megatron.core.dist_checkpointing import exchange_utils
+
+    if sharded_state_dict_fn is None:
+        sharded_state_dict_fn = lambda model: model.sharded_state_dict()
+
+    def _save(model, ckpt_dir, pg_cache_path=None, pg_cache_create=False):
+        save_strategy = FullyParallelSaveStrategyWrapper(
+            TorchDistSaveShardedStrategy(),
+            parallelization_group,
+            True,
+            pg_cache_path=pg_cache_path,
+            pg_cache_create=pg_cache_create,
+        )
+        save(sharded_state_dict_fn(model), ckpt_dir, save_strategy)
+
+    def _load(model, ckpt_dir, pg_cache_path=None):
+        load_strategy = FullyParallelLoadStrategyWrapper(
+            TorchDistLoadShardedStrategy(), parallelization_group, pg_cache_path=pg_cache_path
+        )
+        state_dict, missing_keys, unexpected_keys = load(
+            sharded_state_dict_fn(model), ckpt_dir, load_strategy, strict=StrictHandling.RETURN_ALL
+        )
+        # Potential mismatch is because of extra states which is ok
+        assert all('_extra_state' in k for k in missing_keys)
+        assert all('_extra_state' in k for k in unexpected_keys)
+        return state_dict
+
+    with (
+        TempNamedDir(tmp_path_dist_ckpt / 'pg_cache_dir', sync=True) as cache_dir,
+        TempNamedDir(tmp_path_dist_ckpt / 'pg_cache_ckpt_plain', sync=True) as ckpt_dir_plain,
+        TempNamedDir(tmp_path_dist_ckpt / 'pg_cache_ckpt_cached', sync=True) as ckpt_dir_cached,
+    ):
+        cache_path = str(cache_dir)
+        model_A = initialize_model_fn(1)
+
+        # Reference save, then the same save with the cache being created.
+        exchange_utils._PG_DIST_CACHE.clear()
+        _save(model_A, ckpt_dir_plain)
+        exchange_utils._PG_DIST_CACHE.clear()
+        _save(model_A, ckpt_dir_cached, pg_cache_path=cache_path, pg_cache_create=True)
+        torch.distributed.barrier()
+
+        # Load both back into freshly initialized models (seed 2, so the loaded
+        # values can only come from the checkpoints). The cached load drops the
+        # in-process memo first so it genuinely reads the distribution from disk.
+        model_B_plain = initialize_model_fn(2)
+        exchange_utils._PG_DIST_CACHE.clear()
+        loaded_plain = _load(model_B_plain, ckpt_dir_plain)
+
+        model_B_cached = initialize_model_fn(2)
+        exchange_utils._PG_DIST_CACHE.clear()
+        loaded_cached = _load(model_B_cached, ckpt_dir_cached, pg_cache_path=cache_path)
+
+        # The cached load must return exactly what the uncached load returns.
+        diffs = diff(loaded_plain, loaded_cached)
+        assert not any(map(bool, diffs)), diffs
+
+        # ... and both checkpoints must hold the same tensors on disk.
+        Utils.destroy_model_parallel()
+        Utils.initialize_model_parallel(1, 1)
+        diffs = diff(load_plain_tensors(ckpt_dir_plain), load_plain_tensors(ckpt_dir_cached))
+        assert not any(map(bool, diffs)), diffs
+
+    exchange_utils._PG_DIST_CACHE.clear()
+    Utils.destroy_model_parallel()
+
+
 def common_test_state_dict_comparison(initialize_model_fn, tmp_path_dist_ckpt):
     tp = 2
     pp = 4

--- a/tests/unit_tests/dist_checkpointing/models/test_gpt_model.py
+++ b/tests/unit_tests/dist_checkpointing/models/test_gpt_model.py
@@ -20,6 +20,7 @@ from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.utils import is_te_min_version
 from tests.unit_tests.dist_checkpointing.models.common import (
     common_test_parallel_reconfiguration_e2e,
+    common_test_pg_distribution_cache_e2e,
     common_test_simple_sharded_state_dict_save_load,
     common_test_state_dict_comparison,
     common_test_vocab_size_padding_change,
@@ -155,6 +156,24 @@ class TestGPTModelReconfiguration:
             load_order,
             store_order,
             metadata={'singleton_local_shards': singleton_local_shards},
+        )
+
+    @pytest.mark.parametrize(('tp', 'pp'), [(1, 1), (2, 1), (1, 2), (2, 2)])
+    def test_pg_distribution_cache_e2e(self, tmp_path_dist_ckpt, tp, pp):
+        """A real sharded GPT checkpoint must round-trip identically through the
+        PG-distribution cache (--ckpt-pg-tensors-cache-path).
+
+        Covers tensor and pipeline parallelism: each pipeline stage has its own
+        data-parallel group, hence its own cache file, so the cached distribution
+        must stay stage-local.
+        """
+        Utils.initialize_model_parallel(tp, pp)
+        common_test_pg_distribution_cache_e2e(
+            lambda seed: initialize_gpt_model(
+                seed, gpt_te_spec, tensor_model_parallel_size=tp, pipeline_model_parallel_size=pp
+            ),
+            tmp_path_dist_ckpt,
+            ps.get_data_parallel_group(with_context_parallel=True),
         )
 
     def test_state_dict_comparison(self, tmp_path_dist_ckpt):

--- a/tests/unit_tests/dist_checkpointing/models/test_moe_experts.py
+++ b/tests/unit_tests/dist_checkpointing/models/test_moe_experts.py
@@ -29,6 +29,7 @@ from megatron.core.transformer.spec_utils import get_submodules
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.utils import is_te_min_version
 from tests.unit_tests.dist_checkpointing import TempNamedDir
+from tests.unit_tests.dist_checkpointing.models.common import common_test_pg_distribution_cache_e2e
 from tests.unit_tests.test_utilities import Utils
 
 fp8_available, reason_for_no_fp8 = check_fp8_support()
@@ -131,6 +132,35 @@ class TestExpertLayerReconfiguration:
 
     def teardown_method(self, method):
         Utils.destroy_model_parallel()
+
+    @pytest.mark.parametrize('save_load_process_group', ['dp', 'ep_dp'])
+    @pytest.mark.parametrize(('tp', 'pp', 'ep'), [(1, 1, 1), (1, 1, 2), (1, 2, 2), (2, 1, 2)])
+    @pytest.mark.parametrize('expert_type', expert_type)
+    def test_pg_distribution_cache_e2e(
+        self, tmp_path_dist_ckpt, tp, pp, ep, expert_type, save_load_process_group
+    ):
+        """MoE experts must round-trip identically through the PG-distribution cache.
+
+        Experts are the case the cache targets: they dominate the shard count and can
+        be distributed over either parallelization group that
+        --ckpt-fully-parallel-{save,load}-process-group selects, so both 'dp' and
+        'ep_dp' are covered here, across tensor, pipeline and expert parallelism.
+        """
+        Utils.initialize_model_parallel(tp, pp, expert_model_parallel_size=ep)
+        if save_load_process_group == 'ep_dp':
+            parallelization_group = parallel_state.get_expert_data_parallel_group()
+        else:
+            parallelization_group = parallel_state.get_data_parallel_group(
+                with_context_parallel=True
+            )
+        common_test_pg_distribution_cache_e2e(
+            lambda seed: initialize_expert_layer(seed, expert_type=expert_type),
+            tmp_path_dist_ckpt,
+            parallelization_group,
+            sharded_state_dict_fn=lambda model: model.sharded_state_dict(
+                prefix=f'{parallel_state.get_pipeline_model_parallel_rank()}.'
+            ),
+        )
 
     @pytest.mark.internal
     @pytest.mark.parametrize(

--- a/tests/unit_tests/dist_checkpointing/test_pg_distribution_cache.py
+++ b/tests/unit_tests/dist_checkpointing/test_pg_distribution_cache.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+
+"""Unit tests for the PG-distribution disk cache (``--ckpt-pg-tensors-cache-path``).
+
+The FullyParallel save/load distribution is a deterministic function of the
+sharded-state-dict structure and the parallel layout, computed via a single
+``all_gather_object`` (``_gather_shards_metadata``). The cache persists that
+result so later jobs can:
+  * CREATE (``pg_cache_create=True``): gather once and write the distribution.
+  * READ  (``pg_cache_create=False``): load it from disk and skip the gather.
+
+These tests run at world_size=2 (TP=2) but make no world-size-specific
+assertions, so they hold at any size.
+"""
+
+import os
+
+import torch
+
+from megatron.core.dist_checkpointing import ShardedTensor, exchange_utils
+from megatron.core.dist_checkpointing.exchange_utils import (
+    _pg_dist_cache_file_path,
+    determine_main_replica_uniform_distribution,
+)
+from tests.unit_tests.dist_checkpointing import TempNamedDir
+from tests.unit_tests.test_utilities import Utils
+
+
+def _state_dict():
+    # Fully-replicated tensors of different sizes; varying replica_id makes
+    # different ranks the main replica, so the save distribution is non-trivial.
+    return {
+        f"sd_key{i}": ShardedTensor.from_rank_offsets(
+            f"key{i}", torch.ones(10 * (i + 1)), replica_id=(Utils.rank + i) % Utils.world_size
+        )
+        for i in range(4)
+    }
+
+
+class TestPgDistributionCache:
+    def setup_method(self, method):
+        Utils.destroy_model_parallel()
+        exchange_utils._PG_DIST_CACHE.clear()
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+        exchange_utils._PG_DIST_CACHE.clear()
+
+    def test_create_writes_cache_and_read_matches(self, tmp_path_dist_ckpt):
+        Utils.initialize_model_parallel(2, 1)
+        group = torch.distributed.group.WORLD
+        with TempNamedDir(tmp_path_dist_ckpt / "pg_cache") as cache_dir:
+            cache_path = str(cache_dir)
+
+            # CREATE: runs the gather once and writes the cache file.
+            created = determine_main_replica_uniform_distribution(
+                _state_dict(), group, pg_cache_path=cache_path, pg_cache_create=True
+            )
+            torch.distributed.barrier()
+            assert os.path.exists(_pg_dist_cache_file_path(cache_path, group))
+
+            # Drop the in-process memo so the next call truly reads from disk.
+            exchange_utils._PG_DIST_CACHE.clear()
+
+            # READ: loads the distribution from disk.
+            read = determine_main_replica_uniform_distribution(
+                _state_dict(), group, pg_cache_path=cache_path, pg_cache_create=False
+            )
+
+            # The deterministic distribution decisions round-trip exactly.
+            assert read.main_rank_for_shard == created.main_rank_for_shard
+            assert read.all_ranks_for_shard == created.all_ranks_for_shard
+
+    def test_read_path_skips_the_gather_collective(self, tmp_path_dist_ckpt):
+        Utils.initialize_model_parallel(2, 1)
+        group = torch.distributed.group.WORLD
+        with TempNamedDir(tmp_path_dist_ckpt / "pg_cache_skip") as cache_dir:
+            cache_path = str(cache_dir)
+
+            created = determine_main_replica_uniform_distribution(
+                _state_dict(), group, pg_cache_path=cache_path, pg_cache_create=True
+            )
+            torch.distributed.barrier()
+            exchange_utils._PG_DIST_CACHE.clear()
+
+            # Make the metadata-exchange collective explode; the READ path must
+            # never reach it.
+            orig_gather = exchange_utils._gather_shards_metadata
+
+            def _boom(*args, **kwargs):
+                raise AssertionError("READ path must not run the all_gather_object collective")
+
+            exchange_utils._gather_shards_metadata = _boom
+            try:
+                read = determine_main_replica_uniform_distribution(
+                    _state_dict(), group, pg_cache_path=cache_path, pg_cache_create=False
+                )
+            finally:
+                exchange_utils._gather_shards_metadata = orig_gather
+
+            assert read is not None
+            assert read.main_rank_for_shard == created.main_rank_for_shard

--- a/tests/unit_tests/dist_checkpointing/test_pg_distribution_cache.py
+++ b/tests/unit_tests/dist_checkpointing/test_pg_distribution_cache.py
@@ -1,0 +1,198 @@
+# Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+
+"""Unit tests for the PG-distribution disk cache (``--ckpt-pg-tensors-cache-path``).
+
+The FullyParallel save/load distribution is a deterministic function of the
+sharded-state-dict structure and the parallel layout, computed via a single
+``all_gather_object`` (``_gather_shards_metadata``). The cache persists that
+result so later jobs can:
+  * CREATE (``pg_cache_create=True``): gather once and write the distribution.
+  * READ  (``pg_cache_create=False``): load it from disk and skip the gather.
+
+These tests run at world_size=2 (TP=2) but make no world-size-specific
+assertions, so they hold at any size.
+"""
+
+import os
+
+import torch
+
+from megatron.core.dist_checkpointing import ShardedTensor, exchange_utils
+from megatron.core.dist_checkpointing.exchange_utils import (
+    _pg_dist_cache_file_path,
+    determine_main_replica_uniform_distribution,
+)
+from megatron.core.dist_checkpointing.strategies.fully_parallel import (
+    FullyParallelLoadStrategyWrapper,
+    FullyParallelSaveStrategyWrapper,
+)
+from megatron.core.dist_checkpointing.strategies.torch import (
+    TorchDistLoadShardedStrategy,
+    TorchDistSaveShardedStrategy,
+)
+from tests.unit_tests.dist_checkpointing import TempNamedDir
+from tests.unit_tests.test_utilities import Utils
+
+
+def _state_dict():
+    # Fully-replicated tensors of different sizes; varying replica_id makes
+    # different ranks the main replica, so the save distribution is non-trivial.
+    return {
+        f"sd_key{i}": ShardedTensor.from_rank_offsets(
+            f"key{i}", torch.ones(10 * (i + 1)), replica_id=(Utils.rank + i) % Utils.world_size
+        )
+        for i in range(4)
+    }
+
+
+def _rank_marked_state_dict():
+    """Replicated shards whose *content* identifies the rank holding them.
+
+    Replicas normally carry identical data, which makes the elected main replica
+    unobservable in the loaded values. Marking each rank's copy with its own rank
+    makes the save distribution visible end-to-end: the loaded value tells you
+    which rank the distribution elected to write that shard.
+    """
+    return {
+        f"sd_key{i}": ShardedTensor.from_rank_offsets(
+            f"key{i}",
+            torch.full((10 * (i + 1),), float(Utils.rank)),
+            replica_id=(Utils.rank + i) % Utils.world_size,
+        )
+        for i in range(4)
+    }
+
+
+class TestPgDistributionCache:
+    def setup_method(self, method):
+        Utils.destroy_model_parallel()
+        exchange_utils._PG_DIST_CACHE.clear()
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+        exchange_utils._PG_DIST_CACHE.clear()
+
+    def test_create_writes_cache_and_read_matches(self, tmp_path_dist_ckpt):
+        Utils.initialize_model_parallel(2, 1)
+        group = torch.distributed.group.WORLD
+        with TempNamedDir(tmp_path_dist_ckpt / "pg_cache") as cache_dir:
+            cache_path = str(cache_dir)
+
+            # CREATE: runs the gather once and writes the cache file.
+            created = determine_main_replica_uniform_distribution(
+                _state_dict(), group, pg_cache_path=cache_path, pg_cache_create=True
+            )
+            torch.distributed.barrier()
+            assert os.path.exists(_pg_dist_cache_file_path(cache_path, group))
+
+            # Drop the in-process memo so the next call truly reads from disk.
+            exchange_utils._PG_DIST_CACHE.clear()
+
+            # READ: loads the distribution from disk.
+            read = determine_main_replica_uniform_distribution(
+                _state_dict(), group, pg_cache_path=cache_path, pg_cache_create=False
+            )
+
+            # The deterministic distribution decisions round-trip exactly.
+            assert read.main_rank_for_shard == created.main_rank_for_shard
+            assert read.all_ranks_for_shard == created.all_ranks_for_shard
+
+    def test_read_path_skips_the_gather_collective(self, tmp_path_dist_ckpt):
+        Utils.initialize_model_parallel(2, 1)
+        group = torch.distributed.group.WORLD
+        with TempNamedDir(tmp_path_dist_ckpt / "pg_cache_skip") as cache_dir:
+            cache_path = str(cache_dir)
+
+            created = determine_main_replica_uniform_distribution(
+                _state_dict(), group, pg_cache_path=cache_path, pg_cache_create=True
+            )
+            torch.distributed.barrier()
+            exchange_utils._PG_DIST_CACHE.clear()
+
+            # Make the metadata-exchange collective explode; the READ path must
+            # never reach it.
+            orig_gather = exchange_utils._gather_shards_metadata
+
+            def _boom(*args, **kwargs):
+                raise AssertionError("READ path must not run the all_gather_object collective")
+
+            exchange_utils._gather_shards_metadata = _boom
+            try:
+                read = determine_main_replica_uniform_distribution(
+                    _state_dict(), group, pg_cache_path=cache_path, pg_cache_create=False
+                )
+            finally:
+                exchange_utils._gather_shards_metadata = orig_gather
+
+            assert read is not None
+            assert read.main_rank_for_shard == created.main_rank_for_shard
+
+    def test_checkpoint_roundtrip_matches_without_cache(self, tmp_path_dist_ckpt):
+        """A real save+load with the cache must return exactly what it does without it.
+
+        The cache only replaces *how* the save/load distribution is obtained, so a
+        checkpoint written and read back through it must be indistinguishable from
+        the default path. This exercises the full FullyParallel save -> load
+        round-trip, which is what would break if a cached distribution were applied
+        to the wrong shards.
+        """
+        Utils.initialize_model_parallel(2, 1)
+        group = torch.distributed.group.WORLD
+
+        # Reference (no cache): plain save + load.
+        with TempNamedDir(tmp_path_dist_ckpt / "rt_plain", sync=True) as plain_dir:
+            FullyParallelSaveStrategyWrapper(TorchDistSaveShardedStrategy(), group).save(
+                _rank_marked_state_dict(), plain_dir
+            )
+            torch.distributed.barrier()
+            plain_loaded = FullyParallelLoadStrategyWrapper(
+                TorchDistLoadShardedStrategy(), group
+            ).load(_rank_marked_state_dict(), plain_dir)
+
+        exchange_utils._PG_DIST_CACHE.clear()
+
+        # Same round-trip, but the distribution is written to and then read back
+        # from the on-disk cache.
+        with TempNamedDir(tmp_path_dist_ckpt / "rt_cache_dir", sync=True) as cache_dir:
+            cache_path = str(cache_dir)
+            with TempNamedDir(tmp_path_dist_ckpt / "rt_cached", sync=True) as cached_ckpt_dir:
+                # CREATE: this save computes and persists the distribution.
+                FullyParallelSaveStrategyWrapper(
+                    TorchDistSaveShardedStrategy(),
+                    group,
+                    pg_cache_path=cache_path,
+                    pg_cache_create=True,
+                ).save(_rank_marked_state_dict(), cached_ckpt_dir)
+                torch.distributed.barrier()
+
+                # The create-mode save must have persisted the distribution, and
+                # dropping the in-process memo forces the load to read that file.
+                assert os.path.exists(_pg_dist_cache_file_path(cache_path, group))
+                exchange_utils._PG_DIST_CACHE.clear()
+
+                # READ: the load takes the distribution from disk. Fail loudly if it
+                # falls back to the collective, which would make this test vacuous.
+                orig_gather = exchange_utils._gather_shards_metadata
+
+                def _boom(*args, **kwargs):
+                    raise AssertionError("cached load must not run the all_gather_object")
+
+                exchange_utils._gather_shards_metadata = _boom
+                try:
+                    cached_loaded = FullyParallelLoadStrategyWrapper(
+                        TorchDistLoadShardedStrategy(), group, pg_cache_path=cache_path
+                    ).load(_rank_marked_state_dict(), cached_ckpt_dir)
+                finally:
+                    exchange_utils._gather_shards_metadata = orig_gather
+
+        assert cached_loaded.keys() == plain_loaded.keys()
+        for key, expected in plain_loaded.items():
+            actual = cached_loaded[key]
+            assert torch.equal(actual, expected), f"mismatch for {key}"
+        # Guard against a vacuous comparison: each loaded shard must be a
+        # rank-marked tensor of the expected shape (a single rank's copy).
+        for i, key in enumerate(sorted(plain_loaded)):
+            shard = plain_loaded[key]
+            assert shard.shape == (10 * (i + 1),)
+            assert torch.equal(shard, torch.full_like(shard, shard[0].item()))
+            assert 0 <= shard[0].item() < Utils.world_size


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do ?

Cache the FullyParallel save distribution on disk (`--ckpt-pg-tensors-cache-path` / `--ckpt-pg-tensors-cache-create`) so the planning `all_gather_object` is skipped across jobs.
 
## Issue tracking

Linked issue: <!-- TODO: open a feature-request issue and reference it here (required for new features) -->

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code
- [x] I have added relevant documentation
- [x] I have run the autoformatter.sh on my PR

---

# Cache the fully-parallel save/load shard distribution on disk

## Problem

When saving or loading a distributed checkpoint with fully-parallel
save/load enabled, `determine_main_replica_uniform_distribution` runs a
world-wide `all_gather_object` over the parallelization group to exchange every
rank's shard *metadata* and decide which rank is the main saver/loader of each
shard. At large scale this gather is the dominant cost of the planning step and
runs on **every job**.

Its result, however, is a pure deterministic function of the sharded-state-dict
structure and the parallel layout. For a fixed model config and world size it is
**identical across jobs and across resumes** — so paying for the collective on
every job is wasteful.

## Solution

Allow the per-parallelization-group distribution to be cached on disk and reused,
skipping the collective entirely on subsequent jobs. Two new (optional) knobs:

- `--ckpt-pg-tensors-cache-path <DIR>`: when set (and *create* is off), the
  distribution for each group is **read from disk** and the `all_gather_object`
  is skipped — both for save and load.
- `--ckpt-pg-tensors-cache-create`: run once with a matching config/world size.
  The collective runs as usual, but **both** the save (`ignore_groups=False`)
  and load (`ignore_groups=True`) distributions are derived from that single
  gather and written to disk (one file per group). Later jobs set only
  `--ckpt-pg-tensors-cache-path` to consume them.

Default (neither set) preserves the original collective-based behaviour exactly.

### Implementation

`megatron/core/dist_checkpointing/exchange_utils.py` — `determine_main_replica_uniform_distribution`
is refactored into composable pieces so the gather and the post-gather logic can
be cached/replayed independently:

- `_gather_shards_metadata()` — the single `all_gather_object` (data stripped via
  `without_data()`, so the payload is tiny).
- `_build_shard_distribution(all_shards, ignore_groups)` — the pure,
  rank-independent algorithm; rank-independence is what makes the result safe to
  persist and reload.
- `_pg_dist_cache_file_path()` — one file per group, keyed by `min(global ranks)`
  of the group (a collision-free id derivable with no collective).
- `_load_pg_dist_cache()` / `_create_pg_dist_cache()` — read / atomically write
  (`temp + os.replace`) the `{ignore_groups: ShardDistribution}` map; only the
  group's writer rank writes.
- A process-global memo (`_PG_DIST_CACHE`) makes each group create-or-read at most
  once per job (later saves / the load wrapper's reuse hit memory). The memo is
  checked **before** the collective so all ranks of a group hit/miss in lockstep.

`fully_parallel.py` — `FullyParallelSaveStrategyWrapper` and
`FullyParallelLoadStrategyWrapper` gain `pg_cache_path` / `pg_cache_create` and
pass them through. In **read** mode the save wrapper also skips the first-save
`validate_sharding_integrity` check, because that triggers its own world collective
(`determine_global_metadata`) which would defeat skipping the distribution gather.

`checkpointing.py` — wires the two args into both wrappers.

`config/training_config.py` — defines the two `CheckpointConfig` fields.

## Files changed

- `megatron/core/dist_checkpointing/exchange_utils.py`
- `megatron/core/dist_checkpointing/strategies/fully_parallel.py`
- `megatron/training/checkpointing.py`
- `megatron/training/config/training_config.py`

## Usage

First job (create the cache once, on a matching config/world size):
```
--ckpt-fully-parallel-save --ckpt-fully-parallel-load \
--ckpt-pg-tensors-cache-path $CONTAINER/pg_dist_cache --ckpt-pg-tensors-cache-create
```
Subsequent jobs (reuse, collective skipped):
```
--ckpt-fully-parallel-save --ckpt-fully-parallel-load \
--ckpt-pg-tensors-cache-path $CONTAINER/pg_dist_cache
```

## Correctness constraints

The cache is consumed with **no existence/validity checks** by design (lowest
latency). It is only valid when the consuming run has the **same model config,
parallel layout, and world size** as the run that created it. A mismatch yields a
wrong shard map. Treat the cache as config-specific and regenerate it whenever the
structure changes.

## Testing notes

- **Unit test** (`tests/unit_tests/dist_checkpointing/test_pg_distribution_cache.py`,
  `TestPgDistributionCache`): (1) CREATE writes the cache file and, after clearing
  the in-process memo, READ loads an **identical** distribution from disk
  (`main_rank_for_shard` / `all_ranks_for_shard` match); (2) the READ path is proven
  to **skip the collective** by monkeypatching `_gather_shards_metadata` to raise and
  asserting it is never called. World-size-agnostic (validated locally at ws=2;
  holds at ws=8 in CI).
- Default path (no flags) is byte-for-byte the original behaviour — the refactor
  splits the function but the create/default code path produces the same
  `ShardDistribution`.
- End-to-end: create a cache with `--ckpt-pg-tensors-cache-create`, then run a
  second job with only `--ckpt-pg-tensors-cache-path` and confirm saves/loads
  succeed and the distribution all_gather no longer appears.
