### PR TITLE
Add comm-time benchmark for experimental FSDP symmetric memory

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -19,12 +19,13 @@ from collections.abc import Iterable
 
 import torch
 import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
 import torch.distributed.tensor as dist_tensor
 from torch.distributed import DeviceMesh
 from torch.distributed.tensor import DTensor
 
 from .layout import GlobalLayout, Shape, non_leading_numel
-from .placement import Flat, Partial, Placement, Replicate
+from .placement import Flat, Partial, Placement, Replicate, changed_mesh_axis
 
 
 @dataclasses.dataclass(frozen=True)
@@ -120,6 +121,11 @@ class DBuffer:
         # existing Storage releases the allocation while preserving those aliases
         # for a later reallocate_storage().
         self._resize_storage(0)
+
+    def rendezvous(self, mesh_axis: int) -> None:
+        """Rendezvous this local buffer for symmetric-memory collectives."""
+        group = self.mesh.get_group(mesh_axis)
+        symm_mem.rendezvous(self.local_buffer, group=group.group_name)
 
     def _resize_storage(self, numel: int) -> None:
         self.local_buffer.untyped_storage().resize_(numel * self.local_buffer.element_size())
@@ -294,19 +300,7 @@ class DBuffer:
             )
         _validate_placements(new_placements)
 
-        changed_axis: int | None = None
-        for axis, (old_placement, new_placement) in enumerate(
-            zip(self.placements, new_placements, strict=True)
-        ):
-            if old_placement == new_placement:
-                continue
-            if changed_axis is not None:
-                raise NotImplementedError(
-                    "redistribute() currently supports one placement change, "
-                    f"got changed axes {changed_axis} and {axis}."
-                )
-            changed_axis = axis
-
+        changed_axis = changed_mesh_axis(self.placements, new_placements)
         if changed_axis is None:
             if out is None:
                 return self

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
@@ -27,6 +27,7 @@ def fully_shard(
     mesh: DeviceMesh,
     placements: Placements,
     mixed_precision_policy: MixedPrecisionPolicy | None = None,
+    use_symm_mem: bool = False,
 ) -> None:
     """Shard one module as a per-module FSDP unit.
 
@@ -39,6 +40,8 @@ def fully_shard(
         placements: Parameter, gradient, and optimizer placements.
         mixed_precision_policy: Optional precision policy. Defaults to FP32 main weights
             and parameter-dtype main gradients.
+        use_symm_mem: Allocate all-gather and reduce-scatter staging buffers from
+            PyTorch's NCCL symmetric-memory pool.
     """
     if isinstance(module, FsdpModule):
         raise ValueError("This module is already managed by FSDP.")
@@ -49,7 +52,11 @@ def fully_shard(
     try:
         assert isinstance(module, FsdpModule)
         FsdpModule.__init__(
-            module, mesh=mesh, placements=placements, mixed_precision_policy=mixed_precision_policy
+            module,
+            mesh=mesh,
+            placements=placements,
+            mixed_precision_policy=mixed_precision_policy,
+            use_symm_mem=use_symm_mem,
         )
     except Exception:
         module.__class__ = original_cls

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -34,7 +34,11 @@ class FsdpModule:
     _num_training_parameters: int
 
     def __init__(
-        self, mesh: DeviceMesh, placements: Placements, mixed_precision_policy: MixedPrecisionPolicy
+        self,
+        mesh: DeviceMesh,
+        placements: Placements,
+        mixed_precision_policy: MixedPrecisionPolicy,
+        use_symm_mem: bool = False,
     ) -> None:
         """Initialize FSDP runtime state on an already-constructed module."""
         owned_parameters = _collect_owned_parameters(self)
@@ -49,6 +53,7 @@ class FsdpModule:
                 mesh=mesh,
                 placements=placements,
                 mixed_precision_policy=mixed_precision_policy,
+                use_symm_mem=use_symm_mem,
             )
             for group_parameters in _group_parameters(owned_parameters)
         ]

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -15,15 +15,17 @@
 """Parameter-group runtime state for the minimal Megatron-FSDP path."""
 
 from collections.abc import Iterable
+from contextlib import nullcontext
 
 import torch
 import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
 from torch import nn
 from torch.distributed import DeviceMesh
 
 from ..mixed_precision import MixedPrecisionPolicy
 from .dbuffer import DBuffer
-from .placement import Partial, Placements, Replicate
+from .placement import Partial, Placements, Replicate, changed_mesh_axis
 
 _CONTAINING_PARAMETER_GROUP_ATTR = "_mfsdp_parameter_group"
 
@@ -47,6 +49,7 @@ class FsdpParameterGroup:
     model_weight: DBuffer
     main_grad: DBuffer | None
     _unsharded_model_weight: DBuffer
+    _symm_mem_pool: torch.cuda.MemPool | None
 
     def __init__(
         self,
@@ -55,6 +58,7 @@ class FsdpParameterGroup:
         mesh: DeviceMesh,
         placements: Placements,
         mixed_precision_policy: MixedPrecisionPolicy,
+        use_symm_mem: bool = False,
     ) -> None:
         """Create persistent sharded buffers for a group of parameters.
 
@@ -64,6 +68,8 @@ class FsdpParameterGroup:
             mesh: Device mesh used for all DBuffer storage in this version.
             placements: Parameter, gradient, and optimizer placements.
             mixed_precision_policy: Precision policy for main weights and gradients.
+            use_symm_mem: Allocate communication staging buffers from PyTorch's
+                NCCL symmetric-memory pool.
         """
         if not parameters:
             raise ValueError("FsdpParameterGroup requires at least one parameter.")
@@ -100,13 +106,21 @@ class FsdpParameterGroup:
             placements=main_weight_placements,
         )
 
-        self._unsharded_model_weight = DBuffer(
-            mesh=self.mesh,
-            placements=[Replicate()] * self.mesh.ndim,
-            tensor_shapes=tensor_shapes,
-            dtype=self.dtype,
-            device=self.main_weight.device,
-        )
+        if use_symm_mem:
+            # PyTorch caches this in C++ and returns early when the backend is already NCCL.
+            symm_mem.set_backend("NCCL")
+            self._symm_mem_pool = symm_mem.get_mem_pool(self.main_weight.device)
+        else:
+            self._symm_mem_pool = None
+
+        with self._symmetric_memory_context():
+            self._unsharded_model_weight = DBuffer(
+                mesh=self.mesh,
+                placements=[Replicate()] * self.mesh.ndim,
+                tensor_shapes=tensor_shapes,
+                dtype=self.dtype,
+                device=self.main_weight.device,
+            )
         if main_weight_dtype == self.dtype and main_weight_placements == model_weight_placements:
             self.model_weight = self.main_weight
         else:
@@ -144,7 +158,6 @@ class FsdpParameterGroup:
                     f"Got main_grad placements {self.main_grad.placements} and "
                     f"main_weight placements {self.main_weight.placements}."
                 )
-
         sharded_parameters: list[nn.Parameter] = []
         unsharded_parameters: list[nn.Parameter] = []
         main_grad_dtype = self.main_grad.dtype if self.main_grad is not None else None
@@ -166,6 +179,11 @@ class FsdpParameterGroup:
 
         self._switch_to_sharded_parameters()
         self._unsharded_model_weight.release_storage()
+
+    def _symmetric_memory_context(self):
+        if self._symm_mem_pool is None:
+            return nullcontext()
+        return torch.cuda.use_mem_pool(self._symm_mem_pool)
 
     def _set_module_parameters(self, parameters: tuple[nn.Parameter, ...]) -> None:
         for name, parameter in zip(self.parameter_names, parameters, strict=True):
@@ -189,15 +207,21 @@ class FsdpParameterGroup:
 
     def unshard_parameters(self) -> None:
         """Install full parameters for local compute."""
-        self._unsharded_model_weight.reallocate_storage()
+        with self._symmetric_memory_context():
+            self._unsharded_model_weight.reallocate_storage()
         # This buffer backs unsharded Parameters whose views may be saved by autograd.
         # Autograd records a tensor's version counter when saving it for backward, and
         # in-place writes like the out= redistribution below increment that counter even
         # under no_grad. Without preserving it, backward can fail with "modified by an
         # inplace operation" even though FSDP only materialized internal storage.
+        gather_axis = changed_mesh_axis(
+            self.model_weight.placements, self._unsharded_model_weight.placements
+        )
         with torch.autograd._unsafe_preserve_version_counter(
             self._unsharded_model_weight.local_buffer
         ):
+            if self._symm_mem_pool is not None and gather_axis is not None:
+                self._unsharded_model_weight.rendezvous(gather_axis)
             self.model_weight.redistribute(
                 self._unsharded_model_weight.placements, out=self._unsharded_model_weight
             )
@@ -236,9 +260,13 @@ class FsdpParameterGroup:
                 raise RuntimeError(f"Missing gradient for FSDP parameter {name!r}.")
             grads.append(parameter.grad)
 
-        partial_grad = DBuffer.distribute_tensors(
-            grads, mesh=self.mesh, placements=[Partial(dist.ReduceOp.AVG)] * self.mesh.ndim
-        )
+        # NCCL symmetric-memory reduce-scatter only selects the symmetric kernel for SUM today.
+        # Preserve AVG semantics by reducing SUM and scaling the output below.
+        partial_op = dist.ReduceOp.AVG if self._symm_mem_pool is None else dist.ReduceOp.SUM
+        with self._symmetric_memory_context():
+            partial_grad = DBuffer.distribute_tensors(
+                grads, mesh=self.mesh, placements=[Partial(partial_op)] * self.mesh.ndim
+            )
 
         # zero_grad(set_to_none=True) clears sharded parameter grads, so the next
         # backward can reduce directly into main_grad. zero_grad(set_to_none=False)
@@ -247,10 +275,20 @@ class FsdpParameterGroup:
         can_reduce_into_main_grad = (
             not has_sharded_grads and partial_grad.dtype == self.main_grad.dtype
         )
+        reduce_axis = changed_mesh_axis(partial_grad.placements, self.main_grad.placements)
+        if reduce_axis is None:
+            raise RuntimeError("FSDP gradient reduction requires a changed placement axis.")
+        grad_divisor = self.mesh.size(reduce_axis) if partial_op == dist.ReduceOp.SUM else 1
+        if self._symm_mem_pool is not None:
+            partial_grad.rendezvous(reduce_axis)
         if can_reduce_into_main_grad:
             partial_grad.redistribute(self.main_grad.placements, out=self.main_grad)
+            if grad_divisor != 1:
+                self.main_grad.local_buffer.div_(grad_divisor)
         else:
             reduced_grad = partial_grad.redistribute(self.main_grad.placements)
+            if grad_divisor != 1:
+                reduced_grad.local_buffer.div_(grad_divisor)
             if has_sharded_grads:
                 self.main_grad.local_buffer.add_(reduced_grad.local_buffer)
             else:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -217,10 +217,12 @@ class FsdpParameterGroup:
         gather_axis = changed_mesh_axis(
             self.model_weight.placements, self._unsharded_model_weight.placements
         )
+        if gather_axis is None:
+            raise RuntimeError("FSDP parameter unshard requires a changed placement axis.")
         with torch.autograd._unsafe_preserve_version_counter(
             self._unsharded_model_weight.local_buffer
         ):
-            if self._symm_mem_pool is not None and gather_axis is not None:
+            if self._symm_mem_pool is not None:
                 self._unsharded_model_weight.rendezvous(gather_axis)
             self.model_weight.redistribute(
                 self._unsharded_model_weight.placements, out=self._unsharded_model_weight

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/placement.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/placement.py
@@ -30,6 +30,7 @@ sharded        ``Replicate``  ``allgather()``
 """
 
 import dataclasses
+from collections.abc import Iterable
 
 import torch.distributed as dist
 
@@ -56,6 +57,25 @@ class Partial(Placement):
 @dataclasses.dataclass(frozen=True)
 class Flat(Placement):
     """Flat per-unit dim-0 sharded local buffer placement."""
+
+
+def changed_mesh_axis(
+    old_placements: Iterable[Placement], new_placements: Iterable[Placement]
+) -> int | None:
+    """Return the changed mesh axis, requiring at most one placement change."""
+    changed_axis = None
+    for axis, (old_placement, new_placement) in enumerate(
+        zip(old_placements, new_placements, strict=True)
+    ):
+        if old_placement == new_placement:
+            continue
+        if changed_axis is not None:
+            raise NotImplementedError(
+                "Expected at most one changed placement axis, "
+                f"got changed axes {changed_axis} and {axis}."
+            )
+        changed_axis = axis
+    return changed_axis
 
 
 @dataclasses.dataclass(frozen=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,7 @@ test = [
     "pytest-cov",
     "pytest-random-order",
     "pytest-asyncio",
+    "pytest-benchmark",
     "pygithub",
     "pydantic",
     "tensorboard",

--- a/tests/unit_tests/distributed/megatron_fsdp/test_symmetric_memory.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_symmetric_memory.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Unit tests for experimental FSDP symmetric-memory staging."""
+
+import pytest
+import torch
+from torch import nn
+from torch.distributed.device_mesh import init_device_mesh
+from torch.profiler import ProfilerActivity, profile
+
+from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
+    Flat,
+    Placements,
+    fully_shard,
+)
+
+
+class TinyModel(nn.Module):
+    """Small model with two separately shardable units."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.fc1 = nn.Linear(8, 16)
+        self.relu = nn.ReLU()
+        self.fc2 = nn.Linear(16, 4)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the tiny model."""
+        return self.fc2(self.relu(self.fc1(x)))
+
+
+def _flat_placements() -> Placements:
+    return Placements(dp_axes=[0], parameter=[Flat()], gradient=[Flat()], optimizer=[Flat()])
+
+
+def _kernels(prof: torch.profiler.profile) -> list[str]:
+    return [event.name for event in prof.events()]
+
+
+def _is_symmetric_kernel(kernel: str) -> bool:
+    return "ncclSymk" in kernel
+
+
+def _count_symmetric_kernels(kernels: list[str], subname: str) -> int:
+    return sum(
+        1
+        for kernel in kernels
+        if _is_symmetric_kernel(kernel) and subname in kernel
+    )
+
+
+@pytest.mark.parametrize("num_microbatches", [1, 3])
+def test_fully_shard_symmetric_memory_matches_default_and_profiles_nccl(
+    distributed_setup, num_microbatches
+):
+    """NCCL symmetric-memory staging should preserve training parity and hit symmetric kernels."""
+    world_size = distributed_setup.world_size
+    device = distributed_setup.device
+    if world_size < 2:
+        pytest.skip("This test requires at least 2 ranks.")
+
+    mesh = init_device_mesh(device.type, (world_size,))
+    num_sharded_modules = 2
+    num_training_steps = 5
+
+    def train(use_symm_mem: bool) -> list[torch.Tensor]:
+        torch.manual_seed(1234)
+        model = TinyModel().to(device)
+        fully_shard(
+            model.fc1, mesh=mesh, placements=_flat_placements(), use_symm_mem=use_symm_mem
+        )
+        fully_shard(
+            model.fc2, mesh=mesh, placements=_flat_placements(), use_symm_mem=use_symm_mem
+        )
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.05)
+
+        micro_batch_size = 2
+        x = torch.randn(num_microbatches, micro_batch_size, 8, device=device)
+        target = torch.randn(num_microbatches, micro_batch_size, 4, device=device)
+        microbatches = tuple(zip(x.unbind(), target.unbind()))
+
+        losses = []
+        for _ in range(num_training_steps):
+            optimizer.zero_grad()
+            for microbatch_x, microbatch_target in microbatches:
+                loss = torch.nn.functional.mse_loss(model(microbatch_x), microbatch_target)
+                losses.append(loss.detach())
+                (loss / num_microbatches).backward()
+            optimizer.step()
+
+        return losses
+
+    with profile(activities=[ProfilerActivity.CUDA]) as prof_without_symm_mem:
+        losses_without_symm_mem = train(use_symm_mem=False)
+        torch.cuda.synchronize()
+
+    with profile(activities=[ProfilerActivity.CUDA]) as prof_with_symm_mem:
+        losses_with_symm_mem = train(use_symm_mem=True)
+        torch.cuda.synchronize()
+
+    torch.testing.assert_close(
+        torch.stack(losses_with_symm_mem),
+        torch.stack(losses_without_symm_mem),
+        msg="Symmetric-memory FSDP losses did not match default FSDP losses.",
+    )
+
+    kernels_without_symm_mem = _kernels(prof_without_symm_mem)
+    assert _count_symmetric_kernels(kernels_without_symm_mem, "AllGather") == 0
+    assert _count_symmetric_kernels(kernels_without_symm_mem, "ReduceScatter") == 0
+
+    kernels_with_symm_mem = _kernels(prof_with_symm_mem)
+    expected_reduce_scatter_kernel_count = num_training_steps * num_microbatches * num_sharded_modules
+    nccl_kernels_with_symm_mem = [
+        kernel for kernel in kernels_with_symm_mem if "nccl" in kernel.lower()
+    ]
+    assert (
+        _count_symmetric_kernels(kernels_with_symm_mem, "ReduceScatter")
+        == expected_reduce_scatter_kernel_count
+    ), (
+        "Unexpected NCCL symmetric-memory reduce-scatter kernel count. "
+        f"Observed NCCL kernels: {nccl_kernels_with_symm_mem[:20]}"
+    )
+
+    expected_all_gather_kernel_count = 2 * expected_reduce_scatter_kernel_count
+    assert (
+        _count_symmetric_kernels(kernels_with_symm_mem, "AllGather")
+        == expected_all_gather_kernel_count
+    ), (
+        "Unexpected NCCL symmetric-memory all-gather kernel count. "
+        f"Observed NCCL kernels: {nccl_kernels_with_symm_mem[:20]}"
+    )

--- a/tests/unit_tests/distributed/megatron_fsdp/test_symmetric_memory.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_symmetric_memory.py
@@ -2,6 +2,8 @@
 
 """Unit tests for experimental FSDP symmetric-memory staging."""
 
+import math
+
 import pytest
 import torch
 from torch import nn
@@ -43,11 +45,7 @@ def _is_symmetric_kernel(kernel: str) -> bool:
 
 
 def _count_symmetric_kernels(kernels: list[str], subname: str) -> int:
-    return sum(
-        1
-        for kernel in kernels
-        if _is_symmetric_kernel(kernel) and subname in kernel
-    )
+    return sum(1 for kernel in kernels if _is_symmetric_kernel(kernel) and subname in kernel)
 
 
 @pytest.mark.parametrize("num_microbatches", [1, 3])
@@ -85,9 +83,7 @@ def test_fully_shard_symmetric_memory_matches_default_and_profiles_nccl(
         optimizer = torch.optim.SGD(model.parameters(), lr=0.05, foreach=False)
 
         micro_batch_size = 2
-        x = torch.randn(
-            num_microbatches, micro_batch_size, 8, device=device, dtype=torch.bfloat16
-        )
+        x = torch.randn(num_microbatches, micro_batch_size, 8, device=device, dtype=torch.bfloat16)
         target = torch.randn(
             num_microbatches, micro_batch_size, 4, device=device, dtype=torch.bfloat16
         )
@@ -123,7 +119,9 @@ def test_fully_shard_symmetric_memory_matches_default_and_profiles_nccl(
     assert _count_symmetric_kernels(kernels_without_symm_mem, "ReduceScatter") == 0
 
     kernels_with_symm_mem = _kernels(prof_with_symm_mem)
-    expected_reduce_scatter_kernel_count = num_training_steps * num_microbatches * num_sharded_modules
+    expected_reduce_scatter_kernel_count = (
+        num_training_steps * num_microbatches * num_sharded_modules
+    )
     nccl_kernels_with_symm_mem = [
         kernel for kernel in kernels_with_symm_mem if "nccl" in kernel.lower()
     ]
@@ -143,3 +141,138 @@ def test_fully_shard_symmetric_memory_matches_default_and_profiles_nccl(
         "Unexpected NCCL symmetric-memory all-gather kernel count. "
         f"Observed NCCL kernels: {nccl_kernels_with_symm_mem[:20]}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Communication-time benchmark (runs by default under torchrun).
+#
+# For each hidden size (a pytest parameter), shards a single Linear(hidden, hidden)
+# and reports the communication time of its all-gather (weights) and
+# reduce-scatter (grads) for default (ring) vs symmetric memory, using bf16
+# params + fp32 main weights. The collective sizes depend only on the weight
+# (hidden^2), so hidden is the only knob; batch / warmup / step counts don't
+# change what is measured and are fixed internally.
+#
+# "Communication time" is the MIN device time across ranks for each recorded collective:
+# NCCL LL/symm kernels spin-wait for peers, so a rank's device time = transfer + wait. The
+# least-waited rank approximates the intrinsic transfer time -- it matches a synchronized
+# pure-NCCL microbench. The across-ranks min does most of the work, so a single profiled
+# step suffices.
+#
+# Run (single node, 8 GPUs):
+#   torchrun --nproc_per_node=8 -m pytest -q -s \
+#     tests/unit_tests/distributed/megatron_fsdp/test_symmetric_memory.py -k benchmark
+# ---------------------------------------------------------------------------
+
+
+# CPU-side c10d collective ops -> communication type. With record_shapes=True these
+# carry the buffer shapes (so we get the message size), and their device_time_total is
+# the launched NCCL kernel's time -- for both the ring and symmetric backends.
+_EVENT_NAME_TO_COLLECTIVE = {
+    "c10d::_allgather_base_": "all_gather",
+    "c10d::_reduce_scatter_base_": "reduce_scatter",
+}
+
+
+def _collective_records(prof, *, element_size: int):
+    """One record per collective instance observed in the profiled step, in program order.
+
+    Size comes from the c10d op's recorded shapes (full buffer = max numel); time from its
+    device_time_total (= the launched NCCL kernel's time). The c10d ops are CPU-side, so they
+    appear in dispatcher call order -- identical across ranks for this symmetric step -- which
+    is the order the caller's positional cross-rank min relies on.
+    """
+    records = []
+    for ev in prof.events():
+        # prof.events() includes every op in the step; keep only the collective ops.
+        ctype = _EVENT_NAME_TO_COLLECTIVE.get(ev.name)
+        if ctype is None:
+            continue
+        # A collective with no attributed device time means its NCCL kernel wasn't
+        # captured -- fail loudly rather than drop the record and skew the min.
+        assert ev.device_time_total > 0, (
+            f"{ev.name} recorded no device time (device_time_total="
+            f"{ev.device_time_total}); its NCCL kernel was not captured."
+        )
+        numel = max((math.prod(s) for s in ev.input_shapes if s), default=0)
+        records.append(
+            {"collective": ctype, "bytes": numel * element_size, "us": ev.device_time_total}
+        )
+    return records
+
+
+@pytest.mark.parametrize("hidden", [1024, 2048, 4096, 8192])
+@pytest.mark.parametrize("use_symm_mem", [False, True])
+def test_symmetric_memory_comm_time_benchmark(benchmark, distributed_setup, hidden, use_symm_mem):
+    """Benchmark one sharded Linear(hidden, hidden) step (bf16 params + fp32 main weights).
+
+    pytest-benchmark's ``benchmark`` fixture times the wall-clock per step; one record per
+    collective instance -- each with the cross-rank min kernel time (the wait-free
+    communication time) -- is attached as ``benchmark.extra_info["communications"]``.
+    """
+    world_size = distributed_setup.world_size
+    device = distributed_setup.device
+    if world_size < 2:
+        pytest.skip("This benchmark requires at least 2 ranks.")
+
+    mesh = init_device_mesh(device.type, (world_size,))
+    # Warm the communicator with a barrier so the symmetric rendezvous below is never the
+    # first NCCL op on this group -- otherwise NCCL window registration fails
+    # (pytorch/pytorch#188567).
+    torch.distributed.barrier(device_ids=[device.index])
+
+    torch.manual_seed(1234)
+    model = nn.Linear(hidden, hidden, bias=False).to(device=device, dtype=torch.bfloat16)
+    # The default MixedPrecisionPolicy() already keeps fp32 main weights + param-dtype
+    # (bf16) grads, so no policy is passed. foreach=False so stock SGD tolerates the
+    # fp32-param / bf16-grad pairing (the foreach path rejects mixed dtypes).
+    fully_shard(model, mesh=mesh, placements=_flat_placements(), use_symm_mem=use_symm_mem)
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.01, foreach=False)
+    # batch only drives a fwd/bwd; it does not affect the collective sizes (those depend on
+    # the weight, hidden^2).
+    x = torch.randn(512, hidden, device=device, dtype=torch.bfloat16)
+
+    def step():
+        optimizer.zero_grad()
+        model(x).sum().backward()  # any backward produces the weight grad -> reduce-scatter
+        optimizer.step()
+        torch.cuda.synchronize()
+
+    # Wall-clock per step FIRST. pedantic's warmup_rounds (untimed) absorb the one-time costs --
+    # symm window registration on the first symm collective, allocator growth, NCCL channel
+    # setup -- so both its timed rounds AND the profiling below are steady-state. Fixed
+    # rounds/iterations keep every rank issuing the same number of collectives in lockstep;
+    # auto-calibrated benchmark(step) would pick per-rank counts and deadlock.
+    benchmark.pedantic(step, rounds=5, iterations=1, warmup_rounds=2)
+
+    # Profile a SINGLE step (model fully warm from pedantic above). The cross-rank min below
+    # reduces over this step's ~2 all-gather + 1 reduce-scatter instances x ranks -- enough
+    # for the least-waited (wait-free) time without looping.
+    with profile(
+        activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA], record_shapes=True
+    ) as prof:
+        step()
+
+    communications = _collective_records(prof, element_size=x.element_size())
+    # The cross-rank min below is positional, so records[i] must be the same collective on
+    # every rank. Program order gives that for this symmetric step; the one way it breaks is a
+    # rank dropping an instance (e.g. a zero-duration event filtered out), which shifts every
+    # later position -- so assert the counts match before reducing.
+    n = len(communications)
+    n_max = torch.tensor(n, device=device)
+    n_min = torch.tensor(n, device=device)
+    torch.distributed.all_reduce(n_max, op=torch.distributed.ReduceOp.MAX)
+    torch.distributed.all_reduce(n_min, op=torch.distributed.ReduceOp.MIN)
+    assert n_min.item() == n == n_max.item(), (
+        f"ranks recorded different collective counts (this rank {n}, "
+        f"range {n_min.item()}..{n_max.item()}); records are misaligned."
+    )
+    # Reduce each record's time across ranks: within a collective the least-waited rank's
+    # kernel time ~= the intrinsic transfer (NCCL LL/symm kernels spin-wait for peers, so a
+    # rank's device time = transfer + wait-for-slowest-peer), so min over ranks is the
+    # tightest wait-free estimate.
+    mins = torch.tensor([c["us"] for c in communications], device=device)
+    torch.distributed.all_reduce(mins, op=torch.distributed.ReduceOp.MIN)
+    for c, v in zip(communications, mins.tolist()):
+        c["us"] = v
+    benchmark.extra_info["communications"] = communications

--- a/tests/unit_tests/distributed/megatron_fsdp/test_symmetric_memory.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_symmetric_memory.py
@@ -59,7 +59,6 @@ def test_fully_shard_symmetric_memory_matches_default_and_profiles_nccl(
         pytest.skip("This test requires at least 2 ranks.")
 
     mesh = init_device_mesh(device.type, (world_size,))
-    num_sharded_modules = 2
     num_training_steps = 5
 
     def train(use_symm_mem: bool) -> list[torch.Tensor]:
@@ -119,9 +118,8 @@ def test_fully_shard_symmetric_memory_matches_default_and_profiles_nccl(
     assert _count_symmetric_kernels(kernels_without_symm_mem, "ReduceScatter") == 0
 
     kernels_with_symm_mem = _kernels(prof_with_symm_mem)
-    expected_reduce_scatter_kernel_count = (
-        num_training_steps * num_microbatches * num_sharded_modules
-    )
+    # 2 sharded modules (fc1, fc2), one reduce-scatter each per microbatch step.
+    expected_reduce_scatter_kernel_count = num_training_steps * num_microbatches * 2
     nccl_kernels_with_symm_mem = [
         kernel for kernel in kernels_with_symm_mem if "nccl" in kernel.lower()
     ]

--- a/tests/unit_tests/distributed/megatron_fsdp/test_symmetric_memory.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_symmetric_memory.py
@@ -8,6 +8,7 @@ from torch import nn
 from torch.distributed.device_mesh import init_device_mesh
 from torch.profiler import ProfilerActivity, profile
 
+from megatron.core.distributed.fsdp.src.megatron_fsdp import MixedPrecisionPolicy
 from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
     Flat,
     Placements,
@@ -65,18 +66,31 @@ def test_fully_shard_symmetric_memory_matches_default_and_profiles_nccl(
 
     def train(use_symm_mem: bool) -> list[torch.Tensor]:
         torch.manual_seed(1234)
-        model = TinyModel().to(device)
+        model = TinyModel().to(device=device, dtype=torch.bfloat16)
+        mixed_precision_policy = MixedPrecisionPolicy(main_params_dtype=torch.float32)
         fully_shard(
-            model.fc1, mesh=mesh, placements=_flat_placements(), use_symm_mem=use_symm_mem
+            model.fc1,
+            mesh=mesh,
+            placements=_flat_placements(),
+            mixed_precision_policy=mixed_precision_policy,
+            use_symm_mem=use_symm_mem,
         )
         fully_shard(
-            model.fc2, mesh=mesh, placements=_flat_placements(), use_symm_mem=use_symm_mem
+            model.fc2,
+            mesh=mesh,
+            placements=_flat_placements(),
+            mixed_precision_policy=mixed_precision_policy,
+            use_symm_mem=use_symm_mem,
         )
-        optimizer = torch.optim.SGD(model.parameters(), lr=0.05)
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.05, foreach=False)
 
         micro_batch_size = 2
-        x = torch.randn(num_microbatches, micro_batch_size, 8, device=device)
-        target = torch.randn(num_microbatches, micro_batch_size, 4, device=device)
+        x = torch.randn(
+            num_microbatches, micro_batch_size, 8, device=device, dtype=torch.bfloat16
+        )
+        target = torch.randn(
+            num_microbatches, micro_batch_size, 4, device=device, dtype=torch.bfloat16
+        )
         microbatches = tuple(zip(x.unbind(), target.unbind()))
 
         losses = []

--- a/uv.lock
+++ b/uv.lock
@@ -2283,6 +2283,7 @@ test = [
     { name = "pygithub" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-benchmark" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "pytest-random-order" },
@@ -2381,6 +2382,7 @@ test = [
     { name = "pygithub" },
     { name = "pytest", specifier = "==8.3.5" },
     { name = "pytest-asyncio" },
+    { name = "pytest-benchmark" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "pytest-random-order" },
@@ -3655,6 +3657,15 @@ wheels = [
 ]
 
 [[package]]
+name = "py-cpuinfo"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690", size = 104716, upload-time = "2022-10-25T20:38:06.303Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5", size = 22335, upload-time = "2022-10-25T20:38:27.636Z" },
+]
+
+[[package]]
 name = "py-spy"
 version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -4008,6 +4019,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "pytest-benchmark"
+version = "5.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "py-cpuinfo" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/24/34/9f732b76456d64faffbef6232f1f9dbec7a7c4999ff46282fa418bd1af66/pytest_benchmark-5.2.3.tar.gz", hash = "sha256:deb7317998a23c650fd4ff76e1230066a76cb45dcece0aca5607143c619e7779", size = 341340, upload-time = "2025-11-09T18:48:43.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/29/e756e715a48959f1c0045342088d7ca9762a2f509b945f362a316e9412b7/pytest_benchmark-5.2.3-py3-none-any.whl", hash = "sha256:bc839726ad20e99aaa0d11a127445457b4219bdb9e80a1afc4b51da7f96b0803", size = 45255, upload-time = "2025-11-09T18:48:39.765Z" },
 ]
 
 [[package]]
@@ -5155,15 +5179,15 @@ name = "torch"
 version = "2.12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
-    { name = "filelock", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "fsspec", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "jinja2", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "networkx", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "setuptools", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "sympy", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "triton", marker = "sys_platform == 'never'" },
-    { name = "typing-extensions", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "cuda-bindings", marker = "python_version < '0'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "triton" },
+    { name = "typing-extensions" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds a communication-time benchmark for the experimental Megatron-FSDP NCCL symmetric-memory path, split out of #5440 to keep that PR focused on the core staging feature.

`test_symmetric_memory_comm_time_benchmark` shards a single `Linear(hidden, hidden)` and records, per collective, the cross-rank minimum NCCL kernel device time (the wait-free transfer cost) for the ring vs symmetric-memory backends, attached as `benchmark.extra_info["communications"]`. Adds the `pytest-benchmark` test dependency (with the corresponding `uv.lock` update).

## Benchmark (communication time)

Single node, 8×H100, bf16 params + fp32 main weights. Each value is the cross-rank minimum of the NCCL collective kernel's device time (all-gather shown as the mean of its two per-step instances; message size is the full buffer `hidden² × 2 B`).

| hidden | msg size | all-gather off → on | speedup | reduce-scatter off → on | speedup |
|-------:|---------:|--------------------:|:-------:|------------------------:|:-------:|
| 1024   | 2 MiB    | 20.2 → 10.9 µs      | 1.86×   | 18.6 → 10.8 µs          | 1.72×   |
| 2048   | 8 MiB    | 43.4 → 27.4 µs      | 1.59×   | 47.0 → 28.8 µs          | 1.63×   |
| 4096   | 32 MiB   | 118.9 → 95.3 µs     | 1.25×   | 112.6 → 100.5 µs        | 1.12×   |
| 8192   | 128 MiB  | 385.3 → 363.2 µs    | 1.06×   | 374.9 → 375.6 µs        | 1.00×   |

Symmetric memory reduces collective kernel time across the board, with the largest gains on small/latency-bound messages converging toward parity as the transfer becomes bandwidth-bound. Wall-clock per step is not reported: at these sizes the step is dominated by FSDP host-side dispatch (~2 ms/step), so wall-clock does not track communication.

## Note

This PR currently includes the core symmetric-memory staging changes from #5440 (it was branched from that work). Once #5440 merges, this branch will be rebased onto `main` so the diff shows only the benchmark.

## Validation

- `python -m torch.distributed.run --nproc-per-node 8 -m pytest -q -s tests/unit_tests/distributed/megatron_fsdp/test_symmetric_memory.py -k benchmark` (8×H100; produces the table above)
