### PR TITLE
rl: release G-submission gate slots on consumption instead of assembly

### DIFF
--- a/megatron/rl/agent/api.py
+++ b/megatron/rl/agent/api.py
@@ -227,7 +227,12 @@ class _GranularityConfig(NamedTuple):
 
 
 class _SubmissionGate:
-    """Gate capacity is measured in units of the configured submission granularity."""
+    """Gate capacity is measured in units of the configured submission granularity.
+
+    Releases are keyed on (state, granularity) so release sites for different
+    granularities can coexist on the same code path (e.g. stage_consume's
+    reorder branch releases per group for G submission and per batch for B).
+    """
 
     def __init__(
         self,
@@ -256,8 +261,8 @@ class _SubmissionGate:
             self.held += 1
             self.acquire_calls += 1
 
-    def release_after(self, state: ReleaseState) -> None:
-        if self._release_on == state:
+    def release_after(self, state: ReleaseState, granularity: SubmissionGranularity) -> None:
+        if self._submission == granularity and self._release_on == state:
             self._sem.release()
             self.held -= 1
             self.release_calls += 1
@@ -401,7 +406,7 @@ class _RolloutPipeline:
             self.request, item.params.inference_request
         )
         inferred_at = time.monotonic()
-        self.gate.release_after("inferred")
+        self.gate.release_after("inferred", "R")
         if item.infer_dequeued_at:
             self.engine_dwell.append(inferred_at - item.infer_dequeued_at)
         self.inferred_count += 1
@@ -430,13 +435,19 @@ class _RolloutPipeline:
                 rollouts = await asyncio.gather(
                     *[item.item.params.build_rollout(item.response) for item in completed]
                 )
-                self.gate.release_after("assembled")
+                # No-op under the current map (G releases at "consumed"); kept so
+                # flipping RELEASE_STATE_BY_SUBMISSION["G"] back to "assembled"
+                # restores run-ahead-to-assembly for experiments.
+                self.gate.release_after("assembled", "G")
                 self.assembled_count += 1
                 # NOTE: this filter is currently non-functional dead code:
                 # _GranularityConfig._validate rejects filter_groups_with_same_reward
                 # at pipeline construction, so `keep` is always True. Kept for a
                 # future PR that regenerates dropped groups instead of
-                # under-delivering to the caller.
+                # under-delivering to the caller. That PR must also release the
+                # gate slot on the drop path: with G/B releasing at "consumed",
+                # a dropped group never reaches stage_consume, so its slot (and
+                # eventually its batch's) would leak permanently.
                 keep = (
                     not self.request.filter_groups_with_same_reward
                     or np.std([rollout.reward for rollout in rollouts]) > 1e-6
@@ -474,6 +485,7 @@ class _RolloutPipeline:
                     return
                 self._record_output_dwell(group)
                 yield group
+                self.gate.release_after("consumed", "G")
 
         next_batch_id = 0
         pending = self._consume_pending
@@ -493,7 +505,8 @@ class _RolloutPipeline:
                 next_batch_id += 1
                 for group in batch:
                     yield group
-                self.gate.release_after("consumed")
+                    self.gate.release_after("consumed", "G")
+                self.gate.release_after("consumed", "B")
 
 
 class GroupedRolloutGenerator(Agent, ABC):

--- a/megatron/rl/agent/api.py
+++ b/megatron/rl/agent/api.py
@@ -19,12 +19,7 @@ from ..inference import (
     LLMChatMessage,
     ReturnsRaw,
 )
-from ..rollout_granularity import (
-    RELEASE_STATE_BY_SUBMISSION,
-    ConsumptionGranularity,
-    ReleaseState,
-    SubmissionGranularity,
-)
+from ..rollout_granularity import ConsumptionGranularity, SubmissionGranularity
 
 
 class AgentBaseModel(BaseModel, extra='allow'):
@@ -229,9 +224,11 @@ class _GranularityConfig(NamedTuple):
 class _SubmissionGate:
     """Gate capacity is measured in units of the configured submission granularity.
 
-    Releases are keyed on (state, granularity) so release sites for different
-    granularities can coexist on the same code path (e.g. stage_consume's
-    reorder branch releases per group for G submission and per batch for B).
+    Each granularity has a single release point: R slots free when inference
+    completes, so the gate bounds engine concurrency in rollouts. G and B
+    slots free when the trainer consumes the group/batch, so the gate
+    enforces the --rl-generation-lag run-ahead cap in groups/batches
+    respectively.
     """
 
     def __init__(
@@ -242,7 +239,6 @@ class _SubmissionGate:
     ) -> None:
         self._sem = asyncio.Semaphore(capacity)
         self._submission = submission
-        self._release_on = RELEASE_STATE_BY_SUBMISSION[submission]
         self.capacity = capacity
         # Observability counters, updated only on the configured submission
         # granularity (the only path that touches the semaphore). `held`
@@ -261,8 +257,8 @@ class _SubmissionGate:
             self.held += 1
             self.acquire_calls += 1
 
-    def release_after(self, state: ReleaseState, granularity: SubmissionGranularity) -> None:
-        if self._submission == granularity and self._release_on == state:
+    def release_for(self, granularity: SubmissionGranularity) -> None:
+        if self._submission == granularity:
             self._sem.release()
             self.held -= 1
             self.release_calls += 1
@@ -406,7 +402,7 @@ class _RolloutPipeline:
             self.request, item.params.inference_request
         )
         inferred_at = time.monotonic()
-        self.gate.release_after("inferred", "R")
+        self.gate.release_for("R")
         if item.infer_dequeued_at:
             self.engine_dwell.append(inferred_at - item.infer_dequeued_at)
         self.inferred_count += 1
@@ -435,17 +431,13 @@ class _RolloutPipeline:
                 rollouts = await asyncio.gather(
                     *[item.item.params.build_rollout(item.response) for item in completed]
                 )
-                # No-op under the current map (G releases at "consumed"); kept so
-                # flipping RELEASE_STATE_BY_SUBMISSION["G"] back to "assembled"
-                # restores run-ahead-to-assembly for experiments.
-                self.gate.release_after("assembled", "G")
                 self.assembled_count += 1
                 # NOTE: this filter is currently non-functional dead code:
                 # _GranularityConfig._validate rejects filter_groups_with_same_reward
                 # at pipeline construction, so `keep` is always True. Kept for a
                 # future PR that regenerates dropped groups instead of
                 # under-delivering to the caller. That PR must also release the
-                # gate slot on the drop path: with G/B releasing at "consumed",
+                # gate slot on the drop path: G/B slots free on consumption, and
                 # a dropped group never reaches stage_consume, so its slot (and
                 # eventually its batch's) would leak permanently.
                 keep = (
@@ -485,7 +477,7 @@ class _RolloutPipeline:
                     return
                 self._record_output_dwell(group)
                 yield group
-                self.gate.release_after("consumed", "G")
+                self.gate.release_for("G")
 
         next_batch_id = 0
         pending = self._consume_pending
@@ -505,8 +497,8 @@ class _RolloutPipeline:
                 next_batch_id += 1
                 for group in batch:
                     yield group
-                    self.gate.release_after("consumed", "G")
-                self.gate.release_after("consumed", "B")
+                    self.gate.release_for("G")
+                self.gate.release_for("B")
 
 
 class GroupedRolloutGenerator(Agent, ABC):

--- a/megatron/rl/rollout_granularity.py
+++ b/megatron/rl/rollout_granularity.py
@@ -9,9 +9,15 @@ ConsumptionGranularity = Literal["G", "B"]
 ReleaseState = Literal["inferred", "assembled", "consumed"]
 
 
+# R releases its slot when inference completes: the gate bounds engine
+# concurrency in rollouts. G and B release when the trainer consumes the
+# group/batch: the gate enforces the --rl-generation-lag run-ahead cap in
+# groups/batches respectively. G previously released at "assembled", which
+# let submission outrun consumption without bound (in-flight backlog grew
+# past the lag cap since assembled-but-unconsumed groups held no slot).
 RELEASE_STATE_BY_SUBMISSION: dict[SubmissionGranularity, ReleaseState] = {
     "R": "inferred",
-    "G": "assembled",
+    "G": "consumed",
     "B": "consumed",
 }
 

--- a/megatron/rl/rollout_granularity.py
+++ b/megatron/rl/rollout_granularity.py
@@ -6,20 +6,6 @@ from typing import Literal
 
 SubmissionGranularity = Literal["R", "G", "B"]
 ConsumptionGranularity = Literal["G", "B"]
-ReleaseState = Literal["inferred", "assembled", "consumed"]
-
-
-# R releases its slot when inference completes: the gate bounds engine
-# concurrency in rollouts. G and B release when the trainer consumes the
-# group/batch: the gate enforces the --rl-generation-lag run-ahead cap in
-# groups/batches respectively. G previously released at "assembled", which
-# let submission outrun consumption without bound (in-flight backlog grew
-# past the lag cap since assembled-but-unconsumed groups held no slot).
-RELEASE_STATE_BY_SUBMISSION: dict[SubmissionGranularity, ReleaseState] = {
-    "R": "inferred",
-    "G": "consumed",
-    "B": "consumed",
-}
 
 
 def get_rl_parallel_generation_tasks(args) -> int:

--- a/tests/unit_tests/rl/test_grouped_rollouts.py
+++ b/tests/unit_tests/rl/test_grouped_rollouts.py
@@ -19,7 +19,6 @@ from megatron.rl.agent.api import (
 from megatron.rl.agent.reward_only_agent import RewardOnlyAgent
 from megatron.rl.agent.weighted_multi_task import AgentConfig, WeightedMultiTask
 from megatron.rl.inference import InferenceResponse, LLMChatMessage, ReturnsRaw
-from megatron.rl.rollout_granularity import RELEASE_STATE_BY_SUBMISSION
 
 
 class MockInferenceInterface(ReturnsRaw):
@@ -112,24 +111,19 @@ async def _flush(rounds: int = 50):
 
 
 class TestSubmissionGate:
-    def test_release_state_map(self):
-        assert RELEASE_STATE_BY_SUBMISSION == {"R": "inferred", "G": "consumed", "B": "consumed"}
-
     @pytest.mark.asyncio
     @pytest.mark.parametrize("submission", ["R", "G", "B"])
-    async def test_release_requires_matching_state_and_granularity(self, submission):
+    async def test_release_requires_matching_granularity(self, submission):
         gate = _SubmissionGate(capacity=1, submission=submission)
         await gate.acquire_for(submission)
         assert gate.held == 1
-        release_on = RELEASE_STATE_BY_SUBMISSION[submission]
-        for state in ("inferred", "assembled", "consumed"):
-            for granularity in ("R", "G", "B"):
-                if state == release_on and granularity == submission:
-                    continue
-                gate.release_after(state, granularity)
+        for granularity in ("R", "G", "B"):
+            if granularity == submission:
+                continue
+            gate.release_for(granularity)
         assert gate.held == 1
         assert gate.release_calls == 0
-        gate.release_after(release_on, submission)
+        gate.release_for(submission)
         assert gate.held == 0
         assert gate.release_calls == 1
 

--- a/tests/unit_tests/rl/test_grouped_rollouts.py
+++ b/tests/unit_tests/rl/test_grouped_rollouts.py
@@ -14,10 +14,12 @@ from megatron.rl.agent.api import (
     Rollout,
     RolloutGenerator,
     RolloutRequest,
+    _SubmissionGate,
 )
 from megatron.rl.agent.reward_only_agent import RewardOnlyAgent
 from megatron.rl.agent.weighted_multi_task import AgentConfig, WeightedMultiTask
 from megatron.rl.inference import InferenceResponse, LLMChatMessage, ReturnsRaw
+from megatron.rl.rollout_granularity import RELEASE_STATE_BY_SUBMISSION
 
 
 class MockInferenceInterface(ReturnsRaw):
@@ -101,6 +103,106 @@ class CountingRewardAgent(RewardOnlyAgent):
 
     async def get_reward(self, response, golden, finish_reason):
         return float(int(response.removeprefix("t")) == golden["idx"])
+
+
+async def _flush(rounds: int = 50):
+    """Let pipeline stage tasks settle (mock inference is zero-delay)."""
+    for _ in range(rounds):
+        await asyncio.sleep(0)
+
+
+class TestSubmissionGate:
+    def test_release_state_map(self):
+        assert RELEASE_STATE_BY_SUBMISSION == {"R": "inferred", "G": "consumed", "B": "consumed"}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("submission", ["R", "G", "B"])
+    async def test_release_requires_matching_state_and_granularity(self, submission):
+        gate = _SubmissionGate(capacity=1, submission=submission)
+        await gate.acquire_for(submission)
+        assert gate.held == 1
+        release_on = RELEASE_STATE_BY_SUBMISSION[submission]
+        for state in ("inferred", "assembled", "consumed"):
+            for granularity in ("R", "G", "B"):
+                if state == release_on and granularity == submission:
+                    continue
+                gate.release_after(state, granularity)
+        assert gate.held == 1
+        assert gate.release_calls == 0
+        gate.release_after(release_on, submission)
+        assert gate.held == 0
+        assert gate.release_calls == 1
+
+
+class TestConsumptionRelease:
+    """G-submission gate slots must recycle on trainer consumption, not assembly."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "consumption_granularity, num_groups",
+        [
+            pytest.param("G", 1, id="group_consumption"),
+            pytest.param("B", 2, id="batch_consumption"),
+        ],
+    )
+    async def test_group_submission_stalls_until_consumption(
+        self, consumption_granularity, num_groups
+    ):
+        capacity = 4
+        gen = MockGenerator(parallel_generation_tasks=capacity)
+        request = GroupedRolloutRequest(
+            num_groups=num_groups,
+            rollouts_per_group=1,
+            inference_interface=MockInferenceInterface(),
+            streaming=True,
+            submission_granularity="G",
+            consumption_granularity=consumption_granularity,
+        )
+        it = gen.get_grouped_rollouts(request)
+        try:
+            for pulled in range(1, capacity + 3):
+                # wait_for turns the deadlock failure mode (a slot never freed)
+                # into a test failure instead of a hang.
+                await asyncio.wait_for(anext(it), timeout=10)
+                await _flush()
+                # Each yield frees exactly one group slot on the consumer's next
+                # resume, so submission tracks consumption with a one-slot skew
+                # (the release for the latest pull hasn't fired yet). On
+                # assembly-release semantics this runs away unbounded; if no
+                # consume-site release existed, the loop would deadlock at
+                # `pulled == capacity + 1`.
+                assert gen.prepare_group_rollout_calls == capacity + pulled - 1
+        finally:
+            await it.aclose()
+
+    @pytest.mark.asyncio
+    async def test_batch_submission_releases_once_per_batch(self):
+        gen = MockGenerator(parallel_generation_tasks=1)
+        request = GroupedRolloutRequest(
+            num_groups=2,
+            rollouts_per_group=1,
+            inference_interface=MockInferenceInterface(),
+            streaming=True,
+            submission_granularity="B",
+            consumption_granularity="B",
+        )
+        it = gen.get_grouped_rollouts(request)
+        try:
+            await asyncio.wait_for(anext(it), timeout=10)
+            await asyncio.wait_for(anext(it), timeout=10)
+            await _flush()
+            gate = gen._active_pipeline.gate
+            # Batch 0 fully yielded but the consumer hasn't come back yet: its
+            # single batch slot is still held (a per-group release here would
+            # show release_calls == 2 and prepared == 4).
+            assert gate.release_calls == 0
+            assert gen.prepare_group_rollout_calls == 2
+            await asyncio.wait_for(anext(it), timeout=10)
+            await _flush()
+            assert gate.release_calls == 1
+            assert gen.prepare_group_rollout_calls == 4
+        finally:
+            await it.aclose()
 
 
 class TestRewardRollouts:


### PR DESCRIPTION
## What does this PR do?

With G submission, the rollout pipeline's submission gate freed slots when a group finished **assembling**, so submission ran open-loop ahead of trainer consumption: the `(lag+1) * prompts` run-ahead cap was never enforced, in-flight backlog grew without bound (43k rollouts by step 8 in a lag5 G/G run), staleness exceeded the configured `--rl-generation-lag`, and fast envs converted engine capacity into unconsumable surplus that starved the binding env's admission.

This PR moves the G-submission release point to trainer **consumption** (`stage_consume`), matching B. R still releases when inference completes. With that, each granularity has exactly one release point fully determined by the granularity, so the second commit removes the now-redundant release-state indirection (`ReleaseState`, `RELEASE_STATE_BY_SUBMISSION`) and collapses `release_after(state, granularity)` to `release_for(granularity)`, mirroring `acquire_for`.

**Known bounded caveat:** `WeightedMultiTask`'s `balanced_rollouts` queue pulls up to one round (≤ `prompts_per_step` groups) ahead of true trainer consumption, so per-env backlog is now "capacity + ≤ 1 round" rather than zero. Expected observable shifts: `pipeline_gate_held` sits near capacity in steady state, and G-run generation genuinely stalls at the run-ahead cap.

## Changes

- `megatron/rl/agent/api.py`: release G slots in `stage_consume`, keyed per granularity so the reorder branch releases per group for G and per batch for B without cross-granularity over/under-release; drop the release-state indirection.
- `megatron/rl/rollout_granularity.py`: remove `ReleaseState` and `RELEASE_STATE_BY_SUBMISSION`.
- `tests/unit_tests/rl/test_grouped_rollouts.py`: new unit tests covering run-ahead enforcement under G submission.

## Testing

`tests/unit_tests/rl/test_grouped_rollouts.py` — 23 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)