### PR TITLE
Add async distributed checkpoint load

### DIFF
--- a/megatron/core/dist_checkpointing/__init__.py
+++ b/megatron/core/dist_checkpointing/__init__.py
@@ -1,6 +1,19 @@
 # Copyright (c) 2022-2023, NVIDIA CORPORATION.  All rights reserved.
 
+from .async_load_manager import (
+    AsyncCheckpointLoader,
+    AsyncLoadHandle,
+    LoadState,
+    TopologyPlanCache,
+    compute_checkpoint_save_topology_fingerprint,
+    resolve_checkpoint_iter_dir,
+)
 from .core import check_is_distributed_checkpoint
+from .cpu_shadow import (
+    ShadowBufferPool,
+    build_cpu_shadow_sharded_state_dict,
+    unwrap_for_sharded_state_dict,
+)
 from .mapping import LocalNonpersistentObject, ShardedObject, ShardedTensor
 from .serialization import (
     load,
@@ -8,6 +21,9 @@ from .serialization import (
     load_content_metadata,
     load_plain_tensors,
     load_tensors_metadata,
+    prepare_async_load,
+    prepare_async_load_reusing_topology,
     remove_sharded_tensors,
     save,
+    start_async_load_from_plan,
 )

--- a/megatron/core/dist_checkpointing/async_load_manager.py
+++ b/megatron/core/dist_checkpointing/async_load_manager.py
@@ -1,0 +1,297 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+
+"""High-level orchestration for async checkpoint loading.
+
+:class:`AsyncCheckpointLoader` combines the async-load entrypoints from
+``serialization`` with a :class:`~megatron.core.dist_checkpointing.cpu_shadow.ShadowBufferPool`
+and a per-topology plan cache, so repeated loads of same-topology checkpoints
+only pay for disk reads.
+"""
+
+from __future__ import annotations
+
+import enum
+import hashlib
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+import torch
+
+from .cpu_shadow import ShadowBufferPool
+
+logger = logging.getLogger(__name__)
+
+# Same tracker filename as megatron.training.checkpointing (not imported here:
+# megatron.core must not depend on megatron.training).
+_CHECKPOINT_TRACKER_FILENAME = 'latest_checkpointed_iteration.txt'
+
+
+def resolve_checkpoint_iter_dir(load_dir: str) -> str:
+    """Resolve a Megatron load dir to its latest ``iter_*`` / ``release`` subdir.
+
+    Args:
+        load_dir (str): base checkpoint directory (or an iter dir, returned as-is).
+
+    Returns: path of the checkpoint directory for the latest iteration.
+    """
+    tracker = Path(load_dir) / _CHECKPOINT_TRACKER_FILENAME
+    if not tracker.is_file():
+        if Path(load_dir).name == "release" or Path(load_dir).name.startswith("iter_"):
+            return load_dir
+        raise FileNotFoundError(f"No tracker file at {tracker} and {load_dir} is not an iter dir")
+    token = tracker.read_text().strip()
+    if token == "release":
+        return str(Path(load_dir) / "release")
+    if not token.isdigit():
+        raise ValueError(f"Unexpected tracker contents at {tracker}: {token!r}")
+    return str(Path(load_dir) / f"iter_{int(token):07d}")
+
+
+def compute_checkpoint_save_topology_fingerprint(checkpoint_dir: str) -> str:
+    """sha256 of the per-FQN chunk layout in ``checkpoint_dir/.metadata``.
+
+    Checkpoints saved with the same parallel topology produce the same
+    fingerprint and can share one async load plan.
+    """
+    from .strategies.cached_metadata_filesystem_reader import CachedMetadataFileSystemReader
+
+    metadata = CachedMetadataFileSystemReader(checkpoint_dir).read_metadata()
+    h = hashlib.sha256()
+    for fqn in sorted(metadata.state_dict_metadata.keys()):
+        entry = metadata.state_dict_metadata[fqn]
+        h.update(fqn.encode("utf-8"))
+        h.update(b"|" + type(entry).__name__.encode("utf-8") + b"|")
+        chunks = getattr(entry, "chunks", None)
+        if chunks is None:
+            continue
+        size = getattr(entry, "size", None)
+        if size is not None:
+            h.update(repr(tuple(size)).encode("utf-8"))
+        props = getattr(entry, "properties", None)
+        if props is not None and getattr(props, "dtype", None) is not None:
+            h.update(repr(props.dtype).encode("utf-8"))
+        # DCP doesn't guarantee chunk order; sort so the hash is reproducible.
+        h.update(repr(sorted((tuple(c.offsets), tuple(c.sizes)) for c in chunks)).encode("utf-8"))
+    return h.hexdigest()
+
+
+class TopologyPlanCache:
+    """One ``AsyncLoadPlan`` per distinct save-time topology fingerprint.
+
+    Sharing a template plan across checkpoints with mismatched save-time
+    layouts would read wrong file bytes, so plans are keyed by
+    :func:`compute_checkpoint_save_topology_fingerprint`.
+    """
+
+    def __init__(self):
+        self._plans: dict[str, Any] = {}
+        self._dir_to_fingerprint: dict[str, str] = {}
+        self._n_hits = 0
+        self._n_misses = 0
+
+    def __len__(self) -> int:
+        return len(self._plans)
+
+    def get_or_build(self, checkpoint_iter_dir: str, pool: ShadowBufferPool):
+        """Return the cached plan for this checkpoint's topology, building it
+        (a collective) on first sight of a new fingerprint.
+
+        Returns: tuple of (plan, fingerprint).
+        """
+        fingerprint = self._dir_to_fingerprint.get(checkpoint_iter_dir)
+        if fingerprint is None:
+            fingerprint = compute_checkpoint_save_topology_fingerprint(checkpoint_iter_dir)
+            self._dir_to_fingerprint[checkpoint_iter_dir] = fingerprint
+        cached = self._plans.get(fingerprint)
+        if cached is not None:
+            self._n_hits += 1
+            return cached, fingerprint
+
+        self._n_misses += 1
+        tmpl_shadow = pool.acquire()
+        try:
+            # Call-time import to avoid a circular import with the package init.
+            from megatron.core import dist_checkpointing
+
+            plan = dist_checkpointing.prepare_async_load(tmpl_shadow, checkpoint_iter_dir)
+        finally:
+            pool.release(tmpl_shadow)
+        self._plans[fingerprint] = plan
+        return plan, fingerprint
+
+    def stats(self) -> dict[str, int]:
+        """Cache statistics for logging."""
+        return {
+            "distinct_plans": len(self._plans),
+            "distinct_checkpoints": len(self._dir_to_fingerprint),
+            "hits": self._n_hits,
+            "misses": self._n_misses,
+        }
+
+
+class LoadState(enum.Enum):
+    """Lifecycle state of an :class:`AsyncLoadHandle`."""
+
+    KICKED = "kicked"
+    FINALIZED = "finalized"
+    RELEASED = "released"
+
+
+@dataclass
+class AsyncLoadHandle:
+    """One in-flight (or finalized) async load.
+
+    The handle owns the leased shadow from ``kick`` until ``release``; the
+    finalized tree returned by ``poll``/``finalize`` aliases that shadow's
+    pinned storage and is only valid until ``release``.
+    """
+
+    key: str
+    request: Any  # AsyncLoadRequest
+    shadow: dict
+    call_idx: int
+    state: LoadState = LoadState.KICKED
+
+
+class AsyncCheckpointLoader:
+    """Stream torch_dist checkpoints into pinned-CPU shadows asynchronously.
+
+    Bound to one ``model`` for its lifetime (the shadow shape depends on it).
+    Loads are identified by an opaque ``key``; the loader owns the shadow pool,
+    the topology plan cache and the monotonic ``call_idx``. What happens with
+    the finalized tensors is the caller's concern.
+    """
+
+    def __init__(self, model, *, num_shadow_buffers: int = 1):
+        self._model = model
+        self._pool = ShadowBufferPool(model, num_buffers=num_shadow_buffers)
+        self._plan_cache = TopologyPlanCache()
+        self._dir_cache: dict[str, str] = {}
+        self._call_idx = 0
+
+    @property
+    def call_idx(self) -> int:
+        """Monotonic sequence number of the last kicked load."""
+        return self._call_idx
+
+    def num_free_shadows(self) -> int:
+        """Number of currently free shadow buffers."""
+        return self._pool.num_free()
+
+    def num_shadow_buffers(self) -> int:
+        """Total number of shadow buffers."""
+        return self._pool.num_buffers()
+
+    def plan_cache_stats(self) -> dict[str, int]:
+        """Statistics of the topology plan cache."""
+        return self._plan_cache.stats()
+
+    def resolve_iter_dir(self, load_dir: str) -> str:
+        """Resolve and cache ``load_dir``'s latest iteration directory.
+
+        The result is cached: a tracker file updated later (e.g. a new
+        iteration saved into the same load_dir) is not re-read.
+        """
+        iter_dir = self._dir_cache.get(load_dir)
+        if iter_dir is None:
+            iter_dir = resolve_checkpoint_iter_dir(load_dir)
+            self._dir_cache[load_dir] = iter_dir
+        return iter_dir
+
+    @torch.no_grad()
+    def load_finalized_to_model(self, finalized: dict, *, strict: bool = False) -> None:
+        """Load a finalized state dict directly into the bound model chunks.
+
+        ``finalized`` is keyed like Megatron checkpoints: ``finalized['model']``
+        for a single chunk, ``finalized[f'model{i}']`` per chunk with virtual
+        pipeline parallelism. With ``strict=False``, entries absent from the
+        checkpoint (e.g. TE ``extra_state``) keep their current values.
+        """
+        if len(self._model) == 1:
+            self._model[0].load_state_dict(finalized["model"], strict=strict)
+        else:
+            for i, model_i in enumerate(self._model):
+                key = f"model{i}"
+                if key in finalized:
+                    model_i.load_state_dict(finalized[key], strict=strict)
+
+    def prewarm_plans(self, load_dirs: Iterable[str]) -> None:
+        """Build every topology plan up front while the pool is idle.
+
+        Every rank must call this with the same ``load_dirs`` in the same
+        order (plan building is a collective).
+        """
+        for load_dir in load_dirs:
+            iter_dir = self.resolve_iter_dir(load_dir)
+            self._plan_cache.get_or_build(iter_dir, self._pool)
+
+    def kick(self, key: str, load_dir: str) -> AsyncLoadHandle:
+        """Start an async load of ``load_dir`` into a leased shadow.
+
+        Collective ordered operation: every rank must kick the same ``key`` in
+        the same order so ``call_idx`` stays in lockstep. Raises if no shadow
+        buffer is free.
+        """
+        iter_dir = self.resolve_iter_dir(load_dir)
+        # Plan build may itself acquire+release a shadow, so it must happen
+        # before the acquire below — nesting would self-deadlock at
+        # num_buffers=1.
+        plan, _ = self._plan_cache.get_or_build(iter_dir, self._pool)
+
+        from megatron.core import dist_checkpointing
+
+        shadow = self._pool.acquire()
+        try:
+            prepared_plan = dist_checkpointing.prepare_async_load_reusing_topology(
+                shadow, iter_dir, plan
+            )
+        except BaseException:
+            self._pool.release(shadow)
+            raise
+
+        self._call_idx += 1
+        call_idx = self._call_idx
+        request = dist_checkpointing.start_async_load_from_plan(prepared_plan, call_idx=call_idx)
+        return AsyncLoadHandle(key=key, request=request, shadow=shadow, call_idx=call_idx)
+
+    def poll(self, handle: AsyncLoadHandle):
+        """Non-blocking collective poll.
+
+        Returns: the finalized tree (aliasing the handle's shadow storage,
+            valid until ``release``) when every rank's read finished, else None.
+        """
+        if handle.state is not LoadState.KICKED:
+            raise RuntimeError(f"poll() on handle in state {handle.state}; expected KICKED.")
+        finalized = handle.request.maybe_finalize(blocking=False)
+        if finalized is None:
+            return None
+        handle.state = LoadState.FINALIZED
+        return finalized
+
+    def finalize(self, handle: AsyncLoadHandle):
+        """Blocking collective finalize.
+
+        Returns: the finalized tree (aliasing the handle's shadow storage,
+            valid until ``release``).
+        """
+        if handle.state is not LoadState.KICKED:
+            raise RuntimeError(f"finalize() on handle in state {handle.state}; expected KICKED.")
+        finalized = handle.request.maybe_finalize(blocking=True)
+        handle.state = LoadState.FINALIZED
+        return finalized
+
+    def release(self, handle: AsyncLoadHandle) -> None:
+        """Return the handle's shadow to the pool.
+
+        Call only after the finalized tree has been fully consumed — it
+        aliases the shadow's pinned storage.
+        """
+        if handle.state is not LoadState.FINALIZED:
+            raise RuntimeError(
+                f"release() on handle in state {handle.state}; finalize/poll the load "
+                "before releasing (the finalized tree aliases the shadow's pinned storage)."
+            )
+        self._pool.release(handle.shadow)
+        handle.state = LoadState.RELEASED

--- a/megatron/core/dist_checkpointing/cpu_shadow.py
+++ b/megatron/core/dist_checkpointing/cpu_shadow.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+
+"""Pinned-CPU shadow state dicts for async checkpoint loading.
+
+A "shadow" is a tree shaped like a model's sharded_state_dict, but with every
+ShardedTensor/Factory ``.data`` replaced by a pinned CPU buffer. Async loads
+read checkpoint bytes into the shadow instead of live GPU weights.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+import torch
+
+from .dict_utils import dict_list_map_outplace
+from .mapping import ShardedTensor, ShardedTensorFactory
+
+
+def build_cpu_shadow_sharded_state_dict(model) -> dict:
+    """Build a shadow of ``model``'s sharded state dict backed by pinned CPU buffers.
+
+    Replacing ``factory.data`` (the GPU param) with a CPU buffer keeps the later
+    ``apply_factories`` chunking from aliasing into live GPU storage.
+
+    Args:
+        model: list of model chunks (as passed to Megatron checkpointing).
+
+    Returns: dict keyed like Megatron checkpoints ('model' or 'model{i}').
+    """
+    shadow: dict[str, Any] = {}
+    for i, model_i in enumerate(model):
+        key = "model" if len(model) == 1 else f"model{i}"
+        model_sd = unwrap_for_sharded_state_dict(model_i).sharded_state_dict()
+        shadow[key] = dict_list_map_outplace(_shadow_leaf, model_sd)
+    return shadow
+
+
+def unwrap_for_sharded_state_dict(module):
+    """Strip DDP / Float16Module wrappers so the produced keys match the keys
+    in the on-disk checkpoint metadata (which was saved without DDP wrap)."""
+    while hasattr(module, "module") and isinstance(getattr(module, "module"), torch.nn.Module):
+        module = module.module
+    return module
+
+
+def _shadow_leaf(node: Any) -> Any:
+    """Copy a ShardedTensor/Factory with ``.data`` replaced by a pinned CPU
+    buffer; pass any other leaf through untouched."""
+    if isinstance(node, (ShardedTensor, ShardedTensorFactory)):
+        new_node = copy.copy(node)
+        new_node.data = _new_pinned_like(node.data)
+        return new_node
+    return node
+
+
+def _new_pinned_like(original: torch.Tensor) -> torch.Tensor:
+    try:
+        return torch.empty(original.shape, dtype=original.dtype, device="cpu", pin_memory=True)
+    except RuntimeError:
+        return torch.empty(original.shape, dtype=original.dtype, device="cpu")
+
+
+class ShadowBufferPool:
+    """Pool of ``num_buffers`` pinned-CPU shadow trees shared by every load.
+
+    A shadow only lives between kick and commit, so a small pool suffices:
+    ``num_buffers=1`` (default) keeps host RAM independent of the number of
+    distinct checkpoints; ``num_buffers>1`` enables double-buffering.
+
+    ``acquire`` raises rather than blocks when no buffer is free — blocking
+    inside a collective-ordered kick would deadlock, since the release that
+    frees a buffer is also caller-driven and collective.
+    """
+
+    def __init__(self, model, num_buffers: int = 1):
+        if num_buffers < 1:
+            raise ValueError(f"ShadowBufferPool needs num_buffers >= 1, got {num_buffers}")
+        self._all: list[dict] = [
+            build_cpu_shadow_sharded_state_dict(model) for _ in range(num_buffers)
+        ]
+        self._free: list[dict] = list(self._all)
+
+    def num_buffers(self) -> int:
+        """Total number of shadow buffers owned by the pool."""
+        return len(self._all)
+
+    def num_free(self) -> int:
+        """Number of currently free shadow buffers."""
+        return len(self._free)
+
+    def acquire(self) -> dict:
+        """Lease a free shadow tree; raises RuntimeError when none is free."""
+        if not self._free:
+            raise RuntimeError(
+                "ShadowBufferPool exhausted — finalize and release an outstanding "
+                "async load before acquiring another shadow."
+            )
+        return self._free.pop()
+
+    def release(self, shadow: dict) -> None:
+        """Return a previously acquired shadow tree to the pool."""
+        if not any(shadow is buf for buf in self._all):
+            raise RuntimeError("ShadowBufferPool.release() called with a foreign shadow tree.")
+        if any(shadow is buf for buf in self._free):
+            raise RuntimeError("ShadowBufferPool.release() called twice for the same shadow tree.")
+        self._free.append(shadow)

--- a/megatron/core/dist_checkpointing/serialization.py
+++ b/megatron/core/dist_checkpointing/serialization.py
@@ -166,6 +166,152 @@ def load(
         return common_state_dict
 
 
+def _prepare_async_load_common(
+    sharded_state_dict: ShardedStateDict,
+    checkpoint_dir: str,
+    sharded_strategy: Optional[TorchDistLoadShardedStrategy],
+    required_strategy_attr: str,
+):
+    """Shared preamble of the async-load entrypoints.
+
+    Mirrors :func:`load` up to the sharded-strategy dispatch. The async path
+    skips the strict-mode / access-integrity validation (which is itself
+    collective) and behaves like ``StrictHandling.ASSUME_OK_UNEXPECTED``.
+
+    Returns: tuple of (sharded_strategy, common_state_dict, sharded_state_dict,
+        sh_ten_factories).
+    """
+    verify_checkpoint(checkpoint_dir)
+    if sharded_strategy is None:
+        sharded_strategy = TorchDistLoadShardedStrategy()
+    if not hasattr(sharded_strategy, required_strategy_attr):
+        raise TypeError(
+            f"sharded_strategy {type(sharded_strategy).__name__} does not implement "
+            f"{required_strategy_attr}."
+        )
+
+    force_all_tensors_to_non_fp8(sharded_state_dict)
+
+    common_state_dict = load_common(checkpoint_dir)
+
+    sharded_state_dict, nonpersistent_state_dict, sh_ten_factories = load_preprocess(
+        sharded_state_dict
+    )
+    merge(common_state_dict, nonpersistent_state_dict)
+
+    sharded_state_dict, _ = extract_sharded_base(sharded_state_dict)
+
+    return sharded_strategy, common_state_dict, sharded_state_dict, sh_ten_factories
+
+
+def _wrap_plan_finalize_into_common(prepared_plan, common_state_dict, sh_ten_factories):
+    """Rebind ``prepared_plan.finalize_fn`` to return the full merged state dict
+    (common + loaded + factory merges), matching what :func:`load` returns."""
+    inner_finalize_fn = prepared_plan.finalize_fn
+
+    def finalize_into_common() -> StateDict:
+        loaded_state_dict = inner_finalize_fn()
+        # Shallow copy: protects the top-level mapping so the plan can be
+        # replayed; each plan is finalized at most once per read.
+        merged = dict(common_state_dict)
+        merge(merged, loaded_state_dict)
+        return apply_factory_merges(merged, sh_ten_factories)
+
+    prepared_plan.finalize_fn = finalize_into_common
+    return prepared_plan
+
+
+def prepare_async_load(
+    sharded_state_dict: ShardedStateDict,
+    checkpoint_dir: str,
+    sharded_strategy: Optional[TorchDistLoadShardedStrategy] = None,
+):
+    """Run the plan phase of an async load; pair with :func:`start_async_load_from_plan`.
+
+    The returned plan caches the collective DCP planning work, so repeated
+    reloads of the same checkpoint only pay for disk reads.
+
+    Args:
+        sharded_state_dict (ShardedStateDict): state dict of the existing model
+            populated with ShardedTensors, used as a loading mapping.
+        checkpoint_dir (str): directory with the checkpoint.
+        sharded_strategy (TorchDistLoadShardedStrategy, optional): configures
+            loading behavior for sharded tensors.
+
+    Returns: an AsyncLoadPlan.
+    """
+    sharded_strategy, common_state_dict, sharded_state_dict, sh_ten_factories = (
+        _prepare_async_load_common(
+            sharded_state_dict, checkpoint_dir, sharded_strategy, "prepare_async_load"
+        )
+    )
+
+    prepared_plan = sharded_strategy.prepare_async_load(sharded_state_dict, checkpoint_dir)
+    return _wrap_plan_finalize_into_common(prepared_plan, common_state_dict, sh_ten_factories)
+
+
+def prepare_async_load_reusing_topology(
+    sharded_state_dict: ShardedStateDict,
+    checkpoint_dir: str,
+    template_plan,
+    sharded_strategy: Optional[TorchDistLoadShardedStrategy] = None,
+):
+    """Collective-free counterpart of :func:`prepare_async_load`.
+
+    Reuses the collective planning work cached in ``template_plan`` and only
+    performs local per-checkpoint setup. The caller must guarantee that
+    ``sharded_state_dict`` has the same structure and parallel topology as the
+    one used to build ``template_plan``.
+
+    Args:
+        sharded_state_dict (ShardedStateDict): state dict of the existing model
+            populated with ShardedTensors, used as a loading mapping.
+        checkpoint_dir (str): directory with the checkpoint.
+        template_plan (AsyncLoadPlan): plan built by :func:`prepare_async_load`
+            for a checkpoint with identical topology.
+        sharded_strategy (TorchDistLoadShardedStrategy, optional): configures
+            loading behavior for sharded tensors.
+
+    Returns: an AsyncLoadPlan.
+    """
+    sharded_strategy, common_state_dict, sharded_state_dict, sh_ten_factories = (
+        _prepare_async_load_common(
+            sharded_state_dict,
+            checkpoint_dir,
+            sharded_strategy,
+            "prepare_async_load_reusing_topology",
+        )
+    )
+
+    prepared_plan = sharded_strategy.prepare_async_load_reusing_topology(
+        sharded_state_dict, checkpoint_dir, template_plan
+    )
+    return _wrap_plan_finalize_into_common(prepared_plan, common_state_dict, sh_ten_factories)
+
+
+def start_async_load_from_plan(prepared_plan, call_idx: int = 0):
+    """Spawn the async read thread for a previously prepared plan.
+
+    Args:
+        prepared_plan (AsyncLoadPlan): plan built by :func:`prepare_async_load`
+            or :func:`prepare_async_load_reusing_topology`.
+        call_idx (int, optional): sequence number validated across ranks at
+            finalization. Defaults to 0.
+
+    Returns: an AsyncLoadRequest; call ``maybe_finalize()`` to obtain the
+        loaded state dict.
+    """
+    from .strategies.async_load_utils import spawn_async_read
+
+    return spawn_async_read(
+        storage_reader=prepared_plan.storage_reader,
+        final_local_plan=prepared_plan.final_local_plan,
+        worker_planner=prepared_plan.worker_planner,
+        finalize_fn=prepared_plan.finalize_fn,
+        call_idx=call_idx,
+    )
+
+
 def load_common_state_dict(checkpoint_dir: Union[str, Path]) -> StateDict:
     """Load common (non-sharded) objects state dict from the checkpoint.
 

--- a/megatron/core/dist_checkpointing/strategies/async_load_utils.py
+++ b/megatron/core/dist_checkpointing/strategies/async_load_utils.py
@@ -1,0 +1,203 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+
+"""Async load utilities for dist_checkpointing.
+
+The disk read runs in a Python thread of the calling process: it only performs
+file I/O and memcpy into the destination CPU tensors (releasing the GIL for
+both), and never touches ``torch.distributed`` or CUDA, so it can overlap with
+NCCL collectives issued by the main thread. A thread (rather than a spawned
+process) writes directly into the caller's pinned tensors with no IPC and no
+interpreter re-import cost.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Optional
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class AsyncLoadPlan:
+    """Cacheable result of the plan phase of an async load.
+
+    Built once per checkpoint via
+    :meth:`TorchDistLoadShardedStrategy.prepare_async_load` and replayed with
+    :func:`spawn_async_read`. The planner is the same instance that was set up
+    during the plan phase, bound to ``worker_state_dict`` — the read thread
+    reuses it so sharded read items resolve into the correct destination
+    tensors.
+
+    Note: ``worker_state_dict`` stays bound to the destination tensors that
+    were live at prepare time. If a caller recycles those tensors, the plan
+    must be rebuilt (or rebound via ``prepare_async_load_reusing_topology``)
+    before reuse.
+    """
+
+    storage_reader: Any
+    final_local_plan: Any
+    metadata: Any
+    worker_state_dict: Dict[str, Any]
+    worker_planner: Any
+    finalize_fn: Callable[[], Any]
+
+
+def _thread_entry(
+    storage_reader,
+    final_local_plan,
+    worker_planner,
+    done_event: threading.Event,
+    error_holder: dict,
+) -> None:
+    """Read-thread entry point: pure file I/O + memcpy, no distributed or CUDA calls."""
+    try:
+        future = storage_reader.read_data(final_local_plan, worker_planner)
+        future.wait()
+    except BaseException as e:  # noqa: BLE001 — re-raised on finalize
+        error_holder["exc"] = e
+    finally:
+        done_event.set()
+
+
+@dataclass
+class AsyncLoadRequest:
+    """Handle to an in-flight async load.
+
+    ``maybe_finalize`` is collective. With ``blocking=True`` it joins the read
+    thread and finalizes. With ``blocking=False`` it first checks across ranks
+    whether every read thread has finished and returns None otherwise — this
+    check is mandatory, since finalizing on a subset of ranks while others are
+    still reading would deadlock any collective issued downstream.
+    """
+
+    thread: threading.Thread
+    done_event: threading.Event
+    error_holder: dict
+    finalize_fn: Callable[[], Any]
+    call_idx: int = 0
+    _finalized: bool = False
+
+    def is_done(self) -> bool:
+        """True if this rank's read thread has finished (local check only)."""
+        return self.done_event.is_set()
+
+    @staticmethod
+    def _sync_all_workers_done(local_is_alive: int) -> bool:
+        """Cross-rank check: True iff every rank's read thread is done."""
+        if not torch.distributed.is_initialized():
+            return local_is_alive == 0
+        ten = torch.tensor([local_is_alive], dtype=torch.int, device=torch.cuda.current_device())
+        torch.distributed.all_reduce(ten)
+        return ten[0].item() == 0
+
+    def maybe_finalize(self, blocking: bool = True) -> Optional[Any]:
+        """Join the read thread, synchronize with peers and run finalization.
+
+        Args:
+            blocking (bool, optional): if False, returns None (without joining)
+                unless the read thread finished on every rank. Defaults to True.
+
+        Returns: the loaded state dict, or None if ``blocking=False`` and some
+            rank is still reading.
+        """
+        if self._finalized:
+            raise RuntimeError("AsyncLoadRequest.maybe_finalize already called.")
+
+        if not blocking:
+            local_is_alive = int(not self.done_event.is_set())
+            if not self._sync_all_workers_done(local_is_alive):
+                return None
+
+        self.thread.join()
+
+        # Broadcast the error flag before raising locally, so that ranks whose
+        # read succeeded don't enter the call_idx collective below (and hang)
+        # while a failed rank has already raised.
+        local_has_error = int("exc" in self.error_holder)
+        if torch.distributed.is_initialized():
+            err_ten = torch.tensor(
+                [local_has_error], dtype=torch.int, device=torch.cuda.current_device()
+            )
+            torch.distributed.all_reduce(err_ten, op=torch.distributed.ReduceOp.MAX)
+            any_rank_has_error = bool(err_ten.item())
+        else:
+            any_rank_has_error = bool(local_has_error)
+
+        if local_has_error:
+            self._finalized = True
+            raise RuntimeError(
+                f"Async load thread failed: {self.error_holder['exc']!r}"
+            ) from self.error_holder["exc"]
+        if any_rank_has_error:
+            self._finalized = True
+            raise RuntimeError(
+                "Async load aborted: a peer rank's read thread raised. "
+                "See that rank's stderr for the original exception."
+            )
+
+        # Every rank must finalize the same call_idx. MIN and MAX are reduced
+        # together so that all ranks observe a mismatch and raise.
+        min_idx, max_idx = self._world_min_max(self.call_idx)
+        if min_idx != max_idx:
+            self._finalized = True
+            raise RuntimeError(
+                f"Async load call_idx mismatch across ranks (local={self.call_idx}, "
+                f"min={min_idx}, max={max_idx}); some ranks skipped or reordered "
+                f"maybe_finalize."
+            )
+
+        result = self.finalize_fn()
+        self._finalized = True
+        return result
+
+    @staticmethod
+    def _world_min_max(value: int) -> "tuple[int, int]":
+        """All-reduce (min, max) of ``value`` across ranks in one collective."""
+        if not torch.distributed.is_initialized():
+            return value, value
+        ten = torch.tensor([value, -value], dtype=torch.int, device=torch.cuda.current_device())
+        torch.distributed.all_reduce(ten, op=torch.distributed.ReduceOp.MAX)
+        return -int(ten[1].item()), int(ten[0].item())
+
+
+def spawn_async_read(
+    storage_reader,
+    final_local_plan,
+    worker_planner,
+    finalize_fn: Callable[[], Any],
+    call_idx: int = 0,
+) -> AsyncLoadRequest:
+    """Launch a background thread performing ``storage_reader.read_data``.
+
+    Args:
+        storage_reader: DCP storage reader with metadata already set up.
+        final_local_plan: this rank's slice of the load plan.
+        worker_planner: the planner used during the plan phase, bound to the
+            destination state dict.
+        finalize_fn (Callable): produces the final state dict once the read
+            is complete.
+        call_idx (int, optional): sequence number validated across ranks at
+            finalization. Defaults to 0.
+
+    Returns: an AsyncLoadRequest handle.
+    """
+    done_event = threading.Event()
+    error_holder: dict = {}
+    thread = threading.Thread(
+        target=_thread_entry,
+        args=(storage_reader, final_local_plan, worker_planner, done_event, error_holder),
+        name=f"dist-checkpointing-async-load-{call_idx}",
+        daemon=True,
+    )
+    thread.start()
+    return AsyncLoadRequest(
+        thread=thread,
+        done_event=done_event,
+        error_holder=error_holder,
+        finalize_fn=finalize_fn,
+        call_idx=call_idx,
+    )

--- a/megatron/core/dist_checkpointing/strategies/torch.py
+++ b/megatron/core/dist_checkpointing/strategies/torch.py
@@ -57,6 +57,8 @@ if TYPE_CHECKING:
     from nvidia_resiliency_ext.checkpointing.async_ckpt.state_dict_saver import (
         CheckpointMetadataCache,
     )
+
+    from .async_load_utils import AsyncLoadPlan, AsyncLoadRequest
 else:
     CheckpointMetadataCache = Any
     NVRxAsyncRequest = Any
@@ -918,6 +920,217 @@ class TorchDistLoadShardedStrategy:
         )
         _restore_dict_types(mcore_state_dict, orig_sharded_state_dict)
         return mcore_state_dict
+
+    def _setup_async_load_state(self, sharded_state_dict: ShardedStateDict, checkpoint_dir: Path):
+        """Local (collective-free) setup shared by the async-load plan phases.
+
+        Mirrors :meth:`load` up to the DCP dispatch.
+
+        Returns: tuple of (pyt_state_dict, planner, storage_reader, finalize_fn).
+        """
+        flexible_shape_sharded_tensors = [
+            sh_ten
+            for sh_ten in nested_values(sharded_state_dict)
+            if isinstance(sh_ten, ShardedTensor) and not sh_ten.allow_shape_mismatch
+        ]
+        allow_shape_mismatch_sharded_tensors = {
+            sh_ten.key: sh_ten
+            for sh_ten in nested_values(sharded_state_dict)
+            if isinstance(sh_ten, ShardedTensor) and sh_ten.allow_shape_mismatch
+        }
+
+        orig_sharded_state_dict = sharded_state_dict
+        (sharded_state_dict, flat_mapping, rename_mapping) = (
+            _replace_state_dict_keys_with_sharded_keys(sharded_state_dict)
+        )
+        pyt_state_dict = mcore_to_pyt_state_dict(sharded_state_dict, True)
+
+        storage_reader = _get_filesystem_reader(checkpoint_dir, cache_metadata=True)
+        planner = MCoreLoadPlanner(
+            shapes_validation_sharded_tensors=flexible_shape_sharded_tensors,
+            allow_shape_mismatch_sharded_tensors=allow_shape_mismatch_sharded_tensors,
+            flatten_state_dict=False,
+            flatten_sharded_tensors=False,
+        )
+
+        def _finalize() -> StateDict:
+            mcore_state_dict = {k: _unwrap_pyt_sharded_tensor(v) for k, v in pyt_state_dict.items()}
+            mcore_state_dict = _replace_sharded_keys_with_state_dict_keys(
+                mcore_state_dict, flat_mapping, rename_mapping  # type: ignore[arg-type]
+            )
+            _restore_dict_types(mcore_state_dict, orig_sharded_state_dict)
+            return mcore_state_dict
+
+        return pyt_state_dict, planner, storage_reader, _finalize
+
+    def prepare_async_load(
+        self, sharded_state_dict: ShardedStateDict, checkpoint_dir: Path
+    ) -> "AsyncLoadPlan":
+        """Run the plan phase of an async load and return a reusable plan.
+
+        Performs the collective DCP planning (metadata read, plan exchange,
+        destination tensor resolution). The returned plan can be cached and
+        replayed with :meth:`start_async_load_from_plan` for every reload of
+        the same checkpoint, skipping the plan phase entirely.
+
+        Args:
+            sharded_state_dict (ShardedStateDict): sharded state dict with mapping
+                information to instruct loading
+            checkpoint_dir (Path): checkpoint directory
+
+        Returns: an AsyncLoadPlan.
+        """
+        from torch.distributed.checkpoint.utils import _DistWrapper
+
+        from .async_load_utils import AsyncLoadPlan
+
+        pyt_state_dict, planner, storage_reader, finalize_fn = self._setup_async_load_state(
+            sharded_state_dict, checkpoint_dir
+        )
+
+        # Replicate torch.distributed.checkpoint's load plan phase.
+        storage_reader.reset()
+        dist_wrapper = _DistWrapper(group=None, use_dist=True, coordinator_rank=0)
+        use_collectives = True
+        metadata: Optional[Metadata] = None
+
+        def local_step():
+            nonlocal use_collectives
+            nonlocal metadata
+            try:
+                metadata = storage_reader.read_metadata()
+            except Exception:
+                logger.info("Global metadata is not found. Falling back to rank local metadata.")
+
+            if (
+                not metadata
+                and "kwargs" in inspect.signature(storage_reader.read_metadata).parameters
+            ):
+                try:
+                    metadata = storage_reader.read_metadata(rank=dist_wrapper.rank)
+                    use_collectives = False
+                except Exception:
+                    logger.info("Rank local metadata is not found.")
+
+            assert metadata is not None
+            planner.set_up_planner(pyt_state_dict, metadata, dist_wrapper.is_coordinator)
+
+            if "kwargs" in inspect.signature(storage_reader.set_up_storage_reader).parameters:
+                storage_reader.set_up_storage_reader(
+                    metadata,
+                    dist_wrapper.is_coordinator,
+                    rank=dist_wrapper.rank,
+                    use_collectives=use_collectives,
+                )
+            else:
+                storage_reader.set_up_storage_reader(metadata, dist_wrapper.is_coordinator)
+
+            local_plan = planner.create_local_plan()
+            local_plan = storage_reader.prepare_local_plan(local_plan)
+            return local_plan
+
+        def global_step(all_local_plans):
+            all_local_plans = planner.create_global_plan(all_local_plans)
+            all_local_plans = storage_reader.prepare_global_plan(all_local_plans)
+            return all_local_plans
+
+        central_plan = dist_wrapper.reduce_scatter("plan", local_step, global_step)
+        final_local_plan = planner.finish_plan(central_plan)
+        self.cached_global_metadata = metadata
+
+        # The worker thread reuses the planner (bound to pyt_state_dict during
+        # set_up_planner) so that sharded read items resolve into the correct
+        # narrowed destination sub-slices.
+        return AsyncLoadPlan(
+            storage_reader=storage_reader,
+            final_local_plan=final_local_plan,
+            metadata=metadata,
+            worker_state_dict=pyt_state_dict,
+            worker_planner=planner,
+            finalize_fn=finalize_fn,
+        )
+
+    def start_async_load_from_plan(
+        self, prepared_plan: "AsyncLoadPlan", call_idx: int = 0
+    ) -> "AsyncLoadRequest":
+        """Spawn the read thread for a previously prepared plan.
+
+        No collectives and no metadata reads, so it is safe to call while
+        other work (e.g. a forward pass) is in flight on the main thread.
+
+        Args:
+            prepared_plan (AsyncLoadPlan): plan built by :meth:`prepare_async_load`.
+            call_idx (int, optional): sequence number validated across ranks at
+                finalization. Defaults to 0.
+
+        Returns: an AsyncLoadRequest handle.
+        """
+        from .async_load_utils import spawn_async_read
+
+        return spawn_async_read(
+            storage_reader=prepared_plan.storage_reader,
+            final_local_plan=prepared_plan.final_local_plan,
+            worker_planner=prepared_plan.worker_planner,
+            finalize_fn=prepared_plan.finalize_fn,
+            call_idx=call_idx,
+        )
+
+    def prepare_async_load_reusing_topology(
+        self,
+        sharded_state_dict: ShardedStateDict,
+        checkpoint_dir: Path,
+        template_plan: "AsyncLoadPlan",
+    ) -> "AsyncLoadPlan":
+        """Build an AsyncLoadPlan reusing a template plan's collective work.
+
+        For loading multiple checkpoints that share the exact same state dict
+        structure and parallel topology: reuses ``template_plan.final_local_plan``
+        (built collectively by :meth:`prepare_async_load`) and only performs the
+        local per-checkpoint setup. The caller is responsible for the topology
+        actually matching; a mismatch may raise during the read or load wrong
+        shards.
+
+        Args:
+            sharded_state_dict (ShardedStateDict): sharded state dict with mapping
+                information to instruct loading
+            checkpoint_dir (Path): checkpoint directory
+            template_plan (AsyncLoadPlan): plan built by :meth:`prepare_async_load`
+                for a checkpoint with identical topology
+
+        Returns: an AsyncLoadPlan bound to this checkpoint's destination tensors.
+        """
+        from .async_load_utils import AsyncLoadPlan
+
+        pyt_state_dict, planner, storage_reader, finalize_fn = self._setup_async_load_state(
+            sharded_state_dict, checkpoint_dir
+        )
+
+        storage_reader.reset()
+        rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
+        metadata = storage_reader.read_metadata()
+
+        # is_coordinator=False everywhere: no collective is taking place, the
+        # planner state is only needed so resolve_tensor maps read items back
+        # to this checkpoint's pyt_state_dict.
+        planner.set_up_planner(pyt_state_dict, metadata, is_coordinator=False)
+
+        if "kwargs" in inspect.signature(storage_reader.set_up_storage_reader).parameters:
+            storage_reader.set_up_storage_reader(
+                metadata, is_coordinator=False, rank=rank, use_collectives=False
+            )
+        else:
+            storage_reader.set_up_storage_reader(metadata, False)
+
+        self.cached_global_metadata = metadata
+
+        return AsyncLoadPlan(
+            storage_reader=storage_reader,
+            final_local_plan=template_plan.final_local_plan,
+            metadata=metadata,
+            worker_state_dict=pyt_state_dict,
+            worker_planner=planner,
+            finalize_fn=finalize_fn,
+        )
 
     def load_tensors_metadata(self, checkpoint_dir: Path, metadata: Metadata = None):
         """Uses tensors metadata stored in the metadata file."""

--- a/tests/unit_tests/dist_checkpointing/test_async_load.py
+++ b/tests/unit_tests/dist_checkpointing/test_async_load.py
@@ -1,0 +1,227 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+
+"""Tests for the async distributed checkpoint load path."""
+
+import time
+
+import pytest
+import torch
+
+from megatron.core.dist_checkpointing import (
+    ShardedTensor,
+    load,
+    prepare_async_load,
+    prepare_async_load_reusing_topology,
+    save,
+    start_async_load_from_plan,
+)
+from megatron.core.dist_checkpointing.async_load_manager import AsyncCheckpointLoader
+from megatron.core.dist_checkpointing.cpu_shadow import ShadowBufferPool
+from megatron.core.dist_checkpointing.dict_utils import diff
+from tests.unit_tests.dist_checkpointing import TempNamedDir
+from tests.unit_tests.test_utilities import Utils
+
+
+def sharded_state_dict(fill_value: float):
+    """Sharded state dict with rank-dependent shards and a common entry."""
+    return {
+        'sd_keyA': ShardedTensor.from_rank_offsets(
+            'keyA', torch.full((2, 4), fill_value) + Utils.rank, (0, Utils.rank, Utils.world_size)
+        ),
+        'sd_keyB': ShardedTensor.from_rank_offsets(
+            'keyB',
+            torch.arange(3 * 5 * 7, dtype=torch.float).reshape(3, 5, 7) * fill_value,
+            (2, Utils.rank, Utils.world_size),
+        ),
+        'lr': 0.01,
+    }
+
+
+def assert_state_dicts_equal(actual, expected):
+    diffs = diff(actual, expected)
+    assert not any(len(x) for x in diffs), diffs
+
+
+class TestAsyncLoad:
+    def setup_method(self, method):
+        Utils.initialize_model_parallel()
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    def test_async_load_matches_sync_load(self, tmp_path_dist_ckpt):
+        with TempNamedDir(
+            tmp_path_dist_ckpt / 'test_async_load_matches_sync_load', sync=True
+        ) as ckpt_dir:
+            save(sharded_state_dict(1.0), ckpt_dir)
+            torch.distributed.barrier()
+
+            sync_loaded = load(sharded_state_dict(0.0), ckpt_dir)
+
+            plan = prepare_async_load(sharded_state_dict(0.0), ckpt_dir)
+            request = start_async_load_from_plan(plan)
+            async_loaded = request.maybe_finalize(blocking=True)
+
+            assert_state_dicts_equal(async_loaded, sync_loaded)
+
+    def test_async_load_non_blocking_poll(self, tmp_path_dist_ckpt):
+        with TempNamedDir(
+            tmp_path_dist_ckpt / 'test_async_load_non_blocking_poll', sync=True
+        ) as ckpt_dir:
+            save(sharded_state_dict(2.0), ckpt_dir)
+            torch.distributed.barrier()
+
+            sync_loaded = load(sharded_state_dict(0.0), ckpt_dir)
+
+            plan = prepare_async_load(sharded_state_dict(0.0), ckpt_dir)
+            request = start_async_load_from_plan(plan)
+            async_loaded = None
+            for _ in range(6000):
+                async_loaded = request.maybe_finalize(blocking=False)
+                if async_loaded is not None:
+                    break
+                time.sleep(0.01)
+            assert async_loaded is not None, 'async load did not complete in time'
+            assert request.is_done()
+
+            assert_state_dicts_equal(async_loaded, sync_loaded)
+
+    def test_reuse_topology_across_checkpoints(self, tmp_path_dist_ckpt):
+        with (
+            TempNamedDir(tmp_path_dist_ckpt / 'test_reuse_topology_A', sync=True) as ckpt_dir_a,
+            TempNamedDir(tmp_path_dist_ckpt / 'test_reuse_topology_B', sync=True) as ckpt_dir_b,
+        ):
+            save(sharded_state_dict(1.0), ckpt_dir_a)
+            save(sharded_state_dict(3.0), ckpt_dir_b)
+            torch.distributed.barrier()
+
+            sync_loaded_a = load(sharded_state_dict(0.0), ckpt_dir_a)
+            sync_loaded_b = load(sharded_state_dict(0.0), ckpt_dir_b)
+
+            # Template plan pays the collective planning cost once...
+            template_plan = prepare_async_load(sharded_state_dict(0.0), ckpt_dir_a)
+            request_a = start_async_load_from_plan(template_plan)
+            async_loaded_a = request_a.maybe_finalize(blocking=True)
+            assert_state_dicts_equal(async_loaded_a, sync_loaded_a)
+
+            # ...and the second checkpoint reuses it with local-only setup.
+            plan_b = prepare_async_load_reusing_topology(
+                sharded_state_dict(0.0), ckpt_dir_b, template_plan
+            )
+            request_b = start_async_load_from_plan(plan_b)
+            async_loaded_b = request_b.maybe_finalize(blocking=True)
+            assert_state_dicts_equal(async_loaded_b, sync_loaded_b)
+
+    @pytest.mark.skipif(Utils.world_size < 2, reason='call_idx mismatch requires at least 2 ranks')
+    def test_maybe_finalize_call_idx_mismatch_raises(self, tmp_path_dist_ckpt):
+        with TempNamedDir(tmp_path_dist_ckpt / 'test_call_idx_mismatch', sync=True) as ckpt_dir:
+            save(sharded_state_dict(1.0), ckpt_dir)
+            torch.distributed.barrier()
+
+            plan = prepare_async_load(sharded_state_dict(0.0), ckpt_dir)
+            request = start_async_load_from_plan(plan, call_idx=int(Utils.rank == 0))
+            with pytest.raises(RuntimeError, match='call_idx mismatch'):
+                request.maybe_finalize(blocking=True)
+
+
+class _DummyModelChunk(torch.nn.Module):
+    """Minimal module exposing a ShardedTensor sharded_state_dict for the loader."""
+
+    def __init__(self, fill_value: float):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.full((2, 4), fill_value) + Utils.rank)
+
+    def sharded_state_dict(self):
+        return {
+            'weight': ShardedTensor.from_rank_offsets(
+                'weight', self.weight.data, (0, Utils.rank, Utils.world_size)
+            )
+        }
+
+
+def _save_ckpt_with_tracker(base_dir, state_dict, iteration=1):
+    """Save ``state_dict`` under ``base_dir/iter_*`` and write the tracker file,
+    mirroring Megatron's on-disk layout so the loader's resolver works."""
+    iter_dir = base_dir / f'iter_{iteration:07d}'
+    if Utils.rank == 0:
+        iter_dir.mkdir(parents=True, exist_ok=True)
+    torch.distributed.barrier()
+    save(state_dict, iter_dir)
+    if Utils.rank == 0:
+        (base_dir / 'latest_checkpointed_iteration.txt').write_text(str(iteration))
+    torch.distributed.barrier()
+
+
+class TestShadowBufferPool:
+    def setup_method(self, method):
+        Utils.initialize_model_parallel()
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    def test_acquire_release_and_exhaustion(self):
+        pool = ShadowBufferPool([_DummyModelChunk(1.0)], num_buffers=1)
+        assert pool.num_buffers() == 1 and pool.num_free() == 1
+
+        shadow = pool.acquire()
+        assert pool.num_free() == 0
+        with pytest.raises(RuntimeError, match='exhausted'):
+            pool.acquire()
+
+        pool.release(shadow)
+        assert pool.num_free() == 1
+        with pytest.raises(RuntimeError, match='twice'):
+            pool.release(shadow)
+
+    def test_foreign_shadow_rejected(self):
+        pool = ShadowBufferPool([_DummyModelChunk(1.0)], num_buffers=1)
+        with pytest.raises(RuntimeError, match='foreign'):
+            pool.release({'model': {}})
+
+
+class TestAsyncCheckpointLoader:
+    def setup_method(self, method):
+        Utils.initialize_model_parallel()
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    def test_kick_finalize_release_into_model(self, tmp_path_dist_ckpt):
+        saved_model = [_DummyModelChunk(5.0)]
+        with TempNamedDir(tmp_path_dist_ckpt / 'test_loader_e2e', sync=True) as base_dir:
+            _save_ckpt_with_tracker(base_dir, saved_model[0].sharded_state_dict())
+
+            # Fresh model with different weights; the load must overwrite them.
+            target_model = [_DummyModelChunk(0.0)]
+            loader = AsyncCheckpointLoader(target_model)
+
+            handle = loader.kick('ckpt', str(base_dir))
+            finalized = loader.finalize(handle)
+            loader.load_finalized_to_model(finalized, strict=True)
+            loader.release(handle)
+
+            expected = torch.full((2, 4), 5.0) + Utils.rank
+            assert torch.equal(target_model[0].weight.data.cpu(), expected)
+
+    def test_reusing_topology_plan_cache_hit(self, tmp_path_dist_ckpt):
+        with (
+            TempNamedDir(tmp_path_dist_ckpt / 'test_loader_cache_a', sync=True) as base_a,
+            TempNamedDir(tmp_path_dist_ckpt / 'test_loader_cache_b', sync=True) as base_b,
+        ):
+            _save_ckpt_with_tracker(base_a, _DummyModelChunk(1.0).sharded_state_dict())
+            _save_ckpt_with_tracker(base_b, _DummyModelChunk(2.0).sharded_state_dict())
+
+            loader = AsyncCheckpointLoader([_DummyModelChunk(0.0)])
+
+            for key, base, fill in (('a', base_a, 1.0), ('b', base_b, 2.0)):
+                handle = loader.kick(key, str(base))
+                finalized = loader.finalize(handle)
+                loader.load_finalized_to_model(finalized, strict=True)
+                loader.release(handle)
+                expected = torch.full((2, 4), fill) + Utils.rank
+                assert torch.equal(loader._model[0].weight.data.cpu(), expected)
+
+            # Same topology -> one plan built, second load is a cache hit.
+            stats = loader.plan_cache_stats()
+            assert stats['distinct_plans'] == 1
+            assert stats['hits'] == 1 and stats['misses'] == 1


### PR DESCRIPTION
## What

Adds an async distributed checkpoint load path to `megatron/core/dist_checkpointing` that overlaps checkpoint disk reads with other work (e.g. a peer model's forward pass).

- `prepare_async_load` runs the world-collective DCP planning phase and returns a reusable `AsyncLoadPlan`.
- `start_async_load_from_plan` launches a background **thread** that only does file I/O + memcpy into pinned CPU tensors and never touches `torch.distributed`, so it cannot race the main thread's collectives.
- `AsyncLoadRequest.maybe_finalize` joins the thread and synchronizes completion / errors / ordering (`call_idx`) across ranks.
- `prepare_async_load_reusing_topology` reuses a template plan's collective result for another checkpoint of identical topology, doing only local per-checkpoint setup.

A higher-level orchestration layer is included:
- `cpu_shadow.py`: pinned-CPU shadow state dicts + `ShadowBufferPool`.
- `async_load_manager.py`: `AsyncCheckpointLoader` with a per-topology plan cache keyed by a save-time layout fingerprint.

New public entrypoints are exported from `megatron.core.dist_checkpointing`.

## Tests

`tests/unit_tests/dist_checkpointing/test_async_load.py` (8 tests): async/sync-load equivalence, non-blocking polling, topology reuse across checkpoints, cross-rank `call_idx` validation, `ShadowBufferPool` acquire/release semantics, and an end-to-end `AsyncCheckpointLoader` kick/finalize path. Verified on 2 and 8 GPUs; existing sync-load tests (`test_torch_dist.py`, `TestSerialization`) remain green (the sync `load()` path is untouched — all changes are additive).

## Future work (kept out of this PR to keep it focused)

- Cache the structure-derived state (`pyt_state_dict`, key mappings, planner, finalize closure) per shadow buffer: in the common same-topology / same-shadow reload, only the checkpoint metadata actually changes, yet `_setup_async_load_state` currently rebuilds `mcore_to_pyt_state_dict` (the bulk of the per-kick cost) every time.
- Fast-path full-plan replay when the same checkpoint is reloaded into the same shadow: skip prepare entirely and re-run the read thread over the cached plan.
- Fold the two `all_reduce`s in `maybe_finalize` (error flag, `call_idx` min/max) into a single collective.
