### PR TITLE
Integrate experimental Megatron FSDP v2 with MCore

### DIFF
--- a/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
+++ b/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
@@ -13,8 +13,11 @@
 # limitations under the License.
 
 import logging
+import os
 import random
 from typing import Dict, List, Optional, Tuple, Type
+
+__all__ = ["FullyShardedDataParallel"]
 
 try:
     import einops
@@ -51,6 +54,12 @@ try:
         MegatronFSDP,
         MixedPrecisionPolicy,
     )
+    from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
+        Flat,
+        Placements,
+        fully_shard,
+    )
+    from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.module import FsdpModule
 
     HAVE_MEGATRON_FSDP = True
 except ImportError as import_megatron_fsdp_error:
@@ -60,7 +69,7 @@ except ImportError as import_megatron_fsdp_error:
 logger = logging.getLogger(__name__)
 
 
-class FullyShardedDataParallel(_BaseDataParallel):
+class FullyShardedDataParallelV1(_BaseDataParallel):
     """
     Fully Sharded Data Parallel (FSDP) wrapper for the Megatron model.
     """
@@ -112,7 +121,7 @@ class FullyShardedDataParallel(_BaseDataParallel):
         config: TransformerConfig,
         ddp_config: DistributedDataParallelConfig,
         module: torch.nn.Module,
-        fsdp_unit_modules: Optional[List[torch.nn.Module]] = None,
+        fsdp_unit_modules: Optional[List[Type[torch.nn.Module]]] = None,
         disable_bucketing: bool = False,
         device: Optional[torch.device] = None,
         pg_collection: Optional[ProcessGroupCollection] = None,
@@ -481,6 +490,194 @@ class FullyShardedDataParallel(_BaseDataParallel):
             broadcast_list = [None]
         torch.distributed.broadcast_object_list(broadcast_list, group=self.tp_group, group_src=0)
         _load_rng_state_dict(broadcast_list[0])
+
+
+class FullyShardedDataParallelV2(_BaseDataParallel):
+    """Experimental Megatron FSDP v2 wrapper for the Megatron model."""
+
+    def __init__(
+        self,
+        config: TransformerConfig,
+        ddp_config: DistributedDataParallelConfig,
+        module: torch.nn.Module,
+        fsdp_unit_modules: Optional[List[Type[torch.nn.Module]]] = None,
+        disable_bucketing: bool = False,
+        device: Optional[torch.device] = None,
+        pg_collection: Optional[ProcessGroupCollection] = None,
+    ):
+        if not HAVE_MEGATRON_FSDP:
+            raise IMPORT_MEGATRON_FSDP_ERROR
+        if pg_collection is None:
+            pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+        self._validate_config(config, ddp_config, module, pg_collection, disable_bucketing)
+
+        if has_config_logger_enabled(config):
+            log_config_to_disk(config, locals(), prefix=type(self).__name__)
+
+        self.ddp_config = ddp_config
+
+        if fsdp_unit_modules is None:
+            fsdp_unit_modules = [TransformerLayer, MoETransformerLayer, MambaLayer]
+
+        log_single_rank(
+            logger, logging.INFO, f'Setting up DistributedDataParallel with config {ddp_config}'
+        )
+        self.mp_policy = MixedPrecisionPolicy(
+            main_params_dtype=ddp_config.megatron_fsdp_main_params_dtype,
+            main_grads_dtype=ddp_config.megatron_fsdp_main_grads_dtype,
+            grad_comm_dtype=ddp_config.megatron_fsdp_grad_comm_dtype,
+        )
+        log_single_rank(
+            logger,
+            logging.INFO,
+            f'Setting up Megatron-FSDP MixedPrecisionPolicy with config {self.mp_policy}',
+        )
+
+        if device is None:
+            device = next(module.parameters()).device
+        dp_group = pg_collection.dp_cp
+        mesh = DeviceMesh.from_group(dp_group, device_type=device.type, mesh_dim_names=("dp",))
+        placements = Placements(
+            dp_axes=[0], parameter=[Flat()], gradient=[Flat()], optimizer=[Flat()]
+        )
+        for submodule in reversed(list(module.modules())):
+            if submodule is module:
+                continue
+            if any(isinstance(submodule, module_type) for module_type in fsdp_unit_modules):
+                fully_shard(
+                    submodule,
+                    mesh=mesh,
+                    placements=placements,
+                    mixed_precision_policy=self.mp_policy,
+                )
+        fully_shard(module, mesh=mesh, placements=placements, mixed_precision_policy=self.mp_policy)
+        super().__init__(config=config, module=module)
+
+        # MCore optimizer wrappers consume reduced gradients through ``main_grad``.
+        # The v2 parameter groups own that persistent storage, so expose DTensor
+        # views of it on the resting sharded parameters without allocating copies.
+        for fsdp_module in module.modules():
+            if not isinstance(fsdp_module, FsdpModule):
+                continue
+            for parameter_group in fsdp_module.parameter_groups():
+                if parameter_group.main_grad is None:
+                    continue
+                for index, parameter in enumerate(parameter_group.sharded_parameters):
+                    parameter.main_grad = parameter_group.main_grad.get_dtensor(index)
+
+    @staticmethod
+    def _validate_config(
+        config: TransformerConfig,
+        ddp_config: DistributedDataParallelConfig,
+        module: torch.nn.Module,
+        pg_collection: ProcessGroupCollection,
+        disable_bucketing: bool,
+    ) -> None:
+        """Reject features outside the initial MFSDP v2 integration scope."""
+        if disable_bucketing:
+            raise ValueError("MFSDP v2 does not support disabling bucketing.")
+        if not hasattr(pg_collection, 'dp_cp'):
+            raise ValueError("MFSDP v2 requires an explicit dp_cp process group.")
+
+        parallel_sizes = {
+            "tensor model parallelism": config.tensor_model_parallel_size,
+            "pipeline model parallelism": config.pipeline_model_parallel_size,
+            "context parallelism": config.context_parallel_size,
+            "expert model parallelism": config.expert_model_parallel_size,
+        }
+        unsupported_parallelism = [name for name, size in parallel_sizes.items() if size != 1]
+        if unsupported_parallelism:
+            raise ValueError(
+                "MFSDP v2 currently requires TP=PP=CP=EP=1; unsupported: "
+                + ", ".join(unsupported_parallelism)
+            )
+
+        for group_name in ("tp", "pp", "cp", "ep"):
+            group = getattr(pg_collection, group_name, None)
+            if group is not None and group.size() != 1:
+                raise ValueError(
+                    f"MFSDP v2 currently requires {group_name.upper()} process-group size 1, "
+                    f"got {group.size()}."
+                )
+
+        if getattr(config, "num_moe_experts", None) is not None or any(
+            not getattr(parameter, "allreduce", True) for parameter in module.parameters()
+        ):
+            raise ValueError("MFSDP v2 does not currently support expert parameters.")
+        if ddp_config.data_parallel_sharding_strategy != "optim_grads_params":
+            raise ValueError(
+                "MFSDP v2 requires data_parallel_sharding_strategy='optim_grads_params'."
+            )
+        if ddp_config.num_distributed_optimizer_instances != 1:
+            raise ValueError("MFSDP v2 does not currently support HSDP.")
+        if ddp_config.outer_dp_sharding_strategy != "no_shard":
+            raise ValueError("MFSDP v2 does not currently support outer DP sharding.")
+        if ddp_config.overlap_grad_reduce or ddp_config.overlap_param_gather:
+            raise ValueError("MFSDP v2 does not currently support communication overlap modes.")
+        if config.gradient_accumulation_fusion:
+            raise ValueError("MFSDP v2 does not currently support gradient accumulation fusion.")
+        if config.calculate_per_token_loss:
+            raise ValueError("MFSDP v2 does not currently support per-token loss normalization.")
+        if config.fp8 or config.fp4 or ddp_config.fp8_param_gather or ddp_config.fp4_param_gather:
+            raise ValueError("MFSDP v2 does not currently support FP8 or FP4.")
+        if config.cuda_graph_impl != "none" or ddp_config.megatron_fsdp_cuda_graph_mode:
+            raise ValueError("MFSDP v2 does not currently support CUDA graphs.")
+
+        unsupported_v1_options = {
+            "fsdp_double_buffer": ddp_config.fsdp_double_buffer,
+            "fsdp_db_use_persist_buf_on_alloc_fail": (
+                ddp_config.fsdp_db_use_persist_buf_on_alloc_fail
+            ),
+            "fsdp_all_gather_in_start_param_sync=False": (
+                not ddp_config.fsdp_all_gather_in_start_param_sync
+            ),
+            "nccl_ub": ddp_config.nccl_ub,
+            "disable_symmetric_registration": ddp_config.disable_symmetric_registration,
+            "fsdp_manual_registration": ddp_config.fsdp_manual_registration,
+            "delay_wgrad_compute": ddp_config.delay_wgrad_compute,
+            "suggested_communication_unit_size": (
+                ddp_config.suggested_communication_unit_size is not None
+            ),
+            "num_buckets": ddp_config.num_buckets is not None,
+            "megatron_fsdp_use_decoupled_grad": ddp_config.megatron_fsdp_use_decoupled_grad,
+            "megatron_fsdp_enable_fine_grained_param_gather": (
+                ddp_config.megatron_fsdp_enable_fine_grained_param_gather
+            ),
+            "megatron_fsdp_max_pool_double_buffer": (
+                ddp_config.megatron_fsdp_max_pool_double_buffer
+            ),
+        }
+        enabled_v1_options = [name for name, enabled in unsupported_v1_options.items() if enabled]
+        if enabled_v1_options:
+            raise ValueError(
+                "MFSDP v2 does not support v1 tuning options: " + ", ".join(enabled_v1_options)
+            )
+
+    def start_param_sync(self, *unused, **unused_kwargs) -> None:
+        """MFSDP v2 gathers parameters from its forward pre-hook."""
+
+    def start_grad_sync(self, *unused, **unused_kwargs) -> None:
+        """MFSDP v2 reduces gradients during backward."""
+
+    def finish_grad_sync(self, *unused, **unused_kwargs) -> None:
+        """MFSDP v2 gradient reduction is complete when backward returns."""
+
+    def synchronize_param_gather(self, *unused, **unused_kwargs) -> None:
+        """MFSDP v2 parameter gathers complete inside module hooks."""
+
+    def broadcast_params(self) -> None:
+        """Reject parameter broadcast, which is unsupported by MFSDP v2."""
+        raise NotImplementedError(
+            "MFSDP v2 does not support parameter broadcast/data-parallel random initialization."
+        )
+
+    def stop_communication(self) -> None:
+        """MFSDP v2 communication is complete when backward returns."""
+
+
+FullyShardedDataParallel = (
+    FullyShardedDataParallelV2 if os.getenv("USE_MFSDP_V2") == "1" else FullyShardedDataParallelV1
+)
 
 
 def _get_hsdp_tp_mesh(outer_fsdp_dp_group, dp_cp_group, tp_group, ep_size=1):

--- a/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
+++ b/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
@@ -559,7 +559,7 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
         for fsdp_module in module.modules():
             if not isinstance(fsdp_module, FsdpModule):
                 continue
-            for parameter_group in fsdp_module.parameter_groups():
+            for parameter_group in fsdp_module.parameter_groups:
                 if parameter_group.main_grad is None:
                     continue
                 for index, parameter in enumerate(parameter_group.sharded_parameters):

--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -57,6 +57,7 @@ from megatron.core.optimizer_param_scheduler import (
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.transformer.fsdp_dtensor_checkpoint import get_global_unique_param_name
 
+from ..distributed.fsdp.mcore_fsdp_adapter import FullyShardedDataParallelV2
 from ..distributed.param_and_grad_buffer import _ParamAndGradBuffer
 from ..transformer.module import MegatronModule
 from ..utils import get_model_config, get_pg_rank, get_pg_size, is_te_min_version, log_single_rank
@@ -1032,6 +1033,30 @@ def get_megatron_optimizer(
 
     log_single_rank(logger, logging.INFO, f'Setting up optimizer with config {config}')
 
+    is_mfsdp_v2 = isinstance(model_chunks[0], FullyShardedDataParallelV2)
+    if is_mfsdp_v2:
+        if len(model_chunks) != 1:
+            raise ValueError("MFSDP v2 currently supports exactly one model chunk.")
+        if config.optimizer != "adam":
+            raise ValueError("MFSDP v2 currently supports only Adam/AdamW.")
+        if config.use_distributed_optimizer:
+            raise ValueError("MFSDP v2 does not use Megatron's DistributedOptimizer.")
+        if config.overlap_param_gather_with_optimizer_step:
+            raise ValueError("MFSDP v2 does not support optimizer-step parameter-gather overlap.")
+        unsupported_optimizer_features = {
+            "optimizer CPU offload": config.optimizer_cpu_offload,
+            "precision-aware optimizer": config.use_precision_aware_optimizer,
+            "layer-wise distributed optimizer": config.use_layer_wise_distributed_optimizer,
+            "optimizer CUDA graphs": config.optimizer_cuda_graph,
+        }
+        enabled_optimizer_features = [
+            name for name, enabled in unsupported_optimizer_features.items() if enabled
+        ]
+        if enabled_optimizer_features:
+            raise ValueError(
+                "MFSDP v2 does not currently support " + ", ".join(enabled_optimizer_features) + "."
+            )
+
     # Separate out first model chunk if overlapping param AG with optimizer step.
     if config.overlap_param_gather_with_optimizer_step:
         all_dense_model_chunks = [[model_chunks[0]], model_chunks[1:]]
@@ -1076,14 +1101,20 @@ def get_megatron_optimizer(
         for model_chunk, overlap_param_gather_with_optimizer_step in zip(
             all_dense_model_chunks, overlap_param_gather_with_optimizer_step_flags
         ):
-            param_groups, buffers = _get_param_groups_and_buffers(
-                model_chunk,
-                model_chunk_offset=model_chunk_offset,
-                config=config,
-                config_overrides=config_overrides,
-                filter_fn=lambda g: True,
-                buffer_name='buffers',
-            )
+            if is_mfsdp_v2:
+                param_groups = _get_param_groups(model_chunk, config, config_overrides)
+                buffers = None
+                if any(group['is_expert_parallel'] for group in param_groups):
+                    raise ValueError("MFSDP v2 does not currently support expert parameters.")
+            else:
+                param_groups, buffers = _get_param_groups_and_buffers(
+                    model_chunk,
+                    model_chunk_offset=model_chunk_offset,
+                    config=config,
+                    config_overrides=config_overrides,
+                    filter_fn=lambda g: True,
+                    buffer_name='buffers',
+                )
 
             optimizer_part = _get_megatron_optimizer_based_on_param_groups(
                 config=config,

--- a/tests/test_utils/recipes/h100/unit-tests.yaml
+++ b/tests/test_utils/recipes/h100/unit-tests.yaml
@@ -39,6 +39,10 @@ spec:
     BUCKET="{test_case}"
     UNIT_TEST_REPEAT={n_repeat}
 
+    if [[ "$BUCKET" == tests/unit_tests/distributed/mfsdp_v2/* ]]; then
+        export USE_MFSDP_V2=1
+    fi
+
     if [[ "$TAG" == "latest" ]]; then
         TEST_PATH="/opt/megatron-lm"
     else

--- a/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
@@ -98,10 +98,10 @@ class TestMcoreAdapter:
         # Post-order wrapping gives the selected TransformerLayer its own parameter group;
         # the root FSDP unit should own only the parameters of the remaining Linear module.
         child_parameter_names = {
-            name for group in wrapped.module[0].parameter_groups() for name in group.parameter_names
+            name for group in wrapped.module[0].parameter_groups for name in group.parameter_names
         }
         root_parameter_names = {
-            name for group in wrapped.module.parameter_groups() for name in group.parameter_names
+            name for group in wrapped.module.parameter_groups for name in group.parameter_names
         }
         assert child_parameter_names
         assert root_parameter_names == {"1.weight", "1.bias"}
@@ -129,7 +129,7 @@ class TestMcoreAdapter:
         parameter_groups = [
             parameter_group
             for fsdp_module in fsdp_modules
-            for parameter_group in fsdp_module.parameter_groups()
+            for parameter_group in fsdp_module.parameter_groups
         ]
         for parameter_group in parameter_groups:
             assert parameter_group.main_weight.dtype == torch.float32

--- a/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
@@ -1,0 +1,177 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""MCore adapter and optimizer integration tests for experimental MFSDP v2."""
+
+import pytest
+import torch
+from torch.distributed.tensor import DTensor
+
+from megatron.core.distributed import DistributedDataParallelConfig
+from megatron.core.distributed.fsdp.mcore_fsdp_adapter import FullyShardedDataParallel
+from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.module import FsdpModule
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec
+from megatron.core.optimizer import OptimizerConfig, get_megatron_optimizer
+from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.transformer.transformer_block import TransformerBlock
+from megatron.core.transformer.transformer_config import TransformerConfig
+from megatron.core.transformer.transformer_layer import TransformerLayer
+from tests.unit_tests.test_utilities import Utils
+
+
+def _process_groups() -> ProcessGroupCollection:
+    return ProcessGroupCollection.use_mpu_process_groups(
+        required_pgs=["tp", "pp", "mp", "cp", "ep", "tp_ep_pp", "dp", "dp_cp", "expt_dp"]
+    )
+
+
+def _transformer_config(**overrides) -> TransformerConfig:
+    values = dict(
+        num_layers=1,
+        hidden_size=16,
+        num_attention_heads=4,
+        ffn_hidden_size=32,
+        bf16=True,
+        params_dtype=torch.bfloat16,
+        attention_dropout=0.0,
+        hidden_dropout=0.0,
+    )
+    values.update(overrides)
+    return TransformerConfig(**values)
+
+
+def _ddp_config(**overrides) -> DistributedDataParallelConfig:
+    values = dict(
+        use_megatron_fsdp=True,
+        use_distributed_optimizer=False,
+        data_parallel_sharding_strategy="optim_grads_params",
+        megatron_fsdp_main_params_dtype=torch.float32,
+        megatron_fsdp_main_grads_dtype=torch.float32,
+    )
+    values.update(overrides)
+    return DistributedDataParallelConfig(**values)
+
+
+def _build_layer(
+    config: TransformerConfig, pg_collection: ProcessGroupCollection
+) -> TransformerLayer:
+    layer = TransformerLayer(
+        config=config,
+        submodules=get_gpt_layer_local_spec().submodules,
+        layer_number=1,
+        pg_collection=pg_collection,
+        add_layer_offset=False,
+    )
+    return layer.to(dtype=config.params_dtype)
+
+
+class TestMcoreAdapter:
+    """Exercise a dense MCore transformer block over two data-parallel ranks."""
+
+    def setup_method(self):
+        Utils.initialize_model_parallel(1, 1)
+        if torch.distributed.get_world_size() != 2:
+            pytest.skip("MFSDP v2 MCore integration test requires exactly two ranks.")
+        model_parallel_cuda_manual_seed(1234)
+
+    def teardown_method(self):
+        Utils.destroy_model_parallel()
+
+    def test_wraps_fsdp_unit_modules_before_root(self):
+        config = _transformer_config()
+        pg_collection = _process_groups()
+        layer = _build_layer(config, pg_collection)
+        model = torch.nn.Sequential(layer, torch.nn.Linear(config.hidden_size, config.hidden_size))
+        model = model.to(device="cuda", dtype=config.params_dtype)
+
+        wrapped = FullyShardedDataParallel(
+            config=config,
+            ddp_config=_ddp_config(),
+            module=model,
+            fsdp_unit_modules=[TransformerLayer],
+            pg_collection=pg_collection,
+        )
+
+        assert isinstance(wrapped.module, FsdpModule)
+        assert isinstance(wrapped.module[0], FsdpModule)
+
+        # Post-order wrapping gives the selected TransformerLayer its own parameter group;
+        # the root FSDP unit should own only the parameters of the remaining Linear module.
+        child_parameter_names = {
+            name for group in wrapped.module[0].parameter_groups() for name in group.parameter_names
+        }
+        root_parameter_names = {
+            name for group in wrapped.module.parameter_groups() for name in group.parameter_names
+        }
+        assert child_parameter_names
+        assert root_parameter_names == {"1.weight", "1.bias"}
+
+    def test_build_train_and_step(self):
+        config = _transformer_config(num_layers=2)
+        pg_collection = _process_groups()
+        model = FullyShardedDataParallel(
+            config=config,
+            ddp_config=_ddp_config(),
+            module=TransformerBlock(
+                config=config, spec=get_gpt_layer_local_spec(), pg_collection=pg_collection
+            ).to(device="cuda", dtype=config.params_dtype),
+        )
+
+        assert isinstance(model.module, TransformerBlock)
+        assert isinstance(model.module, FsdpModule)
+        assert callable(model.module.forward)
+        assert callable(model.module.sharded_state_dict)
+        assert all(isinstance(parameter, DTensor) for parameter in model.module.parameters())
+        fsdp_modules = [
+            module for module in model.module.modules() if isinstance(module, FsdpModule)
+        ]
+        assert len([module for module in fsdp_modules if isinstance(module, TransformerLayer)]) == 2
+        parameter_groups = [
+            parameter_group
+            for fsdp_module in fsdp_modules
+            for parameter_group in fsdp_module.parameter_groups()
+        ]
+        for parameter_group in parameter_groups:
+            assert parameter_group.main_weight.dtype == torch.float32
+            assert parameter_group.main_grad is not None
+            assert parameter_group.main_grad.dtype == torch.float32
+
+        optimizer = get_megatron_optimizer(
+            OptimizerConfig(
+                optimizer="adam",
+                lr=1.0e-3,
+                bf16=True,
+                params_dtype=torch.bfloat16,
+                use_distributed_optimizer=False,
+                clip_grad=0.0,
+            ),
+            [model],
+            use_gloo_process_groups=False,
+            pg_collection=pg_collection,
+        )
+        assert optimizer.config.use_distributed_optimizer is False
+
+        initial_buffers = [group.main_weight.local_buffer.clone() for group in parameter_groups]
+        losses = []
+        for _ in range(3):
+            optimizer.zero_grad(set_to_none=True)
+            hidden_states = torch.randn(
+                8, 2, config.hidden_size, device="cuda", dtype=torch.bfloat16
+            )
+            output = model(hidden_states=hidden_states, attention_mask=None)
+            loss = output.float().square().mean()
+            assert torch.isfinite(loss)
+            loss.backward()
+            success, _, _ = optimizer.step()
+            assert success
+            losses.append(loss.detach())
+
+        gathered_losses = [torch.empty_like(torch.stack(losses)) for _ in range(2)]
+        torch.distributed.all_gather(gathered_losses, torch.stack(losses))
+        torch.testing.assert_close(gathered_losses[0], gathered_losses[1])
+        assert all(isinstance(parameter, DTensor) for parameter in model.parameters())
+        buffer_changes = [
+            (initial - group.main_weight.local_buffer).abs().max().item()
+            for initial, group in zip(initial_buffers, parameter_groups)
+        ]
+        assert any(change > 0 for change in buffer_changes)


### PR DESCRIPTION
## Summary

- preserve the existing Megatron FSDP implementation as `FullyShardedDataParallelV1`
- add an experimental `FullyShardedDataParallelV2` adapter over the `fully_shard` API
- select the public `FullyShardedDataParallel` alias with `USE_MFSDP_V2`
- wrap configured FSDP unit module types in post-order before wrapping the root model
- connect V2's sharded parameters and persistent gradients to the existing MCore optimizer setup
- add two-rank structural and train/step coverage plus an H100 unit-test recipe

## Motivation

The experimental Megatron FSDP V2 implementation exposes a composable `fully_shard` API but does not yet have a minimal MCore data-parallel adapter. This change adds that integration while keeping V1 as the default and rejecting unsupported V2 configurations early.

## Validation

- `BASE_REF=main CHECK_ONLY=true SKIP_DOCS=true bash tools/autoformat.sh`
  - Black, isort, pylint, and Ruff pass
  - `mypy` is not installed in the local environment; the project script treats that as optional
- `python -m py_compile` on the changed Python files
- two-rank post-order wrapping test passes on both ranks
- the two-layer forward/backward/step test passes on rank 1, but rank 0 currently fails its parameter-update assertion because TE FusedAdam silently skips an optimizer group whose final local tensor is empty

The fused-optimizer failure is independently reproducible without Megatron or DTensor: https://gist.github.com/wujingyue/c8b5f59a2e9ccfcd19f303b7a20ae59b

This PR is intentionally a draft while the V2-specific optimizer path is refined.
