### PR TITLE
fix(deepseek_v4): fix gradient checkpointing failure in mlite

### DIFF
--- a/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py
@@ -321,7 +321,7 @@ def _configure_attention_backend(chunks: list[nn.Module], *, backend: str | None
 
 
 def _iter_transformer_units(chunk: nn.Module) -> list[nn.Module]:
-    model = getattr(chunk, "model", None)
+    model = getattr(chunk, "model", chunk)
     if model is None:
         return []
     layers = list(getattr(model, "layers", {}).values())


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
<!-- Add a one line overview of what this PR aims to accomplish. -->

This MR mirrors https://github.com/verl-project/Megatron-LM/pull/4

**Description**: During the training of DeepSeek V4, it was observed that gradient checkpointing in `mlite` was not taking effect, resulting in excessively high VRAM usage\. Given the massive parameter scale of DeepSeek V4, functioning gradient checkpointing is critical for preventing OOM errors and maintaining a reasonable memory footprint\.

**Root Cause**: Upon investigation, the issue was traced back to the `_iter_transformer_units` function in `protocol.py`\. The logic failed to correctly extract the transformer `layers`\. Specifically, when the passed `chunk` was the model instance itself, `getattr(chunk, "model", None)` returned `None`\. This caused the subsequent layer extraction to yield an empty list, completely bypassing the gradient checkpointing logic\.

<img width="2592" height="1846" alt="image" src="https://github.com/user-attachments/assets/111a1189-19d7-439a-850a-49d93ae3e35a" />


**Solution**: Updated the layer extraction logic to include a fallback: `model = getattr(chunk, "model", None) or chunk`\. This ensures that if the chunk itself is the model, the layers are correctly identified and passed to the checkpointing mechanism\.

<img width="3454" height="1048" alt="image" src="https://github.com/user-attachments/assets/f368a4ed-a4cb-4aaa-a677-d67b9c0a16f7" />
<img width="3454" height="1036" alt="image" src="https://github.com/user-attachments/assets/6e4b4c42-b906-4f5b-ae67-168a863e7e25" />


**Impact**:

- Gradient checkpointing is now correctly applied\.

- Peak VRAM usage has significantly decreased\.

- The active memory timeline now displays the expected sawtooth pattern characteristic of normal gradient checkpointing\.

**Note for Reproduction**: 

To simplify the reproduction process and save computational resources during debugging, the memory profiling and tests were conducted using a truncated version of the original DeepSeek V4 Flash model (reduced from 43 layers down to 3 layers).

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
