### PR TITLE
Disable TE CUDA graph parameter gradient clones

### DIFF
--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -2707,6 +2707,10 @@ class TECudaGraphHelper:
                 # Starting from TE 2.7.0, make_graphed_callables() optimizes the graph memory usage
                 # by reusing input/output data buffers between graphs.
                 kwargs['_reuse_graph_input_output_buffers'] = True
+            if is_te_min_version("2.19.0"):
+                # MCore consumes parameter gradients through its accumulation hooks during each
+                # replay, before TE can overwrite the static buffers on a later replay.
+                kwargs['clone_param_grads_on_return'] = False
 
             if sample_kwargs:
                 kwargs['sample_kwargs'] = sample_kwargs

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -104,6 +104,14 @@ def get_gtp_runner_streams() -> List[torch.cuda.Stream]:
     return _GTP_RUNNER_STREAMS
 
 
+def _set_te_param_grad_clone_policy(kwargs: Dict[str, Any]) -> None:
+    """Disable TE parameter-gradient clones when the public option is available."""
+    if 'clone_param_grads_on_return' in inspect.signature(make_graphed_callables).parameters:
+        # MCore consumes parameter gradients through its accumulation hooks during each replay,
+        # before TE can overwrite the static gradient buffers on a later replay.
+        kwargs['clone_param_grads_on_return'] = False
+
+
 def _set_skip_fp8_weight_update_tensor(skip: bool) -> None:
     """Toggle TE's FP8 "skip weight refresh" flag between microbatches.
 
@@ -2437,6 +2445,7 @@ class TECudaGraphHelper:
                 # Starting from TE 2.7.0, make_graphed_callables() optimizes the graph memory usage
                 # by reusing input/output data buffers between graphs.
                 kwargs['_reuse_graph_input_output_buffers'] = True
+            _set_te_param_grad_clone_policy(kwargs)
 
             if sample_kwargs:
                 kwargs['sample_kwargs'] = sample_kwargs

--- a/tests/unit_tests/transformer/test_cuda_graphs.py
+++ b/tests/unit_tests/transformer/test_cuda_graphs.py
@@ -1230,6 +1230,10 @@ class TestTECudaGraphHelper:
         assert (
             'sample_kwargs' in make_graphed_callables_kwargs
         ), "sample_kwargs should be present in make_graphed_callables_kwargs for TE >= 1.10.0"
+        if is_te_min_version("2.19.0"):
+            assert make_graphed_callables_kwargs['clone_param_grads_on_return'] is False
+        else:
+            assert 'clone_param_grads_on_return' not in make_graphed_callables_kwargs
         sample_kwargs = make_graphed_callables_kwargs['sample_kwargs']
 
         # Basic checks

--- a/tests/unit_tests/transformer/test_cuda_graphs.py
+++ b/tests/unit_tests/transformer/test_cuda_graphs.py
@@ -35,6 +35,7 @@ from megatron.core.transformer.cuda_graphs import (
     CudaGraphManager,
     TECudaGraphHelper,
     _CudagraphGlobalRecord,
+    _set_te_param_grad_clone_policy,
     create_cudagraphs,
 )
 from megatron.core.transformer.enums import CudaGraphModule, CudaGraphScope, InferenceCudaGraphScope
@@ -976,6 +977,32 @@ class TestParallelHybridBlockCudagraphs:
 # Global storage for comparing unique buffer counts across different num_microbatches,
 # keyed by (pp_size, vpp_size)
 _unique_buffer_counts = {}
+
+
+def test_set_te_param_grad_clone_policy(monkeypatch):
+    """MCore opts out through the public TE API while remaining compatible with older TE."""
+
+    def make_graphed_callables_with_clone_policy(*, clone_param_grads_on_return=True):
+        return clone_param_grads_on_return
+
+    monkeypatch.setattr(
+        'megatron.core.transformer.cuda_graphs.make_graphed_callables',
+        make_graphed_callables_with_clone_policy,
+    )
+    kwargs = {}
+    _set_te_param_grad_clone_policy(kwargs)
+    assert kwargs['clone_param_grads_on_return'] is False
+
+    def legacy_make_graphed_callables():
+        return None
+
+    monkeypatch.setattr(
+        'megatron.core.transformer.cuda_graphs.make_graphed_callables',
+        legacy_make_graphed_callables,
+    )
+    kwargs = {}
+    _set_te_param_grad_clone_policy(kwargs)
+    assert 'clone_param_grads_on_return' not in kwargs
 
 
 class TestTECudaGraphHelper:


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Disable Transformer Engine parameter-gradient clones for MCore CUDA graphs with Transformer Engine 2.19.0 and later.

Transformer Engine's `clone_param_grads_on_return` option keeps parameter-gradient outputs stable across later graph replays. MCore consumes parameter gradients through its accumulation hooks during each replay, before those static buffers can be overwritten, so retaining cloned gradients is unnecessary and extends their lifetime.

This change passes `clone_param_grads_on_return=False` when the installed Transformer Engine version is at least 2.19.0. Older Transformer Engine versions remain supported because MCore does not pass the new keyword to them.

## Issue tracking

Related to NVIDIA/TransformerEngine#2937.

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Validation

- Existing `TECudaGraphHelper` coverage now checks the final `make_graphed_callables` kwargs for both sides of the TE 2.19.0 version boundary.
- `tests/unit_tests/transformer/test_cuda_graphs.py` passed in the MCore CI container on eight H100 ranks: 67 passed, 3 skipped, and 20 deselected per active rank.
- Black, isort, pylint, ruff, Python compilation, and `git diff --check` passed.

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate review once CI is green.
