### PR TITLE
Refit: local plan building, node-add cache key, and NIXL backend

### DIFF
--- a/megatron/core/resharding/README.md
+++ b/megatron/core/resharding/README.md
@@ -80,7 +80,7 @@ swap_model_weights(None, None, "nccl",
 | `nccl` | GPU P2P via `batch_isend_irecv` | Intra-node / single cluster | Lowest latency; default choice |
 | `gloo` | CPU-staged via Gloo PG | Cross-cluster / multi-node | Higher latency; works where NCCL cross-cluster doesn't |
 | `nvshmem` | Pipelined NVSHMEM puts | High-throughput intra-node | Requires NVSHMEM; uses double-buffered kernel pipeline |
-| `nixl` | GPU RDMA via NIXL (UCX), receiver-initiated READ | Cross-cluster / non-collocated | Requires NIXL; transfers GPU memory directly (no host staging) |
+| `nixl` | GPU RDMA via NIXL (UCX), sender-initiated WRITE | Cross-cluster / non-collocated | Requires NIXL; transfers GPU memory directly (no host staging) |
 
 All backends detect same-rank (local) transfers via `task_id` and
 short-circuit them into direct `tensor.copy_()` instead of going
@@ -104,9 +104,10 @@ through the network stack.
 4. Each rank keeps only the ops where it is the sender or receiver.
 5. The plan is cached so repeated refits skip steps 1-4.
 
-Because planning is local and deterministic, the destination pool can **grow**
-(nodes added): all ranks re-gather over the new world and replay, and `task_id`s
-stay consistent as long as every rank agrees on `world_size` and iteration order.
+The deterministic schedule stays stable when a larger roster is supplied: existing
+transfers keep their `task_id`s and newly appended destination ranks receive new
+ones. Live process-group membership changes and their orchestration remain future
+work; this module does not currently add or remove ranks from a running group.
 
 ## MXFP8 Transform
 
@@ -156,11 +157,12 @@ attribute with the following groups:
 | File | Role |
 |------|------|
 | `refit.py` | Public API, caching, MXFP8 auto-detection |
-| `planner.py` | Centralized plan builder (metadata, LCM/block-interleaved planners) |
+| `planner.py` | Local deterministic plan builder (metadata, LCM/block-interleaved planners) |
 | `execution.py` | Plan executor (send/recv submission, writeback, format conversion) |
 | `transforms.py` | `ReshardTransform` base class, `MXFP8ReshardTransform` |
 | `utils.py` | `TransferOp`, `ReshardPlan`, `ParameterMetadata`, `ShardingDescriptor` |
 | `copy_services/nccl_copy_service.py` | NCCL backend |
 | `copy_services/gloo_copy_service.py` | Gloo backend |
+| `copy_services/nixl_copy_service.py` | NIXL/UCX backend |
 | `copy_services/nvshmem_copy_service.py` | NVSHMEM backend (delegates to `nvshmem_copy_service/`) |
 | `nvshmem_copy_service/` | Full NVSHMEM implementation (planning, memory, kernels, pipeline) |

--- a/megatron/core/resharding/README.md
+++ b/megatron/core/resharding/README.md
@@ -10,7 +10,8 @@ inference model that may use a different parallelism layout.
 ```
 refit.py            High-level API: swap_model_weights, caching, MXFP8 auto-detection
     |
-planner.py          Centralized plan builder (rank 0 builds, scatters to all)
+planner.py          Local plan builder (every rank all-gathers metadata, replays
+                    the same deterministic schedule, keeps only its own ops)
     |
 execution.py        Submits send/recv ops to a CopyService, handles writebacks
     |
@@ -79,6 +80,7 @@ swap_model_weights(None, None, "nccl",
 | `nccl` | GPU P2P via `batch_isend_irecv` | Intra-node / single cluster | Lowest latency; default choice |
 | `gloo` | CPU-staged via Gloo PG | Cross-cluster / multi-node | Higher latency; works where NCCL cross-cluster doesn't |
 | `nvshmem` | Pipelined NVSHMEM puts | High-throughput intra-node | Requires NVSHMEM; uses double-buffered kernel pipeline |
+| `nixl` | GPU RDMA via NIXL (UCX), receiver-initiated READ | Cross-cluster / non-collocated | Requires NIXL; transfers GPU memory directly (no host staging) |
 
 All backends detect same-rank (local) transfers via `task_id` and
 short-circuit them into direct `tensor.copy_()` instead of going
@@ -87,14 +89,24 @@ through the network stack.
 ## How the Reshard Plan Works
 
 1. Each rank extracts parameter metadata (shape, sharding, TP/EP/PP groups).
-2. Metadata is gathered to rank 0 via `dist.gather_object()`.
-3. Rank 0 builds a complete transfer schedule:
-   - For each destination param, finds the matching source param(s) by name.
-   - Routes to a dimension-specific planner (LCM tiling for standard TP,
+2. Metadata is all-gathered so **every** rank has the full picture
+   (`dist.all_gather_object()`) — no rank-0 bottleneck, no scatter.
+3. Every rank independently replays the **same deterministic schedule**
+   (`_iter_global_transfer_ops`):
+   - Iterate destination ranks, then each rank's destination params in gathered
+     order; for each destination param, find the matching source param(s) by name.
+   - Route to a dimension-specific planner (LCM tiling for standard TP,
      block-interleaved for partitioned params like Mamba `in_proj`).
-   - Produces `TransferOp` pairs with globally unique `task_id` values.
-4. Plans are scattered back; each rank receives only its own send/recv ops.
+   - Assign a monotonic `task_id` per sub-op.  Because the iteration order and
+     counter are a pure function of the gathered metadata, the send op computed
+     on the sender and the recv op computed on the receiver get the **same**
+     `task_id` without any central authority.
+4. Each rank keeps only the ops where it is the sender or receiver.
 5. The plan is cached so repeated refits skip steps 1-4.
+
+Because planning is local and deterministic, the destination pool can **grow**
+(nodes added): all ranks re-gather over the new world and replay, and `task_id`s
+stay consistent as long as every rank agrees on `world_size` and iteration order.
 
 ## MXFP8 Transform
 

--- a/megatron/core/resharding/__init__.py
+++ b/megatron/core/resharding/__init__.py
@@ -1,6 +1,11 @@
 # Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
 from .execution import execute_reshard_plan
-from .planner import build_local_reshard_plan, build_plan_from_rosters, index_metadata_rosters
+from .planner import (
+    build_centralized_reshard_plan,
+    build_local_reshard_plan,
+    build_plan_from_rosters,
+    index_metadata_rosters,
+)
 from .refit import (
     clear_service_cache,
     get_or_create_service,
@@ -11,6 +16,7 @@ from .transforms import MXFP8ReshardTransform, ReshardTransform
 from .utils import ParameterMetadata, ReshardPlan, ShardingDescriptor, TransferOp
 
 __all__ = [
+    "build_centralized_reshard_plan",
     "build_local_reshard_plan",
     "build_plan_from_rosters",
     "index_metadata_rosters",

--- a/megatron/core/resharding/__init__.py
+++ b/megatron/core/resharding/__init__.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
 from .execution import execute_reshard_plan
-from .planner import build_centralized_reshard_plan
+from .planner import build_local_reshard_plan, build_plan_from_rosters, index_metadata_rosters
 from .refit import (
     clear_service_cache,
     get_or_create_service,
@@ -11,7 +11,9 @@ from .transforms import MXFP8ReshardTransform, ReshardTransform
 from .utils import ParameterMetadata, ReshardPlan, ShardingDescriptor, TransferOp
 
 __all__ = [
-    "build_centralized_reshard_plan",
+    "build_local_reshard_plan",
+    "build_plan_from_rosters",
+    "index_metadata_rosters",
     "execute_reshard_plan",
     "MXFP8ReshardTransform",
     "ReshardTransform",

--- a/megatron/core/resharding/copy_services/__init__.py
+++ b/megatron/core/resharding/copy_services/__init__.py
@@ -4,6 +4,13 @@ from __future__ import annotations
 from .base import CopyService
 from .gloo_copy_service import GlooCopyService
 from .nccl_copy_service import NCCLCopyService
+from .nixl_copy_service import NixlCopyService
 from .nvshmem_copy_service import NVSHMEMCopyService
 
-__all__ = ["CopyService", "GlooCopyService", "NCCLCopyService", "NVSHMEMCopyService"]
+__all__ = [
+    "CopyService",
+    "GlooCopyService",
+    "NCCLCopyService",
+    "NixlCopyService",
+    "NVSHMEMCopyService",
+]

--- a/megatron/core/resharding/copy_services/base.py
+++ b/megatron/core/resharding/copy_services/base.py
@@ -37,6 +37,11 @@ class CopyService(ABC):
     remote transfers simply ignore it.
     """
 
+    # Most torch.distributed backends retain the executor's historical
+    # process-group rendezvous after run(). Backends whose run() protocol already
+    # establishes completion across every participating peer can opt out.
+    requires_process_group_barrier = True
+
     def __init__(self, group=None):
         self.group = group
         # group.rank()/size() supports cross-cluster ProcessGroups where members

--- a/megatron/core/resharding/copy_services/nixl_copy_service.py
+++ b/megatron/core/resharding/copy_services/nixl_copy_service.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 from __future__ import annotations
 
 import logging
@@ -44,22 +44,21 @@ class NixlCopyService(CopyService):
 
     Each rank runs a NIXL agent. To WRITE into a peer it needs that peer's agent
     metadata (connection info) plus a {task_id: (addr, len, dev)} map of the peer's
-    registered recv buffers. This peer table is built once and cached, either by a
-    torch all-gather handshake (the only collective) or — so membership can grow
-    without one — by update_membership installing an orchestrator-relayed roster
-    (see local_roster_entry). Buffers are registered locally, not exchanged.
+    registered recv buffers. A one-time torch all-gather builds and caches this
+    peer table. Buffers are registered locally, not exchanged.
 
     Every refit after that is pure NIXL and sender-driven: a receiver signals each
     source that its buffers are free ("ready"); the source waits, syncs its weights,
     and issues one WRITE per receiver, each carrying a "data" notification. Those two
     notifications order producer and consumer per refit, so there's no barrier and no
-    per-refit collective. Notifications are tagged with the membership epoch and a
-    per-refit sequence, so stale ones are ignored. Same-rank transfers skip NIXL and
-    copy directly.
+    per-refit collective. Notifications are tagged with a per-refit sequence, so stale
+    ones are ignored. Same-rank transfers skip NIXL and copy directly.
 
     Registered buffers are assumed address-stable across refits; if a recv address
     changes after setup, call clear_service_cache() to rebuild.
     """
+
+    requires_process_group_barrier = False
 
     def __init__(self, group=None, agent_name: Optional[str] = None):
         super().__init__(group=group)
@@ -68,7 +67,7 @@ class NixlCopyService(CopyService):
         self.group = group
 
         try:
-            from nixl._api import nixl_agent, nixl_agent_config
+            from nixl._api import nixl_agent, nixl_agent_config  # type: ignore[import-not-found]
         except ImportError as e:
             raise ImportError(
                 "NixlCopyService requires the 'nixl' package; install it or use "
@@ -80,6 +79,8 @@ class NixlCopyService(CopyService):
         # Name by group rank, which is unique across the (possibly cross-world)
         # group. dist.get_rank() would collide: separate worlds each have a rank 0.
         self.agent_name = agent_name or f"refit-nixl-rank-{self.rank}"
+        # This backend is intentionally UCX-only: refit moves CPU/CUDA tensors
+        # directly between ranks and does not use NIXL's storage-oriented plugins.
         self.agent = nixl_agent(self.agent_name, nixl_agent_config(backends=["UCX"]))
 
         self.send_ops: List[SendOp] = []
@@ -87,20 +88,17 @@ class NixlCopyService(CopyService):
         self._copy_stream = torch.cuda.Stream()
 
         # Peer table {group rank -> (agent_name, agent_metadata, recv_descs)},
-        # populated by the first run's handshake or by update_membership. A dict,
-        # not a list, so the rank set can grow when nodes are added.
+        # populated by the first run's handshake.
         self._remote_agent_names: Dict[int, str] = {}  # group rank -> agent name
         self._gathered: Optional[Dict[int, tuple]] = None
         self._recv_descs: Optional[Dict[int, _MemDesc]] = None
         # RDMA registrations, kept across refits; send and recv tracked separately
         # so a changing side doesn't re-pin the other.
         self._reg: Dict[str, tuple] = {}  # 'send'/'recv' -> (handle, signature)
-        # Notifications are tagged (kind, epoch, seq): epoch bumps on a membership
-        # change so stale notifs from the old roster are ignored; seq is the
-        # per-refit counter. _future_notifs buffers tags we're not draining yet.
-        self._epoch = 0
+        # Notifications are tagged (kind, seq). _future_notifs buffers tags for
+        # later refits that we're not draining yet.
         self._seq = 0
-        self._future_notifs: Dict[Tuple[str, int, int], int] = {}
+        self._future_notifs: Dict[Tuple[str, int], int] = {}
 
     def submit_send(self, src_tensor: torch.Tensor, dest_rank: int, task_id: Optional[int] = None):
         self.send_ops.append(SendOp(task_id=task_id, tensor=src_tensor, dest_rank=dest_rank))
@@ -128,51 +126,16 @@ class NixlCopyService(CopyService):
 
     def _handshake(self, recv_descs: Dict[int, _MemDesc]) -> None:
         # Initial bootstrap over the torch group: share agent metadata and recv
-        # descriptors, connect to every peer, cache the peer table. This is the
-        # one torch collective; update_membership grows the table without it.
+        # descriptors, connect to every peer, and cache the peer table. This is
+        # NIXL's one torch collective.
         payload = (self.agent_name, self.agent.get_agent_metadata(), recv_descs)
         gathered: List[Optional[tuple]] = [None] * self.world_size
         dist.all_gather_object(gathered, payload, group=self.group)
-        roster = {rank: entry for rank, entry in enumerate(gathered) if entry is not None}
-        self.update_membership(roster, epoch=0)
-
-    def local_roster_entry(self, recv_items) -> tuple:
-        """Register this rank's recv buffers and return its roster entry
-        (agent_name, agent_metadata, recv_descs) for the orchestrator to
-        distribute. ``recv_items`` is an iterable of (task_id, tensor).
-
-        Registration must happen before the metadata is read: a peer can only
-        WRITE into these buffers if the metadata it holds already covers them.
-        """
-        items = list(recv_items)
-        self._register("recv", [t for _, t in items])
-        descs = {task_id: self._mem_desc(t) for task_id, t in items}
-        return (self.agent_name, self.agent.get_agent_metadata(), descs)
-
-    def update_membership(self, roster: Dict[int, tuple], epoch: int) -> None:
-        """Install a peer roster without a torch collective.
-
-        ``roster`` maps group rank -> (agent_name, agent_metadata, recv_descs) and
-        must include this rank. The orchestrator assembles it (relaying each node's
-        agent metadata and recv descriptors) when a node is added, and every rank
-        calls this at a refit boundary; a joining node uses it in place of the
-        initial handshake. New peers are connected via add_remote_agent.
-
-        ``epoch`` is the orchestrator's membership generation — a value all ranks
-        share for the same roster (not a local counter, since a joining node has
-        seen fewer changes). It tags notifications so any left over from a previous
-        roster are ignored, and must increase on every membership change.
-        """
-        if self._gathered is None:
-            self._gathered = {}
-        for rank, (name, metadata, _descs) in roster.items():
-            if rank != self.rank and rank not in self._remote_agent_names:
+        self._gathered = {rank: entry for rank, entry in enumerate(gathered) if entry is not None}
+        for rank, (name, metadata, _descs) in self._gathered.items():
+            if rank != self.rank:
                 self._remote_agent_names[rank] = self.agent.add_remote_agent(metadata) or name
-        self._gathered.update(roster)
-        self._recv_descs = roster[self.rank][2] if self.rank in roster else self._recv_descs
-        self._epoch = epoch
-        self._seq = 0
-        self._future_notifs.clear()
+        self._recv_descs = recv_descs
 
     def _do_local_copies(self) -> None:
         # Collocated (same-rank) transfers never hit the network.
@@ -188,6 +151,8 @@ class NixlCopyService(CopyService):
     def _plan_writes(self, remote_sends: List[SendOp]):
         # Group writes by destination agent: one WRITE per receiver pushes all its
         # regions at once, with local[i] landing in remote[i].
+        if self._gathered is None:
+            raise RuntimeError("NixlCopyService: handshake has not completed")
         by_dst: Dict[int, Tuple[List[torch.Tensor], List[_MemDesc]]] = {}
         for op in remote_sends:
             dst_entry = self._gathered.get(op.dest_rank)
@@ -204,21 +169,20 @@ class NixlCopyService(CopyService):
         return by_dst
 
     @staticmethod
-    def _notif(kind: str, epoch: int, seq: int) -> bytes:
-        return f"{kind}{epoch}.{seq}".encode()
+    def _notif(kind: str, seq: int) -> bytes:
+        return f"{kind}{seq}".encode()
 
     @staticmethod
-    def _parse_notif(m: bytes) -> Tuple[str, int, int]:
-        epoch, seq = m[1:].split(b".")
-        return chr(m[0]), int(epoch), int(seq)
+    def _parse_notif(m: bytes) -> Tuple[str, int]:
+        return chr(m[0]), int(m[1:])
 
     def _await_notifs(self, kind: str, expected: int, seq: int) -> None:
         # Wait for `expected` notifications of this kind ('R' ready / 'D' data)
-        # tagged with this (epoch, refit). Buffer any tagged otherwise — e.g. a
-        # data notif arriving while we're still collecting ready signals.
+        # tagged with this refit. Buffer any tagged otherwise — e.g. a data notif
+        # arriving while we're still collecting ready signals.
         if expected == 0:
             return
-        want = (kind, self._epoch, seq)
+        want = (kind, seq)
         got = self._future_notifs.pop(want, 0)
         while got < expected:
             for _agent, msgs in self.agent.get_new_notifs().items():
@@ -255,7 +219,7 @@ class NixlCopyService(CopyService):
 
         # Tell each source our destination buffers are free for this refit; this is
         # what orders a source's write after we've consumed the previous one.
-        ready = self._notif("R", self._epoch, seq)
+        ready = self._notif("R", seq)
         for src_rank in {op.src_rank for op in remote_recvs}:
             self.agent.send_notif(self._remote_agent_names[src_rank], ready)
 
@@ -265,7 +229,7 @@ class NixlCopyService(CopyService):
         if remote_sends:
             torch.cuda.current_stream().synchronize()
 
-        data = self._notif("D", self._epoch, seq)
+        data = self._notif("D", seq)
         handles = []
         for dst_rank, (local_tensors, remote_descs) in self._plan_writes(remote_sends).items():
             # local and remote are the same memory class (GPU->GPU for refit); the
@@ -280,15 +244,16 @@ class NixlCopyService(CopyService):
                 raise RuntimeError(f"NixlCopyService: WRITE to dst {dst_rank} failed to start")
             handles.append((dst_rank, handle))
 
-        # Wait for our own writes to land, then for every source writing into us.
+        # NIXL's asynchronous Python API exposes transfer completion through
+        # check_xfer_state(); the official examples poll it until DONE. Transfers
+        # progress in the backend, so yield the Python thread between checks.
         for dst_rank, handle in handles:
-            while True:
-                state = self.agent.check_xfer_state(handle)
-                if state == "DONE":
-                    break
-                if state == "ERR":
-                    raise RuntimeError(f"NixlCopyService: WRITE to dst {dst_rank} errored")
+            state = self.agent.check_xfer_state(handle)
+            while state not in ("DONE", "ERR"):
                 time.sleep(0)
+                state = self.agent.check_xfer_state(handle)
+            if state == "ERR":
+                raise RuntimeError(f"NixlCopyService: WRITE to dst {dst_rank} errored")
             self.agent.release_xfer_handle(handle)
         self._await_notifs("D", len({op.src_rank for op in remote_recvs}), seq)
 

--- a/megatron/core/resharding/copy_services/nixl_copy_service.py
+++ b/megatron/core/resharding/copy_services/nixl_copy_service.py
@@ -67,7 +67,7 @@ class NixlCopyService(CopyService):
         self.group = group
 
         try:
-            from nixl._api import nixl_agent, nixl_agent_config  # type: ignore[import-not-found]
+            from nixl._api import nixl_agent, nixl_agent_config
         except ImportError as e:
             raise ImportError(
                 "NixlCopyService requires the 'nixl' package; install it or use "

--- a/megatron/core/resharding/copy_services/nixl_copy_service.py
+++ b/megatron/core/resharding/copy_services/nixl_copy_service.py
@@ -1,0 +1,312 @@
+# Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Dict, List, Optional, Tuple
+
+import torch
+import torch.distributed as dist
+
+from .base import CopyService, RecvOp, SendOp, match_local_ops_by_task_id
+
+logger = logging.getLogger(__name__)
+
+# Transports that let UCX read/write CUDA memory. Without one of these UCX sees
+# a GPU pointer as host memory and segfaults mid-transfer.
+_CUDA_UCX_TRANSPORTS = ("cuda_copy", "cuda_ipc")
+
+# (addr, len_bytes, device_id) for a registered region. Exchanged between ranks
+# so a sender can WRITE straight into a receiver's destination buffer.
+_MemDesc = Tuple[int, int, int]
+
+
+def _ensure_cuda_ucx_transports() -> None:
+    """Add cuda transports to UCX_TLS if it's pinned to a host-only allowlist.
+
+    UCX reads UCX_TLS once at agent init. Deployments often set it to e.g. "tcp",
+    which can't touch GPU memory. Only augment a plain inclusion list; leave an
+    unset value (defaults to "all") or an exclusion list ("^...") alone.
+    """
+    tls = os.environ.get("UCX_TLS")
+    if not tls:
+        return
+    tokens = [t.strip() for t in tls.split(",") if t.strip()]
+    if not tokens or tokens[0].startswith("^") or any("cuda" in t for t in tokens):
+        return
+    os.environ["UCX_TLS"] = tls + "," + ",".join(_CUDA_UCX_TRANSPORTS)
+    logger.warning("UCX_TLS=%r has no cuda transport; using %r", tls, os.environ["UCX_TLS"])
+
+
+class NixlCopyService(CopyService):
+    """Refit transport over NIXL (UCX/RDMA), for cross-cluster non-collocated refit.
+
+    Each rank runs a NIXL agent. To WRITE into a peer it needs that peer's agent
+    metadata (connection info) plus a {task_id: (addr, len, dev)} map of the peer's
+    registered recv buffers. This peer table is built once and cached, either by a
+    torch all-gather handshake (the only collective) or — so membership can grow
+    without one — by update_membership installing an orchestrator-relayed roster
+    (see local_roster_entry). Buffers are registered locally, not exchanged.
+
+    Every refit after that is pure NIXL and sender-driven: a receiver signals each
+    source that its buffers are free ("ready"); the source waits, syncs its weights,
+    and issues one WRITE per receiver, each carrying a "data" notification. Those two
+    notifications order producer and consumer per refit, so there's no barrier and no
+    per-refit collective. Notifications are tagged with the membership epoch and a
+    per-refit sequence, so stale ones are ignored. Same-rank transfers skip NIXL and
+    copy directly.
+
+    Registered buffers are assumed address-stable across refits; if a recv address
+    changes after setup, call clear_service_cache() to rebuild.
+    """
+
+    def __init__(self, group=None, agent_name: Optional[str] = None):
+        super().__init__(group=group)
+        # Object collectives (the one-time handshake) run on this group to support
+        # cross-world PGs.
+        self.group = group
+
+        try:
+            from nixl._api import nixl_agent, nixl_agent_config
+        except ImportError as e:
+            raise ImportError(
+                "NixlCopyService requires the 'nixl' package; install it or use "
+                "another refit backend (nccl/gloo/nvshmem)."
+            ) from e
+
+        _ensure_cuda_ucx_transports()
+
+        # Name by group rank, which is unique across the (possibly cross-world)
+        # group. dist.get_rank() would collide: separate worlds each have a rank 0.
+        self.agent_name = agent_name or f"refit-nixl-rank-{self.rank}"
+        self.agent = nixl_agent(self.agent_name, nixl_agent_config(backends=["UCX"]))
+
+        self.send_ops: List[SendOp] = []
+        self.recv_ops: List[RecvOp] = []
+        self._copy_stream = torch.cuda.Stream()
+
+        # Peer table {group rank -> (agent_name, agent_metadata, recv_descs)},
+        # populated by the first run's handshake or by update_membership. A dict,
+        # not a list, so the rank set can grow when nodes are added.
+        self._remote_agent_names: Dict[int, str] = {}  # group rank -> agent name
+        self._gathered: Optional[Dict[int, tuple]] = None
+        self._recv_descs: Optional[Dict[int, _MemDesc]] = None
+        # RDMA registrations, kept across refits; send and recv tracked separately
+        # so a changing side doesn't re-pin the other.
+        self._reg: Dict[str, tuple] = {}  # 'send'/'recv' -> (handle, signature)
+        # Notifications are tagged (kind, epoch, seq): epoch bumps on a membership
+        # change so stale notifs from the old roster are ignored; seq is the
+        # per-refit counter. _future_notifs buffers tags we're not draining yet.
+        self._epoch = 0
+        self._seq = 0
+        self._future_notifs: Dict[Tuple[str, int, int], int] = {}
+
+    def submit_send(self, src_tensor: torch.Tensor, dest_rank: int, task_id: Optional[int] = None):
+        self.send_ops.append(SendOp(task_id=task_id, tensor=src_tensor, dest_rank=dest_rank))
+
+    def submit_recv(self, dest_tensor: torch.Tensor, src_rank: int, task_id: Optional[int] = None):
+        self.recv_ops.append(RecvOp(task_id=task_id, tensor=dest_tensor, src_rank=src_rank))
+
+    @staticmethod
+    def _mem_desc(tensor: torch.Tensor) -> _MemDesc:
+        if not tensor.is_contiguous():
+            raise RuntimeError("NixlCopyService requires contiguous tensors")
+        dev = tensor.get_device()  # -1 for host tensors; NIXL addresses DRAM as device 0
+        return (tensor.data_ptr(), tensor.numel() * tensor.element_size(), dev if dev >= 0 else 0)
+
+    def _register(self, which: str, tensors: List[torch.Tensor]) -> None:
+        # Re-register only when the set of regions changes.
+        sig = tuple((t.data_ptr(), t.numel() * t.element_size()) for t in tensors)
+        cached = self._reg.get(which)
+        if cached is not None and cached[1] == sig:
+            return
+        if cached is not None and cached[0] is not None:
+            self.agent.deregister_memory(cached[0])
+        handle = self.agent.register_memory(tensors) if tensors else None
+        self._reg[which] = (handle, sig)
+
+    def _handshake(self, recv_descs: Dict[int, _MemDesc]) -> None:
+        # Initial bootstrap over the torch group: share agent metadata and recv
+        # descriptors, connect to every peer, cache the peer table. This is the
+        # one torch collective; update_membership grows the table without it.
+        payload = (self.agent_name, self.agent.get_agent_metadata(), recv_descs)
+        gathered: List[Optional[tuple]] = [None] * self.world_size
+        dist.all_gather_object(gathered, payload, group=self.group)
+        roster = {rank: entry for rank, entry in enumerate(gathered) if entry is not None}
+        self.update_membership(roster, epoch=0)
+
+    def local_roster_entry(self, recv_items) -> tuple:
+        """Register this rank's recv buffers and return its roster entry
+        (agent_name, agent_metadata, recv_descs) for the orchestrator to
+        distribute. ``recv_items`` is an iterable of (task_id, tensor).
+
+        Registration must happen before the metadata is read: a peer can only
+        WRITE into these buffers if the metadata it holds already covers them.
+        """
+        items = list(recv_items)
+        self._register("recv", [t for _, t in items])
+        descs = {task_id: self._mem_desc(t) for task_id, t in items}
+        return (self.agent_name, self.agent.get_agent_metadata(), descs)
+
+    def update_membership(self, roster: Dict[int, tuple], epoch: int) -> None:
+        """Install a peer roster without a torch collective.
+
+        ``roster`` maps group rank -> (agent_name, agent_metadata, recv_descs) and
+        must include this rank. The orchestrator assembles it (relaying each node's
+        agent metadata and recv descriptors) when a node is added, and every rank
+        calls this at a refit boundary; a joining node uses it in place of the
+        initial handshake. New peers are connected via add_remote_agent.
+
+        ``epoch`` is the orchestrator's membership generation — a value all ranks
+        share for the same roster (not a local counter, since a joining node has
+        seen fewer changes). It tags notifications so any left over from a previous
+        roster are ignored, and must increase on every membership change.
+        """
+        if self._gathered is None:
+            self._gathered = {}
+        for rank, (name, metadata, _descs) in roster.items():
+            if rank != self.rank and rank not in self._remote_agent_names:
+                self._remote_agent_names[rank] = self.agent.add_remote_agent(metadata) or name
+        self._gathered.update(roster)
+        self._recv_descs = roster[self.rank][2] if self.rank in roster else self._recv_descs
+        self._epoch = epoch
+        self._seq = 0
+        self._future_notifs.clear()
+
+    def _do_local_copies(self) -> None:
+        # Collocated (same-rank) transfers never hit the network.
+        local_sends = [op for op in self.send_ops if op.dest_rank == self.rank]
+        local_recvs = [op for op in self.recv_ops if op.src_rank == self.rank]
+        if not local_sends and not local_recvs:
+            return
+        pairs = match_local_ops_by_task_id(local_sends, local_recvs, "NixlCopyService", self.rank)
+        with torch.no_grad(), torch.cuda.stream(self._copy_stream):
+            for send_op, recv_op in pairs:
+                recv_op.tensor.copy_(send_op.tensor)
+
+    def _plan_writes(self, remote_sends: List[SendOp]):
+        # Group writes by destination agent: one WRITE per receiver pushes all its
+        # regions at once, with local[i] landing in remote[i].
+        by_dst: Dict[int, Tuple[List[torch.Tensor], List[_MemDesc]]] = {}
+        for op in remote_sends:
+            dst_entry = self._gathered.get(op.dest_rank)
+            if dst_entry is None:
+                raise RuntimeError(f"NixlCopyService: no metadata from dst rank {op.dest_rank}")
+            remote_desc = dst_entry[2].get(op.task_id)
+            if remote_desc is None:
+                raise RuntimeError(
+                    f"NixlCopyService: dst rank {op.dest_rank} missing task_id {op.task_id}"
+                )
+            local_list, remote_list = by_dst.setdefault(op.dest_rank, ([], []))
+            local_list.append(op.tensor)
+            remote_list.append(remote_desc)
+        return by_dst
+
+    @staticmethod
+    def _notif(kind: str, epoch: int, seq: int) -> bytes:
+        return f"{kind}{epoch}.{seq}".encode()
+
+    @staticmethod
+    def _parse_notif(m: bytes) -> Tuple[str, int, int]:
+        epoch, seq = m[1:].split(b".")
+        return chr(m[0]), int(epoch), int(seq)
+
+    def _await_notifs(self, kind: str, expected: int, seq: int) -> None:
+        # Wait for `expected` notifications of this kind ('R' ready / 'D' data)
+        # tagged with this (epoch, refit). Buffer any tagged otherwise — e.g. a
+        # data notif arriving while we're still collecting ready signals.
+        if expected == 0:
+            return
+        want = (kind, self._epoch, seq)
+        got = self._future_notifs.pop(want, 0)
+        while got < expected:
+            for _agent, msgs in self.agent.get_new_notifs().items():
+                for m in msgs:
+                    tag = self._parse_notif(m)
+                    if tag == want:
+                        got += 1
+                    else:
+                        self._future_notifs[tag] = self._future_notifs.get(tag, 0) + 1
+            if got < expected:
+                time.sleep(0)  # NIXL delivers notifs on its own thread
+
+    def run(self):
+        remote_sends = [op for op in self.send_ops if op.dest_rank != self.rank]
+        remote_recvs = [op for op in self.recv_ops if op.src_rank != self.rank]
+        seq = self._seq
+
+        # Overlaps with the writes below.
+        self._do_local_copies()
+
+        # Both sides of a WRITE must be registered: our send tensors (we read them)
+        # and our recv buffers (peers write into them).
+        self._register("send", [op.tensor for op in remote_sends])
+        self._register("recv", [op.tensor for op in remote_recvs])
+
+        recv_descs = {op.task_id: self._mem_desc(op.tensor) for op in remote_recvs}
+        if self._gathered is None:
+            self._handshake(recv_descs)
+        elif recv_descs != self._recv_descs:
+            raise RuntimeError(
+                "NixlCopyService: recv tensor addresses changed after setup; "
+                "call clear_service_cache() to rebuild the handshake."
+            )
+
+        # Tell each source our destination buffers are free for this refit; this is
+        # what orders a source's write after we've consumed the previous one.
+        ready = self._notif("R", self._epoch, seq)
+        for src_rank in {op.src_rank for op in remote_recvs}:
+            self.agent.send_notif(self._remote_agent_names[src_rank], ready)
+
+        # As a source: wait for every receiver's ready, then push once the weights
+        # are finished (a peer must not read a half-written buffer).
+        self._await_notifs("R", len({op.dest_rank for op in remote_sends}), seq)
+        if remote_sends:
+            torch.cuda.current_stream().synchronize()
+
+        data = self._notif("D", self._epoch, seq)
+        handles = []
+        for dst_rank, (local_tensors, remote_descs) in self._plan_writes(remote_sends).items():
+            # local and remote are the same memory class (GPU->GPU for refit); the
+            # remote tuples carry no type, so take it from the send tensor.
+            mem_type = "cuda" if local_tensors[0].is_cuda else "cpu"
+            local_xfer = self.agent.get_xfer_descs(local_tensors)
+            remote_xfer = self.agent.get_xfer_descs(remote_descs, mem_type=mem_type)
+            handle = self.agent.initialize_xfer(
+                "WRITE", local_xfer, remote_xfer, self._remote_agent_names[dst_rank], notif_msg=data
+            )
+            if self.agent.transfer(handle) == "ERR":
+                raise RuntimeError(f"NixlCopyService: WRITE to dst {dst_rank} failed to start")
+            handles.append((dst_rank, handle))
+
+        # Wait for our own writes to land, then for every source writing into us.
+        for dst_rank, handle in handles:
+            while True:
+                state = self.agent.check_xfer_state(handle)
+                if state == "DONE":
+                    break
+                if state == "ERR":
+                    raise RuntimeError(f"NixlCopyService: WRITE to dst {dst_rank} errored")
+                time.sleep(0)
+            self.agent.release_xfer_handle(handle)
+        self._await_notifs("D", len({op.src_rank for op in remote_recvs}), seq)
+
+        torch.cuda.current_stream().wait_stream(self._copy_stream)
+        self._seq += 1
+        self.send_ops.clear()
+        self.recv_ops.clear()
+
+    def close(self) -> None:
+        for handle, _sig in self._reg.values():
+            if handle is not None:
+                self.agent.deregister_memory(handle)
+        self._reg.clear()
+        for name in self._remote_agent_names.values():
+            try:
+                self.agent.remove_remote_agent(name)
+            except Exception:
+                pass
+        self._remote_agent_names.clear()
+        self._gathered = None
+        self._recv_descs = None

--- a/megatron/core/resharding/execution.py
+++ b/megatron/core/resharding/execution.py
@@ -195,7 +195,8 @@ def execute_reshard_plan(
     logger.info(f"Executing {len(plan.send_ops)} sends + {len(plan.recv_ops)} recvs")
     service.run()
     torch.cuda.synchronize()
-    dist.barrier(group=group)
+    if service.requires_process_group_barrier:
+        dist.barrier(group=group)
 
     # Write back received buffers into their destination parameter slices.
     #

--- a/megatron/core/resharding/execution.py
+++ b/megatron/core/resharding/execution.py
@@ -64,7 +64,7 @@ def execute_reshard_plan(
     transform: Optional[ReshardTransform] = None,
 ) -> None:
     """
-    Execute a reshard plan (from centralized controller).
+    Execute a reshard plan (built locally on each rank).
     A communication service must be provided to abstract transport.
     Expected service API: submit_send(tensor, dest_rank, task_id),
     submit_recv(tensor, src_rank, task_id), run().

--- a/megatron/core/resharding/planner.py
+++ b/megatron/core/resharding/planner.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import logging
 import math
+import warnings
 
 import torch
 import torch.distributed as dist
@@ -406,9 +407,9 @@ def build_plan_from_rosters(
 ) -> ReshardPlan:
     """Replay the deterministic global schedule and keep only this rank's ops.
 
-    Pure and collective-free, so it can be re-run whenever the rosters change —
-    e.g. after a node is added and announces its metadata over NIXL — to rebuild
-    this rank's plan locally without touching the process group.
+    Pure and collective-free, so it can be tested or reused with preassembled
+    rosters without touching the process group. Live membership orchestration
+    is intentionally outside this module.
     """
     my_plan = ReshardPlan([], [])
     for (
@@ -453,7 +454,7 @@ def build_plan_from_rosters(
 def build_local_reshard_plan(
     src_module: torch.nn.Module,
     dst_module: torch.nn.Module,
-    num_experts: int = None,
+    num_experts: int | None = None,
     group=None,
     src_rank_offset: int = 0,
     dst_rank_offset: int = 0,
@@ -466,9 +467,8 @@ def build_local_reshard_plan(
     metadata.
 
     The metadata gather (the one collective) and the plan build are split into
-    index_metadata_rosters + build_plan_from_rosters, so the build can also run
-    off rosters assembled another way — e.g. from a node that joined later and
-    announced itself over NIXL, rebuilding the plan without a process group.
+    index_metadata_rosters + build_plan_from_rosters, so the deterministic build
+    can also be tested against preassembled rosters without a process group.
 
     src_module/dst_module may be None for non-collocated ranks (destination-only,
     source-only, or idle). Each rank contributes metadata only for the models it
@@ -498,3 +498,27 @@ def build_local_reshard_plan(
     dst_param_metadata_by_rank, src_param_metadata = index_metadata_rosters(gathered_pairs)
     del gathered_pairs
     return build_plan_from_rosters(dst_param_metadata_by_rank, src_param_metadata, my_global_rank)
+
+
+def build_centralized_reshard_plan(
+    src_module: torch.nn.Module,
+    dst_module: torch.nn.Module,
+    num_experts: int | None = None,
+    group=None,
+    src_rank_offset: int = 0,
+    dst_rank_offset: int = 0,
+) -> ReshardPlan:
+    """Deprecated compatibility wrapper for :func:`build_local_reshard_plan`."""
+    warnings.warn(
+        "build_centralized_reshard_plan is deprecated; use build_local_reshard_plan instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return build_local_reshard_plan(
+        src_module,
+        dst_module,
+        num_experts=num_experts,
+        group=group,
+        src_rank_offset=src_rank_offset,
+        dst_rank_offset=dst_rank_offset,
+    )

--- a/megatron/core/resharding/planner.py
+++ b/megatron/core/resharding/planner.py
@@ -301,7 +301,156 @@ def _determine_source_ranks_for_dst_param(
     return _finalize_dp_transfers(param_name, src_metadata, dst_metadata, my_global_rank)
 
 
-def build_centralized_reshard_plan(
+def _iter_global_transfer_ops(
+    dst_param_metadata_by_rank: dict[int, dict[str, ParameterMetadata]],
+    src_param_metadata: dict[str, list[ParameterMetadata]],
+):
+    """Yield the whole reshard schedule in a deterministic order.
+
+    The iteration order (dst rank ascending, then that rank's dst params in
+    gathered order, then per-source sub-ops) depends only on the rosters, so
+    replaying this on any rank produces the same sequence and assigns the same
+    task_id to the same transfer. That's what lets each rank build its own
+    send/recv ops while sender and receiver still agree on task_id.
+
+    Ranks are taken from the roster keys rather than range(world_size), so a
+    sparse or growing rank set (nodes added later) rebuilds identically.
+
+    Yields (task_id, dst_rank, src_rank, src_slice, dst_slice, src_metadata,
+    dst_metadata). PP is handled implicitly: each rank contributes metadata only
+    for the params it owns, and any source holding the same resolved_name can
+    serve as sender (with DP balancing).
+    """
+    # Shared between a send and its recv; NVSHMEM builds a schedule from it and
+    # local copies match on it.
+    next_task_id = 0
+    for dst_rank in sorted(dst_param_metadata_by_rank):
+        dst_rank_params = dst_param_metadata_by_rank[dst_rank]
+        for resolved_name, dst_metadata in dst_rank_params.items():
+            src_meta_list = src_param_metadata.get(resolved_name)
+            if not src_meta_list and resolved_name.endswith("output_layer.weight"):
+                # Tied embeddings: the source shares the output projection with
+                # the input embedding, so it has no separate output_layer.weight.
+                # A pp>1 destination materializes one (embedding and output land
+                # on different stages), e.g. pp=1 (tied) -> pp=2. Source it from
+                # the embedding weight (same shape + vocab/TP shard); that tensor
+                # then feeds both the destination embedding and output_layer.
+                for emb_name in ("embedding.word_embeddings.weight", "word_embeddings.weight"):
+                    src_meta_list = src_param_metadata.get(emb_name)
+                    if src_meta_list:
+                        break
+            if not src_meta_list:
+                raise RuntimeError(
+                    f"Destination parameter '{resolved_name}' on rank {dst_rank} "
+                    "not found in source model."
+                )
+            # Choose a representative source metadata with DP round-robin balancing.
+            src_metadata = select_src_metadata_balanced(src_meta_list, dst_metadata, dst_rank)
+            sources = _determine_source_ranks_for_dst_param(
+                resolved_name, src_metadata, dst_metadata, dst_rank
+            )
+            for src_rank, src_slice, dst_slice in sources:
+                task_id = next_task_id
+                next_task_id += 1
+                yield task_id, dst_rank, src_rank, src_slice, dst_slice, src_metadata, dst_metadata
+
+
+def _extract_module_metadata(
+    module, owner_rank, num_experts, rank_offset, rank_list_cache
+) -> list[ParameterMetadata]:
+    """Metadata for a module's params and persistent buffers, or [] if None.
+
+    Persistent buffers travel too so training state (e.g. MoE router expert_bias)
+    refits with the weights.
+    """
+    if module is None:
+        return []
+    pg = getattr(module, "pg_collection", None)
+    if pg is None:
+        raise ValueError("Module must have pg_collection")
+    layer_prefix_map = _build_layer_module_prefix_map(module)
+    return [
+        extract_param_metadata(
+            p,
+            name,
+            owner_rank,
+            pg,
+            num_experts=num_experts,
+            layer_module_prefix_map=layer_prefix_map,
+            rank_offset=rank_offset,
+            _rank_list_cache=rank_list_cache,
+        )
+        for name, p in named_refit_tensors(module)
+    ]
+
+
+def index_metadata_rosters(gathered_pairs: list):
+    """Turn a rank-ordered list of ``(src_meta, dst_meta)`` (index == rank) into the
+    two rosters the plan builder consumes: dst params keyed by rank, and src params
+    keyed by resolved_name. The list may come from the all-gather, or be reassembled
+    in rank order as nodes are added, before calling build_plan_from_rosters.
+    """
+    dst_param_metadata_by_rank: dict[int, dict[str, ParameterMetadata]] = {}
+    src_param_metadata: dict[str, list[ParameterMetadata]] = {}
+    for rank_id, (src_meta_list, dst_meta_list) in enumerate(gathered_pairs):
+        dst_param_metadata_by_rank[rank_id] = {m.resolved_name: m for m in dst_meta_list}
+        for metadata in src_meta_list:
+            src_param_metadata.setdefault(metadata.resolved_name, []).append(metadata)
+    return dst_param_metadata_by_rank, src_param_metadata
+
+
+def build_plan_from_rosters(
+    dst_param_metadata_by_rank: dict[int, dict[str, ParameterMetadata]],
+    src_param_metadata: dict[str, list[ParameterMetadata]],
+    my_global_rank: int,
+) -> ReshardPlan:
+    """Replay the deterministic global schedule and keep only this rank's ops.
+
+    Pure and collective-free, so it can be re-run whenever the rosters change —
+    e.g. after a node is added and announces its metadata over NIXL — to rebuild
+    this rank's plan locally without touching the process group.
+    """
+    my_plan = ReshardPlan([], [])
+    for (
+        task_id,
+        dst_rank,
+        src_rank,
+        src_slice,
+        dst_slice,
+        src_metadata,
+        dst_metadata,
+    ) in _iter_global_transfer_ops(dst_param_metadata_by_rank, src_param_metadata):
+        if dst_rank == my_global_rank:
+            my_plan.recv_ops.append(
+                TransferOp(
+                    param_name=dst_metadata.name,
+                    peer_rank=src_rank,
+                    is_send=False,
+                    my_slice=dst_slice,
+                    peer_slice=src_slice,
+                    task_id=task_id,
+                )
+            )
+        if src_rank == my_global_rank:
+            my_plan.send_ops.append(
+                TransferOp(
+                    param_name=src_metadata.name,
+                    peer_rank=dst_rank,
+                    is_send=True,
+                    my_slice=src_slice,
+                    peer_slice=dst_slice,
+                    task_id=task_id,
+                )
+            )
+
+    logger.info(
+        f"Rank {my_global_rank}: Built plan locally - {len(my_plan.recv_ops)} recvs, "
+        f"{len(my_plan.send_ops)} sends"
+    )
+    return my_plan
+
+
+def build_local_reshard_plan(
     src_module: torch.nn.Module,
     dst_module: torch.nn.Module,
     num_experts: int = None,
@@ -310,161 +459,42 @@ def build_centralized_reshard_plan(
     dst_rank_offset: int = 0,
 ) -> ReshardPlan:
     """
-    Centralized planning: Rank 0 builds complete plan for all ranks, then scatters.
+    Build this rank's reshard plan locally: all-gather the parameter metadata,
+    replay the global schedule (see _iter_global_transfer_ops), and keep only the
+    ops where this rank is the sender or receiver. No rank-0 bottleneck and no
+    scatter, since sender and receiver derive matching task_ids from the same
+    metadata.
 
-    Supports None for src_module and/or dst_module to enable non-collocated mode:
-    - src_module=None: Rank doesn't have source model (destination-only)
-    - dst_module=None: Rank doesn't have destination model (source-only)
-    - Both provided: Rank has both models (collocated mode)
+    The metadata gather (the one collective) and the plan build are split into
+    index_metadata_rosters + build_plan_from_rosters, so the build can also run
+    off rosters assembled another way — e.g. from a node that joined later and
+    announced itself over NIXL, rebuilding the plan without a process group.
 
-    Each rank provides metadata only for the models it owns, including parallel group
-    membership (tensor_parallel_group_ranks, expert_parallel_group_ranks, etc.).
-    This metadata is sufficient for rank 0 to build correct transfer plans without
-    requiring dummy models.
+    src_module/dst_module may be None for non-collocated ranks (destination-only,
+    source-only, or idle). Each rank contributes metadata only for the models it
+    owns, including its parallel-group membership.
     """
-    # Use group.rank() instead of dist.get_rank(group) to support cross-cluster
-    # ProcessGroups where members have independent default PGs (same default rank).
+    # group.rank()/size() (not dist.get_rank(group)) support cross-cluster PGs
+    # whose members have independent default PGs.
     my_global_rank = group.rank() if group is not None else dist.get_rank()
     world_size = group.size() if group is not None else dist.get_world_size()
 
-    # Shared cache for deduplicating rank lists across all metadata on this
-    # rank.  Params sharing the same TP/DP/EP/PP groups will reference one
-    # list object, making pickle ~75% smaller for the gather.
-    _rank_list_cache: dict = {}
-
-    def _extract_metadata(module, rank_offset):
-        """Extract per-parameter metadata from a module, or [] if module is None.
-
-        Includes both ``nn.Parameter`` instances and persistent buffers — the
-        latter so that buffers carrying training state (e.g. MoE router
-        ``expert_bias``) travel with the weights during refit.
-        """
-        if module is None:
-            return []
-        pg = getattr(module, "pg_collection", None)
-        if pg is None:
-            raise ValueError("Module must have pg_collection")
-        layer_prefix_map = _build_layer_module_prefix_map(module)
-        return [
-            extract_param_metadata(
-                p,
-                name,
-                my_global_rank,
-                pg,
-                num_experts=num_experts,
-                layer_module_prefix_map=layer_prefix_map,
-                rank_offset=rank_offset,
-                _rank_list_cache=_rank_list_cache,
-            )
-            for name, p in named_refit_tensors(module)
-        ]
-
-    my_src_metadata = _extract_metadata(src_module, src_rank_offset)
-    my_dst_metadata = _extract_metadata(dst_module, dst_rank_offset)
-
-    # Gather (src, dst) tuples in one collective so we pay one pickle round-trip
-    # instead of two.  Only rank 0 needs the full picture; other ranks just need
-    # their own plan from the later scatter.
-    gathered_pairs = [None] * world_size if my_global_rank == 0 else None
-    dist.gather_object((my_src_metadata, my_dst_metadata), gathered_pairs, group_dst=0, group=group)
-
-    # Free local metadata — no longer needed after gather.
-    del my_src_metadata, my_dst_metadata
-
-    # Parameter to metadata maps keyed by resolved_name (only populated on rank 0)
-    dst_param_metadata_by_rank = {}
-    src_param_metadata: dict[str, list[ParameterMetadata]] = {}
-
-    if my_global_rank == 0:
-        for rank_id, (src_meta_list, dst_meta_list) in enumerate(gathered_pairs):
-            dst_param_metadata_by_rank[rank_id] = {m.resolved_name: m for m in dst_meta_list}
-            for metadata in src_meta_list:
-                src_param_metadata.setdefault(metadata.resolved_name, []).append(metadata)
-
-        # Free the raw gathered list — data is now in the indexed dicts.
-        del gathered_pairs
-
-    # Build the plan on global rank 0 and broadcast to all ranks
-    if my_global_rank == 0:
-        plans_for_all_ranks = {r: ReshardPlan([], []) for r in range(world_size)}
-        # Global monotonically increasing ID for non-local transfers.
-        # This is shared between the corresponding send/recv ops so that
-        # NVSHMEM can build schedule.
-        next_task_id = 0
-
-        # Pipeline-parallel (PP) "mapping" is handled implicitly.
-        # Each rank contributes metadata only for the parameters it actually owns
-        # (i.e., the module partitioning for its PP stage). When PP sizes differ
-        # between source and destination, we don't compute an explicit stage-to-stage
-        # mapping here; instead, we iterate destination ranks and plan copies for the
-        # parameters present on those ranks. Any source rank that has the same logical
-        # parameter (matched by resolved_name) can serve as a sender (with DP balancing),
-        # and TP slicing is applied when applicable.
-        for dst_rank in range(world_size):
-            dst_rank_params = dst_param_metadata_by_rank.get(dst_rank, {})
-            for resolved_name, dst_metadata in dst_rank_params.items():
-                src_meta_list = src_param_metadata.get(resolved_name)
-                if not src_meta_list and resolved_name.endswith("output_layer.weight"):
-                    # Tied embeddings: the source shares the output projection with
-                    # the input embedding, so it has no separate output_layer.weight.
-                    # A pp>1 destination materializes one (embedding and output land
-                    # on different stages), e.g. pp=1 (tied) -> pp=2. Source it from
-                    # the embedding weight (same shape + vocab/TP shard); that tensor
-                    # then feeds both the destination embedding and output_layer.
-                    for emb_name in ("embedding.word_embeddings.weight", "word_embeddings.weight"):
-                        src_meta_list = src_param_metadata.get(emb_name)
-                        if src_meta_list:
-                            break
-                if not src_meta_list:
-                    raise RuntimeError(
-                        f"Destination parameter '{resolved_name}' on rank {dst_rank} "
-                        "not found in source model."
-                    )
-                # Choose a representative source metadata with DP round-robin balancing
-                src_metadata = select_src_metadata_balanced(src_meta_list, dst_metadata, dst_rank)
-                sources = _determine_source_ranks_for_dst_param(
-                    resolved_name, src_metadata, dst_metadata, dst_rank
-                )
-                for src_rank, src_slice, dst_slice in sources:
-                    task_id = next_task_id
-                    next_task_id += 1
-
-                    plans_for_all_ranks[dst_rank].recv_ops.append(
-                        TransferOp(
-                            param_name=dst_metadata.name,
-                            peer_rank=src_rank,
-                            is_send=False,
-                            my_slice=dst_slice,
-                            peer_slice=src_slice,
-                            task_id=task_id,
-                        )
-                    )
-                    plans_for_all_ranks[src_rank].send_ops.append(
-                        TransferOp(
-                            param_name=src_metadata.name,
-                            peer_rank=dst_rank,
-                            is_send=True,
-                            my_slice=src_slice,
-                            peer_slice=dst_slice,
-                            task_id=task_id,
-                        )
-                    )
-        plans_list = [plans_for_all_ranks[r] for r in range(world_size)]
-
-        # Free planning intermediates on rank 0 before the scatter.
-        del plans_for_all_ranks, dst_param_metadata_by_rank, src_param_metadata
-    else:
-        plans_list = None
-
-    # Scatter: each rank receives only its own plan (not all plans).
-    my_plan_list = [None]
-    torch.distributed.scatter_object_list(my_plan_list, plans_list, group_src=0, group=group)
-    my_plan = my_plan_list[0]
-    del plans_list  # Free the full list on rank 0.
-
-    logger.info(
-        f"Rank {my_global_rank}: Received plan - {len(my_plan.recv_ops)} recvs, "
-        f"{len(my_plan.send_ops)} sends"
+    # Dedup rank lists so params sharing a group reuse one list object; shrinks
+    # the pickled all-gather ~75%.
+    rank_list_cache: dict = {}
+    my_src_metadata = _extract_module_metadata(
+        src_module, my_global_rank, num_experts, src_rank_offset, rank_list_cache
+    )
+    my_dst_metadata = _extract_module_metadata(
+        dst_module, my_global_rank, num_experts, dst_rank_offset, rank_list_cache
     )
 
-    return my_plan
+    # One all-gather gives every rank the full (src, dst) picture, replacing the
+    # gather-to-0 + scatter.
+    gathered_pairs = [None] * world_size
+    dist.all_gather_object(gathered_pairs, (my_src_metadata, my_dst_metadata), group=group)
+    del my_src_metadata, my_dst_metadata
+
+    dst_param_metadata_by_rank, src_param_metadata = index_metadata_rosters(gathered_pairs)
+    del gathered_pairs
+    return build_plan_from_rosters(dst_param_metadata_by_rank, src_param_metadata, my_global_rank)

--- a/megatron/core/resharding/refit.py
+++ b/megatron/core/resharding/refit.py
@@ -121,7 +121,7 @@ def get_or_create_service(backend: RefitBackendName, group=None) -> CopyService:
     when swap_model_weights is called multiple times with the same backend.
 
     Args:
-        backend: Backend name ("nccl", "gloo", or "nvshmem").
+        backend: Backend name ("nccl", "gloo", "nvshmem", or "nixl").
         group: Optional process group for NCCL backend.
     """
     if backend in _service_cache:

--- a/megatron/core/resharding/refit.py
+++ b/megatron/core/resharding/refit.py
@@ -21,16 +21,17 @@ from megatron.core.inference.quantization.utils import (
 from megatron.core.models.common.language_module.language_module import LanguageModule
 from megatron.core.utils import unwrap_model
 
-from . import build_centralized_reshard_plan, execute_reshard_plan
+from . import build_local_reshard_plan, execute_reshard_plan
 from .copy_services.base import CopyService
 from .copy_services.gloo_copy_service import GlooCopyService
 from .copy_services.nccl_copy_service import NCCLCopyService
+from .copy_services.nixl_copy_service import NixlCopyService
 from .copy_services.nvshmem_copy_service import NVSHMEMCopyService
 from .transforms import MXFP8ReshardTransform, ReshardTransform
 from .utils import invalidate_refit_tensor_cache, named_persistent_buffers
 
 # Supported refit backend names
-RefitBackendName = Literal["nccl", "gloo", "nvshmem"]
+RefitBackendName = Literal["nccl", "gloo", "nvshmem", "nixl"]
 
 
 @dataclass(frozen=True)
@@ -44,6 +45,9 @@ class _PlanCacheKey:
     src_config: Optional[Tuple[int, int, int, int, int]]
     dst_config: Optional[Tuple[int, int, int, int, int]]
     num_experts: Optional[int]
+    # Adding inference nodes leaves the configs and offsets unchanged, so without
+    # world_size the stale pre-growth plan would be reused.
+    world_size: int = 0
     # Rank offsets distinguish non-collocated configurations that would otherwise
     # share the same (rank, sizes, num_experts) tuple but route to different
     # global ranks.
@@ -89,13 +93,16 @@ def _build_plan_cache_key(
     pool_index: int = 0,
 ) -> _PlanCacheKey:
     """Build cache key for reshard plan."""
-    # group.rank() supports cross-cluster ProcessGroups.
+    # group.rank()/size() support cross-cluster ProcessGroups where members
+    # have independent default PGs.
     rank = group.rank() if group is not None else torch.distributed.get_rank()
+    world_size = group.size() if group is not None else torch.distributed.get_world_size()
     return _PlanCacheKey(
         rank=rank,
         src_config=_get_config_tuple(src_core),
         dst_config=_get_config_tuple(tgt_core),
         num_experts=num_experts,
+        world_size=world_size,
         src_rank_offset=src_rank_offset,
         dst_rank_offset=dst_rank_offset,
         pool_index=pool_index,
@@ -126,6 +133,8 @@ def get_or_create_service(backend: RefitBackendName, group=None) -> CopyService:
         service = GlooCopyService(group=group)
     elif backend == "nvshmem":
         service = NVSHMEMCopyService(group=group)
+    elif backend == "nixl":
+        service = NixlCopyService(group=group)
     else:
         raise ValueError(f"Unknown backend '{backend}'")
 
@@ -202,7 +211,8 @@ def _build_or_get_plan(
     """Return the cached reshard plan, building it (collectively) if not yet cached.
 
     All participating ranks must call this simultaneously when the plan is not
-    yet cached, because build_centralized_reshard_plan uses collective communication.
+    yet cached, because build_local_reshard_plan uses collective communication
+    (an all_gather of parameter metadata).
     """
     global _plan_cache
     cache_key = _build_plan_cache_key(
@@ -215,7 +225,7 @@ def _build_or_get_plan(
         pool_index=pool_index,
     )
     if cache_key not in _plan_cache:
-        _plan_cache[cache_key] = build_centralized_reshard_plan(
+        _plan_cache[cache_key] = build_local_reshard_plan(
             src_core,
             tgt_core,
             num_experts=num_experts,

--- a/tests/unit_tests/resharding/test_copy_services.py
+++ b/tests/unit_tests/resharding/test_copy_services.py
@@ -16,6 +16,7 @@ from megatron.core.resharding.copy_services.base import (
     SendOp,
     match_local_ops_by_task_id,
 )
+from megatron.core.resharding.copy_services.nixl_copy_service import NixlCopyService
 
 
 def _t():
@@ -164,3 +165,8 @@ class TestCopyServiceClose:
         assert svc.closed is False
         svc.close()
         assert svc.closed is True
+
+
+def test_nixl_service_skips_redundant_process_group_barrier():
+    """NIXL's ready/data protocol provides its own peer completion."""
+    assert NixlCopyService.requires_process_group_barrier is False

--- a/tests/unit_tests/resharding/test_execution.py
+++ b/tests/unit_tests/resharding/test_execution.py
@@ -6,7 +6,7 @@ These test the send/recv submission logic, writeback paths, and
 non-collocated mode handling.  Requires CUDA (uses torch.cuda.synchronize).
 """
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
@@ -261,6 +261,17 @@ class TestTransformPath:
 
 class TestEdgeCases:
     """Test edge cases in execute_reshard_plan."""
+
+    def test_service_can_skip_process_group_barrier(self):
+        """A self-synchronizing backend does not use the executor's barrier."""
+        Utils.initialize_distributed()
+        service = MockCopyService()
+        service.requires_process_group_barrier = False
+
+        with patch("megatron.core.resharding.execution.dist.barrier") as barrier:
+            execute_reshard_plan(ReshardPlan(send_ops=[], recv_ops=[]), None, None, service)
+
+        barrier.assert_not_called()
 
     def test_empty_plan(self):
         """Empty plan (no ops) should complete without error."""

--- a/tests/unit_tests/resharding/test_planner.py
+++ b/tests/unit_tests/resharding/test_planner.py
@@ -15,6 +15,8 @@ from megatron.core.resharding.planner import (
     _build_descriptors_for_param,
     _finalize_dp_transfers,
     _plan_tp,
+    build_plan_from_rosters,
+    index_metadata_rosters,
 )
 from megatron.core.resharding.utils import ParameterMetadata, ShardingDescriptor
 
@@ -360,3 +362,77 @@ class TestBuildDescriptors:
 
         descs = _build_descriptors_for_param(src, dst)
         assert descs == []
+
+
+# ===========================================================================
+# build_plan_from_rosters (local, deterministic planning + node-add stability)
+# ===========================================================================
+
+
+def _plan_edges(plans):
+    """Collect (task_id, src_rank, dst_rank) transfers from a {rank: ReshardPlan}.
+
+    Reads them once from every send op and once from every recv op; the two sets
+    must be equal for the plan to be consistent (a matching, same-task_id recv for
+    every send).
+    """
+    sends = {(op.task_id, r, op.peer_rank) for r, p in plans.items() for op in p.send_ops}
+    recvs = {(op.task_id, op.peer_rank, r) for r, p in plans.items() for op in p.recv_ops}
+    return sends, recvs
+
+
+def _build_all(gathered_pairs):
+    """Build every rank's plan from a rank-ordered list of (src_meta, dst_meta)."""
+    dst_by_rank, src_by_name = index_metadata_rosters(gathered_pairs)
+    return {rank: build_plan_from_rosters(dst_by_rank, src_by_name, rank) for rank in dst_by_rank}
+
+
+def _recv_sig(plan):
+    """Identity of a plan's recv ops (task_id + slices), for stability comparisons."""
+    return [(op.task_id, op.peer_rank, op.my_slice, op.peer_slice) for op in plan.recv_ops]
+
+
+class TestBuildPlanFromRosters:
+    """Local plan building replayed independently per rank."""
+
+    def test_task_ids_match_across_ranks(self):
+        """Sender and receiver, planned independently, agree on task_id per transfer.
+
+        rank 0 sources a replicated weight; ranks 1 and 2 each receive a full copy.
+        """
+        gathered = [
+            ([_meta(owner_rank=0, tp_ranks=[0], dp_ranks=[0])], []),  # rank 0: source
+            ([], [_meta(owner_rank=1, tp_ranks=[1], dp_ranks=[1])]),  # rank 1: dest
+            ([], [_meta(owner_rank=2, tp_ranks=[2], dp_ranks=[2])]),  # rank 2: dest
+        ]
+        plans = _build_all(gathered)
+        sends, recvs = _plan_edges(plans)
+
+        # Every send has a matching recv with the same task_id, and vice versa.
+        assert sends == recvs
+        # Two transfers: 0->1 and 0->2, with distinct task_ids.
+        assert len(sends) == 2
+        assert {(s, d) for _, s, d in sends} == {(0, 1), (0, 2)}
+        assert len({tid for tid, _, _ in sends}) == 2
+
+    def test_node_add_keeps_existing_task_ids_stable(self):
+        """Appending a rank rebuilds locally without renumbering existing transfers."""
+        base = [
+            ([_meta(owner_rank=0, tp_ranks=[0], dp_ranks=[0])], []),
+            ([], [_meta(owner_rank=1, tp_ranks=[1], dp_ranks=[1])]),
+            ([], [_meta(owner_rank=2, tp_ranks=[2], dp_ranks=[2])]),
+        ]
+        before = _build_all(base)
+
+        # A new destination rank 3 joins; everyone replays over the grown roster.
+        grown = base + [([], [_meta(owner_rank=3, tp_ranks=[3], dp_ranks=[3])])]
+        after = _build_all(grown)
+
+        sends_after, recvs_after = _plan_edges(after)
+        assert sends_after == recvs_after
+        # Existing receivers keep the exact same recv ops (task_id + slices).
+        for rank in (1, 2):
+            assert _recv_sig(before[rank]) == _recv_sig(after[rank])
+        # The new rank added exactly one transfer with a fresh task_id.
+        assert len(sends_after) == 3
+        assert {(s, d) for _, s, d in sends_after} == {(0, 1), (0, 2), (0, 3)}

--- a/tests/unit_tests/resharding/test_planner.py
+++ b/tests/unit_tests/resharding/test_planner.py
@@ -11,6 +11,7 @@ import math
 
 import pytest
 
+import megatron.core.resharding.planner as planner
 from megatron.core.resharding.planner import (
     _build_descriptors_for_param,
     _finalize_dp_transfers,
@@ -436,3 +437,26 @@ class TestBuildPlanFromRosters:
         # The new rank added exactly one transfer with a fresh task_id.
         assert len(sends_after) == 3
         assert {(s, d) for _, s, d in sends_after} == {(0, 1), (0, 2), (0, 3)}
+
+
+def test_centralized_planner_compatibility_wrapper(monkeypatch):
+    """The previous public planner name warns and forwards every argument."""
+    sentinel = object()
+    forwarded = {}
+
+    def fake_local(src_module, dst_module, **kwargs):
+        forwarded["args"] = (src_module, dst_module)
+        forwarded["kwargs"] = kwargs
+        return sentinel
+
+    monkeypatch.setattr(planner, "build_local_reshard_plan", fake_local)
+    with pytest.warns(DeprecationWarning, match="build_local_reshard_plan"):
+        result = planner.build_centralized_reshard_plan(
+            "src", "dst", num_experts=8, group="group", src_rank_offset=3, dst_rank_offset=7
+        )
+
+    assert result is sentinel
+    assert forwarded == {
+        "args": ("src", "dst"),
+        "kwargs": {"num_experts": 8, "group": "group", "src_rank_offset": 3, "dst_rank_offset": 7},
+    }


### PR DESCRIPTION
1) Local deterministic global planning instead of rank 0 building and sending to everyone.
2) We are adding nixl backend as a communication backend.

The point of these changes is that this would allow us to hopefully be able to handle arbitrary nodes coming in and out of the training and inference groups without resetting the job.

- [ ] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
<!-- Add a one line overview of what this PR aims to accomplish. -->

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
