### PR TITLE
[dev] moe(perf): Add FlashQLA backend for Hopper/SM90 gated delta net (GDN).

### DIFF
--- a/megatron/core/ssm/gated_delta_net.py
+++ b/megatron/core/ssm/gated_delta_net.py
@@ -8,7 +8,7 @@
 import logging
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import Optional, Union
+from typing import Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
@@ -60,6 +60,117 @@ except ImportError:
 
 
 logger = logging.getLogger(__name__)
+
+
+_GATED_DELTA_RULE_BACKEND_SUPPORTS_DETERMINISTIC_MODE = {
+    # External fused backends are guarded as not deterministic-mode certified
+    # until bitwise determinism is validated under Megatron.
+    "fla": False,
+    "flash_qla": False,
+    "torch": True,
+}
+_FLASH_QLA_SUPPORTED_CUDA_CAPABILITIES = ((9, 0), (10, 0), (12, 0))
+
+
+def _assert_gated_delta_rule_backend_supports_deterministic_mode(
+    backend: str, deterministic_mode: bool
+) -> None:
+    """Validate deterministic-mode support for a Gated Delta Rule backend."""
+    if backend not in _GATED_DELTA_RULE_BACKEND_SUPPORTS_DETERMINISTIC_MODE:
+        raise ValueError(f"Unsupported gated_delta_rule_backend: {backend!r}.")
+    if (
+        deterministic_mode
+        and not _GATED_DELTA_RULE_BACKEND_SUPPORTS_DETERMINISTIC_MODE[backend]
+    ):
+        raise ValueError(
+            "deterministic_mode=True requires a deterministic GatedDeltaNet gated "
+            "delta rule backend. Set gated_delta_rule_backend='torch' instead of "
+            f"{backend!r}."
+        )
+
+
+def _current_cuda_device_capability() -> Optional[Tuple[int, int]]:
+    """Return the active CUDA device capability, or None when CUDA is unavailable."""
+    if not torch.cuda.is_available():
+        return None
+    return torch.cuda.get_device_capability(torch.cuda.current_device())
+
+
+def _load_flash_qla_chunk_gated_delta_rule():
+    """Import FlashQLA lazily so unsupported runs can still import this module."""
+    try:
+        from flash_qla import chunk_gated_delta_rule as flash_qla_chunk_gated_delta_rule
+    except (ImportError, RuntimeError, ValueError) as exc:
+        raise ImportError(
+            "FlashQLA gated delta rule backend requires the `flash_qla` package "
+            "on a supported Hopper/Blackwell CUDA device."
+        ) from exc
+
+    def _flash_qla_chunk_gated_delta_rule_adapter(*args, cp_context=None, **kwargs):
+        """Adapt FlashQLA to the FLA-like call signature used by GatedDeltaNet."""
+        cu_seqlens_cpu = kwargs.pop("cu_seqlens_cpu", None)
+        if cp_context is not None:
+            raise ValueError(
+                "FlashQLA gated delta rule backend does not support chunkwise "
+                "inter-card context parallelism. Use gated_delta_rule_backend='fla' "
+                "with linear_cp_mode='chunkwise', or use FlashQLA only with "
+                "linear_cp_mode='headwise'."
+            )
+        if cu_seqlens_cpu is not None:
+            raise ValueError("FlashQLA gated delta rule backend does not use cu_seqlens_cpu.")
+        return flash_qla_chunk_gated_delta_rule(*args, **kwargs)
+
+    return _flash_qla_chunk_gated_delta_rule_adapter
+
+
+def _select_gated_delta_rule_backend(
+    backend: str,
+    *,
+    deterministic_mode: bool,
+    cp_size: int,
+    key_head_dim: int,
+    value_head_dim: int,
+    linear_cp_mode: Optional[str] = None,
+):
+    """Return the callable implementing the requested Gated Delta Rule backend."""
+    _assert_gated_delta_rule_backend_supports_deterministic_mode(
+        backend, deterministic_mode
+    )
+
+    if backend == "torch":
+        return torch_chunk_gated_delta_rule
+
+    if backend == "fla":
+        if not HAVE_FLA:
+            raise ImportError(
+                "FLA gated delta rule backend requires `flash-linear-attention`."
+            )
+        return chunk_gated_delta_rule
+
+    if backend == "flash_qla":
+        if cp_size != 1 and linear_cp_mode != "headwise":
+            raise ValueError(
+                "FlashQLA gated delta rule backend is currently guarded to "
+                "context_parallel_size=1 for chunkwise CP. Use "
+                "gated_delta_rule_backend='fla' with linear_cp_mode='chunkwise', "
+                "or set linear_cp_mode='headwise' for FlashQLA."
+            )
+        if key_head_dim != 128 or value_head_dim != 128:
+            raise ValueError(
+                "FlashQLA gated delta rule backend currently requires "
+                f"linear_key_head_dim=128 and linear_value_head_dim=128, got "
+                f"{key_head_dim=} and {value_head_dim=}."
+            )
+        capability = _current_cuda_device_capability()
+        if capability not in _FLASH_QLA_SUPPORTED_CUDA_CAPABILITIES:
+            raise ValueError(
+                "FlashQLA gated delta rule backend is supported only on Hopper/Blackwell "
+                f"SM90/SM100/SM120 ({_FLASH_QLA_SUPPORTED_CUDA_CAPABILITIES}); "
+                f"got {capability}. Use gated_delta_rule_backend='fla' on other GPUs."
+            )
+        return _load_flash_qla_chunk_gated_delta_rule()
+
+    raise ValueError(f"Unsupported gated_delta_rule_backend: {backend!r}.")
 
 
 @dataclass
@@ -131,6 +242,7 @@ class GatedDeltaNet(MegatronModule):
         self.tp_size = self.pg_collection.tp.size()
         self.sp_size = self.tp_size if config.sequence_parallel else 1
         self.gdn_pre_gated_delta_rule_fusion = config.gdn_pre_gated_delta_rule_fusion
+        self.gated_delta_rule_backend = config.gated_delta_rule_backend
 
         # Attributes from config
         self.config = config
@@ -241,10 +353,14 @@ class GatedDeltaNet(MegatronModule):
         setattr(self.A_log, "tensor_model_parallel", True)
         setattr(self.A_log, "partition_dim", 0)
 
-        if self.config.deterministic_mode:
-            self.gated_delta_rule = torch_chunk_gated_delta_rule
-        else:
-            self.gated_delta_rule = chunk_gated_delta_rule
+        self.gated_delta_rule = _select_gated_delta_rule_backend(
+            self.gated_delta_rule_backend,
+            deterministic_mode=self.config.deterministic_mode,
+            cp_size=self.cp_size,
+            key_head_dim=self.key_head_dim,
+            value_head_dim=self.value_head_dim,
+            linear_cp_mode=self.config.linear_cp_mode,
+        )
 
         # Output layernorm before projection
         self.out_norm = build_module(
@@ -1310,8 +1426,8 @@ def torch_chunk_gated_delta_rule(
 ):
     # pylint: disable=line-too-long
     '''
-    Torch-native implementation of chunked gated delta rule for deterministic mode.
-    Need this because FLA is not deterministic.
+    Torch-native implementation of chunked gated delta rule.
+    This backend is deterministic and is intended for deterministic mode.
 
     Reference: https://github.com/huggingface/transformers/blob/144c8ce2809a2e21914017652700e1ecb450501e/src/transformers/models/qwen3_next/modeling_qwen3_next.py#L470-L547
     '''

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -391,6 +391,9 @@ class TransformerConfig(ModelParallelConfig):
     This is only valid without chunkwise CP: padding a chunk-local causal-conv input changes
     the sequence seen by later chunks and therefore changes the GDN recurrence numerics."""
 
+    gated_delta_rule_backend: Literal["fla", "flash_qla", "torch"] = "fla"
+    """Backend for the GatedDeltaNet gated delta rule."""
+
     ####################
     # initialization
     ####################
@@ -1552,7 +1555,33 @@ class TransformerConfig(ModelParallelConfig):
                     "cp_partition_mode='contiguous' currently is only supported with dsv4_hybrid."
                 )
 
+        valid_gdr_backends = ("fla", "flash_qla", "torch")
+        if self.gated_delta_rule_backend not in valid_gdr_backends:
+            raise ValueError(
+                "gated_delta_rule_backend must be one of "
+                f"{valid_gdr_backends}, got {self.gated_delta_rule_backend!r}."
+            )
+        if (
+            self.gated_delta_rule_backend != "fla"
+            and self.experimental_attention_variant != "gated_delta_net"
+        ):
+            raise ValueError(
+                "gated_delta_rule_backend can select a non-default backend only when "
+                "experimental_attention_variant='gated_delta_net'."
+            )
+
         if self.experimental_attention_variant in ["gated_delta_net"]:
+            nondeterministic_gdr_backends = ("fla", "flash_qla")
+            if (
+                self.deterministic_mode
+                and self.gated_delta_rule_backend in nondeterministic_gdr_backends
+            ):
+                raise ValueError(
+                    "deterministic_mode=True requires a deterministic GatedDeltaNet "
+                    "gated delta rule backend. Set gated_delta_rule_backend='torch' "
+                    f"instead of {self.gated_delta_rule_backend!r}."
+                )
+
             assert (
                 self.linear_attention_freq is not None
             ), f"linear_attention_freq must be set for linear attention."

--- a/tests/unit_tests/ssm/test_gated_delta_net.py
+++ b/tests/unit_tests/ssm/test_gated_delta_net.py
@@ -19,6 +19,7 @@ from megatron.core.models.gpt.experimental_attention_variant_module_specs import
 from megatron.core.models.gpt.gpt_model import GPTModel
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.ssm import gated_delta_net as gdn_module
 from megatron.core.ssm.gated_delta_net import (
     GatedDeltaNet,
     _build_head_perm_for_split_sections,
@@ -145,6 +146,106 @@ def test_gdn_headwise_cp_head_divisibility_includes_cp_size():
             linear_cp_mode="headwise",
             linear_num_key_heads=4,
             linear_num_value_heads=8,
+        )
+
+
+@pytest.mark.parametrize("gated_delta_rule_backend", ["fla", "flash_qla", "torch"])
+def test_gated_delta_rule_backend_accepts_gdn_modes(gated_delta_rule_backend):
+    config = _make_gdn_config(gated_delta_rule_backend=gated_delta_rule_backend)
+    assert config.gated_delta_rule_backend == gated_delta_rule_backend
+
+
+def test_gated_delta_rule_backend_rejects_invalid_value():
+    with pytest.raises(ValueError, match="gated_delta_rule_backend must be one of"):
+        _make_gdn_config(gated_delta_rule_backend="flashinfer")
+
+
+def test_gated_delta_rule_backend_requires_gdn_variant_for_non_default():
+    with pytest.raises(ValueError, match="experimental_attention_variant='gated_delta_net'"):
+        _make_gdn_config(
+            experimental_attention_variant=None,
+            linear_attention_freq=None,
+            gated_delta_rule_backend="torch",
+        )
+
+
+@pytest.mark.parametrize("gated_delta_rule_backend", ["fla", "flash_qla"])
+def test_gated_delta_rule_backend_rejects_uncertified_deterministic_mode(
+    gated_delta_rule_backend,
+):
+    with pytest.raises(ValueError, match="deterministic_mode=True"):
+        _make_gdn_config(
+            deterministic_mode=True,
+            gated_delta_rule_backend=gated_delta_rule_backend,
+        )
+
+
+def test_gated_delta_rule_backend_allows_torch_deterministic_mode():
+    config = _make_gdn_config(
+        deterministic_mode=True,
+        gated_delta_rule_backend="torch",
+    )
+    assert config.gated_delta_rule_backend == "torch"
+
+
+def test_torch_gated_delta_rule_backend_selector():
+    backend = gdn_module._select_gated_delta_rule_backend(
+        "torch",
+        deterministic_mode=True,
+        cp_size=1,
+        key_head_dim=128,
+        value_head_dim=128,
+    )
+    assert backend is gdn_module.torch_chunk_gated_delta_rule
+
+
+def test_flash_qla_gated_delta_rule_backend_rejects_chunkwise_cp():
+    with pytest.raises(ValueError, match="chunkwise CP"):
+        gdn_module._select_gated_delta_rule_backend(
+            "flash_qla",
+            deterministic_mode=False,
+            cp_size=2,
+            key_head_dim=128,
+            value_head_dim=128,
+            linear_cp_mode="chunkwise",
+        )
+
+
+def test_flash_qla_gated_delta_rule_backend_allows_headwise_cp(monkeypatch):
+    sentinel = object()
+    monkeypatch.setattr(gdn_module, "_current_cuda_device_capability", lambda: (10, 0))
+    monkeypatch.setattr(gdn_module, "_load_flash_qla_chunk_gated_delta_rule", lambda: sentinel)
+    backend = gdn_module._select_gated_delta_rule_backend(
+        "flash_qla",
+        deterministic_mode=False,
+        cp_size=2,
+        key_head_dim=128,
+        value_head_dim=128,
+        linear_cp_mode="headwise",
+    )
+    assert backend is sentinel
+
+
+def test_flash_qla_gated_delta_rule_backend_rejects_non_128_head_dim():
+    with pytest.raises(ValueError, match="linear_key_head_dim=128"):
+        gdn_module._select_gated_delta_rule_backend(
+            "flash_qla",
+            deterministic_mode=False,
+            cp_size=1,
+            key_head_dim=64,
+            value_head_dim=128,
+        )
+
+
+def test_flash_qla_gated_delta_rule_backend_rejects_unsupported_gpu(monkeypatch):
+    monkeypatch.setattr(gdn_module, "_current_cuda_device_capability", lambda: (8, 0))
+    with pytest.raises(ValueError, match="SM90/SM100/SM120"):
+        gdn_module._select_gated_delta_rule_backend(
+            "flash_qla",
+            deterministic_mode=False,
+            cp_size=1,
+            key_head_dim=128,
+            value_head_dim=128,
         )
 
 
@@ -602,6 +703,7 @@ class TestFusedPreGatedDeltaRule:
             transformer_impl="transformer_engine",
             deterministic_mode=deterministic_mode,
             gdn_pre_gated_delta_rule_fusion=gdn_pre_gated_delta_rule_fusion,
+            gated_delta_rule_backend="torch" if deterministic_mode else "fla",
         )
         gdn_submodules = get_experimental_attention_variant_module_spec(
             config=transformer_config


### PR DESCRIPTION
- [ ] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do ?
<!-- Add a one line overview of what this PR aims to accomplish. -->

- **Add a guarded FlashQLA backend for Hopper/SM90 GDN runs.**
- Add `gated_delta_rule_backend` for GatedDeltaNet with `fla`, `flash_qla`, and `torch` options.
  - Stop using `deterministic_mode` to choose the Gated Delta Rule backend. Deterministic mode now validates whether the selected backend is allowed.
  - Keep FLA as the default backend and keep torch-native as the explicit deterministic backend.

## Benchmarks

GDN shapes from Qwen3.5 recipes:

  | Model | Linear q/k heads | Linear v heads | q/k dim | v dim | LA freq | Max seq |
  | --- | ---: | ---: | ---: | ---: | ---: | ---: |
  | Qwen3.5-35B-A3B | 16 | **32** | 128 | 128 | 4 | 262144 |
  | Qwen3.5-397B-A17B | 16 | **64** | 128 | 128 | 4 | 262144 |

Hopper platform gated delta rule speedup (FlashQLA vs FLA):

| model | seq len | fwd speedup | bwd speedup | total speedup |
  |---|---:|---:|---:|---:|
  | Qwen3.5-35B-A3B | 4096 | 2.064x | 1.211x | 1.374x |
  | Qwen3.5-35B-A3B | 16384 | 2.840x | 1.225x | 1.455x |
  | Qwen3.5-35B-A3B | 65536 | 3.493x | 1.231x | 1.505x |
  | Qwen3.5-397B-A17B | 4096 | 3.270x | 2.085x | 2.326x |
  | Qwen3.5-397B-A17B | 16384 | 3.468x | 2.162x | 2.415x |
  | Qwen3.5-397B-A17B | 65536 | 3.666x | 2.209x | 2.485x |

E2E training speedup on Hopper, FLA vs FlashQLA

| Model | run | median iter | median TFLOP/s/GPU | peak memory allocated |
|---|---|---:|---:|---:|
  | Qwen3.5-35B-A3B | FLA | 70.8967s | 165.8 | 47,937 MB |
  | Qwen3.5-35B-A3B | FlashQLA | 67.4084s | 174.4 (1.05x) | 45,157 MB |

## Convergence Test

FlashQLA is in green; FLA (baseline) is in orange.

<img width="1435" height="805" alt="image" src="https://github.com/user-attachments/assets/c7946377-e82f-47ac-ac18-efc3b08652e2" />

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
