### PR TITLE
fix(arguments): gate FSDP high-priority streams on Blackwell for both backends

### DIFF
--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1399,7 +1399,7 @@ def validate_args(args, defaults={}):
     # Setting FSDP communication groups for high priority streams for Blackwell and later architectures
     # Assigning high priority to communication streams ensures that communication kernels are scheduled
     # with higher priority, minimizing the exposed communication when it is overlapped with other computation kernels.
-    if args.use_torch_fsdp2 or args.use_megatron_fsdp and get_device_arch_version() >= 10:
+    if (args.use_torch_fsdp2 or args.use_megatron_fsdp) and get_device_arch_version() >= 10:
         if 'dp_cp' not in args.high_priority_stream_groups:
             args.high_priority_stream_groups.append('dp_cp')
         if args.expert_model_parallel_size  > 1 and 'ep_dp' not in args.high_priority_stream_groups:


### PR DESCRIPTION
### What

The FSDP high-priority stream setup in `validate_args` is documented as being **"for Blackwell and later architectures"**, but the condition drops the parentheses:

```python
if args.use_torch_fsdp2 or args.use_megatron_fsdp and get_device_arch_version() >= 10:
```

Since `and` binds tighter than `or`, this parses as `use_torch_fsdp2 or (use_megatron_fsdp and arch >= 10)`. The `arch >= 10` (Blackwell) gate therefore only applies to `--use-megatron-fsdp`. With `--use-torch-fsdp2`, the block runs on **every** architecture and appends `'dp_cp'` (and `'ep_dp'` under expert parallelism) to `high_priority_stream_groups` on pre-Blackwell GPUs (e.g. Hopper), where it isn't intended.

_No linked issue — found by reading the code._

### Fix

Parenthesize so the architecture gate applies to both FSDP backends:

```python
if (args.use_torch_fsdp2 or args.use_megatron_fsdp) and get_device_arch_version() >= 10:
```

This matches the comment and the adjacent architecture check in the same function, which already uses the parenthesized form:

```python
if (args.tensor_model_parallel_size > 1 or args.context_parallel_size > 1) \
    and get_device_arch_version() < 10:
```

### Behavior

Only the `--use-torch-fsdp2` + pre-Blackwell case changes (it no longer sets the Blackwell-only high-priority streams). Verified the precedence divergence standalone:

| use_torch_fsdp2 | use_megatron_fsdp | arch | before | after |
|---|---|---|---|---|
| True | False | 9 (pre-Blackwell) | enters ❌ | skips ✅ |
| True | True | 9 | enters ❌ | skips ✅ |
| False | True | 9 | skips | skips |
| any | any | ≥ 10 | enters | enters |

`validate_args` isn't cleanly unit-testable off-GPU (full training import chain), so the change is kept to the single-line precedence fix and the pre-existing formatting in the file is left untouched to keep the diff scoped. The intent is unambiguous from the "Blackwell and later" comment and the adjacent parenthesized check.
