### PR TITLE
[Core] Add DP-balanced sequence packing scheduler

### DIFF
--- a/megatron/core/datasets/data_schedule.py
+++ b/megatron/core/datasets/data_schedule.py
@@ -1,12 +1,22 @@
 # Copyright (c) 2025 NVIDIA CORPORATION.  All rights reserved.
 
-from typing import Any, List, Optional
+import enum
+from typing import Any, Dict, List, Optional, Type
 
 import torch
 
 from megatron.core import parallel_state
+from megatron.core.datasets.data_schedule_utils import (
+    broadcast_scalars,
+    broadcast_to_pp_group,
+    build_packed_microbatches,
+    create_data_iterator,
+    get_batch_and_global_seqlens,
+    reroute_samples_to_dcp_ranks,
+)
 from megatron.core.pipeline_parallel.hybrid_cp_schedule import BalancedCPScheduler
 from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.transformer.enums import LayerType
 
 
 class HybridCPDataLoaderWrapper:
@@ -299,3 +309,460 @@ class HybridCPDataLoaderWrapper:
             batch, global_ids_this_rank, global_id_seqlens, sample_id_groups, offsets
         )
         return samples_this_rank_with_id, sample_id_groups
+
+
+class BasePackingScheduler:
+    """Base class for sequence packing schedulers."""
+
+    def __init__(
+        self,
+        max_seqlen_per_dp_cp_rank: int,
+        cp_size: int,
+        dp_size: int,
+        microbatch_group_size_per_vp_stage: int | None,
+    ):
+        """
+        Args:
+            max_seqlen_per_dp_cp_rank: The maximum sequence length per DPxCP rank.
+            cp_size: The context parallel size.
+            dp_size: The data parallel size.
+            microbatch_group_size_per_vp_stage: The microbatch group size per virtual
+            pipeline stage, only used when enabling VPP, otherwise None.
+        """
+        if max_seqlen_per_dp_cp_rank <= 0:
+            raise ValueError("max_seqlen_per_dp_cp_rank must be positive.")
+        if cp_size <= 0 or dp_size <= 0:
+            raise ValueError("cp_size and dp_size must be positive.")
+        if (
+            microbatch_group_size_per_vp_stage is not None
+            and microbatch_group_size_per_vp_stage <= 0
+        ):
+            raise ValueError("microbatch_group_size_per_vp_stage must be positive.")
+        self.max_seqlen_per_dp_cp_rank = max_seqlen_per_dp_cp_rank
+        self.cp_size = cp_size
+        self.dp_size = dp_size
+        self.microbatch_group_size_per_vp_stage = microbatch_group_size_per_vp_stage
+
+    def get_required_sample_keys(self) -> List[str]:
+        """Return the required key of each batch."""
+        raise NotImplementedError
+
+    def get_groups_and_subsamples(
+        self, sample_id_seqlens: List[tuple[int, int]]
+    ) -> List[List[List[int]]]:
+        """Schedule samples into per-microbatch, per-DP×CP-rank groups."""
+        raise NotImplementedError
+
+    def run(
+        self,
+        data_iterator,
+        num_microbatches,
+        dp_group,
+        tp_group,
+        pp_group,
+        dp_cp_group,
+        dev,
+        config,
+    ):
+        """
+        Run the scheduler and return the new data_iterator.
+
+        Args:
+            data_iterator: The data iterator.
+            num_microbatches: The number of microbatches to fetch.
+            dp_group: Data parallel process group.
+            tp_group: Tensor parallel process group.
+            pp_group: Pipeline parallel process group.
+            dp_cp_group: Data parallel + context parallel process group.
+            dev: CUDA device.
+            config: Model parallel config.
+
+        Returns:
+            new_data_iterator: The new data iterator (or list for VPP).
+            num_micro_batches: Number of micro batches after scheduling.
+            seqlen_sum_this_global_batch: Total tokens for FLOPs calculation.
+            seqlen_squared_sum_this_global_batch: Sum of squared seqlens for FLOPs.
+        """
+        raise NotImplementedError
+
+
+def _get_vpp_stages_needing_data(config, pp_rank: int, pp_size: int) -> List[bool]:
+    """Return which virtual stages on a physical PP rank consume full batches."""
+
+    configured_vpp_size = getattr(config, "virtual_pipeline_model_parallel_size", None)
+    vpp_size = configured_vpp_size if configured_vpp_size is not None else 1
+    needs_data = [False] * vpp_size
+
+    if pp_rank == 0:
+        needs_data[0] = True
+    if pp_rank == pp_size - 1:
+        needs_data[-1] = True
+
+    layout = getattr(config, "pipeline_model_parallel_layout", None)
+    if layout is not None:
+        physical_stage_layout = layout.layout[pp_rank]
+        assert len(physical_stage_layout) == vpp_size, (
+            f"Pipeline layout has {len(physical_stage_layout)} virtual stages on PP rank "
+            f"{pp_rank}, expected {vpp_size}."
+        )
+        for vp_stage, stage_layout in enumerate(physical_stage_layout):
+            needs_data[vp_stage] |= LayerType.mtp in stage_layout
+    elif getattr(config, "mtp_num_layers", None) is not None and pp_rank == pp_size - 1:
+        # Without a custom layout, MTP is colocated with the final pipeline stage.
+        needs_data[-1] = True
+
+    return needs_data
+
+
+class DpBalancedScheduler(BasePackingScheduler):
+    """Packs sequences in their original order until reaching the max limit of sequence length."""
+
+    def __init__(
+        self,
+        max_seqlen_per_dp_cp_rank: int,
+        cp_size: int,
+        dp_size: int,
+        microbatch_group_size_per_vp_stage: int | None,
+    ):
+        super().__init__(
+            max_seqlen_per_dp_cp_rank, cp_size, dp_size, microbatch_group_size_per_vp_stage
+        )
+        self.max_seq_len_all_ranks = self.max_seqlen_per_dp_cp_rank * self.cp_size
+
+    def get_required_sample_keys(self) -> List[str]:
+        """Return the required key of each batch."""
+        return [
+            "tokens",
+            "labels",
+            "loss_mask",
+            "position_ids",
+            "original_seq_len",  # Length of the original sequence length, should be a gpu tensor.
+            "padded_seq_len",  # Length of the padded sequence length, should be a gpu tensor.
+        ]
+
+    def get_groups_and_subsamples(
+        self, sample_id_seqlens: List[tuple[int, int]]
+    ) -> List[List[List[int]]]:
+        """
+        Packs sequences in their original order until reaching the max limit of sequence length.
+        """
+        sample_id_groups = []
+        packed_id_groups = []
+        sum_seqlen = 0
+        single_microbatch = []
+
+        for sample_id, seqlen in sample_id_seqlens:
+            if seqlen > self.max_seq_len_all_ranks:
+                raise ValueError(
+                    f"Sample {sample_id} has padded length {seqlen}, exceeding the "
+                    f"per-microbatch capacity {self.max_seq_len_all_ranks}."
+                )
+            if sum_seqlen + seqlen <= self.max_seq_len_all_ranks:
+                single_microbatch.append(sample_id)
+                sum_seqlen += seqlen
+            else:
+                packed_id_groups.append(single_microbatch)
+                single_microbatch = [sample_id]
+                sum_seqlen = seqlen
+        if len(single_microbatch) > 0:
+            packed_id_groups.append(single_microbatch)
+
+        # we want the number of packed sequences to be multiple of dp_size
+        # so we move few samples from previous microbatch
+        # to the end of the microbatches if needed
+        num_packed_sequence = len(packed_id_groups)
+
+        # when enabling vpp, we want the number of packed sequences to be
+        # multiple of dp_size * microbatch_group_size_per_vp_stage
+        multiple = self.dp_size * (
+            self.microbatch_group_size_per_vp_stage
+            if self.microbatch_group_size_per_vp_stage is not None
+            else 1
+        )
+        if num_packed_sequence % multiple != 0:
+            remainder = num_packed_sequence % multiple
+            num_to_move = multiple - remainder
+            i = num_packed_sequence - 1
+            while num_to_move > 0:
+                while i >= 0 and len(packed_id_groups[i]) <= 1:
+                    i -= 1
+                if i < 0:
+                    raise ValueError("Not enough samples to align packed microbatches")
+                seq_id = packed_id_groups[i].pop()
+                packed_id_groups.append([seq_id])
+                num_to_move -= 1
+
+        assert len(packed_id_groups) % multiple == 0
+
+        num_micro_batches = int(len(packed_id_groups) / self.dp_size)
+        for i in range(num_micro_batches):
+            sample_id_groups.append([])
+            for j in range(self.cp_size * self.dp_size):
+                seq_id = int(i * self.dp_size + j / self.cp_size)
+                sample_id_groups[i].append(packed_id_groups[seq_id])
+        return sample_id_groups
+
+    def run(
+        self,
+        data_iterator,
+        num_microbatches: int,
+        dp_group,
+        tp_group,
+        pp_group,
+        dp_cp_group,
+        dev: torch.device,
+        config,
+    ):
+        """
+        Run the complete scheduling pipeline.
+
+        Steps:
+            1. Fetch batches and gather global sequence lengths
+            2. Check required sample keys
+            3. Schedule samples into groups
+            4. Reroute samples to DCP ranks
+            5. Build packed microbatches
+            6. Calculate FLOPs info
+            7. Broadcast to PP group (for middle PP stages)
+            8. Broadcast to TP group (for non-TP-0 ranks)
+            9. Handle VPP if enabled
+
+        Args:
+            data_iterator: The data iterator.
+            num_microbatches: The number of microbatches to fetch.
+            dp_group: Data parallel process group.
+            tp_group: Tensor parallel process group.
+            pp_group: Pipeline parallel process group.
+            dp_cp_group: Data parallel + context parallel process group.
+            dev: CUDA device.
+            config: Model parallel config.
+
+        Returns:
+            new_data_iterator: The new data iterator (or list for VPP).
+            num_micro_batches: Number of micro batches after scheduling.
+            seqlen_sum_this_global_batch: Total tokens for FLOPs calculation.
+            seqlen_squared_sum_this_global_batch: Sum of squared seqlens for FLOPs.
+        """
+
+        total_dcp_gpus = dp_cp_group.size()
+        is_first_pp_stage = pp_group.rank() == 0
+        is_last_pp_stage = pp_group.rank() == pp_group.size() - 1
+        vpp_needs_data = _get_vpp_stages_needing_data(
+            config, pp_rank=pp_group.rank(), pp_size=pp_group.size()
+        )
+        owns_raw_data = any(vpp_needs_data)
+        mtp_on_this_pp_stage = owns_raw_data and not (is_first_pp_stage or is_last_pp_stage)
+
+        # Handle VPP: extract the data iterator owned by this physical PP stage.
+        if (
+            config.virtual_pipeline_model_parallel_size is not None
+            and config.virtual_pipeline_model_parallel_size > 1
+        ):
+            vpp_size = config.virtual_pipeline_model_parallel_size
+            if data_iterator is not None:
+                assert len(data_iterator) == vpp_size
+                if owns_raw_data:
+                    data_iterator = next(
+                        (
+                            iterator
+                            for vp_stage, iterator in enumerate(data_iterator)
+                            if vpp_needs_data[vp_stage] and iterator is not None
+                        ),
+                        None,
+                    )
+                else:
+                    data_iterator = None
+        else:
+            vpp_needs_data = None
+
+        # Only TP rank zero consumes raw data. Intermediate PP stages may still
+        # receive a redundant iterator from legacy callers; ignore it and use
+        # metadata broadcast from the first stage instead.
+        if data_iterator is not None and not owns_raw_data:
+            data_iterator = None
+        if tp_group.rank() == 0 and owns_raw_data:
+            assert (
+                data_iterator is not None
+            ), "Sequence packing requires a data iterator on embedding, loss, and MTP stages."
+        if data_iterator is not None:
+            assert tp_group.rank() == 0, "Only TP rank 0 should have a data iterator"
+
+            # Step 1: Fetch batches and gather global sequence lengths
+            (
+                batch,
+                global_id_seqlens,
+                global_ids_this_rank,
+                offsets,
+                seqlen_sum_this_global_batch,
+                seqlen_squared_sum_this_global_batch,
+            ) = get_batch_and_global_seqlens(data_iterator, num_microbatches, dp_group)
+
+            # Step 2: Check required sample keys
+            for key in self.get_required_sample_keys():
+                assert (
+                    key in batch[0]
+                ), f"Batch missing required key {key}, provided keys: {batch[0].keys()}"
+
+            # Step 3: Schedule samples into groups
+            sample_id_groups = self.get_groups_and_subsamples(global_id_seqlens)
+
+            # Validate scheduling result
+            set_gbs = set()
+            for group in sample_id_groups:
+                for sub in group:
+                    set_gbs.update(sub)
+            assert len(set_gbs) == len(global_id_seqlens), (
+                f"set_gbs length: {len(set_gbs)} != "
+                f"global_id_seqlens length: {len(global_id_seqlens)}"
+            )
+
+            # Step 4: Reroute samples to DCP ranks
+            samples_this_rank_with_id = reroute_samples_to_dcp_ranks(
+                batch,
+                global_ids_this_rank,
+                global_id_seqlens,
+                sample_id_groups,
+                offsets,
+                dp_group,
+                dp_cp_group,
+                total_dcp_gpus,
+            )
+
+            dcp_rank = dp_cp_group.rank()
+            num_micro_batches = len(sample_id_groups)
+
+            grouped_samples = [
+                [
+                    samples_this_rank_with_id[sub_sample_id]
+                    for sub_sample_id in sample_id_groups[i][dcp_rank]
+                ]
+                for i in range(num_micro_batches)
+            ]
+
+            # Step 5: Build packed microbatches
+            new_samples = build_packed_microbatches(grouped_samples, dev)
+
+        else:
+            (
+                new_samples,
+                num_micro_batches,
+                seqlen_sum_this_global_batch,
+                seqlen_squared_sum_this_global_batch,
+            ) = (None, None, None, None)
+
+        # Step 7: Broadcast to PP group (for middle PP stages)
+        if tp_group.rank() == 0:
+            (
+                new_samples,
+                num_micro_batches,
+                seqlen_sum_this_global_batch,
+                seqlen_squared_sum_this_global_batch,
+            ) = broadcast_to_pp_group(
+                new_samples,
+                num_micro_batches,
+                seqlen_sum_this_global_batch,
+                seqlen_squared_sum_this_global_batch,
+                pp_group,
+                dev,
+                preserve_local_samples=mtp_on_this_pp_stage,
+            )
+
+        # Step 8: Broadcast to TP group. Keep the integer count separate from
+        # float64 FLOP statistics so neither is truncated through float32.
+        num_micro_batches = int(
+            broadcast_scalars([num_micro_batches], tp_group, dev, dtype=torch.int64)[0]
+        )
+        (seqlen_sum_this_global_batch, seqlen_squared_sum_this_global_batch) = broadcast_scalars(
+            [seqlen_sum_this_global_batch, seqlen_squared_sum_this_global_batch],
+            tp_group,
+            dev,
+            dtype=torch.float64,
+        )
+
+        # Step 9: create data_iterator and handle VPP if enabled
+        new_data_iterator = create_data_iterator(
+            new_samples,
+            tp_group,
+            config,
+            vpp_needs_data=vpp_needs_data,
+            needs_full_data=owns_raw_data,
+        )
+
+        return (
+            new_data_iterator,
+            num_micro_batches,
+            seqlen_sum_this_global_batch,
+            seqlen_squared_sum_this_global_batch,
+        )
+
+
+class PackingSchedulerEnum(enum.Enum):
+    """Enum for supported sequence packing algorithms."""
+
+    DP_BALANCED = "dp_balanced"
+
+
+scheduler_map: Dict[PackingSchedulerEnum, Type[BasePackingScheduler]] = {
+    PackingSchedulerEnum.DP_BALANCED: DpBalancedScheduler
+}
+
+
+def wrap_data_iterator(
+    data_iterator, config, num_microbatches: int, pg_collection: ProcessGroupCollection
+):
+    """
+    A wrapper function that wraps around an existing data_iterator
+    and return the num_micro_batches for sequence packing.
+
+    Args:
+        data_iterator: The original data_iterator to wrap around
+        config: The config object containing the max_seqlen_per_dp_cp_rank
+        num_microbatches: Number of input microbatches to schedule.
+        pg_collection: Explicit process groups used for scheduling.
+    """
+
+    dp_cp_group = pg_collection.dp_cp
+    dp_group = pg_collection.dp
+    tp_group = pg_collection.tp
+    pp_group = pg_collection.pp
+    assert (
+        dp_cp_group is not None
+        and dp_group is not None
+        and tp_group is not None
+        and pp_group is not None
+    ), "dp_cp_group, dp_group, tp_group must not be None when using sequence packing"
+
+    dev = torch.cuda.current_device()
+    dp_size = dp_group.size()
+    cp_size = dp_cp_group.size() // dp_size
+
+    # Convert string to enum
+    scheduler_type = PackingSchedulerEnum(config.sequence_packing_scheduler)
+
+    scheduler = scheduler_map[scheduler_type](
+        config.max_seqlen_per_dp_cp_rank,
+        cp_size,
+        dp_size,
+        # When VPP is enabled, align num_micro_batches to this multiple.
+        (
+            None
+            if config.virtual_pipeline_model_parallel_size is None
+            else config.microbatch_group_size_per_vp_stage
+        ),
+    )
+
+    (
+        new_data_iterator,
+        num_micro_batches,
+        seqlen_sum_this_global_batch,
+        seqlen_squared_sum_this_global_batch,
+    ) = scheduler.run(
+        data_iterator, num_microbatches, dp_group, tp_group, pp_group, dp_cp_group, dev, config
+    )
+
+    return (
+        new_data_iterator,
+        num_micro_batches,
+        seqlen_sum_this_global_batch,
+        seqlen_squared_sum_this_global_batch,
+    )

--- a/megatron/core/datasets/data_schedule_utils.py
+++ b/megatron/core/datasets/data_schedule_utils.py
@@ -1,0 +1,619 @@
+# Copyright (c) 2025 NVIDIA CORPORATION.  All rights reserved.
+
+from typing import Dict, List
+
+import torch
+
+from megatron.core.rerun_state_machine import RerunDataIterator
+
+
+def _unpack_batch(batch: List[Dict[str, torch.Tensor]]) -> List[Dict[str, torch.Tensor]]:
+    """Normalize batches into one dictionary per variable-length sequence."""
+
+    if not batch:
+        return []
+
+    data_keys = ("tokens", "labels", "loss_mask", "position_ids")
+
+    def _without_collate_dim(value):
+        if isinstance(value, torch.Tensor) and value.ndim == 2 and value.shape[0] == 1:
+            return value.squeeze(0)
+        return value
+
+    # Variable-length datasets already emit one sequence per sample.
+    if "padded_seq_len" in batch[0]:
+        normalized_batch = []
+        for sample in batch:
+            normalized = {key: _without_collate_dim(value) for key, value in sample.items()}
+            if "original_seq_len" not in normalized:
+                normalized["original_seq_len"] = normalized["padded_seq_len"].clone()
+            original_length = int(normalized["original_seq_len"].reshape(-1)[0].item())
+            padded_length = int(normalized["padded_seq_len"].reshape(-1)[0].item())
+            if original_length <= 0 or original_length > padded_length:
+                raise ValueError(
+                    "Each real sequence length must be positive and no larger than its "
+                    "physical length"
+                )
+            for key in data_keys:
+                if key in normalized and normalized[key].numel() != padded_length:
+                    raise ValueError(f"{key} must contain padded_seq_len values")
+            normalized_batch.append(normalized)
+        return normalized_batch
+
+    batch_unpacked = []
+    original_sequence_lengths = []
+    padded_sequence_lengths = []
+    device = batch[0]["cu_seqlens"].device
+    for sample in batch:
+        cu_seqlens = _without_collate_dim(sample["cu_seqlens"])
+        if "cu_seqlens_original" not in sample:
+            raise ValueError(
+                "Pre-packed samples require cu_seqlens_original so the packing scheduler "
+                "can distinguish real tokens from physical padding."
+            )
+        cu_seqlens_original = _without_collate_dim(sample["cu_seqlens_original"])
+        if cu_seqlens_original.numel() != cu_seqlens.numel():
+            raise ValueError("cu_seqlens_original must have the same width as cu_seqlens")
+        normalized_data = {
+            key: _without_collate_dim(sample[key]) for key in data_keys if key in sample
+        }
+        for sequence_index in range(cu_seqlens.numel() - 1):
+            start = int(cu_seqlens[sequence_index].item())
+            end = int(cu_seqlens[sequence_index + 1].item())
+            if end == start:
+                continue
+            original_length = int(
+                (
+                    cu_seqlens_original[sequence_index + 1] - cu_seqlens_original[sequence_index]
+                ).item()
+            )
+            padded_length = end - start
+            if original_length <= 0 or original_length > padded_length:
+                raise ValueError(
+                    "Each real sequence length must be positive and no larger than its "
+                    "physical length"
+                )
+            batch_unpacked.append({key: value[start:end] for key, value in normalized_data.items()})
+            original_sequence_lengths.append(original_length)
+            padded_sequence_lengths.append(padded_length)
+
+    original_lengths = torch.tensor(original_sequence_lengths, dtype=torch.int32, device=device)
+    padded_lengths = torch.tensor(padded_sequence_lengths, dtype=torch.int32, device=device)
+    for index, sample in enumerate(batch_unpacked):
+        sample["original_seq_len"] = original_lengths[index : index + 1]
+        sample["padded_seq_len"] = padded_lengths[index : index + 1]
+
+    return batch_unpacked
+
+
+def _get_global_seqlens_and_ids(subsample_seqlens: torch.Tensor, dp_group):
+    """
+    Gathers the sequence lengths of all subsamples from all DP ranks and calculates global IDs.
+    """
+    # Collect the number of subsamples from all ranks
+    num_local_subsamples = subsample_seqlens.shape[0]
+    device = subsample_seqlens.device
+    local_len = torch.tensor([num_local_subsamples], dtype=torch.int32, device=device)
+    dp_subsample_count = [torch.zeros_like(local_len) for _ in range(dp_group.size())]
+    torch.distributed.all_gather(dp_subsample_count, local_len, group=dp_group)
+
+    # Find the max number of subsamples across all ranks and pad subsample_seqlens to max length
+    dp_subsample_counts = torch.stack(dp_subsample_count, dim=0).cpu().view(-1)
+    max_sub_samples = int(dp_subsample_counts.max().item())
+
+    if num_local_subsamples < max_sub_samples:
+        subsample_seqlens_padded = torch.cat(
+            [
+                subsample_seqlens,
+                torch.zeros(
+                    max_sub_samples - num_local_subsamples, dtype=torch.int32, device=device
+                ),
+            ],
+            dim=0,
+        )
+    else:
+        subsample_seqlens_padded = subsample_seqlens
+
+    # Gather the subsample_seqlens from all ranks
+    seqlens_gathered = [torch.empty_like(subsample_seqlens_padded) for _ in range(dp_group.size())]
+    torch.distributed.all_gather(seqlens_gathered, subsample_seqlens_padded, group=dp_group)
+
+    # Trim each seqlens_gathered to the length of the correct sample
+    for dp_rank, seqlen in enumerate(seqlens_gathered):
+        seqlens_gathered[dp_rank] = seqlen[: dp_subsample_counts[dp_rank]]
+
+    seqlens_gathered = torch.cat(seqlens_gathered, dim=0)
+    seqlens_gathered = seqlens_gathered.cpu().tolist()
+
+    # Calculate the offsets to assign unique global ID to each subsample.
+    csum = torch.cumsum(dp_subsample_counts, dim=0, dtype=torch.int32)
+    offsets = torch.cat([torch.zeros(1, dtype=torch.int32), csum], dim=0)
+
+    # Calculate global ID for each subsample
+    dp_rank = dp_group.rank()
+    global_ids = torch.arange(len(seqlens_gathered), dtype=torch.int32, device=device)
+
+    # Create a list of (global_id, seqlen) tuples for scheduling
+    global_id_seqlens = [(i, seqlens_gathered[i]) for i in range(len(global_ids))]
+
+    # Get the global IDs locally present on this rank
+    start_idx = int(offsets[dp_rank].item())
+    end_idx = int(offsets[dp_rank + 1].item())
+
+    global_ids_this_rank = global_ids[start_idx:end_idx]
+
+    return global_id_seqlens, global_ids_this_rank, offsets, seqlens_gathered
+
+
+def _get_group_local_ranks(subgroup, parent_group) -> List[int]:
+    """Map subgroup members to their local ranks in a containing process group."""
+
+    parent_ranks = torch.distributed.get_process_group_ranks(parent_group)
+    parent_rank_by_global_rank = {
+        global_rank: rank for rank, global_rank in enumerate(parent_ranks)
+    }
+    subgroup_ranks = torch.distributed.get_process_group_ranks(subgroup)
+    try:
+        return [parent_rank_by_global_rank[global_rank] for global_rank in subgroup_ranks]
+    except KeyError as exc:
+        raise ValueError("subgroup must be contained in parent_group") from exc
+
+
+def _pack_sequences(
+    samples: List, padded_lengths: torch.Tensor, original_lengths: torch.Tensor, dev: torch.device
+) -> Dict[str, torch.Tensor]:
+    """Pack multiple samples into a single packed sample."""
+
+    def _pack_tensors(tensors):
+        return torch.cat([t.reshape(-1) for t in tensors], dim=0)
+
+    tokens = _pack_tensors([sample["tokens"] for sample in samples])
+    labels = _pack_tensors([sample["labels"] for sample in samples])
+    loss_mask = _pack_tensors([sample["loss_mask"] for sample in samples])
+    position_ids = _pack_tensors([sample["position_ids"] for sample in samples])
+
+    new_sample = {}
+    new_sample["tokens"] = tokens
+    new_sample["labels"] = labels
+    new_sample["loss_mask"] = loss_mask
+    new_sample["position_ids"] = position_ids
+
+    padded_lengths = padded_lengths.to(device=dev, dtype=torch.int32, non_blocking=True).reshape(-1)
+    cu_seqlens_padded = torch.empty(padded_lengths.numel() + 1, device=dev, dtype=torch.int32)
+    cu_seqlens_padded[0] = 0
+    cu_seqlens_padded[1:] = torch.cumsum(padded_lengths, dim=0)
+    max_seqlen = torch.max(padded_lengths).to(dtype=torch.int32)
+
+    new_sample["cu_seqlens_padded"] = cu_seqlens_padded
+    new_sample["max_seqlen"] = max_seqlen
+
+    original_lengths = original_lengths.to(
+        device=dev, dtype=torch.int32, non_blocking=True
+    ).reshape(-1)
+    cu_seqlens = torch.empty(original_lengths.numel() + 1, device=dev, dtype=torch.int32)
+    cu_seqlens[0] = 0
+    cu_seqlens[1:] = torch.cumsum(original_lengths, dim=0).reshape(-1)
+    new_sample["cu_seqlens"] = cu_seqlens
+
+    return new_sample
+
+
+def broadcast_tensor(item, src_rank, group) -> None:
+    """Broadcast a tensor from src_rank to all ranks in the group."""
+    if item is not None:
+        torch.distributed.broadcast(item, src_rank, group=group)
+
+
+def _serialize_packed_metadata(
+    samples: List[Dict[str, torch.Tensor]], device: torch.device
+) -> torch.Tensor:
+    """Serialize packed-sequence metadata without floating-point casts."""
+
+    tensors = [torch.tensor([len(samples)], dtype=torch.int64, device=device)]
+    for sample in samples:
+        cu_seqlens = sample["cu_seqlens"].reshape(-1).to(dtype=torch.int64, device=device)
+        cu_seqlens_padded = (
+            sample["cu_seqlens_padded"].reshape(-1).to(dtype=torch.int64, device=device)
+        )
+        lengths = torch.tensor(
+            [cu_seqlens.numel(), cu_seqlens_padded.numel()], dtype=torch.int64, device=device
+        )
+        tensors.append(
+            torch.cat(
+                (sample["max_seqlen"].reshape(1).to(dtype=torch.int64, device=device), lengths)
+            )
+        )
+        tensors.extend((cu_seqlens, cu_seqlens_padded))
+    return torch.cat(tensors)
+
+
+def _deserialize_packed_metadata(payload: torch.Tensor) -> List[Dict[str, torch.Tensor]]:
+    """Deserialize length-prefixed packed-sequence metadata."""
+
+    assert payload.dtype == torch.int64
+    cursor = 0
+    num_samples = int(payload[cursor].item())
+    cursor += 1
+    samples = []
+    for _ in range(num_samples):
+        max_seqlen = payload[cursor].to(torch.int32)
+        cu_seqlens_len = int(payload[cursor + 1].item())
+        cu_seqlens_padded_len = int(payload[cursor + 2].item())
+        cursor += 3
+
+        cu_seqlens = payload[cursor : cursor + cu_seqlens_len].to(torch.int32)
+        cursor += cu_seqlens_len
+        cu_seqlens_padded = payload[cursor : cursor + cu_seqlens_padded_len].to(torch.int32)
+        cursor += cu_seqlens_padded_len
+        samples.append(
+            {
+                "max_seqlen": max_seqlen,
+                "cu_seqlens": cu_seqlens,
+                "cu_seqlens_padded": cu_seqlens_padded,
+            }
+        )
+
+    assert cursor == payload.numel(), (
+        f"Packed metadata decoder consumed {cursor} values, "
+        f"but payload contains {payload.numel()}."
+    )
+    return samples
+
+
+def broadcast_to_pp_group(
+    new_samples,
+    num_micro_batches,
+    seqlen_sum_this_global_batch,
+    seqlen_squared_sum_this_global_batch,
+    pp_group,
+    dev,
+    preserve_local_samples: bool = False,
+):
+    """Broadcast packed metadata and batch statistics to intermediate PP stages."""
+
+    if pp_group.size() <= 2:
+        return (
+            new_samples,
+            num_micro_batches,
+            seqlen_sum_this_global_batch,
+            seqlen_squared_sum_this_global_batch,
+        )
+
+    pp_src_rank = torch.distributed.get_process_group_ranks(pp_group)[0]
+    if pp_group.rank() == 0:
+        metadata = _serialize_packed_metadata(new_samples, dev)
+        metadata_size = torch.tensor(metadata.numel(), dtype=torch.int64, device=dev)
+        stats = torch.tensor(
+            [seqlen_sum_this_global_batch, seqlen_squared_sum_this_global_batch],
+            dtype=torch.float64,
+            device=dev,
+        )
+    else:
+        metadata_size = torch.zeros((), dtype=torch.int64, device=dev)
+        stats = torch.zeros(2, dtype=torch.float64, device=dev)
+
+    broadcast_tensor(metadata_size, pp_src_rank, pp_group)
+    if pp_group.rank() != 0:
+        metadata = torch.empty(int(metadata_size.item()), dtype=torch.int64, device=dev)
+    broadcast_tensor(metadata, pp_src_rank, pp_group)
+    broadcast_tensor(stats, pp_src_rank, pp_group)
+
+    if pp_group.rank() not in (0, pp_group.size() - 1) and not preserve_local_samples:
+        new_samples = _deserialize_packed_metadata(metadata)
+        num_micro_batches = len(new_samples)
+        seqlen_sum_this_global_batch = float(stats[0].item())
+        seqlen_squared_sum_this_global_batch = float(stats[1].item())
+
+    return (
+        new_samples,
+        num_micro_batches,
+        seqlen_sum_this_global_batch,
+        seqlen_squared_sum_this_global_batch,
+    )
+
+
+def broadcast_scalars(values: List, group, dev, dtype=torch.float32) -> List:
+    """
+    Broadcast scalar values from rank 0 to all ranks in the group.
+
+    Args:
+        values: List of scalar values to broadcast (only used on rank 0).
+        group: The process group to broadcast within.
+        dev: The device to use for the tensor.
+        dtype: The data type for the tensor.
+
+    Returns:
+        List of broadcasted values.
+    """
+    if group.size() <= 1:
+        return values
+
+    src_rank = torch.distributed.get_process_group_ranks(group)[0]
+    num_values = len(values)
+
+    if group.rank() == 0:
+        info_to_broadcast = torch.tensor(values, dtype=dtype, device=dev)
+    else:
+        info_to_broadcast = torch.zeros(num_values, dtype=dtype, device=dev)
+
+    broadcast_tensor(info_to_broadcast, src_rank, group)
+
+    if group.rank() != 0:
+        values = info_to_broadcast.cpu().tolist()
+
+    return values
+
+
+def create_data_iterator(
+    new_samples, tp_group, config, vpp_needs_data=None, needs_full_data: bool = False
+):
+    """Create TP-rank-zero iterators with the standard dataloader batch dimension."""
+
+    def _normalize_sample(sample):
+        normalized = dict(sample)
+        for key in (
+            "tokens",
+            "labels",
+            "loss_mask",
+            "position_ids",
+            "cu_seqlens",
+            "cu_seqlens_padded",
+        ):
+            value = normalized.get(key)
+            if isinstance(value, torch.Tensor) and value.ndim == 1:
+                normalized[key] = value.unsqueeze(0)
+        if isinstance(normalized.get("max_seqlen"), torch.Tensor):
+            normalized["max_seqlen"] = normalized["max_seqlen"].reshape(1)
+        return normalized
+
+    if tp_group.rank() != 0:
+        if (
+            config.virtual_pipeline_model_parallel_size is not None
+            and config.virtual_pipeline_model_parallel_size > 1
+        ):
+            return [None] * config.virtual_pipeline_model_parallel_size
+        return None
+
+    new_samples = [_normalize_sample(sample) for sample in new_samples]
+    metadata_keys = ("max_seqlen", "cu_seqlens", "cu_seqlens_padded")
+
+    if (
+        config.virtual_pipeline_model_parallel_size is not None
+        and config.virtual_pipeline_model_parallel_size > 1
+    ):
+        vpp_size = config.virtual_pipeline_model_parallel_size
+        assert vpp_needs_data is not None and len(vpp_needs_data) == vpp_size
+        iterators = []
+        for stage_needs_data in vpp_needs_data:
+            if stage_needs_data:
+                assert needs_full_data
+                samples = [dict(sample) for sample in new_samples]
+            else:
+                samples = [{key: sample[key] for key in metadata_keys} for sample in new_samples]
+            iterators.append(RerunDataIterator(iter(samples)))
+        return iterators
+
+    return RerunDataIterator(iter(new_samples))
+
+
+def reroute_samples_to_dcp_ranks(
+    batch,
+    global_ids_this_rank,
+    global_id_seqlens,
+    sample_id_groups,
+    offsets,
+    dp_group,
+    dp_cp_group,
+    total_dcp_gpus,
+):
+    """
+    Reroutes the sub-samples to the correct rank after scheduling.
+
+    For each key in the batch dict, we perform an all-to-all communication
+    to transfer the data to the correct ranks.
+    """
+
+    dp_ranks = _get_group_local_ranks(dp_group, dp_cp_group)
+
+    def _gid_to_src_rank(gid: int) -> int:
+        gid_tensor = torch.tensor(gid, dtype=offsets.dtype, device=offsets.device)
+        dp_src_rank = int(torch.bucketize(gid_tensor, offsets[1:] - 1).item())
+        return dp_ranks[dp_src_rank]
+
+    gid2local_id = {int(gid): i for i, gid in enumerate(global_ids_this_rank)}
+    global_ids_this_rank_set = set(gid2local_id)
+    dcp_rank = dp_cp_group.rank()
+    dp_rank_set = set(dp_ranks)
+
+    data_keys = [
+        key
+        for key in (
+            "tokens",
+            "labels",
+            "loss_mask",
+            "position_ids",
+            "original_seq_len",
+            "padded_seq_len",
+        )
+        if key in batch[0]
+    ]
+
+    # Create the send plan
+    combined_sample_id_groups: List[List[int]] = [[] for _ in range(total_dcp_gpus)]
+    for d in range(total_dcp_gpus):
+        for sample_id_group in sample_id_groups:
+            combined_sample_id_groups[d].extend(sample_id_group[d])
+    for dest_rank in range(total_dcp_gpus):
+        combined_sample_id_groups[dest_rank].sort()
+
+    send_ids_sorted = [
+        gid
+        for d in range(total_dcp_gpus)
+        if d in dp_rank_set
+        for gid in combined_sample_id_groups[d]
+        if gid in global_ids_this_rank_set
+    ]
+
+    send_num_split = [0] * total_dcp_gpus
+    send_lens_split = [0] * total_dcp_gpus
+    for dest_rank in range(total_dcp_gpus):
+        if dest_rank in dp_rank_set:
+            send_seq_lens = [
+                global_id_seqlens[gid][1]
+                for gid in combined_sample_id_groups[dest_rank]
+                if gid in global_ids_this_rank_set
+            ]
+            send_num_split[dest_rank] = len(send_seq_lens)
+            send_lens_split[dest_rank] = sum(send_seq_lens)
+        else:
+            send_lens_split[dest_rank] = 0
+
+    # Create the recv plan
+    recv_sample_id_groups = [[] for _ in range(total_dcp_gpus)]
+    for gid in combined_sample_id_groups[dcp_rank]:
+        src_rank = _gid_to_src_rank(gid)
+        recv_sample_id_groups[src_rank].append(gid)
+
+    recv_lens_split = [0] * total_dcp_gpus
+    for src_rank in range(total_dcp_gpus):
+        recv_lens_split[src_rank] = sum(
+            [global_id_seqlens[gid][1] for gid in recv_sample_id_groups[src_rank]]
+        )
+
+    recv_ids_sorted = [gid for d in range(total_dcp_gpus) for gid in recv_sample_id_groups[d]]
+    recv_counts = [len(recv_sample_id_groups[d]) for d in range(total_dcp_gpus)]
+
+    recv_samples = [{k: None for k in data_keys} for _ in range(sum(recv_counts))]
+
+    def _pack_sample_by_key(key: str) -> torch.Tensor:
+        flattened_tensors = []
+        for gid in send_ids_sorted:
+            t = batch[gid2local_id[gid]][key].to(torch.cuda.current_device(), non_blocking=True)
+            flattened_tensors.append(t.reshape(-1))
+        return (
+            torch.cat(flattened_tensors, dim=0)
+            if flattened_tensors
+            else torch.empty(0, device=torch.cuda.current_device(), dtype=batch[0][key].dtype)
+        )
+
+    def _unpack_sample_by_key(key: str, recv_tensor: torch.Tensor):
+        cursor = 0
+        for i, gid in enumerate(recv_ids_sorted):
+            sample_len = (
+                1 if key in ["original_seq_len", "padded_seq_len"] else global_id_seqlens[gid][1]
+            )
+            recv_samples[i][key] = recv_tensor[cursor : cursor + sample_len]
+            cursor += sample_len
+        assert cursor == recv_tensor.numel()
+
+    for key in data_keys:
+        output_split_sizes, input_split_sizes = (
+            (recv_counts, send_num_split)
+            if key in ["original_seq_len", "padded_seq_len"]
+            else (recv_lens_split, send_lens_split)
+        )
+        send_tensor = _pack_sample_by_key(key)
+        recv_tensor_size = sum(output_split_sizes)
+        recv_tensor = torch.empty(
+            recv_tensor_size, device=torch.cuda.current_device(), dtype=send_tensor.dtype
+        )
+        torch.distributed.all_to_all_single(
+            output=recv_tensor,
+            input=send_tensor,
+            output_split_sizes=output_split_sizes,
+            input_split_sizes=input_split_sizes,
+            group=dp_cp_group,
+        )
+        _unpack_sample_by_key(key, recv_tensor)
+
+    recv_sample_with_id = {recv_id: recv_samples[i] for i, recv_id in enumerate(recv_ids_sorted)}
+    return recv_sample_with_id
+
+
+def build_packed_microbatches(
+    grouped_samples: List[List[Dict[str, torch.Tensor]]], dev: torch.device
+) -> List[Dict[str, torch.Tensor]]:
+    """Build packed samples for each microbatch."""
+    num_micro_batches = len(grouped_samples)
+    seg_starts: List[int] = [0]
+    original_lens_tensors = []
+    padded_lens_tensors = []
+
+    for i in range(num_micro_batches):
+        samples = grouped_samples[i]
+        seg_starts.append(seg_starts[-1] + len(samples))
+        original_lens_tensors.extend([s["original_seq_len"].reshape(-1) for s in samples])
+        padded_lens_tensors.extend([s["padded_seq_len"].reshape(-1) for s in samples])
+
+    padded_lens_all_gpu = torch.cat(padded_lens_tensors, dim=0).to(dtype=torch.int32)
+    original_lens_all_gpu = torch.cat(original_lens_tensors, dim=0).to(dtype=torch.int32)
+
+    new_samples: List[Dict[str, torch.Tensor]] = []
+    for i in range(num_micro_batches):
+        samples = grouped_samples[i]
+        lens_padded = padded_lens_all_gpu[seg_starts[i] : seg_starts[i + 1]]
+        lens_original = original_lens_all_gpu[seg_starts[i] : seg_starts[i + 1]]
+        new_sample = _pack_sequences(samples, lens_padded, lens_original, dev)
+        new_samples.append(new_sample)
+
+    return new_samples
+
+
+def get_batch_and_global_seqlens(data_iterator, num_microbatches, dp_group):
+    """
+    Get the batch and global sequence lengths.
+    Each DP rank loads the same number of sequences, so we need to gather the sequence
+    lengths from all ranks then we can schedule the sequences into groups.
+    Args:
+        data_iterator: The data iterator.
+        num_microbatches: The number of microbatches.
+        dp_group: The data parallel group.
+
+    Returns:
+        batch: The batch.
+        global_id_seqlens: The global sequence lengths.
+        global_ids_this_rank: The global IDs locally present on this rank.
+    """
+
+    batch_list = [next(data_iterator) for _ in range(num_microbatches)]
+
+    batch = []
+    for item in batch_list:
+        if isinstance(item, dict):
+            batch.append(item)
+        elif isinstance(item, list):
+            batch.extend(item)
+        else:
+            raise ValueError(f"Invalid item type: {type(item)}")
+
+    # in sft_dataset.py, sequences are already packed before rescheduling,
+    # so we need to unpack them here and repack after rescheduling.
+    # This is only to adapt to the current megatron-lm sft_dataset.
+    # If you implement your own dataset, just have __getitem__ return List[Dict]
+    # and this step can be skipped.
+    batch = _unpack_batch(batch)
+    if not batch:
+        raise ValueError("Sequence packing requires at least one non-empty sample.")
+
+    subsample_seqlens = torch.cat([sample["padded_seq_len"] for sample in batch]).to(
+        dtype=torch.int32, device=torch.cuda.current_device()
+    )
+
+    global_id_seqlens, global_ids_this_rank, offsets, _ = _get_global_seqlens_and_ids(
+        subsample_seqlens, dp_group
+    )
+
+    original_lengths = torch.cat([sample["original_seq_len"] for sample in batch]).to(
+        dtype=torch.float64, device=torch.cuda.current_device()
+    )
+    global_stats = torch.stack((original_lengths.sum(), torch.square(original_lengths).sum()))
+    torch.distributed.all_reduce(global_stats, group=dp_group)
+
+    return (
+        batch,
+        global_id_seqlens,
+        global_ids_this_rank,
+        offsets,
+        float(global_stats[0].item()),
+        float(global_stats[1].item()),
+    )

--- a/megatron/core/datasets/readme.md
+++ b/megatron/core/datasets/readme.md
@@ -204,6 +204,26 @@ If the later training job does not specify `--global-batch-size` (which is neede
 
 `tools/prepare_cache.py` does not support `--mock-data`, `--sft`, `--fim-data`, or `--step-batch-size-schedule`.
 
+## Packing Scheduler
+
+The packing scheduler re-schedules variable-length sequences across DP×CP ranks to improve GPU utilization. It is built around the following modules:
+
+### `data_schedule`
+
+This module contains the high-level scheduling logic and entry points:
+
+- **`HybridCPDataLoaderWrapper`**: A wrapper class for hybrid context parallel (CP) scheduling. For every `__next__` call, it: (1) pulls a batch of packed samples from each DP rank, (2) gathers sequence lengths across the DP group, (3) schedules sub-samples using the `BalancedCPScheduler`, (4) reroutes sub-samples to the correct DPxCP ranks via all-to-all communication.
+
+- **`BasePackingScheduler`**: Abstract base class for packing schedulers. Defines the interface for `get_groups_and_subsamples()` (scheduling algorithm) and `run()` (full scheduling pipeline including fetch, schedule, reroute, pack, broadcast, and VPP handling).
+
+- **`DpBalancedScheduler`**: A concrete scheduler that packs sequences in their original order until reaching the max sequence length limit per DPxCP rank. Supports aligning the number of microbatches to DP size and VPP stage multiples.
+
+- **`wrap_data_iterator()`**: Top-level entry point that wraps an existing `data_iterator`. It creates the requested scheduler, runs the scheduling pipeline, broadcasts metadata and the new microbatch count, and returns a new iterator with global-batch FLOPs statistics. Callers provide an explicit `ProcessGroupCollection`.
+
+### `data_schedule_utils.py`
+
+This module contains the scheduler's packing, routing, and length-prefixed PP metadata helpers. Scheduled batches use the canonical TP/CP batch utilities in `megatron.core.utils`.
+
 ## Fast DataLoader initialization
 
 Especially for large-scale runs, DataLoader initialization can take several minutes, since it involves opening and memory-mapping multiple files and can significantly stress the filesystem. To speed up this process, we have developed the following three optimizations, controlled by configuration flags:

--- a/megatron/core/utils.py
+++ b/megatron/core/utils.py
@@ -2036,6 +2036,43 @@ def is_submodule(module, parent_module, strict=True):
 ########################
 
 
+def _build_thd_padding_mask(
+    cu_seqlens: torch.Tensor, cu_seqlens_padded: torch.Tensor
+) -> torch.Tensor:
+    """Build a THD padding mask from real and physical sequence boundaries."""
+
+    cu_seqlens = cu_seqlens.reshape(-1)
+    cu_seqlens_padded = cu_seqlens_padded.reshape(-1)
+    assert cu_seqlens.numel() == cu_seqlens_padded.numel()
+
+    total_tokens = int(cu_seqlens_padded[-1].item())
+    if total_tokens == 0:
+        return torch.empty(0, dtype=torch.bool, device=cu_seqlens.device)
+
+    positions = torch.arange(
+        total_tokens, dtype=cu_seqlens_padded.dtype, device=cu_seqlens_padded.device
+    )
+    sequence_indices = torch.searchsorted(cu_seqlens_padded[1:].contiguous(), positions, right=True)
+    valid_lengths = (cu_seqlens[1:] - cu_seqlens[:-1]).clamp(min=0)
+    valid_ends = cu_seqlens_padded[:-1] + valid_lengths
+    return positions >= valid_ends[sequence_indices]
+
+
+def _sanitize_thd_padding_values(batch: Dict[str, Any], padding_mask: torch.Tensor) -> None:
+    """Replace padded token-like values with safe neutral values in-place."""
+
+    pad_values = {"tokens": 0, "labels": 0, "loss_mask": 0.0, "position_ids": 0}
+    for key, pad_value in pad_values.items():
+        tensor = batch.get(key)
+        if tensor is None:
+            continue
+        assert tensor.shape == padding_mask.shape, (
+            f"{key} shape {tuple(tensor.shape)} must match padding-mask shape "
+            f"{tuple(padding_mask.shape)}."
+        )
+        batch[key] = tensor.masked_fill(padding_mask, pad_value)
+
+
 def get_batch_on_this_tp_rank(
     batch: dict[str, torch.Tensor],
     has_cu_seqlens: bool,
@@ -2051,6 +2088,8 @@ def get_batch_on_this_tp_rank(
     pipeline_model_parallel_size: int = 1,
     is_pipeline_first_stage: bool = False,
     is_pipeline_last_stage: bool = False,
+    variable_seq_lengths: bool = False,
+    has_padding_mask: bool = False,
 ):
     """Broadcast batch tensors from TP rank 0 to all other ranks in the TP group.
 
@@ -2065,8 +2104,7 @@ def get_batch_on_this_tp_rank(
     rank 0 first sends the numel, then the tensor itself, so receivers can
     allocate the correct buffer size.
 
-    For hybrid-CP, the sequence length may differ per micro-batch (since it
-    depends on `local_cp_size`), so the actual sequence length is broadcast
+    For hybrid CP and variable-length scheduling, the batch shape is broadcast
     before allocating receive buffers on non-zero TP ranks.
 
     Args:
@@ -2091,19 +2129,36 @@ def get_batch_on_this_tp_rank(
         pipeline_model_parallel_size (int): Number of pipeline-parallel stages.
         is_pipeline_first_stage (bool): Whether this rank is on the first PP stage.
         is_pipeline_last_stage (bool): Whether this rank is on the last PP stage.
+        variable_seq_lengths (bool): Whether each microbatch may have a different
+            physical sequence length.
+        has_padding_mask (bool): Whether to build and broadcast a THD padding mask.
 
     Returns:
         dict[str, torch.Tensor]: The batch dict with all tensors populated on
         every TP rank. Keys include 'tokens', 'labels', 'loss_mask',
         'position_ids', 'attention_mask', 'cu_seqlens', 'cu_seqlens_padded',
-        'max_seqlen', 'local_cp_size', and 'hybrid_cp_group'.
+        'max_seqlen', 'padding_mask', 'local_cp_size', and 'hybrid_cp_group'.
     """
 
     def _broadcast(item):
         if item is not None:
             torch.distributed.broadcast(item, broadcast_src_rank, group=broadcast_group)
 
+    if has_padding_mask and not has_cu_seqlens:
+        raise ValueError("has_padding_mask requires has_cu_seqlens")
+
+    dynamic_seq_length = is_hybrid_cp or variable_seq_lengths
+
     if tp_rank == 0:
+        batch.setdefault("padding_mask", None)
+        if has_padding_mask:
+            assert batch.get("cu_seqlens") is not None
+            assert batch.get("cu_seqlens_padded") is not None
+            padding_mask = _build_thd_padding_mask(
+                batch["cu_seqlens"], batch["cu_seqlens_padded"]
+            ).reshape(1, -1)
+            batch["padding_mask"] = padding_mask
+            _sanitize_thd_padding_values(batch, padding_mask)
 
         def _broadcast_cu_seqlens(cu_seqlens):
             dev = torch.cuda.current_device()
@@ -2120,11 +2175,18 @@ def get_batch_on_this_tp_rank(
                 ), f"Expected cu_seqlens to be of type torch.int32, got {cu_seqlens.dtype}"
                 _broadcast(cu_seqlens)
 
-        if is_hybrid_cp:
-            hybrid_cp_seq_length = torch.tensor(
-                batch['tokens'].shape[1], dtype=torch.int32, device=torch.cuda.current_device()
+        if dynamic_seq_length:
+            reference_tensor = batch["padding_mask"] if has_padding_mask else None
+            if reference_tensor is None:
+                for key in ("tokens", "labels"):
+                    if batch.get(key) is not None:
+                        reference_tensor = batch[key]
+                        break
+            assert reference_tensor is not None
+            batch_shape = torch.tensor(
+                reference_tensor.shape[:2], dtype=torch.int32, device=torch.cuda.current_device()
             )
-            _broadcast(hybrid_cp_seq_length)
+            _broadcast(batch_shape)
 
         if pipeline_model_parallel_size == 1 or mtp_on_this_rank:
             _broadcast(batch['tokens'])
@@ -2138,6 +2200,8 @@ def get_batch_on_this_tp_rank(
                     _broadcast_cu_seqlens(batch['cu_seqlens_padded'])
             if create_attention_mask_in_dataloader:
                 _broadcast(batch['attention_mask'])
+            if has_padding_mask:
+                _broadcast(batch['padding_mask'])
             if is_hybrid_cp:
                 _broadcast(batch['local_cp_size'])
 
@@ -2154,6 +2218,8 @@ def get_batch_on_this_tp_rank(
                     _broadcast_cu_seqlens(batch['cu_seqlens_padded'])
             if create_attention_mask_in_dataloader:
                 _broadcast(batch['attention_mask'])
+            if has_padding_mask:
+                _broadcast(batch['padding_mask'])
 
         elif is_pipeline_last_stage:
             batch["tokens"] = None
@@ -2168,6 +2234,8 @@ def get_batch_on_this_tp_rank(
                     _broadcast_cu_seqlens(batch['cu_seqlens_padded'])
             if create_attention_mask_in_dataloader:
                 _broadcast(batch['attention_mask'])
+            if has_padding_mask:
+                _broadcast(batch['padding_mask'])
 
         elif has_cu_seqlens:
             # NOTE(asolergi-nv): Broadcast required THD metadata to intermediate stages.
@@ -2181,15 +2249,20 @@ def get_batch_on_this_tp_rank(
             _broadcast(batch['max_seqlen'])
             if cp_size > 1:
                 _broadcast_cu_seqlens(batch['cu_seqlens_padded'])
+            if has_padding_mask:
+                _broadcast(batch['padding_mask'])
+
+        if cp_size == 1 and (has_cu_seqlens or is_hybrid_cp):
+            _broadcast_cu_seqlens(batch.get('cu_seqlens_padded'))
 
     else:
-        if is_hybrid_cp:
-            hybrid_cp_seq_length = torch.tensor(
-                0, dtype=torch.int32, device=torch.cuda.current_device()
-            )
-            _broadcast(hybrid_cp_seq_length)
-            shape = (micro_batch_size, hybrid_cp_seq_length.item())
+        if dynamic_seq_length:
+            batch_shape = torch.zeros(2, dtype=torch.int32, device=torch.cuda.current_device())
+            _broadcast(batch_shape)
+            dynamic_micro_batch_size, sequence_length = (int(value) for value in batch_shape)
+            shape = (dynamic_micro_batch_size, sequence_length)
         else:
+            sequence_length = seq_length
             shape = (micro_batch_size, seq_length)
 
         tokens = torch.empty(shape, dtype=torch.int64, device=torch.cuda.current_device())
@@ -2200,16 +2273,19 @@ def get_batch_on_this_tp_rank(
         cu_seqlens_padded = None
         max_seqlen = None
         attention_mask = None
+        padding_mask = None
         local_cp_size = None
 
         if has_cu_seqlens or is_hybrid_cp:
             max_seqlen = torch.empty(1, dtype=torch.int32, device=torch.cuda.current_device())
         if create_attention_mask_in_dataloader:
             attention_mask = torch.empty(
-                (micro_batch_size, 1, seq_length, seq_length),
+                (shape[0], 1, sequence_length, sequence_length),
                 dtype=torch.bool,
                 device=torch.cuda.current_device(),
             )
+        if has_padding_mask:
+            padding_mask = torch.empty(shape, dtype=torch.bool, device=torch.cuda.current_device())
 
         if is_hybrid_cp:
             local_cp_size = torch.empty(1, dtype=torch.int32, device=torch.cuda.current_device())
@@ -2249,6 +2325,8 @@ def get_batch_on_this_tp_rank(
                     cu_seqlens_padded = _broadcast_cu_seqlens()
             if create_attention_mask_in_dataloader:
                 _broadcast(attention_mask)
+            if has_padding_mask:
+                _broadcast(padding_mask)
             if is_hybrid_cp:
                 _broadcast(local_cp_size)
 
@@ -2265,6 +2343,8 @@ def get_batch_on_this_tp_rank(
                     cu_seqlens_padded = _broadcast_cu_seqlens()
             if create_attention_mask_in_dataloader:
                 _broadcast(attention_mask)
+            if has_padding_mask:
+                _broadcast(padding_mask)
 
         elif is_pipeline_last_stage:
             tokens = None
@@ -2279,6 +2359,8 @@ def get_batch_on_this_tp_rank(
                     cu_seqlens_padded = _broadcast_cu_seqlens()
             if create_attention_mask_in_dataloader:
                 _broadcast(attention_mask)
+            if has_padding_mask:
+                _broadcast(padding_mask)
 
         elif has_cu_seqlens:
             # NOTE(asolergi-nv): Broadcast required THD metadata to intermediate stages.
@@ -2291,6 +2373,11 @@ def get_batch_on_this_tp_rank(
             _broadcast(max_seqlen)
             if cp_size > 1:
                 cu_seqlens_padded = _broadcast_cu_seqlens()
+            if has_padding_mask:
+                _broadcast(padding_mask)
+
+        if cp_size == 1 and (has_cu_seqlens or is_hybrid_cp):
+            cu_seqlens_padded = _broadcast_cu_seqlens()
 
         batch = {
             'tokens': tokens,
@@ -2298,6 +2385,7 @@ def get_batch_on_this_tp_rank(
             'loss_mask': loss_mask,
             'position_ids': position_ids,
             'attention_mask': attention_mask,
+            'padding_mask': padding_mask,
             'cu_seqlens': cu_seqlens,
             'cu_seqlens_padded': cu_seqlens_padded,
             'max_seqlen': max_seqlen,
@@ -2348,15 +2436,13 @@ def _get_batch_on_this_cp_rank_per_document_balancing(
             if batch["cu_seqlens_padded"] is not None
             else batch["cu_seqlens"]
         )[0]
-        index = tex.thd_get_partitioned_indices(
-            cu_seqlens_for_te,
-            (
-                batch["tokens"].size(1) if batch["tokens"] is not None else batch["labels"].size(1)
-            ),  # NOTE(asolergi-nv): Labels to enable PP!
-            cp_size,
-            cp_rank,
+        sequence_tensor = next(
+            batch[key] for key in ("tokens", "labels", "padding_mask") if batch.get(key) is not None
         )
-        SEQUENCE_KEYS = ('tokens', 'labels', 'loss_mask', 'position_ids')
+        index = tex.thd_get_partitioned_indices(
+            cu_seqlens_for_te, sequence_tensor.size(1), cp_size, cp_rank
+        )
+        SEQUENCE_KEYS = ('tokens', 'labels', 'loss_mask', 'position_ids', 'padding_mask')
         for key in SEQUENCE_KEYS:
             if batch.get(key) is not None:
                 batch[key] = batch[key].index_select(1, index)
@@ -2497,7 +2583,7 @@ def flatten_batch_for_packed_sequences(batch: Dict[str, Any]) -> Dict[str, Any]:
         return batch
 
     seq_length = None
-    for key in ('tokens', 'labels', 'loss_mask', 'position_ids'):
+    for key in ('tokens', 'labels', 'loss_mask', 'position_ids', 'padding_mask'):
         if batch.get(key) is not None:
             seq_length = batch[key].shape[1]
             break
@@ -2512,7 +2598,7 @@ def flatten_batch_for_packed_sequences(batch: Dict[str, Any]) -> Dict[str, Any]:
     if batch.get('max_seqlen') is not None:
         batch['max_seqlen'] = batch['max_seqlen'].max().unsqueeze(0)
 
-    for key in ('tokens', 'labels', 'loss_mask', 'position_ids'):
+    for key in ('tokens', 'labels', 'loss_mask', 'position_ids', 'padding_mask'):
         if batch.get(key) is not None:
             batch[key] = batch[key].reshape(1, -1)
 

--- a/tests/unit_tests/test_sequence_packing.py
+++ b/tests/unit_tests/test_sequence_packing.py
@@ -1,0 +1,363 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from megatron.core import parallel_state
+from megatron.core.datasets.data_schedule import (
+    DpBalancedScheduler,
+    _get_vpp_stages_needing_data,
+    wrap_data_iterator,
+)
+from megatron.core.datasets.data_schedule_utils import (
+    _deserialize_packed_metadata,
+    _get_group_local_ranks,
+    _serialize_packed_metadata,
+    _unpack_batch,
+)
+from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.rerun_state_machine import RerunDataIterator
+from megatron.core.transformer.enums import LayerType
+from megatron.core.utils import (
+    _build_thd_padding_mask,
+    _sanitize_thd_padding_values,
+    get_batch_on_this_tp_rank,
+)
+from megatron.training.global_vars import unset_global_variables
+from tests.unit_tests.test_utilities import Utils
+
+
+def test_scheduler_thd_padding_mask_from_cu_seqlens():
+    cu_seqlens = torch.tensor([0, 3, 5], dtype=torch.int32)
+    cu_seqlens_padded = torch.tensor([0, 4, 8], dtype=torch.int32)
+
+    padding_mask = _build_thd_padding_mask(cu_seqlens, cu_seqlens_padded)
+
+    assert torch.equal(
+        padding_mask, torch.tensor([False, False, False, True, False, False, True, True])
+    )
+
+
+def test_scheduler_sanitizes_thd_padding_values():
+    padding_mask = torch.tensor([[False, False, True, False, True]])
+    batch = {
+        "tokens": torch.tensor([[11, 12, -1, 21, -1]], dtype=torch.int64),
+        "labels": torch.tensor([[12, 13, -1, 22, -1]], dtype=torch.int64),
+        "loss_mask": torch.ones((1, 5), dtype=torch.float32),
+        "position_ids": torch.tensor([[0, 1, 2, 0, 1]], dtype=torch.int64),
+    }
+
+    _sanitize_thd_padding_values(batch, padding_mask)
+
+    assert torch.equal(batch["tokens"], torch.tensor([[11, 12, 0, 21, 0]]))
+    assert torch.equal(batch["labels"], torch.tensor([[12, 13, 0, 22, 0]]))
+    assert torch.equal(batch["loss_mask"], torch.tensor([[1.0, 1.0, 0.0, 1.0, 0.0]]))
+    assert torch.equal(batch["position_ids"], torch.tensor([[0, 1, 0, 0, 0]]))
+
+
+def test_canonical_tp_batch_broadcasts_dynamic_shape_padding_and_metadata(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: torch.device("cpu"))
+    payloads = []
+
+    def _record_broadcast(tensor, *_args, **_kwargs):
+        payloads.append(tensor.clone())
+
+    monkeypatch.setattr(torch.distributed, "broadcast", _record_broadcast)
+    source_batch = {
+        "tokens": torch.tensor([[11, 12, -1, 21, -1, -1]], dtype=torch.int64),
+        "labels": torch.tensor([[12, 13, -1, 22, -1, -1]], dtype=torch.int64),
+        "loss_mask": torch.ones((1, 6), dtype=torch.float32),
+        "position_ids": torch.tensor([[0, 1, 2, 0, 1, 2]], dtype=torch.int64),
+        "attention_mask": None,
+        "cu_seqlens": torch.tensor([[0, 2, 3]], dtype=torch.int32),
+        "cu_seqlens_padded": torch.tensor([[0, 3, 6]], dtype=torch.int32),
+        "max_seqlen": torch.tensor([3], dtype=torch.int32),
+    }
+    common_kwargs = {
+        "has_cu_seqlens": True,
+        "is_hybrid_cp": False,
+        "create_attention_mask_in_dataloader": False,
+        "broadcast_src_rank": 0,
+        "broadcast_group": object(),
+        "cp_size": 1,
+        "micro_batch_size": 4,
+        "seq_length": 128,
+        "mtp_on_this_rank": False,
+        "pipeline_model_parallel_size": 1,
+        "variable_seq_lengths": True,
+        "has_padding_mask": True,
+    }
+
+    source = get_batch_on_this_tp_rank(source_batch, tp_rank=0, **common_kwargs)
+
+    recorded_payloads = iter(payloads)
+
+    def _replay_broadcast(tensor, *_args, **_kwargs):
+        tensor.copy_(next(recorded_payloads))
+
+    monkeypatch.setattr(torch.distributed, "broadcast", _replay_broadcast)
+    received = get_batch_on_this_tp_rank({}, tp_rank=1, **common_kwargs)
+
+    assert received["tokens"].shape == (1, 6)
+    assert torch.equal(received["tokens"], source["tokens"])
+    assert torch.equal(received["padding_mask"], source["padding_mask"])
+    assert torch.equal(received["cu_seqlens"], source["cu_seqlens"])
+    assert torch.equal(received["cu_seqlens_padded"], source["cu_seqlens_padded"])
+    assert source["padding_mask"].tolist() == [[False, False, True, False, True, True]]
+
+
+def test_dp_balanced_scheduler_can_split_group_zero_for_vpp_alignment():
+    scheduler = DpBalancedScheduler(
+        max_seqlen_per_dp_cp_rank=2, cp_size=1, dp_size=1, microbatch_group_size_per_vp_stage=2
+    )
+
+    groups = scheduler.get_groups_and_subsamples([(7, 1), (11, 1)])
+
+    assert groups == [[[7]], [[11]]]
+
+
+def test_dp_balanced_scheduler_rejects_impossible_alignment():
+    scheduler = DpBalancedScheduler(
+        max_seqlen_per_dp_cp_rank=2, cp_size=1, dp_size=1, microbatch_group_size_per_vp_stage=2
+    )
+
+    with pytest.raises(ValueError, match="Not enough samples"):
+        scheduler.get_groups_and_subsamples([(7, 1)])
+
+
+def test_dp_balanced_scheduler_rejects_oversized_sample():
+    scheduler = DpBalancedScheduler(
+        max_seqlen_per_dp_cp_rank=4, cp_size=2, dp_size=1, microbatch_group_size_per_vp_stage=None
+    )
+
+    with pytest.raises(ValueError, match="exceeding"):
+        scheduler.get_groups_and_subsamples([(3, 9)])
+
+
+def test_packed_metadata_round_trip_is_length_prefixed_and_integer_safe():
+    large_offset = 2**24 + 17
+    samples = [
+        {
+            "max_seqlen": torch.tensor(0, dtype=torch.int32),
+            "cu_seqlens": torch.tensor([0], dtype=torch.int32),
+            "cu_seqlens_padded": torch.tensor([0], dtype=torch.int32),
+        },
+        {
+            "max_seqlen": torch.tensor(large_offset, dtype=torch.int32),
+            "cu_seqlens": torch.tensor([0, large_offset], dtype=torch.int32),
+            "cu_seqlens_padded": torch.tensor([0, large_offset], dtype=torch.int32),
+        },
+    ]
+
+    payload = _serialize_packed_metadata(samples, torch.device("cpu"))
+    restored = _deserialize_packed_metadata(payload)
+
+    assert payload.dtype == torch.int64
+    assert len(restored) == len(samples)
+    for actual, expected in zip(restored, samples):
+        assert torch.equal(actual["max_seqlen"], expected["max_seqlen"])
+        assert torch.equal(actual["cu_seqlens"], expected["cu_seqlens"])
+        assert torch.equal(actual["cu_seqlens_padded"], expected["cu_seqlens_padded"])
+
+
+def test_packed_metadata_decoder_rejects_trailing_values():
+    payload = _serialize_packed_metadata([], torch.device("cpu"))
+    malformed = torch.cat((payload, torch.tensor([0], dtype=torch.int64)))
+
+    with pytest.raises(AssertionError, match="decoder consumed"):
+        _deserialize_packed_metadata(malformed)
+
+
+def test_unpack_batch_accepts_variable_length_samples_with_collate_dim():
+    batch = [
+        {
+            "tokens": torch.tensor([[1, 2, 0]]),
+            "labels": torch.tensor([[2, 3, 0]]),
+            "loss_mask": torch.tensor([[1.0, 1.0, 0.0]]),
+            "position_ids": torch.tensor([[0, 1, 2]]),
+            "padded_seq_len": torch.tensor([[3]], dtype=torch.int32),
+            "original_seq_len": torch.tensor([[2]], dtype=torch.int32),
+        }
+    ]
+
+    unpacked = _unpack_batch(batch)
+
+    assert unpacked[0]["tokens"].shape == (3,)
+    assert unpacked[0]["padded_seq_len"].shape == (1,)
+    assert unpacked[0]["original_seq_len"].item() == 2
+
+
+def test_unpack_batch_preserves_real_and_physical_packed_lengths():
+    batch = [
+        {
+            "tokens": torch.tensor([[1, 2, 0, 3, 0, 0]]),
+            "labels": torch.tensor([[2, 0, 0, 0, 0, 0]]),
+            "loss_mask": torch.tensor([[1.0, 1.0, 0.0, 1.0, 0.0, 0.0]]),
+            "position_ids": torch.tensor([[0, 1, 2, 0, 1, 2]]),
+            "cu_seqlens": torch.tensor([[0, 3, 6, 6]], dtype=torch.int32),
+            "cu_seqlens_original": torch.tensor([[0, 2, 3, 3]], dtype=torch.int32),
+        }
+    ]
+
+    unpacked = _unpack_batch(batch)
+
+    assert [sample["original_seq_len"].item() for sample in unpacked] == [2, 1]
+    assert [sample["padded_seq_len"].item() for sample in unpacked] == [3, 3]
+    assert [sample["tokens"].numel() for sample in unpacked] == [3, 3]
+
+
+def test_group_local_rank_mapping_does_not_assume_global_rank_order(monkeypatch):
+    subgroup = object()
+    parent_group = object()
+    ranks = {subgroup: [0, 4], parent_group: [0, 2, 4, 6]}
+    monkeypatch.setattr(torch.distributed, "get_process_group_ranks", ranks.__getitem__)
+
+    assert _get_group_local_ranks(subgroup, parent_group) == [0, 2]
+
+
+def test_vpp_data_ownership_includes_custom_layout_mtp_stage():
+    config = SimpleNamespace(
+        virtual_pipeline_model_parallel_size=2,
+        pipeline_model_parallel_layout=SimpleNamespace(
+            layout=[
+                [[LayerType.embedding], [LayerType.decoder]],
+                [[LayerType.decoder], [LayerType.mtp]],
+                [[LayerType.decoder], [LayerType.loss]],
+            ]
+        ),
+        mtp_num_layers=1,
+    )
+
+    assert _get_vpp_stages_needing_data(config, pp_rank=0, pp_size=3) == [True, False]
+    assert _get_vpp_stages_needing_data(config, pp_rank=1, pp_size=3) == [False, True]
+    assert _get_vpp_stages_needing_data(config, pp_rank=2, pp_size=3) == [False, True]
+
+
+def _process_groups() -> ProcessGroupCollection:
+    return ProcessGroupCollection(
+        tp=parallel_state.get_tensor_model_parallel_group(),
+        pp=parallel_state.get_pipeline_model_parallel_group(),
+        dp=parallel_state.get_data_parallel_group(
+            with_context_parallel=False, partial_data_parallel=False
+        ),
+        dp_cp=parallel_state.get_data_parallel_group(
+            with_context_parallel=True, partial_data_parallel=False
+        ),
+    )
+
+
+def _sample(sequence_length: int) -> dict[str, torch.Tensor]:
+    device = torch.device("cuda", torch.cuda.current_device())
+    tokens = torch.arange(sequence_length, dtype=torch.int64, device=device)
+    return {
+        "tokens": tokens,
+        "labels": tokens + 1,
+        "loss_mask": torch.ones(sequence_length, dtype=torch.float32, device=device),
+        "position_ids": torch.arange(sequence_length, dtype=torch.int64, device=device),
+        "original_seq_len": torch.tensor([sequence_length], dtype=torch.int32, device=device),
+        "padded_seq_len": torch.tensor([sequence_length], dtype=torch.int32, device=device),
+    }
+
+
+@pytest.mark.parametrize(
+    ("tp", "pp", "cp", "vpp", "middle_has_legacy_iterator", "mtp_pp_rank", "mtp_vp_stage"),
+    [
+        (1, 1, 8, None, False, None, None),
+        (2, 1, 4, None, False, None, None),
+        (2, 4, 1, None, True, None, None),
+        (2, 2, 1, None, False, None, None),
+        (1, 4, 1, 4, True, 1, 2),
+    ],
+)
+def test_wrap_data_iterator(tp, pp, cp, vpp, middle_has_legacy_iterator, mtp_pp_rank, mtp_vp_stage):
+    Utils.initialize_model_parallel(tp, pp, vpp, context_parallel_size=cp)
+    try:
+        pg_collection = _process_groups()
+        dp_size = pg_collection.dp.size()
+        global_sequence_lengths = [128 + 64 * (index % 4) for index in range(16)]
+        input_microbatches = len(global_sequence_lengths) // dp_size
+        dp_rank = pg_collection.dp.rank()
+        local_lengths = global_sequence_lengths[
+            dp_rank * input_microbatches : (dp_rank + 1) * input_microbatches
+        ]
+        samples = [_sample(sequence_length) for sequence_length in local_lengths]
+
+        pp_rank = pg_collection.pp.rank()
+        tp_rank = pg_collection.tp.rank()
+        is_endpoint = pp_rank in (0, pp - 1)
+        if tp_rank == 0 and (is_endpoint or middle_has_legacy_iterator):
+            data_iterator = RerunDataIterator(iter(samples))
+        else:
+            data_iterator = None
+
+        if vpp is not None and tp_rank == 0:
+            # Packed datasets are currently built on every TP-zero virtual stage.
+            data_iterator = [RerunDataIterator(iter(samples)) for _ in range(vpp)]
+
+        pipeline_layout = None
+        if mtp_pp_rank is not None:
+            layout = [[[LayerType.decoder] for _ in range(vpp)] for _ in range(pp)]
+            layout[mtp_pp_rank][mtp_vp_stage] = [LayerType.mtp]
+            pipeline_layout = SimpleNamespace(layout=layout)
+
+        config = SimpleNamespace(
+            max_seqlen_per_dp_cp_rank=512,
+            microbatch_group_size_per_vp_stage=2,
+            virtual_pipeline_model_parallel_size=vpp,
+            sequence_packing_scheduler="dp_balanced",
+            pipeline_model_parallel_layout=pipeline_layout,
+            mtp_num_layers=1 if mtp_pp_rank is not None else None,
+        )
+        (packed_iterator, output_microbatches, total_tokens, sequence_square_sum) = (
+            wrap_data_iterator(
+                data_iterator, config, input_microbatches, pg_collection=pg_collection
+            )
+        )
+
+        assert isinstance(output_microbatches, int)
+        assert total_tokens == float(sum(global_sequence_lengths))
+        assert sequence_square_sum == float(sum(length**2 for length in global_sequence_lengths))
+
+        if tp_rank != 0:
+            if vpp is None:
+                assert packed_iterator is None
+            else:
+                assert packed_iterator == [None] * vpp
+            return
+
+        expected_metadata = {"cu_seqlens", "cu_seqlens_padded", "max_seqlen"}
+
+        def _consume(iterator):
+            batches = [next(iterator) for _ in range(output_microbatches)]
+            for batch in batches:
+                assert expected_metadata <= batch.keys()
+                assert batch["cu_seqlens"].ndim == 2
+                assert batch["cu_seqlens_padded"].ndim == 2
+            return batches
+
+        if vpp is None:
+            batches = _consume(packed_iterator)
+            if is_endpoint:
+                assert {"tokens", "labels", "loss_mask", "position_ids"} <= batches[0].keys()
+            else:
+                assert set(batches[0]) == expected_metadata
+        else:
+            assert len(packed_iterator) == vpp
+            stage_batches = [_consume(iterator) for iterator in packed_iterator]
+            full_stages = set()
+            if pp_rank == 0:
+                full_stages.add(0)
+            if pp_rank == pp - 1:
+                full_stages.add(vpp - 1)
+            if pp_rank == mtp_pp_rank:
+                full_stages.add(mtp_vp_stage)
+            for stage, batches in enumerate(stage_batches):
+                if stage in full_stages:
+                    assert {"tokens", "labels", "loss_mask", "position_ids"} <= batches[0].keys()
+                else:
+                    assert set(batches[0]) == expected_metadata
+    finally:
+        Utils.destroy_model_parallel()
+        unset_global_variables()


### PR DESCRIPTION
Part 2 of the split of #3386. Original changes by @xiaoyao0115 (tailaim); this version is ported to current `main` and incorporates the review feedback.

## What changed

- Add a DP-balanced packing scheduler with explicit `ProcessGroupCollection` inputs.
- Reuse and extend the canonical TP/CP batch utilities instead of maintaining a second scheduler-specific batch path.
- Preserve distinct real and physical sequence boundaries, generate/sanitize THD padding masks, and broadcast variable batch shapes and length-prefixed integer metadata without float casts.
- Handle PP/VPP/MTP data ownership, including middle MTP stages and the group-zero VPP alignment case.
- Route ranks by process-group membership rather than global-rank arithmetic, including alternate rank mappings.
- Add focused pure and distributed regressions for metadata, grouping, MTP/VPP, TP broadcast, and DP×CP routing.

## Review issues addressed

This removes the duplicate `get_batch` utility, avoids new global process-group reads, fixes the middle-PP iterator assertion, fixes group-zero alignment, and eliminates sentinel/float32 metadata encoding.

## Validation

- Black, isort, Ruff, Pylint, `py_compile`, and `git diff --check`: passed.
- Focused pytest command: `pytest -q tests/unit_tests/test_sequence_packing.py`.
- Local pytest collection is blocked because this host environment does not provide PyTorch (`ModuleNotFoundError: torch`); distributed GPU coverage is delegated to CI.

## Split series

- #5563 — padding-mask SP fix
- #5560 — core scheduler and batch utilities
- #5562 — packing scheduler config
- #5561 — typed SFT/varlen producers
- Training integration follows after these land, keeping its CODEOWNERS scope isolated.