### PR TITLE
[data] Support Nemotron-SFT, RP2, and CodeForge datasets in the varlen loader

### DIFF
--- a/megatron/core/tokenizers/text/libraries/sft_tokenizer.py
+++ b/megatron/core/tokenizers/text/libraries/sft_tokenizer.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 
 from dataclasses import dataclass
-from typing import Dict, List, Union
+from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
 
@@ -128,7 +128,11 @@ class SFTTokenizer:
         return arr[0] if arr.ndim == 2 and arr.shape[0] == 1 else arr
 
     def tokenize_conversation(
-        self, conversation: List[Dict], return_target: bool, add_generation_prompt: bool
+        self,
+        conversation: List[Dict],
+        return_target: bool,
+        add_generation_prompt: bool,
+        chat_template_kwargs: Optional[Dict[str, Any]] = None,
     ):
         """Convert a conversation to tokens.
 
@@ -142,11 +146,14 @@ class SFTTokenizer:
                 ]
             return_target (bool): Return target tokens with system and assistant masked.
             add_generation_prompt (bool): Add assistant prefix to the end.
+            chat_template_kwargs (Optional[Dict[str, Any]]): Additional keyword arguments passed
+                to the Hugging Face chat template, such as top-level tool definitions.
         """
         # Skip system message if the tokenizer doesn't have a system role.
         if not self._prompt_config.has_system_role and conversation[0]["role"] == "system":
             conversation = conversation[1:]
 
+        template_kwargs = dict(chat_template_kwargs or {})
         tokens = self._extract_token_ids(
             self._tokenizer.apply_chat_template(
                 conversation,
@@ -155,6 +162,7 @@ class SFTTokenizer:
                 return_assistant_token_mask=False,
                 return_tensors="np",
                 chat_template=self._prompt_config.custom_chat_template,
+                **template_kwargs,
             )
         )
 

--- a/megatron/core/tokenizers/text/libraries/sft_tokenizer.py
+++ b/megatron/core/tokenizers/text/libraries/sft_tokenizer.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Union
 
 import numpy as np
 
@@ -132,7 +132,7 @@ class SFTTokenizer:
         conversation: List[Dict],
         return_target: bool,
         add_generation_prompt: bool,
-        chat_template_kwargs: Optional[Dict[str, Any]] = None,
+        chat_template_kwargs: Dict[str, Any] | None = None,
     ):
         """Convert a conversation to tokens.
 
@@ -146,7 +146,7 @@ class SFTTokenizer:
                 ]
             return_target (bool): Return target tokens with system and assistant masked.
             add_generation_prompt (bool): Add assistant prefix to the end.
-            chat_template_kwargs (Optional[Dict[str, Any]]): Additional keyword arguments passed
+            chat_template_kwargs (Dict[str, Any] | None): Additional keyword arguments passed
                 to the Hugging Face chat template, such as top-level tool definitions.
         """
         # Skip system message if the tokenizer doesn't have a system role.

--- a/megatron/core/tokenizers/text/text_tokenizer.py
+++ b/megatron/core/tokenizers/text/text_tokenizer.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 
 from collections import OrderedDict
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from megatron.core.tokenizers.base_tokenizer import MegatronTokenizerBase
 from megatron.core.tokenizers.text.libraries.abstract_tokenizer import MegatronTokenizerTextAbstract
@@ -121,7 +121,11 @@ class MegatronTokenizerText(MegatronTokenizerBase):
         )
 
     def tokenize_conversation(
-        self, conversation: List[Dict], return_target: bool, add_generation_prompt: bool
+        self,
+        conversation: List[Dict],
+        return_target: bool,
+        add_generation_prompt: bool,
+        chat_template_kwargs: Optional[Dict[str, Any]] = None,
     ):
         """Convert a conversation to tokens. Needed for SFTTokenizer.
 
@@ -135,6 +139,8 @@ class MegatronTokenizerText(MegatronTokenizerBase):
                 ]
             return_target (bool): Return target tokens with system and assistant masked.
             add_generation_prompt (bool): Add assistant prefix to the end.
+            chat_template_kwargs (Optional[Dict[str, Any]]): Additional keyword arguments passed
+                to the tokenizer's chat template.
         """
 
         if self.library == 'sft':
@@ -142,6 +148,7 @@ class MegatronTokenizerText(MegatronTokenizerBase):
                 conversation=conversation,
                 return_target=return_target,
                 add_generation_prompt=add_generation_prompt,
+                chat_template_kwargs=chat_template_kwargs,
             )
         else:
             raise NotImplementedError("This method is supported only for SFTTokenizer.")

--- a/megatron/core/tokenizers/text/text_tokenizer.py
+++ b/megatron/core/tokenizers/text/text_tokenizer.py
@@ -125,7 +125,7 @@ class MegatronTokenizerText(MegatronTokenizerBase):
         conversation: List[Dict],
         return_target: bool,
         add_generation_prompt: bool,
-        chat_template_kwargs: Optional[Dict[str, Any]] = None,
+        chat_template_kwargs: Dict[str, Any] | None = None,
     ):
         """Convert a conversation to tokens. Needed for SFTTokenizer.
 
@@ -139,7 +139,7 @@ class MegatronTokenizerText(MegatronTokenizerBase):
                 ]
             return_target (bool): Return target tokens with system and assistant masked.
             add_generation_prompt (bool): Add assistant prefix to the end.
-            chat_template_kwargs (Optional[Dict[str, Any]]): Additional keyword arguments passed
+            chat_template_kwargs (Dict[str, Any] | None): Additional keyword arguments passed
                 to the tokenizer's chat template.
         """
 

--- a/megatron/training/datasets/varlen_dataset.py
+++ b/megatron/training/datasets/varlen_dataset.py
@@ -13,8 +13,8 @@ Compared to :class:`SFTDataset`, this dataset adds:
 
   * **Multi-source loading** — accepts HuggingFace Hub repo ids
     (``owner/repo``), local ``.parquet`` files, and local ``.jsonl/.json``
-    files; the latter are read via pandas to sidestep pyarrow's per-chunk
-    JSON schema inference which fails when sample fields vary across rows.
+    files. Hub repos may expose multiple configs and splits; these are joined
+    logically without requiring their Arrow schemas to be identical.
 
   * **Auto schema detection** — four input layouts are auto-detected by column
     name. The three instruction-tuning layouts are normalized to the messages
@@ -40,17 +40,23 @@ Compared to :class:`SFTDataset`, this dataset adds:
 
 Limitations (raise a clear ``ValueError`` instead of silently mishandling):
 
-  * Sample content/value must be a plain string — multi-modal content lists
-    (image+text parts) are not supported.
+  * OpenAI/OpenCode text and tool-result content blocks are supported, but
+    image/audio/video content requires a multimodal dataset path.
   * Tree-structured (OpenAssistant oasst1) and preference (chosen/rejected)
     datasets are out of scope.
-  * For HF Hub repos, only ``split="train"`` is loaded.
+
+For HF Hub repos, all configs are selected. Each config uses its ``train``
+split when present, otherwise all of its thematic splits. If the Hub Arrow
+builder cannot unify heterogeneous JSON rows, the rows are streamed into a
+map-style single-payload-column cache so Megatron can still index them.
 """
 
 import json
+import logging
 import os
+from bisect import bisect_right
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Tuple
 
 import numpy as np
 import torch
@@ -66,6 +72,10 @@ from megatron.training.datasets.sft_dataset import (
     SFTLowLevelDataset,
 )
 from megatron.training.datasets.utils import load_json_arg
+
+logger = logging.getLogger(__name__)
+
+_HF_PAYLOAD_COLUMN = "__varlen_json_payload__"
 
 # Field-name synonyms (probed in order; first non-empty wins).
 _INSTRUCTION_FIELDS: Tuple[str, ...] = ("instruction", "prompt", "query", "question")
@@ -141,6 +151,96 @@ def _ensure_str_content(content: Any, where: str) -> str:
     return content
 
 
+def _json_text(value: Any, where: str) -> str:
+    """Convert a structured text payload to its stable JSON representation."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, ensure_ascii=False, sort_keys=True)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"VarlenDataset: {where} is not JSON serializable.") from exc
+
+
+def _normalize_openai_content(content: Any, where: str) -> Tuple[str, Dict[str, str]]:
+    """Normalize text-only OpenAI/OpenCode content blocks to a string.
+
+    OpenCode stores tool outputs as ``tool-result`` blocks rather than plain
+    strings. Text blocks are losslessly flattened for text chat templates;
+    image/audio/video blocks remain unsupported by this text-only dataset.
+    """
+    if content is None:
+        return "", {}
+    if isinstance(content, str):
+        return content, {}
+    if not isinstance(content, list):
+        raise ValueError(
+            f"VarlenDataset: {where} content must be a string or a list of text blocks, "
+            f"got {type(content).__name__}."
+        )
+
+    pieces: List[str] = []
+    metadata: Dict[str, str] = {}
+    for index, block in enumerate(content):
+        block_where = f"{where} content block {index}"
+        if isinstance(block, str):
+            pieces.append(block)
+            continue
+        if not isinstance(block, dict):
+            raise ValueError(
+                f"VarlenDataset: {block_where} must be a string or object, "
+                f"got {type(block).__name__}."
+            )
+
+        block_type = block.get("type")
+        if block_type in ("text", "input_text", "output_text"):
+            pieces.append(_json_text(block.get("text", block.get("value")), block_where))
+        elif block_type == "tool-result":
+            output = block.get("output")
+            if isinstance(output, dict):
+                output = output.get("value", output.get("content", output))
+            pieces.append(_json_text(output, f"{block_where} output"))
+            if block.get("toolCallId"):
+                metadata.setdefault("tool_call_id", str(block["toolCallId"]))
+            if block.get("toolName"):
+                metadata.setdefault("name", str(block["toolName"]))
+        else:
+            raise ValueError(
+                f"VarlenDataset: unsupported {block_where} type {block_type!r}. "
+                "Multimodal image/audio/video content requires a multimodal dataset path."
+            )
+
+    return "\n".join(pieces), metadata
+
+
+def _normalize_tools(tools: Any) -> List[Dict[str, Any]]:
+    """Convert OpenCode tool definitions; preserve OpenAI definitions."""
+    normalized_tools: List[Dict[str, Any]] = []
+    for index, tool in enumerate(_ensure_list_field(tools, "tools")):
+        if not isinstance(tool, dict):
+            raise ValueError(
+                f"VarlenDataset: tools[{index}] must be an object, got {type(tool).__name__}."
+            )
+        if "id" not in tool:
+            normalized_tools.append(tool)
+            continue
+        input_schema = tool.get("inputSchema") or {}
+        if not isinstance(input_schema, dict):
+            raise ValueError(f"VarlenDataset: tools[{index}].inputSchema must be an object.")
+        normalized_tools.append(
+            {
+                "type": "function",
+                "function": {
+                    "name": str(tool["id"]),
+                    "description": str(tool.get("description") or ""),
+                    "parameters": input_schema.get("jsonSchema", input_schema),
+                },
+            }
+        )
+    return normalized_tools
+
+
 def _ensure_list_field(value: Any, field_name: str) -> List[Any]:
     """Return a list field, decoding JSON-encoded parquet columns when needed."""
     if value in (None, ""):
@@ -201,22 +301,72 @@ def _messages_passthrough(sample: Dict[str, Any]) -> ChatTemplateSample:
     ``nvidia/Nemotron-SFT-Math-v3``.
     """
     raw = _ensure_list_field(sample.get("messages"), "messages")
-    if raw and raw[0].get("role") != "system":
-        raw = [{"role": "system", "content": ""}] + raw
     out: List[Dict[str, Any]] = []
-    for m in raw:
-        role = m.get("role") or "user"
-        content = _ensure_str_content(m.get("content"), f"messages turn role={role}")
+    role_map = {"developer": "system"}
+    supported_roles = {"system", "user", "assistant", "tool"}
+    for index, m in enumerate(raw):
+        if not isinstance(m, dict):
+            raise ValueError(
+                f"VarlenDataset: messages[{index}] must be an object, " f"got {type(m).__name__}."
+            )
+        role = str(m.get("role") or "user").lower()
+        role = role_map.get(role, role)
+        if role not in supported_roles:
+            raise ValueError(f"VarlenDataset: unsupported messages[{index}] role {role!r}.")
+        content, content_metadata = _normalize_openai_content(
+            m.get("content"), f"messages turn {index} role={role}"
+        )
         normalized = dict(m)
         normalized["role"] = role
         normalized["content"] = content
+        for key, value in content_metadata.items():
+            normalized.setdefault(key, value)
+
+        tool_calls = normalized.get("tool_calls")
+        if tool_calls not in (None, ""):
+            normalized["tool_calls"] = _ensure_list_field(
+                tool_calls, f"messages[{index}].tool_calls"
+            )
+
+        function_call = normalized.get("function_call")
+        if function_call and not normalized.get("tool_calls"):
+            if isinstance(function_call, str):
+                try:
+                    function_call = json.loads(function_call)
+                except json.JSONDecodeError as exc:
+                    raise ValueError(
+                        f"VarlenDataset: messages[{index}].function_call contains invalid JSON."
+                    ) from exc
+            if not isinstance(function_call, dict):
+                raise ValueError(
+                    f"VarlenDataset: messages[{index}].function_call must be an object."
+                )
+            normalized["tool_calls"] = [{"type": "function", "function": dict(function_call)}]
         out.append(normalized)
 
-    tools = _ensure_list_field(sample.get("tools"), "tools")
-    if not tools:
-        chat_template_kwargs: Dict[str, Any] = {}
-    else:
-        chat_template_kwargs = {"tools": tools}
+    if out and out[0]["role"] != "system":
+        out.insert(0, {"role": "system", "content": ""})
+
+    chat_template_kwargs = sample.get("chat_template_kwargs")
+    if isinstance(chat_template_kwargs, str):
+        try:
+            chat_template_kwargs = json.loads(chat_template_kwargs)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                "VarlenDataset: field 'chat_template_kwargs' contains invalid JSON."
+            ) from exc
+    if chat_template_kwargs is None:
+        chat_template_kwargs = {}
+    if not isinstance(chat_template_kwargs, dict):
+        raise ValueError(
+            "VarlenDataset: field 'chat_template_kwargs' must be an object or a "
+            "JSON-encoded object."
+        )
+    chat_template_kwargs = dict(chat_template_kwargs)
+
+    tools = _normalize_tools(sample.get("tools"))
+    if tools:
+        chat_template_kwargs["tools"] = tools
     return ChatTemplateSample(out, chat_template_kwargs)
 
 
@@ -266,14 +416,51 @@ def _select_converter(column_names: List[str]) -> Tuple[Callable[[Dict[str, Any]
     )
 
 
+def _iter_hf_data_file_rows(data_file: str) -> Iterator[Dict[str, Any]]:
+    """Read raw JSONL or Parquet rows without a declared HF schema."""
+    import fsspec
+
+    normalized_path = data_file.lower().split("?", 1)[0]
+    if normalized_path.endswith(".parquet"):
+        import pyarrow.parquet as pq
+
+        with fsspec.open(data_file, "rb") as stream:
+            parquet_file = pq.ParquetFile(stream)
+            for batch in parquet_file.iter_batches(batch_size=1024):
+                yield from batch.to_pylist()
+        return
+
+    with fsspec.open(data_file, "rt", encoding="utf-8", compression="infer") as stream:
+        for line in stream:
+            if line.strip():
+                row = json.loads(line)
+                if not isinstance(row, dict):
+                    raise ValueError(f"VarlenDataset: expected JSON objects in {data_file!r}.")
+                yield row
+
+
+def _iter_hf_rows_as_json(data_files: List[str]):
+    """Stream raw heterogeneous Hub rows as one JSON payload column."""
+    for data_file in data_files:
+        for row in _iter_hf_data_file_rows(data_file):
+            yield {_HF_PAYLOAD_COLUMN: json.dumps(row, ensure_ascii=False)}
+
+
+def _json_payload_to_item(sample: Dict[str, Any]) -> Any:
+    """Decode and normalize a row produced by :func:`_iter_hf_rows_as_json`."""
+    row = json.loads(sample[_HF_PAYLOAD_COLUMN])
+    converter, _ = _select_converter(list(row))
+    return converter(row)
+
+
 class VarlenLowLevelDataset(SFTLowLevelDataset):
     """Low-level loader: HF Hub repo / local parquet / local jsonl, normalized.
 
     Dataset path interpretation:
 
-      * HF Hub repo id (e.g. ``Yukang/LongAlpaca-12k``) — contains ``/`` and
-        does not exist on the local filesystem; loaded via
-        ``datasets.load_dataset(path, split="train")``.
+      * HF Hub repo id (e.g. ``nvidia/Nemotron-SFT-Math-v4``) — contains ``/``
+        and does not exist locally. By default, all configs are considered;
+        each uses ``train`` when available, otherwise all thematic splits.
       * Local ``.parquet`` — loaded via
         ``datasets.load_dataset("parquet", data_files=path, split="all")``;
         parquet's footer schema makes chunked loading safe.
@@ -284,25 +471,88 @@ class VarlenLowLevelDataset(SFTLowLevelDataset):
         chunk and fails with ``CastError`` when the union of fields varies
         between rows (e.g. LongAlpaca-12k).
 
-    A per-sample converter is selected once at construction time based on
-    column names and applied at access time. OpenAI-style samples retain both
-    messages and chat-template metadata, other instruction-tuning schemas
-    convert to a messages list, and the ``pretrain-text`` fallback returns the
-    raw string instead.
+    Each config/split remains a separate map-style component and is joined by
+    index arithmetic. This avoids requiring Arrow feature compatibility across
+    components. A per-component converter is selected from its columns. Hub
+    JSON that fails Arrow schema unification is streamed into a cached JSON
+    payload column and normalized per row.
     """
 
     def __init__(self, dataset_path: str) -> None:
         try:
-            from datasets import Dataset, load_dataset
+            from datasets import (
+                Dataset,
+                Features,
+                Value,
+                get_dataset_config_names,
+                get_dataset_split_names,
+                load_dataset,
+                load_dataset_builder,
+            )
+            from datasets.exceptions import DatasetGenerationError
         except ImportError as exc:
             raise ImportError(
                 "VarlenDataset requires the `datasets` library " "(pip install datasets)."
             ) from exc
+        try:
+            from datasets.table import CastError
+        except ImportError:
+            CastError = DatasetGenerationError
+
+        self._datasets: List[Any] = []
+        self._converters: List[Callable[[Dict[str, Any]], Any]] = []
+        self._schema_names: List[str] = []
+        self._cumulative_sizes: List[int] = []
+
+        def add_component(dataset: Any, payload: bool = False) -> None:
+            if payload:
+                converter = _json_payload_to_item
+                schema_name = "json-payload"
+            else:
+                converter, schema_name = _select_converter(list(dataset.column_names))
+            self._datasets.append(dataset)
+            self._converters.append(converter)
+            self._schema_names.append(schema_name)
+            previous_size = self._cumulative_sizes[-1] if self._cumulative_sizes else 0
+            self._cumulative_sizes.append(previous_size + len(dataset))
 
         if _looks_like_hf_id(dataset_path):
-            self.dataset = load_dataset(dataset_path, split="train")
+            selected_sources: List[Tuple[str, str]] = []
+            for selected_config in get_dataset_config_names(dataset_path):
+                available_splits = get_dataset_split_names(dataset_path, selected_config)
+                selected_splits = ["train"] if "train" in available_splits else available_splits
+                selected_sources.extend(
+                    (selected_config, selected_split) for selected_split in selected_splits
+                )
+
+            if not selected_sources:
+                raise ValueError(f"VarlenDataset: no config/split was found in {dataset_path}.")
+
+            for selected_config, selected_split in selected_sources:
+                source = f"{dataset_path}:{selected_config}/{selected_split}"
+                try:
+                    dataset = load_dataset(dataset_path, name=selected_config, split=selected_split)
+                    add_component(dataset)
+                except (DatasetGenerationError, CastError):
+                    builder = load_dataset_builder(dataset_path, name=selected_config)
+                    data_files = builder.config.data_files.get(selected_split)
+                    if not data_files:
+                        raise ValueError(
+                            f"VarlenDataset: could not resolve raw files for {source}."
+                        )
+                    logger.warning(
+                        "Arrow schema generation failed for %s; materializing a map-style "
+                        "JSON payload cache directly from the raw data files.",
+                        source,
+                    )
+                    dataset = Dataset.from_generator(
+                        _iter_hf_rows_as_json,
+                        features=Features({_HF_PAYLOAD_COLUMN: Value("string")}),
+                        gen_kwargs={"data_files": [str(data_file) for data_file in data_files]},
+                    )
+                    add_component(dataset, payload=True)
         elif dataset_path.endswith(".parquet"):
-            self.dataset = load_dataset("parquet", data_files=dataset_path, split="all")
+            add_component(load_dataset("parquet", data_files=dataset_path, split="all"))
         else:
             try:
                 import pandas as pd
@@ -312,21 +562,38 @@ class VarlenLowLevelDataset(SFTLowLevelDataset):
                     "files (pip install pandas)."
                 ) from exc
             df = pd.read_json(dataset_path, lines=True)
-            self.dataset = Dataset.from_pandas(df, preserve_index=False)
+            add_component(Dataset.from_pandas(df, preserve_index=False))
 
-        self._converter, self._schema_name = _select_converter(list(self.dataset.column_names))
+        if not self._datasets:
+            raise ValueError(f"VarlenDataset: no data was loaded from {dataset_path!r}.")
+        self.dataset = self._datasets[0] if len(self._datasets) == 1 else tuple(self._datasets)
+        unique_schema_names = list(dict.fromkeys(self._schema_names))
+        self._schema_name = (
+            unique_schema_names[0]
+            if len(unique_schema_names) == 1
+            else f"mixed({','.join(unique_schema_names)})"
+        )
 
     @property
     def schema_name(self) -> str:
         """Detected schema name: ``alpaca`` / ``sharegpt`` / ``openai-messages`` /
-        ``pretrain-text`` (the raw ``text``-column fallback)."""
+        ``pretrain-text`` / ``json-payload`` (the raw-schema fallback)."""
         return self._schema_name
 
     def __len__(self) -> int:
-        return len(self.dataset)
+        return self._cumulative_sizes[-1]
 
     def __getitem__(self, idx: int) -> Any:
-        return self._converter(self.dataset[idx])
+        idx = int(idx)
+        if idx < 0:
+            idx += len(self)
+        if idx < 0 or idx >= len(self):
+            raise IndexError(idx)
+        component_index = bisect_right(self._cumulative_sizes, idx)
+        component_start = self._cumulative_sizes[component_index - 1] if component_index > 0 else 0
+        return self._converters[component_index](
+            self._datasets[component_index][idx - component_start]
+        )
 
 
 class VarlenDataset(SFTDataset):

--- a/megatron/training/datasets/varlen_dataset.py
+++ b/megatron/training/datasets/varlen_dataset.py
@@ -47,7 +47,9 @@ Limitations (raise a clear ``ValueError`` instead of silently mishandling):
   * For HF Hub repos, only ``split="train"`` is loaded.
 """
 
+import json
 import os
+from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
 
 import numpy as np
@@ -87,6 +89,14 @@ _SHAREGPT_ROLE_MAP: Dict[str, str] = {
     "function": "tool",
     "observation": "tool",
 }
+
+
+@dataclass
+class ChatTemplateSample:
+    """Conversation plus keyword arguments consumed by the chat template."""
+
+    messages: List[Dict[str, Any]]
+    chat_template_kwargs: Dict[str, Any] = field(default_factory=dict)
 
 
 def _looks_like_hf_id(path: str) -> bool:
@@ -131,6 +141,23 @@ def _ensure_str_content(content: Any, where: str) -> str:
     return content
 
 
+def _ensure_list_field(value: Any, field_name: str) -> List[Any]:
+    """Return a list field, decoding JSON-encoded parquet columns when needed."""
+    if value in (None, ""):
+        return []
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"VarlenDataset: field '{field_name}' contains invalid JSON.") from exc
+    if not isinstance(value, list):
+        raise ValueError(
+            f"VarlenDataset: field '{field_name}' must be a list or a JSON-encoded list, "
+            f"got {type(value).__name__}."
+        )
+    return value
+
+
 def _alpaca_to_messages(sample: Dict[str, Any]) -> List[Dict[str, str]]:
     """Convert an Alpaca/Dolly-style sample to a 3-turn messages list."""
     instruction = _first_present(sample, _INSTRUCTION_FIELDS) or ""
@@ -151,7 +178,7 @@ def _sharegpt_to_messages(sample: Dict[str, Any]) -> List[Dict[str, str]]:
     with one, so ``SFTDataset._split_conversations`` treats the sample as a
     single conversation.
     """
-    conv = sample.get("conversations") or []
+    conv = _ensure_list_field(sample.get("conversations"), "conversations")
     out: List[Dict[str, str]] = []
     first_speaker = (conv[0].get("from") or "").lower() if conv else ""
     if first_speaker != "system":
@@ -164,22 +191,33 @@ def _sharegpt_to_messages(sample: Dict[str, Any]) -> List[Dict[str, str]]:
     return out
 
 
-def _messages_passthrough(sample: Dict[str, Any]) -> List[Dict[str, str]]:
-    """Pass through an OpenAI ``messages`` sample, ensuring a leading system turn.
+def _messages_passthrough(sample: Dict[str, Any]) -> ChatTemplateSample:
+    """Normalize an OpenAI ``messages`` sample without dropping template metadata.
 
-    Strips any keys other than ``role``/``content`` (e.g. ``name``,
-    ``tool_calls``) since they are not part of the chat-template input
-    expected by SFTTokenizer.
+    Fields such as ``reasoning_content``, ``tool_calls``, ``name``, and
+    ``tool_call_id`` are interpreted by model-specific Hugging Face chat
+    templates. Top-level ``tools`` are forwarded as a template keyword
+    argument. This is required for tool-integrated datasets such as
+    ``nvidia/Nemotron-SFT-Math-v3``.
     """
-    raw = list(sample.get("messages") or [])
+    raw = _ensure_list_field(sample.get("messages"), "messages")
     if raw and raw[0].get("role") != "system":
         raw = [{"role": "system", "content": ""}] + raw
-    out: List[Dict[str, str]] = []
+    out: List[Dict[str, Any]] = []
     for m in raw:
         role = m.get("role") or "user"
         content = _ensure_str_content(m.get("content"), f"messages turn role={role}")
-        out.append({"role": role, "content": content})
-    return out
+        normalized = dict(m)
+        normalized["role"] = role
+        normalized["content"] = content
+        out.append(normalized)
+
+    tools = _ensure_list_field(sample.get("tools"), "tools")
+    if not tools:
+        chat_template_kwargs: Dict[str, Any] = {}
+    else:
+        chat_template_kwargs = {"tools": tools}
+    return ChatTemplateSample(out, chat_template_kwargs)
 
 
 def _raw_text_loader(sample: Dict[str, Any]) -> str:
@@ -247,9 +285,10 @@ class VarlenLowLevelDataset(SFTLowLevelDataset):
         between rows (e.g. LongAlpaca-12k).
 
     A per-sample converter is selected once at construction time based on
-    column names and applied at access time. The instruction-tuning schemas
-    convert to a messages list; the ``pretrain-text`` fallback returns the raw
-    string instead.
+    column names and applied at access time. OpenAI-style samples retain both
+    messages and chat-template metadata, other instruction-tuning schemas
+    convert to a messages list, and the ``pretrain-text`` fallback returns the
+    raw string instead.
     """
 
     def __init__(self, dataset_path: str) -> None:
@@ -286,7 +325,7 @@ class VarlenLowLevelDataset(SFTLowLevelDataset):
     def __len__(self) -> int:
         return len(self.dataset)
 
-    def __getitem__(self, idx: int) -> List[Dict[str, str]]:
+    def __getitem__(self, idx: int) -> Any:
         return self._converter(self.dataset[idx])
 
 
@@ -342,9 +381,10 @@ class VarlenDataset(SFTDataset):
             eod is not None
         ), "VarlenDataset requires the tokenizer to expose an EOD/EOS token id."
 
-        # 1. Pull a single item from the low-level dataset. For SFT schemas
-        #    (alpaca / sharegpt / openai-messages) this is a messages list;
-        #    for the pretrain-text schema it is a raw string.
+        # 1. Pull a single item from the low-level dataset. OpenAI-style data
+        #    carries messages plus optional chat-template kwargs (for example,
+        #    top-level tool definitions); other SFT schemas return a messages
+        #    list, and pretrain-text returns a raw string.
         item = self.dataset[int(self.indices[idx % len(self.indices)])]
 
         assert not self.config.reset_position_ids
@@ -358,6 +398,15 @@ class VarlenDataset(SFTDataset):
             ids = list(tokenizer.tokenize(item))
             tokens_list = ids
             targets_list = list(ids)
+        elif isinstance(item, ChatTemplateSample):
+            tokens, targets = tokenizer.tokenize_conversation(
+                item.messages,
+                return_target=True,
+                add_generation_prompt=False,
+                chat_template_kwargs=item.chat_template_kwargs,
+            )
+            tokens_list = tokens.tolist()
+            targets_list = targets.tolist()
         else:
             tokens, targets = tokenizer.tokenize_conversation(
                 item, return_target=True, add_generation_prompt=False

--- a/megatron/training/datasets/varlen_dataset.py
+++ b/megatron/training/datasets/varlen_dataset.py
@@ -29,8 +29,9 @@ Compared to :class:`SFTDataset`, this dataset adds:
         ``instruction|prompt|query|question`` + one of
         ``output|response|completion|answer``, plus optional context field
         ``input|context``.
-      * **pretrain-text** — column ``text``; returns the raw string (no
-        messages list, no role masking), tokenized as plain pretraining text.
+      * **pretrain-text** — column ``text``, ``raw_content`` (RedPajama V2 /
+        RP2), or ``content`` (CodeForge); returns the raw string (no messages
+        list, no role masking), tokenized as plain pretraining text.
 
   * **Mock variant** — :class:`MockVarlenDataset` mirrors
     :class:`MockSFTDataset` end-to-end (synthetic lognormal sequence-length
@@ -82,6 +83,9 @@ _INSTRUCTION_FIELDS: Tuple[str, ...] = ("instruction", "prompt", "query", "quest
 _OUTPUT_FIELDS: Tuple[str, ...] = ("output", "response", "completion", "answer")
 # Supplementary user-turn context: Stanford Alpaca's "input", Dolly's "context".
 _EXTRA_INPUT_FIELDS: Tuple[str, ...] = ("input", "context")
+# Raw pretraining text: canonical datasets use "text", RedPajama V2 uses
+# "raw_content", and CodeForge uses "content".
+_PRETRAIN_TEXT_FIELDS: Tuple[str, ...] = ("text", "raw_content", "content")
 
 # ShareGPT "from" value -> chat-template "role". Unknown values fall back to
 # "user" so downstream tokenization does not crash on unfamiliar speakers.
@@ -126,15 +130,15 @@ def _looks_like_hf_id(path: str) -> bool:
 
 def _first_present(sample: Dict[str, Any], fields: Iterable[str]) -> Optional[str]:
     """Return the first non-empty string value among the given fields, or None."""
-    for f in fields:
-        v = sample.get(f)
-        if v in (None, ""):
+    for field_name in fields:
+        value = sample.get(field_name)
+        if value in (None, ""):
             continue
-        if not isinstance(v, str):
+        if not isinstance(value, str):
             raise ValueError(
-                f"VarlenDataset: field '{f}' must be a string, " f"got {type(v).__name__}."
+                f"VarlenDataset: field '{field_name}' must be a string, got {type(value).__name__}."
             )
-        return v
+        return value
     return None
 
 
@@ -307,7 +311,7 @@ def _messages_passthrough(sample: Dict[str, Any]) -> ChatTemplateSample:
     for index, m in enumerate(raw):
         if not isinstance(m, dict):
             raise ValueError(
-                f"VarlenDataset: messages[{index}] must be an object, " f"got {type(m).__name__}."
+                f"VarlenDataset: messages[{index}] must be an object, got {type(m).__name__}."
             )
         role = str(m.get("role") or "user").lower()
         role = role_map.get(role, role)
@@ -371,29 +375,23 @@ def _messages_passthrough(sample: Dict[str, Any]) -> ChatTemplateSample:
 
 
 def _raw_text_loader(sample: Dict[str, Any]) -> str:
-    """Return the ``text`` column unchanged for pretrain-style packed runs.
+    """Return a recognized raw-text column unchanged for pretrain-style packed runs.
 
     Unlike the SFT schemas this returns a plain string (no messages list).
     :class:`VarlenDataset.__getitem__` dispatches on the return type to pick
     a tokenization path that skips chat templating and prompt masking.
     """
-    text = sample.get("text") or ""
-    if not isinstance(text, str):
-        raise ValueError(
-            f"VarlenDataset (pretrain-text schema): 'text' must be a string, "
-            f"got {type(text).__name__}."
-        )
-    return text
+    return _first_present(sample, _PRETRAIN_TEXT_FIELDS) or ""
 
 
 def _select_converter(column_names: List[str]) -> Tuple[Callable[[Dict[str, Any]], Any], str]:
     """Pick a sample converter based on dataset column names.
 
     Priority (most explicit first): openai-messages > sharegpt > alpaca/dolly
-    > pretrain-text. ``pretrain-text`` is the fallback for datasets that
-    only carry a single ``text`` column (e.g. Dolma / OLMo midtraining
-    corpora) — long-context pretraining packed through the same THD path
-    as SFT.
+    > pretrain-text. ``pretrain-text`` is the fallback for datasets whose
+    document body is stored in ``text`` (e.g. Dolma / OLMo), ``raw_content``
+    (RedPajama V2 / RP2), or ``content`` (CodeForge) — long-context
+    pretraining packed through the same THD path as SFT.
     """
     cols = set(column_names)
     if "messages" in cols:
@@ -404,7 +402,7 @@ def _select_converter(column_names: List[str]) -> Tuple[Callable[[Dict[str, Any]
     has_out = any(f in cols for f in _OUTPUT_FIELDS)
     if has_instr and has_out:
         return _alpaca_to_messages, "alpaca"
-    if "text" in cols:
+    if any(field in cols for field in _PRETRAIN_TEXT_FIELDS):
         return _raw_text_loader, "pretrain-text"
     raise ValueError(
         "VarlenDataset cannot infer schema from columns "
@@ -412,7 +410,7 @@ def _select_converter(column_names: List[str]) -> Tuple[Callable[[Dict[str, Any]
         f"alpaca/dolly ({'|'.join(_INSTRUCTION_FIELDS)} + "
         f"{'|'.join(_OUTPUT_FIELDS)} [+ optional {'|'.join(_EXTRA_INPUT_FIELDS)}]), "
         "sharegpt (conversations), openai-messages (messages), "
-        "pretrain-text (text)."
+        f"pretrain-text ({'|'.join(_PRETRAIN_TEXT_FIELDS)})."
     )
 
 

--- a/tests/unit_tests/data/test_varlen_dataset.py
+++ b/tests/unit_tests/data/test_varlen_dataset.py
@@ -210,11 +210,11 @@ def test_messages_passthrough_preserves_math_v3_template_fields():
         }
     )
     assert sample.chat_template_kwargs == {"tools": tools}
-    assert sample.messages[1]["content"] == ""
-    assert sample.messages[1]["reasoning_content"] == "I should calculate this."
-    assert sample.messages[1]["tool_calls"][0]["function"]["name"] == "stateful_python_code_exec"
-    assert sample.messages[2]["name"] == "stateful_python_code_exec"
-    assert sample.messages[2]["tool_call_id"] == "call-1"
+    assert sample.messages[2]["content"] == ""
+    assert sample.messages[2]["reasoning_content"] == "I should calculate this."
+    assert sample.messages[2]["tool_calls"][0]["function"]["name"] == "stateful_python_code_exec"
+    assert sample.messages[3]["name"] == "stateful_python_code_exec"
+    assert sample.messages[3]["tool_call_id"] == "call-1"
 
 
 def test_messages_passthrough_rejects_non_list_tools():

--- a/tests/unit_tests/data/test_varlen_dataset.py
+++ b/tests/unit_tests/data/test_varlen_dataset.py
@@ -22,10 +22,12 @@ import torch
 # not require torch.distributed.
 from megatron.training.datasets.sft_dataset import IGNORE_INDEX
 from megatron.training.datasets.varlen_dataset import (
+    ChatTemplateSample,
     MockVarlenDataset,
     VarlenDataset,
     VarlenLowLevelDataset,
     _alpaca_to_messages,
+    _ensure_list_field,
     _looks_like_hf_id,
     _messages_passthrough,
     _raw_text_loader,
@@ -148,14 +150,16 @@ def test_sharegpt_role_map(speaker, expected_role):
 
 
 def test_messages_passthrough_prepends_system_when_missing():
-    out = _messages_passthrough(
+    sample = _messages_passthrough(
         {"messages": [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "hello"}]}
     )
+    out = sample.messages
     assert [m["role"] for m in out] == ["system", "user", "assistant"]
+    assert sample.chat_template_kwargs == {}
 
 
 def test_messages_passthrough_keeps_existing_system():
-    out = _messages_passthrough(
+    sample = _messages_passthrough(
         {
             "messages": [
                 {"role": "system", "content": "be terse"},
@@ -164,23 +168,76 @@ def test_messages_passthrough_keeps_existing_system():
             ]
         }
     )
+    out = sample.messages
     assert [m["role"] for m in out] == ["system", "user", "assistant"]
     assert out[0]["content"] == "be terse"
 
 
-def test_messages_passthrough_strips_extra_keys():
-    """OpenAI-style messages may carry ``name`` / ``tool_calls`` etc.;
-    chat-template input only wants ``role`` and ``content``."""
-    out = _messages_passthrough(
+def test_messages_passthrough_preserves_math_v3_template_fields():
+    tools = [
         {
+            "type": "function",
+            "function": {"name": "stateful_python_code_exec", "parameters": {"type": "object"}},
+        }
+    ]
+    sample = _messages_passthrough(
+        {
+            "tools": tools,
             "messages": [
-                {"role": "user", "content": "hi", "name": "alice"},
-                {"role": "assistant", "content": "hi alice", "tool_calls": [{"function": "foo"}]},
-            ]
+                {"role": "user", "content": "solve"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "reasoning_content": "I should calculate this.",
+                    "tool_calls": [
+                        {
+                            "id": "call-1",
+                            "type": "function",
+                            "function": {
+                                "name": "stateful_python_code_exec",
+                                "arguments": '{"code":"1 + 1"}',
+                            },
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "name": "stateful_python_code_exec",
+                    "tool_call_id": "call-1",
+                    "content": "2",
+                },
+            ],
         }
     )
-    for m in out:
-        assert set(m.keys()) == {"role", "content"}
+    assert sample.chat_template_kwargs == {"tools": tools}
+    assert sample.messages[1]["content"] == ""
+    assert sample.messages[1]["reasoning_content"] == "I should calculate this."
+    assert sample.messages[1]["tool_calls"][0]["function"]["name"] == "stateful_python_code_exec"
+    assert sample.messages[2]["name"] == "stateful_python_code_exec"
+    assert sample.messages[2]["tool_call_id"] == "call-1"
+
+
+def test_messages_passthrough_rejects_non_list_tools():
+    with pytest.raises(ValueError, match="field 'tools' must be a list"):
+        _messages_passthrough(
+            {"messages": [{"role": "user", "content": "hi"}], "tools": {"name": "bad"}}
+        )
+
+
+def test_messages_passthrough_decodes_json_encoded_parquet_columns():
+    messages = [
+        {"role": "user", "content": "solve"},
+        {"role": "assistant", "content": "2", "reasoning_content": "1 + 1"},
+    ]
+    tools = [{"type": "function", "function": {"name": "python"}}]
+    sample = _messages_passthrough({"messages": json.dumps(messages), "tools": json.dumps(tools)})
+    assert sample.messages == [{"role": "system", "content": ""}, *messages]
+    assert sample.chat_template_kwargs == {"tools": tools}
+
+
+def test_ensure_list_field_rejects_invalid_json():
+    with pytest.raises(ValueError, match="contains invalid JSON"):
+        _ensure_list_field("[broken", "messages")
 
 
 # ----------------------------------------------------------------------------
@@ -370,7 +427,8 @@ def test_low_level_loads_jsonl_messages(tmp_path):
     ll = VarlenLowLevelDataset(path)
     assert ll.schema_name == "openai-messages"
     sample = ll[0]
-    assert [m["role"] for m in sample] == ["system", "user", "assistant"]
+    assert isinstance(sample, ChatTemplateSample)
+    assert [m["role"] for m in sample.messages] == ["system", "user", "assistant"]
 
 
 def test_low_level_jsonl_heterogeneous_columns(tmp_path):
@@ -439,6 +497,7 @@ class _FakeTokenizer:
     def __init__(self, eod: int = 0, pad=None):
         self._eod = eod
         self._pad = pad
+        self.last_chat_template_kwargs = None
 
     @property
     def eod(self):
@@ -451,7 +510,10 @@ class _FakeTokenizer:
     def tokenize(self, text):
         return [ord(c) % 100 + 1 for c in text]  # always >= 1, never eod (0)
 
-    def tokenize_conversation(self, messages, return_target=True, add_generation_prompt=False):
+    def tokenize_conversation(
+        self, messages, return_target=True, add_generation_prompt=False, chat_template_kwargs=None
+    ):
+        self.last_chat_template_kwargs = chat_template_kwargs
         tokens, targets = [], []
         for m in messages:
             ids = self.tokenize(m["content"])
@@ -526,6 +588,22 @@ def test_getitem_thd_sft_prompt_is_masked():
     loss_mask = out["loss_mask"]
     assert torch.all(loss_mask[labels == IGNORE_INDEX] == 0.0)
     assert loss_mask.sum() > 0  # assistant span still contributes
+
+
+def test_getitem_forwards_openai_chat_template_kwargs():
+    tok = _FakeTokenizer(eod=0, pad=7)
+    tools = [{"type": "function", "function": {"name": "python"}}]
+    item = ChatTemplateSample(
+        messages=[
+            {"role": "user", "content": "question"},
+            {"role": "assistant", "content": "answer", "reasoning_content": "reason"},
+        ],
+        chat_template_kwargs={"tools": tools},
+    )
+    ds = _make_varlen([item], _make_config(tok, seq_length=64))
+    out = ds[0]
+    assert tok.last_chat_template_kwargs == {"tools": tools}
+    assert out["tokens"].numel() > 0
 
 
 def test_getitem_thd_pad_masked_by_position_keeps_real_eod():

--- a/tests/unit_tests/data/test_varlen_dataset.py
+++ b/tests/unit_tests/data/test_varlen_dataset.py
@@ -235,6 +235,117 @@ def test_messages_passthrough_decodes_json_encoded_parquet_columns():
     assert sample.chat_template_kwargs == {"tools": tools}
 
 
+def test_messages_passthrough_decodes_swe_v3_tool_calls():
+    tool_calls = [
+        {
+            "id": "call-1",
+            "type": "function",
+            "function": {"name": "execute_bash", "arguments": '{"command":"ls"}'},
+        }
+    ]
+    sample = _messages_passthrough(
+        {
+            "messages": [
+                {"role": "user", "content": "inspect"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "reasoning_content": "I should inspect the repository.",
+                    "tool_calls": json.dumps(tool_calls),
+                },
+            ]
+        }
+    )
+    assert sample.messages[2]["tool_calls"] == tool_calls
+
+
+def test_messages_passthrough_normalizes_opencode_tools_and_results():
+    sample = _messages_passthrough(
+        {
+            "tools": [
+                {
+                    "id": "shell",
+                    "description": "Run a command",
+                    "inputSchema": {
+                        "jsonSchema": {
+                            "type": "object",
+                            "properties": {"command": {"type": "string"}},
+                        }
+                    },
+                }
+            ],
+            "messages": [
+                {"role": "user", "content": "list files"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call-1",
+                            "type": "function",
+                            "function": {"name": "shell", "arguments": '{"command":"ls"}'},
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "content": [
+                        {
+                            "type": "tool-result",
+                            "toolCallId": "call-1",
+                            "toolName": "shell",
+                            "output": {"type": "text", "value": "a.txt"},
+                        }
+                    ],
+                },
+            ],
+        }
+    )
+    assert sample.chat_template_kwargs["tools"] == [
+        {
+            "type": "function",
+            "function": {
+                "name": "shell",
+                "description": "Run a command",
+                "parameters": {"type": "object", "properties": {"command": {"type": "string"}}},
+            },
+        }
+    ]
+    assert sample.messages[3]["content"] == "a.txt"
+    assert sample.messages[3]["tool_call_id"] == "call-1"
+    assert sample.messages[3]["name"] == "shell"
+
+
+def test_messages_passthrough_normalizes_legacy_roles_and_function_call():
+    sample = _messages_passthrough(
+        {
+            "messages": [
+                {"role": "developer", "content": "Use tools."},
+                {"role": "user", "content": "calculate"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "function_call": {"name": "python", "arguments": '{"code":"1+1"}'},
+                },
+            ]
+        }
+    )
+    assert [message["role"] for message in sample.messages] == ["system", "user", "assistant"]
+    assert sample.messages[2]["tool_calls"] == [
+        {"type": "function", "function": {"name": "python", "arguments": '{"code":"1+1"}'}}
+    ]
+
+
+def test_messages_passthrough_preserves_agentic_chat_template_kwargs():
+    sample = _messages_passthrough(
+        {
+            "messages": [{"role": "user", "content": "search"}],
+            "chat_template_kwargs": json.dumps({"thinking": True}),
+        }
+    )
+    assert sample.chat_template_kwargs == {"thinking": True}
+
+
 def test_ensure_list_field_rejects_invalid_json():
     with pytest.raises(ValueError, match="contains invalid JSON"):
         _ensure_list_field("[broken", "messages")
@@ -245,8 +356,8 @@ def test_ensure_list_field_rejects_invalid_json():
 # ----------------------------------------------------------------------------
 
 
-def test_messages_rejects_list_content():
-    with pytest.raises(ValueError, match="must be a string"):
+def test_messages_rejects_multimodal_list_content():
+    with pytest.raises(ValueError, match="unsupported.*type 'image'"):
         _messages_passthrough(
             {"messages": [{"role": "user", "content": [{"type": "image", "url": "x.png"}]}]}
         )
@@ -473,6 +584,92 @@ def test_low_level_loads_jsonl_pretrain_text(tmp_path):
     # Each item is a raw string, NOT a messages list.
     assert ll[0] == "Doc one body..."
     assert ll[1] == "Doc two body..."
+
+
+class _FakeHubDataset:
+    def __init__(self, rows):
+        self.rows = rows
+        self.column_names = list(dict.fromkeys(key for row in rows for key in row))
+
+    def __len__(self):
+        return len(self.rows)
+
+    def __getitem__(self, index):
+        return self.rows[index]
+
+
+def test_low_level_hub_loads_all_configs_and_thematic_splits(monkeypatch):
+    datasets = pytest.importorskip("datasets")
+    calls = []
+
+    monkeypatch.setattr(datasets, "get_dataset_config_names", lambda path: ["cfg-a", "cfg-b"])
+    monkeypatch.setattr(
+        datasets,
+        "get_dataset_split_names",
+        lambda path, config: ["train", "validation"] if config == "cfg-a" else ["python", "cpp"],
+    )
+
+    def fake_load_dataset(path, name, split):
+        calls.append((path, name, split))
+        return _FakeHubDataset([{"messages": [{"role": "user", "content": f"{name}/{split}"}]}])
+
+    monkeypatch.setattr(datasets, "load_dataset", fake_load_dataset)
+    low_level = VarlenLowLevelDataset("nvidia/Nemotron-SFT-Test")
+
+    assert calls == [
+        ("nvidia/Nemotron-SFT-Test", "cfg-a", "train"),
+        ("nvidia/Nemotron-SFT-Test", "cfg-b", "python"),
+        ("nvidia/Nemotron-SFT-Test", "cfg-b", "cpp"),
+    ]
+    assert len(low_level) == 3
+    assert low_level[0].messages[1]["content"] == "cfg-a/train"
+    assert low_level[1].messages[1]["content"] == "cfg-b/python"
+    assert low_level[-1].messages[1]["content"] == "cfg-b/cpp"
+    with pytest.raises(IndexError):
+        low_level[3]
+
+
+def test_low_level_hub_falls_back_to_raw_json_payload(monkeypatch, tmp_path):
+    datasets = pytest.importorskip("datasets")
+    from datasets.exceptions import DatasetGenerationError
+
+    raw_path = _write_jsonl(
+        tmp_path,
+        [
+            {
+                "messages": [
+                    {"role": "user", "content": "question"},
+                    {"role": "assistant", "content": "answer"},
+                ]
+            },
+            {"messages": [{"role": "user", "content": "not selected"}]},
+        ],
+    )
+    monkeypatch.setattr(datasets, "get_dataset_config_names", lambda path: ["default"])
+    monkeypatch.setattr(datasets, "get_dataset_split_names", lambda path, config: ["train"])
+    monkeypatch.setattr(
+        datasets,
+        "load_dataset_builder",
+        lambda path, name: SimpleNamespace(
+            config=SimpleNamespace(data_files={"train": [raw_path]})
+        ),
+    )
+
+    def fake_load_dataset(path, name, split):
+        raise DatasetGenerationError("incompatible nested JSON schema")
+
+    def fake_from_generator(generator, features, gen_kwargs):
+        assert list(features) == ["__varlen_json_payload__"]
+        assert isinstance(gen_kwargs["data_files"], list)
+        return _FakeHubDataset(list(generator(**gen_kwargs)))
+
+    monkeypatch.setattr(datasets, "load_dataset", fake_load_dataset)
+    monkeypatch.setattr(datasets.Dataset, "from_generator", staticmethod(fake_from_generator))
+
+    low_level = VarlenLowLevelDataset("nvidia/Nemotron-SFT-Math-v4")
+    assert len(low_level) == 2
+    assert low_level.schema_name == "json-payload"
+    assert low_level[0].messages[2]["content"] == "answer"
 
 
 # ----------------------------------------------------------------------------

--- a/tests/unit_tests/data/test_varlen_dataset.py
+++ b/tests/unit_tests/data/test_varlen_dataset.py
@@ -378,9 +378,10 @@ def test_sharegpt_rejects_list_value():
 # ----------------------------------------------------------------------------
 
 
-def test_raw_text_loader_returns_string():
-    """``text``-column samples are returned as plain strings (not messages)."""
-    out = _raw_text_loader({"text": "Once upon a time...", "id": "doc-1"})
+@pytest.mark.parametrize("field", ["text", "raw_content", "content"])
+def test_raw_text_loader_returns_string(field):
+    """Recognized pretraining columns are returned as plain strings (not messages)."""
+    out = _raw_text_loader({field: "Once upon a time...", "id": "doc-1"})
     assert isinstance(out, str)
     assert out == "Once upon a time..."
 
@@ -390,9 +391,15 @@ def test_raw_text_loader_handles_empty():
     assert _raw_text_loader({}) == ""
 
 
-def test_raw_text_rejects_non_string():
-    with pytest.raises(ValueError, match="must be a string"):
-        _raw_text_loader({"text": [1, 2, 3]})
+def test_raw_text_loader_uses_first_non_empty_alias():
+    sample = {"text": "", "raw_content": "RP2 body", "content": "CodeForge body"}
+    assert _raw_text_loader(sample) == "RP2 body"
+
+
+@pytest.mark.parametrize("field", ["text", "raw_content", "content"])
+def test_raw_text_rejects_non_string(field):
+    with pytest.raises(ValueError, match=rf"field '{field}' must be a string"):
+        _raw_text_loader({field: [1, 2, 3]})
 
 
 # ----------------------------------------------------------------------------
@@ -458,15 +465,30 @@ def test_select_converter_pretrain_text_with_metadata():
     assert name == "pretrain-text"
 
 
-def test_select_converter_alpaca_beats_pretrain_text():
-    """When both ``instruction``/``output`` and ``text`` are present (rare),
-    the alpaca schema is more specific and should win."""
-    fn, name = _select_converter(["text", "instruction", "output"])
+@pytest.mark.parametrize(
+    "columns",
+    [
+        ["raw_content", "doc_id", "meta", "quality_signals"],
+        ["content", "commit_id", "rel_path", "language"],
+    ],
+)
+def test_select_converter_pretrain_text_dataset_aliases(columns):
+    """RP2 and CodeForge expose non-canonical names for their document bodies."""
+    fn, name = _select_converter(columns)
+    assert name == "pretrain-text"
+    assert fn is _raw_text_loader
+
+
+@pytest.mark.parametrize("raw_text_field", ["text", "raw_content", "content"])
+def test_select_converter_alpaca_beats_pretrain_text(raw_text_field):
+    """Alpaca fields are more specific than any raw pretraining-text alias."""
+    fn, name = _select_converter([raw_text_field, "instruction", "output"])
     assert name == "alpaca"
 
 
-def test_select_converter_messages_beats_pretrain_text():
-    fn, name = _select_converter(["text", "messages"])
+@pytest.mark.parametrize("raw_text_field", ["text", "raw_content", "content"])
+def test_select_converter_messages_beats_pretrain_text(raw_text_field):
+    fn, name = _select_converter([raw_text_field, "messages"])
     assert name == "openai-messages"
 
 
@@ -584,6 +606,53 @@ def test_low_level_loads_jsonl_pretrain_text(tmp_path):
     # Each item is a raw string, NOT a messages list.
     assert ll[0] == "Doc one body..."
     assert ll[1] == "Doc two body..."
+
+
+@pytest.mark.parametrize(
+    "rows,expected",
+    [
+        (
+            [
+                {
+                    "raw_content": "RP2 document one",
+                    "doc_id": "rp2-1",
+                    "meta": "{}",
+                    "quality_signals": "{}",
+                },
+                {
+                    "raw_content": "RP2 document two",
+                    "doc_id": "rp2-2",
+                    "meta": "{}",
+                    "quality_signals": "{}",
+                },
+            ],
+            ["RP2 document one", "RP2 document two"],
+        ),
+        (
+            [
+                {
+                    "content": "CodeForge source one",
+                    "commit_id": "abc1234",
+                    "rel_path": "one.py",
+                    "language": "Python",
+                },
+                {
+                    "content": "CodeForge source two",
+                    "commit_id": "def5678",
+                    "rel_path": "two.cpp",
+                    "language": "C++",
+                },
+            ],
+            ["CodeForge source one", "CodeForge source two"],
+        ),
+    ],
+)
+def test_low_level_loads_jsonl_pretrain_text_dataset_aliases(tmp_path, rows, expected):
+    pytest.importorskip("datasets")
+    pytest.importorskip("pandas")
+    low_level = VarlenLowLevelDataset(_write_jsonl(tmp_path, rows))
+    assert low_level.schema_name == "pretrain-text"
+    assert [low_level[index] for index in range(len(low_level))] == expected
 
 
 class _FakeHubDataset:

--- a/tests/unit_tests/tokenizers/test_tokenizer.py
+++ b/tests/unit_tests/tokenizers/test_tokenizer.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -9,6 +10,8 @@ from packaging import version
 
 from megatron.core.tokenizers import MegatronTokenizer
 from megatron.core.tokenizers.text.libraries.bytelevel_tokenizer import ByteLevelTokenizer
+from megatron.core.tokenizers.text.libraries.sft_tokenizer import SFTTokenizer
+from megatron.core.tokenizers.text.text_tokenizer import MegatronTokenizerText
 from megatron.core.tokenizers.utils.build_tokenizer import build_tokenizer
 
 try:
@@ -60,6 +63,58 @@ def get_chat_template():
                 {% if add_generation_prompt %}
                 <|assistant|>
                 {% endif %}"""
+
+
+def test_sft_tokenizer_wrapper_forwards_chat_template_kwargs():
+    tokenizer = object.__new__(MegatronTokenizerText)
+    tokenizer.library = "sft"
+    tokenizer._tokenizer = MagicMock()
+    expected = (np.array([1, 2]), np.array([1, 2]))
+    tokenizer._tokenizer.tokenize_conversation.return_value = expected
+    messages = [{"role": "user", "content": "solve"}]
+    template_kwargs = {"tools": [{"type": "function"}]}
+
+    result = tokenizer.tokenize_conversation(
+        messages,
+        return_target=True,
+        add_generation_prompt=False,
+        chat_template_kwargs=template_kwargs,
+    )
+
+    assert result is expected
+    tokenizer._tokenizer.tokenize_conversation.assert_called_once_with(
+        conversation=messages,
+        return_target=True,
+        add_generation_prompt=False,
+        chat_template_kwargs=template_kwargs,
+    )
+
+
+def test_sft_tokenizer_passes_tools_to_huggingface_chat_template():
+    huggingface_tokenizer = MagicMock()
+    huggingface_tokenizer.apply_chat_template.return_value = {"input_ids": np.array([[11, 12, 13]])}
+    tokenizer = object.__new__(SFTTokenizer)
+    tokenizer._tokenizer = huggingface_tokenizer
+    tokenizer._prompt_format = "default"
+    tokenizer._prompt_config = SimpleNamespace(
+        custom_chat_template="test-template", has_system_role=True
+    )
+    messages = [
+        {"role": "user", "content": "solve"},
+        {"role": "assistant", "content": "2", "reasoning_content": "1 + 1"},
+    ]
+    tools = [{"type": "function", "function": {"name": "python"}}]
+
+    tokens, targets = tokenizer.tokenize_conversation(
+        messages,
+        return_target=True,
+        add_generation_prompt=False,
+        chat_template_kwargs={"tools": tools},
+    )
+
+    np.testing.assert_array_equal(tokens, np.array([11, 12, 13]))
+    np.testing.assert_array_equal(targets, tokens)
+    assert huggingface_tokenizer.apply_chat_template.call_args.kwargs["tools"] == tools
 
 
 def test_sp_tokenizer():

--- a/tests/unit_tests/tokenizers/test_tokenizer.py
+++ b/tests/unit_tests/tokenizers/test_tokenizer.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -8,6 +9,8 @@ import torch
 from packaging import version
 
 from megatron.core.tokenizers import MegatronTokenizer
+from megatron.core.tokenizers.text.libraries.sft_tokenizer import SFTTokenizer
+from megatron.core.tokenizers.text.text_tokenizer import MegatronTokenizerText
 from megatron.core.tokenizers.utils.build_tokenizer import build_tokenizer
 
 try:
@@ -59,6 +62,58 @@ def get_chat_template():
                 {% if add_generation_prompt %}
                 <|assistant|>
                 {% endif %}"""
+
+
+def test_sft_tokenizer_wrapper_forwards_chat_template_kwargs():
+    tokenizer = object.__new__(MegatronTokenizerText)
+    tokenizer.library = "sft"
+    tokenizer._tokenizer = MagicMock()
+    expected = (np.array([1, 2]), np.array([1, 2]))
+    tokenizer._tokenizer.tokenize_conversation.return_value = expected
+    messages = [{"role": "user", "content": "solve"}]
+    template_kwargs = {"tools": [{"type": "function"}]}
+
+    result = tokenizer.tokenize_conversation(
+        messages,
+        return_target=True,
+        add_generation_prompt=False,
+        chat_template_kwargs=template_kwargs,
+    )
+
+    assert result is expected
+    tokenizer._tokenizer.tokenize_conversation.assert_called_once_with(
+        conversation=messages,
+        return_target=True,
+        add_generation_prompt=False,
+        chat_template_kwargs=template_kwargs,
+    )
+
+
+def test_sft_tokenizer_passes_tools_to_huggingface_chat_template():
+    huggingface_tokenizer = MagicMock()
+    huggingface_tokenizer.apply_chat_template.return_value = {"input_ids": np.array([[11, 12, 13]])}
+    tokenizer = object.__new__(SFTTokenizer)
+    tokenizer._tokenizer = huggingface_tokenizer
+    tokenizer._prompt_format = "default"
+    tokenizer._prompt_config = SimpleNamespace(
+        custom_chat_template="test-template", has_system_role=True
+    )
+    messages = [
+        {"role": "user", "content": "solve"},
+        {"role": "assistant", "content": "2", "reasoning_content": "1 + 1"},
+    ]
+    tools = [{"type": "function", "function": {"name": "python"}}]
+
+    tokens, targets = tokenizer.tokenize_conversation(
+        messages,
+        return_target=True,
+        add_generation_prompt=False,
+        chat_template_kwargs={"tools": tools},
+    )
+
+    np.testing.assert_array_equal(tokens, np.array([11, 12, 13]))
+    np.testing.assert_array_equal(targets, tokens)
+    assert huggingface_tokenizer.apply_chat_template.call_args.kwargs["tools"] == tools
 
 
 def test_sp_tokenizer():


### PR DESCRIPTION
## What does this PR do?

Extend `VarlenDataset` to support the current public `nvidia/Nemotron-SFT-*` text datasets.

- Preserve message metadata, tools, and dataset-provided chat-template kwargs.
- Accept raw pretraining text from `text`, RP2 `raw_content`, and CodeForge `content` fields.
- Normalize OpenAI, legacy function-call, OpenCode tool, structured tool-result, and JSON-encoded Parquet fields.
- Discover and logically join multiple Hugging Face configs and splits.
- Fall back to a cached map-style JSON payload dataset by reading raw JSONL/Parquet files when Hugging Face Arrow schema casting fails.

## Why?

The existing loader assumed one `train` split and string-only message content. That changed tool-aware tokenization and could not load repositories with thematic splits, OpenCode tool-result blocks, JSON-encoded tool calls, or heterogeneous schemas such as Math-v4.

## Scope

This covers the 16 current public `nvidia/Nemotron-SFT-*` text repositories and their 67 configs/splits, plus RP2 and CodeForge raw-text schemas. Multimodal/VLM datasets remain out of scope for this text-only loader.

## Validation

- Streamed one real Hub sample from all 67 configs/splits across the 16 repositories.
- Normalized and tokenized all 67 samples with the Qwen3-30B-A3B chat template (239 to 104,948 tokens).
- Exercised the raw JSONL/Parquet fallback with real Agentic-v2, Math-v4, and SWE-v3 data.
- Audited all 32,768 rows in the Math-v3 benchmark snapshot and completed the existing fixed-CP4 and dynamic-CP 100-iteration runs without NaNs or skipped iterations.
- Added unit coverage for RP2/CodeForge field detection, alias priority, validation, and local JSONL loading.
- Python 3.11 compile checks, schema invariant smoke tests, and `git diff --check` pass locally; the full formatter and pytest suite run in CI.

Pending: GB200 pytest could not be scheduled because the Slurm controller was unavailable.