### PR TITLE
[Dev] Log per-parameter norms with Megatron FSDP

### DIFF
--- a/docs/user-guide/features/megatron_fsdp.md
+++ b/docs/user-guide/features/megatron_fsdp.md
@@ -174,6 +174,10 @@ unset CUDA_DEVICE_MAX_CONNECTIONS
 --fsdp-manual-registration
 ```
 
+For debugging convergence, `--log-per-param-norm` logs each Megatron FSDP
+parameter's parameter and gradient L2 norm. It requires `--log-params-norm` and
+adds synchronization overhead, so it should be enabled only for diagnostic runs.
+
 ### 🤖 Megatron-Core
 
 Megatron-FSDP has a lower-level `FullyShardedDataParallel` class API that can be used with a simplified version of Megatron-LM's training loop.

--- a/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
+++ b/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -215,6 +215,7 @@ class FullyShardedDataParallel(_BaseDataParallel):
         self.finish_grad_sync = self.module.finish_grad_sync
         self.scale_gradients = self.module.scale_gradients
         self.zero_grad_buffer = self.module.zero_grad_buffer
+        self.log_per_param_norms = self.module._log_per_param_norms
         self.broadcast_params = self.module.broadcast_params
         self.synchronize_param_gather = self.module.synchronize_param_gather
         self.module.state_dict_for_save_checkpoint = self.module.state_dict

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
@@ -1436,6 +1436,55 @@ class MegatronFSDP(torch.nn.Module):
         """
         self.param_and_grad_buffer.copy_main_weights_to_model_weights()
 
+    @torch.no_grad()
+    def _compute_per_param_norms(self) -> Dict[str, Dict[str, float]]:
+        """Compute parameter and gradient L2 norms from optimizer-facing FSDP storage."""
+        results = {}
+        param_to_group = self.param_and_grad_buffer.param_to_param_group
+        sharded_params = self.data_parallel_sharding_strategy == "optim_grads_params"
+        sharded_grads = self.data_parallel_sharding_strategy != "no_shard"
+
+        for name, param in self.module.named_parameters():
+            if not param.requires_grad:
+                continue
+
+            local_param = to_local_if_dtensor(param)
+            param_sq = local_param.float().square().sum()
+            grad_sq = torch.zeros((), dtype=torch.float32, device=local_param.device)
+
+            group = self.param_and_grad_buffer.parameter_groups[param_to_group[param]]
+            grad_buffer = group.hfsdp_helper_gbuf or group.main_grad_buffer
+            if group.requires_grad and grad_buffer is not None and grad_buffer.data is not None:
+                local_grad = grad_buffer.get_item(group.param_idx[param], only_shard=True)
+                grad_sq = local_grad.float().square().sum()
+
+            is_expert_parallel = not getattr(param, "allreduce", True)
+            dp_group = self.dist_index.get_dp_group(is_expert_parallel=is_expert_parallel)
+            if sharded_params:
+                torch.distributed.all_reduce(param_sq, group=dp_group)
+            if sharded_grads:
+                torch.distributed.all_reduce(grad_sq, group=dp_group)
+
+            param_norm, grad_norm = torch.stack((param_sq, grad_sq)).sqrt().cpu().tolist()
+            results[name] = {"param_norm": param_norm, "grad_norm": grad_norm}
+
+        return results
+
+    def _log_per_param_norms(self, iteration: int, prefix: str = "") -> None:
+        """Log per-parameter parameter and gradient L2 norms on rank zero."""
+        norms = self._compute_per_param_norms()
+        if torch.distributed.get_rank() != 0:
+            return
+        for name in sorted(norms):
+            logger.info(
+                "%s iter=%d param=%s param_norm=%.6f grad_norm=%.6f",
+                prefix,
+                iteration,
+                name,
+                norms[name]["param_norm"],
+                norms[name]["grad_norm"],
+            )
+
     def broadcast_params(self):
         """
         Syncs parameters across all DP ranks.

--- a/megatron/training/config/training_config.py
+++ b/megatron/training/config/training_config.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 import signal
 from dataclasses import dataclass, field
 from typing import List, Literal, Optional
@@ -268,6 +268,12 @@ class LoggerConfig:
     log_params_norm: bool = False
     """If set, calculate and log parameters norm."""
 
+    log_per_param_norm: bool = False
+    """If set, log parameter and gradient norms for each Megatron FSDP parameter.
+
+    Requires ``log_params_norm`` because this diagnostic runs at the same logging point.
+    """
+
     log_throughput: bool = False
     """If set, calculate and log throughput per GPU."""
 
@@ -386,6 +392,10 @@ class LoggerConfig:
 
     save_config_filepath: str | None = None
     """If set, save the task configuration (ConfigContainer) to this file."""
+
+    def __post_init__(self):
+        if self.log_per_param_norm and not self.log_params_norm:
+            raise ValueError("log_per_param_norm requires log_params_norm")
 
 
 @dataclass(kw_only=True)

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 """Pretrain utilities."""
 import argparse
@@ -4279,6 +4279,12 @@ def train(
 
         if args.log_params_norm:
             params_norm = calc_params_l2_norm(model)
+            if args.log_per_param_norm:
+                model_chunks = model if isinstance(model, list) else [model]
+                for model_chunk in model_chunks:
+                    if not hasattr(model_chunk, 'log_per_param_norms'):
+                        raise RuntimeError("--log-per-param-norm currently requires Megatron FSDP.")
+                    model_chunk.log_per_param_norms(iteration, prefix="[PER-PARAM]")
         if optimizer is not None:
             learning_rate = get_canonical_lr_for_logging(optimizer.param_groups)
         else:

--- a/tests/unit_tests/distributed/megatron_fsdp/test_per_param_norm.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_per_param_norm.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+import torch
+
+from megatron.core.distributed.fsdp.src.megatron_fsdp.megatron_fsdp import MegatronFSDP
+
+
+class _GradBuffer:
+    def __init__(self, grad):
+        self.data = grad
+        self._grad = grad
+
+    def get_item(self, item_id, only_shard):
+        assert item_id == 0
+        assert only_shard
+        return self._grad
+
+
+def _fsdp_shell(strategy):
+    param = torch.nn.Parameter(torch.tensor([3.0, 4.0]))
+    module = torch.nn.Module()
+    module.register_parameter("weight", param)
+    grad_buffer = _GradBuffer(torch.tensor([5.0, 12.0]))
+    parameter_group = SimpleNamespace(
+        requires_grad=True,
+        hfsdp_helper_gbuf=None,
+        main_grad_buffer=grad_buffer,
+        param_idx={param: 0},
+    )
+
+    fsdp = object.__new__(MegatronFSDP)
+    torch.nn.Module.__init__(fsdp)
+    fsdp.module = module
+    fsdp.data_parallel_sharding_strategy = strategy
+    fsdp.param_and_grad_buffer = SimpleNamespace(
+        param_to_param_group={param: 0}, parameter_groups=[parameter_group]
+    )
+    fsdp.dist_index = SimpleNamespace(get_dp_group=Mock(return_value="dp-group"))
+    return fsdp, param
+
+
+@pytest.mark.parametrize(
+    ("strategy", "expected_collectives"),
+    [("no_shard", 0), ("optim", 1), ("optim_grads", 1), ("optim_grads_params", 2)],
+)
+def test_compute_per_param_norms_reduces_only_sharded_values(strategy, expected_collectives):
+    fsdp, _ = _fsdp_shell(strategy)
+
+    with patch("torch.distributed.all_reduce") as all_reduce:
+        norms = MegatronFSDP._compute_per_param_norms(fsdp)
+
+    assert norms == {"weight": {"param_norm": 5.0, "grad_norm": 13.0}}
+    assert all_reduce.call_count == expected_collectives
+    fsdp.dist_index.get_dp_group.assert_called_once_with(is_expert_parallel=False)
+
+
+def test_compute_per_param_norms_uses_expert_data_parallel_group():
+    fsdp, param = _fsdp_shell("optim_grads_params")
+    param.allreduce = False
+
+    with patch("torch.distributed.all_reduce"):
+        MegatronFSDP._compute_per_param_norms(fsdp)
+
+    fsdp.dist_index.get_dp_group.assert_called_once_with(is_expert_parallel=True)

--- a/tests/unit_tests/training/test_logger_config.py
+++ b/tests/unit_tests/training/test_logger_config.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import pytest
+
+from megatron.training.config.training_config import LoggerConfig
+
+
+def test_per_param_norm_requires_global_param_norm_logging():
+    with pytest.raises(ValueError, match="log_per_param_norm requires log_params_norm"):
+        LoggerConfig(log_per_param_norm=True)
+
+
+def test_per_param_norm_logging_accepts_complete_configuration():
+    config = LoggerConfig(log_params_norm=True, log_per_param_norm=True)
+
+    assert config.log_params_norm
+    assert config.log_per_param_norm


### PR DESCRIPTION
- [ ] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
## What changed

- Add `--log-per-param-norm` as an opt-in convergence diagnostic for Megatron FSDP.
- Log parameter and optimizer-facing gradient L2 norms for each trainable parameter.
- Use the expert data-parallel group for expert parameters.
- Reduce only values that are actually sharded by the selected FSDP strategy, avoiding duplicated norms for replicated parameters or gradients.
- Validate that per-parameter logging is enabled together with `--log-params-norm`.
- Fail clearly when the option is used with an unsupported non-FSDP wrapper instead of silently ignoring logging failures.
- Document the synchronization overhead and diagnostic-only intent.

## Motivation

A global parameter norm can show that two training runs diverged, but it cannot identify which parameter group diverged first. Per-parameter parameter and gradient norms make convergence comparisons between distributed implementations easier to diagnose.

This is intentionally split from the Megatron FSDP v2 prototype PR. The standalone PR contains the shared training/configuration surface and the existing Megatron FSDP implementation. The v2-specific implementation remains in the prototype until that implementation is available on the target branch.

## Usage

```bash
--log-params-norm \
--log-per-param-norm
```

Example output:

```text
[PER-PARAM] iter=10 param=decoder.layers.0.self_attention.linear_qkv.weight param_norm=12.345678 grad_norm=0.012345
```

This option performs additional reductions and device-to-host synchronization for logging. It should be used for diagnostic runs rather than throughput benchmarks.

## Validation

- Added strategy coverage for `no_shard`, `optim`, `optim_grads`, and `optim_grads_params`.
- Added expert data-parallel group selection coverage.
- Added configuration validation coverage.
- `ruff check` passed for all changed Python files.
- `black --check` passed for all changed Python files.
- `tools/check_copyright.py` passed for all changed Python files.
- `py_compile` and `git diff --check` passed.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
