### PR TITLE
ci: increase Download test data retry attempts from 3 to 5

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -572,14 +572,14 @@ jobs:
         shell: bash
         run: |
           echo "::group::Download test data"
-          for attempt in 1 2 3; do
+          for attempt in 1 2 3 4 5; do
             if pip install --no-cache-dir click requests \
               && python tests/test_utils/python_scripts/download_unit_tests_dataset.py --assets-dir ./assets; then
               break
             fi
             echo "Download test data attempt ${attempt} failed, retrying..." >&2
-            if [ "${attempt}" -eq 3 ]; then
-              echo "Download test data failed after 3 attempts" >&2
+            if [ "${attempt}" -eq 5 ]; then
+              echo "Download test data failed after 5 attempts" >&2
               exit 1
             fi
             sleep 10


### PR DESCRIPTION
Automated change for commit `f4e040ff75647906ae0988afde2fda1f651ee56d` on branch `ci/implement-9aa1b6aa86fb`.

Opened manually: the CI-Events `implement-issue` workflow pushed the fork commit successfully, but the `create-pullrequest` egress could not open the PR — its `svcnemo-autobot` `github_write_token` is returning HTTP 401 (Bad credentials) and needs rotation.