### PR TITLE
ci: check megatron.inference imports

### DIFF
--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -83,6 +83,14 @@ jobs:
           package-name: megatron.training
           python-binary: ${{ env.UV_PROJECT_ENVIRONMENT }}/bin/python
 
+      - name: Check imports for megatron.inference
+        uses: ./FW-CI-templates/.github/actions/check-imports
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        with:
+          package-name: megatron.inference
+          python-binary: ${{ env.UV_PROJECT_ENVIRONMENT }}/bin/python
+
   uv-test-pytorch:
     needs: [pre-flight]
     if: |


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Adds the existing recursive import check for `megatron.inference` to the CPU installation workflow.

The top-level inference namespace is intentionally checked from the source tree, so this step exposes the checkout through `PYTHONPATH` without changing package discovery in `pyproject.toml`.

## Issue tracking

Fixes #5525

## Validation

- `BASE_REF=main CHECK_ONLY=true SKIP_DOCS=false bash tools/autoformat.sh`
- `actionlint` 1.7.7, allowing the repository's existing `linux-amd64-cpu16` custom runner label
- YAML parse and exact workflow contract assertion
- `NVIDIA-NeMo/FW-CI-templates` v0.63.2 `check_imports.py`: 2/2 `megatron.inference` modules imported in a Python 3.12 CPU-only environment (with an import-only Triton shim on macOS)
- `git diff --check`

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests — not applicable; this change adds a CI import check.
- [ ] I have added relevant functional tests — not applicable; no runtime behavior changes.
- [ ] I have added proper typing — not applicable; no Python code changes.
- [ ] I have added relevant documentation — not applicable; no user-facing behavior changes.
- [x] I have run `tools/autoformat.sh` on this PR.
