### PR TITLE
Use NVIDIA inference credentials for Claude actions

### DIFF
--- a/.github/workflows/claude-complexity-label.yml
+++ b/.github/workflows/claude-complexity-label.yml
@@ -25,8 +25,10 @@ jobs:
 
       - name: Run Claude Complexity Analysis
         uses: anthropics/claude-code-action@v1
+        env:
+          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.NVIDIA_INFERENCE_KEY }}
           github_token: ${{ secrets.PAT }}
           prompt: |
             REPO: ${{ env.REPO }}

--- a/.github/workflows/claude-complexity-label.yml
+++ b/.github/workflows/claude-complexity-label.yml
@@ -62,3 +62,4 @@ jobs:
             Do NOT post any comments on the PR. Only apply the label.
           claude_args: |
             --allowedTools "Bash(gh pr diff:*),Bash(gh pr edit:*),Bash(gh pr view:*)"
+            --model "${{ vars.CLAUDE_MODEL }}"

--- a/.github/workflows/claude-complexity-label.yml
+++ b/.github/workflows/claude-complexity-label.yml
@@ -28,6 +28,7 @@ jobs:
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.NVIDIA_INFERENCE_URL }}
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
+          DISABLE_PROMPT_CACHING: "1"
         with:
           anthropic_api_key: ${{ secrets.NVIDIA_INFERENCE_KEY }}
           github_token: ${{ secrets.PAT }}

--- a/.github/workflows/claude-complexity-label.yml
+++ b/.github/workflows/claude-complexity-label.yml
@@ -27,6 +27,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.NVIDIA_INFERENCE_URL }}
+          CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
         with:
           anthropic_api_key: ${{ secrets.NVIDIA_INFERENCE_KEY }}
           github_token: ${{ secrets.PAT }}

--- a/.github/workflows/claude-complexity-label.yml
+++ b/.github/workflows/claude-complexity-label.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Run Claude Complexity Analysis
         uses: anthropics/claude-code-action@v1
         env:
-          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+          ANTHROPIC_BASE_URL: ${{ secrets.NVIDIA_INFERENCE_URL }}
         with:
           anthropic_api_key: ${{ secrets.NVIDIA_INFERENCE_KEY }}
           github_token: ${{ secrets.PAT }}

--- a/.github/workflows/claude-copy-to-main.yml
+++ b/.github/workflows/claude-copy-to-main.yml
@@ -64,6 +64,7 @@ jobs:
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.NVIDIA_INFERENCE_URL }}
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
+          DISABLE_PROMPT_CACHING: "1"
         with:
           anthropic_api_key: ${{ secrets.NVIDIA_INFERENCE_KEY }}
           trigger_phrase: "/claude copy"

--- a/.github/workflows/claude-copy-to-main.yml
+++ b/.github/workflows/claude-copy-to-main.yml
@@ -61,8 +61,10 @@ jobs:
 
       - name: Run Claude Copy to Main
         uses: anthropics/claude-code-action@v1
+        env:
+          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.NVIDIA_INFERENCE_KEY }}
           trigger_phrase: "/claude copy"
           github_token: ${{ secrets.PAT }}
           prompt: |

--- a/.github/workflows/claude-copy-to-main.yml
+++ b/.github/workflows/claude-copy-to-main.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Run Claude Copy to Main
         uses: anthropics/claude-code-action@v1
         env:
-          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+          ANTHROPIC_BASE_URL: ${{ secrets.NVIDIA_INFERENCE_URL }}
         with:
           anthropic_api_key: ${{ secrets.NVIDIA_INFERENCE_KEY }}
           trigger_phrase: "/claude copy"

--- a/.github/workflows/claude-copy-to-main.yml
+++ b/.github/workflows/claude-copy-to-main.yml
@@ -124,4 +124,4 @@ jobs:
             - Do NOT force push.
           claude_args: |
             --allowedTools "Bash(git:*),Bash(gh:*),Read,Edit"
-            --model "claude-opus-4-6"
+            --model "${{ vars.CLAUDE_MODEL }}"

--- a/.github/workflows/claude-copy-to-main.yml
+++ b/.github/workflows/claude-copy-to-main.yml
@@ -63,6 +63,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.NVIDIA_INFERENCE_URL }}
+          CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
         with:
           anthropic_api_key: ${{ secrets.NVIDIA_INFERENCE_KEY }}
           trigger_phrase: "/claude copy"

--- a/.github/workflows/claude_review.yml
+++ b/.github/workflows/claude_review.yml
@@ -45,8 +45,10 @@ jobs:
 
       - name: Run Claude Light Review
         uses: anthropics/claude-code-action@v1
+        env:
+          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.NVIDIA_INFERENCE_KEY }}
           trigger_phrase: "/claude review"
           show_full_output: true
           claude_args: |
@@ -144,8 +146,10 @@ jobs:
 
       - name: Run Claude Strict Review
         uses: anthropics/claude-code-action@v1
+        env:
+          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.NVIDIA_INFERENCE_KEY }}
           trigger_phrase: "/claude strict-review"
           show_full_output: true
           claude_args: |

--- a/.github/workflows/claude_review.yml
+++ b/.github/workflows/claude_review.yml
@@ -48,6 +48,7 @@ jobs:
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.NVIDIA_INFERENCE_URL }}
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
+          DISABLE_PROMPT_CACHING: "1"
         with:
           anthropic_api_key: ${{ secrets.NVIDIA_INFERENCE_KEY }}
           trigger_phrase: "/claude review"
@@ -150,6 +151,7 @@ jobs:
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.NVIDIA_INFERENCE_URL }}
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
+          DISABLE_PROMPT_CACHING: "1"
         with:
           anthropic_api_key: ${{ secrets.NVIDIA_INFERENCE_KEY }}
           trigger_phrase: "/claude strict-review"

--- a/.github/workflows/claude_review.yml
+++ b/.github/workflows/claude_review.yml
@@ -55,7 +55,7 @@ jobs:
           show_full_output: true
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Read"
-            --model "claude-opus-4-6"
+            --model "${{ vars.CLAUDE_MODEL }}"
           prompt: |
             REPO: ${{ env.REPO }}
             PR NUMBER: ${{ env.PR_NUMBER }}
@@ -158,7 +158,7 @@ jobs:
           show_full_output: true
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(git diff:*),Bash(git show:*),Bash(git log:*),Read"
-            --model "claude-opus-4-6"
+            --model "${{ vars.CLAUDE_MODEL }}"
           prompt: |
             REPO: ${{ env.REPO }}
             PR NUMBER: ${{ env.PR_NUMBER }}

--- a/.github/workflows/claude_review.yml
+++ b/.github/workflows/claude_review.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Run Claude Light Review
         uses: anthropics/claude-code-action@v1
         env:
-          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+          ANTHROPIC_BASE_URL: ${{ secrets.NVIDIA_INFERENCE_URL }}
         with:
           anthropic_api_key: ${{ secrets.NVIDIA_INFERENCE_KEY }}
           trigger_phrase: "/claude review"
@@ -147,7 +147,7 @@ jobs:
       - name: Run Claude Strict Review
         uses: anthropics/claude-code-action@v1
         env:
-          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+          ANTHROPIC_BASE_URL: ${{ secrets.NVIDIA_INFERENCE_URL }}
         with:
           anthropic_api_key: ${{ secrets.NVIDIA_INFERENCE_KEY }}
           trigger_phrase: "/claude strict-review"

--- a/.github/workflows/claude_review.yml
+++ b/.github/workflows/claude_review.yml
@@ -47,6 +47,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.NVIDIA_INFERENCE_URL }}
+          CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
         with:
           anthropic_api_key: ${{ secrets.NVIDIA_INFERENCE_KEY }}
           trigger_phrase: "/claude review"
@@ -148,6 +149,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.NVIDIA_INFERENCE_URL }}
+          CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
         with:
           anthropic_api_key: ${{ secrets.NVIDIA_INFERENCE_KEY }}
           trigger_phrase: "/claude strict-review"

--- a/.github/workflows/community-request-assignee.yml
+++ b/.github/workflows/community-request-assignee.yml
@@ -134,7 +134,7 @@ jobs:
         id: claude-analysis
         uses: anthropics/claude-code-action@v1
         env:
-          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+          ANTHROPIC_BASE_URL: ${{ secrets.NVIDIA_INFERENCE_URL }}
           GH_TOKEN: ${{ github.token }}
         with:
           anthropic_api_key: ${{ secrets.NVIDIA_INFERENCE_KEY }}

--- a/.github/workflows/community-request-assignee.yml
+++ b/.github/workflows/community-request-assignee.yml
@@ -204,7 +204,7 @@ jobs:
             Do not assign the issue. Do not comment on the issue. Do not send Slack messages.
             Only return the structured JSON requested by the schema.
           claude_args: |
-            --model "claude-opus-4-6"
+            --model "${{ vars.CLAUDE_MODEL }}"
             --allowedTools "Read,Bash(rg:*),Bash(git ls-files:*),Bash(git log:*),Bash(git blame:*),Bash(git show:*),Bash(gh pr view:*),Bash(gh pr list:*)"
             --json-schema '{"type":"object","properties":{"assignee":{"type":["string","null"]},"potential_assignee":{"type":["string","null"]},"potential_assignee_reason":{"type":["string","null"]},"confidence":{"type":"number","minimum":0,"maximum":1},"fallback_to_oncall":{"type":"boolean"},"issue_type":{"type":"string","enum":["bug","feature_request","other"]},"feature_topic":{"type":["string","null"]},"root_cause_pr":{"anyOf":[{"type":"object","properties":{"number":{"type":"integer"},"title":{"type":"string"},"url":{"type":"string"},"author":{"type":"string"},"reason":{"type":"string"}},"required":["number","title","url","author","reason"],"additionalProperties":false},{"type":"null"}]},"relevant_paths":{"type":"array","items":{"type":"string"}},"evidence":{"type":"array","items":{"type":"string"}},"rationale":{"type":"string"},"slack_context":{"type":"string"}},"required":["assignee","potential_assignee","potential_assignee_reason","confidence","fallback_to_oncall","issue_type","feature_topic","root_cause_pr","relevant_paths","evidence","rationale","slack_context"],"additionalProperties":false}'
 

--- a/.github/workflows/community-request-assignee.yml
+++ b/.github/workflows/community-request-assignee.yml
@@ -135,6 +135,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.NVIDIA_INFERENCE_URL }}
+          CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
           GH_TOKEN: ${{ github.token }}
         with:
           anthropic_api_key: ${{ secrets.NVIDIA_INFERENCE_KEY }}

--- a/.github/workflows/community-request-assignee.yml
+++ b/.github/workflows/community-request-assignee.yml
@@ -136,6 +136,7 @@ jobs:
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.NVIDIA_INFERENCE_URL }}
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
+          DISABLE_PROMPT_CACHING: "1"
           GH_TOKEN: ${{ github.token }}
         with:
           anthropic_api_key: ${{ secrets.NVIDIA_INFERENCE_KEY }}

--- a/.github/workflows/community-request-assignee.yml
+++ b/.github/workflows/community-request-assignee.yml
@@ -134,9 +134,10 @@ jobs:
         id: claude-analysis
         uses: anthropics/claude-code-action@v1
         env:
+          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
           GH_TOKEN: ${{ github.token }}
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.NVIDIA_INFERENCE_KEY }}
           github_token: ${{ github.token }}
           track_progress: false
           prompt: |

--- a/.github/workflows/nightly-sync-main-to-dev.yml
+++ b/.github/workflows/nightly-sync-main-to-dev.yml
@@ -304,6 +304,6 @@ jobs:
           show_full_output: true
           claude_args: |
             --allowedTools "Bash,Read,Edit,Write,Grep,Glob,Agent"
-            --model "${{ secrets.CLAUDE_MODEL }}"
+            --model "${{ vars.CLAUDE_MODEL }}"
             --effort max
             --max-turns 1500

--- a/.github/workflows/nightly-sync-main-to-dev.yml
+++ b/.github/workflows/nightly-sync-main-to-dev.yml
@@ -185,7 +185,7 @@ jobs:
         if: steps.check-sync.outputs.skip != 'true'
         uses: anthropics/claude-code-action@v1
         env:
-          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+          ANTHROPIC_BASE_URL: ${{ secrets.NVIDIA_INFERENCE_URL }}
         with:
           anthropic_api_key: ${{ secrets.NVIDIA_INFERENCE_KEY }}
           github_token: ${{ secrets.PAT }}

--- a/.github/workflows/nightly-sync-main-to-dev.yml
+++ b/.github/workflows/nightly-sync-main-to-dev.yml
@@ -184,8 +184,10 @@ jobs:
       - name: Run Claude Code to merge, fix, and iterate
         if: steps.check-sync.outputs.skip != 'true'
         uses: anthropics/claude-code-action@v1
+        env:
+          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.NVIDIA_INFERENCE_KEY }}
           github_token: ${{ secrets.PAT }}
           prompt: |
             You are an automated sync bot. Merge `main` into `dev`, create a

--- a/.github/workflows/nightly-sync-main-to-dev.yml
+++ b/.github/workflows/nightly-sync-main-to-dev.yml
@@ -187,6 +187,7 @@ jobs:
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.NVIDIA_INFERENCE_URL }}
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
+          DISABLE_PROMPT_CACHING: "1"
         with:
           anthropic_api_key: ${{ secrets.NVIDIA_INFERENCE_KEY }}
           github_token: ${{ secrets.PAT }}

--- a/.github/workflows/nightly-sync-main-to-dev.yml
+++ b/.github/workflows/nightly-sync-main-to-dev.yml
@@ -186,6 +186,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.NVIDIA_INFERENCE_URL }}
+          CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
         with:
           anthropic_api_key: ${{ secrets.NVIDIA_INFERENCE_KEY }}
           github_token: ${{ secrets.PAT }}

--- a/.github/workflows/nightly-sync-main-to-dev.yml
+++ b/.github/workflows/nightly-sync-main-to-dev.yml
@@ -304,6 +304,6 @@ jobs:
           show_full_output: true
           claude_args: |
             --allowedTools "Bash,Read,Edit,Write,Grep,Glob,Agent"
-            --model "us/aws/anthropic/eccn-claude-opus-4-8"
+            --model "${{ secrets.CLAUDE_MODEL }}"
             --effort max
             --max-turns 1500

--- a/.github/workflows/nightly-sync-main-to-dev.yml
+++ b/.github/workflows/nightly-sync-main-to-dev.yml
@@ -304,6 +304,6 @@ jobs:
           show_full_output: true
           claude_args: |
             --allowedTools "Bash,Read,Edit,Write,Grep,Glob,Agent"
-            --model "opus[1m]"
+            --model "us/aws/anthropic/eccn-claude-opus-4-8"
             --effort max
             --max-turns 1500


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

All Claude workflows now use the NVIDIA inference endpoint. Validated by running [nightly sync action](https://github.com/NVIDIA/Megatron-LM/actions/runs/28482548327) on this PR.