### PR TITLE
[codex] Add restart first-iteration verification

### DIFF
--- a/docs/advanced/index.md
+++ b/docs/advanced/index.md
@@ -12,3 +12,4 @@
 In-depth technical discussions and optimization guides:
 
 - [Optimizing DeepSeek-V3 Training on GB200 NVL72](https://github.com/NVIDIA/Megatron-LM/blob/dev/docs/discussions/deepseek-v3-gb200-optimization/deepseek-v3-gb200-reproduce-guide.md) - Achieving 970 TFLOPS/GPU with MXFP8, kernel optimizations, and HybridEP
+- [Verifying restart first-iteration optimizations](restart-first-iteration-verification.md) - Rejecting changes that only move iteration-1 work into initialization

--- a/docs/advanced/restart-first-iteration-verification.md
+++ b/docs/advanced/restart-first-iteration-verification.md
@@ -82,6 +82,16 @@ regression over iterations 10 through 20:
 The verifier compares the treatment median with the mean of the two control
 medians and fails if any iteration in the requested range is missing.
 
+If logging every iteration changes the production numerical schedule, use two
+same-scale ABAs instead of weakening either gate. Run the production logging
+cadence for at least 20 iterations with `--require-iteration-20` as the exact
+correctness gate. Then run a separate every-iteration ABA for the steady-state
+range without `--require-iteration-20`; it must still match iteration-1
+numerics, report zero skipped or NaN iterations, and pass the startup and full
+wall gates. Keep the recipe, image, rank topology, cache, and treatment fixed
+between the two ABAs. A diagnostic performance run never overrides a failed or
+missing production-cadence exactness run.
+
 When the experiment has an absolute service-level target, add, for example,
 `--maximum-treatment-iteration-1-s 5`. This is an additional gate: it does not
 replace the startup-through-iteration-1 or complete-wall checks, so moving work

--- a/docs/advanced/restart-first-iteration-verification.md
+++ b/docs/advanced/restart-first-iteration-verification.md
@@ -67,6 +67,19 @@ first-iteration gain was relocated into startup, if full wall time regressed,
 if the controls are too far apart, if scale differs, or if printed numerics
 differ.
 
+For settings that can change steady-state throughput, also gate an inclusive
+iteration range. For example, this rejects more than a 2% median iteration-time
+regression over iterations 10 through 20:
+
+```bash
+  --steady-state-start-iteration 10 \
+  --steady-state-end-iteration 20 \
+  --maximum-steady-state-regression-percent 2
+```
+
+The verifier compares the treatment median with the mean of the two control
+medians and fails if any iteration in the requested range is missing.
+
 When the experiment has an absolute service-level target, add, for example,
 `--maximum-treatment-iteration-1-s 5`. This is an additional gate: it does not
 replace the startup-through-iteration-1 or complete-wall checks, so moving work

--- a/docs/advanced/restart-first-iteration-verification.md
+++ b/docs/advanced/restart-first-iteration-verification.md
@@ -45,7 +45,9 @@ only `[ITER1-ENV-ABA]` legs, so the measured control/treatment/control runs must
 still pass iteration-1, startup-through-iteration-1, and complete-wall gates.
 
 `tools/first_iter/verify_restart.py` enforces these gates for launcher logs that
-contain the standard `[ITER1-ENV-ABA]` and `[ULTRAHALF-ITER1CAP]` markers:
+contain the standard `[ITER1-ENV-ABA]` and `[ULTRAHALF-ITER1CAP]` markers.
+The wall marker may use integer or decimal seconds; the verifier preserves
+millisecond precision so subsecond gains cannot be hidden by display rounding:
 
 ```bash
 python tools/first_iter/verify_restart.py \

--- a/docs/advanced/restart-first-iteration-verification.md
+++ b/docs/advanced/restart-first-iteration-verification.md
@@ -1,0 +1,77 @@
+<!---
+Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+-->
+
+# Verify restart first-iteration optimizations
+
+A shorter printed iteration 1 is not sufficient evidence of a restart win.
+Initialization or model construction can absorb the same work before the
+training timer starts. Validate all restart optimizations with a same-allocation
+control/treatment/control run and report these four measurements separately:
+
+1. `time to initialize megatron`;
+2. `before library-setup` through `before the start of training step`;
+3. printed iteration-1 elapsed time;
+4. the launcher's complete `srun` wall time, including teardown.
+
+The acceptance metric is `pre-training + iteration 1`. It must improve by a
+declared practical threshold, and the complete `srun` wall must not regress.
+Loss and gradient fields must match the controls exactly, with zero skipped or
+NaN iterations. Performance runs must also state node/rank count and disable
+profilers unless profiling is the explicit purpose of the run. Use
+`--minimum-startup-through-iteration-1-improvement-s` to reject an iteration
+timer reduction that merely moved the same cost into initialization. Also set
+`--minimum-srun-wall-improvement-s` when work could move before the first
+startup marker (for example, cache extraction or process bootstrap). Choose
+both thresholds before examining the treatment.
+
+The treatment's printed iteration 1 must also be no slower than the control
+mean. Use `--minimum-iteration-1-improvement-s` when an experiment needs a
+nonzero practical-significance threshold in addition to the end-to-end gates.
+
+The controls must be close enough for causal attribution. By default the
+verifier rejects an ABA when Control A versus Control B differs by more than
+1 second in iteration 1, 5 seconds in startup through iteration 1, or 10 seconds
+in complete `srun` wall. A large first-leg allocation-priming penalty can
+otherwise make a treatment in the middle look faster even when it is not.
+Override the `--max-control-*-spread-s` options only when the experiment defines
+and documents a different stability budget.
+
+When a cluster has a repeatable first-launch allocation penalty, the launcher
+may run one complete, unmeasured control before the measured ABA. Mark it with
+`[ITER1-ENV-PRIME]`, keep its configuration identical to the measured controls,
+and do not use it as a performance baseline. The verifier deliberately reads
+only `[ITER1-ENV-ABA]` legs, so the measured control/treatment/control runs must
+still pass iteration-1, startup-through-iteration-1, and complete-wall gates.
+
+`tools/first_iter/verify_restart.py` enforces these gates for launcher logs that
+contain the standard `[ITER1-ENV-ABA]` and `[ULTRAHALF-ITER1CAP]` markers:
+
+```bash
+python tools/first_iter/verify_restart.py \
+  --aba-log /path/to/ultrahalf_env_aba_JOB.out \
+  --treatment-label nccl_topo_cache \
+  --expected-nodes 16 \
+  --expected-world 64 \
+  --minimum-startup-through-iteration-1-improvement-s 0.5 \
+  --minimum-srun-wall-improvement-s 0.5
+```
+
+For a 20-iteration numerical gate, add `--require-iteration-20`. Treat this as
+mandatory before accepting changes to communicator creation, process-group
+reuse, topology or graph selection, collective ordering, or compiled-kernel
+selection. A short run is only a screening gate for those changes: later
+iterations can expose numerical drift, deadlocks, or end-to-end regressions
+that are invisible at iteration 1. The command exits nonzero if the apparent
+first-iteration gain was relocated into startup, if full wall time regressed,
+if the controls are too far apart, if scale differs, or if printed numerics
+differ.
+
+When the experiment has an absolute service-level target, add, for example,
+`--maximum-treatment-iteration-1-s 5`. This is an additional gate: it does not
+replace the startup-through-iteration-1 or complete-wall checks, so moving work
+before the iteration timer still fails.
+
+Cluster-specific launch commands, cache implementation details, and preserved
+HSG evidence belong in the companion first-iteration tooling repository rather
+than Megatron Core production code.

--- a/tests/unit_tests/tools/first_iter/__init__.py
+++ b/tests/unit_tests/tools/first_iter/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.

--- a/tests/unit_tests/tools/first_iter/test_verify_restart.py
+++ b/tests/unit_tests/tools/first_iter/test_verify_restart.py
@@ -18,6 +18,7 @@ def _run_metrics(
     pre_training: float,
     iter_1: float,
     iteration_20_loss: str | None = None,
+    steady_state_elapsed_s: float | None = None,
 ) -> RunMetrics:
     iteration = IterationMetrics(
         iteration=1,
@@ -28,24 +29,44 @@ def _run_metrics(
         nan=0,
         timestamp=datetime(2026, 6, 29),
     )
+    iteration_20 = (
+        IterationMetrics(
+            iteration=20,
+            elapsed_s=0.71 if steady_state_elapsed_s is None else steady_state_elapsed_s,
+            loss=iteration_20_loss,
+            grad_norm="9.284",
+            skipped=0,
+            nan=0,
+            timestamp=datetime(2026, 6, 29),
+        )
+        if iteration_20_loss is not None
+        else None
+    )
+    iterations = {1: iteration}
+    if steady_state_elapsed_s is not None:
+        iterations.update(
+            {
+                index: IterationMetrics(
+                    iteration=index,
+                    elapsed_s=steady_state_elapsed_s,
+                    loss="1.218087E+01",
+                    grad_norm="9.284",
+                    skipped=0,
+                    nan=0,
+                    timestamp=datetime(2026, 6, 29),
+                )
+                for index in range(10, 20)
+            }
+        )
+    if iteration_20 is not None:
+        iterations[20] = iteration_20
     return RunMetrics(
         path=path,
         initialization_s=init,
         pre_training_s=pre_training,
         iteration_1=iteration,
-        iteration_20=(
-            IterationMetrics(
-                iteration=20,
-                elapsed_s=0.71,
-                loss=iteration_20_loss,
-                grad_norm="9.284",
-                skipped=0,
-                nan=0,
-                timestamp=datetime(2026, 6, 29),
-            )
-            if iteration_20_loss is not None
-            else None
-        ),
+        iteration_20=iteration_20,
+        iterations=iterations,
     )
 
 
@@ -407,3 +428,65 @@ def test_verify_aba_rejects_control_order_bias(tmp_path: Path) -> None:
     assert any("control iteration-1 spread" in failure for failure in failures)
     assert any("control startup-through-iteration-1 spread" in failure for failure in failures)
     assert any("control srun-wall spread" in failure for failure in failures)
+
+
+def test_verify_aba_rejects_steady_state_regression(tmp_path: Path) -> None:
+    legs = [
+        AbaLeg(
+            label="control-a",
+            nodes=16,
+            world=64,
+            srun_wall_s=120,
+            metrics=_run_metrics(
+                tmp_path / "a.log",
+                init=14,
+                pre_training=18,
+                iter_1=9.0,
+                iteration_20_loss="1.218087E+01",
+                steady_state_elapsed_s=0.70,
+            ),
+        ),
+        AbaLeg(
+            label="treatment",
+            nodes=16,
+            world=64,
+            srun_wall_s=110,
+            metrics=_run_metrics(
+                tmp_path / "t.log",
+                init=14,
+                pre_training=17,
+                iter_1=8.0,
+                iteration_20_loss="1.218087E+01",
+                steady_state_elapsed_s=0.76,
+            ),
+        ),
+        AbaLeg(
+            label="control-b",
+            nodes=16,
+            world=64,
+            srun_wall_s=120,
+            metrics=_run_metrics(
+                tmp_path / "b.log",
+                init=14,
+                pre_training=18,
+                iter_1=9.0,
+                iteration_20_loss="1.218087E+01",
+                steady_state_elapsed_s=0.70,
+            ),
+        ),
+    ]
+
+    failures = verify_aba(
+        legs,
+        treatment_label="treatment",
+        expected_nodes=16,
+        expected_world=64,
+        phase_tolerance_s=0,
+        wall_tolerance_s=0,
+        require_iteration_20=True,
+        steady_state_start_iteration=10,
+        steady_state_end_iteration=20,
+        maximum_steady_state_regression_percent=2.0,
+    )
+
+    assert any("steady-state iteration time regressed" in failure for failure in failures)

--- a/tests/unit_tests/tools/first_iter/test_verify_restart.py
+++ b/tests/unit_tests/tools/first_iter/test_verify_restart.py
@@ -1,0 +1,409 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from tools.first_iter.verify_restart import (
+    AbaLeg,
+    IterationMetrics,
+    RunMetrics,
+    parse_run_log,
+    verify_aba,
+)
+
+
+def _run_metrics(
+    path: Path,
+    init: float,
+    pre_training: float,
+    iter_1: float,
+    iteration_20_loss: str | None = None,
+) -> RunMetrics:
+    iteration = IterationMetrics(
+        iteration=1,
+        elapsed_s=iter_1,
+        loss="1.218077E+01",
+        grad_norm="9.282",
+        skipped=0,
+        nan=0,
+        timestamp=datetime(2026, 6, 29),
+    )
+    return RunMetrics(
+        path=path,
+        initialization_s=init,
+        pre_training_s=pre_training,
+        iteration_1=iteration,
+        iteration_20=(
+            IterationMetrics(
+                iteration=20,
+                elapsed_s=0.71,
+                loss=iteration_20_loss,
+                grad_norm="9.284",
+                skipped=0,
+                nan=0,
+                timestamp=datetime(2026, 6, 29),
+            )
+            if iteration_20_loss is not None
+            else None
+        ),
+    )
+
+
+def test_parse_run_log_includes_pre_training_phase(tmp_path: Path) -> None:
+    before = datetime(2026, 6, 29, 17, 48, 0)
+    training = before + timedelta(seconds=19.25)
+    log = tmp_path / "run.log"
+    log.write_text(
+        "\n".join(
+            [
+                "0: time to initialize megatron (seconds): 10.500",
+                f"0: [before library-setup] datetime: {before:%Y-%m-%d %H:%M:%S.%f}",
+                f"0: [before the start of training step] datetime: {training:%Y-%m-%d %H:%M:%S.%f}",
+                "63: [2026-06-29 17:48:28.073200] iteration        1/ 10 | "
+                "elapsed time per iteration (ms): 8823.2 | lm loss: 1.218077E+01 | "
+                "grad norm: 9.282 | number of skipped iterations: 0 | number of nan iterations: 0 |",
+            ]
+        )
+    )
+
+    metrics = parse_run_log(log)
+
+    assert metrics.initialization_s == 10.5
+    assert metrics.pre_training_s == 19.25
+    assert metrics.iteration_1.elapsed_s == 8.8232
+    assert metrics.startup_through_iteration_1_s == 28.0732
+
+
+def test_verify_aba_rejects_relocation_into_pre_training(tmp_path: Path) -> None:
+    control_a = AbaLeg(
+        label="control-a",
+        nodes=16,
+        world=64,
+        srun_wall_s=110,
+        metrics=_run_metrics(tmp_path / "a.log", init=13, pre_training=18, iter_1=12),
+    )
+    treatment = AbaLeg(
+        label="treatment",
+        nodes=16,
+        world=64,
+        srun_wall_s=112,
+        metrics=_run_metrics(tmp_path / "t.log", init=20, pre_training=27, iter_1=5),
+    )
+    control_b = AbaLeg(
+        label="control-b",
+        nodes=16,
+        world=64,
+        srun_wall_s=108,
+        metrics=_run_metrics(tmp_path / "b.log", init=13, pre_training=18, iter_1=12),
+    )
+
+    failures = verify_aba(
+        [control_a, treatment, control_b],
+        treatment_label="treatment",
+        expected_nodes=16,
+        expected_world=64,
+        phase_tolerance_s=0,
+        wall_tolerance_s=0,
+        require_iteration_20=False,
+    )
+
+    assert any("startup-through-iteration-1 regressed" in failure for failure in failures)
+    assert any("srun wall regressed" in failure for failure in failures)
+
+
+def test_verify_aba_rejects_plain_phase_relocation(tmp_path: Path) -> None:
+    legs = [
+        AbaLeg(
+            label="control-a",
+            nodes=16,
+            world=64,
+            srun_wall_s=110,
+            metrics=_run_metrics(tmp_path / "a.log", init=13, pre_training=18, iter_1=12),
+        ),
+        AbaLeg(
+            label="treatment",
+            nodes=16,
+            world=64,
+            srun_wall_s=110,
+            metrics=_run_metrics(tmp_path / "t.log", init=20, pre_training=25, iter_1=5),
+        ),
+        AbaLeg(
+            label="control-b",
+            nodes=16,
+            world=64,
+            srun_wall_s=110,
+            metrics=_run_metrics(tmp_path / "b.log", init=13, pre_training=18, iter_1=12),
+        ),
+    ]
+
+    failures = verify_aba(
+        legs,
+        treatment_label="treatment",
+        expected_nodes=16,
+        expected_world=64,
+        phase_tolerance_s=0,
+        wall_tolerance_s=0,
+        require_iteration_20=False,
+        minimum_phase_improvement_s=0.5,
+    )
+
+    assert any(
+        "startup-through-iteration-1 did not improve enough" in failure for failure in failures
+    )
+
+
+def test_verify_aba_accepts_real_end_to_end_win(tmp_path: Path) -> None:
+    legs = [
+        AbaLeg(
+            label="control-a",
+            nodes=16,
+            world=64,
+            srun_wall_s=110,
+            metrics=_run_metrics(
+                tmp_path / "a.log", init=13.372, pre_training=18.1469, iter_1=12.8003
+            ),
+        ),
+        AbaLeg(
+            label="topology-cache",
+            nodes=16,
+            world=64,
+            srun_wall_s=105,
+            metrics=_run_metrics(
+                tmp_path / "t.log", init=14.633, pre_training=19.5356, iter_1=8.8232
+            ),
+        ),
+        AbaLeg(
+            label="control-b",
+            nodes=16,
+            world=64,
+            srun_wall_s=108,
+            metrics=_run_metrics(
+                tmp_path / "b.log", init=13.407, pre_training=19.2088, iter_1=12.3538
+            ),
+        ),
+    ]
+
+    failures = verify_aba(
+        legs,
+        treatment_label="topology-cache",
+        expected_nodes=16,
+        expected_world=64,
+        phase_tolerance_s=0,
+        wall_tolerance_s=0,
+        require_iteration_20=False,
+    )
+
+    assert failures == []
+
+
+def test_verify_aba_rejects_relocation_before_startup_marker(tmp_path: Path) -> None:
+    legs = [
+        AbaLeg(
+            label="control-a",
+            nodes=16,
+            world=64,
+            srun_wall_s=110,
+            metrics=_run_metrics(tmp_path / "a.log", init=13, pre_training=18, iter_1=12),
+        ),
+        AbaLeg(
+            label="treatment",
+            nodes=16,
+            world=64,
+            srun_wall_s=110,
+            metrics=_run_metrics(tmp_path / "t.log", init=12, pre_training=17, iter_1=10),
+        ),
+        AbaLeg(
+            label="control-b",
+            nodes=16,
+            world=64,
+            srun_wall_s=110,
+            metrics=_run_metrics(tmp_path / "b.log", init=13, pre_training=18, iter_1=12),
+        ),
+    ]
+
+    failures = verify_aba(
+        legs,
+        treatment_label="treatment",
+        expected_nodes=16,
+        expected_world=64,
+        phase_tolerance_s=0,
+        wall_tolerance_s=0,
+        require_iteration_20=False,
+        minimum_phase_improvement_s=0.5,
+        minimum_wall_improvement_s=0.5,
+    )
+
+    assert any("srun wall did not improve enough" in failure for failure in failures)
+
+
+def test_verify_aba_rejects_late_numeric_drift(tmp_path: Path) -> None:
+    legs = [
+        AbaLeg(
+            label="control-a",
+            nodes=16,
+            world=64,
+            srun_wall_s=119,
+            metrics=_run_metrics(
+                tmp_path / "a.log",
+                init=15.9,
+                pre_training=19.1,
+                iter_1=9.4,
+                iteration_20_loss="1.218087E+01",
+            ),
+        ),
+        AbaLeg(
+            label="treatment",
+            nodes=16,
+            world=64,
+            srun_wall_s=110,
+            metrics=_run_metrics(
+                tmp_path / "t.log",
+                init=18.8,
+                pre_training=18.0,
+                iter_1=8.4,
+                iteration_20_loss="1.218086E+01",
+            ),
+        ),
+        AbaLeg(
+            label="control-b",
+            nodes=16,
+            world=64,
+            srun_wall_s=109,
+            metrics=_run_metrics(
+                tmp_path / "b.log",
+                init=17.1,
+                pre_training=17.9,
+                iter_1=9.0,
+                iteration_20_loss="1.218087E+01",
+            ),
+        ),
+    ]
+
+    failures = verify_aba(
+        legs,
+        treatment_label="treatment",
+        expected_nodes=16,
+        expected_world=64,
+        phase_tolerance_s=0,
+        wall_tolerance_s=0,
+        require_iteration_20=True,
+    )
+
+    assert any("iteration 20 loss mismatch" in failure for failure in failures)
+
+
+def test_verify_aba_rejects_no_first_iteration_gain(tmp_path: Path) -> None:
+    legs = [
+        AbaLeg(
+            label="control-a",
+            nodes=16,
+            world=64,
+            srun_wall_s=106,
+            metrics=_run_metrics(tmp_path / "a.log", init=14, pre_training=18, iter_1=8.8051),
+        ),
+        AbaLeg(
+            label="treatment",
+            nodes=16,
+            world=64,
+            srun_wall_s=105,
+            metrics=_run_metrics(tmp_path / "t.log", init=14, pre_training=17, iter_1=8.9773),
+        ),
+        AbaLeg(
+            label="control-b",
+            nodes=16,
+            world=64,
+            srun_wall_s=106,
+            metrics=_run_metrics(tmp_path / "b.log", init=14, pre_training=18, iter_1=8.7804),
+        ),
+    ]
+
+    failures = verify_aba(
+        legs,
+        treatment_label="treatment",
+        expected_nodes=16,
+        expected_world=64,
+        phase_tolerance_s=0,
+        wall_tolerance_s=0,
+        require_iteration_20=False,
+    )
+
+    assert any("iteration 1 did not improve enough" in failure for failure in failures)
+
+
+def test_verify_aba_rejects_treatment_above_absolute_target(tmp_path: Path) -> None:
+    legs = [
+        AbaLeg(
+            label="control-a",
+            nodes=16,
+            world=64,
+            srun_wall_s=106,
+            metrics=_run_metrics(tmp_path / "a.log", init=14, pre_training=18, iter_1=8.7),
+        ),
+        AbaLeg(
+            label="treatment",
+            nodes=16,
+            world=64,
+            srun_wall_s=103,
+            metrics=_run_metrics(tmp_path / "t.log", init=14, pre_training=17, iter_1=5.1),
+        ),
+        AbaLeg(
+            label="control-b",
+            nodes=16,
+            world=64,
+            srun_wall_s=106,
+            metrics=_run_metrics(tmp_path / "b.log", init=14, pre_training=18, iter_1=8.6),
+        ),
+    ]
+
+    failures = verify_aba(
+        legs,
+        treatment_label="treatment",
+        expected_nodes=16,
+        expected_world=64,
+        phase_tolerance_s=0,
+        wall_tolerance_s=0,
+        require_iteration_20=False,
+        maximum_treatment_iteration_1_s=5.0,
+    )
+
+    assert any("treatment iteration 1 exceeds target" in failure for failure in failures)
+
+
+def test_verify_aba_rejects_control_order_bias(tmp_path: Path) -> None:
+    legs = [
+        AbaLeg(
+            label="control-a",
+            nodes=16,
+            world=64,
+            srun_wall_s=120,
+            metrics=_run_metrics(tmp_path / "a.log", init=21, pre_training=27, iter_1=10.0),
+        ),
+        AbaLeg(
+            label="treatment",
+            nodes=16,
+            world=64,
+            srun_wall_s=109,
+            metrics=_run_metrics(tmp_path / "t.log", init=13, pre_training=17, iter_1=8.4),
+        ),
+        AbaLeg(
+            label="control-b",
+            nodes=16,
+            world=64,
+            srun_wall_s=108,
+            metrics=_run_metrics(tmp_path / "b.log", init=13, pre_training=18, iter_1=8.3),
+        ),
+    ]
+
+    failures = verify_aba(
+        legs,
+        treatment_label="treatment",
+        expected_nodes=16,
+        expected_world=64,
+        phase_tolerance_s=0,
+        wall_tolerance_s=0,
+        require_iteration_20=False,
+    )
+
+    assert any("control iteration-1 spread" in failure for failure in failures)
+    assert any("control startup-through-iteration-1 spread" in failure for failure in failures)
+    assert any("control srun-wall spread" in failure for failure in failures)

--- a/tests/unit_tests/tools/first_iter/test_verify_restart.py
+++ b/tests/unit_tests/tools/first_iter/test_verify_restart.py
@@ -7,6 +7,7 @@ from tools.first_iter.verify_restart import (
     AbaLeg,
     IterationMetrics,
     RunMetrics,
+    _format_table,
     parse_run_log,
     verify_aba,
 )
@@ -255,6 +256,18 @@ def test_verify_aba_rejects_relocation_before_startup_marker(tmp_path: Path) -> 
     )
 
     assert any("srun wall did not improve enough" in failure for failure in failures)
+
+
+def test_subsecond_srun_wall_is_reported_at_millisecond_precision(tmp_path: Path) -> None:
+    leg = AbaLeg(
+        label="treatment",
+        nodes=16,
+        world=64,
+        srun_wall_s=105.057,
+        metrics=_run_metrics(tmp_path / "t.log", init=13, pre_training=18, iter_1=8),
+    )
+
+    assert "105.057" in _format_table([leg])
 
 
 def test_verify_aba_rejects_late_numeric_drift(tmp_path: Path) -> None:

--- a/tools/first_iter/__init__.py
+++ b/tools/first_iter/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.

--- a/tools/first_iter/verify_restart.py
+++ b/tools/first_iter/verify_restart.py
@@ -257,8 +257,8 @@ def verify_aba(
     if control_wall_spread > max_control_wall_spread_s:
         failures.append(
             "control srun-wall spread is too large for causal attribution: "
-            f"spread={control_wall_spread:.1f}s "
-            f"maximum={max_control_wall_spread_s:.1f}s"
+            f"spread={control_wall_spread:.3f}s "
+            f"maximum={max_control_wall_spread_s:.3f}s"
         )
 
     numeric_fields = ("loss", "grad_norm")
@@ -362,15 +362,15 @@ def verify_aba(
     if wall_improvement < minimum_wall_improvement_s:
         failures.append(
             "srun wall did not improve enough: "
-            f"treatment={treatment.srun_wall_s:.1f}s "
-            f"control_mean={control_wall_mean:.1f}s "
-            f"improvement={wall_improvement:.1f}s "
-            f"minimum={minimum_wall_improvement_s:.1f}s"
+            f"treatment={treatment.srun_wall_s:.3f}s "
+            f"control_mean={control_wall_mean:.3f}s "
+            f"improvement={wall_improvement:.3f}s "
+            f"minimum={minimum_wall_improvement_s:.3f}s"
         )
     if treatment.srun_wall_s > control_wall_mean + wall_tolerance_s:
         failures.append(
-            f"srun wall regressed: treatment={treatment.srun_wall_s:.1f}s "
-            f"control_mean={control_wall_mean:.1f}s tolerance={wall_tolerance_s:.1f}s"
+            f"srun wall regressed: treatment={treatment.srun_wall_s:.3f}s "
+            f"control_mean={control_wall_mean:.3f}s tolerance={wall_tolerance_s:.3f}s"
         )
     return failures
 
@@ -384,7 +384,7 @@ def _format_table(legs: list[AbaLeg]) -> str:
         rows.append(
             f"{leg.label:<20} {metrics.initialization_s:>7.3f}  {metrics.pre_training_s:>12.3f}  "
             f"{metrics.iteration_1.elapsed_s:>8.4f}  "
-            f"{metrics.startup_through_iteration_1_s:>16.4f}  {leg.srun_wall_s:>7.1f}  "
+            f"{metrics.startup_through_iteration_1_s:>16.4f}  {leg.srun_wall_s:>7.3f}  "
             f"{metrics.iteration_1.loss:<10} {metrics.iteration_1.grad_norm}"
         )
     return "\n".join(rows)

--- a/tools/first_iter/verify_restart.py
+++ b/tools/first_iter/verify_restart.py
@@ -1,0 +1,387 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Verify first-iteration restart gains without accepting cost relocation."""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import re
+from datetime import datetime
+from pathlib import Path
+
+_TIMESTAMP_FORMAT = "%Y-%m-%d %H:%M:%S.%f"
+_MARKER_RE = re.compile(
+    r"\[(?P<name>before library-setup|after megatron is initialized|"
+    r"after model, optimizer, and learning rate scheduler are built|"
+    r"after dataloaders are built|before the start of training step)\] "
+    r"datetime:\s*(?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+)"
+)
+_INIT_RE = re.compile(r"time to initialize megatron \(seconds\):\s*(?P<seconds>[0-9.]+)")
+_ITER_RE = re.compile(
+    r"\[(?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+)\] "
+    r"iteration\s+(?P<iteration>\d+)/.*?"
+    r"elapsed time per iteration \(ms\):\s*(?P<elapsed_ms>[0-9.]+).*?"
+    r"lm loss:\s*(?P<loss>[0-9.Ee+-]+).*?"
+    r"grad norm:\s*(?P<grad_norm>[0-9.Ee+-]+).*?"
+    r"number of skipped iterations:\s*(?P<skipped>\d+).*?"
+    r"number of nan iterations:\s*(?P<nan>\d+)"
+)
+_ABA_START_RE = re.compile(r"\[ITER1-ENV-ABA\] start leg=(?P<label>\S+)")
+_SCALE_RE = re.compile(r"\[ULTRAHALF-ITER1CAP\] nodes=(?P<nodes>\d+) world=(?P<world>\d+)")
+_RUN_DIR_RE = re.compile(r"run_dir=(?P<run_dir>\S+)")
+_SRUN_WALL_RE = re.compile(r"\[ULTRAHALF-ITER1CAP\] srun wall:\s*(?P<seconds>[0-9.]+)s")
+
+
+@dataclasses.dataclass(frozen=True)
+class IterationMetrics:
+    iteration: int
+    elapsed_s: float
+    loss: str
+    grad_norm: str
+    skipped: int
+    nan: int
+    timestamp: datetime
+
+
+@dataclasses.dataclass(frozen=True)
+class RunMetrics:
+    path: Path
+    initialization_s: float
+    pre_training_s: float
+    iteration_1: IterationMetrics
+    iteration_20: IterationMetrics | None
+
+    @property
+    def startup_through_iteration_1_s(self) -> float:
+        """Library setup through the end of iteration 1, excluding container launch."""
+
+        return self.pre_training_s + self.iteration_1.elapsed_s
+
+
+@dataclasses.dataclass
+class AbaLeg:
+    label: str
+    nodes: int | None = None
+    world: int | None = None
+    run_dir: Path | None = None
+    srun_wall_s: float | None = None
+    metrics: RunMetrics | None = None
+
+
+def _parse_timestamp(value: str) -> datetime:
+    return datetime.strptime(value, _TIMESTAMP_FORMAT)
+
+
+def parse_run_log(path: Path) -> RunMetrics:
+    """Parse Megatron startup markers and printed iteration metrics."""
+
+    text = path.read_text(errors="replace")
+    markers = {
+        match.group("name"): _parse_timestamp(match.group("timestamp"))
+        for match in _MARKER_RE.finditer(text)
+    }
+    required_markers = {"before library-setup", "before the start of training step"}
+    missing = sorted(required_markers - markers.keys())
+    if missing:
+        raise ValueError(f"{path}: missing startup marker(s): {', '.join(missing)}")
+
+    init_matches = list(_INIT_RE.finditer(text))
+    if len(init_matches) != 1:
+        raise ValueError(
+            f"{path}: expected one Megatron initialization timing, found {len(init_matches)}"
+        )
+
+    iterations: dict[int, IterationMetrics] = {}
+    for match in _ITER_RE.finditer(text):
+        iteration = int(match.group("iteration"))
+        iterations[iteration] = IterationMetrics(
+            iteration=iteration,
+            elapsed_s=float(match.group("elapsed_ms")) / 1000.0,
+            loss=match.group("loss"),
+            grad_norm=match.group("grad_norm"),
+            skipped=int(match.group("skipped")),
+            nan=int(match.group("nan")),
+            timestamp=_parse_timestamp(match.group("timestamp")),
+        )
+    if 1 not in iterations:
+        raise ValueError(f"{path}: iteration 1 was not logged")
+
+    pre_training_s = (
+        markers["before the start of training step"] - markers["before library-setup"]
+    ).total_seconds()
+    if pre_training_s < 0:
+        raise ValueError(f"{path}: startup markers are out of order")
+
+    return RunMetrics(
+        path=path,
+        initialization_s=float(init_matches[0].group("seconds")),
+        pre_training_s=pre_training_s,
+        iteration_1=iterations[1],
+        iteration_20=iterations.get(20),
+    )
+
+
+def _find_run_log(run_dir: Path) -> Path:
+    matches = sorted((run_dir / "logs").glob("*.log"))
+    if len(matches) != 1:
+        raise ValueError(f"{run_dir}: expected one run log, found {len(matches)}")
+    return matches[0]
+
+
+def parse_aba_log(path: Path) -> list[AbaLeg]:
+    """Resolve each same-allocation ABA leg and its Megatron run log."""
+
+    legs: list[AbaLeg] = []
+    current: AbaLeg | None = None
+    for line in path.read_text(errors="replace").splitlines():
+        if match := _ABA_START_RE.search(line):
+            current = AbaLeg(label=match.group("label"))
+            legs.append(current)
+            continue
+        if current is None:
+            continue
+        if match := _SCALE_RE.search(line):
+            current.nodes = int(match.group("nodes"))
+            current.world = int(match.group("world"))
+        if match := _RUN_DIR_RE.search(line):
+            current.run_dir = Path(match.group("run_dir"))
+        if match := _SRUN_WALL_RE.search(line):
+            current.srun_wall_s = float(match.group("seconds"))
+
+    if len(legs) != 3:
+        raise ValueError(f"{path}: expected three ABA legs, found {len(legs)}")
+    for leg in legs:
+        if leg.nodes is None or leg.world is None or leg.run_dir is None or leg.srun_wall_s is None:
+            raise ValueError(f"{path}: incomplete launcher metadata for leg {leg.label}")
+        leg.metrics = parse_run_log(_find_run_log(leg.run_dir))
+    return legs
+
+
+def _mean(left: float, right: float) -> float:
+    return (left + right) / 2.0
+
+
+def _spread(left: float, right: float) -> float:
+    return abs(left - right)
+
+
+def verify_aba(
+    legs: list[AbaLeg],
+    treatment_label: str,
+    expected_nodes: int,
+    expected_world: int,
+    phase_tolerance_s: float,
+    wall_tolerance_s: float,
+    require_iteration_20: bool,
+    minimum_iteration_1_improvement_s: float = 0.0,
+    minimum_phase_improvement_s: float = 0.0,
+    minimum_wall_improvement_s: float = 0.0,
+    max_control_iteration_1_spread_s: float = 1.0,
+    max_control_phase_spread_s: float = 5.0,
+    max_control_wall_spread_s: float = 10.0,
+    maximum_treatment_iteration_1_s: float | None = None,
+) -> list[str]:
+    """Return gate failures; an empty list means the ABA passes."""
+
+    by_label = {leg.label: leg for leg in legs}
+    expected_labels = {"control-a", treatment_label, "control-b"}
+    failures: list[str] = []
+    if set(by_label) != expected_labels:
+        return [f"expected ABA labels {sorted(expected_labels)}, found {sorted(by_label)}"]
+
+    control_a = by_label["control-a"]
+    treatment = by_label[treatment_label]
+    control_b = by_label["control-b"]
+    for leg in legs:
+        if leg.nodes != expected_nodes or leg.world != expected_world:
+            failures.append(
+                f"{leg.label}: expected {expected_nodes} nodes/{expected_world} ranks, "
+                f"found {leg.nodes}/{leg.world}"
+            )
+        assert leg.metrics is not None
+        if leg.metrics.iteration_1.skipped or leg.metrics.iteration_1.nan:
+            failures.append(f"{leg.label}: iteration 1 has skipped or NaN iterations")
+        if require_iteration_20:
+            if leg.metrics.iteration_20 is None:
+                failures.append(f"{leg.label}: iteration 20 was not logged")
+            elif leg.metrics.iteration_20.skipped or leg.metrics.iteration_20.nan:
+                failures.append(f"{leg.label}: iteration 20 has skipped or NaN iterations")
+
+    assert (
+        control_a.metrics is not None
+        and treatment.metrics is not None
+        and control_b.metrics is not None
+    )
+    control_iteration_1_spread = _spread(
+        control_a.metrics.iteration_1.elapsed_s, control_b.metrics.iteration_1.elapsed_s
+    )
+    if control_iteration_1_spread > max_control_iteration_1_spread_s:
+        failures.append(
+            "control iteration-1 spread is too large for causal attribution: "
+            f"spread={control_iteration_1_spread:.4f}s "
+            f"maximum={max_control_iteration_1_spread_s:.4f}s"
+        )
+
+    control_phase_spread = _spread(
+        control_a.metrics.startup_through_iteration_1_s,
+        control_b.metrics.startup_through_iteration_1_s,
+    )
+    if control_phase_spread > max_control_phase_spread_s:
+        failures.append(
+            "control startup-through-iteration-1 spread is too large for causal attribution: "
+            f"spread={control_phase_spread:.4f}s "
+            f"maximum={max_control_phase_spread_s:.4f}s"
+        )
+
+    assert control_a.srun_wall_s is not None and control_b.srun_wall_s is not None
+    control_wall_spread = _spread(control_a.srun_wall_s, control_b.srun_wall_s)
+    if control_wall_spread > max_control_wall_spread_s:
+        failures.append(
+            "control srun-wall spread is too large for causal attribution: "
+            f"spread={control_wall_spread:.1f}s "
+            f"maximum={max_control_wall_spread_s:.1f}s"
+        )
+
+    numeric_fields = ("loss", "grad_norm")
+    for field in numeric_fields:
+        values = [
+            getattr(leg.metrics.iteration_1, field) for leg in (control_a, treatment, control_b)
+        ]
+        if len(set(values)) != 1:
+            failures.append(f"iteration 1 {field} mismatch: {values}")
+        if require_iteration_20 and all(leg.metrics.iteration_20 is not None for leg in legs):
+            values_20 = [
+                getattr(leg.metrics.iteration_20, field)
+                for leg in (control_a, treatment, control_b)
+            ]
+            if len(set(values_20)) != 1:
+                failures.append(f"iteration 20 {field} mismatch: {values_20}")
+
+    control_iteration_1_mean = _mean(
+        control_a.metrics.iteration_1.elapsed_s, control_b.metrics.iteration_1.elapsed_s
+    )
+    iteration_1_improvement = control_iteration_1_mean - treatment.metrics.iteration_1.elapsed_s
+    if iteration_1_improvement < minimum_iteration_1_improvement_s:
+        failures.append(
+            "iteration 1 did not improve enough: "
+            f"treatment={treatment.metrics.iteration_1.elapsed_s:.4f}s "
+            f"control_mean={control_iteration_1_mean:.4f}s "
+            f"improvement={iteration_1_improvement:.4f}s "
+            f"minimum={minimum_iteration_1_improvement_s:.4f}s"
+        )
+    if (
+        maximum_treatment_iteration_1_s is not None
+        and treatment.metrics.iteration_1.elapsed_s > maximum_treatment_iteration_1_s
+    ):
+        failures.append(
+            "treatment iteration 1 exceeds target: "
+            f"treatment={treatment.metrics.iteration_1.elapsed_s:.4f}s "
+            f"maximum={maximum_treatment_iteration_1_s:.4f}s"
+        )
+
+    control_phase_mean = _mean(
+        control_a.metrics.startup_through_iteration_1_s,
+        control_b.metrics.startup_through_iteration_1_s,
+    )
+    phase_improvement = control_phase_mean - treatment.metrics.startup_through_iteration_1_s
+    if phase_improvement < minimum_phase_improvement_s:
+        failures.append(
+            "startup-through-iteration-1 did not improve enough: "
+            f"treatment={treatment.metrics.startup_through_iteration_1_s:.4f}s "
+            f"control_mean={control_phase_mean:.4f}s "
+            f"improvement={phase_improvement:.4f}s "
+            f"minimum={minimum_phase_improvement_s:.4f}s"
+        )
+    if treatment.metrics.startup_through_iteration_1_s > control_phase_mean + phase_tolerance_s:
+        failures.append(
+            "startup-through-iteration-1 regressed: "
+            f"treatment={treatment.metrics.startup_through_iteration_1_s:.4f}s "
+            f"control_mean={control_phase_mean:.4f}s tolerance={phase_tolerance_s:.4f}s"
+        )
+
+    assert (
+        control_a.srun_wall_s is not None
+        and treatment.srun_wall_s is not None
+        and control_b.srun_wall_s is not None
+    )
+    control_wall_mean = _mean(control_a.srun_wall_s, control_b.srun_wall_s)
+    wall_improvement = control_wall_mean - treatment.srun_wall_s
+    if wall_improvement < minimum_wall_improvement_s:
+        failures.append(
+            "srun wall did not improve enough: "
+            f"treatment={treatment.srun_wall_s:.1f}s "
+            f"control_mean={control_wall_mean:.1f}s "
+            f"improvement={wall_improvement:.1f}s "
+            f"minimum={minimum_wall_improvement_s:.1f}s"
+        )
+    if treatment.srun_wall_s > control_wall_mean + wall_tolerance_s:
+        failures.append(
+            f"srun wall regressed: treatment={treatment.srun_wall_s:.1f}s "
+            f"control_mean={control_wall_mean:.1f}s tolerance={wall_tolerance_s:.1f}s"
+        )
+    return failures
+
+
+def _format_table(legs: list[AbaLeg]) -> str:
+    header = "leg                 init(s)  pre-train(s)  iter1(s)  startup+iter1(s)  srun(s)  loss       grad"
+    rows = [header]
+    for leg in legs:
+        assert leg.metrics is not None and leg.srun_wall_s is not None
+        metrics = leg.metrics
+        rows.append(
+            f"{leg.label:<20} {metrics.initialization_s:>7.3f}  {metrics.pre_training_s:>12.3f}  "
+            f"{metrics.iteration_1.elapsed_s:>8.4f}  "
+            f"{metrics.startup_through_iteration_1_s:>16.4f}  {leg.srun_wall_s:>7.1f}  "
+            f"{metrics.iteration_1.loss:<10} {metrics.iteration_1.grad_norm}"
+        )
+    return "\n".join(rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--aba-log", type=Path, required=True)
+    parser.add_argument("--treatment-label", required=True)
+    parser.add_argument("--expected-nodes", type=int, default=16)
+    parser.add_argument("--expected-world", type=int, default=64)
+    parser.add_argument("--phase-tolerance-s", type=float, default=0.0)
+    parser.add_argument("--wall-tolerance-s", type=float, default=0.0)
+    parser.add_argument("--minimum-iteration-1-improvement-s", type=float, default=0.0)
+    parser.add_argument(
+        "--minimum-startup-through-iteration-1-improvement-s", type=float, default=0.0
+    )
+    parser.add_argument("--minimum-srun-wall-improvement-s", type=float, default=0.0)
+    parser.add_argument("--max-control-iteration-1-spread-s", type=float, default=1.0)
+    parser.add_argument("--max-control-phase-spread-s", type=float, default=5.0)
+    parser.add_argument("--max-control-wall-spread-s", type=float, default=10.0)
+    parser.add_argument("--maximum-treatment-iteration-1-s", type=float)
+    parser.add_argument("--require-iteration-20", action="store_true")
+    args = parser.parse_args()
+
+    legs = parse_aba_log(args.aba_log)
+    print(_format_table(legs))
+    failures = verify_aba(
+        legs=legs,
+        treatment_label=args.treatment_label,
+        expected_nodes=args.expected_nodes,
+        expected_world=args.expected_world,
+        phase_tolerance_s=args.phase_tolerance_s,
+        wall_tolerance_s=args.wall_tolerance_s,
+        require_iteration_20=args.require_iteration_20,
+        minimum_iteration_1_improvement_s=args.minimum_iteration_1_improvement_s,
+        minimum_phase_improvement_s=(args.minimum_startup_through_iteration_1_improvement_s),
+        minimum_wall_improvement_s=args.minimum_srun_wall_improvement_s,
+        max_control_iteration_1_spread_s=args.max_control_iteration_1_spread_s,
+        max_control_phase_spread_s=args.max_control_phase_spread_s,
+        max_control_wall_spread_s=args.max_control_wall_spread_s,
+        maximum_treatment_iteration_1_s=args.maximum_treatment_iteration_1_s,
+    )
+    if failures:
+        for failure in failures:
+            print(f"FAIL: {failure}")
+        raise SystemExit(1)
+    print("PASS: exact numerics, scale, startup-through-iteration-1, and srun-wall gates")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/first_iter/verify_restart.py
+++ b/tools/first_iter/verify_restart.py
@@ -9,6 +9,7 @@ import dataclasses
 import re
 from datetime import datetime
 from pathlib import Path
+from statistics import median
 
 _TIMESTAMP_FORMAT = "%Y-%m-%d %H:%M:%S.%f"
 _MARKER_RE = re.compile(
@@ -51,12 +52,25 @@ class RunMetrics:
     pre_training_s: float
     iteration_1: IterationMetrics
     iteration_20: IterationMetrics | None
+    iterations: dict[int, IterationMetrics] = dataclasses.field(default_factory=dict)
 
     @property
     def startup_through_iteration_1_s(self) -> float:
         """Library setup through the end of iteration 1, excluding container launch."""
 
         return self.pre_training_s + self.iteration_1.elapsed_s
+
+    def median_iteration_s(self, start: int, end: int) -> float:
+        """Return the median elapsed time for an inclusive iteration range."""
+
+        missing = [
+            iteration for iteration in range(start, end + 1) if iteration not in self.iterations
+        ]
+        if missing:
+            raise ValueError(
+                f"{self.path}: missing iteration(s) {missing} for steady-state range {start}-{end}"
+            )
+        return median(self.iterations[iteration].elapsed_s for iteration in range(start, end + 1))
 
 
 @dataclasses.dataclass
@@ -119,6 +133,7 @@ def parse_run_log(path: Path) -> RunMetrics:
         pre_training_s=pre_training_s,
         iteration_1=iterations[1],
         iteration_20=iterations.get(20),
+        iterations=iterations,
     )
 
 
@@ -181,6 +196,9 @@ def verify_aba(
     max_control_phase_spread_s: float = 5.0,
     max_control_wall_spread_s: float = 10.0,
     maximum_treatment_iteration_1_s: float | None = None,
+    steady_state_start_iteration: int | None = None,
+    steady_state_end_iteration: int | None = None,
+    maximum_steady_state_regression_percent: float | None = None,
 ) -> list[str]:
     """Return gate failures; an empty list means the ABA passes."""
 
@@ -300,6 +318,40 @@ def verify_aba(
             f"control_mean={control_phase_mean:.4f}s tolerance={phase_tolerance_s:.4f}s"
         )
 
+    if maximum_steady_state_regression_percent is not None:
+        if steady_state_start_iteration is None or steady_state_end_iteration is None:
+            failures.append(
+                "steady-state start and end iterations are required when a regression limit is set"
+            )
+        elif steady_state_start_iteration > steady_state_end_iteration:
+            failures.append("steady-state start iteration must not exceed the end iteration")
+        else:
+            try:
+                control_a_steady = control_a.metrics.median_iteration_s(
+                    steady_state_start_iteration, steady_state_end_iteration
+                )
+                treatment_steady = treatment.metrics.median_iteration_s(
+                    steady_state_start_iteration, steady_state_end_iteration
+                )
+                control_b_steady = control_b.metrics.median_iteration_s(
+                    steady_state_start_iteration, steady_state_end_iteration
+                )
+            except ValueError as error:
+                failures.append(str(error))
+            else:
+                control_steady_mean = _mean(control_a_steady, control_b_steady)
+                steady_state_regression_percent = (
+                    (treatment_steady - control_steady_mean) / control_steady_mean * 100.0
+                )
+                if steady_state_regression_percent > maximum_steady_state_regression_percent:
+                    failures.append(
+                        "steady-state iteration time regressed: "
+                        f"treatment_median={treatment_steady:.4f}s "
+                        f"control_mean_median={control_steady_mean:.4f}s "
+                        f"regression={steady_state_regression_percent:.2f}% "
+                        f"maximum={maximum_steady_state_regression_percent:.2f}%"
+                    )
+
     assert (
         control_a.srun_wall_s is not None
         and treatment.srun_wall_s is not None
@@ -338,6 +390,14 @@ def _format_table(legs: list[AbaLeg]) -> str:
     return "\n".join(rows)
 
 
+def _format_steady_state(legs: list[AbaLeg], start: int, end: int) -> str:
+    values = []
+    for leg in legs:
+        assert leg.metrics is not None
+        values.append(f"{leg.label}={leg.metrics.median_iteration_s(start, end):.4f}s")
+    return f"steady-state median iterations {start}-{end}: " + " ".join(values)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--aba-log", type=Path, required=True)
@@ -355,11 +415,28 @@ def main() -> None:
     parser.add_argument("--max-control-phase-spread-s", type=float, default=5.0)
     parser.add_argument("--max-control-wall-spread-s", type=float, default=10.0)
     parser.add_argument("--maximum-treatment-iteration-1-s", type=float)
+    parser.add_argument("--steady-state-start-iteration", type=int)
+    parser.add_argument("--steady-state-end-iteration", type=int)
+    parser.add_argument("--maximum-steady-state-regression-percent", type=float)
     parser.add_argument("--require-iteration-20", action="store_true")
     args = parser.parse_args()
 
     legs = parse_aba_log(args.aba_log)
     print(_format_table(legs))
+    if (
+        args.maximum_steady_state_regression_percent is not None
+        and args.steady_state_start_iteration is not None
+        and args.steady_state_end_iteration is not None
+    ):
+        try:
+            print(
+                _format_steady_state(
+                    legs, args.steady_state_start_iteration, args.steady_state_end_iteration
+                )
+            )
+        except ValueError:
+            # verify_aba reports the missing range as a normal gate failure.
+            pass
     failures = verify_aba(
         legs=legs,
         treatment_label=args.treatment_label,
@@ -375,6 +452,9 @@ def main() -> None:
         max_control_phase_spread_s=args.max_control_phase_spread_s,
         max_control_wall_spread_s=args.max_control_wall_spread_s,
         maximum_treatment_iteration_1_s=args.maximum_treatment_iteration_1_s,
+        steady_state_start_iteration=args.steady_state_start_iteration,
+        steady_state_end_iteration=args.steady_state_end_iteration,
+        maximum_steady_state_regression_percent=(args.maximum_steady_state_regression_percent),
     )
     if failures:
         for failure in failures:


### PR DESCRIPTION
## What changed

- add a standalone parser/verifier for same-allocation control/treatment/control restart experiments
- gate true iteration 1, startup through iteration 1, complete `srun` wall, scale, exact printed numerics, skipped/NaN iterations, and control stability
- add an optional absolute SOL threshold and mandatory iteration-20 gate for communication/kernel-selection changes
- document why a shorter printed iteration can be timer-boundary relocation

## Why

Restart optimizations can move compilation or communicator setup before the training timer without improving recovery time. This verifier makes the end-to-end and numerical acceptance contract machine-checkable.

The tool is cluster-independent. HSG-specific launch commands and evidence remain in the companion first-iteration tooling repository.

## Validation

- `uv run --no-sync isort --check-only ...`
- `uv run --no-sync black --check ...`
- `uv run --no-sync ruff check ...`
- 9 standalone verifier tests passed under Python 3.12
- accepted HSG64 short and 20-iteration logs pass the strengthened phase/wall checks; known relocation cases fail
