### PR TITLE
[dev] Lite: /bump lite DeepSeek v4 RL to dev

### DIFF
--- a/experimental/lite/examples/miles/miles_mlite/weight_update.py
+++ b/experimental/lite/examples/miles/miles_mlite/weight_update.py
@@ -11,6 +11,7 @@ from collections.abc import Sequence
 import ray
 import torch
 import torch.distributed as dist
+from megatron.lite.primitive.ckpt.hf_weights import DEFAULT_EXPORT_BUFFER_MAX_SIZE_BYTES
 
 logger = logging.getLogger(__name__)
 
@@ -183,7 +184,13 @@ class RawHFWeightUpdater:
     def _export_weight_chunks(self):
         chunk = []
         chunk_bytes = 0
-        limit = int(getattr(self.args, "update_weight_buffer_size", 2**30))
+        limit = int(
+            getattr(
+                self.args,
+                "update_weight_buffer_size",
+                DEFAULT_EXPORT_BUFFER_MAX_SIZE_BYTES,
+            )
+        )
         export_kwargs = {}
         if getattr(self.args, "mlite_export_dtype", None):
             export_kwargs["export_dtype"] = self.args.mlite_export_dtype

--- a/experimental/lite/examples/verl/scripts/deepseek_v4_chat_template.jinja
+++ b/experimental/lite/examples/verl/scripts/deepseek_v4_chat_template.jinja
@@ -1,0 +1,1 @@
+{% for message in messages %}{% if message["content"] is string %}{{ message["content"] }}{% else %}{% for content in message["content"] %}{% if content["type"] == "text" %}{{ content["text"] }}{% endif %}{% endfor %}{% endif %}{% if not loop.last %}{{ "\n\n" }}{% endif %}{% endfor %}{% if add_generation_prompt %}{{ "\n" }}{% endif %}

--- a/experimental/lite/examples/verl/scripts/run_deepseek_v4_dapo.sh
+++ b/experimental/lite/examples/verl/scripts/run_deepseek_v4_dapo.sh
@@ -1,0 +1,347 @@
+#!/usr/bin/env bash
+# DeepSeek-V4 DAPO launcher.
+#
+# Validated hero dependency contract (CW H100, 2026-07-17):
+#   VERL: 6a937b63
+#   Python: 3.12
+#   PyTorch: 2.12.0a0 nv26.05, CUDA 13.2
+#   vLLM: 0.25.1
+#   Transformer Engine: >= 2.15.0
+#   nvidia-cudnn-frontend: >= 1.27.0, with DSA q_causal_offsets
+#   FlashInfer: 0.6.13
+#   nvidia-cutlass-dsl: 4.5.2
+#   TileLang: 0.1.9
+#
+# validate_deepseek_v4_dapo.py enforces this contract before a real run.
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Key experiment knobs
+# ---------------------------------------------------------------------------
+
+# Rollout routed-expert weights: choose 4 (MXFP4 + Marlin) or
+# 8 (FP8 + FlashInfer CUTLASS). Dense rollout weights remain FP8 in both modes.
+ROLLOUT_WEIGHT_BITS="${ROLLOUT_WEIGHT_BITS:-8}"
+
+# Router replay (R3): record vLLM's routed-expert choices and replay them in
+# the actor when recomputing log-probs. Disable only for parity/debug A/B runs.
+ENABLE_R3="${ENABLE_R3:-True}"
+
+# ---------------------------------------------------------------------------
+# Run inputs and geometry
+# ---------------------------------------------------------------------------
+
+: "${MODEL_PATH:?set MODEL_PATH to the official DeepSeek-V4 checkpoint}"
+DAPO_DATA_DIR="${DAPO_DATA_DIR:-}"
+TRAIN_FILES="${TRAIN_FILES:-${DAPO_DATA_DIR:+${DAPO_DATA_DIR}/dapo-math-17k.parquet}}"
+VAL_FILES="${VAL_FILES:-${DAPO_DATA_DIR:+${DAPO_DATA_DIR}/aime-2024.parquet}}"
+OUTPUT_ROOT="${OUTPUT_ROOT:-}"
+
+NNODES="${NNODES:-1}"
+NGPUS_PER_NODE="${NGPUS_PER_NODE:-${NPROC_PER_NODE:-8}}"
+ACTOR_PP="${ACTOR_PP:-4}"
+ACTOR_CP="${ACTOR_CP:-4}"
+ACTOR_EP="${ACTOR_EP:-8}"
+ROLLOUT_TP="${ROLLOUT_TP:-8}"
+
+TRAIN_BATCH_SIZE="${TRAIN_BATCH_SIZE:-32}"
+PPO_MINI_BATCH_SIZE="${PPO_MINI_BATCH_SIZE:-32}"
+MAX_PROMPT_LENGTH="${MAX_PROMPT_LENGTH:-2048}"
+MAX_RESPONSE_LENGTH="${MAX_RESPONSE_LENGTH:-6144}"
+ROLLOUT_N="${ROLLOUT_N:-8}"
+ROLLOUT_GPU_MEMORY_UTILIZATION="${ROLLOUT_GPU_MEMORY_UTILIZATION:-0.60}"
+
+PARAM_OFFLOAD="${PARAM_OFFLOAD:-True}"
+OPTIMIZER_OFFLOAD="${OPTIMIZER_OFFLOAD:-True}"
+GRAD_OFFLOAD="${GRAD_OFFLOAD:-False}"
+
+TOTAL_EPOCHS="${TOTAL_EPOCHS:-15}"
+TOTAL_TRAINING_STEPS="${TOTAL_TRAINING_STEPS:-null}"
+SAVE_FREQ="${SAVE_FREQ:-20}"
+TEST_FREQ="${TEST_FREQ:-5}"
+RESUME_MODE="${RESUME_MODE:-auto}"
+RESUME_FROM_PATH="${RESUME_FROM_PATH:-null}"
+
+# ---------------------------------------------------------------------------
+# Repository paths and fixed recipe
+# ---------------------------------------------------------------------------
+
+[[ "${VERBOSE:-0}" == "1" ]] && set -x
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -L)"
+EXAMPLE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd -L)"
+LITE_ROOT="$(cd "${EXAMPLE_ROOT}/../.." && pwd -L)"
+REPO_ROOT="$(cd "${LITE_ROOT}/../.." && pwd -L)"
+VALIDATOR="${SCRIPT_DIR}/validate_deepseek_v4_dapo.py"
+CHAT_TEMPLATE_FILE="${SCRIPT_DIR}/deepseek_v4_chat_template.jinja"
+OUTPUT_ROOT="${OUTPUT_ROOT:-${EXAMPLE_ROOT}/outputs/ds4_dapo}"
+
+add_pythonpath() {
+  if [[ -n "${1:-}" ]]; then
+    export PYTHONPATH="${1}:${PYTHONPATH:-}"
+  fi
+}
+
+add_pythonpath "${EXAMPLE_ROOT}"
+add_pythonpath "${LITE_ROOT}"
+add_pythonpath "${REPO_ROOT}"
+add_pythonpath "${VERL_ROOT:-}"
+add_pythonpath "${MEGATRON_ROOT:-}"
+
+export CUDA_DEVICE_MAX_CONNECTIONS=1
+export VLLM_USE_V1=1
+export VERL_VLLM_FP8_QUANT_ENABLED=1
+
+case "${ROLLOUT_WEIGHT_BITS}" in
+  4)
+    ROLLOUT_RESYNC_FORMAT=mxfp4
+    ROLLOUT_EXPERT_DTYPE=fp4
+    ROLLOUT_MOE_BACKEND=marlin
+    ROLLOUT_SCALE_FMT=ue8m0
+    ;;
+  8)
+    ROLLOUT_RESYNC_FORMAT=block_fp8
+    ROLLOUT_EXPERT_DTYPE=fp8
+    ROLLOUT_MOE_BACKEND=flashinfer_cutlass
+    ROLLOUT_SCALE_FMT=float32
+    ;;
+  *)
+    echo "ROLLOUT_WEIGHT_BITS must be 4 or 8, got ${ROLLOUT_WEIGHT_BITS}" >&2
+    exit 2
+    ;;
+esac
+
+case "${ENABLE_R3,,}" in
+  true|1|yes|on)
+    ENABLE_R3=True
+    ROUTER_REPLAY_MODE=R3
+    ENABLE_ROLLOUT_ROUTING_REPLAY=True
+    R3_TAG=on
+    ;;
+  false|0|no|off)
+    ENABLE_R3=False
+    ROUTER_REPLAY_MODE=disabled
+    ENABLE_ROLLOUT_ROUTING_REPLAY=False
+    R3_TAG=off
+    ;;
+  *)
+    echo "ENABLE_R3 must be a boolean, got ${ENABLE_R3}" >&2
+    exit 2
+    ;;
+esac
+
+: "${TRAIN_FILES:?set TRAIN_FILES or DAPO_DATA_DIR}"
+: "${VAL_FILES:?set VAL_FILES or DAPO_DATA_DIR}"
+
+MAX_SEQ_LEN=$((MAX_PROMPT_LENGTH + MAX_RESPONSE_LENGTH))
+DEFAULT_RUN_NAME="ds4_dapo_pp${ACTOR_PP}_ep${ACTOR_EP}_cp${ACTOR_CP}"
+DEFAULT_RUN_NAME+="_rtp${ROLLOUT_TP}_w${ROLLOUT_WEIGHT_BITS}_r3${R3_TAG}"
+RUN_NAME="${RUN_NAME:-${DEFAULT_RUN_NAME}}"
+CKPT_DIR="${CKPT_DIR:-${OUTPUT_ROOT}/checkpoints/${RUN_NAME}}"
+LOG_FILE="${LOG_FILE:-${OUTPUT_ROOT}/${RUN_NAME}.log}"
+JSONL_FILE="${JSONL_FILE:-${OUTPUT_ROOT}/${RUN_NAME}.jsonl}"
+CMD_FILE="${CMD_FILE:-${OUTPUT_ROOT}/${RUN_NAME}.cmd.sh}"
+
+mkdir -p \
+  "${OUTPUT_ROOT}" \
+  "${CKPT_DIR}" \
+  "$(dirname "${LOG_FILE}")" \
+  "$(dirname "${JSONL_FILE}")" \
+  "$(dirname "${CMD_FILE}")"
+export VERL_FILE_LOGGER_PATH="${JSONL_FILE}"
+
+python3 "${VALIDATOR}" geometry \
+  --model-config "${MODEL_PATH}/config.json" \
+  --rollout-tp "${ROLLOUT_TP}"
+
+DS4_CHAT_TEMPLATE="${DEEPSEEK_V4_FLASH_CHAT_TEMPLATE:-$(<"${CHAT_TEMPLATE_FILE}")}"
+
+# ---------------------------------------------------------------------------
+# Hydra configuration
+# ---------------------------------------------------------------------------
+
+ALGORITHM=(
+  "algorithm.adv_estimator=grpo"
+  "algorithm.use_kl_in_reward=False"
+  "algorithm.kl_ctrl.kl_coef=0.0"
+  "algorithm.rollout_correction.bypass_mode=False"
+  "algorithm.norm_adv_by_std_in_grpo=False"
+)
+
+# Use veRL's native RLHFDataset. Inputs must already follow its rule-reward
+# schema (prompt, data_source, and reward_model.ground_truth).
+DATA=(
+  "data.train_files=${TRAIN_FILES}"
+  "data.val_files=${VAL_FILES}"
+  "data.train_batch_size=${TRAIN_BATCH_SIZE}"
+  "data.prompt_key=prompt"
+  "data.return_raw_chat=True"
+  "data.max_prompt_length=${MAX_PROMPT_LENGTH}"
+  "data.max_response_length=${MAX_RESPONSE_LENGTH}"
+  "data.filter_overlong_prompts=True"
+  "data.truncation=error"
+  "data.dataloader_num_workers=8"
+)
+
+MODEL=(
+  "actor_rollout_ref.model.path=${MODEL_PATH}"
+  "actor_rollout_ref.model.trust_remote_code=True"
+  "actor_rollout_ref.model.use_fused_kernels=True"
+  "actor_rollout_ref.model.custom_chat_template='${DS4_CHAT_TEMPLATE}'"
+)
+
+ACTOR=(
+  "actor@actor_rollout_ref.actor=mlite_actor"
+  "actor_rollout_ref.actor.optim.lr=1e-6"
+  "actor_rollout_ref.actor.optim.weight_decay=0.1"
+  "actor_rollout_ref.actor.optim.betas=[0.9,0.95]"
+  "actor_rollout_ref.actor.optim.clip_grad=1.0"
+  "actor_rollout_ref.actor.optim.lr_warmup_steps=0"
+  "actor_rollout_ref.actor.optim.lr_warmup_init=0"
+  "actor_rollout_ref.actor.optim.lr_decay_style=constant"
+  "actor_rollout_ref.actor.ppo_mini_batch_size=${PPO_MINI_BATCH_SIZE}"
+  "actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=1"
+  "actor_rollout_ref.actor.use_dynamic_bsz=True"
+  "actor_rollout_ref.actor.ppo_max_token_len_per_gpu=${MAX_SEQ_LEN}"
+  "actor_rollout_ref.actor.use_kl_loss=False"
+  "actor_rollout_ref.actor.kl_loss_coef=0.0"
+  "actor_rollout_ref.actor.entropy_coeff=0"
+  "actor_rollout_ref.actor.policy_loss.loss_mode=vanilla"
+  "actor_rollout_ref.actor.clip_ratio_low=0.2"
+  "actor_rollout_ref.actor.clip_ratio_high=0.28"
+  "actor_rollout_ref.actor.clip_ratio_c=10.0"
+  "actor_rollout_ref.actor.loss_agg_mode=token-mean"
+  "actor_rollout_ref.actor.engine.dtype=bfloat16"
+  "actor_rollout_ref.actor.engine.model_name=deepseek_v4"
+  "actor_rollout_ref.actor.engine.impl=lite"
+  "actor_rollout_ref.actor.engine.tp=1"
+  "actor_rollout_ref.actor.engine.pp=${ACTOR_PP}"
+  "actor_rollout_ref.actor.engine.vpp=1"
+  "actor_rollout_ref.actor.engine.cp=${ACTOR_CP}"
+  "actor_rollout_ref.actor.engine.ep=${ACTOR_EP}"
+  "actor_rollout_ref.actor.engine.etp=1"
+  "actor_rollout_ref.actor.engine.param_offload=${PARAM_OFFLOAD}"
+  "actor_rollout_ref.actor.engine.optimizer_offload=${OPTIMIZER_OFFLOAD}"
+  "actor_rollout_ref.actor.engine.grad_offload=${GRAD_OFFLOAD}"
+  "actor_rollout_ref.actor.engine.attention_backend_override=fused"
+  "actor_rollout_ref.actor.engine.impl_cfg.use_thd=True"
+  "+actor_rollout_ref.actor.engine.impl_cfg.optimizer=fsdp2"
+  "actor_rollout_ref.actor.engine.load_hf_weights=True"
+  "+actor_rollout_ref.actor.engine.cross_entropy_fusion=True"
+  "actor_rollout_ref.actor.engine.resync_format=${ROLLOUT_RESYNC_FORMAT}"
+  "+actor_rollout_ref.actor.engine.resync_config.expert_dtype=${ROLLOUT_EXPERT_DTYPE}"
+  "+actor_rollout_ref.actor.engine.impl_cfg.recompute=full"
+  "+actor_rollout_ref.actor.engine.impl_cfg.mtp_enable=True"
+  "+actor_rollout_ref.actor.engine.impl_cfg.mtp_enable_train=True"
+  "actor_rollout_ref.actor.engine.router_replay_mode=${ROUTER_REPLAY_MODE}"
+)
+
+if [[ "${OPTIMIZER_OFFLOAD}" =~ ^(True|true|1)$ ]]; then
+  ACTOR+=(
+    "+actor_rollout_ref.actor.optim.override_optimizer_config.offload_fraction=1.0"
+    "+actor_rollout_ref.actor.optim.override_optimizer_config.use_precision_aware_optimizer=True"
+    "+actor_rollout_ref.actor.optim.override_optimizer_config.decoupled_weight_decay=True"
+  )
+fi
+
+VLLM_CONFIG="actor_rollout_ref.rollout.engine_kwargs.vllm"
+VLLM_QUANT_CONFIG="${VLLM_CONFIG}.hf_overrides.quantization_config"
+VLLM_WORKER_EXTENSION="verl.workers.rollout.vllm_rollout.utils"
+VLLM_WORKER_EXTENSION+=".vLLMColocateWorkerExtension"
+
+ROLLOUT=(
+  "actor_rollout_ref.rollout.name=vllm"
+  "actor_rollout_ref.rollout.mode=async"
+  "actor_rollout_ref.rollout.tensor_model_parallel_size=${ROLLOUT_TP}"
+  "actor_rollout_ref.rollout.gpu_memory_utilization=${ROLLOUT_GPU_MEMORY_UTILIZATION}"
+  "actor_rollout_ref.rollout.n=${ROLLOUT_N}"
+  "actor_rollout_ref.rollout.calculate_log_probs=True"
+  "actor_rollout_ref.rollout.log_prob_use_dynamic_bsz=True"
+  "actor_rollout_ref.rollout.log_prob_max_token_len_per_gpu=${MAX_SEQ_LEN}"
+  "actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1"
+  "actor_rollout_ref.rollout.prompt_length=${MAX_PROMPT_LENGTH}"
+  "actor_rollout_ref.rollout.response_length=${MAX_RESPONSE_LENGTH}"
+  "actor_rollout_ref.rollout.max_model_len=${MAX_SEQ_LEN}"
+  "actor_rollout_ref.rollout.max_num_seqs=32"
+  "actor_rollout_ref.rollout.max_num_batched_tokens=${MAX_SEQ_LEN}"
+  "actor_rollout_ref.rollout.temperature=1.0"
+  "actor_rollout_ref.rollout.top_p=1.0"
+  "actor_rollout_ref.rollout.top_k=-1"
+  "actor_rollout_ref.rollout.val_kwargs.temperature=0.0"
+  "actor_rollout_ref.rollout.val_kwargs.top_p=1.0"
+  "actor_rollout_ref.rollout.val_kwargs.do_sample=False"
+  "actor_rollout_ref.rollout.val_kwargs.n=1"
+  "actor_rollout_ref.rollout.free_cache_engine=True"
+  "actor_rollout_ref.rollout.load_format=dummy"
+  "actor_rollout_ref.rollout.enable_rollout_routing_replay=${ENABLE_ROLLOUT_ROUTING_REPLAY}"
+  "actor_rollout_ref.rollout.enforce_eager=True"
+  "+${VLLM_CONFIG}.disable_custom_all_reduce=True"
+  "+${VLLM_CONFIG}.worker_extension_cls=${VLLM_WORKER_EXTENSION}"
+  "+${VLLM_CONFIG}.kv_cache_dtype=fp8"
+  "+${VLLM_CONFIG}.moe_backend=${ROLLOUT_MOE_BACKEND}"
+  "+${VLLM_CONFIG}.hf_overrides.expert_dtype=${ROLLOUT_EXPERT_DTYPE}"
+  "+${VLLM_QUANT_CONFIG}.activation_scheme=dynamic"
+  "+${VLLM_QUANT_CONFIG}.fmt=e4m3"
+  "+${VLLM_QUANT_CONFIG}.quant_method=fp8"
+  "+${VLLM_QUANT_CONFIG}.scale_fmt=${ROLLOUT_SCALE_FMT}"
+  "+${VLLM_QUANT_CONFIG}.weight_block_size=[128,128]"
+)
+
+TRAINER=(
+  "critic.enable=False"
+  "trainer.balance_batch=True"
+  "trainer.logger=[console,file]"
+  "trainer.project_name=verl-mlite-ds4-dapo"
+  "trainer.experiment_name=${RUN_NAME}"
+  "trainer.n_gpus_per_node=${NGPUS_PER_NODE}"
+  "trainer.nnodes=${NNODES}"
+  "trainer.save_freq=${SAVE_FREQ}"
+  "trainer.test_freq=${TEST_FREQ}"
+  "trainer.total_epochs=${TOTAL_EPOCHS}"
+  "trainer.total_training_steps=${TOTAL_TRAINING_STEPS}"
+  "trainer.resume_mode=${RESUME_MODE}"
+  "trainer.resume_from_path=${RESUME_FROM_PATH}"
+  "trainer.default_local_dir=${CKPT_DIR}"
+  "trainer.val_before_train=False"
+  "trainer.log_val_generations=10"
+)
+
+REWARD=(
+  "+reward.reward_kwargs.overlong_buffer_cfg.enable=True"
+  "+reward.reward_kwargs.overlong_buffer_cfg.len=4096"
+  "+reward.reward_kwargs.overlong_buffer_cfg.penalty_factor=1.0"
+  "+reward.reward_kwargs.overlong_buffer_cfg.log=False"
+)
+
+COMMAND=(
+  python3 -m verl.trainer.main_ppo
+  "hydra.searchpath=[pkg://verl_mlite.config]"
+  "${ALGORITHM[@]}"
+  "${DATA[@]}"
+  "${MODEL[@]}"
+  "${ACTOR[@]}"
+  "${ROLLOUT[@]}"
+  "${TRAINER[@]}"
+  "${REWARD[@]}"
+  "$@"
+)
+
+printf '%q ' "${COMMAND[@]}" >"${CMD_FILE}"
+printf '\n' >>"${CMD_FILE}"
+
+if [[ "${DRY_RUN:-0}" == "1" ]]; then
+  printf '%q ' "${COMMAND[@]}"
+  printf '\n'
+  exit 0
+fi
+
+python3 "${VALIDATOR}" environment
+
+echo "[ds4-dapo] weights=expert-w${ROLLOUT_WEIGHT_BITS}/dense-w8 r3=${ENABLE_R3}"
+echo "[ds4-dapo] train=${TRAIN_FILES} val=${VAL_FILES} cmd=${CMD_FILE}"
+
+set +e
+"${COMMAND[@]}" 2>&1 | tee "${LOG_FILE}"
+cmd_rc="${PIPESTATUS[0]}"
+set -e
+exit "${cmd_rc}"

--- a/experimental/lite/examples/verl/scripts/run_deepseek_v4_dapo.sh
+++ b/experimental/lite/examples/verl/scripts/run_deepseek_v4_dapo.sh
@@ -179,6 +179,7 @@ DATA=(
   "data.max_prompt_length=${MAX_PROMPT_LENGTH}"
   "data.max_response_length=${MAX_RESPONSE_LENGTH}"
   "data.filter_overlong_prompts=True"
+  "+data.apply_chat_template_kwargs.chat_template='${DS4_CHAT_TEMPLATE}'"
   "data.truncation=error"
   "data.dataloader_num_workers=8"
 )

--- a/experimental/lite/examples/verl/scripts/validate_deepseek_v4_dapo.py
+++ b/experimental/lite/examples/verl/scripts/validate_deepseek_v4_dapo.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Validate the fixed DeepSeek-V4 DAPO launch contract."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.metadata as metadata
+import inspect
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from packaging.version import Version
+
+
+EXACT_DEPENDENCIES = {
+    "vllm": "0.25.1",
+    "flashinfer-python": "0.6.13",
+    "nvidia-cutlass-dsl": "4.5.2",
+    "tilelang": "0.1.9",
+}
+MINIMUM_DEPENDENCIES = {
+    "transformer-engine": "2.15.0",
+    "nvidia-cudnn-frontend": "1.27.0",
+}
+EXPECTED_VERL_COMMIT = "6a937b63"
+
+
+def installed(name: str) -> str:
+    try:
+        return metadata.version(name)
+    except metadata.PackageNotFoundError as exc:
+        raise SystemExit(f"DS4 dependency is missing: {name}") from exc
+
+
+def validate_geometry(model_config: Path, rollout_tp: int) -> None:
+    config = json.loads(model_config.read_text(encoding="utf-8"))
+    o_groups = config.get("o_groups")
+    if not isinstance(o_groups, int) or o_groups < 1 or o_groups % rollout_tp != 0:
+        raise SystemExit(
+            f"DS4 o_groups={o_groups} must be divisible by rollout_tp={rollout_tp}"
+        )
+    print(
+        f"DS4_ROLLOUT_TP_PREFLIGHT_PASSED o_groups={o_groups} rollout_tp={rollout_tp}",
+        flush=True,
+    )
+
+
+def verl_commit() -> str:
+    declared = os.environ.get("VERL_COMMIT")
+    root = os.environ.get("VERL_ROOT")
+    if declared is None and root:
+        try:
+            declared = subprocess.check_output(
+                ["git", "-C", root, "rev-parse", "HEAD"],
+                text=True,
+                stderr=subprocess.DEVNULL,
+            ).strip()
+        except (OSError, subprocess.CalledProcessError):
+            pass
+    if declared is None:
+        raise SystemExit(
+            f"VERL provenance is not verifiable; set VERL_COMMIT={EXPECTED_VERL_COMMIT}"
+        )
+    if not declared.startswith(EXPECTED_VERL_COMMIT):
+        raise SystemExit(f"DS4 requires VERL {EXPECTED_VERL_COMMIT}, got {declared}")
+    return declared
+
+
+def validate_environment() -> None:
+    actual = {
+        name: installed(name) for name in EXACT_DEPENDENCIES | MINIMUM_DEPENDENCIES
+    }
+    bad_exact = {
+        name: (actual[name], wanted)
+        for name, wanted in EXACT_DEPENDENCIES.items()
+        if Version(actual[name]) != Version(wanted)
+    }
+    bad_minimum = {
+        name: (actual[name], wanted)
+        for name, wanted in MINIMUM_DEPENDENCIES.items()
+        if Version(actual[name]) < Version(wanted)
+    }
+    if bad_exact or bad_minimum:
+        raise SystemExit(
+            f"DS4 dependency mismatch: exact={bad_exact} minimum={bad_minimum}"
+        )
+    if sys.version_info[:2] != (3, 12):
+        raise SystemExit(f"DS4 requires Python 3.12, got {sys.version}")
+
+    import cudnn
+    import torch
+    import transformer_engine.pytorch as te
+    from cudnn import DSA
+
+    if not torch.__version__.startswith("2.12.0a0") or torch.version.cuda != "13.2":
+        raise SystemExit(
+            "DS4 requires PyTorch 2.12 nv26.05 / CUDA 13.2, "
+            f"got torch={torch.__version__} cuda={torch.version.cuda}"
+        )
+    if "q_causal_offsets" not in inspect.signature(
+        DSA.indexer_forward_wrapper
+    ).parameters:
+        raise SystemExit(
+            "nvidia-cudnn-frontend lacks q_causal_offsets required by fused DSA CP"
+        )
+
+    declared_verl = verl_commit()
+    print(
+        "DS4_DEPENDENCY_CONTRACT_PASSED "
+        f"verl={declared_verl} python={sys.version.split()[0]} "
+        f"torch={torch.__version__} torch_cuda={torch.version.cuda} "
+        f"vllm={actual['vllm']} te={actual['transformer-engine']} "
+        f"cudnn_frontend={actual['nvidia-cudnn-frontend']} "
+        f"flashinfer={actual['flashinfer-python']} "
+        f"cutlass={actual['nvidia-cutlass-dsl']} tilelang={actual['tilelang']} "
+        f"te_origin={te.__file__} cudnn_origin={cudnn.__file__}",
+        flush=True,
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    geometry = subparsers.add_parser("geometry")
+    geometry.add_argument("--model-config", type=Path, required=True)
+    geometry.add_argument("--rollout-tp", type=int, required=True)
+    subparsers.add_parser("environment")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.command == "geometry":
+        validate_geometry(args.model_config, args.rollout_tp)
+    else:
+        validate_environment()
+
+
+if __name__ == "__main__":
+    main()

--- a/experimental/lite/examples/verl/scripts/validate_deepseek_v4_dapo.py
+++ b/experimental/lite/examples/verl/scripts/validate_deepseek_v4_dapo.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 """Validate the fixed DeepSeek-V4 DAPO launch contract."""
 
 from __future__ import annotations

--- a/experimental/lite/examples/verl/sitecustomize.py
+++ b/experimental/lite/examples/verl/sitecustomize.py
@@ -1,6 +1,9 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Process-wide compatibility hooks for the VERL MLite examples."""
 
-from verl_mlite.compat import apply_runtime_patches
+import os
 
-apply_runtime_patches()
+if os.environ.get("VERL_MLITE_SKIP_RUNTIME_PATCHES") != "1":
+    from verl_mlite.compat import apply_runtime_patches
+
+    apply_runtime_patches()

--- a/experimental/lite/examples/verl/verl_mlite/compat.py
+++ b/experimental/lite/examples/verl/verl_mlite/compat.py
@@ -3,12 +3,382 @@
 
 from __future__ import annotations
 
+import gc
+import importlib.abc
+import importlib.machinery
 import importlib.util
+import os
+import queue
 import sys
+import threading
 from collections.abc import Iterable
+from concurrent.futures import ThreadPoolExecutor
+from contextvars import copy_context
 from functools import wraps
 from pathlib import Path
 from typing import Any
+
+_VLLM_ASYNC_SERVER_MODULE = (
+    "verl.workers.rollout.vllm_rollout.vllm_async_server"
+)
+_VLLM_ROLLOUT_CONSUMER_MODULE = (
+    "verl.workers.rollout.vllm_rollout.vllm_rollout"
+)
+_REGISTERED_HF_CONFIG_TYPES: set[str] = set()
+
+_VLLM_IMPORTABLE: bool | None = None
+
+
+_BUCKETED_SENDER_MODULE = "verl.workers.rollout.vllm_rollout.bucketed_weight_transfer"
+
+def _vllm_importable() -> bool:
+    """Whether ``import vllm`` succeeds in THIS process.
+
+    A fat rollout overlay (native vLLM 0.25 = torch 2.11+cu130, Transformers v5)
+    can only be imported inside the vLLM rollout Ray actor, which is scoped to
+    the overlay's torch + CUDA libs via the compat vLLM-server profile. The
+    training driver and worker processes keep the container/SM90 stack, whose
+    vllm build is ABI/CUDA-incompatible with this container — importing it there
+    dies with e.g. ``libcudart.so.12: cannot open shared object file`` (SM90's
+    CUDA-12 vllm in a CUDA-13 container) or the Transformers-v4/v5 mismatch.
+    Every vllm-touching patch below is therefore a no-op wherever vllm is
+    unimportable, so importing verl_mlite on the driver (hydra config
+    validation instantiates the engine module tree, which used to eagerly import
+    the rollout vllm utils) and running apply_runtime_patches there no longer
+    crash on the rollout engine's vllm. The result is cached because the import
+    outcome is fixed per process and a failed attempt is slow to retry.
+    """
+    global _VLLM_IMPORTABLE
+    if _VLLM_IMPORTABLE is None:
+        try:
+            # A bare ``import vllm`` only runs the lazy PEP-562 package shell and
+            # succeeds even where the real engine is unusable, so force the same
+            # entrypoint VERL pulls (``from vllm import LLM``). Accessing ``LLM``
+            # triggers the lazy load of vllm.entrypoints -> vllm.config ->
+            # vllm.platforms -> ``vllm._C``, i.e. the exact chain that dies on the
+            # driver with libcudart.so.12 / the torch-ABI mismatch.
+            getattr(importlib.import_module("vllm"), "LLM")
+            _VLLM_IMPORTABLE = True
+        except Exception:
+            _VLLM_IMPORTABLE = False
+    return _VLLM_IMPORTABLE
+
+
+def _register_opaque_hf_config() -> bool:
+    """Let VERL preserve config fields for an MLite-owned model type."""
+    model_type = os.environ.get("VERL_MLITE_HF_CONFIG_MODEL_TYPE", "").strip()
+    if not model_type or model_type in _REGISTERED_HF_CONFIG_TYPES:
+        return False
+
+    from transformers import AutoConfig, PretrainedConfig
+
+    config_cls = type(
+        "MLiteOpaqueConfig",
+        (PretrainedConfig,),
+        {"model_type": model_type},
+    )
+    try:
+        AutoConfig.register(model_type, config_cls)
+    except ValueError:
+        # A newer Transformers already owns this model type.
+        _REGISTERED_HF_CONFIG_TYPES.add(model_type)
+        return False
+    _REGISTERED_HF_CONFIG_TYPES.add(model_type)
+    return True
+
+
+class _VllmThinFinder(importlib.abc.MetaPathFinder):
+    """Resolve only the top-level ``vllm`` package from a rollout site."""
+
+    _verl_mlite_vllm_thin_finder = True
+
+    def __init__(self, site: str):
+        self._site = site
+
+    def find_spec(self, fullname, path, target=None):
+        if fullname != "vllm":
+            return None
+        return importlib.machinery.PathFinder.find_spec(fullname, [self._site], target)
+
+
+def _install_vllm_thin_finder() -> bool:
+    site = os.environ.get("VERL_MLITE_VLLM_SITE", "").strip()
+    if not site:
+        return False
+    # A THIN overlay ships vllm but no torch: the container/training torch is
+    # shared, so this global meta-path finder can safely redirect EVERY process's
+    # ``import vllm`` (driver + rollout) to the overlay. A FAT overlay instead
+    # bundles its own torch (native vLLM 0.25 = torch 2.11+cu130) and a newer
+    # vllm whose hard Transformers-v5 requirement mismatches the training
+    # driver's Transformers-v4 stack. It must reach ONLY the rollout Ray actor,
+    # which acquires it through the scoped verl_mlite.compat vLLM-server profile
+    # (its site is prepended to that actor's PYTHONPATH). Installing a global
+    # finder for a fat overlay forces the driver's incidental ``import vllm``
+    # (verl config validation instantiates the rollout module tree) onto the fat
+    # vllm 0.25 and dies with "Support for Transformers v4 ... removed in vLLM
+    # v0.24.0" (job 13956329). The presence of bundled CUDA libs distinguishes a
+    # fat overlay, so skip the global finder for it and let the driver keep its
+    # own (container/SM90) vllm.
+    if _vllm_site_ld_library_path(site):
+        return False
+    if any(
+        getattr(finder, "_verl_mlite_vllm_thin_finder", False)
+        for finder in sys.meta_path
+    ):
+        return False
+    sys.meta_path.insert(0, _VllmThinFinder(site))
+    return True
+
+
+def _patch_transformers_vision2seq_alias() -> bool:
+    """Restore the Transformers 4 vision auto-class name removed in v5.
+
+    VERL's ``verl.utils.model`` does a top-level ``from transformers import
+    AutoModelForVision2Seq`` that every training/rollout worker hits regardless
+    of the rollout overlay. Under the single torch2.12/cu13 stack the alias must
+    apply unconditionally (transformers v5 is the only world now), so this is no
+    longer gated on ``VERL_MLITE_VLLM_SITE`` (the retired fat/thin split env).
+
+    A one-shot attribute set on the top-level module does NOT survive: importing
+    VERL's vLLM utilities re-execs Transformers' ``_LazyModule`` and rebuilds a
+    fresh instance whose ``_class_to_module`` map has no ``AutoModelForVision2Seq``
+    entry, so the injected attribute is dropped and the ``from transformers
+    import`` line fails again. We therefore patch the ``_LazyModule`` *class*'s
+    ``__getattr__`` so every instance -- current and any rebuilt one -- resolves
+    the removed name to ``AutoModelForImageTextToText``.
+    """
+    import transformers
+
+    try:
+        from transformers.utils import import_utils as _iu
+
+        lazy_cls = _iu._LazyModule
+    except Exception:  # pragma: no cover - transformers internals moved
+        lazy_cls = None
+
+    if lazy_cls is not None and not getattr(
+        lazy_cls, "_mlite_vision2seq_patched", False
+    ):
+        _orig_getattr = lazy_cls.__getattr__
+
+        def _getattr_with_vision2seq_alias(self, name):
+            if name == "AutoModelForVision2Seq":
+                return _orig_getattr(self, "AutoModelForImageTextToText")
+            return _orig_getattr(self, name)
+
+        lazy_cls.__getattr__ = _getattr_with_vision2seq_alias
+        lazy_cls._mlite_vision2seq_patched = True
+
+    # Belt-and-suspenders: also expose it on the current module object so code
+    # that does ``hasattr(transformers, "AutoModelForVision2Seq")`` short-circuits.
+    if not hasattr(transformers, "AutoModelForVision2Seq"):
+        replacement = getattr(transformers, "AutoModelForImageTextToText", None)
+        if replacement is not None:
+            transformers.AutoModelForVision2Seq = replacement
+            return True
+    return lazy_cls is not None
+
+
+def _install_vllm_triton_kernels_alias() -> bool:
+    """Prefer the rollout vLLM's complete vendored Triton kernel package."""
+    if not os.environ.get("VERL_MLITE_VLLM_SITE", "").strip():
+        return False
+    if not _vllm_importable():
+        return False
+    vendored = importlib.import_module("vllm.third_party.triton_kernels")
+    if sys.modules.get("triton_kernels") is vendored:
+        return False
+    sys.modules["triton_kernels"] = vendored
+    return True
+
+
+def _vllm_site_pythonpath_prefixes(site: str) -> list[str]:
+    """Extra PYTHONPATH entries a rollout overlay needs ahead of its site root.
+
+    Fat overlays (e.g. the native vLLM 0.25 DS4 closure) ship cutlass-dsl under
+    ``nvidia_cutlass_dsl/python_packages`` via a ``.pth`` that is NOT processed
+    when the site is reached through ``PYTHONPATH`` rather than site-packages
+    import. Without an explicit prefix a stray conda cutlass shadows it and
+    flashinfer dies with ``cute.nvgpu.OperandMajorMode``. Thin overlays that lack
+    the directory contribute nothing, so this stays a no-op for them.
+    """
+    prefixes: list[str] = []
+    cutlass = os.path.join(site, "nvidia_cutlass_dsl", "python_packages")
+    if os.path.isdir(cutlass):
+        prefixes.append(cutlass)
+    return prefixes
+
+
+def _vllm_site_ld_library_path(site: str) -> list[str]:
+    """CUDA runtime lib dirs a rollout overlay bundles for its own torch build.
+
+    A native-CUDA overlay (torch 2.11+cu130) colocated inside a cu128 training
+    container must expose its bundled ``nvidia/*/lib`` and ``torch/lib`` to the
+    rollout actor's loader, but ONLY to that actor — the training driver keeps
+    the container's cu128 stack. Scoping this to the vLLM Ray-actor runtime env
+    (rather than a process-wide LD_LIBRARY_PATH) is what keeps the two CUDA
+    majors from colliding. Overlays whose torch matches the container ship no
+    such dirs, so this returns nothing and stays a no-op.
+    """
+    import glob
+
+    lib_dirs = sorted(glob.glob(os.path.join(site, "nvidia", "*", "lib")))
+    torch_lib = os.path.join(site, "torch", "lib")
+    if os.path.isdir(torch_lib):
+        lib_dirs.append(torch_lib)
+    return [d for d in lib_dirs if os.path.isdir(d)]
+
+
+def _vllm_server_profile_env() -> dict[str, str]:
+    """Build the dependency profile applied only to vLLM server Ray actors."""
+    site = os.environ.get("VERL_MLITE_VLLM_SITE", "").strip()
+    if not site:
+        return {}
+    pythonpath = os.environ.get("PYTHONPATH", "").strip()
+    # Keep vLLM's dependency closure on the rollout site. The scoped compatibility
+    # alias above lets VERL import against that site's Transformers v5 build. Fat
+    # overlays additionally need their bundled cutlass ahead of the site root.
+    pythonpath_entries = _vllm_site_pythonpath_prefixes(site) + [site]
+    if pythonpath:
+        pythonpath_entries.append(pythonpath)
+    result = {
+        "PYTHONPATH": os.pathsep.join(pythonpath_entries),
+        "PYTHONNOUSERSITE": "1",
+    }
+    ld_library_entries = _vllm_site_ld_library_path(site)
+    if ld_library_entries:
+        existing_ld = os.environ.get("LD_LIBRARY_PATH", "").strip()
+        if existing_ld:
+            ld_library_entries.append(existing_ld)
+        result["LD_LIBRARY_PATH"] = os.pathsep.join(ld_library_entries)
+    shim = os.environ.get("VERL_MLITE_VLLM_LD_PRELOAD", "").strip()
+    existing_preload = os.environ.get("LD_PRELOAD", "").strip()
+    if shim:
+        result["LD_PRELOAD"] = f"{shim}:{existing_preload}" if existing_preload else shim
+    elif existing_preload:
+        result["LD_PRELOAD"] = existing_preload
+    return result
+
+
+class _RayActorClassProfile:
+    """Merge a process profile into one Ray actor class's ``runtime_env``."""
+
+    def __init__(self, actor_class: Any, env_vars: dict[str, str]):
+        self._actor_class = actor_class
+        self._env_vars = dict(env_vars)
+
+    def options(self, **kwargs: Any) -> Any:
+        runtime_env = dict(kwargs.get("runtime_env") or {})
+        env_vars = dict(runtime_env.get("env_vars") or {})
+        env_vars.update(self._env_vars)
+        runtime_env["env_vars"] = env_vars
+        kwargs["runtime_env"] = runtime_env
+        return self._actor_class.options(**kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._actor_class, name)
+
+
+def _patch_verl_vllm_headless_api_server_count() -> bool:
+    """Normalize vLLM's headless API server count for VERL's direct caller."""
+    if not os.environ.get("VERL_MLITE_VLLM_SITE", "").strip():
+        return False
+    if not _vllm_importable():
+        return False
+
+    server_module = importlib.import_module(_VLLM_ASYNC_SERVER_MODULE)
+    original_run_headless = server_module.run_headless
+    if getattr(
+        original_run_headless,
+        "_verl_mlite_api_server_count_patch",
+        False,
+    ):
+        return False
+
+    @wraps(original_run_headless)
+    def patched_run_headless(args: Any) -> Any:
+        if getattr(args, "api_server_count", None) is None:
+            args.api_server_count = 0
+        return original_run_headless(args)
+
+    patched_run_headless._verl_mlite_api_server_count_patch = True
+    server_module.run_headless = patched_run_headless
+    return True
+
+
+def _patch_vllm_server_profile() -> bool:
+    profile = _vllm_server_profile_env()
+    if not profile:
+        return False
+    if not _vllm_importable():
+        return False
+    changed = _patch_verl_vllm_headless_api_server_count()
+    server_module = importlib.import_module(_VLLM_ASYNC_SERVER_MODULE)
+    vLLMReplica = server_module.vLLMReplica
+
+    if getattr(vLLMReplica, "_verl_mlite_server_profile_patch", False):
+        return changed
+    original_init = vLLMReplica.__init__
+
+    @wraps(original_init)
+    def patched_init(self: Any, *args: Any, **kwargs: Any) -> None:
+        original_init(self, *args, **kwargs)
+        self.server_class = _RayActorClassProfile(self.server_class, profile)
+
+    vLLMReplica.__init__ = patched_init
+    vLLMReplica._verl_mlite_server_profile_patch = True
+    return True
+
+
+def _normalize_vllm_visible_device_id(device_id: int) -> int:
+    """Translate a leaked physical CUDA id back to vLLM's visible-list index."""
+    visible_devices = [
+        value.strip()
+        for value in os.environ.get("CUDA_VISIBLE_DEVICES", "").split(",")
+        if value.strip()
+    ]
+    if device_id < 0 or not visible_devices or device_id < len(visible_devices):
+        return device_id
+
+    physical_id = str(device_id)
+    if physical_id in visible_devices:
+        return visible_devices.index(physical_id)
+    return device_id
+
+
+def _patch_verl_vllm_device_uuid() -> bool:
+    """Keep VERL/vLLM UUID lookup on the Ray actor's visible CUDA device."""
+    if not os.environ.get("VERL_MLITE_VLLM_SITE", "").strip():
+        return False
+    if not _vllm_importable():
+        return False
+
+    utils = importlib.import_module("verl.workers.rollout.vllm_rollout.utils")
+    original_get_device_uuid = utils.get_device_uuid
+    changed = False
+    if getattr(original_get_device_uuid, "_verl_mlite_visible_device_patch", False):
+        patched_get_device_uuid = original_get_device_uuid
+    else:
+        @wraps(original_get_device_uuid)
+        def patched_get_device_uuid(device_id: int) -> str:
+            return original_get_device_uuid(
+                _normalize_vllm_visible_device_id(device_id)
+            )
+
+        patched_get_device_uuid._verl_mlite_visible_device_patch = True
+        utils.get_device_uuid = patched_get_device_uuid
+        changed = True
+
+    # Importing the leaf ``utils`` module first executes the package __init__,
+    # which can bind the original helper into this consumer before we replace it.
+    consumer = sys.modules.get(_VLLM_ROLLOUT_CONSUMER_MODULE)
+    if (
+        consumer is not None
+        and getattr(consumer, "get_device_uuid", None) is not patched_get_device_uuid
+    ):
+        consumer.get_device_uuid = patched_get_device_uuid
+        changed = True
+    return changed
 
 
 def _patch_transformers_rope_ignore_keys() -> None:
@@ -55,8 +425,952 @@ def _patch_transformers_rope_ignore_keys() -> None:
         cls._verl_mlite_rope_ignore_keys_patch = True
 
 
+def _patch_transformers_apply_chat_template_return_dict() -> bool:
+    """Restore Transformers v4's ``apply_chat_template`` list-of-ids return type.
+
+    In Transformers v5 the ``return_dict`` default of
+    ``PreTrainedTokenizerBase.apply_chat_template`` flipped from ``False`` to
+    ``True``, so a ``tokenize=True`` call now yields a ``BatchEncoding`` mapping
+    (``{"input_ids": [...], "attention_mask": [...]}``) instead of a bare
+    ``list[int]``. VERL's agent loop
+    (``verl.experimental.agent_loop.agent_loop.AgentLoop.apply_chat_template``)
+    was written against v4 and treats the result as a token-id list: it forwards
+    the value straight into ``TokensPrompt(prompt_token_ids=...)``. vLLM's input
+    validator then evaluates ``max(prompt_ids)`` over the mapping's *keys*,
+    yielding the string ``"input_ids"`` and crashing the rollout with
+    ``TypeError: '>' not supported between instances of 'str' and 'int'``
+    (job 13961728, single torch2.12/cu13 stack). We default ``return_dict`` back
+    to ``False`` whenever the caller does not set it explicitly, restoring the v4
+    contract while leaving callers that request a dict untouched. When
+    ``tokenize=False`` Transformers already forces ``return_dict=False``, so this
+    only affects the tokenizing path.
+    """
+    try:
+        from transformers.tokenization_utils_base import PreTrainedTokenizerBase
+    except Exception:  # pragma: no cover - transformers internals moved
+        return False
+
+    original = PreTrainedTokenizerBase.apply_chat_template
+    if getattr(original, "_verl_mlite_return_dict_default_patch", False):
+        return False
+
+    @wraps(original)
+    def patched(self: Any, *args: Any, **kwargs: Any) -> Any:
+        if "return_dict" not in kwargs:
+            kwargs["return_dict"] = False
+        return original(self, *args, **kwargs)
+
+    patched._verl_mlite_return_dict_default_patch = True
+    PreTrainedTokenizerBase.apply_chat_template = patched
+    return True
+
+
+def _trace_runtime_patch(stage: str, result: Any = None) -> None:
+    """Report patch ordering only for an explicitly traced startup."""
+    if os.environ.get("VERL_MLITE_RUNTIME_PATCH_TRACE") != "1":
+        return
+
+    import json
+
+    transformers = sys.modules.get("transformers")
+    module_vars = vars(transformers) if transformers is not None else {}
+    objects = module_vars.get("_objects")
+    missing = object()
+
+    def raw_binding(name: str) -> tuple[Any, str]:
+        if name in module_vars:
+            return module_vars[name], "namespace"
+        if isinstance(objects, dict) and name in objects:
+            return objects[name], "_objects"
+        return missing, "absent"
+
+    alias, alias_source = raw_binding("AutoModelForVision2Seq")
+    replacement, replacement_source = raw_binding(
+        "AutoModelForImageTextToText"
+    )
+    payload = {
+        "alias_is_replacement": (
+            alias is not missing
+            and replacement is not missing
+            and alias is replacement
+        ),
+        "alias_source": alias_source,
+        "changed": result,
+        "event": "runtime_patch",
+        "pid": os.getpid(),
+        "replacement_source": replacement_source,
+        "step": stage,
+        "transformers_file": module_vars.get("__file__"),
+        "transformers_id": id(transformers) if transformers is not None else None,
+        "transformers_loaded": transformers is not None,
+    }
+    sys.stderr.write(
+        "VERL_MLITE_RUNTIME_PATCH_TRACE "
+        f"{json.dumps(payload, sort_keys=True)}\n"
+    )
+    sys.stderr.flush()
+
+
+def _patch_verl_dsv4_mxfp4_check() -> bool:
+    """Make verl's DeepSeek-V4 mxfp4 MoE check factory-aware for vLLM >= 0.24.
+
+    verl #6473 ships ``verl.utils.vllm.vllm_dsv4_fp8_utils._is_mxfp4_fused_moe_module``
+    as ``isinstance(module, FusedMoE) and isinstance(module.quant_method, Mxfp4MoEMethod)``.
+    That assumes ``FusedMoE`` is a class. vLLM 0.25.1 refactored ``FusedMoE`` into
+    a *factory function* (it returns a ``MoERunner``), so the first ``isinstance``
+    raises ``TypeError: isinstance() arg 2 must be a type``. This fires
+    unconditionally during the DS4 fp8 resync weight-prep
+    (``update_weights_from_ipc`` -> ``prepare_quanted_weights_for_loading`` ->
+    ``prepare_deepseek_v4_weights_for_loading`` -> ``_restore_moe_params_for_loading``).
+
+    Replace it with a version that keys off ``module.quant_method`` -- the real
+    mxfp4 discriminator (``Mxfp4MoEMethod`` is a proper class in 0.25.1) -- and
+    only then confirms a fused-MoE module via the real classes. DeepSeek-V4 uses
+    the fp8_ds_mla block layout, not mxfp4, so this returns ``False`` for it and
+    the resync proceeds. verl source is untouched; we override our side only.
+    """
+    if not _vllm_importable():
+        return False
+    try:
+        module = importlib.import_module("verl.utils.vllm.vllm_dsv4_fp8_utils")
+    except Exception:
+        return False
+    existing = getattr(module, "_is_mxfp4_fused_moe_module", None)
+    if getattr(existing, "_verl_mlite_factory_aware", False):
+        return True
+
+    def _is_mxfp4_fused_moe_module(candidate: Any) -> bool:
+        from vllm.model_executor.layers.quantization.mxfp4 import Mxfp4MoEMethod
+
+        quant_method = getattr(candidate, "quant_method", None)
+        is_mxfp4 = isinstance(quant_method, Mxfp4MoEMethod)
+        # Diagnostic (deduped by type pair): emit the real runtime module and
+        # quant_method types so we can confirm the MoE experts are fp8 (not the
+        # mxfp4 4-bit fallback). ``FusedMoE`` is a factory function on vLLM
+        # >= 0.24, so the original ``isinstance(module, FusedMoE)`` type guard is
+        # invalid; the quant_method is the definitive discriminator.
+        seen = _is_mxfp4_fused_moe_module.__dict__.setdefault("_diag_seen", set())
+        diag_key = (type(candidate).__name__, type(quant_method).__name__)
+        if diag_key not in seen:
+            seen.add(diag_key)
+            sys.stderr.write(
+                "VERL_MLITE_MXFP4_DIAG "
+                f"module={type(candidate).__module__}.{type(candidate).__name__} "
+                f"quant_method={type(quant_method).__module__}."
+                f"{type(quant_method).__name__} is_mxfp4={is_mxfp4}\n"
+            )
+            sys.stderr.flush()
+        return is_mxfp4
+
+    _is_mxfp4_fused_moe_module._verl_mlite_factory_aware = True
+    module._is_mxfp4_fused_moe_module = _is_mxfp4_fused_moe_module
+    return True
+
+
+def _restore_dsv4_attn_sink_padding(model: Any) -> int:
+    """Restore the ``-inf`` FlashMLA sink padding erased by dummy loading."""
+    restored = 0
+    for module in model.modules():
+        sink = getattr(module, "attn_sink", None)
+        real_heads = getattr(module, "n_local_heads", None)
+        padded_heads = getattr(module, "padded_heads", None)
+        if sink is None or not isinstance(real_heads, int) or not isinstance(padded_heads, int):
+            continue
+        if sink.ndim != 1 or sink.numel() != padded_heads:
+            continue
+        if not 0 <= real_heads <= padded_heads:
+            continue
+        if real_heads < padded_heads:
+            sink.data[real_heads:].fill_(-float("inf"))
+            restored += 1
+    return restored
+
+
+# ============================================================================
+# DS4 RL weight-resync: dense FP8 linear finalize (SHORT-TERM bridge)
+# ============================================================================
+# WHY THIS EXISTS / THE CLEAN DESIGN WE ARE NOT YET DOING:
+#   A resync should be "cold-load replayed with fresh weights": the only place
+#   that knows kernel-runtime layout (deepgemm ue8m0 requant, wo_a is_bmm 2D->3D,
+#   indexer wk fusion) is vLLM's native load_weights + process_weights_after_loading;
+#   resync should reuse it so rollout weights == cold-load weights bit-for-bit.
+#
+#   Clean 3-layer contract (target end state, NOT implemented here):
+#     1. producer (mlite): emit a neutral self-describing typed weight stream
+#        WeightSpec{dtype: bf16|fp8_e4m3|fp4_e2m1, quant, scale, scale_dtype};
+#        pick a *format* (bf16/block_fp8/block_fp4), never name a consumer.
+#     2. transport: format-agnostic byte-aligned buckets, carries (name,tensor,spec).
+#     3. consumer adapter: optional transcode (bf16->fp8 / fp4->fp8 = "verl does
+#        arbitrary quant") -> ONE uniform reset_weights_for_reload() over every quant
+#        module (MoE/dense/indexer) -> native load -> native process-all (once).
+#
+#   The current path instead rides verl #6473's is_fp8_model refit
+#   (load_quanted_weights -> _restore_moe_params / _prepare_linear_params /
+#   process_deepseek_v4_weights_after_loading), which finalizes only MoE and leaves
+#   dense attn/indexer FP8 linears in checkpoint layout != cold-load (verified:
+#   weight+scale sha differ, indexer.wq_b drift ~4.5%; sparse indexer amplifies into
+#   decode-only rollout divergence). #6473 is itself hacky and we do not want to
+#   extend it.
+#
+# TODO(upstream, remove this bridge once landed):
+#   * verl: file an issue proposing the neutral typed-stream contract + a single
+#     type-agnostic reset (not the per-quant-type _restore_moe/_prepare_linear refit).
+#   * vLLM: file a PR adding reset_weights_for_reload() (or make
+#     process_weights_after_loading idempotent/reversible) so RL refit can cleanly
+#     reuse the cold-load path.
+#
+# SHORT-TERM (below): recreate dense block-FP8 linear params to checkpoint layout
+# before the resync load (create_weights, uniform, incl wo_a is_bmm) so the single
+# post-load process matches cold-load. This is a bridge, scoped to DS4, additive.
+# ============================================================================
+def _recreate_dense_fp8_linear_params(model) -> int:
+    """Reset every dense block-FP8 LinearBase to fresh checkpoint-layout params so
+    the single post-load process_weights_after_loading matches cold load bit-for-bit
+    (see module block above). Returns the count recreated."""
+    import torch
+    try:
+        from vllm.model_executor.layers.linear import LinearBase
+        from vllm.model_executor.layers.quantization.fp8 import Fp8LinearMethod
+    except Exception:
+        return 0
+    recreated = 0
+    for _name, layer in model.named_modules():
+        if not (isinstance(layer, LinearBase)
+                and isinstance(getattr(layer, "quant_method", None), Fp8LinearMethod)):
+            continue
+        qm = layer.quant_method
+        if not getattr(qm, "block_quant", False):
+            continue
+        old_w = getattr(layer, "weight", None)
+        wl = getattr(old_w, "weight_loader", None) if old_w is not None else None
+        if wl is None:
+            continue
+        try:
+            qm.create_weights(
+                layer,
+                input_size_per_partition=int(layer.input_size_per_partition),
+                output_partition_sizes=list(layer.output_partition_sizes),
+                input_size=int(layer.input_size),
+                output_size=int(layer.output_size),
+                params_dtype=getattr(layer, "orig_dtype", torch.bfloat16),
+                weight_loader=wl,
+            )
+            recreated += 1
+        except Exception as _re:
+            sys.stderr.write(f"VERL_MLITE_DENSE_RECREATE_SKIP {_name}: {_re!r}\n")
+            sys.stderr.flush()
+            raise RuntimeError(
+                f"failed to recreate dense FP8 parameters for {_name}"
+            ) from _re
+    return recreated
+
+
+def _patch_verl_dsv4_prepare_recreates_dense() -> bool:
+    """SHORT-TERM bridge: wrap prepare_quanted_weights_for_loading so DS4 dense
+    block-FP8 linears are recreated to checkpoint layout before every resync load,
+    pairing with the post-load dense process in _patch_verl_dsv4_fp8_process_weights.
+    See the module block above for the clean design + upstream TODOs."""
+    if not _vllm_importable():
+        return False
+    try:
+        mod = importlib.import_module("verl.utils.vllm.vllm_fp8_utils")
+    except Exception:
+        return False
+    original = getattr(mod, "prepare_quanted_weights_for_loading", None)
+    if original is None or getattr(original, "_verl_mlite_dense_recreate", False):
+        return True
+
+    @wraps(original)
+    def prepare_quanted_weights_for_loading(model_runner, *args, **kwargs):
+        try:
+            from verl.utils.vllm.vllm_dsv4_fp8_utils import is_deepseek_v4_model
+            from vllm.config import set_current_vllm_config
+
+            model = model_runner.model
+            if is_deepseek_v4_model(model):
+                # Fp8LinearMethod.create_weights consults vLLM's process-global
+                # config. Online reload runs outside the cold model-loader
+                # context, so restore that context while recreating parameters.
+                with set_current_vllm_config(model_runner.vllm_config):
+                    n = _recreate_dense_fp8_linear_params(model)
+                if n:
+                    sys.stderr.write(
+                        f"VERL_MLITE_DENSE_RECREATE recreated {n} dense FP8 linear "
+                        "param set(s) to checkpoint layout before resync load\n")
+                    sys.stderr.flush()
+        except Exception as exc:
+            sys.stderr.write(f"VERL_MLITE_DENSE_RECREATE error: {exc!r}\n")
+            sys.stderr.flush()
+            raise
+        # Ordering is part of the online-reload contract.  verl's DS4 prepare
+        # step wraps the *current* parameters and attaches loaders which accept
+        # already-local TP shards from IPC.  Recreating after that step replaces
+        # those wrapped parameters and silently restores the cold-load loader,
+        # which slices the local shard by TP a second time.  Reset first, then
+        # let verl attach its online loaders to the fresh checkpoint layout.
+        return original(model_runner, *args, **kwargs)
+
+    prepare_quanted_weights_for_loading._verl_mlite_dense_recreate = True
+    mod.prepare_quanted_weights_for_loading = prepare_quanted_weights_for_loading
+    return True
+
+
+def _patch_verl_dsv4_fp8_prepare_state() -> bool:
+    """Keep pure-FP8 DS4 reload preparation outside the per-bucket loop.
+
+    VERL uses the truthiness of ``prepare_quanted_weights_for_loading`` to tell
+    ``_update_weights`` that preparation already ran once before IPC receive.
+    The DS4 helper returns only whether MXFP4/MegaMoE parameters were restored,
+    so a pure-FP8 model incorrectly returns ``False``. Each bucket then repeats
+    prepare/process and recreates dense parameters underneath earlier loads.
+    """
+    if not _vllm_importable():
+        return False
+    try:
+        fp8_utils = importlib.import_module("verl.utils.vllm.vllm_fp8_utils")
+    except Exception:
+        return False
+    original = getattr(fp8_utils, "prepare_quanted_weights_for_loading", None)
+    if original is None or getattr(original, "_verl_mlite_ds4_fp8_state", False):
+        return original is not None
+
+    @wraps(original)
+    def prepare_quanted_weights_for_loading(model_runner, *args, **kwargs):
+        state = original(model_runner, *args, **kwargs)
+        if state:
+            return state
+
+        model = model_runner.model
+        from verl.utils.vllm.vllm_dsv4_fp8_utils import is_deepseek_v4_model
+        from vllm.model_executor.layers.fused_moe.routed_experts import RoutedExperts
+        from vllm.model_executor.layers.quantization.fp8 import Fp8MoEMethod
+
+        pure_fp8 = is_deepseek_v4_model(model) and any(
+            isinstance(module, RoutedExperts)
+            and isinstance(getattr(module, "quant_method", None), Fp8MoEMethod)
+            for module in model.modules()
+        )
+        if pure_fp8:
+            sys.stderr.write(
+                "VERL_MLITE_FP8_PREPARE_STATE promoted DS4 pure-FP8 reload "
+                "state to one-shot lifecycle\n"
+            )
+            sys.stderr.flush()
+            return True
+        return state
+
+    prepare_quanted_weights_for_loading._verl_mlite_ds4_fp8_state = True
+    fp8_utils.prepare_quanted_weights_for_loading = prepare_quanted_weights_for_loading
+    return True
+
+
+_DSV4_LAYERWISE_RELOAD_STATE = object()
+
+
+def _patch_verl_dsv4_native_layerwise_reload() -> bool:
+    """Use vLLM's native layerwise reload lifecycle for DS4 FP8 resync.
+
+    vLLM records checkpoint-layout metadata during model construction.  Its
+    layerwise reload API restores that layout, buffers complete logical layers,
+    runs each quant method's native finalizer exactly once, then copies results
+    back into the original kernel storage (preserving cudagraph references).
+    This is the supported reset/load/process contract; it replaces verl's DS4
+    boolean prepare state and our former dense recreation bridge.
+    """
+    if not _vllm_importable():
+        return False
+    try:
+        fp8_utils = importlib.import_module("verl.utils.vllm.vllm_fp8_utils")
+        dsv4_utils = importlib.import_module("verl.utils.vllm.vllm_dsv4_fp8_utils")
+        rollout_utils = importlib.import_module(
+            "verl.workers.rollout.vllm_rollout.utils"
+        )
+    except Exception:
+        return False
+    original_prepare = getattr(fp8_utils, "prepare_quanted_weights_for_loading", None)
+    original_process = getattr(fp8_utils, "process_quanted_weights_after_loading", None)
+    original_load = getattr(fp8_utils, "load_quanted_weights", None)
+    if original_prepare is None or original_process is None or original_load is None:
+        return False
+    if getattr(original_prepare, "_verl_mlite_ds4_layerwise", False):
+        return True
+
+    @wraps(original_prepare)
+    def prepare_quanted_weights_for_loading(model_runner, *args, **kwargs):
+        model = model_runner.model
+        if not dsv4_utils.is_deepseek_v4_model(model):
+            return original_prepare(model_runner, *args, **kwargs)
+        from vllm.config import set_current_vllm_config
+        from vllm.model_executor.model_loader.reload import initialize_layerwise_reload
+        from vllm.model_executor.model_loader.reload.meta import SKIP_TENSORS
+
+        # These DS4 buffers already live in kernel/runtime layout and are
+        # updated directly by VERL's buffer path (or restored below).  Keeping
+        # them out of the meta restore prevents ``copy_`` into a meta buffer
+        # from silently discarding router state between IPC buckets.
+        SKIP_TENSORS.update(
+            {"tid2eid", "expert_bias", "e_score_correction_bias", "attn_sink"}
+        )
+        with set_current_vllm_config(model_runner.vllm_config):
+            initialize_layerwise_reload(model)
+        model._verl_mlite_ds4_layerwise_reload_active = True
+        sys.stderr.write(
+            "VERL_MLITE_DSV4_LAYERWISE_RELOAD initialized native vLLM reload\n"
+        )
+        sys.stderr.flush()
+        return _DSV4_LAYERWISE_RELOAD_STATE
+
+    @wraps(original_process)
+    def process_quanted_weights_after_loading(model_runner, reload_state):
+        if reload_state is not _DSV4_LAYERWISE_RELOAD_STATE:
+            return original_process(model_runner, reload_state)
+        from vllm.config import set_current_vllm_config
+        from vllm.model_executor.model_loader.reload import finalize_layerwise_processing
+
+        try:
+            with set_current_vllm_config(model_runner.vllm_config):
+                finalize_layerwise_processing(
+                    model_runner.model,
+                    model_runner.vllm_config.model_config,
+                )
+        finally:
+            model_runner.model._verl_mlite_ds4_layerwise_reload_active = False
+        restored_sinks = _restore_dsv4_attn_sink_padding(model_runner.model)
+        # ``load_quanted_weights`` clones IPC bucket views because vLLM's
+        # layerwise loader may retain them until a complete logical layer is
+        # available.  ``finalize_layerwise_processing`` drops those references,
+        # but PyTorch's caching allocator otherwise keeps the temporary device
+        # storage mapped.  In colocated sleep mode that storage competes with
+        # vLLM's cuMem weight mappings on the next wake-up and can OOM even
+        # though no live tensor owns it (observed on every rank of a 128-GPU
+        # DS4 run).  Release the now-dead staging blocks at the lifecycle
+        # boundary; doing this per IPC bucket would be both too early and slow.
+        gc.collect()
+        import torch
+
+        torch.cuda.empty_cache()
+        records = getattr(model_runner.model, "_verl_mlite_weight_fingerprint", None)
+        if records is not None:
+            from megatron.lite.primitive.ckpt.weight_sync_fingerprint import (
+                report_stream_fingerprint,
+            )
+
+            report_stream_fingerprint("receiver", 0, records)
+            del model_runner.model._verl_mlite_weight_fingerprint
+        sys.stderr.write(
+            "VERL_MLITE_DSV4_LAYERWISE_RELOAD finalized native vLLM reload "
+            f"attention_sinks_restored={restored_sinks}\n"
+        )
+        sys.stderr.flush()
+
+    @wraps(original_load)
+    def load_quanted_weights(weights, model_runner, *args, **kwargs):
+        model = model_runner.model
+        if getattr(model, "_verl_mlite_ds4_layerwise_reload_active", False):
+            weights = list(weights)
+            from megatron.lite.primitive.ckpt.weight_sync_fingerprint import (
+                tensor_fingerprint_record,
+                weight_sync_fingerprint_enabled,
+            )
+
+            if weight_sync_fingerprint_enabled():
+                records = getattr(model, "_verl_mlite_weight_fingerprint", None)
+                if records is None:
+                    records = []
+                    model._verl_mlite_weight_fingerprint = records
+                records.extend(
+                    tensor_fingerprint_record(name, tensor) for name, tensor in weights
+                )
+            # Layerwise reload may retain loader arguments across multiple IPC
+            # callbacks.  The receiver reuses its communication buffer after
+            # each callback, so persist every tensor until its logical layer is
+            # finalized instead of retaining a view into overwritten storage.
+            weights = [(name, tensor.clone()) for name, tensor in weights]
+        return original_load(weights, model_runner, *args, **kwargs)
+
+    prepare_quanted_weights_for_loading._verl_mlite_ds4_layerwise = True
+    process_quanted_weights_after_loading._verl_mlite_ds4_layerwise = True
+    load_quanted_weights._verl_mlite_ds4_layerwise = True
+    fp8_utils.prepare_quanted_weights_for_loading = prepare_quanted_weights_for_loading
+    fp8_utils.process_quanted_weights_after_loading = process_quanted_weights_after_loading
+    fp8_utils.load_quanted_weights = load_quanted_weights
+    # ``utils.py`` imports this function at module import time, so replacing the
+    # defining module alone would leave the live rollout callback on the stale
+    # binding and defeat cross-bucket tensor persistence.
+    rollout_utils.load_quanted_weights = load_quanted_weights
+    return True
+
+
+def _patch_verl_dsv4_fp8_process_weights() -> bool:
+    """Restore the proven pre-dense-bridge DS4 post-reload behavior.
+
+    Pure-FP8 routed experts still need their native MoE finalize once after the
+    bucket stream, and attention sink padding must be restored.  Dense FP8
+    linears are intentionally *not* reset or re-finalized here: vLLM preserves
+    their RL reload loaders and an extra dense finalize is not idempotent.
+    """
+    if not _vllm_importable():
+        return False
+    try:
+        utils = importlib.import_module(
+            "verl.workers.rollout.vllm_rollout.utils"
+        )
+    except Exception:
+        return False
+    ext_cls = getattr(utils, "vLLMColocateWorkerExtension", None)
+    original = getattr(ext_cls, "update_weights_from_ipc", None)
+    if original is None or getattr(original, "_verl_mlite_fp8_process", False):
+        return True
+
+    @wraps(original)
+    def update_weights_from_ipc(self, *args, **kwargs):
+        result = original(self, *args, **kwargs)
+        model = self.model_runner.model
+        from verl.utils.vllm.vllm_dsv4_fp8_utils import is_deepseek_v4_model
+
+        if not is_deepseek_v4_model(model):
+            return result
+        restored_sinks = _restore_dsv4_attn_sink_padding(model)
+        if restored_sinks:
+            sys.stderr.write(
+                "VERL_MLITE_ATTN_SINK_PADDING "
+                f"restored -inf padding on {restored_sinks} DS4 attention module(s)\n"
+            )
+            sys.stderr.flush()
+        from vllm.model_executor.layers.fused_moe.routed_experts import RoutedExperts
+        from vllm.model_executor.layers.quantization.fp8 import Fp8MoEMethod
+
+        processed = 0
+        for module in model.modules():
+            if isinstance(module, RoutedExperts) and isinstance(
+                getattr(module, "quant_method", None), Fp8MoEMethod
+            ):
+                module.quant_method.process_weights_after_loading(module)
+                processed += 1
+        if processed:
+            sys.stderr.write(
+                "VERL_MLITE_FP8_PROCESS "
+                f"ran process_weights_after_loading on {processed} "
+                "DS4 RoutedExperts+Fp8MoEMethod module(s) after resync\n"
+            )
+            sys.stderr.flush()
+        return result
+
+    update_weights_from_ipc._verl_mlite_fp8_process = True
+    ext_cls.update_weights_from_ipc = update_weights_from_ipc
+    return True
+
+
+class _SyncBucketProducer:
+    """Pack one sender bucket at a time into a caller-owned staging slot."""
+
+    def __init__(self, weights, bucket_size: int):
+        from verl_mlite.rollout.layer_cluster import resync_layer_cluster_key
+
+        self._weights = iter(weights)
+        self._bucket_size = bucket_size
+        self._pending = None
+        self._exhausted = False
+        self._layer_cluster_key = resync_layer_cluster_key
+
+    def next_bucket(self, staging):
+        import torch
+
+        if staging.device.type == "cuda":
+            torch.cuda.set_device(staging.device)
+        if self._exhausted:
+            return "eof", None, None, 0, None, True
+
+        offset = 0
+        bucket_meta = {}
+        bucket_layer_key = None
+        while True:
+            try:
+                if self._pending is None:
+                    name, weight = next(self._weights)
+                else:
+                    name, weight = self._pending
+                    self._pending = None
+            except StopIteration:
+                self._exhausted = True
+                if not bucket_meta:
+                    return "eof", None, None, 0, None, True
+                break
+
+            layer_key = self._layer_cluster_key(name)
+            if (
+                bucket_meta
+                and bucket_layer_key is not None
+                and layer_key != bucket_layer_key
+            ):
+                self._pending = (name, weight)
+                break
+
+            # Fix-A (resync IPC byte-alignment): pad every tensor's start
+            # offset up to an 8-byte boundary. The receiver reconstructs each
+            # tensor as ``buffer[offset:offset+size].view(dtype)``, and
+            # ``Tensor.view(dtype)`` requires the byte ``storage_offset`` to be
+            # divisible by ``dtype.itemsize``. A pure BF16/FP32 stream keeps
+            # every offset even, so it never trips (why the proxy stays green).
+            # But DS4 real-weight resync ships block-FP8 tensors (itemsize 1);
+            # an odd-numel FP8 tensor leaves ``offset`` odd and the *next*
+            # BF16/FP32 tensor in the same bucket crashes on the view. Aligning
+            # to 8 bytes covers every dtype we transport (fp8/bf16/fp16/fp32)
+            # and is byte-lossless — the receiver reads the padded offset we
+            # record in ``bucket_meta`` unchanged. See
+            # tests/unit/verl/test_resync_bucket_byte_alignment.py.
+            offset = (offset + 7) & ~7
+            if offset + weight.nbytes > self._bucket_size and bucket_meta:
+                self._pending = (name, weight)
+                break
+            if weight.nbytes > self._bucket_size:
+                return "direct", name, weight, 0, None, False
+
+            if not bucket_meta:
+                bucket_layer_key = layer_key
+            bucket_meta[name] = {
+                "name": name,
+                "shape": weight.shape,
+                "dtype": weight.dtype,
+                "offset": offset,
+                "handle": None,
+            }
+            staging[offset : offset + weight.nbytes].copy_(
+                weight.view(-1).view(torch.uint8), non_blocking=True
+            )
+            offset += weight.nbytes
+            # Padding can push a full bucket a few bytes past exact equality, so
+            # break on ``>=`` rather than ``==``.
+            if offset >= self._bucket_size:
+                break
+
+        ready = None
+        if staging.device.type == "cuda":
+            ready = torch.cuda.Event()
+            ready.record(torch.cuda.current_stream(staging.device))
+        return "bucket", bucket_meta, None, offset, ready, self._exhausted
+
+
+def _install_bucketed_sender_prefetch(sender_cls: type) -> bool:
+    """Overlap synchronous weight production with the receiver's bucket ACK."""
+    if getattr(sender_cls, "_mlite_weight_prefetch_patch", False):
+        return False
+
+    original_async_send_weights = sender_cls.async_send_weights
+
+    async def prefetched_async_send_weights(self, weights):
+        import torch
+
+        if not isinstance(weights, Iterable) or hasattr(weights, "__aiter__") or self.use_shm:
+            return await original_async_send_weights(self, weights)
+
+        executor = None
+        stop = threading.Event()
+        free_slots = None
+        ready_results = None
+        held_slot = None
+        try:
+            self._init_socket()
+            self._init_buffer()
+            if self.buffer.device.type != "cuda" and not getattr(
+                self, "_mlite_prefetch_allow_cpu", False
+            ):
+                raise RuntimeError("MLite sender prefetch requires a CUDA IPC buffer")
+
+            staging_slots = [torch.empty_like(self.buffer) for _ in range(2)]
+            producer = _SyncBucketProducer(weights, self.bucket_size)
+            free_slots = queue.Queue(maxsize=2)
+            ready_results = queue.Queue(maxsize=2)
+            for slot_index in range(2):
+                free_slots.put_nowait(slot_index)
+            executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="mlite-weight-prefetch")
+
+            def put_ready(result):
+                while not stop.is_set():
+                    try:
+                        ready_results.put(result, timeout=0.05)
+                        return True
+                    except queue.Full:
+                        continue
+                return False
+
+            def produce():
+                slot_index = None
+                try:
+                    while not stop.is_set():
+                        try:
+                            slot_index = free_slots.get(timeout=0.05)
+                        except queue.Empty:
+                            continue
+                        result = producer.next_bucket(staging_slots[slot_index])
+                        if not put_ready((*result, slot_index)):
+                            return
+                        slot_index = None
+                        kind, *_, is_last = result
+                        if kind == "eof" or is_last:
+                            return
+                except BaseException as exc:
+                    put_ready(("error", exc, None, 0, None, True, slot_index))
+
+            context = copy_context()
+            worker_future = executor.submit(context.run, produce)
+            while True:
+                try:
+                    result = ready_results.get(timeout=0.1)
+                except queue.Empty:
+                    if worker_future.done():
+                        worker_future.result()
+                        raise RuntimeError("MLite weight prefetch stopped without a terminal result")
+                    continue
+
+                kind, metadata_or_name, direct_weight, used_bytes, ready, is_last, held_slot = (
+                    result
+                )
+                if kind == "error":
+                    raise metadata_or_name
+                if kind == "eof":
+                    free_slots.put_nowait(held_slot)
+                    held_slot = None
+                    self.socket.send_pyobj({"bucket_meta": {}, "is_last": True})
+                    self.socket.recv()
+                    break
+                if kind == "direct":
+                    free_slots.put_nowait(held_slot)
+                    held_slot = None
+                    self._direct_send_large_weight(metadata_or_name, direct_weight)
+                    continue
+
+                if ready is not None:
+                    ready.synchronize()
+                staging = staging_slots[held_slot]
+                self.buffer[:used_bytes].copy_(staging[:used_bytes], non_blocking=True)
+                if self.buffer.device.type == "cuda":
+                    torch.cuda.synchronize(self.buffer.device)
+                free_slots.put_nowait(held_slot)
+                held_slot = None
+
+                self.socket.send_pyobj(
+                    {"bucket_meta": metadata_or_name, "is_last": is_last}
+                )
+                self.socket.recv()
+                if is_last:
+                    break
+        finally:
+            stop.set()
+            if held_slot is not None and free_slots is not None:
+                try:
+                    free_slots.put_nowait(held_slot)
+                except queue.Full:
+                    pass
+            if executor is not None:
+                executor.shutdown(wait=True, cancel_futures=True)
+            self._cleanup()
+
+    sender_cls.async_send_weights = prefetched_async_send_weights
+    sender_cls._mlite_weight_prefetch_patch = True
+    return True
+
+
+def _weight_sync_probe_enabled() -> bool:
+    return os.getenv("MLITE_WEIGHT_SYNC_PROBE", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _weight_sync_fingerprint_enabled() -> bool:
+    return os.getenv("MLITE_WEIGHT_SYNC_FINGERPRINT", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _instrument_bucketed_weight_sender(sender_cls: type) -> bool:
+    """Patch veRL's sender only while the opt-in sync probe is enabled."""
+    if getattr(sender_cls, "_mlite_weight_sync_probe_patch", False):
+        return False
+
+    import torch
+    import torch.distributed as dist
+    from torch.utils._python_dispatch import TorchDispatchMode
+
+    from megatron.lite.primitive.ckpt.weight_sync_probe import (
+        get_weight_sync_probe,
+        weight_sync_probe_session,
+    )
+
+    probe = get_weight_sync_probe()
+    original_init_socket = sender_cls._init_socket
+    original_async_send_weights = sender_cls.async_send_weights
+
+    class _ProfiledSocket:
+        def __init__(self, socket):
+            self._socket = socket
+
+        def __getattr__(self, name):
+            return getattr(self._socket, name)
+
+        def send_pyobj(self, *args, **kwargs):
+            with probe.measure("handshake"):
+                return self._socket.send_pyobj(*args, **kwargs)
+
+        def recv(self, *args, **kwargs):
+            with probe.measure("handshake"):
+                return self._socket.recv(*args, **kwargs)
+
+    class _H2DCopyMode(TorchDispatchMode):
+        def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+            kwargs = kwargs or {}
+            if func is torch.ops.aten.copy_.default and len(args) >= 2:
+                dst, src = args[:2]
+                if (
+                    isinstance(dst, torch.Tensor)
+                    and isinstance(src, torch.Tensor)
+                    and dst.device.type == "cuda"
+                    and src.device.type == "cpu"
+                ):
+                    with probe.measure("h2d", nbytes=src.nbytes, device=dst.device):
+                        return func(*args, **kwargs)
+            return func(*args, **kwargs)
+
+    def profiled_init_socket(self, *args, **kwargs):
+        result = original_init_socket(self, *args, **kwargs)
+        self.socket = _ProfiledSocket(self.socket)
+        return result
+
+    async def profiled_async_send_weights(self, weights):
+        backend = os.getenv("MLITE_WEIGHT_SYNC_PROBE_BACKEND", "unknown")
+        from megatron.lite.primitive.ckpt.weight_sync_fingerprint import (
+            report_stream_fingerprint,
+            tensor_fingerprint_record,
+            weight_sync_fingerprint_enabled,
+        )
+
+        fingerprint_records = []
+
+        def fingerprinted_weights():
+            for name, tensor in weights:
+                if weight_sync_fingerprint_enabled():
+                    fingerprint_records.append(tensor_fingerprint_record(name, tensor))
+                yield name, tensor
+
+        original_all_gather_into_tensor = dist.all_gather_into_tensor
+
+        def profiled_all_gather_into_tensor(output, tensor, *args, **kwargs):
+            with probe.measure("mbridge_gather", nbytes=output.nbytes, device=tensor.device):
+                return original_all_gather_into_tensor(output, tensor, *args, **kwargs)
+
+        with weight_sync_probe_session(backend), _H2DCopyMode():
+            dist.all_gather_into_tensor = profiled_all_gather_into_tensor
+            try:
+                result = await original_async_send_weights(self, fingerprinted_weights())
+                if weight_sync_fingerprint_enabled():
+                    rank = dist.get_rank() if dist.is_initialized() else 0
+                    report_stream_fingerprint("sender", rank, fingerprint_records)
+                return result
+            finally:
+                dist.all_gather_into_tensor = original_all_gather_into_tensor
+
+    sender_cls._init_socket = profiled_init_socket
+    sender_cls.async_send_weights = profiled_async_send_weights
+    sender_cls._mlite_weight_sync_probe_patch = True
+    return True
+
+
+class _SenderPatchLoader(importlib.abc.Loader):
+    def __init__(self, loader: importlib.abc.Loader):
+        self._loader = loader
+
+    def create_module(self, spec):
+        create_module = getattr(self._loader, "create_module", None)
+        return create_module(spec) if create_module is not None else None
+
+    def exec_module(self, module) -> None:
+        self._loader.exec_module(module)
+        _install_bucketed_sender_prefetch(module.BucketedWeightSender)
+        if _weight_sync_probe_enabled() or _weight_sync_fingerprint_enabled():
+            _instrument_bucketed_weight_sender(module.BucketedWeightSender)
+
+
+class _SenderPatchFinder(importlib.abc.MetaPathFinder):
+    _mlite_weight_sync_probe_finder = True
+
+    def __init__(self):
+        self._mlite_weight_sync_probe_requested = False
+
+    def find_spec(self, fullname, path, target=None):
+        if fullname != _BUCKETED_SENDER_MODULE:
+            return None
+        spec = importlib.machinery.PathFinder.find_spec(fullname, path, target)
+        if spec is not None and spec.loader is not None:
+            spec.loader = _SenderPatchLoader(spec.loader)
+        return spec
+
+
+def _patch_bucketed_weight_transfer() -> bool:
+    module = sys.modules.get(_BUCKETED_SENDER_MODULE)
+    if module is not None:
+        return _install_bucketed_sender_prefetch(module.BucketedWeightSender)
+    if any(getattr(finder, "_mlite_weight_sync_probe_finder", False) for finder in sys.meta_path):
+        return False
+    sys.meta_path.insert(0, _SenderPatchFinder())
+    return True
+
+
+def _patch_bucketed_weight_sender() -> bool:
+    """Install production prefetch plus optional probe instrumentation."""
+    changed = _patch_bucketed_weight_transfer()
+    if not (_weight_sync_probe_enabled() or _weight_sync_fingerprint_enabled()):
+        return changed
+
+    module = sys.modules.get(_BUCKETED_SENDER_MODULE)
+    if module is not None:
+        changed = _instrument_bucketed_weight_sender(module.BucketedWeightSender) or changed
+    else:
+        finder = next(
+            finder
+            for finder in sys.meta_path
+            if getattr(finder, "_mlite_weight_sync_probe_finder", False)
+        )
+        if not finder._mlite_weight_sync_probe_requested:
+            finder._mlite_weight_sync_probe_requested = True
+            changed = True
+    return changed
+
+
 def apply_runtime_patches() -> None:
-    _patch_transformers_rope_ignore_keys()
+    _trace_runtime_patch("00.begin")
+    result = _patch_transformers_vision2seq_alias()
+    _trace_runtime_patch("01.transformers_alias", result)
+    result = _register_opaque_hf_config()
+    _trace_runtime_patch("02.opaque_hf_config", result)
+    result = _install_vllm_thin_finder()
+    _trace_runtime_patch("03.vllm_thin_finder", result)
+    result = _install_vllm_triton_kernels_alias()
+    _trace_runtime_patch("04.vllm_triton_kernels_alias", result)
+    result = _patch_verl_vllm_device_uuid()
+    _trace_runtime_patch("05.verl_vllm_device_uuid", result)
+    # Importing VERL's vLLM utilities can rebuild Transformers' lazy top-level
+    # module, which drops compatibility attributes installed on the old module.
+    result = _patch_transformers_vision2seq_alias()
+    _trace_runtime_patch("06.transformers_alias_after_uuid", result)
+    result = _patch_transformers_rope_ignore_keys()
+    _trace_runtime_patch("07.transformers_rope_ignore_keys", result)
+    result = _patch_transformers_apply_chat_template_return_dict()
+    _trace_runtime_patch("07b.transformers_apply_chat_template_return_dict", result)
+    result = _patch_bucketed_weight_sender()
+    _trace_runtime_patch("08.bucketed_weight_sender", result)
+    result = _patch_verl_dsv4_mxfp4_check()
+    _trace_runtime_patch("08b.verl_dsv4_mxfp4_check", result)
+    result = _patch_verl_dsv4_native_layerwise_reload()
+    _trace_runtime_patch("08c.verl_dsv4_native_layerwise_reload", result)
+    result = _patch_vllm_server_profile()
+    _trace_runtime_patch("09.vllm_server_profile", result)
+    _trace_runtime_patch("10.end")
 
 
 def _load_verl_file(relative_path: str, module_name: str):

--- a/experimental/lite/examples/verl/verl_mlite/config/engine/mlite.yaml
+++ b/experimental/lite/examples/verl/verl_mlite/config/engine/mlite.yaml
@@ -8,6 +8,9 @@ grad_offload: false
 forward_only: false
 dtype: bfloat16
 export_dtype: bfloat16
+resync_format: null
+resync_config: {}
+router_replay_mode: disabled
 load_hf_weights: true
 
 model_name: auto

--- a/experimental/lite/examples/verl/verl_mlite/engine/config.py
+++ b/experimental/lite/examples/verl/verl_mlite/engine/config.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import importlib
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -30,6 +31,9 @@ class MegatronLiteEngineConfig(EngineConfig):
     router_aux_loss_coef: float | None = None
     cross_entropy_fusion: bool | None = None
     export_dtype: str | None = "bfloat16"
+    resync_format: str | None = None
+    resync_config: dict[str, Any] = field(default_factory=dict)
+    router_replay_mode: str = "disabled"
     load_hf_weights: bool = True
     impl_cfg: dict[str, Any] = field(default_factory=dict)
 
@@ -41,3 +45,21 @@ class MegatronLiteEngineConfig(EngineConfig):
             )
         if self.custom_backend_module:
             importlib.import_module(self.custom_backend_module)
+        if self.resync_format is not None:
+            from megatron.lite.runtime.contracts.weights import ResyncFormat
+
+            object.__setattr__(
+                self,
+                "resync_format",
+                ResyncFormat.parse(self.resync_format).value,
+            )
+        if not isinstance(self.resync_config, Mapping):
+            raise TypeError("resync_config must be a mapping")
+        object.__setattr__(self, "resync_config", dict(self.resync_config))
+        if self.resync_config and self.resync_format is None:
+            raise ValueError("resync_config requires resync_format")
+        if self.router_replay_mode not in ("disabled", "R3"):
+            raise ValueError(
+                "MegatronLiteEngine supports router_replay_mode='disabled' or 'R3', "
+                f"got {self.router_replay_mode!r}"
+            )

--- a/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
+++ b/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
@@ -438,7 +438,8 @@ class MegatronLiteEngine(BaseEngine):
         save_contents = self.checkpoint_config.get("save_contents", None)
         save_model = save_contents is None or "model" in save_contents
         save_optimizer = save_contents is None or "optimizer" in save_contents
-        if not save_model and not save_optimizer:
+        save_hf_model = save_contents is not None and "hf_model" in save_contents
+        if not save_model and not save_optimizer and not save_hf_model:
             if self._rank == 0:
                 print(
                     f"Skipping Megatron Lite checkpoint save at step {global_step}: save_contents={save_contents}"
@@ -454,28 +455,72 @@ class MegatronLiteEngine(BaseEngine):
             self.to(device="cuda", model=True, optimizer=False, grad=False)
             torch.cuda.synchronize()
         try:
-            save_training_checkpoint(
-                self.module,
-                self.handle._optimizer,
-                global_step,
-                local_path,
-                self.handle._config.parallel,
-                self.handle._parallel_state,
-                get_placements=placement_fn,
-                is_expert=expert_classifier,
-                save_model=save_model,
-                save_optimizer=save_optimizer,
-            )
+            if save_model or save_optimizer:
+                save_training_checkpoint(
+                    self.module,
+                    self.handle._optimizer,
+                    global_step,
+                    local_path,
+                    self.handle._config.parallel,
+                    self.handle._parallel_state,
+                    get_placements=placement_fn,
+                    is_expert=expert_classifier,
+                    save_model=save_model,
+                    save_optimizer=save_optimizer,
+                )
             if self.handle._lr_scheduler is not None and self._rank == 0:
                 torch.save(
                     self.handle._lr_scheduler.state_dict(),
                     os.path.join(local_path, _LR_SCHEDULER_STATE),
                 )
+            if save_hf_model:
+                self._save_hf_checkpoint(local_path)
             if dist.is_initialized():
                 dist.barrier()
         finally:
             if reload_params_for_save:
                 self.to(device="cpu", model=True, optimizer=False, grad=False)
+
+    def _save_hf_checkpoint(self, local_path: str) -> None:
+        proto = self.handle._extras.get("protocol")
+        if proto is None or not hasattr(proto, "save_hf_weights"):
+            raise RuntimeError(
+                "hf_model save requested, but the model protocol does not expose "
+                "save_hf_weights; refusing to report a successful checkpoint save."
+            )
+
+        model_chunks = self.handle._extras.get("model_chunks", [self.handle._model])
+        model_cfg = self.handle._extras.get("model_cfg")
+        if model_cfg is None:
+            raise RuntimeError(
+                "hf_model save requested, but the runtime handle has no model_cfg; "
+                "the model-specific exporter cannot be called safely."
+            )
+        ps = self.handle._parallel_state
+        hf_local_path = os.path.join(local_path, "huggingface")
+
+        if self._rank == 0:
+            os.makedirs(hf_local_path, exist_ok=True)
+        if dist.is_initialized():
+            dist.barrier()
+
+        proto.save_hf_weights(model_chunks, hf_local_path, model_cfg, ps)
+
+        if self._rank == 0:
+            hf_config = getattr(self.model_config, "hf_config", None)
+            if hf_config is not None:
+                auto_map = getattr(hf_config, "auto_map", None)
+                if isinstance(auto_map, dict) and None in auto_map:
+                    hf_config.auto_map = {k: v for k, v in auto_map.items() if k is not None}
+                hf_config.save_pretrained(hf_local_path)
+            tokenizer = getattr(self.model_config, "tokenizer", None)
+            if tokenizer is not None:
+                tokenizer.save_pretrained(hf_local_path)
+            processor = getattr(self.model_config, "processor", None)
+            if processor is not None:
+                processor.save_pretrained(hf_local_path)
+        if dist.is_initialized():
+            dist.barrier()
 
     def load_checkpoint(
         self,

--- a/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
+++ b/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
@@ -25,7 +25,7 @@ from verl.utils import tensordict_utils as tu
 from verl.utils.device import get_device_id, get_device_name
 from verl.utils.memory_utils import aggressive_empty_cache
 from verl.workers.config import HFModelConfig, OptimizerConfig
-from verl_mlite.compat import load_verl_engine_api
+from verl_mlite.compat import _patch_bucketed_weight_sender, load_verl_engine_api
 
 try:
     # Recent VERL wraps per-step metric values in a Metric aggregator that
@@ -35,6 +35,8 @@ except Exception:  # pragma: no cover - older VERL without Metric
     _VerlMetric = None
 
 from .config import MegatronLiteEngineConfig
+
+_patch_bucketed_weight_sender()
 
 BaseEngine, BaseEngineCtx, EngineRegistry, postprocess_batch_func, prepare_micro_batches = (
     load_verl_engine_api()
@@ -379,7 +381,11 @@ class MegatronLiteEngine(BaseEngine):
             for key in ("limit", "include_mtp_only", "include_local_prefixes")
             if key in kwargs
         }
-        if self.engine_config.model_name == "qwen3_5":
+        if self.engine_config.resync_format is not None:
+            export_kwargs["target"] = self.engine_config.resync_format
+            if self.engine_config.resync_config:
+                export_kwargs["resync_config"] = dict(self.engine_config.resync_config)
+        elif self.engine_config.model_name == "qwen3_5":
             export_kwargs["target"] = "vllm"
         if self.engine_config.export_dtype:
             export_kwargs["export_dtype"] = self.engine_config.export_dtype
@@ -686,12 +692,23 @@ class MegatronLiteEngine(BaseEngine):
         if loss_function is not None or forward_only:
             runtime_loss_fn = self._make_runtime_loss_fn(loss_function, num_micro_batches, reduced_outputs)
 
+        replay_specs = [
+            runtime_batch.routed_experts is not None
+            for runtime_batch, _loss_context in runtime_batches
+        ]
+        replay_enabled = self.engine_config.router_replay_mode == "R3"
+        if replay_enabled and not all(replay_specs):
+            raise ValueError(
+                "router_replay_mode='R3' requires routed_experts on every "
+                "actor micro-batch in a step."
+            )
         result = self.runtime.forward_backward(
             self.handle,
             iter(runtime_batches),
             loss_fn=runtime_loss_fn,
             num_microbatches=num_micro_batches,
             forward_only=forward_only,
+            router_replay={"action": "replay"} if replay_enabled else None,
         )
         if reduced_outputs is not None:
             return postprocess_batch_func(output_lst=reduced_outputs, indices=indices, data=data)
@@ -725,11 +742,18 @@ class MegatronLiteEngine(BaseEngine):
                 "MegatronLiteEngine supports only nested no-padding THD batches."
             )
         loss_mask = self._loss_mask_for_packing(micro_batch, input_ids)
+        routed_experts = micro_batch.get("routed_experts", None)
+        if routed_experts is not None and not getattr(routed_experts, "is_nested", False):
+            raise ValueError(
+                "R3 routed_experts must use VERL's jagged no-padding layout; "
+                f"got shape {tuple(routed_experts.shape)}."
+            )
         return PackedBatch(
             input_ids=input_ids.values().contiguous(),
             labels=input_ids.values().contiguous(),
             loss_mask=None if loss_mask is None else loss_mask.values().contiguous().float(),
             seq_lens=input_ids.offsets().diff().to(dtype=torch.int64),
+            routed_experts=routed_experts,
         )
 
     def _make_runtime_loss_context(
@@ -756,8 +780,35 @@ class MegatronLiteEngine(BaseEngine):
             return None
 
         loss_mask = micro_batch["loss_mask"]
+        input_lengths = input_ids.offsets().diff().tolist()
         if getattr(loss_mask, "is_nested", False):
-            return loss_mask
+            # VERL delivers ``response_mask`` / ``loss_mask`` as a *response-only*
+            # nested tensor (shape ``[bsz, response_len]``), while ``input_ids`` is
+            # the full ``[prompt; response]`` packed sequence. Returning it as-is
+            # left the packed loss_mask (sum of response lengths) shorter than the
+            # ``input_ids`` seq_lens, so ``_nested_from_packed_tensor`` narrowed a
+            # full-length slice out of a response-only buffer and crashed the
+            # actor-update step. Expand it here to the full sequence the same way
+            # the native Megatron path does (``_build_mtp_loss_mask_nested``):
+            # left-pad each row with prompt zeros and keep the whole valid response
+            # span (response_mask may carry internal zeros for tool outputs).
+            resp_offsets = loss_mask.offsets().tolist()
+            resp_values = loss_mask.values()
+            rows = []
+            for i, total in enumerate(input_lengths):
+                start, end = resp_offsets[i], resp_offsets[i + 1]
+                response_piece = resp_values[start:end]
+                prompt_len = total - (end - start)
+                if prompt_len < 0:
+                    raise ValueError(
+                        f"response loss mask has {end - start} tokens but packed input "
+                        f"sequence has {total} tokens"
+                    )
+                prompt_pad = torch.zeros(
+                    prompt_len, dtype=response_piece.dtype, device=response_piece.device
+                )
+                rows.append(torch.cat([prompt_pad, response_piece], dim=0))
+            return torch.nested.as_nested_tensor(rows, layout=torch.jagged)
 
         rows = []
         for seq_ids, row_mask in zip(input_ids.unbind(0), loss_mask, strict=True):

--- a/experimental/lite/examples/verl/verl_mlite/rollout/__init__.py
+++ b/experimental/lite/examples/verl/verl_mlite/rollout/__init__.py
@@ -1,1 +1,3 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 """Rollout-engine extensions for MLite weight synchronization."""

--- a/experimental/lite/examples/verl/verl_mlite/rollout/__init__.py
+++ b/experimental/lite/examples/verl/verl_mlite/rollout/__init__.py
@@ -1,0 +1,1 @@
+"""Rollout-engine extensions for MLite weight synchronization."""

--- a/experimental/lite/examples/verl/verl_mlite/rollout/layer_cluster.py
+++ b/experimental/lite/examples/verl/verl_mlite/rollout/layer_cluster.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""HF layer clustering for vLLM layerwise-reload IPC streams."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Iterable, Iterator
+from typing import Any
+
+_LAYER_INDEX_RE = re.compile(
+    r"(?:^|\.)"
+    r"(?:(?P<prefix>model\.(?:language_model\.)?)?layers\.(?P<layer>\d+))"
+    r"(?:\.|$)"
+)
+_MTP_INDEX_RE = re.compile(r"(?:^|\.)(?:(?:model\.)?mtp\.(?P<mtp>\d+))(?:\.|$)")
+
+_EMBED_NAMES = frozenset(
+    {
+        "embed.weight",
+        "model.embed.weight",
+        "model.embed_tokens.weight",
+    }
+)
+_NORM_NAMES = frozenset({"norm.weight", "model.norm.weight"})
+_HEAD_NAMES = frozenset(
+    {
+        "head.weight",
+        "lm_head.weight",
+        "model.lm_head.weight",
+    }
+)
+
+
+def resync_layer_cluster_key(name: str) -> tuple[int, int]:
+    """Return a stable sortable key that groups checkpoint tensors by decoder layer.
+
+    Tensors that belong to the same HF decoder layer (weights and their ``.scale``
+  companions) must be loaded in one contiguous ``load_weights`` batch while the
+    vLLM layerwise-reload lifecycle is active. Otherwise multiple submodules stay
+    in the deferred ``online_process_loader`` state and staging memory accumulates
+    across layers (observed as the 53-58 GiB receiver peak in r1-r11).
+    """
+    if name in _EMBED_NAMES:
+        return (0, 0)
+    layer_match = _LAYER_INDEX_RE.search(name)
+    if layer_match is not None:
+        return (1, int(layer_match.group("layer")))
+    mtp_match = _MTP_INDEX_RE.search(name)
+    if mtp_match is not None:
+        return (2, int(mtp_match.group("mtp")))
+    if name in _NORM_NAMES:
+        return (3, 0)
+    if name in _HEAD_NAMES:
+        return (4, 0)
+    return (5, hash(name.split(".", 1)[0]) & 0xFFFF)
+
+
+class LayerClusterBuffer:
+    """Accumulate IPC buckets and flush one HF layer cluster at a time."""
+
+    def __init__(self, load_fn: Callable[[list[tuple[str, Any]]], None]) -> None:
+        self._load_fn = load_fn
+        self._buffer: list[tuple[str, Any]] = []
+        self._current_key: tuple[int, int] | None = None
+        self.flush_count = 0
+
+    def ingest_bucket(self, bucket: Iterable[tuple[str, Any]]) -> None:
+        for name, tensor in bucket:
+            key = resync_layer_cluster_key(name)
+            if self._current_key is not None and key != self._current_key:
+                self._flush()
+            self._current_key = key
+            self._buffer.append((name, tensor))
+
+    def finalize(self) -> None:
+        self._flush()
+
+    def _flush(self) -> None:
+        if not self._buffer:
+            return
+        self._load_fn(self._buffer)
+        self.flush_count += 1
+        self._buffer = []
+
+
+def iter_layer_clustered_weights(
+    weights: Iterable[tuple[str, Any]],
+) -> Iterator[tuple[str, Any]]:
+    """Reorder a flat export stream so each HF layer cluster is contiguous."""
+    current_key: tuple[int, int] | None = None
+    buffer: list[tuple[str, Any]] = []
+
+    def flush() -> Iterator[tuple[str, Any]]:
+        nonlocal buffer, current_key
+        if buffer:
+            yield from buffer
+            buffer = []
+            current_key = None
+
+    for name, tensor in weights:
+        key = resync_layer_cluster_key(name)
+        if current_key is not None and key != current_key:
+            yield from flush()
+        current_key = key
+        buffer.append((name, tensor))
+    yield from flush()
+
+
+__all__ = [
+    "LayerClusterBuffer",
+    "iter_layer_clustered_weights",
+    "resync_layer_cluster_key",
+]

--- a/experimental/lite/megatron/lite/model/deepseek_v4/__init__.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/__init__.py
@@ -1,2 +1,1 @@
-# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 from .config import DeepseekV4Config

--- a/experimental/lite/megatron/lite/model/deepseek_v4/__init__.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/__init__.py
@@ -1,1 +1,3 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 from .config import DeepseekV4Config

--- a/experimental/lite/megatron/lite/model/deepseek_v4/config.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/config.py
@@ -47,6 +47,12 @@ class DeepseekV4Config:
     mtp_loss_scaling_factor: float = 0.1
     rms_norm_eps: float = 1e-6
     initializer_range: float = 0.02
+    # Preserved from the HF config so DS4 fp8 resync can read the quant contract
+    # (_quantization_contract requires config.quantization_config; from_hf copies
+    # keys that match a dataclass field, so these must be declared).
+    expert_dtype: str = "fp4"
+    quantization_config: dict[str, Any] = field(default_factory=dict)
+    topk_method: str = "noaux_tc"
 
     @property
     def num_experts(self) -> int:

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/checkpoint.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import math
 import re
+import time
 
 import torch
 import torch.distributed as dist
@@ -42,6 +43,13 @@ from megatron.lite.primitive.ckpt.hf_weights import (
 )
 from megatron.lite.primitive.parallel import ParallelState
 from megatron.lite.primitive.utils import ensure_divisible, log_rank0
+from megatron.lite.runtime.contracts.weights import ResyncFormat
+
+
+_QUANTIZED_RESYNC_TARGETS = {
+    ResyncFormat.BLOCK_FP8.value,
+    ResyncFormat.MXFP4.value,
+}
 
 
 def EXPERT_CLASSIFIER(name: str) -> bool:
@@ -144,6 +152,20 @@ def _global_expert_idx_from_local(local_idx: int, config: DeepseekV4Config, ps: 
     return ps.ep_rank * num_local + local_idx
 
 
+def _router_buffer_matches_layer_kind(name: str, config: DeepseekV4Config) -> bool:
+    """Keep only the router buffer serialized by the corresponding HF layer."""
+    match = _BLOCK_KEY_RE.match(name)
+    if match is None:
+        return False
+    block, index_text, _ = match.groups()
+    is_hash_layer = block == "layers" and int(index_text) < config.num_hash_layers
+    if name.endswith(".mlp.gate.tid2eid"):
+        return is_hash_layer
+    if name.endswith(".mlp.gate.expert_bias"):
+        return not is_hash_layer
+    return False
+
+
 def _hf_names_for_state_key(name: str, config: DeepseekV4Config) -> list[str]:
     """Map a bare DS4 native key (global layer idx, global expert id) to HF name(s).
 
@@ -221,7 +243,10 @@ def _scale_to_float(scale: torch.Tensor) -> torch.Tensor:
     if scale.dtype.is_floating_point:
         return scale.float()
     if scale.dtype == torch.uint8:
-        return torch.pow(torch.tensor(2.0, dtype=torch.float32), scale.float() - 127.0)
+        return torch.pow(
+            torch.tensor(2.0, dtype=torch.float32, device=scale.device),
+            scale.float() - 127.0,
+        )
     return scale.float()
 
 
@@ -278,6 +303,8 @@ def _copy_param(
     scale: torch.Tensor | None = None,
 ) -> None:
     if scale is not None:
+        tensor = tensor.to(device=param.device)
+        scale = scale.to(device=param.device)
         tensor = _dequantize_scaled_tensor(tensor, scale, param.shape)
     elif param.dtype.is_floating_point and not tensor.dtype.is_floating_point:
         raise RuntimeError(
@@ -287,15 +314,63 @@ def _copy_param(
     param.data.copy_(tensor.to(device=param.device, dtype=param.dtype))
 
 
-def _read_hf_tensor(
-    reader: SafeTensorReader, hf_name: str, target_shape: torch.Size | tuple[int, ...]
-) -> torch.Tensor:
-    scale_name = _scale_name_for_hf_name(hf_name)
-    tensor = reader.get_tensor(hf_name)
-    scale = reader.get_tensor(scale_name) if _has(reader, scale_name) else None
-    if scale is not None:
-        return _dequantize_scaled_tensor(tensor, scale, torch.Size(target_shape))
-    return tensor
+def _copy_hf_tensors(
+    reader: SafeTensorReader,
+    target: nn.Parameter | torch.Tensor,
+    hf_names: list[str],
+) -> None:
+    if len(hf_names) == 1:
+        destinations = [target]
+    elif len(hf_names) == 2:
+        first = target.shape[0] // 2
+        destinations = [target[:first], target[first:]]
+    else:
+        raise ValueError(f"Expected one or two HF tensors, got {hf_names}")
+
+    for destination, hf_name in zip(destinations, hf_names, strict=True):
+        scale_name = _scale_name_for_hf_name(hf_name)
+        scale = reader.get_tensor(scale_name) if _has(reader, scale_name) else None
+        _copy_param(destination, reader.get_tensor(hf_name), scale=scale)
+
+
+def _replica_group_for_state_key(name: str, ps: ParallelState):
+    if EXPERT_CLASSIFIER(name):
+        return getattr(ps, "ep_dp_group", None)
+    return getattr(ps, "dp_cp_group", None)
+
+
+def _replica_source_group_rank(name: str, ps: ParallelState) -> int:
+    if not EXPERT_CLASSIFIER(name):
+        return 0
+    expert_dp_size = int(getattr(ps, "expert_dp_size", 1))
+    if expert_dp_size < 1:
+        raise ValueError(f"Invalid expert_dp_size={expert_dp_size}")
+    return int(getattr(ps, "ep_rank", 0)) % expert_dp_size
+
+
+def _copy_replicated_hf_tensors(
+    reader: SafeTensorReader,
+    target: nn.Parameter | torch.Tensor,
+    hf_names: list[str],
+    *,
+    group,
+    source_group_rank: int = 0,
+) -> bool:
+    """Read once per replica group, then broadcast the full local parameter."""
+    if group is None or not dist.is_initialized() or dist.get_world_size(group) <= 1:
+        _copy_hf_tensors(reader, target, hf_names)
+        return True
+
+    group_ranks = dist.get_process_group_ranks(group)
+    if not 0 <= source_group_rank < len(group_ranks):
+        raise ValueError(
+            f"source_group_rank={source_group_rank} is outside group size {len(group_ranks)}"
+        )
+    is_reader = dist.get_rank(group) == source_group_rank
+    if is_reader:
+        _copy_hf_tensors(reader, target, hf_names)
+    dist.broadcast(target.data, src=group_ranks[source_group_rank], group=group)
+    return is_reader
 
 
 def load_hf_weights(
@@ -316,7 +391,6 @@ def load_hf_weights(
     if (ps.tp_size, ps.etp_size) != (1, 1):
         raise NotImplementedError("DeepSeek V4 direct HF load currently supports only TP=ETP=1.")
 
-    reader = SafeTensorReader(path)
     base_model = unwrap_model(model)
     state = base_model.state_dict()
     # local pipeline position -> global layer index (identity at PP=1)
@@ -326,33 +400,38 @@ def load_hf_weights(
         else {}
     )
     loaded = 0
+    local_reads = 0
     missing: list[str] = []
-    for name, target in state.items():
-        if _is_native_metadata_key(name):
-            continue
-        global_name = to_global_layer_name(name, layer_map)
-        hf_names = _hf_names_for_state_key(_to_global_expert_name(global_name, config, ps), config)
-        if not hf_names or not all(_has(reader, hf_name) for hf_name in hf_names):
-            missing.append(name)
-            continue
-        if len(hf_names) == 2:
-            first = target.shape[0] // 2
-            tensor = torch.cat(
-                [
-                    _read_hf_tensor(reader, hf_names[0], (first, *target.shape[1:])),
-                    _read_hf_tensor(
-                        reader, hf_names[1], (target.shape[0] - first, *target.shape[1:])
-                    ),
-                ],
-                dim=0,
+    load_started = time.monotonic()
+    with SafeTensorReader(path) as reader:
+        for name, target in state.items():
+            if _is_native_metadata_key(name):
+                continue
+            global_name = to_global_layer_name(name, layer_map)
+            hf_names = _hf_names_for_state_key(
+                _to_global_expert_name(global_name, config, ps), config
             )
-            target.data.copy_(tensor.to(device=target.device, dtype=target.dtype))
-        else:
-            scale_name = _scale_name_for_hf_name(hf_names[0])
-            scale = reader.get_tensor(scale_name) if _has(reader, scale_name) else None
-            _copy_param(target, reader.get_tensor(hf_names[0]), scale=scale)
-        loaded += 1
+            if not hf_names or not all(_has(reader, hf_name) for hf_name in hf_names):
+                missing.append(name)
+                continue
+            local_reads += int(
+                _copy_replicated_hf_tensors(
+                    reader,
+                    target,
+                    hf_names,
+                    group=_replica_group_for_state_key(name, ps),
+                    source_group_rank=_replica_source_group_rank(name, ps),
+                )
+            )
+            loaded += 1
 
+    if local_reads:
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        print(
+            "[megatron.lite] DeepSeek V4 checkpoint reader complete "
+            f"rank={rank} local_tensors={local_reads} elapsed_seconds={time.monotonic() - load_started:.3f}",
+            flush=True,
+        )
     log_rank0(f"DeepSeek V4 native loaded {loaded} tensors from {path}")
     for name in missing:
         log_rank0(f"WARNING: DeepSeek V4 checkpoint tensor missing: {name}")
@@ -460,8 +539,8 @@ class DeepseekV4WeightSpec:
         return f"{prefix}.weight{local_idx}"
 
 
-def export_hf_weights(model, config: DeepseekV4Config, ps: ParallelState, **kwargs):
-    """Export DS4 weights as HF (name, tensor) pairs via the SHARED exporter.
+def _export_unquantized_weights(model, config: DeepseekV4Config, ps: ParallelState, **kwargs):
+    """Export gathered DS4 BF16 weights and persistent router buffers.
 
     Identical structure to kimi/glm5: delegate to the shared ``_export`` (which
     does the TP/ETP/EP/PP gather, including the PP ``all_gather_object`` reached
@@ -473,13 +552,13 @@ def export_hf_weights(model, config: DeepseekV4Config, ps: ParallelState, **kwar
 
     spec = DeepseekV4WeightSpec(config)
     rank0_only = bool(kwargs.get("rank0_only", False))
+    cpu = bool(kwargs.get("cpu", False))
     export_dtype = _resolve_export_dtype(kwargs.get("export_dtype"))
     yield from _export(model, spec, ps, vocab_size=config.vocab_size, **kwargs)
 
     rank = dist.get_rank() if dist.is_initialized() else 0
-    if rank0_only and rank != 0:
-        return
     chunks = list(model) if isinstance(model, list | nn.ModuleList) else [model]
+    local_buffers: list[tuple[str, torch.Tensor]] = []
     for chunk in chunks:
         base_chunk = unwrap_model(chunk)
         layer_map = (
@@ -490,18 +569,99 @@ def export_hf_weights(model, config: DeepseekV4Config, ps: ParallelState, **kwar
         for name, buffer in base_chunk.named_buffers():
             # Persistent router buffers carried into HF: hash-layer ``tid2eid``
             # and the (made-persistent for non-hash layers) ``expert_bias``.
-            if not (name.endswith(".mlp.gate.tid2eid") or name.endswith(".mlp.gate.expert_bias")):
-                continue
             global_name = to_global_layer_name(name, layer_map)
-            for hf_name, hf_tensor in spec.native_to_hf(global_name, buffer.detach().cpu()):
-                yield hf_name, _cast_export_tensor(hf_tensor, export_dtype)
+            if not _router_buffer_matches_layer_kind(global_name, config):
+                continue
+            for hf_name, hf_tensor in spec.native_to_hf(global_name, buffer.detach()):
+                local_buffers.append((hf_name, hf_tensor.contiguous()))
+
+    emit = not (rank0_only and rank != 0)
+    if ps.pp_size <= 1:
+        if emit:
+            for hf_name, tensor in local_buffers:
+                tensor = tensor.cpu() if cpu else tensor
+                yield hf_name, _cast_export_tensor(tensor, export_dtype)
+        return
+
+    # Router state is stored as buffers, so the parameter-only shared exporter
+    # above cannot carry it across PP stages.  Every actor rank feeds one rollout
+    # worker; yielding only this rank's local buffers leaves each online vLLM
+    # replica with router state for just one pipeline stage.  Stream every PP
+    # stage's buffers over the same PP group used for parameters so each rank
+    # emits a complete model without materializing the full checkpoint.
+    bcast_device = (
+        torch.device("cuda", torch.cuda.current_device())
+        if torch.cuda.is_available()
+        else torch.device("cpu")
+    )
+    for src_pp in range(ps.pp_size):
+        src_global = ps.pp_global_ranks[src_pp]
+        is_source = src_pp == ps.pp_rank
+        if is_source:
+            stage_buffers = [
+                (name, tensor.to(bcast_device).contiguous()) for name, tensor in local_buffers
+            ]
+            header = [
+                [(name, tuple(tensor.shape), tensor.dtype) for name, tensor in stage_buffers]
+            ]
+        else:
+            stage_buffers = []
+            header = [None]
+        dist.broadcast_object_list(
+            header, src=src_global, group=ps.pp_group, device=bcast_device
+        )
+        for idx, (hf_name, shape, dtype) in enumerate(header[0]):
+            tensor = (
+                stage_buffers[idx][1]
+                if is_source
+                else torch.empty(shape, dtype=dtype, device=bcast_device)
+            )
+            dist.broadcast(tensor, src=src_global, group=ps.pp_group)
+            if emit:
+                output = tensor.cpu() if cpu else tensor
+                yield hf_name, _cast_export_tensor(output, export_dtype)
+
+
+def export_hf_weights(model, config: DeepseekV4Config, ps: ParallelState, **kwargs):
+    """Export DS4 weights as HF or serialized vLLM-checkpoint pairs.
+
+    The default remains the ordinary HF/BF16 stream. ``block_fp8`` and
+    ``mxfp4`` are model-owned adapters over that gathered stream; the runtime
+    and veRL engine do not classify individual DS4 tensors. ``mxfp4`` describes
+    the routed-expert representation; dense quantized weights remain block FP8.
+    """
+    target = kwargs.pop("target", "hf")
+    resync_config = kwargs.pop("resync_config", None)
+    if target not in {"hf", ResyncFormat.BF16.value, *_QUANTIZED_RESYNC_TARGETS}:
+        raise ValueError(f"Unsupported DeepSeek-V4 export target: {target!r}")
+    weights = _export_unquantized_weights(model, config, ps, **kwargs)
+    if target in _QUANTIZED_RESYNC_TARGETS:
+        from megatron.lite.model.deepseek_v4.lite.resync import export_resync_weights
+
+        if target == ResyncFormat.MXFP4.value:
+            resync_config = dict(resync_config or {})
+            configured_dtype = resync_config.get("expert_dtype")
+            if configured_dtype not in {None, "fp4"}:
+                raise ValueError(
+                    "DeepSeek-V4 target='mxfp4' requires expert_dtype='fp4', "
+                    f"got {configured_dtype!r}"
+                )
+            resync_config["expert_dtype"] = "fp4"
+        yield from export_resync_weights(weights, config, resync_config=resync_config)
+    else:
+        if resync_config:
+            raise ValueError(
+                "DeepSeek-V4 resync_config requires a quantized export target"
+            )
+        yield from weights
 
 
 def save_hf_weights(model, path: str, config: DeepseekV4Config, ps: ParallelState, **kwargs) -> None:
     from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
 
     rank = dist.get_rank() if dist.is_initialized() else 0
-    out = dict(export_hf_weights(model, config, ps, rank0_only=True, **kwargs))
+    kwargs.pop("cpu", None)
+    out = dict(export_hf_weights(model, config, ps, rank0_only=True, cpu=True, **kwargs))
     if rank == 0 and out:
         save_safetensors(out, path)
     if dist.is_initialized():

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/checkpoint.py
@@ -657,15 +657,16 @@ def export_hf_weights(model, config: DeepseekV4Config, ps: ParallelState, **kwar
 
 
 def save_hf_weights(model, path: str, config: DeepseekV4Config, ps: ParallelState, **kwargs) -> None:
-    from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
+    """Export + write sharded safetensors via ``stream_export_to_shards``."""
+    from megatron.lite.primitive.ckpt.hf_weights import stream_export_to_shards
 
-    rank = dist.get_rank() if dist.is_initialized() else 0
     kwargs.pop("cpu", None)
-    out = dict(export_hf_weights(model, config, ps, rank0_only=True, cpu=True, **kwargs))
-    if rank == 0 and out:
-        save_safetensors(out, path)
-    if dist.is_initialized():
-        dist.barrier()
+    shard_size_bytes = int(kwargs.pop("shard_size_bytes", 5 * 1024**3))
+    stream_export_to_shards(
+        export_hf_weights(model, config, ps, rank0_only=True, cpu=True, **kwargs),
+        path,
+        shard_size_bytes=shard_size_bytes,
+    )
 
 
 __all__ = [

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/model.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/model.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import os
 from contextlib import nullcontext
+from typing import Any
 
 import torch
 import torch.nn as nn
@@ -60,20 +61,30 @@ from megatron.lite.primitive.parallel.mhc import (
     fold_mhc_hidden_for_pipeline,
     unfold_mhc_hidden_from_pipeline,
 )
+from megatron.lite.primitive.parallel.thd import _roll_packed_thd_left_local
 from megatron.lite.primitive.utils import build_fp8_recipe
 
 
 def _roll_mtp_left(
     tensor: torch.Tensor,
     *,
+    packed_seq_params=None,
     dims: int = -1,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Shift labels/ids one position left (next-token target for MTP depth d).
 
-    DS4 inputs are dense ``[B, S]`` (TP=1, MTP runs only at CP==1), so -- unlike
-    Kimi -- there is no packed-THD branch here; a plain ``torch.roll`` on the
-    sequence dim suffices.
+    THD-packed inputs concatenate multiple sequences, so a plain ``torch.roll``
+    leaks the next sequence's first token across the boundary. Route through the
+    per-sequence THD-aware roll (contiguous cu_seqlens at CP==1, where DS4 MTP
+    runs) when packed_seq_params is available; fall back to plain roll otherwise.
     """
+    cu_seqlens = None if packed_seq_params is None else getattr(packed_seq_params, "cu_seqlens_q", None)
+    if cu_seqlens is not None:
+        # DS4 uses a CONTIGUOUS THD/CP layout (not TE/Megatron zigzag), so roll
+        # per-sequence via cu_seqlens directly -- never the zigzag reconstruction
+        # in roll_packed_thd_left (which GLM/Kimi use for their zigzag layout).
+        dim = dims if dims >= 0 else tensor.dim() + dims
+        return _roll_packed_thd_left_local(tensor, cu_seqlens_padded=cu_seqlens, dims=dim)
     dim = dims if dims >= 0 else tensor.dim() + dims
     rolled = torch.roll(tensor, shifts=-1, dims=dim)
     rolled.select(dim, -1).zero_()
@@ -100,10 +111,19 @@ class DeepseekV4CSAAttention(nn.Module):
         self.ps = ps
         self.self_attn = CompressedSparseAttention(config, layer_idx=layer_idx, ps=ps)
 
-    def forward(self, x: torch.Tensor, *, position_ids: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self, x: torch.Tensor, *, position_ids: torch.Tensor, packed_seq_params: Any = None
+    ) -> torch.Tensor:
         # Skeleton feeds SBHD [S, B, H]; CSA needs batch-first [B, S, H].
+        # packed_seq_params (cu_seqlens etc.) passes through unchanged: the THD
+        # token axis lives in S, so the [S, B] <-> [B, S] transpose leaves it alone.
         x_bsh = x.transpose(0, 1).contiguous()
-        out_bsh = self.self_attn(x_bsh, position_ids=position_ids, attention_mask=None)
+        out_bsh = self.self_attn(
+            x_bsh,
+            position_ids=position_ids,
+            attention_mask=None,
+            packed_seq_params=packed_seq_params,
+        )
         # Back to SBHD [S, B, H] for the skeleton.
         return out_bsh.transpose(0, 1).contiguous()
 
@@ -151,13 +171,18 @@ class DeepseekV4Layer(nn.Module):
         *,
         position_ids: torch.Tensor,
         input_ids: torch.Tensor | None = None,
+        packed_seq_params: Any = None,
     ) -> torch.Tensor:
         # x is SBHD mHC [S, B, hc_mult, H].  HyperConnection collapses the
         # streams to a 3-D [S, B, H] pre-mix, the sub-block runs SBHD, and
         # HyperConnection.post recombines into the 4-D residual streams.
         residual = x
         attn_in, post, comb = self.attn_hc(x)
-        attn_out = self.self_attn(self.input_layernorm(attn_in), position_ids=position_ids)
+        attn_out = self.self_attn(
+            self.input_layernorm(attn_in),
+            position_ids=position_ids,
+            packed_seq_params=packed_seq_params,
+        )
         x = HyperConnection.post(attn_out, residual, post, comb)
 
         residual = x
@@ -403,6 +428,7 @@ class DeepseekV4Model(nn.Module):
         use_fused_kernels: bool = False,
         calculate_entropy: bool = False,
         enable_mtp: bool = True,
+        packed_seq_params: Any = None,
     ) -> dict:
         # THD-packed inputs may arrive 1-D ([total_tokens]); VocabParallelEmbedding
         # and the dense skeleton expect [B, S], so add the batch row (matches the
@@ -433,7 +459,12 @@ class DeepseekV4Model(nn.Module):
         )
         with fp8_ctx:
             for layer in self.layers.values():
-                h = layer(h, position_ids=position_ids, input_ids=input_ids)
+                h = layer(
+                    h,
+                    position_ids=position_ids,
+                    input_ids=input_ids,
+                    packed_seq_params=packed_seq_params,
+                )
 
         output: dict = {"hidden_states": fold_mhc_hidden_for_pipeline(h)}
         if self.lm_head is None or self.norm is None or self.hc_head is None:
@@ -458,7 +489,8 @@ class DeepseekV4Model(nn.Module):
             and self.ps.cp_size == 1
         )
         mtp_hidden_states = self._apply_mtp(
-            mtp_source, input_ids=input_ids, position_ids=position_ids, run_mtp=run_mtp
+            mtp_source, input_ids=input_ids, position_ids=position_ids, run_mtp=run_mtp,
+            packed_seq_params=packed_seq_params,
         )
         if mtp_hidden_states is not None:
             output["mtp_hidden_states"] = mtp_hidden_states
@@ -472,6 +504,7 @@ class DeepseekV4Model(nn.Module):
                 loss_mask=loss_mask,
                 temperature=temperature_value,
                 use_fused_kernels=use_fused_kernels,
+                packed_seq_params=packed_seq_params,
             )
             if mtp_result is not None:
                 hidden_for_head, mtp_loss = mtp_result
@@ -517,6 +550,7 @@ class DeepseekV4Model(nn.Module):
         input_ids: torch.Tensor | None,
         position_ids: torch.Tensor | None,
         run_mtp: bool,
+        packed_seq_params=None,
     ) -> list[torch.Tensor] | None:
         if not run_mtp:
             return None
@@ -528,7 +562,7 @@ class DeepseekV4Model(nn.Module):
         source = mtp_source
         outputs: list[torch.Tensor] = []
         for mtp_layer in self.mtp:
-            mtp_input_ids, _ = _roll_mtp_left(mtp_input_ids, dims=-1)
+            mtp_input_ids, _ = _roll_mtp_left(mtp_input_ids, packed_seq_params=packed_seq_params, dims=-1)
             source = mtp_layer(
                 input_ids=mtp_input_ids,
                 hidden_states=source,
@@ -546,6 +580,7 @@ class DeepseekV4Model(nn.Module):
         loss_mask: torch.Tensor | None,
         temperature: float,
         use_fused_kernels: bool,
+        packed_seq_params=None,
     ) -> tuple[torch.Tensor, torch.Tensor] | None:
         if mtp_hidden_states is None or not self.mtp_enable_train:
             return None
@@ -557,8 +592,8 @@ class DeepseekV4Model(nn.Module):
 
         mtp_loss_values = []
         for mtp_hidden in mtp_hidden_states:
-            mtp_labels, _ = _roll_mtp_left(mtp_labels, dims=-1)
-            mtp_loss_mask, num_tokens = _roll_mtp_left(mtp_loss_mask, dims=-1)
+            mtp_labels, _ = _roll_mtp_left(mtp_labels, packed_seq_params=packed_seq_params, dims=-1)
+            mtp_loss_mask, num_tokens = _roll_mtp_left(mtp_loss_mask, packed_seq_params=packed_seq_params, dims=-1)
             labels_sb = mtp_labels.transpose(0, 1).contiguous()
             mask_sb = mtp_loss_mask.transpose(0, 1).contiguous()
 

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/moe.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/moe.py
@@ -69,6 +69,13 @@ class DeepseekV4MoE(nn.Module):
             scores = logits.float().sigmoid()
         indices = self.gate.tid2eid[input_ids.reshape(-1).to(torch.int64)]
         weights = scores.gather(1, indices)
+        # R3's rollout tensor contains one column for every DS4 MoE layer,
+        # including the input-deterministic hash layers.  Consume/replay those
+        # columns here so later learned-router layers retain the same global
+        # layer index as vLLM.  Replay changes only indices; normalization and
+        # route scaling below still use this actor's live scores.
+        if self.gate.router_replay is not None:
+            weights, indices = self.gate.router_replay.apply(scores, weights, indices)
         if self.topk > 1:
             weights = weights / (weights.sum(dim=-1, keepdim=True) + 1e-20)
         return (weights * self.route_scale).to(dtype=x.dtype), indices

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py
@@ -15,7 +15,12 @@ from megatron.lite.model.deepseek_v4.lite.checkpoint import (
     load_hf_weights as _load_hf_weights_impl,
     save_hf_weights as _save_hf_weights_impl,
 )
-from megatron.lite.model.protocol_utils import add_loss_context_kwargs
+from megatron.lite.model.protocol_utils import (
+    add_loss_context_kwargs,
+    nested_from_packed,
+    pack_r3_replay_mask as _pack_r3_replay_mask,
+    pack_routed_experts as _pack_routed_experts,
+)
 from megatron.lite.primitive.bundle import ModelBundle
 from megatron.lite.primitive.parallel import ParallelState, init_parallel
 from megatron.lite.primitive.parallel.cp import (
@@ -79,6 +84,7 @@ _MODEL_FORWARD_KEYS = (
     "temperature",
     "calculate_entropy",
     "enable_mtp",
+    "packed_seq_params",
 )
 
 
@@ -126,23 +132,12 @@ def _infer_cp_local_seq_len(
     return seq_len // cp_size if seq_len % cp_size == 0 else seq_len
 
 
-def _nested_from_packed_tensor(tensor, seq_lens):
-    if tensor is None:
-        return None
-    if tensor.dim() == 2 and tensor.size(0) == 1:
-        tensor = tensor.squeeze(0)
-    if tensor.dim() != 1:
-        raise ValueError(f"PackedBatch tensor must be 1-D, got {tuple(tensor.shape)}.")
-
-    pieces = []
-    offset = 0
-    for length_t in seq_lens:
-        length = int(length_t.item())
-        pieces.append(tensor.narrow(0, offset, length))
-        offset += length
-    if offset != tensor.numel():
-        raise ValueError(f"PackedBatch sizes sum to {offset}, tensor has {tensor.numel()} tokens.")
-    return torch.nested.as_nested_tensor(pieces, layout=torch.jagged)
+# The 1-D-packed -> jagged-nested split is model-agnostic and lives in the shared
+# protocol_utils layer. DS4 only forks the *CP layout* pair (contiguous DSA, see
+# ``_prepare_packed_batch_kwargs`` below); this pre-CP primitive must not diverge,
+# so alias the shared implementation instead of re-copying it. Keeping the local
+# name preserves existing call sites and unit tests.
+_nested_from_packed_tensor = nested_from_packed
 
 
 def _prepare_packed_batch_kwargs(model, batch: PackedBatch) -> dict[str, Any]:
@@ -155,9 +150,9 @@ def _prepare_packed_batch_kwargs(model, batch: PackedBatch) -> dict[str, Any]:
         cp_group=ps.cp_group,
         split_cp=False,
         labels=_nested_from_packed_tensor(batch.labels, seq_lens),
-        roll_labels=True,
-        roll_loss_mask=True,
         loss_mask=_nested_from_packed_tensor(batch.loss_mask, seq_lens),
+        roll_labels=batch.labels is not None,
+        roll_loss_mask=batch.loss_mask is not None,
     )
     kwargs: dict[str, Any] = {
         "input_ids": packed.input_ids,
@@ -169,7 +164,6 @@ def _prepare_packed_batch_kwargs(model, batch: PackedBatch) -> dict[str, Any]:
     }
     add_loss_context_kwargs(kwargs)
     _prepare_packed_contiguous_cp_kwargs(model, kwargs)
-    kwargs.pop("packed_seq_params", None)
     return {key: value for key, value in kwargs.items() if key in _MODEL_FORWARD_KEYS}
 
 
@@ -270,6 +264,28 @@ def unpack_forward_output(model: nn.Module, batch: PackedBatch, output) -> Any:
     return unpack_thd_to_nested(output, meta, contiguous=True)
 
 
+def pack_routed_experts(model: nn.Module, batch: PackedBatch, routed_experts):
+    """Pack R3 routes using DS4's contiguous CP token layout."""
+
+    return _pack_routed_experts(model, batch, routed_experts, contiguous=True)
+
+
+def pack_r3_replay_mask(model: nn.Module, batch: PackedBatch) -> torch.Tensor:
+    """Pack the causal R3 mask using DS4's contiguous CP token layout."""
+
+    return _pack_r3_replay_mask(model, batch, contiguous=True)
+
+
+def router_replay_roots(chunk: nn.Module) -> list[nn.Module]:
+    """Return main decoder layers only; rollout R3 has no MTP layer axis."""
+
+    model = getattr(chunk, "model", chunk)
+    layers = getattr(model, "layers", None)
+    if layers is None:
+        return [chunk]
+    return list(layers.values())
+
+
 def _apply_mtp_config(model_cfg: DeepseekV4Config, impl_cfg: ImplConfig) -> None:
     override = impl_cfg.num_nextn_predict_layers
     if override is None:
@@ -321,9 +337,10 @@ def _configure_attention_backend(chunks: list[nn.Module], *, backend: str | None
 
 
 def _iter_transformer_units(chunk: nn.Module) -> list[nn.Module]:
-    model = getattr(chunk, "model", None)
-    if model is None:
-        return []
+    # Native DS4 chunks are DeepseekV4Model instances themselves. Keep support
+    # for wrapper-style chunks, but do not require a `.model` indirection or
+    # recompute/offload silently applies to zero transformer layers.
+    model = getattr(chunk, "model", chunk)
     layers = list(getattr(model, "layers", {}).values())
     mtp_layers = list(getattr(model, "mtp", []))
     return [*layers, *mtp_layers]

--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/resync.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/resync.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""DeepSeek-V4 checkpoint-format resync adapter."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator, Mapping
+from typing import Any
+
+import torch
+
+from megatron.lite.primitive.quantization.block_fp8 import quantize_block_fp8
+from megatron.lite.primitive.quantization.mxfp4 import quantize_mxfp4
+
+_EXPERT_DTYPES = {"fp4", "fp8"}
+
+
+def _scale_name(weight_name: str) -> str:
+    return f"{weight_name[:-7]}.scale"
+
+
+def _matches_prefix(name: str, prefix: str) -> bool:
+    return name == prefix or name.startswith(f"{prefix}.")
+
+
+def is_routed_expert(name: str) -> bool:
+    return ".ffn.experts." in name and ".shared_experts." not in name
+
+
+def is_release_unquantized_weight(name: str) -> bool:
+    """Match the unscaled families in the official V4 Flash checkpoint index."""
+    if name in {"embed.weight", "head.weight", "norm.weight"}:
+        return True
+    if name.endswith("norm.weight") or name.endswith(".ffn.gate.weight"):
+        return True
+    if ".attn.compressor." in name:
+        return True
+    if ".attn.indexer." in name and not name.endswith(".attn.indexer.wq_b.weight"):
+        return True
+    return False
+
+
+def _quantization_contract(
+    config: Any, resync_config: Mapping[str, Any] | None = None
+) -> tuple[str, tuple[int, int], tuple[str, ...]]:
+    quant_config = getattr(config, "quantization_config", None)
+    if not isinstance(quant_config, dict) or not quant_config:
+        raise ValueError("DeepSeek-V4 checkpoint resync requires quantization_config")
+    options = dict(resync_config or {})
+    unsupported = sorted(options.keys() - {"expert_dtype"})
+    if unsupported:
+        raise ValueError(f"unsupported DeepSeek-V4 resync_config keys: {unsupported}")
+    expert_dtype = (
+        options.get("expert_dtype")
+        or getattr(config, "expert_dtype", None)
+        or quant_config.get("expert_dtype", "fp4")
+    )
+    if expert_dtype not in _EXPERT_DTYPES:
+        raise ValueError(
+            f"unsupported DeepSeek-V4 expert_dtype={expert_dtype!r}; "
+            f"expected one of {sorted(_EXPERT_DTYPES)}"
+        )
+    raw_block_shape = quant_config.get("weight_block_size", (128, 128))
+    if len(raw_block_shape) != 2:
+        raise ValueError(
+            f"weight_block_size must have two dimensions, got {raw_block_shape}"
+        )
+    block_shape = tuple(int(value) for value in raw_block_shape)
+    ignored = tuple(
+        quant_config.get("ignored_layers")
+        or quant_config.get("modules_to_not_convert")
+        or ()
+    )
+    return expert_dtype, block_shape, ignored
+
+
+def export_resync_weights(
+    weights: Iterable[tuple[str, torch.Tensor]],
+    config: Any,
+    *,
+    resync_config: Mapping[str, Any] | None = None,
+) -> Iterator[tuple[str, torch.Tensor]]:
+    """Convert gathered DS4 BF16 weights to original checkpoint representation."""
+    expert_dtype, block_shape, ignored = _quantization_contract(config, resync_config)
+    # vLLM's FP8 expert online-reload path materializes block scales as
+    # float32 ``weight_scale_inv`` tensors.  Keep W8 resync scales in that
+    # representation; serializing them as UE8M0 causes a large online-reload
+    # regression even though W4/MXFP4 legitimately uses UE8M0 scales.
+    fp8_scale_format = "e8m0" if expert_dtype == "fp4" else "float32"
+
+    for name, tensor in weights:
+        if (
+            not name.endswith(".weight")
+            or tensor.ndim < 2
+            or not tensor.dtype.is_floating_point
+            or is_release_unquantized_weight(name)
+            or any(_matches_prefix(name, prefix) for prefix in ignored)
+        ):
+            yield name, tensor
+            continue
+
+        if is_routed_expert(name) and expert_dtype == "fp4":
+            quantized, scale = quantize_mxfp4(tensor)
+        else:
+            quantized, scale = quantize_block_fp8(
+                tensor, block_shape, scale_format=fp8_scale_format
+            )
+        yield name, quantized
+        yield _scale_name(name), scale
+
+
+__all__ = [
+    "export_resync_weights",
+    "is_release_unquantized_weight",
+    "is_routed_expert",
+]

--- a/experimental/lite/megatron/lite/model/glm5/__init__.py
+++ b/experimental/lite/megatron/lite/model/glm5/__init__.py
@@ -1,4 +1,3 @@
-# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """GLM-5 model family."""
 
 from megatron.lite.model.glm5.config import Glm5Config

--- a/experimental/lite/megatron/lite/model/glm5/__init__.py
+++ b/experimental/lite/megatron/lite/model/glm5/__init__.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 """GLM-5 model family."""
 
 from megatron.lite.model.glm5.config import Glm5Config

--- a/experimental/lite/megatron/lite/model/glm5/config.py
+++ b/experimental/lite/megatron/lite/model/glm5/config.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 """GLM-5 architecture config."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/model/glm5/config.py
+++ b/experimental/lite/megatron/lite/model/glm5/config.py
@@ -1,4 +1,3 @@
-# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """GLM-5 architecture config."""
 
 from __future__ import annotations

--- a/experimental/lite/megatron/lite/model/glm5/lite/__init__.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/__init__.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 """Native GLM-5 lite implementation."""
 
 from megatron.lite.model.glm5.lite.model import Glm5Model

--- a/experimental/lite/megatron/lite/model/glm5/lite/__init__.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/__init__.py
@@ -1,4 +1,3 @@
-# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Native GLM-5 lite implementation."""
 
 from megatron.lite.model.glm5.lite.model import Glm5Model

--- a/experimental/lite/megatron/lite/model/glm5/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/checkpoint.py
@@ -24,17 +24,13 @@ no-ops here; they are kept for structural parity with Kimi.
 from __future__ import annotations
 
 import torch
-import torch.distributed as dist
 import torch.nn as nn
 from torch.distributed.tensor import Replicate, Shard
 
 from megatron.lite.model.glm5.config import Glm5Config
 from megatron.lite.primitive.ckpt.hf_weights import (
     SafeTensorReader,
-    _cast_export_tensor,
-    _resolve_export_dtype,
     parse_expert_idx,
-    to_global_layer_name,
     unwrap_model,
 )
 from megatron.lite.primitive.parallel import ParallelState
@@ -349,6 +345,10 @@ class Glm5WeightSpec:
         del native_name
         return hf_tensors[0]
 
+    @staticmethod
+    def is_export_buffer(native_name: str) -> bool:
+        return native_name.endswith(".moe.router.expert_bias")
+
     # GLM-5 ONLY: DSA attention native suffix -> HF suffix.  The wrapper places
     # the DSA module under `self_attention.self_attention.*`; the HF model uses
     # `self_attn.*` with identical submodule names.
@@ -626,41 +626,23 @@ def load_hf_weights(model: nn.Module, path: str, config: Glm5Config, ps: Paralle
 def export_hf_weights(model, config: Glm5Config, ps: ParallelState, **kwargs):
     from megatron.lite.primitive.ckpt.hf_weights import export_hf_weights as _export
 
+    if config is None:
+        raise ValueError("GLM5 HF export requires a non-null model config")
     spec = Glm5WeightSpec(config)
-    rank0_only = bool(kwargs.get("rank0_only", False))
-    cpu = bool(kwargs.get("cpu", False))
-    export_dtype = _resolve_export_dtype(kwargs.get("export_dtype"))
     yield from _export(model, spec, ps, vocab_size=config.vocab_size, **kwargs)
-    rank = dist.get_rank() if dist.is_initialized() else 0
-    if rank0_only and rank != 0:
-        return
-    chunks = list(model) if isinstance(model, list | nn.ModuleList) else [model]
-    for chunk in chunks:
-        base_chunk = unwrap_model(chunk)
-        layer_map = (
-            {i: base_chunk.layer_indices[i] for i in range(len(base_chunk.layer_indices))}
-            if hasattr(base_chunk, "layer_indices")
-            else {}
-        )
-        for name, buffer in base_chunk.named_buffers():
-            if not name.endswith(".moe.router.expert_bias"):
-                continue
-            global_name = to_global_layer_name(name, layer_map)
-            export_buffer = buffer.detach().cpu() if cpu else buffer.detach()
-            for hf_name, hf_tensor in spec.native_to_hf(global_name, export_buffer):
-                yield hf_name, _cast_export_tensor(hf_tensor, export_dtype)
 
 
 def save_hf_weights(model, path: str, config: Glm5Config, ps: ParallelState, **kwargs) -> None:
-    from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
+    """Export + write sharded safetensors via ``stream_export_to_shards``."""
+    from megatron.lite.primitive.ckpt.hf_weights import stream_export_to_shards
 
-    rank = dist.get_rank() if dist.is_initialized() else 0
     kwargs.pop("cpu", None)
-    out = dict(export_hf_weights(model, config, ps, rank0_only=True, cpu=True, **kwargs))
-    if rank == 0 and out:
-        save_safetensors(out, path)
-    if dist.is_initialized():
-        dist.barrier()
+    shard_size_bytes = int(kwargs.pop("shard_size_bytes", 5 * 1024**3))
+    stream_export_to_shards(
+        export_hf_weights(model, config, ps, rank0_only=True, cpu=True, **kwargs),
+        path,
+        shard_size_bytes=shard_size_bytes,
+    )
 
 
 __all__ = [

--- a/experimental/lite/megatron/lite/model/glm5/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/checkpoint.py
@@ -628,6 +628,7 @@ def export_hf_weights(model, config: Glm5Config, ps: ParallelState, **kwargs):
 
     spec = Glm5WeightSpec(config)
     rank0_only = bool(kwargs.get("rank0_only", False))
+    cpu = bool(kwargs.get("cpu", False))
     export_dtype = _resolve_export_dtype(kwargs.get("export_dtype"))
     yield from _export(model, spec, ps, vocab_size=config.vocab_size, **kwargs)
     rank = dist.get_rank() if dist.is_initialized() else 0
@@ -645,7 +646,8 @@ def export_hf_weights(model, config: Glm5Config, ps: ParallelState, **kwargs):
             if not name.endswith(".moe.router.expert_bias"):
                 continue
             global_name = to_global_layer_name(name, layer_map)
-            for hf_name, hf_tensor in spec.native_to_hf(global_name, buffer.detach().cpu()):
+            export_buffer = buffer.detach().cpu() if cpu else buffer.detach()
+            for hf_name, hf_tensor in spec.native_to_hf(global_name, export_buffer):
                 yield hf_name, _cast_export_tensor(hf_tensor, export_dtype)
 
 
@@ -653,7 +655,8 @@ def save_hf_weights(model, path: str, config: Glm5Config, ps: ParallelState, **k
     from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
 
     rank = dist.get_rank() if dist.is_initialized() else 0
-    out = dict(export_hf_weights(model, config, ps, rank0_only=True, **kwargs))
+    kwargs.pop("cpu", None)
+    out = dict(export_hf_weights(model, config, ps, rank0_only=True, cpu=True, **kwargs))
     if rank == 0 and out:
         save_safetensors(out, path)
     if dist.is_initialized():

--- a/experimental/lite/megatron/lite/model/kimi_k2/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/lite/checkpoint.py
@@ -618,6 +618,7 @@ def export_hf_weights(model, config: KimiK2Config, ps: ParallelState, **kwargs):
 
     spec = KimiK2WeightSpec(config)
     rank0_only = bool(kwargs.get("rank0_only", False))
+    cpu = bool(kwargs.get("cpu", False))
     export_dtype = _resolve_export_dtype(kwargs.get("export_dtype"))
     yield from _export(model, spec, ps, vocab_size=config.vocab_size, **kwargs)
     rank = dist.get_rank() if dist.is_initialized() else 0
@@ -635,7 +636,8 @@ def export_hf_weights(model, config: KimiK2Config, ps: ParallelState, **kwargs):
             if not name.endswith(".moe.router.expert_bias"):
                 continue
             global_name = to_global_layer_name(name, layer_map)
-            for hf_name, hf_tensor in spec.native_to_hf(global_name, buffer.detach().cpu()):
+            export_buffer = buffer.detach().cpu() if cpu else buffer.detach()
+            for hf_name, hf_tensor in spec.native_to_hf(global_name, export_buffer):
                 yield hf_name, _cast_export_tensor(hf_tensor, export_dtype)
 
 
@@ -643,7 +645,7 @@ def save_hf_weights(model, path: str, config: KimiK2Config, ps: ParallelState) -
     from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
 
     rank = dist.get_rank() if dist.is_initialized() else 0
-    out = dict(export_hf_weights(model, config, ps, rank0_only=True))
+    out = dict(export_hf_weights(model, config, ps, rank0_only=True, cpu=True))
     if rank == 0 and out:
         save_safetensors(out, path)
     if dist.is_initialized():

--- a/experimental/lite/megatron/lite/model/kimi_k2/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/lite/checkpoint.py
@@ -4,17 +4,13 @@
 from __future__ import annotations
 
 import torch
-import torch.distributed as dist
 import torch.nn as nn
 from torch.distributed.tensor import Replicate, Shard
 
 from megatron.lite.model.kimi_k2.config import KimiK2Config
 from megatron.lite.primitive.ckpt.hf_weights import (
     SafeTensorReader,
-    _cast_export_tensor,
-    _resolve_export_dtype,
     parse_expert_idx,
-    to_global_layer_name,
     unwrap_model,
 )
 from megatron.lite.primitive.parallel import ParallelState
@@ -343,6 +339,10 @@ class KimiK2WeightSpec:
         del native_name
         return hf_tensors[0]
 
+    @staticmethod
+    def is_export_buffer(native_name: str) -> bool:
+        return native_name.endswith(".moe.router.expert_bias")
+
     def native_to_hf(
         self, native_name: str, tensor: torch.Tensor
     ) -> list[tuple[str, torch.Tensor]]:
@@ -617,39 +617,20 @@ def export_hf_weights(model, config: KimiK2Config, ps: ParallelState, **kwargs):
     from megatron.lite.primitive.ckpt.hf_weights import export_hf_weights as _export
 
     spec = KimiK2WeightSpec(config)
-    rank0_only = bool(kwargs.get("rank0_only", False))
-    cpu = bool(kwargs.get("cpu", False))
-    export_dtype = _resolve_export_dtype(kwargs.get("export_dtype"))
     yield from _export(model, spec, ps, vocab_size=config.vocab_size, **kwargs)
-    rank = dist.get_rank() if dist.is_initialized() else 0
-    if rank0_only and rank != 0:
-        return
-    chunks = list(model) if isinstance(model, list | nn.ModuleList) else [model]
-    for chunk in chunks:
-        base_chunk = unwrap_model(chunk)
-        layer_map = (
-            {i: base_chunk.layer_indices[i] for i in range(len(base_chunk.layer_indices))}
-            if hasattr(base_chunk, "layer_indices")
-            else {}
-        )
-        for name, buffer in base_chunk.named_buffers():
-            if not name.endswith(".moe.router.expert_bias"):
-                continue
-            global_name = to_global_layer_name(name, layer_map)
-            export_buffer = buffer.detach().cpu() if cpu else buffer.detach()
-            for hf_name, hf_tensor in spec.native_to_hf(global_name, export_buffer):
-                yield hf_name, _cast_export_tensor(hf_tensor, export_dtype)
 
 
-def save_hf_weights(model, path: str, config: KimiK2Config, ps: ParallelState) -> None:
-    from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
+def save_hf_weights(model, path: str, config: KimiK2Config, ps: ParallelState, **kwargs) -> None:
+    """Export + write sharded safetensors via ``stream_export_to_shards``."""
+    from megatron.lite.primitive.ckpt.hf_weights import stream_export_to_shards
 
-    rank = dist.get_rank() if dist.is_initialized() else 0
-    out = dict(export_hf_weights(model, config, ps, rank0_only=True, cpu=True))
-    if rank == 0 and out:
-        save_safetensors(out, path)
-    if dist.is_initialized():
-        dist.barrier()
+    kwargs.pop("cpu", None)
+    shard_size_bytes = int(kwargs.pop("shard_size_bytes", 5 * 1024**3))
+    stream_export_to_shards(
+        export_hf_weights(model, config, ps, rank0_only=True, cpu=True, **kwargs),
+        path,
+        shard_size_bytes=shard_size_bytes,
+    )
 
 
 __all__ = [

--- a/experimental/lite/megatron/lite/model/kimi_k2/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/kimi_k2/lite/protocol.py
@@ -278,6 +278,12 @@ def export_hf_weights(chunks, model_cfg: KimiK2Config, ps: ParallelState, **kwar
     yield from export_impl(chunks, model_cfg, ps, **kwargs)
 
 
+def save_hf_weights(chunks, path: str, model_cfg: KimiK2Config, ps: ParallelState) -> None:
+    from megatron.lite.model.kimi_k2.lite.checkpoint import save_hf_weights as save_impl
+
+    save_impl(chunks, path, model_cfg, ps)
+
+
 def vocab_size(model_cfg) -> int | None:
     cfg = getattr(model_cfg, "text_config", model_cfg)
     return getattr(cfg, "vocab_size", None)
@@ -292,5 +298,6 @@ __all__ = [
     "export_hf_weights",
     "is_expert_param",
     "load_hf_weights",
+    "save_hf_weights",
     "vocab_size",
 ]

--- a/experimental/lite/megatron/lite/model/protocol_utils.py
+++ b/experimental/lite/megatron/lite/model/protocol_utils.py
@@ -20,6 +20,7 @@ from megatron.lite.primitive.parallel.thd import (
     pack_nested_thd,
     parallel_state_from_model,
     prepare_packed_thd_kwargs_for_context_parallel,
+    split_packed_to_cp_local,
     thd_pack_meta,
     unpack_thd_to_nested,
 )
@@ -100,6 +101,99 @@ def unpack_thd_forward_output(model, batch: PackedBatch, output: torch.Tensor) -
     return unpack_thd_to_nested(output, meta, contiguous=False)
 
 
+def pack_routed_experts(
+    model, batch: PackedBatch, routed_experts, *, contiguous: bool = False
+) -> list[torch.Tensor]:
+    """Pack jagged ``[batch, seq, layers, topk]`` R3 routes for local routers."""
+
+    ps = _parallel_state(model)
+    meta = thd_pack_meta(
+        batch.seq_lens,
+        tp_size=ps.tp_size,
+        cp_size=ps.cp_size,
+        cp_group=ps.cp_group if ps.cp_size > 1 else None,
+    )
+    rows = (
+        list(routed_experts.unbind(0))
+        if getattr(routed_experts, "is_nested", False)
+        else [routed_experts[i] for i in range(routed_experts.size(0))]
+    )
+    if len(rows) != int(meta.lengths.numel()):
+        raise ValueError(
+            f"routed_experts has {len(rows)} sequences, batch has {int(meta.lengths.numel())}."
+        )
+    if not rows or rows[0].dim() != 3:
+        shape = None if not rows else tuple(rows[0].shape)
+        raise ValueError(
+            f"routed_experts rows must be [seq, layers, topk], got {shape}."
+        )
+    num_layers, topk = int(rows[0].size(1)), int(rows[0].size(2))
+    total_padded = int(meta.cu_seqlens_padded[-1].item())
+    device = batch.input_ids.device
+    full = torch.zeros(total_padded, num_layers, topk, dtype=torch.long, device=device)
+    for idx, row in enumerate(rows):
+        length = int(meta.lengths[idx].item())
+        route_length = int(row.size(0))
+        # Rollout routes are attached to consumed next-token logits, so vLLM
+        # normally returns one fewer route row than the actor input has tokens.
+        # The missing final row predicts no token and is excluded by the R3
+        # replay mask below; leave its placeholder zeroed so native routing is
+        # used there.  Also accept full-length rows for offline/test producers.
+        if route_length not in (length - 1, length):
+            raise ValueError(
+                f"routed_experts seq {idx} has {route_length} tokens, "
+                f"expected {length - 1} rollout rows or {length} full rows."
+            )
+        start = int(meta.cu_seqlens_padded[idx].item())
+        full[start : start + route_length] = row.to(device=device, dtype=torch.long)
+
+    if contiguous:
+        if ps.cp_size > 1:
+            local_len = total_padded // ps.cp_size
+            full = full[ps.cp_rank * local_len : (ps.cp_rank + 1) * local_len]
+        local = full
+    else:
+        local = split_packed_to_cp_local(
+            full,
+            cu_seqlens_padded=meta.cu_seqlens_padded,
+            cp_size=ps.cp_size,
+            cp_rank=ps.cp_rank,
+            dim=0,
+        )
+    if ps.tp_size > 1:
+        tp_local = local.size(0) // ps.tp_size
+        local = local[ps.tp_rank * tp_local : (ps.tp_rank + 1) * tp_local]
+    return [local[:, layer, :].contiguous() for layer in range(num_layers)]
+
+
+def pack_r3_replay_mask(
+    model, batch: PackedBatch, *, contiguous: bool = False
+) -> torch.Tensor:
+    """Build and pack the causal R3 mask from a full-sequence loss mask.
+
+    Every row before the final token can influence a response-token logprob.
+    The final row has no consumed next-token logit and stays on native routing.
+    Sequences without response tokens are not replayed.
+    """
+
+    rows = []
+    offset = 0
+    for length_tensor in batch.seq_lens:
+        length = int(length_tensor.item())
+        has_response = True
+        if batch.loss_mask is not None:
+            has_response = bool(batch.loss_mask[offset : offset + length].sum().item())
+        row = torch.zeros(length, dtype=torch.long, device=batch.input_ids.device)
+        if has_response and length > 1:
+            row[:-1] = 1
+        rows.append(row[:, None, None])
+        offset += length
+    nested = torch.nested.as_nested_tensor(rows, layout=torch.jagged)
+    return pack_routed_experts(model, batch, nested, contiguous=contiguous)[0][
+        :, 0
+    ].bool()
+
+
 def add_loss_context_kwargs(kwargs: dict[str, Any], *, include_return_log_probs: bool = False) -> None:
     loss_context = get_loss_context()
     if loss_context is None:
@@ -123,6 +217,8 @@ __all__ = [
     "add_cross_entropy_fusion",
     "add_loss_context_kwargs",
     "nested_from_packed",
+    "pack_r3_replay_mask",
+    "pack_routed_experts",
     "pack_thd_forward_kwargs",
     "set_cross_entropy_fusion",
     "unpack_thd_forward_output",

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/checkpoint.py
@@ -307,6 +307,17 @@ class Qwen35WeightSpec:
             return _merge_gate_up_tp_shards(_allgather_tp_shards(tensor, ps))
         return None
 
+    def merge_dense_shards(
+        self, native_name: str, shards: list[torch.Tensor]
+    ) -> torch.Tensor | None:
+        if native_name.endswith(".linear_attn.in_proj.linear.weight"):
+            return _merge_linear_attn_in_proj_tp_shards(shards, cfg=self.config)
+        if native_name.endswith(".linear_attn.conv1d.weight"):
+            return _merge_linear_attn_conv1d_tp_shards(shards, cfg=self.config)
+        if native_name.endswith(".moe.shared_expert.gate_up.linear.weight"):
+            return _merge_gate_up_tp_shards(shards)
+        return None
+
     def packed_expert_group_name(self, native_name: str) -> str | None:
         if re.fullmatch(r"layers\.\d+\.moe\.experts\.fc[12]\.weight\d+", native_name) is None:
             return None

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/model.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/model.py
@@ -237,7 +237,7 @@ class Qwen35Layer(nn.Module):
         moe_act_recompute: bool = False,
         use_thd: bool = False,
         deterministic: bool = False,
-        gdn_cp_mode: str = "replicated",
+        gdn_cp_mode: str = "headwise",
     ):
         super().__init__()
         self.layer_idx = layer_idx
@@ -341,7 +341,7 @@ class Qwen35Model(nn.Module):
         mtp_enable_train: bool = False,
         mtp_detach_encoder: bool = False,
         mount_vision_model: bool = False,
-        gdn_cp_mode: str = "replicated",
+        gdn_cp_mode: str = "headwise",
     ):
         super().__init__()
         del attention_backend_override

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
@@ -66,7 +66,12 @@ class ImplConfig:
     mtp_loss_scaling_factor: float = 0.1
     mtp_use_repeated_layer: bool | None = None
     mount_vision_model: bool = False
-    gdn_cp_mode: str = "replicated"
+    # GatedDeltaNet context-parallel mode: "headwise" (default, head-parallel a2a;
+    # bitwise-exact vs CP-off and memory-sharded), "replicated" (all-gather, exact but
+    # full sequence replicated on every rank), or "chunkwise" (FLA ring; seq-shard +
+    # all heads, best memory; bf16-floor vs CP-off, faithful packing-aware mirror of
+    # upstream Megatron linear_cp_mode='chunkwise').
+    gdn_cp_mode: str = "headwise"
 
 
 def _full_attn_module(layer, name: str):

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
@@ -12,6 +12,7 @@ Protocol convention (what runtime calls):
   Optional (in ModelBundle.extras or module-level):
     load_hf_weights(chunk, hf_path, model_cfg, ps)  — HF weight loading
     export_hf_weights(chunks, model_cfg, ps)         — HF weight export
+    save_hf_weights(chunks, path, model_cfg, ps)     — HF checkpoint writing
     vocab_size(model_cfg) -> int                     — benchmark metadata
   Escape hatch:
     create_runtime(hf_path, cfg) -> Runtime          — fully override runtime
@@ -57,6 +58,7 @@ __all__ = [
     "build_model_config",
     "export_hf_weights",
     "load_hf_weights",
+    "save_hf_weights",
     "vocab_size",
 ]
 
@@ -319,6 +321,17 @@ def export_hf_weights(
 
     for chunk in chunks:
         yield from _export(chunk, model_cfg, ps, **kwargs)
+
+
+def save_hf_weights(
+    chunks: list[nn.Module],
+    path: str,
+    model_cfg: Qwen3MoEConfig,
+    ps: ParallelState,
+) -> None:
+    from megatron.lite.model.qwen3_moe.lite.checkpoint import save_hf_weights as _save
+
+    _save(chunks, path, model_cfg, ps)
 
 
 # ---------------------------------------------------------------------------

--- a/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
@@ -13,9 +13,10 @@ from __future__ import annotations
 import json
 import os
 import re
-from collections.abc import Generator
+from collections.abc import Generator, Iterable
+from contextlib import ExitStack
 from pathlib import Path
-from typing import Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 import torch
 import torch.distributed as dist
@@ -27,6 +28,46 @@ try:
     from torch.distributed.tensor import DTensor
 except Exception:  # pragma: no cover - older torch without DTensor
     DTensor = None  # type: ignore[assignment]
+
+from megatron.lite.primitive.ckpt.weight_sync_probe import get_weight_sync_probe
+
+
+def _tensor_nbytes(tensor: torch.Tensor) -> int:
+    return tensor.numel() * tensor.element_size()
+
+
+def _to_cpu(tensor: torch.Tensor) -> torch.Tensor:
+    if tensor.device.type == "cpu":
+        return tensor
+    with get_weight_sync_probe().measure("d2h", nbytes=_tensor_nbytes(tensor), device=tensor.device):
+        return tensor.cpu()
+
+
+def _copy_to_cpu(dst: torch.Tensor, src: torch.Tensor) -> None:
+    if src.device.type == "cpu":
+        dst.copy_(src)
+        return
+    with get_weight_sync_probe().measure("d2h", nbytes=_tensor_nbytes(src), device=src.device):
+        dst.copy_(src)
+
+
+def _ep_all_gather(outputs: list[torch.Tensor], tensor: torch.Tensor, group) -> None:
+    with get_weight_sync_probe().measure(
+        "ep_gather",
+        nbytes=sum(_tensor_nbytes(output) for output in outputs),
+        device=tensor.device,
+    ):
+        dist.all_gather(outputs, tensor, group=group)
+
+
+def _native_to_hf(spec: HFWeights, name: str, tensor: torch.Tensor):
+    with get_weight_sync_probe().measure("mapping") as sample:
+        mapped = spec.native_to_hf(name, tensor)
+        sample.nbytes = sum(_tensor_nbytes(value) for _, value in mapped)
+        return mapped
+
+
+DEFAULT_EXPORT_BUFFER_MAX_SIZE_BYTES = 2 * 1024**3
 
 
 def _materialize_dtensor(tensor: torch.Tensor) -> torch.Tensor:
@@ -42,7 +83,10 @@ def _materialize_dtensor(tensor: torch.Tensor) -> torch.Tensor:
     params (dist_opt backend) pass through untouched.
     """
     if DTensor is not None and isinstance(tensor, DTensor):
-        return tensor.full_tensor()
+        with get_weight_sync_probe().measure("fsdp_gather", device=tensor.device) as sample:
+            result = tensor.full_tensor()
+            sample.nbytes = _tensor_nbytes(result)
+            return result
     return tensor
 
 
@@ -103,11 +147,34 @@ class HFWeights(Protocol):
 
 
 class SafeTensorReader:
-    """Read individual tensors from an HF safetensors directory."""
+    """Read tensors from an HF safetensors directory.
+
+    As a context manager, keep one lazy mmap handle per referenced shard and
+    close every handle on exit. The one-shot API retains its historical
+    open/read/close behavior.
+    """
 
     def __init__(self, path: str):
         self.path = Path(path)
         self.index = self._load_index()
+        self._stack: ExitStack | None = None
+        self._handles: dict[Path, Any] = {}
+
+    def __enter__(self) -> SafeTensorReader:
+        if self._stack is not None:
+            raise RuntimeError("SafeTensorReader context cannot be entered twice")
+        self._stack = ExitStack()
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        del exc_type, exc, traceback
+        self.close()
+
+    def close(self) -> None:
+        stack, self._stack = self._stack, None
+        self._handles.clear()
+        if stack is not None:
+            stack.close()
 
     def _load_index(self) -> dict[str, str]:
         idx_file = self.path / "model.safetensors.index.json"
@@ -121,6 +188,14 @@ class SafeTensorReader:
             filepath = self.path / self.index[name]
         else:
             filepath = self.path / "model.safetensors"
+        if self._stack is not None:
+            handle = self._handles.get(filepath)
+            if handle is None:
+                handle = self._stack.enter_context(
+                    safe_open(str(filepath), framework="pt", device="cpu")
+                )
+                self._handles[filepath] = handle
+            return handle.get_tensor(name)
         with safe_open(str(filepath), framework="pt", device="cpu") as f:
             return f.get_tensor(name)
 
@@ -222,6 +297,307 @@ def allgather_concat(
     gathered = [torch.empty_like(tensor) for _ in range(world_size)]
     dist.all_gather(gathered, tensor.contiguous(), group=group)
     return torch.cat(gathered, dim=dim)
+
+
+def bucketed_all_gather_into_tensor(
+    bucket: list[tuple[str, torch.Tensor]],
+    *,
+    group: dist.ProcessGroup | None,
+    group_size: int,
+    buffer_max_size_bytes: int = DEFAULT_EXPORT_BUFFER_MAX_SIZE_BYTES,
+) -> list[tuple[str, torch.Tensor, list[torch.Tensor]]]:
+    """Gather a same-dtype tensor bucket through bounded flat GPU buffers."""
+    if not bucket:
+        return []
+    if group_size <= 1:
+        return [(name, tensor, [tensor]) for name, tensor in bucket]
+
+    dtype = bucket[0][1].dtype
+    device = bucket[0][1].device
+    if any(tensor.dtype != dtype for _, tensor in bucket):
+        raise ValueError("bucket tensors must share the same dtype")
+    if buffer_max_size_bytes <= 0:
+        raise ValueError("buffer_max_size_bytes must be positive")
+
+    element_size = bucket[0][1].element_size()
+    per_rank_buffer_bytes = max(buffer_max_size_bytes // group_size, element_size)
+    max_chunk_numel = max(1, per_rank_buffer_bytes // element_size)
+    flat_shards = [tensor.reshape(-1) for _, tensor in bucket]
+    numel_per_tensor = [tensor.numel() for tensor in flat_shards]
+    total_numel = sum(numel_per_tensor)
+
+    # Normal export buckets are capped before entering this function, so they
+    # fit in one collective. Keep the rank-major receive buffer alive through
+    # returned views instead of allocating and copying ``num_tensors * world``
+    # temporary shards. Oversized single tensors use the bounded chunked path
+    # below.
+    if total_numel <= max_chunk_numel:
+        send_buffer = torch.empty(total_numel, dtype=dtype, device=device)
+        send_views = list(send_buffer.split(numel_per_tensor))
+        torch._foreach_copy_(send_views, flat_shards)
+        recv_buffer = torch.empty(group_size * total_numel, dtype=dtype, device=device)
+        dist.all_gather_into_tensor(recv_buffer, send_buffer, group=group)
+
+        offsets = []
+        offset = 0
+        for numel in numel_per_tensor:
+            offsets.append(offset)
+            offset += numel
+        return [
+            (
+                name,
+                tensor,
+                [
+                    recv_buffer[
+                        rank * total_numel + offsets[idx] : rank * total_numel
+                        + offsets[idx]
+                        + numel_per_tensor[idx]
+                    ].view_as(tensor)
+                    for rank in range(group_size)
+                ],
+            )
+            for idx, (name, tensor) in enumerate(bucket)
+        ]
+
+    gathered_shards_by_rank = [
+        [torch.empty_like(tensor) for _, tensor in bucket] for _ in range(group_size)
+    ]
+    gathered_flat_views = [
+        [tensor.view(-1) for tensor in rank_shards] for rank_shards in gathered_shards_by_rank
+    ]
+
+    send_buffer = torch.empty(max_chunk_numel, dtype=dtype, device=device)
+    recv_buffer = torch.empty(group_size * max_chunk_numel, dtype=dtype, device=device)
+    tensor_idx = 0
+    tensor_offset = 0
+    while tensor_idx < len(bucket):
+        chunk_segments = []
+        chunk_numel = 0
+        while tensor_idx < len(bucket) and chunk_numel < max_chunk_numel:
+            available = numel_per_tensor[tensor_idx] - tensor_offset
+            take_numel = min(available, max_chunk_numel - chunk_numel)
+            send_buffer[chunk_numel : chunk_numel + take_numel].copy_(
+                flat_shards[tensor_idx][tensor_offset : tensor_offset + take_numel]
+            )
+            chunk_segments.append((tensor_idx, tensor_offset, chunk_numel, take_numel))
+            chunk_numel += take_numel
+            tensor_offset += take_numel
+            if tensor_offset == numel_per_tensor[tensor_idx]:
+                tensor_idx += 1
+                tensor_offset = 0
+
+        recv_view = recv_buffer[: group_size * chunk_numel]
+        dist.all_gather_into_tensor(recv_view, send_buffer[:chunk_numel], group=group)
+        for rank in range(group_size):
+            rank_recv_view = recv_view[rank * chunk_numel : (rank + 1) * chunk_numel]
+            for tensor_i, output_offset, chunk_offset, segment_numel in chunk_segments:
+                gathered_flat_views[rank][tensor_i][
+                    output_offset : output_offset + segment_numel
+                ].copy_(rank_recv_view[chunk_offset : chunk_offset + segment_numel])
+
+    return [
+        (
+            name,
+            tensor,
+            [gathered_shards_by_rank[rank][idx] for rank in range(group_size)],
+        )
+        for idx, (name, tensor) in enumerate(bucket)
+    ]
+
+
+def _iter_bucketed_materialized_tensors(
+    named_tensors: Iterable[tuple[str, torch.Tensor]],
+    *,
+    buffer_max_size_bytes: int = DEFAULT_EXPORT_BUFFER_MAX_SIZE_BYTES,
+) -> Generator[tuple[str, torch.Tensor], None, None]:
+    """Materialize sharded DTensors through bounded, layout-aware flat gathers.
+
+    Replicated DTensors and plain tensors are already complete on every DP rank,
+    so they bypass collectives.  They remain in the pending stream until the
+    current sharded bucket is flushed, which preserves parameter order without
+    breaking a flat bucket at every replicated parameter.
+    """
+    bucket: list[tuple[str, torch.Tensor]] = []
+    metadata: list[tuple[int, tuple[int, ...]]] = []
+    pending: list[tuple[str, torch.Tensor | None, int | None]] = []
+    bucket_bytes = 0
+    bucket_group = None
+    bucket_group_ranks: tuple[int, ...] | None = None
+    bucket_group_size = 1
+
+    def _flush_bucket():
+        nonlocal bucket, metadata, pending, bucket_bytes
+        nonlocal bucket_group, bucket_group_ranks, bucket_group_size
+        if not pending:
+            return
+        materialized: list[torch.Tensor] = []
+        if bucket:
+            with get_weight_sync_probe().measure(
+                "fsdp_gather", device=bucket[0][1].device
+            ) as sample:
+                gathered = bucketed_all_gather_into_tensor(
+                    bucket,
+                    group=bucket_group,
+                    group_size=bucket_group_size,
+                    buffer_max_size_bytes=buffer_max_size_bytes,
+                )
+                total_global_numel = sum(
+                    local_tensor.numel() * bucket_group_size
+                    for _, local_tensor in bucket
+                )
+                materialized_buffer = torch.empty(
+                    total_global_numel,
+                    dtype=bucket[0][1].dtype,
+                    device=bucket[0][1].device,
+                )
+                source_views: list[torch.Tensor] = []
+                destination_views: list[torch.Tensor] = []
+                materialized_offset = 0
+                for (_, _, shards), (shard_dim, global_shape) in zip(
+                    gathered, metadata, strict=True
+                ):
+                    global_numel = 1
+                    for size in global_shape:
+                        global_numel *= size
+                    full = materialized_buffer[
+                        materialized_offset : materialized_offset + global_numel
+                    ].view(global_shape)
+                    local_extent = shards[0].shape[shard_dim]
+                    for rank, shard in enumerate(shards):
+                        source_views.append(shard)
+                        destination_views.append(
+                            full.narrow(
+                                shard_dim,
+                                rank * local_extent,
+                                local_extent,
+                            )
+                        )
+                    materialized.append(full)
+                    materialized_offset += global_numel
+                torch._foreach_copy_(destination_views, source_views)
+                sample.nbytes = _tensor_nbytes(materialized_buffer)
+
+        outputs = []
+        for name, local_tensor, bucket_idx in pending:
+            if bucket_idx is None:
+                assert local_tensor is not None
+                outputs.append((name, local_tensor))
+            else:
+                outputs.append((name, materialized[bucket_idx]))
+        bucket = []
+        metadata = []
+        pending = []
+        bucket_bytes = 0
+        bucket_group = None
+        bucket_group_ranks = None
+        bucket_group_size = 1
+        yield from outputs
+
+    for name, tensor in named_tensors:
+        if DTensor is None or not isinstance(tensor, DTensor):
+            if bucket:
+                pending.append((name, tensor, None))
+            else:
+                yield name, tensor
+            continue
+
+        placements = tuple(tensor.placements)
+        placement = placements[0] if len(placements) == 1 else None
+        shard_dim = getattr(placement, "dim", None)
+        if placement is not None and type(placement).__name__ == "Replicate":
+            local = tensor.to_local()
+            if bucket:
+                pending.append((name, local, None))
+            else:
+                yield name, local
+            continue
+        if (
+            placement is None
+            or type(placement).__name__ != "Shard"
+            or shard_dim is None
+        ):
+            yield from _flush_bucket()
+            yield name, _materialize_dtensor(tensor)
+            continue
+
+        local = tensor.to_local()
+        global_shape = tuple(int(size) for size in tensor.shape)
+        shard_dim = int(shard_dim) % len(global_shape) if global_shape else -1
+        group = tensor.device_mesh.get_group(0)
+        group_size = dist.get_world_size(group)
+        if group_size <= 1:
+            if bucket:
+                pending.append((name, local, None))
+            else:
+                yield name, local
+            continue
+        group_ranks = tuple(dist.get_process_group_ranks(group))
+        evenly_sharded = (
+            shard_dim >= 0
+            and global_shape[shard_dim] % group_size == 0
+            and local.shape[shard_dim] * group_size == global_shape[shard_dim]
+        )
+        if not evenly_sharded:
+            yield from _flush_bucket()
+            yield name, _materialize_dtensor(tensor)
+            continue
+
+        local_bytes = local.numel() * local.element_size()
+        per_rank_limit = max(buffer_max_size_bytes // group_size, 1)
+        if local_bytes > per_rank_limit:
+            yield from _flush_bucket()
+            local_extent = local.shape[shard_dim]
+            bytes_per_extent = local_bytes // local_extent
+            chunk_extent = max(per_rank_limit // bytes_per_extent, 1)
+            full = torch.empty(global_shape, dtype=local.dtype, device=local.device)
+            with get_weight_sync_probe().measure(
+                "fsdp_gather", device=local.device
+            ) as sample:
+                for offset in range(0, local_extent, chunk_extent):
+                    extent = min(chunk_extent, local_extent - offset)
+                    local_chunk = local.narrow(shard_dim, offset, extent)
+                    _, _, gathered_chunks = bucketed_all_gather_into_tensor(
+                        [(name, local_chunk)],
+                        group=group,
+                        group_size=group_size,
+                        buffer_max_size_bytes=buffer_max_size_bytes,
+                    )[0]
+                    for rank, gathered_chunk in enumerate(gathered_chunks):
+                        full.narrow(
+                            shard_dim,
+                            rank * local_extent + offset,
+                            extent,
+                        ).copy_(gathered_chunk)
+                sample.nbytes = _tensor_nbytes(full)
+            yield name, full
+            continue
+
+        incompatible = bool(bucket) and (
+            local.dtype != bucket[0][1].dtype
+            or local.device != bucket[0][1].device
+            or group_ranks != bucket_group_ranks
+            or group_size != bucket_group_size
+            or bucket_bytes + local_bytes > per_rank_limit
+        )
+        if incompatible:
+            yield from _flush_bucket()
+
+        bucket.append((name, local))
+        metadata.append((shard_dim, global_shape))
+        pending.append((name, None, len(bucket) - 1))
+        bucket_bytes += local_bytes
+        if bucket_group is None:
+            bucket_group = group
+            bucket_group_ranks = group_ranks
+            bucket_group_size = group_size
+        if bucket_bytes >= per_rank_limit:
+            yield from _flush_bucket()
+
+    yield from _flush_bucket()
+
+
+def _maybe_cpu(tensor: torch.Tensor, *, cpu: bool) -> torch.Tensor:
+    return _to_cpu(tensor) if cpu else tensor
 
 
 def remap_layer_index(name: str, global_to_local: dict[int, int]) -> str | None:
@@ -389,6 +765,27 @@ def _resolve_param_name(name: str, state_dict: dict) -> str | None:
     return None
 
 
+def _merge_dense_shards(
+    name: str,
+    tensor: torch.Tensor,
+    shards: list[torch.Tensor],
+    spec: HFWeights,
+) -> torch.Tensor:
+    custom_merge = getattr(spec, "merge_dense_shards", None)
+    if callable(custom_merge):
+        merged = custom_merge(name, shards)
+        if merged is not None:
+            return merged
+
+    tp_info = spec.tp_spec(name)
+    if tp_info is None:
+        return tensor
+    split_dim, tp_or_etp = tp_info
+    if tp_or_etp != 0:
+        return tensor
+    return torch.cat(shards, dim=split_dim)
+
+
 def export_hf_weights(
     model: nn.Module | list[nn.Module],
     spec: HFWeights,
@@ -398,6 +795,8 @@ def export_hf_weights(
     limit: int | None = None,
     rank0_only: bool = False,
     export_dtype: str | torch.dtype | None = None,
+    cpu: bool = False,
+    buffer_max_size_bytes: int = DEFAULT_EXPORT_BUFFER_MAX_SIZE_BYTES,
 ) -> Generator[tuple[str, torch.Tensor], None, None]:
     """Export model weights as HF-format (name, tensor) pairs.
 
@@ -418,7 +817,192 @@ def export_hf_weights(
 
     if ps.pp_size <= 1:
         exported_params = 0
-        expert_groups: dict[str, list[tuple[int, str, torch.Tensor]]] = {}
+        expert_bucket: list[tuple[str, torch.Tensor]] = []
+        expert_bucket_bytes = 0
+        packed_expert_buffers: dict[str, dict[int, torch.Tensor]] = {}
+        expert_bucket_limit_bytes = (
+            buffer_max_size_bytes
+            if ps.ep_size <= 1
+            else max(buffer_max_size_bytes // ps.ep_size, 1)
+        )
+        dense_bucket: list[tuple[str, torch.Tensor]] = []
+        dense_bucket_bytes = 0
+        dense_bucket_limit_bytes = (
+            buffer_max_size_bytes
+            if ps.tp_size <= 1
+            else max(buffer_max_size_bytes // ps.tp_size, 1)
+        )
+
+        def _iter_mapped(gathered_tensors: dict[str, torch.Tensor]):
+            if rank0_only and rank != 0:
+                return
+            for native_name, gathered_tensor in gathered_tensors.items():
+                if vocab_size is not None and ("embed" in native_name or "head" in native_name):
+                    gathered_tensor = gathered_tensor[:vocab_size]
+                for hf_name, hf_tensor in _native_to_hf(spec, native_name, gathered_tensor):
+                    yield hf_name, _cast_export_tensor(hf_tensor, resolved_export_dtype)
+
+        def _flush_dense_bucket():
+            nonlocal dense_bucket, dense_bucket_bytes
+            if not dense_bucket:
+                return
+            gathered_bucket = bucketed_all_gather_into_tensor(
+                dense_bucket,
+                group=ps.tp_group,
+                group_size=ps.tp_size,
+                buffer_max_size_bytes=buffer_max_size_bytes,
+            )
+            dense_bucket = []
+            dense_bucket_bytes = 0
+            for native_name, local_tensor, shards in gathered_bucket:
+                merged = _merge_dense_shards(native_name, local_tensor, shards, spec)
+                yield from _iter_mapped({native_name: _maybe_cpu(merged, cpu=cpu)})
+
+        def _flush_expert_bucket():
+            nonlocal expert_bucket, expert_bucket_bytes
+            if not expert_bucket:
+                return
+            gathered_bucket = bucketed_all_gather_into_tensor(
+                expert_bucket,
+                group=ps.ep_group,
+                group_size=ps.ep_size,
+                buffer_max_size_bytes=buffer_max_size_bytes,
+            )
+            expert_bucket = []
+            expert_bucket_bytes = 0
+            experts_per_rank = spec.num_experts // ps.ep_size
+            for native_name, _, shards in gathered_bucket:
+                local_idx = parse_expert_idx(native_name)
+                packed_group_name = getattr(spec, "packed_expert_group_name", None)
+                packed_name = (
+                    packed_group_name(native_name)
+                    if callable(packed_group_name)
+                    else None
+                )
+                for ep_rank, shard in enumerate(shards):
+                    global_idx = ep_rank * experts_per_rank + local_idx
+                    global_name = set_expert_idx(native_name, global_idx)
+                    export_shard = _maybe_cpu(shard, cpu=cpu)
+                    if packed_name is None:
+                        yield from _iter_mapped({global_name: export_shard})
+                        continue
+                    packed_expert_buffers.setdefault(packed_name, {})[
+                        global_idx
+                    ] = export_shard
+                if packed_name is not None:
+                    packed = packed_expert_buffers[packed_name]
+                    if len(packed) == spec.num_experts:
+                        packed_tensor = torch.stack(
+                            [packed[idx] for idx in range(spec.num_experts)], dim=0
+                        )
+                        del packed_expert_buffers[packed_name]
+                        yield from _iter_mapped({packed_name: packed_tensor})
+
+        def _iter_native_params():
+            for chunk in chunks:
+                base_chunk = unwrap_model(chunk)
+                layer_map = (
+                    {
+                        i: base_chunk.layer_indices[i]
+                        for i in range(len(base_chunk.layer_indices))
+                    }
+                    if hasattr(base_chunk, "layer_indices")
+                    else {}
+                )
+                for name, param in base_chunk.named_parameters():
+                    tensor = _cast_export_tensor(
+                        param.data.detach(), resolved_export_dtype
+                    )
+                    yield to_global_layer_name(name, layer_map), tensor
+
+        native_params = _iter_native_params()
+        materialized_params = (
+            _iter_bucketed_materialized_tensors(
+                native_params, buffer_max_size_bytes=buffer_max_size_bytes
+            )
+            if not cpu and limit is None
+            else (
+                (name, _materialize_dtensor(tensor)) for name, tensor in native_params
+            )
+        )
+        for gname, tensor in materialized_params:
+            gathered_one: dict[str, torch.Tensor] = {}
+            if spec.is_expert(gname):
+                yield from _flush_dense_bucket()
+                if limit is None:
+                    tensor = _gather_expert_etp(gname, tensor, spec, ps)
+                    tensor_bytes = tensor.numel() * tensor.element_size()
+                    should_flush = bool(expert_bucket) and (
+                        tensor.dtype != expert_bucket[0][1].dtype
+                        or expert_bucket_bytes + tensor_bytes > expert_bucket_limit_bytes
+                    )
+                    if should_flush:
+                        yield from _flush_expert_bucket()
+                    expert_bucket.append((gname, tensor))
+                    expert_bucket_bytes += tensor_bytes
+                    exported_params += 1
+                    if (
+                        len(expert_bucket) >= 4
+                        or expert_bucket_bytes >= expert_bucket_limit_bytes
+                    ):
+                        yield from _flush_expert_bucket()
+                    continue
+                _gather_expert(gname, tensor, spec, ps, gathered_one, cpu=cpu)
+            else:
+                yield from _flush_expert_bucket()
+                tp_info = spec.tp_spec(gname)
+                is_tp = tp_info is not None and tp_info[1] == 0 and ps.tp_size > 1
+                if is_tp:
+                    tensor_bytes = tensor.numel() * tensor.element_size()
+                    should_flush = bool(dense_bucket) and (
+                        tensor.dtype != dense_bucket[0][1].dtype
+                        or dense_bucket_bytes + tensor_bytes > dense_bucket_limit_bytes
+                    )
+                    if should_flush:
+                        yield from _flush_dense_bucket()
+                    dense_bucket.append((gname, tensor))
+                    dense_bucket_bytes += tensor_bytes
+                    exported_params += 1
+                    if dense_bucket_bytes >= dense_bucket_limit_bytes:
+                        yield from _flush_dense_bucket()
+                    if limit is not None and exported_params >= limit:
+                        yield from _flush_dense_bucket()
+                        return
+                    continue
+
+                yield from _flush_dense_bucket()
+                gathered_one[gname] = _maybe_cpu(tensor, cpu=cpu)
+
+            exported_params += 1
+            yield from _iter_mapped(gathered_one)
+
+            if limit is not None and exported_params >= limit:
+                return
+
+        yield from _flush_dense_bucket()
+        yield from _flush_expert_bucket()
+        return
+
+    # Streaming pp>1 export. The legacy path materialized every PP stage's
+    # gathered dict on every rank (all_gather_object) before the first yield.
+    # Instead: each stage in turn lazily gathers just enough params to fill one
+    # bounded bucket, broadcasts a (name, shape, dtype) header then the tensors
+    # one at a time over the NCCL pp_group; params are yielded and released on
+    # arrival. Peak residency = one bucket + one in-flight param. pp=1 untouched.
+    gather_cpu = cpu
+    emit = not (rank0_only and rank != 0)
+    bcast_device = (
+        torch.device("cuda", torch.cuda.current_device())
+        if torch.cuda.is_available()
+        else torch.device("cpu")
+    )
+
+    def _iter_own_gathered() -> Generator[tuple[str, torch.Tensor], None, None]:
+        """Lazily yield this PP stage's fully TP/ETP/EP-collapsed params.
+
+        Advanced only during this rank's source turn, so at most one bucket of
+        gathered params is ever resident — the whole stage is never built.
+        """
         for chunk in chunks:
             base_chunk = unwrap_model(chunk)
             layer_map = (
@@ -428,104 +1012,86 @@ def export_hf_weights(
             )
             for name, param in base_chunk.named_parameters():
                 gname = to_global_layer_name(name, layer_map)
-                tensor = _materialize_dtensor(param.data.detach())
-
-                gathered_one: dict[str, torch.Tensor] = {}
+                t = _materialize_dtensor(param.data.detach())
                 if spec.is_expert(gname):
-                    if limit is None:
-                        expert_groups.setdefault(_expert_group_key(gname), []).append(
-                            (parse_expert_idx(gname), gname, tensor)
-                        )
-                        exported_params += 1
-                        continue
-                    _gather_expert(gname, tensor, spec, ps, gathered_one)
+                    one: dict[str, torch.Tensor] = {}
+                    _gather_expert(gname, t, spec, ps, one, cpu=False)
+                    for gathered_name, gathered_tensor in one.items():
+                        yield gathered_name, gathered_tensor
                 else:
-                    gathered_one[gname] = _gather_dense(gname, tensor, spec, ps)
+                    yield gname, _gather_dense(gname, t, spec, ps, cpu=False)
 
-                exported_params += 1
-                if not rank0_only or rank == 0:
-                    for native_name, gathered_tensor in gathered_one.items():
-                        if vocab_size is not None and (
-                            "embed" in native_name or "head" in native_name
-                        ):
-                            gathered_tensor = gathered_tensor[:vocab_size]
-                        for hf_name, hf_tensor in spec.native_to_hf(native_name, gathered_tensor):
-                            yield hf_name, _cast_export_tensor(hf_tensor, resolved_export_dtype)
-
-                if limit is not None and exported_params >= limit:
-                    return
-
-        for group_key in sorted(expert_groups):
-            gathered_group: dict[str, torch.Tensor] = {}
-            _gather_expert_group(expert_groups[group_key], spec, ps, gathered_group)
-            if not rank0_only or rank == 0:
-                for native_name in sorted(gathered_group, key=parse_expert_idx):
-                    gathered_tensor = gathered_group[native_name]
-                    for hf_name, hf_tensor in spec.native_to_hf(native_name, gathered_tensor):
-                        yield hf_name, _cast_export_tensor(hf_tensor, resolved_export_dtype)
-        return
-
-    gathered: dict[str, torch.Tensor] = {}
-    for chunk in chunks:
-        base_chunk = unwrap_model(chunk)
-        # Map local layer indices to global for PP
-        layer_map = (
-            {i: base_chunk.layer_indices[i] for i in range(len(base_chunk.layer_indices))}
-            if hasattr(base_chunk, "layer_indices")
-            else {}
-        )
-        for name, param in base_chunk.named_parameters():
-            gname = to_global_layer_name(name, layer_map)
-            t = _materialize_dtensor(param.data.detach())
-
-            if spec.is_expert(gname):
-                _gather_expert(gname, t, spec, ps, gathered)
-            else:
-                gathered[gname] = _gather_dense(gname, t, spec, ps)
-
-    # PP gather
-    if ps.pp_size > 1:
-        all_states: list[dict | None] = [None] * ps.pp_size
-        dist.all_gather_object(all_states, gathered, group=ps.pp_group)
-        gathered = {}
-        for s in all_states:
-            if s is not None:
-                gathered.update(s)
-
-    rank = dist.get_rank() if dist.is_initialized() else 0
-    if rank0_only and rank != 0:
-        return
-
-    # Vocab trim
-    if vocab_size is not None:
-        for key in list(gathered.keys()):
-            if "embed" in key or "head" in key:
-                gathered[key] = gathered[key][:vocab_size]
-
-    # Convert Megatron Lite names → HF names via spec
-    for native_name, tensor in gathered.items():
-        for hf_name, hf_tensor in spec.native_to_hf(native_name, tensor):
+    def _emit_param(native_name: str, tensor: torch.Tensor):
+        tensor = _maybe_cpu(tensor, cpu=gather_cpu)
+        if vocab_size is not None and ("embed" in native_name or "head" in native_name):
+            tensor = tensor[:vocab_size]
+        for hf_name, hf_tensor in _native_to_hf(spec, native_name, tensor):
             yield hf_name, _cast_export_tensor(hf_tensor, resolved_export_dtype)
 
+    own = _iter_own_gathered()
+    for src_pp in range(ps.pp_size):
+        src_global = ps.pp_global_ranks[src_pp]
+        is_source = src_pp == ps.pp_rank
+        while True:
+            bucket: list[tuple[str, torch.Tensor]] = []
+            if is_source:
+                bucket_bytes = 0
+                for gathered_name, gathered_tensor in own:
+                    gathered_tensor = gathered_tensor.to(bcast_device).contiguous()
+                    bucket.append((gathered_name, gathered_tensor))
+                    bucket_bytes += _tensor_nbytes(gathered_tensor)
+                    if bucket_bytes >= buffer_max_size_bytes:
+                        break
+                header: list[Any] = [
+                    [(name, tuple(tensor.shape), tensor.dtype) for name, tensor in bucket]
+                ]
+            else:
+                header = [None]
+            dist.broadcast_object_list(
+                header, src=src_global, group=ps.pp_group, device=bcast_device
+            )
+            entries = header[0]
+            if not entries:
+                break  # empty header = end of this stage's stream
+            for idx, (native_name, shape, dtype) in enumerate(entries):
+                if is_source:
+                    tensor = bucket[idx][1]
+                else:
+                    tensor = torch.empty(shape, dtype=dtype, device=bcast_device)
+                dist.broadcast(tensor, src=src_global, group=ps.pp_group)
+                if emit:
+                    yield from _emit_param(native_name, tensor)
+                del tensor
+            del bucket
+    return
 
-def _gather_dense(name: str, tensor: torch.Tensor, spec: HFWeights, ps) -> torch.Tensor:
+
+def _gather_dense(
+    name: str, tensor: torch.Tensor, spec: HFWeights, ps, *, cpu: bool = True
+) -> torch.Tensor:
     """Gather a dense (non-expert) param across TP."""
     custom_gather = getattr(spec, "gather_dense", None)
     if callable(custom_gather):
         gathered = custom_gather(name, tensor, ps)
         if gathered is not None:
-            return gathered.cpu()
+            return _maybe_cpu(gathered, cpu=cpu)
 
     tp_info = spec.tp_spec(name)
     if tp_info is not None and ps.tp_size > 1:
         split_d, tp_or_etp = tp_info
         if tp_or_etp == 0:
             tensor = allgather_concat(tensor, ps.tp_size, ps.tp_group, dim=split_d)
-    return tensor.cpu()
+    return _maybe_cpu(tensor, cpu=cpu)
 
 
 def _gather_expert(
-    name: str, tensor: torch.Tensor, spec: HFWeights, ps, out: dict[str, torch.Tensor]
+    name: str,
+    tensor: torch.Tensor,
+    spec: HFWeights,
+    ps,
+    out: dict[str, torch.Tensor],
+    *,
+    cpu: bool = True,
 ) -> None:
     """Gather an expert param across ETP + EP."""
     tensor = _gather_expert_etp(name, tensor, spec, ps)
@@ -535,12 +1101,12 @@ def _gather_expert(
     if ps.ep_size > 1 and ps.ep_group is not None:
         n_local = spec.num_experts // ps.ep_size
         ep_gathered = [torch.empty_like(tensor) for _ in range(ps.ep_size)]
-        dist.all_gather(ep_gathered, tensor.contiguous(), group=ps.ep_group)
+        _ep_all_gather(ep_gathered, tensor.contiguous(), ps.ep_group)
         for ep_rank, ep_tensor in enumerate(ep_gathered):
             global_idx = ep_rank * n_local + local_idx
-            out[set_expert_idx(name, global_idx)] = ep_tensor.cpu()
+            out[set_expert_idx(name, global_idx)] = _maybe_cpu(ep_tensor, cpu=cpu)
     else:
-        out[name] = tensor.cpu()
+        out[name] = _maybe_cpu(tensor, cpu=cpu)
 
 
 def _gather_expert_etp(name: str, tensor: torch.Tensor, spec: HFWeights, ps) -> torch.Tensor:
@@ -555,56 +1121,6 @@ def _gather_expert_etp(name: str, tensor: torch.Tensor, spec: HFWeights, ps) -> 
     return tensor
 
 
-def _expert_group_key(name: str) -> str:
-    return re.sub(r"weight\d+$", "weight", name)
-
-
-def _gather_expert_group(
-    entries: list[tuple[int, str, torch.Tensor]], spec: HFWeights, ps, out: dict[str, torch.Tensor]
-) -> None:
-    """Gather local experts in one EP collective per layer/kind."""
-    prepared = [
-        (local_idx, name, _gather_expert_etp(name, tensor, spec, ps))
-        for local_idx, name, tensor in sorted(entries)
-    ]
-    packed_group_name = getattr(spec, "packed_expert_group_name", None)
-    if callable(packed_group_name):
-        packed_name = packed_group_name(prepared[0][1])
-        if packed_name is not None:
-            if ps.ep_size <= 1 or ps.ep_group is None:
-                out[packed_name] = torch.stack(
-                    [tensor.contiguous() for _, _, tensor in prepared], dim=0
-                ).cpu()
-                return
-
-            sample = prepared[0][2]
-            packed = torch.empty((spec.num_experts, *sample.shape), dtype=sample.dtype, device="cpu")
-            for batch_start in range(0, len(prepared), 4):
-                batch = prepared[batch_start : batch_start + 4]
-                stacked = torch.stack([tensor.contiguous() for _, _, tensor in batch], dim=0)
-                ep_gathered = [torch.empty_like(stacked) for _ in range(ps.ep_size)]
-                dist.all_gather(ep_gathered, stacked, group=ps.ep_group)
-                for ep_rank, ep_tensor in enumerate(ep_gathered):
-                    for batch_idx, (local_idx, _, _) in enumerate(batch):
-                        packed[ep_rank * (spec.num_experts // ps.ep_size) + local_idx].copy_(ep_tensor[batch_idx])
-            out[packed_name] = packed
-            return
-
-    if ps.ep_size <= 1 or ps.ep_group is None:
-        for _, name, tensor in prepared:
-            out[name] = tensor.cpu()
-        return
-
-    n_local = spec.num_experts // ps.ep_size
-    stacked = torch.stack([tensor.contiguous() for _, _, tensor in prepared], dim=0)
-    ep_gathered = [torch.empty_like(stacked) for _ in range(ps.ep_size)]
-    dist.all_gather(ep_gathered, stacked, group=ps.ep_group)
-    for ep_rank, ep_tensor in enumerate(ep_gathered):
-        for slot, (local_idx, name, _) in enumerate(prepared):
-            global_idx = ep_rank * n_local + local_idx
-            out[set_expert_idx(name, global_idx)] = ep_tensor[slot].cpu()
-
-
 def save_hf_weights(
     model: nn.Module | list[nn.Module],
     hf_path: str,
@@ -615,7 +1131,11 @@ def save_hf_weights(
 ) -> None:
     """Export + write to safetensors."""
     rank = dist.get_rank() if dist.is_initialized() else 0
-    out = dict(export_hf_weights(model, spec, ps, vocab_size=vocab_size, rank0_only=True))
+    out = dict(
+        export_hf_weights(
+            model, spec, ps, vocab_size=vocab_size, rank0_only=True, cpu=True
+        )
+    )
     if rank == 0 and out:
         save_safetensors(out, hf_path)
     if dist.is_initialized():

--- a/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/hf_weights.py
@@ -815,6 +815,27 @@ def export_hf_weights(
     rank = dist.get_rank() if dist.is_initialized() else 0
     resolved_export_dtype = _resolve_export_dtype(export_dtype)
 
+    def _iter_native_tensors():
+        """Yield parameters plus model-declared persistent export buffers."""
+        is_export_buffer = getattr(spec, "is_export_buffer", None)
+        for chunk in chunks:
+            base_chunk = unwrap_model(chunk)
+            layer_map = (
+                {
+                    i: base_chunk.layer_indices[i]
+                    for i in range(len(base_chunk.layer_indices))
+                }
+                if hasattr(base_chunk, "layer_indices")
+                else {}
+            )
+            for name, param in base_chunk.named_parameters():
+                yield to_global_layer_name(name, layer_map), param.data.detach()
+            if callable(is_export_buffer):
+                for name, buffer in base_chunk.named_buffers():
+                    global_name = to_global_layer_name(name, layer_map)
+                    if is_export_buffer(global_name):
+                        yield global_name, buffer.detach()
+
     if ps.pp_size <= 1:
         exported_params = 0
         expert_bucket: list[tuple[str, torch.Tensor]] = []
@@ -898,24 +919,10 @@ def export_hf_weights(
                         del packed_expert_buffers[packed_name]
                         yield from _iter_mapped({packed_name: packed_tensor})
 
-        def _iter_native_params():
-            for chunk in chunks:
-                base_chunk = unwrap_model(chunk)
-                layer_map = (
-                    {
-                        i: base_chunk.layer_indices[i]
-                        for i in range(len(base_chunk.layer_indices))
-                    }
-                    if hasattr(base_chunk, "layer_indices")
-                    else {}
-                )
-                for name, param in base_chunk.named_parameters():
-                    tensor = _cast_export_tensor(
-                        param.data.detach(), resolved_export_dtype
-                    )
-                    yield to_global_layer_name(name, layer_map), tensor
-
-        native_params = _iter_native_params()
+        native_params = (
+            (name, _cast_export_tensor(tensor, resolved_export_dtype))
+            for name, tensor in _iter_native_tensors()
+        )
         materialized_params = (
             _iter_bucketed_materialized_tensors(
                 native_params, buffer_max_size_bytes=buffer_max_size_bytes
@@ -1003,23 +1010,15 @@ def export_hf_weights(
         Advanced only during this rank's source turn, so at most one bucket of
         gathered params is ever resident — the whole stage is never built.
         """
-        for chunk in chunks:
-            base_chunk = unwrap_model(chunk)
-            layer_map = (
-                {i: base_chunk.layer_indices[i] for i in range(len(base_chunk.layer_indices))}
-                if hasattr(base_chunk, "layer_indices")
-                else {}
-            )
-            for name, param in base_chunk.named_parameters():
-                gname = to_global_layer_name(name, layer_map)
-                t = _materialize_dtensor(param.data.detach())
-                if spec.is_expert(gname):
-                    one: dict[str, torch.Tensor] = {}
-                    _gather_expert(gname, t, spec, ps, one, cpu=False)
-                    for gathered_name, gathered_tensor in one.items():
-                        yield gathered_name, gathered_tensor
-                else:
-                    yield gname, _gather_dense(gname, t, spec, ps, cpu=False)
+        for gname, tensor in _iter_native_tensors():
+            tensor = _materialize_dtensor(tensor)
+            if spec.is_expert(gname):
+                one: dict[str, torch.Tensor] = {}
+                _gather_expert(gname, tensor, spec, ps, one, cpu=False)
+                for gathered_name, gathered_tensor in one.items():
+                    yield gathered_name, gathered_tensor
+            else:
+                yield gname, _gather_dense(gname, tensor, spec, ps, cpu=False)
 
     def _emit_param(native_name: str, tensor: torch.Tensor):
         tensor = _maybe_cpu(tensor, cpu=gather_cpu)
@@ -1121,6 +1120,90 @@ def _gather_expert_etp(name: str, tensor: torch.Tensor, spec: HFWeights, ps) -> 
     return tensor
 
 
+def stream_export_to_shards(
+    export_iter: Iterable[tuple[str, torch.Tensor]],
+    path: str,
+    *,
+    shard_size_bytes: int = 5 * 1024**3,
+) -> None:
+    """Consume ``export_iter`` and write sharded safetensors on rank 0.
+
+    Flushes to disk once a shard reaches ``shard_size_bytes`` (default 5 GiB)
+    so rank 0's peak CPU RAM stays at ~one shard instead of the whole model.
+    Non-rank-0 still drains the iterator to drive collective communication
+    inside model-specific ``export_hf_weights`` implementations.
+
+    Emits ``model.safetensors`` when the export fits in a single shard, or
+    ``model-{i:05d}-of-{total:05d}.safetensors`` + ``model.safetensors.index.json``
+    when multiple shards are produced (HF-compatible layout).
+    """
+    rank = dist.get_rank() if dist.is_initialized() else 0
+    if rank == 0:
+        os.makedirs(path, exist_ok=True)
+        # Reusing an export directory must not leave stale shards or an index
+        # that describes a previous export.  Restrict cleanup to files owned by
+        # this writer; unrelated user files in the directory are preserved.
+        stale_patterns = (
+            re.compile(r"^model(?:-\d{5}-of-\d{5})?\.safetensors$"),
+            re.compile(r"^model\.safetensors\.index\.json$"),
+            re.compile(r"^\.model-shard-\d{5}\.safetensors$"),
+        )
+        for entry in os.listdir(path):
+            if any(pattern.fullmatch(entry) for pattern in stale_patterns):
+                os.remove(os.path.join(path, entry))
+
+    shard: dict[str, torch.Tensor] = {}
+    shard_bytes = 0
+    tmp_names: list[str] = []
+    shard_keys: list[list[str]] = []
+    total_size = 0
+
+    def _flush() -> None:
+        nonlocal shard, shard_bytes
+        if not shard:
+            return
+        tmp = f".model-shard-{len(tmp_names) + 1:05d}.safetensors"
+        save_safetensors(shard, path, filename=tmp)
+        tmp_names.append(tmp)
+        shard_keys.append(list(shard.keys()))
+        shard = {}
+        shard_bytes = 0
+
+    for name, tensor in export_iter:
+        if rank != 0:
+            continue
+        nbytes = _tensor_nbytes(tensor)
+        if shard and shard_bytes + nbytes > shard_size_bytes:
+            _flush()
+        shard[name] = tensor
+        shard_bytes += nbytes
+        total_size += nbytes
+
+    if rank == 0:
+        _flush()
+        total = len(tmp_names)
+        if total == 1:
+            os.rename(
+                os.path.join(path, tmp_names[0]),
+                os.path.join(path, "model.safetensors"),
+            )
+        elif total > 1:
+            weight_map: dict[str, str] = {}
+            for idx, (tmp, keys) in enumerate(zip(tmp_names, shard_keys), start=1):
+                final = f"model-{idx:05d}-of-{total:05d}.safetensors"
+                os.rename(os.path.join(path, tmp), os.path.join(path, final))
+                for k in keys:
+                    weight_map[k] = final
+            with open(os.path.join(path, "model.safetensors.index.json"), "w") as f:
+                json.dump(
+                    {"metadata": {"total_size": total_size}, "weight_map": weight_map},
+                    f,
+                )
+
+    if dist.is_initialized():
+        dist.barrier()
+
+
 def save_hf_weights(
     model: nn.Module | list[nn.Module],
     hf_path: str,
@@ -1128,15 +1211,13 @@ def save_hf_weights(
     ps,
     *,
     vocab_size: int | None = None,
+    shard_size_bytes: int = 5 * 1024**3,
 ) -> None:
-    """Export + write to safetensors."""
-    rank = dist.get_rank() if dist.is_initialized() else 0
-    out = dict(
+    """Export + write sharded safetensors via ``stream_export_to_shards``."""
+    stream_export_to_shards(
         export_hf_weights(
             model, spec, ps, vocab_size=vocab_size, rank0_only=True, cpu=True
-        )
+        ),
+        hf_path,
+        shard_size_bytes=shard_size_bytes,
     )
-    if rank == 0 and out:
-        save_safetensors(out, hf_path)
-    if dist.is_initialized():
-        dist.barrier()

--- a/experimental/lite/megatron/lite/primitive/ckpt/weight_sync_fingerprint.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/weight_sync_fingerprint.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Low-overhead fingerprints for online rollout weight-transfer streams."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from collections.abc import Iterable
+
+import torch
+
+_ENV_NAME = "MLITE_WEIGHT_SYNC_FINGERPRINT"
+_REPORT_PREFIX = "MLITE_WEIGHT_SYNC_FINGERPRINT "
+
+
+def weight_sync_fingerprint_enabled() -> bool:
+    return os.getenv(_ENV_NAME, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _sample_payload(name: str, tensor: torch.Tensor) -> tuple[bool, bytes]:
+    """Sample data for a stable subset of tensors without copying full weights."""
+    name_hash = hashlib.sha256(name.encode()).digest()
+    important = any(
+        marker in name
+        for marker in ("embed_tokens", "lm_head", "attn_sink", "expert_bias", "tid2eid")
+    )
+    sampled = important or name_hash[0] < 16  # About 1/16 of ordinary tensors.
+    if not sampled or tensor.numel() == 0:
+        return sampled, b""
+
+    raw = tensor.detach().contiguous().view(torch.uint8).reshape(-1)
+    count = min(256, raw.numel())
+    if count == raw.numel():
+        sample = raw
+    else:
+        # ``torch.linspace(..., dtype=int64)`` computes through floating point
+        # on CUDA.  For multi-billion-byte expert tensors its rounded endpoint
+        # can become ``numel`` and trip ScatterGatherKernel's bounds assert.
+        # Integer arithmetic keeps every index in [0, numel - 1].
+        indices = _sample_indices(raw.numel(), count, device=raw.device)
+        sample = raw.index_select(0, indices)
+    return sampled, bytes(sample.cpu().tolist())
+
+
+def _sample_indices(numel: int, count: int, *, device=None) -> torch.Tensor:
+    if not 1 <= count <= numel:
+        raise ValueError(f"expected 1 <= count <= numel, got count={count}, numel={numel}")
+    if count == 1:
+        return torch.zeros(1, dtype=torch.int64, device=device)
+    positions = torch.arange(count, dtype=torch.int64, device=device)
+    return positions.mul_(numel - 1).floor_divide_(count - 1)
+
+
+def tensor_fingerprint_record(name: str, tensor: torch.Tensor) -> dict[str, object]:
+    sampled, payload = _sample_payload(name, tensor)
+    metadata = {
+        "name": name,
+        "dtype": str(tensor.dtype),
+        "shape": list(tensor.shape),
+        "nbytes": tensor.nbytes,
+        "sampled": sampled,
+    }
+    digest = hashlib.sha256()
+    digest.update(json.dumps(metadata, sort_keys=True, separators=(",", ":")).encode())
+    digest.update(payload)
+    metadata["sha256"] = digest.hexdigest()
+    return metadata
+
+
+def stream_fingerprint(records: Iterable[dict[str, object]]) -> dict[str, object]:
+    ordered = sorted(records, key=lambda record: str(record["name"]))
+    digest = hashlib.sha256()
+    total_bytes = 0
+    sampled_tensors = 0
+    for record in ordered:
+        digest.update(str(record["sha256"]).encode())
+        total_bytes += int(record["nbytes"])
+        sampled_tensors += int(bool(record["sampled"]))
+    return {
+        "sha256": digest.hexdigest(),
+        "tensors": len(ordered),
+        "sampled_tensors": sampled_tensors,
+        "bytes": total_bytes,
+    }
+
+
+def report_stream_fingerprint(role: str, rank: int, records) -> None:
+    report = {"role": role, "rank": rank, **stream_fingerprint(records)}
+    print(_REPORT_PREFIX + json.dumps(report, sort_keys=True), flush=True)
+
+
+__all__ = [
+    "report_stream_fingerprint",
+    "stream_fingerprint",
+    "tensor_fingerprint_record",
+    "weight_sync_fingerprint_enabled",
+]

--- a/experimental/lite/megatron/lite/primitive/ckpt/weight_sync_probe.py
+++ b/experimental/lite/megatron/lite/primitive/ckpt/weight_sync_probe.py
@@ -1,0 +1,138 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Opt-in wall-time and payload accounting for rollout weight synchronization."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from typing import Iterator
+
+import torch
+import torch.distributed as dist
+
+_ENV_NAME = "MLITE_WEIGHT_SYNC_PROBE"
+_REPORT_PREFIX = "MLITE_WEIGHT_SYNC_PROBE "
+
+
+def weight_sync_probe_enabled() -> bool:
+    return os.getenv(_ENV_NAME, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+@dataclass
+class _StageStats:
+    calls: int = 0
+    bytes: int = 0
+    wall_s: float = 0.0
+
+
+@dataclass
+class _Session:
+    backend: str
+    started_at: float
+    depth: int = 1
+    stages: dict[str, _StageStats] = field(default_factory=dict)
+
+
+@dataclass
+class ProbeSample:
+    nbytes: int = 0
+
+
+class WeightSyncProbe:
+    def __init__(self) -> None:
+        self._session: ContextVar[_Session | None] = ContextVar(
+            "mlite_weight_sync_probe_session", default=None
+        )
+
+    @property
+    def active(self) -> bool:
+        return weight_sync_probe_enabled() and self._session.get() is not None
+
+    @contextmanager
+    def session(self, backend: str) -> Iterator[None]:
+        if not weight_sync_probe_enabled():
+            yield
+            return
+
+        current = self._session.get()
+        if current is not None:
+            current.depth += 1
+            try:
+                yield
+            finally:
+                current.depth -= 1
+            return
+
+        session = _Session(backend=backend, started_at=time.perf_counter())
+        token = self._session.set(session)
+        try:
+            yield
+        finally:
+            total_wall_s = time.perf_counter() - session.started_at
+            self._session.reset(token)
+            rank = (
+                dist.get_rank() if dist.is_available() and dist.is_initialized() else 0
+            )
+            report = {
+                "backend": session.backend,
+                "rank": rank,
+                "stages": {
+                    name: {
+                        "calls": stats.calls,
+                        "bytes": stats.bytes,
+                        "wall_s": stats.wall_s,
+                    }
+                    for name, stats in sorted(session.stages.items())
+                },
+                "total_wall_s": total_wall_s,
+            }
+            print(_REPORT_PREFIX + json.dumps(report, sort_keys=True), flush=True)
+
+    @contextmanager
+    def measure(
+        self, stage: str, *, nbytes: int = 0, device: torch.device | str | None = None
+    ) -> Iterator[ProbeSample]:
+        session = self._session.get()
+        if not weight_sync_probe_enabled() or session is None:
+            yield ProbeSample(nbytes=nbytes)
+            return
+
+        if device is not None and torch.cuda.is_available():
+            torch.cuda.synchronize(device)
+        started_at = time.perf_counter()
+        sample = ProbeSample(nbytes=nbytes)
+        try:
+            yield sample
+        finally:
+            if device is not None and torch.cuda.is_available():
+                torch.cuda.synchronize(device)
+            stats = session.stages.setdefault(stage, _StageStats())
+            stats.calls += 1
+            stats.bytes += int(sample.nbytes)
+            stats.wall_s += time.perf_counter() - started_at
+
+
+_PROBE = WeightSyncProbe()
+
+
+def get_weight_sync_probe() -> WeightSyncProbe:
+    return _PROBE
+
+
+@contextmanager
+def weight_sync_probe_session(backend: str) -> Iterator[None]:
+    with _PROBE.session(backend):
+        yield
+
+
+__all__ = [
+    "ProbeSample",
+    "WeightSyncProbe",
+    "get_weight_sync_probe",
+    "weight_sync_probe_enabled",
+    "weight_sync_probe_session",
+]

--- a/experimental/lite/megatron/lite/primitive/modules/attention/csa.py
+++ b/experimental/lite/megatron/lite/primitive/modules/attention/csa.py
@@ -5,11 +5,28 @@ from typing import Any
 import torch
 import torch.nn as nn
 import transformer_engine.pytorch as te
-from megatron.lite.primitive.modules.attention.dsa import rotate_activation
-from megatron.lite.primitive.modules.attention.cp import (
-    compress_contiguous_chunks_for_cp,
-    iter_cp_sources,
+# Zero-copy imports of the DSv4 THD-CP helpers that live in Megatron Core. The
+# lite CSA module reuses Core's differentiable kernels, CP row-mapping utilities,
+# and CuTeDSL layout kernels rather than vendoring them; see the module docstring
+# of ``csa_cp_utils`` / ``csa_cp_layout_kernels`` for the exact contracts.
+from megatron.core.tensor_parallel.mappings import gather_from_sequence_parallel_region
+from megatron.core.transformer.experimental_attention_variant import (
+    csa_cp_layout_kernels,
+    csa_cp_utils as cp_utils,
 )
+from megatron.core.transformer.experimental_attention_variant.csa import (
+    _unfused_indexer_sparse_attn_from_topk,
+    unfused_compressed_sparse_attn,
+)
+from megatron.core.transformer.experimental_attention_variant.dsa import (
+    DSAIndexerLossAutoScaler,
+    DSAIndexerLossLoggingHelper,
+)
+from megatron.core.transformer.experimental_attention_variant.dsa_kernels import (
+    FusedIndexerSparseAttnFromTopkFunc,
+    dsa_sparse_attn,
+)
+from megatron.lite.primitive.modules.attention.dsa import rotate_activation
 from megatron.lite.primitive.parallel.state import ParallelState
 from megatron.lite.primitive.utils.rotary import (
     _yarn_find_correction_range,
@@ -182,21 +199,87 @@ class CompressedSequenceCompressor(nn.Module):
         compressed = apply_partial_rope(compressed, cos, sin, self.rope_head_dim)
         return rotate_activation(compressed) if self.rotate else compressed
 
+    def _overlap_transform_thd(
+        self, tensor: torch.Tensor, is_first_in_seg: torch.Tensor, fill_value: float
+    ) -> torch.Tensor:
+        """Batched overlapping-window transform for the THD (pre-grouped) layout.
 
-def _source_scores_mask(
-    q_positions: torch.Tensor, k_positions: torch.Tensor, *, sliding_window: int
-) -> torch.Tensor:
-    q_pos = q_positions.unsqueeze(-1)
-    k_pos = k_positions.unsqueeze(1)
-    return (k_pos <= q_pos) & (k_pos >= q_pos - sliding_window + 1)
+        Mirrors Core ``Compressor._overlap_transform_thd``: operates on the flat
+        ``(total_comp, ratio, 1, coff * head_dim)`` tensor from all segments at
+        once. ``is_first_in_seg`` is a ``(total_comp,)`` bool mask, ``True`` for
+        each compressed entry that starts a new segment (no predecessor group).
+        Output shape ``(total_comp, 2 * ratio, 1, head_dim)``.
+        """
+        n, ratio, b_dim, _ = tensor.size()
+        d = self.head_dim
+        out = tensor.new_full((n, 2 * ratio, b_dim, d), fill_value)
+        out[:, ratio:] = tensor[:, :, :, d:]
+        prev_data = torch.roll(tensor[:, :, :, :d], shifts=1, dims=0)
+        prev_data[is_first_in_seg] = fill_value
+        out[:, :ratio] = prev_data
+        return out
 
+    def _forward_thd(
+        self,
+        hidden_compact: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        *,
+        max_seqlen_q: int,
+        compressed_group_ids: torch.Tensor,
+    ) -> tuple[torch.Tensor | None, None]:
+        """Pre-grouped THD compression for the DSv4 CP path.
 
-def _compressed_scores_mask(
-    q_positions: torch.Tensor, comp_positions: torch.Tensor, *, ratio: int
-) -> torch.Tensor:
-    visible = (q_positions + 1) // ratio
-    comp_ids = comp_positions // ratio
-    return comp_ids.unsqueeze(1) < visible.unsqueeze(-1)
+        ``hidden_compact`` is ``(compact_group_capacity * ratio, 1, hidden)``,
+        already packed into ratio-sized groups by
+        ``cp_utils.prepare_cp_compressor_input``; ``compressed_group_ids`` is
+        ``(compact_group_capacity,)`` int32 giving each compressed group's
+        per-sequence compressed id (its RoPE position is ``id * ratio``).
+
+        Reproduces Core ``Compressor._forward_thd`` pre-grouped semantics using
+        lite's compressor params (``wkv``/``wgate``/``ape``/``norm``) and lite's
+        RoPE convention (``build_compressed_rope_cos_sin`` + ``apply_partial_rope``)
+        so the CP path stays numerically identical to lite's BSHD path. ``cu_seqlens``
+        and ``max_seqlen_q`` are accepted to match Core's signature; they are only
+        needed by Core's fused-RoPE cache, which lite does not use.
+
+        Returns ``(compressed_thd (total_comp, 1, head_dim), None)``.
+        """
+        del cu_seqlens, max_seqlen_q  # Only used by Core's fused-RoPE cache path.
+        ratio = self.compress_ratio
+        total_comp = int(compressed_group_ids.shape[0])
+        if total_comp == 0:
+            return None, None
+        kv = self.wkv(hidden_compact)  # (total_comp * ratio, 1, coff * head_dim)
+        gate = self.wgate(hidden_compact)
+        kv_grouped = kv.reshape(total_comp, ratio, 1, -1)
+        gate_grouped = gate.reshape(total_comp, ratio, 1, -1)
+        gate_grouped = gate_grouped + self.ape.view(1, ratio, 1, -1).to(gate_grouped.device)
+        if self.overlap:
+            is_first = compressed_group_ids[:total_comp] == 0
+            kv_grouped = self._overlap_transform_thd(kv_grouped, is_first, 0.0)
+            gate_grouped = self._overlap_transform_thd(gate_grouped, is_first, float("-inf"))
+        # Non-overlap (coff == 1): kv_grouped/gate_grouped are already
+        # (total_comp, ratio, 1, head_dim); no windowing needed.
+        weights = torch.softmax(gate_grouped.float(), dim=1).to(kv_grouped.dtype)
+        compressed = (kv_grouped * weights).sum(dim=1)  # (total_comp, 1, head_dim)
+        compressed = self.norm(compressed)
+        positions = compressed_group_ids[:total_comp].clamp_min(0).to(torch.long) * ratio
+        cos, sin = build_compressed_rope_cos_sin(
+            positions.view(1, total_comp),
+            self.rope_head_dim,
+            self.config.compress_rope_theta,
+            config=self.config,
+            use_yarn=ratio > 1,
+            device=compressed.device,
+            dtype=compressed.dtype,
+        )
+        # apply_partial_rope wants the sequence axis at dim -2; view as (1, total_comp, d).
+        compressed = compressed.transpose(0, 1)  # (1, total_comp, head_dim)
+        compressed = apply_partial_rope(compressed, cos, sin, self.rope_head_dim)
+        compressed = compressed.transpose(0, 1)  # (total_comp, 1, head_dim)
+        if self.rotate:
+            compressed = rotate_activation(compressed)
+        return compressed, None
 
 
 def _window_topk_indices(
@@ -241,15 +324,30 @@ class CompressedSparseAttention(nn.Module):
         *,
         layer_idx: int,
         ps: ParallelState,
+        apply_dsa_kernel_fusion: bool = True,
+        dsa_indexer_loss_coeff: float = 0.0,
+        dsa_indexer_use_sparse_loss: bool = False,
+        calculate_per_token_loss: bool = False,
     ):
         super().__init__()
         self.config = config
         self.ps = ps
+        self.layer_idx = layer_idx
         self.attention_backend = "torch"
         self.num_heads = config.num_attention_heads
         self.head_dim = config.head_dim
         self.rope_head_dim = config.qk_rope_head_dim
+        self.softmax_scale = self.head_dim**-0.5
         self.num_heads_per_group = config.num_attention_heads // config.o_groups
+        # Kernel / indexer-loss knobs are implementation config (not part of the
+        # HF model config), threaded as constructor arguments like GLM-5's DSA.
+        # Fused DSA kernels are the production default; the unfused sparse-attn /
+        # indexer-loss path (Core's ``_unfused_indexer_sparse_attn_from_topk``) is
+        # a debug fallback selected via ``apply_dsa_kernel_fusion=False``.
+        self.apply_dsa_kernel_fusion = apply_dsa_kernel_fusion
+        self.dsa_indexer_loss_coeff = dsa_indexer_loss_coeff
+        self.dsa_indexer_use_sparse_loss = dsa_indexer_use_sparse_loss
+        self.calculate_per_token_loss = calculate_per_token_loss
         # MTP layers use layer_idx == num_hidden_layers (+i), which is past the
         # per-decoder-layer compress_ratios list (length num_hidden_layers); fall
         # back to the last real layer's ratio so the MTP CSA still builds.
@@ -287,7 +385,17 @@ class CompressedSparseAttention(nn.Module):
         *,
         position_ids: torch.Tensor,
         attention_mask: torch.Tensor | None = None,
+        packed_seq_params: Any = None,
     ) -> torch.Tensor:
+        # THD packed sequences take the primary DSv4 CP path. THD is the only
+        # sequence-parallel route now: the BSHD dense fallback has been removed.
+        if packed_seq_params is not None:
+            if attention_mask is not None:
+                raise ValueError(
+                    "THD packed CSA expects attention_mask=None; masks are derived "
+                    "from cu_seqlens / position_ids."
+                )
+            return self._forward_thd_packed(x, position_ids, packed_seq_params)
         if self.ps.cp_size > 1 and attention_mask is not None:
             raise ValueError("CP expects attention_mask=None; masks are derived from position_ids.")
         batch, seq_len, _ = x.shape
@@ -339,139 +447,15 @@ class CompressedSparseAttention(nn.Module):
                 sin=sin,
             )
 
-        dense_score_parts = []
-        dense_value_parts = []
-        for _source_rank, source_kv, source_pos in iter_cp_sources(
-            kv,
-            position_ids,
-            cp_rank=self.ps.cp_rank,
-            cp_size=self.ps.cp_size,
-            cp_group=self.ps.cp_group,
-        ):
-            source_heads = source_kv.expand(-1, self.num_heads, -1, -1)
-            scores = torch.matmul(q.float(), source_heads.float().transpose(-1, -2)) / (
-                self.head_dim**0.5
-            )
-            source_mask = _source_scores_mask(
-                position_ids,
-                source_pos,
-                sliding_window=self.config.sliding_window,
-            ).unsqueeze(1)
-            scores = scores.masked_fill(~source_mask, -float("inf"))
-            dense_score_parts.append(scores)
-            dense_value_parts.append(source_heads)
-        dense_scores = torch.cat(dense_score_parts, dim=-1)
-        if attention_mask is not None:
-            dense_scores = dense_scores + attention_mask.to(dtype=dense_scores.dtype)
-        score_parts = [dense_scores]
-        value_parts = [torch.cat(dense_value_parts, dim=2)]
-
-        if self.compressor is not None:
-            compressed_pack = compress_contiguous_chunks_for_cp(
-                self.compressor,
-                x,
-                position_ids=position_ids,
-                cp_rank=self.ps.cp_rank,
-                cp_size=self.ps.cp_size,
-                cp_group=self.ps.cp_group,
-                compress_kwargs={"rope_theta": self.config.compress_rope_theta},
-            )
-        else:
-            compressed_pack = None
-        if compressed_pack is not None:
-            compressed, compressed_pos = compressed_pack
-            compressed, compressed_pos = self._gather_cp_sources(
-                compressed, compressed_pos, seq_dim=2
-            )
-            compressed_values = compressed.expand(-1, self.num_heads, -1, -1)
-            compressed_scores = torch.matmul(
-                q.float(), compressed_values.float().transpose(-1, -2)
-            ) / (self.head_dim**0.5)
-            compressed_valid = _compressed_scores_mask(
-                position_ids,
-                compressed_pos,
-                ratio=self.compress_ratio,
-            ).unsqueeze(1)
-            compressed_scores = compressed_scores.masked_fill(~compressed_valid, -float("inf"))
-
-            if self.indexer is not None:
-                index_comp_pack = compress_contiguous_chunks_for_cp(
-                    self.indexer.compressor,
-                    x,
-                    position_ids=position_ids,
-                    cp_rank=self.ps.cp_rank,
-                    cp_size=self.ps.cp_size,
-                    cp_group=self.ps.cp_group,
-                    compress_kwargs={"rope_theta": self.config.compress_rope_theta},
-                )
-                if index_comp_pack is not None:
-                    index_comp, index_pos = index_comp_pack
-                    index_comp, index_pos = self._gather_cp_sources(
-                        index_comp, index_pos, seq_dim=2
-                    )
-                    idx_cos, idx_sin = build_compressed_rope_cos_sin(
-                        position_ids,
-                        self.indexer.rope_head_dim,
-                        self.config.compress_rope_theta,
-                        config=self.config,
-                        use_yarn=self.compress_ratio > 1,
-                        device=x.device,
-                        dtype=x.dtype,
-                    )
-                    q_idx = (
-                        self.indexer.wq_b(q_low)
-                        .view(
-                            batch, seq_len, self.indexer.index_n_heads, self.indexer.index_head_dim
-                        )
-                        .transpose(1, 2)
-                    )
-                    q_idx = apply_partial_rope(q_idx, idx_cos, idx_sin, self.indexer.rope_head_dim)
-                    index_weights = (
-                        self.indexer.weights_proj(x).float()
-                        * (self.indexer.index_n_heads**-0.5)
-                        * self.indexer.softmax_scale
-                    )
-                    k_idx = index_comp.squeeze(1)
-                    index_scores = torch.einsum(
-                        "bhsd,btd->bsht", q_idx.float(), k_idx.float()
-                    ).relu()
-                    index_scores = (index_scores * index_weights.unsqueeze(-1)).sum(dim=2)
-                    index_valid = _compressed_scores_mask(
-                        position_ids,
-                        index_pos,
-                        ratio=self.compress_ratio,
-                    )
-                    index_scores = index_scores.masked_fill(~index_valid, -float("inf"))
-                    topk = min(self.indexer.index_topk, index_scores.size(-1))
-                    topk_indices = index_scores.topk(topk, dim=-1).indices
-                    topk_mask = torch.zeros_like(index_scores, dtype=torch.bool)
-                    topk_mask.scatter_(-1, topk_indices, True)
-                    compressed_scores = compressed_scores + index_scores.unsqueeze(1)
-                    compressed_scores = compressed_scores.masked_fill(
-                        ~topk_mask.unsqueeze(1), -float("inf")
-                    )
-            score_parts.append(compressed_scores)
-            value_parts.append(compressed_values)
-
-        scores = torch.cat(score_parts, dim=-1)
-        sink = (
-            self.sinks.view(1, self.num_heads, 1, 1)
-            .expand(batch, -1, seq_len, -1)
-            .to(dtype=scores.dtype)
+        # The BSHD dense-softmax fallback (and its CP all-gather loop) has been
+        # removed: DSv4 sequence parallelism now goes exclusively through the THD
+        # packed CP path (``packed_seq_params is not None`` above), and the only
+        # supported BSHD routes are the CP=1 fused sparse kernels dispatched above.
+        raise NotImplementedError(
+            "DSv4 CSA BSHD path supports only the CP=1 fused sparse backends; pass "
+            "packed_seq_params for the THD context-parallel path. The dense BSHD "
+            "fallback was removed."
         )
-        combined_scores = torch.cat([scores, sink], dim=-1)
-        combined_scores = combined_scores - combined_scores.max(dim=-1, keepdim=True).values
-        probs = torch.softmax(combined_scores, dim=-1, dtype=torch.float32).to(dtype=q.dtype)
-
-        context = q.new_zeros(batch, self.num_heads, seq_len, self.head_dim)
-        offset = 0
-        for values in value_parts:
-            next_offset = offset + values.size(2)
-            partial = torch.matmul(probs[..., offset:next_offset], values)
-            context = context + partial
-            offset = next_offset
-
-        return self._project_context(context, cos, sin)
 
     def _project_context(
         self, context: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor
@@ -482,22 +466,6 @@ class CompressedSparseAttention(nn.Module):
             batch, seq_len, self.config.o_groups, self.num_heads_per_group * self.head_dim
         )
         return self.wo_b(self.wo_a(grouped).flatten(2))
-
-    def _gather_cp_sources(
-        self, tensor: torch.Tensor, position_ids: torch.Tensor, *, seq_dim: int
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        parts, pos_parts = [], []
-        for _rank, source, source_pos in iter_cp_sources(
-            tensor,
-            position_ids,
-            cp_rank=self.ps.cp_rank,
-            cp_size=self.ps.cp_size,
-            cp_group=self.ps.cp_group,
-        ):
-            parts.append(source)
-            pos_parts.append(source_pos)
-        pos = torch.cat(pos_parts, dim=1)
-        return torch.cat(parts, dim=seq_dim), pos
 
     def _forward_fused_sparse_no_indexer_cp1(
         self,
@@ -712,3 +680,380 @@ class CompressedSparseAttention(nn.Module):
         if pad:
             context = context[:, :, :orig_seq_len, :].contiguous()
         return self._project_context(context, cos, sin)
+
+    # ------------------------------------------------------------------
+    # THD packed context-parallel path
+    # ------------------------------------------------------------------
+
+    def _thd_cu_seqlens(self, packed_seq_params: Any) -> torch.Tensor:
+        """Padded cu_seqlens (falling back to unpadded) for the THD packed layout."""
+        return (
+            packed_seq_params.cu_seqlens_q_padded
+            if packed_seq_params.cu_seqlens_q_padded is not None
+            else packed_seq_params.cu_seqlens_q
+        )
+
+    def _project_boundary_kv(
+        self,
+        boundary_hidden: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        global_start: int,
+        rope_theta: float,
+    ) -> torch.Tensor:
+        """Project the exchanged left-boundary hidden rows into MQA KV rows.
+
+        Faithful to the DSv4 hybrid-attention boundary-KV path: the boundary rows
+        sit immediately left of this rank's block, so they are KV-projected
+        (``wkv`` -> ``kv_norm``) and RoPE'd at their own within-sequence positions
+        (``global_start - d_window .. global_start - 1``) using lite's RoPE
+        convention. Returns ``(d_window, 1, 1, head_dim)`` matching Core's
+        ``boundary_kv.squeeze(-2).squeeze(1)`` contract in ``_forward_thd_cp``.
+        """
+        d_window = boundary_hidden.shape[0]
+        bkv = self.kv_norm(self.wkv(boundary_hidden.reshape(d_window, -1)))  # (d_window, head_dim)
+        b_pos = cp_utils._thd_cp_position_ids(cu_seqlens, int(global_start) - d_window, d_window)
+        cos, sin = build_compressed_rope_cos_sin(
+            b_pos.view(1, d_window).long(),
+            self.rope_head_dim,
+            rope_theta,
+            config=self.config,
+            use_yarn=self.compress_ratio > 1,
+            device=bkv.device,
+            dtype=bkv.dtype,
+        )
+        bkv = bkv.view(1, 1, d_window, self.head_dim)  # (batch=1, head=1, seq=d_window, hd)
+        bkv = apply_partial_rope(bkv, cos, sin, self.rope_head_dim)
+        return bkv.permute(2, 0, 1, 3).contiguous()  # (d_window, 1, 1, head_dim)
+
+    def _forward_thd_packed(
+        self,
+        x: torch.Tensor,
+        position_ids: torch.Tensor,
+        packed_seq_params: Any,
+    ) -> torch.Tensor:
+        """Build THD-packed q/key/x/qr, exchange boundaries, and run CP attention.
+
+        ``x`` is ``[1, total, hidden]`` (batch-first, packed). Produces the
+        TE-THD-convention tensors consumed by :meth:`_forward_thd_cp`, then applies
+        the output projection (inverse RoPE + ``wo``) via :meth:`_project_context`.
+        Returns ``[1, total, hidden]`` for the SBHD shim.
+        """
+        batch, seq_len, _ = x.shape
+        if batch != 1:
+            raise RuntimeError(
+                f"DSv4 THD packed CSA expects batch-collapsed input [1, total, h]; got batch={batch}."
+            )
+        cp_group = self.ps.cp_group
+        cp_rank = self.ps.cp_rank
+        cu_seqlens = self._thd_cu_seqlens(packed_seq_params)
+        global_start = cp_rank * seq_len
+
+        attention_rope_theta = (
+            self.config.compress_rope_theta if self.compress_ratio > 1 else self.config.rope_theta
+        )
+        # Positions come from cu_seqlens + this rank's global offset (CP-correct
+        # within-sequence positions), not the raw position_ids tensor, so the
+        # mapping is identical to the unsharded reference at cp_size == 1.
+        del position_ids
+        local_pos = cp_utils._thd_cp_position_ids(cu_seqlens, global_start, seq_len).view(1, seq_len)
+        cos, sin = build_compressed_rope_cos_sin(
+            local_pos.long(),
+            self.rope_head_dim,
+            attention_rope_theta,
+            config=self.config,
+            use_yarn=self.compress_ratio > 1,
+            device=x.device,
+            dtype=x.dtype,
+        )
+        q_low = self.q_norm(self.wq_a(x))
+        q = self.wq_b(q_low).view(batch, seq_len, self.num_heads, self.head_dim).transpose(1, 2)
+        q = q * torch.rsqrt(
+            q.float().pow(2).mean(dim=-1, keepdim=True) + self.config.rms_norm_eps
+        ).to(dtype=q.dtype)
+        kv = self.kv_norm(self.wkv(x)).view(batch, seq_len, 1, self.head_dim).transpose(1, 2)
+        q = apply_partial_rope(q, cos, sin, self.rope_head_dim)
+        kv = apply_partial_rope(kv, cos, sin, self.rope_head_dim)
+
+        # TE-THD convention: query (total, np, hn); key (total, 1, 1, hn); x/qr (total, 1, *).
+        query_thd = q.squeeze(0).transpose(0, 1).contiguous()  # (total, np, hn)
+        key_thd = kv.permute(2, 0, 1, 3).contiguous()  # (total, 1, 1, hn)
+        x_thd = x.transpose(0, 1).contiguous()  # (total, 1, hidden)
+        qr_thd = q_low.transpose(0, 1).contiguous()  # (total, 1, q_lora_rank)
+
+        if self.ps.cp_size > 1:
+            boundary_hidden = cp_utils.exchange_cp_boundary_hidden(
+                x_thd, self.compress_ratio, self.config.sliding_window, cp_group
+            )
+        else:
+            # cp_size == 1 has no left neighbour, so the boundary window is exactly
+            # zeros. Core reaches ``_forward_thd_cp`` only at cp>1 and never calls
+            # the P2P exchange with an empty op list; the lite path routes cp=1 THD
+            # through the same method, so materialize the zero boundary directly
+            # (matching ``cp_utils.exchange_cp_boundary_hidden``'s D_window sizing).
+            d_comp = (
+                8 if self.compress_ratio == 4 else self.compress_ratio if self.compress_ratio > 1 else 0
+            )
+            d_window = max(int(self.config.sliding_window), d_comp)
+            boundary_hidden = x_thd.new_zeros((d_window,) + tuple(x_thd.shape[1:]))
+        boundary_kv = self._project_boundary_kv(
+            boundary_hidden, cu_seqlens, global_start, attention_rope_theta
+        )
+
+        context = self._forward_thd_cp(
+            query_thd, key_thd, x_thd, qr_thd, boundary_hidden, boundary_kv, packed_seq_params
+        )
+        # context: (total, 1, np * hn). Reshape to (1, np, total, hn) for the shared
+        # output projection (inverse RoPE + wo), then return (1, total, hidden).
+        context = (
+            context.squeeze(1)
+            .view(seq_len, self.num_heads, self.head_dim)
+            .permute(1, 0, 2)
+            .unsqueeze(0)
+            .contiguous()
+        )
+        return self._project_context(context, cos, sin)
+
+    def _forward_thd_cp(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        x: torch.Tensor,
+        qr: torch.Tensor,
+        boundary_hidden: torch.Tensor | None,
+        boundary_kv: torch.Tensor | None,
+        packed_seq_params: Any,
+    ) -> torch.Tensor:
+        """THD-packed context-parallel branch (faithful port of Core
+        ``CompressedSparseAttention._forward_thd_cp``).
+
+        Builds this rank's local KV context from boundary rows and fixed-capacity
+        compressed KV, then runs sparse attention with an optional indexer loss.
+        RoPE is applied to the indexer query with lite's convention (deviating from
+        Core's ``cp_utils.apply_thd_cp_local_rope_*``) so the CP path stays
+        identical to lite's BSHD path; ``apply_dsa_kernel_fusion`` gates the
+        fused vs. differentiable-unfused kernels exactly as Core does.
+        """
+        cp_group = self.ps.cp_group
+        cp_size = self.ps.cp_size
+        cp_rank = self.ps.cp_rank
+
+        l_local = query.shape[0]
+        if l_local != key.shape[0]:
+            raise RuntimeError("DSv4 THD CP path currently supports self-attention only.")
+        cu_seqlens = self._thd_cu_seqlens(packed_seq_params)
+        max_seqlen_q = int(packed_seq_params.max_seqlen_q)
+
+        global_start = cp_rank * l_local
+        kv_local = key.squeeze(-2).squeeze(1)  # (l_local, head_dim)
+        if boundary_hidden is None or boundary_kv is None:
+            raise RuntimeError(
+                "DSv4 THD CP path requires boundary_hidden and boundary_kv from the "
+                "hidden-only boundary exchange and boundary KV projection path."
+            )
+        boundary_kv = boundary_kv.squeeze(-2).squeeze(1)  # (d_window, head_dim)
+        d_window = boundary_hidden.shape[0]
+        compressed_kv_rank_major = kv_local.new_empty((0, kv_local.shape[-1]))
+        cu_seqlens_compressed = None
+
+        compressed_topk = seq_to_rank_row = None
+        indexer_layout = q_indexer_cp = weights_indexer_cp = None
+        k_indexer_rank_major = k_indexer_seq_major = None
+        ratio = self.compress_ratio
+        indexer = self.indexer
+        indexer_loss_coeff = self.dsa_indexer_loss_coeff or 0.0
+        training_with_grad = self.training and torch.is_grad_enabled()
+        sparse_indexer_loss = self.dsa_indexer_use_sparse_loss
+        calculate_per_token_loss = self.calculate_per_token_loss
+
+        if self.compressor is not None and ratio > 1:
+            compressed_lens = torch.div(
+                cu_seqlens[1:] - cu_seqlens[:-1], ratio, rounding_mode="floor"
+            )
+            cu_seqlens_compressed = torch.cat(
+                (
+                    torch.zeros_like(cu_seqlens[:1]),
+                    torch.cumsum(compressed_lens, dim=0, dtype=torch.int32),
+                )
+            )
+            hidden_compact, compressed_group_ids, seq_to_rank_row = (
+                cp_utils.prepare_cp_compressor_input(
+                    x,
+                    boundary_hidden,
+                    cu_seqlens,
+                    cu_seqlens_compressed,
+                    global_start,
+                    cp_size,
+                    ratio,
+                )
+            )
+
+            if indexer is not None:
+                indexer_x, indexer_qr = x.detach(), qr.detach()
+                if indexer_x.shape[1] != 1:
+                    raise RuntimeError(
+                        f"DSv4 THD CP indexer expects bsz=1, got {indexer_x.shape[1]}."
+                    )
+                q_indexer_cp = indexer.wq_b(indexer_qr.squeeze(1)).view(
+                    l_local, indexer.index_n_heads, indexer.index_head_dim
+                )
+                idx_pos = cp_utils._thd_cp_position_ids(cu_seqlens, global_start, l_local)
+                idx_cos, idx_sin = build_compressed_rope_cos_sin(
+                    idx_pos.view(1, l_local).long(),
+                    indexer.rope_head_dim,
+                    self.config.compress_rope_theta,
+                    config=self.config,
+                    use_yarn=ratio > 1,
+                    device=q_indexer_cp.device,
+                    dtype=q_indexer_cp.dtype,
+                )
+                # lite RoPE wants the sequence axis at dim -2: (1, n_heads, l_local, hd).
+                q_rope = q_indexer_cp.permute(1, 0, 2).unsqueeze(0)
+                q_rope = apply_partial_rope(q_rope, idx_cos, idx_sin, indexer.rope_head_dim)
+                q_indexer_cp = q_rope.squeeze(0).permute(1, 0, 2).contiguous()
+                q_indexer_cp = rotate_activation(q_indexer_cp)
+                weights_indexer_cp = indexer.weights_proj(indexer_x.squeeze(1)) * (
+                    indexer.index_n_heads**-0.5
+                )
+
+                indexer_compressed_local, _ = indexer.compressor._forward_thd(
+                    hidden_compact.detach(),
+                    cu_seqlens,
+                    max_seqlen_q=max_seqlen_q,
+                    compressed_group_ids=compressed_group_ids,
+                )
+                k_indexer_rank_major = gather_from_sequence_parallel_region(
+                    indexer_compressed_local.squeeze(1), group=cp_group
+                )
+                k_indexer_seq_major = torch.index_select(
+                    k_indexer_rank_major, 0, seq_to_rank_row.clamp_min(0)
+                )
+                compressed_topk, indexer_layout = cp_utils.compute_cp_indexer_topk(
+                    q_indexer_cp,
+                    weights_indexer_cp,
+                    k_indexer_seq_major,
+                    cu_seqlens,
+                    cu_seqlens_compressed,
+                    global_start,
+                    ratio,
+                    indexer.index_topk,
+                    indexer.softmax_scale,
+                    max_seqlen_q=max_seqlen_q,
+                    use_fused=self.apply_dsa_kernel_fusion,
+                )
+
+            compressed_kv_local, _ = self.compressor._forward_thd(
+                hidden_compact,
+                cu_seqlens,
+                max_seqlen_q=max_seqlen_q,
+                compressed_group_ids=compressed_group_ids,
+            )
+            compressed_kv_rank_major = gather_from_sequence_parallel_region(
+                compressed_kv_local.squeeze(1), group=cp_group
+            )
+
+        kv_full_thd = torch.cat((boundary_kv, kv_local, compressed_kv_rank_major), dim=0)
+        use_indexer_loss = (
+            training_with_grad and indexer_loss_coeff > 0 and compressed_topk is not None
+        )
+        compressed_width = (
+            compressed_topk.shape[-1]
+            if compressed_topk is not None
+            else (max_seqlen_q // ratio if ratio > 1 else 0)
+        )
+        topk_idxs, topk_length, indexer_topk_rank_major = (
+            csa_cp_layout_kernels.build_attention_indices(
+                cu_seqlens,
+                global_start,
+                l_local,
+                d_window,
+                self.config.sliding_window,
+                ratio,
+                compressed_width,
+                compressed_topk,
+                cu_seqlens_compressed=cu_seqlens_compressed,
+                seq_to_rank_row=seq_to_rank_row,
+                for_indexer_loss=use_indexer_loss,
+            )
+        )
+
+        if use_indexer_loss:
+            k_indexer_for_loss = k_indexer_rank_major
+            compressed_kv_for_loss = compressed_kv_rank_major
+            if not sparse_indexer_loss:
+                k_indexer_for_loss = k_indexer_seq_major
+                compressed_kv_for_loss = torch.index_select(
+                    compressed_kv_rank_major, 0, seq_to_rank_row.clamp_min(0)
+                )
+            cu_seqlens_q_unpadded = None
+            if (
+                packed_seq_params.cu_seqlens_q is not None
+                and packed_seq_params.cu_seqlens_q_padded is not None
+                and packed_seq_params.cu_seqlens_q.data_ptr()
+                != packed_seq_params.cu_seqlens_q_padded.data_ptr()
+            ):
+                cu_seqlens_q_unpadded = packed_seq_params.cu_seqlens_q
+            q_padding_mask = None
+            if cu_seqlens_q_unpadded is not None:
+                global_rows = torch.arange(
+                    global_start,
+                    global_start + l_local,
+                    device=query.device,
+                    dtype=cu_seqlens.dtype,
+                )
+                batch_ids = torch.bucketize(
+                    global_rows, cu_seqlens[1:], out_int32=True, right=True
+                ).clamp_max(cu_seqlens.shape[0] - 2)
+                real_seqlens = cu_seqlens_q_unpadded[1:] - cu_seqlens_q_unpadded[:-1]
+                positions = global_rows - cu_seqlens[batch_ids]
+                q_padding_mask = positions >= real_seqlens[batch_ids]
+            apply_from_topk = (
+                FusedIndexerSparseAttnFromTopkFunc.apply
+                if self.apply_dsa_kernel_fusion
+                else _unfused_indexer_sparse_attn_from_topk
+            )
+            output, indexer_loss = apply_from_topk(
+                query,
+                kv_full_thd,
+                self.sinks.float(),
+                topk_idxs,
+                q_indexer_cp,
+                k_indexer_for_loss,
+                weights_indexer_cp,
+                indexer_topk_rank_major,
+                compressed_kv_for_loss,
+                self.softmax_scale,
+                indexer.softmax_scale,
+                indexer_loss_coeff,
+                1 if calculate_per_token_loss else l_local * cp_size,
+                sparse_indexer_loss,
+                ratio,
+                max_seqlen_q,
+                indexer_layout,
+                q_padding_mask,
+            )
+            if indexer_loss_coeff > 0:
+                DSAIndexerLossLoggingHelper.save_loss_to_tracker(
+                    loss=indexer_loss,
+                    layer_number=self.layer_idx,
+                    num_layers=self.config.num_hidden_layers
+                    + self.config.num_nextn_predict_layers,
+                    reduce_group=cp_group,
+                )
+            output = DSAIndexerLossAutoScaler.apply(output, indexer_loss)
+            return output.unsqueeze(1)
+
+        if self.apply_dsa_kernel_fusion:
+            output = dsa_sparse_attn(
+                query,
+                kv_full_thd,
+                self.sinks.float(),
+                topk_idxs,
+                self.softmax_scale,
+                topk_length=topk_length,
+                is_thd=True,
+            )
+        else:
+            output = unfused_compressed_sparse_attn(
+                query, kv_full_thd, self.sinks.float(), topk_idxs, self.softmax_scale
+            )
+        return output.unsqueeze(1)

--- a/experimental/lite/megatron/lite/primitive/modules/gated_delta_net.py
+++ b/experimental/lite/megatron/lite/primitive/modules/gated_delta_net.py
@@ -1,5 +1,34 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-"""Qwen-style Gated DeltaNet primitive."""
+"""Qwen-style Gated DeltaNet primitive.
+
+Context-parallel (CP) modes
+---------------------------
+- ``headwise`` (default under CP): head-parallel all-to-all. Each rank all-to-alls
+  its zigzag sequence shard so it ends up holding the *full* sequence for ``1/cp`` of
+  the heads (with the matching slices of conv1d / A_log / dt_bias), runs the ordinary
+  full-sequence gated-delta recurrence, then all-to-alls back. Heads are independent,
+  so this is numerically **bitwise-identical to CP-off** while sharding the per-head
+  state/activation memory across ranks. This mirrors upstream Megatron
+  ``linear_cp_mode='headwise'`` (``megatron/core/ssm/gated_delta_net.py``).
+  but every rank materialises the full sequence for *all* heads (worst memory).
+- ``chunkwise``: FLA ``cp_context`` ring path. Each rank keeps its ``1/cp`` sequence
+  shard *and* all heads; the recurrence's per-chunk state is passed around the CP ring
+  by the FLA kernel. This shards both sequence and per-head state memory (best memory).
+  Chunkwise is a *packing-aware faithful mirror* of upstream Megatron
+  ``linear_cp_mode='chunkwise'`` (``megatron/core/ssm/gated_delta_net.py`` @ d1384c2d9):
+  the Megatron zigzag CP layout is reshuffled to contiguous-time chunks with a single
+  packing-aware all-to-all keyed on the *global* ``cu_seqlens`` (``_resolve_cu_seqlens``
+  validates padded lengths and per-sequence ``% cp_size`` divisibility), the FLA
+  recurrence runs, then the output is reshuffled back to zigzag. Because the ring
+  accumulates chunk state across ranks, chunkwise matches CP-off at the bf16 floor
+  rather than bitwise (``headwise`` is bitwise-exact).
+
+An earlier local chunkwise (``sharded``) copy diverged from upstream on the packed/THD
+path — it sliced ``cu_seqlens // cp_size`` per sequence and swapped each slice as if it
+were unpacked, corrupting multi-sequence / non-``cp``-divisible reshuffles and producing
+a large RL train/inference log-prob mismatch. This module restores chunkwise as a
+faithful mirror of the upstream packing-aware reshuffle.
+"""
 
 from __future__ import annotations
 
@@ -19,7 +48,10 @@ from megatron.lite.primitive.parallel import (
     RowParallelLinear,
 )
 from megatron.lite.primitive.parallel.cp import (
+    all_to_all_hidden_shards,
+    build_headwise_section_perm,
     contiguous_to_zigzag_chunks,
+    get_parameter_local_cp_headwise,
     zigzag_reconstruct_from_cp_parts,
     zigzag_slice_for_cp,
     zigzag_to_contiguous_chunks,
@@ -44,15 +76,19 @@ except ImportError:
     _HAS_FLA = False
 
 try:
-    from fla.ops.cp import build_cp_context as _fla_build_cp_context  # pyright: ignore[reportMissingImports]
+    from fla.ops.cp import (
+        build_cp_context as _fla_build_cp_context,  # pyright: ignore[reportMissingImports]
+    )
 except ImportError:
     _fla_build_cp_context = None
 
 _CONV_PAD_ALIGNMENT = 4096
 
+_CP_MODES = {"headwise", "chunkwise"}
+
 
 class GatedDeltaNet(nn.Module):
-    """Native Gated DeltaNet with dense/packed all-gather CP support."""
+    """Native Gated DeltaNet with head-parallel / chunkwise CP support."""
 
     def __init__(
         self,
@@ -66,11 +102,13 @@ class GatedDeltaNet(nn.Module):
         rms_norm_eps: float,
         ps: ParallelState,
         deterministic: bool = False,
-        cp_mode: str = "replicated",
+        cp_mode: str = "headwise",
     ):
         super().__init__()
-        if cp_mode not in {"sharded", "replicated"}:
-            raise ValueError(f"Unsupported GatedDeltaNet CP mode: {cp_mode!r}.")
+        if cp_mode not in _CP_MODES:
+            raise ValueError(
+                f"Unsupported GatedDeltaNet CP mode: {cp_mode!r}; expected one of {sorted(_CP_MODES)}."
+            )
         self.ps = ps
         self.deterministic = bool(deterministic)
         self.cp_mode = cp_mode
@@ -97,6 +135,7 @@ class GatedDeltaNet(nn.Module):
             zero_centered_gamma=True,
         )
         conv_dim_local = self.qk_dim_local * 2 + self.v_dim_local
+        self.conv_dim_local = conv_dim_local
         self.conv1d = nn.Conv1d(
             in_channels=conv_dim_local,
             out_channels=conv_dim_local,
@@ -113,9 +152,23 @@ class GatedDeltaNet(nn.Module):
         )
         self.norm = te.RMSNorm(self.dv, eps=rms_norm_eps, zero_centered_gamma=True)
         self.o_proj = RowParallelLinear(self.v_dim, hidden_size, ps, bias=False)
-        self._cp_context_cache: dict[
-            tuple[int, int, torch.device], tuple[torch.Tensor, object]
-        ] = {}
+        # (global cu_seqlens, FLA cp_context) keyed on (seq_len_global, batch, device)
+        # for the non-packed chunkwise path, where both are static across forwards.
+        self._chunkwise_cp_context_cache: dict[tuple, tuple[torch.Tensor, object]] = {}
+
+    # The six ``qkvzba`` sections and the three conv channel sections, in hidden order.
+    def _qkvzba_sections(self) -> list[int]:
+        return [
+            self.qk_dim_local,
+            self.qk_dim_local,
+            self.v_dim_local,
+            self.v_dim_local,
+            self.num_v_heads_local,
+            self.num_v_heads_local,
+        ]
+
+    def _conv_sections(self) -> list[int]:
+        return [self.qk_dim_local, self.qk_dim_local, self.v_dim_local]
 
     def forward(
         self, x: torch.Tensor, position_ids: torch.Tensor | None = None, packed_seq_params=None
@@ -124,32 +177,60 @@ class GatedDeltaNet(nn.Module):
         is_packed = packed_seq_params is not None
         qkvzba = self.in_proj(x).transpose(0, 1).contiguous()
         cu_seqlens = self._packed_cu_seqlens(packed_seq_params) if is_packed else None
+
+        headwise = False
+        chunkwise = False
         cp_context = None
-        replicated = False
+        reshuffle_cu = None
+        cp_div = 1
         if self.ps.cp_size > 1:
             if self.ps.cp_group is None:
                 raise RuntimeError("CP>1 requires ParallelState.cp_group.")
-            if self.cp_mode == "replicated":
-                qkvzba, cu_seqlens = self._replicate_cp_qkvzba(qkvzba, cu_seqlens)
-                replicated = True
-            else:
-                if not _HAS_FLA or _fla_build_cp_context is None:
-                    raise NotImplementedError(
-                        "GatedDeltaNet all-gather CP requires FLA kernels."
-                    )
+            if self.cp_mode == "chunkwise":
                 if not is_packed and qkvzba.shape[0] > 1:
                     raise ValueError(
-                        "GatedDeltaNet all-gather CP with SBHD inputs currently requires "
+                        "GatedDeltaNet chunkwise CP with SBHD inputs currently requires "
                         "micro_batch_size == 1. Use packed THD input or micro_batch_size=1."
                     )
-                qkvzba = self._cp_swap_qkvzba(
-                    qkvzba,
-                    cu_seqlens if is_packed else None,
-                    to_contiguous=True,
+                cp_context, cu_seqlens = self._build_chunkwise_cp_context(
+                    qkvzba, cu_seqlens, is_packed
                 )
-                cu_seqlens, cp_context = self._build_cp_context(qkvzba, cu_seqlens)
+                # Packed THD reshuffles with the global cu_seqlens (packing-aware); the
+                # non-packed path is a plain two-chunk swap (``cu_seqlens is None``).
+                reshuffle_cu = cu_seqlens if is_packed else None
+                qkvzba = self._chunkwise_reshuffle(qkvzba, reshuffle_cu, to_contiguous=True)
+                chunkwise = True
+            else:  # headwise
+                if not is_packed and qkvzba.shape[0] > 1:
+                    raise ValueError(
+                        "GatedDeltaNet headwise CP with SBHD inputs currently requires "
+                        "micro_batch_size == 1. Use packed THD input or micro_batch_size=1."
+                    )
+                qkvzba, cu_seqlens = self._headwise_cp2hp(qkvzba, cu_seqlens)
+                headwise = True
+                cp_div = self.ps.cp_size
+
         batch, seq_len = qkvzba.shape[:2]
-        query, key, value, gate, beta, alpha = self._split_proj(qkvzba)
+
+        # Per-rank parameter slices (identity unless headwise).
+        if headwise:
+            conv_weight = get_parameter_local_cp_headwise(
+                self.conv1d.weight,
+                dim=0,
+                cp_size=self.ps.cp_size,
+                cp_rank=self.ps.cp_rank,
+                split_sections=self._conv_sections(),
+            )
+            A_log = get_parameter_local_cp_headwise(
+                self.A_log, dim=0, cp_size=self.ps.cp_size, cp_rank=self.ps.cp_rank
+            )
+            dt_bias = get_parameter_local_cp_headwise(
+                self.dt_bias, dim=0, cp_size=self.ps.cp_size, cp_rank=self.ps.cp_rank
+            )
+        else:
+            conv_weight, A_log, dt_bias = None, self.A_log, self.dt_bias
+
+        query, key, value, gate, beta, alpha = self._split_proj(qkvzba, cp_div)
         qkv = torch.cat(
             [
                 query.reshape(batch, seq_len, -1),
@@ -160,12 +241,17 @@ class GatedDeltaNet(nn.Module):
         )
 
         qkv = self._causal_conv1d(
-            qkv, seq_len, cu_seqlens=cu_seqlens, cp_context=cp_context
+            qkv,
+            seq_len,
+            cu_seqlens=cu_seqlens,
+            conv_weight=conv_weight,
+            cp_div=cp_div,
+            cp_context=cp_context,
         )
         query, key, value, gate, beta, alpha = self._prepare_qkv(
-            qkv, gate, beta, alpha, batch, seq_len
+            qkv, gate, beta, alpha, batch, seq_len, cp_div
         )
-        g, beta = self._compute_g_and_beta(self.A_log, self.dt_bias, alpha, beta)
+        g, beta = self._compute_g_and_beta(A_log, dt_bias, alpha, beta)
         out, _ = self._gated_delta_rule(
             query,
             key,
@@ -179,153 +265,192 @@ class GatedDeltaNet(nn.Module):
         )
 
         out = self._apply_gated_norm(out, gate)
-        out = out.reshape(batch, seq_len, self.v_dim_local)
+        out = out.reshape(batch, seq_len, self.v_dim_local // cp_div)
         if self.ps.cp_size > 1:
-            if replicated:
-                out = self._slice_replicated_output(out, cu_seqlens)
-            else:
-                out = self._cp_swap_qkvzba(
-                    out,
-                    cu_seqlens if is_packed else None,
-                    to_contiguous=False,
-                )
+            if chunkwise:
+                # Inverse of the pre-recurrence reshuffle: restore the Megatron
+                # attention-load-balanced zigzag layout downstream layers expect.
+                out = self._chunkwise_reshuffle(out, reshuffle_cu, to_contiguous=False)
+            else:  # headwise
+                out = self._headwise_hp2cp(out, cu_seqlens)
             batch, seq_len = out.shape[:2]
         out = out.transpose(0, 1).contiguous()
         return self.o_proj(out)
 
-    def _all_gather_cp_tensor(self, tensor: torch.Tensor) -> list[torch.Tensor]:
-        if self.ps.cp_size <= 1:
-            return [tensor]
-        try:
-            from torch.distributed.nn.functional import all_gather
-
-            return list(all_gather(tensor, group=self.ps.cp_group))
-        except Exception:
-            parts = [torch.empty_like(tensor) for _ in range(self.ps.cp_size)]
-            torch.distributed.all_gather(parts, tensor, group=self.ps.cp_group)
-            return parts
-
-    def _replicate_cp_qkvzba(
+    # ------------------------------------------------------------------ CP: headwise
+    def _headwise_cp2hp(
         self,
         qkvzba: torch.Tensor,
         cu_seqlens: torch.Tensor | None,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """Zigzag-sharded ``[b, s_local, h]`` -> contiguous full-seq ``[b, s_global, h/cp]``.
+
+        Permutes the hidden dim section-wise so a plain hidden-scatter all-to-all leaves
+        each rank with ``1/cp`` heads of every section, then reassembles the full
+        sequence from the per-rank shards with the verified zigzag reconstruction.
+        """
+        cp_size = self.ps.cp_size
+        perm = build_headwise_section_perm(
+            self._qkvzba_sections(), cp_size, qkvzba.device
+        )
+        qkvzba = qkvzba.index_select(-1, perm)
+        h = qkvzba.shape[-1]
+        hpc = h // cp_size
+        send_parts = [qkvzba[..., k * hpc : (k + 1) * hpc].contiguous() for k in range(cp_size)]
+        recv = all_to_all_hidden_shards(send_parts, self.ps.cp_group)
         if cu_seqlens is None:
-            parts = self._all_gather_cp_tensor(qkvzba)
-            return zigzag_reconstruct_from_cp_parts(parts, seq_dim=1), None
+            full = zigzag_reconstruct_from_cp_parts(recv, seq_dim=1)
+            return full.contiguous(), None
         if qkvzba.shape[0] != 1:
             raise ValueError("Packed THD GatedDeltaNet expects a single packed batch row.")
-        parts = self._all_gather_cp_tensor(qkvzba[0].contiguous())
+        parts = [p[0].contiguous() for p in recv]
         full = reconstruct_packed_from_cp_parts(
             parts,
             cu_seqlens_padded=cu_seqlens,
-            cp_size=self.ps.cp_size,
+            cp_size=cp_size,
             dim=0,
         )
         return full.unsqueeze(0).contiguous(), cu_seqlens
 
-    def _slice_replicated_output(
+    def _headwise_hp2cp(
         self,
         out: torch.Tensor,
         cu_seqlens: torch.Tensor | None,
     ) -> torch.Tensor:
+        """Inverse of :meth:`_headwise_cp2hp` for the value output.
+
+        Full-seq ``[b, s_global, v/cp]`` (this rank owns value-head shard ``cp_rank``) ->
+        zigzag-sharded ``[b, s_local, v]`` with all heads. The value section's per-rank
+        blocks are contiguous, so concatenating the received hidden shards in rank order
+        restores the natural head order (no inverse permutation required).
+        """
+        cp_size = self.ps.cp_size
         if cu_seqlens is None:
-            return zigzag_slice_for_cp(out, self.ps.cp_rank, self.ps.cp_size, seq_dim=1)
+            send_parts = [
+                zigzag_slice_for_cp(out, j, cp_size, seq_dim=1).contiguous()
+                for j in range(cp_size)
+            ]
+            recv = all_to_all_hidden_shards(send_parts, self.ps.cp_group)
+            return torch.cat(recv, dim=-1).contiguous()
         if out.shape[0] != 1:
             raise ValueError("Packed THD GatedDeltaNet expects a single packed batch row.")
-        local = split_packed_to_cp_local(
-            out[0].contiguous(),
-            cu_seqlens_padded=cu_seqlens,
-            cp_size=self.ps.cp_size,
-            cp_rank=self.ps.cp_rank,
-            dim=0,
-        )
-        return local.unsqueeze(0).contiguous()
+        base = out[0].contiguous()
+        send_parts = [
+            split_packed_to_cp_local(
+                base,
+                cu_seqlens_padded=cu_seqlens,
+                cp_size=cp_size,
+                cp_rank=j,
+                dim=0,
+            ).contiguous()
+            for j in range(cp_size)
+        ]
+        recv = all_to_all_hidden_shards(send_parts, self.ps.cp_group)
+        return torch.cat(recv, dim=-1).unsqueeze(0).contiguous()
 
-    def _cp_swap_qkvzba(
+    # ------------------------------------------------------------------ CP: chunkwise
+    def _resolve_cu_seqlens(
+        self, cu_seqlens: torch.Tensor, total_seq_len: int
+    ) -> torch.Tensor:
+        """Validate the global (padded) packed cu_seqlens for chunkwise CP.
+
+        Mirrors upstream Megatron ``GatedDeltaNet._resolve_cu_seqlens``: the padded
+        cumulative lengths must cover the whole global sequence and every per-sequence
+        length must be divisible by ``cp_size`` (chunk boundaries land on CP shards).
+        """
+        total_cu = int(cu_seqlens[-1].item())
+        if total_cu != total_seq_len:
+            raise ValueError(
+                f"GDN chunkwise: cu_seqlens[-1]={total_cu} does not match "
+                f"total_sequence_length={total_seq_len} (global, padding-inclusive)."
+            )
+        seq_lengths = cu_seqlens[1:] - cu_seqlens[:-1]
+        if (seq_lengths % self.ps.cp_size != 0).any():
+            raise ValueError(
+                "GDN chunkwise: all per-sequence cu_seqlens lengths must be divisible by "
+                f"cp_size={self.ps.cp_size}, but got lengths {seq_lengths.tolist()}."
+            )
+        return cu_seqlens
+
+    def _build_chunkwise_cp_context(
+        self,
+        qkvzba: torch.Tensor,
+        cu_seqlens: torch.Tensor | None,
+        is_packed: bool,
+    ) -> tuple[object, torch.Tensor]:
+        """Build the FLA ring ``cp_context`` and resolve the global cu_seqlens.
+
+        For packed THD the (padded) global cu_seqlens is validated; for the non-packed
+        dense case the only cu_seqlens source is the static global sequence length and
+        batch size, so both the cu_seqlens and the (allocation-heavy) cp_context are
+        cached to keep them stable across forwards.
+        """
+        if not _HAS_FLA or _fla_build_cp_context is None:
+            raise NotImplementedError(
+                "GatedDeltaNet chunkwise CP requires the FLA cp_context ring kernel."
+            )
+        batch, seq_len_local = qkvzba.shape[:2]
+        seq_len_global = seq_len_local * self.ps.cp_size
+        conv_kernel = self.conv1d.kernel_size[0]
+        if is_packed:
+            cu = self._resolve_cu_seqlens(cu_seqlens, seq_len_global)
+            cp_context = _fla_build_cp_context(
+                cu_seqlens=cu,
+                group=self.ps.cp_group,
+                conv1d_kernel_size=conv_kernel,
+            )
+            return cp_context, cu
+
+        cache_key = (seq_len_global, batch, qkvzba.device)
+        cached = self._chunkwise_cp_context_cache.get(cache_key)
+        if cached is None:
+            dense_cu = (
+                torch.arange(batch + 1, device=qkvzba.device, dtype=torch.long)
+                * seq_len_global
+            )
+            cp_context = _fla_build_cp_context(
+                cu_seqlens=dense_cu,
+                group=self.ps.cp_group,
+                conv1d_kernel_size=conv_kernel,
+            )
+            cached = (dense_cu, cp_context)
+            self._chunkwise_cp_context_cache[cache_key] = cached
+        dense_cu, cp_context = cached
+        return cp_context, dense_cu
+
+    def _chunkwise_reshuffle(
         self,
         tensor: torch.Tensor,
         cu_seqlens: torch.Tensor | None,
         *,
         to_contiguous: bool,
     ) -> torch.Tensor:
-        if cu_seqlens is None:
-            swap = (
-                zigzag_to_contiguous_chunks
-                if to_contiguous
-                else contiguous_to_zigzag_chunks
-            )
-            return swap(tensor, self.ps.cp_group, seq_dim=1)
-        if tensor.shape[0] != 1:
-            raise ValueError(
-                "Packed THD GatedDeltaNet expects a single packed batch row."
-            )
-        local_cu_seqlens = cu_seqlens // self.ps.cp_size
-        pieces = []
-        swap = (
-            zigzag_to_contiguous_chunks
-            if to_contiguous
-            else contiguous_to_zigzag_chunks
-        )
-        for idx in range(int(local_cu_seqlens.numel()) - 1):
-            start = int(local_cu_seqlens[idx].item())
-            end = int(local_cu_seqlens[idx + 1].item())
-            if end <= start:
-                continue
-            pieces.append(swap(tensor[:, start:end, :], self.ps.cp_group, seq_dim=1))
-        if not pieces:
-            return tensor
-        return torch.cat(pieces, dim=1).contiguous()
+        """Reshuffle CP chunks between Megatron zigzag and contiguous-time layout.
 
-    def _build_cp_context(
-        self,
-        qkvzba: torch.Tensor,
-        cu_seqlens: torch.Tensor | None,
-    ) -> tuple[torch.Tensor, object]:
-        if _fla_build_cp_context is None:
-            raise NotImplementedError(
-                "GatedDeltaNet all-gather CP requires FLA cp context."
-            )
-        if cu_seqlens is not None:
-            return (
-                cu_seqlens,
-                _fla_build_cp_context(
-                    cu_seqlens=cu_seqlens,
-                    group=self.ps.cp_group,
-                    conv1d_kernel_size=self.conv1d.kernel_size[0],
-                ),
-            )
+        ``cu_seqlens`` (the global packed layout) selects the packing-aware THD swap;
+        ``None`` selects the plain two-chunk SBHD swap. Shape is preserved either way.
+        """
+        swap = zigzag_to_contiguous_chunks if to_contiguous else contiguous_to_zigzag_chunks
+        return swap(tensor, self.ps.cp_group, seq_dim=1, cu_seqlens=cu_seqlens)
 
-        batch, local_seq_len = qkvzba.shape[:2]
-        global_seq_len = local_seq_len * self.ps.cp_size
-        cache_key = (global_seq_len, batch, qkvzba.device)
-        cached = self._cp_context_cache.get(cache_key)
-        if cached is None:
-            dense_cu_seqlens = (
-                torch.arange(batch + 1, device=qkvzba.device, dtype=torch.long)
-                * global_seq_len
-            )
-            cached = (
-                dense_cu_seqlens,
-                _fla_build_cp_context(
-                    cu_seqlens=dense_cu_seqlens,
-                    group=self.ps.cp_group,
-                    conv1d_kernel_size=self.conv1d.kernel_size[0],
-                ),
-            )
-            self._cp_context_cache[cache_key] = cached
-        return cached
-
+    # ------------------------------------------------------------------ compute
     def _causal_conv1d(
         self,
         qkv: torch.Tensor,
         seq_len: int,
         *,
         cu_seqlens: torch.Tensor | None,
-        cp_context,
+        conv_weight: torch.Tensor | None,
+        cp_div: int,
+        cp_context=None,
     ) -> torch.Tensor:
+        # ``conv_weight`` is the (headwise) per-rank slice; None means use the full module.
+        weight = self.conv1d.weight if conv_weight is None else conv_weight
+        groups = self.conv_dim_local // cp_div
         if _HAS_FLA and (cp_context is not None or cu_seqlens is not None or not self.deterministic):
             orig_seq_len = qkv.shape[1]
+            # Chunkwise CP must not pad conv inputs: padding chunk-local causal-conv
+            # inputs would change later chunk numerics across the ring.
             pad_n = 0 if cp_context is not None else (-orig_seq_len % _CONV_PAD_ALIGNMENT)
             conv_input = qkv
             conv_cu_seqlens = cu_seqlens
@@ -339,7 +464,7 @@ class GatedDeltaNet(nn.Module):
                 kwargs["cp_context"] = cp_context
             qkv, _ = _fla_causal_conv1d(
                 x=conv_input,
-                weight=self.conv1d.weight.squeeze(1),
+                weight=weight.squeeze(1),
                 bias=None,
                 activation="silu",
                 cu_seqlens=conv_cu_seqlens,
@@ -349,9 +474,14 @@ class GatedDeltaNet(nn.Module):
                 qkv = qkv[:, :orig_seq_len, :]
             return qkv
         if cu_seqlens is None and cp_context is None:
-            return F.silu(
-                self.conv1d(qkv.transpose(1, 2))[:, :, :seq_len].transpose(1, 2)
+            conv_out = F.conv1d(
+                qkv.transpose(1, 2),
+                weight=weight,
+                bias=None,
+                padding=self.conv1d.padding[0],
+                groups=groups,
             )
+            return F.silu(conv_out[:, :, :seq_len].transpose(1, 2))
         raise NotImplementedError("GatedDeltaNet packed THD requires FLA causal conv.")
 
     def _gated_delta_rule(
@@ -365,9 +495,9 @@ class GatedDeltaNet(nn.Module):
         initial_state: torch.Tensor | None,
         output_final_state: bool,
         cu_seqlens: torch.Tensor | None,
-        cp_context,
+        cp_context=None,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
-        if _HAS_FLA and (cp_context is not None or not self.deterministic):
+        if _HAS_FLA and (cp_context is not None or cu_seqlens is not None or not self.deterministic):
             kwargs = {}
             if cp_context is not None:
                 kwargs["cp_context"] = cp_context
@@ -385,7 +515,7 @@ class GatedDeltaNet(nn.Module):
             )
         if cp_context is not None:
             raise NotImplementedError(
-                "GatedDeltaNet all-gather CP requires FLA gated delta rule."
+                "GatedDeltaNet chunkwise CP requires the FLA gated delta rule kernel."
             )
         return torch_chunk_gated_delta_rule(
             query,
@@ -410,39 +540,33 @@ class GatedDeltaNet(nn.Module):
             )
         return cu_seqlens
 
-    def _split_proj(self, qkvzba: torch.Tensor):
-        q, k, v, z, b, a = qkvzba.split(
-            [
-                self.qk_dim_local,
-                self.qk_dim_local,
-                self.v_dim_local,
-                self.v_dim_local,
-                self.num_v_heads_local,
-                self.num_v_heads_local,
-            ],
-            dim=-1,
-        )
+    def _split_proj(self, qkvzba: torch.Tensor, cp_div: int):
+        qk = self.qk_dim_local // cp_div
+        vd = self.v_dim_local // cp_div
+        nvh = self.num_v_heads_local // cp_div
+        nkh = self.num_k_heads_local // cp_div
+        q, k, v, z, b, a = qkvzba.split([qk, qk, vd, vd, nvh, nvh], dim=-1)
         batch, seq_len = qkvzba.shape[:2]
         return (
-            q.reshape(batch, seq_len, self.num_k_heads_local, self.dk),
-            k.reshape(batch, seq_len, self.num_k_heads_local, self.dk),
-            v.reshape(batch, seq_len, self.num_v_heads_local, self.dv),
-            z.reshape(batch, seq_len, self.num_v_heads_local, self.dv),
-            b.reshape(batch, seq_len, self.num_v_heads_local),
-            a.reshape(batch, seq_len, self.num_v_heads_local),
+            q.reshape(batch, seq_len, nkh, self.dk),
+            k.reshape(batch, seq_len, nkh, self.dk),
+            v.reshape(batch, seq_len, nvh, self.dv),
+            z.reshape(batch, seq_len, nvh, self.dv),
+            b.reshape(batch, seq_len, nvh),
+            a.reshape(batch, seq_len, nvh),
         )
 
     @jit_fuser
     def _prepare_qkv(
-        self, qkv: torch.Tensor, gate, beta, alpha, batch: int, seq_len: int
+        self, qkv: torch.Tensor, gate, beta, alpha, batch: int, seq_len: int, cp_div: int
     ):
-        query_key, value = qkv.split([2 * self.qk_dim_local, self.v_dim_local], dim=-1)
-        query_key = query_key.reshape(
-            batch, seq_len, 2 * self.num_k_heads_local, self.dk
-        )
-        value = value.reshape(batch, seq_len, self.num_v_heads_local, self.dv)
+        qk = self.qk_dim_local // cp_div
+        nkh = self.num_k_heads_local // cp_div
+        query_key, value = qkv.split([2 * qk, self.v_dim_local // cp_div], dim=-1)
+        query_key = query_key.reshape(batch, seq_len, 2 * nkh, self.dk)
+        value = value.reshape(batch, seq_len, self.num_v_heads_local // cp_div, self.dv)
         query_key = self._l2norm(query_key.contiguous())
-        query, key = query_key.split(self.num_k_heads_local, dim=2)
+        query, key = query_key.split(nkh, dim=2)
         if self.v_heads_per_k_head > 1:
             query = query.repeat_interleave(self.v_heads_per_k_head, dim=2)
             key = key.repeat_interleave(self.v_heads_per_k_head, dim=2)

--- a/experimental/lite/megatron/lite/primitive/modules/router.py
+++ b/experimental/lite/megatron/lite/primitive/modules/router.py
@@ -10,6 +10,13 @@ import torch.distributed as dist  # pyright: ignore[reportMissingImports]
 import torch.nn as nn  # pyright: ignore[reportMissingImports]
 
 from megatron.lite.primitive.modules.moe import MoEAuxLossAutoScaler
+from megatron.lite.primitive.modules.router_replay import (
+    RouterReplay,
+    RouterReplayAction,
+    attach_router_replay,
+    detach_router_replay,
+    gather_replayed_router_scores,
+)
 from megatron.lite.primitive.utils.moe import (
     compute_routing_scores_for_aux_loss,
     router_gating_linear,
@@ -63,6 +70,7 @@ class TopKRouter(nn.Module):
         self.use_pre_softmax = use_pre_softmax
         self.moe_router_fusion = moe_router_fusion
         self.router_dtype = router_dtype
+        self.router_replay: RouterReplay | None = None
 
         self.gate = nn.Linear(config.hidden_size, config.num_experts, bias=False)
         self.register_buffer(
@@ -96,6 +104,16 @@ class TopKRouter(nn.Module):
             topk_scores, topk_indices = _ordered_topk_from_routing_map(
                 probs_dense, routing_map, self.topk
             )
+        if self.router_replay is not None:
+            selected_indices = self.router_replay.select_indices(topk_indices)
+            if selected_indices is not topk_indices:
+                topk_indices = selected_indices
+                topk_scores = gather_replayed_router_scores(
+                    logits,
+                    topk_indices,
+                    score_function="softmax",
+                    use_pre_softmax=self.use_pre_softmax,
+                )
         if self.router_dtype is None:
             topk_scores = topk_scores.to(x.dtype)
 
@@ -159,6 +177,7 @@ class SigmoidTopKRouter(nn.Module):
         self.compute_aux_loss = compute_aux_loss
         self.use_pre_softmax = use_pre_softmax
         self.moe_router_fusion = moe_router_fusion
+        self.router_replay: RouterReplay | None = None
 
         self.gate = nn.Linear(config.hidden_size, config.n_routed_experts, bias=False)
         self.register_buffer(
@@ -184,6 +203,16 @@ class SigmoidTopKRouter(nn.Module):
         topk_scores, topk_indices = _ordered_topk_from_routing_map(
             probs_dense, routing_map, self.topk
         )
+        if self.router_replay is not None:
+            selected_indices = self.router_replay.select_indices(topk_indices)
+            if selected_indices is not topk_indices:
+                topk_indices = selected_indices
+                topk_scores = gather_replayed_router_scores(
+                    logits,
+                    topk_indices,
+                    score_function=self.score_function,
+                    scaling_factor=self.scaling_factor,
+                )
         topk_scores = topk_scores.to(logits.dtype)
 
         apply_aux_loss = (
@@ -215,4 +244,11 @@ class SigmoidTopKRouter(nn.Module):
         return topk_scores, topk_indices
 
 
-__all__ = ["SigmoidTopKRouter", "TopKRouter"]
+__all__ = [
+    "RouterReplay",
+    "RouterReplayAction",
+    "SigmoidTopKRouter",
+    "TopKRouter",
+    "attach_router_replay",
+    "detach_router_replay",
+]

--- a/experimental/lite/megatron/lite/primitive/modules/router_replay.py
+++ b/experimental/lite/megatron/lite/primitive/modules/router_replay.py
@@ -1,0 +1,188 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Dependency-light MoE router replay state machine."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class RouterReplayAction(Enum):
+    RECORD = "record"
+    REPLAY_FORWARD = "replay_forward"
+    REPLAY_BACKWARD = "replay_backward"
+
+
+class RouterReplay:
+    """Replay expert indices while gathering scores from the live router."""
+
+    global_router_replay_instances: list["RouterReplay"] = []
+
+    def __init__(self) -> None:
+        self.target_topk_idx: torch.Tensor | None = None
+        self.target_replay_mask: torch.Tensor | None = None
+        self.recorded_topk_idx: torch.Tensor | None = None
+        self.router_replay_action: RouterReplayAction | None = None
+        self.replay_backward_list: list[torch.Tensor] = []
+        self.replay_backward_mask_list: list[torch.Tensor | None] = []
+        RouterReplay.global_router_replay_instances.append(self)
+
+    @staticmethod
+    def clear_global_router_replay_instances() -> None:
+        RouterReplay.global_router_replay_instances.clear()
+
+    @staticmethod
+    def set_replay_data(
+        all_layers_topk_indices: list[torch.Tensor],
+        replay_mask: torch.Tensor | None = None,
+    ) -> None:
+        instances = RouterReplay.global_router_replay_instances
+        if len(all_layers_topk_indices) != len(instances):
+            raise ValueError(
+                f"router replay expects {len(instances)} per-layer tensors, "
+                f"got {len(all_layers_topk_indices)}."
+            )
+        for instance, indices in zip(instances, all_layers_topk_indices, strict=True):
+            instance.target_topk_idx = indices
+            instance.target_replay_mask = replay_mask
+            # Activation checkpoint recomputation can happen after later PP
+            # micro-batches have replaced the forward target.  Preserve the
+            # per-microbatch sequence for REPLAY_BACKWARD, matching Megatron's
+            # pipeline schedule contract.
+            instance.replay_backward_list.append(indices)
+            instance.replay_backward_mask_list.append(replay_mask)
+
+    @staticmethod
+    def get_recorded_data() -> list[torch.Tensor | None]:
+        return [
+            instance.recorded_topk_idx
+            for instance in RouterReplay.global_router_replay_instances
+        ]
+
+    @staticmethod
+    def set_global_router_replay_action(action: RouterReplayAction) -> None:
+        for instance in RouterReplay.global_router_replay_instances:
+            instance.router_replay_action = action
+
+    @staticmethod
+    def clear_global_state() -> None:
+        for instance in RouterReplay.global_router_replay_instances:
+            instance.target_topk_idx = None
+            instance.target_replay_mask = None
+            instance.recorded_topk_idx = None
+            instance.router_replay_action = None
+            instance.replay_backward_list.clear()
+            instance.replay_backward_mask_list.clear()
+
+    def apply(
+        self,
+        probs_dense: torch.Tensor,
+        topk_scores: torch.Tensor,
+        topk_indices: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        selected = self.select_indices(topk_indices)
+        if selected is topk_indices:
+            return topk_scores, topk_indices
+        return probs_dense.gather(-1, selected).to(topk_scores.dtype), selected
+
+    def select_indices(self, native_indices: torch.Tensor) -> torch.Tensor:
+        """Return replayed/native indices according to action and causal mask."""
+
+        action = self.router_replay_action
+        if action == RouterReplayAction.RECORD:
+            self.recorded_topk_idx = native_indices
+            return native_indices
+        if action == RouterReplayAction.REPLAY_FORWARD:
+            target = self.target_topk_idx
+            mask = self.target_replay_mask
+        elif action == RouterReplayAction.REPLAY_BACKWARD:
+            if not self.replay_backward_list:
+                raise RuntimeError(
+                    "router replay backward is active but its target queue is empty."
+                )
+            target = self.replay_backward_list.pop(0)
+            mask = self.replay_backward_mask_list.pop(0)
+        else:
+            return native_indices
+        if target is None:
+            raise RuntimeError("router replay is active but no target indices were set.")
+
+        target = target.to(device=native_indices.device, dtype=torch.long)
+        if target.shape != native_indices.shape:
+            raise ValueError(
+                "router replay target shape does not match live routing: "
+                f"target={tuple(target.shape)} live={tuple(native_indices.shape)}."
+            )
+        if mask is None:
+            return target
+        mask = mask.to(device=native_indices.device, dtype=torch.bool).reshape(-1, 1)
+        if mask.size(0) != target.size(0):
+            raise ValueError(
+                "router replay mask length does not match routing rows: "
+                f"mask={mask.size(0)} rows={target.size(0)}."
+            )
+        return torch.where(mask, target, native_indices)
+
+
+def attach_router_replay(model: nn.Module, *, reset: bool = True) -> int:
+    if reset:
+        RouterReplay.clear_global_router_replay_instances()
+    count = 0
+    for module in model.modules():
+        if hasattr(module, "router_replay"):
+            module.router_replay = RouterReplay()
+            count += 1
+    return count
+
+
+def detach_router_replay(model: nn.Module) -> None:
+    for module in model.modules():
+        if hasattr(module, "router_replay"):
+            module.router_replay = None
+
+
+def gather_replayed_router_scores(
+    logits: torch.Tensor,
+    indices: torch.Tensor,
+    *,
+    score_function: str,
+    use_pre_softmax: bool = False,
+    scaling_factor: float | None = None,
+) -> torch.Tensor:
+    """Recompute live gate weights for externally selected expert indices."""
+
+    if score_function == "softmax":
+        if use_pre_softmax:
+            scores = torch.softmax(logits, dim=-1, dtype=torch.float32).gather(
+                -1, indices
+            )
+        else:
+            scores = torch.softmax(
+                logits.gather(-1, indices), dim=-1, dtype=torch.float32
+            )
+    elif score_function in ("sigmoid", "sqrtsoftplus"):
+        dense = (
+            logits.float().sigmoid()
+            if score_function == "sigmoid"
+            else F.softplus(logits.float()).sqrt()
+        )
+        scores = dense.gather(-1, indices)
+        if indices.size(-1) > 1:
+            scores = scores / (scores.sum(dim=-1, keepdim=True) + 1e-20)
+    else:
+        raise ValueError(f"unsupported router replay score function {score_function!r}")
+    if scaling_factor:
+        scores = scores * scaling_factor
+    return scores
+
+
+__all__ = [
+    "RouterReplay",
+    "RouterReplayAction",
+    "attach_router_replay",
+    "detach_router_replay",
+    "gather_replayed_router_scores",
+]

--- a/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/optimizer.py
+++ b/experimental/lite/megatron/lite/primitive/optimizers/fsdp2/optimizer.py
@@ -579,14 +579,13 @@ def _collect_tp_replicated_grad_params(
 def _fsdp2_unit_reshard_after_forward(
     ps: ParallelState, *, reshard_after_forward: bool | int | None
 ) -> bool | int | None:
-    if ps.pp_size > 1:
-        return False
     return reshard_after_forward
 
 
-def _fsdp2_prefetch_depth(ps: ParallelState, *, default_depth: int) -> int:
-    if ps.pp_size > 1:
-        return 0
+def _fsdp2_prefetch_depth(_ps: ParallelState, *, default_depth: int) -> int:
+    # FSDP2 prefetch targets are constructed independently for each local
+    # model chunk.  They never cross a pipeline stage (or a VPP chunk), so PP
+    # does not require disabling parameter all-gather overlap.
     return default_depth
 
 

--- a/experimental/lite/megatron/lite/primitive/parallel/cp.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/cp.py
@@ -173,14 +173,25 @@ def zigzag_to_contiguous_chunks(
     tensor: torch.Tensor,
     cp_group: dist.ProcessGroup | None,
     seq_dim: int = 1,
+    cu_seqlens: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Swap a CP-local tensor from Megatron zigzag layout to contiguous chunks.
 
     Zigzag CP layout assigns rank ``r`` global chunks ``[r, 2*cp-r-1]``.
     Linear-attention all-gather CP kernels expect rank ``r`` to hold chunks
-    ``[2*r, 2*r+1]``. The conversion is a chunk-level all-to-all and preserves
-    the local tensor shape.
+    ``[2*r, 2*r+1]``.
+
+    SBHD tensors (``cu_seqlens is None``) hold exactly two equal chunks per rank
+    and use a chunk-level all-to-all that preserves the local tensor shape. Packed
+    THD tensors pass the *global* (pre-CP-split) ``cu_seqlens`` and use a single
+    packed-token all-to-all whose routing is packing-aware, so per-sequence zigzag
+    chunk boundaries are honoured even when sequences do not evenly divide the CP
+    size. Mirrors upstream Megatron ``context_parallel_layout``.
     """
+    if cu_seqlens is not None:
+        return _zigzag_contiguous_thd_swap(
+            tensor, cp_group, seq_dim, cu_seqlens, source_layout="zigzag", target_layout="contiguous"
+        )
     return _zigzag_contiguous_chunk_swap(tensor, cp_group, seq_dim, to_contiguous=True)
 
 
@@ -188,8 +199,13 @@ def contiguous_to_zigzag_chunks(
     tensor: torch.Tensor,
     cp_group: dist.ProcessGroup | None,
     seq_dim: int = 1,
+    cu_seqlens: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Inverse of :func:`zigzag_to_contiguous_chunks`."""
+    if cu_seqlens is not None:
+        return _zigzag_contiguous_thd_swap(
+            tensor, cp_group, seq_dim, cu_seqlens, source_layout="contiguous", target_layout="zigzag"
+        )
     return _zigzag_contiguous_chunk_swap(tensor, cp_group, seq_dim, to_contiguous=False)
 
 
@@ -281,6 +297,188 @@ def _zigzag_contiguous_chunk_swap(
     return out.contiguous()
 
 
+def get_thd_context_parallel_rank_indices(
+    cu_seqlens: torch.Tensor, cp_size: int, cp_rank: int, layout: str
+) -> torch.Tensor:
+    """Return global THD token indices owned by one CP rank in a layout.
+
+    Args:
+        cu_seqlens: Global packed-sequence cumulative lengths before CP partitioning.
+        cp_size: Context-parallel group size.
+        cp_rank: Context-parallel rank.
+        layout: Either ``"zigzag"`` or ``"contiguous"``.
+
+    The returned indices are ordered exactly as the rank-local THD tensor is stored.
+    ``"zigzag"`` follows Megatron's per-sequence load-balanced chunk order; ``"contiguous"``
+    partitions the flattened packed THD buffer into rank-contiguous spans. Mirrors upstream
+    Megatron ``context_parallel_layout.get_thd_context_parallel_rank_indices``.
+    """
+    if layout not in ("zigzag", "contiguous"):
+        raise ValueError(f"Unsupported context-parallel layout {layout!r}.")
+    if cp_size < 1:
+        raise ValueError(f"cp_size must be >= 1, got {cp_size}.")
+    if not 0 <= cp_rank < cp_size:
+        raise ValueError(f"cp_rank must be in [0, {cp_size}), got {cp_rank}.")
+    if cu_seqlens.dim() != 1:
+        raise ValueError(f"cu_seqlens must be 1-D, got shape {tuple(cu_seqlens.shape)}.")
+
+    cu = cu_seqlens.to(dtype=torch.long)
+    if cu.numel() == 0 or cu[0].item() != 0:
+        raise ValueError(f"cu_seqlens must start at 0, got {cu_seqlens}.")
+
+    if torch.any(torch.diff(cu) < 0):
+        raise ValueError(f"cu_seqlens must be nondecreasing, got {cu_seqlens}.")
+
+    nonduplicate_boundaries = torch.ones(cu.numel(), device=cu.device, dtype=torch.bool)
+    nonduplicate_boundaries[1:] = cu[1:] != cu[:-1]
+    cu = cu[nonduplicate_boundaries]
+
+    total_tokens = int(cu[-1].item())
+    positions = torch.arange(total_tokens, device=cu.device, dtype=torch.long)
+    if total_tokens == 0:
+        return positions
+
+    seq_lens = torch.diff(cu)
+    chunk_divisor = 2 * cp_size
+    if torch.any(seq_lens % chunk_divisor != 0):
+        raise ValueError(
+            "All packed sequence lengths must be divisible by "
+            f"2 * cp_size ({chunk_divisor}) for zigzag/contiguous CP layout conversion, "
+            f"got {seq_lens}."
+        )
+
+    if layout == "contiguous":
+        part_len = total_tokens // cp_size
+        rank_start = cp_rank * part_len
+        return positions[rank_start : rank_start + part_len]
+
+    seq_idx = torch.bucketize(positions, cu[1:], right=True)
+    global_starts = cu[:-1]
+    pos_in_seq = positions - global_starts[seq_idx]
+    chunk_lens = (seq_lens // chunk_divisor)[seq_idx]
+    chunk = pos_in_seq // chunk_lens
+    offset = pos_in_seq - chunk * chunk_lens
+
+    owner = torch.where(chunk < cp_size, chunk, 2 * cp_size - chunk - 1)
+    local_slot = torch.where(chunk < cp_size, torch.zeros_like(chunk), torch.ones_like(chunk))
+
+    local_starts = (global_starts // cp_size)[seq_idx]
+    local_pos = local_starts + local_slot * chunk_lens + offset
+
+    rank_mask = owner == cp_rank
+    rank_positions = positions[rank_mask]
+    rank_local_pos = local_pos[rank_mask]
+    return rank_positions[torch.argsort(rank_local_pos)]
+
+
+def _zigzag_contiguous_thd_swap(
+    tensor: torch.Tensor,
+    cp_group: Optional[dist.ProcessGroup],
+    seq_dim: int,
+    cu_seqlens: torch.Tensor,
+    *,
+    source_layout: str,
+    target_layout: str,
+) -> torch.Tensor:
+    """Single-all-to-all THD permutation between zigzag and contiguous layouts.
+
+    The packed THD tensor stays packed: we first group local tokens by their target
+    CP rank, exchange those groups once, then scatter received tokens back into the
+    target rank-local order. Mirrors upstream Megatron
+    ``context_parallel_layout._zigzag_contiguous_thd_swap`` (packing-aware routing
+    from the *global* ``cu_seqlens``).
+    """
+    cp_size = dist.get_world_size(cp_group) if cp_group is not None else 1
+    if cp_size <= 1:
+        return tensor
+    cp_rank = dist.get_rank(cp_group)
+
+    if seq_dim != 0:
+        tensor = tensor.movedim(seq_dim, 0)
+    tensor = tensor.contiguous()
+
+    cu = cu_seqlens.to(device=tensor.device, dtype=torch.long)
+    source_by_rank = [
+        get_thd_context_parallel_rank_indices(cu, cp_size, rank, source_layout)
+        for rank in range(cp_size)
+    ]
+    target_by_rank = [
+        get_thd_context_parallel_rank_indices(cu, cp_size, rank, target_layout)
+        for rank in range(cp_size)
+    ]
+
+    local_source_indices = source_by_rank[cp_rank]
+    local_target_indices = target_by_rank[cp_rank]
+    if tensor.size(0) != local_source_indices.numel():
+        raise ValueError(
+            f"Local THD tensor length ({tensor.size(0)}) does not match {source_layout} "
+            f"rank-{cp_rank} partition length ({local_source_indices.numel()})."
+        )
+
+    total_tokens = int(cu[-1].item())
+    target_owner = torch.empty(total_tokens, device=tensor.device, dtype=torch.long)
+    target_local_pos = torch.empty(total_tokens, device=tensor.device, dtype=torch.long)
+    for rank, indices in enumerate(target_by_rank):
+        target_owner[indices] = rank
+        target_local_pos[indices] = torch.arange(indices.numel(), device=tensor.device)
+
+    local_target_owner = target_owner[local_source_indices]
+    local_target_pos = target_local_pos[local_source_indices]
+
+    send_parts: list[torch.Tensor] = []
+    input_split_sizes: list[int] = []
+    for dst_rank in range(cp_size):
+        dst_mask = local_target_owner == dst_rank
+        dst_rows = dst_mask.nonzero(as_tuple=False).flatten()
+        if dst_rows.numel() > 0:
+            dst_rows = dst_rows[torch.argsort(local_target_pos[dst_rows])]
+            send_part = tensor.index_select(0, dst_rows)
+        else:
+            send_part = tensor.narrow(0, 0, 0)
+        send_parts.append(send_part)
+        input_split_sizes.append(send_part.size(0))
+    send_buf = torch.cat(send_parts, dim=0).contiguous()
+
+    output_split_sizes: list[int] = []
+    recv_target_positions: list[torch.Tensor] = []
+    for src_rank in range(cp_size):
+        src_indices = source_by_rank[src_rank]
+        src_to_this_rank = target_owner[src_indices] == cp_rank
+        recv_global_indices = src_indices[src_to_this_rank]
+        if recv_global_indices.numel() > 0:
+            recv_positions = target_local_pos[recv_global_indices]
+            recv_positions = recv_positions[torch.argsort(recv_positions)]
+        else:
+            recv_positions = local_target_indices.narrow(0, 0, 0)
+        recv_target_positions.append(recv_positions)
+        output_split_sizes.append(int(recv_positions.numel()))
+
+    recv_shape = (sum(output_split_sizes), *send_buf.shape[1:])
+    recv_buf = torch.empty(recv_shape, dtype=send_buf.dtype, device=send_buf.device)
+    from torch.distributed.nn.functional import all_to_all_single
+
+    recv_buf = all_to_all_single(
+        recv_buf,
+        send_buf,
+        output_split_sizes=output_split_sizes,
+        input_split_sizes=input_split_sizes,
+        group=cp_group,
+    )
+
+    out_shape = (local_target_indices.numel(),) + tuple(tensor.shape[1:])
+    out = tensor.new_empty(out_shape)
+    offset = 0
+    for recv_positions in recv_target_positions:
+        recv_len = int(recv_positions.numel())
+        if recv_len > 0:
+            out[recv_positions] = recv_buf[offset : offset + recv_len]
+            offset += recv_len
+
+    if seq_dim != 0:
+        out = out.movedim(0, seq_dim)
+    return out.contiguous()
+
+
 def zigzag_position_ids_for_cp(
     seq_len: int,
     cp_rank: int,
@@ -350,10 +548,101 @@ def split_packed_for_cp(
     return new_ids, new_pos, new_cu, max(new_lengths)
 
 
+def build_headwise_section_perm(
+    split_sections: tuple[int, ...] | list[int],
+    cp_size: int,
+    device: torch.device,
+) -> torch.Tensor:
+    """Permutation over the hidden dim so a single contiguous ``1/cp`` slice equals
+    the concatenation of each section's ``k``-th contiguous block.
+
+    ``qkvzba`` is a concatenation of independently-headed sections (q, k, v, z,
+    beta, alpha). Head-parallel CP wants each rank to own ``1/cp`` heads of *every*
+    section. Applying this permutation before a plain hidden-scatter all-to-all makes
+    rank ``k``'s contiguous hidden shard hold section-block ``k`` of each section, so
+    the per-section split downstream (and the matching parameter slicing) is exact.
+
+    Mirrors upstream Megatron ``_build_head_perm_for_split_sections``.
+    """
+    assert all(
+        s % cp_size == 0 for s in split_sections
+    ), f"split_sections {tuple(split_sections)} must each be divisible by cp_size={cp_size}."
+    offset = 0
+    parts = []
+    for s in split_sections:
+        parts.append(
+            torch.arange(offset, offset + s, device=device, dtype=torch.long).view(cp_size, -1)
+        )
+        offset += s
+    return torch.cat(parts, dim=-1).view(-1)
+
+
+def get_parameter_local_cp_headwise(
+    param: torch.Tensor,
+    dim: int,
+    cp_size: int,
+    cp_rank: int,
+    split_sections: Optional[list[int]] = None,
+) -> torch.Tensor:
+    """Return this CP rank's head-wise slice of a parameter.
+
+    With ``split_sections`` the parameter is first split into sections along ``dim``,
+    each section is sliced to its rank-``cp_rank`` contiguous block, and the blocks are
+    re-concatenated — matching :func:`build_headwise_section_perm`. Slicing happens in
+    the forward path so gradients flow back to the full (cp_size=1) parameter.
+
+    Mirrors upstream Megatron ``get_parameter_local_cp_headwise``.
+    """
+    if cp_size <= 1:
+        return param
+    if split_sections is not None:
+        pieces = torch.split(param, split_sections, dim=dim)
+        return torch.cat(
+            [get_parameter_local_cp_headwise(p, dim, cp_size, cp_rank) for p in pieces],
+            dim=dim,
+        )
+    dim_size = param.size(dim)
+    assert (
+        dim_size % cp_size == 0
+    ), f"parameter dim {dim} size {dim_size} not divisible by cp_size={cp_size}."
+    slices: list[slice] = [slice(None)] * param.dim()
+    block = dim_size // cp_size
+    slices[dim] = slice(cp_rank * block, (cp_rank + 1) * block)
+    return param[tuple(slices)]
+
+
+def all_to_all_hidden_shards(
+    send_parts: list[torch.Tensor],
+    cp_group: dist.ProcessGroup | None,
+) -> list[torch.Tensor]:
+    """Even all-to-all over a CP group: ``send_parts[j]`` is delivered to rank ``j``;
+    the returned ``recv[i]`` is the tensor rank ``i`` sent to this rank.
+
+    All parts must share the same shape and dtype. Autograd-aware via
+    ``torch.distributed.nn.functional.all_to_all_single``.
+    """
+    cp_size = dist.get_world_size(cp_group) if cp_group is not None else 1
+    if cp_size <= 1:
+        return [send_parts[0]]
+    assert len(send_parts) == cp_size, (len(send_parts), cp_size)
+    ref = send_parts[0]
+    send = torch.stack([p.contiguous() for p in send_parts], dim=0)  # [cp, *shape]
+    flat = send.reshape(cp_size, -1).contiguous()
+    from torch.distributed.nn.functional import all_to_all_single
+
+    recv_flat = all_to_all_single(torch.empty_like(flat), flat, group=cp_group)
+    recv = recv_flat.reshape(cp_size, *ref.shape)
+    return [recv[i] for i in range(cp_size)]
+
+
 __all__ = [
+    "all_to_all_hidden_shards",
+    "build_headwise_section_perm",
     "contiguous_position_ids_for_cp",
     "contiguous_slice_for_cp",
     "contiguous_to_zigzag_chunks",
+    "get_parameter_local_cp_headwise",
+    "get_thd_context_parallel_rank_indices",
     "split_packed_for_cp",
     "zigzag_to_contiguous_chunks",
     "zigzag_reconstruct_from_cp_parts",

--- a/experimental/lite/megatron/lite/primitive/parallel/pipeline.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/pipeline.py
@@ -32,13 +32,25 @@ def forward_backward_pipelining(
     """
     Run forward and backward passes with pipeline parallelism.
 
+    Under THD + dynamic batching every micro-batch packs a different number of
+    tokens, so the inter-stage hidden — and therefore its P2P recv buffer — is a
+    different shape per micro-batch. Rather than deriving that shape locally from
+    the batch (which requires replicating the model's THD/CP/TP scatter and breaks
+    the moment those diverge), the 1F1B and forward-only schedules use Megatron's
+    dynamic shape exchange: before every inter-stage tensor transfer the sender
+    transmits the exact ``size()`` of the tensor it is about to send and the
+    receiver sizes its recv buffer from that. See ``_communicate_shapes``.
+
     Args:
         forward_step_fn: Callable(model, batch) -> output_dict with "loss" and "hidden_states"
         model_chunks: local model chunks. ``len>1`` enables interleaved VPP.
         data_iter: iterator yielding micro-batches
         config: training config
         ps: parallel state
-        tensor_shape: shape of hidden states passed between stages [B, S, H]
+        tensor_shape: nominal inter-stage hidden shape [S, B, H]. Used only by the
+            interleaved VPP schedule (fixed-shape); the 1F1B and forward-only
+            schedules ignore it and exchange the true per-micro-batch shape at
+            runtime.
         grad_sync_fn: called before the last micro-batch's backward to enable
                        overlapped gradient ReduceScatter in DistributedOptimizer.
 
@@ -230,6 +242,14 @@ def _1f1b_schedule(
     1-Forward-1-Backward pipeline schedule using batch_isend_irecv.
 
     Communication is always done via combined send+recv to avoid deadlocks.
+
+    Under THD + dynamic batching each micro-batch packs a different number of
+    tokens, so a single fixed ``tensor_shape`` would truncate the recv of the
+    later, larger micro-batches (NCCL size mismatch -> deadlock). Every recv here
+    goes through ``_send_recv_pipeline(..., dynamic_shape=True)``: the sender first
+    transmits the exact ``size()`` of the hidden/grad it is about to send and the
+    receiver sizes its recv buffer from that. No local shape derivation, no fixed
+    ``tensor_shape`` fallback — a desync fails loud instead of silently truncating.
     """
     num_warmup = min(ps.pp_size - ps.pp_rank - 1, num_microbatches)
     num_steady = num_microbatches - num_warmup
@@ -243,18 +263,6 @@ def _1f1b_schedule(
     output_hiddens: list[torch.Tensor | None] = []
     losses: list[torch.Tensor | None] = []
     outputs: list[dict] = []
-
-    # Fix 3: Pre-allocate recv buffers to avoid torch.empty per P2P call.
-    _fwd_recv_buf = (
-        torch.empty(tensor_shape, dtype=_PIPELINE_TENSOR_DTYPE, device="cuda")
-        if not ps.pp_is_first
-        else None
-    )
-    _bwd_recv_buf = (
-        torch.empty(tensor_shape, dtype=_PIPELINE_TENSOR_DTYPE, device="cuda")
-        if not ps.pp_is_last
-        else None
-    )
 
     def _run_forward(input_tensor, batch, loss_context=None):
         _set_aux_loss_scale(pre_forward_hook, num_microbatches)
@@ -279,6 +287,8 @@ def _1f1b_schedule(
         return inp_t.grad if inp_t is not None else None
 
     def _p2p(send_fwd=None, send_bwd=None, recv_fwd=False, recv_bwd=False):
+        # Megatron dynamic shape exchange: the recv buffer is sized from the shape
+        # the sender transmits, so no per-mb shape has to be tracked here.
         return _send_recv_pipeline(
             send_fwd,
             send_bwd,
@@ -286,8 +296,7 @@ def _1f1b_schedule(
             recv_bwd,
             ps,
             tensor_shape,
-            fwd_recv_buf=_fwd_recv_buf,
-            bwd_recv_buf=_bwd_recv_buf,
+            dynamic_shape=True,
         )
 
     # ── Warmup: pure forward passes ──
@@ -303,7 +312,12 @@ def _1f1b_schedule(
         hidden = out.get("hidden_states")
         loss_s = out["loss"] / num_microbatches if "loss" in out and ps.pp_is_last else None
 
-        need_recv_next = not ps.pp_is_first and k < num_warmup - 1
+        # Recv the next forward input for every remaining warmup mb AND — on the
+        # last warmup step — for the first STEADY mb (num_steady > 0). Middle
+        # stages (num_warmup >= 1 with steady work) otherwise never receive their
+        # first steady input -> None input / unmatched send -> crash/NCCL hang on
+        # PP >= 3. PP2 has no such stage, so this is a no-op there.
+        need_recv_next = not ps.pp_is_first and (k < num_warmup - 1 or num_steady > 0)
         if not ps.pp_is_last:
             fwd_input, _ = _p2p(send_fwd=hidden, recv_fwd=need_recv_next)
         elif need_recv_next:
@@ -371,6 +385,119 @@ def _1f1b_schedule(
 # Pipeline communication helpers
 # ══════════════════════════════════════════════════════════════════════
 _PIPELINE_TENSOR_DTYPE = torch.bfloat16
+# Inter-stage hidden states are rank-3 [S, B, H] (hc_mult is folded into H), so
+# the dynamic shape exchange transmits a fixed-length int64 vector of this size.
+# Matches megatron.core.pipeline_parallel.p2p_communication._communicate_shapes.
+_PIPELINE_SHAPE_NDIM = 3
+
+
+def _pipeline_device() -> "torch.device | int":
+    """Device for pipeline P2P buffers.
+
+    Returns ``torch.cuda.current_device()`` on GPU — byte-for-byte what the
+    production 1F1B path used before (``device="cuda"`` == the current device) —
+    and falls back to CPU when CUDA is unavailable, so the dynamic shape exchange
+    can be exercised under a gloo process group in unit tests without a GPU.
+    """
+    if torch.cuda.is_available():
+        return torch.cuda.current_device()
+    return torch.device("cpu")
+
+
+def _communicate_shapes(
+    send_fwd: torch.Tensor | None,
+    send_bwd: torch.Tensor | None,
+    recv_fwd: bool,
+    recv_bwd: bool,
+    ps: ParallelState,
+    *,
+    batch_p2p: bool = True,
+) -> tuple[tuple[int, ...] | None, tuple[int, ...] | None]:
+    """Exchange inter-stage tensor shapes before the tensor P2P (Megatron way).
+
+    Under THD variable-length packing every micro-batch is a different shape, so
+    the receiver cannot know the recv-buffer size a priori. Instead of deriving it
+    locally from the batch, the sender transmits the exact ``size()`` of the tensor
+    it is about to send and the receiver reads it here, then sizes its recv buffer
+    from the returned shape. The shape hop travels in the SAME direction as the
+    tensor hop it precedes (fwd -> next rank, bwd -> prev rank).
+
+    Returns ``(recv_fwd_shape, recv_bwd_shape)``; each is ``None`` when that
+    direction is not being received. A received dim <= 0 means the two stages
+    disagree on whether a transfer happens (protocol desync) -> raise, fail loud.
+
+    Mirrors ``megatron.core.pipeline_parallel.p2p_communication.
+    _P2PCommunicator._communicate_shapes``.
+    """
+    device = _pipeline_device()
+    recv_fwd_t = (
+        torch.empty(_PIPELINE_SHAPE_NDIM, dtype=torch.int64, device=device) if recv_fwd else None
+    )
+    recv_bwd_t = (
+        torch.empty(_PIPELINE_SHAPE_NDIM, dtype=torch.int64, device=device) if recv_bwd else None
+    )
+    send_fwd_t = (
+        torch.tensor(tuple(send_fwd.size()), dtype=torch.int64, device=device)
+        if send_fwd is not None
+        else None
+    )
+    send_bwd_t = (
+        torch.tensor(tuple(send_bwd.size()), dtype=torch.int64, device=device)
+        if send_bwd is not None
+        else None
+    )
+
+    p2p_group = ps.pp_group
+
+    def _ops() -> list:
+        ops: list[dist.P2POp] = []
+        if send_fwd_t is not None:
+            ops.append(dist.P2POp(dist.isend, send_fwd_t, ps.pp_next_rank, p2p_group))
+        if recv_fwd_t is not None:
+            ops.append(dist.P2POp(dist.irecv, recv_fwd_t, ps.pp_prev_rank, p2p_group))
+        if send_bwd_t is not None:
+            ops.append(dist.P2POp(dist.isend, send_bwd_t, ps.pp_prev_rank, p2p_group))
+        if recv_bwd_t is not None:
+            ops.append(dist.P2POp(dist.irecv, recv_bwd_t, ps.pp_next_rank, p2p_group))
+        return ops
+
+    if batch_p2p:
+        ops = _ops()
+        if ops:
+            for req in dist.batch_isend_irecv(ops):
+                req.wait()
+    else:
+        reqs = []
+        if send_fwd_t is not None:
+            reqs.append(dist.isend(send_fwd_t, ps.pp_next_rank, group=p2p_group))
+        if recv_fwd_t is not None:
+            reqs.append(dist.irecv(recv_fwd_t, ps.pp_prev_rank, group=p2p_group))
+        if send_bwd_t is not None:
+            reqs.append(dist.isend(send_bwd_t, ps.pp_prev_rank, group=p2p_group))
+        if recv_bwd_t is not None:
+            reqs.append(dist.irecv(recv_bwd_t, ps.pp_next_rank, group=p2p_group))
+        for req in reqs:
+            req.wait()
+    # Guard against the known batch_isend_irecv race before the buffers are read
+    # (matches Megatron core's torch.cuda.synchronize() in _communicate_shapes).
+    # No-op / unavailable on CPU (gloo unit tests) — the race is CUDA-stream only.
+    if torch.cuda.is_available() and (
+        send_fwd_t is not None or send_bwd_t is not None or recv_fwd or recv_bwd
+    ):
+        torch.cuda.synchronize()
+
+    def _shape(t: torch.Tensor | None) -> tuple[int, ...] | None:
+        if t is None:
+            return None
+        shape = tuple(int(x) for x in t.tolist())
+        if any(d <= 0 for d in shape):
+            raise RuntimeError(
+                f"pipeline dynamic shape exchange received a non-positive dim {shape} "
+                f"(rank {dist.get_rank()}): the two stages disagree on the P2P transfer."
+            )
+        return shape
+
+    return _shape(recv_fwd_t), _shape(recv_bwd_t)
 
 
 def _deallocate_output_tensor(tensor: torch.Tensor | None) -> None:
@@ -407,8 +534,16 @@ def _send_recv_pipeline(
     bwd_recv_buf: torch.Tensor | None = None,
     batch_p2p: bool = True,
     clone_recv: bool = False,
+    dynamic_shape: bool = False,
 ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
-    """P2P communication between pipeline stages."""
+    """P2P communication between pipeline stages.
+
+    ``dynamic_shape=True`` runs Megatron's dynamic shape exchange first: the recv
+    buffers are sized from the shape the sender transmits (``_communicate_shapes``)
+    rather than from the fixed ``tensor_shape`` / pre-allocated ``*_recv_buf``. This
+    is what makes THD variable-length PP correct — each micro-batch is a different
+    shape and no local derivation is needed.
+    """
     _dbg = int(os.environ.get("MEGATRON_LITE_PP_DEBUG", "0"))
     rank = dist.get_rank()
 
@@ -418,25 +553,47 @@ def _send_recv_pipeline(
 
     p2p_group = ps.pp_group
 
+    # Megatron dynamic shape exchange: learn the recv shapes from the senders
+    # before allocating recv buffers. The passed fwd/bwd_recv_buf and tensor_shape
+    # are ignored for receiving in this mode (shapes vary per micro-batch).
+    recv_fwd_shape: tuple[int, ...] | None = None
+    recv_bwd_shape: tuple[int, ...] | None = None
+    # TODO(perf): dynamic_shape allocates a fresh recv buffer per micro-batch
+    # (shapes vary, so a single fixed buffer cannot be reused). The CUDA caching
+    # allocator absorbs most of the cost, but variable shapes still fragment it.
+    # A future optimization could pre-allocate one max-sequence-length buffer and
+    # narrow into it (with clone_recv=True to avoid aliasing across micro-batches),
+    # or keep a per-shape buffer pool, to remove the per-recv allocation.
+    if dynamic_shape:
+        recv_fwd_shape, recv_bwd_shape = _communicate_shapes(
+            send_fwd, send_bwd, recv_fwd, recv_bwd, ps, batch_p2p=batch_p2p
+        )
+
     if send_fwd is not None:
         t = send_fwd.to(_PIPELINE_TENSOR_DTYPE)
         ops.append(dist.P2POp(dist.isend, t, ps.pp_next_rank, p2p_group))
     if recv_fwd:
-        fwd_buf = (
-            fwd_recv_buf
-            if fwd_recv_buf is not None
-            else torch.empty(tensor_shape, dtype=_PIPELINE_TENSOR_DTYPE, device="cuda")
-        )
+        if dynamic_shape:
+            fwd_buf = torch.empty(recv_fwd_shape, dtype=_PIPELINE_TENSOR_DTYPE, device=_pipeline_device())
+        else:
+            fwd_buf = (
+                fwd_recv_buf
+                if fwd_recv_buf is not None
+                else torch.empty(tensor_shape, dtype=_PIPELINE_TENSOR_DTYPE, device=_pipeline_device())
+            )
         ops.append(dist.P2POp(dist.irecv, fwd_buf, ps.pp_prev_rank, p2p_group))
     if send_bwd is not None:
         t = send_bwd.to(_PIPELINE_TENSOR_DTYPE)
         ops.append(dist.P2POp(dist.isend, t, ps.pp_prev_rank, p2p_group))
     if recv_bwd:
-        bwd_buf = (
-            bwd_recv_buf
-            if bwd_recv_buf is not None
-            else torch.empty(tensor_shape, dtype=_PIPELINE_TENSOR_DTYPE, device="cuda")
-        )
+        if dynamic_shape:
+            bwd_buf = torch.empty(recv_bwd_shape, dtype=_PIPELINE_TENSOR_DTYPE, device=_pipeline_device())
+        else:
+            bwd_buf = (
+                bwd_recv_buf
+                if bwd_recv_buf is not None
+                else torch.empty(tensor_shape, dtype=_PIPELINE_TENSOR_DTYPE, device=_pipeline_device())
+            )
         ops.append(dist.P2POp(dist.irecv, bwd_buf, ps.pp_next_rank, p2p_group))
 
     if ops:
@@ -530,7 +687,13 @@ def _forward_only_pipeline_schedule(
     pre_forward_hook=None,
     loss_fn=None,
 ):
-    """Simple PP/VPP forward-only schedule used for log-prob inference."""
+    """Simple PP/VPP forward-only schedule used for log-prob inference.
+
+    Uses Megatron dynamic shape exchange at every stage boundary so THD
+    variable-length micro-batches size their recv buffers from the sender's real
+    shape (``_send_recv_pipeline(..., dynamic_shape=True)``) instead of a fixed
+    ``tensor_shape``.
+    """
     num_chunks = len(model_chunks)
     total_stages = ps.pp_size * num_chunks
     outputs: list[dict] = []
@@ -580,6 +743,7 @@ def _forward_only_pipeline_schedule(
                     tensor_shape,
                     batch_p2p=False,
                     clone_recv=True,
+                    dynamic_shape=True,
                 )
                 if recv_next:
                     pending_activation = fwd_buf

--- a/experimental/lite/megatron/lite/primitive/quantization/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/quantization/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Checkpoint-format quantization primitives."""
+
+from megatron.lite.primitive.quantization.block_fp8 import quantize_block_fp8
+from megatron.lite.primitive.quantization.mxfp4 import quantize_mxfp4
+
+__all__ = ["quantize_block_fp8", "quantize_mxfp4"]

--- a/experimental/lite/megatron/lite/primitive/quantization/block_fp8.py
+++ b/experimental/lite/megatron/lite/primitive/quantization/block_fp8.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Pure-tensor block-FP8 checkpoint serialization."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import torch
+
+ScaleFormat = Literal["float32", "e8m0"]
+
+
+def _validate(tensor: torch.Tensor, block_shape: tuple[int, int]) -> None:
+    if tensor.ndim < 2:
+        raise ValueError(
+            f"block-FP8 tensor must have at least two dimensions, got {tensor.shape}"
+        )
+    if not tensor.dtype.is_floating_point:
+        raise TypeError(f"block-FP8 source must be floating point, got {tensor.dtype}")
+    block_m, block_k = block_shape
+    if block_m <= 0 or block_k <= 0:
+        raise ValueError(f"block shape must be positive, got {block_shape}")
+    if tensor.shape[-2] % block_m or tensor.shape[-1] % block_k:
+        raise ValueError(
+            f"tensor trailing shape {tuple(tensor.shape[-2:])} must be divisible by "
+            f"block shape {block_shape}"
+        )
+
+
+def _encode_e8m0(scale: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    exponent = torch.ceil(torch.log2(scale)).clamp(-127, 127)
+    encoded = (exponent + 127).to(torch.uint8)
+    rounded = torch.exp2(exponent)
+    return rounded, encoded.view(torch.float8_e8m0fnu)
+
+
+def quantize_block_fp8(
+    tensor: torch.Tensor,
+    block_shape: tuple[int, int] = (128, 128),
+    *,
+    scale_format: ScaleFormat = "float32",
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize trailing 2-D blocks to E4M3 and checkpoint-format descales."""
+    _validate(tensor, block_shape)
+    if scale_format not in {"float32", "e8m0"}:
+        raise ValueError(f"unsupported block-FP8 scale format: {scale_format!r}")
+
+    source = tensor.float()
+    block_m, block_k = block_shape
+    *leading, rows, columns = source.shape
+    row_blocks = rows // block_m
+    column_blocks = columns // block_k
+    blocked = source.reshape(*leading, row_blocks, block_m, column_blocks, block_k)
+    amax = blocked.abs().amax(dim=(-3, -1))
+    fp8_max = torch.finfo(torch.float8_e4m3fn).max
+    # Match vLLM/DeepGEMM checkpoint quantization: clamp the block amax before
+    # dividing by E4M3's finite maximum, then optionally ceil to UE8M0.
+    scale_f = amax.clamp_min(1e-4) / fp8_max
+    if scale_format == "e8m0":
+        scale_f, serialized_scale = _encode_e8m0(scale_f)
+    else:
+        serialized_scale = scale_f
+
+    expanded = scale_f.repeat_interleave(block_m, dim=-2).repeat_interleave(
+        block_k, dim=-1
+    )
+    quantized = (source / expanded).clamp(-fp8_max, fp8_max).to(torch.float8_e4m3fn)
+    return quantized, serialized_scale.contiguous()
+
+
+def dequantize_block_fp8(
+    tensor: torch.Tensor,
+    scale: torch.Tensor,
+    block_shape: tuple[int, int] = (128, 128),
+) -> torch.Tensor:
+    """Dequantize a tensor emitted by :func:`quantize_block_fp8`."""
+    _validate(tensor, block_shape)
+    block_m, block_k = block_shape
+    expected = (
+        *tensor.shape[:-2],
+        tensor.shape[-2] // block_m,
+        tensor.shape[-1] // block_k,
+    )
+    if tuple(scale.shape) != expected:
+        raise ValueError(
+            f"scale shape {tuple(scale.shape)} does not match expected {expected}"
+        )
+    scale_f = scale.float()
+    expanded = scale_f.repeat_interleave(block_m, dim=-2).repeat_interleave(
+        block_k, dim=-1
+    )
+    return tensor.float() * expanded
+
+
+__all__ = ["ScaleFormat", "dequantize_block_fp8", "quantize_block_fp8"]

--- a/experimental/lite/megatron/lite/primitive/quantization/mxfp4.py
+++ b/experimental/lite/megatron/lite/primitive/quantization/mxfp4.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""MXFP4 E2M1 + UE8M0 checkpoint serialization."""
+
+from __future__ import annotations
+
+import torch
+
+MXFP4_BLOCK_SIZE = 32
+_E2M1_POSITIVE = (0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0)
+
+
+def _validate(tensor: torch.Tensor) -> None:
+    if tensor.ndim < 1:
+        raise ValueError("MXFP4 tensor must have at least one dimension")
+    if not tensor.dtype.is_floating_point:
+        raise TypeError(f"MXFP4 source must be floating point, got {tensor.dtype}")
+    if tensor.shape[-1] % MXFP4_BLOCK_SIZE:
+        raise ValueError(
+            f"tensor last dimension {tensor.shape[-1]} must be divisible by "
+            f"{MXFP4_BLOCK_SIZE}"
+        )
+
+
+def _select_scale(blocks: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    amax = blocks.abs().amax(dim=-1)
+    floor = 6.0 * (2.0**-126)
+    exponent = torch.ceil(torch.log2(amax.clamp_min(floor) / 6.0)).clamp(-127, 127)
+    encoded = (exponent + 127).to(torch.uint8)
+    return torch.exp2(exponent), encoded.view(torch.float8_e8m0fnu)
+
+
+def _quantize_nibbles(values: torch.Tensor) -> torch.Tensor:
+    magnitude = values.abs()
+    # Midpoints between [0, .5, 1, 1.5, 2, 3, 4, 6]. Start with strict
+    # greater-than so ties stay on the lower encoding, then promote only the
+    # three midpoints whose upper encoding is even. This reproduces PTX
+    # ``cvt.rn.satfinite.e2m1x2.f32`` without an 8x codebook-distance tensor.
+    boundaries = (0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0)
+    index = torch.zeros_like(magnitude, dtype=torch.uint8)
+    for boundary in boundaries:
+        index += (magnitude > boundary).to(torch.uint8)
+    for upper_even_boundary in (0.75, 1.75, 3.5):
+        index += (magnitude == upper_even_boundary).to(torch.uint8)
+    sign = torch.where(values.signbit(), torch.tensor(8, device=values.device), 0).to(
+        torch.uint8
+    )
+    return index | sign
+
+
+def quantize_mxfp4(tensor: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Serialize the last dimension in 32-value MXFP4 blocks."""
+    _validate(tensor)
+    source = tensor.float()
+    blocks = source.reshape(*source.shape[:-1], -1, MXFP4_BLOCK_SIZE)
+    scale_f, scale = _select_scale(blocks)
+    normalized = blocks / scale_f.unsqueeze(-1)
+    nibbles = _quantize_nibbles(normalized).reshape(
+        *source.shape[:-1], source.shape[-1]
+    )
+    packed = nibbles[..., 0::2] | (nibbles[..., 1::2] << 4)
+    return packed.contiguous().view(torch.int8), scale.contiguous()
+
+
+def dequantize_mxfp4(packed: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+    """Dequantize checkpoint-format MXFP4 for CPU validation."""
+    if packed.dtype != torch.int8:
+        raise TypeError(f"MXFP4 packed tensor must be int8, got {packed.dtype}")
+    expected = (*packed.shape[:-1], packed.shape[-1] * 2 // MXFP4_BLOCK_SIZE)
+    if tuple(scale.shape) != expected:
+        raise ValueError(
+            f"scale shape {tuple(scale.shape)} does not match expected {expected}"
+        )
+    table = torch.tensor(
+        (*_E2M1_POSITIVE, *(value * -1.0 for value in _E2M1_POSITIVE)),
+        dtype=torch.float32,
+        device=packed.device,
+    )
+    raw = packed.view(torch.uint8)
+    values = torch.stack((table[(raw & 0x0F).long()], table[(raw >> 4).long()]), dim=-1)
+    values = values.flatten(-2)
+    expanded_scale = scale.float().repeat_interleave(MXFP4_BLOCK_SIZE, dim=-1)
+    return values * expanded_scale
+
+
+__all__ = ["MXFP4_BLOCK_SIZE", "dequantize_mxfp4", "quantize_mxfp4"]

--- a/experimental/lite/megatron/lite/runtime/backends/__init__.py
+++ b/experimental/lite/megatron/lite/runtime/backends/__init__.py
@@ -79,6 +79,7 @@ class Runtime(ABC):
         *,
         num_microbatches: int = 1,
         forward_only: bool = False,
+        router_replay: Any = None,
     ) -> ForwardResult:
         """Forward + backward pass over data.
 

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/router_replay.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/router_replay.py
@@ -1,0 +1,164 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Model-agnostic MoE router replay for the MLite runtime."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import torch
+import torch.distributed as dist
+
+from megatron.lite.model import protocol_utils
+from megatron.lite.primitive.modules.router_replay import (
+    RouterReplay,
+    RouterReplayAction,
+    attach_router_replay,
+    detach_router_replay,
+)
+from megatron.lite.primitive.parallel.thd import parallel_state_from_model
+
+
+def _protocol_fn(protocol, name: str, fallback):
+    fn = getattr(protocol, name, None) if protocol is not None else None
+    return fn or fallback
+
+
+class RouterReplayDriver:
+    """Own the record/replay lifecycle for one ``forward_backward`` call."""
+
+    def __init__(self, handle, action: str):
+        if action not in ("record", "replay"):
+            raise ValueError(
+                f"router replay action must be 'record' or 'replay', got {action!r}."
+            )
+        self.handle = handle
+        self.action = action
+        self._chunks = handle._extras.get("model_chunks", [handle._model])
+        self._protocol = handle._extras.get("protocol")
+        self._num_routers = 0
+        self._ps = None
+        self._pp_offset = 0
+        self._pp_total = 0
+
+    def _replay_roots(self):
+        selector = (
+            getattr(self._protocol, "router_replay_roots", None)
+            if self._protocol is not None
+            else None
+        )
+        for chunk in self._chunks:
+            roots = selector(chunk) if selector is not None else [chunk]
+            yield from roots
+
+    @classmethod
+    def maybe_create(cls, handle, spec: Any) -> "RouterReplayDriver | None":
+        if not spec:
+            return None
+        action = spec.get("action") if isinstance(spec, dict) else spec
+        if action in (None, "disabled"):
+            return None
+        return cls(handle, action)
+
+    def begin(self) -> None:
+        RouterReplay.clear_global_router_replay_instances()
+        self._num_routers = sum(
+            attach_router_replay(root, reset=False) for root in self._replay_roots()
+        )
+        if self._num_routers == 0:
+            raise RuntimeError("router replay requested but the model has no MoE routers.")
+        self._ps = parallel_state_from_model(self._chunks[-1])
+        self._compute_pp_layout()
+        if self.action == "record":
+            RouterReplay.set_global_router_replay_action(RouterReplayAction.RECORD)
+
+    def _compute_pp_layout(self) -> None:
+        ps = self._ps
+        if ps is None or ps.pp_size <= 1:
+            self._pp_total = self._num_routers
+            return
+        counts = [torch.zeros(1, dtype=torch.long, device="cuda") for _ in range(ps.pp_size)]
+        dist.all_gather(
+            counts,
+            torch.tensor([self._num_routers], dtype=torch.long, device="cuda"),
+            group=ps.pp_group,
+        )
+        values = [int(count.item()) for count in counts]
+        self._pp_offset = sum(values[: ps.pp_rank])
+        self._pp_total = sum(values)
+
+    def wrap(self, forward_step: Callable) -> Callable:
+        if self.action == "record":
+            return self._wrap_record(forward_step)
+        return self._wrap_replay(forward_step)
+
+    def _wrap_record(self, forward_step: Callable) -> Callable:
+        def stepped(model, batch):
+            RouterReplay.set_global_router_replay_action(RouterReplayAction.RECORD)
+            return forward_step(model, batch)
+
+        return stepped
+
+    def _wrap_replay(self, forward_step: Callable) -> Callable:
+        def stepped(model, batch):
+            routed = getattr(batch, "routed_experts", None)
+            if routed is None:
+                raise ValueError("R3 router replay requires batch.routed_experts.")
+            routed = self._select_local_layers(routed)
+            pack_routes = _protocol_fn(
+                self._protocol, "pack_routed_experts", protocol_utils.pack_routed_experts
+            )
+            pack_mask = _protocol_fn(
+                self._protocol, "pack_r3_replay_mask", protocol_utils.pack_r3_replay_mask
+            )
+            targets = pack_routes(model, batch, routed)
+            replay_mask = pack_mask(model, batch)
+            RouterReplay.set_replay_data(targets, replay_mask=replay_mask)
+            RouterReplay.set_global_router_replay_action(RouterReplayAction.REPLAY_FORWARD)
+            try:
+                return forward_step(model, batch)
+            finally:
+                # Pipeline schedules may recompute checkpointed router forwards
+                # after one or more newer micro-batches have run.  Those calls
+                # must consume the saved per-microbatch FIFO, not the latest
+                # forward target.
+                RouterReplay.set_global_router_replay_action(
+                    RouterReplayAction.REPLAY_BACKWARD
+                )
+
+        return stepped
+
+    def _select_local_layers(self, routed):
+        ps = self._ps
+        if ps is None or ps.pp_size <= 1:
+            expected = self._num_routers
+            actual = (
+                int(routed.values().size(1))
+                if getattr(routed, "is_nested", False)
+                else int(routed.size(-2))
+            )
+            if actual != expected:
+                raise ValueError(
+                    f"R3 route layer count mismatch: rollout={actual}, actor={expected}. "
+                    "DS4 routing must include hash and learned MoE layers in model order."
+                )
+            return routed
+        lo, hi = self._pp_offset, self._pp_offset + self._num_routers
+        first_row = next(iter(routed.unbind(0)))
+        if int(first_row.size(1)) != self._pp_total:
+            raise ValueError(
+                f"R3 route layer count mismatch: rollout={first_row.size(1)}, "
+                f"actor={self._pp_total}. DS4 routing must include hash and learned "
+                "MoE layers in model order."
+            )
+        rows = [row[:, lo:hi, :] for row in routed.unbind(0)]
+        return torch.nested.as_nested_tensor(rows, layout=torch.jagged)
+
+    def end(self) -> None:
+        RouterReplay.clear_global_state()
+        for root in self._replay_roots():
+            detach_router_replay(root)
+        RouterReplay.clear_global_router_replay_instances()
+
+
+__all__ = ["RouterReplayDriver"]

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import gc
 import os
 from collections.abc import Callable, Iterator
 from dataclasses import fields as dc_fields
@@ -362,6 +363,14 @@ class MegatronLiteRuntime(RuntimeBase):
             for chunk in model_chunks:
                 yield from chunk.named_parameters()
 
+    def release_export_scratch(self, handle: ModelHandle) -> None:
+        """Release retained full-parameter scratch before colocated rollout wake."""
+        model_chunks = handle._extras.get("model_chunks", [handle._model])
+        for chunk in model_chunks:
+            release = getattr(chunk, "release_export_scratch", None)
+            if callable(release):
+                release()
+
     # ── Memory ──
 
     def to(
@@ -381,19 +390,36 @@ class MegatronLiteRuntime(RuntimeBase):
             offload_optimizer,
         )
 
+        # A model+gradient transfer is the training context boundary.  On its
+        # CPU side the colocated rollout is about to map its sleeping weights;
+        # on its CUDA side training is taking the device back.  Keep the whole
+        # release/restore contract here rather than teaching VERL about backend
+        # scratch buffers or optimizer residency.
+        training_transfer = model and grad
         if device == "cpu":
             if model:
                 offload_model_to_cpu(model_chunks)
-            if optimizer and handle._optimizer is not None:
+            if (optimizer or training_transfer) and handle._optimizer is not None:
                 offload_state = getattr(handle._optimizer, "offload_state_to_cpu", None)
                 if callable(offload_state):
                     offload_state()
                 else:
                     offload_optimizer(handle._optimizer)
+            if training_transfer:
+                self.release_export_scratch(handle)
+                if torch.cuda.is_available():
+                    torch.cuda.synchronize()
+                    # R3/full-recompute may leave CUDA tensors reachable only
+                    # through dead Python cycles until the next periodic GC.
+                    # vLLM remaps its sleeping weights immediately after this
+                    # boundary, so collect those cycles before asking the CUDA
+                    # allocator to return their now-unused blocks.
+                    gc.collect()
+                    torch.cuda.empty_cache()
         elif device == "cuda":
             if model:
                 load_model_to_gpu(model_chunks, load_grad=grad)
-            if optimizer and handle._optimizer is not None:
+            if (optimizer or training_transfer) and handle._optimizer is not None:
                 load_state = getattr(handle._optimizer, "load_state_to_device", None)
                 if callable(load_state):
                     load_state()
@@ -418,8 +444,10 @@ class MegatronLiteRuntime(RuntimeBase):
         *,
         num_microbatches: int = 1,
         forward_only: bool = False,
+        router_replay: Any = None,
     ) -> ForwardResult:
         from megatron.lite.primitive.train_step import run_microbatch_loop
+        from megatron.lite.runtime.backends.mlite.router_replay import RouterReplayDriver
 
         forward_step = handle._extras["forward_step"]
         if num_microbatches < 1:
@@ -432,6 +460,11 @@ class MegatronLiteRuntime(RuntimeBase):
         else:
             data_iter = iter([data])
 
+        replay_driver = RouterReplayDriver.maybe_create(handle, router_replay)
+        if replay_driver is not None:
+            replay_driver.begin()
+            forward_step = replay_driver.wrap(forward_step)
+
         ps = handle._parallel_state
         if ps.pp_size > 1:
             from types import SimpleNamespace
@@ -442,23 +475,31 @@ class MegatronLiteRuntime(RuntimeBase):
             first_item = next(data_iter)
             first_batch, _loss_context = split_loss_context(first_item)
             data_iter = chain([first_item], data_iter)
-            tensor_shape = _infer_pipeline_tensor_shape(
-                first_batch, handle._extras.get("model_cfg"), ps
-            )
+            model_cfg = handle._extras.get("model_cfg")
+            # Nominal inter-stage shape for the fixed-shape VPP path. The 1F1B and
+            # forward-only schedules ignore this and use Megatron dynamic shape
+            # exchange (the sender transmits its real per-micro-batch size), so THD
+            # variable-length packing no longer needs a locally-derived shape.
+            tensor_shape = _infer_pipeline_tensor_shape(first_batch, model_cfg, ps)
+
             model_chunks = handle._extras.get("model_chunks", [handle._model])
             pipeline_chunks = [unwrap_model(chunk) for chunk in model_chunks]
             pipeline_forward_step, pipeline_loss_fn = _pipeline_callbacks(forward_step, loss_fn)
-            outputs = forward_backward_pipelining(
-                pipeline_forward_step,
-                pipeline_chunks,
-                data_iter,
-                SimpleNamespace(num_microbatches=num_microbatches),
-                ps,
-                tensor_shape=tensor_shape,
-                pre_forward_hook=handle._extras.get("pre_forward_hook"),
-                loss_fn=pipeline_loss_fn,
-                forward_only=forward_only,
-            )
+            try:
+                outputs = forward_backward_pipelining(
+                    pipeline_forward_step,
+                    pipeline_chunks,
+                    data_iter,
+                    SimpleNamespace(num_microbatches=num_microbatches),
+                    ps,
+                    tensor_shape=tensor_shape,
+                    pre_forward_hook=handle._extras.get("pre_forward_hook"),
+                    loss_fn=pipeline_loss_fn,
+                    forward_only=forward_only,
+                )
+            finally:
+                if replay_driver is not None:
+                    replay_driver.end()
             out = _last_loss_output(outputs)
             loss_obj = out.get("loss") if out else None
             if isinstance(loss_obj, torch.Tensor):
@@ -474,17 +515,21 @@ class MegatronLiteRuntime(RuntimeBase):
                 dist.broadcast(loss_payload, src=ps.pp_global_ranks[-1], group=ps.pp_group)
             out = {"loss": loss_payload[1]} if bool(loss_payload[0].item()) else {}
         else:
-            out = run_microbatch_loop(
-                handle._model,
-                data_iter,
-                num_microbatches,
-                forward_step,
-                optimizer=handle._optimizer if not forward_only else None,
-                dist_opt=not forward_only,
-                pre_forward_hook=handle._extras.get("pre_forward_hook"),
-                loss_fn=loss_fn,
-                forward_only=forward_only,
-            )
+            try:
+                out = run_microbatch_loop(
+                    handle._model,
+                    data_iter,
+                    num_microbatches,
+                    forward_step,
+                    optimizer=handle._optimizer if not forward_only else None,
+                    dist_opt=not forward_only,
+                    pre_forward_hook=handle._extras.get("pre_forward_hook"),
+                    loss_fn=loss_fn,
+                    forward_only=forward_only,
+                )
+            finally:
+                if replay_driver is not None:
+                    replay_driver.end()
 
         if not forward_only:
             finalize_grads = handle._extras.get("finalize_grads")

--- a/experimental/lite/megatron/lite/runtime/contracts/weights.py
+++ b/experimental/lite/megatron/lite/runtime/contracts/weights.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Contracts for model-to-rollout weight streams."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class ResyncFormat(str, Enum):
+    BF16 = "bf16"
+    BLOCK_FP8 = "block_fp8"
+    MXFP4 = "mxfp4"
+
+    @classmethod
+    def parse(cls, value: "str | ResyncFormat") -> "ResyncFormat":
+        if isinstance(value, cls):
+            return value
+        try:
+            return cls(value)
+        except ValueError as exc:
+            supported = ", ".join(item.value for item in cls)
+            raise ValueError(
+                f"unsupported resync_format={value!r}; expected one of: {supported}"
+            ) from exc
+
+
+__all__ = ["ResyncFormat"]

--- a/experimental/lite/megatron/lite/runtime/megatron_utils.py
+++ b/experimental/lite/megatron/lite/runtime/megatron_utils.py
@@ -96,6 +96,30 @@ def _is_megatron_ddp(model_chunk: Any) -> bool:
     )
 
 
+def _reshard_fsdp2_modules(model_chunk: Any) -> None:
+    """Return nested FSDP2 modules to their sharded state before offload.
+
+    ``reshard_after_forward`` controls the normal forward/backward schedule,
+    but it is not a context-switch barrier: prefetch, export, or an exception
+    can leave one or more units materialized when VERL asks us to offload the
+    model.  Calling ``Module.to("cpu")`` in that state moves full parameters
+    and can also make FSDP2 reset a partially materialized plain Parameter as
+    though it were a sharded DTensor.  Reshard children before parents so only
+    local shards cross the device boundary.
+    """
+    try:
+        from torch.distributed.fsdp import FSDPModule
+    except ImportError:
+        return
+
+    modules = getattr(model_chunk, "modules", None)
+    if not callable(modules):
+        return
+    for module in reversed(list(modules())):
+        if isinstance(module, FSDPModule):
+            module.reshard()
+
+
 def offload_model_to_cpu(model_list: list) -> None:
     """Offload DDP model to CPU via buffer-resize (zero-copy on GPU side)."""
     for model_chunk in model_list:
@@ -116,6 +140,7 @@ def offload_model_to_cpu(model_list: list) -> None:
                 if not param.requires_grad and param.device.type != "cpu":
                     param.data = param.data.to("cpu", non_blocking=True)
         else:
+            _reshard_fsdp2_modules(model_chunk)
             model_chunk.to("cpu")
 
 

--- a/experimental/lite/tests/smoke/primitive/gdn_cp_mode_parity.py
+++ b/experimental/lite/tests/smoke/primitive/gdn_cp_mode_parity.py
@@ -1,0 +1,331 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Qwen3.5 GatedDeltaNet CP-mode precision parity proxy.
+
+Matrix (baseline = CP off / full sequence, cp_size=1):
+  SBHD: gdn_cp_mode in {"headwise"(default), "chunkwise"} x CP in {cp2/cp4}
+  packed THD: gdn_cp_mode="chunkwise" (the RL path) vs CP-off dense reference
+
+``headwise`` is bitwise-exact vs CP-off; ``chunkwise`` runs the FLA ring
+(cross-rank chunk-state reassociation) so it is expected at the bf16 floor, not bitwise.
+The packed THD arm exercises the packing-aware reshuffle the old ``sharded`` copy broke.
+
+Design
+------
+The primitive input is SBHD ``x = [seq, batch, hidden]``; CP shards along the
+seq dim (dim 0) with the Megatron **zigzag** layout. Each rank feeds its zigzag
+shard; the module internally head-parallelises / reconstructs the sequence and
+returns the rank-local zigzag shard of the output.
+
+- ``headwise`` (default): head-parallel all-to-all. Each rank ends up with the
+  full sequence for ``1/cp`` of the heads (plus the matching conv1d/A_log/dt_bias
+  slices), runs the ordinary full-sequence recurrence, then all-to-alls back. Heads
+  are independent -> **bitwise identical** to the CP-off reference, memory sharded.
+  on every rank, then zigzag-slice the output. Also bitwise identical to CP-off, but
+  every rank materialises the full sequence for all heads (worst memory).
+
+Reference = a cp_size=1 module (identical weights) run on the FULL sequence on
+rank 0. For every rank we compare its CP output to the zigzag slice of the
+reference output (forward), and likewise for the input gradient; weight grads are
+CP-all-reduced then compared to the reference weight grads. Both modes are expected
+to be bitwise-exact (max_abs == 0) vs the reference.
+
+Run under: torchrun --nproc_per_node={2,4} gdn_cp_mode_parity.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+import traceback
+
+import torch
+import torch.distributed as dist
+
+# --- proxy geometry: REAL Qwen3.5 GDN head config (16 k / 32 v heads, dk=dv=128,
+# conv=4). Head counts are kept real (not truncated) because headwise CP shards
+# heads across ranks, so num_k_heads must stay divisible by cp_size (>=4 here). ---
+HIDDEN = 256
+NUM_K_HEADS = 16
+K_HEAD_DIM = 128
+NUM_V_HEADS = 32
+V_HEAD_DIM = 128
+CONV_KERNEL = 4
+RMS_EPS = 1e-6
+SEQ = 2048          # divisible by 2*cp_size for cp in {2,4} and by FLA chunk 64
+BATCH = 1
+DTYPE = torch.bfloat16
+SEED = 20260714
+
+
+def _make_ps(cp_size, cp_rank, cp_group):
+    from megatron.lite.primitive.parallel.state import ParallelState
+
+    return ParallelState(cp_group=cp_group, cp_size=cp_size, cp_rank=cp_rank)
+
+
+def _make_gdn(cp_size, cp_rank, cp_group, cp_mode):
+    from megatron.lite.primitive.modules.gated_delta_net import GatedDeltaNet
+
+    return GatedDeltaNet(
+        hidden_size=HIDDEN,
+        linear_num_key_heads=NUM_K_HEADS,
+        linear_key_head_dim=K_HEAD_DIM,
+        linear_num_value_heads=NUM_V_HEADS,
+        linear_value_head_dim=V_HEAD_DIM,
+        linear_conv_kernel_dim=CONV_KERNEL,
+        rms_norm_eps=RMS_EPS,
+        ps=_make_ps(cp_size, cp_rank, cp_group),
+        deterministic=True,
+        cp_mode=cp_mode,
+    )
+
+
+def _randomize_and_broadcast(module):
+    """Give the module non-degenerate weights, identical across ranks (src=0)."""
+    torch.manual_seed(SEED)
+    with torch.no_grad():
+        for name, p in module.named_parameters():
+            # A_log defaults to 0 and dt_bias to 1 -> gating is trivial; perturb so
+            # the delta-rule recurrence is genuinely exercised.
+            if name.endswith("A_log"):
+                p.copy_(torch.randn_like(p) * 0.5 - 1.0)
+            elif name.endswith("dt_bias"):
+                p.copy_(torch.randn_like(p) * 0.1)
+            else:
+                p.mul_(1.0)  # keep nn default init (already random for lin/conv)
+    for p in module.parameters():
+        dist.broadcast(p.data, src=0)
+    for b in module.buffers():
+        dist.broadcast(b.data, src=0)
+
+
+def _diff(a, b):
+    a = a.float()
+    b = b.float()
+    d = (a - b).abs()
+    max_abs = d.max().item()
+    scale = b.abs().max().clamp_min(1e-8)
+    max_rel = (d.max() / scale).item()
+    return max_abs, max_rel, scale.item()
+
+
+def run_matrix(cp_size, cp_rank, cp_group, cp1_group, device, rank, world):
+    from megatron.lite.primitive.parallel.cp import zigzag_slice_for_cp
+
+    results = {}
+    # full-sequence input, identical on every rank
+    torch.manual_seed(SEED + 1)
+    full_x = torch.randn(SEQ, BATCH, HIDDEN, device=device, dtype=DTYPE)
+    dist.broadcast(full_x, src=0)
+    torch.manual_seed(SEED + 2)
+    ref_cotangent = torch.randn(SEQ, BATCH, HIDDEN, device=device, dtype=DTYPE)
+    dist.broadcast(ref_cotangent, src=0)
+
+    # ----- reference (cp off, cp1) is built per-mode on rank 0 with identical weights -----
+    ref_out_full = None
+    ref_in_grad_full = None
+    ref_wgrads = None
+
+    # headwise is bitwise-exact vs CP-off (heads independent); chunkwise
+    # runs the FLA ring so it reassociates in bf16 and is expected at the bf16 floor,
+    # not bitwise (still orders of magnitude below the old packed-path O(1) corruption).
+    for cp_mode in ("headwise", "chunkwise"):
+        cp_mod = _make_gdn(cp_size, cp_rank, cp_group, cp_mode).to(device=device, dtype=DTYPE)
+        _randomize_and_broadcast(cp_mod)
+
+        # reference module (cp1) with identical weights, on rank 0
+        ref_mod = None
+        if rank == 0:
+            ref_mod = _make_gdn(1, 0, cp1_group, cp_mode).to(device=device, dtype=DTYPE)
+            ref_mod.load_state_dict(cp_mod.state_dict())
+
+        # ---- forward ----
+        local_x = (
+            zigzag_slice_for_cp(full_x, cp_rank, cp_size, seq_dim=0)
+            .detach()
+            .requires_grad_(True)
+        )
+        cp_out = cp_mod(local_x)  # [S_local, B, H]
+
+        # Compare each rank's local out vs the zigzag slice of the reference out.
+        if rank == 0:
+            ref_x = full_x.detach().requires_grad_(True)
+            with torch.enable_grad():
+                ref_out = ref_mod(ref_x)
+            # backward on reference with the zigzag-sliced cotangent (full)
+            ref_out.backward(ref_cotangent)
+            ref_in_grad_full = ref_x.grad.detach().clone()
+            ref_wgrads = {n: (p.grad.detach().clone() if p.grad is not None else None)
+                          for n, p in ref_mod.named_parameters()}
+            ref_out_full = ref_out.detach().clone()
+
+        # broadcast ref_out_full so every rank can slice its own expected shard
+        if ref_out_full is None:
+            ref_out_full = torch.empty(SEQ, BATCH, HIDDEN, device=device, dtype=DTYPE)
+        dist.broadcast(ref_out_full, src=0)
+        expected_local = zigzag_slice_for_cp(ref_out_full, cp_rank, cp_size, seq_dim=0)
+        f_abs, f_rel, f_scale = _diff(cp_out.detach(), expected_local)
+
+        # ---- backward ---- (cotangent = zigzag slice of the shared full cotangent)
+        local_cot = zigzag_slice_for_cp(ref_cotangent, cp_rank, cp_size, seq_dim=0)
+        cp_out.backward(local_cot)
+        cp_in_grad = local_x.grad.detach().clone()
+
+        # broadcast ref input grad; compare zigzag slice
+        if ref_in_grad_full is None:
+            ref_in_grad_full = torch.empty(SEQ, BATCH, HIDDEN, device=device, dtype=DTYPE)
+        dist.broadcast(ref_in_grad_full, src=0)
+        expected_in_grad = zigzag_slice_for_cp(ref_in_grad_full, cp_rank, cp_size, seq_dim=0)
+        g_abs, g_rel, g_scale = _diff(cp_in_grad, expected_in_grad)
+
+        # weight grads: CP-all-reduce (sum) then compare on rank 0
+        for n, p in cp_mod.named_parameters():
+            if p.grad is None:
+                p.grad = torch.zeros_like(p)
+            dist.all_reduce(p.grad, op=dist.ReduceOp.SUM, group=cp_group)
+        w_abs = w_rel = 0.0
+        worst_w = None
+        if rank == 0:
+            for n, p in cp_mod.named_parameters():
+                rg = ref_wgrads.get(n)
+                if rg is None:
+                    rg = torch.zeros_like(p.grad)
+                a, r, _ = _diff(p.grad, rg)
+                if a > w_abs:
+                    w_abs, worst_w = a, n
+                w_rel = max(w_rel, r)
+
+        results[cp_mode] = dict(
+            f_abs=f_abs, f_rel=f_rel, f_scale=f_scale,
+            g_abs=g_abs, g_rel=g_rel, g_scale=g_scale,
+            w_abs=w_abs, w_rel=w_rel, worst_w=worst_w,
+        )
+        if cp_rank == 0:
+            print(
+                f"GDN_CP_PARITY mode={cp_mode} cp={cp_size} seq={SEQ} "
+                f"fwd[max_abs={f_abs:.3e} max_rel={f_rel:.3e} scale={f_scale:.3e}] "
+                f"in_grad[max_abs={g_abs:.3e} max_rel={g_rel:.3e} scale={g_scale:.3e}] "
+                f"w_grad[max_abs={w_abs:.3e} max_rel={w_rel:.3e} worst={worst_w}]",
+                flush=True,
+            )
+        del cp_mod, ref_mod
+        torch.cuda.empty_cache()
+        dist.barrier()
+
+    return results
+
+
+# Packed THD lengths (each divisible by 2*cp for cp in {2,4}); a sequence deliberately
+# spans the contiguous CP-rank boundary so the packing-aware reshuffle is exercised.
+PACKED_LENS = [1024, 512, 512]  # total 2048
+
+
+def run_packed_matrix(cp_size, cp_rank, cp_group, cp1_group, device, rank, world):
+    """Packed THD chunkwise parity: CP chunkwise vs CP-off dense reference.
+
+    This is the path RL actually runs (``impl_cfg.use_thd=True``) and the one the old
+    ``sharded`` copy corrupted. Reference = a cp1 module on the FULL packed sequence;
+    each CP rank is fed its zigzag shard + the *global* cu_seqlens. A correct
+    packing-aware reshuffle keeps the packed chunkwise output at the bf16 ring floor vs
+    the reference (was ~O(1) / 220x-ppo_kl before the fix).
+    """
+    from megatron.lite.primitive.parallel.thd import split_packed_to_cp_local
+    from megatron.lite.primitive.utils.packed_seq import PackedSeqParams
+
+    lens = torch.tensor(PACKED_LENS, dtype=torch.int32, device=device)
+    cu = torch.zeros(len(PACKED_LENS) + 1, dtype=torch.int32, device=device)
+    torch.cumsum(lens, dim=0, out=cu[1:])
+    total = int(cu[-1].item())
+    max_seqlen = int(lens.max().item())
+
+    def _psp(cp_sz, cp_rk, grp):
+        extra = {}
+        if cp_sz > 1:
+            extra["local_cp_size"] = cp_sz
+            extra["cp_group"] = grp
+        return PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=cu,
+            cu_seqlens_kv=cu,
+            max_seqlen_q=max_seqlen,
+            max_seqlen_kv=max_seqlen,
+            cu_seqlens_q_padded=cu,
+            cu_seqlens_kv_padded=cu,
+            cp_rank=cp_rk,
+            **extra,
+        )
+
+    torch.manual_seed(SEED + 5)
+    full_x = torch.randn(total, BATCH, HIDDEN, device=device, dtype=DTYPE)
+    dist.broadcast(full_x, src=0)
+
+    cp_mod = _make_gdn(cp_size, cp_rank, cp_group, "chunkwise").to(device=device, dtype=DTYPE)
+    _randomize_and_broadcast(cp_mod)
+
+    ref_out_full = None
+    if rank == 0:
+        ref_mod = _make_gdn(1, 0, cp1_group, "chunkwise").to(device=device, dtype=DTYPE)
+        ref_mod.load_state_dict(cp_mod.state_dict())
+        with torch.no_grad():
+            ref_out_full = ref_mod(full_x, packed_seq_params=_psp(1, 0, cp1_group)).detach().clone()
+        del ref_mod
+    if ref_out_full is None:
+        ref_out_full = torch.empty(total, BATCH, HIDDEN, device=device, dtype=DTYPE)
+    dist.broadcast(ref_out_full, src=0)
+
+    local_x = split_packed_to_cp_local(
+        full_x, cu_seqlens_padded=cu, cp_size=cp_size, cp_rank=cp_rank, dim=0
+    ).contiguous()
+    with torch.no_grad():
+        cp_out = cp_mod(local_x, packed_seq_params=_psp(cp_size, cp_rank, cp_group))
+
+    expected_local = split_packed_to_cp_local(
+        ref_out_full, cu_seqlens_padded=cu, cp_size=cp_size, cp_rank=cp_rank, dim=0
+    )
+    f_abs, f_rel, f_scale = _diff(cp_out.detach(), expected_local)
+    if cp_rank == 0:
+        print(
+            f"GDN_CP_PACKED_PARITY mode=chunkwise cp={cp_size} lens={PACKED_LENS} "
+            f"fwd[max_abs={f_abs:.3e} max_rel={f_rel:.3e} scale={f_scale:.3e}]",
+            flush=True,
+        )
+    del cp_mod
+    torch.cuda.empty_cache()
+    dist.barrier()
+
+
+def main():
+    rank = int(os.environ["RANK"])
+    world = int(os.environ["WORLD_SIZE"])
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(local_rank)
+    dist.init_process_group("nccl")
+    device = torch.device("cuda", local_rank)
+
+    cp_size = world
+    cp_rank = rank
+    cp_group = dist.new_group(list(range(world)))
+    cp1_group = dist.new_group([0])
+
+    if rank == 0:
+        import megatron.lite.primitive.modules.gated_delta_net as g
+
+        print(f"GDN_CP_ENV world={world} HAS_FLA={g._HAS_FLA}", flush=True)
+
+    run_matrix(cp_size, cp_rank, cp_group, cp1_group, device, rank, world)
+    run_packed_matrix(cp_size, cp_rank, cp_group, cp1_group, device, rank, world)
+
+    dist.barrier()
+    dist.destroy_process_group()
+    if rank == 0:
+        print("GDN_CP_PARITY_DONE", flush=True)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        print("GDN_CP_PARITY_ERROR", flush=True)
+        traceback.print_exc()
+        sys.stdout.flush()
+        sys.stderr.flush()
+        os._exit(1)

--- a/experimental/lite/tests/smoke/primitive/test_save_load_export_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_save_load_export_smoke.py
@@ -465,7 +465,9 @@ def _export_and_reload(handle: ModelHandle, cfg, protocol, out_dir: str, model_n
     elif hasattr(protocol, "export_hf_weights"):
         from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
 
-        weights = dict(protocol.export_hf_weights(chunks, cfg, ps, rank0_only=True))
+        weights = dict(
+            protocol.export_hf_weights(chunks, cfg, ps, rank0_only=True, cpu=True)
+        )
         if dist.get_rank() == 0 and weights:
             save_safetensors(weights, out_dir)
     else:

--- a/experimental/lite/tests/smoke/primitive/test_save_load_export_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_save_load_export_smoke.py
@@ -185,13 +185,15 @@ def _deepseek_v4():
         hidden_size=128,
         moe_intermediate_size=16,
         num_hidden_layers=2,
-        num_attention_heads=8,
+        num_attention_heads=64,
         num_key_value_heads=1,
-        head_dim=64,
-        qk_rope_head_dim=16,
+        # Keep the production fused-kernel geometry; only model width/depth and
+        # expert counts are reduced for the proxy.
+        head_dim=512,
+        qk_rope_head_dim=64,
         q_lora_rank=32,
         o_lora_rank=32,
-        o_groups=2,
+        o_groups=8,
         n_routed_experts=4,
         n_shared_experts=1,
         num_experts_per_tok=2,
@@ -201,8 +203,9 @@ def _deepseek_v4():
         sliding_window=128,
         num_hash_layers=2,
         hc_mult=2,
-        index_head_dim=64,
-        index_n_heads=8,
+        # The authoritative SM90 DSA indexer kernel requires 128 exactly.
+        index_head_dim=128,
+        index_n_heads=64,
         index_topk=512,
         # DeepSeek-V4 really has MTP; its ImplConfig defaults mtp_enable=True and
         # requires >=1 nextn layer, so give it one (exercises MTP weight IO too).
@@ -483,19 +486,22 @@ def _export_and_reload(handle: ModelHandle, cfg, protocol, out_dir: str, model_n
     shards = [f for f in os.listdir(out_dir) if f.endswith(".safetensors")]
     assert shards, f"no safetensors exported to {out_dir}"
     keys: set[str] = set()
-    # The shared exporter casts EVERY floating tensor to bf16 (``_cast_export_tensor``
-    # with export_dtype=bf16) and leaves integers untouched.  So every float weight
-    # — including the router correction bias — must be bf16, while integer auxiliary
-    # buffers (e.g. DS4 hash-routing ``tid2eid`` index tables; casting them would
-    # corrupt the indices) keep their native integral dtype.  Excluding such buffers
-    # from the export would be a de-scope; we keep them and check their dtype.
+    # Trainable model weights are bf16. Kimi/GLM router correction biases are
+    # deliberately persistent fp32 state in both the native model and official HF
+    # checkpoints, while integer auxiliary buffers (for example DS4 ``tid2eid``)
+    # retain their integral dtype.
     for shard in shards:
         with safe_open(os.path.join(out_dir, shard), framework="pt") as fh:
             for key in fh.keys():
                 tensor = fh.get_tensor(key)
                 if tensor.dtype.is_floating_point:
-                    assert tensor.dtype == torch.bfloat16, (
-                        f"{key} exported as {tensor.dtype}, want bf16"
+                    expected_dtype = (
+                        torch.float32
+                        if key.endswith(".e_score_correction_bias")
+                        else torch.bfloat16
+                    )
+                    assert tensor.dtype == expected_dtype, (
+                        f"{key} exported as {tensor.dtype}, want {expected_dtype}"
                     )
                 else:
                     assert tensor.dtype in (torch.int64, torch.int32, torch.bool), (

--- a/experimental/lite/tests/unit/examples/test_ds4_dapo_script.py
+++ b/experimental/lite/tests/unit/examples/test_ds4_dapo_script.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 from __future__ import annotations
 
 import json

--- a/experimental/lite/tests/unit/examples/test_ds4_dapo_script.py
+++ b/experimental/lite/tests/unit/examples/test_ds4_dapo_script.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT = (
+    Path(__file__).resolve().parents[3]
+    / "examples"
+    / "verl"
+    / "scripts"
+    / "run_deepseek_v4_dapo.sh"
+)
+
+
+@pytest.mark.parametrize(
+    (
+        "weight_bits",
+        "enable_r3",
+        "expert_dtype",
+        "resync_format",
+        "moe_backend",
+        "scale_fmt",
+        "router_mode",
+        "rollout_replay",
+    ),
+    [
+        ("4", "True", "fp4", "mxfp4", "marlin", "ue8m0", "R3", "True"),
+        (
+            "8",
+            "False",
+            "fp8",
+            "block_fp8",
+            "flashinfer_cutlass",
+            "float32",
+            "disabled",
+            "False",
+        ),
+    ],
+)
+def test_ds4_dapo_weight_and_r3_knobs(
+    tmp_path: Path,
+    weight_bits: str,
+    enable_r3: str,
+    expert_dtype: str,
+    resync_format: str,
+    moe_backend: str,
+    scale_fmt: str,
+    router_mode: str,
+    rollout_replay: str,
+) -> None:
+    model = tmp_path / "model"
+    model.mkdir()
+    (model / "config.json").write_text(json.dumps({"o_groups": 8}), encoding="utf-8")
+    env = {
+        **os.environ,
+        "MODEL_PATH": str(model),
+        "OUTPUT_ROOT": str(tmp_path / "output"),
+        "TRAIN_FILES": str(tmp_path / "train.parquet"),
+        "VAL_FILES": str(tmp_path / "val.parquet"),
+        "ROLLOUT_WEIGHT_BITS": weight_bits,
+        "ENABLE_R3": enable_r3,
+        "DRY_RUN": "1",
+    }
+    result = subprocess.run(
+        ["bash", str(SCRIPT)], env=env, text=True, capture_output=True, check=True
+    )
+    command = result.stdout
+    assert f"resync_config.expert_dtype={expert_dtype}" in command
+    assert f"engine.resync_format={resync_format}" in command
+    assert f"hf_overrides.expert_dtype={expert_dtype}" in command
+    assert f"moe_backend={moe_backend}" in command
+    assert f"quantization_config.scale_fmt={scale_fmt}" in command
+    assert f"router_replay_mode={router_mode}" in command
+    assert f"enable_rollout_routing_replay={rollout_replay}" in command
+    assert "actor_rollout_ref.actor.engine.impl_cfg.optimizer=fsdp2" in command
+    assert "actor_rollout_ref.actor.engine.attention_backend_override=fused" in command
+    assert "actor_rollout_ref.rollout.enforce_eager=True" in command
+    assert "algorithm.rollout_correction.bypass_mode=False" in command
+    assert "data.max_response_length=6144" in command
+    assert "actor_rollout_ref.model.custom_chat_template=" in command
+    assert "data.custom_cls" not in command
+    assert "data.label_key" not in command
+    assert "data.default_data_source" not in command
+
+
+@pytest.mark.parametrize(
+    ("name", "value", "message"),
+    [
+        ("ROLLOUT_WEIGHT_BITS", "16", "must be 4 or 8"),
+        ("ENABLE_R3", "maybe", "must be a boolean"),
+    ],
+)
+def test_ds4_dapo_rejects_invalid_feature_knob(
+    tmp_path: Path, name: str, value: str, message: str
+) -> None:
+    model = tmp_path / "model"
+    model.mkdir()
+    (model / "config.json").write_text(json.dumps({"o_groups": 8}), encoding="utf-8")
+    env = {
+        **os.environ,
+        "MODEL_PATH": str(model),
+        "OUTPUT_ROOT": str(tmp_path / "output"),
+        "DRY_RUN": "1",
+        name: value,
+    }
+    result = subprocess.run(
+        ["bash", str(SCRIPT)], env=env, text=True, capture_output=True
+    )
+    assert result.returncode == 2
+    assert message in result.stderr

--- a/experimental/lite/tests/unit/examples/test_ds4_dapo_script.py
+++ b/experimental/lite/tests/unit/examples/test_ds4_dapo_script.py
@@ -83,6 +83,7 @@ def test_ds4_dapo_weight_and_r3_knobs(
     assert "algorithm.rollout_correction.bypass_mode=False" in command
     assert "data.max_response_length=6144" in command
     assert "actor_rollout_ref.model.custom_chat_template=" in command
+    assert "+data.apply_chat_template_kwargs.chat_template=" in command
     assert "data.custom_cls" not in command
     assert "data.label_key" not in command
     assert "data.default_data_source" not in command

--- a/experimental/lite/tests/unit/model/test_deepseek_v4_hf_load_local_to_global.py
+++ b/experimental/lite/tests/unit/model/test_deepseek_v4_hf_load_local_to_global.py
@@ -76,3 +76,49 @@ def test_ds4_load_hf_resolves_local_pp_layer_to_global(tmp_path):
     torch.testing.assert_close(
         model.layers["1"].input_layernorm.weight.detach(), torch.full((dim,), 5.0)
     )
+
+
+def test_ds4_export_streams_router_buffers_from_every_pp_stage(monkeypatch):
+    from megatron.lite.model.deepseek_v4.lite import checkpoint as ckpt
+    from megatron.lite.primitive.ckpt import hf_weights
+
+    class Gate(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.register_buffer("expert_bias", torch.tensor([0.25, -0.5]))
+
+    class Layer(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.mlp = nn.Module()
+            self.mlp.gate = Gate()
+
+    class StageOne(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layer_indices = [1]
+            self.layers = nn.ModuleDict({"0": Layer()})
+
+    remote = torch.tensor([3, 1, 4], dtype=torch.int64)
+
+    def fake_broadcast_object_list(header, *, src, **_kwargs):
+        if src == 0:
+            header[0] = [("layers.0.ffn.gate.tid2eid", tuple(remote.shape), remote.dtype)]
+
+    def fake_broadcast(tensor, *, src, **_kwargs):
+        if src == 0:
+            tensor.copy_(remote)
+
+    monkeypatch.setattr(hf_weights, "export_hf_weights", lambda *_args, **_kwargs: iter(()))
+    monkeypatch.setattr(ckpt.dist, "get_rank", lambda: 1)
+    monkeypatch.setattr(ckpt.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(ckpt.dist, "broadcast_object_list", fake_broadcast_object_list)
+    monkeypatch.setattr(ckpt.dist, "broadcast", fake_broadcast)
+
+    ps = SimpleNamespace(pp_size=2, pp_rank=1, pp_global_ranks=[0, 1], pp_group=object())
+    cfg = SimpleNamespace(num_hash_layers=1, vocab_size=8)
+
+    exported = dict(ckpt._export_unquantized_weights(StageOne(), cfg, ps))
+
+    assert torch.equal(exported["layers.0.ffn.gate.tid2eid"], remote)
+    assert torch.equal(exported["layers.1.ffn.gate.bias"], torch.tensor([0.25, -0.5]))

--- a/experimental/lite/tests/unit/model/test_deepseek_v4_recompute_units.py
+++ b/experimental/lite/tests/unit/model/test_deepseek_v4_recompute_units.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import torch.nn as nn
+
+from megatron.lite.model.deepseek_v4.lite.protocol import _iter_transformer_units
+
+
+class _NativeChunk(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.layers = nn.ModuleDict({"0": nn.Linear(2, 2), "1": nn.Linear(2, 2)})
+        self.mtp = nn.ModuleList([nn.Linear(2, 2)])
+
+
+def test_iter_transformer_units_accepts_native_ds4_chunk() -> None:
+    chunk = _NativeChunk()
+
+    assert _iter_transformer_units(chunk) == [*chunk.layers.values(), *chunk.mtp]
+
+
+def test_iter_transformer_units_accepts_wrapper_chunk() -> None:
+    native = _NativeChunk()
+    wrapper = nn.Module()
+    wrapper.model = native
+
+    assert _iter_transformer_units(wrapper) == [*native.layers.values(), *native.mtp]

--- a/experimental/lite/tests/unit/model/test_deepseek_v4_resync.py
+++ b/experimental/lite/tests/unit/model/test_deepseek_v4_resync.py
@@ -1,0 +1,81 @@
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+
+
+_RESYNC_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "megatron"
+    / "lite"
+    / "model"
+    / "deepseek_v4"
+    / "lite"
+    / "resync.py"
+)
+_SPEC = importlib.util.spec_from_file_location(
+    "deepseek_v4_resync_under_test", _RESYNC_PATH
+)
+assert _SPEC is not None and _SPEC.loader is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+export_resync_weights = _MODULE.export_resync_weights
+
+
+def test_fp8_resync_exports_float32_block_scales() -> None:
+    config = SimpleNamespace(
+        expert_dtype="fp8",
+        quantization_config={"weight_block_size": [128, 128]},
+    )
+    source = torch.randn(128, 128, dtype=torch.bfloat16)
+
+    exported = dict(
+        export_resync_weights(
+            [("layers.0.ffn.experts.0.up_proj.weight", source)],
+            config,
+            resync_config={"expert_dtype": "fp8"},
+        )
+    )
+
+    assert exported["layers.0.ffn.experts.0.up_proj.scale"].dtype == torch.float32
+
+
+def test_fp4_resync_uses_mxfp4_only_for_routed_experts(monkeypatch) -> None:
+    calls: list[tuple[str, str | None]] = []
+
+    def fake_mxfp4(tensor: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        calls.append(("mxfp4", None))
+        return tensor.to(torch.uint8), torch.ones(1, dtype=torch.uint8)
+
+    def fake_block_fp8(
+        tensor: torch.Tensor,
+        _block_shape: tuple[int, int],
+        *,
+        scale_format: str,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        calls.append(("block_fp8", scale_format))
+        return tensor.to(torch.float8_e4m3fn), torch.ones(1, dtype=torch.uint8)
+
+    monkeypatch.setattr(_MODULE, "quantize_mxfp4", fake_mxfp4)
+    monkeypatch.setattr(_MODULE, "quantize_block_fp8", fake_block_fp8)
+    config = SimpleNamespace(
+        expert_dtype="fp4",
+        quantization_config={"weight_block_size": [128, 128]},
+    )
+    source = torch.randn(2, 2, dtype=torch.bfloat16)
+
+    exported = dict(
+        export_resync_weights(
+            [
+                ("layers.0.ffn.experts.0.up_proj.weight", source),
+                ("layers.0.attn.out_proj.weight", source),
+            ],
+            config,
+            resync_config={"expert_dtype": "fp4"},
+        )
+    )
+
+    assert calls == [("mxfp4", None), ("block_fp8", "e8m0")]
+    assert exported["layers.0.ffn.experts.0.up_proj.weight"].dtype == torch.uint8
+    assert exported["layers.0.attn.out_proj.weight"].dtype == torch.float8_e4m3fn

--- a/experimental/lite/tests/unit/model/test_deepseek_v4_resync.py
+++ b/experimental/lite/tests/unit/model/test_deepseek_v4_resync.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 import importlib.util
 from pathlib import Path
 from types import SimpleNamespace

--- a/experimental/lite/tests/unit/model/test_glm5_lite_cp_smoke.py
+++ b/experimental/lite/tests/unit/model/test_glm5_lite_cp_smoke.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 from __future__ import annotations
 
 import pytest

--- a/experimental/lite/tests/unit/model/test_glm5_lite_cp_smoke.py
+++ b/experimental/lite/tests/unit/model/test_glm5_lite_cp_smoke.py
@@ -1,4 +1,3 @@
-# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 from __future__ import annotations
 
 import pytest

--- a/experimental/lite/tests/unit/model/test_glm5_lite_static.py
+++ b/experimental/lite/tests/unit/model/test_glm5_lite_static.py
@@ -1,4 +1,3 @@
-# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Static and CPU smoke tests for native GLM-5 lite."""
 
 from __future__ import annotations

--- a/experimental/lite/tests/unit/model/test_glm5_lite_static.py
+++ b/experimental/lite/tests/unit/model/test_glm5_lite_static.py
@@ -1,8 +1,12 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 """Static and CPU smoke tests for native GLM-5 lite."""
 
 from __future__ import annotations
 
 from pathlib import Path
+
+import pytest
 
 
 def _make_train_config(ps):
@@ -390,11 +394,11 @@ def test_glm5_checkpoint_exports_and_saves_hf_style_weights(tmp_path):
     state = model.state_dict()
 
     assert torch.equal(
-        exported["model.layers.1.mlp.experts.2.gate_proj.weight"],
+        exported["model.layers.1.mlp.experts.2.gate_proj.weight"].detach().cpu(),
         state["layers.1.moe.experts.fc1.weight2"][: cfg.moe_intermediate_size].detach().cpu(),
     )
     assert torch.equal(
-        exported["model.layers.1.mlp.gate.e_score_correction_bias"],
+        exported["model.layers.1.mlp.gate.e_score_correction_bias"].detach().cpu(),
         state["layers.1.moe.router.expert_bias"].detach().cpu(),
     )
     assert "model.layers.1.mlp.experts.gate_up_proj" not in exported
@@ -444,6 +448,14 @@ def test_glm5_checkpoint_exports_and_saves_hf_style_weights(tmp_path):
         .to(torch.bfloat16)
         .to(torch.float32),
     )
+
+
+def test_glm5_hf_export_rejects_missing_model_config():
+    from megatron.lite.model.glm5.lite.checkpoint import export_hf_weights
+    from megatron.lite.primitive.parallel import ParallelState
+
+    with pytest.raises(ValueError, match="non-null model config"):
+        next(export_hf_weights(None, None, ParallelState()))
 
 
 def test_glm5_checkpoint_exports_and_loads_mtp_layers(tmp_path):

--- a/experimental/lite/tests/unit/model/test_hf_save_protocol_contract.py
+++ b/experimental/lite/tests/unit/model/test_hf_save_protocol_contract.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""HF-save entry-point contract for every registered Lite model protocol."""
+
+from __future__ import annotations
+
+import ast
+import importlib
+from pathlib import Path
+
+import pytest
+
+from megatron.lite.model.registry import TRAIN_RUNTIME_MODULES
+
+pytestmark = pytest.mark.mlite
+
+LITE_ROOT = Path(__file__).resolve().parents[3]
+_REGISTERED_PROTOCOLS = sorted(TRAIN_RUNTIME_MODULES.items())
+
+
+@pytest.mark.parametrize(
+    ("runtime_name", "module_name"),
+    _REGISTERED_PROTOCOLS,
+    ids=[runtime_name for runtime_name, _ in _REGISTERED_PROTOCOLS],
+)
+def test_registered_protocol_exposes_hf_save(
+    runtime_name: str, module_name: str
+) -> None:
+    protocol_path = LITE_ROOT / Path(*module_name.split(".")).with_suffix(".py")
+    tree = ast.parse(protocol_path.read_text())
+    functions = {
+        node.name for node in tree.body if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+
+    assert "save_hf_weights" in functions, (
+        f"{runtime_name} ({module_name}) cannot honor save_contents=['hf_model']"
+    )
+
+
+@pytest.mark.parametrize("model_name", ["kimi_k2", "qwen3_moe"])
+def test_new_hf_save_protocols_delegate_all_arguments(
+    model_name: str, monkeypatch: pytest.MonkeyPatch, transformer_engine_import_stub
+) -> None:
+    transformer_engine_import_stub()
+    protocol = importlib.import_module(f"megatron.lite.model.{model_name}.lite.protocol")
+    checkpoint = importlib.import_module(f"megatron.lite.model.{model_name}.lite.checkpoint")
+    calls = []
+    monkeypatch.setattr(
+        checkpoint,
+        "save_hf_weights",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+    chunks, model_cfg, parallel_state = object(), object(), object()
+
+    protocol.save_hf_weights(
+        chunks,
+        "/tmp/hf-save-contract",
+        model_cfg,
+        parallel_state,
+    )
+
+    assert calls == [
+        (
+            (chunks, "/tmp/hf-save-contract", model_cfg, parallel_state),
+            {},
+        )
+    ]

--- a/experimental/lite/tests/unit/model/test_qwen35_export.py
+++ b/experimental/lite/tests/unit/model/test_qwen35_export.py
@@ -54,8 +54,8 @@ def test_qwen35_protocol_registers_vllm_export_entrypoint() -> None:
 
 
 def test_qwen35_gdn_cp_mode_is_configurable() -> None:
-    assert ImplConfig().gdn_cp_mode == "replicated"
-    assert ImplConfig(gdn_cp_mode="sharded").gdn_cp_mode == "sharded"
+    assert ImplConfig().gdn_cp_mode == "headwise"
+    assert ImplConfig(gdn_cp_mode="replicated").gdn_cp_mode == "replicated"
 
 
 def test_qwen35_export_uses_hf_checkpoint_names_without_module_prefix() -> None:
@@ -154,24 +154,43 @@ def test_qwen35_export_preserves_runtime_parameter_dtype_by_default() -> None:
     )
 
 
+def test_qwen35_online_export_keeps_weights_on_the_source_device() -> None:
+    class TinyQwen35Module(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.norm = nn.LayerNorm(8, device="meta")
+
+    exported = dict(
+        export_hf_weights(
+            TinyQwen35Module(),
+            _tiny_config(),
+            _single_rank_parallel_state(),
+            cpu=False,
+        )
+    )
+
+    assert exported["model.language_model.norm.weight"].device.type == "meta"
+
+
 def test_qwen35_export_batches_ep_expert_gather(monkeypatch) -> None:
     class TinyQwen35Module(nn.Module):
         def __init__(self, config: Qwen35Config) -> None:
             super().__init__()
-            self.layers = nn.ModuleList([nn.Module()])
-            self.layers[0].moe = nn.Module()
-            self.layers[0].moe.experts = nn.Module()
-            self.layers[0].moe.experts.fc1 = nn.Module()
+            self.layers = nn.ModuleList([nn.Module(), nn.Module()])
 
             rows = config.moe_intermediate_size * 2
-            for local_idx in range(config.num_experts // 2):
-                tensor = torch.arange(rows * config.hidden_size, dtype=torch.bfloat16).reshape(
-                    rows, config.hidden_size
-                )
-                tensor = tensor + local_idx * 1000
-                self.layers[0].moe.experts.fc1.register_parameter(
-                    f"weight{local_idx}", nn.Parameter(tensor)
-                )
+            for layer_idx, layer in enumerate(self.layers):
+                layer.moe = nn.Module()
+                layer.moe.experts = nn.Module()
+                layer.moe.experts.fc1 = nn.Module()
+                for local_idx in range(config.num_experts // 2):
+                    tensor = torch.arange(
+                        rows * config.hidden_size, dtype=torch.bfloat16
+                    ).reshape(rows, config.hidden_size)
+                    tensor = tensor + layer_idx * 10000 + local_idx * 1000
+                    layer.moe.experts.fc1.register_parameter(
+                        f"weight{local_idx}", nn.Parameter(tensor)
+                    )
 
     cfg = _tiny_config()
     cfg.num_experts = 16
@@ -187,24 +206,40 @@ def test_qwen35_export_batches_ep_expert_gather(monkeypatch) -> None:
     )
     gather_calls = []
 
-    def fake_all_gather(outputs, tensor, group=None):
+    def fake_all_gather(output, tensor, group=None):
         del group
-        gather_calls.append(tensor.clone())
-        outputs[0].copy_(tensor)
-        outputs[1].copy_(tensor + 2000)
+        gather_calls.append(
+            tensor.clone().reshape(-1, cfg.moe_intermediate_size * 2, cfg.hidden_size)
+        )
+        output[: tensor.numel()].copy_(tensor)
+        output[tensor.numel() :].copy_(tensor + 2000)
 
-    monkeypatch.setattr("megatron.lite.primitive.ckpt.hf_weights.dist.all_gather", fake_all_gather)
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.hf_weights.dist.all_gather_into_tensor",
+        fake_all_gather,
+    )
 
     exported = dict(export_hf_weights(model, cfg, ps))
 
-    assert len(gather_calls) == 2
-    assert all(call.shape[0] <= 4 for call in gather_calls)
+    assert len(gather_calls) == 4
+    assert all(call.shape[0] == 4 for call in gather_calls)
     local_tensors = [
         getattr(model.layers[0].moe.experts.fc1, f"weight{i}").detach()
         for i in range(cfg.num_experts // ps.ep_size)
     ]
     expected = torch.stack(local_tensors + [tensor + 2000 for tensor in local_tensors])
     assert torch.equal(exported["model.language_model.layers.0.mlp.experts.gate_up_proj"], expected)
+    layer1_tensors = [
+        getattr(model.layers[1].moe.experts.fc1, f"weight{i}").detach()
+        for i in range(cfg.num_experts // ps.ep_size)
+    ]
+    layer1_expected = torch.stack(
+        layer1_tensors + [tensor + 2000 for tensor in layer1_tensors]
+    )
+    assert torch.equal(
+        exported["model.language_model.layers.1.mlp.experts.gate_up_proj"],
+        layer1_expected,
+    )
 
 
 def test_qwen35_export_uses_packed_expert_group_names(monkeypatch) -> None:
@@ -270,15 +305,18 @@ def test_qwen35_export_rank0_only_still_participates_in_ep_gather(monkeypatch) -
     )
     gather_calls = []
 
-    def fake_all_gather(outputs, tensor, group=None):
+    def fake_all_gather(output, tensor, group=None):
         del group
         gather_calls.append(tensor.clone())
-        outputs[0].copy_(tensor)
-        outputs[1].copy_(tensor + 2)
+        output[: tensor.numel()].copy_(tensor)
+        output[tensor.numel() :].copy_(tensor + 2)
 
     monkeypatch.setattr("megatron.lite.primitive.ckpt.hf_weights.dist.is_initialized", lambda: True)
     monkeypatch.setattr("megatron.lite.primitive.ckpt.hf_weights.dist.get_rank", lambda: 1)
-    monkeypatch.setattr("megatron.lite.primitive.ckpt.hf_weights.dist.all_gather", fake_all_gather)
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.hf_weights.dist.all_gather_into_tensor",
+        fake_all_gather,
+    )
 
     exported = list(export_hf_weights(TinyQwen35Module(cfg), cfg, ps, rank0_only=True))
 
@@ -451,14 +489,15 @@ def test_qwen35_export_uses_mbridge_conv1d_tp_gather(monkeypatch) -> None:
     )
     gather_calls = []
 
-    def fake_all_gather(outputs, tensor, group=None):
+    def fake_all_gather(output, tensor, group=None):
         assert group is ps.tp_group
-        gather_calls.append(tensor.clone())
-        outputs[0].copy_(shards[0])
-        outputs[1].copy_(shards[1])
+        gather_calls.append(tensor.clone().reshape_as(shards[0]))
+        output[: tensor.numel()].copy_(shards[0].view(-1))
+        output[tensor.numel() :].copy_(shards[1].view(-1))
 
     monkeypatch.setattr(
-        "megatron.lite.model.qwen3_5.lite.checkpoint.dist.all_gather", fake_all_gather
+        "megatron.lite.primitive.ckpt.hf_weights.dist.all_gather_into_tensor",
+        fake_all_gather,
     )
 
     exported = dict(export_hf_weights(TinyQwen35Module(shards[0]), cfg, ps))

--- a/experimental/lite/tests/unit/model/test_thd_packing_consistency.py
+++ b/experimental/lite/tests/unit/model/test_thd_packing_consistency.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Reproduce the DS4 THD packing inconsistency crash (seq_len 206 > packed tensor 128).
+
+``_nested_from_packed_tensor(tensor, seq_lens)`` narrows a 1-D packed tensor one
+sequence at a time. When a declared ``seq_len`` exceeds the remaining length of
+the packed tensor (i.e. ``seq_lens`` is inconsistent with ``input_ids.numel()``),
+``tensor.narrow(0, offset, length)`` raises ``RuntimeError`` "...exceeds dimension
+size..." -- exactly the 206 > 128 crash seen at the actor-update step.
+
+These tests only reproduce the inconsistency (proving it must crash); they do not
+exercise the fix (which restores full-length loss_mask upstream in the engine).
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from megatron.lite.model.deepseek_v4.lite.protocol import _nested_from_packed_tensor
+
+
+def test_reproduce_seqlen_exceeds_packed_tensor_206_over_128():
+    """Packed tensor holds 128 tokens but seq_lens declares 206 -> narrow overruns."""
+    packed = torch.arange(128, dtype=torch.long)           # 128 tokens
+    seq_lens = torch.tensor([206], dtype=torch.long)        # declares 206 (> 128)
+    with pytest.raises(RuntimeError) as ei:
+        _nested_from_packed_tensor(packed, seq_lens)
+    msg = str(ei.value).lower()
+    assert "exceeds" in msg or "size" in msg or "range" in msg, str(ei.value)
+
+
+def test_reproduce_multi_seq_second_overruns():
+    """Multiple sequences: the second one pushes the cumulative offset past the end."""
+    packed = torch.arange(128, dtype=torch.long)
+    seq_lens = torch.tensor([100, 128], dtype=torch.long)   # 100+128=228 > 128
+    with pytest.raises(RuntimeError):
+        _nested_from_packed_tensor(packed, seq_lens)
+
+
+def test_sum_mismatch_underrun_raises_valueerror():
+    """seq_lens sum < numel (each fits, but the buffer is not filled) -> ValueError.
+
+    This distinguishes the two inconsistency kinds: overrun -> RuntimeError (narrow),
+    underrun -> ValueError (the offset != numel sum check).
+    """
+    packed = torch.arange(128, dtype=torch.long)
+    seq_lens = torch.tensor([100], dtype=torch.long)        # 100 < 128
+    with pytest.raises(ValueError, match="sizes sum to 100"):
+        _nested_from_packed_tensor(packed, seq_lens)
+
+
+def test_consistent_packing_succeeds():
+    """Consistent case (sum(seq_lens) == numel) returns a nested tensor.
+
+    Control case: proves the crash comes from the inconsistency, not the function.
+    """
+    packed = torch.arange(128, dtype=torch.long)
+    seq_lens = torch.tensor([50, 78], dtype=torch.long)     # 50+78=128
+    out = _nested_from_packed_tensor(packed, seq_lens)
+    assert out is not None
+    assert out.size(0) == 2                                  # 2 segments

--- a/experimental/lite/tests/unit/primitive/test_block_fp8_roundtrip.py
+++ b/experimental/lite/tests/unit/primitive/test_block_fp8_roundtrip.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Block-FP8 quantize/dequantize round-trip fidelity.
+
+Validates numerical fidelity only (the quantize->dequantize round-trip error stays
+within the E4M3 blockwise magnitude); it does not validate layout, axis order, or
+fusion. Zero GPU, pure tensors. DS4 routed experts use expert_dtype=fp8 ->
+quantize_block_fp8 with scale_format="float32", so every case here exercises the
+float32 scale branch.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from megatron.lite.primitive.quantization.block_fp8 import (
+    dequantize_block_fp8,
+    quantize_block_fp8,
+)
+
+# E4M3 has 3 mantissa bits -> per-value resolution ~2^-3 = 12.5%. With blockwise
+# per-128x128 absmax scaling, the overall (Frobenius) energy relative error should
+# be ~2^-3/sqrt(3), i.e. a few percent. We gate on 6%; element-wise max-rel is not
+# a criterion (near-zero elements inside a block have naturally large rel error).
+FROBENIUS_TOL = 0.06
+
+
+def _frobenius_rel_err(restored: torch.Tensor, source: torch.Tensor) -> float:
+    return (
+        torch.linalg.vector_norm(restored.float() - source.float())
+        / torch.linalg.vector_norm(source.float())
+    ).item()
+
+
+def _roundtrip(source: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    weight, scale = quantize_block_fp8(source, (128, 128), scale_format="float32")
+    restored = dequantize_block_fp8(weight, scale, (128, 128))
+    return weight, scale, restored
+
+
+def test_roundtrip_extreme_negative_and_near_zero_values() -> None:
+    """Tensor with E4M3 extremes / negatives / near-zero / exact-zero round-trips within fp8 magnitude."""
+    torch.manual_seed(0)
+    fp8_max = torch.finfo(torch.float8_e4m3fn).max  # 448.0
+    source = torch.empty(256, 256)
+    # Mix in block-level large magnitudes (+/- near fp8_max), tiny values, exact 0,
+    # and a regular small-weight scale.
+    source[:128, :128] = torch.linspace(-fp8_max, fp8_max, 128 * 128).reshape(128, 128)
+    source[:128, 128:] = torch.full((128, 128), 1e-4)
+    source[128:, :128] = torch.randn(128, 128) * 0.02
+    block = torch.randn(128, 128) * 0.02
+    block[0, 0] = fp8_max          # one large outlier in the block sets the scale
+    block[1, 1] = -fp8_max
+    block[2, 2] = 0.0              # exact zero must round-trip back to zero
+    source[128:, 128:] = block
+
+    weight, scale, restored = _roundtrip(source)
+
+    assert weight.dtype == torch.float8_e4m3fn
+    assert scale.dtype == torch.float32
+    assert scale.shape == (2, 2)  # 256/128 x 256/128
+    assert torch.isfinite(restored).all(), "dequant produced NaN/Inf"
+    # Exact-zero elements must restore to 0 (finite scale, quantization preserves 0).
+    assert restored[128 + 2, 128 + 2].abs().item() == 0.0
+    rel = _frobenius_rel_err(restored, source)
+    assert rel < FROBENIUS_TOL, f"Frobenius rel err {rel:.4f} >= {FROBENIUS_TOL}"
+
+
+@pytest.mark.parametrize(
+    "shape,label",
+    [
+        ((512, 1024), "w1_gate_up_I_by_H"),   # expert gate/up: [I, H]
+        ((1024, 512), "w2_down_H_by_I"),      # expert down:    [H, I]
+    ],
+)
+def test_roundtrip_ds4_expert_shapes(shape: tuple[int, int], label: str) -> None:
+    """DS4 routed-expert weight shapes (w1[I,H]/w2[H,I]) round-trip under a realistic weight distribution."""
+    torch.manual_seed(1234)
+    # Realistic weight-like distribution: small-scale normal + a few outliers (which set each block's scale).
+    source = torch.randn(*shape) * 0.02
+    outlier_mask = torch.rand(*shape) < 0.001
+    source = torch.where(outlier_mask, torch.sign(source) * 5.0, source)
+
+    weight, scale, restored = _roundtrip(source)
+
+    assert weight.shape == source.shape, f"{label}: quantization changed the shape (suspect axis/layout error)"
+    assert scale.shape == (shape[0] // 128, shape[1] // 128)
+    assert torch.isfinite(restored).all()
+    rel = _frobenius_rel_err(restored, source)
+    assert rel < FROBENIUS_TOL, f"{label}: Frobenius rel err {rel:.4f} >= {FROBENIUS_TOL}"
+
+
+def test_roundtrip_is_deterministic() -> None:
+    """The same input quantized/dequantized twice is bit-identical (no randomness; usable as a CI baseline)."""
+    source = torch.randn(128, 128) * 0.05
+    _, _, a = _roundtrip(source)
+    _, _, b = _roundtrip(source)
+    assert torch.equal(a, b)

--- a/experimental/lite/tests/unit/primitive/test_csa_thd_cp.py
+++ b/experimental/lite/tests/unit/primitive/test_csa_thd_cp.py
@@ -1,0 +1,220 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Unit tests for the DeepSeek-V4 CSA THD context-parallel path.
+
+Coverage strategy (see the module docstring of
+``megatron.core.transformer.experimental_attention_variant.csa_cp_layout_kernels``):
+the full ``_forward_thd_cp`` is gated behind CuTeDSL/CUDA kernels
+(``prepare_cp_compressor_input`` and ``build_attention_indices``), so its numeric
+``CP=1 == unsharded`` invariant is only reachable on a GPU with those kernels and
+is marked ``gpu``. The CPU-reachable pieces -- the THD tensor layout built by the
+dispatch, the zero left-boundary at ``cp_size == 1``, the boundary-KV projection,
+the differentiability of that pre-CP path, and the pre-grouped compressor overlap
+transform -- are exercised directly here by stubbing ``_forward_thd_cp``.
+
+These tests require a real Transformer Engine install (Megatron Core's CSA module
+imports ``transformer_engine.pytorch.float8_tensor``); they skip cleanly when it
+is absent rather than failing collection.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.mlite
+
+
+def _csa():
+    """Import the lite CSA module or skip (needs real TE + Megatron Core)."""
+    return pytest.importorskip("megatron.lite.primitive.modules.attention.csa")
+
+
+def _tiny_config():
+    from megatron.lite.model.deepseek_v4.config import DeepseekV4Config
+
+    return DeepseekV4Config(
+        hidden_size=32,
+        num_attention_heads=4,
+        head_dim=8,
+        qk_rope_head_dim=4,
+        q_lora_rank=16,
+        o_lora_rank=16,
+        o_groups=2,
+        compress_ratios=[4],
+        sliding_window=4,
+        index_head_dim=8,
+        index_n_heads=4,
+        index_topk=4,
+        rms_norm_eps=1e-6,
+        initializer_range=0.02,
+        num_hidden_layers=1,
+        num_nextn_predict_layers=1,
+    )
+
+
+def _ps(cp_size: int = 1, cp_rank: int = 0):
+    group = SimpleNamespace(size=lambda: cp_size, rank=lambda: cp_rank)
+    return SimpleNamespace(cp_size=cp_size, cp_rank=cp_rank, cp_group=group)
+
+
+def _packed_seq_params(seq_len: int, device: torch.device):
+    cu = torch.tensor([0, seq_len], dtype=torch.int32, device=device)
+    return SimpleNamespace(
+        qkv_format="thd",
+        cu_seqlens_q=cu,
+        cu_seqlens_q_padded=None,
+        cu_seqlens_kv=cu,
+        cu_seqlens_kv_padded=None,
+        max_seqlen_q=seq_len,
+        max_seqlen_kv=seq_len,
+    )
+
+
+def _d_window(config) -> int:
+    d_comp = 8 if config.compress_ratios[0] == 4 else config.compress_ratios[0]
+    return max(int(config.sliding_window), d_comp)
+
+
+# ---------------------------------------------------------------------------
+# Pure-tensor logic (no CUDA / no CuTeDSL).
+# ---------------------------------------------------------------------------
+
+
+def test_overlap_transform_thd_layout():
+    """Pre-grouped THD overlap transform matches the DSv4 windowing contract."""
+    csa = _csa()
+    d = 3
+    fake_self = SimpleNamespace(head_dim=d)
+    ratio, n = 4, 2
+    # (total_comp, ratio, 1, coff * d) with coff == 2.
+    tensor = torch.arange(n * ratio * 1 * (2 * d), dtype=torch.float32).reshape(n, ratio, 1, 2 * d)
+    is_first = torch.tensor([True, False])
+    out = csa.CompressedSequenceCompressor._overlap_transform_thd(
+        fake_self, tensor, is_first, fill_value=0.0
+    )
+    assert out.shape == (n, 2 * ratio, 1, d)
+    # Second half is the [d:] channel of the same group.
+    assert torch.equal(out[:, ratio:], tensor[:, :, :, d:])
+    # First group starts a segment -> its first half is fill (0).
+    assert torch.equal(out[0, :ratio], torch.zeros(ratio, 1, d))
+    # Second group pulls the [:d] channel of the previous group.
+    assert torch.equal(out[1, :ratio], tensor[0, :, :, :d])
+
+
+# ---------------------------------------------------------------------------
+# THD dispatch + boundary-KV projection (CPU-reachable with real TE; the
+# CuTeDSL-gated core is stubbed out).
+# ---------------------------------------------------------------------------
+
+
+def test_forward_thd_packed_builds_layout_and_is_differentiable(monkeypatch):
+    csa = _csa()
+    torch.manual_seed(0)
+    config = _tiny_config()
+    try:
+        module = csa.CompressedSparseAttention(config, layer_idx=0, ps=_ps())
+    except RuntimeError as exc:  # te.RMSNorm/te.Linear unavailable (stubbed TE)
+        pytest.skip(f"real Transformer Engine required to build CSA: {exc}")
+
+    seq_len = 8  # divisible by ratio; >= D_window so the boundary window fits.
+    device = torch.device("cpu")
+    x = torch.randn(1, seq_len, config.hidden_size, device=device, requires_grad=True)
+    position_ids = torch.arange(seq_len, device=device).unsqueeze(0)
+    psp = _packed_seq_params(seq_len, device)
+
+    captured = {}
+
+    def _fake_forward_thd_cp(query, key, x_thd, qr, boundary_hidden, boundary_kv, packed):
+        captured.update(
+            query=query,
+            key=key,
+            x_thd=x_thd,
+            qr=qr,
+            boundary_hidden=boundary_hidden,
+            boundary_kv=boundary_kv,
+        )
+        # (total_q, 1, np * hn) attention-context contract; keep it in the graph.
+        return query.reshape(seq_len, 1, config.num_attention_heads * config.head_dim)
+
+    monkeypatch.setattr(module, "_forward_thd_cp", _fake_forward_thd_cp)
+
+    out = module(x, position_ids=position_ids, packed_seq_params=psp)
+
+    nh, hd, hidden = config.num_attention_heads, config.head_dim, config.hidden_size
+    assert captured["query"].shape == (seq_len, nh, hd)
+    assert captured["key"].shape == (seq_len, 1, 1, hd)
+    assert captured["x_thd"].shape == (seq_len, 1, hidden)
+    assert captured["qr"].shape == (seq_len, 1, config.q_lora_rank)
+    dwin = _d_window(config)
+    assert captured["boundary_hidden"].shape == (dwin, 1, hidden)
+    # cp_size == 1 -> zero left boundary.
+    assert torch.count_nonzero(captured["boundary_hidden"]) == 0
+    assert captured["boundary_kv"].shape == (dwin, 1, 1, hd)
+    # Output is projected back to [B, S, hidden] for the SBHD shim.
+    assert out.shape == (1, seq_len, hidden)
+
+    # The pre-CP path (projection + boundary + differentiable layout) must carry
+    # gradients back to the hidden input (no non-differentiable collective).
+    out.sum().backward()
+    assert x.grad is not None
+    assert torch.isfinite(x.grad).all()
+
+
+def test_project_boundary_kv_shape(monkeypatch):
+    csa = _csa()
+    torch.manual_seed(0)
+    config = _tiny_config()
+    try:
+        module = csa.CompressedSparseAttention(config, layer_idx=0, ps=_ps())
+    except RuntimeError as exc:
+        pytest.skip(f"real Transformer Engine required to build CSA: {exc}")
+
+    dwin = _d_window(config)
+    boundary_hidden = torch.randn(dwin, 1, config.hidden_size)
+    cu = torch.tensor([0, 8], dtype=torch.int32)
+    bkv = module._project_boundary_kv(
+        boundary_hidden, cu, global_start=0, rope_theta=config.compress_rope_theta
+    )
+    assert bkv.shape == (dwin, 1, 1, config.head_dim)
+    assert torch.isfinite(bkv).all()
+
+
+# ---------------------------------------------------------------------------
+# CP=1 == unsharded numeric invariant (GPU + CuTeDSL only).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.gpu
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA + CuTeDSL kernels")
+def test_cp1_thd_equals_bshd_fused():
+    """CP=1 THD packed attention equals the (unsharded) CP=1 BSHD fused path.
+
+    Both routes share the DSv4 sparse-attention formula (sliding window +
+    compressed KV + learned indexer top-k + attention sink); for a single
+    ratio-aligned sequence with no CP sharding they must produce the same
+    output. This is the concrete ``CP=1 == unsharded`` CP invariant, runnable
+    only where the CuTeDSL layout kernels and DSA kernels are available.
+    """
+    csa = _csa()
+    torch.manual_seed(0)
+    config = _tiny_config()
+    device = torch.device("cuda")
+    module = csa.CompressedSparseAttention(config, layer_idx=0, ps=_ps()).to(device)
+    # Select a fused sparse backend for both the BSHD and THD routes.
+    module.attention_backend = "flash"
+    module.apply_dsa_kernel_fusion = True
+    module.eval()
+
+    seq_len = 8
+    x = torch.randn(1, seq_len, config.hidden_size, device=device)
+    position_ids = torch.arange(seq_len, device=device).unsqueeze(0)
+
+    with torch.no_grad():
+        out_bshd = module(x, position_ids=position_ids)
+        out_thd = module(
+            x, position_ids=position_ids, packed_seq_params=_packed_seq_params(seq_len, device)
+        )
+
+    assert out_thd.shape == out_bshd.shape == (1, seq_len, config.hidden_size)
+    torch.testing.assert_close(out_thd, out_bshd, rtol=2e-2, atol=2e-2)

--- a/experimental/lite/tests/unit/primitive/test_fsdp2_offload_gpu.py
+++ b/experimental/lite/tests/unit/primitive/test_fsdp2_offload_gpu.py
@@ -13,10 +13,12 @@ from megatron.lite.primitive.optimizers.fsdp2 import (
     FSDP2Config,
     build_fsdp2_adamw,
     build_fsdp2_device_mesh,
+    build_fsdp2_training_optimizer,
     fsdp2_available,
     wrap_fsdp2,
 )
 from megatron.lite.primitive.optimizers.fsdp2.adamw import iter_torch_optimizers, to_local_tensor
+from megatron.lite.primitive.parallel import init_parallel
 from megatron.lite.primitive.parallel.state import ParallelState
 from megatron.lite.runtime.backends.mlite.runtime import MegatronLiteRuntime
 from megatron.lite.runtime.contracts.handle import ModelHandle
@@ -41,6 +43,73 @@ class TinyModel(nn.Module):
 
     def forward(self, x):
         return self.out(self.unit1(self.unit0(x)))
+
+
+class TinyExpertBank(nn.Module):
+    def __init__(self, hidden_size: int):
+        super().__init__()
+        self.up = nn.Linear(hidden_size, hidden_size, bias=False)
+        self.down = nn.Linear(hidden_size, hidden_size, bias=False)
+
+    def forward(self, x):
+        return self.down(torch.nn.functional.gelu(self.up(x)))
+
+
+class TinyMoEUnit(nn.Module):
+    def __init__(self, hidden_size: int):
+        super().__init__()
+        self.dense = nn.Linear(hidden_size, hidden_size, bias=False)
+        self.experts = TinyExpertBank(hidden_size)
+
+    def forward(self, x):
+        return x + self.experts(self.dense(x))
+
+
+class TinyPipelineMoEModel(nn.Module):
+    def __init__(self, hidden_size: int = 64, num_units: int = 3):
+        super().__init__()
+        self.units = nn.ModuleList(TinyMoEUnit(hidden_size) for _ in range(num_units))
+
+    def forward(self, x):
+        for unit in self.units:
+            x = unit(x)
+        return x
+
+
+class MemoryStressExperts(nn.Module):
+    def __init__(self, numel: int):
+        super().__init__()
+        self.weight = nn.Parameter(
+            torch.empty(numel, device="cuda", dtype=torch.bfloat16)
+        )
+
+    def forward(self, x):
+        return x + self.weight[0] * 0
+
+
+class MemoryStressMoEUnit(nn.Module):
+    def __init__(self, expert_numel: int):
+        super().__init__()
+        self.dense_scale = nn.Parameter(
+            torch.ones(1, device="cuda", dtype=torch.bfloat16)
+        )
+        self.experts = MemoryStressExperts(expert_numel)
+
+    def forward(self, x):
+        return self.experts(x * self.dense_scale[0])
+
+
+class MemoryStressMoEModel(nn.Module):
+    def __init__(self, expert_numel: int, num_units: int):
+        super().__init__()
+        self.units = nn.ModuleList(
+            MemoryStressMoEUnit(expert_numel) for _ in range(num_units)
+        )
+
+    def forward(self, x):
+        for unit in self.units:
+            x = unit(x)
+        return x
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -159,3 +228,222 @@ def test_fsdp2_offload_fraction_keeps_optimizer_update_state_on_cpu_single_gpu()
     assert torch.isfinite(torch.tensor(grad_norm))
     assert _local_param_devices(model) == {"cuda"}
     assert _optimizer_state_devices(optimizer) == {"cpu"}
+
+
+@pytest.mark.gpu
+@pytest.mark.distributed
+def test_fsdp2_pp_edp_reshard_and_offload_roundtrip_eight_gpus():
+    if dist.get_world_size() != 8:
+        pytest.skip("PP2+CP2+EP2/EDP2 coverage requires torchrun with exactly 8 ranks.")
+
+    ps = init_parallel(SimpleNamespace(tp=1, pp=2, cp=2, ep=2, etp=1, vpp=1))
+    assert ps.dp_cp_size == 4
+    assert ps.expert_dp_size == 2
+
+    torch.manual_seed(1234)
+    model = TinyPipelineMoEModel().cuda().to(dtype=torch.bfloat16)
+    expert_global_numels = {
+        name: param.numel()
+        for name, param in model.named_parameters()
+        if ".experts." in name
+    }
+    optimizer = build_fsdp2_training_optimizer(
+        [model],
+        SimpleNamespace(
+            optimizer="adam",
+            lr=1.0e-3,
+            weight_decay=0.0,
+            adam_beta1=0.9,
+            adam_beta2=0.95,
+            adam_eps=1.0e-8,
+            clip_grad=1.0,
+            offload_fraction=1.0,
+        ),
+        ps,
+        unit_modules=(TinyMoEUnit,),
+        leaf_module_names=(),
+        expert_classifier=lambda name: ".experts." in f".{name}",
+        reshard_after_forward=True,
+        forward_prefetch_depth=0,
+        backward_prefetch_depth=0,
+        use_fp32_shards=False,
+        use_fp32_master=True,
+    )
+
+    def assert_experts_are_local_shards(device: str) -> None:
+        named_params = dict(model.named_parameters())
+        for name, global_numel in expert_global_numels.items():
+            local = to_local_tensor(named_params[name].detach())
+            assert local.device.type == device
+            assert local.numel() == global_numel // ps.expert_dp_size
+
+    def assert_grad_devices(device: str) -> None:
+        grads = [param.grad for param in model.parameters()]
+        assert all(grad is not None for grad in grads)
+        assert {to_local_tensor(grad).device.type for grad in grads if grad is not None} == {
+            device
+        }
+
+    def check_expert_shard_after_forward(_module, _inputs, _output) -> None:
+        assert_experts_are_local_shards("cuda")
+
+    hooks = [
+        unit.experts.register_forward_hook(check_expert_shard_after_forward)
+        for unit in model.units
+    ]
+
+    def train_backward(seed: int) -> None:
+        torch.manual_seed(seed)
+        x = torch.randn(4, 64, device="cuda", dtype=torch.bfloat16)
+        optimizer.zero_grad()
+        model(x).float().square().mean().backward()
+        torch.cuda.synchronize()
+        assert_experts_are_local_shards("cuda")
+        assert_grad_devices("cuda")
+
+    assert_experts_are_local_shards("cuda")
+    train_backward(4321)
+
+    handle = ModelHandle(
+        model=model, optimizer=optimizer, parallel_state=ps, _extras={"model_chunks": [model]}
+    )
+    runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
+    runtime.to(handle, "cpu", model=True, optimizer=True, grad=True)
+    assert_experts_are_local_shards("cpu")
+    assert_grad_devices("cpu")
+
+    runtime.to(handle, "cuda", model=True, optimizer=True, grad=True)
+    assert_experts_are_local_shards("cuda")
+    assert_grad_devices("cuda")
+    train_backward(4322)
+    for hook in hooks:
+        hook.remove()
+
+    runtime.to(handle, "cpu", model=True, optimizer=True, grad=True)
+    torch.cuda.empty_cache()
+
+    # Ten 512-MiB experts leave about 2.5 GiB resident with EDP2. Restrict
+    # the allocator to the resident shards plus three full expert buffers.
+    # Correct post-forward resharding stays below the limit; retaining expert
+    # materializations across layers must OOM and fail this test.
+    expert_bytes = 512 * 1024**2
+    expert_numel = expert_bytes // torch.empty((), dtype=torch.bfloat16).element_size()
+    stress_model = MemoryStressMoEModel(expert_numel, num_units=10)
+    stress_optimizer = build_fsdp2_training_optimizer(
+        [stress_model],
+        SimpleNamespace(
+            optimizer="adam",
+            lr=1.0e-3,
+            weight_decay=0.0,
+            adam_beta1=0.9,
+            adam_beta2=0.95,
+            adam_eps=1.0e-8,
+            clip_grad=1.0,
+            offload_fraction=0.0,
+        ),
+        ps,
+        unit_modules=(MemoryStressMoEUnit,),
+        leaf_module_names=(),
+        expert_classifier=lambda name: ".experts." in f".{name}",
+        reshard_after_forward=True,
+        forward_prefetch_depth=0,
+        backward_prefetch_depth=0,
+        use_fp32_shards=False,
+        use_fp32_master=False,
+    )
+    del stress_optimizer
+    torch.cuda.empty_cache()
+    resident_bytes = torch.cuda.memory_allocated()
+    stress_shard_checks = []
+
+    def check_stress_expert_shard(_module, _inputs, _output) -> None:
+        local = to_local_tensor(_module.weight.detach())
+        assert local.numel() == expert_numel // ps.expert_dp_size
+        stress_shard_checks.append(True)
+
+    stress_hooks = [
+        unit.experts.register_forward_hook(check_stress_expert_shard)
+        for unit in stress_model.units
+    ]
+    device_bytes = torch.cuda.get_device_properties(torch.cuda.current_device()).total_memory
+    memory_limit_bytes = resident_bytes + 3 * expert_bytes
+    memory_fraction = min(0.9, memory_limit_bytes / device_bytes)
+    torch.cuda.set_per_process_memory_fraction(memory_fraction)
+    try:
+        with torch.no_grad():
+            stress_output = stress_model(
+                torch.ones(1, device="cuda", dtype=torch.bfloat16)
+            )
+        torch.cuda.synchronize()
+        assert torch.cuda.memory_allocated() <= resident_bytes + expert_bytes
+        assert len(stress_shard_checks) == len(stress_model.units)
+        del stress_output
+    finally:
+        torch.cuda.set_per_process_memory_fraction(1.0)
+        for hook in stress_hooks:
+            hook.remove()
+
+    stress_handle = ModelHandle(
+        model=stress_model,
+        optimizer=None,
+        parallel_state=ps,
+        _extras={"model_chunks": [stress_model]},
+    )
+    runtime.to(stress_handle, "cpu", model=True, optimizer=False, grad=False)
+    del stress_model, stress_handle
+    torch.cuda.empty_cache()
+
+    # Exercise the context-switch case that motivated the explicit reshard
+    # barrier: parameters are intentionally left materialized after forward,
+    # then runtime.to(..., "cpu") must reshard them before Module.to() sees
+    # their DTensor state.
+    materialized_model = TinyPipelineMoEModel(hidden_size=512, num_units=1).cuda().to(
+        dtype=torch.bfloat16
+    )
+    materialized_expert_numels = {
+        name: param.numel()
+        for name, param in materialized_model.named_parameters()
+        if ".experts." in name
+    }
+    build_fsdp2_training_optimizer(
+        [materialized_model],
+        SimpleNamespace(
+            optimizer="adam",
+            lr=1.0e-3,
+            weight_decay=0.0,
+            adam_beta1=0.9,
+            adam_beta2=0.95,
+            adam_eps=1.0e-8,
+            clip_grad=1.0,
+            offload_fraction=0.0,
+        ),
+        ps,
+        unit_modules=(TinyMoEUnit,),
+        leaf_module_names=(),
+        expert_classifier=lambda name: ".experts." in f".{name}",
+        reshard_after_forward=False,
+        forward_prefetch_depth=0,
+        backward_prefetch_depth=0,
+        use_fp32_shards=False,
+        use_fp32_master=False,
+    )
+    x = torch.randn(2, 512, device="cuda", dtype=torch.bfloat16)
+    output = materialized_model(x)
+    del output, x
+    torch.cuda.synchronize()
+
+    materialized_handle = ModelHandle(
+        model=materialized_model,
+        optimizer=None,
+        parallel_state=ps,
+        _extras={"model_chunks": [materialized_model]},
+    )
+    runtime.to(materialized_handle, "cpu", model=True, optimizer=False, grad=False)
+    for name, param in materialized_model.named_parameters():
+        local = to_local_tensor(param.detach())
+        assert local.device.type == "cpu"
+        if name in materialized_expert_numels:
+            assert local.numel() == materialized_expert_numels[name] // ps.expert_dp_size
+
+    runtime.to(materialized_handle, "cuda", model=True, optimizer=False, grad=False)
+    assert _local_param_devices(materialized_model) == {"cuda"}

--- a/experimental/lite/tests/unit/primitive/test_fsdp2_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_fsdp2_unit.py
@@ -64,9 +64,108 @@ class NestedToyBlock(ToyBlock):
         self.inner = ToyBlock()
 
 
+class ToyExperts(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.proj = nn.Linear(4, 4, bias=False)
+
+    def forward(self, x):
+        return self.proj(x)
+
+
+class ToyMoEBlock(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.dense = nn.Linear(4, 4, bias=False)
+        self.experts = ToyExperts()
+
+    def forward(self, x):
+        return self.experts(self.dense(x))
+
+
 def test_fsdp2_config_validates_empty_wrap_surface():
     with pytest.raises(ValueError, match="wrap_root=True"):
         FSDP2Config(wrap_root=False)
+
+
+def test_fsdp2_pipeline_preserves_reshard_after_forward_setting():
+    ps = SimpleNamespace(pp_size=4)
+
+    assert (
+        fsdp2_optimizer._fsdp2_unit_reshard_after_forward(
+            ps, reshard_after_forward=True
+        )
+        is True
+    )
+
+
+def test_fsdp2_pipeline_wraps_dense_and_experts_with_reshard(monkeypatch):
+    model = ToyMoEBlock()
+    dense_calls = []
+    expert_calls = []
+    expert_mesh = SimpleNamespace(name="expert_dp")
+    optimizer = object()
+    ps = ParallelState(
+        pp_size=2,
+        ep_size=2,
+        dp_cp_size=4,
+        expert_dp_size=2,
+        ep_dp_group=object(),
+    )
+
+    def fake_wrap_expert(module, _ps, config, **kwargs):
+        expert_calls.append((module, config, kwargs))
+        return module
+
+    def fake_wrap_dense(module, _ps, config, **kwargs):
+        dense_calls.append((module, config, kwargs))
+        return module
+
+    monkeypatch.setattr(
+        fsdp2_optimizer,
+        "build_fsdp2_process_group_mesh",
+        lambda *args, **kwargs: expert_mesh,
+    )
+    monkeypatch.setattr(fsdp2_optimizer, "wrap_fsdp2_module", fake_wrap_expert)
+    monkeypatch.setattr(fsdp2_optimizer, "wrap_fsdp2", fake_wrap_dense)
+    monkeypatch.setattr(
+        fsdp2_optimizer,
+        "build_fsdp2_adamw",
+        lambda *args, **kwargs: optimizer,
+    )
+
+    result = fsdp2_optimizer.build_fsdp2_training_optimizer(
+        [model],
+        None,
+        ps,
+        unit_modules=(ToyMoEBlock,),
+        expert_classifier=lambda name: ".experts." in f".{name}",
+        reshard_after_forward=True,
+        use_fp32_shards=False,
+        use_fp32_master=False,
+    )
+
+    assert result is optimizer
+    assert len(expert_calls) == 1
+    expert_module, expert_config, expert_kwargs = expert_calls[0]
+    assert expert_module is model.experts
+    assert expert_config.reshard_after_forward is True
+    assert expert_kwargs["reshard_after_forward"] is True
+    assert expert_kwargs["mesh"] is expert_mesh
+
+    assert len(dense_calls) == 1
+    dense_module, dense_config, dense_kwargs = dense_calls[0]
+    assert dense_module is model
+    assert dense_config.reshard_after_forward is True
+    assert dense_config.last_unit_reshard_after_forward is True
+    assert dense_kwargs["ignored_params"] == set(model.experts.parameters())
+
+
+@pytest.mark.parametrize("depth", [0, 1, 2])
+def test_fsdp2_pipeline_preserves_prefetch_depth(depth: int):
+    ps = SimpleNamespace(pp_size=4)
+
+    assert fsdp2_optimizer._fsdp2_prefetch_depth(ps, default_depth=depth) == depth
 
 
 @pytest.mark.parametrize("field", ["mesh_dim_name", "device_type"])

--- a/experimental/lite/tests/unit/primitive/test_gdn_chunkwise_thd_reshuffle.py
+++ b/experimental/lite/tests/unit/primitive/test_gdn_chunkwise_thd_reshuffle.py
@@ -1,0 +1,132 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Packing-aware THD CP reshuffle for the restored GDN ``chunkwise`` mode.
+
+The GDN ``chunkwise`` CP mode reshuffles the Megatron zigzag CP layout to
+contiguous-time chunks (and back) around the FLA recurrence. For packed THD this
+reshuffle must route on the *global* ``cu_seqlens`` so per-sequence zigzag chunk
+boundaries survive even when a sequence spans the contiguous CP-rank boundary — the
+exact case the removed ``sharded`` copy corrupted (it sliced ``cu_seqlens // cp`` and
+swapped each sequence independently).
+
+``test_thd_rank_indices_*`` pin the index math on CPU without any distributed setup;
+``test_thd_reshuffle_roundtrip_gloo`` runs the real primitive under gloo and asserts a
+bitwise round-trip against the ground-truth contiguous span. The per-head recurrence is
+unchanged FLA GPU code, so a bitwise-correct reshuffle => the GPU chunkwise path is fed
+the same contiguous-time tokens upstream Megatron feeds its kernel (GPU numeric parity
+is the separate ``gpu`` gate).
+"""
+from __future__ import annotations
+
+import multiprocessing
+import os
+
+import pytest
+import torch
+
+from megatron.lite.primitive.parallel.cp import get_thd_context_parallel_rank_indices
+
+pytestmark = pytest.mark.mlite
+
+# Hand-computed indices for the anchor case (cp=2, cu=[0,8,12]): seq0 len8 splits into
+# 4 chunks [0,1|2,3|4,5|6,7] with zigzag owners r0,r1,r1,r0; seq1 len4 -> [8|9|10|11]
+# owners r0,r1,r1,r0. Contiguous halves are the trivial global slices.
+ANCHOR_CU = [0, 8, 12]
+ANCHOR_ZIGZAG = {0: [0, 1, 6, 7, 8, 11], 1: [2, 3, 4, 5, 9, 10]}
+ANCHOR_CONTIGUOUS = {0: [0, 1, 2, 3, 4, 5], 1: [6, 7, 8, 9, 10, 11]}
+
+
+def test_thd_rank_indices_match_hand_computed_anchor():
+    cu = torch.tensor(ANCHOR_CU, dtype=torch.long)
+    for rank in range(2):
+        zz = get_thd_context_parallel_rank_indices(cu, 2, rank, "zigzag").tolist()
+        cont = get_thd_context_parallel_rank_indices(cu, 2, rank, "contiguous").tolist()
+        assert zz == ANCHOR_ZIGZAG[rank], f"zigzag rank{rank}: {zz}"
+        assert cont == ANCHOR_CONTIGUOUS[rank], f"contiguous rank{rank}: {cont}"
+
+
+@pytest.mark.parametrize(
+    "cp, cu",
+    [
+        (2, [0, 8, 12]),
+        (4, [0, 16, 24, 32]),
+        (2, [0, 16, 24]),
+    ],
+)
+def test_thd_rank_indices_partition_invariants(cp, cu):
+    """Each layout partitions the global tokens exactly once; contiguous is a plain slice."""
+    cu_t = torch.tensor(cu, dtype=torch.long)
+    total = cu[-1]
+    part = total // cp
+    for layout in ("zigzag", "contiguous"):
+        owned = [
+            get_thd_context_parallel_rank_indices(cu_t, cp, r, layout).tolist() for r in range(cp)
+        ]
+        flat = sorted(idx for span in owned for idx in span)
+        assert flat == list(range(total)), f"{layout} not a clean partition: {flat}"
+        assert all(len(span) == part for span in owned), f"{layout} uneven shards"
+    for r in range(cp):
+        cont = get_thd_context_parallel_rank_indices(cu_t, cp, r, "contiguous").tolist()
+        assert cont == list(range(r * part, (r + 1) * part))
+
+
+def test_thd_rank_indices_rejects_indivisible_length():
+    # seq len 6 is not divisible by 2*cp=4 -> zigzag chunking is undefined.
+    cu = torch.tensor([0, 6], dtype=torch.long)
+    with pytest.raises(ValueError):
+        get_thd_context_parallel_rank_indices(cu, 2, 0, "zigzag")
+
+
+# --------------------------------------------------------------------- gloo round-trip
+def _reshuffle_worker(rank, world, cu_list, port, results):
+    os.environ.update(
+        MASTER_ADDR="127.0.0.1", MASTER_PORT=str(port), RANK=str(rank), WORLD_SIZE=str(world)
+    )
+    import torch.distributed as dist
+
+    from megatron.lite.primitive.parallel.cp import (
+        contiguous_to_zigzag_chunks,
+        zigzag_to_contiguous_chunks,
+    )
+
+    dist.init_process_group("gloo", rank=rank, world_size=world)
+    group = dist.new_group(list(range(world)))
+    try:
+        cu = torch.tensor(cu_list, dtype=torch.long)
+        total = int(cu[-1])
+        part = total // world
+        torch.manual_seed(20260715)
+        full = torch.randn(total, 8)  # identical across ranks (same seed)
+
+        zz_idx = get_thd_context_parallel_rank_indices(cu, world, rank, "zigzag")
+        local_zigzag = full.index_select(0, zz_idx).contiguous()
+
+        got_contig = zigzag_to_contiguous_chunks(local_zigzag, group, seq_dim=0, cu_seqlens=cu)
+        expect_contig = full[rank * part : (rank + 1) * part].contiguous()
+        fwd = (got_contig - expect_contig).abs().max().item()
+
+        back = contiguous_to_zigzag_chunks(got_contig, group, seq_dim=0, cu_seqlens=cu)
+        rt = (back - local_zigzag).abs().max().item()
+        results.append((rank, fwd, rt))
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.distributed
+@pytest.mark.parametrize(
+    "cp, cu, port",
+    [
+        (2, [0, 8, 12], 29630),
+        (4, [0, 16, 24, 32], 29631),
+        (2, [0, 16, 24], 29632),
+    ],
+)
+def test_thd_reshuffle_roundtrip_gloo(cp, cu, port):
+    import torch.multiprocessing as mp
+
+    mgr = multiprocessing.Manager()
+    results = mgr.list()
+    mp.spawn(_reshuffle_worker, args=(cp, cu, port, results), nprocs=cp, join=True)
+    assert len(results) == cp, f"missing ranks: {list(results)}"
+    for rank, fwd, rt in results:
+        assert fwd == 0.0, f"rank{rank} zigzag->contiguous not bitwise: max_abs={fwd}"
+        assert rt == 0.0, f"rank{rank} round-trip not bitwise: max_abs={rt}"

--- a/experimental/lite/tests/unit/primitive/test_hf_weights_streaming.py
+++ b/experimental/lite/tests/unit/primitive/test_hf_weights_streaming.py
@@ -25,6 +25,7 @@ from megatron.lite.primitive.ckpt.hf_weights import (
     _iter_bucketed_materialized_tensors,
     bucketed_all_gather_into_tensor,
     export_hf_weights,
+    stream_export_to_shards,
 )
 
 
@@ -57,6 +58,78 @@ def test_safe_tensor_reader_context_reuses_and_closes_shard(monkeypatch, tmp_pat
 
     assert events == ["enter", ("get", "a"), ("get", "b"), "exit"]
 
+
+def test_stream_export_removes_stale_owned_files_when_reusing_directory(tmp_path) -> None:
+    for name in (
+        "model.safetensors",
+        "model-00001-of-00002.safetensors",
+        "model.safetensors.index.json",
+        ".model-shard-00001.safetensors",
+    ):
+        (tmp_path / name).write_text("stale")
+    unrelated = tmp_path / "README.txt"
+    unrelated.write_text("keep")
+
+    stream_export_to_shards(
+        iter([("new", torch.ones(2))]), str(tmp_path), shard_size_bytes=1024
+    )
+
+    assert (tmp_path / "model.safetensors").exists()
+    assert unrelated.read_text() == "keep"
+    assert not (tmp_path / "model-00001-of-00002.safetensors").exists()
+    assert not (tmp_path / "model.safetensors.index.json").exists()
+    assert not (tmp_path / ".model-shard-00001.safetensors").exists()
+
+
+def test_stream_export_flushes_bounded_shards_and_writes_hf_index(
+    tmp_path, monkeypatch
+) -> None:
+    flushed = []
+
+    def fake_save_safetensors(tensors, path, *, filename):
+        flushed.append(
+            (list(tensors), sum(t.numel() * t.element_size() for t in tensors.values()))
+        )
+        (Path(path) / filename).touch()
+
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.hf_weights.save_safetensors",
+        fake_save_safetensors,
+    )
+    tensors = [(f"weight_{i}", torch.ones(2, dtype=torch.float32)) for i in range(3)]
+
+    stream_export_to_shards(iter(tensors), str(tmp_path), shard_size_bytes=8)
+
+    assert flushed == [(["weight_0"], 8), (["weight_1"], 8), (["weight_2"], 8)]
+    index = json.loads((tmp_path / "model.safetensors.index.json").read_text())
+    assert index["metadata"] == {"total_size": 24}
+    assert index["weight_map"] == {
+        "weight_0": "model-00001-of-00003.safetensors",
+        "weight_1": "model-00002-of-00003.safetensors",
+        "weight_2": "model-00003-of-00003.safetensors",
+    }
+
+
+def test_stream_export_nonzero_rank_drains_iterator_for_collectives(
+    tmp_path, monkeypatch
+) -> None:
+    consumed = []
+    barriers = []
+
+    def export_iter():
+        for i in range(3):
+            consumed.append(i)
+            yield f"weight_{i}", torch.ones(1)
+
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda: 1)
+    monkeypatch.setattr(torch.distributed, "barrier", lambda: barriers.append(True))
+
+    stream_export_to_shards(export_iter(), str(tmp_path), shard_size_bytes=4)
+
+    assert consumed == [0, 1, 2]
+    assert barriers == [True]
+    assert list(tmp_path.iterdir()) == []
 
 
 def test_export_defaults_to_device_resident_tensors() -> None:
@@ -489,10 +562,12 @@ def test_pp_export_streams_over_nccl_and_matches_materialized(monkeypatch) -> No
         def __init__(self) -> None:
             super().__init__()
             self.weight = nn.Parameter(local_weight.clone())
+            self.register_buffer("router_bias", torch.tensor([1.0, 2.0]))
 
     class Spec:
         num_experts = 0
         is_expert = staticmethod(lambda name: False)
+        is_export_buffer = staticmethod(lambda name: name == "router_bias")
         tp_spec = staticmethod(lambda name: None)
         native_to_hf = staticmethod(lambda name, tensor: [(name, tensor)])
 
@@ -504,8 +579,11 @@ def test_pp_export_streams_over_nccl_and_matches_materialized(monkeypatch) -> No
     })()
 
     groups = []
-    remote_headers = iter([[("weight2", (2, 3), torch.float32)], []])
-    remote_tensors = iter([remote_weight])
+    remote_bias = torch.tensor([3.0, 4.0])
+    remote_headers = iter(
+        [[("weight2", (2, 3), torch.float32), ("router_bias2", (2,), torch.float32)], []]
+    )
+    remote_tensors = iter([remote_weight, remote_bias])
 
     def fake_broadcast_object_list(object_list, src=None, group=None, device=None):
         groups.append(group)
@@ -526,9 +604,11 @@ def test_pp_export_streams_over_nccl_and_matches_materialized(monkeypatch) -> No
     exported = dict(export_hf_weights(Model(), Spec(), ps))
 
     assert set(groups) == {"nccl-pp"}
-    assert exported.keys() == {"weight", "weight2"}
+    assert exported.keys() == {"weight", "router_bias", "weight2", "router_bias2"}
     assert torch.equal(exported["weight"], local_weight)
+    assert torch.equal(exported["router_bias"], torch.tensor([1.0, 2.0]))
     assert torch.equal(exported["weight2"], remote_weight)
+    assert torch.equal(exported["router_bias2"], remote_bias)
 
 
 

--- a/experimental/lite/tests/unit/primitive/test_hf_weights_streaming.py
+++ b/experimental/lite/tests/unit/primitive/test_hf_weights_streaming.py
@@ -1,0 +1,612 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+from __future__ import annotations
+
+import importlib.util
+import inspect
+import json
+import sys
+import types
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+import pytest
+
+if importlib.util.find_spec("safetensors") is None:
+    safetensors = types.ModuleType("safetensors")
+    safetensors.safe_open = None
+    safetensors_torch = types.ModuleType("safetensors.torch")
+    safetensors_torch.save_file = None
+    sys.modules["safetensors"] = safetensors
+    sys.modules["safetensors.torch"] = safetensors_torch
+
+from megatron.lite.primitive.ckpt.hf_weights import (
+    SafeTensorReader,
+    _iter_bucketed_materialized_tensors,
+    bucketed_all_gather_into_tensor,
+    export_hf_weights,
+)
+
+
+def test_safe_tensor_reader_context_reuses_and_closes_shard(monkeypatch, tmp_path) -> None:
+    (tmp_path / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {"a": "shard.safetensors", "b": "shard.safetensors"}})
+    )
+    events = []
+
+    class Handle:
+        def __enter__(self):
+            events.append("enter")
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            events.append("exit")
+
+        def get_tensor(self, name):
+            events.append(("get", name))
+            return torch.tensor([1 if name == "a" else 2])
+
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.hf_weights.safe_open",
+        lambda *args, **kwargs: Handle(),
+    )
+
+    with SafeTensorReader(str(tmp_path)) as reader:
+        assert reader.get_tensor("a").item() == 1
+        assert reader.get_tensor("b").item() == 2
+
+    assert events == ["enter", ("get", "a"), ("get", "b"), "exit"]
+
+
+
+def test_export_defaults_to_device_resident_tensors() -> None:
+    assert inspect.signature(export_hf_weights).parameters["cpu"].default is False
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_gpu_resident_export_is_bitwise_equal_to_legacy_cpu_export() -> None:
+    class Model(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.weight = nn.Parameter(
+                torch.arange(12, dtype=torch.bfloat16, device="cuda").reshape(3, 4)
+            )
+
+    class Spec:
+        num_experts = 0
+
+        @staticmethod
+        def is_expert(name):
+            return False
+
+        @staticmethod
+        def tp_spec(name):
+            return None
+
+        @staticmethod
+        def native_to_hf(name, tensor):
+            return [(name, tensor)]
+
+    ps = type(
+        "ParallelState",
+        (),
+        {
+            "pp_size": 1,
+            "tp_size": 1,
+            "tp_group": None,
+            "ep_size": 1,
+            "ep_group": None,
+            "etp_size": 1,
+            "etp_group": None,
+        },
+    )()
+    model = Model()
+
+    legacy = dict(export_hf_weights(model, Spec(), ps, cpu=True))
+    resident = dict(export_hf_weights(model, Spec(), ps))
+
+    assert legacy.keys() == resident.keys()
+    assert legacy["weight"].device.type == "cpu"
+    assert resident["weight"].device.type == "cuda"
+    assert torch.equal(legacy["weight"], resident["weight"].cpu())
+
+
+def test_bucketed_all_gather_uses_bounded_flat_buffers(monkeypatch) -> None:
+    bucket = [
+        ("first", torch.arange(6, dtype=torch.float32).reshape(2, 3)),
+        ("second", torch.arange(5, dtype=torch.float32)),
+    ]
+    calls = []
+
+    def fake_all_gather_into_tensor(output, tensor, group=None):
+        assert group == "tp"
+        calls.append((output.numel(), tensor.numel()))
+        output[: tensor.numel()].copy_(tensor)
+        output[tensor.numel() :].copy_(tensor + 100)
+
+    monkeypatch.setattr(torch.distributed, "all_gather_into_tensor", fake_all_gather_into_tensor)
+
+    gathered = bucketed_all_gather_into_tensor(
+        bucket,
+        group="tp",
+        group_size=2,
+        buffer_max_size_bytes=32,
+    )
+
+    assert len(calls) == 3
+    assert all(recv_numel * 4 <= 32 for recv_numel, _ in calls)
+    assert all(recv_numel == 2 * send_numel for recv_numel, send_numel in calls)
+    assert torch.equal(gathered[0][2][0], bucket[0][1])
+    assert torch.equal(gathered[0][2][1], bucket[0][1] + 100)
+    assert torch.equal(gathered[1][2][0], bucket[1][1])
+    assert torch.equal(gathered[1][2][1], bucket[1][1] + 100)
+
+
+def test_fsdp_dtensors_share_one_bounded_flat_collective(monkeypatch) -> None:
+    class Shard:
+        def __init__(self, dim: int) -> None:
+            self.dim = dim
+
+    class Mesh:
+        def __init__(self, group) -> None:
+            self.group = group
+
+        def get_group(self, mesh_dim):
+            assert mesh_dim == 0
+            return self.group
+
+    class FakeDTensor:
+        def __init__(self, local, shape, shard_dim, group):
+            self._local = local
+            self.shape = shape
+            self.device = local.device
+            self.dtype = local.dtype
+            self.device_mesh = Mesh(group)
+            self.placements = (Shard(shard_dim),)
+
+        def to_local(self):
+            return self._local
+
+        def full_tensor(self):
+            raise AssertionError("per-parameter full_tensor must not be used")
+
+    first_group = object()
+    equivalent_group = object()
+    single_rank_group = object()
+    first = FakeDTensor(
+        torch.arange(6, dtype=torch.float32).reshape(2, 3),
+        (4, 3),
+        0,
+        first_group,
+    )
+    single = FakeDTensor(
+        torch.arange(3, dtype=torch.float32), (3,), 0, single_rank_group
+    )
+    second = FakeDTensor(
+        torch.arange(4, dtype=torch.float32).reshape(2, 2),
+        (2, 4),
+        1,
+        equivalent_group,
+    )
+    calls = []
+
+    def fake_all_gather_into_tensor(output, tensor, group=None):
+        assert group is first_group
+        calls.append(tensor.clone())
+        output[: tensor.numel()].copy_(tensor)
+        output[tensor.numel() :].copy_(tensor + 100)
+
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.hf_weights.DTensor", FakeDTensor
+    )
+    monkeypatch.setattr(
+        torch.distributed,
+        "get_world_size",
+        lambda group: 1 if group is single_rank_group else 2,
+    )
+    monkeypatch.setattr(
+        torch.distributed,
+        "get_process_group_ranks",
+        lambda group: [0] if group is single_rank_group else [0, 1],
+    )
+    monkeypatch.setattr(
+        torch.distributed, "all_gather_into_tensor", fake_all_gather_into_tensor
+    )
+
+    outputs = list(
+        _iter_bucketed_materialized_tensors(
+            [
+                ("first", first),
+                ("plain", torch.tensor([7.0])),
+                ("single", single),
+                ("second", second),
+            ],
+            buffer_max_size_bytes=1024,
+        )
+    )
+    materialized = dict(outputs)
+
+    assert len(calls) == 1
+    assert [name for name, _ in outputs] == ["first", "plain", "single", "second"]
+    assert materialized["single"] is single.to_local()
+    assert torch.equal(
+        materialized["first"],
+        torch.cat([first.to_local(), first.to_local() + 100], dim=0),
+    )
+    assert torch.equal(
+        materialized["second"],
+        torch.cat([second.to_local(), second.to_local() + 100], dim=1),
+    )
+
+
+def test_oversized_fsdp_shard_is_gathered_in_shard_dimension_chunks(
+    monkeypatch,
+) -> None:
+    class Shard:
+        dim = 1
+
+    class Mesh:
+        @staticmethod
+        def get_group(mesh_dim):
+            assert mesh_dim == 0
+            return "fsdp"
+
+    class FakeDTensor:
+        def __init__(self, local):
+            self._local = local
+            self.shape = (local.shape[0], local.shape[1] * 2)
+            self.device_mesh = Mesh()
+            self.placements = (Shard(),)
+
+        def to_local(self):
+            return self._local
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    local = torch.arange(10, dtype=torch.float32, device=device).reshape(2, 5)
+    calls = []
+
+    def fake_all_gather_into_tensor(output, tensor, group=None):
+        assert group == "fsdp"
+        calls.append(tensor.shape)
+        output[: tensor.numel()].copy_(tensor)
+        output[tensor.numel() :].copy_(tensor + 100)
+
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.hf_weights.DTensor", FakeDTensor
+    )
+    monkeypatch.setattr(torch.distributed, "get_world_size", lambda group: 2)
+    monkeypatch.setattr(
+        torch.distributed, "get_process_group_ranks", lambda group: [0, 1]
+    )
+    monkeypatch.setattr(
+        torch.distributed, "all_gather_into_tensor", fake_all_gather_into_tensor
+    )
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.hf_weights.torch.empty_like",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("oversized shards must not allocate full rank copies")
+        ),
+    )
+
+    outputs = dict(
+        _iter_bucketed_materialized_tensors(
+            [("oversized", FakeDTensor(local))], buffer_max_size_bytes=32
+        )
+    )
+
+    assert calls == [torch.Size([4]), torch.Size([4]), torch.Size([2])]
+    assert torch.equal(outputs["oversized"], torch.cat([local, local + 100], dim=1))
+
+
+def test_replicated_dtensor_uses_local_tensor_without_collective(monkeypatch) -> None:
+    class Replicate:
+        pass
+
+    class FakeDTensor:
+        def __init__(self, local):
+            self._local = local
+            self.shape = local.shape
+            self.device = local.device
+            self.dtype = local.dtype
+            self.placements = (Replicate(),)
+
+        def to_local(self):
+            return self._local
+
+        def full_tensor(self):
+            raise AssertionError("replicated parameters must not call full_tensor")
+
+    local = torch.arange(5, dtype=torch.float32)
+    monkeypatch.setattr(
+        "megatron.lite.primitive.ckpt.hf_weights.DTensor", FakeDTensor
+    )
+    monkeypatch.setattr(
+        torch.distributed,
+        "all_gather_into_tensor",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("replicated parameters must not be gathered")
+        ),
+    )
+
+    outputs = list(
+        _iter_bucketed_materialized_tensors([("replicated", FakeDTensor(local))])
+    )
+
+    assert outputs[0][0] == "replicated"
+    assert outputs[0][1] is local
+
+
+def test_export_batches_adjacent_tp_weights_into_one_flat_collective(
+    monkeypatch,
+) -> None:
+    class Model(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.first = nn.Parameter(torch.arange(4, dtype=torch.float32).reshape(2, 2))
+            self.second = nn.Parameter(torch.arange(3, dtype=torch.float32).reshape(1, 3))
+
+    class Spec:
+        num_experts = 0
+
+        @staticmethod
+        def is_expert(name):
+            return False
+
+        @staticmethod
+        def tp_spec(name):
+            return (0, 0)
+
+        @staticmethod
+        def native_to_hf(name, tensor):
+            return [(name, tensor)]
+
+    ps = type(
+        "ParallelState",
+        (),
+        {
+            "pp_size": 1,
+            "tp_size": 2,
+            "tp_group": "tp",
+            "ep_size": 1,
+            "ep_group": None,
+            "etp_size": 1,
+            "etp_group": None,
+        },
+    )()
+    calls = []
+
+    def fake_all_gather_into_tensor(output, tensor, group=None):
+        assert group == "tp"
+        calls.append(tensor.clone())
+        output[: tensor.numel()].copy_(tensor)
+        output[tensor.numel() :].copy_(tensor + 10)
+
+    monkeypatch.setattr(torch.distributed, "all_gather_into_tensor", fake_all_gather_into_tensor)
+
+    exported = dict(export_hf_weights(Model(), Spec(), ps, cpu=False, buffer_max_size_bytes=1024))
+
+    assert len(calls) == 1
+    assert torch.equal(
+        exported["first"],
+        torch.cat([torch.arange(4).reshape(2, 2), torch.arange(4).reshape(2, 2) + 10]),
+    )
+    assert torch.equal(
+        exported["second"],
+        torch.cat([torch.arange(3).reshape(1, 3), torch.arange(3).reshape(1, 3) + 10]),
+    )
+
+
+def test_expert_export_yields_when_bounded_ep_bucket_fills(monkeypatch) -> None:
+    class ExpertGroup(nn.Module):
+        def __init__(self, offset: int) -> None:
+            super().__init__()
+            for idx in range(2):
+                self.register_parameter(
+                    f"weight{idx}",
+                    nn.Parameter(torch.arange(4, dtype=torch.float32) + offset + idx * 10),
+                )
+
+    class Model(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.first = nn.Module()
+            self.first.experts = ExpertGroup(0)
+            self.second = nn.Module()
+            self.second.experts = ExpertGroup(1000)
+
+        def named_parameters(self, *args, **kwargs):
+            for item in super().named_parameters(*args, **kwargs):
+                visited.append(item[0])
+                yield item
+
+    class Spec:
+        num_experts = 4
+
+        @staticmethod
+        def is_expert(name):
+            return ".experts." in name
+
+        @staticmethod
+        def tp_spec(name):
+            return None
+
+        @staticmethod
+        def packed_expert_group_name(name):
+            return name.rsplit(".weight", 1)[0] + ".packed"
+
+        @staticmethod
+        def native_to_hf(name, tensor):
+            assert name.endswith(".packed")
+            return [(name, tensor)]
+
+    ps = type(
+        "ParallelState",
+        (),
+        {
+            "pp_size": 1,
+            "tp_size": 1,
+            "tp_group": None,
+            "ep_size": 2,
+            "ep_group": "ep",
+            "etp_size": 1,
+            "etp_group": None,
+        },
+    )()
+    visited = []
+
+    def fake_all_gather_into_tensor(output, tensor, group=None):
+        assert group == "ep"
+        output[: tensor.numel()].copy_(tensor)
+        output[tensor.numel() :].copy_(tensor + 100)
+
+    monkeypatch.setattr(
+        torch.distributed, "all_gather_into_tensor", fake_all_gather_into_tensor
+    )
+
+    stream = export_hf_weights(
+        Model(), Spec(), ps, cpu=False, buffer_max_size_bytes=64
+    )
+    name, tensor = next(stream)
+
+    assert name == "first.experts.packed"
+    assert len(visited) == 2
+    expected_local = [
+        torch.arange(4, dtype=torch.float32),
+        torch.arange(4, dtype=torch.float32) + 10,
+    ]
+    assert torch.equal(
+        tensor, torch.stack(expected_local + [value + 100 for value in expected_local])
+    )
+
+
+def test_pp_export_streams_over_nccl_and_matches_materialized(monkeypatch) -> None:
+    """Streamed pp2 export must be bitwise-equal to the legacy materialized
+    dict, with every header/tensor exchange on the NCCL pp_group."""
+    local_weight = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+    remote_weight = local_weight + 100
+
+    class Model(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.weight = nn.Parameter(local_weight.clone())
+
+    class Spec:
+        num_experts = 0
+        is_expert = staticmethod(lambda name: False)
+        tp_spec = staticmethod(lambda name: None)
+        native_to_hf = staticmethod(lambda name, tensor: [(name, tensor)])
+
+    ps = type("ParallelState", (), {
+        "pp_size": 2, "pp_rank": 0, "pp_global_ranks": [0, 1],
+        "tp_size": 1, "tp_group": None, "ep_size": 1, "ep_group": None,
+        "etp_size": 1, "etp_group": None,
+        "pp_group": "nccl-pp", "pp_cpu_group": "gloo-pp",
+    })()
+
+    groups = []
+    remote_headers = iter([[("weight2", (2, 3), torch.float32)], []])
+    remote_tensors = iter([remote_weight])
+
+    def fake_broadcast_object_list(object_list, src=None, group=None, device=None):
+        groups.append(group)
+        if src != 0:
+            object_list[0] = next(remote_headers)
+
+    def fake_broadcast(tensor, src=None, group=None):
+        groups.append(group)
+        if src != 0:
+            tensor.copy_(next(remote_tensors))
+
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda group=None: 0)
+    monkeypatch.setattr(torch.distributed, "broadcast_object_list",
+                        fake_broadcast_object_list)
+    monkeypatch.setattr(torch.distributed, "broadcast", fake_broadcast)
+
+    exported = dict(export_hf_weights(Model(), Spec(), ps))
+
+    assert set(groups) == {"nccl-pp"}
+    assert exported.keys() == {"weight", "weight2"}
+    assert torch.equal(exported["weight"], local_weight)
+    assert torch.equal(exported["weight2"], remote_weight)
+
+
+
+def test_pp_export_never_materializes_the_whole_stage(monkeypatch) -> None:
+    """Residency guard: with one-param buckets, pulling the first streamed param
+    must visit exactly one of three stage params — the legacy path would have
+    visited all three before yielding anything."""
+    visited: list[str] = []
+    params = {
+        "weight_a": torch.arange(6, dtype=torch.float32).reshape(2, 3),
+        "weight_b": torch.arange(6, dtype=torch.float32).reshape(2, 3) + 10,
+        "weight_c": torch.arange(6, dtype=torch.float32).reshape(2, 3) + 20,
+    }
+
+    class Model(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            for name, value in params.items():
+                self.register_parameter(name, nn.Parameter(value.clone()))
+
+        def named_parameters(self, *args, **kwargs):
+            for item in super().named_parameters(*args, **kwargs):
+                visited.append(item[0])
+                yield item
+
+    class Spec:
+        num_experts = 0
+
+        @staticmethod
+        def is_expert(name):
+            return False
+
+        @staticmethod
+        def tp_spec(name):
+            return None
+
+        @staticmethod
+        def native_to_hf(name, tensor):
+            return [(name, tensor)]
+
+    ps = type(
+        "ParallelState",
+        (),
+        {
+            "pp_size": 2,
+            "pp_rank": 0,
+            "pp_global_ranks": [0, 1],
+            "tp_size": 1,
+            "tp_group": None,
+            "ep_size": 1,
+            "ep_group": None,
+            "etp_size": 1,
+            "etp_group": None,
+            "pp_group": "nccl-pp",
+            "pp_cpu_group": "gloo-pp",
+        },
+    )()
+
+    my_global = 0
+
+    def fake_broadcast_object_list(object_list, src=None, group=None, device=None):
+        if src != my_global:
+            object_list[0] = []  # never reached: we stop after the first param
+
+    def fake_broadcast(tensor, src=None, group=None):
+        pass  # source (rank 0) broadcasts straight from its bucket
+
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda group=None: 0)
+    monkeypatch.setattr(
+        torch.distributed, "broadcast_object_list", fake_broadcast_object_list
+    )
+    monkeypatch.setattr(torch.distributed, "broadcast", fake_broadcast)
+
+    # buffer_max_size_bytes=1 caps every bucket at a single parameter.
+    stream = export_hf_weights(Model(), Spec(), ps, buffer_max_size_bytes=1)
+    first_name, first_tensor = next(stream)
+
+    assert first_name == "weight_a"
+    assert torch.equal(first_tensor, params["weight_a"])
+    assert visited == ["weight_a"]

--- a/experimental/lite/tests/unit/primitive/test_pipeline_thd_shape_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_pipeline_thd_shape_unit.py
@@ -1,0 +1,200 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""CPU unit tests for THD dynamic-batch P2P shapes in the pipeline layer.
+
+Under THD each micro-batch packs a different token count, so the inter-stage recv
+buffer is a different shape per mb; a fixed buffer sized from the first mb truncates
+later, larger ones (size mismatch -> abort/hang). Megatron's dynamic shape exchange
+sizes the recv buffer from the exact ``size()`` the sender puts on the wire. Two
+tiers: ``_1f1b_schedule`` (recv<->mb off-by-one guard at every stage position) and
+a real 2-process gloo PP2 proof (NEW sizes-from-wire green; OLD fixed-buffer red).
+"""
+
+from __future__ import annotations
+
+import multiprocessing
+import os
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.distributed as dist
+
+from megatron.lite.primitive.ckpt.hf_weights import unwrap_model
+from megatron.lite.primitive.parallel import pipeline as pl
+
+
+def _make_ps(pp_size: int, pp_rank: int) -> SimpleNamespace:
+    return SimpleNamespace(
+        pp_size=pp_size, pp_rank=pp_rank,
+        pp_is_first=(pp_rank == 0), pp_is_last=(pp_rank == pp_size - 1),
+        pp_prev_rank=pp_rank - 1, pp_next_rank=pp_rank + 1, pp_group=None,
+    )
+
+
+# --- _1f1b_schedule: recv<->microbatch mapping under variable shapes ---
+class _MockModel(torch.nn.Module):
+    def __init__(self, hidden: int):
+        super().__init__()
+        self.hidden = hidden
+        self.weight = torch.nn.Parameter(torch.ones(hidden, hidden))
+        self._input_tensor = None
+
+    def set_input_tensor(self, t):
+        self._input_tensor = t
+
+
+def _run_schedule(pp_size, pp_rank, seq_lens, hidden=8):
+    """Run the real _1f1b_schedule for one rank with _send_recv_pipeline mocked to
+    play the peer (recv tensor of the peer-sent shape, in transfer order); records
+    recv shapes to prove each recv maps to the right mb."""
+    ps = _make_ps(pp_size, pp_rank)
+    num_mb = len(seq_lens)
+    fwd_shapes = [(int(s), 1, hidden) for s in seq_lens]
+    model = _MockModel(hidden)
+    recorded_fwd, recorded_bwd = [], []
+    fwd_q, bwd_q = list(fwd_shapes), list(fwd_shapes)  # both arrive in mb order
+
+    def fake_srp(send_fwd, send_bwd, recv_fwd, recv_bwd, ps_, tensor_shape,
+                 *, fwd_recv_buf=None, bwd_recv_buf=None, batch_p2p=True,
+                 clone_recv=False, dynamic_shape=False):
+        assert dynamic_shape, "1F1B schedule must use dynamic shape exchange"
+        assert fwd_recv_buf is None and bwd_recv_buf is None, "dynamic recv must not pre-size"
+        fwd_out = bwd_out = None
+        if recv_fwd:
+            shp = fwd_q.pop(0); recorded_fwd.append(shp)
+            fwd_out = torch.ones(shp, requires_grad=True)
+        if recv_bwd:
+            shp = bwd_q.pop(0); recorded_bwd.append(shp)
+            bwd_out = torch.ones(shp)
+        return fwd_out, bwd_out
+
+    def forward_step_fn(m, batch):
+        s = int(batch["S"])
+        if ps.pp_is_first:
+            base = torch.ones(s, 1, hidden, requires_grad=True)
+        else:
+            inp = unwrap_model(m)._input_tensor
+            assert inp is not None, "middle/last stage forwarded with a None input"
+            assert tuple(inp.shape) == (s, 1, hidden), (
+                f"input shape {tuple(inp.shape)} != {(s, 1, hidden)} for mb S={s}")
+            base = inp
+        hidden_t = base * m.weight.sum()
+        out = {"hidden_states": hidden_t}
+        if ps.pp_is_last:
+            out["loss"] = hidden_t.float().sum()
+        return out
+
+    batches = [{"S": s} for s in seq_lens]
+    orig_srp, pl._send_recv_pipeline = pl._send_recv_pipeline, fake_srp
+    try:
+        pl._1f1b_schedule(
+            forward_step_fn, model, iter([(b, None) for b in batches]),
+            num_mb, SimpleNamespace(num_microbatches=num_mb), ps, fwd_shapes[0])
+    finally:
+        pl._send_recv_pipeline = orig_srp
+    return recorded_fwd, recorded_bwd, fwd_shapes
+
+
+VARLEN = [5, 9, 3, 7]  # deliberately non-uniform, ascending & descending mix
+
+
+@pytest.mark.parametrize("pp_rank", [1, 2])
+def test_middle_stage_recv_shapes_match_each_microbatch(pp_rank):
+    # PP4 interior stage: every fwd AND bwd recv sized for its own micro-batch.
+    rf, rb, fs = _run_schedule(4, pp_rank, VARLEN)
+    assert rf == fs and rb == fs, (rf, rb, fs)
+
+
+def test_last_stage_recv_shapes_match_each_microbatch():
+    rf, rb, fs = _run_schedule(4, 3, VARLEN)  # last: every fwd input, no bwd recv
+    assert rf == fs and rb == [], (rf, rb, fs)
+
+
+def test_first_stage_recv_shapes_match_each_microbatch():
+    rf, rb, fs = _run_schedule(4, 0, VARLEN)  # first: no fwd input, one bwd grad/mb
+    assert rf == [] and rb == fs, (rf, rb, fs)
+
+
+def test_pp2_recv_shapes_match_each_microbatch():
+    rf, rb, fs = _run_schedule(2, 0, VARLEN)  # first stage
+    assert rf == [] and rb == fs, (rf, rb, fs)
+    rf2, rb2, _ = _run_schedule(2, 1, VARLEN)  # last stage
+    assert rf2 == fs and rb2 == [], (rf2, rb2)
+
+
+# --- Tier-A: real gloo 2-process PP2, real _send_recv_pipeline, variable seq ---
+# NEW sizes the recv buffer from the wire so the S=7 mb (> first S=5) round-trips
+# bitwise; OLD's fixed S=5 buffer overflows on S=7 and gloo aborts the receiver
+# (spawn failure = red). Direct isend/irecv (gloo has no batch_isend_irecv); fp32.
+_PP_H = 8
+_PP_VARLEN = [5, 3, 7]  # 7 > first(5) is the overflow case
+
+
+def _pp_hidden(mb_idx: int, seqlen: int) -> torch.Tensor:  # deterministic [S,1,H]
+    gen = torch.Generator().manual_seed(20260715 + mb_idx)
+    return torch.randn(seqlen, 1, _PP_H, generator=gen)
+
+
+def _dynamic_shape_worker(rank, world, port, results):
+    os.environ.update(MASTER_ADDR="127.0.0.1", MASTER_PORT=str(port),
+                      RANK=str(rank), WORLD_SIZE=str(world))
+    pl._PIPELINE_TENSOR_DTYPE = torch.float32  # gloo-safe; sizing is dtype-agnostic
+    dist.init_process_group("gloo", rank=rank, world_size=world)
+    try:
+        ps = _make_ps(2, rank)
+        detail = []
+        for i, s in enumerate(_PP_VARLEN):
+            if rank == 0:
+                pl._send_recv_pipeline(_pp_hidden(i, s), None, False, False, ps,
+                                       (1, 1, _PP_H), batch_p2p=False, dynamic_shape=True)
+            else:
+                fwd_buf, _ = pl._send_recv_pipeline(None, None, True, False, ps,
+                                                    (1, 1, _PP_H), batch_p2p=False, dynamic_shape=True)
+                expect = _pp_hidden(i, s)
+                detail.append((s, tuple(fwd_buf.shape) == (s, 1, _PP_H),
+                               bool(torch.equal(fwd_buf.detach().float(), expect.float()))))
+        results.append((rank, detail))
+    finally:
+        dist.destroy_process_group()
+
+
+def _fixed_buffer_worker(rank, world, port, results):
+    os.environ.update(MASTER_ADDR="127.0.0.1", MASTER_PORT=str(port),
+                      RANK=str(rank), WORLD_SIZE=str(world))
+    pl._PIPELINE_TENSOR_DTYPE = torch.float32
+    dist.init_process_group("gloo", rank=rank, world_size=world)
+    try:
+        ps = _make_ps(2, rank)
+        first_len = _PP_VARLEN[0]  # fixed recv buffer sized from the FIRST mb (S=5)
+        if rank == 0:
+            pl._send_recv_pipeline(_pp_hidden(2, _PP_VARLEN[2]), None, False, False, ps,
+                                   (first_len, 1, _PP_H), batch_p2p=False, dynamic_shape=False)
+        else:
+            fixed_buf = torch.empty(first_len, 1, _PP_H, dtype=torch.float32)  # only fits S=5
+            pl._send_recv_pipeline(None, None, True, False, ps, (first_len, 1, _PP_H),
+                                   fwd_recv_buf=fixed_buf, batch_p2p=False, dynamic_shape=False)
+        results.append((rank, "no_abort"))  # reaching here without abort is the bug
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.distributed
+def test_dynamic_shape_variable_len_recv_gloo():  # NEW: recv sized from wire, 0 mismatch
+    import torch.multiprocessing as mp
+    results = multiprocessing.Manager().list()
+    mp.spawn(_dynamic_shape_worker, args=(2, 29663, results), nprocs=2, join=True)
+    by_rank = dict(results)
+    assert set(by_rank) == {0, 1}, f"missing ranks: {list(by_rank)}"
+    recv_detail = by_rank[1]  # last stage recorded every fwd recv
+    assert len(recv_detail) == len(_PP_VARLEN), recv_detail
+    for s, shape_ok, bitwise_ok in recv_detail:
+        assert shape_ok, f"S={s}: recv buffer not sized from the wire"
+        assert bitwise_ok, f"S={s}: recv hidden not bitwise-equal to sent hidden"
+
+
+@pytest.mark.distributed
+def test_fixed_buffer_truncates_variable_len_gloo():  # OLD: fixed buffer overflows -> abort
+    import torch.multiprocessing as mp
+    results = multiprocessing.Manager().list()
+    with pytest.raises(Exception):  # gloo aborts the receiver -> spawn failure
+        mp.spawn(_fixed_buffer_worker, args=(2, 29664, results), nprocs=2, join=True)

--- a/experimental/lite/tests/unit/primitive/test_router_replay_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_router_replay_unit.py
@@ -1,0 +1,299 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""CPU coverage for MLite R3 router replay."""
+
+from types import SimpleNamespace
+
+import torch
+import torch.nn as nn
+
+
+def test_replay_mask_uses_live_scores_and_keeps_native_unmasked_row():
+    from megatron.lite.primitive.modules.router_replay import RouterReplay, RouterReplayAction
+
+    RouterReplay.clear_global_router_replay_instances()
+    replay = RouterReplay()
+    dense = torch.tensor(
+        [[0.1, 0.2, 0.7], [0.6, 0.3, 0.1]], requires_grad=True
+    )
+    native_indices = torch.tensor([[2, 1], [0, 1]])
+    native_scores = dense.gather(1, native_indices)
+    target = torch.tensor([[0, 1], [2, 1]])
+    RouterReplay.set_replay_data([target], replay_mask=torch.tensor([True, False]))
+    RouterReplay.set_global_router_replay_action(RouterReplayAction.REPLAY_FORWARD)
+
+    scores, indices = replay.apply(dense, native_scores, native_indices)
+
+    assert torch.equal(indices, torch.tensor([[0, 1], [0, 1]]))
+    torch.testing.assert_close(scores, dense.gather(1, indices))
+    scores.square().sum().backward()
+    assert dense.grad is not None
+    assert dense.grad.abs().sum() > 0
+
+
+def test_replayed_sqrtsoftplus_scores_are_live_normalized_and_nonzero():
+    from megatron.lite.primitive.modules.router_replay import (
+        gather_replayed_router_scores,
+    )
+
+    logits = torch.tensor([[4.0, -3.0, 0.5, -1.0]], requires_grad=True)
+    # Select experts that are not the natural top-2; a sparse native routing
+    # tensor would contain zeros here, which was the PR49 half-finished bug.
+    indices = torch.tensor([[1, 3]])
+    scores = gather_replayed_router_scores(
+        logits,
+        indices,
+        score_function="sqrtsoftplus",
+        scaling_factor=2.5,
+    )
+    assert torch.all(scores > 0)
+    torch.testing.assert_close(scores.sum(dim=-1), torch.tensor([2.5]))
+    scores.square().sum().backward()
+    assert logits.grad is not None
+    assert logits.grad[0, 1].abs() > 0
+    assert logits.grad[0, 3].abs() > 0
+
+
+def test_backward_replay_keeps_fifo_across_pipeline_warmup_forwards():
+    from megatron.lite.primitive.modules.router_replay import RouterReplay, RouterReplayAction
+
+    RouterReplay.clear_global_router_replay_instances()
+    replay = RouterReplay()
+    first = torch.tensor([[10, 11]])
+    second = torch.tensor([[20, 21]])
+    native = torch.tensor([[0, 1]])
+
+    # Simulate two PP warmup forwards before either checkpoint recomputation.
+    RouterReplay.set_replay_data([first])
+    RouterReplay.set_replay_data([second])
+    RouterReplay.set_global_router_replay_action(RouterReplayAction.REPLAY_BACKWARD)
+
+    assert torch.equal(replay.select_indices(native), first)
+    assert torch.equal(replay.select_indices(native), second)
+
+
+def test_ds4_hash_router_records_and_replays_its_layer_column():
+    import pytest
+
+    pytest.importorskip("transformer_engine")
+    from megatron.lite.model.deepseek_v4.lite.moe import DeepseekV4MoE
+    from megatron.lite.primitive.modules.router_replay import RouterReplay, RouterReplayAction
+
+    RouterReplay.clear_global_router_replay_instances()
+    module = DeepseekV4MoE.__new__(DeepseekV4MoE)
+    nn.Module.__init__(module)
+    gate = nn.Module()
+    gate.gate = nn.Linear(2, 4, bias=False)
+    gate.score_function = "sigmoid"
+    gate.num_experts = 4
+    gate.register_buffer("tid2eid", torch.tensor([[0, 1], [2, 3]], dtype=torch.long))
+    gate.router_replay = RouterReplay()
+    module.gate = gate
+    module.topk = 2
+    module.route_scale = 1.0
+    x = torch.tensor([[1.0, -1.0], [0.5, 0.25]])
+    token_ids = torch.tensor([0, 1])
+
+    RouterReplay.set_global_router_replay_action(RouterReplayAction.RECORD)
+    _, recorded = module._hash_route(x, token_ids)
+    assert torch.equal(gate.router_replay.recorded_topk_idx, recorded)
+
+    target = torch.tensor([[1, 0], [3, 2]])
+    RouterReplay.set_replay_data([target], replay_mask=torch.tensor([True, True]))
+    RouterReplay.set_global_router_replay_action(RouterReplayAction.REPLAY_FORWARD)
+    weights, replayed = module._hash_route(x, token_ids)
+    assert torch.equal(replayed, target)
+    torch.testing.assert_close(weights.sum(dim=-1), torch.ones(2))
+
+
+def test_r3_mask_replays_every_causal_row_except_last():
+    from megatron.lite.model.protocol_utils import pack_r3_replay_mask
+    from megatron.lite.primitive.parallel import ParallelState
+    from megatron.lite.primitive.parallel.thd import thd_pack_meta
+    from megatron.lite.runtime.contracts import PackedBatch
+
+    lengths = torch.tensor([3, 5], dtype=torch.long)
+    batch = PackedBatch(
+        input_ids=torch.arange(8),
+        labels=torch.arange(8),
+        seq_lens=lengths,
+        loss_mask=torch.tensor([0, 1, 1, 0, 0, 1, 1, 1], dtype=torch.float32),
+    )
+    model = SimpleNamespace(ps=ParallelState())
+    mask = pack_r3_replay_mask(model, batch)
+    meta = thd_pack_meta(lengths, tp_size=1, cp_size=1)
+
+    expected = torch.zeros_like(mask)
+    for idx, length in enumerate(lengths.tolist()):
+        start = int(meta.cu_seqlens_padded[idx].item())
+        expected[start : start + length - 1] = True
+    assert torch.equal(mask, expected)
+
+
+def test_ds4_replay_roots_exclude_mtp_layers():
+    from megatron.lite.model.deepseek_v4.lite.protocol import router_replay_roots
+
+    main_layers = nn.ModuleDict({"0": nn.Linear(2, 2), "1": nn.Linear(2, 2)})
+    mtp_layers = nn.ModuleList([nn.Linear(2, 2)])
+    model = nn.Module()
+    model.layers = main_layers
+    model.mtp = mtp_layers
+    chunk = nn.Module()
+    chunk.model = model
+
+    assert router_replay_roots(chunk) == list(main_layers.values())
+
+
+def test_r3_driver_replays_layer_order_and_causal_rows_end_to_end():
+    from megatron.lite.primitive.parallel import ParallelState
+    from megatron.lite.runtime.backends.mlite.router_replay import RouterReplayDriver
+    from megatron.lite.runtime.contracts import PackedBatch
+
+    class FakeRouter(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.router_replay = None
+
+        def forward(self, native):
+            return self.router_replay.select_indices(native)
+
+    class FakeModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.ps = ParallelState()
+            self.routers = nn.ModuleList([FakeRouter(), FakeRouter()])
+
+    model = FakeModel()
+    handle = SimpleNamespace(
+        _model=model,
+        _extras={"model_chunks": [model], "protocol": None},
+    )
+    batch = PackedBatch(
+        input_ids=torch.arange(5),
+        labels=torch.arange(5),
+        seq_lens=torch.tensor([3, 2]),
+        loss_mask=torch.tensor([0, 1, 1, 0, 1], dtype=torch.float32),
+        routed_experts=torch.nested.as_nested_tensor(
+            [
+                torch.tensor(
+                    [
+                        [[10, 11], [20, 21]],
+                        [[12, 13], [22, 23]],
+                        [[14, 15], [24, 25]],
+                    ]
+                ),
+                torch.tensor(
+                    [
+                        [[16, 17], [26, 27]],
+                        [[18, 19], [28, 29]],
+                    ]
+                ),
+            ],
+            layout=torch.jagged,
+        ),
+    )
+    native = torch.tensor([[0, 1], [2, 3], [4, 5], [6, 7], [8, 9]])
+
+    driver = RouterReplayDriver.maybe_create(handle, {"action": "replay"})
+    assert driver is not None
+    driver.begin()
+    try:
+        stepped = driver.wrap(
+            lambda active_model, _batch: [router(native) for router in active_model.routers]
+        )
+        layer0, layer1 = stepped(model, batch)
+    finally:
+        driver.end()
+
+    # Every row that can causally affect a response token uses rollout routes.
+    # The final row of each sequence stays native because it predicts no token.
+    assert torch.equal(
+        layer0,
+        torch.tensor([[10, 11], [12, 13], [4, 5], [16, 17], [8, 9]]),
+    )
+    assert torch.equal(
+        layer1,
+        torch.tensor([[20, 21], [22, 23], [4, 5], [26, 27], [8, 9]]),
+    )
+    assert all(router.router_replay is None for router in model.routers)
+
+
+def test_r3_driver_accepts_next_token_routes_without_final_input_row():
+    from megatron.lite.primitive.parallel import ParallelState
+    from megatron.lite.runtime.backends.mlite.router_replay import RouterReplayDriver
+    from megatron.lite.runtime.contracts import PackedBatch
+
+    class FakeRouter(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.router_replay = None
+
+        def forward(self, native):
+            return self.router_replay.select_indices(native)
+
+    class FakeModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.ps = ParallelState()
+            self.routers = nn.ModuleList([FakeRouter()])
+
+    model = FakeModel()
+    handle = SimpleNamespace(
+        _model=model,
+        _extras={"model_chunks": [model], "protocol": None},
+    )
+    batch = PackedBatch(
+        input_ids=torch.arange(5),
+        labels=torch.arange(5),
+        seq_lens=torch.tensor([3, 2]),
+        loss_mask=torch.tensor([0, 1, 1, 0, 1], dtype=torch.float32),
+        routed_experts=torch.nested.as_nested_tensor(
+            [
+                torch.tensor([[[10, 11]], [[12, 13]]]),
+                torch.tensor([[[20, 21]]]),
+            ],
+            layout=torch.jagged,
+        ),
+    )
+    native = torch.tensor([[0, 1], [2, 3], [4, 5], [6, 7], [8, 9]])
+
+    driver = RouterReplayDriver.maybe_create(handle, {"action": "replay"})
+    assert driver is not None
+    driver.begin()
+    try:
+        stepped = driver.wrap(lambda active_model, _batch: active_model.routers[0](native))
+        actual = stepped(model, batch)
+    finally:
+        driver.end()
+
+    # vLLM supplies routes for causal rows only.  The absent final row of each
+    # input sequence remains native and therefore needs no synthetic route.
+    assert torch.equal(
+        actual,
+        torch.tensor([[10, 11], [12, 13], [4, 5], [20, 21], [8, 9]]),
+    )
+
+
+def test_r3_driver_slices_global_layer_axis_for_pipeline_stage():
+    from megatron.lite.runtime.backends.mlite.router_replay import RouterReplayDriver
+
+    driver = RouterReplayDriver(
+        SimpleNamespace(_model=nn.Module(), _extras={}),
+        "replay",
+    )
+    driver._ps = SimpleNamespace(pp_size=2)
+    driver._num_routers = 2
+    driver._pp_offset = 2
+    driver._pp_total = 4
+    routed = torch.nested.as_nested_tensor(
+        [
+            torch.arange(3 * 4 * 2).reshape(3, 4, 2),
+            torch.arange(2 * 4 * 2).reshape(2, 4, 2) + 100,
+        ],
+        layout=torch.jagged,
+    )
+
+    local = driver._select_local_layers(routed)
+
+    assert getattr(local, "is_nested", False)
+    for actual, source in zip(local.unbind(0), routed.unbind(0), strict=True):
+        assert torch.equal(actual, source[:, 2:4, :])

--- a/experimental/lite/tests/unit/primitive/test_weight_sync_fingerprint.py
+++ b/experimental/lite/tests/unit/primitive/test_weight_sync_fingerprint.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+from __future__ import annotations
+
+import torch
+
+from megatron.lite.primitive.ckpt.weight_sync_fingerprint import (
+    _sample_indices,
+    stream_fingerprint,
+    tensor_fingerprint_record,
+)
+
+
+def test_stream_fingerprint_is_order_independent():
+    a = tensor_fingerprint_record("model.embed_tokens.weight", torch.arange(32))
+    b = tensor_fingerprint_record("model.layers.0.weight", torch.arange(8))
+    assert stream_fingerprint([a, b]) == stream_fingerprint([b, a])
+
+
+def test_stream_fingerprint_detects_sampled_payload_change():
+    before = tensor_fingerprint_record("model.embed_tokens.weight", torch.arange(32))
+    value = torch.arange(32)
+    value[-1] = 100
+    after = tensor_fingerprint_record("model.embed_tokens.weight", value)
+    assert before["sha256"] != after["sha256"]
+
+
+def test_sample_indices_stay_in_bounds_for_multi_billion_byte_tensor():
+    numel = 9_000_000_001
+    indices = _sample_indices(numel, 256)
+    assert indices[0].item() == 0
+    assert indices[-1].item() == numel - 1
+    assert indices.min().item() >= 0
+    assert indices.max().item() < numel

--- a/experimental/lite/tests/unit/primitive/test_weight_sync_probe.py
+++ b/experimental/lite/tests/unit/primitive/test_weight_sync_probe.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+from __future__ import annotations
+
+import json
+import importlib.util
+import sys
+import types
+
+import torch
+
+if importlib.util.find_spec("safetensors") is None:
+    safetensors = types.ModuleType("safetensors")
+    safetensors.safe_open = None
+    safetensors_torch = types.ModuleType("safetensors.torch")
+    safetensors_torch.save_file = None
+    sys.modules["safetensors"] = safetensors
+    sys.modules["safetensors.torch"] = safetensors_torch
+
+from megatron.lite.primitive.ckpt import hf_weights
+from megatron.lite.primitive.ckpt.weight_sync_probe import (
+    get_weight_sync_probe,
+    weight_sync_probe_session,
+)
+
+
+def _report_from_stdout(stdout: str) -> dict:
+    line = next(
+        line
+        for line in stdout.splitlines()
+        if line.startswith("MLITE_WEIGHT_SYNC_PROBE ")
+    )
+    return json.loads(line.split(" ", 1)[1])
+
+
+def test_probe_is_silent_when_disabled(monkeypatch, capsys):
+    monkeypatch.delenv("MLITE_WEIGHT_SYNC_PROBE", raising=False)
+
+    with weight_sync_probe_session("mlite"):
+        with get_weight_sync_probe().measure("mapping") as sample:
+            sample.nbytes = 16
+
+    assert capsys.readouterr().out == ""
+
+
+def test_probe_reports_nested_stage_totals(monkeypatch, capsys):
+    monkeypatch.setenv("MLITE_WEIGHT_SYNC_PROBE", "1")
+
+    with weight_sync_probe_session("mlite"):
+        with get_weight_sync_probe().measure("fsdp_gather") as sample:
+            sample.nbytes = 32
+        with get_weight_sync_probe().measure("fsdp_gather") as sample:
+            sample.nbytes = 64
+
+    report = _report_from_stdout(capsys.readouterr().out)
+    assert report["backend"] == "mlite"
+    assert report["stages"]["fsdp_gather"]["calls"] == 2
+    assert report["stages"]["fsdp_gather"]["bytes"] == 96
+    assert report["stages"]["fsdp_gather"]["wall_s"] >= 0.0
+    assert report["total_wall_s"] >= report["stages"]["fsdp_gather"]["wall_s"]
+
+
+def test_cpu_staging_only_counts_device_to_host(monkeypatch, capsys):
+    monkeypatch.setenv("MLITE_WEIGHT_SYNC_PROBE", "true")
+    tensor = torch.arange(4, dtype=torch.float32)
+
+    with weight_sync_probe_session("mlite"):
+        result = hf_weights._to_cpu(tensor)
+
+    assert result is tensor
+    report = _report_from_stdout(capsys.readouterr().out)
+    assert "d2h" not in report["stages"]
+
+
+def test_mapping_counts_output_payload(monkeypatch, capsys):
+    monkeypatch.setenv("MLITE_WEIGHT_SYNC_PROBE", "1")
+    tensor = torch.ones(2, dtype=torch.bfloat16)
+
+    class Spec:
+        @staticmethod
+        def native_to_hf(name, value):
+            return [(f"hf.{name}", value), (f"hf.{name}.copy", value.clone())]
+
+    with weight_sync_probe_session("mlite"):
+        mapped = hf_weights._native_to_hf(Spec(), "weight", tensor)
+
+    assert [name for name, _ in mapped] == ["hf.weight", "hf.weight.copy"]
+    report = _report_from_stdout(capsys.readouterr().out)
+    assert report["stages"]["mapping"] == {
+        "calls": 1,
+        "bytes": 2 * tensor.nbytes,
+        "wall_s": report["stages"]["mapping"]["wall_s"],
+    }

--- a/experimental/lite/tests/unit/runtime/test_runtime_backend_unit.py
+++ b/experimental/lite/tests/unit/runtime/test_runtime_backend_unit.py
@@ -225,6 +225,90 @@ def test_runtime_to_prefers_optimizer_specific_offload_hooks():
     assert optimizer.calls == ["offload", "load"]
 
 
+def test_training_transfer_parks_optimizer_and_releases_scratch(monkeypatch):
+    events = []
+
+    class Chunk:
+        def release_export_scratch(self):
+            events.append("release-scratch")
+
+    class Optimizer:
+        def offload_state_to_cpu(self):
+            events.append("offload-optimizer")
+
+        def load_state_to_device(self):
+            events.append("load-optimizer")
+
+    import megatron.lite.runtime.megatron_utils as megatron_utils
+
+    monkeypatch.setattr(
+        megatron_utils,
+        "offload_model_to_cpu",
+        lambda chunks: events.append("offload-model"),
+    )
+    monkeypatch.setattr(
+        megatron_utils,
+        "load_model_to_gpu",
+        lambda chunks, load_grad: events.append("load-model"),
+    )
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "synchronize", lambda: events.append("synchronize"))
+    monkeypatch.setattr(
+        "megatron.lite.runtime.backends.mlite.runtime.gc.collect",
+        lambda: events.append("collect"),
+    )
+    monkeypatch.setattr(torch.cuda, "empty_cache", lambda: events.append("empty-cache"))
+    chunk = Chunk()
+    handle = ModelHandle(
+        model=chunk,
+        optimizer=Optimizer(),
+        _extras={"model_chunks": [chunk]},
+    )
+    runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
+
+    runtime.to(handle, "cpu", model=True, optimizer=False, grad=True)
+    runtime.to(handle, "cuda", model=True, optimizer=False, grad=True)
+
+    assert events == [
+        "offload-model",
+        "offload-optimizer",
+        "release-scratch",
+        "synchronize",
+        "collect",
+        "empty-cache",
+        "load-model",
+        "load-optimizer",
+    ]
+
+
+def test_export_transfer_does_not_move_optimizer_or_release_scratch(monkeypatch):
+    events = []
+
+    class Chunk:
+        def release_export_scratch(self):
+            events.append("release-scratch")
+
+    import megatron.lite.runtime.megatron_utils as megatron_utils
+
+    monkeypatch.setattr(
+        megatron_utils,
+        "offload_model_to_cpu",
+        lambda chunks: events.append("offload-model"),
+    )
+    chunk = Chunk()
+    handle = ModelHandle(
+        model=chunk,
+        optimizer=HookedOptimizer(),
+        _extras={"model_chunks": [chunk]},
+    )
+
+    MegatronLiteRuntime.__new__(MegatronLiteRuntime).to(
+        handle, "cpu", model=True, optimizer=False, grad=False
+    )
+
+    assert events == ["offload-model"]
+
+
 class _FakeStorage:
     def __init__(self, size: int):
         self._size = size
@@ -368,6 +452,29 @@ def test_native_model_move_helpers_do_not_require_megatron_core(monkeypatch):
     load_model_to_gpu([model])
 
     assert model.calls == ["cpu", "cuda"]
+
+
+def test_native_model_offload_reshards_fsdp2_before_cpu_move(monkeypatch):
+    import megatron.lite.runtime.megatron_utils as megatron_utils
+
+    model = _FakeNativeModel()
+    events = []
+
+    monkeypatch.setattr(
+        megatron_utils,
+        "_reshard_fsdp2_modules",
+        lambda model_chunk: events.append(("reshard", model_chunk)),
+    )
+    original_to = model.to
+
+    def tracked_to(device):
+        events.append(("to", device))
+        return original_to(device)
+
+    model.to = tracked_to
+    megatron_utils.offload_model_to_cpu([model])
+
+    assert events == [("reshard", model), ("to", "cpu")]
 
 
 def test_model_handle_dp_defaults():

--- a/experimental/lite/tests/unit/runtime/test_weight_contracts.py
+++ b/experimental/lite/tests/unit/runtime/test_weight_contracts.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 import pytest
 
 from megatron.lite.runtime.contracts.weights import ResyncFormat

--- a/experimental/lite/tests/unit/runtime/test_weight_contracts.py
+++ b/experimental/lite/tests/unit/runtime/test_weight_contracts.py
@@ -1,0 +1,17 @@
+import pytest
+
+from megatron.lite.runtime.contracts.weights import ResyncFormat
+
+
+@pytest.mark.parametrize(
+    "expected",
+    [ResyncFormat.BF16, ResyncFormat.BLOCK_FP8, ResyncFormat.MXFP4],
+)
+def test_resync_format_round_trip(expected: ResyncFormat) -> None:
+    assert ResyncFormat.parse(expected.value) is expected
+    assert ResyncFormat.parse(expected) is expected
+
+
+def test_resync_format_rejects_unknown_value() -> None:
+    with pytest.raises(ValueError, match="mxfp4"):
+        ResyncFormat.parse("fp4")

--- a/experimental/lite/tests/unit/verl/test_compat_dense_recreate.py
+++ b/experimental/lite/tests/unit/verl/test_compat_dense_recreate.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from contextlib import contextmanager
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+from verl_mlite import compat
+
+
+def _install_fake_reload_modules(monkeypatch, original):
+    fp8_utils = ModuleType("verl.utils.vllm.vllm_fp8_utils")
+    fp8_utils.prepare_quanted_weights_for_loading = original
+    dsv4_utils = ModuleType("verl.utils.vllm.vllm_dsv4_fp8_utils")
+    dsv4_utils.is_deepseek_v4_model = lambda model: True
+    vllm_config = ModuleType("vllm.config")
+    events = []
+
+    @contextmanager
+    def set_current_vllm_config(config):
+        events.append(("enter", config))
+        try:
+            yield
+        finally:
+            events.append(("exit", config))
+
+    vllm_config.set_current_vllm_config = set_current_vllm_config
+    monkeypatch.setitem(sys.modules, fp8_utils.__name__, fp8_utils)
+    monkeypatch.setitem(sys.modules, dsv4_utils.__name__, dsv4_utils)
+    monkeypatch.setitem(sys.modules, vllm_config.__name__, vllm_config)
+    monkeypatch.setattr(compat, "_vllm_importable", lambda: True)
+    return fp8_utils, events
+
+
+def test_dense_recreate_runs_under_model_runner_vllm_config(monkeypatch) -> None:
+    original_calls = []
+
+    def original(model_runner):
+        original_calls.append(("prepare", model_runner.model))
+        return "state"
+
+    fp8_utils, events = _install_fake_reload_modules(
+        monkeypatch, original
+    )
+    monkeypatch.setattr(
+        compat,
+        "_recreate_dense_fp8_linear_params",
+        lambda model: events.append(("recreate", model)) or 1,
+    )
+
+    assert compat._patch_verl_dsv4_prepare_recreates_dense()
+    runner = SimpleNamespace(model=object(), vllm_config=object())
+    assert fp8_utils.prepare_quanted_weights_for_loading(runner) == "state"
+    assert events == [
+        ("enter", runner.vllm_config),
+        ("recreate", runner.model),
+        ("exit", runner.vllm_config),
+    ]
+    assert original_calls == [("prepare", runner.model)]
+
+
+def test_dense_recreate_precedes_verl_online_loader_attachment(monkeypatch) -> None:
+    order = []
+
+    def original(model_runner):
+        order.append("attach-online-loaders")
+        return True
+
+    fp8_utils, _ = _install_fake_reload_modules(monkeypatch, original)
+    monkeypatch.setattr(
+        compat,
+        "_recreate_dense_fp8_linear_params",
+        lambda model: order.append("recreate") or 1,
+    )
+
+    assert compat._patch_verl_dsv4_prepare_recreates_dense()
+    runner = SimpleNamespace(model=object(), vllm_config=object())
+    assert fp8_utils.prepare_quanted_weights_for_loading(runner) is True
+    assert order == ["recreate", "attach-online-loaders"]
+
+
+def test_dense_recreate_failure_is_not_silently_ignored(monkeypatch) -> None:
+    fp8_utils, _ = _install_fake_reload_modules(monkeypatch, lambda model_runner: True)
+    monkeypatch.setattr(
+        compat,
+        "_recreate_dense_fp8_linear_params",
+        lambda model: (_ for _ in ()).throw(RuntimeError("recreate failed")),
+    )
+
+    assert compat._patch_verl_dsv4_prepare_recreates_dense()
+    runner = SimpleNamespace(model=object(), vllm_config=object())
+    with pytest.raises(RuntimeError, match="recreate failed"):
+        fp8_utils.prepare_quanted_weights_for_loading(runner)

--- a/experimental/lite/tests/unit/verl/test_compat_fp8_prepare_state.py
+++ b/experimental/lite/tests/unit/verl/test_compat_fp8_prepare_state.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import sys
+from types import ModuleType, SimpleNamespace
+
+from verl_mlite import compat
+
+
+def test_pure_fp8_ds4_prepare_state_is_promoted(monkeypatch) -> None:
+    fp8_utils = ModuleType("verl.utils.vllm.vllm_fp8_utils")
+    calls = []
+    fp8_utils.prepare_quanted_weights_for_loading = (
+        lambda model_runner: calls.append(model_runner) or False
+    )
+    dsv4_utils = ModuleType("verl.utils.vllm.vllm_dsv4_fp8_utils")
+    dsv4_utils.is_deepseek_v4_model = lambda model: True
+
+    routed_module = ModuleType(
+        "vllm.model_executor.layers.fused_moe.routed_experts"
+    )
+    fp8_module = ModuleType("vllm.model_executor.layers.quantization.fp8")
+
+    class RoutedExperts:
+        pass
+
+    class Fp8MoEMethod:
+        pass
+
+    routed_module.RoutedExperts = RoutedExperts
+    fp8_module.Fp8MoEMethod = Fp8MoEMethod
+    expert = RoutedExperts()
+    expert.quant_method = Fp8MoEMethod()
+    model = SimpleNamespace(modules=lambda: [expert])
+    runner = SimpleNamespace(model=model)
+
+    monkeypatch.setitem(sys.modules, fp8_utils.__name__, fp8_utils)
+    monkeypatch.setitem(sys.modules, dsv4_utils.__name__, dsv4_utils)
+    monkeypatch.setitem(sys.modules, routed_module.__name__, routed_module)
+    monkeypatch.setitem(sys.modules, fp8_module.__name__, fp8_module)
+    monkeypatch.setattr(compat, "_vllm_importable", lambda: True)
+
+    assert compat._patch_verl_dsv4_fp8_prepare_state()
+    assert fp8_utils.prepare_quanted_weights_for_loading(runner) is True
+    assert calls == [runner]
+
+
+def test_non_ds4_false_prepare_state_stays_false(monkeypatch) -> None:
+    fp8_utils = ModuleType("verl.utils.vllm.vllm_fp8_utils")
+    fp8_utils.prepare_quanted_weights_for_loading = lambda model_runner: False
+    dsv4_utils = ModuleType("verl.utils.vllm.vllm_dsv4_fp8_utils")
+    dsv4_utils.is_deepseek_v4_model = lambda model: False
+    routed_module = ModuleType(
+        "vllm.model_executor.layers.fused_moe.routed_experts"
+    )
+    fp8_module = ModuleType("vllm.model_executor.layers.quantization.fp8")
+    routed_module.RoutedExperts = type("RoutedExperts", (), {})
+    fp8_module.Fp8MoEMethod = type("Fp8MoEMethod", (), {})
+
+    monkeypatch.setitem(sys.modules, fp8_utils.__name__, fp8_utils)
+    monkeypatch.setitem(sys.modules, dsv4_utils.__name__, dsv4_utils)
+    monkeypatch.setitem(sys.modules, routed_module.__name__, routed_module)
+    monkeypatch.setitem(sys.modules, fp8_module.__name__, fp8_module)
+    monkeypatch.setattr(compat, "_vllm_importable", lambda: True)
+
+    assert compat._patch_verl_dsv4_fp8_prepare_state()
+    runner = SimpleNamespace(model=SimpleNamespace(modules=lambda: []))
+    assert fp8_utils.prepare_quanted_weights_for_loading(runner) is False

--- a/experimental/lite/tests/unit/verl/test_compat_native_layerwise_reload.py
+++ b/experimental/lite/tests/unit/verl/test_compat_native_layerwise_reload.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from contextlib import contextmanager
+import sys
+from types import ModuleType, SimpleNamespace
+
+import torch
+
+from verl_mlite import compat
+
+
+def test_ds4_uses_native_vllm_layerwise_reload(monkeypatch) -> None:
+    events = []
+    fp8_utils = ModuleType("verl.utils.vllm.vllm_fp8_utils")
+    fp8_utils.prepare_quanted_weights_for_loading = (
+        lambda runner: events.append("legacy-prepare") or False
+    )
+    fp8_utils.process_quanted_weights_after_loading = (
+        lambda runner, state: events.append(("legacy-process", state))
+    )
+    captured_weights = []
+    fp8_utils.load_quanted_weights = (
+        lambda weights, runner: captured_weights.extend(weights) or "loaded"
+    )
+    dsv4_utils = ModuleType("verl.utils.vllm.vllm_dsv4_fp8_utils")
+    dsv4_utils.is_deepseek_v4_model = lambda model: model.is_ds4
+    vllm_config = ModuleType("vllm.config")
+    reload_api = ModuleType("vllm.model_executor.model_loader.reload")
+    reload_meta = ModuleType("vllm.model_executor.model_loader.reload.meta")
+    rollout_utils = ModuleType("verl.workers.rollout.vllm_rollout.utils")
+    reload_meta.SKIP_TENSORS = {"existing"}
+
+    @contextmanager
+    def set_current_vllm_config(config):
+        events.append(("enter-config", config))
+        try:
+            yield
+        finally:
+            events.append(("exit-config", config))
+
+    vllm_config.set_current_vllm_config = set_current_vllm_config
+    reload_api.initialize_layerwise_reload = (
+        lambda model: events.append(("initialize", model))
+    )
+    reload_api.finalize_layerwise_processing = (
+        lambda model, config: events.append(("finalize", model, config))
+    )
+    rollout_utils.load_quanted_weights = fp8_utils.load_quanted_weights
+    for module in (
+        fp8_utils,
+        dsv4_utils,
+        vllm_config,
+        reload_api,
+        reload_meta,
+        rollout_utils,
+    ):
+        monkeypatch.setitem(sys.modules, module.__name__, module)
+    monkeypatch.setattr(compat, "_vllm_importable", lambda: True)
+    monkeypatch.setattr(
+        compat,
+        "_restore_dsv4_attn_sink_padding",
+        lambda model: events.append(("restore-attention", model)) or 4,
+    )
+    monkeypatch.setattr(
+        torch.cuda, "empty_cache", lambda: events.append("empty-device-cache")
+    )
+    model = SimpleNamespace(is_ds4=True)
+    config = SimpleNamespace(model_config=object())
+    runner = SimpleNamespace(model=model, vllm_config=config)
+    assert compat._patch_verl_dsv4_native_layerwise_reload()
+    state = fp8_utils.prepare_quanted_weights_for_loading(runner)
+    assert state is compat._DSV4_LAYERWISE_RELOAD_STATE
+    source = torch.arange(4)
+    assert rollout_utils.load_quanted_weights([("weight", source)], runner) == "loaded"
+    assert captured_weights[0][1].data_ptr() != source.data_ptr()
+    assert model._verl_mlite_ds4_layerwise_reload_active is True
+    fp8_utils.process_quanted_weights_after_loading(runner, state)
+    assert model._verl_mlite_ds4_layerwise_reload_active is False
+    assert "legacy-prepare" not in events
+    assert not any(isinstance(event, tuple) and event[0] == "legacy-process" for event in events)
+    assert events == [
+        ("enter-config", config),
+        ("initialize", model),
+        ("exit-config", config),
+        ("enter-config", config),
+        ("finalize", model, config.model_config),
+        ("exit-config", config),
+        ("restore-attention", model),
+        "empty-device-cache",
+    ]
+    assert reload_meta.SKIP_TENSORS == {
+        "existing",
+        "tid2eid",
+        "expert_bias",
+        "e_score_correction_bias",
+        "attn_sink",
+    }
+
+
+def test_non_ds4_keeps_verl_reload_path(monkeypatch) -> None:
+    events = []
+    fp8_utils = ModuleType("verl.utils.vllm.vllm_fp8_utils")
+    fp8_utils.prepare_quanted_weights_for_loading = lambda runner: "legacy-state"
+    fp8_utils.process_quanted_weights_after_loading = (
+        lambda runner, state: events.append(state)
+    )
+    fp8_utils.load_quanted_weights = lambda weights, runner: list(weights)
+    dsv4_utils = ModuleType("verl.utils.vllm.vllm_dsv4_fp8_utils")
+    dsv4_utils.is_deepseek_v4_model = lambda model: False
+    rollout_utils = ModuleType("verl.workers.rollout.vllm_rollout.utils")
+    rollout_utils.load_quanted_weights = fp8_utils.load_quanted_weights
+    monkeypatch.setitem(sys.modules, fp8_utils.__name__, fp8_utils)
+    monkeypatch.setitem(sys.modules, dsv4_utils.__name__, dsv4_utils)
+    monkeypatch.setitem(sys.modules, rollout_utils.__name__, rollout_utils)
+    monkeypatch.setattr(compat, "_vllm_importable", lambda: True)
+
+    runner = SimpleNamespace(model=object())
+    assert compat._patch_verl_dsv4_native_layerwise_reload()
+    state = fp8_utils.prepare_quanted_weights_for_loading(runner)
+    assert state == "legacy-state"
+    source = torch.arange(2)
+    loaded = rollout_utils.load_quanted_weights([("weight", source)], runner)
+    assert loaded[0][1] is source
+    fp8_utils.process_quanted_weights_after_loading(runner, state)
+    assert events == ["legacy-state"]

--- a/experimental/lite/tests/unit/verl/test_compat_post_reload_fixups.py
+++ b/experimental/lite/tests/unit/verl/test_compat_post_reload_fixups.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import sys
+from types import ModuleType, SimpleNamespace
+
+from verl_mlite import compat
+
+
+def test_post_reload_restores_attention_and_only_finalizes_moe(monkeypatch) -> None:
+    events = []
+
+    class Extension:
+        def __init__(self, model):
+            self.model_runner = SimpleNamespace(model=model)
+
+        def update_weights_from_ipc(self):
+            events.append("load")
+            return "loaded"
+
+    utils = ModuleType("verl.workers.rollout.vllm_rollout.utils")
+    utils.vLLMColocateWorkerExtension = Extension
+    dsv4_utils = ModuleType("verl.utils.vllm.vllm_dsv4_fp8_utils")
+    dsv4_utils.is_deepseek_v4_model = lambda model: True
+    routed_experts = ModuleType(
+        "vllm.model_executor.layers.fused_moe.routed_experts"
+    )
+    fp8 = ModuleType("vllm.model_executor.layers.quantization.fp8")
+
+    class RoutedExperts:
+        pass
+
+    class Fp8MoEMethod:
+        def process_weights_after_loading(self, module):
+            events.append("finalize-moe")
+
+    routed_experts.RoutedExperts = RoutedExperts
+    fp8.Fp8MoEMethod = Fp8MoEMethod
+    monkeypatch.setitem(sys.modules, utils.__name__, utils)
+    monkeypatch.setitem(sys.modules, dsv4_utils.__name__, dsv4_utils)
+    monkeypatch.setitem(sys.modules, routed_experts.__name__, routed_experts)
+    monkeypatch.setitem(sys.modules, fp8.__name__, fp8)
+    monkeypatch.setattr(compat, "_vllm_importable", lambda: True)
+    monkeypatch.setattr(
+        compat,
+        "_restore_dsv4_attn_sink_padding",
+        lambda model: events.append("restore-attention") or 4,
+    )
+
+    class DenseQuantMethod:
+        def process_weights_after_loading(self, module):
+            raise AssertionError("online reload must not re-finalize dense FP8")
+
+    moe = RoutedExperts()
+    moe.quant_method = Fp8MoEMethod()
+    dense = SimpleNamespace(quant_method=DenseQuantMethod())
+    model = SimpleNamespace(
+        modules=lambda: iter((moe, dense)),
+    )
+    assert compat._patch_verl_dsv4_fp8_process_weights()
+    assert Extension(model).update_weights_from_ipc() == "loaded"
+    assert events == ["load", "restore-attention", "finalize-moe"]

--- a/experimental/lite/tests/unit/verl/test_mlite_engine_checkpoint.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_engine_checkpoint.py
@@ -185,3 +185,75 @@ def test_load_checkpoint_restores_scheduler_and_param_offload_reload(tmp_path, m
     assert load_kwargs["is_expert"] is expert_classifier
     assert load_kwargs["load_model"] is True
     assert load_kwargs["load_optimizer"] is True
+
+
+def test_hf_model_save_fails_loudly_when_protocol_has_no_export(tmp_path):
+    engine, *_ = _initialized_engine(checkpoint_config={"save_contents": ["hf_model"]})
+    engine.handle._model = engine.module
+    engine.handle._extras["protocol"] = SimpleNamespace()
+
+    with pytest.raises(RuntimeError, match="does not expose save_hf_weights"):
+        engine.save_checkpoint(str(tmp_path), global_step=1)
+
+
+def test_hf_model_save_fails_loudly_when_model_config_is_missing(tmp_path):
+    engine, *_ = _initialized_engine(checkpoint_config={"save_contents": ["hf_model"]})
+    engine.handle._model = engine.module
+    calls = []
+    engine.handle._extras["protocol"] = SimpleNamespace(
+        save_hf_weights=lambda *args: calls.append(args)
+    )
+
+    with pytest.raises(RuntimeError, match="no model_cfg"):
+        engine.save_checkpoint(str(tmp_path), global_step=1)
+    assert calls == []
+
+
+def test_hf_model_only_save_uses_protocol_and_writes_hf_metadata(tmp_path, monkeypatch):
+    engine, module, *_ = _initialized_engine(
+        checkpoint_config={"save_contents": ["hf_model"]}
+    )
+    model_cfg = object()
+    chunks = [module, object()]
+    export_calls = []
+    metadata_calls = []
+
+    class Artifact:
+        def __init__(self, name):
+            self.name = name
+
+        def save_pretrained(self, path):
+            metadata_calls.append((self.name, path))
+
+    hf_config = Artifact("config")
+    hf_config.auto_map = {None: "invalid", "AutoModel": "modeling.Model"}
+    engine.model_config.hf_config = hf_config
+    engine.model_config.tokenizer = Artifact("tokenizer")
+    engine.model_config.processor = Artifact("processor")
+    engine.handle._model = module
+    engine.handle._extras.update(
+        {
+            "model_cfg": model_cfg,
+            "model_chunks": chunks,
+            "protocol": SimpleNamespace(
+                save_hf_weights=lambda *args: export_calls.append(args)
+            ),
+        }
+    )
+    monkeypatch.setattr(
+        "verl_mlite.engine.mlite_engine.save_training_checkpoint",
+        lambda *args, **kwargs: pytest.fail(
+            "hf_model-only save wrote a native checkpoint"
+        ),
+    )
+
+    engine.save_checkpoint(str(tmp_path), global_step=1)
+
+    hf_path = str(tmp_path / "huggingface")
+    assert export_calls == [(chunks, hf_path, model_cfg, engine.handle._parallel_state)]
+    assert metadata_calls == [
+        ("config", hf_path),
+        ("tokenizer", hf_path),
+        ("processor", hf_path),
+    ]
+    assert hf_config.auto_map == {"AutoModel": "modeling.Model"}

--- a/experimental/lite/tests/unit/verl/test_mlite_engine_config.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_engine_config.py
@@ -138,6 +138,37 @@ def test_mlite_config_threads_rl_parallel_and_impl_settings() -> None:
     assert config.impl_cfg["deterministic"] is False
 
 
+def test_online_weight_export_requests_gpu_resident_bounded_streaming() -> None:
+    engine = _engine(engine_config=_engine_config(export_dtype="bfloat16"))
+    captured = {}
+
+    class Runtime:
+        @staticmethod
+        def export_weights(handle, **kwargs):
+            captured["handle"] = handle
+            captured["kwargs"] = kwargs
+            return iter(())
+
+    engine.runtime = Runtime()
+    engine.handle = object()
+    engine._initial_sync_cache_cleared = True
+
+    weights, metadata = engine.get_per_tensor_param(limit=3)
+
+    assert list(weights) == []
+    assert metadata is None
+    assert captured == {
+        "handle": engine.handle,
+        "kwargs": {
+            "buffer_max_size_bytes": 2 * 1024**3,
+            "cpu": False,
+            "export_dtype": "bfloat16",
+            "limit": 3,
+            "target": "vllm",
+        },
+    }
+
+
 def test_local_lr_scheduler_warmup_decay_and_state_roundtrip() -> None:
     optimizer = SimpleNamespace(param_groups=[{"lr": 0.0, "weight_decay": 0.1}])
     opt = SimpleNamespace(

--- a/experimental/lite/tests/unit/verl/test_mlite_engine_loss_mask_packing.py
+++ b/experimental/lite/tests/unit/verl/test_mlite_engine_loss_mask_packing.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Regression coverage for THD loss-mask packing in the MLite VERL engine.
+
+VERL hands the actor-update batch a *response-only* ``loss_mask`` /
+``response_mask`` nested tensor (shape ``[bsz, response_len]``), while
+``input_ids`` is the full ``[prompt; response]`` packed sequence. The engine
+must expand that mask to the full sequence length before the model protocol
+packs it against the ``input_ids`` seq_lens. Returning the response-only mask
+unchanged left ``loss_mask`` shorter than the declared seq_lens and crashed the
+update step inside ``_nested_from_packed_tensor``::
+
+    torch.narrow(0, offset, 206): start + length exceeds dimension size (128)
+
+These tests exercise the pure ``_loss_mask_for_packing`` static logic end-to-end
+with ``_nested_from_packed_tensor``; no GPU, model init, or torch.distributed.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from tensordict import TensorDict
+
+from verl_mlite.engine.mlite_engine import MegatronLiteEngine
+from megatron.lite.model.deepseek_v4.lite.protocol import _nested_from_packed_tensor
+
+pytestmark = pytest.mark.mlite
+
+
+def _full_input_ids(full_lengths: list[int]) -> torch.Tensor:
+    return torch.nested.as_nested_tensor(
+        [torch.arange(length) for length in full_lengths], layout=torch.jagged
+    )
+
+
+def _response_mask_row(response_len: int) -> torch.Tensor:
+    # Include an internal zero to model a masked span (e.g. tool output); the
+    # whole valid response span must be preserved, not collapsed to its sum.
+    row = torch.ones(response_len, dtype=torch.float32)
+    if response_len > 4:
+        row[3] = 0.0
+    return row
+
+
+def _assert_packs_to_full(packed_mask, input_ids, full_lengths, response_lengths):
+    seq_lens = input_ids.offsets().diff().to(torch.int64)
+    # Must be full-length: sum of response lengths alone would be too short.
+    assert int(packed_mask.values().numel()) == sum(full_lengths)
+    # Packing against the full seq_lens must not overflow (the original crash).
+    nested = _nested_from_packed_tensor(packed_mask.values().contiguous(), seq_lens)
+    rows = nested.unbind(0)
+    for i, (total, resp) in enumerate(zip(full_lengths, response_lengths, strict=True)):
+        prompt_len = total - resp
+        # Prompt positions are masked out (zeros); response span is kept intact.
+        assert torch.count_nonzero(rows[i][:prompt_len]) == 0
+        assert rows[i][prompt_len:].numel() == resp
+
+
+def test_nested_response_only_loss_mask_expands_to_full_length():
+    """The production crash case: response-only nested mask + full input_ids."""
+    full_lengths = [206, 130, 40]
+    response_lengths = [78, 30, 20]  # sum 128 < a single full length (206)
+    input_ids = _full_input_ids(full_lengths)
+    loss_mask = torch.nested.as_nested_tensor(
+        [_response_mask_row(r) for r in response_lengths], layout=torch.jagged
+    )
+    micro_batch = TensorDict(
+        {"input_ids": input_ids, "loss_mask": loss_mask}, batch_size=[len(full_lengths)]
+    )
+
+    packed = MegatronLiteEngine._loss_mask_for_packing(micro_batch, input_ids)
+    _assert_packs_to_full(packed, input_ids, full_lengths, response_lengths)
+
+
+def test_full_length_nested_loss_mask_is_unchanged():
+    """A response covering the whole sequence (prompt_len == 0) still round-trips."""
+    full_lengths = [100, 100]
+    response_lengths = [100, 100]
+    input_ids = _full_input_ids(full_lengths)
+    loss_mask = torch.nested.as_nested_tensor(
+        [torch.ones(r, dtype=torch.float32) for r in response_lengths], layout=torch.jagged
+    )
+    micro_batch = TensorDict(
+        {"input_ids": input_ids, "loss_mask": loss_mask}, batch_size=[len(full_lengths)]
+    )
+
+    packed = MegatronLiteEngine._loss_mask_for_packing(micro_batch, input_ids)
+    _assert_packs_to_full(packed, input_ids, full_lengths, response_lengths)
+
+
+def test_dense_response_loss_mask_expands_to_full_length():
+    """The dense (V0 left_right_2_no_padding) path stays full-length too."""
+    full_lengths = [206, 130, 40]
+    response_lengths = [78, 30, 20]
+    input_ids = _full_input_ids(full_lengths)
+    max_response = max(response_lengths)
+    dense = torch.zeros(len(response_lengths), max_response, dtype=torch.float32)
+    for i, r in enumerate(response_lengths):
+        dense[i, :r] = torch.ones(r, dtype=torch.float32)
+    micro_batch = TensorDict(
+        {"input_ids": input_ids, "loss_mask": dense}, batch_size=[len(full_lengths)]
+    )
+
+    packed = MegatronLiteEngine._loss_mask_for_packing(micro_batch, input_ids)
+    seq_lens = input_ids.offsets().diff().to(torch.int64)
+    assert int(packed.values().numel()) == sum(full_lengths)
+    # Must not overflow when packed against the full seq_lens.
+    _nested_from_packed_tensor(packed.values().contiguous(), seq_lens)
+
+
+def test_response_longer_than_input_is_rejected():
+    """A response mask longer than its input sequence is a hard error, not silent."""
+    full_lengths = [40]
+    input_ids = _full_input_ids(full_lengths)
+    loss_mask = torch.nested.as_nested_tensor(
+        [torch.ones(64, dtype=torch.float32)], layout=torch.jagged
+    )
+    micro_batch = TensorDict(
+        {"input_ids": input_ids, "loss_mask": loss_mask}, batch_size=[1]
+    )
+    with pytest.raises(ValueError, match="tokens but packed input"):
+        MegatronLiteEngine._loss_mask_for_packing(micro_batch, input_ids)


### PR DESCRIPTION
## What does this PR do?

This PR synchronizes the remaining Megatron-Lite changes required for end-to-end DeepSeek-V4-Flash RL from `ISEEKYAN/Megatron-LM:main` onto the latest `NVIDIA/Megatron-LM:dev`. The diff is scoped strictly to `experimental/lite` and does not replace or delete non-Lite NVIDIA code.

The main additions are:

- a maintained veRL/DAPO launcher using native `RLHFDataset`
- THD-aware sequence packing across pipeline/context parallel execution
- fused DSA/CSA paths and DS4 MTP/label correctness fixes
- actor-to-vLLM resync with W4 MXFP4 and W8 block-FP8 contracts
- native layer-wise vLLM reload, alignment fixes, and sender/receiver fingerprints
- optional router routing replay (R3), including PP-safe router-buffer gathering
- FSDP2 PP+EDP reshard/offload/prefetch correctness and memory fixes
- streaming HF/checkpoint export to keep peak host/GPU memory bounded

Parallel-history conflicts under `experimental/lite` were resolved in favor of the current Lite implementation while retaining NVIDIA-only content such as existing copyright headers.

## Related implementation PRs

Stable patch-id comparison against NVIDIA `dev` identifies these eight fork PRs as the remaining, non-equivalent changes:

- [#85 — GPU-bounded streaming HF export](https://github.com/ISEEKYAN/Megatron-LM/pull/85)
- [#101 — DeepSeek V4 compressed sparse attention under context parallelism](https://github.com/ISEEKYAN/Megatron-LM/pull/101)
- [#102 — streaming pipeline-parallel export](https://github.com/ISEEKYAN/Megatron-LM/pull/102)
- [#107 — GDN headwise context parallelism](https://github.com/ISEEKYAN/Megatron-LM/pull/107)
- [#111 — GDN chunkwise THD context parallelism](https://github.com/ISEEKYAN/Megatron-LM/pull/111)
- [#109 — DS4 GRPO, quantized resync, R3, and veRL integration](https://github.com/ISEEKYAN/Megatron-LM/pull/109) ([verl-project #11](https://github.com/verl-project/Megatron-LM/pull/11))
- [#116 — native veRL RLHFDataset integration](https://github.com/ISEEKYAN/Megatron-LM/pull/116) ([verl-project #12](https://github.com/verl-project/Megatron-LM/pull/12))
- [#117 — propagate the DS4 chat template into native dataset filtering](https://github.com/ISEEKYAN/Megatron-LM/pull/117) ([verl-project #13](https://github.com/verl-project/Megatron-LM/pull/13))

Fork PR #84 is intentionally excluded: its stable patch-id exactly matches NVIDIA PR #5694. Earlier foundation changes are already present in NVIDIA `dev` through PR #5577, and the label-shifting fix is already present through NVIDIA PR #5682.

## Acknowledgements

Special thanks to [@shyoshyo](https://github.com/shyoshyo) from ByteDance for testing the DeepSeek V4 Megatron-Lite integration and contributing several of the fixes included in this work.

## DS4 RL validation

- 8-GPU fresh W4 + R3 runs completed two steps with rollout-correction KL `0.06099` / `0.06860` and PPO KL `0.00256` / `0.00340`.
- 128-GPU W4/W8 resync diagnostics matched sender/receiver fingerprints across 67,612 tensors.
- A fresh 128-GPU W4 + R3 five-step run completed step 1 with rollout-correction KL `0.09505`, K3 KL `0.09279`, PPO KL `5.74e-05`, and peak allocated/reserved GPU memory of `22.88/29.99 GiB`; the remaining steps were still running when this description was prepared.
- The 128-GPU run matched all 67,612 actor/vLLM streamed tensors and exercised R3 during actor forward/backward.

## Tests

```text
bash -n experimental/lite/examples/verl/scripts/run_deepseek_v4_dapo.sh
python experimental/lite/examples/verl/scripts/validate_deepseek_v4_dapo.py --help
python -m pytest -q \
  experimental/lite/tests/unit/examples/test_ds4_dapo_script.py \
  experimental/lite/tests/unit/model/test_deepseek_v4_resync.py \
  experimental/lite/tests/unit/primitive/test_block_fp8_roundtrip.py \
  experimental/lite/tests/unit/primitive/test_weight_sync_fingerprint.py \
  experimental/lite/tests/unit/runtime/test_weight_contracts.py
```

Result: `17 passed`.

## DCO

Both commits carry a matching author and `Signed-off-by: Yan Bai <bayan@nvidia.com>` trailer.