### PR TITLE
Add initial MCore integration for MFSDP v2

### DIFF
--- a/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
+++ b/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
@@ -541,6 +541,8 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
         )
         for submodule in reversed(list(module.modules())):
             if submodule is module:
+                # The root is always sharded after selected child units so it is not
+                # wrapped twice when its type also appears in fsdp_unit_modules.
                 continue
             if any(isinstance(submodule, module_type) for module_type in fsdp_unit_modules):
                 fully_shard(
@@ -566,17 +568,19 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
         if not hasattr(pg_collection, 'dp_cp'):
             raise ValueError("MFSDP v2 requires an explicit dp_cp process group.")
 
-        parallel_sizes = {
-            "tensor model parallelism": config.tensor_model_parallel_size,
-            "pipeline model parallelism": config.pipeline_model_parallel_size,
-            "context parallelism": config.context_parallel_size,
-            "expert model parallelism": config.expert_model_parallel_size,
-        }
-        unsupported_parallelism = [name for name, size in parallel_sizes.items() if size != 1]
-        if unsupported_parallelism:
+        unsupported_parallelisms = [
+            "tensor_model_parallel_size",
+            "pipeline_model_parallel_size",
+            "context_parallel_size",
+            "expert_model_parallel_size",
+        ]
+        if any(getattr(config, parallelism) != 1 for parallelism in unsupported_parallelisms):
             raise ValueError(
-                "MFSDP v2 currently requires TP=PP=CP=EP=1; unsupported: "
-                + ", ".join(unsupported_parallelism)
+                "MFSDP v2 does not currently support: "
+                + ", ".join(
+                    f"{parallelism}={getattr(config, parallelism)}"
+                    for parallelism in unsupported_parallelisms
+                )
             )
 
         for group_name in ("tp", "pp", "cp", "ep"):

--- a/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
+++ b/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
@@ -13,8 +13,11 @@
 # limitations under the License.
 
 import logging
+import os
 import random
 from typing import Dict, List, Optional, Tuple, Type
+
+__all__ = ["FullyShardedDataParallel"]
 
 try:
     import einops
@@ -51,6 +54,12 @@ try:
         MegatronFSDP,
         MixedPrecisionPolicy,
     )
+    from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
+        Flat,
+        Placements,
+        fully_shard,
+    )
+    from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.module import FsdpModule
 
     HAVE_MEGATRON_FSDP = True
 except ImportError as import_megatron_fsdp_error:
@@ -60,7 +69,7 @@ except ImportError as import_megatron_fsdp_error:
 logger = logging.getLogger(__name__)
 
 
-class FullyShardedDataParallel(_BaseDataParallel):
+class FullyShardedDataParallelV1(_BaseDataParallel):
     """
     Fully Sharded Data Parallel (FSDP) wrapper for the Megatron model.
     """
@@ -112,7 +121,7 @@ class FullyShardedDataParallel(_BaseDataParallel):
         config: TransformerConfig,
         ddp_config: DistributedDataParallelConfig,
         module: torch.nn.Module,
-        fsdp_unit_modules: Optional[List[torch.nn.Module]] = None,
+        fsdp_unit_modules: Optional[List[Type[torch.nn.Module]]] = None,
         disable_bucketing: bool = False,
         device: Optional[torch.device] = None,
         pg_collection: Optional[ProcessGroupCollection] = None,
@@ -481,6 +490,194 @@ class FullyShardedDataParallel(_BaseDataParallel):
             broadcast_list = [None]
         torch.distributed.broadcast_object_list(broadcast_list, group=self.tp_group, group_src=0)
         _load_rng_state_dict(broadcast_list[0])
+
+
+class FullyShardedDataParallelV2(_BaseDataParallel):
+    """Experimental Megatron FSDP v2 wrapper for the Megatron model."""
+
+    def __init__(
+        self,
+        config: TransformerConfig,
+        ddp_config: DistributedDataParallelConfig,
+        module: torch.nn.Module,
+        fsdp_unit_modules: Optional[List[Type[torch.nn.Module]]] = None,
+        disable_bucketing: bool = False,
+        device: Optional[torch.device] = None,
+        pg_collection: Optional[ProcessGroupCollection] = None,
+    ):
+        if not HAVE_MEGATRON_FSDP:
+            raise IMPORT_MEGATRON_FSDP_ERROR
+        if pg_collection is None:
+            pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+        self._validate_config(config, ddp_config, module, pg_collection, disable_bucketing)
+
+        if has_config_logger_enabled(config):
+            log_config_to_disk(config, locals(), prefix=type(self).__name__)
+
+        self.ddp_config = ddp_config
+
+        if fsdp_unit_modules is None:
+            fsdp_unit_modules = [TransformerLayer, MoETransformerLayer, MambaLayer]
+
+        log_single_rank(
+            logger, logging.INFO, f'Setting up DistributedDataParallel with config {ddp_config}'
+        )
+        self.mp_policy = MixedPrecisionPolicy(
+            main_params_dtype=ddp_config.megatron_fsdp_main_params_dtype,
+            main_grads_dtype=ddp_config.megatron_fsdp_main_grads_dtype,
+            grad_comm_dtype=ddp_config.megatron_fsdp_grad_comm_dtype,
+        )
+        log_single_rank(
+            logger,
+            logging.INFO,
+            f'Setting up Megatron-FSDP MixedPrecisionPolicy with config {self.mp_policy}',
+        )
+
+        if device is None:
+            device = next(module.parameters()).device
+        dp_group = pg_collection.dp_cp
+        mesh = DeviceMesh.from_group(dp_group, device_type=device.type, mesh_dim_names=("dp",))
+        placements = Placements(
+            dp_axes=[0], parameter=[Flat()], gradient=[Flat()], optimizer=[Flat()]
+        )
+        for submodule in reversed(list(module.modules())):
+            if submodule is module:
+                continue
+            if any(isinstance(submodule, module_type) for module_type in fsdp_unit_modules):
+                fully_shard(
+                    submodule,
+                    mesh=mesh,
+                    placements=placements,
+                    mixed_precision_policy=self.mp_policy,
+                )
+        fully_shard(module, mesh=mesh, placements=placements, mixed_precision_policy=self.mp_policy)
+        super().__init__(config=config, module=module)
+
+        # MCore optimizer wrappers consume reduced gradients through ``main_grad``.
+        # The v2 parameter groups own that persistent storage, so expose DTensor
+        # views of it on the resting sharded parameters without allocating copies.
+        for fsdp_module in module.modules():
+            if not isinstance(fsdp_module, FsdpModule):
+                continue
+            for parameter_group in fsdp_module.parameter_groups():
+                if parameter_group.main_grad is None:
+                    continue
+                for index, parameter in enumerate(parameter_group.sharded_parameters):
+                    parameter.main_grad = parameter_group.main_grad.get_dtensor(index)
+
+    @staticmethod
+    def _validate_config(
+        config: TransformerConfig,
+        ddp_config: DistributedDataParallelConfig,
+        module: torch.nn.Module,
+        pg_collection: ProcessGroupCollection,
+        disable_bucketing: bool,
+    ) -> None:
+        """Reject features outside the initial MFSDP v2 integration scope."""
+        if disable_bucketing:
+            raise ValueError("MFSDP v2 does not support disabling bucketing.")
+        if not hasattr(pg_collection, 'dp_cp'):
+            raise ValueError("MFSDP v2 requires an explicit dp_cp process group.")
+
+        parallel_sizes = {
+            "tensor model parallelism": config.tensor_model_parallel_size,
+            "pipeline model parallelism": config.pipeline_model_parallel_size,
+            "context parallelism": config.context_parallel_size,
+            "expert model parallelism": config.expert_model_parallel_size,
+        }
+        unsupported_parallelism = [name for name, size in parallel_sizes.items() if size != 1]
+        if unsupported_parallelism:
+            raise ValueError(
+                "MFSDP v2 currently requires TP=PP=CP=EP=1; unsupported: "
+                + ", ".join(unsupported_parallelism)
+            )
+
+        for group_name in ("tp", "pp", "cp", "ep"):
+            group = getattr(pg_collection, group_name, None)
+            if group is not None and group.size() != 1:
+                raise ValueError(
+                    f"MFSDP v2 currently requires {group_name.upper()} process-group size 1, "
+                    f"got {group.size()}."
+                )
+
+        if getattr(config, "num_moe_experts", None) is not None or any(
+            not getattr(parameter, "allreduce", True) for parameter in module.parameters()
+        ):
+            raise ValueError("MFSDP v2 does not currently support expert parameters.")
+        if ddp_config.data_parallel_sharding_strategy != "optim_grads_params":
+            raise ValueError(
+                "MFSDP v2 requires data_parallel_sharding_strategy='optim_grads_params'."
+            )
+        if ddp_config.num_distributed_optimizer_instances != 1:
+            raise ValueError("MFSDP v2 does not currently support HSDP.")
+        if ddp_config.outer_dp_sharding_strategy != "no_shard":
+            raise ValueError("MFSDP v2 does not currently support outer DP sharding.")
+        if ddp_config.overlap_grad_reduce or ddp_config.overlap_param_gather:
+            raise ValueError("MFSDP v2 does not currently support communication overlap modes.")
+        if config.gradient_accumulation_fusion:
+            raise ValueError("MFSDP v2 does not currently support gradient accumulation fusion.")
+        if config.calculate_per_token_loss:
+            raise ValueError("MFSDP v2 does not currently support per-token loss normalization.")
+        if config.fp8 or config.fp4 or ddp_config.fp8_param_gather or ddp_config.fp4_param_gather:
+            raise ValueError("MFSDP v2 does not currently support FP8 or FP4.")
+        if config.cuda_graph_impl != "none" or ddp_config.megatron_fsdp_cuda_graph_mode:
+            raise ValueError("MFSDP v2 does not currently support CUDA graphs.")
+
+        unsupported_v1_options = {
+            "fsdp_double_buffer": ddp_config.fsdp_double_buffer,
+            "fsdp_db_use_persist_buf_on_alloc_fail": (
+                ddp_config.fsdp_db_use_persist_buf_on_alloc_fail
+            ),
+            "fsdp_all_gather_in_start_param_sync=False": (
+                not ddp_config.fsdp_all_gather_in_start_param_sync
+            ),
+            "nccl_ub": ddp_config.nccl_ub,
+            "disable_symmetric_registration": ddp_config.disable_symmetric_registration,
+            "fsdp_manual_registration": ddp_config.fsdp_manual_registration,
+            "delay_wgrad_compute": ddp_config.delay_wgrad_compute,
+            "suggested_communication_unit_size": (
+                ddp_config.suggested_communication_unit_size is not None
+            ),
+            "num_buckets": ddp_config.num_buckets is not None,
+            "megatron_fsdp_use_decoupled_grad": ddp_config.megatron_fsdp_use_decoupled_grad,
+            "megatron_fsdp_enable_fine_grained_param_gather": (
+                ddp_config.megatron_fsdp_enable_fine_grained_param_gather
+            ),
+            "megatron_fsdp_max_pool_double_buffer": (
+                ddp_config.megatron_fsdp_max_pool_double_buffer
+            ),
+        }
+        enabled_v1_options = [name for name, enabled in unsupported_v1_options.items() if enabled]
+        if enabled_v1_options:
+            raise ValueError(
+                "MFSDP v2 does not support v1 tuning options: " + ", ".join(enabled_v1_options)
+            )
+
+    def start_param_sync(self, *unused, **unused_kwargs) -> None:
+        """MFSDP v2 gathers parameters from its forward pre-hook."""
+
+    def start_grad_sync(self, *unused, **unused_kwargs) -> None:
+        """MFSDP v2 reduces gradients during backward."""
+
+    def finish_grad_sync(self, *unused, **unused_kwargs) -> None:
+        """MFSDP v2 gradient reduction is complete when backward returns."""
+
+    def synchronize_param_gather(self, *unused, **unused_kwargs) -> None:
+        """MFSDP v2 parameter gathers complete inside module hooks."""
+
+    def broadcast_params(self) -> None:
+        """Reject parameter broadcast, which is unsupported by MFSDP v2."""
+        raise NotImplementedError(
+            "MFSDP v2 does not support parameter broadcast/data-parallel random initialization."
+        )
+
+    def stop_communication(self) -> None:
+        """MFSDP v2 communication is complete when backward returns."""
+
+
+FullyShardedDataParallel = (
+    FullyShardedDataParallelV2 if os.getenv("USE_MFSDP_V2") == "1" else FullyShardedDataParallelV1
+)
 
 
 def _get_hsdp_tp_mesh(outer_fsdp_dp_group, dp_cp_group, tp_group, ep_size=1):

--- a/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
+++ b/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
@@ -59,7 +59,6 @@ try:
         Placements,
         fully_shard,
     )
-    from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.module import FsdpModule
 
     HAVE_MEGATRON_FSDP = True
 except ImportError as import_megatron_fsdp_error:
@@ -552,18 +551,6 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
                 )
         fully_shard(module, mesh=mesh, placements=placements, mixed_precision_policy=self.mp_policy)
         super().__init__(config=config, module=module)
-
-        # MCore optimizer wrappers consume reduced gradients through ``main_grad``.
-        # The v2 parameter groups own that persistent storage, so expose DTensor
-        # views of it on the resting sharded parameters without allocating copies.
-        for fsdp_module in module.modules():
-            if not isinstance(fsdp_module, FsdpModule):
-                continue
-            for parameter_group in fsdp_module.parameter_groups:
-                if parameter_group.main_grad is None:
-                    continue
-                for index, parameter in enumerate(parameter_group.sharded_parameters):
-                    parameter.main_grad = parameter_group.main_grad.get_dtensor(index)
 
     @staticmethod
     def _validate_config(

--- a/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
+++ b/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
@@ -664,7 +664,7 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
 
 
 FullyShardedDataParallel = (
-    FullyShardedDataParallelV2 if os.getenv("USE_MFSDP_V2") == "1" else FullyShardedDataParallelV1
+    FullyShardedDataParallelV2 if os.getenv("MFSDP_VERSION") == "2" else FullyShardedDataParallelV1
 )
 
 

--- a/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
+++ b/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
@@ -614,35 +614,32 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
         if config.cuda_graph_impl != "none" or ddp_config.megatron_fsdp_cuda_graph_mode:
             raise ValueError("MFSDP v2 does not currently support CUDA graphs.")
 
-        unsupported_v1_options = {
-            "fsdp_double_buffer": ddp_config.fsdp_double_buffer,
-            "fsdp_db_use_persist_buf_on_alloc_fail": (
-                ddp_config.fsdp_db_use_persist_buf_on_alloc_fail
-            ),
-            "fsdp_all_gather_in_start_param_sync=False": (
-                not ddp_config.fsdp_all_gather_in_start_param_sync
-            ),
-            "nccl_ub": ddp_config.nccl_ub,
-            "disable_symmetric_registration": ddp_config.disable_symmetric_registration,
-            "fsdp_manual_registration": ddp_config.fsdp_manual_registration,
-            "delay_wgrad_compute": ddp_config.delay_wgrad_compute,
-            "suggested_communication_unit_size": (
-                ddp_config.suggested_communication_unit_size is not None
-            ),
-            "num_buckets": ddp_config.num_buckets is not None,
-            "megatron_fsdp_use_decoupled_grad": ddp_config.megatron_fsdp_use_decoupled_grad,
-            "megatron_fsdp_enable_fine_grained_param_gather": (
-                ddp_config.megatron_fsdp_enable_fine_grained_param_gather
-            ),
-            "megatron_fsdp_max_pool_double_buffer": (
-                ddp_config.megatron_fsdp_max_pool_double_buffer
-            ),
-        }
-        enabled_v1_options = [name for name, enabled in unsupported_v1_options.items() if enabled]
-        if enabled_v1_options:
+        if ddp_config.fsdp_double_buffer:
+            raise ValueError("MFSDP v2 does not support fsdp_double_buffer.")
+        if ddp_config.fsdp_db_use_persist_buf_on_alloc_fail:
+            raise ValueError("MFSDP v2 does not support fsdp_db_use_persist_buf_on_alloc_fail.")
+        if ddp_config.fsdp_all_gather_in_start_param_sync:
+            raise ValueError("MFSDP v2 does not support fsdp_all_gather_in_start_param_sync.")
+        if ddp_config.nccl_ub:
+            raise ValueError("MFSDP v2 does not support nccl_ub.")
+        if ddp_config.disable_symmetric_registration:
+            raise ValueError("MFSDP v2 does not support disable_symmetric_registration.")
+        if ddp_config.fsdp_manual_registration:
+            raise ValueError("MFSDP v2 does not support fsdp_manual_registration.")
+        if ddp_config.delay_wgrad_compute:
+            raise ValueError("MFSDP v2 does not support delay_wgrad_compute.")
+        if ddp_config.suggested_communication_unit_size is not None:
+            raise ValueError("MFSDP v2 does not support suggested_communication_unit_size.")
+        if ddp_config.num_buckets is not None:
+            raise ValueError("MFSDP v2 does not support num_buckets.")
+        if ddp_config.megatron_fsdp_use_decoupled_grad:
+            raise ValueError("MFSDP v2 does not support megatron_fsdp_use_decoupled_grad.")
+        if ddp_config.megatron_fsdp_enable_fine_grained_param_gather:
             raise ValueError(
-                "MFSDP v2 does not support v1 tuning options: " + ", ".join(enabled_v1_options)
+                "MFSDP v2 does not support megatron_fsdp_enable_fine_grained_param_gather."
             )
+        if ddp_config.megatron_fsdp_max_pool_double_buffer:
+            raise ValueError("MFSDP v2 does not support megatron_fsdp_max_pool_double_buffer.")
 
     def start_param_sync(self, *unused, **unused_kwargs) -> None:
         """MFSDP v2 gathers parameters from its forward pre-hook."""

--- a/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
+++ b/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
@@ -559,7 +559,7 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
         for fsdp_module in module.modules():
             if not isinstance(fsdp_module, FsdpModule):
                 continue
-            for parameter_group in fsdp_module.parameter_groups():
+            for parameter_group in fsdp_module.parameter_groups:
                 if parameter_group.main_grad is None:
                     continue
                 for index, parameter in enumerate(parameter_group.sharded_parameters):

--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -1051,19 +1051,16 @@ def get_megatron_optimizer(
             raise ValueError("MFSDP v2 does not currently support loss scaling.")
         if config.overlap_param_gather_with_optimizer_step:
             raise ValueError("MFSDP v2 does not support optimizer-step parameter-gather overlap.")
-        unsupported_optimizer_features = {
-            "optimizer CPU offload": config.optimizer_cpu_offload,
-            "precision-aware optimizer": config.use_precision_aware_optimizer,
-            "layer-wise distributed optimizer": config.use_layer_wise_distributed_optimizer,
-            "optimizer CUDA graphs": config.optimizer_cuda_graph,
-        }
-        enabled_optimizer_features = [
-            name for name, enabled in unsupported_optimizer_features.items() if enabled
-        ]
-        if enabled_optimizer_features:
+        if config.optimizer_cpu_offload:
+            raise ValueError("MFSDP v2 does not currently support optimizer CPU offload.")
+        if config.use_precision_aware_optimizer:
+            raise ValueError("MFSDP v2 does not currently support precision-aware optimizer.")
+        if config.use_layer_wise_distributed_optimizer:
             raise ValueError(
-                "MFSDP v2 does not currently support " + ", ".join(enabled_optimizer_features) + "."
+                "MFSDP v2 does not currently support layer-wise distributed optimizer."
             )
+        if config.optimizer_cuda_graph:
+            raise ValueError("MFSDP v2 does not currently support optimizer CUDA graphs.")
 
     # Separate out first model chunk if overlapping param AG with optimizer step.
     if config.overlap_param_gather_with_optimizer_step:

--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -1021,9 +1021,12 @@ def get_megatron_optimizer(
 
     check_config_overrides_consistency(config, config_overrides)
 
+    is_mfsdp_v2 = isinstance(model_chunks[0], FullyShardedDataParallelV2)
     # TODO: the standard and emerging optimizer paths handle pg_collection differently;
     # unify them so both use a single pg_collection-based flow.
     if config.optimizer not in ('adam', 'sgd'):
+        if is_mfsdp_v2:
+            raise ValueError("MFSDP v2 currently supports only standard Adam/AdamW/SGD.")
         return _get_megatron_emerging_optimizer(
             config=config,
             model_chunks=model_chunks,
@@ -1033,14 +1036,13 @@ def get_megatron_optimizer(
 
     log_single_rank(logger, logging.INFO, f'Setting up optimizer with config {config}')
 
-    is_mfsdp_v2 = isinstance(model_chunks[0], FullyShardedDataParallelV2)
     if is_mfsdp_v2:
         if len(model_chunks) != 1:
             raise ValueError("MFSDP v2 currently supports exactly one model chunk.")
-        if config.optimizer != "adam":
-            raise ValueError("MFSDP v2 currently supports only Adam/AdamW.")
-        if config.use_distributed_optimizer:
-            raise ValueError("MFSDP v2 does not use Megatron's DistributedOptimizer.")
+        if not config.use_distributed_optimizer:
+            raise ValueError("MFSDP v2 requires Megatron's DistributedOptimizer wrapper.")
+        if not config.bf16 or config.fp16 or config.loss_scale is not None:
+            raise ValueError("MFSDP v2 currently supports only unscaled BF16 training.")
         if config.overlap_param_gather_with_optimizer_step:
             raise ValueError("MFSDP v2 does not support optimizer-step parameter-gather overlap.")
         unsupported_optimizer_features = {
@@ -1103,9 +1105,21 @@ def get_megatron_optimizer(
         ):
             if is_mfsdp_v2:
                 param_groups = _get_param_groups(model_chunk, config, config_overrides)
+                # TE FusedAdam can skip pending updates when a group ends in an empty tensor:
+                # https://github.com/NVIDIA/TransformerEngine/issues/3207.
+                # Empty local shards have no optimizer state or data to update, so omit them.
+                for param_group in param_groups:
+                    param_group['params'] = [
+                        parameter
+                        for parameter in param_group['params']
+                        if parameter.to_local().numel() > 0
+                    ]
+                param_groups = [
+                    param_group for param_group in param_groups if param_group['params']
+                ]
+                # MFSDP v2 owns its sharded parameter and gradient storage, so
+                # DistributedOptimizer returns before initializing per_model_buffers.
                 buffers = None
-                if any(group['is_expert_parallel'] for group in param_groups):
-                    raise ValueError("MFSDP v2 does not currently support expert parameters.")
             else:
                 param_groups, buffers = _get_param_groups_and_buffers(
                     model_chunk,

--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -57,6 +57,7 @@ from megatron.core.optimizer_param_scheduler import (
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.transformer.fsdp_dtensor_checkpoint import get_global_unique_param_name
 
+from ..distributed.fsdp.mcore_fsdp_adapter import FullyShardedDataParallelV2
 from ..distributed.param_and_grad_buffer import _ParamAndGradBuffer
 from ..transformer.module import MegatronModule
 from ..utils import get_model_config, get_pg_rank, get_pg_size, is_te_min_version, log_single_rank
@@ -1032,6 +1033,30 @@ def get_megatron_optimizer(
 
     log_single_rank(logger, logging.INFO, f'Setting up optimizer with config {config}')
 
+    is_mfsdp_v2 = isinstance(model_chunks[0], FullyShardedDataParallelV2)
+    if is_mfsdp_v2:
+        if len(model_chunks) != 1:
+            raise ValueError("MFSDP v2 currently supports exactly one model chunk.")
+        if config.optimizer != "adam":
+            raise ValueError("MFSDP v2 currently supports only Adam/AdamW.")
+        if config.use_distributed_optimizer:
+            raise ValueError("MFSDP v2 does not use Megatron's DistributedOptimizer.")
+        if config.overlap_param_gather_with_optimizer_step:
+            raise ValueError("MFSDP v2 does not support optimizer-step parameter-gather overlap.")
+        unsupported_optimizer_features = {
+            "optimizer CPU offload": config.optimizer_cpu_offload,
+            "precision-aware optimizer": config.use_precision_aware_optimizer,
+            "layer-wise distributed optimizer": config.use_layer_wise_distributed_optimizer,
+            "optimizer CUDA graphs": config.optimizer_cuda_graph,
+        }
+        enabled_optimizer_features = [
+            name for name, enabled in unsupported_optimizer_features.items() if enabled
+        ]
+        if enabled_optimizer_features:
+            raise ValueError(
+                "MFSDP v2 does not currently support " + ", ".join(enabled_optimizer_features) + "."
+            )
+
     # Separate out first model chunk if overlapping param AG with optimizer step.
     if config.overlap_param_gather_with_optimizer_step:
         all_dense_model_chunks = [[model_chunks[0]], model_chunks[1:]]
@@ -1076,14 +1101,20 @@ def get_megatron_optimizer(
         for model_chunk, overlap_param_gather_with_optimizer_step in zip(
             all_dense_model_chunks, overlap_param_gather_with_optimizer_step_flags
         ):
-            param_groups, buffers = _get_param_groups_and_buffers(
-                model_chunk,
-                model_chunk_offset=model_chunk_offset,
-                config=config,
-                config_overrides=config_overrides,
-                filter_fn=lambda g: True,
-                buffer_name='buffers',
-            )
+            if is_mfsdp_v2:
+                param_groups = _get_param_groups(model_chunk, config, config_overrides)
+                buffers = None
+                if any(group['is_expert_parallel'] for group in param_groups):
+                    raise ValueError("MFSDP v2 does not currently support expert parameters.")
+            else:
+                param_groups, buffers = _get_param_groups_and_buffers(
+                    model_chunk,
+                    model_chunk_offset=model_chunk_offset,
+                    config=config,
+                    config_overrides=config_overrides,
+                    filter_fn=lambda g: True,
+                    buffer_name='buffers',
+                )
 
             optimizer_part = _get_megatron_optimizer_based_on_param_groups(
                 config=config,

--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -754,6 +754,9 @@ def _get_megatron_emerging_optimizer(
         eopt_name = bare_name
         use_layer_wise = True
 
+    if isinstance(model_chunks[0], FullyShardedDataParallelV2):
+        raise ValueError("MFSDP v2 with emerging optimizers is not currently validated.")
+
     if not HAVE_EMERGING_OPTIMIZERS:
         raise ImportError(
             f"emerging-optimizers package is required for optimizer='{eopt_name}'. "
@@ -1025,8 +1028,6 @@ def get_megatron_optimizer(
     # TODO: the standard and emerging optimizer paths handle pg_collection differently;
     # unify them so both use a single pg_collection-based flow.
     if config.optimizer not in ('adam', 'sgd'):
-        if is_mfsdp_v2:
-            raise ValueError("MFSDP v2 currently supports only standard Adam/AdamW/SGD.")
         return _get_megatron_emerging_optimizer(
             config=config,
             model_chunks=model_chunks,
@@ -1041,8 +1042,13 @@ def get_megatron_optimizer(
             raise ValueError("MFSDP v2 currently supports exactly one model chunk.")
         if not config.use_distributed_optimizer:
             raise ValueError("MFSDP v2 requires Megatron's DistributedOptimizer wrapper.")
-        if not config.bf16 or config.fp16 or config.loss_scale is not None:
-            raise ValueError("MFSDP v2 currently supports only unscaled BF16 training.")
+        if config.fp16:
+            raise ValueError(
+                "MFSDP v2 does not currently support FP16 training because FP16 triggers "
+                "loss unscale."
+            )
+        if config.loss_scale is not None:
+            raise ValueError("MFSDP v2 does not currently support loss scaling.")
         if config.overlap_param_gather_with_optimizer_step:
             raise ValueError("MFSDP v2 does not support optimizer-step parameter-gather overlap.")
         unsupported_optimizer_features = {

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -665,8 +665,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         self.distributed_optimizer_instance_id = distributed_optimizer_instance_id
 
         assert (
-            self._uses_mfsdp_v2()
-            or isinstance(optimizer, (Adam, torch.optim.AdamW, HybridDeviceOptimizer))
+            isinstance(optimizer, (Adam, torch.optim.AdamW, HybridDeviceOptimizer))
             or optimizer is None
         ), (
             "Only Adam and HybridDeviceOptimizer currently supported, "

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -47,6 +47,7 @@ from ..dist_checkpointing.mapping import (
     ShardedTensorFactory,
 )
 from ..dist_checkpointing.utils import extract_sharded_tensors_and_factories
+from ..distributed.fsdp.mcore_fsdp_adapter import FullyShardedDataParallelV2
 from ..distributed.param_and_grad_buffer import (
     _ParamAndGradBuffer,
     group_params_for_buffers,
@@ -664,7 +665,8 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         self.distributed_optimizer_instance_id = distributed_optimizer_instance_id
 
         assert (
-            isinstance(optimizer, (Adam, torch.optim.AdamW, HybridDeviceOptimizer))
+            self._uses_mfsdp_v2()
+            or isinstance(optimizer, (Adam, torch.optim.AdamW, HybridDeviceOptimizer))
             or optimizer is None
         ), (
             "Only Adam and HybridDeviceOptimizer currently supported, "
@@ -679,6 +681,12 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
 
         self.is_stub_optimizer = False
         if self.ddp_config.use_megatron_fsdp:
+            if self._uses_mfsdp_v2():
+                # V1 sets this marker inside MegatronFSDP's param-and-grad buffer setup. V2
+                # bypasses that buffer path, so mark optimizer params here for generic MCore
+                # gradient statistics to consume the local shard of MFSDP DTensor gradients.
+                for parameter in self.get_parameters():
+                    parameter.__fsdp_param__ = True
             # Megatron-FSDP will manage optimizer weights and gradients.
             return
 
@@ -760,6 +768,10 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
             self.optimizer.param_groups = [g["orig_group"] for g in self.opt_group_ranges]
             self.optimizer.load_state_dict(self.optimizer.state_dict())
 
+    def _uses_mfsdp_v2(self) -> bool:
+        """Whether MFSDP v2 owns this optimizer's parameter and gradient shards."""
+        return isinstance(self.model_chunks[0], FullyShardedDataParallelV2)
+
     def _get_model_param_range_map(self, param: torch.nn.Parameter):
         """
         Given a model param, get the index sub-range of the param that this
@@ -786,6 +798,10 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         optimizer state (e.g., exp_avg, exp_avg_sq) are stored in a separate
         checkpoint file by calling 'save_parameter_state()'.
         """
+        if self._uses_mfsdp_v2():
+            # TODO: Add MFSDP v2 optimizer checkpointing support. See #5534.
+            raise NotImplementedError("MFSDP v2 optimizer checkpointing is not yet supported.")
+
         inner_state_dict = self.optimizer.state_dict()
         state_dict = {}
 
@@ -869,6 +885,10 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         - state_order : The index of a parameter within the shared parameter
             list.
         """
+        if self._uses_mfsdp_v2():
+            # TODO: Add MFSDP v2 optimizer checkpointing support. See #5534.
+            raise NotImplementedError("MFSDP v2 optimizer checkpointing is not yet supported.")
+
         if self.ddp_config.use_megatron_fsdp:
             # When using Megatron-FSDP, directly load the optimizer state
             # into the wrapped optimizer.
@@ -1443,6 +1463,9 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
 
         Regular state dict parameters are saved on DP rank 0 and loaded on all ranks.
         """
+        if self._uses_mfsdp_v2():
+            # TODO: Add MFSDP v2 optimizer checkpointing support. See #5534.
+            raise NotImplementedError("MFSDP v2 optimizer checkpointing is not yet supported.")
         if sharding_type is not None:
             log_single_rank(
                 logger,
@@ -2511,6 +2534,16 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         Args:
             set_to_none (bool): if true, set grads to None.
         """
+        if self._uses_mfsdp_v2():
+            if not self.is_stub_optimizer:
+                self.optimizer.zero_grad(set_to_none=set_to_none)
+            # MFSDP v2 filters empty local DTensor shards out of optimizer param groups as
+            # a TE FusedAdam workaround: https://github.com/NVIDIA/TransformerEngine/issues/3207.
+            # A rank with no local optimizer params can still have stale module grads to clear.
+            for model_chunk in self.model_chunks:
+                model_chunk.zero_grad(set_to_none=set_to_none)
+            return
+
         if self.ddp_config.use_megatron_fsdp:
             for model_chunk in self.model_chunks:
                 # Zero gradients managed by Megatron-FSDP.
@@ -2718,6 +2751,11 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
             return
 
         if self.ddp_config.use_megatron_fsdp:
+            if self._uses_mfsdp_v2():
+                # MFSDP v2 currently syncs compute weights from optimized main weights
+                # inside its forward pre-hook. That sync should eventually move here,
+                # after the optimizer step, to avoid repeating it before every microbatch.
+                return
             # Update Megatron-FSDP's compute weights with optimized main weights.
             # If using quantized parameters, this will also perform quantization.
             for model_chunk in self.model_chunks:

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -680,12 +680,6 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
 
         self.is_stub_optimizer = False
         if self.ddp_config.use_megatron_fsdp:
-            if self._uses_mfsdp_v2():
-                # V1 sets this marker inside MegatronFSDP's param-and-grad buffer setup. V2
-                # bypasses that buffer path, so mark optimizer params here for generic MCore
-                # gradient statistics to consume the local shard of MFSDP DTensor gradients.
-                for parameter in self.get_parameters():
-                    parameter.__fsdp_param__ = True
             # Megatron-FSDP will manage optimizer weights and gradients.
             return
 

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1976,6 +1976,10 @@ def get_megatron_ddp_config(args: argparse.Namespace) -> DistributedDataParallel
         kwargs["megatron_fsdp_main_grads_dtype"] = args.megatron_fsdp_main_grads_dtype
         kwargs["megatron_fsdp_grad_comm_dtype"] = args.megatron_fsdp_grad_comm_dtype
         kwargs["megatron_fsdp_use_decoupled_grad"] = args.use_precision_aware_optimizer
+        if args.use_megatron_fsdp and os.getenv("MFSDP_VERSION") == "2":
+            # MFSDP v2 gathers parameters from module hooks rather than the V1
+            # start_param_sync path, so disable the V1-only startup all-gather knob.
+            kwargs["fsdp_all_gather_in_start_param_sync"] = False
         if args.use_megatron_fsdp and args.cuda_graph_impl != "none":
             # Run Megatron-FSDP in CUDA graph-safe mode. Avoids some graph-unsafe host-side
             # operations (such as pointer dereferencing) that can break CUDA graph replay.

--- a/tests/test_utils/recipes/h100/unit-tests.yaml
+++ b/tests/test_utils/recipes/h100/unit-tests.yaml
@@ -39,6 +39,9 @@ spec:
     BUCKET="{test_case}"
     UNIT_TEST_REPEAT={n_repeat}
 
+    # Set this in the bucket launcher, not mfsdp_v2/conftest.py. Pytest imports the
+    # parent unit-test conftest first, which imports megatron.core and resolves the
+    # MFSDP adapter alias before a v2-local conftest could set USE_MFSDP_V2.
     if [[ "$BUCKET" == tests/unit_tests/distributed/mfsdp_v2/* ]]; then
         export USE_MFSDP_V2=1
     fi

--- a/tests/test_utils/recipes/h100/unit-tests.yaml
+++ b/tests/test_utils/recipes/h100/unit-tests.yaml
@@ -41,9 +41,9 @@ spec:
 
     # Set this in the bucket launcher, not mfsdp_v2/conftest.py. Pytest imports the
     # parent unit-test conftest first, which imports megatron.core and resolves the
-    # MFSDP adapter alias before a v2-local conftest could set USE_MFSDP_V2.
+    # MFSDP adapter alias before a v2-local conftest could set MFSDP_VERSION.
     if [[ "$BUCKET" == tests/unit_tests/distributed/mfsdp_v2/* ]]; then
-        export USE_MFSDP_V2=1
+        export MFSDP_VERSION=2
     fi
 
     if [[ "$TAG" == "latest" ]]; then

--- a/tests/test_utils/recipes/h100/unit-tests.yaml
+++ b/tests/test_utils/recipes/h100/unit-tests.yaml
@@ -39,6 +39,10 @@ spec:
     BUCKET="{test_case}"
     UNIT_TEST_REPEAT={n_repeat}
 
+    if [[ "$BUCKET" == tests/unit_tests/distributed/mfsdp_v2/* ]]; then
+        export USE_MFSDP_V2=1
+    fi
+
     if [[ "$TAG" == "latest" ]]; then
         TEST_PATH="/opt/megatron-lm"
     else

--- a/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
@@ -2,16 +2,16 @@
 
 """MCore adapter and optimizer integration tests for experimental MFSDP v2."""
 
+from dataclasses import replace
+
 import pytest
 import torch
-from torch.distributed.tensor import DTensor
 
 from megatron.core.distributed import DistributedDataParallelConfig
 from megatron.core.distributed.fsdp.mcore_fsdp_adapter import FullyShardedDataParallel
 from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.module import FsdpModule
 from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec
 from megatron.core.optimizer import OptimizerConfig, get_megatron_optimizer
-from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.transformer_block import TransformerBlock
 from megatron.core.transformer.transformer_config import TransformerConfig
@@ -19,50 +19,19 @@ from megatron.core.transformer.transformer_layer import TransformerLayer
 from tests.unit_tests.test_utilities import Utils
 
 
-def _process_groups() -> ProcessGroupCollection:
-    return ProcessGroupCollection.use_mpu_process_groups(
-        required_pgs=["tp", "pp", "mp", "cp", "ep", "tp_ep_pp", "dp", "dp_cp", "expt_dp"]
-    )
-
-
-def _transformer_config(**overrides) -> TransformerConfig:
-    values = dict(
-        num_layers=1,
-        hidden_size=16,
-        num_attention_heads=4,
-        ffn_hidden_size=32,
-        bf16=True,
-        params_dtype=torch.bfloat16,
-        attention_dropout=0.0,
-        hidden_dropout=0.0,
-    )
-    values.update(overrides)
-    return TransformerConfig(**values)
-
-
-def _ddp_config(**overrides) -> DistributedDataParallelConfig:
-    values = dict(
-        use_megatron_fsdp=True,
-        use_distributed_optimizer=False,
-        data_parallel_sharding_strategy="optim_grads_params",
-        megatron_fsdp_main_params_dtype=torch.float32,
-        megatron_fsdp_main_grads_dtype=torch.float32,
-    )
-    values.update(overrides)
-    return DistributedDataParallelConfig(**values)
-
-
-def _build_layer(
-    config: TransformerConfig, pg_collection: ProcessGroupCollection
-) -> TransformerLayer:
-    layer = TransformerLayer(
+def _build_layer(config: TransformerConfig) -> TransformerLayer:
+    return TransformerLayer(
         config=config,
         submodules=get_gpt_layer_local_spec().submodules,
         layer_number=1,
-        pg_collection=pg_collection,
         add_layer_offset=False,
     )
-    return layer.to(dtype=config.params_dtype)
+
+
+def _build_block(config: TransformerConfig) -> TransformerBlock:
+    return TransformerBlock(config=config, spec=get_gpt_layer_local_spec()).to(
+        device="cuda", dtype=config.params_dtype
+    )
 
 
 class TestMcoreAdapter:
@@ -78,18 +47,31 @@ class TestMcoreAdapter:
         Utils.destroy_model_parallel()
 
     def test_wraps_fsdp_unit_modules_before_root(self):
-        config = _transformer_config()
-        pg_collection = _process_groups()
-        layer = _build_layer(config, pg_collection)
+        config = TransformerConfig(
+            num_layers=1,
+            hidden_size=16,
+            num_attention_heads=4,
+            ffn_hidden_size=32,
+            bf16=True,
+            params_dtype=torch.bfloat16,
+            attention_dropout=0.0,
+            hidden_dropout=0.0,
+        )
+        layer = _build_layer(config)
         model = torch.nn.Sequential(layer, torch.nn.Linear(config.hidden_size, config.hidden_size))
         model = model.to(device="cuda", dtype=config.params_dtype)
 
         wrapped = FullyShardedDataParallel(
             config=config,
-            ddp_config=_ddp_config(),
+            ddp_config=DistributedDataParallelConfig(
+                use_megatron_fsdp=True,
+                use_distributed_optimizer=True,
+                data_parallel_sharding_strategy="optim_grads_params",
+                megatron_fsdp_main_params_dtype=torch.float32,
+                megatron_fsdp_main_grads_dtype=torch.float32,
+            ),
             module=model,
             fsdp_unit_modules=[TransformerLayer],
-            pg_collection=pg_collection,
         )
 
         assert isinstance(wrapped.module, FsdpModule)
@@ -107,71 +89,79 @@ class TestMcoreAdapter:
         assert root_parameter_names == {"1.weight", "1.bias"}
 
     def test_build_train_and_step(self):
-        config = _transformer_config(num_layers=2)
-        pg_collection = _process_groups()
+        config = TransformerConfig(
+            num_layers=2,
+            hidden_size=16,
+            num_attention_heads=4,
+            ffn_hidden_size=32,
+            bf16=True,
+            params_dtype=torch.bfloat16,
+            attention_dropout=0.0,
+            hidden_dropout=0.0,
+        )
+        reference_model = _build_block(config)
+        model = _build_block(config)
+        model.load_state_dict(reference_model.state_dict())
+        # get_megatron_optimizer expects every model chunk to expose ddp_config. The
+        # reference model remains unwrapped/unsharded, so it cannot use the
+        # DistributedOptimizer path that expects DDP/FSDP buffer metadata.
+        reference_model.ddp_config = DistributedDataParallelConfig(use_distributed_optimizer=False)
+
         model = FullyShardedDataParallel(
             config=config,
-            ddp_config=_ddp_config(),
-            module=TransformerBlock(
-                config=config, spec=get_gpt_layer_local_spec(), pg_collection=pg_collection
-            ).to(device="cuda", dtype=config.params_dtype),
-        )
-
-        assert isinstance(model.module, TransformerBlock)
-        assert isinstance(model.module, FsdpModule)
-        assert callable(model.module.forward)
-        assert callable(model.module.sharded_state_dict)
-        assert all(isinstance(parameter, DTensor) for parameter in model.module.parameters())
-        fsdp_modules = [
-            module for module in model.module.modules() if isinstance(module, FsdpModule)
-        ]
-        assert len([module for module in fsdp_modules if isinstance(module, TransformerLayer)]) == 2
-        parameter_groups = [
-            parameter_group
-            for fsdp_module in fsdp_modules
-            for parameter_group in fsdp_module.parameter_groups
-        ]
-        for parameter_group in parameter_groups:
-            assert parameter_group.main_weight.dtype == torch.float32
-            assert parameter_group.main_grad is not None
-            assert parameter_group.main_grad.dtype == torch.float32
-
-        optimizer = get_megatron_optimizer(
-            OptimizerConfig(
-                optimizer="adam",
-                lr=1.0e-3,
-                bf16=True,
-                params_dtype=torch.bfloat16,
-                use_distributed_optimizer=False,
-                clip_grad=0.0,
+            ddp_config=DistributedDataParallelConfig(
+                use_megatron_fsdp=True,
+                use_distributed_optimizer=True,
+                data_parallel_sharding_strategy="optim_grads_params",
+                megatron_fsdp_main_params_dtype=torch.float32,
+                megatron_fsdp_main_grads_dtype=torch.bfloat16,
             ),
-            [model],
-            use_gloo_process_groups=False,
-            pg_collection=pg_collection,
+            module=model,
         )
-        assert optimizer.config.use_distributed_optimizer is False
 
-        initial_buffers = [group.main_weight.local_buffer.clone() for group in parameter_groups]
+        reference_optimizer_config = OptimizerConfig(
+            optimizer="adam",
+            lr=1.0e-3,
+            weight_decay=0.0,
+            bf16=True,
+            params_dtype=torch.bfloat16,
+            use_distributed_optimizer=False,
+            clip_grad=0.0,
+        )
+        optimizer_config = replace(reference_optimizer_config, use_distributed_optimizer=True)
+        reference_optimizer = get_megatron_optimizer(
+            reference_optimizer_config, [reference_model], use_gloo_process_groups=False
+        )
+        optimizer = get_megatron_optimizer(optimizer_config, [model], use_gloo_process_groups=False)
+
+        batches = [
+            torch.randn(8, 2, config.hidden_size, device="cuda", dtype=torch.bfloat16)
+            for _ in range(3)
+        ]
+
+        reference_losses = []
+        for batch in batches:
+            reference_optimizer.zero_grad(set_to_none=True)
+            reference_output = reference_model(hidden_states=batch, attention_mask=None)
+            reference_loss = reference_output.square().mean()
+            reference_loss.backward()
+            reference_success, _, _ = reference_optimizer.step()
+            assert reference_success
+            reference_losses.append(reference_loss.detach())
+
         losses = []
-        for _ in range(3):
+        for batch in batches:
+            model.zero_grad_buffer()
             optimizer.zero_grad(set_to_none=True)
-            hidden_states = torch.randn(
-                8, 2, config.hidden_size, device="cuda", dtype=torch.bfloat16
-            )
-            output = model(hidden_states=hidden_states, attention_mask=None)
-            loss = output.float().square().mean()
-            assert torch.isfinite(loss)
+            output = model(hidden_states=batch, attention_mask=None)
+            loss = output.square().mean()
             loss.backward()
             success, _, _ = optimizer.step()
             assert success
             losses.append(loss.detach())
 
-        gathered_losses = [torch.empty_like(torch.stack(losses)) for _ in range(2)]
-        torch.distributed.all_gather(gathered_losses, torch.stack(losses))
-        torch.testing.assert_close(gathered_losses[0], gathered_losses[1])
-        assert all(isinstance(parameter, DTensor) for parameter in model.parameters())
-        buffer_changes = [
-            (initial - group.main_weight.local_buffer).abs().max().item()
-            for initial, group in zip(initial_buffers, parameter_groups)
-        ]
-        assert any(change > 0 for change in buffer_changes)
+        losses = torch.stack(losses)
+        reference_losses = torch.stack(reference_losses)
+        assert torch.isfinite(losses).all()
+        assert torch.isfinite(reference_losses).all()
+        torch.testing.assert_close(losses, reference_losses, rtol=1e-3, atol=1e-3)

--- a/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
@@ -98,10 +98,10 @@ class TestMcoreAdapter:
         # Post-order wrapping gives the selected TransformerLayer its own parameter group;
         # the root FSDP unit should own only the parameters of the remaining Linear module.
         child_parameter_names = {
-            name for group in wrapped.module[0].parameter_groups() for name in group.parameter_names
+            name for group in wrapped.module[0].parameter_groups for name in group.parameter_names
         }
         root_parameter_names = {
-            name for group in wrapped.module.parameter_groups() for name in group.parameter_names
+            name for group in wrapped.module.parameter_groups for name in group.parameter_names
         }
         assert child_parameter_names
         assert root_parameter_names == {"1.weight", "1.bias"}
@@ -129,7 +129,7 @@ class TestMcoreAdapter:
         parameter_groups = [
             parameter_group
             for fsdp_module in fsdp_modules
-            for parameter_group in fsdp_module.parameter_groups()
+            for parameter_group in fsdp_module.parameter_groups
         ]
         for parameter_group in parameter_groups:
             assert parameter_group.main_weight.dtype == torch.float32

--- a/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
@@ -1,0 +1,177 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""MCore adapter and optimizer integration tests for experimental MFSDP v2."""
+
+import pytest
+import torch
+from torch.distributed.tensor import DTensor
+
+from megatron.core.distributed import DistributedDataParallelConfig
+from megatron.core.distributed.fsdp.mcore_fsdp_adapter import FullyShardedDataParallel
+from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.module import FsdpModule
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec
+from megatron.core.optimizer import OptimizerConfig, get_megatron_optimizer
+from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.transformer.transformer_block import TransformerBlock
+from megatron.core.transformer.transformer_config import TransformerConfig
+from megatron.core.transformer.transformer_layer import TransformerLayer
+from tests.unit_tests.test_utilities import Utils
+
+
+def _process_groups() -> ProcessGroupCollection:
+    return ProcessGroupCollection.use_mpu_process_groups(
+        required_pgs=["tp", "pp", "mp", "cp", "ep", "tp_ep_pp", "dp", "dp_cp", "expt_dp"]
+    )
+
+
+def _transformer_config(**overrides) -> TransformerConfig:
+    values = dict(
+        num_layers=1,
+        hidden_size=16,
+        num_attention_heads=4,
+        ffn_hidden_size=32,
+        bf16=True,
+        params_dtype=torch.bfloat16,
+        attention_dropout=0.0,
+        hidden_dropout=0.0,
+    )
+    values.update(overrides)
+    return TransformerConfig(**values)
+
+
+def _ddp_config(**overrides) -> DistributedDataParallelConfig:
+    values = dict(
+        use_megatron_fsdp=True,
+        use_distributed_optimizer=False,
+        data_parallel_sharding_strategy="optim_grads_params",
+        megatron_fsdp_main_params_dtype=torch.float32,
+        megatron_fsdp_main_grads_dtype=torch.float32,
+    )
+    values.update(overrides)
+    return DistributedDataParallelConfig(**values)
+
+
+def _build_layer(
+    config: TransformerConfig, pg_collection: ProcessGroupCollection
+) -> TransformerLayer:
+    layer = TransformerLayer(
+        config=config,
+        submodules=get_gpt_layer_local_spec().submodules,
+        layer_number=1,
+        pg_collection=pg_collection,
+        add_layer_offset=False,
+    )
+    return layer.to(dtype=config.params_dtype)
+
+
+class TestMcoreAdapter:
+    """Exercise a dense MCore transformer block over two data-parallel ranks."""
+
+    def setup_method(self):
+        Utils.initialize_model_parallel(1, 1)
+        if torch.distributed.get_world_size() != 2:
+            pytest.skip("MFSDP v2 MCore integration test requires exactly two ranks.")
+        model_parallel_cuda_manual_seed(1234)
+
+    def teardown_method(self):
+        Utils.destroy_model_parallel()
+
+    def test_wraps_fsdp_unit_modules_before_root(self):
+        config = _transformer_config()
+        pg_collection = _process_groups()
+        layer = _build_layer(config, pg_collection)
+        model = torch.nn.Sequential(layer, torch.nn.Linear(config.hidden_size, config.hidden_size))
+        model = model.to(device="cuda", dtype=config.params_dtype)
+
+        wrapped = FullyShardedDataParallel(
+            config=config,
+            ddp_config=_ddp_config(),
+            module=model,
+            fsdp_unit_modules=[TransformerLayer],
+            pg_collection=pg_collection,
+        )
+
+        assert isinstance(wrapped.module, FsdpModule)
+        assert isinstance(wrapped.module[0], FsdpModule)
+
+        # Post-order wrapping gives the selected TransformerLayer its own parameter group;
+        # the root FSDP unit should own only the parameters of the remaining Linear module.
+        child_parameter_names = {
+            name for group in wrapped.module[0].parameter_groups() for name in group.parameter_names
+        }
+        root_parameter_names = {
+            name for group in wrapped.module.parameter_groups() for name in group.parameter_names
+        }
+        assert child_parameter_names
+        assert root_parameter_names == {"1.weight", "1.bias"}
+
+    def test_build_train_and_step(self):
+        config = _transformer_config(num_layers=2)
+        pg_collection = _process_groups()
+        model = FullyShardedDataParallel(
+            config=config,
+            ddp_config=_ddp_config(),
+            module=TransformerBlock(
+                config=config, spec=get_gpt_layer_local_spec(), pg_collection=pg_collection
+            ).to(device="cuda", dtype=config.params_dtype),
+        )
+
+        assert isinstance(model.module, TransformerBlock)
+        assert isinstance(model.module, FsdpModule)
+        assert callable(model.module.forward)
+        assert callable(model.module.sharded_state_dict)
+        assert all(isinstance(parameter, DTensor) for parameter in model.module.parameters())
+        fsdp_modules = [
+            module for module in model.module.modules() if isinstance(module, FsdpModule)
+        ]
+        assert len([module for module in fsdp_modules if isinstance(module, TransformerLayer)]) == 2
+        parameter_groups = [
+            parameter_group
+            for fsdp_module in fsdp_modules
+            for parameter_group in fsdp_module.parameter_groups()
+        ]
+        for parameter_group in parameter_groups:
+            assert parameter_group.main_weight.dtype == torch.float32
+            assert parameter_group.main_grad is not None
+            assert parameter_group.main_grad.dtype == torch.float32
+
+        optimizer = get_megatron_optimizer(
+            OptimizerConfig(
+                optimizer="adam",
+                lr=1.0e-3,
+                bf16=True,
+                params_dtype=torch.bfloat16,
+                use_distributed_optimizer=False,
+                clip_grad=0.0,
+            ),
+            [model],
+            use_gloo_process_groups=False,
+            pg_collection=pg_collection,
+        )
+        assert optimizer.config.use_distributed_optimizer is False
+
+        initial_buffers = [group.main_weight.local_buffer.clone() for group in parameter_groups]
+        losses = []
+        for _ in range(3):
+            optimizer.zero_grad(set_to_none=True)
+            hidden_states = torch.randn(
+                8, 2, config.hidden_size, device="cuda", dtype=torch.bfloat16
+            )
+            output = model(hidden_states=hidden_states, attention_mask=None)
+            loss = output.float().square().mean()
+            assert torch.isfinite(loss)
+            loss.backward()
+            success, _, _ = optimizer.step()
+            assert success
+            losses.append(loss.detach())
+
+        gathered_losses = [torch.empty_like(torch.stack(losses)) for _ in range(2)]
+        torch.distributed.all_gather(gathered_losses, torch.stack(losses))
+        torch.testing.assert_close(gathered_losses[0], gathered_losses[1])
+        assert all(isinstance(parameter, DTensor) for parameter in model.parameters())
+        buffer_changes = [
+            (initial - group.main_weight.local_buffer).abs().max().item()
+            for initial, group in zip(initial_buffers, parameter_groups)
+        ]
+        assert any(change > 0 for change in buffer_changes)

--- a/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
@@ -69,6 +69,7 @@ class TestMcoreAdapter:
                 data_parallel_sharding_strategy="optim_grads_params",
                 megatron_fsdp_main_params_dtype=torch.float32,
                 megatron_fsdp_main_grads_dtype=torch.float32,
+                fsdp_all_gather_in_start_param_sync=False,
             ),
             module=model,
             fsdp_unit_modules=[TransformerLayer],
@@ -115,6 +116,7 @@ class TestMcoreAdapter:
                 data_parallel_sharding_strategy="optim_grads_params",
                 megatron_fsdp_main_params_dtype=torch.float32,
                 megatron_fsdp_main_grads_dtype=torch.bfloat16,
+                fsdp_all_gather_in_start_param_sync=False,
             ),
             module=model,
         )

--- a/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
@@ -136,31 +136,40 @@ class TestMcoreAdapter:
         )
         optimizer = get_megatron_optimizer(optimizer_config, [model], use_gloo_process_groups=False)
 
-        batches = [
-            torch.randn(8, 2, config.hidden_size, device="cuda", dtype=torch.bfloat16)
+        steps = [
+            [
+                torch.randn(8, 2, config.hidden_size, device="cuda", dtype=torch.bfloat16)
+                for _ in range(2)
+            ]
             for _ in range(3)
         ]
 
         reference_losses = []
-        for batch in batches:
+        for microbatches in steps:
             reference_optimizer.zero_grad(set_to_none=True)
-            reference_output = reference_model(hidden_states=batch, attention_mask=None)
-            reference_loss = reference_output.square().mean()
-            reference_loss.backward()
+            microbatch_losses = []
+            for batch in microbatches:
+                reference_output = reference_model(hidden_states=batch, attention_mask=None)
+                reference_loss = reference_output.square().mean()
+                (reference_loss / len(microbatches)).backward()
+                microbatch_losses.append(reference_loss.detach())
             reference_success, _, _ = reference_optimizer.step()
             assert reference_success
-            reference_losses.append(reference_loss.detach())
+            reference_losses.append(torch.stack(microbatch_losses).mean())
 
         losses = []
-        for batch in batches:
+        for microbatches in steps:
             model.zero_grad_buffer()
             optimizer.zero_grad(set_to_none=True)
-            output = model(hidden_states=batch, attention_mask=None)
-            loss = output.square().mean()
-            loss.backward()
+            microbatch_losses = []
+            for batch in microbatches:
+                output = model(hidden_states=batch, attention_mask=None)
+                loss = output.square().mean()
+                (loss / len(microbatches)).backward()
+                microbatch_losses.append(loss.detach())
             success, _, _ = optimizer.step()
             assert success
-            losses.append(loss.detach())
+            losses.append(torch.stack(microbatch_losses).mean())
 
         losses = torch.stack(losses)
         reference_losses = torch.stack(reference_losses)


### PR DESCRIPTION
## Summary

Related to #5614.

This PR adds the initial MCore integration path for experimental MFSDP v2:

- expose `FullyShardedDataParallel` as the MFSDP adapter alias selected by `MFSDP_VERSION=2`
- wrap configured FSDP unit modules before the root module for MFSDP v2
- route MFSDP v2 optimizer setup through MCore `DistributedOptimizer`
- use MFSDP v2 DTensor parameter/gradient shards directly instead of V1 param-and-grad buffers
- disable the V1 startup parameter all-gather knob when `MFSDP_VERSION=2`, since V2 gathers parameters from module hooks
- filter empty local DTensor shards from optimizer param groups while TransformerEngine FusedAdam handling is fixed upstream
- fail fast for unsupported V2 configuration paths, including loss scaling, FP16, V1-only FSDP tuning options, HSDP, FP8/FP4, and unsupported optimizer features
- add distributed unit coverage against an unsharded MCore mixed-precision optimizer reference
- route the H100 unit-test recipe’s MFSDP v2 bucket through `MFSDP_VERSION=2`

## Notes

MFSDP v2 optimizer checkpointing is still intentionally unsupported in this initial path. See #5534.

The empty-shard optimizer filtering is tied to NVIDIA/TransformerEngine#3207.

## Validation

Ran a 5-iteration `pretrain_hybrid.py` DP=2 smoke with the same mock-data/model settings for no FSDP, MFSDP v1, and MFSDP v2. The MFSDP commands pass `--ckpt-format fsdp_dtensor` only because current Megatron-FSDP argument validation requires it; this smoke does not save or load checkpoints.

```bash
COMMON_ARGS=(
  pretrain_hybrid.py
  --mock-data
  --tokenizer-type NullTokenizer
  --vocab-size 1024
  --null-tokenizer-eod-id 0
  --null-tokenizer-pad-id 1
  --bf16
  --no-gradient-accumulation-fusion
  --tensor-model-parallel-size 1
  --pipeline-model-parallel-size 1
  --context-parallel-size 1
  --expert-model-parallel-size 1
  --num-layers 2
  --hidden-size 64
  --ffn-hidden-size 128
  --num-attention-heads 4
  --group-query-attention
  --num-query-groups 4
  --mamba-num-heads 8
  --mamba-head-dim 8
  --mamba-num-groups 8
  --hybrid-layer-pattern 'M*'
  --spec megatron.core.models.hybrid.hybrid_layer_specs hybrid_stack_spec
  --seq-length 16
  --max-position-embeddings 16
  --micro-batch-size 1
  --global-batch-size 2
  --train-iters 5
  --eval-iters 0
  --eval-interval 100000
  --save-interval 100000
  --log-interval 1
  --lr 1e-4
  --min-lr 1e-5
  --lr-decay-style constant
  --weight-decay 0.0
  --clip-grad 0.0
  --attention-backend unfused
  --transformer-impl transformer_engine
  --distributed-backend nccl
)

# no FSDP
CUDA_VISIBLE_DEVICES=0,1 UV_NO_SYNC=1 \
  uv run python -m torch.distributed.run --nproc-per-node 2 \
  "${COMMON_ARGS[@]}" \
  --use-distributed-optimizer

# MFSDP v1
env -u MFSDP_VERSION CUDA_VISIBLE_DEVICES=0,1 UV_NO_SYNC=1 \
  uv run python -m torch.distributed.run --nproc-per-node 2 \
  "${COMMON_ARGS[@]}" \
  --use-megatron-fsdp \
  --use-distributed-optimizer \
  --ckpt-format fsdp_dtensor

# MFSDP v2
MFSDP_VERSION=2 CUDA_VISIBLE_DEVICES=0,1 UV_NO_SYNC=1 \
  uv run python -m torch.distributed.run --nproc-per-node 2 \
  "${COMMON_ARGS[@]}" \
  --use-megatron-fsdp \
  --use-distributed-optimizer \
  --ckpt-format fsdp_dtensor
```

Logged rank-0 `lm loss`:

| iteration | no FSDP | MFSDP v1 | MFSDP v2 |
| ---: | ---: | ---: | ---: |
| 1 | 6.945961 | 6.945961 | 6.945961 |
| 2 | 6.946891 | 6.946891 | 6.946891 |
| 3 | 6.958145 | 6.958147 | 6.958147 |
| 4 | 6.924651 | 6.924606 | 6.924606 |
| 5 | 6.908551 | 6.908510 | 6.908510 |

No skipped or NaN iterations were reported in any run.
