### PR TITLE
Increase Megatron-FSDP overlap test dim to 8192 for reliable overlap

### DIFF
--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -319,7 +319,7 @@ def test_overlaps_all_gather_and_compute(distributed_setup):
         pytest.skip("This test requires at least 2 ranks.")
 
     mesh = init_device_mesh(device.type, (world_size,))
-    dim = 4096
+    dim = 8192
     num_children = 4
     dtype = torch.bfloat16
     model = MultiChildModel(dim=dim, num_children=num_children).to(dtype=dtype)


### PR DESCRIPTION
## Summary

`test_overlaps_all_gather_and_compute` asserts that at least `num_children - 1`
forward all-gathers overlap GEMM compute. At `dim = 4096` the GEMM kernels are
short enough that kernel launch/dispatch latency dominates, so the independent
all-gather and GEMM kernels do not reliably co-reside on the GPU. On a single
**DGX H100 node (8×H100)** with **default NCCL settings** the test fails nearly
every run — any one of the eight ranks missing an overlap fails the whole test.
Raising the GEMM size to `dim = 8192` makes each kernel long enough to amortize
launch latency so the forward all-gathers reliably overlap the preceding
child's GEMM.

## Validation (8×H100, default NCCL)

| dim | ALLPASS |
|---|---|
| 4096 (before) | 0 / 12 |
| **8192 (this PR)** | **25 / 25** |

## Why the flakiness doesn't show up in CI

The unit-test harness `tests/unit_tests/run_ci_test.sh` exports
`NCCL_MAX_NCHANNELS=1` (to reduce NCCL memory). That serializes the all-gather
onto a single channel, producing a longer, lighter-weight all-gather kernel
that happens to overlap even the small `dim = 4096` GEMM. Isolated on 8×H100:

| NCCL env (dim=4096) | ALLPASS |
|---|---|
| default | 0 / 12 |
| `NCCL_MAX_NCHANNELS=1` only | 10 / 10 |

So the test was implicitly relying on a memory-reduction env var unrelated to
the feature under test. Bumping `dim` removes that hidden dependency so it
passes under both default and CI NCCL configs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
