### PR TITLE
Stabilize mfsdp_v2 overlap test by enlarging the model

### DIFF
--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -311,8 +311,6 @@ def test_root_backward_returns_to_resting_memory(distributed_setup):
     )
 
 
-@pytest.mark.flaky
-@pytest.mark.flaky_in_dev
 def test_overlaps_communication_and_compute(distributed_setup):
     """Forward and backward communication should overlap GEMM compute."""
     world_size = distributed_setup.world_size
@@ -321,7 +319,14 @@ def test_overlaps_communication_and_compute(distributed_setup):
         pytest.skip("This test requires at least 2 ranks.")
 
     mesh = init_device_mesh(device.type, (world_size,))
-    dim = 8192
+    # A large hidden size keeps the per-layer GEMMs long enough that the
+    # collectives reliably overlap them. The overlap count is otherwise
+    # launch-bound: the host issues kernels with gaps (amplified by CI's
+    # `coverage run` wrapper), so with short GEMMs a collective can land in a
+    # gap between GEMMs instead of running alongside one, making the count jitter
+    # run to run. At dim=16384 the GEMMs dominate that launch jitter and the
+    # overlap becomes deterministic. (dim=8192 was flaky under coverage.)
+    dim = 16384
     num_children = 4
     dtype = torch.bfloat16
     model = MultiChildModel(dim=dim, num_children=num_children).to(dtype=dtype)
@@ -348,7 +353,16 @@ def test_overlaps_communication_and_compute(distributed_setup):
         # drop the CUDA events.
         torch.cuda.synchronize(device)
 
-    cuda_events = [event for event in prof.events() if event.device_type.name == "CUDA"]
+    # Keep only real device kernels. NCCL also emits a per-collective op-range
+    # annotation (e.g. "nccl:_reduce_scatter_base") that the profiler tags as a
+    # CUDA event; excluding the "nccl:"-prefixed annotations avoids double-counting
+    # the reduce-scatters (whose name contains "reduce_scatter"). Real kernels are
+    # named like "ncclDevKernel_ReduceScatter_..." / "ncclDevKernel_AllGather_...".
+    cuda_events = [
+        event
+        for event in prof.events()
+        if event.device_type.name == "CUDA" and not event.name.startswith("nccl:")
+    ]
     all_gather_events = [
         event
         for event in cuda_events
@@ -367,8 +381,16 @@ def test_overlaps_communication_and_compute(distributed_setup):
         for event in cuda_events
         if any(token in event.name.lower() for token in ("gemm", "cutlass", "cublas", "nvjet"))
     ]
-    assert all_gather_events, [event.name for event in cuda_events]
-    assert reduce_scatter_events, [event.name for event in cuda_events]
+    # Each of the num_children children plus the root all-gathers in forward and
+    # again in backward, and each reduce-scatters once in backward.
+    assert len(all_gather_events) == 2 * (num_children + 1), (
+        f"Expected {2 * (num_children + 1)} all-gather kernels, "
+        f"got {[event.name for event in all_gather_events]}."
+    )
+    assert len(reduce_scatter_events) == num_children + 1, (
+        f"Expected {num_children + 1} reduce-scatter kernels, "
+        f"got {[event.name for event in reduce_scatter_events]}."
+    )
     assert gemm_events, [event.name for event in cuda_events]
 
     all_gather_streams = {event.device_resource_id for event in all_gather_events}
@@ -388,16 +410,16 @@ def test_overlaps_communication_and_compute(distributed_setup):
         any(_events_overlap(reduce_scatter_event, gemm_event) for gemm_event in gemm_events)
         for reduce_scatter_event in reduce_scatter_events
     )
-    # Communication overlaps compute only partially due to SM contention (the
-    # SM-based NCCL collectives share SMs with the GEMMs) and the count varies
-    # run to run, so assert only that overlap meaningfully happens rather than the
-    # theoretical maximum (2*(num_children - 1) / num_children - 1). Symmetric-memory
-    # collectives (use_symm_mem, ~SM-free) would let these thresholds be tightened.
-    assert all_gather_overlap_count >= 2, (
+    # With dim large enough for the GEMMs to dominate launch jitter (see above),
+    # the prefetched collectives overlap compute deterministically, so assert the
+    # theoretical maxima (2*(num_children - 1) all-gathers across forward and
+    # backward, num_children - 1 reduce-scatters in backward) rather than a loose
+    # floor.
+    assert all_gather_overlap_count >= 2 * (num_children - 1), (
         f"Expected all-gather to overlap compute, "
         f"got {all_gather_overlap_count}/{len(all_gather_events)}."
     )
-    assert reduce_scatter_overlap_count >= 1, (
+    assert reduce_scatter_overlap_count >= num_children - 1, (
         f"Expected reduce-scatter to overlap compute, "
         f"got {reduce_scatter_overlap_count}/{len(reduce_scatter_events)}."
     )

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -353,15 +353,14 @@ def test_overlaps_communication_and_compute(distributed_setup):
         # drop the CUDA events.
         torch.cuda.synchronize(device)
 
-    # Keep only real device kernels. NCCL also emits a per-collective op-range
-    # annotation (e.g. "nccl:_reduce_scatter_base") that the profiler tags as a
-    # CUDA event; excluding the "nccl:"-prefixed annotations avoids double-counting
-    # the reduce-scatters (whose name contains "reduce_scatter"). Real kernels are
-    # named like "ncclDevKernel_ReduceScatter_..." / "ncclDevKernel_AllGather_...".
+    # Keep only real device kernels. NCCL also emits per-collective GPU user
+    # annotations (e.g. "nccl:_reduce_scatter_base") that the profiler reports as
+    # CUDA events. Filtering by activity type avoids counting those annotations as
+    # kernels without relying on their current naming convention.
     cuda_events = [
         event
         for event in prof.events()
-        if event.device_type.name == "CUDA" and not event.name.startswith("nccl:")
+        if event.device_type.name == "CUDA" and event.activity_type == "kernel"
     ]
     all_gather_events = [
         event


### PR DESCRIPTION
## What

Re-enable and stabilize `test_overlaps_communication_and_compute` in the `mfsdp_v2`
unit-test bucket by enlarging the model to `dim=16384`.

## Why

The test was flaky under CI's `coverage run` wrapper and had been disabled with
`@pytest.mark.flaky` + `@pytest.mark.flaky_in_dev`. The flakiness is **launch-bound,
not a real overlap regression**: `coverage`'s per-line tracing slows host-side kernel
launches, so at `dim=8192` the GEMMs are short enough that a collective can land in a
gap *between* GEMMs instead of running alongside one — making the overlap count jitter
(the reduce-scatter dipped to 0 on individual ranks, the failure CI hit).

Measured under CI-parity coverage (`--source=megatron/core`, 8×H100), min overlap
across ranks:

| dim | reduce-scatter overlap |
|-----|------------------------|
| 8192 (old) | flaky (~11–15% of iterations dip below the max, including 0) |
| 12288 | deterministic |
| **16384** | **deterministic** (350+ iterations, 0 dips; 15/15 test runs under coverage) |

Raising `dim` makes the GEMMs dominate the launch jitter, so overlap becomes
deterministic. Wall-time impact is negligible (~+15–40 ms on the single profiled
step; dominated by fixed process-group/model setup).

## What changed

- `dim` 8192 → 16384.
- Drop the `@pytest.mark.flaky` / `@pytest.mark.flaky_in_dev` markers (re-enable).
- Tighten the overlap-count assertions from loose floors (`>=2`, `>=1`) back to the
  theoretical maxima (`2*(num_children - 1)` all-gathers, `num_children - 1`
  reduce-scatters).
- Count only real device kernels: exclude the NCCL per-collective op-range annotations
  (`nccl:_reduce_scatter_base`) that the profiler tags as CUDA events and that were
  double-counting the reduce-scatters; assert the exact kernel counts
  (`2*(num_children + 1)` all-gathers, `num_children + 1` reduce-scatters).

## Supersedes

This replaces the earlier symmetric-memory / zero-CTA approach on this branch.
Investigation showed the reduce-scatter flakiness is a coverage-induced host-launch
race, not GPU/SM contention — so no collective-side change (symm-mem, zero-CTA) makes
it deterministic, but a larger model does. Zero-CTA was in fact *flakier* than the
default ring collectives at `dim=8192`.

Stabilizes the overlap test introduced in #5719.