### PR TITLE
[dev] Sync Megatron Lite with the latest implementation

### DIFF
--- a/experimental/lite/examples/bench/correctness.py
+++ b/experimental/lite/examples/bench/correctness.py
@@ -235,6 +235,8 @@ def _activation_probe_context(handle, probe_names: list[str], *, record_grad: bo
 
 
 def _update_hash_with_tensor(h: Any, name: str, tensor: torch.Tensor) -> None:
+    if hasattr(tensor, "to_local"):
+        tensor = tensor.to_local()
     t = tensor.detach().contiguous().cpu()
     h.update(name.encode("utf-8"))
     h.update(b"\0")
@@ -286,7 +288,7 @@ def _weight_fingerprint(rt, handle) -> dict[str, Any]:
     count = 0
     details = []
     include_details = os.environ.get("MLITE_CORRECTNESS_WEIGHT_DETAILS") == "1"
-    for name, tensor in sorted(rt.export_weights(handle, cpu=True), key=lambda item: item[0]):
+    for name, tensor in sorted(rt.export_weights(handle), key=lambda item: item[0]):
         _update_hash_with_tensor(h, str(name), tensor)
         if include_details:
             detail = _hash_tensor(tensor)
@@ -308,7 +310,8 @@ def _forward_logits(rt, handle, batch: Any) -> torch.Tensor | None:
         num_microbatches=1,
         forward_only=True,
     )
-    return result.model_output.vocab_parallel_logits
+    output = result.model_output
+    return output.vocab_parallel_logits if output.vocab_parallel_logits is not None else (-output.log_probs if output.log_probs is not None else None)
 
 
 def run_backend(
@@ -345,7 +348,8 @@ def run_backend(
                     handle, data_iter, loss_fn=None, num_microbatches=session_cfg.num_microbatches
                 )
                 _sync(session_cfg.device)
-                logits = _hash_tensor(result.model_output.vocab_parallel_logits)
+                output = result.model_output
+                logits = _hash_tensor(output.vocab_parallel_logits if output.vocab_parallel_logits is not None else (-output.log_probs if output.log_probs is not None else None))
                 grads = _grad_fingerprint(handle)
 
                 if session_cfg.no_optimizer:
@@ -354,11 +358,14 @@ def run_backend(
                     update_successful, grad_norm, num_zeros = rt.optimizer_step(handle)
                     rt.lr_scheduler_step(handle)
                 _sync(session_cfg.device)
+                loss = result.metrics.get("loss")
+                if loss is None:
+                    loss = result.model_output.loss
 
             steps.append(
                 {
                     "step": step,
-                    "loss": _scalar(result.metrics.get("loss", 0.0)),
+                    "loss": _scalar(0.0 if loss is None else loss),
                     "logits": logits,
                     "grad_fingerprint": grads,
                     "grad_norm": _scalar(grad_norm),

--- a/experimental/lite/examples/bench/session.py
+++ b/experimental/lite/examples/bench/session.py
@@ -206,7 +206,7 @@ def run_pretrain_session(
             )
             trace = StepTrace(
                 step=step,
-                loss=float(result.metrics.get("loss", 0.0)),
+                loss=float(result.metrics.get("loss", result.model_output.loss) or 0.0),
                 grad_norm=float(grad_norm),
                 step_ms=elapsed_ms,
                 peak_mem_gb=_peak_memory_gb(cfg.device),

--- a/experimental/lite/examples/miles/README.md
+++ b/experimental/lite/examples/miles/README.md
@@ -1,0 +1,66 @@
+# Miles Megatron Lite Example
+
+This example runs radixark/miles with Megatron Lite as the training actor by
+applying the miles runtime patch from
+`experimental/lite/examples/miles/miles_mlite/backend_patch.py`.
+
+The patch intentionally keeps `--train-backend megatron`: miles imports
+`MegatronTrainRayActor` from its Megatron backend module inside the actor
+allocation path, so replacing that source symbol before allocation routes the
+existing Megatron slot to `MLiteTrainRayActor` without changing miles code or CLI
+choices.
+
+## Layout
+
+- `miles_mlite/launch.py`: registers MLite CLI flags, optionally imports the
+  patch, parses miles arguments, and calls the normal miles train loop.
+- `scripts/run_qwen3moe_sft.sh`: short SFT launcher for Qwen3-30B-A3B style
+  MoE checkpoints.
+- `scripts/run_qwen3moe_grpo.sh`: GRPO launcher using miles rollout and MLite
+  policy-loss training.
+- `REQUIRED_MILES.txt`: source commit pinned for the miles API shape.
+
+## SFT
+
+Run inside a Slurm GPU allocation/container with miles, Megatron-LM, and
+Megatron Lite importable:
+
+```bash
+export MILES_ROOT=/path/to/miles
+export MEGATRON_ROOT=/path/to/full/Megatron-LM  # if Megatron-Core is not installed
+export MODEL_PATH=/path/to/Qwen3-30B-A3B
+export TRAIN_DATA=/path/to/messages.parquet
+export CONTAINER_IMAGE=/path/to/miles.sqsh
+bash experimental/lite/examples/miles/scripts/run_qwen3moe_sft.sh
+```
+
+Useful knobs:
+
+- `TP_SIZE`, `PP_SIZE`, `CP_SIZE`, `EP_SIZE`, `ETP_SIZE`
+- `GLOBAL_BATCH_SIZE`, `ROLLOUT_BATCH_SIZE`, `MAX_TOKENS_PER_GPU`
+- `OPTIMIZER_OFFLOAD=1`, `PARAM_OFFLOAD=1`
+- `MLITE_MODEL_NAME=qwen3_moe`, `MLITE_OPTIMIZER_BACKEND=dist_opt`
+- `TRAIN_BACKEND=mlite` uses the patch; `TRAIN_BACKEND=megatron` leaves the
+  native miles Megatron actor untouched for A/B runs.
+- `DRY_RUN=1` prints the resolved Ray job command without launching
+
+## GRPO
+
+```bash
+export MILES_ROOT=/path/to/miles
+export MEGATRON_ROOT=/path/to/full/Megatron-LM  # if Megatron-Core is not installed
+export MODEL_PATH=/path/to/Qwen3-30B-A3B
+export PROMPT_DATA=/path/to/prompts.jsonl
+export CONTAINER_IMAGE=/path/to/miles.sqsh
+bash experimental/lite/examples/miles/scripts/run_qwen3moe_grpo.sh
+```
+
+The GRPO launcher selects `--loss-type policy_loss`,
+`--advantage-estimator grpo`, `--use-rollout-logprobs`, and
+`--megatron-to-hf-mode raw`. MLite exports HF-format weights directly, so the
+rollout resync path bypasses mbridge conversion and sends raw HF tensors through
+miles update-weight APIs.
+
+GPU validation should be run through Slurm. A successful smoke must use
+`DRY_RUN=0`, finish with `sacct` exit code `0:0`, and show real training loss
+progression in the Slurm log.

--- a/experimental/lite/examples/miles/REQUIRED_MILES.txt
+++ b/experimental/lite/examples/miles/REQUIRED_MILES.txt
@@ -1,0 +1,11 @@
+radixark/miles source reference for this example.
+
+Repository: https://github.com/radixark/miles
+Branch: main
+Commit: 55c8d8b22f82a5afa0db69b758e5df281c6f8f2d
+
+The runtime patch relies on miles.ray.actor_group importing
+miles.backends.megatron_utils.actor.MegatronTrainRayActor inside actor
+allocation, and on miles.ray.train_actor.TrainRayActor exposing init, train,
+save_model, update_weights, sleep, wake_up, connect_actor_critic, and
+_get_parallel_config.

--- a/experimental/lite/examples/miles/miles_mlite/__init__.py
+++ b/experimental/lite/examples/miles/miles_mlite/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Miles launcher helpers for the Megatron Lite backend patch."""

--- a/experimental/lite/examples/miles/miles_mlite/arguments.py
+++ b/experimental/lite/examples/miles/miles_mlite/arguments.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Megatron Lite flags for miles launchers."""
+
+from __future__ import annotations
+
+_OPTIMIZER_BACKEND_TO_IMPL = {
+    "dist_opt": "dist_opt",
+    "fsdp2": "fsdp2",
+}
+
+
+def optimizer_backend_to_impl(backend: str) -> str:
+    if backend not in _OPTIMIZER_BACKEND_TO_IMPL:
+        raise ValueError(
+            f"Unsupported --mlite-optimizer-backend {backend!r}; "
+            f"expected one of {sorted(_OPTIMIZER_BACKEND_TO_IMPL)}."
+        )
+    return _OPTIMIZER_BACKEND_TO_IMPL[backend]
+
+
+def add_mlite_arguments(parser):
+    """Register Megatron Lite flags on a miles parser."""
+    group = parser.add_argument_group(title="megatron-lite")
+    group.add_argument(
+        "--mlite-backend-patch",
+        action="store_true",
+        default=False,
+        help="Patch the miles Megatron actor slot to use Megatron Lite.",
+    )
+    group.add_argument(
+        "--mlite-model-name",
+        type=str,
+        default="auto",
+        help="Megatron Lite model registry name; 'auto' infers it from the HF config.",
+    )
+    group.add_argument(
+        "--mlite-impl",
+        type=str,
+        default="lite",
+        help="Megatron Lite model implementation variant.",
+    )
+    group.add_argument(
+        "--mlite-optimizer-backend",
+        type=str,
+        default="dist_opt",
+        choices=sorted(_OPTIMIZER_BACKEND_TO_IMPL),
+        help="Optimizer backend: dist_opt or fsdp2.",
+    )
+    group.add_argument(
+        "--mlite-attention-backend",
+        type=str,
+        default=None,
+        help="Override attention backend. Defaults to --attention-backend, then 'flash'.",
+    )
+    group.add_argument(
+        "--mlite-optimizer-offload",
+        action="store_true",
+        default=False,
+        help="Offload optimizer state to CPU via offload_fraction=1.0.",
+    )
+    group.add_argument(
+        "--mlite-param-offload",
+        action="store_true",
+        default=False,
+        help="Offload model parameters to CPU during training/rollout alternation.",
+    )
+    group.add_argument(
+        "--mlite-export-dtype",
+        type=str,
+        default=None,
+        choices=["bf16", "bfloat16", "fp16", "float16", "fp32", "float32", "float"],
+        help="Optional dtype cast when exporting HF-format rollout weights.",
+    )
+    return parser
+
+
+def validate_mlite_args(args) -> None:
+    if not getattr(args, "hf_checkpoint", None):
+        raise ValueError("--hf-checkpoint is required for the Megatron Lite backend patch.")
+    args.variable_seq_lengths = True
+    if not hasattr(args, "calculate_per_token_loss"):
+        args.calculate_per_token_loss = False
+    if not hasattr(args, "use_rollout_logprobs"):
+        args.use_rollout_logprobs = False

--- a/experimental/lite/examples/miles/miles_mlite/backend_patch.py
+++ b/experimental/lite/examples/miles/miles_mlite/backend_patch.py
@@ -1,0 +1,504 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Monkeypatch the miles Megatron train actor to use Megatron Lite.
+
+miles chooses its train actor by a function-local import of
+``miles.backends.megatron_utils.actor.MegatronTrainRayActor``. Replacing that
+source symbol before actor-group construction lets the example use the existing
+``--train-backend megatron`` slot without changing miles code or CLI choices.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import shutil
+import sys
+from argparse import Namespace
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+import torch
+from miles.ray.train_actor import TrainRayActor as _MilesTrainRayActor
+
+from .arguments import optimizer_backend_to_impl, validate_mlite_args
+from .data import build_runtime_microbatches
+from .loss import make_runtime_loss_fn
+from .weight_update import RawHFWeightUpdater
+
+logger = logging.getLogger(__name__)
+
+
+def _env_flag(name: str, default: bool = False) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.lower() in {"1", "true", "yes", "on"}
+
+
+def _rank() -> int:
+    if torch.distributed.is_available() and torch.distributed.is_initialized():
+        return torch.distributed.get_rank()
+    return 0
+
+
+def _barrier() -> None:
+    if torch.distributed.is_available() and torch.distributed.is_initialized():
+        torch.distributed.barrier()
+
+
+def _iter_local_parameters(handle):
+    model_chunks = handle._extras.get("model_chunks", [handle._model])
+    for chunk_id, chunk in enumerate(model_chunks):
+        for name, param in chunk.named_parameters():
+            yield f"{chunk_id}:{name}", param
+
+
+def _install_set_input_tensor_proxy(handle) -> None:
+    for chunk in handle._extras.get("model_chunks", [handle._model]):
+        if hasattr(chunk, "set_input_tensor"):
+            continue
+        module = getattr(chunk, "module", None)
+        setter = getattr(module, "set_input_tensor", None)
+        if not callable(setter):
+            continue
+        try:
+            setattr(chunk, "set_input_tensor", setter)
+        except Exception:
+            object.__setattr__(chunk, "set_input_tensor", setter)
+
+
+def _capture_checkpoint_probe(handle):
+    fallback = None
+    for key, param in _iter_local_parameters(handle):
+        if fallback is None:
+            fallback = (key, param)
+        if "norm" in key and param.numel() <= 1_000_000:
+            return key, param.detach().float().cpu().clone()
+    if fallback is None:
+        return None, None
+    key, param = fallback
+    return key, param.detach().float().cpu().clone()
+
+
+def _find_local_parameter(handle, key: str):
+    for candidate_key, param in _iter_local_parameters(handle):
+        if candidate_key == key:
+            return param
+    return None
+
+
+def _clear_checkpoint_contents(path: str) -> None:
+    root = Path(path)
+    root.mkdir(parents=True, exist_ok=True)
+    for child in root.iterdir():
+        if child.name == "ray_done":
+            continue
+        if child.is_dir():
+            shutil.rmtree(child)
+        else:
+            child.unlink()
+
+
+def _looks_like_mlite_checkpoint(path: str) -> bool:
+    root = Path(path)
+    if root.name.startswith("step_"):
+        return (root / "metadata.json").exists() or (root / "common.pt").exists()
+    if not root.is_dir():
+        return False
+    for child in root.iterdir():
+        if child.name.startswith("step_") and child.is_dir():
+            return True
+    return (root / "metadata.json").exists() or (root / "common.pt").exists()
+
+
+def _group(rank: int, size: int, group):
+    return SimpleNamespace(rank=rank, size=size, group=group, gloo_group=None)
+
+
+def _install_miles_parallel_state(ps) -> None:
+    try:
+        parallel_mod = importlib.import_module("miles.backends.training_utils.parallel")
+    except ImportError:
+        return
+    state = parallel_mod.ParallelState(
+        intra_dp=_group(ps.dp_rank, ps.dp_size, ps.dp_group),
+        intra_dp_cp=_group(getattr(ps, "dp_cp_rank", ps.dp_rank), getattr(ps, "dp_cp_size", ps.dp_size), getattr(ps, "dp_cp_group", ps.dp_group)),
+        cp=_group(ps.cp_rank, ps.cp_size, ps.cp_group),
+        tp=_group(ps.tp_rank, ps.tp_size, ps.tp_group),
+        pp=_group(ps.pp_rank, ps.pp_size, ps.pp_group),
+        ep=_group(getattr(ps, "ep_rank", 0), getattr(ps, "ep_size", 1), getattr(ps, "ep_group", None)),
+        etp=_group(getattr(ps, "etp_rank", 0), getattr(ps, "etp_size", 1), getattr(ps, "etp_group", None)),
+        cp_comm_type=getattr(ps, "cp_comm_type", None),
+        is_pp_last_stage=ps.pp_rank == ps.pp_size - 1,
+        vpp_size=1,
+        microbatch_group_size_per_vp_stage=1,
+    )
+    parallel_mod.set_parallel_state(state)
+
+
+class _MLiteTrainRayActorMixin:
+    def _build_mlite_config(self, args: Namespace):
+        from megatron.lite.runtime.backends.mlite.config import MegatronLiteConfig
+        from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig
+
+        validate_mlite_args(args)
+        parallel = ParallelConfig(
+            tp=args.tensor_model_parallel_size,
+            etp=getattr(args, "expert_tensor_parallel_size", None),
+            ep=getattr(args, "expert_model_parallel_size", 1),
+            pp=args.pipeline_model_parallel_size,
+            vpp=getattr(args, "virtual_pipeline_model_parallel_size", None) or 1,
+            cp=args.context_parallel_size,
+        )
+        optimizer = OptimizerConfig(
+            optimizer=args.optimizer,
+            lr=args.lr,
+            min_lr=args.min_lr if args.min_lr is not None else 0.0,
+            clip_grad=args.clip_grad,
+            weight_decay=args.weight_decay,
+            lr_decay_style=args.lr_decay_style,
+            adam_beta1=getattr(args, "adam_beta1", None),
+            adam_beta2=getattr(args, "adam_beta2", None),
+            adam_eps=getattr(args, "adam_eps", None),
+        )
+        if getattr(args, "mlite_optimizer_offload", False):
+            optimizer.offload_fraction = 1.0
+            optimizer.use_precision_aware_optimizer = True
+            optimizer.decoupled_weight_decay = True
+
+        attention_backend = args.mlite_attention_backend
+        if attention_backend is None:
+            raw = getattr(args, "attention_backend", None)
+            attention_backend = getattr(raw, "name", raw)
+        attention_backend = attention_backend or "flash"
+
+        return MegatronLiteConfig(
+            model_name=args.mlite_model_name,
+            impl=args.mlite_impl,
+            hf_path=args.hf_checkpoint,
+            parallel=parallel,
+            optimizer=optimizer,
+            attention_backend_override=attention_backend,
+            load_hf_weights=True,
+            impl_cfg={
+                "use_thd": True,
+                "optimizer": optimizer_backend_to_impl(args.mlite_optimizer_backend),
+            },
+        )
+
+    def init(
+        self,
+        args: Namespace,
+        role: str,
+        with_ref: bool = False,
+        with_opd_teacher: bool = False,
+    ) -> int | None:
+        super().init(args, role, with_ref, with_opd_teacher=with_opd_teacher)
+        if role != "actor":
+            raise NotImplementedError("Megatron Lite miles backend supports actor training only.")
+        if with_ref or with_opd_teacher:
+            raise NotImplementedError("Reference/teacher model swapping is not implemented for the MLite patch.")
+
+        if args.debug_rollout_only:
+            self.args = args
+            return 0
+
+        from megatron.lite.runtime import RuntimeConfig, create_runtime
+
+        self._cfg = self._build_mlite_config(args)
+        self.runtime = create_runtime(
+            RuntimeConfig(backend="mlite", hf_path=args.hf_checkpoint, backend_cfg=self._cfg)
+        )
+        self.handle = self.runtime.build_model()
+        _install_set_input_tensor_proxy(self.handle)
+
+        ps = self.handle._parallel_state
+        _install_miles_parallel_state(ps)
+        self.train_parallel_config = {
+            "dp_size": ps.dp_size,
+            "cp_size": ps.cp_size,
+            "vpp_size": self._cfg.parallel.vpp or 1,
+            "microbatch_group_size_per_vp_stage": 1,
+        }
+        self.weight_updater = RawHFWeightUpdater(args, self.runtime, self.handle)
+
+        start_rollout_id = 0
+        if getattr(args, "load", None):
+            if _looks_like_mlite_checkpoint(args.load):
+                loaded = self.runtime.load_checkpoint(
+                    self.handle,
+                    args.load,
+                    load_optimizer=_env_flag("MLITE_LOAD_OPTIMIZER_CHECKPOINT", False),
+                    load_rng=_env_flag("MLITE_LOAD_RNG_CHECKPOINT", False),
+                )
+                if _env_flag("MLITE_RESET_ROLLOUT_AFTER_LOAD", False):
+                    start_rollout_id = 0
+                else:
+                    start_rollout_id = int(loaded) + 1
+                if _rank() == 0:
+                    logger.info(
+                        "MLITE_MILES_GRPO_INITIAL_LOAD_DONE path=%s loaded_step=%s start_rollout_id=%s",
+                        args.load,
+                        loaded,
+                        start_rollout_id,
+                    )
+            else:
+                if _rank() == 0:
+                    logger.info(
+                        "MLITE_MILES_GRPO_INITIAL_LOAD_SKIPPED path=%s reason=not_mlite_checkpoint",
+                        args.load,
+                    )
+
+        if getattr(args, "offload_train", False) or getattr(args, "mlite_param_offload", False):
+            self.sleep()
+        return start_rollout_id
+
+    def _process_rollout_data(self, rollout_data_ref):
+        data_mod = importlib.import_module("miles.utils.data")
+        ps = self.handle._parallel_state
+        rollout_data = data_mod.process_rollout_data(self.args, rollout_data_ref, ps.dp_rank, ps.dp_size)
+        rollout_data["tokens"] = [torch.as_tensor(t, dtype=torch.long) for t in rollout_data["tokens"]]
+        rollout_data["loss_masks"] = [torch.as_tensor(t, dtype=torch.float32) for t in rollout_data["loss_masks"]]
+        device = torch.device("cuda", torch.cuda.current_device())
+        for key in ("rollout_log_probs", "log_probs", "ref_log_probs", "advantages", "returns"):
+            if key in rollout_data and rollout_data[key] is not None:
+                rollout_data[key] = [
+                    torch.as_tensor(t, dtype=torch.float32, device=device).reshape(-1)
+                    for t in rollout_data[key]
+                ]
+        return rollout_data
+
+    def _compute_advantages_and_returns(self, rollout_data) -> None:
+        loss_mod = importlib.import_module("miles.backends.training_utils.loss")
+        loss_mod.compute_advantages_and_returns(self.args, rollout_data)
+
+    def _build_microbatches(self, rollout_data, *, calculate_entropy: bool = False):
+        return build_runtime_microbatches(
+            rollout_data,
+            micro_batch_size=getattr(self.args, "micro_batch_size", 1) or 1,
+            use_dynamic_batch_size=getattr(self.args, "use_dynamic_batch_size", False),
+            max_tokens_per_gpu=getattr(self.args, "max_tokens_per_gpu", 0) or 0,
+            calculate_entropy=calculate_entropy,
+            temperature=float(getattr(self.args, "rollout_temperature", 1.0) or 1.0),
+        )
+
+    def _compute_log_probs(self, rollout_data) -> list[torch.Tensor] | None:
+        microbatches = self._build_microbatches(
+            rollout_data,
+            calculate_entropy=bool(getattr(self.args, "use_rollout_entropy", False)),
+        )
+        if not microbatches:
+            return []
+        store: list[dict[str, list[torch.Tensor]]] = []
+        with self.runtime.eval_mode(self.handle):
+            self.runtime.forward_backward(
+                self.handle,
+                (mb.as_runtime_item() for mb in microbatches),
+                loss_fn=make_runtime_loss_fn(
+                    self.args,
+                    self.handle,
+                    forward_store=store,
+                    loss_context_iter=(mb.loss_context() for mb in microbatches),
+                ),
+                num_microbatches=len(microbatches),
+                forward_only=True,
+            )
+        if not store and not self.runtime.is_mp_src_rank_with_outputs(self.handle):
+            return None
+        return [item for micro in store for item in micro["log_probs"]]
+
+    def train(self, rollout_id: int, rollout_data_ref) -> None:
+        self._last_rollout_id = rollout_id
+        if getattr(self.args, "offload_train", False) or getattr(self.args, "mlite_param_offload", False):
+            self.wake_up()
+
+        rollout_data = self._process_rollout_data(rollout_data_ref)
+        if self.args.debug_rollout_only:
+            return None
+
+        loss_type = getattr(self.args, "loss_type", "sft_loss")
+        if loss_type == "policy_loss" and getattr(self.args, "compute_advantages_and_returns", True):
+            if not getattr(self.args, "use_rollout_logprobs", False) or getattr(self.args, "get_mismatch_metrics", False):
+                log_probs = self._compute_log_probs(rollout_data)
+                if log_probs is not None:
+                    rollout_data["log_probs"] = log_probs
+            elif "rollout_log_probs" not in rollout_data:
+                log_probs = self._compute_log_probs(rollout_data)
+                if log_probs is not None:
+                    rollout_data["log_probs"] = log_probs
+            elif _rank() == 0:
+                logger.info(
+                    "MLITE_MILES_GRPO_USING_ROLLOUT_LOGPROBS rollout=%s count=%s",
+                    rollout_id,
+                    len(rollout_data["rollout_log_probs"]),
+                )
+            self._compute_advantages_and_returns(rollout_data)
+
+        microbatches = self._build_microbatches(rollout_data)
+        if not microbatches:
+            logger.warning("rollout %s: empty data shard", rollout_id)
+            return None
+
+        with self.runtime.train_mode(self.handle):
+            self.runtime.zero_grad(self.handle)
+            result = self.runtime.forward_backward(
+                self.handle,
+                (mb.as_runtime_item() for mb in microbatches),
+                loss_fn=make_runtime_loss_fn(
+                    self.args,
+                    self.handle,
+                    loss_context_iter=(mb.loss_context() for mb in microbatches),
+                ),
+                num_microbatches=len(microbatches),
+                forward_only=False,
+            )
+            _, grad_norm, _ = self.runtime.optimizer_step(self.handle)
+            lr = self.runtime.lr_scheduler_step(self.handle)
+
+        logger.info(
+            "rollout %s | train/loss %s | grad_norm %.4f | lr %s | num_microbatches %s",
+            rollout_id,
+            result.metrics.get("loss"),
+            float(grad_norm),
+            lr,
+            len(microbatches),
+        )
+        return None
+
+    def save_model(self, rollout_id: int, force_sync: bool = False) -> None:
+        if self.args.debug_rollout_only:
+            return
+        save_dir = getattr(self.args, "save", None)
+        if not save_dir:
+            return
+        save_optimizer = _env_flag("MLITE_SAVE_OPTIMIZER_CHECKPOINT", False)
+        save_rng = _env_flag("MLITE_SAVE_RNG_CHECKPOINT", False)
+        verify_load = _env_flag("MLITE_VERIFY_CHECKPOINT_LOAD", True)
+        delete_after_load = _env_flag("MLITE_DELETE_CHECKPOINT_AFTER_LOAD", True)
+
+        probe_key, before = _capture_checkpoint_probe(self.handle)
+        self.runtime.save_checkpoint(
+            self.handle,
+            save_dir,
+            step=rollout_id,
+            save_optimizer=save_optimizer,
+            save_rng=save_rng,
+        )
+
+        max_abs = None
+        loaded = None
+        if verify_load:
+            loaded = self.runtime.load_checkpoint(
+                self.handle,
+                save_dir,
+                load_optimizer=save_optimizer,
+                load_rng=save_rng,
+            )
+            if probe_key is not None and before is not None:
+                after_param = _find_local_parameter(self.handle, probe_key)
+                if after_param is None:
+                    raise RuntimeError(f"checkpoint load probe parameter missing after load: {probe_key}")
+                after = after_param.detach().float().cpu()
+                max_abs = float(torch.max(torch.abs(after - before)).item())
+                if max_abs != 0.0:
+                    raise RuntimeError(
+                        f"checkpoint load probe mismatch for {probe_key}: max_abs={max_abs}"
+                    )
+
+        if _rank() == 0:
+            logger.info(
+                "MLITE_MILES_GRPO_SAVE_LOAD_DONE rollout=%s path=%s loaded_step=%s "
+                "probe=%s max_abs=%s save_optimizer=%s save_rng=%s",
+                rollout_id,
+                save_dir,
+                loaded,
+                probe_key,
+                max_abs,
+                save_optimizer,
+                save_rng,
+            )
+
+        _barrier()
+        if delete_after_load and _rank() == 0:
+            _clear_checkpoint_contents(save_dir)
+            logger.info("MLITE_MILES_GRPO_CHECKPOINT_CLEANED path=%s", save_dir)
+        _barrier()
+
+    def update_weights(self, info=None) -> None:
+        if self.args.debug_train_only or self.args.debug_rollout_only:
+            return
+        if info is None:
+            raise ValueError("update_weights requires rollout engine info from the miles rollout manager.")
+        if getattr(self.args, "offload_train", False) or getattr(self.args, "mlite_param_offload", False):
+            self.wake_up()
+
+        rollout_engines = info.rollout_engines
+        rollout_engine_lock = info.rollout_engine_lock
+        has_new_engines = info.has_new_engines
+        engine_gpu_counts = getattr(info, "engine_gpu_counts", None)
+        engine_gpu_offsets = getattr(info, "engine_gpu_offsets", None)
+        del info
+
+        if has_new_engines:
+            self.weight_updater.connect_rollout_engines(
+                rollout_engines,
+                rollout_engine_lock,
+                engine_gpu_counts=engine_gpu_counts,
+                engine_gpu_offsets=engine_gpu_offsets,
+            )
+            import ray
+
+            if torch.distributed.get_rank() == 0:
+                ray.get(self.rollout_manager.clear_updatable_has_new_engines.remote())
+
+        if getattr(self.args, "debug_skip_weight_update", False):
+            logger.warning("Skipping MLite actor-to-rollout weight update because --debug-skip-weight-update is set.")
+            return
+        self.weight_updater.update_weights()
+
+    def sleep(self, *args, **kwargs) -> None:
+        if not (getattr(self.args, "offload_train", False) or getattr(self.args, "mlite_param_offload", False)):
+            return
+        self.runtime.to(self.handle, "cpu")
+
+    def wake_up(self, *args, **kwargs) -> None:
+        if not (getattr(self.args, "offload_train", False) or getattr(self.args, "mlite_param_offload", False)):
+            return
+        self.runtime.to(self.handle, "cuda")
+
+    def connect_actor_critic(self, critic_group=None, **kwargs):
+        raise NotImplementedError("Megatron Lite miles backend does not support critic training yet.")
+
+    def _get_parallel_config(self):
+        return self.train_parallel_config
+
+
+class MLiteTrainRayActor(_MLiteTrainRayActorMixin, _MilesTrainRayActor):
+    """Megatron Lite TrainRayActor patched into miles."""
+
+
+def _load_or_synthesize_actor_module(import_error: ImportError) -> ModuleType:
+    module_name = "miles.backends.megatron_utils.actor"
+    actor_mod = ModuleType(module_name)
+    actor_mod.__package__ = "miles.backends.megatron_utils"
+    actor_mod.__doc__ = "Synthetic MLite actor patch module for miles."
+    sys.modules[module_name] = actor_mod
+
+    parent_mod = importlib.import_module(actor_mod.__package__)
+    setattr(parent_mod, "actor", actor_mod)
+    logger.warning("Using synthetic %s because the original module failed to import: %s", module_name, import_error)
+    return actor_mod
+
+
+def patch_miles_backend() -> type:
+    """Patch installed miles and return the patched actor class."""
+    importlib.import_module("miles")
+    try:
+        actor_mod = importlib.import_module("miles.backends.megatron_utils.actor")
+    except ImportError as exc:
+        actor_mod = _load_or_synthesize_actor_module(exc)
+    actor_mod.MegatronTrainRayActor = MLiteTrainRayActor
+    logger.info("Patched miles MegatronTrainRayActor with Megatron Lite.")
+    return MLiteTrainRayActor

--- a/experimental/lite/examples/miles/miles_mlite/config/qwen3moe.yaml
+++ b/experimental/lite/examples/miles/miles_mlite/config/qwen3moe.yaml
@@ -1,0 +1,12 @@
+# Reference settings consumed by the example shell launchers.
+model_name: qwen3_moe
+mlite_impl: lite
+train_backend: megatron
+megatron_to_hf_mode: raw
+optimizer_backend: dist_opt
+default_parallel:
+  tp: 2
+  pp: 1
+  cp: 1
+  ep: 8
+  etp: 1

--- a/experimental/lite/examples/miles/miles_mlite/data.py
+++ b/experimental/lite/examples/miles/miles_mlite/data.py
@@ -1,0 +1,180 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Rollout-data conversion for the miles MLite actor."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+from megatron.lite.runtime.contracts.data import PackedBatch
+from megatron.lite.runtime.contracts.loss import LossContext
+
+
+@dataclass(slots=True)
+class RuntimeMicroBatch:
+    runtime_batch: PackedBatch
+    source_batch: dict[str, Any]
+
+    def loss_context(self) -> LossContext:
+        return LossContext(
+            temperature=float(self.source_batch.get("temperature", 1.0)),
+            calculate_entropy=bool(self.source_batch.get("calculate_entropy", False)),
+            return_log_probs=True,
+            source_batch=self.source_batch,
+        )
+
+    def as_runtime_item(self):
+        return self.runtime_batch
+
+
+def _as_tensor_list(values, *, dtype, device) -> list[torch.Tensor]:
+    return [torch.as_tensor(v, dtype=dtype, device=device).reshape(-1) for v in values]
+
+
+def _optional_tensor_list(data: dict[str, Any], key: str, *, dtype, device) -> list[torch.Tensor] | None:
+    if key not in data or data[key] is None:
+        return None
+    return _as_tensor_list(data[key], dtype=dtype, device=device)
+
+
+def _group_microbatches(
+    total_lengths: list[int],
+    *,
+    micro_batch_size: int,
+    use_dynamic_batch_size: bool,
+    max_tokens_per_gpu: int,
+) -> list[list[int]]:
+    num_samples = len(total_lengths)
+    if num_samples == 0:
+        return []
+    if not use_dynamic_batch_size:
+        mbs = max(int(micro_batch_size), 1)
+        return [list(range(i, min(i + mbs, num_samples))) for i in range(0, num_samples, mbs)]
+
+    budget = max(int(max_tokens_per_gpu), 1)
+    groups: list[list[int]] = []
+    current: list[int] = []
+    current_tokens = 0
+    for idx, length in enumerate(total_lengths):
+        length = int(length)
+        if current and current_tokens + length > budget:
+            groups.append(current)
+            current = []
+            current_tokens = 0
+        current.append(idx)
+        current_tokens += length
+    if current:
+        groups.append(current)
+    return groups
+
+
+def response_mask_to_full(loss_mask: torch.Tensor, total_length: int, response_length: int) -> torch.Tensor:
+    prompt_length = total_length - response_length
+    if loss_mask.numel() != response_length:
+        raise ValueError(
+            f"response loss mask length {loss_mask.numel()} does not match response_length={response_length}."
+        )
+    return F.pad(loss_mask.float(), (prompt_length, 0), value=0.0)
+
+
+def response_mask_to_aligned_full(
+    loss_mask: torch.Tensor, total_length: int, response_length: int
+) -> torch.Tensor:
+    prompt_length = total_length - response_length
+    left_pad = max(prompt_length - 1, 0)
+    right_pad = total_length - response_length - left_pad
+    return F.pad(loss_mask.float(), (left_pad, right_pad), value=0.0)
+
+
+def _select(values: list[Any] | None, group: list[int]) -> list[Any] | None:
+    if values is None:
+        return None
+    return [values[i] for i in group]
+
+
+def _put_if_present(batch: dict[str, Any], key: str, values: list[Any] | None, group: list[int]) -> None:
+    selected = _select(values, group)
+    if selected is not None:
+        batch[key] = selected
+
+
+def build_runtime_microbatches(
+    rollout_data: dict[str, Any],
+    *,
+    micro_batch_size: int,
+    use_dynamic_batch_size: bool,
+    max_tokens_per_gpu: int,
+    calculate_entropy: bool = False,
+    temperature: float = 1.0,
+) -> list[RuntimeMicroBatch]:
+    """Build model-agnostic PackedBatch items plus loss-side source metadata."""
+    device = torch.device("cuda", torch.cuda.current_device())
+    tokens = _as_tensor_list(rollout_data["tokens"], dtype=torch.long, device=device)
+    response_loss_masks = _as_tensor_list(rollout_data["loss_masks"], dtype=torch.float32, device=device)
+    rollout_log_probs = _optional_tensor_list(rollout_data, "rollout_log_probs", dtype=torch.float32, device=device)
+    old_log_probs = _optional_tensor_list(rollout_data, "log_probs", dtype=torch.float32, device=device)
+    ref_log_probs = _optional_tensor_list(rollout_data, "ref_log_probs", dtype=torch.float32, device=device)
+    advantages = _optional_tensor_list(rollout_data, "advantages", dtype=torch.float32, device=device)
+    returns = _optional_tensor_list(rollout_data, "returns", dtype=torch.float32, device=device)
+
+    total_lengths = [int(x) for x in rollout_data["total_lengths"]]
+    response_lengths = [int(x) for x in rollout_data["response_lengths"]]
+    rewards = rollout_data.get("rewards")
+
+    groups = _group_microbatches(
+        total_lengths,
+        micro_batch_size=micro_batch_size,
+        use_dynamic_batch_size=use_dynamic_batch_size,
+        max_tokens_per_gpu=max_tokens_per_gpu,
+    )
+
+    microbatches: list[RuntimeMicroBatch] = []
+    for group in groups:
+        group_tokens = [tokens[i] for i in group]
+        group_total_lengths = [total_lengths[i] for i in group]
+        group_response_lengths = [response_lengths[i] for i in group]
+        group_response_masks = [response_loss_masks[i] for i in group]
+        full_masks = [
+            response_mask_to_full(mask, total, response)
+            for mask, total, response in zip(
+                group_response_masks, group_total_lengths, group_response_lengths, strict=True
+            )
+        ]
+        aligned_masks = [
+            response_mask_to_aligned_full(mask, total, response)
+            for mask, total, response in zip(
+                group_response_masks, group_total_lengths, group_response_lengths, strict=True
+            )
+        ]
+
+        flat_tokens = torch.cat(group_tokens, dim=0).contiguous()
+        runtime_batch = PackedBatch(
+            input_ids=flat_tokens,
+            labels=flat_tokens,
+            loss_mask=torch.cat(full_masks, dim=0).contiguous(),
+            seq_lens=torch.tensor(group_total_lengths, dtype=torch.int64, device=device),
+        )
+
+        source_batch: dict[str, Any] = {
+            "unconcat_tokens": group_tokens,
+            "total_lengths": group_total_lengths,
+            "response_lengths": group_response_lengths,
+            "loss_masks": group_response_masks,
+            "full_loss_masks": full_masks,
+            "aligned_loss_masks": aligned_masks,
+            "temperature": temperature,
+            "calculate_entropy": calculate_entropy,
+        }
+        _put_if_present(source_batch, "rollout_log_probs", rollout_log_probs, group)
+        _put_if_present(source_batch, "log_probs", old_log_probs, group)
+        _put_if_present(source_batch, "ref_log_probs", ref_log_probs, group)
+        _put_if_present(source_batch, "advantages", advantages, group)
+        _put_if_present(source_batch, "returns", returns, group)
+        if rewards is not None:
+            source_batch["rewards"] = [rewards[i] for i in group]
+
+        microbatches.append(RuntimeMicroBatch(runtime_batch, source_batch))
+
+    return microbatches

--- a/experimental/lite/examples/miles/miles_mlite/launch.py
+++ b/experimental/lite/examples/miles/miles_mlite/launch.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Launch miles with the Megatron Lite backend patch."""
+
+from __future__ import annotations
+
+import asyncio
+
+from miles.utils import arguments as miles_arguments
+from miles.utils.tracking_utils import finish_tracking
+from miles_mlite.arguments import add_mlite_arguments, validate_mlite_args
+
+
+def _patch_epsilon_alias_for_miles_validate() -> None:
+    original_validate = miles_arguments.hf_validate_args
+    if getattr(original_validate, "_mlite_epsilon_alias", False):
+        return
+
+    def validate_with_epsilon_alias(args, hf_config):
+        if hasattr(args, "norm_epsilon") and not hasattr(args, "layernorm_epsilon"):
+            args.layernorm_epsilon = args.norm_epsilon
+        if hasattr(args, "layernorm_epsilon") and not hasattr(args, "norm_epsilon"):
+            args.norm_epsilon = args.layernorm_epsilon
+        return original_validate(args, hf_config)
+
+    validate_with_epsilon_alias._mlite_epsilon_alias = True
+    miles_arguments.hf_validate_args = validate_with_epsilon_alias
+
+
+def _select_train_loop(args):
+    if getattr(args, "colocate", False):
+        from train import train
+    else:
+        from train_async import train
+    return train
+
+
+def main() -> None:
+    _patch_epsilon_alias_for_miles_validate()
+    args = miles_arguments.parse_args(add_custom_arguments=add_mlite_arguments)
+    if getattr(args, "mlite_backend_patch", False):
+        from miles_mlite.backend_patch import patch_miles_backend
+
+        patch_miles_backend()
+        validate_mlite_args(args)
+    train = _select_train_loop(args)
+    try:
+        asyncio.run(train(args))
+    finally:
+        finish_tracking()
+
+
+if __name__ == "__main__":
+    main()

--- a/experimental/lite/examples/miles/miles_mlite/loss.py
+++ b/experimental/lite/examples/miles/miles_mlite/loss.py
@@ -1,0 +1,168 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""External loss functions for the miles MLite actor."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from typing import Any
+
+import torch
+from megatron.lite.runtime.contracts.loss import LossContext
+
+
+def _nested_to_list(output: torch.Tensor, seq_lens: torch.Tensor) -> list[torch.Tensor]:
+    if getattr(output, "is_nested", False):
+        return [x.reshape(-1) for x in output.unbind()]
+    tensor = output
+    if tensor.dim() == 2 and tensor.size(0) == 1:
+        tensor = tensor.squeeze(0)
+    pieces = []
+    offset = 0
+    for length_t in seq_lens:
+        length = int(length_t.item())
+        pieces.append(tensor.narrow(0, offset, length).reshape(-1))
+        offset += length
+    return pieces
+
+
+def _unpack_output(handle, runtime_batch, output: torch.Tensor) -> list[torch.Tensor]:
+    proto = handle._extras.get("protocol")
+    unpack = getattr(proto, "unpack_forward_output", None)
+    if unpack is None:
+        raise ValueError("Model protocol must expose unpack_forward_output for miles losses.")
+    model = handle._model[0] if isinstance(handle._model, list | tuple) else handle._model
+    return _nested_to_list(unpack(model, runtime_batch, output), runtime_batch.seq_lens)
+
+
+def extract_response_log_probs(raw_output: dict[str, torch.Tensor], runtime_batch, source_batch, handle):
+    log_probs = raw_output.get("log_probs")
+    if log_probs is None:
+        raise ValueError("Megatron Lite model output must contain token log_probs.")
+    full_log_probs = _unpack_output(handle, runtime_batch, log_probs)
+    response_log_probs = []
+    for values, mask in zip(full_log_probs, source_batch["aligned_loss_masks"], strict=True):
+        active = mask.to(device=values.device).bool()
+        if values.numel() != active.numel():
+            raise ValueError(
+                f"log_probs length {values.numel()} does not match aligned mask length {active.numel()}."
+            )
+        response_log_probs.append(values[active])
+    return response_log_probs
+
+
+def _masked_sample_mean(values: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+    mask = mask.to(device=values.device, dtype=values.dtype)
+    return (values * mask).sum() / mask.sum().clamp_min(1.0)
+
+
+def _mean_scalars(values: list[torch.Tensor], device) -> torch.Tensor:
+    if not values:
+        return torch.zeros((), device=device, dtype=torch.float32)
+    return torch.stack([v.float() for v in values]).mean()
+
+
+def _policy_loss(
+    args,
+    current: list[torch.Tensor],
+    source_batch: dict[str, Any],
+) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+    old = source_batch.get("rollout_log_probs") if getattr(args, "use_rollout_logprobs", False) else None
+    if old is None:
+        old = source_batch.get("log_probs")
+    if old is None:
+        raise ValueError("policy_loss requires actor log_probs or rollout_log_probs.")
+    advantages = source_batch.get("advantages")
+    if advantages is None:
+        raise ValueError("policy_loss requires advantages. Did GRPO preprocessing run?")
+
+    eps_clip = float(getattr(args, "eps_clip", 0.2))
+    eps_clip_high = float(getattr(args, "eps_clip_high", eps_clip))
+    losses = []
+    clipfracs = []
+    kls = []
+    for cur, old_lp, adv, mask in zip(current, old, advantages, source_batch["loss_masks"], strict=True):
+        cur = cur.float()
+        old_lp = old_lp.to(device=cur.device, dtype=cur.dtype)
+        adv = adv.to(device=cur.device, dtype=cur.dtype)
+        if cur.numel() != old_lp.numel() or cur.numel() != adv.numel():
+            raise ValueError(
+                "policy_loss tensor length mismatch: "
+                f"current={cur.numel()} old={old_lp.numel()} advantages={adv.numel()}."
+            )
+        active = mask.to(device=cur.device, dtype=cur.dtype)
+        ppo_kl = old_lp - cur
+        ratio = (-ppo_kl).exp()
+        pg_losses1 = -ratio * adv
+        pg_losses2 = -ratio.clamp(1.0 - eps_clip, 1.0 + eps_clip_high) * adv
+        pg_losses = torch.maximum(pg_losses1, pg_losses2)
+        losses.append(_masked_sample_mean(pg_losses, active))
+        clipfracs.append(_masked_sample_mean((pg_losses2 > pg_losses1).float(), active))
+        kls.append(_masked_sample_mean(ppo_kl, active))
+
+    loss = _mean_scalars(losses, current[0].device)
+    entropy_loss = torch.zeros_like(loss)
+    if getattr(args, "entropy_coef", 0.0):
+        # MLite model protocols can return entropy, but qwen3_moe keeps this optional.
+        entropy_loss = torch.zeros_like(loss)
+        loss = loss - float(args.entropy_coef) * entropy_loss
+
+    metrics = {
+        "loss": loss.detach(),
+        "pg_loss": loss.detach(),
+        "pg_clipfrac": _mean_scalars(clipfracs, current[0].device).detach(),
+        "ppo_kl": _mean_scalars(kls, current[0].device).detach(),
+        "entropy_loss": entropy_loss.detach(),
+    }
+    return loss, metrics
+
+
+def _sft_loss(current: list[torch.Tensor], source_batch: dict[str, Any]) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+    losses = []
+    for log_probs, mask in zip(current, source_batch["loss_masks"], strict=True):
+        mask = mask.to(device=log_probs.device, dtype=log_probs.dtype)
+        if log_probs.numel() != mask.numel():
+            raise ValueError(
+                f"SFT log_probs length {log_probs.numel()} does not match response mask length {mask.numel()}."
+            )
+        losses.append(-_masked_sample_mean(log_probs.float(), mask))
+    loss = _mean_scalars(losses, current[0].device)
+    return loss, {"loss": loss.detach()}
+
+
+def make_runtime_loss_fn(
+    args,
+    handle,
+    *,
+    forward_store: list[dict[str, list[torch.Tensor]]] | None = None,
+    loss_context_iter: Iterator[LossContext] | None = None,
+) -> Callable:
+    """Build a Megatron Lite runtime loss_fn for SFT, forward-only logprob, or policy loss."""
+
+    def _next_loss_context() -> LossContext | None:
+        if loss_context_iter is None:
+            return None
+        try:
+            return next(loss_context_iter)
+        except StopIteration as exc:
+            raise RuntimeError("MLite miles loss context iterator ended before loss_fn calls.") from exc
+
+    def _loss_fn(raw_output: dict[str, torch.Tensor], runtime_batch, loss_context=None):
+        if loss_context is None:
+            loss_context = _next_loss_context()
+        if loss_context is None or loss_context.source_batch is None:
+            raise ValueError("MLite miles loss_fn requires a LossContext with source_batch.")
+        source_batch = loss_context.source_batch
+        current = extract_response_log_probs(raw_output, runtime_batch, source_batch, handle)
+        if forward_store is not None:
+            forward_store.append({"log_probs": [x.detach() for x in current]})
+            zero = torch.zeros((), device=current[0].device, dtype=torch.float32)
+            return zero, {"loss": zero.detach()}
+
+        loss_type = getattr(args, "loss_type", "sft_loss")
+        if loss_type == "sft_loss":
+            return _sft_loss(current, source_batch)
+        if loss_type == "policy_loss":
+            return _policy_loss(args, current, source_batch)
+        raise NotImplementedError(f"Megatron Lite miles actor does not support loss_type={loss_type!r}.")
+
+    return _loss_fn

--- a/experimental/lite/examples/miles/miles_mlite/reward_log.py
+++ b/experimental/lite/examples/miles/miles_mlite/reward_log.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Rollout-side reward marker logging for the miles MLite example.
+
+miles' built-in rollout logger (``miles.ray.rollout.metrics.log_rollout_data``)
+emits response-length / perf / zero-std stats but no reward mean. This thin hook,
+wired through ``--custom-rollout-log-function-path``, runs in the rollout manager
+(which holds every sample, so no parallel gather is needed) and logs a reward /
+pass-rate marker. Reward scoring itself stays with miles (``--rm-type``); this only
+reuses miles' ``compute_pass_rate`` to surface the signal. It is reward-rule
+agnostic. Returning False lets miles' built-in logger run as well.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from miles.utils.metric_utils import compute_pass_rate
+
+logger = logging.getLogger(__name__)
+
+
+def log_rollout_data(rollout_id, args, samples, rollout_extra_metrics, rollout_time) -> bool:
+    rewards = [float(sample.get_reward_value(args)) for sample in samples]
+    if not rewards:
+        return False
+    passrate = compute_pass_rate(
+        rewards,
+        group_size=args.n_samples_per_prompt,
+        num_groups=args.rollout_batch_size,
+    )
+    metrics = {
+        "reward/score/mean": sum(rewards) / len(rewards),
+        "reward/score/nonzero": sum(1 for reward in rewards if reward != 0.0),
+        "reward/score/count": len(rewards),
+    }
+    metrics.update({f"reward/passrate/{key}": value for key, value in passrate.items()})
+    logger.info("reward/score/passrate rollout %s: %s", rollout_id, metrics)
+    return False

--- a/experimental/lite/examples/miles/miles_mlite/weight_update.py
+++ b/experimental/lite/examples/miles/miles_mlite/weight_update.py
@@ -1,0 +1,294 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Raw HF weight update bridge for miles rollout engines."""
+
+from __future__ import annotations
+
+import logging
+import importlib
+from dataclasses import replace
+from collections.abc import Sequence
+
+import ray
+import torch
+import torch.distributed as dist
+
+logger = logging.getLogger(__name__)
+
+
+class RawHFWeightUpdater:
+    """Send MLite-exported HF-format weights through miles update APIs."""
+
+    def __init__(self, args, runtime, handle) -> None:
+        self.args = args
+        self.runtime = runtime
+        self.handle = handle
+        self.weight_version = 0
+        self._ipc_gather_group = None
+        self._ipc_gather_src = None
+        self._ipc_engine = None
+        self._model_update_groups = None
+        self._distributed_group_name = None
+        self.rollout_engines = []
+        self.distributed_rollout_engines = []
+        self.use_distribute = False
+
+    @property
+    def _ps(self):
+        return self.handle._parallel_state
+
+    @property
+    def _is_distributed_src_rank(self) -> bool:
+        ps = self._ps
+        return (
+            int(getattr(ps, "dp_rank", 0) or 0) == 0
+            and int(getattr(ps, "cp_rank", 0) or 0) == 0
+            and int(getattr(ps, "tp_rank", 0) or 0) == 0
+        )
+
+    def connect_rollout_engines(
+        self,
+        rollout_engines: Sequence,
+        rollout_engine_lock,
+        *,
+        engine_gpu_counts: Sequence[int] | None = None,
+        engine_gpu_offsets: Sequence[int] | None = None,
+    ) -> None:
+        broadcast = importlib.import_module(
+            "miles.backends.megatron_utils.update_weight.update_weight_from_distributed.broadcast"
+        )
+        connect_rollout_engines_from_distributed = broadcast.connect_rollout_engines_from_distributed
+        disconnect_rollout_engines_from_distributed = broadcast.disconnect_rollout_engines_from_distributed
+
+        self.rollout_engines = list(rollout_engines)
+        self.rollout_engine_lock = rollout_engine_lock
+
+        if engine_gpu_counts is None:
+            engine_gpu_counts = [self.args.rollout_num_gpus_per_engine] * len(rollout_engines)
+        if engine_gpu_offsets is None:
+            engine_gpu_offsets = []
+            offset = 0
+            for count in engine_gpu_counts:
+                engine_gpu_offsets.append(offset)
+                offset += count
+
+        if not getattr(self.args, "colocate", False):
+            colocate_engine_nums = 0
+        else:
+            total_actor_gpus = self.args.actor_num_nodes * self.args.actor_num_gpus_per_node
+            colocate_engine_nums = 0
+            for gpu_offset, gpu_count in zip(engine_gpu_offsets, engine_gpu_counts, strict=True):
+                if gpu_offset + gpu_count > total_actor_gpus:
+                    break
+                colocate_engine_nums += 1
+
+        self.use_distribute = len(rollout_engines) > colocate_engine_nums
+        self.distributed_rollout_engines = list(rollout_engines[colocate_engine_nums:])
+        self.rollout_engines = list(rollout_engines[:colocate_engine_nums])
+
+        if self.use_distribute and self._is_distributed_src_rank:
+            self._distributed_group_name = f"mlite-pp_{getattr(self._ps, 'pp_rank', 0)}"
+            if self._model_update_groups is not None:
+                disconnect_rollout_engines_from_distributed(
+                    self.args,
+                    self._distributed_group_name,
+                    self._model_update_groups,
+                    self.distributed_rollout_engines,
+                )
+            self._model_update_groups = connect_rollout_engines_from_distributed(
+                self.args,
+                self._distributed_group_name,
+                self.distributed_rollout_engines,
+                engine_gpu_counts=engine_gpu_counts[colocate_engine_nums:],
+            )
+
+        self._connect_colocated_groups(engine_gpu_counts[:colocate_engine_nums], engine_gpu_offsets[:colocate_engine_nums])
+
+    @property
+    def _active_rollout_engines(self):
+        return [*self.rollout_engines, *self.distributed_rollout_engines]
+
+    def _connect_colocated_groups(self, engine_gpu_counts, engine_gpu_offsets) -> None:
+        rank = dist.get_rank()
+        self._ipc_gather_group = None
+        self._ipc_gather_src = None
+        self._ipc_engine = None
+
+        for engine_idx, (offset, count) in enumerate(zip(engine_gpu_offsets, engine_gpu_counts, strict=True)):
+            group_ranks = list(range(offset, offset + count))
+            new_group = dist.new_group(ranks=group_ranks, backend="gloo")
+            if rank in group_ranks:
+                self._ipc_gather_group = new_group
+                self._ipc_gather_src = offset
+                self._ipc_engine = self.rollout_engines[engine_idx]
+
+    def update_weights(self) -> None:
+        common = importlib.import_module("miles.backends.megatron_utils.update_weight.common")
+        broadcast = importlib.import_module(
+            "miles.backends.megatron_utils.update_weight.update_weight_from_distributed.broadcast"
+        )
+        distributed_utils = importlib.import_module("miles.utils.distributed_utils")
+        sglang_utils = importlib.import_module("miles.backends.megatron_utils.sglang")
+        _check_weight_sync_results = common._check_weight_sync_results
+        post_process_weights = common.post_process_weights
+        update_weights_from_distributed = broadcast.update_weights_from_distributed
+        get_gloo_group = distributed_utils.get_gloo_group
+        monkey_patch_torch_reductions = sglang_utils.monkey_patch_torch_reductions
+
+        self.weight_version += 1
+        monkey_patch_torch_reductions()
+        rank = dist.get_rank()
+        if rank == 0:
+            mode = self.args.pause_generation_mode
+            ray.get([engine.pause_generation.remote(mode=mode) for engine in self._active_rollout_engines])
+            ray.get([engine.flush_cache.remote() for engine in self._active_rollout_engines])
+        dist.barrier(group=get_gloo_group())
+
+        refs = []
+        live_tensors = []
+        for chunk in self._export_weight_chunks():
+            colocated_refs, long_lived = _send_to_colocated_engine_direct(
+                hf_named_tensors=chunk,
+                ipc_engine=self._ipc_engine,
+                ipc_gather_src=self._ipc_gather_src,
+                ipc_gather_group=self._ipc_gather_group,
+                weight_version=self.weight_version,
+            )
+            refs.extend(colocated_refs)
+            if long_lived is not None:
+                live_tensors.append(long_lived)
+            if self.use_distribute and self._is_distributed_src_rank:
+                refs.extend(
+                    update_weights_from_distributed(
+                        self._distributed_group_name,
+                        self._model_update_groups,
+                        self.weight_version,
+                        self.distributed_rollout_engines,
+                        chunk,
+                    )
+                )
+        if refs:
+            _check_weight_sync_results(ray.get(refs), is_lora=False)
+        del live_tensors
+
+        dist.barrier(group=get_gloo_group())
+        if rank == 0:
+            post_process_weights(
+                rollout_engines=self._active_rollout_engines,
+                restore_weights_before_load=False,
+                post_process_quantization=True,
+            )
+            ray.get([engine.continue_generation.remote() for engine in self._active_rollout_engines])
+        dist.barrier(group=get_gloo_group())
+
+    def _export_weight_chunks(self):
+        chunk = []
+        chunk_bytes = 0
+        limit = int(getattr(self.args, "update_weight_buffer_size", 2**30))
+        export_kwargs = {}
+        if getattr(self.args, "mlite_export_dtype", None):
+            export_kwargs["export_dtype"] = self.args.mlite_export_dtype
+        for name, tensor in self._iter_local_hf_weights(**export_kwargs):
+            if not self._needs_weight_payload:
+                del tensor
+                continue
+            tensor = tensor.detach()
+            if not tensor.is_cuda:
+                tensor = tensor.to(device=torch.cuda.current_device(), non_blocking=True)
+            item_bytes = tensor.numel() * tensor.element_size()
+            if chunk and chunk_bytes + item_bytes > limit:
+                torch.cuda.synchronize()
+                yield chunk
+                chunk = []
+                chunk_bytes = 0
+            chunk.append((name, tensor))
+            chunk_bytes += item_bytes
+        if chunk:
+            torch.cuda.synchronize()
+            yield chunk
+
+    @property
+    def _needs_weight_payload(self) -> bool:
+        return self._is_distributed_src_rank or self._ipc_gather_group is not None
+
+    def _iter_local_hf_weights(self, **export_kwargs):
+        """Export this PP stage only; each PP source broadcasts its own group."""
+
+        ps = self._ps
+        if int(getattr(ps, "pp_size", 1) or 1) <= 1:
+            yield from self.runtime.export_weights(self.handle, **export_kwargs)
+            return
+
+        proto = self.handle._extras.get("protocol")
+        model_cfg = self.handle._extras.get("model_cfg")
+        model_chunks = self.handle._extras.get("model_chunks", [self.handle._model])
+        if proto and hasattr(proto, "export_hf_weights"):
+            local_pp_ps = replace(
+                ps,
+                pp_group=None,
+                pp_cpu_group=None,
+                pp_global_ranks=None,
+                pp_size=1,
+                pp_rank=0,
+                pp_is_first=True,
+                pp_is_last=True,
+                pp_next_rank=-1,
+                pp_prev_rank=-1,
+            )
+            yield from proto.export_hf_weights(model_chunks, model_cfg, local_pp_ps, **export_kwargs)
+            return
+
+        for chunk in model_chunks:
+            yield from chunk.named_parameters()
+
+
+def _send_to_colocated_engine_direct(
+    hf_named_tensors,
+    *,
+    ipc_engine,
+    ipc_gather_src,
+    ipc_gather_group,
+    weight_version=None,
+):
+    if ipc_gather_group is None:
+        return [], None
+
+    sglang_utils = importlib.import_module("miles.backends.megatron_utils.sglang")
+    model_runner = importlib.import_module("sglang.srt.model_executor.model_runner")
+    MultiprocessingSerializer = sglang_utils.MultiprocessingSerializer
+    LocalSerializedTensor = model_runner.LocalSerializedTensor
+
+    is_gather_src = dist.get_rank() == ipc_gather_src
+    serialized_tensors = [
+        (name, MultiprocessingSerializer.serialize(tensor)) for name, tensor in hf_named_tensors
+    ]
+    serialized_named_tensors = [None] * dist.get_world_size(ipc_gather_group) if is_gather_src else None
+    dist.gather_object(
+        serialized_tensors,
+        object_gather_list=serialized_named_tensors,
+        dst=ipc_gather_src,
+        group=ipc_gather_group,
+    )
+
+    refs = []
+    if is_gather_src:
+        named_tensors = []
+        for tensor_group in zip(*serialized_named_tensors, strict=True):
+            names = {name for name, _ in tensor_group}
+            if len(names) != 1:
+                raise RuntimeError(f"Mismatched TP tensor names during weight sync: {sorted(names)}")
+            name = tensor_group[0][0]
+            named_tensors.append(
+                (name, LocalSerializedTensor(values=[rank_part[1] for rank_part in tensor_group]))
+            )
+        payload = [
+            MultiprocessingSerializer.serialize(named_tensors, output_str=True)
+            for _ in range(len(serialized_named_tensors))
+        ]
+        refs.append(
+            ipc_engine.update_weights_from_tensor.remote(
+                serialized_named_tensors=payload,
+                weight_version=str(weight_version),
+            )
+        )
+
+    return refs, [tensor for _, tensor in hf_named_tensors]

--- a/experimental/lite/examples/miles/scripts/run_qwen3moe_grpo.sh
+++ b/experimental/lite/examples/miles/scripts/run_qwen3moe_grpo.sh
@@ -1,0 +1,422 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=mlite_miles_grpo
+#SBATCH --partition=batch
+#SBATCH --account=coreai_devtech_all
+#SBATCH --nodes=2
+#SBATCH --ntasks-per-node=1
+#SBATCH --gres=gpu:8
+#SBATCH --cpus-per-task=64
+#SBATCH --mem=1000G
+#SBATCH --time=04:00:00
+#SBATCH --output=/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/code/env/mlite_miles_grpo-%j.log
+
+# Qwen3 MoE GRPO using miles' qwen3-next-80B-A3B 8-GPU recipe, with only
+# the training backend swapped to Megatron Lite.
+set -euo pipefail
+
+if [[ "${VERBOSE:-0}" == "1" ]]; then set -x; fi
+
+resolve_script_path() {
+   if [[ -n "${MLITE_MILES_SCRIPT_PATH:-}" ]]; then
+      readlink -f "${MLITE_MILES_SCRIPT_PATH}"
+      return
+   fi
+   if [[ -n "${SLURM_JOB_ID:-}" ]] && command -v scontrol >/dev/null 2>&1; then
+      local command_path
+      command_path="$(
+         scontrol show job "${SLURM_JOB_ID}" | tr ' ' '\n' | sed -n 's/^Command=//p' | head -1
+      )"
+      if [[ -n "${command_path}" && -r "${command_path}" ]]; then
+         readlink -f "${command_path}"
+         return
+      fi
+   fi
+   readlink -f "${BASH_SOURCE[0]}"
+}
+
+SCRIPT_PATH="$(resolve_script_path)"
+CONTAINER_IMAGE="${CONTAINER_IMAGE:-/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/code/env/miles.sqsh}"
+CONTAINER_MOUNTS="${CONTAINER_MOUNTS:-/lustre:/lustre}"
+DRY_RUN="${DRY_RUN:-0}"
+RAY_PORT="${RAY_PORT:-6379}"
+RAY_DASHBOARD_PORT="${RAY_DASHBOARD_PORT:-8265}"
+RAY_EXPECTED_NODES="${RAY_EXPECTED_NODES:-2}"
+SYSTEM_PATH="${MLITE_SYSTEM_PATH:-/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin}"
+SYSTEM_CC="${MLITE_CC:-/usr/bin/gcc}"
+SYSTEM_CXX="${MLITE_CXX:-/usr/bin/g++}"
+SYSTEM_CPATH="${MLITE_CPATH:-/usr/include:/usr/include/x86_64-linux-gnu}"
+
+MLITE_SAVE_OPTIMIZER_CHECKPOINT="${MLITE_SAVE_OPTIMIZER_CHECKPOINT:-0}"
+MLITE_SAVE_RNG_CHECKPOINT="${MLITE_SAVE_RNG_CHECKPOINT:-0}"
+MLITE_LOAD_OPTIMIZER_CHECKPOINT="${MLITE_LOAD_OPTIMIZER_CHECKPOINT:-0}"
+MLITE_LOAD_RNG_CHECKPOINT="${MLITE_LOAD_RNG_CHECKPOINT:-0}"
+MLITE_VERIFY_CHECKPOINT_LOAD="${MLITE_VERIFY_CHECKPOINT_LOAD:-1}"
+MLITE_DELETE_CHECKPOINT_AFTER_LOAD="${MLITE_DELETE_CHECKPOINT_AFTER_LOAD:-1}"
+MLITE_RESET_ROLLOUT_AFTER_LOAD="${MLITE_RESET_ROLLOUT_AFTER_LOAD:-1}"
+
+if [[ "${IN_MILES_CONTAINER:-0}" != "1" ]]; then
+   if [[ ! -r "${CONTAINER_IMAGE}" ]]; then
+      echo "Container image not readable: ${CONTAINER_IMAGE}" >&2
+      exit 2
+   fi
+   if [[ -z "${MASTER_ADDR:-}" && -n "${SLURM_JOB_NODELIST:-}" ]] && command -v scontrol >/dev/null 2>&1; then
+      MASTER_ADDR="$(scontrol show hostnames "${SLURM_JOB_NODELIST}" | head -n1)"
+   fi
+   MASTER_ADDR="${MASTER_ADDR:-127.0.0.1}"
+
+   SRUN_CMD=(
+      srun
+      --nodes=2
+      --ntasks=2
+      --ntasks-per-node=1
+      --container-image="${CONTAINER_IMAGE}"
+      --container-mounts="${CONTAINER_MOUNTS}"
+      --container-workdir=/
+      env
+      -u CONDA_PREFIX
+      -u CONDA_DEFAULT_ENV
+      -u CONDA_EXE
+      -u CONDA_PYTHON_EXE
+      -u CONDA_SHLVL
+      -u _CE_CONDA
+      -u _CE_M
+      PATH="${SYSTEM_PATH}"
+      CC="${SYSTEM_CC}"
+      CXX="${SYSTEM_CXX}"
+      CPATH="${SYSTEM_CPATH}"
+      IN_MILES_CONTAINER=1
+      MLITE_MILES_SCRIPT_PATH="${SCRIPT_PATH}"
+      MASTER_ADDR="${MASTER_ADDR}"
+      RAY_PORT="${RAY_PORT}"
+      RAY_DASHBOARD_PORT="${RAY_DASHBOARD_PORT}"
+      RAY_EXPECTED_NODES="${RAY_EXPECTED_NODES}"
+      MLITE_SAVE_OPTIMIZER_CHECKPOINT="${MLITE_SAVE_OPTIMIZER_CHECKPOINT}"
+      MLITE_SAVE_RNG_CHECKPOINT="${MLITE_SAVE_RNG_CHECKPOINT}"
+      MLITE_LOAD_OPTIMIZER_CHECKPOINT="${MLITE_LOAD_OPTIMIZER_CHECKPOINT}"
+      MLITE_LOAD_RNG_CHECKPOINT="${MLITE_LOAD_RNG_CHECKPOINT}"
+      MLITE_VERIFY_CHECKPOINT_LOAD="${MLITE_VERIFY_CHECKPOINT_LOAD}"
+      MLITE_DELETE_CHECKPOINT_AFTER_LOAD="${MLITE_DELETE_CHECKPOINT_AFTER_LOAD}"
+      MLITE_RESET_ROLLOUT_AFTER_LOAD="${MLITE_RESET_ROLLOUT_AFTER_LOAD}"
+      bash "${SCRIPT_PATH}"
+   )
+
+   if [[ "${DRY_RUN}" == "1" ]]; then
+      printf 'outer: '
+      printf '%q ' "${SRUN_CMD[@]}"
+      printf '\n'
+      IN_MILES_CONTAINER=1 DRY_RUN=1 bash "${SCRIPT_PATH}"
+      exit 0
+   fi
+
+   if [[ -z "${SLURM_JOB_ID:-}" ]]; then
+      echo "Submit this script with sbatch, or run DRY_RUN=1 bash ${SCRIPT_PATH} for a local command check." >&2
+      exit 2
+   fi
+
+   exec "${SRUN_CMD[@]}"
+fi
+
+set -ex
+
+export PATH="${SYSTEM_PATH}"
+export CC="${SYSTEM_CC}"
+export CXX="${SYSTEM_CXX}"
+export CPATH="${SYSTEM_CPATH}"
+unset CONDA_PREFIX CONDA_DEFAULT_ENV CONDA_EXE CONDA_PYTHON_EXE CONDA_SHLVL _CE_CONDA _CE_M
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd -L)"
+EXAMPLE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd -L)"
+LITE_ROOT="$(cd "${EXAMPLE_ROOT}/../.." && pwd -L)"
+REPO_ROOT="$(cd "${LITE_ROOT}/../.." && pwd -L)"
+
+MILES_ROOT="${MILES_ROOT:-/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/code/miles}"
+MEGATRON_ROOT="${MEGATRON_ROOT:-/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/code/megatron_lite/Megatron-LM}"
+MODEL_PATH="${MODEL_PATH:-/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/shunyad/models/Qwen/Qwen3-30B-A3B}"
+RUN_ROOT="${RUN_ROOT:-/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/code/env/mlite_miles_runs}"
+DAPO_MATH_DATA="${DAPO_MATH_DATA:-/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/achartier/dapo-math-17k/dapo-math-17k.jsonl}"
+LOAD_DIR="${LOAD_DIR:-${RUN_ROOT}/qwen3moe_sft_mlite/13021984}"
+SAVE_DIR="${SAVE_DIR:-${RUN_ROOT}/qwen3moe_grpo_mlite/${SLURM_JOB_ID:-dryrun}}"
+REF_LOAD="${REF_LOAD:-${MODEL_PATH}}"
+
+if [[ ! -d "${MODEL_PATH}" ]]; then
+   echo "MODEL_PATH does not exist: ${MODEL_PATH}" >&2
+   exit 2
+fi
+if [[ ! -s "${DAPO_MATH_DATA}" ]]; then
+   echo "DAPO_MATH_DATA does not exist: ${DAPO_MATH_DATA}" >&2
+   exit 2
+fi
+if [[ ! -d "${LOAD_DIR}" ]]; then
+   echo "LOAD_DIR does not exist: ${LOAD_DIR}" >&2
+   exit 2
+fi
+mkdir -p "${SAVE_DIR}"
+
+if [[ "${DRY_RUN}" == "1" ]]; then
+   NVLINK_COUNT=0
+   HAS_NVLINK=0
+else
+   NVLINK_COUNT=$(nvidia-smi topo -m 2>/dev/null | grep -o 'NV[0-9][0-9]*' | wc -l)
+   if [[ "${NVLINK_COUNT}" -gt 0 ]]; then
+      HAS_NVLINK=1
+   else
+      HAS_NVLINK=0
+   fi
+fi
+echo "HAS_NVLINK: ${HAS_NVLINK} (detected ${NVLINK_COUNT} NVLink references)"
+
+source "${MILES_ROOT}/scripts/models/qwen3-30B-A3B.sh"
+
+export PYTHONBUFFERED=16
+export PYTHONUNBUFFERED=1
+export CUDA_DEVICE_MAX_CONNECTIONS="${CUDA_DEVICE_MAX_CONNECTIONS:-1}"
+export MASTER_ADDR="${MASTER_ADDR:-127.0.0.1}"
+export RAY_PORT RAY_DASHBOARD_PORT RAY_EXPECTED_NODES
+export no_proxy="127.0.0.1,${MASTER_ADDR}"
+export MLITE_SAVE_OPTIMIZER_CHECKPOINT MLITE_SAVE_RNG_CHECKPOINT
+export MLITE_LOAD_OPTIMIZER_CHECKPOINT MLITE_LOAD_RNG_CHECKPOINT
+export MLITE_VERIFY_CHECKPOINT_LOAD MLITE_DELETE_CHECKPOINT_AFTER_LOAD
+export MLITE_RESET_ROLLOUT_AFTER_LOAD
+
+add_pythonpath() { [[ -n "${1:-}" ]] && export PYTHONPATH="${1}:${PYTHONPATH:-}"; }
+add_pythonpath "${EXAMPLE_ROOT}"
+add_pythonpath "${LITE_ROOT}/examples"
+add_pythonpath "${LITE_ROOT}"
+add_pythonpath "${REPO_ROOT}"
+add_pythonpath "${MEGATRON_ROOT}"
+add_pythonpath "${MILES_ROOT}"
+
+CKPT_ARGS=(
+   --hf-checkpoint "${MODEL_PATH}"
+   --ref-load "${REF_LOAD}"
+   --load "${LOAD_DIR}"
+   --save "${SAVE_DIR}"
+   --save-interval 20
+)
+
+ROLLOUT_ARGS=(
+   --prompt-data "${DAPO_MATH_DATA}"
+   --input-key prompt
+   --label-key label
+   --apply-chat-template
+   --rollout-shuffle
+   --rm-type deepscaler
+   --num-rollout "${NUM_ROLLOUT:-5}"
+   --rollout-batch-size 16
+   --n-samples-per-prompt 4
+   --rollout-max-response-len 8192
+   --rollout-temperature 0.8
+   --global-batch-size 64
+   --balance-data
+   --custom-rollout-log-function-path miles_mlite.reward_log.log_rollout_data
+)
+
+PERF_ARGS=(
+   --tensor-model-parallel-size 2
+   --sequence-parallel
+   --pipeline-model-parallel-size 1
+   --context-parallel-size 1
+   --expert-model-parallel-size 8
+   --expert-tensor-parallel-size 1
+   --recompute-granularity full
+   --recompute-method uniform
+   --recompute-num-layers 1
+   --use-dynamic-batch-size
+   --max-tokens-per-gpu 2048
+)
+
+GRPO_ARGS=(
+   --advantage-estimator gspo
+   --use-rollout-logprobs
+   --kl-loss-coef 0.00
+   --kl-loss-type low_var_kl
+   --kl-coef 0.00
+   --entropy-coef 0.00
+   --eps-clip 4e-4
+)
+
+OPTIMIZER_ARGS=(
+   --optimizer adam
+   --lr 1e-6
+   --lr-decay-style constant
+   --weight-decay 0.1
+   --adam-beta1 0.9
+   --adam-beta2 0.98
+)
+
+BACKEND_ARGS=(
+   --train-backend megatron
+   --model-name qwen3_moe
+   --megatron-to-hf-mode raw
+   --mlite-backend-patch
+   --mlite-model-name qwen3_moe
+   --mlite-impl lite
+   --mlite-optimizer-backend dist_opt
+   --mlite-optimizer-offload
+)
+
+SGLANG_ARGS=(
+   --rollout-num-gpus-per-engine 2
+   --rollout-num-gpus 8
+   --sglang-mem-fraction-static 0.8
+   --sglang-ep-size 1
+   --sglang-cuda-graph-bs 1 2 4 8 $(seq 16 8 128)
+   --update-weight-buffer-size $((1024 * 1024 * 1024 * 4))
+)
+
+MISC_ARGS=(
+   --attention-dropout 0.0
+   --hidden-dropout 0.0
+   --accumulate-allreduce-grads-in-fp32
+   --attention-softmax-in-fp32
+   --attention-backend flash
+   --moe-token-dispatcher-type alltoall
+   --log-passrate
+)
+
+JOB_ARGS=(
+   python3 -m miles_mlite.launch
+   --actor-num-nodes 1
+   --actor-num-gpus-per-node 8
+   --num-gpus-per-node 8
+   "${MODEL_ARGS[@]}"
+   "${CKPT_ARGS[@]}"
+   "${ROLLOUT_ARGS[@]}"
+   "${OPTIMIZER_ARGS[@]}"
+   "${GRPO_ARGS[@]}"
+   "${PERF_ARGS[@]}"
+   "${SGLANG_ARGS[@]}"
+   "${MISC_ARGS[@]}"
+   "${BACKEND_ARGS[@]}"
+)
+
+RUNTIME_ENV_JSON="$(
+python3 - <<PY
+import json
+import os
+
+paths = [
+    "${EXAMPLE_ROOT}",
+    "${LITE_ROOT}/examples",
+    "${LITE_ROOT}",
+    "${REPO_ROOT}",
+    "${MILES_ROOT}",
+    "${MEGATRON_ROOT}",
+]
+env = {
+    "PYTHONPATH": ":".join(paths + [os.environ.get("PYTHONPATH", "")]),
+    "PATH": os.environ.get("PATH", "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"),
+    "CC": os.environ.get("CC", "/usr/bin/gcc"),
+    "CXX": os.environ.get("CXX", "/usr/bin/g++"),
+    "CPATH": os.environ.get("CPATH", "/usr/include:/usr/include/x86_64-linux-gnu"),
+    "CUDA_DEVICE_MAX_CONNECTIONS": os.environ.get("CUDA_DEVICE_MAX_CONNECTIONS", "1"),
+    "NCCL_NVLS_ENABLE": "${HAS_NVLINK}",
+    "MASTER_ADDR": os.environ.get("MASTER_ADDR", "127.0.0.1"),
+    "MLITE_SAVE_OPTIMIZER_CHECKPOINT": os.environ.get("MLITE_SAVE_OPTIMIZER_CHECKPOINT", "0"),
+    "MLITE_SAVE_RNG_CHECKPOINT": os.environ.get("MLITE_SAVE_RNG_CHECKPOINT", "0"),
+    "MLITE_LOAD_OPTIMIZER_CHECKPOINT": os.environ.get("MLITE_LOAD_OPTIMIZER_CHECKPOINT", "0"),
+    "MLITE_LOAD_RNG_CHECKPOINT": os.environ.get("MLITE_LOAD_RNG_CHECKPOINT", "0"),
+    "MLITE_VERIFY_CHECKPOINT_LOAD": os.environ.get("MLITE_VERIFY_CHECKPOINT_LOAD", "1"),
+    "MLITE_DELETE_CHECKPOINT_AFTER_LOAD": os.environ.get("MLITE_DELETE_CHECKPOINT_AFTER_LOAD", "1"),
+    "MLITE_RESET_ROLLOUT_AFTER_LOAD": os.environ.get("MLITE_RESET_ROLLOUT_AFTER_LOAD", "1"),
+    "no_proxy": os.environ.get("no_proxy", "127.0.0.1,localhost"),
+}
+print(json.dumps({"env_vars": env}))
+PY
+)"
+
+if [[ "${DRY_RUN}" == "1" ]]; then
+   printf 'inner ray head: ray start --head --node-ip-address=%q --port=%q --num-gpus=8 --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=%q\n' \
+      "${MASTER_ADDR}" "${RAY_PORT}" "${RAY_DASHBOARD_PORT}"
+   printf 'inner ray worker: ray start --address=%q --num-gpus=8 --node-ip-address=<worker> --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=%q\n' \
+      "${MASTER_ADDR}:${RAY_PORT}" "${RAY_DASHBOARD_PORT}"
+   printf 'inner ray job: ray job submit --address=%q --runtime-env-json=%q -- ' \
+      "${RAY_ADDRESS:-http://127.0.0.1:${RAY_DASHBOARD_PORT}}" "${RUNTIME_ENV_JSON}"
+   printf '%q ' "${JOB_ARGS[@]}"
+   printf '\n'
+   exit 0
+fi
+
+RAY_NODE_RANK="${SLURM_PROCID:-0}"
+RAY_DONE_FILE="${RUN_ROOT}/.mlite_miles_grpo_${SLURM_JOB_ID:-manual}.done"
+NODE_ADDR="$(hostname -s)"
+
+ray stop --force || true
+pkill -9 sglang || true
+pkill -9 ray || true
+sleep 3
+ray stop --force || true
+
+cleanup() {
+   if [[ "${RAY_NODE_RANK}" == "0" ]]; then
+      touch "${RAY_DONE_FILE}" || true
+   fi
+   ray stop --force || true
+}
+trap cleanup EXIT
+
+if [[ "${RAY_NODE_RANK}" != "0" ]]; then
+   for attempt in $(seq 1 120); do
+      if ray start \
+         --address="${MASTER_ADDR}:${RAY_PORT}" \
+         --num-gpus 8 \
+         --node-ip-address "${NODE_ADDR}" \
+         --disable-usage-stats \
+         --dashboard-host=0.0.0.0 \
+         --dashboard-port="${RAY_DASHBOARD_PORT}"; then
+         break
+      fi
+      if [[ "${attempt}" == "120" ]]; then
+         echo "Failed to join Ray head at ${MASTER_ADDR}:${RAY_PORT}" >&2
+         exit 1
+      fi
+      sleep 2
+   done
+   while [[ ! -f "${RAY_DONE_FILE}" ]]; do
+      sleep 10
+   done
+   exit 0
+fi
+
+rm -f "${RAY_DONE_FILE}"
+
+ray start \
+   --head \
+   --node-ip-address "${MASTER_ADDR}" \
+   --port="${RAY_PORT}" \
+   --num-gpus 8 \
+   --disable-usage-stats \
+   --dashboard-host=0.0.0.0 \
+   --dashboard-port="${RAY_DASHBOARD_PORT}"
+
+python3 - <<'PY'
+import os
+import time
+
+import ray
+
+expected = int(os.environ.get("RAY_EXPECTED_NODES", "1"))
+address = f"{os.environ['MASTER_ADDR']}:{os.environ['RAY_PORT']}"
+ray.init(address=address)
+deadline = time.time() + 300
+while True:
+    alive = [node for node in ray.nodes() if node.get("Alive")]
+    print(f"RAY_CLUSTER_NODES {len(alive)}/{expected}", flush=True)
+    if len(alive) >= expected:
+        break
+    if time.time() > deadline:
+        raise SystemExit(f"Timed out waiting for Ray nodes: {len(alive)}/{expected}")
+    time.sleep(2)
+ray.shutdown()
+PY
+
+set +e
+ray job submit \
+   --address "${RAY_ADDRESS:-http://127.0.0.1:${RAY_DASHBOARD_PORT}}" \
+   --runtime-env-json "${RUNTIME_ENV_JSON}" \
+   -- \
+   "${JOB_ARGS[@]}"
+rc=$?
+set -e
+echo "MILES_MLITE_GRPO_DONE rc=${rc}"
+exit "${rc}"

--- a/experimental/lite/examples/miles/scripts/run_qwen3moe_sft.sh
+++ b/experimental/lite/examples/miles/scripts/run_qwen3moe_sft.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=mlite_miles_sft
+#SBATCH --partition=batch
+#SBATCH --account=coreai_devtech_all
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --gres=gpu:8
+#SBATCH --cpus-per-task=64
+#SBATCH --mem=2010G
+#SBATCH --time=00:45:00
+#SBATCH --output=/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/code/env/mlite_miles_sft-%j.log
+
+# Qwen3 MoE SFT with miles using either the Megatron Lite patch or native Megatron.
+set -euo pipefail
+
+if [[ "${VERBOSE:-0}" == "1" ]]; then set -x; fi
+
+resolve_script_path() {
+   if [[ -n "${MLITE_MILES_SCRIPT_PATH:-}" ]]; then
+      readlink -f "${MLITE_MILES_SCRIPT_PATH}"
+      return
+   fi
+   if [[ -n "${SLURM_JOB_ID:-}" ]] && command -v scontrol >/dev/null 2>&1; then
+      local command_path
+      command_path="$(
+         scontrol show job "${SLURM_JOB_ID}" | tr ' ' '\n' | sed -n 's/^Command=//p' | head -1
+      )"
+      if [[ -n "${command_path}" && -r "${command_path}" ]]; then
+         readlink -f "${command_path}"
+         return
+      fi
+   fi
+   readlink -f "${BASH_SOURCE[0]}"
+}
+
+SCRIPT_PATH="$(resolve_script_path)"
+CONTAINER_IMAGE="${CONTAINER_IMAGE:-/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/code/env/miles.sqsh}"
+CONTAINER_MOUNTS="${CONTAINER_MOUNTS:-/lustre:/lustre}"
+DRY_RUN="${DRY_RUN:-0}"
+unset PYTORCH_CUDA_ALLOC_CONF PYTORCH_ALLOC_CONF
+
+if [[ "${IN_MILES_CONTAINER:-0}" != "1" ]]; then
+   if [[ ! -r "${CONTAINER_IMAGE}" ]]; then
+      echo "Container image not readable: ${CONTAINER_IMAGE}" >&2
+      exit 2
+   fi
+
+   SRUN_CMD=(
+      srun
+      --container-image="${CONTAINER_IMAGE}"
+      --container-mounts="${CONTAINER_MOUNTS}"
+      --container-workdir=/
+      env IN_MILES_CONTAINER=1 MLITE_MILES_SCRIPT_PATH="${SCRIPT_PATH}"
+      bash "${SCRIPT_PATH}"
+   )
+
+   if [[ "${DRY_RUN}" == "1" ]]; then
+      printf 'outer: '
+      printf '%q ' "${SRUN_CMD[@]}"
+      printf '\n'
+      IN_MILES_CONTAINER=1 DRY_RUN=1 bash "${SCRIPT_PATH}"
+      exit 0
+   fi
+
+   if [[ -z "${SLURM_JOB_ID:-}" ]]; then
+      echo "Submit this script with sbatch, or run DRY_RUN=1 bash ${SCRIPT_PATH} for a local command check." >&2
+      exit 2
+   fi
+
+   exec "${SRUN_CMD[@]}"
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -L)"
+EXAMPLE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd -L)"
+LITE_ROOT="$(cd "${EXAMPLE_ROOT}/../.." && pwd -L)"
+REPO_ROOT="$(cd "${LITE_ROOT}/../.." && pwd -L)"
+
+add_pythonpath() { [[ -n "${1:-}" ]] && export PYTHONPATH="${1}:${PYTHONPATH:-}"; }
+
+MILES_ROOT="${MILES_ROOT:-/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/code/miles}"
+MEGATRON_ROOT="${MEGATRON_ROOT:-/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/code/megatron_lite/Megatron-LM}"
+MODEL_PATH="${MODEL_PATH:-/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/shunyad/models/Qwen/Qwen3-30B-A3B}"
+TRAIN_DATA="${TRAIN_DATA:?Set TRAIN_DATA to a messages parquet file for miles SFT.}"
+
+add_pythonpath "${EXAMPLE_ROOT}"
+add_pythonpath "${LITE_ROOT}/examples"
+add_pythonpath "${LITE_ROOT}"
+add_pythonpath "${REPO_ROOT}"
+add_pythonpath "${MEGATRON_ROOT}"
+add_pythonpath "${MILES_ROOT}"
+
+MODEL_SCRIPT="${MODEL_SCRIPT:-${MILES_ROOT}/scripts/models/qwen3-30B-A3B.sh}"
+NUM_GPUS="${NUM_GPUS:-8}"
+TRAIN_BACKEND="${TRAIN_BACKEND:-mlite}"
+case "${TRAIN_BACKEND}" in
+   mlite|megatron) ;;
+   *) echo "TRAIN_BACKEND must be 'mlite' or 'megatron'." >&2; exit 2 ;;
+esac
+RUN_ROOT="${RUN_ROOT:-/lustre/fs1/portfolios/coreai/projects/coreai_devtech_all/users/bayan/code/env/mlite_miles_runs}"
+SAVE_DIR="${SAVE_DIR:-${RUN_ROOT}/qwen3moe_sft_${TRAIN_BACKEND}/${SLURM_JOB_ID:-dryrun}}"
+LOG_DIR="${LOG_DIR:-${RUN_ROOT}/logs}"
+
+TP_SIZE="${TP_SIZE:-2}"
+PP_SIZE="${PP_SIZE:-1}"
+CP_SIZE="${CP_SIZE:-1}"
+EP_SIZE="${EP_SIZE:-8}"
+ETP_SIZE="${ETP_SIZE:-1}"
+MLITE_MODEL_NAME="${MLITE_MODEL_NAME:-qwen3_moe}"
+MLITE_OPTIMIZER_BACKEND="${MLITE_OPTIMIZER_BACKEND:-dist_opt}"
+OPTIMIZER_OFFLOAD="${OPTIMIZER_OFFLOAD:-1}"
+PARAM_OFFLOAD="${PARAM_OFFLOAD:-0}"
+if [[ -z "${MEGATRON_TO_HF_MODE:-}" ]]; then
+   if [[ "${TRAIN_BACKEND}" == "mlite" ]]; then
+      MEGATRON_TO_HF_MODE="raw"
+   else
+      MEGATRON_TO_HF_MODE="bridge"
+   fi
+fi
+
+LR="${LR:-1e-5}"
+ROLLOUT_BATCH_SIZE="${ROLLOUT_BATCH_SIZE:-128}"
+GLOBAL_BATCH_SIZE="${GLOBAL_BATCH_SIZE:-128}"
+MAX_TOKENS_PER_GPU="${MAX_TOKENS_PER_GPU:-9216}"
+NUM_EPOCH="${NUM_EPOCH:-1}"
+NUM_ROLLOUT="${NUM_ROLLOUT:-3}"
+SAVE_INTERVAL="${SAVE_INTERVAL:-100000}"
+
+mkdir -p "${SAVE_DIR}" "${LOG_DIR}"
+source "${MODEL_SCRIPT}"
+
+export CUDA_DEVICE_MAX_CONNECTIONS="${CUDA_DEVICE_MAX_CONNECTIONS:-1}"
+export PYTHONUNBUFFERED=1
+export MASTER_ADDR="${MASTER_ADDR:-127.0.0.1}"
+export no_proxy="${no_proxy:-127.0.0.1,${MASTER_ADDR}}"
+
+BACKEND_ARGS=(
+   --train-backend megatron
+   --model-name qwen3_moe
+   --megatron-to-hf-mode "${MEGATRON_TO_HF_MODE}"
+)
+if [[ "${TRAIN_BACKEND}" == "mlite" ]]; then
+   BACKEND_ARGS+=(
+      --mlite-backend-patch
+      --mlite-model-name "${MLITE_MODEL_NAME}"
+      --mlite-impl lite
+      --mlite-optimizer-backend "${MLITE_OPTIMIZER_BACKEND}"
+   )
+   if [[ "${OPTIMIZER_OFFLOAD}" == "1" || "${OPTIMIZER_OFFLOAD}" == "true" || "${OPTIMIZER_OFFLOAD}" == "True" ]]; then
+      BACKEND_ARGS+=(--mlite-optimizer-offload)
+   fi
+   if [[ "${PARAM_OFFLOAD}" == "1" || "${PARAM_OFFLOAD}" == "true" || "${PARAM_OFFLOAD}" == "True" ]]; then
+      BACKEND_ARGS+=(--mlite-param-offload)
+   fi
+fi
+
+CKPT_ARGS=(
+   --hf-checkpoint "${MODEL_PATH}"
+   --save "${SAVE_DIR}"
+   --save-interval "${SAVE_INTERVAL}"
+)
+
+SFT_ARGS=(
+   --rollout-function-path miles.rollout.sft_rollout.generate_rollout
+   --prompt-data "${TRAIN_DATA}"
+   --input-key messages
+   --rollout-shuffle
+   --num-epoch "${NUM_EPOCH}"
+   --num-rollout "${NUM_ROLLOUT}"
+   --rollout-batch-size "${ROLLOUT_BATCH_SIZE}"
+   --global-batch-size "${GLOBAL_BATCH_SIZE}"
+   --loss-type sft_loss
+   --calculate-per-token-loss
+   --disable-compute-advantages-and-returns
+   --debug-train-only
+)
+
+PERF_ARGS=(
+   --tensor-model-parallel-size "${TP_SIZE}"
+   --sequence-parallel
+   --pipeline-model-parallel-size "${PP_SIZE}"
+   --context-parallel-size "${CP_SIZE}"
+   --expert-model-parallel-size "${EP_SIZE}"
+   --expert-tensor-parallel-size "${ETP_SIZE}"
+   --use-dynamic-batch-size
+   --max-tokens-per-gpu "${MAX_TOKENS_PER_GPU}"
+)
+
+OPTIMIZER_ARGS=(
+   --optimizer adam
+   --lr "${LR}"
+   --lr-decay-style constant
+   --weight-decay 0.1
+   --adam-beta1 0.9
+   --adam-beta2 0.95
+   --clip-grad 1.0
+)
+if [[ "${TRAIN_BACKEND}" == "megatron" ]] && [[ "${OPTIMIZER_OFFLOAD}" == "1" || "${OPTIMIZER_OFFLOAD}" == "true" || "${OPTIMIZER_OFFLOAD}" == "True" ]]; then
+   OPTIMIZER_ARGS+=(
+      --optimizer-cpu-offload
+      --overlap-cpu-optimizer-d2h-h2d
+      --use-precision-aware-optimizer
+   )
+fi
+
+MISC_ARGS=(
+   --attention-dropout 0.0
+   --hidden-dropout 0.0
+   --attention-backend flash
+   --log-throughput
+)
+
+JOB_ARGS=(
+   python3 -m miles_mlite.launch
+   --actor-num-nodes 1
+   --actor-num-gpus-per-node "${NUM_GPUS}"
+   --num-gpus-per-node "${NUM_GPUS}"
+   "${MODEL_ARGS[@]}"
+   "${BACKEND_ARGS[@]}"
+   "${CKPT_ARGS[@]}"
+   "${SFT_ARGS[@]}"
+   "${OPTIMIZER_ARGS[@]}"
+   "${PERF_ARGS[@]}"
+   "${MISC_ARGS[@]}"
+)
+
+RUNTIME_ENV_JSON="$(
+python3 - <<PY
+import json, os
+paths = ["${EXAMPLE_ROOT}", "${LITE_ROOT}/examples", "${LITE_ROOT}", "${REPO_ROOT}", "${MILES_ROOT}", "${MEGATRON_ROOT}"]
+env = {
+    "PYTHONPATH": ":".join(paths + [os.environ.get("PYTHONPATH", "")]),
+    "CUDA_DEVICE_MAX_CONNECTIONS": os.environ.get("CUDA_DEVICE_MAX_CONNECTIONS", "1"),
+}
+print(json.dumps({"env_vars": env}))
+PY
+)"
+
+if [[ "${DRY_RUN}" == "1" ]]; then
+   printf 'inner ray start: ray start --head --node-ip-address=%q --num-gpus=%q --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port=%q\n' "${MASTER_ADDR}" "${NUM_GPUS}" "${RAY_DASHBOARD_PORT:-8265}"
+   printf 'inner ray job: ray job submit --address=%q --runtime-env-json=%q -- ' "${RAY_ADDRESS:-http://127.0.0.1:8265}" "${RUNTIME_ENV_JSON}"
+   printf '%q ' "${JOB_ARGS[@]}"
+   printf '\n'
+   exit 0
+fi
+
+trap 'ray stop --force || true' EXIT
+ray stop --force || true
+ray start --head --node-ip-address "${MASTER_ADDR}" --num-gpus "${NUM_GPUS}" --disable-usage-stats --dashboard-host=0.0.0.0 --dashboard-port="${RAY_DASHBOARD_PORT:-8265}"
+set +e
+ray job submit \
+   --address "${RAY_ADDRESS:-http://127.0.0.1:8265}" \
+   --runtime-env-json "${RUNTIME_ENV_JSON}" \
+   -- \
+   "${JOB_ARGS[@]}"
+rc=$?
+set -e
+echo "MILES_${TRAIN_BACKEND^^}_SFT_DONE rc=${rc}"
+exit "${rc}"

--- a/experimental/lite/examples/verl/README.md
+++ b/experimental/lite/examples/verl/README.md
@@ -25,7 +25,7 @@ Install or expose these packages before running:
 
 - VERL with the new engine worker path.
   See [`REQUIRED_VERL.txt`](REQUIRED_VERL.txt) for the reference upstream
-  release tag.
+  source pin (commit).
 - Megatron-LM from this repository, or another source tree via
   `MEGATRON_ROOT=/path/to/Megatron-LM`.
 - Megatron Lite from this repository. The script automatically adds
@@ -149,16 +149,15 @@ Useful GRPO knobs:
 - `ACTOR_TP`, `ACTOR_PP`, `ACTOR_VPP`, `ACTOR_CP`, `ACTOR_EP`, `ACTOR_ETP`
 - `PARAM_OFFLOAD`, `OPTIMIZER_OFFLOAD`, `GRAD_OFFLOAD`
 - `INFER_BACKEND=vllm`
-- `USE_LEGACY_WORKER_IMPL=disable` to use VERL's new engine worker path
 - `POLICY_LOSS_MODE=vanilla` and `LOSS_AGG_MODE=seq-mean-token-sum-norm`
   select the pure GRPO baseline policy loss and aggregation mode.
 
 The GRPO launcher keeps the reference policy disabled by default
 (`algorithm.use_kl_in_reward=False`, `actor_rollout_ref.actor.use_kl_loss=False`)
 so the example exercises the current MLite actor path without expanding scope
-to a separate reference model. It also disables VERL's legacy worker path by
-default so `actor@actor_rollout_ref.actor=mlite_actor` is handled by the new
-engine worker implementation.
+to a separate reference model. On latest verl, both the v0 and V1 trainer paths
+route `actor@actor_rollout_ref.actor=mlite_actor` to the unified engine workers,
+so the MLite actor is wired up correctly without any extra worker-path knob.
 
 By default, GSM8K GRPO artifacts are written under
 `experimental/lite/examples/verl/outputs/qwen35_gsm8k_grpo`.
@@ -189,4 +188,4 @@ cover end-to-end SFT or GRPO training.
     `actor_rollout_ref.actor.engine.impl=lite`,
     `actor_rollout_ref.actor.engine.ep=8`,
     `algorithm.adv_estimator=grpo`, `actor_rollout_ref.actor.policy_loss.loss_mode=vanilla`,
-    `critic.enable=False`, and `trainer.use_legacy_worker_impl=disable`.
+    and `critic.enable=False`.

--- a/experimental/lite/examples/verl/REQUIRED_VERL.txt
+++ b/experimental/lite/examples/verl/REQUIRED_VERL.txt
@@ -1,3 +1,4 @@
-# Reference VERL release for the Megatron Lite VERL example.
-# Latest GitHub release checked on 2026-06-06: v0.8.0.
-verl @ git+https://github.com/verl-project/verl.git@v0.8.0
+# Reference VERL source for the Megatron Lite VERL example.
+# Requires verl latest main (engine-worker / V1 trainer architecture).
+# Pinned reference commit: a6ef5009 (verl main as of 2026-06-22).
+verl @ git+https://github.com/verl-project/verl.git@a6ef5009

--- a/experimental/lite/examples/verl/scripts/run_qwen3moe_gsm8k_grpo.sh
+++ b/experimental/lite/examples/verl/scripts/run_qwen3moe_gsm8k_grpo.sh
@@ -114,7 +114,8 @@ RESUME_MODE="${RESUME_MODE:-auto}"
 RESUME_FROM_PATH="${RESUME_FROM_PATH:-null}"
 LOG_VAL_GENERATIONS="${LOG_VAL_GENERATIONS:-10}"
 LOGGER="${LOGGER:-[console,file]}"
-USE_LEGACY_WORKER_IMPL="${USE_LEGACY_WORKER_IMPL:-disable}"
+# Recent VERL always uses the unified engine workers; the launcher sets no
+# worker-path override.
 DRY_RUN="${DRY_RUN:-0}"
 EXTRA_ARGS=("$@")
 
@@ -163,8 +164,8 @@ export TRITON_CACHE_DIR="${TRITON_CACHE_DIR:-${CACHE_ROOT}/triton_${USER:-user}}
 
 ALGORITHM=(
   "algorithm.adv_estimator=grpo"
-  "algorithm.use_kl_in_reward=False"
-  "algorithm.kl_ctrl.kl_coef=0.0"
+  "algorithm.use_kl_in_reward=${USE_KL_IN_REWARD:-False}"
+  "algorithm.kl_ctrl.kl_coef=${KL_COEF:-0.0}"
   "algorithm.rollout_correction.bypass_mode=True"
   "algorithm.norm_adv_by_std_in_grpo=False"
 )
@@ -200,8 +201,8 @@ ACTOR=(
   "actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=${ACTOR_PPO_MICRO_BATCH_SIZE_PER_GPU}"
   "actor_rollout_ref.actor.use_dynamic_bsz=${USE_DYNAMIC_BSZ}"
   "actor_rollout_ref.actor.ppo_max_token_len_per_gpu=${PPO_MAX_TOKEN_LEN_PER_GPU}"
-  "actor_rollout_ref.actor.use_kl_loss=False"
-  "actor_rollout_ref.actor.kl_loss_coef=0.0"
+  "actor_rollout_ref.actor.use_kl_loss=${USE_KL_LOSS:-False}"
+  "actor_rollout_ref.actor.kl_loss_coef=${KL_LOSS_COEF:-0.0}"
   "actor_rollout_ref.actor.entropy_coeff=${ENTROPY_COEFF}"
   "actor_rollout_ref.actor.policy_loss.loss_mode=${POLICY_LOSS_MODE}"
   "actor_rollout_ref.actor.loss_agg_mode=${LOSS_AGG_MODE}"
@@ -228,6 +229,15 @@ if [[ "${OPTIMIZER_OFFLOAD}" == "True" || "${OPTIMIZER_OFFLOAD}" == "true" || "$
     "+actor_rollout_ref.actor.optim.override_optimizer_config.use_precision_aware_optimizer=${USE_PRECISION_AWARE_OPTIMIZER}"
     "+actor_rollout_ref.actor.optim.override_optimizer_config.decoupled_weight_decay=${DECOUPLED_WEIGHT_DECAY}"
   )
+fi
+
+# Reference policy: only built when KL loss/reward is enabled. Route it through
+# the mlite engine (forward-only) so it runs on the same mesh as the actor;
+# otherwise the ref worker falls back to the FSDP engine config and mlite's
+# get_data_parallel_size() raises AttributeError on the missing `tp` field. Left
+# off the default path so KL-free GRPO never composes the ref override.
+if [[ "${USE_KL_LOSS:-False}" =~ ^(True|true|1)$ || "${USE_KL_IN_REWARD:-False}" =~ ^(True|true|1)$ ]]; then
+  ACTOR+=("ref@actor_rollout_ref.ref=mlite_ref")
 fi
 
 ROLLOUT=(
@@ -279,7 +289,6 @@ TRAINER=(
   "trainer.default_local_dir=${CKPT_DIR}"
   "trainer.val_before_train=False"
   "trainer.log_val_generations=${LOG_VAL_GENERATIONS}"
-  "trainer.use_legacy_worker_impl=${USE_LEGACY_WORKER_IMPL}"
 )
 
 COMMAND=(

--- a/experimental/lite/examples/verl/verl_mlite/config/ref/__init__.py
+++ b/experimental/lite/examples/verl/verl_mlite/config/ref/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.

--- a/experimental/lite/examples/verl/verl_mlite/config/ref/mlite_ref.yaml
+++ b/experimental/lite/examples/verl/verl_mlite/config/ref/mlite_ref.yaml
@@ -1,0 +1,41 @@
+# Megatron Lite reference-model config for VERL's new engine worker path.
+#
+# The reference policy is built by ActorRolloutRefWorker from
+# `actor_rollout_ref.ref.engine`, independently of the actor. Without an mlite
+# ref config the ref worker falls back to the default FSDP engine config, whose
+# object has no `tp`/`cp`/`pp`, so mlite's get_data_parallel_size() raises
+# `AttributeError: 'FSDPEngineConfig' object has no attribute 'tp'` as soon as a
+# reference policy is requested (use_kl_loss / use_kl_in_reward). This config
+# routes the ref worker through the mlite engine, forward-only, mirroring the
+# actor's parallel layout so the reference log-probs are computed on the same
+# mesh as the actor.
+#
+# Wire it from the launcher with:  ref@actor_rollout_ref.ref=mlite_ref
+defaults:
+  - ref
+  - /optim@optim: megatron
+  - /engine@engine: mlite
+  - _self_
+
+_target_: verl.workers.config.ActorConfig
+
+strategy: mlite
+
+engine:
+  # ref model is forward-only (no optimizer / backward)
+  forward_only: True
+  # mirror the actor's parallel layout so ref runs on the same mesh
+  model_name: ${oc.select:actor_rollout_ref.actor.engine.model_name,auto}
+  impl: ${oc.select:actor_rollout_ref.actor.engine.impl,lite}
+  dtype: ${oc.select:actor_rollout_ref.actor.engine.dtype,bfloat16}
+  tp: ${oc.select:actor_rollout_ref.actor.engine.tp,1}
+  pp: ${oc.select:actor_rollout_ref.actor.engine.pp,1}
+  vpp: ${oc.select:actor_rollout_ref.actor.engine.vpp,1}
+  cp: ${oc.select:actor_rollout_ref.actor.engine.cp,1}
+  ep: ${oc.select:actor_rollout_ref.actor.engine.ep,1}
+  etp: ${oc.select:actor_rollout_ref.actor.engine.etp,null}
+  attention_backend_override: ${oc.select:actor_rollout_ref.actor.engine.attention_backend_override,flash}
+  # ref only runs forward, so default to offloading params to free GPU memory
+  param_offload: ${oc.select:actor_rollout_ref.ref.param_offload,True}
+  impl_cfg:
+    use_thd: ${oc.select:actor_rollout_ref.actor.engine.impl_cfg.use_thd,true}

--- a/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
+++ b/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
@@ -23,8 +23,16 @@ from tensordict import TensorDict
 from verl.trainer.config import CheckpointConfig
 from verl.utils import tensordict_utils as tu
 from verl.utils.device import get_device_id, get_device_name
+from verl.utils.memory_utils import aggressive_empty_cache
 from verl.workers.config import HFModelConfig, OptimizerConfig
 from verl_mlite.compat import load_verl_engine_api
+
+try:
+    # Recent VERL wraps per-step metric values in a Metric aggregator that
+    # reduce_metrics() knows how to fold; older VERL expects list-of-scalars.
+    from verl.utils.metric import Metric as _VerlMetric
+except Exception:  # pragma: no cover - older VERL without Metric
+    _VerlMetric = None
 
 from .config import MegatronLiteEngineConfig
 
@@ -363,6 +371,9 @@ class MegatronLiteEngine(BaseEngine):
         self._require_initialized()
         if self.is_param_offload_enabled:
             self.to("cuda", model=True, optimizer=False, grad=False)
+        if not getattr(self, "_initial_sync_cache_cleared", False):
+            aggressive_empty_cache(force_sync=True)
+            self._initial_sync_cache_cleared = True
         export_kwargs = {
             key: kwargs[key]
             for key in ("limit", "include_mtp_only", "include_local_prefixes")
@@ -662,8 +673,9 @@ class MegatronLiteEngine(BaseEngine):
             )
 
         runtime_loss_fn = None
+        reduced_outputs = [] if (loss_function is not None or forward_only) and self.is_mp_src_rank_with_outputs() else None
         if loss_function is not None or forward_only:
-            runtime_loss_fn = self._make_runtime_loss_fn(loss_function, forward_only=forward_only)
+            runtime_loss_fn = self._make_runtime_loss_fn(loss_function, num_micro_batches, reduced_outputs)
 
         result = self.runtime.forward_backward(
             self.handle,
@@ -672,15 +684,23 @@ class MegatronLiteEngine(BaseEngine):
             num_microbatches=num_micro_batches,
             forward_only=forward_only,
         )
+        if reduced_outputs is not None:
+            return postprocess_batch_func(output_lst=reduced_outputs, indices=indices, data=data)
         metrics = dict(result.metrics)
-        micro_outputs = metrics.pop("_micro_outputs", None)
-        if micro_outputs is not None and self.is_mp_src_rank_with_outputs():
-            return postprocess_batch_func(output_lst=micro_outputs, indices=indices, data=data)
-        loss = float(metrics.get("loss", 0.0))
+        loss = result.model_output.loss
+        losses = [] if loss is None else torch.as_tensor(loss).detach().flatten().cpu().tolist()
         return {
             "model_output": {},
-            "loss": [loss],
-            "metrics": {key: [value] for key, value in metrics.items()},
+            "loss": losses,
+            # Pass Metric aggregators through unchanged (reduce_metrics folds them);
+            # list-wrap plain scalars as the legacy contract expects.
+            "metrics": {
+                key: value
+                if isinstance(value, list)
+                or (_VerlMetric is not None and isinstance(value, _VerlMetric))
+                else [value]
+                for key, value in metrics.items()
+            },
         }
 
     def _make_runtime_batch(self, micro_batch: TensorDict) -> PackedBatch:
@@ -765,7 +785,7 @@ class MegatronLiteEngine(BaseEngine):
             output["entropy"] = unpack(self.module, runtime_batch, entropy)
         return output
 
-    def _make_runtime_loss_fn(self, loss_function, *, forward_only: bool):
+    def _make_runtime_loss_fn(self, loss_function, num_microbatches: int, output_lst=None):
         def _loss_fn(
             raw_output: dict[str, torch.Tensor],
             runtime_batch: PackedBatch,
@@ -794,7 +814,15 @@ class MegatronLiteEngine(BaseEngine):
                 )
 
             raw_output["_verl_metrics"] = metrics
-            return loss, metrics
+            if output_lst is not None:
+                output_lst.append(
+                    {
+                        "model_output": model_output,
+                        "loss": float(loss.detach().item()),
+                        "metrics": metrics,
+                    }
+                )
+            return (loss * num_microbatches if loss_function is not None else loss), metrics
 
         return _loss_fn
 

--- a/experimental/lite/megatron/lite/model/deepseek_v4/__init__.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/__init__.py
@@ -1,0 +1,1 @@
+from .config import DeepseekV4Config

--- a/experimental/lite/megatron/lite/model/deepseek_v4/__init__.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/__init__.py
@@ -1,1 +1,2 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 from .config import DeepseekV4Config

--- a/experimental/lite/megatron/lite/model/deepseek_v4/config.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/config.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+from __future__ import annotations
+
+from dataclasses import dataclass, field, fields
+from typing import Any
+
+from megatron.lite.primitive.config import load_hf_config_dict
+
+
+@dataclass
+class DeepseekV4Config:
+    vocab_size: int = 129280
+    hidden_size: int = 4096
+    moe_intermediate_size: int = 2048
+    num_hidden_layers: int = 43
+    num_attention_heads: int = 64
+    num_key_value_heads: int = 1
+    head_dim: int = 128
+    qk_rope_head_dim: int = 64
+    q_lora_rank: int = 1024
+    o_lora_rank: int = 1024
+    o_groups: int = 8
+    n_routed_experts: int = 256
+    n_shared_experts: int = 1
+    num_experts_per_tok: int = 6
+    routed_scaling_factor: float = 1.5
+    norm_topk_prob: bool = True
+    scoring_func: str = "sqrtsoftplus"
+    swiglu_limit: float = 10.0
+    max_position_embeddings: int = 1_048_576
+    rope_theta: float = 10_000.0
+    compress_rope_theta: float = 160_000.0
+    rotary_scaling_factor: float = 40.0
+    original_max_position_embeddings: int = 4096
+    beta_fast: float = 32.0
+    beta_slow: float = 1.0
+    compress_ratios: list[int] = field(default_factory=list)
+    sliding_window: int = 128
+    num_hash_layers: int = 3
+    hc_eps: float = 1e-6
+    hc_mult: int = 4
+    hc_sinkhorn_iters: int = 20
+    index_head_dim: int = 128
+    index_n_heads: int = 64
+    index_topk: int = 512
+    num_nextn_predict_layers: int = 1
+    mtp_loss_scaling_factor: float = 0.1
+    rms_norm_eps: float = 1e-6
+    initializer_range: float = 0.02
+
+    @property
+    def num_experts(self) -> int:
+        return self.n_routed_experts
+
+    @classmethod
+    def from_hf(cls, path: str, **overrides) -> DeepseekV4Config:
+        return cls._from_hf_dict(load_hf_config_dict(path), **overrides)
+
+    @classmethod
+    def _from_hf_dict(cls, hf: dict[str, Any], **overrides) -> DeepseekV4Config:
+        hf_fields = {item.name for item in fields(cls)}
+        kwargs = {key: value for key, value in hf.items() if key in hf_fields and value is not None}
+        if "num_nextn_predict_layers" not in kwargs and hf.get("num_nextn_predict") is not None:
+            kwargs["num_nextn_predict_layers"] = int(hf["num_nextn_predict"])
+        rope_parameters = hf.get("rope_parameters")
+        if isinstance(rope_parameters, dict):
+            if "rope_theta" not in kwargs:
+                kwargs["rope_theta"] = float(rope_parameters.get("rope_theta", cls.rope_theta))
+        rope_scaling = hf.get("rope_scaling")
+        if isinstance(rope_scaling, dict):
+            if rope_scaling.get("factor") is not None:
+                kwargs["rotary_scaling_factor"] = float(rope_scaling["factor"])
+            if rope_scaling.get("original_max_position_embeddings") is not None:
+                kwargs["original_max_position_embeddings"] = int(
+                    rope_scaling["original_max_position_embeddings"]
+                )
+            if rope_scaling.get("beta_fast") is not None:
+                kwargs["beta_fast"] = float(rope_scaling["beta_fast"])
+            if rope_scaling.get("beta_slow") is not None:
+                kwargs["beta_slow"] = float(rope_scaling["beta_slow"])
+        kwargs.update(overrides)
+        return cls(**kwargs)

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/__init__.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Native DeepSeek V4 (ds4flash) lite implementation."""
+
+from megatron.lite.model.deepseek_v4.lite.model import DeepseekV4Model
+
+__all__ = ["DeepseekV4Model"]

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/checkpoint.py
@@ -1,0 +1,518 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""DeepSeek V4 (ds4flash) lite native <-> HF checkpoint mapping.
+
+Like kimi_k2 / glm5: ``DeepseekV4WeightSpec`` encodes the per-param native -> HF
+name (+ TP/EP shard spec); export/save route through the shared
+``primitive/ckpt/hf_weights.py`` exporter (its PP ``all_gather_object`` is
+reached by all ranks before any ``rank0_only`` filter, so PP>1 export doesn't
+desync).  Native names are bare ``DeepseekV4Model`` keys; ``self.layers`` is a
+ModuleDict keyed by GLOBAL layer index (kimi uses a local ModuleList), so the
+exporter's local->global remap is an identity here.
+
+HF targets are canonical HF DeepSeek (``model.embed_tokens.weight`` /
+``model.norm.weight`` / ``lm_head.weight`` / ``model.layers.<i>.self_attn.*`` /
+``...mlp.experts.<id>.{gate,up,down}_proj.weight``).  DS4 extras:
+  * CSA: ``self_attn.*`` incl. ``compressor.*`` / ``indexer.*``; ``sinks`` ->
+    ``self_attn.attn_sink``.
+  * mHC: ``attn_hc`` / ``ffn_hc`` -> ``...self_attn.hc_*`` / ``...mlp.hc_*``;
+    model-wide ``hc_head`` -> ``model.hc_head.*`` (no HF analogue, kept
+    model.-rooted; fidelity vs Megatron's latest mHC is a TODO).
+  * MTP: folded into the decoder namespace at ``model.layers.<num_hidden+i>``.
+
+CSA is not TP-capable: DS4 runs TP=ETP=1 (only EP shards experts), like GLM-5.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+
+from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
+from megatron.lite.primitive.ckpt.hf_weights import (
+    SafeTensorReader,
+    _cast_export_tensor,
+    _resolve_export_dtype,
+    parse_expert_idx,
+    to_global_layer_name,
+    unwrap_model,
+)
+from megatron.lite.primitive.parallel import ParallelState
+from megatron.lite.primitive.utils import ensure_divisible, log_rank0
+
+
+def EXPERT_CLASSIFIER(name: str) -> bool:
+    return ".experts." in name and ".shared_experts." not in name
+
+
+def PLACEMENT_FN(param_name: str) -> list:
+    # distckpt sharded placement (TP=ETP=1 for ds4; shares kimi/glm5's
+    # Experts/SwiGLUMLP/VocabParallel structure). EP-sharded experts must carry
+    # an explicit placement or the dist-opt checkpoint won't restore them
+    # bit-exactly. The CSA/mHC/MTP-norm params fall through to all-Replicate.
+    from torch.distributed.tensor import Replicate, Shard
+
+    if ".experts." in param_name and ".shared_experts." not in param_name:
+        if "fc1" in param_name:
+            return [Replicate(), Replicate(), Shard(0), Shard(0)]
+        if "fc2" in param_name:
+            return [Replicate(), Replicate(), Shard(0), Shard(1)]
+        return [Replicate(), Replicate(), Replicate(), Replicate()]
+    if "eh_proj.linear.weight" in param_name:
+        return [Replicate(), Replicate(), Replicate(), Shard(0)]
+    if "gate_up" in param_name:
+        return [Replicate(), Replicate(), Replicate(), Shard(0)]
+    if "down" in param_name:
+        return [Replicate(), Replicate(), Replicate(), Shard(1)]
+    if "embed" in param_name or "head" in param_name:
+        return [Replicate(), Replicate(), Replicate(), Shard(0)]
+    return [Replicate(), Replicate(), Replicate(), Replicate()]
+
+
+# Native <-> HF name mapping (shared by export spec and load path).  Native
+# names are bare DeepseekV4Model state_dict keys with GLOBAL layer indices.
+_BLOCK_KEY_RE = re.compile(r"^(layers|mtp)\.(\d+)\.(.+)$")
+_GROUPED_EXPERT_RE = re.compile(r"^mlp\.experts\.fc([12])\.weight(\d+)$")
+# Native top-level params -> real DeepSeek-V4-Flash release names (NOT DeepSeek-V3 HF
+# names; the V4 release uses bare `embed.weight` / `head.weight` / `norm.weight` and a
+# `layers.N.attn.* / ffn.* / hc_*` layout). This same mapping drives both the load path
+# and the export spec, so MLite round-trips against the real release / vLLM ds4 format.
+_TOP_LEVEL = {
+    "embed_tokens.embedding.weight": "embed.weight",
+    "norm.weight": "norm.weight",
+    "hc_head.hc_fn": "hc_head_fn",
+    "hc_head.hc_base": "hc_head_base",
+    "hc_head.hc_scale": "hc_head_scale",
+    "lm_head.col.linear.weight": "head.weight",
+}
+
+
+def _map_block_attr(attr: str, block: str) -> str | tuple[str, ...] | None:
+    """Map a native per-block attr -> real V4-Flash suffix (relative to layers.N / mtp.N)."""
+    if attr == "input_layernorm.weight":
+        return "attn_norm.weight"
+    if attr == "post_attention_layernorm.weight":
+        return "ffn_norm.weight"
+    # CSA attention: native `self_attn.self_attn.*` (the SBHD wrapper adds one extra
+    # `self_attn` level) -> real `attn.*`. Covers compressor.* / indexer.* / wq_a / wkv / ...
+    sub = None
+    if attr.startswith("self_attn.self_attn."):
+        sub = attr.removeprefix("self_attn.self_attn.")
+    elif attr.startswith("self_attn."):
+        sub = attr.removeprefix("self_attn.")
+    if sub is not None:
+        return "attn.attn_sink" if sub == "sinks" else f"attn.{sub}"
+    if attr.startswith("mlp.gate."):
+        suffix = attr.removeprefix("mlp.gate.")
+        return "ffn.gate." + {
+            "gate.weight": "weight",
+            "weight": "weight",
+            "expert_bias": "bias",
+            "e_score_correction_bias": "bias",
+            "tid2eid": "tid2eid",
+        }.get(suffix, suffix)
+    if attr.startswith("mlp.shared_experts."):
+        proj = attr.removeprefix("mlp.shared_experts.").removesuffix(".weight")
+        if proj == "gate_up":
+            return "ffn.shared_experts.w1.weight", "ffn.shared_experts.w3.weight"
+        if proj == "down":
+            return "ffn.shared_experts.w2.weight"
+        return f"ffn.shared_experts.{proj}.weight"
+    # mHC (hyper-connections): native attn_hc/ffn_hc.{base,fn,scale} -> hc_attn_*/hc_ffn_*;
+    # mtp carries its own hc_head.hc_* -> hc_head_*.
+    for prefix, target in (("attn_hc", "hc_attn"), ("ffn_hc", "hc_ffn")):
+        if attr.startswith(f"{prefix}."):
+            return f"{target}_{attr.rsplit('.', 1)[-1]}"
+    if attr.startswith("hc_head."):
+        return f"hc_head_{attr.rsplit('.', 1)[-1].removeprefix('hc_')}"
+    if block == "mtp" and attr in {
+        "e_proj.weight",
+        "h_proj.weight",
+        "enorm.weight",
+        "hnorm.weight",
+        "norm.weight",
+    }:
+        return attr
+    return None
+
+
+def _global_expert_idx_from_local(local_idx: int, config: DeepseekV4Config, ps: ParallelState) -> int:
+    num_local = ensure_divisible(config.n_routed_experts, ps.ep_size)
+    return ps.ep_rank * num_local + local_idx
+
+
+def _hf_names_for_state_key(name: str, config: DeepseekV4Config) -> list[str]:
+    """Map a bare DS4 native key (global layer idx, global expert id) to HF name(s).
+
+    Callers (load path + shared exporter) supply global expert ids first.
+    """
+    mapped = _TOP_LEVEL.get(name)
+    if mapped is not None:
+        return [mapped]
+    match = _BLOCK_KEY_RE.match(name)
+    if match is None:
+        return []
+    block, index, attr = match.groups()
+    # Real V4-Flash keeps decoder layers under ``layers.{i}`` and the MTP block under its
+    # own ``mtp.{i}`` namespace (no ``model.`` prefix, no continued global index).
+    prefix = f"layers.{index}" if block == "layers" else f"mtp.{index}"
+    mapped = _map_block_attr(attr, block)
+    if mapped is not None:
+        if isinstance(mapped, tuple):
+            return [f"{prefix}.{part}" for part in mapped]
+        return [f"{prefix}.{mapped}"]
+    expert = _GROUPED_EXPERT_RE.match(attr)
+    if expert is None:
+        return []
+    fc, expert_id = expert.groups()
+    # native fused gate_up (fc1) -> real w1 (gate) + w3 (up); fc2 -> w2 (down).
+    expert_prefix = f"{prefix}.ffn.experts.{int(expert_id)}"
+    if fc == "1":
+        return [f"{expert_prefix}.w1.weight", f"{expert_prefix}.w3.weight"]
+    return [f"{expert_prefix}.w2.weight"]
+
+
+# ======================================================================
+# FP4 / scaled-tensor dequant helpers (load path).
+# ======================================================================
+
+_FP4_E2M1_TABLE = (
+    0.0,
+    0.5,
+    1.0,
+    1.5,
+    2.0,
+    3.0,
+    4.0,
+    6.0,
+    0.0,
+    -0.5,
+    -1.0,
+    -1.5,
+    -2.0,
+    -3.0,
+    -4.0,
+    -6.0,
+)
+
+
+def _has(reader: SafeTensorReader, name: str) -> bool:
+    if reader.index:
+        return name in reader.index
+    try:
+        reader.get_tensor(name)
+    except Exception:
+        return False
+    return True
+
+
+def _is_native_metadata_key(name: str) -> bool:
+    return name.endswith("._extra_state")
+
+
+def _scale_name_for_hf_name(name: str) -> str:
+    return f"{name[:-7] if name.endswith('.weight') else name}.scale"
+
+
+def _scale_to_float(scale: torch.Tensor) -> torch.Tensor:
+    if scale.dtype.is_floating_point:
+        return scale.float()
+    if scale.dtype == torch.uint8:
+        return torch.pow(torch.tensor(2.0, dtype=torch.float32), scale.float() - 127.0)
+    return scale.float()
+
+
+def _expand_block_scale(
+    scale: torch.Tensor, target_shape: torch.Size | tuple[int, ...]
+) -> torch.Tensor:
+    target = tuple(int(dim) for dim in target_shape)
+    while scale.ndim > len(target) and scale.shape[0] == 1:
+        scale = scale.squeeze(0)
+    while scale.ndim < len(target):
+        scale = scale.unsqueeze(-1)
+    if tuple(scale.shape) == target:
+        return scale
+    out = scale
+    for dim, size in enumerate(target):
+        if out.shape[dim] == size:
+            continue
+        repeat = math.ceil(size / out.shape[dim])
+        out = out.repeat_interleave(repeat, dim=dim)
+    slices = tuple(slice(0, size) for size in target)
+    return out[slices]
+
+
+def _unpack_fp4_e2m1_if_needed(
+    tensor: torch.Tensor, target_shape: torch.Size | tuple[int, ...]
+) -> torch.Tensor:
+    target = tuple(int(dim) for dim in target_shape)
+    if (
+        tensor.dtype != torch.int8
+        or tensor.ndim != len(target)
+        or tuple(tensor.shape[:-1]) != target[:-1]
+        or tensor.shape[-1] * 2 != target[-1]
+    ):
+        return tensor.float()
+
+    table = torch.tensor(_FP4_E2M1_TABLE, dtype=torch.float32, device=tensor.device)
+    packed = tensor.view(torch.uint8)
+    low = packed & 0x0F
+    high = (packed >> 4) & 0x0F
+    return torch.stack((table[low.long()], table[high.long()]), dim=-1).flatten(-2)
+
+
+def _dequantize_scaled_tensor(
+    tensor: torch.Tensor, scale: torch.Tensor, shape: torch.Size
+) -> torch.Tensor:
+    scale_f = _expand_block_scale(_scale_to_float(scale), shape)
+    return _unpack_fp4_e2m1_if_needed(tensor, shape) * scale_f
+
+
+def _copy_param(
+    param: nn.Parameter | torch.Tensor,
+    tensor: torch.Tensor,
+    *,
+    scale: torch.Tensor | None = None,
+) -> None:
+    if scale is not None:
+        tensor = _dequantize_scaled_tensor(tensor, scale, param.shape)
+    elif param.dtype.is_floating_point and not tensor.dtype.is_floating_point:
+        raise RuntimeError(
+            f"Refusing to copy quantized tensor with dtype {tensor.dtype} into {tuple(param.shape)} "
+            "without a matching .scale tensor."
+        )
+    param.data.copy_(tensor.to(device=param.device, dtype=param.dtype))
+
+
+def _read_hf_tensor(
+    reader: SafeTensorReader, hf_name: str, target_shape: torch.Size | tuple[int, ...]
+) -> torch.Tensor:
+    scale_name = _scale_name_for_hf_name(hf_name)
+    tensor = reader.get_tensor(hf_name)
+    scale = reader.get_tensor(scale_name) if _has(reader, scale_name) else None
+    if scale is not None:
+        return _dequantize_scaled_tensor(tensor, scale, torch.Size(target_shape))
+    return tensor
+
+
+def load_hf_weights(
+    model: nn.Module, path: str, config: DeepseekV4Config, ps: ParallelState
+) -> None:
+    """Load HF safetensors into the DS4 model.
+
+    Kept as DS4's native loader (the inverse of the spec's ``native_to_hf``):
+    it walks the native ``state_dict`` and resolves each key's HF name(s) via
+    ``_hf_names_for_state_key`` -- the SAME mapping the export spec uses, so the
+    round-trip names stay consistent.  EP-local expert ids are converted to
+    global before mapping.  CSA is TP=ETP=1, so there is no TP split here.
+
+    Under PP the ``self.layers`` ModuleDict is keyed by LOCAL pipeline position,
+    so -- like the exporter -- the local layer index is lifted to global before
+    mapping (identity at PP=1); else a non-first stage reads the wrong layer.
+    """
+    if (ps.tp_size, ps.etp_size) != (1, 1):
+        raise NotImplementedError("DeepSeek V4 direct HF load currently supports only TP=ETP=1.")
+
+    reader = SafeTensorReader(path)
+    base_model = unwrap_model(model)
+    state = base_model.state_dict()
+    # local pipeline position -> global layer index (identity at PP=1)
+    layer_map = (
+        {i: base_model.layer_indices[i] for i in range(len(base_model.layer_indices))}
+        if hasattr(base_model, "layer_indices")
+        else {}
+    )
+    loaded = 0
+    missing: list[str] = []
+    for name, target in state.items():
+        if _is_native_metadata_key(name):
+            continue
+        global_name = to_global_layer_name(name, layer_map)
+        hf_names = _hf_names_for_state_key(_to_global_expert_name(global_name, config, ps), config)
+        if not hf_names or not all(_has(reader, hf_name) for hf_name in hf_names):
+            missing.append(name)
+            continue
+        if len(hf_names) == 2:
+            first = target.shape[0] // 2
+            tensor = torch.cat(
+                [
+                    _read_hf_tensor(reader, hf_names[0], (first, *target.shape[1:])),
+                    _read_hf_tensor(
+                        reader, hf_names[1], (target.shape[0] - first, *target.shape[1:])
+                    ),
+                ],
+                dim=0,
+            )
+            target.data.copy_(tensor.to(device=target.device, dtype=target.dtype))
+        else:
+            scale_name = _scale_name_for_hf_name(hf_names[0])
+            scale = reader.get_tensor(scale_name) if _has(reader, scale_name) else None
+            _copy_param(target, reader.get_tensor(hf_names[0]), scale=scale)
+        loaded += 1
+
+    log_rank0(f"DeepSeek V4 native loaded {loaded} tensors from {path}")
+    for name in missing:
+        log_rank0(f"WARNING: DeepSeek V4 checkpoint tensor missing: {name}")
+
+
+def _to_global_expert_name(name: str, config: DeepseekV4Config, ps: ParallelState) -> str:
+    """Rewrite an EP-local expert ``weight<local>`` suffix to its global id.
+
+    The native ``state_dict`` carries the EP-local expert index; the HF target
+    name uses the global expert id.  Non-expert names pass through unchanged.
+    """
+    match = _BLOCK_KEY_RE.match(name)
+    if match is None:
+        return name
+    block, index, attr = match.groups()
+    expert = _GROUPED_EXPERT_RE.match(attr)
+    if expert is None:
+        return name
+    fc, local_idx = expert.groups()
+    global_idx = _global_expert_idx_from_local(int(local_idx), config, ps)
+    return f"{block}.{index}.mlp.experts.fc{fc}.weight{global_idx}"
+
+
+# ======================================================================
+# Export: shared TP/ETP/EP/PP gather via DeepseekV4WeightSpec.
+# ======================================================================
+
+
+class DeepseekV4WeightSpec:
+    """Export DS4 lite weights to HF DeepSeek-V4 names (CSA / mHC / MTP / MoE).
+
+    Mirrors ``KimiK2WeightSpec`` / ``Glm5WeightSpec`` on DS4's bare native names
+    with global layer indices.  The shared exporter rewrites EP-local expert
+    ``weight<local>`` ids to global before calling ``native_to_hf``.
+    """
+
+    def __init__(self, config: DeepseekV4Config):
+        self.config = config
+
+    @property
+    def num_experts(self) -> int:
+        return self.config.n_routed_experts
+
+    def weight_map(self) -> dict[str, list[str]]:
+        return {}
+
+    def hf_to_native(self, native_name: str, hf_tensors: list[torch.Tensor]) -> torch.Tensor:
+        del native_name
+        return hf_tensors[0]
+
+    def native_to_hf(
+        self, native_name: str, tensor: torch.Tensor
+    ) -> list[tuple[str, torch.Tensor]]:
+        # ``native_name`` is the global native name; experts already carry the
+        # global expert id (shared exporter rewrote weight<local> -> weight<gid>).
+        hf_names = _hf_names_for_state_key(native_name, self.config)
+        if not hf_names:
+            return []
+        if len(hf_names) == 1:
+            return [(hf_names[0], tensor)]
+        if len(hf_names) == 2:
+            # 2 targets == fused gate/up split into (w1, w3) for shared/routed
+            # experts; split the leading dim exactly as the bespoke export did.
+            first, second = tensor.chunk(2, dim=0)
+            return [
+                (hf_names[0], first.contiguous()),
+                (hf_names[1], second.contiguous()),
+            ]
+        raise AssertionError(f"Unexpected HF name fan-out for {native_name}: {hf_names}")
+
+    def qkv_spec(self, native_name: str) -> tuple[int, int, int] | None:
+        del native_name
+        return None
+
+    def tp_spec(self, native_name: str) -> tuple[int, int] | None:
+        # DS4 is TP=ETP=1 (CSA is not TP-capable); only EP shards experts.  The
+        # expert (split_dim, ETP) entries are declared so the shared ETP path
+        # would be correct if ETP were ever enabled; embed/head/eh_proj carry
+        # the vocab split-dim spec for completeness (no-op at TP=1).
+        if self.is_expert(native_name):
+            if ".fc1." in native_name:
+                return (0, 1)
+            if ".fc2." in native_name:
+                return (1, 1)
+            return None
+        if native_name.endswith(".eh_proj.linear.weight"):
+            return (0, 0)
+        if native_name in {
+            "embed_tokens.embedding.weight",
+            "lm_head.col.linear.weight",
+        }:
+            return (0, 0)
+        return None
+
+    def is_expert(self, native_name: str) -> bool:
+        return ".mlp.experts." in native_name and ".shared_experts." not in native_name
+
+    def expert_global_id(self, native_name: str) -> int | None:
+        if self.is_expert(native_name):
+            return parse_expert_idx(native_name)
+        return None
+
+    def expert_local_name(self, native_name: str, local_idx: int) -> str:
+        prefix = native_name.rsplit(".weight", 1)[0]
+        return f"{prefix}.weight{local_idx}"
+
+
+def export_hf_weights(model, config: DeepseekV4Config, ps: ParallelState, **kwargs):
+    """Export DS4 weights as HF (name, tensor) pairs via the SHARED exporter.
+
+    Identical structure to kimi/glm5: delegate to the shared ``_export`` (which
+    does the TP/ETP/EP/PP gather, including the PP ``all_gather_object`` reached
+    by ALL ranks before any ``rank0_only`` filter), then append the persistent
+    router buffers (``tid2eid`` for hash layers, ``expert_bias`` for non-hash
+    layers) which the parameter-only ``_export`` does not visit.
+    """
+    from megatron.lite.primitive.ckpt.hf_weights import export_hf_weights as _export
+
+    spec = DeepseekV4WeightSpec(config)
+    rank0_only = bool(kwargs.get("rank0_only", False))
+    export_dtype = _resolve_export_dtype(kwargs.get("export_dtype"))
+    yield from _export(model, spec, ps, vocab_size=config.vocab_size, **kwargs)
+
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    if rank0_only and rank != 0:
+        return
+    chunks = list(model) if isinstance(model, list | nn.ModuleList) else [model]
+    for chunk in chunks:
+        base_chunk = unwrap_model(chunk)
+        layer_map = (
+            {i: base_chunk.layer_indices[i] for i in range(len(base_chunk.layer_indices))}
+            if hasattr(base_chunk, "layer_indices")
+            else {}
+        )
+        for name, buffer in base_chunk.named_buffers():
+            # Persistent router buffers carried into HF: hash-layer ``tid2eid``
+            # and the (made-persistent for non-hash layers) ``expert_bias``.
+            if not (name.endswith(".mlp.gate.tid2eid") or name.endswith(".mlp.gate.expert_bias")):
+                continue
+            global_name = to_global_layer_name(name, layer_map)
+            for hf_name, hf_tensor in spec.native_to_hf(global_name, buffer.detach().cpu()):
+                yield hf_name, _cast_export_tensor(hf_tensor, export_dtype)
+
+
+def save_hf_weights(model, path: str, config: DeepseekV4Config, ps: ParallelState, **kwargs) -> None:
+    from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
+
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    out = dict(export_hf_weights(model, config, ps, rank0_only=True, **kwargs))
+    if rank == 0 and out:
+        save_safetensors(out, path)
+    if dist.is_initialized():
+        dist.barrier()
+
+
+__all__ = [
+    "EXPERT_CLASSIFIER",
+    "DeepseekV4WeightSpec",
+    "PLACEMENT_FN",
+    "export_hf_weights",
+    "load_hf_weights",
+    "save_hf_weights",
+]

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/model.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/model.py
@@ -1,0 +1,615 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""DeepSeek V4 (ds4flash) lite native model.
+
+A clone of the Kimi-K2 (deepseek_v3) lite model -- same approach as GLM-5 --
+inheriting Kimi's Megatron plumbing (SBHD ``[S, B, H]`` layout, VocabParallel
+embed/head, ``set_input_tensor``, ``build_pipeline_chunk_layout`` boundaries,
+MTP via ``layout.has_mtp``, dist-opt/distckpt via the protocol).  Three
+model-wide DS4 deviations (documented inline at each site):
+
+1. Attention = CSA, not MLA.  The CSA primitive is batch-first ``[B, S, H]`` and
+   needs explicit ``position_ids``; ``DeepseekV4CSAAttention`` wraps it with an
+   SBHD<->BSHD shim (like GLM-5's DSA shim).  Per-layer behaviour is driven by
+   ``config.compress_ratios[layer_idx]`` inside CSA.
+
+2. mHC (multi-head hyper-connection): the hidden carries ``hc_mult`` parallel
+   residual streams (4-D ``[S, B, hc_mult, H]`` in SBHD), expanded after embed
+   and contracted before the head, persisting across layers and PP stages; each
+   layer wraps attn/FFN in a ``HyperConnection``.  At PP boundaries the 4-D
+   hidden folds to 3-D ``[S, B, hc_mult*H]`` to match the P2P buffer
+   (``_infer_pipeline_tensor_shape`` scales hidden by ``hc_mult``); fold/unfold
+   live in ``primitive/parallel/mhc.py``.
+
+3. MoE = hash-routed DeepSeek: first ``num_hash_layers`` use a token-id hash
+   route, the rest the shared sigmoid-topk router (``DeepseekV4MoE`` over the
+   shared Experts/Router/Dispatcher).
+
+CSA is not TP-capable, so DS4 is a documented TP=1 case (protocol gate raises
+for TP>1/ETP>1); VPP/PP/EP/CP work, inherited from the Kimi skeleton.
+"""
+
+from __future__ import annotations
+
+import os
+from contextlib import nullcontext
+
+import torch
+import torch.nn as nn
+import transformer_engine.pytorch as te
+
+from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
+from megatron.lite.model.deepseek_v4.lite.moe import DeepseekV4MoE
+from megatron.lite.primitive.modules.attention.csa import CompressedSparseAttention
+from megatron.lite.primitive.modules.attention.hca import HyperConnection
+from megatron.lite.primitive.modules.attention.mhc import MultiHeadHyperConnectionHead
+from megatron.lite.primitive.modules.mtp import MTPLossAutoScaler
+from megatron.lite.primitive.ops.cross_entropy import vocab_parallel_cross_entropy
+from megatron.lite.primitive.ops.linear_cross_entropy import linear_cross_entropy
+from megatron.lite.primitive.ops.logprob import vocab_parallel_entropy
+from megatron.lite.primitive.parallel import (
+    ParallelState,
+    VocabParallelEmbedding,
+    VocabParallelOutput,
+    build_pipeline_chunk_layout,
+    gather_from_sequence_parallel,
+    scatter_to_sequence_parallel,
+)
+from megatron.lite.primitive.parallel.mhc import (
+    contract_mhc_hidden_for_pipeline,
+    expand_mhc_hidden_for_pipeline,
+    fold_mhc_hidden_for_pipeline,
+    unfold_mhc_hidden_from_pipeline,
+)
+from megatron.lite.primitive.utils import build_fp8_recipe
+
+
+def _roll_mtp_left(
+    tensor: torch.Tensor,
+    *,
+    dims: int = -1,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Shift labels/ids one position left (next-token target for MTP depth d).
+
+    DS4 inputs are dense ``[B, S]`` (TP=1, MTP runs only at CP==1), so -- unlike
+    Kimi -- there is no packed-THD branch here; a plain ``torch.roll`` on the
+    sequence dim suffices.
+    """
+    dim = dims if dims >= 0 else tensor.dim() + dims
+    rolled = torch.roll(tensor, shifts=-1, dims=dim)
+    rolled.select(dim, -1).zero_()
+    return rolled, rolled.sum()
+
+
+# -- DS4 ONLY: CSA attention wrapper.  Holds ``CompressedSparseAttention`` and
+# adapts it to the skeleton's SBHD-in / SBHD-out attention contract, mirroring
+# GLM-5's ``Glm5DSAAttention`` DSA shim.  Per-layer behaviour (window / compress
+# / indexer) is selected inside CSA via ``config.compress_ratios[layer_idx]``.
+class DeepseekV4CSAAttention(nn.Module):
+    """SBHD ``[S, B, H]`` shim around the batch-first CSA primitive.
+
+    The skeleton hands attention a 3-D SBHD tensor ``[S, B, H]`` (the
+    hyper-connection has already collapsed the ``hc_mult`` streams to a single
+    pre-mix stream).  CSA is hard-wired ``[B, S, H]`` and needs ``position_ids``.
+    This wrapper transposes ``[S, B, H] -> [B, S, H]``, runs CSA, and transposes
+    the ``[B, S, H]`` output back to ``[S, B, H]``.  The skeleton therefore never
+    observes the batch-first interior.
+    """
+
+    def __init__(self, config: DeepseekV4Config, *, layer_idx: int, ps: ParallelState):
+        super().__init__()
+        self.ps = ps
+        self.self_attn = CompressedSparseAttention(config, layer_idx=layer_idx, ps=ps)
+
+    def forward(self, x: torch.Tensor, *, position_ids: torch.Tensor) -> torch.Tensor:
+        # Skeleton feeds SBHD [S, B, H]; CSA needs batch-first [B, S, H].
+        x_bsh = x.transpose(0, 1).contiguous()
+        out_bsh = self.self_attn(x_bsh, position_ids=position_ids, attention_mask=None)
+        # Back to SBHD [S, B, H] for the skeleton.
+        return out_bsh.transpose(0, 1).contiguous()
+
+
+class DeepseekV4Layer(nn.Module):
+    """One decoder layer.
+
+    Structurally the Kimi layer, but the plain ``x = x + sublayer(norm(x))``
+    residual is replaced by DS4's per-layer ``HyperConnection`` (mHC), and
+    attention is CSA via the SBHD shim above.  The hidden is the 4-D SBHD mHC
+    tensor ``[S, B, hc_mult, H]`` end-to-end.  Attribute names (``self_attn`` /
+    ``input_layernorm`` / ``post_attention_layernorm`` / ``mlp`` / ``attn_hc`` /
+    ``ffn_hc``) are preserved from the previous DS4 model so the HF checkpoint
+    weight names are unchanged.
+    """
+
+    def __init__(
+        self,
+        config: DeepseekV4Config,
+        ps: ParallelState,
+        layer_idx: int,
+        *,
+        use_deepep: bool = False,
+    ):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.ps = ps
+        self.input_layernorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        # DS4 ONLY: CSA attention behind the SBHD shim (Kimi builds MLA here).
+        self.self_attn = DeepseekV4CSAAttention(config, layer_idx=layer_idx, ps=ps)
+        # DS4 ONLY: hash-routed MoE family (shared Experts/Router/dispatcher).
+        self.mlp = DeepseekV4MoE(config, ps, layer_idx=layer_idx, use_deepep=use_deepep)
+        # DS4 ONLY: per-layer multi-head hyper-connections wrapping attn + ffn.
+        self.attn_hc = HyperConnection(
+            config.hidden_size, config.hc_mult, config.hc_sinkhorn_iters, config.hc_eps
+        )
+        self.ffn_hc = HyperConnection(
+            config.hidden_size, config.hc_mult, config.hc_sinkhorn_iters, config.hc_eps
+        )
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        *,
+        position_ids: torch.Tensor,
+        input_ids: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        # x is SBHD mHC [S, B, hc_mult, H].  HyperConnection collapses the
+        # streams to a 3-D [S, B, H] pre-mix, the sub-block runs SBHD, and
+        # HyperConnection.post recombines into the 4-D residual streams.
+        residual = x
+        attn_in, post, comb = self.attn_hc(x)
+        attn_out = self.self_attn(self.input_layernorm(attn_in), position_ids=position_ids)
+        x = HyperConnection.post(attn_out, residual, post, comb)
+
+        residual = x
+        ffn_in, post, comb = self.ffn_hc(x)
+        # DS4 hash-routed MoE indexes tid2eid[input_ids.reshape(-1)] and must
+        # align with the flattened hidden.  The skeleton is SBHD, so the FFN
+        # input flattens in (S, B) order; transpose input_ids [B, S] -> [S, B]
+        # so its flatten matches.  (No-op semantics for non-hash layers.)
+        mlp_input_ids = None if input_ids is None else input_ids.transpose(0, 1).contiguous()
+        ffn_out = self.mlp(self.post_attention_layernorm(ffn_in), input_ids=mlp_input_ids)
+        return HyperConnection.post(ffn_out, residual, post, comb)
+
+
+class DeepseekV4MTPLayer(DeepseekV4Layer):
+    """MTP depth layer: Kimi's MTP combiner, adapted to DS4's mHC hidden.
+
+    Like Kimi's ``KimiK2MTPLayer`` it owns ``enorm`` / ``hnorm`` and a projection
+    to fuse the rolled-token embedding with the running hidden, then runs one
+    transformer layer.  DS4 differences: the projection uses DS4's
+    ``e_proj`` / ``h_proj`` names (preserved for HF export), the embedding /
+    hidden are lifted into the ``hc_mult`` streams, and ``contract`` collapses
+    the streams via ``hc_head`` + ``norm`` before the (shared) head.
+    """
+
+    def __init__(
+        self,
+        config: DeepseekV4Config,
+        ps: ParallelState,
+        layer_idx: int,
+        *,
+        embedding: VocabParallelEmbedding,
+        use_deepep: bool,
+        detach_encoder: bool,
+    ):
+        super().__init__(config, ps, layer_idx, use_deepep=use_deepep)
+        self.config = config
+        object.__setattr__(self, "embedding", embedding)
+        self.detach_encoder = detach_encoder
+        self.e_proj = nn.Linear(config.hidden_size, config.hidden_size, bias=False)
+        self.h_proj = nn.Linear(config.hidden_size, config.hidden_size, bias=False)
+        self.enorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.hnorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.norm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.hc_head = MultiHeadHyperConnectionHead(config.hidden_size, config.hc_mult, config.hc_eps)
+
+    def forward(
+        self,
+        *,
+        input_ids: torch.Tensor,
+        hidden_states: torch.Tensor,
+        position_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        # hidden_states is the per-stream mHC source [S, B, hc_mult, H].
+        embedded = self.embedding(input_ids)
+        embedded = scatter_to_sequence_parallel(embedded, self.ps)
+        if self.detach_encoder:
+            embedded = embedded.detach()
+            hidden_states = hidden_states.detach()
+        embedded = self.enorm(embedded)
+        # e_proj on the [S, B, H] embedding, broadcast across the hc_mult streams;
+        # h_proj on the normed mHC hidden keeps the per-stream state.
+        projected = self.e_proj(embedded).unsqueeze(2) + self.h_proj(self.hnorm(hidden_states))
+        return super().forward(projected, position_ids=position_ids, input_ids=input_ids)
+
+    def contract(self, x: torch.Tensor) -> torch.Tensor:
+        # Collapse the hc_mult streams [S, B, hc_mult, H] -> [S, B, H].
+        return self.norm(self.hc_head(x))
+
+
+def _temperature_to_float(temperature: float | torch.Tensor) -> float:
+    if isinstance(temperature, torch.Tensor):
+        if temperature.numel() != 1:
+            raise ValueError("DeepseekV4Model supports scalar temperature only.")
+        return float(temperature.detach().float().item())
+    return float(temperature)
+
+
+def _apply_attention_backend_override(backend: str | None) -> None:
+    if backend in (None, "flash"):
+        backend = "fused"
+    env = {
+        "auto": ("1", "1", "1"),
+        "flash": ("1", "0", "0"),
+        "fused": ("0", "1", "0"),
+        "unfused": ("0", "0", "1"),
+        "local": ("0", "0", "1"),
+    }.get(backend)
+    if env is None:
+        raise ValueError(
+            "attention_backend_override must be one of "
+            "{'auto', 'flash', 'fused', 'unfused', 'local'}"
+        )
+    (
+        os.environ["NVTE_FLASH_ATTN"],
+        os.environ["NVTE_FUSED_ATTN"],
+        os.environ["NVTE_UNFUSED_ATTN"],
+    ) = env
+
+
+class DeepseekV4Model(nn.Module):
+    """DS4 model.  Mirrors ``KimiK2Model``: ``build_pipeline_chunk_layout`` for
+    embed/head/layer placement, ``set_input_tensor`` for the PP recv buffer, a
+    shared embed/head, MTP gated on ``layout.has_mtp``, SBHD scatter at embed,
+    and a single forward producing the loss / logits / MTP outputs.
+
+    DS4 differences (all documented inline): the hidden is the 4-D SBHD mHC
+    tensor; it is expanded after embed and contracted before the head; pipeline
+    stage boundaries fold/unfold the ``hc_mult`` streams to match the 3-D P2P
+    buffer; attention is CSA; the MoE is hash-routed and so layers receive
+    ``input_ids``.  Attribute names (``embed_tokens`` / ``norm`` / ``lm_head`` /
+    ``hc_head`` / ``layers`` ModuleDict) are preserved from the previous DS4 so
+    HF checkpoint names are unchanged.
+    """
+
+    def __init__(
+        self,
+        config: DeepseekV4Config,
+        train_config,
+        ps: ParallelState,
+        *,
+        vpp_chunk_id: int | None = None,
+        use_thd: bool = False,
+        hf_path: str = "",
+        attention_backend_override: str | None = None,
+        mtp_enable: bool = False,
+        mtp_enable_train: bool = False,
+        mtp_detach_encoder: bool = False,
+        use_deepep: bool = False,
+    ):
+        super().__init__()
+        del hf_path, use_thd  # DS4 CSA derives its own masking from position_ids.
+        _apply_attention_backend_override(attention_backend_override)
+        self.config = config
+        self.train_config = train_config
+        self.ps = ps
+        self.hc_mult = int(config.hc_mult)
+        self._input_tensor: torch.Tensor | None = None
+        self.mtp_enable_train = bool(mtp_enable and mtp_enable_train)
+        self.mtp_loss_scaling_factor = config.mtp_loss_scaling_factor
+
+        layout = build_pipeline_chunk_layout(
+            config.num_hidden_layers,
+            ps,
+            train_config.vpp,
+            vpp_chunk_id,
+            num_mtp_layers=config.num_nextn_predict_layers if mtp_enable else 0,
+        )
+        self.layer_indices = layout.layer_indices
+        self.pre_process = layout.has_embed
+        self.post_process = layout.has_head
+        # DS4 does not tie embeddings; the attribute is preserved for the
+        # dist-opt / distckpt interface (matches the previous DS4 model).
+        self.share_embeddings_and_output_weights = False
+        self.vision_model: nn.Module | None = None
+
+        self.embed_tokens: VocabParallelEmbedding | None = None
+        if layout.has_embed:
+            self.embed_tokens = VocabParallelEmbedding(config.vocab_size, config.hidden_size, ps)
+
+        # Key by LOCAL pipeline-stage position (0..len-1), not the global layer id,
+        # so parameter names ("layers.{local}.…") follow the same convention as the
+        # other lite models (glm5 / kimi_k2 use nn.ModuleList → local names). The
+        # shared HF weight map (build via enumerate(layer_indices)) is keyed by local
+        # position; keying this dict by the global id instead double-maps under an
+        # uneven PP split (a stage owning [1,2] would remap layers.1→layers.2 and
+        # drop layer 1 on export/load). The global id is still passed to the layer
+        # for its dense-vs-MoE / per-layer logic.
+        self.layers = nn.ModuleDict(
+            {
+                str(local): DeepseekV4Layer(config, ps, global_idx, use_deepep=use_deepep)
+                for local, global_idx in enumerate(self.layer_indices)
+            }
+        )
+
+        self.norm: nn.Module | None = None
+        self.hc_head: MultiHeadHyperConnectionHead | None = None
+        self.lm_head: VocabParallelOutput | None = None
+        if layout.has_head:
+            self.norm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+            self.hc_head = MultiHeadHyperConnectionHead(
+                config.hidden_size, config.hc_mult, config.hc_eps
+            )
+            self.lm_head = VocabParallelOutput(config.vocab_size, config.hidden_size, ps)
+
+        self.mtp_embed: VocabParallelEmbedding | None = None
+        self.mtp: nn.ModuleList = nn.ModuleList()
+        if mtp_enable and config.num_nextn_predict_layers > 0 and layout.has_mtp:
+            mtp_embedding = self.embed_tokens
+            if mtp_embedding is None:
+                mtp_embedding = VocabParallelEmbedding(config.vocab_size, config.hidden_size, ps)
+                self.mtp_embed = mtp_embedding
+            self.mtp = nn.ModuleList(
+                [
+                    DeepseekV4MTPLayer(
+                        config,
+                        ps,
+                        config.num_hidden_layers + idx,
+                        embedding=mtp_embedding,
+                        use_deepep=use_deepep,
+                        detach_encoder=mtp_detach_encoder,
+                    )
+                    for idx in range(config.num_nextn_predict_layers)
+                ]
+            )
+
+    def set_input_tensor(self, input_tensor):
+        if isinstance(input_tensor, list):
+            if len(input_tensor) > 1:
+                raise ValueError("DeepseekV4Model expects a single pipeline input tensor.")
+            input_tensor = input_tensor[0] if input_tensor else None
+        self._input_tensor = input_tensor
+
+    def _embed_or_recv(
+        self, input_ids: torch.Tensor | None, hidden_states: torch.Tensor | None
+    ) -> tuple[torch.Tensor, torch.Tensor | None, int]:
+        """Return (mHC hidden [S, B, hc_mult, H], input_ids, seq_len) for this stage."""
+        if self.embed_tokens is not None:
+            assert input_ids is not None
+            # Embed -> SBHD [S, B, H] -> SP scatter (no-op at TP=1) -> expand to
+            # the hc_mult parallel residual streams.
+            h = self.embed_tokens(input_ids)
+            h = scatter_to_sequence_parallel(h, self.ps)
+            seq_len = h.size(0)
+            h = expand_mhc_hidden_for_pipeline(h, hc_mult=self.hc_mult)
+            return h, input_ids, seq_len
+        if hidden_states is None:
+            hidden_states = self._input_tensor
+        assert hidden_states is not None
+        # Non-first PP stage: the previous stage folded the streams into the
+        # hidden dim ([S, B, hc_mult * H]); unfold back to [S, B, hc_mult, H]
+        # instead of re-expanding (which would discard the cross-stream state).
+        h = unfold_mhc_hidden_from_pipeline(hidden_states, hc_mult=self.hc_mult)
+        return h, input_ids, h.size(0)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None = None,
+        hidden_states: torch.Tensor | None = None,
+        position_ids: torch.Tensor | None = None,
+        labels: torch.Tensor | None = None,
+        loss_mask: torch.Tensor | None = None,
+        temperature: float | torch.Tensor = 1.0,
+        use_fused_kernels: bool = False,
+        calculate_entropy: bool = False,
+        enable_mtp: bool = True,
+    ) -> dict:
+        # THD-packed inputs may arrive 1-D ([total_tokens]); VocabParallelEmbedding
+        # and the dense skeleton expect [B, S], so add the batch row (matches the
+        # previous DS4 and the [1, S] single-sequence convention).
+        if input_ids is not None and input_ids.dim() == 1:
+            input_ids = input_ids.unsqueeze(0)
+        if position_ids is not None and position_ids.dim() == 1:
+            position_ids = position_ids.unsqueeze(0)
+        if labels is not None and labels.dim() == 1:
+            labels = labels.unsqueeze(0)
+        if loss_mask is not None and loss_mask.dim() == 1:
+            loss_mask = loss_mask.unsqueeze(0)
+        h, input_ids, _seq_len = self._embed_or_recv(input_ids, hidden_states)
+
+        # CSA is batch-first and needs [B, S] position ids; build them from the
+        # SBHD hidden when not supplied.  position_ids is the only forward arg
+        # that crosses into the batch-first CSA interior.
+        if position_ids is None:
+            seq_len, batch = h.size(0), h.size(1)
+            position_ids = (
+                torch.arange(seq_len, device=h.device).unsqueeze(0).expand(batch, -1)
+            )
+
+        fp8_ctx = (
+            te.fp8_autocast(enabled=True, fp8_recipe=build_fp8_recipe(self.train_config))
+            if self.train_config.fp8
+            else nullcontext()
+        )
+        with fp8_ctx:
+            for layer in self.layers.values():
+                h = layer(h, position_ids=position_ids, input_ids=input_ids)
+
+        output: dict = {"hidden_states": fold_mhc_hidden_for_pipeline(h)}
+        if self.lm_head is None or self.norm is None or self.hc_head is None:
+            # Non-last PP stage: fold the hc_mult streams into the hidden dim so
+            # the pipeline P2P buffer ([S, B, hc_mult * H]) carries the full
+            # hyper-connection state.
+            return output
+
+        # Last stage: contract the mHC streams, then run head / MTP / loss
+        # exactly as the Kimi skeleton does.
+        mtp_source = h
+        hidden_for_head = contract_mhc_hidden_for_pipeline(h, norm=self.norm, head=self.hc_head)
+
+        # MTP runs on the head stage (where self.mtp is built with a valid bound
+        # embedding -- self.embed_tokens when present, else the self.mtp_embed
+        # fallback, mirroring Kimi).  Disabled at CP>1 (the rolled MTP targets are
+        # not CP-sliced) and when no input_ids are available.
+        run_mtp = (
+            enable_mtp
+            and input_ids is not None
+            and len(self.mtp) > 0
+            and self.ps.cp_size == 1
+        )
+        mtp_hidden_states = self._apply_mtp(
+            mtp_source, input_ids=input_ids, position_ids=position_ids, run_mtp=run_mtp
+        )
+        if mtp_hidden_states is not None:
+            output["mtp_hidden_states"] = mtp_hidden_states
+
+        if labels is not None:
+            temperature_value = _temperature_to_float(temperature)
+            mtp_result = self._apply_mtp_loss(
+                hidden_for_head,
+                mtp_hidden_states=mtp_hidden_states,
+                labels=labels,
+                loss_mask=loss_mask,
+                temperature=temperature_value,
+                use_fused_kernels=use_fused_kernels,
+            )
+            if mtp_result is not None:
+                hidden_for_head, mtp_loss = mtp_result
+                output["mtp_loss"] = mtp_loss
+            labels_sb = labels.transpose(0, 1).contiguous()
+            if use_fused_kernels:
+                hidden_full = gather_from_sequence_parallel(hidden_for_head, self.ps)
+                log_probs, entropy = linear_cross_entropy(
+                    hidden_full,
+                    self._head_weight_for_fused_ce(hidden_full),
+                    labels_sb,
+                    temperature_value,
+                    self.ps.tp_group,
+                )
+                output["loss"] = (-log_probs).mean()
+                output["log_probs"] = log_probs.transpose(0, 1).contiguous()
+                if calculate_entropy:
+                    output["entropy"] = entropy.transpose(0, 1).contiguous()
+            else:
+                logits = self.lm_head(hidden_for_head)
+                if temperature_value != 1.0:
+                    logits = logits / temperature_value
+                loss = vocab_parallel_cross_entropy(logits, labels_sb, self.ps.tp_group)
+                output["loss"] = loss.mean()
+                output["log_probs"] = (-loss).transpose(0, 1).contiguous()
+                if calculate_entropy:
+                    entropy = vocab_parallel_entropy(logits, self.ps.tp_group)
+                    output["entropy"] = entropy.transpose(0, 1).contiguous()
+        else:
+            logits = self.lm_head(hidden_for_head)
+            output["logits"] = self.lm_head.gather(logits).transpose(0, 1).contiguous()
+            if mtp_hidden_states is not None:
+                output["mtp_logits"] = [
+                    self.lm_head.gather(self.lm_head(mtp_hidden)).transpose(0, 1).contiguous()
+                    for mtp_hidden in mtp_hidden_states
+                ]
+        return output
+
+    def _apply_mtp(
+        self,
+        mtp_source: torch.Tensor,
+        *,
+        input_ids: torch.Tensor | None,
+        position_ids: torch.Tensor | None,
+        run_mtp: bool,
+    ) -> list[torch.Tensor] | None:
+        if not run_mtp:
+            return None
+        assert input_ids is not None
+        # DS4 MTP rolls input_ids per depth and runs each MTP layer on the
+        # running per-stream source, contracting each depth's output to [S, B, H]
+        # for the head.  Mirrors Kimi's KimiK2MTPBlock loop.
+        mtp_input_ids = input_ids
+        source = mtp_source
+        outputs: list[torch.Tensor] = []
+        for mtp_layer in self.mtp:
+            mtp_input_ids, _ = _roll_mtp_left(mtp_input_ids, dims=-1)
+            source = mtp_layer(
+                input_ids=mtp_input_ids,
+                hidden_states=source,
+                position_ids=position_ids,
+            )
+            outputs.append(mtp_layer.contract(source))
+        return outputs
+
+    def _apply_mtp_loss(
+        self,
+        hidden_states: torch.Tensor,
+        *,
+        mtp_hidden_states: list[torch.Tensor] | None,
+        labels: torch.Tensor,
+        loss_mask: torch.Tensor | None,
+        temperature: float,
+        use_fused_kernels: bool,
+    ) -> tuple[torch.Tensor, torch.Tensor] | None:
+        if mtp_hidden_states is None or not self.mtp_enable_train:
+            return None
+        if loss_mask is None:
+            mtp_loss_mask = torch.ones_like(labels, dtype=torch.float32)
+        else:
+            mtp_loss_mask = loss_mask.to(dtype=torch.float32).clone()
+        mtp_labels = labels.clone()
+
+        mtp_loss_values = []
+        for mtp_hidden in mtp_hidden_states:
+            mtp_labels, _ = _roll_mtp_left(mtp_labels, dims=-1)
+            mtp_loss_mask, num_tokens = _roll_mtp_left(mtp_loss_mask, dims=-1)
+            labels_sb = mtp_labels.transpose(0, 1).contiguous()
+            mask_sb = mtp_loss_mask.transpose(0, 1).contiguous()
+
+            if use_fused_kernels:
+                mtp_hidden_full = gather_from_sequence_parallel(mtp_hidden, self.ps)
+                log_probs, _entropy = linear_cross_entropy(
+                    mtp_hidden_full,
+                    self._head_weight_for_fused_ce(mtp_hidden_full),
+                    labels_sb,
+                    temperature,
+                    self.ps.tp_group,
+                )
+                token_loss = -log_probs
+            else:
+                logits = self.lm_head(mtp_hidden)
+                if temperature != 1.0:
+                    logits = logits / temperature
+                token_loss = vocab_parallel_cross_entropy(logits, labels_sb, self.ps.tp_group)
+
+            token_loss = token_loss * mask_sb.to(dtype=token_loss.dtype)
+            num_tokens = num_tokens.to(dtype=token_loss.dtype).clamp_min(1.0)
+            mtp_loss_values.append(token_loss.sum() / num_tokens)
+
+            mtp_loss_scale = self.mtp_loss_scaling_factor / max(len(mtp_hidden_states), 1)
+            hidden_states = MTPLossAutoScaler.apply(
+                hidden_states,
+                mtp_loss_scale * token_loss / num_tokens,
+            )
+
+        if not mtp_loss_values:
+            return None
+        return (
+            hidden_states,
+            torch.stack([loss.detach().float() for loss in mtp_loss_values]).mean(),
+        )
+
+    def _head_weight_for_fused_ce(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        assert self.lm_head is not None
+        weight = self.lm_head.col.linear.weight
+        return (
+            weight if weight.dtype == hidden_states.dtype else weight.to(dtype=hidden_states.dtype)
+        )
+
+
+__all__ = [
+    "CompressedSparseAttention",
+    "DeepseekV4CSAAttention",
+    "DeepseekV4Layer",
+    "DeepseekV4Model",
+    "DeepseekV4MTPLayer",
+    "HyperConnection",
+    "MTPLossAutoScaler",
+    "MultiHeadHyperConnectionHead",
+]

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/moe.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/moe.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
+from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
+from megatron.lite.primitive.modules.experts import Experts
+from megatron.lite.primitive.modules.mlp import SwiGLUMLP
+from megatron.lite.primitive.modules.router import SigmoidTopKRouter
+from megatron.lite.primitive.parallel.state import ParallelState
+
+
+class DeepseekV4MoE(nn.Module):
+    """Model-specific assembly over shared router, Experts, dispatcher, and shared MLP.
+
+    Allowlist reason: this owns DS4 hash routing wiring, while expert compute stays shared.
+    """
+
+    def __init__(
+        self,
+        config: DeepseekV4Config,
+        ps: ParallelState,
+        *,
+        layer_idx: int,
+        use_deepep: bool = False,
+    ):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.topk = config.num_experts_per_tok
+        self.route_scale = config.routed_scaling_factor
+        self.is_hash_layer = layer_idx < config.num_hash_layers
+        self.gate = SigmoidTopKRouter(config, ps, compute_aux_loss=False)
+        if self.is_hash_layer:
+            self.gate.register_buffer(
+                "tid2eid",
+                torch.zeros(config.vocab_size, self.topk, dtype=torch.int64),
+                persistent=True,
+            )
+        else:
+            self.gate._non_persistent_buffers_set.discard("expert_bias")
+        self.experts = Experts(config, ps)
+        shared_intermediate = config.n_shared_experts * config.moe_intermediate_size
+        self.shared_experts = (
+            SwiGLUMLP(
+                config.hidden_size,
+                shared_intermediate,
+                swiglu_limit=config.swiglu_limit,
+            )
+            if config.n_shared_experts > 0
+            else None
+        )
+        self.dispatcher = TokenDispatcher(
+            config.n_routed_experts,
+            config.hidden_size,
+            ps,
+            use_deepep=use_deepep,
+        )
+
+    def _hash_route(
+        self,
+        x: torch.Tensor,
+        input_ids: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        logits = self.gate.gate(x).view(-1, self.gate.num_experts)
+        if self.gate.score_function == "sqrtsoftplus":
+            scores = F.softplus(logits.float()).sqrt()
+        else:
+            scores = logits.float().sigmoid()
+        indices = self.gate.tid2eid[input_ids.reshape(-1).to(torch.int64)]
+        weights = scores.gather(1, indices)
+        if self.topk > 1:
+            weights = weights / (weights.sum(dim=-1, keepdim=True) + 1e-20)
+        return (weights * self.route_scale).to(dtype=x.dtype), indices
+
+    def forward(self, x: torch.Tensor, *, input_ids: torch.Tensor | None = None) -> torch.Tensor:
+        shape = x.shape
+        x_flat = x.reshape(-1, self.hidden_size)
+        if self.is_hash_layer and input_ids is not None:
+            weights, indices = self._hash_route(x_flat, input_ids)
+        else:
+            weights, indices = self.gate(x_flat)
+        dispatched, tpe, permuted_probs = self.dispatcher.dispatch(x_flat, weights, indices)
+        del weights, indices
+        self.dispatcher.wait_dispatch_event()
+        out = self.experts(
+            dispatched,
+            tpe,
+            permuted_probs,
+            tokens_per_expert_list=getattr(self.dispatcher, "_local_tpe_list", None),
+        )
+        out = self.dispatcher.combine(out)
+        if self.shared_experts is not None:
+            out = out + self.shared_experts(x_flat)
+        return out.view(shape)

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py
@@ -1,0 +1,492 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
+from megatron.lite.model.deepseek_v4.lite.checkpoint import (
+    EXPERT_CLASSIFIER,
+    PLACEMENT_FN,
+    export_hf_weights as _export_hf_weights_impl,
+    load_hf_weights as _load_hf_weights_impl,
+    save_hf_weights as _save_hf_weights_impl,
+)
+from megatron.lite.model.protocol_utils import add_loss_context_kwargs
+from megatron.lite.primitive.bundle import ModelBundle
+from megatron.lite.primitive.parallel import ParallelState, init_parallel
+from megatron.lite.primitive.parallel.cp import (
+    contiguous_position_ids_for_cp,
+    contiguous_slice_for_cp,
+    local_position_ids_for_cp,
+    local_sequence_tensor_for_cp,
+)
+from megatron.lite.primitive.parallel.thd import (
+    pack_nested_thd,
+    parallel_state_from_model,
+    thd_pack_meta,
+    unpack_thd_to_nested,
+)
+from megatron.lite.primitive.recompute import apply_recompute, parse_recompute_spec
+from megatron.lite.runtime.contracts import OptimizerConfig, PackedBatch, ParallelConfig
+
+
+def is_expert_param(name: str) -> bool:
+    return EXPERT_CLASSIFIER(name)
+
+
+@dataclass(frozen=True)
+class ImplConfig:
+    parallel: ParallelConfig = field(default_factory=ParallelConfig)
+    optimizer: str | None = "dist_opt"
+    optimizer_config: OptimizerConfig | None = None
+    hf_path: str = ""
+    recompute: list[str] = field(default_factory=list)
+    offload: list[str] = field(default_factory=list)
+    use_thd: bool = False
+    use_deepep: bool = False
+    attention_backend_override: str | None = None
+    deterministic: bool = True
+    mtp_enable: bool = True
+    mtp_enable_train: bool = False
+    mtp_detach_encoder: bool = False
+    mtp_num_layers: int | None = None
+    num_nextn_predict_layers: int | None = None
+    mtp_loss_scaling_factor: float = 0.1
+
+
+MODULE_MAP = {
+    "attn": lambda layer: layer.self_attn,
+    "core_attn": lambda layer: layer.self_attn,
+    "moe": lambda layer: layer.mlp,
+    "experts": lambda layer: layer.mlp.experts,
+    "router": lambda layer: layer.mlp.gate,
+    "attn_norm": lambda layer: layer.input_layernorm,
+    "ffn_norm": lambda layer: layer.post_attention_layernorm,
+}
+
+# The Kimi-derived model has no ``attention_mask`` arg (CSA derives its causal /
+# sliding-window masking from ``position_ids``, as the previous DS4 did with
+# attention_mask=None); keep it out of the forward whitelist.
+_MODEL_FORWARD_KEYS = (
+    "input_ids",
+    "position_ids",
+    "labels",
+    "loss_mask",
+    "temperature",
+    "calculate_entropy",
+    "enable_mtp",
+)
+
+
+def build_model_config(source: str | Path | dict, **overrides) -> DeepseekV4Config:
+    if isinstance(source, dict):
+        cfg = DeepseekV4Config._from_hf_dict(source)
+    else:
+        cfg = DeepseekV4Config.from_hf(str(source))
+    for key, value in overrides.items():
+        if hasattr(cfg, key):
+            setattr(cfg, key, value)
+    return cfg
+
+
+def _normalize_ds4_position_ids(position_ids):
+    if position_ids is None:
+        return None
+    if position_ids.dim() == 3:
+        if position_ids.size(0) == 3:
+            position_ids = position_ids[0]
+        elif position_ids.size(1) == 1:
+            position_ids = position_ids.squeeze(1)
+    if position_ids.dim() == 1:
+        position_ids = position_ids.unsqueeze(0)
+    return position_ids
+
+
+def _as_batch_row(tensor):
+    if tensor is not None and tensor.dim() == 1:
+        return tensor.unsqueeze(0)
+    return tensor
+
+
+def _infer_cp_local_seq_len(
+    *,
+    input_ids,
+    position_ids,
+    cp_size,
+):
+    seq_len = input_ids.size(1)
+    if cp_size <= 1:
+        return seq_len
+    if position_ids is not None and position_ids.size(-1) in (seq_len, seq_len * cp_size):
+        return seq_len
+    return seq_len // cp_size if seq_len % cp_size == 0 else seq_len
+
+
+def _nested_from_packed_tensor(tensor, seq_lens):
+    if tensor is None:
+        return None
+    if tensor.dim() == 2 and tensor.size(0) == 1:
+        tensor = tensor.squeeze(0)
+    if tensor.dim() != 1:
+        raise ValueError(f"PackedBatch tensor must be 1-D, got {tuple(tensor.shape)}.")
+
+    pieces = []
+    offset = 0
+    for length_t in seq_lens:
+        length = int(length_t.item())
+        pieces.append(tensor.narrow(0, offset, length))
+        offset += length
+    if offset != tensor.numel():
+        raise ValueError(f"PackedBatch sizes sum to {offset}, tensor has {tensor.numel()} tokens.")
+    return torch.nested.as_nested_tensor(pieces, layout=torch.jagged)
+
+
+def _prepare_packed_batch_kwargs(model, batch: PackedBatch) -> dict[str, Any]:
+    ps = parallel_state_from_model(model) or ParallelState()
+    seq_lens = batch.sizes().to(device=batch.input_ids.device)
+    packed = pack_nested_thd(
+        _nested_from_packed_tensor(batch.input_ids, seq_lens),
+        cp_size=ps.cp_size,
+        cp_rank=ps.cp_rank,
+        cp_group=ps.cp_group,
+        split_cp=False,
+        labels=_nested_from_packed_tensor(batch.labels, seq_lens),
+        loss_mask=_nested_from_packed_tensor(batch.loss_mask, seq_lens),
+    )
+    kwargs: dict[str, Any] = {
+        "input_ids": packed.input_ids,
+        "labels": packed.labels,
+        "loss_mask": packed.loss_mask,
+        "position_ids": packed.position_ids,
+        "packed_seq_params": packed.packed_seq_params,
+        "enable_mtp": False,
+    }
+    add_loss_context_kwargs(kwargs)
+    _prepare_packed_contiguous_cp_kwargs(model, kwargs)
+    kwargs.pop("packed_seq_params", None)
+    return {key: value for key, value in kwargs.items() if key in _MODEL_FORWARD_KEYS}
+
+
+def _base_model_forward_kwargs(batch: PackedBatch):
+    kwargs: dict[str, Any] = {"input_ids": _as_batch_row(batch.input_ids)}
+    if batch.labels is not None:
+        kwargs["labels"] = _as_batch_row(batch.labels)
+    if batch.loss_mask is not None:
+        kwargs["loss_mask"] = _as_batch_row(batch.loss_mask)
+    add_loss_context_kwargs(kwargs)
+    position_ids = _normalize_ds4_position_ids(getattr(batch, "position_ids", None))
+    if position_ids is not None:
+        kwargs["position_ids"] = position_ids
+    return kwargs
+
+
+def _prepare_packed_contiguous_cp_kwargs(model, kwargs):
+    ps = parallel_state_from_model(model) or ParallelState()
+    if ps.cp_size <= 1:
+        return kwargs
+    for key in ("input_ids", "labels", "loss_mask", "position_ids"):
+        tensor = kwargs.get(key)
+        if tensor is not None:
+            kwargs[key] = contiguous_slice_for_cp(tensor, ps.cp_rank, ps.cp_size, seq_dim=1)
+    return kwargs
+
+
+def _prepare_contiguous_cp_kwargs(model, kwargs):
+    ps = parallel_state_from_model(model) or ParallelState()
+    local_seq_len = _infer_cp_local_seq_len(
+        input_ids=kwargs["input_ids"],
+        position_ids=kwargs.get("position_ids"),
+        cp_size=ps.cp_size,
+    )
+    kwargs["input_ids"] = local_sequence_tensor_for_cp(
+        kwargs["input_ids"],
+        local_seq_len=local_seq_len,
+        cp_rank=ps.cp_rank,
+        cp_size=ps.cp_size,
+        name="input_ids",
+    )
+    if kwargs.get("position_ids") is None:
+        full_seq_len = local_seq_len * ps.cp_size
+        position_ids = contiguous_position_ids_for_cp(
+            full_seq_len,
+            cp_rank=ps.cp_rank,
+            cp_size=ps.cp_size,
+            device=kwargs["input_ids"].device,
+        ).expand(kwargs["input_ids"].size(0), -1)
+    else:
+        position_ids = local_position_ids_for_cp(
+            kwargs["position_ids"],
+            batch=kwargs["input_ids"].size(0),
+            local_seq_len=kwargs["input_ids"].size(1),
+            cp_rank=ps.cp_rank,
+            cp_size=ps.cp_size,
+        )
+    kwargs["position_ids"] = position_ids
+    for key in ("labels", "loss_mask"):
+        if kwargs.get(key) is not None:
+            kwargs[key] = local_sequence_tensor_for_cp(
+                kwargs[key],
+                local_seq_len=kwargs["input_ids"].size(1),
+                cp_rank=ps.cp_rank,
+                cp_size=ps.cp_size,
+                name=key,
+            )
+    return kwargs
+
+
+def _prepare_model_forward_kwargs(model, batch: PackedBatch):
+    # THD-packed inputs (1-D values, or a single padded [1, S] row) carry their own
+    # cu_seqlens and go through the packed builder. A dense multi-row [B, S] batch is
+    # split per row under contiguous CP, where contiguous_position_ids_for_cp rebuilds
+    # the per-rank global position ids.
+    input_ids = batch.input_ids
+    is_thd_packed = input_ids.dim() == 1 or (input_ids.dim() == 2 and input_ids.size(0) == 1)
+    if is_thd_packed:
+        return _prepare_packed_batch_kwargs(model, batch)
+    kwargs = _base_model_forward_kwargs(batch)
+    return _prepare_contiguous_cp_kwargs(model, kwargs)
+
+
+def _forward_step(model: nn.Module, batch: PackedBatch) -> dict:
+    return model(**_prepare_model_forward_kwargs(model, batch))
+
+
+def unpack_forward_output(model: nn.Module, batch: PackedBatch, output) -> Any:
+    # DeepSeek-V4 packs each sequence to the (zigzag) TE alignment but slices CP
+    # contiguously for the fused DSA indexer, so reconstruct contiguously.
+    ps = parallel_state_from_model(model) or ParallelState()
+    meta = thd_pack_meta(
+        batch.seq_lens,
+        tp_size=ps.tp_size,
+        cp_size=ps.cp_size,
+        cp_group=ps.cp_group if ps.cp_size > 1 else None,
+    )
+    return unpack_thd_to_nested(output, meta, contiguous=True)
+
+
+def _apply_mtp_config(model_cfg: DeepseekV4Config, impl_cfg: ImplConfig) -> None:
+    override = impl_cfg.num_nextn_predict_layers
+    if override is None:
+        override = impl_cfg.mtp_num_layers
+    if override is not None:
+        if override < 0:
+            raise ValueError(f"DeepSeek V4 MTP layer count must be >=0, got {override}.")
+        model_cfg.num_nextn_predict_layers = int(override)
+    if impl_cfg.mtp_enable:
+        if model_cfg.num_nextn_predict_layers <= 0:
+            raise ValueError("mtp_enable=True but DeepSeek V4 config has no MTP layers.")
+        model_cfg.mtp_loss_scaling_factor = impl_cfg.mtp_loss_scaling_factor
+    else:
+        model_cfg.num_nextn_predict_layers = 0
+
+
+def _make_aux_loss_hook():
+    """Per-step hook that syncs the MTP auxiliary-loss backward scale to the main
+    loss scale (DP size / gradient accumulation), mirroring the sibling protocols
+    (kimi_k2 / glm5 / qwen3_5 / qwen3_moe).
+
+    DS4 only injects an MTP auxiliary loss: its MoE router is aux-loss-free
+    (``SigmoidTopKRouter(..., compute_aux_loss=False)``) and its CSA indexer runs
+    with ``sparse_loss=False``, so -- unlike GLM-5, which also scales the MoE-aux
+    and DSA-indexer losses -- only ``MTPLossAutoScaler`` needs scaling here.
+    Without this hook the injected MTP gradient keeps ``MTPLossAutoScaler``'s
+    class-default scale of 1.0 and is mis-weighted relative to the main loss.
+    """
+    from megatron.lite.primitive.modules.mtp import MTPLossAutoScaler
+
+    def hook(scale: torch.Tensor) -> None:
+        MTPLossAutoScaler.set_loss_scale(scale)
+
+    return hook
+
+
+def _optimizer_backend_name(optimizer: Any) -> str | None:
+    if isinstance(optimizer, dict) or isinstance(optimizer, OptimizerConfig):
+        return "dist_opt"
+    return optimizer
+
+
+def _configure_attention_backend(chunks: list[nn.Module], *, backend: str | None) -> None:
+    backend_name = backend or "torch"
+    for chunk in chunks:
+        for module in chunk.modules():
+            if hasattr(module, "attention_backend"):
+                module.attention_backend = backend_name
+
+
+def _iter_transformer_units(chunk: nn.Module) -> list[nn.Module]:
+    model = getattr(chunk, "model", None)
+    if model is None:
+        return []
+    layers = list(getattr(model, "layers", {}).values())
+    mtp_layers = list(getattr(model, "mtp", []))
+    return [*layers, *mtp_layers]
+
+
+def _validate_parallel_scope(p: ParallelConfig) -> None:
+    """DS4 CSA attention is not tensor-parallel-capable (documented TP=1 case).
+
+    PP / VPP / EP / CP are inherited from the Kimi skeleton and work; only
+    TP>1 / ETP>1 are unsupported.  Mirrors GLM-5's gate.
+    """
+    etp = 1 if p.etp is None else p.etp
+    if p.tp > 1:
+        raise NotImplementedError(
+            "DeepSeek V4 native CSA attention does not support tensor parallelism; "
+            f"got tp={p.tp}. Use tp=1 (PP/VPP/EP/CP are supported)."
+        )
+    if etp > 1:
+        raise NotImplementedError(
+            "DeepSeek V4 native CSA attention does not support expert tensor parallelism; "
+            f"got etp={etp}. Use etp=1 (EP is supported)."
+        )
+
+
+def build_model(model_cfg: DeepseekV4Config, *, impl_cfg: ImplConfig) -> ModelBundle:
+    from megatron.lite.model.deepseek_v4.lite.model import DeepseekV4Model
+
+    p = impl_cfg.parallel
+    _validate_parallel_scope(p)
+    _apply_mtp_config(model_cfg, impl_cfg)
+    mtp_enable = bool(impl_cfg.mtp_enable) and model_cfg.num_nextn_predict_layers > 0
+    mtp_enable_train = mtp_enable and bool(impl_cfg.mtp_enable_train)
+    ps = init_parallel(impl_cfg.parallel)
+    vpp = None if p.vpp == 1 else p.vpp
+    train_cfg = SimpleNamespace(
+        tp=ps.tp_size,
+        ep=ps.ep_size,
+        etp=ps.etp_size,
+        pp=ps.pp_size,
+        cp=ps.cp_size,
+        vpp=vpp,
+        fp8=False,
+        use_deepep=impl_cfg.use_deepep,
+    )
+
+    def _chunk(i: int | None = None):
+        return (
+            DeepseekV4Model(
+                model_cfg,
+                train_cfg,
+                ps,
+                vpp_chunk_id=i,
+                use_deepep=impl_cfg.use_deepep,
+                use_thd=impl_cfg.use_thd,
+                hf_path=impl_cfg.hf_path,
+                attention_backend_override=impl_cfg.attention_backend_override,
+                mtp_enable=mtp_enable,
+                mtp_enable_train=mtp_enable_train,
+                mtp_detach_encoder=impl_cfg.mtp_detach_encoder,
+            )
+            .to(torch.bfloat16)
+            .cuda()
+        )
+
+    chunks = [_chunk(i) for i in range(vpp)] if vpp is not None else [_chunk()]
+    _configure_attention_backend(chunks, backend=impl_cfg.attention_backend_override)
+
+    recompute_spec = parse_recompute_spec(impl_cfg.recompute)
+    if recompute_spec:
+        for chunk in chunks:
+            apply_recompute(_iter_transformer_units(chunk), recompute_spec, MODULE_MAP)
+
+    if impl_cfg.offload:
+        from megatron.lite.primitive.recompute import apply_offload
+
+        for chunk in chunks:
+            apply_offload(_iter_transformer_units(chunk), impl_cfg.offload, MODULE_MAP)
+
+    optimizer = None
+    finalize_grads = None
+    post_model_load_hook = None
+    optimizer_backend = "none"
+    optimizer_name = _optimizer_backend_name(impl_cfg.optimizer)
+    if optimizer_name == "dist_opt":
+        from megatron.lite.primitive.ckpt import attach_model_sharded_state_dict
+        from megatron.lite.primitive.optimizers.megatron_wrap import (
+            build_dist_opt_training_optimizer,
+        )
+        from megatron.lite.runtime.megatron_utils import register_training_hooks
+
+        optimizer, finalize_grads = build_dist_opt_training_optimizer(
+            chunks,
+            model_cfg=model_cfg,
+            impl_cfg=impl_cfg,
+            ps=ps,
+            model_name="deepseek_v4",
+            is_expert=is_expert_param,
+            deterministic=impl_cfg.deterministic,
+        )
+        attach_model_sharded_state_dict(
+            chunks, ps, get_placements=PLACEMENT_FN, is_expert=is_expert_param
+        )
+        register_training_hooks(chunks, optimizer)
+        optimizer_backend = "dist_opt"
+    elif optimizer_name == "fsdp2":
+        optimizer_backend = "fsdp2"
+
+        def _post_model_load_hook():
+            from megatron.lite.model.deepseek_v4.lite.model import DeepseekV4Layer
+            from megatron.lite.primitive.optimizers.fsdp2 import build_fsdp2_training_optimizer
+
+            return {
+                "optimizer": build_fsdp2_training_optimizer(
+                    chunks,
+                    impl_cfg.optimizer_config,
+                    ps,
+                    unit_modules=(DeepseekV4Layer,),
+                    expert_classifier=is_expert_param,
+                    deterministic=impl_cfg.deterministic,
+                    vpp=impl_cfg.parallel.vpp,
+                    leaf_module_names=(),
+                    use_fp32_shards=False,
+                )
+            }
+
+        post_model_load_hook = _post_model_load_hook
+    elif optimizer_name is None:
+        optimizer_backend = "none"
+    else:
+        raise ValueError(f"Unknown DeepSeek V4 lite optimizer: {impl_cfg.optimizer!r}.")
+
+    return ModelBundle(
+        chunks=chunks,
+        parallel_state=ps,
+        optimizer=optimizer,
+        finalize_grads=finalize_grads,
+        forward_step=_forward_step,
+        extras={
+            "model_cfg": model_cfg,
+            "optimizer_backend": optimizer_backend,
+            "post_model_load_hook": post_model_load_hook,
+            "pre_forward_hook": _make_aux_loss_hook(),
+        },
+    )
+
+
+def load_hf_weights(
+    chunk: nn.Module, hf_path: str, model_cfg: DeepseekV4Config, ps: ParallelState
+) -> None:
+    if not hf_path:
+        return
+    _load_hf_weights_impl(chunk, hf_path, model_cfg, ps)
+
+
+def export_hf_weights(
+    chunks: list[nn.Module], model_cfg: DeepseekV4Config, ps: ParallelState, **kwargs
+):
+    yield from _export_hf_weights_impl(chunks, model_cfg, ps, **kwargs)
+
+
+def save_hf_weights(
+    chunks: list[nn.Module], path: str, model_cfg: DeepseekV4Config, ps: ParallelState, **kwargs
+) -> None:
+    _save_hf_weights_impl(chunks, path, model_cfg, ps, **kwargs)
+
+
+def vocab_size(model_cfg: DeepseekV4Config) -> int | None:
+    return model_cfg.vocab_size

--- a/experimental/lite/megatron/lite/model/glm5/__init__.py
+++ b/experimental/lite/megatron/lite/model/glm5/__init__.py
@@ -1,0 +1,5 @@
+"""GLM-5 model family."""
+
+from megatron.lite.model.glm5.config import Glm5Config
+
+__all__ = ["Glm5Config"]

--- a/experimental/lite/megatron/lite/model/glm5/__init__.py
+++ b/experimental/lite/megatron/lite/model/glm5/__init__.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """GLM-5 model family."""
 
 from megatron.lite.model.glm5.config import Glm5Config

--- a/experimental/lite/megatron/lite/model/glm5/config.py
+++ b/experimental/lite/megatron/lite/model/glm5/config.py
@@ -1,0 +1,200 @@
+"""GLM-5 architecture config."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import fields as dc_fields
+from typing import Any
+
+from megatron.lite.primitive.config import load_hf_config_dict
+
+_HF_FIELDS = frozenset(
+    {
+        "attention_dropout",
+        "calculate_per_token_loss",
+        "dsa_indexer_loss_coeff",
+        "dsa_indexer_use_sparse_loss",
+        "first_k_dense_replace",
+        "head_dim",
+        "hidden_size",
+        "index_head_dim",
+        "index_n_heads",
+        "index_topk",
+        "indexer_layer_norm_eps",
+        "indexer_rope_interleave",
+        "indexer_rope_first",
+        "indexer_use_hadamard",
+        "initializer_range",
+        "intermediate_size",
+        "kv_lora_rank",
+        "max_position_embeddings",
+        "mlp_layer_types",
+        "moe_intermediate_size",
+        "n_group",
+        "n_routed_experts",
+        "n_shared_experts",
+        "norm_topk_prob",
+        "mtp_loss_scaling_factor",
+        "mtp_use_repeated_layer",
+        "num_attention_heads",
+        "num_experts_per_tok",
+        "num_hidden_layers",
+        "num_key_value_heads",
+        "num_nextn_predict_layers",
+        "q_lora_rank",
+        "qk_head_dim",
+        "qk_nope_head_dim",
+        "qk_rope_head_dim",
+        "latent_rms_norm_eps",
+        "rms_norm_eps",
+        "rope_interleave",
+        "rope_theta",
+        "routed_scaling_factor",
+        "topk_group",
+        "v_head_dim",
+        "vocab_size",
+    }
+)
+
+
+@dataclass
+class Glm5Config:
+    """Pure GLM-5 MoE + MLA + DSA architecture parameters."""
+
+    num_hidden_layers: int = 78
+    hidden_size: int = 6144
+    num_attention_heads: int = 64
+    num_key_value_heads: int = 64
+    head_dim: int = 64
+    vocab_size: int = 154880
+    max_position_embeddings: int = 202752
+    rms_norm_eps: float = 1e-5
+    attention_dropout: float = 0.0
+    initializer_range: float = 0.02
+
+    q_lora_rank: int = 2048
+    kv_lora_rank: int = 512
+    qk_head_dim: int = 256
+    qk_nope_head_dim: int = 192
+    qk_rope_head_dim: int = 64
+    v_head_dim: int = 256
+
+    index_head_dim: int = 128
+    index_n_heads: int = 32
+    index_topk: int = 2048
+    indexer_layer_norm_eps: float = 1e-6
+    indexer_rope_interleave: bool = False
+    indexer_rope_first: bool = True
+    indexer_use_hadamard: bool = False
+    dsa_indexer_loss_coeff: float = 0.0
+    dsa_indexer_use_sparse_loss: bool = False
+    calculate_per_token_loss: bool = False
+    rope_interleave: bool = False
+    rope_theta: float = 1_000_000.0
+    latent_rms_norm_eps: float = 1e-6
+
+    intermediate_size: int = 12288
+    moe_intermediate_size: int = 2048
+    first_k_dense_replace: int = 3
+    n_routed_experts: int = 256
+    n_shared_experts: int = 1
+    num_experts_per_tok: int = 8
+    n_group: int = 1
+    topk_group: int = 1
+    routed_scaling_factor: float = 2.5
+    norm_topk_prob: bool = True
+    num_nextn_predict_layers: int = 1
+    mtp_loss_scaling_factor: float = 0.1
+    mtp_use_repeated_layer: bool = False
+    mlp_layer_types: list[str] | None = None
+
+    def __post_init__(self):
+        self._validate()
+
+    @property
+    def num_experts(self) -> int:
+        return self.n_routed_experts
+
+    def is_moe_layer(self, layer_idx: int) -> bool:
+        if self.mlp_layer_types is not None and layer_idx < len(self.mlp_layer_types):
+            return self.mlp_layer_types[layer_idx] == "sparse"
+        return layer_idx >= self.first_k_dense_replace
+
+    def _validate(self) -> None:
+        errors: list[str] = []
+
+        def check(cond: bool, message: str) -> None:
+            if not cond:
+                errors.append(message)
+
+        check(self.num_hidden_layers >= 1, "num_hidden_layers must be >= 1")
+        check(self.hidden_size > 0, "hidden_size must be > 0")
+        check(self.q_lora_rank > 0, "q_lora_rank must be > 0")
+        check(self.kv_lora_rank > 0, "kv_lora_rank must be > 0")
+        check(
+            self.qk_head_dim == self.qk_nope_head_dim + self.qk_rope_head_dim,
+            "qk_head_dim must equal qk_nope_head_dim + qk_rope_head_dim",
+        )
+        check(
+            self.index_head_dim >= self.qk_rope_head_dim,
+            "index_head_dim must be >= qk_rope_head_dim",
+        )
+        check(self.dsa_indexer_loss_coeff >= 0.0, "dsa_indexer_loss_coeff must be >= 0")
+        check(
+            self.num_key_value_heads == self.num_attention_heads,
+            "initial GLM5 native path expects MLA heads to be ungrouped",
+        )
+        check(self.vocab_size > 0, "vocab_size must be > 0")
+        check(self.num_nextn_predict_layers >= 0, "num_nextn_predict_layers must be >= 0")
+        check(self.n_routed_experts >= 1, "n_routed_experts must be >= 1")
+        check(
+            1 <= self.num_experts_per_tok <= self.n_routed_experts,
+            "num_experts_per_tok must be in [1, n_routed_experts]",
+        )
+        check(1 <= self.topk_group <= self.n_group, "topk_group must be in [1, n_group]")
+        if self.mlp_layer_types is not None:
+            expected_layer_type_lengths = {
+                self.num_hidden_layers,
+                self.num_hidden_layers + self.num_nextn_predict_layers,
+            }
+            check(
+                len(self.mlp_layer_types) in expected_layer_type_lengths,
+                "len(mlp_layer_types) must equal num_hidden_layers or "
+                "num_hidden_layers + num_nextn_predict_layers",
+            )
+            for idx, layer_type in enumerate(self.mlp_layer_types):
+                check(
+                    layer_type in {"dense", "sparse"},
+                    f"mlp_layer_types[{idx}] must be 'dense' or 'sparse'",
+                )
+
+        if errors:
+            raise ValueError(
+                f"Invalid Glm5Config ({len(errors)} error"
+                f"{'s' if len(errors) != 1 else ''}):\n  " + "\n  ".join(errors)
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {f.name: getattr(self, f.name) for f in dc_fields(self)}
+
+    @classmethod
+    def from_hf(cls, path_or_name: str, **overrides) -> Glm5Config:
+        return cls._from_hf_dict(load_hf_config_dict(path_or_name), **overrides)
+
+    @classmethod
+    def from_hf_config(cls, hf_config, **overrides) -> Glm5Config:
+        hf = hf_config.to_dict() if hasattr(hf_config, "to_dict") else vars(hf_config)
+        return cls._from_hf_dict(hf, **overrides)
+
+    @classmethod
+    def _from_hf_dict(cls, hf: dict[str, Any], **overrides) -> Glm5Config:
+        kwargs = {
+            key: value for key, value in hf.items() if key in _HF_FIELDS and value is not None
+        }
+        if "num_nextn_predict_layers" not in kwargs and hf.get("num_nextn_predict") is not None:
+            kwargs["num_nextn_predict_layers"] = int(hf["num_nextn_predict"])
+        rope_parameters = hf.get("rope_parameters")
+        if isinstance(rope_parameters, dict) and "rope_theta" not in kwargs:
+            kwargs["rope_theta"] = float(rope_parameters.get("rope_theta", cls.rope_theta))
+        kwargs.update(overrides)
+        return cls(**kwargs)

--- a/experimental/lite/megatron/lite/model/glm5/config.py
+++ b/experimental/lite/megatron/lite/model/glm5/config.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """GLM-5 architecture config."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/model/glm5/lite/__init__.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/__init__.py
@@ -1,0 +1,5 @@
+"""Native GLM-5 lite implementation."""
+
+from megatron.lite.model.glm5.lite.model import Glm5Model
+
+__all__ = ["Glm5Model"]

--- a/experimental/lite/megatron/lite/model/glm5/lite/__init__.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/__init__.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Native GLM-5 lite implementation."""
 
 from megatron.lite.model.glm5.lite.model import Glm5Model

--- a/experimental/lite/megatron/lite/model/glm5/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/checkpoint.py
@@ -1,0 +1,672 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""GLM-5 (deepseek_v3_2) lite native checkpoint mapping.
+
+Cloned from ``megatron/lite/model/kimi_k2/lite/checkpoint.py`` (deepseek_v3)
+and renamed KimiK2 -> Glm5.  The MoE / dense-MLP / embed / head / MTP weight
+mapping is structurally identical to Kimi.  The ONLY adaptations are in the
+attention block:
+
+  * GLM-5's attention is the DSA primitive ``DynamicSparseAttention`` (wrapped
+    by ``Glm5DSAAttention``), whose native parameters live under
+    ``self_attention.self_attention.*`` -- i.e. ``q_a_proj`` / ``q_a_layernorm``
+    / ``q_b_proj`` / ``kv_a_proj_with_mqa`` / ``kv_a_layernorm`` / ``kv_b_proj``
+    / ``o_proj`` plus the indexer (``indexer.wq_b`` / ``indexer.wk`` /
+    ``indexer.k_norm`` / ``indexer.weights_proj``).  Kimi's MLA names
+    (``linear_q_down_proj`` etc.) are replaced accordingly.
+  * The HF weight NAMES match GLM-5's HF model: the DSA submodule names map 1:1
+    to ``model.layers.{i}.self_attn.*`` (and ``...self_attn.indexer.*``),
+    preserving the names the previous GLM-5 checkpoint used.
+
+GLM-5 is TP=1 (DSA is not tensor-parallel-capable), so the ``_tp`` helpers are
+no-ops here; they are kept for structural parity with Kimi.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from torch.distributed.tensor import Replicate, Shard
+
+from megatron.lite.model.glm5.config import Glm5Config
+from megatron.lite.primitive.ckpt.hf_weights import (
+    SafeTensorReader,
+    _cast_export_tensor,
+    _resolve_export_dtype,
+    parse_expert_idx,
+    to_global_layer_name,
+    unwrap_model,
+)
+from megatron.lite.primitive.parallel import ParallelState
+from megatron.lite.primitive.utils import ensure_divisible, log_rank0
+
+
+def EXPERT_CLASSIFIER(name: str) -> bool:
+    return "experts" in name and "router" not in name and "shared" not in name
+
+
+def PLACEMENT_FN(param_name: str) -> list:
+    if "experts" in param_name and "router" not in param_name and "shared" not in param_name:
+        if "fc1" in param_name:
+            return [Replicate(), Replicate(), Shard(0), Shard(0)]
+        if "fc2" in param_name:
+            return [Replicate(), Replicate(), Shard(0), Shard(1)]
+        return [Replicate(), Replicate(), Replicate(), Replicate()]
+    if "eh_proj.linear.weight" in param_name:
+        return [Replicate(), Replicate(), Replicate(), Shard(0)]
+    # GLM-5 DSA is TP=1 (no head sharding of attention projections).
+    if "gate_up" in param_name:
+        return [Replicate(), Replicate(), Replicate(), Shard(0)]
+    if "down" in param_name:
+        return [Replicate(), Replicate(), Replicate(), Shard(1)]
+    if "embed" in param_name or "head" in param_name:
+        return [Replicate(), Replicate(), Replicate(), Shard(0)]
+    return [Replicate(), Replicate(), Replicate(), Replicate()]
+
+
+def _tp(tensor: torch.Tensor, rank: int, size: int, dim: int = 0) -> torch.Tensor:
+    return tensor if size <= 1 else tensor.chunk(size, dim=dim)[rank].contiguous()
+
+
+def _split_gate_up(tensor: torch.Tensor, rank: int, size: int) -> torch.Tensor:
+    if size <= 1:
+        return tensor
+    ffn = tensor.shape[0] // 2
+    gate = tensor[:ffn].chunk(size, dim=0)[rank]
+    up = tensor[ffn:].chunk(size, dim=0)[rank]
+    return torch.cat([gate, up], dim=0).contiguous()
+
+
+def _has(reader: SafeTensorReader, name: str) -> bool:
+    if reader.index:
+        return name in reader.index
+    try:
+        reader.get_tensor(name)
+    except Exception:
+        return False
+    return True
+
+
+def _dequant_fp8_weight(reader: SafeTensorReader, name: str, weight: torch.Tensor) -> torch.Tensor:
+    scale_name = f"{name}_scale_inv"
+    if weight.dim() != 2 or weight.element_size() != 1 or not _has(reader, scale_name):
+        return weight
+    scale = reader.get_tensor(scale_name).float()
+    rows, cols = weight.shape
+    expanded = scale.repeat_interleave(128, dim=0).repeat_interleave(128, dim=1)
+    expanded = expanded[:rows, :cols]
+    return weight.float() * expanded
+
+
+def _unpack_int4_from_int32(packed: torch.Tensor, shape: torch.Size) -> torch.Tensor:
+    if packed.dtype != torch.int32:
+        raise ValueError(f"Expected packed int4 tensor to be int32, got {packed.dtype}.")
+    pack_factor = 8
+    mask = 0xF
+    rows, cols = int(shape[0]), int(shape[1])
+    unpacked = torch.empty((packed.shape[0], packed.shape[1] * pack_factor), dtype=torch.int32)
+    for offset in range(pack_factor):
+        unpacked[:, offset::pack_factor] = (packed >> (4 * offset)) & mask
+    return (unpacked[:rows, :cols] - 8).to(torch.int8)
+
+
+def _dequant_int4_weight(reader: SafeTensorReader, name: str) -> torch.Tensor:
+    packed = reader.get_tensor(f"{name}_packed")
+    scale = reader.get_tensor(f"{name}_scale")
+    shape_tensor = reader.get_tensor(f"{name}_shape")
+    shape = torch.Size(int(x) for x in shape_tensor.tolist())
+
+    unpacked = _unpack_int4_from_int32(packed, shape).to(scale.dtype)
+    if scale.dim() != 2 or unpacked.dim() != 2:
+        raise ValueError(
+            f"Expected groupwise int4 tensors for {name}, got "
+            f"weight={tuple(unpacked.shape)} scale={tuple(scale.shape)}."
+        )
+    if scale.shape[0] not in (1, unpacked.shape[0]):
+        raise ValueError(
+            f"Unsupported int4 scale rows for {name}: "
+            f"weight={tuple(unpacked.shape)} scale={tuple(scale.shape)}."
+        )
+    if unpacked.shape[1] % scale.shape[1] != 0:
+        raise ValueError(
+            f"Unsupported int4 group layout for {name}: "
+            f"weight={tuple(unpacked.shape)} scale={tuple(scale.shape)}."
+        )
+
+    group_size = unpacked.shape[1] // scale.shape[1]
+    return (unpacked.unflatten(-1, (scale.shape[1], group_size)) * scale.unsqueeze(-1)).flatten(
+        start_dim=-2
+    )
+
+
+def _get(reader: SafeTensorReader, name: str) -> torch.Tensor:
+    if not _has(reader, name) and _has(reader, f"{name}_packed"):
+        return _dequant_int4_weight(reader, name)
+    tensor = reader.get_tensor(name)
+    return _dequant_fp8_weight(reader, name, tensor)
+
+
+def _text_prefix(reader: SafeTensorReader) -> str:
+    for prefix in ("model", "language_model.model", "model.language_model"):
+        if _has(reader, f"{prefix}.embed_tokens.weight"):
+            return prefix
+    raise KeyError("Could not find GLM-5 text model prefix in HF checkpoint.")
+
+
+def _lm_head_name(reader: SafeTensorReader, text_prefix: str) -> str:
+    candidates = [
+        "lm_head.weight",
+        "language_model.lm_head.weight",
+        f"{text_prefix}.lm_head.weight",
+    ]
+    for name in candidates:
+        if _has(reader, name):
+            return name
+    raise KeyError("Could not find GLM-5 lm_head.weight in HF checkpoint.")
+
+
+def _load_vocab(
+    reader: SafeTensorReader, name: str, cfg: Glm5Config, ps: ParallelState
+) -> torch.Tensor:
+    from megatron.lite.primitive.parallel import pad_vocab_for_tp
+
+    tensor = _get(reader, name)
+    padded = pad_vocab_for_tp(cfg.vocab_size, ps.tp_size)
+    if tensor.size(0) < padded:
+        pad = torch.zeros(padded - tensor.size(0), tensor.size(1), dtype=tensor.dtype)
+        tensor = torch.cat([tensor, pad], dim=0)
+    return _tp(tensor, ps.tp_rank, ps.tp_size)
+
+
+def _load_attention(
+    out: dict[str, torch.Tensor],
+    *,
+    local_prefix: str,
+    hf_prefix: str,
+    reader: SafeTensorReader,
+    ps: ParallelState,
+) -> None:
+    # GLM-5 ONLY: DSA attention.  Native params live under
+    # `<local_prefix>.self_attention.self_attention.*` (the wrapper adds one
+    # `self_attention` level around the DSA module).  HF names are GLM-5's
+    # `<hf_prefix>.{...}` (DSA submodule names map 1:1 to the HF model).
+    ap = f"{local_prefix}.self_attention.self_attention"
+    out[f"{ap}.q_a_proj.weight"] = _get(reader, f"{hf_prefix}.q_a_proj.weight")
+    out[f"{ap}.q_a_layernorm.weight"] = _get(reader, f"{hf_prefix}.q_a_layernorm.weight")
+    out[f"{ap}.q_b_proj.weight"] = _get(reader, f"{hf_prefix}.q_b_proj.weight")
+    out[f"{ap}.kv_a_proj_with_mqa.weight"] = _get(
+        reader, f"{hf_prefix}.kv_a_proj_with_mqa.weight"
+    )
+    out[f"{ap}.kv_a_layernorm.weight"] = _get(reader, f"{hf_prefix}.kv_a_layernorm.weight")
+    out[f"{ap}.kv_b_proj.weight"] = _get(reader, f"{hf_prefix}.kv_b_proj.weight")
+    out[f"{ap}.o_proj.weight"] = _get(reader, f"{hf_prefix}.o_proj.weight")
+    # DSA indexer.
+    ip = f"{ap}.indexer"
+    hip = f"{hf_prefix}.indexer"
+    out[f"{ip}.wq_b.weight"] = _get(reader, f"{hip}.wq_b.weight")
+    out[f"{ip}.wk.weight"] = _get(reader, f"{hip}.wk.weight")
+    out[f"{ip}.k_norm.weight"] = _get(reader, f"{hip}.k_norm.weight")
+    if _has(reader, f"{hip}.k_norm.bias"):
+        out[f"{ip}.k_norm.bias"] = _get(reader, f"{hip}.k_norm.bias")
+    out[f"{ip}.weights_proj.weight"] = _get(reader, f"{hip}.weights_proj.weight")
+
+
+def _load_dense_mlp(
+    out: dict[str, torch.Tensor],
+    *,
+    local_prefix: str,
+    hf_mlp_prefix: str,
+    hf_layer_prefix: str,
+    reader: SafeTensorReader,
+    ps: ParallelState,
+) -> None:
+    out[f"{local_prefix}.mlp.gate_up.linear.layer_norm_weight"] = _get(
+        reader,
+        f"{hf_layer_prefix}.post_attention_layernorm.weight",
+    )
+    gate_up = torch.cat(
+        [
+            _get(reader, f"{hf_mlp_prefix}.gate_proj.weight"),
+            _get(reader, f"{hf_mlp_prefix}.up_proj.weight"),
+        ],
+        dim=0,
+    )
+    out[f"{local_prefix}.mlp.gate_up.linear.weight"] = _split_gate_up(
+        gate_up,
+        ps.tp_rank,
+        ps.tp_size,
+    )
+    out[f"{local_prefix}.mlp.down.linear.weight"] = _tp(
+        _get(reader, f"{hf_mlp_prefix}.down_proj.weight"),
+        ps.tp_rank,
+        ps.tp_size,
+        dim=1,
+    )
+
+
+def _load_shared_expert(
+    out: dict[str, torch.Tensor],
+    *,
+    local_prefix: str,
+    hf_mlp_prefix: str,
+    reader: SafeTensorReader,
+    ps: ParallelState,
+) -> None:
+    prefixes = [f"{hf_mlp_prefix}.shared_experts", f"{hf_mlp_prefix}.shared_expert"]
+    shared = next(prefix for prefix in prefixes if _has(reader, f"{prefix}.down_proj.weight"))
+    gate_up = torch.cat(
+        [
+            _get(reader, f"{shared}.gate_proj.weight"),
+            _get(reader, f"{shared}.up_proj.weight"),
+        ],
+        dim=0,
+    )
+    out[f"{local_prefix}.moe.shared_expert.gate_up.linear.weight"] = _split_gate_up(
+        gate_up,
+        ps.tp_rank,
+        ps.tp_size,
+    )
+    out[f"{local_prefix}.moe.shared_expert.down.linear.weight"] = _tp(
+        _get(reader, f"{shared}.down_proj.weight"),
+        ps.tp_rank,
+        ps.tp_size,
+        dim=1,
+    )
+
+
+def _load_experts(
+    out: dict[str, torch.Tensor],
+    *,
+    local_prefix: str,
+    hf_mlp_prefix: str,
+    cfg: Glm5Config,
+    ps: ParallelState,
+    reader: SafeTensorReader,
+) -> None:
+    num_local = ensure_divisible(cfg.num_experts, ps.ep_size)
+    local_start = ps.ep_rank * num_local
+    for local_idx in range(num_local):
+        global_idx = local_start + local_idx
+        ep = f"{hf_mlp_prefix}.experts.{global_idx}"
+        fc1 = torch.cat(
+            [
+                _get(reader, f"{ep}.gate_proj.weight"),
+                _get(reader, f"{ep}.up_proj.weight"),
+            ],
+            dim=0,
+        )
+        fc2 = _get(reader, f"{ep}.down_proj.weight")
+        if ps.etp_size > 1:
+            fc1 = _split_gate_up(fc1, ps.etp_rank, ps.etp_size)
+            fc2 = _tp(fc2, ps.etp_rank, ps.etp_size, dim=1)
+        out[f"{local_prefix}.moe.experts.fc1.weight{local_idx}"] = fc1
+        out[f"{local_prefix}.moe.experts.fc2.weight{local_idx}"] = fc2
+
+
+def _copy_loaded_state(model: nn.Module, loaded: dict[str, torch.Tensor]) -> None:
+    state = model.state_dict()
+    resolved: dict[str, torch.Tensor] = {}
+    for name, tensor in loaded.items():
+        actual = name if name in state else None
+        if actual is None:
+            for key in state:
+                if name in key:
+                    actual = key
+                    break
+        if actual is not None:
+            resolved[actual] = tensor
+        else:
+            log_rank0(f"WARNING: glm5 checkpoint tensor has no target param: {name}")
+
+    for name, target in model.named_parameters():
+        if name not in resolved:
+            log_rank0(f"WARNING: {name} not loaded from checkpoint")
+            continue
+        tensor = resolved[name].to(device=target.device)
+        target.data.copy_(tensor.to(dtype=target.dtype))
+
+    for name, target in model.named_buffers():
+        if name not in resolved:
+            continue
+        tensor = resolved[name].to(device=target.device)
+        target.data.copy_(tensor.to(dtype=target.dtype) if target.is_floating_point() else tensor)
+
+
+class Glm5WeightSpec:
+    """Export GLM-5 lite weights to HF GLM-5 (deepseek_v3_2) names."""
+
+    def __init__(self, config: Glm5Config):
+        self.config = config
+
+    @property
+    def num_experts(self) -> int:
+        return self.config.num_experts
+
+    def weight_map(self) -> dict[str, list[str]]:
+        return {}
+
+    def hf_to_native(self, native_name: str, hf_tensors: list[torch.Tensor]) -> torch.Tensor:
+        del native_name
+        return hf_tensors[0]
+
+    # GLM-5 ONLY: DSA attention native suffix -> HF suffix.  The wrapper places
+    # the DSA module under `self_attention.self_attention.*`; the HF model uses
+    # `self_attn.*` with identical submodule names.
+    _ATTN_SUFFIX_MAP: dict[str, str] = {
+        "self_attention.self_attention.q_a_proj.weight": "q_a_proj.weight",
+        "self_attention.self_attention.q_a_layernorm.weight": "q_a_layernorm.weight",
+        "self_attention.self_attention.q_b_proj.weight": "q_b_proj.weight",
+        "self_attention.self_attention.kv_a_proj_with_mqa.weight": "kv_a_proj_with_mqa.weight",
+        "self_attention.self_attention.kv_a_layernorm.weight": "kv_a_layernorm.weight",
+        "self_attention.self_attention.kv_b_proj.weight": "kv_b_proj.weight",
+        "self_attention.self_attention.o_proj.weight": "o_proj.weight",
+        "self_attention.self_attention.indexer.wq_b.weight": "indexer.wq_b.weight",
+        "self_attention.self_attention.indexer.wk.weight": "indexer.wk.weight",
+        "self_attention.self_attention.indexer.k_norm.weight": "indexer.k_norm.weight",
+        "self_attention.self_attention.indexer.k_norm.bias": "indexer.k_norm.bias",
+        "self_attention.self_attention.indexer.weights_proj.weight": "indexer.weights_proj.weight",
+    }
+
+    def native_to_hf(
+        self, native_name: str, tensor: torch.Tensor
+    ) -> list[tuple[str, torch.Tensor]]:
+        if native_name == "mtp_embed.embedding.weight":
+            return []
+        if native_name.startswith("mtp.layers."):
+            parts = native_name.split(".")
+            mtp_idx = int(parts[2])
+            hf_layer_idx = self.config.num_hidden_layers + mtp_idx
+            hp = f"model.layers.{hf_layer_idx}"
+            if native_name.endswith(".enorm.weight"):
+                return [(f"{hp}.enorm.weight", tensor)]
+            if native_name.endswith(".hnorm.weight"):
+                return [(f"{hp}.hnorm.weight", tensor)]
+            if native_name.endswith(".eh_proj.linear.weight"):
+                return [(f"{hp}.eh_proj.weight", tensor)]
+            if native_name.endswith(".final_layernorm.weight"):
+                return [(f"{hp}.shared_head.norm.weight", tensor)]
+            proxy = native_name.replace(
+                f"mtp.layers.{mtp_idx}.transformer_layer",
+                f"layers.{hf_layer_idx}",
+            )
+            return self.native_to_hf(proxy, tensor)
+        if native_name == "embed.embedding.weight":
+            return [("model.embed_tokens.weight", tensor)]
+        if native_name == "norm.weight":
+            return [("model.norm.weight", tensor)]
+        if native_name == "head.col.linear.weight":
+            return [("lm_head.weight", tensor)]
+
+        parts = native_name.split(".")
+        if len(parts) < 3 or parts[0] != "layers":
+            return []
+        layer_idx = int(parts[1])
+        suffix = ".".join(parts[2:])
+        hp = f"model.layers.{layer_idx}"
+        ap = f"{hp}.self_attn"
+        mp = f"{hp}.mlp"
+
+        if suffix == "input_layernorm.weight":
+            return [(f"{hp}.input_layernorm.weight", tensor)]
+
+        # GLM-5 ONLY: DSA attention (incl. indexer) maps 1:1 onto self_attn.*.
+        attn_hf = self._ATTN_SUFFIX_MAP.get(suffix)
+        if attn_hf is not None:
+            return [(f"{ap}.{attn_hf}", tensor)]
+
+        if suffix == "mlp.gate_up.linear.layer_norm_weight":
+            return [(f"{hp}.post_attention_layernorm.weight", tensor)]
+        if suffix == "mlp.gate_up.linear.weight":
+            gate, up = tensor.chunk(2, dim=0)
+            return [
+                (f"{mp}.gate_proj.weight", gate.contiguous()),
+                (f"{mp}.up_proj.weight", up.contiguous()),
+            ]
+        if suffix == "mlp.down.linear.weight":
+            return [(f"{mp}.down_proj.weight", tensor)]
+
+        if suffix == "mlp_norm.weight":
+            return [(f"{hp}.post_attention_layernorm.weight", tensor)]
+        if suffix == "moe.router.gate.weight":
+            return [(f"{mp}.gate.weight", tensor)]
+        if suffix == "moe.router.expert_bias":
+            return [(f"{mp}.gate.e_score_correction_bias", tensor.float())]
+        if suffix == "moe.shared_expert.gate_up.linear.weight":
+            gate, up = tensor.chunk(2, dim=0)
+            return [
+                (f"{mp}.shared_experts.gate_proj.weight", gate.contiguous()),
+                (f"{mp}.shared_experts.up_proj.weight", up.contiguous()),
+            ]
+        if suffix == "moe.shared_expert.down.linear.weight":
+            return [(f"{mp}.shared_experts.down_proj.weight", tensor)]
+
+        if ".moe.experts.fc1.weight" in native_name:
+            expert_idx = parse_expert_idx(native_name)
+            gate, up = tensor.chunk(2, dim=0)
+            return [
+                (f"{mp}.experts.{expert_idx}.gate_proj.weight", gate.contiguous()),
+                (f"{mp}.experts.{expert_idx}.up_proj.weight", up.contiguous()),
+            ]
+        if ".moe.experts.fc2.weight" in native_name:
+            expert_idx = parse_expert_idx(native_name)
+            return [(f"{mp}.experts.{expert_idx}.down_proj.weight", tensor)]
+
+        return []
+
+    def qkv_spec(self, native_name: str) -> tuple[int, int, int] | None:
+        del native_name
+        return None
+
+    def tp_spec(self, native_name: str) -> tuple[int, int] | None:
+        # GLM-5 is TP=1 (DSA not TP-capable); only EP / ETP shard tensors.
+        if native_name.startswith("mtp.layers.") and ".transformer_layer." in native_name:
+            proxy = native_name.replace(".transformer_layer.", ".")
+            return self.tp_spec(proxy)
+        if native_name.endswith(".eh_proj.linear.weight"):
+            return (0, 0)
+        if self.is_expert(native_name):
+            if ".fc1." in native_name:
+                return (0, 1)
+            if ".fc2." in native_name:
+                return (1, 1)
+            return None
+        if native_name in {"embed.embedding.weight", "head.col.linear.weight"}:
+            return (0, 0)
+        if native_name.endswith(".mlp.gate_up.linear.weight"):
+            return (0, 0)
+        if native_name.endswith(".mlp.down.linear.weight"):
+            return (1, 0)
+        if native_name.endswith(".moe.shared_expert.gate_up.linear.weight"):
+            return (0, 0)
+        if native_name.endswith(".moe.shared_expert.down.linear.weight"):
+            return (1, 0)
+        return None
+
+    def is_expert(self, native_name: str) -> bool:
+        return ".moe.experts." in native_name and ".router." not in native_name
+
+    def expert_global_id(self, native_name: str) -> int | None:
+        if self.is_expert(native_name):
+            return parse_expert_idx(native_name)
+        return None
+
+    def expert_local_name(self, native_name: str, local_idx: int) -> str:
+        prefix = native_name.rsplit(".weight", 1)[0]
+        return f"{prefix}.weight{local_idx}"
+
+
+def load_hf_weights(model: nn.Module, path: str, config: Glm5Config, ps: ParallelState) -> None:
+    base_model = unwrap_model(model)
+    reader = SafeTensorReader(path)
+    out: dict[str, torch.Tensor] = {}
+
+    prefix = _text_prefix(reader)
+
+    if getattr(base_model, "embed", None) is not None:
+        out["embed.embedding.weight"] = _load_vocab(
+            reader, f"{prefix}.embed_tokens.weight", config, ps
+        )
+    if getattr(base_model, "mtp_embed", None) is not None:
+        out["mtp_embed.embedding.weight"] = _load_vocab(
+            reader,
+            f"{prefix}.embed_tokens.weight",
+            config,
+            ps,
+        )
+    if getattr(base_model, "norm", None) is not None:
+        out["norm.weight"] = _get(reader, f"{prefix}.norm.weight")
+    if getattr(base_model, "head", None) is not None:
+        out["head.col.linear.weight"] = _load_vocab(
+            reader, _lm_head_name(reader, prefix), config, ps
+        )
+
+    for local_idx, global_idx in enumerate(base_model.layer_indices):
+        lp = f"layers.{local_idx}"
+        hp = f"{prefix}.layers.{global_idx}"
+        out[f"{lp}.input_layernorm.weight"] = _get(reader, f"{hp}.input_layernorm.weight")
+        _load_attention(
+            out,
+            local_prefix=lp,
+            hf_prefix=f"{hp}.self_attn",
+            reader=reader,
+            ps=ps,
+        )
+        if config.is_moe_layer(global_idx):
+            out[f"{lp}.mlp_norm.weight"] = _get(reader, f"{hp}.post_attention_layernorm.weight")
+            out[f"{lp}.moe.router.gate.weight"] = _get(reader, f"{hp}.mlp.gate.weight")
+            bias_name = f"{hp}.mlp.gate.e_score_correction_bias"
+            if _has(reader, bias_name):
+                out[f"{lp}.moe.router.expert_bias"] = _get(reader, bias_name).float()
+            _load_shared_expert(
+                out, local_prefix=lp, hf_mlp_prefix=f"{hp}.mlp", reader=reader, ps=ps
+            )
+            _load_experts(
+                out,
+                local_prefix=lp,
+                hf_mlp_prefix=f"{hp}.mlp",
+                cfg=config,
+                ps=ps,
+                reader=reader,
+            )
+        else:
+            _load_dense_mlp(
+                out,
+                local_prefix=lp,
+                hf_mlp_prefix=f"{hp}.mlp",
+                hf_layer_prefix=hp,
+                reader=reader,
+                ps=ps,
+            )
+
+    mtp = getattr(base_model, "mtp", None)
+    if mtp is not None:
+        for local_idx, _mtp_layer in enumerate(mtp.layers):
+            global_idx = config.num_hidden_layers + local_idx
+            lp = f"mtp.layers.{local_idx}"
+            hp = f"{prefix}.layers.{global_idx}"
+            tlp = f"{lp}.transformer_layer"
+            out[f"{lp}.enorm.weight"] = _get(reader, f"{hp}.enorm.weight")
+            out[f"{lp}.hnorm.weight"] = _get(reader, f"{hp}.hnorm.weight")
+            out[f"{lp}.eh_proj.linear.weight"] = _tp(
+                _get(reader, f"{hp}.eh_proj.weight"),
+                ps.tp_rank,
+                ps.tp_size,
+            )
+            shared_head_norm = f"{hp}.shared_head.norm.weight"
+            final_norm = (
+                shared_head_norm
+                if _has(reader, shared_head_norm)
+                else f"{hp}.final_layernorm.weight"
+            )
+            out[f"{lp}.final_layernorm.weight"] = _get(reader, final_norm)
+            out[f"{tlp}.input_layernorm.weight"] = _get(reader, f"{hp}.input_layernorm.weight")
+            _load_attention(
+                out,
+                local_prefix=tlp,
+                hf_prefix=f"{hp}.self_attn",
+                reader=reader,
+                ps=ps,
+            )
+            if config.is_moe_layer(global_idx):
+                out[f"{tlp}.mlp_norm.weight"] = _get(
+                    reader, f"{hp}.post_attention_layernorm.weight"
+                )
+                out[f"{tlp}.moe.router.gate.weight"] = _get(reader, f"{hp}.mlp.gate.weight")
+                bias_name = f"{hp}.mlp.gate.e_score_correction_bias"
+                if _has(reader, bias_name):
+                    out[f"{tlp}.moe.router.expert_bias"] = _get(reader, bias_name).float()
+                _load_shared_expert(
+                    out,
+                    local_prefix=tlp,
+                    hf_mlp_prefix=f"{hp}.mlp",
+                    reader=reader,
+                    ps=ps,
+                )
+                _load_experts(
+                    out,
+                    local_prefix=tlp,
+                    hf_mlp_prefix=f"{hp}.mlp",
+                    cfg=config,
+                    ps=ps,
+                    reader=reader,
+                )
+            else:
+                _load_dense_mlp(
+                    out,
+                    local_prefix=tlp,
+                    hf_mlp_prefix=f"{hp}.mlp",
+                    hf_layer_prefix=hp,
+                    reader=reader,
+                    ps=ps,
+                )
+
+    _copy_loaded_state(base_model, out)
+
+
+def export_hf_weights(model, config: Glm5Config, ps: ParallelState, **kwargs):
+    from megatron.lite.primitive.ckpt.hf_weights import export_hf_weights as _export
+
+    spec = Glm5WeightSpec(config)
+    rank0_only = bool(kwargs.get("rank0_only", False))
+    export_dtype = _resolve_export_dtype(kwargs.get("export_dtype"))
+    yield from _export(model, spec, ps, vocab_size=config.vocab_size, **kwargs)
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    if rank0_only and rank != 0:
+        return
+    chunks = list(model) if isinstance(model, list | nn.ModuleList) else [model]
+    for chunk in chunks:
+        base_chunk = unwrap_model(chunk)
+        layer_map = (
+            {i: base_chunk.layer_indices[i] for i in range(len(base_chunk.layer_indices))}
+            if hasattr(base_chunk, "layer_indices")
+            else {}
+        )
+        for name, buffer in base_chunk.named_buffers():
+            if not name.endswith(".moe.router.expert_bias"):
+                continue
+            global_name = to_global_layer_name(name, layer_map)
+            for hf_name, hf_tensor in spec.native_to_hf(global_name, buffer.detach().cpu()):
+                yield hf_name, _cast_export_tensor(hf_tensor, export_dtype)
+
+
+def save_hf_weights(model, path: str, config: Glm5Config, ps: ParallelState, **kwargs) -> None:
+    from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
+
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    out = dict(export_hf_weights(model, config, ps, rank0_only=True, **kwargs))
+    if rank == 0 and out:
+        save_safetensors(out, path)
+    if dist.is_initialized():
+        dist.barrier()
+
+
+__all__ = [
+    "EXPERT_CLASSIFIER",
+    "Glm5WeightSpec",
+    "PLACEMENT_FN",
+    "_dequant_int4_weight",
+    "_dequant_fp8_weight",
+    "export_hf_weights",
+    "load_hf_weights",
+    "save_hf_weights",
+]

--- a/experimental/lite/megatron/lite/model/glm5/lite/model.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/model.py
@@ -1,0 +1,966 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""GLM-5 (deepseek_v3_2) lite native model.
+
+This model is a near-verbatim clone of the Kimi-K2 (deepseek_v3) lite model
+(``megatron/lite/model/kimi_k2/lite/model.py``).  It inherits ALL of Kimi's
+Megatron plumbing unchanged: SBHD ``[S, B, H]`` layout, sequence-parallel
+scatter/gather, ``VocabParallelEmbedding`` / ``VocabParallelOutput``,
+``share_embeddings_and_output_weights``, ``set_input_tensor``,
+``build_pipeline_chunk_layout``-based pipeline boundaries, MTP, and the
+dist-opt / distckpt integration.
+
+The ONLY functional difference from Kimi is the attention module: where Kimi
+uses ``MultiLatentAttention`` (MLA), GLM-5 uses Dynamic Sparse Attention (DSA).
+The DSA primitive is hard-wired batch-first ``[B, S, H]`` and expects explicit
+``cos`` / ``sin`` / ``position_ids`` + ``packed_seq_params``, so it is wrapped
+by ``Glm5DSAAttention`` which transposes ``[S, B, H] -> [B, S, H]`` before DSA
+and back after, and builds the rotary embeddings / position ids locally.  The
+surrounding Kimi skeleton therefore stays byte-for-byte SBHD and untouched.
+
+NOTE: DSA is NOT tensor-parallel-capable, so GLM-5 is a documented TP=1 special
+case (the protocol gate raises for TP>1 / ETP>1).  VPP / PP / EP / CP work,
+inherited from Kimi.
+"""
+
+from __future__ import annotations
+
+import inspect
+import os
+from contextlib import nullcontext
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+import transformer_engine.pytorch as te
+
+from megatron.lite.model.glm5.config import Glm5Config
+from megatron.lite.primitive.modules.attention import (
+    DynamicSparseAttention,
+    build_rotary_embeddings,
+)
+from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
+from megatron.lite.primitive.modules.experts import Experts
+from megatron.lite.primitive.modules.moe import MoEAuxLossAutoScaler
+from megatron.lite.primitive.modules.mtp import MTPLossAutoScaler
+from megatron.lite.primitive.ops.cross_entropy import vocab_parallel_cross_entropy
+from megatron.lite.primitive.ops.linear_cross_entropy import linear_cross_entropy
+from megatron.lite.primitive.ops.logprob import vocab_parallel_entropy
+from megatron.lite.primitive.ops.sp_ops import ReduceScatterDim0
+from megatron.lite.primitive.kernels.swiglu import bias_swiglu_impl
+from megatron.lite.primitive.parallel import (
+    ColumnParallelLinear,
+    ParallelState,
+    RowParallelLinear,
+    VanillaColumnParallelLinear,
+    VocabParallelEmbedding,
+    VocabParallelOutput,
+    build_pipeline_chunk_layout,
+    gather_from_sequence_parallel,
+    roll_packed_thd_left,
+    scatter_to_sequence_parallel,
+)
+from megatron.lite.primitive.utils import build_fp8_recipe
+from megatron.lite.primitive.utils.moe import (
+    compute_routing_scores_for_aux_loss,
+    router_gating_linear,
+    switch_load_balancing_loss_func,
+    topk_routing_with_score_function,
+)
+
+# -- GLM-5 ONLY: SP-grad parameter suffixes for the DSA attention (Kimi's MLA
+# suffixes -- linear_q_down_proj / linear_kv_down_proj / *_up_proj.linear.* --
+# are replaced by the DSA module's parameter names).  These tag the
+# layernorm-fronted columns whose grads must be all-reduced across SP ranks.
+# (At GLM-5's enforced TP=1 this list is unused, but is kept structurally so
+# the model stays a faithful Kimi clone.)
+_SP_GRAD_SUFFIXES: tuple[str, ...] = (
+    ".input_layernorm.weight",
+    ".self_attention.q_a_proj.weight",
+    ".self_attention.q_a_layernorm.weight",
+    ".self_attention.kv_a_proj_with_mqa.weight",
+    ".self_attention.kv_a_layernorm.weight",
+    ".mlp_norm.weight",
+    ".mlp.gate_up.linear.layer_norm_weight",
+    ".moe.router.gate.weight",
+    ".norm.weight",
+)
+
+
+def _collect_sp_grad_params(model: nn.Module) -> list[nn.Parameter]:
+    return [
+        param
+        for name, param in model.named_parameters()
+        if any(name.endswith(suffix) for suffix in _SP_GRAD_SUFFIXES) or name == "norm.weight"
+    ]
+
+
+def _swiglu(x: torch.Tensor) -> torch.Tensor:
+    if x.is_cuda:
+        return bias_swiglu_impl(x, None, False, False)
+    x1, x2 = torch.chunk(x, 2, dim=-1)
+    return F.silu(x1) * x2
+
+
+def _reduce_scatter_to_sequence_parallel(x: torch.Tensor, ps: ParallelState) -> torch.Tensor:
+    if ps.tp_size == 1:
+        return x
+    return ReduceScatterDim0.apply(x, ps.tp_size, ps.tp_rank, ps.tp_group)
+
+
+def _ordered_topk_from_routing_map(
+    probs_dense: torch.Tensor, routing_map: torch.Tensor, topk: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    expert_ids = torch.arange(
+        probs_dense.size(-1), device=probs_dense.device, dtype=torch.long
+    ).expand_as(routing_map)
+    masked_ids = torch.where(
+        routing_map, expert_ids, torch.full_like(expert_ids, probs_dense.size(-1))
+    )
+    topk_indices = torch.sort(masked_ids, dim=-1).values[:, :topk]
+    topk_scores = torch.gather(probs_dense, dim=-1, index=topk_indices)
+    return topk_scores, topk_indices
+
+
+def _router_linear(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    router_dtype: torch.dtype,
+) -> torch.Tensor:
+    if x.is_cuda:
+        return router_gating_linear(x, weight, bias, router_dtype)
+    return F.linear(
+        x.to(router_dtype),
+        weight.to(router_dtype),
+        None if bias is None else bias.to(router_dtype),
+    )
+
+
+def _topk_routing_supports_groups() -> bool:
+    params = inspect.signature(topk_routing_with_score_function).parameters
+    return "num_groups" in params and "group_topk" in params
+
+
+# -- GLM-5 ONLY: DSA attention wrapper.  Holds ``DynamicSparseAttention`` and
+# adapts it to Kimi's SBHD-in / SBHD-out attention contract.  Everything outside
+# this class (norms, residual, MoE, MTP, embed, head, SP scatter/gather) is
+# identical to Kimi.
+class Glm5DSAAttention(nn.Module):
+    """SBHD ``[S, B, H]`` shim around the batch-first DSA primitive.
+
+    Kimi's decoder layer calls ``self.self_attention(x_sbhd, packed_seq_params=)``
+    where ``x_sbhd`` is ``[S, B, H]``.  DSA is hard-wired ``[B, S, H]`` and needs
+    explicit ``cos`` / ``sin`` / ``position_ids``.  This wrapper:
+      1. transposes ``[S, B, H] -> [B, S, H]``,
+      2. builds ``position_ids`` (local sequence) and the rotary ``cos`` / ``sin``,
+      3. runs DSA,
+      4. transposes the ``[B, S, H]`` output back to ``[S, B, H]``.
+    The Kimi skeleton therefore never observes the batch-first interior.
+    """
+
+    def __init__(self, config: Glm5Config, ps: ParallelState):
+        super().__init__()
+        self.ps = ps
+        self.qk_rope_head_dim = config.qk_rope_head_dim
+        self.rope_theta = config.rope_theta
+        self.self_attention = DynamicSparseAttention(
+            hidden_size=config.hidden_size,
+            num_attention_heads=config.num_attention_heads,
+            q_lora_rank=config.q_lora_rank,
+            kv_lora_rank=config.kv_lora_rank,
+            qk_nope_head_dim=config.qk_nope_head_dim,
+            qk_rope_head_dim=config.qk_rope_head_dim,
+            v_head_dim=config.v_head_dim,
+            index_n_heads=config.index_n_heads,
+            index_head_dim=config.index_head_dim,
+            index_topk=config.index_topk,
+            rms_norm_eps=config.rms_norm_eps,
+            rope_interleaved=config.rope_interleave,
+            latent_rms_norm_eps=config.latent_rms_norm_eps,
+            indexer_layer_norm_eps=config.indexer_layer_norm_eps,
+            indexer_rope_interleaved=config.indexer_rope_interleave,
+            indexer_rope_first=config.indexer_rope_first,
+            indexer_use_hadamard=config.indexer_use_hadamard,
+            indexer_loss_coeff=config.dsa_indexer_loss_coeff,
+            indexer_use_sparse_loss=config.dsa_indexer_use_sparse_loss,
+            calculate_per_token_loss=config.calculate_per_token_loss,
+            cp_size=ps.cp_size,
+            cp_rank=ps.cp_rank,
+            cp_group=ps.cp_group,
+        )
+
+    def forward(self, x: torch.Tensor, packed_seq_params=None) -> torch.Tensor:
+        # Kimi feeds SBHD [S, B, H]; DSA needs batch-first [B, S, H].
+        x_bsh = x.transpose(0, 1).contiguous()
+        batch, seq_len, _ = x_bsh.shape
+        # Local (this-rank) position ids; DSA reconstructs the full sequence
+        # itself when CP > 1.
+        position_ids = (
+            torch.arange(seq_len, device=x_bsh.device, dtype=torch.long)
+            .unsqueeze(0)
+            .expand(batch, -1)
+        )
+        cos, sin = build_rotary_embeddings(
+            position_ids=position_ids,
+            dim=self.qk_rope_head_dim,
+            rope_theta=self.rope_theta,
+            dtype=x_bsh.dtype,
+        )
+        out_bsh = self.self_attention(
+            x_bsh,
+            cos=cos,
+            sin=sin,
+            position_ids=position_ids,
+            attention_mask=None,
+            packed_seq_params=packed_seq_params,
+        )
+        # Back to SBHD [S, B, H] for the Kimi skeleton.
+        return out_bsh.transpose(0, 1).contiguous()
+
+
+class Glm5SigmoidTopKRouter(nn.Module):
+    """GLM-5 sigmoid router with group-limited routing and persistent expert bias.
+
+    Byte-identical to Kimi's ``KimiK2SigmoidTopKRouter`` except for the config
+    type and that GLM-5 has no ``aux_loss_alpha`` HF field -- the aux coefficient
+    therefore defaults to 0 (aux loss contributes 0).
+    """
+
+    def __init__(
+        self,
+        config: Glm5Config,
+        ps: ParallelState,
+        *,
+        router_bias_rate: float = 0.0,
+        compute_aux_loss: bool = True,
+        use_pre_softmax: bool = False,
+        moe_router_fusion: bool = False,
+    ):
+        super().__init__()
+        if router_bias_rate > 0:
+            raise NotImplementedError(
+                "GLM-5 expert-bias EMA update is not implemented in lite yet."
+            )
+        self.topk = config.num_experts_per_tok
+        self.num_experts = config.n_routed_experts
+        # GLM-5 has no aux_loss_alpha HF field; default the coefficient to 0.
+        self.aux_loss_coeff = getattr(config, "aux_loss_alpha", 0.0)
+        self.scaling_factor = config.routed_scaling_factor
+        self.num_groups = config.n_group if (config.n_group and config.n_group > 1) else None
+        self.group_topk = config.topk_group if self.num_groups is not None else None
+        self.router_bias_rate = router_bias_rate
+        self.compute_aux_loss = compute_aux_loss
+        self.use_pre_softmax = use_pre_softmax
+        self.moe_router_fusion = moe_router_fusion
+
+        self.gate = nn.Linear(config.hidden_size, config.n_routed_experts, bias=False)
+        self.register_buffer(
+            "expert_bias",
+            torch.zeros(config.n_routed_experts, dtype=torch.float32),
+            persistent=True,
+        )
+        self.register_buffer(
+            "local_tokens_per_expert",
+            torch.zeros(config.n_routed_experts, dtype=torch.float32),
+            persistent=False,
+        )
+        self._aux_loss_group = ps.tp_group if ps.tp_size > 1 else None
+
+    def _apply(self, fn):
+        super()._apply(fn)
+        self.expert_bias.data = self.expert_bias.data.float()
+        self.local_tokens_per_expert.data = self.local_tokens_per_expert.data.float()
+        return self
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        logits = _router_linear(x, self.gate.weight, None, torch.float32)
+        logits = logits.view(-1, self.num_experts)
+        num_tokens = logits.size(0)
+        routing_kwargs = {}
+        if self.num_groups is not None and self.group_topk is not None:
+            if not _topk_routing_supports_groups():
+                raise NotImplementedError(
+                    "topk_routing_with_score_function does not support group-limited routing."
+                )
+            routing_kwargs = dict(num_groups=self.num_groups, group_topk=self.group_topk)
+        probs_dense, routing_map = topk_routing_with_score_function(
+            logits,
+            self.topk,
+            use_pre_softmax=self.use_pre_softmax,
+            score_function="sigmoid",
+            expert_bias=self.expert_bias.to(logits.dtype),
+            scaling_factor=(self.scaling_factor or None),
+            fused=self.moe_router_fusion,
+            **routing_kwargs,
+        )
+        if torch.is_grad_enabled():
+            with torch.no_grad():
+                self.local_tokens_per_expert += routing_map.sum(dim=0)
+        topk_scores, topk_indices = _ordered_topk_from_routing_map(
+            probs_dense, routing_map, self.topk
+        )
+        topk_scores = topk_scores.to(logits.dtype)
+
+        if self.compute_aux_loss and self.training and torch.is_grad_enabled():
+            _, aux_scores = compute_routing_scores_for_aux_loss(
+                logits, self.topk, score_function="sigmoid", fused=self.moe_router_fusion
+            )
+            tokens_per_expert = routing_map.sum(dim=0).to(torch.int64)
+            total_num_tokens = num_tokens
+            if self._aux_loss_group is not None:
+                dist.all_reduce(tokens_per_expert, group=self._aux_loss_group)
+                total_num_tokens = num_tokens * dist.get_world_size(group=self._aux_loss_group)
+            aux_loss = switch_load_balancing_loss_func(
+                aux_scores,
+                tokens_per_expert,
+                total_num_tokens,
+                self.topk,
+                self.num_experts,
+                self.aux_loss_coeff,
+                fused=False,
+            )
+            topk_scores = MoEAuxLossAutoScaler.apply(topk_scores, aux_loss)
+
+        return topk_scores, topk_indices
+
+
+class DenseMLP(nn.Module):
+    def __init__(self, config: Glm5Config, ps: ParallelState):
+        super().__init__()
+        self.gate_up = ColumnParallelLinear(
+            config.hidden_size,
+            config.intermediate_size * 2,
+            ps,
+            bias=False,
+            normalization="RMSNorm",
+            eps=config.rms_norm_eps,
+        )
+        self.down = RowParallelLinear(config.intermediate_size, config.hidden_size, ps, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.down(_swiglu(self.gate_up(x)))
+
+
+class SharedExpert(nn.Module):
+    def __init__(self, config: Glm5Config, ps: ParallelState):
+        super().__init__()
+        self.ps = ps
+        # GLM-5 has no shared_expert_intermediate_size property; compute it from
+        # n_shared_experts * moe_intermediate_size (matches Kimi's property).
+        ffn = config.n_shared_experts * config.moe_intermediate_size
+        self.gate_up = _LocalLinear(config.hidden_size, ffn * 2 // ps.tp_size)
+        self.down = _LocalLinear(ffn // ps.tp_size, config.hidden_size)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        squeeze_batch = x.dim() == 2
+        if squeeze_batch:
+            x = x.unsqueeze(1)
+        full_x = gather_from_sequence_parallel(x, self.ps)
+        partial_out = self.down(_swiglu(self.gate_up(full_x)))
+        out = _reduce_scatter_to_sequence_parallel(partial_out, self.ps)
+        return out.squeeze(1) if squeeze_batch else out
+
+
+class _LocalLinear(nn.Module):
+    """TE linear without built-in TP collectives; weight remains TP-local."""
+
+    def __init__(self, in_features: int, out_features: int):
+        super().__init__()
+        self.linear = te.Linear(
+            in_features,
+            out_features,
+            bias=False,
+            params_dtype=torch.bfloat16,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.linear(x)
+
+
+class MoELayer(nn.Module):
+    def __init__(
+        self,
+        config: Glm5Config,
+        ps: ParallelState,
+        *,
+        use_deepep: bool,
+        router_bias_rate: float,
+        fp8: bool,
+        moe_act_recompute: bool,
+    ):
+        super().__init__()
+        if fp8:
+            raise NotImplementedError("GLM-5 lite MoE fp8 training is not implemented yet.")
+        self.router = Glm5SigmoidTopKRouter(
+            config,
+            ps,
+            router_bias_rate=router_bias_rate,
+            compute_aux_loss=True,
+            use_pre_softmax=True,
+        )
+        self.experts = Experts(
+            config,
+            ps,
+            fp8=fp8,
+            moe_act_recompute=moe_act_recompute,
+        )
+        self.dispatcher = TokenDispatcher(
+            config.num_experts,
+            config.hidden_size,
+            ps,
+            use_deepep=use_deepep,
+        )
+        self.shared_expert = SharedExpert(config, ps)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        input_shape = x.shape
+
+        flat_x = x.view(-1, x.size(-1))
+        scores, indices = self.router(flat_x)
+        dispatched, tpe, permuted_probs = self.dispatcher.dispatch(flat_x, scores, indices)
+        del scores, indices
+        self.dispatcher.wait_dispatch_event()
+        expert_out = self.experts(
+            dispatched,
+            tpe,
+            permuted_probs,
+            tokens_per_expert_list=getattr(self.dispatcher, "_local_tpe_list", None),
+        )
+        routed_out = self.dispatcher.combine(expert_out)
+        shared_out = self.shared_expert(x)
+        output = routed_out.view(input_shape)
+        output += shared_out
+        return output.to(x.dtype)
+
+
+class Glm5Layer(nn.Module):
+    def __init__(
+        self,
+        config: Glm5Config,
+        ps: ParallelState,
+        layer_idx: int,
+        *,
+        use_deepep: bool = False,
+        router_bias_rate: float = 0.0,
+        fp8: bool = False,
+        moe_act_recompute: bool = False,
+        use_thd: bool = False,
+    ):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.input_layernorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        # GLM-5 ONLY: DSA attention (Kimi builds MultiLatentAttention here).
+        # The wrapper preserves the SBHD self_attention(x, packed_seq_params=)
+        # contract so this layer's forward stays identical to Kimi's.
+        del use_thd  # DSA derives its own THD handling from packed_seq_params.
+        self.self_attention = Glm5DSAAttention(config, ps)
+        if config.is_moe_layer(layer_idx):
+            self.mlp_norm: nn.Module | None = te.RMSNorm(
+                config.hidden_size, eps=config.rms_norm_eps
+            )
+            self.moe: MoELayer | None = MoELayer(
+                config,
+                ps,
+                use_deepep=use_deepep,
+                router_bias_rate=router_bias_rate,
+                fp8=fp8,
+                moe_act_recompute=moe_act_recompute,
+            )
+            self.mlp: DenseMLP | None = None
+        else:
+            self.mlp_norm = None
+            self.moe = None
+            self.mlp = DenseMLP(config, ps)
+
+    def forward(self, x: torch.Tensor, packed_seq_params=None) -> torch.Tensor:
+        x = x + self.self_attention(self.input_layernorm(x), packed_seq_params=packed_seq_params)
+        if self.moe is not None:
+            assert self.mlp_norm is not None
+            mlp_input = self.mlp_norm(x)
+            return x + self.moe(mlp_input)
+        assert self.mlp is not None
+        return x + self.mlp(x)
+
+
+def _roll_mtp_left(
+    tensor: torch.Tensor,
+    *,
+    packed_seq_params=None,
+    dims: int = -1,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if packed_seq_params is not None:
+        return roll_packed_thd_left(tensor, packed_seq_params=packed_seq_params, dims=dims)
+    dim = dims if dims >= 0 else tensor.dim() + dims
+    rolled = torch.roll(tensor, shifts=-1, dims=dim)
+    rolled.select(dim, -1).zero_()
+    return rolled, rolled.sum()
+
+
+class Glm5MTPLayer(nn.Module):
+    def __init__(
+        self,
+        config: Glm5Config,
+        ps: ParallelState,
+        layer_idx: int,
+        *,
+        embedding: VocabParallelEmbedding,
+        use_deepep: bool,
+        router_bias_rate: float,
+        fp8: bool,
+        moe_act_recompute: bool,
+        use_thd: bool,
+        detach_encoder: bool,
+    ):
+        super().__init__()
+        self.ps = ps
+        object.__setattr__(self, "embedding", embedding)
+        self.detach_encoder = detach_encoder
+        self.enorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.hnorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.eh_proj = VanillaColumnParallelLinear(
+            config.hidden_size * 2,
+            config.hidden_size,
+            ps,
+            sp=ps.tp_size > 1,
+            gather_output=True,
+        )
+        self.transformer_layer = Glm5Layer(
+            config,
+            ps,
+            config.num_hidden_layers + layer_idx,
+            use_deepep=use_deepep,
+            router_bias_rate=router_bias_rate,
+            fp8=fp8,
+            moe_act_recompute=moe_act_recompute,
+            use_thd=use_thd,
+        )
+        self.final_layernorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        *,
+        input_ids: torch.Tensor,
+        position_ids: torch.Tensor | None,
+        hidden_states: torch.Tensor,
+        rotary_position_ids: torch.Tensor | None = None,
+        packed_seq_params=None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+        del rotary_position_ids
+        input_ids, _ = _roll_mtp_left(input_ids, packed_seq_params=packed_seq_params, dims=-1)
+        if position_ids is not None:
+            position_ids, _ = _roll_mtp_left(
+                position_ids, packed_seq_params=packed_seq_params, dims=-1
+            )
+        decoder_input = self.embedding(input_ids)
+        decoder_input = scatter_to_sequence_parallel(decoder_input, self.ps)
+
+        if self.detach_encoder:
+            decoder_input = decoder_input.detach()
+            hidden_states = hidden_states.detach()
+
+        decoder_input = self.enorm(decoder_input)
+        hidden_states = self.hnorm(hidden_states)
+        hidden_states = torch.cat((decoder_input, hidden_states), dim=-1)
+        hidden_states = self.eh_proj(hidden_states)
+        hidden_states = scatter_to_sequence_parallel(hidden_states, self.ps)
+        hidden_states = self.transformer_layer(hidden_states, packed_seq_params=packed_seq_params)
+        hidden_states = self.final_layernorm(hidden_states)
+        return hidden_states, input_ids, position_ids
+
+
+class Glm5MTPBlock(nn.Module):
+    def __init__(
+        self,
+        config: Glm5Config,
+        ps: ParallelState,
+        *,
+        embedding: VocabParallelEmbedding,
+        use_deepep: bool,
+        router_bias_rate: float,
+        fp8: bool,
+        moe_act_recompute: bool,
+        use_thd: bool,
+        detach_encoder: bool,
+        repeated_layer: bool,
+    ):
+        super().__init__()
+        self.num_layers = config.num_nextn_predict_layers
+        self.repeated_layer = repeated_layer
+        layers_to_build = 1 if repeated_layer else self.num_layers
+        self.layers = nn.ModuleList(
+            [
+                Glm5MTPLayer(
+                    config,
+                    ps,
+                    idx,
+                    embedding=embedding,
+                    use_deepep=use_deepep,
+                    router_bias_rate=router_bias_rate,
+                    fp8=fp8,
+                    moe_act_recompute=moe_act_recompute,
+                    use_thd=use_thd,
+                    detach_encoder=detach_encoder,
+                )
+                for idx in range(layers_to_build)
+            ]
+        )
+
+    def forward(
+        self,
+        *,
+        input_ids: torch.Tensor,
+        position_ids: torch.Tensor | None,
+        hidden_states: torch.Tensor,
+        packed_seq_params=None,
+    ) -> list[torch.Tensor]:
+        outputs: list[torch.Tensor] = []
+        rotary_position_ids = position_ids
+        for depth in range(self.num_layers):
+            layer = self.layers[0] if self.repeated_layer else self.layers[depth]
+            hidden_states, input_ids, position_ids = layer(
+                input_ids=input_ids,
+                position_ids=position_ids,
+                hidden_states=hidden_states,
+                rotary_position_ids=rotary_position_ids,
+                packed_seq_params=packed_seq_params,
+            )
+            outputs.append(hidden_states)
+        return outputs
+
+
+def _temperature_to_float(temperature: float | torch.Tensor) -> float:
+    if isinstance(temperature, torch.Tensor):
+        if temperature.numel() != 1:
+            raise ValueError("Glm5Model supports scalar temperature only.")
+        return float(temperature.detach().float().item())
+    return float(temperature)
+
+
+def _apply_attention_backend_override(backend: str | None) -> None:
+    if backend in (None, "flash"):
+        backend = "fused"
+    env = {
+        "auto": ("1", "1", "1"),
+        "flash": ("1", "0", "0"),
+        "fused": ("0", "1", "0"),
+        "unfused": ("0", "0", "1"),
+        "local": ("0", "0", "1"),
+    }.get(backend)
+    if env is None:
+        raise ValueError(
+            "attention_backend_override must be one of "
+            "{'auto', 'flash', 'fused', 'unfused', 'local'}"
+        )
+    (
+        os.environ["NVTE_FLASH_ATTN"],
+        os.environ["NVTE_FUSED_ATTN"],
+        os.environ["NVTE_UNFUSED_ATTN"],
+    ) = env
+
+
+class Glm5Model(nn.Module):
+    def __init__(
+        self,
+        config: Glm5Config,
+        train_config,
+        ps: ParallelState,
+        *,
+        vpp_chunk_id: int | None = None,
+        router_bias_rate: float = 0.0,
+        use_thd: bool = False,
+        hf_path: str = "",
+        attention_backend_override: str | None = None,
+        mtp_enable: bool = False,
+        mtp_enable_train: bool = False,
+        mtp_detach_encoder: bool = False,
+    ):
+        super().__init__()
+        del hf_path
+        _apply_attention_backend_override(attention_backend_override)
+        self.config = config
+        self.train_config = train_config
+        self.ps = ps
+        self._input_tensor: torch.Tensor | None = None
+        self.mtp_enable_train = bool(mtp_enable and mtp_enable_train)
+        self.mtp_loss_scaling_factor = config.mtp_loss_scaling_factor
+
+        layout = build_pipeline_chunk_layout(
+            config.num_hidden_layers,
+            ps,
+            train_config.vpp,
+            vpp_chunk_id,
+            num_mtp_layers=config.num_nextn_predict_layers if mtp_enable else 0,
+        )
+        self.layer_indices = layout.layer_indices
+        self.pre_process = layout.has_embed
+        self.post_process = layout.has_head
+        # GLM-5 does not tie embeddings (no tie_word_embeddings HF field); the
+        # attribute is preserved for the dist-opt / distckpt interface.
+        self.share_embeddings_and_output_weights = bool(
+            getattr(config, "tie_word_embeddings", False)
+        )
+        self.vision_model: nn.Module | None = None
+
+        self.embed: VocabParallelEmbedding | None = None
+        if layout.has_embed:
+            self.embed = VocabParallelEmbedding(config.vocab_size, config.hidden_size, ps)
+
+        recompute_modules = getattr(train_config, "recompute_modules", [])
+        moe_act_recompute = "moe_act" in recompute_modules and "moe" not in recompute_modules
+        self.layers = nn.ModuleList(
+            [
+                Glm5Layer(
+                    config,
+                    ps,
+                    idx,
+                    use_deepep=train_config.use_deepep,
+                    router_bias_rate=router_bias_rate,
+                    fp8=train_config.fp8,
+                    moe_act_recompute=moe_act_recompute,
+                    use_thd=use_thd,
+                )
+                for idx in self.layer_indices
+            ]
+        )
+
+        self.norm: nn.Module | None = None
+        self.head: VocabParallelOutput | None = None
+        if layout.has_head:
+            self.norm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+            self.head = VocabParallelOutput(config.vocab_size, config.hidden_size, ps)
+
+        self.mtp_embed: VocabParallelEmbedding | None = None
+        self.mtp: Glm5MTPBlock | None = None
+        if mtp_enable and config.num_nextn_predict_layers > 0 and layout.has_mtp:
+            mtp_embedding = self.embed
+            if mtp_embedding is None:
+                mtp_embedding = VocabParallelEmbedding(config.vocab_size, config.hidden_size, ps)
+                self.mtp_embed = mtp_embedding
+            self.mtp = Glm5MTPBlock(
+                config,
+                ps,
+                embedding=mtp_embedding,
+                use_deepep=train_config.use_deepep,
+                router_bias_rate=router_bias_rate,
+                fp8=train_config.fp8,
+                moe_act_recompute=moe_act_recompute,
+                use_thd=use_thd,
+                detach_encoder=mtp_detach_encoder,
+                repeated_layer=config.mtp_use_repeated_layer,
+            )
+
+        self.sp_params: list[nn.Parameter] = []
+        if ps.tp_size > 1:
+            self.sp_params = _collect_sp_grad_params(self)
+
+    def set_input_tensor(self, input_tensor):
+        if isinstance(input_tensor, list):
+            if len(input_tensor) > 1:
+                raise ValueError("Glm5Model expects a single pipeline input tensor.")
+            input_tensor = input_tensor[0] if input_tensor else None
+        self._input_tensor = input_tensor
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None = None,
+        hidden_states: torch.Tensor | None = None,
+        position_ids: torch.Tensor | None = None,
+        packed_seq_params=None,
+        labels: torch.Tensor | None = None,
+        loss_mask: torch.Tensor | None = None,
+        temperature: float | torch.Tensor = 1.0,
+        use_fused_kernels: bool = False,
+        calculate_entropy: bool = False,
+    ) -> dict:
+        if self.embed is not None:
+            assert input_ids is not None
+            h = self.embed(input_ids)
+        else:
+            if hidden_states is None:
+                hidden_states = self._input_tensor
+            assert hidden_states is not None
+            h = hidden_states
+
+        fp8_ctx = (
+            te.fp8_autocast(enabled=True, fp8_recipe=build_fp8_recipe(self.train_config))
+            if self.train_config.fp8
+            else nullcontext()
+        )
+        with fp8_ctx:
+            if self.embed is not None:
+                h = scatter_to_sequence_parallel(h, self.ps)
+            for layer in self.layers:
+                h = layer(h, packed_seq_params=packed_seq_params)
+
+        output = {"hidden_states": h}
+        if self.head is not None:
+            assert self.norm is not None
+            hidden_for_head = self.norm(h)
+            mtp_hidden_states = self._apply_mtp(
+                hidden_for_head,
+                input_ids=input_ids,
+                position_ids=position_ids,
+                packed_seq_params=packed_seq_params,
+            )
+            if mtp_hidden_states is not None:
+                output["mtp_hidden_states"] = mtp_hidden_states
+            if labels is not None:
+                temperature_value = _temperature_to_float(temperature)
+                mtp_result = self._apply_mtp_loss(
+                    hidden_for_head,
+                    mtp_hidden_states=mtp_hidden_states,
+                    labels=labels,
+                    loss_mask=loss_mask,
+                    packed_seq_params=packed_seq_params,
+                    temperature=temperature_value,
+                    use_fused_kernels=use_fused_kernels,
+                )
+                if mtp_result is not None:
+                    hidden_for_head, mtp_loss = mtp_result
+                    output["mtp_loss"] = mtp_loss
+                labels_sb = labels.transpose(0, 1).contiguous()
+                if use_fused_kernels:
+                    hidden_full = gather_from_sequence_parallel(hidden_for_head, self.ps)
+                    log_probs, entropy = linear_cross_entropy(
+                        hidden_full,
+                        self._head_weight_for_fused_ce(hidden_full),
+                        labels_sb,
+                        temperature_value,
+                        self.ps.tp_group,
+                    )
+                    output["loss"] = (-log_probs).mean()
+                    output["log_probs"] = log_probs.transpose(0, 1).contiguous()
+                    if calculate_entropy:
+                        output["entropy"] = entropy.transpose(0, 1).contiguous()
+                else:
+                    logits = self.head(hidden_for_head)
+                    if temperature_value != 1.0:
+                        logits = logits / temperature_value
+                    loss = vocab_parallel_cross_entropy(logits, labels_sb, self.ps.tp_group)
+                    output["loss"] = loss.mean()
+                    output["log_probs"] = (-loss).transpose(0, 1).contiguous()
+                    if calculate_entropy:
+                        entropy = vocab_parallel_entropy(logits, self.ps.tp_group)
+                        output["entropy"] = entropy.transpose(0, 1).contiguous()
+            else:
+                logits = self.head(hidden_for_head)
+                output["logits"] = self.head.gather(logits).transpose(0, 1).contiguous()
+                if mtp_hidden_states is not None:
+                    output["mtp_logits"] = [
+                        self.head.gather(self.head(mtp_hidden)).transpose(0, 1).contiguous()
+                        for mtp_hidden in mtp_hidden_states
+                    ]
+        return output
+
+    def _apply_mtp(
+        self,
+        hidden_states: torch.Tensor,
+        *,
+        input_ids: torch.Tensor | None,
+        position_ids: torch.Tensor | None,
+        packed_seq_params,
+    ) -> list[torch.Tensor] | None:
+        if self.mtp is None:
+            return None
+        if input_ids is None:
+            if self.mtp_enable_train:
+                raise ValueError("MTP training requires input_ids.")
+            return None
+        return self.mtp(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            hidden_states=hidden_states,
+            packed_seq_params=packed_seq_params,
+        )
+
+    def _apply_mtp_loss(
+        self,
+        hidden_states: torch.Tensor,
+        *,
+        mtp_hidden_states: list[torch.Tensor] | None,
+        labels: torch.Tensor,
+        loss_mask: torch.Tensor | None,
+        packed_seq_params,
+        temperature: float,
+        use_fused_kernels: bool,
+    ) -> tuple[torch.Tensor, torch.Tensor] | None:
+        if mtp_hidden_states is None:
+            return None
+        if not self.mtp_enable_train:
+            return None
+        if loss_mask is None:
+            mtp_loss_mask = torch.ones_like(labels, dtype=torch.float32)
+        else:
+            mtp_loss_mask = loss_mask.to(dtype=torch.float32).clone()
+        mtp_labels = labels.clone()
+
+        mtp_loss_values = []
+        for mtp_hidden in mtp_hidden_states:
+            mtp_labels, _ = _roll_mtp_left(
+                mtp_labels,
+                packed_seq_params=packed_seq_params,
+                dims=-1,
+            )
+            mtp_loss_mask, num_tokens = _roll_mtp_left(
+                mtp_loss_mask,
+                packed_seq_params=packed_seq_params,
+                dims=-1,
+            )
+            labels_sb = mtp_labels.transpose(0, 1).contiguous()
+            mask_sb = mtp_loss_mask.transpose(0, 1).contiguous()
+
+            if use_fused_kernels:
+                mtp_hidden_full = gather_from_sequence_parallel(mtp_hidden, self.ps)
+                log_probs, _entropy = linear_cross_entropy(
+                    mtp_hidden_full,
+                    self._head_weight_for_fused_ce(mtp_hidden_full),
+                    labels_sb,
+                    temperature,
+                    self.ps.tp_group,
+                )
+                token_loss = -log_probs
+            else:
+                logits = self.head(mtp_hidden)
+                if temperature != 1.0:
+                    logits = logits / temperature
+                token_loss = vocab_parallel_cross_entropy(logits, labels_sb, self.ps.tp_group)
+
+            token_loss = token_loss * mask_sb.to(dtype=token_loss.dtype)
+            num_tokens = num_tokens.to(dtype=token_loss.dtype).clamp_min(1.0)
+            mtp_loss_values.append(token_loss.sum() / num_tokens)
+
+            mtp_loss_scale = self.mtp_loss_scaling_factor / max(len(mtp_hidden_states), 1)
+            hidden_states = MTPLossAutoScaler.apply(
+                hidden_states,
+                mtp_loss_scale * token_loss / num_tokens,
+            )
+
+        if not mtp_loss_values:
+            return None
+        return (
+            hidden_states,
+            torch.stack([loss.detach().float() for loss in mtp_loss_values]).mean(),
+        )
+
+    def _head_weight_for_fused_ce(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        assert self.head is not None
+        weight = self.head.col.linear.weight
+        return (
+            weight if weight.dtype == hidden_states.dtype else weight.to(dtype=hidden_states.dtype)
+        )
+
+
+__all__ = [
+    "DenseMLP",
+    "DynamicSparseAttention",
+    "Glm5DSAAttention",
+    "Glm5Layer",
+    "Glm5MTPBlock",
+    "Glm5MTPLayer",
+    "Glm5Model",
+    "Glm5SigmoidTopKRouter",
+    "MoELayer",
+    "MTPLossAutoScaler",
+    "SharedExpert",
+]

--- a/experimental/lite/megatron/lite/model/glm5/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/protocol.py
@@ -1,0 +1,343 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""GLM-5 (deepseek_v3_2) lite native model protocol for Megatron Lite runtime.
+
+Cloned from ``megatron/lite/model/kimi_k2/lite/protocol.py`` (deepseek_v3) and
+renamed KimiK2 -> Glm5.  The build / optimizer / checkpoint plumbing is
+identical to Kimi; the only adaptations are:
+  * the config type (``Glm5Config``),
+  * the DSA indexer-loss pre-forward hook (``DSAIndexerLossAutoScaler`` in
+    addition to the MoE aux-loss scaler),
+  * the attention ``MODULE_MAP`` entries point at the DSA ``self_attention``
+    instead of MLA, and
+  * a ``_validate_parallel_scope`` gate: GLM-5's DSA attention is NOT
+    tensor-parallel-capable, so TP>1 / ETP>1 raise ``NotImplementedError``.
+    PP / VPP / EP / CP all work (inherited from Kimi).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import torch
+import torch.nn as nn
+from megatron.lite.model.glm5.config import Glm5Config
+from megatron.lite.model.protocol_utils import (
+    add_cross_entropy_fusion,
+    add_loss_context_kwargs,
+    pack_thd_forward_kwargs,
+    set_cross_entropy_fusion,
+    unpack_thd_forward_output,
+)
+from megatron.lite.primitive.bundle import ModelBundle
+from megatron.lite.primitive.parallel import ParallelState, init_parallel
+from megatron.lite.primitive.recompute import apply_recompute, parse_recompute_spec
+from megatron.lite.runtime.contracts import OptimizerConfig, ParallelConfig
+from megatron.lite.runtime.contracts.data import PackedBatch
+
+
+def EXPERT_CLASSIFIER(name: str) -> bool:
+    return "experts" in name and "router" not in name and "shared" not in name
+
+
+def PLACEMENT_FN(param_name: str) -> list:
+    from megatron.lite.model.glm5.lite.checkpoint import PLACEMENT_FN as placement_fn
+
+    return placement_fn(param_name)
+
+
+def is_expert_param(name: str) -> bool:
+    return EXPERT_CLASSIFIER(name)
+
+
+def _maybe(module_name: str):
+    def getter(layer):
+        module = getattr(layer, module_name, None)
+        return module
+
+    return getter
+
+
+def _moe_module(name: str):
+    def getter(layer):
+        moe = getattr(layer, "moe", None)
+        return getattr(moe, name, None) if moe is not None else None
+
+    return getter
+
+
+# GLM-5 ONLY: attention entries point at the DSA wrapper / module instead of
+# Kimi's MLA.  Everything else mirrors Kimi's MODULE_MAP.
+MODULE_MAP = {
+    "core_attn": lambda layer: layer.self_attention.self_attention,
+    "experts": _moe_module("experts"),
+    "moe": _maybe("moe"),
+    "router": _moe_module("router"),
+    "mlp": _maybe("mlp"),
+    "mlp_norm": lambda layer: layer.mlp_norm,
+    "attn_proj": lambda layer: layer.self_attention.self_attention.o_proj,
+    "self_attn": lambda layer: layer.self_attention,
+    "dsa": lambda layer: layer.self_attention.self_attention,
+}
+
+
+@dataclass(frozen=True)
+class ImplConfig:
+    parallel: ParallelConfig = field(default_factory=ParallelConfig)
+    optimizer: str | None = "dist_opt"
+    recompute: list[str] = field(default_factory=list)
+    offload: list[str] = field(default_factory=list)
+    use_deepep: bool = False
+    use_thd: bool = False
+    cross_entropy_fusion: bool = False
+    hf_path: str = ""
+    attention_backend_override: str | None = None
+    router_aux_loss_coef: float | None = None
+    router_bias_rate: float = 0.0
+    deterministic: bool = True
+    optimizer_config: OptimizerConfig | None = None
+    mtp_enable: bool = False
+    mtp_enable_train: bool = False
+    mtp_detach_encoder: bool = False
+    mtp_loss_scaling_factor: float = 0.1
+    mtp_use_repeated_layer: bool | None = None
+
+
+def build_model_config(source: str | Path | dict, **overrides) -> Glm5Config:
+    if isinstance(source, dict):
+        cfg = Glm5Config._from_hf_dict(source)
+    else:
+        cfg = Glm5Config.from_hf(str(source))
+    for key, value in overrides.items():
+        if hasattr(cfg, key):
+            setattr(cfg, key, value)
+    return cfg
+
+
+def _forward_step(model: nn.Module, batch: PackedBatch) -> dict:
+    kwargs = pack_thd_forward_kwargs(model, batch)
+    add_loss_context_kwargs(kwargs)
+    add_cross_entropy_fusion(kwargs, model)
+    return model(**kwargs)
+
+
+def unpack_forward_output(model: nn.Module, batch: PackedBatch, output) -> Any:
+    return unpack_thd_forward_output(model, batch, output)
+
+
+def _make_aux_loss_hook():
+    # GLM-5 ONLY: also scale the DSA indexer auxiliary loss (Kimi has no indexer).
+    from megatron.lite.primitive.modules.attention.dsa import DSAIndexerLossAutoScaler
+    from megatron.lite.primitive.modules.moe import MoEAuxLossAutoScaler
+    from megatron.lite.primitive.modules.mtp import MTPLossAutoScaler
+
+    def hook(scale: torch.Tensor) -> None:
+        MoEAuxLossAutoScaler.set_loss_scale(scale)
+        MTPLossAutoScaler.set_loss_scale(scale)
+        DSAIndexerLossAutoScaler.set_loss_scale(scale)
+
+    return hook
+
+
+def _validate_parallel_scope(p: ParallelConfig) -> None:
+    """GLM-5 DSA attention is not tensor-parallel-capable (documented TP=1 case).
+
+    PP / VPP / EP / CP are inherited from the Kimi skeleton and work; only
+    TP>1 / ETP>1 are unsupported.
+    """
+    etp = 1 if p.etp is None else p.etp
+    if p.tp > 1:
+        raise NotImplementedError(
+            "GLM-5 native DSA attention does not support tensor parallelism; "
+            f"got tp={p.tp}. Use tp=1 (PP/VPP/EP/CP are supported)."
+        )
+    if etp > 1:
+        raise NotImplementedError(
+            "GLM-5 native DSA attention does not support expert tensor parallelism; "
+            f"got etp={etp}. Use etp=1 (EP is supported)."
+        )
+
+
+def _build_dist_opt_optimizer(
+    chunks, model_cfg: Glm5Config, impl_cfg: ImplConfig, ps: ParallelState
+):
+    from megatron.lite.primitive.optimizers.megatron_wrap import build_dist_opt_training_optimizer
+
+    return build_dist_opt_training_optimizer(
+        chunks,
+        model_cfg=model_cfg,
+        impl_cfg=impl_cfg,
+        ps=ps,
+        model_name="glm5",
+        is_expert=is_expert_param,
+        deterministic=impl_cfg.deterministic,
+    )
+
+
+def build_model(model_cfg: Glm5Config, *, impl_cfg: ImplConfig) -> ModelBundle:
+    p = impl_cfg.parallel
+    _validate_parallel_scope(p)
+    if impl_cfg.use_deepep and (p.etp is not None and p.etp > 1):
+        raise ValueError("use_deepep and etp>1 are mutually exclusive")
+    if impl_cfg.router_aux_loss_coef is not None:
+        # GLM-5 has no aux_loss_alpha HF field; honour an explicit override only.
+        model_cfg.aux_loss_alpha = impl_cfg.router_aux_loss_coef
+    mtp_enable = bool(impl_cfg.mtp_enable)
+    mtp_enable_train = mtp_enable and bool(impl_cfg.mtp_enable_train)
+    if mtp_enable:
+        if model_cfg.num_nextn_predict_layers <= 0:
+            raise ValueError("mtp_enable=True but HF config has no num_nextn_predict_layers.")
+        model_cfg.mtp_loss_scaling_factor = impl_cfg.mtp_loss_scaling_factor
+        if impl_cfg.mtp_use_repeated_layer is not None:
+            model_cfg.mtp_use_repeated_layer = impl_cfg.mtp_use_repeated_layer
+    elif hasattr(model_cfg, "num_nextn_predict_layers"):
+        model_cfg.num_nextn_predict_layers = 0
+
+    from megatron.lite.model.glm5.lite.model import Glm5Model
+
+    ps = init_parallel(p)
+    recompute_spec = parse_recompute_spec(impl_cfg.recompute)
+    vpp = None if p.vpp == 1 else p.vpp
+    train_cfg = SimpleNamespace(
+        tp=ps.tp_size,
+        ep=ps.ep_size,
+        etp=ps.etp_size,
+        pp=ps.pp_size,
+        cp=ps.cp_size,
+        vpp=vpp,
+        use_deepep=impl_cfg.use_deepep,
+        fp8=False,
+        recompute_modules=recompute_spec,
+        deterministic=impl_cfg.deterministic,
+    )
+    model_kwargs: dict[str, Any] = dict(
+        router_bias_rate=impl_cfg.router_bias_rate,
+        use_thd=impl_cfg.use_thd,
+        hf_path=impl_cfg.hf_path,
+        attention_backend_override=impl_cfg.attention_backend_override,
+        mtp_enable=mtp_enable,
+        mtp_enable_train=mtp_enable_train,
+        mtp_detach_encoder=impl_cfg.mtp_detach_encoder,
+    )
+
+    if vpp is None:
+        chunks = [Glm5Model(model_cfg, train_cfg, ps, **model_kwargs).to(torch.bfloat16).cuda()]
+    else:
+        chunks = [
+            Glm5Model(
+                model_cfg,
+                train_cfg,
+                ps,
+                vpp_chunk_id=i,
+                **model_kwargs,
+            )
+            .to(torch.bfloat16)
+            .cuda()
+            for i in range(vpp)
+        ]
+    set_cross_entropy_fusion(chunks, impl_cfg.cross_entropy_fusion)
+
+    if recompute_spec:
+        for chunk in chunks:
+            apply_recompute(chunk.layers, recompute_spec, MODULE_MAP)
+
+    if impl_cfg.offload:
+        from megatron.lite.primitive.recompute import apply_offload
+
+        for chunk in chunks:
+            apply_offload(chunk.layers, impl_cfg.offload, MODULE_MAP)
+
+    optimizer = None
+    finalize_grads = None
+    post_model_load_hook = None
+    optimizer_backend = "none"
+    if impl_cfg.optimizer == "dist_opt":
+        optimizer, finalize_grads = _build_dist_opt_optimizer(chunks, model_cfg, impl_cfg, ps)
+        from megatron.lite.primitive.ckpt import attach_model_sharded_state_dict
+        from megatron.lite.runtime.megatron_utils import register_training_hooks
+
+        attach_model_sharded_state_dict(
+            chunks, ps, get_placements=PLACEMENT_FN, is_expert=is_expert_param
+        )
+        register_training_hooks(chunks, optimizer)
+        optimizer_backend = "dist_opt"
+    elif impl_cfg.optimizer == "fsdp2":
+        optimizer_backend = "fsdp2"
+
+        def _post_model_load_hook():
+            from megatron.lite.model.glm5.lite.model import Glm5Layer
+            from megatron.lite.primitive.optimizers.fsdp2 import build_fsdp2_training_optimizer
+
+            return {
+                "optimizer": build_fsdp2_training_optimizer(
+                    chunks,
+                    impl_cfg.optimizer_config,
+                    ps,
+                    unit_modules=(Glm5Layer,),
+                    expert_classifier=is_expert_param,
+                    deterministic=impl_cfg.deterministic,
+                    vpp=impl_cfg.parallel.vpp,
+                    leaf_module_names=(),
+                )
+            }
+
+        post_model_load_hook = _post_model_load_hook
+    elif impl_cfg.optimizer is not None:
+        raise ValueError(f"Unknown glm5 lite optimizer: {impl_cfg.optimizer!r}.")
+
+    return ModelBundle(
+        chunks=chunks,
+        parallel_state=ps,
+        optimizer=optimizer,
+        finalize_grads=finalize_grads,
+        forward_step=_forward_step,
+        extras={
+            "model_cfg": model_cfg,
+            "optimizer_backend": optimizer_backend,
+            "post_model_load_hook": post_model_load_hook,
+            "pre_forward_hook": _make_aux_loss_hook(),
+        },
+    )
+
+
+def load_hf_weights(
+    chunk: nn.Module, hf_path: str, model_cfg: Glm5Config, ps: ParallelState
+) -> None:
+    if not hf_path:
+        return
+    from megatron.lite.model.glm5.lite.checkpoint import load_hf_weights as load_impl
+
+    load_impl(chunk, hf_path, model_cfg, ps)
+
+
+def export_hf_weights(chunks, model_cfg: Glm5Config, ps: ParallelState, **kwargs):
+    from megatron.lite.model.glm5.lite.checkpoint import export_hf_weights as export_impl
+
+    yield from export_impl(chunks, model_cfg, ps, **kwargs)
+
+
+def save_hf_weights(chunks, path: str, model_cfg: Glm5Config, ps: ParallelState, **kwargs):
+    from megatron.lite.model.glm5.lite.checkpoint import save_hf_weights as save_impl
+
+    save_impl(chunks, path, model_cfg, ps, **kwargs)
+
+
+def vocab_size(model_cfg) -> int | None:
+    cfg = getattr(model_cfg, "text_config", model_cfg)
+    return getattr(cfg, "vocab_size", None)
+
+
+__all__ = [
+    "EXPERT_CLASSIFIER",
+    "ImplConfig",
+    "PLACEMENT_FN",
+    "build_model",
+    "build_model_config",
+    "export_hf_weights",
+    "is_expert_param",
+    "load_hf_weights",
+    "save_hf_weights",
+    "vocab_size",
+]

--- a/experimental/lite/megatron/lite/model/kimi_k2/__init__.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Kimi K2 model package."""

--- a/experimental/lite/megatron/lite/model/kimi_k2/config.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/config.py
@@ -1,0 +1,175 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Kimi K2 / DeepSeekV3-style model configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from megatron.lite.primitive.config import load_hf_config_dict
+
+_HF_FIELDS = frozenset(
+    {
+        "num_hidden_layers",
+        "hidden_size",
+        "num_attention_heads",
+        "num_key_value_heads",
+        "vocab_size",
+        "rms_norm_eps",
+        "max_position_embeddings",
+        "intermediate_size",
+        "moe_intermediate_size",
+        "n_routed_experts",
+        "n_shared_experts",
+        "num_experts_per_tok",
+        "n_group",
+        "topk_group",
+        "topk_method",
+        "norm_topk_prob",
+        "scoring_func",
+        "seq_aux",
+        "first_k_dense_replace",
+        "moe_layer_freq",
+        "aux_loss_alpha",
+        "routed_scaling_factor",
+        "q_lora_rank",
+        "kv_lora_rank",
+        "qk_nope_head_dim",
+        "qk_rope_head_dim",
+        "v_head_dim",
+        "rope_theta",
+        "rope_scaling",
+        "tie_word_embeddings",
+        "num_nextn_predict_layers",
+        "mtp_loss_scaling_factor",
+        "mtp_use_repeated_layer",
+    }
+)
+
+
+@dataclass
+class KimiK2Config:
+    """Pure architecture parameters for Kimi K2 Instruct."""
+
+    num_hidden_layers: int = 61
+    hidden_size: int = 7168
+    num_attention_heads: int = 64
+    num_key_value_heads: int = 64
+    vocab_size: int = 163840
+    rms_norm_eps: float = 1e-6
+    max_position_embeddings: int = 131072
+    intermediate_size: int = 18432
+    moe_intermediate_size: int = 2048
+    n_routed_experts: int = 384
+    n_shared_experts: int = 1
+    num_experts_per_tok: int = 8
+    n_group: int | None = 1
+    topk_group: int | None = 1
+    topk_method: str = "noaux_tc"
+    norm_topk_prob: bool = True
+    scoring_func: str = "sigmoid"
+    seq_aux: bool = True
+    first_k_dense_replace: int = 1
+    moe_layer_freq: int = 1
+    aux_loss_alpha: float = 0.001
+    routed_scaling_factor: float = 2.827
+    q_lora_rank: int = 1536
+    kv_lora_rank: int = 512
+    qk_nope_head_dim: int = 128
+    qk_rope_head_dim: int = 64
+    v_head_dim: int = 128
+    rope_theta: float = 50_000.0
+    rope_scaling: dict = field(
+        default_factory=lambda: {
+            "type": "yarn",
+            "factor": 32.0,
+            "original_max_position_embeddings": 4096,
+            "beta_fast": 1.0,
+            "beta_slow": 1.0,
+            "mscale": 1.0,
+            "mscale_all_dim": 1.0,
+        }
+    )
+    tie_word_embeddings: bool = False
+    num_nextn_predict_layers: int = 0
+    mtp_loss_scaling_factor: float = 0.1
+    mtp_use_repeated_layer: bool = False
+
+    @property
+    def num_experts(self) -> int:
+        return self.n_routed_experts
+
+    @property
+    def shared_expert_intermediate_size(self) -> int:
+        return self.moe_intermediate_size * self.n_shared_experts
+
+    @property
+    def q_head_dim(self) -> int:
+        return self.qk_nope_head_dim + self.qk_rope_head_dim
+
+    def __post_init__(self) -> None:
+        errors: list[str] = []
+
+        def _check(cond: bool, msg: str) -> None:
+            if not cond:
+                errors.append(msg)
+
+        _check(self.num_hidden_layers >= 1, "num_hidden_layers must be >= 1")
+        _check(self.hidden_size > 0, "hidden_size must be > 0")
+        _check(self.num_attention_heads >= 1, "num_attention_heads must be >= 1")
+        _check(
+            self.num_attention_heads % self.num_key_value_heads == 0,
+            "num_attention_heads must be divisible by num_key_value_heads",
+        )
+        _check(self.q_lora_rank > 0, "q_lora_rank must be > 0")
+        _check(self.kv_lora_rank > 0, "kv_lora_rank must be > 0")
+        _check(self.qk_nope_head_dim > 0, "qk_nope_head_dim must be > 0")
+        _check(self.qk_rope_head_dim > 0, "qk_rope_head_dim must be > 0")
+        _check(self.v_head_dim > 0, "v_head_dim must be > 0")
+        _check(self.n_routed_experts >= 1, "n_routed_experts must be >= 1")
+        _check(
+            1 <= self.num_experts_per_tok <= self.n_routed_experts,
+            "num_experts_per_tok must be in [1, n_routed_experts]",
+        )
+        if self.n_group is not None or self.topk_group is not None:
+            _check(
+                self.n_group is not None and self.topk_group is not None,
+                "n_group and topk_group must be set together",
+            )
+            if self.n_group is not None and self.topk_group is not None:
+                _check(self.n_group >= 1, "n_group must be >= 1")
+                _check(1 <= self.topk_group <= self.n_group, "topk_group must be in [1, n_group]")
+                _check(
+                    self.n_routed_experts % self.n_group == 0,
+                    "n_routed_experts must be divisible by n_group",
+                )
+        _check(0 <= self.first_k_dense_replace <= self.num_hidden_layers, "bad dense prefix")
+        _check(self.num_nextn_predict_layers >= 0, "num_nextn_predict_layers must be >= 0")
+        if errors:
+            raise ValueError("Invalid KimiK2Config:\n  " + "\n  ".join(errors))
+
+    @classmethod
+    def from_hf(cls, path: str, **overrides) -> KimiK2Config:
+        return cls._from_hf_dict(load_hf_config_dict(path), **overrides)
+
+    @classmethod
+    def from_hf_config(cls, hf_config, **overrides) -> KimiK2Config:
+        return cls._from_hf_dict(hf_config.to_dict(), **overrides)
+
+    @classmethod
+    def _from_hf_dict(cls, hf: dict, **overrides) -> KimiK2Config:
+        if "text_config" in hf and isinstance(hf["text_config"], dict):
+            hf = hf["text_config"]
+        kwargs = {k: v for k, v in hf.items() if k in _HF_FIELDS}
+        if "rope_scaling" in kwargs and kwargs["rope_scaling"] is None:
+            kwargs.pop("rope_scaling")
+        kwargs.update(overrides)
+        return cls(**kwargs)
+
+    def is_moe_layer(self, layer_idx: int) -> bool:
+        if layer_idx < self.first_k_dense_replace:
+            return False
+        freq = int(self.moe_layer_freq or 1)
+        return (layer_idx - self.first_k_dense_replace) % freq == 0
+
+
+__all__ = ["KimiK2Config"]

--- a/experimental/lite/megatron/lite/model/kimi_k2/lite/__init__.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/lite/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Kimi K2 lite native sub-package."""

--- a/experimental/lite/megatron/lite/model/kimi_k2/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/lite/checkpoint.py
@@ -1,0 +1,662 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Kimi K2 lite native checkpoint mapping."""
+
+from __future__ import annotations
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from torch.distributed.tensor import Replicate, Shard
+
+from megatron.lite.model.kimi_k2.config import KimiK2Config
+from megatron.lite.primitive.ckpt.hf_weights import (
+    SafeTensorReader,
+    _cast_export_tensor,
+    _resolve_export_dtype,
+    parse_expert_idx,
+    to_global_layer_name,
+    unwrap_model,
+)
+from megatron.lite.primitive.parallel import ParallelState
+from megatron.lite.primitive.utils import ensure_divisible, log_rank0
+
+
+def EXPERT_CLASSIFIER(name: str) -> bool:
+    return "experts" in name and "router" not in name and "shared" not in name
+
+
+def PLACEMENT_FN(param_name: str) -> list:
+    if "experts" in param_name and "router" not in param_name and "shared" not in param_name:
+        if "fc1" in param_name:
+            return [Replicate(), Replicate(), Shard(0), Shard(0)]
+        if "fc2" in param_name:
+            return [Replicate(), Replicate(), Shard(0), Shard(1)]
+        return [Replicate(), Replicate(), Replicate(), Replicate()]
+    if "eh_proj.linear.weight" in param_name:
+        return [Replicate(), Replicate(), Replicate(), Shard(0)]
+    if "linear_q_up_proj.linear.weight" in param_name:
+        return [Replicate(), Replicate(), Replicate(), Shard(0)]
+    if "linear_kv_up_proj.linear.weight" in param_name:
+        return [Replicate(), Replicate(), Replicate(), Shard(0)]
+    if "linear_proj.linear.weight" in param_name:
+        return [Replicate(), Replicate(), Replicate(), Shard(1)]
+    if "gate_up" in param_name:
+        return [Replicate(), Replicate(), Replicate(), Shard(0)]
+    if "down" in param_name:
+        return [Replicate(), Replicate(), Replicate(), Shard(1)]
+    if "embed" in param_name or "head" in param_name:
+        return [Replicate(), Replicate(), Replicate(), Shard(0)]
+    return [Replicate(), Replicate(), Replicate(), Replicate()]
+
+
+def _tp(tensor: torch.Tensor, rank: int, size: int, dim: int = 0) -> torch.Tensor:
+    return tensor if size <= 1 else tensor.chunk(size, dim=dim)[rank].contiguous()
+
+
+def _split_gate_up(tensor: torch.Tensor, rank: int, size: int) -> torch.Tensor:
+    if size <= 1:
+        return tensor
+    ffn = tensor.shape[0] // 2
+    gate = tensor[:ffn].chunk(size, dim=0)[rank]
+    up = tensor[ffn:].chunk(size, dim=0)[rank]
+    return torch.cat([gate, up], dim=0).contiguous()
+
+
+def _has(reader: SafeTensorReader, name: str) -> bool:
+    if reader.index:
+        return name in reader.index
+    try:
+        reader.get_tensor(name)
+    except Exception:
+        return False
+    return True
+
+
+def _dequant_fp8_weight(reader: SafeTensorReader, name: str, weight: torch.Tensor) -> torch.Tensor:
+    scale_name = f"{name}_scale_inv"
+    if weight.dim() != 2 or weight.element_size() != 1 or not _has(reader, scale_name):
+        return weight
+    scale = reader.get_tensor(scale_name).float()
+    rows, cols = weight.shape
+    expanded = scale.repeat_interleave(128, dim=0).repeat_interleave(128, dim=1)
+    expanded = expanded[:rows, :cols]
+    return weight.float() * expanded
+
+
+def _unpack_int4_from_int32(packed: torch.Tensor, shape: torch.Size) -> torch.Tensor:
+    if packed.dtype != torch.int32:
+        raise ValueError(f"Expected packed int4 tensor to be int32, got {packed.dtype}.")
+    pack_factor = 8
+    mask = 0xF
+    rows, cols = int(shape[0]), int(shape[1])
+    unpacked = torch.empty((packed.shape[0], packed.shape[1] * pack_factor), dtype=torch.int32)
+    for offset in range(pack_factor):
+        unpacked[:, offset::pack_factor] = (packed >> (4 * offset)) & mask
+    return (unpacked[:rows, :cols] - 8).to(torch.int8)
+
+
+def _dequant_int4_weight(reader: SafeTensorReader, name: str) -> torch.Tensor:
+    packed = reader.get_tensor(f"{name}_packed")
+    scale = reader.get_tensor(f"{name}_scale")
+    shape_tensor = reader.get_tensor(f"{name}_shape")
+    shape = torch.Size(int(x) for x in shape_tensor.tolist())
+
+    unpacked = _unpack_int4_from_int32(packed, shape).to(scale.dtype)
+    if scale.dim() != 2 or unpacked.dim() != 2:
+        raise ValueError(
+            f"Expected groupwise int4 tensors for {name}, got "
+            f"weight={tuple(unpacked.shape)} scale={tuple(scale.shape)}."
+        )
+    if scale.shape[0] not in (1, unpacked.shape[0]):
+        raise ValueError(
+            f"Unsupported int4 scale rows for {name}: "
+            f"weight={tuple(unpacked.shape)} scale={tuple(scale.shape)}."
+        )
+    if unpacked.shape[1] % scale.shape[1] != 0:
+        raise ValueError(
+            f"Unsupported int4 group layout for {name}: "
+            f"weight={tuple(unpacked.shape)} scale={tuple(scale.shape)}."
+        )
+
+    group_size = unpacked.shape[1] // scale.shape[1]
+    return (unpacked.unflatten(-1, (scale.shape[1], group_size)) * scale.unsqueeze(-1)).flatten(
+        start_dim=-2
+    )
+
+
+def _get(reader: SafeTensorReader, name: str) -> torch.Tensor:
+    if not _has(reader, name) and _has(reader, f"{name}_packed"):
+        return _dequant_int4_weight(reader, name)
+    tensor = reader.get_tensor(name)
+    return _dequant_fp8_weight(reader, name, tensor)
+
+
+def _text_prefix(reader: SafeTensorReader) -> str:
+    for prefix in ("model", "language_model.model", "model.language_model"):
+        if _has(reader, f"{prefix}.embed_tokens.weight"):
+            return prefix
+    raise KeyError("Could not find Kimi K2 text model prefix in HF checkpoint.")
+
+
+def _lm_head_name(reader: SafeTensorReader, text_prefix: str) -> str:
+    candidates = [
+        "lm_head.weight",
+        "language_model.lm_head.weight",
+        f"{text_prefix}.lm_head.weight",
+    ]
+    for name in candidates:
+        if _has(reader, name):
+            return name
+    raise KeyError("Could not find Kimi K2 lm_head.weight in HF checkpoint.")
+
+
+def _load_vocab(
+    reader: SafeTensorReader, name: str, cfg: KimiK2Config, ps: ParallelState
+) -> torch.Tensor:
+    from megatron.lite.primitive.parallel import pad_vocab_for_tp
+
+    tensor = _get(reader, name)
+    padded = pad_vocab_for_tp(cfg.vocab_size, ps.tp_size)
+    if tensor.size(0) < padded:
+        pad = torch.zeros(padded - tensor.size(0), tensor.size(1), dtype=tensor.dtype)
+        tensor = torch.cat([tensor, pad], dim=0)
+    return _tp(tensor, ps.tp_rank, ps.tp_size)
+
+
+def _load_attention(
+    out: dict[str, torch.Tensor],
+    *,
+    local_prefix: str,
+    hf_prefix: str,
+    reader: SafeTensorReader,
+    ps: ParallelState,
+) -> None:
+    out[f"{local_prefix}.self_attention.linear_q_down_proj.weight"] = _get(
+        reader,
+        f"{hf_prefix}.q_a_proj.weight",
+    )
+    out[f"{local_prefix}.self_attention.linear_q_up_proj.linear.layer_norm_weight"] = _get(
+        reader,
+        f"{hf_prefix}.q_a_layernorm.weight",
+    )
+    out[f"{local_prefix}.self_attention.linear_q_up_proj.linear.weight"] = _tp(
+        _get(reader, f"{hf_prefix}.q_b_proj.weight"),
+        ps.tp_rank,
+        ps.tp_size,
+    )
+    out[f"{local_prefix}.self_attention.linear_kv_down_proj.weight"] = _get(
+        reader,
+        f"{hf_prefix}.kv_a_proj_with_mqa.weight",
+    )
+    out[f"{local_prefix}.self_attention.linear_kv_up_proj.linear.layer_norm_weight"] = _get(
+        reader,
+        f"{hf_prefix}.kv_a_layernorm.weight",
+    )
+    out[f"{local_prefix}.self_attention.linear_kv_up_proj.linear.weight"] = _tp(
+        _get(reader, f"{hf_prefix}.kv_b_proj.weight"),
+        ps.tp_rank,
+        ps.tp_size,
+    )
+    out[f"{local_prefix}.self_attention.linear_proj.linear.weight"] = _tp(
+        _get(reader, f"{hf_prefix}.o_proj.weight"),
+        ps.tp_rank,
+        ps.tp_size,
+        dim=1,
+    )
+
+
+def _load_dense_mlp(
+    out: dict[str, torch.Tensor],
+    *,
+    local_prefix: str,
+    hf_mlp_prefix: str,
+    hf_layer_prefix: str,
+    reader: SafeTensorReader,
+    ps: ParallelState,
+) -> None:
+    out[f"{local_prefix}.mlp.gate_up.linear.layer_norm_weight"] = _get(
+        reader,
+        f"{hf_layer_prefix}.post_attention_layernorm.weight",
+    )
+    gate_up = torch.cat(
+        [
+            _get(reader, f"{hf_mlp_prefix}.gate_proj.weight"),
+            _get(reader, f"{hf_mlp_prefix}.up_proj.weight"),
+        ],
+        dim=0,
+    )
+    out[f"{local_prefix}.mlp.gate_up.linear.weight"] = _split_gate_up(
+        gate_up,
+        ps.tp_rank,
+        ps.tp_size,
+    )
+    out[f"{local_prefix}.mlp.down.linear.weight"] = _tp(
+        _get(reader, f"{hf_mlp_prefix}.down_proj.weight"),
+        ps.tp_rank,
+        ps.tp_size,
+        dim=1,
+    )
+
+
+def _load_shared_expert(
+    out: dict[str, torch.Tensor],
+    *,
+    local_prefix: str,
+    hf_mlp_prefix: str,
+    reader: SafeTensorReader,
+    ps: ParallelState,
+) -> None:
+    prefixes = [f"{hf_mlp_prefix}.shared_experts", f"{hf_mlp_prefix}.shared_expert"]
+    shared = next(prefix for prefix in prefixes if _has(reader, f"{prefix}.down_proj.weight"))
+    gate_up = torch.cat(
+        [
+            _get(reader, f"{shared}.gate_proj.weight"),
+            _get(reader, f"{shared}.up_proj.weight"),
+        ],
+        dim=0,
+    )
+    out[f"{local_prefix}.moe.shared_expert.gate_up.linear.weight"] = _split_gate_up(
+        gate_up,
+        ps.tp_rank,
+        ps.tp_size,
+    )
+    out[f"{local_prefix}.moe.shared_expert.down.linear.weight"] = _tp(
+        _get(reader, f"{shared}.down_proj.weight"),
+        ps.tp_rank,
+        ps.tp_size,
+        dim=1,
+    )
+
+
+def _load_experts(
+    out: dict[str, torch.Tensor],
+    *,
+    local_prefix: str,
+    hf_mlp_prefix: str,
+    cfg: KimiK2Config,
+    ps: ParallelState,
+    reader: SafeTensorReader,
+) -> None:
+    num_local = ensure_divisible(cfg.num_experts, ps.ep_size)
+    local_start = ps.ep_rank * num_local
+    for local_idx in range(num_local):
+        global_idx = local_start + local_idx
+        ep = f"{hf_mlp_prefix}.experts.{global_idx}"
+        fc1 = torch.cat(
+            [
+                _get(reader, f"{ep}.gate_proj.weight"),
+                _get(reader, f"{ep}.up_proj.weight"),
+            ],
+            dim=0,
+        )
+        fc2 = _get(reader, f"{ep}.down_proj.weight")
+        if ps.etp_size > 1:
+            fc1 = _split_gate_up(fc1, ps.etp_rank, ps.etp_size)
+            fc2 = _tp(fc2, ps.etp_rank, ps.etp_size, dim=1)
+        out[f"{local_prefix}.moe.experts.fc1.weight{local_idx}"] = fc1
+        out[f"{local_prefix}.moe.experts.fc2.weight{local_idx}"] = fc2
+
+
+def _copy_loaded_state(model: nn.Module, loaded: dict[str, torch.Tensor]) -> None:
+    state = model.state_dict()
+    resolved: dict[str, torch.Tensor] = {}
+    for name, tensor in loaded.items():
+        actual = name if name in state else None
+        if actual is None:
+            for key in state:
+                if name in key:
+                    actual = key
+                    break
+        if actual is not None:
+            resolved[actual] = tensor
+        else:
+            log_rank0(f"WARNING: kimi_k2 checkpoint tensor has no target param: {name}")
+
+    for name, target in model.named_parameters():
+        if name not in resolved:
+            log_rank0(f"WARNING: {name} not loaded from checkpoint")
+            continue
+        tensor = resolved[name].to(device=target.device)
+        target.data.copy_(tensor.to(dtype=target.dtype))
+
+    for name, target in model.named_buffers():
+        if name not in resolved:
+            continue
+        tensor = resolved[name].to(device=target.device)
+        target.data.copy_(tensor.to(dtype=target.dtype) if target.is_floating_point() else tensor)
+
+
+class KimiK2WeightSpec:
+    """Export Kimi K2 lite weights to HF DeepSeekV3/Kimi-style names."""
+
+    def __init__(self, config: KimiK2Config):
+        self.config = config
+
+    @property
+    def num_experts(self) -> int:
+        return self.config.num_experts
+
+    def weight_map(self) -> dict[str, list[str]]:
+        return {}
+
+    def hf_to_native(self, native_name: str, hf_tensors: list[torch.Tensor]) -> torch.Tensor:
+        del native_name
+        return hf_tensors[0]
+
+    def native_to_hf(
+        self, native_name: str, tensor: torch.Tensor
+    ) -> list[tuple[str, torch.Tensor]]:
+        if native_name == "mtp_embed.embedding.weight":
+            return []
+        if native_name.startswith("mtp.layers."):
+            parts = native_name.split(".")
+            mtp_idx = int(parts[2])
+            hf_layer_idx = self.config.num_hidden_layers + mtp_idx
+            hp = f"model.layers.{hf_layer_idx}"
+            if native_name.endswith(".enorm.weight"):
+                return [(f"{hp}.enorm.weight", tensor)]
+            if native_name.endswith(".hnorm.weight"):
+                return [(f"{hp}.hnorm.weight", tensor)]
+            if native_name.endswith(".eh_proj.linear.weight"):
+                return [(f"{hp}.eh_proj.weight", tensor)]
+            if native_name.endswith(".final_layernorm.weight"):
+                return [(f"{hp}.shared_head.norm.weight", tensor)]
+            proxy = native_name.replace(
+                f"mtp.layers.{mtp_idx}.transformer_layer",
+                f"layers.{hf_layer_idx}",
+            )
+            return self.native_to_hf(proxy, tensor)
+        if native_name == "embed.embedding.weight":
+            return [("model.embed_tokens.weight", tensor)]
+        if native_name == "norm.weight":
+            return [("model.norm.weight", tensor)]
+        if native_name == "head.col.linear.weight":
+            return [("lm_head.weight", tensor)]
+
+        parts = native_name.split(".")
+        if len(parts) < 3 or parts[0] != "layers":
+            return []
+        layer_idx = int(parts[1])
+        suffix = ".".join(parts[2:])
+        hp = f"model.layers.{layer_idx}"
+        ap = f"{hp}.self_attn"
+        mp = f"{hp}.mlp"
+
+        if suffix == "input_layernorm.weight":
+            return [(f"{hp}.input_layernorm.weight", tensor)]
+        if suffix == "self_attention.linear_q_down_proj.weight":
+            return [(f"{ap}.q_a_proj.weight", tensor)]
+        if suffix == "self_attention.linear_q_up_proj.linear.layer_norm_weight":
+            return [(f"{ap}.q_a_layernorm.weight", tensor)]
+        if suffix == "self_attention.linear_q_up_proj.linear.weight":
+            return [(f"{ap}.q_b_proj.weight", tensor)]
+        if suffix == "self_attention.linear_kv_down_proj.weight":
+            return [(f"{ap}.kv_a_proj_with_mqa.weight", tensor)]
+        if suffix == "self_attention.linear_kv_up_proj.linear.layer_norm_weight":
+            return [(f"{ap}.kv_a_layernorm.weight", tensor)]
+        if suffix == "self_attention.linear_kv_up_proj.linear.weight":
+            return [(f"{ap}.kv_b_proj.weight", tensor)]
+        if suffix == "self_attention.linear_proj.linear.weight":
+            return [(f"{ap}.o_proj.weight", tensor)]
+
+        if suffix == "mlp.gate_up.linear.layer_norm_weight":
+            return [(f"{hp}.post_attention_layernorm.weight", tensor)]
+        if suffix == "mlp.gate_up.linear.weight":
+            gate, up = tensor.chunk(2, dim=0)
+            return [
+                (f"{mp}.gate_proj.weight", gate.contiguous()),
+                (f"{mp}.up_proj.weight", up.contiguous()),
+            ]
+        if suffix == "mlp.down.linear.weight":
+            return [(f"{mp}.down_proj.weight", tensor)]
+
+        if suffix == "mlp_norm.weight":
+            return [(f"{hp}.post_attention_layernorm.weight", tensor)]
+        if suffix == "moe.router.gate.weight":
+            return [(f"{mp}.gate.weight", tensor)]
+        if suffix == "moe.router.expert_bias":
+            return [(f"{mp}.gate.e_score_correction_bias", tensor.float())]
+        if suffix == "moe.shared_expert.gate_up.linear.weight":
+            gate, up = tensor.chunk(2, dim=0)
+            return [
+                (f"{mp}.shared_experts.gate_proj.weight", gate.contiguous()),
+                (f"{mp}.shared_experts.up_proj.weight", up.contiguous()),
+            ]
+        if suffix == "moe.shared_expert.down.linear.weight":
+            return [(f"{mp}.shared_experts.down_proj.weight", tensor)]
+
+        if ".moe.experts.fc1.weight" in native_name:
+            expert_idx = parse_expert_idx(native_name)
+            gate, up = tensor.chunk(2, dim=0)
+            return [
+                (f"{mp}.experts.{expert_idx}.gate_proj.weight", gate.contiguous()),
+                (f"{mp}.experts.{expert_idx}.up_proj.weight", up.contiguous()),
+            ]
+        if ".moe.experts.fc2.weight" in native_name:
+            expert_idx = parse_expert_idx(native_name)
+            return [(f"{mp}.experts.{expert_idx}.down_proj.weight", tensor)]
+
+        return []
+
+    def qkv_spec(self, native_name: str) -> tuple[int, int, int] | None:
+        del native_name
+        return None
+
+    def tp_spec(self, native_name: str) -> tuple[int, int] | None:
+        if native_name.startswith("mtp.layers.") and ".transformer_layer." in native_name:
+            proxy = native_name.replace(".transformer_layer.", ".")
+            return self.tp_spec(proxy)
+        if native_name.endswith(".eh_proj.linear.weight"):
+            return (0, 0)
+        if self.is_expert(native_name):
+            if ".fc1." in native_name:
+                return (0, 1)
+            if ".fc2." in native_name:
+                return (1, 1)
+            return None
+        if native_name in {"embed.embedding.weight", "head.col.linear.weight"}:
+            return (0, 0)
+        if native_name.endswith(".self_attention.linear_q_up_proj.linear.weight"):
+            return (0, 0)
+        if native_name.endswith(".self_attention.linear_kv_up_proj.linear.weight"):
+            return (0, 0)
+        if native_name.endswith(".self_attention.linear_proj.linear.weight"):
+            return (1, 0)
+        if native_name.endswith(".mlp.gate_up.linear.weight"):
+            return (0, 0)
+        if native_name.endswith(".mlp.down.linear.weight"):
+            return (1, 0)
+        if native_name.endswith(".moe.shared_expert.gate_up.linear.weight"):
+            return (0, 0)
+        if native_name.endswith(".moe.shared_expert.down.linear.weight"):
+            return (1, 0)
+        return None
+
+    def is_expert(self, native_name: str) -> bool:
+        return ".moe.experts." in native_name and ".router." not in native_name
+
+    def expert_global_id(self, native_name: str) -> int | None:
+        if self.is_expert(native_name):
+            return parse_expert_idx(native_name)
+        return None
+
+    def expert_local_name(self, native_name: str, local_idx: int) -> str:
+        prefix = native_name.rsplit(".weight", 1)[0]
+        return f"{prefix}.weight{local_idx}"
+
+
+def load_hf_weights(model: nn.Module, path: str, config: KimiK2Config, ps: ParallelState) -> None:
+    base_model = unwrap_model(model)
+    reader = SafeTensorReader(path)
+    out: dict[str, torch.Tensor] = {}
+
+    prefix = _text_prefix(reader)
+
+    if getattr(base_model, "embed", None) is not None:
+        out["embed.embedding.weight"] = _load_vocab(
+            reader, f"{prefix}.embed_tokens.weight", config, ps
+        )
+    if getattr(base_model, "mtp_embed", None) is not None:
+        out["mtp_embed.embedding.weight"] = _load_vocab(
+            reader,
+            f"{prefix}.embed_tokens.weight",
+            config,
+            ps,
+        )
+    if getattr(base_model, "norm", None) is not None:
+        out["norm.weight"] = _get(reader, f"{prefix}.norm.weight")
+    if getattr(base_model, "head", None) is not None:
+        out["head.col.linear.weight"] = _load_vocab(
+            reader, _lm_head_name(reader, prefix), config, ps
+        )
+
+    for local_idx, global_idx in enumerate(base_model.layer_indices):
+        lp = f"layers.{local_idx}"
+        hp = f"{prefix}.layers.{global_idx}"
+        out[f"{lp}.input_layernorm.weight"] = _get(reader, f"{hp}.input_layernorm.weight")
+        _load_attention(
+            out,
+            local_prefix=lp,
+            hf_prefix=f"{hp}.self_attn",
+            reader=reader,
+            ps=ps,
+        )
+        if config.is_moe_layer(global_idx):
+            out[f"{lp}.mlp_norm.weight"] = _get(reader, f"{hp}.post_attention_layernorm.weight")
+            out[f"{lp}.moe.router.gate.weight"] = _get(reader, f"{hp}.mlp.gate.weight")
+            bias_name = f"{hp}.mlp.gate.e_score_correction_bias"
+            if _has(reader, bias_name):
+                out[f"{lp}.moe.router.expert_bias"] = _get(reader, bias_name).float()
+            _load_shared_expert(
+                out, local_prefix=lp, hf_mlp_prefix=f"{hp}.mlp", reader=reader, ps=ps
+            )
+            _load_experts(
+                out,
+                local_prefix=lp,
+                hf_mlp_prefix=f"{hp}.mlp",
+                cfg=config,
+                ps=ps,
+                reader=reader,
+            )
+        else:
+            _load_dense_mlp(
+                out,
+                local_prefix=lp,
+                hf_mlp_prefix=f"{hp}.mlp",
+                hf_layer_prefix=hp,
+                reader=reader,
+                ps=ps,
+            )
+
+    mtp = getattr(base_model, "mtp", None)
+    if mtp is not None:
+        for local_idx, _mtp_layer in enumerate(mtp.layers):
+            global_idx = config.num_hidden_layers + local_idx
+            lp = f"mtp.layers.{local_idx}"
+            hp = f"{prefix}.layers.{global_idx}"
+            tlp = f"{lp}.transformer_layer"
+            out[f"{lp}.enorm.weight"] = _get(reader, f"{hp}.enorm.weight")
+            out[f"{lp}.hnorm.weight"] = _get(reader, f"{hp}.hnorm.weight")
+            out[f"{lp}.eh_proj.linear.weight"] = _tp(
+                _get(reader, f"{hp}.eh_proj.weight"),
+                ps.tp_rank,
+                ps.tp_size,
+            )
+            shared_head_norm = f"{hp}.shared_head.norm.weight"
+            final_norm = (
+                shared_head_norm
+                if _has(reader, shared_head_norm)
+                else f"{hp}.final_layernorm.weight"
+            )
+            out[f"{lp}.final_layernorm.weight"] = _get(reader, final_norm)
+            out[f"{tlp}.input_layernorm.weight"] = _get(reader, f"{hp}.input_layernorm.weight")
+            _load_attention(
+                out,
+                local_prefix=tlp,
+                hf_prefix=f"{hp}.self_attn",
+                reader=reader,
+                ps=ps,
+            )
+            if config.is_moe_layer(global_idx):
+                out[f"{tlp}.mlp_norm.weight"] = _get(
+                    reader, f"{hp}.post_attention_layernorm.weight"
+                )
+                out[f"{tlp}.moe.router.gate.weight"] = _get(reader, f"{hp}.mlp.gate.weight")
+                bias_name = f"{hp}.mlp.gate.e_score_correction_bias"
+                if _has(reader, bias_name):
+                    out[f"{tlp}.moe.router.expert_bias"] = _get(reader, bias_name).float()
+                _load_shared_expert(
+                    out,
+                    local_prefix=tlp,
+                    hf_mlp_prefix=f"{hp}.mlp",
+                    reader=reader,
+                    ps=ps,
+                )
+                _load_experts(
+                    out,
+                    local_prefix=tlp,
+                    hf_mlp_prefix=f"{hp}.mlp",
+                    cfg=config,
+                    ps=ps,
+                    reader=reader,
+                )
+            else:
+                _load_dense_mlp(
+                    out,
+                    local_prefix=tlp,
+                    hf_mlp_prefix=f"{hp}.mlp",
+                    hf_layer_prefix=hp,
+                    reader=reader,
+                    ps=ps,
+                )
+
+    _copy_loaded_state(base_model, out)
+
+
+def export_hf_weights(model, config: KimiK2Config, ps: ParallelState, **kwargs):
+    from megatron.lite.primitive.ckpt.hf_weights import export_hf_weights as _export
+
+    spec = KimiK2WeightSpec(config)
+    rank0_only = bool(kwargs.get("rank0_only", False))
+    export_dtype = _resolve_export_dtype(kwargs.get("export_dtype"))
+    yield from _export(model, spec, ps, vocab_size=config.vocab_size, **kwargs)
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    if rank0_only and rank != 0:
+        return
+    chunks = list(model) if isinstance(model, list | nn.ModuleList) else [model]
+    for chunk in chunks:
+        base_chunk = unwrap_model(chunk)
+        layer_map = (
+            {i: base_chunk.layer_indices[i] for i in range(len(base_chunk.layer_indices))}
+            if hasattr(base_chunk, "layer_indices")
+            else {}
+        )
+        for name, buffer in base_chunk.named_buffers():
+            if not name.endswith(".moe.router.expert_bias"):
+                continue
+            global_name = to_global_layer_name(name, layer_map)
+            for hf_name, hf_tensor in spec.native_to_hf(global_name, buffer.detach().cpu()):
+                yield hf_name, _cast_export_tensor(hf_tensor, export_dtype)
+
+
+def save_hf_weights(model, path: str, config: KimiK2Config, ps: ParallelState) -> None:
+    from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
+
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    out = dict(export_hf_weights(model, config, ps, rank0_only=True))
+    if rank == 0 and out:
+        save_safetensors(out, path)
+    if dist.is_initialized():
+        dist.barrier()
+
+
+__all__ = [
+    "EXPERT_CLASSIFIER",
+    "KimiK2WeightSpec",
+    "PLACEMENT_FN",
+    "_dequant_int4_weight",
+    "_dequant_fp8_weight",
+    "export_hf_weights",
+    "load_hf_weights",
+    "save_hf_weights",
+]

--- a/experimental/lite/megatron/lite/model/kimi_k2/lite/model.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/lite/model.py
@@ -1,0 +1,854 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Kimi K2 lite native model."""
+
+from __future__ import annotations
+
+import inspect
+import os
+from contextlib import nullcontext
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+import transformer_engine.pytorch as te
+
+from megatron.lite.model.kimi_k2.config import KimiK2Config
+from megatron.lite.primitive.modules.attention import MultiLatentAttention
+from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
+from megatron.lite.primitive.modules.experts import Experts
+from megatron.lite.primitive.modules.moe import MoEAuxLossAutoScaler
+from megatron.lite.primitive.modules.mtp import MTPLossAutoScaler
+from megatron.lite.primitive.ops.cross_entropy import vocab_parallel_cross_entropy
+from megatron.lite.primitive.ops.linear_cross_entropy import linear_cross_entropy
+from megatron.lite.primitive.ops.logprob import vocab_parallel_entropy
+from megatron.lite.primitive.ops.sp_ops import ReduceScatterDim0
+from megatron.lite.primitive.kernels.swiglu import bias_swiglu_impl
+from megatron.lite.primitive.parallel import (
+    ColumnParallelLinear,
+    ParallelState,
+    RowParallelLinear,
+    VanillaColumnParallelLinear,
+    VocabParallelEmbedding,
+    VocabParallelOutput,
+    build_pipeline_chunk_layout,
+    gather_from_sequence_parallel,
+    roll_packed_thd_left,
+    scatter_to_sequence_parallel,
+)
+from megatron.lite.primitive.utils import build_fp8_recipe
+from megatron.lite.primitive.utils.moe import (
+    compute_routing_scores_for_aux_loss,
+    router_gating_linear,
+    switch_load_balancing_loss_func,
+    topk_routing_with_score_function,
+)
+
+_SP_GRAD_SUFFIXES: tuple[str, ...] = (
+    ".input_layernorm.weight",
+    ".self_attention.linear_q_down_proj.weight",
+    ".self_attention.linear_q_up_proj.linear.layer_norm_weight",
+    ".self_attention.linear_kv_down_proj.weight",
+    ".self_attention.linear_kv_up_proj.linear.layer_norm_weight",
+    ".mlp_norm.weight",
+    ".mlp.gate_up.linear.layer_norm_weight",
+    ".moe.router.gate.weight",
+    ".norm.weight",
+)
+
+
+def _collect_sp_grad_params(model: nn.Module) -> list[nn.Parameter]:
+    return [
+        param
+        for name, param in model.named_parameters()
+        if any(name.endswith(suffix) for suffix in _SP_GRAD_SUFFIXES) or name == "norm.weight"
+    ]
+
+
+def _swiglu(x: torch.Tensor) -> torch.Tensor:
+    if x.is_cuda:
+        return bias_swiglu_impl(x, None, False, False)
+    x1, x2 = torch.chunk(x, 2, dim=-1)
+    return F.silu(x1) * x2
+
+
+def _reduce_scatter_to_sequence_parallel(x: torch.Tensor, ps: ParallelState) -> torch.Tensor:
+    if ps.tp_size == 1:
+        return x
+    return ReduceScatterDim0.apply(x, ps.tp_size, ps.tp_rank, ps.tp_group)
+
+
+def _ordered_topk_from_routing_map(
+    probs_dense: torch.Tensor, routing_map: torch.Tensor, topk: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    expert_ids = torch.arange(
+        probs_dense.size(-1), device=probs_dense.device, dtype=torch.long
+    ).expand_as(routing_map)
+    masked_ids = torch.where(
+        routing_map, expert_ids, torch.full_like(expert_ids, probs_dense.size(-1))
+    )
+    topk_indices = torch.sort(masked_ids, dim=-1).values[:, :topk]
+    topk_scores = torch.gather(probs_dense, dim=-1, index=topk_indices)
+    return topk_scores, topk_indices
+
+
+def _router_linear(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    router_dtype: torch.dtype,
+) -> torch.Tensor:
+    if x.is_cuda:
+        return router_gating_linear(x, weight, bias, router_dtype)
+    return F.linear(
+        x.to(router_dtype),
+        weight.to(router_dtype),
+        None if bias is None else bias.to(router_dtype),
+    )
+
+
+def _topk_routing_supports_groups() -> bool:
+    params = inspect.signature(topk_routing_with_score_function).parameters
+    return "num_groups" in params and "group_topk" in params
+
+
+class KimiK2SigmoidTopKRouter(nn.Module):
+    """Kimi K2 sigmoid router with group-limited routing and persistent expert bias."""
+
+    def __init__(
+        self,
+        config: KimiK2Config,
+        ps: ParallelState,
+        *,
+        router_bias_rate: float = 0.0,
+        compute_aux_loss: bool = True,
+        use_pre_softmax: bool = False,
+        moe_router_fusion: bool = False,
+    ):
+        super().__init__()
+        if router_bias_rate > 0:
+            raise NotImplementedError(
+                "Kimi K2 expert-bias EMA update is not implemented in lite yet."
+            )
+        self.topk = config.num_experts_per_tok
+        self.num_experts = config.n_routed_experts
+        self.aux_loss_coeff = config.aux_loss_alpha
+        self.scaling_factor = config.routed_scaling_factor
+        self.num_groups = config.n_group
+        self.group_topk = config.topk_group
+        self.router_bias_rate = router_bias_rate
+        self.compute_aux_loss = compute_aux_loss
+        self.use_pre_softmax = use_pre_softmax
+        self.moe_router_fusion = moe_router_fusion
+
+        self.gate = nn.Linear(config.hidden_size, config.n_routed_experts, bias=False)
+        self.register_buffer(
+            "expert_bias",
+            torch.zeros(config.n_routed_experts, dtype=torch.float32),
+            persistent=True,
+        )
+        self.register_buffer(
+            "local_tokens_per_expert",
+            torch.zeros(config.n_routed_experts, dtype=torch.float32),
+            persistent=False,
+        )
+        self._aux_loss_group = ps.tp_group if ps.tp_size > 1 else None
+
+    def _apply(self, fn):
+        super()._apply(fn)
+        self.expert_bias.data = self.expert_bias.data.float()
+        self.local_tokens_per_expert.data = self.local_tokens_per_expert.data.float()
+        return self
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        logits = _router_linear(x, self.gate.weight, None, torch.float32)
+        logits = logits.view(-1, self.num_experts)
+        num_tokens = logits.size(0)
+        routing_kwargs = {}
+        if self.num_groups is not None and self.group_topk is not None:
+            if not _topk_routing_supports_groups():
+                raise NotImplementedError(
+                    "topk_routing_with_score_function does not support group-limited routing."
+                )
+            routing_kwargs = dict(num_groups=self.num_groups, group_topk=self.group_topk)
+        probs_dense, routing_map = topk_routing_with_score_function(
+            logits,
+            self.topk,
+            use_pre_softmax=self.use_pre_softmax,
+            score_function="sigmoid",
+            expert_bias=self.expert_bias.to(logits.dtype),
+            scaling_factor=(self.scaling_factor or None),
+            fused=self.moe_router_fusion,
+            **routing_kwargs,
+        )
+        if torch.is_grad_enabled():
+            with torch.no_grad():
+                self.local_tokens_per_expert += routing_map.sum(dim=0)
+        topk_scores, topk_indices = _ordered_topk_from_routing_map(
+            probs_dense, routing_map, self.topk
+        )
+        topk_scores = topk_scores.to(logits.dtype)
+
+        if self.compute_aux_loss and self.training and torch.is_grad_enabled():
+            _, aux_scores = compute_routing_scores_for_aux_loss(
+                logits, self.topk, score_function="sigmoid", fused=self.moe_router_fusion
+            )
+            tokens_per_expert = routing_map.sum(dim=0).to(torch.int64)
+            total_num_tokens = num_tokens
+            if self._aux_loss_group is not None:
+                dist.all_reduce(tokens_per_expert, group=self._aux_loss_group)
+                total_num_tokens = num_tokens * dist.get_world_size(group=self._aux_loss_group)
+            aux_loss = switch_load_balancing_loss_func(
+                aux_scores,
+                tokens_per_expert,
+                total_num_tokens,
+                self.topk,
+                self.num_experts,
+                self.aux_loss_coeff,
+                fused=False,
+            )
+            topk_scores = MoEAuxLossAutoScaler.apply(topk_scores, aux_loss)
+
+        return topk_scores, topk_indices
+
+
+class DenseMLP(nn.Module):
+    def __init__(self, config: KimiK2Config, ps: ParallelState):
+        super().__init__()
+        self.gate_up = ColumnParallelLinear(
+            config.hidden_size,
+            config.intermediate_size * 2,
+            ps,
+            bias=False,
+            normalization="RMSNorm",
+            eps=config.rms_norm_eps,
+        )
+        self.down = RowParallelLinear(config.intermediate_size, config.hidden_size, ps, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.down(_swiglu(self.gate_up(x)))
+
+
+class SharedExpert(nn.Module):
+    def __init__(self, config: KimiK2Config, ps: ParallelState):
+        super().__init__()
+        self.ps = ps
+        ffn = config.shared_expert_intermediate_size
+        self.gate_up = _LocalLinear(config.hidden_size, ffn * 2 // ps.tp_size)
+        self.down = _LocalLinear(ffn // ps.tp_size, config.hidden_size)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        squeeze_batch = x.dim() == 2
+        if squeeze_batch:
+            x = x.unsqueeze(1)
+        full_x = gather_from_sequence_parallel(x, self.ps)
+        partial_out = self.down(_swiglu(self.gate_up(full_x)))
+        out = _reduce_scatter_to_sequence_parallel(partial_out, self.ps)
+        return out.squeeze(1) if squeeze_batch else out
+
+
+class _LocalLinear(nn.Module):
+    """TE linear without built-in TP collectives; weight remains TP-local."""
+
+    def __init__(self, in_features: int, out_features: int):
+        super().__init__()
+        self.linear = te.Linear(
+            in_features,
+            out_features,
+            bias=False,
+            params_dtype=torch.bfloat16,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.linear(x)
+
+
+class MoELayer(nn.Module):
+    def __init__(
+        self,
+        config: KimiK2Config,
+        ps: ParallelState,
+        *,
+        use_deepep: bool,
+        router_bias_rate: float,
+        fp8: bool,
+        moe_act_recompute: bool,
+    ):
+        super().__init__()
+        if fp8:
+            raise NotImplementedError("Kimi K2 lite MoE fp8 training is not implemented yet.")
+        self.router = KimiK2SigmoidTopKRouter(
+            config,
+            ps,
+            router_bias_rate=router_bias_rate,
+            compute_aux_loss=True,
+            use_pre_softmax=True,
+        )
+        self.experts = Experts(
+            config,
+            ps,
+            fp8=fp8,
+            moe_act_recompute=moe_act_recompute,
+        )
+        self.dispatcher = TokenDispatcher(
+            config.num_experts,
+            config.hidden_size,
+            ps,
+            use_deepep=use_deepep,
+        )
+        self.shared_expert = SharedExpert(config, ps)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        input_shape = x.shape
+
+        flat_x = x.view(-1, x.size(-1))
+        scores, indices = self.router(flat_x)
+        dispatched, tpe, permuted_probs = self.dispatcher.dispatch(flat_x, scores, indices)
+        del scores, indices
+        self.dispatcher.wait_dispatch_event()
+        expert_out = self.experts(
+            dispatched,
+            tpe,
+            permuted_probs,
+            tokens_per_expert_list=getattr(self.dispatcher, "_local_tpe_list", None),
+        )
+        routed_out = self.dispatcher.combine(expert_out)
+        shared_out = self.shared_expert(x)
+        output = routed_out.view(input_shape)
+        output += shared_out
+        return output.to(x.dtype)
+
+
+class KimiK2Layer(nn.Module):
+    def __init__(
+        self,
+        config: KimiK2Config,
+        ps: ParallelState,
+        layer_idx: int,
+        *,
+        use_deepep: bool = False,
+        router_bias_rate: float = 0.0,
+        fp8: bool = False,
+        moe_act_recompute: bool = False,
+        use_thd: bool = False,
+    ):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.input_layernorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.self_attention = MultiLatentAttention(
+            hidden_size=config.hidden_size,
+            num_attention_heads=config.num_attention_heads,
+            q_lora_rank=config.q_lora_rank,
+            kv_lora_rank=config.kv_lora_rank,
+            qk_nope_head_dim=config.qk_nope_head_dim,
+            qk_rope_head_dim=config.qk_rope_head_dim,
+            v_head_dim=config.v_head_dim,
+            ps=ps,
+            rms_norm_eps=config.rms_norm_eps,
+            rope_theta=config.rope_theta,
+            rope_scaling=config.rope_scaling,
+            use_thd=use_thd,
+        )
+        if config.is_moe_layer(layer_idx):
+            self.mlp_norm: nn.Module | None = te.RMSNorm(
+                config.hidden_size, eps=config.rms_norm_eps
+            )
+            self.moe: MoELayer | None = MoELayer(
+                config,
+                ps,
+                use_deepep=use_deepep,
+                router_bias_rate=router_bias_rate,
+                fp8=fp8,
+                moe_act_recompute=moe_act_recompute,
+            )
+            self.mlp: DenseMLP | None = None
+        else:
+            self.mlp_norm = None
+            self.moe = None
+            self.mlp = DenseMLP(config, ps)
+
+    def forward(self, x: torch.Tensor, packed_seq_params=None) -> torch.Tensor:
+        x = x + self.self_attention(self.input_layernorm(x), packed_seq_params=packed_seq_params)
+        if self.moe is not None:
+            assert self.mlp_norm is not None
+            mlp_input = self.mlp_norm(x)
+            return x + self.moe(mlp_input)
+        assert self.mlp is not None
+        return x + self.mlp(x)
+
+
+def _roll_mtp_left(
+    tensor: torch.Tensor,
+    *,
+    packed_seq_params=None,
+    dims: int = -1,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if packed_seq_params is not None:
+        return roll_packed_thd_left(tensor, packed_seq_params=packed_seq_params, dims=dims)
+    dim = dims if dims >= 0 else tensor.dim() + dims
+    rolled = torch.roll(tensor, shifts=-1, dims=dim)
+    rolled.select(dim, -1).zero_()
+    return rolled, rolled.sum()
+
+
+class KimiK2MTPLayer(nn.Module):
+    def __init__(
+        self,
+        config: KimiK2Config,
+        ps: ParallelState,
+        layer_idx: int,
+        *,
+        embedding: VocabParallelEmbedding,
+        use_deepep: bool,
+        router_bias_rate: float,
+        fp8: bool,
+        moe_act_recompute: bool,
+        use_thd: bool,
+        detach_encoder: bool,
+    ):
+        super().__init__()
+        self.ps = ps
+        object.__setattr__(self, "embedding", embedding)
+        self.detach_encoder = detach_encoder
+        self.enorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.hnorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.eh_proj = VanillaColumnParallelLinear(
+            config.hidden_size * 2,
+            config.hidden_size,
+            ps,
+            sp=ps.tp_size > 1,
+            gather_output=True,
+        )
+        self.transformer_layer = KimiK2Layer(
+            config,
+            ps,
+            config.num_hidden_layers + layer_idx,
+            use_deepep=use_deepep,
+            router_bias_rate=router_bias_rate,
+            fp8=fp8,
+            moe_act_recompute=moe_act_recompute,
+            use_thd=use_thd,
+        )
+        self.final_layernorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        *,
+        input_ids: torch.Tensor,
+        position_ids: torch.Tensor | None,
+        hidden_states: torch.Tensor,
+        rotary_position_ids: torch.Tensor | None = None,
+        packed_seq_params=None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+        del rotary_position_ids
+        input_ids, _ = _roll_mtp_left(input_ids, packed_seq_params=packed_seq_params, dims=-1)
+        if position_ids is not None:
+            position_ids, _ = _roll_mtp_left(
+                position_ids, packed_seq_params=packed_seq_params, dims=-1
+            )
+        decoder_input = self.embedding(input_ids)
+        decoder_input = scatter_to_sequence_parallel(decoder_input, self.ps)
+
+        if self.detach_encoder:
+            decoder_input = decoder_input.detach()
+            hidden_states = hidden_states.detach()
+
+        decoder_input = self.enorm(decoder_input)
+        hidden_states = self.hnorm(hidden_states)
+        hidden_states = torch.cat((decoder_input, hidden_states), dim=-1)
+        hidden_states = self.eh_proj(hidden_states)
+        hidden_states = scatter_to_sequence_parallel(hidden_states, self.ps)
+        hidden_states = self.transformer_layer(hidden_states, packed_seq_params=packed_seq_params)
+        hidden_states = self.final_layernorm(hidden_states)
+        return hidden_states, input_ids, position_ids
+
+
+class KimiK2MTPBlock(nn.Module):
+    def __init__(
+        self,
+        config: KimiK2Config,
+        ps: ParallelState,
+        *,
+        embedding: VocabParallelEmbedding,
+        use_deepep: bool,
+        router_bias_rate: float,
+        fp8: bool,
+        moe_act_recompute: bool,
+        use_thd: bool,
+        detach_encoder: bool,
+        repeated_layer: bool,
+    ):
+        super().__init__()
+        self.num_layers = config.num_nextn_predict_layers
+        self.repeated_layer = repeated_layer
+        layers_to_build = 1 if repeated_layer else self.num_layers
+        self.layers = nn.ModuleList(
+            [
+                KimiK2MTPLayer(
+                    config,
+                    ps,
+                    idx,
+                    embedding=embedding,
+                    use_deepep=use_deepep,
+                    router_bias_rate=router_bias_rate,
+                    fp8=fp8,
+                    moe_act_recompute=moe_act_recompute,
+                    use_thd=use_thd,
+                    detach_encoder=detach_encoder,
+                )
+                for idx in range(layers_to_build)
+            ]
+        )
+
+    def forward(
+        self,
+        *,
+        input_ids: torch.Tensor,
+        position_ids: torch.Tensor | None,
+        hidden_states: torch.Tensor,
+        packed_seq_params=None,
+    ) -> list[torch.Tensor]:
+        outputs: list[torch.Tensor] = []
+        rotary_position_ids = position_ids
+        for depth in range(self.num_layers):
+            layer = self.layers[0] if self.repeated_layer else self.layers[depth]
+            hidden_states, input_ids, position_ids = layer(
+                input_ids=input_ids,
+                position_ids=position_ids,
+                hidden_states=hidden_states,
+                rotary_position_ids=rotary_position_ids,
+                packed_seq_params=packed_seq_params,
+            )
+            outputs.append(hidden_states)
+        return outputs
+
+
+def _temperature_to_float(temperature: float | torch.Tensor) -> float:
+    if isinstance(temperature, torch.Tensor):
+        if temperature.numel() != 1:
+            raise ValueError("KimiK2Model supports scalar temperature only.")
+        return float(temperature.detach().float().item())
+    return float(temperature)
+
+
+def _apply_attention_backend_override(backend: str | None) -> None:
+    if backend in (None, "flash"):
+        backend = "fused"
+    env = {
+        "auto": ("1", "1", "1"),
+        "flash": ("1", "0", "0"),
+        "fused": ("0", "1", "0"),
+        "unfused": ("0", "0", "1"),
+        "local": ("0", "0", "1"),
+    }.get(backend)
+    if env is None:
+        raise ValueError(
+            "attention_backend_override must be one of "
+            "{'auto', 'flash', 'fused', 'unfused', 'local'}"
+        )
+    (
+        os.environ["NVTE_FLASH_ATTN"],
+        os.environ["NVTE_FUSED_ATTN"],
+        os.environ["NVTE_UNFUSED_ATTN"],
+    ) = env
+
+
+class KimiK2Model(nn.Module):
+    def __init__(
+        self,
+        config: KimiK2Config,
+        train_config,
+        ps: ParallelState,
+        *,
+        vpp_chunk_id: int | None = None,
+        router_bias_rate: float = 0.0,
+        use_thd: bool = False,
+        hf_path: str = "",
+        attention_backend_override: str | None = None,
+        mtp_enable: bool = False,
+        mtp_enable_train: bool = False,
+        mtp_detach_encoder: bool = False,
+    ):
+        super().__init__()
+        del hf_path
+        _apply_attention_backend_override(attention_backend_override)
+        self.config = config
+        self.train_config = train_config
+        self.ps = ps
+        self._input_tensor: torch.Tensor | None = None
+        self.mtp_enable_train = bool(mtp_enable and mtp_enable_train)
+        self.mtp_loss_scaling_factor = config.mtp_loss_scaling_factor
+
+        layout = build_pipeline_chunk_layout(
+            config.num_hidden_layers,
+            ps,
+            train_config.vpp,
+            vpp_chunk_id,
+            num_mtp_layers=config.num_nextn_predict_layers if mtp_enable else 0,
+        )
+        self.layer_indices = layout.layer_indices
+        self.pre_process = layout.has_embed
+        self.post_process = layout.has_head
+        self.share_embeddings_and_output_weights = bool(config.tie_word_embeddings)
+        self.vision_model: nn.Module | None = None
+
+        self.embed: VocabParallelEmbedding | None = None
+        if layout.has_embed:
+            self.embed = VocabParallelEmbedding(config.vocab_size, config.hidden_size, ps)
+
+        recompute_modules = getattr(train_config, "recompute_modules", [])
+        moe_act_recompute = "moe_act" in recompute_modules and "moe" not in recompute_modules
+        self.layers = nn.ModuleList(
+            [
+                KimiK2Layer(
+                    config,
+                    ps,
+                    idx,
+                    use_deepep=train_config.use_deepep,
+                    router_bias_rate=router_bias_rate,
+                    fp8=train_config.fp8,
+                    moe_act_recompute=moe_act_recompute,
+                    use_thd=use_thd,
+                )
+                for idx in self.layer_indices
+            ]
+        )
+
+        self.norm: nn.Module | None = None
+        self.head: VocabParallelOutput | None = None
+        if layout.has_head:
+            self.norm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+            self.head = VocabParallelOutput(config.vocab_size, config.hidden_size, ps)
+
+        self.mtp_embed: VocabParallelEmbedding | None = None
+        self.mtp: KimiK2MTPBlock | None = None
+        if mtp_enable and config.num_nextn_predict_layers > 0 and layout.has_mtp:
+            mtp_embedding = self.embed
+            if mtp_embedding is None:
+                mtp_embedding = VocabParallelEmbedding(config.vocab_size, config.hidden_size, ps)
+                self.mtp_embed = mtp_embedding
+            self.mtp = KimiK2MTPBlock(
+                config,
+                ps,
+                embedding=mtp_embedding,
+                use_deepep=train_config.use_deepep,
+                router_bias_rate=router_bias_rate,
+                fp8=train_config.fp8,
+                moe_act_recompute=moe_act_recompute,
+                use_thd=use_thd,
+                detach_encoder=mtp_detach_encoder,
+                repeated_layer=config.mtp_use_repeated_layer,
+            )
+
+        self.sp_params: list[nn.Parameter] = []
+        if ps.tp_size > 1:
+            self.sp_params = _collect_sp_grad_params(self)
+
+    def set_input_tensor(self, input_tensor):
+        if isinstance(input_tensor, list):
+            if len(input_tensor) > 1:
+                raise ValueError("KimiK2Model expects a single pipeline input tensor.")
+            input_tensor = input_tensor[0] if input_tensor else None
+        self._input_tensor = input_tensor
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None = None,
+        hidden_states: torch.Tensor | None = None,
+        position_ids: torch.Tensor | None = None,
+        packed_seq_params=None,
+        labels: torch.Tensor | None = None,
+        loss_mask: torch.Tensor | None = None,
+        temperature: float | torch.Tensor = 1.0,
+        use_fused_kernels: bool = False,
+        calculate_entropy: bool = False,
+    ) -> dict:
+        if self.embed is not None:
+            assert input_ids is not None
+            h = self.embed(input_ids)
+        else:
+            if hidden_states is None:
+                hidden_states = self._input_tensor
+            assert hidden_states is not None
+            h = hidden_states
+
+        fp8_ctx = (
+            te.fp8_autocast(enabled=True, fp8_recipe=build_fp8_recipe(self.train_config))
+            if self.train_config.fp8
+            else nullcontext()
+        )
+        with fp8_ctx:
+            if self.embed is not None:
+                h = scatter_to_sequence_parallel(h, self.ps)
+            for layer in self.layers:
+                h = layer(h, packed_seq_params=packed_seq_params)
+
+        output = {"hidden_states": h}
+        if self.head is not None:
+            assert self.norm is not None
+            hidden_for_head = self.norm(h)
+            mtp_hidden_states = self._apply_mtp(
+                hidden_for_head,
+                input_ids=input_ids,
+                position_ids=position_ids,
+                packed_seq_params=packed_seq_params,
+            )
+            if mtp_hidden_states is not None:
+                output["mtp_hidden_states"] = mtp_hidden_states
+            if labels is not None:
+                temperature_value = _temperature_to_float(temperature)
+                mtp_result = self._apply_mtp_loss(
+                    hidden_for_head,
+                    mtp_hidden_states=mtp_hidden_states,
+                    labels=labels,
+                    loss_mask=loss_mask,
+                    packed_seq_params=packed_seq_params,
+                    temperature=temperature_value,
+                    use_fused_kernels=use_fused_kernels,
+                )
+                if mtp_result is not None:
+                    hidden_for_head, mtp_loss = mtp_result
+                    output["mtp_loss"] = mtp_loss
+                labels_sb = labels.transpose(0, 1).contiguous()
+                if use_fused_kernels:
+                    hidden_full = gather_from_sequence_parallel(hidden_for_head, self.ps)
+                    log_probs, entropy = linear_cross_entropy(
+                        hidden_full,
+                        self._head_weight_for_fused_ce(hidden_full),
+                        labels_sb,
+                        temperature_value,
+                        self.ps.tp_group,
+                    )
+                    output["loss"] = (-log_probs).mean()
+                    output["log_probs"] = log_probs.transpose(0, 1).contiguous()
+                    if calculate_entropy:
+                        output["entropy"] = entropy.transpose(0, 1).contiguous()
+                else:
+                    logits = self.head(hidden_for_head)
+                    if temperature_value != 1.0:
+                        logits = logits / temperature_value
+                    loss = vocab_parallel_cross_entropy(logits, labels_sb, self.ps.tp_group)
+                    output["loss"] = loss.mean()
+                    output["log_probs"] = (-loss).transpose(0, 1).contiguous()
+                    if calculate_entropy:
+                        entropy = vocab_parallel_entropy(logits, self.ps.tp_group)
+                        output["entropy"] = entropy.transpose(0, 1).contiguous()
+            else:
+                logits = self.head(hidden_for_head)
+                output["logits"] = self.head.gather(logits).transpose(0, 1).contiguous()
+                if mtp_hidden_states is not None:
+                    output["mtp_logits"] = [
+                        self.head.gather(self.head(mtp_hidden)).transpose(0, 1).contiguous()
+                        for mtp_hidden in mtp_hidden_states
+                    ]
+        return output
+
+    def _apply_mtp(
+        self,
+        hidden_states: torch.Tensor,
+        *,
+        input_ids: torch.Tensor | None,
+        position_ids: torch.Tensor | None,
+        packed_seq_params,
+    ) -> list[torch.Tensor] | None:
+        if self.mtp is None:
+            return None
+        if input_ids is None:
+            if self.mtp_enable_train:
+                raise ValueError("MTP training requires input_ids.")
+            return None
+        return self.mtp(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            hidden_states=hidden_states,
+            packed_seq_params=packed_seq_params,
+        )
+
+    def _apply_mtp_loss(
+        self,
+        hidden_states: torch.Tensor,
+        *,
+        mtp_hidden_states: list[torch.Tensor] | None,
+        labels: torch.Tensor,
+        loss_mask: torch.Tensor | None,
+        packed_seq_params,
+        temperature: float,
+        use_fused_kernels: bool,
+    ) -> tuple[torch.Tensor, torch.Tensor] | None:
+        if mtp_hidden_states is None:
+            return None
+        if not self.mtp_enable_train:
+            return None
+        if loss_mask is None:
+            mtp_loss_mask = torch.ones_like(labels, dtype=torch.float32)
+        else:
+            mtp_loss_mask = loss_mask.to(dtype=torch.float32).clone()
+        mtp_labels = labels.clone()
+
+        mtp_loss_values = []
+        for mtp_hidden in mtp_hidden_states:
+            mtp_labels, _ = _roll_mtp_left(
+                mtp_labels,
+                packed_seq_params=packed_seq_params,
+                dims=-1,
+            )
+            mtp_loss_mask, num_tokens = _roll_mtp_left(
+                mtp_loss_mask,
+                packed_seq_params=packed_seq_params,
+                dims=-1,
+            )
+            labels_sb = mtp_labels.transpose(0, 1).contiguous()
+            mask_sb = mtp_loss_mask.transpose(0, 1).contiguous()
+
+            if use_fused_kernels:
+                mtp_hidden_full = gather_from_sequence_parallel(mtp_hidden, self.ps)
+                log_probs, _entropy = linear_cross_entropy(
+                    mtp_hidden_full,
+                    self._head_weight_for_fused_ce(mtp_hidden_full),
+                    labels_sb,
+                    temperature,
+                    self.ps.tp_group,
+                )
+                token_loss = -log_probs
+            else:
+                logits = self.head(mtp_hidden)
+                if temperature != 1.0:
+                    logits = logits / temperature
+                token_loss = vocab_parallel_cross_entropy(logits, labels_sb, self.ps.tp_group)
+
+            token_loss = token_loss * mask_sb.to(dtype=token_loss.dtype)
+            num_tokens = num_tokens.to(dtype=token_loss.dtype).clamp_min(1.0)
+            mtp_loss_values.append(token_loss.sum() / num_tokens)
+
+            mtp_loss_scale = self.mtp_loss_scaling_factor / max(len(mtp_hidden_states), 1)
+            hidden_states = MTPLossAutoScaler.apply(
+                hidden_states,
+                mtp_loss_scale * token_loss / num_tokens,
+            )
+
+        if not mtp_loss_values:
+            return None
+        return (
+            hidden_states,
+            torch.stack([loss.detach().float() for loss in mtp_loss_values]).mean(),
+        )
+
+    def _head_weight_for_fused_ce(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        assert self.head is not None
+        weight = self.head.col.linear.weight
+        return (
+            weight if weight.dtype == hidden_states.dtype else weight.to(dtype=hidden_states.dtype)
+        )
+
+
+__all__ = [
+    "DenseMLP",
+    "KimiK2MTPBlock",
+    "KimiK2MTPLayer",
+    "KimiK2Layer",
+    "KimiK2Model",
+    "MoELayer",
+    "MTPLossAutoScaler",
+    "MultiLatentAttention",
+    "SharedExpert",
+]

--- a/experimental/lite/megatron/lite/model/kimi_k2/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/lite/protocol.py
@@ -1,0 +1,296 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Kimi K2 lite impl - native model protocol for Megatron Lite runtime."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import torch
+import torch.nn as nn
+from megatron.lite.model.kimi_k2.config import KimiK2Config
+from megatron.lite.model.protocol_utils import (
+    add_cross_entropy_fusion,
+    add_loss_context_kwargs,
+    pack_thd_forward_kwargs,
+    set_cross_entropy_fusion,
+    unpack_thd_forward_output,
+)
+from megatron.lite.primitive.bundle import ModelBundle
+from megatron.lite.primitive.parallel import ParallelState, init_parallel
+from megatron.lite.primitive.recompute import apply_recompute, parse_recompute_spec
+from megatron.lite.runtime.contracts import OptimizerConfig, ParallelConfig
+from megatron.lite.runtime.contracts.data import PackedBatch
+
+
+def EXPERT_CLASSIFIER(name: str) -> bool:
+    return "experts" in name and "router" not in name and "shared" not in name
+
+
+def PLACEMENT_FN(param_name: str) -> list:
+    from megatron.lite.model.kimi_k2.lite.checkpoint import PLACEMENT_FN as placement_fn
+
+    return placement_fn(param_name)
+
+
+def is_expert_param(name: str) -> bool:
+    return EXPERT_CLASSIFIER(name)
+
+
+def _maybe(module_name: str):
+    def getter(layer):
+        module = getattr(layer, module_name, None)
+        return module
+
+    return getter
+
+
+def _moe_module(name: str):
+    def getter(layer):
+        moe = getattr(layer, "moe", None)
+        return getattr(moe, name, None) if moe is not None else None
+
+    return getter
+
+
+MODULE_MAP = {
+    "core_attn": lambda layer: layer.self_attention.core_attn,
+    "experts": _moe_module("experts"),
+    "moe": _maybe("moe"),
+    "router": _moe_module("router"),
+    "mlp": _maybe("mlp"),
+    "mlp_norm": lambda layer: layer.mlp_norm,
+    "attn_proj": lambda layer: layer.self_attention.linear_proj,
+    "mla": lambda layer: layer.self_attention,
+}
+
+
+@dataclass(frozen=True)
+class ImplConfig:
+    parallel: ParallelConfig = field(default_factory=ParallelConfig)
+    optimizer: str | None = "dist_opt"
+    recompute: list[str] = field(default_factory=list)
+    offload: list[str] = field(default_factory=list)
+    use_deepep: bool = False
+    use_thd: bool = False
+    cross_entropy_fusion: bool = False
+    hf_path: str = ""
+    attention_backend_override: str | None = None
+    router_aux_loss_coef: float | None = None
+    router_bias_rate: float = 0.0
+    deterministic: bool = True
+    optimizer_config: OptimizerConfig | None = None
+    mtp_enable: bool = False
+    mtp_enable_train: bool = False
+    mtp_detach_encoder: bool = False
+    mtp_loss_scaling_factor: float = 0.1
+    mtp_use_repeated_layer: bool | None = None
+
+
+def build_model_config(source: str | Path | dict, **overrides) -> KimiK2Config:
+    if isinstance(source, dict):
+        cfg = KimiK2Config._from_hf_dict(source)
+    else:
+        cfg = KimiK2Config.from_hf(str(source))
+    for key, value in overrides.items():
+        if hasattr(cfg, key):
+            setattr(cfg, key, value)
+    return cfg
+
+
+def _forward_step(model: nn.Module, batch: PackedBatch) -> dict:
+    kwargs = pack_thd_forward_kwargs(model, batch)
+    add_loss_context_kwargs(kwargs)
+    add_cross_entropy_fusion(kwargs, model)
+    return model(**kwargs)
+
+
+def unpack_forward_output(model: nn.Module, batch: PackedBatch, output) -> Any:
+    return unpack_thd_forward_output(model, batch, output)
+
+
+def _make_aux_loss_hook():
+    from megatron.lite.primitive.modules.moe import MoEAuxLossAutoScaler
+    from megatron.lite.primitive.modules.mtp import MTPLossAutoScaler
+
+    def hook(scale: torch.Tensor) -> None:
+        MoEAuxLossAutoScaler.set_loss_scale(scale)
+        MTPLossAutoScaler.set_loss_scale(scale)
+
+    return hook
+
+
+def _build_dist_opt_optimizer(
+    chunks, model_cfg: KimiK2Config, impl_cfg: ImplConfig, ps: ParallelState
+):
+    from megatron.lite.primitive.optimizers.megatron_wrap import build_dist_opt_training_optimizer
+
+    return build_dist_opt_training_optimizer(
+        chunks,
+        model_cfg=model_cfg,
+        impl_cfg=impl_cfg,
+        ps=ps,
+        model_name="kimi_k2",
+        is_expert=is_expert_param,
+        deterministic=impl_cfg.deterministic,
+    )
+
+
+def build_model(model_cfg: KimiK2Config, *, impl_cfg: ImplConfig) -> ModelBundle:
+    p = impl_cfg.parallel
+    if impl_cfg.use_deepep and (p.etp is not None and p.etp > 1):
+        raise ValueError("use_deepep and etp>1 are mutually exclusive")
+    if impl_cfg.router_aux_loss_coef is not None:
+        model_cfg.aux_loss_alpha = impl_cfg.router_aux_loss_coef
+    mtp_enable = bool(impl_cfg.mtp_enable)
+    mtp_enable_train = mtp_enable and bool(impl_cfg.mtp_enable_train)
+    if mtp_enable:
+        if model_cfg.num_nextn_predict_layers <= 0:
+            raise ValueError("mtp_enable=True but HF config has no num_nextn_predict_layers.")
+        model_cfg.mtp_loss_scaling_factor = impl_cfg.mtp_loss_scaling_factor
+        if impl_cfg.mtp_use_repeated_layer is not None:
+            model_cfg.mtp_use_repeated_layer = impl_cfg.mtp_use_repeated_layer
+    elif hasattr(model_cfg, "num_nextn_predict_layers"):
+        model_cfg.num_nextn_predict_layers = 0
+
+    from megatron.lite.model.kimi_k2.lite.model import KimiK2Model
+
+    ps = init_parallel(p)
+    recompute_spec = parse_recompute_spec(impl_cfg.recompute)
+    vpp = None if p.vpp == 1 else p.vpp
+    train_cfg = SimpleNamespace(
+        tp=ps.tp_size,
+        ep=ps.ep_size,
+        etp=ps.etp_size,
+        pp=ps.pp_size,
+        cp=ps.cp_size,
+        vpp=vpp,
+        use_deepep=impl_cfg.use_deepep,
+        fp8=False,
+        recompute_modules=recompute_spec,
+        deterministic=impl_cfg.deterministic,
+    )
+    model_kwargs: dict[str, Any] = dict(
+        router_bias_rate=impl_cfg.router_bias_rate,
+        use_thd=impl_cfg.use_thd,
+        hf_path=impl_cfg.hf_path,
+        attention_backend_override=impl_cfg.attention_backend_override,
+        mtp_enable=mtp_enable,
+        mtp_enable_train=mtp_enable_train,
+        mtp_detach_encoder=impl_cfg.mtp_detach_encoder,
+    )
+
+    if vpp is None:
+        chunks = [KimiK2Model(model_cfg, train_cfg, ps, **model_kwargs).to(torch.bfloat16).cuda()]
+    else:
+        chunks = [
+            KimiK2Model(
+                model_cfg,
+                train_cfg,
+                ps,
+                vpp_chunk_id=i,
+                **model_kwargs,
+            )
+            .to(torch.bfloat16)
+            .cuda()
+            for i in range(vpp)
+        ]
+    set_cross_entropy_fusion(chunks, impl_cfg.cross_entropy_fusion)
+
+    if recompute_spec:
+        for chunk in chunks:
+            apply_recompute(chunk.layers, recompute_spec, MODULE_MAP)
+
+    if impl_cfg.offload:
+        from megatron.lite.primitive.recompute import apply_offload
+
+        for chunk in chunks:
+            apply_offload(chunk.layers, impl_cfg.offload, MODULE_MAP)
+
+    optimizer = None
+    finalize_grads = None
+    post_model_load_hook = None
+    optimizer_backend = "none"
+    if impl_cfg.optimizer == "dist_opt":
+        optimizer, finalize_grads = _build_dist_opt_optimizer(chunks, model_cfg, impl_cfg, ps)
+        from megatron.lite.primitive.ckpt import attach_model_sharded_state_dict
+        from megatron.lite.runtime.megatron_utils import register_training_hooks
+
+        attach_model_sharded_state_dict(
+            chunks, ps, get_placements=PLACEMENT_FN, is_expert=is_expert_param
+        )
+        register_training_hooks(chunks, optimizer)
+        optimizer_backend = "dist_opt"
+    elif impl_cfg.optimizer == "fsdp2":
+        optimizer_backend = "fsdp2"
+
+        def _post_model_load_hook():
+            from megatron.lite.model.kimi_k2.lite.model import KimiK2Layer
+            from megatron.lite.primitive.optimizers.fsdp2 import build_fsdp2_training_optimizer
+
+            return {
+                "optimizer": build_fsdp2_training_optimizer(
+                    chunks,
+                    impl_cfg.optimizer_config,
+                    ps,
+                    unit_modules=(KimiK2Layer,),
+                    expert_classifier=is_expert_param,
+                    deterministic=impl_cfg.deterministic,
+                    vpp=impl_cfg.parallel.vpp,
+                    leaf_module_names=(),
+                )
+            }
+
+        post_model_load_hook = _post_model_load_hook
+    elif impl_cfg.optimizer is not None:
+        raise ValueError(f"Unknown kimi_k2 lite optimizer: {impl_cfg.optimizer!r}.")
+
+    return ModelBundle(
+        chunks=chunks,
+        parallel_state=ps,
+        optimizer=optimizer,
+        finalize_grads=finalize_grads,
+        forward_step=_forward_step,
+        extras={
+            "model_cfg": model_cfg,
+            "optimizer_backend": optimizer_backend,
+            "post_model_load_hook": post_model_load_hook,
+            "pre_forward_hook": _make_aux_loss_hook(),
+        },
+    )
+
+
+def load_hf_weights(
+    chunk: nn.Module, hf_path: str, model_cfg: KimiK2Config, ps: ParallelState
+) -> None:
+    if not hf_path:
+        return
+    from megatron.lite.model.kimi_k2.lite.checkpoint import load_hf_weights as load_impl
+
+    load_impl(chunk, hf_path, model_cfg, ps)
+
+
+def export_hf_weights(chunks, model_cfg: KimiK2Config, ps: ParallelState, **kwargs):
+    from megatron.lite.model.kimi_k2.lite.checkpoint import export_hf_weights as export_impl
+
+    yield from export_impl(chunks, model_cfg, ps, **kwargs)
+
+
+def vocab_size(model_cfg) -> int | None:
+    cfg = getattr(model_cfg, "text_config", model_cfg)
+    return getattr(cfg, "vocab_size", None)
+
+
+__all__ = [
+    "EXPERT_CLASSIFIER",
+    "ImplConfig",
+    "PLACEMENT_FN",
+    "build_model",
+    "build_model_config",
+    "export_hf_weights",
+    "is_expert_param",
+    "load_hf_weights",
+    "vocab_size",
+]

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/model.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/model.py
@@ -15,7 +15,6 @@ import torch.nn as nn
 import transformer_engine.pytorch as te
 
 from megatron.lite.model.qwen3_5.config import Qwen35Config
-from megatron.lite.primitive.kernels.swiglu import bias_swiglu_impl
 from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
 from megatron.lite.primitive.modules.experts import Experts, swiglu_with_probs
 from megatron.lite.primitive.modules.gated_delta_net import GatedDeltaNet
@@ -233,7 +232,7 @@ class Qwen35Layer(nn.Module):
         moe_act_recompute: bool = False,
         use_thd: bool = False,
         deterministic: bool = False,
-        gdn_cp_mode: str = "fla_allgather",
+        gdn_cp_mode: str = "replicated",
     ):
         super().__init__()
         self.layer_idx = layer_idx
@@ -336,7 +335,7 @@ class Qwen35Model(nn.Module):
         mtp_enable_train: bool = False,
         mtp_detach_encoder: bool = False,
         mount_vision_model: bool = False,
-        gdn_cp_mode: str = "fla_allgather",
+        gdn_cp_mode: str = "replicated",
     ):
         super().__init__()
         del attention_backend_override

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
@@ -66,7 +66,7 @@ class ImplConfig:
     mtp_loss_scaling_factor: float = 0.1
     mtp_use_repeated_layer: bool | None = None
     mount_vision_model: bool = False
-    gdn_cp_mode: str = "fla_allgather"
+    gdn_cp_mode: str = "replicated"
 
 
 def _full_attn_module(layer, name: str):

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
@@ -132,6 +132,11 @@ def _forward_step(model: nn.Module, batch: PackedBatch) -> dict:
     return model(**kwargs)
 
 
+def _forward_step_bshd(model: nn.Module, batch: PackedBatch) -> dict:
+    labels = batch.labels.reshape(1, -1) if batch.labels is not None else None
+    return model(input_ids=batch.input_ids.reshape(1, -1), labels=labels, packed_seq_params=None)
+
+
 def unpack_forward_output(model: nn.Module, batch: PackedBatch, output) -> Any:
     return unpack_thd_forward_output(model, batch, output)
 
@@ -278,7 +283,7 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
         parallel_state=ps,
         optimizer=optimizer,
         finalize_grads=finalize_grads,
-        forward_step=_forward_step,
+        forward_step=_forward_step if impl_cfg.use_thd else _forward_step_bshd,
         extras={
             "model_cfg": model_cfg,
             # Lite's router uses megatron.lite's MoEAuxLossAutoScaler; hand the

--- a/experimental/lite/megatron/lite/model/registry.py
+++ b/experimental/lite/megatron/lite/model/registry.py
@@ -92,6 +92,27 @@ register_model(
     impls={"lite": "megatron.lite.model.qwen3_5.lite.protocol"},
 )
 
+register_model(
+    "kimi_k2",
+    package="megatron.lite.model.kimi_k2",
+    hf_model_types=["kimi_k2", "deepseek_v3"],
+    impls={"lite": "megatron.lite.model.kimi_k2.lite.protocol"},
+)
+
+register_model(
+    "glm5",
+    package="megatron.lite.model.glm5",
+    hf_model_types=["glm_moe_dsa"],
+    impls={"lite": "megatron.lite.model.glm5.lite.protocol"},
+)
+
+register_model(
+    "deepseek_v4",
+    package="megatron.lite.model.deepseek_v4",
+    hf_model_types=["deepseek_v4"],
+    impls={"lite": "megatron.lite.model.deepseek_v4.lite.protocol"},
+)
+
 
 # ---------------------------------------------------------------------------
 # Lookup functions

--- a/experimental/lite/megatron/lite/primitive/ckpt/distckpt.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/distckpt.py
@@ -70,6 +70,7 @@ def save_dist_opt_checkpoint(
     """Save model and DistributedOptimizer state through mcore dist_checkpointing."""
 
     os.makedirs(checkpoint_dir, exist_ok=True)
+    metadata = _dist_opt_checkpoint_metadata(optimizer)
     model_sd = _model_sharded_state_dict(model) if save_model or save_optimizer else {}
     state_dict: dict[str, Any] = {"step": int(step)}
     if save_model:
@@ -79,7 +80,7 @@ def save_dist_opt_checkpoint(
         patches = _patch_empty_native_optimizer_state_dicts(optimizer, fallback_step=step)
         try:
             state_dict["optimizer"] = optimizer.sharded_state_dict(
-                _single_or_all_model_state(model_sd), metadata=_DISTOPT_METADATA
+                _single_or_all_model_state(model_sd), metadata=metadata
             )
         finally:
             _restore_state_dict_patches(patches)
@@ -87,7 +88,7 @@ def save_dist_opt_checkpoint(
         state_dict,
         checkpoint_dir,
         validate_access_integrity=False,
-        content_metadata=_DISTOPT_METADATA,
+        content_metadata=metadata,
     )
 
 
@@ -101,6 +102,7 @@ def load_dist_opt_checkpoint(
 ) -> int:
     """Load a mcore dist_checkpointing checkpoint into model and DistributedOptimizer."""
 
+    metadata = _dist_opt_checkpoint_metadata(optimizer)
     model_sd = _model_sharded_state_dict(model) if load_model or load_optimizer else {}
     load_sd: dict[str, Any] = {"step": 0}
     if load_model:
@@ -109,7 +111,7 @@ def load_dist_opt_checkpoint(
         patches = _patch_empty_native_optimizer_state_dicts(optimizer, fallback_step=0)
         try:
             load_sd["optimizer"] = optimizer.sharded_state_dict(
-                _single_or_all_model_state(model_sd), is_loading=True, metadata=_DISTOPT_METADATA
+                _single_or_all_model_state(model_sd), is_loading=True, metadata=metadata
             )
         finally:
             _restore_state_dict_patches(patches)
@@ -259,6 +261,14 @@ def _iter_distributed_optimizers(optimizer: Any) -> Iterable[Any]:
             yield from visit(child)
 
     yield from visit(optimizer)
+
+
+def _dist_opt_checkpoint_metadata(optimizer: Any) -> dict[str, Any]:
+    dist_opts = tuple(_iter_distributed_optimizers(optimizer))
+    return {
+        **_DISTOPT_METADATA,
+        "distrib_optim_fully_reshardable_mem_efficient": bool(dist_opts) and all(getattr(opt, "data_parallel_group_gloo", None) is not None for opt in dist_opts),
+    }
 
 
 def _iter_optimizer_children(obj: Any, *, known_inner: Any | None = None) -> Iterable[Any]:

--- a/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
@@ -23,6 +23,28 @@ import torch.nn as nn
 from safetensors import safe_open
 from safetensors.torch import save_file as _safe_save
 
+try:
+    from torch.distributed.tensor import DTensor
+except Exception:  # pragma: no cover - older torch without DTensor
+    DTensor = None  # type: ignore[assignment]
+
+
+def _materialize_dtensor(tensor: torch.Tensor) -> torch.Tensor:
+    """Reconstruct a plain local tensor from an FSDP2 ``DTensor`` parameter.
+
+    FSDP2 (``fully_shard``) stores parameters as ``DTensor`` sharded over the
+    data-parallel mesh, while manual TP/EP sharding leaves each rank holding its
+    own local shard as a regular tensor. The HF export gather (``_gather_dense`` /
+    ``_gather_expert``) and the downstream rollout weight sender both assume plain
+    ``torch.Tensor`` inputs; handing them a ``DTensor`` raises
+    ``aten.copy_.default: got mixed torch.Tensor and DTensor``. ``full_tensor()``
+    gathers the FSDP shards back into the full (TP/EP-local) tensor; non-DTensor
+    params (dist_opt backend) pass through untouched.
+    """
+    if DTensor is not None and isinstance(tensor, DTensor):
+        return tensor.full_tensor()
+    return tensor
+
 
 @runtime_checkable
 class HFWeights(Protocol):
@@ -406,7 +428,7 @@ def export_hf_weights(
             )
             for name, param in base_chunk.named_parameters():
                 gname = to_global_layer_name(name, layer_map)
-                tensor = param.data.detach()
+                tensor = _materialize_dtensor(param.data.detach())
 
                 gathered_one: dict[str, torch.Tensor] = {}
                 if spec.is_expert(gname):
@@ -454,7 +476,7 @@ def export_hf_weights(
         )
         for name, param in base_chunk.named_parameters():
             gname = to_global_layer_name(name, layer_map)
-            t = param.data.detach()
+            t = _materialize_dtensor(param.data.detach())
 
             if spec.is_expert(gname):
                 _gather_expert(gname, t, spec, ps, gathered)
@@ -555,10 +577,17 @@ def _gather_expert_group(
                 ).cpu()
                 return
 
-            stacked = torch.stack([tensor.contiguous() for _, _, tensor in prepared], dim=0)
-            ep_gathered = [torch.empty_like(stacked) for _ in range(ps.ep_size)]
-            dist.all_gather(ep_gathered, stacked, group=ps.ep_group)
-            out[packed_name] = torch.cat(ep_gathered, dim=0).cpu()
+            sample = prepared[0][2]
+            packed = torch.empty((spec.num_experts, *sample.shape), dtype=sample.dtype, device="cpu")
+            for batch_start in range(0, len(prepared), 4):
+                batch = prepared[batch_start : batch_start + 4]
+                stacked = torch.stack([tensor.contiguous() for _, _, tensor in batch], dim=0)
+                ep_gathered = [torch.empty_like(stacked) for _ in range(ps.ep_size)]
+                dist.all_gather(ep_gathered, stacked, group=ps.ep_group)
+                for ep_rank, ep_tensor in enumerate(ep_gathered):
+                    for batch_idx, (local_idx, _, _) in enumerate(batch):
+                        packed[ep_rank * (spec.num_experts // ps.ep_size) + local_idx].copy_(ep_tensor[batch_idx])
+            out[packed_name] = packed
             return
 
     if ps.ep_size <= 1 or ps.ep_group is None:

--- a/experimental/lite/megatron/lite/primitive/modules/gated_delta_net.py
+++ b/experimental/lite/megatron/lite/primitive/modules/gated_delta_net.py
@@ -66,10 +66,10 @@ class GatedDeltaNet(nn.Module):
         rms_norm_eps: float,
         ps: ParallelState,
         deterministic: bool = False,
-        cp_mode: str = "fla_allgather",
+        cp_mode: str = "replicated",
     ):
         super().__init__()
-        if cp_mode not in {"fla_allgather", "legacy_full_gather"}:
+        if cp_mode not in {"sharded", "replicated"}:
             raise ValueError(f"Unsupported GatedDeltaNet CP mode: {cp_mode!r}.")
         self.ps = ps
         self.deterministic = bool(deterministic)
@@ -125,13 +125,13 @@ class GatedDeltaNet(nn.Module):
         qkvzba = self.in_proj(x).transpose(0, 1).contiguous()
         cu_seqlens = self._packed_cu_seqlens(packed_seq_params) if is_packed else None
         cp_context = None
-        legacy_full_gather = False
+        replicated = False
         if self.ps.cp_size > 1:
             if self.ps.cp_group is None:
                 raise RuntimeError("CP>1 requires ParallelState.cp_group.")
-            if self.cp_mode == "legacy_full_gather":
-                qkvzba, cu_seqlens = self._legacy_full_gather_qkvzba(qkvzba, cu_seqlens)
-                legacy_full_gather = True
+            if self.cp_mode == "replicated":
+                qkvzba, cu_seqlens = self._replicate_cp_qkvzba(qkvzba, cu_seqlens)
+                replicated = True
             else:
                 if not _HAS_FLA or _fla_build_cp_context is None:
                     raise NotImplementedError(
@@ -181,8 +181,8 @@ class GatedDeltaNet(nn.Module):
         out = self._apply_gated_norm(out, gate)
         out = out.reshape(batch, seq_len, self.v_dim_local)
         if self.ps.cp_size > 1:
-            if legacy_full_gather:
-                out = self._legacy_slice_output(out, cu_seqlens)
+            if replicated:
+                out = self._slice_replicated_output(out, cu_seqlens)
             else:
                 out = self._cp_swap_qkvzba(
                     out,
@@ -205,7 +205,7 @@ class GatedDeltaNet(nn.Module):
             torch.distributed.all_gather(parts, tensor, group=self.ps.cp_group)
             return parts
 
-    def _legacy_full_gather_qkvzba(
+    def _replicate_cp_qkvzba(
         self,
         qkvzba: torch.Tensor,
         cu_seqlens: torch.Tensor | None,
@@ -224,7 +224,7 @@ class GatedDeltaNet(nn.Module):
         )
         return full.unsqueeze(0).contiguous(), cu_seqlens
 
-    def _legacy_slice_output(
+    def _slice_replicated_output(
         self,
         out: torch.Tensor,
         cu_seqlens: torch.Tensor | None,

--- a/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/adamw.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/adamw.py
@@ -261,7 +261,12 @@ class FP32AdamW:
             if not isinstance(loaded, list) or len(loaded) != len(self.params):
                 raise ValueError(f"Invalid FP32 AdamW {target_name} state.")
             for param, src in zip(self.params, loaded, strict=True):
-                self.state[param][key].copy_(src)
+                target = self.state[param][key]
+                local_target = to_local_tensor(target)
+                local_src = to_local_tensor(src).to(
+                    device=local_target.device, dtype=local_target.dtype
+                )
+                local_target.copy_(local_src)
         loaded_steps = state_dict.get("steps")
         if loaded_steps is not None:
             if not isinstance(loaded_steps, list) or len(loaded_steps) != len(self.params):
@@ -283,6 +288,9 @@ class FP32AdamW:
                     continue
                 group["weight_decay"] = float(loaded_weight_decays[idx])
                 idx += len(group["params"])
+
+        for param in self.params:
+            self._copy_master_to_param(param, self.state[param]["master_param"])
 
 
 def build_adamw_optimizer(

--- a/experimental/lite/megatron/lite/primitive/utils/moe.py
+++ b/experimental/lite/megatron/lite/primitive/utils/moe.py
@@ -8,6 +8,7 @@ from typing import Optional, Tuple
 import torch
 
 from transformer_engine.pytorch.cpp_extensions import general_gemm
+from transformer_engine.pytorch.module import base as te_module_base
 from transformer_engine.pytorch.permutation import moe_permute as fused_permute
 from transformer_engine.pytorch.permutation import (
     moe_permute_and_pad_with_probs as fused_permute_and_pad_with_probs,
@@ -33,7 +34,10 @@ def _te_general_gemm(
     bias: torch.Tensor | None = None,
     grad: bool = False,
 ):
+    if (get_workspace := getattr(te_module_base, "get_workspace", None)) is None:
+        return None
     kwargs = dict(
+        workspace=get_workspace(),
         out_dtype=out_dtype,
         quantization_params=None,
         gelu=None,

--- a/experimental/lite/megatron/lite/runtime/backends/bridge/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/bridge/runtime.py
@@ -786,11 +786,6 @@ class BridgeRuntime(RuntimeBase):
             micro_batch_size=1,
         )
 
-        if not forward_only:
-            from megatron.core.distributed.finalize_model_grads import finalize_model_grads
-
-            finalize_model_grads(model_list)
-
         loss_val = last_loss[0]
         if mpu.get_pipeline_model_parallel_world_size() > 1:
             loss_t = torch.tensor([loss_val or 0.0], device="cuda")

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
@@ -16,7 +16,7 @@ from megatron.lite.runtime.backends import Runtime as RuntimeBase
 from megatron.lite.runtime.backends.mlite.config import MegatronLiteConfig
 from megatron.lite.runtime.contracts.data import ForwardResult, ModelOutputs, PackedBatch
 from megatron.lite.runtime.contracts.handle import ModelHandle
-from megatron.lite.runtime.contracts.loss import split_loss_context
+from megatron.lite.runtime.contracts.loss import get_loss_context, split_loss_context, use_loss_context
 
 
 def _build_impl_cfg(proto, rt_cfg: MegatronLiteConfig):
@@ -131,6 +131,27 @@ def _checkpoint_module(model: Any) -> torch.nn.Module:
     raise TypeError(
         f"Checkpoint model must be an nn.Module or sequence of modules, got {type(model).__name__}."
     )
+
+
+def _pipeline_callbacks(forward_step: Callable, loss_fn: Callable | None):
+    def wrapped_forward_step(model, item):
+        batch, loss_context = split_loss_context(item)
+        if loss_context is None:
+            return forward_step(model, batch)
+        with use_loss_context(loss_context):
+            return forward_step(model, batch)
+
+    if loss_fn is None:
+        return wrapped_forward_step, None
+
+    def wrapped_loss_fn(output, item, loss_context=None):
+        batch, item_loss_context = split_loss_context(item)
+        loss_context = loss_context or item_loss_context or get_loss_context()
+        if loss_context is None:
+            return loss_fn(output, batch)
+        return loss_fn(output, batch, loss_context)
+
+    return wrapped_forward_step, wrapped_loss_fn
 
 
 class MegatronLiteRuntime(RuntimeBase):
@@ -409,6 +430,7 @@ class MegatronLiteRuntime(RuntimeBase):
         if ps.pp_size > 1:
             from types import SimpleNamespace
 
+            from megatron.lite.primitive.ckpt.hf_weights import unwrap_model
             from megatron.lite.primitive.parallel.pipeline import forward_backward_pipelining
 
             first_item = next(data_iter)
@@ -417,15 +439,18 @@ class MegatronLiteRuntime(RuntimeBase):
             tensor_shape = _infer_pipeline_tensor_shape(
                 first_batch, handle._extras.get("model_cfg"), ps
             )
+            model_chunks = handle._extras.get("model_chunks", [handle._model])
+            pipeline_chunks = [unwrap_model(chunk) for chunk in model_chunks]
+            pipeline_forward_step, pipeline_loss_fn = _pipeline_callbacks(forward_step, loss_fn)
             outputs = forward_backward_pipelining(
-                forward_step,
-                handle._extras.get("model_chunks", [handle._model]),
+                pipeline_forward_step,
+                pipeline_chunks,
                 data_iter,
                 SimpleNamespace(num_microbatches=num_microbatches),
                 ps,
                 tensor_shape=tensor_shape,
                 pre_forward_hook=handle._extras.get("pre_forward_hook"),
-                loss_fn=loss_fn,
+                loss_fn=pipeline_loss_fn,
                 forward_only=forward_only,
             )
             out = _last_loss_output(outputs)
@@ -434,12 +459,14 @@ class MegatronLiteRuntime(RuntimeBase):
                 loss_float = float(loss_obj.detach().item())
             elif loss_obj is not None:
                 loss_float = float(loss_obj)
-            else:
-                loss_float = 0.0
-            loss_t = torch.tensor([loss_float], device="cuda")
+            loss_payload = torch.tensor(
+                [loss_obj is not None, loss_float if loss_obj is not None else 0.0],
+                device="cuda",
+                dtype=torch.float32,
+            )
             if ps.pp_group is not None and ps.pp_global_ranks is not None:
-                dist.broadcast(loss_t, src=ps.pp_global_ranks[-1], group=ps.pp_group)
-            out = {"loss": loss_t.squeeze(0)}
+                dist.broadcast(loss_payload, src=ps.pp_global_ranks[-1], group=ps.pp_group)
+            out = {"loss": loss_payload[1]} if bool(loss_payload[0].item()) else {}
         else:
             out = run_microbatch_loop(
                 handle._model,
@@ -459,22 +486,13 @@ class MegatronLiteRuntime(RuntimeBase):
                 finalize_grads()
 
         loss_tensor = out.get("loss") if out else None
-        loss_val = (
-            loss_tensor.item()
-            if isinstance(loss_tensor, torch.Tensor)
-            else float(loss_tensor or 0.0)
-        )
-        metrics: dict = {"loss": loss_val}
-        for m in out.get("_loss_fn_metrics", []) if out else []:
-            for k, v in m.items():
-                if k not in metrics:
-                    metrics[k] = v
+        metric_rows = out.get("_loss_fn_metrics", []) if out else []
         if ps.pp_size > 1:
-            for item in outputs:
-                for k, v in item.get("metrics", {}).items():
-                    if k not in metrics:
-                        metrics[k] = v
-            metrics["_micro_outputs"] = outputs
+            metric_rows += [item["metrics"] for item in outputs if item.get("metrics")]
+        metrics: dict = {}
+        for row in metric_rows:
+            for key, value in row.items():
+                metrics.setdefault(key, []).append(value)
 
         return ForwardResult(
             model_output=ModelOutputs(

--- a/experimental/lite/skills/application/miles.md
+++ b/experimental/lite/skills/application/miles.md
@@ -1,0 +1,15 @@
+# Miles Application Skill
+
+Use this when wiring Megatron Lite into radixark/miles examples.
+
+- Keep the external miles CLI backend as `--train-backend megatron`; the MLite
+  integration is activated by importing `miles_mlite.backend_patch` before miles
+  constructs `RayTrainGroup`.
+- Add `experimental/lite`, `experimental/lite/examples`, this repository root,
+  and the miles checkout to `PYTHONPATH` for both the driver and Ray runtime
+  environment.
+- Use `--model-name qwen3_moe` and `--megatron-to-hf-mode raw` for Qwen3 MoE
+  rollout resync. MLite `export_weights` already emits HF-format tensors.
+- Use user-facing optimizer naming `dist_opt` in example CLI text.
+- GPU validation must go through Slurm/container. Dry-run output is not evidence
+  of a passed SFT or GRPO path.

--- a/experimental/lite/tests/smoke/model/test_glm5_lite_fsdp2_smoke.py
+++ b/experimental/lite/tests/smoke/model/test_glm5_lite_fsdp2_smoke.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pytestmark = [pytest.mark.mlite, pytest.mark.smoke, pytest.mark.gpu, pytest.mark.distributed]
+
+
+def _init_dist_or_skip():
+    import torch
+    import torch.distributed as dist
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for GLM5 FSDP2 smoke.")
+    if "RANK" not in os.environ or "WORLD_SIZE" not in os.environ:
+        pytest.skip("Run with torchrun so FSDP2 ranks are available.")
+    if int(os.environ.get("WORLD_SIZE", "1")) < 2:
+        pytest.skip("GLM5 FSDP2 smoke requires at least 2 ranks.")
+    if int(os.environ.get("WORLD_SIZE", "1")) > 8:
+        pytest.skip("Megatron Lite smoke tests are capped at single-node 8 GPUs.")
+
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    torch.cuda.set_device(local_rank)
+    created_pg = False
+    if not dist.is_initialized():
+        dist.init_process_group("nccl")
+        created_pg = True
+    yield torch.device("cuda", local_rank)
+    if created_pg and dist.is_initialized():
+        dist.destroy_process_group()
+
+
+@pytest.fixture(scope="module")
+def cuda_dist():
+    yield from _init_dist_or_skip()
+
+
+def _tiny_config_kwargs():
+    return dict(
+        num_hidden_layers=2,
+        hidden_size=128,
+        num_attention_heads=64,
+        num_key_value_heads=64,
+        head_dim=256,
+        vocab_size=32,
+        max_position_embeddings=512,
+        initializer_range=0.002,
+        q_lora_rank=16,
+        kv_lora_rank=512,
+        qk_head_dim=256,
+        qk_nope_head_dim=192,
+        qk_rope_head_dim=64,
+        v_head_dim=256,
+        index_head_dim=128,
+        index_n_heads=32,
+        index_topk=512,
+        intermediate_size=20,
+        moe_intermediate_size=6,
+        first_k_dense_replace=1,
+        n_routed_experts=3,
+        n_shared_experts=1,
+        num_experts_per_tok=3,
+    )
+
+
+def test_glm5_tiny_model_builds_and_steps_with_fsdp2_backend(cuda_dist):
+    import torch
+
+    from megatron.lite.model.glm5.config import Glm5Config
+    from megatron.lite.model.glm5.lite import protocol
+    from megatron.lite.primitive.optimizers.fsdp2 import FSDP2Optimizer, fsdp2_available
+    from megatron.lite.runtime.contracts import OptimizerConfig, ParallelConfig
+
+    if not fsdp2_available():
+        pytest.skip("Installed PyTorch does not expose FSDP2 fully_shard.")
+
+    device = cuda_dist
+    cfg = Glm5Config(**_tiny_config_kwargs())
+    impl_cfg = protocol.ImplConfig(
+        parallel=ParallelConfig(),
+        optimizer="fsdp2",
+        optimizer_config=OptimizerConfig(
+            optimizer="adam", lr=1.0e-3, weight_decay=0.0, clip_grad=1.0, offload_fraction=0.0
+        ),
+        deterministic=True,
+    )
+
+    torch.manual_seed(20260612)
+    torch.cuda.manual_seed_all(20260612)
+    bundle = protocol.build_model(cfg, impl_cfg=impl_cfg)
+    assert bundle.extras["optimizer_backend"] == "fsdp2"
+    assert bundle.optimizer is None
+    assert callable(bundle.extras["post_model_load_hook"])
+
+    model = bundle.chunks[0]
+    model.initialize_weights()
+    updates = bundle.extras["post_model_load_hook"]()
+    bundle.optimizer = updates["optimizer"]
+    assert isinstance(bundle.optimizer, FSDP2Optimizer)
+
+    model.train()
+    batch, seq = 1, 512
+    input_ids = torch.randint(0, cfg.vocab_size, (batch, seq), device=device)
+    bundle.optimizer.zero_grad()
+    output = model(input_ids=input_ids)
+    assert output["logits"].shape == (batch, seq, cfg.vocab_size)
+    loss = output["logits"].float().square().mean()
+    assert torch.isfinite(loss)
+    loss.backward()
+
+    success, grad_norm, _ = bundle.optimizer.step()
+    assert success
+    assert torch.isfinite(torch.tensor(grad_norm, device=device))

--- a/experimental/lite/tests/smoke/primitive/test_auto_pipeline_layout_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_auto_pipeline_layout_smoke.py
@@ -1,0 +1,454 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Pipeline-layout smoke: real models build through the layout and train on PP>1.
+
+Builds {qwen3_5, qwen3_moe, kimi_k2, glm5, deepseek_v4} with ``num_hidden_layers=9``
+on pp=4 (not divisible) and asserts the layout drives a real model, not just the
+layout math: each builds, trains a finite-loss step over the uneven split, and HF
+export reconstructs every decoder layer. This exercises the auto layout mode on real
+models; the custom ``pp_layout`` string mode and the exact per-stage splits (incl.
+the real 43/61/78 counts) are pinned in the deterministic unit tests.
+
+Topology follows the save/load/export smoke's validated dist_opt capability:
+tp2/ep2 for TP-capable models, tp1/ep2 for glm5 / deepseek_v4 (native lite TP=1).
+CP=1: cp>1 on these tiny proxy seqs breaks TE attention backend selection
+(orthogonal to layout; covered by the dedicated CP smokes).
+
+Run: torchrun --nproc_per_node=8 -m pytest --mlite-smoke, selecting per-env subsets
+with -k (qwen3_5 on the qwen3.5 site; the rest on the DSA overlay). Models also
+gate themselves with importorskip.
+"""
+from __future__ import annotations
+
+import os
+import re
+from datetime import timedelta
+
+import pytest
+import torch
+import torch.distributed as dist
+from megatron.lite.primitive.ckpt.hf_weights import unwrap_model
+from megatron.lite.primitive.deterministic import set_deterministic
+from megatron.lite.runtime.backends.mlite.runtime import MegatronLiteRuntime
+from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig
+from megatron.lite.runtime.contracts.data import PackedBatch
+
+pytestmark = [pytest.mark.mlite, pytest.mark.smoke, pytest.mark.gpu, pytest.mark.distributed]
+
+# 9 decoders over pp=4 is non-divisible; 9 is small enough to stay fast yet leaves no
+# empty stage even for the MTP model (deepseek_v4 adds a slot on the last stage).
+_NUM_LAYERS = 9
+_PP = 4
+
+# GLM5 / DeepSeek-V4 native lite support TP=1 only (matches the save/load smoke).
+_TP1_ONLY = {"glm5", "deepseek_v4"}
+
+
+def _require_te() -> None:
+    te = pytest.importorskip(
+        "transformer_engine.pytorch",
+        reason="auto pipeline-layout smoke requires real Transformer Engine.",
+    )
+    assert hasattr(te, "Linear"), "smoke requires real Transformer Engine Linear."
+
+
+def _optimizer_config() -> OptimizerConfig:
+    return OptimizerConfig(
+        optimizer="adam",
+        lr=1.0e-3,
+        weight_decay=0.0,
+        adam_beta1=0.9,
+        adam_beta2=0.95,
+        adam_eps=1.0e-8,
+        clip_grad=1.0,
+        offload_fraction=0.0,
+    )
+
+
+def _random_packed_batch(vocab_size: int) -> PackedBatch:
+    return PackedBatch(
+        input_ids=torch.randint(0, vocab_size, (2048,), device="cuda"),
+        labels=torch.randint(0, vocab_size, (2048,), device="cuda"),
+        seq_lens=torch.full((1,), 2048, dtype=torch.int64, device="cuda"),
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Tiny non-divisible model configs (mirror the save/load smoke, num_hidden_layers=9).
+# ──────────────────────────────────────────────────────────────────────────
+def _qwen3_5():
+    pytest.importorskip("fla", reason="qwen3_5 needs the FLA / GatedDeltaNet stack.")
+    _require_te()
+    from megatron.lite.model.qwen3_5.config import Qwen35Config
+    from megatron.lite.model.qwen3_5.lite import protocol
+
+    cfg = Qwen35Config(
+        num_hidden_layers=_NUM_LAYERS,
+        hidden_size=16,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=4,
+        vocab_size=64,
+        num_experts=4,
+        num_experts_per_tok=2,
+        moe_intermediate_size=8,
+        shared_expert_intermediate_size=8,
+        linear_num_key_heads=2,
+        linear_key_head_dim=4,
+        linear_num_value_heads=2,
+        linear_value_head_dim=4,
+        linear_conv_kernel_dim=4,
+        layer_types=(["full_attention", "linear_attention"] * ((_NUM_LAYERS + 1) // 2))[
+            :_NUM_LAYERS
+        ],
+        partial_rotary_factor=1.0,
+        max_position_embeddings=4096,
+    )
+    return cfg, protocol
+
+
+def _qwen3_moe():
+    _require_te()
+    from megatron.lite.model.qwen3_moe.config import Qwen3MoEConfig
+    from megatron.lite.model.qwen3_moe.lite import protocol
+
+    cfg = Qwen3MoEConfig(
+        num_hidden_layers=_NUM_LAYERS,
+        hidden_size=16,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=4,
+        vocab_size=64,
+        num_experts=4,
+        num_experts_per_tok=1,
+        moe_intermediate_size=8,
+        max_position_embeddings=4096,
+        layer_types=["full_attention"] * _NUM_LAYERS,
+    )
+    return cfg, protocol
+
+
+def _kimi_k2():
+    _require_te()
+    from megatron.lite.model.kimi_k2.config import KimiK2Config
+    from megatron.lite.model.kimi_k2.lite import protocol
+
+    cfg = KimiK2Config(
+        num_hidden_layers=_NUM_LAYERS,
+        hidden_size=64,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        vocab_size=128,
+        intermediate_size=96,
+        moe_intermediate_size=16,
+        n_routed_experts=4,
+        n_shared_experts=1,
+        num_experts_per_tok=2,
+        n_group=2,
+        topk_group=1,
+        first_k_dense_replace=1,
+        q_lora_rank=16,
+        kv_lora_rank=12,
+        qk_nope_head_dim=8,
+        qk_rope_head_dim=8,
+        v_head_dim=8,
+        max_position_embeddings=4096,
+        rope_theta=10000.0,
+        rope_scaling={
+            "type": "yarn",
+            "factor": 1.0,
+            "original_max_position_embeddings": 4096,
+            "beta_fast": 1.0,
+            "beta_slow": 1.0,
+            "mscale": 1.0,
+            "mscale_all_dim": 1.0,
+        },
+    )
+    return cfg, protocol
+
+
+def _glm5():
+    pytest.importorskip("cudnn", reason="glm5 fused DSA needs the cudnn DSA stack.")
+    _require_te()
+    from megatron.lite.model.glm5.config import Glm5Config
+    from megatron.lite.model.glm5.lite import protocol
+
+    cfg = Glm5Config(
+        num_hidden_layers=_NUM_LAYERS,
+        hidden_size=128,
+        num_attention_heads=64,
+        num_key_value_heads=64,
+        head_dim=256,
+        vocab_size=32,
+        max_position_embeddings=4096,
+        initializer_range=0.002,
+        q_lora_rank=16,
+        kv_lora_rank=512,
+        qk_head_dim=256,
+        qk_nope_head_dim=192,
+        qk_rope_head_dim=64,
+        v_head_dim=256,
+        index_head_dim=128,
+        index_n_heads=32,
+        index_topk=512,
+        intermediate_size=20,
+        moe_intermediate_size=6,
+        first_k_dense_replace=1,
+        n_routed_experts=4,
+        n_shared_experts=1,
+        num_experts_per_tok=2,
+    )
+    return cfg, protocol
+
+
+def _deepseek_v4():
+    pytest.importorskip("cudnn", reason="deepseek_v4 fused DSA needs the cudnn DSA stack.")
+    _require_te()
+    from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
+    from megatron.lite.model.deepseek_v4.lite import protocol
+
+    cfg = DeepseekV4Config(
+        vocab_size=64,
+        hidden_size=128,
+        moe_intermediate_size=16,
+        num_hidden_layers=_NUM_LAYERS,
+        num_attention_heads=8,
+        num_key_value_heads=1,
+        head_dim=64,
+        qk_rope_head_dim=16,
+        q_lora_rank=32,
+        o_lora_rank=32,
+        o_groups=2,
+        n_routed_experts=4,
+        n_shared_experts=1,
+        num_experts_per_tok=2,
+        routed_scaling_factor=1.5,
+        max_position_embeddings=4096,
+        compress_ratios=[4, 4],
+        sliding_window=128,
+        num_hash_layers=2,
+        hc_mult=2,
+        index_head_dim=64,
+        index_n_heads=8,
+        index_topk=512,
+        # Real MTP: an extra nextn layer on the last stage exercises the
+        # MTP-aware branch of the auto layout balancing.
+        num_nextn_predict_layers=1,
+        rms_norm_eps=1e-6,
+    )
+    return cfg, protocol
+
+
+MODELS = {
+    "qwen3_5": _qwen3_5,
+    "qwen3_moe": _qwen3_moe,
+    "kimi_k2": _kimi_k2,
+    "glm5": _glm5,
+    "deepseek_v4": _deepseek_v4,
+}
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Distributed harness (mirrors the save/load/export smoke).
+# ──────────────────────────────────────────────────────────────────────────
+@pytest.fixture(scope="module", autouse=True)
+def _single_node_cuda_dist():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for auto pipeline-layout smoke.")
+    if int(os.environ.get("WORLD_SIZE", "1")) > 8:
+        pytest.skip("Megatron Lite smoke tests are capped at single-node 8 GPUs.")
+
+    os.environ.setdefault("CUBLAS_WORKSPACE_CONFIG", ":4096:8")
+    os.environ.setdefault("NVTE_ALLOW_NONDETERMINISTIC_ALGO", "0")
+    os.environ.setdefault("RANK", "0")
+    os.environ.setdefault("WORLD_SIZE", "1")
+    os.environ.setdefault("LOCAL_RANK", "0")
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", "29577")
+
+    torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
+    created_pg = False
+    if not dist.is_initialized():
+        timeout_s = int(os.environ.get("MLITE_DIST_TIMEOUT_S", "180"))
+        dist.init_process_group(
+            backend="nccl", init_method="env://", timeout=timedelta(seconds=timeout_s)
+        )
+        created_pg = True
+    yield
+    try:
+        from megatron.core import parallel_state as mpu
+
+        if mpu.is_initialized():
+            mpu.destroy_model_parallel()
+    finally:
+        if created_pg and dist.is_initialized():
+            dist.destroy_process_group()
+
+
+# Process groups lite's init_parallel creates per build, recorded so the autouse
+# teardown can free them (mcore's destroy_model_parallel frees only mcore's groups).
+_BUILT_PARALLEL_STATES: list = []
+_PS_GROUP_ATTRS = (
+    "tp_group", "ep_group", "etp_group", "cp_group", "pp_group", "pp_cpu_group",
+    "dp_group", "dp_cp_group", "tp_ep_group", "ep_dp_group",
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_parallel_state_between_tests():
+    yield
+    import gc
+
+    from megatron.core import parallel_state as mpu
+
+    if mpu.is_initialized():
+        mpu.destroy_model_parallel()
+    # Finalize the just-built model first so DDP releases its group references, then
+    # explicitly destroy the process groups lite's init_parallel created for this
+    # test. Without this, lite's ~10 fresh NCCL/gloo groups per build leak across the
+    # ~6 builds in one torchrun process and make a later PP P2P / export collective
+    # fail nondeterministically (mcore's destroy_model_parallel frees only its own).
+    gc.collect()
+    for ps in _BUILT_PARALLEL_STATES:
+        for attr in _PS_GROUP_ATTRS:
+            group = getattr(ps, attr, None)
+            if group is not None:
+                try:
+                    dist.destroy_process_group(group)
+                except Exception:
+                    pass
+    _BUILT_PARALLEL_STATES.clear()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+
+def _proxy_topology(model_name: str, pp_layout=None) -> ParallelConfig:
+    # PP is held at 4 (the layout axis under test); the rest follow the save/load
+    # smoke's validated dist_opt capability. CP=1 — see module docstring.
+    # pp_layout=None -> auto mode; a string -> custom mode (advanced explicit layout).
+    if model_name in _TP1_ONLY:  # glm5 / deepseek_v4: native lite is TP=1 only.
+        return ParallelConfig(tp=1, ep=2, etp=1, pp=_PP, cp=1, pp_layout=pp_layout)
+    return ParallelConfig(tp=2, ep=2, etp=1, pp=_PP, cp=1, pp_layout=pp_layout)
+
+
+def _build_handle(model_name: str, *, seed: int, pp_layout=None):
+    from types import SimpleNamespace
+
+    from megatron.lite.runtime.contracts.handle import ModelHandle
+
+    cfg, protocol = MODELS[model_name]()
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+    parallel = _proxy_topology(model_name, pp_layout=pp_layout)
+    impl_cfg = protocol.ImplConfig(
+        parallel=parallel,
+        optimizer="dist_opt",
+        optimizer_config=_optimizer_config(),
+        use_deepep=False,
+        deterministic=True,
+    )
+    bundle = protocol.build_model(cfg, impl_cfg=impl_cfg)
+    chunks = bundle.chunks
+    extras = dict(bundle.extras)
+    extras.update(
+        {
+            "model_chunks": chunks,
+            "forward_step": bundle.forward_step,
+            "finalize_grads": bundle.finalize_grads,
+            "protocol": protocol,
+        }
+    )
+    handle = ModelHandle(
+        model=chunks,
+        optimizer=bundle.optimizer,
+        parallel_state=bundle.parallel_state,
+        config=SimpleNamespace(parallel=parallel),
+        _extras=extras,
+    )
+    _BUILT_PARALLEL_STATES.append(bundle.parallel_state)
+    return handle, cfg
+
+
+def _local_layer_indices(handle) -> list[int]:
+    chunk = unwrap_model(handle._extras["model_chunks"][0])
+    return list(chunk.layer_indices)
+
+
+# Decoder layer ids in exported HF names: matches both `model.layers.N.` (HF-rooted,
+# most models) and bare `layers.N.` (deepseek_v4-flash release naming).
+_HF_LAYER_RE = re.compile(r"(?:^|\.)layers\.(\d+)\.")
+
+
+def _hf_decoder_layer_indices(names) -> set[int]:
+    """Decoder layer ids referenced by exported HF weight names (``...layers.N...``)."""
+    return {int(m.group(1)) for n in names if (m := _HF_LAYER_RE.search(n))}
+
+
+@pytest.mark.parametrize("model_name", list(MODELS))
+def test_uneven_pp_builds_trains_and_exports(model_name):
+    """A non-divisible layer count builds an uneven PP split, trains a step, and
+    exports every layer. Build + train + export share one model build (one heavy
+    distributed build per test keeps the builds in one torchrun process bounded).
+
+    - build: the non-divisible count produces a valid balanced uneven split (not
+      "not divisible"); this stage owns a sorted, in-range, contiguous decoder run.
+    - train: one real step over the uneven pipeline yields a finite loss (proves PP
+      P2P across stages of unequal depth actually runs the built model).
+    - export: HF export all-gathers the per-stage shards (keyed on global layer
+      names) back to a complete state — every decoder layer 0..N-1 reconstructed,
+      every tensor finite. Regression guard for the deepseek_v4 local-vs-global
+      layer-key bug; a dropped/duplicated stage would silently corrupt exports.
+    """
+    if dist.get_world_size() != 8:
+        pytest.skip("auto pipeline-layout proxy smoke requires exactly 8 GPUs.")
+
+    set_deterministic(2026)
+
+    handle, cfg = _build_handle(model_name, seed=4242)
+    ps = handle._parallel_state
+    assert ps.pp_size == _PP
+    assert cfg.num_hidden_layers == _NUM_LAYERS
+
+    local = _local_layer_indices(handle)
+    assert local == sorted(local) and len(set(local)) == len(local), local
+    assert local and all(0 <= i < _NUM_LAYERS for i in local), local
+    assert local == list(range(local[0], local[0] + len(local))), local
+
+    runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
+    batch = _random_packed_batch(cfg.vocab_size)
+    runtime.zero_grad(handle)
+    result = runtime.forward_backward(handle, iter([batch]), None, num_microbatches=1)
+    runtime.optimizer_step(handle)
+    loss = result.model_output.loss
+    assert loss is not None and torch.isfinite(loss).all(), (
+        f"{model_name}: non-finite loss {loss} on uneven PP layout"
+    )
+
+    # Export across the uneven PP split (every rank materializes the full HF state).
+    protocol = handle._extras["protocol"]
+    chunks = handle._extras["model_chunks"]
+    exported = list(protocol.export_hf_weights(chunks, cfg, ps))
+    present = _hf_decoder_layer_indices([name for name, _ in exported])
+    expected = set(range(cfg.num_hidden_layers))
+    assert expected.issubset(present), (
+        f"{model_name}: uneven-PP export dropped decoder layers "
+        f"{sorted(expected - present)} (have {sorted(present)}); PP gather lost a stage"
+    )
+    for name, tensor in exported:
+        assert torch.isfinite(tensor.float()).all(), (
+            f"{model_name}: non-finite exported tensor {name} from uneven PP gather"
+        )
+    if dist.get_rank() == 0:
+        print(
+            "NON_SKIP_UNEVEN_PP_BUILD_TRAIN_EXPORT "
+            f"model={model_name} num_layers={cfg.num_hidden_layers} "
+            f"split={local} exported_decoder_layers={len(present & expected)}"
+        )
+
+
+# Custom-string mode (``ParallelConfig.pp_layout``) is covered by the deterministic
+# unit tests (test_parallel_unit.py: the explicit string is honored verbatim, differs
+# from the auto split, and a >pp-stage string raises). It shares the build path with
+# the auto matrix above (only ``ps.pp_layout`` differs), so it is not given a separate
+# GPU build here: keeping this smoke to one heavy distributed build per model avoids a
+# trailing build tripping NCCL P2P comm-init timeouts from process-group churn.

--- a/experimental/lite/tests/smoke/primitive/test_qwen35_hf_numeric_roundtrip_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_qwen35_hf_numeric_roundtrip_smoke.py
@@ -1,0 +1,224 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Qwen3.5 HF<->lite checkpoint NUMERIC round-trip + ground-truth smoke.
+
+The existing export unit tests (tests/unit/model/test_qwen35_export.py) and the
+save/load/export coverage smoke only assert NAMES / DTYPE / FINITENESS, never
+numeric fidelity — so a transform that is self-consistent on the round-trip but
+wrong vs real HF would pass silently. This smoke closes that blind spot:
+
+  test_qwen35_save_load_numeric_roundtrip
+    build A(seed1) -> save_hf -> build B(seed2) -> load_hf(B) -> assert every
+    param allclose(A, B). Catches ASYMMETRIC load/export bugs (load != inverse
+    of export). Vocab embed/head rows >= vocab_size are unused TP-padding (random
+    in A, zeroed on reload) and are excluded; the real model has vocab%128==0 so
+    no padding exists.
+
+  test_qwen35_real_hf_load_export_matches_original  [opt-in: QWEN35_HF_DIR]
+    GROUND TRUTH against real Qwen3.5 safetensors: load real HF -> export ->
+    compare to the ORIGINAL safetensors tensor-by-tensor. Catches HF-file-level
+    mismatches that native round-trip cannot see. It does NOT prove the loaded
+    native layout is semantically correct if load/export are mutually inverse but
+    both wrong vs forward semantics. Needs an 80GB GPU; loads only the first 8
+    decoder layers to bound memory/time.
+
+Run single GPU:
+  torchrun --nproc_per_node=1 -m pytest tests/smoke/primitive/test_qwen35_hf_numeric_roundtrip_smoke.py
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+
+pytestmark = [pytest.mark.mlite, pytest.mark.smoke, pytest.mark.gpu]
+
+
+def _qwen35_tiny_cfg():
+    pytest.importorskip("fla", reason="qwen3_5 needs the FLA / GatedDeltaNet stack.")
+    pytest.importorskip(
+        "transformer_engine.pytorch", reason="qwen3_5 smoke needs real Transformer Engine."
+    )
+    from megatron.lite.model.qwen3_5.config import Qwen35Config
+
+    return Qwen35Config(
+        num_hidden_layers=2,
+        hidden_size=16,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=4,
+        vocab_size=64,
+        num_experts=4,
+        num_experts_per_tok=2,
+        moe_intermediate_size=8,
+        shared_expert_intermediate_size=8,
+        linear_num_key_heads=2,
+        linear_key_head_dim=4,
+        linear_num_value_heads=2,
+        linear_value_head_dim=4,
+        linear_conv_kernel_dim=4,
+        layer_types=["full_attention", "linear_attention"],
+        partial_rotary_factor=1.0,
+        max_position_embeddings=4096,
+    )
+
+
+def _build(cfg, seed):
+    from megatron.lite.model.qwen3_5.lite import protocol
+    from megatron.lite.runtime.contracts.config import ParallelConfig
+
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+    parallel = ParallelConfig(tp=1, pp=1, cp=1, ep=1, etp=1, vpp=1)
+    impl = protocol.ImplConfig(
+        parallel=parallel, optimizer="dist_opt", use_deepep=False, deterministic=True
+    )
+    bundle = protocol.build_model(cfg, impl_cfg=impl)
+    return bundle, protocol
+
+
+def _named(chunks):
+    out = {}
+    for i, chunk in enumerate(chunks):
+        for name, param in chunk.named_parameters():
+            out[f"{i}.{name}"] = param.detach().float().cpu().clone()
+    return out
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _single_rank_dist():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required for qwen3.5 numeric round-trip smoke.")
+    created = False
+    if not dist.is_initialized():
+        for k, v in {
+            "MASTER_ADDR": "127.0.0.1",
+            "MASTER_PORT": "29597",
+            "RANK": "0",
+            "WORLD_SIZE": "1",
+            "LOCAL_RANK": "0",
+        }.items():
+            os.environ.setdefault(k, v)
+        local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+        torch.cuda.set_device(local_rank)
+        dist.init_process_group("nccl")
+        created = True
+    yield
+    if created and dist.is_initialized():
+        dist.destroy_process_group()
+
+
+def test_qwen35_save_load_numeric_roundtrip(tmp_path):
+    if dist.get_world_size() != 1:
+        pytest.skip("numeric round-trip smoke runs single-rank (tp1).")
+    cfg = _qwen35_tiny_cfg()
+    a, proto = _build(cfg, seed=1)
+    b, _ = _build(cfg, seed=2)
+
+    before = _named(a.chunks)
+    b_before = _named(b.chunks)
+    assert sum(1 for k in before if not torch.equal(before[k], b_before[k])) > 0
+
+    out_dir = str(tmp_path / "hf")
+    os.makedirs(out_dir, exist_ok=True)
+    proto.save_hf_weights(a.chunks, out_dir, cfg, a.parallel_state)
+    proto.load_hf_weights(b.chunks[0], out_dir, cfg, b.parallel_state)
+
+    pa, pb = _named(a.chunks), _named(b.chunks)
+    vocab = cfg.vocab_size
+    mism = []
+    for k in pa:
+        ta, tb = pa[k], pb[k]
+        if k.endswith("embed.embedding.weight") or k.endswith("head.col.linear.weight"):
+            assert ta.shape[0] >= vocab
+            ta, tb = ta[:vocab], tb[:vocab]  # exclude unused TP-padding rows
+        # atol/rtol=1e-3 are bf16-cast round-trip tolerances.
+        if not torch.allclose(ta, tb, atol=1e-3, rtol=1e-3):
+            mism.append(f"{k} (max_abs_diff={(ta - tb).abs().max().item()})")
+    assert not mism, "HF save->load not numeric round-trip:\n" + "\n".join(mism)
+
+
+@pytest.mark.skipif(
+    not os.environ.get("QWEN35_HF_DIR"),
+    reason="set QWEN35_HF_DIR to a real Qwen3.5 HF checkpoint to run the ground-truth check.",
+)
+def test_qwen35_real_hf_load_export_matches_original(tmp_path):
+    if dist.get_world_size() != 1:
+        pytest.skip("ground-truth smoke runs single-rank (tp1).")
+    import json
+
+    from safetensors import safe_open
+
+    from megatron.lite.model.qwen3_5.config import Qwen35Config
+    from megatron.lite.model.qwen3_5.lite import protocol
+    from megatron.lite.runtime.contracts.config import ParallelConfig
+
+    model_dir = os.environ["QWEN35_HF_DIR"]
+    cfg = Qwen35Config.from_hf(model_dir)
+    n = min(8, cfg.num_hidden_layers)
+    cfg.num_hidden_layers = n
+    cfg.layer_types = cfg.layer_types[:n]
+    cfg.num_nextn_predict_layers = 0
+    # Ensure both attention branches are actually exercised in the truncated model.
+    assert "full_attention" in cfg.layer_types
+    assert "linear_attention" in cfg.layer_types
+
+    parallel = ParallelConfig(tp=1, pp=1, cp=1, ep=1, etp=1, vpp=1)
+    impl = protocol.ImplConfig(
+        parallel=parallel, optimizer="dist_opt", use_deepep=False, deterministic=True
+    )
+    bundle = protocol.build_model(cfg, impl_cfg=impl)
+    protocol.load_hf_weights(bundle.chunks[0], model_dir, cfg, bundle.parallel_state)
+
+    out_dir = str(tmp_path / "hf_export")
+    os.makedirs(out_dir, exist_ok=True)
+    protocol.save_hf_weights(bundle.chunks, out_dir, cfg, bundle.parallel_state)
+
+    orig_map = json.load(open(os.path.join(model_dir, "model.safetensors.index.json")))[
+        "weight_map"
+    ]
+
+    def _orig(key):
+        with safe_open(os.path.join(model_dir, orig_map[key]), framework="pt") as fh:
+            return fh.get_tensor(key).float()
+
+    exported = {}
+    for fn in os.listdir(out_dir):
+        if fn.endswith(".safetensors"):
+            with safe_open(os.path.join(out_dir, fn), framework="pt") as fh:
+                for key in fh.keys():
+                    exported[key] = fh.get_tensor(key).float()
+
+    # Derive the expected comparison set from the ORIGINAL weight map (not from
+    # `exported`): otherwise a tensor the exporter silently drops would never be
+    # compared and a missing-export bug would pass undetected.
+    #
+    # Scope to what this truncated text-only build actually produces: the first
+    # `n` decoder layers (prefix `model.language_model.layers.{i}.`) plus the
+    # global embed/norm/head tensors. The original checkpoint also carries the
+    # MTP head (`mtp.*`, disabled here via num_nextn_predict_layers=0) and the
+    # vision tower (`model.visual.*`, not built on the text path); both are
+    # intentionally NOT built/exported, so they are excluded from expected_keys.
+    global_keys = (
+        "model.language_model.embed_tokens.weight",
+        "model.language_model.norm.weight",
+        "lm_head.weight",
+    )
+    layer_prefixes = tuple(f"model.language_model.layers.{i}." for i in range(n))
+    expected_keys = {
+        k for k in orig_map if k.startswith(layer_prefixes) or k in global_keys
+    }
+    assert expected_keys, "no comparable tensors found in original weight map."
+
+    missing = expected_keys - set(exported)
+    assert not missing, "export missing tensors: " + ", ".join(sorted(missing))
+
+    mism = []
+    for k in sorted(expected_keys):
+        o, e = _orig(k), exported[k]
+        if o.shape != e.shape:
+            mism.append(f"{k} shape {tuple(o.shape)} != {tuple(e.shape)}")
+        elif not torch.allclose(o, e, atol=2e-2, rtol=2e-2):  # bf16-cast export tolerance
+            mism.append(f"{k} max_abs_diff={(o - e).abs().max().item()}")
+    assert not mism, "lite export does not match original HF safetensors:\n" + "\n".join(mism)

--- a/experimental/lite/tests/smoke/primitive/test_save_load_export_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_save_load_export_smoke.py
@@ -1,0 +1,720 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Save / load / export coverage smoke across the supported models and backends.
+
+Matrix: {qwen3_5, qwen3_moe, kimi_k2, glm5, deepseek_v4} x {dist_opt, fsdp2}.
+
+Each (model, backend) case does a faithful round-trip:
+  build -> train one real step -> save checkpoint -> build fresh -> load ->
+  assert parameters restored bit-exactly -> export HF weights (bf16) ->
+  reload exported safetensors and assert dtype/finiteness.
+
+dist_opt cases use the Megatron distributed-checkpoint path on a
+tp2/ep2/pp2 topology (exactly 8 GPUs). fsdp2 cases use torch DCP on a
+pure-DP mesh. Both checkpoint paths are exercised through the unified
+MegatronLiteRuntime so the matrix guards the runtime entry points.
+
+Run with torchrun --nproc_per_node=8 -m pytest, selecting per-env subsets
+with -k (qwen3_5 needs the qwen3.5 canary site; the four deepseek/qwen3_moe
+models need the DSA overlay). Models gate themselves with importorskip so a
+wrong-env invocation skips rather than errors.
+"""
+from __future__ import annotations
+
+import os
+from datetime import timedelta
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.distributed as dist
+
+from megatron.lite.primitive.deterministic import set_deterministic
+from megatron.lite.runtime.backends.mlite.runtime import MegatronLiteRuntime
+from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig
+from megatron.lite.runtime.contracts.data import PackedBatch
+from megatron.lite.runtime.contracts.handle import ModelHandle
+
+pytestmark = [pytest.mark.mlite, pytest.mark.smoke, pytest.mark.gpu, pytest.mark.distributed]
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Model registry: name -> builder returning (tiny_config, protocol_module).
+# Each builder importorskips its env-specific deps so a wrong-env run skips.
+# ──────────────────────────────────────────────────────────────────────────
+def _require_te() -> None:
+    te = pytest.importorskip(
+        "transformer_engine.pytorch",
+        reason="save/load/export smoke requires real Transformer Engine.",
+    )
+    assert hasattr(te, "Linear"), "smoke requires real Transformer Engine Linear."
+
+
+def _qwen3_5():
+    pytest.importorskip("fla", reason="qwen3_5 needs the FLA / GatedDeltaNet stack.")
+    _require_te()
+    from megatron.lite.model.qwen3_5.config import Qwen35Config
+    from megatron.lite.model.qwen3_5.lite import protocol
+
+    cfg = Qwen35Config(
+        num_hidden_layers=2,
+        hidden_size=16,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=4,
+        vocab_size=64,
+        num_experts=4,
+        num_experts_per_tok=2,
+        moe_intermediate_size=8,
+        shared_expert_intermediate_size=8,
+        linear_num_key_heads=2,
+        linear_key_head_dim=4,
+        linear_num_value_heads=2,
+        linear_value_head_dim=4,
+        linear_conv_kernel_dim=4,
+        # Mix full + linear attention so the distckpt linear_attn TP-shard
+        # path (the in_proj/conv1d/layer_norm sharding fixes) is covered.
+        layer_types=["full_attention", "linear_attention"],
+        partial_rotary_factor=1.0,
+        max_position_embeddings=4096,
+    )
+    return cfg, protocol
+
+
+def _qwen3_moe():
+    _require_te()
+    from megatron.lite.model.qwen3_moe.config import Qwen3MoEConfig
+    from megatron.lite.model.qwen3_moe.lite import protocol
+
+    cfg = Qwen3MoEConfig(
+        num_hidden_layers=2,
+        hidden_size=16,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=4,
+        vocab_size=64,
+        num_experts=4,
+        num_experts_per_tok=1,
+        moe_intermediate_size=8,
+        max_position_embeddings=4096,
+        layer_types=["full_attention", "full_attention"],
+    )
+    return cfg, protocol
+
+
+def _kimi_k2():
+    _require_te()
+    from megatron.lite.model.kimi_k2.config import KimiK2Config
+    from megatron.lite.model.kimi_k2.lite import protocol
+
+    cfg = KimiK2Config(
+        num_hidden_layers=2,
+        hidden_size=64,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        vocab_size=128,
+        intermediate_size=96,
+        moe_intermediate_size=16,
+        n_routed_experts=4,
+        n_shared_experts=1,
+        num_experts_per_tok=2,
+        n_group=2,
+        topk_group=1,
+        first_k_dense_replace=1,
+        q_lora_rank=16,
+        kv_lora_rank=12,
+        qk_nope_head_dim=8,
+        qk_rope_head_dim=8,
+        v_head_dim=8,
+        max_position_embeddings=4096,
+        rope_theta=10000.0,
+        rope_scaling={
+            "type": "yarn",
+            "factor": 1.0,
+            "original_max_position_embeddings": 4096,
+            "beta_fast": 1.0,
+            "beta_slow": 1.0,
+            "mscale": 1.0,
+            "mscale_all_dim": 1.0,
+        },
+    )
+    return cfg, protocol
+
+
+def _glm5():
+    pytest.importorskip("cudnn", reason="glm5 fused DSA needs the cudnn DSA stack.")
+    _require_te()
+    from megatron.lite.model.glm5.config import Glm5Config
+    from megatron.lite.model.glm5.lite import protocol
+
+    cfg = Glm5Config(
+        num_hidden_layers=2,
+        hidden_size=128,
+        num_attention_heads=64,
+        num_key_value_heads=64,
+        head_dim=256,
+        vocab_size=32,
+        max_position_embeddings=4096,
+        initializer_range=0.002,
+        q_lora_rank=16,
+        kv_lora_rank=512,
+        qk_head_dim=256,
+        qk_nope_head_dim=192,
+        qk_rope_head_dim=64,
+        v_head_dim=256,
+        index_head_dim=128,
+        index_n_heads=32,
+        index_topk=512,
+        intermediate_size=20,
+        moe_intermediate_size=6,
+        first_k_dense_replace=1,
+        n_routed_experts=4,
+        n_shared_experts=1,
+        num_experts_per_tok=2,
+    )
+    return cfg, protocol
+
+
+def _deepseek_v4():
+    pytest.importorskip("cudnn", reason="deepseek_v4 fused DSA needs the cudnn DSA stack.")
+    _require_te()
+    from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
+    from megatron.lite.model.deepseek_v4.lite import protocol
+
+    cfg = DeepseekV4Config(
+        vocab_size=64,
+        hidden_size=128,
+        moe_intermediate_size=16,
+        num_hidden_layers=2,
+        num_attention_heads=8,
+        num_key_value_heads=1,
+        head_dim=64,
+        qk_rope_head_dim=16,
+        q_lora_rank=32,
+        o_lora_rank=32,
+        o_groups=2,
+        n_routed_experts=4,
+        n_shared_experts=1,
+        num_experts_per_tok=2,
+        routed_scaling_factor=1.5,
+        max_position_embeddings=4096,
+        compress_ratios=[4, 4],
+        sliding_window=128,
+        num_hash_layers=2,
+        hc_mult=2,
+        index_head_dim=64,
+        index_n_heads=8,
+        index_topk=512,
+        # DeepSeek-V4 really has MTP; its ImplConfig defaults mtp_enable=True and
+        # requires >=1 nextn layer, so give it one (exercises MTP weight IO too).
+        num_nextn_predict_layers=1,
+        rms_norm_eps=1e-6,
+    )
+    return cfg, protocol
+
+
+MODELS = {
+    "qwen3_5": _qwen3_5,
+    "qwen3_moe": _qwen3_moe,
+    "kimi_k2": _kimi_k2,
+    "glm5": _glm5,
+    "deepseek_v4": _deepseek_v4,
+}
+
+BACKENDS = ("dist_opt", "fsdp2")
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Distributed harness
+# ──────────────────────────────────────────────────────────────────────────
+@pytest.fixture(scope="module", autouse=True)
+def _single_node_cuda_dist():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for save/load/export smoke.")
+    if int(os.environ.get("WORLD_SIZE", "1")) > 8:
+        pytest.skip("Megatron Lite smoke tests are capped at single-node 8 GPUs.")
+
+    os.environ.setdefault("CUBLAS_WORKSPACE_CONFIG", ":4096:8")
+    os.environ.setdefault("NVTE_ALLOW_NONDETERMINISTIC_ALGO", "0")
+    os.environ.setdefault("RANK", "0")
+    os.environ.setdefault("WORLD_SIZE", "1")
+    os.environ.setdefault("LOCAL_RANK", "0")
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", "29555")
+
+    torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
+
+    # Diagnostic: dump all thread stacks and force-exit after N seconds so a
+    # hang self-reports fast (keeps each run well under the time budget) instead
+    # of stalling on NCCL's slow watchdog/abort. Opt-in via MLITE_HANG_DUMP_S.
+    hang_dump_s = os.environ.get("MLITE_HANG_DUMP_S")
+    if hang_dump_s:
+        import faulthandler
+
+        faulthandler.dump_traceback_later(int(hang_dump_s), exit=True)
+
+    created_pg = False
+    if not dist.is_initialized():
+        # Short timeout so a desynced collective fails fast instead of stalling
+        # the whole job on the multi-minute NCCL watchdog default.
+        timeout_s = int(os.environ.get("MLITE_DIST_TIMEOUT_S", "180"))
+        dist.init_process_group(
+            backend="nccl", init_method="env://", timeout=timedelta(seconds=timeout_s)
+        )
+        created_pg = True
+    yield
+    try:
+        from megatron.core import parallel_state as mpu
+
+        if mpu.is_initialized():
+            mpu.destroy_model_parallel()
+    finally:
+        if created_pg and dist.is_initialized():
+            dist.destroy_process_group()
+
+
+@pytest.fixture(autouse=True)
+def _reset_parallel_state_between_tests():
+    """Tear down Megatron model-parallel groups after each case.
+
+    The matrix builds models with different topologies (tp2/ep2/pp2 for
+    dist_opt, pure-DP for fsdp2). Leaving a prior case's mpu groups initialized
+    desyncs the next case's collectives, so reset between tests.
+    """
+    yield
+    from megatron.core import parallel_state as mpu
+
+    if mpu.is_initialized():
+        mpu.destroy_model_parallel()
+
+
+# GLM5 / DeepSeek-V4 native lite support TP=ETP=VPP=1 only (EP/PP/CP wired
+# through primitives), so their dist_opt topology shards via ep/pp/cp instead.
+_TP1_ONLY = {"glm5", "deepseek_v4"}
+
+
+def _topology(model_name: str, backend: str) -> ParallelConfig:
+    if backend == "fsdp2":
+        # fsdp2 + pp2: FSDP2 shards over dp(=4) within each of 2 pipeline stages,
+        # so save/load is exercised with pipeline parallelism (not just pure DP).
+        return ParallelConfig(tp=1, ep=1, etp=1, pp=2, cp=1)
+    # Diagnostic hook: MLITE_FORCE_TOPO="tp,ep,etp,pp,cp" overrides any model's
+    # topology to isolate which parallel dim triggers a hang.
+    forced = os.environ.get("MLITE_FORCE_TOPO")
+    if forced:
+        tp, ep, etp, pp, cp = (int(x) for x in forced.split(","))
+        return ParallelConfig(tp=tp, ep=ep, etp=etp, pp=pp, cp=cp)
+    # Diagnostic hook: force the tp1/pp2 topology on any model to isolate
+    # whether a tp1+pp2 pipeline-P2P bug is generic (not DSA-specific).
+    if model_name in _TP1_ONLY or os.environ.get("MLITE_FORCE_TP1"):
+        # tp1 x pp2 x cp1 x dp4 = 8 ranks; ep2 within the expert space.
+        # CP is intentionally 1: save/load fidelity does not need the DSA CP path
+        # (covered by the dedicated CP smokes), and CP+tiny-seq risks fused-DSA hangs.
+        return ParallelConfig(tp=1, ep=2, etp=1, pp=2, cp=1)
+    # tp2 x pp2 x cp1 x dp2 = 8 ranks; ep2 within the expert space.
+    return ParallelConfig(tp=2, ep=2, etp=1, pp=2, cp=1)
+
+
+def _optimizer_config(offload_fraction: float = 0.0) -> OptimizerConfig:
+    return OptimizerConfig(
+        optimizer="adam",
+        lr=1.0e-3,
+        weight_decay=0.0,
+        adam_beta1=0.9,
+        adam_beta2=0.95,
+        adam_eps=1.0e-8,
+        clip_grad=1.0,
+        offload_fraction=offload_fraction,
+    )
+
+
+def _build_handle(
+    model_name: str,
+    backend: str,
+    *,
+    seed: int,
+    topology: ParallelConfig | None = None,
+    offload_fraction: float = 0.0,
+):
+    cfg, protocol = MODELS[model_name]()
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+    parallel = topology or _topology(model_name, backend)
+    impl_cfg = protocol.ImplConfig(
+        parallel=parallel,
+        optimizer=backend,
+        optimizer_config=_optimizer_config(offload_fraction),
+        use_deepep=False,
+        deterministic=True,
+    )
+    bundle = protocol.build_model(cfg, impl_cfg=impl_cfg)
+    chunks = bundle.chunks
+
+    if bundle.extras.get("optimizer_backend") == "fsdp2":
+        for chunk in chunks:
+            if hasattr(chunk, "initialize_weights"):
+                chunk.initialize_weights()
+        optimizer = bundle.extras["post_model_load_hook"]()["optimizer"]
+    else:
+        optimizer = bundle.optimizer
+
+    extras = dict(bundle.extras)
+    extras.update(
+        {
+            "model_chunks": chunks,
+            "forward_step": bundle.forward_step,
+            "finalize_grads": bundle.finalize_grads,
+            "protocol": protocol,
+        }
+    )
+    handle = ModelHandle(
+        model=chunks,
+        optimizer=optimizer,
+        parallel_state=bundle.parallel_state,
+        config=SimpleNamespace(parallel=parallel),
+        _extras=extras,
+    )
+    return handle, cfg, protocol
+
+
+def _shared_tmp_path(tmp_path, suffix: str) -> str:
+    payload = [os.path.join(str(tmp_path), suffix) if dist.get_rank() == 0 else None]
+    dist.broadcast_object_list(payload, src=0)
+    path = payload[0]
+    if dist.get_rank() == 0:
+        os.makedirs(path, exist_ok=True)
+    dist.barrier()
+    return path
+
+
+def _random_packed_batch(vocab_size: int) -> PackedBatch:
+    return PackedBatch(
+        input_ids=torch.randint(0, vocab_size, (2048,), device="cuda"),
+        labels=torch.randint(0, vocab_size, (2048,), device="cuda"),
+        seq_lens=torch.full((1,), 2048, dtype=torch.int64, device="cuda"),
+    )
+
+
+def _train_step(handle: ModelHandle, backend: str, cfg) -> None:
+    # Unified path for both backends: the runtime routes pp>1 through the
+    # pipeline schedule regardless of optimizer backend, so fsdp2 also exercises
+    # pipeline parallelism here (not just pure DP).
+    runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
+    batch = _random_packed_batch(cfg.vocab_size)
+    runtime.zero_grad(handle)
+    runtime.forward_backward(handle, iter([batch]), None, num_microbatches=1)
+    runtime.optimizer_step(handle)
+    runtime.zero_grad(handle)
+
+
+def _local_named_params(handle: ModelHandle) -> dict[str, torch.Tensor]:
+    from megatron.lite.primitive.optimizers.fsdp2.adamw import to_local_tensor
+
+    params: dict[str, torch.Tensor] = {}
+    for chunk_idx, chunk in enumerate(handle._extras["model_chunks"]):
+        for name, param in chunk.named_parameters():
+            params[f"{chunk_idx}.{name}"] = to_local_tensor(param.detach()).cpu().float().clone()
+    return params
+
+
+def _assert_params_bitwise_equal(lhs: ModelHandle, rhs: ModelHandle) -> None:
+    lhs_params = _local_named_params(lhs)
+    rhs_params = _local_named_params(rhs)
+    assert lhs_params.keys() == rhs_params.keys()
+    assert lhs_params, "expected at least one local parameter to compare."
+    mismatches = []
+    for name in lhs_params:
+        if not torch.equal(lhs_params[name], rhs_params[name]):
+            diff = (lhs_params[name] - rhs_params[name]).abs().max().item()
+            mismatches.append(f"{name} (max_abs_diff={diff})")
+    assert not mismatches, "save/load not bitwise; mismatched params:\n" + "\n".join(mismatches)
+
+
+def _is_valid_hf_export_key(key: str, model_name: str) -> bool:
+    """Whether an exported key matches the model's real HF release naming.
+
+    Most models use the ``model.``-rooted HF convention. DeepSeek-V4-Flash ships
+    a bare layout (``embed.weight`` / ``head.weight`` / ``norm.weight`` /
+    ``layers.N.*`` / ``mtp.N.*`` / ``hc_head_*``), so allow that for deepseek_v4.
+    """
+    if model_name == "deepseek_v4":
+        return key.startswith(("layers.", "mtp.")) or key in (
+            "embed.weight",
+            "head.weight",
+            "norm.weight",
+            "hc_head_base",
+            "hc_head_fn",
+            "hc_head_scale",
+        )
+    return key.startswith("model.") or key in ("lm_head.weight",)
+
+
+def _export_and_reload(handle: ModelHandle, cfg, protocol, out_dir: str, model_name: str) -> None:
+    """Export HF weights (bf16) and assert the reloaded shards are valid.
+
+    Prefer the model's ``save_hf_weights`` wrapper; some models only expose the
+    ``export_hf_weights`` generator, so fall back to gathering it and writing
+    the safetensors ourselves (rank 0). Every supported model must offer one of
+    the two — otherwise it has no export path at all, which is a hard failure.
+    """
+    chunks = handle._extras["model_chunks"]
+    ps = handle._parallel_state
+
+    if hasattr(protocol, "save_hf_weights"):
+        protocol.save_hf_weights(chunks, out_dir, cfg, ps)
+    elif hasattr(protocol, "export_hf_weights"):
+        from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
+
+        weights = dict(protocol.export_hf_weights(chunks, cfg, ps, rank0_only=True))
+        if dist.get_rank() == 0 and weights:
+            save_safetensors(weights, out_dir)
+    else:
+        raise AssertionError(f"{protocol.__name__} exposes no HF export path.")
+    dist.barrier()
+
+    if dist.get_rank() != 0:
+        dist.barrier()
+        return
+
+    from safetensors import safe_open
+
+    shards = [f for f in os.listdir(out_dir) if f.endswith(".safetensors")]
+    assert shards, f"no safetensors exported to {out_dir}"
+    keys: set[str] = set()
+    # The shared exporter casts EVERY floating tensor to bf16 (``_cast_export_tensor``
+    # with export_dtype=bf16) and leaves integers untouched.  So every float weight
+    # — including the router correction bias — must be bf16, while integer auxiliary
+    # buffers (e.g. DS4 hash-routing ``tid2eid`` index tables; casting them would
+    # corrupt the indices) keep their native integral dtype.  Excluding such buffers
+    # from the export would be a de-scope; we keep them and check their dtype.
+    for shard in shards:
+        with safe_open(os.path.join(out_dir, shard), framework="pt") as fh:
+            for key in fh.keys():
+                tensor = fh.get_tensor(key)
+                if tensor.dtype.is_floating_point:
+                    assert tensor.dtype == torch.bfloat16, (
+                        f"{key} exported as {tensor.dtype}, want bf16"
+                    )
+                else:
+                    assert tensor.dtype in (torch.int64, torch.int32, torch.bool), (
+                        f"{key} exported as unexpected non-float dtype {tensor.dtype}"
+                    )
+                assert torch.isfinite(tensor.float()).all(), f"{key} has non-finite values"
+                assert _is_valid_hf_export_key(key, model_name), (
+                    f"unexpected non-HF export key: {key}"
+                )
+                keys.add(key)
+    assert keys, "exported zero tensors"
+    # PP-gather completeness: the rank-0 export must carry EVERY decoder layer's
+    # weights (all pipeline stages gathered), not just the first stage's — guards
+    # against a pp-blind export silently dropping later stages' layers.
+    num_layers = int(getattr(cfg, "num_hidden_layers"))
+
+    def _has_layer(i: int) -> bool:
+        # Match both the ``model.``-rooted convention (``model.layers.{i}.``) and
+        # the bare DeepSeek-V4-Flash layout (``layers.{i}.``), which has no prefix.
+        prefix = f"layers.{i}."
+        return any(k.startswith(prefix) or f".{prefix}" in k for k in keys)
+
+    missing = [i for i in range(num_layers) if not _has_layer(i)]
+    assert not missing, (
+        f"export missing decoder layers {missing} (PP gather incomplete); "
+        f"sample keys: {sorted(keys)[:6]}"
+    )
+    dist.barrier()
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("model_name", list(MODELS))
+def test_save_load_roundtrip(model_name, backend, tmp_path):
+    """Checkpoint save -> fresh build -> load restores parameters bit-exactly.
+
+    Covers all 5 models x {dist_opt + distckpt, fsdp2 + dcp} (10 combos) — the
+    primary regression guard for the runtime checkpoint entry points.
+    """
+    if dist.get_world_size() != 8:
+        pytest.skip("save/load proxy smoke requires exactly 8 GPUs.")
+
+    set_deterministic(2026)
+
+    saved, cfg, _protocol = _build_handle(model_name, backend, seed=4242)
+    _train_step(saved, backend, cfg)
+
+    ckpt_dir = _shared_tmp_path(tmp_path, "ckpt")
+    runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
+    runtime.save_checkpoint(saved, ckpt_dir, step=1)
+
+    loaded, _cfg2, _proto2 = _build_handle(model_name, backend, seed=9999)
+    assert runtime.load_checkpoint(loaded, ckpt_dir) == 1
+    _assert_params_bitwise_equal(saved, loaded)
+
+
+@pytest.mark.parametrize("model_name", list(MODELS))
+def test_export_hf_bf16_reload(model_name, tmp_path):
+    """Export HF weights (bf16) and reload the safetensors shards.
+
+    Export output is backend-agnostic, so this exercises the canonical export
+    path: a dist_opt model whose TP/EP/PP shards are gathered to full HF
+    tensors. NOTE: exporting directly from a live fsdp2 (DTensor-sharded) model
+    is NOT covered here — save_hf_weights' gather is not DTensor-aware and
+    deadlocks; tracked as a known gap.
+    """
+    if dist.get_world_size() != 8:
+        pytest.skip("export proxy smoke requires exactly 8 GPUs.")
+
+    set_deterministic(2026)
+
+    handle, cfg, protocol = _build_handle(model_name, "dist_opt", seed=4242)
+    _train_step(handle, "dist_opt", cfg)
+
+    export_dir = _shared_tmp_path(tmp_path, "hf_export")
+    _export_and_reload(handle, cfg, protocol, export_dir, model_name)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Runtime offload / onload roundtrip (RL Best tier: runtime.to(cpu/cuda))
+#
+# Exercises the real runtime.to() used to reclaim GPU between train and rollout:
+# param + optimizer state move CPU<->GPU as a whole (NOT offload_fraction).
+# 3 delivery models x 2 optimizers on the 8-GPU proxy2 topology.
+# ──────────────────────────────────────────────────────────────────────────
+
+# qwen3_5 offload is validated separately (its GatedDeltaNet linear-attention
+# path and run env differ); the others run here.
+DELIVERY_MODELS = ("deepseek_v4", "glm5", "kimi_k2")
+
+
+def _offload_topology(model_name: str) -> ParallelConfig:
+    # proxy2 = 8-GPU pp2/ep2/cp2.  CSA/DSA (glm5, ds4) are TP=1 only, so they
+    # fill 8 ranks with dp2 (tp1·cp2·pp2·dp2=8); TP-capable MoE models use tp2
+    # (tp2·cp2·pp2·dp1=8).
+    forced = os.environ.get("MLITE_FORCE_TOPO")
+    if forced:
+        tp, ep, etp, pp, cp = (int(x) for x in forced.split(","))
+        return ParallelConfig(tp=tp, ep=ep, etp=etp, pp=pp, cp=cp)
+    if model_name in _TP1_ONLY:  # glm5, deepseek_v4: CSA/DSA are TP=1 only
+        return ParallelConfig(tp=1, ep=2, etp=1, pp=2, cp=2)
+    return ParallelConfig(tp=2, ep=2, etp=1, pp=2, cp=2)
+
+
+def _iter_opt_state_tensors(handle: ModelHandle, backend: str):
+    """Yield (key, tensor) over optimizer state for either backend — the same
+    tensors runtime.to() offloads, so device / value can be inspected."""
+    opt = handle._optimizer
+    if backend == "fsdp2":
+        from megatron.lite.primitive.optimizers.fsdp2.adamw import iter_torch_optimizers
+
+        for ci, child in enumerate(iter_torch_optimizers(opt.optimizer)):
+            for pi, st in enumerate(getattr(child, "state", {}).values()):
+                if isinstance(st, dict):
+                    for k, v in st.items():
+                        if isinstance(v, torch.Tensor):
+                            yield f"{ci}.{pi}.{k}", v
+    else:
+        from megatron.core.optimizer import ChainedOptimizer
+
+        opts = opt.chained_optimizers if isinstance(opt, ChainedOptimizer) else [opt]
+        for oi, sub in enumerate(opts):
+            inner = getattr(sub, "optimizer", None)
+            if inner is None:
+                continue
+            for pi, st in enumerate(inner.state.values()):
+                for k, v in st.items():
+                    if isinstance(v, torch.Tensor):
+                        yield f"{oi}.{pi}.{k}", v
+
+
+def _opt_state_devices(handle: ModelHandle, backend: str) -> set[str]:
+    from megatron.lite.primitive.optimizers.fsdp2.adamw import to_local_tensor
+
+    return {to_local_tensor(v).device.type for _, v in _iter_opt_state_tensors(handle, backend)}
+
+
+def _opt_state_snapshot(handle: ModelHandle, backend: str) -> dict[str, torch.Tensor]:
+    from megatron.lite.primitive.optimizers.fsdp2.adamw import to_local_tensor
+
+    return {
+        k: to_local_tensor(v.detach()).cpu().float().clone()
+        for k, v in _iter_opt_state_tensors(handle, backend)
+    }
+
+
+def _local_param_devices(handle: ModelHandle) -> set[str]:
+    from megatron.lite.primitive.optimizers.fsdp2.adamw import to_local_tensor
+
+    return {
+        to_local_tensor(p.detach()).device.type
+        for chunk in handle._extras["model_chunks"]
+        for p in chunk.parameters()
+    }
+
+
+def _assert_named_bitwise_equal(lhs: dict, rhs: dict, label: str) -> None:
+    assert lhs.keys() == rhs.keys(), f"{label} keys differ across offload roundtrip."
+    mismatches = []
+    for name in lhs:
+        if not torch.equal(lhs[name], rhs[name]):
+            diff = (lhs[name] - rhs[name]).abs().max().item()
+            mismatches.append(f"{name} (max_abs_diff={diff})")
+    assert not mismatches, f"{label} not bitwise after offload/onload:\n" + "\n".join(mismatches)
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("model_name", DELIVERY_MODELS)
+def test_offload_onload_roundtrip(model_name, backend, tmp_path):
+    """runtime.to(cpu) -> to(cuda) restores params + optimizer state exactly and
+    training continues — the RL train<->rollout GPU-reclaim path."""
+    if dist.get_world_size() != 8:
+        pytest.skip("offload/onload proxy smoke requires exactly 8 GPUs.")
+
+    set_deterministic(2026)
+    handle, cfg, _ = _build_handle(
+        model_name, backend, seed=4242, topology=_offload_topology(model_name)
+    )
+    _train_step(handle, backend, cfg)  # populate optimizer (exp_avg) state
+
+    runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
+    params_before = _local_named_params(handle)
+    opt_before = _opt_state_snapshot(handle, backend)
+    assert opt_before, "expected optimizer state after a train step."
+    assert _opt_state_devices(handle, backend) == {"cuda"}
+
+    runtime.to(handle, "cpu", model=True, optimizer=True, grad=True)
+    assert _opt_state_devices(handle, backend) == {"cpu"}, "optimizer state not offloaded to CPU."
+    if backend == "fsdp2":
+        # fsdp2 moves params to CPU directly; dist_opt instead frees the GPU
+        # buffer storage (params keep a 0-size cuda handle), so assert only fsdp2.
+        assert _local_param_devices(handle) == {"cpu"}, "params not offloaded to CPU."
+
+    runtime.to(handle, "cuda", model=True, optimizer=True, grad=True)
+    assert _opt_state_devices(handle, backend) == {"cuda"}, "optimizer state not back on GPU."
+    assert _local_param_devices(handle) == {"cuda"}, "params not back on GPU."
+
+    _assert_named_bitwise_equal(params_before, _local_named_params(handle), "param")
+    _assert_named_bitwise_equal(opt_before, _opt_state_snapshot(handle, backend), "optimizer-state")
+
+    _train_step(handle, backend, cfg)  # continues training after onload
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("model_name", ["kimi_k2"])
+def test_offload_fraction_keeps_optimizer_state_on_cpu(model_name, backend, tmp_path):
+    """offload_fraction>0 keeps the optimizer update state on CPU and still
+    trains.  One delivery model is enough to guard the real-model wiring
+    (generic TinyModel coverage already exists)."""
+    if dist.get_world_size() != 8:
+        pytest.skip("offload_fraction proxy smoke requires exactly 8 GPUs.")
+
+    set_deterministic(2026)
+    handle, cfg, _ = _build_handle(
+        model_name,
+        backend,
+        seed=4242,
+        topology=_offload_topology(model_name),
+        offload_fraction=1.0,
+    )
+    _train_step(handle, backend, cfg)
+    assert "cpu" in _opt_state_devices(handle, backend), (
+        "offload_fraction=1.0 should keep optimizer update state on CPU."
+    )
+    _train_step(handle, backend, cfg)  # trains with the offloaded update state

--- a/experimental/lite/tests/unit/examples/test_bench_example.py
+++ b/experimental/lite/tests/unit/examples/test_bench_example.py
@@ -8,8 +8,10 @@ import sys
 from contextlib import nullcontext
 from pathlib import Path
 
+import torch
+
 from megatron.lite.runtime.contracts.config import ParallelConfig
-from megatron.lite.runtime.contracts.data import ForwardResult
+from megatron.lite.runtime.contracts.data import ForwardResult, ModelOutputs
 from megatron.lite.runtime.contracts.handle import ModelHandle
 
 _LITE_ROOT = str(Path(__file__).resolve().parents[3])
@@ -136,7 +138,7 @@ class _FakeRuntime:
 
     def forward_backward(self, handle, data, loss_fn, *, num_microbatches: int = 1):
         self.loss += 1
-        return ForwardResult(metrics={"loss": float(self.loss)})
+        return ForwardResult(model_output=ModelOutputs(loss=torch.tensor(float(self.loss))))
 
     def optimizer_step(self, handle):
         return True, 3.5, 0

--- a/experimental/lite/tests/unit/model/test_deepseek_v4_hf_load_local_to_global.py
+++ b/experimental/lite/tests/unit/model/test_deepseek_v4_hf_load_local_to_global.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""DeepSeek-V4 HF load must lift LOCAL pipeline layer indices to GLOBAL.
+
+Under PP the model's ``self.layers`` ModuleDict is keyed by LOCAL pipeline
+position, so a non-first stage's native ``state_dict`` keys carry local indices
+(``layers.0`` ...). The HF release is keyed by GLOBAL layer index, so -- exactly
+like the exporter -- ``load_hf_weights`` must map local->global via
+``to_global_layer_name(name, layer_map)`` before resolving HF names. Without it a
+non-first stage reads the wrong global layer's weights.
+
+This is a CPU unit test: a minimal stand-in stage (no GPU/TE) whose layers are
+keyed locally but carry ``layer_indices`` = the global ids it owns, plus a tiny
+on-disk safetensors keyed by GLOBAL names. ``load_hf_weights`` must copy each
+local layer the GLOBAL layer's tensor; pre-fix it resolves local names, finds
+nothing, and leaves the params untouched.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+
+pytestmark = pytest.mark.mlite
+
+
+class _LayerNorm(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.weight = nn.Parameter(torch.zeros(dim))
+
+
+class _Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.input_layernorm = _LayerNorm(dim)
+
+
+class _Stage(nn.Module):
+    """A non-first PP stage: layers keyed by LOCAL position, ``layer_indices``
+    gives the GLOBAL ids it owns (e.g. [4, 5] for the 3rd stage of pp)."""
+
+    def __init__(self, global_ids: list[int], dim: int):
+        super().__init__()
+        self.layer_indices = list(global_ids)
+        self.layers = nn.ModuleDict({str(i): _Block(dim) for i in range(len(global_ids))})
+
+
+def test_ds4_load_hf_resolves_local_pp_layer_to_global(tmp_path):
+    from safetensors.torch import save_file
+
+    from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
+    from megatron.lite.model.deepseek_v4.lite import checkpoint as ckpt
+
+    dim = 4
+    global_ids = [4, 5]  # this stage owns global layers 4 and 5, keyed local 0 and 1
+    model = _Stage(global_ids, dim)
+    cfg = DeepseekV4Config(num_hidden_layers=8, n_routed_experts=8)
+    ps = SimpleNamespace(tp_size=1, etp_size=1, ep_size=1, ep_rank=0)
+
+    # Real-release layout is keyed by GLOBAL layer index; input_layernorm maps to
+    # the bare V4-Flash ``attn_norm.weight``.
+    save_file(
+        {f"layers.{g}.attn_norm.weight": torch.full((dim,), float(g)) for g in global_ids},
+        str(tmp_path / "model.safetensors"),
+    )
+
+    ckpt.load_hf_weights(model, str(tmp_path), cfg, ps)
+
+    # local layer 0 -> global 4 -> filled with 4.0; local 1 -> global 5 -> 5.0.
+    # Pre-fix, load resolved layers.0/layers.1 (local), found nothing, left zeros.
+    torch.testing.assert_close(
+        model.layers["0"].input_layernorm.weight.detach(), torch.full((dim,), 4.0)
+    )
+    torch.testing.assert_close(
+        model.layers["1"].input_layernorm.weight.detach(), torch.full((dim,), 5.0)
+    )

--- a/experimental/lite/tests/unit/model/test_glm5_lite_cp_smoke.py
+++ b/experimental/lite/tests/unit/model/test_glm5_lite_cp_smoke.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 from __future__ import annotations
 
 import pytest

--- a/experimental/lite/tests/unit/model/test_glm5_lite_cp_smoke.py
+++ b/experimental/lite/tests/unit/model/test_glm5_lite_cp_smoke.py
@@ -1,0 +1,462 @@
+from __future__ import annotations
+
+import pytest
+
+
+def _make_train_config(ps):
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        tp=ps.tp_size,
+        ep=ps.ep_size,
+        etp=ps.etp_size,
+        pp=ps.pp_size,
+        cp=ps.cp_size,
+        vpp=None,
+        use_deepep=False,
+        fp8=False,
+        recompute_modules=[],
+        deterministic=True,
+    )
+
+
+def _make_glm5_model(cfg, ps, **kwargs):
+    from megatron.lite.model.glm5.lite.model import Glm5Model
+
+    return Glm5Model(cfg, _make_train_config(ps), ps, **kwargs)
+
+
+def _init_dist_or_skip():
+    import os
+
+    import torch
+    import torch.distributed as dist
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for GLM5 CP smoke.")
+    if "RANK" not in os.environ or "WORLD_SIZE" not in os.environ:
+        pytest.skip("Run with torchrun so CP ranks are available.")
+
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    torch.cuda.set_device(local_rank)
+    if not dist.is_initialized():
+        dist.init_process_group("nccl")
+    if dist.get_world_size() < 2:
+        pytest.skip("GLM5 CP smoke requires at least 2 ranks.")
+    return torch.device("cuda", local_rank)
+
+
+def _tiny_config_kwargs():
+    return dict(
+        num_hidden_layers=2,
+        hidden_size=128,
+        num_attention_heads=64,
+        num_key_value_heads=64,
+        head_dim=256,
+        vocab_size=32,
+        max_position_embeddings=512,
+        initializer_range=0.002,
+        q_lora_rank=16,
+        kv_lora_rank=512,
+        qk_head_dim=256,
+        qk_nope_head_dim=192,
+        qk_rope_head_dim=64,
+        v_head_dim=256,
+        index_head_dim=128,
+        index_n_heads=32,
+        index_topk=512,
+        intermediate_size=20,
+        moe_intermediate_size=6,
+        first_k_dense_replace=1,
+        n_routed_experts=3,
+        n_shared_experts=1,
+        num_experts_per_tok=3,
+    )
+
+
+def _tiny_hf_parity_config_kwargs():
+    kwargs = _tiny_config_kwargs()
+    kwargs.update(index_topk=512, max_position_embeddings=512)
+    return kwargs
+
+
+def _fused_dsa_seq_len(world: int) -> int:
+    seq = 512
+    if seq % (2 * world) != 0:
+        pytest.skip(f"GLM5 fused DSA CP smoke requires seq={seq} divisible by 2*world={2 * world}.")
+    return seq
+
+
+def _to_hf_deepseek_v3_config(cfg):
+    from transformers.models.deepseek_v3.configuration_deepseek_v3 import DeepseekV3Config
+
+    return DeepseekV3Config(
+        hidden_size=cfg.hidden_size,
+        intermediate_size=cfg.intermediate_size,
+        moe_intermediate_size=cfg.moe_intermediate_size,
+        num_hidden_layers=cfg.num_hidden_layers,
+        num_attention_heads=cfg.num_attention_heads,
+        num_key_value_heads=cfg.num_key_value_heads,
+        vocab_size=cfg.vocab_size,
+        n_shared_experts=cfg.n_shared_experts,
+        n_routed_experts=cfg.n_routed_experts,
+        routed_scaling_factor=cfg.routed_scaling_factor,
+        kv_lora_rank=cfg.kv_lora_rank,
+        q_lora_rank=cfg.q_lora_rank,
+        qk_rope_head_dim=cfg.qk_rope_head_dim,
+        v_head_dim=cfg.v_head_dim,
+        qk_nope_head_dim=cfg.qk_nope_head_dim,
+        n_group=cfg.n_group,
+        topk_group=cfg.topk_group,
+        num_experts_per_tok=cfg.num_experts_per_tok,
+        first_k_dense_replace=cfg.first_k_dense_replace,
+        norm_topk_prob=cfg.norm_topk_prob,
+        max_position_embeddings=cfg.max_position_embeddings,
+        rms_norm_eps=cfg.rms_norm_eps,
+        tie_word_embeddings=False,
+        rope_theta=cfg.rope_theta,
+        rope_scaling=None,
+        rope_interleave=cfg.rope_interleave,
+        attention_bias=False,
+        attention_dropout=0.0,
+        use_cache=False,
+    )
+
+
+def _capture_tensor_output(outputs):
+    return outputs[0].detach() if isinstance(outputs, tuple) else outputs.detach()
+
+
+def _distributed_diff_stats(actual, expected) -> tuple[float, float]:
+    import torch
+    import torch.distributed as dist
+
+    diff = (actual.float() - expected.float()).abs()
+    max_abs = diff.max()
+    scale = torch.maximum(actual.float().abs().max(), expected.float().abs().max()).clamp_min(1e-6)
+    stats = torch.stack([max_abs, scale])
+    if dist.is_initialized():
+        dist.all_reduce(stats, op=dist.ReduceOp.MAX)
+    return float(stats[0].item()), float((stats[0] / stats[1]).item())
+
+
+def _hf_state_dict_for_glm5_loader(model):
+    return {
+        name: tensor.detach().cpu().contiguous().clone()
+        for name, tensor in model.state_dict().items()
+    }
+
+
+def _make_dsa(*, cp_size: int = 1, cp_rank: int = 0, cp_group=None):
+    from megatron.lite.primitive.modules.attention import DynamicSparseAttention
+
+    return DynamicSparseAttention(
+        hidden_size=128,
+        num_attention_heads=64,
+        q_lora_rank=16,
+        kv_lora_rank=512,
+        qk_nope_head_dim=192,
+        qk_rope_head_dim=64,
+        v_head_dim=256,
+        index_n_heads=32,
+        index_head_dim=128,
+        index_topk=512,
+        rms_norm_eps=1e-5,
+        cp_size=cp_size,
+        cp_rank=cp_rank,
+        cp_group=cp_group,
+    )
+
+
+@pytest.mark.gpu
+def test_glm5_dsa_cp2_matches_full_sequence_reference_forward_and_grad():
+    import torch
+    import torch.distributed as dist
+
+    from megatron.lite.primitive.modules.attention import build_rope_cache
+    from megatron.lite.primitive.parallel.cp import zigzag_position_ids_for_cp, zigzag_slice_for_cp
+    from megatron.lite.primitive.parallel.state import ParallelState
+
+    device = _init_dist_or_skip()
+    world = dist.get_world_size()
+    rank = dist.get_rank()
+    ps = ParallelState(cp_group=dist.group.WORLD, cp_size=world, cp_rank=rank)
+
+    torch.manual_seed(2026)
+    cp_attn = _make_dsa(cp_size=world, cp_rank=rank, cp_group=ps.cp_group).to(
+        device=device, dtype=torch.bfloat16
+    )
+    torch.manual_seed(2026)
+    ref_attn = _make_dsa().to(device=device, dtype=torch.bfloat16)
+
+    batch, seq = 1, _fused_dsa_seq_len(world)
+    torch.manual_seed(99)
+    full_x = torch.randn(batch, seq, 128, device=device, dtype=torch.bfloat16)
+    local_x = zigzag_slice_for_cp(full_x, rank, world, seq_dim=1).detach().requires_grad_(True)
+    ref_x = full_x.detach().clone().requires_grad_(True)
+
+    cos, sin = build_rope_cache(
+        dim=64, max_position_embeddings=seq, rope_theta=1_000_000.0, device=device
+    )
+    local_pos = zigzag_position_ids_for_cp(seq, rank, world, device).expand(batch, -1)
+    full_pos = torch.arange(seq, device=device, dtype=torch.long).unsqueeze(0).expand(batch, -1)
+
+    cp_out = cp_attn(local_x, cos=cos, sin=sin, position_ids=local_pos)
+    ref_out = ref_attn(ref_x, cos=cos, sin=sin, position_ids=full_pos)
+    expected = zigzag_slice_for_cp(ref_out, rank, world, seq_dim=1)
+    torch.testing.assert_close(cp_out, expected, atol=3e-2, rtol=3e-2)
+
+    cp_out.float().sum().backward()
+    ref_out.float().sum().backward()
+    expected_grad = zigzag_slice_for_cp(ref_x.grad, rank, world, seq_dim=1)
+    assert local_x.grad is not None
+    torch.testing.assert_close(local_x.grad, expected_grad, atol=8e-2, rtol=8e-2)
+
+
+@pytest.mark.gpu
+def test_glm5_tiny_model_cp2_matches_full_sequence_reference_forward():
+    import torch
+    import torch.distributed as dist
+
+    from megatron.lite.model.glm5.config import Glm5Config
+    from megatron.lite.primitive.parallel.cp import zigzag_slice_for_cp
+    from megatron.lite.primitive.parallel.state import ParallelState
+
+    device = _init_dist_or_skip()
+    world = dist.get_world_size()
+    rank = dist.get_rank()
+    cfg = Glm5Config(**_tiny_config_kwargs())
+    cfg.mlp_layer_types = ["dense", "dense"]
+    ps = ParallelState(cp_group=dist.group.WORLD, cp_size=world, cp_rank=rank)
+
+    torch.manual_seed(777)
+    cp_model = _make_glm5_model(cfg, ps=ps).to(device=device, dtype=torch.bfloat16)
+    torch.manual_seed(777)
+    ref_model = _make_glm5_model(cfg, ps=ParallelState()).to(
+        device=device, dtype=torch.bfloat16
+    )
+    cp_model.eval()
+    ref_model.eval()
+
+    batch, seq = 1, _fused_dsa_seq_len(world)
+    torch.manual_seed(100)
+    full_hidden = torch.randn(batch, seq, cfg.hidden_size, device=device, dtype=torch.bfloat16)
+    local_hidden = zigzag_slice_for_cp(full_hidden, rank, world, seq_dim=1).contiguous()
+
+    with torch.no_grad():
+        cp_hidden = cp_model(hidden_states=local_hidden)["hidden_states"]
+        ref_hidden = ref_model(hidden_states=full_hidden)["hidden_states"]
+    expected = zigzag_slice_for_cp(ref_hidden, rank, world, seq_dim=1)
+
+    torch.testing.assert_close(cp_hidden, expected, atol=1e-1, rtol=1e-1)
+
+
+@pytest.mark.gpu
+def test_glm5_tiny_model_cp2_forward_backward_smoke():
+    import torch
+    import torch.distributed as dist
+
+    from megatron.lite.model.glm5.config import Glm5Config
+    from megatron.lite.primitive.parallel.cp import zigzag_slice_for_cp
+    from megatron.lite.primitive.parallel.state import ParallelState
+
+    device = _init_dist_or_skip()
+    world = dist.get_world_size()
+    rank = dist.get_rank()
+    cfg = Glm5Config(**_tiny_config_kwargs())
+    cfg.mlp_layer_types = ["dense", "dense"]
+    ps = ParallelState(cp_group=dist.group.WORLD, cp_size=world, cp_rank=rank)
+
+    torch.manual_seed(1234)
+    model = _make_glm5_model(cfg, ps=ps).to(device=device, dtype=torch.bfloat16)
+
+    batch, seq = 1, _fused_dsa_seq_len(world)
+    torch.manual_seed(55)
+    full_ids = torch.randint(0, cfg.vocab_size, (batch, seq), device=device)
+    input_ids = zigzag_slice_for_cp(full_ids, rank, world, seq_dim=1).contiguous()
+
+    output = model(input_ids=input_ids)
+    assert output["hidden_states"].shape == (batch, seq // world, cfg.hidden_size)
+    assert torch.isfinite(output["hidden_states"].float()).all()
+    loss = output["hidden_states"].float().square().mean()
+    assert loss.ndim == 0
+    assert torch.isfinite(loss)
+    loss.backward()
+
+    grad_norm = torch.zeros((), device=device)
+    for param in model.parameters():
+        if param.grad is not None:
+            grad_norm = grad_norm + param.grad.detach().float().norm()
+    assert torch.isfinite(grad_norm)
+
+
+@pytest.mark.gpu
+def test_glm5_packed_thd_variable_sequence_cp2_forward_backward_smoke():
+    import torch
+    import torch.distributed as dist
+
+    from megatron.lite.model.glm5.config import Glm5Config
+    from megatron.lite.primitive.parallel.state import ParallelState
+    from megatron.lite.primitive.parallel.thd import pack_nested_thd, unpack_packed_thd_to_nested
+
+    device = _init_dist_or_skip()
+    world = dist.get_world_size()
+    rank = dist.get_rank()
+    cfg_kwargs = _tiny_config_kwargs()
+    cfg_kwargs.update(max_position_embeddings=64, num_nextn_predict_layers=1)
+    cfg = Glm5Config(**cfg_kwargs)
+    cfg.mlp_layer_types = ["dense", "dense"]
+    ps = ParallelState(cp_group=dist.group.WORLD, cp_size=world, cp_rank=rank)
+
+    torch.manual_seed(20260614)
+    model = _make_glm5_model(cfg, ps=ps, mtp_enable=True, mtp_enable_train=True).to(
+        device=device, dtype=torch.bfloat16
+    )
+    model.train()
+
+    lengths = [16, 20, 24]
+    ids = torch.nested.as_nested_tensor(
+        [
+            torch.randint(0, cfg.vocab_size, (length,), device=device, dtype=torch.long)
+            for length in lengths
+        ],
+        layout=torch.jagged,
+    )
+    labels = torch.nested.as_nested_tensor(
+        [
+            torch.randint(0, cfg.vocab_size, (length,), device=device, dtype=torch.long)
+            for length in lengths
+        ],
+        layout=torch.jagged,
+    )
+    loss_mask = torch.nested.as_nested_tensor(
+        [torch.ones(length, device=device, dtype=torch.float32) for length in lengths],
+        layout=torch.jagged,
+    )
+    packed = pack_nested_thd(
+        ids,
+        cp_size=world,
+        cp_rank=rank,
+        cp_group=ps.cp_group,
+        labels=labels,
+        loss_mask=loss_mask,
+    )
+
+    out = model(
+        input_ids=packed.input_ids,
+        labels=packed.labels,
+        loss_mask=packed.loss_mask,
+        position_ids=packed.position_ids,
+        packed_seq_params=packed.packed_seq_params,
+    )
+    assert torch.isfinite(out["loss"])
+    assert "mtp_loss" in out
+    out["loss"].backward()
+
+    grad_norm = torch.zeros((), device=device)
+    for param in model.parameters():
+        if param.grad is not None:
+            grad_norm = grad_norm + param.grad.detach().float().norm()
+    assert torch.isfinite(grad_norm)
+
+    nested_log_probs = unpack_packed_thd_to_nested(out["log_probs"], packed)
+    assert nested_log_probs.offsets().numel() == len(lengths) + 1
+    assert [int(x) for x in nested_log_probs.offsets().diff().cpu()] == lengths
+
+    if rank == 0:
+        print(
+            "NON_SKIP_GLM5_THD_CP_SMOKE_PASSED "
+            f"world_size={world} lengths={lengths} "
+            f"loss={float(out['loss'].detach().item()):.6e} "
+            f"grad_norm={float(grad_norm.detach().item()):.6e}"
+        )
+
+
+@pytest.mark.gpu
+def test_glm5_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
+    import torch
+    import torch.distributed as dist
+    from transformers.models.deepseek_v3.modeling_deepseek_v3 import DeepseekV3ForCausalLM
+
+    from megatron.lite.model.glm5.config import Glm5Config
+    from megatron.lite.model.glm5.lite.checkpoint import load_hf_weights
+    from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
+    from megatron.lite.primitive.parallel.cp import zigzag_slice_for_cp
+    from megatron.lite.primitive.parallel.state import ParallelState
+
+    device = _init_dist_or_skip()
+    world = dist.get_world_size()
+    rank = dist.get_rank()
+    cfg = Glm5Config(**_tiny_hf_parity_config_kwargs())
+
+    torch.manual_seed(20260611)
+    hf_ref = DeepseekV3ForCausalLM(_to_hf_deepseek_v3_config(cfg)).to(
+        device=device, dtype=torch.bfloat16
+    )
+    hf_ref.eval()
+    rank_tmp_path = tmp_path / f"rank{rank}"
+    save_safetensors(_hf_state_dict_for_glm5_loader(hf_ref), str(rank_tmp_path))
+
+    ps = ParallelState(cp_group=dist.group.WORLD, cp_size=world, cp_rank=rank)
+    native = _make_glm5_model(cfg, ps=ps).to(device=device, dtype=torch.bfloat16)
+    native.eval()
+    load_hf_weights(native, str(rank_tmp_path), cfg, ps)
+
+    batch, seq = 1, _fused_dsa_seq_len(world)
+    torch.manual_seed(311)
+    full_ids = torch.randint(0, cfg.vocab_size, (batch, seq), device=device)
+    local_ids = zigzag_slice_for_cp(full_ids, rank, world, seq_dim=1).contiguous()
+
+    hf_layer_outputs = []
+    native_layer_outputs = []
+    hooks = []
+    for layer in hf_ref.model.layers:
+        hooks.append(
+            layer.register_forward_hook(
+                lambda _module, _inputs, outputs: hf_layer_outputs.append(
+                    _capture_tensor_output(outputs)
+                )
+            )
+        )
+    for layer in native.layers:
+        hooks.append(
+            layer.register_forward_hook(
+                lambda _module, _inputs, outputs: native_layer_outputs.append(
+                    _capture_tensor_output(outputs)
+                )
+            )
+        )
+
+    with torch.no_grad():
+        if rank == 0:
+            print(
+                "glm5_hf_native_parity reference=transformers.DeepseekV3ForCausalLM "
+                "mode=dense_mla_reference_with_full_topk_dsa"
+            )
+        hf_logits = hf_ref(full_ids).logits
+        native_logits = native(input_ids=local_ids)["logits"]
+
+    for hook in hooks:
+        hook.remove()
+
+    assert len(hf_layer_outputs) == cfg.num_hidden_layers
+    assert len(native_layer_outputs) == cfg.num_hidden_layers
+    for layer_idx, (actual, full_expected) in enumerate(
+        zip(native_layer_outputs, hf_layer_outputs, strict=True)
+    ):
+        expected = zigzag_slice_for_cp(full_expected, rank, world, seq_dim=1).contiguous()
+        max_abs, max_rel = _distributed_diff_stats(actual, expected)
+        if rank == 0:
+            print(
+                f"glm5_hf_native_parity layer={layer_idx} "
+                f"max_abs_diff={max_abs:.6e} max_rel_diff={max_rel:.6e}"
+            )
+        torch.testing.assert_close(actual.float(), expected.float(), atol=1.5e-1, rtol=1.5e-1)
+
+    expected = zigzag_slice_for_cp(hf_logits, rank, world, seq_dim=1).contiguous()
+    max_abs, max_rel = _distributed_diff_stats(native_logits, expected)
+    if rank == 0:
+        print(
+            "glm5_hf_native_parity logits " f"max_abs_diff={max_abs:.6e} max_rel_diff={max_rel:.6e}"
+        )
+    torch.testing.assert_close(native_logits.float(), expected.float(), atol=1.5e-1, rtol=1.5e-1)

--- a/experimental/lite/tests/unit/model/test_glm5_lite_static.py
+++ b/experimental/lite/tests/unit/model/test_glm5_lite_static.py
@@ -1,0 +1,645 @@
+"""Static and CPU smoke tests for native GLM-5 lite."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _make_train_config(ps):
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        tp=ps.tp_size,
+        ep=ps.ep_size,
+        etp=ps.etp_size,
+        pp=ps.pp_size,
+        cp=ps.cp_size,
+        vpp=None,
+        use_deepep=False,
+        fp8=False,
+        recompute_modules=[],
+        deterministic=True,
+    )
+
+
+def _make_glm5_model(cfg, ps=None, **kwargs):
+    from megatron.lite.model.glm5.lite.model import Glm5Model
+    from megatron.lite.primitive.parallel import ParallelState
+
+    ps = ParallelState() if ps is None else ps
+    return Glm5Model(cfg, _make_train_config(ps), ps, **kwargs)
+
+
+def _tiny_config_kwargs():
+    return dict(
+        num_hidden_layers=2,
+        hidden_size=16,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        head_dim=4,
+        vocab_size=32,
+        max_position_embeddings=16,
+        q_lora_rank=8,
+        kv_lora_rank=4,
+        qk_head_dim=8,
+        qk_nope_head_dim=4,
+        qk_rope_head_dim=4,
+        v_head_dim=4,
+        index_head_dim=8,
+        index_n_heads=2,
+        index_topk=2,
+        intermediate_size=20,
+        moe_intermediate_size=6,
+        first_k_dense_replace=1,
+        n_routed_experts=3,
+        n_shared_experts=1,
+        num_experts_per_tok=2,
+    )
+
+
+def test_glm5_registry_resolves_lite():
+    from megatron.lite.model.registry import (
+        get_train_runtime_module,
+        resolve_model_type_from_hf,
+        resolve_runtime_model_name,
+    )
+
+    runtime_name = resolve_runtime_model_name("glm5", "lite")
+    assert runtime_name == "glm5"
+    module = get_train_runtime_module(runtime_name)
+    assert module.__name__ == "megatron.lite.model.glm5.lite.protocol"
+    assert resolve_model_type_from_hf({"model_type": "glm_moe_dsa"}) == "glm5"
+
+
+def test_glm5_config_reads_hf_architecture_fields():
+    from megatron.lite.model.glm5.config import Glm5Config
+
+    cfg = Glm5Config._from_hf_dict(
+        {
+            "model_type": "glm_moe_dsa",
+            "hidden_size": 6144,
+            "num_hidden_layers": 78,
+            "num_attention_heads": 64,
+            "num_key_value_heads": 64,
+            "q_lora_rank": 2048,
+            "kv_lora_rank": 512,
+            "qk_head_dim": 256,
+            "qk_nope_head_dim": 192,
+            "qk_rope_head_dim": 64,
+            "v_head_dim": 256,
+            "index_head_dim": 128,
+            "index_n_heads": 32,
+            "index_topk": 2048,
+            "first_k_dense_replace": 3,
+            "n_routed_experts": 256,
+            "n_shared_experts": 1,
+            "num_experts_per_tok": 8,
+            "vocab_size": 154880,
+            "rope_parameters": {"rope_theta": 1000000, "rope_type": "default"},
+        }
+    )
+
+    assert cfg.q_lora_rank == 2048
+    assert cfg.kv_lora_rank == 512
+    assert cfg.index_topk == 2048
+    assert cfg.num_nextn_predict_layers == 1
+    assert cfg.rope_theta == 1_000_000.0
+    assert cfg.is_moe_layer(2) is False
+    assert cfg.is_moe_layer(3) is True
+
+
+def test_glm5_config_ignores_null_hf_optional_fields():
+    from megatron.lite.model.glm5.config import Glm5Config
+
+    cfg = Glm5Config._from_hf_dict(
+        {
+            "model_type": "glm_moe_dsa",
+            "indexer_rope_first": None,
+            "indexer_use_hadamard": None,
+            "mlp_layer_types": None,
+        }
+    )
+
+    assert cfg.indexer_rope_first is True
+    assert cfg.indexer_use_hadamard is False
+    assert cfg.mlp_layer_types is None
+
+
+def test_glm5_config_preserves_mtp_aliases_and_layer_types():
+    from megatron.lite.model.glm5.config import Glm5Config
+
+    cfg = Glm5Config._from_hf_dict(
+        {
+            **_tiny_config_kwargs(),
+            "num_nextn_predict": 1,
+            "mtp_loss_scaling_factor": 0.2,
+            "mlp_layer_types": ["dense", "sparse", "sparse"],
+        }
+    )
+
+    assert cfg.num_nextn_predict_layers == 1
+    assert cfg.mtp_loss_scaling_factor == 0.2
+    assert cfg.is_moe_layer(2) is True
+
+
+def test_glm5_lite_does_not_import_wrappers_or_sibling_models():
+    root = Path(__file__).resolve().parents[3] / "megatron" / "lite" / "model" / "glm5" / "lite"
+    for path in root.glob("*.py"):
+        text = path.read_text()
+        assert "megatron.lite.model.qwen" not in text
+        assert "mbridge" not in text
+        assert "MCore" not in text
+        assert "megatron.core" not in text
+
+
+def test_glm5_lite_uses_shared_mla_and_dsa_primitive():
+    root = Path(__file__).resolve().parents[3] / "megatron" / "lite"
+    model_text = (root / "model" / "glm5" / "lite" / "model.py").read_text()
+    primitive_text = (root / "primitive" / "modules" / "attention" / "dsa.py").read_text()
+    kernel_text = (root / "primitive" / "kernels" / "dsa_kernels.py").read_text()
+
+    assert "DynamicSparseAttention" in model_text
+    assert (
+        "from megatron.lite.primitive.modules.attention.mla import MultiLatentAttention"
+        in primitive_text
+    )
+    assert "class DynamicSparseAttention" in primitive_text
+    assert "class MultiLatentAttention" not in primitive_text
+    assert "class DSAIndexer" in primitive_text
+    assert "megatron.core" not in primitive_text
+    assert "dsa_kernels.fused_indexer_sparse_attn" in primitive_text
+    assert "dsa_kernels.dsa_sparse_attn" in primitive_text
+    assert "dsa_kernels.indexer_topk" in primitive_text
+    assert "value_dim" in kernel_text
+    assert "from cudnn.deepseek_sparse_attention import DSA" in kernel_text
+    assert "from cudnn import DSA" in kernel_text
+    assert "cudnn.deepseek_sparse_attention.indexer_forward._interface_sm90" in kernel_text
+    assert "cudnn.deepseek_sparse_attention.indexer_forward._interface" in kernel_text
+    assert "torch.cuda.get_device_capability(device)" in kernel_text
+    assert "torch.topk" not in primitive_text
+    assert "torch.softmax" not in primitive_text
+    assert "torch.matmul" not in primitive_text
+
+
+def test_glm5_dsa_kernel_routes_indexer_forward_by_sm(monkeypatch):
+    from megatron.lite.primitive.kernels import dsa_kernels
+
+    sm90_entry = object()
+    sm100_entry = object()
+
+    monkeypatch.setattr(dsa_kernels, "_load_indexer_fwd_sm90", lambda: sm90_entry)
+    monkeypatch.setattr(dsa_kernels, "_load_indexer_fwd_sm100", lambda: sm100_entry)
+
+    monkeypatch.setattr(dsa_kernels.torch.cuda, "get_device_capability", lambda device: (9, 0))
+    assert dsa_kernels._select_indexer_forward(None) is sm90_entry
+
+    monkeypatch.setattr(dsa_kernels.torch.cuda, "get_device_capability", lambda device: (10, 0))
+    assert dsa_kernels._select_indexer_forward(None) is sm100_entry
+
+    monkeypatch.setattr(dsa_kernels.torch.cuda, "get_device_capability", lambda device: (8, 0))
+    assert dsa_kernels._select_indexer_forward(None) is None
+
+
+def test_glm5_dsa_training_forward_uses_fused_kernel(monkeypatch):
+    import pytest
+    import torch
+
+    from megatron.lite.primitive.modules.attention import dsa
+    from megatron.lite.primitive.modules.attention import DynamicSparseAttention, build_rope_cache
+
+    if not torch.cuda.is_available():
+        pytest.skip("GLM-5 native attention requires CUDA (Transformer Engine RMSNorm)")
+    device = torch.device("cuda")
+
+    calls = {}
+
+    def fake_fused_indexer_sparse_attn(
+        query,
+        kv_full,
+        attn_sink,
+        window_idxs,
+        q_indexer,
+        k_indexer,
+        weights,
+        indexer_topk,
+        ratio,
+        softmax_scale,
+        indexer_softmax_scale=1.0,
+        loss_coeff=0.0,
+        sparse_loss=False,
+        kv_offset=0,
+        calculate_per_token_loss=False,
+        value_dim=None,
+    ):
+        del attn_sink, q_indexer, k_indexer, weights, softmax_scale, indexer_softmax_scale
+        calls["training"] = {
+            "query_shape": tuple(query.shape),
+            "kv_shape": tuple(kv_full.shape),
+            "window_shape": tuple(window_idxs.shape),
+            "indexer_topk": indexer_topk,
+            "ratio": ratio,
+            "loss_coeff": loss_coeff,
+            "sparse_loss": sparse_loss,
+            "kv_offset": kv_offset,
+            "calculate_per_token_loss": calculate_per_token_loss,
+            "value_dim": value_dim,
+        }
+        return query.new_zeros(
+            query.shape[0], query.shape[1], query.shape[2] * value_dim
+        ), torch.zeros((), device=query.device, dtype=torch.float32)
+
+    monkeypatch.setattr(
+        dsa._dsa_kernels, "fused_indexer_sparse_attn", fake_fused_indexer_sparse_attn
+    )
+
+    attn = DynamicSparseAttention(
+        hidden_size=16,
+        num_attention_heads=2,
+        q_lora_rank=8,
+        kv_lora_rank=4,
+        qk_nope_head_dim=4,
+        qk_rope_head_dim=4,
+        v_head_dim=4,
+        index_n_heads=2,
+        index_head_dim=8,
+        index_topk=2,
+        rms_norm_eps=1e-5,
+    )
+    attn.to(device=device, dtype=torch.bfloat16)
+    attn.train()
+    x = torch.randn(1, 4, 16, device=device, dtype=torch.bfloat16)
+    cos, sin = build_rope_cache(
+        dim=4, max_position_embeddings=4, rope_theta=1_000_000.0, device=device
+    )
+    position_ids = torch.arange(4, device=device).unsqueeze(0)
+
+    out = attn(x, cos=cos, sin=sin, position_ids=position_ids)
+
+    assert out.shape == (1, 4, 16)
+    assert calls["training"] == {
+        "query_shape": (4, 1, 2, 8),
+        "kv_shape": (4, 1, 8),
+        "window_shape": (1, 4, 0),
+        "indexer_topk": 2,
+        "ratio": 1,
+        "loss_coeff": 0.0,
+        "sparse_loss": False,
+        "kv_offset": 0,
+        "calculate_per_token_loss": False,
+        "value_dim": 4,
+    }
+
+
+def test_glm5_dsa_eval_forward_uses_fused_sparse_attention(monkeypatch):
+    import pytest
+    import torch
+
+    from megatron.lite.primitive.modules.attention import dsa
+    from megatron.lite.primitive.modules.attention import DynamicSparseAttention, build_rope_cache
+
+    if not torch.cuda.is_available():
+        pytest.skip("GLM-5 native attention requires CUDA (Transformer Engine RMSNorm)")
+    device = torch.device("cuda")
+
+    calls = {}
+
+    def fake_indexer_topk(q_indexer, k_indexer, weights, topk, ratio, indexer_softmax_scale=1.0):
+        del q_indexer, k_indexer, weights, indexer_softmax_scale
+        calls["indexer"] = {"topk": topk, "ratio": ratio}
+        idx = torch.zeros((1, 4, topk), dtype=torch.int32, device=device)
+        return idx, torch.full((1, 4), topk, dtype=torch.int32, device=device)
+
+    def fake_dsa_sparse_attn(
+        query,
+        kv_full,
+        attn_sink,
+        topk_idxs,
+        softmax_scale,
+        topk_length=None,
+        indexer_topk=0,
+        value_dim=None,
+    ):
+        del kv_full, attn_sink, topk_idxs, softmax_scale, indexer_topk
+        calls["sparse"] = {"topk_length_is_set": topk_length is not None, "value_dim": value_dim}
+        return query.new_zeros(query.shape[0], query.shape[1], query.shape[2] * value_dim)
+
+    monkeypatch.setattr(dsa._dsa_kernels, "indexer_topk", fake_indexer_topk)
+    monkeypatch.setattr(dsa._dsa_kernels, "dsa_sparse_attn", fake_dsa_sparse_attn)
+
+    attn = DynamicSparseAttention(
+        hidden_size=16,
+        num_attention_heads=2,
+        q_lora_rank=8,
+        kv_lora_rank=4,
+        qk_nope_head_dim=4,
+        qk_rope_head_dim=4,
+        v_head_dim=4,
+        index_n_heads=2,
+        index_head_dim=8,
+        index_topk=2,
+        rms_norm_eps=1e-5,
+    )
+    attn.to(device=device, dtype=torch.bfloat16)
+    attn.eval()
+    x = torch.randn(1, 4, 16, device=device, dtype=torch.bfloat16)
+    cos, sin = build_rope_cache(
+        dim=4, max_position_embeddings=4, rope_theta=1_000_000.0, device=device
+    )
+    position_ids = torch.arange(4, device=device).unsqueeze(0)
+
+    with torch.no_grad():
+        out = attn(x, cos=cos, sin=sin, position_ids=position_ids)
+
+    assert out.shape == (1, 4, 16)
+    assert calls["indexer"] == {"topk": 2, "ratio": 1}
+    assert calls["sparse"] == {"topk_length_is_set": True, "value_dim": 4}
+
+
+def test_glm5_lite_model_exports_native_state_names():
+    from megatron.lite.model.glm5.config import Glm5Config
+
+    model = _make_glm5_model(Glm5Config(**_tiny_config_kwargs()))
+    keys = set(model.state_dict())
+
+    assert "embed.embedding.weight" in keys
+    assert "layers.0.self_attention.self_attention.q_a_proj.weight" in keys
+    assert "layers.0.mlp.gate_up.linear.weight" in keys
+    assert "layers.1.moe.router.gate.weight" in keys
+    assert "layers.1.moe.experts.fc1.weight0" in keys
+    assert "layers.1.moe.shared_expert.gate_up.linear.weight" in keys
+    assert "head.col.linear.weight" in keys
+
+
+def test_glm5_checkpoint_exports_and_saves_hf_style_weights(tmp_path):
+    import torch
+    from safetensors import safe_open
+
+    from megatron.lite.model.glm5.config import Glm5Config
+    from megatron.lite.model.glm5.lite.checkpoint import (
+        export_hf_weights,
+        save_hf_weights,
+    )
+    from megatron.lite.primitive.parallel import ParallelState
+
+    cfg = Glm5Config(**_tiny_config_kwargs())
+    ps = ParallelState()
+    model = _make_glm5_model(cfg, ps=ps)
+    model.layers[1].moe.router.expert_bias.copy_(torch.tensor([0.25, -0.5, 1.0]))
+
+    exported = dict(export_hf_weights(model, cfg, ps))
+    state = model.state_dict()
+
+    assert torch.equal(
+        exported["model.layers.1.mlp.experts.2.gate_proj.weight"],
+        state["layers.1.moe.experts.fc1.weight2"][: cfg.moe_intermediate_size].detach().cpu(),
+    )
+    assert torch.equal(
+        exported["model.layers.1.mlp.gate.e_score_correction_bias"],
+        state["layers.1.moe.router.expert_bias"].detach().cpu(),
+    )
+    assert "model.layers.1.mlp.experts.gate_up_proj" not in exported
+
+    hf_dir = tmp_path / "hf"
+    save_hf_weights(model, str(hf_dir), cfg, ps)
+    with safe_open(str(hf_dir / "model.safetensors"), framework="pt", device="cpu") as handle:
+        assert torch.equal(
+            handle.get_tensor("model.layers.1.mlp.experts.2.down_proj.weight"),
+            state["layers.1.moe.experts.fc2.weight2"].detach().cpu(),
+        )
+        assert torch.equal(
+            handle.get_tensor("model.layers.1.mlp.gate.e_score_correction_bias"),
+            state["layers.1.moe.router.expert_bias"].detach().cpu(),
+        )
+
+    loaded = _make_glm5_model(cfg, ps=ps)
+    from megatron.lite.model.glm5.lite.checkpoint import load_hf_weights
+
+    load_hf_weights(loaded, str(hf_dir), cfg, ps)
+    assert torch.equal(
+        loaded.state_dict()["layers.1.moe.router.expert_bias"].detach().cpu(),
+        state["layers.1.moe.router.expert_bias"].detach().cpu(),
+    )
+
+    hf_bf16_dir = tmp_path / "hf_bf16"
+    save_hf_weights(model, str(hf_bf16_dir), cfg, ps, export_dtype=torch.bfloat16)
+    with safe_open(str(hf_bf16_dir / "model.safetensors"), framework="pt", device="cpu") as handle:
+        floating_dtypes = {
+            handle.get_tensor(key).dtype
+            for key in handle.keys()
+            if handle.get_tensor(key).is_floating_point()
+        }
+        assert floating_dtypes == {torch.bfloat16}
+
+    loaded_bf16 = _make_glm5_model(cfg, ps=ps)
+    load_hf_weights(loaded_bf16, str(hf_bf16_dir), cfg, ps)
+    assert torch.equal(
+        loaded_bf16.state_dict()["layers.1.moe.experts.fc1.weight2"][
+            cfg.moe_intermediate_size :
+        ]
+        .detach()
+        .cpu(),
+        state["layers.1.moe.experts.fc1.weight2"][cfg.moe_intermediate_size :]
+        .detach()
+        .cpu()
+        .to(torch.bfloat16)
+        .to(torch.float32),
+    )
+
+
+def test_glm5_checkpoint_exports_and_loads_mtp_layers(tmp_path):
+    import torch
+
+    from megatron.lite.model.glm5.config import Glm5Config
+    from megatron.lite.model.glm5.lite.checkpoint import export_hf_weights, load_hf_weights
+    from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
+    from megatron.lite.primitive.parallel import ParallelState
+
+    cfg = Glm5Config(**_tiny_config_kwargs(), num_nextn_predict_layers=1)
+    ps = ParallelState()
+    model = _make_glm5_model(cfg, ps=ps, mtp_enable=True)
+    state = model.state_dict()
+
+    assert "mtp.layers.0.eh_proj.linear.weight" in state
+    assert "mtp.layers.0.transformer_layer.input_layernorm.weight" in state
+
+    exported = dict(export_hf_weights(model, cfg, ps))
+    assert "model.layers.2.eh_proj.weight" in exported
+    assert "model.layers.2.enorm.weight" in exported
+    assert "model.layers.2.hnorm.weight" in exported
+    assert "model.layers.2.shared_head.norm.weight" in exported
+    assert "model.layers.2.input_layernorm.weight" in exported
+    assert "model.layers.2.mlp.gate.weight" in exported
+
+    save_safetensors(exported, str(tmp_path))
+    loaded = _make_glm5_model(cfg, ps=ps, mtp_enable=True)
+    load_hf_weights(loaded, str(tmp_path), cfg, ps)
+    assert torch.equal(
+        loaded.state_dict()["mtp.layers.0.eh_proj.linear.weight"],
+        state["mtp.layers.0.eh_proj.linear.weight"],
+    )
+
+
+def test_glm5_router_modules_use_current_names_and_bias_buffers():
+    import torch
+
+    from megatron.lite.model.glm5.config import Glm5Config
+    from megatron.lite.model.glm5.lite.model import Glm5SigmoidTopKRouter
+
+    model = _make_glm5_model(
+        Glm5Config(**_tiny_config_kwargs(), num_nextn_predict_layers=1), mtp_enable=True
+    )
+    routers = [module for module in model.modules() if isinstance(module, Glm5SigmoidTopKRouter)]
+    assert len(routers) == 2
+    for router in routers:
+        assert hasattr(router, "gate")
+        assert hasattr(router, "expert_bias")
+        assert torch.isfinite(router.gate.weight).all()
+        assert torch.equal(
+            router.expert_bias, torch.zeros_like(router.expert_bias)
+        )
+
+
+def test_glm5_protocol_allows_cp_only_parallel_scope():
+    import pytest
+
+    from megatron.lite.model.glm5.lite.protocol import _validate_parallel_scope
+    from megatron.lite.runtime.contracts import ParallelConfig
+
+    # CP-only as well as PP/VPP/EP are supported and must validate cleanly.
+    _validate_parallel_scope(ParallelConfig(tp=1, ep=1, etp=1, cp=2, pp=1, vpp=1))
+    _validate_parallel_scope(ParallelConfig(tp=1, ep=1, etp=1, cp=1, pp=2, vpp=2))
+    # GLM-5 native DSA attention rejects tensor / expert-tensor parallelism.
+    with pytest.raises(NotImplementedError):
+        _validate_parallel_scope(ParallelConfig(tp=2, ep=1, etp=1, cp=1, pp=1, vpp=1))
+    with pytest.raises(NotImplementedError):
+        _validate_parallel_scope(ParallelConfig(tp=1, ep=1, etp=2, cp=1, pp=1, vpp=1))
+
+
+def test_glm5_impl_config_accepts_runtime_mtp_fields():
+    from megatron.lite.model.glm5.config import Glm5Config
+    from megatron.lite.model.glm5.lite.protocol import ImplConfig
+
+    cfg = Glm5Config(**_tiny_config_kwargs(), num_nextn_predict_layers=1)
+
+    assert ImplConfig(mtp_enable=False, mtp_enable_train=False).mtp_enable is False
+    assert ImplConfig(mtp_enable=True, mtp_enable_train=True).mtp_enable_train is True
+    assert cfg.num_nextn_predict_layers == 1
+
+
+def test_glm5_protocol_uses_mlite_optimizer_api():
+    from megatron.lite.model.glm5.lite.protocol import ImplConfig
+
+    protocol_path = (
+        Path(__file__).resolve().parents[3]
+        / "megatron"
+        / "lite"
+        / "model"
+        / "glm5"
+        / "lite"
+        / "protocol.py"
+    )
+    protocol_text = protocol_path.read_text()
+
+    assert ImplConfig().optimizer == "dist_opt"
+    assert "build_dist_opt_training_optimizer" in protocol_text
+
+
+def test_glm5_lite_tiny_forward_backward(monkeypatch):
+    import pytest
+    import torch
+
+    from megatron.lite.model.glm5.config import Glm5Config
+    from megatron.lite.primitive.modules.attention import dsa
+
+    if not torch.cuda.is_available():
+        pytest.skip("GLM-5 native model requires CUDA (Transformer Engine RMSNorm)")
+    device = torch.device("cuda")
+
+    def fake_fused_indexer_sparse_attn(
+        query,
+        kv_full,
+        attn_sink,
+        window_idxs,
+        q_indexer,
+        k_indexer,
+        weights,
+        indexer_topk,
+        ratio,
+        softmax_scale,
+        indexer_softmax_scale=1.0,
+        loss_coeff=0.0,
+        sparse_loss=False,
+        kv_offset=0,
+        calculate_per_token_loss=False,
+        value_dim=None,
+    ):
+        del (
+            kv_full,
+            attn_sink,
+            window_idxs,
+            q_indexer,
+            k_indexer,
+            weights,
+            indexer_topk,
+            ratio,
+            softmax_scale,
+            indexer_softmax_scale,
+            loss_coeff,
+            sparse_loss,
+            kv_offset,
+            calculate_per_token_loss,
+        )
+        return query.new_zeros(
+            query.shape[0], query.shape[1], query.shape[2] * value_dim
+        ), torch.zeros((), device=query.device, dtype=torch.float32)
+
+    monkeypatch.setattr(
+        dsa._dsa_kernels, "fused_indexer_sparse_attn", fake_fused_indexer_sparse_attn
+    )
+
+    torch.manual_seed(1234)
+    model = _make_glm5_model(Glm5Config(**_tiny_config_kwargs())).to(
+        device=device, dtype=torch.bfloat16
+    )
+    input_ids = torch.randint(0, model.config.vocab_size, (2, 5), device=device)
+    labels = torch.randint(0, model.config.vocab_size, (2, 5), device=device)
+
+    output = model(input_ids=input_ids, labels=labels)
+
+    # hidden_states stays in (seq, batch, hidden) layout; logits are transposed
+    # back to (batch, seq, *) inside forward.
+    assert output["hidden_states"].shape == (5, 2, model.config.hidden_size)
+    assert output["loss"].ndim == 0
+    output["loss"].backward()
+    grad_norm = sum(
+        param.grad.detach().float().norm() for param in model.parameters() if param.grad is not None
+    )
+    assert torch.isfinite(grad_norm)
+
+    mtp_model = _make_glm5_model(
+        Glm5Config(**_tiny_config_kwargs(), num_nextn_predict_layers=1),
+        mtp_enable=True,
+        mtp_enable_train=True,
+    ).to(device=device, dtype=torch.bfloat16)
+    # Inference path (no labels) exposes the per-MTP-head logits.
+    mtp_infer = mtp_model(input_ids=input_ids)
+    assert len(mtp_infer["mtp_hidden_states"]) == 1
+    assert len(mtp_infer["mtp_logits"]) == 1
+    assert mtp_infer["mtp_hidden_states"][0].shape == (5, 2, mtp_model.config.hidden_size)
+    assert mtp_infer["mtp_logits"][0].shape == (2, 5, mtp_model.config.vocab_size)
+
+    # Training path (with labels) returns the MTP loss instead of logits.
+    mtp_output = mtp_model(
+        input_ids=input_ids, labels=labels, loss_mask=torch.ones_like(labels, dtype=torch.float32)
+    )
+
+    assert len(mtp_output["mtp_hidden_states"]) == 1
+    assert mtp_output["mtp_hidden_states"][0].shape == (5, 2, mtp_model.config.hidden_size)
+    assert mtp_output["mtp_loss"].ndim == 0
+    mtp_output["loss"].backward()
+    mtp_grad_norm = sum(
+        param.grad.detach().float().norm()
+        for param in mtp_model.parameters()
+        if param.grad is not None
+    )
+    assert torch.isfinite(mtp_grad_norm)

--- a/experimental/lite/tests/unit/model/test_glm5_lite_static.py
+++ b/experimental/lite/tests/unit/model/test_glm5_lite_static.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Static and CPU smoke tests for native GLM-5 lite."""
 
 from __future__ import annotations

--- a/experimental/lite/tests/unit/model/test_kimi_k2_int4_dequant.py
+++ b/experimental/lite/tests/unit/model/test_kimi_k2_int4_dequant.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Bit-exact parity for the Kimi K2 INT4 load-path dequant.
+
+Kimi ships INT4-packed release weights (eight offset-binary INT4 values per
+int32 slot + per-group scales).  The MLite load path dequantizes them in
+``kimi_k2/lite/checkpoint.py`` without any ``transformers`` / external-bridge
+dependency.  This test pins that dequant to be bit-exact against the reference
+algorithm in ``megatron.bridge`` (``conversion/quantization_utils.py``:
+``quantize_to_int4`` / ``dequantize_int4``), which the load path was written to
+match.  The reference is vendored here (CPU-only, no GPU) so the guard runs in
+unit CI and does not import megatron.bridge.
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+# ---------------------------------------------------------------------------
+# Reference INT4 quant/dequant, copied verbatim from megatron.bridge
+# conversion/quantization_utils.py (quantize_to_int4 / dequantize_int4).  These
+# define the "ground truth" packed layout + group-scale semantics that the
+# MLite load path must reproduce exactly.
+# ---------------------------------------------------------------------------
+def _bridge_quantize_to_int4(
+    weight: torch.Tensor, group_size: int = 32, scale_dtype: torch.dtype = torch.bfloat16
+):
+    out_features, in_features = weight.shape
+    weight_shape = torch.tensor([out_features, in_features], dtype=torch.int32)
+
+    w = weight.float()
+    num_groups = (in_features + group_size - 1) // group_size
+    w_grouped = w.view(out_features, num_groups, -1)
+
+    group_max = w_grouped.abs().amax(dim=-1)
+    scale = (group_max / 7.0).clamp(min=1e-10)
+
+    scale_expanded = scale.unsqueeze(-1).expand_as(w_grouped)
+    w_q = (w_grouped / scale_expanded).round().clamp(-8, 7)
+
+    w_q = w_q.view(out_features, -1)[:, :in_features]
+    w_q = (w_q + 8).to(torch.uint8)
+
+    assert in_features % 8 == 0
+    w_q_grouped = w_q.view(out_features, in_features // 8, 8).to(torch.int32)
+    packed = torch.zeros(out_features, in_features // 8, dtype=torch.int32)
+    for i in range(8):
+        packed |= (w_q_grouped[:, :, i] & 0xF) << (i * 4)
+
+    return packed, scale.to(scale_dtype), weight_shape
+
+
+def _bridge_dequantize_int4(
+    weight_packed: torch.Tensor, weight_scale: torch.Tensor, weight_shape: torch.Tensor
+) -> torch.Tensor:
+    local_out, local_packed_in = weight_packed.shape
+    local_in = local_packed_in * 8
+
+    shifts = torch.arange(8) * 4
+    unpacked = ((weight_packed.unsqueeze(-1) >> shifts) & 0xF).float()
+    unpacked = unpacked.reshape(local_out, local_in) - 8
+
+    scale = weight_scale.float()
+    if scale.ndim == 1:
+        scale = scale.view(local_out, scale.numel() // local_out)
+    else:
+        scale = scale.view(local_out, -1)
+    elements_per_group = local_in // scale.shape[1]
+    scale_expanded = scale.repeat_interleave(elements_per_group, dim=1)[:, :local_in]
+
+    return (unpacked * scale_expanded).to(torch.bfloat16)
+
+
+class _StubReader:
+    """Minimal ``SafeTensorReader`` stand-in for the dequant helpers.
+
+    The load helpers only call ``.get_tensor(name)`` and consult ``.index`` (via
+    ``_has``); a dict + key set is enough.
+    """
+
+    def __init__(self, tensors: dict[str, torch.Tensor]):
+        self._tensors = dict(tensors)
+        self.index = set(self._tensors)
+
+    def get_tensor(self, name: str) -> torch.Tensor:
+        return self._tensors[name]
+
+
+def test_kimi_int4_dequant_bit_exact_to_bridge():
+    from megatron.lite.model.kimi_k2.lite.checkpoint import _dequant_int4_weight
+
+    torch.manual_seed(2026)
+    # out_features arbitrary; in_features divisible by both 8 (pack factor) and 32
+    # (group_size) so the packed/group layout is exercised with >1 group per row.
+    weight = torch.randn(40, 128, dtype=torch.bfloat16)
+
+    packed, scale, shape = _bridge_quantize_to_int4(weight)
+    reference = _bridge_dequantize_int4(packed, scale, shape)
+
+    reader = _StubReader(
+        {"w_packed": packed, "w_scale": scale, "w_shape": shape}
+    )
+    got = _dequant_int4_weight(reader, "w")
+
+    assert got.dtype == torch.bfloat16
+    assert got.shape == reference.shape
+    assert torch.equal(got, reference), (
+        "MLite INT4 dequant diverged from the megatron.bridge reference: "
+        f"max|diff|={(got.float() - reference.float()).abs().max().item()}"
+    )
+
+
+def test_kimi_get_passes_through_bf16_when_unquantized():
+    """``_get`` must load a plain bf16 tensor unchanged (no scale, no packing).
+
+    MLite export/save emits bf16, so reloading an exported (or already bf16)
+    checkpoint must hit the no-dequant path — the third load case alongside
+    FP8 (``*_scale_inv``) and INT4 (``*_packed``).
+    """
+    from megatron.lite.model.kimi_k2.lite.checkpoint import _get
+
+    torch.manual_seed(7)
+    weight = torch.randn(16, 24, dtype=torch.bfloat16)
+    reader = _StubReader({"layer.weight": weight})
+
+    got = _get(reader, "layer.weight")
+    assert got.dtype == torch.bfloat16
+    assert torch.equal(got, weight)
+
+
+def test_kimi_get_dispatches_to_int4_when_packed_present():
+    """When only ``*_packed`` exists (no plain tensor), ``_get`` dequantizes INT4."""
+    from megatron.lite.model.kimi_k2.lite.checkpoint import _get
+
+    torch.manual_seed(11)
+    weight = torch.randn(8, 64, dtype=torch.bfloat16)
+    packed, scale, shape = _bridge_quantize_to_int4(weight)
+    reader = _StubReader({"w_packed": packed, "w_scale": scale, "w_shape": shape})
+
+    got = _get(reader, "w")
+    assert torch.equal(got, _bridge_dequantize_int4(packed, scale, shape))

--- a/experimental/lite/tests/unit/model/test_kimi_k2_lite_cp_smoke.py
+++ b/experimental/lite/tests/unit/model/test_kimi_k2_lite_cp_smoke.py
@@ -1,0 +1,535 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+def _init_dist_or_skip():
+    import os
+
+    import torch
+    import torch.distributed as dist
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for Kimi K2 CP smoke.")
+    if "RANK" not in os.environ or "WORLD_SIZE" not in os.environ:
+        pytest.skip("Run with torchrun so CP ranks are available.")
+
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    torch.cuda.set_device(local_rank)
+    if not dist.is_initialized():
+        dist.init_process_group("nccl")
+    if dist.get_world_size() < 2:
+        pytest.skip("Kimi K2 CP smoke requires at least 2 ranks.")
+    return torch.device("cuda", local_rank)
+
+
+def _tiny_config():
+    from megatron.lite.model.kimi_k2.config import KimiK2Config
+
+    return KimiK2Config(
+        num_hidden_layers=2,
+        hidden_size=64,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        vocab_size=128,
+        intermediate_size=96,
+        moe_intermediate_size=16,
+        n_routed_experts=4,
+        n_shared_experts=1,
+        num_experts_per_tok=2,
+        n_group=2,
+        topk_group=1,
+        first_k_dense_replace=1,
+        q_lora_rank=16,
+        kv_lora_rank=12,
+        qk_nope_head_dim=8,
+        qk_rope_head_dim=8,
+        v_head_dim=8,
+        max_position_embeddings=128,
+        rope_theta=10000.0,
+        rope_scaling={
+            "type": "yarn",
+            "factor": 1.0,
+            "original_max_position_embeddings": 128,
+            "beta_fast": 1.0,
+            "beta_slow": 1.0,
+            "mscale": 1.0,
+            "mscale_all_dim": 1.0,
+        },
+    )
+
+
+def _tiny_hf_parity_config():
+    from megatron.lite.model.kimi_k2.config import KimiK2Config
+
+    return KimiK2Config(
+        num_hidden_layers=2,
+        hidden_size=64,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        vocab_size=128,
+        intermediate_size=96,
+        moe_intermediate_size=16,
+        n_routed_experts=4,
+        n_shared_experts=1,
+        num_experts_per_tok=2,
+        n_group=2,
+        topk_group=1,
+        first_k_dense_replace=1,
+        q_lora_rank=16,
+        kv_lora_rank=12,
+        qk_nope_head_dim=8,
+        qk_rope_head_dim=8,
+        v_head_dim=8,
+        max_position_embeddings=128,
+        rope_theta=10000.0,
+        rope_scaling={
+            "type": "yarn",
+            "factor": 1.0,
+            "original_max_position_embeddings": 128,
+            "beta_fast": 1.0,
+            "beta_slow": 1.0,
+            "mscale": 1.0,
+            "mscale_all_dim": 1.0,
+        },
+    )
+
+
+def _train_cfg(cp: int):
+    return SimpleNamespace(
+        tp=1,
+        ep=1,
+        etp=1,
+        pp=1,
+        cp=cp,
+        vpp=None,
+        use_deepep=False,
+        fp8=False,
+        recompute_modules={},
+        deterministic=False,
+    )
+
+
+def _to_hf_deepseek_v3_config(cfg):
+    from transformers.models.deepseek_v3.configuration_deepseek_v3 import DeepseekV3Config
+
+    rope_scaling = dict(cfg.rope_scaling)
+    rope_scaling.setdefault("rope_type", rope_scaling.get("type", "yarn"))
+    return DeepseekV3Config(
+        hidden_size=cfg.hidden_size,
+        intermediate_size=cfg.intermediate_size,
+        moe_intermediate_size=cfg.moe_intermediate_size,
+        num_hidden_layers=cfg.num_hidden_layers,
+        num_attention_heads=cfg.num_attention_heads,
+        num_key_value_heads=cfg.num_key_value_heads,
+        vocab_size=cfg.vocab_size,
+        n_shared_experts=cfg.n_shared_experts,
+        n_routed_experts=cfg.n_routed_experts,
+        routed_scaling_factor=cfg.routed_scaling_factor,
+        kv_lora_rank=cfg.kv_lora_rank,
+        q_lora_rank=cfg.q_lora_rank,
+        qk_rope_head_dim=cfg.qk_rope_head_dim,
+        v_head_dim=cfg.v_head_dim,
+        qk_nope_head_dim=cfg.qk_nope_head_dim,
+        n_group=cfg.n_group,
+        topk_group=cfg.topk_group,
+        num_experts_per_tok=cfg.num_experts_per_tok,
+        first_k_dense_replace=cfg.first_k_dense_replace,
+        norm_topk_prob=cfg.norm_topk_prob,
+        max_position_embeddings=cfg.max_position_embeddings,
+        rms_norm_eps=cfg.rms_norm_eps,
+        tie_word_embeddings=cfg.tie_word_embeddings,
+        rope_theta=cfg.rope_theta,
+        rope_scaling=rope_scaling,
+        rope_interleave=True,
+        attention_bias=False,
+        attention_dropout=0.0,
+        use_cache=False,
+    )
+
+
+def _capture_tensor_output(outputs):
+    return outputs[0].detach() if isinstance(outputs, tuple) else outputs.detach()
+
+
+def _distributed_diff_stats(actual, expected) -> tuple[float, float]:
+    import torch
+    import torch.distributed as dist
+
+    diff = (actual.float() - expected.float()).abs()
+    max_abs = diff.max()
+    scale = torch.maximum(actual.float().abs().max(), expected.float().abs().max()).clamp_min(1e-6)
+    stats = torch.stack([max_abs, scale])
+    if dist.is_initialized():
+        dist.all_reduce(stats, op=dist.ReduceOp.MAX)
+    return float(stats[0].item()), float((stats[0] / stats[1]).item())
+
+
+def _hf_state_dict_for_kimi_loader(model):
+    state = {
+        name: tensor.detach().cpu().contiguous().clone()
+        for name, tensor in model.state_dict().items()
+    }
+    for name, gate_up in list(state.items()):
+        if not name.endswith(".mlp.experts.gate_up_proj"):
+            continue
+        prefix = name.removesuffix(".gate_up_proj")
+        down = state.get(f"{prefix}.down_proj")
+        gate, up = gate_up.chunk(2, dim=1)
+        for expert_idx in range(gate_up.size(0)):
+            state[f"{prefix}.{expert_idx}.gate_proj.weight"] = gate[expert_idx].contiguous().clone()
+            state[f"{prefix}.{expert_idx}.up_proj.weight"] = up[expert_idx].contiguous().clone()
+            if down is not None:
+                state[f"{prefix}.{expert_idx}.down_proj.weight"] = (
+                    down[expert_idx].contiguous().clone()
+                )
+    return state
+
+
+def test_kimi_k2_mla_cp2_matches_full_sequence_reference_forward_and_grad():
+    import torch
+    import torch.distributed as dist
+
+    device = _init_dist_or_skip()
+    from megatron.lite.primitive.modules.attention import MultiLatentAttention
+    from megatron.lite.primitive.parallel import ParallelState
+    from megatron.lite.primitive.parallel.cp import zigzag_slice_for_cp
+    from megatron.lite.primitive.parallel.state import init_parallel
+    from megatron.lite.runtime.contracts import ParallelConfig
+
+    world = dist.get_world_size()
+    rank = dist.get_rank()
+    cfg = _tiny_config()
+    ps = init_parallel(ParallelConfig(tp=1, ep=1, etp=1, cp=world, pp=1))
+
+    kwargs = dict(
+        hidden_size=cfg.hidden_size,
+        num_attention_heads=cfg.num_attention_heads,
+        q_lora_rank=cfg.q_lora_rank,
+        kv_lora_rank=cfg.kv_lora_rank,
+        qk_nope_head_dim=cfg.qk_nope_head_dim,
+        qk_rope_head_dim=cfg.qk_rope_head_dim,
+        v_head_dim=cfg.v_head_dim,
+        rms_norm_eps=cfg.rms_norm_eps,
+        rope_theta=cfg.rope_theta,
+        rope_scaling=cfg.rope_scaling,
+        use_thd=False,
+    )
+    torch.manual_seed(20260531)
+    cp_layer = MultiLatentAttention(ps=ps, **kwargs).to(device=device, dtype=torch.bfloat16)
+    torch.manual_seed(20260531)
+    ref_layer = MultiLatentAttention(ps=ParallelState(), **kwargs).to(
+        device=device,
+        dtype=torch.bfloat16,
+    )
+
+    seq, batch = 8 * world, 1
+    torch.manual_seed(123)
+    full_x = torch.randn(seq, batch, cfg.hidden_size, device=device, dtype=torch.bfloat16)
+    local_x = zigzag_slice_for_cp(full_x, rank, world, seq_dim=0).detach().requires_grad_(True)
+    ref_x = full_x.detach().clone().requires_grad_(True)
+
+    cp_out = cp_layer(local_x)
+    ref_out = ref_layer(ref_x)
+    expected = zigzag_slice_for_cp(ref_out, rank, world, seq_dim=0)
+    torch.testing.assert_close(cp_out, expected, atol=5e-2, rtol=5e-2)
+
+    cp_out.float().sum().backward()
+    expected.float().sum().backward()
+    expected_grad = zigzag_slice_for_cp(ref_x.grad, rank, world, seq_dim=0)
+    assert local_x.grad is not None
+    torch.testing.assert_close(local_x.grad, expected_grad, atol=1e-1, rtol=1e-1)
+
+
+def test_kimi_k2_tiny_model_cp2_matches_full_sequence_reference_forward():
+    import torch
+    import torch.distributed as dist
+
+    device = _init_dist_or_skip()
+    from megatron.lite.model.kimi_k2.lite.model import KimiK2Model
+    from megatron.lite.primitive.parallel import ParallelState
+    from megatron.lite.primitive.parallel.cp import zigzag_slice_for_cp
+    from megatron.lite.primitive.parallel.state import init_parallel
+    from megatron.lite.runtime.contracts import ParallelConfig
+
+    world = dist.get_world_size()
+    rank = dist.get_rank()
+    cfg = _tiny_config()
+    ps = init_parallel(ParallelConfig(tp=1, ep=1, etp=1, cp=world, pp=1))
+
+    torch.manual_seed(777)
+    cp_model = KimiK2Model(cfg, _train_cfg(world), ps, use_thd=False).to(
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    torch.manual_seed(777)
+    ref_model = KimiK2Model(cfg, _train_cfg(1), ParallelState(), use_thd=False).to(
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    cp_model.eval()
+    ref_model.eval()
+
+    batch, seq = 1, 8 * world
+    torch.manual_seed(100)
+    full_ids = torch.randint(0, cfg.vocab_size, (batch, seq), device=device)
+    full_labels = torch.randint(0, cfg.vocab_size, (batch, seq), device=device)
+    input_ids = zigzag_slice_for_cp(full_ids, rank, world, seq_dim=1).contiguous()
+    labels = zigzag_slice_for_cp(full_labels, rank, world, seq_dim=1).contiguous()
+
+    with torch.no_grad():
+        cp_out = cp_model(input_ids=input_ids, labels=labels)
+        ref_out = ref_model(input_ids=full_ids, labels=full_labels)
+
+    expected_hidden = zigzag_slice_for_cp(ref_out["hidden_states"], rank, world, seq_dim=0)
+    expected_log_probs = zigzag_slice_for_cp(ref_out["log_probs"], rank, world, seq_dim=1)
+    torch.testing.assert_close(cp_out["hidden_states"], expected_hidden, atol=1e-1, rtol=1e-1)
+    torch.testing.assert_close(cp_out["log_probs"], expected_log_probs, atol=1e-1, rtol=1e-1)
+
+
+def test_kimi_k2_tiny_model_cp2_matches_hf_reference_logits(tmp_path):
+    import torch
+    import torch.distributed as dist
+    from transformers.models.deepseek_v3.modeling_deepseek_v3 import DeepseekV3ForCausalLM
+
+    device = _init_dist_or_skip()
+    from megatron.lite.model.kimi_k2.lite.checkpoint import load_hf_weights
+    from megatron.lite.model.kimi_k2.lite.model import KimiK2Model
+    from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
+    from megatron.lite.primitive.parallel.cp import zigzag_slice_for_cp
+    from megatron.lite.primitive.parallel.state import init_parallel
+    from megatron.lite.runtime.contracts import ParallelConfig
+
+    world = dist.get_world_size()
+    rank = dist.get_rank()
+    cfg = _tiny_hf_parity_config()
+
+    torch.manual_seed(20260610)
+    hf_ref = DeepseekV3ForCausalLM(_to_hf_deepseek_v3_config(cfg)).to(
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    hf_ref.eval()
+    rank_tmp_path = tmp_path / f"rank{rank}"
+    save_safetensors(
+        _hf_state_dict_for_kimi_loader(hf_ref),
+        str(rank_tmp_path),
+    )
+
+    ps = init_parallel(ParallelConfig(tp=1, ep=1, etp=1, cp=world, pp=1))
+    native = KimiK2Model(cfg, _train_cfg(world), ps, use_thd=False).to(
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    native.eval()
+    load_hf_weights(native, str(rank_tmp_path), cfg, ps)
+
+    batch, seq = 1, 4 * world
+    torch.manual_seed(310)
+    full_ids = torch.randint(0, cfg.vocab_size, (batch, seq), device=device)
+    local_ids = zigzag_slice_for_cp(full_ids, rank, world, seq_dim=1).contiguous()
+
+    hf_layer_outputs = []
+    native_layer_outputs = []
+    hooks = []
+    for layer in hf_ref.model.layers:
+        hooks.append(
+            layer.register_forward_hook(
+                lambda _module, _inputs, outputs: hf_layer_outputs.append(
+                    _capture_tensor_output(outputs)
+                )
+            )
+        )
+    for layer in native.layers:
+        hooks.append(
+            layer.register_forward_hook(
+                lambda _module, _inputs, outputs: native_layer_outputs.append(
+                    _capture_tensor_output(outputs)
+                )
+            )
+        )
+
+    with torch.no_grad():
+        if rank == 0:
+            print(
+                "kimi_k2_hf_native_parity reference=transformers.DeepseekV3ForCausalLM "
+                "rope=DeepseekV3RotaryEmbedding+apply_rotary_pos_emb_interleave"
+            )
+        hf_logits = hf_ref(full_ids).logits
+        native_logits = native(input_ids=local_ids)["logits"]
+
+    for hook in hooks:
+        hook.remove()
+
+    assert len(hf_layer_outputs) == cfg.num_hidden_layers
+    assert len(native_layer_outputs) == cfg.num_hidden_layers
+    for layer_idx, (actual, full_expected) in enumerate(
+        zip(native_layer_outputs, hf_layer_outputs, strict=True)
+    ):
+        expected = zigzag_slice_for_cp(full_expected, rank, world, seq_dim=1)
+        expected = expected.transpose(0, 1).contiguous()
+        max_abs, max_rel = _distributed_diff_stats(actual, expected)
+        if rank == 0:
+            print(
+                f"kimi_k2_hf_native_parity layer={layer_idx} "
+                f"max_abs_diff={max_abs:.6e} max_rel_diff={max_rel:.6e}"
+            )
+        torch.testing.assert_close(
+            actual.float(),
+            expected.float(),
+            atol=1.5e-1,
+            rtol=1.5e-1,
+        )
+
+    expected = zigzag_slice_for_cp(hf_logits, rank, world, seq_dim=1).contiguous()
+    max_abs, max_rel = _distributed_diff_stats(native_logits, expected)
+    if rank == 0:
+        print(
+            "kimi_k2_hf_native_parity logits "
+            f"max_abs_diff={max_abs:.6e} max_rel_diff={max_rel:.6e}"
+        )
+    torch.testing.assert_close(
+        native_logits.float(),
+        expected.float(),
+        atol=1.5e-1,
+        rtol=1.5e-1,
+    )
+
+
+def test_kimi_k2_packed_thd_variable_sequence_cp2_smoke():
+    import torch
+    import torch.distributed as dist
+
+    device = _init_dist_or_skip()
+    from megatron.lite.model.kimi_k2.lite.model import KimiK2Model
+    from megatron.lite.primitive.parallel.state import init_parallel
+    from megatron.lite.primitive.parallel.thd import pack_nested_thd, unpack_packed_thd_to_nested
+    from megatron.lite.runtime.contracts import ParallelConfig
+
+    world = dist.get_world_size()
+    rank = dist.get_rank()
+    cfg = _tiny_config()
+    ps = init_parallel(ParallelConfig(tp=1, ep=1, etp=1, cp=world, pp=1))
+
+    torch.manual_seed(20260614)
+    model = KimiK2Model(cfg, _train_cfg(world), ps, use_thd=True).to(
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    model.train()
+
+    lengths = [5, 7, 9]
+    ids = torch.nested.as_nested_tensor(
+        [
+            torch.randint(0, cfg.vocab_size, (length,), device=device, dtype=torch.long)
+            for length in lengths
+        ],
+        layout=torch.jagged,
+    )
+    labels = torch.nested.as_nested_tensor(
+        [
+            torch.randint(0, cfg.vocab_size, (length,), device=device, dtype=torch.long)
+            for length in lengths
+        ],
+        layout=torch.jagged,
+    )
+    loss_mask = torch.nested.as_nested_tensor(
+        [torch.ones(length, device=device, dtype=torch.float32) for length in lengths],
+        layout=torch.jagged,
+    )
+    packed = pack_nested_thd(
+        ids,
+        cp_size=world,
+        cp_rank=rank,
+        cp_group=ps.cp_group,
+        labels=labels,
+        loss_mask=loss_mask,
+    )
+
+    out = model(
+        input_ids=packed.input_ids,
+        labels=packed.labels,
+        loss_mask=packed.loss_mask,
+        position_ids=packed.position_ids,
+        packed_seq_params=packed.packed_seq_params,
+    )
+    assert torch.isfinite(out["loss"])
+    out["loss"].backward()
+    nested_log_probs = unpack_packed_thd_to_nested(out["log_probs"], packed)
+    assert nested_log_probs.offsets().numel() == len(lengths) + 1
+    assert [int(x) for x in nested_log_probs.offsets().diff().cpu()] == lengths
+
+    if rank == 0:
+        print(
+            "NON_SKIP_KIMI_K2_THD_CP_SMOKE_PASSED "
+            f"world_size={world} lengths={lengths} "
+            f"loss={float(out['loss'].detach().item()):.6e}"
+        )
+
+
+def test_kimi_k2_tiny_model_fsdp2_optimizer_step_smoke():
+    import torch
+    import torch.distributed as dist
+
+    device = _init_dist_or_skip()
+    from megatron.lite.model.kimi_k2.lite.protocol import ImplConfig, build_model
+    from megatron.lite.primitive.optimizers.fsdp2 import FSDP2Optimizer, fsdp2_available
+    from megatron.lite.runtime.contracts import OptimizerConfig, ParallelConfig
+
+    if not fsdp2_available():
+        pytest.skip("Installed PyTorch does not expose FSDP2 fully_shard.")
+
+    rank = dist.get_rank()
+    world = dist.get_world_size()
+    cfg = _tiny_config()
+    impl_cfg = ImplConfig(
+        parallel=ParallelConfig(tp=1, ep=1, etp=1, cp=1, pp=1),
+        optimizer="fsdp2",
+        optimizer_config=OptimizerConfig(
+            optimizer="adam",
+            lr=1.0e-4,
+            weight_decay=0.0,
+            clip_grad=1.0,
+            adam_beta1=0.9,
+            adam_beta2=0.95,
+            adam_eps=1.0e-8,
+        ),
+    )
+
+    torch.manual_seed(20260612)
+    bundle = build_model(cfg, impl_cfg=impl_cfg)
+    assert bundle.optimizer is None
+    assert bundle.extras["optimizer_backend"] == "fsdp2"
+    post_model_load_hook = bundle.extras["post_model_load_hook"]
+    assert post_model_load_hook is not None
+    updates = post_model_load_hook()
+    optimizer = updates["optimizer"]
+    assert isinstance(optimizer, FSDP2Optimizer)
+    assert optimizer.name == "fsdp2"
+
+    model = bundle.chunks[0]
+    model.train()
+    optimizer.zero_grad()
+
+    batch, seq = 1, 8
+    torch.manual_seed(20260613 + rank)
+    input_ids = torch.randint(0, cfg.vocab_size, (batch, seq), device=device)
+    labels = torch.randint(0, cfg.vocab_size, (batch, seq), device=device)
+
+    out = model(input_ids=input_ids, labels=labels)
+    loss = out["loss"]
+    assert torch.isfinite(loss)
+    loss.backward()
+    success, grad_norm, num_zeros = optimizer.step()
+    assert success
+    assert num_zeros == 0
+    assert torch.isfinite(torch.tensor(grad_norm))
+    if rank == 0:
+        print(
+            "kimi_k2_fsdp2_smoke optimizer=fsdp2 "
+            f"world_size={world} loss={float(loss.detach().item()):.6e} "
+            f"grad_norm={grad_norm:.6e}"
+        )

--- a/experimental/lite/tests/unit/model/test_kimi_k2_lite_static.py
+++ b/experimental/lite/tests/unit/model/test_kimi_k2_lite_static.py
@@ -1,0 +1,340 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Static smoke coverage for Kimi K2 lite native implementation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def test_kimi_k2_lite_registry_resolves():
+    from megatron.lite.model.registry import (
+        get_train_runtime_module,
+        resolve_model_type_from_hf,
+        resolve_runtime_model_name,
+    )
+
+    runtime_name = resolve_runtime_model_name("kimi_k2", "lite")
+    assert runtime_name == "kimi_k2"
+    assert resolve_model_type_from_hf({"model_type": "kimi_k2"}) == "kimi_k2"
+    assert resolve_model_type_from_hf({"model_type": "deepseek_v3"}) == "kimi_k2"
+    module = get_train_runtime_module(runtime_name)
+    assert module.__name__ == "megatron.lite.model.kimi_k2.lite.protocol"
+
+
+def test_kimi_k2_config_reads_hf_fields():
+    from megatron.lite.model.kimi_k2.config import KimiK2Config
+
+    cfg = KimiK2Config._from_hf_dict(
+        {
+            "model_type": "kimi_k2",
+            "num_hidden_layers": 3,
+            "hidden_size": 32,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 4,
+            "vocab_size": 128,
+            "intermediate_size": 64,
+            "moe_intermediate_size": 16,
+            "n_routed_experts": 8,
+            "n_shared_experts": 2,
+            "num_experts_per_tok": 2,
+            "n_group": 4,
+            "topk_group": 2,
+            "topk_method": "noaux_tc",
+            "norm_topk_prob": True,
+            "scoring_func": "sigmoid",
+            "seq_aux": True,
+            "first_k_dense_replace": 1,
+            "q_lora_rank": 12,
+            "kv_lora_rank": 10,
+            "qk_nope_head_dim": 6,
+            "qk_rope_head_dim": 2,
+            "v_head_dim": 8,
+            "rope_scaling": {"type": "yarn", "factor": 32.0},
+        }
+    )
+
+    assert cfg.num_experts == 8
+    assert cfg.n_group == 4
+    assert cfg.topk_group == 2
+    assert cfg.shared_expert_intermediate_size == 32
+    assert cfg.q_head_dim == 8
+    assert not cfg.is_moe_layer(0)
+    assert cfg.is_moe_layer(1)
+
+
+def test_kimi_k2_lite_does_not_import_wrappers_or_sibling_models():
+    root = Path(__file__).resolve().parents[3] / "megatron" / "lite" / "model" / "kimi_k2" / "lite"
+    forbidden = (
+        "megatron.lite.model.qwen3_5",
+        "megatron.lite.model.qwen3_moe",
+        "bridge_model",
+        "hybrid",
+        "build_mcore_context",
+        "from mbridge",
+        "import mbridge",
+    )
+    for path in root.glob("*.py"):
+        text = path.read_text()
+        for token in forbidden:
+            assert token not in text
+
+
+def test_kimi_k2_lite_implementation_files_stay_small():
+    root = Path(__file__).resolve().parents[3] / "megatron" / "lite" / "model" / "kimi_k2" / "lite"
+    for name in ("model.py", "protocol.py", "checkpoint.py"):
+        line_count = len((root / name).read_text().splitlines())
+        assert line_count < 1000, f"{name} has {line_count} lines"
+
+
+def test_kimi_k2_lite_uses_shared_mla_primitive():
+    lite_root = Path(__file__).resolve().parents[3] / "megatron" / "lite"
+    model_root = lite_root / "model" / "kimi_k2" / "lite"
+    primitive_mla = lite_root / "primitive" / "modules" / "attention" / "mla.py"
+    model_text = (model_root / "model.py").read_text()
+    mla_text = primitive_mla.read_text()
+
+    assert (
+        "from megatron.lite.primitive.modules.attention import MultiLatentAttention" in model_text
+    )
+    assert not (model_root / "mla.py").exists()
+    assert "class MultiLatentAttention" not in model_text
+    assert "class MultiLatentAttention" in mla_text
+    assert "megatron.core" not in mla_text
+    assert "KimiK2SigmoidTopKRouter" in model_text
+
+
+def test_kimi_k2_lite_optimizer_names_are_current():
+    root = Path(__file__).resolve().parents[3] / "megatron" / "lite" / "model" / "kimi_k2" / "lite"
+    protocol_text = (root / "protocol.py").read_text()
+
+    assert 'optimizer: str | None = "dist_opt"' in protocol_text
+    assert 'impl_cfg.optimizer == "dist_opt"' in protocol_text
+    assert 'impl_cfg.optimizer == "fsdp2"' in protocol_text
+    for forbidden in ("m" + "c_full", 'optimizer == "m' + 'c"'):
+        assert forbidden not in protocol_text
+
+
+def test_kimi_k2_dist_opt_deterministic_default_is_enabled():
+    from megatron.lite.model.kimi_k2.lite.protocol import ImplConfig
+
+    cfg = ImplConfig(optimizer="dist_opt", deterministic=True, mtp_enable=True)
+
+    assert cfg.optimizer == "dist_opt"
+    assert cfg.deterministic is True
+    assert cfg.mtp_enable is True
+
+
+def test_kimi_k2_impl_config_accepts_runtime_mtp_fields():
+    from megatron.lite.model.kimi_k2.config import KimiK2Config
+    from megatron.lite.model.kimi_k2.lite.protocol import ImplConfig
+
+    cfg = KimiK2Config(
+        num_hidden_layers=1,
+        hidden_size=8,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        vocab_size=16,
+        intermediate_size=12,
+        moe_intermediate_size=4,
+        n_routed_experts=2,
+        n_shared_experts=1,
+        num_experts_per_tok=1,
+        n_group=1,
+        topk_group=1,
+        first_k_dense_replace=1,
+        q_lora_rank=4,
+        kv_lora_rank=4,
+        qk_nope_head_dim=2,
+        qk_rope_head_dim=2,
+        v_head_dim=2,
+        num_nextn_predict_layers=1,
+    )
+
+    assert ImplConfig(mtp_enable=False, mtp_enable_train=False).mtp_enable is False
+    assert ImplConfig(mtp_enable=True, mtp_enable_train=True).mtp_enable_train is True
+    assert cfg.num_nextn_predict_layers == 1
+
+
+def test_kimi_k2_mtp_and_pp_layout_rules_are_explicit():
+    from megatron.lite.primitive.parallel import ParallelState, build_pipeline_chunk_layout
+
+    model_text = (
+        Path(__file__).resolve().parents[3]
+        / "megatron"
+        / "lite"
+        / "model"
+        / "kimi_k2"
+        / "lite"
+        / "model.py"
+    ).read_text()
+
+    rank0 = ParallelState(pp_size=2, pp_rank=0, pp_is_first=True, pp_is_last=False)
+    rank1 = ParallelState(pp_size=2, pp_rank=1, pp_is_first=False, pp_is_last=True)
+
+    assert build_pipeline_chunk_layout(4, rank0).layer_indices == [0, 1]
+    assert build_pipeline_chunk_layout(4, rank1).layer_indices == [2, 3]
+    # MTP is built on the stage the layout designates (layout.has_mtp), not a
+    # hard-coded head rank.
+    assert (
+        "if mtp_enable and config.num_nextn_predict_layers > 0 and layout.has_mtp"
+        in model_text
+    )
+    assert "self.mtp_embed = mtp_embedding" in model_text
+
+    # pp-only: VPP / interleaving raises rather than silently mis-splitting.
+    with pytest.raises(NotImplementedError):
+        build_pipeline_chunk_layout(4, rank1, vpp=2, vpp_chunk_id=1)
+
+    # Non-divisible counts auto-balance (no "not divisible" error): 3/pp2 -> [2, 1].
+    assert build_pipeline_chunk_layout(3, rank0).layer_indices == [0, 1]
+    assert build_pipeline_chunk_layout(3, rank1).layer_indices == [2]
+
+
+def test_kimi_k2_checkpoint_exports_hf_names():
+    torch = pytest.importorskip("torch")
+
+    from megatron.lite.model.kimi_k2.config import KimiK2Config
+    from megatron.lite.model.kimi_k2.lite import protocol
+    from megatron.lite.model.kimi_k2.lite.checkpoint import (
+        KimiK2WeightSpec,
+        export_hf_weights,
+        save_hf_weights,
+    )
+
+    cfg = KimiK2Config(
+        num_hidden_layers=2,
+        hidden_size=8,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        vocab_size=16,
+        intermediate_size=12,
+        moe_intermediate_size=4,
+        n_routed_experts=2,
+        n_shared_experts=1,
+        num_experts_per_tok=1,
+        n_group=1,
+        topk_group=1,
+        first_k_dense_replace=1,
+        q_lora_rank=4,
+        kv_lora_rank=4,
+        qk_nope_head_dim=2,
+        qk_rope_head_dim=2,
+        v_head_dim=2,
+        num_nextn_predict_layers=1,
+    )
+    spec = KimiK2WeightSpec(cfg)
+
+    assert callable(export_hf_weights)
+    assert callable(save_hf_weights)
+    assert hasattr(protocol, "export_hf_weights")
+    assert spec.tp_spec("layers.1.self_attention.linear_proj.linear.weight") == (1, 0)
+    assert spec.tp_spec("layers.1.moe.experts.fc1.weight0") == (0, 1)
+    assert spec.expert_global_id("layers.1.moe.experts.fc2.weight1") == 1
+
+    gate_up = torch.arange(8 * 8, dtype=torch.float32).view(8, 8)
+    exported = dict(spec.native_to_hf("layers.1.moe.experts.fc1.weight0", gate_up))
+    assert set(exported) == {
+        "model.layers.1.mlp.experts.0.gate_proj.weight",
+        "model.layers.1.mlp.experts.0.up_proj.weight",
+    }
+    torch.testing.assert_close(
+        exported["model.layers.1.mlp.experts.0.gate_proj.weight"],
+        gate_up[:4],
+    )
+    torch.testing.assert_close(
+        exported["model.layers.1.mlp.experts.0.up_proj.weight"],
+        gate_up[4:],
+    )
+
+    bias = torch.arange(2, dtype=torch.float32)
+    assert spec.native_to_hf("layers.1.moe.router.expert_bias", bias) == [
+        ("model.layers.1.mlp.gate.e_score_correction_bias", bias)
+    ]
+    assert spec.native_to_hf("mtp.layers.0.enorm.weight", bias) == [
+        ("model.layers.2.enorm.weight", bias)
+    ]
+    assert spec.native_to_hf("mtp.layers.0.eh_proj.linear.weight", gate_up) == [
+        ("model.layers.2.eh_proj.weight", gate_up)
+    ]
+    assert spec.native_to_hf("mtp.layers.0.final_layernorm.weight", bias) == [
+        ("model.layers.2.shared_head.norm.weight", bias)
+    ]
+    mtp_export = dict(
+        spec.native_to_hf("mtp.layers.0.transformer_layer.mlp.gate_up.linear.weight", gate_up)
+    )
+    assert set(mtp_export) == {
+        "model.layers.2.mlp.gate_proj.weight",
+        "model.layers.2.mlp.up_proj.weight",
+    }
+
+
+def test_kimi_k2_fp8_checkpoint_dequant_cpu_path():
+    torch = pytest.importorskip("torch")
+    if not hasattr(torch, "float8_e4m3fn"):
+        pytest.skip("torch float8_e4m3fn is required for this smoke.")
+
+    from megatron.lite.model.kimi_k2.lite.checkpoint import _dequant_fp8_weight
+
+    class Reader:
+        index = {"w_scale_inv": "fake.safetensors"}
+
+        @staticmethod
+        def get_tensor(name):
+            assert name == "w_scale_inv"
+            return torch.full((1, 1), 2.0, dtype=torch.float32)
+
+    weight = torch.tensor([[1.0, -2.0], [3.0, -4.0]], dtype=torch.float32).to(torch.float8_e4m3fn)
+    out = _dequant_fp8_weight(Reader(), "w", weight)
+
+    torch.testing.assert_close(out, weight.float() * 2.0)
+
+
+def test_kimi_k2_int4_checkpoint_dequant_cpu_path():
+    torch = pytest.importorskip("torch")
+
+    from megatron.lite.model.kimi_k2.lite.checkpoint import _get
+
+    values = torch.tensor([[-8, -7, -1, 0, 1, 2, 6, 7, -8, 7]], dtype=torch.int8)
+    unsigned = (values + 8).to(torch.int32)
+    packed = torch.zeros((1, 2), dtype=torch.int32)
+    for offset in range(8):
+        packed[:, 0] |= unsigned[:, offset] << (4 * offset)
+    for offset in range(2):
+        packed[:, 1] |= unsigned[:, 8 + offset] << (4 * offset)
+
+    class Reader:
+        index = {
+            "w_packed": "fake.safetensors",
+            "w_scale": "fake.safetensors",
+            "w_shape": "fake.safetensors",
+        }
+
+        @staticmethod
+        def get_tensor(name):
+            return {
+                "w_packed": packed,
+                "w_scale": torch.tensor([[0.5, 2.0]], dtype=torch.float32),
+                "w_shape": torch.tensor([1, 10], dtype=torch.int64),
+            }[name]
+
+    out = _get(Reader(), "w")
+    expected = torch.cat([values[:, :5].float() * 0.5, values[:, 5:].float() * 2.0], dim=1)
+
+    torch.testing.assert_close(out, expected)
+
+
+def test_kimi_k2_real_checkpoint_prefix_helpers():
+    from megatron.lite.model.kimi_k2.lite.checkpoint import _lm_head_name, _text_prefix
+
+    class Reader:
+        index = {
+            "language_model.model.embed_tokens.weight": "fake.safetensors",
+            "language_model.lm_head.weight": "fake.safetensors",
+        }
+
+    prefix = _text_prefix(Reader())
+
+    assert prefix == "language_model.model"
+    assert _lm_head_name(Reader(), prefix) == "language_model.lm_head.weight"

--- a/experimental/lite/tests/unit/model/test_qwen35_export.py
+++ b/experimental/lite/tests/unit/model/test_qwen35_export.py
@@ -13,6 +13,7 @@ from megatron.lite.model.qwen3_5.lite.checkpoint import (
     _merge_linear_attn_in_proj_tp_shards,
     export_hf_weights,
 )
+from megatron.lite.model.qwen3_5.lite.protocol import ImplConfig
 from megatron.lite.model.registry import TRAIN_RUNTIME_MODULES, resolve_runtime_model_name
 
 
@@ -50,6 +51,11 @@ def test_qwen35_protocol_registers_vllm_export_entrypoint() -> None:
 
     assert key == "qwen3_5"
     assert callable(module.export_hf_weights)
+
+
+def test_qwen35_gdn_cp_mode_is_configurable() -> None:
+    assert ImplConfig().gdn_cp_mode == "replicated"
+    assert ImplConfig(gdn_cp_mode="sharded").gdn_cp_mode == "sharded"
 
 
 def test_qwen35_export_uses_hf_checkpoint_names_without_module_prefix() -> None:
@@ -168,6 +174,7 @@ def test_qwen35_export_batches_ep_expert_gather(monkeypatch) -> None:
                 )
 
     cfg = _tiny_config()
+    cfg.num_experts = 16
     model = TinyQwen35Module(cfg)
     ps = SimpleNamespace(
         pp_size=1,
@@ -190,16 +197,13 @@ def test_qwen35_export_batches_ep_expert_gather(monkeypatch) -> None:
 
     exported = dict(export_hf_weights(model, cfg, ps))
 
-    assert len(gather_calls) == 1
-    assert gather_calls[0].shape[0] == cfg.num_experts // ps.ep_size
+    assert len(gather_calls) == 2
+    assert all(call.shape[0] <= 4 for call in gather_calls)
     local_tensors = [
-        model.layers[0].moe.experts.fc1.weight0.detach(),
-        model.layers[0].moe.experts.fc1.weight1.detach(),
+        getattr(model.layers[0].moe.experts.fc1, f"weight{i}").detach()
+        for i in range(cfg.num_experts // ps.ep_size)
     ]
-    expected = torch.stack(
-        [local_tensors[0], local_tensors[1], local_tensors[0] + 2000, local_tensors[1] + 2000],
-        dim=0,
-    )
+    expected = torch.stack(local_tensors + [tensor + 2000 for tensor in local_tensors])
     assert torch.equal(exported["model.language_model.layers.0.mlp.experts.gate_up_proj"], expected)
 
 

--- a/experimental/lite/tests/unit/model/test_qwen_config_unit.py
+++ b/experimental/lite/tests/unit/model/test_qwen_config_unit.py
@@ -89,8 +89,8 @@ def test_qwen35_config_from_text_config_splits_mtp_layer_types():
     assert cfg.mrope_section == [1, 1, 0]
 
 
-def test_qwen_lite_protocols_build_configs_from_hf_dicts():
-    pytest.importorskip("transformer_engine.pytorch")
+def test_qwen_lite_protocols_build_configs_from_hf_dicts(transformer_engine_import_stub):
+    transformer_engine_import_stub()
 
     from megatron.lite.model.qwen3_5.lite import protocol as qwen35_protocol
     from megatron.lite.model.qwen3_moe.lite import protocol as qwen3_protocol

--- a/experimental/lite/tests/unit/primitive/test_fsdp2_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_fsdp2_unit.py
@@ -389,6 +389,9 @@ def test_fp32_adamw_state_dict_roundtrip_cpu():
     param.grad = torch.tensor([0.5, -0.25], dtype=torch.bfloat16)
     optimizer.step()
     state = optimizer.state_dict()
+    expected = {key: state[key][0].clone() for key in ("master_params", "exp_avgs", "exp_avg_sqs")}
+    for key, value in expected.items():
+        state[key][0] = SimpleNamespace(_local_tensor=value)
 
     loaded_param = nn.Parameter(torch.tensor([9.0, 9.0], dtype=torch.bfloat16))
     loaded_optimizer = build_adamw_optimizer(
@@ -408,11 +411,9 @@ def test_fp32_adamw_state_dict_roundtrip_cpu():
     loaded_state = loaded_optimizer.state_dict()
 
     assert loaded_state["step_count"] == state["step_count"]
-    for key in ("master_params", "exp_avgs", "exp_avg_sqs", "steps"):
-        assert len(loaded_state[key]) == len(state[key])
-    torch.testing.assert_close(loaded_state["master_params"][0], state["master_params"][0])
-    torch.testing.assert_close(loaded_state["exp_avgs"][0], state["exp_avgs"][0])
-    torch.testing.assert_close(loaded_state["exp_avg_sqs"][0], state["exp_avg_sqs"][0])
+    torch.testing.assert_close(loaded_param, expected["master_params"].to(torch.bfloat16))
+    for key, value in expected.items():
+        torch.testing.assert_close(loaded_state[key][0], value)
     assert loaded_state["steps"] == state["steps"]
 
 

--- a/experimental/lite/tests/unit/primitive/test_training_checkpoint.py
+++ b/experimental/lite/tests/unit/primitive/test_training_checkpoint.py
@@ -15,6 +15,7 @@ from megatron.core.dist_checkpointing.strategies.torch import (
 )
 from megatron.lite.primitive.ckpt import dcp
 from megatron.lite.primitive.ckpt.distckpt import (
+    _dist_opt_checkpoint_metadata,
     _model_sharded_state_dict,
     _rank_offsets_and_replica_id,
     _single_or_all_model_state,
@@ -25,6 +26,22 @@ from megatron.lite.primitive.parallel import ParallelState
 from megatron.lite.primitive.protocols import default_expert_classifier, default_placement_fn
 from megatron.lite.runtime.backends.mlite.runtime import MegatronLiteRuntime
 from megatron.lite.runtime.contracts.handle import ModelHandle
+
+
+@pytest.mark.parametrize("groups, expected", [([], False), ([object(), object()], True), ([object(), None], False)])
+def test_dist_opt_checkpoint_memory_efficient_metadata(groups, expected) -> None:
+    opts = [
+        SimpleNamespace(
+            data_parallel_group_gloo=group,
+            sharded_state_dict=lambda: None,
+            gbuf_ranges={},
+            buffers=[],
+            optimizer=object(),
+        )
+        for group in groups
+    ]
+    metadata = _dist_opt_checkpoint_metadata(SimpleNamespace(chained_optimizers=opts))
+    assert metadata["distrib_optim_fully_reshardable_mem_efficient"] is expected
 
 
 def _assert_state_equal(actual, expected) -> None:

--- a/experimental/lite/tests/unit/runtime/test_runtime_backend_unit.py
+++ b/experimental/lite/tests/unit/runtime/test_runtime_backend_unit.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import torch
 import torch.nn as nn
 
 from megatron.lite.runtime import create_runtime
@@ -18,11 +19,50 @@ from megatron.lite.runtime.backends.mlite.runtime import (
     MegatronLiteRuntime,
     _apply_attention_backend_env,
     _build_impl_cfg,
+    _pipeline_callbacks,
 )
 from megatron.lite.runtime.contracts.config import OptimizerConfig, ParallelConfig, RuntimeConfig
 from megatron.lite.runtime.contracts.handle import ModelHandle
+from megatron.lite.runtime.contracts.loss import LossContext, get_loss_context, use_loss_context
 
 pytestmark = pytest.mark.mlite
+
+
+def test_runtime_returns_loss_separately_from_microbatch_metrics():
+    model = nn.Linear(1, 1, bias=False)
+    handle = ModelHandle(
+        model=model,
+        parallel_state=types.SimpleNamespace(pp_size=1),
+        _extras={"forward_step": lambda module, batch: {"value": module(batch["x"])}},
+    )
+    batches = iter([{"x": torch.ones(1, 1), "micro": i} for i in range(2)])
+    result = MegatronLiteRuntime.__new__(MegatronLiteRuntime).forward_backward(
+        handle,
+        batches,
+        lambda out, batch: (out["value"].sum(), {"micro": batch["micro"]}),
+        num_microbatches=2,
+    )
+
+    assert result.metrics == {"micro": [0, 1]}
+    assert result.model_output.loss is not None
+
+
+def test_pipeline_callbacks_accept_wrapped_and_presplit_context():
+    context = LossContext(source_batch="source")
+    seen = []
+    forward, loss = _pipeline_callbacks(
+        lambda _model, batch: seen.append((batch, get_loss_context()))
+        or {"loss": torch.tensor(1.0)},
+        lambda out, batch, ctx: (out["loss"], {"batch": batch, "source": ctx.source_batch}),
+    )
+
+    output = forward(None, ("wrapped", context))
+    with use_loss_context(context):
+        forward(None, "presplit")
+    _, metrics = loss(output, "presplit", context)
+
+    assert seen == [("wrapped", context), ("presplit", context)]
+    assert metrics == {"batch": "presplit", "source": "source"}
 
 
 def test_runtime_config_defaults_to_mlite_backend():

--- a/experimental/lite/tests/unit/verl/test_mlite_engine_config.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_engine_config.py
@@ -2,9 +2,11 @@
 from types import SimpleNamespace
 
 import pytest
+import torch
 
 from verl_mlite.engine.config import MegatronLiteEngineConfig
 from verl_mlite.engine.mlite_engine import MegatronLiteEngine, _build_lr_scheduler
+from megatron.lite.runtime.contracts import LossContext
 
 
 def _optimizer_config(**override_optimizer_config) -> SimpleNamespace:
@@ -47,6 +49,27 @@ def _engine_config(**kwargs) -> MegatronLiteEngineConfig:
     values = {"custom_backend_module": None, "impl_cfg": {"use_thd": True}}
     values.update(kwargs)
     return MegatronLiteEngineConfig(**values)
+
+
+@pytest.mark.parametrize("num_microbatches", [1, 4])
+def test_verl_loss_hook_preserves_gradient_and_micro_outputs(num_microbatches):
+    engine = _engine(engine_config=_engine_config())
+    weight = torch.nn.Parameter(torch.tensor(1.0))
+    outputs = []
+    engine._build_verl_model_output = lambda **_kwargs: {"log_probs": weight * 3}
+    engine.get_data_parallel_group = lambda: None
+
+    hook = engine._make_runtime_loss_fn(
+        lambda model_output, **_kwargs: (model_output["log_probs"] / num_microbatches, {}),
+        num_microbatches=num_microbatches,
+        output_lst=outputs,
+    )
+    for _ in range(num_microbatches):
+        loss, _ = hook({}, object(), LossContext(source_batch=object()))
+        (loss / num_microbatches).backward()
+
+    torch.testing.assert_close(weight.grad, torch.tensor(3.0))
+    assert [output["loss"] for output in outputs] == [3.0 / num_microbatches] * num_microbatches
 
 
 def test_optimizer_offload_enables_full_optimizer_state_offload_by_default() -> None:

--- a/experimental/lite/tests/unit/verl/test_mlite_engine_cp_smoke.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_engine_cp_smoke.py
@@ -1,0 +1,288 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+from __future__ import annotations
+
+import json
+from types import MethodType, SimpleNamespace
+
+import pytest
+
+pytestmark = [
+    pytest.mark.mlite,
+    pytest.mark.smoke,
+    pytest.mark.gpu,
+    pytest.mark.distributed,
+]
+
+
+def _init_dist_or_skip():
+    import os
+
+    import torch
+    import torch.distributed as dist
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for MLite VERL CP smoke.")
+    if "RANK" not in os.environ or "WORLD_SIZE" not in os.environ:
+        pytest.skip("Run with torchrun so CP ranks are available.")
+
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    torch.cuda.set_device(local_rank)
+    if not dist.is_initialized():
+        dist.init_process_group("nccl")
+    if dist.get_world_size() < 2:
+        pytest.skip("MLite VERL CP smoke requires at least 2 ranks.")
+    return torch.device("cuda", local_rank)
+
+
+def _write_kimi_config(path) -> None:
+    config = {
+        "model_type": "deepseek_v3",
+        "num_hidden_layers": 2,
+        "hidden_size": 64,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 4,
+        "vocab_size": 128,
+        "intermediate_size": 96,
+        "moe_intermediate_size": 16,
+        "n_routed_experts": 4,
+        "n_shared_experts": 1,
+        "num_experts_per_tok": 2,
+        "n_group": 2,
+        "topk_group": 1,
+        "first_k_dense_replace": 1,
+        "q_lora_rank": 16,
+        "kv_lora_rank": 12,
+        "qk_nope_head_dim": 8,
+        "qk_rope_head_dim": 8,
+        "v_head_dim": 8,
+        "max_position_embeddings": 128,
+        "rope_theta": 10000.0,
+        "rope_scaling": {
+            "type": "yarn",
+            "factor": 1.0,
+            "original_max_position_embeddings": 128,
+            "beta_fast": 1.0,
+            "beta_slow": 1.0,
+            "mscale": 1.0,
+            "mscale_all_dim": 1.0,
+        },
+    }
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "config.json").write_text(json.dumps(config), encoding="utf-8")
+
+
+def _write_glm5_config(path) -> None:
+    config = {
+        "model_type": "glm_moe_dsa",
+        "num_hidden_layers": 2,
+        "hidden_size": 128,
+        "num_attention_heads": 64,
+        "num_key_value_heads": 64,
+        "head_dim": 256,
+        "vocab_size": 32,
+        "max_position_embeddings": 64,
+        "initializer_range": 0.002,
+        "q_lora_rank": 16,
+        "kv_lora_rank": 512,
+        "qk_head_dim": 256,
+        "qk_nope_head_dim": 192,
+        "qk_rope_head_dim": 64,
+        "v_head_dim": 256,
+        "index_head_dim": 128,
+        "index_n_heads": 32,
+        "index_topk": 512,
+        "intermediate_size": 20,
+        "moe_intermediate_size": 6,
+        "first_k_dense_replace": 1,
+        "n_routed_experts": 3,
+        "n_shared_experts": 1,
+        "num_experts_per_tok": 3,
+        "num_nextn_predict_layers": 1,
+        "mlp_layer_types": ["dense", "dense"],
+    }
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "config.json").write_text(json.dumps(config), encoding="utf-8")
+
+
+def _write_deepseek_v4_config(path) -> None:
+    config = {
+        "model_type": "deepseek_v4",
+        "num_hidden_layers": 2,
+        "hidden_size": 128,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 1,
+        "head_dim": 32,
+        "vocab_size": 128,
+        "max_position_embeddings": 128,
+        "initializer_range": 0.02,
+        "q_lora_rank": 64,
+        "qk_rope_head_dim": 16,
+        "o_lora_rank": 64,
+        "o_groups": 4,
+        "index_head_dim": 16,
+        "index_n_heads": 4,
+        "index_topk": 4,
+        "moe_intermediate_size": 32,
+        "n_routed_experts": 4,
+        "n_shared_experts": 1,
+        "num_experts_per_tok": 2,
+        "num_hash_layers": 1,
+        "num_nextn_predict_layers": 0,
+        "compress_ratios": [4, 4],
+        "compress_rope_theta": 160000.0,
+        "hc_mult": 2,
+        "hc_eps": 1e-6,
+        "hc_sinkhorn_iters": 4,
+        "rms_norm_eps": 1e-6,
+        "rope_theta": 10000.0,
+        "sliding_window": 128,
+        "swiglu_limit": 10.0,
+        "scoring_func": "sqrtsoftplus",
+        "topk_method": "noaux_tc",
+        "norm_topk_prob": True,
+        "routed_scaling_factor": 1.0,
+    }
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "config.json").write_text(json.dumps(config), encoding="utf-8")
+
+
+def _optimizer_config() -> SimpleNamespace:
+    return SimpleNamespace(
+        optimizer="adam",
+        lr=1e-6,
+        min_lr=None,
+        min_lr_ratio=None,
+        clip_grad=1.0,
+        weight_decay=0.0,
+        lr_warmup_steps_ratio=0.0,
+        total_training_steps=1,
+        lr_warmup_steps=0,
+        lr_warmup_init=0.0,
+        lr_decay_steps=None,
+        lr_decay_style="constant",
+        weight_decay_incr_style="constant",
+        lr_wsd_decay_style="exponential",
+        lr_wsd_decay_steps=None,
+        use_checkpoint_opt_param_scheduler=False,
+        betas=(0.9, 0.95),
+        override_optimizer_config={},
+    )
+
+
+@pytest.mark.parametrize(
+    ("model_name", "model_type", "write_config", "vocab_size", "lengths"),
+    [
+        ("kimi_k2", "deepseek_v3", _write_kimi_config, 128, [5, 7, 9]),
+        ("glm5", "glm_moe_dsa", _write_glm5_config, 32, [16, 20, 24]),
+        ("deepseek_v4", "deepseek_v4", _write_deepseek_v4_config, 128, [16, 20, 24]),
+    ],
+)
+def test_mlite_engine_runtime_thd_cp_uses_typed_packed_batch(
+    tmp_path, model_name, model_type, write_config, vocab_size, lengths
+):
+    torch = pytest.importorskip("torch")
+    dist = pytest.importorskip("torch.distributed")
+    TensorDict = pytest.importorskip("tensordict").TensorDict
+    from verl_mlite.compat import apply_runtime_patches
+
+    apply_runtime_patches()
+    from verl_mlite.engine.config import MegatronLiteEngineConfig
+    from verl_mlite.engine.mlite_engine import MegatronLiteEngine
+    from megatron.lite.runtime.contracts import PackedBatch
+
+    device = _init_dist_or_skip()
+    world = dist.get_world_size()
+    rank = dist.get_rank()
+    hf_path = tmp_path / f"tiny-{model_name}"
+    write_config(hf_path)
+
+    engine = MegatronLiteEngine(
+        model_config=SimpleNamespace(
+            local_path=str(hf_path),
+            hf_config={"model_type": model_type},
+            mtp=None,
+        ),
+        engine_config=MegatronLiteEngineConfig(
+            model_name=model_name,
+            cp=world,
+            impl_cfg={
+                "use_thd": True,
+                "optimizer": None,
+                "deterministic": False,
+                "mtp_enable": False,
+            },
+            use_fused_kernels=False,
+        ),
+        optimizer_config=_optimizer_config(),
+        checkpoint_config={},
+    )
+    original_build_config = engine._build_mlite_config
+
+    def _build_config_without_loading_weights(self):
+        config = original_build_config()
+        config.load_hf_weights = False
+        return config
+
+    engine._build_mlite_config = MethodType(_build_config_without_loading_weights, engine)
+    engine.initialize()
+    engine.optimizer_zero_grad()
+
+    input_ids = torch.nested.as_nested_tensor(
+        [
+            torch.randint(0, vocab_size, (length,), device=device, dtype=torch.long)
+            for length in lengths
+        ],
+        layout=torch.jagged,
+    )
+    loss_mask = torch.nested.as_nested_tensor(
+        [torch.ones(length, device=device, dtype=torch.float32) for length in lengths],
+        layout=torch.jagged,
+    )
+    micro_batch = TensorDict(
+        {"input_ids": input_ids, "loss_mask": loss_mask},
+        batch_size=[len(lengths)],
+        device=device,
+    )
+
+    runtime_batch = engine._make_runtime_batch(micro_batch)
+    loss_context = engine._make_runtime_loss_context(micro_batch, loss_scale=1.0)
+    assert isinstance(runtime_batch, PackedBatch)
+    # Connector batch is model-agnostic: true seq lengths, no padding, no extras.
+    assert runtime_batch.seq_lens.tolist() == lengths
+    assert int(runtime_batch.input_ids.numel()) == sum(lengths)
+    assert not runtime_batch.extras
+
+    with engine.train_mode():
+        result = engine.runtime.forward_backward(
+            engine.handle,
+            iter([(runtime_batch, loss_context)]),
+            loss_fn=None,
+            num_microbatches=1,
+            forward_only=False,
+        )
+
+    assert torch.isfinite(result.model_output.loss)
+    assert result.model_output.log_probs is not None
+    grad_norm = torch.zeros((), dtype=torch.float32, device=device)
+    for param in engine.module.parameters():
+        if param.grad is not None:
+            grad_norm = grad_norm + param.grad.detach().float().norm()
+    dist.all_reduce(grad_norm, op=dist.ReduceOp.SUM)
+    assert torch.isfinite(grad_norm)
+    assert grad_norm.item() > 0.0
+
+    verl_output = engine._build_verl_model_output(
+        raw_output={"log_probs": result.model_output.log_probs},
+        runtime_batch=runtime_batch,
+    )
+    nested_log_probs = verl_output["log_probs"]
+    assert [int(x) for x in nested_log_probs.offsets().diff().cpu()] == lengths
+
+    if rank == 0:
+        print(
+            "NON_SKIP_VERL_MLITE_RUNTIME_THD_CP_SMOKE_PASSED "
+            f"model={model_name} "
+            f"world_size={world} lengths={lengths} "
+            f"loss={float(result.model_output.loss.detach().item()):.6e} "
+            f"grad_norm_sum={float(grad_norm.item()):.6e}"
+        )


### PR DESCRIPTION
## Summary

This PR brings `experimental/lite` (MLite) on `dev` up to parity with the MLite
content on `ISEEKYAN/Megatron-LM:main`. It is a single, self-contained update on
top of the four MLite base PRs already in `dev`.

- Diff vs `dev`: **70 files** (46 added, 24 modified), `+12461 / -100`
- Scope is strictly `experimental/lite/**` — no `megatron/core/**` changes.
- Branch content is identical to `ISEEKYAN/main@69ea18d07`.

## What's included

**Models**
- Kimi K2 (DeepSeek-V3 architecture)
- GLM5 (reuses Kimi K2 shared capabilities)
- DeepSeek-V4 (reuses Kimi/GLM attention, MoE, CP and pipeline paths)

**Runtime / infra**
- runtime, loss-contract and benchmark fixes; compatibility fixes
  (e.g. Qwen3-MoE non-THD path, TE workspace)
- checkpoint, HF export, FSDP2 restore
- cross-model save/load/export, auto-pipeline, and VERL CP integration

**Application layer**
- Miles (`examples/miles/**`) GRPO/SFT scripts for Qwen3-MoE
- VERL reference-policy config

## Scope & constraints

- Changes are confined to `experimental/lite/**`; the root branch `README.md`
  from the source is intentionally **not** carried over.
- MLite's dependence on `megatron.core` is limited to the explicit, sanctioned
  boundaries (distributed optimizer, distributed checkpoint, pipeline layout,
  and the Bridge/runtime adapter). No new ordinary primitive/model `megatron.core`
  imports were reintroduced, and no `megatron/core/**` files are patched.

## Verification

- `python -m compileall experimental/lite` — **pass**
- Full CPU unit tests were **not** run in the authoring environment (missing
  `safetensors`, Transformer Engine, Triton); GPU/Slurm suites were not run on a
  login node. Reviewers should run the MLite CPU/static gates and the per-model
  GPU smokes in a proper container before merge.