### PR TITLE
fix(pipeline): scale DSv4 hybrid indexer loss

### DIFF
--- a/megatron/core/pipeline_parallel/schedules.py
+++ b/megatron/core/pipeline_parallel/schedules.py
@@ -277,7 +277,7 @@ def _get_experimental_attention_variant_loss_scale_func(config):
     if loss_scale_func is not None:
         return loss_scale_func
 
-    if getattr(config, 'experimental_attention_variant', None) == 'dsa':
+    if getattr(config, 'experimental_attention_variant', None) in ('dsa', 'dsv4_hybrid'):
         from megatron.core.transformer.experimental_attention_variant.dsa import (
             DSAIndexerLossAutoScaler,
         )

--- a/tests/unit_tests/pipeline_parallel/test_schedules.py
+++ b/tests/unit_tests/pipeline_parallel/test_schedules.py
@@ -377,7 +377,8 @@ def test_dsa_indexer_loss_scale_accepts_dict_output_tensor():
     )
 
 
-def test_dsa_indexer_loss_scale_defaults_from_variant_without_mutating_config():
+@pytest.mark.parametrize("variant", ["dsa", "dsv4_hybrid"])
+def test_indexer_loss_scale_defaults_from_variant_without_mutating_config(variant):
     from megatron.core.transformer.experimental_attention_variant.dsa import (
         DSAIndexerLossAutoScaler,
     )
@@ -385,7 +386,7 @@ def test_dsa_indexer_loss_scale_defaults_from_variant_without_mutating_config():
     config = SimpleNamespace(
         calculate_per_token_loss=True,
         experimental_attention_variant_loss_scale_func=None,
-        experimental_attention_variant='dsa',
+        experimental_attention_variant=variant,
         grad_scale_func=lambda tensor: tensor * 7.0,
         num_moe_experts=None,
         mtp_num_layers=None,


### PR DESCRIPTION
## What

Teach the pipeline loss-scale selector that the dsv4_hybrid attention variant uses the same DSA indexer-loss auto-scaler as dsa. The parameterized test verifies both names and preserves the caller config.

This two-file correctness hook is deliberately independent: peeling it away keeps the attention implementation PR out of the pipeline-parallel CODEOWNER group.

## Provenance

- Supports the DSv4 hybrid attention introduced in #4458.
- Refactors the corresponding pipeline hook captured in #5795.
- Original attention implementation by the #4458 authors; DSv4 main adaptation by @hxbai.
- Reconstructed against current main; feature cutoff: 2026-07-21.
- GPTModel integration is intentionally excluded.

## Testing

- ruff, Black --check, Python compilation, and git diff --check passed.
- Focused pytest execution is blocked because the repository uv environment on this host has no Torch; execution is left to CI.