### PR TITLE
docs: add bare-metal Megatron / TE install skill

### DIFF
--- a/skills/mcore-build-and-dependency/SKILL.md
+++ b/skills/mcore-build-and-dependency/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mcore-build-and-dependency
-description: Megatron-LM installation-path routing, container-based development setup, and dependency management. Covers choosing between the supported container and bare-metal CUDA path, acquiring and launching the CI container, uv package management, and updating uv.lock.
+description: Megatron-LM installation-path routing, container-based development setup, and dependency management. Covers choosing between the PyTorch NGC Container and bare-metal CUDA path, acquiring and launching the development container, uv package management, and updating uv.lock.
 license: Apache-2.0
 when_to_use: Routing a request to install Megatron; adding, removing, or updating a dependency; editing pyproject.toml or uv.lock; uv.lock merge conflict; setting up a dev environment; pulling or building the CI container; container build errors; uv errors; 'how do I install', 'uv sync fails', 'ModuleNotFoundError'.
 metadata:
@@ -9,23 +9,23 @@ metadata:
 
 # Build & Dependency Guide
 
-Choose the installation environment before giving commands. The CI container is
-the supported, reproducible development path; bare-metal CUDA is a separate path
-with its own Transformer Engine installation workflow.
+Choose the installation environment before giving commands. The PyTorch NGC
+Container is the supported, reproducible development path; bare-metal CUDA is a
+separate path with its own Transformer Engine installation workflow.
 
 ## Installation Path Decision
 
 For an otherwise unspecified request such as "Install Megatron", ask this one
 question before selecting commands or an installation skill:
 
-> Are you setting up the supported NGC/CI container path, or a bare-metal CUDA
-> host without Docker?
+> Are you using the [PyTorch NGC Container](https://catalog.ngc.nvidia.com/orgs/nvidia/-/containers/pytorch),
+> or a CUDA host without Docker?
 
 Do not assume a container from an ambiguous installation request. Route the
 answer as follows:
 
-- **Container, NGC, CI, Docker, or reproducible development environment:** use
-  this skill's container workflow.
+- **PyTorch NGC Container, Docker, or reproducible development environment:**
+  use this skill's container workflow.
 - **Bare metal, CUDA host, no Docker, Colab, or source install with Transformer
   Engine:** use `mcore-transformer-engine-install` for the pinned-PyPI TE
   install and CUDA smoke test.

--- a/skills/mcore-build-and-dependency/SKILL.md
+++ b/skills/mcore-build-and-dependency/SKILL.md
@@ -20,12 +20,19 @@ up front before the longer workflow:
 
 - Run dependency work inside the Megatron-LM CI container, not on the host.
 - The container venv is `/opt/venv`, already on `PATH`.
-- Default `dev` uses `docker/.ngc_version.dev` and the `dev` uv group; `lts`
-  uses `docker/.ngc_version.lts` and the `lts` uv group. The `container::lts`
-  PR label selects the LTS path; otherwise CI uses `dev`.
-- Install commands inside the container: `uv sync --locked --group dev --group test`,
-  `uv sync --locked --only-group linting`, or
-  `uv sync --locked --group lts --group test`.
+- Default `dev` uses `docker/.ngc_version.dev` and the `dev` extra; `lts`
+  uses `docker/.ngc_version.lts` and `docker/lts/requirements.txt`. The
+  `container::lts` PR label selects the LTS path; otherwise CI uses `dev`.
+- Source-install smoke tests outside the CI container use `uv pip install -e ...`
+  in a disposable environment. Bootstrap PyTorch with `uv pip install
+  --no-config ...` first so the CI override does not suppress it. Do not present
+  `uv sync` as the generic source install command.
+- Transformer Engine bare-metal installs are CUDA-native builds. Use
+  `mcore-transformer-engine-install` for pinned PyPI TE install, fork testing,
+  and TE-specific smoke-test failures.
+- CI/container install commands use `uv sync --locked`, for example
+  `uv sync --locked --extra dev --all-groups` or
+  `uv sync --locked --only-group linting`.
 - Dependency edits use `uv add <package>` followed by `uv lock`, both inside
   the container.
 - `docker/Dockerfile.ci.dev` has `main` and `jet` stages. The `jet` stage needs
@@ -160,21 +167,24 @@ srun \
 
 ## Dependency Management
 
-Dependencies are declared in `pyproject.toml`. The venv lives at `/opt/venv`
-inside the container (already on `PATH`).
+Dependencies are declared in `pyproject.toml`. The CI/container venv lives at
+`/opt/venv` inside the container (already on `PATH`).
 
-> **All `uv` operations must be run inside the container.**
-> Never run `uv sync` / `uv pip install` on the host.
+> **All dependency maintenance and `uv sync` / `uv lock` operations must be run
+> inside the container.** Source-install smoke tests may use
+> `uv pip install -e ...` in a disposable local or Colab environment.
 
-### uv Dependency Groups
+### uv Extras and Dependency Groups
 
-| Group | Purpose |
-|-------|---------|
-| `training` | Runtime training extras |
-| `dev` | Full dev environment (TransformerEngine, ModelOpt, …) |
-| `test` | pytest, coverage, nemo-run |
-| `linting` | ruff, black, isort, pylint |
-| `build` | Cython, pybind11, nvidia-mathdx |
+| Name | Type | Purpose |
+|------|------|---------|
+| `training` | extra | Runtime training extras |
+| `dev` | extra | Full dev environment (ModelOpt, resiliency, datasets, …) |
+| `te` | extra | Transformer Engine source build |
+| `ssm` | extra | Mamba SSM and causal conv source builds |
+| `test` | dependency group | pytest, coverage, nemo-run |
+| `linting` | dependency group | ruff, black, isort, pylint |
+| `build` | dependency group | Cython, pybind11, nvidia-mathdx |
 
 > The previous `lts` extra has been emptied. LTS deps are pinned in
 > `docker/lts/requirements.txt` rather than `pyproject.toml`. Do not add new
@@ -184,7 +194,7 @@ Install commands (inside the container):
 
 ```bash
 # Full dev + test environment
-uv sync --locked --group dev --group test
+uv sync --locked --extra dev --all-groups
 
 # Linting only
 uv sync --locked --only-group linting

--- a/skills/mcore-build-and-dependency/SKILL.md
+++ b/skills/mcore-build-and-dependency/SKILL.md
@@ -1,24 +1,45 @@
 ---
 name: mcore-build-and-dependency
-description: Container-based dev environment setup and dependency management for Megatron-LM. Covers acquiring and launching the CI container, uv package management, and updating uv.lock.
+description: Megatron-LM installation-path routing, container-based development setup, and dependency management. Covers choosing between the supported container and bare-metal CUDA path, acquiring and launching the CI container, uv package management, and updating uv.lock.
 license: Apache-2.0
-when_to_use: Adding, removing, or updating a dependency; editing pyproject.toml or uv.lock; uv.lock merge conflict; setting up a dev environment; pulling or building the CI container; container build errors; uv errors; 'how do I install', 'uv sync fails', 'ModuleNotFoundError'.
+when_to_use: Routing a request to install Megatron; adding, removing, or updating a dependency; editing pyproject.toml or uv.lock; uv.lock merge conflict; setting up a dev environment; pulling or building the CI container; container build errors; uv errors; 'how do I install', 'uv sync fails', 'ModuleNotFoundError'.
 metadata:
   author: Oliver Koenig <okoenig@nvidia.com>
 ---
 
 # Build & Dependency Guide
 
-The core principle: **build and develop inside containers** — the CI container
-ships the correct CUDA toolkit, PyTorch build, and pre-compiled native extensions
-(TransformerEngine, DeepEP, …) that cannot be reproduced on a bare host.
+Choose the installation environment before giving commands. The CI container is
+the supported, reproducible development path; bare-metal CUDA is a separate path
+with its own Transformer Engine installation workflow.
+
+## Installation Path Decision
+
+For an otherwise unspecified request such as "Install Megatron", ask this one
+question before selecting commands or an installation skill:
+
+> Are you setting up the supported NGC/CI container path, or a bare-metal CUDA
+> host without Docker?
+
+Do not assume a container from an ambiguous installation request. Route the
+answer as follows:
+
+- **Container, NGC, CI, Docker, or reproducible development environment:** use
+  this skill's container workflow.
+- **Bare metal, CUDA host, no Docker, Colab, or source install with Transformer
+  Engine:** use `mcore-transformer-engine-install` for the pinned-PyPI TE
+  install and CUDA smoke test.
+- **PyPI-only Megatron Core package:** use the README's `uv pip install
+  megatron-core` path; do not introduce a container or Transformer Engine unless
+  the user needs GPU-native components.
 
 ## Answer-First Constants
 
 For text-only dependency or container questions, give these repo-specific facts
 up front before the longer workflow:
 
-- Run dependency work inside the Megatron-LM CI container, not on the host.
+- For a user who chooses the supported development path, run dependency work
+  inside the Megatron-LM CI container, not on the host.
 - The container venv is `/opt/venv`, already on `PATH`.
 - Default `dev` uses `docker/.ngc_version.dev` and the `dev` extra; `lts`
   uses `docker/.ngc_version.lts` and `docker/lts/requirements.txt`. The

--- a/skills/mcore-build-and-dependency/skill-card.md
+++ b/skills/mcore-build-and-dependency/skill-card.md
@@ -1,5 +1,5 @@
 ## Description: <br>
-Container-based dev environment setup and dependency management for Megatron-LM. Covers acquiring and launching the CI container, uv package management, and updating uv.lock. <br>
+Megatron-LM installation-path routing, container-based development setup, and dependency management. Covers choosing between the PyTorch NGC Container and bare-metal CUDA path, container setup, uv package management, and updating uv.lock. <br>
 
 This skill is ready for commercial/non-commercial use. <br>
 
@@ -9,7 +9,7 @@ NVIDIA <br>
 ### License/Terms of Use: <br>
 Apache 2.0 <br>
 ## Use Case: <br>
-Developers and engineers setting up containerized development environments for Megatron-LM, managing Python dependencies with uv, and resolving build or dependency issues. <br>
+Developers and engineers choosing between the PyTorch NGC Container and a bare-metal CUDA host for Megatron-LM, managing Python dependencies with uv, and resolving build or dependency issues. <br>
 
 ### Deployment Geography for Use: <br>
 Global <br>
@@ -21,6 +21,7 @@ Mitigation: Review and scan skill before deployment. <br>
 ## Reference(s): <br>
 - [Megatron-LM Repository](https://github.com/NVIDIA/Megatron-LM) <br>
 - [Megatron Core Developer Guide](https://docs.nvidia.com/megatron-core/developer-guide/latest/index.html) <br>
+- [PyTorch NGC Container](https://catalog.ngc.nvidia.com/orgs/nvidia/-/containers/pytorch) <br>
 - [NVIDIA Pyxis](https://github.com/NVIDIA/pyxis) <br>
 - [NVIDIA Enroot](https://github.com/NVIDIA/enroot) <br>
 

--- a/skills/mcore-transformer-engine-install/SKILL.md
+++ b/skills/mcore-transformer-engine-install/SKILL.md
@@ -29,6 +29,9 @@ For text-only Transformer Engine install questions, give these facts first:
   native code locally and can take 10-15+ minutes or
   longer depending on CPU resources, memory, cache state, and build
   parallelism.
+- Use `install_te_pypi.sh --preflight` when checking CUDA, PyTorch, visible GPU
+  capability, selected TE architecture flags, cuDNN paths, disk space, or build
+  parallelism before starting the native TE build.
 - Run a CUDA TE smoke test immediately after install.
 
 Official TE install prerequisites to check before long debugging loops: Linux or
@@ -43,15 +46,23 @@ From the Megatron-LM repo root on a CUDA host:
 ```bash
 bash skills/mcore-transformer-engine-install/scripts/install_te_pypi.sh \
   --torch-backend cu128 \
-  --cuda-arch h100
+  --preflight
 ```
 
-Use `--cuda-arch b200` for B200/GB200 Blackwell GPUs,
-`--cuda-arch rtx-pro-6000` for RTX PRO Blackwell proxy hosts,
-`--cuda-arch l4` for L4/L40S, `--cuda-arch a100` for A100, or omit it to let
-the helper detect the first visible GPU after PyTorch is installed. B200/GB200
+```bash
+bash skills/mcore-transformer-engine-install/scripts/install_te_pypi.sh \
+  --torch-backend cu128
+```
+
+By default, the helper detects the first visible GPU after PyTorch is installed
+and sets `NVTE_CUDA_ARCHS` and `TORCH_CUDA_ARCH_LIST` from
+`torch.cuda.get_device_capability(0)`. Use `--cuda-arch b200`,
+`--cuda-arch rtx-pro-6000`, `--cuda-arch h100`, `--cuda-arch l4`, or
+`--cuda-arch a100` only when you need to override detection for a benchmark,
+cross-target build, or multi-GPU host where GPU 0 is not the target. B200/GB200
 maps to `NVTE_CUDA_ARCHS=100` and `TORCH_CUDA_ARCH_LIST=10.0`; RTX PRO
-Blackwell maps to `NVTE_CUDA_ARCHS=120` and `TORCH_CUDA_ARCH_LIST=12.0`.
+Blackwell maps to `NVTE_CUDA_ARCHS=120` and `TORCH_CUDA_ARCH_LIST=12.0`;
+H100 maps to `90`/`9.0`; L4/L40S maps to `89`/`8.9`; A100 maps to `80`/`8.0`.
 Blackwell requires CUDA 12.8+. Use `--te-version` to bump the pinned PyPI
 Transformer Engine version after the smoke test is validated. The default TE spec is
 `transformer_engine[pytorch]==2.11.0`.
@@ -63,9 +74,11 @@ editable without extras, install pinned PyPI `transformer_engine[pytorch]` with
 `transformer_engine.pytorch.Linear` smoke test. It prints a pre-build notice
 because the PyPI TE install can still compile locally and can take 10-15+
 minutes depending mostly on CPU resources, memory, cache state, and build
-parallelism. Add `--extras training` only when the environment needs optional
-training dependencies such as tokenizers, Transformers, W&B, or related runtime
-packages.
+parallelism. `--preflight` stops after the torch/bootstrap phase and prints the
+CUDA/PyTorch/GPU/header/path/disk/build settings that will be used before
+Megatron editable install or TE native compilation starts. Add `--extras
+training` only when the environment needs optional training dependencies such
+as tokenizers, Transformers, W&B, or related runtime packages.
 
 ## Manual Flow
 
@@ -114,13 +127,24 @@ uv pip install --no-config --python .venv/bin/python -e .
 # Optional: add training dependencies when needed.
 uv pip install --no-config --python .venv/bin/python -e ".[training]"
 
-# SM120 GPU example for RTX PRO Blackwell. Use 10.0/100 for B200/GB200,
-# 9.0/90 for H100, 8.9/89 for L4/L40S, or 8.0/80 for A100.
+read -r NVTE_CUDA_ARCHS TORCH_CUDA_ARCH_LIST < <(.venv/bin/python - <<'PY'
+import torch
+
+major, minor = torch.cuda.get_device_capability(0)
+print(f"{major}{minor} {major}.{minor}")
+PY
+)
+
 MAX_JOBS=4 NVTE_BUILD_THREADS_PER_JOB=1 NVTE_FRAMEWORK=pytorch \
-  NVTE_CUDA_ARCHS=120 TORCH_CUDA_ARCH_LIST=12.0 \
+  NVTE_CUDA_ARCHS="${NVTE_CUDA_ARCHS}" TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST}" \
   uv pip install --no-config --python .venv/bin/python --no-build-isolation \
     "transformer_engine[pytorch]==2.11.0"
 ```
+
+Override `NVTE_CUDA_ARCHS` and `TORCH_CUDA_ARCH_LIST` manually only when you
+need a fixed target, such as `100`/`10.0` for B200/GB200, `120`/`12.0` for
+RTX PRO Blackwell, `90`/`9.0` for H100, `89`/`8.9` for L4/L40S, or `80`/`8.0`
+for A100.
 
 Smoke test:
 

--- a/skills/mcore-transformer-engine-install/SKILL.md
+++ b/skills/mcore-transformer-engine-install/SKILL.md
@@ -24,6 +24,10 @@ For text-only Transformer Engine install questions, give these facts first:
 - A visible GPU and NVIDIA driver are not enough: native TE builds need a CUDA
   Toolkit with an executable `nvcc`. Set `CUDA_PATH` to its root; the helper
   adds `${CUDA_PATH}/bin` to `PATH`.
+- Do not download or install a CUDA Toolkit automatically when `nvcc` is
+  missing. Report the prerequisite and ask whether the user wants the PyTorch
+  NGC Container or has approved CUDA Toolkit provisioning; a local runfile is a
+  multi-gigabyte host-setup step, not a normal TE install step.
 - Set `CUDNN_PATH` and `CUDNN_HOME` to the venv's cuDNN package when cuDNN comes
   from Python wheels.
 - Limit parallel native compilation with `MAX_JOBS`, starting at `4`, and set
@@ -65,9 +69,11 @@ bash skills/mcore-transformer-engine-install/scripts/install_te_pypi.sh \
 
 On a driver-only host, `nvidia-smi` can work while `nvcc` is absent. Prefer the
 [PyTorch NGC Container](https://catalog.ngc.nvidia.com/orgs/nvidia/-/containers/pytorch)
-when it is available. For a required bare-metal install without sudo, install a
-CUDA Toolkit matching the PyTorch CUDA **major** version into a writable
-directory. Do not install or replace the NVIDIA driver.
+when it is available. Use this recovery only after the user explicitly chooses
+bare metal and approves the multi-gigabyte Toolkit download. For a required
+bare-metal install without sudo, install a CUDA Toolkit matching the PyTorch
+CUDA **major** version into a writable directory. Do not install or replace the
+NVIDIA driver.
 
 Download the appropriate Linux runfile from the
 [CUDA Toolkit Archive](https://developer.nvidia.com/cuda-toolkit-archive), then:
@@ -231,7 +237,7 @@ change. Source-install smoke tests can still use the helper in this skill.
 |---------|--------------|-----------|
 | `torch.cuda.is_available()` is false | CPU PyTorch wheel, hidden GPU, or driver/toolkit mismatch | Reinstall PyTorch with `--no-config --torch-backend=<cuXXX>` and check `nvidia-smi` |
 | `cmake: command not found` or `ninja: command not found` | Build tools missing from the venv | Install `cmake ninja` before TE |
-| `nvcc` is missing or `CUDA_PATH` has no `bin/nvcc` | Driver-only host, incomplete toolkit, or a Python CUDA wheel without a usable `nvcc` executable | Prefer the PyTorch NGC Container. Otherwise install a matching CUDA Toolkit with `--toolkit --toolkitpath=<writable-dir>` (no `--driver`), export `CUDA_PATH`, then rerun `--preflight` |
+| `nvcc` is missing or `CUDA_PATH` has no `bin/nvcc` | Driver-only host, incomplete toolkit, or a Python CUDA wheel without a usable `nvcc` executable | Report the prerequisite and ask whether to use the PyTorch NGC Container or explicitly provision a matching CUDA Toolkit. For the latter, use `--toolkit --toolkitpath=<writable-dir>` (no `--driver`), export `CUDA_PATH`, then rerun `--preflight` |
 | `fatal error: nccl.h: No such file or directory` | NVIDIA wheel headers not on include path | Export `${VENV_SITE}/nvidia/*/include` into `CPATH` |
 | `fatal error: cudnn.h: No such file or directory` | cuDNN wheel headers not on include path | Export NVIDIA include dirs and keep `--no-build-isolation` |
 | Linker cannot find CUDA/NCCL/cuDNN libraries | NVIDIA wheel libs not on library paths | Export `${VENV_SITE}/nvidia/*/lib` into `LIBRARY_PATH` and `LD_LIBRARY_PATH` |

--- a/skills/mcore-transformer-engine-install/SKILL.md
+++ b/skills/mcore-transformer-engine-install/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mcore-transformer-engine-install
-description: Bare-metal CUDA installation and smoke testing for Transformer Engine with Megatron-LM. Use when installing Megatron with a pinned PyPI Transformer Engine version, debugging transformer-engine native builds, testing H100/L4/L40S/A100 CUDA installs outside the NGC container, handling missing cmake/ninja/NCCL/cuDNN headers, or validating that transformer_engine.pytorch works with Megatron Core.
+description: Bare-metal CUDA installation and smoke testing for Transformer Engine with Megatron-LM. Use when installing Megatron with a pinned PyPI Transformer Engine version, debugging transformer-engine native builds, testing B200/GB200/H100/L4/L40S/A100 CUDA installs outside the NGC container, handling missing cmake/ninja/NCCL/cuDNN headers, or validating that transformer_engine.pytorch works with Megatron Core.
 ---
 
 # MCore Transformer Engine Install
@@ -46,10 +46,12 @@ bash skills/mcore-transformer-engine-install/scripts/install_te_pypi.sh \
   --cuda-arch h100
 ```
 
-Use `--cuda-arch l4` for L4/L40S, `--cuda-arch a100` for A100, or omit it to
-let the helper detect the first visible GPU after PyTorch is installed. Use
-`--te-version` to bump the pinned PyPI Transformer Engine version after the
-smoke test is validated. The default TE spec is
+Use `--cuda-arch b200` for B200/GB200 Blackwell GPUs, `--cuda-arch l4` for
+L4/L40S, `--cuda-arch a100` for A100, or omit it to let the helper detect the
+first visible GPU after PyTorch is installed. B200/GB200 maps to
+`NVTE_CUDA_ARCHS=100` and `TORCH_CUDA_ARCH_LIST=10.0`; Blackwell requires CUDA
+12.8+. Use `--te-version` to bump the pinned PyPI Transformer Engine version
+after the smoke test is validated. The default TE spec is
 `transformer_engine[pytorch]==2.11.0`.
 
 The helper performs the full sequence: create `.venv`, install CUDA PyTorch and
@@ -110,9 +112,9 @@ uv pip install --no-config --python .venv/bin/python -e .
 # Optional: add training dependencies when needed.
 uv pip install --no-config --python .venv/bin/python -e ".[training]"
 
-# SM90 GPU. Use NVTE_CUDA_ARCHS=89 and TORCH_CUDA_ARCH_LIST=8.9 for L4/L40S.
+# SM100 GPU. Use 9.0/90 for H100, 8.9/89 for L4/L40S, or 8.0/80 for A100.
 MAX_JOBS=4 NVTE_BUILD_THREADS_PER_JOB=1 NVTE_FRAMEWORK=pytorch \
-  NVTE_CUDA_ARCHS=90 TORCH_CUDA_ARCH_LIST=9.0 \
+  NVTE_CUDA_ARCHS=100 TORCH_CUDA_ARCH_LIST=10.0 \
   uv pip install --no-config --python .venv/bin/python --no-build-isolation \
     "transformer_engine[pytorch]==2.11.0"
 ```

--- a/skills/mcore-transformer-engine-install/SKILL.md
+++ b/skills/mcore-transformer-engine-install/SKILL.md
@@ -29,8 +29,7 @@ For text-only Transformer Engine install questions, give these facts first:
   diagnosing a missing GPU or broken driver.
 - Do not download or install a CUDA Toolkit automatically when `nvcc` is
   missing. Report the prerequisite and ask whether the user wants the PyTorch
-  NGC Container or has approved CUDA Toolkit provisioning; a local runfile is a
-  multi-gigabyte host-setup step, not a normal TE install step.
+  NGC Container or a separately provisioned CUDA Toolkit.
 - Set `CUDNN_PATH` and `CUDNN_HOME` to the venv's cuDNN package when cuDNN comes
   from Python wheels.
 - Limit parallel native compilation with `MAX_JOBS`, starting at `4`, and set
@@ -67,31 +66,6 @@ bash skills/mcore-transformer-engine-install/scripts/install_te_pypi.sh \
 bash skills/mcore-transformer-engine-install/scripts/install_te_pypi.sh \
   --torch-backend cu128
 ```
-
-## CUDA Toolkit Without Sudo
-
-On a driver-only host, `nvidia-smi` can work while `nvcc` is absent. Prefer the
-[PyTorch NGC Container](https://catalog.ngc.nvidia.com/orgs/nvidia/-/containers/pytorch)
-when it is available. Use this recovery only after the user explicitly chooses
-bare metal and approves the multi-gigabyte Toolkit download. For a required
-bare-metal install without sudo, install a CUDA Toolkit matching the PyTorch
-CUDA **major** version into a writable directory. Do not install or replace the
-NVIDIA driver.
-
-Download the appropriate Linux runfile from the
-[CUDA Toolkit Archive](https://developer.nvidia.com/cuda-toolkit-archive), then:
-
-```bash
-sh cuda_<version>_linux.run --silent --toolkit --toolkitpath="$PWD/.cuda"
-export CUDA_PATH="$PWD/.cuda"
-export PATH="$CUDA_PATH/bin:$PATH"
-export LD_LIBRARY_PATH="$CUDA_PATH/lib64:${LD_LIBRARY_PATH:-}"
-nvcc --version
-```
-
-Then run the helper's `--preflight` command. Do not assume the
-`nvidia-cuda-nvcc-cu12` Python wheel supplies a usable Linux `nvcc`; verify with
-`nvcc --version` before starting a TE build.
 
 ## Sandbox GPU Visibility
 
@@ -256,7 +230,7 @@ change. Source-install smoke tests can still use the helper in this skill.
 | `torch.cuda.is_available()` is false | CPU PyTorch wheel, hidden GPU, or driver/toolkit mismatch | Reinstall PyTorch with `--no-config --torch-backend=<cuXXX>` and check `nvidia-smi` |
 | `nvidia-smi` fails only in an agent sandbox | The sandbox does not expose NVIDIA device nodes | Re-run `nvidia-smi` on the host after approval; do not diagnose a broken driver from the sandbox result |
 | `cmake: command not found` or `ninja: command not found` | Build tools missing from the venv | Install `cmake ninja` before TE |
-| `nvcc` is missing or `CUDA_PATH` has no `bin/nvcc` | Driver-only host, incomplete toolkit, or a Python CUDA wheel without a usable `nvcc` executable | Report the prerequisite and ask whether to use the PyTorch NGC Container or explicitly provision a matching CUDA Toolkit. For the latter, use `--toolkit --toolkitpath=<writable-dir>` (no `--driver`), export `CUDA_PATH`, then rerun `--preflight` |
+| `nvcc` is missing or `CUDA_PATH` has no `bin/nvcc` | Driver-only host or incomplete toolkit | Ask whether to use the [PyTorch NGC Container](https://catalog.ngc.nvidia.com/orgs/nvidia/-/containers/pytorch) or provision a matching CUDA Toolkit, then set `CUDA_PATH` and rerun `--preflight` |
 | `fatal error: nccl.h: No such file or directory` | NVIDIA wheel headers not on include path | Export `${VENV_SITE}/nvidia/*/include` into `CPATH` |
 | `fatal error: cudnn.h: No such file or directory` | cuDNN wheel headers not on include path | Export NVIDIA include dirs and keep `--no-build-isolation` |
 | Linker cannot find CUDA/NCCL/cuDNN libraries | NVIDIA wheel libs not on library paths | Export `${VENV_SITE}/nvidia/*/lib` into `LIBRARY_PATH` and `LD_LIBRARY_PATH` |

--- a/skills/mcore-transformer-engine-install/SKILL.md
+++ b/skills/mcore-transformer-engine-install/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: mcore-transformer-engine-install
+description: Bare-metal CUDA installation and smoke testing for Transformer Engine with Megatron-LM. Use when installing Megatron with a pinned PyPI Transformer Engine version, debugging transformer-engine native builds, testing H100/L4/L40S/A100 CUDA installs outside the NGC container, handling missing cmake/ninja/NCCL/cuDNN headers, or validating that transformer_engine.pytorch works with Megatron Core.
+---
+
+# MCore Transformer Engine Install
+
+## Answer-First Constants
+
+For text-only Transformer Engine install questions, give these facts first:
+
+- Prefer the NGC container when the user wants the supported, reproducible path.
+- For bare-metal installs, use `uv pip install`, not `uv sync`.
+- Default bare-metal installs should use a pinned PyPI Transformer Engine
+  version. Do not use `.[te]` for that path because this repository's uv source
+  configuration can route `transformer-engine` to the pinned Git source.
+- Install CUDA-enabled PyTorch and build tools before installing pinned
+  `transformer_engine[pytorch]` from PyPI.
+- Use `--no-build-isolation`; Transformer Engine imports PyTorch while building.
+- Set `NVTE_FRAMEWORK=pytorch` for Megatron installs so TE does not spend time
+  probing or building unrelated framework integrations.
+- Export NVIDIA wheel `include` and `lib` directories into `CPATH`,
+  `LIBRARY_PATH`, and `LD_LIBRARY_PATH` before the TE build.
+- Set `CUDA_PATH`; set `CUDNN_PATH` and `CUDNN_HOME` to the venv's cuDNN package
+  when cuDNN comes from Python wheels.
+- Limit parallel native compilation with `MAX_JOBS`, starting at `4`, and set
+  `NVTE_BUILD_THREADS_PER_JOB=1` if compilation is memory-heavy.
+- Warn users before the native TE build starts: even PyPI TE installs compile
+  native code locally and can take 10-15+ minutes or
+  longer depending on CPU resources, memory, cache state, and build
+  parallelism.
+- Run a CUDA TE smoke test immediately after install.
+
+Official TE install prerequisites to check before long debugging loops: Linux or
+WSL2, CUDA 12.1+ for Hopper/Ada/Ampere, CUDA 12.8+ for Blackwell, cuDNN 9.3+,
+GCC 9+ or Clang 10+ with C++17 support, Python 3.12 recommended, CMake 3.18+,
+Ninja, Git 2.17+, and pybind11 2.6.0+.
+
+## Fast Path
+
+From the Megatron-LM repo root on a CUDA host:
+
+```bash
+bash skills/mcore-transformer-engine-install/scripts/install_te_pypi.sh \
+  --torch-backend cu128 \
+  --cuda-arch h100
+```
+
+Use `--cuda-arch l4` for L4/L40S, `--cuda-arch a100` for A100, or omit it to
+let the helper detect the first visible GPU after PyTorch is installed. Use
+`--te-version` to bump the pinned PyPI Transformer Engine version after the
+smoke test is validated. The default TE spec is
+`transformer_engine[pytorch]==2.11.0`.
+
+The helper performs the full sequence: create `.venv`, install CUDA PyTorch and
+build dependencies, export NVIDIA wheel header/library paths, install Megatron
+editable without extras, install pinned PyPI `transformer_engine[pytorch]` with
+`--no-config --no-build-isolation`, then run a CUDA
+`transformer_engine.pytorch.Linear` smoke test. It prints a pre-build notice
+because the PyPI TE install can still compile locally and can take 10-15+
+minutes depending mostly on CPU resources, memory, cache state, and build
+parallelism. Add `--extras training` only when the environment needs optional
+training dependencies such as tokenizers, Transformers, W&B, or related runtime
+packages.
+
+## Manual Flow
+
+Use this when editing commands by hand or explaining the install:
+
+```bash
+uv venv --python 3.12
+uv pip install --no-config --python .venv/bin/python --torch-backend=cu128 \
+  "torch==2.10.0" "setuptools>=80,<82" wheel packaging pybind11 Cython hatchling cmake ninja nvidia-mathdx numpy
+```
+
+Export headers and libraries from the NVIDIA wheels installed in the venv:
+
+```bash
+VENV_SITE="$(.venv/bin/python - <<'PY'
+import site
+
+print(site.getsitepackages()[0])
+PY
+)"
+for INCLUDE_DIR in "${VENV_SITE}"/nvidia/*/include; do
+  if [ -d "${INCLUDE_DIR}" ]; then
+    export CPATH="${INCLUDE_DIR}:${CPATH:-}"
+  fi
+done
+for LIB_DIR in "${VENV_SITE}"/nvidia/*/lib; do
+  if [ -d "${LIB_DIR}" ]; then
+    export LIBRARY_PATH="${LIB_DIR}:${LIBRARY_PATH:-}"
+    export LD_LIBRARY_PATH="${LIB_DIR}:${LD_LIBRARY_PATH:-}"
+  fi
+done
+CUDA_HOME="$(dirname "$(dirname "$(command -v nvcc)")")"
+export CUDA_PATH="${CUDA_PATH:-${CUDA_HOME}}"
+if [ -d "${VENV_SITE}/nvidia/cudnn" ]; then
+  export CUDNN_PATH="${CUDNN_PATH:-${VENV_SITE}/nvidia/cudnn}"
+  export CUDNN_HOME="${CUDNN_HOME:-${CUDNN_PATH}}"
+  export LD_LIBRARY_PATH="${CUDNN_PATH}/lib:${LD_LIBRARY_PATH:-}"
+fi
+```
+
+Install Megatron and pinned PyPI TE:
+
+```bash
+uv pip install --no-config --python .venv/bin/python -e .
+
+# Optional: add training dependencies when needed.
+uv pip install --no-config --python .venv/bin/python -e ".[training]"
+
+# SM90 GPU. Use NVTE_CUDA_ARCHS=89 and TORCH_CUDA_ARCH_LIST=8.9 for L4/L40S.
+MAX_JOBS=4 NVTE_BUILD_THREADS_PER_JOB=1 NVTE_FRAMEWORK=pytorch \
+  NVTE_CUDA_ARCHS=90 TORCH_CUDA_ARCH_LIST=9.0 \
+  uv pip install --no-config --python .venv/bin/python --no-build-isolation \
+    "transformer_engine[pytorch]==2.11.0"
+```
+
+Smoke test:
+
+```bash
+.venv/bin/python - <<'PY'
+import torch
+import megatron.core
+from transformer_engine.pytorch import Linear
+
+assert torch.cuda.is_available(), "CUDA is not visible to PyTorch"
+layer = Linear(8, 8).cuda()
+x = torch.randn(2, 8, device="cuda")
+y = layer(x)
+torch.cuda.synchronize()
+print("megatron cuda+te smoke: ok", y.shape)
+PY
+```
+
+If you installed `--extras training`, also verify the training package imports:
+
+```bash
+.venv/bin/python -c "import megatron.training"
+```
+
+## Testing a TE Fork
+
+For a throwaway fork test, change only the `transformer-engine` entry in
+`[tool.uv.sources]` in `pyproject.toml` to the fork URL and commit SHA, then run
+`skills/mcore-transformer-engine-install/scripts/install_te_source.sh`. Do not
+commit a fork URL to Megatron-LM unless the user explicitly wants that source
+change in the PR.
+
+For a committed dependency change, follow `mcore-build-and-dependency`: update
+`pyproject.toml`, run `uv lock` inside the container, and include the lockfile
+change. Source-install smoke tests can still use the helper in this skill.
+
+## Failure Map
+
+| Symptom | Likely cause | First fix |
+|---------|--------------|-----------|
+| `torch.cuda.is_available()` is false | CPU PyTorch wheel, hidden GPU, or driver/toolkit mismatch | Reinstall PyTorch with `--no-config --torch-backend=<cuXXX>` and check `nvidia-smi` |
+| `cmake: command not found` or `ninja: command not found` | Build tools missing from the venv | Install `cmake ninja` before TE |
+| `fatal error: nccl.h: No such file or directory` | NVIDIA wheel headers not on include path | Export `${VENV_SITE}/nvidia/*/include` into `CPATH` |
+| `fatal error: cudnn.h: No such file or directory` | cuDNN wheel headers not on include path | Export NVIDIA include dirs and keep `--no-build-isolation` |
+| Linker cannot find CUDA/NCCL/cuDNN libraries | NVIDIA wheel libs not on library paths | Export `${VENV_SITE}/nvidia/*/lib` into `LIBRARY_PATH` and `LD_LIBRARY_PATH` |
+| Build dies or is killed | Native build exceeded memory | Lower `MAX_JOBS`, retry on a larger GPU host, or use the NGC container |
+| Build isolation imports fail | TE cannot see PyTorch/build deps in isolated env | Use `--no-build-isolation` after preinstalling build deps |
+| `CUDNN_STATUS_SUBLIBRARY_LOADING_FAILED` | TE built against one cuDNN but runtime loads another | Set `CUDNN_PATH`, `CUDNN_HOME`, and `LD_LIBRARY_PATH` to the venv cuDNN package before building |
+| `uv` tries to clone TransformerEngine from GitHub | The command used `.[te]` or did not pass `--no-config` from a Megatron checkout | Use the PyPI helper or run `uv pip install --no-config --no-build-isolation "transformer_engine[pytorch]==<version>"` |
+| `ModuleNotFoundError: transformer_engine_torch` after install | TE native extension did not build or import | Re-run with the helper and inspect the first native build error |
+
+## Completion Criteria
+
+Do not call the bare-metal TE install done until all of these pass:
+
+1. `python -c "import torch; print(torch.cuda.is_available())"` prints `True`.
+2. `python -c "import transformer_engine.pytorch"` succeeds.
+3. The smoke test above runs a CUDA forward pass and synchronizes.
+4. `import megatron.core` succeeds in the same venv.
+5. If `--extras training` was installed, `import megatron.training` also
+   succeeds in the same venv.

--- a/skills/mcore-transformer-engine-install/SKILL.md
+++ b/skills/mcore-transformer-engine-install/SKILL.md
@@ -29,6 +29,10 @@ For text-only Transformer Engine install questions, give these facts first:
   native code locally and can take 10-15+ minutes or
   longer depending on CPU resources, memory, cache state, and build
   parallelism.
+- In automated installs and benchmarks, run the helper in the foreground. If
+  logs must be saved, use `set -o pipefail` with `tee`; avoid backgrounding the
+  install and polling with fixed `sleep` intervals because that inflates wall
+  time and command count after the build has already finished.
 - Use `install_te_pypi.sh --preflight` when checking CUDA, PyTorch, visible GPU
   capability, selected TE architecture flags, cuDNN paths, disk space, or build
   parallelism before starting the native TE build.
@@ -53,6 +57,20 @@ bash skills/mcore-transformer-engine-install/scripts/install_te_pypi.sh \
 bash skills/mcore-transformer-engine-install/scripts/install_te_pypi.sh \
   --torch-backend cu128
 ```
+
+For automation that needs a log artifact, keep the install on the foreground
+critical path:
+
+```bash
+set -o pipefail
+bash skills/mcore-transformer-engine-install/scripts/install_te_pypi.sh \
+  --torch-backend cu128 2>&1 | tee artifacts/te-install.log
+```
+
+Do not background the helper and poll it with coarse fixed sleeps unless the
+execution environment has a hard command timeout. If backgrounding is
+unavoidable, poll at a short interval and check the exit file immediately after
+each sleep before running the smoke test.
 
 By default, the helper detects the first visible GPU after PyTorch is installed
 and sets `NVTE_CUDA_ARCHS` and `TORCH_CUDA_ARCH_LIST` from

--- a/skills/mcore-transformer-engine-install/SKILL.md
+++ b/skills/mcore-transformer-engine-install/SKILL.md
@@ -24,6 +24,9 @@ For text-only Transformer Engine install questions, give these facts first:
 - A visible GPU and NVIDIA driver are not enough: native TE builds need a CUDA
   Toolkit with an executable `nvcc`. Set `CUDA_PATH` to its root; the helper
   adds `${CUDA_PATH}/bin` to `PATH`.
+- If `nvidia-smi` or a CUDA device probe fails inside an agent sandbox, treat it
+  as inconclusive. Re-run that read-only probe on the host after approval before
+  diagnosing a missing GPU or broken driver.
 - Do not download or install a CUDA Toolkit automatically when `nvcc` is
   missing. Report the prerequisite and ask whether the user wants the PyTorch
   NGC Container or has approved CUDA Toolkit provisioning; a local runfile is a
@@ -89,6 +92,21 @@ nvcc --version
 Then run the helper's `--preflight` command. Do not assume the
 `nvidia-cuda-nvcc-cu12` Python wheel supplies a usable Linux `nvcc`; verify with
 `nvcc --version` before starting a TE build.
+
+## Sandbox GPU Visibility
+
+Some agent sandboxes do not expose `/dev/nvidia*`, even when the host GPU and
+driver are healthy. If a sandboxed `nvidia-smi` reports that it cannot
+communicate with the driver, do not ask the user to repair the driver yet. Run
+this read-only check outside the sandbox after approval:
+
+```bash
+nvidia-smi --query-gpu=name,driver_version,compute_cap --format=csv,noheader
+```
+
+Only a failed host-level check blocks the bare-metal installation. A successful
+host-level check means the remaining question is the CUDA Toolkit (`nvcc`), not
+GPU visibility.
 
 For automation that needs a log artifact, keep the install on the foreground
 critical path:
@@ -236,6 +254,7 @@ change. Source-install smoke tests can still use the helper in this skill.
 | Symptom | Likely cause | First fix |
 |---------|--------------|-----------|
 | `torch.cuda.is_available()` is false | CPU PyTorch wheel, hidden GPU, or driver/toolkit mismatch | Reinstall PyTorch with `--no-config --torch-backend=<cuXXX>` and check `nvidia-smi` |
+| `nvidia-smi` fails only in an agent sandbox | The sandbox does not expose NVIDIA device nodes | Re-run `nvidia-smi` on the host after approval; do not diagnose a broken driver from the sandbox result |
 | `cmake: command not found` or `ninja: command not found` | Build tools missing from the venv | Install `cmake ninja` before TE |
 | `nvcc` is missing or `CUDA_PATH` has no `bin/nvcc` | Driver-only host, incomplete toolkit, or a Python CUDA wheel without a usable `nvcc` executable | Report the prerequisite and ask whether to use the PyTorch NGC Container or explicitly provision a matching CUDA Toolkit. For the latter, use `--toolkit --toolkitpath=<writable-dir>` (no `--driver`), export `CUDA_PATH`, then rerun `--preflight` |
 | `fatal error: nccl.h: No such file or directory` | NVIDIA wheel headers not on include path | Export `${VENV_SITE}/nvidia/*/include` into `CPATH` |

--- a/skills/mcore-transformer-engine-install/SKILL.md
+++ b/skills/mcore-transformer-engine-install/SKILL.md
@@ -21,8 +21,11 @@ For text-only Transformer Engine install questions, give these facts first:
   probing or building unrelated framework integrations.
 - Export NVIDIA wheel `include` and `lib` directories into `CPATH`,
   `LIBRARY_PATH`, and `LD_LIBRARY_PATH` before the TE build.
-- Set `CUDA_PATH`; set `CUDNN_PATH` and `CUDNN_HOME` to the venv's cuDNN package
-  when cuDNN comes from Python wheels.
+- A visible GPU and NVIDIA driver are not enough: native TE builds need a CUDA
+  Toolkit with an executable `nvcc`. Set `CUDA_PATH` to its root; the helper
+  adds `${CUDA_PATH}/bin` to `PATH`.
+- Set `CUDNN_PATH` and `CUDNN_HOME` to the venv's cuDNN package when cuDNN comes
+  from Python wheels.
 - Limit parallel native compilation with `MAX_JOBS`, starting at `4`, and set
   `NVTE_BUILD_THREADS_PER_JOB=1` if compilation is memory-heavy.
 - Warn users before the native TE build starts: even PyPI TE installs compile
@@ -57,6 +60,29 @@ bash skills/mcore-transformer-engine-install/scripts/install_te_pypi.sh \
 bash skills/mcore-transformer-engine-install/scripts/install_te_pypi.sh \
   --torch-backend cu128
 ```
+
+## CUDA Toolkit Without Sudo
+
+On a driver-only host, `nvidia-smi` can work while `nvcc` is absent. Prefer the
+[PyTorch NGC Container](https://catalog.ngc.nvidia.com/orgs/nvidia/-/containers/pytorch)
+when it is available. For a required bare-metal install without sudo, install a
+CUDA Toolkit matching the PyTorch CUDA **major** version into a writable
+directory. Do not install or replace the NVIDIA driver.
+
+Download the appropriate Linux runfile from the
+[CUDA Toolkit Archive](https://developer.nvidia.com/cuda-toolkit-archive), then:
+
+```bash
+sh cuda_<version>_linux.run --silent --toolkit --toolkitpath="$PWD/.cuda"
+export CUDA_PATH="$PWD/.cuda"
+export PATH="$CUDA_PATH/bin:$PATH"
+export LD_LIBRARY_PATH="$CUDA_PATH/lib64:${LD_LIBRARY_PATH:-}"
+nvcc --version
+```
+
+Then run the helper's `--preflight` command. Do not assume the
+`nvidia-cuda-nvcc-cu12` Python wheel supplies a usable Linux `nvcc`; verify with
+`nvcc --version` before starting a TE build.
 
 For automation that needs a log artifact, keep the install on the foreground
 critical path:
@@ -205,6 +231,7 @@ change. Source-install smoke tests can still use the helper in this skill.
 |---------|--------------|-----------|
 | `torch.cuda.is_available()` is false | CPU PyTorch wheel, hidden GPU, or driver/toolkit mismatch | Reinstall PyTorch with `--no-config --torch-backend=<cuXXX>` and check `nvidia-smi` |
 | `cmake: command not found` or `ninja: command not found` | Build tools missing from the venv | Install `cmake ninja` before TE |
+| `nvcc` is missing or `CUDA_PATH` has no `bin/nvcc` | Driver-only host, incomplete toolkit, or a Python CUDA wheel without a usable `nvcc` executable | Prefer the PyTorch NGC Container. Otherwise install a matching CUDA Toolkit with `--toolkit --toolkitpath=<writable-dir>` (no `--driver`), export `CUDA_PATH`, then rerun `--preflight` |
 | `fatal error: nccl.h: No such file or directory` | NVIDIA wheel headers not on include path | Export `${VENV_SITE}/nvidia/*/include` into `CPATH` |
 | `fatal error: cudnn.h: No such file or directory` | cuDNN wheel headers not on include path | Export NVIDIA include dirs and keep `--no-build-isolation` |
 | Linker cannot find CUDA/NCCL/cuDNN libraries | NVIDIA wheel libs not on library paths | Export `${VENV_SITE}/nvidia/*/lib` into `LIBRARY_PATH` and `LD_LIBRARY_PATH` |

--- a/skills/mcore-transformer-engine-install/SKILL.md
+++ b/skills/mcore-transformer-engine-install/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mcore-transformer-engine-install
-description: Bare-metal CUDA installation and smoke testing for Transformer Engine with Megatron-LM. Use when installing Megatron with a pinned PyPI Transformer Engine version, debugging transformer-engine native builds, testing B200/GB200/H100/L4/L40S/A100 CUDA installs outside the NGC container, handling missing cmake/ninja/NCCL/cuDNN headers, or validating that transformer_engine.pytorch works with Megatron Core.
+description: Bare-metal CUDA installation and smoke testing for Transformer Engine with Megatron-LM. Use when installing Megatron with a pinned PyPI Transformer Engine version, debugging transformer-engine native builds, testing B200/GB200/RTX PRO Blackwell/H100/L4/L40S/A100 CUDA installs outside the NGC container, handling missing cmake/ninja/NCCL/cuDNN headers, or validating that transformer_engine.pytorch works with Megatron Core.
 ---
 
 # MCore Transformer Engine Install
@@ -46,12 +46,14 @@ bash skills/mcore-transformer-engine-install/scripts/install_te_pypi.sh \
   --cuda-arch h100
 ```
 
-Use `--cuda-arch b200` for B200/GB200 Blackwell GPUs, `--cuda-arch l4` for
-L4/L40S, `--cuda-arch a100` for A100, or omit it to let the helper detect the
-first visible GPU after PyTorch is installed. B200/GB200 maps to
-`NVTE_CUDA_ARCHS=100` and `TORCH_CUDA_ARCH_LIST=10.0`; Blackwell requires CUDA
-12.8+. Use `--te-version` to bump the pinned PyPI Transformer Engine version
-after the smoke test is validated. The default TE spec is
+Use `--cuda-arch b200` for B200/GB200 Blackwell GPUs,
+`--cuda-arch rtx-pro-6000` for RTX PRO Blackwell proxy hosts,
+`--cuda-arch l4` for L4/L40S, `--cuda-arch a100` for A100, or omit it to let
+the helper detect the first visible GPU after PyTorch is installed. B200/GB200
+maps to `NVTE_CUDA_ARCHS=100` and `TORCH_CUDA_ARCH_LIST=10.0`; RTX PRO
+Blackwell maps to `NVTE_CUDA_ARCHS=120` and `TORCH_CUDA_ARCH_LIST=12.0`.
+Blackwell requires CUDA 12.8+. Use `--te-version` to bump the pinned PyPI
+Transformer Engine version after the smoke test is validated. The default TE spec is
 `transformer_engine[pytorch]==2.11.0`.
 
 The helper performs the full sequence: create `.venv`, install CUDA PyTorch and
@@ -112,9 +114,10 @@ uv pip install --no-config --python .venv/bin/python -e .
 # Optional: add training dependencies when needed.
 uv pip install --no-config --python .venv/bin/python -e ".[training]"
 
-# SM100 GPU. Use 9.0/90 for H100, 8.9/89 for L4/L40S, or 8.0/80 for A100.
+# SM120 GPU example for RTX PRO Blackwell. Use 10.0/100 for B200/GB200,
+# 9.0/90 for H100, 8.9/89 for L4/L40S, or 8.0/80 for A100.
 MAX_JOBS=4 NVTE_BUILD_THREADS_PER_JOB=1 NVTE_FRAMEWORK=pytorch \
-  NVTE_CUDA_ARCHS=100 TORCH_CUDA_ARCH_LIST=10.0 \
+  NVTE_CUDA_ARCHS=120 TORCH_CUDA_ARCH_LIST=12.0 \
   uv pip install --no-config --python .venv/bin/python --no-build-isolation \
     "transformer_engine[pytorch]==2.11.0"
 ```

--- a/skills/mcore-transformer-engine-install/agents/openai.yaml
+++ b/skills/mcore-transformer-engine-install/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "MCore Transformer Engine Install"
+  short_description: "Install pinned PyPI TE for Megatron"
+  default_prompt: "Use $mcore-transformer-engine-install to install a pinned PyPI Transformer Engine version for Megatron."

--- a/skills/mcore-transformer-engine-install/scripts/install_te_pypi.sh
+++ b/skills/mcore-transformer-engine-install/scripts/install_te_pypi.sh
@@ -1,0 +1,350 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Install Megatron-LM with a pinned PyPI Transformer Engine release on a CUDA host.
+The Transformer Engine PyTorch extension still performs native compilation and
+can take 10-15+ minutes depending on CPU resources, memory, cache state, and
+build parallelism.
+
+Run from the Megatron-LM repository root:
+  bash skills/mcore-transformer-engine-install/scripts/install_te_pypi.sh \
+    --torch-backend cu128 --cuda-arch a100
+
+Options:
+  --python VERSION        Python version for uv venv (default: 3.12)
+  --venv PATH             Virtualenv path (default: .venv)
+  --torch-backend BACKEND uv torch backend, e.g. cu128 or cu130 (default: cu128)
+  --torch-version VERSION PyTorch version to install (default: 2.10.0)
+  --te-version VERSION    Transformer Engine PyPI version (default: 2.11.0)
+  --te-spec SPEC          Full TE spec (default: transformer_engine[pytorch]==TE_VERSION)
+  --cuda-arch ARCH        h100, l4, l40s, a100, sm90, sm89, sm80, or auto
+  --extras EXTRAS         Editable Megatron extras, excluding te (default: none; use training for training deps)
+  --max-jobs N            Native build parallelism (default: 4)
+  --repo-root PATH        Megatron-LM repository root (default: current git root)
+  --no-smoke              Skip the CUDA Transformer Engine smoke test
+  -h, --help              Show this help
+
+Environment overrides:
+  NVTE_CUDA_ARCHS and TORCH_CUDA_ARCH_LIST override --cuda-arch detection.
+  NVTE_FRAMEWORK defaults to pytorch.
+  NVTE_BUILD_THREADS_PER_JOB defaults to 1.
+EOF
+}
+
+PYTHON_VERSION="${PYTHON_VERSION:-3.12}"
+VENV_PATH="${VENV_PATH:-.venv}"
+TORCH_BACKEND="${TORCH_BACKEND:-cu128}"
+TORCH_VERSION="${TORCH_VERSION:-2.10.0}"
+TE_VERSION="${TE_VERSION:-2.11.0}"
+TE_SPEC="${TE_SPEC:-}"
+CUDA_ARCH="${CUDA_ARCH:-auto}"
+INSTALL_EXTRAS="${INSTALL_EXTRAS:-}"
+MAX_JOBS="${MAX_JOBS:-4}"
+RUN_SMOKE=1
+REPO_ROOT="${REPO_ROOT:-}"
+PHASE_ACTIVE=""
+
+phase_mark() {
+  if [[ -z "${ATE_INSTALL_PHASE_LOG:-}" ]]; then
+    return 0
+  fi
+  local phase="$1"
+  local event="$2"
+  local status="${3:-}"
+  python3 - "${ATE_INSTALL_PHASE_LOG}" "${phase}" "${event}" "${status}" <<'PY'
+import datetime
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+path = Path(sys.argv[1])
+epoch = time.time()
+payload = {
+    "at": datetime.datetime.fromtimestamp(epoch, datetime.timezone.utc).isoformat(),
+    "epoch": round(epoch, 6),
+    "event": sys.argv[3],
+    "phase": sys.argv[2],
+    "pid": os.getpid(),
+}
+if sys.argv[4]:
+    payload["exit_code"] = int(sys.argv[4])
+path.parent.mkdir(parents=True, exist_ok=True)
+with path.open("a", encoding="utf-8") as f:
+    f.write(json.dumps(payload, sort_keys=True) + "\n")
+PY
+}
+
+phase_start() {
+  PHASE_ACTIVE="$1"
+  phase_mark "$1" start
+}
+
+phase_end() {
+  local phase="$1"
+  local status="${2:-0}"
+  phase_mark "${phase}" end "${status}"
+  if [[ "${PHASE_ACTIVE}" == "${phase}" ]]; then
+    PHASE_ACTIVE=""
+  fi
+}
+
+phase_trap() {
+  local status=$?
+  if [[ "${status}" -ne 0 && -n "${PHASE_ACTIVE}" ]]; then
+    phase_mark "${PHASE_ACTIVE}" end "${status}"
+  fi
+}
+
+trap phase_trap EXIT
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --python)
+      PYTHON_VERSION="$2"
+      shift 2
+      ;;
+    --venv)
+      VENV_PATH="$2"
+      shift 2
+      ;;
+    --torch-backend)
+      TORCH_BACKEND="$2"
+      shift 2
+      ;;
+    --torch-version)
+      TORCH_VERSION="$2"
+      shift 2
+      ;;
+    --te-version)
+      TE_VERSION="$2"
+      shift 2
+      ;;
+    --te-spec)
+      TE_SPEC="$2"
+      shift 2
+      ;;
+    --cuda-arch)
+      CUDA_ARCH="$2"
+      shift 2
+      ;;
+    --extras)
+      INSTALL_EXTRAS="$2"
+      shift 2
+      ;;
+    --max-jobs)
+      MAX_JOBS="$2"
+      shift 2
+      ;;
+    --repo-root)
+      REPO_ROOT="$2"
+      shift 2
+      ;;
+    --no-smoke)
+      RUN_SMOKE=0
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "${TE_SPEC}" ]]; then
+  TE_SPEC="transformer_engine[pytorch]==${TE_VERSION}"
+fi
+
+if [[ ",${INSTALL_EXTRAS}," == *",te,"* ]]; then
+  echo "Do not include the 'te' extra with this helper." >&2
+  echo "It can route uv to the repository-pinned Transformer Engine Git source." >&2
+  echo "Use --extras training for training dependencies, or install a TE source/fork path separately." >&2
+  exit 2
+fi
+
+if [[ -z "${REPO_ROOT}" ]]; then
+  REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+fi
+
+cd "${REPO_ROOT}"
+
+if [[ ! -f pyproject.toml ]] || [[ ! -d megatron ]]; then
+  echo "Expected Megatron-LM repo root, got: ${REPO_ROOT}" >&2
+  exit 1
+fi
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "uv is required but was not found on PATH." >&2
+  exit 1
+fi
+
+if ! command -v nvcc >/dev/null 2>&1; then
+  echo "nvcc is required for Transformer Engine native builds but was not found on PATH." >&2
+  exit 1
+fi
+
+if [[ -z "${CUDA_PATH:-}" ]]; then
+  NVCC_PATH="$(command -v nvcc)"
+  CUDA_PATH="$(cd "$(dirname "${NVCC_PATH}")/.." && pwd)"
+  export CUDA_PATH
+fi
+
+PYTHON_BIN="${VENV_PATH}/bin/python"
+
+phase_start "torch-bootstrap"
+
+if [[ -x "${PYTHON_BIN}" ]]; then
+  EXISTING_PYTHON_VERSION="$("${PYTHON_BIN}" - <<'PY'
+import sys
+
+print(f"{sys.version_info.major}.{sys.version_info.minor}")
+PY
+)"
+  if [[ "${EXISTING_PYTHON_VERSION}" != "${PYTHON_VERSION}" ]]; then
+    echo "Existing virtualenv at ${VENV_PATH} uses Python ${EXISTING_PYTHON_VERSION}, expected ${PYTHON_VERSION}." >&2
+    echo "Remove it or rerun with UV_VENV_CLEAR=1 if this helper owns that environment." >&2
+    exit 1
+  fi
+  echo "Reusing existing virtualenv at ${VENV_PATH}."
+else
+  uv venv --python "${PYTHON_VERSION}" "${VENV_PATH}"
+fi
+
+uv pip install --no-config --python "${PYTHON_BIN}" --torch-backend="${TORCH_BACKEND}" \
+  "torch==${TORCH_VERSION}" "setuptools>=80,<82" wheel packaging pybind11 Cython \
+  hatchling cmake ninja nvidia-mathdx numpy
+
+"${PYTHON_BIN}" - <<'PY'
+import torch
+
+print("torch:", torch.__version__, "torch cuda:", torch.version.cuda)
+assert torch.cuda.is_available(), "CUDA is not visible to PyTorch"
+print("gpu:", torch.cuda.get_device_name(0), "capability:", torch.cuda.get_device_capability(0))
+PY
+
+phase_end "torch-bootstrap" 0
+phase_start "megatron+te-install"
+
+VENV_SITE="$("${PYTHON_BIN}" - <<'PY'
+import site
+
+print(site.getsitepackages()[0])
+PY
+)"
+
+for INCLUDE_DIR in "${VENV_SITE}"/nvidia/*/include; do
+  if [[ -d "${INCLUDE_DIR}" ]]; then
+    export CPATH="${INCLUDE_DIR}:${CPATH:-}"
+  fi
+done
+
+for LIB_DIR in "${VENV_SITE}"/nvidia/*/lib; do
+  if [[ -d "${LIB_DIR}" ]]; then
+    export LIBRARY_PATH="${LIB_DIR}:${LIBRARY_PATH:-}"
+    export LD_LIBRARY_PATH="${LIB_DIR}:${LD_LIBRARY_PATH:-}"
+  fi
+done
+
+if [[ -d "${VENV_SITE}/nvidia/cudnn" ]]; then
+  export CUDNN_PATH="${CUDNN_PATH:-${VENV_SITE}/nvidia/cudnn}"
+  export CUDNN_HOME="${CUDNN_HOME:-${CUDNN_PATH}}"
+  export LD_LIBRARY_PATH="${CUDNN_PATH}/lib:${LD_LIBRARY_PATH:-}"
+fi
+
+case "${CUDA_ARCH}" in
+  h100|sm90)
+    DEFAULT_NVTE_CUDA_ARCHS=90
+    DEFAULT_TORCH_CUDA_ARCH_LIST=9.0
+    ;;
+  l4|l40s|sm89)
+    DEFAULT_NVTE_CUDA_ARCHS=89
+    DEFAULT_TORCH_CUDA_ARCH_LIST=8.9
+    ;;
+  a100|sm80)
+    DEFAULT_NVTE_CUDA_ARCHS=80
+    DEFAULT_TORCH_CUDA_ARCH_LIST=8.0
+    ;;
+  auto)
+    read -r DEFAULT_NVTE_CUDA_ARCHS DEFAULT_TORCH_CUDA_ARCH_LIST < <("${PYTHON_BIN}" - <<'PY'
+import torch
+
+major, minor = torch.cuda.get_device_capability(0)
+print(f"{major}{minor} {major}.{minor}")
+PY
+)
+    ;;
+  *)
+    echo "Unsupported --cuda-arch '${CUDA_ARCH}'. Use h100, l4, l40s, a100, sm90, sm89, sm80, or auto." >&2
+    exit 2
+    ;;
+esac
+
+export MAX_JOBS
+export NVTE_BUILD_THREADS_PER_JOB="${NVTE_BUILD_THREADS_PER_JOB:-1}"
+export NVTE_FRAMEWORK="${NVTE_FRAMEWORK:-pytorch}"
+export NVTE_CUDA_ARCHS="${NVTE_CUDA_ARCHS:-${DEFAULT_NVTE_CUDA_ARCHS}}"
+export TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST:-${DEFAULT_TORCH_CUDA_ARCH_LIST}}"
+
+echo "Using CUDA_PATH=${CUDA_PATH}"
+echo "Using CUDNN_PATH=${CUDNN_PATH:-<not set>}"
+echo "Using NVTE_FRAMEWORK=${NVTE_FRAMEWORK}"
+echo "Using NVTE_CUDA_ARCHS=${NVTE_CUDA_ARCHS}"
+echo "Using TORCH_CUDA_ARCH_LIST=${TORCH_CUDA_ARCH_LIST}"
+echo "Using MAX_JOBS=${MAX_JOBS}"
+echo "Using NVTE_BUILD_THREADS_PER_JOB=${NVTE_BUILD_THREADS_PER_JOB}"
+if [[ -n "${INSTALL_EXTRAS}" ]]; then
+  echo "Installing Megatron editable extras: ${INSTALL_EXTRAS}"
+else
+  echo "Installing Megatron editable extras: <none>"
+fi
+
+if [[ -n "${INSTALL_EXTRAS}" ]]; then
+  uv pip install --no-config --python "${PYTHON_BIN}" -e ".[${INSTALL_EXTRAS}]"
+else
+  uv pip install --no-config --python "${PYTHON_BIN}" -e .
+fi
+
+CHECK_TRAINING_IMPORT=0
+if [[ ",${INSTALL_EXTRAS}," == *",training,"* ]]; then
+  CHECK_TRAINING_IMPORT=1
+fi
+export CHECK_TRAINING_IMPORT
+
+echo "Starting pinned PyPI Transformer Engine install: ${TE_SPEC}"
+echo "Transformer Engine native compilation can take 10-15+ minutes depending on CPU resources, memory, cache state, and build parallelism."
+echo "Some build steps may be quiet for a while; wait for the final smoke test before deciding it is stuck."
+
+uv pip install --no-config --python "${PYTHON_BIN}" --no-build-isolation "${TE_SPEC}"
+
+if [[ "${RUN_SMOKE}" -eq 1 ]]; then
+  "${PYTHON_BIN}" - <<'PY'
+import importlib.metadata as metadata
+import os
+
+import torch
+import megatron.core
+from transformer_engine.pytorch import Linear
+
+if os.environ.get("CHECK_TRAINING_IMPORT") == "1":
+    import megatron.training
+
+assert torch.cuda.is_available(), "CUDA is not visible to PyTorch"
+layer = Linear(8, 8).cuda()
+x = torch.randn(2, 8, device="cuda")
+y = layer(x)
+torch.cuda.synchronize()
+print("torch:", torch.__version__, "cuda:", torch.version.cuda)
+print("transformer-engine:", metadata.version("transformer-engine"))
+print("megatron cuda+te smoke: ok", tuple(y.shape))
+PY
+fi
+
+phase_end "megatron+te-install" 0

--- a/skills/mcore-transformer-engine-install/scripts/install_te_pypi.sh
+++ b/skills/mcore-transformer-engine-install/scripts/install_te_pypi.sh
@@ -232,7 +232,8 @@ else
   NVCC_PATH="$(command -v nvcc || true)"
   if [[ -z "${NVCC_PATH}" ]]; then
     echo "nvcc is required for Transformer Engine native builds but was not found." >&2
-    echo "Use the PyTorch NGC Container, or install a matching CUDA Toolkit and set CUDA_PATH." >&2
+    echo "This helper does not install a CUDA Toolkit automatically." >&2
+    echo "Choose the PyTorch NGC Container, or explicitly provision a matching CUDA Toolkit and set CUDA_PATH." >&2
     echo "For a user-local install, install only the toolkit into a writable directory; do not install a driver." >&2
     exit 1
   fi

--- a/skills/mcore-transformer-engine-install/scripts/install_te_pypi.sh
+++ b/skills/mcore-transformer-engine-install/scripts/install_te_pypi.sh
@@ -10,7 +10,7 @@ build parallelism.
 
 Run from the Megatron-LM repository root:
   bash skills/mcore-transformer-engine-install/scripts/install_te_pypi.sh \
-    --torch-backend cu128 --cuda-arch a100
+    --torch-backend cu128
 
 Options:
   --python VERSION        Python version for uv venv (default: 3.12)
@@ -19,10 +19,11 @@ Options:
   --torch-version VERSION PyTorch version to install (default: 2.10.0)
   --te-version VERSION    Transformer Engine PyPI version (default: 2.11.0)
   --te-spec SPEC          Full TE spec (default: transformer_engine[pytorch]==TE_VERSION)
-  --cuda-arch ARCH        b200, gb200, rtx-pro-6000, h100, l4, l40s, a100, sm120, sm100, sm90, sm89, sm80, or auto
+  --cuda-arch ARCH        Override target GPU: b200, gb200, rtx-pro-6000, h100, l4, l40s, a100, sm120, sm100, sm90, sm89, sm80, or auto (default: auto)
   --extras EXTRAS         Editable Megatron extras, excluding te (default: none; use training for training deps)
   --max-jobs N            Native build parallelism (default: 4)
   --repo-root PATH        Megatron-LM repository root (default: current git root)
+  --preflight             Bootstrap venv/PyTorch, print CUDA/TE build checks, then exit before Megatron/TE install
   --no-smoke              Skip the CUDA Transformer Engine smoke test
   -h, --help              Show this help
 
@@ -43,6 +44,7 @@ CUDA_ARCH="${CUDA_ARCH:-auto}"
 INSTALL_EXTRAS="${INSTALL_EXTRAS:-}"
 MAX_JOBS="${MAX_JOBS:-4}"
 RUN_SMOKE=1
+RUN_PREFLIGHT=0
 REPO_ROOT="${REPO_ROOT:-}"
 PHASE_ACTIVE=""
 
@@ -143,6 +145,10 @@ while [[ $# -gt 0 ]]; do
       REPO_ROOT="$2"
       shift 2
       ;;
+    --preflight|--dry-run-checks)
+      RUN_PREFLIGHT=1
+      shift
+      ;;
     --no-smoke)
       RUN_SMOKE=0
       shift
@@ -231,7 +237,6 @@ print("gpu:", torch.cuda.get_device_name(0), "capability:", torch.cuda.get_devic
 PY
 
 phase_end "torch-bootstrap" 0
-phase_start "megatron+te-install"
 
 VENV_SITE="$("${PYTHON_BIN}" - <<'PY'
 import site
@@ -300,6 +305,69 @@ export NVTE_BUILD_THREADS_PER_JOB="${NVTE_BUILD_THREADS_PER_JOB:-1}"
 export NVTE_FRAMEWORK="${NVTE_FRAMEWORK:-pytorch}"
 export NVTE_CUDA_ARCHS="${NVTE_CUDA_ARCHS:-${DEFAULT_NVTE_CUDA_ARCHS}}"
 export TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST:-${DEFAULT_TORCH_CUDA_ARCH_LIST}}"
+
+print_preflight_summary() {
+  echo "Preflight summary:"
+  echo "  repo root: ${REPO_ROOT}"
+  echo "  venv: ${VENV_PATH}"
+  echo "  python: $("${PYTHON_BIN}" --version 2>&1)"
+  echo "  torch backend: ${TORCH_BACKEND}"
+  echo "  requested torch: ${TORCH_VERSION}"
+  "${PYTHON_BIN}" - <<'PY'
+import torch
+
+print(f"  installed torch: {torch.__version__} cuda: {torch.version.cuda}")
+print(f"  gpu[0]: {torch.cuda.get_device_name(0)} capability: {torch.cuda.get_device_capability(0)}")
+PY
+  echo "  CUDA_PATH: ${CUDA_PATH}"
+  echo "  nvcc:"
+  nvcc --version | sed 's/^/    /'
+  echo "  venv site-packages: ${VENV_SITE}"
+  echo "  CUDNN_PATH: ${CUDNN_PATH:-<not set>}"
+  echo "  NVIDIA include dirs:"
+  local found_include=0
+  for INCLUDE_DIR in "${VENV_SITE}"/nvidia/*/include; do
+    if [[ -d "${INCLUDE_DIR}" ]]; then
+      echo "    ${INCLUDE_DIR}"
+      found_include=1
+    fi
+  done
+  if [[ "${found_include}" -eq 0 ]]; then
+    echo "    <none>"
+  fi
+  echo "  NVIDIA lib dirs:"
+  local found_lib=0
+  for LIB_DIR in "${VENV_SITE}"/nvidia/*/lib; do
+    if [[ -d "${LIB_DIR}" ]]; then
+      echo "    ${LIB_DIR}"
+      found_lib=1
+    fi
+  done
+  if [[ "${found_lib}" -eq 0 ]]; then
+    echo "    <none>"
+  fi
+  echo "  NVTE_FRAMEWORK: ${NVTE_FRAMEWORK}"
+  echo "  NVTE_CUDA_ARCHS: ${NVTE_CUDA_ARCHS}"
+  echo "  TORCH_CUDA_ARCH_LIST: ${TORCH_CUDA_ARCH_LIST}"
+  echo "  MAX_JOBS: ${MAX_JOBS}"
+  echo "  NVTE_BUILD_THREADS_PER_JOB: ${NVTE_BUILD_THREADS_PER_JOB}"
+  echo "  TE spec: ${TE_SPEC}"
+  if [[ -n "${INSTALL_EXTRAS}" ]]; then
+    echo "  Megatron editable extras: ${INSTALL_EXTRAS}"
+  else
+    echo "  Megatron editable extras: <none>"
+  fi
+  echo "  free disk:"
+  df -h "${REPO_ROOT}" | sed 's/^/    /'
+}
+
+if [[ "${RUN_PREFLIGHT}" -eq 1 ]]; then
+  print_preflight_summary
+  echo "Preflight complete. Megatron editable install and Transformer Engine native build were not run."
+  exit 0
+fi
+
+phase_start "megatron+te-install"
 
 echo "Using CUDA_PATH=${CUDA_PATH}"
 echo "Using CUDNN_PATH=${CUDNN_PATH:-<not set>}"

--- a/skills/mcore-transformer-engine-install/scripts/install_te_pypi.sh
+++ b/skills/mcore-transformer-engine-install/scripts/install_te_pypi.sh
@@ -101,6 +101,36 @@ phase_trap() {
   fi
 }
 
+print_cuda_version_alignment() {
+  local prefix="${1:-}"
+  local nvcc_cuda=""
+  local torch_cuda=""
+
+  nvcc_cuda="$(nvcc --version | sed -n 's/.*release \([0-9][0-9.]*\),.*/\1/p' | head -1 || true)"
+  torch_cuda="$("${PYTHON_BIN}" - <<'PY'
+import torch
+
+print(torch.version.cuda or "")
+PY
+)"
+
+  if [[ -z "${nvcc_cuda}" || -z "${torch_cuda}" ]]; then
+    return 0
+  fi
+
+  local nvcc_major nvcc_minor torch_major torch_minor
+  IFS=. read -r nvcc_major nvcc_minor _ <<< "${nvcc_cuda}"
+  IFS=. read -r torch_major torch_minor _ <<< "${torch_cuda}"
+
+  if [[ "${nvcc_major}" != "${torch_major}" ]]; then
+    echo "${prefix}WARNING: nvcc CUDA ${nvcc_cuda} and PyTorch CUDA ${torch_cuda} have different major versions."
+    echo "${prefix}Set CUDA_PATH/PATH to a CUDA ${torch_cuda} toolkit or choose a matching --torch-backend before building Transformer Engine."
+  elif [[ "${nvcc_minor:-0}" != "${torch_minor:-0}" ]]; then
+    echo "${prefix}Note: nvcc CUDA ${nvcc_cuda} and PyTorch CUDA ${torch_cuda} differ."
+    echo "${prefix}CUDA minor-version compatibility is often acceptable, but matching them improves reproducibility."
+  fi
+}
+
 trap phase_trap EXIT
 
 while [[ $# -gt 0 ]]; do
@@ -322,6 +352,7 @@ PY
   echo "  CUDA_PATH: ${CUDA_PATH}"
   echo "  nvcc:"
   nvcc --version | sed 's/^/    /'
+  print_cuda_version_alignment "  "
   echo "  venv site-packages: ${VENV_SITE}"
   echo "  CUDNN_PATH: ${CUDNN_PATH:-<not set>}"
   echo "  NVIDIA include dirs:"
@@ -376,6 +407,7 @@ echo "Using NVTE_CUDA_ARCHS=${NVTE_CUDA_ARCHS}"
 echo "Using TORCH_CUDA_ARCH_LIST=${TORCH_CUDA_ARCH_LIST}"
 echo "Using MAX_JOBS=${MAX_JOBS}"
 echo "Using NVTE_BUILD_THREADS_PER_JOB=${NVTE_BUILD_THREADS_PER_JOB}"
+print_cuda_version_alignment
 if [[ -n "${INSTALL_EXTRAS}" ]]; then
   echo "Installing Megatron editable extras: ${INSTALL_EXTRAS}"
 else

--- a/skills/mcore-transformer-engine-install/scripts/install_te_pypi.sh
+++ b/skills/mcore-transformer-engine-install/scripts/install_te_pypi.sh
@@ -222,16 +222,24 @@ if ! command -v uv >/dev/null 2>&1; then
   exit 1
 fi
 
-if ! command -v nvcc >/dev/null 2>&1; then
-  echo "nvcc is required for Transformer Engine native builds but was not found on PATH." >&2
-  exit 1
-fi
-
-if [[ -z "${CUDA_PATH:-}" ]]; then
-  NVCC_PATH="$(command -v nvcc)"
+if [[ -n "${CUDA_PATH:-}" ]]; then
+  NVCC_PATH="${CUDA_PATH%/}/bin/nvcc"
+  if [[ ! -x "${NVCC_PATH}" ]]; then
+    echo "CUDA_PATH=${CUDA_PATH} does not contain an executable bin/nvcc." >&2
+    exit 1
+  fi
+else
+  NVCC_PATH="$(command -v nvcc || true)"
+  if [[ -z "${NVCC_PATH}" ]]; then
+    echo "nvcc is required for Transformer Engine native builds but was not found." >&2
+    echo "Use the PyTorch NGC Container, or install a matching CUDA Toolkit and set CUDA_PATH." >&2
+    echo "For a user-local install, install only the toolkit into a writable directory; do not install a driver." >&2
+    exit 1
+  fi
   CUDA_PATH="$(cd "$(dirname "${NVCC_PATH}")/.." && pwd)"
-  export CUDA_PATH
 fi
+export CUDA_PATH
+export PATH="${CUDA_PATH}/bin:${PATH}"
 
 PYTHON_BIN="${VENV_PATH}/bin/python"
 

--- a/skills/mcore-transformer-engine-install/scripts/install_te_pypi.sh
+++ b/skills/mcore-transformer-engine-install/scripts/install_te_pypi.sh
@@ -19,7 +19,7 @@ Options:
   --torch-version VERSION PyTorch version to install (default: 2.10.0)
   --te-version VERSION    Transformer Engine PyPI version (default: 2.11.0)
   --te-spec SPEC          Full TE spec (default: transformer_engine[pytorch]==TE_VERSION)
-  --cuda-arch ARCH        h100, l4, l40s, a100, sm90, sm89, sm80, or auto
+  --cuda-arch ARCH        b200, gb200, h100, l4, l40s, a100, sm100, sm90, sm89, sm80, or auto
   --extras EXTRAS         Editable Megatron extras, excluding te (default: none; use training for training deps)
   --max-jobs N            Native build parallelism (default: 4)
   --repo-root PATH        Megatron-LM repository root (default: current git root)
@@ -260,6 +260,10 @@ if [[ -d "${VENV_SITE}/nvidia/cudnn" ]]; then
 fi
 
 case "${CUDA_ARCH}" in
+  b200|gb200|sm100)
+    DEFAULT_NVTE_CUDA_ARCHS=100
+    DEFAULT_TORCH_CUDA_ARCH_LIST=10.0
+    ;;
   h100|sm90)
     DEFAULT_NVTE_CUDA_ARCHS=90
     DEFAULT_TORCH_CUDA_ARCH_LIST=9.0
@@ -282,7 +286,7 @@ PY
 )
     ;;
   *)
-    echo "Unsupported --cuda-arch '${CUDA_ARCH}'. Use h100, l4, l40s, a100, sm90, sm89, sm80, or auto." >&2
+    echo "Unsupported --cuda-arch '${CUDA_ARCH}'. Use b200, gb200, h100, l4, l40s, a100, sm100, sm90, sm89, sm80, or auto." >&2
     exit 2
     ;;
 esac

--- a/skills/mcore-transformer-engine-install/scripts/install_te_pypi.sh
+++ b/skills/mcore-transformer-engine-install/scripts/install_te_pypi.sh
@@ -19,7 +19,7 @@ Options:
   --torch-version VERSION PyTorch version to install (default: 2.10.0)
   --te-version VERSION    Transformer Engine PyPI version (default: 2.11.0)
   --te-spec SPEC          Full TE spec (default: transformer_engine[pytorch]==TE_VERSION)
-  --cuda-arch ARCH        b200, gb200, h100, l4, l40s, a100, sm100, sm90, sm89, sm80, or auto
+  --cuda-arch ARCH        b200, gb200, rtx-pro-6000, h100, l4, l40s, a100, sm120, sm100, sm90, sm89, sm80, or auto
   --extras EXTRAS         Editable Megatron extras, excluding te (default: none; use training for training deps)
   --max-jobs N            Native build parallelism (default: 4)
   --repo-root PATH        Megatron-LM repository root (default: current git root)
@@ -260,6 +260,10 @@ if [[ -d "${VENV_SITE}/nvidia/cudnn" ]]; then
 fi
 
 case "${CUDA_ARCH}" in
+  rtx-pro-6000|rtxpro6000|rtx-pro-blackwell|sm120)
+    DEFAULT_NVTE_CUDA_ARCHS=120
+    DEFAULT_TORCH_CUDA_ARCH_LIST=12.0
+    ;;
   b200|gb200|sm100)
     DEFAULT_NVTE_CUDA_ARCHS=100
     DEFAULT_TORCH_CUDA_ARCH_LIST=10.0
@@ -286,7 +290,7 @@ PY
 )
     ;;
   *)
-    echo "Unsupported --cuda-arch '${CUDA_ARCH}'. Use b200, gb200, h100, l4, l40s, a100, sm100, sm90, sm89, sm80, or auto." >&2
+    echo "Unsupported --cuda-arch '${CUDA_ARCH}'. Use b200, gb200, rtx-pro-6000, h100, l4, l40s, a100, sm120, sm100, sm90, sm89, sm80, or auto." >&2
     exit 2
     ;;
 esac

--- a/skills/mcore-transformer-engine-install/scripts/install_te_source.sh
+++ b/skills/mcore-transformer-engine-install/scripts/install_te_source.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Install Megatron-LM with Transformer Engine from source on a CUDA host.
+The Transformer Engine source build can take 10-15+ minutes depending on CPU
+resources, memory, cache state, and build parallelism.
+
+Run from the Megatron-LM repository root:
+  bash skills/mcore-transformer-engine-install/scripts/install_te_source.sh \
+    --torch-backend cu128 --cuda-arch h100
+
+Options:
+  --python VERSION        Python version for uv venv (default: 3.12)
+  --venv PATH             Virtualenv path (default: .venv)
+  --torch-backend BACKEND uv torch backend, e.g. cu128 or cu130 (default: cu128)
+  --cuda-arch ARCH        h100, l4, l40s, a100, sm90, sm89, sm80, or auto
+  --extras EXTRAS         Editable install extras (default: training,te)
+  --max-jobs N            Native build parallelism (default: 4)
+  --repo-root PATH        Megatron-LM repository root (default: current git root)
+  --no-smoke              Skip the CUDA Transformer Engine smoke test
+  -h, --help              Show this help
+
+Environment overrides:
+  NVTE_CUDA_ARCHS and TORCH_CUDA_ARCH_LIST override --cuda-arch detection.
+  NVTE_FRAMEWORK defaults to pytorch.
+  NVTE_BUILD_THREADS_PER_JOB defaults to 1.
+EOF
+}
+
+PYTHON_VERSION="${PYTHON_VERSION:-3.12}"
+VENV_PATH="${VENV_PATH:-.venv}"
+TORCH_BACKEND="${TORCH_BACKEND:-cu128}"
+CUDA_ARCH="${CUDA_ARCH:-auto}"
+INSTALL_EXTRAS="${INSTALL_EXTRAS:-training,te}"
+MAX_JOBS="${MAX_JOBS:-4}"
+RUN_SMOKE=1
+REPO_ROOT="${REPO_ROOT:-}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --python)
+      PYTHON_VERSION="$2"
+      shift 2
+      ;;
+    --venv)
+      VENV_PATH="$2"
+      shift 2
+      ;;
+    --torch-backend)
+      TORCH_BACKEND="$2"
+      shift 2
+      ;;
+    --cuda-arch)
+      CUDA_ARCH="$2"
+      shift 2
+      ;;
+    --extras)
+      INSTALL_EXTRAS="$2"
+      shift 2
+      ;;
+    --max-jobs)
+      MAX_JOBS="$2"
+      shift 2
+      ;;
+    --repo-root)
+      REPO_ROOT="$2"
+      shift 2
+      ;;
+    --no-smoke)
+      RUN_SMOKE=0
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "${REPO_ROOT}" ]]; then
+  REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+fi
+
+cd "${REPO_ROOT}"
+
+if [[ ! -f pyproject.toml ]] || [[ ! -d megatron ]]; then
+  echo "Expected Megatron-LM repo root, got: ${REPO_ROOT}" >&2
+  exit 1
+fi
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "uv is required but was not found on PATH." >&2
+  exit 1
+fi
+
+if ! command -v nvcc >/dev/null 2>&1; then
+  echo "nvcc is required for Transformer Engine source builds but was not found on PATH." >&2
+  exit 1
+fi
+
+if [[ -z "${CUDA_PATH:-}" ]]; then
+  NVCC_PATH="$(command -v nvcc)"
+  CUDA_PATH="$(cd "$(dirname "${NVCC_PATH}")/.." && pwd)"
+  export CUDA_PATH
+fi
+
+uv venv --python "${PYTHON_VERSION}" "${VENV_PATH}"
+PYTHON_BIN="${VENV_PATH}/bin/python"
+
+uv pip install --no-config --python "${PYTHON_BIN}" --torch-backend="${TORCH_BACKEND}" \
+  "torch>=2.6.0" "setuptools>=80" wheel packaging pybind11 Cython hatchling cmake ninja nvidia-mathdx
+
+"${PYTHON_BIN}" - <<'PY'
+import torch
+
+print("torch:", torch.__version__, "torch cuda:", torch.version.cuda)
+assert torch.cuda.is_available(), "CUDA is not visible to PyTorch"
+print("gpu:", torch.cuda.get_device_name(0), "capability:", torch.cuda.get_device_capability(0))
+PY
+
+VENV_SITE="$("${PYTHON_BIN}" - <<'PY'
+import site
+
+print(site.getsitepackages()[0])
+PY
+)"
+
+for INCLUDE_DIR in "${VENV_SITE}"/nvidia/*/include; do
+  if [[ -d "${INCLUDE_DIR}" ]]; then
+    export CPATH="${INCLUDE_DIR}:${CPATH:-}"
+  fi
+done
+
+for LIB_DIR in "${VENV_SITE}"/nvidia/*/lib; do
+  if [[ -d "${LIB_DIR}" ]]; then
+    export LIBRARY_PATH="${LIB_DIR}:${LIBRARY_PATH:-}"
+    export LD_LIBRARY_PATH="${LIB_DIR}:${LD_LIBRARY_PATH:-}"
+  fi
+done
+
+if [[ -d "${VENV_SITE}/nvidia/cudnn" ]]; then
+  export CUDNN_PATH="${CUDNN_PATH:-${VENV_SITE}/nvidia/cudnn}"
+  export CUDNN_HOME="${CUDNN_HOME:-${CUDNN_PATH}}"
+  export LD_LIBRARY_PATH="${CUDNN_PATH}/lib:${LD_LIBRARY_PATH:-}"
+fi
+
+case "${CUDA_ARCH}" in
+  h100|sm90)
+    DEFAULT_NVTE_CUDA_ARCHS=90
+    DEFAULT_TORCH_CUDA_ARCH_LIST=9.0
+    ;;
+  l4|l40s|sm89)
+    DEFAULT_NVTE_CUDA_ARCHS=89
+    DEFAULT_TORCH_CUDA_ARCH_LIST=8.9
+    ;;
+  a100|sm80)
+    DEFAULT_NVTE_CUDA_ARCHS=80
+    DEFAULT_TORCH_CUDA_ARCH_LIST=8.0
+    ;;
+  auto)
+    read -r DEFAULT_NVTE_CUDA_ARCHS DEFAULT_TORCH_CUDA_ARCH_LIST < <("${PYTHON_BIN}" - <<'PY'
+import torch
+
+major, minor = torch.cuda.get_device_capability(0)
+print(f"{major}{minor} {major}.{minor}")
+PY
+)
+    ;;
+  *)
+    echo "Unsupported --cuda-arch '${CUDA_ARCH}'. Use h100, l4, l40s, a100, sm90, sm89, sm80, or auto." >&2
+    exit 2
+    ;;
+esac
+
+export MAX_JOBS
+export NVTE_BUILD_THREADS_PER_JOB="${NVTE_BUILD_THREADS_PER_JOB:-1}"
+export NVTE_FRAMEWORK="${NVTE_FRAMEWORK:-pytorch}"
+export NVTE_CUDA_ARCHS="${NVTE_CUDA_ARCHS:-${DEFAULT_NVTE_CUDA_ARCHS}}"
+export TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST:-${DEFAULT_TORCH_CUDA_ARCH_LIST}}"
+
+echo "Using CUDA_PATH=${CUDA_PATH}"
+echo "Using CUDNN_PATH=${CUDNN_PATH:-<not set>}"
+echo "Using NVTE_FRAMEWORK=${NVTE_FRAMEWORK}"
+echo "Using NVTE_CUDA_ARCHS=${NVTE_CUDA_ARCHS}"
+echo "Using TORCH_CUDA_ARCH_LIST=${TORCH_CUDA_ARCH_LIST}"
+echo "Using MAX_JOBS=${MAX_JOBS}"
+echo "Using NVTE_BUILD_THREADS_PER_JOB=${NVTE_BUILD_THREADS_PER_JOB}"
+echo "Starting Megatron + Transformer Engine source install."
+echo "Transformer Engine native compilation can take 10-15+ minutes depending on CPU resources, memory, cache state, and build parallelism."
+echo "Some build steps may be quiet for a while; wait for the final smoke test before deciding it is stuck."
+
+uv pip install --python "${PYTHON_BIN}" --no-build-isolation -e ".[${INSTALL_EXTRAS}]"
+
+if [[ "${RUN_SMOKE}" -eq 1 ]]; then
+  "${PYTHON_BIN}" - <<'PY'
+import torch
+import megatron.core
+import megatron.training
+from transformer_engine.pytorch import Linear
+
+assert torch.cuda.is_available(), "CUDA is not visible to PyTorch"
+layer = Linear(8, 8).cuda()
+x = torch.randn(2, 8, device="cuda")
+y = layer(x)
+torch.cuda.synchronize()
+print("megatron cuda+te smoke: ok", tuple(y.shape))
+PY
+fi

--- a/skills/mcore-transformer-engine-install/scripts/install_te_source.sh
+++ b/skills/mcore-transformer-engine-install/scripts/install_te_source.sh
@@ -15,7 +15,7 @@ Options:
   --python VERSION        Python version for uv venv (default: 3.12)
   --venv PATH             Virtualenv path (default: .venv)
   --torch-backend BACKEND uv torch backend, e.g. cu128 or cu130 (default: cu128)
-  --cuda-arch ARCH        h100, l4, l40s, a100, sm90, sm89, sm80, or auto
+  --cuda-arch ARCH        b200, gb200, h100, l4, l40s, a100, sm100, sm90, sm89, sm80, or auto
   --extras EXTRAS         Editable install extras (default: training,te)
   --max-jobs N            Native build parallelism (default: 4)
   --repo-root PATH        Megatron-LM repository root (default: current git root)
@@ -152,6 +152,10 @@ if [[ -d "${VENV_SITE}/nvidia/cudnn" ]]; then
 fi
 
 case "${CUDA_ARCH}" in
+  b200|gb200|sm100)
+    DEFAULT_NVTE_CUDA_ARCHS=100
+    DEFAULT_TORCH_CUDA_ARCH_LIST=10.0
+    ;;
   h100|sm90)
     DEFAULT_NVTE_CUDA_ARCHS=90
     DEFAULT_TORCH_CUDA_ARCH_LIST=9.0
@@ -174,7 +178,7 @@ PY
 )
     ;;
   *)
-    echo "Unsupported --cuda-arch '${CUDA_ARCH}'. Use h100, l4, l40s, a100, sm90, sm89, sm80, or auto." >&2
+    echo "Unsupported --cuda-arch '${CUDA_ARCH}'. Use b200, gb200, h100, l4, l40s, a100, sm100, sm90, sm89, sm80, or auto." >&2
     exit 2
     ;;
 esac

--- a/skills/mcore-transformer-engine-install/scripts/install_te_source.sh
+++ b/skills/mcore-transformer-engine-install/scripts/install_te_source.sh
@@ -15,7 +15,7 @@ Options:
   --python VERSION        Python version for uv venv (default: 3.12)
   --venv PATH             Virtualenv path (default: .venv)
   --torch-backend BACKEND uv torch backend, e.g. cu128 or cu130 (default: cu128)
-  --cuda-arch ARCH        b200, gb200, h100, l4, l40s, a100, sm100, sm90, sm89, sm80, or auto
+  --cuda-arch ARCH        b200, gb200, rtx-pro-6000, h100, l4, l40s, a100, sm120, sm100, sm90, sm89, sm80, or auto
   --extras EXTRAS         Editable install extras (default: training,te)
   --max-jobs N            Native build parallelism (default: 4)
   --repo-root PATH        Megatron-LM repository root (default: current git root)
@@ -152,6 +152,10 @@ if [[ -d "${VENV_SITE}/nvidia/cudnn" ]]; then
 fi
 
 case "${CUDA_ARCH}" in
+  rtx-pro-6000|rtxpro6000|rtx-pro-blackwell|sm120)
+    DEFAULT_NVTE_CUDA_ARCHS=120
+    DEFAULT_TORCH_CUDA_ARCH_LIST=12.0
+    ;;
   b200|gb200|sm100)
     DEFAULT_NVTE_CUDA_ARCHS=100
     DEFAULT_TORCH_CUDA_ARCH_LIST=10.0
@@ -178,7 +182,7 @@ PY
 )
     ;;
   *)
-    echo "Unsupported --cuda-arch '${CUDA_ARCH}'. Use b200, gb200, h100, l4, l40s, a100, sm100, sm90, sm89, sm80, or auto." >&2
+    echo "Unsupported --cuda-arch '${CUDA_ARCH}'. Use b200, gb200, rtx-pro-6000, h100, l4, l40s, a100, sm120, sm100, sm90, sm89, sm80, or auto." >&2
     exit 2
     ;;
 esac


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Adds a focused skill and helper scripts for bare-metal Megatron Core + Transformer Engine installation.

This PR:

- Adds `skills/mcore-transformer-engine-install` with pinned PyPI Transformer Engine install guidance, CUDA header/library export handling, GPU architecture auto-detection, and CUDA smoke-test criteria.
- Adds helper scripts for pinned PyPI Transformer Engine installs and source/fork install experiments.
- Updates the existing `mcore-build-and-dependency` skill so CI/container `uv sync --locked` remains separate from disposable source-install smoke tests.
- Documents known traps around `--no-build-isolation`, `--no-config`, cuDNN/NCCL headers, CUDA toolkit/PyTorch CUDA mismatch, native build duration, and avoiding coarse polling in benchmark automation.
- Adds Blackwell/B200/GB200 and RTX PRO Blackwell architecture mappings while keeping auto-detection as the default path.

This intentionally does not change the public README or install guide; the goal is to prove and preserve the agent skill/helper path first.

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Validation

Install-only benchmark runs used a clean CUDA container with a Megatron Core + Transformer Engine CUDA smoke test as the success artifact.

| GPU | Baseline | With skill | Delta | Tokens |
| --- | ---: | ---: | ---: | ---: |
| A100 | 355.9s | 268.8s | 87.1s faster, 24.5% | - | 
| H100 | 376.7s | 304.8s | 71.9s faster, 19.1% | 491K -> 252K, 48.5% lower | 

## Benchmark harness

The paired agent runs used [sbhavani/ate-bench](https://github.com/sbhavani/ate-bench/tree/codex/add-codex-agent), branch `codex/add-codex-agent`. This fork adds Codex support and the `experiments/run-megatron-install-comparison.sh` runner. 

The benchmark harness builds on [PithTrain](https://github.com/mlc-ai/pith-train) and its ATE-Bench evaluation work. @haok1402 @MasterJH5574

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [x] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

No Python imports were changed, so `uv run isort` was not required. This is a skill documentation and shell-helper change; validation focused on CUDA installation smoke tests and shell syntax checks rather than unit/functional test suites.

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.


