### PR TITLE
Test mFSDP v2 overlap with default and symmetric memory

### DIFF
--- a/tests/unit_tests/distributed/mfsdp_v2/conftest.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/conftest.py
@@ -41,6 +41,16 @@ def distributed_setup() -> Iterator[DistributedSetup]:
     else:
         device = torch.device("cpu")
 
+    # Eagerly initialize the default process group with device_id so the NCCL
+    # communicator is fully established up front. NCCL symmetric-memory window
+    # registration (use_symm_mem=True) fails with a "window register / invalid
+    # argument" error when the rendezvous is the first NCCL op on the process group
+    # (https://github.com/pytorch/pytorch/issues/188567). Passing device_id forces
+    # eager communicator initialization, and a full-world init_device_mesh reuses
+    # this default group, so the eager init carries through to the mesh's collectives.
+    if device.type == "cuda" and not dist.is_initialized():
+        dist.init_process_group(backend="nccl", device_id=device)
+
     yield DistributedSetup(rank=rank, world_size=world_size, device=device)
 
     if dist.is_initialized():

--- a/tests/unit_tests/distributed/mfsdp_v2/conftest.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/conftest.py
@@ -41,16 +41,6 @@ def distributed_setup() -> Iterator[DistributedSetup]:
     else:
         device = torch.device("cpu")
 
-    # Eagerly initialize the default process group with device_id so the NCCL
-    # communicator is fully established up front. NCCL symmetric-memory window
-    # registration (use_symm_mem=True) fails with a "window register / invalid
-    # argument" error when the rendezvous is the first NCCL op on the process group
-    # (https://github.com/pytorch/pytorch/issues/188567). Passing device_id forces
-    # eager communicator initialization, and a full-world init_device_mesh reuses
-    # this default group, so the eager init carries through to the mesh's collectives.
-    if device.type == "cuda" and not dist.is_initialized():
-        dist.init_process_group(backend="nccl", device_id=device)
-
     yield DistributedSetup(rank=rank, world_size=world_size, device=device)
 
     if dist.is_initialized():

--- a/tests/unit_tests/distributed/mfsdp_v2/profiler_utils.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/profiler_utils.py
@@ -17,44 +17,31 @@ def _linked_correlation_id(event: FunctionEvent) -> int | None:
     return getattr(event, "linked_correlation_id", None)
 
 
-def _is_device_work(event: FunctionEvent) -> bool:
-    return event.device_type == DeviceType.CUDA and not event.name.startswith("nccl:")
+def _is_device_kernel(event: FunctionEvent) -> bool:
+    return (
+        event.device_type == DeviceType.CUDA
+        and event.activity_type == "kernel"
+        and not event.name.startswith("nccl:")
+    )
 
 
 def collect_linked_device_events(
     events: list[FunctionEvent], cpu_event_name_substring: str
 ) -> list[FunctionEvent]:
-    """Collect device events linked to matching CPU op instances.
+    """Collect device kernel events linked to matching CPU op instances.
 
     Device events are attributed by their launching CPU op rather than searched by their
     own name: device-side names vary across GPU architectures and kernel libraries -- for
-    example a matmul kernel is named ``nvjet_``/``cutlass_``/``cublas_``... while its CPU
-    op is simply ``aten::mm``, and under zero-CTA the all-gather is not even a distinct
-    kernel, just a generic copy-engine ``Memcpy``.
+    example a matmul kernel is named ``nvjet_``/``cutlass_``/``cublas_``... while its
+    CPU op is simply ``aten::mm``.
 
-    Returns a flat list of device events in matching CPU-op order.
-    """
-    return [
-        event
-        for group in collect_linked_device_event_groups(events, cpu_event_name_substring)
-        for event in group
-    ]
-
-
-def collect_linked_device_event_groups(
-    events: list[FunctionEvent], cpu_event_name_substring: str
-) -> list[list[FunctionEvent]]:
-    """Collect device events grouped by matching CPU op instance.
-
-    One logical CPU op can emit multiple device events; zero-CTA all-gather, for example,
-    decomposes into several copy-engine memcpys.
+    Zero-CTA all-gather copy-engine memcpys are not kernels and are intentionally not
+    returned.
     """
     # A correlation id is shared by a device event and the leaf runtime op that issued it,
     # not the enclosing matched op, so walk cpu_parent up from each correlated leaf. Id 0
     # is the "no device correlation" sentinel and is skipped.
-    correlation_to_group: dict[int, int] = {}
-    group_index_by_cpu_event: dict[int, int] = {}
-    groups: list[list[FunctionEvent]] = []
+    matching_correlations: set[int] = set()
     for event in events:
         correlation_id = _linked_correlation_id(event)
         if event.device_type != DeviceType.CPU or not correlation_id:
@@ -62,20 +49,12 @@ def collect_linked_device_event_groups(
         node = event
         while node is not None:
             if cpu_event_name_substring in node.name:
-                cpu_event_id = id(node)
-                group_index = group_index_by_cpu_event.get(cpu_event_id)
-                if group_index is None:
-                    group_index = len(groups)
-                    group_index_by_cpu_event[cpu_event_id] = group_index
-                    groups.append([])
-                correlation_to_group[correlation_id] = group_index
+                matching_correlations.add(correlation_id)
                 break
             node = node.cpu_parent
 
-    for event in events:
-        correlation_id = _linked_correlation_id(event)
-        group_index = correlation_to_group.get(correlation_id)
-        if _is_device_work(event) and group_index is not None:
-            groups[group_index].append(event)
-
-    return [group for group in groups if group]
+    return [
+        event
+        for event in events
+        if _is_device_kernel(event) and _linked_correlation_id(event) in matching_correlations
+    ]

--- a/tests/unit_tests/distributed/mfsdp_v2/profiler_utils.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/profiler_utils.py
@@ -13,6 +13,14 @@ def events_overlap(first: FunctionEvent, second: FunctionEvent) -> bool:
     )
 
 
+def _linked_correlation_id(event: FunctionEvent) -> int | None:
+    return getattr(event, "linked_correlation_id", None)
+
+
+def _is_device_work(event: FunctionEvent) -> bool:
+    return event.device_type == DeviceType.CUDA and not event.name.startswith("nccl:")
+
+
 def collect_linked_device_events(
     events: list[FunctionEvent], cpu_event_name_substring: str
 ) -> list[FunctionEvent]:
@@ -24,25 +32,50 @@ def collect_linked_device_events(
     op is simply ``aten::mm``, and under zero-CTA the all-gather is not even a distinct
     kernel, just a generic copy-engine ``Memcpy``.
 
-    Returns a list of device events in event order.
+    Returns a flat list of device events in matching CPU-op order.
+    """
+    return [
+        event
+        for group in collect_linked_device_event_groups(events, cpu_event_name_substring)
+        for event in group
+    ]
+
+
+def collect_linked_device_event_groups(
+    events: list[FunctionEvent], cpu_event_name_substring: str
+) -> list[list[FunctionEvent]]:
+    """Collect device events grouped by matching CPU op instance.
+
+    One logical CPU op can emit multiple device events; zero-CTA all-gather, for example,
+    decomposes into several copy-engine memcpys.
     """
     # A correlation id is shared by a device event and the leaf runtime op that issued it,
     # not the enclosing matched op, so walk cpu_parent up from each correlated leaf. Id 0
     # is the "no device correlation" sentinel and is skipped.
-    matching_correlations: set[int] = set()
+    correlation_to_group: dict[int, int] = {}
+    group_index_by_cpu_event: dict[int, int] = {}
+    groups: list[list[FunctionEvent]] = []
     for event in events:
-        if event.device_type != DeviceType.CPU or not event.linked_correlation_id:
+        correlation_id = _linked_correlation_id(event)
+        if event.device_type != DeviceType.CPU or not correlation_id:
             continue
         node = event
         while node is not None:
             if cpu_event_name_substring in node.name:
-                matching_correlations.add(event.linked_correlation_id)
+                cpu_event_id = id(node)
+                group_index = group_index_by_cpu_event.get(cpu_event_id)
+                if group_index is None:
+                    group_index = len(groups)
+                    group_index_by_cpu_event[cpu_event_id] = group_index
+                    groups.append([])
+                correlation_to_group[correlation_id] = group_index
                 break
             node = node.cpu_parent
 
-    return [
-        event
-        for event in events
-        if event.device_type == DeviceType.CUDA
-        and event.linked_correlation_id in matching_correlations
-    ]
+    for event in events:
+        correlation_id = _linked_correlation_id(event)
+        group_index = correlation_to_group.get(correlation_id)
+        if _is_device_work(event) and group_index is not None:
+            groups[group_index].append(event)
+
+    return [group for group in groups if group]

--- a/tests/unit_tests/distributed/mfsdp_v2/profiler_utils.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/profiler_utils.py
@@ -2,8 +2,6 @@
 
 """Helpers for parsing ``torch.profiler`` events in the mfsdp_v2 tests."""
 
-import re
-
 from torch.autograd import DeviceType
 from torch.autograd.profiler_util import FunctionEvent
 
@@ -16,7 +14,7 @@ def events_overlap(first: FunctionEvent, second: FunctionEvent) -> bool:
 
 
 def collect_linked_device_events(
-    events: list[FunctionEvent], cpu_event_name_pattern: re.Pattern
+    events: list[FunctionEvent], cpu_event_name_substring: str
 ) -> dict[FunctionEvent, list[FunctionEvent]]:
     """Map each matching CPU op instance to the device events linked to it.
 
@@ -38,7 +36,7 @@ def collect_linked_device_events(
             continue
         node = event
         while node is not None:
-            if cpu_event_name_pattern.search(node.name):
+            if cpu_event_name_substring in node.name:
                 op_by_correlation[event.linked_correlation_id] = node
                 break
             node = node.cpu_parent

--- a/tests/unit_tests/distributed/mfsdp_v2/profiler_utils.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/profiler_utils.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Helpers for parsing ``torch.profiler`` events in the mfsdp_v2 tests."""
+
+import re
+
+from torch.autograd.profiler_util import FunctionEvent
+
+
+def events_overlap(first: FunctionEvent, second: FunctionEvent) -> bool:
+    return (
+        first.time_range.start < second.time_range.end
+        and second.time_range.start < first.time_range.end
+    )
+
+
+def collect_linked_device_events(
+    events: list[FunctionEvent], cpu_event_name_pattern: re.Pattern
+) -> dict[FunctionEvent, list[FunctionEvent]]:
+    """Map each matching CPU op instance to the device events linked to it.
+
+    Device events are attributed by their launching CPU op rather than searched by their
+    own name: device-side names vary across GPU architectures and kernel libraries -- for
+    example a matmul kernel is named ``nvjet_``/``cutlass_``/``cublas_``... while its CPU
+    op is simply ``aten::mm``, and under zero-CTA the all-gather is not even a distinct
+    kernel, just a generic copy-engine ``Memcpy``.
+
+    Returns a dict, in event order, from each matching op (one per instance) to its
+    device events.
+    """
+    # A correlation id is shared by a device event and the leaf runtime op that issued it,
+    # not the enclosing matched op, so walk cpu_parent up from each correlated leaf. Id 0
+    # is the "no device correlation" sentinel and is skipped.
+    op_by_correlation: dict[int, FunctionEvent] = {}
+    for event in events:
+        if event.device_type.name != "CPU" or not event.linked_correlation_id:
+            continue
+        node = event
+        while node is not None:
+            if cpu_event_name_pattern.search(node.name):
+                op_by_correlation[event.linked_correlation_id] = node
+                break
+            node = node.cpu_parent
+
+    device_events_by_op: dict[FunctionEvent, list[FunctionEvent]] = {}
+    for event in events:
+        if event.device_type.name != "CUDA":
+            continue
+        op = op_by_correlation.get(event.linked_correlation_id)
+        if op is not None:
+            device_events_by_op.setdefault(op, []).append(event)
+    return device_events_by_op

--- a/tests/unit_tests/distributed/mfsdp_v2/profiler_utils.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/profiler_utils.py
@@ -4,6 +4,7 @@
 
 import re
 
+from torch.autograd import DeviceType
 from torch.autograd.profiler_util import FunctionEvent
 
 
@@ -33,7 +34,7 @@ def collect_linked_device_events(
     # is the "no device correlation" sentinel and is skipped.
     op_by_correlation: dict[int, FunctionEvent] = {}
     for event in events:
-        if event.device_type.name != "CPU" or not event.linked_correlation_id:
+        if event.device_type != DeviceType.CPU or not event.linked_correlation_id:
             continue
         node = event
         while node is not None:
@@ -44,7 +45,7 @@ def collect_linked_device_events(
 
     device_events_by_op: dict[FunctionEvent, list[FunctionEvent]] = {}
     for event in events:
-        if event.device_type.name != "CUDA":
+        if event.device_type != DeviceType.CUDA:
             continue
         op = op_by_correlation.get(event.linked_correlation_id)
         if op is not None:

--- a/tests/unit_tests/distributed/mfsdp_v2/profiler_utils.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/profiler_utils.py
@@ -15,8 +15,8 @@ def events_overlap(first: FunctionEvent, second: FunctionEvent) -> bool:
 
 def collect_linked_device_events(
     events: list[FunctionEvent], cpu_event_name_substring: str
-) -> dict[FunctionEvent, list[FunctionEvent]]:
-    """Map each matching CPU op instance to the device events linked to it.
+) -> list[list[FunctionEvent]]:
+    """Collect device events linked to each matching CPU op instance.
 
     Device events are attributed by their launching CPU op rather than searched by their
     own name: device-side names vary across GPU architectures and kernel libraries -- for
@@ -24,8 +24,8 @@ def collect_linked_device_events(
     op is simply ``aten::mm``, and under zero-CTA the all-gather is not even a distinct
     kernel, just a generic copy-engine ``Memcpy``.
 
-    Returns a dict, in event order, from each matching op (one per instance) to its
-    device events.
+    Returns a list, in event order, where each entry contains the device events for one
+    matching op instance.
     """
     # A correlation id is shared by a device event and the leaf runtime op that issued it,
     # not the enclosing matched op, so walk cpu_parent up from each correlated leaf. Id 0
@@ -48,4 +48,4 @@ def collect_linked_device_events(
         op = op_by_correlation.get(event.linked_correlation_id)
         if op is not None:
             device_events_by_op.setdefault(op, []).append(event)
-    return device_events_by_op
+    return list(device_events_by_op.values())

--- a/tests/unit_tests/distributed/mfsdp_v2/profiler_utils.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/profiler_utils.py
@@ -4,6 +4,7 @@
 
 from torch.autograd import DeviceType
 from torch.autograd.profiler_util import FunctionEvent
+from torch.profiler import profile as TorchProfiler
 
 
 def events_overlap(first: FunctionEvent, second: FunctionEvent) -> bool:
@@ -13,20 +14,8 @@ def events_overlap(first: FunctionEvent, second: FunctionEvent) -> bool:
     )
 
 
-def _linked_correlation_id(event: FunctionEvent) -> int | None:
-    return getattr(event, "linked_correlation_id", None)
-
-
-def _is_device_kernel(event: FunctionEvent) -> bool:
-    return (
-        event.device_type == DeviceType.CUDA
-        and event.activity_type == "kernel"
-        and not event.name.startswith("nccl:")
-    )
-
-
-def collect_linked_device_events(
-    events: list[FunctionEvent], cpu_event_name_substring: str
+def collect_linked_kernels(
+    prof: TorchProfiler, cpu_event_name_substring: str
 ) -> list[FunctionEvent]:
     """Collect device kernel events linked to matching CPU op instances.
 
@@ -41,20 +30,26 @@ def collect_linked_device_events(
     # A correlation id is shared by a device event and the leaf runtime op that issued it,
     # not the enclosing matched op, so walk cpu_parent up from each correlated leaf. Id 0
     # is the "no device correlation" sentinel and is skipped.
+    events = prof.events()
     matching_correlations: set[int] = set()
     for event in events:
-        correlation_id = _linked_correlation_id(event)
-        if event.device_type != DeviceType.CPU or not correlation_id:
+        if event.device_type != DeviceType.CPU or not event.linked_correlation_id:
             continue
         node = event
         while node is not None:
             if cpu_event_name_substring in node.name:
-                matching_correlations.add(correlation_id)
+                matching_correlations.add(event.linked_correlation_id)
                 break
             node = node.cpu_parent
 
-    return [
-        event
-        for event in events
-        if _is_device_kernel(event) and _linked_correlation_id(event) in matching_correlations
-    ]
+    linked_kernels: list[FunctionEvent] = []
+    for event in events:
+        if event.device_type != DeviceType.CUDA:
+            continue
+        if event.activity_type != "kernel":
+            continue
+        if event.linked_correlation_id not in matching_correlations:
+            continue
+        linked_kernels.append(event)
+
+    return linked_kernels

--- a/tests/unit_tests/distributed/mfsdp_v2/profiler_utils.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/profiler_utils.py
@@ -15,8 +15,8 @@ def events_overlap(first: FunctionEvent, second: FunctionEvent) -> bool:
 
 def collect_linked_device_events(
     events: list[FunctionEvent], cpu_event_name_substring: str
-) -> list[list[FunctionEvent]]:
-    """Collect device events linked to each matching CPU op instance.
+) -> list[FunctionEvent]:
+    """Collect device events linked to matching CPU op instances.
 
     Device events are attributed by their launching CPU op rather than searched by their
     own name: device-side names vary across GPU architectures and kernel libraries -- for
@@ -24,28 +24,25 @@ def collect_linked_device_events(
     op is simply ``aten::mm``, and under zero-CTA the all-gather is not even a distinct
     kernel, just a generic copy-engine ``Memcpy``.
 
-    Returns a list, in event order, where each entry contains the device events for one
-    matching op instance.
+    Returns a list of device events in event order.
     """
     # A correlation id is shared by a device event and the leaf runtime op that issued it,
     # not the enclosing matched op, so walk cpu_parent up from each correlated leaf. Id 0
     # is the "no device correlation" sentinel and is skipped.
-    op_by_correlation: dict[int, FunctionEvent] = {}
+    matching_correlations: set[int] = set()
     for event in events:
         if event.device_type != DeviceType.CPU or not event.linked_correlation_id:
             continue
         node = event
         while node is not None:
             if cpu_event_name_substring in node.name:
-                op_by_correlation[event.linked_correlation_id] = node
+                matching_correlations.add(event.linked_correlation_id)
                 break
             node = node.cpu_parent
 
-    device_events_by_op: dict[FunctionEvent, list[FunctionEvent]] = {}
-    for event in events:
-        if event.device_type != DeviceType.CUDA:
-            continue
-        op = op_by_correlation.get(event.linked_correlation_id)
-        if op is not None:
-            device_events_by_op.setdefault(op, []).append(event)
-    return list(device_events_by_op.values())
+    return [
+        event
+        for event in events
+        if event.device_type == DeviceType.CUDA
+        and event.linked_correlation_id in matching_correlations
+    ]

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -488,7 +488,7 @@ def test_root_backward_returns_to_resting_memory(distributed_setup):
 @pytest.mark.parametrize(
     "use_symm_mem",
     [
-        pytest.param(False, marks=[pytest.mark.flaky, pytest.mark.flaky_in_dev], id="default"),
+        pytest.param(False, id="default"),
         pytest.param(True, id="symmetric_memory"),
     ],
 )
@@ -510,6 +510,13 @@ def test_overlaps_communication_and_compute(distributed_setup, use_symm_mem):
     num_children = 4
     dtype = torch.bfloat16
 
+    # new_group requires a default process group. Initialize it here so this test works
+    # in isolation. Do not eagerly initialize it with device_id in the shared fixture:
+    # that can hang teardown after communicator splits; see
+    # https://github.com/pytorch/pytorch/issues/190396.
+    if not dist.is_initialized():
+        dist.init_process_group(backend="nccl")
+
     if use_symm_mem:
         # Dedicated communicator with NCCL's zero-CTA policy. cta_policy is a
         # per-communicator property, so scoping it to this group leaves the rest of the
@@ -518,13 +525,13 @@ def test_overlaps_communication_and_compute(distributed_setup, use_symm_mem):
         # memcpys). This 1-D group models the DP (FSDP) sub-mesh that mfsdp is handed in
         # production: with EP/TP the full device mesh is multi-dimensional, but mfsdp
         # requires an all-FSDP mesh (see experimental/module.py) and never sees the TP/EP
-        # axes, so only the DP communicator needs the zero-CTA policy. Creating the group
-        # off the conftest's device_id eager-initialized default process group uses a comm
-        # split, which avoids the cold-communicator symmetric-memory rendezvous failure
-        # (https://github.com/pytorch/pytorch/issues/188567).
+        # axes, so only the DP communicator needs the zero-CTA policy.
         zero_cta_options = dist.ProcessGroupNCCL.Options()
         zero_cta_options.config.cta_policy = dist.ProcessGroupNCCL.NCCL_CTA_POLICY_ZERO
         dp_group = dist.new_group(backend="nccl", pg_options=zero_cta_options)
+        # NCCL window registration can fail when symmetric-memory rendezvous is the first
+        # operation on a communicator, so initialize this communicator explicitly.
+        dist.barrier(group=dp_group, device_ids=[device.index])
     else:
         dp_group = dist.new_group(backend="nccl")
 

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -497,12 +497,29 @@ def test_overlaps_communication_and_compute(distributed_setup):
     dim = 16384
     num_children = 4
     dtype = torch.bfloat16
+
+    # Use NCCL symmetric-memory collectives so the all-gather and reduce-scatter run
+    # as SM-light NVLS multicast kernels (ncclSymk*) instead of SM-based ring kernels.
+    # Ring kernels contend with the GEMMs for SMs, so their overlap count jitters with
+    # launch timing (amplified by CI's coverage wrapper) and dips below the theoretical
+    # maximum; the multicast kernels offload data movement to NVLink/NVSwitch and keep
+    # the overlap count deterministic, which is what lets the strict thresholds below hold.
+    # (Symmetric-memory window registration needs an initialized NCCL communicator; the
+    # conftest eagerly initializes the process group with device_id so this holds.)
     model = MultiChildModel(dim=dim, num_children=num_children).to(dtype=dtype)
     placements = _flat_placements()
     policy = MixedPrecisionPolicy(main_params_dtype=dtype, main_grads_dtype=dtype)
     for layer in model.layers:
-        fully_shard(layer, mesh=mesh, placements=placements, mixed_precision_policy=policy)
-    fully_shard(model, mesh=mesh, placements=placements, mixed_precision_policy=policy)
+        fully_shard(
+            layer,
+            mesh=mesh,
+            placements=placements,
+            mixed_precision_policy=policy,
+            use_symm_mem=True,
+        )
+    fully_shard(
+        model, mesh=mesh, placements=placements, mixed_precision_policy=policy, use_symm_mem=True
+    )
 
     x = torch.randn(4096, dim, device=device, dtype=dtype, requires_grad=True)
 
@@ -560,18 +577,20 @@ def test_overlaps_communication_and_compute(distributed_setup):
         any(_events_overlap(reduce_scatter_event, gemm_event) for gemm_event in gemm_events)
         for reduce_scatter_event in reduce_scatter_events
     )
-    # With dim large enough for the GEMMs to dominate launch jitter (see above),
-    # the prefetched collectives overlap compute deterministically, so assert the
-    # theoretical maxima (2*(num_children - 1) all-gathers across forward and
-    # backward, num_children - 1 reduce-scatters in backward) rather than a loose
-    # floor.
-    assert all_gather_overlap_count >= 2 * (num_children - 1), (
-        f"Expected all-gather to overlap compute, "
+    # With symmetric-memory (SM-light multicast) collectives the overlap count is
+    # deterministic, so assert the theoretical maximum. Each of the num_children - 1
+    # non-root children contributes a forward all-gather and a backward all-gather that
+    # overlap a GEMM (2 * (num_children - 1)), and each non-root child's reduce-scatter
+    # overlaps a backward GEMM (num_children - 1).
+    expected_all_gather_overlap = 2 * (num_children - 1)
+    expected_reduce_scatter_overlap = num_children - 1
+    assert all_gather_overlap_count >= expected_all_gather_overlap, (
+        f"Expected at least {expected_all_gather_overlap} all-gathers to overlap compute, "
         f"got {all_gather_overlap_count}/{len(all_gather_events)}."
     )
-    assert reduce_scatter_overlap_count >= num_children - 1, (
-        f"Expected reduce-scatter to overlap compute, "
-        f"got {reduce_scatter_overlap_count}/{len(reduce_scatter_events)}."
+    assert reduce_scatter_overlap_count >= expected_reduce_scatter_overlap, (
+        f"Expected at least {expected_reduce_scatter_overlap} reduce-scatters to overlap "
+        f"compute, got {reduce_scatter_overlap_count}/{len(reduce_scatter_events)}."
     )
 
 

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -23,7 +23,6 @@ from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
 )
 from megatron.core.distributed.fsdp.src.megatron_fsdp.mixed_precision import MixedPrecisionPolicy
 from tests.unit_tests.distributed.mfsdp_v2.profiler_utils import (
-    collect_linked_device_event_groups,
     collect_linked_device_events,
     events_overlap,
 )
@@ -580,33 +579,26 @@ def test_overlaps_communication_and_compute(distributed_setup, use_symm_mem):
         f"{[event.name for event in gemm_events]}"
     )
 
-    all_gather_event_groups = collect_linked_device_event_groups(
-        events, _ALL_GATHER_OP_NAME_SUBSTRING
-    )
-    reduce_scatter_event_groups = collect_linked_device_event_groups(
-        events, _REDUCE_SCATTER_OP_NAME_SUBSTRING
-    )
+    all_gather_events = collect_linked_device_events(events, _ALL_GATHER_OP_NAME_SUBSTRING)
+    reduce_scatter_events = collect_linked_device_events(events, _REDUCE_SCATTER_OP_NAME_SUBSTRING)
     # The num_children child layers plus the root are each a sharded module; each does a
-    # forward and a backward all-gather and one reduce-scatter. Zero-CTA all-gather can
-    # emit several copy-engine events, so count linked CPU-op groups here.
+    # forward and a backward all-gather and one reduce-scatter. Zero-CTA moves the
+    # all-gather to copy-engine memcpys, so it should not emit all-gather kernels.
     num_sharded_modules = num_children + 1
-    assert len(reduce_scatter_event_groups) == num_sharded_modules, (
-        f"Expected {num_sharded_modules} reduce-scatters, got "
-        f"{len(reduce_scatter_event_groups)}: "
-        f"{[[event.name for event in group] for group in reduce_scatter_event_groups]}"
+    expected_all_gather_count = 0 if use_symm_mem else 2 * num_sharded_modules
+    assert len(all_gather_events) == expected_all_gather_count, (
+        f"Expected {expected_all_gather_count} all-gather kernels, got "
+        f"{len(all_gather_events)}: {[event.name for event in all_gather_events]}"
     )
-    assert len(all_gather_event_groups) == 2 * num_sharded_modules, (
-        f"Expected {2 * num_sharded_modules} all-gathers, got "
-        f"{len(all_gather_event_groups)}: "
-        f"{[[event.name for event in group] for group in all_gather_event_groups]}"
+    assert len(reduce_scatter_events) == num_sharded_modules, (
+        f"Expected {num_sharded_modules} reduce-scatter kernels, got "
+        f"{len(reduce_scatter_events)}: {[event.name for event in reduce_scatter_events]}"
     )
 
-    all_gather_events = [event for group in all_gather_event_groups for event in group]
-    reduce_scatter_events = [event for group in reduce_scatter_event_groups for event in group]
     all_gather_streams = {event.device_resource_id for event in all_gather_events}
     reduce_scatter_streams = {event.device_resource_id for event in reduce_scatter_events}
     gemm_streams = {event.device_resource_id for event in gemm_events}
-    if not use_symm_mem:
+    if all_gather_events:
         assert len(all_gather_streams) == 1
     assert len(reduce_scatter_streams) == 1
     assert all_gather_streams.isdisjoint(reduce_scatter_streams)
@@ -614,22 +606,21 @@ def test_overlaps_communication_and_compute(distributed_setup, use_symm_mem):
     assert reduce_scatter_streams.isdisjoint(gemm_streams)
 
     all_gather_overlap_count = sum(
-        any(events_overlap(event, gemm) for event in group for gemm in gemm_events)
-        for group in all_gather_event_groups
+        any(events_overlap(event, gemm) for gemm in gemm_events) for event in all_gather_events
     )
     reduce_scatter_overlap_count = sum(
-        any(events_overlap(event, gemm) for event in group for gemm in gemm_events)
-        for group in reduce_scatter_event_groups
+        any(events_overlap(event, gemm) for gemm in gemm_events) for event in reduce_scatter_events
     )
     expected_all_gather_overlap = 2 * (num_children - 1)
     expected_reduce_scatter_overlap = num_children - 1
-    assert all_gather_overlap_count >= expected_all_gather_overlap, (
-        f"Expected at least {expected_all_gather_overlap} all-gathers to "
-        f"overlap compute, got {all_gather_overlap_count}/{len(all_gather_event_groups)}."
-    )
+    if not use_symm_mem:
+        assert all_gather_overlap_count >= expected_all_gather_overlap, (
+            f"Expected at least {expected_all_gather_overlap} all-gathers to "
+            f"overlap compute, got {all_gather_overlap_count}/{len(all_gather_events)}."
+        )
     assert reduce_scatter_overlap_count >= expected_reduce_scatter_overlap, (
         f"Expected at least {expected_reduce_scatter_overlap} reduce-scatters to overlap "
-        f"compute, got {reduce_scatter_overlap_count}/{len(reduce_scatter_event_groups)}."
+        f"compute, got {reduce_scatter_overlap_count}/{len(reduce_scatter_events)}."
     )
 
     # Release the dedicated communicator so it does not leak into the shared session.

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -623,10 +623,7 @@ def test_overlaps_communication_and_compute(distributed_setup, use_symm_mem):
         f"compute, got {reduce_scatter_overlap_count}/{len(reduce_scatter_events)}."
     )
 
-    # Release the dedicated communicator so it does not leak into the shared session
-    # (the mfsdp_v2 bucket keeps one process group alive across tests). On a failure
-    # above the group leaks, which is acceptable. Destroying this subgroup leaves the
-    # default process group and conftest teardown barrier.
+    # Release the dedicated communicator so it does not leak into the shared session.
     dist.destroy_process_group(dp_group)
 
 

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -23,7 +23,7 @@ from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
 )
 from megatron.core.distributed.fsdp.src.megatron_fsdp.mixed_precision import MixedPrecisionPolicy
 from tests.unit_tests.distributed.mfsdp_v2.profiler_utils import (
-    collect_linked_device_events,
+    collect_linked_kernels,
     events_overlap,
 )
 
@@ -564,63 +564,58 @@ def test_overlaps_communication_and_compute(distributed_setup, use_symm_mem):
         # drop the CUDA events.
         torch.cuda.synchronize(device)
 
-    events = prof.events()
-    # A GEMM launches under aten::mm as the matmul kernel plus a cudaMemsetAsync
-    # (device events collected by CPU op -- see collect_linked_device_events);
-    # keep the matmuls.
-    gemm_events = [
-        event
-        for event in collect_linked_device_events(events, _GEMM_OP_NAME_SUBSTRING)
-        if "memset" not in event.name.lower()
-    ]
-    # Each of the num_children child Linears runs one forward and two backward matmuls.
-    assert len(gemm_events) == 3 * num_children, (
-        f"Expected {3 * num_children} GEMMs, got {len(gemm_events)}: "
-        f"{[event.name for event in gemm_events]}"
+    gemm_kernels = collect_linked_kernels(prof, _GEMM_OP_NAME_SUBSTRING)
+    # Each child Linear runs one forward and two backward matmuls. aten::mm may also
+    # launch auxiliary kernels, so check only the matmul lower bound.
+    assert len(gemm_kernels) >= 3 * num_children, (
+        f"Expected at least {3 * num_children} kernels linked to GEMMs, got "
+        f"{len(gemm_kernels)}: "
+        f"{[event.name for event in gemm_kernels]}"
     )
 
-    all_gather_events = collect_linked_device_events(events, _ALL_GATHER_OP_NAME_SUBSTRING)
-    reduce_scatter_events = collect_linked_device_events(events, _REDUCE_SCATTER_OP_NAME_SUBSTRING)
+    allgather_kernels = collect_linked_kernels(prof, _ALL_GATHER_OP_NAME_SUBSTRING)
+    reduce_scatter_kernels = collect_linked_kernels(prof, _REDUCE_SCATTER_OP_NAME_SUBSTRING)
     # The num_children child layers plus the root are each a sharded module; each does a
     # forward and a backward all-gather and one reduce-scatter. Zero-CTA moves the
     # all-gather to copy-engine memcpys, so it should not emit all-gather kernels.
     num_sharded_modules = num_children + 1
-    expected_all_gather_count = 0 if use_symm_mem else 2 * num_sharded_modules
-    assert len(all_gather_events) == expected_all_gather_count, (
-        f"Expected {expected_all_gather_count} all-gather kernels, got "
-        f"{len(all_gather_events)}: {[event.name for event in all_gather_events]}"
+    expected_allgather_kernel_count = 0 if use_symm_mem else 2 * num_sharded_modules
+    assert len(allgather_kernels) == expected_allgather_kernel_count, (
+        f"Expected {expected_allgather_kernel_count} all-gather kernels, got "
+        f"{len(allgather_kernels)}: {[event.name for event in allgather_kernels]}"
     )
-    assert len(reduce_scatter_events) == num_sharded_modules, (
+    assert len(reduce_scatter_kernels) == num_sharded_modules, (
         f"Expected {num_sharded_modules} reduce-scatter kernels, got "
-        f"{len(reduce_scatter_events)}: {[event.name for event in reduce_scatter_events]}"
+        f"{len(reduce_scatter_kernels)}: {[event.name for event in reduce_scatter_kernels]}"
     )
 
-    all_gather_streams = {event.device_resource_id for event in all_gather_events}
-    reduce_scatter_streams = {event.device_resource_id for event in reduce_scatter_events}
-    gemm_streams = {event.device_resource_id for event in gemm_events}
-    if all_gather_events:
-        assert len(all_gather_streams) == 1
+    allgather_streams = {event.device_resource_id for event in allgather_kernels}
+    reduce_scatter_streams = {event.device_resource_id for event in reduce_scatter_kernels}
+    gemm_streams = {event.device_resource_id for event in gemm_kernels}
+    if allgather_kernels:
+        assert len(allgather_streams) == 1
     assert len(reduce_scatter_streams) == 1
-    assert all_gather_streams.isdisjoint(reduce_scatter_streams)
-    assert all_gather_streams.isdisjoint(gemm_streams)
+    assert allgather_streams.isdisjoint(reduce_scatter_streams)
+    assert allgather_streams.isdisjoint(gemm_streams)
     assert reduce_scatter_streams.isdisjoint(gemm_streams)
 
-    all_gather_overlap_count = sum(
-        any(events_overlap(event, gemm) for gemm in gemm_events) for event in all_gather_events
+    allgather_overlap_count = sum(
+        any(events_overlap(event, gemm) for gemm in gemm_kernels) for event in allgather_kernels
     )
     reduce_scatter_overlap_count = sum(
-        any(events_overlap(event, gemm) for gemm in gemm_events) for event in reduce_scatter_events
+        any(events_overlap(event, gemm) for gemm in gemm_kernels)
+        for event in reduce_scatter_kernels
     )
-    expected_all_gather_overlap = 2 * (num_children - 1)
+    expected_allgather_overlap = 2 * (num_children - 1)
     expected_reduce_scatter_overlap = num_children - 1
     if not use_symm_mem:
-        assert all_gather_overlap_count >= expected_all_gather_overlap, (
-            f"Expected at least {expected_all_gather_overlap} all-gathers to "
-            f"overlap compute, got {all_gather_overlap_count}/{len(all_gather_events)}."
+        assert allgather_overlap_count >= expected_allgather_overlap, (
+            f"Expected at least {expected_allgather_overlap} all-gathers to "
+            f"overlap compute, got {allgather_overlap_count}/{len(allgather_kernels)}."
         )
     assert reduce_scatter_overlap_count >= expected_reduce_scatter_overlap, (
         f"Expected at least {expected_reduce_scatter_overlap} reduce-scatters to overlap "
-        f"compute, got {reduce_scatter_overlap_count}/{len(reduce_scatter_events)}."
+        f"compute, got {reduce_scatter_overlap_count}/{len(reduce_scatter_kernels)}."
     )
 
     # Release the dedicated communicator so it does not leak into the shared session.

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -126,10 +126,9 @@ def _mb(num_bytes: int) -> str:
 
 
 # CPU ops that a device event chains up to via cpu_parent, used to attribute the device
-# work. mfsdp's all-gather / reduce-scatter (dist.all_gather_into_tensor /
-# reduce_scatter_tensor) dispatch to c10d::_..._base_; the Linear matmuls to aten::mm.
-_ALL_GATHER_OP_PATTERN = re.compile(r"_allgather_base")
-_REDUCE_SCATTER_OP_PATTERN = re.compile(r"_reduce_scatter_base")
+# work to its enclosing collective or matmul operation.
+_ALL_GATHER_OP_PATTERN = re.compile(r"allgather")
+_REDUCE_SCATTER_OP_PATTERN = re.compile(r"reduce_scatter")
 _GEMM_OP_PATTERN = re.compile(r"aten::mm")
 
 

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -3,12 +3,13 @@
 """Unit tests for the minimal Megatron-FSDP path."""
 
 import logging
+import re
 
 import pytest
 import torch
 import torch.distributed as dist
 from torch import nn
-from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
 from torch.distributed.tensor import DTensor
 from torch.profiler import ProfilerActivity, profile
 
@@ -22,6 +23,10 @@ from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
     microbatch,
 )
 from megatron.core.distributed.fsdp.src.megatron_fsdp.mixed_precision import MixedPrecisionPolicy
+from tests.unit_tests.distributed.mfsdp_v2.profiler_utils import (
+    collect_linked_device_events,
+    events_overlap,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -120,11 +125,12 @@ def _mb(num_bytes: int) -> str:
     return f"{num_bytes / 1024**2:.2f} MB"
 
 
-def _events_overlap(first, second) -> bool:
-    return (
-        first.time_range.start < second.time_range.end
-        and second.time_range.start < first.time_range.end
-    )
+# CPU ops that a device event chains up to via cpu_parent, used to attribute the device
+# work. mfsdp's all-gather / reduce-scatter (dist.all_gather_into_tensor /
+# reduce_scatter_tensor) dispatch to c10d::_..._base_; the Linear matmuls to aten::mm.
+_ALL_GATHER_OP_PATTERN = re.compile(r"_allgather_base")
+_REDUCE_SCATTER_OP_PATTERN = re.compile(r"_reduce_scatter_base")
+_GEMM_OP_PATTERN = re.compile(r"aten::mm")
 
 
 def _nccl_events(cuda_events, *name_fragments):
@@ -480,13 +486,19 @@ def test_root_backward_returns_to_resting_memory(distributed_setup):
 
 
 def test_overlaps_communication_and_compute(distributed_setup):
-    """Forward and backward communication should overlap GEMM compute."""
+    """Forward and backward communication should overlap GEMM compute.
+
+    Uses NCCL's zero-CTA policy so the all-gather runs on the copy engine (SM-free)
+    instead of an SM-based kernel: it can never contend with the GEMMs for SMs, so the
+    overlap count is deterministic and the strict theoretical-maximum thresholds hold.
+    (The SM-based ring collectives this replaces jitter with launch timing -- amplified
+    by CI's coverage wrapper -- and dip below the maximum.)
+    """
     world_size = distributed_setup.world_size
     device = distributed_setup.device
     if world_size < 2:
         pytest.skip("This test requires at least 2 ranks.")
 
-    mesh = init_device_mesh(device.type, (world_size,))
     # A large hidden size keeps the per-layer GEMMs long enough that the
     # collectives reliably overlap them. The overlap count is otherwise
     # launch-bound: the host issues kernels with gaps (amplified by CI's
@@ -498,14 +510,22 @@ def test_overlaps_communication_and_compute(distributed_setup):
     num_children = 4
     dtype = torch.bfloat16
 
-    # Use NCCL symmetric-memory collectives so the all-gather and reduce-scatter run
-    # as SM-light NVLS multicast kernels (ncclSymk*) instead of SM-based ring kernels.
-    # Ring kernels contend with the GEMMs for SMs, so their overlap count jitters with
-    # launch timing (amplified by CI's coverage wrapper) and dips below the theoretical
-    # maximum; the multicast kernels offload data movement to NVLink/NVSwitch and keep
-    # the overlap count deterministic, which is what lets the strict thresholds below hold.
-    # (Symmetric-memory window registration needs an initialized NCCL communicator; the
-    # conftest eagerly initializes the process group with device_id so this holds.)
+    # Dedicated communicator with NCCL's zero-CTA policy. cta_policy is a
+    # per-communicator property, so scoping it to this group leaves the rest of the
+    # bucket on default-CTA symmetric-memory kernels (test_symmetric_memory.py asserts
+    # ncclSymk all-gather kernel counts, which zero-CTA would turn into copy-engine
+    # memcpys). This 1-D group models the DP (FSDP) sub-mesh that mfsdp is handed in
+    # production: with EP/TP the full device mesh is multi-dimensional, but mfsdp
+    # requires an all-FSDP mesh (see experimental/module.py) and never sees the TP/EP
+    # axes, so only the DP communicator needs the zero-CTA policy. Creating the group
+    # off the conftest's device_id eager-initialized default process group uses a comm
+    # split, which avoids the cold-communicator symmetric-memory rendezvous failure
+    # (https://github.com/pytorch/pytorch/issues/188567).
+    zero_cta_options = dist.ProcessGroupNCCL.Options()
+    zero_cta_options.config.cta_policy = dist.ProcessGroupNCCL.NCCL_CTA_POLICY_ZERO
+    dp_group = dist.new_group(backend="nccl", pg_options=zero_cta_options)
+
+    mesh = DeviceMesh.from_group(dp_group, device.type)
     model = MultiChildModel(dim=dim, num_children=num_children).to(dtype=dtype)
     placements = _flat_placements()
     policy = MixedPrecisionPolicy(main_params_dtype=dtype, main_grads_dtype=dtype)
@@ -538,30 +558,38 @@ def test_overlaps_communication_and_compute(distributed_setup):
         # drop the CUDA events.
         torch.cuda.synchronize(device)
 
-    cuda_events = [event for event in prof.events() if event.device_type.name == "CUDA"]
-    all_gather_events = _nccl_events(cuda_events, "allgather")
-    reduce_scatter_events = _nccl_events(cuda_events, "reducescatter", "reduce_scatter")
-    # GEMM device-kernel names vary across CUDA/cuBLAS versions and GPU archs
-    # (e.g. "*gemm*", "cutlass*", "cublas*", and cuBLASLt's Hopper "nvjet_sm90_*").
-    gemm_events = [
-        event
-        for event in cuda_events
-        if any(token in event.name.lower() for token in ("gemm", "cutlass", "cublas", "nvjet"))
-    ]
-    # Each of the num_children children plus the root all-gathers in forward and
-    # again in backward, and each reduce-scatters once in backward.
-    assert len(all_gather_events) == 2 * (num_children + 1), (
-        f"Expected {2 * (num_children + 1)} all-gather kernels, "
-        f"got {[event.name for event in all_gather_events]}."
+    events = prof.events()
+    # A GEMM launches under aten::mm as the matmul kernel plus a cudaMemsetAsync (device
+    # events collected by CPU op -- see collect_linked_device_events); keep the matmuls.
+    gemm_events = []
+    for op_device_events in collect_linked_device_events(events, _GEMM_OP_PATTERN).values():
+        gemm_events += [event for event in op_device_events if "memset" not in event.name.lower()]
+    # Each of the num_children child Linears runs one forward and two backward matmuls.
+    assert len(gemm_events) == 3 * num_children, (
+        f"Expected {3 * num_children} GEMMs, got {len(gemm_events)}: "
+        f"{[event.name for event in gemm_events]}"
     )
-    assert len(reduce_scatter_events) == num_children + 1, (
-        f"Expected {num_children + 1} reduce-scatter kernels, "
-        f"got {[event.name for event in reduce_scatter_events]}."
-    )
-    assert gemm_events, [event.name for event in cuda_events]
 
-    all_gather_streams = {event.device_resource_id for event in all_gather_events}
-    reduce_scatter_streams = {event.device_resource_id for event in reduce_scatter_events}
+    all_gather_events = collect_linked_device_events(events, _ALL_GATHER_OP_PATTERN)
+    reduce_scatter_events = collect_linked_device_events(events, _REDUCE_SCATTER_OP_PATTERN)
+    # The num_children child layers plus the root are each a sharded module; each does a
+    # forward and a backward all-gather and one reduce-scatter.
+    num_sharded_modules = num_children + 1
+    assert len(reduce_scatter_events) == num_sharded_modules, (
+        f"Expected {num_sharded_modules} reduce-scatters, got {len(reduce_scatter_events)}: "
+        f"{[op.name for op in reduce_scatter_events]}"
+    )
+    assert len(all_gather_events) == 2 * num_sharded_modules, (
+        f"Expected {2 * num_sharded_modules} all-gathers, got {len(all_gather_events)}: "
+        f"{[op.name for op in all_gather_events]}"
+    )
+
+    all_gather_streams = {
+        event.device_resource_id for group in all_gather_events.values() for event in group
+    }
+    reduce_scatter_streams = {
+        event.device_resource_id for group in reduce_scatter_events.values() for event in group
+    }
     gemm_streams = {event.device_resource_id for event in gemm_events}
     assert len(all_gather_streams) == 1
     assert len(reduce_scatter_streams) == 1
@@ -570,28 +598,32 @@ def test_overlaps_communication_and_compute(distributed_setup):
     assert reduce_scatter_streams.isdisjoint(gemm_streams)
 
     all_gather_overlap_count = sum(
-        any(_events_overlap(all_gather_event, gemm_event) for gemm_event in gemm_events)
-        for all_gather_event in all_gather_events
+        any(events_overlap(event, gemm) for event in group for gemm in gemm_events)
+        for group in all_gather_events.values()
     )
     reduce_scatter_overlap_count = sum(
-        any(_events_overlap(reduce_scatter_event, gemm_event) for gemm_event in gemm_events)
-        for reduce_scatter_event in reduce_scatter_events
+        any(events_overlap(event, gemm) for event in group for gemm in gemm_events)
+        for group in reduce_scatter_events.values()
     )
-    # With symmetric-memory (SM-light multicast) collectives the overlap count is
-    # deterministic, so assert the theoretical maximum. Each of the num_children - 1
-    # non-root children contributes a forward all-gather and a backward all-gather that
-    # overlap a GEMM (2 * (num_children - 1)), and each non-root child's reduce-scatter
-    # overlaps a backward GEMM (num_children - 1).
+    # SM-free all-gather overlaps deterministically, so assert the theoretical maximum:
+    # a forward and a backward all-gather for each of the num_children - 1 non-root
+    # children, and one reduce-scatter per non-root child.
     expected_all_gather_overlap = 2 * (num_children - 1)
     expected_reduce_scatter_overlap = num_children - 1
     assert all_gather_overlap_count >= expected_all_gather_overlap, (
-        f"Expected at least {expected_all_gather_overlap} all-gathers to overlap compute, "
-        f"got {all_gather_overlap_count}/{len(all_gather_events)}."
+        f"Expected at least {expected_all_gather_overlap} copy-engine all-gathers to "
+        f"overlap compute, got {all_gather_overlap_count}/{len(all_gather_events)}."
     )
     assert reduce_scatter_overlap_count >= expected_reduce_scatter_overlap, (
         f"Expected at least {expected_reduce_scatter_overlap} reduce-scatters to overlap "
         f"compute, got {reduce_scatter_overlap_count}/{len(reduce_scatter_events)}."
     )
+
+    # Release the dedicated communicator so it does not leak into the shared session
+    # (the mfsdp_v2 bucket keeps one process group alive across tests). On a failure
+    # above the group leaks, which is acceptable. Destroying this subgroup leaves the
+    # default process group (and the conftest teardown barrier) untouched.
+    dist.destroy_process_group(dp_group)
 
 
 def test_parameterless_parent_with_child_modules_trains(distributed_setup):

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -3,7 +3,6 @@
 """Unit tests for the minimal Megatron-FSDP path."""
 
 import logging
-import re
 
 import pytest
 import torch
@@ -127,9 +126,9 @@ def _mb(num_bytes: int) -> str:
 
 # CPU ops that a device event chains up to via cpu_parent, used to attribute the device
 # work to its enclosing collective or matmul operation.
-_ALL_GATHER_OP_PATTERN = re.compile(r"allgather")
-_REDUCE_SCATTER_OP_PATTERN = re.compile(r"reduce_scatter")
-_GEMM_OP_PATTERN = re.compile(r"aten::mm")
+_ALL_GATHER_OP_NAME_SUBSTRING = "allgather"
+_REDUCE_SCATTER_OP_NAME_SUBSTRING = "reduce_scatter"
+_GEMM_OP_NAME_SUBSTRING = "aten::mm"
 
 
 def _nccl_events(cuda_events, *name_fragments):
@@ -576,7 +575,7 @@ def test_overlaps_communication_and_compute(distributed_setup, use_symm_mem):
     # (device events collected by CPU op -- see collect_linked_device_events);
     # keep the matmuls.
     gemm_events = []
-    for op_device_events in collect_linked_device_events(events, _GEMM_OP_PATTERN).values():
+    for op_device_events in collect_linked_device_events(events, _GEMM_OP_NAME_SUBSTRING).values():
         gemm_events += [event for event in op_device_events if "memset" not in event.name.lower()]
     # Each of the num_children child Linears runs one forward and two backward matmuls.
     assert len(gemm_events) == 3 * num_children, (
@@ -584,8 +583,8 @@ def test_overlaps_communication_and_compute(distributed_setup, use_symm_mem):
         f"{[event.name for event in gemm_events]}"
     )
 
-    all_gather_events = collect_linked_device_events(events, _ALL_GATHER_OP_PATTERN)
-    reduce_scatter_events = collect_linked_device_events(events, _REDUCE_SCATTER_OP_PATTERN)
+    all_gather_events = collect_linked_device_events(events, _ALL_GATHER_OP_NAME_SUBSTRING)
+    reduce_scatter_events = collect_linked_device_events(events, _REDUCE_SCATTER_OP_NAME_SUBSTRING)
     # The num_children child layers plus the root are each a sharded module; each does a
     # forward and a backward all-gather and one reduce-scatter.
     num_sharded_modules = num_children + 1

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -483,13 +483,7 @@ def test_root_backward_returns_to_resting_memory(distributed_setup):
     )
 
 
-@pytest.mark.parametrize(
-    "use_symm_mem",
-    [
-        pytest.param(False, id="default"),
-        pytest.param(True, id="symmetric_memory"),
-    ],
-)
+@pytest.mark.parametrize("use_symm_mem", [False, True], ids=["default", "symmetric_memory"])
 def test_overlaps_communication_and_compute(distributed_setup, use_symm_mem):
     """Forward and backward communication should overlap GEMM compute."""
     world_size = distributed_setup.world_size

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -23,6 +23,7 @@ from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
 )
 from megatron.core.distributed.fsdp.src.megatron_fsdp.mixed_precision import MixedPrecisionPolicy
 from tests.unit_tests.distributed.mfsdp_v2.profiler_utils import (
+    collect_linked_device_event_groups,
     collect_linked_device_events,
     events_overlap,
 )
@@ -579,44 +580,56 @@ def test_overlaps_communication_and_compute(distributed_setup, use_symm_mem):
         f"{[event.name for event in gemm_events]}"
     )
 
-    all_gather_events = collect_linked_device_events(events, _ALL_GATHER_OP_NAME_SUBSTRING)
-    reduce_scatter_events = collect_linked_device_events(events, _REDUCE_SCATTER_OP_NAME_SUBSTRING)
-    # The num_children child layers plus the root are each a sharded module; each does a
-    # forward and a backward all-gather and one reduce-scatter.
-    num_sharded_modules = num_children + 1
-    assert len(reduce_scatter_events) == num_sharded_modules, (
-        f"Expected {num_sharded_modules} reduce-scatters, got {len(reduce_scatter_events)}: "
-        f"{[event.name for event in reduce_scatter_events]}"
+    all_gather_event_groups = collect_linked_device_event_groups(
+        events, _ALL_GATHER_OP_NAME_SUBSTRING
     )
-    assert len(all_gather_events) == 2 * num_sharded_modules, (
-        f"Expected {2 * num_sharded_modules} all-gathers, got {len(all_gather_events)}: "
-        f"{[event.name for event in all_gather_events]}"
+    reduce_scatter_event_groups = collect_linked_device_event_groups(
+        events, _REDUCE_SCATTER_OP_NAME_SUBSTRING
+    )
+    # The num_children child layers plus the root are each a sharded module; each does a
+    # forward and a backward all-gather and one reduce-scatter. Zero-CTA all-gather can
+    # emit several copy-engine events, so count linked CPU-op groups here.
+    num_sharded_modules = num_children + 1
+    assert len(reduce_scatter_event_groups) == num_sharded_modules, (
+        f"Expected {num_sharded_modules} reduce-scatters, got "
+        f"{len(reduce_scatter_event_groups)}: "
+        f"{[[event.name for event in group] for group in reduce_scatter_event_groups]}"
+    )
+    assert len(all_gather_event_groups) == 2 * num_sharded_modules, (
+        f"Expected {2 * num_sharded_modules} all-gathers, got "
+        f"{len(all_gather_event_groups)}: "
+        f"{[[event.name for event in group] for group in all_gather_event_groups]}"
     )
 
+    all_gather_events = [event for group in all_gather_event_groups for event in group]
+    reduce_scatter_events = [event for group in reduce_scatter_event_groups for event in group]
     all_gather_streams = {event.device_resource_id for event in all_gather_events}
     reduce_scatter_streams = {event.device_resource_id for event in reduce_scatter_events}
     gemm_streams = {event.device_resource_id for event in gemm_events}
-    assert len(all_gather_streams) == 1
+    if not use_symm_mem:
+        assert len(all_gather_streams) == 1
     assert len(reduce_scatter_streams) == 1
     assert all_gather_streams.isdisjoint(reduce_scatter_streams)
     assert all_gather_streams.isdisjoint(gemm_streams)
     assert reduce_scatter_streams.isdisjoint(gemm_streams)
 
     all_gather_overlap_count = sum(
-        any(events_overlap(event, gemm) for gemm in gemm_events) for event in all_gather_events
+        any(events_overlap(event, gemm) for event in group for gemm in gemm_events)
+        for group in all_gather_event_groups
     )
     reduce_scatter_overlap_count = sum(
-        any(events_overlap(event, gemm) for gemm in gemm_events) for event in reduce_scatter_events
+        any(events_overlap(event, gemm) for event in group for gemm in gemm_events)
+        for group in reduce_scatter_event_groups
     )
     expected_all_gather_overlap = 2 * (num_children - 1)
     expected_reduce_scatter_overlap = num_children - 1
     assert all_gather_overlap_count >= expected_all_gather_overlap, (
         f"Expected at least {expected_all_gather_overlap} all-gathers to "
-        f"overlap compute, got {all_gather_overlap_count}/{len(all_gather_events)}."
+        f"overlap compute, got {all_gather_overlap_count}/{len(all_gather_event_groups)}."
     )
     assert reduce_scatter_overlap_count >= expected_reduce_scatter_overlap, (
         f"Expected at least {expected_reduce_scatter_overlap} reduce-scatters to overlap "
-        f"compute, got {reduce_scatter_overlap_count}/{len(reduce_scatter_events)}."
+        f"compute, got {reduce_scatter_overlap_count}/{len(reduce_scatter_event_groups)}."
     )
 
     # Release the dedicated communicator so it does not leak into the shared session.

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -612,13 +612,8 @@ def test_overlaps_communication_and_compute(distributed_setup, use_symm_mem):
         any(events_overlap(event, gemm) for event in group for gemm in gemm_events)
         for group in reduce_scatter_events.values()
     )
-    # The symmetric-memory case uses NCCL's zero-CTA policy so the all-gather runs on the
-    # copy engine (SM-free) instead of an SM-based kernel: it can never contend with the
-    # GEMMs for SMs, so the overlap count is deterministic and the strict theoretical
-    # maximum thresholds hold. The default case preserves the original non-symmetric path
-    # with looser thresholds since SM-based NCCL kernels can jitter with launch timing.
-    expected_all_gather_overlap = 2 * (num_children - 1) if use_symm_mem else 2
-    expected_reduce_scatter_overlap = num_children - 1 if use_symm_mem else 1
+    expected_all_gather_overlap = 2 * (num_children - 1)
+    expected_reduce_scatter_overlap = num_children - 1
     assert all_gather_overlap_count >= expected_all_gather_overlap, (
         f"Expected at least {expected_all_gather_overlap} all-gathers to "
         f"overlap compute, got {all_gather_overlap_count}/{len(all_gather_events)}."

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -570,8 +570,7 @@ def test_overlaps_communication_and_compute(distributed_setup, use_symm_mem):
     # keep the matmuls.
     gemm_events = [
         event
-        for op_device_events in collect_linked_device_events(events, _GEMM_OP_NAME_SUBSTRING)
-        for event in op_device_events
+        for event in collect_linked_device_events(events, _GEMM_OP_NAME_SUBSTRING)
         if "memset" not in event.name.lower()
     ]
     # Each of the num_children child Linears runs one forward and two backward matmuls.
@@ -580,28 +579,22 @@ def test_overlaps_communication_and_compute(distributed_setup, use_symm_mem):
         f"{[event.name for event in gemm_events]}"
     )
 
-    all_gather_event_groups = collect_linked_device_events(events, _ALL_GATHER_OP_NAME_SUBSTRING)
-    reduce_scatter_event_groups = collect_linked_device_events(
-        events, _REDUCE_SCATTER_OP_NAME_SUBSTRING
-    )
+    all_gather_events = collect_linked_device_events(events, _ALL_GATHER_OP_NAME_SUBSTRING)
+    reduce_scatter_events = collect_linked_device_events(events, _REDUCE_SCATTER_OP_NAME_SUBSTRING)
     # The num_children child layers plus the root are each a sharded module; each does a
     # forward and a backward all-gather and one reduce-scatter.
     num_sharded_modules = num_children + 1
-    assert len(reduce_scatter_event_groups) == num_sharded_modules, (
-        f"Expected {num_sharded_modules} reduce-scatters, got {len(reduce_scatter_event_groups)}: "
-        f"{[[event.name for event in group] for group in reduce_scatter_event_groups]}"
+    assert len(reduce_scatter_events) == num_sharded_modules, (
+        f"Expected {num_sharded_modules} reduce-scatters, got {len(reduce_scatter_events)}: "
+        f"{[event.name for event in reduce_scatter_events]}"
     )
-    assert len(all_gather_event_groups) == 2 * num_sharded_modules, (
-        f"Expected {2 * num_sharded_modules} all-gathers, got {len(all_gather_event_groups)}: "
-        f"{[[event.name for event in group] for group in all_gather_event_groups]}"
+    assert len(all_gather_events) == 2 * num_sharded_modules, (
+        f"Expected {2 * num_sharded_modules} all-gathers, got {len(all_gather_events)}: "
+        f"{[event.name for event in all_gather_events]}"
     )
 
-    all_gather_streams = {
-        event.device_resource_id for group in all_gather_event_groups for event in group
-    }
-    reduce_scatter_streams = {
-        event.device_resource_id for group in reduce_scatter_event_groups for event in group
-    }
+    all_gather_streams = {event.device_resource_id for event in all_gather_events}
+    reduce_scatter_streams = {event.device_resource_id for event in reduce_scatter_events}
     gemm_streams = {event.device_resource_id for event in gemm_events}
     assert len(all_gather_streams) == 1
     assert len(reduce_scatter_streams) == 1
@@ -610,22 +603,20 @@ def test_overlaps_communication_and_compute(distributed_setup, use_symm_mem):
     assert reduce_scatter_streams.isdisjoint(gemm_streams)
 
     all_gather_overlap_count = sum(
-        any(events_overlap(event, gemm) for event in group for gemm in gemm_events)
-        for group in all_gather_event_groups
+        any(events_overlap(event, gemm) for gemm in gemm_events) for event in all_gather_events
     )
     reduce_scatter_overlap_count = sum(
-        any(events_overlap(event, gemm) for event in group for gemm in gemm_events)
-        for group in reduce_scatter_event_groups
+        any(events_overlap(event, gemm) for gemm in gemm_events) for event in reduce_scatter_events
     )
     expected_all_gather_overlap = 2 * (num_children - 1)
     expected_reduce_scatter_overlap = num_children - 1
     assert all_gather_overlap_count >= expected_all_gather_overlap, (
         f"Expected at least {expected_all_gather_overlap} all-gathers to "
-        f"overlap compute, got {all_gather_overlap_count}/{len(all_gather_event_groups)}."
+        f"overlap compute, got {all_gather_overlap_count}/{len(all_gather_events)}."
     )
     assert reduce_scatter_overlap_count >= expected_reduce_scatter_overlap, (
         f"Expected at least {expected_reduce_scatter_overlap} reduce-scatters to overlap "
-        f"compute, got {reduce_scatter_overlap_count}/{len(reduce_scatter_event_groups)}."
+        f"compute, got {reduce_scatter_overlap_count}/{len(reduce_scatter_events)}."
     )
 
     # Release the dedicated communicator so it does not leak into the shared session.

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -568,34 +568,39 @@ def test_overlaps_communication_and_compute(distributed_setup, use_symm_mem):
     # A GEMM launches under aten::mm as the matmul kernel plus a cudaMemsetAsync
     # (device events collected by CPU op -- see collect_linked_device_events);
     # keep the matmuls.
-    gemm_events = []
-    for op_device_events in collect_linked_device_events(events, _GEMM_OP_NAME_SUBSTRING).values():
-        gemm_events += [event for event in op_device_events if "memset" not in event.name.lower()]
+    gemm_events = [
+        event
+        for op_device_events in collect_linked_device_events(events, _GEMM_OP_NAME_SUBSTRING)
+        for event in op_device_events
+        if "memset" not in event.name.lower()
+    ]
     # Each of the num_children child Linears runs one forward and two backward matmuls.
     assert len(gemm_events) == 3 * num_children, (
         f"Expected {3 * num_children} GEMMs, got {len(gemm_events)}: "
         f"{[event.name for event in gemm_events]}"
     )
 
-    all_gather_events = collect_linked_device_events(events, _ALL_GATHER_OP_NAME_SUBSTRING)
-    reduce_scatter_events = collect_linked_device_events(events, _REDUCE_SCATTER_OP_NAME_SUBSTRING)
+    all_gather_event_groups = collect_linked_device_events(events, _ALL_GATHER_OP_NAME_SUBSTRING)
+    reduce_scatter_event_groups = collect_linked_device_events(
+        events, _REDUCE_SCATTER_OP_NAME_SUBSTRING
+    )
     # The num_children child layers plus the root are each a sharded module; each does a
     # forward and a backward all-gather and one reduce-scatter.
     num_sharded_modules = num_children + 1
-    assert len(reduce_scatter_events) == num_sharded_modules, (
-        f"Expected {num_sharded_modules} reduce-scatters, got {len(reduce_scatter_events)}: "
-        f"{[op.name for op in reduce_scatter_events]}"
+    assert len(reduce_scatter_event_groups) == num_sharded_modules, (
+        f"Expected {num_sharded_modules} reduce-scatters, got {len(reduce_scatter_event_groups)}: "
+        f"{[[event.name for event in group] for group in reduce_scatter_event_groups]}"
     )
-    assert len(all_gather_events) == 2 * num_sharded_modules, (
-        f"Expected {2 * num_sharded_modules} all-gathers, got {len(all_gather_events)}: "
-        f"{[op.name for op in all_gather_events]}"
+    assert len(all_gather_event_groups) == 2 * num_sharded_modules, (
+        f"Expected {2 * num_sharded_modules} all-gathers, got {len(all_gather_event_groups)}: "
+        f"{[[event.name for event in group] for group in all_gather_event_groups]}"
     )
 
     all_gather_streams = {
-        event.device_resource_id for group in all_gather_events.values() for event in group
+        event.device_resource_id for group in all_gather_event_groups for event in group
     }
     reduce_scatter_streams = {
-        event.device_resource_id for group in reduce_scatter_events.values() for event in group
+        event.device_resource_id for group in reduce_scatter_event_groups for event in group
     }
     gemm_streams = {event.device_resource_id for event in gemm_events}
     assert len(all_gather_streams) == 1
@@ -606,21 +611,21 @@ def test_overlaps_communication_and_compute(distributed_setup, use_symm_mem):
 
     all_gather_overlap_count = sum(
         any(events_overlap(event, gemm) for event in group for gemm in gemm_events)
-        for group in all_gather_events.values()
+        for group in all_gather_event_groups
     )
     reduce_scatter_overlap_count = sum(
         any(events_overlap(event, gemm) for event in group for gemm in gemm_events)
-        for group in reduce_scatter_events.values()
+        for group in reduce_scatter_event_groups
     )
     expected_all_gather_overlap = 2 * (num_children - 1)
     expected_reduce_scatter_overlap = num_children - 1
     assert all_gather_overlap_count >= expected_all_gather_overlap, (
         f"Expected at least {expected_all_gather_overlap} all-gathers to "
-        f"overlap compute, got {all_gather_overlap_count}/{len(all_gather_events)}."
+        f"overlap compute, got {all_gather_overlap_count}/{len(all_gather_event_groups)}."
     )
     assert reduce_scatter_overlap_count >= expected_reduce_scatter_overlap, (
         f"Expected at least {expected_reduce_scatter_overlap} reduce-scatters to overlap "
-        f"compute, got {reduce_scatter_overlap_count}/{len(reduce_scatter_events)}."
+        f"compute, got {reduce_scatter_overlap_count}/{len(reduce_scatter_event_groups)}."
     )
 
     # Release the dedicated communicator so it does not leak into the shared session.

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -485,15 +485,15 @@ def test_root_backward_returns_to_resting_memory(distributed_setup):
     )
 
 
-def test_overlaps_communication_and_compute(distributed_setup):
-    """Forward and backward communication should overlap GEMM compute.
-
-    Uses NCCL's zero-CTA policy so the all-gather runs on the copy engine (SM-free)
-    instead of an SM-based kernel: it can never contend with the GEMMs for SMs, so the
-    overlap count is deterministic and the strict theoretical-maximum thresholds hold.
-    (The SM-based ring collectives this replaces jitter with launch timing -- amplified
-    by CI's coverage wrapper -- and dip below the maximum.)
-    """
+@pytest.mark.parametrize(
+    "use_symm_mem",
+    [
+        pytest.param(False, marks=[pytest.mark.flaky, pytest.mark.flaky_in_dev], id="default"),
+        pytest.param(True, id="symmetric_memory"),
+    ],
+)
+def test_overlaps_communication_and_compute(distributed_setup, use_symm_mem):
+    """Forward and backward communication should overlap GEMM compute."""
     world_size = distributed_setup.world_size
     device = distributed_setup.device
     if world_size < 2:
@@ -510,20 +510,23 @@ def test_overlaps_communication_and_compute(distributed_setup):
     num_children = 4
     dtype = torch.bfloat16
 
-    # Dedicated communicator with NCCL's zero-CTA policy. cta_policy is a
-    # per-communicator property, so scoping it to this group leaves the rest of the
-    # bucket on default-CTA symmetric-memory kernels (test_symmetric_memory.py asserts
-    # ncclSymk all-gather kernel counts, which zero-CTA would turn into copy-engine
-    # memcpys). This 1-D group models the DP (FSDP) sub-mesh that mfsdp is handed in
-    # production: with EP/TP the full device mesh is multi-dimensional, but mfsdp
-    # requires an all-FSDP mesh (see experimental/module.py) and never sees the TP/EP
-    # axes, so only the DP communicator needs the zero-CTA policy. Creating the group
-    # off the conftest's device_id eager-initialized default process group uses a comm
-    # split, which avoids the cold-communicator symmetric-memory rendezvous failure
-    # (https://github.com/pytorch/pytorch/issues/188567).
-    zero_cta_options = dist.ProcessGroupNCCL.Options()
-    zero_cta_options.config.cta_policy = dist.ProcessGroupNCCL.NCCL_CTA_POLICY_ZERO
-    dp_group = dist.new_group(backend="nccl", pg_options=zero_cta_options)
+    if use_symm_mem:
+        # Dedicated communicator with NCCL's zero-CTA policy. cta_policy is a
+        # per-communicator property, so scoping it to this group leaves the rest of the
+        # bucket on default-CTA symmetric-memory kernels (test_symmetric_memory.py asserts
+        # ncclSymk all-gather kernel counts, which zero-CTA would turn into copy-engine
+        # memcpys). This 1-D group models the DP (FSDP) sub-mesh that mfsdp is handed in
+        # production: with EP/TP the full device mesh is multi-dimensional, but mfsdp
+        # requires an all-FSDP mesh (see experimental/module.py) and never sees the TP/EP
+        # axes, so only the DP communicator needs the zero-CTA policy. Creating the group
+        # off the conftest's device_id eager-initialized default process group uses a comm
+        # split, which avoids the cold-communicator symmetric-memory rendezvous failure
+        # (https://github.com/pytorch/pytorch/issues/188567).
+        zero_cta_options = dist.ProcessGroupNCCL.Options()
+        zero_cta_options.config.cta_policy = dist.ProcessGroupNCCL.NCCL_CTA_POLICY_ZERO
+        dp_group = dist.new_group(backend="nccl", pg_options=zero_cta_options)
+    else:
+        dp_group = dist.new_group(backend="nccl")
 
     mesh = DeviceMesh.from_group(dp_group, device.type)
     model = MultiChildModel(dim=dim, num_children=num_children).to(dtype=dtype)
@@ -535,10 +538,14 @@ def test_overlaps_communication_and_compute(distributed_setup):
             mesh=mesh,
             placements=placements,
             mixed_precision_policy=policy,
-            use_symm_mem=True,
+            use_symm_mem=use_symm_mem,
         )
     fully_shard(
-        model, mesh=mesh, placements=placements, mixed_precision_policy=policy, use_symm_mem=True
+        model,
+        mesh=mesh,
+        placements=placements,
+        mixed_precision_policy=policy,
+        use_symm_mem=use_symm_mem,
     )
 
     x = torch.randn(4096, dim, device=device, dtype=dtype, requires_grad=True)
@@ -559,8 +566,9 @@ def test_overlaps_communication_and_compute(distributed_setup):
         torch.cuda.synchronize(device)
 
     events = prof.events()
-    # A GEMM launches under aten::mm as the matmul kernel plus a cudaMemsetAsync (device
-    # events collected by CPU op -- see collect_linked_device_events); keep the matmuls.
+    # A GEMM launches under aten::mm as the matmul kernel plus a cudaMemsetAsync
+    # (device events collected by CPU op -- see collect_linked_device_events);
+    # keep the matmuls.
     gemm_events = []
     for op_device_events in collect_linked_device_events(events, _GEMM_OP_PATTERN).values():
         gemm_events += [event for event in op_device_events if "memset" not in event.name.lower()]
@@ -605,13 +613,15 @@ def test_overlaps_communication_and_compute(distributed_setup):
         any(events_overlap(event, gemm) for event in group for gemm in gemm_events)
         for group in reduce_scatter_events.values()
     )
-    # SM-free all-gather overlaps deterministically, so assert the theoretical maximum:
-    # a forward and a backward all-gather for each of the num_children - 1 non-root
-    # children, and one reduce-scatter per non-root child.
-    expected_all_gather_overlap = 2 * (num_children - 1)
-    expected_reduce_scatter_overlap = num_children - 1
+    # The symmetric-memory case uses NCCL's zero-CTA policy so the all-gather runs on the
+    # copy engine (SM-free) instead of an SM-based kernel: it can never contend with the
+    # GEMMs for SMs, so the overlap count is deterministic and the strict theoretical
+    # maximum thresholds hold. The default case preserves the original non-symmetric path
+    # with looser thresholds since SM-based NCCL kernels can jitter with launch timing.
+    expected_all_gather_overlap = 2 * (num_children - 1) if use_symm_mem else 2
+    expected_reduce_scatter_overlap = num_children - 1 if use_symm_mem else 1
     assert all_gather_overlap_count >= expected_all_gather_overlap, (
-        f"Expected at least {expected_all_gather_overlap} copy-engine all-gathers to "
+        f"Expected at least {expected_all_gather_overlap} all-gathers to "
         f"overlap compute, got {all_gather_overlap_count}/{len(all_gather_events)}."
     )
     assert reduce_scatter_overlap_count >= expected_reduce_scatter_overlap, (
@@ -622,7 +632,7 @@ def test_overlaps_communication_and_compute(distributed_setup):
     # Release the dedicated communicator so it does not leak into the shared session
     # (the mfsdp_v2 bucket keeps one process group alive across tests). On a failure
     # above the group leaks, which is acceptable. Destroying this subgroup leaves the
-    # default process group (and the conftest teardown barrier) untouched.
+    # default process group and conftest teardown barrier.
     dist.destroy_process_group(dp_group)
 
 


### PR DESCRIPTION
## What changed

- Parameterize `test_overlaps_communication_and_compute` so it runs both the existing default collective path and the symmetric-memory path.
- Use a dedicated NCCL subgroup for the test mesh; the symmetric-memory case applies NCCL's zero-CTA policy while the default case uses a normal NCCL subgroup.
- Initialize the default process group lazily in the test without fixture-level `device_id` eager init, and explicitly warm the zero-CTA subgroup before constructing the `DeviceMesh`.
- Attribute profiler device kernels through their linked CPU parent operation using `collect_linked_kernels`, so all-gather, reduce-scatter, and GEMM kernels are found without depending on device-side kernel names.
- Filter linked profiler events to CUDA kernels by `activity_type`, so zero-CTA all-gather copy-engine `Memcpy` events are intentionally excluded.
- In the symmetric-memory zero-CTA case, assert that all-gather emits no all-gather kernels while reduce-scatter still emits kernels and overlaps compute.
- Keep the same overlap expectations for default all-gather and for reduce-scatter in both modes on the existing large `dim=16384` workload.

## Why

The overlap test should cover symmetric-memory mFSDP behavior in addition to the default path. The symmetric-memory zero-CTA all-gather is copy-engine work rather than an SM-launched NCCL kernel, and GEMM kernel names vary across GPU architectures, so profiler attribution by linked CPU parent operation is more robust than matching device-side kernel names directly.

## Impact

Test-only change. There is no production-code behavior change.

Related to #5655.

## Validation

- `uv run --no-sync isort tests/unit_tests/distributed/mfsdp_v2/profiler_utils.py tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py`
- `uv run --no-sync python -m compileall tests/unit_tests/distributed/mfsdp_v2/profiler_utils.py tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py`
- `git diff --check`
- `uv run --no-sync python -m pytest --collect-only -q tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py::test_overlaps_communication_and_compute`

Full distributed CUDA execution is left to CI.
