### PR TITLE
feat(pipeline): carry mHC residual streams between stages

### DIFF
--- a/megatron/core/pipeline_parallel/schedules.py
+++ b/megatron/core/pipeline_parallel/schedules.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import contextlib
 from functools import partial
@@ -1161,7 +1161,11 @@ def forward_backward_pipelining_with_interleaving(
 
     model_type = get_model_type(model[0])
 
-    tensor_shape = [seq_length, micro_batch_size, config.hidden_size]
+    tensor_shape = [
+        seq_length,
+        micro_batch_size,
+        _get_pipeline_hidden_size(config, pp_group=p2p_communicator.pp_group),
+    ]
     tensor_shape[0] = tensor_shape[0] // cp_group.size()
     if config.sequence_parallel:
         tensor_shape[0] = tensor_shape[0] // tp_group.size()
@@ -2100,11 +2104,17 @@ def get_tensor_shapes(
     config,
     tp_group: Optional[torch.distributed.ProcessGroup] = None,
     cp_group: Optional[torch.distributed.ProcessGroup] = None,
+    pp_group: Optional[torch.distributed.ProcessGroup] = None,
+    is_recv: bool = True,
 ):
     """Determine tensor shapes for pipeline communication.
 
     Returns [()] for variable_seq_lengths mode (shapes exchanged dynamically),
     or computed shapes for fixed sequence length mode.
+
+    ``pp_group`` and ``is_recv`` distinguish the two mHC boundary shapes. The
+    first stage has no forward receive and the last stage has no forward send;
+    all communication between stages carries the expanded residual streams.
     """
     tensor_shapes = []
 
@@ -2120,8 +2130,33 @@ def get_tensor_shapes(
     if config.sequence_parallel:
         effective_seq_length = effective_seq_length // tp_group.size()
 
-    tensor_shapes.append((effective_seq_length, micro_batch_size, config.hidden_size))
+    hidden_size = _get_pipeline_hidden_size(config, pp_group=pp_group, is_recv=is_recv)
+    tensor_shapes.append((effective_seq_length, micro_batch_size, hidden_size))
     return tensor_shapes
+
+
+def _get_pipeline_hidden_size(
+    config, *, pp_group: Optional[torch.distributed.ProcessGroup], is_recv: Optional[bool] = None
+) -> int:
+    """Return the hidden dimension used by a pipeline communication edge."""
+    hidden_size = config.hidden_size
+    if not getattr(config, 'enable_hyper_connections', False) or pp_group is None:
+        return hidden_size
+
+    pp_rank = pp_group.rank()
+    pp_size = pp_group.size()
+    if pp_size == 1:
+        return hidden_size
+
+    # The interleaved schedule uses one shape for all P2P operations. Its only
+    # active communication edges are between stages, so all of them carry n*C.
+    if is_recv is None:
+        return hidden_size * config.num_residual_streams
+
+    is_inactive_boundary = (is_recv and pp_rank == 0) or (not is_recv and pp_rank == pp_size - 1)
+    if is_inactive_boundary:
+        return hidden_size
+    return hidden_size * config.num_residual_streams
 
 
 def forward_backward_pipelining_without_interleaving(
@@ -2287,6 +2322,9 @@ def forward_backward_pipelining_without_interleaving(
     else:
         backward_func = backward_step
 
+    # Multi-module pipelines exchange variable shapes and do not expose one
+    # pipeline group for the full topology.
+    pp_group = getattr(p2p_communicator, 'pp_group', None)
     recv_tensor_shapes = get_tensor_shapes(
         seq_length=seq_length,
         micro_batch_size=micro_batch_size,
@@ -2294,6 +2332,8 @@ def forward_backward_pipelining_without_interleaving(
         config=config,
         tp_group=tp_group,
         cp_group=cp_group,
+        pp_group=pp_group,
+        is_recv=True,
     )
     send_tensor_shapes = get_tensor_shapes(
         seq_length=seq_length,
@@ -2302,6 +2342,8 @@ def forward_backward_pipelining_without_interleaving(
         config=config,
         tp_group=tp_group,
         cp_group=cp_group,
+        pp_group=pp_group,
+        is_recv=False,
     )
     if adjust_tensor_shapes_fn is not None:
         recv_tensor_shapes, send_tensor_shapes = adjust_tensor_shapes_fn(

--- a/tests/unit_tests/pipeline_parallel/test_mhc_tensor_shapes.py
+++ b/tests/unit_tests/pipeline_parallel/test_mhc_tensor_shapes.py
@@ -1,0 +1,153 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from megatron.core.pipeline_parallel.schedules import _get_pipeline_hidden_size, get_tensor_shapes
+from megatron.core.transformer.transformer_config import TransformerConfig
+
+
+class FakeProcessGroup:
+    """Small process-group stand-in for schedule shape tests."""
+
+    def __init__(self, rank: int, size: int):
+        self._rank = rank
+        self._size = size
+
+    def rank(self) -> int:
+        return self._rank
+
+    def size(self) -> int:
+        return self._size
+
+
+def make_config(**overrides):
+    values = {
+        'hidden_size': 64,
+        'enable_hyper_connections': True,
+        'num_residual_streams': 4,
+        'sequence_parallel': False,
+        'variable_seq_lengths': False,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def get_shapes(config, *, pp_rank=0, pp_size=2, is_recv=True, tp_size=1, cp_size=1):
+    return get_tensor_shapes(
+        seq_length=32,
+        micro_batch_size=2,
+        decoder_seq_length=None,
+        config=config,
+        tp_group=FakeProcessGroup(0, tp_size),
+        cp_group=FakeProcessGroup(0, cp_size),
+        pp_group=FakeProcessGroup(pp_rank, pp_size),
+        is_recv=is_recv,
+    )
+
+
+@pytest.mark.parametrize(
+    "pp_rank,is_recv,hidden_size",
+    [
+        (0, True, 64),
+        (0, False, 256),
+        (1, True, 256),
+        (1, False, 256),
+        (2, True, 256),
+        (2, False, 256),
+        (3, True, 256),
+        (3, False, 64),
+    ],
+)
+def test_non_interleaved_mhc_uses_expanded_shape_between_stages(pp_rank, is_recv, hidden_size):
+    shapes = get_shapes(make_config(), pp_rank=pp_rank, pp_size=4, is_recv=is_recv)
+
+    assert shapes == [(32, 2, hidden_size)]
+
+
+@pytest.mark.parametrize("enable_hyper_connections", [False, True])
+@pytest.mark.parametrize("is_recv", [False, True])
+def test_single_pipeline_stage_keeps_model_hidden_size(enable_hyper_connections, is_recv):
+    config = make_config(enable_hyper_connections=enable_hyper_connections)
+
+    assert get_shapes(config, pp_size=1, is_recv=is_recv) == [(32, 2, 64)]
+
+
+def test_non_mhc_pipeline_keeps_model_hidden_size():
+    config = make_config(enable_hyper_connections=False)
+
+    for rank in range(4):
+        assert get_shapes(config, pp_rank=rank, pp_size=4, is_recv=True) == [(32, 2, 64)]
+        assert get_shapes(config, pp_rank=rank, pp_size=4, is_recv=False) == [(32, 2, 64)]
+
+
+def test_legacy_get_tensor_shapes_call_without_pp_group_is_unchanged():
+    config = make_config()
+
+    shapes = get_tensor_shapes(
+        seq_length=32,
+        micro_batch_size=2,
+        decoder_seq_length=None,
+        config=config,
+        tp_group=FakeProcessGroup(0, 1),
+        cp_group=FakeProcessGroup(0, 1),
+    )
+
+    assert shapes == [(32, 2, 64)]
+
+
+@pytest.mark.parametrize(
+    "enabled,pp_size,hidden_size", [(False, 1, 64), (False, 4, 64), (True, 1, 64), (True, 4, 256)]
+)
+def test_interleaved_pipeline_uses_one_shape_for_all_active_edges(enabled, pp_size, hidden_size):
+    config = make_config(enable_hyper_connections=enabled)
+
+    assert _get_pipeline_hidden_size(config, pp_group=FakeProcessGroup(0, pp_size)) == hidden_size
+
+
+def test_mhc_shape_preserves_context_and_sequence_parallel_scaling():
+    config = make_config(sequence_parallel=True)
+
+    shapes = get_shapes(config, pp_rank=1, pp_size=4, is_recv=True, tp_size=2, cp_size=4)
+
+    assert shapes == [(4, 2, 256)]
+
+
+def test_mhc_shape_uses_decoder_sequence_length():
+    config = make_config()
+
+    shapes = get_tensor_shapes(
+        seq_length=32,
+        micro_batch_size=2,
+        decoder_seq_length=48,
+        config=config,
+        tp_group=FakeProcessGroup(0, 1),
+        cp_group=FakeProcessGroup(0, 2),
+        pp_group=FakeProcessGroup(1, 4),
+        is_recv=True,
+    )
+
+    assert shapes == [(24, 2, 256)]
+
+
+def test_variable_sequence_length_shape_is_unchanged():
+    config = make_config(variable_seq_lengths=True)
+
+    assert get_shapes(config, pp_rank=1, pp_size=4, is_recv=True) == [()]
+
+
+def test_native_mhc_transformer_config_drives_pipeline_shape():
+    config = TransformerConfig(
+        num_layers=8,
+        hidden_size=64,
+        num_attention_heads=4,
+        pipeline_model_parallel_size=2,
+        pipeline_dtype=torch.bfloat16,
+        enable_hyper_connections=True,
+        num_residual_streams=4,
+        use_cpu_initialization=True,
+    )
+
+    assert get_shapes(config, pp_rank=0, pp_size=2, is_recv=False) == [(32, 2, 256)]


### PR DESCRIPTION
## What

Teach the PP/VPP schedules to carry expanded mHC residual streams across real stage-to-stage edges:

- active edges use num_residual_streams times hidden_size;
- first receive, last send, PP=1, non-mHC, and variable-shape paths retain existing behavior;
- interleaved VPP keeps one uniform expanded shape for its active edges;
- MultiModulePipelineCommunicator remains compatible when no single pp_group exists;
- no new global process-group reads are introduced.

## Stack

- Depends on #5936 (which itself depends on #5935).
- Temporary review base: pull-request/5936.
- Files changed contains only pipeline schedules and one CPU shape-test module.
- Before #5936 merges, retarget and refresh this PR to the next stable base/main to preserve review history.

## Provenance

- Reconstructs the pipeline shape portion of #2943.
- Refactors the same schedule support captured in #5795 (commit 07c0d088).
- Original implementation by the #2943 authors; DSv4 adaptation by @hxbai.
- Feature cutoff: 2026-07-21. GPTModel wiring is intentionally excluded.

## Testing

- isort, Black --check, ruff, pylint (10/10), compileall, and git diff --check passed.
- CPU/single-process shape tests are included; local execution is blocked because this host lacks Torch. Real PP/VPP behavior remains for stack GPU CI.