### PR TITLE
  Add VLM support to DynamicInferenceEngine

### DIFF
--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -284,6 +284,11 @@ class DynamicInferenceContext(BaseInferenceContext):
         self.async_sched_step_count = 0
         self.async_sched_compaction_step_count = 0
 
+        # Per-request VLM data (empty when not using multimodal).
+        self._request_to_image_embeddings: Dict[int, Optional[Tensor]] = {}
+        self._request_to_image_token_mask: Dict[int, Optional[Tensor]] = {}
+        self._request_to_image_token_count: Dict[int, int] = {}
+
         self.cache_mla_latent = (
             isinstance(model_config, MLATransformerConfig) and model_config.cache_mla_latents
         )
@@ -2534,6 +2539,11 @@ class DynamicInferenceContext(BaseInferenceContext):
             token_count=0, prefill_req_count=0, decode_req_count=0
         )
 
+        # Reset VLM data.
+        self._request_to_image_embeddings.clear()
+        self._request_to_image_token_mask.clear()
+        self._request_to_image_token_count.clear()
+
     def reset(self) -> None:
         """Reset entire context.
 
@@ -4137,3 +4147,113 @@ class DynamicInferenceContext(BaseInferenceContext):
             'total_request_count': int(total_request_count),
             'max_requests': int(self.max_requests),
         }
+
+    # ----- VLM per-request data management -----
+
+    def add_vlm_request_data(
+        self,
+        request_id: int,
+        image_embeddings: Optional[Tensor],
+        image_token_mask: Optional[Tensor],
+    ) -> None:
+        """Attach per-request image data to the context.
+
+        Called at add_request time when a multimodal request has images.
+        No-op overhead for text-only requests that never call this.
+
+        Args:
+            request_id: The request identifier.
+            image_embeddings: Tensor of shape [seq_img, 1, hidden] or None.
+            image_token_mask: 1-D tensor with -1 for text positions and
+                non-negative indices for image embedding positions; or None.
+        """
+        self._request_to_image_embeddings[request_id] = image_embeddings
+        self._request_to_image_token_mask[request_id] = image_token_mask
+        if image_embeddings is not None:
+            self._request_to_image_token_count[request_id] = int(
+                image_embeddings.shape[0] * image_embeddings.shape[1]
+            )
+        else:
+            self._request_to_image_token_count[request_id] = 0
+
+    def remove_vlm_request_data(self, request_id: int) -> None:
+        """Remove image data for a finished request."""
+        self._request_to_image_embeddings.pop(request_id, None)
+        self._request_to_image_token_mask.pop(request_id, None)
+        self._request_to_image_token_count.pop(request_id, None)
+
+    def current_image_token_mask(self) -> Optional[Tensor]:
+        """Flattened image-token mask aligned with current_input_ids.
+
+        Returns a [1, padded_active_token_count] tensor with -1 for non-image
+        positions and non-negative indices into the concatenated image
+        embeddings, or None when there are no active tokens. During
+        decode-only steps (no image tokens consumed) returns all -1.
+        """
+        if self.padded_active_token_count is None or self.padded_active_token_count == 0:
+            return None
+
+        if self.is_decode_only():
+            return torch.full(
+                (self.padded_active_token_count,),
+                -1,
+                dtype=torch.long,
+                device=torch.cuda.current_device(),
+            )
+
+        segments: List[Tensor] = []
+        cumulative_offset = 0
+        for row_idx in range(self.paused_request_count, self.total_request_count):
+            request_id = int(self.request_ids[row_idx].item())
+            query_len = int(self.request_query_lengths[row_idx].item())
+
+            per_request_mask = self._request_to_image_token_mask.get(request_id, None)
+            if per_request_mask is None:
+                seg = torch.full(
+                    (query_len,), -1, dtype=torch.long, device=torch.cuda.current_device()
+                )
+            else:
+                seg = per_request_mask[:query_len].clone()
+                positive = seg >= 0
+                if positive.any():
+                    seg[positive] += cumulative_offset
+
+            segments.append(seg)
+            cumulative_offset += int(self._request_to_image_token_count.get(request_id, 0))
+
+        if len(segments) == 0:
+            return None
+
+        mask = torch.cat(segments, dim=0)
+        if mask.numel() < int(self.padded_active_token_count):
+            pad = torch.full(
+                (int(self.padded_active_token_count) - mask.numel(),),
+                -1,
+                dtype=torch.long,
+                device=mask.device,
+            )
+            mask = torch.cat([mask, pad], dim=0)
+        return mask.unsqueeze(0)
+
+    def current_image_embeddings(self) -> Optional[Tensor]:
+        """Concatenate image embeddings for active requests.
+
+        Each per-request embedding has shape [seq_img_i, 1, hidden] where
+        seq_img_i may vary across requests under dynamic resolution. Each is
+        flattened to [seq_img_i, hidden], concatenated along dim 0, and
+        unsqueezed to [sum(seq_img_i), 1, hidden]. The downstream consumer
+        does ``permute(1, 0, 2).reshape(-1, hidden)`` to yield the flat
+        [total_image_tokens, hidden] array indexed by
+        :meth:`current_image_token_mask`.
+
+        Returns tensor of shape [total_image_tokens, 1, hidden] or None.
+        """
+        parts: List[Tensor] = []
+        for row_idx in range(self.paused_request_count, self.total_request_count):
+            request_id = int(self.request_ids[row_idx].item())
+            emb = self._request_to_image_embeddings.get(request_id, None)
+            if emb is not None:
+                parts.append(emb.reshape(-1, emb.shape[-1]))
+        if not parts:
+            return None
+        return torch.cat(parts, dim=0).unsqueeze(1)

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -4201,12 +4201,13 @@ class DynamicInferenceContext(BaseInferenceContext):
                 device=torch.cuda.current_device(),
             )
 
+        active_slice = slice(self.paused_request_count, self.total_request_count)
+        active_request_ids = self.request_ids[active_slice].tolist()
+        active_query_lengths = self.request_query_lengths[active_slice].tolist()
+
         segments: List[Tensor] = []
         cumulative_offset = 0
-        for row_idx in range(self.paused_request_count, self.total_request_count):
-            request_id = int(self.request_ids[row_idx].item())
-            query_len = int(self.request_query_lengths[row_idx].item())
-
+        for request_id, query_len in zip(active_request_ids, active_query_lengths):
             per_request_mask = self._request_to_image_token_mask.get(request_id, None)
             if per_request_mask is None:
                 seg = torch.full(
@@ -4248,9 +4249,12 @@ class DynamicInferenceContext(BaseInferenceContext):
 
         Returns tensor of shape [total_image_tokens, 1, hidden] or None.
         """
+        active_request_ids = self.request_ids[
+            self.paused_request_count : self.total_request_count
+        ].tolist()
+
         parts: List[Tensor] = []
-        for row_idx in range(self.paused_request_count, self.total_request_count):
-            request_id = int(self.request_ids[row_idx].item())
+        for request_id in active_request_ids:
             emb = self._request_to_image_embeddings.get(request_id, None)
             if emb is not None:
                 parts.append(emb.reshape(-1, emb.shape[-1]))

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -4190,6 +4190,11 @@ class DynamicInferenceContext(BaseInferenceContext):
         embeddings, or None when there are no active tokens. During
         decode-only steps (no image tokens consumed) returns all -1.
         """
+        # Text-only workloads never populate the per-request VLM dicts; short-
+        # circuit so the decode hot path doesn't pay for .tolist() / torch.cat.
+        if not self._request_to_image_token_mask:
+            return None
+
         if self.padded_active_token_count is None or self.padded_active_token_count == 0:
             return None
 
@@ -4249,6 +4254,11 @@ class DynamicInferenceContext(BaseInferenceContext):
 
         Returns tensor of shape [total_image_tokens, 1, hidden] or None.
         """
+        # Text-only workloads never populate the per-request VLM dicts; short-
+        # circuit so the decode hot path doesn't pay for .tolist() / torch.cat.
+        if not self._request_to_image_embeddings:
+            return None
+
         active_request_ids = self.request_ids[
             self.paused_request_count : self.total_request_count
         ].tolist()

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -1253,6 +1253,20 @@ class DynamicInferenceEngine(AbstractEngine):
         """Expand image tokens, run the vision encoder, register per-request
         image data on the context, and return a DynamicVLMInferenceRequest.
         """
+        # PP>1 needs a non-first-stage embedding recv path (the wrapper's
+        # _recv_only_vision_embeds TODO). Until that lands, only PP=1 is
+        # correct: non-first stages would see None embeddings but a non-None
+        # mask and silently skip image splicing.
+        pp_group = self.controller.pp_group
+        if pp_group is not None and torch.distributed.is_initialized():
+            pp_world_size = torch.distributed.get_world_size(pp_group)
+            if pp_world_size > 1:
+                raise NotImplementedError(
+                    "Dynamic VLM inference currently supports pipeline-parallel "
+                    "world size 1 only; PP>1 requires the non-first-stage "
+                    "embedding recv path which is not yet available upstream."
+                )
+
         device = torch.cuda.current_device()
         if imgs is not None:
             imgs = imgs.to(device=device)

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -1215,7 +1215,44 @@ class DynamicInferenceEngine(AbstractEngine):
         else:
             raise Exception("specialize for <%s>." % type(prompt).__name__)
 
-        # --- VLM: expand image tokens and run vision encoder ---
+        if imgs is not None or num_tiles is not None or imgs_sizes is not None:
+            request = self._build_vlm_request(
+                request_id=request_id,
+                prompt_str=prompt_str,
+                tokens=tokens,
+                sampling_params=sampling_params,
+                imgs=imgs,
+                num_tiles=num_tiles,
+                num_img_embeddings_per_tile=num_img_embeddings_per_tile,
+                imgs_sizes=imgs_sizes,
+            )
+        else:
+            request = DynamicInferenceRequest(
+                request_id=request_id,
+                prompt=prompt_str,
+                prompt_tokens=tokens,
+                sampling_params=sampling_params,
+                block_size_tokens=self.context.block_size_tokens,
+                enable_prefix_caching=self.context.enable_prefix_caching,
+            )
+
+        return self._add_request(request)
+
+    def _build_vlm_request(
+        self,
+        *,
+        request_id: int,
+        prompt_str: Optional[str],
+        tokens: Tensor,
+        sampling_params: Optional[SamplingParams],
+        imgs: Optional[Tensor],
+        num_tiles: Optional[Tensor],
+        num_img_embeddings_per_tile: int,
+        imgs_sizes: Optional[Tensor],
+    ) -> DynamicVLMInferenceRequest:
+        """Expand image tokens, run the vision encoder, register per-request
+        image data on the context, and return a DynamicVLMInferenceRequest.
+        """
         device = torch.cuda.current_device()
         if imgs is not None:
             imgs = imgs.to(device=device)
@@ -1224,7 +1261,6 @@ class DynamicInferenceEngine(AbstractEngine):
         if imgs_sizes is not None:
             imgs_sizes = imgs_sizes.to(device=device)
 
-        # Determine if we have images to process
         is_dynamic_resolution = imgs_sizes is not None and imgs is not None
         total_num_tiles = int(num_tiles.sum().item()) if num_tiles is not None else 0
         num_img_embeddings = num_img_embeddings_per_tile * total_num_tiles
@@ -1234,7 +1270,6 @@ class DynamicInferenceEngine(AbstractEngine):
         image_embeddings: Optional[Tensor] = None
 
         if has_images:
-            # Expand <image> tokens to padding (-1) and build index mask.
             token_list: List[List[int]] = [tokens.tolist()]
             expanded_tokens_list, mask_list = (
                 self.controller.inference_wrapped_model.expand_image_tokens(
@@ -1260,41 +1295,26 @@ class DynamicInferenceEngine(AbstractEngine):
                     )
                 )
 
-        # Store per-request VLM data in the context (no-op dicts when text-only).
         self.context.add_vlm_request_data(
             request_id,
             image_embeddings=image_embeddings,
             image_token_mask=mask_tensor,
         )
 
-        # Initialize request.
-        if has_images:
-            request = DynamicVLMInferenceRequest(
-                request_id=request_id,
-                prompt=prompt_str,
-                prompt_tokens=tokens,
-                sampling_params=sampling_params,
-                block_size_tokens=self.context.block_size_tokens,
-                enable_prefix_caching=self.context.enable_prefix_caching,
-                num_img_embeddings_per_tile=num_img_embeddings_per_tile,
-                imgs=imgs,
-                num_tiles=num_tiles,
-                decoder_seq_length=0,
-                image_embeddings=image_embeddings,
-                image_token_mask=mask_tensor,
-            )
-        else:
-            request = DynamicInferenceRequest(
-                request_id=request_id,
-                prompt=prompt_str,
-                prompt_tokens=tokens,
-                sampling_params=sampling_params,
-                block_size_tokens=self.context.block_size_tokens,
-                enable_prefix_caching=self.context.enable_prefix_caching,
-            )
-
-        # Add request.
-        return self._add_request(request)
+        return DynamicVLMInferenceRequest(
+            request_id=request_id,
+            prompt=prompt_str,
+            prompt_tokens=tokens,
+            sampling_params=sampling_params,
+            block_size_tokens=self.context.block_size_tokens,
+            enable_prefix_caching=self.context.enable_prefix_caching,
+            num_img_embeddings_per_tile=num_img_embeddings_per_tile,
+            imgs=imgs,
+            num_tiles=num_tiles,
+            decoder_seq_length=0,
+            image_embeddings=image_embeddings,
+            image_token_mask=mask_tensor,
+        )
 
     def post_process_requests(
         self,

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -1276,29 +1276,19 @@ class DynamicInferenceEngine(AbstractEngine):
                     token_list, num_tiles=num_tiles, imgs_sizes=imgs_sizes
                 )
             )
-            tokens = torch.tensor(
-                expanded_tokens_list[0], dtype=torch.int64, device=device
-            )
+            tokens = torch.tensor(expanded_tokens_list[0], dtype=torch.int64, device=device)
             mask_tensor = torch.tensor(
                 [(-1 if v is None else int(v)) for v in mask_list[0]], device=device
             )
 
-        if (
-            has_images
-            and imgs is not None
-            and is_pipeline_first_stage(self.controller.pp_group)
-        ):
+        if has_images and imgs is not None and is_pipeline_first_stage(self.controller.pp_group):
             with torch.inference_mode():
-                image_embeddings = (
-                    self.controller.inference_wrapped_model._forward_vision_encoder(
-                        imgs, num_image_tiles=num_tiles, imgs_sizes=imgs_sizes
-                    )
+                image_embeddings = self.controller.inference_wrapped_model._forward_vision_encoder(
+                    imgs, num_image_tiles=num_tiles, imgs_sizes=imgs_sizes
                 )
 
         self.context.add_vlm_request_data(
-            request_id,
-            image_embeddings=image_embeddings,
-            image_token_mask=mask_tensor,
+            request_id, image_embeddings=image_embeddings, image_token_mask=mask_tensor
         )
 
         return DynamicVLMInferenceRequest(

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -23,6 +23,7 @@ from megatron.core.inference.batch_dimensions_utils import (
     CUDAGraphBatchDimensionBuilder,
     InferenceBatchDimensions,
 )
+from megatron.core.inference.communication_utils import is_pipeline_first_stage
 from megatron.core.inference.config import AsyncScheduleMode, KVCacheManagementMode
 from megatron.core.inference.contexts.dynamic_context import (
     BlockOverflowError,
@@ -40,6 +41,7 @@ from megatron.core.inference.inference_request import (
     DynamicInferenceEventType,
     DynamicInferenceRequest,
     DynamicInferenceRequestRecord,
+    DynamicVLMInferenceRequest,
     Status,
 )
 from megatron.core.inference.sampling_params import SamplingParams
@@ -1148,13 +1150,37 @@ class DynamicInferenceEngine(AbstractEngine):
         request_id: int,
         prompt: Union[str, List[int], Tensor],
         sampling_params: Optional[SamplingParams] = None,
+        *,
+        imgs: Optional[Tensor] = None,
+        num_tiles: Optional[Tensor] = None,
+        num_img_embeddings_per_tile: int = 0,
+        imgs_sizes: Optional[Tensor] = None,
     ) -> asyncio.Future[DynamicInferenceRequest]:
         """Add request to inference context.
+
+        Supports both text-only and multimodal requests. For text-only, call
+        with just (request_id, prompt, sampling_params). For multimodal, also
+        pass imgs and either (num_tiles + num_img_embeddings_per_tile) for static
+        resolution or imgs_sizes for dynamic resolution.
+
+        When multimodal kwargs are provided the method will:
+        1. Expand image tokens in the prompt (replace <image> with padding).
+        2. Run the vision encoder to produce image embeddings.
+        3. Store the embeddings and mask in the context for later use by the
+           controller's forward step.
 
         Args:
             request_id (int): Unique ID of request.
             prompt (Union[str, Tensor]): Prompt as either a text string or token IDs.
             sampling_params (Optional[SamplingParams]): Sampling parameters for the request.
+            imgs (Optional[Tensor]): Image tensor [num_tiles, C, H, W] or
+                [1, total_patches, patch_features] (or None).
+            num_tiles (Optional[Tensor]): Number of tiles per image (1-D tensor, or None).
+                Static resolution.
+            num_img_embeddings_per_tile (int): Number of image embeddings per tile.
+                Static resolution.
+            imgs_sizes (Optional[Tensor]): Per-image sizes [N, 2] with [H, W].
+                Dynamic resolution.
 
         Return:
             Returns an asyncio `Future[DynamicInferenceRequest]` for the user to wait on.
@@ -1189,15 +1215,83 @@ class DynamicInferenceEngine(AbstractEngine):
         else:
             raise Exception("specialize for <%s>." % type(prompt).__name__)
 
-        # Initialize request.
-        request = DynamicInferenceRequest(
-            request_id=request_id,
-            prompt=prompt_str,
-            prompt_tokens=tokens,
-            sampling_params=sampling_params,
-            block_size_tokens=self.context.block_size_tokens,
-            enable_prefix_caching=self.context.enable_prefix_caching,
+        # --- VLM: expand image tokens and run vision encoder ---
+        device = torch.cuda.current_device()
+        if imgs is not None:
+            imgs = imgs.to(device=device)
+        if num_tiles is not None:
+            num_tiles = num_tiles.to(device=device)
+        if imgs_sizes is not None:
+            imgs_sizes = imgs_sizes.to(device=device)
+
+        # Determine if we have images to process
+        is_dynamic_resolution = imgs_sizes is not None and imgs is not None
+        total_num_tiles = int(num_tiles.sum().item()) if num_tiles is not None else 0
+        num_img_embeddings = num_img_embeddings_per_tile * total_num_tiles
+        has_images = is_dynamic_resolution or num_img_embeddings > 0
+
+        mask_tensor: Optional[Tensor] = None
+        image_embeddings: Optional[Tensor] = None
+
+        if has_images:
+            # Expand <image> tokens to padding (-1) and build index mask.
+            token_list: List[List[int]] = [tokens.tolist()]
+            expanded_tokens_list, mask_list = (
+                self.controller.inference_wrapped_model.expand_image_tokens(
+                    token_list, num_tiles=num_tiles, imgs_sizes=imgs_sizes
+                )
+            )
+            tokens = torch.tensor(
+                expanded_tokens_list[0], dtype=torch.int64, device=device
+            )
+            mask_tensor = torch.tensor(
+                [(-1 if v is None else int(v)) for v in mask_list[0]], device=device
+            )
+
+        if (
+            has_images
+            and imgs is not None
+            and is_pipeline_first_stage(self.controller.pp_group)
+        ):
+            with torch.inference_mode():
+                image_embeddings = (
+                    self.controller.inference_wrapped_model._forward_vision_encoder(
+                        imgs, num_image_tiles=num_tiles, imgs_sizes=imgs_sizes
+                    )
+                )
+
+        # Store per-request VLM data in the context (no-op dicts when text-only).
+        self.context.add_vlm_request_data(
+            request_id,
+            image_embeddings=image_embeddings,
+            image_token_mask=mask_tensor,
         )
+
+        # Initialize request.
+        if has_images:
+            request = DynamicVLMInferenceRequest(
+                request_id=request_id,
+                prompt=prompt_str,
+                prompt_tokens=tokens,
+                sampling_params=sampling_params,
+                block_size_tokens=self.context.block_size_tokens,
+                enable_prefix_caching=self.context.enable_prefix_caching,
+                num_img_embeddings_per_tile=num_img_embeddings_per_tile,
+                imgs=imgs,
+                num_tiles=num_tiles,
+                decoder_seq_length=0,
+                image_embeddings=image_embeddings,
+                image_token_mask=mask_tensor,
+            )
+        else:
+            request = DynamicInferenceRequest(
+                request_id=request_id,
+                prompt=prompt_str,
+                prompt_tokens=tokens,
+                sampling_params=sampling_params,
+                block_size_tokens=self.context.block_size_tokens,
+                enable_prefix_caching=self.context.enable_prefix_caching,
+            )
 
         # Add request.
         return self._add_request(request)
@@ -1523,6 +1617,11 @@ class DynamicInferenceEngine(AbstractEngine):
 
         # Clear the stop word being finished set after processing
         self.stop_word_being_finished_ids.clear()
+
+        # Remove VLM data for finished requests from the context.
+        for record in finished_request_records:
+            req = record[-1]
+            self.context.remove_vlm_request_data(req.request_id)
 
         return active_request_ids, finished_request_records
 

--- a/megatron/core/inference/inference_request.py
+++ b/megatron/core/inference/inference_request.py
@@ -780,3 +780,16 @@ class VLMInferenceRequest(InferenceRequest):
     imgs: torch.Tensor
     num_tiles: torch.Tensor
     decoder_seq_length: int
+
+
+@dataclass(kw_only=True)
+class DynamicVLMInferenceRequest(DynamicInferenceRequest, VLMInferenceRequest):
+    """Dynamic inference request for VLM models.
+
+    Combines DynamicInferenceRequest (for dynamic batching) with VLMInferenceRequest
+    (for multimodal fields). Also stores pre-computed image embeddings and the image
+    token mask produced by expand_image_tokens.
+    """
+
+    image_embeddings: Optional[torch.Tensor] = None  # [seq_img, 1, hidden]
+    image_token_mask: Optional[torch.Tensor] = None  # 1D, -1=text, >=0=image index

--- a/megatron/core/inference/model_inference_wrappers/multimodal/vlm_inference_wrapper.py
+++ b/megatron/core/inference/model_inference_wrappers/multimodal/vlm_inference_wrapper.py
@@ -156,13 +156,23 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
         batch_size = len(tokens)
         img_embeddings_per_tile = 0  # set below in the static-resolution branch
 
+        # Reject dynamic-resolution requests when the model does not expose
+        # the required attributes. Upstream LLaVAModel sets neither
+        # _dynamic_resolution nor _patch_dim / _class_token_len; without those,
+        # falling through to the static path would silently miscount tokens.
+        if imgs_sizes is not None and not getattr(module, '_dynamic_resolution', False):
+            raise NotImplementedError(
+                "Dynamic-resolution image expansion requires LLaVAModel "
+                "attributes (_dynamic_resolution, _patch_dim, _class_token_len) "
+                "not yet available upstream. Use num_tiles (static resolution) "
+                "or wait for the companion LLaVAModel changes."
+            )
+
         # Compute per-image embedding counts
         if imgs_sizes is not None and getattr(module, '_dynamic_resolution', False):
             # Dynamic resolution: compute per-image embedding count from imgs_sizes
             patch_dim = module._patch_dim
             do_pixel_shuffle = module._pixel_shuffle
-            drop_class_token = module._drop_vision_class_token
-            class_token_len = module._class_token_len
 
             per_image_embeddings = []
             for i in range(imgs_sizes.shape[0]):
@@ -281,6 +291,16 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
             self.model.module.module if hasattr(self.model.module, "module") else self.model.module
         )
 
+        # Reject dynamic-resolution requests when the model does not expose
+        # the required attributes (see expand_image_tokens for context).
+        if imgs_sizes is not None and not getattr(module, '_dynamic_resolution', False):
+            raise NotImplementedError(
+                "Dynamic-resolution vision-encoder forward requires "
+                "LLaVAModel._dynamic_resolution/_patch_dim, not yet available "
+                "upstream. Use num_tiles (static resolution) or wait for the "
+                "companion LLaVAModel changes."
+            )
+
         # Build vision_packed_seq_params for dynamic resolution
         vision_packed_seq_params = None
         if imgs_sizes is not None and getattr(module, '_dynamic_resolution', False):
@@ -374,12 +394,39 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
 
                     image_embeddings_flat = image_embeddings_flat.to(dtype=final_embedding.dtype)
 
+                    # Guard against count disagreement between expand_image_tokens
+                    # (which drove image_token_mask indices) and
+                    # _forward_vision_encoder (which produced image_embeddings).
+                    # Class-token handling or pixel-shuffle rounding differing
+                    # between the two would otherwise silently index out of bounds.
+                    if image_indices.numel() > 0:
+                        max_idx = int(image_indices.max().item())
+                        assert max_idx < image_embeddings_flat.shape[0], (
+                            f"image_indices max ({max_idx}) exceeds "
+                            f"image_embeddings_flat size "
+                            f"({image_embeddings_flat.shape[0]}); "
+                            f"expand_image_tokens count disagrees with "
+                            f"_forward_vision_encoder output"
+                        )
+
                     final_embedding[image_positions] = image_embeddings_flat[image_indices]
 
             # Transpose back to [seq_len, batch, embed_dim]
             final_embedding = final_embedding.transpose(0, 1).contiguous()
         else:
             final_embedding = None
+
+        # This engine plumbing ships without the LLaVAModel.forward_lm_only
+        # entry point. Any VLM caller upstream hits this guard rather than a
+        # confusing AttributeError. Text-only requests never reach here (the
+        # dispatch in _forward gates on image_token_mask).
+        if not hasattr(module, "forward_lm_only"):
+            raise NotImplementedError(
+                "Dynamic VLM forward requires LLaVAModel.forward_lm_only, "
+                "which is not yet available upstream. This PR ships engine "
+                "and wire plumbing; the LLaVAModel companion change lands "
+                "in a follow-up PR."
+            )
 
         output = module.forward_lm_only(
             combined_embeddings=final_embedding,

--- a/megatron/core/inference/model_inference_wrappers/multimodal/vlm_inference_wrapper.py
+++ b/megatron/core/inference/model_inference_wrappers/multimodal/vlm_inference_wrapper.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
 import warnings
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 import torch
 
@@ -147,11 +147,14 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
             mask (List[List[int or None]]): Mask indicating image embedding indices for each
                 position, None for non-image positions.
         """
-        module = self.model.module.module if hasattr(self.model.module, "module") else self.model.module
+        module = (
+            self.model.module.module if hasattr(self.model.module, "module") else self.model.module
+        )
         image_token_index = module.image_token_index
 
         pad_value = -1
         batch_size = len(tokens)
+        img_embeddings_per_tile = 0  # set below in the static-resolution branch
 
         # Compute per-image embedding counts
         if imgs_sizes is not None and getattr(module, '_dynamic_resolution', False):
@@ -226,9 +229,7 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
 
                 image_idx = 0
                 image_embedding_offset = (
-                    sum(
-                        num_tiles_per_sample[i].sum().item() for i in range(batch_idx)
-                    )
+                    sum(num_tiles_per_sample[i].sum().item() for i in range(batch_idx))
                     * img_embeddings_per_tile
                 )
 
@@ -258,7 +259,9 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
 
         return expanded_tokens_list, mask_list
 
-    def _forward_vision_encoder(self, images, num_image_tiles=None, imgs_sizes=None) -> torch.Tensor:
+    def _forward_vision_encoder(
+        self, images, num_image_tiles=None, imgs_sizes=None
+    ) -> torch.Tensor:
         """Run the vision encoder only, returning image embeddings.
 
         Temporarily disables the decoder so that the LLaVA forward only runs
@@ -274,17 +277,21 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
         """
         from megatron.core.packed_seq_params import PackedSeqParams
 
-        module = self.model.module.module if hasattr(self.model.module, "module") else self.model.module
+        module = (
+            self.model.module.module if hasattr(self.model.module, "module") else self.model.module
+        )
 
         # Build vision_packed_seq_params for dynamic resolution
         vision_packed_seq_params = None
         if imgs_sizes is not None and getattr(module, '_dynamic_resolution', False):
             patch_dim = module._patch_dim
             seq_lens = torch.prod(imgs_sizes // patch_dim, dim=-1)
-            cu_seqlens = torch.cat([
-                torch.zeros(1, dtype=torch.int32, device=imgs_sizes.device),
-                torch.cumsum(seq_lens, dim=0).to(torch.int32),
-            ])
+            cu_seqlens = torch.cat(
+                [
+                    torch.zeros(1, dtype=torch.int32, device=imgs_sizes.device),
+                    torch.cumsum(seq_lens, dim=0).to(torch.int32),
+                ]
+            )
             max_seqlen = int(seq_lens.max().item())
             vision_packed_seq_params = PackedSeqParams(
                 qkv_format="thd",
@@ -336,7 +343,9 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
         attention_mask = inference_input.get("attention_mask", None)
         image_embeddings = inference_input.get("image_embeddings", None)
 
-        module = self.model.module.module if hasattr(self.model.module, "module") else self.model.module
+        module = (
+            self.model.module.module if hasattr(self.model.module, "module") else self.model.module
+        )
 
         if is_pipeline_first_stage(self.pp_group) or self._recv_only_vision_embeds:
             # Replace -1 padding with 0 for embedding lookup
@@ -361,13 +370,9 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
                     image_indices = image_token_mask[image_positions]
 
                     # Reshape image embeddings to [total_image_tokens, embed_dim]
-                    image_embeddings_flat = image_embeddings.permute(1, 0, 2).reshape(
-                        -1, embed_dim
-                    )
+                    image_embeddings_flat = image_embeddings.permute(1, 0, 2).reshape(-1, embed_dim)
 
-                    image_embeddings_flat = image_embeddings_flat.to(
-                        dtype=final_embedding.dtype
-                    )
+                    image_embeddings_flat = image_embeddings_flat.to(dtype=final_embedding.dtype)
 
                     final_embedding[image_positions] = image_embeddings_flat[image_indices]
 

--- a/megatron/core/inference/model_inference_wrappers/multimodal/vlm_inference_wrapper.py
+++ b/megatron/core/inference/model_inference_wrappers/multimodal/vlm_inference_wrapper.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
 import warnings
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 import torch
 
@@ -17,6 +17,9 @@ from megatron.core.inference.model_inference_wrappers.gpt.gpt_inference_wrapper 
 # pylint: disable=line-too-long
 class VLMInferenceWrapper(GPTInferenceWrapper):
     """Inference wrapper for VLMs"""
+
+    _recv_only_vision_embeds: bool = False
+    _encoder_only: bool = False
 
     def prep_model_for_inference(self, prompts_tokens: Optional[torch.Tensor] = None):
         """A utility function for preparing model for inference
@@ -123,8 +126,276 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
             "decoder_seq_length": decoder_seq_length,
         }
 
+    # ---- Dynamic inference methods ----
+
+    def expand_image_tokens(self, tokens, num_tiles=None, imgs_sizes=None):
+        """Expand image tokens to multiple pad tokens.
+
+        Supports two modes:
+        - Static resolution (num_tiles provided): each <image> is replaced with
+          tiles_for_that_image * img_embeddings_per_tile padding values.
+        - Dynamic resolution (imgs_sizes provided): each <image> is replaced with
+          (H/patch_dim * W/patch_dim) / 4 (if pixel_shuffle) padding values per image.
+
+        Args:
+            tokens (List[List[int]]): List of token sequences, one per sample.
+            num_tiles (torch.Tensor): Number of tiles per image (static resolution).
+            imgs_sizes (torch.Tensor): Per-image sizes [N, 2] with [H, W] (dynamic resolution).
+
+        Returns:
+            expanded_tokens (List[List[int]]): Tokens with image tokens expanded to -1 pad values.
+            mask (List[List[int or None]]): Mask indicating image embedding indices for each
+                position, None for non-image positions.
+        """
+        module = self.model.module.module if hasattr(self.model.module, "module") else self.model.module
+        image_token_index = module.image_token_index
+
+        pad_value = -1
+        batch_size = len(tokens)
+
+        # Compute per-image embedding counts
+        if imgs_sizes is not None and getattr(module, '_dynamic_resolution', False):
+            # Dynamic resolution: compute per-image embedding count from imgs_sizes
+            patch_dim = module._patch_dim
+            do_pixel_shuffle = module._pixel_shuffle
+            drop_class_token = module._drop_vision_class_token
+            class_token_len = module._class_token_len
+
+            per_image_embeddings = []
+            for i in range(imgs_sizes.shape[0]):
+                h, w = imgs_sizes[i][0].item(), imgs_sizes[i][1].item()
+                num_embeddings = (h // patch_dim) * (w // patch_dim)
+                if do_pixel_shuffle:
+                    num_embeddings //= 4
+                per_image_embeddings.append(num_embeddings)
+        else:
+            # Static resolution: fixed embeddings per tile
+            img_embeddings_per_tile = module.img_seq_len
+            per_image_embeddings = None  # computed per-image below
+
+        # Count images per sample
+        num_images_per_sample = []
+        for sample_tokens in tokens:
+            num_images_per_sample.append(
+                sum(1 for token in sample_tokens if token == image_token_index)
+            )
+
+        expanded_tokens_list = []
+        mask_list = []
+
+        if per_image_embeddings is not None:
+            # Dynamic resolution path
+            image_global_idx = 0
+            for batch_idx in range(batch_size):
+                sample_tokens = tokens[batch_idx]
+                expanded_sample = []
+                mask_sample = []
+                image_embedding_offset = sum(per_image_embeddings[:image_global_idx])
+
+                for token in sample_tokens:
+                    if token == image_token_index and image_global_idx < len(per_image_embeddings):
+                        tokens_for_image = per_image_embeddings[image_global_idx]
+                        expanded_sample.extend([pad_value] * tokens_for_image)
+
+                        start_idx = image_embedding_offset
+                        end_idx = start_idx + tokens_for_image
+                        mask_sample.extend(list(range(start_idx, end_idx)))
+
+                        image_embedding_offset += tokens_for_image
+                        image_global_idx += 1
+                    else:
+                        expanded_sample.append(token)
+                        mask_sample.append(None)
+
+                expanded_tokens_list.append(expanded_sample)
+                mask_list.append(mask_sample)
+        else:
+            # Static resolution path (original logic)
+            num_tiles_per_sample = num_tiles.split(num_images_per_sample, dim=0)
+
+            for batch_idx in range(batch_size):
+                sample_tokens = tokens[batch_idx]
+                sample_num_tiles = (
+                    num_tiles_per_sample[batch_idx]
+                    if len(num_tiles_per_sample[batch_idx]) > 0
+                    else torch.tensor([])
+                )
+
+                expanded_sample = []
+                mask_sample = []
+
+                image_idx = 0
+                image_embedding_offset = (
+                    sum(
+                        num_tiles_per_sample[i].sum().item() for i in range(batch_idx)
+                    )
+                    * img_embeddings_per_tile
+                )
+
+                for token in sample_tokens:
+                    if token == image_token_index:
+                        if image_idx < len(sample_num_tiles):
+                            tiles_for_image = sample_num_tiles[image_idx].item()
+                            tokens_for_image = tiles_for_image * img_embeddings_per_tile
+
+                            expanded_sample.extend([pad_value] * tokens_for_image)
+
+                            start_idx = image_embedding_offset
+                            end_idx = start_idx + tokens_for_image
+                            mask_sample.extend(list(range(start_idx, end_idx)))
+
+                            image_embedding_offset += tokens_for_image
+                            image_idx += 1
+                        else:
+                            expanded_sample.append(token)
+                            mask_sample.append(None)
+                    else:
+                        expanded_sample.append(token)
+                        mask_sample.append(None)
+
+                expanded_tokens_list.append(expanded_sample)
+                mask_list.append(mask_sample)
+
+        return expanded_tokens_list, mask_list
+
+    def _forward_vision_encoder(self, images, num_image_tiles=None, imgs_sizes=None) -> torch.Tensor:
+        """Run the vision encoder only, returning image embeddings.
+
+        Temporarily disables the decoder so that the LLaVA forward only runs
+        the vision encoder + projection.
+
+        Args:
+            images (torch.Tensor): Input images [num_tiles, C, H, W] or [1, total_patches, patch_features].
+            num_image_tiles (torch.Tensor): Number of tiles per image (static resolution).
+            imgs_sizes (torch.Tensor): Per-image sizes [N, 2] with [H, W] (dynamic resolution).
+
+        Returns:
+            torch.Tensor: Image embeddings [img_seq_len, num_tiles, hidden].
+        """
+        from megatron.core.packed_seq_params import PackedSeqParams
+
+        module = self.model.module.module if hasattr(self.model.module, "module") else self.model.module
+
+        # Build vision_packed_seq_params for dynamic resolution
+        vision_packed_seq_params = None
+        if imgs_sizes is not None and getattr(module, '_dynamic_resolution', False):
+            patch_dim = module._patch_dim
+            seq_lens = torch.prod(imgs_sizes // patch_dim, dim=-1)
+            cu_seqlens = torch.cat([
+                torch.zeros(1, dtype=torch.int32, device=imgs_sizes.device),
+                torch.cumsum(seq_lens, dim=0).to(torch.int32),
+            ])
+            max_seqlen = int(seq_lens.max().item())
+            vision_packed_seq_params = PackedSeqParams(
+                qkv_format="thd",
+                cu_seqlens_q=cu_seqlens,
+                cu_seqlens_kv=cu_seqlens,
+                max_seqlen_q=max_seqlen,
+                max_seqlen_kv=max_seqlen,
+            )
+
+        old_add_decoder = module.add_decoder
+        module.add_decoder = False
+        output = self.model(
+            images,
+            [],
+            position_ids=None,
+            attention_mask=None,
+            inference_context=self.inference_context,
+            num_image_tiles=num_image_tiles,
+            runtime_gather_output=True,
+            imgs_sizes=imgs_sizes,
+            vision_packed_seq_params=vision_packed_seq_params,
+        )
+        module.add_decoder = old_add_decoder
+
+        if isinstance(output, tuple):
+            image_embeddings, _ = output
+        else:
+            image_embeddings = output
+        return image_embeddings
+
+    def _forward_dynamic(self, inference_input: Dict[str, Any]) -> torch.Tensor:
+        """Forward for dynamic inference with pre-computed image embeddings.
+
+        On PP first stage: embeds text tokens (replacing -1 padding with 0 for
+        embedding lookup), gets language embeddings, scatters pre-computed image
+        embeddings at mask positions, calls forward_lm_only. On non-first PP stages:
+        passes None embeddings.
+
+        Args:
+            inference_input (Dict[str, Any]): Must contain 'tokens', 'position_ids',
+                'image_token_mask', 'image_embeddings', and optionally 'attention_mask'.
+
+        Returns:
+            torch.Tensor: Language model output logits.
+        """
+        tokens = inference_input["tokens"]
+        position_ids = inference_input["position_ids"]
+        image_token_mask = inference_input.get("image_token_mask", None)
+        attention_mask = inference_input.get("attention_mask", None)
+        image_embeddings = inference_input.get("image_embeddings", None)
+
+        module = self.model.module.module if hasattr(self.model.module, "module") else self.model.module
+
+        if is_pipeline_first_stage(self.pp_group) or self._recv_only_vision_embeds:
+            # Replace -1 padding with 0 for embedding lookup
+            input_ids_text = tokens.clone()
+            input_ids_text[input_ids_text == -1] = 0
+
+            # Get language embeddings: [seq_len, b, h_language]
+            language_embeddings = module.language_model.embedding(
+                input_ids=input_ids_text, position_ids=position_ids
+            )
+
+            # Transpose to [b, seq_len, h_language]
+            language_embeddings = language_embeddings.transpose(1, 0).contiguous()
+
+            embed_dim = language_embeddings.shape[-1]
+            final_embedding = language_embeddings.clone()
+
+            if image_token_mask is not None and image_embeddings is not None:
+                image_positions = image_token_mask >= 0
+
+                if image_positions.any():
+                    image_indices = image_token_mask[image_positions]
+
+                    # Reshape image embeddings to [total_image_tokens, embed_dim]
+                    image_embeddings_flat = image_embeddings.permute(1, 0, 2).reshape(
+                        -1, embed_dim
+                    )
+
+                    image_embeddings_flat = image_embeddings_flat.to(
+                        dtype=final_embedding.dtype
+                    )
+
+                    final_embedding[image_positions] = image_embeddings_flat[image_indices]
+
+            # Transpose back to [seq_len, batch, embed_dim]
+            final_embedding = final_embedding.transpose(0, 1).contiguous()
+        else:
+            final_embedding = None
+
+        output = module.forward_lm_only(
+            combined_embeddings=final_embedding,
+            attention_mask=attention_mask,
+            labels=None,
+            inference_context=self.inference_context,
+            runtime_gather_output=True,
+        )
+
+        return output
+
+    # ---- Static inference path ----
+
     def _forward(self, inference_input: Dict[str, Any]):
         """Runs a forward pass of the model.
+
+        Dispatches to one of three paths:
+        1. Dynamic VLM path: 'image_token_mask' key is present.
+        2. Static VLM path: 'images' key is present (LLaVA forward).
+        3. Pure text (GPT) path: neither key present — delegates to the base
+           GPTInferenceWrapper._forward so that text-only models work unmodified.
 
         Args:
             inference_input(Dict[str, Any]): The input data.
@@ -132,6 +403,36 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
         Returns:
             The model output logits.
         """
+        # Dynamic path: image_token_mask is present
+        if "image_token_mask" in inference_input:
+            return self._forward_dynamic(inference_input)
+
+        # Pure text path: no VLM keys.
+        # Cannot delegate to super()._forward() because the abstract wrapper passes
+        # (tokens, position_ids, attention_mask) positionally, but LLaVAModel.forward
+        # expects (images, input_ids, position_ids, attention_mask).
+        if "images" not in inference_input:
+            tokens = inference_input["tokens"]
+            position_ids = inference_input["position_ids"]
+            attention_mask = inference_input["attention_mask"]
+            # Pass an empty images tensor (not None) to match what the training
+            # data pipeline provides for text-only samples.
+            empty_images = torch.tensor([], device=tokens.device).reshape(0, 0, 0)
+            output = self.model(
+                empty_images,
+                tokens,
+                position_ids,
+                attention_mask=attention_mask,
+                inference_context=self.inference_context,
+                runtime_gather_output=True,
+            )
+            if isinstance(output, tuple):
+                logits, _ = output
+            else:
+                logits = output
+            return logits
+
+        # VLM path: standard LLaVA forward
         images = inference_input["images"]
         tokens = inference_input["tokens"]
         position_ids = inference_input["position_ids"]
@@ -163,6 +464,29 @@ class VLMInferenceWrapper(GPTInferenceWrapper):
             The logits are returned only in the last pipeline stage for PP models.
         """
         tokens = inference_input["tokens"]
+
+        # Dynamic path: image_token_mask present, no decoder_seq_length
+        if "image_token_mask" in inference_input:
+            num_tokens = tokens.size(1)
+            recv_buffer_seq_len = num_tokens
+
+            if self._recv_only_vision_embeds:
+                pass  # TODO: recv image_embeddings when encoder is on separate stage
+
+            if self._encoder_only:
+                pass  # TODO: send image_embeddings down pipeline
+            else:
+                output = super().run_one_forward_step(
+                    inference_input, recv_buffer_seq_len=recv_buffer_seq_len
+                )
+            logits = output
+            return logits
+
+        # Pure text path: no VLM keys, use base GPT forward
+        if "images" not in inference_input:
+            return super().run_one_forward_step(inference_input)
+
+        # Static VLM path
         num_image_tokens = (tokens == self.model.module.image_token_index).sum().item()
         num_img_embeddings = inference_input["num_img_embeddings"]
         decoder_seq_length = inference_input["decoder_seq_length"]

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -706,7 +706,27 @@ class TextGenerationController:
         else:
             return context.current_input_and_position_ids()
 
-    def _dynamic_step_forward_logits(self, input_ids: Tensor, position_ids: Tensor):
+    def _sanitize_dummy_input_ids(self, input_ids: Tensor) -> Tensor:
+        """Replace invalid dummy-forward token IDs while preserving token count.
+
+        Expert-parallel dummy forwards are synthetic; they only keep ranks with
+        no local request participating in the same collectives as active ranks.
+        Their logits are discarded, so any out-of-vocabulary placeholder token
+        can be replaced with a stable valid token without affecting user-visible
+        output. This keeps the dummy path independent of how dynamic VLM
+        resolution expands image placeholders for real requests.
+        """
+        invalid_mask = (input_ids < 0) | (input_ids >= self.vocab_size)
+        if not invalid_mask.any():
+            return input_ids
+
+        input_ids = input_ids.clone()
+        input_ids[invalid_mask] = 0
+        return input_ids
+
+    def _dynamic_step_forward_logits(
+        self, input_ids: Tensor, position_ids: Tensor, *, is_dummy_forward: bool = False
+    ):
         """Forward step the model to get logits for dynamic batching.
 
         This also handles logits-broadcasting for pipeline parallelism.
@@ -714,6 +734,8 @@ class TextGenerationController:
         Args:
             input_ids (Tensor): The input token IDs.
             position_ids (Tensor): The position IDs.
+            is_dummy_forward (bool): Whether this is an expert-parallel dummy
+                forward whose logits will be discarded.
         """
         context = self.inference_wrapped_model.inference_context
         if context.config.materialize_only_last_token_logits:
@@ -721,10 +743,29 @@ class TextGenerationController:
         else:
             logits_seq_len = context.padded_active_token_count
 
+        if is_dummy_forward:
+            input_ids = self._sanitize_dummy_input_ids(input_ids)
+
+        # Check for VLM image data in the context.
+        image_token_mask = context.current_image_token_mask()
+        image_embeddings = context.current_image_embeddings()
+        has_images = (
+            image_token_mask is not None
+            and image_embeddings is not None
+            and (image_token_mask >= 0).any()
+        )
+
+        inference_input = {
+            "tokens": input_ids,
+            "position_ids": position_ids,
+            "attention_mask": None,
+        }
+        if has_images:
+            inference_input["image_token_mask"] = image_token_mask
+            inference_input["image_embeddings"] = image_embeddings
+
         with torch.inference_mode():
-            logits = self.inference_wrapped_model.run_one_forward_step(
-                {"tokens": input_ids, "position_ids": position_ids, "attention_mask": None}
-            )
+            logits = self.inference_wrapped_model.run_one_forward_step(inference_input)
             # logits shape: [1, seq_len, vocab_size]
 
         if not context.config.materialize_only_last_token_logits:
@@ -1607,7 +1648,7 @@ class TextGenerationController:
 
         # attempt to use cuda-graph if possible
         input_ids, position_ids = self._dynamic_step_context_init(is_dummy_forward=True)
-        self._dynamic_step_forward_logits(input_ids, position_ids)
+        self._dynamic_step_forward_logits(input_ids, position_ids, is_dummy_forward=True)
 
         # Disable MoE padding for MTP computation, unless CUDA graphs
         # are active (the graphs were captured with padding enabled).


### PR DESCRIPTION
  Extend the dynamic-batching inference path to accept per-request image
  inputs. The engine now offers VLM kwargs on add_request (imgs,
  imgs_sizes, num_tiles, num_img_embeddings_per_tile) that:

    * expand <image> placeholders into pad tokens (static-resolution and dynamic-resolution cases both supported);
    * run the vision encoder on the first PP stage to produce per-request image embeddings;
    * attach the embeddings and image-token mask to the context so the decoder forward can splice them back in.

  DynamicInferenceContext gains _request_to_image_embeddings/
  _request_to_image_token_mask/_request_to_image_token_count dicts and
  four new accessors (add_vlm_request_data, remove_vlm_request_data,
  current_image_token_mask, current_image_embeddings); the per-request
  data is cleared at reset_metadata and on request completion in
  post_process_requests.

  VLMInferenceWrapper gains expand_image_tokens, _forward_vision_encoder
  and _forward_dynamic to back the engine path. All preexisting wrapper
  methods are unchanged, and the new behavior is dormant unless a caller
  passes imgs/imgs_sizes/num_tiles to add_request, so text-only inference
  is unaffected.

  TextGenerationController._dynamic_step_forward_logits picks up the
  per-request image data from the context and forwards it through the
  wrapper's inference_input dict. Out-of-vocabulary placeholders
  introduced by VLM expansion would otherwise leak into expert-parallel
  dummy forwards (whose logits are discarded but whose token IDs still
  have to be in vocab); _sanitize_dummy_input_ids replaces them with a
  stable valid token on the dummy path only.

  DynamicVLMInferenceRequest combines DynamicInferenceRequest and
  VLMInferenceRequest, carrying the precomputed image_embeddings and
  image_token_mask alongside the usual request state.

- [ ] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
<!-- Add a one line overview of what this PR aims to accomplish. -->

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
