### PR TITLE
[Training] Add variable-length THD datasets

### DIFF
--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -81,6 +81,7 @@ def add_megatron_arguments(parser: argparse.ArgumentParser):
     parser = _add_msc_args(parser)
     parser = _add_kitchen_quantization_arguments(parser)
     parser = _add_sft_args(parser)
+    parser = _add_varlen_dataset_args(parser)
 
     parser = _add_fault_injector_args(parser)
 
@@ -1537,6 +1538,8 @@ def validate_args(args, defaults={}):
     # fsdp_dtensor checkpointing format checks.
     if args.ckpt_format == "fsdp_dtensor":
         assert args.use_megatron_fsdp, "--ckpt-format fsdp_dtensor is only tested with Megatron FSDP."
+
+    _validate_varlen_dataset_args(args)
 
     if args.sequence_packing_scheduler is not None:
         assert args.calculate_per_token_loss, (
@@ -3553,6 +3556,67 @@ def _add_sft_args(parser):
         'Supports file and lognormal distribution modes.',
     )
     return parser
+
+
+def _add_varlen_dataset_args(parser):
+    group = parser.add_argument_group(title='variable-length dataset')
+    group.add_argument(
+        '--use-varlen-dataset',
+        action='store_true',
+        help='Use variable-length instruction or pretraining data.',
+    )
+    group.add_argument(
+        '--varlen-sbhd-validation',
+        action='store_true',
+        help='Use a dense-model fixed-shape reference padded to --seq-length.',
+    )
+    group.add_argument(
+        '--varlen-mock-dataset-config-json',
+        type=str,
+        default=None,
+        help='Inline JSON or a JSON file configuring synthetic variable-length samples.',
+    )
+    return parser
+
+
+def _validate_varlen_dataset_args(args):
+    assert (
+        not args.varlen_sbhd_validation or args.use_varlen_dataset
+    ), "--varlen-sbhd-validation requires --use-varlen-dataset"
+    assert (
+        args.varlen_mock_dataset_config_json is None or args.use_varlen_dataset
+    ), "--varlen-mock-dataset-config-json requires --use-varlen-dataset"
+    assert (
+        args.varlen_mock_dataset_config_json is None or args.mock_data
+    ), "--varlen-mock-dataset-config-json requires --mock-data"
+    if not args.use_varlen_dataset:
+        return
+
+    assert not args.sft, "--use-varlen-dataset and --sft are mutually exclusive"
+    assert not args.fim_data, "--use-varlen-dataset and --fim-data are mutually exclusive"
+    assert not args.reset_position_ids, "--use-varlen-dataset does not support reset position ids"
+    assert not args.reset_attention_mask, (
+        "--use-varlen-dataset does not support reset attention masks"
+    )
+    assert not args.dataloader_inter_document_masking, (
+        "--use-varlen-dataset does not support inter-document masking"
+    )
+    args.create_attention_mask_in_dataloader = False
+    if args.varlen_sbhd_validation:
+        assert not args.dynamic_context_parallel, (
+            "--varlen-sbhd-validation cannot use dynamic context parallelism"
+        )
+        assert (
+            args.sequence_packing_scheduler is None
+        ), "--varlen-sbhd-validation cannot use a sequence packing scheduler"
+        assert not args.mock_data, "--varlen-sbhd-validation is only supported with real datasets"
+        assert args.num_experts is None, (
+            "--varlen-sbhd-validation currently supports dense models only; "
+            "MoE requires physical padding-mask propagation"
+        )
+    elif args.sequence_packing_scheduler is None:
+        args.sequence_packing_scheduler = "dp_balanced"
+
 
 def _add_logits_distillation_args(parser):
     group = parser.add_argument_group(title='Logits Distillation')

--- a/megatron/training/datasets/varlen_dataset.py
+++ b/megatron/training/datasets/varlen_dataset.py
@@ -1,0 +1,959 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+
+"""Variable-length packed (THD) dataset for SFT-style instruction data.
+
+This dataset is the entry point for the ``--use-varlen-dataset`` flag. It is
+independent of the ``--sft`` flag (no implicit coupling) but shares the same
+THD packing / cu_seqlens / dynamic-CP padding logic by extending the existing
+:class:`SFTDataset` family. The variable-length aspect is what matters here:
+samples have wildly different lengths and are packed into THD format for
+training throughput.
+
+Compared to :class:`SFTDataset`, this dataset adds:
+
+  * **Multi-source loading** — accepts HuggingFace Hub repo ids
+    (``owner/repo``), local ``.parquet`` files, and local ``.jsonl/.json``
+    files. Hub repos may expose multiple configs and splits; these are joined
+    logically without requiring their Arrow schemas to be identical.
+
+  * **Auto schema detection** — four input layouts are auto-detected by column
+    name. The three instruction-tuning layouts are normalized to the messages
+    list format expected by the parent ``SFTDataset.__getitem__``; the
+    ``pretrain-text`` fallback instead returns a raw string handled separately
+    in :meth:`VarlenDataset.__getitem__`:
+
+      * **openai-messages** — column ``messages`` (Llama post-training,
+        HuggingFaceH4/no_robots, ...)
+      * **sharegpt** — column ``conversations`` (OpenOrca, Vicuna, ...)
+      * **alpaca / dolly** — at least one of
+        ``instruction|prompt|query|question`` + one of
+        ``output|response|completion|answer``, plus optional context field
+        ``input|context``.
+      * **pretrain-text** — column ``text``; returns the raw string (no
+        messages list, no role masking), tokenized as plain pretraining text.
+
+  * **Mock variant** — :class:`MockVarlenDataset` mirrors
+    :class:`MockSFTDataset` with synthetic lognormal or file-based sequence
+    lengths, configured via ``--varlen-mock-dataset-config-json``.
+
+Limitations (raise a clear ``ValueError`` instead of silently mishandling):
+
+  * OpenAI/OpenCode text and tool-result content blocks are supported, but
+    image/audio/video content requires a multimodal dataset path.
+  * Tree-structured (OpenAssistant oasst1) and preference (chosen/rejected)
+    datasets are out of scope.
+
+For HF Hub repos, all configs are selected. Each config uses its ``train``
+split when present, otherwise all of its thematic splits. If the Hub Arrow
+builder cannot unify heterogeneous JSON rows, the rows are streamed into a
+map-style single-payload-column cache so Megatron can still index them.
+"""
+
+import json
+import logging
+import math
+import os
+from bisect import bisect_right
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Tuple
+
+import torch
+
+from megatron.core.datasets.megatron_dataset import LowLevelDataset
+from megatron.training.datasets.sft_dataset import (
+    IGNORE_INDEX,
+    MockSFTDataset,
+    MockSFTLowLevelDataset,
+    SFTDataset,
+    SFTDatasetConfig,
+    SFTLowLevelDataset,
+)
+
+logger = logging.getLogger(__name__)
+
+_HF_PAYLOAD_COLUMN = "__varlen_json_payload__"
+_HELD_OUT_SPLIT_NAMES = frozenset({"validation", "valid", "val", "test", "dev"})
+
+
+@dataclass
+class VarlenDatasetConfig(SFTDatasetConfig):
+    """Configuration for variable-length real and mock datasets."""
+
+    sbhd_validation: bool = False
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        assert (
+            not self.sbhd_validation or not self.dynamic_context_parallel
+        ), "SBHD validation cannot use dynamic context parallelism"
+
+
+@dataclass
+class ChatTemplateSample:
+    """Conversation plus keyword arguments consumed by the chat template."""
+
+    messages: List[Dict[str, Any]]
+    chat_template_kwargs: Dict[str, Any] = field(default_factory=dict)
+
+
+# Field-name synonyms (probed in order; first non-empty wins).
+_INSTRUCTION_FIELDS: Tuple[str, ...] = ("instruction", "prompt", "query", "question")
+_OUTPUT_FIELDS: Tuple[str, ...] = ("output", "response", "completion", "answer")
+# Supplementary user-turn context: Stanford Alpaca's "input", Dolly's "context".
+_EXTRA_INPUT_FIELDS: Tuple[str, ...] = ("input", "context")
+
+# ShareGPT "from" value -> chat-template "role". Unknown values fall back to
+# "user" so downstream tokenization does not crash on unfamiliar speakers.
+_SHAREGPT_ROLE_MAP: Dict[str, str] = {
+    "human": "user",
+    "user": "user",
+    "gpt": "assistant",
+    "assistant": "assistant",
+    "model": "assistant",
+    "chatgpt": "assistant",
+    "bing": "assistant",
+    "bard": "assistant",
+    "system": "system",
+    "tool": "tool",
+    "function": "tool",
+    "observation": "tool",
+}
+
+
+def _looks_like_hf_id(path: str) -> bool:
+    """Heuristic: does ``path`` look like an ``owner/repo`` HF dataset id?
+
+    True iff ``path`` contains ``/``, is not an absolute/relative file path,
+    and does not exist on the local filesystem.
+    """
+    if not path:
+        return False
+    if os.path.exists(path):
+        return False
+    if path.startswith(("/", "./", "../")):
+        return False
+    return "/" in path
+
+
+def _first_present(sample: Dict[str, Any], fields: Iterable[str]) -> Optional[str]:
+    """Return the first non-empty string value among the given fields, or None."""
+    for f in fields:
+        v = sample.get(f)
+        if v in (None, ""):
+            continue
+        if not isinstance(v, str):
+            raise ValueError(
+                f"VarlenDataset: field '{f}' must be a string, " f"got {type(v).__name__}."
+            )
+        return v
+    return None
+
+
+def _ensure_str_content(content: Any, where: str) -> str:
+    """Validate that a turn's content is a plain string (reject multi-modal lists)."""
+    if content is None:
+        return ""
+    if not isinstance(content, str):
+        raise ValueError(
+            f"VarlenDataset: {where} content must be a string, "
+            f"got {type(content).__name__}. Multi-modal datasets (e.g. "
+            "content as a list of image/text parts) are not supported."
+        )
+    return content
+
+
+def _json_text(value: Any, where: str) -> str:
+    """Convert a structured text payload to its stable JSON representation."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, ensure_ascii=False, sort_keys=True)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"VarlenDataset: {where} is not JSON serializable.") from exc
+
+
+def _normalize_openai_content(content: Any, where: str) -> Tuple[str, Dict[str, str]]:
+    """Normalize text-only OpenAI/OpenCode content blocks to a string.
+
+    OpenCode stores tool outputs as ``tool-result`` blocks rather than plain
+    strings. Text blocks are losslessly flattened for text chat templates;
+    image/audio/video blocks remain unsupported by this text-only dataset.
+    """
+    if content is None:
+        return "", {}
+    if isinstance(content, str):
+        return content, {}
+    if not isinstance(content, list):
+        raise ValueError(
+            f"VarlenDataset: {where} content must be a string or a list of text blocks, "
+            f"got {type(content).__name__}."
+        )
+
+    pieces: List[str] = []
+    metadata: Dict[str, str] = {}
+    for index, block in enumerate(content):
+        block_where = f"{where} content block {index}"
+        if isinstance(block, str):
+            pieces.append(block)
+            continue
+        if not isinstance(block, dict):
+            raise ValueError(
+                f"VarlenDataset: {block_where} must be a string or object, "
+                f"got {type(block).__name__}."
+            )
+
+        block_type = block.get("type")
+        if block_type in ("text", "input_text", "output_text"):
+            pieces.append(_json_text(block.get("text", block.get("value")), block_where))
+        elif block_type == "tool-result":
+            output = block.get("output")
+            if isinstance(output, dict):
+                output = output.get("value", output.get("content", output))
+            pieces.append(_json_text(output, f"{block_where} output"))
+            if block.get("toolCallId"):
+                metadata.setdefault("tool_call_id", str(block["toolCallId"]))
+            if block.get("toolName"):
+                metadata.setdefault("name", str(block["toolName"]))
+        else:
+            raise ValueError(
+                f"VarlenDataset: unsupported {block_where} type {block_type!r}. "
+                "Multimodal image/audio/video content requires a multimodal dataset path."
+            )
+
+    return "\n".join(pieces), metadata
+
+
+def _ensure_list_field(value: Any, field_name: str) -> List[Any]:
+    """Return a list field, decoding JSON-encoded Parquet columns when needed."""
+    if value in (None, ""):
+        return []
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"VarlenDataset: field '{field_name}' contains invalid JSON.") from exc
+    if not isinstance(value, list):
+        raise ValueError(
+            f"VarlenDataset: field '{field_name}' must be a list or a JSON-encoded list, "
+            f"got {type(value).__name__}."
+        )
+    return value
+
+
+def _normalize_tools(tools: Any) -> List[Dict[str, Any]]:
+    """Convert OpenCode tool definitions; preserve OpenAI definitions."""
+    normalized_tools: List[Dict[str, Any]] = []
+    for index, tool in enumerate(_ensure_list_field(tools, "tools")):
+        if not isinstance(tool, dict):
+            raise ValueError(
+                f"VarlenDataset: tools[{index}] must be an object, got {type(tool).__name__}."
+            )
+        if "id" not in tool:
+            normalized_tools.append(tool)
+            continue
+        input_schema = tool.get("inputSchema") or {}
+        if not isinstance(input_schema, dict):
+            raise ValueError(f"VarlenDataset: tools[{index}].inputSchema must be an object.")
+        normalized_tools.append(
+            {
+                "type": "function",
+                "function": {
+                    "name": str(tool["id"]),
+                    "description": str(tool.get("description") or ""),
+                    "parameters": input_schema.get("jsonSchema", input_schema),
+                },
+            }
+        )
+    return normalized_tools
+
+
+def _alpaca_to_messages(sample: Dict[str, Any]) -> List[Dict[str, str]]:
+    """Convert an Alpaca/Dolly-style sample to a 3-turn messages list."""
+    instruction = _first_present(sample, _INSTRUCTION_FIELDS) or ""
+    extra_input = _first_present(sample, _EXTRA_INPUT_FIELDS) or ""
+    output = _first_present(sample, _OUTPUT_FIELDS) or ""
+    user_content = f"{instruction}\n\n{extra_input}" if extra_input else instruction
+    return [
+        {"role": "system", "content": ""},
+        {"role": "user", "content": user_content},
+        {"role": "assistant", "content": output},
+    ]
+
+
+def _sharegpt_to_messages(sample: Dict[str, Any]) -> List[Dict[str, str]]:
+    """Convert a ShareGPT ``conversations`` sample to a messages list.
+
+    Prepends an empty ``system`` turn unless the conversation already starts
+    with one, so ``SFTDataset._split_conversations`` treats the sample as a
+    single conversation.
+    """
+    conv = _ensure_list_field(sample.get("conversations"), "conversations")
+    out: List[Dict[str, str]] = []
+    first_speaker = (conv[0].get("from") or "").lower() if conv else ""
+    if first_speaker != "system":
+        out.append({"role": "system", "content": ""})
+    for turn in conv:
+        speaker = (turn.get("from") or "").lower()
+        role = _SHAREGPT_ROLE_MAP.get(speaker, "user")
+        content = _ensure_str_content(turn.get("value"), f"sharegpt turn role={role}")
+        out.append({"role": role, "content": content})
+    return out
+
+
+def _messages_passthrough(sample: Dict[str, Any]) -> ChatTemplateSample:
+    """Normalize an OpenAI ``messages`` sample without dropping template metadata.
+
+    Fields such as ``reasoning_content``, ``tool_calls``, ``name``, and
+    ``tool_call_id`` are interpreted by model-specific Hugging Face chat
+    templates. Top-level ``tools`` are forwarded as a template keyword
+    argument. This is required for tool-integrated datasets such as
+    ``nvidia/Nemotron-SFT-Math-v3``.
+    """
+    raw = _ensure_list_field(sample.get("messages"), "messages")
+    out: List[Dict[str, Any]] = []
+    role_map = {"developer": "system"}
+    supported_roles = {"system", "user", "assistant", "tool"}
+    for index, message in enumerate(raw):
+        if not isinstance(message, dict):
+            raise ValueError(
+                f"VarlenDataset: messages[{index}] must be an object, "
+                f"got {type(message).__name__}."
+            )
+        role = str(message.get("role") or "user").lower()
+        role = role_map.get(role, role)
+        if role not in supported_roles:
+            raise ValueError(f"VarlenDataset: unsupported messages[{index}] role {role!r}.")
+        content, content_metadata = _normalize_openai_content(
+            message.get("content"), f"messages turn {index} role={role}"
+        )
+        normalized = dict(message)
+        normalized["role"] = role
+        normalized["content"] = content
+        for key, value in content_metadata.items():
+            normalized.setdefault(key, value)
+
+        tool_calls = normalized.get("tool_calls")
+        if tool_calls not in (None, ""):
+            normalized["tool_calls"] = _ensure_list_field(
+                tool_calls, f"messages[{index}].tool_calls"
+            )
+
+        function_call = normalized.get("function_call")
+        if function_call and not normalized.get("tool_calls"):
+            if isinstance(function_call, str):
+                try:
+                    function_call = json.loads(function_call)
+                except json.JSONDecodeError as exc:
+                    raise ValueError(
+                        f"VarlenDataset: messages[{index}].function_call contains invalid JSON."
+                    ) from exc
+            if not isinstance(function_call, dict):
+                raise ValueError(
+                    f"VarlenDataset: messages[{index}].function_call must be an object."
+                )
+            normalized["tool_calls"] = [{"type": "function", "function": dict(function_call)}]
+        out.append(normalized)
+
+    if out and out[0]["role"] != "system":
+        out.insert(0, {"role": "system", "content": ""})
+
+    chat_template_kwargs = sample.get("chat_template_kwargs")
+    if isinstance(chat_template_kwargs, str):
+        try:
+            chat_template_kwargs = json.loads(chat_template_kwargs)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                "VarlenDataset: field 'chat_template_kwargs' contains invalid JSON."
+            ) from exc
+    if chat_template_kwargs is None:
+        chat_template_kwargs = {}
+    if not isinstance(chat_template_kwargs, dict):
+        raise ValueError(
+            "VarlenDataset: field 'chat_template_kwargs' must be an object or a "
+            "JSON-encoded object."
+        )
+    chat_template_kwargs = dict(chat_template_kwargs)
+
+    tools = _normalize_tools(sample.get("tools"))
+    if tools:
+        chat_template_kwargs["tools"] = tools
+    return ChatTemplateSample(out, chat_template_kwargs)
+
+
+def _raw_text_loader(sample: Dict[str, Any]) -> str:
+    """Return the ``text`` column unchanged for pretrain-style packed runs.
+
+    Unlike the SFT schemas this returns a plain string (no messages list).
+    :class:`VarlenDataset.__getitem__` dispatches on the return type to pick
+    a tokenization path that skips chat templating and prompt masking.
+    """
+    text = sample.get("text", "")
+    if text is None:
+        text = ""
+    if not isinstance(text, str):
+        raise ValueError(
+            f"VarlenDataset (pretrain-text schema): 'text' must be a string, "
+            f"got {type(text).__name__}."
+        )
+    return text
+
+
+def _select_converter(column_names: List[str]) -> Tuple[Callable[[Dict[str, Any]], Any], str]:
+    """Pick a sample converter based on dataset column names.
+
+    Priority (most explicit first): openai-messages > sharegpt > alpaca/dolly
+    > pretrain-text. ``pretrain-text`` is the fallback for datasets that
+    only carry a single ``text`` column (e.g. Dolma / OLMo midtraining
+    corpora) — long-context pretraining packed through the same THD path
+    as SFT.
+    """
+    cols = set(column_names)
+    if "messages" in cols:
+        return _messages_passthrough, "openai-messages"
+    if "conversations" in cols:
+        return _sharegpt_to_messages, "sharegpt"
+    has_instr = any(f in cols for f in _INSTRUCTION_FIELDS)
+    has_out = any(f in cols for f in _OUTPUT_FIELDS)
+    if has_instr and has_out:
+        return _alpaca_to_messages, "alpaca"
+    if "text" in cols:
+        return _raw_text_loader, "pretrain-text"
+    raise ValueError(
+        "VarlenDataset cannot infer schema from columns "
+        f"{sorted(cols)}. Supported schemas: "
+        f"alpaca/dolly ({'|'.join(_INSTRUCTION_FIELDS)} + "
+        f"{'|'.join(_OUTPUT_FIELDS)} [+ optional {'|'.join(_EXTRA_INPUT_FIELDS)}]), "
+        "sharegpt (conversations), openai-messages (messages), "
+        "pretrain-text (text)."
+    )
+
+
+def _has_multiple_supported_schemas(column_names: List[str]) -> bool:
+    """Return whether a union schema can contain more than one supported row shape."""
+    cols = set(column_names)
+    matches = int("messages" in cols) + int("conversations" in cols) + int("text" in cols)
+    matches += int(
+        any(field in cols for field in _INSTRUCTION_FIELDS)
+        and any(field in cols for field in _OUTPUT_FIELDS)
+    )
+    return matches > 1
+
+
+def _has_schema_value(value: Any) -> bool:
+    """Return whether a nullable union-schema field carries a row value."""
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return value != ""
+    if isinstance(value, (list, tuple, dict)):
+        return bool(value)
+    if isinstance(value, float) and math.isnan(value):
+        return False
+    return True
+
+
+def _convert_mixed_schema_sample(
+    sample: Dict[str, Any], fallback_converter: Callable[[Dict[str, Any]], Any]
+) -> Any:
+    """Select a converter from populated row fields, falling back for empty rows."""
+    populated_columns = [key for key, value in sample.items() if _has_schema_value(value)]
+    try:
+        converter, _ = _select_converter(populated_columns)
+    except ValueError:
+        converter = fallback_converter
+    return converter(sample)
+
+
+def _select_hf_splits(available_splits: List[str]) -> List[str]:
+    """Prefer train; otherwise retain thematic splits and exclude held-out names."""
+    train_split = next((split for split in available_splits if split.lower() == "train"), None)
+    if train_split is not None:
+        return [train_split]
+    return [split for split in available_splits if split.lower() not in _HELD_OUT_SPLIT_NAMES]
+
+
+def _iter_hf_data_file_rows(data_file: str) -> Iterator[Dict[str, Any]]:
+    """Read raw JSONL or Parquet rows without a declared Hugging Face schema."""
+    import fsspec
+
+    normalized_path = data_file.lower().split("?", 1)[0]
+    if normalized_path.endswith(".parquet"):
+        import pyarrow.parquet as pq
+
+        with fsspec.open(data_file, "rb") as stream:
+            parquet_file = pq.ParquetFile(stream)
+            for batch in parquet_file.iter_batches(batch_size=1024):
+                yield from batch.to_pylist()
+        return
+
+    uncompressed_path = normalized_path
+    for compression_suffix in (".gz", ".bz2", ".xz", ".zst"):
+        if uncompressed_path.endswith(compression_suffix):
+            uncompressed_path = uncompressed_path[: -len(compression_suffix)]
+            break
+    if uncompressed_path.endswith(".json"):
+        with fsspec.open(data_file, "rt", encoding="utf-8", compression="infer") as stream:
+            rows = json.load(stream)
+        if not isinstance(rows, list):
+            raise ValueError(f"VarlenDataset: expected a JSON array in {data_file!r}.")
+        for index, row in enumerate(rows):
+            if not isinstance(row, dict):
+                raise ValueError(f"VarlenDataset: expected an object at {data_file!r}[{index}].")
+            yield row
+        return
+
+    with fsspec.open(data_file, "rt", encoding="utf-8", compression="infer") as stream:
+        for line in stream:
+            if line.strip():
+                row = json.loads(line)
+                if not isinstance(row, dict):
+                    raise ValueError(f"VarlenDataset: expected JSON objects in {data_file!r}.")
+                yield row
+
+
+def _iter_hf_rows_as_json(data_files: List[str]) -> Iterator[Dict[str, str]]:
+    """Stream raw heterogeneous Hub rows as one JSON payload column."""
+    for data_file in data_files:
+        for row in _iter_hf_data_file_rows(data_file):
+            yield {_HF_PAYLOAD_COLUMN: json.dumps(row, ensure_ascii=False)}
+
+
+def _json_payload_to_item(sample: Dict[str, Any]) -> Any:
+    """Decode and normalize a row produced by :func:`_iter_hf_rows_as_json`."""
+    row = json.loads(sample[_HF_PAYLOAD_COLUMN])
+    fallback_converter, _ = _select_converter(list(row))
+    return _convert_mixed_schema_sample(row, fallback_converter)
+
+
+class VarlenLowLevelDataset(SFTLowLevelDataset):
+    """Low-level loader: HF Hub repo / local parquet / local jsonl, normalized.
+
+    Dataset path interpretation:
+
+      * HF Hub repo id (e.g. ``nvidia/Nemotron-SFT-Math-v4``) — contains ``/``
+        and does not exist locally. By default, all configs are considered;
+        each uses ``train`` when available, otherwise all thematic splits.
+      * Local ``.parquet`` — loaded via
+        ``datasets.load_dataset("parquet", data_files=path, split="all")``;
+        parquet's footer schema makes chunked loading safe.
+      * Local ``.json`` arrays and line-delimited jsonl files — loaded via
+        pandas and wrapped in ``Dataset.from_pandas``.
+        We avoid ``datasets.load_dataset("json", ...)`` for local files
+        because its pyarrow-based JSON reader infers schema per parallel
+        chunk and fails with ``CastError`` when the union of fields varies
+        between rows (e.g. LongAlpaca-12k).
+
+    Each config/split remains a separate map-style component and is joined by
+    deterministic interleaving. This avoids requiring Arrow feature
+    compatibility across components and prevents index-based train/validation
+    splits from following config order. Components with nullable union schemas
+    select converters from each row's populated fields. Hub JSON that fails
+    Arrow schema unification is streamed into a cached JSON payload column and
+    normalized per row.
+    """
+
+    def __init__(self, dataset_path: str) -> None:
+        try:
+            from datasets import (
+                Dataset,
+                Features,
+                Value,
+                get_dataset_config_names,
+                get_dataset_split_names,
+                load_dataset,
+                load_dataset_builder,
+            )
+            from datasets.exceptions import DatasetGenerationError
+        except ImportError as exc:
+            raise ImportError(
+                "VarlenDataset requires the `datasets` library " "(pip install datasets)."
+            ) from exc
+        try:
+            from datasets.table import CastError
+        except ImportError:
+            CastError = DatasetGenerationError
+
+        self._datasets: List[Any] = []
+        self._converters: List[Callable[[Dict[str, Any]], Any]] = []
+        self._dispatch_per_row: List[bool] = []
+        self._schema_names: List[str] = []
+        self._cumulative_sizes: List[int] = []
+
+        def add_component(dataset: Any, payload: bool = False) -> None:
+            column_names = list(dataset.column_names)
+            if payload:
+                converter = _json_payload_to_item
+                schema_name = "json-payload"
+                dispatch_per_row = False
+            else:
+                converter, schema_name = _select_converter(column_names)
+                dispatch_per_row = _has_multiple_supported_schemas(column_names)
+            component_size = len(dataset)
+            self._datasets.append(dataset)
+            self._converters.append(converter)
+            self._dispatch_per_row.append(dispatch_per_row)
+            self._schema_names.append(schema_name)
+            previous_size = self._cumulative_sizes[-1] if self._cumulative_sizes else 0
+            self._cumulative_sizes.append(previous_size + component_size)
+
+        if _looks_like_hf_id(dataset_path):
+            selected_sources: List[Tuple[str, str]] = []
+            for selected_config in get_dataset_config_names(dataset_path):
+                available_splits = list(get_dataset_split_names(dataset_path, selected_config))
+                selected_splits = _select_hf_splits(available_splits)
+                selected_sources.extend(
+                    (selected_config, selected_split) for selected_split in selected_splits
+                )
+
+            if not selected_sources:
+                raise ValueError(
+                    f"VarlenDataset: no training or thematic split was found in {dataset_path}; "
+                    f"held-out splits {sorted(_HELD_OUT_SPLIT_NAMES)} are not loaded."
+                )
+
+            for selected_config, selected_split in selected_sources:
+                source = f"{dataset_path}:{selected_config}/{selected_split}"
+                try:
+                    dataset = load_dataset(dataset_path, name=selected_config, split=selected_split)
+                    add_component(dataset)
+                except (DatasetGenerationError, CastError):
+                    builder = load_dataset_builder(dataset_path, name=selected_config)
+                    data_files = builder.config.data_files.get(selected_split)
+                    if not data_files:
+                        raise ValueError(
+                            f"VarlenDataset: could not resolve raw files for {source}."
+                        )
+                    logger.warning(
+                        "Arrow schema generation failed for %s; materializing a map-style "
+                        "JSON payload cache directly from the raw data files.",
+                        source,
+                    )
+                    dataset = Dataset.from_generator(
+                        _iter_hf_rows_as_json,
+                        features=Features({_HF_PAYLOAD_COLUMN: Value("string")}),
+                        gen_kwargs={"data_files": [str(data_file) for data_file in data_files]},
+                    )
+                    add_component(dataset, payload=True)
+        elif dataset_path.endswith(".parquet"):
+            add_component(load_dataset("parquet", data_files=dataset_path, split="all"))
+        else:
+            try:
+                import pandas as pd
+            except ImportError as exc:
+                raise ImportError(
+                    "VarlenDataset requires `pandas` to load local JSON/JSONL "
+                    "files (pip install pandas)."
+                ) from exc
+            df = pd.read_json(dataset_path, lines=not dataset_path.lower().endswith(".json"))
+            add_component(Dataset.from_pandas(df, preserve_index=False))
+
+        if not self._datasets:
+            raise ValueError(f"VarlenDataset: no data was loaded from {dataset_path!r}.")
+        self.dataset = self._datasets[0] if len(self._datasets) == 1 else tuple(self._datasets)
+
+        # A coprime affine permutation scatters contiguous component ranges
+        # across logical indices without storing an O(number-of-samples) map.
+        # Keep the identity mapping for a single component.
+        total_size = self._cumulative_sizes[-1]
+        self._index_permutation_stride = 1
+        self._index_permutation_offset = 0
+        if len(self._datasets) > 1 and total_size > 1:
+            candidate = min(total_size - 1, max(2, total_size * 5 // 8))
+            while math.gcd(candidate, total_size) != 1:
+                candidate += 1
+                if candidate == total_size:
+                    candidate = 1
+            self._index_permutation_stride = candidate
+            self._index_permutation_offset = total_size // 2
+
+        unique_schema_names = list(dict.fromkeys(self._schema_names))
+        self._schema_name = (
+            unique_schema_names[0]
+            if len(unique_schema_names) == 1
+            else f"mixed({','.join(unique_schema_names)})"
+        )
+
+    @property
+    def schema_name(self) -> str:
+        """Detected schema name: ``alpaca`` / ``sharegpt`` / ``openai-messages`` /
+        ``pretrain-text`` / ``json-payload`` (the raw-schema fallback)."""
+        return self._schema_name
+
+    def __len__(self) -> int:
+        return self._cumulative_sizes[-1]
+
+    def _locate_permuted_index(self, idx: int) -> Tuple[int, int]:
+        """Map a logical index to component/local indices without an O(N) index map."""
+        if len(self._datasets) == 1:
+            return 0, idx
+
+        physical_index = (
+            idx * self._index_permutation_stride + self._index_permutation_offset
+        ) % len(self)
+        component_index = bisect_right(self._cumulative_sizes, physical_index)
+        component_start = self._cumulative_sizes[component_index - 1] if component_index > 0 else 0
+        return component_index, physical_index - component_start
+
+    def __getitem__(self, idx: int) -> Any:
+        idx = int(idx)
+        if idx < 0:
+            idx += len(self)
+        if idx < 0 or idx >= len(self):
+            raise IndexError(idx)
+        component_index, local_index = self._locate_permuted_index(idx)
+        sample = self._datasets[component_index][local_index]
+        converter = self._converters[component_index]
+        if self._dispatch_per_row[component_index]:
+            return _convert_mixed_schema_sample(sample, converter)
+        return converter(sample)
+
+
+class VarlenDataset(SFTDataset):
+    """Variable-length single-sample SFT dataset for the packed-sequence path.
+
+    Each ``__getitem__`` returns **one tokenized conversation** in unpacked
+    form: ``tokens``/``labels``/``loss_mask``/``position_ids`` whose length
+    equals the sample's actual token count (padded to ``pad_granularity``,
+    NOT to ``sequence_length``), plus ``original_seq_len``/``padded_seq_len``
+    tensors that the upstream packing scheduler consumes directly via
+    :func:`get_batch_and_global_seqlens`.
+
+    This is the schema described in :class:`BasePackingScheduler.get_required_sample_keys`.
+    It deliberately skips the multi-conversation pre-packing that
+    :class:`SFTDataset.__getitem__` does, letting the upstream scheduler
+    pack variable-length samples across the DPxCP grid with no per-sample
+    padding waste.
+
+    Truncation: samples longer than ``config.sequence_length`` are truncated
+    on the right; an EOD token is appended if the truncation removed it.
+    """
+
+    @staticmethod
+    def numel_low_level_dataset(low_level_dataset: LowLevelDataset) -> int:
+        return len(low_level_dataset)
+
+    @staticmethod
+    def build_low_level_dataset(dataset_path: str, config: VarlenDatasetConfig) -> LowLevelDataset:
+        return VarlenLowLevelDataset(dataset_path)
+
+    def __getitem__(self, idx: int) -> Dict[str, torch.Tensor]:
+        tokenizer = self.config.tokenizer
+        max_len = self.config.sequence_length
+        # HuggingFaceTokenizer returns None for ``pad`` when the underlying
+        # tokenizer has no explicit pad token (common for raw pretraining
+        # tokenizers like Qwen3). Fall back to eod for padding — irrelevant
+        # for loss because loss_mask zeros pad positions out.
+        eod = tokenizer.eod
+        pad = tokenizer.pad if tokenizer.pad is not None else eod
+        assert (
+            eod is not None
+        ), "VarlenDataset requires the tokenizer to expose an EOD/EOS token id."
+
+        # 1. Pull a single item from the low-level dataset. OpenAI-style data
+        #    carries messages plus optional chat-template kwargs (for example,
+        #    top-level tool definitions); other SFT schemas return a messages
+        #    list, and pretrain-text returns a raw string.
+        item = self.dataset[int(self.indices[idx % len(self.indices)])]
+
+        assert not self.config.reset_position_ids
+        assert not self.config.create_attention_mask and not self.config.reset_attention_mask
+
+        # 2. Tokenize. SFT schemas go through tokenize_conversation (chat
+        #    template + role-aware target masking); pretrain-text bypasses
+        #    chat templating and uses the plain ``tokenize`` interface,
+        #    treating every token as a target (no prompt masking).
+        if isinstance(item, str):
+            ids = list(tokenizer.tokenize(item))
+            tokens_list = ids
+            targets_list = list(ids)
+        elif isinstance(item, ChatTemplateSample):
+            tokens, targets = tokenizer.tokenize_conversation(
+                item.messages,
+                return_target=True,
+                add_generation_prompt=False,
+                chat_template_kwargs=item.chat_template_kwargs,
+            )
+            tokens_list = tokens.tolist()
+            targets_list = targets.tolist()
+        else:
+            tokens, targets = tokenizer.tokenize_conversation(
+                item, return_target=True, add_generation_prompt=False
+            )
+            tokens_list = tokens.tolist()
+            targets_list = targets.tolist()
+
+        assert len(tokens_list) == len(targets_list)
+
+        # 2b. Guard against an empty tokenization (e.g. a blank ``pretrain-text``
+        #     row where ``tokenizer.tokenize("")`` returns no ids). Represent it
+        #     as a single end-of-document token so the next-token shift still
+        #     yields a valid 1-token sample instead of raising on
+        #     ``tokens_list[-1]`` below or producing a zero-length sequence.
+        if len(tokens_list) == 0:
+            tokens_list = [eod, eod]
+            targets_list = [eod, eod]
+
+        # 3. Right-truncate to ``sequence_length + 1`` (we drop the last token
+        #    after the input/label shift below). A forced EOD is trainable only
+        #    when truncation stays within an already-trainable span.
+        if len(tokens_list) > max_len + 1:
+            tokens_list = tokens_list[: max_len + 1]
+            targets_list = targets_list[: max_len + 1]
+        if len(tokens_list) == max_len + 1 and tokens_list[-1] != eod:
+            eod_is_trainable = targets_list[-2] != IGNORE_INDEX and targets_list[-1] != IGNORE_INDEX
+            tokens_list[-1] = eod
+            targets_list[-1] = eod if eod_is_trainable else IGNORE_INDEX
+
+        # 4. Ensure EOD is the last token for short samples without turning a
+        #    prompt-only sample into an EOS training target.
+        if tokens_list[-1] != eod:
+            tokens_list.append(eod)
+            targets_list.append(eod if targets_list[-1] != IGNORE_INDEX else IGNORE_INDEX)
+
+        valid_len = len(tokens_list) - 1
+
+        # 5a. SBHD validation mode: right-pad to sequence_length + 1, drop
+        #     packing metadata, return shape [sequence_length]. Useful as a
+        #     dense-model numerical reference for THD verification (no scheduler).
+        if self.config.sbhd_validation:
+            pad_len = max_len + 1 - len(tokens_list)
+            if pad_len > 0:
+                tokens_list.extend([pad] * pad_len)
+                targets_list.extend([pad] * pad_len)
+            assert len(tokens_list) == max_len + 1
+            input_ids = torch.tensor(tokens_list[:-1], dtype=torch.int64)
+            labels = torch.tensor(targets_list[1:], dtype=torch.int64)
+            loss_mask = torch.ones(max_len, dtype=torch.float32)
+            loss_mask[valid_len:] = 0.0  # mask the right-padded tail by position
+            loss_mask[labels == IGNORE_INDEX] = 0.0
+            if self.config.eod_mask_loss:
+                loss_mask[input_ids == eod] = 0.0
+            return {
+                'tokens': input_ids,
+                'labels': labels,
+                'loss_mask': loss_mask,
+                'position_ids': torch.arange(max_len, dtype=torch.int64),
+            }
+
+        original_seq_len = len(tokens_list) - 1  # length after the shift below
+
+        # 5b. THD path: pad to pad_granularity (dp_size * cp_size * 2 * sp),
+        #     the minimum alignment required by CP slicing. We deliberately
+        #     do NOT pad to sequence_length — the upstream packing scheduler
+        #     will combine variable-length samples up to
+        #     max_seqlen_per_dp_cp_rank.
+        pad_granularity = self._calculate_padding_divisor()
+        mod = original_seq_len % pad_granularity
+        if mod != 0:
+            pad_len = pad_granularity - mod
+            tokens_list.extend([pad] * pad_len)
+            targets_list.extend([pad] * pad_len)
+        padded_seq_len = len(tokens_list) - 1
+
+        # 6. Apply the next-token shift.
+        input_ids = torch.tensor(tokens_list[:-1], dtype=torch.int64)
+        labels = torch.tensor(targets_list[1:], dtype=torch.int64)
+        position_ids = torch.arange(padded_seq_len, dtype=torch.int64)
+        loss_mask = torch.ones(padded_seq_len, dtype=torch.float32)
+        loss_mask[valid_len:] = 0.0  # mask the right-padded tail by position
+        loss_mask[labels == IGNORE_INDEX] = 0.0
+        if self.config.eod_mask_loss:
+            loss_mask[input_ids == eod] = 0.0
+
+        return {
+            'tokens': input_ids,
+            'labels': labels,
+            'loss_mask': loss_mask,
+            'position_ids': position_ids,
+            # The packing scheduler consumes these directly; cu_seqlens /
+            # max_seqlen are produced downstream in _pack_sequences.
+            'original_seq_len': torch.tensor([original_seq_len], dtype=torch.int32),
+            'padded_seq_len': torch.tensor([padded_seq_len], dtype=torch.int32),
+        }
+
+
+class MockVarlenDataset(MockSFTDataset):
+    """Mock variable-length dataset for benchmarking the varlen path.
+
+    Uses :class:`MockSFTLowLevelDataset` for sequence-length sampling (lognormal
+    distribution or per-line CSV, using the same JSON schema as
+    ``--sft-mock-dataset-config-json`` but consumed via
+    ``--varlen-mock-dataset-config-json``.
+
+    Output shape mirrors :class:`VarlenDataset.__getitem__` (not the inherited
+    :meth:`MockSFTDataset.__getitem__`) so the mock and real-data paths
+    exercise exactly the same downstream pipeline:
+
+      * THD mode: emits **one unpacked sample** padded to ``pad_granularity``
+        with ``original_seq_len`` / ``padded_seq_len`` tensors. The upstream
+        scheduler packs across the DPxCP grid.
+
+    ``--varlen-sbhd-validation`` is intentionally not implemented for mock
+    data; it is guarded against in argument validation.
+    """
+
+    @staticmethod
+    def build_low_level_dataset(dataset_path: str, config: VarlenDatasetConfig) -> LowLevelDataset:
+        if config.mock_dataset_config is None:
+            mock_config = {
+                "mode": "distribution",
+                "type": "lognormal",
+                "min_seq_len": config.sequence_length // 2,
+                "max_seq_len": config.sequence_length,
+                "mean_seq_len": config.sequence_length // 4 * 3,
+                "lognormal_sigma": 1.1,
+            }
+        else:
+            mock_config = config.mock_dataset_config
+        return MockSFTLowLevelDataset(**mock_config)
+
+    def __getitem__(self, idx: int) -> Dict[str, torch.Tensor]:
+        tokenizer = self.config.tokenizer
+        max_len = self.config.sequence_length
+        eod = tokenizer.eod
+        pad = tokenizer.pad if tokenizer.pad is not None else eod
+
+        # MockSFTLowLevelDataset returns ``length - 1`` token ids; append EOD
+        # to make the conversation end on a stop token, mirroring the real
+        # VarlenDataset path.
+        raw = self.dataset[int(self.indices[idx % len(self.indices)])]
+        tokens_list = raw.tolist()
+        if not tokens_list:
+            tokens_list.append(eod)
+        tokens_list.append(eod)
+        # Mock data uses ``tokens == targets`` (no role masking).
+        targets_list = list(tokens_list)
+
+        # MockVarlenDataset only implements the THD (packed) path; SBHD
+        # validation is a real-data numerical-reference mode (guarded against
+        # --mock-data in validate_args).
+        # THD mode: unpacked single sample, pad to pad_granularity only.
+        if len(tokens_list) > max_len + 1:
+            tokens_list = tokens_list[:max_len] + [eod]
+            targets_list = targets_list[:max_len] + [eod]
+        original_seq_len = len(tokens_list) - 1
+
+        pad_granularity = self._calculate_padding_divisor()
+        mod = original_seq_len % pad_granularity
+        if mod != 0:
+            pad_len = pad_granularity - mod
+            tokens_list.extend([pad] * pad_len)
+            targets_list.extend([pad] * pad_len)
+        padded_seq_len = len(tokens_list) - 1
+
+        input_ids = torch.tensor(tokens_list[:-1], dtype=torch.int64)
+        labels = torch.tensor(targets_list[1:], dtype=torch.int64)
+        loss_mask = torch.ones(padded_seq_len, dtype=torch.float32)
+        loss_mask[original_seq_len:] = 0.0  # mask the right-padded tail by position
+        if self.config.eod_mask_loss:
+            loss_mask[input_ids == eod] = 0.0
+        return {
+            'tokens': input_ids,
+            'labels': labels,
+            'loss_mask': loss_mask,
+            'position_ids': torch.arange(padded_seq_len, dtype=torch.int64),
+            'original_seq_len': torch.tensor([original_seq_len], dtype=torch.int32),
+            'padded_seq_len': torch.tensor([padded_seq_len], dtype=torch.int32),
+        }

--- a/pretrain_gpt.py
+++ b/pretrain_gpt.py
@@ -61,6 +61,11 @@ from megatron.training.arguments import core_transformer_config_from_args, parse
 from megatron.training.datasets.fim_dataset import GPTFIMDataset, GPTFIMDatasetConfig
 from megatron.training.datasets.sft_dataset import MockSFTDataset, SFTDataset, SFTDatasetConfig
 from megatron.training.datasets.utils import load_json_arg
+from megatron.training.datasets.varlen_dataset import (
+    MockVarlenDataset,
+    VarlenDataset,
+    VarlenDatasetConfig,
+)
 from megatron.training.training import update_seqlen_stats_from_cu_seqlens
 from megatron.training.utils import get_blend_and_blend_per_split, is_first_or_last_pipeline_stage
 from model_provider import model_provider
@@ -478,6 +483,15 @@ def core_gpt_dataset_config_from_args(args: Any) -> GPTDatasetConfig:
         )
         return GPTFIMDatasetConfig(**data_args)
 
+    if args.use_varlen_dataset:
+        data_args["mock_dataset_config"] = (
+            load_json_arg(args.varlen_mock_dataset_config_json)
+            if args.varlen_mock_dataset_config_json is not None
+            else None
+        )
+        data_args["sbhd_validation"] = args.varlen_sbhd_validation
+        return VarlenDatasetConfig(**data_args)
+
     if args.sft:
         data_args["mock_dataset_config"] = (
             load_json_arg(args.sft_mock_dataset_config_json)
@@ -500,7 +514,13 @@ def train_valid_test_datasets_provider(train_val_test_num_samples, vp_stage=None
     config = core_gpt_dataset_config_from_args(args)
 
     is_packed_sequence = False
-    if args.sft:
+    if args.use_varlen_dataset:
+        if args.mock_data:
+            dataset_type = MockVarlenDataset
+        else:
+            dataset_type = VarlenDataset
+        is_packed_sequence = not args.varlen_sbhd_validation
+    elif args.sft:
         if args.mock_data:
             dataset_type = MockSFTDataset
         else:

--- a/tests/unit_tests/data/test_varlen_dataset.py
+++ b/tests/unit_tests/data/test_varlen_dataset.py
@@ -1,0 +1,1377 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Unit tests for :mod:`megatron.training.datasets.varlen_dataset`.
+
+These tests cover the schema-detection and message-normalization helpers and
+the :class:`VarlenLowLevelDataset` loader. The end-to-end SFTDataset packing
+behavior is exercised by the existing SFT test suite; here we focus on the
+varlen-specific contracts (auto-detect schema, normalize to messages,
+ValueError on unsupported shapes).
+"""
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+# Import via the public module path so this test gets discovered through the
+# regular pytest entry point. The functions under test are pure Python and do
+# not require torch.distributed.
+from megatron.training.datasets.sft_dataset import IGNORE_INDEX
+from megatron.training.datasets.varlen_dataset import (
+    ChatTemplateSample,
+    MockVarlenDataset,
+    VarlenDataset,
+    VarlenDatasetConfig,
+    VarlenLowLevelDataset,
+    _alpaca_to_messages,
+    _ensure_list_field,
+    _looks_like_hf_id,
+    _messages_passthrough,
+    _raw_text_loader,
+    _select_converter,
+    _sharegpt_to_messages,
+)
+
+# ----------------------------------------------------------------------------
+# _looks_like_hf_id heuristic
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        ("Yukang/LongAlpaca-12k", True),
+        ("HuggingFaceH4/no_robots", True),
+        ("databricks/databricks-dolly-15k", True),
+        ("/tmp/foo.jsonl", False),
+        ("./local.jsonl", False),
+        ("../up.jsonl", False),
+        ("singlename", False),
+        ("", False),
+        (None, False),
+    ],
+)
+def test_looks_like_hf_id(path, expected):
+    assert _looks_like_hf_id(path) is expected
+
+
+def _varlen_args(**overrides):
+    values = {
+        "use_varlen_dataset": False,
+        "varlen_sbhd_validation": False,
+        "varlen_mock_dataset_config_json": None,
+        "sft": False,
+        "fim_data": False,
+        "mock_data": False,
+        "hybrid_context_parallel": False,
+        "dynamic_context_parallel": False,
+        "num_experts": None,
+        "reset_position_ids": False,
+        "reset_attention_mask": False,
+        "dataloader_inter_document_masking": False,
+        "create_attention_mask_in_dataloader": True,
+        "sequence_packing_scheduler": None,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_varlen_validation_selects_default_scheduler():
+    from megatron.training.arguments import _validate_varlen_dataset_args
+
+    args = _varlen_args(use_varlen_dataset=True)
+
+    _validate_varlen_dataset_args(args)
+
+    assert args.sequence_packing_scheduler == "dp_balanced"
+    assert args.create_attention_mask_in_dataloader is False
+
+
+def test_varlen_validation_preserves_explicit_scheduler():
+    from megatron.training.arguments import _validate_varlen_dataset_args
+
+    args = _varlen_args(use_varlen_dataset=True, sequence_packing_scheduler="dp_balanced")
+
+    _validate_varlen_dataset_args(args)
+
+    assert args.sequence_packing_scheduler == "dp_balanced"
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"varlen_sbhd_validation": True},
+        {"varlen_mock_dataset_config_json": "{}", "mock_data": True},
+        {"use_varlen_dataset": True, "varlen_mock_dataset_config_json": "{}"},
+        {"use_varlen_dataset": True, "sft": True},
+        {"use_varlen_dataset": True, "fim_data": True},
+        {"use_varlen_dataset": True, "reset_position_ids": True},
+        {"use_varlen_dataset": True, "reset_attention_mask": True},
+        {"use_varlen_dataset": True, "dataloader_inter_document_masking": True},
+        {
+            "use_varlen_dataset": True,
+            "varlen_sbhd_validation": True,
+            "sequence_packing_scheduler": "dp_balanced",
+        },
+        {"use_varlen_dataset": True, "varlen_sbhd_validation": True, "mock_data": True},
+        {
+            "use_varlen_dataset": True,
+            "varlen_sbhd_validation": True,
+            "dynamic_context_parallel": True,
+        },
+        {"use_varlen_dataset": True, "varlen_sbhd_validation": True, "num_experts": 8},
+    ],
+)
+def test_varlen_validation_rejects_incompatible_options(overrides):
+    from megatron.training.arguments import _validate_varlen_dataset_args
+
+    with pytest.raises(AssertionError):
+        _validate_varlen_dataset_args(_varlen_args(**overrides))
+
+
+# ----------------------------------------------------------------------------
+# Schema converters
+# ----------------------------------------------------------------------------
+
+
+def test_alpaca_canonical_with_input():
+    out = _alpaca_to_messages(
+        {"instruction": "Summarize.", "input": "Long passage", "output": "It says X."}
+    )
+    assert [m["role"] for m in out] == ["system", "user", "assistant"]
+    assert out[1]["content"] == "Summarize.\n\nLong passage"
+    assert out[2]["content"] == "It says X."
+
+
+def test_alpaca_without_input():
+    out = _alpaca_to_messages({"instruction": "Hi.", "output": "Hello."})
+    assert out[0] == {"role": "system", "content": ""}
+    assert out[1]["content"] == "Hi."
+    assert out[2]["content"] == "Hello."
+
+
+@pytest.mark.parametrize(
+    "instr_key,out_key",
+    [
+        ("prompt", "response"),
+        ("query", "answer"),
+        ("question", "completion"),
+        ("instruction", "answer"),
+    ],
+)
+def test_alpaca_field_synonyms(instr_key, out_key):
+    out = _alpaca_to_messages({instr_key: "Q?", out_key: "A."})
+    assert out[1]["content"] == "Q?"
+    assert out[2]["content"] == "A."
+
+
+def test_dolly_instruction_context_response():
+    """Dolly-15k: instruction + context + response, all via synonyms."""
+    out = _alpaca_to_messages(
+        {
+            "instruction": "Who wrote 1984?",
+            "context": "1984 was written in 1948.",
+            "response": "George Orwell.",
+        }
+    )
+    assert out[1]["content"] == "Who wrote 1984?\n\n1984 was written in 1948."
+    assert out[2]["content"] == "George Orwell."
+
+
+def test_sharegpt_human_gpt():
+    out = _sharegpt_to_messages(
+        {"conversations": [{"from": "human", "value": "hi"}, {"from": "gpt", "value": "hello"}]}
+    )
+    assert [m["role"] for m in out] == ["system", "user", "assistant"]
+    assert out[1]["content"] == "hi"
+
+
+def test_sharegpt_preserves_existing_system_turn():
+    out = _sharegpt_to_messages(
+        {
+            "conversations": [
+                {"from": "system", "value": "be terse"},
+                {"from": "human", "value": "hi"},
+                {"from": "gpt", "value": "hello"},
+            ]
+        }
+    )
+    assert [m["role"] for m in out] == ["system", "user", "assistant"]
+    assert out[0]["content"] == "be terse"
+
+
+@pytest.mark.parametrize(
+    "speaker,expected_role",
+    [
+        ("human", "user"),
+        ("user", "user"),
+        ("gpt", "assistant"),
+        ("assistant", "assistant"),
+        ("model", "assistant"),
+        ("chatgpt", "assistant"),
+        ("tool", "tool"),
+        ("function", "tool"),
+        ("alien", "user"),  # unknown speakers fall back to user
+    ],
+)
+def test_sharegpt_role_map(speaker, expected_role):
+    out = _sharegpt_to_messages({"conversations": [{"from": speaker, "value": "x"}]})
+    # First entry is the prepended system turn; second is the actual content.
+    assert out[1]["role"] == expected_role
+
+
+def test_messages_passthrough_prepends_system_when_missing():
+    sample = _messages_passthrough(
+        {"messages": [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "hello"}]}
+    )
+    out = sample.messages
+    assert [m["role"] for m in out] == ["system", "user", "assistant"]
+    assert sample.chat_template_kwargs == {}
+
+
+def test_messages_passthrough_keeps_existing_system():
+    sample = _messages_passthrough(
+        {
+            "messages": [
+                {"role": "system", "content": "be terse"},
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "ok"},
+            ]
+        }
+    )
+    out = sample.messages
+    assert [m["role"] for m in out] == ["system", "user", "assistant"]
+    assert out[0]["content"] == "be terse"
+
+
+def test_messages_passthrough_preserves_math_v3_template_fields():
+    tools = [
+        {
+            "type": "function",
+            "function": {"name": "stateful_python_code_exec", "parameters": {"type": "object"}},
+        }
+    ]
+    sample = _messages_passthrough(
+        {
+            "tools": tools,
+            "messages": [
+                {"role": "user", "content": "solve"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "reasoning_content": "I should calculate this.",
+                    "tool_calls": [
+                        {
+                            "id": "call-1",
+                            "type": "function",
+                            "function": {
+                                "name": "stateful_python_code_exec",
+                                "arguments": '{"code":"1 + 1"}',
+                            },
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "name": "stateful_python_code_exec",
+                    "tool_call_id": "call-1",
+                    "content": "2",
+                },
+            ],
+        }
+    )
+    assert sample.chat_template_kwargs == {"tools": tools}
+    assert sample.messages[2]["content"] == ""
+    assert sample.messages[2]["reasoning_content"] == "I should calculate this."
+    assert sample.messages[2]["tool_calls"][0]["function"]["name"] == "stateful_python_code_exec"
+    assert sample.messages[3]["name"] == "stateful_python_code_exec"
+    assert sample.messages[3]["tool_call_id"] == "call-1"
+
+
+def test_messages_passthrough_rejects_non_list_tools():
+    with pytest.raises(ValueError, match="field 'tools' must be a list"):
+        _messages_passthrough(
+            {"messages": [{"role": "user", "content": "hi"}], "tools": {"name": "bad"}}
+        )
+
+
+def test_messages_passthrough_decodes_json_encoded_parquet_columns():
+    messages = [
+        {"role": "user", "content": "solve"},
+        {"role": "assistant", "content": "2", "reasoning_content": "1 + 1"},
+    ]
+    tools = [{"type": "function", "function": {"name": "python"}}]
+    sample = _messages_passthrough({"messages": json.dumps(messages), "tools": json.dumps(tools)})
+    assert sample.messages == [{"role": "system", "content": ""}, *messages]
+    assert sample.chat_template_kwargs == {"tools": tools}
+
+
+def test_messages_passthrough_decodes_swe_v3_tool_calls():
+    tool_calls = [
+        {
+            "id": "call-1",
+            "type": "function",
+            "function": {"name": "execute_bash", "arguments": '{"command":"ls"}'},
+        }
+    ]
+    sample = _messages_passthrough(
+        {
+            "messages": [
+                {"role": "user", "content": "inspect"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "reasoning_content": "I should inspect the repository.",
+                    "tool_calls": json.dumps(tool_calls),
+                },
+            ]
+        }
+    )
+    assert sample.messages[2]["tool_calls"] == tool_calls
+
+
+def test_messages_passthrough_normalizes_opencode_tools_and_results():
+    sample = _messages_passthrough(
+        {
+            "tools": [
+                {
+                    "id": "shell",
+                    "description": "Run a command",
+                    "inputSchema": {
+                        "jsonSchema": {
+                            "type": "object",
+                            "properties": {"command": {"type": "string"}},
+                        }
+                    },
+                }
+            ],
+            "messages": [
+                {"role": "user", "content": "list files"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call-1",
+                            "type": "function",
+                            "function": {"name": "shell", "arguments": '{"command":"ls"}'},
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "content": [
+                        {
+                            "type": "tool-result",
+                            "toolCallId": "call-1",
+                            "toolName": "shell",
+                            "output": {"type": "text", "value": "a.txt"},
+                        }
+                    ],
+                },
+            ],
+        }
+    )
+    assert sample.chat_template_kwargs["tools"] == [
+        {
+            "type": "function",
+            "function": {
+                "name": "shell",
+                "description": "Run a command",
+                "parameters": {"type": "object", "properties": {"command": {"type": "string"}}},
+            },
+        }
+    ]
+    assert sample.messages[3]["content"] == "a.txt"
+    assert sample.messages[3]["tool_call_id"] == "call-1"
+    assert sample.messages[3]["name"] == "shell"
+
+
+def test_messages_passthrough_normalizes_legacy_roles_and_function_call():
+    sample = _messages_passthrough(
+        {
+            "messages": [
+                {"role": "developer", "content": "Use tools."},
+                {"role": "user", "content": "calculate"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "function_call": {"name": "python", "arguments": '{"code":"1+1"}'},
+                },
+            ]
+        }
+    )
+    assert [message["role"] for message in sample.messages] == ["system", "user", "assistant"]
+    assert sample.messages[2]["tool_calls"] == [
+        {"type": "function", "function": {"name": "python", "arguments": '{"code":"1+1"}'}}
+    ]
+
+
+def test_messages_passthrough_preserves_agentic_chat_template_kwargs():
+    sample = _messages_passthrough(
+        {
+            "messages": [{"role": "user", "content": "search"}],
+            "chat_template_kwargs": json.dumps({"thinking": True}),
+        }
+    )
+    assert sample.chat_template_kwargs == {"thinking": True}
+
+
+def test_ensure_list_field_rejects_invalid_json():
+    with pytest.raises(ValueError, match="contains invalid JSON"):
+        _ensure_list_field("[broken", "messages")
+
+
+# ----------------------------------------------------------------------------
+# Shape validation: reject multi-modal / non-string content
+# ----------------------------------------------------------------------------
+
+
+def test_messages_rejects_multimodal_list_content():
+    with pytest.raises(ValueError, match="unsupported.*type 'image'"):
+        _messages_passthrough(
+            {"messages": [{"role": "user", "content": [{"type": "image", "url": "x.png"}]}]}
+        )
+
+
+def test_alpaca_rejects_non_string_field():
+    with pytest.raises(ValueError, match="must be a string"):
+        _alpaca_to_messages({"instruction": ["a", "b"], "output": "x"})
+
+
+def test_sharegpt_rejects_list_value():
+    with pytest.raises(ValueError, match="must be a string"):
+        _sharegpt_to_messages({"conversations": [{"from": "human", "value": [1, 2, 3]}]})
+
+
+# ----------------------------------------------------------------------------
+# Pretrain-text schema
+# ----------------------------------------------------------------------------
+
+
+def test_raw_text_loader_returns_string():
+    """``text``-column samples are returned as plain strings (not messages)."""
+    out = _raw_text_loader({"text": "Once upon a time...", "id": "doc-1"})
+    assert isinstance(out, str)
+    assert out == "Once upon a time..."
+
+
+def test_raw_text_loader_handles_empty():
+    assert _raw_text_loader({"text": None}) == ""
+    assert _raw_text_loader({}) == ""
+
+
+@pytest.mark.parametrize("value", [[1, 2, 3], 0, False])
+def test_raw_text_rejects_non_string(value):
+    with pytest.raises(ValueError, match="must be a string"):
+        _raw_text_loader({"text": value})
+
+
+# ----------------------------------------------------------------------------
+# Schema selector priority
+# ----------------------------------------------------------------------------
+
+
+def test_select_converter_alpaca():
+    fn, name = _select_converter(["instruction", "output", "file"])
+    assert name == "alpaca"
+    assert fn is _alpaca_to_messages
+
+
+def test_select_converter_alpaca_via_synonyms():
+    fn, name = _select_converter(["prompt", "response"])
+    assert name == "alpaca"
+
+
+def test_select_converter_dolly_columns():
+    fn, name = _select_converter(["instruction", "context", "response", "category"])
+    assert name == "alpaca"
+
+
+def test_select_converter_sharegpt():
+    fn, name = _select_converter(["conversations", "id"])
+    assert name == "sharegpt"
+    assert fn is _sharegpt_to_messages
+
+
+def test_select_converter_messages():
+    fn, name = _select_converter(["messages"])
+    assert name == "openai-messages"
+    assert fn is _messages_passthrough
+
+
+def test_select_converter_priority_messages_over_alpaca():
+    # When both ``messages`` and alpaca-style columns are present, the more
+    # explicit ``messages`` schema wins.
+    fn, name = _select_converter(["messages", "instruction", "output"])
+    assert name == "openai-messages"
+
+
+def test_select_converter_unrecognized_columns():
+    with pytest.raises(ValueError, match="cannot infer schema"):
+        _select_converter(["foo", "bar"])
+
+
+def test_select_converter_alpaca_missing_output():
+    """Having an instruction column but no output column is not a match."""
+    with pytest.raises(ValueError, match="cannot infer schema"):
+        _select_converter(["instruction", "category"])
+
+
+def test_select_converter_pretrain_text():
+    fn, name = _select_converter(["text", "id"])
+    assert name == "pretrain-text"
+    assert fn is _raw_text_loader
+
+
+def test_select_converter_pretrain_text_with_metadata():
+    """Real corpora (e.g. Dolma) have ``text`` + ``url`` + ``metadata``."""
+    fn, name = _select_converter(["text", "url", "metadata", "id"])
+    assert name == "pretrain-text"
+
+
+def test_select_converter_alpaca_beats_pretrain_text():
+    """When both ``instruction``/``output`` and ``text`` are present (rare),
+    the alpaca schema is more specific and should win."""
+    fn, name = _select_converter(["text", "instruction", "output"])
+    assert name == "alpaca"
+
+
+def test_select_converter_messages_beats_pretrain_text():
+    fn, name = _select_converter(["text", "messages"])
+    assert name == "openai-messages"
+
+
+# ----------------------------------------------------------------------------
+# VarlenLowLevelDataset on local jsonl (no HF Hub network needed)
+# ----------------------------------------------------------------------------
+
+
+def _write_jsonl(tmp_path: Path, rows):
+    p = tmp_path / "data.jsonl"
+    with p.open("w") as f:
+        for row in rows:
+            f.write(json.dumps(row) + "\n")
+    return str(p)
+
+
+def test_low_level_loads_json_array(tmp_path):
+    pytest.importorskip("datasets")
+    pytest.importorskip("pandas")
+    path = tmp_path / "data.json"
+    path.write_text(json.dumps([{"instruction": "i1", "output": "o1"}]))
+
+    ll = VarlenLowLevelDataset(str(path))
+
+    assert len(ll) == 1
+    assert ll.schema_name == "alpaca"
+    assert ll[0][2]["content"] == "o1"
+
+
+def test_low_level_loads_jsonl_alpaca(tmp_path):
+    pytest.importorskip("datasets")
+    pytest.importorskip("pandas")
+    path = _write_jsonl(
+        tmp_path,
+        [
+            {"instruction": "i1", "output": "o1"},
+            {"instruction": "i2", "output": "o2", "file": "extra"},
+        ],
+    )
+    ll = VarlenLowLevelDataset(path)
+    assert len(ll) == 2
+    assert ll.schema_name == "alpaca"
+    sample = ll[0]
+    assert [m["role"] for m in sample] == ["system", "user", "assistant"]
+    assert sample[1]["content"] == "i1"
+    assert sample[2]["content"] == "o1"
+
+
+def test_low_level_loads_jsonl_sharegpt(tmp_path):
+    pytest.importorskip("datasets")
+    pytest.importorskip("pandas")
+    path = _write_jsonl(
+        tmp_path,
+        [
+            {"conversations": [{"from": "human", "value": "q1"}, {"from": "gpt", "value": "a1"}]},
+            {"conversations": [{"from": "human", "value": "q2"}, {"from": "gpt", "value": "a2"}]},
+        ],
+    )
+    ll = VarlenLowLevelDataset(path)
+    assert len(ll) == 2
+    assert ll.schema_name == "sharegpt"
+    sample = ll[1]
+    # system prepended + 2 turns from the conversation
+    assert [m["role"] for m in sample] == ["system", "user", "assistant"]
+    assert sample[1]["content"] == "q2"
+
+
+def test_low_level_loads_jsonl_messages(tmp_path):
+    pytest.importorskip("datasets")
+    pytest.importorskip("pandas")
+    path = _write_jsonl(
+        tmp_path,
+        [
+            {
+                "messages": [
+                    {"role": "user", "content": "hi"},
+                    {"role": "assistant", "content": "hello"},
+                ]
+            }
+        ],
+    )
+    ll = VarlenLowLevelDataset(path)
+    assert ll.schema_name == "openai-messages"
+    sample = ll[0]
+    assert isinstance(sample, ChatTemplateSample)
+    assert [m["role"] for m in sample.messages] == ["system", "user", "assistant"]
+
+
+def test_low_level_jsonl_heterogeneous_columns(tmp_path):
+    """Real datasets often mix rows that have / lack an optional field. Our
+    pandas-based loader must accept the union schema without ``CastError``."""
+    pytest.importorskip("datasets")
+    pytest.importorskip("pandas")
+    rows = [{"instruction": "a", "output": "x"}] * 100 + [
+        {"instruction": "b", "output": "y", "file": "extra"}
+    ] * 100
+    path = _write_jsonl(tmp_path, rows)
+    ll = VarlenLowLevelDataset(path)
+    assert len(ll) == 200
+    # Both halves should normalize to the same messages structure.
+    assert [m["role"] for m in ll[0]] == ["system", "user", "assistant"]
+    assert [m["role"] for m in ll[150]] == ["system", "user", "assistant"]
+
+
+def test_low_level_rejects_unknown_schema(tmp_path):
+    pytest.importorskip("datasets")
+    pytest.importorskip("pandas")
+    path = _write_jsonl(tmp_path, [{"foo": "bar"}])
+    with pytest.raises(ValueError, match="cannot infer schema"):
+        VarlenLowLevelDataset(path)
+
+
+def test_low_level_loads_jsonl_pretrain_text(tmp_path):
+    """Pretrain-text corpora (Dolma / OLMo midtraining) typically have
+    ``text`` + extra fields like ``id`` / ``url`` / ``metadata``."""
+    pytest.importorskip("datasets")
+    pytest.importorskip("pandas")
+    path = _write_jsonl(
+        tmp_path,
+        [
+            {"text": "Doc one body...", "id": "1", "url": "https://x/1"},
+            {"text": "Doc two body...", "id": "2", "url": "https://x/2"},
+        ],
+    )
+    ll = VarlenLowLevelDataset(path)
+    assert ll.schema_name == "pretrain-text"
+    assert len(ll) == 2
+    # Each item is a raw string, NOT a messages list.
+    assert ll[0] == "Doc one body..."
+    assert ll[1] == "Doc two body..."
+
+
+class _FakeHubDataset:
+    def __init__(self, rows):
+        self.rows = rows
+        self.column_names = list(dict.fromkeys(key for row in rows for key in row))
+
+    def __len__(self):
+        return len(self.rows)
+
+    def __getitem__(self, index):
+        return self.rows[index]
+
+
+def test_low_level_hub_loads_all_configs_and_thematic_splits(monkeypatch):
+    datasets = pytest.importorskip("datasets")
+    calls = []
+
+    monkeypatch.setattr(datasets, "get_dataset_config_names", lambda path: ["cfg-a", "cfg-b"])
+    monkeypatch.setattr(
+        datasets,
+        "get_dataset_split_names",
+        lambda path, config: (
+            ["train", "validation"]
+            if config == "cfg-a"
+            else ["validation", "python", "test", "cpp", "dev"]
+        ),
+    )
+
+    def fake_load_dataset(path, name, split):
+        calls.append((path, name, split))
+        return _FakeHubDataset([{"messages": [{"role": "user", "content": f"{name}/{split}"}]}])
+
+    monkeypatch.setattr(datasets, "load_dataset", fake_load_dataset)
+    low_level = VarlenLowLevelDataset("nvidia/Nemotron-SFT-Test")
+
+    assert calls == [
+        ("nvidia/Nemotron-SFT-Test", "cfg-a", "train"),
+        ("nvidia/Nemotron-SFT-Test", "cfg-b", "python"),
+        ("nvidia/Nemotron-SFT-Test", "cfg-b", "cpp"),
+    ]
+    assert len(low_level) == 3
+    assert {low_level[index].messages[1]["content"] for index in range(len(low_level))} == {
+        "cfg-a/train",
+        "cfg-b/python",
+        "cfg-b/cpp",
+    }
+    with pytest.raises(IndexError):
+        low_level[3]
+
+
+def test_low_level_hub_rejects_held_out_only_splits(monkeypatch):
+    datasets = pytest.importorskip("datasets")
+
+    monkeypatch.setattr(datasets, "get_dataset_config_names", lambda path: ["default"])
+    monkeypatch.setattr(
+        datasets,
+        "get_dataset_split_names",
+        lambda path, config: ["validation", "valid", "val", "test", "dev"],
+    )
+    monkeypatch.setattr(
+        datasets,
+        "load_dataset",
+        lambda *args, **kwargs: pytest.fail("held-out split should not be loaded"),
+    )
+
+    with pytest.raises(ValueError, match="no training or thematic split"):
+        VarlenLowLevelDataset("nvidia/Nemotron-SFT-Heldout")
+
+
+def test_low_level_hub_keeps_heterogeneous_configs_separate(monkeypatch):
+    datasets = pytest.importorskip("datasets")
+
+    monkeypatch.setattr(datasets, "get_dataset_config_names", lambda path: ["chat", "pretrain"])
+    monkeypatch.setattr(datasets, "get_dataset_split_names", lambda path, config: ["train"])
+
+    def fake_load_dataset(path, name, split):
+        if name == "chat":
+            return _FakeHubDataset([{"messages": [{"role": "user", "content": "question"}]}])
+        return _FakeHubDataset([{"text": "document"}])
+
+    monkeypatch.setattr(datasets, "load_dataset", fake_load_dataset)
+
+    low_level = VarlenLowLevelDataset("nvidia/Nemotron-SFT-Test")
+
+    assert low_level.schema_name == "mixed(openai-messages,pretrain-text)"
+    items = [low_level[index] for index in range(len(low_level))]
+    assert next(item for item in items if isinstance(item, str)) == "document"
+    chat_item = next(item for item in items if isinstance(item, ChatTemplateSample))
+    assert chat_item.messages[1]["content"] == "question"
+
+
+def test_low_level_hub_interleaves_components_across_index_halves(monkeypatch):
+    datasets = pytest.importorskip("datasets")
+    component_sizes = {"cfg-a": 2, "cfg-b": 6}
+
+    monkeypatch.setattr(datasets, "get_dataset_config_names", lambda path: ["cfg-a", "cfg-b"])
+    monkeypatch.setattr(datasets, "get_dataset_split_names", lambda path, config: ["train"])
+
+    def fake_load_dataset(path, name, split):
+        return _FakeHubDataset(
+            [
+                {"messages": [{"role": "user", "content": f"{name}-{index}"}]}
+                for index in range(component_sizes[name])
+            ]
+        )
+
+    monkeypatch.setattr(datasets, "load_dataset", fake_load_dataset)
+    low_level = VarlenLowLevelDataset("nvidia/Nemotron-SFT-Test")
+
+    contents = [low_level[index].messages[1]["content"] for index in range(len(low_level))]
+    midpoint = len(contents) // 2
+    assert set(contents) == {
+        f"{name}-{index}" for name, size in component_sizes.items() for index in range(size)
+    }
+    assert {content.split("-")[1] for content in contents[:midpoint]} == {"a", "b"}
+    assert {content.split("-")[1] for content in contents[midpoint:]} == {"a", "b"}
+
+
+def test_low_level_hub_dispatches_nullable_union_schema_per_row(monkeypatch):
+    datasets = pytest.importorskip("datasets")
+
+    monkeypatch.setattr(datasets, "get_dataset_config_names", lambda path: ["default"])
+    monkeypatch.setattr(datasets, "get_dataset_split_names", lambda path, config: ["train"])
+    monkeypatch.setattr(
+        datasets,
+        "load_dataset",
+        lambda path, name, split: _FakeHubDataset(
+            [
+                {"messages": [{"role": "user", "content": "question"}], "text": None},
+                {"messages": None, "text": "document"},
+                {"messages": None, "text": None},
+            ]
+        ),
+    )
+
+    low_level = VarlenLowLevelDataset("nvidia/Nemotron-SFT-Mixed")
+
+    assert low_level[0].messages[1]["content"] == "question"
+    assert low_level[1] == "document"
+    assert isinstance(low_level[2], ChatTemplateSample)
+    assert low_level[2].messages == []
+
+
+def test_low_level_hub_falls_back_to_raw_json_payload(monkeypatch, tmp_path):
+    datasets = pytest.importorskip("datasets")
+    from datasets.exceptions import DatasetGenerationError
+
+    raw_path = _write_jsonl(
+        tmp_path,
+        [
+            {
+                "messages": [
+                    {"role": "user", "content": "question"},
+                    {"role": "assistant", "content": "answer"},
+                ]
+            },
+            {"messages": [{"role": "user", "content": "not selected"}]},
+        ],
+    )
+    monkeypatch.setattr(datasets, "get_dataset_config_names", lambda path: ["default"])
+    monkeypatch.setattr(datasets, "get_dataset_split_names", lambda path, config: ["train"])
+    monkeypatch.setattr(
+        datasets,
+        "load_dataset_builder",
+        lambda path, name: SimpleNamespace(
+            config=SimpleNamespace(data_files={"train": [raw_path]})
+        ),
+    )
+
+    def fake_load_dataset(path, name, split):
+        raise DatasetGenerationError("incompatible nested JSON schema")
+
+    def fake_from_generator(generator, features, gen_kwargs):
+        assert list(features) == ["__varlen_json_payload__"]
+        assert isinstance(gen_kwargs["data_files"], list)
+        return _FakeHubDataset(list(generator(**gen_kwargs)))
+
+    monkeypatch.setattr(datasets, "load_dataset", fake_load_dataset)
+    monkeypatch.setattr(datasets.Dataset, "from_generator", staticmethod(fake_from_generator))
+
+    low_level = VarlenLowLevelDataset("nvidia/Nemotron-SFT-Math-v4")
+    assert len(low_level) == 2
+    assert low_level.schema_name == "json-payload"
+    assert low_level[0].messages[2]["content"] == "answer"
+
+
+def test_low_level_hub_raw_fallback_loads_json_array(monkeypatch, tmp_path):
+    datasets = pytest.importorskip("datasets")
+    from datasets.exceptions import DatasetGenerationError
+
+    raw_path = tmp_path / "rows.json"
+    raw_path.write_text(
+        json.dumps([{"messages": [{"role": "user", "content": "first"}]}, {"text": "second"}])
+    )
+    monkeypatch.setattr(datasets, "get_dataset_config_names", lambda path: ["default"])
+    monkeypatch.setattr(datasets, "get_dataset_split_names", lambda path, config: ["train"])
+    monkeypatch.setattr(
+        datasets,
+        "load_dataset_builder",
+        lambda path, name: SimpleNamespace(
+            config=SimpleNamespace(data_files={"train": [str(raw_path)]})
+        ),
+    )
+    monkeypatch.setattr(
+        datasets,
+        "load_dataset",
+        lambda path, name, split: (_ for _ in ()).throw(
+            DatasetGenerationError("incompatible nested JSON schema")
+        ),
+    )
+
+    def fake_from_generator(generator, features, gen_kwargs):
+        return _FakeHubDataset(list(generator(**gen_kwargs)))
+
+    monkeypatch.setattr(datasets.Dataset, "from_generator", staticmethod(fake_from_generator))
+
+    low_level = VarlenLowLevelDataset("nvidia/Nemotron-SFT-Mixed")
+
+    assert len(low_level) == 2
+    assert low_level[0].messages[1]["content"] == "first"
+    assert low_level[1] == "second"
+
+
+# ----------------------------------------------------------------------------
+# VarlenDataset / MockVarlenDataset __getitem__ (fake tokenizer, no GPU)
+#
+# These bypass the heavy SFTDataset.__init__ and inject the minimal attributes
+# __getitem__ reads, so the EOD handling / position-based loss masking /
+# pad-to-divisor / packing-metadata contracts can be unit tested without a
+# real tokenizer or torch.distributed.
+# ----------------------------------------------------------------------------
+
+
+class _FakeTokenizer:
+    """Minimal tokenizer for exercising VarlenDataset.__getitem__.
+
+    ``tokenize`` maps each character to a non-zero id (so plain text never
+    collides with ``eod``/``pad``); ``tokenize("")`` returns ``[]`` to exercise
+    the empty-row guard. ``tokenize_conversation`` masks non-assistant turns
+    with ``IGNORE_INDEX`` in the targets.
+    """
+
+    def __init__(self, eod: int = 0, pad=None):
+        self._eod = eod
+        self._pad = pad
+        self.last_chat_template_kwargs = None
+
+    @property
+    def eod(self):
+        return self._eod
+
+    @property
+    def pad(self):
+        return self._pad
+
+    @property
+    def vocab_size(self):
+        return 128
+
+    def tokenize(self, text):
+        return [ord(c) % 100 + 1 for c in text]  # always >= 1, never eod (0)
+
+    def tokenize_conversation(
+        self, messages, return_target=True, add_generation_prompt=False, chat_template_kwargs=None
+    ):
+        self.last_chat_template_kwargs = chat_template_kwargs
+        tokens, targets = [], []
+        for m in messages:
+            ids = self.tokenize(m["content"])
+            tokens.extend(ids)
+            # Only assistant turns contribute to the loss; prompt is masked.
+            targets.extend(ids if m["role"] == "assistant" else [IGNORE_INDEX] * len(ids))
+        return (torch.tensor(tokens, dtype=torch.int64), torch.tensor(targets, dtype=torch.int64))
+
+
+def test_varlen_dataset_config_owns_sbhd_validation():
+    config_args = {
+        "random_seed": 123,
+        "sequence_length": 8,
+        "tokenizer": _FakeTokenizer(),
+        "reset_position_ids": False,
+        "reset_attention_mask": False,
+        "eod_mask_loss": False,
+        "create_attention_mask": False,
+        "context_parallel_size": 1,
+    }
+
+    config = VarlenDatasetConfig(**config_args, sbhd_validation=True)
+
+    assert config.sbhd_validation is True
+    with pytest.raises(AssertionError, match="dynamic context parallelism"):
+        VarlenDatasetConfig(**config_args, sbhd_validation=True, dynamic_context_parallel=True)
+
+
+def _make_config(tokenizer, seq_length=64, *, cp=1, dp=1, sp=1, sbhd=False, eod_mask=False):
+    return SimpleNamespace(
+        tokenizer=tokenizer,
+        sequence_length=seq_length,
+        reset_position_ids=False,
+        create_attention_mask=False,
+        reset_attention_mask=False,
+        eod_mask_loss=eod_mask,
+        sbhd_validation=sbhd,
+        data_parallel_size=dp,
+        context_parallel_size=cp,
+        sequence_parallel_size=sp,
+        hybrid_context_parallel=False,
+        dynamic_context_parallel=False,
+    )
+
+
+def _make_varlen(items, config):
+    ds = VarlenDataset.__new__(VarlenDataset)
+    ds.config = config
+    ds.dataset = items
+    ds.indices = np.arange(len(items))
+    return ds
+
+
+def _make_mock_varlen(token_arrays, config):
+    ds = MockVarlenDataset.__new__(MockVarlenDataset)
+    ds.config = config
+    ds.dataset = token_arrays  # each item exposes .tolist()
+    ds.indices = np.arange(len(token_arrays))
+    return ds
+
+
+def test_getitem_thd_pretrain_text_keys_and_shapes():
+    tok = _FakeTokenizer(eod=0, pad=7)
+    ds = _make_varlen(["hello world"], _make_config(tok, seq_length=64))
+    out = ds[0]
+    assert set(out) == {
+        "tokens",
+        "labels",
+        "loss_mask",
+        "position_ids",
+        "original_seq_len",
+        "padded_seq_len",
+    }
+    n = out["tokens"].numel()
+    assert out["labels"].numel() == n
+    assert out["loss_mask"].numel() == n
+    assert out["position_ids"].numel() == n
+    assert int(out["padded_seq_len"].item()) == n
+
+
+def test_getitem_thd_sft_prompt_is_masked():
+    tok = _FakeTokenizer(eod=0, pad=7)
+    messages = [
+        {"role": "system", "content": ""},
+        {"role": "user", "content": "question"},
+        {"role": "assistant", "content": "answer"},
+    ]
+    ds = _make_varlen([messages], _make_config(tok, seq_length=64))
+    out = ds[0]
+    # Prompt (user) tokens are IGNORE_INDEX in labels and must be masked out;
+    # assistant tokens must contribute to the loss.
+    labels = out["labels"]
+    loss_mask = out["loss_mask"]
+    assert torch.all(loss_mask[labels == IGNORE_INDEX] == 0.0)
+    assert loss_mask.sum() > 0  # assistant span still contributes
+
+
+def test_getitem_forwards_openai_chat_template_kwargs():
+    tok = _FakeTokenizer(eod=0, pad=7)
+    tools = [{"type": "function", "function": {"name": "python"}}]
+    item = ChatTemplateSample(
+        messages=[
+            {"role": "user", "content": "question"},
+            {"role": "assistant", "content": "answer", "reasoning_content": "reason"},
+        ],
+        chat_template_kwargs={"tools": tools},
+    )
+    ds = _make_varlen([item], _make_config(tok, seq_length=64))
+
+    out = ds[0]
+
+    assert tok.last_chat_template_kwargs == {"tools": tools}
+    assert out["tokens"].numel() > 0
+
+
+def test_getitem_thd_pad_masked_by_position_keeps_real_eod():
+    """Regression: with pad falling back to eod, the real end-of-document EOD
+    target must stay in the loss (masked by position, not by value)."""
+    tok = _FakeTokenizer(eod=0, pad=None)  # pad falls back to eod
+    # cp=2 -> pad divisor = cp*2 = 4, so a 3-token doc gets a padding tail.
+    ds = _make_varlen(["abc"], _make_config(tok, seq_length=64, cp=2))
+    out = ds[0]
+    loss_mask = out["loss_mask"].tolist()
+    labels = out["labels"].tolist()
+    # tokens=[a,b,c,eod] padded to 4 -> labels=[b,c,eod,eod(pad)]
+    assert len(loss_mask) == 4
+    # index 2 is the real end-of-document EOD target -> kept (would be wrongly
+    # dropped by value-based ``labels == pad`` masking).
+    assert labels[2] == tok.eod and loss_mask[2] == 1.0
+    # index 3 is the appended pad -> masked.
+    assert loss_mask[3] == 0.0
+
+
+def test_getitem_thd_padded_to_divisor():
+    tok = _FakeTokenizer(eod=0, pad=7)
+    ds = _make_varlen(["abcde"], _make_config(tok, seq_length=64, cp=2))  # divisor 4
+    out = ds[0]
+    assert int(out["padded_seq_len"].item()) % 4 == 0
+
+
+def test_getitem_thd_empty_text_does_not_crash():
+    """A blank pretrain-text row tokenizes to [] -> must not crash and must
+    yield a valid (non-zero-length) sample."""
+    tok = _FakeTokenizer(eod=0, pad=7)
+    ds = _make_varlen([""], _make_config(tok, seq_length=64))
+    out = ds[0]
+    assert out["tokens"].numel() >= 1
+    assert out["labels"].numel() == out["tokens"].numel()
+    assert out["loss_mask"].numel() == out["tokens"].numel()
+
+
+def test_getitem_exact_capacity_reserves_eod():
+    tok = _FakeTokenizer(eod=0, pad=7)
+    ds = _make_varlen(["abcde"], _make_config(tok, seq_length=4))
+
+    out = ds[0]
+
+    assert out["tokens"].numel() == 4
+    assert out["labels"][-1].item() == tok.eod
+    assert out["loss_mask"][-1].item() == 1.0
+
+
+def test_getitem_truncated_prompt_keeps_forced_eod_masked():
+    tok = _FakeTokenizer(eod=0, pad=7)
+    messages = [{"role": "user", "content": "abcde"}]
+    ds = _make_varlen([messages], _make_config(tok, seq_length=4))
+
+    out = ds[0]
+
+    assert out["tokens"].numel() == 4
+    assert out["labels"][-1].item() == IGNORE_INDEX
+    assert out["loss_mask"][-1].item() == 0.0
+
+
+def test_getitem_prompt_only_appended_eod_is_masked():
+    tok = _FakeTokenizer(eod=0, pad=7)
+    messages = [{"role": "user", "content": "abc"}]
+    ds = _make_varlen([messages], _make_config(tok, seq_length=8))
+
+    out = ds[0]
+
+    assert out["labels"][-1].item() == IGNORE_INDEX
+    assert out["loss_mask"][-1].item() == 0.0
+
+
+@pytest.mark.parametrize("sbhd", [False, True])
+def test_getitem_honors_eod_mask_loss(sbhd):
+    tok = _FakeTokenizer(eod=0, pad=7)
+    tok.tokenize = lambda _: [1, tok.eod, 2]
+    ds = _make_varlen(["abc"], _make_config(tok, seq_length=8, sbhd=sbhd, eod_mask=True))
+
+    out = ds[0]
+
+    assert out["tokens"][1].item() == tok.eod
+    assert out["loss_mask"][1].item() == 0.0
+    assert out["labels"][0].item() == tok.eod
+    assert out["loss_mask"][0].item() == 1.0
+
+
+def test_getitem_sbhd_pads_to_seq_length_and_masks_tail():
+    tok = _FakeTokenizer(eod=0, pad=None)
+    ds = _make_varlen(["abc"], _make_config(tok, seq_length=8, sbhd=True))
+    out = ds[0]
+    # SBHD emits fixed [seq_length] samples with no packing metadata.
+    assert set(out) == {"tokens", "labels", "loss_mask", "position_ids"}
+    assert out["tokens"].numel() == 8
+    loss_mask = out["loss_mask"].tolist()
+    # tokens=[a,b,c,eod]: valid_len=3 -> first 3 kept (incl. real eod), rest masked.
+    assert loss_mask[0:3] == [1.0, 1.0, 1.0]
+    assert all(v == 0.0 for v in loss_mask[3:])
+
+
+def test_mock_getitem_thd_keys_and_pad_fallback():
+    tok = _FakeTokenizer(eod=0, pad=None)  # exercise the eod fallback (no crash)
+    ds = _make_mock_varlen([np.array([1, 2, 3, 4], dtype=np.int64)], _make_config(tok, cp=2))
+    out = ds[0]
+    assert set(out) == {
+        "tokens",
+        "labels",
+        "loss_mask",
+        "position_ids",
+        "original_seq_len",
+        "padded_seq_len",
+    }
+    n = out["tokens"].numel()
+    assert out["labels"].numel() == n and out["loss_mask"].numel() == n
+    assert int(out["padded_seq_len"].item()) % 4 == 0
+
+
+def test_mock_getitem_truncates_to_sequence_length():
+    tok = _FakeTokenizer(eod=0, pad=7)
+    ds = _make_mock_varlen([np.arange(1, 10, dtype=np.int64)], _make_config(tok, seq_length=4))
+
+    out = ds[0]
+
+    assert int(out["original_seq_len"].item()) == 4
+    assert out["tokens"].numel() == 4
+
+
+def test_mock_getitem_honors_eod_mask_loss():
+    tok = _FakeTokenizer(eod=0, pad=7)
+    ds = _make_mock_varlen(
+        [np.array([1, tok.eod, 2], dtype=np.int64)], _make_config(tok, eod_mask=True)
+    )
+
+    out = ds[0]
+
+    assert out["tokens"][1].item() == tok.eod
+    assert out["loss_mask"][1].item() == 0.0
+    assert out["labels"][0].item() == tok.eod
+    assert out["loss_mask"][0].item() == 1.0
+
+
+def test_mock_getitem_length_one_is_nonempty():
+    tok = _FakeTokenizer(eod=0, pad=7)
+    ds = _make_mock_varlen([np.array([], dtype=np.int64)], _make_config(tok))
+
+    out = ds[0]
+
+    assert int(out["original_seq_len"].item()) == 1
+    assert out["tokens"].numel() == 1
+
+
+# ----------------------------------------------------------------------------
+# THD handoff: _unpack_batch contract for VarlenDataset-style samples
+#
+# VarlenDataset already emits one unpacked sub-sample carrying ``padded_seq_len``,
+# so _unpack_batch must short-circuit (no cu_seqlens slicing) and only normalize
+# the collate batch dim. SFTDataset-style pre-packed samples (cu_seqlens, no
+# padded_seq_len) still take the slicing path.
+# ----------------------------------------------------------------------------
+
+
+def test_unpack_batch_short_circuits_for_varlen_samples():
+    from megatron.core.datasets.data_schedule_utils import _unpack_batch
+
+    # Two VarlenDataset-style samples, each already a single sub-sample with a
+    # leading batch dim (as added by the default collate_fn) and padded_seq_len.
+    batch = [
+        {
+            "tokens": torch.arange(4, dtype=torch.int64).view(1, 4),
+            "labels": torch.arange(4, dtype=torch.int64).view(1, 4),
+            "loss_mask": torch.ones(1, 4),
+            "position_ids": torch.arange(4, dtype=torch.int64).view(1, 4),
+            "padded_seq_len": torch.tensor([4], dtype=torch.int32),
+        },
+        {
+            "tokens": torch.arange(8, dtype=torch.int64).view(1, 8),
+            "labels": torch.arange(8, dtype=torch.int64).view(1, 8),
+            "loss_mask": torch.ones(1, 8),
+            "position_ids": torch.arange(8, dtype=torch.int64).view(1, 8),
+            "padded_seq_len": torch.tensor([8], dtype=torch.int32),
+            "original_seq_len": torch.tensor([8], dtype=torch.int32),
+        },
+    ]
+    out = _unpack_batch(batch)
+    # Short-circuit: same number of samples (no slicing into sub-samples).
+    assert len(out) == 2
+    # Leading collate batch dim dropped.
+    assert out[0]["tokens"].shape == (4,)
+    assert out[1]["tokens"].shape == (8,)
+    # Missing original_seq_len synthesized from padded_seq_len.
+    assert "original_seq_len" in out[0]
+    assert int(out[0]["original_seq_len"].item()) == 4
+    # Existing original_seq_len preserved.
+    assert int(out[1]["original_seq_len"].item()) == 8
+
+
+# ----------------------------------------------------------------------------
+# DataLoader collate selection (distributed; run under torch.distributed.run).
+#
+# Validates the build_pretraining_data_loader contract for the varlen paths:
+#   * --varlen-sbhd-validation emits fixed-length [seq_length] samples that the
+#     DEFAULT collate stacks into a [mbs, seq_length] batch.
+#   * The THD path (--use-varlen-dataset without SBHD) uses the identity collate
+#     (variable-length dicts are returned as a list, not stacked).
+# ----------------------------------------------------------------------------
+
+
+def _build_varlen_for_loader(items, config, num_samples):
+    from megatron.core.datasets.utils import Split
+
+    ds = VarlenDataset.__new__(VarlenDataset)
+    ds.config = config
+    ds.dataset = items
+    ds.indices = np.arange(len(items))
+    ds.num_samples = num_samples
+    ds.index_split = Split.train
+    return ds
+
+
+def _loader_args(*, use_varlen, sbhd, scheduler, mbs, gbs=None):
+    return SimpleNamespace(
+        dataloader_type='single',
+        micro_batch_size=mbs,
+        global_batch_size=mbs if gbs is None else gbs,
+        full_validation=False,
+        num_workers=0,
+        use_varlen_dataset=use_varlen,
+        varlen_sbhd_validation=sbhd,
+        sequence_packing_scheduler=scheduler,
+    )
+
+
+def test_sbhd_validation_dataloader_uses_default_collate():
+    from megatron.core import parallel_state
+    from megatron.training.datasets.data_samplers import build_pretraining_data_loader
+    from megatron.training.global_vars import destroy_global_vars, set_args
+    from tests.unit_tests.test_utilities import Utils
+
+    Utils.initialize_model_parallel(1, 1)
+    try:
+        tok = _FakeTokenizer(eod=0, pad=7)
+        seq_len, mbs = 16, 2
+        # One global batch needs micro_batch_size * data_parallel_size samples;
+        # size the dataset off the runtime DP world size so this passes under
+        # any --nproc-per-node (the CI default is 8 ranks -> dp=8).
+        dp = parallel_state.get_data_parallel_world_size()
+        n = mbs * dp * 4
+        cfg = _make_config(tok, seq_length=seq_len, sbhd=True)
+        ds = _build_varlen_for_loader(["hello world"] * n, cfg, num_samples=n)
+        set_args(_loader_args(use_varlen=True, sbhd=True, scheduler=None, mbs=mbs))
+        loader = build_pretraining_data_loader(ds, consumed_samples=0)
+        batch = next(iter(loader))
+        # Default collate stacks fixed-length SBHD samples into a tensor batch.
+        assert isinstance(batch, dict)
+        assert batch["tokens"].shape == (mbs, seq_len)
+        assert batch["labels"].shape == (mbs, seq_len)
+        assert batch["loss_mask"].shape == (mbs, seq_len)
+    finally:
+        destroy_global_vars()
+        Utils.destroy_model_parallel()
+
+
+def test_thd_dataloader_uses_identity_collate():
+    from megatron.core import parallel_state
+    from megatron.training.datasets.data_samplers import build_pretraining_data_loader
+    from megatron.training.global_vars import destroy_global_vars, set_args
+    from tests.unit_tests.test_utilities import Utils
+
+    Utils.initialize_model_parallel(1, 1)
+    try:
+        tok = _FakeTokenizer(eod=0, pad=7)
+        mbs = 2
+        dp = parallel_state.get_data_parallel_world_size()
+        n = mbs * dp * 4
+        cfg = _make_config(tok, seq_length=64, sbhd=False)
+        # Variable-length samples so identity collate is required.
+        variable = ["a", "abcdef", "xy", "qwerty"]
+        items = [variable[i % len(variable)] for i in range(n)]
+        ds = _build_varlen_for_loader(items, cfg, num_samples=n)
+        set_args(_loader_args(use_varlen=True, sbhd=False, scheduler="dp_balanced", mbs=mbs))
+        loader = build_pretraining_data_loader(ds, consumed_samples=0)
+        batch = next(iter(loader))
+        # Identity collate returns the raw list of per-sample dicts (unstacked).
+        assert isinstance(batch, list)
+        assert len(batch) == mbs
+        assert "padded_seq_len" in batch[0]
+    finally:
+        destroy_global_vars()
+        Utils.destroy_model_parallel()
+
+
+def test_packing_scheduler_dataloader_yields_microbatches():
+    from megatron.core import parallel_state
+    from megatron.training.datasets.data_samplers import build_pretraining_data_loader
+    from megatron.training.global_vars import destroy_global_vars, set_args
+    from tests.unit_tests.test_utilities import Utils
+
+    Utils.initialize_model_parallel(1, 1)
+    try:
+        tok = _FakeTokenizer(eod=0, pad=7)
+        mbs = 2
+        num_microbatches = 3
+        dp = parallel_state.get_data_parallel_world_size()
+        gbs = mbs * dp * num_microbatches
+        n = gbs * 2
+        cfg = _make_config(tok, seq_length=64, dp=dp, cp=1)
+        variable = ["a", "abcdef", "xy", "qwerty"]
+        items = [variable[i % len(variable)] for i in range(n)]
+        ds = _build_varlen_for_loader(items, cfg, num_samples=n)
+        set_args(
+            _loader_args(use_varlen=True, sbhd=False, scheduler="dp_balanced", mbs=mbs, gbs=gbs)
+        )
+        loader = build_pretraining_data_loader(ds, consumed_samples=0)
+        batch = next(iter(loader))
+        # The packing scheduler calls next(data_iterator) num_microbatches times;
+        # each loader step must therefore be one local microbatch, not all
+        # local samples from the global batch.
+        assert isinstance(batch, list)
+        assert len(batch) == mbs
+        assert "padded_seq_len" in batch[0]
+    finally:
+        destroy_global_vars()
+        Utils.destroy_model_parallel()


### PR DESCRIPTION
## Summary

- Add variable-length THD datasets for Hugging Face, Parquet, JSON, JSONL, and mock-data inputs.
- Add native loading for Nemotron SFT Math v3 and related OpenAI/OpenCode schemas, including tool definitions, reasoning metadata, and tokenizer chat-template keyword forwarding.
- Discover all usable dataset configurations, prefer `train`, fall back to thematic splits, and exclude held-out-only validation/test/dev splits.
- Support heterogeneous row schemas (`messages`, ShareGPT, Alpaca, and plain prompt/response) and deterministic mixing across multiple dataset components.
- Add an SBHD reference path for dense, fixed-CP comparisons.

## User-facing flags

| Flag | Behavior and constraints |
| --- | --- |
| `--use-varlen-dataset` | Enables variable-length instruction or pretraining data. Its default THD mode selects `dp_balanced`; with dynamic CP it preserves `default_dynamic_cp`. THD mode requires per-token loss, `--max-seqlen-per-dp-cp-rank`, and CUDA graphs disabled. It is incompatible with `--sft`, FIM, reset-position/reset-attention behavior, and inter-document masking. |
| `--varlen-sbhd-validation` | Enables the dense, padded SBHD reference path. It requires `--use-varlen-dataset`, is real-data only, and is incompatible with a sequence-packing scheduler, dynamic CP, and MoE. |
| `--varlen-mock-dataset-config-json VALUE` | Supplies inline JSON or a JSON file for synthetic variable-length samples. Requires `--use-varlen-dataset --mock-data`. |

The dynamic CP flags and scheduler are provided by the base PR, #5679.

## Stack and attribution

- Base: #5679, which contains the dynamic CP runtime and scheduler.
- Follow-up: #5811, which provides the Nemotron Math v3 baseline-versus-DCP benchmark harness.
- The loader and training behavior incorporate the example from [xiaoyao0115's branch](https://github.com/xiaoyao0115/Megatron-LM/tree/tailaim/varlen-math-v3-pr5541) and supersede the relevant training portion of #5771.

## Validation

- `uv run isort --check-only` and `uv run ruff check` on changed Python files
- `uv run black --check` on the two new dataset files
- Python byte compilation and `git diff --check`
- Focused manual loader harness covering held-out split filtering, deterministic component mixing, nullable union schemas, and raw JSON-array fallback
- Signed commit verified locally: `96f3e6ac9cfb191b2163ae4ebaf308dd58957da8`

Full pytest execution was not available locally because the environment lacks the required PyTorch and datasets installations. CI was requested on the signed commit.