### PR TITLE
Add microbatch context helper

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/__init__.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/__init__.py
@@ -18,12 +18,4 @@ from .dbuffer import DBuffer
 from .fully_shard import fully_shard
 from .placement import Flat, Partial, Placement, Placements, Replicate
 
-__all__ = [
-    "DBuffer",
-    "Flat",
-    "Partial",
-    "Placement",
-    "Placements",
-    "Replicate",
-    "fully_shard",
-]
+__all__ = ["DBuffer", "Flat", "Partial", "Placement", "Placements", "Replicate", "fully_shard"]

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/__init__.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/__init__.py
@@ -15,7 +15,16 @@
 """Experimental Megatron-FSDP implementation."""
 
 from .dbuffer import DBuffer
-from .fully_shard import fully_shard
+from .fully_shard import fully_shard, microbatch
 from .placement import Flat, Partial, Placement, Placements, Replicate
 
-__all__ = ["DBuffer", "Flat", "Partial", "Placement", "Placements", "Replicate", "fully_shard"]
+__all__ = [
+    "DBuffer",
+    "Flat",
+    "Partial",
+    "Placement",
+    "Placements",
+    "Replicate",
+    "fully_shard",
+    "microbatch",
+]

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/__init__.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/__init__.py
@@ -16,15 +16,11 @@
 
 from .dbuffer import DBuffer
 from .fully_shard import fully_shard
-from .module import FsdpModule
-from .parameter_group import FsdpParameterGroup
 from .placement import Flat, Partial, Placement, Placements, Replicate
 
 __all__ = [
     "DBuffer",
     "Flat",
-    "FsdpModule",
-    "FsdpParameterGroup",
     "Partial",
     "Placement",
     "Placements",

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
@@ -21,6 +21,8 @@ from ..mixed_precision import MixedPrecisionPolicy
 from .module import FsdpModule
 from .placement import Placements
 
+__all__ = ["fully_shard"]
+
 
 def fully_shard(
     module: nn.Module,

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
@@ -14,11 +14,14 @@
 
 """Minimal Megatron-FSDP fully_shard entrypoint."""
 
+from collections.abc import Iterator
+from contextlib import contextmanager
+
 from torch import nn
 from torch.distributed import DeviceMesh
 
 from ..mixed_precision import MixedPrecisionPolicy
-from .module import FsdpModule
+from .module import FsdpContext, FsdpModule
 from .placement import Placements
 
 
@@ -63,9 +66,40 @@ def fully_shard(
         raise
 
 
+@contextmanager
+def microbatch(module: nn.Module, is_last: bool) -> Iterator[None]:
+    """Scope experimental FSDP state to one microbatch.
+
+    Args:
+        module: Module tree whose experimental FSDP roots should use this microbatch state.
+        is_last: Whether forwards in this scope are for the last microbatch.
+    """
+    contexts: list[FsdpContext] = []
+    _collect_fsdp_contexts(module, contexts)
+    previous_states = [(context, context.is_last_microbatch) for context in contexts]
+    for context in contexts:
+        context.is_last_microbatch = is_last
+
+    try:
+        yield
+    finally:
+        for context, is_last_microbatch in previous_states:
+            context.is_last_microbatch = is_last_microbatch
+
+
 def _attach_mixin(module: nn.Module) -> None:
     if isinstance(module, FsdpModule):
         return
     module_cls = module.__class__
     fsdp_cls = type(f"ExperimentalFsdp{module_cls.__name__}", (FsdpModule, module_cls), {})
     module.__class__ = fsdp_cls
+
+
+def _collect_fsdp_contexts(module: nn.Module, contexts: list[FsdpContext]) -> None:
+    if isinstance(module, FsdpModule):
+        module._lazy_init_context()
+        contexts.append(module.context)
+        return
+
+    for child in module.children():
+        _collect_fsdp_contexts(child, contexts)

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
@@ -21,8 +21,6 @@ from ..mixed_precision import MixedPrecisionPolicy
 from .module import FsdpModule
 from .placement import Placements
 
-__all__ = ["fully_shard"]
-
 
 def fully_shard(
     module: nn.Module,

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -114,7 +114,27 @@ class FsdpModule:
         self._register_hooks()
 
     def _lazy_init_context(self) -> None:
-        """Initialize the shared runtime context for this FSDP root subtree."""
+        """Initialize one shared runtime context for this FSDP root subtree.
+
+        MFSDP v2 requires users to apply ``fully_shard`` bottom-up, so child FSDP
+        modules are constructed before their eventual root module is constructed.
+        This method resolves the root lazily on the first forward through the
+        outermost FSDP module and shares that one context with every FSDP
+        descendant.
+
+        Alternatives considered:
+        - Eagerly initialize contexts during ``fully_shard``. When a parent is
+          sharded, we could create a new root context and reassign it to all
+          descendant FSDP modules. This creates transient child contexts that are
+          never used if the parent is later sharded, and each parent shard must
+          walk its descendants again, making nested sharding quadratic.
+        - Store an ``is_root`` field on each FSDP module. ``fully_shard`` could
+          mark newly sharded modules as roots and clear that flag on descendant
+          FSDP modules when a parent is sharded. This avoids creating unused
+          contexts but moves root tracking onto every FSDP module, adding
+          per-module state that must stay consistent with the final sharded
+          module hierarchy.
+        """
         if self._context is not None:
             return
 

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -14,8 +14,6 @@
 
 """Module mixin for the minimal Megatron-FSDP path."""
 
-import dataclasses
-from collections import deque
 from collections.abc import Callable
 from typing import cast
 
@@ -28,49 +26,23 @@ from .parameter_group import FsdpParameterGroup, contained_in_parameter_group
 from .placement import MeshAxis, Placements
 
 
-@dataclasses.dataclass(frozen=True)
-class DelayedRelease:
-    """A module whose unsharded storage can be released after its consumer event."""
-
-    consumer_event: torch.cuda.Event | None
-    module: "FsdpModule"
-
-
 class FsdpContext:
-    """Runtime stream and release scheduler shared by one FSDP subtree."""
+    """Runtime state shared by one experimental FSDP subtree."""
 
-    allgather_stream: torch.cuda.Stream
-    delayed_releases: deque[DelayedRelease]
+    # HFSDP/HSDP need explicit last-microbatch state. First-microbatch state is
+    # unnecessary because it can be detected when ``model_weight``, after syncing
+    # from ``main_weight``, has placements different from ``Placements.optimizer``.
+    is_last_microbatch: bool
     root_module: "FsdpModule"
 
-    def __init__(self, device: torch.device, root_module: "FsdpModule") -> None:
-        """Create rank-local stream state for a root FSDP subtree.
+    def __init__(self, root_module: "FsdpModule") -> None:
+        """Create rank-local runtime state for a root FSDP subtree.
 
         Args:
-            device: Device on which this context schedules communication.
             root_module: Outermost module that owns this context.
         """
         self.root_module = root_module
-        self.delayed_releases = deque()
-        with torch.cuda.device(device):
-            self.allgather_stream = torch.cuda.Stream()
-
-    def enqueue_release(self, module: "FsdpModule") -> None:
-        """Queue a module's unsharded storage for delayed release."""
-        consumer_event = torch.cuda.current_stream(self.allgather_stream.device).record_event()
-        self.delayed_releases.append(DelayedRelease(consumer_event=consumer_event, module=module))
-
-    def drain_delayed_releases(self, target_length: int) -> None:
-        """Release queued module storages FIFO until the queue reaches ``target_length``."""
-        if target_length < 0:
-            raise ValueError(f"target_length must be non-negative, got {target_length}.")
-
-        while len(self.delayed_releases) > target_length:
-            delayed_release = self.delayed_releases.popleft()
-            with torch.cuda.stream(self.allgather_stream):
-                if delayed_release.consumer_event is not None:
-                    self.allgather_stream.wait_event(delayed_release.consumer_event)
-                delayed_release.module.release_unsharded_storage()
+        self.is_last_microbatch = True
 
 
 class FsdpModule:
@@ -138,9 +110,7 @@ class FsdpModule:
         if self._context is not None:
             return
 
-        fsdp_context = FsdpContext(
-            device=self._parameter_groups[0].main_weight.device, root_module=self
-        )
+        context = FsdpContext(root_module=self)
         for submodule in cast(nn.Module, self).modules():
             if not isinstance(submodule, FsdpModule):
                 continue
@@ -149,7 +119,7 @@ class FsdpModule:
                     "FSDP context is already initialized for a descendant module. "
                     "Run forward through the root FSDP module first."
                 )
-            submodule._context = fsdp_context
+            submodule._context = context
 
     @property
     def context(self) -> FsdpContext:
@@ -188,61 +158,30 @@ class FsdpModule:
         """Prepare full parameters for forward compute."""
         self._lazy_init_context()
         self._ready_grad_parameters.clear()
-        if self.is_root():
-            allgather_stream = self.context.allgather_stream
-            allgather_stream.wait_stream(torch.cuda.current_stream(allgather_stream.device))
-        self._unshard_parameter_groups(sync_model_weight=True)
-
-    def _unshard_parameter_groups(self, *, sync_model_weight: bool) -> None:
-        """Materialize full parameters for this FSDP unit."""
-        self.context.drain_delayed_releases(target_length=1)
-
-        allgather_stream = self.context.allgather_stream
-        current_stream = torch.cuda.current_stream(allgather_stream.device)
-
-        with torch.cuda.stream(allgather_stream):
-            for group in self._parameter_groups:
-                if sync_model_weight:
-                    # TODO: After NVIDIA/Megatron-LM#5411 lands, move this sync to the
-                    # optimizer post-step hook instead of running it every microbatch.
-                    group.sync_model_weight_from_main_weight()
-                group.unshard_parameters()
-        current_stream.wait_stream(allgather_stream)
+        for group in self._parameter_groups:
+            group.sync_model_weight_from_main_weight()
+            group.unshard_parameters()
 
     def post_forward(self) -> None:
         """Return parameters to their sharded resting state after forward compute."""
-        self._reshard_parameter_groups()
-        self.context.enqueue_release(self)
-        if self.is_root():
-            self.context.drain_delayed_releases(target_length=0)
-
-    def _reshard_parameter_groups(self) -> None:
         for group in self._parameter_groups:
             group.reshard_parameters()
 
     def pre_backward(self) -> None:
         """Prepare full parameters for backward compute."""
-        self._unshard_parameter_groups(sync_model_weight=False)
+        for group in self._parameter_groups:
+            group.unshard_parameters()
 
     def post_backward(self) -> None:
         """Reduce gradients and return parameters to their sharded resting state."""
         for group in self._parameter_groups:
             if group.requires_grad:
                 group.reduce_gradients()
-        self._reshard_parameter_groups()
-        self.context.enqueue_release(self)
-        if self.is_root():
-            self.context.drain_delayed_releases(target_length=0)
+            group.reshard_parameters()
         self._ready_grad_parameters.clear()
 
-    def release_unsharded_storage(self) -> None:
-        """Release unsharded storage owned by this FSDP unit."""
-        for group in self._parameter_groups:
-            group.release_unsharded_storage()
-
-    @property
     def parameter_groups(self) -> tuple[FsdpParameterGroup, ...]:
-        """Parameter groups owned by this FSDP unit."""
+        """Return parameter groups owned by this FSDP unit."""
         return self._parameter_groups
 
 

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -14,6 +14,8 @@
 
 """Module mixin for the minimal Megatron-FSDP path."""
 
+import dataclasses
+from collections import deque
 from collections.abc import Callable
 from typing import cast
 
@@ -26,10 +28,56 @@ from .parameter_group import FsdpParameterGroup, contained_in_parameter_group
 from .placement import MeshAxis, Placements
 
 
+@dataclasses.dataclass(frozen=True)
+class DelayedRelease:
+    """A module whose unsharded storage can be released after its consumer event."""
+
+    consumer_event: torch.cuda.Event | None
+    module: "FsdpModule"
+
+
+class FsdpContext:
+    """Runtime stream and release scheduler shared by one FSDP subtree."""
+
+    allgather_stream: torch.cuda.Stream
+    delayed_releases: deque[DelayedRelease]
+    root_module: "FsdpModule"
+
+    def __init__(self, device: torch.device, root_module: "FsdpModule") -> None:
+        """Create rank-local stream state for a root FSDP subtree.
+
+        Args:
+            device: Device on which this context schedules communication.
+            root_module: Outermost module that owns this context.
+        """
+        self.root_module = root_module
+        self.delayed_releases = deque()
+        with torch.cuda.device(device):
+            self.allgather_stream = torch.cuda.Stream()
+
+    def enqueue_release(self, module: "FsdpModule") -> None:
+        """Queue a module's unsharded storage for delayed release."""
+        consumer_event = torch.cuda.current_stream(self.allgather_stream.device).record_event()
+        self.delayed_releases.append(DelayedRelease(consumer_event=consumer_event, module=module))
+
+    def drain_delayed_releases(self, target_length: int) -> None:
+        """Release queued module storages FIFO until the queue reaches ``target_length``."""
+        if target_length < 0:
+            raise ValueError(f"target_length must be non-negative, got {target_length}.")
+
+        while len(self.delayed_releases) > target_length:
+            delayed_release = self.delayed_releases.popleft()
+            with torch.cuda.stream(self.allgather_stream):
+                if delayed_release.consumer_event is not None:
+                    self.allgather_stream.wait_event(delayed_release.consumer_event)
+                delayed_release.module.release_unsharded_storage()
+
+
 class FsdpModule:
     """Mixin attached to modules managed by the minimal FSDP path."""
 
     _parameter_groups: tuple[FsdpParameterGroup, ...]
+    _context: FsdpContext | None
     _ready_grad_parameters: set[nn.Parameter]
     _num_training_parameters: int
 
@@ -41,6 +89,7 @@ class FsdpModule:
         use_symm_mem: bool = False,
     ) -> None:
         """Initialize FSDP runtime state on an already-constructed module."""
+        self._context = None
         owned_parameters = _collect_owned_parameters(self)
         axis_indices = tuple(_axis_index(mesh, axis) for axis in placements.dp_axes)
         assert axis_indices == tuple(
@@ -63,6 +112,34 @@ class FsdpModule:
             len(group.sharded_parameters) for group in self._parameter_groups if group.requires_grad
         )
         self._register_hooks()
+
+    def _lazy_init_context(self) -> None:
+        """Initialize the shared runtime context for this FSDP root subtree."""
+        if self._context is not None:
+            return
+
+        fsdp_context = FsdpContext(
+            device=self._parameter_groups[0].main_weight.device, root_module=self
+        )
+        for submodule in cast(nn.Module, self).modules():
+            if not isinstance(submodule, FsdpModule):
+                continue
+            if submodule._context is not None:
+                raise RuntimeError(
+                    "FSDP context is already initialized for a descendant module. "
+                    "Run forward through the root FSDP module first."
+                )
+            submodule._context = fsdp_context
+
+    @property
+    def context(self) -> FsdpContext:
+        """Return the initialized runtime context."""
+        assert self._context is not None
+        return self._context
+
+    def is_root(self) -> bool:
+        """Return whether this module is the outermost FSDP unit in its context."""
+        return self.context.root_module is self
 
     def _register_hooks(self) -> None:
         module = cast(nn.Module, self)
@@ -89,31 +166,63 @@ class FsdpModule:
 
     def pre_forward(self) -> None:
         """Prepare full parameters for forward compute."""
+        self._lazy_init_context()
         self._ready_grad_parameters.clear()
-        for group in self._parameter_groups:
-            group.sync_model_weight_from_main_weight()
-            group.unshard_parameters()
+        if self.is_root():
+            allgather_stream = self.context.allgather_stream
+            allgather_stream.wait_stream(torch.cuda.current_stream(allgather_stream.device))
+        self._unshard_parameter_groups(sync_model_weight=True)
+
+    def _unshard_parameter_groups(self, *, sync_model_weight: bool) -> None:
+        """Materialize full parameters for this FSDP unit."""
+        self.context.drain_delayed_releases(target_length=1)
+
+        allgather_stream = self.context.allgather_stream
+        current_stream = torch.cuda.current_stream(allgather_stream.device)
+
+        with torch.cuda.stream(allgather_stream):
+            for group in self._parameter_groups:
+                if sync_model_weight:
+                    # TODO: After NVIDIA/Megatron-LM#5411 lands, move this sync to the
+                    # optimizer post-step hook instead of running it every microbatch.
+                    group.sync_model_weight_from_main_weight()
+                group.unshard_parameters()
+        current_stream.wait_stream(allgather_stream)
 
     def post_forward(self) -> None:
         """Return parameters to their sharded resting state after forward compute."""
+        self._reshard_parameter_groups()
+        self.context.enqueue_release(self)
+        if self.is_root():
+            self.context.drain_delayed_releases(target_length=0)
+
+    def _reshard_parameter_groups(self) -> None:
         for group in self._parameter_groups:
             group.reshard_parameters()
 
     def pre_backward(self) -> None:
         """Prepare full parameters for backward compute."""
-        for group in self._parameter_groups:
-            group.unshard_parameters()
+        self._unshard_parameter_groups(sync_model_weight=False)
 
     def post_backward(self) -> None:
         """Reduce gradients and return parameters to their sharded resting state."""
         for group in self._parameter_groups:
             if group.requires_grad:
                 group.reduce_gradients()
-            group.reshard_parameters()
+        self._reshard_parameter_groups()
+        self.context.enqueue_release(self)
+        if self.is_root():
+            self.context.drain_delayed_releases(target_length=0)
         self._ready_grad_parameters.clear()
 
+    def release_unsharded_storage(self) -> None:
+        """Release unsharded storage owned by this FSDP unit."""
+        for group in self._parameter_groups:
+            group.release_unsharded_storage()
+
+    @property
     def parameter_groups(self) -> tuple[FsdpParameterGroup, ...]:
-        """Return parameter groups owned by this FSDP unit."""
+        """Parameter groups owned by this FSDP unit."""
         return self._parameter_groups
 
 

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -232,12 +232,9 @@ class FsdpParameterGroup:
     def reshard_parameters(self) -> None:
         """Install sharded DTensor parameters on the owning modules."""
         self._switch_to_sharded_parameters()
-        # At post-backward time, replacing unsharded parameter .data with size-0
-        # empty tensors would also be safe: autograd has consumed the saved
-        # forward views. That alternative is not much cleaner than releasing
-        # this storage, and splitting post-forward and post-backward reshard
-        # behavior would make the caller code less clean, so keep the shared
-        # storage-release path.
+
+    def release_unsharded_storage(self) -> None:
+        """Release this group's full-parameter storage."""
         self._unsharded_model_weight.release_storage()
 
     def reduce_gradients(self) -> None:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -235,12 +235,14 @@ class FsdpParameterGroup:
 
     def release_unsharded_storage(self) -> None:
         """Release this group's full-parameter storage."""
-        # At post-backward time, replacing unsharded parameter .data with size-0
-        # empty tensors would also be safe: autograd has consumed the saved
-        # forward views. That alternative is not much cleaner than releasing
-        # this storage, and splitting post-forward and post-backward reshard
-        # behavior would make the caller code less clean, so keep the shared
-        # storage-release path.
+        # This method is shared by the post-forward and post-backward release
+        # paths. Post-forward must release storage because autograd may have
+        # saved forward views into the unsharded parameters. Post-backward could
+        # replace unsharded parameter .data with size-0 empty tensors, instead
+        # of releasing storage, because autograd has consumed those saved views.
+        # That alternative is not much cleaner, and splitting post-forward and
+        # post-backward reshard behavior would make the caller code less clean,
+        # so keep the shared storage-release path.
         self._unsharded_model_weight.release_storage()
 
     def reduce_gradients(self) -> None:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -235,6 +235,12 @@ class FsdpParameterGroup:
 
     def release_unsharded_storage(self) -> None:
         """Release this group's full-parameter storage."""
+        # At post-backward time, replacing unsharded parameter .data with size-0
+        # empty tensors would also be safe: autograd has consumed the saved
+        # forward views. That alternative is not much cleaner than releasing
+        # this storage, and splitting post-forward and post-backward reshard
+        # behavior would make the caller code less clean, so keep the shared
+        # storage-release path.
         self._unsharded_model_weight.release_storage()
 
     def reduce_gradients(self) -> None:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -232,17 +232,12 @@ class FsdpParameterGroup:
     def reshard_parameters(self) -> None:
         """Install sharded DTensor parameters on the owning modules."""
         self._switch_to_sharded_parameters()
-
-    def release_unsharded_storage(self) -> None:
-        """Release this group's full-parameter storage."""
-        # This method is shared by the post-forward and post-backward release
-        # paths. Post-forward must release storage because autograd may have
-        # saved forward views into the unsharded parameters. Post-backward could
-        # replace unsharded parameter .data with size-0 empty tensors, instead
-        # of releasing storage, because autograd has consumed those saved views.
-        # That alternative is not much cleaner, and splitting post-forward and
-        # post-backward reshard behavior would make the caller code less clean,
-        # so keep the shared storage-release path.
+        # At post-backward time, replacing unsharded parameter .data with size-0
+        # empty tensors would also be safe: autograd has consumed the saved
+        # forward views. That alternative is not much cleaner than releasing
+        # this storage, and splitting post-forward and post-backward reshard
+        # behavior would make the caller code less clean, so keep the shared
+        # storage-release path.
         self._unsharded_model_weight.release_storage()
 
     def reduce_gradients(self) -> None:

--- a/tests/unit_tests/distributed/megatron_fsdp/test_context.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_context.py
@@ -83,7 +83,7 @@ def test_two_child_subtrees_then_parent_collapse_to_one_context(distributed_setu
 
 
 def test_sibling_roots_without_parent_keep_separate_contexts(distributed_setup):
-    """Independent FSDP roots should not share runtime scheduling state."""
+    """Independent FSDP roots should not share runtime state."""
     device = distributed_setup.device
 
     mesh = init_device_mesh(device.type, (distributed_setup.world_size,))

--- a/tests/unit_tests/distributed/megatron_fsdp/test_context.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_context.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Unit tests for experimental Megatron-FSDP runtime contexts."""
+
+import torch
+from torch import nn
+from torch.distributed.device_mesh import init_device_mesh
+
+from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
+    Flat,
+    Placements,
+    fully_shard,
+)
+
+
+class NestedModel(nn.Module):
+    """Model with direct and child-owned parameters."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.bias = nn.Parameter(torch.ones(4))
+        self.inner = nn.Linear(4, 4, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the nested model."""
+        return self.inner(x) + self.bias
+
+
+class MultiChildModel(nn.Module):
+    """Model with direct parameters and multiple child FSDP units."""
+
+    def __init__(self, dim: int, num_children: int) -> None:
+        super().__init__()
+        self.bias = nn.Parameter(torch.ones(dim))
+        self.layers = nn.ModuleList([nn.Linear(dim, dim, bias=False) for _ in range(num_children)])
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run through every child layer with a root-owned bias."""
+        x = x + self.bias
+        for layer in self.layers:
+            x = torch.relu(layer(x))
+        return x
+
+
+def _flat_placements() -> Placements:
+    return Placements(dp_axes=[0], parameter=[Flat()], gradient=[Flat()], optimizer=[Flat()])
+
+
+def test_child_then_parent_share_one_context(distributed_setup):
+    """A parent FSDP unit should lazily create one context for its subtree."""
+    device = distributed_setup.device
+
+    mesh = init_device_mesh(device.type, (distributed_setup.world_size,))
+    model = NestedModel().to(device)
+
+    fully_shard(model.inner, mesh=mesh, placements=_flat_placements())
+    fully_shard(model, mesh=mesh, placements=_flat_placements())
+
+    with torch.no_grad():
+        model(torch.ones(2, 4, device=device))
+
+    assert model.inner.context is model.context
+    assert model.is_root()
+    assert not model.inner.is_root()
+
+
+def test_two_child_subtrees_then_parent_collapse_to_one_context(distributed_setup):
+    """Sharding a parent should lazily assign one context across child subtrees."""
+    device = distributed_setup.device
+
+    mesh = init_device_mesh(device.type, (distributed_setup.world_size,))
+    model = MultiChildModel(dim=4, num_children=2).to(device)
+
+    fully_shard(model.layers[0], mesh=mesh, placements=_flat_placements())
+    fully_shard(model.layers[1], mesh=mesh, placements=_flat_placements())
+    fully_shard(model, mesh=mesh, placements=_flat_placements())
+
+    with torch.no_grad():
+        model(torch.ones(2, 4, device=device))
+
+    assert model.layers[0].context is model.context
+    assert model.layers[1].context is model.context
+
+
+def test_sibling_roots_without_parent_keep_separate_contexts(distributed_setup):
+    """Independent FSDP roots should not share runtime scheduling state."""
+    device = distributed_setup.device
+
+    mesh = init_device_mesh(device.type, (distributed_setup.world_size,))
+    model = MultiChildModel(dim=4, num_children=2).to(device)
+
+    fully_shard(model.layers[0], mesh=mesh, placements=_flat_placements())
+    fully_shard(model.layers[1], mesh=mesh, placements=_flat_placements())
+
+    with torch.no_grad():
+        model(torch.ones(2, 4, device=device))
+
+    assert model.layers[0].context is not model.layers[1].context
+    assert model.layers[0].is_root()
+    assert model.layers[1].is_root()

--- a/tests/unit_tests/distributed/megatron_fsdp/test_experimental_fully_shard.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_experimental_fully_shard.py
@@ -351,21 +351,25 @@ def test_overlaps_all_gather_and_compute(distributed_setup):
         for event in cuda_events
         if "nccl" in event.name.lower() and "allgather" in event.name.lower()
     ]
-    compute_events = [
+    # GEMM device-kernel names vary across CUDA/cuBLAS versions and GPU archs
+    # (e.g. "*gemm*", "cutlass*", "cublas*", and cuBLASLt's Hopper "nvjet_sm90_*").
+    gemm_events = [
         event
         for event in cuda_events
-        if any(token in event.name.lower() for token in ("gemm", "cutlass", "cublas"))
+        if any(
+            token in event.name.lower() for token in ("gemm", "cutlass", "cublas", "nvjet")
+        )
     ]
     assert all_gather_events, [event.name for event in cuda_events]
-    assert compute_events, [event.name for event in cuda_events]
+    assert gemm_events, [event.name for event in cuda_events]
 
     all_gather_streams = {event.device_resource_id for event in all_gather_events}
-    compute_streams = {event.device_resource_id for event in compute_events}
+    gemm_streams = {event.device_resource_id for event in gemm_events}
     assert len(all_gather_streams) == 1
-    assert all_gather_streams.isdisjoint(compute_streams)
+    assert all_gather_streams.isdisjoint(gemm_streams)
 
     overlap_count = sum(
-        any(_events_overlap(all_gather_event, compute_event) for compute_event in compute_events)
+        any(_events_overlap(all_gather_event, gemm_event) for gemm_event in gemm_events)
         for all_gather_event in all_gather_events
     )
     # This profiles a full forward/backward iteration, so backward all-gathers are

--- a/tests/unit_tests/distributed/megatron_fsdp/test_experimental_fully_shard.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_experimental_fully_shard.py
@@ -180,9 +180,7 @@ def test_nested_fully_shard_excludes_child_owned_parameters(distributed_setup):
     fully_shard(model.inner, mesh=mesh, placements=_flat_placements())
     fully_shard(model, mesh=mesh, placements=_flat_placements())
 
-    inner_names = [
-        name for group in model.inner.parameter_groups for name in group.parameter_names
-    ]
+    inner_names = [name for group in model.inner.parameter_groups for name in group.parameter_names]
     outer_names = [name for group in model.parameter_groups for name in group.parameter_names]
 
     assert inner_names == ["weight"]

--- a/tests/unit_tests/distributed/megatron_fsdp/test_experimental_fully_shard.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_experimental_fully_shard.py
@@ -339,8 +339,11 @@ def test_overlaps_all_gather_and_compute(distributed_setup):
 
     with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]) as prof:
         train_one_iteration()
-        prof.step()
-    torch.cuda.synchronize(device)
+        # Synchronize inside the profiler context so in-flight device kernels
+        # complete and get recorded before the profiler stops on __exit__.
+        # Synchronizing after the context would finalize the trace first and
+        # drop the CUDA events.
+        torch.cuda.synchronize(device)
 
     cuda_events = [event for event in prof.events() if event.device_type.name == "CUDA"]
     all_gather_events = [

--- a/tests/unit_tests/distributed/megatron_fsdp/test_experimental_fully_shard.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_experimental_fully_shard.py
@@ -9,6 +9,7 @@ import torch
 from torch import nn
 from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.tensor import DTensor
+from torch.profiler import ProfilerActivity, profile
 
 from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
     Flat,
@@ -45,6 +46,22 @@ class NestedModel(nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Run the nested model."""
         return self.inner(x) + self.bias
+
+
+class MultiChildModel(nn.Module):
+    """Model with direct parameters and multiple child FSDP units."""
+
+    def __init__(self, dim: int, num_children: int) -> None:
+        super().__init__()
+        self.bias = nn.Parameter(torch.ones(dim))
+        self.layers = nn.ModuleList([nn.Linear(dim, dim, bias=False) for _ in range(num_children)])
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run through every child layer with a root-owned bias."""
+        x = x + self.bias
+        for layer in self.layers:
+            x = torch.relu(layer(x))
+        return x
 
 
 class SaveNonLeafWeightView(torch.autograd.Function):
@@ -84,6 +101,13 @@ def _flat_placements() -> Placements:
 
 def _mb(num_bytes: int) -> str:
     return f"{num_bytes / 1024**2:.2f} MB"
+
+
+def _events_overlap(first, second) -> bool:
+    return (
+        first.time_range.start < second.time_range.end
+        and second.time_range.start < first.time_range.end
+    )
 
 
 @pytest.mark.parametrize("num_microbatches", [1, 3])
@@ -157,12 +181,205 @@ def test_nested_fully_shard_excludes_child_owned_parameters(distributed_setup):
     fully_shard(model, mesh=mesh, placements=_flat_placements())
 
     inner_names = [
-        name for group in model.inner.parameter_groups() for name in group.parameter_names
+        name for group in model.inner.parameter_groups for name in group.parameter_names
     ]
-    outer_names = [name for group in model.parameter_groups() for name in group.parameter_names]
+    outer_names = [name for group in model.parameter_groups for name in group.parameter_names]
 
     assert inner_names == ["weight"]
     assert outer_names == ["bias"]
+
+
+def test_forward_peak_memory_bounds_in_flight_child_all_gathers(distributed_setup):
+    """Forward peak memory should stay below three live child all-gathers."""
+    rank = distributed_setup.rank
+    world_size = distributed_setup.world_size
+    device = distributed_setup.device
+    if world_size < 2:
+        pytest.skip("This test requires at least 2 ranks.")
+
+    mesh = init_device_mesh(device.type, (world_size,))
+    dim = 4096
+    dtype = torch.bfloat16
+    model = MultiChildModel(dim=dim, num_children=4).to(dtype=dtype, device=device)
+    placements = _flat_placements()
+    policy = MixedPrecisionPolicy(main_params_dtype=dtype, main_grads_dtype=dtype)
+    for layer in model.layers:
+        fully_shard(layer, mesh=mesh, placements=placements, mixed_precision_policy=policy)
+    fully_shard(model, mesh=mesh, placements=placements, mixed_precision_policy=policy)
+
+    x = torch.randn(2, dim, device=device, dtype=dtype)
+    with torch.no_grad():
+        model(x)
+    torch.cuda.synchronize(device)
+    torch.cuda.empty_cache()
+
+    resting_allocated = torch.cuda.memory_allocated(device)
+    torch.cuda.reset_peak_memory_stats(device)
+    with torch.no_grad():
+        model(x)
+    torch.cuda.synchronize(device)
+    peak_delta = torch.cuda.max_memory_allocated(device) - resting_allocated
+
+    child_weight_nbytes = dim * dim * torch.empty((), dtype=dtype).element_size()
+    bound_nbytes = 3 * child_weight_nbytes
+
+    # A parent forward should keep one previous child unsharded until its compute
+    # stream consumer is safe, plus the current child being unsharded. The bound
+    # is looser than two child weights to avoid coupling this test to CUDA
+    # allocator granularity and small temporary buffers, while still catching
+    # delayed releases piling up across the four child layers.
+    assert peak_delta < bound_nbytes, (
+        "FSDP forward peak memory exceeded the in-flight all-gather bound: "
+        f"rank={rank}, peak_delta={_mb(peak_delta)}, "
+        f"three_child_weights={_mb(bound_nbytes)}"
+    )
+
+
+def test_root_forward_returns_to_resting_memory(distributed_setup):
+    """Root forward should release child all-gather storage before returning."""
+    rank = distributed_setup.rank
+    world_size = distributed_setup.world_size
+    device = distributed_setup.device
+    if world_size < 2:
+        pytest.skip("This test requires at least 2 ranks.")
+
+    mesh = init_device_mesh(device.type, (world_size,))
+    dim = 4096
+    dtype = torch.bfloat16
+    model = MultiChildModel(dim=dim, num_children=2).to(dtype=dtype, device=device)
+    placements = _flat_placements()
+    policy = MixedPrecisionPolicy(main_params_dtype=dtype, main_grads_dtype=dtype)
+    for layer in model.layers:
+        fully_shard(layer, mesh=mesh, placements=placements, mixed_precision_policy=policy)
+    fully_shard(model, mesh=mesh, placements=placements, mixed_precision_policy=policy)
+
+    x = torch.randn(2, dim, device=device, dtype=dtype)
+    torch.cuda.synchronize(device)
+    torch.cuda.empty_cache()
+    resting_allocated = torch.cuda.memory_allocated(device)
+
+    with torch.no_grad():
+        output = model(x)
+    del output
+    torch.cuda.synchronize(device)
+    allocated_after_forward = torch.cuda.memory_allocated(device)
+    extra_allocated = allocated_after_forward - resting_allocated
+    child_weight_nbytes = dim * dim * torch.empty((), dtype=dtype).element_size()
+
+    assert extra_allocated < child_weight_nbytes, (
+        "Root forward did not return to resting memory after draining child releases: "
+        f"rank={rank}, extra_allocated={_mb(extra_allocated)}, "
+        f"one_child_weight={_mb(child_weight_nbytes)}"
+    )
+
+
+def test_root_backward_returns_to_resting_memory(distributed_setup):
+    """Root backward should release child all-gather storage before returning."""
+    rank = distributed_setup.rank
+    world_size = distributed_setup.world_size
+    device = distributed_setup.device
+    if world_size < 2:
+        pytest.skip("This test requires at least 2 ranks.")
+
+    mesh = init_device_mesh(device.type, (world_size,))
+    dim = 4096
+    dtype = torch.bfloat16
+    model = MultiChildModel(dim=dim, num_children=2).to(dtype=dtype, device=device)
+    placements = _flat_placements()
+    policy = MixedPrecisionPolicy(main_params_dtype=dtype, main_grads_dtype=dtype)
+    for layer in model.layers:
+        fully_shard(layer, mesh=mesh, placements=placements, mixed_precision_policy=policy)
+    fully_shard(model, mesh=mesh, placements=placements, mixed_precision_policy=policy)
+
+    x = torch.randn(2, dim, device=device, dtype=dtype, requires_grad=True)
+    output = model(x)
+    loss = output.float().square().mean()
+    torch.cuda.synchronize(device)
+    torch.cuda.empty_cache()
+    allocated_before_backward = torch.cuda.memory_allocated(device)
+
+    loss.backward()
+    del loss, output
+    torch.cuda.synchronize(device)
+    allocated_after_backward = torch.cuda.memory_allocated(device)
+    extra_allocated = allocated_after_backward - allocated_before_backward
+    child_weight_nbytes = dim * dim * torch.empty((), dtype=dtype).element_size()
+
+    assert extra_allocated < child_weight_nbytes, (
+        "Root backward did not return to resting memory after draining child releases: "
+        f"rank={rank}, extra_allocated={_mb(extra_allocated)}, "
+        f"one_child_weight={_mb(child_weight_nbytes)}"
+    )
+
+
+def test_overlaps_all_gather_and_compute(distributed_setup):
+    """A shared root context should let child all-gathers overlap GEMM compute."""
+    world_size = distributed_setup.world_size
+    device = distributed_setup.device
+    if world_size < 2:
+        pytest.skip("This test requires at least 2 ranks.")
+
+    mesh = init_device_mesh(device.type, (world_size,))
+    dim = 4096
+    num_children = 4
+    dtype = torch.bfloat16
+    model = MultiChildModel(dim=dim, num_children=num_children).to(dtype=dtype)
+    placements = _flat_placements()
+    policy = MixedPrecisionPolicy(main_params_dtype=dtype, main_grads_dtype=dtype)
+    for layer in model.layers:
+        fully_shard(layer, mesh=mesh, placements=placements, mixed_precision_policy=policy)
+    fully_shard(model, mesh=mesh, placements=placements, mixed_precision_policy=policy)
+
+    x = torch.randn(4096, dim, device=device, dtype=dtype, requires_grad=True)
+
+    def train_one_iteration() -> None:
+        model.zero_grad(set_to_none=True)
+        model(x).sum().backward()
+
+    train_one_iteration()
+    torch.cuda.synchronize(device)
+
+    with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]) as prof:
+        train_one_iteration()
+        prof.step()
+    torch.cuda.synchronize(device)
+
+    cuda_events = [event for event in prof.events() if event.device_type.name == "CUDA"]
+    all_gather_events = [
+        event
+        for event in cuda_events
+        if "nccl" in event.name.lower() and "allgather" in event.name.lower()
+    ]
+    compute_events = [
+        event
+        for event in cuda_events
+        if any(token in event.name.lower() for token in ("gemm", "cutlass", "cublas"))
+    ]
+    assert all_gather_events, [event.name for event in cuda_events]
+    assert compute_events, [event.name for event in cuda_events]
+
+    all_gather_streams = {event.device_resource_id for event in all_gather_events}
+    compute_streams = {event.device_resource_id for event in compute_events}
+    assert len(all_gather_streams) == 1
+    assert all_gather_streams.isdisjoint(compute_streams)
+
+    overlap_count = sum(
+        any(_events_overlap(all_gather_event, compute_event) for compute_event in compute_events)
+        for all_gather_event in all_gather_events
+    )
+    # This profiles a full forward/backward iteration, so backward all-gathers are
+    # included in all_gather_events. The expected overlap count is from the forward
+    # child pipeline: each child after the first can all-gather while the previous
+    # child computes, giving num_children - 1 overlaps. Backward does not overlap
+    # in this all-gather-only path because gradient reduction is not delayed:
+    # each module synchronously reduces gradients in post_backward before autograd
+    # reaches the next module's pre_backward all-gather. The next PR addresses
+    # this by delaying gradient reduction.
+    expected_overlap_count = num_children - 1
+    assert overlap_count >= expected_overlap_count, (
+        f"Expected at least {expected_overlap_count} all-gather events to overlap compute, "
+        f"got {overlap_count}/{len(all_gather_events)}."
+    )
 
 
 def test_frozen_parameter_group_does_not_allocate_main_grad(distributed_setup):
@@ -178,7 +395,7 @@ def test_frozen_parameter_group_does_not_allocate_main_grad(distributed_setup):
 
     fully_shard(model, mesh=mesh, placements=_flat_placements())
 
-    (group,) = model.parameter_groups()
+    (group,) = model.parameter_groups
     assert not group.requires_grad
     assert group.main_grad is None
 
@@ -260,7 +477,7 @@ def test_cpu_initialized_parameters_shard_to_mesh_device(distributed_setup):
 
     fully_shard(model, mesh=mesh, placements=_flat_placements())
 
-    (group,) = model.parameter_groups()
+    (group,) = model.parameter_groups
     full_weight = group.model_weight.allgather(0).get_local_tensor(0)
     assert full_weight.device.type == device.type
     torch.testing.assert_close(full_weight, expected_weight)
@@ -277,7 +494,7 @@ def test_non_leaf_parameter_view_survives_storage_resize(distributed_setup):
     model = NonLeafViewModel().to(device)
     fully_shard(model, mesh=mesh, placements=_flat_placements())
 
-    group = model.parameter_groups()[0]
+    group = model.parameter_groups[0]
     x = torch.randn(8, device=device, requires_grad=True)
     loss = model(x).sum()
 

--- a/tests/unit_tests/distributed/megatron_fsdp/test_experimental_fully_shard.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_experimental_fully_shard.py
@@ -9,12 +9,12 @@ import torch
 from torch import nn
 from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.tensor import DTensor
-from torch.profiler import ProfilerActivity, profile
 
 from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
     Flat,
     Placements,
     fully_shard,
+    microbatch,
 )
 from megatron.core.distributed.fsdp.src.megatron_fsdp.mixed_precision import MixedPrecisionPolicy
 
@@ -46,22 +46,6 @@ class NestedModel(nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Run the nested model."""
         return self.inner(x) + self.bias
-
-
-class MultiChildModel(nn.Module):
-    """Model with direct parameters and multiple child FSDP units."""
-
-    def __init__(self, dim: int, num_children: int) -> None:
-        super().__init__()
-        self.bias = nn.Parameter(torch.ones(dim))
-        self.layers = nn.ModuleList([nn.Linear(dim, dim, bias=False) for _ in range(num_children)])
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Run through every child layer with a root-owned bias."""
-        x = x + self.bias
-        for layer in self.layers:
-            x = torch.relu(layer(x))
-        return x
 
 
 class SaveNonLeafWeightView(torch.autograd.Function):
@@ -101,13 +85,6 @@ def _flat_placements() -> Placements:
 
 def _mb(num_bytes: int) -> str:
     return f"{num_bytes / 1024**2:.2f} MB"
-
-
-def _events_overlap(first, second) -> bool:
-    return (
-        first.time_range.start < second.time_range.end
-        and second.time_range.start < first.time_range.end
-    )
 
 
 @pytest.mark.parametrize("num_microbatches", [1, 3])
@@ -180,211 +157,13 @@ def test_nested_fully_shard_excludes_child_owned_parameters(distributed_setup):
     fully_shard(model.inner, mesh=mesh, placements=_flat_placements())
     fully_shard(model, mesh=mesh, placements=_flat_placements())
 
-    inner_names = [name for group in model.inner.parameter_groups for name in group.parameter_names]
-    outer_names = [name for group in model.parameter_groups for name in group.parameter_names]
+    inner_names = [
+        name for group in model.inner.parameter_groups() for name in group.parameter_names
+    ]
+    outer_names = [name for group in model.parameter_groups() for name in group.parameter_names]
 
     assert inner_names == ["weight"]
     assert outer_names == ["bias"]
-
-
-def test_forward_peak_memory_bounds_in_flight_child_all_gathers(distributed_setup):
-    """Forward peak memory should stay below three live child all-gathers."""
-    rank = distributed_setup.rank
-    world_size = distributed_setup.world_size
-    device = distributed_setup.device
-    if world_size < 2:
-        pytest.skip("This test requires at least 2 ranks.")
-
-    mesh = init_device_mesh(device.type, (world_size,))
-    dim = 4096
-    dtype = torch.bfloat16
-    model = MultiChildModel(dim=dim, num_children=4).to(dtype=dtype, device=device)
-    placements = _flat_placements()
-    policy = MixedPrecisionPolicy(main_params_dtype=dtype, main_grads_dtype=dtype)
-    for layer in model.layers:
-        fully_shard(layer, mesh=mesh, placements=placements, mixed_precision_policy=policy)
-    fully_shard(model, mesh=mesh, placements=placements, mixed_precision_policy=policy)
-
-    x = torch.randn(2, dim, device=device, dtype=dtype)
-    with torch.no_grad():
-        model(x)
-    torch.cuda.synchronize(device)
-    torch.cuda.empty_cache()
-
-    resting_allocated = torch.cuda.memory_allocated(device)
-    torch.cuda.reset_peak_memory_stats(device)
-    with torch.no_grad():
-        model(x)
-    torch.cuda.synchronize(device)
-    peak_delta = torch.cuda.max_memory_allocated(device) - resting_allocated
-
-    child_weight_nbytes = dim * dim * torch.empty((), dtype=dtype).element_size()
-    bound_nbytes = 3 * child_weight_nbytes
-
-    # A parent forward should keep one previous child unsharded until its compute
-    # stream consumer is safe, plus the current child being unsharded. The bound
-    # is looser than two child weights to avoid coupling this test to CUDA
-    # allocator granularity and small temporary buffers, while still catching
-    # delayed releases piling up across the four child layers.
-    assert peak_delta < bound_nbytes, (
-        "FSDP forward peak memory exceeded the in-flight all-gather bound: "
-        f"rank={rank}, peak_delta={_mb(peak_delta)}, "
-        f"three_child_weights={_mb(bound_nbytes)}"
-    )
-
-
-def test_root_forward_returns_to_resting_memory(distributed_setup):
-    """Root forward should release child all-gather storage before returning."""
-    rank = distributed_setup.rank
-    world_size = distributed_setup.world_size
-    device = distributed_setup.device
-    if world_size < 2:
-        pytest.skip("This test requires at least 2 ranks.")
-
-    mesh = init_device_mesh(device.type, (world_size,))
-    dim = 4096
-    dtype = torch.bfloat16
-    model = MultiChildModel(dim=dim, num_children=2).to(dtype=dtype, device=device)
-    placements = _flat_placements()
-    policy = MixedPrecisionPolicy(main_params_dtype=dtype, main_grads_dtype=dtype)
-    for layer in model.layers:
-        fully_shard(layer, mesh=mesh, placements=placements, mixed_precision_policy=policy)
-    fully_shard(model, mesh=mesh, placements=placements, mixed_precision_policy=policy)
-
-    x = torch.randn(2, dim, device=device, dtype=dtype)
-    torch.cuda.synchronize(device)
-    torch.cuda.empty_cache()
-    resting_allocated = torch.cuda.memory_allocated(device)
-
-    with torch.no_grad():
-        output = model(x)
-    del output
-    torch.cuda.synchronize(device)
-    allocated_after_forward = torch.cuda.memory_allocated(device)
-    extra_allocated = allocated_after_forward - resting_allocated
-    child_weight_nbytes = dim * dim * torch.empty((), dtype=dtype).element_size()
-
-    assert extra_allocated < child_weight_nbytes, (
-        "Root forward did not return to resting memory after draining child releases: "
-        f"rank={rank}, extra_allocated={_mb(extra_allocated)}, "
-        f"one_child_weight={_mb(child_weight_nbytes)}"
-    )
-
-
-def test_root_backward_returns_to_resting_memory(distributed_setup):
-    """Root backward should release child all-gather storage before returning."""
-    rank = distributed_setup.rank
-    world_size = distributed_setup.world_size
-    device = distributed_setup.device
-    if world_size < 2:
-        pytest.skip("This test requires at least 2 ranks.")
-
-    mesh = init_device_mesh(device.type, (world_size,))
-    dim = 4096
-    dtype = torch.bfloat16
-    model = MultiChildModel(dim=dim, num_children=2).to(dtype=dtype, device=device)
-    placements = _flat_placements()
-    policy = MixedPrecisionPolicy(main_params_dtype=dtype, main_grads_dtype=dtype)
-    for layer in model.layers:
-        fully_shard(layer, mesh=mesh, placements=placements, mixed_precision_policy=policy)
-    fully_shard(model, mesh=mesh, placements=placements, mixed_precision_policy=policy)
-
-    x = torch.randn(2, dim, device=device, dtype=dtype, requires_grad=True)
-    output = model(x)
-    loss = output.float().square().mean()
-    torch.cuda.synchronize(device)
-    torch.cuda.empty_cache()
-    allocated_before_backward = torch.cuda.memory_allocated(device)
-
-    loss.backward()
-    del loss, output
-    torch.cuda.synchronize(device)
-    allocated_after_backward = torch.cuda.memory_allocated(device)
-    extra_allocated = allocated_after_backward - allocated_before_backward
-    child_weight_nbytes = dim * dim * torch.empty((), dtype=dtype).element_size()
-
-    assert extra_allocated < child_weight_nbytes, (
-        "Root backward did not return to resting memory after draining child releases: "
-        f"rank={rank}, extra_allocated={_mb(extra_allocated)}, "
-        f"one_child_weight={_mb(child_weight_nbytes)}"
-    )
-
-
-def test_overlaps_all_gather_and_compute(distributed_setup):
-    """A shared root context should let child all-gathers overlap GEMM compute."""
-    world_size = distributed_setup.world_size
-    device = distributed_setup.device
-    if world_size < 2:
-        pytest.skip("This test requires at least 2 ranks.")
-
-    mesh = init_device_mesh(device.type, (world_size,))
-    dim = 4096
-    num_children = 4
-    dtype = torch.bfloat16
-    model = MultiChildModel(dim=dim, num_children=num_children).to(dtype=dtype)
-    placements = _flat_placements()
-    policy = MixedPrecisionPolicy(main_params_dtype=dtype, main_grads_dtype=dtype)
-    for layer in model.layers:
-        fully_shard(layer, mesh=mesh, placements=placements, mixed_precision_policy=policy)
-    fully_shard(model, mesh=mesh, placements=placements, mixed_precision_policy=policy)
-
-    x = torch.randn(4096, dim, device=device, dtype=dtype, requires_grad=True)
-
-    def train_one_iteration() -> None:
-        model.zero_grad(set_to_none=True)
-        model(x).sum().backward()
-
-    train_one_iteration()
-    torch.cuda.synchronize(device)
-
-    with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]) as prof:
-        train_one_iteration()
-        # Synchronize inside the profiler context so in-flight device kernels
-        # complete and get recorded before the profiler stops on __exit__.
-        # Synchronizing after the context would finalize the trace first and
-        # drop the CUDA events.
-        torch.cuda.synchronize(device)
-
-    cuda_events = [event for event in prof.events() if event.device_type.name == "CUDA"]
-    all_gather_events = [
-        event
-        for event in cuda_events
-        if "nccl" in event.name.lower() and "allgather" in event.name.lower()
-    ]
-    # GEMM device-kernel names vary across CUDA/cuBLAS versions and GPU archs
-    # (e.g. "*gemm*", "cutlass*", "cublas*", and cuBLASLt's Hopper "nvjet_sm90_*").
-    gemm_events = [
-        event
-        for event in cuda_events
-        if any(
-            token in event.name.lower() for token in ("gemm", "cutlass", "cublas", "nvjet")
-        )
-    ]
-    assert all_gather_events, [event.name for event in cuda_events]
-    assert gemm_events, [event.name for event in cuda_events]
-
-    all_gather_streams = {event.device_resource_id for event in all_gather_events}
-    gemm_streams = {event.device_resource_id for event in gemm_events}
-    assert len(all_gather_streams) == 1
-    assert all_gather_streams.isdisjoint(gemm_streams)
-
-    overlap_count = sum(
-        any(_events_overlap(all_gather_event, gemm_event) for gemm_event in gemm_events)
-        for all_gather_event in all_gather_events
-    )
-    # This profiles a full forward/backward iteration, so backward all-gathers are
-    # included in all_gather_events. The expected overlap count is from the forward
-    # child pipeline: each child after the first can all-gather while the previous
-    # child computes, giving num_children - 1 overlaps. Backward does not overlap
-    # in this all-gather-only path because gradient reduction is not delayed:
-    # each module synchronously reduces gradients in post_backward before autograd
-    # reaches the next module's pre_backward all-gather. The next PR addresses
-    # this by delaying gradient reduction.
-    expected_overlap_count = num_children - 1
-    assert overlap_count >= expected_overlap_count, (
-        f"Expected at least {expected_overlap_count} all-gather events to overlap compute, "
-        f"got {overlap_count}/{len(all_gather_events)}."
-    )
 
 
 def test_frozen_parameter_group_does_not_allocate_main_grad(distributed_setup):
@@ -400,7 +179,7 @@ def test_frozen_parameter_group_does_not_allocate_main_grad(distributed_setup):
 
     fully_shard(model, mesh=mesh, placements=_flat_placements())
 
-    (group,) = model.parameter_groups
+    (group,) = model.parameter_groups()
     assert not group.requires_grad
     assert group.main_grad is None
 
@@ -467,6 +246,24 @@ def test_next_forward_uses_optimizer_updated_weights(distributed_setup):
         torch.testing.assert_close(second_loss, first_loss)
 
 
+def test_microbatch_scopes_child_contexts(distributed_setup):
+    """microbatch() should scope FSDP child contexts under an unwrapped parent."""
+    world_size = distributed_setup.world_size
+    device = distributed_setup.device
+
+    mesh = init_device_mesh(device.type, (world_size,))
+    model = nn.Sequential(nn.Linear(1, 1, bias=False), nn.Linear(1, 1, bias=False)).to(device)
+    for layer in model:
+        fully_shard(layer, mesh=mesh, placements=_flat_placements())
+
+    with microbatch(model, is_last=False):
+        for layer in model:
+            assert not layer.context.is_last_microbatch
+
+    for layer in model:
+        assert layer.context.is_last_microbatch
+
+
 def test_cpu_initialized_parameters_shard_to_mesh_device(distributed_setup):
     """CPU-initialized parameters should be sharded with their real values."""
     world_size = distributed_setup.world_size
@@ -482,7 +279,7 @@ def test_cpu_initialized_parameters_shard_to_mesh_device(distributed_setup):
 
     fully_shard(model, mesh=mesh, placements=_flat_placements())
 
-    (group,) = model.parameter_groups
+    (group,) = model.parameter_groups()
     full_weight = group.model_weight.allgather(0).get_local_tensor(0)
     assert full_weight.device.type == device.type
     torch.testing.assert_close(full_weight, expected_weight)
@@ -499,7 +296,7 @@ def test_non_leaf_parameter_view_survives_storage_resize(distributed_setup):
     model = NonLeafViewModel().to(device)
     fully_shard(model, mesh=mesh, placements=_flat_placements())
 
-    group = model.parameter_groups[0]
+    group = model.parameter_groups()[0]
     x = torch.randn(8, device=device, requires_grad=True)
     loss = model(x).sum()
 


### PR DESCRIPTION
## Summary
- Add `FsdpContext` with `is_last_microbatch` state for experimental FSDP.
- Add `microbatch(module, is_last)` to scope microbatch state across FSDP contexts.
- Add `FsdpModule.context` and root ownership tracking for lazily initialized context state.
- Expose only `fully_shard` and `microbatch` from the experimental package root.
- Add coverage for shared child/root contexts and unwrapped-parent child contexts.

## Testing
- `PATH=".venv/bin:$PATH" BASE_REF=main CHECK_ONLY=true SKIP_DOCS=false bash tools/autoformat.sh`
- `git diff --check`
- `rg -n "is_first_microbatch|is_first\\b" megatron/core/distributed/fsdp/src/megatron_fsdp/experimental tests/unit_tests/distributed/megatron_fsdp/test_context.py tests/unit_tests/distributed/megatron_fsdp/test_experimental_fully_shard.py` (no matches)
- `/opt/venv/bin/python -m torch.distributed.run --nproc-per-node 2 -m pytest -q tests/unit_tests/distributed/megatron_fsdp/test_context.py tests/unit_tests/distributed/megatron_fsdp/test_experimental_fully_shard.py --tb=short --disable-warnings -rN` (`13 passed`)
