### PR TITLE
[DeepSeek-V4] Tighten fused backward parity tolerance

### DIFF
--- a/tests/unit_tests/transformer/experimental_attention_variant/test_dsv4_hybrid_native_parity.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_dsv4_hybrid_native_parity.py
@@ -58,19 +58,18 @@ _SEED = 1234
 #   forward output.
 #
 # Each constant covers the worst case across the whole parametrization for its
-# (path, direction) bucket. Values sit ~1.3-2.5x above the measured worst-case
-# drift over the full matrix (variant x ratio x seqlen x segment-layout); the
-# forward buckets have wide headroom (the layer output is a well-averaged
-# quantity), the backward buckets are near their physical floor:
+# (path, direction) bucket. The previous 2e-2 fused-backward budget covered
+# ``attn_sink`` drift caused by an in-place inverse RoPE mutation of the output
+# retained for DSA backward. With that output preserved by #5526, the remaining
+# backward floor is set by compressor / indexer gradients:
 #   * fused-fwd    worst ~8e-4  (layer ``out``)                       -> 2e-3
-#   * fused-bwd    worst ~1.6e-2 (``core_attention.attn_sink`` — a per-head
-#                  scalar grad with no spatial averaging; the binding param)  -> 2e-2
+#   * fused-bwd    compressor / indexer grads, ratio > 1             -> 3e-3
 #   * unfused-fwd  worst ~7e-4  (layer ``out``)                       -> 1.5e-3
 #   * unfused-bwd  worst ~2e-3  (compressor / indexer grads, ratio > 1) -> 3e-3
 # A real positioning/aggregation regression collapses cosine far below these
 # floors, so the budgets still trip on genuine bugs.
 _FUSED_FWD_SIMILARITY_EPS = 2e-3
-_FUSED_BWD_SIMILARITY_EPS = 2e-2
+_FUSED_BWD_SIMILARITY_EPS = 3e-3
 _UNFUSED_FWD_SIMILARITY_EPS = 1.5e-3
 _UNFUSED_BWD_SIMILARITY_EPS = 3e-3
 


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do ?

Tightens the DeepSeek-V4 hybrid fused-backward parity tolerance from `2e-2` to `3e-3` now that #5526 preserves the raw attention output retained for DSA backward.

## Issue tracking

Linked issue: Related to #5526

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Test plan

- [x] Full `test_dsv4_hybrid_native_parity.py` parametrization (`138 passed`, `0 skipped`; all collected node IDs, no `-k` filter)
- [x] `tools/autoformat.sh`
