### PR TITLE
Avoid per-segment GPU->CPU syncs in the unfused DSA THD helpers

### DIFF
--- a/megatron/core/transformer/experimental_attention_variant/dsa.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa.py
@@ -477,11 +477,18 @@ def fused_qk_topk_naive_thd(
 
     topk_thd = torch.full((total_q, index_topk), -1, dtype=torch.int64, device=device)
 
+    # Copy the cumulative-sequence-length offsets to host once (two D2H
+    # syncs) rather than calling ``.item()`` four times per segment (4*B
+    # device->host syncs). The integer offsets are identical; only the
+    # number of GPU->CPU synchronisations changes.
+    cu_seqlens_q_host = cu_seqlens_q.tolist()
+    cu_seqlens_kv_host = cu_seqlens_kv.tolist()
+
     for b in range(B):
-        q_start = int(cu_seqlens_q[b].item())
-        q_end = int(cu_seqlens_q[b + 1].item())
-        k_start = int(cu_seqlens_kv[b].item())
-        k_end = int(cu_seqlens_kv[b + 1].item())
+        q_start = cu_seqlens_q_host[b]
+        q_end = cu_seqlens_q_host[b + 1]
+        k_start = cu_seqlens_kv_host[b]
+        k_end = cu_seqlens_kv_host[b + 1]
         sq_b = q_end - q_start
         sk_b = k_end - k_start
         if sq_b == 0 or sk_b == 0:
@@ -829,11 +836,18 @@ def fwd_fused_indexer_loss_naive_thd(
     topk_indices_thd = torch.full((total_q, topk), -1, dtype=torch.int32, device=device)
     weighted_losses = []
 
+    # Copy the cumulative-sequence-length offsets to host once (two D2H
+    # syncs) rather than calling ``.item()`` four times per segment (4*B
+    # device->host syncs). The integer offsets are identical; only the
+    # number of GPU->CPU synchronisations changes.
+    cu_seqlens_q_host = cu_seqlens_q.tolist()
+    cu_seqlens_compressed_idx_host = cu_seqlens_compressed_idx.tolist()
+
     for b in range(B):
-        q_start = int(cu_seqlens_q[b].item())
-        q_end = int(cu_seqlens_q[b + 1].item())
-        k_start = int(cu_seqlens_compressed_idx[b].item())
-        k_end = int(cu_seqlens_compressed_idx[b + 1].item())
+        q_start = cu_seqlens_q_host[b]
+        q_end = cu_seqlens_q_host[b + 1]
+        k_start = cu_seqlens_compressed_idx_host[b]
+        k_end = cu_seqlens_compressed_idx_host[b + 1]
         seqlen_q_b = q_end - q_start
         seqlen_k_b = k_end - k_start
         if seqlen_q_b == 0 or seqlen_k_b == 0:
@@ -933,11 +947,18 @@ def bwd_fused_indexer_loss_naive_thd(
     grad_weights = torch.zeros_like(weights)
     grad_k = torch.zeros_like(k)
 
+    # Copy the cumulative-sequence-length offsets to host once (two D2H
+    # syncs) rather than calling ``.item()`` four times per segment (4*B
+    # device->host syncs). The integer offsets are identical; only the
+    # number of GPU->CPU synchronisations changes.
+    cu_seqlens_q_host = cu_seqlens_q.tolist()
+    cu_seqlens_compressed_idx_host = cu_seqlens_compressed_idx.tolist()
+
     for b in range(B):
-        q_start = int(cu_seqlens_q[b].item())
-        q_end = int(cu_seqlens_q[b + 1].item())
-        k_start = int(cu_seqlens_compressed_idx[b].item())
-        k_end = int(cu_seqlens_compressed_idx[b + 1].item())
+        q_start = cu_seqlens_q_host[b]
+        q_end = cu_seqlens_q_host[b + 1]
+        k_start = cu_seqlens_compressed_idx_host[b]
+        k_end = cu_seqlens_compressed_idx_host[b + 1]
         seqlen_q_b = q_end - q_start
         seqlen_k_b = k_end - k_start
         if seqlen_q_b == 0 or seqlen_k_b == 0:


### PR DESCRIPTION
### What
The unfused THD helpers `fused_qk_topk_naive_thd`, `fwd_fused_indexer_loss_naive_thd` and `bwd_fused_indexer_loss_naive_thd` read the cumulative-sequence-length offsets inside the per-segment loop:

```python
for b in range(B):
    q_start = int(cu_seqlens_q[b].item())
    q_end   = int(cu_seqlens_q[b + 1].item())
    k_start = int(cu_seqlens_x[b].item())
    k_end   = int(cu_seqlens_x[b + 1].item())
```

Each `.item()` is a device->host copy plus a stream synchronize, so the loop issues `4*B` GPU->CPU syncs per call.

### Change
Hoist the two offset tensors to host once with `.tolist()` (2 syncs total, independent of `B`) and index the resulting Python lists.

### Why it's safe
`.tolist()` yields the same Python ints as the per-element `.item()` calls, so every slice bound is unchanged -- behaviour is bitwise-identical. Only the number of GPU->CPU synchronizations changes: `4*B` -> `2` per call.

### Impact
Removes `4*B - 2` device->host synchronizations per call in each helper; the saving grows with batch size. These are `_naive`/unfused reference helpers, so the change is purely host-side loop hygiene with no effect on the compute path.

One of two small, independent host-side sync-reduction fixes in the experimental sparse-attention variants.