### PR TITLE
Scatter embeddings for sequence parallelism in standalone LM forwards

### DIFF
--- a/megatron/core/models/gpt/gpt_model.py
+++ b/megatron/core/models/gpt/gpt_model.py
@@ -332,6 +332,12 @@ class GPTModel(LanguageModule):
                     f"input_ids shape {input_ids.shape}"
                 )
             decoder_input = self.embedding(input_ids=input_ids, position_ids=position_ids)
+            if self.config.sequence_parallel and not self.embedding.scatter_to_sequence_parallel:
+                # The embedding skips SP scatter for models whose outer wrapper scatters instead
+                # (e.g. VLM LMs); scatter here so a standalone LM forward isn't double-gathered.
+                decoder_input = tensor_parallel.scatter_to_sequence_parallel_region(
+                    decoder_input, group=self.pg_collection.tp
+                )
             if padding_mask is not None and self.config.sequence_parallel:
                 padding_mask = (
                     tensor_parallel.scatter_to_sequence_parallel_region(

--- a/megatron/core/models/hybrid/hybrid_model.py
+++ b/megatron/core/models/hybrid/hybrid_model.py
@@ -464,6 +464,13 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
                 and is_using_quantization_scales(self.config)
             ):
                 decoder_input[inference_context.padding_slice] = 0.0
+
+            if self.config.sequence_parallel and not self.embedding.scatter_to_sequence_parallel:
+                # The embedding skips SP scatter for models whose outer wrapper scatters instead
+                # (e.g. VLM LMs); scatter here so a standalone LM forward isn't double-gathered.
+                decoder_input = tensor_parallel.scatter_to_sequence_parallel_region(
+                    decoder_input, group=self.pg_collection.tp
+                )
         else:
             # intermediate stage of pipeline
             # decoder will get hidden_states from encoder.input_tensor


### PR DESCRIPTION
## What

Fix a sequence-parallel correctness bug for **standalone language-model forwards** of models whose embedding is built with `scatter_embedding_sequence_parallel=False`.

## Why

Some models build their `GPTModel` embedding with `scatter_embedding_sequence_parallel=False` so the embedding output stays **un-scattered** for a caller that merges/scatters it. The prime example is **vision-language (and omni/audio) models**: the outer multimodal model calls `language_model.embedding()` directly, merges the vision/audio embeddings with the text embeddings, and only then scatters the combined sequence for sequence parallelism (and passes it in as `decoder_input`).

When such a language model is run **standalone** — `GPTModel.forward(input_ids=..., decoder_input=None)`, e.g. distilling or PTQ-ing only the language-model tower of a VLM — that outer scatter is bypassed. Under sequence parallelism the embeddings then stay full-length on **every** TP rank, the decoder runs the full sequence, and the output-side sequence-parallel gather **doubles** the sequence. Downstream this shows up as a `TP_size × seq_length` vs `seq_length` shape mismatch.

Concretely, ModelOpt language-model distillation of a VLM (Qwen3-VL/Qwen3.5-VL, Gemma3-VL, …) at TP=2 + SP fails in the KD loss-mask step:

```
RuntimeError: The size of tensor a (32) must match the size of tensor b (16) at non-singleton dimension 0
```

(32 = TP_size(2) × seq_length(16).) Plain TP (no SP) works; standard LMs work; only the standalone-LM + SP case of these `scatter=False` models is affected.

## Fix

In `GPTModel._preprocess`, when the model embeds internally under sequence parallelism and the embedding was built **not** to scatter, scatter the sequence here:

```python
decoder_input = self.embedding(input_ids=input_ids, position_ids=position_ids)
if self.config.sequence_parallel and not self.embedding.scatter_to_sequence_parallel:
    decoder_input = tensor_parallel.scatter_to_sequence_parallel_region(decoder_input)
```

This only affects models that set `scatter_embedding_sequence_parallel=False`; standard models (`scatter=True`) are unchanged (the guard is false), and the `decoder_input`-provided path (normal VLM inference) is untouched.

## Testing

Validated on `nvcr.io/nvidia/nemo:26.06` via ModelOpt/Megatron-Bridge language-model distillation: **Gemma3-VL and Qwen3.5-VL** both pass at **TP=2 + SP** with this change (previously both failed at the loss-mask step). Single-GPU and TP-without-SP were already passing and remain so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
