### PR TITLE
[core] Clarify GPT output_processor callback contract

### DIFF
--- a/megatron/core/models/common/model_chunk_schedule_plan.py
+++ b/megatron/core/models/common/model_chunk_schedule_plan.py
@@ -351,7 +351,7 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
         loss_mask: Optional[Tensor] = None,
         padding_mask=None,
         *,
-        output_processor: Optional[Callable[..., Tensor]] = None,
+        output_processor: Optional[Callable[..., Any]] = None,
         output_processor_context: Optional[Any] = None,
     ):
         """Initialize the schedule plan of all Transformer layers' sub-modules.

--- a/megatron/core/models/gpt/gpt_model.py
+++ b/megatron/core/models/gpt/gpt_model.py
@@ -531,9 +531,9 @@ class GPTModel(LanguageModule):
         inference_params: Optional[BaseInferenceContext] = None,
         loss_mask: Optional[Tensor] = None,
         padding_mask: Optional[Tensor] = None,
-        output_processor: Optional[Callable[..., Tensor]] = None,
+        output_processor: Optional[Callable[..., Any]] = None,
         output_processor_context: Optional[Any] = None,
-    ) -> Tensor:
+    ) -> Any:
         """Forward function of the GPT Model This function passes the input tensors
         through the embedding layer, and then the decoder and finally into the post
         processing layer (optional).
@@ -810,7 +810,7 @@ class GPTModel(LanguageModule):
         loss_mask: Optional[Tensor] = None,
         padding_mask: Optional[Tensor] = None,
         *,
-        output_processor: Optional[Callable[..., Tensor]] = None,
+        output_processor: Optional[Callable[..., Any]] = None,
         output_processor_context: Optional[Any] = None,
     ):
         """Builds a computation schedule plan for the model.

--- a/tests/unit_tests/models/test_gpt_model.py
+++ b/tests/unit_tests/models/test_gpt_model.py
@@ -144,6 +144,7 @@ class TestGPTModel:
         ).cuda()
 
         context = {"selected_token_positions": torch.tensor([0, 2], device="cuda")}
+        created = {}
         seen = {}
 
         def output_processor(**kwargs):
@@ -158,7 +159,14 @@ class TestGPTModel:
                 dim=-1, index=kwargs["labels"].unsqueeze(-1)
             )
             token_logprobs = token_logprobs.squeeze(-1)
-            return token_logprobs.index_select(1, kwargs["context"]["selected_token_positions"])
+            result = {
+                "payload": token_logprobs.index_select(
+                    1, kwargs["context"]["selected_token_positions"]
+                ),
+                "tag": "structured",
+            }
+            created["result"] = result
+            return result
 
         with torch.no_grad():
             logits = self.gpt_model.forward(
@@ -176,10 +184,14 @@ class TestGPTModel:
                 output_processor_context=context,
             )
 
-        assert torch.allclose(output, expected)
+        assert output is created["result"]
+        assert isinstance(output, dict)
+        assert torch.allclose(output["payload"], expected)
+        assert output["tag"] == "structured"
         assert seen["context"] is context
         assert seen["output_layer"] is self.gpt_model.output_layer
         assert seen["output_weight"] is None
+        assert seen["output_layer"].weight is not None
         assert seen["labels"] is labels
         assert seen["runtime_gather_output"] is None
         assert seen["config"] is config


### PR DESCRIPTION
## What does this PR do?

This PR clarifies the return contract of `GPTModel`'s optional `output_processor` callback.

Specifically, it:

- generalizes the callback return annotation from `Tensor` to `Any`;
- documents that, for direct `GPTModel.forward()` calls, the processor result becomes the forward result;
- adds direct-forward unit coverage for a structured, non-Tensor callback result.

## Motivation

The runtime hook already returns the processor result directly, but its existing `Callable[..., Tensor]` annotation is narrower than the actual behavior.

Downstream validation exposed this mismatch using a structured model output. This PR keeps the contract objective-neutral and does not introduce framework- or RL-specific output types.

## Scope

This is a typing, documentation, and unit-test change. It does not change:

- `_postprocess()` runtime behavior;
- the default logits or loss path;
- MTP behavior;
- 1F1B scheduling;
- schedule-plan output conversion;
- `float16_to_fp32()` behavior.

## Testing

Focused callback and schedule-plan tests:

```text
CUDA_VISIBLE_DEVICES=0 pytest -q tests/unit_tests/models/test_gpt_model.py \
  -k "output_processor or schedule_plan"

2 passed, 14 deselected
```

Full test file:

```text
CUDA_VISIBLE_DEVICES=0 pytest -q tests/unit_tests/models/test_gpt_model.py

13 passed, 1 skipped, 2 failed
```

This matches the clean `main` baseline exactly. The same two custom-process-group tests fail on `main`: both construct an 8-rank `HyperCommGrid` under a local `world_size=1` run, so no PR-introduced regression was found.

Additional checks completed successfully:

- `python3 -m py_compile`
- `git diff --check`
- `isort --check-only`
- `ruff check --no-fix`

The repository-pinned pre-commit and Black toolchain was not available locally, so the official project CI remains required for those checks.

Related to #4590.

Follow-up to #4686.