### PR TITLE
fix(pipeline): fix prefetch logic for non-first stages in 1F1B schedule for mlite

### DIFF
--- a/experimental/lite/megatron/lite/primitive/parallel/pipeline.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/pipeline.py
@@ -288,6 +288,7 @@ def _1f1b_schedule(
             tensor_shape,
             fwd_recv_buf=_fwd_recv_buf,
             bwd_recv_buf=_bwd_recv_buf,
+            clone_recv=True,
         )
 
     # ── Warmup: pure forward passes ──
@@ -303,7 +304,10 @@ def _1f1b_schedule(
         hidden = out.get("hidden_states")
         loss_s = out["loss"] / num_microbatches if "loss" in out and ps.pp_is_last else None
 
-        need_recv_next = not ps.pp_is_first and k < num_warmup - 1
+        # Non-first stages need to prefetch the fwd_input for the next forward:
+        # either the next warmup step (k+1 < num_warmup) or the first steady step
+        # (num_steady > 0). Equivalently: any remaining forward in this iteration.
+        need_recv_next = not ps.pp_is_first and (k + 1) < num_microbatches
         if not ps.pp_is_last:
             fwd_input, _ = _p2p(send_fwd=hidden, recv_fwd=need_recv_next)
         elif need_recv_next:

--- a/experimental/lite/tests/unit/primitive/test_pipeline_schedule_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_pipeline_schedule_unit.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+from collections import Counter
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import megatron.lite.primitive.parallel.pipeline as pipeline_mod
+from megatron.lite.primitive.parallel.pipeline import _1f1b_schedule
+from megatron.lite.primitive.parallel.state import ParallelState
+
+pytestmark = pytest.mark.mlite
+
+
+class _DummyStage(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.current_input: torch.Tensor | None = None
+        self.forward_inputs: list[torch.Tensor] = []
+
+    def set_input_tensor(self, tensor: torch.Tensor) -> None:
+        self.current_input = tensor
+        self.forward_inputs.append(tensor)
+
+
+class _FakePipelineP2P:
+    """Stand-in for `_send_recv_pipeline` that fills every fwd receive with a
+    monotonically increasing value so the test can tell which microbatch's
+    activation ends up in a retained input tensor."""
+
+    def __init__(self, *, force_clone: bool | None = None):
+        self.force_clone = force_clone
+        self.counts: Counter[str] = Counter()
+        self.clone_recv_args: list[bool] = []
+
+    def __call__(
+        self,
+        send_fwd: torch.Tensor | None,
+        send_bwd: torch.Tensor | None,
+        recv_fwd: bool,
+        recv_bwd: bool,
+        ps: ParallelState,
+        tensor_shape: tuple[int, ...],
+        *,
+        fwd_recv_buf: torch.Tensor | None = None,
+        bwd_recv_buf: torch.Tensor | None = None,
+        batch_p2p: bool = True,
+        clone_recv: bool = False,
+    ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+        del ps, batch_p2p
+        self.clone_recv_args.append(clone_recv)
+        clone = self.force_clone if self.force_clone is not None else clone_recv
+
+        if send_fwd is not None:
+            self.counts["send_fwd"] += 1
+        if send_bwd is not None:
+            self.counts["send_bwd"] += 1
+
+        fwd_buf = None
+        bwd_buf = None
+        if recv_fwd:
+            self.counts["recv_fwd"] += 1
+            fwd_buf = fwd_recv_buf if fwd_recv_buf is not None else torch.empty(tensor_shape)
+            with torch.no_grad():
+                fwd_buf.fill_(float(self.counts["recv_fwd"]))
+            if clone:
+                fwd_buf = fwd_buf.clone()
+            fwd_buf.grad = None
+            fwd_buf.requires_grad_()
+        if recv_bwd:
+            self.counts["recv_bwd"] += 1
+            bwd_buf = bwd_recv_buf if bwd_recv_buf is not None else torch.empty(tensor_shape)
+            with torch.no_grad():
+                bwd_buf.fill_(1.0)
+            if clone:
+                bwd_buf = bwd_buf.clone()
+
+        return fwd_buf, bwd_buf
+
+
+def _patch_pipeline_for_cpu(monkeypatch: pytest.MonkeyPatch) -> None:
+    orig_empty = torch.empty
+
+    def _cpu_empty(*args, **kwargs):
+        kwargs = dict(kwargs)
+        kwargs.pop("device", None)
+        return orig_empty(*args, **kwargs)
+
+    monkeypatch.setattr(torch, "empty", _cpu_empty)
+    monkeypatch.setattr(pipeline_mod, "_PIPELINE_TENSOR_DTYPE", torch.float32)
+
+
+def _parallel_state(pp_size: int, pp_rank: int) -> ParallelState:
+    return ParallelState(
+        pp_size=pp_size,
+        pp_rank=pp_rank,
+        pp_is_first=(pp_rank == 0),
+        pp_is_last=(pp_rank == pp_size - 1),
+        pp_prev_rank=pp_rank - 1,
+        pp_next_rank=pp_rank + 1,
+    )
+
+
+def _forward_step(model: _DummyStage, batch: dict[str, float]) -> dict:
+    assert model.current_input is not None
+    hidden = model.current_input * batch["scale"]
+    return {"hidden_states": hidden, "model_output": batch["id"]}
+
+
+def _run_1f1b_schedule(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    pp_size: int,
+    pp_rank: int,
+    num_microbatches: int,
+    force_clone: bool | None = None,
+) -> tuple[_DummyStage, _FakePipelineP2P, list[dict]]:
+    _patch_pipeline_for_cpu(monkeypatch)
+    transport = _FakePipelineP2P(force_clone=force_clone)
+    monkeypatch.setattr(pipeline_mod, "_send_recv_pipeline", transport)
+
+    model = _DummyStage()
+    batches = iter({"id": i, "scale": float(i + 2)} for i in range(num_microbatches))
+    outputs = _1f1b_schedule(
+        _forward_step,
+        model,
+        batches,
+        num_microbatches,
+        SimpleNamespace(),
+        _parallel_state(pp_size, pp_rank),
+        tensor_shape=(2, 3),
+    )
+    return model, transport, outputs
+
+
+# (pp_size, pp_rank, num_microbatches).  num_warmup W = pp_size - pp_rank - 1.
+# Cross-covers:
+#   * the boundary case the prefetch fix addressed (W=1);
+#   * the historically silent-corruption case (W>=2);
+#   * num_microbatches < pp_size, == pp_size, and > pp_size;
+#   * multiple pp_ranks per pp_size and multiple pp_sizes.
+# Every case targets a middle (non-first, non-last) stage so all four p2p
+# directions must transfer exactly num_microbatches tensors.
+_SCHEDULE_CASES: list[tuple[int, int, int]] = [
+    # ── pp_size=4 ──
+    (4, 2, 1),  # W=1, num_microbatches < pp_size (warmup only, no steady)
+    (4, 2, 2),  # W=1, exercises warmup->steady transition
+    (4, 2, 5),  # W=1, num_microbatches > pp_size
+    (4, 1, 2),  # W=2, num_microbatches == W (all warmup, no steady)
+    (4, 1, 3),  # W=2, three retained inputs; alias would silently corrupt grads
+    (4, 1, 4),  # W=2, num_microbatches == pp_size
+    (4, 1, 5),  # W=2, num_microbatches > pp_size
+    # ── pp_size=5 (deeper pipeline) ──
+    (5, 1, 3),  # W=3, num_microbatches < pp_size
+    (5, 1, 5),  # W=3, num_microbatches == pp_size
+    (5, 1, 7),  # W=3, num_microbatches > pp_size
+    (5, 2, 4),  # W=2 mid-rank
+    (5, 3, 6),  # W=1 penultimate rank, num_microbatches > pp_size
+]
+
+_MULTI_MB_CASES = [c for c in _SCHEDULE_CASES if c[2] >= 2]
+
+
+@pytest.mark.parametrize(("pp_size", "pp_rank", "num_microbatches"), _SCHEDULE_CASES)
+def test_1f1b_schedule_balances_p2p_and_never_forwards_none(
+    monkeypatch, pp_size: int, pp_rank: int, num_microbatches: int
+):
+    model, transport, outputs = _run_1f1b_schedule(
+        monkeypatch,
+        pp_size=pp_size,
+        pp_rank=pp_rank,
+        num_microbatches=num_microbatches,
+    )
+
+    # Every microbatch reaches forward with a non-None input, i.e. the
+    # warmup->steady transition never leaves fwd_input dangling even when
+    # num_microbatches < pp_size.
+    assert len(model.forward_inputs) == num_microbatches
+    assert all(tensor is not None for tensor in model.forward_inputs)
+
+    # Adjacent forward and backward send/receive counts stay balanced.
+    for op in ("send_fwd", "recv_fwd", "send_bwd", "recv_bwd"):
+        assert transport.counts[op] == num_microbatches, (
+            f"{op}={transport.counts[op]} != num_microbatches={num_microbatches} "
+            f"(pp_size={pp_size}, pp_rank={pp_rank})"
+        )
+
+    # The local `_p2p` wrapper must propagate clone_recv=True on every call so
+    # that retained inputs get fresh storage instead of aliasing _fwd_recv_buf.
+    assert transport.clone_recv_args and all(transport.clone_recv_args)
+
+    assert len(outputs) == num_microbatches
+
+
+@pytest.mark.parametrize(("pp_size", "pp_rank", "num_microbatches"), _MULTI_MB_CASES)
+def test_1f1b_schedule_clones_retained_forward_inputs(
+    monkeypatch, pp_size: int, pp_rank: int, num_microbatches: int
+):
+    model, _transport, _outputs = _run_1f1b_schedule(
+        monkeypatch,
+        pp_size=pp_size,
+        pp_rank=pp_rank,
+        num_microbatches=num_microbatches,
+    )
+
+    assert len(model.forward_inputs) == num_microbatches
+
+    # Every simultaneously-retained forward input must live in its own storage,
+    # not alias into the shared _fwd_recv_buf.
+    ptrs = [t.data_ptr() for t in model.forward_inputs]
+    assert len(set(ptrs)) == len(ptrs), f"aliased retained inputs: {ptrs}"
+
+    # The i-th retained input must still carry the value written by the i-th
+    # forward receive (1, 2, 3, ...), i.e. no later receive overwrote it.
+    for i, tensor in enumerate(model.forward_inputs):
+        expected = float(i + 1)
+        assert torch.all(tensor == expected), (
+            f"forward_inputs[{i}] expected fill={expected}, got {tensor.tolist()}"
+        )
+
+
+@pytest.mark.parametrize(("pp_size", "pp_rank", "num_microbatches"), _MULTI_MB_CASES)
+def test_1f1b_schedule_no_clone_negative_control_aliases_inputs(
+    monkeypatch, pp_size: int, pp_rank: int, num_microbatches: int
+):
+    """Force clone_recv=False in the fake transport to reproduce the alias:
+    without the clone every retained input references the same _fwd_recv_buf,
+    so by the time the last receive completes they all read the last value."""
+    model, transport, _outputs = _run_1f1b_schedule(
+        monkeypatch,
+        pp_size=pp_size,
+        pp_rank=pp_rank,
+        num_microbatches=num_microbatches,
+        force_clone=False,
+    )
+
+    assert len(model.forward_inputs) == num_microbatches
+
+    ptrs = {t.data_ptr() for t in model.forward_inputs}
+    assert len(ptrs) == 1, f"expected all retained inputs to alias, got ptrs={ptrs}"
+
+    last_recv_value = float(transport.counts["recv_fwd"])
+    for tensor in model.forward_inputs:
+        assert torch.all(tensor == last_recv_value), (
+            f"expected aliased buf to hold last recv value {last_recv_value}, "
+            f"got {tensor.tolist()}"
+        )


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
<!-- Add a one line overview of what this PR aims to accomplish. -->

This MR mirrors https://github.com/verl-project/Megatron-LM/pull/5

## Summary

Fix a pipeline-parallel 1F1B scheduling bug where the penultimate PP stage could crash entering the steady phase, and close a long-standing receive-buffer aliasing issue that this fix would otherwise make more reachable.

Two coupled changes in `_1f1b_schedule`:

1. **Prefetch boundary fix** — receive the next forward input whenever any forward pass remains in the iteration, not only within warmup.
2. **Clone-on-receive fix** — request cloned receive tensors from the local P2P wrapper so retained microbatch inputs no longer alias a shared preallocated buffer.

Regression coverage in `test_pipeline_schedule_unit.py` exercises the real `_1f1b_schedule` control flow.

## Root Cause

### 1. Missing prefetch at the warmup→steady boundary

The old guard for non-first stages was:

```python
need_recv_next = not ps.pp_is_first and k < num_warmup - 1
```

This only prefetched the next input while iterating strictly inside warmup. It missed the transition between the last warmup step and the first steady step, so a non-first stage could enter the next forward without a valid input tensor.

### 2. Receive-buffer aliasing (pre-existing, silently corrupting)

`_1f1b_schedule` preallocates a single `_fwd_recv_buf` and reuses it for every forward receive, while each received `fwd_input` is retained in `input_tensors` until its matching backward. Because the local `_send_recv_pipeline` wrapper defaults to `clone_recv=False`, all retained inputs can reference the same storage. A subsequent `dist.irecv` then overwrites an earlier microbatch's autograd leaf in place. Since `irecv` writes storage without bumping the autograd version, this silently corrupts gradients instead of raising.

The alias has existed since the initial commit of `_1f1b_schedule` (`395aa1e66`): the single `_fwd_recv_buf`, the local `_p2p` wrapper defaulting to `clone_recv=False`, and the retention of `fwd_input` in `input_tensors` have coexisted from day one, while the sibling VPP schedules already pass `clone_recv=True`.

Under the old `k < num_warmup - 1` guard, the alias was already silently exercised on any non-first, non-penultimate stage with `num_warmup >= 2` (at `k = 0` the prefetch is truthy when `W >= 2`, so `irecv` overwrites `_fwd_recv_buf` before the just-forwarded microbatch's leaf is appended to `input_tensors`). The old boundary uniquely protected only the `W = 1` (penultimate) case, and even there only accidentally: that configuration was crashing on the missing steady-state input before any backward could observe the corruption.

The `(k + 1) < num_microbatches` fix does not introduce the aliasing — it closes the last configuration in which the bug happened to be masked. Combining it with `clone_recv=True` addresses both the previously silent (`W >= 2`) and the newly reachable (`W = 1`) paths.

## Fix

```diff
-        need_recv_next = not ps.pp_is_first and k < num_warmup - 1
+        # Non-first stages need to prefetch the fwd_input for the next forward:
+        # either the next warmup step (k+1 < num_warmup) or the first steady step
+        # (num_steady > 0). Equivalently: any remaining forward in this iteration.
+        need_recv_next = not ps.pp_is_first and (k + 1) < num_microbatches
```

```diff
     return _send_recv_pipeline(
         send_fwd, send_bwd, recv_fwd, recv_bwd, ps, tensor_shape,
         fwd_recv_buf=_fwd_recv_buf,
         bwd_recv_buf=_bwd_recv_buf,
+        clone_recv=True,
     )
```

The `clone_recv=True` path preserves the preallocated communication buffer while giving every retained microbatch its own storage, matching the existing convention in the sibling VPP schedules and standard Megatron semantics (each receive yields a fresh tensor).

## User-visible Impact

- Before: the penultimate PP stage failed on `_embed_or_recv` with `AssertionError: hidden_states is not None`:

  ```
  File "/usr/local/lib/python3.12/dist-packages/ray/_private/function_manager.py", line 687, in actor_method_executor
    return method(__ray_actor, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/ray/util/tracing/tracing_helper.py", line 463, in _resume_span
    return method(self, *_args, **_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "verl/single_controller/base/decorator.py", line 431, in inner
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "verl/utils/transferqueue_utils.py", line 329, in inner
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "verl/utils/profiler/profile.py", line 183, in wrapper
    return func(self_instance, *args, **kwargs_inner)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "verl/workers/engine_workers.py", line 352, in train_batch
    output = self.engine.train_batch(data, loss_function=self.loss_fn)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "verl/workers/engine/base.py", line 126, in train_batch
    outputs = self.forward_backward_batch(data, loss_function, forward_only=False)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "Megatron-LM-Lite/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py", line 364, in forward_backward_batch
    return self._forward_backward_batch_with_runtime(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "Megatron-LM-Lite/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py", line 691, in _forward_backward_batch_with_runtime
    result = self.runtime.forward_backward(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "Megatron-LM-Lite/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py", line 451, in forward_backward
    outputs = forward_backward_pipelining(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "Megatron-LM-Lite/experimental/lite/megatron/lite/primitive/parallel/pipeline.py", line 101, in forward_backward_pipelining
    return _1f1b_schedule(
           ^^^^^^^^^^^^^^^
  File "Megatron-LM-Lite/experimental/lite/megatron/lite/primitive/parallel/pipeline.py", line 332, in _1f1b_schedule
    out = _run_forward(fwd_input, batch, loss_ctx)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "Megatron-LM-Lite/experimental/lite/megatron/lite/primitive/parallel/pipeline.py", line 267, in _run_forward
    out = forward_step_fn(model, batch)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "Megatron-LM-Lite/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py", line 146, in wrapped_forward_step
    return forward_step(model, batch)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "Megatron-LM-Lite/experimental/lite/megatron/lite/model/deepseek_v4/lite/protocol.py", line 257, in _forward_step
    return model(**_prepare_model_forward_kwargs(model, batch))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1778, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1884, in _call_impl
    return inner()
           ^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1832, in inner
    result = forward_call(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "Megatron-LM-Lite/experimental/lite/megatron/lite/model/deepseek_v4/lite/model.py", line 493, in forward
    h, input_ids, _seq_len = self._embed_or_recv(input_ids, hidden_states)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "Megatron-LM-Lite/experimental/lite/megatron/lite/model/deepseek_v4/lite/model.py", line 391, in _embed_or_recv
    assert hidden_states is not None
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  AssertionError
  ```

- After: the penultimate stage receives its steady-state input on time, and non-penultimate stages no longer silently corrupt gradients via a shared receive buffer.

## Testing

Regression coverage in `test_pipeline_schedule_unit.py` drives the real `_1f1b_schedule` with a mocked `_send_recv_pipeline` and verifies:

- **Warmup→steady transition**: no forward step is fed `None`, and forward send/recv counts stay balanced across configurations, including `num_microbatches < pp_size` and the penultimate-stage (`W = 1`) case.
- **Clone plumbing**: `clone_recv=True` is threaded through the local `_p2p` wrapper.
- **Storage isolation**: forward inputs simultaneously retained for backward have distinct `data_ptr`s under the real schedule.
- **Negative control**: with `force_clone=False`, retained inputs share a `data_ptr` and all take the value of the last receive, reproducing the alias and confirming the test's discriminative power.


:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
