### PR TITLE
Support destination CP in non-colocated bridge communicator

### DIFF
--- a/megatron/core/pipeline_parallel/bridge_communicator.py
+++ b/megatron/core/pipeline_parallel/bridge_communicator.py
@@ -79,7 +79,8 @@ class BridgeCommunicator:
     ):
         """Initialize the bridge communicator between source and destination grids.
 
-        CP is not supported yet. Will be added in follow up PR.
+        Source CP greater than one is not supported. Destination CP gradients are
+        reduced on the destination leader's TP lane before the backward send.
 
         Args:
             src_grid: Source HyperCommGrid
@@ -102,18 +103,17 @@ class BridgeCommunicator:
         assert tensor_ndim in (2, 3), f"tensor_ndim must be 2 or 3, got {tensor_ndim}"
         self.tensor_ndim = tensor_ndim
 
-        # TODO (ykarnati, pthombre) - CP support will be added in follow up PR.
         if 'cp' in self.src_grid.dim_names:
             assert self.src_grid.shape[self.src_grid.dim_names.index('cp')] == 1, (
                 f"Source grid CP size must be 1, got "
                 f"{self.src_grid.shape[self.src_grid.dim_names.index('cp')]}"
             )
 
-        if 'cp' in self.dest_grid.dim_names:
-            assert self.dest_grid.shape[self.dest_grid.dim_names.index('cp')] == 1, (
-                f"Destination grid CP size must be 1, got "
-                f"{self.dest_grid.shape[self.dest_grid.dim_names.index('cp')]}"
-            )
+        self.dest_cp_size = (
+            self.dest_grid.shape[self.dest_grid.dim_names.index('cp')]
+            if 'cp' in self.dest_grid.dim_names
+            else 1
+        )
 
         self.current_rank = dist.get_rank()
         self.comm_map: Dict[int, RankCommInfo] = {}
@@ -163,6 +163,16 @@ class BridgeCommunicator:
         self.dest_tp_leaders, self.dest_local_leader_rank = self.get_leader_rank(
             self.dest_grid, is_src=False
         )
+
+        self.dest_cp_reduce_pg = None
+        if (
+            self.dest_cp_size > 1
+            and self.dest_local_leader_rank is not None
+            and self.current_rank in self.dest_grid_broadcast_ranks
+        ):
+            dest_cp_pg = self.dest_grid.get_pg("cp")
+            if self.dest_local_leader_rank in dist.get_process_group_ranks(dest_cp_pg):
+                self.dest_cp_reduce_pg = dest_cp_pg
 
         bridge_ranks = sorted(set(self.src_tp_leaders) | set(self.dest_tp_leaders))
         self.bridge_pg = self._get_or_create_bridge_pg(bridge_ranks)
@@ -478,6 +488,20 @@ class BridgeCommunicator:
             )
             return received_tensor
 
+    def _reduce_dest_cp_gradient(self, grad_tensor: torch.Tensor) -> torch.Tensor:
+        """Reduce destination CP gradient shards onto the destination leader."""
+        if self.dest_cp_size == 1 or self.dest_cp_reduce_pg is None:
+            return grad_tensor
+
+        grad_tensor = grad_tensor.contiguous()
+        dist.reduce(
+            grad_tensor,
+            dst=self.dest_local_leader_rank,
+            op=dist.ReduceOp.SUM,
+            group=self.dest_cp_reduce_pg,
+        )
+        return grad_tensor
+
     def send_backward(self, grad_tensor: torch.Tensor):
         """Send backward gradient tensor.
 
@@ -494,6 +518,8 @@ class BridgeCommunicator:
 
         rank_info = self.comm_map.get(self.current_rank)
         assert rank_info is not None, f"Rank {self.current_rank} is not in the comm map"
+
+        grad_tensor = self._reduce_dest_cp_gradient(grad_tensor)
 
         if rank_info.role == CommRole.RECEIVER:
             assert (
@@ -751,6 +777,8 @@ class BridgeCommunicator:
 
         rank_info = self.comm_map.get(self.current_rank)
         assert rank_info is not None, f"Rank {self.current_rank} is not in the comm map"
+
+        grad_tensor = self._reduce_dest_cp_gradient(grad_tensor)
 
         if rank_info.role == CommRole.RECEIVER:
             assert (

--- a/megatron/core/pipeline_parallel/bridge_communicator.py
+++ b/megatron/core/pipeline_parallel/bridge_communicator.py
@@ -81,7 +81,8 @@ class BridgeCommunicator:
     ):
         """Initialize the bridge communicator between source and destination grids.
 
-        CP is not supported yet. Will be added in follow up PR.
+        Source CP greater than one is not supported. Destination CP gradients are
+        reduced on the destination leader's TP lane before the backward send.
 
         Args:
             src_grid: Source HyperCommGrid
@@ -104,18 +105,17 @@ class BridgeCommunicator:
         assert tensor_ndim in (2, 3), f"tensor_ndim must be 2 or 3, got {tensor_ndim}"
         self.tensor_ndim = tensor_ndim
 
-        # TODO (ykarnati, pthombre) - CP support will be added in follow up PR.
         if 'cp' in self.src_grid.dim_names:
             assert self.src_grid.shape[self.src_grid.dim_names.index('cp')] == 1, (
                 f"Source grid CP size must be 1, got "
                 f"{self.src_grid.shape[self.src_grid.dim_names.index('cp')]}"
             )
 
-        if 'cp' in self.dest_grid.dim_names:
-            assert self.dest_grid.shape[self.dest_grid.dim_names.index('cp')] == 1, (
-                f"Destination grid CP size must be 1, got "
-                f"{self.dest_grid.shape[self.dest_grid.dim_names.index('cp')]}"
-            )
+        self.dest_cp_size = (
+            self.dest_grid.shape[self.dest_grid.dim_names.index('cp')]
+            if 'cp' in self.dest_grid.dim_names
+            else 1
+        )
 
         self.current_rank = dist.get_rank()
         self.comm_map: Dict[int, RankCommInfo] = {}
@@ -165,6 +165,16 @@ class BridgeCommunicator:
         self.dest_tp_leaders, self.dest_local_leader_rank = self.get_leader_rank(
             self.dest_grid, is_src=False
         )
+
+        self.dest_cp_reduce_pg = None
+        if (
+            self.dest_cp_size > 1
+            and self.dest_local_leader_rank is not None
+            and self.current_rank in self.dest_grid_broadcast_ranks
+        ):
+            dest_cp_pg = self.dest_grid.get_pg("cp")
+            if self.dest_local_leader_rank in dist.get_process_group_ranks(dest_cp_pg):
+                self.dest_cp_reduce_pg = dest_cp_pg
 
         bridge_ranks = sorted(set(self.src_tp_leaders) | set(self.dest_tp_leaders))
         self.bridge_pg = self._get_or_create_bridge_pg(bridge_ranks)
@@ -505,6 +515,20 @@ class BridgeCommunicator:
             )
             return received_tensor
 
+    def _reduce_dest_cp_gradient(self, grad_tensor: torch.Tensor) -> torch.Tensor:
+        """Reduce destination CP gradient shards onto the destination leader."""
+        if self.dest_cp_size == 1 or self.dest_cp_reduce_pg is None:
+            return grad_tensor
+
+        grad_tensor = grad_tensor.contiguous()
+        dist.reduce(
+            grad_tensor,
+            dst=self.dest_local_leader_rank,
+            op=dist.ReduceOp.SUM,
+            group=self.dest_cp_reduce_pg,
+        )
+        return grad_tensor
+
     def send_backward(self, grad_tensor: torch.Tensor):
         """Send backward gradient tensor.
 
@@ -521,6 +545,8 @@ class BridgeCommunicator:
 
         rank_info = self.comm_map.get(self.current_rank)
         assert rank_info is not None, f"Rank {self.current_rank} is not in the comm map"
+
+        grad_tensor = self._reduce_dest_cp_gradient(grad_tensor)
 
         if rank_info.role == CommRole.RECEIVER:
             assert (
@@ -811,6 +837,8 @@ class BridgeCommunicator:
 
         rank_info = self.comm_map.get(self.current_rank)
         assert rank_info is not None, f"Rank {self.current_rank} is not in the comm map"
+
+        grad_tensor = self._reduce_dest_cp_gradient(grad_tensor)
 
         if rank_info.role == CommRole.RECEIVER:
             assert (

--- a/tests/unit_tests/models/mimo/test_mimo_1f1b_schedule.py
+++ b/tests/unit_tests/models/mimo/test_mimo_1f1b_schedule.py
@@ -328,7 +328,6 @@ def get_vision_submodules_spec(
     from megatron.core.transformer.transformer_block import TransformerBlock
 
     tp_size = pg_collection.tp.size() if pg_collection.tp is not None else 1
-    cp_size = pg_collection.cp.size() if pg_collection.cp is not None else 1
     pp_size = pg_collection.pp.size() if pg_collection.pp is not None else 1
     pp_rank = dist.get_rank(pg_collection.pp)
 
@@ -352,7 +351,6 @@ def get_vision_submodules_spec(
         pipeline_dtype=pipeline_dtype,
         bf16=bf16,
         calculate_per_token_loss=per_token_loss,
-        context_parallel_size=cp_size,
         **extra_kwargs,
     )
     vision_encoder_spec = ModuleSpec(
@@ -566,248 +564,6 @@ class DataIterator:
         }
 
 
-class _BatchIterator:
-    """Finite iterator over deterministic, pre-generated microbatches."""
-
-    def __init__(self, batches):
-        self.batches = batches
-        self.index = 0
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        if self.index >= len(self.batches):
-            raise StopIteration
-        batch = self.batches[self.index]
-        self.index += 1
-        return batch
-
-
-def _clone_batch_value(value):
-    """Clone a nested batch so sequential reference/target runs cannot share mutations."""
-    if isinstance(value, torch.Tensor):
-        return value.clone()
-    if isinstance(value, dict):
-        return {key: _clone_batch_value(item) for key, item in value.items()}
-    return value
-
-
-def _generate_and_broadcast_global_batches(
-    global_micro_batch_size,
-    seq_length,
-    hidden_size,
-    vocab_size,
-    encoder_name,
-    num_microbatches,
-    modality_dtype=torch.bfloat16,
-    image_token_id=50257,
-):
-    """Generate deterministic global microbatches once and broadcast them to every rank."""
-    image_seq_length = seq_length // 2
-    batches = []
-
-    for _ in range(num_microbatches):
-        if dist.get_rank() == 0:
-            encoder_hidden_states = torch.randn(
-                image_seq_length,
-                global_micro_batch_size,
-                hidden_size,
-                device='cuda',
-                dtype=modality_dtype,
-            )
-            image_tokens = torch.full(
-                (global_micro_batch_size, image_seq_length),
-                image_token_id,
-                dtype=torch.long,
-                device='cuda',
-            )
-            text_tokens = torch.randint(
-                1,
-                vocab_size,
-                (global_micro_batch_size, seq_length - image_seq_length),
-                device='cuda',
-            )
-            input_ids = torch.cat([image_tokens, text_tokens], dim=1)
-        else:
-            encoder_hidden_states = torch.empty(
-                image_seq_length,
-                global_micro_batch_size,
-                hidden_size,
-                device='cuda',
-                dtype=modality_dtype,
-            )
-            input_ids = torch.empty(
-                global_micro_batch_size, seq_length, dtype=torch.long, device='cuda'
-            )
-
-        dist.broadcast(encoder_hidden_states, src=0)
-        dist.broadcast(input_ids, src=0)
-
-        labels = input_ids.clone()
-        labels[input_ids == image_token_id] = -100
-        loss_mask = torch.ones(
-            global_micro_batch_size, seq_length, device='cuda', dtype=torch.float32
-        )
-        loss_mask[input_ids == image_token_id] = 0.0
-        position_ids = (
-            torch.arange(seq_length, device='cuda')
-            .unsqueeze(0)
-            .expand(global_micro_batch_size, -1)
-            .clone()
-        )
-        batches.append(
-            {
-                "input_ids": input_ids,
-                "labels": labels,
-                "loss_mask": loss_mask,
-                "position_ids": position_ids,
-                "modality_inputs": {
-                    encoder_name: {
-                        "clip_encoder": {
-                            'hidden_states': encoder_hidden_states,
-                            'attention_mask': None,
-                        }
-                    }
-                },
-            }
-        )
-
-    return batches
-
-
-def _slice_batch(global_batch, num_slices, slice_rank):
-    """Slice a global batch for one encoder DP rank."""
-    batch_size = global_batch['input_ids'].shape[0]
-    assert batch_size % num_slices == 0
-    slice_size = batch_size // num_slices
-    start = slice_rank * slice_size
-    end = start + slice_size
-
-    batch = {
-        key: global_batch[key][start:end].contiguous()
-        for key in ['input_ids', 'labels', 'loss_mask', 'position_ids']
-    }
-    batch['modality_inputs'] = {}
-    for modality_name, modality_data in global_batch['modality_inputs'].items():
-        batch['modality_inputs'][modality_name] = {}
-        for encoder_name, encoder_data in modality_data.items():
-            batch['modality_inputs'][modality_name][encoder_name] = {}
-            for key, tensor in encoder_data.items():
-                if isinstance(tensor, torch.Tensor):
-                    batch['modality_inputs'][modality_name][encoder_name][key] = tensor[
-                        :, start:end, :
-                    ].contiguous()
-                else:
-                    batch['modality_inputs'][modality_name][encoder_name][key] = tensor
-    return batch
-
-
-def _build_noncolocated_role_batches(global_batches, encoder_grid, llm_grid):
-    """Build encoder-DP slices or full LLM batches for this disjoint-grid rank."""
-    if is_rank_in_grid(encoder_grid):
-        encoder_dp = encoder_grid.get_pg("dp")
-        return [
-            _slice_batch(batch, encoder_dp.size(), encoder_dp.rank()) for batch in global_batches
-        ]
-    if is_rank_in_grid(llm_grid):
-        return [_clone_batch_value(batch) for batch in global_batches]
-    raise AssertionError(f"Rank {dist.get_rank()} belongs to neither MIMO grid")
-
-
-def _copy_ref_params_to_dist(ref_module, dist_module, ref_tp_group, dist_tp_group):
-    """Copy parameters across differing TP layouts by gathering then re-slicing shards.
-
-    This helper is shared with the colocated MIMO correctness tests. It must be called before
-    constructing the distributed optimizer, which snapshots parameter data into master weights.
-    """
-    ref_tp_size = ref_tp_group.size()
-    dist_tp_size = dist_tp_group.size()
-    dist_tp_rank = dist_tp_group.rank()
-    ref_params = dict(ref_module.named_parameters())
-
-    with torch.no_grad():
-        for name, dist_param in dist_module.named_parameters():
-            assert name in ref_params, f"Distributed parameter {name!r} is missing from reference"
-            ref_param = ref_params[name]
-            if ref_param.shape == dist_param.shape:
-                dist_param.data.copy_(ref_param.data.to(dist_param.dtype))
-                continue
-
-            partition_dim = getattr(dist_param, 'partition_dim', -1)
-            assert partition_dim >= 0, (
-                f"Parameter {name!r} differs in shape but has no TP partition dimension: "
-                f"reference={tuple(ref_param.shape)}, distributed={tuple(dist_param.shape)}"
-            )
-            ref_shards = [torch.empty_like(ref_param.data) for _ in range(ref_tp_size)]
-            dist.all_gather(ref_shards, ref_param.data.contiguous(), group=ref_tp_group)
-            full_param = torch.cat(ref_shards, dim=partition_dim)
-            dist_shard = torch.tensor_split(full_param, dist_tp_size, dim=partition_dim)[
-                dist_tp_rank
-            ]
-            assert dist_shard.shape == dist_param.shape, (
-                f"Parameter {name!r} reshard shape {tuple(dist_shard.shape)} does not match "
-                f"distributed shape {tuple(dist_param.shape)}"
-            )
-            dist_param.data.copy_(dist_shard.to(dist_param.dtype))
-
-
-def _snapshot_first_layer_encoder_grads(mimo_model, encoder_name):
-    """Snapshot first-layer encoder main gradients before the optimizer consumes them."""
-    encoder = mimo_model.modality_submodules[encoder_name].module
-    gradients = {}
-    for name, parameter in encoder.named_parameters():
-        if '.layers.0.' not in name:
-            continue
-        main_grad = getattr(parameter, 'main_grad', None)
-        if main_grad is not None:
-            gradients[name] = main_grad.detach().clone()
-    assert gradients, "Expected non-empty first-layer encoder main_grad snapshot"
-    return gradients
-
-
-def _forward_step_with_per_token_loss(data_iterator, model):
-    """Forward step using the per-token loss contract expected by configure_grad_sync."""
-
-    def loss_func(loss_mask, output_tensor):
-        def _ret(loss, num_tokens, reduced):
-            return loss, num_tokens, {'loss_reduced': reduced}
-
-        zero = torch.tensor(0.0, device='cuda', requires_grad=True)
-        one = torch.tensor(1, device='cuda', dtype=torch.int)
-        if output_tensor is None:
-            return _ret(zero, one, 0.0)
-
-        if isinstance(output_tensor, dict):
-            output = output_tensor.get(
-                MIMO_LANGUAGE_MODULE_KEY, next(iter(output_tensor.values()), None)
-            )
-        else:
-            output = output_tensor
-
-        if output is None:
-            return _ret(zero, one, 0.0)
-
-        loss = output.float().sum()
-        num_tokens = loss_mask.sum().to(torch.int).clamp(min=1) if loss_mask is not None else one
-        return _ret(loss, num_tokens, loss)
-
-    batch = next(data_iterator) if data_iterator is not None else {'input_ids': None}
-    output_tensor, loss_mask = model(**batch)
-    return output_tensor, partial(loss_func, loss_mask)
-
-
-def _assert_finite_losses(losses, llm_grid):
-    """Require finite reported losses on the terminal language stage."""
-    if not (is_rank_in_grid(llm_grid) and is_pp_last_stage(llm_grid.get_pg("pp"))):
-        return
-    assert losses, "Expected losses on last LLM stage"
-    for loss_dict in losses:
-        assert 'loss_reduced' in loss_dict
-        loss = torch.as_tensor(loss_dict['loss_reduced'])
-        assert torch.isfinite(loss).all(), f"Expected finite loss, got {loss}"
-
-
 # ============================================================================
 # Test Runner
 # ============================================================================
@@ -822,7 +578,6 @@ def run_mimo_1f1b_test(
     llm_pp,
     llm_dp,
     llm_offset,
-    encoder_cp=1,
     llm_cp=1,
     hidden_size=256,
     num_layers=2,
@@ -848,7 +603,7 @@ def run_mimo_1f1b_test(
     encoder_name = "images"
 
     encoder_grid = create_hypercomm_grid(
-        offset=encoder_offset, tp=encoder_tp, cp=encoder_cp, pp=encoder_pp, dp=encoder_dp
+        offset=encoder_offset, tp=encoder_tp, cp=1, pp=encoder_pp, dp=encoder_dp
     )
     llm_grid = create_hypercomm_grid(offset=llm_offset, tp=llm_tp, cp=llm_cp, pp=llm_pp, dp=llm_dp)
 
@@ -1013,87 +768,6 @@ def run_mimo_1f1b_test(
         mimo_model.destroy()
 
 
-def _run_deterministic_1f1b_configuration(
-    mimo_model,
-    module_to_grid_map,
-    topology,
-    language_pg,
-    vision_pg,
-    encoder_grid,
-    llm_grid,
-    encoder_name,
-    batches,
-    optimizer,
-    micro_batch_size,
-    seq_length,
-    num_microbatches,
-):
-    """Run one deterministic non-colocated 1F1B step and snapshot encoder gradients."""
-    mimo_model.config.no_sync_func = build_no_sync_func(mimo_model)
-    grad_sync_topology = SimpleNamespace(
-        grids=module_to_grid_map,
-        module_pgs={
-            MIMO_LANGUAGE_MODULE_KEY: language_pg,
-            **{name: vision_pg for name in mimo_model.modality_submodules},
-        },
-    )
-    configure_grad_sync(SimpleNamespace(), mimo_model, grad_sync_topology)
-
-    communicator = MultiModulePipelineCommunicator(
-        module_to_grid_map,
-        topology,
-        mimo_model.config,
-        dim_mapping={'s': 0, 'h': 2, 'b': 1},
-        module_output_ndim={encoder_name: 2},
-    )
-
-    module_pgs = {}
-    language_model_module_name = None
-    if is_rank_in_grid(encoder_grid):
-        module_pgs[encoder_name] = vision_pg
-    if is_rank_in_grid(llm_grid):
-        module_pgs[MIMO_LANGUAGE_MODULE_KEY] = language_pg
-        language_model_module_name = MIMO_LANGUAGE_MODULE_KEY
-    pg_collection = MultiModuleProcessGroupCollection(
-        module_pgs=module_pgs, language_model_module_name=language_model_module_name
-    )
-
-    needs_data = (
-        is_rank_in_grid(encoder_grid) and is_pp_first_stage(encoder_grid.get_pg("pp"))
-    ) or (
-        is_rank_in_grid(llm_grid)
-        and (is_pp_first_stage(llm_grid.get_pg("pp")) or is_pp_last_stage(llm_grid.get_pg("pp")))
-    )
-    data_iterator = _BatchIterator(batches) if needs_data else None
-
-    optimizer.zero_grad()
-    losses = schedule.forward_backward_pipelining_without_interleaving(
-        forward_step_func=_forward_step_with_per_token_loss,
-        data_iterator=data_iterator,
-        model=[mimo_model],
-        num_microbatches=num_microbatches,
-        seq_length=seq_length,
-        micro_batch_size=micro_batch_size,
-        forward_only=False,
-        p2p_communicator=communicator,
-        pg_collection=pg_collection,
-    )
-
-    encoder_grads = (
-        _snapshot_first_layer_encoder_grads(mimo_model, encoder_name)
-        if is_rank_in_grid(encoder_grid)
-        else {}
-    )
-    success, grad_norm, _ = optimizer.step()
-    assert success, "Optimizer step failed"
-    assert grad_norm is not None and grad_norm > 0, f"Expected positive grad norm, got {grad_norm}"
-    assert torch.isfinite(
-        torch.as_tensor(grad_norm)
-    ).all(), f"Expected finite grad norm, got {grad_norm}"
-    _assert_finite_losses(losses, llm_grid)
-    return encoder_grads
-
-
 # ============================================================================
 # Tests
 # ============================================================================
@@ -1206,11 +880,17 @@ class TestMimo1F1BSchedule:
             num_microbatches=4,
         )
 
-    def test_fan_in_dp4_to_dp1_llm_tp2_pp2_8gpu(self):
-        """Fan-in 4→1: Encoder DP=4 → LLM TP=2 PP=2 DP=1, on 8 GPUs.
+    @pytest.mark.parametrize(
+        "llm_tp,llm_cp,hidden_size",
+        [(2, 1, 256), (1, 2, 128)],
+        ids=["tp2-cp1", "tp1-cp2"],
+    )
+    def test_fan_in_dp4_to_dp1_llm_pp2_8gpu(self, llm_tp, llm_cp, hidden_size):
+        """Fan-in 4→1: Encoder DP=4 → LLM PP=2 DP=1 with TP or CP.
 
         High fan-in ratio. Each encoder rank processes MBS=1, bridge concatenates
-        4 × [img_seq, H] → [4*img_seq, H]. LLM has both TP and PP.
+        4 × [img_seq, H] → [4*img_seq, H]. The CP2 case exercises destination
+        CP gradient reconstruction in steady-state and cooldown backward paths.
         """
         if self.world_size != 8:
             pytest.skip(f"Requires 8 GPUs, got {self.world_size}")
@@ -1220,235 +900,18 @@ class TestMimo1F1BSchedule:
             encoder_pp=1,
             encoder_dp=4,
             encoder_offset=0,
-            llm_tp=2,
+            llm_tp=llm_tp,
+            llm_cp=llm_cp,
             llm_pp=2,
             llm_dp=1,
             llm_offset=4,
-            hidden_size=256,
+            hidden_size=hidden_size,
             num_layers=2,
             vocab_size=1000,
             seq_length=64,
             micro_batch_size=4,
             num_microbatches=4,
         )
-
-    def test_fan_in_dp4_to_cp2_llm_pp2_8gpu(self):
-        """Destination CP=2 exercises steady-state and cooldown bridge backward paths."""
-        if self.world_size != 8:
-            pytest.skip(f"Requires 8 GPUs, got {self.world_size}")
-
-        run_mimo_1f1b_test(
-            encoder_tp=1,
-            encoder_cp=1,
-            encoder_pp=1,
-            encoder_dp=4,
-            encoder_offset=0,
-            llm_tp=1,
-            llm_cp=2,
-            llm_pp=2,
-            llm_dp=1,
-            llm_offset=4,
-            hidden_size=128,
-            num_layers=2,
-            vocab_size=1000,
-            seq_length=64,
-            micro_batch_size=4,
-            num_microbatches=4,
-        )
-
-    def test_noncolocated_cp2_matches_cp1_baseline(self):
-        """CP2 reconstructs the same encoder gradient as a deterministic CP1 baseline."""
-        if self.world_size != 8:
-            pytest.skip(f"Requires 8 GPUs, got {self.world_size}")
-
-        import os
-
-        for key, value in {
-            "NVTE_ALLOW_NONDETERMINISTIC_ALGO": "0",
-            "CUDA_DEVICE_MAX_CONNECTIONS": "1",
-            "CUBLAS_WORKSPACE_CONFIG": ":4096:8",
-        }.items():
-            os.environ[key] = value
-        os.environ.pop('NVTE_FLASH_ATTN', None)
-        os.environ.pop('NVTE_FUSED_ATTN', None)
-        os.environ.pop('NVTE_UNFUSED_ATTN', None)
-        previous_deterministic_algorithms = torch.are_deterministic_algorithms_enabled()
-        previous_cudnn_deterministic = torch.backends.cudnn.deterministic
-        previous_cudnn_benchmark = torch.backends.cudnn.benchmark
-        torch.use_deterministic_algorithms(True)
-        torch.backends.cudnn.deterministic = True
-        torch.backends.cudnn.benchmark = False
-
-        encoder_name = "images"
-        hidden_size = 128
-        seq_length = 64
-        vocab_size = 1000
-        micro_batch_size = 4
-        num_microbatches = 4
-        ref_mimo = None
-        target_mimo = None
-
-        try:
-            ref_encoder_grid = create_hypercomm_grid(offset=0, tp=1, cp=1, pp=1, dp=4)
-            ref_llm_grid = create_hypercomm_grid(offset=4, tp=2, cp=1, pp=2, dp=1)
-            target_encoder_grid = create_hypercomm_grid(offset=0, tp=1, cp=1, pp=1, dp=4)
-            target_llm_grid = create_hypercomm_grid(offset=4, tp=1, cp=2, pp=2, dp=1)
-            create_all_embedding_groups(
-                [ref_encoder_grid, ref_llm_grid, target_encoder_grid, target_llm_grid]
-            )
-
-            ddp_config = DistributedDataParallelConfig(
-                overlap_grad_reduce=True, bucket_size=10000, use_distributed_optimizer=False
-            )
-
-            torch.manual_seed(12345)
-            (ref_mimo, ref_module_to_grid_map, ref_topology, ref_language_pg, ref_vision_pg) = (
-                get_mimo_model(
-                    encoder_name=encoder_name,
-                    encoder_grid=ref_encoder_grid,
-                    llm_grid=ref_llm_grid,
-                    hidden_size=hidden_size,
-                    num_layers=2,
-                    vocab_size=vocab_size,
-                    seq_len=seq_length,
-                    ddp_config=ddp_config,
-                    bf16=True,
-                    bias=False,
-                    dropout=False,
-                    per_token_loss=True,
-                )
-            )
-
-            torch.manual_seed(12345)
-            (
-                target_mimo,
-                target_module_to_grid_map,
-                target_topology,
-                target_language_pg,
-                target_vision_pg,
-            ) = get_mimo_model(
-                encoder_name=encoder_name,
-                encoder_grid=target_encoder_grid,
-                llm_grid=target_llm_grid,
-                hidden_size=hidden_size,
-                num_layers=2,
-                vocab_size=vocab_size,
-                seq_len=seq_length,
-                ddp_config=ddp_config,
-                bf16=True,
-                bias=False,
-                dropout=False,
-                per_token_loss=True,
-            )
-
-            if is_rank_in_grid(ref_encoder_grid):
-                _copy_ref_params_to_dist(
-                    ref_mimo.modality_submodules[encoder_name].module,
-                    target_mimo.modality_submodules[encoder_name].module,
-                    ref_encoder_grid.get_pg("tp"),
-                    target_encoder_grid.get_pg("tp"),
-                )
-            else:
-                assert is_rank_in_grid(ref_llm_grid)
-                _copy_ref_params_to_dist(
-                    ref_mimo.language_model.module,
-                    target_mimo.language_model.module,
-                    ref_llm_grid.get_pg("tp"),
-                    target_llm_grid.get_pg("tp"),
-                )
-            dist.barrier()
-
-            opt_config = OptimizerConfig(
-                optimizer='adam',
-                lr=1e-4,
-                weight_decay=0.01,
-                clip_grad=1.0,
-                bf16=True,
-                use_distributed_optimizer=False,
-            )
-            ref_optimizer = get_mimo_optimizer(ref_mimo, opt_config)
-
-            torch.manual_seed(99999)
-            global_batches = _generate_and_broadcast_global_batches(
-                global_micro_batch_size=micro_batch_size,
-                seq_length=seq_length,
-                hidden_size=hidden_size,
-                vocab_size=vocab_size,
-                encoder_name=encoder_name,
-                num_microbatches=num_microbatches,
-            )
-            ref_batches = _build_noncolocated_role_batches(
-                global_batches, ref_encoder_grid, ref_llm_grid
-            )
-            target_batches = _build_noncolocated_role_batches(
-                global_batches, target_encoder_grid, target_llm_grid
-            )
-
-            ref_grads = _run_deterministic_1f1b_configuration(
-                ref_mimo,
-                ref_module_to_grid_map,
-                ref_topology,
-                ref_language_pg,
-                ref_vision_pg,
-                ref_encoder_grid,
-                ref_llm_grid,
-                encoder_name,
-                ref_batches,
-                ref_optimizer,
-                micro_batch_size,
-                seq_length,
-                num_microbatches,
-            )
-            dist.barrier()
-            target_optimizer = get_mimo_optimizer(target_mimo, opt_config)
-            target_grads = _run_deterministic_1f1b_configuration(
-                target_mimo,
-                target_module_to_grid_map,
-                target_topology,
-                target_language_pg,
-                target_vision_pg,
-                target_encoder_grid,
-                target_llm_grid,
-                encoder_name,
-                target_batches,
-                target_optimizer,
-                micro_batch_size,
-                seq_length,
-                num_microbatches,
-            )
-
-            local_error = None
-            if is_rank_in_grid(ref_encoder_grid):
-                if set(ref_grads) != set(target_grads):
-                    local_error = (
-                        f"First-layer gradient names differ: reference={set(ref_grads)}, "
-                        f"target={set(target_grads)}"
-                    )
-                else:
-                    for name in sorted(ref_grads):
-                        try:
-                            torch.testing.assert_close(
-                                target_grads[name], ref_grads[name], rtol=1e-3, atol=1e-3
-                            )
-                        except AssertionError as error:
-                            local_error = f"First-layer gradient {name!r} differs: {error}"
-                            break
-
-            gradients_match = torch.tensor(
-                0 if local_error else 1, device='cuda', dtype=torch.int32
-            )
-            dist.all_reduce(gradients_match, op=dist.ReduceOp.MIN)
-            assert gradients_match.item() == 1, (
-                local_error or "A remote encoder rank reported a CP1-vs-CP2 gradient mismatch"
-            )
-        finally:
-            if target_mimo is not None:
-                target_mimo.destroy()
-            if ref_mimo is not None:
-                ref_mimo.destroy()
-            torch.use_deterministic_algorithms(previous_deterministic_algorithms)
-            torch.backends.cudnn.deterministic = previous_cudnn_deterministic
-            torch.backends.cudnn.benchmark = previous_cudnn_benchmark
 
     def test_fan_out_dp1_to_dp4_enc_tp2_pp2_8gpu(self):
         """Fan-out 1→4: Encoder TP=2 PP=2 DP=1 → LLM DP=4, on 8 GPUs.

--- a/tests/unit_tests/models/mimo/test_mimo_1f1b_schedule.py
+++ b/tests/unit_tests/models/mimo/test_mimo_1f1b_schedule.py
@@ -148,29 +148,28 @@ def create_all_embedding_groups(grids):
     """Create embedding PGs for all grids upfront.
 
     dist.new_group is a collective — ALL ranks must call it, even non-members.
-    We create all embedding groups in a consistent order across all ranks to
-    avoid hangs from asymmetric new_group calls.
+    Enumerate every PP subgroup from each grid so all ranks create the same
+    deduplicated sequence of embedding groups. Looking only at ``grid.get_pg("pp")``
+    would expose the caller's local subgroup and make different ranks issue
+    different ``new_group`` calls.
 
     Args:
         grids: List of all HyperCommGrids that need embedding groups.
     """
     for grid in grids:
-        pp_group = grid.get_pg("pp")
-        if not pp_group:
-            continue
+        for pp_ranks in grid.get_rank_enum("pp"):
+            pp_ranks = sorted(pp_ranks)
+            cache_key = tuple(pp_ranks)
 
-        pp_ranks = sorted(dist.get_process_group_ranks(pp_group))
-        cache_key = tuple(pp_ranks)
-
-        if cache_key not in _embedding_pg_cache:
-            pos_embd_ranks = [pp_ranks[0]]
-            embd_ranks = [pp_ranks[0]]
-            if pp_ranks[-1] != pp_ranks[0]:
-                embd_ranks.append(pp_ranks[-1])
-            _embedding_pg_cache[cache_key] = (
-                dist.new_group(ranks=pos_embd_ranks),
-                dist.new_group(ranks=embd_ranks),
-            )
+            if cache_key not in _embedding_pg_cache:
+                pos_embd_ranks = [pp_ranks[0]]
+                embd_ranks = [pp_ranks[0]]
+                if pp_ranks[-1] != pp_ranks[0]:
+                    embd_ranks.append(pp_ranks[-1])
+                _embedding_pg_cache[cache_key] = (
+                    dist.new_group(ranks=pos_embd_ranks),
+                    dist.new_group(ranks=embd_ranks),
+                )
 
 
 def add_embedding_groups(pg_collection, is_language_model=False):
@@ -246,6 +245,7 @@ def get_language_model_spec(
     pp_rank = dist.get_rank(pg_collection.pp)
     pp_size = dist.get_world_size(pg_collection.pp)
     tp_size = pg_collection.tp.size() if pg_collection.tp is not None else 1
+    cp_size = pg_collection.cp.size() if pg_collection.cp is not None else 1
 
     pipeline_dtype = torch.bfloat16 if bf16 else torch.float32
     extra_kwargs = {}
@@ -269,6 +269,7 @@ def get_language_model_spec(
         cross_entropy_loss_fusion=True,
         cross_entropy_fusion_impl='native',
         calculate_per_token_loss=per_token_loss,
+        context_parallel_size=cp_size,
         **extra_kwargs,
     )
     return ModuleSpec(
@@ -327,6 +328,7 @@ def get_vision_submodules_spec(
     from megatron.core.transformer.transformer_block import TransformerBlock
 
     tp_size = pg_collection.tp.size() if pg_collection.tp is not None else 1
+    cp_size = pg_collection.cp.size() if pg_collection.cp is not None else 1
     pp_size = pg_collection.pp.size() if pg_collection.pp is not None else 1
     pp_rank = dist.get_rank(pg_collection.pp)
 
@@ -350,6 +352,7 @@ def get_vision_submodules_spec(
         pipeline_dtype=pipeline_dtype,
         bf16=bf16,
         calculate_per_token_loss=per_token_loss,
+        context_parallel_size=cp_size,
         **extra_kwargs,
     )
     vision_encoder_spec = ModuleSpec(
@@ -454,7 +457,7 @@ def get_mimo_model(
         module_to_grid_map=module_to_grid_map,
     )
 
-    mimo_model = MimoModel(mimo_config)
+    mimo_model = MimoModel(mimo_config, cp_group=language_pg.cp, tp_group=language_pg.tp)
     mimo_model.to(torch.device("cuda"))
     if bf16:
         mimo_model.to(torch.bfloat16)
@@ -563,6 +566,248 @@ class DataIterator:
         }
 
 
+class _BatchIterator:
+    """Finite iterator over deterministic, pre-generated microbatches."""
+
+    def __init__(self, batches):
+        self.batches = batches
+        self.index = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.index >= len(self.batches):
+            raise StopIteration
+        batch = self.batches[self.index]
+        self.index += 1
+        return batch
+
+
+def _clone_batch_value(value):
+    """Clone a nested batch so sequential reference/target runs cannot share mutations."""
+    if isinstance(value, torch.Tensor):
+        return value.clone()
+    if isinstance(value, dict):
+        return {key: _clone_batch_value(item) for key, item in value.items()}
+    return value
+
+
+def _generate_and_broadcast_global_batches(
+    global_micro_batch_size,
+    seq_length,
+    hidden_size,
+    vocab_size,
+    encoder_name,
+    num_microbatches,
+    modality_dtype=torch.bfloat16,
+    image_token_id=50257,
+):
+    """Generate deterministic global microbatches once and broadcast them to every rank."""
+    image_seq_length = seq_length // 2
+    batches = []
+
+    for _ in range(num_microbatches):
+        if dist.get_rank() == 0:
+            encoder_hidden_states = torch.randn(
+                image_seq_length,
+                global_micro_batch_size,
+                hidden_size,
+                device='cuda',
+                dtype=modality_dtype,
+            )
+            image_tokens = torch.full(
+                (global_micro_batch_size, image_seq_length),
+                image_token_id,
+                dtype=torch.long,
+                device='cuda',
+            )
+            text_tokens = torch.randint(
+                1,
+                vocab_size,
+                (global_micro_batch_size, seq_length - image_seq_length),
+                device='cuda',
+            )
+            input_ids = torch.cat([image_tokens, text_tokens], dim=1)
+        else:
+            encoder_hidden_states = torch.empty(
+                image_seq_length,
+                global_micro_batch_size,
+                hidden_size,
+                device='cuda',
+                dtype=modality_dtype,
+            )
+            input_ids = torch.empty(
+                global_micro_batch_size, seq_length, dtype=torch.long, device='cuda'
+            )
+
+        dist.broadcast(encoder_hidden_states, src=0)
+        dist.broadcast(input_ids, src=0)
+
+        labels = input_ids.clone()
+        labels[input_ids == image_token_id] = -100
+        loss_mask = torch.ones(
+            global_micro_batch_size, seq_length, device='cuda', dtype=torch.float32
+        )
+        loss_mask[input_ids == image_token_id] = 0.0
+        position_ids = (
+            torch.arange(seq_length, device='cuda')
+            .unsqueeze(0)
+            .expand(global_micro_batch_size, -1)
+            .clone()
+        )
+        batches.append(
+            {
+                "input_ids": input_ids,
+                "labels": labels,
+                "loss_mask": loss_mask,
+                "position_ids": position_ids,
+                "modality_inputs": {
+                    encoder_name: {
+                        "clip_encoder": {
+                            'hidden_states': encoder_hidden_states,
+                            'attention_mask': None,
+                        }
+                    }
+                },
+            }
+        )
+
+    return batches
+
+
+def _slice_batch(global_batch, num_slices, slice_rank):
+    """Slice a global batch for one encoder DP rank."""
+    batch_size = global_batch['input_ids'].shape[0]
+    assert batch_size % num_slices == 0
+    slice_size = batch_size // num_slices
+    start = slice_rank * slice_size
+    end = start + slice_size
+
+    batch = {
+        key: global_batch[key][start:end].contiguous()
+        for key in ['input_ids', 'labels', 'loss_mask', 'position_ids']
+    }
+    batch['modality_inputs'] = {}
+    for modality_name, modality_data in global_batch['modality_inputs'].items():
+        batch['modality_inputs'][modality_name] = {}
+        for encoder_name, encoder_data in modality_data.items():
+            batch['modality_inputs'][modality_name][encoder_name] = {}
+            for key, tensor in encoder_data.items():
+                if isinstance(tensor, torch.Tensor):
+                    batch['modality_inputs'][modality_name][encoder_name][key] = tensor[
+                        :, start:end, :
+                    ].contiguous()
+                else:
+                    batch['modality_inputs'][modality_name][encoder_name][key] = tensor
+    return batch
+
+
+def _build_noncolocated_role_batches(global_batches, encoder_grid, llm_grid):
+    """Build encoder-DP slices or full LLM batches for this disjoint-grid rank."""
+    if is_rank_in_grid(encoder_grid):
+        encoder_dp = encoder_grid.get_pg("dp")
+        return [
+            _slice_batch(batch, encoder_dp.size(), encoder_dp.rank()) for batch in global_batches
+        ]
+    if is_rank_in_grid(llm_grid):
+        return [_clone_batch_value(batch) for batch in global_batches]
+    raise AssertionError(f"Rank {dist.get_rank()} belongs to neither MIMO grid")
+
+
+def _copy_ref_params_to_dist(ref_module, dist_module, ref_tp_group, dist_tp_group):
+    """Copy parameters across differing TP layouts by gathering then re-slicing shards.
+
+    This helper is shared with the colocated MIMO correctness tests. It must be called before
+    constructing the distributed optimizer, which snapshots parameter data into master weights.
+    """
+    ref_tp_size = ref_tp_group.size()
+    dist_tp_size = dist_tp_group.size()
+    dist_tp_rank = dist_tp_group.rank()
+    ref_params = dict(ref_module.named_parameters())
+
+    with torch.no_grad():
+        for name, dist_param in dist_module.named_parameters():
+            assert name in ref_params, f"Distributed parameter {name!r} is missing from reference"
+            ref_param = ref_params[name]
+            if ref_param.shape == dist_param.shape:
+                dist_param.data.copy_(ref_param.data.to(dist_param.dtype))
+                continue
+
+            partition_dim = getattr(dist_param, 'partition_dim', -1)
+            assert partition_dim >= 0, (
+                f"Parameter {name!r} differs in shape but has no TP partition dimension: "
+                f"reference={tuple(ref_param.shape)}, distributed={tuple(dist_param.shape)}"
+            )
+            ref_shards = [torch.empty_like(ref_param.data) for _ in range(ref_tp_size)]
+            dist.all_gather(ref_shards, ref_param.data.contiguous(), group=ref_tp_group)
+            full_param = torch.cat(ref_shards, dim=partition_dim)
+            dist_shard = torch.tensor_split(full_param, dist_tp_size, dim=partition_dim)[
+                dist_tp_rank
+            ]
+            assert dist_shard.shape == dist_param.shape, (
+                f"Parameter {name!r} reshard shape {tuple(dist_shard.shape)} does not match "
+                f"distributed shape {tuple(dist_param.shape)}"
+            )
+            dist_param.data.copy_(dist_shard.to(dist_param.dtype))
+
+
+def _snapshot_first_layer_encoder_grads(mimo_model, encoder_name):
+    """Snapshot first-layer encoder main gradients before the optimizer consumes them."""
+    encoder = mimo_model.modality_submodules[encoder_name].module
+    gradients = {}
+    for name, parameter in encoder.named_parameters():
+        if '.layers.0.' not in name:
+            continue
+        main_grad = getattr(parameter, 'main_grad', None)
+        if main_grad is not None:
+            gradients[name] = main_grad.detach().clone()
+    assert gradients, "Expected non-empty first-layer encoder main_grad snapshot"
+    return gradients
+
+
+def _forward_step_with_per_token_loss(data_iterator, model):
+    """Forward step using the per-token loss contract expected by configure_grad_sync."""
+
+    def loss_func(loss_mask, output_tensor):
+        def _ret(loss, num_tokens, reduced):
+            return loss, num_tokens, {'loss_reduced': reduced}
+
+        zero = torch.tensor(0.0, device='cuda', requires_grad=True)
+        one = torch.tensor(1, device='cuda', dtype=torch.int)
+        if output_tensor is None:
+            return _ret(zero, one, 0.0)
+
+        if isinstance(output_tensor, dict):
+            output = output_tensor.get(
+                MIMO_LANGUAGE_MODULE_KEY, next(iter(output_tensor.values()), None)
+            )
+        else:
+            output = output_tensor
+
+        if output is None:
+            return _ret(zero, one, 0.0)
+
+        loss = output.float().sum()
+        num_tokens = loss_mask.sum().to(torch.int).clamp(min=1) if loss_mask is not None else one
+        return _ret(loss, num_tokens, loss)
+
+    batch = next(data_iterator) if data_iterator is not None else {'input_ids': None}
+    output_tensor, loss_mask = model(**batch)
+    return output_tensor, partial(loss_func, loss_mask)
+
+
+def _assert_finite_losses(losses, llm_grid):
+    """Require finite reported losses on the terminal language stage."""
+    if not (is_rank_in_grid(llm_grid) and is_pp_last_stage(llm_grid.get_pg("pp"))):
+        return
+    assert losses, "Expected losses on last LLM stage"
+    for loss_dict in losses:
+        assert 'loss_reduced' in loss_dict
+        loss = torch.as_tensor(loss_dict['loss_reduced'])
+        assert torch.isfinite(loss).all(), f"Expected finite loss, got {loss}"
+
+
 # ============================================================================
 # Test Runner
 # ============================================================================
@@ -577,6 +822,8 @@ def run_mimo_1f1b_test(
     llm_pp,
     llm_dp,
     llm_offset,
+    encoder_cp=1,
+    llm_cp=1,
     hidden_size=256,
     num_layers=2,
     vocab_size=1000,
@@ -601,9 +848,9 @@ def run_mimo_1f1b_test(
     encoder_name = "images"
 
     encoder_grid = create_hypercomm_grid(
-        offset=encoder_offset, tp=encoder_tp, cp=1, pp=encoder_pp, dp=encoder_dp
+        offset=encoder_offset, tp=encoder_tp, cp=encoder_cp, pp=encoder_pp, dp=encoder_dp
     )
-    llm_grid = create_hypercomm_grid(offset=llm_offset, tp=llm_tp, cp=1, pp=llm_pp, dp=llm_dp)
+    llm_grid = create_hypercomm_grid(offset=llm_offset, tp=llm_tp, cp=llm_cp, pp=llm_pp, dp=llm_dp)
 
     # Create all embedding PGs upfront — dist.new_group is a collective that
     # requires ALL ranks to participate, so we must create them before any
@@ -749,16 +996,102 @@ def run_mimo_1f1b_test(
         assert (
             grad_norm is not None and grad_norm > 0
         ), f"Expected positive grad norm, got {grad_norm}"
+        assert torch.isfinite(
+            torch.as_tensor(grad_norm)
+        ).all(), f"Expected finite grad norm, got {grad_norm}"
 
         # Verify results on last LLM stage
         if is_rank_in_grid(llm_grid) and is_pp_last_stage(llm_grid.get_pg("pp")):
             assert len(losses) > 0, "Expected losses on last LLM stage"
             for loss_dict in losses:
                 assert 'loss_reduced' in loss_dict
+                loss = torch.as_tensor(loss_dict['loss_reduced'])
+                assert torch.isfinite(loss).all(), f"Expected finite loss, got {loss}"
 
         return losses
     finally:
         mimo_model.destroy()
+
+
+def _run_deterministic_1f1b_configuration(
+    mimo_model,
+    module_to_grid_map,
+    topology,
+    language_pg,
+    vision_pg,
+    encoder_grid,
+    llm_grid,
+    encoder_name,
+    batches,
+    optimizer,
+    micro_batch_size,
+    seq_length,
+    num_microbatches,
+):
+    """Run one deterministic non-colocated 1F1B step and snapshot encoder gradients."""
+    mimo_model.config.no_sync_func = build_no_sync_func(mimo_model)
+    grad_sync_topology = SimpleNamespace(
+        grids=module_to_grid_map,
+        module_pgs={
+            MIMO_LANGUAGE_MODULE_KEY: language_pg,
+            **{name: vision_pg for name in mimo_model.modality_submodules},
+        },
+    )
+    configure_grad_sync(SimpleNamespace(), mimo_model, grad_sync_topology)
+
+    communicator = MultiModulePipelineCommunicator(
+        module_to_grid_map,
+        topology,
+        mimo_model.config,
+        dim_mapping={'s': 0, 'h': 2, 'b': 1},
+        module_output_ndim={encoder_name: 2},
+    )
+
+    module_pgs = {}
+    language_model_module_name = None
+    if is_rank_in_grid(encoder_grid):
+        module_pgs[encoder_name] = vision_pg
+    if is_rank_in_grid(llm_grid):
+        module_pgs[MIMO_LANGUAGE_MODULE_KEY] = language_pg
+        language_model_module_name = MIMO_LANGUAGE_MODULE_KEY
+    pg_collection = MultiModuleProcessGroupCollection(
+        module_pgs=module_pgs, language_model_module_name=language_model_module_name
+    )
+
+    needs_data = (
+        is_rank_in_grid(encoder_grid) and is_pp_first_stage(encoder_grid.get_pg("pp"))
+    ) or (
+        is_rank_in_grid(llm_grid)
+        and (is_pp_first_stage(llm_grid.get_pg("pp")) or is_pp_last_stage(llm_grid.get_pg("pp")))
+    )
+    data_iterator = _BatchIterator(batches) if needs_data else None
+
+    optimizer.zero_grad()
+    losses = schedule.forward_backward_pipelining_without_interleaving(
+        forward_step_func=_forward_step_with_per_token_loss,
+        data_iterator=data_iterator,
+        model=[mimo_model],
+        num_microbatches=num_microbatches,
+        seq_length=seq_length,
+        micro_batch_size=micro_batch_size,
+        forward_only=False,
+        p2p_communicator=communicator,
+        pg_collection=pg_collection,
+    )
+
+    encoder_grads = (
+        _snapshot_first_layer_encoder_grads(mimo_model, encoder_name)
+        if is_rank_in_grid(encoder_grid)
+        else {}
+    )
+    success, grad_norm, _ = optimizer.step()
+    assert success, "Optimizer step failed"
+    assert grad_norm is not None and grad_norm > 0, f"Expected positive grad norm, got {grad_norm}"
+    assert torch.isfinite(
+        torch.as_tensor(grad_norm)
+    ).all(), f"Expected finite grad norm, got {grad_norm}"
+    _assert_finite_losses(losses, llm_grid)
+    return encoder_grads
 
 
 # ============================================================================
@@ -898,6 +1231,224 @@ class TestMimo1F1BSchedule:
             micro_batch_size=4,
             num_microbatches=4,
         )
+
+    def test_fan_in_dp4_to_cp2_llm_pp2_8gpu(self):
+        """Destination CP=2 exercises steady-state and cooldown bridge backward paths."""
+        if self.world_size != 8:
+            pytest.skip(f"Requires 8 GPUs, got {self.world_size}")
+
+        run_mimo_1f1b_test(
+            encoder_tp=1,
+            encoder_cp=1,
+            encoder_pp=1,
+            encoder_dp=4,
+            encoder_offset=0,
+            llm_tp=1,
+            llm_cp=2,
+            llm_pp=2,
+            llm_dp=1,
+            llm_offset=4,
+            hidden_size=128,
+            num_layers=2,
+            vocab_size=1000,
+            seq_length=64,
+            micro_batch_size=4,
+            num_microbatches=4,
+        )
+
+    def test_noncolocated_cp2_matches_cp1_baseline(self):
+        """CP2 reconstructs the same encoder gradient as a deterministic CP1 baseline."""
+        if self.world_size != 8:
+            pytest.skip(f"Requires 8 GPUs, got {self.world_size}")
+
+        import os
+
+        for key, value in {
+            "NVTE_ALLOW_NONDETERMINISTIC_ALGO": "0",
+            "CUDA_DEVICE_MAX_CONNECTIONS": "1",
+            "CUBLAS_WORKSPACE_CONFIG": ":4096:8",
+        }.items():
+            os.environ[key] = value
+        os.environ.pop('NVTE_FLASH_ATTN', None)
+        os.environ.pop('NVTE_FUSED_ATTN', None)
+        os.environ.pop('NVTE_UNFUSED_ATTN', None)
+        previous_deterministic_algorithms = torch.are_deterministic_algorithms_enabled()
+        previous_cudnn_deterministic = torch.backends.cudnn.deterministic
+        previous_cudnn_benchmark = torch.backends.cudnn.benchmark
+        torch.use_deterministic_algorithms(True)
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False
+
+        encoder_name = "images"
+        hidden_size = 128
+        seq_length = 64
+        vocab_size = 1000
+        micro_batch_size = 4
+        num_microbatches = 4
+        ref_mimo = None
+        target_mimo = None
+
+        try:
+            ref_encoder_grid = create_hypercomm_grid(offset=0, tp=1, cp=1, pp=1, dp=4)
+            ref_llm_grid = create_hypercomm_grid(offset=4, tp=2, cp=1, pp=2, dp=1)
+            target_encoder_grid = create_hypercomm_grid(offset=0, tp=1, cp=1, pp=1, dp=4)
+            target_llm_grid = create_hypercomm_grid(offset=4, tp=1, cp=2, pp=2, dp=1)
+            create_all_embedding_groups(
+                [ref_encoder_grid, ref_llm_grid, target_encoder_grid, target_llm_grid]
+            )
+
+            ddp_config = DistributedDataParallelConfig(
+                overlap_grad_reduce=True, bucket_size=10000, use_distributed_optimizer=False
+            )
+
+            torch.manual_seed(12345)
+            (ref_mimo, ref_module_to_grid_map, ref_topology, ref_language_pg, ref_vision_pg) = (
+                get_mimo_model(
+                    encoder_name=encoder_name,
+                    encoder_grid=ref_encoder_grid,
+                    llm_grid=ref_llm_grid,
+                    hidden_size=hidden_size,
+                    num_layers=2,
+                    vocab_size=vocab_size,
+                    seq_len=seq_length,
+                    ddp_config=ddp_config,
+                    bf16=True,
+                    bias=False,
+                    dropout=False,
+                    per_token_loss=True,
+                )
+            )
+
+            torch.manual_seed(12345)
+            (
+                target_mimo,
+                target_module_to_grid_map,
+                target_topology,
+                target_language_pg,
+                target_vision_pg,
+            ) = get_mimo_model(
+                encoder_name=encoder_name,
+                encoder_grid=target_encoder_grid,
+                llm_grid=target_llm_grid,
+                hidden_size=hidden_size,
+                num_layers=2,
+                vocab_size=vocab_size,
+                seq_len=seq_length,
+                ddp_config=ddp_config,
+                bf16=True,
+                bias=False,
+                dropout=False,
+                per_token_loss=True,
+            )
+
+            if is_rank_in_grid(ref_encoder_grid):
+                _copy_ref_params_to_dist(
+                    ref_mimo.modality_submodules[encoder_name].module,
+                    target_mimo.modality_submodules[encoder_name].module,
+                    ref_encoder_grid.get_pg("tp"),
+                    target_encoder_grid.get_pg("tp"),
+                )
+            else:
+                assert is_rank_in_grid(ref_llm_grid)
+                _copy_ref_params_to_dist(
+                    ref_mimo.language_model.module,
+                    target_mimo.language_model.module,
+                    ref_llm_grid.get_pg("tp"),
+                    target_llm_grid.get_pg("tp"),
+                )
+            dist.barrier()
+
+            opt_config = OptimizerConfig(
+                optimizer='adam',
+                lr=1e-4,
+                weight_decay=0.01,
+                clip_grad=1.0,
+                bf16=True,
+                use_distributed_optimizer=False,
+            )
+            ref_optimizer = get_mimo_optimizer(ref_mimo, opt_config)
+
+            torch.manual_seed(99999)
+            global_batches = _generate_and_broadcast_global_batches(
+                global_micro_batch_size=micro_batch_size,
+                seq_length=seq_length,
+                hidden_size=hidden_size,
+                vocab_size=vocab_size,
+                encoder_name=encoder_name,
+                num_microbatches=num_microbatches,
+            )
+            ref_batches = _build_noncolocated_role_batches(
+                global_batches, ref_encoder_grid, ref_llm_grid
+            )
+            target_batches = _build_noncolocated_role_batches(
+                global_batches, target_encoder_grid, target_llm_grid
+            )
+
+            ref_grads = _run_deterministic_1f1b_configuration(
+                ref_mimo,
+                ref_module_to_grid_map,
+                ref_topology,
+                ref_language_pg,
+                ref_vision_pg,
+                ref_encoder_grid,
+                ref_llm_grid,
+                encoder_name,
+                ref_batches,
+                ref_optimizer,
+                micro_batch_size,
+                seq_length,
+                num_microbatches,
+            )
+            dist.barrier()
+            target_optimizer = get_mimo_optimizer(target_mimo, opt_config)
+            target_grads = _run_deterministic_1f1b_configuration(
+                target_mimo,
+                target_module_to_grid_map,
+                target_topology,
+                target_language_pg,
+                target_vision_pg,
+                target_encoder_grid,
+                target_llm_grid,
+                encoder_name,
+                target_batches,
+                target_optimizer,
+                micro_batch_size,
+                seq_length,
+                num_microbatches,
+            )
+
+            local_error = None
+            if is_rank_in_grid(ref_encoder_grid):
+                if set(ref_grads) != set(target_grads):
+                    local_error = (
+                        f"First-layer gradient names differ: reference={set(ref_grads)}, "
+                        f"target={set(target_grads)}"
+                    )
+                else:
+                    for name in sorted(ref_grads):
+                        try:
+                            torch.testing.assert_close(
+                                target_grads[name], ref_grads[name], rtol=1e-3, atol=1e-3
+                            )
+                        except AssertionError as error:
+                            local_error = f"First-layer gradient {name!r} differs: {error}"
+                            break
+
+            gradients_match = torch.tensor(
+                0 if local_error else 1, device='cuda', dtype=torch.int32
+            )
+            dist.all_reduce(gradients_match, op=dist.ReduceOp.MIN)
+            assert gradients_match.item() == 1, (
+                local_error or "A remote encoder rank reported a CP1-vs-CP2 gradient mismatch"
+            )
+        finally:
+            if target_mimo is not None:
+                target_mimo.destroy()
+            if ref_mimo is not None:
+                ref_mimo.destroy()
+            torch.use_deterministic_algorithms(previous_deterministic_algorithms)
+            torch.backends.cudnn.deterministic = previous_cudnn_deterministic
+            torch.backends.cudnn.benchmark = previous_cudnn_benchmark
 
     def test_fan_out_dp1_to_dp4_enc_tp2_pp2_8gpu(self):
         """Fan-out 1→4: Encoder TP=2 PP=2 DP=1 → LLM DP=4, on 8 GPUs.

--- a/tests/unit_tests/models/mimo/test_mimo_1f1b_schedule.py
+++ b/tests/unit_tests/models/mimo/test_mimo_1f1b_schedule.py
@@ -131,29 +131,28 @@ def create_all_embedding_groups(grids):
     """Create embedding PGs for all grids upfront.
 
     dist.new_group is a collective — ALL ranks must call it, even non-members.
-    We create all embedding groups in a consistent order across all ranks to
-    avoid hangs from asymmetric new_group calls.
+    Enumerate every PP subgroup from each grid so all ranks create the same
+    deduplicated sequence of embedding groups. Looking only at ``grid.get_pg("pp")``
+    would expose the caller's local subgroup and make different ranks issue
+    different ``new_group`` calls.
 
     Args:
         grids: List of all HyperCommGrids that need embedding groups.
     """
     for grid in grids:
-        pp_group = grid.get_pg("pp")
-        if not pp_group:
-            continue
+        for pp_ranks in grid.get_rank_enum("pp"):
+            pp_ranks = sorted(pp_ranks)
+            cache_key = tuple(pp_ranks)
 
-        pp_ranks = sorted(dist.get_process_group_ranks(pp_group))
-        cache_key = tuple(pp_ranks)
-
-        if cache_key not in _embedding_pg_cache:
-            pos_embd_ranks = [pp_ranks[0]]
-            embd_ranks = [pp_ranks[0]]
-            if pp_ranks[-1] != pp_ranks[0]:
-                embd_ranks.append(pp_ranks[-1])
-            _embedding_pg_cache[cache_key] = (
-                dist.new_group(ranks=pos_embd_ranks),
-                dist.new_group(ranks=embd_ranks),
-            )
+            if cache_key not in _embedding_pg_cache:
+                pos_embd_ranks = [pp_ranks[0]]
+                embd_ranks = [pp_ranks[0]]
+                if pp_ranks[-1] != pp_ranks[0]:
+                    embd_ranks.append(pp_ranks[-1])
+                _embedding_pg_cache[cache_key] = (
+                    dist.new_group(ranks=pos_embd_ranks),
+                    dist.new_group(ranks=embd_ranks),
+                )
 
 
 def add_embedding_groups(pg_collection, is_language_model=False):
@@ -229,6 +228,7 @@ def get_language_model_spec(
     pp_rank = dist.get_rank(pg_collection.pp)
     pp_size = dist.get_world_size(pg_collection.pp)
     tp_size = pg_collection.tp.size() if pg_collection.tp is not None else 1
+    cp_size = pg_collection.cp.size() if pg_collection.cp is not None else 1
 
     pipeline_dtype = torch.bfloat16 if bf16 else torch.float32
     extra_kwargs = {}
@@ -252,6 +252,7 @@ def get_language_model_spec(
         cross_entropy_loss_fusion=True,
         cross_entropy_fusion_impl='native',
         calculate_per_token_loss=per_token_loss,
+        context_parallel_size=cp_size,
         **extra_kwargs,
     )
     return ModuleSpec(
@@ -310,6 +311,7 @@ def get_vision_submodules_spec(
     from megatron.core.transformer.transformer_block import TransformerBlock
 
     tp_size = pg_collection.tp.size() if pg_collection.tp is not None else 1
+    cp_size = pg_collection.cp.size() if pg_collection.cp is not None else 1
     pp_size = pg_collection.pp.size() if pg_collection.pp is not None else 1
     pp_rank = dist.get_rank(pg_collection.pp)
 
@@ -333,6 +335,7 @@ def get_vision_submodules_spec(
         pipeline_dtype=pipeline_dtype,
         bf16=bf16,
         calculate_per_token_loss=per_token_loss,
+        context_parallel_size=cp_size,
         **extra_kwargs,
     )
     vision_encoder_spec = ModuleSpec(
@@ -440,7 +443,7 @@ def get_mimo_model(
         module_to_grid_map=module_to_grid_map,
     )
 
-    mimo_model = MimoModel(mimo_config)
+    mimo_model = MimoModel(mimo_config, cp_group=language_pg.cp, tp_group=language_pg.tp)
     mimo_model.to(torch.device("cuda"))
     if bf16:
         mimo_model.to(torch.bfloat16)
@@ -577,6 +580,248 @@ class DataIterator:
         }
 
 
+class _BatchIterator:
+    """Finite iterator over deterministic, pre-generated microbatches."""
+
+    def __init__(self, batches):
+        self.batches = batches
+        self.index = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.index >= len(self.batches):
+            raise StopIteration
+        batch = self.batches[self.index]
+        self.index += 1
+        return batch
+
+
+def _clone_batch_value(value):
+    """Clone a nested batch so sequential reference/target runs cannot share mutations."""
+    if isinstance(value, torch.Tensor):
+        return value.clone()
+    if isinstance(value, dict):
+        return {key: _clone_batch_value(item) for key, item in value.items()}
+    return value
+
+
+def _generate_and_broadcast_global_batches(
+    global_micro_batch_size,
+    seq_length,
+    hidden_size,
+    vocab_size,
+    encoder_name,
+    num_microbatches,
+    modality_dtype=torch.bfloat16,
+    image_token_id=50257,
+):
+    """Generate deterministic global microbatches once and broadcast them to every rank."""
+    image_seq_length = seq_length // 2
+    batches = []
+
+    for _ in range(num_microbatches):
+        if dist.get_rank() == 0:
+            encoder_hidden_states = torch.randn(
+                image_seq_length,
+                global_micro_batch_size,
+                hidden_size,
+                device='cuda',
+                dtype=modality_dtype,
+            )
+            image_tokens = torch.full(
+                (global_micro_batch_size, image_seq_length),
+                image_token_id,
+                dtype=torch.long,
+                device='cuda',
+            )
+            text_tokens = torch.randint(
+                1,
+                vocab_size,
+                (global_micro_batch_size, seq_length - image_seq_length),
+                device='cuda',
+            )
+            input_ids = torch.cat([image_tokens, text_tokens], dim=1)
+        else:
+            encoder_hidden_states = torch.empty(
+                image_seq_length,
+                global_micro_batch_size,
+                hidden_size,
+                device='cuda',
+                dtype=modality_dtype,
+            )
+            input_ids = torch.empty(
+                global_micro_batch_size, seq_length, dtype=torch.long, device='cuda'
+            )
+
+        dist.broadcast(encoder_hidden_states, src=0)
+        dist.broadcast(input_ids, src=0)
+
+        labels = input_ids.clone()
+        labels[input_ids == image_token_id] = -100
+        loss_mask = torch.ones(
+            global_micro_batch_size, seq_length, device='cuda', dtype=torch.float32
+        )
+        loss_mask[input_ids == image_token_id] = 0.0
+        position_ids = (
+            torch.arange(seq_length, device='cuda')
+            .unsqueeze(0)
+            .expand(global_micro_batch_size, -1)
+            .clone()
+        )
+        batches.append(
+            {
+                "input_ids": input_ids,
+                "labels": labels,
+                "loss_mask": loss_mask,
+                "position_ids": position_ids,
+                "modality_inputs": {
+                    encoder_name: {
+                        "clip_encoder": {
+                            'hidden_states': encoder_hidden_states,
+                            'attention_mask': None,
+                        }
+                    }
+                },
+            }
+        )
+
+    return batches
+
+
+def _slice_batch(global_batch, num_slices, slice_rank):
+    """Slice a global batch for one encoder DP rank."""
+    batch_size = global_batch['input_ids'].shape[0]
+    assert batch_size % num_slices == 0
+    slice_size = batch_size // num_slices
+    start = slice_rank * slice_size
+    end = start + slice_size
+
+    batch = {
+        key: global_batch[key][start:end].contiguous()
+        for key in ['input_ids', 'labels', 'loss_mask', 'position_ids']
+    }
+    batch['modality_inputs'] = {}
+    for modality_name, modality_data in global_batch['modality_inputs'].items():
+        batch['modality_inputs'][modality_name] = {}
+        for encoder_name, encoder_data in modality_data.items():
+            batch['modality_inputs'][modality_name][encoder_name] = {}
+            for key, tensor in encoder_data.items():
+                if isinstance(tensor, torch.Tensor):
+                    batch['modality_inputs'][modality_name][encoder_name][key] = tensor[
+                        :, start:end, :
+                    ].contiguous()
+                else:
+                    batch['modality_inputs'][modality_name][encoder_name][key] = tensor
+    return batch
+
+
+def _build_noncolocated_role_batches(global_batches, encoder_grid, llm_grid):
+    """Build encoder-DP slices or full LLM batches for this disjoint-grid rank."""
+    if is_rank_in_grid(encoder_grid):
+        encoder_dp = encoder_grid.get_pg("dp")
+        return [
+            _slice_batch(batch, encoder_dp.size(), encoder_dp.rank()) for batch in global_batches
+        ]
+    if is_rank_in_grid(llm_grid):
+        return [_clone_batch_value(batch) for batch in global_batches]
+    raise AssertionError(f"Rank {dist.get_rank()} belongs to neither MIMO grid")
+
+
+def _copy_ref_params_to_dist(ref_module, dist_module, ref_tp_group, dist_tp_group):
+    """Copy parameters across differing TP layouts by gathering then re-slicing shards.
+
+    This helper is shared with the colocated MIMO correctness tests. It must be called before
+    constructing the distributed optimizer, which snapshots parameter data into master weights.
+    """
+    ref_tp_size = ref_tp_group.size()
+    dist_tp_size = dist_tp_group.size()
+    dist_tp_rank = dist_tp_group.rank()
+    ref_params = dict(ref_module.named_parameters())
+
+    with torch.no_grad():
+        for name, dist_param in dist_module.named_parameters():
+            assert name in ref_params, f"Distributed parameter {name!r} is missing from reference"
+            ref_param = ref_params[name]
+            if ref_param.shape == dist_param.shape:
+                dist_param.data.copy_(ref_param.data.to(dist_param.dtype))
+                continue
+
+            partition_dim = getattr(dist_param, 'partition_dim', -1)
+            assert partition_dim >= 0, (
+                f"Parameter {name!r} differs in shape but has no TP partition dimension: "
+                f"reference={tuple(ref_param.shape)}, distributed={tuple(dist_param.shape)}"
+            )
+            ref_shards = [torch.empty_like(ref_param.data) for _ in range(ref_tp_size)]
+            dist.all_gather(ref_shards, ref_param.data.contiguous(), group=ref_tp_group)
+            full_param = torch.cat(ref_shards, dim=partition_dim)
+            dist_shard = torch.tensor_split(full_param, dist_tp_size, dim=partition_dim)[
+                dist_tp_rank
+            ]
+            assert dist_shard.shape == dist_param.shape, (
+                f"Parameter {name!r} reshard shape {tuple(dist_shard.shape)} does not match "
+                f"distributed shape {tuple(dist_param.shape)}"
+            )
+            dist_param.data.copy_(dist_shard.to(dist_param.dtype))
+
+
+def _snapshot_first_layer_encoder_grads(mimo_model, encoder_name):
+    """Snapshot first-layer encoder main gradients before the optimizer consumes them."""
+    encoder = mimo_model.modality_submodules[encoder_name].module
+    gradients = {}
+    for name, parameter in encoder.named_parameters():
+        if '.layers.0.' not in name:
+            continue
+        main_grad = getattr(parameter, 'main_grad', None)
+        if main_grad is not None:
+            gradients[name] = main_grad.detach().clone()
+    assert gradients, "Expected non-empty first-layer encoder main_grad snapshot"
+    return gradients
+
+
+def _forward_step_with_per_token_loss(data_iterator, model):
+    """Forward step using the per-token loss contract expected by configure_grad_sync."""
+
+    def loss_func(loss_mask, output_tensor):
+        def _ret(loss, num_tokens, reduced):
+            return loss, num_tokens, {'loss_reduced': reduced}
+
+        zero = torch.tensor(0.0, device='cuda', requires_grad=True)
+        one = torch.tensor(1, device='cuda', dtype=torch.int)
+        if output_tensor is None:
+            return _ret(zero, one, 0.0)
+
+        if isinstance(output_tensor, dict):
+            output = output_tensor.get(
+                MIMO_LANGUAGE_MODULE_KEY, next(iter(output_tensor.values()), None)
+            )
+        else:
+            output = output_tensor
+
+        if output is None:
+            return _ret(zero, one, 0.0)
+
+        loss = output.float().sum()
+        num_tokens = loss_mask.sum().to(torch.int).clamp(min=1) if loss_mask is not None else one
+        return _ret(loss, num_tokens, loss)
+
+    batch = next(data_iterator) if data_iterator is not None else {'input_ids': None}
+    output_tensor, loss_mask = model(**batch)
+    return output_tensor, partial(loss_func, loss_mask)
+
+
+def _assert_finite_losses(losses, llm_grid):
+    """Require finite reported losses on the terminal language stage."""
+    if not (is_rank_in_grid(llm_grid) and is_pp_last_stage(llm_grid.get_pg("pp"))):
+        return
+    assert losses, "Expected losses on last LLM stage"
+    for loss_dict in losses:
+        assert 'loss_reduced' in loss_dict
+        loss = torch.as_tensor(loss_dict['loss_reduced'])
+        assert torch.isfinite(loss).all(), f"Expected finite loss, got {loss}"
+
+
 # ============================================================================
 # Test Runner
 # ============================================================================
@@ -591,6 +836,8 @@ def run_mimo_1f1b_test(
     llm_pp,
     llm_dp,
     llm_offset,
+    encoder_cp=1,
+    llm_cp=1,
     hidden_size=256,
     num_layers=2,
     vocab_size=1000,
@@ -617,9 +864,9 @@ def run_mimo_1f1b_test(
     encoder_name = "images"
 
     encoder_grid = create_hypercomm_grid(
-        offset=encoder_offset, tp=encoder_tp, cp=1, pp=encoder_pp, dp=encoder_dp
+        offset=encoder_offset, tp=encoder_tp, cp=encoder_cp, pp=encoder_pp, dp=encoder_dp
     )
-    llm_grid = create_hypercomm_grid(offset=llm_offset, tp=llm_tp, cp=1, pp=llm_pp, dp=llm_dp)
+    llm_grid = create_hypercomm_grid(offset=llm_offset, tp=llm_tp, cp=llm_cp, pp=llm_pp, dp=llm_dp)
 
     # Create all embedding PGs upfront — dist.new_group is a collective that
     # requires ALL ranks to participate, so we must create them before any
@@ -776,16 +1023,102 @@ def run_mimo_1f1b_test(
         assert (
             grad_norm is not None and grad_norm > 0
         ), f"Expected positive grad norm, got {grad_norm}"
+        assert torch.isfinite(
+            torch.as_tensor(grad_norm)
+        ).all(), f"Expected finite grad norm, got {grad_norm}"
 
         # Verify results on last LLM stage
         if is_rank_in_grid(llm_grid) and is_pp_last_stage(llm_grid.get_pg("pp")):
             assert len(losses) > 0, "Expected losses on last LLM stage"
             for loss_dict in losses:
                 assert 'loss_reduced' in loss_dict
+                loss = torch.as_tensor(loss_dict['loss_reduced'])
+                assert torch.isfinite(loss).all(), f"Expected finite loss, got {loss}"
 
         return losses
     finally:
         mimo_model.destroy()
+
+
+def _run_deterministic_1f1b_configuration(
+    mimo_model,
+    module_to_grid_map,
+    topology,
+    language_pg,
+    vision_pg,
+    encoder_grid,
+    llm_grid,
+    encoder_name,
+    batches,
+    optimizer,
+    micro_batch_size,
+    seq_length,
+    num_microbatches,
+):
+    """Run one deterministic non-colocated 1F1B step and snapshot encoder gradients."""
+    mimo_model.config.no_sync_func = build_no_sync_func(mimo_model)
+    grad_sync_topology = SimpleNamespace(
+        grids=module_to_grid_map,
+        module_pgs={
+            MIMO_LANGUAGE_MODULE_KEY: language_pg,
+            **{name: vision_pg for name in mimo_model.modality_submodules},
+        },
+    )
+    configure_grad_sync(SimpleNamespace(), mimo_model, grad_sync_topology)
+
+    communicator = MultiModulePipelineCommunicator(
+        module_to_grid_map,
+        topology,
+        mimo_model.config,
+        dim_mapping={'s': 0, 'h': 2, 'b': 1},
+        module_output_ndim={encoder_name: 2},
+    )
+
+    module_pgs = {}
+    language_model_module_name = None
+    if is_rank_in_grid(encoder_grid):
+        module_pgs[encoder_name] = vision_pg
+    if is_rank_in_grid(llm_grid):
+        module_pgs[MIMO_LANGUAGE_MODULE_KEY] = language_pg
+        language_model_module_name = MIMO_LANGUAGE_MODULE_KEY
+    pg_collection = MultiModuleProcessGroupCollection(
+        module_pgs=module_pgs, language_model_module_name=language_model_module_name
+    )
+
+    needs_data = (
+        is_rank_in_grid(encoder_grid) and is_pp_first_stage(encoder_grid.get_pg("pp"))
+    ) or (
+        is_rank_in_grid(llm_grid)
+        and (is_pp_first_stage(llm_grid.get_pg("pp")) or is_pp_last_stage(llm_grid.get_pg("pp")))
+    )
+    data_iterator = _BatchIterator(batches) if needs_data else None
+
+    optimizer.zero_grad()
+    losses = schedule.forward_backward_pipelining_without_interleaving(
+        forward_step_func=_forward_step_with_per_token_loss,
+        data_iterator=data_iterator,
+        model=[mimo_model],
+        num_microbatches=num_microbatches,
+        seq_length=seq_length,
+        micro_batch_size=micro_batch_size,
+        forward_only=False,
+        p2p_communicator=communicator,
+        pg_collection=pg_collection,
+    )
+
+    encoder_grads = (
+        _snapshot_first_layer_encoder_grads(mimo_model, encoder_name)
+        if is_rank_in_grid(encoder_grid)
+        else {}
+    )
+    success, grad_norm, _ = optimizer.step()
+    assert success, "Optimizer step failed"
+    assert grad_norm is not None and grad_norm > 0, f"Expected positive grad norm, got {grad_norm}"
+    assert torch.isfinite(
+        torch.as_tensor(grad_norm)
+    ).all(), f"Expected finite grad norm, got {grad_norm}"
+    _assert_finite_losses(losses, llm_grid)
+    return encoder_grads
 
 
 # ============================================================================
@@ -925,6 +1258,224 @@ class TestMimo1F1BSchedule:
             micro_batch_size=4,
             num_microbatches=4,
         )
+
+    def test_fan_in_dp4_to_cp2_llm_pp2_8gpu(self):
+        """Destination CP=2 exercises steady-state and cooldown bridge backward paths."""
+        if self.world_size != 8:
+            pytest.skip(f"Requires 8 GPUs, got {self.world_size}")
+
+        run_mimo_1f1b_test(
+            encoder_tp=1,
+            encoder_cp=1,
+            encoder_pp=1,
+            encoder_dp=4,
+            encoder_offset=0,
+            llm_tp=1,
+            llm_cp=2,
+            llm_pp=2,
+            llm_dp=1,
+            llm_offset=4,
+            hidden_size=128,
+            num_layers=2,
+            vocab_size=1000,
+            seq_length=64,
+            micro_batch_size=4,
+            num_microbatches=4,
+        )
+
+    def test_noncolocated_cp2_matches_cp1_baseline(self):
+        """CP2 reconstructs the same encoder gradient as a deterministic CP1 baseline."""
+        if self.world_size != 8:
+            pytest.skip(f"Requires 8 GPUs, got {self.world_size}")
+
+        import os
+
+        for key, value in {
+            "NVTE_ALLOW_NONDETERMINISTIC_ALGO": "0",
+            "CUDA_DEVICE_MAX_CONNECTIONS": "1",
+            "CUBLAS_WORKSPACE_CONFIG": ":4096:8",
+        }.items():
+            os.environ[key] = value
+        os.environ.pop('NVTE_FLASH_ATTN', None)
+        os.environ.pop('NVTE_FUSED_ATTN', None)
+        os.environ.pop('NVTE_UNFUSED_ATTN', None)
+        previous_deterministic_algorithms = torch.are_deterministic_algorithms_enabled()
+        previous_cudnn_deterministic = torch.backends.cudnn.deterministic
+        previous_cudnn_benchmark = torch.backends.cudnn.benchmark
+        torch.use_deterministic_algorithms(True)
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False
+
+        encoder_name = "images"
+        hidden_size = 128
+        seq_length = 64
+        vocab_size = 1000
+        micro_batch_size = 4
+        num_microbatches = 4
+        ref_mimo = None
+        target_mimo = None
+
+        try:
+            ref_encoder_grid = create_hypercomm_grid(offset=0, tp=1, cp=1, pp=1, dp=4)
+            ref_llm_grid = create_hypercomm_grid(offset=4, tp=2, cp=1, pp=2, dp=1)
+            target_encoder_grid = create_hypercomm_grid(offset=0, tp=1, cp=1, pp=1, dp=4)
+            target_llm_grid = create_hypercomm_grid(offset=4, tp=1, cp=2, pp=2, dp=1)
+            create_all_embedding_groups(
+                [ref_encoder_grid, ref_llm_grid, target_encoder_grid, target_llm_grid]
+            )
+
+            ddp_config = DistributedDataParallelConfig(
+                overlap_grad_reduce=True, bucket_size=10000, use_distributed_optimizer=False
+            )
+
+            torch.manual_seed(12345)
+            (ref_mimo, ref_module_to_grid_map, ref_topology, ref_language_pg, ref_vision_pg) = (
+                get_mimo_model(
+                    encoder_name=encoder_name,
+                    encoder_grid=ref_encoder_grid,
+                    llm_grid=ref_llm_grid,
+                    hidden_size=hidden_size,
+                    num_layers=2,
+                    vocab_size=vocab_size,
+                    seq_len=seq_length,
+                    ddp_config=ddp_config,
+                    bf16=True,
+                    bias=False,
+                    dropout=False,
+                    per_token_loss=True,
+                )
+            )
+
+            torch.manual_seed(12345)
+            (
+                target_mimo,
+                target_module_to_grid_map,
+                target_topology,
+                target_language_pg,
+                target_vision_pg,
+            ) = get_mimo_model(
+                encoder_name=encoder_name,
+                encoder_grid=target_encoder_grid,
+                llm_grid=target_llm_grid,
+                hidden_size=hidden_size,
+                num_layers=2,
+                vocab_size=vocab_size,
+                seq_len=seq_length,
+                ddp_config=ddp_config,
+                bf16=True,
+                bias=False,
+                dropout=False,
+                per_token_loss=True,
+            )
+
+            if is_rank_in_grid(ref_encoder_grid):
+                _copy_ref_params_to_dist(
+                    ref_mimo.modality_submodules[encoder_name].module,
+                    target_mimo.modality_submodules[encoder_name].module,
+                    ref_encoder_grid.get_pg("tp"),
+                    target_encoder_grid.get_pg("tp"),
+                )
+            else:
+                assert is_rank_in_grid(ref_llm_grid)
+                _copy_ref_params_to_dist(
+                    ref_mimo.language_model.module,
+                    target_mimo.language_model.module,
+                    ref_llm_grid.get_pg("tp"),
+                    target_llm_grid.get_pg("tp"),
+                )
+            dist.barrier()
+
+            opt_config = OptimizerConfig(
+                optimizer='adam',
+                lr=1e-4,
+                weight_decay=0.01,
+                clip_grad=1.0,
+                bf16=True,
+                use_distributed_optimizer=False,
+            )
+            ref_optimizer = get_mimo_optimizer(ref_mimo, opt_config)
+
+            torch.manual_seed(99999)
+            global_batches = _generate_and_broadcast_global_batches(
+                global_micro_batch_size=micro_batch_size,
+                seq_length=seq_length,
+                hidden_size=hidden_size,
+                vocab_size=vocab_size,
+                encoder_name=encoder_name,
+                num_microbatches=num_microbatches,
+            )
+            ref_batches = _build_noncolocated_role_batches(
+                global_batches, ref_encoder_grid, ref_llm_grid
+            )
+            target_batches = _build_noncolocated_role_batches(
+                global_batches, target_encoder_grid, target_llm_grid
+            )
+
+            ref_grads = _run_deterministic_1f1b_configuration(
+                ref_mimo,
+                ref_module_to_grid_map,
+                ref_topology,
+                ref_language_pg,
+                ref_vision_pg,
+                ref_encoder_grid,
+                ref_llm_grid,
+                encoder_name,
+                ref_batches,
+                ref_optimizer,
+                micro_batch_size,
+                seq_length,
+                num_microbatches,
+            )
+            dist.barrier()
+            target_optimizer = get_mimo_optimizer(target_mimo, opt_config)
+            target_grads = _run_deterministic_1f1b_configuration(
+                target_mimo,
+                target_module_to_grid_map,
+                target_topology,
+                target_language_pg,
+                target_vision_pg,
+                target_encoder_grid,
+                target_llm_grid,
+                encoder_name,
+                target_batches,
+                target_optimizer,
+                micro_batch_size,
+                seq_length,
+                num_microbatches,
+            )
+
+            local_error = None
+            if is_rank_in_grid(ref_encoder_grid):
+                if set(ref_grads) != set(target_grads):
+                    local_error = (
+                        f"First-layer gradient names differ: reference={set(ref_grads)}, "
+                        f"target={set(target_grads)}"
+                    )
+                else:
+                    for name in sorted(ref_grads):
+                        try:
+                            torch.testing.assert_close(
+                                target_grads[name], ref_grads[name], rtol=1e-3, atol=1e-3
+                            )
+                        except AssertionError as error:
+                            local_error = f"First-layer gradient {name!r} differs: {error}"
+                            break
+
+            gradients_match = torch.tensor(
+                0 if local_error else 1, device='cuda', dtype=torch.int32
+            )
+            dist.all_reduce(gradients_match, op=dist.ReduceOp.MIN)
+            assert gradients_match.item() == 1, (
+                local_error or "A remote encoder rank reported a CP1-vs-CP2 gradient mismatch"
+            )
+        finally:
+            if target_mimo is not None:
+                target_mimo.destroy()
+            if ref_mimo is not None:
+                ref_mimo.destroy()
+            torch.use_deterministic_algorithms(previous_deterministic_algorithms)
+            torch.backends.cudnn.deterministic = previous_cudnn_deterministic
+            torch.backends.cudnn.benchmark = previous_cudnn_benchmark
 
     def test_fan_out_dp1_to_dp4_enc_tp2_pp2_8gpu(self):
         """Fan-out 1→4: Encoder TP=2 PP=2 DP=1 → LLM DP=4, on 8 GPUs.

--- a/tests/unit_tests/models/mimo/test_mimo_1f1b_schedule.py
+++ b/tests/unit_tests/models/mimo/test_mimo_1f1b_schedule.py
@@ -311,7 +311,6 @@ def get_vision_submodules_spec(
     from megatron.core.transformer.transformer_block import TransformerBlock
 
     tp_size = pg_collection.tp.size() if pg_collection.tp is not None else 1
-    cp_size = pg_collection.cp.size() if pg_collection.cp is not None else 1
     pp_size = pg_collection.pp.size() if pg_collection.pp is not None else 1
     pp_rank = dist.get_rank(pg_collection.pp)
 
@@ -335,7 +334,6 @@ def get_vision_submodules_spec(
         pipeline_dtype=pipeline_dtype,
         bf16=bf16,
         calculate_per_token_loss=per_token_loss,
-        context_parallel_size=cp_size,
         **extra_kwargs,
     )
     vision_encoder_spec = ModuleSpec(
@@ -580,248 +578,6 @@ class DataIterator:
         }
 
 
-class _BatchIterator:
-    """Finite iterator over deterministic, pre-generated microbatches."""
-
-    def __init__(self, batches):
-        self.batches = batches
-        self.index = 0
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        if self.index >= len(self.batches):
-            raise StopIteration
-        batch = self.batches[self.index]
-        self.index += 1
-        return batch
-
-
-def _clone_batch_value(value):
-    """Clone a nested batch so sequential reference/target runs cannot share mutations."""
-    if isinstance(value, torch.Tensor):
-        return value.clone()
-    if isinstance(value, dict):
-        return {key: _clone_batch_value(item) for key, item in value.items()}
-    return value
-
-
-def _generate_and_broadcast_global_batches(
-    global_micro_batch_size,
-    seq_length,
-    hidden_size,
-    vocab_size,
-    encoder_name,
-    num_microbatches,
-    modality_dtype=torch.bfloat16,
-    image_token_id=50257,
-):
-    """Generate deterministic global microbatches once and broadcast them to every rank."""
-    image_seq_length = seq_length // 2
-    batches = []
-
-    for _ in range(num_microbatches):
-        if dist.get_rank() == 0:
-            encoder_hidden_states = torch.randn(
-                image_seq_length,
-                global_micro_batch_size,
-                hidden_size,
-                device='cuda',
-                dtype=modality_dtype,
-            )
-            image_tokens = torch.full(
-                (global_micro_batch_size, image_seq_length),
-                image_token_id,
-                dtype=torch.long,
-                device='cuda',
-            )
-            text_tokens = torch.randint(
-                1,
-                vocab_size,
-                (global_micro_batch_size, seq_length - image_seq_length),
-                device='cuda',
-            )
-            input_ids = torch.cat([image_tokens, text_tokens], dim=1)
-        else:
-            encoder_hidden_states = torch.empty(
-                image_seq_length,
-                global_micro_batch_size,
-                hidden_size,
-                device='cuda',
-                dtype=modality_dtype,
-            )
-            input_ids = torch.empty(
-                global_micro_batch_size, seq_length, dtype=torch.long, device='cuda'
-            )
-
-        dist.broadcast(encoder_hidden_states, src=0)
-        dist.broadcast(input_ids, src=0)
-
-        labels = input_ids.clone()
-        labels[input_ids == image_token_id] = -100
-        loss_mask = torch.ones(
-            global_micro_batch_size, seq_length, device='cuda', dtype=torch.float32
-        )
-        loss_mask[input_ids == image_token_id] = 0.0
-        position_ids = (
-            torch.arange(seq_length, device='cuda')
-            .unsqueeze(0)
-            .expand(global_micro_batch_size, -1)
-            .clone()
-        )
-        batches.append(
-            {
-                "input_ids": input_ids,
-                "labels": labels,
-                "loss_mask": loss_mask,
-                "position_ids": position_ids,
-                "modality_inputs": {
-                    encoder_name: {
-                        "clip_encoder": {
-                            'hidden_states': encoder_hidden_states,
-                            'attention_mask': None,
-                        }
-                    }
-                },
-            }
-        )
-
-    return batches
-
-
-def _slice_batch(global_batch, num_slices, slice_rank):
-    """Slice a global batch for one encoder DP rank."""
-    batch_size = global_batch['input_ids'].shape[0]
-    assert batch_size % num_slices == 0
-    slice_size = batch_size // num_slices
-    start = slice_rank * slice_size
-    end = start + slice_size
-
-    batch = {
-        key: global_batch[key][start:end].contiguous()
-        for key in ['input_ids', 'labels', 'loss_mask', 'position_ids']
-    }
-    batch['modality_inputs'] = {}
-    for modality_name, modality_data in global_batch['modality_inputs'].items():
-        batch['modality_inputs'][modality_name] = {}
-        for encoder_name, encoder_data in modality_data.items():
-            batch['modality_inputs'][modality_name][encoder_name] = {}
-            for key, tensor in encoder_data.items():
-                if isinstance(tensor, torch.Tensor):
-                    batch['modality_inputs'][modality_name][encoder_name][key] = tensor[
-                        :, start:end, :
-                    ].contiguous()
-                else:
-                    batch['modality_inputs'][modality_name][encoder_name][key] = tensor
-    return batch
-
-
-def _build_noncolocated_role_batches(global_batches, encoder_grid, llm_grid):
-    """Build encoder-DP slices or full LLM batches for this disjoint-grid rank."""
-    if is_rank_in_grid(encoder_grid):
-        encoder_dp = encoder_grid.get_pg("dp")
-        return [
-            _slice_batch(batch, encoder_dp.size(), encoder_dp.rank()) for batch in global_batches
-        ]
-    if is_rank_in_grid(llm_grid):
-        return [_clone_batch_value(batch) for batch in global_batches]
-    raise AssertionError(f"Rank {dist.get_rank()} belongs to neither MIMO grid")
-
-
-def _copy_ref_params_to_dist(ref_module, dist_module, ref_tp_group, dist_tp_group):
-    """Copy parameters across differing TP layouts by gathering then re-slicing shards.
-
-    This helper is shared with the colocated MIMO correctness tests. It must be called before
-    constructing the distributed optimizer, which snapshots parameter data into master weights.
-    """
-    ref_tp_size = ref_tp_group.size()
-    dist_tp_size = dist_tp_group.size()
-    dist_tp_rank = dist_tp_group.rank()
-    ref_params = dict(ref_module.named_parameters())
-
-    with torch.no_grad():
-        for name, dist_param in dist_module.named_parameters():
-            assert name in ref_params, f"Distributed parameter {name!r} is missing from reference"
-            ref_param = ref_params[name]
-            if ref_param.shape == dist_param.shape:
-                dist_param.data.copy_(ref_param.data.to(dist_param.dtype))
-                continue
-
-            partition_dim = getattr(dist_param, 'partition_dim', -1)
-            assert partition_dim >= 0, (
-                f"Parameter {name!r} differs in shape but has no TP partition dimension: "
-                f"reference={tuple(ref_param.shape)}, distributed={tuple(dist_param.shape)}"
-            )
-            ref_shards = [torch.empty_like(ref_param.data) for _ in range(ref_tp_size)]
-            dist.all_gather(ref_shards, ref_param.data.contiguous(), group=ref_tp_group)
-            full_param = torch.cat(ref_shards, dim=partition_dim)
-            dist_shard = torch.tensor_split(full_param, dist_tp_size, dim=partition_dim)[
-                dist_tp_rank
-            ]
-            assert dist_shard.shape == dist_param.shape, (
-                f"Parameter {name!r} reshard shape {tuple(dist_shard.shape)} does not match "
-                f"distributed shape {tuple(dist_param.shape)}"
-            )
-            dist_param.data.copy_(dist_shard.to(dist_param.dtype))
-
-
-def _snapshot_first_layer_encoder_grads(mimo_model, encoder_name):
-    """Snapshot first-layer encoder main gradients before the optimizer consumes them."""
-    encoder = mimo_model.modality_submodules[encoder_name].module
-    gradients = {}
-    for name, parameter in encoder.named_parameters():
-        if '.layers.0.' not in name:
-            continue
-        main_grad = getattr(parameter, 'main_grad', None)
-        if main_grad is not None:
-            gradients[name] = main_grad.detach().clone()
-    assert gradients, "Expected non-empty first-layer encoder main_grad snapshot"
-    return gradients
-
-
-def _forward_step_with_per_token_loss(data_iterator, model):
-    """Forward step using the per-token loss contract expected by configure_grad_sync."""
-
-    def loss_func(loss_mask, output_tensor):
-        def _ret(loss, num_tokens, reduced):
-            return loss, num_tokens, {'loss_reduced': reduced}
-
-        zero = torch.tensor(0.0, device='cuda', requires_grad=True)
-        one = torch.tensor(1, device='cuda', dtype=torch.int)
-        if output_tensor is None:
-            return _ret(zero, one, 0.0)
-
-        if isinstance(output_tensor, dict):
-            output = output_tensor.get(
-                MIMO_LANGUAGE_MODULE_KEY, next(iter(output_tensor.values()), None)
-            )
-        else:
-            output = output_tensor
-
-        if output is None:
-            return _ret(zero, one, 0.0)
-
-        loss = output.float().sum()
-        num_tokens = loss_mask.sum().to(torch.int).clamp(min=1) if loss_mask is not None else one
-        return _ret(loss, num_tokens, loss)
-
-    batch = next(data_iterator) if data_iterator is not None else {'input_ids': None}
-    output_tensor, loss_mask = model(**batch)
-    return output_tensor, partial(loss_func, loss_mask)
-
-
-def _assert_finite_losses(losses, llm_grid):
-    """Require finite reported losses on the terminal language stage."""
-    if not (is_rank_in_grid(llm_grid) and is_pp_last_stage(llm_grid.get_pg("pp"))):
-        return
-    assert losses, "Expected losses on last LLM stage"
-    for loss_dict in losses:
-        assert 'loss_reduced' in loss_dict
-        loss = torch.as_tensor(loss_dict['loss_reduced'])
-        assert torch.isfinite(loss).all(), f"Expected finite loss, got {loss}"
-
-
 # ============================================================================
 # Test Runner
 # ============================================================================
@@ -836,7 +592,6 @@ def run_mimo_1f1b_test(
     llm_pp,
     llm_dp,
     llm_offset,
-    encoder_cp=1,
     llm_cp=1,
     hidden_size=256,
     num_layers=2,
@@ -864,7 +619,7 @@ def run_mimo_1f1b_test(
     encoder_name = "images"
 
     encoder_grid = create_hypercomm_grid(
-        offset=encoder_offset, tp=encoder_tp, cp=encoder_cp, pp=encoder_pp, dp=encoder_dp
+        offset=encoder_offset, tp=encoder_tp, cp=1, pp=encoder_pp, dp=encoder_dp
     )
     llm_grid = create_hypercomm_grid(offset=llm_offset, tp=llm_tp, cp=llm_cp, pp=llm_pp, dp=llm_dp)
 
@@ -1040,87 +795,6 @@ def run_mimo_1f1b_test(
         mimo_model.destroy()
 
 
-def _run_deterministic_1f1b_configuration(
-    mimo_model,
-    module_to_grid_map,
-    topology,
-    language_pg,
-    vision_pg,
-    encoder_grid,
-    llm_grid,
-    encoder_name,
-    batches,
-    optimizer,
-    micro_batch_size,
-    seq_length,
-    num_microbatches,
-):
-    """Run one deterministic non-colocated 1F1B step and snapshot encoder gradients."""
-    mimo_model.config.no_sync_func = build_no_sync_func(mimo_model)
-    grad_sync_topology = SimpleNamespace(
-        grids=module_to_grid_map,
-        module_pgs={
-            MIMO_LANGUAGE_MODULE_KEY: language_pg,
-            **{name: vision_pg for name in mimo_model.modality_submodules},
-        },
-    )
-    configure_grad_sync(SimpleNamespace(), mimo_model, grad_sync_topology)
-
-    communicator = MultiModulePipelineCommunicator(
-        module_to_grid_map,
-        topology,
-        mimo_model.config,
-        dim_mapping={'s': 0, 'h': 2, 'b': 1},
-        module_output_ndim={encoder_name: 2},
-    )
-
-    module_pgs = {}
-    language_model_module_name = None
-    if is_rank_in_grid(encoder_grid):
-        module_pgs[encoder_name] = vision_pg
-    if is_rank_in_grid(llm_grid):
-        module_pgs[MIMO_LANGUAGE_MODULE_KEY] = language_pg
-        language_model_module_name = MIMO_LANGUAGE_MODULE_KEY
-    pg_collection = MultiModuleProcessGroupCollection(
-        module_pgs=module_pgs, language_model_module_name=language_model_module_name
-    )
-
-    needs_data = (
-        is_rank_in_grid(encoder_grid) and is_pp_first_stage(encoder_grid.get_pg("pp"))
-    ) or (
-        is_rank_in_grid(llm_grid)
-        and (is_pp_first_stage(llm_grid.get_pg("pp")) or is_pp_last_stage(llm_grid.get_pg("pp")))
-    )
-    data_iterator = _BatchIterator(batches) if needs_data else None
-
-    optimizer.zero_grad()
-    losses = schedule.forward_backward_pipelining_without_interleaving(
-        forward_step_func=_forward_step_with_per_token_loss,
-        data_iterator=data_iterator,
-        model=[mimo_model],
-        num_microbatches=num_microbatches,
-        seq_length=seq_length,
-        micro_batch_size=micro_batch_size,
-        forward_only=False,
-        p2p_communicator=communicator,
-        pg_collection=pg_collection,
-    )
-
-    encoder_grads = (
-        _snapshot_first_layer_encoder_grads(mimo_model, encoder_name)
-        if is_rank_in_grid(encoder_grid)
-        else {}
-    )
-    success, grad_norm, _ = optimizer.step()
-    assert success, "Optimizer step failed"
-    assert grad_norm is not None and grad_norm > 0, f"Expected positive grad norm, got {grad_norm}"
-    assert torch.isfinite(
-        torch.as_tensor(grad_norm)
-    ).all(), f"Expected finite grad norm, got {grad_norm}"
-    _assert_finite_losses(losses, llm_grid)
-    return encoder_grads
-
-
 # ============================================================================
 # Tests
 # ============================================================================
@@ -1233,11 +907,17 @@ class TestMimo1F1BSchedule:
             num_microbatches=4,
         )
 
-    def test_fan_in_dp4_to_dp1_llm_tp2_pp2_8gpu(self):
-        """Fan-in 4→1: Encoder DP=4 → LLM TP=2 PP=2 DP=1, on 8 GPUs.
+    @pytest.mark.parametrize(
+        "llm_tp,llm_cp,hidden_size",
+        [(2, 1, 256), (1, 2, 128)],
+        ids=["tp2-cp1", "tp1-cp2"],
+    )
+    def test_fan_in_dp4_to_dp1_llm_pp2_8gpu(self, llm_tp, llm_cp, hidden_size):
+        """Fan-in 4→1: Encoder DP=4 → LLM PP=2 DP=1 with TP or CP.
 
         High fan-in ratio. Each encoder rank processes MBS=1, bridge concatenates
-        4 × [img_seq, H] → [4*img_seq, H]. LLM has both TP and PP.
+        4 × [img_seq, H] → [4*img_seq, H]. The CP2 case exercises destination
+        CP gradient reconstruction in steady-state and cooldown backward paths.
         """
         if self.world_size != 8:
             pytest.skip(f"Requires 8 GPUs, got {self.world_size}")
@@ -1247,235 +927,18 @@ class TestMimo1F1BSchedule:
             encoder_pp=1,
             encoder_dp=4,
             encoder_offset=0,
-            llm_tp=2,
+            llm_tp=llm_tp,
+            llm_cp=llm_cp,
             llm_pp=2,
             llm_dp=1,
             llm_offset=4,
-            hidden_size=256,
+            hidden_size=hidden_size,
             num_layers=2,
             vocab_size=1000,
             seq_length=64,
             micro_batch_size=4,
             num_microbatches=4,
         )
-
-    def test_fan_in_dp4_to_cp2_llm_pp2_8gpu(self):
-        """Destination CP=2 exercises steady-state and cooldown bridge backward paths."""
-        if self.world_size != 8:
-            pytest.skip(f"Requires 8 GPUs, got {self.world_size}")
-
-        run_mimo_1f1b_test(
-            encoder_tp=1,
-            encoder_cp=1,
-            encoder_pp=1,
-            encoder_dp=4,
-            encoder_offset=0,
-            llm_tp=1,
-            llm_cp=2,
-            llm_pp=2,
-            llm_dp=1,
-            llm_offset=4,
-            hidden_size=128,
-            num_layers=2,
-            vocab_size=1000,
-            seq_length=64,
-            micro_batch_size=4,
-            num_microbatches=4,
-        )
-
-    def test_noncolocated_cp2_matches_cp1_baseline(self):
-        """CP2 reconstructs the same encoder gradient as a deterministic CP1 baseline."""
-        if self.world_size != 8:
-            pytest.skip(f"Requires 8 GPUs, got {self.world_size}")
-
-        import os
-
-        for key, value in {
-            "NVTE_ALLOW_NONDETERMINISTIC_ALGO": "0",
-            "CUDA_DEVICE_MAX_CONNECTIONS": "1",
-            "CUBLAS_WORKSPACE_CONFIG": ":4096:8",
-        }.items():
-            os.environ[key] = value
-        os.environ.pop('NVTE_FLASH_ATTN', None)
-        os.environ.pop('NVTE_FUSED_ATTN', None)
-        os.environ.pop('NVTE_UNFUSED_ATTN', None)
-        previous_deterministic_algorithms = torch.are_deterministic_algorithms_enabled()
-        previous_cudnn_deterministic = torch.backends.cudnn.deterministic
-        previous_cudnn_benchmark = torch.backends.cudnn.benchmark
-        torch.use_deterministic_algorithms(True)
-        torch.backends.cudnn.deterministic = True
-        torch.backends.cudnn.benchmark = False
-
-        encoder_name = "images"
-        hidden_size = 128
-        seq_length = 64
-        vocab_size = 1000
-        micro_batch_size = 4
-        num_microbatches = 4
-        ref_mimo = None
-        target_mimo = None
-
-        try:
-            ref_encoder_grid = create_hypercomm_grid(offset=0, tp=1, cp=1, pp=1, dp=4)
-            ref_llm_grid = create_hypercomm_grid(offset=4, tp=2, cp=1, pp=2, dp=1)
-            target_encoder_grid = create_hypercomm_grid(offset=0, tp=1, cp=1, pp=1, dp=4)
-            target_llm_grid = create_hypercomm_grid(offset=4, tp=1, cp=2, pp=2, dp=1)
-            create_all_embedding_groups(
-                [ref_encoder_grid, ref_llm_grid, target_encoder_grid, target_llm_grid]
-            )
-
-            ddp_config = DistributedDataParallelConfig(
-                overlap_grad_reduce=True, bucket_size=10000, use_distributed_optimizer=False
-            )
-
-            torch.manual_seed(12345)
-            (ref_mimo, ref_module_to_grid_map, ref_topology, ref_language_pg, ref_vision_pg) = (
-                get_mimo_model(
-                    encoder_name=encoder_name,
-                    encoder_grid=ref_encoder_grid,
-                    llm_grid=ref_llm_grid,
-                    hidden_size=hidden_size,
-                    num_layers=2,
-                    vocab_size=vocab_size,
-                    seq_len=seq_length,
-                    ddp_config=ddp_config,
-                    bf16=True,
-                    bias=False,
-                    dropout=False,
-                    per_token_loss=True,
-                )
-            )
-
-            torch.manual_seed(12345)
-            (
-                target_mimo,
-                target_module_to_grid_map,
-                target_topology,
-                target_language_pg,
-                target_vision_pg,
-            ) = get_mimo_model(
-                encoder_name=encoder_name,
-                encoder_grid=target_encoder_grid,
-                llm_grid=target_llm_grid,
-                hidden_size=hidden_size,
-                num_layers=2,
-                vocab_size=vocab_size,
-                seq_len=seq_length,
-                ddp_config=ddp_config,
-                bf16=True,
-                bias=False,
-                dropout=False,
-                per_token_loss=True,
-            )
-
-            if is_rank_in_grid(ref_encoder_grid):
-                _copy_ref_params_to_dist(
-                    ref_mimo.modality_submodules[encoder_name].module,
-                    target_mimo.modality_submodules[encoder_name].module,
-                    ref_encoder_grid.get_pg("tp"),
-                    target_encoder_grid.get_pg("tp"),
-                )
-            else:
-                assert is_rank_in_grid(ref_llm_grid)
-                _copy_ref_params_to_dist(
-                    ref_mimo.language_model.module,
-                    target_mimo.language_model.module,
-                    ref_llm_grid.get_pg("tp"),
-                    target_llm_grid.get_pg("tp"),
-                )
-            dist.barrier()
-
-            opt_config = OptimizerConfig(
-                optimizer='adam',
-                lr=1e-4,
-                weight_decay=0.01,
-                clip_grad=1.0,
-                bf16=True,
-                use_distributed_optimizer=False,
-            )
-            ref_optimizer = get_mimo_optimizer(ref_mimo, opt_config)
-
-            torch.manual_seed(99999)
-            global_batches = _generate_and_broadcast_global_batches(
-                global_micro_batch_size=micro_batch_size,
-                seq_length=seq_length,
-                hidden_size=hidden_size,
-                vocab_size=vocab_size,
-                encoder_name=encoder_name,
-                num_microbatches=num_microbatches,
-            )
-            ref_batches = _build_noncolocated_role_batches(
-                global_batches, ref_encoder_grid, ref_llm_grid
-            )
-            target_batches = _build_noncolocated_role_batches(
-                global_batches, target_encoder_grid, target_llm_grid
-            )
-
-            ref_grads = _run_deterministic_1f1b_configuration(
-                ref_mimo,
-                ref_module_to_grid_map,
-                ref_topology,
-                ref_language_pg,
-                ref_vision_pg,
-                ref_encoder_grid,
-                ref_llm_grid,
-                encoder_name,
-                ref_batches,
-                ref_optimizer,
-                micro_batch_size,
-                seq_length,
-                num_microbatches,
-            )
-            dist.barrier()
-            target_optimizer = get_mimo_optimizer(target_mimo, opt_config)
-            target_grads = _run_deterministic_1f1b_configuration(
-                target_mimo,
-                target_module_to_grid_map,
-                target_topology,
-                target_language_pg,
-                target_vision_pg,
-                target_encoder_grid,
-                target_llm_grid,
-                encoder_name,
-                target_batches,
-                target_optimizer,
-                micro_batch_size,
-                seq_length,
-                num_microbatches,
-            )
-
-            local_error = None
-            if is_rank_in_grid(ref_encoder_grid):
-                if set(ref_grads) != set(target_grads):
-                    local_error = (
-                        f"First-layer gradient names differ: reference={set(ref_grads)}, "
-                        f"target={set(target_grads)}"
-                    )
-                else:
-                    for name in sorted(ref_grads):
-                        try:
-                            torch.testing.assert_close(
-                                target_grads[name], ref_grads[name], rtol=1e-3, atol=1e-3
-                            )
-                        except AssertionError as error:
-                            local_error = f"First-layer gradient {name!r} differs: {error}"
-                            break
-
-            gradients_match = torch.tensor(
-                0 if local_error else 1, device='cuda', dtype=torch.int32
-            )
-            dist.all_reduce(gradients_match, op=dist.ReduceOp.MIN)
-            assert gradients_match.item() == 1, (
-                local_error or "A remote encoder rank reported a CP1-vs-CP2 gradient mismatch"
-            )
-        finally:
-            if target_mimo is not None:
-                target_mimo.destroy()
-            if ref_mimo is not None:
-                ref_mimo.destroy()
-            torch.use_deterministic_algorithms(previous_deterministic_algorithms)
-            torch.backends.cudnn.deterministic = previous_cudnn_deterministic
-            torch.backends.cudnn.benchmark = previous_cudnn_benchmark
 
     def test_fan_out_dp1_to_dp4_enc_tp2_pp2_8gpu(self):
         """Fan-out 1→4: Encoder TP=2 PP=2 DP=1 → LLM DP=4, on 8 GPUs.

--- a/tests/unit_tests/models/mimo/test_mimo_1f1b_schedule.py
+++ b/tests/unit_tests/models/mimo/test_mimo_1f1b_schedule.py
@@ -908,9 +908,7 @@ class TestMimo1F1BSchedule:
         )
 
     @pytest.mark.parametrize(
-        "llm_tp,llm_cp,hidden_size",
-        [(2, 1, 256), (1, 2, 128)],
-        ids=["tp2-cp1", "tp1-cp2"],
+        "llm_tp,llm_cp,hidden_size", [(2, 1, 256), (1, 2, 128)], ids=["tp2-cp1", "tp1-cp2"]
     )
     def test_fan_in_dp4_to_dp1_llm_pp2_8gpu(self, llm_tp, llm_cp, hidden_size):
         """Fan-in 4→1: Encoder DP=4 → LLM PP=2 DP=1 with TP or CP.

--- a/tests/unit_tests/models/mimo/test_mimo_colocated_correctness.py
+++ b/tests/unit_tests/models/mimo/test_mimo_colocated_correctness.py
@@ -68,7 +68,6 @@ from megatron.core.optimizer.optimizer_config import OptimizerConfig
 from megatron.core.transformer.enums import ModelType
 from megatron.core.utils import unwrap_model
 from tests.unit_tests.models.mimo.test_mimo_1f1b_schedule import (
-    _copy_ref_params_to_dist,
     build_no_sync_func,
     create_all_embedding_groups,
     create_hypercomm_grid,
@@ -196,6 +195,7 @@ def _generate_and_broadcast_global_batches(
     num_batches,
     image_token_id=50257,
     mask_pattern="uniform",
+    modality_dtype=torch.float32,
 ):
     """Generate global batches on rank 0 and broadcast so every rank sees
     identical data. Dist pre-slices per rank; ref consumes the full batch.
@@ -221,7 +221,11 @@ def _generate_and_broadcast_global_batches(
     for batch_idx in range(num_batches):
         if rank == 0:
             encoder_hidden_states = torch.randn(
-                image_seq_length, global_mbs, hidden_size, device='cuda', dtype=torch.float32
+                image_seq_length,
+                global_mbs,
+                hidden_size,
+                device='cuda',
+                dtype=modality_dtype,
             )
             image_tokens = torch.full(
                 (global_mbs, image_seq_length), image_token_id, dtype=torch.long, device='cuda'
@@ -232,7 +236,11 @@ def _generate_and_broadcast_global_batches(
             input_ids = torch.cat([image_tokens, text_tokens], dim=1)
         else:
             encoder_hidden_states = torch.empty(
-                image_seq_length, global_mbs, hidden_size, device='cuda', dtype=torch.float32
+                image_seq_length,
+                global_mbs,
+                hidden_size,
+                device='cuda',
+                dtype=modality_dtype,
             )
             input_ids = torch.empty(global_mbs, seq_length, dtype=torch.long, device='cuda')
 
@@ -335,6 +343,57 @@ def _slice_global_batch_by_dp(global_batch, dp_pg):
     if dp_size <= 1:
         return global_batch
     return _slice_batch(global_batch, dp_size, dist.get_rank(dp_pg))
+
+
+def _copy_ref_params_to_dist(ref_module, dist_module, ref_tp_group, dist_tp_group):
+    """Copy ref params into dist, handling differing TP shardings.
+
+    When ref and dist params have the same shape (same TP size and layout
+    at offset=0), shards align 1:1 and we copy directly. When shapes differ
+    (different TP sizes), we all-gather ref's shards across ``ref_tp_group``
+    to reconstruct the full weight, then slice by the dist ``partition_dim``
+    for this rank's dist TP shard.
+
+    Must be called **before** constructing the distributed optimizer, which
+    clones current param data into fp32 master weights at __init__.
+    """
+    ref_tp_size = dist.get_world_size(ref_tp_group)
+    dist_tp_rank = dist.get_rank(dist_tp_group)
+    dist_tp_size = dist.get_world_size(dist_tp_group)
+    ref_params = dict(ref_module.named_parameters())
+
+    with torch.no_grad():
+        for name, dist_param in dist_module.named_parameters():
+            assert name in ref_params, f"Param '{name}' in dist but not in ref"
+            ref_param = ref_params[name]
+            partition_dim = getattr(dist_param, 'partition_dim', -1)
+
+            if ref_param.shape == dist_param.shape:
+                # Same shard size (same TP layout or both replicated).
+                dist_param.data.copy_(ref_param.data.to(dist_param.dtype))
+                continue
+
+            assert partition_dim >= 0, (
+                f"Param '{name}': shapes differ "
+                f"(ref={tuple(ref_param.shape)}, dist={tuple(dist_param.shape)}) "
+                f"but partition_dim<0 — cannot reshard a replicated param."
+            )
+
+            # Different TP sizes: gather ref shards, then slice for dist.
+            shards = [torch.empty_like(ref_param.data) for _ in range(ref_tp_size)]
+            dist.all_gather(shards, ref_param.data.contiguous(), group=ref_tp_group)
+            full_weight = torch.cat(shards, dim=partition_dim)
+            dist_slice = torch.tensor_split(full_weight, dist_tp_size, dim=partition_dim)[
+                dist_tp_rank
+            ]
+
+            assert dist_slice.shape == dist_param.shape, (
+                f"Param '{name}': sliced.shape={tuple(dist_slice.shape)} != "
+                f"dist.shape={tuple(dist_param.shape)} "
+                f"(ref_tp={ref_tp_size}, dist_tp={dist_tp_size}, "
+                f"partition_dim={partition_dim})"
+            )
+            dist_param.data.copy_(dist_slice.to(dist_param.dtype))
 
 
 def _global_abs_diff_stats(a, b, pg=None):

--- a/tests/unit_tests/models/mimo/test_mimo_colocated_correctness.py
+++ b/tests/unit_tests/models/mimo/test_mimo_colocated_correctness.py
@@ -68,6 +68,7 @@ from megatron.core.optimizer.optimizer_config import OptimizerConfig
 from megatron.core.transformer.enums import ModelType
 from megatron.core.utils import unwrap_model
 from tests.unit_tests.models.mimo.test_mimo_1f1b_schedule import (
+    _copy_ref_params_to_dist,
     build_no_sync_func,
     create_all_embedding_groups,
     create_hypercomm_grid,
@@ -334,57 +335,6 @@ def _slice_global_batch_by_dp(global_batch, dp_pg):
     if dp_size <= 1:
         return global_batch
     return _slice_batch(global_batch, dp_size, dist.get_rank(dp_pg))
-
-
-def _copy_ref_params_to_dist(ref_module, dist_module, ref_tp_group, dist_tp_group):
-    """Copy ref params into dist, handling differing TP shardings.
-
-    When ref and dist params have the same shape (same TP size and layout
-    at offset=0), shards align 1:1 and we copy directly. When shapes differ
-    (different TP sizes), we all-gather ref's shards across ``ref_tp_group``
-    to reconstruct the full weight, then slice by the dist ``partition_dim``
-    for this rank's dist TP shard.
-
-    Must be called **before** constructing the distributed optimizer, which
-    clones current param data into fp32 master weights at __init__.
-    """
-    ref_tp_size = dist.get_world_size(ref_tp_group)
-    dist_tp_rank = dist.get_rank(dist_tp_group)
-    dist_tp_size = dist.get_world_size(dist_tp_group)
-    ref_params = dict(ref_module.named_parameters())
-
-    with torch.no_grad():
-        for name, dist_param in dist_module.named_parameters():
-            assert name in ref_params, f"Param '{name}' in dist but not in ref"
-            ref_param = ref_params[name]
-            partition_dim = getattr(dist_param, 'partition_dim', -1)
-
-            if ref_param.shape == dist_param.shape:
-                # Same shard size (same TP layout or both replicated).
-                dist_param.data.copy_(ref_param.data.to(dist_param.dtype))
-                continue
-
-            assert partition_dim >= 0, (
-                f"Param '{name}': shapes differ "
-                f"(ref={tuple(ref_param.shape)}, dist={tuple(dist_param.shape)}) "
-                f"but partition_dim<0 — cannot reshard a replicated param."
-            )
-
-            # Different TP sizes: gather ref shards, then slice for dist.
-            shards = [torch.empty_like(ref_param.data) for _ in range(ref_tp_size)]
-            dist.all_gather(shards, ref_param.data.contiguous(), group=ref_tp_group)
-            full_weight = torch.cat(shards, dim=partition_dim)
-            dist_slice = torch.tensor_split(full_weight, dist_tp_size, dim=partition_dim)[
-                dist_tp_rank
-            ]
-
-            assert dist_slice.shape == dist_param.shape, (
-                f"Param '{name}': sliced.shape={tuple(dist_slice.shape)} != "
-                f"dist.shape={tuple(dist_param.shape)} "
-                f"(ref_tp={ref_tp_size}, dist_tp={dist_tp_size}, "
-                f"partition_dim={partition_dim})"
-            )
-            dist_param.data.copy_(dist_slice.to(dist_param.dtype))
 
 
 def _global_abs_diff_stats(a, b, pg=None):

--- a/tests/unit_tests/models/mimo/test_mimo_colocated_correctness.py
+++ b/tests/unit_tests/models/mimo/test_mimo_colocated_correctness.py
@@ -195,6 +195,7 @@ def _generate_and_broadcast_global_batches(
     num_batches,
     image_token_id=50257,
     mask_pattern="uniform",
+    modality_dtype=torch.float32,
 ):
     """Generate global batches on rank 0 and broadcast so every rank sees
     identical data. Dist pre-slices per rank; ref consumes the full batch.
@@ -220,7 +221,11 @@ def _generate_and_broadcast_global_batches(
     for batch_idx in range(num_batches):
         if rank == 0:
             encoder_hidden_states = torch.randn(
-                image_seq_length, global_mbs, hidden_size, device='cuda', dtype=torch.float32
+                image_seq_length,
+                global_mbs,
+                hidden_size,
+                device='cuda',
+                dtype=modality_dtype,
             )
             image_tokens = torch.full(
                 (global_mbs, image_seq_length), image_token_id, dtype=torch.long, device='cuda'
@@ -231,7 +236,11 @@ def _generate_and_broadcast_global_batches(
             input_ids = torch.cat([image_tokens, text_tokens], dim=1)
         else:
             encoder_hidden_states = torch.empty(
-                image_seq_length, global_mbs, hidden_size, device='cuda', dtype=torch.float32
+                image_seq_length,
+                global_mbs,
+                hidden_size,
+                device='cuda',
+                dtype=modality_dtype,
             )
             input_ids = torch.empty(global_mbs, seq_length, dtype=torch.long, device='cuda')
 
@@ -334,6 +343,57 @@ def _slice_global_batch_by_dp(global_batch, dp_pg):
     if dp_size <= 1:
         return global_batch
     return _slice_batch(global_batch, dp_size, dist.get_rank(dp_pg))
+
+
+def _copy_ref_params_to_dist(ref_module, dist_module, ref_tp_group, dist_tp_group):
+    """Copy ref params into dist, handling differing TP shardings.
+
+    When ref and dist params have the same shape (same TP size and layout
+    at offset=0), shards align 1:1 and we copy directly. When shapes differ
+    (different TP sizes), we all-gather ref's shards across ``ref_tp_group``
+    to reconstruct the full weight, then slice by the dist ``partition_dim``
+    for this rank's dist TP shard.
+
+    Must be called **before** constructing the distributed optimizer, which
+    clones current param data into fp32 master weights at __init__.
+    """
+    ref_tp_size = dist.get_world_size(ref_tp_group)
+    dist_tp_rank = dist.get_rank(dist_tp_group)
+    dist_tp_size = dist.get_world_size(dist_tp_group)
+    ref_params = dict(ref_module.named_parameters())
+
+    with torch.no_grad():
+        for name, dist_param in dist_module.named_parameters():
+            assert name in ref_params, f"Param '{name}' in dist but not in ref"
+            ref_param = ref_params[name]
+            partition_dim = getattr(dist_param, 'partition_dim', -1)
+
+            if ref_param.shape == dist_param.shape:
+                # Same shard size (same TP layout or both replicated).
+                dist_param.data.copy_(ref_param.data.to(dist_param.dtype))
+                continue
+
+            assert partition_dim >= 0, (
+                f"Param '{name}': shapes differ "
+                f"(ref={tuple(ref_param.shape)}, dist={tuple(dist_param.shape)}) "
+                f"but partition_dim<0 — cannot reshard a replicated param."
+            )
+
+            # Different TP sizes: gather ref shards, then slice for dist.
+            shards = [torch.empty_like(ref_param.data) for _ in range(ref_tp_size)]
+            dist.all_gather(shards, ref_param.data.contiguous(), group=ref_tp_group)
+            full_weight = torch.cat(shards, dim=partition_dim)
+            dist_slice = torch.tensor_split(full_weight, dist_tp_size, dim=partition_dim)[
+                dist_tp_rank
+            ]
+
+            assert dist_slice.shape == dist_param.shape, (
+                f"Param '{name}': sliced.shape={tuple(dist_slice.shape)} != "
+                f"dist.shape={tuple(dist_param.shape)} "
+                f"(ref_tp={ref_tp_size}, dist_tp={dist_tp_size}, "
+                f"partition_dim={partition_dim})"
+            )
+            dist_param.data.copy_(dist_slice.to(dist_param.dtype))
 
 
 def _global_abs_diff_stats(a, b, pg=None):

--- a/tests/unit_tests/models/mimo/test_mimo_colocated_correctness.py
+++ b/tests/unit_tests/models/mimo/test_mimo_colocated_correctness.py
@@ -336,57 +336,6 @@ def _slice_global_batch_by_dp(global_batch, dp_pg):
     return _slice_batch(global_batch, dp_size, dist.get_rank(dp_pg))
 
 
-def _copy_ref_params_to_dist(ref_module, dist_module, ref_tp_group, dist_tp_group):
-    """Copy ref params into dist, handling differing TP shardings.
-
-    When ref and dist params have the same shape (same TP size and layout
-    at offset=0), shards align 1:1 and we copy directly. When shapes differ
-    (different TP sizes), we all-gather ref's shards across ``ref_tp_group``
-    to reconstruct the full weight, then slice by the dist ``partition_dim``
-    for this rank's dist TP shard.
-
-    Must be called **before** constructing the distributed optimizer, which
-    clones current param data into fp32 master weights at __init__.
-    """
-    ref_tp_size = dist.get_world_size(ref_tp_group)
-    dist_tp_rank = dist.get_rank(dist_tp_group)
-    dist_tp_size = dist.get_world_size(dist_tp_group)
-    ref_params = dict(ref_module.named_parameters())
-
-    with torch.no_grad():
-        for name, dist_param in dist_module.named_parameters():
-            assert name in ref_params, f"Param '{name}' in dist but not in ref"
-            ref_param = ref_params[name]
-            partition_dim = getattr(dist_param, 'partition_dim', -1)
-
-            if ref_param.shape == dist_param.shape:
-                # Same shard size (same TP layout or both replicated).
-                dist_param.data.copy_(ref_param.data.to(dist_param.dtype))
-                continue
-
-            assert partition_dim >= 0, (
-                f"Param '{name}': shapes differ "
-                f"(ref={tuple(ref_param.shape)}, dist={tuple(dist_param.shape)}) "
-                f"but partition_dim<0 — cannot reshard a replicated param."
-            )
-
-            # Different TP sizes: gather ref shards, then slice for dist.
-            shards = [torch.empty_like(ref_param.data) for _ in range(ref_tp_size)]
-            dist.all_gather(shards, ref_param.data.contiguous(), group=ref_tp_group)
-            full_weight = torch.cat(shards, dim=partition_dim)
-            dist_slice = torch.tensor_split(full_weight, dist_tp_size, dim=partition_dim)[
-                dist_tp_rank
-            ]
-
-            assert dist_slice.shape == dist_param.shape, (
-                f"Param '{name}': sliced.shape={tuple(dist_slice.shape)} != "
-                f"dist.shape={tuple(dist_param.shape)} "
-                f"(ref_tp={ref_tp_size}, dist_tp={dist_tp_size}, "
-                f"partition_dim={partition_dim})"
-            )
-            dist_param.data.copy_(dist_slice.to(dist_param.dtype))
-
-
 def _global_abs_diff_stats(a, b, pg=None):
     """Absolute-diff stats plus reference-tensor magnitude stats, across ``pg``.
 

--- a/tests/unit_tests/models/mimo/test_mimo_colocated_correctness.py
+++ b/tests/unit_tests/models/mimo/test_mimo_colocated_correctness.py
@@ -221,11 +221,7 @@ def _generate_and_broadcast_global_batches(
     for batch_idx in range(num_batches):
         if rank == 0:
             encoder_hidden_states = torch.randn(
-                image_seq_length,
-                global_mbs,
-                hidden_size,
-                device='cuda',
-                dtype=modality_dtype,
+                image_seq_length, global_mbs, hidden_size, device='cuda', dtype=modality_dtype
             )
             image_tokens = torch.full(
                 (global_mbs, image_seq_length), image_token_id, dtype=torch.long, device='cuda'
@@ -236,11 +232,7 @@ def _generate_and_broadcast_global_batches(
             input_ids = torch.cat([image_tokens, text_tokens], dim=1)
         else:
             encoder_hidden_states = torch.empty(
-                image_seq_length,
-                global_mbs,
-                hidden_size,
-                device='cuda',
-                dtype=modality_dtype,
+                image_seq_length, global_mbs, hidden_size, device='cuda', dtype=modality_dtype
             )
             input_ids = torch.empty(global_mbs, seq_length, dtype=torch.long, device='cuda')
 

--- a/tests/unit_tests/models/mimo/test_mimo_noncolocated_cp_correctness.py
+++ b/tests/unit_tests/models/mimo/test_mimo_noncolocated_cp_correctness.py
@@ -1,0 +1,370 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Numerical correctness for destination CP in the non-colocated MIMO bridge."""
+
+from functools import partial
+
+import pytest
+import torch
+import torch.distributed as dist
+from packaging import version
+
+import megatron.core.pipeline_parallel.schedules as schedule
+from megatron.core.distributed import DistributedDataParallelConfig
+from megatron.core.models.mimo.config.role import MIMO_LANGUAGE_MODULE_KEY
+from megatron.core.models.mimo.optimizer import get_mimo_optimizer
+from megatron.core.optimizer.optimizer_config import OptimizerConfig
+from megatron.core.pipeline_parallel.multimodule_communicator import MultiModulePipelineCommunicator
+from megatron.core.pipeline_parallel.utils import is_pp_first_stage, is_pp_last_stage
+from megatron.core.process_groups_config import MultiModuleProcessGroupCollection
+from tests.unit_tests.models.mimo.test_mimo_1f1b_schedule import (
+    create_all_embedding_groups,
+    create_hypercomm_grid,
+    destroy_all_grids,
+    get_mimo_model,
+    is_rank_in_grid,
+)
+from tests.unit_tests.models.mimo.test_mimo_colocated_correctness import (
+    _BatchIterator,
+    _copy_ref_params_to_dist,
+    _generate_and_broadcast_global_batches,
+    _set_deterministic_env,
+    _slice_batch,
+    _snapshot_first_layer_encoder_grads,
+    _wire_training_hooks,
+)
+from tests.unit_tests.test_utilities import Utils
+
+
+def _clone_batch_value(value):
+    """Clone a nested batch so sequential reference and target runs cannot share mutations."""
+    if isinstance(value, torch.Tensor):
+        return value.clone()
+    if isinstance(value, dict):
+        return {key: _clone_batch_value(item) for key, item in value.items()}
+    return value
+
+
+def _build_noncolocated_role_batches(global_batches, encoder_grid, llm_grid):
+    """Build encoder-DP slices or full LLM batches for this disjoint-grid rank."""
+    if is_rank_in_grid(encoder_grid):
+        encoder_dp = encoder_grid.get_pg("dp")
+        return [
+            _slice_batch(batch, encoder_dp.size(), encoder_dp.rank()) for batch in global_batches
+        ]
+    if is_rank_in_grid(llm_grid):
+        return [_clone_batch_value(batch) for batch in global_batches]
+    raise AssertionError(f"Rank {dist.get_rank()} belongs to neither MIMO grid")
+
+
+def _forward_step(data_iterator, model):
+    """Forward step using the per-token loss contract expected by the MIMO grad hooks."""
+
+    def loss_func(loss_mask, output_tensor):
+        def result(loss, num_tokens, reduced):
+            return loss, num_tokens, {'loss_reduced': reduced}
+
+        zero = torch.tensor(0.0, device='cuda', requires_grad=True)
+        one = torch.tensor(1, device='cuda', dtype=torch.int)
+        if output_tensor is None:
+            return result(zero, one, 0.0)
+
+        if isinstance(output_tensor, dict):
+            output = output_tensor.get(
+                MIMO_LANGUAGE_MODULE_KEY, next(iter(output_tensor.values()), None)
+            )
+        else:
+            output = output_tensor
+
+        if output is None:
+            return result(zero, one, 0.0)
+
+        loss = output.float().sum()
+        num_tokens = loss_mask.sum().to(torch.int).clamp(min=1) if loss_mask is not None else one
+        return result(loss, num_tokens, loss)
+
+    batch = next(data_iterator) if data_iterator is not None else {'input_ids': None}
+    output_tensor, loss_mask = model(**batch)
+    return output_tensor, partial(loss_func, loss_mask)
+
+
+def _run_1f1b_configuration(
+    mimo_model,
+    module_to_grid_map,
+    topology,
+    language_pg,
+    vision_pg,
+    encoder_grid,
+    llm_grid,
+    encoder_name,
+    batches,
+    optimizer,
+    micro_batch_size,
+    seq_length,
+    num_microbatches,
+):
+    """Run one deterministic non-colocated 1F1B step and snapshot encoder gradients."""
+    _wire_training_hooks(mimo_model, module_to_grid_map, language_pg, vision_pg)
+    communicator = MultiModulePipelineCommunicator(
+        module_to_grid_map,
+        topology,
+        mimo_model.config,
+        dim_mapping={'s': 0, 'h': 2, 'b': 1},
+        module_output_ndim={encoder_name: 2},
+    )
+
+    module_pgs = {}
+    language_model_module_name = None
+    if is_rank_in_grid(encoder_grid):
+        module_pgs[encoder_name] = vision_pg
+    if is_rank_in_grid(llm_grid):
+        module_pgs[MIMO_LANGUAGE_MODULE_KEY] = language_pg
+        language_model_module_name = MIMO_LANGUAGE_MODULE_KEY
+    pg_collection = MultiModuleProcessGroupCollection(
+        module_pgs=module_pgs, language_model_module_name=language_model_module_name
+    )
+
+    needs_data = (
+        is_rank_in_grid(encoder_grid) and is_pp_first_stage(encoder_grid.get_pg("pp"))
+    ) or (
+        is_rank_in_grid(llm_grid)
+        and (is_pp_first_stage(llm_grid.get_pg("pp")) or is_pp_last_stage(llm_grid.get_pg("pp")))
+    )
+    data_iterator = _BatchIterator(batches) if needs_data else None
+
+    optimizer.zero_grad()
+    losses = schedule.forward_backward_pipelining_without_interleaving(
+        forward_step_func=_forward_step,
+        data_iterator=data_iterator,
+        model=[mimo_model],
+        num_microbatches=num_microbatches,
+        seq_length=seq_length,
+        micro_batch_size=micro_batch_size,
+        forward_only=False,
+        p2p_communicator=communicator,
+        pg_collection=pg_collection,
+    )
+
+    encoder_grads = (
+        _snapshot_first_layer_encoder_grads(mimo_model, encoder_name)
+        if is_rank_in_grid(encoder_grid)
+        else {}
+    )
+    success, grad_norm, _ = optimizer.step()
+    assert success, "Optimizer step failed"
+    assert grad_norm is not None and grad_norm > 0, f"Expected positive grad norm, got {grad_norm}"
+    assert torch.isfinite(
+        torch.as_tensor(grad_norm)
+    ).all(), f"Expected finite grad norm, got {grad_norm}"
+
+    if is_rank_in_grid(llm_grid) and is_pp_last_stage(llm_grid.get_pg("pp")):
+        assert losses, "Expected losses on last LLM stage"
+        for loss_dict in losses:
+            loss = torch.as_tensor(loss_dict['loss_reduced'])
+            assert torch.isfinite(loss).all(), f"Expected finite loss, got {loss}"
+    return encoder_grads
+
+
+@pytest.mark.skipif(
+    version.parse(torch.__version__) < version.parse('2.3.0'),
+    reason="Device mesh requires PyTorch 2.3+",
+)
+class TestNonColocatedCPCorrectness:
+    """Compare destination CP=2 encoder gradients with a deterministic CP=1 baseline."""
+
+    @classmethod
+    def setup_class(cls):
+        Utils.initialize_distributed()
+        cls.world_size = dist.get_world_size()
+
+    @classmethod
+    def teardown_class(cls):
+        Utils.destroy_model_parallel()
+
+    def teardown_method(self):
+        destroy_all_grids()
+
+    def test_cp2_matches_cp1_encoder_gradients(self):
+        """CP2 reconstructs the same encoder gradient as a deterministic CP1 baseline."""
+        if self.world_size != 8:
+            pytest.skip(f"Requires 8 GPUs, got {self.world_size}")
+
+        _set_deterministic_env()
+        previous_deterministic_algorithms = torch.are_deterministic_algorithms_enabled()
+        previous_cudnn_deterministic = torch.backends.cudnn.deterministic
+        previous_cudnn_benchmark = torch.backends.cudnn.benchmark
+        torch.use_deterministic_algorithms(True)
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False
+
+        encoder_name = "images"
+        hidden_size = 128
+        seq_length = 64
+        vocab_size = 1000
+        micro_batch_size = 4
+        num_microbatches = 4
+        ref_mimo = None
+        target_mimo = None
+
+        try:
+            ref_encoder_grid = create_hypercomm_grid(offset=0, tp=1, cp=1, pp=1, dp=4)
+            ref_llm_grid = create_hypercomm_grid(offset=4, tp=2, cp=1, pp=2, dp=1)
+            target_encoder_grid = create_hypercomm_grid(offset=0, tp=1, cp=1, pp=1, dp=4)
+            target_llm_grid = create_hypercomm_grid(offset=4, tp=1, cp=2, pp=2, dp=1)
+            create_all_embedding_groups(
+                [ref_encoder_grid, ref_llm_grid, target_encoder_grid, target_llm_grid]
+            )
+
+            ddp_config = DistributedDataParallelConfig(
+                overlap_grad_reduce=True, bucket_size=10000, use_distributed_optimizer=False
+            )
+            torch.manual_seed(12345)
+            (ref_mimo, ref_module_to_grid_map, ref_topology, ref_language_pg, ref_vision_pg) = (
+                get_mimo_model(
+                    encoder_name=encoder_name,
+                    encoder_grid=ref_encoder_grid,
+                    llm_grid=ref_llm_grid,
+                    hidden_size=hidden_size,
+                    num_layers=2,
+                    vocab_size=vocab_size,
+                    seq_len=seq_length,
+                    ddp_config=ddp_config,
+                    bf16=True,
+                    bias=False,
+                    dropout=False,
+                    per_token_loss=True,
+                )
+            )
+
+            torch.manual_seed(12345)
+            (
+                target_mimo,
+                target_module_to_grid_map,
+                target_topology,
+                target_language_pg,
+                target_vision_pg,
+            ) = get_mimo_model(
+                encoder_name=encoder_name,
+                encoder_grid=target_encoder_grid,
+                llm_grid=target_llm_grid,
+                hidden_size=hidden_size,
+                num_layers=2,
+                vocab_size=vocab_size,
+                seq_len=seq_length,
+                ddp_config=ddp_config,
+                bf16=True,
+                bias=False,
+                dropout=False,
+                per_token_loss=True,
+            )
+
+            if is_rank_in_grid(ref_encoder_grid):
+                _copy_ref_params_to_dist(
+                    ref_mimo.modality_submodules[encoder_name].module,
+                    target_mimo.modality_submodules[encoder_name].module,
+                    ref_encoder_grid.get_pg("tp"),
+                    target_encoder_grid.get_pg("tp"),
+                )
+            else:
+                assert is_rank_in_grid(ref_llm_grid)
+                _copy_ref_params_to_dist(
+                    ref_mimo.language_model.module,
+                    target_mimo.language_model.module,
+                    ref_llm_grid.get_pg("tp"),
+                    target_llm_grid.get_pg("tp"),
+                )
+            dist.barrier()
+
+            optimizer_config = OptimizerConfig(
+                optimizer='adam',
+                lr=1e-4,
+                weight_decay=0.01,
+                clip_grad=1.0,
+                bf16=True,
+                use_distributed_optimizer=False,
+            )
+            ref_optimizer = get_mimo_optimizer(ref_mimo, optimizer_config)
+
+            torch.manual_seed(99999)
+            global_batches = _generate_and_broadcast_global_batches(
+                global_mbs=micro_batch_size,
+                seq_length=seq_length,
+                hidden_size=hidden_size,
+                vocab_size=vocab_size,
+                encoder_name=encoder_name,
+                num_batches=num_microbatches,
+                modality_dtype=torch.bfloat16,
+            )
+            ref_batches = _build_noncolocated_role_batches(
+                global_batches, ref_encoder_grid, ref_llm_grid
+            )
+            target_batches = _build_noncolocated_role_batches(
+                global_batches, target_encoder_grid, target_llm_grid
+            )
+
+            ref_grads = _run_1f1b_configuration(
+                ref_mimo,
+                ref_module_to_grid_map,
+                ref_topology,
+                ref_language_pg,
+                ref_vision_pg,
+                ref_encoder_grid,
+                ref_llm_grid,
+                encoder_name,
+                ref_batches,
+                ref_optimizer,
+                micro_batch_size,
+                seq_length,
+                num_microbatches,
+            )
+            dist.barrier()
+
+            target_optimizer = get_mimo_optimizer(target_mimo, optimizer_config)
+            target_grads = _run_1f1b_configuration(
+                target_mimo,
+                target_module_to_grid_map,
+                target_topology,
+                target_language_pg,
+                target_vision_pg,
+                target_encoder_grid,
+                target_llm_grid,
+                encoder_name,
+                target_batches,
+                target_optimizer,
+                micro_batch_size,
+                seq_length,
+                num_microbatches,
+            )
+
+            local_error = None
+            if is_rank_in_grid(ref_encoder_grid):
+                if set(ref_grads) != set(target_grads):
+                    local_error = (
+                        f"First-layer gradient names differ: reference={set(ref_grads)}, "
+                        f"target={set(target_grads)}"
+                    )
+                else:
+                    for name in sorted(ref_grads):
+                        try:
+                            torch.testing.assert_close(
+                                target_grads[name], ref_grads[name], rtol=1e-3, atol=1e-3
+                            )
+                        except AssertionError as error:
+                            local_error = f"First-layer gradient {name!r} differs: {error}"
+                            break
+
+            gradients_match = torch.tensor(
+                0 if local_error else 1, device='cuda', dtype=torch.int32
+            )
+            dist.all_reduce(gradients_match, op=dist.ReduceOp.MIN)
+            assert gradients_match.item() == 1, (
+                local_error or "A remote encoder rank reported a CP1-vs-CP2 gradient mismatch"
+            )
+        finally:
+            if target_mimo is not None:
+                target_mimo.destroy()
+            if ref_mimo is not None:
+                ref_mimo.destroy()
+            torch.use_deterministic_algorithms(previous_deterministic_algorithms)
+            torch.backends.cudnn.deterministic = previous_cudnn_deterministic
+            torch.backends.cudnn.benchmark = previous_cudnn_benchmark

--- a/tests/unit_tests/models/mimo/test_mimo_noncolocated_cp_correctness.py
+++ b/tests/unit_tests/models/mimo/test_mimo_noncolocated_cp_correctness.py
@@ -219,7 +219,7 @@ class TestNonColocatedCPCorrectness:
                 overlap_grad_reduce=True, bucket_size=10000, use_distributed_optimizer=False
             )
             torch.manual_seed(12345)
-            (ref_mimo, ref_module_to_grid_map, ref_topology, ref_language_pg, ref_vision_pg) = (
+            ref_mimo, ref_module_to_grid_map, ref_topology, ref_language_pg, ref_vision_pg = (
                 get_mimo_model(
                     encoder_name=encoder_name,
                     encoder_grid=ref_encoder_grid,

--- a/tests/unit_tests/pipeline_parallel/test_bridge_communicator.py
+++ b/tests/unit_tests/pipeline_parallel/test_bridge_communicator.py
@@ -326,6 +326,25 @@ class TestBridgeCommunicator:
         ]
         assert all(rank not in expected for rank in member_ranks)
 
+    def test_destination_cp_topology(self):
+        """Destination CP keeps DP-based routing and reduces only on the leader TP lane."""
+        src_grid = create_hypercomm_grid(offset=0, tp=1, cp=1, pp=1, dp=4)
+        dest_grid = create_hypercomm_grid(offset=4, tp=2, cp=2, pp=1, dp=1)
+        bridge = BridgeCommunicator(src_grid, dest_grid, comm_dtype=torch.float32)
+
+        assert bridge.dest_tp_leaders == [4]
+        assert bridge.get_boundary_pp_stage_ranks(dest_grid, is_src=False) == [[4, 6, 5, 7]]
+
+        rank = dist.get_rank()
+        expected_broadcast_ranks = [4, 6, 5, 7] if rank >= 4 else []
+        assert bridge.dest_grid_broadcast_ranks == expected_broadcast_ranks
+
+        if rank in (4, 6):
+            assert bridge.dest_cp_reduce_pg is not None
+            assert dist.get_process_group_ranks(bridge.dest_cp_reduce_pg) == [4, 6]
+        else:
+            assert bridge.dest_cp_reduce_pg is None
+
     def test_send_forward_recv_forward(self):
         """Test send_forward and recv_forward operations."""
 
@@ -369,6 +388,56 @@ class TestBridgeCommunicator:
                 128,
                 512,
             ), f"Expected gradient shape {(4, 128, 512)}, got {received_gradient.shape}"
+
+    def test_cp_gradient_reconstruction(self):
+        """Complementary destination-CP gradients are summed before fan-in splitting."""
+        src_grid = create_hypercomm_grid(offset=0, tp=1, cp=1, pp=1, dp=4)
+        dest_grid = create_hypercomm_grid(offset=4, tp=2, cp=2, pp=1, dp=1)
+        bridge = BridgeCommunicator(src_grid, dest_grid, comm_dtype=torch.float32, tensor_ndim=2)
+
+        rows_per_chunk = 2
+        hidden_size = 3
+        chunk_values = (1.0, -2.0, 3.0, -4.0)
+        payload_shape = (4 * rows_per_chunk, hidden_size)
+        expected_source_shape = (rows_per_chunk, hidden_size)
+        source_shape_matches = True
+        source_values_match = True
+
+        if bridge.is_current_rank_in_grid(dest_grid):
+            cp_rank = dist.get_rank(group=dest_grid.get_pg("cp"))
+            owned_chunks = (0, 3) if cp_rank == 0 else (1, 2)
+            local_gradient = torch.zeros(payload_shape, device="cuda", dtype=torch.float32)
+            for chunk_idx in owned_chunks:
+                chunk_start = chunk_idx * rows_per_chunk
+                local_gradient[chunk_start : chunk_start + rows_per_chunk].fill_(
+                    chunk_values[chunk_idx]
+                )
+            bridge.send_backward(local_gradient)
+        else:
+            received_gradient = bridge.recv_backward()
+            source_shape_matches = received_gradient.shape == expected_source_shape
+            source_values_match = source_shape_matches and torch.equal(
+                received_gradient,
+                torch.full(
+                    expected_source_shape,
+                    chunk_values[dist.get_rank()],
+                    device="cuda",
+                    dtype=torch.float32,
+                ),
+            )
+
+        # Synchronize the exact source-side oracle only after every rank has completed its
+        # bridge role, so an assertion failure cannot strand another rank in bridge P2P.
+        source_checks = torch.tensor(
+            [source_shape_matches, source_values_match], device="cuda", dtype=torch.int32
+        )
+        dist.all_reduce(source_checks, op=dist.ReduceOp.MIN)
+        assert (
+            source_checks[0].item() == 1
+        ), f"Every source rank must receive fan-in split shape {expected_source_shape}"
+        assert (
+            source_checks[1].item() == 1
+        ), "Every source rank must receive its exact signed CP-reconstructed gradient chunk"
 
     def test_send_forward_recv_backward_send_backward_recv_forward(self):
         """Test combined send_forward_recv_backward and send_backward_recv_forward operations."""

--- a/tests/unit_tests/pipeline_parallel/test_bridge_communicator.py
+++ b/tests/unit_tests/pipeline_parallel/test_bridge_communicator.py
@@ -405,6 +405,25 @@ class TestBridgeCommunicator:
             dist.get_process_group_ranks(bridge.bridge_pg)
         )
 
+    def test_destination_cp_topology(self):
+        """Destination CP keeps DP-based routing and reduces only on the leader TP lane."""
+        src_grid = create_hypercomm_grid(offset=0, tp=1, cp=1, pp=1, dp=4)
+        dest_grid = create_hypercomm_grid(offset=4, tp=2, cp=2, pp=1, dp=1)
+        bridge = BridgeCommunicator(src_grid, dest_grid, comm_dtype=torch.float32)
+
+        assert bridge.dest_tp_leaders == [4]
+        assert bridge.get_boundary_pp_stage_ranks(dest_grid, is_src=False) == [[4, 6, 5, 7]]
+
+        rank = dist.get_rank()
+        expected_broadcast_ranks = [4, 6, 5, 7] if rank >= 4 else []
+        assert bridge.dest_grid_broadcast_ranks == expected_broadcast_ranks
+
+        if rank in (4, 6):
+            assert bridge.dest_cp_reduce_pg is not None
+            assert dist.get_process_group_ranks(bridge.dest_cp_reduce_pg) == [4, 6]
+        else:
+            assert bridge.dest_cp_reduce_pg is None
+
     def test_send_forward_recv_forward(self):
         """Test send_forward and recv_forward operations."""
 
@@ -448,6 +467,56 @@ class TestBridgeCommunicator:
                 128,
                 512,
             ), f"Expected gradient shape {(4, 128, 512)}, got {received_gradient.shape}"
+
+    def test_cp_gradient_reconstruction(self):
+        """Complementary destination-CP gradients are summed before fan-in splitting."""
+        src_grid = create_hypercomm_grid(offset=0, tp=1, cp=1, pp=1, dp=4)
+        dest_grid = create_hypercomm_grid(offset=4, tp=2, cp=2, pp=1, dp=1)
+        bridge = BridgeCommunicator(src_grid, dest_grid, comm_dtype=torch.float32, tensor_ndim=2)
+
+        rows_per_chunk = 2
+        hidden_size = 3
+        chunk_values = (1.0, -2.0, 3.0, -4.0)
+        payload_shape = (4 * rows_per_chunk, hidden_size)
+        expected_source_shape = (rows_per_chunk, hidden_size)
+        source_shape_matches = True
+        source_values_match = True
+
+        if bridge.is_current_rank_in_grid(dest_grid):
+            cp_rank = dist.get_rank(group=dest_grid.get_pg("cp"))
+            owned_chunks = (0, 3) if cp_rank == 0 else (1, 2)
+            local_gradient = torch.zeros(payload_shape, device="cuda", dtype=torch.float32)
+            for chunk_idx in owned_chunks:
+                chunk_start = chunk_idx * rows_per_chunk
+                local_gradient[chunk_start : chunk_start + rows_per_chunk].fill_(
+                    chunk_values[chunk_idx]
+                )
+            bridge.send_backward(local_gradient)
+        else:
+            received_gradient = bridge.recv_backward()
+            source_shape_matches = received_gradient.shape == expected_source_shape
+            source_values_match = source_shape_matches and torch.equal(
+                received_gradient,
+                torch.full(
+                    expected_source_shape,
+                    chunk_values[dist.get_rank()],
+                    device="cuda",
+                    dtype=torch.float32,
+                ),
+            )
+
+        # Synchronize the exact source-side oracle only after every rank has completed its
+        # bridge role, so an assertion failure cannot strand another rank in bridge P2P.
+        source_checks = torch.tensor(
+            [source_shape_matches, source_values_match], device="cuda", dtype=torch.int32
+        )
+        dist.all_reduce(source_checks, op=dist.ReduceOp.MIN)
+        assert (
+            source_checks[0].item() == 1
+        ), f"Every source rank must receive fan-in split shape {expected_source_shape}"
+        assert (
+            source_checks[1].item() == 1
+        ), "Every source rank must receive its exact signed CP-reconstructed gradient chunk"
 
     def test_send_forward_recv_backward_send_backward_recv_forward(self):
         """Test combined send_forward_recv_backward and send_backward_recv_forward operations."""


### PR DESCRIPTION
- [ ] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Support destination/LLM context parallelism greater than one in the non-colocated MIMO bridge communicator. Source/encoder CP greater than one remains out of scope.

The destination leader continues to receive and broadcast the complete modality embedding tensor across the destination TP x CP boundary group. During backward, CP-local sparse modality gradients are SUM-reduced over the destination leader's existing CP group at TP0 before the leader performs the existing cross-grid backward send. CP=1 remains a no-op.

This also adds:

- an exact signed gradient-reconstruction test for complementary CP-local gradients;
- a parameterized 8-GPU CP=1/CP=2 1F1B schedule test covering steady state and cooldown;
- a focused non-colocated correctness test comparing deterministic CP=1 and CP=2 encoder gradients while reusing the existing MIMO correctness helpers;
- explicit MIMO CP/TP process-group plumbing in the test model construction.

## Issue tracking

Linked issue: TBD

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code
- [x] I have added relevant documentation
- [x] I have run the autoformatter.sh on my PR

## Validation

- Pre-implementation RED: COG job `13602562` failed at the former destination CP=1 assertion.
- Focused bridge reconstruction/topology tests: COG job `13613096`; 2 passed and 29 deselected on every rank.
- Parameterized CP=1/CP=2 1F1B smoke plus deterministic CP=1/CP=2 gradient oracle: COG job `13613095`; 3 passed and 6 deselected on every rank.
- Full shared 1F1B schedule file: COG job `13613238`; 6 passed and 2 skipped on every rank.
- Inspected separate stdout and stderr for ranks 0-7 for all successful jobs; no traceback, assertion, distributed runtime, NCCL, timeout, or child-failure signatures.
- `uv run isort --check-only` on the changed MIMO test files.
- `uv run ruff check` on all changed Python files.
- Python compilation and `git diff --check`.

The COG source validation used the cached PyTorch 26.04 container. The newly bumped 26.06 container did not reach pytest in this COG environment because its bootstrap image lacks `uv`; this was an environment-setup failure rather than a test failure.
