### PR TITLE
fix(multimodal): forward Qwen3.5-VL RoPE max sequence length

### DIFF
--- a/examples/multimodal_dev/models/qwen35_vl/specs.py
+++ b/examples/multimodal_dev/models/qwen35_vl/specs.py
@@ -19,7 +19,7 @@ from megatron.core.transformer.transformer_block import TransformerBlockSubmodul
 from megatron.core.transformer.transformer_config import TransformerConfig
 
 
-def _apply_rope_fp32(t, freqs, config, cu_seqlens=None, mscale=1.0, cp_group=None):
+def _apply_rope_fp32(t, freqs, config, cu_seqlens=None, mscale=1.0, cp_group=None, max_seqlen=None):
     """Apply rotary positional embedding in fp32, then cast back to original dtype.
 
     Mirrors ``Qwen3VLSelfAttention.apply_rotary_pos_emb_absolute`` in Megatron-Bridge
@@ -53,11 +53,14 @@ def _apply_rope_fp32(t, freqs, config, cu_seqlens=None, mscale=1.0, cp_group=Non
             multi_latent_attention=getattr(config, 'multi_latent_attention', False),
             mscale=mscale,
             cp_group=cp_group,
+            max_seqlen=max_seqlen,
         )
     return out.to(orig_dtype)
 
 
-def _apply_rope_fp32_no_cp(t, freqs, config, cu_seqlens=None, mscale=1.0, cp_group=None):
+def _apply_rope_fp32_no_cp(
+    t, freqs, config, cu_seqlens=None, mscale=1.0, cp_group=None, max_seqlen=None
+):
     """Same as ``_apply_rope_fp32`` but forces CP-size=1.
 
     The vision encoder uses THD packed sequences for variable-resolution
@@ -66,7 +69,13 @@ def _apply_rope_fp32_no_cp(t, freqs, config, cu_seqlens=None, mscale=1.0, cp_gro
     trivial group so the vision RoPE sees the full packed sequence.
     """
     return _apply_rope_fp32(
-        t, freqs, config, cu_seqlens, mscale, cp_group=_NO_CP_GROUP,
+        t,
+        freqs,
+        config,
+        cu_seqlens=cu_seqlens,
+        mscale=mscale,
+        cp_group=_NO_CP_GROUP,
+        max_seqlen=max_seqlen,
     )
 
 


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
  ## Summary

  Forward `max_seqlen` through the Qwen3.5-VL fp32 RoPE wrappers.

  The THD rotary embedding implementation now accepts `max_seqlen`. The Qwen3.5-VL wrapper must preserve this argument when:

  - Applying fp32 RoPE to packed vision sequences.
  - Replacing the context-parallel group with the trivial vision CP group.

  This keeps Qwen3.5-VL compatible with the updated RoPE API and ensures packed vision sequences use the correct maximum sequence length.

  This change was extracted from #5032 so it can be reviewed and merged independently.

  ## Testing

  - `ruff check examples/multimodal_dev/models/qwen35_vl/specs.py`
  - Exercised by a 20-step Qwen3.5-VL 35B-A3B training run.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
