### PR TITLE
Bump mcore skill versions for signature refresh

### DIFF
--- a/skills/mcore-create-issue/SKILL.md
+++ b/skills/mcore-create-issue/SKILL.md
@@ -7,6 +7,7 @@ user_invocable: true
 argument: "GitHub Actions run or job URL"
 metadata:
   author: Oliver Koenig <okoenig@nvidia.com>
+  version: "1.0.1"
 ---
 
 # Triage CI Failure into a GitHub Issue

--- a/skills/mcore-linting-and-formatting/SKILL.md
+++ b/skills/mcore-linting-and-formatting/SKILL.md
@@ -5,6 +5,7 @@ license: Apache-2.0
 when_to_use: Running linting or autoformat; fixing style violations before a PR; 'pre-commit fails', 'ruff error', 'isort', 'mypy', 'style violation', 'how do I format', 'autoformat.sh'.
 metadata:
   author: Oliver Koenig <okoenig@nvidia.com>
+  version: "1.0.1"
 ---
 
 # Linting and Formatting

--- a/skills/mcore-run-on-slurm/SKILL.md
+++ b/skills/mcore-run-on-slurm/SKILL.md
@@ -5,6 +5,7 @@ license: Apache-2.0
 when_to_use: Submitting a SLURM job; writing or debugging an sbatch script; configuring multi-node distributed training; setting MASTER_ADDR / MASTER_PORT / WORLD_SIZE; diagnosing a SLURM job failure; 'how do I run on the cluster', 'sbatch', 'multi-node training'.
 metadata:
   author: Oliver Koenig <okoenig@nvidia.com>
+  version: "1.0.1"
 ---
 
 # Run Megatron-LM on SLURM

--- a/skills/mcore-split-pr/SKILL.md
+++ b/skills/mcore-split-pr/SKILL.md
@@ -7,6 +7,7 @@ user_invocable: true
 argument: "PR URL or number"
 metadata:
   author: Philip Petrakian <ppetrakian@nvidia.com>
+  version: "1.0.1"
 ---
 
 # Split PR by CODEOWNERS Groups

--- a/skills/mcore-testing/SKILL.md
+++ b/skills/mcore-testing/SKILL.md
@@ -5,6 +5,7 @@ license: Apache-2.0
 when_to_use: Adding or running a unit or functional test; understanding the test layout; writing a recipe YAML; downloading or updating golden values; reproducing a test failure locally; 'how do I add a test', 'run unit tests', 'pytest fails', 'test layout', 'golden values', 'recipe YAML', 'marker filter'.
 metadata:
   author: Oliver Koenig <okoenig@nvidia.com>
+  version: "1.0.1"
 ---
 
 # Testing Guide


### PR DESCRIPTION
## Summary

- bump the metadata version to `1.0.1` for all five cataloged mcore skills
- touch each affected `SKILL.md` so `/nvskills-ci` can refresh their signatures in one run

## Impact

This is a metadata-only change. It does not alter skill behavior; it allows the catalog to accept the pending source updates after the refreshed signatures are merged.

## Validation

- parsed YAML frontmatter and confirmed `metadata.version: "1.0.1"` for all five skills
- `git diff --check`
- confirmed the PR diff contains exactly the five requested `SKILL.md` files

The generic `quick_validate.py` validator is not applicable here because it rejects the repository's existing extended frontmatter keys (`argument`, `user_invocable`, and `when_to_use`).
