### PR TITLE
[dev] lite:Add GLM5.2 IndexShare DSA support

### DIFF
--- a/experimental/lite/megatron/lite/model/glm5/config.py
+++ b/experimental/lite/megatron/lite/model/glm5/config.py
@@ -13,15 +13,16 @@ from megatron.lite.primitive.config import load_hf_config_dict
 _HF_FIELDS = frozenset(
     {
         "attention_dropout",
-        "calculate_per_token_loss",
-        "dsa_indexer_loss_coeff",
-        "dsa_indexer_use_sparse_loss",
         "first_k_dense_replace",
         "head_dim",
         "hidden_size",
         "index_head_dim",
         "index_n_heads",
+        "index_share_for_mtp_iteration",
+        "index_skip_topk_offset",
         "index_topk",
+        "index_topk_freq",
+        "indexer_types",
         "indexer_layer_norm_eps",
         "indexer_rope_interleave",
         "indexer_rope_first",
@@ -59,6 +60,33 @@ _HF_FIELDS = frozenset(
 )
 
 
+_INDEXER_TYPES = frozenset({"full", "shared"})
+
+
+def _infer_dsa_indexer_type(layer_number: int, *, topk_freq: int, skip_topk_offset: int) -> str:
+    if topk_freq <= 1:
+        return "full"
+    skip_topk = (max(layer_number - skip_topk_offset, 0) % topk_freq) != 0
+    return "shared" if skip_topk else "full"
+
+
+def _source_dsa_compute_layer(layer_number: int, *, topk_freq: int, skip_topk_offset: int) -> int:
+    if (
+        _infer_dsa_indexer_type(
+            layer_number, topk_freq=topk_freq, skip_topk_offset=skip_topk_offset
+        )
+        == "full"
+    ):
+        return layer_number
+    source_layer = layer_number - (max(layer_number - skip_topk_offset, 0) % topk_freq)
+    if source_layer < 1:
+        raise ValueError(
+            "DSA IndexShare schedule makes layer "
+            f"{layer_number} shared before any full source layer."
+        )
+    return source_layer
+
+
 @dataclass
 class Glm5Config:
     """Pure GLM-5 MoE + MLA + DSA architecture parameters."""
@@ -84,13 +112,14 @@ class Glm5Config:
     index_head_dim: int = 128
     index_n_heads: int = 32
     index_topk: int = 2048
+    index_topk_freq: int = 1
+    index_skip_topk_offset: int = 0
+    indexer_types: list[str] | None = None
+    index_share_for_mtp_iteration: bool = False
     indexer_layer_norm_eps: float = 1e-6
     indexer_rope_interleave: bool = False
     indexer_rope_first: bool = True
     indexer_use_hadamard: bool = False
-    dsa_indexer_loss_coeff: float = 0.0
-    dsa_indexer_use_sparse_loss: bool = False
-    calculate_per_token_loss: bool = False
     rope_interleave: bool = False
     rope_theta: float = 1_000_000.0
     latent_rms_norm_eps: float = 1e-6
@@ -122,6 +151,34 @@ class Glm5Config:
             return self.mlp_layer_types[layer_idx] == "sparse"
         return layer_idx >= self.first_k_dense_replace
 
+    @property
+    def uses_dsa_index_share(self) -> bool:
+        return self.index_topk_freq > 1
+
+    def dsa_indexer_type(self, layer_idx: int) -> str:
+        if layer_idx < 0:
+            raise ValueError(f"layer_idx must be non-negative, got {layer_idx}")
+        if layer_idx < self.num_hidden_layers and self.indexer_types is not None:
+            return self.indexer_types[layer_idx]
+        return _infer_dsa_indexer_type(
+            layer_idx + 1,
+            topk_freq=self.index_topk_freq,
+            skip_topk_offset=self.index_skip_topk_offset,
+        )
+
+    def builds_dsa_indexer(self, layer_idx: int) -> bool:
+        return self.dsa_indexer_type(layer_idx) == "full"
+
+    def dsa_indexer_source_layer(self, layer_idx: int) -> int:
+        return (
+            _source_dsa_compute_layer(
+                layer_idx + 1,
+                topk_freq=self.index_topk_freq,
+                skip_topk_offset=self.index_skip_topk_offset,
+            )
+            - 1
+        )
+
     def _validate(self) -> None:
         errors: list[str] = []
 
@@ -141,7 +198,11 @@ class Glm5Config:
             self.index_head_dim >= self.qk_rope_head_dim,
             "index_head_dim must be >= qk_rope_head_dim",
         )
-        check(self.dsa_indexer_loss_coeff >= 0.0, "dsa_indexer_loss_coeff must be >= 0")
+        check(self.index_topk_freq >= 1, "index_topk_freq must be >= 1")
+        check(
+            self.index_skip_topk_offset >= 0,
+            "index_skip_topk_offset must be >= 0",
+        )
         check(
             self.num_key_value_heads == self.num_attention_heads,
             "initial GLM5 native path expects MLA heads to be ungrouped",
@@ -169,6 +230,42 @@ class Glm5Config:
                     layer_type in {"dense", "sparse"},
                     f"mlp_layer_types[{idx}] must be 'dense' or 'sparse'",
                 )
+
+        if self.indexer_types is not None:
+            check(
+                len(self.indexer_types) == self.num_hidden_layers,
+                "len(indexer_types) must equal num_hidden_layers",
+            )
+            for idx, indexer_type in enumerate(self.indexer_types):
+                check(
+                    indexer_type in _INDEXER_TYPES,
+                    f"indexer_types[{idx}] must be 'full' or 'shared'",
+                )
+
+        if self.index_topk_freq >= 1 and self.index_skip_topk_offset >= 0:
+            layer_count = self.num_hidden_layers + self.num_nextn_predict_layers
+            for layer_idx in range(layer_count):
+                try:
+                    _source_dsa_compute_layer(
+                        layer_idx + 1,
+                        topk_freq=self.index_topk_freq,
+                        skip_topk_offset=self.index_skip_topk_offset,
+                    )
+                except ValueError as exc:
+                    check(False, str(exc))
+
+            if self.indexer_types is not None and len(self.indexer_types) == self.num_hidden_layers:
+                for idx, indexer_type in enumerate(self.indexer_types):
+                    expected = _infer_dsa_indexer_type(
+                        idx + 1,
+                        topk_freq=self.index_topk_freq,
+                        skip_topk_offset=self.index_skip_topk_offset,
+                    )
+                    check(
+                        indexer_type == expected,
+                        f"indexer_types[{idx}]={indexer_type!r} does not match "
+                        f"index_topk_freq/index_skip_topk_offset schedule {expected!r}",
+                    )
 
         if errors:
             raise ValueError(

--- a/experimental/lite/megatron/lite/model/glm5/lite/checkpoint.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/checkpoint.py
@@ -28,11 +28,7 @@ import torch.nn as nn
 from torch.distributed.tensor import Replicate, Shard
 
 from megatron.lite.model.glm5.config import Glm5Config
-from megatron.lite.primitive.ckpt.hf_weights import (
-    SafeTensorReader,
-    parse_expert_idx,
-    unwrap_model,
-)
+from megatron.lite.primitive.ckpt.hf_weights import SafeTensorReader, parse_expert_idx, unwrap_model
 from megatron.lite.primitive.parallel import ParallelState
 from megatron.lite.primitive.utils import ensure_divisible, log_rank0
 
@@ -181,6 +177,7 @@ def _load_attention(
     hf_prefix: str,
     reader: SafeTensorReader,
     ps: ParallelState,
+    load_indexer: bool = True,
 ) -> None:
     # GLM-5 ONLY: DSA attention.  Native params live under
     # `<local_prefix>.self_attention.self_attention.*` (the wrapper adds one
@@ -190,12 +187,15 @@ def _load_attention(
     out[f"{ap}.q_a_proj.weight"] = _get(reader, f"{hf_prefix}.q_a_proj.weight")
     out[f"{ap}.q_a_layernorm.weight"] = _get(reader, f"{hf_prefix}.q_a_layernorm.weight")
     out[f"{ap}.q_b_proj.weight"] = _get(reader, f"{hf_prefix}.q_b_proj.weight")
-    out[f"{ap}.kv_a_proj_with_mqa.weight"] = _get(
-        reader, f"{hf_prefix}.kv_a_proj_with_mqa.weight"
-    )
+    out[f"{ap}.kv_a_proj_with_mqa.weight"] = _get(reader, f"{hf_prefix}.kv_a_proj_with_mqa.weight")
     out[f"{ap}.kv_a_layernorm.weight"] = _get(reader, f"{hf_prefix}.kv_a_layernorm.weight")
     out[f"{ap}.kv_b_proj.weight"] = _get(reader, f"{hf_prefix}.kv_b_proj.weight")
     out[f"{ap}.o_proj.weight"] = _get(reader, f"{hf_prefix}.o_proj.weight")
+    # GLM5.2 shared IndexShare layers do not instantiate a local indexer and
+    # their HF checkpoints do not carry self_attn.indexer.* tensors.
+    if not load_indexer:
+        return
+
     # DSA indexer.
     ip = f"{ap}.indexer"
     hip = f"{hf_prefix}.indexer"
@@ -409,6 +409,11 @@ class Glm5WeightSpec:
         if suffix == "input_layernorm.weight":
             return [(f"{hp}.input_layernorm.weight", tensor)]
 
+        if suffix.startswith(
+            "self_attention.self_attention.indexer."
+        ) and not self.config.builds_dsa_indexer(layer_idx):
+            return []
+
         # GLM-5 ONLY: DSA attention (incl. indexer) maps 1:1 onto self_attn.*.
         attn_hf = self._ATTN_SUFFIX_MAP.get(suffix)
         if attn_hf is not None:
@@ -530,6 +535,7 @@ def load_hf_weights(model: nn.Module, path: str, config: Glm5Config, ps: Paralle
             hf_prefix=f"{hp}.self_attn",
             reader=reader,
             ps=ps,
+            load_indexer=config.builds_dsa_indexer(global_idx),
         )
         if config.is_moe_layer(global_idx):
             out[f"{lp}.mlp_norm.weight"] = _get(reader, f"{hp}.post_attention_layernorm.weight")
@@ -586,6 +592,7 @@ def load_hf_weights(model: nn.Module, path: str, config: Glm5Config, ps: Paralle
                 hf_prefix=f"{hp}.self_attn",
                 reader=reader,
                 ps=ps,
+                load_indexer=config.builds_dsa_indexer(global_idx),
             )
             if config.is_moe_layer(global_idx):
                 out[f"{tlp}.mlp_norm.weight"] = _get(

--- a/experimental/lite/megatron/lite/model/glm5/lite/model.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/model.py
@@ -14,7 +14,7 @@ uses ``MultiLatentAttention`` (MLA), GLM-5 uses Dynamic Sparse Attention (DSA).
 The DSA primitive is hard-wired batch-first ``[B, S, H]`` and expects explicit
 ``cos`` / ``sin`` / ``position_ids`` + ``packed_seq_params``, so it is wrapped
 by ``Glm5DSAAttention`` which transposes ``[S, B, H] -> [B, S, H]`` before DSA
-and back after, and builds the rotary embeddings / position ids locally.  The
+and back after, and builds rotary embeddings from protocol-provided positions.
 surrounding Kimi skeleton therefore stays byte-for-byte SBHD and untouched.
 
 NOTE: DSA is NOT tensor-parallel-capable, so GLM-5 is a documented TP=1 special
@@ -35,9 +35,12 @@ import torch.nn.functional as F
 import transformer_engine.pytorch as te
 
 from megatron.lite.model.glm5.config import Glm5Config
+from megatron.lite.primitive.kernels.swiglu import bias_swiglu_impl
 from megatron.lite.primitive.modules.attention import (
+    DSAIndexShareState,
     DynamicSparseAttention,
     build_rotary_embeddings,
+    dsa,
 )
 from megatron.lite.primitive.modules.dispatcher import TokenDispatcher
 from megatron.lite.primitive.modules.experts import Experts
@@ -47,7 +50,6 @@ from megatron.lite.primitive.ops.cross_entropy import vocab_parallel_cross_entro
 from megatron.lite.primitive.ops.linear_cross_entropy import linear_cross_entropy
 from megatron.lite.primitive.ops.logprob import vocab_parallel_entropy
 from megatron.lite.primitive.ops.sp_ops import ReduceScatterDim0
-from megatron.lite.primitive.kernels.swiglu import bias_swiglu_impl
 from megatron.lite.primitive.parallel import (
     ColumnParallelLinear,
     ParallelState,
@@ -60,6 +62,7 @@ from megatron.lite.primitive.parallel import (
     roll_packed_thd_left,
     scatter_to_sequence_parallel,
 )
+from megatron.lite.primitive.parallel.cp import contiguous_position_ids_for_cp
 from megatron.lite.primitive.utils import build_fp8_recipe
 from megatron.lite.primitive.utils.moe import (
     compute_routing_scores_for_aux_loss,
@@ -153,13 +156,24 @@ class Glm5DSAAttention(nn.Module):
     where ``x_sbhd`` is ``[S, B, H]``.  DSA is hard-wired ``[B, S, H]`` and needs
     explicit ``cos`` / ``sin`` / ``position_ids``.  This wrapper:
       1. transposes ``[S, B, H] -> [B, S, H]``,
-      2. builds ``position_ids`` (local sequence) and the rotary ``cos`` / ``sin``,
+      2. consumes explicit packed/CP ``position_ids`` and builds rotary
+         ``cos`` / ``sin``,
       3. runs DSA,
       4. transposes the ``[B, S, H]`` output back to ``[S, B, H]``.
     The Kimi skeleton therefore never observes the batch-first interior.
     """
 
-    def __init__(self, config: Glm5Config, ps: ParallelState):
+    def __init__(
+        self,
+        config: Glm5Config,
+        ps: ParallelState,
+        layer_idx: int,
+        *,
+        dsa_cp_mode: str = "native",
+        dsa_indexer_loss_coeff: float = 0.0,
+        dsa_indexer_use_sparse_loss: bool = False,
+        calculate_per_token_loss: bool = False,
+    ):
         super().__init__()
         self.ps = ps
         self.qk_rope_head_dim = config.qk_rope_head_dim
@@ -182,25 +196,60 @@ class Glm5DSAAttention(nn.Module):
             indexer_rope_interleaved=config.indexer_rope_interleave,
             indexer_rope_first=config.indexer_rope_first,
             indexer_use_hadamard=config.indexer_use_hadamard,
-            indexer_loss_coeff=config.dsa_indexer_loss_coeff,
-            indexer_use_sparse_loss=config.dsa_indexer_use_sparse_loss,
-            calculate_per_token_loss=config.calculate_per_token_loss,
+            layer_number=layer_idx + 1,
+            index_topk_freq=config.index_topk_freq,
+            index_skip_topk_offset=config.index_skip_topk_offset,
+            indexer_type=config.dsa_indexer_type(layer_idx),
+            indexer_loss_coeff=dsa_indexer_loss_coeff,
+            indexer_use_sparse_loss=dsa_indexer_use_sparse_loss,
+            calculate_per_token_loss=calculate_per_token_loss,
             cp_size=ps.cp_size,
             cp_rank=ps.cp_rank,
             cp_group=ps.cp_group,
+            cp_mode=dsa_cp_mode,
         )
 
-    def forward(self, x: torch.Tensor, packed_seq_params=None) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        position_ids: torch.Tensor | None = None,
+        packed_seq_params=None,
+        dsa_index_share_state: DSAIndexShareState | None = None,
+    ) -> torch.Tensor:
         # Kimi feeds SBHD [S, B, H]; DSA needs batch-first [B, S, H].
         x_bsh = x.transpose(0, 1).contiguous()
         batch, seq_len, _ = x_bsh.shape
-        # Local (this-rank) position ids; DSA reconstructs the full sequence
-        # itself when CP > 1.
-        position_ids = (
-            torch.arange(seq_len, device=x_bsh.device, dtype=torch.long)
-            .unsqueeze(0)
-            .expand(batch, -1)
-        )
+        if position_ids is None:
+            if packed_seq_params is not None:
+                raise ValueError(
+                    "GLM5 packed DSA requires explicit per-sequence position_ids."
+                )
+            if self.ps.cp_size > 1:
+                position_ids = contiguous_position_ids_for_cp(
+                    seq_len * self.ps.cp_size,
+                    self.ps.cp_rank,
+                    self.ps.cp_size,
+                    x_bsh.device,
+                )
+            else:
+                position_ids = torch.arange(
+                    seq_len, device=x_bsh.device, dtype=torch.long
+                ).unsqueeze(0)
+        position_ids = position_ids.to(device=x_bsh.device, dtype=torch.long)
+        if position_ids.dim() == 1:
+            position_ids = position_ids.unsqueeze(0)
+        if position_ids.shape[-1] != seq_len:
+            raise ValueError(
+                "GLM5 DSA position_ids must match the local sequence length, "
+                f"got {tuple(position_ids.shape)} for local length {seq_len}."
+            )
+        if position_ids.shape[0] == 1 and batch > 1:
+            position_ids = position_ids.expand(batch, -1)
+        elif position_ids.shape[0] != batch:
+            raise ValueError(
+                "GLM5 DSA position_ids batch dimension must be 1 or match hidden states, "
+                f"got {tuple(position_ids.shape)} for batch {batch}."
+            )
         cos, sin = build_rotary_embeddings(
             position_ids=position_ids,
             dim=self.qk_rope_head_dim,
@@ -214,6 +263,7 @@ class Glm5DSAAttention(nn.Module):
             position_ids=position_ids,
             attention_mask=None,
             packed_seq_params=packed_seq_params,
+            index_share_state=dsa_index_share_state,
         )
         # Back to SBHD [S, B, H] for the Kimi skeleton.
         return out_bsh.transpose(0, 1).contiguous()
@@ -446,6 +496,10 @@ class Glm5Layer(nn.Module):
         fp8: bool = False,
         moe_act_recompute: bool = False,
         use_thd: bool = False,
+        dsa_cp_mode: str = "native",
+        dsa_indexer_loss_coeff: float = 0.0,
+        dsa_indexer_use_sparse_loss: bool = False,
+        calculate_per_token_loss: bool = False,
     ):
         super().__init__()
         self.layer_idx = layer_idx
@@ -454,7 +508,15 @@ class Glm5Layer(nn.Module):
         # The wrapper preserves the SBHD self_attention(x, packed_seq_params=)
         # contract so this layer's forward stays identical to Kimi's.
         del use_thd  # DSA derives its own THD handling from packed_seq_params.
-        self.self_attention = Glm5DSAAttention(config, ps)
+        self.self_attention = Glm5DSAAttention(
+            config,
+            ps,
+            layer_idx,
+            dsa_cp_mode=dsa_cp_mode,
+            dsa_indexer_loss_coeff=dsa_indexer_loss_coeff,
+            dsa_indexer_use_sparse_loss=dsa_indexer_use_sparse_loss,
+            calculate_per_token_loss=calculate_per_token_loss,
+        )
         if config.is_moe_layer(layer_idx):
             self.mlp_norm: nn.Module | None = te.RMSNorm(
                 config.hidden_size, eps=config.rms_norm_eps
@@ -473,8 +535,19 @@ class Glm5Layer(nn.Module):
             self.moe = None
             self.mlp = DenseMLP(config, ps)
 
-    def forward(self, x: torch.Tensor, packed_seq_params=None) -> torch.Tensor:
-        x = x + self.self_attention(self.input_layernorm(x), packed_seq_params=packed_seq_params)
+    def forward(
+        self,
+        x: torch.Tensor,
+        position_ids: torch.Tensor | None = None,
+        packed_seq_params=None,
+        dsa_index_share_state: DSAIndexShareState | None = None,
+    ) -> torch.Tensor:
+        x = x + self.self_attention(
+            self.input_layernorm(x),
+            position_ids=position_ids,
+            packed_seq_params=packed_seq_params,
+            dsa_index_share_state=dsa_index_share_state,
+        )
         if self.moe is not None:
             assert self.mlp_norm is not None
             mlp_input = self.mlp_norm(x)
@@ -511,6 +584,10 @@ class Glm5MTPLayer(nn.Module):
         moe_act_recompute: bool,
         use_thd: bool,
         detach_encoder: bool,
+        dsa_cp_mode: str,
+        dsa_indexer_loss_coeff: float,
+        dsa_indexer_use_sparse_loss: bool,
+        calculate_per_token_loss: bool,
     ):
         super().__init__()
         self.ps = ps
@@ -534,6 +611,10 @@ class Glm5MTPLayer(nn.Module):
             fp8=fp8,
             moe_act_recompute=moe_act_recompute,
             use_thd=use_thd,
+            dsa_cp_mode=dsa_cp_mode,
+            dsa_indexer_loss_coeff=dsa_indexer_loss_coeff,
+            dsa_indexer_use_sparse_loss=dsa_indexer_use_sparse_loss,
+            calculate_per_token_loss=calculate_per_token_loss,
         )
         self.final_layernorm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
 
@@ -545,8 +626,11 @@ class Glm5MTPLayer(nn.Module):
         hidden_states: torch.Tensor,
         rotary_position_ids: torch.Tensor | None = None,
         packed_seq_params=None,
+        dsa_index_share_state: DSAIndexShareState | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
-        del rotary_position_ids
+        attention_position_ids = (
+            rotary_position_ids if rotary_position_ids is not None else position_ids
+        )
         input_ids, _ = _roll_mtp_left(input_ids, packed_seq_params=packed_seq_params, dims=-1)
         if position_ids is not None:
             position_ids, _ = _roll_mtp_left(
@@ -564,7 +648,12 @@ class Glm5MTPLayer(nn.Module):
         hidden_states = torch.cat((decoder_input, hidden_states), dim=-1)
         hidden_states = self.eh_proj(hidden_states)
         hidden_states = scatter_to_sequence_parallel(hidden_states, self.ps)
-        hidden_states = self.transformer_layer(hidden_states, packed_seq_params=packed_seq_params)
+        hidden_states = self.transformer_layer(
+            hidden_states,
+            position_ids=attention_position_ids,
+            packed_seq_params=packed_seq_params,
+            dsa_index_share_state=dsa_index_share_state,
+        )
         hidden_states = self.final_layernorm(hidden_states)
         return hidden_states, input_ids, position_ids
 
@@ -583,6 +672,10 @@ class Glm5MTPBlock(nn.Module):
         use_thd: bool,
         detach_encoder: bool,
         repeated_layer: bool,
+        dsa_cp_mode: str,
+        dsa_indexer_loss_coeff: float,
+        dsa_indexer_use_sparse_loss: bool,
+        calculate_per_token_loss: bool,
     ):
         super().__init__()
         self.num_layers = config.num_nextn_predict_layers
@@ -601,6 +694,10 @@ class Glm5MTPBlock(nn.Module):
                     moe_act_recompute=moe_act_recompute,
                     use_thd=use_thd,
                     detach_encoder=detach_encoder,
+                    dsa_cp_mode=dsa_cp_mode,
+                    dsa_indexer_loss_coeff=dsa_indexer_loss_coeff,
+                    dsa_indexer_use_sparse_loss=dsa_indexer_use_sparse_loss,
+                    calculate_per_token_loss=calculate_per_token_loss,
                 )
                 for idx in range(layers_to_build)
             ]
@@ -613,6 +710,7 @@ class Glm5MTPBlock(nn.Module):
         position_ids: torch.Tensor | None,
         hidden_states: torch.Tensor,
         packed_seq_params=None,
+        dsa_index_share_state: DSAIndexShareState | None = None,
     ) -> list[torch.Tensor]:
         outputs: list[torch.Tensor] = []
         rotary_position_ids = position_ids
@@ -624,6 +722,7 @@ class Glm5MTPBlock(nn.Module):
                 hidden_states=hidden_states,
                 rotary_position_ids=rotary_position_ids,
                 packed_seq_params=packed_seq_params,
+                dsa_index_share_state=dsa_index_share_state,
             )
             outputs.append(hidden_states)
         return outputs
@@ -659,6 +758,28 @@ def _apply_attention_backend_override(backend: str | None) -> None:
     ) = env
 
 
+def _dsa_index_share_decoder_layer_groups(config: Glm5Config) -> list[list[int]] | None:
+    if not config.uses_dsa_index_share:
+        return None
+
+    groups: list[list[int]] = []
+    current: list[int] = []
+    current_source: int | None = None
+    for layer_idx in range(config.num_hidden_layers):
+        if config.dsa_indexer_type(layer_idx) == "shared":
+            source_idx = config.dsa_indexer_source_layer(layer_idx)
+        else:
+            source_idx = layer_idx
+        if current and source_idx != current_source:
+            groups.append(current)
+            current = []
+        current.append(layer_idx)
+        current_source = source_idx
+    if current:
+        groups.append(current)
+    return groups
+
+
 class Glm5Model(nn.Module):
     def __init__(
         self,
@@ -671,6 +792,10 @@ class Glm5Model(nn.Module):
         use_thd: bool = False,
         hf_path: str = "",
         attention_backend_override: str | None = None,
+        dsa_cp_mode: str = "native",
+        dsa_indexer_loss_coeff: float = 0.0,
+        dsa_indexer_use_sparse_loss: bool = False,
+        calculate_per_token_loss: bool = False,
         mtp_enable: bool = False,
         mtp_enable_train: bool = False,
         mtp_detach_encoder: bool = False,
@@ -691,10 +816,28 @@ class Glm5Model(nn.Module):
             train_config.vpp,
             vpp_chunk_id,
             num_mtp_layers=config.num_nextn_predict_layers if mtp_enable else 0,
+            decoder_layer_groups=_dsa_index_share_decoder_layer_groups(config),
         )
         self.layer_indices = layout.layer_indices
         self.pre_process = layout.has_embed
         self.post_process = layout.has_head
+        local_dsa_layer_indices = list(self.layer_indices)
+        if layout.has_mtp:
+            mtp_layers_to_build = (
+                1 if config.mtp_use_repeated_layer else config.num_nextn_predict_layers
+            )
+            local_dsa_layer_indices.extend(
+                range(
+                    config.num_hidden_layers,
+                    config.num_hidden_layers + mtp_layers_to_build,
+                )
+            )
+        dsa.validate_dsa_index_share_pipeline_split(
+            local_dsa_layer_indices,
+            topk_freq=config.index_topk_freq,
+            skip_topk_offset=config.index_skip_topk_offset,
+            indexer_types=config.indexer_types,
+        )
         # GLM-5 does not tie embeddings (no tie_word_embeddings HF field); the
         # attribute is preserved for the dist-opt / distckpt interface.
         self.share_embeddings_and_output_weights = bool(
@@ -707,6 +850,11 @@ class Glm5Model(nn.Module):
             self.embed = VocabParallelEmbedding(config.vocab_size, config.hidden_size, ps)
 
         recompute_modules = getattr(train_config, "recompute_modules", [])
+        offload_modules = getattr(train_config, "offload_modules", [])
+        self._retain_index_share_for_recompute = bool(
+            {"full", "core_attn", "self_attn", "dsa"}
+            & set([*recompute_modules, *offload_modules])
+        )
         moe_act_recompute = "moe_act" in recompute_modules and "moe" not in recompute_modules
         self.layers = nn.ModuleList(
             [
@@ -719,6 +867,10 @@ class Glm5Model(nn.Module):
                     fp8=train_config.fp8,
                     moe_act_recompute=moe_act_recompute,
                     use_thd=use_thd,
+                    dsa_cp_mode=dsa_cp_mode,
+                    dsa_indexer_loss_coeff=dsa_indexer_loss_coeff,
+                    dsa_indexer_use_sparse_loss=dsa_indexer_use_sparse_loss,
+                    calculate_per_token_loss=calculate_per_token_loss,
                 )
                 for idx in self.layer_indices
             ]
@@ -748,6 +900,10 @@ class Glm5Model(nn.Module):
                 use_thd=use_thd,
                 detach_encoder=mtp_detach_encoder,
                 repeated_layer=config.mtp_use_repeated_layer,
+                dsa_cp_mode=dsa_cp_mode,
+                dsa_indexer_loss_coeff=dsa_indexer_loss_coeff,
+                dsa_indexer_use_sparse_loss=dsa_indexer_use_sparse_loss,
+                calculate_per_token_loss=calculate_per_token_loss,
             )
 
         self.sp_params: list[nn.Parameter] = []
@@ -788,10 +944,22 @@ class Glm5Model(nn.Module):
             else nullcontext()
         )
         with fp8_ctx:
+            dsa_index_share_state = (
+                DSAIndexShareState(
+                    retain_for_recompute=self._retain_index_share_for_recompute
+                )
+                if self.config.uses_dsa_index_share
+                else None
+            )
             if self.embed is not None:
                 h = scatter_to_sequence_parallel(h, self.ps)
             for layer in self.layers:
-                h = layer(h, packed_seq_params=packed_seq_params)
+                h = layer(
+                    h,
+                    position_ids=position_ids,
+                    packed_seq_params=packed_seq_params,
+                    dsa_index_share_state=dsa_index_share_state,
+                )
 
         output = {"hidden_states": h}
         if self.head is not None:
@@ -802,6 +970,7 @@ class Glm5Model(nn.Module):
                 input_ids=input_ids,
                 position_ids=position_ids,
                 packed_seq_params=packed_seq_params,
+                dsa_index_share_state=dsa_index_share_state,
             )
             if mtp_hidden_states is not None:
                 output["mtp_hidden_states"] = mtp_hidden_states
@@ -851,6 +1020,8 @@ class Glm5Model(nn.Module):
                         self.head.gather(self.head(mtp_hidden)).transpose(0, 1).contiguous()
                         for mtp_hidden in mtp_hidden_states
                     ]
+        if dsa_index_share_state is not None:
+            dsa_index_share_state.finish_forward()
         return output
 
     def _apply_mtp(
@@ -860,6 +1031,7 @@ class Glm5Model(nn.Module):
         input_ids: torch.Tensor | None,
         position_ids: torch.Tensor | None,
         packed_seq_params,
+        dsa_index_share_state: DSAIndexShareState | None,
     ) -> list[torch.Tensor] | None:
         if self.mtp is None:
             return None
@@ -872,6 +1044,7 @@ class Glm5Model(nn.Module):
             position_ids=position_ids,
             hidden_states=hidden_states,
             packed_seq_params=packed_seq_params,
+            dsa_index_share_state=dsa_index_share_state,
         )
 
     def _apply_mtp_loss(

--- a/experimental/lite/megatron/lite/model/glm5/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/glm5/lite/protocol.py
@@ -23,16 +23,23 @@ from typing import Any
 
 import torch
 import torch.nn as nn
+
 from megatron.lite.model.glm5.config import Glm5Config
 from megatron.lite.model.protocol_utils import (
     add_cross_entropy_fusion,
     add_loss_context_kwargs,
-    pack_thd_forward_kwargs,
+    nested_from_packed,
     set_cross_entropy_fusion,
-    unpack_thd_forward_output,
 )
 from megatron.lite.primitive.bundle import ModelBundle
 from megatron.lite.primitive.parallel import ParallelState, init_parallel
+from megatron.lite.primitive.parallel.cp import contiguous_slice_for_cp
+from megatron.lite.primitive.parallel.thd import (
+    pack_nested_thd,
+    parallel_state_from_model,
+    thd_pack_meta,
+    unpack_thd_to_nested,
+)
 from megatron.lite.primitive.recompute import apply_recompute, parse_recompute_spec
 from megatron.lite.runtime.contracts import OptimizerConfig, ParallelConfig
 from megatron.lite.runtime.contracts.data import PackedBatch
@@ -94,6 +101,10 @@ class ImplConfig:
     cross_entropy_fusion: bool = False
     hf_path: str = ""
     attention_backend_override: str | None = None
+    dsa_cp_mode: str = "native"
+    dsa_indexer_loss_coeff: float = 0.0
+    dsa_indexer_use_sparse_loss: bool = False
+    calculate_per_token_loss: bool = False
     router_aux_loss_coef: float | None = None
     router_bias_rate: float = 0.0
     deterministic: bool = True
@@ -103,6 +114,15 @@ class ImplConfig:
     mtp_detach_encoder: bool = False
     mtp_loss_scaling_factor: float = 0.1
     mtp_use_repeated_layer: bool | None = None
+
+    def __post_init__(self) -> None:
+        if self.dsa_cp_mode not in {"native", "legacy_gather_all"}:
+            raise ValueError(
+                "dsa_cp_mode must be 'native' or 'legacy_gather_all', "
+                f"got {self.dsa_cp_mode!r}"
+            )
+        if self.dsa_indexer_loss_coeff < 0.0:
+            raise ValueError("dsa_indexer_loss_coeff must be >= 0")
 
 
 def build_model_config(source: str | Path | dict, **overrides) -> Glm5Config:
@@ -116,15 +136,60 @@ def build_model_config(source: str | Path | dict, **overrides) -> Glm5Config:
     return cfg
 
 
+def _pack_glm5_thd_forward_kwargs(
+    model: nn.Module, batch: PackedBatch
+) -> dict[str, Any]:
+    """Pack GLM5 THD inputs in sequential allgather-CP layout."""
+    ps = parallel_state_from_model(model) or ParallelState()
+    seq_lens = batch.seq_lens
+    packed = pack_nested_thd(
+        nested_from_packed(batch.input_ids, seq_lens),
+        tp_size=ps.tp_size,
+        cp_size=ps.cp_size,
+        cp_rank=ps.cp_rank,
+        cp_group=ps.cp_group if ps.cp_size > 1 else None,
+        split_cp=False,
+        labels=nested_from_packed(batch.labels, seq_lens),
+        roll_labels=batch.labels is not None,
+        loss_mask=nested_from_packed(batch.loss_mask, seq_lens),
+        roll_loss_mask=batch.loss_mask is not None,
+    )
+    kwargs: dict[str, Any] = {
+        "input_ids": packed.input_ids,
+        "labels": packed.labels,
+        "loss_mask": packed.loss_mask,
+        "position_ids": packed.position_ids,
+        "packed_seq_params": packed.packed_seq_params,
+    }
+    kwargs["packed_seq_params"].cp_layout = "contiguous"
+    if ps.cp_size > 1:
+        for key in ("input_ids", "labels", "loss_mask", "position_ids"):
+            tensor = kwargs[key]
+            if tensor is not None:
+                kwargs[key] = contiguous_slice_for_cp(
+                    tensor, ps.cp_rank, ps.cp_size, seq_dim=1
+                )
+    return kwargs
+
+
 def _forward_step(model: nn.Module, batch: PackedBatch) -> dict:
-    kwargs = pack_thd_forward_kwargs(model, batch)
+    kwargs = _pack_glm5_thd_forward_kwargs(model, batch)
     add_loss_context_kwargs(kwargs)
     add_cross_entropy_fusion(kwargs, model)
     return model(**kwargs)
 
 
 def unpack_forward_output(model: nn.Module, batch: PackedBatch, output) -> Any:
-    return unpack_thd_forward_output(model, batch, output)
+    """Reconstruct sequential CP shards and drop GLM5 THD padding."""
+    ps = parallel_state_from_model(model) or ParallelState()
+    meta = thd_pack_meta(
+        batch.seq_lens,
+        tp_size=ps.tp_size,
+        cp_size=ps.cp_size,
+        cp_group=ps.cp_group if ps.cp_size > 1 else None,
+        contiguous=True,
+    )
+    return unpack_thd_to_nested(output, meta, contiguous=True)
 
 
 def _make_aux_loss_hook():
@@ -188,7 +253,9 @@ def build_model(model_cfg: Glm5Config, *, impl_cfg: ImplConfig) -> ModelBundle:
     mtp_enable_train = mtp_enable and bool(impl_cfg.mtp_enable_train)
     if mtp_enable:
         if model_cfg.num_nextn_predict_layers <= 0:
-            raise ValueError("mtp_enable=True but HF config has no num_nextn_predict_layers.")
+            raise ValueError(
+                "mtp_enable=True but HF config has no num_nextn_predict_layers."
+            )
         model_cfg.mtp_loss_scaling_factor = impl_cfg.mtp_loss_scaling_factor
         if impl_cfg.mtp_use_repeated_layer is not None:
             model_cfg.mtp_use_repeated_layer = impl_cfg.mtp_use_repeated_layer
@@ -210,6 +277,7 @@ def build_model(model_cfg: Glm5Config, *, impl_cfg: ImplConfig) -> ModelBundle:
         use_deepep=impl_cfg.use_deepep,
         fp8=False,
         recompute_modules=recompute_spec,
+        offload_modules=list(impl_cfg.offload),
         deterministic=impl_cfg.deterministic,
     )
     model_kwargs: dict[str, Any] = dict(
@@ -217,13 +285,21 @@ def build_model(model_cfg: Glm5Config, *, impl_cfg: ImplConfig) -> ModelBundle:
         use_thd=impl_cfg.use_thd,
         hf_path=impl_cfg.hf_path,
         attention_backend_override=impl_cfg.attention_backend_override,
+        dsa_cp_mode=impl_cfg.dsa_cp_mode,
+        dsa_indexer_loss_coeff=impl_cfg.dsa_indexer_loss_coeff,
+        dsa_indexer_use_sparse_loss=impl_cfg.dsa_indexer_use_sparse_loss,
+        calculate_per_token_loss=impl_cfg.calculate_per_token_loss,
         mtp_enable=mtp_enable,
         mtp_enable_train=mtp_enable_train,
         mtp_detach_encoder=impl_cfg.mtp_detach_encoder,
     )
 
     if vpp is None:
-        chunks = [Glm5Model(model_cfg, train_cfg, ps, **model_kwargs).to(torch.bfloat16).cuda()]
+        chunks = [
+            Glm5Model(model_cfg, train_cfg, ps, **model_kwargs)
+            .to(torch.bfloat16)
+            .cuda()
+        ]
     else:
         chunks = [
             Glm5Model(
@@ -254,7 +330,9 @@ def build_model(model_cfg: Glm5Config, *, impl_cfg: ImplConfig) -> ModelBundle:
     post_model_load_hook = None
     optimizer_backend = "none"
     if impl_cfg.optimizer == "dist_opt":
-        optimizer, finalize_grads = _build_dist_opt_optimizer(chunks, model_cfg, impl_cfg, ps)
+        optimizer, finalize_grads = _build_dist_opt_optimizer(
+            chunks, model_cfg, impl_cfg, ps
+        )
         from megatron.lite.primitive.ckpt import attach_model_sharded_state_dict
         from megatron.lite.runtime.megatron_utils import register_training_hooks
 
@@ -318,7 +396,9 @@ def export_hf_weights(chunks, model_cfg: Glm5Config, ps: ParallelState, **kwargs
     yield from export_impl(chunks, model_cfg, ps, **kwargs)
 
 
-def save_hf_weights(chunks, path: str, model_cfg: Glm5Config, ps: ParallelState, **kwargs):
+def save_hf_weights(
+    chunks, path: str, model_cfg: Glm5Config, ps: ParallelState, **kwargs
+):
     from megatron.lite.model.glm5.lite.checkpoint import save_hf_weights as save_impl
 
     save_impl(chunks, path, model_cfg, ps, **kwargs)

--- a/experimental/lite/megatron/lite/primitive/kernels/dsa_kernels.py
+++ b/experimental/lite/megatron/lite/primitive/kernels/dsa_kernels.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 """
 DSA kernel wrappers for Megatron's DSv4 sparse attention.
@@ -77,6 +77,21 @@ def _get_topk_alignment() -> int:
     return 128
 
 
+def _pad_sparse_kv_rows(kv: Tensor, alignment: int) -> Tensor:
+    """Pad a ragged KV tail for FlashMLA without changing logical indices.
+
+    CP+THD invokes sparse attention once per packed segment.  Unlike the dense
+    path, a segment can end at an arbitrary row (for example 520), while the
+    SM90/SM100 FlashMLA sparse kernels load KV in aligned blocks.  Keep logical
+    top-k indices in the original range and append unreachable zero rows only
+    to make the physical KV allocation block-aligned.
+    """
+    pad_rows = (-kv.shape[0]) % alignment
+    if pad_rows == 0:
+        return kv
+    return torch.cat((kv, kv.new_zeros((pad_rows, *kv.shape[1:]))), dim=0)
+
+
 def _dsa_fwd_flash_mla(
     q: Tensor,
     kv: Tensor,
@@ -105,6 +120,9 @@ def _dsa_fwd_flash_mla(
         pad_width = TopK_padded - TopK
         topk_idxs = torch.nn.functional.pad(topk_idxs, (0, pad_width), value=-1)
 
+    # Packed CP segments can have ragged KV lengths.  The top-k values remain
+    # in the logical (unpadded) range, so these extra rows are unreachable.
+    kv = _pad_sparse_kv_rows(kv, _get_topk_alignment())
     kv_3d = kv.unsqueeze(1)  # (total_S_kv, 1, D)  h_kv=1
     indices = topk_idxs.unsqueeze(1)  # (total_S_q, 1, TopK_padded) h_kv=1
 
@@ -560,6 +578,238 @@ def indexer_topk(
     return topk_indices, topk_length
 
 
+def _cudnn_topk_block(
+    dsa_namespace, scores: Tensor, width: int
+) -> Tuple[Tensor, Tensor]:
+    """Run cuDNN radix top-k and validate its varlen shape contract."""
+    num_cols = scores.shape[-1]
+    scores = scores.contiguous()
+    seq_lens = torch.full(
+        (scores.shape[0],), num_cols, device=scores.device, dtype=torch.int32
+    )
+    next_n = 1
+    min_seq_len = int(seq_lens.min().item())
+    max_seq_len = int(seq_lens.max().item())
+    print(
+        "MLite DSA indexer_top_k contract: "
+        f"input_values.shape={tuple(scores.shape)}, "
+        f"seq_lens.min={min_seq_len}, seq_lens.max={max_seq_len}, "
+        f"top_k={width}, next_n={next_n}",
+        flush=True,
+    )
+    if scores.shape[0] != seq_lens.numel() * next_n:
+        raise RuntimeError(
+            "cuDNN indexer_top_k row contract violated: "
+            f"n_rows={scores.shape[0]}, seq_lens={seq_lens.numel()}, next_n={next_n}."
+        )
+    if min_seq_len < 0 or max_seq_len > num_cols:
+        raise RuntimeError(
+            "cuDNN indexer_top_k column contract violated: "
+            f"seq_lens range=[{min_seq_len}, {max_seq_len}], num_cols={num_cols}."
+        )
+    result = dsa_namespace.indexer_top_k_wrapper(
+        scores,
+        seq_lens,
+        top_k=width,
+        next_n=next_n,
+        return_val=False,
+    )
+    indices = result["indices"]
+    valid = (indices >= 0) & (indices < num_cols)
+    safe_indices = indices.clamp(min=0, max=num_cols - 1).long()
+    values = torch.gather(scores, -1, safe_indices)
+    values = torch.where(valid, values, torch.full_like(values, float("-inf")))
+    return values, torch.where(valid, indices, torch.full_like(indices, -1))
+
+
+def indexer_topk_with_mask(
+    q_indexer: Tensor,
+    k_indexer: Tensor,
+    weights: Tensor,
+    topk: int,
+    mask: Tensor,
+    indexer_softmax_scale: float = 1.0,
+) -> Tuple[Tensor, Tensor]:
+    """Score CP local-Q against global-K with an explicit position mask.
+
+    This is deliberately local rather than a zero-copy wrapper around Megatron
+    Core's experimental DSA helpers.  At NVIDIA/Megatron-LM dev@1378a4806,
+    ``fused_qk_topk_naive_thd`` assumes contiguous, aligned Q/K segments,
+    reconstructs the causal mask from segment length plus ``ratio``, and
+    clamps top-k to the segment K length.  GLM5 contiguous allgather-CP instead
+    needs an explicit mask from sequential local-Q positions to full-sequence
+    global-K positions, with top-k spanning global-K rather than the local
+    segment.  Keep this helper until Core can express that contract without
+    changing CP semantics.
+    """
+    q_bshd, k_bsd, _w_bsh, w_bsh_scaled = _sbhd_to_bshd_indexer_inputs(
+        q_indexer, k_indexer, weights, indexer_softmax_scale
+    )
+    b, sq, _heads, _dim = q_bshd.shape
+    sk = k_bsd.shape[1]
+    mask = mask.to(device=q_bshd.device, dtype=torch.float32)
+    width = min(int(topk), sk)
+    best_values = None
+    best_indices = None
+    block_size = 2048
+    for start in range(0, sk, block_size):
+        end = min(start + block_size, sk)
+        scores = torch.einsum("bqhd,bkd->bqhk", q_bshd.float(), k_bsd[:, start:end].float())
+        scores = torch.relu(scores).mul(w_bsh_scaled.float().unsqueeze(-1)).sum(dim=2)
+        scores = scores + mask[:, start:end].unsqueeze(0)
+        block_width = min(width, end - start)
+        if scores.is_cuda:
+            _ensure_dsa_namespace()
+            flat_scores = scores.reshape(b * sq, end - start).contiguous()
+            values, indices = _cudnn_topk_block(
+                _DSA,
+                flat_scores,
+                block_width,
+            )
+            values = values.view(b, sq, block_width)
+            indices = indices.view(b, sq, block_width)
+        else:
+            values, indices = torch.topk(scores, k=block_width, dim=-1)
+        indices = indices + start
+        if best_values is not None:
+            values = torch.cat((best_values, values), dim=-1)
+            indices = torch.cat((best_indices, indices), dim=-1)
+            keep = min(width, values.shape[-1])
+            values, selected = torch.topk(values, k=keep, dim=-1)
+            indices = torch.gather(indices, -1, selected)
+        best_values, best_indices = values, indices
+    assert best_values is not None and best_indices is not None
+    values, indices = best_values, best_indices
+    indices = torch.where(torch.isfinite(values), indices, torch.full_like(indices, -1)).int()
+    if width < topk:
+        indices = torch.nn.functional.pad(indices, (0, topk - width), value=-1)
+    return q_bshd.new_empty(0), indices
+
+
+def cp_indexer_loss(
+    q_indexer: Tensor,
+    k_indexer: Tensor,
+    weights: Tensor,
+    topk_indices: Tensor,
+    query: Tensor,
+    kv: Tensor,
+    *,
+    mask: Tensor,
+    softmax_scale: float,
+    loss_coeff: float,
+    sparse_loss: bool,
+    calculate_per_token_loss: bool,
+) -> Tensor:
+    """Compute the IndexShare KL for CP local-Q/global-K explicit masking.
+
+    This fills the same Core gap as :func:`indexer_topk_with_mask`: NVIDIA
+    Megatron-LM dev@1378a4806's
+    ``fwd_fused_indexer_loss_naive_thd`` and
+    ``bwd_fused_indexer_loss_naive_thd`` assume continuous, aligned Q/K
+    segments and build their causal mask from segment lengths plus ``ratio``.
+    They cannot represent GLM5 contiguous allgather-CP's explicit sequential
+    local-Q/global-K position mask, and their paired top-k path must not reduce
+    global-K coverage to the local segment.  Retain this implementation while
+    preserving that CP contract.
+    """
+    if loss_coeff == 0:
+        return (q_indexer.sum() + k_indexer.sum() + weights.sum()) * 0.0
+
+    q_bshd, k_bsd, _w_raw, w_scaled = _sbhd_to_bshd_indexer_inputs(
+        q_indexer, k_indexer, weights, 1.0
+    )
+    w_scaled = w_scaled.float() * float(q_indexer.shape[-1] ** -0.5)
+    q_attn = query.permute(1, 0, 2, 3).float()
+    kv_bkd = kv.permute(1, 0, 2).float()
+    valid = torch.isfinite(mask)
+    b, sq, _heads, _dim = q_bshd.shape
+    sk = k_bsd.shape[1]
+
+    if sparse_loss:
+        safe = topk_indices.clamp_min(0).long()
+        selected_k = torch.gather(
+            k_bsd.unsqueeze(1).expand(-1, sq, -1, -1),
+            2,
+            safe.unsqueeze(-1).expand(-1, -1, -1, k_bsd.shape[-1]),
+        )
+        index_logits = torch.einsum("bqhd,bqtd->bqht", q_bshd.float(), selected_k.float())
+        index_logits = torch.relu(index_logits).mul(w_scaled.unsqueeze(-1)).sum(dim=2)
+        selected_kv = torch.gather(
+            kv_bkd.unsqueeze(1).expand(-1, sq, -1, -1),
+            2,
+            safe.unsqueeze(-1).expand(-1, -1, -1, kv_bkd.shape[-1]),
+        )
+        attn_logits = torch.einsum("bqhd,bqtd->bqht", q_attn, selected_kv)
+        attn_logits = attn_logits * float(softmax_scale)
+        selected_valid = topk_indices >= 0
+        row_valid = selected_valid.any(dim=-1, keepdim=True)
+        index_logits = torch.where(row_valid, index_logits, torch.zeros_like(index_logits))
+        attn_logits = torch.where(
+            row_valid.unsqueeze(2), attn_logits, torch.zeros_like(attn_logits)
+        )
+        index_logits = index_logits.masked_fill(~selected_valid & row_valid, float("-inf"))
+        attn_logits = attn_logits.masked_fill(
+            ((~selected_valid) & row_valid).unsqueeze(2), float("-inf")
+        )
+        predict = torch.softmax(index_logits, dim=-1)
+        target = torch.softmax(attn_logits, dim=-1, dtype=torch.float32).mean(dim=2)
+        target = torch.where(row_valid, target, torch.zeros_like(target))
+        predict = torch.where(row_valid, predict, torch.zeros_like(predict))
+        kl_per_row = (
+            target * (torch.log(target + 1.0e-10) - torch.log(predict + 1.0e-10))
+        ).sum(dim=-1)
+    else:
+        block_size = 2048
+        index_lse = torch.full((b, sq), float("-inf"), device=query.device)
+        attn_lse = torch.full(
+            (b, sq, query.shape[2]), float("-inf"), device=query.device
+        )
+        for start in range(0, sk, block_size):
+            end = min(start + block_size, sk)
+            block_valid = valid[:, start:end].unsqueeze(0)
+            idx = torch.einsum(
+                "bqhd,bkd->bqhk", q_bshd.float(), k_bsd[:, start:end].float()
+            )
+            idx = torch.relu(idx).mul(w_scaled.unsqueeze(-1)).sum(dim=2)
+            idx = idx.masked_fill(~block_valid, float("-inf"))
+            attn = torch.einsum("bqhd,bkd->bqhk", q_attn, kv_bkd[:, start:end])
+            attn = (attn * float(softmax_scale)).masked_fill(
+                ~block_valid.unsqueeze(2), float("-inf")
+            )
+            index_lse = torch.logaddexp(index_lse, torch.logsumexp(idx, dim=-1))
+            attn_lse = torch.logaddexp(attn_lse, torch.logsumexp(attn, dim=-1))
+
+        row_valid = torch.isfinite(index_lse)
+        safe_index_lse = torch.where(row_valid, index_lse, torch.zeros_like(index_lse))
+        safe_attn_lse = torch.where(
+            row_valid.unsqueeze(-1), attn_lse, torch.zeros_like(attn_lse)
+        )
+        kl_per_row = torch.zeros((b, sq), device=query.device, dtype=torch.float32)
+        for start in range(0, sk, block_size):
+            end = min(start + block_size, sk)
+            block_valid = valid[:, start:end].unsqueeze(0)
+            idx = torch.einsum(
+                "bqhd,bkd->bqhk", q_bshd.float(), k_bsd[:, start:end].float()
+            )
+            idx = torch.relu(idx).mul(w_scaled.unsqueeze(-1)).sum(dim=2)
+            attn = torch.einsum("bqhd,bkd->bqhk", q_attn, kv_bkd[:, start:end])
+            attn = attn * float(softmax_scale)
+            idx = idx.masked_fill(~block_valid, float("-inf"))
+            attn = attn.masked_fill(~block_valid.unsqueeze(2), float("-inf"))
+            predict_log = idx - safe_index_lse.unsqueeze(-1)
+            predict_log = torch.where(block_valid, predict_log, torch.zeros_like(predict_log))
+            target = torch.exp(attn - safe_attn_lse.unsqueeze(-1)).mean(dim=2)
+            target = torch.where(block_valid, target, torch.zeros_like(target))
+            term = target * (torch.log(target + 1.0e-10) - predict_log)
+            kl_per_row = kl_per_row + torch.where(
+                block_valid, term, torch.zeros_like(term)
+            ).sum(dim=-1)
+        kl_per_row = torch.where(row_valid, kl_per_row, torch.zeros_like(kl_per_row))
+
+    reduced = kl_per_row.sum() if calculate_per_token_loss else kl_per_row.mean()
+    return reduced * float(loss_coeff)
+
+
 # ---------------------------------------------------------------------------
 # Path B: fused indexer + sparse attention (training)
 # ---------------------------------------------------------------------------
@@ -816,14 +1066,13 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
         kv_offset: int,
         calculate_per_token_loss: bool,
         value_dim: Optional[int],
-    ) -> Tuple[Tensor, Tensor]:
+    ) -> Tuple[Tensor, Tensor, Tensor]:
         """Fused forward: indexer scoring, sparse attention, KL loss, and indexer backward."""
         _ensure_dsa_namespace()
 
         sq, b, np_, d = query.shape
         skv = kv_full.shape[0]
         n_comp = k_indexer.shape[0]
-        idx_nh, idx_hd = q_indexer.shape[2], q_indexer.shape[3]
 
         requested_topk = indexer_topk
         effective_topk = min(requested_topk, n_comp)
@@ -994,11 +1243,12 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
         # ---- 8. Return. ---------------------------------------------------
         d_v = out_flat.shape[-1]
         output = out_flat.reshape(sq, b, np_, d_v).reshape(sq, b, np_ * d_v)
-        return output, indexer_loss
+        return output, indexer_loss, compress_topk_idxs
 
     @staticmethod
-    def backward(ctx, grad_output, grad_loss):
+    def backward(ctx, grad_output, grad_loss, grad_topk_indices=None):
         """Backward: sparse attention bwd + scale pre-computed indexer grads."""
+        del grad_topk_indices
         (
             q_flat,
             kv_flat,
@@ -1061,6 +1311,44 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
         )
 
 
+def _fused_indexer_sparse_attn_apply(
+    query: Tensor,
+    kv_full: Tensor,
+    attn_sink: Tensor,
+    window_idxs: Tensor,
+    q_indexer: Tensor,
+    k_indexer: Tensor,
+    weights: Tensor,
+    indexer_topk: int,
+    ratio: int,
+    softmax_scale: float,
+    indexer_softmax_scale: float = 1.0,
+    loss_coeff: float = 0.0,
+    sparse_loss: bool = False,
+    kv_offset: int = 0,
+    calculate_per_token_loss: bool = False,
+    value_dim: Optional[int] = None,
+) -> Tuple[Tensor, Tensor, Tensor]:
+    return FusedIndexerSparseAttnFunc.apply(
+        query,
+        kv_full,
+        attn_sink,
+        window_idxs,
+        q_indexer,
+        k_indexer,
+        weights,
+        indexer_topk,
+        ratio,
+        softmax_scale,
+        indexer_softmax_scale,
+        loss_coeff,
+        sparse_loss,
+        kv_offset,
+        calculate_per_token_loss,
+        value_dim,
+    )
+
+
 def fused_indexer_sparse_attn(
     query: Tensor,
     kv_full: Tensor,
@@ -1117,7 +1405,47 @@ def fused_indexer_sparse_attn(
         ``(output, indexer_loss)`` where ``output`` is ``(sq, b, np * d_v)``
         bf16 and ``indexer_loss`` is a scalar f32.
     """
-    return FusedIndexerSparseAttnFunc.apply(
+    output, indexer_loss, _topk_indices = _fused_indexer_sparse_attn_apply(
+        query,
+        kv_full,
+        attn_sink,
+        window_idxs,
+        q_indexer,
+        k_indexer,
+        weights,
+        indexer_topk,
+        ratio,
+        softmax_scale,
+        indexer_softmax_scale,
+        loss_coeff,
+        sparse_loss,
+        kv_offset,
+        calculate_per_token_loss,
+        value_dim,
+    )
+    return output, indexer_loss
+
+
+def fused_indexer_sparse_attn_with_topk(
+    query: Tensor,
+    kv_full: Tensor,
+    attn_sink: Tensor,
+    window_idxs: Tensor,
+    q_indexer: Tensor,
+    k_indexer: Tensor,
+    weights: Tensor,
+    indexer_topk: int,
+    ratio: int,
+    softmax_scale: float,
+    indexer_softmax_scale: float = 1.0,
+    loss_coeff: float = 0.0,
+    sparse_loss: bool = False,
+    kv_offset: int = 0,
+    calculate_per_token_loss: bool = False,
+    value_dim: Optional[int] = None,
+) -> Tuple[Tensor, Tensor, Tensor]:
+    """Path B plus the fused top-k indices for DSA IndexShare source layers."""
+    return _fused_indexer_sparse_attn_apply(
         query,
         kv_full,
         attn_sink,
@@ -1139,8 +1467,11 @@ def fused_indexer_sparse_attn(
 
 __all__ = [
     "build_flat_topk_idxs",
+    "cp_indexer_loss",
     "local_to_global_flat",
     "dsa_sparse_attn",
     "indexer_topk",
+    "indexer_topk_with_mask",
     "fused_indexer_sparse_attn",
+    "fused_indexer_sparse_attn_with_topk",
 ]

--- a/experimental/lite/megatron/lite/primitive/modules/attention/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/modules/attention/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 from megatron.lite.primitive.modules.attention.dsa import (
+    DSAIndexShareState,
     DynamicSparseAttention,
     RMSNorm,
     build_rope_cache,
@@ -8,6 +9,7 @@ from megatron.lite.primitive.modules.attention.dsa import (
 from megatron.lite.primitive.modules.attention.mla import MultiLatentAttention
 
 __all__ = [
+    "DSAIndexShareState",
     "DynamicSparseAttention",
     "MultiLatentAttention",
     "RMSNorm",

--- a/experimental/lite/megatron/lite/primitive/modules/attention/dsa.py
+++ b/experimental/lite/megatron/lite/primitive/modules/attention/dsa.py
@@ -7,34 +7,51 @@ keep model config classes out of the primitive layer.
 
 from __future__ import annotations
 
+from collections.abc import Hashable
 from typing import TYPE_CHECKING
 
 import torch
 import torch.nn as nn
 import transformer_engine.pytorch as te
 
-from megatron.lite.primitive.parallel.cp import (
-    zigzag_reconstruct_from_cp_parts,
-    zigzag_slice_for_cp,
-)
-from megatron.lite.primitive.parallel.thd import (
-    reconstruct_packed_from_cp_parts,
-    split_packed_to_cp_local,
-)
-
 from megatron.lite.primitive.kernels import dsa_kernels as _dsa_kernels
+from megatron.lite.primitive.modules.attention.cp import iter_cp_sources
+from megatron.lite.primitive.parallel.cp import (
+    contiguous_position_ids_for_cp,
+    contiguous_slice_for_cp,
+)
 
 if TYPE_CHECKING:
     from megatron.lite.primitive.modules.attention.mla import MultiLatentAttention
 
 
+# cuDNN FE 1.27's indexer_top_k decode-varlen kernel loads score columns in
+# 512-thread tiles. CP aligns gathered projected KV once so the physical
+# score width cannot end in a partial tile; the causal mask preserves the
+# original logical sequence boundary.
+_CUDNN_DSA_TOPK_COLUMN_ALIGNMENT = 512
+
+
 def _fused_indexer_sparse_attn(*args, value_dim: int | None = None, **kwargs):
     try:
-        return _dsa_kernels.fused_indexer_sparse_attn(*args, value_dim=value_dim, **kwargs)
+        return _dsa_kernels.fused_indexer_sparse_attn(
+            *args, value_dim=value_dim, **kwargs
+        )
     except TypeError as exc:
         if "value_dim" not in str(exc):
             raise
         return _dsa_kernels.fused_indexer_sparse_attn(*args, **kwargs)
+
+
+def _fused_indexer_sparse_attn_with_topk(*args, value_dim: int | None = None, **kwargs):
+    try:
+        return _dsa_kernels.fused_indexer_sparse_attn_with_topk(
+            *args, value_dim=value_dim, **kwargs
+        )
+    except TypeError as exc:
+        if "value_dim" not in str(exc):
+            raise
+        return _dsa_kernels.fused_indexer_sparse_attn_with_topk(*args, **kwargs)
 
 
 class DSAIndexerLossAutoScaler(torch.autograd.Function):
@@ -55,7 +72,9 @@ class DSAIndexerLossAutoScaler(torch.autograd.Function):
                 1.0, device=indexer_loss.device
             )
         indexer_loss_backward_scale = DSAIndexerLossAutoScaler.main_loss_backward_scale
-        scaled_indexer_loss_grad = torch.ones_like(indexer_loss) * indexer_loss_backward_scale
+        scaled_indexer_loss_grad = (
+            torch.ones_like(indexer_loss) * indexer_loss_backward_scale
+        )
         return grad_output, scaled_indexer_loss_grad
 
     @staticmethod
@@ -100,12 +119,19 @@ def rotate_activation(x: torch.Tensor) -> torch.Tensor:
 
 
 def build_rope_cache(
-    *, dim: int, max_position_embeddings: int, rope_theta: float, device: torch.device | None = None
+    *,
+    dim: int,
+    max_position_embeddings: int,
+    rope_theta: float,
+    device: torch.device | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     inv_freq = 1.0 / (
-        rope_theta ** (torch.arange(0, dim, 2, dtype=torch.float32, device=device) / dim)
+        rope_theta
+        ** (torch.arange(0, dim, 2, dtype=torch.float32, device=device) / dim)
     )
-    positions = torch.arange(max_position_embeddings, dtype=torch.float32, device=device)
+    positions = torch.arange(
+        max_position_embeddings, dtype=torch.float32, device=device
+    )
     freqs = torch.outer(positions, inv_freq)
     return freqs.cos(), freqs.sin()
 
@@ -116,13 +142,22 @@ def build_rotary_embeddings(
     device = position_ids.device
     inv_freq = 1.0 / (
         rope_theta
-        ** (torch.arange(0, dim, 2, dtype=torch.int64, device=device).to(torch.float32) / dim)
+        ** (
+            torch.arange(0, dim, 2, dtype=torch.int64, device=device).to(torch.float32)
+            / dim
+        )
     )
-    inv_freq_expanded = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1)
+    inv_freq_expanded = (
+        inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1)
+    )
     position_ids_expanded = position_ids[:, None, :].float()
-    device_type = device.type if isinstance(device.type, str) and device.type != "mps" else "cpu"
+    device_type = (
+        device.type if isinstance(device.type, str) and device.type != "mps" else "cpu"
+    )
     with torch.autocast(device_type=device_type, enabled=False):
-        freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)
+        freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(
+            1, 2
+        )
         emb = torch.cat((freqs, freqs), dim=-1)
         cos = emb.cos()
         sin = emb.sin()
@@ -198,7 +233,9 @@ def _rotary_embeddings_from_cache(
     return cos.to(dtype=dtype), sin.to(dtype=dtype)
 
 
-def _all_gather_cp(tensor: torch.Tensor, *, cp_size: int, cp_group) -> list[torch.Tensor]:
+def _all_gather_cp(
+    tensor: torch.Tensor, *, cp_size: int, cp_group
+) -> list[torch.Tensor]:
     if cp_size <= 1:
         return [tensor]
     if cp_group is None:
@@ -206,6 +243,318 @@ def _all_gather_cp(tensor: torch.Tensor, *, cp_size: int, cp_group) -> list[torc
     from torch.distributed.nn.functional import all_gather
 
     return list(all_gather(tensor.contiguous(), group=cp_group))
+
+
+def _dense_cp_layout(
+    *, local_seq: int, cp_size: int, cp_rank: int, device: torch.device
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return contiguous local-query positions and global KV order."""
+    full_seq = local_seq * cp_size
+    query_positions = contiguous_position_ids_for_cp(
+        full_seq, cp_rank, cp_size, device
+    ).flatten()
+    return query_positions, torch.arange(full_seq, device=device, dtype=torch.long)
+
+
+def _packed_cp_layout(
+    cu_seqlens: torch.Tensor,
+    *,
+    cp_size: int,
+    cp_rank: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return contiguous THD local-query positions and global KV order."""
+    cu_seqlens = cu_seqlens.to(device=device, dtype=torch.long)
+    total = int(cu_seqlens[-1].item())
+    if total % cp_size:
+        raise ValueError(
+            f"Packed sequential CP requires total tokens divisible by cp_size; "
+            f"got total={total}, cp_size={cp_size}."
+        )
+    query_positions = contiguous_position_ids_for_cp(
+        total, cp_rank, cp_size, device
+    ).flatten()
+    # Sequential shards are gathered in rank order, which is already global KV order.
+    return query_positions, torch.arange(total, device=device, dtype=torch.long)
+
+
+def _pad_cp_projected_kv(
+    kv: torch.Tensor,
+    index_k: torch.Tensor | None,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Physically align gathered CP KV for cuDNN top-k score loads."""
+    logical_rows = kv.shape[0]
+    aligned_rows = (
+        (logical_rows + _CUDNN_DSA_TOPK_COLUMN_ALIGNMENT - 1)
+        // _CUDNN_DSA_TOPK_COLUMN_ALIGNMENT
+        * _CUDNN_DSA_TOPK_COLUMN_ALIGNMENT
+    )
+    pad_rows = aligned_rows - logical_rows
+    if pad_rows == 0:
+        return kv, index_k
+
+    kv = torch.cat((kv, kv.new_zeros((pad_rows, *kv.shape[1:]))), dim=0)
+    if index_k is not None:
+        index_k = torch.cat(
+            (index_k, index_k.new_zeros((pad_rows, *index_k.shape[1:]))), dim=0
+        )
+    return kv, index_k
+
+
+def _build_cp_causal_mask(
+    query_positions: torch.Tensor,
+    key_positions: torch.Tensor,
+    *,
+    cu_seqlens: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Build the explicit local-Q/global-K causal validity mask used by DSA CP."""
+    query_positions = query_positions.to(dtype=torch.long)
+    key_positions = key_positions.to(device=query_positions.device, dtype=torch.long)
+    valid = key_positions.unsqueeze(0) <= query_positions.unsqueeze(1)
+    if cu_seqlens is not None:
+        cu_seqlens = cu_seqlens.to(device=query_positions.device, dtype=torch.long)
+        query_segments = torch.bucketize(query_positions, cu_seqlens[1:], right=True)
+        key_segments = torch.bucketize(key_positions, cu_seqlens[1:], right=True)
+        valid = valid & (query_segments.unsqueeze(1) == key_segments.unsqueeze(0))
+    zeros = torch.zeros((), device=query_positions.device, dtype=torch.float32)
+    return torch.where(valid, zeros, torch.full_like(zeros, float("-inf")))
+
+
+def _index_scores_and_topk(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    weights: torch.Tensor,
+    *,
+    mask: torch.Tensor,
+    topk: int,
+    scale: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Kernel-routed CP indexer over local Q and gathered projected K."""
+    result = _dsa_kernels.indexer_topk_with_mask(
+        q,
+        k,
+        weights,
+        topk,
+        mask,
+        indexer_softmax_scale=scale,
+    )
+    if q.is_cuda:
+        # cuDNN FE 1.27's decode-varlen wrapper owns an asynchronous scratch
+        # buffer that is not returned to PyTorch.  Finish that launch before
+        # compactify can reuse the allocation; CUDA_LAUNCH_BLOCKING previously
+        # hid this lifetime bug during the focused THD run.
+        torch.cuda.current_stream(q.device).synchronize()
+    return result
+
+
+def _cp_indexer_loss(
+    q_indexer: torch.Tensor,
+    k_indexer: torch.Tensor,
+    weights: torch.Tensor,
+    topk_indices: torch.Tensor,
+    query: torch.Tensor,
+    kv: torch.Tensor,
+    *,
+    mask: torch.Tensor,
+    softmax_scale: float,
+    loss_coeff: float,
+    sparse_loss: bool,
+    calculate_per_token_loss: bool,
+) -> torch.Tensor:
+    """Kernel-layer KL target for explicit local-Q/global-K CP masking."""
+    return _dsa_kernels.cp_indexer_loss(
+        q_indexer,
+        k_indexer,
+        weights,
+        topk_indices,
+        query,
+        kv,
+        mask=mask,
+        softmax_scale=softmax_scale,
+        loss_coeff=loss_coeff,
+        sparse_loss=sparse_loss,
+        calculate_per_token_loss=calculate_per_token_loss,
+    )
+
+
+def is_dsa_skip_topk_layer(
+    layer_number: int, skip_topk_offset: int, topk_freq: int
+) -> bool:
+    """Return whether a 1-indexed layer reuses a previous DSA indexer top-k."""
+    if layer_number < 1:
+        raise ValueError(f"layer_number must be >= 1, got {layer_number}")
+    if topk_freq < 1:
+        raise ValueError(f"topk_freq must be >= 1, got {topk_freq}")
+    if skip_topk_offset < 0:
+        raise ValueError(f"skip_topk_offset must be >= 0, got {skip_topk_offset}")
+    if topk_freq == 1:
+        return False
+    return (max(layer_number - skip_topk_offset, 0) % topk_freq) != 0
+
+
+def source_dsa_compute_layer(
+    layer_number: int, skip_topk_offset: int, topk_freq: int
+) -> int:
+    """Return the 1-indexed full/indexer layer used by ``layer_number``."""
+    if not is_dsa_skip_topk_layer(layer_number, skip_topk_offset, topk_freq):
+        return layer_number
+    source_layer = layer_number - (max(layer_number - skip_topk_offset, 0) % topk_freq)
+    if source_layer < 1:
+        raise ValueError(
+            "DSA IndexShare schedule makes layer "
+            f"{layer_number} shared before any full source layer."
+        )
+    return source_layer
+
+
+def dsa_indexer_type_for_layer(
+    layer_number: int, skip_topk_offset: int, topk_freq: int
+) -> str:
+    return (
+        "shared"
+        if is_dsa_skip_topk_layer(layer_number, skip_topk_offset, topk_freq)
+        else "full"
+    )
+
+
+class DSAIndexShareState:
+    """Per-forward top-k holder for DSA cross-layer IndexShare.
+
+    Only one source layer is resident on GPU at a time.  When activation
+    checkpointing needs old source groups during backward recomputation, they
+    are retained on CPU and paged back one group at a time.  This keeps the GPU
+    working set bounded instead of letting checkpoint closures retain every
+    source layer's ``[B, S, topk]`` tensor.
+    """
+
+    def __init__(self, *, retain_for_recompute: bool = True):
+        self.retain_for_recompute = retain_for_recompute
+        self._resident_source_layer: int | None = None
+        self._resident_topk_by_layer: dict[
+            tuple[int, Hashable | None], torch.Tensor
+        ] = {}
+        self._cpu_topk_by_layer: dict[tuple[int, Hashable | None], torch.Tensor] = {}
+        self._sealed = False
+
+    @staticmethod
+    def _key(
+        layer_number: int, sequence_key: Hashable | None
+    ) -> tuple[int, Hashable | None]:
+        return layer_number, sequence_key
+
+    def save_topk(
+        self,
+        layer_number: int,
+        topk_indices: torch.Tensor,
+        *,
+        sequence_key: Hashable | None = None,
+    ) -> None:
+        if self._sealed:
+            # A full source layer is being recomputed in backward.  Its shared
+            # consumers have already run in reverse order, so no later layer
+            # needs the newly produced top-k.
+            if self._resident_source_layer == layer_number:
+                self._resident_topk_by_layer.clear()
+                self._resident_source_layer = None
+            return
+
+        if self._resident_source_layer not in (None, layer_number):
+            self._evict_resident(retain=self.retain_for_recompute)
+        self._resident_source_layer = layer_number
+        self._resident_topk_by_layer[self._key(layer_number, sequence_key)] = (
+            topk_indices.detach()
+        )
+
+    def finish_forward(self) -> None:
+        """Evict the final GPU source group before returning model outputs."""
+        if self._sealed:
+            return
+        self._evict_resident(retain=self.retain_for_recompute)
+        self._sealed = True
+
+    def _evict_resident(self, *, retain: bool) -> None:
+        if retain:
+            for key, topk in self._resident_topk_by_layer.items():
+                self._cpu_topk_by_layer[key] = topk.detach().to(device="cpu")
+        self._resident_topk_by_layer.clear()
+        self._resident_source_layer = None
+
+    @property
+    def _topk_by_layer(self) -> dict[tuple[int, Hashable | None], torch.Tensor]:
+        """Private compatibility view used by focused validation harnesses."""
+        return {**self._cpu_topk_by_layer, **self._resident_topk_by_layer}
+
+    def get_topk(
+        self,
+        layer_number: int,
+        source_layer: int,
+        *,
+        sequence_key: Hashable | None = None,
+        device: torch.device | None = None,
+    ) -> torch.Tensor:
+        key = self._key(source_layer, sequence_key)
+        if key in self._resident_topk_by_layer:
+            return self._resident_topk_by_layer[key]
+        if key not in self._cpu_topk_by_layer:
+            available = sorted(self._topk_by_layer)
+            raise AssertionError(
+                "DSA IndexShare shared layer "
+                f"{layer_number} needs top-k indices from source layer {source_layer}, "
+                "but that source did not run earlier in this forward. "
+                "Cross-PP top-k sharing is not supported. "
+                f"Available cache keys: {available}."
+            )
+
+        if self._resident_source_layer != source_layer:
+            # During backward, groups are consumed in reverse order.  The CPU
+            # copy already remains authoritative, so dropping the previous GPU
+            # group does not require another device-to-host transfer.
+            self._resident_topk_by_layer.clear()
+            self._resident_source_layer = source_layer
+        topk = self._cpu_topk_by_layer[key]
+        if device is not None and topk.device != device:
+            topk = topk.to(device=device)
+        self._resident_topk_by_layer[key] = topk
+        return topk
+
+
+def validate_dsa_index_share_pipeline_split(
+    layer_indices: list[int],
+    *,
+    topk_freq: int,
+    skip_topk_offset: int,
+    indexer_types: list[str] | None = None,
+) -> None:
+    """Fail fast if a local PP stage starts on a shared DSA IndexShare layer."""
+    if topk_freq <= 1 and not indexer_types:
+        return
+
+    positions = {layer_idx: pos for pos, layer_idx in enumerate(layer_indices)}
+    for layer_idx in layer_indices:
+        if indexer_types is not None and layer_idx < len(indexer_types):
+            indexer_type = indexer_types[layer_idx]
+        else:
+            indexer_type = dsa_indexer_type_for_layer(
+                layer_idx + 1, skip_topk_offset, topk_freq
+            )
+        if indexer_type != "shared":
+            continue
+
+        source_idx = (
+            source_dsa_compute_layer(layer_idx + 1, skip_topk_offset, topk_freq) - 1
+        )
+        if source_idx not in positions:
+            raise ValueError(
+                "DSA IndexShare cannot cross pipeline stages: layer "
+                f"{layer_idx} is shared from source layer {source_idx}, but this "
+                f"stage only owns layers {layer_indices}."
+            )
+        if positions[source_idx] >= positions[layer_idx]:
+            raise ValueError(
+                "DSA IndexShare source layer must execute before its shared layer "
+                f"within a pipeline stage, got source={source_idx}, layer={layer_idx}, "
+                f"stage layers={layer_indices}."
+            )
 
 
 class DSAIndexer(nn.Module):
@@ -260,18 +609,31 @@ class DSAIndexer(nn.Module):
             )
         batch, seq_len, _ = x.shape
         cos, sin = _rotary_embeddings_from_cache(
-            cos, sin, position_ids, device=x.device, dtype=x.dtype, dim=self.qk_rope_head_dim
+            cos,
+            sin,
+            position_ids,
+            device=x.device,
+            dtype=x.dtype,
+            dim=self.qk_rope_head_dim,
         )
 
         q = self.wq_b(q_resid).view(batch, seq_len, self.num_heads, self.head_dim)
 
         k = self.k_norm(self.wk(x))
         if self.rope_first:
-            q_pe, q_nope = torch.split(q, [self.qk_rope_head_dim, self.qk_nope_head_dim], dim=-1)
-            k_pe, k_nope = torch.split(k, [self.qk_rope_head_dim, self.qk_nope_head_dim], dim=-1)
+            q_pe, q_nope = torch.split(
+                q, [self.qk_rope_head_dim, self.qk_nope_head_dim], dim=-1
+            )
+            k_pe, k_nope = torch.split(
+                k, [self.qk_rope_head_dim, self.qk_nope_head_dim], dim=-1
+            )
         else:
-            q_nope, q_pe = torch.split(q, [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
-            k_nope, k_pe = torch.split(k, [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
+            q_nope, q_pe = torch.split(
+                q, [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1
+            )
+            k_nope, k_pe = torch.split(
+                k, [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1
+            )
         q_pe = apply_rotary_pos_emb(q_pe, cos, sin, unsqueeze_dim=2)
         k_pe = apply_rotary_pos_emb(k_pe.unsqueeze(2), cos, sin, unsqueeze_dim=2)
         k_pe = k_pe.squeeze(2)
@@ -345,18 +707,27 @@ class DynamicSparseAttention(nn.Module):
         indexer_rope_interleaved: bool | None = None,
         indexer_rope_first: bool = False,
         indexer_use_hadamard: bool = True,
+        layer_number: int | None = None,
+        index_topk_freq: int = 1,
+        index_skip_topk_offset: int = 0,
+        indexer_type: str | None = None,
         indexer_loss_coeff: float = 0.0,
         indexer_use_sparse_loss: bool = False,
         calculate_per_token_loss: bool = False,
         cp_size: int = 1,
         cp_rank: int = 0,
         cp_group=None,
+        cp_mode: str = "native",
     ):
         super().__init__()
         if cp_size < 1:
             raise ValueError(f"cp_size must be >= 1, got {cp_size}")
         if not 0 <= cp_rank < cp_size:
             raise ValueError(f"cp_rank must be in [0, {cp_size}), got {cp_rank}")
+        if cp_mode not in {"native", "legacy_gather_all"}:
+            raise ValueError(
+                "cp_mode must be 'native' or 'legacy_gather_all', " f"got {cp_mode!r}"
+            )
         self.num_heads = num_attention_heads
         self.q_lora_rank = q_lora_rank
         self.kv_lora_rank = kv_lora_rank
@@ -366,40 +737,78 @@ class DynamicSparseAttention(nn.Module):
         self.v_head_dim = v_head_dim
         self.rope_interleaved = rope_interleaved
         self.softmax_scale = self.qk_head_dim**-0.5
+        self.index_topk = index_topk
+        self.indexer_softmax_scale = index_head_dim**-0.5
         self.indexer_loss_coeff = indexer_loss_coeff
         self.indexer_use_sparse_loss = indexer_use_sparse_loss
         self.calculate_per_token_loss = calculate_per_token_loss
         self.cp_size = cp_size
         self.cp_rank = cp_rank
         self.cp_group = cp_group
-        latent_rms_norm_eps = rms_norm_eps if latent_rms_norm_eps is None else latent_rms_norm_eps
+        self.cp_mode = cp_mode
+        self.layer_number = 1 if layer_number is None else layer_number
+        self.index_topk_freq = index_topk_freq
+        self.index_skip_topk_offset = index_skip_topk_offset
+        inferred_indexer_type = dsa_indexer_type_for_layer(
+            self.layer_number, self.index_skip_topk_offset, self.index_topk_freq
+        )
+        if indexer_type is None:
+            indexer_type = inferred_indexer_type
+        if indexer_type not in {"full", "shared"}:
+            raise ValueError(
+                f"indexer_type must be 'full' or 'shared', got {indexer_type!r}"
+            )
+        if indexer_type != inferred_indexer_type:
+            raise ValueError(
+                f"indexer_type={indexer_type!r} for layer {self.layer_number} does not match "
+                f"IndexShare schedule {inferred_indexer_type!r}."
+            )
+        self.indexer_type = indexer_type
+        self.index_share_enabled = self.index_topk_freq > 1
+        self.skip_topk = indexer_type == "shared"
+        self.index_share_source_layer = source_dsa_compute_layer(
+            self.layer_number, self.index_skip_topk_offset, self.index_topk_freq
+        )
+        latent_rms_norm_eps = (
+            rms_norm_eps if latent_rms_norm_eps is None else latent_rms_norm_eps
+        )
         indexer_rope_interleaved = (
-            rope_interleaved if indexer_rope_interleaved is None else indexer_rope_interleaved
+            rope_interleaved
+            if indexer_rope_interleaved is None
+            else indexer_rope_interleaved
         )
 
         self.q_a_proj = nn.Linear(hidden_size, q_lora_rank, bias=False)
         self.q_a_layernorm = RMSNorm(q_lora_rank, eps=latent_rms_norm_eps)
-        self.q_b_proj = nn.Linear(q_lora_rank, num_attention_heads * self.qk_head_dim, bias=False)
+        self.q_b_proj = nn.Linear(
+            q_lora_rank, num_attention_heads * self.qk_head_dim, bias=False
+        )
         self.kv_a_proj_with_mqa = nn.Linear(
             hidden_size, kv_lora_rank + qk_rope_head_dim, bias=False
         )
         self.kv_a_layernorm = RMSNorm(kv_lora_rank, eps=latent_rms_norm_eps)
         self.kv_b_proj = nn.Linear(
-            kv_lora_rank, num_attention_heads * (qk_nope_head_dim + v_head_dim), bias=False
+            kv_lora_rank,
+            num_attention_heads * (qk_nope_head_dim + v_head_dim),
+            bias=False,
         )
-        self.o_proj = nn.Linear(num_attention_heads * v_head_dim, hidden_size, bias=False)
-        self.indexer = DSAIndexer(
-            hidden_size=hidden_size,
-            q_lora_rank=q_lora_rank,
-            qk_rope_head_dim=qk_rope_head_dim,
-            index_n_heads=index_n_heads,
-            index_head_dim=index_head_dim,
-            index_topk=index_topk,
-            rope_interleaved=indexer_rope_interleaved,
-            layer_norm_eps=indexer_layer_norm_eps,
-            rope_first=indexer_rope_first,
-            use_hadamard=indexer_use_hadamard,
+        self.o_proj = nn.Linear(
+            num_attention_heads * v_head_dim, hidden_size, bias=False
         )
+        self.indexer: DSAIndexer | None = None
+        if not self.skip_topk:
+            self.indexer = DSAIndexer(
+                hidden_size=hidden_size,
+                q_lora_rank=q_lora_rank,
+                qk_rope_head_dim=qk_rope_head_dim,
+                index_n_heads=index_n_heads,
+                index_head_dim=index_head_dim,
+                index_topk=index_topk,
+                rope_interleaved=indexer_rope_interleaved,
+                layer_norm_eps=indexer_layer_norm_eps,
+                rope_first=indexer_rope_first,
+                use_hadamard=indexer_use_hadamard,
+            )
         self.register_buffer(
             "attn_sink",
             torch.full((num_attention_heads,), -1.0e20, dtype=torch.float32),
@@ -415,6 +824,7 @@ class DynamicSparseAttention(nn.Module):
         position_ids: torch.Tensor,
         attention_mask: torch.Tensor | None = None,
         packed_seq_params=None,
+        index_share_state: DSAIndexShareState | None = None,
     ) -> torch.Tensor:
         if attention_mask is not None:
             raise NotImplementedError(
@@ -422,30 +832,333 @@ class DynamicSparseAttention(nn.Module):
                 "is not supported."
             )
         if packed_seq_params is not None:
+            if self.cp_size > 1 and self.cp_mode == "native":
+                return self._forward_packed_cp_native(
+                    x,
+                    cos,
+                    sin,
+                    position_ids,
+                    packed_seq_params,
+                    index_share_state=index_share_state,
+                )
             if self.cp_size > 1:
-                x, position_ids = self._gather_packed_cp_inputs(x, position_ids, packed_seq_params)
-                cos, sin = self._gather_packed_cp_rotary(cos, sin, packed_seq_params, x.device)
-            out = self._forward_packed_full(x, cos, sin, position_ids, packed_seq_params)
+                x, position_ids = self._gather_packed_cp_inputs(
+                    x, position_ids, packed_seq_params
+                )
+                cos, sin = self._gather_packed_cp_rotary(
+                    cos, sin, packed_seq_params, x.device
+                )
+            out = self._forward_packed_full(
+                x,
+                cos,
+                sin,
+                position_ids,
+                packed_seq_params,
+                index_share_state=index_share_state,
+            )
             if self.cp_size > 1:
-                out = split_packed_to_cp_local(
-                    out,
-                    cu_seqlens_padded=self._packed_cu_seqlens(packed_seq_params, x.device),
-                    cp_size=self.cp_size,
-                    cp_rank=self.cp_rank,
-                    dim=1,
+                out = contiguous_slice_for_cp(
+                    out, self.cp_rank, self.cp_size, seq_dim=1
                 )
             return out
+
+        if self.cp_size > 1 and self.cp_mode == "native":
+            return self._forward_dense_cp_native(
+                x,
+                cos,
+                sin,
+                position_ids,
+                index_share_state=index_share_state,
+            )
 
         cp_restore = self.cp_size > 1
         if cp_restore:
             x, position_ids, attention_mask = self._gather_cp_inputs(
                 x, position_ids, attention_mask
             )
+            cos, sin = self._gather_dense_cp_rotary(cos, sin, full_seq=x.shape[1])
 
-        out = self._forward_dense_full(x, cos, sin, position_ids)
+        out = self._forward_dense_full(
+            x, cos, sin, position_ids, index_share_state=index_share_state
+        )
         if cp_restore:
-            out = zigzag_slice_for_cp(out, self.cp_rank, self.cp_size, seq_dim=1)
+            out = contiguous_slice_for_cp(out, self.cp_rank, self.cp_size, seq_dim=1)
         return out
+
+    def _project_cp_inputs(
+        self,
+        x: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        position_ids: torch.Tensor,
+    ) -> tuple[
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor | None,
+        torch.Tensor | None,
+        torch.Tensor | None,
+    ]:
+        """Project rank-local hidden rows before any CP collective."""
+        batch, local_seq, _ = x.shape
+        q_resid = self.q_a_layernorm(self.q_a_proj(x))
+        q = self.q_b_proj(q_resid).view(
+            batch, local_seq, self.num_heads, self.qk_head_dim
+        )
+        q_nope, q_pe = torch.split(
+            q, [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1
+        )
+        local_cos, local_sin = _rotary_embeddings_from_cache(
+            cos,
+            sin,
+            position_ids,
+            device=x.device,
+            dtype=x.dtype,
+            dim=self.qk_rope_head_dim,
+        )
+        q_pe = apply_rotary_pos_emb(q_pe, local_cos, local_sin, unsqueeze_dim=2)
+        k_up_weight, v_up_weight = self._split_kv_b_weights()
+        q_nope = torch.einsum("bshd,hdr->bshr", q_nope, k_up_weight)
+        query = torch.cat([q_nope, q_pe], dim=-1).transpose(0, 1).contiguous()
+
+        kv_latent, k_pe = torch.split(
+            self.kv_a_proj_with_mqa(x),
+            [self.kv_lora_rank, self.qk_rope_head_dim],
+            dim=-1,
+        )
+        kv_latent = self.kv_a_layernorm(kv_latent)
+        k_pe = apply_rotary_pos_emb(
+            k_pe.unsqueeze(2), local_cos, local_sin, unsqueeze_dim=2
+        ).squeeze(2)
+        kv = torch.cat([kv_latent, k_pe], dim=-1).transpose(0, 1).contiguous()
+
+        q_indexer = k_indexer = weights_indexer = None
+        if not self.skip_topk:
+            assert self.indexer is not None
+            q_indexer, k_indexer, weights_indexer = self.indexer.forward_before_topk(
+                x.detach(), q_resid.detach(), local_cos, local_sin, position_ids
+            )
+        return query, kv, v_up_weight, q_indexer, k_indexer, weights_indexer
+
+    def _gather_projected_cp(
+        self,
+        tensor: torch.Tensor,
+        kv_reorder: torch.Tensor,
+        *,
+        contiguous: bool = False,
+    ) -> torch.Tensor:
+        if not contiguous:
+            parts = _all_gather_cp(
+                tensor, cp_size=self.cp_size, cp_group=self.cp_group
+            )
+            rank_major = torch.cat(parts, dim=0)
+            return rank_major.index_select(0, kv_reorder)
+        local_positions = contiguous_position_ids_for_cp(
+            tensor.shape[0] * self.cp_size,
+            self.cp_rank,
+            self.cp_size,
+            tensor.device,
+        )
+        parts = [
+            source
+            for _rank, source, _positions in iter_cp_sources(
+                tensor,
+                local_positions,
+                cp_rank=self.cp_rank,
+                cp_size=self.cp_size,
+                cp_group=self.cp_group,
+            )
+        ]
+        rank_major = torch.cat(parts, dim=0)
+        return rank_major.index_select(0, kv_reorder)
+
+    def _run_cp_sparse_segment(
+        self,
+        query: torch.Tensor,
+        kv: torch.Tensor,
+        q_indexer: torch.Tensor | None,
+        k_indexer: torch.Tensor | None,
+        weights_indexer: torch.Tensor | None,
+        mask: torch.Tensor,
+        *,
+        index_share_state: DSAIndexShareState | None,
+        index_share_cache_key: Hashable | None,
+    ) -> torch.Tensor:
+        batch = query.shape[1]
+        topk_indices: torch.Tensor | None = None
+        if self.skip_topk:
+            if index_share_state is None:
+                raise AssertionError(
+                    "DSA IndexShare shared layers require a per-forward DSAIndexShareState."
+                )
+            topk_indices = index_share_state.get_topk(
+                self.layer_number,
+                self.index_share_source_layer,
+                sequence_key=index_share_cache_key,
+                device=query.device,
+            )
+        else:
+            assert q_indexer is not None and k_indexer is not None
+            assert weights_indexer is not None
+            _scores, topk_indices = _index_scores_and_topk(
+                q_indexer,
+                k_indexer,
+                weights_indexer,
+                mask=mask,
+                topk=self.index_topk,
+                scale=self.indexer_softmax_scale,
+            )
+            if self.index_share_enabled and index_share_state is not None:
+                index_share_state.save_topk(
+                    self.layer_number,
+                    topk_indices,
+                    sequence_key=index_share_cache_key,
+                )
+
+        flat_idxs, flat_tlen = _dsa_kernels.build_flat_topk_idxs(
+            topk_indices,
+            batch_size=batch,
+            seqlen_kv=kv.shape[0],
+            compact=True,
+        )
+        out = _dsa_kernels.dsa_sparse_attn(
+            query,
+            kv,
+            self.attn_sink.float(),
+            flat_idxs,
+            self.softmax_scale,
+            topk_length=flat_tlen,
+            value_dim=self.kv_lora_rank,
+        )
+        if self.training and torch.is_grad_enabled() and not self.skip_topk:
+            indexer_loss = _cp_indexer_loss(
+                q_indexer,
+                k_indexer,
+                weights_indexer,
+                topk_indices,
+                query.detach(),
+                kv.detach(),
+                mask=mask,
+                softmax_scale=self.softmax_scale,
+                loss_coeff=self.indexer_loss_coeff,
+                sparse_loss=self.indexer_use_sparse_loss,
+                calculate_per_token_loss=self.calculate_per_token_loss,
+            )
+            out = DSAIndexerLossAutoScaler.apply(out, indexer_loss)
+        return out
+
+    def _project_cp_output(
+        self, out: torch.Tensor, v_up_weight: torch.Tensor
+    ) -> torch.Tensor:
+        local_seq, batch = out.shape[:2]
+        out = out.view(local_seq, batch, self.num_heads, self.kv_lora_rank)
+        out = out.permute(1, 0, 2, 3).contiguous()
+        out = torch.einsum("bshr,hvr->bshv", out, v_up_weight)
+        out = out.reshape(batch, local_seq, self.num_heads * self.v_head_dim)
+        return self.o_proj(out)
+
+    def _forward_dense_cp_native(
+        self,
+        x: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        position_ids: torch.Tensor,
+        *,
+        index_share_state: DSAIndexShareState | None,
+    ) -> torch.Tensor:
+        query_pos, kv_reorder = _dense_cp_layout(
+            local_seq=x.shape[1],
+            cp_size=self.cp_size,
+            cp_rank=self.cp_rank,
+            device=x.device,
+        )
+        query, kv_local, v_up_weight, q_idx, k_idx_local, idx_weights = (
+            self._project_cp_inputs(x, cos, sin, position_ids)
+        )
+        kv = self._gather_projected_cp(kv_local, kv_reorder)
+        k_idx = (
+            self._gather_projected_cp(k_idx_local, kv_reorder)
+            if k_idx_local is not None
+            else None
+        )
+        if kv.is_cuda and not self.skip_topk:
+            kv, k_idx = _pad_cp_projected_kv(kv, k_idx)
+        mask = _build_cp_causal_mask(
+            query_pos,
+            torch.arange(kv.shape[0], device=x.device),
+        )
+        out = self._run_cp_sparse_segment(
+            query,
+            kv,
+            q_idx,
+            k_idx,
+            idx_weights,
+            mask,
+            index_share_state=index_share_state,
+            index_share_cache_key=None,
+        )
+        return self._project_cp_output(out, v_up_weight)
+
+    def _forward_packed_cp_native(
+        self,
+        x: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        position_ids: torch.Tensor,
+        packed_seq_params,
+        *,
+        index_share_state: DSAIndexShareState | None,
+    ) -> torch.Tensor:
+        if x.shape[0] != 1:
+            raise RuntimeError(
+                "GLM5 THD+CP DSA expects batch-collapsed input [1, total, hidden]."
+            )
+        cu_seqlens = self._packed_cu_seqlens(packed_seq_params, x.device)
+        cp_layout = getattr(packed_seq_params, "cp_layout", "contiguous")
+        if cp_layout != "contiguous":
+            raise ValueError(
+                "GLM5 THD+CP DSA requires contiguous allgather-CP layout, "
+                f"got {cp_layout!r}."
+            )
+        query_pos, kv_reorder = _packed_cp_layout(
+            cu_seqlens,
+            cp_size=self.cp_size,
+            cp_rank=self.cp_rank,
+            device=x.device,
+        )
+        if query_pos.numel() != x.shape[1]:
+            raise RuntimeError(
+                "GLM5 THD+CP local token count does not match packed CP layout: "
+                f"x={x.shape[1]}, layout={cp_layout!r}, expected={query_pos.numel()}."
+            )
+        query, kv_local, v_up_weight, q_idx, k_idx_local, idx_weights = (
+            self._project_cp_inputs(x, cos, sin, position_ids)
+        )
+        kv = self._gather_projected_cp(kv_local, kv_reorder, contiguous=True)
+        k_idx = (
+            self._gather_projected_cp(k_idx_local, kv_reorder, contiguous=True)
+            if k_idx_local is not None
+            else None
+        )
+        if kv.is_cuda and not self.skip_topk:
+            kv, k_idx = _pad_cp_projected_kv(kv, k_idx)
+        key_pos = torch.arange(kv.shape[0], device=x.device, dtype=torch.long)
+        mask = _build_cp_causal_mask(
+            query_pos,
+            key_pos,
+            cu_seqlens=cu_seqlens,
+        )
+        out = self._run_cp_sparse_segment(
+            query,
+            kv,
+            q_idx,
+            k_idx,
+            idx_weights,
+            mask,
+            index_share_state=index_share_state,
+            index_share_cache_key=None,
+        )
+        return self._project_cp_output(out, v_up_weight)
 
     def _forward_packed_full(
         self,
@@ -454,6 +1167,8 @@ class DynamicSparseAttention(nn.Module):
         sin: torch.Tensor,
         position_ids: torch.Tensor,
         packed_seq_params,
+        *,
+        index_share_state: DSAIndexShareState | None,
     ) -> torch.Tensor:
         cu_seqlens = self._packed_cu_seqlens(packed_seq_params, x.device)
         if position_ids.dim() == 1:
@@ -476,6 +1191,8 @@ class DynamicSparseAttention(nn.Module):
                     seg_cos,
                     seg_sin,
                     position_ids[:, start:end],
+                    index_share_state=index_share_state,
+                    index_share_cache_key=idx,
                 )
             )
         if pieces:
@@ -488,14 +1205,26 @@ class DynamicSparseAttention(nn.Module):
         cos: torch.Tensor,
         sin: torch.Tensor,
         position_ids: torch.Tensor,
+        *,
+        index_share_state: DSAIndexShareState | None = None,
+        index_share_cache_key: Hashable | None = None,
     ) -> torch.Tensor:
 
         batch, seq_len, _ = x.shape
         q_resid = self.q_a_layernorm(self.q_a_proj(x))
-        q = self.q_b_proj(q_resid).view(batch, seq_len, self.num_heads, self.qk_head_dim)
-        q_nope, q_pe = torch.split(q, [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
+        q = self.q_b_proj(q_resid).view(
+            batch, seq_len, self.num_heads, self.qk_head_dim
+        )
+        q_nope, q_pe = torch.split(
+            q, [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1
+        )
         cos, sin = _rotary_embeddings_from_cache(
-            cos, sin, position_ids, device=x.device, dtype=x.dtype, dim=self.qk_rope_head_dim
+            cos,
+            sin,
+            position_ids,
+            device=x.device,
+            dtype=x.dtype,
+            dim=self.qk_rope_head_dim,
         )
 
         q_pe = apply_rotary_pos_emb(q_pe, cos, sin, unsqueeze_dim=2)
@@ -504,48 +1233,113 @@ class DynamicSparseAttention(nn.Module):
         query_states = torch.cat([q_nope, q_pe], dim=-1).transpose(0, 1).contiguous()
 
         kv_latent, k_pe = torch.split(
-            self.kv_a_proj_with_mqa(x), [self.kv_lora_rank, self.qk_rope_head_dim], dim=-1
+            self.kv_a_proj_with_mqa(x),
+            [self.kv_lora_rank, self.qk_rope_head_dim],
+            dim=-1,
         )
         kv_latent = self.kv_a_layernorm(kv_latent)
-        k_pe = apply_rotary_pos_emb(k_pe.unsqueeze(2), cos, sin, unsqueeze_dim=2).squeeze(2)
+        k_pe = apply_rotary_pos_emb(
+            k_pe.unsqueeze(2), cos, sin, unsqueeze_dim=2
+        ).squeeze(2)
         kv_full = torch.cat([kv_latent, k_pe], dim=-1).transpose(0, 1).contiguous()
 
-        q_indexer, k_indexer, weights_indexer = self.indexer.forward_before_topk(
-            x.detach(), q_resid.detach(), cos, sin, position_ids
-        )
-        effective_indexer_topk = min(self.indexer.index_topk, seq_len)
-
-        if self.training and torch.is_grad_enabled():
-            window_idxs = torch.empty(batch, seq_len, 0, device=x.device, dtype=torch.int32)
-            out, indexer_loss = _fused_indexer_sparse_attn(
-                query_states,
-                kv_full,
-                self.attn_sink.float(),
-                window_idxs,
-                q_indexer,
-                k_indexer,
-                weights_indexer,
-                self.indexer.index_topk,
-                1,
-                self.softmax_scale,
-                self.indexer.softmax_scale,
-                self.indexer_loss_coeff,
-                sparse_loss=self.indexer_use_sparse_loss,
-                kv_offset=0,
-                calculate_per_token_loss=self.calculate_per_token_loss,
-                value_dim=self.kv_lora_rank,
+        topk_indices: torch.Tensor | None = None
+        q_indexer = k_indexer = weights_indexer = None
+        if self.skip_topk:
+            if index_share_state is None:
+                raise AssertionError(
+                    "DSA IndexShare shared layers require a per-forward "
+                    "DSAIndexShareState."
+                )
+            topk_indices = index_share_state.get_topk(
+                self.layer_number,
+                self.index_share_source_layer,
+                sequence_key=index_share_cache_key,
+                device=x.device,
             )
+        else:
+            assert self.indexer is not None
+            q_indexer, k_indexer, weights_indexer = self.indexer.forward_before_topk(
+                x.detach(), q_resid.detach(), cos, sin, position_ids
+            )
+        effective_indexer_topk = min(self.index_topk, seq_len)
+
+        if self.training and torch.is_grad_enabled() and not self.skip_topk:
+            window_idxs = torch.empty(
+                batch, seq_len, 0, device=x.device, dtype=torch.int32
+            )
+            assert (
+                q_indexer is not None
+                and k_indexer is not None
+                and weights_indexer is not None
+            )
+            if self.index_share_enabled:
+                out, indexer_loss, topk_indices = _fused_indexer_sparse_attn_with_topk(
+                    query_states,
+                    kv_full,
+                    self.attn_sink.float(),
+                    window_idxs,
+                    q_indexer,
+                    k_indexer,
+                    weights_indexer,
+                    self.index_topk,
+                    1,
+                    self.softmax_scale,
+                    self.indexer_softmax_scale,
+                    self.indexer_loss_coeff,
+                    sparse_loss=self.indexer_use_sparse_loss,
+                    kv_offset=0,
+                    calculate_per_token_loss=self.calculate_per_token_loss,
+                    value_dim=self.kv_lora_rank,
+                )
+                if index_share_state is not None:
+                    index_share_state.save_topk(
+                        self.layer_number,
+                        topk_indices,
+                        sequence_key=index_share_cache_key,
+                    )
+            else:
+                out, indexer_loss = _fused_indexer_sparse_attn(
+                    query_states,
+                    kv_full,
+                    self.attn_sink.float(),
+                    window_idxs,
+                    q_indexer,
+                    k_indexer,
+                    weights_indexer,
+                    self.index_topk,
+                    1,
+                    self.softmax_scale,
+                    self.indexer_softmax_scale,
+                    self.indexer_loss_coeff,
+                    sparse_loss=self.indexer_use_sparse_loss,
+                    kv_offset=0,
+                    calculate_per_token_loss=self.calculate_per_token_loss,
+                    value_dim=self.kv_lora_rank,
+                )
             if self.indexer_loss_coeff > 0:
                 out = DSAIndexerLossAutoScaler.apply(out, indexer_loss)
         else:
-            topk_indices, _ = _dsa_kernels.indexer_topk(
-                q_indexer,
-                k_indexer,
-                weights_indexer,
-                effective_indexer_topk,
-                1,
-                indexer_softmax_scale=self.indexer.softmax_scale,
-            )
+            if topk_indices is None:
+                assert (
+                    q_indexer is not None
+                    and k_indexer is not None
+                    and weights_indexer is not None
+                )
+                topk_indices, _ = _dsa_kernels.indexer_topk(
+                    q_indexer,
+                    k_indexer,
+                    weights_indexer,
+                    effective_indexer_topk,
+                    1,
+                    indexer_softmax_scale=self.indexer_softmax_scale,
+                )
+                if self.index_share_enabled and index_share_state is not None:
+                    index_share_state.save_topk(
+                        self.layer_number,
+                        topk_indices,
+                        sequence_key=index_share_cache_key,
+                    )
             flat_idxs, flat_tlen = _dsa_kernels.build_flat_topk_idxs(
                 topk_indices, batch_size=batch, seqlen_kv=seq_len, compact=True
             )
@@ -569,18 +1363,28 @@ class DynamicSparseAttention(nn.Module):
         kv_b = self.kv_b_proj.weight.view(
             self.num_heads, self.qk_nope_head_dim + self.v_head_dim, self.kv_lora_rank
         )
-        return (kv_b[:, : self.qk_nope_head_dim, :], kv_b[:, self.qk_nope_head_dim :, :])
+        return (
+            kv_b[:, : self.qk_nope_head_dim, :],
+            kv_b[:, self.qk_nope_head_dim :, :],
+        )
 
     def _gather_cp_inputs(
-        self, x: torch.Tensor, position_ids: torch.Tensor, attention_mask: torch.Tensor | None
+        self,
+        x: torch.Tensor,
+        position_ids: torch.Tensor,
+        attention_mask: torch.Tensor | None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
         local_batch, local_seq = x.shape[:2]
         x_parts = _all_gather_cp(x, cp_size=self.cp_size, cp_group=self.cp_group)
-        full_x = zigzag_reconstruct_from_cp_parts(x_parts, seq_dim=1)
+        full_x = torch.cat(x_parts, dim=1)
         full_seq = full_x.shape[1]
 
         full_position_ids = self._full_cp_position_ids(
-            position_ids, batch=local_batch, local_seq=local_seq, full_seq=full_seq, device=x.device
+            position_ids,
+            batch=local_batch,
+            local_seq=local_seq,
+            full_seq=full_seq,
+            device=x.device,
         )
         if attention_mask is not None:
             expected = (full_seq, full_seq)
@@ -590,6 +1394,27 @@ class DynamicSparseAttention(nn.Module):
                     f"full sequence {expected}, got {tuple(attention_mask.shape)}."
                 )
         return full_x, full_position_ids, attention_mask
+
+    def _gather_dense_cp_rotary(
+        self, cos: torch.Tensor, sin: torch.Tensor, *, full_seq: int
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if cos.dim() != 3 or sin.dim() != 3:
+            return cos, sin
+        if cos.shape[1] == full_seq and sin.shape[1] == full_seq:
+            return cos, sin
+        expected_local_seq = full_seq // self.cp_size
+        if cos.shape[1] != expected_local_seq or sin.shape[1] != expected_local_seq:
+            raise ValueError(
+                "GLM5 DynamicSparseAttention CP rotary caches must be either local or full sequence "
+                f"length, got cos={tuple(cos.shape)} sin={tuple(sin.shape)} for "
+                f"local_seq={expected_local_seq}, full_seq={full_seq}."
+            )
+        cos_parts = _all_gather_cp(cos, cp_size=self.cp_size, cp_group=self.cp_group)
+        sin_parts = _all_gather_cp(sin, cp_size=self.cp_size, cp_group=self.cp_group)
+        return (
+            torch.cat(cos_parts, dim=1),
+            torch.cat(sin_parts, dim=1),
+        )
 
     def _full_cp_position_ids(
         self,
@@ -617,7 +1442,7 @@ class DynamicSparseAttention(nn.Module):
             cp_size=self.cp_size,
             cp_group=self.cp_group,
         )
-        return zigzag_reconstruct_from_cp_parts(pos_parts, seq_dim=1)
+        return torch.cat(pos_parts, dim=1)
 
     def _gather_packed_cp_inputs(
         self, x: torch.Tensor, position_ids: torch.Tensor, packed_seq_params
@@ -626,9 +1451,7 @@ class DynamicSparseAttention(nn.Module):
         cu_seqlens = self._packed_cu_seqlens(packed_seq_params, x.device)
         full_seq = int(cu_seqlens[-1].item())
         x_parts = _all_gather_cp(x, cp_size=self.cp_size, cp_group=self.cp_group)
-        full_x = reconstruct_packed_from_cp_parts(
-            x_parts, cu_seqlens_padded=cu_seqlens, cp_size=self.cp_size, dim=1
-        )
+        full_x = torch.cat(x_parts, dim=1)
 
         if position_ids.dim() == 1:
             position_ids = position_ids.unsqueeze(0)
@@ -640,14 +1463,18 @@ class DynamicSparseAttention(nn.Module):
                 "GLM5 packed DynamicSparseAttention CP position_ids must be either local or full packed length, "
                 f"got {tuple(position_ids.shape)} for local_seq={local_seq}, full_seq={full_seq}."
             )
-        pos_parts = _all_gather_cp(position_ids, cp_size=self.cp_size, cp_group=self.cp_group)
-        full_position_ids = reconstruct_packed_from_cp_parts(
-            pos_parts, cu_seqlens_padded=cu_seqlens, cp_size=self.cp_size, dim=1
+        pos_parts = _all_gather_cp(
+            position_ids, cp_size=self.cp_size, cp_group=self.cp_group
         )
+        full_position_ids = torch.cat(pos_parts, dim=1)
         return full_x, full_position_ids
 
     def _gather_packed_cp_rotary(
-        self, cos: torch.Tensor, sin: torch.Tensor, packed_seq_params, device: torch.device
+        self,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        packed_seq_params,
+        device: torch.device,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         if cos.dim() != 3 or sin.dim() != 3:
             return cos, sin
@@ -657,12 +1484,8 @@ class DynamicSparseAttention(nn.Module):
             return cos, sin
         cos_parts = _all_gather_cp(cos, cp_size=self.cp_size, cp_group=self.cp_group)
         sin_parts = _all_gather_cp(sin, cp_size=self.cp_size, cp_group=self.cp_group)
-        full_cos = reconstruct_packed_from_cp_parts(
-            cos_parts, cu_seqlens_padded=cu_seqlens, cp_size=self.cp_size, dim=1
-        )
-        full_sin = reconstruct_packed_from_cp_parts(
-            sin_parts, cu_seqlens_padded=cu_seqlens, cp_size=self.cp_size, dim=1
-        )
+        full_cos = torch.cat(cos_parts, dim=1)
+        full_sin = torch.cat(sin_parts, dim=1)
         return full_cos, full_sin
 
     @staticmethod
@@ -671,7 +1494,9 @@ class DynamicSparseAttention(nn.Module):
         if cu_seqlens is None:
             cu_seqlens = getattr(packed_seq_params, "cu_seqlens_q", None)
         if cu_seqlens is None:
-            raise ValueError("GLM5 packed DynamicSparseAttention requires packed cu_seqlens.")
+            raise ValueError(
+                "GLM5 packed DynamicSparseAttention requires packed cu_seqlens."
+            )
         return cu_seqlens.to(device=device, dtype=torch.int32)
 
     @staticmethod
@@ -684,6 +1509,7 @@ class DynamicSparseAttention(nn.Module):
 
 
 __all__ = [
+    "DSAIndexShareState",
     "DSAIndexer",
     "DSAIndexerLossAutoScaler",
     "DynamicSparseAttention",
@@ -694,4 +1520,5 @@ __all__ = [
     "build_rotary_embeddings",
     "rotate_activation",
     "rotate_half",
+    "validate_dsa_index_share_pipeline_split",
 ]

--- a/experimental/lite/megatron/lite/primitive/parallel/pp.py
+++ b/experimental/lite/megatron/lite/primitive/parallel/pp.py
@@ -13,6 +13,7 @@ final/loss stage — mlite's MTP shares the head there; cross-stage MTP is a fol
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -28,21 +29,132 @@ class PipelineChunkLayout:
     has_mtp: bool = False
 
 
-def _auto_layout(num_hidden_layers: int, pp_size: int, num_mtp_layers: int):
+def _auto_layout(
+    num_hidden_layers: int,
+    pp_size: int,
+    num_mtp_layers: int,
+    *,
+    rows: list[list[str]] | None = None,
+):
     """Balance ``[E, decoder*N, mtp*K, loss]`` into even contiguous chunks; the
     embedding/MTP/loss slots make their stages carry fewer decoders (e.g. 6/pp4 ->
     [1,2,2,1]) — Megatron's embedding/loss split accounting."""
-    from megatron.core.transformer.pipeline_parallel_layer_layout import (
-        PipelineParallelLayerLayout,
-    )
+    from megatron.core.transformer.pipeline_parallel_layer_layout import PipelineParallelLayerLayout
 
-    units = ["embedding"] + ["decoder"] * num_hidden_layers + ["mtp"] * max(num_mtp_layers, 0) + ["loss"]
-    base, remainder = divmod(len(units), pp_size)
-    rows, pos = [], 0
-    for size in (base + (1 if s < remainder else 0) for s in range(pp_size)):
-        rows.append(units[pos : pos + size])
-        pos += size
+    if rows is None:
+        units = ["embedding"] + ["decoder"] * num_hidden_layers + ["mtp"] * max(num_mtp_layers, 0) + ["loss"]
+        base, remainder = divmod(len(units), pp_size)
+        rows, pos = [], 0
+        for size in (base + (1 if s < remainder else 0) for s in range(pp_size)):
+            rows.append(units[pos : pos + size])
+            pos += size
     return PipelineParallelLayerLayout(rows, pipeline_model_parallel_size=pp_size)
+
+
+def _validate_decoder_layer_groups(
+    num_hidden_layers: int,
+    decoder_layer_groups: Sequence[Sequence[int]],
+) -> list[list[int]]:
+    groups = [list(group) for group in decoder_layer_groups]
+    if any(not group for group in groups):
+        raise ValueError("decoder_layer_groups must not contain empty groups.")
+    flattened = [layer_idx for group in groups for layer_idx in group]
+    expected = list(range(num_hidden_layers))
+    if flattened != expected:
+        raise ValueError(
+            "decoder_layer_groups must cover decoder layers 0..num_hidden_layers-1 "
+            f"exactly once in order; got {flattened[:8]}...{flattened[-8:]} "
+            f"for num_hidden_layers={num_hidden_layers}."
+        )
+    for group in groups:
+        if group != list(range(group[0], group[0] + len(group))):
+            raise ValueError(f"decoder_layer_groups must be contiguous; got {group}.")
+    return groups
+
+
+def _auto_layout_with_decoder_groups(
+    num_hidden_layers: int,
+    pp_size: int,
+    num_mtp_layers: int,
+    decoder_layer_groups: Sequence[Sequence[int]],
+):
+    """Auto-balance like ``_auto_layout`` while never splitting protected decoder groups."""
+    groups = _validate_decoder_layer_groups(num_hidden_layers, decoder_layer_groups)
+    lengths = [len(group) for group in groups]
+    prefix = [0]
+    for length in lengths:
+        prefix.append(prefix[-1] + length)
+
+    tail_slots = max(num_mtp_layers, 0) + 1  # MTP slots plus loss.
+    total_cells = num_hidden_layers + 1 + tail_slots
+    base, remainder = divmod(total_cells, pp_size)
+    target_cells = [base + (1 if stage < remainder else 0) for stage in range(pp_size)]
+
+    def overhead(stage: int) -> int:
+        return (1 if stage == 0 else 0) + (tail_slots if stage == pp_size - 1 else 0)
+
+    # Linear partition DP: minimize the largest per-stage cell count, then prefer
+    # non-empty decoder stages and closeness to Megatron's unprotected target sizes.
+    n_groups = len(groups)
+    dp: list[dict[int, tuple[int, int, int, int | None]]] = []
+    first: dict[int, tuple[int, int, int, int | None]] = {}
+    for end in range(n_groups + 1):
+        cells = overhead(0) + prefix[end]
+        first[end] = (
+            cells,
+            1 if end == 0 else 0,
+            abs(cells - target_cells[0]),
+            None,
+        )
+    dp.append(first)
+
+    for stage in range(1, pp_size):
+        current: dict[int, tuple[int, int, int, int | None]] = {}
+        for end in range(n_groups + 1):
+            best: tuple[int, int, int, int | None] | None = None
+            for start, prev in dp[stage - 1].items():
+                if start > end:
+                    continue
+                cells = overhead(stage) + prefix[end] - prefix[start]
+                score = (
+                    max(prev[0], cells),
+                    prev[1] + (1 if end == start else 0),
+                    prev[2] + abs(cells - target_cells[stage]),
+                    start,
+                )
+                if best is None or score[:3] < best[:3]:
+                    best = score
+            assert best is not None
+            current[end] = best
+        dp.append(current)
+
+    segments: list[tuple[int, int]] = []
+    end = n_groups
+    for stage in range(pp_size - 1, 0, -1):
+        start = dp[stage][end][3]
+        assert start is not None
+        segments.append((start, end))
+        end = start
+    segments.append((0, end))
+    segments.reverse()
+
+    rows: list[list[str]] = []
+    for stage, (start, end) in enumerate(segments):
+        row: list[str] = []
+        if stage == 0:
+            row.append("embedding")
+        for group_len in lengths[start:end]:
+            row.extend(["decoder"] * group_len)
+        if stage == pp_size - 1:
+            row.extend(["mtp"] * max(num_mtp_layers, 0))
+            row.append("loss")
+        rows.append(row)
+    return _auto_layout(
+        num_hidden_layers,
+        pp_size,
+        num_mtp_layers,
+        rows=rows,
+    )
 
 
 def build_pipeline_chunk_layout(
@@ -52,6 +164,7 @@ def build_pipeline_chunk_layout(
     vpp_chunk_id: int | None = None,
     *,
     num_mtp_layers: int = 0,
+    decoder_layer_groups: Sequence[Sequence[int]] | None = None,
 ) -> PipelineChunkLayout:
     """``layer_indices`` / ``has_embed`` / ``has_head`` / ``has_mtp`` for this PP rank,
     from ``ps.pp_layout`` (custom) or an auto-balanced layout. ``has_mtp`` follows the
@@ -68,15 +181,17 @@ def build_pipeline_chunk_layout(
         )
 
     from megatron.core.transformer.enums import LayerType
-    from megatron.core.transformer.pipeline_parallel_layer_layout import (
-        PipelineParallelLayerLayout,
-    )
+    from megatron.core.transformer.pipeline_parallel_layer_layout import PipelineParallelLayerLayout
 
     pp_layout = getattr(ps, "pp_layout", None)
     if pp_layout is not None:
         layout = PipelineParallelLayerLayout(pp_layout, pipeline_model_parallel_size=ps.pp_size)
         if layout.virtual_pipeline_model_parallel_size > 1:
             raise NotImplementedError("VPP pp_layout is not supported (one stage per pp rank).")
+    elif decoder_layer_groups is not None:
+        layout = _auto_layout_with_decoder_groups(
+            num_hidden_layers, ps.pp_size, num_mtp_layers, decoder_layer_groups
+        )
     else:
         layout = _auto_layout(num_hidden_layers, ps.pp_size, num_mtp_layers)
 

--- a/experimental/lite/tests/smoke/model/test_glm5_dsa_acceptance_smoke.py
+++ b/experimental/lite/tests/smoke/model/test_glm5_dsa_acceptance_smoke.py
@@ -1,0 +1,282 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+from __future__ import annotations
+
+import copy
+
+import pytest
+import torch
+
+pytestmark = [pytest.mark.mlite, pytest.mark.smoke, pytest.mark.gpu]
+
+
+def _make_dsa():
+    pytest.importorskip("cudnn", reason="GLM5 DSA accept-with-proof needs cudnn DSA.")
+    from megatron.lite.primitive.modules.attention import DynamicSparseAttention
+
+    return DynamicSparseAttention(
+        hidden_size=128,
+        num_attention_heads=64,
+        q_lora_rank=16,
+        kv_lora_rank=512,
+        qk_nope_head_dim=192,
+        qk_rope_head_dim=64,
+        v_head_dim=256,
+        index_n_heads=32,
+        index_head_dim=128,
+        index_topk=512,
+        rms_norm_eps=1e-5,
+        layer_number=1,
+    )
+
+
+def _run_once(module, x, cos, sin, position_ids, *, fused_training: bool):
+    module.zero_grad(set_to_none=True)
+    module.train(fused_training)
+    local_x = x.detach().clone().requires_grad_(True)
+    out = module(local_x, cos=cos, sin=sin, position_ids=position_ids)
+    loss = out.float().square().mean()
+    loss.backward()
+    param_grads = {
+        name: param.grad.detach().float().clone()
+        for name, param in module.named_parameters()
+        if param.grad is not None
+    }
+    return {
+        "loss": loss.detach().float().clone(),
+        "out": out.detach().float().clone(),
+        "x_grad": local_x.grad.detach().float().clone(),
+        "param_grads": param_grads,
+    }
+
+
+def _causal_mask(seq_q: int, seq_k: int, *, ratio: int, device: torch.device) -> torch.Tensor:
+    q_idx = torch.arange(seq_q, device=device)
+    k_idx = torch.arange(seq_k, device=device)
+    valid_per_q = ((q_idx + 1) // ratio).clamp(max=seq_k)
+    return k_idx.unsqueeze(0) < valid_per_q.unsqueeze(1)
+
+
+def _torch_indexer_scores(
+    q_indexer: torch.Tensor,
+    k_indexer: torch.Tensor,
+    weights: torch.Tensor,
+    *,
+    ratio: int,
+    indexer_softmax_scale: float,
+) -> torch.Tensor:
+    q_bshd = q_indexer.permute(1, 0, 2, 3).float()
+    k_bsd = k_indexer.permute(1, 0, 2).float()
+    w_bsh = weights.permute(1, 0, 2).float()
+    scores = torch.einsum("bqhd,bkd->bqhk", q_bshd, k_bsd)
+    scores = torch.relu(scores).mul(w_bsh.unsqueeze(-1)).sum(dim=2)
+    scores = scores * float(indexer_softmax_scale)
+    causal = _causal_mask(scores.shape[1], scores.shape[2], ratio=ratio, device=scores.device)
+    return torch.where(causal.unsqueeze(0), scores, torch.full_like(scores, -torch.inf))
+
+
+def _torch_topk_from_scores(scores: torch.Tensor, topk: int) -> torch.Tensor:
+    effective_topk = min(topk, scores.shape[-1])
+    values, indices = torch.topk(scores, k=effective_topk, dim=-1)
+    indices = torch.where(torch.isfinite(values), indices, torch.full_like(indices, -1))
+    if effective_topk < topk:
+        pad = torch.full(
+            (*indices.shape[:-1], topk - effective_topk),
+            -1,
+            device=indices.device,
+            dtype=indices.dtype,
+        )
+        indices = torch.cat([indices, pad], dim=-1)
+    return indices.int()
+
+
+def _gather_sequence(source: torch.Tensor, indices: torch.Tensor) -> torch.Tensor:
+    safe_indices = indices.clamp(min=0).long()
+    expanded = source.unsqueeze(1).expand(-1, indices.shape[1], -1, -1)
+    gathered = torch.gather(
+        expanded,
+        dim=2,
+        index=safe_indices.unsqueeze(-1).expand(-1, -1, -1, source.shape[-1]),
+    )
+    return torch.where(indices.unsqueeze(-1) >= 0, gathered, torch.zeros_like(gathered))
+
+
+def _torch_sparse_attention(
+    query_states: torch.Tensor,
+    kv_full: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_indices: torch.Tensor,
+    *,
+    softmax_scale: float,
+    value_dim: int,
+) -> torch.Tensor:
+    query_bshd = query_states.permute(1, 0, 2, 3).float()
+    kv_bsd = kv_full.permute(1, 0, 2).float()
+    selected_keys = _gather_sequence(kv_bsd, topk_indices)
+    selected_values = _gather_sequence(kv_bsd[..., :value_dim], topk_indices)
+    scores = torch.einsum("bqhd,bqtd->bqht", query_bshd, selected_keys)
+    scores = scores * float(softmax_scale)
+    scores = torch.where(
+        topk_indices.unsqueeze(2) >= 0, scores, torch.full_like(scores, -torch.inf)
+    )
+    sink = attn_sink.float().view(1, 1, -1, 1).expand(scores.shape[0], scores.shape[1], -1, -1)
+    probs = torch.softmax(torch.cat([scores, sink], dim=-1), dim=-1)[..., :-1]
+    out = torch.einsum("bqht,bqtr->bqhr", probs, selected_values)
+    return out.permute(1, 0, 2, 3).reshape(
+        query_states.shape[0], query_states.shape[1], query_states.shape[2] * value_dim
+    )
+
+
+def _torch_unfused_dsa_forward(module, x, cos, sin, position_ids):
+    from megatron.lite.primitive.modules.attention.dsa import (
+        _rotary_embeddings_from_cache,
+        apply_rotary_pos_emb,
+    )
+
+    batch, seq_len, _ = x.shape
+    q_resid = module.q_a_layernorm(module.q_a_proj(x))
+    q = module.q_b_proj(q_resid).view(batch, seq_len, module.num_heads, module.qk_head_dim)
+    q_nope, q_pe = torch.split(q, [module.qk_nope_head_dim, module.qk_rope_head_dim], dim=-1)
+    cos, sin = _rotary_embeddings_from_cache(
+        cos, sin, position_ids, device=x.device, dtype=x.dtype, dim=module.qk_rope_head_dim
+    )
+    q_pe = apply_rotary_pos_emb(q_pe, cos, sin, unsqueeze_dim=2)
+
+    k_up_weight, v_up_weight = module._split_kv_b_weights()
+    q_nope = torch.einsum("bshd,hdr->bshr", q_nope, k_up_weight)
+    query_states = torch.cat([q_nope, q_pe], dim=-1).transpose(0, 1).contiguous()
+
+    kv_latent, k_pe = torch.split(
+        module.kv_a_proj_with_mqa(x), [module.kv_lora_rank, module.qk_rope_head_dim], dim=-1
+    )
+    kv_latent = module.kv_a_layernorm(kv_latent)
+    k_pe = apply_rotary_pos_emb(k_pe.unsqueeze(2), cos, sin, unsqueeze_dim=2).squeeze(2)
+    kv_full = torch.cat([kv_latent, k_pe], dim=-1).transpose(0, 1).contiguous()
+
+    assert module.indexer is not None
+    q_indexer, k_indexer, weights_indexer = module.indexer.forward_before_topk(
+        x, q_resid, cos, sin, position_ids
+    )
+    indexer_scores = _torch_indexer_scores(
+        q_indexer,
+        k_indexer,
+        weights_indexer,
+        ratio=1,
+        indexer_softmax_scale=module.indexer_softmax_scale,
+    )
+    topk_indices = _torch_topk_from_scores(
+        indexer_scores, min(module.index_topk, indexer_scores.shape[-1])
+    )
+    out = _torch_sparse_attention(
+        query_states,
+        kv_full,
+        module.attn_sink,
+        topk_indices,
+        softmax_scale=module.softmax_scale,
+        value_dim=module.kv_lora_rank,
+    )
+    out = out.to(x.dtype).view(seq_len, batch, module.num_heads, module.kv_lora_rank)
+    out = out.permute(1, 0, 2, 3).contiguous()
+    out = torch.einsum("bshr,hvr->bshv", out, v_up_weight)
+    out = out.reshape(batch, seq_len, module.num_heads * module.v_head_dim)
+    return module.o_proj(out)
+
+
+def _run_once_torch_unfused(module, x, cos, sin, position_ids):
+    module.zero_grad(set_to_none=True)
+    module.train(True)
+    local_x = x.detach().clone().requires_grad_(True)
+    out = _torch_unfused_dsa_forward(module, local_x, cos, sin, position_ids)
+    loss = out.float().square().mean()
+    loss.backward()
+    param_grads = {
+        name: param.grad.detach().float().clone()
+        for name, param in module.named_parameters()
+        if param.grad is not None
+    }
+    return {
+        "loss": loss.detach().float().clone(),
+        "out": out.detach().float().clone(),
+        "x_grad": local_x.grad.detach().float().clone(),
+        "param_grads": param_grads,
+    }
+
+
+def _max_abs(a: torch.Tensor, b: torch.Tensor) -> float:
+    return float((a - b).abs().max().item())
+
+
+def _max_param_grad_abs(a: dict, b: dict) -> float:
+    common = set(a["param_grads"]) & set(b["param_grads"])
+    if not common:
+        return 0.0
+    return max(_max_abs(a["param_grads"][name], b["param_grads"][name]) for name in common)
+
+
+def test_glm5_dsa_run_to_run_accept_with_proof():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for GLM5 DSA accept-with-proof smoke.")
+
+    from megatron.lite.primitive.modules.attention import build_rope_cache
+
+    device = torch.device("cuda", int(torch.cuda.current_device()))
+    torch.manual_seed(20260626)
+    fused = _make_dsa().to(device=device, dtype=torch.bfloat16)
+    unfused = copy.deepcopy(fused).to(device=device, dtype=torch.bfloat16)
+
+    batch, seq, hidden = 1, 512, 128
+    x = torch.randn(batch, seq, hidden, device=device, dtype=torch.bfloat16)
+    cos, sin = build_rope_cache(
+        dim=64,
+        max_position_embeddings=seq,
+        rope_theta=1_000_000.0,
+        device=device,
+    )
+    position_ids = torch.arange(seq, device=device, dtype=torch.long).unsqueeze(0)
+
+    fused_a = _run_once(fused, x, cos, sin, position_ids, fused_training=True)
+    fused_b = _run_once(fused, x, cos, sin, position_ids, fused_training=True)
+    unfused_a = _run_once_torch_unfused(unfused, x, cos, sin, position_ids)
+    unfused_b = _run_once_torch_unfused(unfused, x, cos, sin, position_ids)
+
+    fused_r2r_out = _max_abs(fused_a["out"], fused_b["out"])
+    fused_r2r_x_grad = _max_abs(fused_a["x_grad"], fused_b["x_grad"])
+    fused_r2r_param_grad = _max_param_grad_abs(fused_a, fused_b)
+    unfused_r2r_out = _max_abs(unfused_a["out"], unfused_b["out"])
+    unfused_r2r_x_grad = _max_abs(unfused_a["x_grad"], unfused_b["x_grad"])
+    unfused_r2r_param_grad = _max_param_grad_abs(unfused_a, unfused_b)
+    fused_vs_unfused_out = _max_abs(fused_a["out"], unfused_a["out"])
+    fused_vs_unfused_x_grad = _max_abs(fused_a["x_grad"], unfused_a["x_grad"])
+    fused_vs_unfused_param_grad = _max_param_grad_abs(fused_a, unfused_a)
+    loss_diff = abs(float(fused_a["loss"].item()) - float(unfused_a["loss"].item()))
+
+    noise_floor = max(
+        fused_r2r_x_grad,
+        fused_r2r_param_grad,
+        unfused_r2r_x_grad,
+        unfused_r2r_param_grad,
+    )
+    assert torch.isfinite(fused_a["loss"])
+    assert torch.isfinite(unfused_a["loss"])
+    assert unfused_r2r_out == 0.0
+    assert unfused_r2r_x_grad == 0.0
+    assert unfused_r2r_param_grad == 0.0
+    assert fused_vs_unfused_out <= 5.0e-2
+    assert fused_vs_unfused_x_grad <= max(5.0e-1, 16.0 * noise_floor)
+    assert fused_vs_unfused_param_grad <= max(5.0e-1, 16.0 * noise_floor)
+
+    print(
+        "NON_SKIP_GLM5_DSA_RUN_TO_RUN_ACCEPT_WITH_PROOF "
+        f"fused_loss={float(fused_a['loss'].item()):.6e} "
+        f"unfused_loss={float(unfused_a['loss'].item()):.6e} "
+        f"loss_diff={loss_diff:.6e} "
+        f"fused_r2r_out_max_abs={fused_r2r_out:.6e} "
+        f"fused_r2r_x_grad_max_abs={fused_r2r_x_grad:.6e} "
+        f"fused_r2r_param_grad_max_abs={fused_r2r_param_grad:.6e} "
+        f"unfused_r2r_out_max_abs={unfused_r2r_out:.6e} "
+        f"unfused_r2r_x_grad_max_abs={unfused_r2r_x_grad:.6e} "
+        f"unfused_r2r_param_grad_max_abs={unfused_r2r_param_grad:.6e} "
+        f"fused_vs_unfused_out_max_abs={fused_vs_unfused_out:.6e} "
+        f"fused_vs_unfused_x_grad_max_abs={fused_vs_unfused_x_grad:.6e} "
+        f"fused_vs_unfused_param_grad_max_abs={fused_vs_unfused_param_grad:.6e} "
+        f"noise_floor={noise_floor:.6e}"
+    )

--- a/experimental/lite/tests/smoke/primitive/test_auto_pipeline_layout_smoke.py
+++ b/experimental/lite/tests/smoke/primitive/test_auto_pipeline_layout_smoke.py
@@ -26,6 +26,7 @@ from datetime import timedelta
 import pytest
 import torch
 import torch.distributed as dist
+
 from megatron.lite.primitive.ckpt.hf_weights import unwrap_model
 from megatron.lite.primitive.deterministic import set_deterministic
 from megatron.lite.runtime.backends.mlite.runtime import MegatronLiteRuntime
@@ -64,11 +65,11 @@ def _optimizer_config() -> OptimizerConfig:
     )
 
 
-def _random_packed_batch(vocab_size: int) -> PackedBatch:
+def _random_packed_batch(vocab_size: int, *, num_tokens: int = 2048) -> PackedBatch:
     return PackedBatch(
-        input_ids=torch.randint(0, vocab_size, (2048,), device="cuda"),
-        labels=torch.randint(0, vocab_size, (2048,), device="cuda"),
-        seq_lens=torch.full((1,), 2048, dtype=torch.int64, device="cuda"),
+        input_ids=torch.randint(0, vocab_size, (num_tokens,), device="cuda"),
+        labels=torch.randint(0, vocab_size, (num_tokens,), device="cuda"),
+        seq_lens=torch.full((1,), num_tokens, dtype=torch.int64, device="cuda"),
     )
 
 
@@ -196,6 +197,50 @@ def _glm5():
         n_routed_experts=4,
         n_shared_experts=1,
         num_experts_per_tok=2,
+    )
+    return cfg, protocol
+
+
+def _glm52_indexer_types(num_layers=78):
+    full_layers = {0, 1, 2, *range(6, num_layers, 4)}
+    return ["full" if idx in full_layers else "shared" for idx in range(num_layers)]
+
+
+def _glm52_indexshare():
+    pytest.importorskip("cudnn", reason="glm5 fused DSA needs the cudnn DSA stack.")
+    _require_te()
+    from megatron.lite.model.glm5.config import Glm5Config
+    from megatron.lite.model.glm5.lite import protocol
+
+    cfg = Glm5Config(
+        num_hidden_layers=78,
+        hidden_size=128,
+        num_attention_heads=64,
+        num_key_value_heads=64,
+        head_dim=256,
+        vocab_size=32,
+        max_position_embeddings=512,
+        initializer_range=0.002,
+        q_lora_rank=16,
+        kv_lora_rank=512,
+        qk_head_dim=256,
+        qk_nope_head_dim=192,
+        qk_rope_head_dim=64,
+        v_head_dim=256,
+        index_head_dim=128,
+        index_n_heads=32,
+        index_topk=512,
+        intermediate_size=20,
+        moe_intermediate_size=6,
+        first_k_dense_replace=1,
+        n_routed_experts=4,
+        n_shared_experts=1,
+        num_experts_per_tok=2,
+        num_nextn_predict_layers=1,
+        index_topk_freq=4,
+        index_skip_topk_offset=3,
+        indexer_types=_glm52_indexer_types(),
+        index_share_for_mtp_iteration=True,
     )
     return cfg, protocol
 
@@ -330,23 +375,35 @@ def _proxy_topology(model_name: str, pp_layout=None) -> ParallelConfig:
     return ParallelConfig(tp=2, ep=2, etp=1, pp=_PP, cp=1, pp_layout=pp_layout)
 
 
-def _build_handle(model_name: str, *, seed: int, pp_layout=None):
+def _build_handle_from_config(
+    model_name: str,
+    cfg,
+    protocol,
+    *,
+    seed: int,
+    parallel: ParallelConfig | None = None,
+    pp_layout=None,
+    impl_overrides: dict | None = None,
+):
     from types import SimpleNamespace
 
     from megatron.lite.runtime.contracts.handle import ModelHandle
 
-    cfg, protocol = MODELS[model_name]()
     torch.manual_seed(seed)
     torch.cuda.manual_seed_all(seed)
 
-    parallel = _proxy_topology(model_name, pp_layout=pp_layout)
-    impl_cfg = protocol.ImplConfig(
+    if parallel is None:
+        parallel = _proxy_topology(model_name, pp_layout=pp_layout)
+    impl_kwargs = dict(
         parallel=parallel,
         optimizer="dist_opt",
         optimizer_config=_optimizer_config(),
         use_deepep=False,
         deterministic=True,
     )
+    if impl_overrides:
+        impl_kwargs.update(impl_overrides)
+    impl_cfg = protocol.ImplConfig(**impl_kwargs)
     bundle = protocol.build_model(cfg, impl_cfg=impl_cfg)
     chunks = bundle.chunks
     extras = dict(bundle.extras)
@@ -367,6 +424,17 @@ def _build_handle(model_name: str, *, seed: int, pp_layout=None):
     )
     _BUILT_PARALLEL_STATES.append(bundle.parallel_state)
     return handle, cfg
+
+
+def _build_handle(model_name: str, *, seed: int, pp_layout=None):
+    cfg, protocol = MODELS[model_name]()
+    return _build_handle_from_config(
+        model_name,
+        cfg,
+        protocol,
+        seed=seed,
+        pp_layout=pp_layout,
+    )
 
 
 def _local_layer_indices(handle) -> list[int]:
@@ -443,6 +511,81 @@ def test_uneven_pp_builds_trains_and_exports(model_name):
             "NON_SKIP_UNEVEN_PP_BUILD_TRAIN_EXPORT "
             f"model={model_name} num_layers={cfg.num_hidden_layers} "
             f"split={local} exported_decoder_layers={len(present & expected)}"
+        )
+
+
+def test_glm52_indexshare_78_layer_uneven_pp_builds_trains_and_keeps_share_groups():
+    """GLM5.2 has 78 trunk layers plus one MTP layer and reuses DSA indexer
+    top-k across groups. The real PP build must use the auto layout while keeping
+    each full source layer on the same stage as its shared layers."""
+    if dist.get_world_size() != 8:
+        pytest.skip("GLM5.2 IndexShare uneven-PP smoke requires exactly 8 GPUs.")
+
+    from megatron.lite.primitive.modules.attention.dsa import (
+        validate_dsa_index_share_pipeline_split,
+    )
+
+    set_deterministic(2026)
+
+    cfg, protocol = _glm52_indexshare()
+    parallel = ParallelConfig(tp=1, ep=1, etp=1, pp=8, cp=1)
+    handle, cfg = _build_handle_from_config(
+        "glm5",
+        cfg,
+        protocol,
+        seed=5252,
+        parallel=parallel,
+        impl_overrides={"mtp_enable": True, "mtp_enable_train": True},
+    )
+    ps = handle._parallel_state
+    assert ps.pp_size == 8
+    assert cfg.num_hidden_layers == 78
+    assert cfg.num_nextn_predict_layers == 1
+    assert cfg.uses_dsa_index_share is True
+
+    local = _local_layer_indices(handle)
+    assert local == sorted(local) and len(set(local)) == len(local), local
+    validate_dsa_index_share_pipeline_split(
+        local,
+        topk_freq=cfg.index_topk_freq,
+        skip_topk_offset=cfg.index_skip_topk_offset,
+        indexer_types=cfg.indexer_types,
+    )
+    local_shared_sources = [
+        (layer_idx, cfg.dsa_indexer_source_layer(layer_idx))
+        for layer_idx in local
+        if cfg.dsa_indexer_type(layer_idx) == "shared"
+    ]
+    assert all(source_idx in local for _, source_idx in local_shared_sources), local_shared_sources
+
+    runtime = MegatronLiteRuntime.__new__(MegatronLiteRuntime)
+    batch = _random_packed_batch(cfg.vocab_size, num_tokens=512)
+    runtime.zero_grad(handle)
+    result = runtime.forward_backward(handle, iter([batch]), None, num_microbatches=1)
+    runtime.optimizer_step(handle)
+    loss = result.model_output.loss
+    assert loss is not None and torch.isfinite(loss).all(), (
+        f"glm52_indexshare: non-finite loss {loss} on 78-layer uneven PP layout"
+    )
+
+    stage_info = {
+        "pp_rank": ps.pp_rank,
+        "layers": local,
+        "shared_sources": local_shared_sources,
+        "has_mtp": bool(unwrap_model(handle._extras["model_chunks"][0]).mtp is not None),
+    }
+    gathered = [None for _ in range(dist.get_world_size())]
+    dist.all_gather_object(gathered, stage_info)
+    if dist.get_rank() == 0:
+        ordered = sorted(gathered, key=lambda item: item["pp_rank"])
+        splits = [item["layers"] for item in ordered]
+        shared_pairs = sum(len(item["shared_sources"]) for item in ordered)
+        mtp_ranks = [item["pp_rank"] for item in ordered if item["has_mtp"]]
+        print(
+            "NON_SKIP_GLM52_INDEXSHARE_UNEVEN_PP_PASSED "
+            f"pp=8 num_layers=78 mtp_layers=1 splits={splits} "
+            f"shared_pairs={shared_pairs} mtp_ranks={mtp_ranks} "
+            f"loss={float(loss.detach().item()):.6e}"
         )
 
 

--- a/experimental/lite/tests/unit/model/test_glm5_lite_cp_smoke.py
+++ b/experimental/lite/tests/unit/model/test_glm5_lite_cp_smoke.py
@@ -278,7 +278,8 @@ def test_glm5_tiny_model_cp2_forward_backward_smoke():
     input_ids = zigzag_slice_for_cp(full_ids, rank, world, seq_dim=1).contiguous()
 
     output = model(input_ids=input_ids)
-    assert output["hidden_states"].shape == (batch, seq // world, cfg.hidden_size)
+    # The model contract keeps hidden states in sequence-major (SBH) layout.
+    assert output["hidden_states"].shape == (seq // world, batch, cfg.hidden_size)
     assert torch.isfinite(output["hidden_states"].float()).all()
     loss = output["hidden_states"].float().square().mean()
     assert loss.ndim == 0
@@ -298,16 +299,27 @@ def test_glm5_packed_thd_variable_sequence_cp2_forward_backward_smoke():
     import torch.distributed as dist
 
     from megatron.lite.model.glm5.config import Glm5Config
+    from megatron.lite.model.glm5.lite.protocol import _forward_step, unpack_forward_output
     from megatron.lite.primitive.parallel.state import ParallelState
-    from megatron.lite.primitive.parallel.thd import pack_nested_thd, unpack_packed_thd_to_nested
+    from megatron.lite.runtime.contracts.data import PackedBatch
 
     device = _init_dist_or_skip()
     world = dist.get_world_size()
     rank = dist.get_rank()
     cfg_kwargs = _tiny_config_kwargs()
-    cfg_kwargs.update(max_position_embeddings=64, num_nextn_predict_layers=1)
-    cfg = Glm5Config(**cfg_kwargs)
-    cfg.mlp_layer_types = ["dense", "dense"]
+    cfg_kwargs.update(
+        max_position_embeddings=64,
+        num_hidden_layers=6,
+        num_nextn_predict_layers=1,
+    )
+    indexer_types = ["full", "full", "full", "shared", "shared", "shared"]
+    cfg = Glm5Config(
+        **cfg_kwargs,
+        index_topk_freq=4,
+        index_skip_topk_offset=3,
+        indexer_types=indexer_types,
+    )
+    cfg.mlp_layer_types = ["dense"] * 7
     ps = ParallelState(cp_group=dist.group.WORLD, cp_size=world, cp_rank=rank)
 
     torch.manual_seed(20260614)
@@ -317,42 +329,36 @@ def test_glm5_packed_thd_variable_sequence_cp2_forward_backward_smoke():
     model.train()
 
     lengths = [16, 20, 24]
-    ids = torch.nested.as_nested_tensor(
-        [
-            torch.randint(0, cfg.vocab_size, (length,), device=device, dtype=torch.long)
-            for length in lengths
-        ],
-        layout=torch.jagged,
-    )
-    labels = torch.nested.as_nested_tensor(
-        [
-            torch.randint(0, cfg.vocab_size, (length,), device=device, dtype=torch.long)
-            for length in lengths
-        ],
-        layout=torch.jagged,
-    )
-    loss_mask = torch.nested.as_nested_tensor(
-        [torch.ones(length, device=device, dtype=torch.float32) for length in lengths],
-        layout=torch.jagged,
-    )
-    packed = pack_nested_thd(
-        ids,
-        cp_size=world,
-        cp_rank=rank,
-        cp_group=ps.cp_group,
-        labels=labels,
-        loss_mask=loss_mask,
+    batch = PackedBatch(
+        input_ids=torch.cat(
+            [
+                torch.randint(
+                    0, cfg.vocab_size, (length,), device=device, dtype=torch.long
+                )
+                for length in lengths
+            ]
+        ),
+        labels=torch.cat(
+            [
+                torch.randint(
+                    0, cfg.vocab_size, (length,), device=device, dtype=torch.long
+                )
+                for length in lengths
+            ]
+        ),
+        seq_lens=torch.tensor(lengths, device=device, dtype=torch.int32),
+        loss_mask=torch.ones(sum(lengths), device=device, dtype=torch.float32),
     )
 
-    out = model(
-        input_ids=packed.input_ids,
-        labels=packed.labels,
-        loss_mask=packed.loss_mask,
-        position_ids=packed.position_ids,
-        packed_seq_params=packed.packed_seq_params,
-    )
+    out = _forward_step(model, batch)
     assert torch.isfinite(out["loss"])
     assert "mtp_loss" in out
+    assert model.layers[3].self_attention.self_attention.skip_topk is True
+    assert model.mtp is not None
+    assert (
+        model.mtp.layers[0].transformer_layer.self_attention.self_attention.skip_topk
+        is False
+    )
     out["loss"].backward()
 
     grad_norm = torch.zeros((), device=device)
@@ -361,14 +367,14 @@ def test_glm5_packed_thd_variable_sequence_cp2_forward_backward_smoke():
             grad_norm = grad_norm + param.grad.detach().float().norm()
     assert torch.isfinite(grad_norm)
 
-    nested_log_probs = unpack_packed_thd_to_nested(out["log_probs"], packed)
+    nested_log_probs = unpack_forward_output(model, batch, out["log_probs"])
     assert nested_log_probs.offsets().numel() == len(lengths) + 1
     assert [int(x) for x in nested_log_probs.offsets().diff().cpu()] == lengths
 
     if rank == 0:
         print(
             "NON_SKIP_GLM5_THD_CP_SMOKE_PASSED "
-            f"world_size={world} lengths={lengths} "
+            f"world_size={world} lengths={lengths} index_share=true mtp_indexer=full "
             f"loss={float(out['loss'].detach().item()):.6e} "
             f"grad_norm={float(grad_norm.detach().item()):.6e}"
         )

--- a/experimental/lite/tests/unit/model/test_glm5_lite_static.py
+++ b/experimental/lite/tests/unit/model/test_glm5_lite_static.py
@@ -61,6 +61,11 @@ def _tiny_config_kwargs():
     )
 
 
+def _glm52_indexer_types(num_layers=78):
+    full_layers = {0, 1, 2, *range(6, num_layers, 4)}
+    return ["full" if idx in full_layers else "shared" for idx in range(num_layers)]
+
+
 def test_glm5_registry_resolves_lite():
     from megatron.lite.model.registry import (
         get_train_runtime_module,
@@ -127,6 +132,50 @@ def test_glm5_config_ignores_null_hf_optional_fields():
     assert cfg.indexer_rope_first is True
     assert cfg.indexer_use_hadamard is False
     assert cfg.mlp_layer_types is None
+
+
+def test_glm52_config_validates_index_share_schedule():
+    import pytest
+
+    from megatron.lite.model.glm5.config import Glm5Config
+
+    indexer_types = _glm52_indexer_types()
+    cfg = Glm5Config(
+        **{
+            **_tiny_config_kwargs(),
+            "num_hidden_layers": 78,
+            "num_nextn_predict_layers": 1,
+        },
+        index_topk_freq=4,
+        index_skip_topk_offset=3,
+        indexer_types=indexer_types,
+        index_share_for_mtp_iteration=True,
+    )
+
+    assert indexer_types.count("full") == 21
+    assert indexer_types.count("shared") == 57
+    assert cfg.uses_dsa_index_share is True
+    assert cfg.dsa_indexer_type(2) == "full"
+    assert cfg.dsa_indexer_type(3) == "shared"
+    assert cfg.dsa_indexer_source_layer(3) == 2
+    assert cfg.dsa_indexer_type(74) == "full"
+    assert cfg.dsa_indexer_type(77) == "shared"
+    assert cfg.dsa_indexer_source_layer(77) == 74
+    # MTP layer 78 (0-based) is outside trunk indexer_types and is full by
+    # the same global layer-number schedule.
+    assert cfg.dsa_indexer_type(78) == "full"
+    assert cfg.builds_dsa_indexer(78) is True
+    assert cfg.index_share_for_mtp_iteration is True
+
+    bad_types = list(indexer_types)
+    bad_types[3] = "full"
+    with pytest.raises(ValueError, match="indexer_types\\[3\\]"):
+        Glm5Config(
+            **{**_tiny_config_kwargs(), "num_hidden_layers": 78},
+            index_topk_freq=4,
+            index_skip_topk_offset=3,
+            indexer_types=bad_types,
+        )
 
 
 def test_glm5_config_preserves_mtp_aliases_and_layer_types():
@@ -208,8 +257,11 @@ def test_glm5_dsa_training_forward_uses_fused_kernel(monkeypatch):
     import pytest
     import torch
 
-    from megatron.lite.primitive.modules.attention import dsa
-    from megatron.lite.primitive.modules.attention import DynamicSparseAttention, build_rope_cache
+    from megatron.lite.primitive.modules.attention import (
+        DynamicSparseAttention,
+        build_rope_cache,
+        dsa,
+    )
 
     if not torch.cuda.is_available():
         pytest.skip("GLM-5 native attention requires CUDA (Transformer Engine RMSNorm)")
@@ -298,8 +350,11 @@ def test_glm5_dsa_eval_forward_uses_fused_sparse_attention(monkeypatch):
     import pytest
     import torch
 
-    from megatron.lite.primitive.modules.attention import dsa
-    from megatron.lite.primitive.modules.attention import DynamicSparseAttention, build_rope_cache
+    from megatron.lite.primitive.modules.attention import (
+        DynamicSparseAttention,
+        build_rope_cache,
+        dsa,
+    )
 
     if not torch.cuda.is_available():
         pytest.skip("GLM-5 native attention requires CUDA (Transformer Engine RMSNorm)")
@@ -374,15 +429,56 @@ def test_glm5_lite_model_exports_native_state_names():
     assert "head.col.linear.weight" in keys
 
 
+def test_glm52_index_share_shared_layers_omit_indexer_modules():
+    import pytest
+
+    try:
+        import transformer_engine.pytorch  # noqa: F401
+    except (ModuleNotFoundError, OSError) as exc:
+        pytest.skip(f"Transformer Engine is not importable in this environment: {exc}")
+
+    from megatron.lite.model.glm5.config import Glm5Config
+
+    cfg = Glm5Config(
+        **{
+            **_tiny_config_kwargs(),
+            "num_hidden_layers": 6,
+            "num_nextn_predict_layers": 1,
+        },
+        index_topk_freq=4,
+        index_skip_topk_offset=3,
+        indexer_types=_glm52_indexer_types(num_layers=6),
+    )
+    model = _make_glm5_model(cfg, mtp_enable=True)
+    attention_modules = [layer.self_attention.self_attention for layer in model.layers]
+
+    assert [module.indexer is not None for module in attention_modules] == [
+        True,
+        True,
+        True,
+        False,
+        False,
+        False,
+    ]
+    assert model.mtp is not None
+    mtp_attention = model.mtp.layers[0].transformer_layer.self_attention.self_attention
+    assert mtp_attention.layer_number == 7
+    assert mtp_attention.indexer is not None
+
+    keys = set(model.state_dict())
+    assert "layers.2.self_attention.self_attention.indexer.wq_b.weight" in keys
+    assert "layers.3.self_attention.self_attention.indexer.wq_b.weight" not in keys
+    assert (
+        "mtp.layers.0.transformer_layer.self_attention.self_attention.indexer.wq_b.weight" in keys
+    )
+
+
 def test_glm5_checkpoint_exports_and_saves_hf_style_weights(tmp_path):
     import torch
     from safetensors import safe_open
 
     from megatron.lite.model.glm5.config import Glm5Config
-    from megatron.lite.model.glm5.lite.checkpoint import (
-        export_hf_weights,
-        save_hf_weights,
-    )
+    from megatron.lite.model.glm5.lite.checkpoint import export_hf_weights, save_hf_weights
     from megatron.lite.primitive.parallel import ParallelState
 
     cfg = Glm5Config(**_tiny_config_kwargs())
@@ -437,9 +533,7 @@ def test_glm5_checkpoint_exports_and_saves_hf_style_weights(tmp_path):
     loaded_bf16 = _make_glm5_model(cfg, ps=ps)
     load_hf_weights(loaded_bf16, str(hf_bf16_dir), cfg, ps)
     assert torch.equal(
-        loaded_bf16.state_dict()["layers.1.moe.experts.fc1.weight2"][
-            cfg.moe_intermediate_size :
-        ]
+        loaded_bf16.state_dict()["layers.1.moe.experts.fc1.weight2"][cfg.moe_intermediate_size :]
         .detach()
         .cpu(),
         state["layers.1.moe.experts.fc1.weight2"][cfg.moe_intermediate_size :]
@@ -491,6 +585,136 @@ def test_glm5_checkpoint_exports_and_loads_mtp_layers(tmp_path):
     )
 
 
+def test_glm52_checkpoint_mapping_skips_shared_indexer_without_te():
+    import importlib.util
+
+    import torch
+
+    from megatron.lite.model.glm5.config import Glm5Config
+
+    checkpoint_path = (
+        Path(__file__).resolve().parents[3]
+        / "megatron"
+        / "lite"
+        / "model"
+        / "glm5"
+        / "lite"
+        / "checkpoint.py"
+    )
+    module_spec = importlib.util.spec_from_file_location("_glm5_checkpoint_test", checkpoint_path)
+    assert module_spec is not None and module_spec.loader is not None
+    checkpoint_module = importlib.util.module_from_spec(module_spec)
+    module_spec.loader.exec_module(checkpoint_module)
+
+    cfg = Glm5Config(
+        **{
+            **_tiny_config_kwargs(),
+            "num_hidden_layers": 6,
+            "num_nextn_predict_layers": 1,
+        },
+        index_topk_freq=4,
+        index_skip_topk_offset=3,
+        indexer_types=_glm52_indexer_types(num_layers=6),
+        index_share_for_mtp_iteration=True,
+    )
+    spec = checkpoint_module.Glm5WeightSpec(cfg)
+    tensor = torch.ones(1)
+
+    assert spec.native_to_hf(
+        "layers.2.self_attention.self_attention.indexer.wq_b.weight", tensor
+    ) == [("model.layers.2.self_attn.indexer.wq_b.weight", tensor)]
+    assert (
+        spec.native_to_hf("layers.3.self_attention.self_attention.indexer.wq_b.weight", tensor)
+        == []
+    )
+    assert spec.native_to_hf(
+        "mtp.layers.0.transformer_layer.self_attention.self_attention.indexer.wq_b.weight",
+        tensor,
+    ) == [("model.layers.6.self_attn.indexer.wq_b.weight", tensor)]
+
+    base_names = {
+        "model.layers.3.self_attn.q_a_proj.weight",
+        "model.layers.3.self_attn.q_a_layernorm.weight",
+        "model.layers.3.self_attn.q_b_proj.weight",
+        "model.layers.3.self_attn.kv_a_proj_with_mqa.weight",
+        "model.layers.3.self_attn.kv_a_layernorm.weight",
+        "model.layers.3.self_attn.kv_b_proj.weight",
+        "model.layers.3.self_attn.o_proj.weight",
+    }
+
+    class Reader:
+        index = {name: "model.safetensors" for name in base_names}
+
+        def get_tensor(self, name):
+            if name not in self.index:
+                raise KeyError(name)
+            return torch.ones(1)
+
+    out = {}
+    checkpoint_module._load_attention(
+        out,
+        local_prefix="layers.3",
+        hf_prefix="model.layers.3.self_attn",
+        reader=Reader(),
+        ps=object(),
+        load_indexer=False,
+    )
+    assert "layers.3.self_attention.self_attention.q_a_proj.weight" in out
+    assert not any(".indexer." in name for name in out)
+
+
+def test_glm52_checkpoint_skips_shared_indexer_weights_and_loads_full_layers(tmp_path):
+    import pytest
+    import torch
+
+    try:
+        import transformer_engine.pytorch  # noqa: F401
+    except (ModuleNotFoundError, OSError) as exc:
+        pytest.skip(f"Transformer Engine is not importable in this environment: {exc}")
+
+    from megatron.lite.model.glm5.config import Glm5Config
+    from megatron.lite.model.glm5.lite.checkpoint import export_hf_weights, load_hf_weights
+    from megatron.lite.primitive.ckpt.hf_weights import save_safetensors
+    from megatron.lite.primitive.parallel import ParallelState
+
+    cfg = Glm5Config(
+        **{
+            **_tiny_config_kwargs(),
+            "num_hidden_layers": 6,
+            "num_nextn_predict_layers": 1,
+        },
+        index_topk_freq=4,
+        index_skip_topk_offset=3,
+        indexer_types=_glm52_indexer_types(num_layers=6),
+        index_share_for_mtp_iteration=True,
+    )
+    ps = ParallelState()
+    model = _make_glm5_model(cfg, ps=ps, mtp_enable=True)
+    state = model.state_dict()
+
+    exported = dict(export_hf_weights(model, cfg, ps))
+    assert "model.layers.2.self_attn.indexer.wq_b.weight" in exported
+    assert "model.layers.3.self_attn.indexer.wq_b.weight" not in exported
+    assert "model.layers.6.self_attn.indexer.wq_b.weight" in exported
+
+    save_safetensors(exported, str(tmp_path))
+    loaded = _make_glm5_model(cfg, ps=ps, mtp_enable=True)
+    load_hf_weights(loaded, str(tmp_path), cfg, ps)
+    loaded_state = loaded.state_dict()
+
+    assert torch.equal(
+        loaded_state["layers.2.self_attention.self_attention.indexer.wq_b.weight"],
+        state["layers.2.self_attention.self_attention.indexer.wq_b.weight"],
+    )
+    assert "layers.3.self_attention.self_attention.indexer.wq_b.weight" not in loaded_state
+    assert torch.equal(
+        loaded_state[
+            "mtp.layers.0.transformer_layer.self_attention.self_attention.indexer.wq_b.weight"
+        ],
+        state["mtp.layers.0.transformer_layer.self_attention.self_attention.indexer.wq_b.weight"],
+    )
+
+
 def test_glm5_router_modules_use_current_names_and_bias_buffers():
     import torch
 
@@ -506,9 +730,7 @@ def test_glm5_router_modules_use_current_names_and_bias_buffers():
         assert hasattr(router, "gate")
         assert hasattr(router, "expert_bias")
         assert torch.isfinite(router.gate.weight).all()
-        assert torch.equal(
-            router.expert_bias, torch.zeros_like(router.expert_bias)
-        )
+        assert torch.equal(router.expert_bias, torch.zeros_like(router.expert_bias))
 
 
 def test_glm5_protocol_allows_cp_only_parallel_scope():
@@ -536,6 +758,71 @@ def test_glm5_impl_config_accepts_runtime_mtp_fields():
     assert ImplConfig(mtp_enable=False, mtp_enable_train=False).mtp_enable is False
     assert ImplConfig(mtp_enable=True, mtp_enable_train=True).mtp_enable_train is True
     assert cfg.num_nextn_predict_layers == 1
+
+
+def test_glm5_dsa_execution_policy_lives_in_impl_config_only(
+    transformer_engine_import_stub,
+):
+    from dataclasses import fields
+
+    transformer_engine_import_stub()
+    from megatron.lite.model.glm5.config import Glm5Config
+    from megatron.lite.model.glm5.lite.protocol import ImplConfig
+
+    architecture_fields = {field.name for field in fields(Glm5Config)}
+
+    assert {
+        "dsa_cp_mode",
+        "dsa_indexer_loss_coeff",
+        "dsa_indexer_use_sparse_loss",
+        "calculate_per_token_loss",
+    }.isdisjoint(architecture_fields)
+    assert ImplConfig().dsa_cp_mode == "native"
+    assert ImplConfig().dsa_indexer_loss_coeff == 0.0
+    assert ImplConfig().dsa_indexer_use_sparse_loss is False
+    assert ImplConfig().calculate_per_token_loss is False
+    assert ImplConfig(dsa_cp_mode="legacy_gather_all").dsa_cp_mode == "legacy_gather_all"
+
+
+def test_glm5_production_cp_path_has_no_zigzag_layout():
+    lite_root = Path(__file__).resolve().parents[3] / "megatron" / "lite"
+    model_text = (lite_root / "model" / "glm5" / "lite" / "model.py").read_text()
+    dsa_text = (lite_root / "primitive" / "modules" / "attention" / "dsa.py").read_text()
+
+    assert "zigzag" not in model_text
+    assert "zigzag" not in dsa_text
+
+
+def test_glm5_attention_receives_impl_dsa_policy(monkeypatch, transformer_engine_import_stub):
+    import torch.nn as nn
+
+    transformer_engine_import_stub()
+    from megatron.lite.model.glm5.config import Glm5Config
+    from megatron.lite.model.glm5.lite import model as model_module
+    from megatron.lite.primitive.parallel import ParallelState
+
+    captured = {}
+
+    class FakeDSA(nn.Module):
+        def __init__(self, **kwargs):
+            super().__init__()
+            captured.update(kwargs)
+
+    monkeypatch.setattr(model_module, "DynamicSparseAttention", FakeDSA)
+    model_module.Glm5DSAAttention(
+        Glm5Config(**_tiny_config_kwargs()),
+        ParallelState(cp_size=2, cp_rank=0),
+        0,
+        dsa_cp_mode="legacy_gather_all",
+        dsa_indexer_loss_coeff=0.25,
+        dsa_indexer_use_sparse_loss=True,
+        calculate_per_token_loss=True,
+    )
+
+    assert captured["cp_mode"] == "legacy_gather_all"
+    assert captured["indexer_loss_coeff"] == 0.25
+    assert captured["indexer_use_sparse_loss"] is True
+    assert captured["calculate_per_token_loss"] is True
 
 
 def test_glm5_protocol_uses_mlite_optimizer_api():

--- a/experimental/lite/tests/unit/primitive/test_attention_moe_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_attention_moe_unit.py
@@ -52,6 +52,35 @@ def _walk_grad_fn_names(tensor: torch.Tensor) -> set[str]:
     return names
 
 
+def test_attention_public_api_is_narrow():
+    from megatron.lite.primitive.modules import attention
+
+    assert attention.__all__ == [
+        "DSAIndexShareState",
+        "DynamicSparseAttention",
+        "MultiLatentAttention",
+        "RMSNorm",
+        "build_rope_cache",
+        "build_rotary_embeddings",
+    ]
+    assert attention.DynamicSparseAttention is attention.dsa.DynamicSparseAttention
+    assert attention.DSAIndexShareState is attention.dsa.DSAIndexShareState
+    for internal_name in (
+        "dsa_indexer_type_for_layer",
+        "is_dsa_skip_topk_layer",
+        "source_dsa_compute_layer",
+        "validate_dsa_index_share_pipeline_split",
+    ):
+        assert not hasattr(attention, internal_name)
+    for internal_name in (
+        "dsa_indexer_type_for_layer",
+        "is_dsa_skip_topk_layer",
+        "source_dsa_compute_layer",
+    ):
+        assert internal_name not in attention.dsa.__all__
+    assert "validate_dsa_index_share_pipeline_split" in attention.dsa.__all__
+
+
 def test_gqa_split_grouped_qkvg_preserves_q_gate_kv_order():
     split_grouped_qkvg = _split_grouped_qkvg()
     qkv = torch.arange(24).reshape(1, 24)
@@ -147,3 +176,109 @@ def test_topk_router_aux_loss_contributes_gate_gradient(monkeypatch):
     assert torch.isfinite(grad_with_aux).all()
     assert torch.isfinite(grad_no_aux).all()
     assert (grad_with_aux - grad_no_aux).abs().sum().item() > 0.0
+
+
+def test_dsa_index_share_schedule_and_state():
+    from megatron.lite.primitive.modules.attention.dsa import (
+        DSAIndexShareState,
+        dsa_indexer_type_for_layer,
+        is_dsa_skip_topk_layer,
+        source_dsa_compute_layer,
+    )
+
+    assert is_dsa_skip_topk_layer(3, skip_topk_offset=3, topk_freq=4) is False
+    assert is_dsa_skip_topk_layer(4, skip_topk_offset=3, topk_freq=4) is True
+    assert dsa_indexer_type_for_layer(7, skip_topk_offset=3, topk_freq=4) == "full"
+    assert source_dsa_compute_layer(6, skip_topk_offset=3, topk_freq=4) == 3
+
+    state = DSAIndexShareState()
+    topk = torch.tensor([[[0, 1], [1, 2]]], dtype=torch.int32)
+    state.save_topk(3, topk, sequence_key=0)
+    assert torch.equal(state.get_topk(6, 3, sequence_key=0), topk)
+    with pytest.raises(AssertionError, match="source layer 3"):
+        state.get_topk(5, 3, sequence_key=1)
+
+    state.save_topk(7, topk + 1, sequence_key=0)
+    assert state._resident_source_layer == 7
+    assert state._topk_by_layer[(3, 0)].device.type == "cpu"
+    state.finish_forward()
+    assert state._resident_source_layer is None
+    assert all(value.device.type == "cpu" for value in state._topk_by_layer.values())
+
+
+def test_dsa_index_share_state_drops_old_groups_without_recompute():
+    from megatron.lite.primitive.modules.attention.dsa import DSAIndexShareState
+
+    state = DSAIndexShareState(retain_for_recompute=False)
+    topk = torch.tensor([[[0, 1], [1, 2]]], dtype=torch.int32)
+    state.save_topk(3, topk)
+    state.save_topk(7, topk)
+    with pytest.raises(AssertionError, match="source layer 3"):
+        state.get_topk(4, 3)
+    state.finish_forward()
+    assert state._topk_by_layer == {}
+
+
+def test_glm5_dsa_wrapper_forwards_explicit_position_ids():
+    from megatron.lite.model.glm5.lite.model import Glm5DSAAttention
+
+    class CaptureDSA(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.position_ids = None
+
+        def forward(self, x, **kwargs):
+            self.position_ids = kwargs["position_ids"]
+            return x
+
+    wrapper = Glm5DSAAttention.__new__(Glm5DSAAttention)
+    torch.nn.Module.__init__(wrapper)
+    wrapper.ps = SimpleNamespace(cp_size=1, cp_rank=0)
+    wrapper.qk_rope_head_dim = 4
+    wrapper.rope_theta = 1_000_000.0
+    wrapper.self_attention = CaptureDSA()
+    hidden = torch.randn(5, 2, 8)
+    position_ids = torch.tensor([[0, 1, 2, 3, 4], [0, 1, 0, 1, 2]])
+
+    output = wrapper(hidden, position_ids=position_ids)
+
+    assert output.shape == hidden.shape
+    assert torch.equal(wrapper.self_attention.position_ids, position_ids)
+
+
+def test_dsa_index_share_pipeline_guard_rejects_cross_stage_sources():
+    from megatron.lite.primitive.modules.attention.dsa import (
+        validate_dsa_index_share_pipeline_split,
+    )
+
+    validate_dsa_index_share_pipeline_split(
+        [0, 1, 2, 3],
+        topk_freq=4,
+        skip_topk_offset=3,
+    )
+    with pytest.raises(ValueError, match="cannot cross pipeline stages"):
+        validate_dsa_index_share_pipeline_split(
+            [3, 4, 5],
+            topk_freq=4,
+            skip_topk_offset=3,
+        )
+    with pytest.raises(ValueError, match="must execute before"):
+        validate_dsa_index_share_pipeline_split(
+            [3, 2],
+            topk_freq=4,
+            skip_topk_offset=3,
+        )
+    # Global layer index 3 is the first MTP layer for a 3-layer trunk in this
+    # configuration.  It is shared from trunk layer 2 and must not sit alone on
+    # the final pipeline stage.
+    with pytest.raises(ValueError, match="cannot cross pipeline stages"):
+        validate_dsa_index_share_pipeline_split(
+            [3],
+            topk_freq=4,
+            skip_topk_offset=3,
+        )
+    validate_dsa_index_share_pipeline_split(
+        [2, 3],
+        topk_freq=4,
+        skip_topk_offset=3,
+    )

--- a/experimental/lite/tests/unit/primitive/test_dsa_cp_native_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_dsa_cp_native_unit.py
@@ -1,0 +1,354 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.mlite
+
+
+@pytest.fixture(autouse=True)
+def _te_import_stub(transformer_engine_import_stub):
+    transformer_engine_import_stub()
+
+
+def test_dense_cp_layout_keeps_local_queries_and_restores_global_kv_order():
+    from megatron.lite.primitive.modules.attention.dsa import _dense_cp_layout
+
+    query_positions, kv_reorder = _dense_cp_layout(
+        local_seq=4,
+        cp_size=2,
+        cp_rank=0,
+        device=torch.device("cpu"),
+    )
+
+    assert query_positions.tolist() == [0, 1, 2, 3]
+    gathered_positions = torch.tensor([0, 1, 2, 3, 4, 5, 6, 7])
+    assert gathered_positions.index_select(0, kv_reorder).tolist() == list(range(8))
+
+
+def test_packed_cp_layout_uses_contiguous_global_coordinates():
+    from megatron.lite.primitive.modules.attention.dsa import _packed_cp_layout
+
+    cu_seqlens = torch.tensor([0, 8, 16], dtype=torch.int32)
+    query_positions, kv_reorder = _packed_cp_layout(
+        cu_seqlens,
+        cp_size=2,
+        cp_rank=0,
+        device=torch.device("cpu"),
+    )
+
+    assert query_positions.tolist() == list(range(8))
+    gathered_positions = torch.arange(16)
+    assert gathered_positions.index_select(0, kv_reorder).tolist() == list(range(16))
+
+
+def test_cp_projected_kv_is_physically_aligned_for_cudnn_topk():
+    from megatron.lite.primitive.modules.attention.dsa import _pad_cp_projected_kv
+
+    kv = torch.arange(520 * 3, dtype=torch.float32).view(520, 1, 3)
+    index_k = torch.arange(520 * 2, dtype=torch.float32).view(520, 1, 2)
+
+    padded_kv, padded_index_k = _pad_cp_projected_kv(kv, index_k)
+
+    assert padded_kv.shape == (1024, 1, 3)
+    assert padded_index_k is not None and padded_index_k.shape == (1024, 1, 2)
+    assert torch.equal(padded_kv[:520], kv)
+    assert torch.equal(padded_index_k[:520], index_k)
+    assert torch.count_nonzero(padded_kv[520:]) == 0
+    assert torch.count_nonzero(padded_index_k[520:]) == 0
+
+
+def test_cp_causal_mask_blocks_future_and_cross_packed_sequence_keys():
+    from megatron.lite.primitive.modules.attention.dsa import _build_cp_causal_mask
+
+    query_positions = torch.tensor([1, 8, 15], dtype=torch.long)
+    # Keys beyond the final logical boundary model physically aligned CP padding.
+    key_positions = torch.arange(20, dtype=torch.long)
+    cu_seqlens = torch.tensor([0, 8, 16], dtype=torch.int32)
+
+    mask = _build_cp_causal_mask(
+        query_positions,
+        key_positions,
+        cu_seqlens=cu_seqlens,
+    )
+    valid = mask == 0
+
+    assert valid[0].nonzero().flatten().tolist() == [0, 1]
+    assert valid[1].nonzero().flatten().tolist() == [8]
+    assert valid[2].nonzero().flatten().tolist() == list(range(8, 16))
+
+
+def test_ragged_packed_kv_is_physically_aligned_without_changing_valid_rows():
+    from megatron.lite.primitive.kernels.dsa_kernels import _pad_sparse_kv_rows
+
+    kv = torch.arange(520 * 3, dtype=torch.float32).view(520, 3)
+    padded = _pad_sparse_kv_rows(kv, 128)
+
+    assert padded.shape == (640, 3)
+    assert torch.equal(padded[:520], kv)
+    assert torch.count_nonzero(padded[520:]) == 0
+    assert _pad_sparse_kv_rows(padded, 128) is padded
+
+
+def test_ragged_indexer_scores_keep_physical_width_and_report_cudnn_contract(capsys):
+    from megatron.lite.primitive.kernels.dsa_kernels import _cudnn_topk_block
+
+    scores = torch.randn(3, 520)
+    fake_dsa = Mock()
+    returned = torch.zeros((3, 512), dtype=torch.int32)
+    returned[0, -1] = 700
+    fake_dsa.indexer_top_k_wrapper.return_value = {"indices": returned}
+
+    values, indices = _cudnn_topk_block(fake_dsa, scores, width=512)
+
+    call = fake_dsa.indexer_top_k_wrapper.call_args
+    input_values, seq_lens = call.args
+    assert input_values.shape == (3, 520)
+    assert torch.equal(input_values, scores)
+    assert seq_lens.tolist() == [520, 520, 520]
+    assert call.kwargs == {"top_k": 512, "next_n": 1, "return_val": False}
+    assert "input_values.shape=(3, 520)" in capsys.readouterr().out
+    assert values.shape == indices.shape == (3, 512)
+    assert indices[0, -1] == -1
+    assert torch.isneginf(values[0, -1])
+
+
+def test_dense_cp_native_collective_only_receives_projected_kv_and_indexer_k():
+    from megatron.lite.primitive.modules.attention.dsa import DynamicSparseAttention
+
+    gathered_widths = []
+    gather_modes = []
+    sentinel = torch.randn(1, 4, 64)
+
+    def project_inputs(x, cos, sin, position_ids):
+        del x, cos, sin, position_ids
+        return (
+            torch.randn(4, 1, 2, 8),
+            torch.randn(4, 1, 8),
+            torch.randn(2, 2, 4),
+            torch.randn(4, 1, 2, 4),
+            torch.randn(4, 1, 4),
+            torch.randn(4, 1, 2),
+        )
+
+    def gather_projected(tensor, reorder, *, contiguous=False):
+        gathered_widths.append(tensor.shape[-1])
+        gather_modes.append(contiguous)
+        return torch.cat([tensor, tensor], dim=0).index_select(0, reorder)
+
+    def run_sparse(query, kv, q_idx, k_idx, weights, mask, **kwargs):
+        del q_idx, k_idx, weights, mask, kwargs
+        assert query.shape[0] == 4
+        assert kv.shape[0] == 8
+        return torch.randn(4, 1, 8)
+
+    fake = SimpleNamespace(
+        cp_size=2,
+        cp_rank=0,
+        _project_cp_inputs=project_inputs,
+        _gather_projected_cp=gather_projected,
+        _run_cp_sparse_segment=run_sparse,
+        _project_cp_output=lambda out, weight: sentinel,
+    )
+    x = torch.randn(1, 4, 64)
+    result = DynamicSparseAttention._forward_dense_cp_native(
+        fake,
+        x,
+        torch.empty(0),
+        torch.empty(0),
+        torch.empty(0),
+        index_share_state=None,
+    )
+
+    assert result is sentinel
+    assert gathered_widths == [8, 4]
+    assert gather_modes == [False, False]
+    assert x.shape[-1] not in gathered_widths
+
+
+def test_packed_cp_native_explicitly_selects_contiguous_projected_gather():
+    from megatron.lite.primitive.modules.attention.dsa import DynamicSparseAttention
+
+    gather_modes = []
+    sentinel = torch.randn(1, 4, 64)
+
+    def project_inputs(x, cos, sin, position_ids):
+        del x, cos, sin, position_ids
+        return (
+            torch.randn(4, 1, 2, 8),
+            torch.randn(4, 1, 8),
+            torch.randn(2, 2, 4),
+            torch.randn(4, 1, 2, 4),
+            torch.randn(4, 1, 4),
+            torch.randn(4, 1, 2),
+        )
+
+    def gather_projected(tensor, reorder, *, contiguous=False):
+        gather_modes.append(contiguous)
+        return torch.cat([tensor, tensor], dim=0).index_select(0, reorder)
+
+    def run_sparse(query, kv, q_idx, k_idx, weights, mask, **kwargs):
+        del q_idx, k_idx, weights, mask, kwargs
+        assert query.shape[0] == 4
+        assert kv.shape[0] == 8
+        return torch.randn(4, 1, 8)
+
+    fake = SimpleNamespace(
+        cp_size=2,
+        cp_rank=0,
+        _packed_cu_seqlens=lambda params, device: params.cu_seqlens_q.to(device),
+        _project_cp_inputs=project_inputs,
+        _gather_projected_cp=gather_projected,
+        _run_cp_sparse_segment=run_sparse,
+        _project_cp_output=lambda out, weight: sentinel,
+    )
+    params = SimpleNamespace(
+        cp_layout="contiguous",
+        cu_seqlens_q=torch.tensor([0, 8], dtype=torch.int32),
+    )
+    result = DynamicSparseAttention._forward_packed_cp_native(
+        fake,
+        torch.randn(1, 4, 64),
+        torch.empty(0),
+        torch.empty(0),
+        torch.empty(0),
+        params,
+        index_share_state=None,
+    )
+
+    assert result is sentinel
+    assert gather_modes == [True, True]
+
+
+def test_cp_indexer_topk_respects_explicit_global_position_mask():
+    from megatron.lite.primitive.kernels.dsa_kernels import indexer_topk_with_mask
+
+    torch.manual_seed(7)
+    q = torch.randn(2, 1, 2, 4)
+    k = torch.randn(8, 1, 4)
+    weights = torch.randn(2, 1, 2)
+    mask = torch.full((2, 8), float("-inf"))
+    mask[0, :2] = 0
+    mask[1, :7] = 0
+
+    _scores, actual = indexer_topk_with_mask(q, k, weights, 4, mask, 4**-0.5)
+    reference = torch.einsum("qbhd,kbd->bqhk", q.float(), k.float())
+    reference = torch.relu(reference).mul(weights.permute(1, 0, 2).unsqueeze(-1)).sum(dim=2)
+    reference = reference * (4**-0.5) + mask.unsqueeze(0)
+    values, expected = torch.topk(reference, k=4, dim=-1)
+    expected = torch.where(torch.isfinite(values), expected, torch.full_like(expected, -1))
+
+    assert torch.equal(actual, expected.int())
+    assert (actual[0, 0][actual[0, 0] >= 0] < 2).all()
+    assert (actual[0, 1][actual[0, 1] >= 0] < 7).all()
+
+
+def test_cp_dense_indexer_loss_matches_full_score_reference_and_backpropagates():
+    from megatron.lite.primitive.kernels.dsa_kernels import cp_indexer_loss, indexer_topk_with_mask
+
+    torch.manual_seed(11)
+    q = torch.randn(3, 1, 2, 4, requires_grad=True)
+    k = torch.randn(6, 1, 4, requires_grad=True)
+    weights = torch.randn(3, 1, 2, requires_grad=True)
+    query = torch.randn(3, 1, 2, 4)
+    kv = torch.randn(6, 1, 4)
+    mask = torch.full((3, 6), float("-inf"))
+    mask[0, :1] = 0
+    mask[1, :4] = 0
+    mask[2, :6] = 0
+    _scores, topk = indexer_topk_with_mask(q, k, weights, 3, mask, 4**-0.5)
+
+    actual = cp_indexer_loss(
+        q,
+        k,
+        weights,
+        topk,
+        query,
+        kv,
+        mask=mask,
+        softmax_scale=4**-0.5,
+        loss_coeff=0.7,
+        sparse_loss=False,
+        calculate_per_token_loss=False,
+    )
+
+    index_logits = torch.einsum("qbhd,kbd->bqhk", q.float(), k.float())
+    index_logits = torch.relu(index_logits).mul(weights.permute(1, 0, 2).unsqueeze(-1)).sum(dim=2)
+    index_logits = index_logits * (4**-0.5) + mask.unsqueeze(0)
+    predict = torch.softmax(index_logits, dim=-1)
+    attn_logits = torch.einsum("qbhd,kbd->bqhk", query.float(), kv.float())
+    attn_logits = attn_logits * (4**-0.5) + mask.unsqueeze(0).unsqueeze(2)
+    target = torch.softmax(attn_logits, dim=-1).mean(dim=2)
+    expected = (
+        target * (torch.log(target + 1.0e-10) - torch.log(predict + 1.0e-10))
+    ).sum(dim=-1).mean() * 0.7
+
+    torch.testing.assert_close(actual, expected, atol=1e-6, rtol=1e-6)
+    actual.backward()
+    assert q.grad is not None and torch.isfinite(q.grad).all()
+    assert k.grad is not None and torch.isfinite(k.grad).all()
+    assert weights.grad is not None and torch.isfinite(weights.grad).all()
+
+
+def test_cp_sparse_indexer_loss_ignores_invalid_topk_sentinels():
+    from megatron.lite.primitive.kernels.dsa_kernels import cp_indexer_loss
+
+    torch.manual_seed(19)
+    q = torch.randn(2, 1, 2, 4, requires_grad=True)
+    k = torch.randn(5, 1, 4, requires_grad=True)
+    weights = torch.randn(2, 1, 2, requires_grad=True)
+    query = torch.randn(2, 1, 2, 4)
+    kv = torch.randn(5, 1, 4)
+    topk = torch.tensor([[[0, -1, -1], [2, 1, 0]]], dtype=torch.int32)
+    mask = torch.zeros((2, 5), dtype=torch.float32)
+
+    loss = cp_indexer_loss(
+        q,
+        k,
+        weights,
+        topk,
+        query,
+        kv,
+        mask=mask,
+        softmax_scale=4**-0.5,
+        loss_coeff=0.5,
+        sparse_loss=True,
+        calculate_per_token_loss=False,
+    )
+
+    assert torch.isfinite(loss)
+    loss.backward()
+    assert q.grad is not None and torch.isfinite(q.grad).all()
+    assert k.grad is not None and torch.isfinite(k.grad).all()
+    assert weights.grad is not None and torch.isfinite(weights.grad).all()
+
+
+def test_zero_cp_indexer_loss_keeps_zero_grad_edges_for_indexer_parameters():
+    from megatron.lite.primitive.kernels.dsa_kernels import cp_indexer_loss
+
+    q = torch.randn(2, 1, 2, 4, requires_grad=True)
+    k = torch.randn(3, 1, 4, requires_grad=True)
+    weights = torch.randn(2, 1, 2, requires_grad=True)
+    loss = cp_indexer_loss(
+        q,
+        k,
+        weights,
+        torch.zeros((1, 2, 1), dtype=torch.int32),
+        torch.randn(2, 1, 2, 4),
+        torch.randn(3, 1, 4),
+        mask=torch.zeros((2, 3)),
+        softmax_scale=0.5,
+        loss_coeff=0.0,
+        sparse_loss=True,
+        calculate_per_token_loss=False,
+    )
+
+    loss.backward()
+    assert q.grad is not None and torch.count_nonzero(q.grad) == 0
+    assert k.grad is not None and torch.count_nonzero(k.grad) == 0
+    assert weights.grad is not None and torch.count_nonzero(weights.grad) == 0

--- a/experimental/lite/tests/unit/primitive/test_parallel_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_parallel_unit.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import pytest
 import torch
+
 from megatron.lite.primitive.parallel import (
     ParallelState,
     build_pipeline_chunk_layout,
@@ -128,9 +129,7 @@ def _mcore_reference_decoder_ids(num_layers: int, pp: int, mtp: int) -> list[lis
     """Per-stage decoder ids from mcore's PipelineParallelLayerLayout, built directly
     from the canonical unit sequence — the independent reference the glue must match."""
     from megatron.core.transformer.enums import LayerType
-    from megatron.core.transformer.pipeline_parallel_layer_layout import (
-        PipelineParallelLayerLayout,
-    )
+    from megatron.core.transformer.pipeline_parallel_layer_layout import PipelineParallelLayerLayout
 
     units = ["embedding"] + ["decoder"] * num_layers + ["mtp"] * mtp + ["loss"]
     base, rem = divmod(len(units), pp)
@@ -164,6 +163,75 @@ def test_auto_layout_is_legal_and_balanced(model, pp, mtp):
     # balanced: per-stage unit cells (decoders + embedding/loss/mtp slots) differ by <=1
     cells = [len(c.layer_indices) + c.has_embed + c.has_head + (mtp if c.has_mtp else 0) for c in chunks]
     assert max(cells) - min(cells) <= 1
+
+
+def _glm52_index_share_groups(num_layers: int = 78) -> list[list[int]]:
+    from megatron.lite.primitive.modules.attention.dsa import (
+        dsa_indexer_type_for_layer,
+        source_dsa_compute_layer,
+    )
+
+    groups: list[list[int]] = []
+    current: list[int] = []
+    current_source: int | None = None
+    for layer_idx in range(num_layers):
+        layer_number = layer_idx + 1
+        if dsa_indexer_type_for_layer(layer_number, skip_topk_offset=3, topk_freq=4) == "shared":
+            source_idx = source_dsa_compute_layer(layer_number, skip_topk_offset=3, topk_freq=4) - 1
+        else:
+            source_idx = layer_idx
+        if current and source_idx != current_source:
+            groups.append(current)
+            current = []
+        current.append(layer_idx)
+        current_source = source_idx
+    if current:
+        groups.append(current)
+    return groups
+
+
+def test_grouped_pp_layout_keeps_glm52_indexshare_groups_inside_stage():
+    from megatron.lite.primitive.modules.attention.dsa import (
+        validate_dsa_index_share_pipeline_split,
+    )
+
+    chunks = [
+        build_pipeline_chunk_layout(
+            78,
+            ps,
+            num_mtp_layers=1,
+            decoder_layer_groups=_glm52_index_share_groups(),
+        )
+        for ps in _ranks(8)
+    ]
+    indices = [chunk.layer_indices for chunk in chunks]
+
+    _assert_full_contiguous_cover(indices, 78)
+    assert chunks[-1].has_mtp is True
+    assert [chunk.has_mtp for chunk in chunks[:-1]] == [False] * 7
+    for stage_indices in indices:
+        validate_dsa_index_share_pipeline_split(
+            stage_indices,
+            topk_freq=4,
+            skip_topk_offset=3,
+            indexer_types=None,
+        )
+
+
+def test_ungrouped_glm52_auto_layout_would_trip_indexshare_guard():
+    from megatron.lite.primitive.modules.attention.dsa import (
+        validate_dsa_index_share_pipeline_split,
+    )
+
+    bad_indices = _layout_indices(78, 8, num_mtp_layers=1)
+    with pytest.raises(ValueError, match="DSA IndexShare cannot cross pipeline stages"):
+        for stage_indices in bad_indices:
+            validate_dsa_index_share_pipeline_split(
+                stage_indices,
+                topk_freq=4,
+                skip_topk_offset=3,
+                indexer_types=None,
+            )
 
 
 def test_pp_layout_custom_string_mode_is_used_verbatim():


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Adds GLM5.2 (DeepSeek-V3.2) IndexShare DSA support to Megatron Lite.  A configurable IndexShare schedule lets `full` layers compute DSA top-k indices and lets subsequent `shared` layers reuse that source.  The existing GLM5 behavior is preserved when `index_topk_freq=1`.

The change also makes the GLM5 DSA path safe for packed THD and context parallelism, protects pipeline placement of source/consumer pairs (including MTP), bounds cache residency during forward/recompute/offload, and correctly omits shared-indexer weights from checkpoint conversion.

The source implementation and complete validation log are available at https://github.com/ISEEKYAN/Megatron-LM/pull/66.

:warning: This is a feature-sized change. It is submitted as a draft; please advise whether an upstream design discussion or a split into runtime and validation PRs is preferred.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: _Not yet filed — this must be replaced with the NVIDIA feature-request issue before marking the PR ready for review._

## Implementation details

- **IndexShare schedule:** `full` layers compute top-k and following `shared` layers reuse the source. Shared layers have neither indexer parameters nor indexer loss. `index_topk_freq=1` selects the established all-full path.
- **Packed and CP positions:** the protocol derives and CP-splits per-sequence positions; model, layer, and DSA wrapper forward them unchanged. Packed DSA requires explicit positions, while the dense CP fallback uses the shared zigzag-position primitive.
- **Pipeline safety:** the split guard accounts for both trunk and MTP logical layer indices, preventing a shared MTP layer from being placed on another pipeline stage from its full source.
- **Cache lifecycle:** normal forward holds only the current source group on GPU and releases it after consumers. Recompute/offload keeps historical groups on CPU, pages at most one source group back during backward, and clears the resident group afterward.
- **Checkpoint mapping:** shared layers omit indexer weights during import/export; full layers retain the existing mapping.

### MTP schedule

The official GLM5.2 layout has 78 decoder layers plus one MTP layer. The MTP transformer is global zero-based layer 78 (one-based layer 79), which is a `full` indexer layer under `freq=4, offset=3`; it computes its own top-k rather than sharing the final trunk layer's result.

## Validation

### Original GPU validation (Slurm, non-skip)

- Actual causal models versus Hugging Face at sequence length 1024: full-logits cosine `0.9998986721`; all values finite.
- Packed THD + CP2 + IndexShare + MTP: two-GPU `_forward_step`, forward and backward completed; loss `5.269021e+00`, grad norm `6.683617e+01`.
- Recompute cache lifecycle: two source groups, CPU history `4,194,304` bytes, no GPU-resident cache entries after forward or backward, finite gradient norm.
- Fused DSA primitive versus Megatron reference: source/shared/MTP max absolute differences `0.001953125 / 0.001953125 / 0.0009765625`.
- HF BF16 save/load round trips with IndexShare disabled and enabled: `max_abs=0.0` for both.
- Uneven 78-layer pipeline, VERL runtime, fused run-to-run acceptance, and pipeline-layout matrix completed successfully (`56 passed, 1 xfailed`).

### Port pre-checks

- `python -m compileall` on every changed Python file.
- `uv run isort --check-only` after formatting the changed Python files.
- `tools/check_copyright.py` passed for all 15 changed files.
- `git diff --check` passed.

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests.
- [x] I have added relevant functional tests.
- [ ] I have added proper typing to my code ([typing guidelines](https://docs.python.org/3/library/typing.html)).
- [ ] I have added relevant documentation.
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR.

## Compliance

- This port is a fresh commit on `dev` with a DCO `Signed-off-by: Yan Bai <bayan@nvidia.com>` trailer.
- All changed files satisfy the current NVIDIA copyright-header check; the DSA kernel wrapper header was updated to the 2026 NVIDIA CORPORATION & AFFILIATES form.