### PR TITLE
Fix `isort` target Python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -236,7 +236,7 @@ mamba-ssm = { git = "https://github.com/state-spaces/mamba.git", rev = "0048fbf2
 [tool.isort]
 profile = "black"                                                          # black-compatible
 line_length = 100                                                          # should match black parameters
-py_version = 310                                                           # python 3.10 as a target version
+py_version = 312                                                           # python 3.12 as a target version
 known_first_party = ["megatron"]                                           # FIRSTPARTY section
 known_third_party = ["transformer_engine"]                                 # THIRDPARTY section
 sections = ["FUTURE", "STDLIB", "THIRDPARTY", "FIRSTPARTY", "LOCALFOLDER"]


### PR DESCRIPTION
Now `isort` target Python version matches `requires-python` again, meaning that packages like `tomllib` will be correctly included in the stdlib import section.

- [X] I, the PR author, have personally reviewed every line of this PR.
