### PR TITLE
ci: keep 8-GPU EP8 GB200 MoE tests off the 4-GPU GitHub PR runner

### DIFF
--- a/tests/test_utils/recipes/gb200/moe.yaml
+++ b/tests/test_utils/recipes/gb200/moe.yaml
@@ -201,12 +201,12 @@ products:
   - test_case: [gpt3_moe_mcore_te_ep8_resume_torch_dist_dist_muon]
     products:
       - environment: [dev]
-        scope: [L0, L2]
+        scope: [L2]
         platforms: [dgx_gb200]
   - test_case: [gpt3_moe_mcore_te_ep8_resume_torch_dist_muon]
     products:
       - environment: [dev]
-        scope: [L0, L2]
+        scope: [L2]
         platforms: [dgx_gb200]
   - test_case: [gpt3_moe_mcore_te_tp2_pp2_ep4_etp1_fine_grained_offloading]
     products:


### PR DESCRIPTION
## Background

The two EP8 GB200 MoE tests hard-require **8 GPUs** (`--expert-model-parallel-size 8`, `--num-experts 8`) and are meant to run on GitLab's 2-node GB200 runner:

- `gpt3_moe_mcore_te_ep8_resume_torch_dist_dist_muon`
- `gpt3_moe_mcore_te_ep8_resume_torch_dist_muon`

#5316 (*"ci: Update test configurations to unify legacy scope names"*) rescoped both from `[mr, mr-slim]` → `[L0, L2]`. The **`L0`** tier routes them into the **GitHub slim-PR** matrix, which executes on the single **4-GPU** `nvidia-ci-gcp-gpu-x4` runner (GitHub can't do multi-node). There they die in `initialize_model_parallel` before any training runs:

```
RuntimeError: world_size (4) is not divisible by expert_tensor_model_pipeline_parallel size (8)
```

This breaks **every slim (L0) PR run** since #5316 landed (2026-07-07) — the topology mismatch is deterministic, not flaky, and unrelated to whatever the PR itself changes. Observed on #5696, #5134, #5707, #5008, and counting.

## What changed

- Drop the `L0` tier from both EP8 entries in `gb200/moe.yaml`: `scope: [L0, L2]` → `scope: [L2]`.

## Details

- `L0`/`L1` are the GitHub PR tiers (→ 4-GPU runner); `L2`/`L3` run on GitLab's 8-GPU GB200 nightly/weekly, where EP8 fits. Every other 8-GPU test in this recipe is already `L2`/`L3`/`nightly` — the `[L0, L2]` pair was the lone anomaly.
- GitHub PR-time coverage for the EP8 path is already provided by the `*_1node` (EP-reduced 8→4) variants in `moe-1node.yaml`.
- Swept all 35 L0/L1 GB200 tests: these two are the **only** ones whose parallelism exceeds 4 GPUs — no other tests need this change.

```mermaid
flowchart LR
  T["EP8 MoE test<br/>(needs 8 GPUs)"]
  T -->|"L0 → GitHub slim PR"| G["4-GPU runner<br/>nvidia-ci-gcp-gpu-x4"]
  T -->|"L2 → GitLab nightly"| L["2-node / 8-GPU<br/>dgx_gb200"]
  G --> X["❌ world_size 4 %% 8 != 0"]
  L --> OK["✅ runs"]
  style X fill:#fdd,stroke:#c00
  style OK fill:#dfd,stroke:#0a0
```

## Tested

- Reproduced the selection with the repo's own `recipe_parser.load_and_flatten` at the failing run's SHA: with `--scope L0 --platform dgx_gb200`, the `[L0, L2]` rows are selected onto the 4-GPU runner; after this change they are not.
- Failing job for reference: run `28947191678`, job `moe/gpt3_moe_mcore_te_ep8_resume_torch_dist_dist_muon` — `world_size (4) is not divisible by ... size (8)` at `parallel_state.py:788`.
