### PR TITLE
Unset NCCL overrides for MFSDP v2 tests

### DIFF
--- a/tests/unit_tests/distributed/mfsdp_v2/conftest.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/conftest.py
@@ -21,6 +21,12 @@ class DistributedSetup:
 @pytest.fixture(scope="function")
 def distributed_setup() -> Iterator[DistributedSetup]:
     """Read torchrun rank state and set up this rank's local device."""
+    # Some MFSDP v2 tests are sensitive to NCCL algorithm/channel choices. Clear
+    # CI launcher overrides before init_device_mesh initializes NCCL communicators
+    # so this bucket uses NCCL settings closer to production.
+    os.environ.pop("NCCL_MAX_NCHANNELS", None)
+    os.environ.pop("NCCL_NVLS_ENABLE", None)
+
     if "RANK" not in os.environ or "WORLD_SIZE" not in os.environ:
         pytest.skip("Not running under torchrun. Use torchrun to run this test file.")
 


### PR DESCRIPTION
## Summary
- Leave the unit-test runner NCCL memory-saving overrides unchanged for the general CI path.
- Clear `NCCL_MAX_NCHANNELS` and `NCCL_NVLS_ENABLE` in the MFSDP v2 `distributed_setup` fixture before tests initialize `init_device_mesh` / NCCL communicators. Would have caught #5770 earlier.

## Why
`test_symmetric_memory.py` and `test_fully_shard.py` include tests that are sensitive to NCCL algorithm and channel choices. Clearing the CI launcher overrides in the MFSDP v2 fixture makes this bucket exercise NCCL default behavior, which better matches realistic runs.

## Testing
- `bash -n tests/unit_tests/run_ci_test.sh`
- `python -m py_compile tests/unit_tests/distributed/mfsdp_v2/conftest.py`
- `git diff --check`
- `env NCCL_MAX_NCHANNELS=1 NCCL_NVLS_ENABLE=0 uv run --no-sync python -m torch.distributed.run --standalone --nproc-per-node 2 -m pytest -q tests/unit_tests/distributed/mfsdp_v2/test_context.py --tb=short` (`3 passed`)
- Verified with `NCCL_DEBUG=INFO` that the MFSDP v2 fixture path clears both vars before communicator initialization: control run used `1 coll channels`; fixture/pytest path used `4 coll channels` and did not report the env overrides.
- CI requested; expected known failure: `test_overlaps_all_gather_and_compute`.
