### PR TITLE
fix: add label shifting to mlite THD packing to align SFT loss with M…

### DIFF
--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py
@@ -155,6 +155,8 @@ def _prepare_packed_batch_kwargs(model, batch: PackedBatch) -> dict[str, Any]:
         cp_group=ps.cp_group,
         split_cp=False,
         labels=_nested_from_packed_tensor(batch.labels, seq_lens),
+        roll_labels=True,
+        roll_loss_mask=True,
         loss_mask=_nested_from_packed_tensor(batch.loss_mask, seq_lens),
     )
     kwargs: dict[str, Any] = {


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
<!-- Add a one line overview of what this PR aims to accomplish. -->

Fix a bug


## Description



**Context** 

During the parity testing between [`mlite`](https://github.com/verl-project/verl/pull/6791) backend and the [`megatron bridge`](https://github.com/verl-project/verl/pull/6603) backend with DeepSeek V4 Flash SFT training, we observed a significant discrepancy in the training metrics\. Specifically, the initial step loss in `mlite` was abnormally high \(around 24 vs 16 from `megatron bridge`\), and the `train/loss` and `train/grad_norm` curves failed to align with the Megatron baseline\.




**Note on Experimental Simplification:**

To reduce replication difficulty and conserve compute resources, we simplified the experimental setup on both sides while ensuring validity:

- **Model Architecture:** The original 43\-layer DeepSeek V4 Flash was pruned down to first 3 layers, and MTP \(Multi\-Token Prediction\) was completely disabled\.

- **Compute Resources:** The hardware requirement was scaled down from the recommended 16 nodes \(128x H20 GPUs\) to a single node \(8x H20 GPUs\)\.

- **Parallelism Configuration:** The training config was simplified from `PP16 EP8 TP1 CP1` to `PP1 EP8 TP1 CP1`\.

- *Since the control experiments on both sides were conducted under the exact same simplified configuration, the parity comparison remains fully valid and reasonable\.*




**Root Cause**

Investigation revealed an issue with the token alignment logic during the SFT phase:

- The underlying SFT loss logic in `verl` assumes that `log_probs` are already aligned for `next-token` prediction\.

- However, during the THD data packing process in `mlite` \(`protocol.py`\), the `labels` were passed to the Cross\-Entropy \(CE\) calculation **without being left\-shifted**\.

- This misalignment caused the original, unshifted labels to be fed directly into the CE loss, leading to a semantic mismatch that severely inflated the initial loss\.



**Solution**

- Added the `roll_labels=True` parameter to the THD packing logic within the `_prepare_packed_batch_kwargs` function in `protocol.py`\.

- This ensures that the labels correctly undergo a left\-shift operation during SFT, perfectly aligning them with the next\-token prediction `log_probs`\.



**Validation**

1. **Single\-step test:** After the fix, the initial step loss in `mlite` successfully dropped from \~24 to a normal value of \~16\.81\.

2. **Parity test:** Running the full alignment script confirmed that the metrics for `mlite` and `test-deepseek-v4-flash-megatron` are now perfectly matched\.

    - `train/loss` trajectories are almost identical\.

    - `train/grad_norm` trajectories are almost identical\.



**Screenshots**

- `train/loss` parity: 
<img width="843" height="451" alt="img_v3_0213b_b1500cb1-bee3-4fa1-bf90-b274265eecdg" src="https://github.com/user-attachments/assets/ea2234b7-07f1-47d4-ba3c-90d18188775f" />


- `train/grad_norm` parity:
<img width="831" height="434" alt="image" src="https://github.com/user-attachments/assets/4334c595-49a9-47f0-a68d-1ffa143d503e" />

🟣 Purple line: mlite before the fix.

🔴 Red line: mlite after the label roll fix.

🟡 Yellow line: megatron bridge (Target baseline).
(As shown in the charts, the red and yellow lines now perfectly overlap.)



:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
