### PR TITLE
Add --ckpt-metadata to reuse prepared checkpoint metadata across saves

### DIFF
--- a/megatron/core/dist_checkpointing/strategies/torch.py
+++ b/megatron/core/dist_checkpointing/strategies/torch.py
@@ -650,6 +650,18 @@ class TorchDistSaveShardedStrategy:
 
         self.validated_loaded_metadata_reuse = False
 
+        # `--ckpt-metadata`: a prepared, complete Metadata (carrying storage_data).
+        # When set (read mode), every save writes it verbatim as the checkpoint
+        # `.metadata` and the nvrx finalize/planning skip both gather collectives.
+        self.prepared_metadata: Optional[Metadata] = None
+        # `--ckpt-metadata` + `--ckpt-metadata-create`: path to *create* the
+        # prepared metadata. While `prepared_metadata` is still None (i.e. on the
+        # very first save) the save runs the full collectives and the nvrx
+        # finalize writes the complete metadata to this path AND returns it; we
+        # then stash it as `prepared_metadata` so subsequent saves in this job
+        # take the fast (collective-free) path.
+        self.ckpt_metadata_create_path: Optional[str] = None
+
     def save(self, sharded_state_dict: ShardedStateDict, checkpoint_dir: Path):
         """Sync save always uses the built-in implementation."""
         async_request = self.async_save(sharded_state_dict, checkpoint_dir, async_strategy="mcore")
@@ -723,6 +735,12 @@ class TorchDistSaveShardedStrategy:
                     )
             state_dict_saver_kwargs["enable_cache"] = self.use_cached_ckpt_structure
             state_dict_saver_kwargs["metadata_cache"] = self._metadata_cache
+            # `--ckpt-metadata`: hand the prepared metadata to the planner so it
+            # skips the plan `gather_object` too (its result is discarded when we
+            # reuse the full metadata). Combined with the finalize skip, the only
+            # remaining save collective is the 1-int failure all_reduce.
+            if self.prepared_metadata is not None:
+                state_dict_saver_kwargs["reuse_metadata_obj"] = self.prepared_metadata
         else:
             # MCore's async implementation
             args_cached_plans = None
@@ -806,10 +824,38 @@ class TorchDistSaveShardedStrategy:
                         save_state_dict_ret = list(save_state_dict_ret)
                         save_state_dict_ret[1] = self.cached_global_metadata
 
-        return self._get_save_and_finalize_callbacks(writer, save_state_dict_ret, async_strategy)
+        # `--ckpt-metadata` (nvrx only). Either reuse a prepared metadata (skip
+        # both gathers) or, in create mode on the first save, tell the finalize to
+        # build + persist + return the complete metadata.
+        reuse_metadata_obj = (
+            self.prepared_metadata
+            if (async_strategy == "nvrx" and self.prepared_metadata is not None)
+            else None
+        )
+        create_metadata_path = (
+            self.ckpt_metadata_create_path
+            if (
+                async_strategy == "nvrx"
+                and self.prepared_metadata is None
+                and self.ckpt_metadata_create_path is not None
+            )
+            else None
+        )
+        return self._get_save_and_finalize_callbacks(
+            writer,
+            save_state_dict_ret,
+            async_strategy,
+            reuse_metadata_obj=reuse_metadata_obj,
+            create_metadata_path=create_metadata_path,
+        )
 
     def _get_save_and_finalize_callbacks(
-        self, writer, save_state_dict_ret, async_strategy
+        self,
+        writer,
+        save_state_dict_ret,
+        async_strategy,
+        reuse_metadata_obj=None,
+        create_metadata_path=None,
     ) -> AsyncRequest | NVRxAsyncRequest:
         save_fn_args = writer.get_save_function_and_args()
         save_fn, preload_fn, save_args = save_fn_args
@@ -819,8 +865,23 @@ class TorchDistSaveShardedStrategy:
         async_request = modules["AsyncRequest"]
         save_state_dict_async_finalize = modules["save_state_dict_async_finalize"]
 
+        # `reuse_metadata_obj` / `create_metadata_path` are nvrx-only kwargs (the
+        # mcore finalize doesn't accept them), so only pass them when present.
+        finalize_kwargs = {}
+        if reuse_metadata_obj is not None:
+            finalize_kwargs["reuse_metadata_obj"] = reuse_metadata_obj
+        if create_metadata_path is not None:
+            finalize_kwargs["create_metadata_path"] = create_metadata_path
+
+        strategy = self
+
         def finalize_fn():
-            save_state_dict_async_finalize(*save_state_dict_ret)
+            created = save_state_dict_async_finalize(*save_state_dict_ret, **finalize_kwargs)
+            # Create mode: the finalize returns the complete metadata on every
+            # rank; stash it so subsequent saves in this job reuse it (and thus
+            # take the collective-free fast path).
+            if created is not None:
+                strategy.prepared_metadata = created
 
         return make_nvrx_async_request(
             async_request, save_fn, save_args, [finalize_fn], preload_fn=preload_fn

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2893,6 +2893,25 @@ def _add_checkpointing_args(parser):
     group.add_argument('--ckpt-fully-parallel-save', action='store_true',
                        dest='ckpt_fully_parallel_save_deprecated',
                        help='Deprecated: see --no-ckpt-fully-parallel-save.')
+    group.add_argument('--ckpt-metadata', type=str, default=None,
+                       help='Path to a prepared distributed-checkpoint `.metadata` '
+                       'file. When set, '
+                       'every SAVE reuses this metadata: the nvrx async planning '
+                       '+ finalize SKIP both `gather_object` collectives (failures '
+                       'detected via a cheap all_reduce), while each checkpoint dir '
+                       'still gets its own complete `.metadata`. The LOAD path is '
+                       'unaffected and always reads each checkpoint\'s own '
+                       '`.metadata`. Requires the structure / world size / '
+                       'dist-ckpt-workers to match the run that produced the '
+                       'metadata (the user owns this guarantee).')
+    group.add_argument('--ckpt-metadata-create', action='store_true', default=False,
+                       help='Create the `--ckpt-metadata` file instead of reading '
+                       'it. Use for the '
+                       'very first job, when no prepared metadata exists yet: the '
+                       'first checkpoint save runs the normal save-plan/metadata '
+                       'collectives and writes the resulting complete metadata to '
+                       'the `--ckpt-metadata` path; subsequent saves in the SAME '
+                       'job then reuse it and take the collective-free fast path.')
     return parser
 
 

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -6,6 +6,7 @@ import contextlib
 import inspect
 import multiprocessing
 import os
+import pickle
 import random
 import re
 import shutil
@@ -811,6 +812,32 @@ def save_checkpoint(
                         else:
                             logger.debug(
                                 'Failed to plug in the read metadata from the load strategy...'
+                            )
+                    # `--ckpt-metadata`: reuse a prepared, complete `.metadata`
+                    # file for every SAVE, skipping the
+                    # save-side gathers (nvrx). The LOAD path is unaffected — it
+                    # always reads each checkpoint's own `.metadata`. Two modes,
+                    # mirroring the PG-tensors cache:
+                    #   * read (default): read the file now and reuse it from the
+                    #     first save.
+                    #   * create (`--ckpt-metadata-create`): the first save of
+                    #     this job runs the full collectives and *creates* the
+                    #     file; subsequent saves in this job reuse it.
+                    # Either way, every checkpoint dir still gets its own complete
+                    # `.metadata` (self-contained), so the metadata is stored both
+                    # per-checkpoint and at the `--ckpt-metadata` path.
+                    ckpt_metadata_path = getattr(args, 'ckpt_metadata', None)
+                    if ckpt_metadata_path:
+                        if getattr(args, 'ckpt_metadata_create', False):
+                            save_strategy.ckpt_metadata_create_path = ckpt_metadata_path
+                            logger.debug(
+                                f"Will create prepared checkpoint metadata at {ckpt_metadata_path}"
+                            )
+                        else:
+                            with open(ckpt_metadata_path, 'rb') as f:
+                                save_strategy.prepared_metadata = pickle.load(f)
+                            logger.debug(
+                                f"Using prepared checkpoint metadata from {ckpt_metadata_path}"
                             )
 
                 if args.ckpt_fully_parallel_save:


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do ?

Add `--ckpt-metadata` / `--ckpt-metadata-create` to reuse a prepared `.metadata` so the nvrx async save skips **both** save-side `gather_object` collectives. **Paired with** the `nvidia-resiliency-ext` PR (link below).

> Note: the unit test for this feature lives in the paired **nvidia-resiliency-ext** PR (the reuse logic is in nvrx; Megatron only wires the flags). Link the two PRs together.

## Issue tracking

Linked issue: <!-- TODO: open a feature-request issue and reference it here (required for new features) -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code
- [x] I have added relevant documentation
- [x] I have run the autoformatter.sh on my PR

---

# Reuse a prepared `.metadata` across checkpoint saves (collective-free save)

This is a **linked pair of PRs** — both must land for the feature to work:

- **NVRx** (`asolergi-nv/nvidia-resiliency-ext`, branch `feat/ckpt-metadata-reuse`): adds the backend reuse path to the async saver.
- **Megatron-LM** (`asolergi-nv/Megatron-LM`, branch `feat/ckpt-metadata-reuse`): adds the `--ckpt-metadata` / `--ckpt-metadata-create` knobs that drive it.

The Megatron PR depends on the NVRx PR (it passes the new `reuse_metadata_obj` / `create_metadata_path` arguments). Merge/release NVRx first.

---

## Problem

On the NVRx async save path, every distributed checkpoint save performs two
cross-rank collectives that scale with world size and are pure coordination
(no model data):

1. **Planning** — `gather_object(local_plan)` to the coordinator to build the
   global `Metadata`.
2. **Finalize** — `gather_object(write_results)` to assemble and write `.metadata`.

For large jobs these gathers are a non-trivial, recurring tax on every save,
even though the checkpoint **structure is constant** across an entire run
(same model, parallelism, and world size). The global `Metadata` is therefore
identical save-to-save and across resumes — it is wasteful to rebuild it every
time via collectives.

## Solution

Allow a **prepared, complete `Metadata`** object to be supplied to the save, so
both gathers are skipped entirely:

### NVRx side (`async_ckpt/state_dict_saver.py`)
- `save_state_dict_async_plan(..., reuse_metadata_obj=None)`: when a prepared
  metadata is supplied, the decentralized planning branch skips **both** the
  `verify_global_md_reuse` all-reduce and the `gather_object(local_plan)` —
  planning becomes purely local.
- `save_state_dict_async_finalize(..., reuse_metadata_obj=None, create_metadata_path=None)`:
  the reuse path skips `gather_object(write_results)` and instead detects write
  failures with a **single `all_reduce(MIN)` of a 1-element flag**, then writes
  the prepared metadata verbatim as `.metadata`.
- **Create mode** (`create_metadata_path`): the first save runs the normal
  (collective) path, then the coordinator reads back the just-written complete
  metadata, broadcasts it, and persists it to a container-local file so later
  saves in the job/run can reuse it. Returns the complete metadata.

A single, tiny `all_reduce(MIN)` is intentionally retained on the reuse path for
write-failure safety (so a failed rank still aborts the whole job).

### Megatron side
- `--ckpt-metadata <FILE>`: reuse mode — load the prepared `.metadata` (pickle)
  and hand it to the save strategy as `prepared_metadata` (skips both gathers).
- `--ckpt-metadata-create`: first-job mode — the first save creates the
  `<FILE>` via the collective path, then subsequent saves reuse it.
- `TorchDistSaveShardedStrategy` gains `prepared_metadata` / `ckpt_metadata_create_path`
  and passes `reuse_metadata_obj` / `create_metadata_path` through to NVRx; the
  async `finalize_fn` captures the returned complete metadata in create mode.

## Save-side collectives in NVRx (and which disappear)

Each NVRx async save (decentralized plan path) triggers these cross-rank
collectives — none of which move model/optimizer *data*; they only coordinate
the checkpoint's `Metadata`:

| Phase | Collective | Purpose |
|---|---|---|
| Planning (`save_state_dict_async_plan`) | `all_reduce` inside `verify_global_md_reuse` | check whether the previously-loaded plans still match (only when prior plans were loaded) |
| Planning | `gather_object(local_plan)` → coordinator | gather every rank's local plan to build the global `Metadata` |
| Finalize (`save_state_dict_async_finalize`) | `gather_object(write_results)` → coordinator | gather every rank's write results to assemble and write `.metadata` |
| Finalize | `broadcast(failures_occurred)` (1 int) | propagate write-failure status to all ranks |

### Which disappear after the first save(s), and why

- **Planning `all_reduce` + `gather_object(local_plan)`** — eliminated by NVRx's
  own `CheckpointMetadataCache`. With `--ckpt-assume-constant-structure`, the cache
  caches the central plan and, once it has observed an *identical* structure on
  **two** consecutive saves, sets `validated_cache_reuse=True` and reuses the
  cached central plan. So these run on save **#1 and #2** (the cache needs two
  matching observations to validate) and then vanish from save **#3** onward.
- **Finalize `gather_object(write_results)` + `broadcast`** — *not* cached by
  stock NVRx: the per-rank write results are re-gathered to rebuild `.metadata`
  on **every** save, so this collective never disappears on its own.

### What `--ckpt-metadata` changes

Supplying a prepared, complete `Metadata` lets the save skip **both** gathers:

- **Reuse mode**: `reuse_metadata_obj` is set → the planning branch skips the
  `verify_global_md_reuse` `all_reduce` *and* `gather_object(local_plan)`
  (planning is purely local), and the finalize skips `gather_object(write_results)`,
  replacing it with a single `all_reduce(MIN)` of a 1-element flag for
  write-failure detection. This holds from the **very first** reuse save — no
  warm-up saves needed — and is independent of `CheckpointMetadataCache`.
- **Create mode** (first job): runs the full collective path once to produce the
  metadata, plus a one-time `broadcast` of the complete metadata to all ranks,
  then persists it; every later save reuses it collective-free.

Net steady-state: the only remaining save-side collective is the 1-element
`all_reduce(MIN)` failure check (kept by design). (The separate mcore-level
collectives — the FullyParallel save-distribution `all_gather_object` and the
sharding-integrity `determine_global_metadata` gather — are addressed by the
sibling Megatron PRs M4 and M5 and are out of scope here.)

## Correctness constraints

Reuse is only valid when the run that **reuses** a `.metadata` has the **same
checkpoint structure, world size, and `--dist-ckpt-workers`** as the run that
**created** it (the caller owns this guarantee). In particular the prepared
metadata must come from a save done with the **same `--keep-redundant-extra-state`
setting**, since that toggle changes the saved item set and per-file byte
offsets. A stale/mismatched prepared metadata produces a wrong shard map and a
load-time unpickling error.

## Usage

First job (create once):
```
--async-save --use-persistent-ckpt-worker \
--ckpt-metadata $CONTAINER/prepared.metadata --ckpt-metadata-create
```
Subsequent jobs (reuse, collective-free saves):
```
--async-save --use-persistent-ckpt-worker \
--ckpt-metadata $CONTAINER/prepared.metadata
```

## Result

With `--ckpt-metadata` reuse active (and constant structure), the only remaining
save-side collective is the 1-element `all_reduce(MIN)` failure check. Both
`gather_object`s are eliminated.
