### PR TITLE
Fix silent expert-weight drop in tools/checkpoint MoE conversion

### DIFF
--- a/tools/checkpoint/loader_mixtral_hf.py
+++ b/tools/checkpoint/loader_mixtral_hf.py
@@ -264,6 +264,7 @@ def _load_checkpoint(queue, args):
     md.output_layer = margs.untie_embeddings_and_output_weights
     md.position_embedding_type = margs.position_embedding_type
     md.linear_bias = margs.add_bias_linear
+    md.qkv_bias = margs.add_qkv_bias
     md.norm_has_bias = False
     md.swiglu = margs.swiglu
     md.previous_tensor_parallel_size = margs.tensor_model_parallel_size

--- a/tools/checkpoint/saver_base.py
+++ b/tools/checkpoint/saver_base.py
@@ -471,10 +471,15 @@ class MegatronCheckpointSaverBase:
                             "mlp_norm_weight" : post_norm_weight
                         }
                         if self.margs.num_experts:
-                            params_dict.update({
-                                "mlp_fc1_weight" : mlp_l0_weight[ep_rank][tp_rank],
-                                "mlp_fc2_weight" : mlp_l1_weight[ep_rank][tp_rank]
-                            })
+                            # CoreMoETESchema registers per-expert keys
+                            # ("mlp_fc1_weight.{i}" -> mlp.experts.local_experts.{i}.linear_fc1.weight),
+                            # so the stacked expert tensor must be split by local-expert index. A
+                            # single stacked "mlp_fc1_weight" key never matches the schema, leaving
+                            # every expert weight uninitialized.
+                            num_local_experts = self.margs.num_experts // self.args.target_expert_parallel_size
+                            for expert_idx in range(num_local_experts):
+                                params_dict[f"mlp_fc1_weight.{expert_idx}"] = mlp_l0_weight[ep_rank][tp_rank][expert_idx]
+                                params_dict[f"mlp_fc2_weight.{expert_idx}"] = mlp_l1_weight[ep_rank][tp_rank][expert_idx]
                         else:
                             params_dict.update({
                                 "mlp_fc1_weight" : mlp_l0_weight[tp_rank],


### PR DESCRIPTION
Fixes #5844.

## What

Two fixes to make `tools/checkpoint/convert.py --loader mixtral_hf --saver mcore` produce a
correct checkpoint for MoE (Mixtral) models:

1. **`tools/checkpoint/saver_base.py`** — emit **per-expert** MoE weight keys so they match
   `CoreMoETESchema`. Previously the saver passed a single stacked `mlp_fc1_weight` /
   `mlp_fc2_weight`, which `ModelSchema._set` never matches against the schema's
   `mlp_fc1_weight.{i}` keys, so every expert weight was silently left uninitialized.
2. **`tools/checkpoint/loader_mixtral_hf.py`** — set `md.qkv_bias` (read unconditionally by
   `saver_base.receive_lm`; the mixtral loader never set it, causing `AttributeError`).

See #5844 for the full root-cause analysis.

## Why

`get_model_schema` returns `CoreMoETESchema` for all MoE models, and that schema uses
per-expert keys (`mlp.experts.local_experts.{i}.linear_fc1.weight`). The saver's stacked key
never matches, so `_set` copies nothing and the experts keep their `--no-initialization`
values. The result is a checkpoint that loads without error but has random expert FFNs. There
is no config where the stacked key is correct (the schema selection hard-asserts TE and has no
grouped-GEMM branch).

## Testing

- **Weight equivalence (direct proof).** Converted `Mixtral-8x7B` HF -> mcore at TP=1/PP=1/EP=1
  and compared the converted tensors against the HF source: token embedding, router
  (`block_sparse_moe.gate`), and expert `linear_fc1` (= `cat([w1, w3])`) / `linear_fc2` (= `w2`)
  for experts 0 and 7 at layers 0, 15, 31. **All 16 sampled tensors are bit-identical
  (`max|delta| = 0.0`).** Before the fix these expert tensors are uninitialized garbage; after
  the fix they exactly reproduce the source, confirming correct values, expert ordering, and
  swiglu concat order.
- **End-to-end.** Converted at TP=4/PP=2/EP=1 and ran validation inference. Before the fix:
  `RuntimeError: found NaN in local forward loss` on the last pipeline stage. After the fix:
  finite, stable validation loss ~1.95 (PPL ~7.05), consistent across H100 (amd64), GB200-NVL
  and GB300-NVL (arm64), for both bf16 and fp8-hybrid.
- The `else` (dense) branch is unchanged, so non-MoE conversions are unaffected.

## Notes / scope

- Only the expert **weights** are exercised here; Mixtral has `add_bias_linear=False` so the
  expert-bias branch (also stacked) is not hit, and `CoreMoETESchema` does not currently define
  per-expert bias keys. Left as-is.
- On `core_v0.18.0` the MoE model build also needed additional data-parallel / expert-tensor-parallel
  fake process groups in the loader and saver; `main`'s saver refactor may already cover that, so
  it is not part of this PR (orthogonal to this correctness fix).