### PR TITLE
feat(training): wire optimizer state offload lifecycle

### DIFF
--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1669,6 +1669,12 @@ def validate_args(args, defaults={}):
             "must be used in conjunction with `--fp8-recipe delayed`."
         )
 
+    if args.offload_optimizer_states:
+        assert args.use_distributed_optimizer, "offload_optimizer_states is only supported with distributed optimizer"
+        assert args.optimizer == 'adam', "offload_optimizer_states is only supported with adam optimizer"
+        assert not args.use_megatron_fsdp, "offload_optimizer_states does not support Megatron-FSDP for now."
+        assert not args.optimizer_cpu_offload, "offload_optimizer_states can not be used with optimizer_cpu_offload."
+
     if args.non_persistent_ckpt_type == "local":
         assert args.non_persistent_local_ckpt_dir is not None, "Tried to use local checkpointing without specifying --local-ckpt-dir!"
     if args.replication:
@@ -2647,6 +2653,14 @@ def _add_training_args(parser):
                        help='Disable pinning of CPU memory for gradients.')
     group.add_argument('--no-pin-cpu-params', action='store_false', dest='pin_cpu_params',
                        help='Disable pinning of CPU memory for parameters.')
+    group.add_argument('--offload-optimizer-states',
+                       action='store_true',
+                       dest='offload_optimizer_states',
+                       help='Offload optimizer states to CPU after each optimizer step and '
+                       'reload them before the next optimizer step. '
+                       'Only support TE FusedAdam optimizer.'
+                       'Note that this still uses pure GPU optimizer instead of '
+                       'HybridDeviceOptimizer for --optimizer-cpu-offload.')
     group.add_argument('--dataloader-type', type=str, default=None,
                        choices=['single', 'cyclic', 'external'],
                        help='Single pass vs multiple pass data loader')

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -2310,6 +2310,12 @@ def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_sch
     save_dgrads_in_this_iteration = (args.save_dgrads_interval is not None and
                                      (iteration + 1) % args.save_dgrads_interval == 0)
     while rerun_state_machine.should_run_forward_backward(data_iterator):
+        # Offload optimizer states to CPU if enabled.
+        if args.offload_optimizer_states:
+            for optim_instance in optimizer.chained_optimizers:
+                if isinstance(optim_instance, DistributedOptimizer):
+                    optim_instance.offload_states()
+
         # Set grad to zero.
         for model_chunk in model:
             model_chunk.zero_grad_buffer()
@@ -2350,6 +2356,14 @@ def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_sch
                 for optim_instance in optimizer.chained_optimizers:
                     if isinstance(optim_instance, DistributedOptimizer):
                         optim_instance._copy_main_params_to_param_buffer()
+
+        # Release GPU memory for offloaded optimizer states.
+        # This needs to be done after _copy_main_params_to_param_buffer().
+        # Separate offload and release to allow early D2H transfer to overlap with other operations.
+        if args.offload_optimizer_states:
+            for optim_instance in optimizer.chained_optimizers:
+                if isinstance(optim_instance, DistributedOptimizer):
+                    optim_instance.release_offloaded_gpu_states()
 
         # Forward pass.
         if save_activations_in_this_iteration:
@@ -3458,9 +3472,21 @@ def train(
         config.param_sync_func = [model_chunk.start_param_sync for model_chunk in model]
         if len(model) == 1:
             config.param_sync_func = config.param_sync_func[0]
-    # Preserve a builder-installed finalize hook; only default it when unset.
-    if config.finalize_model_grads_func is None:
-        config.finalize_model_grads_func = finalize_model_grads
+    # Wrap finalize_model_grads to reload offloaded optimizer states before grad finalization.
+    # This allows H2D transfer to overlap with grad all-reduce.
+    base_finalize_model_grads = config.finalize_model_grads_func or finalize_model_grads
+    if args.offload_optimizer_states:
+
+        def finalize_model_grads_with_state_reload(*fmg_args, **fmg_kwargs):
+            # Reload offloaded states for all DistributedOptimizer instances
+            for optim_instance in optimizer.chained_optimizers:
+                if isinstance(optim_instance, DistributedOptimizer):
+                    optim_instance.reload_offloaded_states()
+            return base_finalize_model_grads(*fmg_args, **fmg_kwargs)
+
+        config.finalize_model_grads_func = finalize_model_grads_with_state_reload
+    elif config.finalize_model_grads_func is None:
+        config.finalize_model_grads_func = base_finalize_model_grads
 
     if args.log_energy:
         energy_monitor.setup()


### PR DESCRIPTION
## What

Wire the optimizer-state offloader into the training lifecycle:

- expose and validate --offload-optimizer-states;
- begin D2H offload before the forward pass;
- release GPU storage after any early parameter-buffer copy;
- begin H2D reload from the gradient-finalization hook so it overlaps gradient synchronization;
- preserve a builder-installed finalize_model_grads_func instead of overwriting it.

## Stack

- Depends on #5933.
- Temporary review base: pull-request/5933.
- Files changed intentionally contains only megatron/training/arguments.py and megatron/training/training.py.
- Before #5933 merges, this PR must be retargeted and refreshed to main to preserve its review history.

## Provenance

- Refreshes the dev implementation from #2987 and its earlier main port #2811.
- Refactors the same feature captured in #5795 (commit 152877ba).
- Original implementation by @hxbai, @yaox12, and the source authors.
- Feature cutoff: 2026-07-21. GPTModel is unrelated and absent.

## Testing

- uv run ruff check megatron/training/arguments.py megatron/training/training.py
- uv run python -m compileall -q megatron/training/arguments.py megatron/training/training.py
- git diff --check
- End-to-end CUDA behavior is covered by the parent implementation tests and will run in stack CI.