### PR TITLE
Add sequence packing planning API

### DIFF
--- a/megatron/core/datasets/sequence_packing/README.md
+++ b/megatron/core/datasets/sequence_packing/README.md
@@ -1,0 +1,190 @@
+# Sequence Packing and Dynamic CP Planning
+
+This package defines an API-only planning layer for the Dynamic CP and sequence
+packing redesign. It separates three concerns that are currently mixed across
+the data iterator, scheduler, and forward/backward schedule:
+
+1. Build packed units from variable-length source sequences.
+2. Place those packed units onto backend-specific rank groups.
+3. Execute the resulting plan by rerouting data, materializing THD tensors, and
+   broadcasting metadata.
+
+The first PR for this package is intentionally non-invasive. It adds contracts
+and design documentation only. Existing runtime behavior remains unchanged.
+
+## Current Main Baseline
+
+Current main already has Dynamic CP support, but the responsibilities are tightly
+coupled:
+
+```text
+HybridCPDataLoaderWrapper
+  - reads packed samples from the data iterator
+  - extracts sub-sample sequence lengths
+  - gathers sequence lengths across DP
+  - calls BalancedCPScheduler
+  - reroutes sub-samples across DPxCP ranks
+
+BalancedCPScheduler
+  - decides local CP size for each sub-sample
+  - assigns sub-samples to DPxCP ranks
+  - groups assignments to avoid CP deadlock
+
+hybrid_context_parallel_forward_backward
+  - consumes the scheduler output
+  - creates one-sample iterators
+  - sets local_cp_size
+  - inserts barriers between groups
+  - drives forward/backward
+```
+
+This works, but it makes it hard to reuse sequence packing for static CP,
+Dynamic CP, HybridEP, or offline planners.
+
+## Target Architecture
+
+```text
+raw variable-length samples
+        |
+        v
+SequencePackingScheduler
+  generic, online or offline
+  answers: which sequences form each pack?
+        |
+        v
+PackDescriptor
+  THD pack intent: sample IDs, lengths, cu_seqlens shape
+        |
+        v
+PlacementScheduler
+  backend-specific
+  answers: which ranks execute each pack?
+        |
+        v
+ExecutionPlan
+  barrier-safe groups of pack assignments
+        |
+        v
+PlanExecutionEngine
+  future shared engine:
+    - reroute samples
+    - materialize THD tensors
+    - build cu_seqlens / cu_seqlens_padded
+    - broadcast TP/PP metadata
+    - execute barriers and train/eval integration
+        |
+        v
+PackedSeqParams / Transformer Engine / MoE backend
+```
+
+## THD's Role
+
+THD is the common packed representation:
+
+```text
+tokens: [T, H, D]
+metadata: cu_seqlens, cu_seqlens_padded, max_seqlen
+```
+
+THD is not the scheduler. It is the representation produced by packing and
+consumed by downstream backends such as standard varlen attention, static CP,
+Dynamic CP, HybridEP, and future placement strategies.
+
+## Scheduler Responsibilities
+
+### SequencePackingScheduler
+
+Generic layer. It maps source sequence metadata to pack descriptors.
+
+Examples:
+
+- Online DP-balanced packing from PR #3386.
+- Offline global bin packing from a precomputed plan file.
+- Future HybridEP-aware packing that balances expert token pressure.
+
+It should not create process groups, run all-to-all, call forward/backward, or
+decide Dynamic CP group membership.
+
+### PlacementScheduler
+
+Backend-specific layer. It maps packs to logical execution resources.
+
+Examples:
+
+- Current main's `BalancedCPScheduler` as a Dynamic CP placement scheduler.
+- Static CP placement, where every pack runs on the same CP group.
+- HybridEP placement, where packs carry expert-parallel routing constraints.
+- No-CP placement, where packs execute on a single data-parallel rank.
+
+### PlanExecutionEngine
+
+Shared future engine. It consumes `ExecutionPlan` and owns the operational
+steps that should not be duplicated by every scheduler:
+
+- sample reroute,
+- THD materialization,
+- padding policy,
+- metadata broadcast,
+- barrier execution,
+- train/eval integration.
+
+This package defines the contract only; engine implementation is future work.
+
+## Mapping Existing Work
+
+### Current Main
+
+Current main's Dynamic CP path maps to the target design as:
+
+```text
+BalancedCPScheduler
+  -> PlacementScheduler for Dynamic CP
+
+HybridCPDataLoaderWrapper + hybrid_context_parallel_forward_backward
+  -> prototype PlanExecutionEngine responsibilities
+```
+
+The first implementation follow-up should preserve current behavior while
+teaching the current Dynamic CP path to emit an `ExecutionPlan`.
+
+### PR #3386
+
+PR #3386 adds an online DP-balanced sequence-packing path. In this design:
+
+```text
+DpBalancedScheduler
+  -> SequencePackingScheduler implementation
+
+data movement, packing materialization, TP/PP broadcast
+  -> PlanExecutionEngine responsibilities
+```
+
+### PR #5191
+
+PR #5191 adds packing inside the existing Dynamic CP path. In this design:
+
+```text
+Dynamic CP placement
+  -> PlacementScheduler implementation
+
+ad hoc pack materialization inside HybridCPDataLoaderWrapper
+  -> shared PlanExecutionEngine responsibility
+```
+
+The long-term goal is to share one packing/materialization engine instead of
+duplicating pack-building logic between PR #3386 and PR #5191.
+
+## Planned Follow-up Sequence
+
+```text
+PR 1: API and design only
+PR 2: adapt current main Dynamic CP to emit ExecutionPlan
+PR 3: adapt #3386's DP-balanced packing to SequencePackingScheduler
+PR 4: compose sequence packing with Dynamic CP placement
+PR 5: implement shared execution engine and remove duplicate materialization
+PR 6: add HybridEP-specific placement/padding extensions
+```
+
+Each implementation PR should keep tests with the code it validates. The
+API-only PR can remain CPU-only because it does not create process groups or run
+distributed collectives.

--- a/megatron/core/datasets/sequence_packing/__init__.py
+++ b/megatron/core/datasets/sequence_packing/__init__.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Public planning API for sequence packing and backend placement."""
+
+from megatron.core.datasets.sequence_packing.api import (
+    ExecutionGroup,
+    ExecutionPlan,
+    PackAssignment,
+    PackDescriptor,
+    PackingConstraints,
+    PlacementKind,
+    PlacementResources,
+    PlacementScheduler,
+    PlanExecutionEngine,
+    RankGroup,
+    SequenceDescriptor,
+    SequencePackingScheduler,
+)
+
+__all__ = [
+    "ExecutionGroup",
+    "ExecutionPlan",
+    "PackAssignment",
+    "PackDescriptor",
+    "PackingConstraints",
+    "PlacementKind",
+    "PlacementResources",
+    "PlacementScheduler",
+    "PlanExecutionEngine",
+    "RankGroup",
+    "SequenceDescriptor",
+    "SequencePackingScheduler",
+]

--- a/megatron/core/datasets/sequence_packing/api.py
+++ b/megatron/core/datasets/sequence_packing/api.py
@@ -1,0 +1,318 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Planning API for sequence packing and backend placement.
+
+This module intentionally contains API types only. It does not move data,
+materialize THD tensors, create process groups, or call forward/backward
+schedules. The goal is to provide a shared contract that can be implemented by
+online schedulers, offline planners, Dynamic CP placement, static CP placement,
+HybridEP placement, and future backends.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Mapping, Optional, Protocol, Sequence, Tuple, runtime_checkable
+
+
+class PlacementKind(str, Enum):
+    """Logical backend selected for a planned pack assignment."""
+
+    DATA_PARALLEL = "data_parallel"
+    STATIC_CP = "static_cp"
+    DYNAMIC_CP = "dynamic_cp"
+    HYBRID_EP = "hybrid_ep"
+    CUSTOM = "custom"
+
+
+def _as_tuple(values: Sequence[int], field_name: str) -> Tuple[int, ...]:
+    result = tuple(int(value) for value in values)
+    if not result:
+        raise ValueError(f"{field_name} must not be empty")
+    return result
+
+
+def _validate_positive(value: int, field_name: str) -> None:
+    if value <= 0:
+        raise ValueError(f"{field_name} must be positive, got {value}")
+
+
+@dataclass(frozen=True)
+class SequenceDescriptor:
+    """Metadata for one source sequence or already-unpacked sub-sample."""
+
+    sample_id: int
+    num_tokens: int
+    padded_num_tokens: Optional[int] = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        _validate_positive(self.num_tokens, "num_tokens")
+        if self.padded_num_tokens is not None and self.padded_num_tokens < self.num_tokens:
+            raise ValueError(
+                "padded_num_tokens must be greater than or equal to num_tokens, "
+                f"got {self.padded_num_tokens} < {self.num_tokens}"
+            )
+
+    @property
+    def materialized_tokens(self) -> int:
+        """Token count the pack materializer should reserve for this sequence."""
+
+        return self.padded_num_tokens if self.padded_num_tokens is not None else self.num_tokens
+
+
+@dataclass(frozen=True)
+class PackingConstraints:
+    """Capacity and alignment constraints used by sequence-packing schedulers."""
+
+    max_tokens_per_pack: int
+    pad_to_multiple: int = 1
+    sequence_parallel_size: int = 1
+    backend_alignment: Optional[int] = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        _validate_positive(self.max_tokens_per_pack, "max_tokens_per_pack")
+        _validate_positive(self.pad_to_multiple, "pad_to_multiple")
+        _validate_positive(self.sequence_parallel_size, "sequence_parallel_size")
+        if self.backend_alignment is not None:
+            _validate_positive(self.backend_alignment, "backend_alignment")
+
+
+@dataclass(frozen=True)
+class PackDescriptor:
+    """Output of a sequence-packing scheduler.
+
+    ``sequence_lengths`` represent real token lengths. ``padded_sequence_lengths``
+    represent the lengths that should be used to materialize THD tensors when
+    per-sequence padding is required.
+    """
+
+    pack_id: int
+    sample_ids: Sequence[int]
+    sequence_lengths: Sequence[int]
+    padded_sequence_lengths: Optional[Sequence[int]] = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        sample_ids = _as_tuple(self.sample_ids, "sample_ids")
+        sequence_lengths = _as_tuple(self.sequence_lengths, "sequence_lengths")
+        if len(sample_ids) != len(sequence_lengths):
+            raise ValueError(
+                "sample_ids and sequence_lengths must have the same length, "
+                f"got {len(sample_ids)} != {len(sequence_lengths)}"
+            )
+        for length in sequence_lengths:
+            _validate_positive(length, "sequence_lengths entries")
+        object.__setattr__(self, "sample_ids", sample_ids)
+        object.__setattr__(self, "sequence_lengths", sequence_lengths)
+
+        if self.padded_sequence_lengths is not None:
+            padded_lengths = _as_tuple(self.padded_sequence_lengths, "padded_sequence_lengths")
+            if len(padded_lengths) != len(sequence_lengths):
+                raise ValueError(
+                    "padded_sequence_lengths and sequence_lengths must have the same length, "
+                    f"got {len(padded_lengths)} != {len(sequence_lengths)}"
+                )
+            for padded_length, real_length in zip(padded_lengths, sequence_lengths):
+                if padded_length < real_length:
+                    raise ValueError(
+                        "padded_sequence_lengths entries must be >= sequence_lengths entries, "
+                        f"got {padded_length} < {real_length}"
+                    )
+            object.__setattr__(self, "padded_sequence_lengths", padded_lengths)
+
+    @property
+    def total_tokens(self) -> int:
+        """Total real tokens in this pack."""
+
+        return sum(self.sequence_lengths)
+
+    @property
+    def materialized_tokens(self) -> int:
+        """Total tokens that will exist after per-sequence padding."""
+
+        lengths = self.padded_sequence_lengths or self.sequence_lengths
+        return sum(lengths)
+
+    @property
+    def cu_seqlens(self) -> Tuple[int, ...]:
+        """Cumulative real sequence lengths for THD metadata."""
+
+        return self._cumulative_lengths(self.sequence_lengths)
+
+    @property
+    def cu_seqlens_padded(self) -> Tuple[int, ...]:
+        """Cumulative padded sequence lengths for THD materialization."""
+
+        lengths = self.padded_sequence_lengths or self.sequence_lengths
+        return self._cumulative_lengths(lengths)
+
+    @staticmethod
+    def _cumulative_lengths(lengths: Sequence[int]) -> Tuple[int, ...]:
+        cursor = 0
+        cumulative = [cursor]
+        for length in lengths:
+            cursor += int(length)
+            cumulative.append(cursor)
+        return tuple(cumulative)
+
+
+@dataclass(frozen=True)
+class RankGroup:
+    """Logical rank group used by placement plans.
+
+    This type deliberately stores logical rank IDs, not concrete
+    ``torch.distributed.ProcessGroup`` objects, so plans can be serialized,
+    tested on CPU, and produced by offline planners.
+    """
+
+    group_id: str
+    ranks: Sequence[int]
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        ranks = _as_tuple(self.ranks, "ranks")
+        if len(set(ranks)) != len(ranks):
+            raise ValueError(f"ranks must be unique, got {ranks}")
+        if any(rank < 0 for rank in ranks):
+            raise ValueError(f"ranks must be non-negative, got {ranks}")
+        object.__setattr__(self, "ranks", ranks)
+
+
+@dataclass(frozen=True)
+class PlacementResources:
+    """Logical resources available to a placement scheduler."""
+
+    dp_size: int = 1
+    cp_size: int = 1
+    ep_size: int = 1
+    tp_size: int = 1
+    pp_size: int = 1
+    rank_groups: Mapping[str, RankGroup] = field(default_factory=dict)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        _validate_positive(self.dp_size, "dp_size")
+        _validate_positive(self.cp_size, "cp_size")
+        _validate_positive(self.ep_size, "ep_size")
+        _validate_positive(self.tp_size, "tp_size")
+        _validate_positive(self.pp_size, "pp_size")
+
+
+@dataclass(frozen=True)
+class PackAssignment:
+    """Placement of one pack onto logical executor ranks."""
+
+    pack_id: int
+    placement_kind: PlacementKind
+    executor_ranks: Sequence[int]
+    rank_group_id: Optional[str] = None
+    local_cp_size: Optional[int] = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        ranks = _as_tuple(self.executor_ranks, "executor_ranks")
+        if len(set(ranks)) != len(ranks):
+            raise ValueError(f"executor_ranks must be unique, got {ranks}")
+        if any(rank < 0 for rank in ranks):
+            raise ValueError(f"executor_ranks must be non-negative, got {ranks}")
+        object.__setattr__(self, "executor_ranks", ranks)
+        if self.local_cp_size is not None:
+            _validate_positive(self.local_cp_size, "local_cp_size")
+
+
+@dataclass(frozen=True)
+class ExecutionGroup:
+    """Barrier-safe group of pack assignments that can execute together."""
+
+    group_id: int
+    assignments: Sequence[PackAssignment]
+    requires_barrier_after: bool = True
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        assignments = tuple(self.assignments)
+        if not assignments:
+            raise ValueError("assignments must not be empty")
+        object.__setattr__(self, "assignments", assignments)
+
+
+@dataclass(frozen=True)
+class ExecutionPlan:
+    """Top-level plan consumed by a future shared execution engine."""
+
+    groups: Sequence[ExecutionGroup]
+    num_microbatches: Optional[int] = None
+    total_tokens: Optional[int] = None
+    sequence_square_sum: Optional[int] = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        groups = tuple(self.groups)
+        if not groups:
+            raise ValueError("groups must not be empty")
+        object.__setattr__(self, "groups", groups)
+        if self.num_microbatches is not None:
+            _validate_positive(self.num_microbatches, "num_microbatches")
+        if self.total_tokens is not None:
+            _validate_positive(self.total_tokens, "total_tokens")
+        if self.sequence_square_sum is not None:
+            _validate_positive(self.sequence_square_sum, "sequence_square_sum")
+
+    @property
+    def assignment_count(self) -> int:
+        """Number of pack assignments in all execution groups."""
+
+        return sum(len(group.assignments) for group in self.groups)
+
+    @property
+    def pack_ids(self) -> Tuple[int, ...]:
+        """Pack IDs in execution order."""
+
+        return tuple(
+            assignment.pack_id for group in self.groups for assignment in group.assignments
+        )
+
+
+@runtime_checkable
+class SequencePackingScheduler(Protocol):
+    """Generic sequence-packing planner.
+
+    Implementations can be online or offline. They should decide which source
+    sequences belong to each pack, but should not decide backend placement.
+    """
+
+    def build_packs(
+        self, sequences: Sequence[SequenceDescriptor], constraints: PackingConstraints
+    ) -> Sequence[PackDescriptor]:
+        """Return pack descriptors for the provided source sequences."""
+
+
+@runtime_checkable
+class PlacementScheduler(Protocol):
+    """Backend-specific placement planner.
+
+    Implementations decide where already-built packs execute. For example,
+    Dynamic CP maps packs to CP1/CP2/CP4 groups, while HybridEP may map packs to
+    expert-parallel resources.
+    """
+
+    def build_plan(
+        self, packs: Sequence[PackDescriptor], resources: PlacementResources
+    ) -> ExecutionPlan:
+        """Return an execution plan for the provided packs and resources."""
+
+
+@runtime_checkable
+class PlanExecutionEngine(Protocol):
+    """Future shared engine that consumes an execution plan.
+
+    The engine is expected to own data reroute, THD materialization, TP/PP
+    metadata broadcast, barriers, and eventual train/eval integration. This PR
+    defines the contract only.
+    """
+
+    def execute_plan(self, plan: ExecutionPlan, samples: Mapping[int, Any]) -> Any:
+        """Execute or materialize ``plan`` using source samples keyed by sample ID."""

--- a/tests/unit_tests/data/test_sequence_packing_api.py
+++ b/tests/unit_tests/data/test_sequence_packing_api.py
@@ -1,0 +1,130 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import pytest
+
+from megatron.core.datasets.sequence_packing import (
+    ExecutionGroup,
+    ExecutionPlan,
+    PackAssignment,
+    PackDescriptor,
+    PackingConstraints,
+    PlacementKind,
+    PlacementResources,
+    PlacementScheduler,
+    RankGroup,
+    SequenceDescriptor,
+    SequencePackingScheduler,
+)
+
+
+def test_pack_descriptor_builds_thd_metadata():
+    pack = PackDescriptor(
+        pack_id=7,
+        sample_ids=[10, 11, 12],
+        sequence_lengths=[5, 2, 4],
+        padded_sequence_lengths=[8, 4, 4],
+    )
+
+    assert pack.sample_ids == (10, 11, 12)
+    assert pack.sequence_lengths == (5, 2, 4)
+    assert pack.total_tokens == 11
+    assert pack.materialized_tokens == 16
+    assert pack.cu_seqlens == (0, 5, 7, 11)
+    assert pack.cu_seqlens_padded == (0, 8, 12, 16)
+
+
+def test_execution_plan_preserves_execution_order():
+    group0 = ExecutionGroup(
+        group_id=0,
+        assignments=[
+            PackAssignment(
+                pack_id=3,
+                placement_kind=PlacementKind.DYNAMIC_CP,
+                executor_ranks=[0, 1],
+                rank_group_id="cp2_0",
+                local_cp_size=2,
+            )
+        ],
+    )
+    group1 = ExecutionGroup(
+        group_id=1,
+        assignments=[
+            PackAssignment(
+                pack_id=4,
+                placement_kind=PlacementKind.DATA_PARALLEL,
+                executor_ranks=[2],
+            )
+        ],
+        requires_barrier_after=False,
+    )
+
+    plan = ExecutionPlan(groups=[group0, group1], num_microbatches=2)
+
+    assert plan.assignment_count == 2
+    assert plan.pack_ids == (3, 4)
+    assert plan.groups[0].requires_barrier_after is True
+    assert plan.groups[1].requires_barrier_after is False
+
+
+def test_api_rejects_invalid_shapes_and_lengths():
+    with pytest.raises(ValueError, match="num_tokens"):
+        SequenceDescriptor(sample_id=0, num_tokens=0)
+
+    with pytest.raises(ValueError, match="padded_num_tokens"):
+        SequenceDescriptor(sample_id=0, num_tokens=8, padded_num_tokens=4)
+
+    with pytest.raises(ValueError, match="same length"):
+        PackDescriptor(pack_id=0, sample_ids=[0, 1], sequence_lengths=[8])
+
+    with pytest.raises(ValueError, match="unique"):
+        RankGroup(group_id="bad", ranks=[0, 0])
+
+    with pytest.raises(ValueError, match="local_cp_size"):
+        PackAssignment(
+            pack_id=0,
+            placement_kind=PlacementKind.DYNAMIC_CP,
+            executor_ranks=[0],
+            local_cp_size=0,
+        )
+
+
+def test_scheduler_protocols_are_structural():
+    class SimplePackingScheduler:
+        def build_packs(self, sequences, constraints):
+            del constraints
+            return [
+                PackDescriptor(
+                    pack_id=0,
+                    sample_ids=[sequence.sample_id for sequence in sequences],
+                    sequence_lengths=[sequence.num_tokens for sequence in sequences],
+                )
+            ]
+
+    class SimplePlacementScheduler:
+        def build_plan(self, packs, resources):
+            assignment = PackAssignment(
+                pack_id=packs[0].pack_id,
+                placement_kind=PlacementKind.STATIC_CP,
+                executor_ranks=resources.rank_groups["cp"].ranks,
+                rank_group_id="cp",
+            )
+            return ExecutionPlan(groups=[ExecutionGroup(group_id=0, assignments=[assignment])])
+
+    packing_scheduler = SimplePackingScheduler()
+    placement_scheduler = SimplePlacementScheduler()
+
+    assert isinstance(packing_scheduler, SequencePackingScheduler)
+    assert isinstance(placement_scheduler, PlacementScheduler)
+
+    sequences = [
+        SequenceDescriptor(sample_id=0, num_tokens=5),
+        SequenceDescriptor(sample_id=1, num_tokens=7),
+    ]
+    packs = packing_scheduler.build_packs(
+        sequences, PackingConstraints(max_tokens_per_pack=16, pad_to_multiple=8)
+    )
+    resources = PlacementResources(cp_size=2, rank_groups={"cp": RankGroup("cp", [0, 1])})
+    plan = placement_scheduler.build_plan(packs, resources)
+
+    assert packs[0].cu_seqlens == (0, 5, 12)
+    assert plan.groups[0].assignments[0].executor_ranks == (0, 1)


### PR DESCRIPTION
## Summary
- Add API-only contracts for sequence packing, backend placement, and future plan execution.
- Document how current Dynamic CP, PR #3386, and PR #5191 map into a shared scheduler/engine design.
- Add CPU-only tests for the new planning dataclasses and protocol contracts.

## Test plan
- `uv run isort megatron/core/datasets/sequence_packing/api.py megatron/core/datasets/sequence_packing/__init__.py tests/unit_tests/data/test_sequence_packing_api.py`
- `uv run python -m py_compile megatron/core/datasets/sequence_packing/api.py megatron/core/datasets/sequence_packing/__init__.py tests/unit_tests/data/test_sequence_packing_api.py`
- `uv run pytest -q tests/unit_tests/data/test_sequence_packing_api.py` (blocked locally: repo unit-test conftest imports `torch`, which is not installed in this environment)

## Notes
- This PR intentionally does not change runtime behavior or wire into the existing Dynamic CP path.
- Commit was created with `-s` but not `-S` because this environment has no `gpg`/`gpg2` binary available.