### PR TITLE
chore(skills): add Regent Open Plugin manifest

### DIFF
--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "megatron-lm",
+  "description": "Megatron-LM repository skills (build and dependency, CI/CD, testing, golden values, linting, base-image bumps, Slurm runs) for Regent agents working on this repo.",
+  "version": "0.1.0"
+}


### PR DESCRIPTION
## What
Adds `.plugin/plugin.json` so this repo's `skills/` becomes a skills-only **Regent Open Plugin**, letting in-cluster CI agents (the `implement-author` and its base `analyst`) activate these skills as `$<plugin>:<skill>`.

## Why
Regent 0.9.44 added Open Plugin support: a namespaced `Plugin` CR sources this repo (git, ref `main`, path `.`), reads `.plugin/plugin.json`, and scans `./skills/` — surfacing the repo's existing skills to the agents that work on it, kept in sync via the plugin's refresh. No per-skill duplication.

## Scope
- Adds **only** `.plugin/plugin.json` (name, description, version). No code or behavior change.
- Claude Code is unaffected — it reads `.claude/skills`, which is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
