### PR TITLE
[Fix] Fix offline dataset cache preparation for phase-specific runs.

### DIFF
--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -54,6 +54,61 @@ from megatron.training.utils import (
 )
 
 
+_ARGPARSE_HELP_FORMAT_RE = re.compile(
+    r"%\((?P<name>[^)]+)\)([#0 +\-]?\d*(?:\.\d+)?[hlL]?[diouxXeEfFgGcrs])"
+)
+
+
+def _escape_literal_help_percent_characters(help_string, params):
+    """Escape literal percent characters while preserving argparse substitutions."""
+
+    pieces = []
+    index = 0
+    while index < len(help_string):
+        if help_string[index] != "%":
+            pieces.append(help_string[index])
+            index += 1
+            continue
+
+        if index + 1 < len(help_string) and help_string[index + 1] == "%":
+            pieces.append("%%")
+            index += 2
+            continue
+
+        match = _ARGPARSE_HELP_FORMAT_RE.match(help_string, index)
+        if match is not None and match.group("name") in params:
+            pieces.append(match.group(0))
+            index = match.end()
+            continue
+
+        pieces.append("%%")
+        index += 1
+
+    return "".join(pieces)
+
+
+class _MegatronHelpFormatter(argparse.HelpFormatter):
+    """Help formatter that treats bare percent characters as literals."""
+
+    def _expand_help(self, action):
+        help_string = self._get_help_string(action)
+        if "%" not in help_string:
+            return help_string
+
+        params = dict(vars(action), prog=self._prog)
+        for name in list(params):
+            value = params[name]
+            if value is argparse.SUPPRESS:
+                del params[name]
+            elif hasattr(value, "__name__"):
+                params[name] = value.__name__
+        if params.get("choices") is not None:
+            params["choices"] = ", ".join(map(str, params["choices"]))
+
+        help_string = _escape_literal_help_percent_characters(help_string, params)
+        return help_string % params
+
+
 def add_megatron_arguments(parser: argparse.ArgumentParser):
     """ "Add Megatron-LM arguments to the given parser."""
 
@@ -131,7 +186,11 @@ def parse_and_validate_args(extra_args_provider=None, ignore_unknown_args=False,
 
 def parse_args(extra_args_provider=None, ignore_unknown_args=False):
     """Parse all arguments."""
-    parser = argparse.ArgumentParser(description='Megatron-LM Arguments', allow_abbrev=False)
+    parser = argparse.ArgumentParser(
+        description='Megatron-LM Arguments',
+        allow_abbrev=False,
+        formatter_class=_MegatronHelpFormatter,
+    )
 
     parser = add_megatron_arguments(parser)
 

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -4803,7 +4803,7 @@ def get_train_valid_test_num_samples():
         phase_transition_samples = (
             [0]
             + [t * args.global_batch_size for t in args.phase_transition_iterations]
-            + [args.train_samples]
+            + [train_samples]
         )
         current_sample = args.iteration * args.global_batch_size
         last_transition_sample = max(s for s in phase_transition_samples if s <= current_sample)

--- a/tests/unit_tests/data/test_prepare_cache.py
+++ b/tests/unit_tests/data/test_prepare_cache.py
@@ -16,6 +16,7 @@ from megatron.core.tokenizers.utils.build_tokenizer import build_tokenizer
 from tests.unit_tests.dist_checkpointing import TempNamedDir
 from tests.unit_tests.test_utilities import Utils
 from tools.prepare_cache import (
+    _get_prepare_cache_num_samples,
     _normalize_prepare_cache_args,
     build_dataset_caches,
     core_gpt_dataset_config_from_args,
@@ -160,12 +161,136 @@ def test_prepare_cache_builds_blended_dataset_cache(tmp_path_dist_ckpt):
 
 
 def test_prepare_cache_world_size_override():
-    args = Namespace(rank=11, world_size=1, prepare_cache_world_size=8)
+    args = Namespace(
+        rank=11,
+        iteration=0,
+        world_size=1,
+        prepare_cache_world_size=8,
+        prepare_cache_start_iteration=None,
+        seq_length=4096,
+        encoder_seq_length=None,
+        micro_batch_size=None,
+        num_layers=None,
+        encoder_num_layers=None,
+        hidden_size=None,
+        num_attention_heads=None,
+        max_position_embeddings=None,
+    )
 
     _normalize_prepare_cache_args(args)
 
     assert args.rank == 0
     assert args.world_size == 8
+
+
+def test_prepare_cache_normalization_adds_training_validation_defaults():
+    args = Namespace(
+        rank=11,
+        iteration=0,
+        world_size=1,
+        prepare_cache_world_size=None,
+        prepare_cache_start_iteration=None,
+        seq_length=4096,
+        encoder_seq_length=None,
+        micro_batch_size=None,
+        num_layers=None,
+        encoder_num_layers=None,
+        hidden_size=None,
+        num_attention_heads=None,
+        max_position_embeddings=None,
+    )
+
+    _normalize_prepare_cache_args(args)
+
+    assert args.rank == 0
+    assert args.micro_batch_size == 1
+    assert args.num_layers == 1
+    assert args.hidden_size == 1
+    assert args.num_attention_heads == 1
+    assert args.max_position_embeddings == 4096
+
+
+def test_prepare_cache_normalization_requires_sequence_length():
+    args = Namespace(
+        rank=11,
+        iteration=0,
+        world_size=1,
+        prepare_cache_world_size=None,
+        prepare_cache_start_iteration=None,
+        seq_length=None,
+        encoder_seq_length=None,
+    )
+
+    with pytest.raises(ValueError, match="--seq-length"):
+        _normalize_prepare_cache_args(args)
+
+
+def test_prepare_cache_normalization_applies_start_iteration():
+    args = Namespace(
+        rank=11,
+        iteration=0,
+        world_size=1,
+        prepare_cache_world_size=None,
+        prepare_cache_start_iteration=74508,
+        seq_length=4096,
+        encoder_seq_length=None,
+        micro_batch_size=None,
+        num_layers=None,
+        encoder_num_layers=None,
+        hidden_size=None,
+        num_attention_heads=None,
+        max_position_embeddings=None,
+    )
+
+    _normalize_prepare_cache_args(args)
+
+    assert args.iteration == 74508
+
+
+def test_prepare_cache_normalization_rejects_negative_start_iteration():
+    args = Namespace(
+        rank=11,
+        iteration=0,
+        world_size=1,
+        prepare_cache_world_size=None,
+        prepare_cache_start_iteration=-1,
+        seq_length=4096,
+        encoder_seq_length=None,
+    )
+
+    with pytest.raises(ValueError, match="--prepare-cache-start-iteration"):
+        _normalize_prepare_cache_args(args)
+
+
+def test_prepare_cache_num_samples_allows_missing_eval_interval_with_no_eval(tmp_path):
+    args = _build_prepare_cache_args(
+        [], tmp_path / "cache", train_iters=4, eval_iters=0, eval_interval=None
+    )
+
+    assert _get_prepare_cache_num_samples(args) == (32, 0, 0)
+
+
+def test_prepare_cache_num_samples_preserves_eval_interval_formula(tmp_path):
+    args = _build_prepare_cache_args(
+        [], tmp_path / "cache", train_iters=4, eval_iters=2, eval_interval=2
+    )
+
+    assert _get_prepare_cache_num_samples(args) == (32, 48, 16)
+
+
+def test_prepare_cache_num_samples_uses_current_phase(tmp_path):
+    args = _build_prepare_cache_args(
+        [],
+        tmp_path / "cache",
+        train_iters=10,
+        global_batch_size=2,
+        eval_iters=0,
+        eval_interval=None,
+        phase_transition_iterations=[4],
+        iteration=4,
+    )
+
+    assert _get_prepare_cache_num_samples(args) == (12, 0, 0)
 
 
 def test_prepare_cache_builds_and_hits_per_split_dataset_cache(tmp_path_dist_ckpt):

--- a/tests/unit_tests/test_arguments_help_formatter.py
+++ b/tests/unit_tests/test_arguments_help_formatter.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import argparse
+
+from megatron.training.arguments import _MegatronHelpFormatter
+
+
+def test_megatron_help_formatter_allows_literal_percent_characters():
+    parser = argparse.ArgumentParser(formatter_class=_MegatronHelpFormatter)
+    parser.add_argument(
+        "--cache-ratio",
+        default="1.0",
+        help="Prepare 5% training cache shards; default %(default)s; escaped 10%%.",
+    )
+
+    help_text = parser.format_help()
+
+    assert "Prepare 5% training cache shards" in help_text
+    assert "default 1.0" in help_text
+    assert "escaped 10%." in help_text

--- a/tests/unit_tests/test_arguments_help_formatter.py
+++ b/tests/unit_tests/test_arguments_help_formatter.py
@@ -13,7 +13,7 @@ def test_megatron_help_formatter_allows_literal_percent_characters():
         help="Prepare 5% training cache shards; default %(default)s; escaped 10%%.",
     )
 
-    help_text = parser.format_help()
+    help_text = " ".join(parser.format_help().split())
 
     assert "Prepare 5% training cache shards" in help_text
     assert "default 1.0" in help_text

--- a/tests/unit_tests/test_eval_batch_size.py
+++ b/tests/unit_tests/test_eval_batch_size.py
@@ -199,6 +199,22 @@ class TestGetTrainValidTestNumSamples:
         # train_samples = 100 * 32 = 3200
         assert train_samples == 3200
 
+    def test_num_samples_iteration_based_phase_uses_train_iters_total(self):
+        """Iteration-based phase boundaries should use train_iters-derived total samples."""
+        args = create_test_args(
+            iteration=100,
+            train_samples=None,
+            train_iters=10000,
+            global_batch_size=512,
+            eval_global_batch_size=512,
+            phase_transition_iterations=[100],
+        )
+        set_args(args)
+
+        train_samples, _, _ = get_train_valid_test_num_samples()
+
+        assert train_samples == (10000 - 100) * 512
+
     def test_num_samples_with_skip_train(self):
         """With skip_train, eval_iters used directly (no multiplier from train_iters/eval_interval)."""
         args = create_test_args(

--- a/tools/prepare_cache.py
+++ b/tools/prepare_cache.py
@@ -8,13 +8,16 @@ Unsupported configurations:
 
 import argparse
 import json
+import sys
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from megatron.core.datasets.blended_megatron_dataset_builder import BlendedMegatronDatasetBuilder
 from megatron.core.datasets.gpt_dataset import GPTDataset, GPTDatasetConfig
 from megatron.core.datasets.utils import compile_helpers
 from megatron.core.tokenizers.utils.build_tokenizer import build_tokenizer
-from megatron.training import get_train_valid_test_num_samples
 from megatron.training.arguments import parse_args, validate_args
 from megatron.training.global_vars import set_args, unset_global_variables
 from megatron.training.training import update_train_iters
@@ -41,6 +44,15 @@ def add_prepare_cache_args(parser: argparse.ArgumentParser) -> argparse.Argument
             "dataset sample counts during cache preparation."
         ),
     )
+    group.add_argument(
+        "--prepare-cache-start-iteration",
+        type=int,
+        default=None,
+        help=(
+            "Optional current training iteration used to select the phase when "
+            "--phase-transition-iterations is set."
+        ),
+    )
     return parser
 
 
@@ -55,11 +67,34 @@ def _normalize_prepare_cache_args(args: Any) -> None:
     """Apply cache-preparation specific argument normalization."""
 
     args.rank = 0
+    args.iteration = getattr(args, "iteration", 0)
+
+    if args.seq_length is None and getattr(args, "encoder_seq_length", None) is None:
+        raise ValueError("--seq-length must be provided for cache preparation")
 
     if args.prepare_cache_world_size is not None:
         if args.prepare_cache_world_size <= 0:
             raise ValueError("--prepare-cache-world-size must be positive")
         args.world_size = args.prepare_cache_world_size
+
+    prepare_cache_start_iteration = getattr(args, "prepare_cache_start_iteration", None)
+    if prepare_cache_start_iteration is not None:
+        if prepare_cache_start_iteration < 0:
+            raise ValueError("--prepare-cache-start-iteration must be non-negative")
+        args.iteration = prepare_cache_start_iteration
+
+    # Offline cache construction does not use model execution parameters, but the shared
+    # training argument validator requires them. Fill minimal values when omitted.
+    if args.micro_batch_size is None:
+        args.micro_batch_size = 1
+    if args.num_layers is None and args.encoder_num_layers is None:
+        args.num_layers = 1
+    if args.hidden_size is None:
+        args.hidden_size = 1
+    if args.num_attention_heads is None:
+        args.num_attention_heads = 1
+    if args.max_position_embeddings is None:
+        args.max_position_embeddings = args.seq_length or args.encoder_seq_length
 
 
 def _validate_prepare_cache_args(args: Any) -> None:
@@ -87,6 +122,59 @@ def _disable_cache_load_only_flags(args: Any) -> Dict[str, bool]:
     args.dataloader_fast_cache_load = False
     args.dataloader_defer_npy_index_mmap = False
     return ignored
+
+
+def _get_prepare_cache_num_samples(args: Any) -> Tuple[Any, Any, Any]:
+    """Return train/validation/test sample targets for offline cache construction."""
+
+    if args.train_samples:
+        train_samples = args.train_samples
+    else:
+        train_samples = args.train_iters * args.global_batch_size
+
+    eval_global_batch_size = getattr(args, "eval_global_batch_size", args.global_batch_size)
+    eval_iters = args.eval_iters or 0
+
+    if args.full_validation:
+        eval_samples = None
+    else:
+        if args.skip_train:
+            validation_eval_iters = eval_iters
+        elif args.eval_interval is None or eval_iters == 0:
+            validation_eval_iters = 0
+        else:
+            assert args.train_iters is not None
+            total_eval_points = args.train_iters // args.eval_interval + 1
+            if args.start_eval_at_iter is not None:
+                skipped_eval_points = args.start_eval_at_iter // args.eval_interval
+                total_eval_points = max(0, total_eval_points - skipped_eval_points)
+            validation_eval_iters = total_eval_points * eval_iters
+        eval_samples = validation_eval_iters * eval_global_batch_size
+
+    test_samples = eval_iters * eval_global_batch_size
+
+    if args.phase_transition_iterations:
+        total_train_samples = (
+            args.train_samples if args.train_samples is not None else train_samples
+        )
+        phase_transition_samples = [
+            0,
+            *[
+                iteration * args.global_batch_size
+                for iteration in args.phase_transition_iterations
+            ],
+            total_train_samples,
+        ]
+        current_sample = args.iteration * args.global_batch_size
+        last_transition_sample = max(
+            sample for sample in phase_transition_samples if sample <= current_sample
+        )
+        next_transition_sample = min(
+            sample for sample in phase_transition_samples if sample > current_sample
+        )
+        train_samples = next_transition_sample - last_transition_sample
+
+    return train_samples, eval_samples, test_samples
 
 
 def _get_dataset_length(dataset: Optional[Any]) -> Optional[Any]:
@@ -169,7 +257,7 @@ def build_dataset_caches(args: Any) -> Dict[str, Any]:
     try:
         # Derive train_iters from --train-samples when needed (pretrain() does the same).
         update_train_iters(args)
-        train_valid_test_num_samples = get_train_valid_test_num_samples()
+        train_valid_test_num_samples = _get_prepare_cache_num_samples(args)
         _print_effective_configuration(args, train_valid_test_num_samples, ignored_flags)
 
         compile_helpers()


### PR DESCRIPTION
## Summary

This PR fixes several issues in `tools/prepare_cache.py` that prevented offline dataset cache generation from working for large phased training runs.

The changes allow cache preparation to run without full model-training arguments, handle `eval_iters=0` without requiring an eval interval, and add support for generating cache only for the current phase via `--prepare-cache-start-iteration`.

## Motivation

`tools/prepare_cache.py` previously reused parts of the training argument and sample-count logic that assume a real training launch. This caused failures during offline cache preparation, including:

- argparse help formatting failures when help strings contain literal `%`
- `validate_args()` assertions for model execution arguments such as `micro_batch_size`
- sample-count calculation failures when `eval_interval` is unset and `eval_iters=0`
- inability to generate cache for a later phase such as `[xxx, xxxx)`

## Changes

- Add a Megatron argparse help formatter that preserves argparse substitutions such as `%(default)s` while escaping literal `%` characters.
- Normalize prepare-cache arguments before validation:
  - require `--seq-length` or encoder sequence length
  - apply `--prepare-cache-world-size`
  - set `iteration=0` by default
  - fill minimal validation-only defaults for model arguments that are unused by offline cache construction
- Add `--prepare-cache-start-iteration` to select the active phase when `--phase-transition-iterations` is provided.
- Replace the training sample-count helper with a prepare-cache-specific implementation that:
  - supports `eval_iters=0`
  - supports missing `eval_interval` when no eval samples are needed
  - computes phase-local train samples based on the current iteration
- Add unit coverage for prepare-cache normalization, sample-count behavior, phase selection, and literal `%` help formatting.

## Example

For generating cache for phase `[xxx, xxxx)`:

```bash
python tools/prepare_cache.py \
  --data-args-path xxxx.txt \
  --split xx,x,x \
  --data-cache-path xxxx \
  --global-batch-size xxxx \
  --train-iters xxxx \
  --phase-transition-iterations "xxxx" \
  --prepare-cache-start-iteration xxxx \
  --eval-iters 0 \
  --eval-interval 1 \
  --seq-length 4096 \
  --tokenizer-type HuggingFaceTokenizer \
  --tokenizer-model xxxx \
  --prepare-cache-world-size xxxx