### PR TITLE
Fix inter-document masking crash and NaNs with TP > 1 and micro_batch_size > 1

### DIFF
--- a/megatron/core/rerun_state_machine.py
+++ b/megatron/core/rerun_state_machine.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
 
+import copy
 import datetime
 import logging
 import math
@@ -1144,7 +1145,9 @@ class RerunDataIterator:
             return n
         n = next(self.iterable)
         if get_rerun_state_machine().get_mode() != RerunMode.DISABLED:
-            self.saved_microbatches.append(n)
+            # Shallow-copy so downstream dict-entry mutations do not
+            # corrupt the saved snapshot used for replay.
+            self.saved_microbatches.append(copy.copy(n))
         return n
 
     def rewind(self) -> None:

--- a/megatron/core/utils.py
+++ b/megatron/core/utils.py
@@ -2203,7 +2203,9 @@ def get_batch_on_this_tp_rank(
         local_cp_size = None
 
         if has_cu_seqlens or is_hybrid_cp:
-            max_seqlen = torch.empty(1, dtype=torch.int32, device=torch.cuda.current_device())
+            max_seqlen = torch.empty(
+                micro_batch_size, dtype=torch.int32, device=torch.cuda.current_device()
+            )
         if create_attention_mask_in_dataloader:
             attention_mask = torch.empty(
                 (micro_batch_size, 1, seq_length, seq_length),
@@ -2225,13 +2227,21 @@ def get_batch_on_this_tp_rank(
                 return None
 
             # cu_seqlens / cu_seqlens_padded carry the dataloader's batch dim
-            # throughout (mbs=1 for packed sequences). Allocate (1, n) so the
-            # shape on receiving ranks matches the (1, n) tensor TP rank 0 sent.
-            cu_seqlens = torch.empty((1, n), dtype=torch.int32, device=dev)
+            # (micro_batch_size, padded_len) after default_collate. Preserve
+            # the 2-D layout so flatten_batch_for_packed_sequences can merge
+            # samples correctly when micro_batch_size > 1.
+            assert n % micro_batch_size == 0, (
+                f"cu_seqlens numel ({n}) is not divisible by "
+                f"micro_batch_size ({micro_batch_size})"
+            )
+            cu_seqlens = torch.empty(
+                (micro_batch_size, n // micro_batch_size), dtype=torch.int32, device=dev
+            )
             _broadcast(cu_seqlens)
-            assert (
-                cu_seqlens.dim() == 2 and cu_seqlens.shape[0] == 1
-            ), f"Expected cu_seqlens shape (1, n), got {tuple(cu_seqlens.shape)}"
+            assert cu_seqlens.dim() == 2 and cu_seqlens.shape[0] == micro_batch_size, (
+                f"Expected cu_seqlens shape ({micro_batch_size}, "
+                f"{n // micro_batch_size}), got {tuple(cu_seqlens.shape)}"
+            )
             assert (
                 cu_seqlens.dtype == torch.int32
             ), f"Expected cu_seqlens to be of type torch.int32, got {cu_seqlens.dtype}"

--- a/tests/unit_tests/data/test_get_batch.py
+++ b/tests/unit_tests/data/test_get_batch.py
@@ -1065,3 +1065,120 @@ def test_hybrid_cp_batch(tp_size, cp_size, seq_length, create_attention_mask):
         assert hybrid_cp_group is None
 
     Utils.destroy_model_parallel()
+
+
+def create_inter_document_masking_data_iterator(seq_length: int = 1024, micro_batch_size: int = 2):
+    """Create a mock data iterator for inter-document masking with mbs > 1.
+
+    Mimics what default_collate produces from GPTDataset with
+    inter_document_masking=True: each sample has its own padded cu_seqlens
+    row, collated into (micro_batch_size, padded_len).
+    """
+    padded_len = seq_length + 1
+    cu_seqlens = torch.full((micro_batch_size, padded_len), seq_length, dtype=torch.int32)
+    max_seqlens = []
+
+    for i in range(micro_batch_size):
+        n_docs = torch.randint(2, 6, (1,)).item()
+        boundaries = sorted(torch.randint(1, seq_length, (n_docs - 1,)).tolist())
+        boundaries = [0] + boundaries + [seq_length]
+        for j, val in enumerate(boundaries):
+            cu_seqlens[i, j] = val
+        seg_lengths = [boundaries[k + 1] - boundaries[k] for k in range(len(boundaries) - 1)]
+        max_seqlens.append(max(seg_lengths))
+
+    max_seqlen = torch.tensor(max_seqlens, dtype=torch.int32)
+
+    tokens = torch.randint(0, 10000, (micro_batch_size, seq_length), dtype=torch.int64)
+    labels = torch.randint(0, 10000, (micro_batch_size, seq_length), dtype=torch.int64)
+    loss_mask = torch.ones(micro_batch_size, seq_length, dtype=torch.float32)
+    position_ids = (
+        torch.arange(seq_length, dtype=torch.int64)
+        .unsqueeze(0)
+        .expand(micro_batch_size, -1)
+        .clone()
+    )
+
+    batch = {
+        "tokens": tokens,
+        "labels": labels,
+        "loss_mask": loss_mask,
+        "position_ids": position_ids,
+        "cu_seqlens": cu_seqlens,
+        "max_seqlen": max_seqlen,
+    }
+    return iter([batch])
+
+
+@pytest.mark.parametrize("tp_size", [1, 2, 4])
+@pytest.mark.parametrize("micro_batch_size", [1, 2, 4])
+@pytest.mark.parametrize("seq_length", [1024])
+def test_inter_document_masking_multi_mbs_batch(tp_size, micro_batch_size, seq_length):
+    """Verify cu_seqlens is correctly broadcast and merged when mbs > 1 with TP > 1.
+
+    Regression test: the receiver in get_batch_on_this_tp_rank used to allocate
+    cu_seqlens as (1, numel) instead of (mbs, padded_len), which caused
+    flatten_batch_for_packed_sequences to silently drop all samples after the
+    first on non-zero TP ranks.
+    """
+    if tp_size > torch.cuda.device_count():
+        pytest.skip(
+            f"Skipping test because tp_size > torch.cuda.device_count() "
+            f"({tp_size} > {torch.cuda.device_count()})"
+        )
+
+    dp_size = int(os.environ.get("WORLD_SIZE", 1)) // tp_size
+    global_batch_size = micro_batch_size * dp_size
+    args = initialize_test_environment(
+        tp_size,
+        pp_size=1,
+        cp_size=1,
+        seq_length=seq_length,
+        micro_batch_size=micro_batch_size,
+        global_batch_size=global_batch_size,
+        sft=False,
+    )
+    args.dataloader_inter_document_masking = True
+
+    data_iterator = None
+    if mpu.get_tensor_model_parallel_rank() == 0:
+        data_iterator = create_inter_document_masking_data_iterator(
+            seq_length, micro_batch_size=micro_batch_size
+        )
+
+    (
+        attention_mask,
+        cu_seqlens,
+        cu_seqlens_padded,
+        hybrid_cp_group,
+        labels,
+        local_cp_size,
+        loss_mask,
+        max_seqlen,
+        position_ids,
+        tokens,
+    ) = get_batch(data_iterator)
+
+    total_tokens = micro_batch_size * seq_length
+
+    assert tokens is not None
+    assert tokens.shape == (1, total_tokens)
+    assert labels is not None
+    assert labels.shape == (1, total_tokens)
+    assert loss_mask is not None
+    assert loss_mask.shape == (1, total_tokens)
+    assert position_ids is not None
+    assert position_ids.shape == (1, total_tokens)
+
+    assert cu_seqlens is not None
+    assert cu_seqlens.dim() == 2
+    assert cu_seqlens.shape[0] == 1
+    assert cu_seqlens.dtype == torch.int32
+    assert cu_seqlens[0, 0].item() == 0
+    assert cu_seqlens[0, -1].item() == total_tokens
+    assert cu_seqlens.shape[1] >= micro_batch_size + 1
+
+    assert max_seqlen is not None
+    assert max_seqlen.numel() == 1
+
+    Utils.destroy_model_parallel()


### PR DESCRIPTION
## Summary
- Fix receiver in `get_batch_on_this_tp_rank` to allocate `cu_seqlens` as `(micro_batch_size, n // micro_batch_size)` instead of `(1, n)`, preserving the batch layout when `micro_batch_size > 1`.
- Fix receiver to allocate `max_seqlen` as `(micro_batch_size,)` instead of `(1,)`, matching the sender's shape after `default_collate`.
- When mbs > 1 with TP > 1, the collapsed shape caused `flatten_batch_for_packed_sequences` to silently drop all samples after the first on non-zero TP ranks, leading to wrong `seq_idx` shapes (Mamba crash) and wrong attention boundaries (NaNs in backward for Transformers).
- Shallow-copy microbatches in `RerunDataIterator` so downstream dict-entry mutations (e.g. from `flatten_batch_for_packed_sequences`) do not corrupt saved snapshots used for replay.
- Add regression test `test_inter_document_masking_multi_mbs_batch` covering `tp_size ∈ {1, 2, 4}` × `micro_batch_size ∈ {1, 2, 4}` with inter-document masking.

## Test plan
- [x] Existing `test_sft_batch`, `test_inter_document_masking_batch`, `test_pretrain_batch`, and `test_hybrid_cp_batch` continue to pass (mbs=1 behavior unchanged).
- [x] New `test_inter_document_masking_multi_mbs_batch` passes with TP > 1 and mbs > 1.
- [x] Mamba + inter-document masking + TP > 1 no longer crashes with `seq_idx must have shape (batch_size, seqlen)`.
- [x] Transformer + inter-document masking + TP > 1 + mbs > 1 no longer produces NaNs in backward.
- [x] `RerunDataIterator` `copy.copy` fix: Confirm the validation rerun completes without assertion errors with `--rerun-mode validate_results --dataloader-inter-document-masking --micro-batch-size >1 --tensor-model-parallel-size >1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)