### PR TITLE
Draft: Add YAML-configurable optimizer group overrides

### DIFF
--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -3,6 +3,7 @@ import copy
 import logging
 import warnings
 from collections import defaultdict
+from collections.abc import Mapping
 from dataclasses import astuple
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
@@ -51,6 +52,7 @@ from megatron.core import parallel_state
 from megatron.core.optimizer.cpu_offloading.hybrid_optimizer import HybridDeviceOptimizer
 from megatron.core.optimizer_param_scheduler import (
     ParamGroupOverride,
+    canonicalize_optimizer_config_value,
     combine_param_group_overrides,
     param_group_override_to_tuple,
 )
@@ -81,6 +83,9 @@ from .optimizer import (
 from .optimizer_config import (
     AdamOptimizerConfig,
     OptimizerConfig,
+    OptimizerInstanceConfig,
+    OptimizerOverrideRecipe,
+    OptimizerParamGroupTarget,
     ParamKey,
     ParamPredicate,
     ParamWithNamePredicate,
@@ -88,6 +93,13 @@ from .optimizer_config import (
 )
 
 logger = logging.getLogger(__name__)
+
+try:
+    import yaml
+
+    HAVE_YAML = True
+except ImportError:
+    HAVE_YAML = False
 
 
 def get_standard_config_overrides(config: OptimizerConfig) -> Dict[ParamKey, ParamGroupOverride]:
@@ -99,6 +111,13 @@ def get_standard_config_overrides(config: OptimizerConfig) -> Dict[ParamKey, Par
     Returns:
         Dict[ParamKey, ParamGroupOverride]: standard config overrides.
     """
+    warnings.warn(
+        "get_standard_config_overrides is deprecated and superseded by "
+        "OptimizerConfig.overrides_config.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     config_overrides: Optional[Dict[ParamKey, ParamGroupOverride]] = {}
     # First, figure out how we are going to do wd skipping. The two main approaches are:
     #  1. The classic megatron approach of skipping all len 1 and bias parameters.
@@ -126,6 +145,245 @@ def get_standard_config_overrides(config: OptimizerConfig) -> Dict[ParamKey, Par
         config_overrides[decoupled_param_key] = decoupled_lr_config
 
     return config_overrides
+
+
+def get_optimizer_overrides_from_config(
+    config: OptimizerConfig,
+    legacy_config_overrides: Optional[Dict[ParamKey, ParamGroupOverride]] = None,
+) -> Union[Dict[ParamKey, ParamGroupOverride], OptimizerOverrideRecipe]:
+    """Build optimizer overrides from ``OptimizerConfig.overrides_config``.
+
+    When ``overrides_config`` is unset, this returns :func:`get_standard_config_overrides`.
+    Otherwise, the configured mapping is authoritative. Like the quantization recipe, named
+    optimizer instances own named parameter groups, while enabled matchers select a parameter
+    group by optimizer alias and group name. Unmatched parameters use the explicit default target.
+
+    Example::
+
+        overrides_config = {
+            "optimizers": {
+                "adam": {
+                    "type": "adam",
+                    "kwargs": {},
+                    "param_groups": {"default": {"eps": 1.0e-12}},
+                },
+                "newon_fast": {
+                    "type": "newon",
+                    "kwargs": {"new_mode": "fast"},
+                    "param_groups": {
+                        "hidden": {
+                            "max_lr": 1.0e-3,
+                            "min_lr": 1.0e-5,
+                            "wd_mult": 1.0,
+                            "new_scale": 0.5,
+                        }
+                    },
+                }
+            },
+            "default": {"optimizer": "adam", "param_group": "default"},
+            "matchers": {
+                "fc1": {
+                    "type": "glob",
+                    "pattern": "*.linear_fc1.weight",
+                    "optimizer": "newon_fast",
+                    "param_group": "hidden",
+                    "enabled": True,
+                }
+            },
+        }
+
+    Args:
+        config (OptimizerConfig): Optimizer configuration containing parsed override data.
+        legacy_config_overrides (Optional[Dict[ParamKey, ParamGroupOverride]]): Deprecated standard
+            layernorm-weight-decay overrides, optionally composed with MuP overrides.
+
+    Returns:
+        Union[Dict[ParamKey, ParamGroupOverride], OptimizerOverrideRecipe]: Legacy programmatic
+            overrides or the parsed optimizer recipe.
+    """
+
+    def as_mapping(value: Any, path: str) -> Mapping[str, Any]:
+        if isinstance(value, Mapping):
+            return value
+        if hasattr(value, "__dict__"):
+            return vars(value)
+        raise TypeError(f"{path} must be a mapping, got {type(value).__name__}")
+
+    if config.overrides_config is None:
+        if legacy_config_overrides is not None:
+            return legacy_config_overrides
+        return get_standard_config_overrides(config)
+
+    assert legacy_config_overrides is None, (
+        "OptimizerConfig.overrides_config requires standard layernorm-weight-decay and MuP "
+        "config overrides to be None."
+    )
+
+    if isinstance(config.overrides_config, str):
+        if not HAVE_YAML:
+            raise ImportError(
+                "PyYAML is required to load optimizer overrides from a YAML file. "
+                "Install it with `pip install pyyaml`."
+            )
+        with open(config.overrides_config, "r", encoding="utf-8") as config_file:
+            raw_recipe = yaml.load(config_file, Loader=yaml.SafeLoader)
+        log_single_rank(
+            logger,
+            logging.INFO,
+            f"Loaded optimizer overrides from path '{config.overrides_config}'.",
+        )
+    else:
+        raw_recipe = config.overrides_config
+
+    recipe = as_mapping(raw_recipe, "overrides_config")
+    unknown_recipe_fields = set(recipe) - {"optimizers", "default", "matchers"}
+    if unknown_recipe_fields:
+        raise ValueError(
+            f"overrides_config has unsupported fields: {sorted(unknown_recipe_fields)}"
+        )
+
+    optimizers = as_mapping(recipe.get("optimizers", {}), "overrides_config.optimizers")
+    if not optimizers:
+        raise ValueError("overrides_config.optimizers must not be empty")
+    matchers = as_mapping(recipe.get("matchers", {}), "overrides_config.matchers")
+    protected_param_group_fields = {
+        "params",
+        "optimizer",
+        "optimizer_instance",
+        "optimizer_kwargs",
+        "param_group",
+        "param_group_kwargs",
+        "default_config",
+        "is_expert_parallel",
+    }
+    parsed_optimizers: Dict[str, OptimizerInstanceConfig] = {}
+
+    for optimizer_name, raw_optimizer in optimizers.items():
+        optimizer_path = f"overrides_config.optimizers.{optimizer_name}"
+        if not isinstance(optimizer_name, str) or not optimizer_name:
+            raise TypeError("overrides_config.optimizers keys must be non-empty strings")
+        optimizer = as_mapping(raw_optimizer, optimizer_path)
+        unknown_optimizer_fields = set(optimizer) - {"type", "kwargs", "param_groups"}
+        if unknown_optimizer_fields:
+            raise ValueError(
+                f"{optimizer_path} has unsupported fields: {sorted(unknown_optimizer_fields)}"
+            )
+        optimizer_type = optimizer.get("type")
+        if not isinstance(optimizer_type, str) or not optimizer_type:
+            raise TypeError(f"{optimizer_path}.type must be a non-empty string")
+        kwargs = as_mapping(optimizer.get("kwargs", {}), f"{optimizer_path}.kwargs")
+        if any(not isinstance(key, str) for key in kwargs):
+            raise TypeError(f"{optimizer_path}.kwargs keys must be strings")
+        if "params" in kwargs:
+            raise ValueError(
+                f"{optimizer_path}.kwargs cannot override the protected 'params' argument"
+            )
+        raw_param_groups = as_mapping(
+            optimizer.get("param_groups", {}), f"{optimizer_path}.param_groups"
+        )
+        if not raw_param_groups:
+            raise ValueError(f"{optimizer_path}.param_groups must not be empty")
+        parsed_param_groups: Dict[str, Dict[str, Any]] = {}
+        for param_group_name, raw_param_group in raw_param_groups.items():
+            param_group_path = f"{optimizer_path}.param_groups.{param_group_name}"
+            if not isinstance(param_group_name, str) or not param_group_name:
+                raise TypeError(f"{optimizer_path}.param_groups keys must be non-empty strings")
+            param_group = as_mapping(raw_param_group, param_group_path)
+            if any(not isinstance(key, str) for key in param_group):
+                raise TypeError(f"{param_group_path} keys must be strings")
+            protected_fields = set(param_group) & protected_param_group_fields
+            if protected_fields:
+                raise ValueError(
+                    f"{param_group_path} cannot override protected fields: "
+                    f"{sorted(protected_fields)}"
+                )
+            parsed_param_groups[param_group_name] = copy.deepcopy(dict(param_group))
+
+        parsed_optimizers[optimizer_name] = OptimizerInstanceConfig(
+            optimizer_type=optimizer_type,
+            kwargs=copy.deepcopy(dict(kwargs)),
+            param_groups=parsed_param_groups,
+        )
+
+    def parse_target(raw_target: Any, path: str) -> OptimizerParamGroupTarget:
+        target = as_mapping(raw_target, path)
+        unknown_target_fields = set(target) - {"optimizer", "param_group"}
+        if unknown_target_fields:
+            raise ValueError(f"{path} has unsupported fields: {sorted(unknown_target_fields)}")
+        optimizer_name = target.get("optimizer")
+        if not isinstance(optimizer_name, str):
+            raise TypeError(f"{path}.optimizer must be a string")
+        if optimizer_name not in parsed_optimizers:
+            raise ValueError(f"{path}.optimizer references unknown optimizer {optimizer_name!r}")
+        param_group_name = target.get("param_group")
+        if not isinstance(param_group_name, str):
+            raise TypeError(f"{path}.param_group must be a string")
+        if param_group_name not in parsed_optimizers[optimizer_name].param_groups:
+            raise ValueError(
+                f"{path}.param_group references unknown parameter group "
+                f"{optimizer_name}.{param_group_name}"
+            )
+        return OptimizerParamGroupTarget(optimizer_name, param_group_name)
+
+    if "default" not in recipe:
+        raise ValueError("overrides_config.default is required")
+    default_target = parse_target(recipe["default"], "overrides_config.default")
+    parsed_matchers: Dict[ParamKey, OptimizerParamGroupTarget] = {}
+
+    for matcher_name, raw_matcher in matchers.items():
+        matcher_path = f"overrides_config.matchers.{matcher_name}"
+        if not isinstance(matcher_name, str):
+            raise TypeError("overrides_config.matchers keys must be strings")
+        matcher = as_mapping(raw_matcher, matcher_path)
+        unknown_matcher_fields = set(matcher) - {
+            "type",
+            "pattern",
+            "optimizer",
+            "param_group",
+            "enabled",
+        }
+        if unknown_matcher_fields:
+            raise ValueError(
+                f"{matcher_path} has unsupported fields: {sorted(unknown_matcher_fields)}"
+            )
+        if not matcher.get("enabled", False):
+            continue
+
+        match_type = matcher.get("type")
+        if match_type != "glob":
+            raise ValueError(f"{matcher_path}.type must be 'glob', got {match_type!r}")
+        pattern = matcher.get("pattern")
+        if not isinstance(pattern, str) or not pattern:
+            raise TypeError(f"{matcher_path}.pattern must be a non-empty string")
+        target = parse_target(
+            {"optimizer": matcher.get("optimizer"), "param_group": matcher.get("param_group")},
+            matcher_path,
+        )
+
+        param_key = ParamKey(name=pattern)
+        if param_key in parsed_matchers:
+            raise ValueError(f"{matcher_path}.pattern duplicates an earlier enabled matcher")
+        parsed_matchers[param_key] = target
+
+    parsed_recipe = OptimizerOverrideRecipe(
+        optimizers=parsed_optimizers, matchers=parsed_matchers, default=default_target
+    )
+    for optimizer_name, optimizer in parsed_recipe.optimizers.items():
+        if optimizer.optimizer_type not in _EMERGING_OPTIMIZERS:
+            continue
+        constructor_only_kwargs = _EMERGING_OPTIMIZERS[
+            optimizer.optimizer_type
+        ].constructor_only_kwargs
+        for param_group_name, param_group in optimizer.param_groups.items():
+            invalid_group_kwargs = set(param_group) & constructor_only_kwargs
+            if invalid_group_kwargs:
+                raise ValueError(
+                    "Constructor-only optimizer arguments cannot be set on parameter group "
+                    f"{optimizer_name}.{param_group_name}: {sorted(invalid_group_kwargs)}. "
+                    f"Move them to overrides_config.optimizers.{optimizer_name}.kwargs or "
+                    "define another optimizer alias."
+                )
+    return parsed_recipe
 
 
 def get_mup_config_overrides(
@@ -162,6 +420,13 @@ def get_mup_config_overrides(
     Returns:
         Dict[ParamKey, ParamGroupOverride]: MuP optimizer overrides.
     """
+    warnings.warn(
+        "get_mup_config_overrides is deprecated and superseded by "
+        "OptimizerConfig.overrides_config.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     optimizer_type_lower = optimizer_type.lower()
     is_sgd_optimizer = optimizer_type_lower == 'sgd'
     is_adam_optimizer = 'adam' in optimizer_type_lower
@@ -300,16 +565,15 @@ def get_mup_config_overrides(
 def _get_param_groups(
     model_chunks: List[MegatronModule],
     config: OptimizerConfig,
-    config_overrides: Optional[Dict[ParamKey, ParamGroupOverride]],
+    config_overrides: Optional[Union[Dict[ParamKey, ParamGroupOverride], OptimizerOverrideRecipe]],
 ) -> List[Dict]:
     """Create parameter groups for optimizer.
 
     Creates parameter groups from provided optimizer config object.
 
-    NOTE There can be more than one match between a ParamKey and a parameter.
-        What we do is merge all of the matching ParamKey overrides into a single ParamGroupOverride
-        for that parameter and use that as the key for that parameter. Any parameters that get
-        the same set of merged overrides will be mapped into the same parameter group.
+    Programmatic ``ParamKey`` overrides retain their historical composition behavior. A serialized
+    optimizer recipe instead resolves every parameter to exactly one named parameter group. Multiple
+    recipe matchers may match only when they select the same target.
 
     Args:
         model_chunks (List[MegatronModule]): model chunks to create parameter
@@ -323,28 +587,47 @@ def _get_param_groups(
         List of parameter groups.
     """
 
-    # Map (pg_overrides, is_expert_parallel) to params.
+    # Map (canonical pg_overrides, is_expert_parallel) to params and the original override.
     params_map = {}
+    param_overrides_map = {}
 
     for model_chunk in model_chunks:
         for name, param in model_chunk.named_parameters():
             if not param.requires_grad:
                 continue
 
-            uses_default_config = False
             # Get optimizer config overrides for this parameter.
-            param_overrides_list: list[ParamGroupOverride] = []
-            if config_overrides is not None:
-                for param_key, param_override in config_overrides.items():
-                    if param_key.matches(param, name):
-                        param_overrides_list.append(param_override)
-
-            if param_overrides_list:
-                param_override: ParamGroupOverride | None = combine_param_group_overrides(
-                    param_overrides_list
+            if isinstance(config_overrides, OptimizerOverrideRecipe):
+                matching_targets = {
+                    target
+                    for param_key, target in config_overrides.matchers.items()
+                    if param_key.matches(param, name)
+                }
+                if len(matching_targets) > 1:
+                    formatted_targets = sorted(
+                        f"{target.optimizer}.{target.param_group}" for target in matching_targets
+                    )
+                    raise ValueError(
+                        f"Parameter {name!r} matches conflicting optimizer parameter groups: "
+                        f"{formatted_targets}"
+                    )
+                target = (
+                    next(iter(matching_targets)) if matching_targets else config_overrides.default
+                )
+                param_override: ParamGroupOverride | None = ParamGroupOverride(
+                    **config_overrides.resolve(target)
                 )
             else:
-                param_override = None
+                param_overrides_list: list[ParamGroupOverride] = []
+                if config_overrides is not None:
+                    for param_key, candidate_override in config_overrides.items():
+                        if param_key.matches(param, name):
+                            param_overrides_list.append(candidate_override)
+
+                if param_overrides_list:
+                    param_override = combine_param_group_overrides(param_overrides_list)
+                else:
+                    param_override = None
 
             is_expert_parallel = not getattr(param, 'allreduce', True)
 
@@ -355,28 +638,26 @@ def _get_param_groups(
             key = (param_override_tuple, is_expert_parallel)
             if key not in params_map:
                 params_map[key] = []
+                param_overrides_map[key] = copy.deepcopy(param_override)
             params_map[key].append(param)
 
     # Distributed checkpoint requires all ranks to have the same param groups,
     # so we need to align the param groups across ranks, otherwise we may have
     # runtime error when loading the checkpoint or numerical error when resuming training.
-    params_key = list(params_map.keys())
-    gathered_params_key = [None for _ in range(torch.distributed.get_world_size())]
-    torch.distributed.all_gather_object(gathered_params_key, params_key)
-    for keys in gathered_params_key:
-        for key in keys:
-            if key not in params_key:
-                params_key.append(key)
-    # Need to pick one of the param_override_tuples to use for the param group.
+    local_param_group_specs = list(param_overrides_map.items())
+    gathered_param_group_specs = [None for _ in range(torch.distributed.get_world_size())]
+    torch.distributed.all_gather_object(gathered_param_group_specs, local_param_group_specs)
+    param_group_specs = {}
+    for rank_specs in gathered_param_group_specs:
+        for key, param_override in rank_specs:
+            param_group_specs.setdefault(key, param_override)
+
     param_groups = []
     # Sort keys, None first.
-    for key in sorted(params_key, key=lambda x: (x[0] is not None, x[0])):
+    for key in sorted(param_group_specs, key=lambda x: (x[0] is not None, x[0], x[1])):
         param_override_tuple, is_expert_parallel = key
         params = params_map[key] if key in params_map else []
-        if param_override_tuple is None:
-            param_override: ParamGroupOverride = {}
-        else:
-            param_override: ParamGroupOverride = {k: v for (k, v) in param_override_tuple}
+        param_override: ParamGroupOverride = copy.deepcopy(param_group_specs[key] or {})
 
         # False if param_group_override is None or empty tuple or if we do not modify the
         #  LR schedule.
@@ -401,12 +682,24 @@ def _get_param_groups(
         assert (
             "params" not in param_override
         ), "'params' should not be in param_override, this is a protected key"
+        param_group_kwargs = param_override.get("param_group_kwargs", {})
+        protected_fields = set(param_group_kwargs) & (
+            set(ParamGroupOverride.__annotations__)
+            | set(default_config)
+            | {"params", "default_config", "is_expert_parallel"}
+        )
+        if protected_fields:
+            raise ValueError(
+                "param_group_kwargs cannot override protected parameter-group fields: "
+                f"{sorted(protected_fields)}"
+            )
         param_group = {
             'params': params,
             'is_expert_parallel': is_expert_parallel,
             'default_config': uses_default_lr_schedule,
             **default_config,
             **param_override,  # keep **param_override last so that users can override other fields.
+            **param_group_kwargs,
         }
         param_groups.append(param_group)
 
@@ -417,7 +710,7 @@ def _get_param_groups_and_buffers(
     model_chunks: List[MegatronModule],
     model_chunk_offset: int,
     config: OptimizerConfig,
-    config_overrides: Optional[Dict[ParamKey, ParamGroupOverride]],
+    config_overrides: Optional[Union[Dict[ParamKey, ParamGroupOverride], OptimizerOverrideRecipe]],
     filter_fn: Callable,
     buffer_name: str,
 ) -> Tuple[List[Dict], Dict[int, List[_ParamAndGradBuffer]]]:
@@ -696,17 +989,15 @@ def _get_megatron_optimizer_based_on_param_groups(
 
 
 def check_config_overrides_consistency(
-    config: OptimizerConfig, config_overrides: Optional[Dict[ParamKey, ParamGroupOverride]]
+    config: OptimizerConfig,
+    config_overrides: Optional[Union[Dict[ParamKey, ParamGroupOverride], OptimizerOverrideRecipe]],
 ):
     """Check if the config overrides are consistent with the config."""
 
-    # TODO: Remove `optimizer` from this eventually (e.g., if we use Muon for some layers and
-    # Adam for other layers). This would need some more refactoring to work though (param_groups
-    # filtered by optimizer passed into _get_megatron_optimizer_based_on_param_groups).
+    # Only fields that cannot vary across chained optimizers remain global consistency checks.
     if config_overrides is not None:
         fields_to_check_for_consistency = [
             'overlap_param_gather_with_optimizer_step',
-            'optimizer',
             'optimizer_cpu_offload',
         ]
         for field_name in fields_to_check_for_consistency:
@@ -725,10 +1016,10 @@ def check_config_overrides_consistency(
 def _get_megatron_emerging_optimizer(
     config: OptimizerConfig,
     model_chunks: List[MegatronModule],
-    config_overrides: Optional[Dict[ParamKey, Any]] = None,
+    config_overrides: Optional[Union[Dict[ParamKey, Any], OptimizerOverrideRecipe]] = None,
     pg_collection: Optional[ProcessGroupCollection] = None,
 ) -> MegatronOptimizer:
-    """Build an emerging optimizer (e.g. Muon) for the given model chunks.
+    """Build a mixed or emerging optimizer for the given model chunks.
 
     Parameter separation (e.g., linear weights -> Muon, rest -> Adam) is expressed as a
     config_override, the same mechanism used for weight-decay and learning-rate overrides.
@@ -740,6 +1031,11 @@ def _get_megatron_emerging_optimizer(
     """
     eopt_name = config.optimizer
     use_layer_wise = config.use_layer_wise_distributed_optimizer
+    if config_overrides is None:
+        config_overrides = {}
+    configured_optimizer_names = {
+        override['optimizer'] for override in config_overrides.values() if 'optimizer' in override
+    }
 
     # Handle legacy "dist_*" optimizer names (e.g. "dist_muon" → "muon" + layer-wise).
     if eopt_name.startswith('dist_'):
@@ -753,9 +1049,15 @@ def _get_megatron_emerging_optimizer(
         eopt_name = bare_name
         use_layer_wise = True
 
-    if not HAVE_EMERGING_OPTIMIZERS:
+    builtin_optimizer_names = {'adam', 'sgd'}
+    selected_optimizer_names = (
+        configured_optimizer_names
+        if isinstance(config_overrides, OptimizerOverrideRecipe)
+        else configured_optimizer_names | {eopt_name}
+    )
+    if not HAVE_EMERGING_OPTIMIZERS and selected_optimizer_names - builtin_optimizer_names:
         raise ImportError(
-            f"emerging-optimizers package is required for optimizer='{eopt_name}'. "
+            "emerging-optimizers package is required for configured optimizer routing. "
             "Install it with: pip install emerging-optimizers"
         )
     assert not (use_layer_wise and config.overlap_param_gather_with_optimizer_step), (
@@ -764,15 +1066,20 @@ def _get_megatron_emerging_optimizer(
         "split model_chunks into (first, rest) groups, so the per-chunk param-gather "
         "dispatch never fires. Disable one of the two flags."
     )
-    if eopt_name not in _EMERGING_OPTIMIZERS:
-        raise ValueError(f"Unsupported emerging optimizer: {eopt_name}")
-    if config.fp16:
+    supported_optimizer_names = builtin_optimizer_names | set(_EMERGING_OPTIMIZERS)
+    unsupported_optimizer_names = selected_optimizer_names - supported_optimizer_names
+    if unsupported_optimizer_names:
+        raise ValueError(
+            f"Unsupported per-parameter optimizers: {sorted(unsupported_optimizer_names)}. "
+            f"Supported optimizers: {sorted(supported_optimizer_names)}"
+        )
+    if config.fp16 and selected_optimizer_names - builtin_optimizer_names:
         raise ValueError('emerging optimizer with fp16 is not supported.')
 
     if pg_collection is None:
         pg_collection = ProcessGroupCollection.use_mpu_process_groups()
 
-    log_single_rank(logger, logging.INFO, f'Setting up emerging optimizer with config {config}')
+    log_single_rank(logger, logging.INFO, f'Setting up mixed optimizer with config {config}')
 
     # Tag parameters with optimizer-specific attributes (expert_tp, is_qkv).
     for model_chunk in model_chunks:
@@ -797,25 +1104,53 @@ def _get_megatron_emerging_optimizer(
                         f"shape={tuple(param.shape)}, split_shapes={qkv_split_shapes}",
                     )
 
-    # Apply optimizer-specific default param overrides (e.g. muon: non-linear -> adam).
-    # For Muon-family optimizers, the scalar optimizer that handles non-linear/embedding
-    # params is configurable via ``config.muon_scalar_optimizer`` (e.g., 'adam' or 'lion');
-    # deep-copy the registry defaults before rewriting so we never mutate shared state.
-    default_param_overrides = copy.deepcopy(_EMERGING_OPTIMIZERS[eopt_name].default_param_overrides)
-    if eopt_name in ('muon', 'adaptive_muon'):
-        for override in default_param_overrides.values():
-            if override.get('optimizer') in ('adam', 'lion'):
-                override['optimizer'] = config.muon_scalar_optimizer
-    config_overrides.update(default_param_overrides)
+    # Apply optimizer-specific routing defaults only when the caller has not supplied routing.
+    # Once any group selects an optimizer, the configured routing is authoritative and unmatched
+    # parameters use its explicit default. Copy registry defaults before rewriting the Muon scalar
+    # optimizer so shared registry state remains unchanged.
+    if (
+        not isinstance(config_overrides, OptimizerOverrideRecipe)
+        and not configured_optimizer_names
+        and eopt_name in _EMERGING_OPTIMIZERS
+    ):
+        default_param_overrides = copy.deepcopy(
+            _EMERGING_OPTIMIZERS[eopt_name].default_param_overrides
+        )
+        if eopt_name in ('muon', 'adaptive_muon'):
+            for override in default_param_overrides.values():
+                if override.get('optimizer') in ('adam', 'lion'):
+                    override['optimizer'] = config.muon_scalar_optimizer
+        config_overrides.update(default_param_overrides)
 
-    # Build param groups and bucket by (optimizer_name, is_expert_parallel).
-    # Layer-wise distributed optimizer handles expert params internally so we skip that split.
+    # Build param groups and bucket by configured optimizer instance and expert status. A recipe
+    # creates one runtime optimizer per alias; legacy programmatic overrides continue to distinguish
+    # constructor-kwargs buckets implicitly.
     all_param_groups = _get_param_groups(model_chunks, config, config_overrides)
     grouped_param_groups = defaultdict(list)
+    configured_instance_kwargs = {}
     for group in all_param_groups:
         opt_name = group.get('optimizer', eopt_name)
+        optimizer_kwargs = group.get("optimizer_kwargs", {})
+        if optimizer_kwargs and opt_name not in _EMERGING_OPTIMIZERS:
+            raise ValueError(
+                f"optimizer_kwargs is only supported for emerging optimizers, got {opt_name!r}"
+            )
+        optimizer_instance = group.get("optimizer_instance")
+        optimizer_kwargs_key = canonicalize_optimizer_config_value(optimizer_kwargs)
+        if optimizer_instance is not None:
+            instance_key = ("configured", optimizer_instance)
+            previous_descriptor = configured_instance_kwargs.setdefault(
+                instance_key, (opt_name, optimizer_kwargs_key)
+            )
+            if previous_descriptor != (opt_name, optimizer_kwargs_key):
+                raise ValueError(
+                    f"Optimizer instance {optimizer_instance!r} resolves to inconsistent "
+                    "optimizer types or constructor kwargs"
+                )
+        else:
+            instance_key = ("legacy", opt_name, optimizer_kwargs_key)
         is_expert = group['is_expert_parallel'] and not use_layer_wise
-        grouped_param_groups[(opt_name, is_expert)].append(group)
+        grouped_param_groups[(instance_key, opt_name, is_expert)].append(group)
 
     # Set up DistOpt process groups + filtered buffers once, only if we'll
     # construct a DistributedOptimizer for non-Muon groups in layer-wise mode.
@@ -843,7 +1178,7 @@ def _get_megatron_emerging_optimizer(
         # whose optimizer is not the primary emerging optimizer (stored in ``eopt_name``,
         # e.g., Muon). This includes scalar optimizers like Adam or Lion.
         not (opt_name == eopt_name and opt_name in _EMERGING_OPTIMIZERS)
-        for (opt_name, _), groups in grouped_param_groups.items()
+        for (_, opt_name, _), groups in grouped_param_groups.items()
         if groups
     ):
         # ``setup_process_groups_for_optimizer`` rejects Gloo groups whenever
@@ -868,25 +1203,33 @@ def _get_megatron_emerging_optimizer(
             if non_layer_wise_buffers:
                 distopt_per_model_buffers[model_chunk_idx] = non_layer_wise_buffers
 
-    # Build an optimizer for each (optimizer_name, is_expert) bucket and combine.
+    # Build an optimizer for each (optimizer_instance, is_expert) bucket and combine.
     # In layer-wise mode, emerging-optimizer (Muon) groups feed into LayerWise,
     # while non-emerging (Adam) groups are managed by a separate DistributedOptimizer
     # — that is, the LayerWise optimizer only owns Muon-managed matrix parameters,
     # and the rest go through DistOpt's standard byte-level shard machinery.
     results = []
     layer_wise_base_results = []  # (raw_optimizer, init_state_fn) feeding LayerWise.
-    for (opt_name, is_expert), groups in grouped_param_groups.items():
+    for (_, opt_name, is_expert), groups in grouped_param_groups.items():
         if not groups:
             continue
 
         model_parallel_group = pg_collection.tp_ep_pp if is_expert else pg_collection.mp
 
-        # Only the primary emerging optimizer (stored in ``eopt_name``, e.g., Muon) is
-        # constructed via ``_create_emerging_optimizer``. Scalar optimizers that also appear
-        # in ``_EMERGING_OPTIMIZERS`` (e.g., Lion) fall through to the standard fallback path.
-        if opt_name == eopt_name and opt_name in _EMERGING_OPTIMIZERS:
+        # Non-layer-wise recipes may construct any registered emerging optimizer. Layer-wise
+        # mode retains the existing primary-optimizer split: scalar optimizers such as Lion use
+        # the DistributedOptimizer fallback instead of joining the Muon layer-wise optimizer.
+        use_emerging_factory = opt_name in _EMERGING_OPTIMIZERS and (
+            not use_layer_wise or opt_name == eopt_name
+        )
+        if use_emerging_factory:
             optimizer, init_state_fn = _create_emerging_optimizer(
-                config, groups, eopt_name, model_chunks, pg_collection
+                config,
+                groups,
+                opt_name,
+                model_chunks,
+                pg_collection,
+                optimizer_kwargs=groups[0].get("optimizer_kwargs"),
             )
             if use_layer_wise:
                 layer_wise_base_results.append((optimizer, init_state_fn))
@@ -1027,16 +1370,23 @@ def get_megatron_optimizer(
         ), "MimoModel does not support virtual pipeline parallelism (multiple model chunks)"
         return get_mimo_optimizer(model_chunks[0], config)
 
-    # None → apply standard defaults. To extend defaults with custom overrides,
-    # start from get_standard_config_overrides(config) and merge yours in.
-    if config_overrides is None:
-        config_overrides = get_standard_config_overrides(config)
+    config_overrides = get_optimizer_overrides_from_config(
+        config, legacy_config_overrides=config_overrides
+    )
 
     check_config_overrides_consistency(config, config_overrides)
 
     # TODO: the standard and emerging optimizer paths handle pg_collection differently;
     # unify them so both use a single pg_collection-based flow.
-    if config.optimizer not in ('adam', 'sgd'):
+    has_mixed_optimizer_routing = any(
+        override.get('optimizer', config.optimizer) != config.optimizer
+        for override in config_overrides.values()
+    )
+    if (
+        isinstance(config_overrides, OptimizerOverrideRecipe)
+        or config.optimizer not in ('adam', 'sgd')
+        or has_mixed_optimizer_routing
+    ):
         return _get_megatron_emerging_optimizer(
             config=config,
             model_chunks=model_chunks,

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -54,6 +54,7 @@ from ..distributed.param_and_grad_buffer import (
 )
 from ..fp4_utils import is_nvfp4tensor, quantize_nvfp4_param_shard
 from ..fp8_utils import dequantize_fp8_tensor, is_float8tensor, quantize_param_shard
+from ..optimizer_param_scheduler import canonicalize_optimizer_config_value
 from ..transformer.fsdp_dtensor_checkpoint import handle_experts_in_state_dict
 from ..transformer.module import MegatronModule
 from .grad_scaler import MegatronGradScaler
@@ -927,7 +928,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                 else:
                     # Treat missing and explicit None identifier values as equivalent.
                     value = None
-                needed_groups.append(value)
+                needed_groups.append(canonicalize_optimizer_config_value(value))
             return tuple(needed_groups)
 
         # Duplicate identifiers here silently clobber: two saved groups with the same tuple

--- a/megatron/core/optimizer/emerging_optimizers.py
+++ b/megatron/core/optimizer/emerging_optimizers.py
@@ -97,6 +97,8 @@ class EmergingOptimizerEntry:
         config_to_kwargs: ``(config, model_chunks, pg_collection) -> dict`` of constructor kwargs.
         default_param_overrides: Per-parameter config overrides applied automatically
             (e.g. route non-linear params to Adam).
+        constructor_only_kwargs: Arguments that configure optimizer-instance behavior and must
+            not be supplied by an individual parameter group.
     """
 
     optimizer_cls: type
@@ -105,9 +107,17 @@ class EmergingOptimizerEntry:
     default_param_overrides: Dict[ParamKey, Dict[str, Any]] = field(
         default_factory=_default_param_overrides_factory
     )
+    constructor_only_kwargs: frozenset[str] = field(default_factory=frozenset)
 
 
-def _create_emerging_optimizer(config, param_groups, eopt_name, model_chunks, pg_collection):
+def _create_emerging_optimizer(
+    config,
+    param_groups,
+    eopt_name,
+    model_chunks,
+    pg_collection,
+    optimizer_kwargs: Dict[str, Any] | None = None,
+):
     """Instantiate an emerging optimizer and return it with its init_state_fn."""
     entry = _EMERGING_OPTIMIZERS[eopt_name]
     if entry.config_to_kwargs is not None:
@@ -116,6 +126,28 @@ def _create_emerging_optimizer(config, param_groups, eopt_name, model_chunks, pg
         eopt_kwargs = _default_adam_based_eopt_config_to_kwargs(
             eopt_name, config, model_chunks, pg_collection
         )
+    configured_kwargs = dict(optimizer_kwargs or {})
+    if "params" in configured_kwargs:
+        raise ValueError("optimizer_kwargs cannot override the protected 'params' argument")
+
+    signature = inspect.signature(entry.optimizer_cls.__init__)
+    accepts_arbitrary_kwargs = any(
+        parameter.kind == inspect.Parameter.VAR_KEYWORD
+        for parameter in signature.parameters.values()
+    )
+    invalid_kwargs = {
+        name
+        for name in configured_kwargs
+        if name not in signature.parameters
+        or signature.parameters[name].kind
+        in {inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.VAR_POSITIONAL}
+    }
+    if invalid_kwargs and not accepts_arbitrary_kwargs:
+        raise ValueError(
+            f"Unsupported optimizer_kwargs for {eopt_name}: {sorted(invalid_kwargs)}. "
+            f"Constructor: {signature}"
+        )
+    eopt_kwargs.update(configured_kwargs)
     optimizer = entry.optimizer_cls(param_groups, **eopt_kwargs)
     return optimizer, entry.init_state_fn
 
@@ -417,7 +449,9 @@ def _default_adam_based_eopt_config_to_kwargs(
 ) -> Dict[str, Any]:
     """Convert OptimizerConfig to default emerging optimizer constructor kwargs."""
     kwargs = _kwargs_from_config(registry.get_optimizer_cls(eopt_name), eopt_name, config)
-    kwargs["betas"] = (config.adam_beta1, config.adam_beta2)
+    beta1 = getattr(config, f"{eopt_name}_beta1", config.adam_beta1)
+    beta2 = getattr(config, f"{eopt_name}_beta2", config.adam_beta2)
+    kwargs["betas"] = (beta1, beta2)
     return kwargs
 
 
@@ -437,6 +471,21 @@ _EMERGING_OPTIMIZERS.update(
                     )
                 ): {'optimizer': 'adam'}
             },
+            constructor_only_kwargs=frozenset(
+                {
+                    "split_qkv",
+                    "is_qkv_fn",
+                    "qkv_split_shapes",
+                    "fp32_matmul_prec",
+                    "coefficient_type",
+                    "num_ns_steps",
+                    "scale_mode",
+                    "extra_scale_factor",
+                    "use_decoupled_weight_decay",
+                    "pg_collection",
+                    "tp_mode",
+                }
+            ),
         ),
         "adaptive_muon": EmergingOptimizerEntry(
             optimizer_cls=TensorParallelAdaptiveMuon,
@@ -449,6 +498,22 @@ _EMERGING_OPTIMIZERS.update(
                     )
                 ): {'optimizer': 'adam'}
             },
+            constructor_only_kwargs=frozenset(
+                {
+                    "split_qkv",
+                    "is_qkv_fn",
+                    "qkv_split_shapes",
+                    "fp32_matmul_prec",
+                    "coefficient_type",
+                    "num_ns_steps",
+                    "scale_mode",
+                    "extra_scale_factor",
+                    "use_decoupled_weight_decay",
+                    "pg_collection",
+                    "tp_mode",
+                    "moment2_method",
+                }
+            ),
         ),
     }
 )

--- a/megatron/core/optimizer/optimizer.py
+++ b/megatron/core/optimizer/optimizer.py
@@ -47,6 +47,7 @@ from ..dist_checkpointing.optimizer import (
 )
 from ..dist_checkpointing.utils import add_prefix_for_sharding
 from ..optimizer_param_scheduler import ParamGroupOverride as _ParamGroupOverride
+from ..optimizer_param_scheduler import canonicalize_optimizer_config_value
 from ..transformer.module import param_is_not_shared
 from ..utils import log_single_rank
 from .clip_grads import clip_grad_by_total_norm_fp32, count_zeros_fp32, get_grad_norm_fp32
@@ -95,29 +96,9 @@ def _multi_tensor_copy_this_to_that(
             that_.copy_(this_)
 
 
-# Per-group keys used to uniquely identify a param_group during save/load matching.
-# Used by ``DistributedOptimizer.load_state_dict`` and
-# ``MegatronOptimizer._filter_and_reorder_param_groups`` to map saved param_groups
-# onto current param_groups by behavioral equivalence.
-#
-# This MUST cover every per-group field that influences scheduler or optimizer behavior;
-# otherwise two groups that differ only in a missing key (e.g. ``max_lr``) will collide
-# in the matching dict and one will silently overwrite the other on load. That's a
-# correctness bug: the load returns silently but the LR/WD applied at the next
-# optimizer step is wrong, leading to loss explosion on a converged-enough model.
-#
-# Source of truth for the user-overridable fields is
-# :class:`megatron.core.optimizer_param_scheduler.ParamGroupOverride` (the keys the
-# scheduler reads from each param_group via ``param_group.get(...)``):
-# ``max_lr``, ``min_lr``, ``start_wd``, ``end_wd``, ``wd_mult``, ``optimizer``.
-# We pull those keys directly from that TypedDict's annotations so future
-# additions to ``ParamGroupOverride`` automatically extend the identifier.
-#
-# The remaining keys (``lr_mult``, ``is_expert_parallel``, ``is_decoupled_lr``) are
-# structural flags set by ``_get_param_groups`` (in this module's ``__init__.py``)
-# on every param_group at construction time. They aren't part of ``ParamGroupOverride``
-# (users don't override them directly; they're implied by ``decoupled_lr`` config and
-# expert-parallel sharding), so we list them explicitly.
+# Save/load identity must cover every behavior-affecting per-group field to prevent
+# distinct groups from colliding during checkpoint restore. ``ParamGroupOverride`` is
+# the source of truth for user overrides; structural keys are listed explicitly below.
 def _param_group_override_keys() -> tuple[str, ...]:
     """Return every field declared on ``ParamGroupOverride``.
 
@@ -608,12 +589,13 @@ class MegatronOptimizer(ABC):
             for key in param_group_identifier_keys:
                 # NeMo aliases ``wd_mult``/``lr_mult`` as ``pre_wd_mult``/``pre_lr_mult``.
                 if key in group:
-                    out.append(group[key])
+                    value = group[key]
                 elif f"pre_{key}" in group:
-                    out.append(group[f"pre_{key}"])
+                    value = group[f"pre_{key}"]
                 else:
                     # Treat missing and explicit None identifier values as equivalent.
-                    out.append(None)
+                    value = None
+                out.append(canonicalize_optimizer_config_value(value))
             return tuple(out)
 
         needed_groups = [_identifier_for(g) for g in current_groups]

--- a/megatron/core/optimizer/optimizer_config.py
+++ b/megatron/core/optimizer/optimizer_config.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
+import copy
 import fnmatch
 from dataclasses import dataclass, field
-from typing import Callable, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterator, Optional, Tuple, Union
 
 import torch
 
@@ -135,6 +136,78 @@ class ParamKey:
         return False
 
 
+@dataclass(frozen=True)
+class OptimizerParamGroupTarget:
+    """Reference to a parameter group owned by a configured optimizer instance."""
+
+    optimizer: str
+    param_group: str
+
+
+@dataclass
+class OptimizerInstanceConfig:
+    """Configuration for one named optimizer instance and its parameter groups."""
+
+    optimizer_type: str
+    kwargs: Dict[str, Any]
+    param_groups: Dict[str, Dict[str, Any]]
+
+
+@dataclass
+class OptimizerOverrideRecipe:
+    """Resolved optimizer instances, parameter groups, defaults, and matchers."""
+
+    optimizers: Dict[str, OptimizerInstanceConfig]
+    matchers: Dict[ParamKey, OptimizerParamGroupTarget]
+    default: OptimizerParamGroupTarget
+
+    def resolve(self, target: OptimizerParamGroupTarget) -> Dict[str, Any]:
+        """Return checkpoint-stable metadata for a configured parameter group."""
+        optimizer = self.optimizers[target.optimizer]
+        raw_group = optimizer.param_groups[target.param_group]
+        named_override_fields = {
+            'max_lr',
+            'min_lr',
+            'start_wd',
+            'end_wd',
+            'wd_mult',
+            'eps',
+            'lr_mult',
+            'is_decoupled_lr',
+        }
+        resolved = {
+            key: copy.deepcopy(value)
+            for key, value in raw_group.items()
+            if key in named_override_fields
+        }
+        arbitrary_group_kwargs = {
+            key: copy.deepcopy(value)
+            for key, value in raw_group.items()
+            if key not in named_override_fields
+        }
+        resolved.update(
+            {
+                'optimizer': optimizer.optimizer_type,
+                'optimizer_instance': target.optimizer,
+                'optimizer_kwargs': copy.deepcopy(optimizer.kwargs),
+                'param_group': target.param_group,
+            }
+        )
+        if arbitrary_group_kwargs:
+            resolved['param_group_kwargs'] = arbitrary_group_kwargs
+        return resolved
+
+    def values(self) -> Iterator[Dict[str, Any]]:
+        """Iterate over every resolved parameter-group configuration."""
+        for optimizer_name, optimizer in self.optimizers.items():
+            for param_group_name in optimizer.param_groups:
+                yield self.resolve(
+                    OptimizerParamGroupTarget(
+                        optimizer=optimizer_name, param_group=param_group_name
+                    )
+                )
+
+
 @dataclass
 class OptimizerConfig:
     """Configuration object for Megatron optimizers."""
@@ -164,6 +237,17 @@ class OptimizerConfig:
 
     apply_wd_to_qk_layernorm: bool = False
     """If true, apply weight decay to qk layernorm as a special case."""
+
+    overrides_config: Optional[Union[str, Dict[str, Any]]] = None
+    """Serialized per-parameter optimizer overrides.
+
+    Accepts either a YAML file path or a mapping following the quantization recipe shape.
+    ``optimizers`` defines named optimizer instances, their constructor-only ``kwargs``, and named
+    ``param_groups`` containing arbitrary parameter-group fields. ``default`` selects the target for
+    unmatched parameters, while enabled glob ``matchers`` select another optimizer and parameter
+    group directly. Numeric values are expected to be resolved by the caller before constructing
+    this config. When provided, this mapping replaces the deprecated standard and MuP overrides.
+    """
 
     ##############
     # Precision

--- a/megatron/core/optimizer_param_scheduler.py
+++ b/megatron/core/optimizer_param_scheduler.py
@@ -3,6 +3,7 @@
 """Learning rate decay and weight decay incr functions."""
 import logging
 import math
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Optional, TypedDict
 
 import torch
@@ -34,7 +35,56 @@ class ParamGroupOverride(TypedDict, total=False):
     start_wd: float
     end_wd: float
     wd_mult: float
+    eps: float
     optimizer: str
+    optimizer_instance: str
+    optimizer_kwargs: dict[str, Any]
+    param_group: str
+    param_group_kwargs: dict[str, Any]
+
+
+def canonicalize_optimizer_config_value(value: Any) -> Any:
+    """Convert nested optimizer config values to a stable, hashable representation.
+
+    Args:
+        value (Any): A scalar or nested mapping, sequence, or set from optimizer config.
+
+    Returns:
+        Any: A recursively tagged tuple representation suitable for grouping and checkpoint keys.
+
+    Raises:
+        TypeError: If a value is neither hashable nor a supported container.
+    """
+    if isinstance(value, Mapping):
+        return (
+            "mapping",
+            tuple(
+                sorted(
+                    (
+                        (
+                            canonicalize_optimizer_config_value(key),
+                            canonicalize_optimizer_config_value(item),
+                        )
+                        for key, item in value.items()
+                    )
+                )
+            ),
+        )
+    if isinstance(value, (list, tuple)):
+        return ("sequence", tuple(canonicalize_optimizer_config_value(item) for item in value))
+    if isinstance(value, (set, frozenset)):
+        return ("set", tuple(sorted(canonicalize_optimizer_config_value(item) for item in value)))
+    try:
+        hash(value)
+    except TypeError as exc:
+        raise TypeError(
+            f"Optimizer config value of type {type(value).__name__} is not hashable or a "
+            "supported container"
+        ) from exc
+    value_type = f"{type(value).__module__}.{type(value).__qualname__}"
+    if isinstance(value, (str, int, float, bool, bytes, type(None))):
+        return ("scalar", value_type, value)
+    return ("scalar", value_type, repr(value))
 
 
 def get_canonical_lr_for_logging(param_groups: list[dict]) -> float | None:
@@ -67,7 +117,12 @@ def param_group_override_to_tuple(
     """
     if param_group_override is None:
         return None
-    return tuple(sorted(param_group_override.items()))
+    return tuple(
+        sorted(
+            (key, canonicalize_optimizer_config_value(value))
+            for key, value in param_group_override.items()
+        )
+    )
 
 
 def combine_param_group_overrides(
@@ -88,6 +143,19 @@ def combine_param_group_overrides(
         if override is None:
             continue
         for key, value in override.items():
+            if key in {"optimizer_kwargs", "param_group_kwargs"}:
+                combined_values = combined_override.setdefault(key, {})
+                for nested_key, nested_value in value.items():
+                    if (
+                        nested_key in combined_values
+                        and combined_values[nested_key] != nested_value
+                    ):
+                        raise ValueError(
+                            f"Conflicting overrides for {key}.{nested_key}: "
+                            f"{combined_values[nested_key]} and {nested_value}"
+                        )
+                    combined_values[nested_key] = nested_value
+                continue
             if key in combined_override:
                 if combined_override[key] != value:
                     raise ValueError(

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -289,7 +289,7 @@ def destroy_global_state():
 
 def print_datetime(string, override_timestamp=None):
     """Note that this call will sync across all ranks. Use override_timestamp if provided;
-       otherwise use current timestamp."""
+    otherwise use current timestamp."""
     torch.distributed.barrier()
     if override_timestamp is None:
         time_str = datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')
@@ -387,10 +387,7 @@ def consume_seqlen_stats_in_iteration() -> Tuple[Optional[float], Optional[float
 
 
 def num_floating_point_operations(
-    args,
-    batch_size,
-    seqlen_squared_sum_in_batch=None,
-    total_real_tokens_in_batch=None,
+    args, batch_size, seqlen_squared_sum_in_batch=None, total_real_tokens_in_batch=None
 ):
     """Compute the number of floating-point operations for one global batch.
 
@@ -429,26 +426,49 @@ def num_floating_point_operations(
         scale_factor = 3.0 / 2.0 if swiglu else 1.0
         return 4 * expansion * scale_factor * total_tokens * hidden_size**2
 
-    def moe_layer_flops(total_tokens, hidden_size, moe_ffn_hidden_size,
-                        shared_expert_ffn_hidden_size, num_experts_routed_to,
-                        moe_latent_size=None, swiglu=False):
+    def moe_layer_flops(
+        total_tokens,
+        hidden_size,
+        moe_ffn_hidden_size,
+        shared_expert_ffn_hidden_size,
+        num_experts_routed_to,
+        moe_latent_size=None,
+        swiglu=False,
+    ):
         """Calculate FLOPs for an MoE layer."""
         scale_factor = 3.0 / 2.0 if swiglu else 1.0
         if moe_latent_size is None:
-            routed_flops = (4 * total_tokens * hidden_size *
-                            moe_ffn_hidden_size * num_experts_routed_to * scale_factor)
+            routed_flops = (
+                4
+                * total_tokens
+                * hidden_size
+                * moe_ffn_hidden_size
+                * num_experts_routed_to
+                * scale_factor
+            )
         else:
             # Routed experts run on moe_latent_size.
-            routed_flops = (4 * total_tokens * moe_latent_size *
-                            moe_ffn_hidden_size * num_experts_routed_to * scale_factor)
+            routed_flops = (
+                4
+                * total_tokens
+                * moe_latent_size
+                * moe_ffn_hidden_size
+                * num_experts_routed_to
+                * scale_factor
+            )
             # Up proj and down proj.
-            routed_flops += (4 * total_tokens * hidden_size * moe_latent_size)
+            routed_flops += 4 * total_tokens * hidden_size * moe_latent_size
         shared_flops = 4 * total_tokens * hidden_size * shared_expert_ffn_hidden_size * scale_factor
         return routed_flops + shared_flops
 
     def attn_layer_flops(
-        total_tokens, seqlen_squared_sum, hidden_size, num_heads, gqa=True,
-        gqa_groups=8, kv_channels=None,
+        total_tokens,
+        seqlen_squared_sum,
+        hidden_size,
+        num_heads,
+        gqa=True,
+        gqa_groups=8,
+        kv_channels=None,
     ):
         """Calculate FLOPs for an attention layer.
 
@@ -464,13 +484,13 @@ def num_floating_point_operations(
         # 4 * total_tokens * h * p * (h + h*(g/n)): QKV + output projections (fwd*3, with FMA*2).
         # 2 * sum(L^2) * h * p: core attention (causal mask -> /2 cancels with FMA *2).
         return (
-            4 * total_tokens * hidden_size * p
-            * (hidden_size + hidden_size * (g / num_heads))
+            4 * total_tokens * hidden_size * p * (hidden_size + hidden_size * (g / num_heads))
             + 2 * seqlen_squared_sum * hidden_size * p
         )
 
-    def mamba_layer_flops(total_tokens, hidden_size, state_dim=16,
-                          head_dim=64, num_groups=1, num_heads=128):
+    def mamba_layer_flops(
+        total_tokens, hidden_size, state_dim=16, head_dim=64, num_groups=1, num_heads=128
+    ):
         """Calculate FLOPs for a Mamba layer."""
         # Note (rwaleffe): flops estimate for scan should be updated based on new SSD kernels,
         # but small percent of overall layer flops
@@ -481,67 +501,115 @@ def num_floating_point_operations(
             nheads = d_in // head_dim
         return (
             (
-                2
-                * total_tokens
-                * hidden_size
-                * (2 * d_in + 2 * num_groups * state_dim + nheads)
+                2 * total_tokens * hidden_size * (2 * d_in + 2 * num_groups * state_dim + nheads)
             )  # in_proj
             + (7 * total_tokens * d_in * state_dim)  # scan
             + (2 * total_tokens * d_in * hidden_size)  # out_proj
         )
 
-    def gdn_layer_flops(total_tokens, hidden_size,
-                        qk_head_dim=128, v_head_dim=128,
-                        num_qk_heads=16, num_v_heads=32,
-                        conv_kernel_dim=4):
+    def gdn_layer_flops(
+        total_tokens,
+        hidden_size,
+        qk_head_dim=128,
+        v_head_dim=128,
+        num_qk_heads=16,
+        num_v_heads=32,
+        conv_kernel_dim=4,
+    ):
         """Calculate FLOPs for a Gated Delta Net (GDN) layer."""
         qk_dim = qk_head_dim * num_qk_heads
         v_dim = v_head_dim * num_v_heads
         return (
-            2 * total_tokens * (
+            2
+            * total_tokens
+            * (
                 # in_proj: hidden_size -> (2*qk_dim + 2*v_dim + 2*num_v_heads)
                 hidden_size * (2 * qk_dim + 2 * v_dim + 2 * num_v_heads)
                 # conv1d
                 + conv_kernel_dim * (2 * qk_dim + v_dim)
                 # gated delta rule: KK^T, VK^T, S(a(I-bKK^T)), and SQ
-                + num_v_heads * (v_head_dim ** 2) * 4
+                + num_v_heads * (v_head_dim**2) * 4
                 # out_proj: v_dim -> hidden_size
                 + hidden_size * v_dim
             )
         )
 
-    def hybrid_flops(total_tokens, seqlen_squared_sum, hidden_size,
-                     num_attn_layers, num_mamba_layers, num_mlp_layers, num_moe_layers,
-                     num_gdn_layers=0,
-                     mamba_state_dim=128, mamba_head_dim=64,
-                     mamba_num_groups=8, mamba_num_heads=128,
-                     num_attn_heads=32, gqa=True,
-                     gqa_groups=8, kv_channels=None,
-                     mlp_expansion=4.0, swiglu=False,
-                     moe_latent_size=None,
-                     moe_ffn_hidden_size=2048, shared_expert_ffn_hidden_size=2048, num_experts_routed_to=1,
-                     gdn_qk_head_dim=128, gdn_v_head_dim=128,
-                     gdn_num_qk_heads=16, gdn_num_v_heads=32,
-                     gdn_conv_kernel_dim=4,
-                     vocab_size=256000, mtp_num_layers=0):
+    def hybrid_flops(
+        total_tokens,
+        seqlen_squared_sum,
+        hidden_size,
+        num_attn_layers,
+        num_mamba_layers,
+        num_mlp_layers,
+        num_moe_layers,
+        num_gdn_layers=0,
+        mamba_state_dim=128,
+        mamba_head_dim=64,
+        mamba_num_groups=8,
+        mamba_num_heads=128,
+        num_attn_heads=32,
+        gqa=True,
+        gqa_groups=8,
+        kv_channels=None,
+        mlp_expansion=4.0,
+        swiglu=False,
+        moe_latent_size=None,
+        moe_ffn_hidden_size=2048,
+        shared_expert_ffn_hidden_size=2048,
+        num_experts_routed_to=1,
+        gdn_qk_head_dim=128,
+        gdn_v_head_dim=128,
+        gdn_num_qk_heads=16,
+        gdn_num_v_heads=32,
+        gdn_conv_kernel_dim=4,
+        vocab_size=256000,
+        mtp_num_layers=0,
+    ):
         """Calculate total FLOPs for the hybrid model."""
         flops_fwd = (
-                num_attn_layers * attn_layer_flops(total_tokens, seqlen_squared_sum,
-                                                   hidden_size, num_attn_heads, gqa,
-                                                   gqa_groups, kv_channels) +
-                num_mlp_layers * mlp_layer_flops(total_tokens, hidden_size,
-                                                 mlp_expansion, swiglu) +
-                num_mamba_layers * mamba_layer_flops(total_tokens, hidden_size,
-                                                     mamba_state_dim, mamba_head_dim,
-                                                     mamba_num_groups, mamba_num_heads) +
-                num_moe_layers * moe_layer_flops(total_tokens, hidden_size, moe_ffn_hidden_size,
-                                                 shared_expert_ffn_hidden_size, num_experts_routed_to,
-                                                 moe_latent_size, swiglu) +
-                num_gdn_layers * gdn_layer_flops(total_tokens, hidden_size,
-                                                  gdn_qk_head_dim, gdn_v_head_dim,
-                                                  gdn_num_qk_heads, gdn_num_v_heads,
-                                                  gdn_conv_kernel_dim) +
-                (2 * total_tokens * hidden_size * vocab_size * (1 + mtp_num_layers))  # logits computation
+            num_attn_layers
+            * attn_layer_flops(
+                total_tokens,
+                seqlen_squared_sum,
+                hidden_size,
+                num_attn_heads,
+                gqa,
+                gqa_groups,
+                kv_channels,
+            )
+            + num_mlp_layers * mlp_layer_flops(total_tokens, hidden_size, mlp_expansion, swiglu)
+            + num_mamba_layers
+            * mamba_layer_flops(
+                total_tokens,
+                hidden_size,
+                mamba_state_dim,
+                mamba_head_dim,
+                mamba_num_groups,
+                mamba_num_heads,
+            )
+            + num_moe_layers
+            * moe_layer_flops(
+                total_tokens,
+                hidden_size,
+                moe_ffn_hidden_size,
+                shared_expert_ffn_hidden_size,
+                num_experts_routed_to,
+                moe_latent_size,
+                swiglu,
+            )
+            + num_gdn_layers
+            * gdn_layer_flops(
+                total_tokens,
+                hidden_size,
+                gdn_qk_head_dim,
+                gdn_v_head_dim,
+                gdn_num_qk_heads,
+                gdn_num_v_heads,
+                gdn_conv_kernel_dim,
+            )
+            + (
+                2 * total_tokens * hidden_size * vocab_size * (1 + mtp_num_layers)
+            )  # logits computation
         )
         return flops_fwd * 3
 
@@ -668,9 +736,7 @@ def num_floating_point_operations(
                 forward_backward_expansion_factor
                 * fma_expansion_factor
                 * (
-                    args.num_attention_heads
-                    * (args.qk_head_dim + args.qk_pos_emb_head_dim)
-                    / 2
+                    args.num_attention_heads * (args.qk_head_dim + args.qk_pos_emb_head_dim) / 2
                     + args.num_attention_heads * args.v_head_dim / 2
                 )
             )
@@ -695,8 +761,7 @@ def num_floating_point_operations(
                         + gate_projection_size
                     )
                     ## out proj
-                    + query_projection_size
-                    * args.hidden_size
+                    + query_projection_size * args.hidden_size
                 )
             )
             # Core-attention (L^2) part: ``QK^T`` and ``(softmax(QK^T)) V``.
@@ -713,8 +778,8 @@ def num_floating_point_operations(
             if isinstance(args.linear_attention_freq, int):
                 linear_attention_pattern = [
                     # [1,1,...,1,0,1,1,...,1,0,...]
-                    0 if ((i + 1) % args.linear_attention_freq == 0)
-                    else 1 for i in range(num_layers)
+                    0 if ((i + 1) % args.linear_attention_freq == 0) else 1
+                    for i in range(num_layers)
                 ]
             elif isinstance(args.linear_attention_freq, list):
                 linear_attention_pattern = args.linear_attention_freq
@@ -751,18 +816,13 @@ def num_floating_point_operations(
                     * fma_expansion_factor
                     * (
                         ## in proj
-                        args.hidden_size
-                        * (2 * qk_dim + 2 * v_dim + 2 * num_v_heads)
+                        args.hidden_size * (2 * qk_dim + 2 * v_dim + 2 * num_v_heads)
                         ## conv1d
-                        + args.linear_conv_kernel_dim
-                        * (2 * qk_dim + v_dim)
+                        + args.linear_conv_kernel_dim * (2 * qk_dim + v_dim)
                         ## gated delta rule
-                        + num_v_heads
-                        * (v_head_dim ** 2)
-                        * 4  # KK^T, VK^T, S(a(I-bKK^T)), and SQ
+                        + num_v_heads * (v_head_dim**2) * 4  # KK^T, VK^T, S(a(I-bKK^T)), and SQ
                         ## out proj
-                        + args.hidden_size
-                        * v_dim
+                        + args.hidden_size * v_dim
                     )
                 )
             else:
@@ -795,8 +855,7 @@ def num_floating_point_operations(
                 * args.hidden_size
                 * (
                     # dense layer (deepseek v2, v3 style)
-                    (args.ffn_hidden_size * ffn_expansion_factor)
-                    * num_dense_layers
+                    (args.ffn_hidden_size * ffn_expansion_factor) * num_dense_layers
                     # routed experts
                     + (
                         (moe_ffn_hidden_size * num_experts_routed_to * ffn_expansion_factor)
@@ -814,8 +873,7 @@ def num_floating_point_operations(
                     )
                     * num_moe_layers
                     # Shared Experts.
-                    + (shared_expert_ffn_hidden_size * ffn_expansion_factor)
-                    * num_moe_layers
+                    + (shared_expert_ffn_hidden_size * ffn_expansion_factor) * num_moe_layers
                 )
                 # Self Attention (token-linear part).
                 + self_attn_term
@@ -853,6 +911,7 @@ def num_floating_point_operations(
             Symbols,
             get_hybrid_layer_counts,
         )
+
         num_mamba_layers, num_gdn_layers, num_attn_layers, num_mlp_layers, num_moe_layers = (
             itemgetter(Symbols.MAMBA, Symbols.GDN, Symbols.ATTENTION, Symbols.MLP, Symbols.MOE)(
                 get_hybrid_layer_counts(args.hybrid_layer_pattern)
@@ -883,10 +942,16 @@ def num_floating_point_operations(
             mlp_expansion=args.ffn_hidden_size / args.hidden_size,
             swiglu=args.swiglu,
             moe_latent_size=args.moe_latent_size,
-            moe_ffn_hidden_size=(args.moe_ffn_hidden_size if args.moe_ffn_hidden_size is not None
-                                 else args.ffn_hidden_size),
-            shared_expert_ffn_hidden_size=(0 if args.moe_shared_expert_intermediate_size is None
-                                           else args.moe_shared_expert_intermediate_size),
+            moe_ffn_hidden_size=(
+                args.moe_ffn_hidden_size
+                if args.moe_ffn_hidden_size is not None
+                else args.ffn_hidden_size
+            ),
+            shared_expert_ffn_hidden_size=(
+                0
+                if args.moe_shared_expert_intermediate_size is None
+                else args.moe_shared_expert_intermediate_size
+            ),
             num_experts_routed_to=args.moe_router_topk,
             gdn_qk_head_dim=args.linear_key_head_dim or 128,
             gdn_v_head_dim=args.linear_value_head_dim or 128,
@@ -940,7 +1005,9 @@ def get_start_time_from_progress_log():
                 # save_checkpoint was called directly (without save_checkpoint_and_time),
                 # which writes "Saved async checkpoint" but not "Saving async checkpoint".
                 if latest_num_floating_point_operations_uncommitted is not None:
-                    latest_num_floating_point_operations = latest_num_floating_point_operations_uncommitted
+                    latest_num_floating_point_operations = (
+                        latest_num_floating_point_operations_uncommitted
+                    )
                     latest_num_floating_point_operations_uncommitted = None
             if world_size_in_line != args.world_size:
                 # Re-start search if we see a different world size.
@@ -954,8 +1021,10 @@ def get_start_time_from_progress_log():
     assert (
         start_time is not None and start_num_floating_point_operations is not None
     ), "Should have seen at least one 'Starting job' entry with same world_size"
-    print_rank_0(f"megatron.training.get_start_time_from_progress_log: "
-                 f"{start_time=}, {start_num_floating_point_operations=}")
+    print_rank_0(
+        f"megatron.training.get_start_time_from_progress_log: "
+        f"{start_time=}, {start_num_floating_point_operations=}"
+    )
     return datetime.strptime(start_time, '%Y-%m-%d %H:%M:%S'), start_num_floating_point_operations
 
 
@@ -972,6 +1041,7 @@ def preprocess_common_state_dict(common_state_dict):
         preprocessed_common_state_dict['args']['use_distributed_optimizer']
         and "optimizer" in preprocessed_common_state_dict
     ):
+
         def reorder_inner_param_groups(optimizer_state_dict):
             # When distributed optimizer loading, source param groups will be reordered,
             # so we reorder the param groups here to prevent warning.
@@ -987,6 +1057,7 @@ def preprocess_common_state_dict(common_state_dict):
             if "param_groups" not in inner_optimizer:
                 return
             param_groups = inner_optimizer["param_groups"]
+
             # Treat missing and explicit None identifier values as equivalent.
             # Wrap each component so None never compares directly with floats or strings.
             def key_fn(pg):
@@ -994,6 +1065,7 @@ def preprocess_common_state_dict(common_state_dict):
                     (value is not None, value)
                     for value in (pg.get(key) for key in param_group_identifier_keys)
                 ]
+
             param_groups.sort(key=key_fn)
             inner_optimizer["param_groups"] = param_groups
 
@@ -1107,8 +1179,8 @@ def pretrain(
 
     if args.fine_grained_activation_offloading:
         from megatron.core.pipeline_parallel.utils import set_ideal_affinity_for_current_gpu
-        set_ideal_affinity_for_current_gpu()
 
+        set_ideal_affinity_for_current_gpu()
 
     if cfg_container.logger.log_progress:
         append_to_progress_log(args.save, "Starting job")
@@ -1127,7 +1199,9 @@ def pretrain(
     # Initialize program_start_global with a fallback value in case set_startup_timestamps() wasn't called
     program_start_global = _TRAIN_START_TIME
     if _STARTUP_TIMESTAMPS['program_start'] is not None:
-        program_start_global = torch.tensor([_STARTUP_TIMESTAMPS['program_start']], dtype=torch.double, device='cuda')
+        program_start_global = torch.tensor(
+            [_STARTUP_TIMESTAMPS['program_start']], dtype=torch.double, device='cuda'
+        )
         torch.distributed.all_reduce(program_start_global, op=torch.distributed.ReduceOp.MIN)
         program_start_global = program_start_global.item()
     set_startup_timestamps(program_start=program_start_global)
@@ -1147,26 +1221,41 @@ def pretrain(
     # Print basic megatron init time (using global min start)
     # NOTE(asolergi-nv): This is not entirely accurate, but we keep it for backwards compatibility.
     print_rank_0(
-        'time to initialize megatron (seconds): {:.3f}'.format(megatron_init_end - _LEGACY_TRAIN_START_TIME)
+        'time to initialize megatron (seconds): {:.3f}'.format(
+            megatron_init_end - _LEGACY_TRAIN_START_TIME
+        )
     )
 
     # Note, not entirely accurate as rank 0 might not be the first or last to hit these timestamps
-    print_datetime('after in-process setup and before initialize_megatron', timestamp_after_inprocess_setup)
-    print_datetime('after in-job setup and before initialize_megatron', timestamp_after_in_job_setup)
+    print_datetime(
+        'after in-process setup and before initialize_megatron', timestamp_after_inprocess_setup
+    )
+    print_datetime(
+        'after in-job setup and before initialize_megatron', timestamp_after_in_job_setup
+    )
 
     if program_start is not None and main_entry is not None and pretrain_entry is not None:
         # Inject startup deltas into timers
         startup_timers = {
-            'startup-program-entry-spread': program_start - program_start_global, # Local program start timestamp vs the global earliest program start timestamp
-            'startup-library-setup': main_entry - program_start, # Local library imports
-            'startup-program-setup': pretrain_entry - main_entry, # Local __main__ entry to pretrain entry
-            'startup-in-process-setup': timestamp_after_inprocess_setup - pretrain_entry, # Local in-process setup
-            'startup-in-job-setup': timestamp_after_in_job_setup - timestamp_after_inprocess_setup, # Local in-job setup
-            'startup-initialize-megatron': timestamp_after_initialize_megatron - timestamp_after_in_job_setup, # Local initialize megatron
-            'startup-set-jit-fusion-options': timestamp_after_set_jit_fusion_options - timestamp_after_initialize_megatron, # Local set JIT fusion options
-            'all-reduce-start-timestamps-tensor': megatron_init_end - timestamp_after_set_jit_fusion_options, # 2x All-reduce, first collective call
-            'startup-megatron-init-local': megatron_init_end - pretrain_entry, # Local megatron init
-            'startup-megatron-init-global': megatron_init_end - program_start_global, # Local megatron init vs the global earliest program start timestamp
+            'startup-program-entry-spread': program_start
+            - program_start_global,  # Local program start timestamp vs the global earliest program start timestamp
+            'startup-library-setup': main_entry - program_start,  # Local library imports
+            'startup-program-setup': pretrain_entry
+            - main_entry,  # Local __main__ entry to pretrain entry
+            'startup-in-process-setup': timestamp_after_inprocess_setup
+            - pretrain_entry,  # Local in-process setup
+            'startup-in-job-setup': timestamp_after_in_job_setup
+            - timestamp_after_inprocess_setup,  # Local in-job setup
+            'startup-initialize-megatron': timestamp_after_initialize_megatron
+            - timestamp_after_in_job_setup,  # Local initialize megatron
+            'startup-set-jit-fusion-options': timestamp_after_set_jit_fusion_options
+            - timestamp_after_initialize_megatron,  # Local set JIT fusion options
+            'all-reduce-start-timestamps-tensor': megatron_init_end
+            - timestamp_after_set_jit_fusion_options,  # 2x All-reduce, first collective call
+            'startup-megatron-init-local': megatron_init_end
+            - pretrain_entry,  # Local megatron init
+            'startup-megatron-init-global': megatron_init_end
+            - program_start_global,  # Local megatron init vs the global earliest program start timestamp
         }
         for name, delta in startup_timers.items():
             timers(name, log_level=0).set_elapsed(delta)
@@ -1209,7 +1298,8 @@ def pretrain(
 
         if cfg_container.checkpoint.replication:
             repl_strategy = CliqueReplicationStrategy.from_replication_params(
-                cfg_container.checkpoint.replication_jump, cfg_container.checkpoint.replication_factor
+                cfg_container.checkpoint.replication_jump,
+                cfg_container.checkpoint.replication_factor,
             )
         else:
             repl_strategy = None
@@ -1277,7 +1367,9 @@ def pretrain(
             # Build an isolated inference config so training config remains unchanged
             inference_config = copy.deepcopy(model_cfg)
             if args.rl_inference_tensor_model_parallel_size is not None:
-                inference_config.tensor_model_parallel_size = args.rl_inference_tensor_model_parallel_size
+                inference_config.tensor_model_parallel_size = (
+                    args.rl_inference_tensor_model_parallel_size
+                )
             if args.rl_inference_pipeline_model_parallel_size is not None:
                 inference_config.pipeline_model_parallel_size = (
                     args.rl_inference_pipeline_model_parallel_size
@@ -1343,11 +1435,15 @@ def pretrain(
         valid_data_iterator = []
         test_data_iterator = []
         for vp_stage in range(len(model)):
-            dataset_provider_parameters = inspect.signature(train_valid_test_dataset_provider).parameters
-            assert "vp_stage" in dataset_provider_parameters, \
-                "vp_stage must be a kwarg in train_valid_test_dataset_provider when using virtual pipeline parallelism"
-            vp_stage_train_valid_test_dataset_provider = \
-                functools.partial(train_valid_test_dataset_provider, vp_stage=vp_stage)
+            dataset_provider_parameters = inspect.signature(
+                train_valid_test_dataset_provider
+            ).parameters
+            assert (
+                "vp_stage" in dataset_provider_parameters
+            ), "vp_stage must be a kwarg in train_valid_test_dataset_provider when using virtual pipeline parallelism"
+            vp_stage_train_valid_test_dataset_provider = functools.partial(
+                train_valid_test_dataset_provider, vp_stage=vp_stage
+            )
             if getattr(train_valid_test_dataset_provider, 'is_distributed', False):
                 vp_stage_train_valid_test_dataset_provider.is_distributed = True
             iterators = build_train_valid_test_data_iterators(
@@ -1437,7 +1533,12 @@ def pretrain(
 
         print_datetime('after training is done')
 
-        if not cfg_container.validation.skip_train and cfg_container.checkpoint.save and iteration != 0 and iteration % cfg_container.checkpoint.save_interval != 0:
+        if (
+            not cfg_container.validation.skip_train
+            and cfg_container.checkpoint.save
+            and iteration != 0
+            and iteration % cfg_container.checkpoint.save_interval != 0
+        ):
             save_checkpoint_and_time(
                 iteration,
                 model,
@@ -1445,7 +1546,7 @@ def pretrain(
                 opt_param_scheduler,
                 num_floating_point_operations_so_far,
                 checkpointing_context,
-                train_data_iterator=train_data_iterator
+                train_data_iterator=train_data_iterator,
             )
 
         one_logger and one_logger.log_metrics(
@@ -1480,12 +1581,18 @@ def pretrain(
             )
         else:
             evaluate_and_print_results(
-                prefix, forward_step_func,
-                valid_data_iterator, model,
-                iteration, process_non_loss_data_func, model_cfg,
-                verbose=True, write_to_tensorboard=not cfg_container.validation.skip_train,
+                prefix,
+                forward_step_func,
+                valid_data_iterator,
+                model,
+                iteration,
+                process_non_loss_data_func,
+                model_cfg,
+                verbose=True,
+                write_to_tensorboard=not cfg_container.validation.skip_train,
                 non_loss_data_func=non_loss_data_func,
-                pg_collection=pg_collection, p2p_communicator=p2p_communicator
+                pg_collection=pg_collection,
+                p2p_communicator=p2p_communicator,
             )
 
     if args.do_test:
@@ -1688,7 +1795,13 @@ def wrap_model_chunks_with_ddp(
     return wrapped
 
 
-def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap_with_ddp=True, config=None, pg_collection=None):
+def get_model(
+    model_provider_func,
+    model_type=ModelType.encoder_or_decoder,
+    wrap_with_ddp=True,
+    config=None,
+    pg_collection=None,
+):
     """Build the model."""
     args = get_args()
     args.model_type = model_type
@@ -1696,10 +1809,13 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
         pg_collection = ProcessGroupCollection.use_mpu_process_groups()
 
         if args.create_all_gather_group:
-            timeout = timedelta(minutes=args.distributed_timeout_minutes) if args.distributed_timeout_minutes else None
+            timeout = (
+                timedelta(minutes=args.distributed_timeout_minutes)
+                if args.distributed_timeout_minutes
+                else None
+            )
             dp_cp_ag, expt_dp_ag = create_all_gather_groups(
-                for_expert_parallelism=(args.expert_model_parallel_size > 1),
-                timeout=timeout,
+                for_expert_parallelism=(args.expert_model_parallel_size > 1), timeout=timeout
             )
             pg_collection.dp_cp_ag = dp_cp_ag
             pg_collection.expt_dp_ag = expt_dp_ag
@@ -1749,7 +1865,6 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
             model.model_type = model_type
         return model
 
-
     if args.init_model_with_meta_device:
         with torch.device('meta'):
             model = build_model()
@@ -1784,9 +1899,7 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
         print(
             ' > number of parameters on (tensor, pipeline) '
             'model parallel rank ({}, {}): {}'.format(
-                get_pg_rank(pg_collection.tp),
-                get_pg_rank(pg_collection.pp),
-                num_parameters,
+                get_pg_rank(pg_collection.tp), get_pg_rank(pg_collection.pp), num_parameters
             ),
             flush=True,
         )
@@ -1808,7 +1921,10 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
 
     # Materialize tensors on meta device (GPU allocation) if not using FSDP2 and not using Megatron FSDP.
     if args.init_model_with_meta_device and not args.use_torch_fsdp2 and not args.use_megatron_fsdp:
-        model = [to_empty_if_meta_device(model_module, device=torch.device("cuda")) for model_module in model]
+        model = [
+            to_empty_if_meta_device(model_module, device=torch.device("cuda"))
+            for model_module in model
+        ]
 
     # Before TE2.x: The model_module.bfloat16()/model_module.half() above will call the inplace
     #               copy of TE's Float8Tensor, which will write an unwanted value (amax calculated
@@ -1832,10 +1948,7 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
         if not getattr(args, "use_torch_fsdp2", False):
             # In the Megatron FSDP and DDP use path, we need to initialize the bucket size.
             ddp_config.bucket_size = resolve_ddp_bucket_size(
-                ddp_config,
-                pg_collection.dp_cp,
-                ddp_config.overlap_grad_reduce,
-                num_parameters,
+                ddp_config, pg_collection.dp_cp, ddp_config.overlap_grad_reduce, num_parameters
             )
 
         # Compute per-chunk bucket sizes / disable_bucketing flags. Bucketing is
@@ -1865,9 +1978,7 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
                 use_layer_wise_distributed_optimizer=getattr(
                     args, 'use_layer_wise_distributed_optimizer', False
                 ),
-                use_layer_wise_param_layout=getattr(
-                    args, 'use_layer_wise_param_layout', True
-                ),
+                use_layer_wise_param_layout=getattr(args, 'use_layer_wise_param_layout', True),
                 DP=DP,
                 pg_collection=pg_collection if args.use_megatron_fsdp else None,
                 bucket_sizes=per_chunk_bucket_sizes,
@@ -1950,11 +2061,16 @@ def get_megatron_optimizer_config(args: Any) -> OptimizerConfig:
             kwargs[f.name] = getattr(args, f.name)
     config = OptimizerConfig(**kwargs)
 
-    # Construct the appropriate config_overrides object. This default handles many cases, but
-    #  can be added to as needed by the user, or replaced entirely with a custom override.
-    config_overrides = get_standard_config_overrides(config=config)
+    # The serialized recipe and legacy standard overrides are mutually exclusive. Leave recipe
+    # parsing to get_megatron_optimizer so passing both APIs can be detected there.
+    config_overrides = (
+        None
+        if config.overrides_config is not None
+        else get_standard_config_overrides(config=config)
+    )
 
     return config, config_overrides
+
 
 def get_megatron_ddp_config(args: argparse.Namespace) -> DistributedDataParallelConfig:
     """Return an MCore DDPConfig from the argparse arguments."""
@@ -1973,9 +2089,12 @@ def get_megatron_ddp_config(args: argparse.Namespace) -> DistributedDataParallel
         kwargs["num_buckets"] = args.ddp_num_buckets
         kwargs["bucket_size"] = args.ddp_bucket_size
         kwargs["pad_buckets_for_high_nccl_busbw"] = args.ddp_pad_buckets_for_high_nccl_busbw
-        kwargs["reduce_scatter_with_fp32_accumulation"] = args.ddp_reduce_scatter_with_fp32_accumulation
-        kwargs["param_name_patterns_for_fp32_local_accumulation"] = \
-            tuple(args.ddp_param_name_patterns_for_fp32_local_accumulation)
+        kwargs["reduce_scatter_with_fp32_accumulation"] = (
+            args.ddp_reduce_scatter_with_fp32_accumulation
+        )
+        kwargs["param_name_patterns_for_fp32_local_accumulation"] = tuple(
+            args.ddp_param_name_patterns_for_fp32_local_accumulation
+        )
         kwargs["average_in_collective"] = args.ddp_average_in_collective
         # Megatron-FSDP arguments.
         kwargs["megatron_fsdp_main_params_dtype"] = args.megatron_fsdp_main_params_dtype
@@ -2039,8 +2158,15 @@ def setup_model_and_optimizer(
                 data_parallel_random_init=cfg.rng.data_parallel_random_init,
             )
         else:
-            assert model_provider_func is not None, "Must provide a model config via config_container or a model_provider_func."
-            return get_model(model_provider_func, model_type, wrap_with_ddp=wrap_with_ddp, pg_collection=pg_collection)
+            assert (
+                model_provider_func is not None
+            ), "Must provide a model config via config_container or a model_provider_func."
+            return get_model(
+                model_provider_func,
+                model_type,
+                wrap_with_ddp=wrap_with_ddp,
+                pg_collection=pg_collection,
+            )
 
     model = _build_model_wrapper(wrap_with_ddp)
     unwrapped_model = unwrap_model(model)
@@ -2063,7 +2189,9 @@ def setup_model_and_optimizer(
         student_logits_capture = StudentLogitsCapture()
         student_logits_capture.attach_hooks(unwrapped_model[-1])
 
-    one_logger and one_logger.log_metrics({"app_build_optimzer_start_time": one_logger_utils.get_timestamp_in_ms()})
+    one_logger and one_logger.log_metrics(
+        {"app_build_optimzer_start_time": one_logger_utils.get_timestamp_in_ms()}
+    )
     if skip_optimizer:
         optimizer, opt_param_scheduler = None, None
         # In RL inference-only mode, train_iters must still be set despite having no optimizer.
@@ -2094,7 +2222,9 @@ def setup_model_and_optimizer(
         )
         opt_param_scheduler = get_optimizer_param_scheduler(optimizer)
 
-    one_logger and one_logger.log_metrics({"app_build_optimzer_finish_time": one_logger_utils.get_timestamp_in_ms()})
+    one_logger and one_logger.log_metrics(
+        {"app_build_optimzer_finish_time": one_logger_utils.get_timestamp_in_ms()}
+    )
 
     if args.moe_use_upcycling:
         torch.distributed.barrier()
@@ -2244,12 +2374,21 @@ def dummy_train_step(data_iterator):
     """Single dummy training step."""
     args = get_args()
     tp_rank = mpu.get_tensor_model_parallel_rank()
-    has_cu_seqlens = getattr(args, 'sft', False) or getattr(args, 'dataloader_inter_document_masking', False)
+    has_cu_seqlens = getattr(args, 'sft', False) or getattr(
+        args, 'dataloader_inter_document_masking', False
+    )
     is_hybrid_cp = args.hybrid_context_parallel
 
     BATCH_KEYS = [
-        "tokens", "labels", "loss_mask", "position_ids", "attention_mask",
-        "cu_seqlens", "cu_seqlens_padded", "max_seqlen", "local_cp_size",
+        "tokens",
+        "labels",
+        "loss_mask",
+        "position_ids",
+        "attention_mask",
+        "cu_seqlens",
+        "cu_seqlens_padded",
+        "max_seqlen",
+        "local_cp_size",
         "hybrid_cp_group",
     ]
 
@@ -2262,7 +2401,11 @@ def dummy_train_step(data_iterator):
             if tp_rank == 0:
                 batch = next(data_iterator)
                 for key in BATCH_KEYS:
-                    batch[key] = batch[key].cuda(non_blocking=True) if key in batch and batch[key] is not None else None
+                    batch[key] = (
+                        batch[key].cuda(non_blocking=True)
+                        if key in batch and batch[key] is not None
+                        else None
+                    )
             batch = get_batch_on_this_tp_rank(
                 batch,
                 broadcast_src_rank=mpu.get_tensor_model_parallel_src_rank(),
@@ -2287,7 +2430,18 @@ def dummy_train_step(data_iterator):
             )
 
 
-def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_scheduler, config, forward_backward_func, iteration=None, pg_collection: Optional[ProcessGroupCollection | MultiModuleProcessGroupCollection] = None, p2p_communicator: Optional[P2PCommunicator] = None):
+def train_step(
+    forward_step_func,
+    data_iterator,
+    model,
+    optimizer,
+    opt_param_scheduler,
+    config,
+    forward_backward_func,
+    iteration=None,
+    pg_collection: Optional[ProcessGroupCollection | MultiModuleProcessGroupCollection] = None,
+    p2p_communicator: Optional[P2PCommunicator] = None,
+):
     """Single training step.
 
     pg_collection: optional carrier forwarded to the schedule for the cross-grid case; None
@@ -2299,16 +2453,23 @@ def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_sch
     timers = get_timers()
 
     rerun_state_machine = get_rerun_state_machine()
-    save_params_in_this_iteration = (args.save_params_interval is not None and
-                                     (iteration + 1) % args.save_params_interval == 0)
-    save_activations_in_this_iteration = (args.save_activations_interval is not None and
-                                          (iteration + 1) % args.save_activations_interval == 0)
-    save_tpe_in_this_iteration = (args.save_tokens_per_expert_interval is not None and
-                                  (iteration + 1) % args.save_tokens_per_expert_interval == 0)
-    save_wgrads_in_this_iteration = (args.save_wgrads_interval is not None and
-                                     (iteration + 1) % args.save_wgrads_interval == 0)
-    save_dgrads_in_this_iteration = (args.save_dgrads_interval is not None and
-                                     (iteration + 1) % args.save_dgrads_interval == 0)
+    save_params_in_this_iteration = (
+        args.save_params_interval is not None and (iteration + 1) % args.save_params_interval == 0
+    )
+    save_activations_in_this_iteration = (
+        args.save_activations_interval is not None
+        and (iteration + 1) % args.save_activations_interval == 0
+    )
+    save_tpe_in_this_iteration = (
+        args.save_tokens_per_expert_interval is not None
+        and (iteration + 1) % args.save_tokens_per_expert_interval == 0
+    )
+    save_wgrads_in_this_iteration = (
+        args.save_wgrads_interval is not None and (iteration + 1) % args.save_wgrads_interval == 0
+    )
+    save_dgrads_in_this_iteration = (
+        args.save_dgrads_interval is not None and (iteration + 1) % args.save_dgrads_interval == 0
+    )
     while rerun_state_machine.should_run_forward_backward(data_iterator):
         # Set grad to zero.
         for model_chunk in model:
@@ -2444,9 +2605,9 @@ def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_sch
     if pg_collection is None:
         pg_collection = ProcessGroupCollection.use_mpu_process_groups()
     for _required in ("mp", "pp", "dp_cp"):
-        assert getattr(pg_collection, _required, None) is not None, (
-            f"model pg_collection used by train_step must define {_required}"
-        )
+        assert (
+            getattr(pg_collection, _required, None) is not None
+        ), f"model pg_collection used by train_step must define {_required}"
     mp_group = pg_collection.mp
     dp_cp_group = pg_collection.dp_cp
     is_last_stage = is_pp_last_stage(pg_collection.pp)
@@ -2506,7 +2667,16 @@ def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_sch
             num_zeros_in_grad,
             log_max_attention_logit,
         )
-    return {}, skipped_iter, should_checkpoint, should_exit, exit_code, grad_norm, num_zeros_in_grad, log_max_attention_logit
+    return (
+        {},
+        skipped_iter,
+        should_checkpoint,
+        should_exit,
+        exit_code,
+        grad_norm,
+        num_zeros_in_grad,
+        log_max_attention_logit,
+    )
 
 
 def training_log(
@@ -2566,35 +2736,39 @@ def training_log(
     # Logging.
     timers_to_log = []
     if args.timing_log_level >= 1:
-        timers_to_log.extend([
-            'forward-backward',
-            'layernorm-grads-all-reduce',
-            'embedding-grads-all-reduce',
-            'all-grads-sync',
-            'params-all-gather',
-            'optimizer-copy-to-main-grad',
-            'optimizer-unscale-and-check-inf',
-            'optimizer-clip-main-grad',
-            'optimizer-count-zeros',
-            'optimizer-inner-step',
-            'optimizer-copy-main-to-model-params',
-            'optimizer',
-        ])
+        timers_to_log.extend(
+            [
+                'forward-backward',
+                'layernorm-grads-all-reduce',
+                'embedding-grads-all-reduce',
+                'all-grads-sync',
+                'params-all-gather',
+                'optimizer-copy-to-main-grad',
+                'optimizer-unscale-and-check-inf',
+                'optimizer-clip-main-grad',
+                'optimizer-count-zeros',
+                'optimizer-inner-step',
+                'optimizer-copy-main-to-model-params',
+                'optimizer',
+            ]
+        )
     if args.timing_log_level >= 2:
-        timers_to_log.extend([
-            'batch-generator',
-            'forward-compute',
-            'backward-compute',
-            'forward-recv',
-            'forward-send',
-            'backward-recv',
-            'backward-send',
-            'forward-send-forward-recv',
-            'forward-send-backward-recv',
-            'backward-send-forward-recv',
-            'backward-send-backward-recv',
-            'forward-backward-send-forward-backward-recv',
-        ])
+        timers_to_log.extend(
+            [
+                'batch-generator',
+                'forward-compute',
+                'backward-compute',
+                'forward-recv',
+                'forward-send',
+                'backward-recv',
+                'backward-send',
+                'forward-send-forward-recv',
+                'forward-send-backward-recv',
+                'backward-send-forward-recv',
+                'backward-send-backward-recv',
+                'forward-backward-send-forward-backward-recv',
+            ]
+        )
     # Add timers from RL loop if needed.
     if args.perform_rl_step:
         timers_to_log.extend(RL_LOGGABLE_TIMER_NAMES)
@@ -2620,7 +2794,9 @@ def training_log(
             wandb_writer.log({'samples vs steps': args.consumed_train_samples}, iteration)
         if learning_rate is not None:
             writer.add_scalar('learning-rate', learning_rate, iteration)
-            writer.add_scalar('learning-rate vs samples', learning_rate, args.consumed_train_samples)
+            writer.add_scalar(
+                'learning-rate vs samples', learning_rate, args.consumed_train_samples
+            )
             if wandb_writer:
                 wandb_writer.log({'learning-rate': learning_rate}, iteration)
         if args.skipped_train_samples > 0:
@@ -2671,10 +2847,14 @@ def training_log(
             if wandb_writer:
                 wandb_writer.log({'params-norm': params_norm}, iteration)
         if args.perform_rl_step:
-            grpo_collection_iteration = iteration // (args.grpo_iterations * ( ( args.grpo_samples_per_iteration )// args.global_batch_size ))
+            grpo_collection_iteration = iteration // (
+                args.grpo_iterations * ((args.grpo_samples_per_iteration) // args.global_batch_size)
+            )
             writer.add_scalar('grpo_collection_iteration', grpo_collection_iteration, iteration)
             if wandb_writer:
-                wandb_writer.log({'grpo_collection_iteration': grpo_collection_iteration}, iteration)
+                wandb_writer.log(
+                    {'grpo_collection_iteration': grpo_collection_iteration}, iteration
+                )
         if args.log_memory_to_tensorboard:
             mem_stats = torch.cuda.memory_stats()
             writer.add_scalar(
@@ -2712,6 +2892,7 @@ def training_log(
                 Symbols,
                 get_hybrid_layer_counts,
             )
+
             layers = itemgetter(Symbols.MOE)(get_hybrid_layer_counts(args.hybrid_layer_pattern))
         else:
             layers = args.num_layers
@@ -2751,7 +2932,9 @@ def training_log(
 
     # Dump memory snapshot and print metrics to stdout.
     if iteration % args.log_interval == 0 or is_first_iteration:
-        if args.record_memory_history and (is_last_rank() or torch.distributed.get_backend() == 'fake'):
+        if args.record_memory_history and (
+            is_last_rank() or torch.distributed.get_backend() == 'fake'
+        ):
             snapshot = torch.cuda.memory._snapshot()
             from pickle import dump
 
@@ -2836,7 +3019,7 @@ def training_log(
         # RL token throughput metrics.
         if args.perform_rl_step:
             log_string += rl_utils.log_rl_throughput_metrics(
-                args, batch_size, elapsed_time_per_iteration, iteration, wandb_writer,
+                args, batch_size, elapsed_time_per_iteration, iteration, wandb_writer
             )
 
         if should_reset:
@@ -2859,8 +3042,11 @@ def training_log(
             if iteration > (loaded_iteration + 1):
                 # Make sure the memory after the second iteration is reported to include optimizer state memory.
                 report_memory_flag = False
-        if args.log_memory_interval is not None and iteration % args.log_memory_interval == 0 and \
-            not reported_memory_in_this_iteration:
+        if (
+            args.log_memory_interval is not None
+            and iteration % args.log_memory_interval == 0
+            and not reported_memory_in_this_iteration
+        ):
             report_memory(
                 f'(after {iteration} iterations)',
                 process_group=pg_collection.dp if pg_collection is not None else None,
@@ -2880,8 +3066,12 @@ def training_log(
 
         # Write timers to wandb, don't reset the counts.
         if args.log_timers_to_tensorboard:
-            timers.write(timers_to_log, writer, iteration, normalizer=args.log_interval, reset=False)
-            timers.write(timers_to_log, wandb_writer, iteration, normalizer=args.log_interval, reset=False)
+            timers.write(
+                timers_to_log, writer, iteration, normalizer=args.log_interval, reset=False
+            )
+            timers.write(
+                timers_to_log, wandb_writer, iteration, normalizer=args.log_interval, reset=False
+            )
         # Log timers to stdout
         timers.log(timers_to_log, normalizer=args.log_interval, reset=should_reset)
 
@@ -2918,7 +3108,7 @@ def compute_throughputs_and_append_to_progress_log(iteration, num_floating_point
         f"Job throughput: {job_throughput:.1f} TFLOP/s/GPU\t"
         f"Cumulative throughput: {cumulative_throughput:.1f} TFLOP/s/GPU\t"
         f"Floating-point operations: {num_floating_point_operations_so_far:.2e}\t"
-        f"Tokens (in billions): {tokens_so_far / 10**9:.2f}"
+        f"Tokens (in billions): {tokens_so_far / 10**9:.2f}",
     )
 
 
@@ -3054,9 +3244,7 @@ def _run_gpu_sniff_test(tag):
     from megatron.core.process_groups_config import ProcessGroupCollection
     from megatron.training.gpu_sniff_test import run_gpu_sniff_test
 
-    pg_collection = ProcessGroupCollection.use_mpu_process_groups(
-        required_pgs=['ep', 'dp', 'tp'],
-    )
+    pg_collection = ProcessGroupCollection.use_mpu_process_groups(required_pgs=['ep', 'dp', 'tp'])
     print_datetime(f'running GPU sniff test ({tag})')
     timers = get_timers()
     timers('gpu-sniff-test', log_level=0).start(barrier=True)
@@ -3073,7 +3261,7 @@ def post_training_step_callbacks(
     iteration,
     prof,
     num_floating_point_operations_since_last_log_event,
-    nsys_nvtx_context = None,
+    nsys_nvtx_context=None,
 ):
     """Run all post-training-step functions (e.g., FT heartbeats, GC)."""
     args = get_args()
@@ -3111,8 +3299,7 @@ def post_training_step_callbacks(
     if (
         args.profile
         and iteration == args.profile_step_end
-        and (len(args.profile_ranks) == 0 or
-             torch.distributed.get_rank() in args.profile_ranks)
+        and (len(args.profile_ranks) == 0 or torch.distributed.get_rank() in args.profile_ranks)
     ):
         # Disable NVTX range when profiling ends.
         if args.nvtx_ranges:
@@ -3128,10 +3315,7 @@ def post_training_step_callbacks(
                 nsys_nvtx_context.__exit__(None, None, None)
 
     # GPU sniff test.
-    if (
-        args.gpu_sniff_test_interval is not None
-        and iteration % args.gpu_sniff_test_interval == 0
-    ):
+    if args.gpu_sniff_test_interval is not None and iteration % args.gpu_sniff_test_interval == 0:
         _run_gpu_sniff_test(f'iteration {iteration:7d}')
 
     # Manual garbage collection.
@@ -3231,12 +3415,8 @@ def checkpoint_and_decide_exit(
             return True
 
     # Exit based on iterations.
-    if (
-        args.exit_interval
-        and iteration % args.exit_interval == 0
-    ) or (
-        args.phase_transition_iterations
-        and iteration in args.phase_transition_iterations
+    if (args.exit_interval and iteration % args.exit_interval == 0) or (
+        args.phase_transition_iterations and iteration in args.phase_transition_iterations
     ):
         if args.save and not saved_checkpoint:
             save_checkpoint_and_time(
@@ -3322,29 +3502,31 @@ def train(
             args.load = None
             args.finetune = True
             load_checkpoint(
-                    model,
-                    None,  # Don't load optimizer state
-                    None,  # Don't load scheduler state
-                    checkpointing_context=checkpointing_context,
-                    skip_load_to_model_and_opt=HAVE_FSDP2
-                    and getattr(args, "use_torch_fsdp2", False)
-                    and args.ckpt_format == "torch_dist",
-                )
-            ref_state_dict = {k: (v.cpu() if v is not None else v) for k, v in model[0].state_dict().items()}
+                model,
+                None,  # Don't load optimizer state
+                None,  # Don't load scheduler state
+                checkpointing_context=checkpointing_context,
+                skip_load_to_model_and_opt=HAVE_FSDP2
+                and getattr(args, "use_torch_fsdp2", False)
+                and args.ckpt_format == "torch_dist",
+            )
+            ref_state_dict = {
+                k: (v.cpu() if v is not None else v) for k, v in model[0].state_dict().items()
+            }
 
             # Reload RL training checkpoint weights
             args.load = load
             args.finetune = finetune
             print_rank_0("> Reloading RL training checkpoint...")
             load_checkpoint(
-                    model,
-                    None,
-                    None,
-                    checkpointing_context=checkpointing_context,
-                    skip_load_to_model_and_opt=HAVE_FSDP2
-                    and getattr(args, "use_torch_fsdp2", False)
-                    and args.ckpt_format == "torch_dist",
-                )
+                model,
+                None,
+                None,
+                checkpointing_context=checkpointing_context,
+                skip_load_to_model_and_opt=HAVE_FSDP2
+                and getattr(args, "use_torch_fsdp2", False)
+                and args.ckpt_format == "torch_dist",
+            )
 
             args.no_load_optim = no_load_optim
 
@@ -3420,8 +3602,10 @@ def train(
     # Make sure rerun_state_machine has the right iteration loaded from checkpoint.
     rerun_state_machine = get_rerun_state_machine()
     if rerun_state_machine.current_iteration != iteration:
-        print_rank_0(f"Overwriting rerun_state_machine.current_iteration from "
-                     f"{rerun_state_machine.current_iteration} to {iteration}...")
+        print_rank_0(
+            f"Overwriting rerun_state_machine.current_iteration from "
+            f"{rerun_state_machine.current_iteration} to {iteration}..."
+        )
         rerun_state_machine.current_iteration = iteration
 
     # Track E2E metrics at the start of training.
@@ -3524,9 +3708,7 @@ def train(
     eval_duration = 0.0
     eval_iterations = 0
     # Wrap forward_backward_func for Full iteration CUDA graph
-    forward_backward_func = get_forward_backward_func(
-        schedule_pg_collection=pg_collection
-    )
+    forward_backward_func = get_forward_backward_func(schedule_pg_collection=pg_collection)
     if args.cuda_graph_impl == "full_iteration":
         forward_backward_func = FullCudaGraphWrapper(
             forward_backward_func,
@@ -3537,11 +3719,7 @@ def train(
     if args.moe_expert_rank_capacity_factor is not None:
         copy_main_params = args.reuse_grad_buf_for_mxfp8_param_ag and args.overlap_param_gather
         forward_backward_func = PagedStashRunner(
-            config,
-            copy_main_params,
-            model,
-            optimizer,
-            forward_backward_func,
+            config, copy_main_params, model, optimizer, forward_backward_func
         )
     if args.optimizer_cuda_graph:
         optimizer.step = OptimizerCudaGraphWrapper(
@@ -3573,23 +3751,26 @@ def train(
             one_logger.store_set('get_e2e_base_metrics', get_e2e_base_metrics)
 
     prof = None
-    nsys_nvtx_context = None # reference to context for nsys profiling, so it can be cleaned up
+    nsys_nvtx_context = None  # reference to context for nsys profiling, so it can be cleaned up
     if (
         args.profile
-        and (len(args.profile_ranks) == 0 or
-             torch.distributed.get_rank() in args.profile_ranks)
+        and (len(args.profile_ranks) == 0 or torch.distributed.get_rank() in args.profile_ranks)
         and args.use_pytorch_profiler
     ):
         if args.pytorch_profiler_collect_chakra:
             et_dir = Path(f"{args.tensorboard_dir}/../chakra")
             et_dir.mkdir(parents=True, exist_ok=True)
-            et = torch.profiler.ExecutionTraceObserver().register_callback(f"{et_dir}/rank-{torch.distributed.get_rank()}.json.gz")
+            et = torch.profiler.ExecutionTraceObserver().register_callback(
+                f"{et_dir}/rank-{torch.distributed.get_rank()}.json.gz"
+            )
         else:
             et = None
+
         def trace_handler(p):
             profile_dir = Path(f"{args.tensorboard_dir}/../torch_profile")
             profile_dir.mkdir(parents=True, exist_ok=True)
             p.export_chrome_trace(f"{profile_dir}/rank-{torch.distributed.get_rank()}.json.gz")
+
         prof = torch.profiler.profile(
             schedule=torch.profiler.schedule(
                 wait=max(args.profile_step_start - 1, 0),
@@ -3636,9 +3817,9 @@ def train(
     # Run training iterations till done.
     buffered_rollouts = None
     while iteration < args.train_iters:
-        if (args.profile
-            and (len(args.profile_ranks) == 0 or
-                 torch.distributed.get_rank() in args.profile_ranks)):
+        if args.profile and (
+            len(args.profile_ranks) == 0 or torch.distributed.get_rank() in args.profile_ranks
+        ):
             # Enable NVTX range when profiling starts and nvtx_ranges is set.
             if iteration == args.profile_step_start and args.nvtx_ranges:
                 configure_nvtx_profiling(True)
@@ -3646,7 +3827,9 @@ def train(
                 prof.step()
             elif iteration == args.profile_step_start:
                 torch.cuda.check_error(torch.cuda.cudart().cudaProfilerStart())
-                nsys_nvtx_context = torch.autograd.profiler.emit_nvtx(record_shapes=args.record_shapes)
+                nsys_nvtx_context = torch.autograd.profiler.emit_nvtx(
+                    record_shapes=args.record_shapes
+                )
                 nsys_nvtx_context.__enter__()
 
         ft_integration.on_checkpointing_start()
@@ -3655,7 +3838,10 @@ def train(
         # Update the timeout for all process groups after initialization
         # We update the timeout after the first successful iteration,
         # which takes longer than others usually
-        if args.distributed_timeout_seconds_after_init is not None and iteration == start_iteration+1:
+        if (
+            args.distributed_timeout_seconds_after_init is not None
+            and iteration == start_iteration + 1
+        ):
             # TODO: some dynamic timeout setting is required
             # based on the iteration time considering interval-based steps (e.g. eval, checkpoint)
             # e.g. timeout for normal iterations vs timeout for iterations with checkpoint
@@ -3714,9 +3900,7 @@ def train(
             if iteration == start_iteration:
                 start_iteration = iteration + 1
             iteration += 1
-            batch_size = (
-                _dp_world_size() * args.micro_batch_size * get_num_microbatches()
-            )
+            batch_size = _dp_world_size() * args.micro_batch_size * get_num_microbatches()
             args.consumed_train_samples += batch_size
             args.skipped_train_samples += batch_size
             continue
@@ -3731,7 +3915,11 @@ def train(
                 torch.cuda.empty_cache()
             with torch.no_grad():
                 train_data_iterator = rl_utils.get_grpo_data_iterator(
-                    model, inference_model, optimizer, iteration, ref_state_dict,
+                    model,
+                    inference_model,
+                    optimizer,
+                    iteration,
+                    ref_state_dict,
                     grpo_iterations=args.grpo_iterations,
                     grpo_prompts_per_step=args.grpo_prompts_per_step,
                     grpo_group_size=args.grpo_group_size,
@@ -3767,7 +3955,14 @@ def train(
                 num_zeros_in_grad,
                 max_attention_logit,
             ) = train_step(
-                forward_step_func, train_data_iterator, model, optimizer, opt_param_scheduler, config, forward_backward_func, iteration=iteration,
+                forward_step_func,
+                train_data_iterator,
+                model,
+                optimizer,
+                opt_param_scheduler,
+                config,
+                forward_backward_func,
+                iteration=iteration,
                 pg_collection=pg_collection,
                 p2p_communicator=p2p_communicator,
             )
@@ -3777,8 +3972,9 @@ def train(
             # Fault delay timing can start at the end of iteration N. Self-firing faults
             # (signals, GIL, GPU) may then manifest in iteration N or N+1 depending on the
             # configured delay; workload-exception faults manifest on a later poll.
-            if _maybe_raise_workload_exception is not None and should_setup_fault_injection_at_iteration(
-                fault_injector_config, iteration
+            if (
+                _maybe_raise_workload_exception is not None
+                and should_setup_fault_injection_at_iteration(fault_injector_config, iteration)
             ):
                 setup_fault_injection(fault_injector_config)
         if should_checkpoint:
@@ -3828,7 +4024,7 @@ def train(
             getattr(args, "fsdp_manual_registration", False)
             and getattr(args, "nccl_ub", False)
             and getattr(args, "use_megatron_fsdp", False)
-            and iteration ==  start_iteration + 1
+            and iteration == start_iteration + 1
         ):
             for model_chunk in model:
                 if isinstance(model_chunk, megatron_FSDP) and getattr(
@@ -3841,14 +4037,10 @@ def train(
         if args.perform_rl_step and args.rl_use_sequence_packing:
             iteration_sequences = rl_utils.get_iteration_sequence_count(args)
             # Track bins separately for packed mode
-            bin_count = (
-                _dp_world_size() * args.micro_batch_size * get_num_microbatches()
-            )
+            bin_count = _dp_world_size() * args.micro_batch_size * get_num_microbatches()
             args.consumed_train_bins += bin_count
         else:
-            batch_size = (
-                _dp_world_size() * args.micro_batch_size * get_num_microbatches()
-            )
+            batch_size = _dp_world_size() * args.micro_batch_size * get_num_microbatches()
             iteration_sequences = batch_size
 
         # Update consumed samples (always means sequences now)
@@ -3915,8 +4107,12 @@ def train(
         is_first_iteration = False
 
         # Evaluation.
-        if args.eval_interval and iteration % args.eval_interval == 0 and args.do_valid \
-                and (args.start_eval_at_iter is None or iteration >= args.start_eval_at_iter):
+        if (
+            args.eval_interval
+            and iteration % args.eval_interval == 0
+            and args.do_valid
+            and (args.start_eval_at_iter is None or iteration >= args.start_eval_at_iter)
+        ):
             if args.log_energy:
                 energy_monitor.pause()
             timers('interval-time').stop()
@@ -3950,16 +4146,25 @@ def train(
                     training_model=rl_training_model,
                 )
             else:
-                evaluate_and_print_results(prefix, forward_step_func,
-                                       valid_data_iterator, model,
-                                       iteration, process_non_loss_data_func,
-                                       config, verbose=False, write_to_tensorboard=True,
-                                       non_loss_data_func=non_loss_data_func,
-                                       pg_collection=pg_collection,
-                                       p2p_communicator=p2p_communicator)
+                evaluate_and_print_results(
+                    prefix,
+                    forward_step_func,
+                    valid_data_iterator,
+                    model,
+                    iteration,
+                    process_non_loss_data_func,
+                    config,
+                    verbose=False,
+                    write_to_tensorboard=True,
+                    non_loss_data_func=non_loss_data_func,
+                    pg_collection=pg_collection,
+                    p2p_communicator=p2p_communicator,
+                )
 
             eval_duration += timers('eval-time').elapsed()
-            eval_iterations += sum(args.eval_iters) if isinstance(args.eval_iters, list) else args.eval_iters
+            eval_iterations += (
+                sum(args.eval_iters) if isinstance(args.eval_iters, list) else args.eval_iters
+            )
             timers('eval-time').stop()
             one_logger_utils.track_e2e_metrics()
 
@@ -4054,7 +4259,9 @@ def train(
             if isinstance(model_module, DDP):
                 for buf in model_module.buffers + model_module.expert_parallel_buffers:
                     if getattr(buf, 'nccl_mem_pool', None) is not None:
-                        nccl_allocator.deregister_mem_pool(buf.nccl_mem_pool, buf.data_parallel_group)
+                        nccl_allocator.deregister_mem_pool(
+                            buf.nccl_mem_pool, buf.data_parallel_group
+                        )
         one_logger and one_logger.log_metrics(
             {'app_finish_time': one_logger_utils.get_timestamp_in_ms()}
         )
@@ -4118,11 +4325,7 @@ def evaluate(
     if args.moe_expert_rank_capacity_factor is not None:
         copy_main_params = args.reuse_grad_buf_for_mxfp8_param_ag and args.overlap_param_gather
         forward_backward_func = PagedStashRunner(
-            config,
-            copy_main_params,
-            model,
-            None,
-            forward_backward_func,
+            config, copy_main_params, model, None, forward_backward_func
         )
 
     if has_nvidia_modelopt and getattr(args, "modelopt_enabled", False):
@@ -4175,7 +4378,9 @@ def evaluate(
                 # Reduce across processes.
                 for key in loss_dicts[0].keys():
                     if key not in total_loss_dict:
-                        total_loss_dict[key] = torch.tensor([0.0, 0.0], dtype=torch.float, device='cuda')
+                        total_loss_dict[key] = torch.tensor(
+                            [0.0, 0.0], dtype=torch.float, device='cuda'
+                        )
                     val = [x[key].view(-1) for x in loss_dicts]
 
                     if val[0].numel() == 2:
@@ -4188,7 +4393,7 @@ def evaluate(
                             val /= torch.distributed.get_world_size(group=eval_pgc.dp_cp)
                             total_loss_dict[key][0] += val
                             total_loss_dict[key][1] += 1
-                        else :
+                        else:
                             val = torch.vstack(val).sum(dim=0)
                             torch.distributed.all_reduce(val, group=eval_pgc.dp_cp)
                             total_loss_dict[key] += val
@@ -4294,11 +4499,13 @@ def evaluate_and_print_results(
         eval_iters = args.eval_iters
 
     if args.validation_set_names:
-        assert args.multiple_validation_sets, \
-            "--validation-set-names requires --multiple-validation-sets"
-        assert len(args.validation_set_names) == len(data_iterators), \
-            f"Number of --validation-set-names ({len(args.validation_set_names)}) must match " \
+        assert (
+            args.multiple_validation_sets
+        ), "--validation-set-names requires --multiple-validation-sets"
+        assert len(args.validation_set_names) == len(data_iterators), (
+            f"Number of --validation-set-names ({len(args.validation_set_names)}) must match "
             f"the number of validation datasets ({len(data_iterators)})"
+        )
 
     for index, (iterator, iterations) in enumerate(zip(data_iterators, eval_iters)):
         suffix = ""
@@ -4328,7 +4535,9 @@ def evaluate_and_print_results(
             ppl = math.exp(min(20, total_loss_dict[key].item()))
             string += '{} PPL: {:.6E} | '.format(key, ppl)
             if writer:
-                writer.add_scalar('{} validation{}'.format(key, suffix), total_loss_dict[key].item(), iteration)
+                writer.add_scalar(
+                    '{} validation{}'.format(key, suffix), total_loss_dict[key].item(), iteration
+                )
                 writer.add_scalar(
                     '{} validation{} vs samples'.format(key, suffix),
                     total_loss_dict[key].item(),
@@ -4337,11 +4546,14 @@ def evaluate_and_print_results(
                 if args.log_validation_ppl_to_tensorboard:
                     writer.add_scalar('{} validation{} ppl'.format(key, suffix), ppl, iteration)
                     writer.add_scalar(
-                        '{} validation{} ppl vs samples'.format(key, suffix), ppl, args.consumed_train_samples
+                        '{} validation{} ppl vs samples'.format(key, suffix),
+                        ppl,
+                        args.consumed_train_samples,
                     )
                 if wandb_writer and is_last_rank():
                     wandb_writer.log(
-                        {'{} validation{}'.format(key, suffix): total_loss_dict[key].item()}, iteration
+                        {'{} validation{}'.format(key, suffix): total_loss_dict[key].item()},
+                        iteration,
                     )
 
         if process_non_loss_data_func is not None and writer and is_last_rank():
@@ -4396,7 +4608,11 @@ def get_train_valid_test_num_samples():
 
     # Get train_samples in current phase.
     if args.phase_transition_iterations:
-        phase_transition_samples = [0] + [t * args.global_batch_size for t in args.phase_transition_iterations] + [args.train_samples]
+        phase_transition_samples = (
+            [0]
+            + [t * args.global_batch_size for t in args.phase_transition_iterations]
+            + [args.train_samples]
+        )
         current_sample = args.iteration * args.global_batch_size
         last_transition_sample = max(s for s in phase_transition_samples if s <= current_sample)
         next_transition_sample = min(s for s in phase_transition_samples if s > current_sample)
@@ -4407,7 +4623,9 @@ def get_train_valid_test_num_samples():
     return (train_samples_in_current_phase, eval_samples, test_samples)
 
 
-def build_train_valid_test_datasets(build_train_valid_test_datasets_provider, train_valid_test_num_samples=None):
+def build_train_valid_test_datasets(
+    build_train_valid_test_datasets_provider, train_valid_test_num_samples=None
+):
     """Build pretraining datasets."""
     if train_valid_test_num_samples is None:
         train_valid_test_num_samples = get_train_valid_test_num_samples()
@@ -4446,8 +4664,14 @@ def build_train_valid_test_data_loaders(build_train_valid_test_datasets_provider
 
     # Get consumed train samples in this phase.
     if args.phase_transition_iterations:
-        last_transition = max(iteration for iteration in (0, *args.phase_transition_iterations) if iteration <= args.iteration)
-        consumed_train_samples_in_current_phase = (args.iteration - last_transition) * args.global_batch_size
+        last_transition = max(
+            iteration
+            for iteration in (0, *args.phase_transition_iterations)
+            if iteration <= args.iteration
+        )
+        consumed_train_samples_in_current_phase = (
+            args.iteration - last_transition
+        ) * args.global_batch_size
     else:
         consumed_train_samples_in_current_phase = args.consumed_train_samples
 
@@ -4464,17 +4688,21 @@ def build_train_valid_test_data_loaders(build_train_valid_test_datasets_provider
             valid_dataloaders = None
             test_dataloader = None
             do_train = (args.train_iters or 0) > 0
-            do_valid = (args.full_validation or args.eval_iters > 0)
-            do_test = (args.full_validation or args.eval_iters > 0)
+            do_valid = args.full_validation or args.eval_iters > 0
+            do_test = args.full_validation or args.eval_iters > 0
 
         else:
             # Build datasets.
-            train_ds, valid_ds, test_ds = build_train_valid_test_datasets(build_train_valid_test_datasets_provider)
+            train_ds, valid_ds, test_ds = build_train_valid_test_datasets(
+                build_train_valid_test_datasets_provider
+            )
             valid_ds = [valid_ds] if not isinstance(valid_ds, list) else valid_ds
             if args.skip_train:
                 train_dataloader = None
             else:
-                train_dataloader = build_pretraining_data_loader(train_ds, consumed_train_samples_in_current_phase)
+                train_dataloader = build_pretraining_data_loader(
+                    train_ds, consumed_train_samples_in_current_phase
+                )
             valid_dataloaders = []
             for valid_d in valid_ds:
                 if args.skip_train or args.full_validation:
@@ -4483,13 +4711,19 @@ def build_train_valid_test_data_loaders(build_train_valid_test_datasets_provider
                     if args.multiple_validation_sets:
                         # TODO(bnorick): for multiple validation sets without full validation, args.consumed_valid_samples is not
                         # correct and needs to be calculated/set per validation set
-                        raise NotImplementedError("--multiple-validation-sets currently requires --full-validation")
-                    valid_dataloaders.append(build_pretraining_data_loader(valid_d, args.consumed_valid_samples))
+                        raise NotImplementedError(
+                            "--multiple-validation-sets currently requires --full-validation"
+                        )
+                    valid_dataloaders.append(
+                        build_pretraining_data_loader(valid_d, args.consumed_valid_samples)
+                    )
             if not args.multiple_validation_sets:
                 assert len(valid_dataloaders) == 1
             test_dataloader = build_pretraining_data_loader(test_ds, 0)
             do_train = train_dataloader is not None and (args.skip_train or args.train_iters > 0)
-            do_valid = valid_dataloaders is not None and (args.full_validation or args.eval_iters > 0)
+            do_valid = valid_dataloaders is not None and (
+                args.full_validation or args.eval_iters > 0
+            )
             do_test = test_dataloader is not None and (args.full_validation or args.eval_iters > 0)
 
         flags = torch.tensor(
@@ -4549,7 +4783,9 @@ def build_train_valid_test_data_iterators(build_train_valid_test_datasets_provid
                     args.eval_iters = [None] * len(valid_dataloaders)
                 else:
                     local_eval_iters = [len(dl) for dl in valid_dataloaders]
-                    eval_iters_tensor = torch.tensor(local_eval_iters, dtype=torch.long, device='cuda')
+                    eval_iters_tensor = torch.tensor(
+                        local_eval_iters, dtype=torch.long, device='cuda'
+                    )
                     torch.distributed.all_reduce(
                         eval_iters_tensor,
                         op=torch.distributed.ReduceOp.MAX,
@@ -4558,7 +4794,9 @@ def build_train_valid_test_data_iterators(build_train_valid_test_datasets_provid
                     args.eval_iters = eval_iters_tensor.tolist()
             else:
                 local_eval_iters = len(valid_dataloaders[0])
-                eval_iters_tensor = torch.tensor([local_eval_iters], dtype=torch.long, device='cuda')
+                eval_iters_tensor = torch.tensor(
+                    [local_eval_iters], dtype=torch.long, device='cuda'
+                )
                 torch.distributed.all_reduce(
                     eval_iters_tensor,
                     op=torch.distributed.ReduceOp.MAX,

--- a/tests/unit_tests/optimizer/test_param_group_identifier_keys.py
+++ b/tests/unit_tests/optimizer/test_param_group_identifier_keys.py
@@ -17,6 +17,15 @@ keys that aren't present on every group (e.g. ``start_wd``/``end_wd``/
 explicitly override them).
 """
 
+from unittest.mock import patch
+
+import torch
+
+from megatron.core.optimizer import (
+    OptimizerConfig,
+    _get_param_groups,
+    get_optimizer_overrides_from_config,
+)
 from megatron.core.optimizer.optimizer import MegatronOptimizer, param_group_identifier_keys
 from megatron.core.optimizer_param_scheduler import ParamGroupOverride
 
@@ -179,6 +188,124 @@ def test_filter_reorder_distinguishes_groups_by_max_lr():
     # current[1] has max_lr=5e-4 → must match the saved group with max_lr=5e-4.
     assert reordered[1]["max_lr"] == 5e-4
     assert reordered[1]["_tag"] == "from_projector"
+
+
+@patch('torch.distributed.get_world_size', return_value=1)
+@patch(
+    'torch.distributed.all_gather_object', lambda output_list, obj: output_list.__setitem__(0, obj)
+)
+def test_configured_eps_groups_remain_distinct_during_checkpoint_reorder(mock_get_world_size):
+    """Configured groups that differ only by epsilon must not collide on checkpoint load."""
+    model = torch.nn.Module()
+    model.left = torch.nn.Linear(4, 4, bias=False)
+    model.right = torch.nn.Linear(4, 4, bias=False)
+    config = OptimizerConfig(
+        lr=1.0e-3,
+        min_lr=1.0e-5,
+        overrides_config={
+            "optimizers": {
+                "adam_main": {
+                    "type": "adam",
+                    "kwargs": {},
+                    "param_groups": {
+                        "default": {},
+                        "left": {"eps": 1.0e-8},
+                        "right": {"eps": 1.0e-12},
+                    },
+                }
+            },
+            "default": {"optimizer": "adam_main", "param_group": "default"},
+            "matchers": {
+                "left": {
+                    "type": "glob",
+                    "pattern": "left.weight",
+                    "optimizer": "adam_main",
+                    "param_group": "left",
+                    "enabled": True,
+                },
+                "right": {
+                    "type": "glob",
+                    "pattern": "right.weight",
+                    "optimizer": "adam_main",
+                    "param_group": "right",
+                    "enabled": True,
+                },
+            },
+        },
+    )
+    current = _get_param_groups([model], config, get_optimizer_overrides_from_config(config))
+    assert {group["eps"] for group in current} == {1.0e-8, 1.0e-12}
+
+    saved = []
+    for group in reversed(current):
+        saved_group = dict(group)
+        saved_group["_tag"] = f"saved_eps_{group['eps']}"
+        saved.append(saved_group)
+
+    reordered = MegatronOptimizer._filter_and_reorder_param_groups(current, saved)
+
+    assert [group["_tag"] for group in reordered] == [
+        f"saved_eps_{group['eps']}" for group in current
+    ]
+
+
+@patch('torch.distributed.get_world_size', return_value=1)
+@patch(
+    'torch.distributed.all_gather_object', lambda output_list, obj: output_list.__setitem__(0, obj)
+)
+def test_nested_optimizer_kwargs_survive_checkpoint_reorder(mock_get_world_size):
+    """Nested constructor and group kwargs form stable checkpoint identities."""
+    model = torch.nn.Module()
+    model.left = torch.nn.Linear(4, 4, bias=False)
+    model.right = torch.nn.Linear(4, 4, bias=False)
+    config = OptimizerConfig(
+        lr=1.0e-3,
+        overrides_config={
+            "optimizers": {
+                "muon_left": {
+                    "type": "muon",
+                    "kwargs": {
+                        "num_ns_steps": 3,
+                        "coefficients": {"type": "polar_express", "values": [1.0, 2.0]},
+                    },
+                    "param_groups": {"default": {"newon_scale": 0.5}},
+                },
+                "muon_right": {
+                    "type": "muon",
+                    "kwargs": {
+                        "num_ns_steps": 5,
+                        "coefficients": {"type": "polar_express", "values": [1.0, 2.0]},
+                    },
+                    "param_groups": {"default": {"newon_scale": 0.75}},
+                },
+            },
+            "default": {"optimizer": "muon_left", "param_group": "default"},
+            "matchers": {
+                name: {
+                    "type": "glob",
+                    "pattern": f"{name}.weight",
+                    "optimizer": f"muon_{name}",
+                    "param_group": "default",
+                    "enabled": True,
+                }
+                for name in ("left", "right")
+            },
+        },
+    )
+    current = _get_param_groups([model], config, get_optimizer_overrides_from_config(config))
+    assert {group["newon_scale"] for group in current} == {0.5, 0.75}
+
+    saved = []
+    for group in reversed(current):
+        saved_group = dict(group)
+        saved_group["_tag"] = f"saved_ns_{group['optimizer_kwargs']['num_ns_steps']}"
+        saved.append(saved_group)
+
+    reordered = MegatronOptimizer._filter_and_reorder_param_groups(current, saved)
+
+    assert [group["_tag"] for group in reordered] == [
+        f"saved_ns_{group['optimizer_kwargs']['num_ns_steps']}" for group in current
+    ]
 
 
 def test_filter_reorder_tolerates_missing_optional_keys():

--- a/tests/unit_tests/test_emerging_optimizers.py
+++ b/tests/unit_tests/test_emerging_optimizers.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
+import copy
 import os
 
 import pytest
@@ -152,7 +153,11 @@ class TestMuonOptimizerMultiRank:
     @pytest.fixture(autouse=True)
     def setup_and_teardown(self):
         """Setup and teardown for each test."""
-        Utils.initialize_model_parallel()
+        tp_size = int(os.getenv('MIXED_OPTIMIZER_TP_SIZE', '1'))
+        pp_size = int(os.getenv('MIXED_OPTIMIZER_PP_SIZE', '1'))
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=tp_size, pipeline_model_parallel_size=pp_size
+        )
         yield
         Utils.destroy_model_parallel()
 
@@ -265,6 +270,298 @@ class TestMuonOptimizerMultiRank:
 
         # Load state dict should not raise error
         optimizer.load_state_dict(state_dict)
+
+    def run_configured_optimizer_arm(self, arm_name, treatment_count, num_steps, tp_size):
+        """Run one deterministic optimizer-routing arm and return its final observables."""
+        torch.manual_seed(42)
+        torch.cuda.manual_seed_all(42)
+        model = Net().bfloat16().cuda()
+        model.requires_grad_(True)
+        model = self.create_ddp_model(model)
+
+        selected_optimizers = {
+            'fc1': 'muon' if treatment_count >= 1 else 'adam',
+            'fc2': 'soap' if treatment_count >= 2 else 'adam',
+            'fc3': 'lion' if treatment_count >= 3 else 'adam',
+        }
+        optimizer_config = OptimizerConfig(
+            optimizer='adam',
+            lr=0.01,
+            weight_decay=0.01,
+            bf16=True,
+            use_distributed_optimizer=False,
+            adam_beta1=0.9,
+            adam_beta2=0.95,
+            adam_eps=1.0e-12,
+            lion_beta1=0.92,
+            lion_beta2=0.98,
+            muon_momentum=0.95,
+            muon_nesterov=True,
+            muon_fp32_matmul_prec="medium",
+            muon_num_ns_steps=5,
+            muon_scale_mode="spectral",
+            muon_tp_mode="duplicated",
+            soap_shampoo_beta=0.95,
+            soap_precondition_frequency=1,
+            soap_use_kl_shampoo=True,
+            overrides_config={
+                "optimizers": {
+                    optimizer_name: {
+                        "type": optimizer_name,
+                        "kwargs": {},
+                        "param_groups": {
+                            "default": {"eps": 1.0e-12} if optimizer_name == "adam" else {}
+                        },
+                    }
+                    for optimizer_name in {"adam", *selected_optimizers.values()}
+                },
+                "default": {"optimizer": "adam", "param_group": "default"},
+                "matchers": {
+                    name: {
+                        "type": "glob",
+                        "pattern": f"*{name}.weight",
+                        "optimizer": optimizer_name,
+                        "param_group": "default",
+                        "enabled": True,
+                    }
+                    for name, optimizer_name in selected_optimizers.items()
+                },
+            },
+        )
+        optimizer = get_megatron_optimizer(
+            config=optimizer_config, model_chunks=[model], use_gloo_process_groups=True
+        )
+
+        expected_optimizers = {'adam', *selected_optimizers.values()}
+        actual_optimizers = {
+            group.get('optimizer', optimizer_config.optimizer) for group in optimizer.param_groups
+        }
+        assert actual_optimizers == expected_optimizers
+        assert len(optimizer.chained_optimizers) == len(expected_optimizers)
+
+        for step in range(num_steps):
+            torch.manual_seed(1000 + step)
+            torch.cuda.manual_seed_all(1000 + step)
+            input_tensor = torch.randn(16, 80, dtype=torch.bfloat16, device='cuda')
+            loss = model(input_tensor).float().square().mean()
+            loss.backward()
+            update_successful, _, _ = optimizer.step()
+            assert update_successful
+            optimizer.zero_grad()
+
+        squared_parameter_norms = [
+            param.detach().float().square().sum() for param in model.parameters()
+        ]
+        parameter_norm = torch.sqrt(torch.stack(squared_parameter_norms).sum())
+        result = torch.stack((loss.detach(), parameter_norm))
+        gathered_results = [
+            torch.empty_like(result) for _ in range(torch.distributed.get_world_size())
+        ]
+        torch.distributed.all_gather(gathered_results, result)
+        assert all(torch.equal(result, other) for other in gathered_results)
+
+        final_loss = loss.detach().item()
+        final_parameter_norm = parameter_norm.item()
+        if torch.distributed.get_rank() == 0:
+            print(
+                "MIXED_OPTIMIZER_RESULT "
+                f"tp={tp_size} arm={arm_name} steps={num_steps} "
+                f"loss={final_loss:.17g} parameter_norm={final_parameter_norm:.17g} "
+                f"optimizers={','.join(sorted(actual_optimizers))}"
+            )
+
+        del optimizer, model
+        torch.cuda.empty_cache()
+        return final_loss, final_parameter_norm
+
+    def test_get_megatron_optimizer_configured_adam_determinism(self):
+        """Two independently initialized Adam runs must have identical final observables."""
+        num_steps = int(os.getenv('MIXED_OPTIMIZER_TEST_STEPS', '1'))
+        tp_size = int(os.getenv('MIXED_OPTIMIZER_TP_SIZE', '1'))
+        deterministic_algorithms_enabled = torch.are_deterministic_algorithms_enabled()
+        torch.use_deterministic_algorithms(True)
+
+        try:
+            adam_a = self.run_configured_optimizer_arm('adam_a', 0, num_steps, tp_size)
+            adam_b = self.run_configured_optimizer_arm('adam_b', 0, num_steps, tp_size)
+            assert adam_a == adam_b
+        finally:
+            torch.use_deterministic_algorithms(deterministic_algorithms_enabled)
+
+    def test_get_megatron_optimizer_configured_mixed_optimizers(self):
+        """Each cumulative Adam/Muon/SOAP/Lion routing change must affect training."""
+        num_steps = int(os.getenv('MIXED_OPTIMIZER_TEST_STEPS', '1'))
+        tp_size = int(os.getenv('MIXED_OPTIMIZER_TP_SIZE', '1'))
+        deterministic_algorithms_enabled = torch.are_deterministic_algorithms_enabled()
+        torch.use_deterministic_algorithms(True)
+
+        try:
+            results = {
+                arm_name: self.run_configured_optimizer_arm(
+                    arm_name, treatment_count, num_steps, tp_size
+                )
+                for arm_name, treatment_count in (
+                    ('adam', 0),
+                    ('muon', 1),
+                    ('soap', 2),
+                    ('lion', 3),
+                )
+            }
+            for previous_arm, current_arm in (('adam', 'muon'), ('muon', 'soap'), ('soap', 'lion')):
+                assert results[current_arm] != results[previous_arm]
+        finally:
+            torch.use_deterministic_algorithms(deterministic_algorithms_enabled)
+
+    def test_configured_optimizer_kwargs_checkpoint_resume(self, request):
+        """Constructor buckets and arbitrary group kwargs survive checkpoint resume."""
+        deterministic_algorithms_enabled = torch.are_deterministic_algorithms_enabled()
+        torch.use_deterministic_algorithms(True)
+        request.addfinalizer(
+            lambda: torch.use_deterministic_algorithms(deterministic_algorithms_enabled)
+        )
+
+        def make_model():
+            return self.create_ddp_model(Net().bfloat16().cuda().requires_grad_(True))
+
+        def make_optimizer(model):
+            config = OptimizerConfig(
+                optimizer='adam',
+                lr=0.01,
+                weight_decay=0.01,
+                bf16=True,
+                use_distributed_optimizer=False,
+                overrides_config={
+                    "optimizers": {
+                        "muon_three": {
+                            "type": "muon",
+                            "kwargs": {"num_ns_steps": 3},
+                            "param_groups": {
+                                "default": {"newon_scale": 0.5},
+                                "secondary": {"newon_scale": 0.6},
+                            },
+                        },
+                        "muon_five": {
+                            "type": "muon",
+                            "kwargs": {"num_ns_steps": 5},
+                            "param_groups": {"default": {"newon_scale": 0.75}},
+                        },
+                        "lion": {
+                            "type": "lion",
+                            "kwargs": {"betas": [0.92, 0.98]},
+                            "param_groups": {"default": {}},
+                        },
+                        "adam": {
+                            "type": "adam",
+                            "kwargs": {},
+                            "param_groups": {"default": {"eps": 1.0e-12}},
+                        },
+                    },
+                    "default": {"optimizer": "adam", "param_group": "default"},
+                    "matchers": {
+                        "fc1": {
+                            "type": "glob",
+                            "pattern": "*fc1.weight",
+                            "optimizer": "muon_three",
+                            "param_group": "default",
+                            "enabled": True,
+                        },
+                        "fc2": {
+                            "type": "glob",
+                            "pattern": "*fc2.weight",
+                            "optimizer": "muon_five",
+                            "param_group": "default",
+                            "enabled": True,
+                        },
+                        "fc3": {
+                            "type": "glob",
+                            "pattern": "*fc3.weight",
+                            "optimizer": "lion",
+                            "param_group": "default",
+                            "enabled": True,
+                        },
+                        "fc4": {
+                            "type": "glob",
+                            "pattern": "*fc4.weight",
+                            "optimizer": "muon_three",
+                            "param_group": "secondary",
+                            "enabled": True,
+                        },
+                    },
+                },
+            )
+            optimizer = get_megatron_optimizer(
+                config=config, model_chunks=[model], use_gloo_process_groups=True
+            )
+            return optimizer
+
+        def train_step(model, optimizer, input_tensor):
+            loss = model(input_tensor).float().square().mean()
+            loss.backward()
+            update_successful, _, _ = optimizer.step()
+            assert update_successful
+            optimizer.zero_grad()
+            return loss.detach()
+
+        def assert_nested_state_equal(expected, actual):
+            if isinstance(expected, torch.Tensor):
+                assert isinstance(actual, torch.Tensor)
+                assert torch.equal(expected, actual)
+            elif isinstance(expected, dict):
+                assert expected.keys() == actual.keys()
+                for key in expected:
+                    assert_nested_state_equal(expected[key], actual[key])
+            elif isinstance(expected, (list, tuple)):
+                assert len(expected) == len(actual)
+                for expected_item, actual_item in zip(expected, actual):
+                    assert_nested_state_equal(expected_item, actual_item)
+            else:
+                assert expected == actual
+
+        torch.manual_seed(42)
+        torch.cuda.manual_seed_all(42)
+        model = make_model()
+        optimizer = make_optimizer(model)
+        muon_groups = [
+            group for group in optimizer.param_groups if group.get("optimizer") == "muon"
+        ]
+        assert sorted(group["optimizer_kwargs"]["num_ns_steps"] for group in muon_groups) == [
+            3,
+            3,
+            5,
+        ]
+        assert sorted(group["newon_scale"] for group in muon_groups) == [0.5, 0.6, 0.75]
+        assert {(group["optimizer_instance"], group["param_group"]) for group in muon_groups} == {
+            ("muon_three", "default"),
+            ("muon_three", "secondary"),
+            ("muon_five", "default"),
+        }
+        assert len(optimizer.chained_optimizers) == 4
+
+        first_input = torch.randn(16, 80, dtype=torch.bfloat16, device='cuda')
+        train_step(model, optimizer, first_input)
+        model_state = copy.deepcopy(model.state_dict())
+        optimizer_state = copy.deepcopy(optimizer.state_dict())
+
+        torch.manual_seed(42)
+        torch.cuda.manual_seed_all(42)
+        resumed_model = make_model()
+        resumed_model.load_state_dict(model_state)
+        resumed_optimizer = make_optimizer(resumed_model)
+        resumed_optimizer.load_state_dict(optimizer_state)
+
+        assert_nested_state_equal(optimizer_state, resumed_optimizer.state_dict())
+        for original_param, resumed_param in zip(model.parameters(), resumed_model.parameters()):
+            assert torch.equal(original_param, resumed_param)
+
+        params_before_resumed_step = [
+            param.detach().clone() for param in resumed_model.parameters()
+        ]
+        second_input = torch.randn(16, 80, dtype=torch.bfloat16, device='cuda')
+        train_step(resumed_model, resumed_optimizer, second_input)
+        assert any(
+            not torch.equal(before, after)
+            for before, after in zip(params_before_resumed_step, resumed_model.parameters())
+        )
 
     def test_get_megatron_optimizer_validation(self):
         """Test validation logic for get_megatron_optimizer."""

--- a/tests/unit_tests/test_optimizer.py
+++ b/tests/unit_tests/test_optimizer.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
+import copy
 import os
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -24,9 +26,16 @@ from megatron.core.optimizer import (
     _get_param_groups,
     check_config_overrides_consistency,
     get_megatron_optimizer,
+    get_mup_config_overrides,
+    get_optimizer_overrides_from_config,
     get_standard_config_overrides,
 )
 from megatron.core.optimizer.distrib_optimizer import DistributedOptimizer
+from megatron.core.optimizer.emerging_optimizers import (
+    _EMERGING_OPTIMIZERS,
+    EmergingOptimizerEntry,
+    _create_emerging_optimizer,
+)
 from megatron.core.optimizer_param_scheduler import ParamGroupOverride
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
@@ -127,6 +136,503 @@ def test_get_param_groups_default_overrides(mock_get_world_size):
     assert wd_mults == {1.0, 0.0}
 
 
+def test_get_optimizer_overrides_from_config_mapping():
+    config = OptimizerConfig(
+        overrides_config={
+            "optimizers": {
+                "soap_main": {
+                    "type": "soap",
+                    "kwargs": {"precondition_frequency": 10},
+                    "param_groups": {
+                        "expert": {
+                            "max_lr": 2.5e-4,
+                            "min_lr": 2.5e-6,
+                            "eps": 1.0e-12,
+                            "wd_mult": 4.0,
+                            "normalize_grads": True,
+                        }
+                    },
+                },
+                "adam_main": {
+                    "type": "adam",
+                    "kwargs": {},
+                    "param_groups": {"default": {}, "norm": {"max_lr": 1.0e-3, "wd_mult": 0.0}},
+                },
+            },
+            "default": {"optimizer": "adam_main", "param_group": "default"},
+            "matchers": {
+                "expert_output": {
+                    "type": "glob",
+                    "pattern": "*.experts.*.linear_fc2.weight",
+                    "optimizer": "soap_main",
+                    "param_group": "expert",
+                    "enabled": True,
+                },
+                "input_norm": {
+                    "type": "glob",
+                    "pattern": "*.input_layernorm.weight",
+                    "optimizer": "adam_main",
+                    "param_group": "norm",
+                    "enabled": True,
+                },
+                "disabled_qk_norm": {
+                    "type": "glob",
+                    "pattern": "*.*_layernorm.weight",
+                    "optimizer": "adam_main",
+                    "param_group": "norm",
+                    "enabled": False,
+                },
+            },
+        }
+    )
+
+    overrides = get_optimizer_overrides_from_config(config)
+    assert len(overrides.matchers) == 2
+    expert_key = next(
+        key for key in overrides.matchers if key.name == "*.experts.*.linear_fc2.weight"
+    )
+    norm_key = next(key for key in overrides.matchers if key.name == "*.input_layernorm.weight")
+    parameter = torch.nn.Parameter(torch.empty(4))
+    assert expert_key.matches(parameter, "decoder.experts.0.linear_fc2.weight")
+    assert not expert_key.matches(parameter, "decoder.linear_fc2.weight")
+    assert norm_key.matches(parameter, "decoder.input_layernorm.weight")
+    assert not norm_key.matches(parameter, "decoder.q_layernorm.weight")
+    assert overrides.resolve(overrides.matchers[expert_key]) == {
+        "max_lr": 2.5e-4,
+        "min_lr": 2.5e-6,
+        "eps": 1.0e-12,
+        "wd_mult": 4.0,
+        "optimizer": "soap",
+        "optimizer_instance": "soap_main",
+        "optimizer_kwargs": {"precondition_frequency": 10},
+        "param_group": "expert",
+        "param_group_kwargs": {"normalize_grads": True},
+    }
+
+
+def test_get_optimizer_overrides_from_config_falls_back_to_standard_overrides():
+    config = OptimizerConfig()
+
+    assert get_optimizer_overrides_from_config(config) == get_standard_config_overrides(config)
+
+
+def test_get_optimizer_overrides_from_config_parsed_namespace():
+    config = OptimizerConfig(
+        overrides_config=SimpleNamespace(
+            optimizers=SimpleNamespace(
+                adam_main=SimpleNamespace(
+                    type="adam",
+                    kwargs={},
+                    param_groups=SimpleNamespace(
+                        default=SimpleNamespace(), hidden=SimpleNamespace(max_lr=1.0e-3)
+                    ),
+                )
+            ),
+            default=SimpleNamespace(optimizer="adam_main", param_group="default"),
+            matchers=SimpleNamespace(
+                fc1=SimpleNamespace(
+                    type="glob",
+                    pattern="*.linear_fc1.weight",
+                    optimizer="adam_main",
+                    param_group="hidden",
+                    enabled=True,
+                )
+            ),
+        )
+    )
+
+    overrides = get_optimizer_overrides_from_config(config)
+    key, target = next(iter(overrides.matchers.items()))
+    assert key.name == "*.linear_fc1.weight"
+    assert overrides.resolve(target) == {
+        "max_lr": 1.0e-3,
+        "optimizer": "adam",
+        "optimizer_instance": "adam_main",
+        "optimizer_kwargs": {},
+        "param_group": "hidden",
+    }
+
+
+def test_get_optimizer_overrides_from_yaml_file(tmp_path):
+    pytest.importorskip("yaml")
+    config_path = tmp_path / "optimizer_overrides.yaml"
+    config_path.write_text(
+        """
+optimizers:
+  adam_main:
+    type: adam
+    kwargs: {}
+    param_groups:
+      default: {}
+      hidden:
+        max_lr: 0.001
+default:
+  optimizer: adam_main
+  param_group: default
+matchers:
+  fc1:
+    type: glob
+    pattern: "*.linear_fc1.weight"
+    optimizer: adam_main
+    param_group: hidden
+    enabled: true
+""",
+        encoding="utf-8",
+    )
+
+    overrides = get_optimizer_overrides_from_config(
+        OptimizerConfig(overrides_config=str(config_path))
+    )
+    key, target = next(iter(overrides.matchers.items()))
+    assert key.name == "*.linear_fc1.weight"
+    assert overrides.resolve(target)["max_lr"] == 1.0e-3
+
+
+@patch('torch.distributed.get_world_size', return_value=1)
+@patch(
+    'torch.distributed.all_gather_object', lambda output_list, obj: output_list.__setitem__(0, obj)
+)
+def test_get_optimizer_overrides_from_config_applies_group_values(mock_get_world_size):
+    model = torch.nn.Module()
+    model.expert_output = torch.nn.Linear(4, 4, bias=False)
+    model.layernorm = torch.nn.LayerNorm(4)
+    config = OptimizerConfig(
+        lr=1.0e-3,
+        min_lr=1.0e-5,
+        overrides_config={
+            "optimizers": {
+                "soap_main": {
+                    "type": "soap",
+                    "kwargs": {"precondition_frequency": 10},
+                    "param_groups": {
+                        "expert": {
+                            "max_lr": 2.5e-4,
+                            "min_lr": 2.5e-6,
+                            "eps": 1.0e-12,
+                            "wd_mult": 4.0,
+                            "normalize_grads": True,
+                            "newon_options": {"mode": "spectral", "steps": [3, 5]},
+                        }
+                    },
+                },
+                "adam_main": {
+                    "type": "adam",
+                    "kwargs": {},
+                    "param_groups": {"default": {}, "layernorm": {"wd_mult": 2.0}},
+                },
+            },
+            "default": {"optimizer": "adam_main", "param_group": "default"},
+            "matchers": {
+                "expert_output": {
+                    "type": "glob",
+                    "pattern": "*expert_output.weight",
+                    "optimizer": "soap_main",
+                    "param_group": "expert",
+                    "enabled": True,
+                },
+                "layernorm_gain": {
+                    "type": "glob",
+                    "pattern": "*layernorm.weight",
+                    "optimizer": "adam_main",
+                    "param_group": "layernorm",
+                    "enabled": True,
+                },
+            },
+        },
+    )
+    overrides = get_optimizer_overrides_from_config(config)
+
+    param_groups = _get_param_groups([model], config, overrides)
+    expert_group = next(
+        group
+        for group in param_groups
+        if any(param is model.expert_output.weight for param in group["params"])
+    )
+
+    assert expert_group["max_lr"] == 2.5e-4
+    assert expert_group["min_lr"] == 2.5e-6
+    assert expert_group["eps"] == 1.0e-12
+    assert expert_group["wd_mult"] == 4.0
+    assert expert_group["optimizer"] == "soap"
+    assert expert_group["optimizer_instance"] == "soap_main"
+    assert expert_group["optimizer_kwargs"] == {"precondition_frequency": 10}
+    assert expert_group["param_group"] == "expert"
+    assert expert_group["param_group_kwargs"] == {
+        "normalize_grads": True,
+        "newon_options": {"mode": "spectral", "steps": [3, 5]},
+    }
+    assert expert_group["normalize_grads"] is True
+    assert expert_group["newon_options"] == {"mode": "spectral", "steps": [3, 5]}
+    layernorm_group = next(
+        group
+        for group in param_groups
+        if any(param is model.layernorm.weight for param in group["params"])
+    )
+    assert layernorm_group["wd_mult"] == 2.0
+
+
+@patch('torch.distributed.get_world_size', return_value=1)
+@patch(
+    'torch.distributed.all_gather_object', lambda output_list, obj: output_list.__setitem__(0, obj)
+)
+def test_configured_matchers_must_resolve_to_one_target(mock_get_world_size):
+    model = torch.nn.Module()
+    model.left = torch.nn.Linear(4, 4, bias=False)
+    base_recipe = {
+        "optimizers": {
+            "adam_main": {
+                "type": "adam",
+                "kwargs": {},
+                "param_groups": {"default": {}, "left": {"eps": 1.0e-8}, "right": {"eps": 1.0e-12}},
+            }
+        },
+        "default": {"optimizer": "adam_main", "param_group": "default"},
+        "matchers": {
+            "all_weights": {
+                "type": "glob",
+                "pattern": "*.weight",
+                "optimizer": "adam_main",
+                "param_group": "left",
+                "enabled": True,
+            },
+            "left_weight": {
+                "type": "glob",
+                "pattern": "left.weight",
+                "optimizer": "adam_main",
+                "param_group": "left",
+                "enabled": True,
+            },
+        },
+    }
+
+    config = OptimizerConfig(lr=1.0e-3, overrides_config=base_recipe)
+    groups = _get_param_groups([model], config, get_optimizer_overrides_from_config(config))
+    assert len(groups) == 1
+    assert groups[0]["param_group"] == "left"
+
+    conflicting_recipe = copy.deepcopy(base_recipe)
+    conflicting_recipe["matchers"]["left_weight"]["param_group"] = "right"
+    config = OptimizerConfig(lr=1.0e-3, overrides_config=conflicting_recipe)
+    with pytest.raises(ValueError, match="matches conflicting optimizer parameter groups"):
+        _get_param_groups([model], config, get_optimizer_overrides_from_config(config))
+
+
+@pytest.mark.parametrize(
+    ("overrides_config", "message"),
+    [
+        ({"bad": {}}, "unsupported fields"),
+        (
+            {
+                "optimizers": {
+                    "bad": {
+                        "type": "adam",
+                        "kwargs": {},
+                        "param_groups": {"default": {}},
+                        "not_an_optimizer_field": 1.0,
+                    }
+                },
+                "default": {"optimizer": "bad", "param_group": "default"},
+                "matchers": {},
+            },
+            "unsupported fields",
+        ),
+        (
+            {
+                "optimizers": {
+                    "bad": {
+                        "type": "adam",
+                        "kwargs": ["not", "a", "mapping"],
+                        "param_groups": {"default": {}},
+                    }
+                },
+                "default": {"optimizer": "bad", "param_group": "default"},
+                "matchers": {},
+            },
+            "kwargs must be a mapping",
+        ),
+        (
+            {
+                "optimizers": {
+                    "bad": {
+                        "type": "adam",
+                        "kwargs": {},
+                        "param_groups": {"default": {"params": "protected"}},
+                    }
+                },
+                "default": {"optimizer": "bad", "param_group": "default"},
+                "matchers": {},
+            },
+            "cannot override protected fields",
+        ),
+        (
+            {
+                "optimizers": {
+                    "valid": {"type": "adam", "kwargs": {}, "param_groups": {"default": {}}}
+                },
+                "default": {"optimizer": "valid", "param_group": "default"},
+                "matchers": {
+                    "bad": {
+                        "type": "glob",
+                        "pattern": "*.weight",
+                        "optimizer": "missing",
+                        "param_group": "default",
+                        "enabled": True,
+                    }
+                },
+            },
+            "unknown optimizer",
+        ),
+        (
+            {
+                "optimizers": {
+                    "valid": {"type": "adam", "kwargs": {}, "param_groups": {"default": {}}}
+                },
+                "default": {"optimizer": "valid", "param_group": "default"},
+                "matchers": {
+                    "bad": {
+                        "type": "regex",
+                        "pattern": ".*weight",
+                        "optimizer": "valid",
+                        "param_group": "default",
+                        "enabled": True,
+                    }
+                },
+            },
+            "type must be 'glob'",
+        ),
+        (
+            {
+                "optimizers": {
+                    "muon_main": {
+                        "type": "muon",
+                        "kwargs": {},
+                        "param_groups": {"bad": {"num_ns_steps": 3}},
+                    }
+                },
+                "default": {"optimizer": "muon_main", "param_group": "bad"},
+                "matchers": {},
+            },
+            "Constructor-only optimizer arguments.*num_ns_steps",
+        ),
+    ],
+)
+def test_get_optimizer_overrides_from_config_rejects_invalid_config(overrides_config, message):
+    with pytest.raises((TypeError, ValueError), match=message):
+        get_optimizer_overrides_from_config(OptimizerConfig(overrides_config=overrides_config))
+
+
+def test_emerging_optimizer_supports_config_only_constructor_kwargs():
+    """A newly registered optimizer can receive new kwargs without OptimizerConfig fields."""
+
+    class NewOn(torch.optim.Optimizer):
+        def __init__(self, params, lr, new_config_kwarg):
+            self.new_config_kwarg = new_config_kwarg
+            super().__init__(params, {"lr": lr})
+
+    entry = EmergingOptimizerEntry(
+        optimizer_cls=NewOn,
+        init_state_fn=lambda optimizer, config=None: None,
+        config_to_kwargs=lambda config, model_chunks, pg_collection: {"lr": config.lr},
+        default_param_overrides={},
+        constructor_only_kwargs=frozenset({"new_config_kwarg"}),
+    )
+    parameter = torch.nn.Parameter(torch.ones(2))
+
+    with patch.dict(_EMERGING_OPTIMIZERS, {"newon": entry}):
+        recipe = get_optimizer_overrides_from_config(
+            OptimizerConfig(
+                overrides_config={
+                    "optimizers": {
+                        "newon_fast": {
+                            "type": "newon",
+                            "kwargs": {"new_config_kwarg": "configured-only-in-yaml"},
+                            "param_groups": {"default": {"new_group_kwarg": 0.75}},
+                        }
+                    },
+                    "default": {"optimizer": "newon_fast", "param_group": "default"},
+                    "matchers": {},
+                }
+            )
+        )
+        resolved_group = recipe.resolve(recipe.default)
+        param_groups = [
+            {"params": [parameter], **resolved_group, **resolved_group["param_group_kwargs"]}
+        ]
+        optimizer, _ = _create_emerging_optimizer(
+            SimpleNamespace(lr=1.0e-3),
+            param_groups,
+            "newon",
+            [],
+            None,
+            optimizer_kwargs=param_groups[0]["optimizer_kwargs"],
+        )
+
+    assert optimizer.new_config_kwarg == "configured-only-in-yaml"
+    assert optimizer.param_groups[0]["new_group_kwarg"] == 0.75
+    assert optimizer.state_dict()["param_groups"][0]["optimizer_kwargs"] == {
+        "new_config_kwarg": "configured-only-in-yaml"
+    }
+
+
+def test_emerging_optimizer_rejects_unknown_constructor_kwargs():
+    class NewOn(torch.optim.Optimizer):
+        def __init__(self, params, lr):
+            super().__init__(params, {"lr": lr})
+
+    entry = EmergingOptimizerEntry(
+        optimizer_cls=NewOn,
+        config_to_kwargs=lambda config, model_chunks, pg_collection: {"lr": config.lr},
+        default_param_overrides={},
+    )
+    with patch.dict(_EMERGING_OPTIMIZERS, {"newon": entry}):
+        with pytest.raises(ValueError, match="Unsupported optimizer_kwargs for newon"):
+            _create_emerging_optimizer(
+                SimpleNamespace(lr=1.0e-3),
+                [{"params": [torch.nn.Parameter(torch.ones(2))]}],
+                "newon",
+                [],
+                None,
+                optimizer_kwargs={"unknown_kwarg": True},
+            )
+
+
+def test_legacy_optimizer_overrides_are_deprecated():
+    with pytest.warns(DeprecationWarning, match="superseded"):
+        get_standard_config_overrides(OptimizerConfig())
+
+    with pytest.warns(DeprecationWarning, match="superseded"):
+        get_mup_config_overrides(OptimizerConfig(), mup_width_mult=1.0)
+
+
+def test_optimizer_override_apis_are_mutually_exclusive():
+    overrides_config = {
+        "optimizers": {
+            "adam_main": {
+                "type": "adam",
+                "kwargs": {},
+                "param_groups": {"default": {}, "weights": {"wd_mult": 0.0}},
+            }
+        },
+        "default": {"optimizer": "adam_main", "param_group": "default"},
+        "matchers": {
+            "weights": {
+                "type": "glob",
+                "pattern": "*.weight",
+                "optimizer": "adam_main",
+                "param_group": "weights",
+                "enabled": True,
+            }
+        },
+    }
+    config = OptimizerConfig(overrides_config=overrides_config)
+    legacy_config_overrides = {ParamKey(name="*.bias"): ParamGroupOverride(wd_mult=0.0)}
+
+    with pytest.raises(AssertionError, match="layernorm-weight-decay and MuP.*None"):
+        get_optimizer_overrides_from_config(config, legacy_config_overrides=legacy_config_overrides)
+    with pytest.raises(AssertionError, match="layernorm-weight-decay and MuP.*None"):
+        get_megatron_optimizer(config, [Net()], config_overrides=legacy_config_overrides)
+
+
 @patch('torch.distributed.get_world_size', return_value=1)
 @patch(
     'torch.distributed.all_gather_object', lambda output_list, obj: output_list.__setitem__(0, obj)
@@ -180,6 +686,41 @@ def test_get_param_groups_multiple_matches(mock_get_world_size):
     param_groups2 = _get_param_groups([net], opt_config, config_overrides)
     assert len(param_groups) == 2
     assert param_groups == param_groups2
+
+
+@patch('torch.distributed.get_world_size', return_value=1)
+@patch(
+    'torch.distributed.all_gather_object', lambda output_list, obj: output_list.__setitem__(0, obj)
+)
+def test_get_param_groups_composes_namespaced_kwargs(mock_get_world_size):
+    model = torch.nn.Module()
+    model.left = torch.nn.Linear(4, 4)
+    overrides = {
+        ParamKey(name="*.weight"): ParamGroupOverride(
+            optimizer_kwargs={"new_config_kwarg": "first"},
+            param_group_kwargs={"new_group_kwarg": 0.5},
+        ),
+        ParamKey(name="left.*"): ParamGroupOverride(
+            optimizer_kwargs={"second_config_kwarg": 3},
+            param_group_kwargs={"second_group_kwarg": True},
+        ),
+    }
+
+    groups = _get_param_groups([model], OptimizerConfig(lr=1.0e-3), overrides)
+    weight_group = next(
+        group for group in groups if any(param is model.left.weight for param in group["params"])
+    )
+
+    assert weight_group["optimizer_kwargs"] == {
+        "new_config_kwarg": "first",
+        "second_config_kwarg": 3,
+    }
+    assert weight_group["param_group_kwargs"] == {
+        "new_group_kwarg": 0.5,
+        "second_group_kwarg": True,
+    }
+    assert weight_group["new_group_kwarg"] == 0.5
+    assert weight_group["second_group_kwarg"] is True
 
 
 @patch('torch.distributed.get_world_size', return_value=1)


### PR DESCRIPTION
Add named optimizer instances, constructor kwargs, and parameter groups to OptimizerConfig overrides. Preserve their identities across checkpoint save/load and model-parallel rank alignment.

- [X] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
Enable configurable per-parameter optimizers.

## Issue tracking

Related to: #5732 in that this provides a sample optimizer configuration approach to enable discussion.

https://github.com/NVIDIA/Megatron-LM/issues/5732

## Contribution process

### Pre-checks

- [X] I have added relevant unit tests
- [X] I have added relevant functional tests
- [X] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [X] I have added relevant documentation
- [X] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

## Summary

- add `OptimizerConfig.overrides_config` as a structured optimizer recipe accepting either a YAML path or an in-memory mapping
- model the recipe after quantization configuration: named optimizer instances own named `param_groups`, enabled glob `matchers` select one exact `(optimizer, param_group)` target, and an explicit `default` handles unmatched parameters
- forward arbitrary alias-level `kwargs` to emerging-optimizer constructors and arbitrary fields in each named parameter group to the optimizer parameter group
- create one runtime optimizer per alias and expert bucket, so one alias can own many parameter groups while two aliases of the same optimizer type can have different constructor arguments
- reject conflicting matcher targets, protected fields, unknown constructor kwargs, and constructor-only Muon settings placed on parameter groups
- retain the legacy standard and MuP override composition path with deprecation warnings; serialized recipes and legacy overrides are mutually exclusive
- reuse the existing emerging-optimizer construction machinery for configured Adam, Muon, SOAP, and Lion chains
- include optimizer alias, named parameter group, constructor kwargs, and group kwargs in stable checkpoint group identity and reorder matching

## Configuration Example and Explanation

```yaml
optimizers:
  adam_main: 
    type: adam
    kwargs: {}
    param_groups: 
      default:
        eps: 1.0e-12

  muon_three:
    type: muon
    kwargs:
      num_ns_steps: 3
    param_groups:
      default:
        newon_scale: 0.5
      secondary: # possible to have multiple named parameter groups under an optimizer, enables muP-style partitioning
        newon_scale: 0.6

  muon_five:
    type: muon
    kwargs:
      num_ns_steps: 5
    param_groups:
      default:
        newon_scale: 0.75

default: # need to assign a default optimizer and parameter group for parameters with no matches
  optimizer: adam_main
  param_group: default

matchers:
  fc1:
    type: glob
    pattern: "*fc1.weight"
    optimizer: muon_three
    param_group: default
    enabled: true
  fc2:
    type: glob
    pattern: "*fc2.weight"
    optimizer: muon_five
    param_group: default
    enabled: true
  fc4:
    type: glob
    pattern: "*fc4.weight"
    optimizer: muon_three
    param_group: secondary
    enabled: true
```

`muon_three` is one optimizer instance with two parameter groups. `muon_five` is a second Muon instance because its instance-wide Newton-Schulz setting differs.

Alias-level `kwargs` are construction-time settings. For a registered emerging optimizer, a newly supported constructor kwarg can therefore be configured without adding another `OptimizerConfig` field; the selected optimizer signature validates it. Parameter-group fields are written directly under `param_groups.<name>`. Muon settings that control the entire instance, such as `num_ns_steps`, `coefficient_type`, and `tp_mode`, are registered as constructor-only and produce a targeted error if placed on a parameter group. Built-in Adam and SGD continue to use their typed `OptimizerConfig` construction surface.

Multiple enabled matchers may match a parameter only if they select the same exact target. Otherwise configuration fails instead of silently composing incompatible groups.

## Checkpoint resume and model parallelism

- optimizer group identity covers every declared `ParamGroupOverride` field, including the optimizer alias, named group, and nested constructor and group kwargs
- nested mappings, sequences, sets, scalars, and `None` are canonicalized deterministically
- ordinary and distributed optimizer checkpoint matching use the same identity
- parameter groups are aligned across ranks before optimizer construction, including empty rank-local groups needed by pipeline and expert layouts
- checkpoint coverage rebuilds a four-instance Adam/Muon/Muon/Lion chain, restores model and optimizer state, verifies the nested state exactly, and performs the next update at TP1/PP1 and TP2/PP2