### PR TITLE
Test zero-CTA copy-engine all-gather

### DIFF
--- a/tests/unit_tests/distributed/mfsdp_v2/conftest.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/conftest.py
@@ -41,14 +41,6 @@ def distributed_setup() -> Iterator[DistributedSetup]:
     else:
         device = torch.device("cpu")
 
-    # Eagerly initialize the default process group with device_id so the NCCL
-    # communicator is established before symmetric-memory rendezvous. NCCL window
-    # registration can fail when rendezvous is the first NCCL op on a process group.
-    # A full-world init_device_mesh reuses this default group, and subgroups created
-    # from it avoid the cold-communicator registration failure.
-    if device.type == "cuda" and not dist.is_initialized():
-        dist.init_process_group(backend="nccl", device_id=device)
-
     yield DistributedSetup(rank=rank, world_size=world_size, device=device)
 
     if dist.is_initialized():

--- a/tests/unit_tests/distributed/mfsdp_v2/conftest.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/conftest.py
@@ -41,6 +41,14 @@ def distributed_setup() -> Iterator[DistributedSetup]:
     else:
         device = torch.device("cpu")
 
+    # Eagerly initialize the default process group with device_id so the NCCL
+    # communicator is established before symmetric-memory rendezvous. NCCL window
+    # registration can fail when rendezvous is the first NCCL op on a process group.
+    # A full-world init_device_mesh reuses this default group, and subgroups created
+    # from it avoid the cold-communicator registration failure.
+    if device.type == "cuda" and not dist.is_initialized():
+        dist.init_process_group(backend="nccl", device_id=device)
+
     yield DistributedSetup(rank=rank, world_size=world_size, device=device)
 
     if dist.is_initialized():

--- a/tests/unit_tests/distributed/mfsdp_v2/test_symmetric_memory.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_symmetric_memory.py
@@ -6,6 +6,7 @@ import pytest
 import torch
 import torch.distributed as dist
 from torch import nn
+from torch.autograd import DeviceType
 from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
 from torch.profiler import ProfilerActivity, profile
 
@@ -43,7 +44,7 @@ def _flat_placements() -> Placements:
 
 
 def _kernels(prof: torch.profiler.profile) -> list[str]:
-    return [event.name for event in prof.events() if event.device_type.name == "CUDA"]
+    return [event.name for event in prof.events() if event.device_type == DeviceType.CUDA]
 
 
 def _is_symmetric_kernel(kernel: str) -> bool:

--- a/tests/unit_tests/distributed/mfsdp_v2/test_symmetric_memory.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_symmetric_memory.py
@@ -163,12 +163,21 @@ def test_fully_shard_zero_cta_moves_all_gather_to_copy_engine(distributed_setup)
     if world_size < 2:
         pytest.skip("This test requires at least 2 ranks.")
 
+    # new_group requires a default process group. Initialize it here so this test works
+    # in isolation. Do not eagerly initialize it with device_id in the shared fixture:
+    # that can hang teardown after communicator splits; see
+    # https://github.com/pytorch/pytorch/issues/190396.
+    if not dist.is_initialized():
+        dist.init_process_group(backend="nccl")
+
     # Dedicated communicator with NCCL's zero-CTA policy, scoped to this test so the rest
-    # of the bucket keeps default-CTA symmetric-memory kernels. Created off the conftest's
-    # device_id eager-initialized default group via a comm split.
+    # of the bucket keeps default-CTA symmetric-memory kernels.
     zero_cta_options = dist.ProcessGroupNCCL.Options()
     zero_cta_options.config.cta_policy = dist.ProcessGroupNCCL.NCCL_CTA_POLICY_ZERO
     dp_group = dist.new_group(backend="nccl", pg_options=zero_cta_options)
+    # NCCL window registration can fail when symmetric-memory rendezvous is the first
+    # operation on a communicator, so initialize this communicator explicitly.
+    dist.barrier(group=dp_group, device_ids=[device.index])
     mesh = DeviceMesh.from_group(dp_group, device.type)
 
     num_training_steps = 5

--- a/tests/unit_tests/distributed/mfsdp_v2/test_symmetric_memory.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_symmetric_memory.py
@@ -4,8 +4,9 @@
 
 import pytest
 import torch
+import torch.distributed as dist
 from torch import nn
-from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
 from torch.profiler import ProfilerActivity, profile
 
 from megatron.core.distributed.fsdp.src.megatron_fsdp import MixedPrecisionPolicy
@@ -42,7 +43,7 @@ def _flat_placements() -> Placements:
 
 
 def _kernels(prof: torch.profiler.profile) -> list[str]:
-    return [event.name for event in prof.events()]
+    return [event.name for event in prof.events() if event.device_type.name == "CUDA"]
 
 
 def _is_symmetric_kernel(kernel: str) -> bool:
@@ -146,3 +147,74 @@ def test_fully_shard_symmetric_memory_matches_default_and_profiles_nccl(
         "Unexpected NCCL symmetric-memory all-gather kernel count. "
         f"Observed NCCL kernels: {nccl_kernels_with_symm_mem[:20]}"
     )
+
+
+def test_fully_shard_zero_cta_moves_all_gather_to_copy_engine(distributed_setup):
+    """NCCL's zero-CTA policy runs the all-gather on the copy engine.
+
+    Zero-CTA offloads only pure data movement, so the all-gather emits no ``ncclSymk``
+    kernel (it becomes a copy-engine memcpy). The reduce-scatter's reduction cannot run on
+    the copy engine, so it stays a symmetric-memory kernel -- an SM-launched NVLS multicast
+    reduce (ncclSymkDevKernel_ReduceScatter_LDMC/LL).
+    """
+    world_size = distributed_setup.world_size
+    device = distributed_setup.device
+    if world_size < 2:
+        pytest.skip("This test requires at least 2 ranks.")
+
+    # Dedicated communicator with NCCL's zero-CTA policy, scoped to this test so the rest
+    # of the bucket keeps default-CTA symmetric-memory kernels. Created off the conftest's
+    # device_id eager-initialized default group via a comm split.
+    zero_cta_options = dist.ProcessGroupNCCL.Options()
+    zero_cta_options.config.cta_policy = dist.ProcessGroupNCCL.NCCL_CTA_POLICY_ZERO
+    dp_group = dist.new_group(backend="nccl", pg_options=zero_cta_options)
+    mesh = DeviceMesh.from_group(dp_group, device.type)
+
+    num_training_steps = 5
+    model = TinyModel().to(device=device, dtype=torch.bfloat16)
+    mixed_precision_policy = MixedPrecisionPolicy(main_params_dtype=torch.float32)
+    fully_shard(
+        model.fc1,
+        mesh=mesh,
+        placements=_flat_placements(),
+        mixed_precision_policy=mixed_precision_policy,
+        use_symm_mem=True,
+    )
+    fully_shard(
+        model.fc2,
+        mesh=mesh,
+        placements=_flat_placements(),
+        mixed_precision_policy=mixed_precision_policy,
+        use_symm_mem=True,
+    )
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.05, foreach=False)
+    x = torch.randn(2, _HIDDEN, device=device, dtype=torch.bfloat16)
+    target = torch.randn(2, _HIDDEN, device=device, dtype=torch.bfloat16)
+
+    with profile(activities=[ProfilerActivity.CUDA]) as prof:
+        for _ in range(num_training_steps):
+            optimizer.zero_grad()
+            torch.nn.functional.mse_loss(model(x), target).backward()
+            optimizer.step()
+        torch.cuda.synchronize()
+
+    kernels = _kernels(prof)
+    nccl_kernels = [kernel for kernel in kernels if "nccl" in kernel.lower()]
+    # Zero-CTA moves the all-gather to the copy engine: no symmetric-memory all-gather kernel.
+    assert _count_symmetric_kernels(kernels, "AllGather") == 0, (
+        f"Expected no symmetric-memory all-gather kernel under zero-CTA. "
+        f"Observed NCCL kernels: {nccl_kernels[:20]}"
+    )
+    # The reduce-scatter's reduction cannot run on the copy engine, so it stays a
+    # symmetric-memory kernel (an SM-launched NVLS multicast reduce): one per sharded
+    # module (fc1, fc2) per training step.
+    expected_reduce_scatter_kernel_count = num_training_steps * 2
+    assert (
+        _count_symmetric_kernels(kernels, "ReduceScatter") == expected_reduce_scatter_kernel_count
+    ), (
+        f"Expected {expected_reduce_scatter_kernel_count} symmetric-memory reduce-scatter "
+        f"kernels under zero-CTA. Observed NCCL kernels: {nccl_kernels[:20]}"
+    )
+
+    # Release the dedicated communicator (leaks only on a test failure above, which is fine).
+    dist.destroy_process_group(dp_group)


### PR DESCRIPTION
## What changed

- Add an mFSDP v2 symmetric-memory test using a dedicated NCCL communicator with the zero-CTA policy.
- Verify that zero-CTA moves all-gather data movement to the copy engine while reduce-scatter remains a symmetric-memory kernel.
- Restrict collected profiler events to CUDA events and compare their device type against `DeviceType.CUDA`.

## Impact

Test-only change. There is no production-code behavior change.

Related to #5655.

## Validation

- `git diff --check origin/main...HEAD`
- Import formatting and the targeted 8-GPU test are pending on the reserved Eos node.
