### PR TITLE
[Main] Support full activation recompute for EP A2A overlap (VPP-stage recompute)

### DIFF
--- a/megatron/core/models/common/model_chunk_schedule_plan.py
+++ b/megatron/core/models/common/model_chunk_schedule_plan.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 from contextlib import nullcontext
 from typing import Any, Callable, Optional
@@ -219,6 +219,39 @@ class TransformerLayerSchedulePlan:
         # After the last forward op, release forward-pass params.
         last_fwd_node.set_post_forward_hook(lambda: post_forward_hook(hook_module))
 
+    def _iter_schedule_nodes(self):
+        """Yield the real ScheduleNode instances of this layer (skips NoopScheduleNode)."""
+        from megatron.core.pipeline_parallel.utils import ScheduleNode
+
+        for node in (
+            self.pre_dispatch_computation,
+            self.moe_dispatch,
+            self.mlp,
+            self.moe_combine,
+            self.mtp_post_process,
+        ):
+            if isinstance(node, ScheduleNode):
+                yield node
+
+    def set_forward_no_grad(self, no_grad: bool):
+        """Toggle no-grad forward for all layer nodes (VPP-stage full recompute).
+
+        The initial forward runs with ``no_grad=True`` (no autograd graph retained);
+        the backward-time recompute runs with ``no_grad=False`` to rebuild the graph.
+        """
+        for node in self._iter_schedule_nodes():
+            node.forward_no_grad = no_grad
+
+    def reset_for_recompute(self):
+        """Free the retained forward activations of this layer, keeping the nodes
+        reusable for a recompute forward. Also clears the per-layer shared state."""
+        for node in self._iter_schedule_nodes():
+            node.reset_for_recompute()
+        if getattr(self, 'layer_state', None) is not None:
+            # Nodes hold a reference to this same layer_state object, so clear it
+            # in place rather than replacing it.
+            self.layer_state.__dict__.clear()
+
     def get_fp8_context(self):
         """
         Get the fp8 context for the transformer layer.
@@ -390,6 +423,20 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
         self.post_process = None
         self.vp_stage = model.vp_stage
 
+        # VPP-stage full recompute (EP A2A overlap): retain only the stage input
+        # tensor across the forward->backward gap and recompute the whole stage
+        # forward at backward time. See recompute_model_chunk_schedule_plan().
+        self.recompute_vpp_stage = (
+            model.config.recompute_granularity == 'full'
+            and model.config.overlap_moe_expert_parallel_comm
+        )
+        # RNG states captured at the start of the stage forward, replayed by the
+        # recompute so dropout / rng-forked ops reproduce the forward pass.
+        self._rng_states = None
+        # Snapshot of the mutable chunk-state fields (input_ids/position_ids/
+        # padding_mask) captured before the forward and restored before recompute.
+        self._recompute_state_snapshot = None
+
         # save the inputs of model.forward() to ModelChunkState
         self._model_chunk_state.input_ids = input_ids
         self._model_chunk_state.position_ids = position_ids
@@ -427,6 +474,13 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
             self.post_process = post_process_cls(
                 model, self._model_chunk_state, self._event, get_comp_stream
             )
+
+        # For VPP-stage full recompute, the initial forward of every transformer
+        # layer runs under no_grad (no activation retained); pre_process and
+        # post_process keep their graphs (they are not recomputed).
+        if self.recompute_vpp_stage:
+            for layer_plan in self._transformer_layers:
+                layer_plan.set_forward_no_grad(True)
 
     def _build_layer_schedule_plan(self, module, comp_stream, comm_stream):
         if module is None:
@@ -496,6 +550,92 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
             self.post_process.model_chunk_state = None
             self.post_process = None
 
+    def snapshot_rng_for_recompute(self):
+        """Capture the RNG states and the mutable chunk-state fields at the start of
+        the stage forward so the backward-time recompute can replay an identical
+        forward.
+
+        The MTP path mutates ``chunk_state.input_ids`` / ``position_ids`` /
+        ``padding_mask`` in place (it rolls the tokens by one and writes them back),
+        so these must be restored to their pre-forward values before recompute,
+        otherwise the recompute would roll them a second time.
+        """
+        if not self.recompute_vpp_stage:
+            return
+        from megatron.core.tensor_parallel.random import _get_all_rng_states
+
+        self._rng_states = _get_all_rng_states()
+        cs = self._model_chunk_state
+        self._recompute_state_snapshot = {
+            'input_ids': cs.input_ids,
+            'position_ids': cs.position_ids,
+            'padding_mask': cs.padding_mask,
+        }
+
+    def release_layer_activations(self):
+        """Free every transformer layer's retained forward activations after the
+        initial forward, keeping only the stage input tensor (pre_process output).
+
+        The layer nodes remain reusable; recompute_model_chunk_schedule_plan() rebuilds
+        their forward state before the backward pass.
+        """
+        if not self.recompute_vpp_stage:
+            return
+        for layer_plan in self._transformer_layers:
+            layer_plan.reset_for_recompute()
+
+    def recompute_model_chunk_schedule_plan(self):
+        """Recompute the whole VPP-stage (model chunk) forward from the retained
+        stage input tensor, rebuilding every layer ScheduleNode's forward state so
+        the subsequent backward can run.
+
+        This is called at the start of the stage backward. The A2A communications
+        issued here are exposed (not overlapped) by design; the normal forward and
+        normal backward A2A overlap is preserved elsewhere in the schedule.
+
+        The mapping from the recomputed activations back to the per-submodule
+        ScheduleNodes is implicit: the same node objects are re-run in the same
+        forward order, so each node repopulates its own ``inputs`` / ``output`` /
+        ``detached`` / ``layer_state`` slots exactly as in the initial forward.
+        """
+        if not self.recompute_vpp_stage:
+            return
+        from megatron.core.tensor_parallel.random import _fork_rng, _set_all_rng_states
+
+        assert self.pre_process is not None and self.pre_process.output is not None, (
+            "VPP-stage full recompute requires the retained stage input tensor "
+            "(pre_process output), but it is missing."
+        )
+        stage_input = self.pre_process.output
+
+        # Restore the mutable chunk-state fields (MTP rolls input_ids/position_ids/
+        # padding_mask in place during the forward) so the recompute starts from the
+        # same inputs as the initial forward.
+        if self._recompute_state_snapshot is not None:
+            cs = self._model_chunk_state
+            cs.input_ids = self._recompute_state_snapshot['input_ids']
+            cs.position_ids = self._recompute_state_snapshot['position_ids']
+            cs.padding_mask = self._recompute_state_snapshot['padding_mask']
+            cs.mtp_hidden_states = None
+            self._recompute_state_snapshot = None
+
+        # Enable grad on the layer nodes' forward so the recompute builds the graph.
+        for layer_plan in self._transformer_layers:
+            layer_plan.set_forward_no_grad(False)
+
+        # Replay the forward RNG stream so dropout / rng-forked ops reproduce the
+        # initial forward. _fork_rng() restores the ambient RNG state on exit.
+        with _fork_rng():
+            if self._rng_states is not None:
+                _set_all_rng_states(*self._rng_states)
+            f_input = stage_input
+            for i, layer_plan in enumerate(self._transformer_layers):
+                nvtx_msg = f"recompute_layer_{i}"
+                nvtx_range_push(nvtx_msg)
+                f_input, _ = TransformerLayerSchedulePlan.run(layer_plan, None, f_input=f_input)
+                nvtx_range_pop(nvtx_msg)
+        self._rng_states = None
+
     @staticmethod
     def run(
         f_schedule_plan,
@@ -540,6 +680,9 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
                 pre_forward(f_schedule_plan.vp_stage)
             f_schedule_plan.record_current_stream()
             f_input = f_schedule_plan.pre_process.forward()
+            # Capture RNG right after pre_process so the stage recompute (at backward
+            # time) replays the same forward random stream. No-op unless recompute is on.
+            f_schedule_plan.snapshot_rng_for_recompute()
 
         if b_schedule_plan:
             b_schedule_plan.record_current_stream()
@@ -547,6 +690,12 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
             if pre_backward is not None:
                 pre_backward(b_schedule_plan.vp_stage)
                 b_schedule_plan.record_current_stream()
+
+            # VPP-stage full recompute: rebuild the whole stage's layer forward
+            # graphs from the retained stage input before any layer backward runs.
+            # The A2A issued here is exposed (not overlapped) by design. No-op unless
+            # recompute is on.
+            b_schedule_plan.recompute_model_chunk_schedule_plan()
 
             if b_schedule_plan.post_process is not None:
                 b_grad = b_schedule_plan.post_process.backward(b_grad)
@@ -615,10 +764,25 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
 
         # post process forward
         if f_schedule_plan is not None and f_schedule_plan.post_process is not None:
+            if (
+                f_schedule_plan.recompute_vpp_stage
+                and f_input is not None
+                and not f_input.requires_grad
+            ):
+                # The stage forward ran under no_grad, so the stage output is a plain
+                # value tensor. post_process needs a grad-requiring leaf so its backward
+                # produces the grad seed that feeds the recomputed last-layer backward.
+                f_input.requires_grad_(True)
             f_input = f_schedule_plan.post_process.forward(f_input)
         # pre process backward
         if b_schedule_plan is not None:
             b_schedule_plan.pre_process.backward(b_grad)
+
+        # Free the forward stage's layer activations now that its forward output has
+        # been consumed (PP send / post_process). Only the stage input tensor is kept
+        # for the backward-time recompute. No-op unless recompute is on.
+        if f_schedule_plan is not None:
+            f_schedule_plan.release_layer_activations()
 
         if f_schedule_plan:
             f_schedule_plan.wait_current_stream()

--- a/megatron/core/models/common/utils.py
+++ b/megatron/core/models/common/utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 """Schedule-plan helpers shared by GPTModel and HybridModel.
 
@@ -280,6 +280,21 @@ class TransformerLayerNode(ScheduleNode):
     def _resolve_free_input(name, is_moe, config, num_local_experts):
         """Free-input policy hook. Subclasses override to specialize."""
         return should_free_input(name, is_moe, config, num_local_experts)
+
+    def reset_for_recompute(self):
+        """Release the forward activation tensors held by this node while keeping the
+        node reusable for a later recompute forward.
+
+        Used by the VPP-stage full recompute path (EP A2A overlap): after the initial
+        (no-grad) forward, the layer node's activation tensors are freed so that only
+        the stage input tensor survives the forward->backward gap. The same node
+        object is later re-run (with grad enabled) to rebuild ``inputs``/``output``/
+        ``detached`` before the backward pass.
+        """
+        self.inputs = None
+        self.output = None
+        self.detached = tuple()
+        self.before_detached = tuple()
 
     def detach(self, t):
         """Detach a tensor and remember it for backward through the schedule node."""

--- a/megatron/core/pipeline_parallel/combined_1f1b.py
+++ b/megatron/core/pipeline_parallel/combined_1f1b.py
@@ -393,6 +393,16 @@ def combined_forward_backward_step(
         # each layer's all-gathered parameters explicitly after its compute.
         # Only needed for optim_grads_params strategy (where params are sharded).
         forward_fsdp_wrapper = find_megatron_fsdp(f_model)
+        # VPP-stage full recompute re-runs the stage forward at backward time, which
+        # needs the (sharded) parameters to be all-gathered again. That interaction
+        # with the FSDP reshard hooks is not yet supported.
+        assert not (
+            forward_fsdp_wrapper is not None
+            and getattr(f_schedule_plan, "recompute_vpp_stage", False)
+        ), (
+            "overlap_moe_expert_parallel_comm full recompute (recompute_granularity=full) "
+            "is not yet supported together with Megatron FSDP."
+        )
         if (
             forward_fsdp_wrapper is not None
             and forward_fsdp_wrapper.ddp_config.data_parallel_sharding_strategy

--- a/megatron/core/pipeline_parallel/utils.py
+++ b/megatron/core/pipeline_parallel/utils.py
@@ -1,8 +1,8 @@
-# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import logging
 from abc import ABC, abstractmethod
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from typing import Callable, Optional
 
 import torch
@@ -182,6 +182,11 @@ class ScheduleNode:
         self.free_input = free_input
         self.inputs = None
         self.outputs = None
+        # When True, the forward function runs under torch.no_grad() so no autograd
+        # graph / saved activations are retained. Used by the VPP-stage full recompute
+        # path (EP A2A overlap): the initial forward keeps only the stage input tensor
+        # and the whole stage is recomputed with grad enabled at backward time.
+        self.forward_no_grad = False
 
     def default_backward_func(self, outputs, output_grad):
         """Default backward function"""
@@ -213,7 +218,12 @@ class ScheduleNode:
                     input.requires_grad = inputs[i].requires_grad
 
             data = tuple(self.inputs)
-            data = self.forward_func(*data)
+            # Under the VPP-stage full recompute path, the initial forward runs
+            # without building an autograd graph; the graph is rebuilt at backward
+            # time by re-running this same forward with grad enabled.
+            grad_ctx = torch.no_grad() if self.forward_no_grad else nullcontext()
+            with grad_ctx:
+                data = self.forward_func(*data)
 
             if not isinstance(data, tuple):
                 data = make_viewless(data)

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -1701,18 +1701,30 @@ class TransformerConfig(ModelParallelConfig):
                     'or "selective".'
                 )
 
+            # EP A2A overlap drives its own VPP-stage full recompute (the whole model
+            # chunk is recomputed as a single unit) and therefore does not use
+            # recompute_method / recompute_num_layers. Skip the block/uniform
+            # requirement below in that case.
+            ep_overlap_full_recompute = (
+                self.overlap_moe_expert_parallel_comm and self.recompute_granularity == "full"
+            )
+
             if self.recompute_method is not None:
                 if self.recompute_method not in ["block", "uniform"]:
                     raise ValueError(
                         f'recompute_method: {self.recompute_method} must be "block" or "uniform".'
                     )
-            elif self.recompute_granularity != "selective":
+            elif self.recompute_granularity != "selective" and not ep_overlap_full_recompute:
                 raise ValueError(
                     f"Using recompute_granularity: {self.recompute_granularity} so "
                     'recompute_method must be "block" or "uniform"'
                 )
 
-            if self.recompute_granularity != "selective" and self.recompute_num_layers is None:
+            if (
+                self.recompute_granularity != "selective"
+                and self.recompute_num_layers is None
+                and not ep_overlap_full_recompute
+            ):
                 raise ValueError(
                     f"When using recompute_granularity: {self.recompute_granularity} "
                     "recompute_num_layers must be between "
@@ -2637,15 +2649,57 @@ class TransformerConfig(ModelParallelConfig):
                 'flex',
             ], 'overlap_moe_expert_parallel_comm is supported with alltoall/flex token dispatcher'
 
-            assert (
-                self.recompute_granularity != 'full'
-            ), 'disable full recomputation when enabling overlap_moe_expert_parallel_comm'
-            assert (
-                self.recompute_method is None
-            ), 'disable recomputation method when enabling overlap_moe_expert_parallel_comm'
-            assert (
-                self.recompute_num_layers is None
-            ), 'recompute_num_layers must be None when enabling overlap_moe_expert_parallel_comm'
+            if self.recompute_granularity == 'full':
+                # EP A2A overlap supports full recompute through a dedicated
+                # VPP-stage (model-chunk) recompute path: only the input tensor of
+                # each VPP stage is retained across the forward->backward gap, and
+                # the whole stage forward is recomputed (with an exposed,
+                # non-overlapped A2A) at the start of its backward. The normal
+                # forward/backward A2A overlap is preserved.
+                # See megatron/core/models/common/model_chunk_schedule_plan.py.
+                assert self.recompute_method is None, (
+                    'recompute_method must be None with overlap_moe_expert_parallel_comm full '
+                    'recompute: the whole VPP stage (model chunk) is recomputed as a single unit'
+                )
+                assert self.recompute_num_layers is None, (
+                    'recompute_num_layers must be None with overlap_moe_expert_parallel_comm '
+                    'full recompute (the whole VPP stage is recomputed as a single unit)'
+                )
+                # The recompute replays the stage forward. With attention/hidden
+                # dropout the forward RNG stream is interleaved across microbatches
+                # in the 1F1B schedule and cannot yet be faithfully replayed, so the
+                # recomputed activations would diverge from the forward pass.
+                assert self.attention_dropout == 0.0 and self.hidden_dropout == 0.0, (
+                    'overlap_moe_expert_parallel_comm full recompute currently requires '
+                    'attention_dropout==0 and hidden_dropout==0 (RNG replay across the '
+                    'interleaved 1F1B schedule is not yet supported for nonzero dropout)'
+                )
+                # The VPP-stage recompute re-runs the stage forward at backward time.
+                # Combining it with CUDA graphs is not yet supported: the graph captures
+                # a fixed forward/backward node sequence and pre-allocates static buffers,
+                # which the inserted (no_grad) initial forward + backward-time recompute
+                # pass does not fit. Full recompute (drop+recompute activations) and CUDA
+                # graphs (fixed pre-allocated buffers) also target opposite memory regimes.
+                assert self.cuda_graph_impl == "none", (
+                    'overlap_moe_expert_parallel_comm full recompute is not yet supported '
+                    'together with CUDA graphs (cuda_graph_impl != "none").'
+                )
+                # Paged stash keeps per-layer activations in a paged buffer, while full
+                # recompute drops and recomputes them — the two activation-memory
+                # strategies are redundant and their stash/restore lifecycle conflicts
+                # with the recompute activation release. Not yet supported together.
+                assert not self.moe_paged_stash, (
+                    'overlap_moe_expert_parallel_comm full recompute is not yet supported '
+                    'together with moe_paged_stash.'
+                )
+            else:
+                assert self.recompute_method is None, (
+                    'disable recomputation method when enabling ' 'overlap_moe_expert_parallel_comm'
+                )
+                assert self.recompute_num_layers is None, (
+                    'recompute_num_layers must be None when enabling '
+                    'overlap_moe_expert_parallel_comm'
+                )
             assert (
                 "moe" not in self.recompute_modules
             ), 'disable moe in recompute_modules when enabling overlap_moe_expert_parallel_comm'


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

> Main-branch counterpart of dev PR NVIDIA/Megatron-LM#5869. The change is
> re-adapted to `main`'s layout (`TransformerLayerNode` lives in
> `megatron/core/models/common/utils.py`; the attention node is
> `pre_dispatch_computation`).

# What does this PR do ?

Adds full activation recompute support for the EP A2A overlap path
(`--overlap-moe-expert-parallel-comm`), which previously hard-asserted
`recompute_granularity=full` off. Recompute is done at **VPP-stage / model-chunk**
granularity: only the input tensor of each VPP stage is retained across the
forward→backward gap, and the whole stage forward is recomputed at the start of
its backward. When `pipeline_model_parallel_size == 1` the VPP stage is the full
model chunk; when PP > 1 each VPP stage is a model chunk.

## Issue tracking

Linked issue: <!-- internal NVIDIA contribution; add issue link if required -->

## Design

- The stage's initial forward runs under `no_grad` (no activation autograd graph
  retained); `pre_process` / `post_process` keep their graphs. Only the stage
  input tensor (`pre_process` output) survives the forward→backward gap, so the
  activation memory of every in-flight microbatch drops to a single input tensor.
- At the start of the stage backward, `recompute_model_chunk_schedule_plan()`
  re-runs the whole stage forward with grad enabled by re-invoking the **same**
  `ScheduleNode` objects in forward order, so each node repopulates its own
  `inputs` / `output` / `detached` / `layer_state`. The activation→node mapping is
  therefore implicit and needs no bookkeeping.
- The A2A communication issued during this recompute is **exposed** (not
  overlapped) by design; the normal forward and normal backward A2A overlap is
  fully preserved.
- RNG states are snapshotted after `pre_process` and replayed for the recompute.
  MTP rolls `input_ids` / `position_ids` / `padding_mask` in place during the
  forward, so these are snapshotted and restored before the recompute to avoid a
  double roll.

## Constraints (asserted)

Under `overlap_moe_expert_parallel_comm` + `recompute_granularity=full`:
- `recompute_method` / `recompute_num_layers` must be `None` (the whole stage is
  recomputed as a single unit).
- `attention_dropout == 0` and `hidden_dropout == 0` — the forward RNG stream is
  interleaved across microbatches in the 1F1B schedule and cannot yet be
  faithfully replayed for nonzero dropout.
- Not yet supported (asserted off, left as follow-up work): Megatron FSDP, CUDA
  graphs (`cuda_graph_impl != "none"`), and `moe_paged_stash`.

## Test results

Verified with a DeepSeek-V3-proxy deterministic recipe (unfused attention,
`deterministic_mode`, `--no-force-balance`) on `TP1/PP4/VPP2EP16`:
<img width="431" height="346" alt="Screenshot 2026-07-21 at 13 42 36" src="https://github.com/user-attachments/assets/47fb318b-7b55-4ea6-a2bb-59e27f7b7cdd" />
<img width="689" height="314" alt="Screenshot 2026-07-21 at 15 51 28" src="https://github.com/user-attachments/assets/1963b1f7-dab9-47ea-ac69-8e4f8b9d3ed8" />
<img width="698" height="321" alt="Screenshot 2026-07-21 at 15 51 54" src="https://github.com/user-attachments/assets/e972ad9a-c992-44c6-a32d-e17f9ee647a2" />

- Overlap + VPP-stage recompute is **bitwise-identical to standard Megatron
  `recompute_granularity=full`** (no overlap).
## Contribution process

### Pre-checks
- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code
- [x] I have added relevant documentation (inline comments / docstrings)
- [x] I have run the autoformatter.sh on my PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)