### PR TITLE
Add context-parallel causal conv1d support

### DIFF
--- a/megatron/core/ssm/causal_conv1d.py
+++ b/megatron/core/ssm/causal_conv1d.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Causal convolution over contiguous context-parallel sequence shards."""
+
+import torch
+
+from megatron.core.tensor_parallel.mappings import all_to_all
+
+try:
+    from causal_conv1d import causal_conv1d_fn
+except ImportError:
+    causal_conv1d_fn = None
+
+
+def _exchange_initial_states(
+    x: torch.Tensor, state_len: int, cp_group: torch.distributed.ProcessGroup
+) -> torch.Tensor | None:
+    """Exchange the preceding rank's tail as the local convolution state.
+
+    All ranks participate in a differentiable ring exchange. Rank 0 zeros the
+    wrapped tail to preserve the global causal boundary.
+    """
+    if state_len < 0:
+        raise ValueError(f"state_len must be non-negative, got {state_len}")
+    if state_len == 0 or cp_group.size() == 1:
+        return None
+    if x.shape[1] < state_len:
+        raise ValueError(
+            "Each local sequence shard must contain at least "
+            f"{state_len} tokens for causal convolution, got {x.shape[1]}"
+        )
+
+    cp_size = cp_group.size()
+    cp_rank = cp_group.rank()
+    batch_size, _, channels = x.shape
+    split_size = batch_size * state_len
+
+    # Pack only the boundary tokens; x remains a strided sequence shard.
+    tail = x[:, -state_len:, :].reshape(split_size, channels)
+    input_splits = [0] * cp_size
+    output_splits = [0] * cp_size
+    input_splits[(cp_rank + 1) % cp_size] = split_size
+    output_splits[(cp_rank - 1) % cp_size] = split_size
+    previous_tail = all_to_all(
+        cp_group, tail, output_split_sizes_=output_splits, input_split_sizes=input_splits
+    ).view(batch_size, state_len, channels)
+
+    if cp_rank == 0:
+        # Preserve the autograd path while enforcing the global left boundary.
+        previous_tail = previous_tail.clone()
+        previous_tail.zero_()
+    return previous_tail.transpose(1, 2)
+
+
+def causal_conv1d_cp(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    activation: str | None,
+    cp_group: torch.distributed.ProcessGroup,
+) -> torch.Tensor:
+    """Apply causal Conv1d to a contiguous context-parallel shard.
+
+    Args:
+        x: Input tensor of shape ``[B, T, D]``.
+        weight: Depthwise weights of shape ``[D, W]``.
+        bias: Optional channel-wise bias.
+        activation: Optional activation passed to ``causal_conv1d_fn``.
+        cp_group: Context-parallel process group ordered by sequence shard.
+
+    Returns:
+        Output tensor of shape ``[B, T, D]``.
+
+    Raises:
+        ImportError: If the optional ``causal-conv1d`` dependency is unavailable.
+    """
+    if causal_conv1d_fn is None:
+        raise ImportError("causal_conv1d_cp requires the optional causal-conv1d dependency")
+
+    initial_states = _exchange_initial_states(
+        x=x, state_len=weight.shape[-1] - 1, cp_group=cp_group
+    )
+    output = causal_conv1d_fn(
+        x=x.transpose(1, 2),
+        weight=weight,
+        bias=bias,
+        initial_states=initial_states,
+        activation=activation,
+    )
+    return output.transpose(1, 2)

--- a/tests/unit_tests/ssm/test_causal_conv1d.py
+++ b/tests/unit_tests/ssm/test_causal_conv1d.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import pytest
+import torch
+import torch.distributed as dist
+
+from megatron.core import parallel_state
+from megatron.core.ssm import causal_conv1d as causal_conv1d_module
+from tests.unit_tests.test_utilities import Utils
+
+try:
+    from causal_conv1d import causal_conv1d_fn
+
+    HAVE_CAUSAL_CONV1D = True
+except ImportError:
+    HAVE_CAUSAL_CONV1D = False
+
+
+def _contiguous_slice(tensor, cp_rank, local_seq_len):
+    return tensor[:, cp_rank * local_seq_len : (cp_rank + 1) * local_seq_len].contiguous()
+
+
+@pytest.mark.internal
+@pytest.mark.skipif(
+    not HAVE_CAUSAL_CONV1D or not torch.cuda.is_available() or Utils.world_size < 2,
+    reason="CP causal convolution parity requires causal-conv1d and at least two GPUs",
+)
+def test_causal_conv1d_cp_matches_full_sequence():
+    Utils.initialize_model_parallel(context_parallel_size=Utils.world_size)
+    try:
+        cp_group = parallel_state.get_context_parallel_group()
+        cp_size = dist.get_world_size(group=cp_group)
+        cp_rank = dist.get_rank(group=cp_group)
+        device = torch.device("cuda", torch.cuda.current_device())
+        dtype = torch.float32
+        rtol, atol = 3e-4, 1e-3
+        local_seq_len = 64
+        global_seq_len = cp_size * local_seq_len
+
+        torch.manual_seed(1234)
+
+        channels, width = 16, 4
+        x_global = torch.randn(1, global_seq_len, channels, device=device, dtype=dtype)
+        weight_global = torch.randn(channels, width, device=device, dtype=dtype)
+        bias_global = torch.randn(channels, device=device, dtype=dtype)
+        dy_global = torch.randn_like(x_global)
+
+        x_ref = x_global.detach().clone().requires_grad_(True)
+        weight_ref = weight_global.detach().clone().requires_grad_(True)
+        bias_ref = bias_global.detach().clone().requires_grad_(True)
+        output_ref = causal_conv1d_fn(
+            x=x_ref.transpose(1, 2), weight=weight_ref, bias=bias_ref, activation="silu"
+        ).transpose(1, 2)
+        output_ref.backward(dy_global)
+
+        x_local = _contiguous_slice(x_global, cp_rank, local_seq_len).detach().requires_grad_(True)
+        weight_local = weight_global.detach().clone().requires_grad_(True)
+        bias_local = bias_global.detach().clone().requires_grad_(True)
+        output_local = causal_conv1d_module.causal_conv1d_cp(
+            x=x_local, weight=weight_local, bias=bias_local, activation="silu", cp_group=cp_group
+        )
+        output_local.backward(_contiguous_slice(dy_global, cp_rank, local_seq_len))
+        dist.all_reduce(weight_local.grad, group=cp_group)
+        dist.all_reduce(bias_local.grad, group=cp_group)
+
+        expected_output = _contiguous_slice(output_ref, cp_rank, local_seq_len)
+        expected_dx = _contiguous_slice(x_ref.grad, cp_rank, local_seq_len)
+        torch.testing.assert_close(output_local, expected_output, rtol=rtol, atol=atol)
+        torch.testing.assert_close(x_local.grad, expected_dx, rtol=rtol, atol=atol)
+        torch.testing.assert_close(weight_local.grad, weight_ref.grad, rtol=rtol, atol=atol)
+        torch.testing.assert_close(bias_local.grad, bias_ref.grad, rtol=rtol, atol=atol)
+    finally:
+        Utils.destroy_model_parallel()


### PR DESCRIPTION
## Summary

- Add a context-parallel wrapper for causal conv1d over contiguous sequence shards.
- No full activation copies are introduced.

## Tests
```
python -m torch.distributed.run --nproc-per-node 4 -m pytest -q \
    tests/unit_tests/ssm/test_causal_conv1d.py
```