### PR TITLE
Suppress noisy external-library log lines on non-rank-0 processes

### DIFF
--- a/megatron/training/initialize.py
+++ b/megatron/training/initialize.py
@@ -336,6 +336,7 @@ def _initialize_distributed(get_embedding_ranks, get_position_embedding_ranks, s
             'world_size': args.world_size,
             'rank': args.rank,
             'timeout': timedelta(minutes=args.distributed_timeout_minutes),
+            'device_id': device_id,
         }
         if args.fake_process_group:
             assert is_torch_min_version(
@@ -562,3 +563,13 @@ def setup_logging() -> None:
         if is_rank0():
             logger.info(f'Setting logging level to {logging_level}')
         logging.getLogger().setLevel(logging_level)
+
+    if not is_rank0():
+        for noisy_logger_name in [
+            'GroupedGemmQuantSm100',
+            'GroupedGemmDsreluSm100',
+            'GroupedGemmSreluSm100',
+            'GroupedGemmWgradSm100',
+            'absl',
+        ]:
+            logging.getLogger(noisy_logger_name).setLevel(logging.ERROR)

--- a/megatron/training/initialize.py
+++ b/megatron/training/initialize.py
@@ -580,3 +580,13 @@ def setup_logging() -> None:
         if is_rank0():
             logger.info(f'Setting logging level to {logging_level}')
         logging.getLogger().setLevel(logging_level)
+
+    if not is_rank0():
+        for noisy_logger_name in [
+            'GroupedGemmQuantSm100',
+            'GroupedGemmDsreluSm100',
+            'GroupedGemmSreluSm100',
+            'GroupedGemmWgradSm100',
+            'absl',
+        ]:
+            logging.getLogger(noisy_logger_name).setLevel(logging.ERROR)

--- a/pretrain_gpt.py
+++ b/pretrain_gpt.py
@@ -17,6 +17,19 @@ rank = int(os.environ.get('RANK', 0))
 if rank != 0:
     warnings.filterwarnings("ignore", category=UserWarning)
     warnings.filterwarnings("ignore", category=FutureWarning)
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+    # Some libraries (e.g., CUTLASS DSL) use warnings.catch_warnings() with
+    # simplefilter("always"), which overrides the filters above. Override
+    # showwarning as a fallback to suppress warnings that slip through.
+    _original_showwarning = warnings.showwarning
+
+    def _rank0_only_showwarning(message, category, filename, lineno, file=None, line=None):
+        if issubclass(category, (UserWarning, FutureWarning, DeprecationWarning)):
+            return
+        _original_showwarning(message, category, filename, lineno, file, line)
+
+    warnings.showwarning = _rank0_only_showwarning
 
 from functools import lru_cache, partial
 from typing import Any, List, Optional, Tuple

--- a/pretrain_hybrid.py
+++ b/pretrain_hybrid.py
@@ -16,6 +16,19 @@ rank = int(os.environ.get('RANK', 0))
 if rank != 0:
     warnings.filterwarnings("ignore", category=UserWarning)
     warnings.filterwarnings("ignore", category=FutureWarning)
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+    # Some libraries (e.g., CUTLASS DSL) use warnings.catch_warnings() with
+    # simplefilter("always"), which overrides the filters above. Override
+    # showwarning as a fallback to suppress warnings that slip through.
+    _original_showwarning = warnings.showwarning
+
+    def _rank0_only_showwarning(message, category, filename, lineno, file=None, line=None):
+        if issubclass(category, (UserWarning, FutureWarning, DeprecationWarning)):
+            return
+        _original_showwarning(message, category, filename, lineno, file, line)
+
+    warnings.showwarning = _rank0_only_showwarning
 
 from functools import lru_cache, partial
 from typing import Any, List, Optional, Tuple


### PR DESCRIPTION
## Summary
- Add `DeprecationWarning` to the warning filter list on non-rank-0 processes in `pretrain_gpt.py` and `pretrain_hybrid.py`. Override `warnings.showwarning` as a fallback for libraries like CUTLASS DSL that use `catch_warnings()` with `simplefilter("always")` to bypass filters.
- Suppress noisy Python loggers (`GroupedGemmQuantSm100`, `GroupedGemmDsreluSm100`, `GroupedGemmSreluSm100`, `GroupedGemmWgradSm100`, `absl`) on non-rank-0 in `setup_logging()`.
- Pass `device_id` to `torch.distributed.init_process_group()` to eliminate the NCCL "Guessing device ID" C++ warning on every rank.

Together these reduce log output from ~160K lines to ~3K lines on a 128-GPU job.

## Test plan
- [x] Verified on oci-hsg with 32-node (128 GPU) job: log went from 159K → 21K → 3K lines
- [x] Remaining non-rank-0 lines are only NCCL version strings (~128) and legitimate rank-127 Megatron output (timers, iteration logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)