### PR TITLE
fix: allow mtp_num_layers=0 with overlap_moe_expert_parallel_comm

### DIFF
--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -2658,9 +2658,11 @@ class TransformerConfig(ModelParallelConfig):
             assert (
                 not self.moe_shared_expert_overlap
             ), 'disable moe_shared_expert_overlap when enabling overlap_moe_expert_parallel_comm'
-            assert (
-                self.mtp_num_layers is None or self.mtp_num_layers == 1
-            ), 'MTP layernum only supports 1 when enabling overlap_moe_expert_parallel_comm.'
+            assert self.mtp_num_layers in (
+                None,
+                0,
+                1,
+            ), 'MTP supports at most one layer when enabling overlap_moe_expert_parallel_comm.'
 
             # NCCL EP (ncclep flex backend) mirrors hybridep's comm/compute overlap, but a few
             # configs are not yet safe under the 1F1B split and are gated here.

--- a/tests/unit_tests/transformer/test_transformer_config.py
+++ b/tests/unit_tests/transformer/test_transformer_config.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import pytest
+
+from megatron.core.transformer.transformer_config import TransformerConfig
+
+
+def _make_overlap_config(mtp_num_layers: int | None) -> TransformerConfig:
+    return TransformerConfig(
+        num_layers=1,
+        hidden_size=128,
+        num_attention_heads=4,
+        num_moe_experts=2,
+        expert_model_parallel_size=2,
+        moe_token_dispatcher_type="alltoall",
+        overlap_moe_expert_parallel_comm=True,
+        bf16=True,
+        mtp_num_layers=mtp_num_layers,
+    )
+
+
+@pytest.mark.parametrize("mtp_num_layers", [None, 0, 1])
+def test_ep_a2a_overlap_accepts_supported_mtp_layer_counts(mtp_num_layers: int | None):
+    config = _make_overlap_config(mtp_num_layers)
+
+    assert config.mtp_num_layers == mtp_num_layers
+
+
+@pytest.mark.parametrize("mtp_num_layers", [-1, 2])
+def test_ep_a2a_overlap_rejects_unsupported_mtp_layer_counts(mtp_num_layers: int):
+    with pytest.raises(AssertionError, match="MTP supports at most one layer"):
+        _make_overlap_config(mtp_num_layers)


### PR DESCRIPTION
## What

Accept `mtp_num_layers == 0` in the `overlap_moe_expert_parallel_comm` validation inside `TransformerConfig.__post_init__`, alongside the existing `None` and `1`:

```python
assert self.mtp_num_layers in (None, 0, 1), (
    'MTP supports at most one layer when enabling overlap_moe_expert_parallel_comm.'
)
```

## Why

`mtp_num_layers == 0` is semantically identical to `None` — both mean *no* multi-token-prediction layers — and is equally compatible with expert-parallel communication overlap. The previous check (`is None or == 1`) rejected `0`, so any config that explicitly defaults `mtp_num_layers` to `0` (rather than `None`) fails configuration validation at finalize time when `overlap_moe_expert_parallel_comm` is enabled, even though the model has no MTP layers.

This surfaced with hybrid/MoE providers whose `mtp_num_layers` field defaults to `0`: enabling MoE expert-parallel comm overlap raised `AssertionError: MTP layernum only supports 1 ...` during `__post_init__`, blocking otherwise-valid runs. The downstream Megatron-Bridge project already relaxed its equivalent guard; this brings the Megatron-Core check in line so `0` is handled at the source.

## Change

- Widen the allowed set from `{None, 1}` to `{None, 0, 1}`.
- No behavior change for `None`/`1`; `>= 2` still (correctly) fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)