### PR TITLE
Fix FSDP2 SwiGLU checkpointing.

### DIFF
--- a/megatron/core/distributed/torch_fully_sharded_data_parallel.py
+++ b/megatron/core/distributed/torch_fully_sharded_data_parallel.py
@@ -96,6 +96,8 @@ class TorchFullyShardedDataParallel(_BaseDataParallel):
                     # micro-batch id, thus removing unnecessary memory stores
                     attrs['_fp8_attrs']['transpose_invalid'] = False
                     del attrs['_fp8_attrs']['transpose']
+                # Mark this parameter as an FSDP2 parameter.
+                attrs["is_torch_fsdp2_param"] = True
                 custom_attrs[name] = {k: v for k, v in attrs.items()}
             return custom_attrs
 

--- a/megatron/core/transformer/mlp.py
+++ b/megatron/core/transformer/mlp.py
@@ -435,13 +435,14 @@ def apply_swiglu_sharded_factory(
     )
     axis_frag = original_sh_ten.axis_fragmentations[swiglu_shard_axis + prepend_axis_num]
 
-    # Detect TP-DP strided sharding (FSDP), in which case we need to map [W; V] to
-    # [ {W_tp0; V_tp0}_dp{1...DP}, {W_tp1; V_tp1}_dp{1...DP}, ... ]
-    # TP sharding produces TP-sharded pairs of W/V, followed by DP sharding!
-    assert tp_group is not None and dp_group is not None
-    tp_size = get_pg_size(tp_group)
-    dp_size = get_pg_size(dp_group)
-    is_dp_sharded = getattr(original_sh_ten, "is_torch_fsdp2_param", False) and dp_size > 1
+    # Only FSDP2 supports torch_dist ShardedTensor. (Add other DP sharding algos here if needed.)
+    is_torch_fsdp2_param = getattr(original_sh_ten, "is_torch_fsdp2_param", False)
+    if is_torch_fsdp2_param:
+        assert dp_group is not None
+        dp_size = get_pg_size(dp_group)
+        is_dp_sharded = dp_size > 1
+    else:
+        is_dp_sharded = False
 
     @torch.no_grad()
     def sh_ten_build_fn(
@@ -486,10 +487,17 @@ def apply_swiglu_sharded_factory(
         ]
 
     @torch.no_grad()
-    def fsdp2_sh_ten_build_fn(
+    def dp_sh_ten_build_fn(
         key: str, t: torch.Tensor, replica_id: ReplicaId, flattened_range: Optional[slice]
     ):
-        # FSDP2 shards the TP-local [W; V] SwiGLU FC1 tensor over DP along dim 0.
+        assert not singleton_local_shards, (
+            "FSDP does not support singleton ShardedTensor for SwiGLU fused FC1. "
+            "Set singleton_local_shards=False, which is the default in MCore."
+        )
+        # FSDP shards the TP-local [W; V] SwiGLU FC1 tensor over DP along dim 0.
+        # TP sharding produces TP-sharded pairs of W/V, followed by DP sharding!
+        assert tp_group is not None and dp_group is not None
+        tp_size = get_pg_size(tp_group)
         global_axis = swiglu_shard_axis + prepend_axis_num
         tp_rank = get_pg_rank(tp_group)
         dp_rank = get_pg_rank(dp_group)
@@ -500,8 +508,8 @@ def apply_swiglu_sharded_factory(
         half_axis_size = tp_local_axis_size // 2
         # Check that the TP-local W or V is cleanly divisible by DP.
         assert half_axis_size % local_axis_size == 0, (
-            "SwiGLU FSDP2 torch_dist checkpoint loading requires each DP shard of "
-            "linear_fc1 to fall wholly inside either the W or V half."
+            "SwiGLU FC1 FSDP ShardedTensor requires each DP shard of "
+            "linear_fc1 to be completely inside either the W or V half."
         )
         # Number of DP shards per W or V TP-shard, and make sure
         # that DP sharding spans both W and V.
@@ -512,13 +520,13 @@ def apply_swiglu_sharded_factory(
         swiglu_half_idx, half_dp_shard_idx = divmod(dp_rank, shards_per_half)
         # If W, then 0. If V, then 1.
         assert swiglu_half_idx in (0, 1)
-        # Map [W; V] to this rank's shard [W_tpx_dpy; V_tpx_dpy].
+        # Map [ W; V ] to this rank's shard [ {W_tpx; V_tpx}_dpy ].
         shard_rank_offset = (
-            # W or V
+            # W or V half of the [W; V] global data.
             swiglu_half_idx * tp_size * shards_per_half
-            # TP Shard
+            # TP Shard Index
             + tp_rank * shards_per_half
-            # TP-DP Shard
+            # TP-DP Shard Index
             + half_dp_shard_idx
         )
 
@@ -534,7 +542,7 @@ def apply_swiglu_sharded_factory(
         ]
 
     # Construct a ShardedTensorFactory.
-    sh_ten_factory_build_function = fsdp2_sh_ten_build_fn if is_dp_sharded else sh_ten_build_fn
+    sh_ten_factory_build_function = dp_sh_ten_build_fn if is_dp_sharded else sh_ten_build_fn
     return ShardedTensorFactory(
         original_sh_ten.key,
         original_sh_ten.data,

--- a/megatron/core/transformer/mlp.py
+++ b/megatron/core/transformer/mlp.py
@@ -26,9 +26,15 @@ from megatron.core.fusions.fused_bias_swiglu import bias_swiglu_impl, weighted_b
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.transformer_config import TransformerConfig
-from megatron.core.transformer.utils import cat_with_oom_fallback, sharded_state_dict_default
+from megatron.core.transformer.utils import (
+    cat_with_oom_fallback,
+    ensure_metadata_has_dp_cp_group,
+    sharded_state_dict_default,
+)
 from megatron.core.typed_torch import apply_module, not_none
 from megatron.core.utils import (
+    get_pg_rank,
+    get_pg_size,
     get_tensor_model_parallel_group_if_none,
     nvtx_range_pop,
     nvtx_range_push,
@@ -355,6 +361,7 @@ class MLP(MegatronModule):
         self, prefix: str = "", sharded_offsets: tuple = (), metadata: Optional[dict] = None
     ) -> ShardedStateDict:
         """Return the sharded state dictionary of the module."""
+        metadata = ensure_metadata_has_dp_cp_group(metadata)
         sharded_state_dict = {}
         singleton_local_shards = (metadata or {}).get('singleton_local_shards', False)
         for name, module in self._modules.items():
@@ -365,7 +372,11 @@ class MLP(MegatronModule):
                 for k, v in sub_sd.items():
                     if k in (f"{prefix}{name}.weight", f"{prefix}{name}.bias"):
                         sub_sd[k] = apply_swiglu_sharded_factory(
-                            v, sharded_offsets, singleton_local_shards
+                            v,
+                            sharded_offsets,
+                            singleton_local_shards,
+                            tp_group=self.tp_group,
+                            dp_group=metadata['dp_cp_group'],
                         )
             sharded_state_dict.update(sub_sd)
         return sharded_state_dict
@@ -404,7 +415,11 @@ class MLP(MegatronModule):
 
 # pylint: disable=missing-function-docstring
 def apply_swiglu_sharded_factory(
-    original_sh_ten, sharded_offsets, singleton_local_shards: bool = False
+    original_sh_ten,
+    sharded_offsets,
+    singleton_local_shards: bool = False,
+    tp_group: torch.distributed.ProcessGroup | None = None,
+    dp_group: torch.distributed.ProcessGroup | None = None,
 ):
     # We must split the tensor into 2 parts, each sharded separately.
     # This requires a ShardedTensorFactory which `chunk`s during saving
@@ -418,15 +433,23 @@ def apply_swiglu_sharded_factory(
     assert (
         original_sh_ten.global_offset[swiglu_shard_axis + prepend_axis_num] % local_axis_size == 0
     )
-    rank_offset = (
-        original_sh_ten.global_offset[swiglu_shard_axis + prepend_axis_num] // local_axis_size
-    )
     axis_frag = original_sh_ten.axis_fragmentations[swiglu_shard_axis + prepend_axis_num]
+
+    # Detect TP-DP strided sharding (FSDP), in which case we need to map [W; V] to
+    # [ {W_tp0; V_tp0}_dp{1...DP}, {W_tp1; V_tp1}_dp{1...DP}, ... ]
+    # TP sharding produces TP-sharded pairs of W/V, followed by DP sharding!
+    assert tp_group is not None and dp_group is not None
+    tp_size = get_pg_size(tp_group)
+    dp_size = get_pg_size(dp_group)
+    is_dp_sharded = getattr(original_sh_ten, "is_torch_fsdp2_param", False) and dp_size > 1
 
     @torch.no_grad()
     def sh_ten_build_fn(
         key: str, t: torch.Tensor, replica_id: ReplicaId, flattened_range: Optional[slice]
     ):
+        rank_offset = (
+            original_sh_ten.global_offset[swiglu_shard_axis + prepend_axis_num] // local_axis_size
+        )
         if singleton_local_shards:
             offset_w = (swiglu_shard_axis + prepend_axis_num, rank_offset, axis_frag)
             offset_v = (swiglu_shard_axis + prepend_axis_num, rank_offset, axis_frag)
@@ -462,10 +485,60 @@ def apply_swiglu_sharded_factory(
             ),
         ]
 
+    @torch.no_grad()
+    def fsdp2_sh_ten_build_fn(
+        key: str, t: torch.Tensor, replica_id: ReplicaId, flattened_range: Optional[slice]
+    ):
+        # FSDP2 shards the TP-local [W; V] SwiGLU FC1 tensor over DP along dim 0.
+        global_axis = swiglu_shard_axis + prepend_axis_num
+        tp_rank = get_pg_rank(tp_group)
+        dp_rank = get_pg_rank(dp_group)
+        # Size of a TP shard for W + V.
+        tp_local_axis_size = original_sh_ten.global_shape[global_axis] // tp_size
+        assert tp_local_axis_size % 2 == 0  # W and V should be symmetrically shaped.
+        # Size of a TP shard for W or V. "Half" size TP-shard.
+        half_axis_size = tp_local_axis_size // 2
+        # Check that the TP-local W or V is cleanly divisible by DP.
+        assert half_axis_size % local_axis_size == 0, (
+            "SwiGLU FSDP2 torch_dist checkpoint loading requires each DP shard of "
+            "linear_fc1 to fall wholly inside either the W or V half."
+        )
+        # Number of DP shards per W or V TP-shard, and make sure
+        # that DP sharding spans both W and V.
+        shards_per_half = half_axis_size // local_axis_size
+        assert dp_size == 2 * shards_per_half
+
+        # Compute if DP rank maps to W or V in [W; V].
+        swiglu_half_idx, half_dp_shard_idx = divmod(dp_rank, shards_per_half)
+        # If W, then 0. If V, then 1.
+        assert swiglu_half_idx in (0, 1)
+        # Map [W; V] to this rank's shard [W_tpx_dpy; V_tpx_dpy].
+        shard_rank_offset = (
+            # W or V
+            swiglu_half_idx * tp_size * shards_per_half
+            # TP Shard
+            + tp_rank * shards_per_half
+            # TP-DP Shard
+            + half_dp_shard_idx
+        )
+
+        return [
+            ShardedTensor.from_rank_offsets(
+                key,
+                t,
+                *sharded_offsets,
+                (global_axis, shard_rank_offset, axis_frag),
+                replica_id=replica_id,
+                prepend_axis_num=prepend_axis_num,
+            )
+        ]
+
+    # Construct a ShardedTensorFactory.
+    sh_ten_factory_build_function = fsdp2_sh_ten_build_fn if is_dp_sharded else sh_ten_build_fn
     return ShardedTensorFactory(
         original_sh_ten.key,
         original_sh_ten.data,
-        sh_ten_build_fn,
+        sh_ten_factory_build_function,
         cat_with_oom_fallback,
         original_sh_ten.replica_id,
         flattened_range=original_sh_ten.flattened_range,

--- a/megatron/core/transformer/moe/experts.py
+++ b/megatron/core/transformer/moe/experts.py
@@ -848,7 +848,11 @@ class TEGroupedMLP(MegatronModule):
                     for k in (f'{name}.weight{i}', f'{name}.bias{i}'):
                         if k in sub_sd:
                             sub_sd[k] = apply_swiglu_sharded_factory(
-                                sub_sd[k], new_sharded_offsets, singleton_local_shards
+                                sub_sd[k],
+                                new_sharded_offsets,
+                                singleton_local_shards,
+                                tp_group=self.tp_group,
+                                dp_group=metadata['dp_cp_group'],
                             )
             if singleton_local_shards:
                 replace_prefix_for_sharding(sub_sd, '', f'{prefix}experts.')

--- a/megatron/core/utils.py
+++ b/megatron/core/utils.py
@@ -1008,8 +1008,11 @@ def make_tp_sharded_tensor_for_checkpoint(
 
     new_offsets.append((tp_axis + prepend_axis_num, tp_rank, tp_size))
 
-    if HAVE_DTENSOR and isinstance(tensor, DTensor):
-        # TP + FSDP2 sharding
+    is_torch_fsdp2_param = (
+        hasattr(tensor, "is_torch_fsdp2_param") and HAVE_DTENSOR and isinstance(tensor, DTensor)
+    )
+    if is_torch_fsdp2_param:
+        # When using FSDP2, every DP shard is a main replica.
         dp_replica_id = 0
         tensor = tensor._local_tensor
 
@@ -1025,7 +1028,7 @@ def make_tp_sharded_tensor_for_checkpoint(
     if replica_id is None:
         replica_id = (0, 0, dp_replica_id)
 
-    return ShardedTensor.from_rank_offsets(
+    sharded_tensor = ShardedTensor.from_rank_offsets(
         key,
         tensor,
         *prepend_offsets,
@@ -1034,6 +1037,11 @@ def make_tp_sharded_tensor_for_checkpoint(
         prepend_axis_num=prepend_axis_num,
         **kwargs,
     )
+    if is_torch_fsdp2_param:
+        # Marker used downstream for FSDP2-related logic, such as TP-DP
+        # sharding / loading for non-trivial parameters like SwiGLU.
+        sharded_tensor.is_torch_fsdp2_param = is_torch_fsdp2_param
+    return sharded_tensor
 
 
 def make_sharded_tensor_for_checkpoint(tensor, key, prepend_offsets=(), replica_id=None, **kwargs):
@@ -1069,16 +1077,20 @@ def make_sharded_tensor_for_checkpoint(tensor, key, prepend_offsets=(), replica_
     dp_size = get_pg_size(dp_cp_group)
     dp_replica_id = get_pg_rank(dp_cp_group)
 
-    if HAVE_DTENSOR and isinstance(tensor, DTensor):
-        # FSDP2 sharding
+    is_torch_fsdp2_param = (
+        hasattr(tensor, "is_torch_fsdp2_param") and HAVE_DTENSOR and isinstance(tensor, DTensor)
+    )
+    if is_torch_fsdp2_param:
+        # When using FSDP2, every DP shard is a main replica.
         dp_replica_id = 0
         tensor = get_full_tensor_if_necessary(tensor)
+        # Add FSDP sharding rank offsets.
         new_offsets.append((prepend_axis_num, dp_rank, dp_size))
 
     if replica_id is None:
         replica_id = (0, get_pg_rank(tp_group), dp_replica_id)
 
-    return ShardedTensor.from_rank_offsets(
+    sharded_tensor = ShardedTensor.from_rank_offsets(
         key,
         tensor,
         *prepend_offsets,
@@ -1087,10 +1099,19 @@ def make_sharded_tensor_for_checkpoint(tensor, key, prepend_offsets=(), replica_
         prepend_axis_num=prepend_axis_num,
         **kwargs,
     )
+    if is_torch_fsdp2_param:
+        # Marker used downstream for FSDP2-related logic, such as TP-DP
+        # sharding / loading for non-trivial parameters like SwiGLU.
+        sharded_tensor.is_torch_fsdp2_param = is_torch_fsdp2_param
+    return sharded_tensor
 
 
 def get_full_tensor_if_necessary(tensor):
-    """For DTensor gets full tensor if some ranks will not have a local copy"""
+    """
+    Captures an edge case where devices out-number elements in a DTensor,
+    for instance when generating a ShardedTensor. Replicate the DTensor
+    on all ranks to avoid empty DTensors on any rank.
+    """
     need_full_tensor = False
     for i in range(tensor.device_mesh.ndim):
         if (

--- a/tests/unit_tests/distributed/test_torch_fully_sharded_parallel.py
+++ b/tests/unit_tests/distributed/test_torch_fully_sharded_parallel.py
@@ -11,13 +11,35 @@ from megatron.core.num_microbatches_calculator import (
     init_num_microbatches_calculator,
     unset_num_microbatches_calculator,
 )
+from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel import ColumnParallelLinear
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer import MegatronModule
+from megatron.core.transformer.mlp import apply_swiglu_sharded_factory
 from megatron.core.transformer.module import Float16Module
 from megatron.core.transformer.transformer_config import TransformerConfig
-from megatron.core.utils import init_method_normal, is_torch_min_version
+from megatron.core.utils import (
+    init_method_normal,
+    is_torch_min_version,
+    make_tp_sharded_tensor_for_checkpoint,
+)
 from tests.unit_tests.test_utilities import Utils
+
+try:
+    from torch.distributed import DeviceMesh
+    from torch.distributed.tensor import DTensor
+    from torch.distributed.tensor.placement_types import Shard
+
+    HAVE_DTENSOR = True
+except ImportError:
+    HAVE_DTENSOR = False
+
+try:
+    import einops
+
+    HAVE_EINOPS = True
+except ImportError:
+    HAVE_EINOPS = False
 
 
 class DummyModel(MegatronModule):
@@ -106,3 +128,117 @@ def test_fsdp2_constructor_with_process_group(init_model_parallel):
     assert _is_fsdp_wrapped_module(fsdp_model.module.module.linear)
     assert _is_fsdp_wrapped_module(fsdp_model.module.module.column_parallel_linear)
     assert not _is_fsdp_wrapped_module(fsdp_model.module.module.conv)
+
+
+@pytest.mark.skipif(not is_torch_min_version("2.4.0"), reason="FSDP2 requires PyTorch >= 2.4")
+@pytest.mark.skipif(not HAVE_EINOPS, reason="einops is not available")
+@pytest.mark.skipif(not HAVE_DTENSOR, reason="DTensor is not available")
+def test_fsdp2_swiglu_sharded_tensor_factory():
+    """
+    Test construction of a TP2 DP{N} ShardedTensor for SwiGLU.
+    """
+    # Initialize distributed with TP2.
+    Utils.initialize_model_parallel(tensor_model_parallel_size=2, pipeline_model_parallel_size=1)
+    pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+    tp_group = pg_collection.tp
+    tp_size = tp_group.size()
+    tp_rank = tp_group.rank()
+    dp_cp_group = pg_collection.dp_cp
+    dp_cp_size = dp_cp_group.size()
+    dp_cp_rank = dp_cp_group.rank()
+
+    # Create FSDP2 DTensor with DP only. (Implicitly TP-sharded before FSDP2 init.)
+    device_mesh = DeviceMesh.from_group(dp_cp_group, device_type="cuda", mesh_dim_names=["dp_cp"])
+    toy_dtensor = DTensor.from_local(
+        torch.randn(2, 8), device_mesh=device_mesh, placements=(Shard(dim=0),)
+    )
+    toy_dtensor.is_torch_fsdp2_param = True
+
+    # Initialize TP-DP ShardedTensor.
+    tp_dp_sh_ten = make_tp_sharded_tensor_for_checkpoint(
+        toy_dtensor,
+        "test_fsdp2_tp_swiglu_weight",
+        # SwiGLU FC1 TP & FSDP2 Sharding Dim
+        tp_axis=0,
+        replica_id=None,
+        prepend_offsets=(),
+        tp_group=tp_group,
+        dp_cp_group=dp_cp_group,
+    )
+    """
+    Before TP2-DP4 Swizzle (TP Rank 1, DP Rank 1):
+    (Pdb) tp_dp_sh_ten
+    ShardedTensor(
+        local_shape=(2, 8),
+        global_shape=(16, 8),
+        # Canonical Data Offset = 2 * (tp_rank * dp_cp_size + dp_cp_rank)
+        # = 2 * (5) = 10
+        global_offset=(10, 0),
+        axis_fragmentations=(8, 1),
+        replica_id=(0, 0, 0),
+        prepend_axis_num=0
+    )
+    """
+
+    # Test SwiGLU factory for FSDP2-TP.
+    swiglu_sh_ten_factory = apply_swiglu_sharded_factory(
+        tp_dp_sh_ten,
+        sharded_offsets=(),  # Vanilla MLP.
+        # Fused W/V.
+        singleton_local_shards=False,
+        tp_group=tp_group,
+        dp_group=dp_cp_group,
+    )
+    sh_ten_shards = swiglu_sh_ten_factory.build()
+
+    """
+    After TP2-DP4 Swizzle (TP Rank 1, DP Rank 1):
+    (Pdb) sh_ten_shards[0]
+    ShardedTensor(
+        local_shape=(2, 8),
+        global_shape=(16, 8),
+        global_offset=(6, 0),   # W/V TP-swizzled, DP-sharded!
+        axis_fragmentations=(8, 1),
+        replica_id=(0, 0, 0),
+        prepend_axis_num=0
+    )
+
+    This is a mapping from the checkpoint [W;V] rank offsets:
+
+        W_tp0_dp0 W_tp0_dp1 W_tp1_dp0 W_tp1_dp1 V_tp0_dp2 V_tp0_dp3 V_tp1_dp2 V_tp1_dp3
+        0         1         2         3         4         5         6         7
+                                      |
+                        Data Offset = 3 * 2 = 6 is just the rank offset x local shape.
+    
+    to the model [ {W_tpx; V_tpx}_dpy ] rank offsets:
+
+        W_tp0_dp0 W_tp0_dp1 V_tp0_dp2 V_tp0_dp3 W_tp1_dp0 W_tp1_dp1 V_tp1_dp2 V_tp1_dp3
+    """
+
+    # Validate FSDP2 TP-DP sharding and swizzle.
+    assert getattr(tp_dp_sh_ten, "is_torch_fsdp2_param", False)
+    assert len(sh_ten_shards) == 1
+    shard = sh_ten_shards[0]
+    toy_tensor_shape = toy_dtensor.to_local().shape
+    assert shard.axis_fragmentations[0] == tp_size * dp_cp_size
+    assert shard.global_shape[0] == tp_size * dp_cp_size * toy_tensor_shape[0]
+    # Expected global data offsets considering the parallelism ranks and tensor shape.
+    expected_global_rank_offsets = {
+        # (TP Rank, DP Rank) -> Global Data Rank Location / Offset
+        (0, 0): 0,
+        (0, 1): 1,
+        (0, 2): 4,
+        (0, 3): 5,
+        (1, 0): 2,
+        (1, 1): 3,
+        (1, 2): 6,
+        (1, 3): 7,
+    }
+    assert (
+        shard.global_offset[0]
+        == expected_global_rank_offsets[(tp_rank, dp_cp_rank)] * toy_tensor_shape[0]
+    )
+
+    # Destroy distributed.
+    Utils.destroy_model_parallel()
+    unset_num_microbatches_calculator()


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
<!-- Add a one line overview of what this PR aims to accomplish. -->

- Fixes a bug (https://github.com/NVIDIA/Megatron-LM/issues/2769) with `torch_dist` checkpointing for FSDP2, where the MLP / MoE SwiGLU weights need to be TP-DP sharded. To remind everyone, the checkpoint files have `[W; V]` weights, and then we:
  - Swizzle / interleave the TP shards, i.e. `[W_tp0, V_tp0, W_tp1, V_tp1, ... ]`
  - For each TP shard pair of W/V, FSDP2 then shards `dim=0`, so you end up with `[ {W_tp0; V_tp0}_dp{1...DP}, {W_tp1; V_tp1}_dp{1...DP}, ... ]`, which is really hard to read but basically the DP sharding is done over the pair for each TP rank, and this is mapped from the simple `[W; V]` checkpointed format.

After making this fix, we have loss parity after loading a ND-parallel `torch_dist` checkpoint (non-trivial):
```
# ND Post-Load
 [2026-07-07 14:43:32.368419] iteration       51/     100 | consumed samples:          816 | elapsed time per iteration (ms): 42941.8 | throughput per GPU (TFLOP/s/GPU): 4.4 | learning rate: 9.900000E-05 | global batch size:    16 | lm loss: 3.642244E-02 | loss scale: 1.0 | grad norm: 0.913 | number ofskipped iterations:   0 | number of nan iterations:   0 |Number of parameters in transformer block in billions:  6.98

# Torch FSDP2 Post-Load
 [2026-07-07 14:44:43.435452] iteration       51/     100 | consumed samples:          816 | elapsed time per iteration (ms): 12756.0 | throughput per GPU (TFLOP/s/GPU): 15.0 | learning rate: 9.900000E-05 | global batch size:    16 | lm loss: 3.642244E-02 | loss scale: 1.0 | grad norm: 0.913 | number of skipped iterations:   0 | number of nan iterations:   0 |Number of parameters in transformer block in billions:  6.98
```
Debugged this with my usual activation bisect approach after confirming that `FSDPParam._sharded_param_data` was indeed updated by the distributed checkpoint load. It was just the middle sections of the SwiGLU weights that were in the wrong order.

Attached my minimal script in the Testing section.

# Testing

- Unit test on the `ShardedTensorFactory` built/acting on the `ShardedTensor`-converted `DTensor` parameters from FSDP2.

To reproduce the bug...
```
#!/bin/bash

declare -A MODEL_CONFIG
MODEL_CONFIG[tokenizer-type]=HuggingFaceTokenizer
MODEL_CONFIG[tokenizer-model]=meta-llama/Meta-Llama-3-8B
MODEL_CONFIG[untie-embeddings-and-output-weights]=true
MODEL_CONFIG[position-embedding-type]=rope
MODEL_CONFIG[rotary-base]=500000
MODEL_CONFIG[max-position-embeddings]=8192
MODEL_CONFIG[num-layers]=32
MODEL_CONFIG[hidden-size]=4096
MODEL_CONFIG[ffn-hidden-size]=14336
MODEL_CONFIG[hidden-dropout]=0.0
MODEL_CONFIG[disable-bias-linear]=true
MODEL_CONFIG[swiglu]=true
MODEL_CONFIG[group-query-attention]=true
MODEL_CONFIG[num-attention-heads]=32
MODEL_CONFIG[num-query-groups]=8
MODEL_CONFIG[kv-channels]=128
MODEL_CONFIG[attention-dropout]=0.0
MODEL_CONFIG[init-method-std]=0.02
MODEL_CONFIG[normalization]=RMSNorm
MODEL_CONFIG[norm-epsilon]=1e-5

declare -A TRAIN_CONFIG
TRAIN_CONFIG[lr]=1e-4
TRAIN_CONFIG[optimizer]=adam
TRAIN_CONFIG[adam-beta1]=0.9
TRAIN_CONFIG[adam-beta2]=0.95
TRAIN_CONFIG[weight-decay]=0.1
TRAIN_CONFIG[clip-grad]=1.0
TRAIN_CONFIG[train-iters]=200
TRAIN_CONFIG[micro-batch-size]=1
TRAIN_CONFIG[global-batch-size]=16
TRAIN_CONFIG[seq-length]=2048
TRAIN_CONFIG[bf16]=true
TRAIN_CONFIG[mock-data]=true
TRAIN_CONFIG[vocab-size]=128256

# TRAIN_CONFIG[use-distributed-optimizer]=true
TRAIN_CONFIG[use-torch-fsdp2]=true
TRAIN_CONFIG[no-gradient-accumulation-fusion]=true
# FSDP4 TP2 works!
TRAIN_CONFIG[tensor-model-parallel-size]=2

TRAIN_CONFIG[log-interval]=1
TRAIN_CONFIG[no-one-logger]=true
TRAIN_CONFIG[log-throughput]=true
TRAIN_CONFIG[load]=checkpoints/debug/megatron/  # torch_dist checkpoint -> FSDP2 model
TRAIN_CONFIG[save]=checkpoints/debug/megatron/
TRAIN_CONFIG[no-load-optim]=true
TRAIN_CONFIG[save-interval]=100
TRAIN_CONFIG[eval-interval]=250
TRAIN_CONFIG[eval-iters]=1

MAIN_ARGS=()
for key in ${!MODEL_CONFIG[@]}; do val=${MODEL_CONFIG[$key]}; [[ $val == true ]] && MAIN_ARGS+=(--$key) || MAIN_ARGS+=(--$key $val); done
for key in ${!TRAIN_CONFIG[@]}; do val=${TRAIN_CONFIG[$key]}; [[ $val == true ]] && MAIN_ARGS+=(--$key) || MAIN_ARGS+=(--$key $val); done

TRUN_ARGS=()
TRUN_ARGS+=(--nnodes=1 --nproc-per-node=8)
TRUN_ARGS+=(--rdzv-backend=c10d --rdzv-endpoint=localhost:15213)

SCRIPT=pretrain_gpt.py
STDOUT=checkpoints/debug/midtrain.log

mkdir -p $(dirname $STDOUT)
export WANDB_RUN_ID=$(echo ${TRAIN_CONFIG[WANDB_EXP_NAME]} | md5sum | cut -c1-5)
uv run python -m torch.distributed.run ${TRUN_ARGS[@]} $SCRIPT ${MAIN_ARGS[@]}
```

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
