### PR TITLE
inference: use Triton MLA cache append during CUDA graph capture

### DIFF
--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -55,9 +55,27 @@ from .mamba_slot_allocator import MAX_INTERMEDIATE_OFFSETS_PER_REQUEST, MambaSlo
 from .routing_metadata import RoutingMetadata
 
 try:
-    from .fused_kv_append_kernel import triton_append_key_value_cache
+    from .fused_kv_append_kernel import (
+        triton_append_key_value_cache,
+        triton_append_mla_latent_cache,
+    )
 except ImportError:
     triton_append_key_value_cache = None
+    triton_append_mla_latent_cache = None
+
+
+def _is_cuda_graph_capture_active() -> bool:
+    """Return True only while the current CUDA stream is actively capturing."""
+    if not torch.cuda.is_initialized():
+        return False
+    is_current_stream_capturing = getattr(torch.cuda, "is_current_stream_capturing", None)
+    if is_current_stream_capturing is None:
+        return False
+    try:
+        return bool(is_current_stream_capturing())
+    except RuntimeError:
+        return False
+
 
 try:
     import flashinfer  # type: ignore # pylint: disable=unused-import
@@ -1591,8 +1609,25 @@ class DynamicInferenceContext(BaseInferenceContext):
         """
         attention_layer_number = self.layer_map[layer_number - 1]
 
+        if (
+            self.cache_mla_latent
+            and triton_append_mla_latent_cache is not None
+            and self._using_cuda_graph_this_step
+            and _is_cuda_graph_capture_active()
+        ):
+            if triton_append_mla_latent_cache(
+                layer_number=attention_layer_number,
+                key=key,
+                memory_buffer=self.memory_buffer,
+                padded_active_token_count=self.padded_active_token_count,
+                token_to_block_idx=self.gpu_view.token_to_block_idx,
+                token_to_local_position_within_kv_block=(
+                    self.gpu_view.token_to_local_position_within_kv_block
+                ),
+            ):
+                return
+
         if triton_append_key_value_cache is not None and not self.cache_mla_latent:
-            # currently does not support MLA latent cache
             return triton_append_key_value_cache(
                 layer_number=attention_layer_number,
                 key=key,

--- a/megatron/core/inference/contexts/fused_kv_append_kernel.py
+++ b/megatron/core/inference/contexts/fused_kv_append_kernel.py
@@ -185,3 +185,128 @@ def triton_append_key_value_cache(
         # Compile-time constant
         BLOCK_SIZE_H=BLOCK_SIZE_H,
     )
+
+
+@triton.jit
+def _append_mla_latent_cache_kernel(
+    # --- Pointers to Tensors ---
+    key_ptr,
+    cache_ptr,
+    block_idx_ptr,
+    local_kv_seq_idx_ptr,
+    # --- Strides for Tensor Memory Layout ---
+    stride_key_token,
+    stride_key_dim,
+    stride_cache_block,
+    stride_cache_pos,
+    stride_cache_dim,
+    # --- Other Parameters ---
+    n_tokens: tl.int32,
+    latent_dim: tl.int32,
+    # --- Compile-Time Constants ---
+    BLOCK_M: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    """
+    Triton kernel to append compressed MLA latent vectors to the paged latent KV cache.
+
+    Each program handles a tile of tokens and latent-dimension columns. Per-token
+    block/local mappings are consumed from the existing ContextGPUView state.
+    """
+
+    token_pid = tl.program_id(0)
+    dim_pid = tl.program_id(1)
+
+    offs_m = token_pid * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_d = dim_pid * BLOCK_D + tl.arange(0, BLOCK_D)
+    mask_m = offs_m < n_tokens
+    mask = mask_m[:, None] & (offs_d[None, :] < latent_dim)
+
+    block_idx = tl.load(block_idx_ptr + offs_m, mask=mask_m, other=0).to(tl.int64)
+    local_pos = tl.load(local_kv_seq_idx_ptr + offs_m, mask=mask_m, other=0).to(tl.int64)
+
+    key_offsets = offs_m[:, None] * stride_key_token + offs_d[None, :] * stride_key_dim
+    values = tl.load(key_ptr + key_offsets, mask=mask, other=0.0)
+
+    cache_offsets = (
+        block_idx[:, None] * stride_cache_block
+        + local_pos[:, None] * stride_cache_pos
+        + offs_d[None, :] * stride_cache_dim
+    )
+    tl.store(cache_ptr + cache_offsets, values, mask=mask)
+
+
+def triton_append_mla_latent_cache(
+    layer_number: int,
+    key: Tensor,
+    memory_buffer: Tensor,
+    padded_active_token_count: int,
+    token_to_block_idx: Tensor,
+    token_to_local_position_within_kv_block: Tensor,
+) -> bool:
+    """
+    Append MLA latent KV cache using a standalone Triton kernel.
+
+    Args:
+        layer_number (int): Attention layer number (0-based).
+        key (Tensor): MLA latent tensor of shape (tokens, latent_dim) or
+            (tokens, 1, latent_dim).
+        memory_buffer (Tensor): The 4D MLA latent cache tensor to write to.
+        padded_active_token_count (int): Number of active + padding tokens to process.
+        token_to_block_idx (Tensor): Tensor mapping token index to cache block index.
+        token_to_local_position_within_kv_block (Tensor): Tensor mapping token index to
+            its position within a block.
+
+    Returns:
+        bool: True when the Triton path handled the append, False when callers should
+        fall back to the PyTorch indexed-assignment path.
+    """
+    if not HAVE_TRITON:
+        return False
+    if (
+        key.device.type != 'cuda'
+        or memory_buffer.device.type != 'cuda'
+        or token_to_block_idx.device.type != 'cuda'
+        or token_to_local_position_within_kv_block.device.type != 'cuda'
+    ):
+        return False
+    if memory_buffer.dim() != 4:
+        return False
+    if key.dim() == 3 and key.size(1) == 1:
+        key = key.squeeze(1)
+    if key.dim() != 2:
+        return False
+
+    n_tokens = padded_active_token_count
+    if n_tokens == 0:
+        return True
+    if key.size(0) < n_tokens:
+        return False
+
+    layer_cache = memory_buffer[layer_number]
+    latent_dim = key.size(-1)
+    if layer_cache.dim() != 3 or layer_cache.size(-1) != latent_dim:
+        return False
+
+    BLOCK_M = 16
+    BLOCK_D = 64
+    grid = (triton.cdiv(n_tokens, BLOCK_M), triton.cdiv(latent_dim, BLOCK_D))
+    cache_strides = layer_cache.stride()
+
+    _append_mla_latent_cache_kernel[grid](
+        key,
+        layer_cache,
+        token_to_block_idx,
+        token_to_local_position_within_kv_block,
+        key.stride(0),
+        key.stride(1),
+        cache_strides[0],
+        cache_strides[1],
+        cache_strides[2],
+        n_tokens=n_tokens,
+        latent_dim=latent_dim,
+        BLOCK_M=BLOCK_M,
+        BLOCK_D=BLOCK_D,
+        num_warps=4,
+    )
+    return True

--- a/tests/unit_tests/inference/contexts/test_dynamic_context.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_context.py
@@ -7,6 +7,7 @@ from unittest import mock
 import pytest
 import torch
 
+import megatron.core.inference.contexts.dynamic_context as dynamic_context_module
 from megatron.core import parallel_state
 from megatron.core.inference.config import InferenceConfig, MambaInferenceStateConfig
 from megatron.core.inference.contexts.dynamic_context import (
@@ -14,13 +15,14 @@ from megatron.core.inference.contexts.dynamic_context import (
     RequestOverflowError,
     TokenOverflowError,
 )
+from megatron.core.inference.contexts.fused_kv_append_kernel import HAVE_TRITON
 from megatron.core.inference.inference_request import DynamicInferenceRequest
 from megatron.core.inference.sampling.torch_sampling import TorchSampling
 from megatron.core.inference.sampling_params import SamplingParams
 from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.transformer_block import get_num_layers_to_build
-from megatron.core.transformer.transformer_config import TransformerConfig
+from megatron.core.transformer.transformer_config import MLATransformerConfig, TransformerConfig
 from tests.unit_tests.test_utilities import Utils
 
 
@@ -3562,3 +3564,220 @@ class TestDynamicContext:
         expected_len = ctx.num_last_token_logits
         assert indices.numel() == expected_len
         assert indices.data_ptr() == ctx.active_logit_idxs.data_ptr()
+
+    def _get_mla_dynamic_context(self, params_dtype=torch.bfloat16):
+        return DynamicInferenceContext(
+            model_config=MLATransformerConfig(
+                params_dtype=params_dtype,
+                num_layers=1,
+                hidden_size=128,
+                num_attention_heads=4,
+                kv_lora_rank=512,
+                qk_pos_emb_head_dim=64,
+                cache_mla_latents=True,
+            ),
+            inference_config=InferenceConfig(
+                max_sequence_length=128,
+                buffer_size_gb=0.01,
+                block_size_tokens=64,
+                max_tokens=128,
+                max_requests=4,
+                unified_memory_level=0,
+                use_flashinfer_fused_rope=False,
+            ),
+        )
+
+    def _seed_mla_append_state(self, ctx, padded_tokens=5):
+        total_blocks = ctx.kv_block_allocator.total_count
+        dummy_block = ctx.kv_block_allocator.dummy_block_idx
+        block_idx = torch.tensor(
+            [0, 2, 0, dummy_block, dummy_block][:padded_tokens],
+            device='cuda',
+            dtype=ctx.gpu_view.token_to_block_idx.dtype,
+        )
+        local_pos = torch.tensor(
+            [62, 63, 0, 0, 1][:padded_tokens],
+            device='cuda',
+            dtype=ctx.gpu_view.token_to_local_position_within_kv_block.dtype,
+        )
+        assert total_blocks > 3
+        ctx.padded_active_token_count = padded_tokens
+        ctx.gpu_view.token_to_block_idx[:padded_tokens] = block_idx
+        ctx.gpu_view.token_to_local_position_within_kv_block[:padded_tokens] = local_pos
+        return block_idx, local_pos
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+    def test_mla_append_eager_uses_indexed_assignment_fallback(self, monkeypatch):
+        ctx = self._get_mla_dynamic_context()
+        block_idx, local_pos = self._seed_mla_append_state(ctx)
+        key = torch.randn(
+            ctx.padded_active_token_count, ctx.kv_reduced_dim, device='cuda', dtype=ctx.params_dtype
+        )
+        ctx.memory_buffer.fill_(-5)
+        expected = ctx.memory_buffer.clone()
+        expected[0, block_idx, local_pos] = key
+        guard_block = 1
+        guard_before = ctx.memory_buffer[0, guard_block].clone()
+        calls = []
+
+        def fake_mla_append(*args, **kwargs):
+            calls.append((args, kwargs))
+            raise AssertionError("MLA Triton append must not run outside CUDA Graph capture")
+
+        monkeypatch.setattr(
+            dynamic_context_module, "triton_append_mla_latent_cache", fake_mla_append
+        )
+        ctx.append_key_value_cache(1, key, None)
+
+        assert calls == []
+        assert torch.equal(ctx.memory_buffer, expected)
+        assert torch.equal(ctx.memory_buffer[0, guard_block], guard_before)
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+    @pytest.mark.skipif(not HAVE_TRITON, reason="Triton required")
+    def test_mla_append_cuda_graph_capture_uses_triton_and_replays(self, monkeypatch):
+        ctx = self._get_mla_dynamic_context()
+        block_idx, local_pos = self._seed_mla_append_state(ctx)
+        key = torch.randn(
+            ctx.padded_active_token_count, ctx.kv_reduced_dim, device='cuda', dtype=ctx.params_dtype
+        )
+        sentinel = -9.0
+        calls = []
+        original_append = dynamic_context_module.triton_append_mla_latent_cache
+
+        def recording_mla_append(*args, **kwargs):
+            calls.append(torch.cuda.is_current_stream_capturing())
+            return original_append(*args, **kwargs)
+
+        warmup_memory = ctx.memory_buffer.clone()
+        warmup_memory.fill_(sentinel)
+        assert original_append(
+            layer_number=0,
+            key=key,
+            memory_buffer=warmup_memory,
+            padded_active_token_count=ctx.padded_active_token_count,
+            token_to_block_idx=ctx.gpu_view.token_to_block_idx,
+            token_to_local_position_within_kv_block=(
+                ctx.gpu_view.token_to_local_position_within_kv_block
+            ),
+        )
+        torch.cuda.synchronize()
+
+        ctx.memory_buffer.fill_(sentinel)
+        expected = ctx.memory_buffer.clone()
+        expected[0, block_idx, local_pos] = key
+        ctx._using_cuda_graph_this_step = True
+        monkeypatch.setattr(
+            dynamic_context_module, "triton_append_mla_latent_cache", recording_mla_append
+        )
+
+        graph = torch.cuda.CUDAGraph()
+        torch.cuda.synchronize()
+        with torch.cuda.graph(graph):
+            ctx.append_key_value_cache(1, key, None)
+        torch.cuda.synchronize()
+
+        assert calls == [True]
+        ctx.memory_buffer.fill_(sentinel)
+        torch.cuda.synchronize()
+        graph.replay()
+        torch.cuda.synchronize()
+
+        assert torch.equal(ctx.memory_buffer, expected)
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+    def test_mla_append_falls_back_when_triton_hook_unavailable(self, monkeypatch):
+        ctx = self._get_mla_dynamic_context()
+        block_idx, local_pos = self._seed_mla_append_state(ctx)
+        key = torch.randn(
+            ctx.padded_active_token_count, ctx.kv_reduced_dim, device='cuda', dtype=ctx.params_dtype
+        )
+        ctx.memory_buffer.fill_(11)
+        active_tokens = 3
+        guard_block = 1
+        guard_before = ctx.memory_buffer[0, guard_block].clone()
+
+        monkeypatch.setattr(dynamic_context_module, "triton_append_mla_latent_cache", None)
+        ctx.append_key_value_cache(1, key, None)
+
+        assert torch.equal(
+            ctx.memory_buffer[0, block_idx[:active_tokens], local_pos[:active_tokens]],
+            key[:active_tokens],
+        )
+        assert torch.equal(ctx.memory_buffer[0, guard_block], guard_before)
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+    def test_regular_kv_append_keeps_existing_triton_hook(self, monkeypatch):
+        ctx = self._get_dynamic_context(
+            params_dtype=torch.float32,
+            num_layers=1,
+            kv_channels=8,
+            num_attention_heads=2,
+            max_sequence_length=128,
+            buffer_size_gb=0.01,
+            block_size_tokens=16,
+            max_tokens=64,
+            max_requests=4,
+        )
+        padded_tokens = 3
+        block_idx = torch.tensor(
+            [0, 1, 0], device='cuda', dtype=ctx.gpu_view.token_to_block_idx.dtype
+        )
+        local_pos = torch.tensor(
+            [14, 15, 0],
+            device='cuda',
+            dtype=ctx.gpu_view.token_to_local_position_within_kv_block.dtype,
+        )
+        ctx.padded_active_token_count = padded_tokens
+        ctx.gpu_view.token_to_block_idx[:padded_tokens] = block_idx
+        ctx.gpu_view.token_to_local_position_within_kv_block[:padded_tokens] = local_pos
+
+        shape = (
+            padded_tokens,
+            1,
+            ctx.num_attention_heads_per_partition,
+            ctx.hidden_size_per_attention_head,
+        )
+        key = torch.randn(shape, device='cuda', dtype=ctx.params_dtype)
+        value = torch.randn(shape, device='cuda', dtype=ctx.params_dtype)
+        ctx.memory_buffer.zero_()
+        expected = ctx.memory_buffer.clone()
+        expected[0, 0, block_idx, local_pos] = key.squeeze(1)
+        expected[1, 0, block_idx, local_pos] = value.squeeze(1)
+        calls = []
+
+        def fake_regular_append(
+            layer_number,
+            key,
+            value,
+            memory_buffer,
+            padded_active_token_count,
+            token_to_block_idx,
+            token_to_local_position_within_kv_block,
+        ):
+            calls.append(layer_number)
+            memory_buffer[
+                0,
+                layer_number,
+                token_to_block_idx[:padded_active_token_count],
+                token_to_local_position_within_kv_block[:padded_active_token_count],
+            ] = key.squeeze(1)[:padded_active_token_count]
+            memory_buffer[
+                1,
+                layer_number,
+                token_to_block_idx[:padded_active_token_count],
+                token_to_local_position_within_kv_block[:padded_active_token_count],
+            ] = value.squeeze(1)[:padded_active_token_count]
+
+        monkeypatch.setattr(
+            dynamic_context_module, "triton_append_key_value_cache", fake_regular_append
+        )
+        monkeypatch.setattr(dynamic_context_module, "triton_append_mla_latent_cache", None)
+        ctx.append_key_value_cache(1, key, value)
+
+        assert calls == [0]
+        assert torch.equal(ctx.memory_buffer, expected)

--- a/tests/unit_tests/inference/contexts/test_fused_kv_append_kernel.py
+++ b/tests/unit_tests/inference/contexts/test_fused_kv_append_kernel.py
@@ -6,6 +6,7 @@ import torch
 from megatron.core.inference.contexts.fused_kv_append_kernel import (
     HAVE_TRITON,
     triton_append_key_value_cache,
+    triton_append_mla_latent_cache,
 )
 from megatron.core.inference.contexts.gpu_view import ContextGPUView
 
@@ -108,3 +109,119 @@ class TestKVAppendLargeBlockIdx:
         assert torch.equal(
             actual_value, expected_value
         ), f"Value not at expected cache position (block {target_block})."
+
+
+def _make_mla_token_mapping(n_tokens: int, block_size: int, device: str):
+    """Create non-contiguous physical block IDs with logical boundary crossings."""
+    start_pos = max(block_size - 3, 0)
+    logical_positions = start_pos + torch.arange(n_tokens, device=device)
+    logical_block_count = int((start_pos + max(n_tokens - 1, 0)) // block_size) + 1
+    total_blocks = max(logical_block_count + 8, 17)
+    dummy_block = total_blocks - 1
+
+    # Leave a few real blocks unused as sentinels, and use a shuffled/non-contiguous map.
+    generator = torch.Generator(device=device)
+    generator.manual_seed(17 * block_size + n_tokens)
+    physical_blocks = torch.randperm(total_blocks - 1, device=device, generator=generator)[
+        :logical_block_count
+    ].to(torch.int64)
+    logical_blocks = torch.div(logical_positions, block_size, rounding_mode='floor')
+    block_idx = physical_blocks[logical_blocks].to(torch.int64)
+    local_pos = (logical_positions % block_size).to(torch.int32)
+    return block_idx, local_pos, total_blocks, dummy_block
+
+
+def _reference_mla_append(key, memory_buffer, layer, n_tokens, block_idx, local_pos):
+    key = key.squeeze(1) if key.dim() == 3 and key.size(1) == 1 else key
+    expected = memory_buffer.clone()
+    expected[layer, block_idx[:n_tokens], local_pos[:n_tokens]] = key[:n_tokens]
+    return expected
+
+
+@pytest.mark.internal
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.skipif(not HAVE_TRITON, reason="Triton required")
+@pytest.mark.parametrize("block_size", [16, 32, 64, 128])
+@pytest.mark.parametrize("latent_dim", [96, 576])
+@pytest.mark.parametrize("n_tokens", [1, 3, 64, 65, 129])
+def test_mla_latent_append_matches_indexed_assignment(block_size, latent_dim, n_tokens):
+    """The MLA latent Triton append matches the PyTorch indexed-assignment fallback."""
+    device = "cuda"
+    dtype = torch.bfloat16
+    layer = 1
+    num_layers = 2
+    sentinel = -7.0
+
+    block_idx, local_pos, total_blocks, dummy_block = _make_mla_token_mapping(
+        n_tokens, block_size, device
+    )
+    active_tokens = max(n_tokens - min(3, n_tokens), 0)
+    if active_tokens < n_tokens:
+        block_idx[active_tokens:n_tokens] = dummy_block
+        local_pos[active_tokens:n_tokens] = torch.arange(
+            n_tokens - active_tokens, device=device, dtype=torch.int32
+        )
+
+    torch.manual_seed(1234 + block_size + latent_dim + n_tokens)
+    key = torch.randn(n_tokens, latent_dim, device=device, dtype=dtype)
+    memory_buffer = torch.full(
+        (num_layers, total_blocks, block_size, latent_dim), sentinel, device=device, dtype=dtype
+    )
+    original = memory_buffer.clone()
+    expected = _reference_mla_append(key, memory_buffer, layer, n_tokens, block_idx, local_pos)
+
+    handled = triton_append_mla_latent_cache(
+        layer_number=layer,
+        key=key,
+        memory_buffer=memory_buffer,
+        padded_active_token_count=n_tokens,
+        token_to_block_idx=block_idx,
+        token_to_local_position_within_kv_block=local_pos,
+    )
+    torch.cuda.synchronize()
+
+    assert handled
+    assert torch.equal(memory_buffer, expected)
+
+    untouched_real_blocks = [
+        block
+        for block in range(total_blocks - 1)
+        if block not in set(block_idx[:active_tokens].tolist())
+    ]
+    if untouched_real_blocks:
+        guard_block = untouched_real_blocks[0]
+        assert torch.equal(memory_buffer[layer, guard_block], original[layer, guard_block])
+
+
+@pytest.mark.internal
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.skipif(not HAVE_TRITON, reason="Triton required")
+def test_mla_latent_append_accepts_sequence_dim_and_fp16():
+    """The wrapper accepts the actual optional singleton sequence dimension."""
+    if not torch.empty((), device="cuda", dtype=torch.float16).is_cuda:
+        pytest.skip("float16 CUDA tensor unsupported")
+
+    device = "cuda"
+    block_size = 64
+    latent_dim = 576
+    n_tokens = 65
+    layer = 0
+    block_idx, local_pos, total_blocks, _ = _make_mla_token_mapping(n_tokens, block_size, device)
+    key = torch.randn(n_tokens, 1, latent_dim, device=device, dtype=torch.float16)
+    memory_buffer = torch.full(
+        (1, total_blocks, block_size, latent_dim), 3.0, device=device, dtype=torch.float16
+    )
+    expected = _reference_mla_append(key, memory_buffer, layer, n_tokens, block_idx, local_pos)
+
+    handled = triton_append_mla_latent_cache(
+        layer_number=layer,
+        key=key,
+        memory_buffer=memory_buffer,
+        padded_active_token_count=n_tokens,
+        token_to_block_idx=block_idx,
+        token_to_local_position_within_kv_block=local_pos,
+    )
+    torch.cuda.synchronize()
+
+    assert handled
+    assert torch.equal(memory_buffer, expected)


### PR DESCRIPTION
## Summary

This draft adds capture-aware Triton dispatch for MLA latent KV-cache append.

The MLA latent cache path previously preferred Triton whenever Triton was available. On an A100, that path was slower during eager execution but substantially faster during CUDA Graph replay. This change uses the Triton MLA append kernel only during CUDA Graph capture and preserves the existing PyTorch indexed-assignment fallback for eager execution, graph misses, warmup, and other non-captured paths.

## What changed

- Added a Triton append kernel for MLA latent KV-cache writes.
- Gated the MLA Triton path on:
  - MLA latent cache mode;
  - Triton availability;
  - the current inference step selecting a CUDA Graph;
  - active CUDA stream capture.
- Preserved the PyTorch indexed-assignment fallback for eager execution.
- Kept the normal KV-cache append path unchanged.
- Added kernel-level and DynamicInferenceContext coverage.
- Added real CUDA Graph capture/replay coverage.

## Validation

Environment:

- GPU: NVIDIA A100-SXM4-80GB
- Compute capability: SM80
- CUDA: 12.8
- PyTorch: 2.8.0+cu128
- Triton: 3.4.0
- dtype: bfloat16
- latent dimension: 576

Results:

- Eager MLA append remains on the PyTorch fallback.
- No obvious eager regression was observed.
- Real local CudaGraphManager capture/replay smoke test passed.
- Python append was called during capture and was not called again during replay.
- CUDA Graph append results are bitwise equal to the PyTorch reference.
- CUDA Graph append latency improved by approximately 2.1x–3.0x across the tested token counts.
- Normal KV-cache append behavior is unchanged.
- 42 relevant tests passed.
- compileall, git diff --check, black, pylint, isort, and pre-commit passed.

## Hardware limitation

Full MLA attention/decode validation was not run because the available GPU is A100/SM80. The relevant upstream FlashMLA path requires SM90/SM100 hardware.

This pull request is intentionally opened as Draft to obtain design feedback and, if possible, validation on H100/H800 or another supported environment.

## Scope boundaries

This change does not modify:

- MLA attention dispatch;
- FlashInfer or FlashMLA dependencies;
- cache layout;
- block allocator or block-table semantics;
- dtype or quantization;
- ordinary KV-cache append behavior;
- pyproject.toml or uv.lock.

This PR is independent of #4918, #4919, and #4920.