### PR TITLE
[Training] Add typed SFT and variable-length dataset producers

### DIFF
--- a/megatron/training/datasets/sft_dataset.py
+++ b/megatron/training/datasets/sft_dataset.py
@@ -1,17 +1,139 @@
 # Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
 
-import atexit, json
-from collections import Counter
-from typing import Any, Dict, Optional
+"""Supervised fine-tuning datasets and typed mock-data producers."""
+
+from dataclasses import dataclass
+from typing import Any, Dict, Literal, Optional
 
 import numpy as np
 import torch
 
 from megatron.core.datasets.gpt_dataset import GPTDatasetConfig
+from megatron.core.datasets.indexed_dataset import IndexedDataset
 from megatron.core.datasets.megatron_dataset import LowLevelDataset, MegatronDataset
 from megatron.core.datasets.utils import Split
 
 IGNORE_INDEX = -100
+
+
+@dataclass
+class SFTDatasetConfig(GPTDatasetConfig):
+    """Training-local configuration for SFT datasets and their mock producers.
+
+    Mock configuration is represented by flat, typed fields. ``mock_data_path``
+    points to a headerless sequence-length file in ``file`` mode and to an
+    ``IndexedDataset`` prefix in ``verification`` mode.
+    """
+
+    mock_data_mode: Literal["distribution", "file", "verification"] = "distribution"
+    """Source used by :class:`MockSFTLowLevelDataset`."""
+
+    mock_data_path: str | None = None
+    """Mode-specific local path; unused in ``distribution`` mode."""
+
+    mock_data_distribution: Literal["lognormal"] = "lognormal"
+    """Synthetic sequence-length distribution."""
+
+    mock_data_min_sequence_length: int | None = None
+    """Minimum generated sequence length, including the final EOD token."""
+
+    mock_data_max_sequence_length: int | None = None
+    """Maximum generated sequence length, including the final EOD token."""
+
+    mock_data_mean_sequence_length: float | None = None
+    """Mean of the unclipped synthetic sequence-length distribution."""
+
+    mock_data_lognormal_sigma: float = 1.1
+    """Sigma of the synthetic lognormal sequence-length distribution."""
+
+    mock_data_seed: int = 0
+    """Seed used by the mock dataset's private NumPy generator."""
+
+    mock_data_size: int = 1_000_000
+    """Number of generated samples in ``distribution`` and ``verification`` modes."""
+
+    emit_packing_metadata: bool = False
+    """Emit real-token boundaries required by the dynamic packing scheduler."""
+
+    def __post_init__(self) -> None:
+        """Set sequence-length defaults and validate the flat mock fields."""
+        super().__post_init__()
+
+        if self.sequence_length < 2:
+            raise ValueError("SFTDatasetConfig.sequence_length must be at least 2")
+
+        if self.mock_data_min_sequence_length is None:
+            self.mock_data_min_sequence_length = max(2, self.sequence_length // 2)
+        if self.mock_data_max_sequence_length is None:
+            self.mock_data_max_sequence_length = max(2, self.sequence_length)
+        if self.mock_data_mean_sequence_length is None:
+            self.mock_data_mean_sequence_length = max(2, self.sequence_length * 3 / 4)
+
+        if self.mock_data_mode not in {"distribution", "file", "verification"}:
+            raise ValueError(
+                "mock_data_mode must be one of 'distribution', 'file', or 'verification'"
+            )
+        if self.mock_data_mode in {"file", "verification"} and not self.mock_data_path:
+            raise ValueError(f"mock_data_path is required in {self.mock_data_mode!r} mode")
+        if self.mock_data_distribution != "lognormal":
+            raise ValueError("mock_data_distribution currently supports only 'lognormal'")
+        if self.mock_data_min_sequence_length < 2:
+            raise ValueError("mock_data_min_sequence_length must be at least 2")
+        if self.mock_data_max_sequence_length < self.mock_data_min_sequence_length:
+            raise ValueError(
+                "mock_data_max_sequence_length must be greater than or equal to "
+                "mock_data_min_sequence_length"
+            )
+        if self.mock_data_mean_sequence_length <= 0:
+            raise ValueError("mock_data_mean_sequence_length must be positive")
+        if self.mock_data_lognormal_sigma < 0:
+            raise ValueError("mock_data_lognormal_sigma must be non-negative")
+        if self.mock_data_size <= 0:
+            raise ValueError("mock_data_size must be positive")
+
+
+def _calculate_padding_divisor(config: GPTDatasetConfig) -> int:
+    """Return the token alignment required by CP and sequence parallelism."""
+    context_parallel_size = config.context_parallel_size or 1
+    sequence_parallel_size = config.sequence_parallel_size or 1
+    if config.hybrid_context_parallel:
+        context_parallel_padding = config.data_parallel_size * context_parallel_size * 2
+    else:
+        context_parallel_padding = context_parallel_size * 2 if context_parallel_size > 1 else 1
+    return context_parallel_padding * sequence_parallel_size
+
+
+def _get_padding_token_id(tokenizer, eod: int) -> int:
+    """Return a valid padding id, falling back to EOD when no pad token exists."""
+
+    pad = None
+    for attribute in ("pad", "pad_id"):
+        try:
+            pad = getattr(tokenizer, attribute)
+        except (AttributeError, NotImplementedError):
+            continue
+        if pad is not None:
+            break
+
+    vocab_size = getattr(tokenizer, "vocab_size", None)
+    if not isinstance(pad, int) or pad < 0 or (vocab_size is not None and pad >= vocab_size):
+        return eod
+    return pad
+
+
+def _normalize_mock_token_ids(token_ids: np.ndarray, tokenizer, verification: bool) -> list[int]:
+    """Keep synthetic mock ids inside the tokenizer vocabulary."""
+
+    vocab_size = int(tokenizer.vocab_size)
+    if vocab_size <= 0:
+        raise ValueError("Mock datasets require a positive tokenizer vocabulary size")
+    token_ids = np.asarray(token_ids, dtype=np.int64).reshape(-1)
+    invalid = (token_ids < 0) | (token_ids >= vocab_size)
+    if np.any(invalid):
+        if verification:
+            raise ValueError("Verification tokens must be inside the tokenizer vocabulary")
+        token_ids = np.mod(token_ids, vocab_size)
+    return token_ids.tolist()
 
 
 class SFTLowLevelDataset:
@@ -35,10 +157,10 @@ class SFTLowLevelDataset:
     def __init__(self, dataset_path: str) -> None:
         try:
             from datasets import load_dataset
-        except ImportError:
+        except ImportError as exc:
             raise ImportError(
                 "SFTDataset currently requires datasets library to be installed"
-            )
+            ) from exc
         self.dataset = load_dataset("json", data_files=dataset_path, split="all")
 
     def __len__(self) -> int:
@@ -61,17 +183,20 @@ class SFTDataset(MegatronDataset):
         config: GPTDatasetConfig,
     ) -> None:
         super().__init__(dataset, dataset_path, indices, num_samples, index_split, config)
+        self.padding_divisor = _calculate_padding_divisor(config)
 
     @staticmethod
     def numel_low_level_dataset(low_level_dataset: LowLevelDataset) -> int:
+        """Return the number of records in the low-level SFT dataset."""
         return len(low_level_dataset)
 
     @staticmethod
     def build_low_level_dataset(dataset_path: str, config: GPTDatasetConfig) -> LowLevelDataset:
+        """Build the JSON-backed low-level SFT dataset."""
         return SFTLowLevelDataset(dataset_path)
 
     def __len__(self) -> int:
-        return self.num_samples
+        return self.num_samples if self.num_samples is not None else len(self.indices)
 
     def _split_conversations(self, merged_conversations):
         split_conversations = []
@@ -83,7 +208,7 @@ class SFTDataset(MegatronDataset):
                     split_conversations.append(current)
                 current = [msg]  # Then start the new conversation
             else:
-                current.append(msg) # Continue accumulating the current conversation
+                current.append(msg)  # Continue accumulating the current conversation
         if current:  # Store any remaining conversation
             split_conversations.append(current)
         return split_conversations
@@ -96,45 +221,57 @@ class SFTDataset(MegatronDataset):
         merged_conversations = self.dataset[int(self.indices[idx % len(self.indices)])]
         split_conversations = self._split_conversations(merged_conversations)
 
-        def extend_with_padding(tokens, targets, positions, pad_len):
+        def extend_with_padding(tokens, targets, positions, padding_flags, pad_len):
             tokens.extend([pad] * pad_len)
             targets.extend([pad] * pad_len)
-            positions.extend(range(positions[-1]+1, positions[-1]+1+pad_len))
+            position_start = positions[-1] + 1 if positions else 0
+            positions.extend(range(position_start, position_start + pad_len))
+            padding_flags.extend([True] * pad_len)
 
         pack_tokens = []
         pack_targets = []
         pack_positions = []
+        pack_padding_flags = []
         cu_seqlens = [0]
+        cu_seqlens_original = [0]
         eod = tokenizer.eod
-        pad = tokenizer.pad
+        if eod is None:
+            raise ValueError("SFTDataset requires an EOD/EOS token id")
+        pad = _get_padding_token_id(tokenizer, eod)
         # TODO(duncan): Track number of convs dropped and/or truncated and amount of end-padding
         for conversation in split_conversations:
-
+            physical_sequence_start = cu_seqlens[-1]
             tokens, targets = tokenizer.tokenize_conversation(
                 conversation, return_target=True, add_generation_prompt=False
             )
 
             tokens_list = tokens.tolist()
             targets_list = targets.tolist()
-
+            if self.config.emit_packing_metadata and len(tokens_list) < 2:
+                # THD real boundaries describe next-token prediction steps, so a
+                # one-token conversation has no representable real sequence.
+                continue
 
             pack_tokens.extend(tokens_list)
             pack_targets.extend(targets_list)
+            pack_padding_flags.extend([False] * len(tokens_list))
 
             assert not self.config.reset_position_ids
             pack_positions.extend(range(len(tokens_list)))
 
-            if self.config.context_parallel_size > 1:
-                pad_granularity = self.config.context_parallel_size * 2
-                mod_token_count = len(pack_tokens) % pad_granularity
-                if mod_token_count != 0:
-                    pad_len = pad_granularity - mod_token_count
-                    extend_with_padding(pack_tokens, pack_targets, pack_positions, pad_len)
+            mod_token_count = len(pack_tokens) % self.padding_divisor
+            if mod_token_count != 0:
+                pad_len = self.padding_divisor - mod_token_count
+                extend_with_padding(
+                    pack_tokens, pack_targets, pack_positions, pack_padding_flags, pad_len
+                )
 
             # TODO(duncan): Consider also padding to multiple of number of tokens here. This might
             # be needed for efficiency (and potentially set via command-line argument).
 
             cu_seqlens.append(len(pack_tokens))
+            real_sequence_length = max(0, len(tokens_list) - 1)
+            cu_seqlens_original.append(cu_seqlens_original[-1] + real_sequence_length)
 
             # Handle any necessary truncation
             if len(pack_tokens) >= pack_length + 1:  # +1 here to account for later alignment
@@ -142,32 +279,53 @@ class SFTDataset(MegatronDataset):
                 max_body = pack_length
                 pack_tokens = pack_tokens[:max_body]
                 pack_targets = pack_targets[:max_body]
+                pack_padding_flags = pack_padding_flags[:max_body]
                 pack_tokens.append(pad)
                 pack_targets.append(pad)
-                pack_positions = pack_positions[:pack_length+1]
+                pack_padding_flags.append(True)
+                pack_positions = pack_positions[: pack_length + 1]
                 # Note len({pack_tokens, pack_targets, pack_positions}) should be pack_length + 1
                 cu_seqlens[-1] = len(pack_tokens) - 1
+                retained_real_tokens = max(
+                    0, min(real_sequence_length, pack_length - physical_sequence_start - 1)
+                )
+                if retained_real_tokens == 0 and self.config.emit_packing_metadata:
+                    # A one-slot tail cannot contain an input/target pair. Fold it into
+                    # the previous sequence's physical padding instead of emitting a
+                    # zero-length real sequence, which THD attention cannot represent.
+                    cu_seqlens[-2] = cu_seqlens[-1]
+                    cu_seqlens.pop()
+                    cu_seqlens_original.pop()
+                else:
+                    cu_seqlens_original[-1] = cu_seqlens_original[-2] + retained_real_tokens
                 break
+
+        if self.config.emit_packing_metadata and len(cu_seqlens) == 1:
+            raise ValueError(
+                "Packing metadata requires at least one conversation with two or more tokens"
+            )
 
         # Handle any necessary padding
         if len(pack_tokens) < pack_length + 1:  # +1 here to account for later alignment
             pad_len = pack_length + 1 - len(pack_tokens)
-            extend_with_padding(pack_tokens, pack_targets, pack_positions, pad_len)
+            extend_with_padding(
+                pack_tokens, pack_targets, pack_positions, pack_padding_flags, pad_len
+            )
             # Note len({pack_tokens, pack_targets, pack_positions}) should be pack_length + 1
             cu_seqlens[-1] = len(pack_tokens) - 1
 
         assert len(pack_tokens) == pack_length + 1
         assert len(pack_targets) == pack_length + 1
         assert len(pack_positions) == pack_length + 1
+        assert len(pack_padding_flags) == pack_length + 1
 
         # Align and convert to tensors
-        input_ids    = torch.tensor(pack_tokens[:-1],  dtype=torch.int64)
-        labels       = torch.tensor(pack_targets[1:], dtype=torch.int64)
+        input_ids = torch.tensor(pack_tokens[:-1], dtype=torch.int64)
+        labels = torch.tensor(pack_targets[1:], dtype=torch.int64)
         position_ids = torch.tensor(pack_positions[:-1], dtype=torch.int64)
 
         # Loss mask.
-        loss_mask = torch.ones(pack_length, dtype=torch.float32)
-        loss_mask[labels == pad] = 0.0  # Mask paddings
+        loss_mask = (~torch.tensor(pack_padding_flags[1:], dtype=torch.bool)).to(torch.float32)
         loss_mask[labels == IGNORE_INDEX] = 0.0  # mask prompts
 
         # TODO(duncan): Optionally create an attention mask
@@ -176,6 +334,7 @@ class SFTDataset(MegatronDataset):
 
         assert len(cu_seqlens) >= 2
         cu_seqlens = torch.tensor(cu_seqlens, dtype=torch.int32)
+        cu_seqlens_original = torch.tensor(cu_seqlens_original, dtype=torch.int32)
         # Calculating max_seqlen here, rather than incrementally above, because of possible
         # effects of truncation and padding
         adjacent_diffs = cu_seqlens[1:] - cu_seqlens[:-1]
@@ -185,12 +344,14 @@ class SFTDataset(MegatronDataset):
         # stack samples with different numbers of documents.  Trailing
         # entries are filled with pack_length; the merge helper strips
         # them later.
-        padded_cu_seqlens = torch.full(
-            (pack_length + 1,), pack_length, dtype=torch.int32,
+        padded_cu_seqlens = torch.full((pack_length + 1,), pack_length, dtype=torch.int32)
+        padded_cu_seqlens[: cu_seqlens.numel()] = cu_seqlens
+        padded_cu_seqlens_original = torch.full(
+            (pack_length + 1,), int(cu_seqlens_original[-1]), dtype=torch.int32
         )
-        padded_cu_seqlens[:cu_seqlens.numel()] = cu_seqlens
+        padded_cu_seqlens_original[: cu_seqlens_original.numel()] = cu_seqlens_original
 
-        return {
+        sample = {
             'tokens': input_ids,
             'labels': labels,
             # 'attention_mask': attention_mask,  # PyTorch collate cannot handle NoneType
@@ -199,3 +360,213 @@ class SFTDataset(MegatronDataset):
             'cu_seqlens': padded_cu_seqlens,
             'max_seqlen': max_seqlen,
         }
+        if getattr(self.config, "emit_packing_metadata", False):
+            sample['cu_seqlens_original'] = padded_cu_seqlens_original
+        return sample
+
+
+class MockSFTLowLevelDataset:
+    """Generate mock token arrays from typed sequence-length settings.
+
+    Args:
+        mode: ``distribution``, ``file``, or ``verification``.
+        path: Headerless sequence-length file for ``file`` mode, or an
+            ``IndexedDataset`` prefix for ``verification`` mode.
+        distribution: Synthetic distribution name. Only ``lognormal`` is
+            currently supported.
+        min_sequence_length: Minimum generated length, including EOD.
+        max_sequence_length: Maximum generated length, including EOD.
+        mean_sequence_length: Mean of the unclipped distribution.
+        lognormal_sigma: Sigma of the lognormal distribution.
+        seed: Seed for a private NumPy random generator.
+        size: Number of generated samples.
+    """
+
+    def __init__(
+        self,
+        mode: Literal["distribution", "file", "verification"],
+        path: str | None,
+        distribution: Literal["lognormal"],
+        min_sequence_length: int,
+        max_sequence_length: int,
+        mean_sequence_length: float,
+        lognormal_sigma: float,
+        seed: int,
+        size: int,
+    ) -> None:
+        self.indexed_dataset: IndexedDataset | None = None
+
+        if mode == "file":
+            if path is None:
+                raise ValueError("path is required in file mode")
+            self.sequence_lengths = self._load_sequence_lengths(path)
+            self.size = int(self.sequence_lengths.size)
+        elif mode in {"distribution", "verification"}:
+            if distribution != "lognormal":
+                raise ValueError(f"Unsupported distribution {distribution!r}")
+            self.sequence_lengths = self._generate_lognormal_samples(
+                size,
+                mean_sequence_length,
+                lognormal_sigma,
+                min_sequence_length,
+                max_sequence_length,
+                seed,
+            )
+            self.size = size
+            if mode == "verification":
+                if path is None:
+                    raise ValueError("path is required in verification mode")
+                self.indexed_dataset = IndexedDataset(path)
+                if len(self.indexed_dataset) == 0:
+                    raise ValueError("verification IndexedDataset must not be empty")
+        else:
+            raise ValueError(
+                f"Unsupported mode {mode!r}; expected 'distribution', 'file', or 'verification'"
+            )
+
+    @staticmethod
+    def _load_sequence_lengths(path: str) -> np.ndarray:
+        """Read all values from a headerless comma-separated numeric file."""
+        try:
+            sequence_lengths = np.loadtxt(path, dtype=np.int64, delimiter=",", ndmin=1)
+        except (OSError, ValueError) as exc:
+            raise ValueError(
+                f"Unable to read headerless integer sequence lengths from {path!r}"
+            ) from exc
+        sequence_lengths = np.asarray(sequence_lengths, dtype=np.int64).reshape(-1)
+        if sequence_lengths.size == 0:
+            raise ValueError("Sequence-length file must contain at least one value")
+        if np.any(sequence_lengths < 2):
+            raise ValueError("Every mock sequence length must be at least 2")
+        return sequence_lengths
+
+    @staticmethod
+    def _generate_lognormal_samples(
+        size: int,
+        mean: float,
+        sigma: float,
+        min_sequence_length: int,
+        max_sequence_length: int,
+        seed: int,
+    ) -> np.ndarray:
+        """Generate deterministic clipped lognormal sequence lengths."""
+        mu = np.log(mean) - sigma**2 / 2
+        rng = np.random.default_rng(seed)
+        samples = rng.lognormal(mu, sigma, size)
+        return np.clip(samples, min_sequence_length, max_sequence_length).astype(np.int64)
+
+    def __len__(self) -> int:
+        return self.size
+
+    def _get_verification_tokens(self, idx: int, target_length: int) -> np.ndarray:
+        """Concatenate indexed documents until ``target_length`` tokens are available."""
+        assert self.indexed_dataset is not None
+        if target_length == 0:
+            return np.empty(0, dtype=np.int64)
+
+        chunks = []
+        total_length = 0
+        document_index = idx % len(self.indexed_dataset)
+        empty_documents_seen = 0
+        while total_length < target_length:
+            document = np.asarray(
+                self.indexed_dataset[document_index % len(self.indexed_dataset)], dtype=np.int64
+            )
+            document_index += 1
+            if document.size == 0:
+                empty_documents_seen += 1
+                if empty_documents_seen >= len(self.indexed_dataset):
+                    raise ValueError("verification IndexedDataset contains no tokens")
+                continue
+            empty_documents_seen = 0
+            remaining = target_length - total_length
+            chunk = document[:remaining]
+            chunks.append(chunk)
+            total_length += int(chunk.size)
+        return np.concatenate(chunks).astype(np.int64, copy=False)
+
+    def __getitem__(self, idx: int) -> np.ndarray:
+        length = int(self.sequence_lengths[idx % self.size])
+        target_length = length - 1  # The mid-level dataset appends EOD.
+        if self.indexed_dataset is not None:
+            return self._get_verification_tokens(idx, target_length)
+        return np.arange(1, length, dtype=np.int64)
+
+
+class MockSFTDataset(SFTDataset):
+    """Fixed-width mock SFT dataset for correctness and throughput tests."""
+
+    def __init__(
+        self,
+        dataset: LowLevelDataset,
+        dataset_path: str | None,
+        indices: np.ndarray,
+        num_samples: int | None,
+        index_split: Split,
+        config: SFTDatasetConfig,
+    ) -> None:
+        super().__init__(dataset, dataset_path, indices, num_samples, index_split, config)
+
+    @staticmethod
+    def build_low_level_dataset(
+        dataset_path: str, config: SFTDatasetConfig
+    ) -> MockSFTLowLevelDataset:
+        """Build a mock source directly from the config's flat typed fields."""
+        del dataset_path
+        assert config.mock_data_min_sequence_length is not None
+        assert config.mock_data_max_sequence_length is not None
+        assert config.mock_data_mean_sequence_length is not None
+        return MockSFTLowLevelDataset(
+            mode=config.mock_data_mode,
+            path=config.mock_data_path,
+            distribution=config.mock_data_distribution,
+            min_sequence_length=config.mock_data_min_sequence_length,
+            max_sequence_length=config.mock_data_max_sequence_length,
+            mean_sequence_length=config.mock_data_mean_sequence_length,
+            lognormal_sigma=config.mock_data_lognormal_sigma,
+            seed=config.mock_data_seed,
+            size=config.mock_data_size,
+        )
+
+    def __getitem__(self, idx: int) -> Dict[str, torch.Tensor]:
+        tokenizer = self.config.tokenizer
+        sequence_length = self.config.sequence_length
+        eod = tokenizer.eod
+        if eod is None:
+            raise ValueError("MockSFTDataset requires an EOD/EOS token id")
+        pad = _get_padding_token_id(tokenizer, eod)
+
+        raw_tokens = self.dataset[int(self.indices[idx % len(self.indices)])]
+        token_ids = _normalize_mock_token_ids(
+            raw_tokens, tokenizer, verification=self.dataset.indexed_dataset is not None
+        )
+        token_ids.append(eod)
+
+        if len(token_ids) > sequence_length:
+            token_ids = token_ids[: sequence_length - 1] + [eod]
+        valid_length = len(token_ids) - 1
+        token_ids.extend([pad] * (sequence_length + 1 - len(token_ids)))
+
+        input_ids = torch.tensor(token_ids[:-1], dtype=torch.int64)
+        labels = torch.tensor(token_ids[1:], dtype=torch.int64)
+        loss_mask = torch.ones(sequence_length, dtype=torch.float32)
+        loss_mask[valid_length:] = 0.0
+        position_ids = torch.arange(sequence_length, dtype=torch.int64)
+
+        # Match SFTDataset's fixed-width contract from #5454 so default_collate
+        # can stack samples with different numbers of packed subsequences.
+        cu_seqlens = torch.full((sequence_length + 1,), sequence_length, dtype=torch.int32)
+        cu_seqlens[0] = 0
+        cu_seqlens_original = torch.full((sequence_length + 1,), valid_length, dtype=torch.int32)
+        cu_seqlens_original[0] = 0
+        sample = {
+            'tokens': input_ids,
+            'labels': labels,
+            'loss_mask': loss_mask,
+            'position_ids': position_ids,
+            'cu_seqlens': cu_seqlens,
+            'max_seqlen': torch.tensor(sequence_length, dtype=torch.int32),
+        }
+        if self.config.emit_packing_metadata:
+            sample['cu_seqlens_original'] = cu_seqlens_original
+        return sample

--- a/megatron/training/datasets/varlen_dataset.py
+++ b/megatron/training/datasets/varlen_dataset.py
@@ -1,0 +1,479 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Variable-length dataset producers for packed THD training.
+
+The real-data loader accepts Hugging Face dataset ids, local parquet files,
+and local JSON/JSONL files. Instruction data is normalized from common
+OpenAI, ShareGPT, and Alpaca layouts; a plain ``text`` column is treated as
+pretraining data. Each mid-level sample remains unpacked so a downstream
+packing scheduler can balance and combine samples across ranks.
+"""
+
+import json
+import os
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Iterable, List, Sequence, Tuple
+
+import numpy as np
+import torch
+
+from megatron.core.datasets.megatron_dataset import LowLevelDataset
+from megatron.core.datasets.utils import Split
+from megatron.training.datasets.sft_dataset import (
+    IGNORE_INDEX,
+    MockSFTDataset,
+    MockSFTLowLevelDataset,
+    SFTDataset,
+    SFTDatasetConfig,
+    _calculate_padding_divisor,
+    _get_padding_token_id,
+    _normalize_mock_token_ids,
+)
+
+_INSTRUCTION_FIELDS: Tuple[str, ...] = ("instruction", "prompt", "query", "question")
+_OUTPUT_FIELDS: Tuple[str, ...] = ("output", "response", "completion", "answer")
+_EXTRA_INPUT_FIELDS: Tuple[str, ...] = ("input", "context")
+
+_SHAREGPT_ROLE_MAP: Dict[str, str] = {
+    "human": "user",
+    "user": "user",
+    "gpt": "assistant",
+    "assistant": "assistant",
+    "model": "assistant",
+    "chatgpt": "assistant",
+    "bing": "assistant",
+    "bard": "assistant",
+    "system": "system",
+    "tool": "tool",
+    "function": "tool",
+    "observation": "tool",
+}
+
+
+@dataclass
+class VarlenDatasetConfig(SFTDatasetConfig):
+    """Training-local configuration for variable-length dataset producers."""
+
+    varlen_sbhd_validation: bool = False
+    """Emit fixed-width SBHD samples instead of variable-length THD samples."""
+
+    def __post_init__(self) -> None:
+        """Validate layout-specific constraints after base SFT validation."""
+        super().__post_init__()
+        if self.varlen_sbhd_validation and self.hybrid_context_parallel:
+            raise ValueError("varlen_sbhd_validation is incompatible with hybrid_context_parallel")
+        if not self.varlen_sbhd_validation:
+            padding_divisor = _calculate_padding_divisor(self)
+            if self.sequence_length % padding_divisor != 0:
+                raise ValueError(
+                    "VarlenDatasetConfig.sequence_length must be divisible by the CP/SP "
+                    f"padding divisor ({padding_divisor})"
+                )
+
+
+class _LocalJsonDataset:
+    """Small index over a local JSON array or newline-delimited JSON file."""
+
+    def __init__(self, path: str) -> None:
+        self.path = path
+        self._records: list[dict[str, Any]] | None = None
+        self._offsets: list[int] | None = None
+        self.column_names: list[str] = []
+
+        with open(path, "rb") as stream:
+            first_non_whitespace = b""
+            while True:
+                value = stream.read(1)
+                if not value or not value.isspace():
+                    first_non_whitespace = value
+                    break
+
+        if first_non_whitespace == b"[":
+            with open(path, encoding="utf-8") as stream:
+                records = json.load(stream)
+            if not isinstance(records, list):
+                raise ValueError(f"Expected a JSON array in {path!r}")
+            self._records = [self._validate_record(record, path) for record in records]
+            self._collect_column_names(self._records)
+        else:
+            self._offsets = []
+            with open(path, "rb") as stream:
+                while True:
+                    offset = stream.tell()
+                    line = stream.readline()
+                    if not line:
+                        break
+                    if not line.strip():
+                        continue
+                    try:
+                        record = json.loads(line)
+                    except json.JSONDecodeError as exc:
+                        raise ValueError(
+                            f"Invalid JSONL record at byte offset {offset} in {path!r}"
+                        ) from exc
+                    record = self._validate_record(record, path)
+                    self._offsets.append(offset)
+                    self._collect_column_names([record])
+
+        if len(self) == 0:
+            raise ValueError(f"Local dataset {path!r} must contain at least one record")
+
+    @staticmethod
+    def _validate_record(record: Any, path: str) -> dict[str, Any]:
+        if not isinstance(record, dict):
+            raise ValueError(f"Every record in {path!r} must be a JSON object")
+        return record
+
+    def _collect_column_names(self, records: Iterable[dict[str, Any]]) -> None:
+        seen = set(self.column_names)
+        for record in records:
+            for key in record:
+                if key not in seen:
+                    self.column_names.append(key)
+                    seen.add(key)
+
+    def __len__(self) -> int:
+        if self._records is not None:
+            return len(self._records)
+        assert self._offsets is not None
+        return len(self._offsets)
+
+    def __getitem__(self, idx: int) -> dict[str, Any]:
+        if self._records is not None:
+            return self._records[idx]
+        assert self._offsets is not None
+        offset = self._offsets[idx]
+        with open(self.path, "rb") as stream:
+            stream.seek(offset)
+            return self._validate_record(json.loads(stream.readline()), self.path)
+
+
+def _looks_like_hf_id(path: str | None) -> bool:
+    """Return whether ``path`` resembles a non-local ``owner/repository`` id."""
+    local_suffixes = (".json", ".jsonl", ".parquet")
+    if (
+        not path
+        or os.path.exists(path)
+        or path.startswith(("/", "./", "../"))
+        or path.lower().endswith(local_suffixes)
+    ):
+        return False
+    return True
+
+
+def _first_present(sample: Dict[str, Any], fields: Iterable[str]) -> str | None:
+    """Return the first non-empty string found under ``fields``."""
+    for field_name in fields:
+        value = sample.get(field_name)
+        if value is None or value == "":
+            continue
+        if not isinstance(value, str):
+            raise ValueError(
+                f"VarlenDataset field {field_name!r} must be a string, "
+                f"got {type(value).__name__}"
+            )
+        return value
+    return None
+
+
+def _ensure_str_content(content: Any, location: str) -> str:
+    """Validate a chat turn's scalar text content."""
+    if content is None:
+        return ""
+    if not isinstance(content, str):
+        raise ValueError(
+            f"VarlenDataset {location} content must be a string, "
+            f"got {type(content).__name__}; multimodal content is not supported"
+        )
+    return content
+
+
+def _alpaca_to_messages(sample: Dict[str, Any]) -> List[Dict[str, str]]:
+    """Convert an Alpaca/Dolly-style record to chat messages."""
+    instruction = _first_present(sample, _INSTRUCTION_FIELDS) or ""
+    extra_input = _first_present(sample, _EXTRA_INPUT_FIELDS) or ""
+    output = _first_present(sample, _OUTPUT_FIELDS) or ""
+    user_content = f"{instruction}\n\n{extra_input}" if extra_input else instruction
+    return [
+        {"role": "system", "content": ""},
+        {"role": "user", "content": user_content},
+        {"role": "assistant", "content": output},
+    ]
+
+
+def _sharegpt_to_messages(sample: Dict[str, Any]) -> List[Dict[str, str]]:
+    """Convert a ShareGPT ``conversations`` record to chat messages."""
+    conversations = sample.get("conversations") or []
+    if not isinstance(conversations, list):
+        raise ValueError("VarlenDataset 'conversations' must be a list")
+
+    messages: List[Dict[str, str]] = []
+    first_speaker = ""
+    if conversations:
+        if not isinstance(conversations[0], dict):
+            raise ValueError("Every ShareGPT turn must be an object")
+        first_speaker = str(conversations[0].get("from") or "").lower()
+    if first_speaker != "system":
+        messages.append({"role": "system", "content": ""})
+
+    for turn in conversations:
+        if not isinstance(turn, dict):
+            raise ValueError("Every ShareGPT turn must be an object")
+        speaker = str(turn.get("from") or "").lower()
+        role = _SHAREGPT_ROLE_MAP.get(speaker, "user")
+        messages.append(
+            {
+                "role": role,
+                "content": _ensure_str_content(
+                    turn.get("value"), f"ShareGPT turn with role {role!r}"
+                ),
+            }
+        )
+    return messages
+
+
+def _messages_passthrough(sample: Dict[str, Any]) -> List[Dict[str, str]]:
+    """Normalize an OpenAI ``messages`` record to role/content pairs."""
+    raw_messages = sample.get("messages") or []
+    if not isinstance(raw_messages, list):
+        raise ValueError("VarlenDataset 'messages' must be a list")
+    if any(not isinstance(message, dict) for message in raw_messages):
+        raise ValueError("Every OpenAI message must be an object")
+
+    if raw_messages and raw_messages[0].get("role") != "system":
+        raw_messages = [{"role": "system", "content": ""}, *raw_messages]
+    return [
+        {
+            "role": str(message.get("role") or "user"),
+            "content": _ensure_str_content(
+                message.get("content"),
+                f"OpenAI message with role {message.get('role') or 'user'!r}",
+            ),
+        }
+        for message in raw_messages
+    ]
+
+
+def _raw_text_loader(sample: Dict[str, Any]) -> str:
+    """Return a pretraining ``text`` value without chat normalization."""
+    text = sample.get("text")
+    if text is None:
+        return ""
+    if not isinstance(text, str):
+        raise ValueError(
+            f"VarlenDataset pretraining text must be a string, got {type(text).__name__}"
+        )
+    return text
+
+
+def _select_converter(column_names: Sequence[str]) -> Tuple[Callable[[Dict[str, Any]], Any], str]:
+    """Choose a record converter from the available column names."""
+    columns = set(column_names)
+    if "messages" in columns:
+        return _messages_passthrough, "openai-messages"
+    if "conversations" in columns:
+        return _sharegpt_to_messages, "sharegpt"
+    if any(field in columns for field in _INSTRUCTION_FIELDS) and any(
+        field in columns for field in _OUTPUT_FIELDS
+    ):
+        return _alpaca_to_messages, "alpaca"
+    if "text" in columns:
+        return _raw_text_loader, "pretrain-text"
+    raise ValueError(
+        "VarlenDataset cannot infer a supported schema from columns " f"{sorted(columns)}"
+    )
+
+
+class VarlenLowLevelDataset:
+    """Load HF, parquet, JSON, or JSONL records and normalize their schema."""
+
+    def __init__(self, dataset_path: str) -> None:
+        if _looks_like_hf_id(dataset_path):
+            try:
+                from datasets import load_dataset
+            except ImportError as exc:
+                raise ImportError(
+                    "VarlenLowLevelDataset requires `datasets` for Hugging Face ids"
+                ) from exc
+            self.dataset = load_dataset(dataset_path, split="train")
+        elif dataset_path.endswith(".parquet"):
+            try:
+                from datasets import load_dataset
+            except ImportError as exc:
+                raise ImportError(
+                    "VarlenLowLevelDataset requires `datasets` for parquet files"
+                ) from exc
+            self.dataset = load_dataset("parquet", data_files=dataset_path, split="all")
+        else:
+            self.dataset = _LocalJsonDataset(dataset_path)
+
+        _, self._schema_name = _select_converter(self.dataset.column_names)
+
+    @property
+    def schema_name(self) -> str:
+        """Detected schema: Alpaca, ShareGPT, OpenAI messages, or pretrain text."""
+        return self._schema_name
+
+    def __len__(self) -> int:
+        return len(self.dataset)
+
+    def __getitem__(self, idx: int) -> Any:
+        record = self.dataset[idx]
+        populated_columns = [key for key, value in record.items() if value is not None]
+        converter, _ = _select_converter(populated_columns)
+        return converter(record)
+
+
+class VarlenDataset(SFTDataset):
+    """Return one unpacked variable-length sample for downstream THD packing."""
+
+    def __init__(
+        self,
+        dataset: LowLevelDataset,
+        dataset_path: str | None,
+        indices: np.ndarray,
+        num_samples: int | None,
+        index_split: Split,
+        config: VarlenDatasetConfig,
+    ) -> None:
+        super().__init__(dataset, dataset_path, indices, num_samples, index_split, config)
+
+    @staticmethod
+    def build_low_level_dataset(
+        dataset_path: str, config: VarlenDatasetConfig
+    ) -> VarlenLowLevelDataset:
+        """Build a normalized low-level variable-length dataset."""
+        del config
+        return VarlenLowLevelDataset(dataset_path)
+
+    def _tokenize_item(self, item: Any) -> tuple[list[int], list[int]]:
+        """Tokenize one raw-text or normalized conversation item."""
+        tokenizer = self.config.tokenizer
+        if isinstance(item, str):
+            token_ids = tokenizer.tokenize(item)
+            if hasattr(token_ids, "tolist"):
+                token_ids = token_ids.tolist()
+            tokens = list(token_ids)
+            targets = list(tokens)
+        else:
+            token_ids, target_ids = tokenizer.tokenize_conversation(
+                item, return_target=True, add_generation_prompt=False
+            )
+            tokens = token_ids.tolist() if hasattr(token_ids, "tolist") else list(token_ids)
+            targets = target_ids.tolist() if hasattr(target_ids, "tolist") else list(target_ids)
+        if len(tokens) != len(targets):
+            raise ValueError("Tokenizer returned different token and target lengths")
+        return tokens, targets
+
+    def __getitem__(self, idx: int) -> Dict[str, torch.Tensor]:
+        tokenizer = self.config.tokenizer
+        sequence_length = self.config.sequence_length
+        eod = tokenizer.eod
+        if eod is None:
+            raise ValueError("VarlenDataset requires an EOD/EOS token id")
+        pad = _get_padding_token_id(tokenizer, eod)
+
+        item = self.dataset[int(self.indices[idx % len(self.indices)])]
+        if self.config.reset_position_ids:
+            raise ValueError("VarlenDataset does not support reset_position_ids")
+        if self.config.create_attention_mask or self.config.reset_attention_mask:
+            raise ValueError("VarlenDataset requires attention-mask creation to be disabled")
+
+        tokens, targets = self._tokenize_item(item)
+        if not tokens:
+            tokens = [eod, eod]
+            targets = [eod, eod]
+        elif tokens[-1] != eod:
+            tokens.append(eod)
+            targets.append(eod)
+        if len(tokens) == 1:
+            tokens.append(eod)
+            targets.append(eod)
+
+        if len(tokens) > sequence_length + 1:
+            tokens = tokens[: sequence_length + 1]
+            targets = targets[: sequence_length + 1]
+
+        valid_length = len(tokens) - 1
+        if self.config.varlen_sbhd_validation:
+            padding_length = sequence_length + 1 - len(tokens)
+            tokens.extend([pad] * padding_length)
+            targets.extend([pad] * padding_length)
+            input_ids = torch.tensor(tokens[:-1], dtype=torch.int64)
+            labels = torch.tensor(targets[1:], dtype=torch.int64)
+            loss_mask = torch.ones(sequence_length, dtype=torch.float32)
+            loss_mask[valid_length:] = 0.0
+            loss_mask[labels == IGNORE_INDEX] = 0.0
+            return {
+                'tokens': input_ids,
+                'labels': labels,
+                'loss_mask': loss_mask,
+                'position_ids': torch.arange(sequence_length, dtype=torch.int64),
+            }
+
+        padding_length = (-valid_length) % self.padding_divisor
+        tokens.extend([pad] * padding_length)
+        targets.extend([pad] * padding_length)
+        padded_length = len(tokens) - 1
+
+        input_ids = torch.tensor(tokens[:-1], dtype=torch.int64)
+        labels = torch.tensor(targets[1:], dtype=torch.int64)
+        loss_mask = torch.ones(padded_length, dtype=torch.float32)
+        loss_mask[valid_length:] = 0.0
+        loss_mask[labels == IGNORE_INDEX] = 0.0
+        return {
+            'tokens': input_ids,
+            'labels': labels,
+            'loss_mask': loss_mask,
+            'position_ids': torch.arange(padded_length, dtype=torch.int64),
+            'original_seq_len': torch.tensor([valid_length], dtype=torch.int32),
+            'padded_seq_len': torch.tensor([padded_length], dtype=torch.int32),
+        }
+
+
+class MockVarlenDataset(MockSFTDataset):
+    """Mock producer with the same unpacked THD output as :class:`VarlenDataset`."""
+
+    @staticmethod
+    def build_low_level_dataset(
+        dataset_path: str, config: VarlenDatasetConfig
+    ) -> MockSFTLowLevelDataset:
+        """Build a mock source from the inherited flat fields."""
+        return MockSFTDataset.build_low_level_dataset(dataset_path, config)
+
+    def __getitem__(self, idx: int) -> Dict[str, torch.Tensor]:
+        if self.config.varlen_sbhd_validation:
+            raise ValueError("MockVarlenDataset supports only unpacked THD output")
+
+        tokenizer = self.config.tokenizer
+        sequence_length = self.config.sequence_length
+        eod = tokenizer.eod
+        if eod is None:
+            raise ValueError("MockVarlenDataset requires an EOD/EOS token id")
+        pad = _get_padding_token_id(tokenizer, eod)
+
+        raw_tokens = self.dataset[int(self.indices[idx % len(self.indices)])]
+        tokens = _normalize_mock_token_ids(
+            raw_tokens, tokenizer, verification=self.dataset.indexed_dataset is not None
+        )
+        tokens.append(eod)
+        if len(tokens) > sequence_length + 1:
+            tokens = tokens[: sequence_length + 1]
+
+        valid_length = len(tokens) - 1
+        padding_length = (-valid_length) % self.padding_divisor
+        tokens.extend([pad] * padding_length)
+        padded_length = len(tokens) - 1
+
+        input_ids = torch.tensor(tokens[:-1], dtype=torch.int64)
+        labels = torch.tensor(tokens[1:], dtype=torch.int64)
+        loss_mask = torch.ones(padded_length, dtype=torch.float32)
+        loss_mask[valid_length:] = 0.0
+        return {
+            'tokens': input_ids,
+            'labels': labels,
+            'loss_mask': loss_mask,
+            'position_ids': torch.arange(padded_length, dtype=torch.int64),
+            'original_seq_len': torch.tensor([valid_length], dtype=torch.int32),
+            'padded_seq_len': torch.tensor([padded_length], dtype=torch.int32),
+        }

--- a/tests/unit_tests/data/test_varlen_dataset.py
+++ b/tests/unit_tests/data/test_varlen_dataset.py
@@ -1,0 +1,520 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""CPU-safe regression tests for training-local SFT and varlen datasets."""
+
+from dataclasses import fields
+
+import numpy as np
+import pytest
+import torch
+
+from megatron.core.datasets.gpt_dataset import GPTDatasetConfig
+from megatron.core.datasets.utils import Split
+from megatron.training.datasets import sft_dataset as sft_dataset_module
+from megatron.training.datasets.sft_dataset import (
+    IGNORE_INDEX,
+    MockSFTDataset,
+    MockSFTLowLevelDataset,
+    SFTDataset,
+    SFTDatasetConfig,
+    _calculate_padding_divisor,
+)
+from megatron.training.datasets.varlen_dataset import (
+    MockVarlenDataset,
+    VarlenDataset,
+    VarlenDatasetConfig,
+    VarlenLowLevelDataset,
+    _alpaca_to_messages,
+    _looks_like_hf_id,
+    _messages_passthrough,
+    _raw_text_loader,
+    _select_converter,
+    _sharegpt_to_messages,
+)
+
+
+class _FakeTokenizer:
+    """Minimal tokenizer with the interfaces exercised by the datasets."""
+
+    vocab_size = 512
+    unique_identifiers = {"class": "_FakeTokenizer"}
+
+    def __init__(self, eod: int = 0, pad: int | None = 511) -> None:
+        self.eod = eod
+        self.eos = eod
+        self.pad = pad
+        self.special_tokens_dict = {"eos_token": eod, "pad_token": pad}
+
+    @staticmethod
+    def tokenize(text: str) -> list[int]:
+        return [ord(character) % 200 + 1 for character in text]
+
+    def tokenize_conversation(
+        self, messages, return_target: bool = True, add_generation_prompt: bool = False
+    ):
+        assert return_target and not add_generation_prompt
+        tokens = []
+        targets = []
+        for message in messages:
+            token_ids = self.tokenize(message["content"])
+            tokens.extend(token_ids)
+            targets.extend(
+                token_ids if message["role"] == "assistant" else [IGNORE_INDEX] * len(token_ids)
+            )
+        return torch.tensor(tokens, dtype=torch.int64), torch.tensor(targets, dtype=torch.int64)
+
+
+def _config(config_type=SFTDatasetConfig, **overrides):
+    values = {
+        "random_seed": 123,
+        "sequence_length": 16,
+        "tokenizer": _FakeTokenizer(),
+        "reset_position_ids": False,
+        "reset_attention_mask": False,
+        "eod_mask_loss": False,
+        "create_attention_mask": False,
+        "context_parallel_size": 1,
+    }
+    values.update(overrides)
+    return config_type(**values)
+
+
+def _mock_source(**overrides):
+    values = {
+        "mode": "distribution",
+        "path": None,
+        "distribution": "lognormal",
+        "min_sequence_length": 4,
+        "max_sequence_length": 12,
+        "mean_sequence_length": 8,
+        "lognormal_sigma": 0.5,
+        "seed": 17,
+        "size": 8,
+    }
+    values.update(overrides)
+    return MockSFTLowLevelDataset(**values)
+
+
+def _mid_level(dataset_type, low_level_dataset, config):
+    return dataset_type(
+        low_level_dataset,
+        None,
+        np.arange(len(low_level_dataset), dtype=np.int64),
+        len(low_level_dataset),
+        Split.train,
+        config,
+    )
+
+
+def test_mock_config_is_flat_and_does_not_modify_core_config():
+    field_names = {field.name for field in fields(SFTDatasetConfig)}
+    assert "mock_data_mode" in field_names
+    assert "mock_data_path" in field_names
+    assert all("json" not in field_name for field_name in field_names)
+    assert "mock_data_mode" not in {field.name for field in fields(GPTDatasetConfig)}
+
+
+def test_mock_config_derives_typed_defaults_from_sequence_length():
+    config = _config(sequence_length=32)
+    assert config.mock_data_min_sequence_length == 16
+    assert config.mock_data_max_sequence_length == 32
+    assert config.mock_data_mean_sequence_length == 24
+
+
+def test_mock_config_requires_path_for_file_mode():
+    with pytest.raises(ValueError, match="mock_data_path is required"):
+        _config(mock_data_mode="file")
+
+
+def test_varlen_config_validates_packing_divisibility():
+    with pytest.raises(ValueError, match="must be divisible"):
+        _config(
+            VarlenDatasetConfig,
+            sequence_length=10,
+            context_parallel_size=2,
+            sequence_parallel_size=2,
+        )
+
+
+def test_varlen_sbhd_config_rejects_hybrid_cp():
+    with pytest.raises(ValueError, match="incompatible"):
+        _config(VarlenDatasetConfig, varlen_sbhd_validation=True, hybrid_context_parallel=True)
+
+
+def test_padding_divisor_covers_standard_and_hybrid_parallelism():
+    standard = _config(context_parallel_size=2, sequence_parallel_size=2)
+    hybrid = _config(
+        sequence_length=32,
+        context_parallel_size=2,
+        sequence_parallel_size=2,
+        data_parallel_size=2,
+        hybrid_context_parallel=True,
+    )
+    assert _calculate_padding_divisor(standard) == 8
+    assert _calculate_padding_divisor(hybrid) == 16
+
+
+def test_mock_file_mode_reads_first_headerless_value(tmp_path):
+    path = tmp_path / "lengths.csv"
+    path.write_text("3\n5\n8\n", encoding="utf-8")
+    dataset = _mock_source(mode="file", path=str(path))
+    assert dataset.sequence_lengths.tolist() == [3, 5, 8]
+    assert dataset[0].tolist() == [1, 2]
+
+
+def test_mock_distribution_is_deterministic_and_bounded():
+    first = _mock_source()
+    second = _mock_source()
+    assert np.array_equal(first.sequence_lengths, second.sequence_lengths)
+    assert first.sequence_lengths.min() >= 4
+    assert first.sequence_lengths.max() <= 12
+
+
+def test_mock_verification_mode_concatenates_indexed_documents(monkeypatch):
+    class _FakeIndexedDataset:
+        def __init__(self, path):
+            assert path == "indexed-prefix"
+            self.documents = [np.array([11, 12]), np.array([21, 22, 23])]
+
+        def __len__(self):
+            return len(self.documents)
+
+        def __getitem__(self, idx):
+            return self.documents[idx]
+
+    monkeypatch.setattr(sft_dataset_module, "IndexedDataset", _FakeIndexedDataset)
+    dataset = _mock_source(
+        mode="verification",
+        path="indexed-prefix",
+        min_sequence_length=5,
+        max_sequence_length=5,
+        mean_sequence_length=5,
+        lognormal_sigma=0,
+    )
+    assert dataset[0].tolist() == [11, 12, 21, 22]
+
+
+def test_mock_sft_keeps_fixed_width_cu_seqlens_and_real_eod(tmp_path):
+    path = tmp_path / "lengths.txt"
+    path.write_text("4\n6\n", encoding="utf-8")
+    config = _config(
+        tokenizer=_FakeTokenizer(eod=0, pad=None),
+        sequence_length=8,
+        mock_data_mode="file",
+        mock_data_path=str(path),
+        emit_packing_metadata=True,
+    )
+    dataset = _mid_level(
+        MockSFTDataset, MockSFTDataset.build_low_level_dataset("unused", config), config
+    )
+    sample = dataset[0]
+    assert sample["tokens"].shape == (8,)
+    assert sample["cu_seqlens"].shape == (9,)
+    assert sample["cu_seqlens"].tolist() == [0] + [8] * 8
+    assert sample["cu_seqlens_original"].tolist() == [0] + [3] * 8
+    assert sample["labels"][2].item() == config.tokenizer.eod
+    assert sample["loss_mask"][2].item() == 1.0
+    assert sample["loss_mask"][3:].sum().item() == 0.0
+
+
+def test_sft_keeps_current_main_fixed_width_cu_seqlens():
+    config = _config(sequence_length=8)
+    conversations = [
+        {"role": "system", "content": ""},
+        {"role": "user", "content": "a"},
+        {"role": "assistant", "content": "b"},
+        {"role": "system", "content": ""},
+        {"role": "user", "content": "cd"},
+        {"role": "assistant", "content": "e"},
+    ]
+    sample = _mid_level(SFTDataset, [conversations], config)[0]
+    assert sample["cu_seqlens"].shape == (9,)
+    assert sample["cu_seqlens"][-1].item() == 8
+    assert sample["cu_seqlens"][-2].item() == 8
+    assert "cu_seqlens_original" not in sample
+
+
+def test_sft_emits_fixed_width_real_boundaries_for_packing_scheduler():
+    config = _config(sequence_length=8, emit_packing_metadata=True)
+    conversations = [
+        {"role": "system", "content": ""},
+        {"role": "user", "content": "a"},
+        {"role": "assistant", "content": "b"},
+        {"role": "system", "content": ""},
+        {"role": "user", "content": "cd"},
+        {"role": "assistant", "content": "e"},
+    ]
+    sample = _mid_level(SFTDataset, [conversations], config)[0]
+
+    assert sample["cu_seqlens_original"].shape == sample["cu_seqlens"].shape
+    assert sample["cu_seqlens_original"].tolist() == [0, 1] + [3] * 7
+    assert torch.all(sample["cu_seqlens_original"] <= sample["cu_seqlens"])
+
+
+def test_sft_no_pad_token_keeps_real_eod_supervision():
+    class _EodTokenizer(_FakeTokenizer):
+        def tokenize_conversation(
+            self, messages, return_target: bool = True, add_generation_prompt: bool = False
+        ):
+            del messages
+            assert return_target and not add_generation_prompt
+            return torch.tensor([7, self.eod]), torch.tensor([IGNORE_INDEX, self.eod])
+
+    config = _config(tokenizer=_EodTokenizer(eod=0, pad=None), sequence_length=8)
+    conversations = [[{"role": "system", "content": ""}]]
+    sample = _mid_level(SFTDataset, conversations, config)[0]
+
+    assert sample["labels"][0].item() == config.tokenizer.eod
+    assert sample["loss_mask"][0].item() == 1.0
+    assert sample["loss_mask"][1:].sum().item() == 0.0
+
+
+def test_sft_truncation_metadata_excludes_final_padding_target():
+    config = _config(sequence_length=8, emit_packing_metadata=True)
+    conversations = [
+        {"role": "system", "content": ""},
+        {"role": "user", "content": "abcdefghij"},
+        {"role": "assistant", "content": "answer"},
+    ]
+    sample = _mid_level(SFTDataset, [conversations], config)[0]
+
+    assert sample["cu_seqlens"][:2].tolist() == [0, 8]
+    assert sample["cu_seqlens_original"][:2].tolist() == [0, 7]
+
+
+def test_sft_packing_metadata_folds_zero_real_token_tail():
+    config = _config(sequence_length=8, emit_packing_metadata=True)
+    conversations = [
+        {"role": "system", "content": ""},
+        {"role": "user", "content": "abcdefg"},
+        {"role": "system", "content": ""},
+        {"role": "user", "content": "xy"},
+    ]
+    sample = _mid_level(SFTDataset, [conversations], config)[0]
+
+    assert sample["cu_seqlens"].tolist() == [0] + [8] * 8
+    assert sample["cu_seqlens_original"].tolist() == [0] + [6] * 8
+
+
+def test_sft_packing_metadata_rejects_record_without_prediction_steps():
+    class _SingleTokenTokenizer(_FakeTokenizer):
+        def tokenize_conversation(
+            self, messages, return_target: bool = True, add_generation_prompt: bool = False
+        ):
+            del messages
+            assert return_target and not add_generation_prompt
+            return torch.tensor([7]), torch.tensor([7])
+
+    config = _config(tokenizer=_SingleTokenTokenizer(), emit_packing_metadata=True)
+    conversations = [[{"role": "system", "content": ""}]]
+    dataset = _mid_level(SFTDataset, conversations, config)
+
+    with pytest.raises(ValueError, match="two or more tokens"):
+        dataset[0]
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        ("owner/repository", True),
+        ("/tmp/data.jsonl", False),
+        ("./data.jsonl", False),
+        ("../data.jsonl", False),
+        ("data.jsonl", False),
+        ("missing/data.jsonl", False),
+        ("wikitext", True),
+        (None, False),
+    ],
+)
+def test_looks_like_hf_id(path, expected):
+    assert _looks_like_hf_id(path) is expected
+
+
+def test_alpaca_converter_supports_context_and_field_synonyms():
+    messages = _alpaca_to_messages(
+        {"prompt": "Question", "context": "Details", "response": "Answer"}
+    )
+    assert [message["role"] for message in messages] == ["system", "user", "assistant"]
+    assert messages[1]["content"] == "Question\n\nDetails"
+    assert messages[2]["content"] == "Answer"
+
+
+def test_sharegpt_converter_maps_roles_and_prepends_system():
+    messages = _sharegpt_to_messages(
+        {
+            "conversations": [
+                {"from": "human", "value": "Question"},
+                {"from": "gpt", "value": "Answer"},
+            ]
+        }
+    )
+    assert [message["role"] for message in messages] == ["system", "user", "assistant"]
+
+
+def test_messages_converter_strips_extra_keys():
+    messages = _messages_passthrough(
+        {
+            "messages": [
+                {"role": "user", "content": "Question", "name": "Alice"},
+                {"role": "assistant", "content": "Answer", "tool_calls": []},
+            ]
+        }
+    )
+    assert [set(message) for message in messages] == [
+        {"role", "content"},
+        {"role", "content"},
+        {"role", "content"},
+    ]
+
+
+def test_converters_reject_multimodal_content():
+    with pytest.raises(ValueError, match="must be a string"):
+        _messages_passthrough({"messages": [{"role": "user", "content": [{"type": "image"}]}]})
+
+
+def test_converter_selection_priority_and_pretrain_text():
+    converter, schema = _select_converter(["text", "messages", "instruction", "output"])
+    assert converter is _messages_passthrough
+    assert schema == "openai-messages"
+    converter, schema = _select_converter(["text", "metadata"])
+    assert converter is _raw_text_loader
+    assert schema == "pretrain-text"
+    assert converter({"text": "document"}) == "document"
+
+
+def test_converter_selection_rejects_unknown_schema():
+    with pytest.raises(ValueError, match="cannot infer"):
+        _select_converter(["id", "metadata"])
+
+
+def test_local_jsonl_loader_handles_heterogeneous_columns(tmp_path):
+    path = tmp_path / "data.jsonl"
+    path.write_text(
+        '{"instruction":"Q1","output":"A1"}\n'
+        '{"instruction":"Q2","output":"A2","source":"extra"}\n',
+        encoding="utf-8",
+    )
+    dataset = VarlenLowLevelDataset(str(path))
+    assert dataset.schema_name == "alpaca"
+    assert len(dataset) == 2
+    assert dataset[1][2] == {"role": "assistant", "content": "A2"}
+
+
+def test_local_json_array_loader_supports_pretrain_text(tmp_path):
+    path = tmp_path / "data.json"
+    path.write_text('[{"text":"first"},{"text":"second","id":2}]', encoding="utf-8")
+    dataset = VarlenLowLevelDataset(str(path))
+    assert dataset.schema_name == "pretrain-text"
+    assert [dataset[index] for index in range(len(dataset))] == ["first", "second"]
+
+
+def test_local_loader_selects_schema_per_record(tmp_path):
+    path = tmp_path / "mixed.json"
+    path.write_text(
+        '[{"messages":[{"role":"user","content":"question"}]},' '{"text":"document"}]',
+        encoding="utf-8",
+    )
+    dataset = VarlenLowLevelDataset(str(path))
+
+    assert dataset[0][0]["role"] == "system"
+    assert dataset[1] == "document"
+
+
+def test_varlen_thd_pads_to_divisor_and_keeps_real_eod():
+    config = _config(
+        VarlenDatasetConfig, tokenizer=_FakeTokenizer(eod=0, pad=None), context_parallel_size=2
+    )
+    dataset = _mid_level(VarlenDataset, ["abc"], config)
+    sample = dataset[0]
+    assert sample["original_seq_len"].item() == 3
+    assert sample["padded_seq_len"].item() == 4
+    assert sample["labels"][2].item() == config.tokenizer.eod
+    assert sample["loss_mask"].tolist() == [1.0, 1.0, 1.0, 0.0]
+
+
+def test_varlen_sft_masks_prompt_targets():
+    config = _config(VarlenDatasetConfig)
+    messages = [
+        {"role": "system", "content": ""},
+        {"role": "user", "content": "Question"},
+        {"role": "assistant", "content": "Answer"},
+    ]
+    sample = _mid_level(VarlenDataset, [messages], config)[0]
+    assert torch.all(sample["loss_mask"][sample["labels"] == IGNORE_INDEX] == 0)
+    assert sample["loss_mask"].sum() > 0
+
+
+def test_varlen_empty_text_produces_nonempty_sample():
+    config = _config(VarlenDatasetConfig)
+    sample = _mid_level(VarlenDataset, [""], config)[0]
+    assert sample["tokens"].numel() >= 1
+    assert sample["labels"].shape == sample["tokens"].shape
+
+
+def test_varlen_sbhd_validation_returns_fixed_width_sample():
+    config = _config(
+        VarlenDatasetConfig,
+        tokenizer=_FakeTokenizer(eod=0, pad=None),
+        sequence_length=8,
+        varlen_sbhd_validation=True,
+    )
+    sample = _mid_level(VarlenDataset, ["abc"], config)[0]
+    assert set(sample) == {"tokens", "labels", "loss_mask", "position_ids"}
+    assert sample["tokens"].shape == (8,)
+    assert sample["loss_mask"].tolist() == [1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+
+
+def test_mock_varlen_matches_real_varlen_metadata_contract():
+    config = _config(
+        VarlenDatasetConfig,
+        tokenizer=_FakeTokenizer(eod=0, pad=None),
+        context_parallel_size=2,
+        mock_data_min_sequence_length=5,
+        mock_data_max_sequence_length=5,
+        mock_data_mean_sequence_length=5,
+        mock_data_lognormal_sigma=0,
+        mock_data_size=2,
+    )
+    low_level = MockVarlenDataset.build_low_level_dataset("unused", config)
+    sample = _mid_level(MockVarlenDataset, low_level, config)[0]
+    assert set(sample) == {
+        "tokens",
+        "labels",
+        "loss_mask",
+        "position_ids",
+        "original_seq_len",
+        "padded_seq_len",
+    }
+    assert sample["original_seq_len"].item() == 4
+    assert sample["padded_seq_len"].item() == 4
+
+
+def test_mock_varlen_supports_null_tokenizer_interface_and_bounds_ids():
+    class _NullTokenizerLike:
+        vocab_size = 4
+        eod = 3
+        pad_id = -1
+        unique_identifiers = {"class": "_NullTokenizerLike"}
+
+    config = _config(
+        VarlenDatasetConfig,
+        tokenizer=_NullTokenizerLike(),
+        sequence_length=8,
+        mock_data_min_sequence_length=8,
+        mock_data_max_sequence_length=8,
+        mock_data_mean_sequence_length=8,
+        mock_data_lognormal_sigma=0,
+        mock_data_size=1,
+    )
+    low_level = MockVarlenDataset.build_low_level_dataset("unused", config)
+    sample = _mid_level(MockVarlenDataset, low_level, config)[0]
+
+    assert sample["tokens"].min().item() >= 0
+    assert sample["tokens"].max().item() < config.tokenizer.vocab_size
+
+
+def test_varlen_truncation_does_not_invent_supervised_eod():
+    config = _config(VarlenDatasetConfig, sequence_length=4)
+    sample = _mid_level(VarlenDataset, ["abcdef"], config)[0]
+
+    assert sample["labels"][-1].item() != config.tokenizer.eod


### PR DESCRIPTION
Part 4 of the split of #3386. Original changes by @xiaoyao0115 (tailaim); this version is ported to current `main` and incorporates the review feedback.

## What changed

- Add flat, typed training-local SFT/mock configuration without JSON-string or nested config fields in core `GPTDatasetConfig`.
- Add deterministic distribution, file, and indexed-verification mock producers with tokenizer-safe padding and vocab-bounded synthetic IDs.
- Add real and mock variable-length producers for OpenAI messages, ShareGPT, Alpaca-style instruction data, raw text, local JSON/JSONL, parquet, and Hugging Face datasets.
- Preserve current fixed-width SFT metadata by default and conditionally emit distinct real/physical boundaries for the packing scheduler.
- Use position-aware padding masks so tokenizers without a distinct pad id retain genuine EOD supervision.
- Add coverage for schema selection, mock modes, fixed-width metadata, truncation edges, zero-step records, and CP/SP padding.

## Review issues addressed

Dataset configuration remains flat and typed; no nested dictionaries, JSON config strings, pandas dependency, or core dataset-config pollution is introduced.

## Validation

- Black, isort, Ruff, Pylint, `py_compile`, and `git diff --check`: passed.
- Focused pytest command: `pytest -q tests/unit_tests/data/test_varlen_dataset.py`.
- Local pytest collection is blocked because this host environment does not provide PyTorch (`ModuleNotFoundError: torch`); runtime coverage is delegated to CI.

The training integration PR will enable `emit_packing_metadata` whenever the scheduler is active.

## Split series

- #5563 — padding-mask SP fix
- #5560 — core scheduler and batch utilities
- #5562 — packing scheduler config
- #5561 — typed SFT/varlen producers
- Training integration follows after these land, keeping its CODEOWNERS scope isolated.