### PR TITLE
Add DeepSeek-V4 (DSA) bit-exact determinism proxy

### DIFF
--- a/tests/unit_tests/determinism/bit_exact_runner.py
+++ b/tests/unit_tests/determinism/bit_exact_runner.py
@@ -14,7 +14,8 @@ are bit-identical. It handles:
 
 * TP, PP, VPP, CP, EP via ``Utils.initialize_model_parallel``.
 * FSDP via ``fully_shard_model`` wrap.
-* MoE auto-enable when ``EP > 1`` (merges ``configs.moe_overrides(tp, ep)``).
+* MoE auto-enable when ``EP > 1`` (via ``configs.merge_moe_overrides``, which
+  keeps a model preset's own expert topology).
 * num_layers auto-bump when ``PP * VPP`` exceeds the preset's layer count.
 * sequence_parallel + tensor_model_parallel_size propagation when MoE+TP.
 * Pipeline schedule (``get_forward_backward_func``) when ``PP > 1``;
@@ -33,7 +34,7 @@ from megatron.core.pipeline_parallel import get_forward_backward_func
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from tests.unit_tests.determinism.configs import (
     apply_parallelism,
-    moe_overrides,
+    merge_moe_overrides,
     required_world_size,
 )
 from tests.unit_tests.determinism.utils import (
@@ -123,7 +124,11 @@ class BitExactRunner:
         if needs_moe:
             tp = init_kwargs.get("tensor_model_parallel_size", 1)
             ep = init_kwargs.get("expert_model_parallel_size", 1)
-            cfg_overrides = {**cfg_overrides, **moe_overrides(tp, ep)}
+            # merge_moe_overrides (not the raw moe_overrides) so a model preset
+            # that already defines its expert topology — like the DeepSeek base
+            # this test builds on — keeps its own num_moe_experts/routing instead
+            # of being overwritten by the generic four-expert defaults.
+            cfg_overrides = merge_moe_overrides(self.base_config(), cfg_overrides, tp, ep)
 
         Utils.destroy_model_parallel()
         Utils.initialize_model_parallel(**init_kwargs)

--- a/tests/unit_tests/determinism/configs.py
+++ b/tests/unit_tests/determinism/configs.py
@@ -72,8 +72,13 @@ def hybrid_base() -> dict:
     return dict(_BASE_HYBRID)
 
 
-def moe_overrides(tp: int = 1, ep: int = 1) -> dict:
-    """Return MoE overrides. When ``tp > 1`` we must also enable
+def moe_overrides(tp: int = 1, ep: int = 1, *, enable_moe: bool = True) -> dict:
+    """Return MoE defaults and parallelism propagation overrides.
+
+    ``enable_moe`` controls whether the generic four-expert topology is
+    included. Specialized model presets such as DeepSeek already define their
+    own topology, so their EP cells set it to ``False`` and receive only the
+    parallelism fields below. When ``tp > 1`` we must also enable
     ``sequence_parallel`` (MoE+TP without SP raises in moe_layer.py) and
     propagate ``tensor_model_parallel_size`` into the config (otherwise
     the SP validator sees TP=1 in the config and rejects SP=True). When
@@ -82,13 +87,95 @@ def moe_overrides(tp: int = 1, ep: int = 1) -> dict:
     ``ColumnParallelLinear``/``RowParallelLinear`` reads
     ``config.expert_model_parallel_size`` to decide whether expert weights
     use the expert tp_group or the dense tp_group."""
-    overrides = dict(_MOE_OVERRIDES)
+    overrides = dict(_MOE_OVERRIDES) if enable_moe else {}
     if tp > 1:
         overrides["sequence_parallel"] = True
         overrides["tensor_model_parallel_size"] = tp
     if ep > 1:
         overrides["expert_model_parallel_size"] = ep
     return overrides
+
+
+def merge_moe_overrides(
+    base_config: dict, config_overrides: dict, tp: int = 1, ep: int = 1
+) -> dict:
+    """Apply MoE parallelism fields without replacing model-defined topology."""
+    model_has_moe = (base_config | config_overrides).get("num_moe_experts") is not None
+    return {**config_overrides, **moe_overrides(tp, ep, enable_moe=not model_has_moe)}
+
+
+# DeepSeek-V3-style proxy base. Built on ``MLATransformerConfig`` by the test
+# factory so YaRN-RoPE / mscale defaults match the real model. Scaled to toy
+# sizes but keeps every determinism-relevant code path the real DSV3 recipe
+# exercises: Multi-Latent Attention (low-rank q/kv projections), sigmoid routing
+# + expert bias, group-limited (node-limited) top-k, seq-aux-loss balancing, and
+# grouped-GEMM experts. MoE is baked in (DSV3 is always MoE), so unlike the dense
+# GPT preset it does not rely on EP>1 to enable experts.
+#
+# MLA head dims intentionally exceed ``hidden_size`` (mirrors
+# tests/unit_tests/transformer/test_multi_latent_attention.py): MLA projects
+# through low-rank latents so the per-head dim is independent of hidden_size.
+def deepseek_base() -> dict:
+    return dict(
+        num_layers=2,
+        hidden_size=128,
+        ffn_hidden_size=256,
+        num_attention_heads=8,
+        # Multi-Latent Attention (proven dims from the MLA unit test).
+        multi_latent_attention=True,
+        q_lora_rank=32,
+        kv_lora_rank=32,
+        qk_head_dim=128,
+        qk_pos_emb_head_dim=64,
+        v_head_dim=128,
+        qk_layernorm=True,
+        rope_type="yarn",
+        rotary_base=10000,
+        original_max_position_embeddings=32,
+        normalization="RMSNorm",
+        gated_linear_unit=True,  # SwiGLU, as in DSV3.
+        # Fine-grained MoE with DSV3 group-limited routing.
+        num_moe_experts=8,
+        moe_router_topk=2,
+        moe_grouped_gemm=True,
+        moe_router_score_function="sigmoid",
+        moe_router_enable_expert_bias=True,
+        moe_router_load_balancing_type="seq_aux_loss",
+        moe_router_num_groups=2,
+        moe_router_group_topk=1,
+        moe_router_dtype="fp32",
+        add_bias_linear=False,
+        use_cpu_initialization=True,
+        bf16=True,
+        params_dtype=torch.bfloat16,
+        pipeline_dtype=torch.bfloat16,
+        sequence_parallel=False,
+        hidden_dropout=0.0,
+        attention_dropout=0.0,
+        deterministic_mode=True,
+    )
+
+
+# DeepSeek-V4-style proxy base: the DSV3 base plus DeepSeek Sparse Attention
+# (DSA — a lightning indexer scores tokens and top-k selection sparsifies core
+# attention). The indexer applies RoPE to a ``qk_pos_emb_head_dim``-wide slice of
+# each indexer head and leaves the remainder un-rotated, so
+# ``dsa_indexer_head_dim`` must exceed the MLA ``qk_pos_emb_head_dim`` (64 here);
+# 128 matches the functional DSA config (``gpt3_mcore_te_tp2_pp2_dsa``) and yields
+# a [64, 64] rope/nope split. topk 8 < seq_len 32 keeps the selection genuinely
+# sparse. A nonzero indexer-loss coefficient keeps the indexer KL loss — and its
+# tensor-parallel score reduction — on the training path. DSA validation rejects
+# context parallelism and requires ``apply_rope_fusion=False``.
+def deepseek_v4_base() -> dict:
+    return dict(
+        deepseek_base(),
+        experimental_attention_variant="dsa",
+        dsa_indexer_n_heads=4,
+        dsa_indexer_head_dim=128,
+        dsa_indexer_topk=8,
+        dsa_indexer_loss_coeff=0.01,
+        apply_rope_fusion=False,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -122,6 +209,13 @@ HYBRID_CONFIGS = [
     # dropped (Mamba path alone is already exercised here).
     pytest.param("M*-", {}, id="mamba-attn-mlp")
 ]
+
+
+# DeepSeek-V4 proxy presets. DSA + MLA + MoE config lives in
+# ``deepseek_v4_base()``; the single canonical cell keeps the matrix cheap while
+# the DSA-specific op paths are additionally covered per-op by
+# ``test_dsa_paths.py``.
+DEEPSEEK_V4_CONFIGS = [pytest.param({}, id="dsv4-like")]
 
 
 # ---------------------------------------------------------------------------
@@ -175,6 +269,30 @@ def parallelism_configs(*, exclude: tuple[str, ...] = ()) -> list:
     """
     excluded = set(exclude)
     return [p for p in PARALLELISM_CONFIGS if p.id not in excluded]
+
+
+# DeepSeek-V4 proxy parallelism matrix — expert-parallel focused.
+#
+# ``tp2-ep2`` is load-bearing: it is the first distributed bit-exact coverage of
+# the DSA indexer-loss tensor-parallel all-reduce (dsa.py attention-score
+# reduction); at TP=2 that reduction is one addition per element and therefore
+# topology-independent.
+#
+# Excluded, with reasons (not determinism failures):
+#   * CP — rejected by DSA config validation.
+#   * FSDP — the deterministic CLI rejects Megatron-FSDP; same-topology FSDP
+#     repeats add no cross-allocation evidence.
+#   * PP / VPP — DSA's indexer-loss logging tracker is not PP-safe on this
+#     revision: with PP>1 the per-stage tracker sizes are not negotiated across
+#     pipeline stages, so one stage issues a collective the other does not and
+#     the run hangs on NCCL P2P setup (non-DSA proxies pass PP in the same
+#     runner). Re-enable these cells once the PP-safe tracker lands.
+DEEPSEEK_V4_PARALLELISM_CONFIGS = [
+    pytest.param({"EP": 2}, id="ep2"),
+    pytest.param({"EP": 4}, id="ep4"),
+    pytest.param({"TP": 2, "EP": 2}, id="tp2-ep2"),
+    pytest.param({"TP": 2, "EP": 4}, id="tp2-ep4"),
+]
 
 
 _SHORTNAME_TO_INIT_KWARG = {

--- a/tests/unit_tests/determinism/correctness/test_deepseek_v4_model.py
+++ b/tests/unit_tests/determinism/correctness/test_deepseek_v4_model.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Model-level determinism check for a DeepSeek-V4-style model (DSA).
+
+DeepSeek-V4 extends the V3 architecture (MLA + fine-grained MoE) with DeepSeek
+Sparse Attention: a lightning indexer scores tokens and top-k selection
+sparsifies core attention. Op-level DSA determinism (the three unique-index
+``scatter_`` mask sites, the indexer-loss manual backward, and the unfused
+sparse attention) is covered by ``test_dsa_paths.py`` at TP=1; this file adds
+the missing **model-level** coverage — DSA inside a full ``GPTModel`` built
+through the same spec path production uses
+(``get_transformer_block_with_experimental_attention_variant_spec``), under
+expert/tensor/pipeline parallelism. The ``tp2-ep2`` cell is the first
+distributed bit-exact exercise of the DSA indexer-loss tensor-parallel
+all-reduce.
+
+Scope note: this branch carries DSA's pure-torch unfused path only. The dev
+branch's DSV4 additions (fused DSA kernels, CSA, hyper-connections) are not
+present here and are intentionally out of scope.
+
+Adding a new parallelism cell is a one-line append to
+``configs.DEEPSEEK_V4_PARALLELISM_CONFIGS``; this file does not change.
+"""
+
+import pytest
+import torch
+
+# The DSA indexer rotates activations with the fast_hadamard_transform CUDA
+# extension (asserted at import-use time in dsa.py). Skip cleanly where the
+# environment does not provide it — a determinism test must run the real
+# kernel, not a mock.
+pytest.importorskip("fast_hadamard_transform")
+
+from megatron.core.models.gpt.experimental_attention_variant_module_specs import (
+    get_transformer_block_with_experimental_attention_variant_spec,
+)
+from megatron.core.models.gpt.gpt_model import GPTModel
+from megatron.core.transformer.transformer_config import MLATransformerConfig
+from tests.unit_tests.determinism.bit_exact_runner import BitExactRunner
+from tests.unit_tests.determinism.configs import (
+    DEEPSEEK_V4_CONFIGS,
+    DEEPSEEK_V4_PARALLELISM_CONFIGS,
+    deepseek_v4_base,
+)
+
+SEQ_LEN = 32
+MICRO_BATCH = 4
+VOCAB_SIZE = 128
+
+
+def build_deepseek_v4(overrides, pre_process=True, post_process=True, vp_stage=None, **_):
+    """DeepSeek-V4-style GPTModel factory (MLA + MoE + DSA) matching the
+    runner's ``build_model`` contract. The block spec is produced by the same
+    dispatch production uses when ``experimental_attention_variant`` is set."""
+    cfg = MLATransformerConfig(**(deepseek_v4_base() | overrides))
+    block_spec = get_transformer_block_with_experimental_attention_variant_spec(
+        config=cfg, vp_stage=vp_stage
+    )
+    return GPTModel(
+        config=cfg,
+        transformer_layer_spec=block_spec,
+        vocab_size=VOCAB_SIZE,
+        max_sequence_length=SEQ_LEN,
+        pre_process=pre_process,
+        post_process=post_process,
+        vp_stage=vp_stage,
+        position_embedding_type="rope",
+    ).cuda()
+
+
+def make_deepseek_v4_inputs():
+    return {
+        "input_ids": torch.randint(
+            0, VOCAB_SIZE, (MICRO_BATCH, SEQ_LEN), device="cuda", dtype=torch.long
+        ),
+        "position_ids": torch.arange(SEQ_LEN, device="cuda", dtype=torch.long)
+        .unsqueeze(0)
+        .repeat(MICRO_BATCH, 1),
+        "attention_mask": torch.ones(
+            MICRO_BATCH, 1, SEQ_LEN, SEQ_LEN, dtype=torch.bool, device="cuda"
+        ),
+    }
+
+
+# supports_pp=False: DSA's indexer-loss logging tracker is not PP-safe on this
+# branch (PP>1 hangs on NCCL P2P setup because per-stage tracker sizes are not
+# negotiated across pipeline stages — a functional bug fixed on the dev branch,
+# not a determinism divergence). This makes any PP cell skip cleanly instead of
+# hanging. See docs/developer/determinism/dsv4-assessment.md.
+RUNNER = BitExactRunner(
+    build_model=build_deepseek_v4,
+    make_inputs=make_deepseek_v4_inputs,
+    base_config=deepseek_v4_base,
+    supports_pp=False,
+    seq_len=SEQ_LEN,
+    micro_batch=MICRO_BATCH,
+)
+
+
+class TestDeepSeekV4ModelDeterminism:
+
+    def setup_method(self, method):
+        RUNNER.setup()
+
+    def teardown_method(self, method):
+        RUNNER.teardown()
+
+    @pytest.mark.internal
+    @pytest.mark.parametrize("parallelism", DEEPSEEK_V4_PARALLELISM_CONFIGS)
+    @pytest.mark.parametrize("cfg_overrides", DEEPSEEK_V4_CONFIGS)
+    def test_bit_exact_under_parallelism(self, cfg_overrides, parallelism):
+        RUNNER.run(cfg_overrides, parallelism)


### PR DESCRIPTION
## What this PR does

Adds a model-level bit-exact **determinism** test for a DeepSeek-V4-style model.
DSV4 extends the V3 architecture (Multi-Latent Attention + fine-grained MoE) with
**DeepSeek Sparse Attention (DSA)**: a lightning indexer scores tokens and top-k
selection sparsifies core attention. `test_dsa_paths.py` covers the DSA ops at
TP=1; this adds the missing **model-level** coverage — a full `GPTModel` built
through the same `get_transformer_block_with_experimental_attention_variant_spec`
dispatch production uses, run twice under `BitExactRunner` and asserted
bit-identical.

Three files:
- **`configs.py`** — `deepseek_base` (MLA + fine-grained MoE with group-limited
  routing) and `deepseek_v4_base` (adds the DSA indexer), plus the DSV4 preset
  and parallelism matrix. `merge_moe_overrides` applies MoE parallelism fields
  without overwriting a preset's own expert topology.
- **`bit_exact_runner.py`** — use `merge_moe_overrides` for the EP-cell merge.
  Backward-compatible: the dense GPT/hybrid presets have no baked-in MoE, so they
  get the same generic defaults as before.
- **`test_deepseek_v4_model.py`** — the proxy.

## Validation

Bit-exact across `ep2` / `ep4` / `tp2-ep2` / `tp2-ep4` on 8×H100. The `tp2-ep2`
cell is the first distributed exercise of the DSA indexer-loss tensor-parallel
all-reduce.

## Notes for reviewers

- The test `importorskip`s `fast_hadamard_transform` (the DSA indexer's rotation
  kernel), so it **skips cleanly** where that extension is not in the image
  rather than failing. It is auto-discovered by the existing
  `determinism/correctness/**/*.py` unit-test glob.
- **Pipeline cells are excluded** on purpose: the current DSA indexer-loss
  logging tracker is not pipeline-safe (PP>1 hangs on NCCL P2P setup because
  per-stage tracker sizes are not negotiated). That is a functional limitation of
  DSA, not a determinism divergence; non-DSA proxies pass PP in the same runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)