### PR TITLE
[Dev] Fix FSDP backward hooks for TE-fused experts

### DIFF
--- a/megatron/core/transformer/moe/experts.py
+++ b/megatron/core/transformer/moe/experts.py
@@ -577,6 +577,7 @@ class TEGroupedMLP(MegatronModule):
 
         # Emulate submodule pre-forward hooks
         ops.register_forward_pre_hook(self._make_fused_impl_pre_forward_hook())
+        ops.register_forward_hook(self._make_fused_impl_post_forward_hook())
 
         return ops
 
@@ -604,6 +605,27 @@ class TEGroupedMLP(MegatronModule):
                         )
 
         return forward_pre_hook
+
+    def _make_fused_impl_post_forward_hook(self) -> Callable:
+        """Forward submodule hooks to the fused output.
+
+        Megatron FSDP uses GroupedLinear forward hooks to attach parameter
+        all-gathers immediately before backward. The op fuser bypasses the
+        GroupedLinear module calls, so attach those hooks to the fused MLP output.
+        """
+
+        def forward_post_hook(_module, _inputs, output):
+            for submodule in chain(self.linear_fc1.modules(), self.linear_fc2.modules()):
+                for hook_id, hook in submodule._forward_hooks.items():
+                    if hook_id in submodule._forward_hooks_with_kwargs:
+                        ret = hook(submodule, (), {}, output)
+                    else:
+                        ret = hook(submodule, (), output)
+                    if ret is not None:
+                        output = ret
+            return output
+
+        return forward_post_hook
 
     def _fused_forward(
         self,

--- a/tests/unit_tests/transformer/moe/test_grouped_mlp.py
+++ b/tests/unit_tests/transformer/moe/test_grouped_mlp.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import argparse
 import sys
@@ -88,6 +88,9 @@ def test_make_fused_ops_reuses_grouped_linear_weights_on_meta_device(monkeypatch
         def register_forward_pre_hook(self, hook):
             self.forward_pre_hook = hook
 
+        def register_forward_hook(self, hook):
+            self.forward_post_hook = hook
+
     fake_te = SimpleNamespace(
         pytorch=SimpleNamespace(
             GroupedLinear=FakeGroupedLinear,
@@ -148,6 +151,7 @@ def test_make_fused_ops_reuses_grouped_linear_weights_on_meta_device(monkeypatch
     assert ops[2].device == "meta"
     assert ops[2].weight is module.linear_fc2.weight
     assert hasattr(ops, "forward_pre_hook")
+    assert hasattr(ops, "forward_post_hook")
 
 
 def test_fused_forward_caches_ops_and_forwards_expected_arguments():
@@ -254,6 +258,34 @@ def test_make_fused_impl_pre_forward_hook_rejects_input_modifying_hook():
         hook(object())
 
 
+def test_make_fused_impl_post_forward_hook_dispatches_submodule_hooks():
+    module = TEGroupedMLP.__new__(TEGroupedMLP)
+    torch.nn.Module.__init__(module)
+    fc1_child = torch.nn.Linear(2, 2)
+    fc2_child = torch.nn.Linear(2, 2)
+    module.linear_fc1 = torch.nn.Sequential(fc1_child)
+    module.linear_fc2 = torch.nn.Sequential(fc2_child)
+
+    calls = []
+
+    def fc1_hook(submodule, _inputs, output):
+        calls.append(("fc1", submodule))
+        return output + 1
+
+    def fc2_hook(submodule, _inputs, _kwargs, output):
+        calls.append(("fc2", submodule))
+        return output + 1
+
+    fc1_child.register_forward_hook(fc1_hook)
+    fc2_child.register_forward_hook(fc2_hook, with_kwargs=True)
+
+    hook = module._make_fused_impl_post_forward_hook()
+    output = hook(None, (), torch.zeros(2, 2))
+
+    assert {label for label, _ in calls} == {"fc1", "fc2"}
+    torch.testing.assert_close(output, torch.full_like(output, 2))
+
+
 def test_make_fused_ops_handles_single_grouped_weight_for_fc1(monkeypatch):
     class FakeGroupedLinear(torch.nn.Module):
         def __init__(
@@ -294,6 +326,9 @@ def test_make_fused_ops_handles_single_grouped_weight_for_fc1(monkeypatch):
     class FakeSequential(list):
         def register_forward_pre_hook(self, hook):
             self.forward_pre_hook = hook
+
+        def register_forward_hook(self, hook):
+            self.forward_post_hook = hook
 
     fake_te = SimpleNamespace(
         pytorch=SimpleNamespace(
@@ -419,6 +454,9 @@ def _make_fake_te_namespace():
     class FakeSequential(list):
         def register_forward_pre_hook(self, hook):
             self.forward_pre_hook = hook
+
+        def register_forward_hook(self, hook):
+            self.forward_post_hook = hook
 
     return (
         SimpleNamespace(


### PR DESCRIPTION
## Summary

- forward the original `GroupedLinear` post-forward hooks to the TE op-fuser output
- preserve Megatron-FSDP pre-backward parameter all-gathers when fused expert execution bypasses the original submodule `forward()` calls
- cover both regular and `with_kwargs=True` post-forward hooks in the grouped-MLP unit tests

## Root cause

The TE op-fuser path already forwards the original `GroupedLinear` pre-forward hooks, but it bypasses their post-forward hooks. Megatron-FSDP uses those post-forward hooks to attach pre-backward all-gathers. With `optim_grads_params`, expert parameters released after forward could therefore remain unavailable when deferred grouped-wgrad ran, resulting in an illegal CUDA memory access.

The non-op-fuser path continues to invoke `GroupedLinear.forward()` normally and is unaffected.

## Test plan

- `CHECK_ONLY=true BASE_REF=dev bash tools/autoformat.sh` (black, isort, pylint, and ruff passed)
- `python tools/check_copyright.py megatron/core/transformer/moe/experts.py tests/unit_tests/transformer/moe/test_grouped_mlp.py`
- Qwen3-235B, 94 layers, TP1/PP1/EP64, 128 GB200 GPUs, MBS=1, MXFP8, Megatron-FSDP `optim_grads_params`, paged stash, TE op fuser, and full-iteration CUDA graph: job `20260702-082849-85c1` completed 9 stable iterations with finite loss/grad norm, median 861.45 TFLOP/s/GPU, and 92,006 MB peak allocated memory

The CI-faithful target unit-test launch did not reach pytest because the Lyris login node could not import `mcore-ci-dev:latest` without registry/Enroot credentials; upstream CI should execute the added test.