### PR TITLE
[Core] Add sequence packing scheduler configuration

### DIFF
--- a/megatron/core/model_parallel_config.py
+++ b/megatron/core/model_parallel_config.py
@@ -58,8 +58,8 @@ class ModelParallelConfig:
     Maximum sequence length per DPxCP rank. This is the maximum sequence length each rank
     can handle without overflowing the memory. Typically, a good starting point is to set this
     to maximum sequence length / context parallel size.
-    This is used to calculate the number and length of sub-samples assigned to 
-    each rank when using hybrid_context_parallel.
+    This is used to calculate the number and length of sub-samples assigned to each rank when
+    using hybrid context parallelism or a sequence packing scheduler.
     """
 
     hybrid_context_parallel: bool = False
@@ -68,6 +68,9 @@ class ModelParallelConfig:
     each CP rank when we use packed samples with variable sequence lengths.
     Please set max_seqlen_per_dp_cp_rank when using hybrid_context_parallel.
     """
+
+    sequence_packing_scheduler: Optional[Literal['dp_balanced']] = None
+    """Scheduler used to balance variable-length packed sequences across data-parallel ranks."""
 
     expert_model_parallel_size: int = 1
     """Distributes Moe Experts across sub data parallel dimension."""
@@ -423,6 +426,24 @@ class ModelParallelConfig:
         See https://docs.python.org/3/library/dataclasses.html#post-init-processing for more
         details.
         """
+        if self.sequence_packing_scheduler is not None:
+            supported_schedulers = ('dp_balanced',)
+            if self.sequence_packing_scheduler not in supported_schedulers:
+                raise ValueError(
+                    f"Unsupported sequence packing scheduler: {self.sequence_packing_scheduler}. "
+                    f"Available schedulers: {supported_schedulers}."
+                )
+            if (
+                isinstance(self.max_seqlen_per_dp_cp_rank, bool)
+                or not isinstance(self.max_seqlen_per_dp_cp_rank, int)
+                or self.max_seqlen_per_dp_cp_rank <= 0
+            ):
+                raise ValueError(
+                    "max_seqlen_per_dp_cp_rank must be a positive integer when using a "
+                    "sequence packing scheduler."
+                )
+            self.variable_seq_lengths = True
+
         if self.sequence_parallel:
             if self.tensor_model_parallel_size <= 1:
                 raise ValueError("Cannot use sequence parallelism without tensor parallelism")

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -1213,6 +1213,26 @@ class TransformerConfig(ModelParallelConfig):
         """
         super().__post_init__()
 
+        if self.sequence_packing_scheduler is not None:
+            if self.moe_token_dispatcher_type != 'alltoall':
+                raise ValueError(
+                    "Sequence packing schedulers require moe_token_dispatcher_type='alltoall', "
+                    f"got {self.moe_token_dispatcher_type!r}."
+                )
+
+            if not HAVE_PACKAGING:
+                raise ImportError(
+                    "packaging is not installed. Please install it with `pip install packaging`."
+                )
+
+            # TODO: Remove this after the convergence issue with TE < 2.9 is fixed.
+            if not (
+                is_te_min_version("2.9.0") or get_te_version() == PkgVersion("2.9.0.dev0+5b3092a")
+            ):
+                raise ValueError(
+                    "Sequence packing schedulers require Transformer Engine >= 2.9.0, "
+                    f"but got {get_te_version()} (TE < 2.9.0 may have convergence issues)."
+                )
         # When fp32 residual connections are enabled, pipeline parallel communication must
         # use fp32 to match the dtype of the residual stream between pipeline stages.
         if self.fp32_residual_connection and self.pipeline_dtype is not None:

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2072,6 +2072,7 @@ def _add_network_size_args(parser):
         "tp_comm_overlap_disable_fc1",
         "pipeline_dtype",
         "variable_seq_lengths",
+        "sequence_packing_scheduler",
         "batch_p2p_comm",
         "batch_p2p_sync",
         "deallocate_pipeline_outputs",

--- a/tests/unit_tests/models/test_hybrid_moe_model.py
+++ b/tests/unit_tests/models/test_hybrid_moe_model.py
@@ -270,6 +270,7 @@ GOLDEN_CONFIG: Dict[str, Any] = {
     "recompute_modules": ["core_attn"],
     "recompute_num_layers": None,
     "rotary_interleaved": False,
+    "sequence_packing_scheduler": None,
     "sequence_parallel": True,
     "softmax_scale": None,
     "softmax_type": "vanilla",

--- a/tests/unit_tests/test_argument_utils.py
+++ b/tests/unit_tests/test_argument_utils.py
@@ -677,6 +677,16 @@ class TestMegatronNetworkArgumentGeneration:
         for field_name in callback_fields:
             assert not hasattr(args, field_name)
 
+    def test_sequence_packing_scheduler_is_not_registered_as_a_cli_arg(self):
+        """The scheduler stays internal until its training integration lands."""
+        from megatron.training.arguments import _add_network_size_args
+
+        parser = ArgumentParser()
+        _add_network_size_args(parser)
+
+        destinations = {action.dest for action in parser._actions}
+        assert "sequence_packing_scheduler" not in destinations
+
 
 # ---------------------------------------------------------------------------
 # Tests for pretrain_cfg_container_from_args

--- a/tests/unit_tests/transformer/test_transformer_config.py
+++ b/tests/unit_tests/transformer/test_transformer_config.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import pytest
+from packaging.version import Version
+
+import megatron.core.transformer.transformer_config as transformer_config_module
+from megatron.core.model_parallel_config import ModelParallelConfig
+from megatron.core.transformer.transformer_config import TransformerConfig
+
+
+def _sequence_packing_config(**overrides):
+    kwargs = {
+        "num_layers": 1,
+        "hidden_size": 16,
+        "num_attention_heads": 1,
+        "sequence_packing_scheduler": "dp_balanced",
+        "max_seqlen_per_dp_cp_rank": 128,
+        "moe_token_dispatcher_type": "alltoall",
+    }
+    kwargs.update(overrides)
+    return TransformerConfig(**kwargs)
+
+
+def test_sequence_packing_scheduler_is_disabled_by_default():
+    config = TransformerConfig(num_layers=1, hidden_size=16, num_attention_heads=1)
+
+    assert config.sequence_packing_scheduler is None
+    assert config.variable_seq_lengths is False
+
+
+def test_sequence_packing_scheduler_name_is_validated_before_te(monkeypatch):
+    monkeypatch.setattr(
+        transformer_config_module,
+        "is_te_min_version",
+        lambda *_args, **_kwargs: pytest.fail("TE validation should not run"),
+    )
+
+    with pytest.raises(ValueError, match="Unsupported sequence packing scheduler"):
+        _sequence_packing_config(
+            sequence_packing_scheduler="unsupported",
+            max_seqlen_per_dp_cp_rank=None,
+            variable_seq_lengths=True,
+        )
+
+
+@pytest.mark.parametrize("max_seqlen_per_dp_cp_rank", [None, 0, -1, 1.5, True])
+def test_sequence_packing_scheduler_requires_positive_max_seqlen(
+    monkeypatch, max_seqlen_per_dp_cp_rank
+):
+    monkeypatch.setattr(
+        transformer_config_module,
+        "is_te_min_version",
+        lambda *_args, **_kwargs: pytest.fail("TE validation should not run"),
+    )
+
+    with pytest.raises(ValueError, match="max_seqlen_per_dp_cp_rank must be a positive integer"):
+        _sequence_packing_config(max_seqlen_per_dp_cp_rank=max_seqlen_per_dp_cp_rank)
+
+
+def test_model_parallel_config_enforces_base_scheduler_invariants():
+    config = ModelParallelConfig(
+        sequence_packing_scheduler="dp_balanced", max_seqlen_per_dp_cp_rank=128
+    )
+
+    assert config.variable_seq_lengths is True
+
+
+def test_sequence_packing_scheduler_requires_alltoall_dispatcher(monkeypatch):
+    monkeypatch.setattr(
+        transformer_config_module,
+        "is_te_min_version",
+        lambda *_args, **_kwargs: pytest.fail("TE validation should not run"),
+    )
+
+    with pytest.raises(ValueError, match="moe_token_dispatcher_type='alltoall'"):
+        _sequence_packing_config(moe_token_dispatcher_type="allgather", variable_seq_lengths=True)
+
+
+def test_sequence_packing_scheduler_requires_supported_te(monkeypatch):
+    monkeypatch.setattr(transformer_config_module, "HAVE_PACKAGING", True)
+    monkeypatch.setattr(transformer_config_module, "is_te_min_version", lambda *_args: False)
+    monkeypatch.setattr(transformer_config_module, "get_te_version", lambda: Version("2.8.0"))
+
+    with pytest.raises(ValueError, match="requires Transformer Engine >= 2.9.0"):
+        _sequence_packing_config()
+
+
+def test_sequence_packing_scheduler_requires_packaging(monkeypatch):
+    monkeypatch.setattr(transformer_config_module, "HAVE_PACKAGING", False)
+
+    with pytest.raises(ImportError, match="packaging is not installed"):
+        _sequence_packing_config()
+
+
+def test_sequence_packing_scheduler_allows_supported_te_development_version(monkeypatch):
+    monkeypatch.setattr(transformer_config_module, "HAVE_PACKAGING", True)
+    monkeypatch.setattr(transformer_config_module, "is_te_min_version", lambda *_args: False)
+    monkeypatch.setattr(
+        transformer_config_module, "get_te_version", lambda: Version("2.9.0.dev0+5b3092a")
+    )
+
+    config = _sequence_packing_config()
+
+    assert config.variable_seq_lengths is True
+
+
+def test_sequence_packing_scheduler_enables_variable_sequence_lengths(monkeypatch):
+    monkeypatch.setattr(transformer_config_module, "HAVE_PACKAGING", True)
+    monkeypatch.setattr(transformer_config_module, "is_te_min_version", lambda *_args: True)
+
+    config = _sequence_packing_config()
+
+    assert config.sequence_packing_scheduler == "dp_balanced"
+    assert config.variable_seq_lengths is True


### PR DESCRIPTION
Part 3 of the split of #3386. Original changes by @xiaoyao0115 (tailaim); this version is ported to current `main` and incorporates the review feedback.

## What changed

- Add a flat, typed `sequence_packing_scheduler` field with the supported `dp_balanced` value.
- Validate the scheduler name and positive integer rank capacity in `ModelParallelConfig`.
- Require the all-to-all MoE dispatcher and Transformer Engine 2.9+ in `TransformerConfig`.
- Enable variable sequence lengths only after scheduler validation succeeds.
- Keep the field out of the generated CLI until the training integration PR lands.
- Add coverage for invalid types, missing packaging, supported TE development builds, defaults, and CLI exclusion.

## Why

The original PR placed nested/JSON-string configuration in dataset config. This PR keeps scheduler configuration flat and typed, with deterministic validation and no dataset-specific configuration coupling.

## Validation

- Black, isort, Ruff, Pylint, `py_compile`, and `git diff --check`: passed.
- Focused pytest command: `pytest -q tests/unit_tests/transformer/test_transformer_config.py tests/unit_tests/test_argument_utils.py -k sequence_packing`.
- Local pytest collection is blocked because this host environment does not provide PyTorch (`ModuleNotFoundError: torch`); runtime coverage is delegated to CI.

## Split series

- #5563 — padding-mask SP fix
- #5560 — core scheduler and batch utilities
- #5562 — packing scheduler config
- #5561 — typed SFT/varlen producers
- Training integration follows after these land, keeping its CODEOWNERS scope isolated.