### PR TITLE
Complete clamped SwiGLU across expert paths

### DIFF
--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -2006,12 +2006,23 @@ if HAVE_TE and is_te_min_version("1.9.0.dev0"):
                 tp_group_for_te = None
 
             if is_te_min_version("2.14.0"):
-                extra_kwargs["single_grouped_weight"] = getattr(
-                    config, "moe_single_grouped_weight", False
-                )
-                extra_kwargs["single_grouped_bias"] = getattr(
-                    config, "moe_single_grouped_bias", False
-                )
+                # Some TE 2.14 builds predate these keyword arguments. Cache the
+                # installed constructor signature instead of relying on the version alone.
+                global _TE_GROUPED_LINEAR_INIT_PARAMS
+                try:
+                    grouped_linear_init_params = _TE_GROUPED_LINEAR_INIT_PARAMS
+                except NameError:
+                    grouped_linear_init_params = _TE_GROUPED_LINEAR_INIT_PARAMS = set(
+                        inspect.signature(te.pytorch.GroupedLinear.__init__).parameters
+                    )
+                if "single_grouped_weight" in grouped_linear_init_params:
+                    extra_kwargs["single_grouped_weight"] = getattr(
+                        config, "moe_single_grouped_weight", False
+                    )
+                if "single_grouped_bias" in grouped_linear_init_params:
+                    extra_kwargs["single_grouped_bias"] = getattr(
+                        config, "moe_single_grouped_bias", False
+                    )
 
             self.te_quant_params: Optional[TEQuantizationParams] = None
             quant_config = get_quant_config_or_none(name, config.quant_recipe)

--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -2424,12 +2424,23 @@ if HAVE_TE and is_te_min_version("1.9.0.dev0"):
                 tp_group_for_te = None
 
             if is_te_min_version("2.14.0"):
-                extra_kwargs["single_grouped_weight"] = getattr(
-                    config, "moe_single_grouped_weight", False
-                )
-                extra_kwargs["single_grouped_bias"] = getattr(
-                    config, "moe_single_grouped_bias", False
-                )
+                # Some TE 2.14 builds predate these keyword arguments. Cache the
+                # installed constructor signature instead of relying on the version alone.
+                global _TE_GROUPED_LINEAR_INIT_PARAMS
+                try:
+                    grouped_linear_init_params = _TE_GROUPED_LINEAR_INIT_PARAMS
+                except NameError:
+                    grouped_linear_init_params = _TE_GROUPED_LINEAR_INIT_PARAMS = set(
+                        inspect.signature(te.pytorch.GroupedLinear.__init__).parameters
+                    )
+                if "single_grouped_weight" in grouped_linear_init_params:
+                    extra_kwargs["single_grouped_weight"] = getattr(
+                        config, "moe_single_grouped_weight", False
+                    )
+                if "single_grouped_bias" in grouped_linear_init_params:
+                    extra_kwargs["single_grouped_bias"] = getattr(
+                        config, "moe_single_grouped_bias", False
+                    )
 
             self.te_quant_params: Optional[TEQuantizationParams] = None
             quant_config = get_quant_config_or_none(name, config.quant_recipe)

--- a/megatron/core/fusions/fused_bias_swiglu.py
+++ b/megatron/core/fusions/fused_bias_swiglu.py
@@ -48,6 +48,31 @@ def weighted_swiglu(y, weights):
     return res.to(dtype)
 
 
+@jit_fuser
+def clamped_swiglu(y, clamp_value):
+    """Perform SwiGLU after clamping both halves of the input."""
+    dtype = y.dtype
+    y_1, y_2 = torch.chunk(y.to(torch.float32), 2, -1)
+    y_1 = y_1.clamp(min=None, max=clamp_value)
+    y_2 = y_2.clamp(min=-clamp_value, max=clamp_value)
+    res = F.silu(y_1) * y_2
+    return res.to(dtype)
+
+
+@jit_fuser
+def bias_clamped_swiglu(y, bias, clamp_value):
+    """Perform clamped SwiGLU after bias addition."""
+    return clamped_swiglu(y + bias, clamp_value)
+
+
+@jit_fuser
+def clamped_weighted_swiglu(y, weights, clamp_value):
+    """Perform token-weighted clamped SwiGLU."""
+    dtype = y.dtype
+    res = clamped_swiglu(y, clamp_value) * weights
+    return res.to(dtype)
+
+
 # gradient of tanh approximation of gelu
 # gradient of actual gelu is:
 # 0.5 * (1. + torch.erf(x * 0.70710678)) + 0.3989423 * x * torch.exp(-0.5 * x * x)
@@ -97,12 +122,50 @@ def weighted_swiglu_back(g, y, weights):
     return input_grad.to(input_dtype), weights_grad.to(w_dtype)
 
 
+@jit_fuser
+def clamped_swiglu_back(g, y, clamp_value):
+    """Compute the input gradient for clamped SwiGLU."""
+    dtype = y.dtype
+    y_1, y_2 = torch.chunk(y.to(torch.float32), 2, -1)
+    y_1c = y_1.clamp(min=None, max=clamp_value)
+    y_2c = y_2.clamp(min=-clamp_value, max=clamp_value)
+    res = torch.cat(
+        (
+            g
+            * torch.sigmoid(y_1c)
+            * (1 + y_1c * (1 - torch.sigmoid(y_1c)))
+            * y_2c
+            * (y_1 <= clamp_value).to(g.dtype),
+            g * F.silu(y_1c) * ((y_2 >= -clamp_value) & (y_2 <= clamp_value)).to(g.dtype),
+        ),
+        -1,
+    )
+    return res.to(dtype)
+
+
+@jit_fuser
+def bias_clamped_swiglu_back(g, y, bias, clamp_value):
+    """Compute the input gradient for clamped SwiGLU with bias."""
+    return clamped_swiglu_back(g, y + bias, clamp_value)
+
+
+@jit_fuser
+def clamped_weighted_swiglu_back(g, y, weights, clamp_value):
+    """Compute input and weight gradients for token-weighted clamped SwiGLU."""
+    input_dtype = y.dtype
+    w_dtype = weights.dtype
+    input_grad = clamped_swiglu_back(g * weights, y, clamp_value)
+    weights_grad = clamped_swiglu(y, clamp_value) * g.to(w_dtype)
+    weights_grad = torch.sum(weights_grad, dim=-1, keepdim=True)
+    return input_grad.to(input_dtype), weights_grad.to(w_dtype)
+
+
 class BiasSwiGLUFunction(torch.autograd.Function):
     """Custom autograd function for SwiGLU activation with bias support."""
 
     @staticmethod
     @nvtx_decorator()
-    def forward(ctx, input, bias, fp8_input_store, cpu_offload_input):
+    def forward(ctx, input, bias, fp8_input_store, cpu_offload_input, clamp_value):
         """Forward pass of biased SwiGLU activation.
 
         Args:
@@ -121,6 +184,9 @@ class BiasSwiGLUFunction(torch.autograd.Function):
         ctx.save_for_backward(input_for_backward, bias)
         ctx.ori_input_dtype = input.dtype
         ctx.fp8_input_store = fp8_input_store
+        ctx.clamp_value = clamp_value
+        if clamp_value is not None and clamp_value > 0:
+            return bias_clamped_swiglu(input, bias, clamp_value)
         return bias_swiglu(input, bias)
 
     @staticmethod
@@ -140,8 +206,11 @@ class BiasSwiGLUFunction(torch.autograd.Function):
         """
         input, bias = ctx.saved_tensors
         input = input.to(ctx.ori_input_dtype) if ctx.fp8_input_store else input
-        tmp = bias_swiglu_back(grad_output, input, bias)
-        return tmp, tmp, None, None
+        if ctx.clamp_value is not None and ctx.clamp_value > 0:
+            tmp = bias_clamped_swiglu_back(grad_output, input, bias, ctx.clamp_value)
+        else:
+            tmp = bias_swiglu_back(grad_output, input, bias)
+        return tmp, tmp, None, None, None
 
 
 class SwiGLUFunction(torch.autograd.Function):
@@ -149,7 +218,7 @@ class SwiGLUFunction(torch.autograd.Function):
 
     @staticmethod
     @nvtx_decorator()
-    def forward(ctx, input, fp8_input_store, cpu_offload_input):
+    def forward(ctx, input, fp8_input_store, cpu_offload_input, clamp_value):
         """Forward pass of SwiGLU activation.
 
         Args:
@@ -166,6 +235,9 @@ class SwiGLUFunction(torch.autograd.Function):
         ctx.save_for_backward(input_for_backward)
         ctx.ori_input_dtype = input.dtype
         ctx.fp8_input_store = fp8_input_store
+        ctx.clamp_value = clamp_value
+        if clamp_value is not None and clamp_value > 0:
+            return clamped_swiglu(input, clamp_value)
         return swiglu(input)
 
     @staticmethod
@@ -184,29 +256,37 @@ class SwiGLUFunction(torch.autograd.Function):
         """
         input = ctx.saved_tensors[0]
         input = input.to(ctx.ori_input_dtype) if ctx.fp8_input_store else input
-        tmp = swiglu_back(grad_output, input)
-        return tmp, None, None
+        if ctx.clamp_value is not None and ctx.clamp_value > 0:
+            tmp = clamped_swiglu_back(grad_output, input, ctx.clamp_value)
+        else:
+            tmp = swiglu_back(grad_output, input)
+        return tmp, None, None, None
 
 
 class WeightedSwiGLUFunction(torch.autograd.Function):
     @staticmethod
-    # bias is an optional argument
-    def forward(ctx, input, weights, fp8_input_store):
+    def forward(ctx, input, weights, fp8_input_store, clamp_value):
         input_for_backward = input.to(torch.float8_e4m3fn) if fp8_input_store else input
         ctx.save_for_backward(input_for_backward, weights)
         ctx.ori_input_dtype = input.dtype
         ctx.fp8_input_store = fp8_input_store
+        ctx.clamp_value = clamp_value
+        if clamp_value is not None and clamp_value > 0:
+            return clamped_weighted_swiglu(input, weights, clamp_value)
         return weighted_swiglu(input, weights)
 
     @staticmethod
     def backward(ctx, grad_output):
         input, weights = ctx.saved_tensors
         input = input.to(ctx.ori_input_dtype) if ctx.fp8_input_store else input
-        tmp, wgrad = weighted_swiglu_back(grad_output, input, weights)
-        return tmp, wgrad, None
+        if ctx.clamp_value is not None and ctx.clamp_value > 0:
+            tmp, wgrad = clamped_weighted_swiglu_back(grad_output, input, weights, ctx.clamp_value)
+        else:
+            tmp, wgrad = weighted_swiglu_back(grad_output, input, weights)
+        return tmp, wgrad, None, None
 
 
-def bias_swiglu_impl(input, bias, fp8_input_store=False, cpu_offload_input=False):
+def bias_swiglu_impl(input, bias, fp8_input_store=False, cpu_offload_input=False, clamp_value=None):
     """Implementation of biased SwiGLU that handles different input shapes.
 
     This function reshapes the input if necessary, applies the SwiGLU activation
@@ -218,6 +298,10 @@ def bias_swiglu_impl(input, bias, fp8_input_store=False, cpu_offload_input=False
             uses the bias-free SwiGLU variant.
         fp8_input_store (bool, optional): Whether to store intermediate values in FP8 format.
             Defaults to False.
+        cpu_offload_input (bool, optional): Whether to mark saved activation inputs for CPU
+            offloading. Defaults to False.
+        clamp_value (float, optional): Maximum gate value and absolute linear value. When None,
+            preserve the legacy unclamped SwiGLU behavior.
 
     Returns:
         torch.Tensor: Result of biased SwiGLU activation.
@@ -229,14 +313,16 @@ def bias_swiglu_impl(input, bias, fp8_input_store=False, cpu_offload_input=False
     assert len(ori_shape) in [2, 3]
     input = input.view(-1, ori_shape[-1])
     if bias is not None:
-        output = BiasSwiGLUFunction.apply(input, bias, fp8_input_store, cpu_offload_input)
+        output = BiasSwiGLUFunction.apply(
+            input, bias, fp8_input_store, cpu_offload_input, clamp_value
+        )
     else:
-        output = SwiGLUFunction.apply(input, fp8_input_store, cpu_offload_input)
+        output = SwiGLUFunction.apply(input, fp8_input_store, cpu_offload_input, clamp_value)
 
     return output if len(ori_shape) == 2 else output.view(ori_shape[0], ori_shape[1], -1)
 
 
-def weighted_bias_swiglu_impl(input, bias, weights, fp8_input_store=False):
+def weighted_bias_swiglu_impl(input, bias, weights, fp8_input_store=False, clamp_value=None):
     """
     Token-wise-weighted bias swiglu fusion.
     """
@@ -246,7 +332,7 @@ def weighted_bias_swiglu_impl(input, bias, weights, fp8_input_store=False):
     if bias is not None:
         raise NotImplementedError("Bias is not supported for weighted swiglu fusion")
     else:
-        output = WeightedSwiGLUFunction.apply(input, weights, fp8_input_store)
+        output = WeightedSwiGLUFunction.apply(input, weights, fp8_input_store, clamp_value)
 
     return output if len(ori_shape) == 2 else output.view(ori_shape[0], ori_shape[1], -1)
 

--- a/megatron/core/transformer/mlp.py
+++ b/megatron/core/transformer/mlp.py
@@ -276,6 +276,7 @@ class MLP(MegatronModule):
                         bias_parallel,
                         per_token_scale.unsqueeze(-1),
                         self.config.activation_func_fp8_input_store,
+                        self.config.activation_func_clamp_value,
                     )
                 elif self.activation_func == quick_gelu and self.config.gated_linear_unit:
                     intermediate_parallel = weighted_bias_quick_geglu_impl(
@@ -307,6 +308,7 @@ class MLP(MegatronModule):
                         self.config.cpu_offloading
                         and self.config.cpu_offloading_activations
                         and HAVE_TE,
+                        self.config.activation_func_clamp_value,
                     )
                 else:
                     raise ValueError("Only support fusion of gelu and swiglu")

--- a/megatron/core/transformer/mlp.py
+++ b/megatron/core/transformer/mlp.py
@@ -281,6 +281,7 @@ class MLP(MegatronModule):
                         bias_parallel,
                         per_token_scale.unsqueeze(-1),
                         self.config.activation_func_fp8_input_store,
+                        self.config.activation_func_clamp_value,
                     )
                 elif self.activation_func == quick_gelu and self.config.gated_linear_unit:
                     intermediate_parallel = weighted_bias_quick_geglu_impl(
@@ -312,6 +313,7 @@ class MLP(MegatronModule):
                         self.config.cpu_offloading
                         and self.config.cpu_offloading_activations
                         and HAVE_TE,
+                        self.config.activation_func_clamp_value,
                     )
                 else:
                     raise ValueError("Only support fusion of gelu and swiglu")

--- a/megatron/core/transformer/moe/experts.py
+++ b/megatron/core/transformer/moe/experts.py
@@ -368,7 +368,14 @@ class TEGroupedMLP(MegatronModule):
         if not (use_glu_fusion or use_srelu_fusion):
             return False
         if self.config.activation_func == F.silu:
-            pass
+            if self.config.activation_func_clamp_value is not None:
+                if not is_te_min_version("2.17.0.dev0"):
+                    return False
+                try:
+                    from transformer_engine.pytorch.ops import ScaledClampedQGeGLU  # noqa: F401
+                except ImportError:
+                    return False
+            return True
         elif self.config.activation_func == quick_gelu:
             try:
                 from transformer_engine.pytorch.ops import ScaledClampedQGeGLU  # noqa: F401
@@ -470,20 +477,35 @@ class TEGroupedMLP(MegatronModule):
         )
         ops.append(op)
 
-        # Activation and post-multiply probs (SwiGLU, clamped quick-GeGLU, or SReLU)
+        # Activation and post-multiply probs (SwiGLU, clamped GLU, or SReLU).
         glu_interleave = self.config.moe_mlp_glu_interleave_size
         activation_recompute_in_mlp = bool(getattr(self, "activation_recompute", False))
         if self.config.activation_func == F.silu and self.config.gated_linear_unit:
-            if (
-                "activation_recompute_in_mlp"
-                in inspect.signature(te.pytorch.ops.ScaledSwiGLU).parameters
-            ):
-                op = te.pytorch.ops.ScaledSwiGLU(
-                    glu_interleave_size=glu_interleave,
-                    activation_recompute_in_mlp=activation_recompute_in_mlp,
-                )
+            clamp_value = self.config.activation_func_clamp_value
+            if clamp_value is not None:
+                clamped_glu_kwargs = {
+                    "glu_interleave_size": glu_interleave,
+                    "alpha": 1.0,
+                    "limit": clamp_value,
+                    "glu_linear_offset": 0.0,
+                }
+                if (
+                    "activation_recompute_in_mlp"
+                    in inspect.signature(te.pytorch.ops.ScaledClampedQGeGLU).parameters
+                ):
+                    clamped_glu_kwargs["activation_recompute_in_mlp"] = activation_recompute_in_mlp
+                op = te.pytorch.ops.ScaledClampedQGeGLU(**clamped_glu_kwargs)
             else:
-                op = te.pytorch.ops.ScaledSwiGLU(glu_interleave_size=glu_interleave)
+                if (
+                    "activation_recompute_in_mlp"
+                    in inspect.signature(te.pytorch.ops.ScaledSwiGLU).parameters
+                ):
+                    op = te.pytorch.ops.ScaledSwiGLU(
+                        glu_interleave_size=glu_interleave,
+                        activation_recompute_in_mlp=activation_recompute_in_mlp,
+                    )
+                else:
+                    op = te.pytorch.ops.ScaledSwiGLU(glu_interleave_size=glu_interleave)
         elif self.config.activation_func == quick_gelu and self.config.gated_linear_unit:
             clamp = self.config.activation_func_clamp_value
             if clamp is not None:
@@ -776,6 +798,7 @@ class TEGroupedMLP(MegatronModule):
                         bias_parallel,
                         permuted_probs,
                         self.config.activation_func_fp8_input_store,
+                        self.config.activation_func_clamp_value,
                     )
                 elif self.activation_func == quick_gelu and self.config.gated_linear_unit:
                     intermediate_parallel = weighted_bias_quick_geglu_impl(

--- a/megatron/core/transformer/moe/experts.py
+++ b/megatron/core/transformer/moe/experts.py
@@ -377,7 +377,14 @@ class TEGroupedMLP(MegatronModule):
         if not (use_glu_fusion or use_srelu_fusion):
             return False
         if self.config.activation_func == F.silu:
-            pass
+            if self.config.activation_func_clamp_value is not None:
+                if not is_te_min_version("2.17.0.dev0"):
+                    return False
+                try:
+                    from transformer_engine.pytorch.ops import ScaledClampedQGeGLU  # noqa: F401
+                except ImportError:
+                    return False
+            return True
         elif self.config.activation_func == quick_gelu:
             try:
                 from transformer_engine.pytorch.ops import ScaledClampedQGeGLU  # noqa: F401
@@ -479,20 +486,35 @@ class TEGroupedMLP(MegatronModule):
         )
         ops.append(op)
 
-        # Activation and post-multiply probs (SwiGLU, clamped quick-GeGLU, or SReLU)
+        # Activation and post-multiply probs (SwiGLU, clamped GLU, or SReLU).
         glu_interleave = self.config.moe_mlp_glu_interleave_size
         activation_recompute_in_mlp = bool(getattr(self, "activation_recompute", False))
         if self.config.activation_func == F.silu and self.config.gated_linear_unit:
-            if (
-                "activation_recompute_in_mlp"
-                in inspect.signature(te.pytorch.ops.ScaledSwiGLU).parameters
-            ):
-                op = te.pytorch.ops.ScaledSwiGLU(
-                    glu_interleave_size=glu_interleave,
-                    activation_recompute_in_mlp=activation_recompute_in_mlp,
-                )
+            clamp_value = self.config.activation_func_clamp_value
+            if clamp_value is not None:
+                clamped_glu_kwargs = {
+                    "glu_interleave_size": glu_interleave,
+                    "alpha": 1.0,
+                    "limit": clamp_value,
+                    "glu_linear_offset": 0.0,
+                }
+                if (
+                    "activation_recompute_in_mlp"
+                    in inspect.signature(te.pytorch.ops.ScaledClampedQGeGLU).parameters
+                ):
+                    clamped_glu_kwargs["activation_recompute_in_mlp"] = activation_recompute_in_mlp
+                op = te.pytorch.ops.ScaledClampedQGeGLU(**clamped_glu_kwargs)
             else:
-                op = te.pytorch.ops.ScaledSwiGLU(glu_interleave_size=glu_interleave)
+                if (
+                    "activation_recompute_in_mlp"
+                    in inspect.signature(te.pytorch.ops.ScaledSwiGLU).parameters
+                ):
+                    op = te.pytorch.ops.ScaledSwiGLU(
+                        glu_interleave_size=glu_interleave,
+                        activation_recompute_in_mlp=activation_recompute_in_mlp,
+                    )
+                else:
+                    op = te.pytorch.ops.ScaledSwiGLU(glu_interleave_size=glu_interleave)
         elif self.config.activation_func == quick_gelu and self.config.gated_linear_unit:
             clamp = self.config.activation_func_clamp_value
             if clamp is not None:
@@ -832,6 +854,7 @@ class TEGroupedMLP(MegatronModule):
                         bias_parallel,
                         permuted_probs,
                         self.config.activation_func_fp8_input_store,
+                        self.config.activation_func_clamp_value,
                     )
                 elif self.activation_func == quick_gelu and self.config.gated_linear_unit:
                     intermediate_parallel = weighted_bias_quick_geglu_impl(

--- a/megatron/core/transformer/moe/experts.py
+++ b/megatron/core/transformer/moe/experts.py
@@ -384,7 +384,6 @@ class TEGroupedMLP(MegatronModule):
                     from transformer_engine.pytorch.ops import ScaledClampedQGeGLU  # noqa: F401
                 except ImportError:
                     return False
-            return True
         elif self.config.activation_func == quick_gelu:
             try:
                 from transformer_engine.pytorch.ops import ScaledClampedQGeGLU  # noqa: F401

--- a/megatron/core/transformer/moe/shared_experts.py
+++ b/megatron/core/transformer/moe/shared_experts.py
@@ -282,6 +282,7 @@ class SharedExpertMLP(MLP):
                         intermediate_parallel,
                         bias_parallel,
                         self.config.activation_func_fp8_input_store,
+                        clamp_value=self.config.activation_func_clamp_value,
                     )
                 else:
                     raise ValueError("Only support fusion of gelu and swiglu")
@@ -291,8 +292,13 @@ class SharedExpertMLP(MLP):
                 if self.config.gated_linear_unit:
 
                     def glu(x):
-                        x = torch.chunk(x, 2, dim=-1)
-                        return self.config.activation_func(x[0]) * x[1]
+                        x_glu, x_linear = torch.chunk(x, 2, dim=-1)
+                        if (clamp_value := self.config.activation_func_clamp_value) is not None:
+                            x_glu = x_glu.clamp(min=None, max=clamp_value)
+                            x_linear = x_linear.clamp(min=-clamp_value, max=clamp_value)
+                        return self.config.activation_func(x_glu) * (
+                            x_linear + self.config.glu_linear_offset
+                        )
 
                     intermediate_parallel = glu(intermediate_parallel)
                 else:
@@ -409,6 +415,15 @@ class FusedSharedExpertMLP(SharedExpertMLP):
                 f"fused kernel, but got activation_func={self.config.activation_func}, "
                 f"gated_linear_unit={self.config.gated_linear_unit}."
             )
+        if self.config.activation_func_clamp_value is not None and (
+            not is_te_min_version("2.17.0.dev0")
+            or not hasattr(te.pytorch.ops, "ScaledClampedQGeGLU")
+        ):
+            raise RuntimeError(
+                f"{self.__class__.__name__} requires Transformer Engine >= 2.17.0.dev0 "
+                "with pytorch.ops.ScaledClampedQGeGLU when "
+                "activation_func_clamp_value is set."
+            )
         if self.config.moe_shared_expert_glu_interleave_size is None:
             raise ValueError(
                 f"{self.__class__.__name__} requires "
@@ -445,7 +460,7 @@ class FusedSharedExpertMLP(SharedExpertMLP):
         return self._fused_grouped_swiglu_recipe
 
     def _make_fused_grouped_swiglu_ops(self) -> torch.nn.Module:
-        """Construct GroupedLinear(num_groups=1) -> ScaledSwiGLU -> GroupedLinear."""
+        """Construct the grouped-linear shared-expert MLP operations."""
         ops = te.pytorch.ops.Sequential()
         tp_world_size = get_pg_size(self.tp_group)
         rng_state_tracker_function = None
@@ -468,7 +483,17 @@ class FusedSharedExpertMLP(SharedExpertMLP):
         op._glu_interleave_size = glu_interleave_size
         ops.append(op)
 
-        ops.append(te.pytorch.ops.ScaledSwiGLU(glu_interleave_size=glu_interleave_size))
+        clamp_value = self.config.activation_func_clamp_value
+        if clamp_value is None:
+            activation_op = te.pytorch.ops.ScaledSwiGLU(glu_interleave_size=glu_interleave_size)
+        else:
+            activation_op = te.pytorch.ops.ScaledClampedQGeGLU(
+                glu_interleave_size=glu_interleave_size,
+                alpha=1.0,
+                limit=clamp_value,
+                glu_linear_offset=0.0,
+            )
+        ops.append(activation_op)
 
         fc2_weight = self.linear_fc2.weight
         op = te.pytorch.ops.GroupedLinear(

--- a/megatron/core/transformer/moe/shared_experts.py
+++ b/megatron/core/transformer/moe/shared_experts.py
@@ -287,6 +287,7 @@ class SharedExpertMLP(MLP):
                         intermediate_parallel,
                         bias_parallel,
                         self.config.activation_func_fp8_input_store,
+                        clamp_value=self.config.activation_func_clamp_value,
                     )
                 else:
                     raise ValueError("Only support fusion of gelu and swiglu")
@@ -296,8 +297,13 @@ class SharedExpertMLP(MLP):
                 if self.config.gated_linear_unit:
 
                     def glu(x):
-                        x = torch.chunk(x, 2, dim=-1)
-                        return self.config.activation_func(x[0]) * x[1]
+                        x_glu, x_linear = torch.chunk(x, 2, dim=-1)
+                        if (clamp_value := self.config.activation_func_clamp_value) is not None:
+                            x_glu = x_glu.clamp(min=None, max=clamp_value)
+                            x_linear = x_linear.clamp(min=-clamp_value, max=clamp_value)
+                        return self.config.activation_func(x_glu) * (
+                            x_linear + self.config.glu_linear_offset
+                        )
 
                     intermediate_parallel = glu(intermediate_parallel)
                 else:
@@ -416,6 +422,15 @@ class FusedSharedExpertMLP(SharedExpertMLP):
                 f"fused kernel, but got activation_func={self.config.activation_func}, "
                 f"gated_linear_unit={self.config.gated_linear_unit}."
             )
+        if self.config.activation_func_clamp_value is not None and (
+            not is_te_min_version("2.17.0.dev0")
+            or not hasattr(te.pytorch.ops, "ScaledClampedQGeGLU")
+        ):
+            raise RuntimeError(
+                f"{self.__class__.__name__} requires Transformer Engine >= 2.17.0.dev0 "
+                "with pytorch.ops.ScaledClampedQGeGLU when "
+                "activation_func_clamp_value is set."
+            )
         if self.config.moe_shared_expert_glu_interleave_size is None:
             raise ValueError(
                 f"{self.__class__.__name__} requires "
@@ -452,7 +467,7 @@ class FusedSharedExpertMLP(SharedExpertMLP):
         return self._fused_grouped_swiglu_recipe
 
     def _make_fused_grouped_swiglu_ops(self) -> torch.nn.Module:
-        """Construct GroupedLinear(num_groups=1) -> ScaledSwiGLU -> GroupedLinear."""
+        """Construct the grouped-linear shared-expert MLP operations."""
         ops = te.pytorch.ops.Sequential()
         tp_world_size = get_pg_size(self.tp_group)
         rng_state_tracker_function = None
@@ -475,7 +490,16 @@ class FusedSharedExpertMLP(SharedExpertMLP):
         op._glu_interleave_size = glu_interleave_size
         ops.append(op)
 
-        activation_op = te.pytorch.ops.ScaledSwiGLU(glu_interleave_size=glu_interleave_size)
+        clamp_value = self.config.activation_func_clamp_value
+        if clamp_value is None:
+            activation_op = te.pytorch.ops.ScaledSwiGLU(glu_interleave_size=glu_interleave_size)
+        else:
+            activation_op = te.pytorch.ops.ScaledClampedQGeGLU(
+                glu_interleave_size=glu_interleave_size,
+                alpha=1.0,
+                limit=clamp_value,
+                glu_linear_offset=0.0,
+            )
         # Shared experts are not router-gated. Mark this fused-op instance so
         # TE can omit the optional forward cuDNN probability tensor without
         # changing the semantics of routed single-group MLPs.

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -217,7 +217,7 @@ class TransformerConfig(ModelParallelConfig):
 
     activation_func_clamp_value: Optional[float] = None
     """Clamp the output of the linear_fc1 in the activation function. Only used when activation_func
-    is quick_gelu."""
+    is quick_gelu or SwiGLU (MoE only)."""
 
     num_moe_experts: Optional[int] = None
     """Number of experts to use for MoE layer. When set, it replaces MLP with MoE layer. Set to None
@@ -2142,6 +2142,33 @@ class TransformerConfig(ModelParallelConfig):
         if self.activation_func_fp8_input_store:
             if self.activation_func != F.silu or not self.gated_linear_unit:
                 raise ValueError("Storing activation input in FP8 is supported only for SwiGLU.")
+
+        if (
+            self.activation_func_clamp_value is not None
+            and self.activation_func == F.silu
+            and self.gated_linear_unit
+        ):
+            if (
+                not math.isfinite(self.activation_func_clamp_value)
+                or self.activation_func_clamp_value <= 0
+            ):
+                raise ValueError(
+                    "activation_func_clamp_value for SwiGLU must be finite and greater than zero."
+                )
+            if self.num_moe_experts is None:
+                raise ValueError(
+                    "activation_func_clamp_value for SwiGLU is only supported with MoE."
+                )
+            if self.glu_linear_offset != 0.0:
+                raise ValueError(
+                    "glu_linear_offset must be zero when activation_func_clamp_value "
+                    "is set for SwiGLU."
+                )
+            if self.use_te_activation_func:
+                raise ValueError(
+                    "use_te_activation_func must be False "
+                    "when activation_func_clamp_value is not None for SwiGLU"
+                )
 
         if self.apply_rope_fusion:
             if self.multi_latent_attention:

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -227,7 +227,7 @@ class TransformerConfig(ModelParallelConfig):
 
     activation_func_clamp_value: Optional[float] = None
     """Clamp the output of the linear_fc1 in the activation function. Only used when activation_func
-    is quick_gelu."""
+    is quick_gelu or SwiGLU (MoE only)."""
 
     num_moe_experts: Optional[int] = None
     """Number of experts to use for MoE layer. When set, it replaces MLP with MoE layer. Set to None
@@ -2187,6 +2187,33 @@ class TransformerConfig(ModelParallelConfig):
         if self.activation_func_fp8_input_store:
             if self.activation_func != F.silu or not self.gated_linear_unit:
                 raise ValueError("Storing activation input in FP8 is supported only for SwiGLU.")
+
+        if (
+            self.activation_func_clamp_value is not None
+            and self.activation_func == F.silu
+            and self.gated_linear_unit
+        ):
+            if (
+                not math.isfinite(self.activation_func_clamp_value)
+                or self.activation_func_clamp_value <= 0
+            ):
+                raise ValueError(
+                    "activation_func_clamp_value for SwiGLU must be finite and greater than zero."
+                )
+            if self.num_moe_experts is None:
+                raise ValueError(
+                    "activation_func_clamp_value for SwiGLU is only supported with MoE."
+                )
+            if self.glu_linear_offset != 0.0:
+                raise ValueError(
+                    "glu_linear_offset must be zero when activation_func_clamp_value "
+                    "is set for SwiGLU."
+                )
+            if self.use_te_activation_func:
+                raise ValueError(
+                    "use_te_activation_func must be False "
+                    "when activation_func_clamp_value is not None for SwiGLU"
+                )
 
         if self.apply_rope_fusion:
             if self.multi_latent_attention:

--- a/tests/unit_tests/fusions/test_swiglu_fusion.py
+++ b/tests/unit_tests/fusions/test_swiglu_fusion.py
@@ -1,7 +1,51 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 import pytest
 import torch
+import torch.nn.functional as F
 
 from megatron.core.fusions.fused_bias_swiglu import bias_swiglu_impl, weighted_bias_swiglu_impl
+from megatron.core.transformer.transformer_config import TransformerConfig
+
+
+def _clamped_swiglu_config(**kwargs):
+    defaults = dict(
+        num_layers=1,
+        hidden_size=16,
+        num_attention_heads=4,
+        num_moe_experts=4,
+        gated_linear_unit=True,
+        activation_func=F.silu,
+        activation_func_clamp_value=10.0,
+    )
+    return TransformerConfig(**(defaults | kwargs))
+
+
+def test_clamped_swiglu_config_accepts_positive_moe_clamp():
+    assert _clamped_swiglu_config().activation_func_clamp_value == 10.0
+
+
+@pytest.mark.parametrize("clamp_value", [0.0, -1.0, float("nan"), float("inf"), float("-inf")])
+def test_clamped_swiglu_config_requires_positive_clamp(clamp_value):
+    with pytest.raises(ValueError, match="greater than zero"):
+        _clamped_swiglu_config(activation_func_clamp_value=clamp_value)
+
+
+def test_clamped_swiglu_config_rejects_linear_offset():
+    with pytest.raises(ValueError, match="glu_linear_offset must be zero"):
+        _clamped_swiglu_config(glu_linear_offset=1.0)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"num_moe_experts": None}, "only supported with MoE"),
+        ({"use_te_activation_func": True}, "use_te_activation_func must be False"),
+    ],
+)
+def test_clamped_swiglu_config_rejects_unsupported_paths(kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        _clamped_swiglu_config(**kwargs)
 
 
 @pytest.mark.parametrize("input_dtype", [torch.bfloat16, torch.float32])
@@ -39,3 +83,120 @@ def test_weighted_bias_swiglu(input_dtype):
     assert weights_2.grad.dtype == weights.grad.dtype
     if input_dtype == torch.float32:
         assert torch.allclose(weights.grad, weights_2.grad, **tols)
+
+
+@pytest.mark.parametrize("input_dtype", [torch.bfloat16, torch.float32])
+def test_clamped_weighted_bias_swiglu(input_dtype):
+    clamp_value = 10.0
+
+    if input_dtype == torch.float32:
+        tols = dict(rtol=1.0e-6, atol=1.0e-6)
+    elif input_dtype == torch.bfloat16:
+        tols = dict(rtol=2.0e-2, atol=1.0e-3)
+    else:
+        raise ValueError(f"Invalid input dtype: {input_dtype}")
+
+    x = (torch.randn(16, 64, dtype=input_dtype, device="cuda") * 5.0).requires_grad_(True)
+    weights = torch.randn(16, 1, dtype=torch.float32, device="cuda", requires_grad=True)
+    bwd_input = torch.randn(16, 32, dtype=input_dtype, device="cuda")
+
+    # Reference: clamp and activate in FP32, then restore the input dtype.
+    y_1, y_2 = torch.chunk(x.to(torch.float32), 2, -1)
+    y = (
+        F.silu(y_1.clamp(min=None, max=clamp_value))
+        * y_2.clamp(min=-clamp_value, max=clamp_value)
+        * weights
+    ).to(input_dtype)
+    y.backward(bwd_input)
+
+    x_fused = x.detach().clone().requires_grad_(True)
+    weights_fused = weights.detach().clone().requires_grad_(True)
+    y_fused = weighted_bias_swiglu_impl(x_fused, None, weights_fused, clamp_value=clamp_value)
+    y_fused.backward(bwd_input.detach().clone())
+
+    assert y_fused.dtype == y.dtype
+    assert torch.allclose(y, y_fused, **tols)
+    assert x_fused.grad.dtype == x.grad.dtype
+    assert torch.allclose(x.grad, x_fused.grad, **tols)
+    assert weights_fused.grad.dtype == weights.grad.dtype
+    if input_dtype == torch.float32:
+        assert torch.allclose(weights.grad, weights_fused.grad, **tols)
+
+
+@pytest.mark.parametrize("input_dtype", [torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("with_bias", [False, True])
+def test_clamped_bias_swiglu_impl(input_dtype, with_bias):
+    clamp_value = 10.0
+
+    if input_dtype == torch.float32:
+        tols = dict(rtol=1.0e-6, atol=1.0e-6)
+    elif input_dtype == torch.bfloat16:
+        tols = dict(rtol=2.0e-2, atol=1.0e-3)
+    else:
+        raise ValueError(f"Invalid input dtype: {input_dtype}")
+
+    x = (torch.randn(16, 64, dtype=input_dtype, device="cuda") * 5.0).requires_grad_(True)
+    bias = (
+        torch.randn(64, dtype=input_dtype, device="cuda").requires_grad_(True)
+        if with_bias
+        else None
+    )
+    bwd_input = torch.randn(16, 32, dtype=input_dtype, device="cuda")
+
+    x_fp32 = x.to(torch.float32)
+    x_effective = x_fp32 + bias.to(torch.float32) if with_bias else x_fp32
+    y_1, y_2 = torch.chunk(x_effective, 2, -1)
+    y = (
+        F.silu(y_1.clamp(min=None, max=clamp_value)) * y_2.clamp(min=-clamp_value, max=clamp_value)
+    ).to(input_dtype)
+    y.backward(bwd_input)
+
+    x_fused = x.detach().clone().requires_grad_(True)
+    bias_fused = bias.detach().clone().requires_grad_(True) if with_bias else None
+    y_fused = bias_swiglu_impl(x_fused, bias_fused, clamp_value=clamp_value)
+    y_fused.backward(bwd_input.detach().clone())
+
+    assert y_fused.dtype == y.dtype
+    assert torch.allclose(y, y_fused, **tols)
+    assert x_fused.grad.dtype == x.grad.dtype
+    assert torch.allclose(x.grad, x_fused.grad, **tols)
+    if with_bias:
+        assert bias_fused.grad.dtype == bias.grad.dtype
+        bias_grad_cos = F.cosine_similarity(
+            bias.grad.flatten().float().unsqueeze(0), bias_fused.grad.flatten().float().unsqueeze(0)
+        ).item()
+        assert bias_grad_cos > 0.999, f"bias.grad cosine similarity = {bias_grad_cos:.6f}"
+
+
+@pytest.mark.parametrize("input_dtype", [torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("with_bias", [False, True])
+def test_bias_swiglu_impl_clamp_none_matches_unclamped(input_dtype, with_bias):
+    if input_dtype == torch.float32:
+        tols = dict(rtol=1.0e-6, atol=1.0e-6)
+    else:
+        tols = dict(rtol=2.0e-2, atol=1.0e-3)
+
+    x = torch.randn(16, 64, dtype=input_dtype, device="cuda").requires_grad_(True)
+    bias = (
+        torch.randn(64, dtype=input_dtype, device="cuda").requires_grad_(True)
+        if with_bias
+        else None
+    )
+    bwd_input = torch.randn(16, 32, dtype=input_dtype, device="cuda")
+
+    y = bias_swiglu_impl(x, bias)
+    y.backward(bwd_input)
+
+    x_explicit = x.detach().clone().requires_grad_(True)
+    bias_explicit = bias.detach().clone().requires_grad_(True) if with_bias else None
+    y_explicit = bias_swiglu_impl(x_explicit, bias_explicit, clamp_value=None)
+    y_explicit.backward(bwd_input.detach().clone())
+
+    assert torch.allclose(y, y_explicit, **tols)
+    assert torch.allclose(x.grad, x_explicit.grad, **tols)
+    if with_bias:
+        bias_grad_cos = F.cosine_similarity(
+            bias.grad.flatten().float().unsqueeze(0),
+            bias_explicit.grad.flatten().float().unsqueeze(0),
+        ).item()
+        assert bias_grad_cos > 0.999, f"bias.grad cosine similarity = {bias_grad_cos:.6f}"

--- a/tests/unit_tests/transformer/moe/test_grouped_mlp.py
+++ b/tests/unit_tests/transformer/moe/test_grouped_mlp.py
@@ -38,6 +38,23 @@ def test_op_fuser_transformer_config_args_are_exposed():
     assert args.moe_mlp_glu_interleave_size == 16
 
 
+def test_clamped_swiglu_allows_te_op_fuser():
+    config = TransformerConfig(
+        num_layers=1,
+        hidden_size=16,
+        num_attention_heads=4,
+        num_moe_experts=4,
+        moe_grouped_gemm=True,
+        gated_linear_unit=True,
+        activation_func=F.silu,
+        activation_func_clamp_value=10.0,
+        use_transformer_engine_op_fuser=True,
+    )
+
+    assert config.activation_func_clamp_value == 10.0
+    assert config.use_transformer_engine_op_fuser is True
+
+
 def test_remove_glu_interleaving_restores_contiguous_gate_and_linear_halves():
     interleaved = torch.tensor([[1, 2, 5, 6, 3, 4, 7, 8], [11, 12, 15, 16, 13, 14, 17, 18]])
     expected = torch.tensor([[1, 2, 3, 4, 5, 6, 7, 8], [11, 12, 13, 14, 15, 16, 17, 18]])
@@ -415,11 +432,21 @@ def _make_fake_te_namespace():
             self.activation_recompute_in_mlp = activation_recompute_in_mlp
 
     class FakeScaledClampedQGeGLU(torch.nn.Module):
-        def __init__(self, glu_interleave_size, *, activation_recompute_in_mlp=False, limit=None):
+        def __init__(
+            self,
+            glu_interleave_size,
+            *,
+            activation_recompute_in_mlp=False,
+            limit=None,
+            alpha=1.702,
+            glu_linear_offset=1.0,
+        ):
             super().__init__()
             self.glu_interleave_size = glu_interleave_size
             self.activation_recompute_in_mlp = activation_recompute_in_mlp
             self.limit = limit
+            self.alpha = alpha
+            self.glu_linear_offset = glu_linear_offset
 
     class FakeScaledSReLU(torch.nn.Module):
         def __init__(self, *, activation_recompute_in_mlp=False):
@@ -447,8 +474,15 @@ def _make_fake_te_namespace():
     )
 
 
-def test_make_fused_ops_uses_clamped_qgeglu_for_quick_gelu(monkeypatch):
-    """quick_gelu + clamp value → ScaledClampedQGeGLU(limit=clamp)."""
+@pytest.mark.parametrize(
+    ("activation_func", "expected_alpha", "expected_offset"),
+    [(quick_gelu, 1.702, 1.0), (F.silu, 1.0, 0.0)],
+    ids=("quick-geglu", "clamped-swiglu"),
+)
+def test_make_fused_ops_uses_clamped_qgeglu(
+    monkeypatch, activation_func, expected_alpha, expected_offset
+):
+    """Clamped quick GeGLU and SwiGLU use the appropriate TE parameters."""
     fake_te, FakeGroupedLinear = _make_fake_te_namespace()
     monkeypatch.setattr(experts_module, "te", fake_te)
 
@@ -458,10 +492,10 @@ def test_make_fused_ops_uses_clamped_qgeglu_for_quick_gelu(monkeypatch):
         moe_mlp_glu_interleave_size=4,
         delay_wgrad_compute=False,
         activation_func_clamp_value=7.0,
-        activation_func=quick_gelu,
+        activation_func=activation_func,
         gated_linear_unit=True,
     )
-    module.activation_func = quick_gelu
+    module.activation_func = activation_func
     module.activation_recompute = True
     common = dict(
         device="cuda",
@@ -483,6 +517,8 @@ def test_make_fused_ops_uses_clamped_qgeglu_for_quick_gelu(monkeypatch):
     assert activation.glu_interleave_size == 4
     assert activation.activation_recompute_in_mlp is True
     assert activation.limit == 7.0
+    assert activation.alpha == expected_alpha
+    assert activation.glu_linear_offset == expected_offset
 
 
 def test_make_fused_ops_uses_scaled_srelu_for_weighted_squared_relu(monkeypatch):
@@ -573,12 +609,18 @@ def _install_fake_te_ops_modules(
 
 
 def _make_fused_impl_support_module(
-    FakeGroupedLinear, *, activation_func, gated_linear_unit, use_fused_weighted_squared_relu=False
+    FakeGroupedLinear,
+    *,
+    activation_func,
+    gated_linear_unit,
+    use_fused_weighted_squared_relu=False,
+    activation_func_clamp_value=None,
 ):
     module = TEGroupedMLP.__new__(TEGroupedMLP)
     torch.nn.Module.__init__(module)
     module.config = SimpleNamespace(
         activation_func=activation_func,
+        activation_func_clamp_value=activation_func_clamp_value,
         gated_linear_unit=gated_linear_unit,
         use_fused_weighted_squared_relu=use_fused_weighted_squared_relu,
         moe_apply_probs_on_input=False,
@@ -632,6 +674,33 @@ def test_is_fused_impl_supported_requires_scaled_fc2_bias(monkeypatch):
     module.linear_fc2.use_bias = True
 
     assert module._is_fused_impl_supported() is False
+
+
+@pytest.mark.parametrize(
+    ("te_217_or_later", "include_clamped_qgeglu", "expected"),
+    [(True, True, True), (False, True, False), (True, False, False)],
+)
+def test_is_fused_impl_supported_gates_clamped_swiglu(
+    monkeypatch, te_217_or_later, include_clamped_qgeglu, expected
+):
+    fake_te, FakeGroupedLinear = _make_fake_te_namespace()
+    monkeypatch.setattr(experts_module, "te", fake_te)
+    monkeypatch.setattr(experts_module, "HAVE_TE", True)
+    monkeypatch.setattr(
+        experts_module, "is_te_min_version", lambda version: version == "2.14.0" or te_217_or_later
+    )
+    _install_fake_te_ops_modules(
+        monkeypatch, fake_te, include_clamped_qgeglu=include_clamped_qgeglu
+    )
+
+    module = _make_fused_impl_support_module(
+        FakeGroupedLinear,
+        activation_func=F.silu,
+        gated_linear_unit=True,
+        activation_func_clamp_value=10.0,
+    )
+
+    assert module._is_fused_impl_supported() is expected
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/transformer/moe/test_grouped_mlp.py
+++ b/tests/unit_tests/transformer/moe/test_grouped_mlp.py
@@ -38,6 +38,23 @@ def test_op_fuser_transformer_config_args_are_exposed():
     assert args.moe_mlp_glu_interleave_size == 16
 
 
+def test_clamped_swiglu_allows_te_op_fuser():
+    config = TransformerConfig(
+        num_layers=1,
+        hidden_size=16,
+        num_attention_heads=4,
+        num_moe_experts=4,
+        moe_grouped_gemm=True,
+        gated_linear_unit=True,
+        activation_func=F.silu,
+        activation_func_clamp_value=10.0,
+        use_transformer_engine_op_fuser=True,
+    )
+
+    assert config.activation_func_clamp_value == 10.0
+    assert config.use_transformer_engine_op_fuser is True
+
+
 def test_remove_glu_interleaving_restores_contiguous_gate_and_linear_halves():
     interleaved = torch.tensor([[1, 2, 5, 6, 3, 4, 7, 8], [11, 12, 15, 16, 13, 14, 17, 18]])
     expected = torch.tensor([[1, 2, 3, 4, 5, 6, 7, 8], [11, 12, 13, 14, 15, 16, 17, 18]])
@@ -452,11 +469,21 @@ def _make_fake_te_namespace():
             self.activation_recompute_in_mlp = activation_recompute_in_mlp
 
     class FakeScaledClampedQGeGLU(torch.nn.Module):
-        def __init__(self, glu_interleave_size, *, activation_recompute_in_mlp=False, limit=None):
+        def __init__(
+            self,
+            glu_interleave_size,
+            *,
+            activation_recompute_in_mlp=False,
+            limit=None,
+            alpha=1.702,
+            glu_linear_offset=1.0,
+        ):
             super().__init__()
             self.glu_interleave_size = glu_interleave_size
             self.activation_recompute_in_mlp = activation_recompute_in_mlp
             self.limit = limit
+            self.alpha = alpha
+            self.glu_linear_offset = glu_linear_offset
 
     class FakeScaledSReLU(torch.nn.Module):
         def __init__(self, *, activation_recompute_in_mlp=False):
@@ -484,8 +511,15 @@ def _make_fake_te_namespace():
     )
 
 
-def test_make_fused_ops_uses_clamped_qgeglu_for_quick_gelu(monkeypatch):
-    """quick_gelu + clamp value → ScaledClampedQGeGLU(limit=clamp)."""
+@pytest.mark.parametrize(
+    ("activation_func", "expected_alpha", "expected_offset"),
+    [(quick_gelu, 1.702, 1.0), (F.silu, 1.0, 0.0)],
+    ids=("quick-geglu", "clamped-swiglu"),
+)
+def test_make_fused_ops_uses_clamped_qgeglu(
+    monkeypatch, activation_func, expected_alpha, expected_offset
+):
+    """Clamped quick GeGLU and SwiGLU use the appropriate TE parameters."""
     fake_te, FakeGroupedLinear = _make_fake_te_namespace()
     monkeypatch.setattr(experts_module, "te", fake_te)
 
@@ -495,10 +529,10 @@ def test_make_fused_ops_uses_clamped_qgeglu_for_quick_gelu(monkeypatch):
         moe_mlp_glu_interleave_size=4,
         delay_wgrad_compute=False,
         activation_func_clamp_value=7.0,
-        activation_func=quick_gelu,
+        activation_func=activation_func,
         gated_linear_unit=True,
     )
-    module.activation_func = quick_gelu
+    module.activation_func = activation_func
     module.activation_recompute = True
     common = dict(
         device="cuda",
@@ -520,6 +554,8 @@ def test_make_fused_ops_uses_clamped_qgeglu_for_quick_gelu(monkeypatch):
     assert activation.glu_interleave_size == 4
     assert activation.activation_recompute_in_mlp is True
     assert activation.limit == 7.0
+    assert activation.alpha == expected_alpha
+    assert activation.glu_linear_offset == expected_offset
 
 
 def test_make_fused_ops_uses_scaled_srelu_for_weighted_squared_relu(monkeypatch):
@@ -610,12 +646,18 @@ def _install_fake_te_ops_modules(
 
 
 def _make_fused_impl_support_module(
-    FakeGroupedLinear, *, activation_func, gated_linear_unit, use_fused_weighted_squared_relu=False
+    FakeGroupedLinear,
+    *,
+    activation_func,
+    gated_linear_unit,
+    use_fused_weighted_squared_relu=False,
+    activation_func_clamp_value=None,
 ):
     module = TEGroupedMLP.__new__(TEGroupedMLP)
     torch.nn.Module.__init__(module)
     module.config = SimpleNamespace(
         activation_func=activation_func,
+        activation_func_clamp_value=activation_func_clamp_value,
         gated_linear_unit=gated_linear_unit,
         use_fused_weighted_squared_relu=use_fused_weighted_squared_relu,
         moe_apply_probs_on_input=False,
@@ -669,6 +711,33 @@ def test_is_fused_impl_supported_requires_scaled_fc2_bias(monkeypatch):
     module.linear_fc2.use_bias = True
 
     assert module._is_fused_impl_supported() is False
+
+
+@pytest.mark.parametrize(
+    ("te_217_or_later", "include_clamped_qgeglu", "expected"),
+    [(True, True, True), (False, True, False), (True, False, False)],
+)
+def test_is_fused_impl_supported_gates_clamped_swiglu(
+    monkeypatch, te_217_or_later, include_clamped_qgeglu, expected
+):
+    fake_te, FakeGroupedLinear = _make_fake_te_namespace()
+    monkeypatch.setattr(experts_module, "te", fake_te)
+    monkeypatch.setattr(experts_module, "HAVE_TE", True)
+    monkeypatch.setattr(
+        experts_module, "is_te_min_version", lambda version: version == "2.14.0" or te_217_or_later
+    )
+    _install_fake_te_ops_modules(
+        monkeypatch, fake_te, include_clamped_qgeglu=include_clamped_qgeglu
+    )
+
+    module = _make_fused_impl_support_module(
+        FakeGroupedLinear,
+        activation_func=F.silu,
+        gated_linear_unit=True,
+        activation_func_clamp_value=10.0,
+    )
+
+    assert module._is_fused_impl_supported() is expected
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/transformer/moe/test_grouped_mlp.py
+++ b/tests/unit_tests/transformer/moe/test_grouped_mlp.py
@@ -691,6 +691,27 @@ def test_is_fused_impl_supported_uses_config_activation_for_swiglu(monkeypatch):
     assert module._is_fused_impl_supported() is True
 
 
+@pytest.mark.parametrize("activation_func_clamp_value", [None, 10.0], ids=("unclamped", "clamped"))
+def test_is_fused_impl_supported_requires_cutedsl_for_swiglu(
+    monkeypatch, activation_func_clamp_value
+):
+    fake_te, FakeGroupedLinear = _make_fake_te_namespace()
+    monkeypatch.setattr(experts_module, "te", fake_te)
+    monkeypatch.setattr(experts_module, "HAVE_TE", True)
+    monkeypatch.setattr(experts_module, "is_te_min_version", lambda _: True)
+    monkeypatch.delenv("NVTE_CUTEDSL_FUSED_GROUPED_MLP", raising=False)
+    _install_fake_te_ops_modules(monkeypatch, fake_te)
+
+    module = _make_fused_impl_support_module(
+        FakeGroupedLinear,
+        activation_func=F.silu,
+        gated_linear_unit=True,
+        activation_func_clamp_value=activation_func_clamp_value,
+    )
+
+    assert module._is_fused_impl_supported() is False
+
+
 def test_is_fused_impl_supported_requires_scaled_fc2_bias(monkeypatch):
     fake_te, FakeGroupedLinear = _make_fake_te_namespace()
 

--- a/tests/unit_tests/transformer/moe/test_shared_experts.py
+++ b/tests/unit_tests/transformer/moe/test_shared_experts.py
@@ -52,6 +52,15 @@ class _FakeTEScaledSwiGLU(torch.nn.Module):
         self.glu_interleave_size = glu_interleave_size
 
 
+class _FakeTEScaledClampedQGeGLU(torch.nn.Module):
+    def __init__(self, glu_interleave_size, *, alpha, limit, glu_linear_offset):
+        super().__init__()
+        self.glu_interleave_size = glu_interleave_size
+        self.alpha = alpha
+        self.limit = limit
+        self.glu_linear_offset = glu_linear_offset
+
+
 class _FakeTESequential(torch.nn.Module):
     def append(self, module):
         self.add_module(str(len(self._modules)), module)
@@ -90,6 +99,7 @@ def _fake_te_module(linear_cls=_FakeTELinear):
             ops=SimpleNamespace(
                 GroupedLinear=_FakeTEGroupedLinear,
                 ScaledSwiGLU=_FakeTEScaledSwiGLU,
+                ScaledClampedQGeGLU=_FakeTEScaledClampedQGeGLU,
                 Sequential=_FakeTESequential,
             ),
             fp8_autocast=_FakeFP8Autocast,
@@ -123,6 +133,7 @@ def _fake_shared_expert(**config_kwargs):
         add_bias_linear=False,
         gated_linear_unit=True,
         activation_func=F.silu,
+        activation_func_clamp_value=None,
         moe_shared_expert_glu_interleave_size=32,
         delay_wgrad_compute=False,
         sequence_parallel=False,
@@ -183,6 +194,21 @@ def test_validate_fused_grouped_swiglu_requires_te(monkeypatch):
         shared_expert._validate_fused_grouped_swiglu()
 
 
+@pytest.mark.parametrize("has_clamped_op", [True, False])
+def test_validate_fused_grouped_swiglu_requires_clamped_te_support(monkeypatch, has_clamped_op):
+    fake_te = _patch_fake_shared_expert_te(monkeypatch)
+    if has_clamped_op:
+        monkeypatch.setattr(
+            shared_experts_module, "is_te_min_version", lambda version: version != "2.17.0.dev0"
+        )
+    else:
+        del fake_te.pytorch.ops.ScaledClampedQGeGLU
+    shared_expert = _fake_shared_expert(activation_func_clamp_value=7.0)
+
+    with pytest.raises(RuntimeError, match="ScaledClampedQGeGLU"):
+        shared_expert._validate_fused_grouped_swiglu()
+
+
 @pytest.mark.parametrize(
     ("config_kwargs", "bad_linear", "match"),
     [
@@ -236,6 +262,21 @@ def test_make_fused_grouped_swiglu_ops_builds_grouped_pipeline(monkeypatch):
     assert fc2_op.kwargs["bias"] is False
     assert fc2_op.kwargs["accumulate_into_main_grad"] is False
     assert fc2_op.weight0 is shared_expert.linear_fc2.weight
+
+
+def test_make_fused_grouped_swiglu_ops_builds_clamped_activation(monkeypatch):
+    _patch_fake_shared_expert_te(monkeypatch)
+    shared_expert = _fake_shared_expert(activation_func_clamp_value=7.0)
+
+    shared_expert._validate_fused_grouped_swiglu()
+    ops = shared_expert._make_fused_grouped_swiglu_ops()
+
+    activation_op = list(ops.children())[1]
+    assert isinstance(activation_op, _FakeTEScaledClampedQGeGLU)
+    assert activation_op.glu_interleave_size == 32
+    assert activation_op.alpha == 1.0
+    assert activation_op.limit == 7.0
+    assert activation_op.glu_linear_offset == 0.0
 
 
 def test_fused_grouped_swiglu_ops_replay_linear_pre_forward_hooks(monkeypatch):
@@ -408,3 +449,72 @@ class TestSharedExperts:
             assert torch.allclose(
                 p_overlap.grad, p_no_overlap.grad
             ), f"max diff: {torch.max(torch.abs(p_overlap.grad - p_no_overlap.grad))}"
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    @pytest.mark.parametrize("bias_activation_fusion", [True, False])
+    def test_shared_expert_clamped_swiglu(self, bias_activation_fusion):
+        """Verify clamped SwiGLU parity for overlapped and synchronous shared experts."""
+        Utils.initialize_model_parallel(tensor_model_parallel_size=1, expert_model_parallel_size=1)
+        clamp_value = 1.0
+
+        _set_random_seed(seed_=123, data_parallel_random_init=False)
+        moe_layer_overlap = self.get_moe_layer(
+            moe_shared_expert_overlap=True,
+            moe_token_dispatcher_type="alltoall",
+            activation_func_clamp_value=clamp_value,
+            bias_activation_fusion=bias_activation_fusion,
+        ).to(dtype=torch.bfloat16)
+
+        _set_random_seed(seed_=123, data_parallel_random_init=False)
+        moe_layer_no_overlap = self.get_moe_layer(
+            moe_shared_expert_overlap=False,
+            moe_token_dispatcher_type="alltoall",
+            activation_func_clamp_value=clamp_value,
+            bias_activation_fusion=bias_activation_fusion,
+        ).to(dtype=torch.bfloat16)
+        moe_layer_no_overlap.load_state_dict(moe_layer_overlap.state_dict())
+
+        hidden_states = (
+            torch.randn((32, 2, self.config.hidden_size), device="cuda", dtype=torch.bfloat16) * 5.0
+        ).requires_grad_(True)
+        hidden_states_no_overlap = hidden_states.detach().clone().requires_grad_(True)
+
+        output_overlap, _ = moe_layer_overlap(hidden_states)
+        output_no_overlap, _ = moe_layer_no_overlap(hidden_states_no_overlap)
+
+        cos_out = F.cosine_similarity(
+            output_overlap.flatten().unsqueeze(0).float(),
+            output_no_overlap.flatten().unsqueeze(0).float(),
+        ).item()
+        assert cos_out > 0.999, (
+            f"shared-expert clamp output mismatch (fusion={bias_activation_fusion}): "
+            f"cos sim = {cos_out:.6f}"
+        )
+
+        output_overlap.mean().backward()
+        output_no_overlap.mean().backward()
+
+        for p_overlap, p_no_overlap in zip(
+            moe_layer_overlap.parameters(), moe_layer_no_overlap.parameters()
+        ):
+            assert torch.allclose(p_overlap.grad, p_no_overlap.grad), (
+                f"shared-expert clamp mismatch (fusion={bias_activation_fusion}); "
+                f"max diff: {torch.max(torch.abs(p_overlap.grad - p_no_overlap.grad))}"
+            )
+
+        _set_random_seed(seed_=123, data_parallel_random_init=False)
+        moe_layer_unclamped = self.get_moe_layer(
+            moe_shared_expert_overlap=False,
+            moe_token_dispatcher_type="alltoall",
+            activation_func_clamp_value=None,
+            bias_activation_fusion=bias_activation_fusion,
+        ).to(dtype=torch.bfloat16)
+        moe_layer_unclamped.load_state_dict(moe_layer_overlap.state_dict())
+
+        hidden_states_unclamped = hidden_states.detach().clone().requires_grad_(True)
+        output_unclamped, _ = moe_layer_unclamped(hidden_states_unclamped)
+        assert not torch.allclose(output_no_overlap, output_unclamped), (
+            "Clamping had no observable effect on shared-expert output; "
+            "activation_func_clamp_value may not be plumbed through."
+        )

--- a/tests/unit_tests/transformer/moe/test_shared_experts.py
+++ b/tests/unit_tests/transformer/moe/test_shared_experts.py
@@ -489,8 +489,18 @@ class TestSharedExperts:
         )
         hidden_states_no_overlap = hidden_states.detach().clone().requires_grad_(True)
 
-        output_overlap, _ = moe_layer_overlap(hidden_states)
-        output_no_overlap, _ = moe_layer_no_overlap(hidden_states_no_overlap)
+        shared_expert_overlap = moe_layer_overlap.shared_experts
+        shared_expert_no_overlap = moe_layer_no_overlap.shared_experts
+        assert shared_expert_overlap is not None
+        assert shared_expert_no_overlap is not None
+
+        # Isolate shared-expert parity from nondeterministic routed-token unpermutation.
+        shared_expert_overlap.pre_forward_comm(hidden_states)
+        shared_expert_overlap.linear_fc1_forward_and_act()
+        shared_expert_overlap.linear_fc2_forward()
+        shared_expert_overlap.post_forward_comm()
+        output_overlap = shared_expert_overlap.get_output()
+        output_no_overlap = shared_expert_no_overlap(hidden_states_no_overlap)
         torch.testing.assert_close(output_overlap, output_no_overlap)
 
         output_overlap.mean().backward()
@@ -498,7 +508,7 @@ class TestSharedExperts:
 
         torch.testing.assert_close(hidden_states.grad, hidden_states_no_overlap.grad)
         for p_overlap, p_no_overlap in zip(
-            moe_layer_overlap.parameters(), moe_layer_no_overlap.parameters()
+            shared_expert_overlap.parameters(), shared_expert_no_overlap.parameters()
         ):
             torch.testing.assert_close(p_overlap.grad, p_no_overlap.grad)
 

--- a/tests/unit_tests/transformer/moe/test_shared_experts.py
+++ b/tests/unit_tests/transformer/moe/test_shared_experts.py
@@ -52,6 +52,15 @@ class _FakeTEScaledSwiGLU(torch.nn.Module):
         self.glu_interleave_size = glu_interleave_size
 
 
+class _FakeTEScaledClampedQGeGLU(torch.nn.Module):
+    def __init__(self, glu_interleave_size, *, alpha, limit, glu_linear_offset):
+        super().__init__()
+        self.glu_interleave_size = glu_interleave_size
+        self.alpha = alpha
+        self.limit = limit
+        self.glu_linear_offset = glu_linear_offset
+
+
 class _FakeTESequential(torch.nn.Module):
     def append(self, module):
         self.add_module(str(len(self._modules)), module)
@@ -90,6 +99,7 @@ def _fake_te_module(linear_cls=_FakeTELinear):
             ops=SimpleNamespace(
                 GroupedLinear=_FakeTEGroupedLinear,
                 ScaledSwiGLU=_FakeTEScaledSwiGLU,
+                ScaledClampedQGeGLU=_FakeTEScaledClampedQGeGLU,
                 Sequential=_FakeTESequential,
             ),
             fp8_autocast=_FakeFP8Autocast,
@@ -123,6 +133,7 @@ def _fake_shared_expert(**config_kwargs):
         add_bias_linear=False,
         gated_linear_unit=True,
         activation_func=F.silu,
+        activation_func_clamp_value=None,
         moe_shared_expert_glu_interleave_size=32,
         delay_wgrad_compute=False,
         sequence_parallel=False,
@@ -185,6 +196,21 @@ def test_validate_fused_grouped_swiglu_requires_te(monkeypatch):
         shared_expert._validate_fused_grouped_swiglu()
 
 
+@pytest.mark.parametrize("has_clamped_op", [True, False])
+def test_validate_fused_grouped_swiglu_requires_clamped_te_support(monkeypatch, has_clamped_op):
+    fake_te = _patch_fake_shared_expert_te(monkeypatch)
+    if has_clamped_op:
+        monkeypatch.setattr(
+            shared_experts_module, "is_te_min_version", lambda version: version != "2.17.0.dev0"
+        )
+    else:
+        del fake_te.pytorch.ops.ScaledClampedQGeGLU
+    shared_expert = _fake_shared_expert(activation_func_clamp_value=7.0)
+
+    with pytest.raises(RuntimeError, match="ScaledClampedQGeGLU"):
+        shared_expert._validate_fused_grouped_swiglu()
+
+
 @pytest.mark.parametrize(
     ("config_kwargs", "bad_linear", "match"),
     [
@@ -239,6 +265,21 @@ def test_make_fused_grouped_swiglu_ops_builds_grouped_pipeline(monkeypatch):
     assert fc2_op.kwargs["bias"] is False
     assert fc2_op.kwargs["accumulate_into_main_grad"] is False
     assert fc2_op.weight0 is shared_expert.linear_fc2.weight
+
+
+def test_make_fused_grouped_swiglu_ops_builds_clamped_activation(monkeypatch):
+    _patch_fake_shared_expert_te(monkeypatch)
+    shared_expert = _fake_shared_expert(activation_func_clamp_value=7.0)
+
+    shared_expert._validate_fused_grouped_swiglu()
+    ops = shared_expert._make_fused_grouped_swiglu_ops()
+
+    activation_op = list(ops.children())[1]
+    assert isinstance(activation_op, _FakeTEScaledClampedQGeGLU)
+    assert activation_op.glu_interleave_size == 32
+    assert activation_op.alpha == 1.0
+    assert activation_op.limit == 7.0
+    assert activation_op.glu_linear_offset == 0.0
 
 
 def test_fused_grouped_swiglu_ops_replay_linear_pre_forward_hooks(monkeypatch):
@@ -415,3 +456,72 @@ class TestSharedExperts:
             assert torch.allclose(
                 p_overlap.grad, p_no_overlap.grad
             ), f"max diff: {torch.max(torch.abs(p_overlap.grad - p_no_overlap.grad))}"
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    @pytest.mark.parametrize("bias_activation_fusion", [True, False])
+    def test_shared_expert_clamped_swiglu(self, bias_activation_fusion):
+        """Verify clamped SwiGLU parity for overlapped and synchronous shared experts."""
+        Utils.initialize_model_parallel(tensor_model_parallel_size=1, expert_model_parallel_size=1)
+        clamp_value = 1.0
+
+        _set_random_seed(seed_=123, data_parallel_random_init=False)
+        moe_layer_overlap = self.get_moe_layer(
+            moe_shared_expert_overlap=True,
+            moe_token_dispatcher_type="alltoall",
+            activation_func_clamp_value=clamp_value,
+            bias_activation_fusion=bias_activation_fusion,
+        ).to(dtype=torch.bfloat16)
+
+        _set_random_seed(seed_=123, data_parallel_random_init=False)
+        moe_layer_no_overlap = self.get_moe_layer(
+            moe_shared_expert_overlap=False,
+            moe_token_dispatcher_type="alltoall",
+            activation_func_clamp_value=clamp_value,
+            bias_activation_fusion=bias_activation_fusion,
+        ).to(dtype=torch.bfloat16)
+        moe_layer_no_overlap.load_state_dict(moe_layer_overlap.state_dict())
+
+        hidden_states = (
+            torch.randn((32, 2, self.config.hidden_size), device="cuda", dtype=torch.bfloat16) * 5.0
+        ).requires_grad_(True)
+        hidden_states_no_overlap = hidden_states.detach().clone().requires_grad_(True)
+
+        output_overlap, _ = moe_layer_overlap(hidden_states)
+        output_no_overlap, _ = moe_layer_no_overlap(hidden_states_no_overlap)
+
+        cos_out = F.cosine_similarity(
+            output_overlap.flatten().unsqueeze(0).float(),
+            output_no_overlap.flatten().unsqueeze(0).float(),
+        ).item()
+        assert cos_out > 0.999, (
+            f"shared-expert clamp output mismatch (fusion={bias_activation_fusion}): "
+            f"cos sim = {cos_out:.6f}"
+        )
+
+        output_overlap.mean().backward()
+        output_no_overlap.mean().backward()
+
+        for p_overlap, p_no_overlap in zip(
+            moe_layer_overlap.parameters(), moe_layer_no_overlap.parameters()
+        ):
+            assert torch.allclose(p_overlap.grad, p_no_overlap.grad), (
+                f"shared-expert clamp mismatch (fusion={bias_activation_fusion}); "
+                f"max diff: {torch.max(torch.abs(p_overlap.grad - p_no_overlap.grad))}"
+            )
+
+        _set_random_seed(seed_=123, data_parallel_random_init=False)
+        moe_layer_unclamped = self.get_moe_layer(
+            moe_shared_expert_overlap=False,
+            moe_token_dispatcher_type="alltoall",
+            activation_func_clamp_value=None,
+            bias_activation_fusion=bias_activation_fusion,
+        ).to(dtype=torch.bfloat16)
+        moe_layer_unclamped.load_state_dict(moe_layer_overlap.state_dict())
+
+        hidden_states_unclamped = hidden_states.detach().clone().requires_grad_(True)
+        output_unclamped, _ = moe_layer_unclamped(hidden_states_unclamped)
+        assert not torch.allclose(output_no_overlap, output_unclamped), (
+            "Clamping had no observable effect on shared-expert output; "
+            "activation_func_clamp_value may not be plumbed through."
+        )

--- a/tests/unit_tests/transformer/moe/test_shared_experts.py
+++ b/tests/unit_tests/transformer/moe/test_shared_experts.py
@@ -280,6 +280,7 @@ def test_make_fused_grouped_swiglu_ops_builds_clamped_activation(monkeypatch):
     assert activation_op.alpha == 1.0
     assert activation_op.limit == 7.0
     assert activation_op.glu_linear_offset == 0.0
+    assert activation_op._grouped_mlp_unit_activation_scale is True
 
 
 def test_fused_grouped_swiglu_ops_replay_linear_pre_forward_hooks(monkeypatch):
@@ -456,6 +457,50 @@ class TestSharedExperts:
             assert torch.allclose(
                 p_overlap.grad, p_no_overlap.grad
             ), f"max diff: {torch.max(torch.abs(p_overlap.grad - p_no_overlap.grad))}"
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_shared_expert_glu_linear_offset_overlap_parity(self):
+        """Nonzero GLU offsets produce identical overlap and synchronous results."""
+        Utils.initialize_model_parallel(tensor_model_parallel_size=1, expert_model_parallel_size=1)
+        shared_expert_kwargs = {
+            "moe_token_dispatcher_type": "alltoall",
+            "bias_activation_fusion": False,
+            "activation_func_clamp_value": None,
+            "glu_linear_offset": 0.5,
+        }
+
+        _set_random_seed(seed_=123, data_parallel_random_init=False)
+        moe_layer_overlap = self.get_moe_layer(
+            moe_shared_expert_overlap=True, **shared_expert_kwargs
+        ).to(dtype=torch.bfloat16)
+
+        _set_random_seed(seed_=123, data_parallel_random_init=False)
+        moe_layer_no_overlap = self.get_moe_layer(
+            moe_shared_expert_overlap=False, **shared_expert_kwargs
+        ).to(dtype=torch.bfloat16)
+        moe_layer_no_overlap.load_state_dict(moe_layer_overlap.state_dict())
+
+        hidden_states = torch.randn(
+            (32, 2, self.config.hidden_size),
+            requires_grad=True,
+            device="cuda",
+            dtype=torch.bfloat16,
+        )
+        hidden_states_no_overlap = hidden_states.detach().clone().requires_grad_(True)
+
+        output_overlap, _ = moe_layer_overlap(hidden_states)
+        output_no_overlap, _ = moe_layer_no_overlap(hidden_states_no_overlap)
+        torch.testing.assert_close(output_overlap, output_no_overlap)
+
+        output_overlap.mean().backward()
+        output_no_overlap.mean().backward()
+
+        torch.testing.assert_close(hidden_states.grad, hidden_states_no_overlap.grad)
+        for p_overlap, p_no_overlap in zip(
+            moe_layer_overlap.parameters(), moe_layer_no_overlap.parameters()
+        ):
+            torch.testing.assert_close(p_overlap.grad, p_no_overlap.grad)
 
     @pytest.mark.internal
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")


### PR DESCRIPTION
# Complete clamped SwiGLU across expert paths

## Summary

Add clamped SwiGLU as one usable feature across the primitive, routed and
shared experts, token-weighted fallbacks, and the Transformer Engine grouped
MLP path.

## Scope and non-goals

- Support bias-free, biased, and token-weighted forward/backward.
- Preserve the legacy unclamped path when the option is disabled.
- Add validation and Transformer Engine operator/constructor-signature gating,
  so optional `GroupedLinear` kwargs are passed only when the installed
  interface accepts them.
- Do not include unrelated activation rewrites, routing features, DSv4
  attention, or recipe changes.

## Provenance

This local recut is reconstructed from the frozen `main` baseline
`bb5647a9bdd0`, not a replay. It references master #5795 and combines #5940
and #5941 into one functional unit, including the completion fixes derived
from #4481 and #5130. Original clamped-SwiGLU and DSv4 integration credit:
@hxbai in #4481, #5130, and #5795.

## Dependencies

None beyond the frozen baseline used for this local recut. This is a reusable
prerequisite outside the nine-PR DSv4-specific series.

## Tests

- Primitive forward/backward for biased, bias-free, and token-weighted modes.
- Routed, shared, and fallback expert paths.
- Transformer Engine grouped-MLP behavior, optional constructor kwargs, and
  unsupported-interface validation.
- Legacy behavior when clamping is disabled.

## Publication

Publish in the first prerequisite round on then-current `main`. This is not a
stacked-review PR.
