### PR TITLE
[dev] lite:Keep rollout weight sync GPU-resident with bounded gathers

### DIFF
--- a/experimental/lite/examples/miles/miles_mlite/weight_update.py
+++ b/experimental/lite/examples/miles/miles_mlite/weight_update.py
@@ -11,6 +11,7 @@ from collections.abc import Sequence
 import ray
 import torch
 import torch.distributed as dist
+from megatron.lite.primitive.ckpt.hf_weights import DEFAULT_EXPORT_BUFFER_MAX_SIZE_BYTES
 
 logger = logging.getLogger(__name__)
 
@@ -183,7 +184,13 @@ class RawHFWeightUpdater:
     def _export_weight_chunks(self):
         chunk = []
         chunk_bytes = 0
-        limit = int(getattr(self.args, "update_weight_buffer_size", 2**30))
+        limit = int(
+            getattr(
+                self.args,
+                "update_weight_buffer_size",
+                DEFAULT_EXPORT_BUFFER_MAX_SIZE_BYTES,
+            )
+        )
         export_kwargs = {}
         if getattr(self.args, "mlite_export_dtype", None):
             export_kwargs["export_dtype"] = self.args.mlite_export_dtype

--- a/experimental/lite/examples/verl/sitecustomize.py
+++ b/experimental/lite/examples/verl/sitecustomize.py
@@ -1,6 +1,16 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Process-wide compatibility hooks for the VERL MLite examples."""
 
-from verl_mlite.compat import apply_runtime_patches
+from verl_mlite.compat import (
+    _patch_bucketed_weight_sender,
+    _weight_sync_probe_enabled,
+    apply_runtime_patches,
+)
 
-apply_runtime_patches()
+if _weight_sync_probe_enabled():
+    # The probe is also used by the Megatron/mbridge control. Keep that path
+    # limited to sender instrumentation instead of importing MLite's optional
+    # Transformers compatibility layer into every Ray and vLLM process.
+    _patch_bucketed_weight_sender()
+else:
+    apply_runtime_patches()

--- a/experimental/lite/examples/verl/verl_mlite/compat.py
+++ b/experimental/lite/examples/verl/verl_mlite/compat.py
@@ -3,12 +3,344 @@
 
 from __future__ import annotations
 
+import importlib.abc
+import importlib.machinery
 import importlib.util
+import os
+import queue
 import sys
+import threading
 from collections.abc import Iterable
+from concurrent.futures import ThreadPoolExecutor
+from contextvars import copy_context
 from functools import wraps
 from pathlib import Path
 from typing import Any
+
+_BUCKETED_SENDER_MODULE = "verl.workers.rollout.vllm_rollout.bucketed_weight_transfer"
+
+
+class _SyncBucketProducer:
+    """Pack one sender bucket at a time into a caller-owned staging slot."""
+
+    def __init__(self, weights, bucket_size: int):
+        self._weights = iter(weights)
+        self._bucket_size = bucket_size
+        self._pending = None
+        self._exhausted = False
+
+    def next_bucket(self, staging):
+        import torch
+
+        if staging.device.type == "cuda":
+            torch.cuda.set_device(staging.device)
+        if self._exhausted:
+            return "eof", None, None, 0, None, True
+
+        offset = 0
+        bucket_meta = {}
+        while True:
+            try:
+                if self._pending is None:
+                    name, weight = next(self._weights)
+                else:
+                    name, weight = self._pending
+                    self._pending = None
+            except StopIteration:
+                self._exhausted = True
+                if not bucket_meta:
+                    return "eof", None, None, 0, None, True
+                break
+
+            if offset + weight.nbytes > self._bucket_size and bucket_meta:
+                self._pending = (name, weight)
+                break
+            if weight.nbytes > self._bucket_size:
+                return "direct", name, weight, 0, None, False
+
+            bucket_meta[name] = {
+                "name": name,
+                "shape": weight.shape,
+                "dtype": weight.dtype,
+                "offset": offset,
+                "handle": None,
+            }
+            staging[offset : offset + weight.nbytes].copy_(
+                weight.view(-1).view(torch.uint8), non_blocking=True
+            )
+            offset += weight.nbytes
+            if offset == self._bucket_size:
+                break
+
+        ready = None
+        if staging.device.type == "cuda":
+            ready = torch.cuda.Event()
+            ready.record(torch.cuda.current_stream(staging.device))
+        return "bucket", bucket_meta, None, offset, ready, self._exhausted
+
+
+def _install_bucketed_sender_prefetch(sender_cls: type) -> bool:
+    """Overlap synchronous weight production with the receiver's bucket ACK."""
+    if getattr(sender_cls, "_mlite_weight_prefetch_patch", False):
+        return False
+
+    original_async_send_weights = sender_cls.async_send_weights
+
+    async def prefetched_async_send_weights(self, weights):
+        import torch
+
+        if not isinstance(weights, Iterable) or hasattr(weights, "__aiter__") or self.use_shm:
+            return await original_async_send_weights(self, weights)
+
+        executor = None
+        stop = threading.Event()
+        free_slots = None
+        ready_results = None
+        held_slot = None
+        try:
+            self._init_socket()
+            self._init_buffer()
+            if self.buffer.device.type != "cuda" and not getattr(
+                self, "_mlite_prefetch_allow_cpu", False
+            ):
+                raise RuntimeError("MLite sender prefetch requires a CUDA IPC buffer")
+
+            staging_slots = [torch.empty_like(self.buffer) for _ in range(2)]
+            producer = _SyncBucketProducer(weights, self.bucket_size)
+            free_slots = queue.Queue(maxsize=2)
+            ready_results = queue.Queue(maxsize=2)
+            for slot_index in range(2):
+                free_slots.put_nowait(slot_index)
+            executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="mlite-weight-prefetch")
+
+            def put_ready(result):
+                while not stop.is_set():
+                    try:
+                        ready_results.put(result, timeout=0.05)
+                        return True
+                    except queue.Full:
+                        continue
+                return False
+
+            def produce():
+                slot_index = None
+                try:
+                    while not stop.is_set():
+                        try:
+                            slot_index = free_slots.get(timeout=0.05)
+                        except queue.Empty:
+                            continue
+                        result = producer.next_bucket(staging_slots[slot_index])
+                        if not put_ready((*result, slot_index)):
+                            return
+                        slot_index = None
+                        kind, *_, is_last = result
+                        if kind == "eof" or is_last:
+                            return
+                except BaseException as exc:
+                    put_ready(("error", exc, None, 0, None, True, slot_index))
+
+            context = copy_context()
+            worker_future = executor.submit(context.run, produce)
+            while True:
+                try:
+                    result = ready_results.get(timeout=0.1)
+                except queue.Empty:
+                    if worker_future.done():
+                        worker_future.result()
+                        raise RuntimeError("MLite weight prefetch stopped without a terminal result")
+                    continue
+
+                kind, metadata_or_name, direct_weight, used_bytes, ready, is_last, held_slot = (
+                    result
+                )
+                if kind == "error":
+                    raise metadata_or_name
+                if kind == "eof":
+                    free_slots.put_nowait(held_slot)
+                    held_slot = None
+                    self.socket.send_pyobj({"bucket_meta": {}, "is_last": True})
+                    self.socket.recv()
+                    break
+                if kind == "direct":
+                    free_slots.put_nowait(held_slot)
+                    held_slot = None
+                    self._direct_send_large_weight(metadata_or_name, direct_weight)
+                    continue
+
+                if ready is not None:
+                    ready.synchronize()
+                staging = staging_slots[held_slot]
+                self.buffer[:used_bytes].copy_(staging[:used_bytes], non_blocking=True)
+                if self.buffer.device.type == "cuda":
+                    torch.cuda.synchronize(self.buffer.device)
+                free_slots.put_nowait(held_slot)
+                held_slot = None
+
+                self.socket.send_pyobj(
+                    {"bucket_meta": metadata_or_name, "is_last": is_last}
+                )
+                self.socket.recv()
+                if is_last:
+                    break
+        finally:
+            stop.set()
+            if held_slot is not None and free_slots is not None:
+                try:
+                    free_slots.put_nowait(held_slot)
+                except queue.Full:
+                    pass
+            if executor is not None:
+                executor.shutdown(wait=True, cancel_futures=True)
+            self._cleanup()
+
+    sender_cls.async_send_weights = prefetched_async_send_weights
+    sender_cls._mlite_weight_prefetch_patch = True
+    return True
+
+
+def _weight_sync_probe_enabled() -> bool:
+    return os.getenv("MLITE_WEIGHT_SYNC_PROBE", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _instrument_bucketed_weight_sender(sender_cls: type) -> bool:
+    """Patch veRL's sender only while the opt-in sync probe is enabled."""
+    if getattr(sender_cls, "_mlite_weight_sync_probe_patch", False):
+        return False
+
+    import torch
+    import torch.distributed as dist
+    from torch.utils._python_dispatch import TorchDispatchMode
+
+    from megatron.lite.primitive.ckpt.weight_sync_probe import (
+        get_weight_sync_probe,
+        weight_sync_probe_session,
+    )
+
+    probe = get_weight_sync_probe()
+    original_init_socket = sender_cls._init_socket
+    original_async_send_weights = sender_cls.async_send_weights
+
+    class _ProfiledSocket:
+        def __init__(self, socket):
+            self._socket = socket
+
+        def __getattr__(self, name):
+            return getattr(self._socket, name)
+
+        def send_pyobj(self, *args, **kwargs):
+            with probe.measure("handshake"):
+                return self._socket.send_pyobj(*args, **kwargs)
+
+        def recv(self, *args, **kwargs):
+            with probe.measure("handshake"):
+                return self._socket.recv(*args, **kwargs)
+
+    class _H2DCopyMode(TorchDispatchMode):
+        def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+            kwargs = kwargs or {}
+            if func is torch.ops.aten.copy_.default and len(args) >= 2:
+                dst, src = args[:2]
+                if (
+                    isinstance(dst, torch.Tensor)
+                    and isinstance(src, torch.Tensor)
+                    and dst.device.type == "cuda"
+                    and src.device.type == "cpu"
+                ):
+                    with probe.measure("h2d", nbytes=src.nbytes, device=dst.device):
+                        return func(*args, **kwargs)
+            return func(*args, **kwargs)
+
+    def profiled_init_socket(self, *args, **kwargs):
+        result = original_init_socket(self, *args, **kwargs)
+        self.socket = _ProfiledSocket(self.socket)
+        return result
+
+    async def profiled_async_send_weights(self, weights):
+        backend = os.getenv("MLITE_WEIGHT_SYNC_PROBE_BACKEND", "unknown")
+        original_all_gather_into_tensor = dist.all_gather_into_tensor
+
+        def profiled_all_gather_into_tensor(output, tensor, *args, **kwargs):
+            with probe.measure("mbridge_gather", nbytes=output.nbytes, device=tensor.device):
+                return original_all_gather_into_tensor(output, tensor, *args, **kwargs)
+
+        with weight_sync_probe_session(backend), _H2DCopyMode():
+            dist.all_gather_into_tensor = profiled_all_gather_into_tensor
+            try:
+                return await original_async_send_weights(self, weights)
+            finally:
+                dist.all_gather_into_tensor = original_all_gather_into_tensor
+
+    sender_cls._init_socket = profiled_init_socket
+    sender_cls.async_send_weights = profiled_async_send_weights
+    sender_cls._mlite_weight_sync_probe_patch = True
+    return True
+
+
+class _SenderPatchLoader(importlib.abc.Loader):
+    def __init__(self, loader: importlib.abc.Loader):
+        self._loader = loader
+
+    def create_module(self, spec):
+        create_module = getattr(self._loader, "create_module", None)
+        return create_module(spec) if create_module is not None else None
+
+    def exec_module(self, module) -> None:
+        self._loader.exec_module(module)
+        _install_bucketed_sender_prefetch(module.BucketedWeightSender)
+        if _weight_sync_probe_enabled():
+            _instrument_bucketed_weight_sender(module.BucketedWeightSender)
+
+
+class _SenderPatchFinder(importlib.abc.MetaPathFinder):
+    _mlite_weight_sync_probe_finder = True
+
+    def __init__(self):
+        self._mlite_weight_sync_probe_requested = False
+
+    def find_spec(self, fullname, path, target=None):
+        if fullname != _BUCKETED_SENDER_MODULE:
+            return None
+        spec = importlib.machinery.PathFinder.find_spec(fullname, path, target)
+        if spec is not None and spec.loader is not None:
+            spec.loader = _SenderPatchLoader(spec.loader)
+        return spec
+
+
+def _patch_bucketed_weight_transfer() -> bool:
+    module = sys.modules.get(_BUCKETED_SENDER_MODULE)
+    if module is not None:
+        return _install_bucketed_sender_prefetch(module.BucketedWeightSender)
+    if any(getattr(finder, "_mlite_weight_sync_probe_finder", False) for finder in sys.meta_path):
+        return False
+    sys.meta_path.insert(0, _SenderPatchFinder())
+    return True
+
+
+def _patch_bucketed_weight_sender() -> bool:
+    """Install production prefetch plus optional probe instrumentation."""
+    changed = _patch_bucketed_weight_transfer()
+    if not _weight_sync_probe_enabled():
+        return changed
+
+    module = sys.modules.get(_BUCKETED_SENDER_MODULE)
+    if module is not None:
+        changed = _instrument_bucketed_weight_sender(module.BucketedWeightSender) or changed
+    else:
+        finder = next(
+            finder
+            for finder in sys.meta_path
+            if getattr(finder, "_mlite_weight_sync_probe_finder", False)
+        )
+        if not finder._mlite_weight_sync_probe_requested:
+            finder._mlite_weight_sync_probe_requested = True
+            changed = True
+    return changed
 
 
 def _patch_transformers_rope_ignore_keys() -> None:
@@ -57,6 +389,7 @@ def _patch_transformers_rope_ignore_keys() -> None:
 
 def apply_runtime_patches() -> None:
     _patch_transformers_rope_ignore_keys()
+    _patch_bucketed_weight_sender()
 
 
 def _load_verl_file(relative_path: str, module_name: str):

--- a/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
+++ b/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
@@ -537,7 +537,16 @@ class MegatronLiteEngine(BaseEngine):
             ),
             optimizer=self._build_mlite_optimizer_config(),
             attention_backend_override=self.engine_config.attention_backend_override,
-            router_aux_loss_coef=self.engine_config.router_aux_loss_coef,
+            # verl's megatron backend hard-disables the load-balancing objective
+            # for RL (config_converter: moe_router_load_balancing_type='none',
+            # "turn off aux_loss as it hurts perf in RL"). Default to the same
+            # semantics instead of falling through to the HF checkpoint's
+            # nonzero router_aux_loss_coef; an explicit engine value still wins.
+            router_aux_loss_coef=(
+                0.0
+                if self.engine_config.router_aux_loss_coef is None
+                else self.engine_config.router_aux_loss_coef
+            ),
             load_hf_weights=self.engine_config.load_hf_weights,
             impl_cfg=self._build_impl_cfg(),
         )

--- a/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
+++ b/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
@@ -25,7 +25,7 @@ from verl.utils import tensordict_utils as tu
 from verl.utils.device import get_device_id, get_device_name
 from verl.utils.memory_utils import aggressive_empty_cache
 from verl.workers.config import HFModelConfig, OptimizerConfig
-from verl_mlite.compat import load_verl_engine_api
+from verl_mlite.compat import _patch_bucketed_weight_sender, load_verl_engine_api
 
 try:
     # Recent VERL wraps per-step metric values in a Metric aggregator that
@@ -35,6 +35,8 @@ except Exception:  # pragma: no cover - older VERL without Metric
     _VerlMetric = None
 
 from .config import MegatronLiteEngineConfig
+
+_patch_bucketed_weight_sender()
 
 BaseEngine, BaseEngineCtx, EngineRegistry, postprocess_batch_func, prepare_micro_batches = (
     load_verl_engine_api()

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/checkpoint.py
@@ -473,6 +473,7 @@ def export_hf_weights(model, config: DeepseekV4Config, ps: ParallelState, **kwar
 
     spec = DeepseekV4WeightSpec(config)
     rank0_only = bool(kwargs.get("rank0_only", False))
+    cpu = bool(kwargs.get("cpu", False))
     export_dtype = _resolve_export_dtype(kwargs.get("export_dtype"))
     yield from _export(model, spec, ps, vocab_size=config.vocab_size, **kwargs)
 
@@ -493,7 +494,8 @@ def export_hf_weights(model, config: DeepseekV4Config, ps: ParallelState, **kwar
             if not (name.endswith(".mlp.gate.tid2eid") or name.endswith(".mlp.gate.expert_bias")):
                 continue
             global_name = to_global_layer_name(name, layer_map)
-            for hf_name, hf_tensor in spec.native_to_hf(global_name, buffer.detach().cpu()):
+            export_buffer = buffer.detach().cpu() if cpu else buffer.detach()
+            for hf_name, hf_tensor in spec.native_to_hf(global_name, export_buffer):
                 yield hf_name, _cast_export_tensor(hf_tensor, export_dtype)
 
 
@@ -501,7 +503,8 @@ def save_hf_weights(model, path: str, config: DeepseekV4Config, ps: ParallelStat
     from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
 
     rank = dist.get_rank() if dist.is_initialized() else 0
-    out = dict(export_hf_weights(model, config, ps, rank0_only=True, **kwargs))
+    kwargs.pop("cpu", None)
+    out = dict(export_hf_weights(model, config, ps, rank0_only=True, cpu=True, **kwargs))
     if rank == 0 and out:
         save_safetensors(out, path)
     if dist.is_initialized():

--- a/experimental/lite/megatron/lite/model/glm5/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/checkpoint.py
@@ -628,6 +628,7 @@ def export_hf_weights(model, config: Glm5Config, ps: ParallelState, **kwargs):
 
     spec = Glm5WeightSpec(config)
     rank0_only = bool(kwargs.get("rank0_only", False))
+    cpu = bool(kwargs.get("cpu", False))
     export_dtype = _resolve_export_dtype(kwargs.get("export_dtype"))
     yield from _export(model, spec, ps, vocab_size=config.vocab_size, **kwargs)
     rank = dist.get_rank() if dist.is_initialized() else 0
@@ -645,7 +646,8 @@ def export_hf_weights(model, config: Glm5Config, ps: ParallelState, **kwargs):
             if not name.endswith(".moe.router.expert_bias"):
                 continue
             global_name = to_global_layer_name(name, layer_map)
-            for hf_name, hf_tensor in spec.native_to_hf(global_name, buffer.detach().cpu()):
+            export_buffer = buffer.detach().cpu() if cpu else buffer.detach()
+            for hf_name, hf_tensor in spec.native_to_hf(global_name, export_buffer):
                 yield hf_name, _cast_export_tensor(hf_tensor, export_dtype)
 
 
@@ -653,7 +655,8 @@ def save_hf_weights(model, path: str, config: Glm5Config, ps: ParallelState, **k
     from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
 
     rank = dist.get_rank() if dist.is_initialized() else 0
-    out = dict(export_hf_weights(model, config, ps, rank0_only=True, **kwargs))
+    kwargs.pop("cpu", None)
+    out = dict(export_hf_weights(model, config, ps, rank0_only=True, cpu=True, **kwargs))
     if rank == 0 and out:
         save_safetensors(out, path)
     if dist.is_initialized():

--- a/experimental/lite/megatron/lite/model/kimi_k2/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/lite/checkpoint.py
@@ -618,6 +618,7 @@ def export_hf_weights(model, config: KimiK2Config, ps: ParallelState, **kwargs):
 
     spec = KimiK2WeightSpec(config)
     rank0_only = bool(kwargs.get("rank0_only", False))
+    cpu = bool(kwargs.get("cpu", False))
     export_dtype = _resolve_export_dtype(kwargs.get("export_dtype"))
     yield from _export(model, spec, ps, vocab_size=config.vocab_size, **kwargs)
     rank = dist.get_rank() if dist.is_initialized() else 0
@@ -635,7 +636,8 @@ def export_hf_weights(model, config: KimiK2Config, ps: ParallelState, **kwargs):
             if not name.endswith(".moe.router.expert_bias"):
                 continue
             global_name = to_global_layer_name(name, layer_map)
-            for hf_name, hf_tensor in spec.native_to_hf(global_name, buffer.detach().cpu()):
+            export_buffer = buffer.detach().cpu() if cpu else buffer.detach()
+            for hf_name, hf_tensor in spec.native_to_hf(global_name, export_buffer):
                 yield hf_name, _cast_export_tensor(hf_tensor, export_dtype)
 
 
@@ -643,7 +645,7 @@ def save_hf_weights(model, path: str, config: KimiK2Config, ps: ParallelState) -
     from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
 
     rank = dist.get_rank() if dist.is_initialized() else 0
-    out = dict(export_hf_weights(model, config, ps, rank0_only=True))
+    out = dict(export_hf_weights(model, config, ps, rank0_only=True, cpu=True))
     if rank == 0 and out:
         save_safetensors(out, path)
     if dist.is_initialized():

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/checkpoint.py
@@ -307,6 +307,17 @@ class Qwen35WeightSpec:
             return _merge_gate_up_tp_shards(_allgather_tp_shards(tensor, ps))
         return None
 
+    def merge_dense_shards(
+        self, native_name: str, shards: list[torch.Tensor]
+    ) -> torch.Tensor | None:
+        if native_name.endswith(".linear_attn.in_proj.linear.weight"):
+            return _merge_linear_attn_in_proj_tp_shards(shards, cfg=self.config)
+        if native_name.endswith(".linear_attn.conv1d.weight"):
+            return _merge_linear_attn_conv1d_tp_shards(shards, cfg=self.config)
+        if native_name.endswith(".moe.shared_expert.gate_up.linear.weight"):
+            return _merge_gate_up_tp_shards(shards)
+        return None
+
     def packed_expert_group_name(self, native_name: str) -> str | None:
         if re.fullmatch(r"layers\.\d+\.moe\.experts\.fc[12]\.weight\d+", native_name) is None:
             return None

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/model.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/model.py
@@ -164,6 +164,7 @@ class MoELayer(nn.Module):
         router_dtype: torch.dtype | None = None,
         preserve_3d_graph: bool = False,
         shared_expert_plain_te: bool = False,
+        moe_permute_fusion: bool | None = None,
     ):
         super().__init__()
         if fp8:
@@ -177,7 +178,11 @@ class MoELayer(nn.Module):
         )
         self.experts = Experts(config, ps, fp8=fp8, moe_act_recompute=moe_act_recompute)
         self.dispatcher = TokenDispatcher(
-            config.num_experts, config.hidden_size, ps, use_deepep=use_deepep
+            config.num_experts,
+            config.hidden_size,
+            ps,
+            use_deepep=use_deepep,
+            moe_permute_fusion=moe_permute_fusion,
         )
         self.shared_expert = SharedExpert(config, ps, use_plain_te_linear=shared_expert_plain_te)
         self.preserve_3d_graph = bool(preserve_3d_graph)
@@ -278,9 +283,10 @@ class Qwen35Layer(nn.Module):
             router_bias_rate=router_bias_rate,
             fp8=fp8,
             moe_act_recompute=moe_act_recompute,
-            router_dtype=torch.float32 if deterministic else None,
+            router_dtype=torch.float32,
             preserve_3d_graph=deterministic,
             shared_expert_plain_te=deterministic,
+            moe_permute_fusion=True,
         )
 
     def forward(

--- a/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import json
 import os
 import re
-from collections.abc import Generator
+from collections.abc import Generator, Iterable
 from pathlib import Path
 from typing import Protocol, runtime_checkable
 
@@ -27,6 +27,46 @@ try:
     from torch.distributed.tensor import DTensor
 except Exception:  # pragma: no cover - older torch without DTensor
     DTensor = None  # type: ignore[assignment]
+
+from megatron.lite.primitive.ckpt.weight_sync_probe import get_weight_sync_probe
+
+
+def _tensor_nbytes(tensor: torch.Tensor) -> int:
+    return tensor.numel() * tensor.element_size()
+
+
+def _to_cpu(tensor: torch.Tensor) -> torch.Tensor:
+    if tensor.device.type == "cpu":
+        return tensor
+    with get_weight_sync_probe().measure("d2h", nbytes=_tensor_nbytes(tensor), device=tensor.device):
+        return tensor.cpu()
+
+
+def _copy_to_cpu(dst: torch.Tensor, src: torch.Tensor) -> None:
+    if src.device.type == "cpu":
+        dst.copy_(src)
+        return
+    with get_weight_sync_probe().measure("d2h", nbytes=_tensor_nbytes(src), device=src.device):
+        dst.copy_(src)
+
+
+def _ep_all_gather(outputs: list[torch.Tensor], tensor: torch.Tensor, group) -> None:
+    with get_weight_sync_probe().measure(
+        "ep_gather",
+        nbytes=sum(_tensor_nbytes(output) for output in outputs),
+        device=tensor.device,
+    ):
+        dist.all_gather(outputs, tensor, group=group)
+
+
+def _native_to_hf(spec: HFWeights, name: str, tensor: torch.Tensor):
+    with get_weight_sync_probe().measure("mapping") as sample:
+        mapped = spec.native_to_hf(name, tensor)
+        sample.nbytes = sum(_tensor_nbytes(value) for _, value in mapped)
+        return mapped
+
+
+DEFAULT_EXPORT_BUFFER_MAX_SIZE_BYTES = 2 * 1024**3
 
 
 def _materialize_dtensor(tensor: torch.Tensor) -> torch.Tensor:
@@ -42,7 +82,10 @@ def _materialize_dtensor(tensor: torch.Tensor) -> torch.Tensor:
     params (dist_opt backend) pass through untouched.
     """
     if DTensor is not None and isinstance(tensor, DTensor):
-        return tensor.full_tensor()
+        with get_weight_sync_probe().measure("fsdp_gather", device=tensor.device) as sample:
+            result = tensor.full_tensor()
+            sample.nbytes = _tensor_nbytes(result)
+            return result
     return tensor
 
 
@@ -224,6 +267,307 @@ def allgather_concat(
     return torch.cat(gathered, dim=dim)
 
 
+def bucketed_all_gather_into_tensor(
+    bucket: list[tuple[str, torch.Tensor]],
+    *,
+    group: dist.ProcessGroup | None,
+    group_size: int,
+    buffer_max_size_bytes: int = DEFAULT_EXPORT_BUFFER_MAX_SIZE_BYTES,
+) -> list[tuple[str, torch.Tensor, list[torch.Tensor]]]:
+    """Gather a same-dtype tensor bucket through bounded flat GPU buffers."""
+    if not bucket:
+        return []
+    if group_size <= 1:
+        return [(name, tensor, [tensor]) for name, tensor in bucket]
+
+    dtype = bucket[0][1].dtype
+    device = bucket[0][1].device
+    if any(tensor.dtype != dtype for _, tensor in bucket):
+        raise ValueError("bucket tensors must share the same dtype")
+    if buffer_max_size_bytes <= 0:
+        raise ValueError("buffer_max_size_bytes must be positive")
+
+    element_size = bucket[0][1].element_size()
+    per_rank_buffer_bytes = max(buffer_max_size_bytes // group_size, element_size)
+    max_chunk_numel = max(1, per_rank_buffer_bytes // element_size)
+    flat_shards = [tensor.reshape(-1) for _, tensor in bucket]
+    numel_per_tensor = [tensor.numel() for tensor in flat_shards]
+    total_numel = sum(numel_per_tensor)
+
+    # Normal export buckets are capped before entering this function, so they
+    # fit in one collective. Keep the rank-major receive buffer alive through
+    # returned views instead of allocating and copying ``num_tensors * world``
+    # temporary shards. Oversized single tensors use the bounded chunked path
+    # below.
+    if total_numel <= max_chunk_numel:
+        send_buffer = torch.empty(total_numel, dtype=dtype, device=device)
+        send_views = list(send_buffer.split(numel_per_tensor))
+        torch._foreach_copy_(send_views, flat_shards)
+        recv_buffer = torch.empty(group_size * total_numel, dtype=dtype, device=device)
+        dist.all_gather_into_tensor(recv_buffer, send_buffer, group=group)
+
+        offsets = []
+        offset = 0
+        for numel in numel_per_tensor:
+            offsets.append(offset)
+            offset += numel
+        return [
+            (
+                name,
+                tensor,
+                [
+                    recv_buffer[
+                        rank * total_numel + offsets[idx] : rank * total_numel
+                        + offsets[idx]
+                        + numel_per_tensor[idx]
+                    ].view_as(tensor)
+                    for rank in range(group_size)
+                ],
+            )
+            for idx, (name, tensor) in enumerate(bucket)
+        ]
+
+    gathered_shards_by_rank = [
+        [torch.empty_like(tensor) for _, tensor in bucket] for _ in range(group_size)
+    ]
+    gathered_flat_views = [
+        [tensor.view(-1) for tensor in rank_shards] for rank_shards in gathered_shards_by_rank
+    ]
+
+    send_buffer = torch.empty(max_chunk_numel, dtype=dtype, device=device)
+    recv_buffer = torch.empty(group_size * max_chunk_numel, dtype=dtype, device=device)
+    tensor_idx = 0
+    tensor_offset = 0
+    while tensor_idx < len(bucket):
+        chunk_segments = []
+        chunk_numel = 0
+        while tensor_idx < len(bucket) and chunk_numel < max_chunk_numel:
+            available = numel_per_tensor[tensor_idx] - tensor_offset
+            take_numel = min(available, max_chunk_numel - chunk_numel)
+            send_buffer[chunk_numel : chunk_numel + take_numel].copy_(
+                flat_shards[tensor_idx][tensor_offset : tensor_offset + take_numel]
+            )
+            chunk_segments.append((tensor_idx, tensor_offset, chunk_numel, take_numel))
+            chunk_numel += take_numel
+            tensor_offset += take_numel
+            if tensor_offset == numel_per_tensor[tensor_idx]:
+                tensor_idx += 1
+                tensor_offset = 0
+
+        recv_view = recv_buffer[: group_size * chunk_numel]
+        dist.all_gather_into_tensor(recv_view, send_buffer[:chunk_numel], group=group)
+        for rank in range(group_size):
+            rank_recv_view = recv_view[rank * chunk_numel : (rank + 1) * chunk_numel]
+            for tensor_i, output_offset, chunk_offset, segment_numel in chunk_segments:
+                gathered_flat_views[rank][tensor_i][
+                    output_offset : output_offset + segment_numel
+                ].copy_(rank_recv_view[chunk_offset : chunk_offset + segment_numel])
+
+    return [
+        (
+            name,
+            tensor,
+            [gathered_shards_by_rank[rank][idx] for rank in range(group_size)],
+        )
+        for idx, (name, tensor) in enumerate(bucket)
+    ]
+
+
+def _iter_bucketed_materialized_tensors(
+    named_tensors: Iterable[tuple[str, torch.Tensor]],
+    *,
+    buffer_max_size_bytes: int = DEFAULT_EXPORT_BUFFER_MAX_SIZE_BYTES,
+) -> Generator[tuple[str, torch.Tensor], None, None]:
+    """Materialize sharded DTensors through bounded, layout-aware flat gathers.
+
+    Replicated DTensors and plain tensors are already complete on every DP rank,
+    so they bypass collectives.  They remain in the pending stream until the
+    current sharded bucket is flushed, which preserves parameter order without
+    breaking a flat bucket at every replicated parameter.
+    """
+    bucket: list[tuple[str, torch.Tensor]] = []
+    metadata: list[tuple[int, tuple[int, ...]]] = []
+    pending: list[tuple[str, torch.Tensor | None, int | None]] = []
+    bucket_bytes = 0
+    bucket_group = None
+    bucket_group_ranks: tuple[int, ...] | None = None
+    bucket_group_size = 1
+
+    def _flush_bucket():
+        nonlocal bucket, metadata, pending, bucket_bytes
+        nonlocal bucket_group, bucket_group_ranks, bucket_group_size
+        if not pending:
+            return
+        materialized: list[torch.Tensor] = []
+        if bucket:
+            with get_weight_sync_probe().measure(
+                "fsdp_gather", device=bucket[0][1].device
+            ) as sample:
+                gathered = bucketed_all_gather_into_tensor(
+                    bucket,
+                    group=bucket_group,
+                    group_size=bucket_group_size,
+                    buffer_max_size_bytes=buffer_max_size_bytes,
+                )
+                total_global_numel = sum(
+                    local_tensor.numel() * bucket_group_size
+                    for _, local_tensor in bucket
+                )
+                materialized_buffer = torch.empty(
+                    total_global_numel,
+                    dtype=bucket[0][1].dtype,
+                    device=bucket[0][1].device,
+                )
+                source_views: list[torch.Tensor] = []
+                destination_views: list[torch.Tensor] = []
+                materialized_offset = 0
+                for (_, _, shards), (shard_dim, global_shape) in zip(
+                    gathered, metadata, strict=True
+                ):
+                    global_numel = 1
+                    for size in global_shape:
+                        global_numel *= size
+                    full = materialized_buffer[
+                        materialized_offset : materialized_offset + global_numel
+                    ].view(global_shape)
+                    local_extent = shards[0].shape[shard_dim]
+                    for rank, shard in enumerate(shards):
+                        source_views.append(shard)
+                        destination_views.append(
+                            full.narrow(
+                                shard_dim,
+                                rank * local_extent,
+                                local_extent,
+                            )
+                        )
+                    materialized.append(full)
+                    materialized_offset += global_numel
+                torch._foreach_copy_(destination_views, source_views)
+                sample.nbytes = _tensor_nbytes(materialized_buffer)
+
+        outputs = []
+        for name, local_tensor, bucket_idx in pending:
+            if bucket_idx is None:
+                assert local_tensor is not None
+                outputs.append((name, local_tensor))
+            else:
+                outputs.append((name, materialized[bucket_idx]))
+        bucket = []
+        metadata = []
+        pending = []
+        bucket_bytes = 0
+        bucket_group = None
+        bucket_group_ranks = None
+        bucket_group_size = 1
+        yield from outputs
+
+    for name, tensor in named_tensors:
+        if DTensor is None or not isinstance(tensor, DTensor):
+            if bucket:
+                pending.append((name, tensor, None))
+            else:
+                yield name, tensor
+            continue
+
+        placements = tuple(tensor.placements)
+        placement = placements[0] if len(placements) == 1 else None
+        shard_dim = getattr(placement, "dim", None)
+        if placement is not None and type(placement).__name__ == "Replicate":
+            local = tensor.to_local()
+            if bucket:
+                pending.append((name, local, None))
+            else:
+                yield name, local
+            continue
+        if (
+            placement is None
+            or type(placement).__name__ != "Shard"
+            or shard_dim is None
+        ):
+            yield from _flush_bucket()
+            yield name, _materialize_dtensor(tensor)
+            continue
+
+        local = tensor.to_local()
+        global_shape = tuple(int(size) for size in tensor.shape)
+        shard_dim = int(shard_dim) % len(global_shape) if global_shape else -1
+        group = tensor.device_mesh.get_group(0)
+        group_size = dist.get_world_size(group)
+        if group_size <= 1:
+            if bucket:
+                pending.append((name, local, None))
+            else:
+                yield name, local
+            continue
+        group_ranks = tuple(dist.get_process_group_ranks(group))
+        evenly_sharded = (
+            shard_dim >= 0
+            and global_shape[shard_dim] % group_size == 0
+            and local.shape[shard_dim] * group_size == global_shape[shard_dim]
+        )
+        if not evenly_sharded:
+            yield from _flush_bucket()
+            yield name, _materialize_dtensor(tensor)
+            continue
+
+        local_bytes = local.numel() * local.element_size()
+        per_rank_limit = max(buffer_max_size_bytes // group_size, 1)
+        if local_bytes > per_rank_limit:
+            yield from _flush_bucket()
+            local_extent = local.shape[shard_dim]
+            bytes_per_extent = local_bytes // local_extent
+            chunk_extent = max(per_rank_limit // bytes_per_extent, 1)
+            full = torch.empty(global_shape, dtype=local.dtype, device=local.device)
+            with get_weight_sync_probe().measure(
+                "fsdp_gather", device=local.device
+            ) as sample:
+                for offset in range(0, local_extent, chunk_extent):
+                    extent = min(chunk_extent, local_extent - offset)
+                    local_chunk = local.narrow(shard_dim, offset, extent)
+                    _, _, gathered_chunks = bucketed_all_gather_into_tensor(
+                        [(name, local_chunk)],
+                        group=group,
+                        group_size=group_size,
+                        buffer_max_size_bytes=buffer_max_size_bytes,
+                    )[0]
+                    for rank, gathered_chunk in enumerate(gathered_chunks):
+                        full.narrow(
+                            shard_dim,
+                            rank * local_extent + offset,
+                            extent,
+                        ).copy_(gathered_chunk)
+                sample.nbytes = _tensor_nbytes(full)
+            yield name, full
+            continue
+
+        incompatible = bool(bucket) and (
+            local.dtype != bucket[0][1].dtype
+            or local.device != bucket[0][1].device
+            or group_ranks != bucket_group_ranks
+            or group_size != bucket_group_size
+            or bucket_bytes + local_bytes > per_rank_limit
+        )
+        if incompatible:
+            yield from _flush_bucket()
+
+        bucket.append((name, local))
+        metadata.append((shard_dim, global_shape))
+        pending.append((name, None, len(bucket) - 1))
+        bucket_bytes += local_bytes
+        if bucket_group is None:
+            bucket_group = group
+            bucket_group_ranks = group_ranks
+            bucket_group_size = group_size
+        if bucket_bytes >= per_rank_limit:
+            yield from _flush_bucket()
+
+    yield from _flush_bucket()
+
+
+def _maybe_cpu(tensor: torch.Tensor, *, cpu: bool) -> torch.Tensor:
+    return _to_cpu(tensor) if cpu else tensor
+
+
 def remap_layer_index(name: str, global_to_local: dict[int, int]) -> str | None:
     if not global_to_local:
         return name
@@ -389,6 +733,27 @@ def _resolve_param_name(name: str, state_dict: dict) -> str | None:
     return None
 
 
+def _merge_dense_shards(
+    name: str,
+    tensor: torch.Tensor,
+    shards: list[torch.Tensor],
+    spec: HFWeights,
+) -> torch.Tensor:
+    custom_merge = getattr(spec, "merge_dense_shards", None)
+    if callable(custom_merge):
+        merged = custom_merge(name, shards)
+        if merged is not None:
+            return merged
+
+    tp_info = spec.tp_spec(name)
+    if tp_info is None:
+        return tensor
+    split_dim, tp_or_etp = tp_info
+    if tp_or_etp != 0:
+        return tensor
+    return torch.cat(shards, dim=split_dim)
+
+
 def export_hf_weights(
     model: nn.Module | list[nn.Module],
     spec: HFWeights,
@@ -398,6 +763,8 @@ def export_hf_weights(
     limit: int | None = None,
     rank0_only: bool = False,
     export_dtype: str | torch.dtype | None = None,
+    cpu: bool = False,
+    buffer_max_size_bytes: int = DEFAULT_EXPORT_BUFFER_MAX_SIZE_BYTES,
 ) -> Generator[tuple[str, torch.Tensor], None, None]:
     """Export model weights as HF-format (name, tensor) pairs.
 
@@ -418,51 +785,170 @@ def export_hf_weights(
 
     if ps.pp_size <= 1:
         exported_params = 0
-        expert_groups: dict[str, list[tuple[int, str, torch.Tensor]]] = {}
-        for chunk in chunks:
-            base_chunk = unwrap_model(chunk)
-            layer_map = (
-                {i: base_chunk.layer_indices[i] for i in range(len(base_chunk.layer_indices))}
-                if hasattr(base_chunk, "layer_indices")
-                else {}
+        expert_bucket: list[tuple[str, torch.Tensor]] = []
+        expert_bucket_bytes = 0
+        packed_expert_buffers: dict[str, dict[int, torch.Tensor]] = {}
+        expert_bucket_limit_bytes = (
+            buffer_max_size_bytes
+            if ps.ep_size <= 1
+            else max(buffer_max_size_bytes // ps.ep_size, 1)
+        )
+        dense_bucket: list[tuple[str, torch.Tensor]] = []
+        dense_bucket_bytes = 0
+        dense_bucket_limit_bytes = (
+            buffer_max_size_bytes
+            if ps.tp_size <= 1
+            else max(buffer_max_size_bytes // ps.tp_size, 1)
+        )
+
+        def _iter_mapped(gathered_tensors: dict[str, torch.Tensor]):
+            if rank0_only and rank != 0:
+                return
+            for native_name, gathered_tensor in gathered_tensors.items():
+                if vocab_size is not None and ("embed" in native_name or "head" in native_name):
+                    gathered_tensor = gathered_tensor[:vocab_size]
+                for hf_name, hf_tensor in _native_to_hf(spec, native_name, gathered_tensor):
+                    yield hf_name, _cast_export_tensor(hf_tensor, resolved_export_dtype)
+
+        def _flush_dense_bucket():
+            nonlocal dense_bucket, dense_bucket_bytes
+            if not dense_bucket:
+                return
+            gathered_bucket = bucketed_all_gather_into_tensor(
+                dense_bucket,
+                group=ps.tp_group,
+                group_size=ps.tp_size,
+                buffer_max_size_bytes=buffer_max_size_bytes,
             )
-            for name, param in base_chunk.named_parameters():
-                gname = to_global_layer_name(name, layer_map)
-                tensor = _materialize_dtensor(param.data.detach())
+            dense_bucket = []
+            dense_bucket_bytes = 0
+            for native_name, local_tensor, shards in gathered_bucket:
+                merged = _merge_dense_shards(native_name, local_tensor, shards, spec)
+                yield from _iter_mapped({native_name: _maybe_cpu(merged, cpu=cpu)})
 
-                gathered_one: dict[str, torch.Tensor] = {}
-                if spec.is_expert(gname):
-                    if limit is None:
-                        expert_groups.setdefault(_expert_group_key(gname), []).append(
-                            (parse_expert_idx(gname), gname, tensor)
-                        )
-                        exported_params += 1
+        def _flush_expert_bucket():
+            nonlocal expert_bucket, expert_bucket_bytes
+            if not expert_bucket:
+                return
+            gathered_bucket = bucketed_all_gather_into_tensor(
+                expert_bucket,
+                group=ps.ep_group,
+                group_size=ps.ep_size,
+                buffer_max_size_bytes=buffer_max_size_bytes,
+            )
+            expert_bucket = []
+            expert_bucket_bytes = 0
+            experts_per_rank = spec.num_experts // ps.ep_size
+            for native_name, _, shards in gathered_bucket:
+                local_idx = parse_expert_idx(native_name)
+                packed_group_name = getattr(spec, "packed_expert_group_name", None)
+                packed_name = (
+                    packed_group_name(native_name)
+                    if callable(packed_group_name)
+                    else None
+                )
+                for ep_rank, shard in enumerate(shards):
+                    global_idx = ep_rank * experts_per_rank + local_idx
+                    global_name = set_expert_idx(native_name, global_idx)
+                    export_shard = _maybe_cpu(shard, cpu=cpu)
+                    if packed_name is None:
+                        yield from _iter_mapped({global_name: export_shard})
                         continue
-                    _gather_expert(gname, tensor, spec, ps, gathered_one)
-                else:
-                    gathered_one[gname] = _gather_dense(gname, tensor, spec, ps)
+                    packed_expert_buffers.setdefault(packed_name, {})[
+                        global_idx
+                    ] = export_shard
+                if packed_name is not None:
+                    packed = packed_expert_buffers[packed_name]
+                    if len(packed) == spec.num_experts:
+                        packed_tensor = torch.stack(
+                            [packed[idx] for idx in range(spec.num_experts)], dim=0
+                        )
+                        del packed_expert_buffers[packed_name]
+                        yield from _iter_mapped({packed_name: packed_tensor})
 
-                exported_params += 1
-                if not rank0_only or rank == 0:
-                    for native_name, gathered_tensor in gathered_one.items():
-                        if vocab_size is not None and (
-                            "embed" in native_name or "head" in native_name
-                        ):
-                            gathered_tensor = gathered_tensor[:vocab_size]
-                        for hf_name, hf_tensor in spec.native_to_hf(native_name, gathered_tensor):
-                            yield hf_name, _cast_export_tensor(hf_tensor, resolved_export_dtype)
+        def _iter_native_params():
+            for chunk in chunks:
+                base_chunk = unwrap_model(chunk)
+                layer_map = (
+                    {
+                        i: base_chunk.layer_indices[i]
+                        for i in range(len(base_chunk.layer_indices))
+                    }
+                    if hasattr(base_chunk, "layer_indices")
+                    else {}
+                )
+                for name, param in base_chunk.named_parameters():
+                    tensor = _cast_export_tensor(
+                        param.data.detach(), resolved_export_dtype
+                    )
+                    yield to_global_layer_name(name, layer_map), tensor
 
-                if limit is not None and exported_params >= limit:
-                    return
+        native_params = _iter_native_params()
+        materialized_params = (
+            _iter_bucketed_materialized_tensors(
+                native_params, buffer_max_size_bytes=buffer_max_size_bytes
+            )
+            if not cpu and limit is None
+            else (
+                (name, _materialize_dtensor(tensor)) for name, tensor in native_params
+            )
+        )
+        for gname, tensor in materialized_params:
+            gathered_one: dict[str, torch.Tensor] = {}
+            if spec.is_expert(gname):
+                yield from _flush_dense_bucket()
+                if limit is None:
+                    tensor = _gather_expert_etp(gname, tensor, spec, ps)
+                    tensor_bytes = tensor.numel() * tensor.element_size()
+                    should_flush = bool(expert_bucket) and (
+                        tensor.dtype != expert_bucket[0][1].dtype
+                        or expert_bucket_bytes + tensor_bytes > expert_bucket_limit_bytes
+                    )
+                    if should_flush:
+                        yield from _flush_expert_bucket()
+                    expert_bucket.append((gname, tensor))
+                    expert_bucket_bytes += tensor_bytes
+                    exported_params += 1
+                    if (
+                        len(expert_bucket) >= 4
+                        or expert_bucket_bytes >= expert_bucket_limit_bytes
+                    ):
+                        yield from _flush_expert_bucket()
+                    continue
+                _gather_expert(gname, tensor, spec, ps, gathered_one, cpu=cpu)
+            else:
+                yield from _flush_expert_bucket()
+                tp_info = spec.tp_spec(gname)
+                is_tp = tp_info is not None and tp_info[1] == 0 and ps.tp_size > 1
+                if is_tp:
+                    tensor_bytes = tensor.numel() * tensor.element_size()
+                    should_flush = bool(dense_bucket) and (
+                        tensor.dtype != dense_bucket[0][1].dtype
+                        or dense_bucket_bytes + tensor_bytes > dense_bucket_limit_bytes
+                    )
+                    if should_flush:
+                        yield from _flush_dense_bucket()
+                    dense_bucket.append((gname, tensor))
+                    dense_bucket_bytes += tensor_bytes
+                    exported_params += 1
+                    if dense_bucket_bytes >= dense_bucket_limit_bytes:
+                        yield from _flush_dense_bucket()
+                    if limit is not None and exported_params >= limit:
+                        yield from _flush_dense_bucket()
+                        return
+                    continue
 
-        for group_key in sorted(expert_groups):
-            gathered_group: dict[str, torch.Tensor] = {}
-            _gather_expert_group(expert_groups[group_key], spec, ps, gathered_group)
-            if not rank0_only or rank == 0:
-                for native_name in sorted(gathered_group, key=parse_expert_idx):
-                    gathered_tensor = gathered_group[native_name]
-                    for hf_name, hf_tensor in spec.native_to_hf(native_name, gathered_tensor):
-                        yield hf_name, _cast_export_tensor(hf_tensor, resolved_export_dtype)
+                yield from _flush_dense_bucket()
+                gathered_one[gname] = _maybe_cpu(tensor, cpu=cpu)
+
+            exported_params += 1
+            yield from _iter_mapped(gathered_one)
+
+            if limit is not None and exported_params >= limit:
+                return
+
+        yield from _flush_dense_bucket()
+        yield from _flush_expert_bucket()
         return
 
     gathered: dict[str, torch.Tensor] = {}
@@ -479,9 +965,9 @@ def export_hf_weights(
             t = _materialize_dtensor(param.data.detach())
 
             if spec.is_expert(gname):
-                _gather_expert(gname, t, spec, ps, gathered)
+                _gather_expert(gname, t, spec, ps, gathered, cpu=cpu)
             else:
-                gathered[gname] = _gather_dense(gname, t, spec, ps)
+                gathered[gname] = _gather_dense(gname, t, spec, ps, cpu=cpu)
 
     # PP gather
     if ps.pp_size > 1:
@@ -504,28 +990,36 @@ def export_hf_weights(
 
     # Convert Megatron Lite names → HF names via spec
     for native_name, tensor in gathered.items():
-        for hf_name, hf_tensor in spec.native_to_hf(native_name, tensor):
+        for hf_name, hf_tensor in _native_to_hf(spec, native_name, tensor):
             yield hf_name, _cast_export_tensor(hf_tensor, resolved_export_dtype)
 
 
-def _gather_dense(name: str, tensor: torch.Tensor, spec: HFWeights, ps) -> torch.Tensor:
+def _gather_dense(
+    name: str, tensor: torch.Tensor, spec: HFWeights, ps, *, cpu: bool = True
+) -> torch.Tensor:
     """Gather a dense (non-expert) param across TP."""
     custom_gather = getattr(spec, "gather_dense", None)
     if callable(custom_gather):
         gathered = custom_gather(name, tensor, ps)
         if gathered is not None:
-            return gathered.cpu()
+            return _maybe_cpu(gathered, cpu=cpu)
 
     tp_info = spec.tp_spec(name)
     if tp_info is not None and ps.tp_size > 1:
         split_d, tp_or_etp = tp_info
         if tp_or_etp == 0:
             tensor = allgather_concat(tensor, ps.tp_size, ps.tp_group, dim=split_d)
-    return tensor.cpu()
+    return _maybe_cpu(tensor, cpu=cpu)
 
 
 def _gather_expert(
-    name: str, tensor: torch.Tensor, spec: HFWeights, ps, out: dict[str, torch.Tensor]
+    name: str,
+    tensor: torch.Tensor,
+    spec: HFWeights,
+    ps,
+    out: dict[str, torch.Tensor],
+    *,
+    cpu: bool = True,
 ) -> None:
     """Gather an expert param across ETP + EP."""
     tensor = _gather_expert_etp(name, tensor, spec, ps)
@@ -535,12 +1029,12 @@ def _gather_expert(
     if ps.ep_size > 1 and ps.ep_group is not None:
         n_local = spec.num_experts // ps.ep_size
         ep_gathered = [torch.empty_like(tensor) for _ in range(ps.ep_size)]
-        dist.all_gather(ep_gathered, tensor.contiguous(), group=ps.ep_group)
+        _ep_all_gather(ep_gathered, tensor.contiguous(), ps.ep_group)
         for ep_rank, ep_tensor in enumerate(ep_gathered):
             global_idx = ep_rank * n_local + local_idx
-            out[set_expert_idx(name, global_idx)] = ep_tensor.cpu()
+            out[set_expert_idx(name, global_idx)] = _maybe_cpu(ep_tensor, cpu=cpu)
     else:
-        out[name] = tensor.cpu()
+        out[name] = _maybe_cpu(tensor, cpu=cpu)
 
 
 def _gather_expert_etp(name: str, tensor: torch.Tensor, spec: HFWeights, ps) -> torch.Tensor:
@@ -555,56 +1049,6 @@ def _gather_expert_etp(name: str, tensor: torch.Tensor, spec: HFWeights, ps) -> 
     return tensor
 
 
-def _expert_group_key(name: str) -> str:
-    return re.sub(r"weight\d+$", "weight", name)
-
-
-def _gather_expert_group(
-    entries: list[tuple[int, str, torch.Tensor]], spec: HFWeights, ps, out: dict[str, torch.Tensor]
-) -> None:
-    """Gather local experts in one EP collective per layer/kind."""
-    prepared = [
-        (local_idx, name, _gather_expert_etp(name, tensor, spec, ps))
-        for local_idx, name, tensor in sorted(entries)
-    ]
-    packed_group_name = getattr(spec, "packed_expert_group_name", None)
-    if callable(packed_group_name):
-        packed_name = packed_group_name(prepared[0][1])
-        if packed_name is not None:
-            if ps.ep_size <= 1 or ps.ep_group is None:
-                out[packed_name] = torch.stack(
-                    [tensor.contiguous() for _, _, tensor in prepared], dim=0
-                ).cpu()
-                return
-
-            sample = prepared[0][2]
-            packed = torch.empty((spec.num_experts, *sample.shape), dtype=sample.dtype, device="cpu")
-            for batch_start in range(0, len(prepared), 4):
-                batch = prepared[batch_start : batch_start + 4]
-                stacked = torch.stack([tensor.contiguous() for _, _, tensor in batch], dim=0)
-                ep_gathered = [torch.empty_like(stacked) for _ in range(ps.ep_size)]
-                dist.all_gather(ep_gathered, stacked, group=ps.ep_group)
-                for ep_rank, ep_tensor in enumerate(ep_gathered):
-                    for batch_idx, (local_idx, _, _) in enumerate(batch):
-                        packed[ep_rank * (spec.num_experts // ps.ep_size) + local_idx].copy_(ep_tensor[batch_idx])
-            out[packed_name] = packed
-            return
-
-    if ps.ep_size <= 1 or ps.ep_group is None:
-        for _, name, tensor in prepared:
-            out[name] = tensor.cpu()
-        return
-
-    n_local = spec.num_experts // ps.ep_size
-    stacked = torch.stack([tensor.contiguous() for _, _, tensor in prepared], dim=0)
-    ep_gathered = [torch.empty_like(stacked) for _ in range(ps.ep_size)]
-    dist.all_gather(ep_gathered, stacked, group=ps.ep_group)
-    for ep_rank, ep_tensor in enumerate(ep_gathered):
-        for slot, (local_idx, name, _) in enumerate(prepared):
-            global_idx = ep_rank * n_local + local_idx
-            out[set_expert_idx(name, global_idx)] = ep_tensor[slot].cpu()
-
-
 def save_hf_weights(
     model: nn.Module | list[nn.Module],
     hf_path: str,
@@ -615,7 +1059,11 @@ def save_hf_weights(
 ) -> None:
     """Export + write to safetensors."""
     rank = dist.get_rank() if dist.is_initialized() else 0
-    out = dict(export_hf_weights(model, spec, ps, vocab_size=vocab_size, rank0_only=True))
+    out = dict(
+        export_hf_weights(
+            model, spec, ps, vocab_size=vocab_size, rank0_only=True, cpu=True
+        )
+    )
     if rank == 0 and out:
         save_safetensors(out, hf_path)
     if dist.is_initialized():

--- a/experimental/lite/megatron/lite/primitive/ckpt/weight_sync_probe.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/weight_sync_probe.py
@@ -1,0 +1,138 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Opt-in wall-time and payload accounting for rollout weight synchronization."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from typing import Iterator
+
+import torch
+import torch.distributed as dist
+
+_ENV_NAME = "MLITE_WEIGHT_SYNC_PROBE"
+_REPORT_PREFIX = "MLITE_WEIGHT_SYNC_PROBE "
+
+
+def weight_sync_probe_enabled() -> bool:
+    return os.getenv(_ENV_NAME, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+@dataclass
+class _StageStats:
+    calls: int = 0
+    bytes: int = 0
+    wall_s: float = 0.0
+
+
+@dataclass
+class _Session:
+    backend: str
+    started_at: float
+    depth: int = 1
+    stages: dict[str, _StageStats] = field(default_factory=dict)
+
+
+@dataclass
+class ProbeSample:
+    nbytes: int = 0
+
+
+class WeightSyncProbe:
+    def __init__(self) -> None:
+        self._session: ContextVar[_Session | None] = ContextVar(
+            "mlite_weight_sync_probe_session", default=None
+        )
+
+    @property
+    def active(self) -> bool:
+        return weight_sync_probe_enabled() and self._session.get() is not None
+
+    @contextmanager
+    def session(self, backend: str) -> Iterator[None]:
+        if not weight_sync_probe_enabled():
+            yield
+            return
+
+        current = self._session.get()
+        if current is not None:
+            current.depth += 1
+            try:
+                yield
+            finally:
+                current.depth -= 1
+            return
+
+        session = _Session(backend=backend, started_at=time.perf_counter())
+        token = self._session.set(session)
+        try:
+            yield
+        finally:
+            total_wall_s = time.perf_counter() - session.started_at
+            self._session.reset(token)
+            rank = (
+                dist.get_rank() if dist.is_available() and dist.is_initialized() else 0
+            )
+            report = {
+                "backend": session.backend,
+                "rank": rank,
+                "stages": {
+                    name: {
+                        "calls": stats.calls,
+                        "bytes": stats.bytes,
+                        "wall_s": stats.wall_s,
+                    }
+                    for name, stats in sorted(session.stages.items())
+                },
+                "total_wall_s": total_wall_s,
+            }
+            print(_REPORT_PREFIX + json.dumps(report, sort_keys=True), flush=True)
+
+    @contextmanager
+    def measure(
+        self, stage: str, *, nbytes: int = 0, device: torch.device | str | None = None
+    ) -> Iterator[ProbeSample]:
+        session = self._session.get()
+        if not weight_sync_probe_enabled() or session is None:
+            yield ProbeSample(nbytes=nbytes)
+            return
+
+        if device is not None and torch.cuda.is_available():
+            torch.cuda.synchronize(device)
+        started_at = time.perf_counter()
+        sample = ProbeSample(nbytes=nbytes)
+        try:
+            yield sample
+        finally:
+            if device is not None and torch.cuda.is_available():
+                torch.cuda.synchronize(device)
+            stats = session.stages.setdefault(stage, _StageStats())
+            stats.calls += 1
+            stats.bytes += int(sample.nbytes)
+            stats.wall_s += time.perf_counter() - started_at
+
+
+_PROBE = WeightSyncProbe()
+
+
+def get_weight_sync_probe() -> WeightSyncProbe:
+    return _PROBE
+
+
+@contextmanager
+def weight_sync_probe_session(backend: str) -> Iterator[None]:
+    with _PROBE.session(backend):
+        yield
+
+
+__all__ = [
+    "ProbeSample",
+    "WeightSyncProbe",
+    "get_weight_sync_probe",
+    "weight_sync_probe_enabled",
+    "weight_sync_probe_session",
+]

--- a/experimental/lite/megatron/lite/primitive/modules/dispatcher.py
+++ b/experimental/lite/megatron/lite/primitive/modules/dispatcher.py
@@ -189,12 +189,21 @@ class _DeepEPCombine(torch.autograd.Function):
 class TokenDispatcher:
 
     def __init__(
-        self, num_experts: int, hidden_size: int, ps: ParallelState, *, use_deepep: bool = True
+        self,
+        num_experts: int,
+        hidden_size: int,
+        ps: ParallelState,
+        *,
+        use_deepep: bool = True,
+        moe_permute_fusion: bool | None = None,
     ):
         self.ps = ps
         self.num_experts = num_experts
         self.ep_size = ps.ep_size
         self.num_local_experts = ensure_divisible(num_experts, ps.ep_size)
+        self.moe_permute_fusion = (
+            _use_moe_permute_fusion() if moe_permute_fusion is None else bool(moe_permute_fusion)
+        )
 
         self.use_deepep = use_deepep and deep_ep is not None and ps.ep_size > 1
         if self.use_deepep:
@@ -245,7 +254,7 @@ class TokenDispatcher:
             expert_output,
             self._row_id_map,
             restore_shape=self._restore_shape,
-            fused=_use_moe_permute_fusion(),
+            fused=self.moe_permute_fusion,
         )
         previous_event = (
             EventOverlap(EventHandle())
@@ -294,7 +303,7 @@ class TokenDispatcher:
             routing_map,
             probs=probs_2d,
             num_out_tokens=num_out,
-            fused=_use_moe_permute_fusion(),
+            fused=self.moe_permute_fusion,
         )[:3]
 
         self._row_id_map = sorted_indices
@@ -308,7 +317,7 @@ class TokenDispatcher:
             expert_output,
             self._row_id_map,
             restore_shape=self._restore_shape,
-            fused=_use_moe_permute_fusion(),
+            fused=self.moe_permute_fusion,
         )
         self._row_id_map = None
         self._restore_shape = None
@@ -336,7 +345,7 @@ class TokenDispatcher:
             routing_map,
             probs=probs_2d,
             num_out_tokens=num_out,
-            fused=_use_moe_permute_fusion(),
+            fused=self.moe_permute_fusion,
         )[:3]
         self._row_id_map = sorted_indices
         self._restore_shape = hidden_states.shape
@@ -398,7 +407,7 @@ class TokenDispatcher:
             combined,
             self._row_id_map,
             restore_shape=self._restore_shape,
-            fused=_use_moe_permute_fusion(),
+            fused=self.moe_permute_fusion,
         )
         self._row_id_map = None
         self._restore_shape = None
@@ -503,7 +512,7 @@ class TokenDispatcher:
             routing_map,
             probs=probs_2d,
             num_out_tokens=num_out,
-            fused=_use_moe_permute_fusion(),
+            fused=self.moe_permute_fusion,
         )[:3]
         self._row_id_map = sorted_indices
         self._restore_shape = recv_hidden.shape
@@ -562,7 +571,7 @@ class TokenDispatcher:
             expert_output,
             self._row_id_map,
             restore_shape=self._restore_shape,
-            fused=_use_moe_permute_fusion(),
+            fused=self.moe_permute_fusion,
         )
         if torch.is_grad_enabled():
             combined = _DeepEPCombine.apply(self.buffer, rank_grouped, self._handle, False, False)

--- a/experimental/lite/megatron/lite/primitive/modules/gated_delta_net.py
+++ b/experimental/lite/megatron/lite/primitive/modules/gated_delta_net.py
@@ -432,6 +432,7 @@ class GatedDeltaNet(nn.Module):
             a.reshape(batch, seq_len, self.num_v_heads_local),
         )
 
+    @jit_fuser
     def _prepare_qkv(
         self, qkv: torch.Tensor, gate, beta, alpha, batch: int, seq_len: int
     ):
@@ -440,9 +441,8 @@ class GatedDeltaNet(nn.Module):
             batch, seq_len, 2 * self.num_k_heads_local, self.dk
         )
         value = value.reshape(batch, seq_len, self.num_v_heads_local, self.dv)
+        query_key = self._l2norm(query_key.contiguous())
         query, key = query_key.split(self.num_k_heads_local, dim=2)
-        query = self._l2norm(query.contiguous())
-        key = self._l2norm(key.contiguous())
         if self.v_heads_per_k_head > 1:
             query = query.repeat_interleave(self.v_heads_per_k_head, dim=2)
             key = key.repeat_interleave(self.v_heads_per_k_head, dim=2)
@@ -455,10 +455,13 @@ class GatedDeltaNet(nn.Module):
             alpha.contiguous(),
         )
 
-    def _l2norm(self, x: torch.Tensor) -> torch.Tensor:
+    @staticmethod
+    @jit_fuser
+    def _l2norm(x: torch.Tensor) -> torch.Tensor:
         return l2norm(x)
 
     @staticmethod
+    @jit_fuser
     def _compute_g_and_beta(A_log, dt_bias, alpha, beta):
         g = -A_log.exp() * F.softplus(alpha.float() + dt_bias)
         return g, beta.sigmoid()

--- a/experimental/lite/megatron/lite/primitive/modules/router.py
+++ b/experimental/lite/megatron/lite/primitive/modules/router.py
@@ -99,7 +99,16 @@ class TopKRouter(nn.Module):
         if self.router_dtype is None:
             topk_scores = topk_scores.to(x.dtype)
 
-        if self.compute_aux_loss and self.training and torch.is_grad_enabled():
+        # A zero/None coefficient means no load-balancing objective (the RL
+        # reference backend runs moe_router_load_balancing_type='none'); do not
+        # attach an aux-loss gradient in that case.
+        apply_aux_loss = (
+            self.compute_aux_loss
+            and bool(self.aux_loss_coeff)
+            and self.training
+            and torch.is_grad_enabled()
+        )
+        if apply_aux_loss:
             routing_map, aux_scores = compute_routing_scores_for_aux_loss(
                 logits, self.topk, score_function="softmax", fused=self.moe_router_fusion
             )
@@ -177,7 +186,13 @@ class SigmoidTopKRouter(nn.Module):
         )
         topk_scores = topk_scores.to(logits.dtype)
 
-        if self.compute_aux_loss and self.training and torch.is_grad_enabled():
+        apply_aux_loss = (
+            self.compute_aux_loss
+            and bool(self.aux_loss_coeff)
+            and self.training
+            and torch.is_grad_enabled()
+        )
+        if apply_aux_loss:
             _, aux_scores = compute_routing_scores_for_aux_loss(
                 logits, self.topk, score_function=self.score_function, fused=self.moe_router_fusion
             )

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
@@ -31,6 +31,12 @@ def _build_impl_cfg(proto, rt_cfg: MegatronLiteConfig):
         and impl_cfg_kwargs.get("attention_backend_override") is None
     ):
         impl_cfg_kwargs["attention_backend_override"] = rt_cfg.attention_backend_override
+    if (
+        "router_aux_loss_coef" in init_fields
+        and impl_cfg_kwargs.get("router_aux_loss_coef") is None
+        and rt_cfg.router_aux_loss_coef is not None
+    ):
+        impl_cfg_kwargs["router_aux_loss_coef"] = rt_cfg.router_aux_loss_coef
     if "hf_path" in init_fields and impl_cfg_kwargs.get("hf_path") in (None, "") and rt_cfg.hf_path:
         impl_cfg_kwargs["hf_path"] = rt_cfg.hf_path
     # Thread the user-level OptimizerConfig so the protocol can pass it to

--- a/experimental/lite/tests/smoke/primitive/test_save_load_export_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_save_load_export_smoke.py
@@ -465,7 +465,9 @@ def _export_and_reload(handle: ModelHandle, cfg, protocol, out_dir: str, model_n
     elif hasattr(protocol, "export_hf_weights"):
         from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
 
-        weights = dict(protocol.export_hf_weights(chunks, cfg, ps, rank0_only=True))
+        weights = dict(
+            protocol.export_hf_weights(chunks, cfg, ps, rank0_only=True, cpu=True)
+        )
         if dist.get_rank() == 0 and weights:
             save_safetensors(weights, out_dir)
     else:

--- a/experimental/lite/tests/unit/model/test_qwen35_export.py
+++ b/experimental/lite/tests/unit/model/test_qwen35_export.py
@@ -154,24 +154,43 @@ def test_qwen35_export_preserves_runtime_parameter_dtype_by_default() -> None:
     )
 
 
+def test_qwen35_online_export_keeps_weights_on_the_source_device() -> None:
+    class TinyQwen35Module(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.norm = nn.LayerNorm(8, device="meta")
+
+    exported = dict(
+        export_hf_weights(
+            TinyQwen35Module(),
+            _tiny_config(),
+            _single_rank_parallel_state(),
+            cpu=False,
+        )
+    )
+
+    assert exported["model.language_model.norm.weight"].device.type == "meta"
+
+
 def test_qwen35_export_batches_ep_expert_gather(monkeypatch) -> None:
     class TinyQwen35Module(nn.Module):
         def __init__(self, config: Qwen35Config) -> None:
             super().__init__()
-            self.layers = nn.ModuleList([nn.Module()])
-            self.layers[0].moe = nn.Module()
-            self.layers[0].moe.experts = nn.Module()
-            self.layers[0].moe.experts.fc1 = nn.Module()
+            self.layers = nn.ModuleList([nn.Module(), nn.Module()])
 
             rows = config.moe_intermediate_size * 2
-            for local_idx in range(config.num_experts // 2):
-                tensor = torch.arange(rows * config.hidden_size, dtype=torch.bfloat16).reshape(
-                    rows, config.hidden_size
-                )
-                tensor = tensor + local_idx * 1000
-                self.layers[0].moe.experts.fc1.register_parameter(
-                    f"weight{local_idx}", nn.Parameter(tensor)
-                )
+            for layer_idx, layer in enumerate(self.layers):
+                layer.moe = nn.Module()
+                layer.moe.experts = nn.Module()
+                layer.moe.experts.fc1 = nn.Module()
+                for local_idx in range(config.num_experts // 2):
+                    tensor = torch.arange(
+                        rows * config.hidden_size, dtype=torch.bfloat16
+                    ).reshape(rows, config.hidden_size)
+                    tensor = tensor + layer_idx * 10000 + local_idx * 1000
+                    layer.moe.experts.fc1.register_parameter(
+                        f"weight{local_idx}", nn.Parameter(tensor)
+                    )
 
     cfg = _tiny_config()
     cfg.num_experts = 16
@@ -187,24 +206,40 @@ def test_qwen35_export_batches_ep_expert_gather(monkeypatch) -> None:
     )
     gather_calls = []
 
-    def fake_all_gather(outputs, tensor, group=None):
+    def fake_all_gather(output, tensor, group=None):
         del group
-        gather_calls.append(tensor.clone())
-        outputs[0].copy_(tensor)
-        outputs[1].copy_(tensor + 2000)
+        gather_calls.append(
+            tensor.clone().reshape(-1, cfg.moe_intermediate_size * 2, cfg.hidden_size)
+        )
+        output[: tensor.numel()].copy_(tensor)
+        output[tensor.numel() :].copy_(tensor + 2000)
 
-    monkeypatch.setattr("megatron.lite.primitive.ckpt.hf_weights.dist.all_gather", fake_all_gather)
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.hf_weights.dist.all_gather_into_tensor",
+        fake_all_gather,
+    )
 
     exported = dict(export_hf_weights(model, cfg, ps))
 
-    assert len(gather_calls) == 2
-    assert all(call.shape[0] <= 4 for call in gather_calls)
+    assert len(gather_calls) == 4
+    assert all(call.shape[0] == 4 for call in gather_calls)
     local_tensors = [
         getattr(model.layers[0].moe.experts.fc1, f"weight{i}").detach()
         for i in range(cfg.num_experts // ps.ep_size)
     ]
     expected = torch.stack(local_tensors + [tensor + 2000 for tensor in local_tensors])
     assert torch.equal(exported["model.language_model.layers.0.mlp.experts.gate_up_proj"], expected)
+    layer1_tensors = [
+        getattr(model.layers[1].moe.experts.fc1, f"weight{i}").detach()
+        for i in range(cfg.num_experts // ps.ep_size)
+    ]
+    layer1_expected = torch.stack(
+        layer1_tensors + [tensor + 2000 for tensor in layer1_tensors]
+    )
+    assert torch.equal(
+        exported["model.language_model.layers.1.mlp.experts.gate_up_proj"],
+        layer1_expected,
+    )
 
 
 def test_qwen35_export_uses_packed_expert_group_names(monkeypatch) -> None:
@@ -270,15 +305,18 @@ def test_qwen35_export_rank0_only_still_participates_in_ep_gather(monkeypatch) -
     )
     gather_calls = []
 
-    def fake_all_gather(outputs, tensor, group=None):
+    def fake_all_gather(output, tensor, group=None):
         del group
         gather_calls.append(tensor.clone())
-        outputs[0].copy_(tensor)
-        outputs[1].copy_(tensor + 2)
+        output[: tensor.numel()].copy_(tensor)
+        output[tensor.numel() :].copy_(tensor + 2)
 
     monkeypatch.setattr("megatron.lite.primitive.ckpt.hf_weights.dist.is_initialized", lambda: True)
     monkeypatch.setattr("megatron.lite.primitive.ckpt.hf_weights.dist.get_rank", lambda: 1)
-    monkeypatch.setattr("megatron.lite.primitive.ckpt.hf_weights.dist.all_gather", fake_all_gather)
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.hf_weights.dist.all_gather_into_tensor",
+        fake_all_gather,
+    )
 
     exported = list(export_hf_weights(TinyQwen35Module(cfg), cfg, ps, rank0_only=True))
 
@@ -451,14 +489,15 @@ def test_qwen35_export_uses_mbridge_conv1d_tp_gather(monkeypatch) -> None:
     )
     gather_calls = []
 
-    def fake_all_gather(outputs, tensor, group=None):
+    def fake_all_gather(output, tensor, group=None):
         assert group is ps.tp_group
-        gather_calls.append(tensor.clone())
-        outputs[0].copy_(shards[0])
-        outputs[1].copy_(shards[1])
+        gather_calls.append(tensor.clone().reshape_as(shards[0]))
+        output[: tensor.numel()].copy_(shards[0].view(-1))
+        output[tensor.numel() :].copy_(shards[1].view(-1))
 
     monkeypatch.setattr(
-        "megatron.lite.model.qwen3_5.lite.checkpoint.dist.all_gather", fake_all_gather
+        "megatron.lite.primitive.ckpt.hf_weights.dist.all_gather_into_tensor",
+        fake_all_gather,
     )
 
     exported = dict(export_hf_weights(TinyQwen35Module(shards[0]), cfg, ps))

--- a/experimental/lite/tests/unit/primitive/test_hf_weights_streaming.py
+++ b/experimental/lite/tests/unit/primitive/test_hf_weights_streaming.py
@@ -1,0 +1,445 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+from __future__ import annotations
+
+import importlib.util
+import inspect
+import sys
+import types
+
+import torch
+import torch.nn as nn
+import pytest
+
+if importlib.util.find_spec("safetensors") is None:
+    safetensors = types.ModuleType("safetensors")
+    safetensors.safe_open = None
+    safetensors_torch = types.ModuleType("safetensors.torch")
+    safetensors_torch.save_file = None
+    sys.modules["safetensors"] = safetensors
+    sys.modules["safetensors.torch"] = safetensors_torch
+
+from megatron.lite.primitive.ckpt.hf_weights import (
+    _iter_bucketed_materialized_tensors,
+    bucketed_all_gather_into_tensor,
+    export_hf_weights,
+)
+
+
+def test_export_defaults_to_device_resident_tensors() -> None:
+    assert inspect.signature(export_hf_weights).parameters["cpu"].default is False
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_gpu_resident_export_is_bitwise_equal_to_legacy_cpu_export() -> None:
+    class Model(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.weight = nn.Parameter(
+                torch.arange(12, dtype=torch.bfloat16, device="cuda").reshape(3, 4)
+            )
+
+    class Spec:
+        num_experts = 0
+
+        @staticmethod
+        def is_expert(name):
+            return False
+
+        @staticmethod
+        def tp_spec(name):
+            return None
+
+        @staticmethod
+        def native_to_hf(name, tensor):
+            return [(name, tensor)]
+
+    ps = type(
+        "ParallelState",
+        (),
+        {
+            "pp_size": 1,
+            "tp_size": 1,
+            "tp_group": None,
+            "ep_size": 1,
+            "ep_group": None,
+            "etp_size": 1,
+            "etp_group": None,
+        },
+    )()
+    model = Model()
+
+    legacy = dict(export_hf_weights(model, Spec(), ps, cpu=True))
+    resident = dict(export_hf_weights(model, Spec(), ps))
+
+    assert legacy.keys() == resident.keys()
+    assert legacy["weight"].device.type == "cpu"
+    assert resident["weight"].device.type == "cuda"
+    assert torch.equal(legacy["weight"], resident["weight"].cpu())
+
+
+def test_bucketed_all_gather_uses_bounded_flat_buffers(monkeypatch) -> None:
+    bucket = [
+        ("first", torch.arange(6, dtype=torch.float32).reshape(2, 3)),
+        ("second", torch.arange(5, dtype=torch.float32)),
+    ]
+    calls = []
+
+    def fake_all_gather_into_tensor(output, tensor, group=None):
+        assert group == "tp"
+        calls.append((output.numel(), tensor.numel()))
+        output[: tensor.numel()].copy_(tensor)
+        output[tensor.numel() :].copy_(tensor + 100)
+
+    monkeypatch.setattr(torch.distributed, "all_gather_into_tensor", fake_all_gather_into_tensor)
+
+    gathered = bucketed_all_gather_into_tensor(
+        bucket,
+        group="tp",
+        group_size=2,
+        buffer_max_size_bytes=32,
+    )
+
+    assert len(calls) == 3
+    assert all(recv_numel * 4 <= 32 for recv_numel, _ in calls)
+    assert all(recv_numel == 2 * send_numel for recv_numel, send_numel in calls)
+    assert torch.equal(gathered[0][2][0], bucket[0][1])
+    assert torch.equal(gathered[0][2][1], bucket[0][1] + 100)
+    assert torch.equal(gathered[1][2][0], bucket[1][1])
+    assert torch.equal(gathered[1][2][1], bucket[1][1] + 100)
+
+
+def test_fsdp_dtensors_share_one_bounded_flat_collective(monkeypatch) -> None:
+    class Shard:
+        def __init__(self, dim: int) -> None:
+            self.dim = dim
+
+    class Mesh:
+        def __init__(self, group) -> None:
+            self.group = group
+
+        def get_group(self, mesh_dim):
+            assert mesh_dim == 0
+            return self.group
+
+    class FakeDTensor:
+        def __init__(self, local, shape, shard_dim, group):
+            self._local = local
+            self.shape = shape
+            self.device = local.device
+            self.dtype = local.dtype
+            self.device_mesh = Mesh(group)
+            self.placements = (Shard(shard_dim),)
+
+        def to_local(self):
+            return self._local
+
+        def full_tensor(self):
+            raise AssertionError("per-parameter full_tensor must not be used")
+
+    first_group = object()
+    equivalent_group = object()
+    single_rank_group = object()
+    first = FakeDTensor(
+        torch.arange(6, dtype=torch.float32).reshape(2, 3),
+        (4, 3),
+        0,
+        first_group,
+    )
+    single = FakeDTensor(
+        torch.arange(3, dtype=torch.float32), (3,), 0, single_rank_group
+    )
+    second = FakeDTensor(
+        torch.arange(4, dtype=torch.float32).reshape(2, 2),
+        (2, 4),
+        1,
+        equivalent_group,
+    )
+    calls = []
+
+    def fake_all_gather_into_tensor(output, tensor, group=None):
+        assert group is first_group
+        calls.append(tensor.clone())
+        output[: tensor.numel()].copy_(tensor)
+        output[tensor.numel() :].copy_(tensor + 100)
+
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.hf_weights.DTensor", FakeDTensor
+    )
+    monkeypatch.setattr(
+        torch.distributed,
+        "get_world_size",
+        lambda group: 1 if group is single_rank_group else 2,
+    )
+    monkeypatch.setattr(
+        torch.distributed,
+        "get_process_group_ranks",
+        lambda group: [0] if group is single_rank_group else [0, 1],
+    )
+    monkeypatch.setattr(
+        torch.distributed, "all_gather_into_tensor", fake_all_gather_into_tensor
+    )
+
+    outputs = list(
+        _iter_bucketed_materialized_tensors(
+            [
+                ("first", first),
+                ("plain", torch.tensor([7.0])),
+                ("single", single),
+                ("second", second),
+            ],
+            buffer_max_size_bytes=1024,
+        )
+    )
+    materialized = dict(outputs)
+
+    assert len(calls) == 1
+    assert [name for name, _ in outputs] == ["first", "plain", "single", "second"]
+    assert materialized["single"] is single.to_local()
+    assert torch.equal(
+        materialized["first"],
+        torch.cat([first.to_local(), first.to_local() + 100], dim=0),
+    )
+    assert torch.equal(
+        materialized["second"],
+        torch.cat([second.to_local(), second.to_local() + 100], dim=1),
+    )
+
+
+def test_oversized_fsdp_shard_is_gathered_in_shard_dimension_chunks(
+    monkeypatch,
+) -> None:
+    class Shard:
+        dim = 1
+
+    class Mesh:
+        @staticmethod
+        def get_group(mesh_dim):
+            assert mesh_dim == 0
+            return "fsdp"
+
+    class FakeDTensor:
+        def __init__(self, local):
+            self._local = local
+            self.shape = (local.shape[0], local.shape[1] * 2)
+            self.device_mesh = Mesh()
+            self.placements = (Shard(),)
+
+        def to_local(self):
+            return self._local
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    local = torch.arange(10, dtype=torch.float32, device=device).reshape(2, 5)
+    calls = []
+
+    def fake_all_gather_into_tensor(output, tensor, group=None):
+        assert group == "fsdp"
+        calls.append(tensor.shape)
+        output[: tensor.numel()].copy_(tensor)
+        output[tensor.numel() :].copy_(tensor + 100)
+
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.hf_weights.DTensor", FakeDTensor
+    )
+    monkeypatch.setattr(torch.distributed, "get_world_size", lambda group: 2)
+    monkeypatch.setattr(
+        torch.distributed, "get_process_group_ranks", lambda group: [0, 1]
+    )
+    monkeypatch.setattr(
+        torch.distributed, "all_gather_into_tensor", fake_all_gather_into_tensor
+    )
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.hf_weights.torch.empty_like",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("oversized shards must not allocate full rank copies")
+        ),
+    )
+
+    outputs = dict(
+        _iter_bucketed_materialized_tensors(
+            [("oversized", FakeDTensor(local))], buffer_max_size_bytes=32
+        )
+    )
+
+    assert calls == [torch.Size([4]), torch.Size([4]), torch.Size([2])]
+    assert torch.equal(outputs["oversized"], torch.cat([local, local + 100], dim=1))
+
+
+def test_replicated_dtensor_uses_local_tensor_without_collective(monkeypatch) -> None:
+    class Replicate:
+        pass
+
+    class FakeDTensor:
+        def __init__(self, local):
+            self._local = local
+            self.shape = local.shape
+            self.device = local.device
+            self.dtype = local.dtype
+            self.placements = (Replicate(),)
+
+        def to_local(self):
+            return self._local
+
+        def full_tensor(self):
+            raise AssertionError("replicated parameters must not call full_tensor")
+
+    local = torch.arange(5, dtype=torch.float32)
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.hf_weights.DTensor", FakeDTensor
+    )
+    monkeypatch.setattr(
+        torch.distributed,
+        "all_gather_into_tensor",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("replicated parameters must not be gathered")
+        ),
+    )
+
+    outputs = list(
+        _iter_bucketed_materialized_tensors([("replicated", FakeDTensor(local))])
+    )
+
+    assert outputs[0][0] == "replicated"
+    assert outputs[0][1] is local
+
+
+def test_export_batches_adjacent_tp_weights_into_one_flat_collective(
+    monkeypatch,
+) -> None:
+    class Model(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.first = nn.Parameter(torch.arange(4, dtype=torch.float32).reshape(2, 2))
+            self.second = nn.Parameter(torch.arange(3, dtype=torch.float32).reshape(1, 3))
+
+    class Spec:
+        num_experts = 0
+
+        @staticmethod
+        def is_expert(name):
+            return False
+
+        @staticmethod
+        def tp_spec(name):
+            return (0, 0)
+
+        @staticmethod
+        def native_to_hf(name, tensor):
+            return [(name, tensor)]
+
+    ps = type(
+        "ParallelState",
+        (),
+        {
+            "pp_size": 1,
+            "tp_size": 2,
+            "tp_group": "tp",
+            "ep_size": 1,
+            "ep_group": None,
+            "etp_size": 1,
+            "etp_group": None,
+        },
+    )()
+    calls = []
+
+    def fake_all_gather_into_tensor(output, tensor, group=None):
+        assert group == "tp"
+        calls.append(tensor.clone())
+        output[: tensor.numel()].copy_(tensor)
+        output[tensor.numel() :].copy_(tensor + 10)
+
+    monkeypatch.setattr(torch.distributed, "all_gather_into_tensor", fake_all_gather_into_tensor)
+
+    exported = dict(export_hf_weights(Model(), Spec(), ps, cpu=False, buffer_max_size_bytes=1024))
+
+    assert len(calls) == 1
+    assert torch.equal(
+        exported["first"],
+        torch.cat([torch.arange(4).reshape(2, 2), torch.arange(4).reshape(2, 2) + 10]),
+    )
+    assert torch.equal(
+        exported["second"],
+        torch.cat([torch.arange(3).reshape(1, 3), torch.arange(3).reshape(1, 3) + 10]),
+    )
+
+
+def test_expert_export_yields_when_bounded_ep_bucket_fills(monkeypatch) -> None:
+    class ExpertGroup(nn.Module):
+        def __init__(self, offset: int) -> None:
+            super().__init__()
+            for idx in range(2):
+                self.register_parameter(
+                    f"weight{idx}",
+                    nn.Parameter(torch.arange(4, dtype=torch.float32) + offset + idx * 10),
+                )
+
+    class Model(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.first = nn.Module()
+            self.first.experts = ExpertGroup(0)
+            self.second = nn.Module()
+            self.second.experts = ExpertGroup(1000)
+
+        def named_parameters(self, *args, **kwargs):
+            for item in super().named_parameters(*args, **kwargs):
+                visited.append(item[0])
+                yield item
+
+    class Spec:
+        num_experts = 4
+
+        @staticmethod
+        def is_expert(name):
+            return ".experts." in name
+
+        @staticmethod
+        def tp_spec(name):
+            return None
+
+        @staticmethod
+        def packed_expert_group_name(name):
+            return name.rsplit(".weight", 1)[0] + ".packed"
+
+        @staticmethod
+        def native_to_hf(name, tensor):
+            assert name.endswith(".packed")
+            return [(name, tensor)]
+
+    ps = type(
+        "ParallelState",
+        (),
+        {
+            "pp_size": 1,
+            "tp_size": 1,
+            "tp_group": None,
+            "ep_size": 2,
+            "ep_group": "ep",
+            "etp_size": 1,
+            "etp_group": None,
+        },
+    )()
+    visited = []
+
+    def fake_all_gather_into_tensor(output, tensor, group=None):
+        assert group == "ep"
+        output[: tensor.numel()].copy_(tensor)
+        output[tensor.numel() :].copy_(tensor + 100)
+
+    monkeypatch.setattr(
+        torch.distributed, "all_gather_into_tensor", fake_all_gather_into_tensor
+    )
+
+    stream = export_hf_weights(
+        Model(), Spec(), ps, cpu=False, buffer_max_size_bytes=64
+    )
+    name, tensor = next(stream)
+
+    assert name == "first.experts.packed"
+    assert len(visited) == 2
+    expected_local = [
+        torch.arange(4, dtype=torch.float32),
+        torch.arange(4, dtype=torch.float32) + 10,
+    ]
+    assert torch.equal(
+        tensor, torch.stack(expected_local + [value + 100 for value in expected_local])
+    )

--- a/experimental/lite/tests/unit/primitive/test_router_aux_loss_gate.py
+++ b/experimental/lite/tests/unit/primitive/test_router_aux_loss_gate.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Aux-loss gating: a zero coefficient must not attach aux-loss gradients.
+
+The RL reference backend (verl megatron) runs
+``moe_router_load_balancing_type='none'`` — no load-balancing gradient at all.
+mLite routers previously attached the switch load-balancing loss through
+``MoEAuxLossAutoScaler`` whenever ``compute_aux_loss=True`` and training,
+even when the coefficient resolved to zero, injecting a coherent all-token
+gradient into every parameter below the router.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import megatron.lite.primitive.modules.router as router_module
+from megatron.lite.primitive.modules.router import SigmoidTopKRouter, TopKRouter
+
+
+def _ps():
+    return SimpleNamespace(tp_size=1)
+
+
+def _config(coef: float) -> SimpleNamespace:
+    return SimpleNamespace(
+        num_experts_per_tok=2,
+        num_experts=4,
+        n_routed_experts=4,
+        router_aux_loss_coef=coef,
+        aux_loss_alpha=coef,
+        hidden_size=8,
+        norm_topk_prob=True,
+        routed_scaling_factor=1.0,
+        scoring_func="sigmoid",
+        n_group=None,
+        topk_group=None,
+    )
+
+
+class _CountingScaler(torch.autograd.Function):
+    calls = 0
+
+    @staticmethod
+    def forward(ctx, output, aux_loss):
+        _CountingScaler.calls += 1
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        return grad_output, None
+
+
+@pytest.fixture
+def counting_scaler(monkeypatch):
+    _CountingScaler.calls = 0
+    monkeypatch.setattr(router_module, "MoEAuxLossAutoScaler", _CountingScaler)
+    return _CountingScaler
+
+
+@pytest.mark.parametrize("coef,expected_calls", [(0.0, 0), (0.001, 1)])
+def test_topk_router_skips_aux_loss_when_coef_zero(counting_scaler, coef, expected_calls):
+    if not torch.cuda.is_available():
+        pytest.skip("TopKRouter gating GEMM requires CUDA")
+    router = TopKRouter(_config(coef), _ps()).cuda()
+    router.train()
+    x = torch.randn(6, 8, device="cuda", requires_grad=True)
+    scores, indices = router(x)
+    assert scores.shape == (6, 2)
+    assert indices.shape == (6, 2)
+    assert counting_scaler.calls == expected_calls
+
+
+@pytest.mark.parametrize("coef,expected_calls", [(0.0, 0), (0.001, 1)])
+def test_sigmoid_router_skips_aux_loss_when_coef_zero(counting_scaler, coef, expected_calls):
+    router = SigmoidTopKRouter(_config(coef), _ps())
+    router.train()
+    x = torch.randn(6, 8, requires_grad=True)
+    scores, indices = router(x)
+    assert scores.shape == (6, 2)
+    assert indices.shape == (6, 2)
+    assert counting_scaler.calls == expected_calls

--- a/experimental/lite/tests/unit/primitive/test_weight_sync_probe.py
+++ b/experimental/lite/tests/unit/primitive/test_weight_sync_probe.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+from __future__ import annotations
+
+import json
+import importlib.util
+import sys
+import types
+
+import torch
+
+if importlib.util.find_spec("safetensors") is None:
+    safetensors = types.ModuleType("safetensors")
+    safetensors.safe_open = None
+    safetensors_torch = types.ModuleType("safetensors.torch")
+    safetensors_torch.save_file = None
+    sys.modules["safetensors"] = safetensors
+    sys.modules["safetensors.torch"] = safetensors_torch
+
+from megatron.lite.primitive.ckpt import hf_weights
+from megatron.lite.primitive.ckpt.weight_sync_probe import (
+    get_weight_sync_probe,
+    weight_sync_probe_session,
+)
+
+
+def _report_from_stdout(stdout: str) -> dict:
+    line = next(
+        line
+        for line in stdout.splitlines()
+        if line.startswith("MLITE_WEIGHT_SYNC_PROBE ")
+    )
+    return json.loads(line.split(" ", 1)[1])
+
+
+def test_probe_is_silent_when_disabled(monkeypatch, capsys):
+    monkeypatch.delenv("MLITE_WEIGHT_SYNC_PROBE", raising=False)
+
+    with weight_sync_probe_session("mlite"):
+        with get_weight_sync_probe().measure("mapping") as sample:
+            sample.nbytes = 16
+
+    assert capsys.readouterr().out == ""
+
+
+def test_probe_reports_nested_stage_totals(monkeypatch, capsys):
+    monkeypatch.setenv("MLITE_WEIGHT_SYNC_PROBE", "1")
+
+    with weight_sync_probe_session("mlite"):
+        with get_weight_sync_probe().measure("fsdp_gather") as sample:
+            sample.nbytes = 32
+        with get_weight_sync_probe().measure("fsdp_gather") as sample:
+            sample.nbytes = 64
+
+    report = _report_from_stdout(capsys.readouterr().out)
+    assert report["backend"] == "mlite"
+    assert report["stages"]["fsdp_gather"]["calls"] == 2
+    assert report["stages"]["fsdp_gather"]["bytes"] == 96
+    assert report["stages"]["fsdp_gather"]["wall_s"] >= 0.0
+    assert report["total_wall_s"] >= report["stages"]["fsdp_gather"]["wall_s"]
+
+
+def test_cpu_staging_only_counts_device_to_host(monkeypatch, capsys):
+    monkeypatch.setenv("MLITE_WEIGHT_SYNC_PROBE", "true")
+    tensor = torch.arange(4, dtype=torch.float32)
+
+    with weight_sync_probe_session("mlite"):
+        result = hf_weights._to_cpu(tensor)
+
+    assert result is tensor
+    report = _report_from_stdout(capsys.readouterr().out)
+    assert "d2h" not in report["stages"]
+
+
+def test_mapping_counts_output_payload(monkeypatch, capsys):
+    monkeypatch.setenv("MLITE_WEIGHT_SYNC_PROBE", "1")
+    tensor = torch.ones(2, dtype=torch.bfloat16)
+
+    class Spec:
+        @staticmethod
+        def native_to_hf(name, value):
+            return [(f"hf.{name}", value), (f"hf.{name}.copy", value.clone())]
+
+    with weight_sync_probe_session("mlite"):
+        mapped = hf_weights._native_to_hf(Spec(), "weight", tensor)
+
+    assert [name for name, _ in mapped] == ["hf.weight", "hf.weight.copy"]
+    report = _report_from_stdout(capsys.readouterr().out)
+    assert report["stages"]["mapping"] == {
+        "calls": 1,
+        "bytes": 2 * tensor.nbytes,
+        "wall_s": report["stages"]["mapping"]["wall_s"],
+    }

--- a/experimental/lite/tests/unit/verl/test_mlite_engine_config.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_engine_config.py
@@ -138,6 +138,37 @@ def test_mlite_config_threads_rl_parallel_and_impl_settings() -> None:
     assert config.impl_cfg["deterministic"] is False
 
 
+def test_online_weight_export_requests_gpu_resident_bounded_streaming() -> None:
+    engine = _engine(engine_config=_engine_config(export_dtype="bfloat16"))
+    captured = {}
+
+    class Runtime:
+        @staticmethod
+        def export_weights(handle, **kwargs):
+            captured["handle"] = handle
+            captured["kwargs"] = kwargs
+            return iter(())
+
+    engine.runtime = Runtime()
+    engine.handle = object()
+    engine._initial_sync_cache_cleared = True
+
+    weights, metadata = engine.get_per_tensor_param(limit=3)
+
+    assert list(weights) == []
+    assert metadata is None
+    assert captured == {
+        "handle": engine.handle,
+        "kwargs": {
+            "buffer_max_size_bytes": 2 * 1024**3,
+            "cpu": False,
+            "export_dtype": "bfloat16",
+            "limit": 3,
+            "target": "vllm",
+        },
+    }
+
+
 def test_local_lr_scheduler_warmup_decay_and_state_roundtrip() -> None:
     optimizer = SimpleNamespace(param_groups=[{"lr": 0.0, "weight_decay": 0.1}])
     opt = SimpleNamespace(


### PR DESCRIPTION
  ## Summary

  Depends on #5694. This ports the GPU-resident bounded streaming weight-sync work from ISEEKYAN/Megatron-LM#85 onto the NVIDIA dev-based branch as one DCO-signed commit.

  - Gather DTensor shards through layout-aware, bounded flat buffers instead of per-parameter materialization.
  - Keep actor-to-vLLM payloads on GPU and stream expert weights through bounded EP buckets.
  - Prefetch two bounded transfer buckets while preserving the existing receiver protocol.
  - Chunk oversized FSDP shards along the shard dimension to preserve the memory bound.
  - Keep online exports device-resident by default while retaining CPU tensors for fallback HF saves.

  ## Performance

  The source PR measured Qwen3.5-35B-A3B `update_weights` on 8xH100 at 11.84s for FSDP2 and 12.05s for distributed optimizer, versus 84.88s before and 11.90s for the Megatron/mbridge reference. Those GPU
  measurements and the 55-test GPU validation are documented in ISEEKYAN/Megatron-LM#85 and were not rerun for this dev-base port.

  ## Validation

  - 34 focused CPU tests passed locally: 11 streaming/probe tests and 23 Qwen3.5 export tests.
  - One CUDA-only streaming test was skipped locally as expected.
  - The veRL engine-config test could not be collected in the local CPU environment because `tensordict` is not installed; this is reported as an environment gap, not a passing result.
  - The port is a single commit with matching Yan Bai author/committer identity and `Signed-off-by` trailer.