### PR TITLE
Add FullyParallel local-replica shadow writes to avoid cross-rank reads on load

### DIFF
--- a/megatron/core/dist_checkpointing/strategies/fully_parallel.py
+++ b/megatron/core/dist_checkpointing/strategies/fully_parallel.py
@@ -23,6 +23,10 @@ from megatron.core.dist_checkpointing.exchange_utils import (
     exchange_loaded_objects_gather_object,
 )
 from megatron.core.dist_checkpointing.mapping import ShardedStateDict, StateDict, is_main_replica
+from megatron.core.dist_checkpointing.strategies.local_replica import (
+    compute_shadow_shard_ids,
+    rewrite_replicas_to_shadow,
+)
 from megatron.core.dist_checkpointing.strategies.torch import (
     TorchDistLoadShardedStrategy,
     TorchDistSaveShardedStrategy,
@@ -75,6 +79,7 @@ class FullyParallelSaveStrategyWrapper:
         do_cache_distribution: bool = False,
         backend: str = "torch_dist",
         version: int = 1,
+        replicate_local_replicas: bool = False,
     ):
         """ """
         self.base_strategy = strategy
@@ -84,8 +89,21 @@ class FullyParallelSaveStrategyWrapper:
         self.do_cache_distribution = do_cache_distribution
         self.backend = backend
         self.version = version
+        # When True, after the standard parallelization step has elected a
+        # main saver per shard, every other rank in the parallelization group
+        # that holds a replica also writes its copy under a per-rank shadow
+        # FQN (see strategies/local_replica.py). Trades extra disk for the
+        # ability of every rank to read its tensors from its own
+        # __<rank>_*.distcp file at load time, eliminating cross-rank reads.
+        self.replicate_local_replicas = replicate_local_replicas
 
         self.cached_distribution: Optional[ShardDistribution] = None
+        # Companion cache for the load-mode distribution that is needed by
+        # the algorithmic shadow filter. Only populated when
+        # ``replicate_local_replicas`` is True; mirrors ``cached_distribution``
+        # so that ``do_cache_distribution=True`` continues to skip every
+        # all_gather on subsequent saves.
+        self.cached_load_distribution: Optional[ShardDistribution] = None
 
     def async_save(
         self,
@@ -117,15 +135,32 @@ class FullyParallelSaveStrategyWrapper:
 
         Returns: None
         """
+        from megatron.core.utils import get_pg_rank
+
         start = time()
         if self.do_cache_distribution and self.cached_distribution is not None:
             logger.debug(f'Apply *cached* save parallelization')
             precomputed_distribution = self.cached_distribution
+            load_distribution = self.cached_load_distribution
         else:
             logger.debug(f'Apply save parallelization')
             precomputed_distribution = determine_main_replica_uniform_distribution(
                 sharded_state_dict, self.parallelization_group
             )
+            # Local-replica mode needs the load-side picker to decide which
+            # shards actually cross-read at load time. We compute it here,
+            # *before* the save distribution mutates ``replica_id`` values,
+            # so that the picker sees the same input as it will at load
+            # time (the user's ``replica_id`` convention from
+            # ``make_(tp_)sharded_tensor_for_checkpoint``). With matching
+            # inputs the deterministic picker produces the same output at
+            # save and load — which is exactly the alignment the filter
+            # relies on.
+            load_distribution: Optional[ShardDistribution] = None
+            if self.replicate_local_replicas:
+                load_distribution = determine_main_replica_uniform_distribution(
+                    sharded_state_dict, self.parallelization_group, True
+                )
 
         distribute_main_replicas_with_precomputed_distribution(
             sharded_state_dict, self.parallelization_group, precomputed_distribution
@@ -135,6 +170,31 @@ class FullyParallelSaveStrategyWrapper:
             validate_sharding_integrity(determine_global_metadata(sharded_state_dict)[1])
         if self.do_cache_distribution:
             self.cached_distribution = precomputed_distribution
+            self.cached_load_distribution = load_distribution
+
+        # Local-replica mode: rename only the local replicas that the load
+        # picker would actually pull over the network. The filter
+        # (``compute_shadow_shard_ids``) returns shard ids where this rank
+        # is the load picker AND the save picker did not pick this rank in
+        # this group — exactly the shards that would otherwise cross-read.
+        # This must run *after* validate_sharding_integrity (which expects
+        # the original key topology) and *after* the cached_distribution
+        # snapshot above (so subsequent saves replay the same rename
+        # deterministically).
+        if self.replicate_local_replicas:
+            global_rank = torch.distributed.get_rank()
+            rank_in_group = get_pg_rank(group=self.parallelization_group)
+            shadow_shard_ids = compute_shadow_shard_ids(
+                precomputed_distribution, load_distribution, rank_in_group
+            )
+            n_renamed = rewrite_replicas_to_shadow(
+                sharded_state_dict, global_rank, shadow_shard_ids=shadow_shard_ids
+            )
+            logger.debug(
+                f"replicate_local_replicas: renamed {n_renamed} ShardedTensors "
+                f"to shadow keys on rank {global_rank} "
+                f"(shadow set size: {len(shadow_shard_ids)})"
+            )
         end = time()
         logger.debug(f"parallel save sharding, time: {end - start}")
 

--- a/megatron/core/dist_checkpointing/strategies/local_replica.py
+++ b/megatron/core/dist_checkpointing/strategies/local_replica.py
@@ -1,0 +1,301 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Helpers for the *local replica* save/load mode.
+
+Background
+----------
+
+In the standard ``FullyParallelSaveStrategyWrapper`` flow, parameters that
+are replicated across the parallelization group (the ``ep_dp`` group in our
+production setup) are written by exactly one rank inside each group. The
+other ranks have ``replica_id != 0`` and the underlying torch_dist save
+drops their write items via ``keep_only_main_replica``. The metadata
+records a single ``(file, offset, length)`` triple per replicated chunk,
+and at load time every peer that needs the chunk opens that single file —
+producing read-side contention on the file system when the world is large.
+
+The *local replica* mode opts into trading extra disk for read locality.
+For each shard, the load-side picker (``ignore_groups=True`` in
+``determine_main_replica_uniform_distribution``) selects one rank per
+parallelization group to actually issue the read; then communicate the data
+to the other ranks across the parallelization group. The save-side picker
+(``ignore_groups=False``) selects one rank per group as the save winner.
+When the two pickers select the **same** rank — which is the common case
+for tensors whose ``replica_id == (0, 0, 0)`` exists somewhere in every
+parallelization group, e.g. expert weights — the load reader is also the
+save writer and the read is local. No shadow needed.
+
+Cross-reads happen exactly when load picks a different rank from save in
+the same group. There are two ways for that to occur:
+
+1. The shard has no save main in this parallelization group at all
+   (``shards_in_this_group`` excludes it in save mode but includes it in
+   load mode) — typical of fully replicated parameters whose global main
+   lives in a single group while every other group has only non-main
+   replicas. Save mode writes nothing in those groups; load mode picks a
+   reader and that reader cross-reads the lone main's file.
+2. The save and load greedy assignments happen to pick different ranks
+   inside the same group because the load scope contains shards that the
+   save scope ignores, perturbing the load-balancing.
+
+In both cases the rank picked by load is exactly the rank that benefits
+from a local copy. So the filter — encoded in
+:func:`compute_shadow_shard_ids` — emits a shadow on a rank if that rank
+is the load picker for the shard *and* the save picker did not pick the
+same rank in the group.
+
+The shadow copy is published under a per-rank renamed FQN
+``__shadow_<global_rank>__<original_fqn>``. The rename is required because
+PyT DCP's ``MetadataIndex.index`` is declared ``compare=False``, so two
+copies under the same ``(fqn, offset)`` collapse on write and only one
+``_StorageInfo`` would survive in the metadata. Each shadow key gets its
+own ``state_dict_metadata`` entry pointing at the writing rank's
+``__<rank>_*.distcp``. The double-underscore prefix is unique enough that
+no real Megatron parameter starts with it.
+
+At load time the rank rewrites its requested FQNs to point at its own
+shadow key when one is in the metadata; the ``_StorageInfo`` for the
+shadow key was authored by this rank during save, so the file the reader
+opens is its local ``__<rank>_*.distcp``. No cross-rank reads.
+
+This module hosts the FQN-rename helpers used by both
+``FullyParallelSaveStrategyWrapper`` (for save-time renaming) and
+``TorchDistLoadShardedStrategy`` (for load-time redirection). Keeping them
+in one place makes the contract between the two sides explicit and easy to
+audit.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Dict, Optional, Set, Tuple
+
+from megatron.core.dist_checkpointing.dict_utils import nested_values
+from megatron.core.dist_checkpointing.mapping import ShardedStateDict, ShardedTensor
+from megatron.core.dist_checkpointing.utils import _sharded_tensor_shard_id, _ShardId
+
+if TYPE_CHECKING:
+    from megatron.core.dist_checkpointing.exchange_utils import ShardDistribution
+
+SHADOW_PREFIX = "__shadow_"
+"""Stable prefix used by every shadow FQN.
+
+Decision: the prefix is purely cosmetic for external tooling (any reader that
+walks ``Metadata.state_dict_metadata`` will see the extra entries and ignore
+them when its state dict does not request them). We avoid the more compact
+``__rR__`` style because ``__shadow_<rank>__`` is grep-friendly and
+self-documenting in a binary checkpoint dump.
+"""
+
+_SHADOW_RE = re.compile(rf"^{re.escape(SHADOW_PREFIX)}(\d+)__(.+)$")
+
+
+def shadow_key(global_rank: int, original_fqn: str) -> str:
+    """Build the shadow FQN under which ``global_rank`` stores its local copy.
+
+    Args:
+        global_rank: ``torch.distributed.get_rank()`` at save time.
+        original_fqn: the FQN the user-facing Megatron module produced
+            (e.g. ``decoder.layers.0.norm.weight``).
+
+    Returns:
+        ``"__shadow_<rank>__<fqn>"`` — a string guaranteed to be unique per
+        ``(rank, fqn)`` pair so that PyT DCP's ``MetadataIndex`` dedup does
+        not collapse copies that come from different ranks.
+    """
+    return f"{SHADOW_PREFIX}{global_rank}__{original_fqn}"
+
+
+def parse_shadow_key(maybe_shadow: str) -> Optional[Tuple[int, str]]:
+    """Inverse of :func:`shadow_key`.
+
+    Returns:
+        ``(global_rank, original_fqn)`` if ``maybe_shadow`` is a shadow key,
+        else ``None``. Used only by ad-hoc inspection / tests; the live save
+        and load paths never need to reverse a shadow key.
+    """
+    m = _SHADOW_RE.match(maybe_shadow)
+    if m is None:
+        return None
+    return int(m.group(1)), m.group(2)
+
+
+def is_shadow_key(fqn: str) -> bool:
+    """True iff ``fqn`` was produced by :func:`shadow_key`.
+
+    The save planner uses this to skip the global-plan volume validator for
+    shadow entries (whose ``chunks`` list intentionally only contains the
+    one rank's local chunk(s); the validator's "chunks must cover the global
+    tensor" rule does not apply).
+    """
+    return _SHADOW_RE.match(fqn) is not None
+
+
+def compute_shadow_shard_ids(
+    save_distribution: Optional["ShardDistribution"],
+    load_distribution: Optional["ShardDistribution"],
+    rank_in_group: int,
+) -> Set[_ShardId]:
+    """Compute which shard ids THIS rank should write as a shadow.
+
+    The cross-read at load time happens exactly when the rank that
+    ``FullyParallelLoad`` picks as the reader for a shard is *not* the
+    rank that physically wrote that shard to disk during save. To
+    eliminate the cross-read it is sufficient — and necessary — for the
+    load-picker rank to have its own copy on disk. This function is the
+    decision rule that produces the shadow set per rank.
+
+    A shard requires a shadow on this rank iff:
+
+    1. ``load_distribution.main_rank_for_shard[shard]`` is this rank
+       (the rank-within-group); i.e. the load-side picker selected
+       this rank to read the shard.
+    2. AND ``save_distribution.main_rank_for_shard.get(shard) != rank``,
+       which captures **both** failure modes that produce a cross-read:
+
+       * The shard was not in save's scope at all in this group (no rank
+         in the group had the user-side ``replica_id == 0`` for that
+         shard, so save mode skipped it). ``save.get(shard)`` is missing.
+         The save-side writer lives in another parallelization group, so
+         loading from "the metadata's primary file" means crossing a
+         file-system boundary inside the same global checkpoint.
+       * The shard was in scope but save and load picked different ranks
+         within this group. The save-side writer is the other rank in
+         the same group; loading from that file is still a cross-read.
+
+    The function intentionally returns the per-rank set rather than a
+    global ``shard_id -> rank`` mapping because the renamer applies the
+    rename only on the local rank — there is no need to materialise the
+    rename plan globally. Each rank computes its own set deterministically
+    from the same gathered metadata, so no extra communication is needed.
+
+    Args:
+        save_distribution: result of
+            ``determine_main_replica_uniform_distribution(..., ignore_groups=False)``.
+        load_distribution: result of
+            ``determine_main_replica_uniform_distribution(..., ignore_groups=True)``.
+        rank_in_group: this rank's rank within the parallelization group
+            (``get_pg_rank(parallelization_group)``).
+
+    Returns:
+        The set of shard ids this rank should write under a shadow FQN.
+    """
+    if save_distribution is None or load_distribution is None:
+        return set()
+    out: Set[_ShardId] = set()
+    save_picks = save_distribution.main_rank_for_shard
+    load_picks = load_distribution.main_rank_for_shard
+    for shard_id, load_main in load_picks.items():
+        if load_main != rank_in_group:
+            continue
+        if save_picks.get(shard_id) == rank_in_group:
+            # I'm both save and load main → I'll read my own file at load
+            # time. No cross-read, no shadow needed.
+            continue
+        out.add(shard_id)
+    return out
+
+
+def rewrite_replicas_to_shadow(
+    sharded_state_dict: ShardedStateDict, global_rank: int, shadow_shard_ids: Set[_ShardId]
+) -> int:
+    """Promote selected local replicas to shadow savers in place.
+
+    Walks every :class:`ShardedTensor` in ``sharded_state_dict``. If the
+    tensor's shard id is in ``shadow_shard_ids`` — the per-rank set
+    produced by :func:`compute_shadow_shard_ids` — we set
+    ``replica_id = 0`` so the underlying
+    ``TorchDistSaveShardedStrategy``'s ``keep_only_main_replica`` filter
+    keeps the write item, and rename ``sh_ten.key`` to the per-rank
+    shadow FQN so PyT DCP's ``MetadataIndex``-keyed dedup does not
+    collapse two ranks' copies into a single storage entry.
+
+    The state dict is mutated in place. Callers are expected to pass the
+    *save-only view* used by
+    :meth:`FullyParallelSaveStrategyWrapper.async_save` — never the live
+    training state — so this mutation does not leak to the user.
+
+    Decision: we don't deep-copy the ShardedTensor because the underlying
+    ``data`` tensor is the same object the rank already holds — a copy
+    would double the host memory footprint of the save state dict for no
+    benefit.
+
+    Returns:
+        Number of ShardedTensors that were renamed to a shadow key. Used
+        by tests and ``logger.debug`` accounting.
+    """
+    n_renamed = 0
+    for sh in nested_values(sharded_state_dict):
+        if not isinstance(sh, ShardedTensor):
+            continue
+        if _sharded_tensor_shard_id(sh) not in shadow_shard_ids:
+            continue
+        sh.key = shadow_key(global_rank, sh.key)
+        sh.replica_id = 0
+        n_renamed += 1
+    return n_renamed
+
+
+def redirect_pyt_state_dict_to_shadows(
+    pyt_state_dict: Dict[str, object],
+    metadata,  # torch.distributed.checkpoint.Metadata
+    global_rank: int,
+) -> Dict[str, str]:
+    """Route a load's PyT state dict at fqn X to ``__shadow_<rank>__X`` when present.
+
+    Iterates the keys currently in ``pyt_state_dict``. For each one whose
+    matching shadow FQN exists in ``metadata.state_dict_metadata``, renames
+    the entry in ``pyt_state_dict`` to the shadow FQN. The returned mapping
+    ``{shadow_fqn: original_fqn}`` is consumed by
+    :func:`restore_pyt_state_dict_from_shadows` to undo the rename after
+    ``checkpoint.load`` has populated the tensor data.
+
+    Decision: we rename inside ``pyt_state_dict`` rather than on the
+    upstream MCore ShardedTensor because (a) ``pyt_state_dict`` is a
+    transient dict owned by the load strategy — mutating it has no
+    user-visible effect, and (b) the rename has to be reversed before the
+    strategy's downstream code (``_unwrap_pyt_sharded_tensor`` /
+    ``_replace_sharded_keys_with_state_dict_keys``) walks the dict, since
+    those routines expect the original keys.
+
+    Returns:
+        ``{shadow_fqn: original_fqn}`` for every key that was rerouted; an
+        empty dict if no shadow keys are present (e.g. when loading a
+        checkpoint saved without local-replica mode).
+    """
+    renames: Dict[str, str] = {}
+    sd_md = getattr(metadata, "state_dict_metadata", None)
+    if sd_md is None:
+        return renames
+    for fqn in list(pyt_state_dict.keys()):
+        sk = shadow_key(global_rank, fqn)
+        if sk in sd_md:
+            pyt_state_dict[sk] = pyt_state_dict.pop(fqn)
+            renames[sk] = fqn
+    return renames
+
+
+def restore_pyt_state_dict_from_shadows(
+    pyt_state_dict: Dict[str, object], renames: Dict[str, str]
+) -> None:
+    """Reverse the rename produced by :func:`redirect_pyt_state_dict_to_shadows`.
+
+    After ``checkpoint.load`` has populated ``pyt_state_dict[shadow_fqn]``
+    with the loaded tensor data, swap the key back to ``original_fqn`` so
+    the rest of ``TorchDistLoadShardedStrategy.load`` (which walks the
+    dict by original keys) sees the data under the user's expected FQN.
+    """
+    for shadow_fqn, original_fqn in renames.items():
+        pyt_state_dict[original_fqn] = pyt_state_dict.pop(shadow_fqn)
+
+
+def filter_non_shadow_keys(state_dict_metadata: Dict[str, object]) -> Dict[str, object]:
+    """Return a copy of ``state_dict_metadata`` with shadow entries removed.
+
+    Used by :class:`MCoreSavePlanner` to bypass the default
+    "chunks must cover the global tensor" volume check on shadow entries —
+    a check that does not apply because each shadow tensor only carries
+    the local rank's chunks and its global shape is the original (full)
+    shape.
+    """
+    return {k: v for k, v in state_dict_metadata.items() if not is_shadow_key(k)}

--- a/megatron/core/dist_checkpointing/strategies/torch.py
+++ b/megatron/core/dist_checkpointing/strategies/torch.py
@@ -475,6 +475,67 @@ class MCoreSavePlanner(DefaultSavePlanner):
         assert not local_plan.planner_data, 'Planner data should be empty with decentralized plan'
         return local_plan
 
+    def _create_global_plan(self, all_plans):
+        """Override the parent's volume validation to skip shadow keys.
+
+        The default ``_validate_global_plan`` in PyT DCP enforces that the
+        union of every chunk's volume equals the global tensor's volume —
+        i.e., the saved chunks fully cover the tensor. That rule does not
+        apply to *shadow* entries produced by the local-replica save mode:
+        each shadow FQN is unique to one rank and only carries that rank's
+        local chunk(s), even though its global shape is the original
+        (full-tensor) shape. So we run the validator over a metadata view
+        with shadow keys filtered out, and only fall back to raising on the
+        non-shadow errors.
+
+        For non-local-replica checkpoints (no shadow keys present) this
+        override is a no-op: the filtered metadata equals the original.
+
+        We implement the override here (rather than monkey-patching
+        ``_validate_global_plan``) to keep the change local to MCore code
+        and to support both the older PyT signature (``-> bool``) and the
+        newer one (``-> list[str]``).
+        """
+        import dataclasses
+
+        from torch.distributed.checkpoint.default_planner import (
+            _validate_global_plan,
+            create_default_global_save_plan,
+        )
+
+        from .local_replica import filter_non_shadow_keys
+
+        deduped_plans = self._dedup_save_plans(all_plans)
+        global_plan, metadata = create_default_global_save_plan(deduped_plans)
+
+        if self.flatten_state_dict:
+            from collections import ChainMap
+
+            planner_data_dict = [p.planner_data for p in global_plan]
+            merged_mappings = dict(ChainMap(*planner_data_dict))
+            metadata = dataclasses.replace(metadata, planner_data=merged_mappings)
+
+        # Strip shadow entries before the volume check (see docstring).
+        metadata_for_validation = dataclasses.replace(
+            metadata, state_dict_metadata=filter_non_shadow_keys(metadata.state_dict_metadata)
+        )
+        result = _validate_global_plan(global_plan, metadata_for_validation)
+        # PyT versions disagree on the return type: older builds return a
+        # bool (``True`` == valid), newer source returns a list of error
+        # strings (empty == valid). Handle both.
+        # TODO(asolergi-nv): Remove the bool type return in the future.
+        if isinstance(result, bool):
+            if not result:
+                raise ValueError("Failed to validate global plan")
+        else:
+            if result:
+                error_summary = "; ".join(result)
+                if len(error_summary) > 500:
+                    error_summary = error_summary[:500] + "... (truncated)"
+                raise ValueError(f"Failed to validate global plan: {error_summary}")
+
+        return global_plan, metadata
+
     def transform_object(self, write_item: WriteItem, object: Any):
         """Make no transformations - bytes objects are already serialized."""
         return object
@@ -852,10 +913,35 @@ def _get_filesystem_reader(
 class TorchDistLoadShardedStrategy:
     """Basic load strategy for the PyT Distributed format."""
 
-    def __init__(self, cache_metadata: bool = False, checkpoint_name: str = None):
+    def __init__(
+        self,
+        cache_metadata: bool = False,
+        checkpoint_name: str = None,
+        replicate_local_replicas: bool = False,
+    ):
+        """
+        Args:
+            cache_metadata (bool): keep the parsed ``.metadata`` pickle alive
+                across calls so the second and later loads avoid re-parsing
+                it. Defaults to False.
+            checkpoint_name (str): name of the checkpoint being loaded.
+            replicate_local_replicas (bool): when True, requests for an FQN
+                whose ``__shadow_<rank>__<fqn>`` is present in the
+                checkpoint metadata are routed to that shadow entry —
+                i.e. to the rank's own ``__<rank>_*.distcp`` file. When
+                False (default) the redirect is skipped, so the load uses
+                the metadata's deduped storage entry exactly as today,
+                even if the checkpoint *does* contain shadow keys. The
+                flag lives on ``__init__`` (not on ``.load``) so the
+                wrapper layers don't need to plumb a foreign kwarg
+                through their ``.load`` signatures — every base strategy
+                that doesn't care about local-replica simply ignores
+                this attribute.
+        """
         self.cached_global_metadata: Optional[Metadata] = None
         self.cache_metadata = cache_metadata
         self.checkpoint_name = checkpoint_name
+        self.replicate_local_replicas = replicate_local_replicas
 
     def load(
         self,
@@ -893,6 +979,23 @@ class TorchDistLoadShardedStrategy:
         fsr = _get_filesystem_reader(
             checkpoint_dir, cache_metadata=self.cache_metadata, async_strategy=async_strategy
         )
+        # Local-replica redirection: if this checkpoint was saved with the
+        # local-replica mode, every replica that *this* rank holds was
+        # written under a `__shadow_<rank>__<fqn>` FQN pointing at the
+        # rank's own __<rank>_*.distcp file. Reroute every load request
+        # whose shadow key is in the metadata so that PyT DCP opens our
+        # local file rather than the dedup-winning peer's file.
+        from .local_replica import (
+            redirect_pyt_state_dict_to_shadows,
+            restore_pyt_state_dict_from_shadows,
+        )
+
+        shadow_renames: Dict[str, str] = {}
+        if self.replicate_local_replicas and torch.distributed.is_initialized():
+            metadata = fsr.read_metadata()  # cached when cache_metadata=True
+            shadow_renames = redirect_pyt_state_dict_to_shadows(
+                pyt_state_dict, metadata, torch.distributed.get_rank()
+            )
         checkpoint.load(
             pyt_state_dict,
             fsr,
@@ -904,6 +1007,10 @@ class TorchDistLoadShardedStrategy:
             ),
             no_dist=True,
         )
+        # Reverse the shadow rename so downstream code (unwrap, key-restore)
+        # sees the original FQNs the user-facing state dict expects.
+        if shadow_renames:
+            restore_pyt_state_dict_from_shadows(pyt_state_dict, shadow_renames)
 
         if self.cache_metadata:
             self.cached_global_metadata = (

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -827,7 +827,12 @@ def save_checkpoint(
                             else mpu.get_expert_data_parallel_group()
                         )
                     save_strategy = FullyParallelSaveStrategyWrapper(
-                        save_strategy, process_group, args.ckpt_assume_constant_structure
+                        save_strategy,
+                        process_group,
+                        args.ckpt_assume_constant_structure,
+                        replicate_local_replicas=getattr(
+                            args, 'ckpt_fully_parallel_save_replicate_local', False
+                        ),
                     )
             # Store save strategy for future checkpoint saves
             if checkpointing_context is not None:
@@ -1612,7 +1617,10 @@ def _load_global_dist_base_checkpoint(
         )
 
     checkpoint_name = get_checkpoint_name(load_dir, iteration, release, return_base_dir=True)
-    load_strategy = TorchDistLoadShardedStrategy(cache_metadata=args.ckpt_assume_constant_structure)
+    load_strategy = TorchDistLoadShardedStrategy(
+        cache_metadata=args.ckpt_assume_constant_structure,
+        replicate_local_replicas=getattr(args, 'ckpt_fully_parallel_load_replicate_local', False),
+    )
     # NOTE: `args.ckpt_fully_parallel_load` applies to both persistent and non-persistent checkpoints.
     if args.ckpt_fully_parallel_load:
         if args.ckpt_fully_parallel_load_process_group == 'dp':

--- a/megatron/training/config/training_config.py
+++ b/megatron/training/config/training_config.py
@@ -560,6 +560,27 @@ class CheckpointConfig:
     "ep_dp": Expert data parallel process group.
     """
 
+    ckpt_fully_parallel_save_replicate_local: bool = False
+    """If True, the fully-parallel save additionally writes a per-rank shadow
+    copy of every replica that this rank holds inside the parallelization
+    group. The metadata records each copy under a ``__shadow_<rank>__<fqn>``
+    key pointing at the rank's own ``__<rank>_*.distcp`` file, so at load
+    time every rank can read its tensors from its own file (no cross-reads).
+    Trades extra checkpoint storage (~``parallelization_group_size`` x for
+    replicated parameters) for read-side locality at scale. Pair with
+    ``ckpt_fully_parallel_load_replicate_local`` to take advantage at load
+    time. Default: False.
+    """
+
+    ckpt_fully_parallel_load_replicate_local: bool = False
+    """If True, the load redirects every requested FQN whose
+    ``__shadow_<rank>__<fqn>`` exists in the metadata to the rank's local
+    shadow entry — eliminating cross-reads at load time. Has no effect when
+    the checkpoint was saved without
+    ``ckpt_fully_parallel_save_replicate_local`` (no shadow keys are
+    present, so there is nothing to redirect). Default: False.
+    """
+
     ckpt_assume_constant_structure: bool = False
     """Assume the checkpoint structure is constant across saves to enable optimizations."""
 

--- a/tests/unit_tests/dist_checkpointing/models/common.py
+++ b/tests/unit_tests/dist_checkpointing/models/common.py
@@ -64,8 +64,17 @@ def common_test_parallel_reconfiguration_e2e(
     src_model_init_kwargs=None,
     dst_model_init_kwargs=None,
     metadata=None,
+    replicate_local_replicas=False,
 ):
-    """Test model saving and loading with different TP/PP"""
+    """Test model saving and loading with different TP/PP.
+
+    The ``replicate_local_replicas`` arg is passed at construction time
+    to the ``FullyParallelSaveStrategyWrapper`` (save side) and to the
+    ``TorchDistLoadShardedStrategy`` (load side) so both halves of the
+    feature are covered from the same callsite. It is only meaningful
+    when ``use_fpsl`` is True (the wrappers run only in that branch); on
+    the no-FP path the flag is ignored.
+    """
     src_model_init_kwargs = src_model_init_kwargs or {}
     dst_model_init_kwargs = dst_model_init_kwargs or {}
     Utils.initialize_model_parallel(*src_tp_pp, **(src_tp_pp_kwargs or {}), order=load_order)
@@ -87,6 +96,7 @@ def common_test_parallel_reconfiguration_e2e(
                 save_strategy,
                 parallel_state.get_data_parallel_group(with_context_parallel=True),
                 True,
+                replicate_local_replicas=replicate_local_replicas,
             )
         save(gpt_model_A.sharded_state_dict(metadata=metadata), ckpt_dir_A, save_strategy)
         regular_state_dict_A = gpt_model_A.state_dict()
@@ -104,7 +114,9 @@ def common_test_parallel_reconfiguration_e2e(
             **dst_model_init_kwargs,
         )
         if use_fpsl:
-            load_strategy = TorchDistLoadShardedStrategy()
+            load_strategy = TorchDistLoadShardedStrategy(
+                replicate_local_replicas=replicate_local_replicas
+            )
             load_strategy = FullyParallelLoadStrategyWrapper(load_strategy)
         else:
             load_strategy = None

--- a/tests/unit_tests/dist_checkpointing/models/test_gpt_model.py
+++ b/tests/unit_tests/dist_checkpointing/models/test_gpt_model.py
@@ -95,17 +95,68 @@ class TestGPTModelReconfiguration:
             'singleton_local_shards',
             'src_layer_spec_fn',
             'dst_layer_spec_fn',
+            'replicate_local_replicas',
         ),
         [
-            (False, 'tp-dp-pp', 'tp-dp-pp', (2, 4), (4, 2), True, gpt_te_spec, gpt_te_spec),
-            (False, 'tp-pp-dp', 'tp-pp-dp', (1, 8), (8, 1), False, gpt_te_spec, gpt_te_spec),
-            (True, 'tp-dp-pp', 'tp-pp-dp', (2, 1), (1, 8), True, gpt_te_spec, gpt_te_spec),
-            (False, 'tp-dp-pp', 'tp-dp-pp', (1, 1), (2, 2), True, gpt_te_spec, gpt_te_spec),
-            (True, 'tp-pp-dp', 'tp-pp-dp', (2, 1), (1, 8), False, gpt_local_spec, gpt_local_spec),
-            (False, 'tp-dp-pp', 'tp-pp-dp', (1, 1), (2, 4), False, gpt_te_spec, gpt_local_spec),
-            (True, 'tp-dp-pp', 'tp-dp-pp', (2, 4), (4, 2), True, gpt_local_spec, gpt_te_spec),
-            (False, 'tp-pp-dp', 'tp-pp-dp', (2, 1), (1, 8), False, gpt_te_spec, gpt_local_spec),
-            (False, 'tp-dp-pp', 'tp-pp-dp', (2, 4), (2, 4), True, gpt_local_spec, gpt_local_spec),
+            (False, 'tp-dp-pp', 'tp-dp-pp', (2, 4), (4, 2), True, gpt_te_spec, gpt_te_spec, False),
+            (False, 'tp-pp-dp', 'tp-pp-dp', (1, 8), (8, 1), False, gpt_te_spec, gpt_te_spec, False),
+            (True, 'tp-dp-pp', 'tp-pp-dp', (2, 1), (1, 8), True, gpt_te_spec, gpt_te_spec, False),
+            (False, 'tp-dp-pp', 'tp-dp-pp', (1, 1), (2, 2), True, gpt_te_spec, gpt_te_spec, False),
+            (
+                True,
+                'tp-pp-dp',
+                'tp-pp-dp',
+                (2, 1),
+                (1, 8),
+                False,
+                gpt_local_spec,
+                gpt_local_spec,
+                False,
+            ),
+            (
+                False,
+                'tp-dp-pp',
+                'tp-pp-dp',
+                (1, 1),
+                (2, 4),
+                False,
+                gpt_te_spec,
+                gpt_local_spec,
+                False,
+            ),
+            (
+                True,
+                'tp-dp-pp',
+                'tp-dp-pp',
+                (2, 4),
+                (4, 2),
+                True,
+                gpt_local_spec,
+                gpt_te_spec,
+                False,
+            ),
+            (
+                False,
+                'tp-pp-dp',
+                'tp-pp-dp',
+                (2, 1),
+                (1, 8),
+                False,
+                gpt_te_spec,
+                gpt_local_spec,
+                False,
+            ),
+            (
+                False,
+                'tp-dp-pp',
+                'tp-pp-dp',
+                (2, 4),
+                (2, 4),
+                True,
+                gpt_local_spec,
+                gpt_local_spec,
+                False,
+            ),
             (
                 False,
                 'tp-dp-pp',
@@ -115,6 +166,7 @@ class TestGPTModelReconfiguration:
                 False,
                 gpt_te_spec,
                 _gpt_te_spec_op_fuser,
+                False,
             ),
             (
                 False,
@@ -125,7 +177,27 @@ class TestGPTModelReconfiguration:
                 False,
                 _gpt_te_spec_op_fuser,
                 gpt_te_spec,
+                False,
             ),
+            # ----- replicate_local_replicas coverage -----
+            # The flag only runs through the FP wrappers, so the cases
+            # below are all use_fpsl=True. Both the local and TE specs
+            # are exercised so we cover the two RMSNorm variants. Each
+            # case asserts the same load-correctness invariant the
+            # baselines check (equal plain state dicts after a reload-
+            # and-resave round trip).
+            (
+                True,
+                'tp-dp-pp',
+                'tp-dp-pp',
+                (2, 4),
+                (4, 2),
+                True,
+                gpt_local_spec,
+                gpt_local_spec,
+                True,
+            ),
+            (True, 'tp-dp-pp', 'tp-dp-pp', (2, 4), (4, 2), False, gpt_te_spec, gpt_te_spec, True),
         ],
     )
     def test_parallel_reconfiguration_e2e(
@@ -139,6 +211,7 @@ class TestGPTModelReconfiguration:
         load_order: str,
         store_order: str,
         singleton_local_shards: bool,
+        replicate_local_replicas: bool,
     ):
         """Test model saving and loading with different TP/PP"""
         if src_layer_spec_fn is None or dst_layer_spec_fn is None:
@@ -155,6 +228,7 @@ class TestGPTModelReconfiguration:
             load_order,
             store_order,
             metadata={'singleton_local_shards': singleton_local_shards},
+            replicate_local_replicas=replicate_local_replicas,
         )
 
     def test_state_dict_comparison(self, tmp_path_dist_ckpt):

--- a/tests/unit_tests/dist_checkpointing/models/test_moe_experts.py
+++ b/tests/unit_tests/dist_checkpointing/models/test_moe_experts.py
@@ -134,25 +134,37 @@ class TestExpertLayerReconfiguration:
 
     @pytest.mark.internal
     @pytest.mark.parametrize(
-        "use_fpsl,src_tp_pp_ep_etp,dest_tp_pp_ep_etp,use_glu",
+        "use_fpsl,src_tp_pp_ep_etp,dest_tp_pp_ep_etp,use_glu,replicate_local_replicas,parallelization_group_kind",
         [
             # changing PP is impossible because the number of layers must be the same
-            (False, (2, 4, 1, 2), (2, 4, 1, 2), False),
-            (True, (2, 4, 1, 2), (2, 4, 1, 2), False),
-            (False, (2, 4, 1, 2), (1, 4, 1, 2), False),
-            (True, (2, 1, 1, 2), (1, 1, 1, 2), False),
-            (False, (1, 1, 1, 1), (1, 1, 1, 1), False),
-            (True, (1, 1, 1, 1), (1, 1, 4, 1), False),
-            (False, (1, 1, 8, 1), (1, 1, 2, 1), False),
-            (False, (2, 2, 2, 2), (4, 2, 1, 4), False),
-            (True, (1, 1, 4, 1), (8, 1, 1, 1), False),
-            (False, (1, 8, 1, 1), (1, 8, 1, 1), False),
-            (False, (1, 1, 4, 1), (2, 1, 1, 2), False),
-            (False, (2, 1, 4, 1), (2, 1, 1, 4), False),
-            (False, (1, 1, 1, 1), (1, 1, 1, 1), True),
-            (False, (1, 1, 1, 1), (1, 1, 4, 1), True),
-            (True, (1, 1, 1, 1), (2, 1, 1, 1), True),
-            (False, (1, 1, 4, 1), (8, 1, 1, 8), True),
+            (False, (2, 4, 1, 2), (2, 4, 1, 2), False, False, "dp"),
+            (True, (2, 4, 1, 2), (2, 4, 1, 2), False, False, "dp"),
+            (False, (2, 4, 1, 2), (1, 4, 1, 2), False, False, "dp"),
+            (True, (2, 1, 1, 2), (1, 1, 1, 2), False, False, "dp"),
+            (False, (1, 1, 1, 1), (1, 1, 1, 1), False, False, "dp"),
+            (True, (1, 1, 1, 1), (1, 1, 4, 1), False, False, "dp"),
+            (False, (1, 1, 8, 1), (1, 1, 2, 1), False, False, "dp"),
+            (False, (2, 2, 2, 2), (4, 2, 1, 4), False, False, "dp"),
+            (True, (1, 1, 4, 1), (8, 1, 1, 1), False, False, "dp"),
+            (False, (1, 8, 1, 1), (1, 8, 1, 1), False, False, "dp"),
+            (False, (1, 1, 4, 1), (2, 1, 1, 2), False, False, "dp"),
+            (False, (2, 1, 4, 1), (2, 1, 1, 4), False, False, "dp"),
+            (False, (1, 1, 1, 1), (1, 1, 1, 1), True, False, "dp"),
+            (False, (1, 1, 1, 1), (1, 1, 4, 1), True, False, "dp"),
+            (True, (1, 1, 1, 1), (2, 1, 1, 1), True, False, "dp"),
+            (False, (1, 1, 4, 1), (8, 1, 1, 8), True, False, "dp"),
+            # ----- replicate_local_replicas coverage -----
+            # The two values mirror the public knob
+            # ``ckpt_fully_parallel_save_process_group: Literal["dp",
+            # "ep_dp"]``: ``"dp"`` covers Megatron's RMSNorm/router-style
+            # replicas (the dp+cp combined group internally), while
+            # ``"ep_dp"`` is the production-realistic group for the MoE
+            # checkpointing hot path. Both must round-trip correctly.
+            # Configs are kept tiny (TP=2, EP=2) so we hit the
+            # save-main-less-group cross-read pattern that the feature
+            # is designed to neutralize.
+            (True, (2, 1, 2, 2), (2, 1, 2, 2), False, True, "dp"),
+            (True, (2, 1, 2, 2), (2, 1, 2, 2), False, True, "ep_dp"),
         ],
     )
     @pytest.mark.parametrize("expert_type", expert_type)
@@ -177,8 +189,24 @@ class TestExpertLayerReconfiguration:
         load_order,
         store_order,
         singleton_local_shards,
+        replicate_local_replicas,
+        parallelization_group_kind,
     ):
-        """Test model saving and loading with different TP/PP/EP/ETP(expert-tensor-parallel)"""
+        """Test model saving and loading with different TP/PP/EP/ETP(expert-tensor-parallel).
+
+        Two extra dimensions on top of the historical sweep:
+
+        * ``replicate_local_replicas`` toggles the local-replica save +
+          load path. Off keeps today's behaviour; on writes and reads
+          shadow keys.
+        * ``parallelization_group_kind`` selects which process group
+          drives save/load distribution. The two production-meaningful
+          options match the public knob (``"dp"`` or ``"ep_dp"``):
+          ``"dp"`` covers all replicated-on-DP parameters and ``"ep_dp"``
+          is the production hot path for MoE checkpoints. For
+          ``replicate_local_replicas=False`` we keep the historical
+          ``"dp"`` choice for backwards-compat with the existing sweep.
+        """
         src_tp, src_pp, src_ep, src_etp = src_tp_pp_ep_etp
         dest_tp, dest_pp, dest_ep, dest_etp = dest_tp_pp_ep_etp
         metadata = {'singleton_local_shards': singleton_local_shards}
@@ -190,6 +218,18 @@ class TestExpertLayerReconfiguration:
             expert_tensor_parallel_size=src_etp,
             order=store_order,
         )
+
+        def _get_parallelization_group():
+            """Pick the FP wrapper's parallelization group from the test param.
+
+            Encapsulated as a closure because the test reinitialises
+            ``parallel_state`` between save and load — the same kind
+            string must look up the *current* group on each side.
+            """
+            if parallelization_group_kind == "ep_dp":
+                return parallel_state.get_expert_data_parallel_group()
+            return parallel_state.get_data_parallel_group(with_context_parallel=True)
+
         with (
             TempNamedDir(
                 tmp_path_dist_ckpt / 'test_expert_layer_reconfiguration_model_A'
@@ -206,8 +246,9 @@ class TestExpertLayerReconfiguration:
             if use_fpsl:
                 save_strategy = FullyParallelSaveStrategyWrapper(
                     save_strategy,
-                    parallel_state.get_data_parallel_group(with_context_parallel=True),
+                    _get_parallelization_group(),
                     True,
+                    replicate_local_replicas=replicate_local_replicas,
                 )
             save(sharded_state_dict, ckpt_dir_A, save_strategy)
             Utils.destroy_model_parallel()
@@ -226,10 +267,11 @@ class TestExpertLayerReconfiguration:
             )
             model_B = initialize_expert_layer(1, use_glu, expert_type)
             if use_fpsl:
-                load_strategy = TorchDistLoadShardedStrategy()
+                load_strategy = TorchDistLoadShardedStrategy(
+                    replicate_local_replicas=replicate_local_replicas
+                )
                 load_strategy = FullyParallelLoadStrategyWrapper(
-                    load_strategy,
-                    parallel_state.get_data_parallel_group(with_context_parallel=True),
+                    load_strategy, _get_parallelization_group()
                 )
             else:
                 load_strategy = None

--- a/tests/unit_tests/dist_checkpointing/test_fully_parallel.py
+++ b/tests/unit_tests/dist_checkpointing/test_fully_parallel.py
@@ -566,12 +566,61 @@ class TestCrossRanksReads:
         else:
             assert not cross_rank_reads
 
+    def test_cross_dp_access_with_local_replica(self, tmp_path_dist_ckpt):
+        """``replicate_local_replicas=True`` eliminates every cross-DP read.
+
+        Reuses the fixture of ``test_cross_dp_access_does_not_disturb_the_distribution``
+        — TP=2, DP=4, several tensors with replication patterns that
+        produce cross-reads under the legacy save/load path. With the
+        feature on, the load picker for each shard is also a writer
+        (either of the original FQN or of its per-rank shadow), so the
+        ``cross_rank_reads`` accumulator must be empty for every rank.
+
+        ``same_rank_reads`` is *not* asserted shard-by-shard here because
+        the redirect intentionally rewrites which file the picker opens
+        (it now opens its own ``__<rank>_*.distcp`` for shadowed shards
+        instead of the main saver's file). That's exactly what the
+        feature is supposed to do; the fact that no cross-read happens
+        is the meaningful invariant.
+        """
+        ranks_placement = {
+            'a': [(0, 0)],
+            'b': [(tp, dp) for tp in range(2) for dp in range(4)],
+            'c': [(0, dp) for dp in range(3)],
+            'd': [(1, 0), (0, 0), (1, 3)],
+            'e': [(1, 0), (1, 2)],
+            'f': [(1, 0), (0, 0), (1, 2)],
+            'g': [(1, 3)],
+        }
+        cross_rank_reads, _ = self.determine_cross_rank_reads(
+            2, ranks_placement, tmp_path_dist_ckpt, replicate_local_replicas=True
+        )
+
+        # The feature's contract: every rank reads only from its own file.
+        assert not cross_rank_reads, (Utils.rank, cross_rank_reads)
+
+    def test_full_dp_reads_with_local_replica(self, tmp_path_dist_ckpt):
+        """Sanity-check the feature on the no-cross-read fixture.
+
+        ``test_full_dp_reads`` already has zero cross-reads under the
+        legacy path (every replicated tensor has a main in the single DP
+        group covering the world). Turning the feature on must keep the
+        invariant — i.e. it should not introduce regressions on the easy
+        cases where save and load pickers already agree.
+        """
+        ranks_placement = {'a': [(0, 0)], 'b': [(0, 1)], 'c': [(0, i) for i in range(8)]}
+        cross_rank_reads, _ = self.determine_cross_rank_reads(
+            1, ranks_placement, tmp_path_dist_ckpt, replicate_local_replicas=True
+        )
+        assert not cross_rank_reads, (Utils.rank, cross_rank_reads)
+
     def determine_cross_rank_reads(
         self,
         tp_size: int,
         ranks_placement: RanksPlacementT,
         tmp_path_dist_ckpt: Path,
         parallel_within_dp: bool = True,
+        replicate_local_replicas: bool = False,
     ):
         Utils.initialize_model_parallel(tp_size, 1)
         parallelization_group = (
@@ -579,15 +628,32 @@ class TestCrossRanksReads:
             if parallel_within_dp
             else torch.distributed.group.WORLD
         )
-        state_dict = self.get_sharded_state_dict(ranks_placement)
+        save_state_dict = self.get_sharded_state_dict(ranks_placement)
         with TempNamedDir(tmp_path_dist_ckpt / 'determine_cross_rank_reads') as ckpt_dir:
             save_strategy = FullyParallelSaveStrategyWrapper(
-                TorchDistSaveShardedStrategy(), parallelization_group
+                TorchDistSaveShardedStrategy(),
+                parallelization_group,
+                replicate_local_replicas=replicate_local_replicas,
             )
-            save_strategy.save(state_dict, ckpt_dir)
+            save_strategy.save(save_state_dict, ckpt_dir)
 
+            # Build a *fresh* state dict for the load. When
+            # ``replicate_local_replicas=True`` the save step mutates
+            # ``sh.key`` / ``sh.replica_id`` in place (the shadow
+            # rename), so reusing ``save_state_dict`` would feed the
+            # load picker a topology that no longer matches the on-disk
+            # checkpoint and would shift the picker to a different rank
+            # — exactly the cross-read regression this helper is
+            # supposed to detect. In production this can't happen
+            # because the load receives a freshly-built sharded state
+            # dict from the model.
+            state_dict = self.get_sharded_state_dict(ranks_placement)
+
+            # Construct the base strategy directly (instead of via
+            # ``get_default_strategy``) so we can pass the
+            # ``replicate_local_replicas`` flag to the load constructor.
             load_strategy = FullyParallelLoadStrategyWrapper(
-                TorchDistLoadShardedStrategy(),
+                TorchDistLoadShardedStrategy(replicate_local_replicas=replicate_local_replicas),
                 parallelization_group,
                 do_cache_distribution=True,
                 exchange_algo='broadcast',
@@ -607,15 +673,27 @@ class TestCrossRanksReads:
                 cross_rank_reads = defaultdict(list)
                 same_rank_reads = defaultdict(list)
 
-                # Debug cross-reads
+                # Debug cross-reads. ``read_item.dest_index.fqn`` may be a
+                # shadow key (``__shadow_<rank>__<orig>``) when load was
+                # opted into the replicate_local_replicas redirect — strip
+                # the prefix so the assertions below stay keyed by the
+                # user's original FQN.
+                from megatron.core.dist_checkpointing.strategies.local_replica import (
+                    parse_shadow_key,
+                )
+
                 for read_item in local_plan.items:
                     item_md = self.metadata.storage_data[read_item.storage_index]
 
                     read_rank = int(item_md.relative_path.split('_')[2])
+                    fqn = read_item.dest_index.fqn
+                    parsed = parse_shadow_key(fqn)
+                    if parsed is not None:
+                        fqn = parsed[1]
                     if read_rank == torch.distributed.get_rank():
-                        same_rank_reads[read_item.dest_index.fqn].append(read_rank)
+                        same_rank_reads[fqn].append(read_rank)
                     else:
-                        cross_rank_reads[read_item.dest_index.fqn].append(read_rank)
+                        cross_rank_reads[fqn].append(read_rank)
 
                 return local_plan
 
@@ -625,3 +703,232 @@ class TestCrossRanksReads:
         Utils.destroy_model_parallel()
 
         return cross_rank_reads, same_rank_reads
+
+
+class TestLocalReplicaSaveLoad:
+    """End-to-end save+load round-trip for the ``replicate_local_replicas`` knob.
+
+    The feature has two independent boolean toggles (one per direction;
+    see design-doc §4 compatibility matrix). For correctness we must make
+    sure that every combination produces tensor-identical loaded state:
+
+    | save | load | what's on disk                                | what load does               |
+    |------|------|-----------------------------------------------|------------------------------|
+    | off  | off  | legacy single-saver-per-shard layout          | reads the metadata's primary |
+    | on   | off  | shadow keys present alongside primary entries | ignores shadows → primary    |
+    | off  | on   | no shadow keys                                | redirect lookup misses → primary |
+    | on   | on   | shadow keys present                           | every rank reads its own file |
+
+    The test exercises both meaningful parallelization-group choices,
+    matching the public knob ``ckpt_fully_parallel_save_process_group:
+    Literal["dp", "ep_dp"]``:
+
+    * ``"dp"`` — Megatron's data-parallel + context-parallel combined
+      group, looked up via ``get_data_parallel_group(with_context_parallel=True)``.
+      Size 4 with TP=2 on 8 ranks. The replicated ``rmsnorm.weight``
+      gets a single global save main on the rank with
+      ``replica_id == (0, 0, 0)``; the other ``dp`` group has no save
+      main → the legacy load forces a cross-read, the new load
+      redirects to a per-rank shadow.
+    * ``"ep_dp"`` — size 2 with TP=2, EP=2 on 8 ranks. The same
+      pattern applies inside each ep_dp group: only the group that
+      contains the world's lone main has a save winner; the remaining
+      three groups have no save main and need a shadow reader to avoid
+      cross-reads.
+
+    Cross-reads themselves are *not* asserted here — that lives in
+    ``TestCrossRanksReads.test_cross_dp_access_with_local_replica``. The
+    contract this class verifies is purely "loaded values equal saved
+    values", which is what the user actually depends on.
+    """
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    @staticmethod
+    def _make_state_dict():
+        """Build a state dict with a replicated and a TP-sharded tensor.
+
+        Uses Megatron's production ``replica_id`` convention
+        ``(0, tp_rank, dp_cp_rank)`` so that:
+
+        * ``rmsnorm.weight`` (1D, fully replicated) has a single global
+          save main on the rank where ``(tp_rank, dp_cp_rank) == (0, 0)``.
+          Every other rank holds the same data as a non-main replica —
+          this is the topology that produces cross-reads under the
+          legacy save and is the primary target of the local-replica
+          shadow rename.
+        * ``linear.weight`` (2D, TP-sharded along axis 0) is owned per
+          ``tp_rank`` and replicated across ``dp_cp_rank``. There is one
+          save main per tp-domain (the rank with ``dp_cp_rank == 0``),
+          which mirrors the production layout for column/row-parallel
+          linear weights.
+
+        The returned ``expected`` dict has the *global* values for
+        verification: a 1D ground truth for the replicated tensor and a
+        ``(2*tp_size, 4)`` matrix whose tp-rank slice each rank should
+        end up holding after the load.
+        """
+        tp_rank = parallel_state.get_tensor_model_parallel_rank()
+        tp_size = parallel_state.get_tensor_model_parallel_world_size()
+        dp_cp_rank = parallel_state.get_data_parallel_rank(with_context_parallel=True)
+
+        replicated = torch.tensor([1.0, 2.0, 3.0, 4.0])
+        rmsnorm = ShardedTensor.from_rank_offsets(
+            'rmsnorm.weight', replicated.clone(), replica_id=(0, tp_rank, dp_cp_rank)
+        )
+
+        full = torch.arange(8 * tp_size, dtype=torch.float32).reshape(2 * tp_size, 4)
+        local = full[2 * tp_rank : 2 * (tp_rank + 1)].clone()
+        linear = ShardedTensor.from_rank_offsets(
+            'linear.weight', local, (0, tp_rank, tp_size), replica_id=(0, 0, dp_cp_rank)
+        )
+        sd = {'rmsnorm.weight': rmsnorm, 'linear.weight': linear}
+        expected = {'rmsnorm.weight': replicated, 'linear.weight': full}
+        return sd, expected
+
+    @pytest.mark.parametrize("group_kind", ["dp", "ep_dp"])
+    @pytest.mark.parametrize(
+        "save_replicate, load_replicate",
+        [(False, False), (True, False), (False, True), (True, True)],
+    )
+    def test_compatibility_matrix(
+        self, tmp_path_dist_ckpt, group_kind, save_replicate, load_replicate
+    ):
+        """Run save and load over each cell of the compat matrix on each group.
+
+        The flow is intentionally minimal so any value mismatch is
+        easy to attribute: build the state dict, save with the FP wrapper
+        configured per the cell, build a *fresh* state dict with zeroed
+        local data, load through the FP wrapper, then assert each tensor
+        equals the per-rank slice of the ground-truth.
+
+        We rebuild the load-side state dict from scratch (rather than
+        reusing the saved one) so we don't accidentally validate the
+        pre-load values still in memory.
+        """
+        if group_kind == "ep_dp":
+            Utils.initialize_model_parallel(
+                tensor_model_parallel_size=2,
+                pipeline_model_parallel_size=1,
+                expert_model_parallel_size=2,
+            )
+            parallelization_group = parallel_state.get_expert_data_parallel_group()
+        else:
+            Utils.initialize_model_parallel(
+                tensor_model_parallel_size=2, pipeline_model_parallel_size=1
+            )
+            parallelization_group = parallel_state.get_data_parallel_group(
+                with_context_parallel=True
+            )
+
+        save_state_dict, expected = self._make_state_dict()
+        with TempNamedDir(tmp_path_dist_ckpt / 'local_replica_compat_matrix') as ckpt_dir:
+            save_strategy = FullyParallelSaveStrategyWrapper(
+                TorchDistSaveShardedStrategy(),
+                parallelization_group,
+                replicate_local_replicas=save_replicate,
+            )
+            save_strategy.save(save_state_dict, ckpt_dir)
+
+            # Fresh state dict for the load: zeroed local data so we
+            # detect any silently-skipped fill-in.
+            load_state_dict, _ = self._make_state_dict()
+            for sh in load_state_dict.values():
+                sh.data = torch.zeros_like(sh.data)
+
+            load_strategy = FullyParallelLoadStrategyWrapper(
+                TorchDistLoadShardedStrategy(replicate_local_replicas=load_replicate),
+                parallelization_group,
+            )
+            loaded = load_strategy.load(load_state_dict, ckpt_dir)
+
+        tp_rank = parallel_state.get_tensor_model_parallel_rank()
+        expected_local_linear = expected['linear.weight'][2 * tp_rank : 2 * (tp_rank + 1)]
+
+        # The replicated tensor should round-trip bit-exactly on every
+        # rank, regardless of which combination of knobs we used. This
+        # is the load-correctness guarantee the design-doc claims.
+        assert torch.equal(loaded['rmsnorm.weight'], expected['rmsnorm.weight']), (
+            Utils.rank,
+            group_kind,
+            save_replicate,
+            load_replicate,
+            loaded['rmsnorm.weight'],
+            expected['rmsnorm.weight'],
+        )
+        assert torch.equal(loaded['linear.weight'], expected_local_linear), (
+            Utils.rank,
+            group_kind,
+            save_replicate,
+            load_replicate,
+            loaded['linear.weight'],
+            expected_local_linear,
+        )
+
+    def test_save_off_no_shadow_keys_in_metadata(self, tmp_path_dist_ckpt):
+        """``replicate_local_replicas=False`` must leave the metadata
+        bit-identical to today's layout — no shadow keys on disk.
+
+        Why this matters: it's the "legacy invariant" half of the compat
+        matrix. If a future refactor accidentally leaks a shadow rename
+        when the knob is off, every checkpoint-consuming tool downstream
+        that walks ``state_dict_metadata`` will see unexpected keys.
+        """
+        import pickle
+
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=2, pipeline_model_parallel_size=1
+        )
+        parallelization_group = parallel_state.get_data_parallel_group(with_context_parallel=True)
+
+        state_dict, _ = self._make_state_dict()
+        with TempNamedDir(tmp_path_dist_ckpt / 'local_replica_off_metadata') as ckpt_dir:
+            save_strategy = FullyParallelSaveStrategyWrapper(
+                TorchDistSaveShardedStrategy(),
+                parallelization_group,
+                replicate_local_replicas=False,
+            )
+            save_strategy.save(state_dict, ckpt_dir)
+
+            torch.distributed.barrier()
+            if Utils.rank == 0:
+                with (ckpt_dir / '.metadata').open('rb') as f:
+                    md = pickle.load(f)
+                shadow_keys = [k for k in md.state_dict_metadata if k.startswith('__shadow_')]
+                assert not shadow_keys, shadow_keys
+            torch.distributed.barrier()
+
+    def test_save_on_produces_shadow_keys_in_metadata(self, tmp_path_dist_ckpt):
+        """When the save knob is on AND the topology actually cross-reads,
+        at least one ``__shadow_*`` entry must appear in the metadata.
+
+        The fixture (TP=2, dp_cp_size=4 with replicated tensor whose only
+        global main is on the (0, 0, 0) rank) is exactly the cross-read
+        topology described in design-doc §3.0, so the filter must
+        produce at least one shadow.
+        """
+        import pickle
+
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=2, pipeline_model_parallel_size=1
+        )
+        parallelization_group = parallel_state.get_data_parallel_group(with_context_parallel=True)
+
+        state_dict, _ = self._make_state_dict()
+        with TempNamedDir(tmp_path_dist_ckpt / 'local_replica_on_metadata') as ckpt_dir:
+            save_strategy = FullyParallelSaveStrategyWrapper(
+                TorchDistSaveShardedStrategy(), parallelization_group, replicate_local_replicas=True
+            )
+            save_strategy.save(state_dict, ckpt_dir)
+
+            torch.distributed.barrier()
+            if Utils.rank == 0:
+                with (ckpt_dir / '.metadata').open('rb') as f:
+                    md = pickle.load(f)
+                shadow_keys = [k for k in md.state_dict_metadata if k.startswith('__shadow_')]
+                # The replicated rmsnorm.weight has a save-main-less
+                # dp_cp group (tp_rank=1) — its load picker should be
+                # promoted to a shadow saver.
+                assert any('rmsnorm.weight' in k for k in shadow_keys), shadow_keys
+            torch.distributed.barrier()


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do ?

Add FullyParallel local-replica shadow writes (`--ckpt-fully-parallel-save-replicate-local`): every replica-holding rank also writes a per-rank shadow copy so each rank reads its own file at load, eliminating cross-rank reads.
 
## Issue tracking

Linked issue: <!-- TODO: open a feature-request issue and reference it here (required for new features) -->

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code
- [x] I have added relevant documentation
- [x] I have run the autoformatter.sh on my PR

---

# FullyParallel local-replica shadow writes (read-local checkpoints)

## Problem

With `--ckpt-fully-parallel-save`, each shard is written by exactly **one**
elected rank in the parallelization (DP) group; the other ranks that hold an
identical replica write nothing. At **load** time those other ranks must then
pull the shard **over the network** from whichever peer wrote it. At scale this
cross-rank (cross-DP) reading is a dominant load-time cost: every rank's load is
gated on reading bytes from other ranks' `.distcp` files, creating
all-to-all-ish read traffic and stragglers.

## Solution

Add an opt-in **local-replica shadow** mode. On save, after the normal
distribution elects one main saver per shard, every *other* rank in the group
that holds a replica **also** writes its own copy under a per-rank "shadow" FQN
`__shadow_<rank>__<fqn>`, recorded in the metadata and pointing at that rank's
own `__<rank>_*.distcp` file. On load, each rank redirects every request whose
shadow key exists in the metadata to its **own** local file — so no rank ever
crosses the network for a tensor it already has locally.

Key design points:
- The save only shadows the replicas that the load picker *would actually
  cross-read* (computed by `compute_shadow_shard_ids` from the save vs. load
  distributions), so it doesn't blindly duplicate everything.
- A `MCoreSavePlanner._create_global_plan` override runs DCP's volume
  validation with shadow keys filtered out (`filter_non_shadow_keys`): a shadow
  entry legitimately carries only one rank's chunk under the full global shape,
  which the default coverage check would otherwise reject. No-op when no shadow
  keys are present.
- Save and load knobs are independent and can be mixed: load with the flag on
  but a non-shadow checkpoint simply finds no shadow keys and falls back to the
  normal (deduped) entries; load with the flag off ignores shadow keys.

## Trade-off

Extra checkpoint storage (up to ~`parallelization_group_size`× for replicated
parameters) in exchange for eliminating cross-rank reads at load. Intended for
large runs where load-time read locality matters more than checkpoint size.

## Files changed

- **New** `megatron/core/dist_checkpointing/strategies/local_replica.py` —
  shadow-key helpers: `shadow_key` / `parse_shadow_key` / `is_shadow_key`,
  `compute_shadow_shard_ids`, `rewrite_replicas_to_shadow`,
  `redirect_pyt_state_dict_to_shadows`, `restore_pyt_state_dict_from_shadows`,
  `filter_non_shadow_keys`.
- `strategies/fully_parallel.py` — `FullyParallelSaveStrategyWrapper` gains
  `replicate_local_replicas`; computes the load distribution and rewrites local
  replicas to shadow keys after the integrity check.
- `strategies/torch.py` — `MCoreSavePlanner._create_global_plan` (shadow-aware
  volume validation); `TorchDistLoadShardedStrategy` gains
  `replicate_local_replicas` and redirects/restores shadow FQNs around
  `checkpoint.load`.
- `training/checkpointing.py` — wires the save/load knobs into the wrappers.
- `training/config/training_config.py` — `ckpt_fully_parallel_save_replicate_local`
  and `ckpt_fully_parallel_load_replicate_local` (both default False).
- Tests: `test_fully_parallel.py` (cross-DP read elimination + a save/load
  compatibility matrix), `models/common.py` (thread the knob through the e2e
  helper), `models/test_gpt_model.py` / `models/test_moe_experts.py`
  (`replicate_local_replicas` reconfiguration coverage).

## Usage

```
# Save shadow copies, and read locally on the next load:
--ckpt-fully-parallel-save --ckpt-fully-parallel-save-replicate-local
--ckpt-fully-parallel-load --ckpt-fully-parallel-load-replicate-local
```

## Backward compatibility

Both flags default to **False** → behavior is byte-identical to today. Old
checkpoints (no shadow keys) load normally even with the load flag on (nothing
to redirect). A shadow checkpoint also loads correctly with the load flag off
(shadow keys are ignored; the primary deduped entries are used).

## Testing notes

`tests/unit_tests/dist_checkpointing/test_fully_parallel.py` adds
`TestCrossRanksReads.test_cross_dp_access_with_local_replica` /
`test_full_dp_reads_with_local_replica` (assert zero cross-rank reads when the
mode is on) and `TestLocalReplicaSaveLoad` (the save-on/off × load-on/off
matrix, plus shadow-key presence/absence in metadata). GPT and MoE-expert
reconfiguration suites gain a `replicate_local_replicas` parametrization. These
are multi-GPU distributed tests (run under the unit-test harness).
