### PR TITLE
fix: exclude bucket-end padding from optimizer checkpoints

### DIFF
--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -1856,6 +1856,13 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                     assert gbuf_world_numel_unpadded <= gbuf_world_numel
                     assert gbuf_world_numel % data_parallel_world_size == 0
                     gbuf_local_numel = gbuf_world_numel // data_parallel_world_size
+                    gbuf_local_numel_unpadded = max(
+                        0,
+                        min(
+                            gbuf_local_numel,
+                            gbuf_world_numel_unpadded - data_parallel_rank * gbuf_local_numel,
+                        ),
+                    )
 
                     sharded_bucket_key = (
                         f'optimizer.distributed.dp_group_idx_{self.data_parallel_group_idx}'
@@ -1870,8 +1877,9 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                     all_pad_tensors = {}
                     for i in range(-1, len(bucket_state)):
                         if i == len(bucket_state) - 1:
-                            # Potential padding at the end
-                            next_param_start = gbuf_local_numel
+                            # Potential intra-param padding at the end. Exclude the
+                            # bucket-end padding beyond the global unpadded boundary.
+                            next_param_start = gbuf_local_numel_unpadded
                         else:
                             next_param_start = bucket_state[i + 1]['gbuf_local_start']
                         if i == -1:

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -1856,6 +1856,9 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                     assert gbuf_world_numel_unpadded <= gbuf_world_numel
                     assert gbuf_world_numel % data_parallel_world_size == 0
                     gbuf_local_numel = gbuf_world_numel // data_parallel_world_size
+                    # Number of elements in this rank's DP-local bucket shard that fall within the
+                    # global unpadded range. This is the full local size on earlier ranks, partial
+                    # on the boundary rank, and zero on ranks containing only bucket-end padding.
                     gbuf_local_numel_unpadded = max(
                         0,
                         min(

--- a/tests/unit_tests/dist_checkpointing/test_optimizer.py
+++ b/tests/unit_tests/dist_checkpointing/test_optimizer.py
@@ -388,6 +388,27 @@ class TestDistributedOptimizer:
         optimizer_state = optimizer.sharded_state_dict(
             {}, metadata={'distrib_optim_sharding_type': 'dp_reshardable'}
         )
+        param_state = optimizer_state['param_state']
+        per_bucket_numel = next(iter(param_state['per_bucket_numel'].data[0].values()))
+        per_bucket_numel_unpadded = next(
+            iter(param_state['per_bucket_numel_unpadded'].data[0].values())
+        )
+        assert per_bucket_numel == [1152, 1024]
+        assert per_bucket_numel_unpadded == [1088, 1024]
+
+        assert parallel_state.get_data_parallel_world_size(with_context_parallel=True) == 8
+        if parallel_state.get_data_parallel_rank(with_context_parallel=True) == 7:
+            sharded_tensors = nested_values(extract_sharded_tensors(optimizer_state)[0])
+            terminal_padding = [
+                sharded_tensor
+                for sharded_tensor in sharded_tensors
+                if '.bucket_idx_0.' in sharded_tensor.key
+                and sharded_tensor.global_offset == (1060,)
+            ]
+            assert len(terminal_padding) == 3
+            assert all(tensor.local_shape == (28,) for tensor in terminal_padding)
+            assert all(tensor.global_shape == (1088,) for tensor in terminal_padding)
+
         with TempNamedDir(tmp_path_dist_ckpt / 'test_bucket_end_padding', sync=True) as ckpt_dir:
             save(optimizer_state, ckpt_dir)
 

--- a/tests/unit_tests/dist_checkpointing/test_optimizer.py
+++ b/tests/unit_tests/dist_checkpointing/test_optimizer.py
@@ -193,6 +193,20 @@ class Model1dFlattenTensor(torch.nn.Module):
         return sharded_state_dict
 
 
+class SharedEmbeddingBoundaryModel(torch.nn.Module):
+    """Small model whose shared embedding split leaves bucket-end padding."""
+
+    def __init__(self):
+        super().__init__()
+        self.shared_weight = torch.nn.Parameter(torch.randn(1024, dtype=torch.bfloat16))
+        self.shared_weight.shared_embedding = True
+        self.tail_weight = torch.nn.Parameter(torch.randn(100, dtype=torch.bfloat16))
+        self.body_weight = torch.nn.Parameter(torch.randn(900, dtype=torch.bfloat16))
+        self.config = TransformerConfig(
+            hidden_size=8, num_attention_heads=1, num_layers=1, bf16=True
+        )
+
+
 def get_param_state_dp_zero(optimizer):
     if isinstance(optimizer, ChainedOptimizer):
         assert len(optimizer.chained_optimizers) == 1
@@ -266,6 +280,15 @@ def initialize_1d_flatten_tensor_model(
     model_parallel_cuda_manual_seed(seed)
 
     return Model1dFlattenTensor()
+
+
+def initialize_shared_embedding_boundary_model(
+    pre_process=True, post_process=True, seed=0, **config_kwargs
+):
+    torch.manual_seed(seed)
+    model_parallel_cuda_manual_seed(seed)
+
+    return SharedEmbeddingBoundaryModel()
 
 
 def initialize_real_model(
@@ -346,6 +369,27 @@ class TestDistributedOptimizer:
 
     def teardown_method(self, method):
         Utils.destroy_model_parallel()
+
+    @pytest.mark.skipif(
+        not is_torch_min_version("2.6a0"), reason="dp_reshardable requires PyTorch 2.6a0 or later"
+    )
+    def test_dp_reshardable_excludes_bucket_end_padding(self, tmp_path_dist_ckpt):
+        """Test that shared-embedding bucket splits exclude DP bucket-end padding."""
+        Utils.initialize_model_parallel(1, 1)
+        _, optimizer = setup_model_and_optimizer(
+            seed=2,
+            tp=1,
+            pp=1,
+            bf16=True,
+            dist_opt=True,
+            initialize_fn=initialize_shared_embedding_boundary_model,
+        )
+
+        optimizer_state = optimizer.sharded_state_dict(
+            {}, metadata={'distrib_optim_sharding_type': 'dp_reshardable'}
+        )
+        with TempNamedDir(tmp_path_dist_ckpt / 'test_bucket_end_padding', sync=True) as ckpt_dir:
+            save(optimizer_state, ckpt_dir)
 
     @pytest.mark.parametrize("fully_parallel", [False, True])
     @pytest.mark.parametrize(


### PR DESCRIPTION
# What does this PR do?

## The problem

Saving a `dp_reshardable` distributed-optimizer checkpoint could fail whenever a bucket carried DP/alignment padding and a rank's final shard mixed two different kinds of padding: valid intra-bucket padding that belongs in the checkpoint, and runtime bucket-end padding that does not. Because the shard was allowed to run all the way to the physical bucket end, it extended past the bucket's declared *unpadded* global size. PyTorch distributed checkpointing then rejected the global save plan and left an incomplete checkpoint behind.

We first hit this in a Nemotron Super PP=2 run, where a shared-embedding bucket boundary produces exactly this geometry — but the bug is not specific to PP=2. Any topology that lands a bucket boundary in the same place is affected.

## The fix

Clip each rank's terminal padding shard to the global unpadded bucket boundary instead of to the physical bucket end. This emits only the valid checkpoint-layout padding and drops the runtime-only bucket tail, yielding a save plan that PyTorch distributed checkpointing accepts for any topology with this bucket geometry.

## Testing

A new DP=8 regression test pins the affected padded/unpadded bucket sizes and the terminal shard geometry, then performs a full distributed-checkpoint save to confirm the plan validates.

<details>
<summary>Concrete failing example, with the numbers worked out</summary>

With PP=2, Nemotron Super isolates its shared embedding copy in its own optimizer bucket. That shifts the *preceding* bucket's boundary, and in the failing run the dense DP size was 8.

Two distinct kinds of padding meet at that boundary:

1. **Checkpoint-layout padding (64-element parameter alignment).** The last real optimizer-state chunk ends at global offset 4,256. Parameter starts must be aligned to multiples of 64, so the next aligned position is:

   ```text
   ceil(4256 / 64) * 64 = 4288
   ```

   Hence `gbuf_world_numel_unpadded = 4288`. The range `[4256, 4288)` is a 32-element alignment gap that *is* part of the logical checkpoint layout.

2. **Runtime bucket-end padding (DP/128 alignment).** The physical bucket end is aligned to `lcm(DP, 128)`:

   ```text
   lcm(8, 128) = 128
   ceil(4288 / 128) * 128 = 4352
   ```

   Hence `gbuf_world_numel = 4352`. The range `[4288, 4352)` is 64 elements of runtime-only bucket-end padding that must **not** be checkpointed.

Each DP rank owns an equal physical slice:

```text
gbuf_local_numel = gbuf_world_numel / DP
                 = 4352 / 8
                 = 544
```

For DP rank 7, the part of its slice that lies inside the logical checkpoint is:

```text
gbuf_local_numel_unpadded
    = clamp(gbuf_world_numel_unpadded - rank * gbuf_local_numel,
            0,
            gbuf_local_numel)
    = clamp(4288 - 7 * 544, 0, 544)
    = 480
```

Rank 7 starts at global offset `7 * 544 = 3808`, and its last real optimizer-state chunk ends at local offset `4256 - 3808 = 448`. So the correct terminal checkpoint padding is `[448, 480)` — 32 elements.

The old code instead extended that padding to `gbuf_local_numel = 544`, giving `[448, 544)` — 96 elements. Globally that shard spanned `[4256, 4352)`, overshooting the declared checkpoint shape of 4,288 by 64 elements. It hit `param`, `exp_avg`, and `exp_avg_sq` alike, and caused PyTorch distributed checkpointing to reject the save plan with `ValueError: Failed to validate global plan`.

This PR uses `gbuf_local_numel_unpadded` as the terminal padding endpoint, so it emits only the valid 32-element checkpoint-layout gap and excludes the 64-element runtime bucket tail.

</details>

- [x] I, the PR author, have personally reviewed every line of this PR.

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge this PR.
