### PR TITLE
Add determinism developer documentation

### DIFF
--- a/docs/developer/determinism/README.md
+++ b/docs/developer/determinism/README.md
@@ -1,0 +1,30 @@
+---
+orphan: true
+---
+
+# Determinism developer reference
+
+> **Audience:** Megatron developers and reviewers working on deterministic
+> training. For setup instructions and supported configurations, use the
+> [Deterministic Training user guide](../../user-guide/deterministic-training.md) —
+> this reference does not repeat it.
+
+Bit-exact determinism means two runs with identical configuration, data, seeds,
+software, and hardware produce identical results. The precise definition and
+the terms used across these pages are in the [glossary](./glossary.md).
+
+## Contents
+
+1. **[`status.md`](./status.md)** — where the effort stands: what deterministic
+   mode enforces today, how it is validated, performance cost, and a pointer to
+   the live roadmap.
+2. **[`op-catalog.md`](./op-catalog.md)** — the per-operation picture, in two
+   buckets: operations with a deterministic code path, and operations
+   deterministic mode does not support yet. The goal is to shrink the second
+   bucket and make the first one fast.
+3. **[`glossary.md`](./glossary.md)** — definitions and abbreviations.
+
+The roadmap itself is tracked dynamically in
+[issue #5785](https://github.com/NVIDIA/Megatron-LM/issues/5785) rather than in
+these documents, so the docs describe what is merged and the issue describes
+what is moving.

--- a/docs/developer/determinism/README.md
+++ b/docs/developer/determinism/README.md
@@ -2,12 +2,12 @@
 orphan: true
 ---
 
-# Determinism developer reference
+# Determinism Developer Reference
 
-> **Audience:** Megatron developers and reviewers working on deterministic
-> training. For setup instructions and supported configurations, use the
-> [Deterministic Training user guide](../../user-guide/deterministic-training.md) —
-> this reference does not repeat it.
+> This reference is for Megatron developers and reviewers working on
+> deterministic training. For setup instructions and supported configurations,
+> use the [Deterministic Training user guide](../../user-guide/deterministic-training.md).
+> This reference does not repeat it.
 
 Bit-exact determinism means two runs with identical configuration, data, seeds,
 software, and hardware produce identical results. The precise definition and
@@ -15,16 +15,14 @@ the terms used across these pages are in the [glossary](./glossary.md).
 
 ## Contents
 
-1. **[`status.md`](./status.md)** — where the effort stands: what deterministic
-   mode enforces today, how it is validated, performance cost, and a pointer to
-   the live roadmap.
-2. **[`op-catalog.md`](./op-catalog.md)** — the per-operation picture, in two
-   buckets: operations with a deterministic code path, and operations
-   deterministic mode does not support yet. The goal is to shrink the second
-   bucket and make the first one fast.
-3. **[`glossary.md`](./glossary.md)** — definitions and abbreviations.
+- [`status.md`](./status.md): what deterministic mode enforces, how it is
+  validated, performance cost, and a pointer to the live roadmap.
+- [`op-catalog.md`](./op-catalog.md): discusses operations with a deterministic
+  code path and operations that deterministic mode does not support. The goal is
+  to shrink the second bucket and make the first one fast.
+- [`glossary.md`](./glossary.md): definitions and abbreviations.
 
-The roadmap itself is tracked dynamically in
+The roadmap is tracked dynamically in
 [issue #5785](https://github.com/NVIDIA/Megatron-LM/issues/5785) rather than in
-these documents, so the docs describe what is merged and the issue describes
-what is moving.
+these documents, so the docs describe what is merged and the issue tracks what
+is in progress.

--- a/docs/developer/determinism/README.md
+++ b/docs/developer/determinism/README.md
@@ -14,12 +14,14 @@ software, and hardware produce identical results.
 
 ## Contents
 
-- [`status.md`](./status.md): what deterministic mode enforces, how it is
-  validated, performance cost, and a pointer to the live roadmap.
-- [`op-catalog.md`](./op-catalog.md): discusses operations with a deterministic
-  code path and operations that deterministic mode does not support. The goal is
-  to shrink the second bucket and make the first one fast.
-- [`glossary.md`](./glossary.md): definitions and abbreviations.
+This reference includes:
+
+- [`status.md`](./status.md): deterministic-mode enforcement, validation,
+  performance cost, and a pointer to the live roadmap
+- [`op-catalog.md`](./op-catalog.md): operations with a deterministic code path,
+  operations that deterministic mode does not support, and the goal to shrink
+  the unsupported set while speeding up the supported set
+- [`glossary.md`](./glossary.md): definitions and abbreviations
 
 The roadmap is tracked dynamically in
 [issue #5785](https://github.com/NVIDIA/Megatron-LM/issues/5785).

--- a/docs/developer/determinism/README.md
+++ b/docs/developer/determinism/README.md
@@ -10,8 +10,7 @@ orphan: true
 > This reference does not repeat it.
 
 Bit-exact determinism means two runs with identical configuration, data, seeds,
-software, and hardware produce identical results. The precise definition and
-the terms used across these pages are in the [glossary](./glossary.md).
+software, and hardware produce identical results.
 
 ## Contents
 
@@ -23,6 +22,4 @@ the terms used across these pages are in the [glossary](./glossary.md).
 - [`glossary.md`](./glossary.md): definitions and abbreviations.
 
 The roadmap is tracked dynamically in
-[issue #5785](https://github.com/NVIDIA/Megatron-LM/issues/5785) rather than in
-these documents, so the docs describe what is merged and the issue tracks what
-is in progress.
+[issue #5785](https://github.com/NVIDIA/Megatron-LM/issues/5785).

--- a/docs/developer/determinism/glossary.md
+++ b/docs/developer/determinism/glossary.md
@@ -2,42 +2,50 @@
 orphan: true
 ---
 
-# Determinism glossary
+# Determinism Glossary
 
 Definitions for the determinism developer reference. The user guide avoids
 these abbreviations where possible.
 
-## The determinism contract
+## Determinism Contract
 
-**Bitwise determinism.** Given fixed inputs and seeds, a run yields identical
-numerical results every time, with everything else held fixed: input data and
-order, model recipe and configuration, parallelism layout (TP/PP/DP/EP/CP/VPP),
-container image and library versions (Megatron-Core, CUDA, cuDNN, NCCL,
-Transformer Engine, PyTorch, driver), NCCL settings, and hardware type and
-topology. The contract is about numerical results, not the computation graph:
-kernel scheduling and execution order may vary as long as every floating-point
-reduction happens in the same order, because floating-point addition is not
-associative and reduction order is the root cause of nearly all training
-non-determinism.
+- **Bitwise determinism**
 
-**Verification.** In practice determinism is verified by tracking the training
-metrics — loss, gradient norm, params norm, num-zeros — for **bitwise-identical
-curves** across two independent runs. The loss works like a checksum of the
-model state: it is a reduction over the sampled logits, so a mismatch anywhere
-propagates into a bitwise difference in the loss/grad curve within a few steps.
-Console logs print at limited precision, so for a strict comparison use the
-full-precision serialized metrics (for example the TensorBoard event files)
-rather than the printed values.
+  Given fixed inputs and seeds, a run yields identical numerical results
+  every time, with everything else held constant. This includes input data
+  and order, model recipe and configuration, parallelism layout (TP, PP,
+  DP, EP, CP, VPP), container image and library versions (Megatron-Core,
+  CUDA, cuDNN, NCCL, Transformer Engine, PyTorch, driver), NCCL settings,
+  and hardware type and topology.
+
+  The contract is about numerical results, not the computation graph.
+  Kernel scheduling and execution order may vary as long as every
+  floating-point reduction happens in the same order. Floating-point
+  addition is not associative, and reduction order is the root cause of
+  nearly all training non-determinism.
+
+- **Verification**
+
+  Verify determinism by tracking training metrics (loss, gradient norm,
+  params norm, num-zeros) for *bitwise-identical curves* across two
+  independent runs. The loss works like a checksum of the model state
+  because it is a reduction over the sampled logits. A mismatch anywhere
+  propagates into a bitwise difference in the loss and gradient curve
+  within a few steps.
+
+  Console logs print at limited precision, so for a strict comparison use
+  the full-precision serialized metrics (for example the TensorBoard event
+  files) rather than the printed values.
 
 ## Terms
 
 | Term | Meaning |
 | --- | --- |
-| Deterministic mode | Execution with `--deterministic-mode`: argument validation and environment defaults from `megatron/training/determinism.py`, plus `torch.use_deterministic_algorithms(True)`. Library code selects deterministic branches via `config.deterministic_mode` or `torch.are_deterministic_algorithms_enabled()`. |
+| Deterministic mode | Execution with `--deterministic-mode`. The argument validation and environment defaults from `megatron/training/determinism.py`, plus `torch.use_deterministic_algorithms(True)`. The library code selects deterministic branches using `config.deterministic_mode` or `torch.are_deterministic_algorithms_enabled()`. |
 | Default mode | Execution without `--deterministic-mode`. |
 | Bit-exact / bitwise identical | Byte-identical values for the compared tensors or serialized metrics (see "Verification" above). |
-| Reproducible | Same result under the same conditions (allocation, caches, environment). Weaker than the contract above: a run can repeat within one allocation and still differ on a different physical topology. |
-| Cross-allocation | Comparison of runs on independently assigned resources — a fresh scheduler allocation, generally different physical nodes and network rings. This is the determinism target, and it is the bar a test must meet to count as a determinism certificate: repeating work inside one allocation exercises less than the contract promises. |
+| Reproducible | Same result under the same conditions (allocation, caches, environment). This guarantee is weaker than the contract above. A run can repeat within one allocation and still differ on a different physical topology. |
+| Cross-allocation | Comparison of runs on independently assigned resources: a fresh scheduler allocation with generally different physical nodes and network rings. This is the determinism target and the bar a test must meet to count as a determinism certificate. Repeating work inside one allocation exercises less than the contract promises. |
 | Collision-free (unique-index) write | An indexed write (`scatter`, `index_put_(accumulate=False)`) whose indices are unique, so no floating-point accumulation happens and ordering cannot change the result. Deterministic without a special kernel. |
 | Fail closed | When deterministic mode encounters a feature it cannot vouch for, it rejects the configuration at validation time instead of silently running it. |
 
@@ -45,7 +53,7 @@ rather than the printed values.
 
 | Term | Meaning |
 | --- | --- |
-| MCore | Megatron Core, the model-parallel training library in this repository. |
+| MCore | Megatron Core: the model-parallel training library in this repository. |
 | DP | Data parallelism: replicas process different batches and synchronize gradients. |
 | TP | Tensor parallelism: one layer is partitioned across devices. |
 | PP | Pipeline parallelism: consecutive layer ranges run on different devices. |
@@ -62,7 +70,7 @@ rather than the printed values.
 | --- | --- |
 | MoE | Mixture of Experts: a layer routes tokens to one or more expert networks. |
 | MLA | Multi-Latent Attention: low-rank latent q/kv projections (DeepSeek family). |
-| DSV3 / DSV4 | DeepSeek-V3- / DeepSeek-V4-style model configurations. DSV3 combines MLA with fine-grained MoE; DSV4 additionally uses DSA sparse attention. |
+| DSV3 / DSV4 | DeepSeek-V3- / DeepSeek-V4-style model configurations. DSV3 combines MLA with fine-grained MoE. DSV4 additionally uses DSA sparse attention. |
 | DSA | DeepSeek Sparse Attention: a lightning indexer scores tokens and top-k selection sparsifies core attention. |
 | MTP | Multi-Token Prediction: auxiliary layers predicting additional future tokens. |
 | SSM | State-space model layers (Mamba family). |

--- a/docs/developer/determinism/glossary.md
+++ b/docs/developer/determinism/glossary.md
@@ -1,0 +1,69 @@
+---
+orphan: true
+---
+
+# Determinism glossary
+
+Definitions for the determinism developer reference. The user guide avoids
+these abbreviations where possible.
+
+## The determinism contract
+
+**Bitwise determinism.** Given fixed inputs and seeds, a run yields identical
+numerical results every time, with everything else held fixed: input data and
+order, model recipe and configuration, parallelism layout (TP/PP/DP/EP/CP/VPP),
+container image and library versions (Megatron-Core, CUDA, cuDNN, NCCL,
+Transformer Engine, PyTorch, driver), NCCL settings, and hardware type and
+topology. The contract is about numerical results, not the computation graph:
+kernel scheduling and execution order may vary as long as every floating-point
+reduction happens in the same order, because floating-point addition is not
+associative and reduction order is the root cause of nearly all training
+non-determinism.
+
+**Verification.** In practice determinism is verified by tracking the training
+metrics — loss, gradient norm, params norm, num-zeros — for **bitwise-identical
+curves** across two independent runs. The loss works like a checksum of the
+model state: it is a reduction over the sampled logits, so a mismatch anywhere
+propagates into a bitwise difference in the loss/grad curve within a few steps.
+Console logs print at limited precision, so for a strict comparison use the
+full-precision serialized metrics (for example the TensorBoard event files)
+rather than the printed values.
+
+## Terms
+
+| Term | Meaning |
+| --- | --- |
+| Deterministic mode | Execution with `--deterministic-mode`: argument validation and environment defaults from `megatron/training/determinism.py`, plus `torch.use_deterministic_algorithms(True)`. Library code selects deterministic branches via `config.deterministic_mode` or `torch.are_deterministic_algorithms_enabled()`. |
+| Default mode | Execution without `--deterministic-mode`. |
+| Bit-exact / bitwise identical | Byte-identical values for the compared tensors or serialized metrics (see "Verification" above). |
+| Reproducible | Same result under the same conditions (allocation, caches, environment). Weaker than the contract above: a run can repeat within one allocation and still differ on a different physical topology. |
+| Cross-allocation | Comparison of runs on independently assigned resources — a fresh scheduler allocation, generally different physical nodes and network rings. This is the determinism target, and it is the bar a test must meet to count as a determinism certificate: repeating work inside one allocation exercises less than the contract promises. |
+| Collision-free (unique-index) write | An indexed write (`scatter`, `index_put_(accumulate=False)`) whose indices are unique, so no floating-point accumulation happens and ordering cannot change the result. Deterministic without a special kernel. |
+| Fail closed | When deterministic mode encounters a feature it cannot vouch for, it rejects the configuration at validation time instead of silently running it. |
+
+## Parallelism and infrastructure
+
+| Term | Meaning |
+| --- | --- |
+| MCore | Megatron Core, the model-parallel training library in this repository. |
+| DP | Data parallelism: replicas process different batches and synchronize gradients. |
+| TP | Tensor parallelism: one layer is partitioned across devices. |
+| PP | Pipeline parallelism: consecutive layer ranges run on different devices. |
+| VPP | Virtual pipeline parallelism: interleaved pipeline chunks that reduce pipeline idle time. |
+| EP | Expert parallelism: experts are partitioned across devices. |
+| CP | Context parallelism: one sequence is partitioned across devices. |
+| A2A | All-to-all collective (MoE token dispatch/combine). A rank-indexed permutation, not a floating-point reduction. |
+| TE | Transformer Engine, NVIDIA's transformer-kernel library. |
+| wgrad / dgrad | Weight gradient / input gradient of a linear layer's backward pass. |
+
+## Model abbreviations
+
+| Term | Meaning |
+| --- | --- |
+| MoE | Mixture of Experts: a layer routes tokens to one or more expert networks. |
+| MLA | Multi-Latent Attention: low-rank latent q/kv projections (DeepSeek family). |
+| DSV3 / DSV4 | DeepSeek-V3- / DeepSeek-V4-style model configurations. DSV3 combines MLA with fine-grained MoE; DSV4 additionally uses DSA sparse attention. |
+| DSA | DeepSeek Sparse Attention: a lightning indexer scores tokens and top-k selection sparsifies core attention. |
+| MTP | Multi-Token Prediction: auxiliary layers predicting additional future tokens. |
+| SSM | State-space model layers (Mamba family). |
+| GDN | Gated delta net, an SSM variant (`megatron/core/ssm/gated_delta_net.py`). |

--- a/docs/developer/determinism/glossary.md
+++ b/docs/developer/determinism/glossary.md
@@ -9,6 +9,8 @@ these abbreviations where possible.
 
 ## Determinism Contract
 
+The contract uses these definitions:
+
 - **Bitwise determinism**
 
   Given fixed inputs and seeds, a run yields identical numerical results
@@ -39,17 +41,21 @@ these abbreviations where possible.
 
 ## Terms
 
+The following terms appear throughout the reference:
+
 | Term | Meaning |
 | --- | --- |
 | Deterministic mode | Execution with `--deterministic-mode`. The argument validation and environment defaults from `megatron/training/determinism.py`, plus `torch.use_deterministic_algorithms(True)`. The library code selects deterministic branches using `config.deterministic_mode` or `torch.are_deterministic_algorithms_enabled()`. |
 | Default mode | Execution without `--deterministic-mode`. |
-| Bit-exact / bitwise identical | Byte-identical values for the compared tensors or serialized metrics (see "Verification" above). |
+| Bit-exact / bitwise identical | Byte-identical values for the compared tensors or serialized metrics (refer to "Verification"). |
 | Reproducible | Same result under the same conditions (allocation, caches, environment). This guarantee is weaker than the contract above. A run can repeat within one allocation and still differ on a different physical topology. |
 | Cross-allocation | Comparison of runs on independently assigned resources: a fresh scheduler allocation with generally different physical nodes and network rings. This is the determinism target and the bar a test must meet to count as a determinism certificate. Repeating work inside one allocation exercises less than the contract promises. |
 | Collision-free (unique-index) write | An indexed write (`scatter`, `index_put_(accumulate=False)`) whose indices are unique, so no floating-point accumulation happens and ordering cannot change the result. Deterministic without a special kernel. |
 | Fail closed | When deterministic mode encounters a feature it cannot vouch for, it rejects the configuration at validation time instead of silently running it. |
 
-## Parallelism and infrastructure
+## Parallelism and Infrastructure
+
+The following abbreviations appear in parallelism and infrastructure discussions:
 
 | Term | Meaning |
 | --- | --- |
@@ -60,16 +66,18 @@ these abbreviations where possible.
 | VPP | Virtual pipeline parallelism: interleaved pipeline chunks that reduce pipeline idle time. |
 | EP | Expert parallelism: experts are partitioned across devices. |
 | CP | Context parallelism: one sequence is partitioned across devices. |
-| A2A | All-to-all collective (MoE token dispatch/combine). A rank-indexed permutation, not a floating-point reduction. |
+| A2A | All-to-all collective (MoE token dispatch and combine). A rank-indexed permutation, not a floating-point reduction. |
 | TE | Transformer Engine, NVIDIA's transformer-kernel library. |
 | wgrad / dgrad | Weight gradient / input gradient of a linear layer's backward pass. |
 
-## Model abbreviations
+## Model Abbreviations
+
+The following abbreviations appear in model discussions:
 
 | Term | Meaning |
 | --- | --- |
 | MoE | Mixture of Experts: a layer routes tokens to one or more expert networks. |
-| MLA | Multi-Latent Attention: low-rank latent q/kv projections (DeepSeek family). |
+| MLA | Multi-Latent Attention: low-rank latent qkv projections (DeepSeek family). |
 | DSV3 / DSV4 | DeepSeek-V3- / DeepSeek-V4-style model configurations. DSV3 combines MLA with fine-grained MoE. DSV4 additionally uses DSA sparse attention. |
 | DSA | DeepSeek Sparse Attention: a lightning indexer scores tokens and top-k selection sparsifies core attention. |
 | MTP | Multi-Token Prediction: auxiliary layers predicting additional future tokens. |

--- a/docs/developer/determinism/op-catalog.md
+++ b/docs/developer/determinism/op-catalog.md
@@ -2,64 +2,68 @@
 orphan: true
 ---
 
-# Determinism op catalog
+# Determinism Operation Catalog
 
-> **Audience:** developers reviewing or extending deterministic-mode coverage.
-> Terms are defined in the [glossary](./glossary.md). This page describes what
-> is merged on `main`; in-progress work is tracked in
-> [issue #5785](https://github.com/NVIDIA/Megatron-LM/issues/5785).
+> This content is for developers reviewing or extending deterministic-mode
+> coverage. Terms are defined in the [glossary](./glossary.md).
 
 The catalog is organized into two buckets. The project goal is to keep shrinking
-the second bucket (operations deterministic mode cannot support yet) and to keep
+the second bucket (operations that deterministic mode cannot support yet) and to keep
 making the first bucket (operations with a deterministic code path) faster.
 
-Most operations in a training step need no entry here at all: elementwise ops,
+Most operations in a training step need no entry here at all. Elementwise ops,
 GEMMs under the pinned cuBLAS workspace, rank-indexed collectives (all-gather,
 all-to-all, broadcast), stable sorts, and unique-index writes are deterministic
 as-is. The tables list only the operations where a choice is made.
 
-## 1. Operations with a deterministic code path
+## Deterministic Code Path Operations
 
 Selected by `torch.are_deterministic_algorithms_enabled()` or
-`config.deterministic_mode`; the default-mode path stays in the other branch.
+`config.deterministic_mode`. The default-mode path stays in the other branch.
 
-| Operation | Where | Deterministic path | Default path |
+| Operation | Where | Deterministic Path | Default Path |
 | --- | --- | --- | --- |
 | MoE token unpermute (combine) | `megatron/core/transformer/moe/moe_utils.py:517` | `index_add_` — deterministic under torch deterministic algorithms and CUDA-graph safe | `scatter_add_` (atomic accumulation) |
-| MoE routing map / probabilities | `megatron/core/transformer/moe/moe_utils.py:823` | `index_put_(accumulate=False)` row-wise writes | out-of-place `scatter` |
+| MoE routing map and probabilities | `megatron/core/transformer/moe/moe_utils.py:823` | `index_put_(accumulate=False)` row-wise writes | out-of-place `scatter` |
 | Vocab-parallel embedding | `megatron/core/tensor_parallel/layers.py:299` | direct indexing `weight[idx]` (deterministic backward) | `F.embedding` (non-deterministic atomic backward) |
 | Gated-delta-net kernel | `megatron/core/ssm/gated_delta_net.py:212` | torch `chunk_gated_delta_rule` | FLA fused kernel |
 | Gated-delta-net causal conv1d | `megatron/core/ssm/gated_delta_net.py:429` | `F.conv1d` (plus transposes) | FLA `causal_conv1d` |
 | Mamba/SSM Triton ops | `megatron/core/ssm/ops/determinism.py` | one fixed autotune config plus a zero-initialized tiled workspace reduced with an ordered `sum` | timing-based autotune, uninitialized workspace |
 | Transformer Engine attention | `megatron/core/extensions/transformer_engine.py:1698` | requires `NVTE_ALLOW_NONDETERMINISTIC_ALGO=0`, under which TE selects only backends that support deterministic execution (including deterministic FlashAttention backward) | TE picks freely, including atomic-accumulation attention backward |
-| Inference DP scheduling / RL rollout order | `megatron/core/inference/engines/dynamic_engine.py`, `megatron/rl/rl_utils.py` | sort by stable key | completion order |
+| Inference DP scheduling and RL rollout order | `megatron/core/inference/engines/dynamic_engine.py`, `megatron/rl/rl_utils.py` | sort by stable key | completion order |
 
-Environment controls that make the rest of the step deterministic (validated
-and defaulted by `--deterministic-mode`; see
-`megatron/training/determinism.py`): `NCCL_ALGO=Ring` (Tree is rejected — its
-reduction order is not user-controllable), `CUBLAS_WORKSPACE_CONFIG=:4096:8`
-(or `:16:8`), `NVTE_ALLOW_NONDETERMINISTIC_ALGO=0`, and `MAMBA_DETERMINISTIC`
-must not be disabled.
+The following environment controls make the rest of the step deterministic.
+The flag `--deterministic-mode` validates and defaults these settings. For
+details, refer to `megatron/training/determinism.py`.
 
-## 2. Operations without determinism support
+- `NCCL_ALGO=Ring`. Tree is rejected because its reduction order is not
+  user-controllable.
+- `CUBLAS_WORKSPACE_CONFIG=:4096:8` (or `:16:8`).
+- `NVTE_ALLOW_NONDETERMINISTIC_ALGO=0`.
+- `MAMBA_DETERMINISTIC` must not be disabled.
+
+## Operations Without Determinism Support
 
 Deterministic mode either rejects these at validation (fails closed) or they
 are known open gaps.
 
-| Operation / feature | Where enforced or observed | Status |
+| Operation or Feature | Where Enforced or Observed | Status |
 | --- | --- | --- |
-| Fused cross-entropy loss (`--cross-entropy-loss-fusion`) | rejected by `--deterministic-mode` (`megatron/training/determinism.py`) | The fused kernel is non-deterministic. Open question whether a deterministic variant is feasible; until then the native vocab-parallel path is used. |
+| Fused cross-entropy loss (`--cross-entropy-loss-fusion`) | rejected by `--deterministic-mode` (`megatron/training/determinism.py`) | The fused kernel is non-deterministic. Whether a deterministic variant is feasible remains an open question. Until then, the framework uses the native vocab-parallel path. |
 | TP communication overlap (`--tp-comm-overlap`) | rejected by `--deterministic-mode` | Overlapped collective ordering is not reproducible. |
 | Packed sequence (`thd`) in gated-delta-net | `megatron/core/ssm/gated_delta_net.py:313` assert | No deterministic packed-sequence SSM path exists yet. |
-| Cross-allocation floating-point collectives (TP all-reduce, DP grad reduce-scatter) | open gap | `NCCL_ALGO=Ring` pins the algorithm but not the physical ring an allocation gets, so bit-exactness across *different* allocations is not guaranteed by the env pin alone for these reductions. Runs repeated within one allocation, or on allocations with identical topology, are covered. |
+| Cross-allocation floating-point collectives (TP all-reduce, DP grad reduce-scatter) | open gap | `NCCL_ALGO=Ring` pins the algorithm but not the physical ring an allocation receives. The environment variable alone does not guarantee bit-exactness across *different* allocations for these reductions. Runs repeated within one allocation, or on allocations with identical topology, remain bit-exact. |
 
-## 3. Performance notes
+## Performance Notes
 
-The deterministic paths above cost roughly 15% step time versus default mode,
-varying by model (MoE-heavy models pay more; measured examples range from ~4%
-on a large dense model to ~17% on a hybrid MoE model). The measured hotspots
-are the deterministic MoE scatter/unpermute path, the sorted router top-k,
-attention backward, and grouped-GEMM wgrad. Reducing this cost is a tracked
-workstream in [issue #5785](https://github.com/NVIDIA/Megatron-LM/issues/5785);
-a change to any row above needs a bit-exact test and a det-vs-default
-performance comparison (`tests/performance_tests/shell_test_utils/determinism/`).
+The deterministic paths above cost roughly 15% of step time compared to
+default mode, which varies by model. MoE-heavy models pay more. Measured
+examples range from approximately 4% on a large dense model to approximately
+17% on a hybrid MoE model. The measured hotspots are the deterministic MoE
+scatter and unpermute path, the sorted router top-k, attention backward, and
+grouped-GEMM wgrad.
+
+Reducing this cost is a tracked workstream in
+[issue #5785](https://github.com/NVIDIA/Megatron-LM/issues/5785). A change to
+any row above needs a bit-exact test and a deterministic-vs-default performance
+comparison (`tests/performance_tests/shell_test_utils/determinism/`).

--- a/docs/developer/determinism/op-catalog.md
+++ b/docs/developer/determinism/op-catalog.md
@@ -1,0 +1,65 @@
+---
+orphan: true
+---
+
+# Determinism op catalog
+
+> **Audience:** developers reviewing or extending deterministic-mode coverage.
+> Terms are defined in the [glossary](./glossary.md). This page describes what
+> is merged on `main`; in-progress work is tracked in
+> [issue #5785](https://github.com/NVIDIA/Megatron-LM/issues/5785).
+
+The catalog is organized into two buckets. The project goal is to keep shrinking
+the second bucket (operations deterministic mode cannot support yet) and to keep
+making the first bucket (operations with a deterministic code path) faster.
+
+Most operations in a training step need no entry here at all: elementwise ops,
+GEMMs under the pinned cuBLAS workspace, rank-indexed collectives (all-gather,
+all-to-all, broadcast), stable sorts, and unique-index writes are deterministic
+as-is. The tables list only the operations where a choice is made.
+
+## 1. Operations with a deterministic code path
+
+Selected by `torch.are_deterministic_algorithms_enabled()` or
+`config.deterministic_mode`; the default-mode path stays in the other branch.
+
+| Operation | Where | Deterministic path | Default path |
+| --- | --- | --- | --- |
+| MoE token unpermute (combine) | `megatron/core/transformer/moe/moe_utils.py:517` | `index_add_` — deterministic under torch deterministic algorithms and CUDA-graph safe | `scatter_add_` (atomic accumulation) |
+| MoE routing map / probabilities | `megatron/core/transformer/moe/moe_utils.py:823` | `index_put_(accumulate=False)` row-wise writes | out-of-place `scatter` |
+| Vocab-parallel embedding | `megatron/core/tensor_parallel/layers.py:299` | direct indexing `weight[idx]` (deterministic backward) | `F.embedding` (non-deterministic atomic backward) |
+| Gated-delta-net kernel | `megatron/core/ssm/gated_delta_net.py:212` | torch `chunk_gated_delta_rule` | FLA fused kernel |
+| Gated-delta-net causal conv1d | `megatron/core/ssm/gated_delta_net.py:429` | `F.conv1d` (plus transposes) | FLA `causal_conv1d` |
+| Mamba/SSM Triton ops | `megatron/core/ssm/ops/determinism.py` | one fixed autotune config plus a zero-initialized tiled workspace reduced with an ordered `sum` | timing-based autotune, uninitialized workspace |
+| Transformer Engine attention | `megatron/core/extensions/transformer_engine.py:1698` | requires `NVTE_ALLOW_NONDETERMINISTIC_ALGO=0`, under which TE selects only backends that support deterministic execution (including deterministic FlashAttention backward) | TE picks freely, including atomic-accumulation attention backward |
+| Inference DP scheduling / RL rollout order | `megatron/core/inference/engines/dynamic_engine.py`, `megatron/rl/rl_utils.py` | sort by stable key | completion order |
+
+Environment controls that make the rest of the step deterministic (validated
+and defaulted by `--deterministic-mode`; see
+`megatron/training/determinism.py`): `NCCL_ALGO=Ring` (Tree is rejected — its
+reduction order is not user-controllable), `CUBLAS_WORKSPACE_CONFIG=:4096:8`
+(or `:16:8`), `NVTE_ALLOW_NONDETERMINISTIC_ALGO=0`, and `MAMBA_DETERMINISTIC`
+must not be disabled.
+
+## 2. Operations without determinism support
+
+Deterministic mode either rejects these at validation (fails closed) or they
+are known open gaps.
+
+| Operation / feature | Where enforced or observed | Status |
+| --- | --- | --- |
+| Fused cross-entropy loss (`--cross-entropy-loss-fusion`) | rejected by `--deterministic-mode` (`megatron/training/determinism.py`) | The fused kernel is non-deterministic. Open question whether a deterministic variant is feasible; until then the native vocab-parallel path is used. |
+| TP communication overlap (`--tp-comm-overlap`) | rejected by `--deterministic-mode` | Overlapped collective ordering is not reproducible. |
+| Packed sequence (`thd`) in gated-delta-net | `megatron/core/ssm/gated_delta_net.py:313` assert | No deterministic packed-sequence SSM path exists yet. |
+| Cross-allocation floating-point collectives (TP all-reduce, DP grad reduce-scatter) | open gap | `NCCL_ALGO=Ring` pins the algorithm but not the physical ring an allocation gets, so bit-exactness across *different* allocations is not guaranteed by the env pin alone for these reductions. Runs repeated within one allocation, or on allocations with identical topology, are covered. |
+
+## 3. Performance notes
+
+The deterministic paths above cost roughly 15% step time versus default mode,
+varying by model (MoE-heavy models pay more; measured examples range from ~4%
+on a large dense model to ~17% on a hybrid MoE model). The measured hotspots
+are the deterministic MoE scatter/unpermute path, the sorted router top-k,
+attention backward, and grouped-GEMM wgrad. Reducing this cost is a tracked
+workstream in [issue #5785](https://github.com/NVIDIA/Megatron-LM/issues/5785);
+a change to any row above needs a bit-exact test and a det-vs-default
+performance comparison (`tests/performance_tests/shell_test_utils/determinism/`).

--- a/docs/developer/determinism/op-catalog.md
+++ b/docs/developer/determinism/op-catalog.md
@@ -7,14 +7,24 @@ orphan: true
 > This content is for developers reviewing or extending deterministic-mode
 > coverage. Terms are defined in the [glossary](./glossary.md).
 
-The catalog is organized into two buckets. The project goal is to keep shrinking
-the second bucket (operations that deterministic mode cannot support yet) and to keep
-making the first bucket (operations with a deterministic code path) faster.
+The catalog has two buckets:
 
-Most operations in a training step need no entry here at all. Elementwise ops,
-GEMMs under the pinned cuBLAS workspace, rank-indexed collectives (all-gather,
-all-to-all, broadcast), stable sorts, and unique-index writes are deterministic
-as-is. The tables list only the operations where a choice is made.
+- Operations with a deterministic code path
+- Operations that deterministic mode cannot support yet
+
+The project goal is to shrink the second bucket and make the first bucket
+faster.
+
+Most operations in a training step need no entry here. The following are
+deterministic as-is:
+
+- Elementwise ops
+- GEMMs under the pinned cuBLAS workspace
+- Rank-indexed collectives (all-gather, all-to-all, broadcast)
+- Stable sorts
+- Unique-index writes
+
+The tables list only the operations where a choice is made.
 
 ## Deterministic Code Path Operations
 
@@ -36,7 +46,7 @@ The following environment controls make the rest of the step deterministic.
 The flag `--deterministic-mode` validates and defaults these settings. For
 details, refer to `megatron/training/determinism.py`.
 
-- `NCCL_ALGO=Ring`. Tree is rejected because its reduction order is not
+- `NCCL_ALGO=Ring`. The tree is rejected because its reduction order is not
   user-controllable.
 - `CUBLAS_WORKSPACE_CONFIG=:4096:8` (or `:16:8`).
 - `NVTE_ALLOW_NONDETERMINISTIC_ALGO=0`.
@@ -57,13 +67,17 @@ are known open gaps.
 ## Performance Notes
 
 The deterministic paths above cost roughly 15% of step time compared to
-default mode, which varies by model. MoE-heavy models pay more. Measured
-examples range from approximately 4% on a large dense model to approximately
-17% on a hybrid MoE model. The measured hotspots are the deterministic MoE
-scatter and unpermute path, the sorted router top-k, attention backward, and
-grouped-GEMM wgrad.
+default mode, which varies by model. Models that rely heavily on Mixture of
+Experts (MoE) pay more. Measured examples range from approximately four percent
+on a large dense model to approximately 17% on a hybrid MoE model. The measured
+hotspots are:
+
+- The deterministic MoE scatter and unpermute path
+- The sorted router top-k
+- Attention backward
+- Grouped-GEMM weight gradient (wgrad)
 
 Reducing this cost is a tracked workstream in
 [issue #5785](https://github.com/NVIDIA/Megatron-LM/issues/5785). A change to
-any row above needs a bit-exact test and a deterministic-vs-default performance
-comparison (`tests/performance_tests/shell_test_utils/determinism/`).
+any row above needs a bit-exact test and a comparison of deterministic and
+default performance (`tests/performance_tests/shell_test_utils/determinism/`).

--- a/docs/developer/determinism/op-catalog.md
+++ b/docs/developer/determinism/op-catalog.md
@@ -23,13 +23,13 @@ Selected by `torch.are_deterministic_algorithms_enabled()` or
 
 | Operation | Where | Deterministic Path | Default Path |
 | --- | --- | --- | --- |
-| MoE token unpermute (combine) | `megatron/core/transformer/moe/moe_utils.py:517` | `index_add_` — deterministic under torch deterministic algorithms and CUDA-graph safe | `scatter_add_` (atomic accumulation) |
-| MoE routing map and probabilities | `megatron/core/transformer/moe/moe_utils.py:823` | `index_put_(accumulate=False)` row-wise writes | out-of-place `scatter` |
-| Vocab-parallel embedding | `megatron/core/tensor_parallel/layers.py:299` | direct indexing `weight[idx]` (deterministic backward) | `F.embedding` (non-deterministic atomic backward) |
-| Gated-delta-net kernel | `megatron/core/ssm/gated_delta_net.py:212` | torch `chunk_gated_delta_rule` | FLA fused kernel |
-| Gated-delta-net causal conv1d | `megatron/core/ssm/gated_delta_net.py:429` | `F.conv1d` (plus transposes) | FLA `causal_conv1d` |
+| MoE token unpermute (combine) | `megatron/core/transformer/moe/moe_utils.py` | `index_add_` — deterministic under torch deterministic algorithms and CUDA-graph safe | `scatter_add_` (atomic accumulation) |
+| MoE routing map and probabilities | `megatron/core/transformer/moe/moe_utils.py` | `index_put_(accumulate=False)` row-wise writes | out-of-place `scatter` |
+| Vocab-parallel embedding | `megatron/core/tensor_parallel/layers.py` | direct indexing `weight[idx]` (deterministic backward) | `F.embedding` (non-deterministic atomic backward) |
+| Gated-delta-net kernel | `megatron/core/ssm/gated_delta_net.py` | torch `chunk_gated_delta_rule` | FLA fused kernel |
+| Gated-delta-net causal conv1d | `megatron/core/ssm/gated_delta_net.py` | `F.conv1d` (plus transposes) | FLA `causal_conv1d` |
 | Mamba/SSM Triton ops | `megatron/core/ssm/ops/determinism.py` | one fixed autotune config plus a zero-initialized tiled workspace reduced with an ordered `sum` | timing-based autotune, uninitialized workspace |
-| Transformer Engine attention | `megatron/core/extensions/transformer_engine.py:1698` | requires `NVTE_ALLOW_NONDETERMINISTIC_ALGO=0`, under which TE selects only backends that support deterministic execution (including deterministic FlashAttention backward) | TE picks freely, including atomic-accumulation attention backward |
+| Transformer Engine attention | `megatron/core/extensions/transformer_engine.py` | requires `NVTE_ALLOW_NONDETERMINISTIC_ALGO=0`, under which TE selects only backends that support deterministic execution (including deterministic FlashAttention backward) | TE picks freely, including atomic-accumulation attention backward |
 | Inference DP scheduling and RL rollout order | `megatron/core/inference/engines/dynamic_engine.py`, `megatron/rl/rl_utils.py` | sort by stable key | completion order |
 
 The following environment controls make the rest of the step deterministic.
@@ -51,7 +51,7 @@ are known open gaps.
 | --- | --- | --- |
 | Fused cross-entropy loss (`--cross-entropy-loss-fusion`) | rejected by `--deterministic-mode` (`megatron/training/determinism.py`) | The fused kernel is non-deterministic. Whether a deterministic variant is feasible remains an open question. Until then, the framework uses the native vocab-parallel path. |
 | TP communication overlap (`--tp-comm-overlap`) | rejected by `--deterministic-mode` | Overlapped collective ordering is not reproducible. |
-| Packed sequence (`thd`) in gated-delta-net | `megatron/core/ssm/gated_delta_net.py:313` assert | No deterministic packed-sequence SSM path exists yet. |
+| Packed sequence (`thd`) in gated-delta-net | assertion in `megatron/core/ssm/gated_delta_net.py` | No deterministic packed-sequence SSM path exists yet. |
 | Cross-allocation floating-point collectives (TP all-reduce, DP grad reduce-scatter) | open gap | `NCCL_ALGO=Ring` pins the algorithm but not the physical ring an allocation receives. The environment variable alone does not guarantee bit-exactness across *different* allocations for these reductions. Runs repeated within one allocation, or on allocations with identical topology, remain bit-exact. |
 
 ## Performance Notes

--- a/docs/developer/determinism/status.md
+++ b/docs/developer/determinism/status.md
@@ -1,0 +1,46 @@
+---
+orphan: true
+---
+
+# Determinism status
+
+> **Audience:** Megatron developers. Setup and supported configurations are in
+> the [user guide](../../user-guide/deterministic-training.md); definitions are
+> in the [glossary](./glossary.md); per-operation detail is in the
+> [op catalog](./op-catalog.md). The live roadmap is
+> [issue #5785](https://github.com/NVIDIA/Megatron-LM/issues/5785).
+
+## What deterministic mode does today
+
+`--deterministic-mode` (see `megatron/training/determinism.py`) validates the
+determinism environment variables and fills canonical defaults, rejects the
+features that have no deterministic path (cross-entropy fusion and TP
+communication overlap), and enables `torch.use_deterministic_algorithms(True)`.
+Library code then selects the deterministic branches listed in the
+[op catalog](./op-catalog.md). The user guide documents the exact flags and
+environment values — they are not repeated here.
+
+## Validation
+
+- **Module-level bit-exact suite** (`tests/unit_tests/determinism/`): runs a
+  model or block twice under restored RNG state and asserts bit-identical
+  outputs and gradients — GPTModel, TransformerBlock, and HybridModel across a
+  TP/EP/FSDP/PP/VPP matrix, including FP8 and FP4 recipes, with scheduling
+  stressors to surface latent ordering races.
+- **Performance gate**
+  (`tests/performance_tests/shell_test_utils/determinism/`): runs a small
+  recipe in deterministic and default mode under Nsight Systems, reports a
+  per-range leaderboard, and fails when the deterministic step time exceeds the
+  documented threshold.
+- **End-to-end verification** is done by comparing full-precision training
+  metrics across two independent runs (see the glossary's "Verification"
+  note). Extending checked-in coverage to production-scale architectures is a
+  roadmap item.
+
+## Performance
+
+Deterministic mode currently costs roughly 15% step time, varying by model and
+precision; the goal is under 10%, with a stretch goal near 5%, so determinism
+can be left on in production runs. The hotspot list and optimization progress
+live in the [op catalog](./op-catalog.md) and
+[issue #5785](https://github.com/NVIDIA/Megatron-LM/issues/5785).

--- a/docs/developer/determinism/status.md
+++ b/docs/developer/determinism/status.md
@@ -2,45 +2,45 @@
 orphan: true
 ---
 
-# Determinism status
+# Determinism Status
 
-> **Audience:** Megatron developers. Setup and supported configurations are in
-> the [user guide](../../user-guide/deterministic-training.md); definitions are
-> in the [glossary](./glossary.md); per-operation detail is in the
-> [op catalog](./op-catalog.md). The live roadmap is
-> [issue #5785](https://github.com/NVIDIA/Megatron-LM/issues/5785).
+> Setup and supported configurations are in the
+> [user guide](../../user-guide/deterministic-training.md).
 
-## What deterministic mode does today
+## Deterministic Mode
 
-`--deterministic-mode` (see `megatron/training/determinism.py`) validates the
+`--deterministic-mode` (refer to `megatron/training/determinism.py`) validates the
 determinism environment variables and fills canonical defaults, rejects the
 features that have no deterministic path (cross-entropy fusion and TP
 communication overlap), and enables `torch.use_deterministic_algorithms(True)`.
-Library code then selects the deterministic branches listed in the
-[op catalog](./op-catalog.md). The user guide documents the exact flags and
-environment values — they are not repeated here.
+The library code then selects the deterministic branches listed in the
+[op catalog](./op-catalog.md). Refer to the user guide for exact flags and
+environment values.
 
 ## Validation
 
-- **Module-level bit-exact suite** (`tests/unit_tests/determinism/`): runs a
+- **Module-level bit-exact suite** (`tests/unit_tests/determinism/`): Runs a
   model or block twice under restored RNG state and asserts bit-identical
-  outputs and gradients — GPTModel, TransformerBlock, and HybridModel across a
-  TP/EP/FSDP/PP/VPP matrix, including FP8 and FP4 recipes, with scheduling
-  stressors to surface latent ordering races.
+  outputs and gradients. Coverage includes:
+
+  - GPTModel, TransformerBlock, and HybridModel
+  - Tensor parallelism, expert parallelism, fully sharded data parallel, pipeline
+    parallelism, and virtual pipeline parallelism
+  - FP8 and FP4 recipes
+  - Scheduling stressors to surface latent ordering races
 - **Performance gate**
-  (`tests/performance_tests/shell_test_utils/determinism/`): runs a small
+  (`tests/performance_tests/shell_test_utils/determinism/`): Runs a small
   recipe in deterministic and default mode under Nsight Systems, reports a
   per-range leaderboard, and fails when the deterministic step time exceeds the
   documented threshold.
-- **End-to-end verification** is done by comparing full-precision training
-  metrics across two independent runs (see the glossary's "Verification"
-  note). Extending checked-in coverage to production-scale architectures is a
-  roadmap item.
+- **End-to-end verification**: Compares full-precision training metrics across
+  two independent runs (refer to the glossary's "Verification" note). Extending
+  checked-in coverage to production-scale architectures is a roadmap item.
 
 ## Performance
 
-Deterministic mode currently costs roughly 15% step time, varying by model and
-precision; the goal is under 10%, with a stretch goal near 5%, so determinism
-can be left on in production runs. The hotspot list and optimization progress
+Deterministic mode increases step time by roughly 15%, varying by model and
+precision. The goal is under 10%, with a stretch goal near 5%, so you can leave
+determinism on in production runs. The hotspot list and optimization progress
 live in the [op catalog](./op-catalog.md) and
 [issue #5785](https://github.com/NVIDIA/Megatron-LM/issues/5785).

--- a/docs/developer/determinism/status.md
+++ b/docs/developer/determinism/status.md
@@ -9,10 +9,14 @@ orphan: true
 
 ## Deterministic Mode
 
-`--deterministic-mode` (refer to `megatron/training/determinism.py`) validates the
-determinism environment variables and fills canonical defaults, rejects the
-features that have no deterministic path (cross-entropy fusion and TP
-communication overlap), and enables `torch.use_deterministic_algorithms(True)`.
+`--deterministic-mode` (refer to `megatron/training/determinism.py`) does the
+following:
+
+- Validates the determinism environment variables and fills canonical defaults
+- Rejects features that have no deterministic path (cross-entropy fusion and
+  tensor parallelism (TP) communication overlap)
+- Enables `torch.use_deterministic_algorithms(True)`
+
 The library code then selects the deterministic branches listed in the
 [op catalog](./op-catalog.md). Refer to the user guide for exact flags and
 environment values.


### PR DESCRIPTION
## What this PR does

Adds a developer-facing determinism reference under `docs/developer/determinism/`.
**Documentation only** — four pages, no code changes:

- `README.md` — orientation and index; points to the existing
  [deterministic-training user guide](https://github.com/NVIDIA/Megatron-LM/blob/main/docs/user-guide/deterministic-training.md)
  for setup, so nothing is duplicated.
- `status.md` — what deterministic mode enforces today, how it is validated,
  and the performance cost. The roadmap lives in #5785 so this page stays static.
- `op-catalog.md` — the per-operation picture in two buckets: ops with a
  deterministic code path, and ops without determinism support. The goal is to
  shrink the second bucket and speed up the first.
- `glossary.md` — the determinism contract, verification via bitwise-identical
  training-metric curves, and term definitions.

## Notes for reviewers

Every file/line cited in these docs is on `main` today — the catalog rows were
checked against the current code before commit. In-progress work (tooling,
perf optimizations) is deliberately not documented here; it is tracked in #5785
and its docs will come with the code that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)