### PR TITLE
Clarify NVIDIA email signing guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,12 @@ skill keyword — infer it from the artifact you read.
 
 - All PRs must be created as **drafts**. Use `gh pr create --draft` or the GitHub UI draft option.
 - Never push branches directly to `https://github.com/NVIDIA/Megatron-LM`. You must push your branch to a personal fork (e.g. `https://github.com/<your-username>/Megatron-LM`), then open a PR from the fork's branch against `NVIDIA/Megatron-LM`.
-- Commit PR changes with both `-s` and `-S`: `-s` adds the required `Signed-off-by` trailer, and `-S` signs the commit so copy-pr-bot and `/ok to test` can verify the pushed commit without manually specifying the SHA.
+- Commit PR changes with both `-s` and `-S`: `-s` adds the required
+  `Signed-off-by` trailer, and `-S` signs the commit so copy-pr-bot and `/ok to
+test` can verify the pushed commit without manually specifying the SHA.
+Megatron Core engineers at NVIDIA should sign using their NVIDIA emails so they
+are automatically added to the right user groups on the internal Slack
+workspace.
 - Read @docs/developer/contribute.md for the full contribution policy, including code style, commit message conventions, and issue guidelines.
 
 ### Code Quality


### PR DESCRIPTION
## Summary

- Clarifies that Megatron Core engineers should sign commits with NVIDIA email addresses so internal workspace group mapping works.

## Validation
- Documentation-only change; no tests run.




