### PR TITLE
Route Lion through DistributedOptimizer and support single-moment checkpointing

### DIFF
--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -798,7 +798,15 @@ def _get_megatron_emerging_optimizer(
                     )
 
     # Apply optimizer-specific default param overrides (e.g. muon: non-linear -> adam).
-    config_overrides.update(_EMERGING_OPTIMIZERS[eopt_name].default_param_overrides)
+    # For Muon-family optimizers, the scalar optimizer that handles non-linear/embedding
+    # params is configurable via ``config.muon_scalar_optimizer`` (e.g., 'adam' or 'lion');
+    # deep-copy the registry defaults before rewriting so we never mutate shared state.
+    default_param_overrides = copy.deepcopy(_EMERGING_OPTIMIZERS[eopt_name].default_param_overrides)
+    if eopt_name in ('muon', 'adaptive_muon'):
+        for override in default_param_overrides.values():
+            if override.get('optimizer') in ('adam', 'lion'):
+                override['optimizer'] = config.muon_scalar_optimizer
+    config_overrides.update(default_param_overrides)
 
     # Build param groups and bucket by (optimizer_name, is_expert_parallel).
     # Layer-wise distributed optimizer handles expert params internally so we skip that split.
@@ -831,7 +839,10 @@ def _get_megatron_emerging_optimizer(
             "fall back to the legacy LayerWise ping-pong path."
         )
     if use_separate_distributed_optimizer and any(
-        opt_name not in _EMERGING_OPTIMIZERS
+        # A separate DistributedOptimizer with byte-level sharding handles any group
+        # whose optimizer is not the primary emerging optimizer (stored in ``eopt_name``,
+        # e.g., Muon). This includes scalar optimizers like Adam or Lion.
+        not (opt_name == eopt_name and opt_name in _EMERGING_OPTIMIZERS)
         for (opt_name, _), groups in grouped_param_groups.items()
         if groups
     ):
@@ -870,7 +881,10 @@ def _get_megatron_emerging_optimizer(
 
         model_parallel_group = pg_collection.tp_ep_pp if is_expert else pg_collection.mp
 
-        if opt_name in _EMERGING_OPTIMIZERS:
+        # Only the primary emerging optimizer (stored in ``eopt_name``, e.g., Muon) is
+        # constructed via ``_create_emerging_optimizer``. Scalar optimizers that also appear
+        # in ``_EMERGING_OPTIMIZERS`` (e.g., Lion) fall through to the standard fallback path.
+        if opt_name == eopt_name and opt_name in _EMERGING_OPTIMIZERS:
             optimizer, init_state_fn = _create_emerging_optimizer(
                 config, groups, eopt_name, model_chunks, pg_collection
             )
@@ -895,7 +909,7 @@ def _get_megatron_emerging_optimizer(
             fallback_config = copy.copy(config)
             fallback_config.optimizer = opt_name
             if use_separate_distributed_optimizer:
-                # Route non-emerging params through a real DistributedOptimizer
+                # Route non-emerging params (adam/lion) through a real DistributedOptimizer
                 # (byte-level sharding) instead of stuffing them inside LayerWise.
                 for group in groups:
                     assert not group['is_expert_parallel'], (

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -666,9 +666,10 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         assert (
             isinstance(optimizer, (Adam, torch.optim.AdamW, HybridDeviceOptimizer))
             or optimizer is None
+            or init_state_fn is not None
         ), (
-            "Only Adam and HybridDeviceOptimizer currently supported, "
-            "due to checkpointing requirements."
+            "Only Adam, HybridDeviceOptimizer, and optimizers with an init_state_fn "
+            "(e.g., Lion) are currently supported, due to checkpointing requirements."
         )
 
         # when freezing sub-models we have no real optimizer
@@ -777,6 +778,27 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         with the non-distributed optimizer).
         """
         return getattr(self, 'grad_stats_parallel_group', None)
+
+    @property
+    def optimizer_state_keys(self):
+        """Return the optimizer's tensor state keys, e.g., ('exp_avg', 'exp_avg_sq') for Adam
+        or ('exp_avg',) for Lion."""
+        _OPTIMIZER_STATE_KEYS = {"lion": ("exp_avg",)}
+        optimizer_name = self.config.optimizer
+        # When Muon is the top-level optimizer, the DistributedOptimizer wrapping
+        # scalar parameters uses muon_scalar_optimizer (e.g., Lion) as the actual
+        # optimizer, so look up state keys by that name instead.
+        if optimizer_name == "muon":
+            optimizer_name = self.config.muon_scalar_optimizer
+        return _OPTIMIZER_STATE_KEYS.get(optimizer_name, ("exp_avg", "exp_avg_sq"))
+
+    def _get_state_key_dtype(self, key):
+        """Return the dtype for a given optimizer state key."""
+        dtype_map = {
+            "exp_avg": self.config.exp_avg_dtype,
+            "exp_avg_sq": self.config.exp_avg_sq_dtype,
+        }
+        return dtype_map.get(key, torch.float32)
 
     def state_dict(self):
         """
@@ -957,8 +979,8 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                             # For precision_aware_optimizer, the empty tensors should also be
                             #  initialized with the correct dtype.
                             tensors = {
-                                "exp_avg": init_shard(self.config.exp_avg_dtype),
-                                "exp_avg_sq": init_shard(self.config.exp_avg_sq_dtype),
+                                key: init_shard(self._get_state_key_dtype(key))
+                                for key in self.optimizer_state_keys
                             }
                             if self.config.use_precision_aware_optimizer_no_fp8_or_ds_fp8:
                                 if self.config.store_param_remainders and self.config.bf16:
@@ -1047,12 +1069,8 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         """Return a dict containing the main param and optimizer states corresponding to the input
         model_param.
 
-        The structure of the returned dict:
-        tensors = {
-            "param": torch.Tensor
-            "exp_avg": torch.Tensor
-            "exp_avg_sq": torch.Tensor
-        }
+        The returned dict always contains "param" and one entry per optimizer state tensor
+        (e.g., "exp_avg" and "exp_avg_sq" for Adam, or just "exp_avg" for Lion).
         """
         group_index, group_order = self.model_param_group_index_map[model_param]
         if self.config.use_precision_aware_optimizer_no_fp8_or_ds_fp8:
@@ -1143,12 +1161,8 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
     def _set_main_param_and_optimizer_states(self, model_param, tensors):
         """Set the main param and optimizer states corresponding to the input model_param.
 
-        The structure of the input `tensors`:
-        tensors = {
-            "param": torch.Tensor
-            "exp_avg": torch.Tensor
-            "exp_avg_sq": torch.Tensor
-        }
+        The input `tensors` dict contains "param" and one entry per optimizer state tensor
+        (e.g., "exp_avg" and "exp_avg_sq" for Adam, or just "exp_avg" for Lion).
         """
         group_index, group_order = self.model_param_group_index_map[model_param]
         if self.config.use_precision_aware_optimizer_no_fp8_or_ds_fp8:
@@ -1271,7 +1285,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                         key: torch.zeros(
                             (buffer_numel_unpadded,), dtype=torch.float32, device="cpu"
                         )
-                        for key in ("param", "exp_avg", "exp_avg_sq")
+                        for key in ("param",) + self.optimizer_state_keys
                     }
                     world_tensors["numel_unpadded"] = buffer_numel_unpadded
 
@@ -1293,7 +1307,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
 
                         local_shards = {
                             key: torch.zeros((gbuf_local_numel,), dtype=torch.float32, device="cpu")
-                            for key in ("param", "exp_avg", "exp_avg_sq")
+                            for key in ("param",) + self.optimizer_state_keys
                         }
 
                         # Build contiguous DP rank shards (for param + optim states).
@@ -1652,8 +1666,8 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         `fully_reshardable` format involves gathering the tensors on DP rank 0 during save.
         Flat DistOpt buffers are unflattened and reshaped into model param like sizes.
         This results in a state dict similar to a regular optimizer one, where each
-        param of shape (X, Y, Z) has corresponding 'param', 'exp_avg' and 'exp_avg_sq'
-        tensors of shape (X, Y, Z) in the optimizer state dict.
+        param of shape (X, Y, Z) has corresponding 'param' and optimizer state
+        tensors (e.g., 'exp_avg', 'exp_avg_sq') of shape (X, Y, Z) in the optimizer state dict.
 
         During loading there is no data exchange - each rank requests to load the whole
         state dict (and flattens and trims the tensors afterwards). It is recommended
@@ -2125,7 +2139,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                         t.numel() for t in state_dict[gbuf_idx][torch.float32]["param"]
                     ]
                     assert sum(model_numels) == sum(checkpoint_numels)
-                for key in ("param", "exp_avg", "exp_avg_sq"):
+                for key in ("param",) + self.optimizer_state_keys:
                     legacy_world_tensors = self._update_legacy_world_tensors(
                         state_dict[gbuf_idx][torch.float32][key],
                         [
@@ -2246,7 +2260,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                         f"({buffer_numel_unpadded}) and checkpoint ({checkpoint_numel_unpadded})"
                     )
                 recv_tensors = {}
-                for key in ("param", "exp_avg", "exp_avg_sq"):
+                for key in ("param",) + self.optimizer_state_keys:
                     offset_in_world_tensors = 0
                     for bucket_idx, gbuf_range_map in enumerate(gbuf_range_map_for_all_buckets):
                         # Compute local DP contiguous shard's size.
@@ -2459,7 +2473,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
 
             # Split the target buffer into two separate buffers.
             fp8_state_dict, non_fp8_state_dict = {}, {}
-            for key in ['param', 'exp_avg', 'exp_avg_sq']:
+            for key in ('param',) + self.optimizer_state_keys:
                 tensor = state_dict[non_fp8_gbuf_idx][non_fp8_param_and_grad_dtype][key]
                 fp8_tensor = torch.empty([fp8_offsets[-1]], dtype=tensor.dtype)
                 non_fp8_tensor = torch.empty([non_fp8_offsets[-1]], dtype=tensor.dtype)

--- a/tests/unit_tests/dist_checkpointing/test_optimizer.py
+++ b/tests/unit_tests/dist_checkpointing/test_optimizer.py
@@ -24,7 +24,8 @@ from megatron.core.models.gpt.gpt_layer_specs import (
     get_gpt_layer_with_transformer_engine_spec as gpt_te_spec,
 )
 from megatron.core.models.gpt.gpt_model import GPTModel
-from megatron.core.optimizer import ChainedOptimizer
+from megatron.core.optimizer import HAVE_EMERGING_OPTIMIZERS, ChainedOptimizer
+from megatron.core.optimizer.distrib_optimizer import DistributedOptimizer
 from megatron.core.tensor_parallel import model_parallel_cuda_manual_seed
 from megatron.core.transformer import MLATransformerConfig, TransformerConfig
 from megatron.core.transformer.mlp import apply_swiglu_sharded_factory
@@ -874,6 +875,99 @@ class TestDistributedOptimizer:
         same_groups = set(g for g in same_groups if g is not None)
         # Check each dst group has at least 1 rank both in src and dest
         assert same_groups == set(range(num_dest_dp_groups))
+
+    @pytest.mark.skipif(
+        not HAVE_EMERGING_OPTIMIZERS, reason="emerging_optimizers package not installed"
+    )
+    @pytest.mark.skipif(
+        not is_torch_min_version("2.6a0"), reason="dp_reshardable requires PyTorch 2.6a0 or later"
+    )
+    @pytest.mark.parametrize('sharding_type', ['dp_reshardable', 'fully_reshardable'])
+    def test_lion_optimizer_checkpoint_round_trip(self, tmp_path_dist_ckpt, sharding_type):
+        """Test DistributedOptimizer checkpoint save/load with Lion (single-moment optimizer).
+
+        Lion is used as the scalar optimizer for Muon (muon_scalar_optimizer='lion'),
+        which is the natural path where Lion ends up inside a DistributedOptimizer.
+        This exercises the dynamic optimizer_state_keys logic with Lion's single
+        moment ('exp_avg') instead of Adam's two ('exp_avg', 'exp_avg_sq').
+        """
+        Utils.initialize_model_parallel(2, 1, order='tp-pp-dp')
+
+        def _get_lion_distopt(optimizer):
+            """Extract the Lion DistributedOptimizer from a Muon+Lion ChainedOptimizer."""
+            assert isinstance(optimizer, ChainedOptimizer)
+            for child in optimizer.chained_optimizers:
+                if isinstance(child, DistributedOptimizer):
+                    return child
+            raise AssertionError("No DistributedOptimizer found in ChainedOptimizer")
+
+        def _seed_random_optimizer_state(distopt, seed):
+            """Seed non-zero random exp_avg values in the DistOpt's raw optimizer state."""
+            torch.manual_seed(seed)
+            for group in distopt.optimizer.param_groups:
+                for p in group['params']:
+                    state = distopt.optimizer.state[p]
+                    if 'exp_avg' in state:
+                        state['exp_avg'].copy_(torch.randn_like(p.data))
+
+        with TempNamedDir(
+            tmp_path_dist_ckpt / 'test_lion_optimizer_checkpoint', sync=True
+        ) as ckpt_dir_A:
+            model_A, optimizer_A = setup_model_and_optimizer(
+                seed=2,
+                tp=2,
+                pp=1,
+                bf16=True,
+                dist_opt=True,
+                optimizer='muon',
+                muon_scalar_optimizer='lion',
+                use_param_layout=True,
+            )
+
+            lion_distopt_A = _get_lion_distopt(optimizer_A)
+            assert lion_distopt_A.optimizer_state_keys == ("exp_avg",)
+            _seed_random_optimizer_state(lion_distopt_A, seed=100)
+
+            metadata = {'distrib_optim_sharding_type': sharding_type}
+
+            model_sharded_sd = model_A[0].sharded_state_dict()
+            optim_sd = optimizer_A.sharded_state_dict(model_sharded_sd, metadata=metadata)
+            save(optim_sd, ckpt_dir_A)
+
+            dp_zero_optim_A = lion_distopt_A.get_parameter_state_dp_zero(use_gloo_comm=False)
+
+            model_B, optimizer_B = setup_model_and_optimizer(
+                seed=3,
+                tp=2,
+                pp=1,
+                bf16=True,
+                dist_opt=True,
+                optimizer='muon',
+                muon_scalar_optimizer='lion',
+                use_param_layout=True,
+            )
+
+            lion_distopt_B = _get_lion_distopt(optimizer_B)
+            _seed_random_optimizer_state(lion_distopt_B, seed=200)
+
+            # Before loading, state should differ.
+            dp_zero_optim_B = lion_distopt_B.get_parameter_state_dp_zero(use_gloo_comm=False)
+            assert not self.check_equal_dp_zero_state(dp_zero_optim_A, dp_zero_optim_B, True)
+
+            model_sharded_sd = model_B[0].sharded_state_dict()
+            load_sharded_state_dict = optimizer_B.sharded_state_dict(
+                model_sharded_sd, metadata=metadata, is_loading=True
+            )
+            state_dict = load(load_sharded_state_dict, ckpt_dir_A)
+            optimizer_B.load_state_dict(state_dict)
+
+            # After loading, state should match.
+            dp_zero_optim_B = lion_distopt_B.get_parameter_state_dp_zero(use_gloo_comm=False)
+            assert self.check_equal_dp_zero_state(
+                dp_zero_optim_A, dp_zero_optim_B, True, raise_if_different=True
+            )
+
+        Utils.destroy_model_parallel()
 
 
 class TestFP32Optimizer:

--- a/tests/unit_tests/dist_checkpointing/utils.py
+++ b/tests/unit_tests/dist_checkpointing/utils.py
@@ -185,6 +185,7 @@ def setup_model_and_optimizer(
     dist_opt=True,
     optimizer='adam',
     use_param_layout=False,
+    muon_scalar_optimizer='adam',
 ):
     optimizer_type = optimizer
     use_layer_wise = False
@@ -226,10 +227,13 @@ def setup_model_and_optimizer(
         use_distributed_optimizer=ddp_use_dist_opt,
         use_layer_wise_distributed_optimizer=use_layer_wise,
         optimizer=optimizer,
+        muon_scalar_optimizer=muon_scalar_optimizer,
     )
 
     if optimizer_type in ('muon', 'dist_muon'):
         config.lr = 0.0
+    elif optimizer_type == 'lion':
+        config.lr = 1e-4
     optimizer = get_megatron_optimizer(config, model)
 
     torch.manual_seed(seed + 1)
@@ -255,11 +259,15 @@ def setup_model_and_optimizer(
     if isinstance(optimizer, ChainedOptimizer):
         _init_states(optimizer)
     else:
+        if hasattr(optimizer, 'optimizer_state_keys'):
+            state_keys = optimizer.optimizer_state_keys
+        else:
+            state_keys = ("exp_avg", "exp_avg_sq")
         for group in optimizer.optimizer.param_groups:
             for p in group['params']:
                 if len(optimizer.optimizer.state[p]) == 0:
-                    optimizer.optimizer.state[p]['exp_avg'] = torch.rand_like(p.data)
-                    optimizer.optimizer.state[p]['exp_avg_sq'] = torch.rand_like(p.data)
+                    for key in state_keys:
+                        optimizer.optimizer.state[p][key] = torch.rand_like(p.data)
 
     optimizer.reload_model_params()
     CachedMetadataFileSystemReader.clear_metadata_cache()

--- a/tests/unit_tests/test_lion_optimizer.py
+++ b/tests/unit_tests/test_lion_optimizer.py
@@ -19,6 +19,7 @@ from megatron.core.optimizer import (
     _get_megatron_optimizer_based_on_param_groups,
     _get_param_groups,
 )
+from megatron.core.optimizer.distrib_optimizer import DistributedOptimizer
 from megatron.core.optimizer.optimizer import FP32Optimizer
 
 requires_emerging_optimizers = pytest.mark.skipif(
@@ -253,3 +254,53 @@ class TestLionOptimizerExactness:
                         rtol=0,
                         msg=f"Step {step}, state '{key}': optimizer states differ",
                     )
+
+
+class TestDistributedOptimizerStateKeys:
+    """Tests for DistributedOptimizer.optimizer_state_keys and _get_state_key_dtype.
+
+    These tests use a mock to avoid needing a full distributed setup.
+    """
+
+    def _make_mock_distopt(self, optimizer_name):
+        """Create a minimal mock with just the config needed for optimizer_state_keys."""
+        mock = object.__new__(DistributedOptimizer)
+        mock.config = OptimizerConfig(optimizer=optimizer_name, lr=1e-4)
+        return mock
+
+    def test_adam_state_keys(self):
+        distopt = self._make_mock_distopt("adam")
+        assert distopt.optimizer_state_keys == ("exp_avg", "exp_avg_sq")
+
+    def test_lion_state_keys(self):
+        distopt = self._make_mock_distopt("lion")
+        assert distopt.optimizer_state_keys == ("exp_avg",)
+
+    def test_sgd_state_keys_defaults_to_adam(self):
+        distopt = self._make_mock_distopt("sgd")
+        assert distopt.optimizer_state_keys == ("exp_avg", "exp_avg_sq")
+
+    def test_get_state_key_dtype_known_keys(self):
+        distopt = self._make_mock_distopt("adam")
+        assert distopt._get_state_key_dtype("exp_avg") == torch.float32
+        assert distopt._get_state_key_dtype("exp_avg_sq") == torch.float32
+
+    def test_get_state_key_dtype_unknown_key(self):
+        distopt = self._make_mock_distopt("adam")
+        assert distopt._get_state_key_dtype("unknown_key") == torch.float32
+
+    def test_get_state_key_dtype_respects_config(self):
+        mock = object.__new__(DistributedOptimizer)
+        mock.config = SimpleNamespace(exp_avg_dtype=torch.bfloat16, exp_avg_sq_dtype=torch.float16)
+        assert mock._get_state_key_dtype("exp_avg") == torch.bfloat16
+        assert mock._get_state_key_dtype("exp_avg_sq") == torch.float16
+
+    def test_muon_with_lion_scalar_optimizer(self):
+        mock = object.__new__(DistributedOptimizer)
+        mock.config = OptimizerConfig(optimizer="muon", lr=1e-4, muon_scalar_optimizer="lion")
+        assert mock.optimizer_state_keys == ("exp_avg",)
+
+    def test_muon_with_adam_scalar_optimizer(self):
+        mock = object.__new__(DistributedOptimizer)
+        mock.config = OptimizerConfig(optimizer="muon", lr=1e-4, muon_scalar_optimizer="adam")
+        assert mock.optimizer_state_keys == ("exp_avg", "exp_avg_sq")


### PR DESCRIPTION
## Summary

The `DistributedOptimizer` checkpointing code hardcoded the assumption that every optimizer uses exactly two moment states (`exp_avg` and `exp_avg_sq`), matching Adam. Optimizers like Lion only use a single moment (`exp_avg`), causing failures during checkpoint save/load.

### Changes

**`megatron/core/optimizer/distrib_optimizer.py`**
- Add `optimizer_state_keys` property that returns the optimizer's tensor state keys via a hardcoded mapping (e.g., `("exp_avg",)` for Lion, defaulting to `("exp_avg", "exp_avg_sq")` for Adam). When Muon is the top-level optimizer, resolves through `config.muon_scalar_optimizer`.
- Add `_get_state_key_dtype` helper that maps state keys to their configured dtypes.
- Replace six hardcoded `("param", "exp_avg", "exp_avg_sq")` tuples with `("param",) + self.optimizer_state_keys` in `load_state_dict`, `get_parameter_state_dp_zero`, `load_parameter_state_from_dp_zero_legacy`, `load_parameter_state_from_dp_zero`, and `split_state_dict_if_needed`.
- Relax the optimizer-type assertion to allow any optimizer that provides an `init_state_fn` (not just Adam and HybridDeviceOptimizer).

**`megatron/core/optimizer/__init__.py`**
- When Lion is used as Muon's scalar optimizer (`muon_scalar_optimizer='lion'`), rewrite the default param overrides so Lion scalar param groups route through the standard fallback path (creating a `DistributedOptimizer`) rather than the emerging-optimizer constructor.
- Fix the `_EMERGING_OPTIMIZERS` membership check to compare against the primary emerging optimizer name (`eopt_name`), so scalar optimizers that happen to also be registered (e.g., Lion) fall through correctly.

**Tests**
- `tests/unit_tests/test_lion_optimizer.py`: Unit tests for `optimizer_state_keys` (Lion, Adam, Muon+Lion, Muon+Adam) and `_get_state_key_dtype`.
- `tests/unit_tests/dist_checkpointing/test_optimizer.py`: End-to-end checkpoint round-trip test using Muon + Lion (`muon_scalar_optimizer='lion'`) with `dp_reshardable` and `fully_reshardable` sharding types. Verifies that Lion's single-moment state survives save/load through `DistributedOptimizer`.
- `tests/unit_tests/dist_checkpointing/utils.py`: Plumb `muon_scalar_optimizer` parameter and Lion learning-rate default through `setup_model_and_optimizer`.

## Test plan

- [x] `tests/unit_tests/test_lion_optimizer.py` — Lion config, factory, exactness, and `DistributedOptimizer` state-key unit tests
- [x] `tests/unit_tests/dist_checkpointing/test_optimizer.py::TestDistributedOptimizer::test_lion_optimizer_checkpoint_round_trip` — checkpoint save/load round-trip with Muon+Lion

🤖 Generated with [Claude Code](https://claude.com/claude-code)