### PR TITLE
Pass device IDs to cleanup barrier

### DIFF
--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import os
-from datetime import timedelta
 from pathlib import Path
 
 import pytest
@@ -44,7 +43,10 @@ def cleanup():
     yield
     if torch.distributed.is_initialized():
         try:
-            torch.distributed.barrier()
+            if torch.cuda.is_available():
+                torch.distributed.barrier(device_ids=[torch.cuda.current_device()])
+            else:
+                torch.distributed.barrier()
         except Exception:
             return
         torch.distributed.destroy_process_group()


### PR DESCRIPTION
## Summary
- Pass the current CUDA device to the unit-test session cleanup barrier when CUDA is available.
- Keep the existing plain barrier path for non-CUDA environments.
- Remove the stale `timedelta` import left over from the old barrier timeout attempt.

## Why
PyTorch warns when an NCCL barrier has to infer the device from the current context. The session cleanup barrier was one source of that warning during unit-test teardown.

## Testing
- `python -m isort --check-only tests/unit_tests/conftest.py`
- `python -m torch.distributed.run --nproc-per-node 1 -m pytest -q tests/unit_tests/test_nccl_allocator.py::TestNCCLAllocator::test_nccl_allocator_init_sets_env_vars -W always::UserWarning`

Note: `uv run isort tests/unit_tests/conftest.py` was attempted but blocked by local `/opt/venv` permission errors; the installed `isort` check passed.