### PR TITLE
[Megatron Lite] Fix qwen3_moe BSHD forward under context parallelism (#5617)

### DIFF
--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
@@ -44,7 +44,8 @@ from megatron.lite.primitive.modules.lora import (
     normalize_lora_config,
     trainable_param_stats,
 )
-from megatron.lite.primitive.parallel import ParallelState, init_parallel
+from megatron.lite.primitive.parallel import ParallelState, init_parallel, zigzag_slice_for_cp
+from megatron.lite.primitive.parallel.thd import parallel_state_from_model
 from megatron.lite.primitive.recompute import apply_recompute, parse_recompute_spec
 from megatron.lite.runtime.contracts import OptimizerConfig, ParallelConfig
 from megatron.lite.runtime.contracts.data import PackedBatch
@@ -133,8 +134,21 @@ def _forward_step(model: nn.Module, batch: PackedBatch) -> dict:
 
 
 def _forward_step_bshd(model: nn.Module, batch: PackedBatch) -> dict:
+    ps = parallel_state_from_model(model) or ParallelState()
+    input_ids = batch.input_ids.reshape(1, -1)
     labels = batch.labels.reshape(1, -1) if batch.labels is not None else None
-    return model(input_ids=batch.input_ids.reshape(1, -1), labels=labels, packed_seq_params=None)
+    loss_mask = batch.loss_mask.reshape(1, -1) if batch.loss_mask is not None else None
+    if ps.cp_size > 1:
+        # GQAttention's non-THD branch expects CP-zigzag-sharded inputs, and
+        # unpack_forward_output() reconstructs zigzag-CP outputs; match both.
+        input_ids = zigzag_slice_for_cp(input_ids, ps.cp_rank, ps.cp_size, seq_dim=1)
+        if labels is not None:
+            labels = zigzag_slice_for_cp(labels, ps.cp_rank, ps.cp_size, seq_dim=1)
+        if loss_mask is not None:
+            loss_mask = zigzag_slice_for_cp(loss_mask, ps.cp_rank, ps.cp_size, seq_dim=1)
+    return model(
+        input_ids=input_ids, labels=labels, loss_mask=loss_mask, packed_seq_params=None
+    )
 
 
 def unpack_forward_output(model: nn.Module, batch: PackedBatch, output) -> Any:


### PR DESCRIPTION
## What

Fixes #5617.

In the experimental Megatron-Lite runtime, a Qwen3-MoE eval-only BSHD (`use_thd=false`) forward with context parallelism and pipeline parallelism enabled together (`CP>1`, `PP>1`) crashes in vocab-parallel cross entropy: the final pipeline stage produces CP-local logits but still receives full-sequence labels.

## Root cause

`_forward_step_bshd()` forwarded `batch.input_ids` / `batch.labels` unchanged, but:

- `GQAttention`'s non-THD branch (and its RoPE frequency slicing) assumes its input is **already CP-zigzag-sharded** (see the "q is CP-zigzag pre-sliced" comment in `primitive/modules/gqa.py`).
- The pipeline runtime's `_infer_pipeline_tensor_shape()` sizes PP activations from the **CP-local** sequence length.

So with `CP>1` the last PP stage's CP-local logits disagreed in shape with the still-full-sequence labels, crashing `vocab_parallel_cross_entropy` (and, with `PP=1`, silently misaligning the loss). Only the THD path did CP splitting (via `pack_thd_forward_kwargs`); the BSHD input side was missing it.

## Fix

`_forward_step_bshd()` now zigzag-splits `input_ids` / `labels` / `loss_mask` with `zigzag_slice_for_cp()` — the same primitive other models (`mla.py`, `dsa.py`, `gated_delta_net.py`) already use for CP — so the input layout matches what attention/RoPE expect. `unpack_forward_output()` already reconstructs zigzag-CP outputs back to full-sequence order via `unpack_thd_forward_output()`, so only the input side needed the change.

## Testing

- Existing `tests/unit/model/test_qwen_config_unit.py` passes (CPU-only, no GPU required).
- Numerically validated separately: BSHD `CP=2, PP=2` eval-only forward now completes and matches the CP-off baseline for both `dist_opt` and FSDP2.

## Scope

BSHD-only (`use_thd=false`) path, as reported. The THD path already handled CP and is unchanged.