### PR TITLE
Fix blend weight validation consuming a shared iterator

### DIFF
--- a/megatron/core/datasets/utils.py
+++ b/megatron/core/datasets/utils.py
@@ -81,7 +81,7 @@ def get_blend_from_list(
                 weight = None
             weight_per_dataset.append(weight)
 
-        is_none = map(lambda _: _ is None, weight_per_dataset)
+        is_none = [weight is None for weight in weight_per_dataset]
         if any(is_none):
             assert all(is_none)
             weight_per_dataset = None

--- a/tests/unit_tests/data/test_builder.py
+++ b/tests/unit_tests/data/test_builder.py
@@ -42,6 +42,25 @@ for split in Split:
 _MARGIN = 0.005
 
 
+def test_get_blend_from_list():
+    # Odd-length list is a plain list of prefixes.
+    assert get_blend_from_list(["p0", "p1", "p2"]) == (["p0", "p1", "p2"], None)
+
+    # Even-length list of numeric weight/prefix pairs.
+    assert get_blend_from_list(["30", "p0", "70", "p1"]) == (["p0", "p1"], [30.0, 70.0])
+
+    # Even-length list where no token parses as a weight is a plain list of prefixes.
+    assert get_blend_from_list(["p0", "p1", "p2", "p3"]) == (["p0", "p1", "p2", "p3"], None)
+
+    # A malformed blend that mixes a numeric weight with a non-numeric one must be
+    # rejected, regardless of the position of the non-numeric token. Previously the
+    # check consumed a shared `map` iterator across any()/all(), so a non-numeric
+    # weight in a non-leading position silently slipped through.
+    for bad in (["x", "p0", "2.0", "p1"], ["1.0", "p0", "x", "p1"]):
+        with pytest.raises(AssertionError):
+            get_blend_from_list(bad)
+
+
 def create_file_prefixes(tokenizer, number_of_files, maximum_number_of_documents, dataset_dir):
     # Create dataset directory
     os.makedirs(dataset_dir, exist_ok=True)


### PR DESCRIPTION
get_blend_from_list built a single lazy `map` iterator and passed it to both any() and all(). Because any() short-circuits at the first truthy element, the subsequent all() only saw the remaining, unconsumed items. This made the "weights must all parse or none parse" check order dependent: a non-numeric weight in a non-leading position (e.g. ["1.0", "p0", "x", "p1"]) silently slipped through and the whole list was misread as a plain list of dataset prefixes instead of raising.

Materialize the booleans into a list so any() and all() both evaluate the full set. Add a unit test covering both orderings and the valid cases.


# What does this PR do?
<!-- Add a one line overview of what this PR aims to accomplish. -->

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.



