### PR TITLE
Register private sampling RNG generators with CUDA graphs

### DIFF
--- a/megatron/core/inference/sampling/flashinfer_sampling.py
+++ b/megatron/core/inference/sampling/flashinfer_sampling.py
@@ -38,6 +38,15 @@ class FlashInferSampling(Sampling):
                 inline_capture=True,
             )
 
+    def cuda_graph_generators(self):
+        """RNG generators used inside the captured `sample_kernel` region.
+
+        `CudaGraphManager` registers these with the graph so their philox offset stays
+        live across replays; otherwise every replay would draw identical random numbers.
+        Satisfies the `CudaGraphGeneratorProvider` contract in `cuda_graphs`.
+        """
+        return (self._rng,)
+
     def sample_kernel(
         self,
         logits: Tensor,

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -15,7 +15,7 @@ from enum import Enum
 from functools import partial
 from itertools import chain, zip_longest
 from math import ceil
-from typing import Any, Dict, List
+from typing import Any, Dict, Iterable, List, Protocol, runtime_checkable
 
 import torch
 from torch.utils._pytree import tree_map as tree_map_pyt
@@ -262,6 +262,22 @@ def _clone_nested_tensors(value: Any) -> Any:
             "Sets of tensors are unsupported in cudagraph helpers; use list/tuple instead"
         )
     return value
+
+
+@runtime_checkable
+class CudaGraphGeneratorProvider(Protocol):
+    """Contract for a graphed module that samples from a private RNG generator.
+
+    A module implementing `cuda_graph_generators` declares generators that are used
+    inside its captured region but are not part of the global RNG tracker (e.g. an
+    inference sampling backend's own generator). `_CudaGraphRunner.create_fwd_graph`
+    registers them with the graph so their philox offset advances on replay instead
+    of being frozen at capture time.
+    """
+
+    def cuda_graph_generators(self) -> Iterable[torch.Generator]:
+        """Return the private RNG generators used inside the captured region."""
+        ...
 
 
 def _ensure_generator_state_is_cudagraph_safe(gen: torch.Generator) -> torch.Generator:
@@ -850,6 +866,16 @@ class _CudaGraphRunner(torch.nn.Module):
                 self.fwd_graph.register_generator_state(
                     _ensure_generator_state_is_cudagraph_safe(gen)
                 )
+
+            # A graphed module may draw from a private generator not tracked by the
+            # global RNG tracker (e.g. an inference sampling backend's own generator).
+            # Register it so its philox offset advances on replay instead of being frozen
+            # at capture. Inert for modules that do not implement the contract.
+            if isinstance(self.base_module, CudaGraphGeneratorProvider):
+                for gen in self.base_module.cuda_graph_generators():
+                    self.fwd_graph.register_generator_state(
+                        _ensure_generator_state_is_cudagraph_safe(gen)
+                    )
 
         args_to_clear_buffers = []
 

--- a/tests/unit_tests/inference/text_generation_controllers/test_text_generation_controller.py
+++ b/tests/unit_tests/inference/text_generation_controllers/test_text_generation_controller.py
@@ -31,12 +31,14 @@ from megatron.core.inference.inference_request import (
 from megatron.core.inference.model_inference_wrappers.gpt.gpt_inference_wrapper import (
     GPTInferenceWrapper,
 )
+from megatron.core.inference.sampling.flashinfer_sampling import FlashInferSampling
 from megatron.core.inference.sampling_params import SamplingParams
 from megatron.core.inference.text_generation_controllers.text_generation_controller import (
     DecodeForwardPrimer,
     TextGenerationController,
 )
 from megatron.core.inference.utils import InferenceMode
+from megatron.core.transformer.cuda_graphs import CudaGraphGeneratorProvider
 from megatron.core.models.gpt.gpt_layer_specs import (
     get_gpt_layer_local_spec,
     get_gpt_mtp_block_spec,
@@ -710,6 +712,69 @@ class TestTextGenerationController(TextGenerationControllerTestBase):
         assert torch.all(
             sampled_logits >= expected_min_values
         ), f"The sampled logits should all be greater than {expected_min_values} but its {sampled_logits}"
+
+    def test_flashinfer_sampling_satisfies_generator_contract(self):
+        """FlashInferSampling exposes, via the CUDA-graph generator contract, the exact
+        generator its kernel draws from — so graph capture can register it graph-safe."""
+        rng = torch.Generator()
+        rng.manual_seed(7)
+        sampling = FlashInferSampling(vocab_size=32, rng=rng, config=None, enable_cuda_graph=False)
+
+        assert isinstance(sampling, CudaGraphGeneratorProvider)
+        generators = tuple(sampling.cuda_graph_generators())
+        assert len(generators) == 1
+        assert generators[0] is rng
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+    def test_flashinfer_sampling_kernel_rng_advances_under_graph(self):
+        """The FlashInfer sampling kernel produces varying draws across graph replays
+        once its generator (exposed via the contract) is registered with the graph."""
+        flashinfer = pytest.importorskip("flashinfer")
+
+        device = torch.device("cuda")
+        rng = torch.Generator(device=device)
+        rng.manual_seed(0)
+        sampling = FlashInferSampling(
+            vocab_size=128, rng=rng, config=None, enable_cuda_graph=False
+        )
+
+        n, vocab = 64, 128
+        # Uniform, unfiltered (top_k=vocab, top_p=1.0) so sampling is fully RNG-driven and
+        # two graph-safe replays are overwhelmingly unlikely to coincide.
+        probs = torch.full((n, vocab), 1.0 / vocab, device=device)
+        top_k = torch.full((n,), vocab, device=device, dtype=torch.int32)
+        top_p = torch.full((n,), 1.0, device=device)
+        out = torch.empty(n, dtype=torch.int64, device=device)
+
+        def draw():
+            out.copy_(
+                flashinfer.sampling.top_k_top_p_sampling_from_probs(
+                    probs, top_k, top_p, generator=rng
+                )
+            )
+
+        warmup = torch.cuda.Stream()
+        warmup.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(warmup):
+            for _ in range(3):
+                draw()
+        torch.cuda.current_stream().wait_stream(warmup)
+
+        graph = torch.cuda.CUDAGraph()
+        for gen in sampling.cuda_graph_generators():
+            graph.register_generator_state(gen)
+        with torch.cuda.graph(graph):
+            draw()
+
+        graph.replay()
+        torch.cuda.synchronize()
+        first = out.clone()
+        graph.replay()
+        torch.cuda.synchronize()
+        second = out.clone()
+        assert not torch.equal(
+            first, second
+        ), "FlashInfer sampling drew identical tokens across replays (frozen RNG)"
 
     @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
     @pytest.mark.parametrize(

--- a/tests/unit_tests/transformer/test_cuda_graphs.py
+++ b/tests/unit_tests/transformer/test_cuda_graphs.py
@@ -31,6 +31,7 @@ from megatron.core.tensor_parallel.random import (
     model_parallel_cuda_manual_seed,
 )
 from megatron.core.transformer.cuda_graphs import (
+    CudaGraphGeneratorProvider,
     CudaGraphManager,
     TECudaGraphHelper,
     _CudagraphGlobalRecord,
@@ -379,6 +380,92 @@ class TestCudaGraphConfigAndArguments:
         assert cfg.inference_cuda_graph_scope == InferenceCudaGraphScope.none
         assert cfg.cuda_graph_modules == []
         assert cfg.cuda_graph_scope is None
+
+
+class TestCudaGraphGeneratorProvider:
+    """The `CudaGraphGeneratorProvider` contract: a graphed module can declare private
+    RNG generators to register with the graph so they advance (rather than freeze) on
+    replay. See `_CudaGraphRunner.create_fwd_graph`."""
+
+    def test_provider_detected_by_structural_typing(self):
+        class _WithGenerators:
+            def __init__(self, generator):
+                self._rng = generator
+
+            def cuda_graph_generators(self):
+                return (self._rng,)
+
+        gen = torch.Generator()
+        module = _WithGenerators(gen)
+        assert isinstance(module, CudaGraphGeneratorProvider)
+        assert tuple(module.cuda_graph_generators()) == (gen,)
+
+    def test_non_provider_module_is_ignored(self):
+        class _PlainModule:
+            pass
+
+        assert not isinstance(_PlainModule(), CudaGraphGeneratorProvider)
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+    def test_registered_generator_advances_across_replays(self):
+        """A provider's generator, once registered, advances on every replay; an
+        identical unregistered generator stays frozen at its captured state."""
+
+        class _SamplingModule:
+            def __init__(self, generator):
+                self._rng = generator
+
+            def cuda_graph_generators(self):
+                return (self._rng,)
+
+        def capture(draw_fn, generators):
+            warmup = torch.cuda.Stream()
+            warmup.wait_stream(torch.cuda.current_stream())
+            with torch.cuda.stream(warmup):
+                for _ in range(3):
+                    draw_fn()
+            torch.cuda.current_stream().wait_stream(warmup)
+            graph = torch.cuda.CUDAGraph()
+            for gen in generators:
+                graph.register_generator_state(gen)
+            with torch.cuda.graph(graph):
+                draw_fn()
+            return graph
+
+        def replay_twice(graph, out):
+            graph.replay()
+            torch.cuda.synchronize()
+            first = out.clone()
+            graph.replay()
+            torch.cuda.synchronize()
+            return first, out.clone()
+
+        device = torch.device("cuda")
+
+        # Registered (graph-safe): draws must vary across replays.
+        reg_gen = torch.Generator(device=device)
+        reg_gen.manual_seed(1234)
+        module = _SamplingModule(reg_gen)
+        assert isinstance(module, CudaGraphGeneratorProvider)
+        reg_out = torch.empty(64, device=device)
+        reg_graph = capture(
+            lambda: reg_out.copy_(torch.rand(64, device=device, generator=reg_gen)),
+            module.cuda_graph_generators(),
+        )
+        first, second = replay_twice(reg_graph, reg_out)
+        assert not torch.equal(first, second), "registered generator did not advance on replay"
+
+        # Control: identical setup without registration stays frozen.
+        ctrl_gen = torch.Generator(device=device)
+        ctrl_gen.manual_seed(1234)
+        ctrl_out = torch.empty(64, device=device)
+        ctrl_graph = capture(
+            lambda: ctrl_out.copy_(torch.rand(64, device=device, generator=ctrl_gen)), ()
+        )
+        ctrl_first, ctrl_second = replay_twice(ctrl_graph, ctrl_out)
+        assert torch.equal(
+            ctrl_first, ctrl_second
+        ), "unregistered generator advanced; the control assumption is invalid"
 
 
 class TestParallelTransformerBlockCudagraphs:


### PR DESCRIPTION
The FlashInfer sampling backend draws from a private torch.Generator inside a CUDA-graph-captured region. That generator is not part of the model-parallel RNG tracker, so on graph replay its philox offset was frozen at capture time and every replay drew identical random numbers.

Add a CudaGraphGeneratorProvider contract that a graphed module implements to declare such generators; _CudaGraphRunner.create_fwd_graph registers them with the graph so their offset advances across replays. FlashInferSampling exposes its sampling generator through this contract.

Add unit tests covering the contract detection, graph-safe advancement across replays, and the FlashInfer sampling kernel under graph replay.

- [ ] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
<!-- Add a one line overview of what this PR aims to accomplish. -->

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
