### PR TITLE
feat(recompute): coordinate checkpoint-without-output recomputation

### DIFF
--- a/megatron/core/tensor_parallel/random.py
+++ b/megatron/core/tensor_parallel/random.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 # Parts of the code here are adapted from PyTorch
 # repo: https://github.com/pytorch/pytorch
@@ -598,7 +598,9 @@ class CheckpointFunction(torch.autograd.Function):
     @staticmethod
     def backward(ctx, *args):
         """Backward pass."""
-        if not torch.autograd._is_checkpoint_valid():
+        from megatron.core.transformer.cuda_graphs import is_graph_capturing
+
+        if not torch.autograd._is_checkpoint_valid() and not is_graph_capturing():
             raise RuntimeError(
                 "Checkpointing is not compatible with .grad(), "
                 "please use .backward() if possible"
@@ -649,10 +651,67 @@ def checkpoint(
     return CheckpointFunction.apply(function, distribute_saved_activations, *args)
 
 
+def _save_args_to_ctx(ctx, args):
+    """Save mixed tensor/non-tensor arguments into autograd ctx.
+
+    Since save_for_backward only supports tensors, this function separates
+    tensor and non-tensor arguments, saving tensors via save_for_backward
+    and storing non-tensor metadata (indices and values) as ctx attributes.
+
+    Use _load_args_from_ctx to reconstruct the original args.
+    """
+    tensor_args = []
+    non_tensor_entries = []
+
+    for index, arg in enumerate(args):
+        if isinstance(arg, torch.Tensor):
+            tensor_args.append(arg)
+            continue
+        non_tensor_entries.append((index, arg))
+
+    ctx.save_for_backward(*detach_variable(tuple(tensor_args)))
+    ctx._non_tensor_entries = tuple(non_tensor_entries)
+    ctx._total_args_count = len(args)
+
+
+def _load_args_from_ctx(ctx):
+    """Load and reconstruct mixed tensor/non-tensor arguments from autograd ctx.
+
+    This is the inverse of _save_args_to_ctx. It retrieves tensors from
+    ctx.saved_tensors and merges them with stored non-tensor arguments
+    to reconstruct the original args in their original order.
+
+    Returns:
+        tuple of reconstructed arguments in their original order.
+    """
+
+    def _detach_with_grad(tensor):
+        detached = tensor.detach()
+        detached.requires_grad_(tensor.requires_grad)
+        return detached
+
+    tensor_iter = iter(_detach_with_grad(t) for t in ctx.saved_tensors)
+    total_args_count = ctx._total_args_count
+    non_tensor_map = dict(ctx._non_tensor_entries)
+
+    reconstructed_args = []
+    for index in range(total_args_count):
+        if index in non_tensor_map:
+            reconstructed_args.append(non_tensor_map[index])
+        else:
+            reconstructed_args.append(next(tensor_iter))
+    return tuple(reconstructed_args)
+
+
 class CheckpointWithoutOutputFunction(torch.autograd.Function):
     """
     Checkpoint Function Helper for CheckpointWithoutOutput.
     Save context for recompute.
+
+    Handles both tensor and non-tensor arguments:
+    - Tensor arguments are saved via save_for_backward
+    - Non-tensor arguments (int, float, bool, None, etc.) are stored separately
+      in ctx attributes and reconstructed during recomputation
     """
 
     @staticmethod
@@ -675,7 +734,10 @@ class CheckpointWithoutOutputFunction(torch.autograd.Function):
 
         with torch.no_grad(), fwd_ctx:
             outputs = run_function(*args)
-        ctx.save_for_backward(*detach_variable(args))
+
+        # Save tensor and non-tensor arguments into ctx for recomputation
+        _save_args_to_ctx(ctx, args)
+
         # the CheckpointWithoutOutput object is passed in, then it can access the saved input
         # tensors later for recomputation
         checkpoint_without_output_obj.ctx = ctx
@@ -692,8 +754,54 @@ class CheckpointWithoutOutputFunction(torch.autograd.Function):
         torch.autograd.backward(outputs, args)
         ctx.outputs = None
         ctx.inputs = None
-        grads = tuple(inp.grad if isinstance(inp, torch.Tensor) else inp for inp in inputs)
+        grads = tuple(inp.grad if isinstance(inp, torch.Tensor) else None for inp in inputs)
         return (None, None) + grads
+
+
+class CheckpointManager:
+    """
+    Manages multiple CheckpointWithoutOutput objects within a TransformerBlock
+    cross layer recomputations, enabling unified recomputation during backward pass.
+    This is particularly useful for scenarios where multiple checkpoint operations have
+    sequential dependencies (i.e., the output of one checkpoint is the input of the next).
+
+    Usage:
+        ckptManager = CheckpointManager()
+        ckpt_function = CheckpointWithoutOutput(ckpt_manager=ckptManager)
+        ckpt_function.checkpoint(run_function, *args)
+        # other checkpointed operations
+        ckpt_manager.discard_all_outputs_and_register_unified_recompute(final_output)
+    """
+
+    def __init__(self):
+        self.checkpoints = []
+        # Set by TransformerBlock before each layer forward.
+        # When True, the layer should keep block-boundary output uncheckpointed.
+        self.is_last_layer_in_recompute_block = False
+
+    def add_checkpoint(self, ckpt):
+        """Add a checkpoint to the manager."""
+        if not isinstance(ckpt, CheckpointWithoutOutput):
+            raise TypeError("Expected CheckpointWithoutOutput object")
+        if ckpt.outputs is None:
+            raise ValueError("CheckpointWithoutOutput must call checkpoint() before adding")
+        self.checkpoints.append(ckpt)
+
+    def discard_all_outputs_and_register_unified_recompute(self, hook_tensor):
+        """Discard all checkpoint outputs to save memory and register unified recompute hook."""
+        for ckpt in self.checkpoints:
+            for output in ckpt.outputs:
+                output.untyped_storage().resize_(0)
+
+        # Register unified recompute hook
+        if hook_tensor.requires_grad:
+            hook_tensor.register_hook(self._unified_recompute_hook)
+
+    def _unified_recompute_hook(self, grad_output):
+        for ckpt in self.checkpoints:
+            # Call _recompute for each checkpoint in forward order
+            # The _recompute method will restore the output tensor storage
+            ckpt._recompute(None)
 
 
 class CheckpointWithoutOutput(object):
@@ -710,8 +818,19 @@ class CheckpointWithoutOutput(object):
     discarded output tensors are directly saved in the following modules for backward computation.
     """
 
-    def __init__(self, fp8=False):
-        self.fp8 = fp8 is not None
+    def __init__(self, fp8=False, ckpt_manager=None):
+        """
+        Initialize CheckpointWithoutOutput.
+
+        Args:
+            fp8: Whether to use FP8 mode. Defaults to False.
+            ckpt_manager: Optional CheckpointManager instance. When provided,
+                         checkpoint() will auto-register to the manager, and
+                         discard_output_and_register_recompute() will only discard
+                         output without registering individual hooks.
+        """
+        self.fp8 = bool(fp8)
+        self.ckpt_manager = ckpt_manager
         self.run_function = None
         self.fwd_cpu_rng_state = None
         self.fwd_cuda_rng_state = None
@@ -720,7 +839,12 @@ class CheckpointWithoutOutput(object):
         self.outputs = None
 
     def checkpoint(self, run_function: Callable[[Unpack[_Ts]], _R], *args: Unpack[_Ts]) -> _R:
-        """Checkpoint function."""
+        """
+        Checkpoint function.
+
+        If ckpt_manager was provided during initialization, this checkpoint
+        will be automatically registered to the manager after execution.
+        """
 
         # If in cuda graph warmup, disable checkpointing, as 'discard_output_and_register_recompute'
         # may be called in a separate graph warmup.
@@ -737,6 +861,11 @@ class CheckpointWithoutOutput(object):
         self.outputs = outputs
         if isinstance(self.outputs, torch.Tensor):
             self.outputs = (self.outputs,)
+
+        # Auto-register to manager if provided
+        if self.ckpt_manager is not None:
+            self.ckpt_manager.add_checkpoint(self)
+
         return outputs
 
     def _recompute(self, _):
@@ -745,7 +874,7 @@ class CheckpointWithoutOutput(object):
         from megatron.core.transformer.cuda_graphs import is_graph_capturing, is_graph_warmup
 
         # The recomputation has been triggered already. Just return.
-        # Handle cudagraphs, do nothing if currently in graph warmup
+        # Handle cudagraphs: do nothing if currently in graph warmup
         if self.ctx is None or is_graph_warmup():
             return
 
@@ -767,17 +896,8 @@ class CheckpointWithoutOutput(object):
                 recompute_ctx = contextlib.nullcontext()
                 fp8_ctx = contextlib.nullcontext()
 
-            # Store the inputs for backward pass
-            inputs = self.ctx.saved_tensors
-
-            def detach(t):
-                if isinstance(t, torch.Tensor):
-                    requires_grad = t.requires_grad
-                    t = t.detach()
-                    t.requires_grad_(requires_grad)
-                return t
-
-            inputs = tuple(detach(t) for t in inputs)
+            # Reconstruct full args list from saved ctx
+            inputs = _load_args_from_ctx(self.ctx)
             with torch.enable_grad(), fp8_ctx, recompute_ctx:
                 outputs = self.run_function(*inputs)
 
@@ -810,10 +930,11 @@ class CheckpointWithoutOutput(object):
         in the forward pass and the gradient of the hook_tensor is computed before the recomputed
         tensors are used.
         """
-
+        # When ckpt_manager is set, this is a no-op.
+        # Manager handles all discarding and hook registration uniformly.
         from megatron.core.transformer.cuda_graphs import is_graph_warmup
 
-        if is_graph_warmup():
+        if self.ckpt_manager is not None or is_graph_warmup():
             return
 
         # use resize to release the output tensor memory and still keep the metadata in the tensors.

--- a/tests/unit_tests/transformer/test_mhc_block_manager.py
+++ b/tests/unit_tests/transformer/test_mhc_block_manager.py
@@ -1,0 +1,397 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import pytest
+import torch
+
+from megatron.core.tensor_parallel.random import (
+    CheckpointManager,
+    CheckpointWithoutOutput,
+    initialize_rng_tracker,
+)
+from tests.unit_tests.test_utilities import Utils
+
+
+class TestCheckpointWithoutOutputManagerAPI:
+    """Test CheckpointWithoutOutput integration with CheckpointManager."""
+
+    def setup_method(self, method):
+        Utils.initialize_model_parallel()
+        initialize_rng_tracker(force_reset=True)
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    def test_auto_register(self):
+        """CheckpointWithoutOutput auto-registers to manager when ckpt_manager is provided."""
+        manager = CheckpointManager()
+
+        def func(x):
+            return x * 2 + 1
+
+        input_t = torch.randn(4, 4, device='cuda', requires_grad=True)
+
+        ckpt = CheckpointWithoutOutput(ckpt_manager=manager)
+        y = ckpt.checkpoint(func, input_t)
+
+        assert len(manager.checkpoints) == 1
+        assert manager.checkpoints[0] is ckpt
+
+        ckpt2 = CheckpointWithoutOutput(ckpt_manager=manager)
+        y2 = ckpt2.checkpoint(torch.nn.functional.gelu, y)
+
+        assert len(manager.checkpoints) == 2
+        assert manager.checkpoints[1] is ckpt2
+
+        loss = y2.sum()
+        manager.discard_all_outputs_and_register_unified_recompute(loss)
+        loss.backward()
+
+        assert input_t.grad is not None
+
+    def test_discard_is_noop_with_manager(self):
+        """discard_output_and_register_recompute is a NO-OP when ckpt_manager is set."""
+        manager = CheckpointManager()
+
+        def func1(x):
+            return x * 2
+
+        def func2(x):
+            return torch.nn.functional.gelu(x)
+
+        input_ref = torch.randn(4, 4, device='cuda', requires_grad=True)
+        y1_ref = func1(input_ref)
+        y2_ref = func2(y1_ref)
+        loss_ref = y2_ref.sum()
+        loss_ref.backward()
+        grad_ref = input_ref.grad.clone()
+
+        input_ckpt = input_ref.detach().clone().requires_grad_(True)
+
+        ckpt1 = CheckpointWithoutOutput(ckpt_manager=manager)
+        y1 = ckpt1.checkpoint(func1, input_ckpt)
+        ckpt1.discard_output_and_register_recompute(y1)
+
+        ckpt2 = CheckpointWithoutOutput(ckpt_manager=manager)
+        y2 = ckpt2.checkpoint(func2, y1)
+        ckpt2.discard_output_and_register_recompute(y2)
+
+        assert y1.untyped_storage().size() > 0, "y1 should NOT be discarded yet"
+        assert y2.untyped_storage().size() > 0, "y2 should NOT be discarded yet"
+
+        loss_ckpt = y2.sum()
+        manager.discard_all_outputs_and_register_unified_recompute(loss_ckpt)
+
+        assert y1.untyped_storage().size() == 0, "y1 should be discarded after manager call"
+        assert y2.untyped_storage().size() == 0, "y2 should be discarded after manager call"
+
+        loss_ckpt.backward()
+        grad_ckpt = input_ckpt.grad.clone()
+
+        assert torch.allclose(grad_ckpt, grad_ref, atol=1e-6)
+
+    def test_backward_compat_without_manager(self):
+        """CheckpointWithoutOutput without ckpt_manager should work exactly as before."""
+
+        def func(x):
+            return torch.nn.functional.gelu(x)
+
+        input_ref = torch.randn(4, 4, device='cuda', requires_grad=True)
+        y_ref = func(input_ref)
+        z_ref = y_ref * 2
+        loss_ref = z_ref.sum()
+        loss_ref.backward()
+        grad_ref = input_ref.grad.clone()
+
+        input_ckpt = input_ref.detach().clone().requires_grad_(True)
+
+        ckpt = CheckpointWithoutOutput()
+        y = ckpt.checkpoint(func, input_ckpt)
+        z = y * 2
+        ckpt.discard_output_and_register_recompute(z)
+
+        assert y.untyped_storage().size() == 0
+
+        loss_ckpt = z.sum()
+        loss_ckpt.backward()
+        grad_ckpt = input_ckpt.grad.clone()
+
+        assert torch.allclose(grad_ckpt, grad_ref, atol=1e-6)
+
+    def test_error_handling(self):
+        """CheckpointManager rejects invalid add_checkpoint calls."""
+        manager = CheckpointManager()
+
+        with pytest.raises(TypeError):
+            manager.add_checkpoint("not a checkpoint")
+
+        ckpt = CheckpointWithoutOutput()
+        with pytest.raises(ValueError):
+            manager.add_checkpoint(ckpt)
+
+
+class TestCheckpointManagerSequentialChain:
+    """Test CheckpointManager with sequential checkpoint chains."""
+
+    def setup_method(self, method):
+        Utils.initialize_model_parallel()
+        initialize_rng_tracker(force_reset=True)
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    def test_basic_sequential_chain(self):
+        """Three sequential checkpoints: gradients match non-checkpointed version."""
+
+        def func1(x):
+            return x * 2 + 1
+
+        def func2(x):
+            return torch.nn.functional.gelu(x)
+
+        def func3(x):
+            return x * x + x
+
+        input_ref = torch.randn(4, 4, device='cuda', requires_grad=True)
+        input_ckpt = input_ref.detach().clone().requires_grad_(True)
+
+        y1_ref = func1(input_ref)
+        y2_ref = func2(y1_ref)
+        y3_ref = func3(y2_ref)
+        loss_ref = y3_ref.sum()
+        loss_ref.backward()
+        grad_ref = input_ref.grad.clone()
+
+        manager = CheckpointManager()
+
+        y1 = CheckpointWithoutOutput(ckpt_manager=manager).checkpoint(func1, input_ckpt)
+        y2 = CheckpointWithoutOutput(ckpt_manager=manager).checkpoint(func2, y1)
+        y3 = CheckpointWithoutOutput(ckpt_manager=manager).checkpoint(func3, y2)
+
+        loss_ckpt = y3.sum()
+        manager.discard_all_outputs_and_register_unified_recompute(loss_ckpt)
+
+        assert y1.untyped_storage().size() == 0, "y1 storage should be released"
+        assert y2.untyped_storage().size() == 0, "y2 storage should be released"
+        assert y3.untyped_storage().size() == 0, "y3 storage should be released"
+
+        loss_ckpt.backward()
+        grad_ckpt = input_ckpt.grad.clone()
+
+        assert torch.allclose(
+            grad_ckpt, grad_ref, atol=1e-6
+        ), f"Gradients mismatch!\nWith manager: {grad_ckpt}\nReference: {grad_ref}"
+
+    def test_sequential_chain_with_dropout(self):
+        """RNG state is restored during recompute so dropout gradients match."""
+
+        def func_with_dropout(x):
+            return torch.nn.functional.dropout(x, p=0.3, training=True)
+
+        def func2(x):
+            return torch.nn.functional.gelu(x)
+
+        input_ref = torch.randn(4, 4, device='cuda', requires_grad=True)
+        input_ckpt = input_ref.detach().clone().requires_grad_(True)
+
+        torch.manual_seed(42)
+        torch.cuda.manual_seed(42)
+
+        y1_ref = func_with_dropout(input_ref)
+        y2_ref = func2(y1_ref)
+        loss_ref = y2_ref.sum()
+        loss_ref.backward()
+        grad_ref = input_ref.grad.clone()
+
+        torch.manual_seed(42)
+        torch.cuda.manual_seed(42)
+
+        manager = CheckpointManager()
+
+        y1 = CheckpointWithoutOutput(ckpt_manager=manager).checkpoint(func_with_dropout, input_ckpt)
+        y2 = CheckpointWithoutOutput(ckpt_manager=manager).checkpoint(func2, y1)
+
+        loss_ckpt = y2.sum()
+        manager.discard_all_outputs_and_register_unified_recompute(loss_ckpt)
+
+        loss_ckpt.backward()
+        grad_ckpt = input_ckpt.grad.clone()
+
+        assert torch.allclose(
+            grad_ckpt, grad_ref, atol=1e-6
+        ), f"Gradients with dropout mismatch!\nWith manager: {grad_ckpt}\nReference: {grad_ref}"
+
+    def test_multiple_outputs(self):
+        """CheckpointManager handles functions that return multiple outputs."""
+
+        def func_multi_output(x):
+            return x * 2, x + 1
+
+        def func_combine(a, b):
+            return a + b
+
+        input_ref = torch.randn(4, 4, device='cuda', requires_grad=True)
+        input_ckpt = input_ref.detach().clone().requires_grad_(True)
+
+        y1a_ref, y1b_ref = func_multi_output(input_ref)
+        y2_ref = func_combine(y1a_ref, y1b_ref)
+        loss_ref = y2_ref.sum()
+        loss_ref.backward()
+        grad_ref = input_ref.grad.clone()
+
+        manager = CheckpointManager()
+
+        y1a, y1b = CheckpointWithoutOutput(ckpt_manager=manager).checkpoint(
+            func_multi_output, input_ckpt
+        )
+        y2 = CheckpointWithoutOutput(ckpt_manager=manager).checkpoint(func_combine, y1a, y1b)
+
+        loss_ckpt = y2.sum()
+        manager.discard_all_outputs_and_register_unified_recompute(loss_ckpt)
+
+        loss_ckpt.backward()
+        grad_ckpt = input_ckpt.grad.clone()
+
+        assert torch.allclose(grad_ckpt, grad_ref, atol=1e-6), (
+            f"Gradients mismatch with multiple outputs!\n"
+            f"With manager: {grad_ckpt}\nReference: {grad_ref}"
+        )
+
+
+class TestCheckpointManagerPartialCheckpoint:
+    """Test CheckpointManager with partial checkpointing (some ops not checkpointed)."""
+
+    def setup_method(self, method):
+        Utils.initialize_model_parallel()
+        initialize_rng_tracker(force_reset=True)
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    def test_partial_checkpoint(self):
+        """
+        Only f and h are checkpointed; g is a regular operation.
+
+        Computation chain:
+            a --[f]--> b --[g]--> c --[h]--> d --[sum]--> loss
+        """
+
+        def func_f(x):
+            return torch.nn.functional.gelu(x * 2 + 1)
+
+        def func_g(x):
+            return x * 3 - 2
+
+        def func_h(x):
+            return torch.sigmoid(x) + x
+
+        input_ref = torch.randn(4, 4, device='cuda', requires_grad=True)
+
+        b_ref = func_f(input_ref)
+        c_ref = func_g(b_ref)
+        d_ref = func_h(c_ref)
+        loss_ref = d_ref.sum()
+        loss_ref.backward()
+        grad_ref = input_ref.grad.clone()
+
+        input_ckpt = input_ref.detach().clone().requires_grad_(True)
+
+        manager = CheckpointManager()
+
+        b = CheckpointWithoutOutput(ckpt_manager=manager).checkpoint(func_f, input_ckpt)
+        c = func_g(b)
+        d = CheckpointWithoutOutput(ckpt_manager=manager).checkpoint(func_h, c)
+
+        loss_ckpt = d.sum()
+        manager.discard_all_outputs_and_register_unified_recompute(loss_ckpt)
+
+        assert b.untyped_storage().size() == 0, "b storage should be released"
+        assert d.untyped_storage().size() == 0, "d storage should be released"
+        assert c.untyped_storage().size() > 0, "c storage should NOT be released (not checkpointed)"
+
+        loss_ckpt.backward()
+        grad_ckpt = input_ckpt.grad.clone()
+
+        assert torch.allclose(grad_ckpt, grad_ref, atol=1e-6), (
+            f"Gradients mismatch with partial checkpoint!\n"
+            f"With manager: {grad_ckpt}\nReference: {grad_ref}"
+        )
+
+    def test_partial_checkpoint_with_tuple_output(self):
+        """
+        Mimics HyperConnection's computation pattern with tuple outputs.
+
+        - compute_mappings: checkpointed, returns tuple (h_pre, h_post, h_res)
+        - aggregate: NOT checkpointed
+        - apply_h_res: checkpointed
+        - apply_h_post: checkpointed
+        """
+
+        def compute_mappings(x):
+            h_pre = torch.sigmoid(x.mean(dim=-1, keepdim=True).expand_as(x))
+            h_post = torch.tanh(x.sum(dim=-1, keepdim=True).expand_as(x))
+            h_res = torch.relu(x)
+            return h_pre, h_post, h_res
+
+        def aggregate(x, h_pre):
+            return x * h_pre
+
+        def apply_h_res(h_res, residual):
+            return h_res + residual * 0.5
+
+        def apply_h_post(y, h_post):
+            return y * h_post + y
+
+        x_ref = torch.randn(4, 4, device='cuda', requires_grad=True)
+        residual_ref = torch.randn(4, 4, device='cuda', requires_grad=True)
+
+        h_pre_ref, h_post_ref, h_res_ref = compute_mappings(x_ref)
+        agg_ref = aggregate(x_ref, h_pre_ref)
+        y_ref = torch.nn.functional.gelu(agg_ref)
+        mixed_ref = apply_h_res(h_res_ref, residual_ref)
+        output_ref = apply_h_post(y_ref, h_post_ref)
+        final_ref = output_ref + mixed_ref
+        loss_ref = final_ref.sum()
+        loss_ref.backward()
+        grad_x_ref = x_ref.grad.clone()
+        grad_residual_ref = residual_ref.grad.clone()
+
+        x_ckpt = x_ref.detach().clone().requires_grad_(True)
+        residual_ckpt = residual_ref.detach().clone().requires_grad_(True)
+
+        manager = CheckpointManager()
+
+        h_pre, h_post, h_res = CheckpointWithoutOutput(ckpt_manager=manager).checkpoint(
+            compute_mappings, x_ckpt
+        )
+        agg = aggregate(x_ckpt, h_pre)
+        y = torch.nn.functional.gelu(agg)
+        mixed = CheckpointWithoutOutput(ckpt_manager=manager).checkpoint(
+            apply_h_res, h_res, residual_ckpt
+        )
+        output = CheckpointWithoutOutput(ckpt_manager=manager).checkpoint(apply_h_post, y, h_post)
+
+        final = output + mixed
+        loss_ckpt = final.sum()
+
+        manager.discard_all_outputs_and_register_unified_recompute(loss_ckpt)
+
+        assert h_pre.untyped_storage().size() == 0, "h_pre storage should be released"
+        assert h_post.untyped_storage().size() == 0, "h_post storage should be released"
+        assert h_res.untyped_storage().size() == 0, "h_res storage should be released"
+        assert mixed.untyped_storage().size() == 0, "mixed storage should be released"
+        assert output.untyped_storage().size() == 0, "output storage should be released"
+
+        assert agg.untyped_storage().size() > 0, "agg storage should NOT be released"
+        assert y.untyped_storage().size() > 0, "y storage should NOT be released"
+
+        loss_ckpt.backward()
+        grad_x_ckpt = x_ckpt.grad.clone()
+        grad_residual_ckpt = residual_ckpt.grad.clone()
+
+        assert torch.allclose(
+            grad_x_ckpt, grad_x_ref, atol=1e-6
+        ), f"Gradients for x mismatch!\nWith manager: {grad_x_ckpt}\nReference: {grad_x_ref}"
+        assert torch.allclose(grad_residual_ckpt, grad_residual_ref, atol=1e-6), (
+            f"Gradients for residual mismatch!\n"
+            f"With manager: {grad_residual_ckpt}\nReference: {grad_residual_ref}"
+        )


### PR DESCRIPTION
## What

Extend CheckpointWithoutOutput so it can safely coordinate several sequential checkpointed operations:

- preserve mixed tensor and non-tensor arguments through recompute;
- return None gradients for metadata arguments;
- add a CheckpointManager that discards all managed outputs and registers one ordered recompute hook;
- preserve CUDA-graph capture behavior;
- add focused unit coverage for argument restoration, hook ordering, storage reuse, gradients, and edge cases.

This reusable recompute primitive is the root of the HybridModel mHC lane, but contains no mHC, model, or GPTModel code itself.

## Provenance

- Reconstructs the checkpoint-management portion of the mHC work from #2943 and the current main proposal #4531.
- Refactors the same implementation captured in #5795 (commit 07c0d088).
- Original implementation by the #2943/#4531 authors; DSv4 adaptation by @hxbai.
- Reconstructed against current main; feature cutoff: 2026-07-21.
- GPTModel integration is intentionally excluded.

## Testing

- uv run isort --check-only on both changed Python files
- uv run ruff check on both changed Python files
- uv run python -m compileall -q on both changed Python files
- Focused tests are included; local execution requires the project Torch runtime and is left to CI.

## Stack follow-up

- #5936 contains the next logical slice and temporarily targets this PR mirror.