### PR TITLE
fix: compute DTensor parameter norms in FP32

### DIFF
--- a/megatron/training/utils/common_utils.py
+++ b/megatron/training/utils/common_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 """General utilities."""
 import json
@@ -201,7 +201,10 @@ def calc_dtensor_params_l2_norm(params):
     """Calculate l2 norm of DTensor parameters."""
     params_data = defaultdict(list)
     for param in params:
-        params_data[param._spec].append(param._local_tensor)
+        local_tensor = param._local_tensor
+        if local_tensor.dtype != torch.float32 and local_tensor.numel() > 0:
+            local_tensor = local_tensor.float()
+        params_data[param._spec].append(local_tensor)
 
     total_norm_2 = torch.zeros((1,), dtype=torch.float32, device='cuda')
     dummy_overflow_buf = torch.zeros((1,), dtype=torch.int, device='cuda')

--- a/tests/unit_tests/test_utils.py
+++ b/tests/unit_tests/test_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import os
 import time
@@ -302,6 +302,33 @@ def test_param_norm_linear(use_distributed_optimizer: bool):
 
     # Teardown.
     _deinit_distributed()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_dtensor_param_norm_uses_fp32_local_shards():
+    """The fused L2 norm should receive FP32 DTensor local shards."""
+    placement = mock.Mock()
+    placement.is_shard.return_value = False
+    placement.is_replicate.return_value = True
+    spec = mock.Mock()
+    spec.device_mesh.get_all_groups.return_value = [None]
+    spec.placements = (placement,)
+
+    local_tensor = torch.tensor([3.0, 4.0], dtype=torch.bfloat16, device="cuda")
+    param = SimpleNamespace(_local_tensor=local_tensor, _spec=spec)
+
+    def l2_norm_stub(_op, _overflow_buf, tensor_lists, _per_parameter):
+        norm_inputs = tensor_lists[0]
+        assert all(tensor.dtype == torch.float32 for tensor in norm_inputs)
+        return torch.linalg.vector_norm(torch.cat(norm_inputs)), None
+
+    with mock.patch(
+        "megatron.training.utils.common_utils.multi_tensor_applier", side_effect=l2_norm_stub
+    ):
+        norm = training_util.calc_dtensor_params_l2_norm([param])
+
+    assert norm == pytest.approx(5.0)
+    assert local_tensor.dtype == torch.bfloat16
 
 
 @pytest.mark.parametrize("use_distributed_optimizer", [False, True])


### PR DESCRIPTION
- [ ] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
Convert non-empty DTensor local parameter shards to FP32 before the fused L2-norm reduction, preserve original parameter storage/dtype, and add a BF16 regression test.
## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
