### PR TITLE
Exercise nested MFSDP CUDA graph capture

### DIFF
--- a/tests/unit_tests/distributed/mfsdp_v2/test_cuda_graph.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_cuda_graph.py
@@ -4,7 +4,6 @@
 
 import logging
 
-import pytest
 import torch
 from torch import nn
 from torch.distributed.device_mesh import init_device_mesh
@@ -18,6 +17,22 @@ from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
 logger = logging.getLogger(__name__)
 
 
+class NestedModel(nn.Module):
+    """Model with a root FSDP unit and multiple child FSDP units."""
+
+    def __init__(self, dim: int, num_children: int) -> None:
+        super().__init__()
+        self.bias = nn.Parameter(torch.zeros(dim))
+        self.layers = nn.ModuleList([nn.Linear(dim, dim, bias=False) for _ in range(num_children)])
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run through every child layer with a root-owned bias."""
+        x = x + self.bias
+        for layer in self.layers:
+            x = layer(x)
+        return x
+
+
 def _flat_placements() -> Placements:
     return Placements(dp_axes=[0], parameter=[Flat()], gradient=[Flat()], optimizer=[Flat()])
 
@@ -26,20 +41,21 @@ def test_captures_full_iteration(distributed_setup):
     """A full training iteration should be CUDA-graphable."""
     world_size = distributed_setup.world_size
     device = distributed_setup.device
-    if world_size < 2:
-        pytest.skip("This test requires at least 2 ranks.")
 
     mesh = init_device_mesh(device.type, (world_size,))
     torch.manual_seed(1234)
-    model = nn.Linear(4, 2, bias=False).to(device)
+    dim = 8
+    model = NestedModel(dim=dim, num_children=2).to(device)
 
-    fully_shard(model, mesh=mesh, placements=_flat_placements())
+    static_input = torch.eye(dim, device=device)
+    static_target = torch.zeros_like(static_input)
+
+    placements = _flat_placements()
+    for layer in model.layers:
+        fully_shard(layer, mesh=mesh, placements=placements)
+    fully_shard(model, mesh=mesh, placements=placements)
+
     optimizer = torch.optim.SGD(model.parameters(), lr=0.25, foreach=False)
-
-    static_input = torch.eye(4, device=device)
-    static_target = torch.tensor(
-        [[1.0, -0.5], [-0.25, 0.75], [0.5, 0.25], [-0.75, -1.0]], device=device
-    )
 
     def train_iteration() -> torch.Tensor:
         optimizer.zero_grad(set_to_none=False)
@@ -49,22 +65,26 @@ def test_captures_full_iteration(distributed_setup):
         optimizer.step()
         return loss.detach()
 
-    warmup_stream = torch.cuda.Stream()
-    warmup_stream.wait_stream(torch.cuda.current_stream())
-    # Warm up before capture. torch.cuda.graph() uses an internal side stream
-    # when `stream` is omitted, so `stream=` is only needed when callers must
-    # control the capture stream, such as when reusing an explicit stream with
-    # a shared graph memory pool across captures.
-    with torch.cuda.stream(warmup_stream):
+    capture_stream = torch.cuda.Stream()
+    capture_stream.wait_stream(torch.cuda.current_stream())
+
+    # Warmup
+    with torch.cuda.stream(capture_stream):
+        # See: https://docs.nvidia.com/dl-cuda-graph/troubleshooting/memory-issues.html#gradient-accumulator-cross-stream-memory-growth
+        # Warm up on the same stream used for capture so autograd's accumulation
+        # path does not create cross-stream gradient-memory growth.
         # The first warmup installs the reusable sharded gradient views; subsequent
         # iterations zero them in place for CUDA graph replay.
         for _ in range(3):
             train_iteration()
 
+    # Capture
     graph = torch.cuda.CUDAGraph()
-    with torch.cuda.graph(graph):
+    with torch.cuda.graph(graph, stream=capture_stream):
         static_loss = train_iteration()
+    torch.cuda.current_stream().wait_stream(capture_stream)
 
+    # Replay
     losses = []
     for _ in range(5):
         graph.replay()


### PR DESCRIPTION
## Summary
- exercise CUDA graph capture through a nested MFSDP module structure
- warm up and capture on the same explicit CUDA stream, with the NVIDIA graph memory guidance linked in the test comment
- keep the single-rank path runnable while multi-rank CI exercises real collective overlap

## Testing
- `uv run --no-sync isort tests/unit_tests/distributed/mfsdp_v2/test_cuda_graph.py`
- `python -m py_compile tests/unit_tests/distributed/mfsdp_v2/test_cuda_graph.py`
- `env -u NCCL_MAX_NCHANNELS -u NCCL_NVLS_ENABLE uv run --no-sync python -m torch.distributed.run --standalone --nproc-per-node 2 -m pytest -q tests/unit_tests/distributed/mfsdp_v2/test_cuda_graph.py::test_captures_full_iteration --tb=short`
- `env -u NCCL_MAX_NCHANNELS -u NCCL_NVLS_ENABLE nsys profile --force-overwrite=true --trace=cuda,nvtx,osrt,cublas --sample=none --cpuctxsw=none --output=artifacts/nsys/test_captures_full_iteration uv run --no-sync python -m torch.distributed.run --standalone --nproc-per-node 2 -m pytest -q tests/unit_tests/distributed/mfsdp_v2/test_cuda_graph.py::test_captures_full_iteration --tb=short`