### PR TITLE
[dev] Align Megatron Lite MoE RL execution contracts

### DIFF
--- a/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
+++ b/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
@@ -537,7 +537,16 @@ class MegatronLiteEngine(BaseEngine):
             ),
             optimizer=self._build_mlite_optimizer_config(),
             attention_backend_override=self.engine_config.attention_backend_override,
-            router_aux_loss_coef=self.engine_config.router_aux_loss_coef,
+            # verl's megatron backend hard-disables the load-balancing objective
+            # for RL (config_converter: moe_router_load_balancing_type='none',
+            # "turn off aux_loss as it hurts perf in RL"). Default to the same
+            # semantics instead of falling through to the HF checkpoint's
+            # nonzero router_aux_loss_coef; an explicit engine value still wins.
+            router_aux_loss_coef=(
+                0.0
+                if self.engine_config.router_aux_loss_coef is None
+                else self.engine_config.router_aux_loss_coef
+            ),
             load_hf_weights=self.engine_config.load_hf_weights,
             impl_cfg=self._build_impl_cfg(),
         )

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/model.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/model.py
@@ -164,6 +164,7 @@ class MoELayer(nn.Module):
         router_dtype: torch.dtype | None = None,
         preserve_3d_graph: bool = False,
         shared_expert_plain_te: bool = False,
+        moe_permute_fusion: bool | None = None,
     ):
         super().__init__()
         if fp8:
@@ -177,7 +178,11 @@ class MoELayer(nn.Module):
         )
         self.experts = Experts(config, ps, fp8=fp8, moe_act_recompute=moe_act_recompute)
         self.dispatcher = TokenDispatcher(
-            config.num_experts, config.hidden_size, ps, use_deepep=use_deepep
+            config.num_experts,
+            config.hidden_size,
+            ps,
+            use_deepep=use_deepep,
+            moe_permute_fusion=moe_permute_fusion,
         )
         self.shared_expert = SharedExpert(config, ps, use_plain_te_linear=shared_expert_plain_te)
         self.preserve_3d_graph = bool(preserve_3d_graph)
@@ -278,9 +283,10 @@ class Qwen35Layer(nn.Module):
             router_bias_rate=router_bias_rate,
             fp8=fp8,
             moe_act_recompute=moe_act_recompute,
-            router_dtype=torch.float32 if deterministic else None,
+            router_dtype=torch.float32,
             preserve_3d_graph=deterministic,
             shared_expert_plain_te=deterministic,
+            moe_permute_fusion=True,
         )
 
     def forward(

--- a/experimental/lite/megatron/lite/primitive/modules/dispatcher.py
+++ b/experimental/lite/megatron/lite/primitive/modules/dispatcher.py
@@ -189,12 +189,21 @@ class _DeepEPCombine(torch.autograd.Function):
 class TokenDispatcher:
 
     def __init__(
-        self, num_experts: int, hidden_size: int, ps: ParallelState, *, use_deepep: bool = True
+        self,
+        num_experts: int,
+        hidden_size: int,
+        ps: ParallelState,
+        *,
+        use_deepep: bool = True,
+        moe_permute_fusion: bool | None = None,
     ):
         self.ps = ps
         self.num_experts = num_experts
         self.ep_size = ps.ep_size
         self.num_local_experts = ensure_divisible(num_experts, ps.ep_size)
+        self.moe_permute_fusion = (
+            _use_moe_permute_fusion() if moe_permute_fusion is None else bool(moe_permute_fusion)
+        )
 
         self.use_deepep = use_deepep and deep_ep is not None and ps.ep_size > 1
         if self.use_deepep:
@@ -245,7 +254,7 @@ class TokenDispatcher:
             expert_output,
             self._row_id_map,
             restore_shape=self._restore_shape,
-            fused=_use_moe_permute_fusion(),
+            fused=self.moe_permute_fusion,
         )
         previous_event = (
             EventOverlap(EventHandle())
@@ -294,7 +303,7 @@ class TokenDispatcher:
             routing_map,
             probs=probs_2d,
             num_out_tokens=num_out,
-            fused=_use_moe_permute_fusion(),
+            fused=self.moe_permute_fusion,
         )[:3]
 
         self._row_id_map = sorted_indices
@@ -308,7 +317,7 @@ class TokenDispatcher:
             expert_output,
             self._row_id_map,
             restore_shape=self._restore_shape,
-            fused=_use_moe_permute_fusion(),
+            fused=self.moe_permute_fusion,
         )
         self._row_id_map = None
         self._restore_shape = None
@@ -336,7 +345,7 @@ class TokenDispatcher:
             routing_map,
             probs=probs_2d,
             num_out_tokens=num_out,
-            fused=_use_moe_permute_fusion(),
+            fused=self.moe_permute_fusion,
         )[:3]
         self._row_id_map = sorted_indices
         self._restore_shape = hidden_states.shape
@@ -398,7 +407,7 @@ class TokenDispatcher:
             combined,
             self._row_id_map,
             restore_shape=self._restore_shape,
-            fused=_use_moe_permute_fusion(),
+            fused=self.moe_permute_fusion,
         )
         self._row_id_map = None
         self._restore_shape = None
@@ -503,7 +512,7 @@ class TokenDispatcher:
             routing_map,
             probs=probs_2d,
             num_out_tokens=num_out,
-            fused=_use_moe_permute_fusion(),
+            fused=self.moe_permute_fusion,
         )[:3]
         self._row_id_map = sorted_indices
         self._restore_shape = recv_hidden.shape
@@ -562,7 +571,7 @@ class TokenDispatcher:
             expert_output,
             self._row_id_map,
             restore_shape=self._restore_shape,
-            fused=_use_moe_permute_fusion(),
+            fused=self.moe_permute_fusion,
         )
         if torch.is_grad_enabled():
             combined = _DeepEPCombine.apply(self.buffer, rank_grouped, self._handle, False, False)

--- a/experimental/lite/megatron/lite/primitive/modules/gated_delta_net.py
+++ b/experimental/lite/megatron/lite/primitive/modules/gated_delta_net.py
@@ -432,6 +432,7 @@ class GatedDeltaNet(nn.Module):
             a.reshape(batch, seq_len, self.num_v_heads_local),
         )
 
+    @jit_fuser
     def _prepare_qkv(
         self, qkv: torch.Tensor, gate, beta, alpha, batch: int, seq_len: int
     ):
@@ -440,9 +441,8 @@ class GatedDeltaNet(nn.Module):
             batch, seq_len, 2 * self.num_k_heads_local, self.dk
         )
         value = value.reshape(batch, seq_len, self.num_v_heads_local, self.dv)
+        query_key = self._l2norm(query_key.contiguous())
         query, key = query_key.split(self.num_k_heads_local, dim=2)
-        query = self._l2norm(query.contiguous())
-        key = self._l2norm(key.contiguous())
         if self.v_heads_per_k_head > 1:
             query = query.repeat_interleave(self.v_heads_per_k_head, dim=2)
             key = key.repeat_interleave(self.v_heads_per_k_head, dim=2)
@@ -455,10 +455,13 @@ class GatedDeltaNet(nn.Module):
             alpha.contiguous(),
         )
 
-    def _l2norm(self, x: torch.Tensor) -> torch.Tensor:
+    @staticmethod
+    @jit_fuser
+    def _l2norm(x: torch.Tensor) -> torch.Tensor:
         return l2norm(x)
 
     @staticmethod
+    @jit_fuser
     def _compute_g_and_beta(A_log, dt_bias, alpha, beta):
         g = -A_log.exp() * F.softplus(alpha.float() + dt_bias)
         return g, beta.sigmoid()

--- a/experimental/lite/megatron/lite/primitive/modules/router.py
+++ b/experimental/lite/megatron/lite/primitive/modules/router.py
@@ -99,7 +99,16 @@ class TopKRouter(nn.Module):
         if self.router_dtype is None:
             topk_scores = topk_scores.to(x.dtype)
 
-        if self.compute_aux_loss and self.training and torch.is_grad_enabled():
+        # A zero/None coefficient means no load-balancing objective (the RL
+        # reference backend runs moe_router_load_balancing_type='none'); do not
+        # attach an aux-loss gradient in that case.
+        apply_aux_loss = (
+            self.compute_aux_loss
+            and bool(self.aux_loss_coeff)
+            and self.training
+            and torch.is_grad_enabled()
+        )
+        if apply_aux_loss:
             routing_map, aux_scores = compute_routing_scores_for_aux_loss(
                 logits, self.topk, score_function="softmax", fused=self.moe_router_fusion
             )
@@ -177,7 +186,13 @@ class SigmoidTopKRouter(nn.Module):
         )
         topk_scores = topk_scores.to(logits.dtype)
 
-        if self.compute_aux_loss and self.training and torch.is_grad_enabled():
+        apply_aux_loss = (
+            self.compute_aux_loss
+            and bool(self.aux_loss_coeff)
+            and self.training
+            and torch.is_grad_enabled()
+        )
+        if apply_aux_loss:
             _, aux_scores = compute_routing_scores_for_aux_loss(
                 logits, self.topk, score_function=self.score_function, fused=self.moe_router_fusion
             )

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
@@ -31,6 +31,12 @@ def _build_impl_cfg(proto, rt_cfg: MegatronLiteConfig):
         and impl_cfg_kwargs.get("attention_backend_override") is None
     ):
         impl_cfg_kwargs["attention_backend_override"] = rt_cfg.attention_backend_override
+    if (
+        "router_aux_loss_coef" in init_fields
+        and impl_cfg_kwargs.get("router_aux_loss_coef") is None
+        and rt_cfg.router_aux_loss_coef is not None
+    ):
+        impl_cfg_kwargs["router_aux_loss_coef"] = rt_cfg.router_aux_loss_coef
     if "hf_path" in init_fields and impl_cfg_kwargs.get("hf_path") in (None, "") and rt_cfg.hf_path:
         impl_cfg_kwargs["hf_path"] = rt_cfg.hf_path
     # Thread the user-level OptimizerConfig so the protocol can pass it to

--- a/experimental/lite/tests/unit/primitive/test_router_aux_loss_gate.py
+++ b/experimental/lite/tests/unit/primitive/test_router_aux_loss_gate.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Aux-loss gating: a zero coefficient must not attach aux-loss gradients.
+
+The RL reference backend (verl megatron) runs
+``moe_router_load_balancing_type='none'`` — no load-balancing gradient at all.
+mLite routers previously attached the switch load-balancing loss through
+``MoEAuxLossAutoScaler`` whenever ``compute_aux_loss=True`` and training,
+even when the coefficient resolved to zero, injecting a coherent all-token
+gradient into every parameter below the router.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import megatron.lite.primitive.modules.router as router_module
+from megatron.lite.primitive.modules.router import SigmoidTopKRouter, TopKRouter
+
+
+def _ps():
+    return SimpleNamespace(tp_size=1)
+
+
+def _config(coef: float) -> SimpleNamespace:
+    return SimpleNamespace(
+        num_experts_per_tok=2,
+        num_experts=4,
+        n_routed_experts=4,
+        router_aux_loss_coef=coef,
+        aux_loss_alpha=coef,
+        hidden_size=8,
+        norm_topk_prob=True,
+        routed_scaling_factor=1.0,
+        scoring_func="sigmoid",
+        n_group=None,
+        topk_group=None,
+    )
+
+
+class _CountingScaler(torch.autograd.Function):
+    calls = 0
+
+    @staticmethod
+    def forward(ctx, output, aux_loss):
+        _CountingScaler.calls += 1
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        return grad_output, None
+
+
+@pytest.fixture
+def counting_scaler(monkeypatch):
+    _CountingScaler.calls = 0
+    monkeypatch.setattr(router_module, "MoEAuxLossAutoScaler", _CountingScaler)
+    return _CountingScaler
+
+
+@pytest.mark.parametrize("coef,expected_calls", [(0.0, 0), (0.001, 1)])
+def test_topk_router_skips_aux_loss_when_coef_zero(counting_scaler, coef, expected_calls):
+    if not torch.cuda.is_available():
+        pytest.skip("TopKRouter gating GEMM requires CUDA")
+    router = TopKRouter(_config(coef), _ps()).cuda()
+    router.train()
+    x = torch.randn(6, 8, device="cuda", requires_grad=True)
+    scores, indices = router(x)
+    assert scores.shape == (6, 2)
+    assert indices.shape == (6, 2)
+    assert counting_scaler.calls == expected_calls
+
+
+@pytest.mark.parametrize("coef,expected_calls", [(0.0, 0), (0.001, 1)])
+def test_sigmoid_router_skips_aux_loss_when_coef_zero(counting_scaler, coef, expected_calls):
+    router = SigmoidTopKRouter(_config(coef), _ps())
+    router.train()
+    x = torch.randn(6, 8, requires_grad=True)
+    scores, indices = router(x)
+    assert scores.shape == (6, 2)
+    assert indices.shape == (6, 2)
+    assert counting_scaler.calls == expected_calls


### PR DESCRIPTION
Port of ISEEKYAN/Megatron-LM#84 onto the `lite` branch.

## Summary

- disable MoE load-balancing auxiliary loss by default in the VERL RL engine while preserving explicit nonzero coefficients
- forward `router_aux_loss_coef` across the MLite runtime-to-protocol boundary
- skip auxiliary-loss autograd wiring entirely when its coefficient is zero
- align Qwen3.5 execution details with the Megatron reference: FP32 router GEMM, compiled joint Q/K L2Norm and g/beta helpers, and explicit MoE permute fusion
- add focused regression coverage for engine defaults, runtime forwarding, router gating, and Qwen3.5 execution contracts

## Root cause

The Megatron VERL path resolves MoE router load balancing to `none`, while MLite inherited the Hugging Face `router_aux_loss_coef=0.001`. MLite therefore optimized PPO plus a coherent all-token auxiliary gradient instead of PPO alone. An initial engine-only fix was insufficient because the top-level coefficient was not forwarded into the model protocol; this PR fixes both boundaries.

The Qwen3.5 router dtype, GDN compile contract, and dispatcher fusion changes close additional forward-parity gaps found during the same investigation. They were not the source of the 3.4x gradient-norm error, but keeping them aligned avoids known backend execution differences.

## Validation

- Slurm job `13522128`: MLite main job, unit-test step, and same-cache training step completed with `0:0`; 13 tests passed. Step 1 produced `pg_loss=0.017241794` and `grad_norm=0.040497918`.
- Megatron training-step anchor from job `13491111`: `grad_norm=0.0413`; the same-cache MLite/Megatron ratio is `0.9806`, inside the `[0.9, 1.1]` gate.
- Slurm job `13521950`: auxiliary-loss red/green regression, with the three new assertions failing before the fix and 11 tests passing after it.
- GDN compile-contract validation: packed-stage job `13493948` matched all recorded forward fingerprints bitwise; focused regression job `13493949` passed 17 tests; static-L2Norm fallback red/green completed in jobs `13494152`/`13494159`.
- Current branch CPU checks: 14 focused tests passed with one unrelated protocol test deselected because this host lacks `safetensors`; `compileall`, Ruff, and `git diff --check` passed.

The same-cache replay is a one-step root-cause gate. A separate five-step 15K anchor comparison remains the follow-up validation before extending training.



Additional end-to-end evidence since the original PR: a 5-step on-policy 15K-response DAPO run with this fix tracks the Megatron reference — final AIME acc@1 0.7354 vs 0.7479, per-step reward trajectory and grad-norm magnitude aligned throughout.
