### PR TITLE
Guard MLA YARN RoPE against cos/sin dim mismatch

### DIFF
--- a/megatron/core/fusions/fused_mla_yarn_rope_apply.py
+++ b/megatron/core/fusions/fused_mla_yarn_rope_apply.py
@@ -251,6 +251,8 @@ class ApplyMLARotaryEmbQ(torch.autograd.Function):
         assert q.stride(-1) == 1
         assert cos.is_contiguous()
         assert sin.is_contiguous()
+        assert cos.shape[-1] == emb_dim
+        assert sin.shape[-1] == emb_dim
         assert headdim == qk_head_dim + emb_dim
         assert emb_dim % 4 == 0
 
@@ -628,6 +630,8 @@ class ApplyMLARotaryEmbKV(torch.autograd.Function):
         assert k_pos_emb.stride(-1) == 1
         assert cos.is_contiguous()
         assert sin.is_contiguous()
+        assert cos.shape[-1] == emb_dim
+        assert sin.shape[-1] == emb_dim
         assert emb_dim % 4 == 0
 
         o_key = kv.new_empty(total_seqlen, nheads, emb_dim + k_dim)


### PR DESCRIPTION
# What does this PR do ?

Assert that `cos`/`sin` have `emb_dim` as their last dimension in the fused MLA
YARN RoPE forward passes, so a mismatched rotary cache fails loudly instead of
reading out of bounds.

## Motivation

The Q and KV Triton kernels in `fused_mla_yarn_rope_apply.py` index `COS`/`SIN`
with a stride of `emb_dim` (`tl.load(COS + token_idx * emb_dim + ...)`), but
`forward()` never checked that the supplied `cos`/`sin` actually have `emb_dim`
as their last dimension. When a caller passes a shorter `cos`/`sin` — e.g. a
rotary cache whose width was misconfigured upstream — the kernel reads past the
end of the buffer and returns arbitrary garbage, which surfaces as
nondeterministic NaNs far downstream and is expensive to localize.

This was hit in practice during DeepSeek-V4 SFT with `apply_rope_fusion=True`
(nondeterministic NaN at iteration 2). The addition of a one-line shape guard
was suggested in the DeepSeek-V4 tracking issue.

Related: #4468

## Change

In both `ApplyMLARotaryEmbQ.forward` and `ApplyMLARotaryEmbKV.forward`, next to
the existing `cos.is_contiguous()` / `sin.is_contiguous()` asserts:

```python
assert cos.shape[-1] == emb_dim
assert sin.shape[-1] == emb_dim
```

The guard runs before the kernel launch, so the misconfiguration raises an
`AssertionError` at the call site instead of producing OOB reads.

## Pre-checks

- [x] I have run the autoformatter on my PR
- [ ] I have added relevant unit tests
- [ ] I have added relevant documentation
