### PR TITLE
Document behavior-focused testing guidance

### DIFF
--- a/skills/mcore-testing/SKILL.md
+++ b/skills/mcore-testing/SKILL.md
@@ -179,6 +179,12 @@ For ad-hoc runs, prefer the direct `torch.distributed.run` invocations above.
 5. If the test needs a dedicated CI bucket, add an entry to
    `tests/test_utils/recipes/h100/unit-tests.yaml`.
 
+Prefer assertions on observable behavior and public interfaces over private
+methods, class selection, or incidental internal state. A behavior-preserving
+refactor should not require changing a test. Test implementation details only
+when the detail is itself an intentional requirement, such as a performance or
+cache contract. See [Google Testing Blog: Test Behavior, Not Implementation](https://testing.googleblog.com/2013/08/testing-on-toilet-test-behavior-not.html).
+
 ---
 
 ## Adding a Functional / Integration Test


### PR DESCRIPTION
## Summary

Add behavior-focused testing guidance to the MCore testing skill.

## Why

I am tired of seeing agents add contrived tests that are tightly coupled to implementation details (e.g. https://github.com/NVIDIA/Megatron-LM/pull/5865/changes/085c85ce4ec2f718d289607ba07918f7c3c70145). This guidance is intended to make agent-authored tests more useful: assert observable behavior and public interfaces so behavior-preserving refactors do not require unnecessary test rewrites. Implementation details remain appropriate to test when they are explicit contracts, such as cache or performance behavior.

## Validation

- `git diff --check`
