### PR TITLE
Add configurable optimizer parameter-group overrides

### DIFF
--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -1,8 +1,10 @@
 # Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
 import copy
 import logging
+import re
 import warnings
 from collections import defaultdict
+from collections.abc import Mapping
 from dataclasses import astuple
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
@@ -126,6 +128,133 @@ def get_standard_config_overrides(config: OptimizerConfig) -> Dict[ParamKey, Par
         config_overrides[decoupled_param_key] = decoupled_lr_config
 
     return config_overrides
+
+
+def get_optimizer_overrides_from_config(
+    config: OptimizerConfig,
+) -> Dict[ParamKey, ParamGroupOverride]:
+    """Build optimizer overrides from ``OptimizerConfig.overrides_config``.
+
+    When ``overrides_config`` is unset, this returns :func:`get_standard_config_overrides`.
+    Otherwise, the configured mapping is authoritative: it maps descriptive group names to a
+    ``param_key`` selector and a ``param_group_override``. Selectors support the serializable
+    ``ParamKey`` name globs and parameter attributes, plus optional positive and negative name
+    regexes. Regexes use :func:`re.search` semantics, and an exclusion always vetoes a positive
+    match.
+
+    Example::
+
+        overrides_config = {
+            "hidden": {
+                "param_key": {"name": ["*.linear_fc1.weight", "*.linear_fc2.weight"]},
+                "param_group_override": {
+                    "max_lr": 1.0e-3,
+                    "min_lr": 1.0e-5,
+                    "eps": 1.0e-12,
+                    "wd_mult": 1.0,
+                },
+            }
+        }
+
+    Args:
+        config (OptimizerConfig): Optimizer configuration containing parsed override data.
+
+    Returns:
+        Dict[ParamKey, ParamGroupOverride]: Configured optimizer overrides.
+    """
+
+    def as_mapping(value: Any, path: str) -> Mapping[str, Any]:
+        if isinstance(value, Mapping):
+            return value
+        if hasattr(value, "__dict__"):
+            return vars(value)
+        raise TypeError(f"{path} must be a mapping, got {type(value).__name__}")
+
+    def as_tuple(value: Any, path: str) -> Tuple[str, ...]:
+        if value is None:
+            return ()
+        if isinstance(value, str):
+            return (value,)
+        if isinstance(value, (list, tuple)) and all(isinstance(item, str) for item in value):
+            return tuple(value)
+        raise TypeError(f"{path} must be a string or sequence of strings")
+
+    if config.overrides_config is None:
+        return get_standard_config_overrides(config)
+
+    configured_groups = as_mapping(config.overrides_config, "overrides_config")
+    allowed_param_key_fields = {"name", "attr", "name_regex", "exclude_name_regex"}
+    allowed_override_fields = set(ParamGroupOverride.__annotations__)
+    overrides: Dict[ParamKey, ParamGroupOverride] = {}
+
+    for group_name, raw_group in configured_groups.items():
+        group_path = f"overrides_config.{group_name}"
+        group = as_mapping(raw_group, group_path)
+        unknown_group_fields = set(group) - {"param_key", "param_group_override"}
+        if unknown_group_fields:
+            raise ValueError(f"{group_path} has unsupported fields: {sorted(unknown_group_fields)}")
+        if "param_key" not in group or "param_group_override" not in group:
+            raise ValueError(f"{group_path} requires param_key and param_group_override")
+
+        key_config = as_mapping(group["param_key"], f"{group_path}.param_key")
+        unknown_key_fields = set(key_config) - allowed_param_key_fields
+        if unknown_key_fields:
+            raise ValueError(
+                f"{group_path}.param_key has unsupported fields: {sorted(unknown_key_fields)}"
+            )
+
+        names = as_tuple(key_config.get("name"), f"{group_path}.param_key.name")
+        attrs = as_tuple(key_config.get("attr"), f"{group_path}.param_key.attr")
+        name_regexes = as_tuple(key_config.get("name_regex"), f"{group_path}.param_key.name_regex")
+        exclude_name_regexes = as_tuple(
+            key_config.get("exclude_name_regex"), f"{group_path}.param_key.exclude_name_regex"
+        )
+        if not (names or attrs or name_regexes):
+            raise ValueError(f"{group_path}.param_key requires a positive selector")
+
+        try:
+            include_regexes = tuple(re.compile(pattern) for pattern in name_regexes)
+            exclude_regexes = tuple(re.compile(pattern) for pattern in exclude_name_regexes)
+        except re.error as error:
+            raise ValueError(f"{group_path}.param_key has invalid regex: {error}") from error
+
+        if include_regexes or exclude_regexes:
+            positive_key = ParamKey(name=names, attr=attrs)
+
+            def matches(
+                param,
+                name,
+                positive_key=positive_key,
+                include_regexes=include_regexes,
+                exclude_regexes=exclude_regexes,
+            ):
+                positive = positive_key.matches(param, name) or any(
+                    pattern.search(name) for pattern in include_regexes
+                )
+                return positive and not any(pattern.search(name) for pattern in exclude_regexes)
+
+            param_key = ParamKey(
+                with_name_predicate=ParamWithNamePredicate(name=f"config:{group_name}", fn=matches)
+            )
+        else:
+            param_key = ParamKey(name=names, attr=attrs)
+
+        override_config = as_mapping(
+            group["param_group_override"], f"{group_path}.param_group_override"
+        )
+        unknown_override_fields = set(override_config) - allowed_override_fields
+        if unknown_override_fields:
+            raise ValueError(
+                f"{group_path}.param_group_override has unsupported fields: "
+                f"{sorted(unknown_override_fields)}"
+            )
+        if not override_config:
+            raise ValueError(f"{group_path}.param_group_override must not be empty")
+        if param_key in overrides:
+            raise ValueError(f"{group_path} duplicates an earlier param_key selector")
+        overrides[param_key] = ParamGroupOverride(**override_config)
+
+    return overrides
 
 
 def get_mup_config_overrides(
@@ -1016,7 +1145,7 @@ def get_megatron_optimizer(
     # None → apply standard defaults. To extend defaults with custom overrides,
     # start from get_standard_config_overrides(config) and merge yours in.
     if config_overrides is None:
-        config_overrides = get_standard_config_overrides(config)
+        config_overrides = get_optimizer_overrides_from_config(config)
 
     check_config_overrides_consistency(config, config_overrides)
 

--- a/megatron/core/optimizer/optimizer_config.py
+++ b/megatron/core/optimizer/optimizer_config.py
@@ -2,7 +2,7 @@
 
 import fnmatch
 from dataclasses import dataclass, field
-from typing import Callable, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Optional, Tuple, Union
 
 import torch
 
@@ -164,6 +164,14 @@ class OptimizerConfig:
 
     apply_wd_to_qk_layernorm: bool = False
     """If true, apply weight decay to qk layernorm as a special case."""
+
+    overrides_config: Optional[Dict[str, Any]] = None
+    """Serialized per-parameter optimizer overrides.
+
+    Each named entry contains a ``param_key`` selector and a ``param_group_override`` mapping.
+    Numeric values are expected to be resolved by the caller before constructing this config. When
+    provided, this mapping replaces the standard parameter-group overrides.
+    """
 
     ##############
     # Precision

--- a/megatron/core/optimizer_param_scheduler.py
+++ b/megatron/core/optimizer_param_scheduler.py
@@ -34,6 +34,7 @@ class ParamGroupOverride(TypedDict, total=False):
     start_wd: float
     end_wd: float
     wd_mult: float
+    eps: float
     optimizer: str
 
 

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -73,7 +73,7 @@ from megatron.core.optimizer import (
     ParamKey,
     get_megatron_optimizer,
     get_mup_config_overrides,
-    get_standard_config_overrides,
+    get_optimizer_overrides_from_config,
 )
 from megatron.core.optimizer.distrib_optimizer import DistributedOptimizer
 from megatron.core.optimizer.layer_wise_optimizer import (
@@ -1952,7 +1952,7 @@ def get_megatron_optimizer_config(args: Any) -> OptimizerConfig:
 
     # Construct the appropriate config_overrides object. This default handles many cases, but
     #  can be added to as needed by the user, or replaced entirely with a custom override.
-    config_overrides = get_standard_config_overrides(config=config)
+    config_overrides = get_optimizer_overrides_from_config(config=config)
 
     return config, config_overrides
 

--- a/tests/unit_tests/test_optimizer.py
+++ b/tests/unit_tests/test_optimizer.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import os
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -24,6 +25,7 @@ from megatron.core.optimizer import (
     _get_param_groups,
     check_config_overrides_consistency,
     get_megatron_optimizer,
+    get_optimizer_overrides_from_config,
     get_standard_config_overrides,
 )
 from megatron.core.optimizer.distrib_optimizer import DistributedOptimizer
@@ -125,6 +127,139 @@ def test_get_param_groups_default_overrides(mock_get_world_size):
     pg0, pg1 = param_groups
     wd_mults = {pg0['wd_mult'], pg1['wd_mult']}
     assert wd_mults == {1.0, 0.0}
+
+
+def test_get_optimizer_overrides_from_config_mapping():
+    config = OptimizerConfig(
+        overrides_config={
+            "expert_output": {
+                "param_key": {"name": ["*.experts.*.linear_fc2.weight"]},
+                "param_group_override": {
+                    "max_lr": 2.5e-4,
+                    "min_lr": 2.5e-6,
+                    "eps": 1.0e-12,
+                    "wd_mult": 4.0,
+                },
+            },
+            "norm_not_qk": {
+                "param_key": {
+                    "name_regex": r"layernorm\.weight$",
+                    "exclude_name_regex": r"\.(?:q|k)_layernorm\.",
+                },
+                "param_group_override": {"max_lr": 1.0e-3, "wd_mult": 0.0},
+            },
+        }
+    )
+
+    overrides = get_optimizer_overrides_from_config(config)
+    assert len(overrides) == 2
+    expert_key = next(key for key in overrides if key.name)
+    norm_key = next(key for key in overrides if key.with_name_predicate)
+    parameter = torch.nn.Parameter(torch.empty(4))
+    assert expert_key.matches(parameter, "decoder.experts.0.linear_fc2.weight")
+    assert not expert_key.matches(parameter, "decoder.linear_fc2.weight")
+    assert norm_key.matches(parameter, "decoder.input_layernorm.weight")
+    assert not norm_key.matches(parameter, "decoder.q_layernorm.weight")
+    assert overrides[expert_key] == {
+        "max_lr": 2.5e-4,
+        "min_lr": 2.5e-6,
+        "eps": 1.0e-12,
+        "wd_mult": 4.0,
+    }
+
+
+def test_get_optimizer_overrides_from_config_falls_back_to_standard_overrides():
+    config = OptimizerConfig()
+
+    assert get_optimizer_overrides_from_config(config) == get_standard_config_overrides(config)
+
+
+def test_get_optimizer_overrides_from_config_parsed_namespace():
+    config = OptimizerConfig(
+        overrides_config=SimpleNamespace(
+            hidden=SimpleNamespace(
+                param_key=SimpleNamespace(name="*.linear_fc1.weight"),
+                param_group_override=SimpleNamespace(max_lr=1.0e-3),
+            )
+        )
+    )
+
+    overrides = get_optimizer_overrides_from_config(config)
+    key, override = next(iter(overrides.items()))
+    assert key.name == ("*.linear_fc1.weight",)
+    assert override == {"max_lr": 1.0e-3}
+
+
+@patch('torch.distributed.get_world_size', return_value=1)
+@patch(
+    'torch.distributed.all_gather_object', lambda output_list, obj: output_list.__setitem__(0, obj)
+)
+def test_get_optimizer_overrides_from_config_applies_group_values(mock_get_world_size):
+    model = torch.nn.Module()
+    model.expert_output = torch.nn.Linear(4, 4, bias=False)
+    model.layernorm = torch.nn.LayerNorm(4)
+    config = OptimizerConfig(
+        lr=1.0e-3,
+        min_lr=1.0e-5,
+        overrides_config={
+            "expert_output": {
+                "param_key": {"name_regex": r"expert_output\.weight$"},
+                "param_group_override": {
+                    "max_lr": 2.5e-4,
+                    "min_lr": 2.5e-6,
+                    "eps": 1.0e-12,
+                    "wd_mult": 4.0,
+                },
+            },
+            "layernorm_gain": {
+                "param_key": {"name_regex": r"layernorm\.weight$"},
+                "param_group_override": {"wd_mult": 2.0},
+            },
+        },
+    )
+    overrides = get_optimizer_overrides_from_config(config)
+
+    param_groups = _get_param_groups([model], config, overrides)
+    expert_group = next(
+        group
+        for group in param_groups
+        if any(param is model.expert_output.weight for param in group["params"])
+    )
+
+    assert expert_group["max_lr"] == 2.5e-4
+    assert expert_group["min_lr"] == 2.5e-6
+    assert expert_group["eps"] == 1.0e-12
+    assert expert_group["wd_mult"] == 4.0
+    layernorm_group = next(
+        group
+        for group in param_groups
+        if any(param is model.layernorm.weight for param in group["params"])
+    )
+    assert layernorm_group["wd_mult"] == 2.0
+
+
+@pytest.mark.parametrize(
+    ("overrides_config", "message"),
+    [
+        ({"bad": {"param_key": {"name": "*.weight"}, "unknown": {}}}, "unsupported fields"),
+        (
+            {"bad": {"param_key": {"name_regex": "["}, "param_group_override": {"max_lr": 1.0e-3}}},
+            "invalid regex",
+        ),
+        (
+            {
+                "bad": {
+                    "param_key": {"name": "*.weight"},
+                    "param_group_override": {"not_an_override": 1.0},
+                }
+            },
+            "unsupported fields",
+        ),
+    ],
+)
+def test_get_optimizer_overrides_from_config_rejects_invalid_config(overrides_config, message):
+    with pytest.raises((TypeError, ValueError), match=message):
+        get_optimizer_overrides_from_config(OptimizerConfig(overrides_config=overrides_config))
 
 
 @patch('torch.distributed.get_world_size', return_value=1)


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Adds a serialized `OptimizerConfig.overrides_config` bridge to Megatron's existing `Dict[ParamKey, ParamGroupOverride]` optimizer-group interface.

## Issue tracking

Linked issue: Fixes #5685

## Design

Each named configuration entry contains:

- a `param_key` selector using existing name globs and parameter attributes;
- optional positive `name_regex` and negative `exclude_name_regex` selectors, compiled internally to `ParamWithNamePredicate`; and
- a `param_group_override` mapping using existing override fields such as `max_lr`, `min_lr`, `eps`, and `wd_mult`.

Numeric scaling expressions are intentionally out of scope. Hydra or another caller resolves width/depth-dependent factors before constructing `OptimizerConfig`. When `overrides_config` is present, it is authoritative and replaces the standard parameter-group overrides; omitting it preserves the existing standard behavior. Existing direct `config_overrides` callers remain unchanged, and arbitrary callables are not deserialized from YAML.

This is sufficient to express the optimizer-side rules in [MSSP](https://arxiv.org/abs/2605.14200): per-parameter-group SGD/Adam learning rates, Adam epsilon, and AdamW weight-decay multipliers. Initialization, residual scaling, router initialization, aggregation, and expert weight sharing remain model-configuration concerns.

## Example

```yaml
overrides_config:
  expert_output:
    param_key:
      name: ["*.experts.*.linear_fc2.weight"]
      exclude_name_regex: ["shared_expert"]
    param_group_override:
      max_lr: 2.5e-4
      min_lr: 2.5e-6
      eps: 1.0e-12
      wd_mult: 4.0
```

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code
- [x] I have added relevant documentation in the public API docstrings
- [x] I have run `tools/autoformat.sh` in check-only mode

## Validation status

- Seven focused unit tests passed, covering mapping and parsed-namespace input, standard fallback, authoritative configured overrides, positive/negative regex matching, invalid configuration rejection, and application of `max_lr`, `min_lr`, `eps`, and `wd_mult` through `_get_param_groups`.
- In-memory MSSP configuration smoke checks passed for Regimes I/II/III with AdamW and SGD: 54 exclusive parameter-group assignments covering pre-resolved learning rates, Adam epsilon, and inverse-LR AdamW `wd_mult` values.
- Check-only Black, isort, pylint, and Ruff passed.
- `mypy` was unavailable in the local environment.
- No training or MSSP coordinate experiment has been run yet; that validation plan remains subject to author approval.