### PR TITLE
Add Sliding Window Attention (SWA) with P2P context parallel backend

### DIFF
--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -35,6 +35,13 @@ from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.mappings import all_gather_last_dim_from_tensor_parallel_region
 from megatron.core.transformer.identity_op import IdentityOp
 from megatron.core.transformer.module import MegatronModule
+from megatron.core.transformer.swa_context_parallel import (
+    SwaP2PSegment,
+    build_swa_p2p_nonpacked_segments,
+    build_swa_p2p_packed_segments,
+    get_swa_p2p_halos,
+    is_swa_p2p_cp_comm_type,
+)
 from megatron.core.transformer.torch_norm import L2Norm, LayerNormBuilder
 from megatron.core.transformer.utils import is_layer_window_attention
 from megatron.core.typed_torch import apply_module, not_none
@@ -306,6 +313,7 @@ class Attention(MegatronModule, ABC):
         self.attn_mask_type = attn_mask_type
         self.attention_type = attention_type
         self.batch_invariant_mode = config.batch_invariant_mode
+        self.swa_p2p = is_swa_p2p_cp_comm_type(cp_comm_type)
 
         # Cache the YaRN concentration factor (a.k.a. attention factor / mscale),
         # which is a pure function of the config and is reused on every forward
@@ -366,12 +374,19 @@ class Attention(MegatronModule, ABC):
             tmp_config.num_query_groups = world_size
         else:
             tmp_config = self.config
+        core_attention_cp_comm_type = cp_comm_type
+        if self.swa_p2p:
+            if tmp_config is self.config:
+                tmp_config = copy.deepcopy(self.config)
+            tmp_config.context_parallel_size = 1
+            tmp_config.cp_comm_type = None
+            core_attention_cp_comm_type = None
         self.core_attention = submodules.core_attention(
             config=tmp_config,
             layer_number=self.layer_number,
             attn_mask_type=self.attn_mask_type,
             attention_type=self.attention_type,
-            cp_comm_type=cp_comm_type,
+            cp_comm_type=core_attention_cp_comm_type,
             softmax_scale=self.config.softmax_scale,
             pg_collection=self.pg_collection,
         )
@@ -460,7 +475,10 @@ class Attention(MegatronModule, ABC):
             extra_kwargs = dict(core_attention_extra_kwargs)
             for name, kwarg_value in zip(tensor_kwarg_names, tensor_kwarg_values):
                 extra_kwargs[name] = kwarg_value
-            output_ = self._run_core_attention(
+            run_core_attention = (
+                self._run_swa_p2p_core_attention if self.swa_p2p else self._run_core_attention
+            )
+            output_ = run_core_attention(
                 query,
                 key,
                 value,
@@ -504,6 +522,183 @@ class Attention(MegatronModule, ABC):
             packed_seq_params=packed_seq_params,
             **extra_kwargs,
         )
+
+    def _get_swa_p2p_left_window(self) -> int:
+        """Return the causal SWA left-window size for this layer."""
+        if not is_layer_window_attention(
+            self.config.window_size, self.config.window_attn_skip_freq, self.layer_number
+        ):
+            raise ValueError(
+                "cp_comm_type='swa_p2p' can only be used on layers with sliding-window attention. "
+                "Use a different cp_comm_type for full-attention layers."
+            )
+        if self.config.window_size is None:
+            raise ValueError("cp_comm_type='swa_p2p' requires config.window_size to be set.")
+
+        left_window, right_window = self.config.window_size
+        if left_window < 0 or right_window != 0:
+            raise ValueError(
+                "cp_comm_type='swa_p2p' currently supports causal SWA only, "
+                f"got window_size={self.config.window_size}."
+            )
+        return left_window
+
+    def _run_swa_p2p_core_attention(
+        self,
+        query,
+        key,
+        value,
+        attention_mask,
+        attn_mask_type=None,
+        attention_bias=None,
+        packed_seq_params=None,
+    ):
+        """Run causal SWA attention with P2P K/V halo exchanges under CP sharding."""
+        if attention_bias is not None:
+            raise NotImplementedError("cp_comm_type='swa_p2p' does not support attention bias.")
+        if attn_mask_type not in (
+            None,
+            AttnMaskType.causal,
+            AttnMaskType.causal_bottom_right,
+            AttnMaskType.arbitrary,
+        ):
+            raise ValueError(
+                "cp_comm_type='swa_p2p' currently supports causal attention only, "
+                f"got attn_mask_type={attn_mask_type}."
+            )
+        if query.size(0) != key.size(0) or key.size(0) != value.size(0):
+            raise ValueError("cp_comm_type='swa_p2p' expects local self-attention Q/K/V lengths.")
+
+        left_window = self._get_swa_p2p_left_window()
+        cp_group = self.pg_collection.cp
+        if packed_seq_params is not None:
+            if attention_mask is not None:
+                raise NotImplementedError(
+                    "cp_comm_type='swa_p2p' packed path does not support an explicit "
+                    "attention_mask."
+                )
+            if packed_seq_params.cp_group is not None:
+                cp_group = packed_seq_params.cp_group
+            if packed_seq_params.local_cp_size is not None:
+                raise NotImplementedError("cp_comm_type='swa_p2p' does not support dynamic CP.")
+            cu_seqlens_padded = (
+                packed_seq_params.cu_seqlens_q_padded
+                if packed_seq_params.cu_seqlens_q_padded is not None
+                else packed_seq_params.cu_seqlens_q
+            )
+            if cu_seqlens_padded is None:
+                raise ValueError("cp_comm_type='swa_p2p' packed path requires cu_seqlens.")
+        cp_size = cp_group.size()
+
+        if cp_size == 1:
+            return self._run_core_attention(
+                query,
+                key,
+                value,
+                attention_mask,
+                attn_mask_type=attn_mask_type,
+                attention_bias=None,
+                packed_seq_params=packed_seq_params,
+            )
+
+        if packed_seq_params is not None:
+            segments_by_rank = build_swa_p2p_packed_segments(cu_seqlens_padded, cp_size)
+        else:
+            segments_by_rank = build_swa_p2p_nonpacked_segments(query.size(0), cp_size)
+
+        local_segments = segments_by_rank[cp_group.rank()]
+
+        if key.shape[1:-1] != value.shape[1:-1]:
+            raise NotImplementedError(
+                "cp_comm_type='swa_p2p' expects K/V tensors with matching non-channel "
+                f"dimensions, got key.shape={key.shape} and value.shape={value.shape}."
+            )
+        key_value = torch.cat((key, value), dim=-1)
+        key_value_halos = get_swa_p2p_halos(key_value, left_window, cp_group, segments_by_rank)
+
+        outputs = []
+        for segment, key_value_halo in zip(local_segments, key_value_halos):
+            key_halo, value_halo = torch.split(
+                key_value_halo, (key.size(-1), value.size(-1)), dim=-1
+            )
+            query_segment = query.narrow(0, segment.local_offset, segment.length)
+            key_segment = key.narrow(0, segment.local_offset, segment.length)
+            value_segment = value.narrow(0, segment.local_offset, segment.length)
+            key_segment = torch.cat((key_halo, key_segment), dim=0)
+            value_segment = torch.cat((value_halo, value_segment), dim=0)
+
+            if packed_seq_params is None:
+                segment_attention_mask = self._get_swa_p2p_segment_attention_mask(
+                    attention_mask, segment, key_halo.size(0), left_window
+                )
+                segment_attn_mask_type = (
+                    AttnMaskType.arbitrary
+                    if segment_attention_mask is not None
+                    else AttnMaskType.causal_bottom_right
+                )
+                segment_packed_seq_params = None
+            else:
+                segment_attention_mask = None
+                segment_attn_mask_type = AttnMaskType.causal_bottom_right
+                segment_packed_seq_params = None
+                query_segment = query_segment.unsqueeze(1)
+                key_segment = key_segment.unsqueeze(1)
+                value_segment = value_segment.unsqueeze(1)
+
+            segment_output = self._run_core_attention(
+                query_segment,
+                key_segment,
+                value_segment,
+                segment_attention_mask,
+                attn_mask_type=segment_attn_mask_type,
+                attention_bias=None,
+                packed_seq_params=segment_packed_seq_params,
+            )
+            if packed_seq_params is not None:
+                segment_output = segment_output.squeeze(1)
+            outputs.append(segment_output)
+
+        return torch.cat(outputs, dim=0)
+
+    def _get_swa_p2p_segment_attention_mask(
+        self,
+        attention_mask: Tensor | None,
+        segment: SwaP2PSegment,
+        halo_len: int,
+        left_window: int,
+    ) -> Tensor | None:
+        """Slice a dense reset attention mask for one SWA P2P segment."""
+        if attention_mask is None:
+            return None
+        if attention_mask.size(-2) < segment.local_offset + segment.length:
+            raise ValueError(
+                "cp_comm_type='swa_p2p' attention_mask query dimension is smaller than "
+                "the local CP sequence length."
+            )
+
+        key_start = segment.global_start - halo_len
+        key_end = segment.global_start + segment.length
+        if attention_mask.size(-1) < key_end:
+            raise ValueError(
+                "cp_comm_type='swa_p2p' attention_mask key dimension is smaller than "
+                "the global CP sequence length."
+            )
+        key_positions = torch.arange(key_start, key_end, device=attention_mask.device)
+        segment_mask = attention_mask[
+            :, :, segment.local_offset : segment.local_offset + segment.length, :
+        ].index_select(-1, key_positions)
+
+        query_positions = torch.arange(
+            segment.global_start,
+            segment.global_start + segment.length,
+            device=attention_mask.device,
+        )
+        key_positions = key_positions.view(1, 1, 1, -1)
+        query_positions = query_positions.view(1, 1, -1, 1)
+        swa_mask = (key_positions > query_positions) | (
+            key_positions < query_positions - left_window
+        )
+        return segment_mask | swa_mask
 
     def _allocate_memory(self, inference_max_sequence_length, batch_size, dim, dtype):
         """Allocate memory to store kv cache during inference."""
@@ -1518,15 +1713,26 @@ class Attention(MegatronModule, ABC):
                 with off_interface(
                     self.offload_core_attention and self.training, query, "core_attn"
                 ) as query:
-                    core_attn_out = apply_module(self.core_attention)(
-                        query,
-                        key,
-                        value,
-                        attention_mask,
-                        attn_mask_type=attn_mask_type,
-                        attention_bias=attention_bias,
-                        packed_seq_params=packed_seq_params,
-                    )
+                    if self.swa_p2p:
+                        core_attn_out = self._run_swa_p2p_core_attention(
+                            query,
+                            key,
+                            value,
+                            attention_mask,
+                            attn_mask_type=attn_mask_type,
+                            attention_bias=attention_bias,
+                            packed_seq_params=packed_seq_params,
+                        )
+                    else:
+                        core_attn_out = apply_module(self.core_attention)(
+                            query,
+                            key,
+                            value,
+                            attention_mask,
+                            attn_mask_type=attn_mask_type,
+                            attention_bias=attention_bias,
+                            packed_seq_params=packed_seq_params,
+                        )
 
             else:
                 # Dynamic batching attention kernel.

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -661,11 +661,7 @@ class Attention(MegatronModule, ABC):
         return torch.cat(outputs, dim=0)
 
     def _get_swa_p2p_segment_attention_mask(
-        self,
-        attention_mask: Tensor | None,
-        segment: SwaP2PSegment,
-        halo_len: int,
-        left_window: int,
+        self, attention_mask: Tensor | None, segment: SwaP2PSegment, halo_len: int, left_window: int
     ) -> Tensor | None:
         """Slice a dense reset attention mask for one SWA P2P segment."""
         if attention_mask is None:

--- a/megatron/core/transformer/swa_context_parallel.py
+++ b/megatron/core/transformer/swa_context_parallel.py
@@ -1,0 +1,421 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Context Parallel helpers for Sliding Window Attention via Halo Exchange."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import DefaultDict
+
+import torch
+
+
+@dataclass(frozen=True)
+class _HaloPart:
+    """One contiguous source slice needed by a destination rank's halo."""
+
+    dst_segment: int
+    src_rank: int
+    src_segment: int
+    src_offset: int
+    length: int
+
+
+@dataclass(frozen=True)
+class SwaP2PSegment:
+    """One contiguous local sequence segment in CP order."""
+
+    sequence_id: int
+    sequence_start: int
+    global_start: int
+    length: int
+    local_offset: int
+
+
+def is_swa_p2p_cp_comm_type(cp_comm_type: str | None) -> bool:
+    """Return whether ``cp_comm_type`` selects the SWA-specific P2P path."""
+    return cp_comm_type is not None and cp_comm_type.replace("_", "").lower() == "swap2p"
+
+
+def _rank_segment_chunk(rank: int, segment: int, cp_size: int) -> int:
+    """Return the global chunk id for ``rank`` and local ``segment``."""
+    if segment == 0:
+        return rank
+    return 2 * cp_size - rank - 1
+
+
+def _build_swa_p2p_halo_plan(
+    segments_by_rank: list[list[SwaP2PSegment]], window_size: int
+) -> tuple[dict[tuple[int, int], list[_HaloPart]], dict[tuple[int, int], list[_HaloPart]]]:
+    """Build deterministic send and receive plans for SWA halos."""
+    cp_size = len(segments_by_rank)
+    send_plan: dict[tuple[int, int], list[_HaloPart]] = {}
+    parts_by_dst: dict[tuple[int, int], list[_HaloPart]] = {}
+
+    if window_size <= 0:
+        for dst_rank in range(cp_size):
+            for dst_segment in range(len(segments_by_rank[dst_rank])):
+                parts_by_dst[(dst_rank, dst_segment)] = []
+        return send_plan, parts_by_dst
+
+    for dst_rank in range(cp_size):
+        for dst_segment, dst_info in enumerate(segments_by_rank[dst_rank]):
+            segment_start = dst_info.global_start
+            halo_start = max(dst_info.sequence_start, segment_start - window_size)
+            parts: list[_HaloPart] = []
+
+            if halo_start < segment_start:
+                for src_rank, src_segments in enumerate(segments_by_rank):
+                    for src_segment, src_info in enumerate(src_segments):
+                        if src_info.sequence_id != dst_info.sequence_id:
+                            continue
+                        src_start = max(halo_start, src_info.global_start)
+                        src_end = min(segment_start, src_info.global_start + src_info.length)
+                        length = src_end - src_start
+                        if length <= 0:
+                            continue
+                        part = _HaloPart(
+                            dst_segment=dst_segment,
+                            src_rank=src_rank,
+                            src_segment=src_segment,
+                            src_offset=src_start - src_info.global_start,
+                            length=length,
+                        )
+                        parts.append(part)
+                        if src_rank != dst_rank:
+                            send_plan.setdefault((src_rank, dst_rank), []).append(part)
+
+            parts.sort(
+                key=lambda part: (
+                    segments_by_rank[part.src_rank][part.src_segment].global_start + part.src_offset
+                )
+            )
+            parts_by_dst[(dst_rank, dst_segment)] = parts
+
+    for parts in send_plan.values():
+        parts.sort(
+            key=lambda part: (
+                segments_by_rank[part.src_rank][part.src_segment].global_start + part.src_offset
+            )
+        )
+
+    return send_plan, parts_by_dst
+
+
+def build_swa_p2p_nonpacked_segments(local_seq_len: int, cp_size: int) -> list[list[SwaP2PSegment]]:
+    """Build segment metadata for MCore non-packed zigzag CP layout."""
+    if cp_size <= 0:
+        raise ValueError(f"swa_p2p expects a positive cp_size, got {cp_size}")
+    if local_seq_len % 2 != 0:
+        raise ValueError(f"swa_p2p expects an even local sequence length, got {local_seq_len}")
+
+    chunk_len = local_seq_len // 2
+    segments_by_rank: list[list[SwaP2PSegment]] = []
+    for rank in range(cp_size):
+        local_offset = 0
+        rank_segments = []
+        for segment in (0, 1):
+            chunk = _rank_segment_chunk(rank, segment, cp_size)
+            rank_segments.append(
+                SwaP2PSegment(
+                    sequence_id=0,
+                    sequence_start=0,
+                    global_start=chunk * chunk_len,
+                    length=chunk_len,
+                    local_offset=local_offset,
+                )
+            )
+            local_offset += chunk_len
+        segments_by_rank.append(rank_segments)
+    return segments_by_rank
+
+
+def _cu_seqlens_to_list(cu_seqlens: torch.Tensor) -> list[int]:
+    """Convert 1-D or batch-leading cu_seqlens to a Python list."""
+    if cu_seqlens.dim() == 2:
+        if cu_seqlens.size(0) != 1:
+            raise ValueError(
+                f"swa_p2p expects packed cu_seqlens with batch size 1, got {cu_seqlens.shape}"
+            )
+        cu_seqlens = cu_seqlens[0]
+    if cu_seqlens.dim() != 1:
+        raise ValueError(f"swa_p2p expects 1-D packed cu_seqlens, got {cu_seqlens.shape}")
+    return [int(v) for v in cu_seqlens.detach().cpu().tolist()]
+
+
+def build_swa_p2p_packed_segments(
+    cu_seqlens_padded: torch.Tensor, cp_size: int
+) -> list[list[SwaP2PSegment]]:
+    """Build segment metadata for packed THD zigzag CP layout."""
+    if cp_size <= 0:
+        raise ValueError(f"swa_p2p expects a positive cp_size, got {cp_size}")
+    cu = _cu_seqlens_to_list(cu_seqlens_padded)
+    if any(end < start for start, end in zip(cu[:-1], cu[1:])):
+        raise ValueError(f"swa_p2p expects monotonic cu_seqlens, got {cu}")
+    local_offsets = [0 for _ in range(cp_size)]
+    segments_by_rank: list[list[SwaP2PSegment]] = [[] for _ in range(cp_size)]
+
+    for sequence_id, (sequence_start, sequence_end) in enumerate(zip(cu[:-1], cu[1:])):
+        sequence_len = sequence_end - sequence_start
+        if sequence_len % (2 * cp_size) != 0:
+            raise ValueError(
+                "swa_p2p packed CP expects padded sequence lengths divisible by 2 * cp_size, "
+                f"got sequence_len={sequence_len}, cp_size={cp_size}"
+            )
+        chunk_len = sequence_len // (2 * cp_size)
+        for rank in range(cp_size):
+            front_start = sequence_start + rank * chunk_len
+            back_start = sequence_end - (rank + 1) * chunk_len
+            for global_start in (front_start, back_start):
+                segments_by_rank[rank].append(
+                    SwaP2PSegment(
+                        sequence_id=sequence_id,
+                        sequence_start=sequence_start,
+                        global_start=global_start,
+                        length=chunk_len,
+                        local_offset=local_offsets[rank],
+                    )
+                )
+                local_offsets[rank] += chunk_len
+
+    return segments_by_rank
+
+
+def _get_cp_global_ranks(cp_group: torch.distributed.ProcessGroup) -> list[int]:
+    """Return global ranks for a CP group."""
+    try:
+        return torch.distributed.get_process_group_ranks(cp_group)
+    except AttributeError:
+        try:
+            return [
+                torch.distributed.get_global_rank(cp_group, group_rank)
+                for group_rank in range(cp_group.size())
+            ]
+        except AttributeError:
+            return list(range(torch.distributed.get_world_size()))
+
+
+def _wait_all(reqs: list[torch.distributed.Work]) -> None:
+    """Wait for all distributed requests."""
+    for req in reqs:
+        req.wait()
+
+
+def _run_p2p_ops(
+    recv_tensors: dict[int, torch.Tensor],
+    send_tensors: dict[int, torch.Tensor],
+    cp_group: torch.distributed.ProcessGroup,
+    cp_rank: int,
+) -> None:
+    """Run one batched P2P exchange with at most one send/recv tensor per peer."""
+    if not recv_tensors and not send_tensors:
+        return
+
+    global_ranks = _get_cp_global_ranks(cp_group)
+    ops: list[torch.distributed.P2POp] = []
+    for peer in sorted(set(recv_tensors) | set(send_tensors)):
+        if peer == cp_rank:
+            continue
+        global_peer = global_ranks[peer]
+        if peer in recv_tensors:
+            ops.append(
+                torch.distributed.P2POp(
+                    torch.distributed.irecv, recv_tensors[peer], global_peer, cp_group
+                )
+            )
+        if peer in send_tensors:
+            ops.append(
+                torch.distributed.P2POp(
+                    torch.distributed.isend, send_tensors[peer], global_peer, cp_group
+                )
+            )
+
+    if ops:
+        _wait_all(torch.distributed.batch_isend_irecv(ops))
+
+
+class _SwaP2PHaloExchange(torch.autograd.Function):
+    """Autograd function that returns previous-token halos and routes halo gradients back."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        input_: torch.Tensor,
+        window_size: int,
+        cp_group: torch.distributed.ProcessGroup,
+        segments_by_rank: list[list[SwaP2PSegment]],
+    ) -> tuple[torch.Tensor, ...]:
+        cp_size = cp_group.size()
+        cp_rank = cp_group.rank()
+        local_segments = segments_by_rank[cp_rank]
+        if cp_size == 1 or window_size <= 0:
+            empty = input_.new_empty((0, *input_.shape[1:]))
+            ctx.cp_group = cp_group
+            ctx.cp_rank = cp_rank
+            ctx.cp_size = cp_size
+            ctx.input_shape = tuple(input_.shape)
+            ctx.send_plan = {}
+            ctx.segments_by_rank = segments_by_rank
+            ctx.parts_by_dst = {(cp_rank, segment): [] for segment in range(len(local_segments))}
+            return tuple(empty for _ in local_segments)
+
+        expected_local_seq_len = sum(segment.length for segment in local_segments)
+        if input_.size(0) != expected_local_seq_len:
+            raise ValueError(
+                "swa_p2p input length does not match CP segment metadata: "
+                f"got {input_.size(0)}, expected {expected_local_seq_len}"
+            )
+
+        send_plan, parts_by_dst = _build_swa_p2p_halo_plan(segments_by_rank, window_size)
+        tensor_tail_shape = tuple(input_.shape[1:])
+
+        send_tensors: dict[int, torch.Tensor] = {}
+        recv_tensors: dict[int, torch.Tensor] = {}
+
+        for peer in range(cp_size):
+            if peer == cp_rank:
+                continue
+            recv_sections = send_plan.get((peer, cp_rank), [])
+            if recv_sections:
+                recv_len = sum(part.length for part in recv_sections)
+                recv_tensors[peer] = input_.new_empty((recv_len, *tensor_tail_shape))
+
+            send_sections = send_plan.get((cp_rank, peer), [])
+            if send_sections:
+                send_parts = [
+                    input_.narrow(
+                        0,
+                        segments_by_rank[cp_rank][part.src_segment].local_offset + part.src_offset,
+                        part.length,
+                    ).contiguous()
+                    for part in send_sections
+                ]
+                send_tensors[peer] = (
+                    torch.cat(send_parts, dim=0) if len(send_parts) > 1 else send_parts[0]
+                )
+
+        _run_p2p_ops(recv_tensors, send_tensors, cp_group, cp_rank)
+
+        recv_offsets: DefaultDict[int, int] = defaultdict(int)
+        halos: list[torch.Tensor] = []
+        for dst_segment in range(len(local_segments)):
+            halo_parts: list[torch.Tensor] = []
+            for part in parts_by_dst[(cp_rank, dst_segment)]:
+                if part.src_rank == cp_rank:
+                    halo_parts.append(
+                        input_.narrow(
+                            0,
+                            segments_by_rank[cp_rank][part.src_segment].local_offset
+                            + part.src_offset,
+                            part.length,
+                        )
+                    )
+                else:
+                    offset = recv_offsets[part.src_rank]
+                    halo_parts.append(recv_tensors[part.src_rank].narrow(0, offset, part.length))
+                    recv_offsets[part.src_rank] += part.length
+
+            if halo_parts:
+                halos.append(torch.cat(halo_parts, dim=0))
+            else:
+                halos.append(input_.new_empty((0, *tensor_tail_shape)))
+
+        ctx.cp_group = cp_group
+        ctx.cp_rank = cp_rank
+        ctx.cp_size = cp_size
+        ctx.input_shape = tuple(input_.shape)
+        ctx.send_plan = send_plan
+        ctx.segments_by_rank = segments_by_rank
+        ctx.parts_by_dst = parts_by_dst
+        return tuple(halos)
+
+    @staticmethod
+    def backward(ctx, *grad_halos: torch.Tensor):
+        cp_group = ctx.cp_group
+        cp_rank = ctx.cp_rank
+        cp_size = ctx.cp_size
+        send_plan = ctx.send_plan
+        segments_by_rank = ctx.segments_by_rank
+        parts_by_dst = ctx.parts_by_dst
+
+        grad_input = grad_halos[0].new_zeros(ctx.input_shape)
+        if cp_size == 1:
+            return grad_input, None, None, None
+
+        grad_parts_by_src: DefaultDict[int, list[torch.Tensor]] = defaultdict(list)
+        for dst_segment, grad_halo in enumerate(grad_halos):
+            halo_offset = 0
+            for part in parts_by_dst[(cp_rank, dst_segment)]:
+                grad_part = grad_halo.narrow(0, halo_offset, part.length)
+                halo_offset += part.length
+                if part.src_rank == cp_rank:
+                    grad_input.narrow(
+                        0,
+                        segments_by_rank[cp_rank][part.src_segment].local_offset + part.src_offset,
+                        part.length,
+                    ).add_(grad_part)
+                else:
+                    grad_parts_by_src[part.src_rank].append(grad_part.contiguous())
+
+        send_tensors: dict[int, torch.Tensor] = {}
+        recv_tensors: dict[int, torch.Tensor] = {}
+
+        for peer in range(cp_size):
+            if peer == cp_rank:
+                continue
+            recv_sections = send_plan.get((cp_rank, peer), [])
+            if recv_sections:
+                recv_len = sum(part.length for part in recv_sections)
+                recv_tensors[peer] = grad_input.new_empty((recv_len, *ctx.input_shape[1:]))
+
+            send_sections = send_plan.get((peer, cp_rank), [])
+            if send_sections:
+                send_parts = grad_parts_by_src.get(peer, [])
+                if not send_parts:
+                    raise RuntimeError(
+                        "swa_p2p backward halo plan mismatch: "
+                        f"missing gradient parts for source rank {peer}."
+                    )
+                send_tensors[peer] = (
+                    torch.cat(send_parts, dim=0) if len(send_parts) > 1 else send_parts[0]
+                )
+
+        _run_p2p_ops(recv_tensors, send_tensors, cp_group, cp_rank)
+
+        for peer, recv_tensor in recv_tensors.items():
+            offset = 0
+            for part in send_plan[(cp_rank, peer)]:
+                grad_input.narrow(
+                    0,
+                    segments_by_rank[cp_rank][part.src_segment].local_offset + part.src_offset,
+                    part.length,
+                ).add_(recv_tensor.narrow(0, offset, part.length))
+                offset += part.length
+
+        return grad_input, None, None, None
+
+
+def get_swa_p2p_halos(
+    input_: torch.Tensor,
+    window_size: int,
+    cp_group: torch.distributed.ProcessGroup,
+    segments_by_rank: list[list[SwaP2PSegment]] | None = None,
+) -> tuple[torch.Tensor, ...]:
+    """Return SWA previous-token halos for a CP tensor.
+
+    Args:
+        input_: Tensor with sequence first, in MCore CP local order
+            ``[front_chunk, back_chunk]``.
+        window_size: Causal sliding-window size on the left side.
+        cp_group: Context-parallel process group.
+        segments_by_rank: Optional CP segment metadata. If omitted, non-packed
+            zigzag layout is inferred from ``input_``.
+
+    Returns:
+        A tuple of halos in rank-local segment order. Each halo is ordered by global token
+        position and contains at most ``window_size`` tokens preceding that local segment.
+    """
+    if segments_by_rank is None:
+        segments_by_rank = build_swa_p2p_nonpacked_segments(input_.size(0), cp_group.size())
+    return _SwaP2PHaloExchange.apply(input_, window_size, cp_group, segments_by_rank)

--- a/megatron/core/transformer/swa_context_parallel.py
+++ b/megatron/core/transformer/swa_context_parallel.py
@@ -246,6 +246,7 @@ class _SwaP2PHaloExchange(torch.autograd.Function):
         cp_group: torch.distributed.ProcessGroup,
         segments_by_rank: list[list[SwaP2PSegment]],
     ) -> tuple[torch.Tensor, ...]:
+        """Exchange previous-token halos needed by each local CP segment."""
         cp_size = cp_group.size()
         cp_rank = cp_group.rank()
         local_segments = segments_by_rank[cp_rank]
@@ -332,6 +333,7 @@ class _SwaP2PHaloExchange(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, *grad_halos: torch.Tensor):
+        """Send halo gradients back to source ranks and accumulate local gradients."""
         cp_group = ctx.cp_group
         cp_rank = ctx.cp_rank
         cp_size = ctx.cp_size

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -935,7 +935,8 @@ class TransformerConfig(ModelParallelConfig):
     and P2P communications in high-level CP groups (e.g., via IBLink).
     "swa_p2p": A causal sliding-window-attention implementation that keeps Q/K/V sequence-sharded
     and exchanges only the previous-token K/V borders required by the local SWA window.
-    In layer-wise CP configurations, use `swa_p2p` for SWA layers and  `p2p` or `a2a+p2p` for full-attention layers.
+    In layer-wise CP configurations, use `swa_p2p` for SWA layers and `p2p` or
+    `a2a+p2p` for full-attention layers.
     """
 
     ##################

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -923,7 +923,7 @@ class TransformerConfig(ModelParallelConfig):
     """Inter-gpu communication type for context parallelism.
     str: all layers share same communication type.
     List[str]: each layer has its separate communication type.
-    cp_comm_type of each layer can be "p2p" or "all_gather" or "a2a" or "a2a+p2p".
+    cp_comm_type of each layer can be "p2p", "all_gather", "a2a", "a2a+p2p", or "swa_p2p".
     "p2p": Exchange KV chunks with P2P communications in ring topology. P2P is async and can be
     overlapped with attention compute.
     "all_gather": All-gather to get full sequence of KV before attention. The all-gather is not
@@ -933,6 +933,9 @@ class TransformerConfig(ModelParallelConfig):
     "a2a+p2p": A hierarchical implementation of context parallelism to attention.
     It uses A2A communications in low-level CP groups (e.g., via NVLink),
     and P2P communications in high-level CP groups (e.g., via IBLink).
+    "swa_p2p": A causal sliding-window-attention implementation that keeps Q/K/V sequence-sharded
+    and exchanges only the previous-token K/V borders required by the local SWA window.
+    In layer-wise CP configurations, use `swa_p2p` for SWA layers and  `p2p` or `a2a+p2p` for full-attention layers.
     """
 
     ##################

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2890,10 +2890,10 @@ def _add_distributed_args(parser):
                        'Set to enable FSDP ZeRO-2.')
     group.add_argument('--cp-comm-type', nargs='+', type=str, default=["p2p"],
                        help='Inter-gpu communication type for context parallelism: '
-                       'p2p, a2a, allgather or a2a+p2p. If a single string is provided, '
-                       'all layers will share the same communication type. Users can also '
-                       'specify separated types for each layer like '
-                       '--cp-comm-type p2p p2p a2a a2a a2a+p2p a2a+p2p')
+                       'p2p, a2a, allgather, a2a+p2p, or swa_p2p. If a single string is '
+                       'provided, all layers will share the same communication type. Users can '
+                       'also specify separated types for each layer like '
+                       '--cp-comm-type swa_p2p swa_p2p a2a+p2p a2a+p2p')
     group.add_argument('--fake-process-group', action='store_true', default=False,
                        help='If set, initialize with fake distributed process group and all distributed communication operations will be skipped. \
                        This is quite useful for profiling memory usage of distributed training with just one GPU. \

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp2_cp4_swa_p2p_hybrid/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp2_cp4_swa_p2p_hybrid/model_config.yaml
@@ -1,0 +1,60 @@
+ENV_VARS:
+  CUDA_DEVICE_MAX_CONNECTIONS: 1
+  NVTE_ALLOW_NONDETERMINISTIC_ALGO: 0
+MODEL_ARGS:
+  --num-layers: 4
+  --hidden-size: 512
+  --num-attention-heads: 8
+  --group-query-attention: true
+  --num-query-groups: 2
+  --log-params-norm: true
+  --log-num-zeros-in-grad: true
+  --log-validation-ppl-to-tensorboard: true
+  --log-timers-to-tensorboard: true
+  --tensorboard-dir: ${TENSORBOARD_PATH}
+  --micro-batch-size: 4
+  --global-batch-size: 32
+  --seq-length: 1024
+  --max-position-embeddings: 1024
+  --train-iters: 25
+  --timing-log-level: 0
+  --lr-decay-iters: 320000
+  --save: ${CHECKPOINT_SAVE_PATH}
+  --load: ${CHECKPOINT_LOAD_PATH}
+  --tokenizer-type: NullTokenizer
+  --vocab-size: 50257
+  --mock-data: true
+  --split: 949,50,1
+  --distributed-backend: nccl
+  --lr: 0.00015
+  --lr-decay-style: cosine
+  --min-lr: 1.0e-5
+  --weight-decay: 1e-2
+  --clip-grad: 1.0
+  --lr-warmup-fraction: .01
+  --log-interval: 1
+  --save-interval: 10000
+  --eval-interval: 1000
+  --eval-iters: 10
+  --transformer-impl: transformer_engine
+  --tensor-model-parallel-size: 1
+  --pipeline-model-parallel-size: 2
+  --context-parallel-size: 4
+  --cp-comm-type: "[swa_p2p p2p swa_p2p p2p]"
+  --window-size: (128,0)
+  --window-attn-skip-freq: 2
+  --sequence-parallel: true
+  --hidden-dropout: 0.0
+  --attention-dropout: 0.0
+  --no-gradient-accumulation-fusion: true
+  --attention-softmax-in-fp32: true
+  --use-mcore-models: true
+  --ckpt-format: torch_dist
+  --dist-ckpt-strictness: log_all # backward compatibility for TE changes
+  --data-cache-path: ${DATA_CACHE_PATH}
+  --bf16: true
+  --attention-backend: flash
+  --log-memory-to-tensorboard: true
+  --async-save: true
+  --use-persistent-ckpt-worker: true
+TEST_TYPE: regular

--- a/tests/test_utils/recipes/h100/gpt.yaml
+++ b/tests/test_utils/recipes/h100/gpt.yaml
@@ -267,6 +267,11 @@ products:
         platforms: [dgx_h100]
       - environment: [lts]
         scope: [nightly]
+  - test_case: [gpt3_mcore_te_tp1_pp2_cp4_swa_p2p_hybrid]
+    products:
+      - environment: [dev]
+        scope: [mr, mr-github]
+        platforms: [dgx_h100]
   - test_case: [gpt3_mcore_te_tp2_pp1_resume_torch_dist_multi_dist_optimizer_instances]
     products:
       - environment: [dev]

--- a/tests/unit_tests/transformer/test_swa_context_parallel.py
+++ b/tests/unit_tests/transformer/test_swa_context_parallel.py
@@ -1,0 +1,587 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import pytest
+import torch
+import torch.distributed as dist
+
+from megatron.core import parallel_state
+from megatron.core.models.gpt.gpt_layer_specs import (
+    get_gpt_layer_with_transformer_engine_spec,
+    get_gpt_layer_with_transformer_engine_submodules,
+)
+from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.transformer.attention import SelfAttention
+from megatron.core.transformer.enums import AttnMaskType
+from megatron.core.transformer.swa_context_parallel import (
+    _build_swa_p2p_halo_plan,
+    build_swa_p2p_nonpacked_segments,
+    build_swa_p2p_packed_segments,
+    get_swa_p2p_halos,
+)
+from megatron.core.transformer.transformer_config import TransformerConfig
+from megatron.core.transformer.transformer_layer import TransformerLayer
+from megatron.core.utils import is_te_min_version
+from tests.unit_tests.test_utilities import Utils
+
+
+def _chunk_for_rank_segment(rank: int, segment: int, cp_size: int) -> int:
+    if segment == 0:
+        return rank
+    return 2 * cp_size - rank - 1
+
+
+def _positions_for_rank(rank: int, cp_size: int, chunk_len: int, device=None) -> torch.Tensor:
+    positions = []
+    for segment in (0, 1):
+        chunk = _chunk_for_rank_segment(rank, segment, cp_size)
+        start = chunk * chunk_len
+        positions.extend(range(start, start + chunk_len))
+    return torch.tensor(positions, dtype=torch.float32, device=device)
+
+
+def _part_positions(part, cp_size: int, chunk_len: int) -> list[int]:
+    chunk = _chunk_for_rank_segment(part.src_rank, part.src_segment, cp_size)
+    start = chunk * chunk_len + part.src_offset
+    return list(range(start, start + part.length))
+
+
+def test_swa_p2p_halo_plan_matches_zigzag_predecessors():
+    cp_size = 4
+    chunk_len = 3
+    window_size = 5
+
+    segments_by_rank = build_swa_p2p_nonpacked_segments(2 * chunk_len, cp_size)
+    _, parts_by_dst = _build_swa_p2p_halo_plan(segments_by_rank, window_size)
+
+    for rank in range(cp_size):
+        for segment in (0, 1):
+            dst_chunk = _chunk_for_rank_segment(rank, segment, cp_size)
+            segment_start = dst_chunk * chunk_len
+            expected = list(range(max(0, segment_start - window_size), segment_start))
+
+            actual = []
+            for part in parts_by_dst[(rank, segment)]:
+                actual.extend(_part_positions(part, cp_size, chunk_len))
+
+            assert actual == expected
+
+
+def test_swa_p2p_packed_segments_keep_sequence_boundaries():
+    cp_size = 2
+    cu_seqlens = torch.tensor([0, 8, 16], dtype=torch.int32)
+
+    segments_by_rank = build_swa_p2p_packed_segments(cu_seqlens, cp_size)
+    _, parts_by_dst = _build_swa_p2p_halo_plan(segments_by_rank, window_size=4)
+
+    seq1_first_segment_rank0 = 2
+    assert segments_by_rank[0][seq1_first_segment_rank0].global_start == 8
+    assert parts_by_dst[(0, seq1_first_segment_rank0)] == []
+
+
+def test_swa_p2p_packed_segments_follow_local_thd_order():
+    cp_size = 4
+    cu_seqlens = torch.tensor([0, 16, 40], dtype=torch.int32)
+
+    segments_by_rank = build_swa_p2p_packed_segments(cu_seqlens, cp_size)
+
+    rank0_segments = segments_by_rank[0]
+    assert [segment.global_start for segment in rank0_segments] == [0, 14, 16, 37]
+    assert [segment.length for segment in rank0_segments] == [2, 2, 3, 3]
+    assert [segment.local_offset for segment in rank0_segments] == [0, 2, 4, 7]
+
+
+@pytest.mark.parametrize(
+    ("cu_seqlens", "cp_size", "match"),
+    [
+        (torch.tensor([0, 10], dtype=torch.int32), 4, "divisible"),
+        (torch.tensor([0, 8, 7], dtype=torch.int32), 2, "monotonic"),
+        (torch.tensor([0, 8], dtype=torch.int32), 0, "positive cp_size"),
+    ],
+)
+def test_swa_p2p_packed_segments_reject_invalid_metadata(cu_seqlens, cp_size, match):
+    with pytest.raises(ValueError, match=match):
+        build_swa_p2p_packed_segments(cu_seqlens, cp_size)
+
+
+@pytest.mark.skipif(Utils.world_size < 2, reason="swa_p2p halo exchange needs >=2 ranks")
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="unit distributed tests use NCCL/CUDA")
+def test_swa_p2p_halo_exchange_forward_backward():
+    cp_size = 2
+    chunk_len = 2
+    window_size = 3
+
+    Utils.initialize_model_parallel(context_parallel_size=cp_size)
+    try:
+        cp_group = parallel_state.get_context_parallel_group()
+        cp_rank = cp_group.rank()
+        device = torch.device("cuda", torch.cuda.current_device())
+
+        local_positions = _positions_for_rank(cp_rank, cp_size, chunk_len, device=device)
+        input_ = local_positions.view(-1, 1, 1, 1).clone().detach().requires_grad_(True)
+
+        front_halo, back_halo = get_swa_p2p_halos(input_, window_size, cp_group)
+
+        for segment, halo in enumerate((front_halo, back_halo)):
+            dst_chunk = _chunk_for_rank_segment(cp_rank, segment, cp_size)
+            segment_start = dst_chunk * chunk_len
+            expected_positions = torch.arange(
+                max(0, segment_start - window_size),
+                segment_start,
+                dtype=input_.dtype,
+                device=device,
+            )
+            torch.testing.assert_close(halo.flatten(), expected_positions)
+
+        (front_halo.sum() + back_halo.sum()).backward()
+
+        global_seq_len = 2 * cp_size * chunk_len
+        expected_global_grad = torch.zeros(global_seq_len, dtype=input_.dtype, device=device)
+        for rank in range(cp_size):
+            for segment in (0, 1):
+                dst_chunk = _chunk_for_rank_segment(rank, segment, cp_size)
+                segment_start = dst_chunk * chunk_len
+                expected_global_grad[max(0, segment_start - window_size) : segment_start] += 1
+
+        expected_local_grad = expected_global_grad.index_select(0, local_positions.long()).view_as(
+            input_
+        )
+        torch.testing.assert_close(input_.grad, expected_local_grad)
+    finally:
+        Utils.destroy_model_parallel()
+
+
+def _zigzag_split(tensor: torch.Tensor, cp_rank: int, cp_size: int, dim: int = 0):
+    if cp_size == 1:
+        return tensor
+    chunk_len = tensor.size(dim) // (2 * cp_size)
+    front = tensor.narrow(dim, cp_rank * chunk_len, chunk_len)
+    back = tensor.narrow(dim, (2 * cp_size - cp_rank - 1) * chunk_len, chunk_len)
+    return torch.cat((front, back), dim=dim).contiguous()
+
+
+def _zigzag_merge(chunks: list[torch.Tensor], cp_size: int) -> torch.Tensor:
+    chunk_len = chunks[0].size(0) // 2
+    parts = [None] * (2 * cp_size)
+    for rank, chunk in enumerate(chunks):
+        parts[rank] = chunk[:chunk_len]
+        parts[2 * cp_size - rank - 1] = chunk[chunk_len:]
+    return torch.cat(parts, dim=0)
+
+
+class _GatherZigZag(torch.autograd.Function):
+    """Gather non-packed zigzag CP outputs with backward sharding."""
+
+    @staticmethod
+    def forward(ctx, local: torch.Tensor, cp_size: int):
+        ctx.cp_size = cp_size
+        ctx.cp_rank = parallel_state.get_context_parallel_rank()
+        gathered = [torch.empty_like(local) for _ in range(cp_size)]
+        dist.all_gather(
+            gathered, local.contiguous(), group=parallel_state.get_context_parallel_group()
+        )
+        return _zigzag_merge(gathered, cp_size)
+
+    @staticmethod
+    def backward(ctx, grad: torch.Tensor):
+        return _zigzag_split(grad, ctx.cp_rank, ctx.cp_size).contiguous(), None
+
+
+class _GatherPackedZigZag(torch.autograd.Function):
+    """Gather packed THD zigzag CP outputs with backward sharding."""
+
+    @staticmethod
+    def forward(ctx, local: torch.Tensor, seqlens: tuple[int, ...], cp_size: int):
+        ctx.seqlens = seqlens
+        ctx.cp_size = cp_size
+        ctx.cp_rank = parallel_state.get_context_parallel_rank()
+        gathered = [torch.empty_like(local) for _ in range(cp_size)]
+        dist.all_gather(
+            gathered, local.contiguous(), group=parallel_state.get_context_parallel_group()
+        )
+
+        outputs = []
+        offsets = [0 for _ in range(cp_size)]
+        for seq_len in seqlens:
+            local_len = seq_len // cp_size
+            seq_chunks = []
+            for rank, rank_tensor in enumerate(gathered):
+                seq_chunks.append(rank_tensor[offsets[rank] : offsets[rank] + local_len])
+                offsets[rank] += local_len
+            outputs.append(_zigzag_merge(seq_chunks, cp_size))
+        return torch.cat(outputs, dim=0)
+
+    @staticmethod
+    def backward(ctx, grad: torch.Tensor):
+        offset = 0
+        chunks = []
+        for seq_len in ctx.seqlens:
+            seq_grad = grad[offset : offset + seq_len, 0, :]
+            chunks.append(_zigzag_split(seq_grad, ctx.cp_rank, ctx.cp_size))
+            offset += seq_len
+        return torch.cat(chunks, dim=0).unsqueeze(1).contiguous(), None, None
+
+
+def _make_config(
+    *,
+    num_layers: int,
+    cp_size: int,
+    cp_comm_type,
+    hidden_size=64,
+    num_attention_heads=4,
+    num_query_groups=4,
+    window_size=(6, 0),
+    window_attn_skip_freq=None,
+) -> TransformerConfig:
+    hierarchical_context_parallel_sizes = None
+    cp_comm_types = cp_comm_type if isinstance(cp_comm_type, list) else [cp_comm_type]
+    if "a2a+p2p" in cp_comm_types:
+        hierarchical_context_parallel_sizes = [2, 2]
+
+    return TransformerConfig(
+        num_layers=num_layers,
+        hidden_size=hidden_size,
+        ffn_hidden_size=4 * hidden_size,
+        num_attention_heads=num_attention_heads,
+        num_query_groups=num_query_groups,
+        use_cpu_initialization=True,
+        bf16=True,
+        params_dtype=torch.bfloat16,
+        pipeline_dtype=torch.bfloat16,
+        autocast_dtype=torch.bfloat16,
+        hidden_dropout=0.0,
+        attention_dropout=0.0,
+        context_parallel_size=cp_size,
+        cp_comm_type=cp_comm_type,
+        no_rope_freq=[1] * num_layers,
+        window_size=window_size,
+        window_attn_skip_freq=window_attn_skip_freq,
+        hierarchical_context_parallel_sizes=hierarchical_context_parallel_sizes,
+    )
+
+
+def _build_attention(
+    config: TransformerConfig,
+    cp_comm_type,
+    layer_number: int = 1,
+    attn_mask_type: AttnMaskType = AttnMaskType.causal,
+):
+    attention = SelfAttention(
+        config,
+        get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules,
+        layer_number=layer_number,
+        attn_mask_type=attn_mask_type,
+        cp_comm_type=cp_comm_type,
+    )
+    return attention.cuda()
+
+
+def _broadcast_module_from_cp_rank0(module: torch.nn.Module):
+    cp_group = parallel_state.get_context_parallel_group()
+    src_rank = dist.get_global_rank(cp_group, 0)
+    for tensor in list(module.parameters()) + list(module.buffers()):
+        dist.broadcast(tensor, src=src_rank, group=cp_group)
+
+
+def _assert_close(actual: torch.Tensor, expected: torch.Tensor, *, atol=2e-2, rtol=2e-2):
+    torch.testing.assert_close(actual.float(), expected.float(), atol=atol, rtol=rtol)
+
+
+def _assert_attention_parity(
+    attention_mask: torch.Tensor | None = None,
+    *,
+    hidden_size=64,
+    num_attention_heads=8,
+    num_query_groups=2,
+    window_size=(6, 0),
+):
+    cp_size = 4
+    seq_len = 64
+    batch_size = 1
+    device = torch.device("cuda", torch.cuda.current_device())
+    cp_rank = parallel_state.get_context_parallel_rank()
+    attn_mask_type = AttnMaskType.arbitrary if attention_mask is not None else AttnMaskType.causal
+
+    model_parallel_cuda_manual_seed(1234)
+    cp_config = _make_config(
+        num_layers=1,
+        cp_size=cp_size,
+        cp_comm_type="swa_p2p",
+        hidden_size=hidden_size,
+        num_attention_heads=num_attention_heads,
+        num_query_groups=num_query_groups,
+        window_size=window_size,
+    )
+    ref_config = _make_config(
+        num_layers=1,
+        cp_size=1,
+        cp_comm_type=None,
+        hidden_size=hidden_size,
+        num_attention_heads=num_attention_heads,
+        num_query_groups=num_query_groups,
+        window_size=window_size,
+    )
+    cp_attention = _build_attention(cp_config, "swa_p2p", attn_mask_type=attn_mask_type)
+    _broadcast_module_from_cp_rank0(cp_attention)
+    ref_attention = _build_attention(ref_config, None, attn_mask_type=attn_mask_type)
+    ref_attention.load_state_dict(cp_attention.state_dict())
+
+    torch.manual_seed(123)
+    full_hidden = torch.randn(seq_len, batch_size, hidden_size, dtype=torch.bfloat16, device=device)
+    torch.manual_seed(456)
+    grad_output = torch.randn_like(full_hidden)
+
+    local_hidden = _zigzag_split(full_hidden, cp_rank, cp_size).detach().requires_grad_(True)
+    ref_hidden = full_hidden.detach().clone().requires_grad_(True)
+
+    local_mask = None
+    if attention_mask is not None:
+        local_mask = _zigzag_split(attention_mask, cp_rank, cp_size, dim=2)
+
+    cp_output, _ = cp_attention(local_hidden, local_mask)
+    gathered_output = _GatherZigZag.apply(cp_output, cp_size)
+    ref_output, _ = ref_attention(ref_hidden, attention_mask)
+
+    _assert_close(gathered_output.detach(), ref_output.detach())
+
+    gathered_output.backward(grad_output)
+    ref_output.backward(grad_output)
+
+    _assert_close(local_hidden.grad, _zigzag_split(ref_hidden.grad, cp_rank, cp_size))
+    cp_group = parallel_state.get_context_parallel_group()
+    for (_name, cp_param), ref_param in zip(
+        cp_attention.named_parameters(), ref_attention.parameters()
+    ):
+        if cp_param.grad is None or ref_param.grad is None:
+            assert cp_param.grad is None and ref_param.grad is None
+            continue
+        cp_grad = cp_param.grad.detach().clone()
+        dist.all_reduce(cp_grad, group=cp_group)
+        _assert_close(cp_grad, ref_param.grad, atol=3e-2, rtol=3e-2)
+
+
+def _make_reset_attention_mask(
+    seq_len: int, document_ends: tuple[int, ...], device, left_window: int
+) -> torch.Tensor:
+    mask = torch.ones((seq_len, seq_len), dtype=torch.bool, device=device)
+    start = 0
+    for end in document_ends:
+        mask[start:end, start:end] = torch.triu(
+            torch.ones((end - start, end - start), dtype=torch.bool, device=device), diagonal=1
+        )
+        start = end
+    query_positions = torch.arange(seq_len, device=device).view(-1, 1)
+    key_positions = torch.arange(seq_len, device=device).view(1, -1)
+    mask |= key_positions < query_positions - left_window
+    return mask.view(1, 1, seq_len, seq_len)
+
+
+def _make_packed_seq_params(seqlens: tuple[int, ...], device) -> PackedSeqParams:
+    cu = torch.zeros(len(seqlens) + 1, dtype=torch.int32, device=device)
+    for idx, seq_len in enumerate(seqlens):
+        cu[idx + 1] = cu[idx] + seq_len
+    return PackedSeqParams(
+        qkv_format="thd",
+        cu_seqlens_q=cu,
+        cu_seqlens_kv=cu,
+        cu_seqlens_q_padded=cu,
+        cu_seqlens_kv_padded=cu,
+        max_seqlen_q=max(seqlens),
+        max_seqlen_kv=max(seqlens),
+    )
+
+
+@pytest.mark.skipif(Utils.world_size < 4, reason="swa_p2p integration tests need CP=4")
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="unit distributed tests use NCCL/CUDA")
+@pytest.mark.skipif(not is_te_min_version("1.2.0"), reason="SWA requires Transformer Engine >= 1.2")
+def test_swa_p2p_attention_matches_cp1_swa_forward_backward():
+    Utils.initialize_model_parallel(context_parallel_size=4)
+    try:
+        _assert_attention_parity()
+    finally:
+        Utils.destroy_model_parallel()
+
+
+@pytest.mark.skipif(Utils.world_size < 4, reason="swa_p2p integration tests need CP=4")
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="unit distributed tests use NCCL/CUDA")
+@pytest.mark.skipif(not is_te_min_version("1.2.0"), reason="SWA requires Transformer Engine >= 1.2")
+def test_swa_p2p_attention_large_window_matches_cp1_swa_forward_backward():
+    Utils.initialize_model_parallel(context_parallel_size=4)
+    try:
+        _assert_attention_parity(window_size=(10, 0))
+    finally:
+        Utils.destroy_model_parallel()
+
+
+@pytest.mark.skipif(Utils.world_size < 4, reason="swa_p2p integration tests need CP=4")
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="unit distributed tests use NCCL/CUDA")
+@pytest.mark.skipif(not is_te_min_version("1.2.0"), reason="SWA requires Transformer Engine >= 1.2")
+def test_swa_p2p_attention_with_reset_mask_matches_cp1_swa():
+    Utils.initialize_model_parallel(context_parallel_size=4)
+    try:
+        mask = _make_reset_attention_mask(
+            seq_len=64,
+            document_ends=(19, 43, 64),
+            device=torch.device("cuda", torch.cuda.current_device()),
+            left_window=6,
+        )
+        _assert_attention_parity(mask)
+    finally:
+        Utils.destroy_model_parallel()
+
+
+@pytest.mark.skipif(Utils.world_size < 4, reason="swa_p2p integration tests need CP=4")
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="unit distributed tests use NCCL/CUDA")
+@pytest.mark.skipif(not is_te_min_version("1.2.0"), reason="SWA requires Transformer Engine >= 1.2")
+def test_swa_p2p_packed_attention_matches_cp1_swa_forward_backward():
+    cp_size = 4
+    seqlens = (32, 24)
+    device = torch.device("cuda", torch.cuda.current_device())
+
+    Utils.initialize_model_parallel(context_parallel_size=cp_size)
+    try:
+        cp_rank = parallel_state.get_context_parallel_rank()
+        model_parallel_cuda_manual_seed(1234)
+        hidden_size = 64
+        cp_attention = _build_attention(
+            _make_config(
+                num_layers=1,
+                cp_size=cp_size,
+                cp_comm_type="swa_p2p",
+                hidden_size=hidden_size,
+                num_attention_heads=8,
+                num_query_groups=2,
+            ),
+            "swa_p2p",
+        )
+        _broadcast_module_from_cp_rank0(cp_attention)
+        ref_attention = _build_attention(
+            _make_config(
+                num_layers=1,
+                cp_size=1,
+                cp_comm_type=None,
+                hidden_size=hidden_size,
+                num_attention_heads=8,
+                num_query_groups=2,
+            ),
+            None,
+        )
+        ref_attention.load_state_dict(cp_attention.state_dict())
+
+        torch.manual_seed(123)
+        seq_tensors = [
+            torch.randn(seq_len, hidden_size, dtype=torch.bfloat16, device=device)
+            for seq_len in seqlens
+        ]
+        full_hidden = torch.cat(seq_tensors, dim=0).unsqueeze(1)
+        local_hidden = torch.cat(
+            [_zigzag_split(seq_tensor, cp_rank, cp_size) for seq_tensor in seq_tensors], dim=0
+        ).unsqueeze(1)
+        local_hidden = local_hidden.detach().requires_grad_(True)
+        ref_hidden = full_hidden.detach().clone().requires_grad_(True)
+
+        packed_seq_params = _make_packed_seq_params(seqlens, device)
+        cp_output, _ = cp_attention(
+            local_hidden, attention_mask=None, packed_seq_params=packed_seq_params
+        )
+        gathered_output = _GatherPackedZigZag.apply(cp_output, seqlens, cp_size)
+        ref_output, _ = ref_attention(
+            ref_hidden, attention_mask=None, packed_seq_params=packed_seq_params
+        )
+
+        _assert_close(gathered_output.detach(), ref_output.detach())
+
+        torch.manual_seed(456)
+        grad_output = torch.randn_like(ref_output)
+        gathered_output.backward(grad_output)
+        ref_output.backward(grad_output)
+
+        grad_chunks = []
+        offset = 0
+        for seq_len in seqlens:
+            grad_chunks.append(
+                _zigzag_split(ref_hidden.grad[offset : offset + seq_len, 0], cp_rank, cp_size)
+            )
+            offset += seq_len
+        expected_local_grad = torch.cat(grad_chunks, dim=0).unsqueeze(1)
+        _assert_close(local_hidden.grad, expected_local_grad)
+
+        cp_group = parallel_state.get_context_parallel_group()
+        for cp_param, ref_param in zip(cp_attention.parameters(), ref_attention.parameters()):
+            if cp_param.grad is None or ref_param.grad is None:
+                assert cp_param.grad is None and ref_param.grad is None
+                continue
+            cp_grad = cp_param.grad.detach().clone()
+            dist.all_reduce(cp_grad, group=cp_group)
+            _assert_close(cp_grad, ref_param.grad, atol=3e-2, rtol=3e-2)
+    finally:
+        Utils.destroy_model_parallel()
+
+
+@pytest.mark.skipif(Utils.world_size < 4, reason="swa_p2p integration tests need CP=4")
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="unit distributed tests use NCCL/CUDA")
+@pytest.mark.skipif(not is_te_min_version("1.2.0"), reason="SWA requires Transformer Engine >= 1.2")
+def test_swa_p2p_packed_attention_rejects_explicit_attention_mask():
+    cp_size = 4
+    seq_len = 32
+    device = torch.device("cuda", torch.cuda.current_device())
+
+    Utils.initialize_model_parallel(context_parallel_size=cp_size)
+    try:
+        cp_rank = parallel_state.get_context_parallel_rank()
+        hidden_size = 64
+        cp_attention = _build_attention(
+            _make_config(
+                num_layers=1,
+                cp_size=cp_size,
+                cp_comm_type="swa_p2p",
+                hidden_size=hidden_size,
+                num_attention_heads=8,
+                num_query_groups=2,
+            ),
+            "swa_p2p",
+            attn_mask_type=AttnMaskType.arbitrary,
+        )
+
+        torch.manual_seed(123)
+        full_hidden = torch.randn(seq_len, hidden_size, dtype=torch.bfloat16, device=device)
+        local_hidden = _zigzag_split(full_hidden, cp_rank, cp_size).unsqueeze(1)
+        packed_seq_params = _make_packed_seq_params((seq_len,), device)
+        attention_mask = torch.zeros((1, 1, local_hidden.size(0), seq_len), dtype=torch.bool)
+        attention_mask = attention_mask.to(device)
+
+        with pytest.raises(NotImplementedError, match="explicit attention_mask"):
+            cp_attention(
+                local_hidden, attention_mask=attention_mask, packed_seq_params=packed_seq_params
+            )
+    finally:
+        Utils.destroy_model_parallel()
+
+
+@pytest.mark.skipif(Utils.world_size < 4, reason="mixed CP communication test needs CP=4")
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="unit distributed tests use NCCL/CUDA")
+@pytest.mark.skipif(not is_te_min_version("1.12.0"), reason="a2a+p2p requires TE >= 1.12")
+def test_swa_p2p_can_mix_with_a2a_p2p_full_attention_layer():
+    Utils.initialize_model_parallel(
+        context_parallel_size=4, hierarchical_context_parallel_sizes=[2, 2]
+    )
+    try:
+        config = _make_config(
+            num_layers=2,
+            cp_size=4,
+            cp_comm_type=["swa_p2p", "a2a+p2p"],
+            window_attn_skip_freq=[1, 0],
+        )
+        spec = get_gpt_layer_with_transformer_engine_spec()
+        layer_1 = TransformerLayer(config, spec.submodules, layer_number=1).cuda()
+        layer_2 = TransformerLayer(config, spec.submodules, layer_number=2).cuda()
+
+        torch.manual_seed(123)
+        hidden_states = torch.randn(16, 1, 64, dtype=torch.bfloat16, device="cuda")
+        hidden_states.requires_grad_(True)
+        output, _ = layer_1(hidden_states=hidden_states, attention_mask=None)
+        output, _ = layer_2(hidden_states=output, attention_mask=None)
+        output.float().sum().backward()
+        assert hidden_states.grad is not None
+    finally:
+        Utils.destroy_model_parallel()


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Add an SWA-specific Context Parallel backend, `cp_comm_type=swa_p2p`, that keeps
Q/K/V sequence-sharded and exchanges only the K/V border required by causal
Sliding Window Attention.

This PR adds a locality-aware CP path for hybrid SWA models where SWA layers do
not need full-sequence K/V and should not be constrained by A2A KV-head
divisibility. The new path:

- builds CP segment metadata for non-packed zigzag CP and packed THD inputs,
- exchanges only previous-token K/V halo slices needed by `window_size=(W, 0)`,
- runs local attention on each CP segment with extended local K/V,
- routes halo K/V gradients back to their owning rank in backward,
- supports layer-wise `cp_comm_type`, so SWA layers can use `swa_p2p` while full
  attention layers continue to use existing CP paths such as `p2p` or
  `a2a+p2p`.

The current implementation intentionally limits `swa_p2p` to causal SWA. It
rejects unsupported cases explicitly, including dynamic CP, attention bias, and
explicit `attention_mask` with packed sequence inputs.

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: Closes #5593

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [x] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Testing

Local checks:

```bash
uv run isort --check-only --diff \
  megatron/core/transformer/attention.py \
  megatron/core/transformer/swa_context_parallel.py \
  tests/unit_tests/transformer/test_swa_context_parallel.py

uv run ruff check \
  megatron/core/transformer/attention.py \
  megatron/core/transformer/swa_context_parallel.py \
  megatron/core/transformer/transformer_config.py \
  megatron/training/arguments.py \
  tests/unit_tests/transformer/test_swa_context_parallel.py

uv run black --check \
  megatron/core/transformer/swa_context_parallel.py \
  tests/unit_tests/transformer/test_swa_context_parallel.py

git diff --check
```

With GPU checks, using [NeMo-26.04](https://catalog.ngc.nvidia.com/orgs/nvidia/-/containers/nemo/26.06) image.

```bash
python3 -m torch.distributed.run \
  --nproc-per-node=4 \
  -m pytest -q tests/unit_tests/transformer/test_swa_context_parallel.py \
  --tb=short --disable-warnings --capture=fd
```

Result: Each tests has passed.

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
