### PR TITLE
Fuse gated RMSNorm in GatedDeltaNet output path

### DIFF
--- a/megatron/core/ssm/gated_delta_net.py
+++ b/megatron/core/ssm/gated_delta_net.py
@@ -53,7 +53,34 @@ except ImportError:
 
     HAVE_FLA = False
 
+# Optional fused gated-RMSNorm kernel. This is a performance-only optimization
+# and is imported separately from the required FLA ops above: an fla build that
+# lacks it must only disable the fusion, never gate core GatedDeltaNet
+# availability (HAVE_FLA).
+try:
+    from fla.modules.fused_norm_gate import rms_norm_gated
+except ImportError:
+    rms_norm_gated = None
+
 logger = logging.getLogger(__name__)
+
+
+def _gated_norm_rmsnorm_compatible(config, out_norm) -> bool:
+    """Whether ``out_norm(x) * silu(gate)`` can be replaced by the fused
+    ``fla.rms_norm_gated`` kernel.
+
+    The fused kernel implements ``rmsnorm(x, weight) * silu(gate)``. It is only a
+    faithful replacement when ``out_norm`` is a plain RMSNorm: it must expose a
+    ``weight`` and must not carry a ``bias`` or the mean-subtraction of a
+    LayerNorm. This deliberately does not fire for the default ``IdentityOp``
+    output norm (no ``weight``) nor for LayerNorm-based norms (``bias`` set).
+    """
+    return (
+        rms_norm_gated is not None
+        and getattr(config, "normalization", None) == "RMSNorm"
+        and getattr(out_norm, "weight", None) is not None
+        and getattr(out_norm, "bias", None) is None
+    )
 
 
 @dataclass
@@ -221,6 +248,26 @@ class GatedDeltaNet(MegatronModule):
             hidden_size=self.value_head_dim,
             eps=self.config.layernorm_epsilon,
         )
+        # Optionally fuse the output RMSNorm with the SiLU output gate into a
+        # single fla kernel (rmsnorm(x, weight) * silu(gate)). Guarded on the
+        # output norm actually being a plain RMSNorm and on a SiLU/swish gate;
+        # any other configuration falls back to the reference two-step path.
+        self._fused_gated_norm = None
+        if self.activation in ("silu", "swish") and _gated_norm_rmsnorm_compatible(
+            self.config, self.out_norm
+        ):
+            self._fused_gated_norm = rms_norm_gated
+            self._fused_gated_norm_eps = getattr(
+                self.out_norm, "eps", self.config.layernorm_epsilon
+            )
+            # Prefer the norm module's own flag; fall back to the config value.
+            self._fused_gated_norm_zero_centered = bool(
+                getattr(
+                    self.out_norm,
+                    "zero_centered_gamma",
+                    getattr(self.config, "layernorm_zero_centered_gamma", False),
+                )
+            )
         self.recompute_norm_out = False
         self.norm_out_checkpoint = None
         if self.config.recompute_granularity == "selective":
@@ -528,7 +575,7 @@ class GatedDeltaNet(MegatronModule):
         return out, out_bias
 
     @jit_fuser
-    def _apply_gated_norm(self, x, gate):
+    def _apply_gated_norm_ref(self, x, gate):
         # Output Norm
         x_dtype = x.dtype
         x = x.reshape(-1, x.shape[-1])
@@ -538,6 +585,28 @@ class GatedDeltaNet(MegatronModule):
         y = y * self.act_fn(gate.float())
         y = y.to(x_dtype)
         return y
+
+    # dtypes the fused fla kernel is known to support; anything else falls back.
+    _FUSED_GATED_NORM_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
+
+    def _apply_gated_norm(self, x, gate):
+        if self._fused_gated_norm is None or x.dtype not in self._FUSED_GATED_NORM_DTYPES:
+            return self._apply_gated_norm_ref(x, gate)
+        # Fused: rmsnorm(x, weight) * silu(gate) in a single kernel.
+        x = x.reshape(-1, x.shape[-1])
+        gate = gate.reshape(-1, gate.shape[-1])
+        weight = self.out_norm.weight
+        # apply-layernorm-1p: effective gamma is (1 + weight); fla uses raw weight.
+        if self._fused_gated_norm_zero_centered:
+            weight = weight + 1.0
+        return self._fused_gated_norm(
+            x,
+            gate,
+            weight,
+            None,
+            activation="swish",
+            eps=self._fused_gated_norm_eps,
+        )
 
     @jit_fuser
     def _prepare_qkv_for_gated_delta_rule(self, qkv, gate, beta, alpha, batch, seq_len):

--- a/tests/unit_tests/ssm/test_gated_delta_net.py
+++ b/tests/unit_tests/ssm/test_gated_delta_net.py
@@ -51,6 +51,13 @@ try:
 except ImportError:
     HAVE_FLA = False
 
+try:
+    from fla.modules.fused_norm_gate import rms_norm_gated  # noqa: F401
+
+    HAVE_FUSED_GATED_NORM = True
+except ImportError:
+    HAVE_FUSED_GATED_NORM = False
+
 # https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/env.html#nccl-multi-rank-gpu-enable
 # NVLS doesn't support one single GPU to be shared by multiple ranks, so disable this in test
 os.environ.update({"NCCL_NVLS_ENABLE": "0"})
@@ -166,6 +173,41 @@ class TestGatedDeltaNet:
             output.dtype == hidden_states.dtype
         ), f"Output dtype {output.dtype=} mismatch with {hidden_states.dtype=}"
 
+    @pytest.mark.skipif(
+        not HAVE_FUSED_GATED_NORM, reason="fused gated-RMSNorm requires fla.rms_norm_gated"
+    )
+    def test_fused_gated_norm_matches_ref(self):
+        # This config (RMSNorm out_norm + SiLU gate) must enable the fused path;
+        # compare the fused _apply_gated_norm against the reference two-step path
+        # on the real module (real out_norm.weight / eps / zero_centered gamma).
+        gdn = self.gdn
+        assert gdn._fused_gated_norm is not None, (
+            "fused gated-RMSNorm should be enabled for RMSNorm out_norm + SiLU gate"
+        )
+        assert gdn._fused_gated_norm_zero_centered is True  # config sets zero-centered
+
+        torch.manual_seed(0)
+        n_tokens, head_dim = 128, gdn.value_head_dim
+        x = torch.randn(n_tokens, head_dim, device="cuda", dtype=torch.bfloat16)
+        gate = torch.randn(n_tokens, head_dim, device="cuda", dtype=torch.bfloat16)
+
+        def run(fn):
+            xr = x.clone().requires_grad_(True)
+            gr = gate.clone().requires_grad_(True)
+            y = fn(xr, gr)
+            y.float().pow(2).sum().backward()
+            return y.float().detach(), xr.grad.float(), gr.grad.float()
+
+        y_f, xg_f, gg_f = run(gdn._apply_gated_norm)  # fused
+        y_r, xg_r, gg_r = run(gdn._apply_gated_norm_ref)  # reference
+
+        def rel(a, b):
+            return (a - b).abs().max().item() / (b.abs().max().item() + 1e-12)
+
+        assert rel(y_f, y_r) < 3e-3, f"forward rel dev {rel(y_f, y_r):.2e}"
+        assert rel(xg_f, xg_r) < 1e-2, f"grad_x rel dev {rel(xg_f, xg_r):.2e}"
+        assert rel(gg_f, gg_r) < 1e-2, f"grad_gate rel dev {rel(gg_f, gg_r):.2e}"
+
     def test_selective_recompute_norm_out(self):
         tp_group = parallel_state.get_tensor_model_parallel_group()
         cp_group = parallel_state.get_context_parallel_group()
@@ -224,6 +266,11 @@ class TestGatedDeltaNet:
         torch.manual_seed(42)
         base_gdn = build_gdn(base_config)
         assert base_gdn.recompute_norm_out is False
+        if HAVE_FUSED_GATED_NORM:
+            # This config enables the fused gated-RMSNorm, so the recompute-vs-
+            # baseline exact-equality checks below also cover the fused path
+            # composing with CheckpointWithoutOutput.
+            assert base_gdn._fused_gated_norm is not None
         base_output, base_grads, base_input_grad = run(base_gdn, hidden_states)
         hidden_states.grad = None
         assert base_gdn.norm_out_checkpoint is None

--- a/tests/unit_tests/ssm/test_gated_delta_net_fused_norm.py
+++ b/tests/unit_tests/ssm/test_gated_delta_net_fused_norm.py
@@ -1,0 +1,145 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Tests for the fused gated-RMSNorm path in GatedDeltaNet.
+
+Two independent concerns are covered:
+
+1. ``_gated_norm_rmsnorm_compatible`` gating logic -- must enable the fused
+   kernel only for a plain RMSNorm output norm and must reject the default
+   ``IdentityOp`` and any LayerNorm-based norm. Pure Python (the rejection
+   cases run without fla; the acceptance case is skipped without fla).
+2. Numerical parity of ``fla.rms_norm_gated`` against the reference two-step
+   ``rmsnorm(x, weight) * silu(gate)`` for both forward and backward, across
+   dtypes and with/without zero-centered gamma. Requires fla + CUDA.
+"""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from megatron.core.ssm.gated_delta_net import _gated_norm_rmsnorm_compatible
+
+try:
+    from fla.modules.fused_norm_gate import rms_norm_gated
+
+    HAVE_FUSED_GATED_NORM = True
+except ImportError:
+    rms_norm_gated = None
+    HAVE_FUSED_GATED_NORM = False
+
+
+class _Cfg:
+    def __init__(self, normalization="RMSNorm"):
+        self.normalization = normalization
+
+
+class _RMSNormLike(torch.nn.Module):
+    """RMSNorm exposes ``weight`` and no ``bias``."""
+
+    def __init__(self, dim):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.ones(dim))
+        self.eps = 1e-5
+
+
+class _LayerNormLike(torch.nn.Module):
+    """LayerNorm exposes both ``weight`` and ``bias``."""
+
+    def __init__(self, dim):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.ones(dim))
+        self.bias = torch.nn.Parameter(torch.zeros(dim))
+        self.eps = 1e-5
+
+
+class _IdentityLike(torch.nn.Module):
+    """The default out_norm (IdentityOp) has neither weight nor bias."""
+
+
+# --------------------------------------------------------------------------- #
+# 1. Gating predicate
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.skipif(not HAVE_FUSED_GATED_NORM, reason="predicate returns False without fla")
+def test_predicate_accepts_rmsnorm():
+    assert _gated_norm_rmsnorm_compatible(_Cfg("RMSNorm"), _RMSNormLike(8)) is True
+
+
+def test_predicate_rejects_identity():
+    # default output norm -> no weight -> must never fuse (would AttributeError).
+    assert _gated_norm_rmsnorm_compatible(_Cfg("RMSNorm"), _IdentityLike()) is False
+
+
+def test_predicate_rejects_layernorm():
+    # LayerNorm carries a bias / mean-subtraction the fused RMSNorm would drop.
+    assert _gated_norm_rmsnorm_compatible(_Cfg("RMSNorm"), _LayerNormLike(8)) is False
+
+
+def test_predicate_rejects_non_rmsnorm_config():
+    # even with a weight-bearing norm, a non-RMSNorm normalization must not fuse.
+    assert _gated_norm_rmsnorm_compatible(_Cfg("LayerNorm"), _RMSNormLike(8)) is False
+
+
+def test_predicate_false_without_fla(monkeypatch):
+    import megatron.core.ssm.gated_delta_net as gdn
+
+    monkeypatch.setattr(gdn, "rms_norm_gated", None)
+    assert gdn._gated_norm_rmsnorm_compatible(_Cfg("RMSNorm"), _RMSNormLike(8)) is False
+
+
+# --------------------------------------------------------------------------- #
+# 2. Numerical parity (forward + backward)
+# --------------------------------------------------------------------------- #
+
+
+def _ref_gated_norm(x, gate, weight, eps, zero_centered):
+    """Reference: rmsnorm(x, gamma) * silu(gate), matching _apply_gated_norm_ref."""
+    x_dtype = x.dtype
+    xf = x.float()
+    gamma = (weight.float() + 1.0) if zero_centered else weight.float()
+    rms = xf * torch.rsqrt(xf.pow(2).mean(-1, keepdim=True) + eps)
+    y = rms * gamma
+    y = y * F.silu(gate.float())
+    return y.to(x_dtype)
+
+
+@pytest.mark.skipif(
+    not (HAVE_FUSED_GATED_NORM and torch.cuda.is_available()),
+    reason="fused parity requires fla + CUDA",
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("zero_centered", [False, True])
+def test_fused_matches_reference_fwd_bwd(dtype, zero_centered):
+    torch.manual_seed(0)
+    T, D, eps = 512, 128, 1e-5
+    # tolerances: fp32 tight; bf16/fp16 within the ~2.5e-4 rel-dev budget observed.
+    ftol = 1e-5 if dtype == torch.float32 else 3e-3
+    gtol = 1e-4 if dtype == torch.float32 else 1e-2
+
+    x = torch.randn(T, D, device="cuda", dtype=dtype)
+    gate = torch.randn(T, D, device="cuda", dtype=dtype)
+    weight = torch.randn(D, device="cuda", dtype=dtype) * 0.1
+
+    def run(fused):
+        xr = x.clone().requires_grad_(True)
+        gr = gate.clone().requires_grad_(True)
+        wr = weight.clone().requires_grad_(True)
+        if fused:
+            w = wr + 1.0 if zero_centered else wr
+            y = rms_norm_gated(xr, gr, w, None, activation="swish", eps=eps)
+        else:
+            y = _ref_gated_norm(xr, gr, wr, eps, zero_centered)
+        y.float().pow(2).sum().backward()
+        return y.float(), xr.grad.float(), gr.grad.float(), wr.grad.float()
+
+    yf, xgf, ggf, wgf = run(True)
+    yr, xgr, ggr, wgr = run(False)
+
+    def rel(a, b):
+        return (a - b).abs().max().item() / (b.abs().max().item() + 1e-12)
+
+    assert rel(yf, yr) < ftol, f"forward rel dev {rel(yf, yr):.2e}"
+    assert rel(xgf, xgr) < gtol, f"grad_x rel dev {rel(xgf, xgr):.2e}"
+    assert rel(ggf, ggr) < gtol, f"grad_gate rel dev {rel(ggf, ggr):.2e}"
+    assert rel(wgf, wgr) < gtol, f"grad_weight rel dev {rel(wgf, wgr):.2e}"


### PR DESCRIPTION
GatedDeltaNet._apply_gated_norm runs the output RMSNorm and the SiLU gating as two separate steps (out_norm(x) then y * silu(gate)). The @jit_fuser decorator cannot fuse across the out_norm module boundary, so the norm result is materialized to global memory and re-read for the gate multiply.

This fuses both into a single kernel via fla's rms_norm_gated, which computes rmsnorm(x, weight) * silu(gate) in one pass. fla is already a dependency of this file (causal_conv1d, l2norm, chunk_gated_delta_rule are imported from it), so no new dependency is introduced; this is the same fused gated-RMSNorm that Mamba/SSM models use in their output path.

The fused path is guarded on the output norm actually being a plain RMSNorm: _gated_norm_rmsnorm_compatible requires config.normalization == "RMSNorm", an exposed weight, and no bias. This rejects the default IdentityOp output norm and any LayerNorm-based norm, both of which fall back to the reference two-step path (kept verbatim as _apply_gated_norm_ref). eps and zero-centered gamma are read from the norm module; the fused call is restricted to fp16/bf16/fp32.

Measured on 8xGB200 (Qwen3.5 35B-A3B, seq 4096, EP8, same-allocation interleaved A/B, 3 valid repeats, median): BF16 +0.74% (379.1 -> 381.9 TFLOP/s/GPU), MXFP8 +0.64%. Single-op numerics vs rmsnorm(x,w)*silu(gate): bf16 max relative deviation 2.5e-4; fixed-seed per-step LM loss over the first 10 steps within 1.5e-4.

- [ ] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
<!-- Add a one line overview of what this PR aims to accomplish. -->

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
