### PR TITLE
Explicit safe MLA RoPE primitives and consumers

### DIFF
--- a/megatron/core/fusions/fused_mla_yarn_rope_apply.py
+++ b/megatron/core/fusions/fused_mla_yarn_rope_apply.py
@@ -29,17 +29,28 @@ if not HAVE_TRITON:
 
 @triton.jit
 def _get_thd_token_idx(cu_seqlens, pid_m, seq_num, cp_rank, cp_size):
-    token_idx = -1
-    this_seq_len = 0
+    # Cast ``pid_m`` and ``cu_seqlens`` loads to a single shared dtype so
+    # the loop-body reassignments don't surface as
+    # "initial value is int32 but redefined as int64" in newer Triton
+    # versions (which promote ``// Python_int`` to int64).
+    pid_m = pid_m.to(tl.int64)
+    token_idx = tl.full((), -1, dtype=tl.int64)
+    this_seq_len = tl.full((), 0, dtype=tl.int64)
     seq_idx = 0
-    last_cum_seqlen = tl.load(cu_seqlens) // cp_size
+    last_cum_seqlen = tl.load(cu_seqlens).to(tl.int64) // cp_size
     while seq_idx < seq_num:
-        cur_cum_seqlen = tl.load(cu_seqlens + seq_idx + 1) // cp_size
+        cur_cum_seqlen = tl.load(cu_seqlens + seq_idx + 1).to(tl.int64) // cp_size
         if token_idx == -1 and cur_cum_seqlen > pid_m:
             token_idx = pid_m - last_cum_seqlen
             this_seq_len = cur_cum_seqlen - last_cum_seqlen
         last_cum_seqlen = cur_cum_seqlen
         seq_idx += 1
+    # Padding tokens beyond cu_seqlens[-1] (from THD CUDA-graph padding)
+    # never match any sequence, leaving token_idx == -1.  Clamp to 0 so
+    # the cos/sin table loads stay in-bounds; the wrong RoPE result is
+    # harmless because padding positions are excluded by loss_mask.
+    if token_idx == -1:
+        token_idx = tl.full((), 0, dtype=tl.int64)
     if cp_size > 1:
         if token_idx < this_seq_len // 2:
             token_idx = token_idx + cp_rank * this_seq_len // 2
@@ -65,29 +76,34 @@ def _get_thd_token_idx(cu_seqlens, pid_m, seq_num, cp_rank, cp_size):
     restore_value=["Q"],
 )
 @triton.jit
-def rotary_fwd_q_kernel(
+def _mla_rope_fwd_inplace_kernel(
     Q,
     COS,
     SIN,
-    qk_head_dim,
+    nope_dim,
     emb_dim: tl.constexpr,
     head_num: tl.constexpr,
     batch_size,
     seq_num,
     cu_seqlens_q,
+    position_ids,
     stride_x_seq,
     stride_x_nheads,
+    stride_cos_seq,
+    stride_sin_seq,
     cp_rank,
     cp_size,
+    INVERSE: tl.constexpr,
+    REMOVE_INTERLEAVING: tl.constexpr,
     BLOCK_H: tl.constexpr,
 ):
     """
-    Triton kernel of the forward pass for applying YARN RoPE to MLA's query.
-    This kernel inplace modifies the input tensor Q.
+    Forward pass: apply RoPE inplace to the trailing emb_dim elements.
+    Reads from interleaved layout, writes back to interleaved layout.
 
     Input:
-        Q: [seq_len, batch_size, head_num, qk_head_dim + emb_dim]
-            or [total_seq_len, head_num, qk_head_dim + emb_dim]
+        Q: [seq_len, batch_size, head_num, nope_dim + emb_dim]
+            or [total_seq_len, head_num, nope_dim + emb_dim]
         COS/SIN: [max_seq_len, emb_dim]
 
         batch_size: batch size for sbhd format, not used for thd format
@@ -97,15 +113,24 @@ def rotary_fwd_q_kernel(
     pid_m = tl.program_id(axis=0)
     pid_head = tl.program_id(axis=1)
 
-    if cu_seqlens_q is None:
+    if position_ids is not None:
+        token_idx = tl.load(position_ids + pid_m)
+    elif cu_seqlens_q is None:
         token_idx = pid_m // batch_size
     else:
         token_idx = _get_thd_token_idx(cu_seqlens_q, pid_m, seq_num, cp_rank, cp_size)
 
-    cos_left = tl.load(COS + token_idx * emb_dim + tl.arange(0, emb_dim // 2))
-    sin_left = tl.load(SIN + token_idx * emb_dim + tl.arange(0, emb_dim // 2))
-    cos_right = tl.load(COS + token_idx * emb_dim + emb_dim // 2 + tl.arange(0, emb_dim // 2))
-    sin_right = tl.load(SIN + token_idx * emb_dim + emb_dim // 2 + tl.arange(0, emb_dim // 2))
+    cos_left = tl.load(COS + token_idx * stride_cos_seq + tl.arange(0, emb_dim // 2))
+    sin_left = tl.load(SIN + token_idx * stride_sin_seq + tl.arange(0, emb_dim // 2))
+    cos_right = tl.load(
+        COS + token_idx * stride_cos_seq + emb_dim // 2 + tl.arange(0, emb_dim // 2)
+    )
+    sin_right = tl.load(
+        SIN + token_idx * stride_sin_seq + emb_dim // 2 + tl.arange(0, emb_dim // 2)
+    )
+    if INVERSE:
+        sin_left = -sin_left
+        sin_right = -sin_right
     cos_left = cos_left.expand_dims(0).broadcast_to(BLOCK_H, emb_dim // 2)
     sin_left = sin_left.expand_dims(0).broadcast_to(BLOCK_H, emb_dim // 2)
     cos_right = cos_right.expand_dims(0).broadcast_to(BLOCK_H, emb_dim // 2)
@@ -113,7 +138,7 @@ def rotary_fwd_q_kernel(
 
     Q = Q + pid_m * stride_x_seq + pid_head * BLOCK_H * stride_x_nheads
 
-    x_off = tl.arange(0, BLOCK_H)[:, None] * stride_x_nheads + qk_head_dim
+    x_off = tl.arange(0, BLOCK_H)[:, None] * stride_x_nheads + nope_dim
     mask = x_off < head_num * stride_x_nheads
     # x1 = t[..., 0::2], x2 = t[..., 1::2]
     x_1_off = x_off + tl.arange(0, emb_dim // 2)[None, :] * 2
@@ -124,10 +149,14 @@ def rotary_fwd_q_kernel(
     x_left = x_1 * cos_left - x_2 * sin_left
     x_right = x_2 * cos_right + x_1 * sin_right
 
-    x_left_off = x_off + tl.arange(0, emb_dim // 2)[None, :]
-    x_right_off = x_left_off + emb_dim // 2
-    tl.store(Q + x_left_off, x_left, mask=mask)
-    tl.store(Q + x_right_off, x_right, mask=mask)
+    if REMOVE_INTERLEAVING:
+        tl.store(Q + x_1_off, x_left, mask=mask)
+        tl.store(Q + x_2_off, x_right, mask=mask)
+    else:
+        x_left_off = x_off + tl.arange(0, emb_dim // 2)[None, :]
+        x_right_off = x_left_off + emb_dim // 2
+        tl.store(Q + x_left_off, x_left, mask=mask)
+        tl.store(Q + x_right_off, x_right, mask=mask)
 
 
 @triton.autotune(
@@ -145,29 +174,34 @@ def rotary_fwd_q_kernel(
     restore_value=["DO"],
 )
 @triton.jit
-def rotary_bwd_q_kernel(
+def _mla_rope_bwd_inplace_kernel(
     DO,
     COS,
     SIN,
-    qk_head_dim,
+    nope_dim,
     emb_dim: tl.constexpr,
     head_num: tl.constexpr,
     batch_size,
     seq_num,
     cu_seqlens_q,
+    position_ids,
     stride_x_seq,
     stride_x_nheads,
+    stride_cos_seq,
+    stride_sin_seq,
     cp_rank,
     cp_size,
+    INVERSE: tl.constexpr,
+    REMOVE_INTERLEAVING: tl.constexpr,
     BLOCK_H: tl.constexpr,
 ):
     """
-    Triton kernel of the backward pass for applying YARN RoPE to MLA's query.
-    This kernel inplace modifies the input tensor DO.
+    Backward pass: inverse RoPE inplace on the trailing emb_dim elements.
+    Reads from interleaved layout, writes to interleaved layout.
 
     Input:
-        DO: [seq_len, batch_size, head_num, qk_head_dim + emb_dim]
-            or [total_seq_len, head_num, qk_head_dim + emb_dim]
+        DO: [seq_len, batch_size, head_num, nope_dim + emb_dim]
+            or [total_seq_len, head_num, nope_dim + emb_dim]
         COS/SIN: [max_seq_len, emb_dim]
 
         batch_size, seq_num, and cu_seqlens_q are the same as in the forward pass
@@ -175,15 +209,24 @@ def rotary_bwd_q_kernel(
     pid_m = tl.program_id(axis=0)
     pid_head = tl.program_id(axis=1)
 
-    if cu_seqlens_q is None:
+    if position_ids is not None:
+        token_idx = tl.load(position_ids + pid_m)
+    elif cu_seqlens_q is None:
         token_idx = pid_m // batch_size
     else:
         token_idx = _get_thd_token_idx(cu_seqlens_q, pid_m, seq_num, cp_rank, cp_size)
 
-    cos_left = tl.load(COS + token_idx * emb_dim + tl.arange(0, emb_dim // 2))
-    sin_left = tl.load(SIN + token_idx * emb_dim + tl.arange(0, emb_dim // 2))
-    cos_right = tl.load(COS + token_idx * emb_dim + emb_dim // 2 + tl.arange(0, emb_dim // 2))
-    sin_right = tl.load(SIN + token_idx * emb_dim + emb_dim // 2 + tl.arange(0, emb_dim // 2))
+    cos_left = tl.load(COS + token_idx * stride_cos_seq + tl.arange(0, emb_dim // 2))
+    sin_left = tl.load(SIN + token_idx * stride_sin_seq + tl.arange(0, emb_dim // 2))
+    cos_right = tl.load(
+        COS + token_idx * stride_cos_seq + emb_dim // 2 + tl.arange(0, emb_dim // 2)
+    )
+    sin_right = tl.load(
+        SIN + token_idx * stride_sin_seq + emb_dim // 2 + tl.arange(0, emb_dim // 2)
+    )
+    if INVERSE:
+        sin_left = -sin_left
+        sin_right = -sin_right
     cos_left = cos_left.expand_dims(0).broadcast_to(BLOCK_H, emb_dim // 2)
     sin_left = sin_left.expand_dims(0).broadcast_to(BLOCK_H, emb_dim // 2)
     cos_right = cos_right.expand_dims(0).broadcast_to(BLOCK_H, emb_dim // 2)
@@ -191,25 +234,32 @@ def rotary_bwd_q_kernel(
 
     DO = DO + pid_m * stride_x_seq + pid_head * BLOCK_H * stride_x_nheads
 
-    x_off = tl.arange(0, BLOCK_H)[:, None] * stride_x_nheads + qk_head_dim
+    x_off = tl.arange(0, BLOCK_H)[:, None] * stride_x_nheads + nope_dim
     mask = x_off < head_num * stride_x_nheads
-    x_left_off = x_off + tl.arange(0, emb_dim // 2)[None, :]
-    x_right_off = x_left_off + emb_dim // 2
-    x_left = tl.load(DO + x_left_off, mask=mask)
-    x_right = tl.load(DO + x_right_off, mask=mask)
+    if REMOVE_INTERLEAVING:
+        x_1_off = x_off + tl.arange(0, emb_dim // 2)[None, :] * 2
+        x_2_off = x_1_off + 1
+        x_left = tl.load(DO + x_1_off, mask=mask)
+        x_right = tl.load(DO + x_2_off, mask=mask)
+    else:
+        x_left_off = x_off + tl.arange(0, emb_dim // 2)[None, :]
+        x_right_off = x_left_off + emb_dim // 2
+        x_left = tl.load(DO + x_left_off, mask=mask)
+        x_right = tl.load(DO + x_right_off, mask=mask)
+        x_1_off = x_off + tl.arange(0, emb_dim // 2)[None, :] * 2
+        x_2_off = x_1_off + 1
 
     x_1 = x_left * cos_left + x_right * sin_right
     x_2 = -x_left * sin_left + x_right * cos_right
 
-    x_1_off = x_off + tl.arange(0, emb_dim // 2)[None, :] * 2
-    x_2_off = x_1_off + 1
     tl.store(DO + x_1_off, x_1, mask=mask)
     tl.store(DO + x_2_off, x_2, mask=mask)
 
 
-class ApplyMLARotaryEmbQ(torch.autograd.Function):
+class _FusedMLARoPEInplace(torch.autograd.Function):
     """
-    Autograd function for applying YARN RoPE to MLA's query.
+    Autograd function for applying RoPE inplace to the trailing emb_dim
+    elements of a multi-head tensor (leaving the first nope_dim elements unchanged).
     """
 
     @staticmethod
@@ -218,22 +268,26 @@ class ApplyMLARotaryEmbQ(torch.autograd.Function):
         q,
         cos,
         sin,
-        qk_head_dim,
+        nope_dim,
         emb_dim,
         cu_seqlens_q,
         cp_rank,
         cp_size,
         rotary_interleaved=False,
+        inverse=False,
+        remove_interleaving=False,
+        position_ids=None,
     ):
         """
-        Forward function for ApplyMLARotaryEmbQ.
+        Forward function for _FusedMLARoPEInplace.
 
         Args:
-            q: [seq_len, batch_size, head_num, qk_head_dim + emb_dim]
-                or [total_seq_len, head_num, qk_head_dim + emb_dim]
+            q: [seq_len, batch_size, head_num, nope_dim + emb_dim]
+                or [total_seq_len, head_num, nope_dim + emb_dim]
             cos/sin: [max_seq_len, 1, 1, emb_dim]
             cu_seqlens_q: [seq_num + 1] accumulated sequence lengths for thd format
             rotary_interleaved: whether to apply RoPE interleaved, only supports False for now
+            inverse: if True, negate sin inside the kernel to apply the inverse rotation
         """
         assert not rotary_interleaved
         max_seqlen = None
@@ -241,6 +295,7 @@ class ApplyMLARotaryEmbQ(torch.autograd.Function):
         seq_num = None
         if cu_seqlens_q is None:
             # sbhd
+            assert position_ids is None
             max_seqlen, batch_size, nheads, headdim = q.shape
             q = q.view(-1, nheads, headdim)
             total_seqlen = q.shape[0]
@@ -248,33 +303,43 @@ class ApplyMLARotaryEmbQ(torch.autograd.Function):
             # thd
             total_seqlen, nheads, headdim = q.shape
             seq_num = len(cu_seqlens_q) - 1
+            if position_ids is not None:
+                assert position_ids.shape == (total_seqlen,)
         assert q.stride(-1) == 1
-        assert cos.is_contiguous()
-        assert sin.is_contiguous()
-        assert headdim == qk_head_dim + emb_dim
+        assert cos.stride(-1) == 1
+        assert sin.stride(-1) == 1
+        assert headdim == nope_dim + emb_dim
         assert emb_dim % 4 == 0
 
         grid = lambda META: (total_seqlen, triton.cdiv(nheads, META["BLOCK_H"]))
-        rotary_fwd_q_kernel[grid](
+        _mla_rope_fwd_inplace_kernel[grid](
             q,
             cos,
             sin,
-            qk_head_dim,
+            nope_dim,
             emb_dim,
             nheads,
             batch_size,
             seq_num,
             cu_seqlens_q,
+            position_ids,
             q.stride(0),
             q.stride(1),
+            cos.stride(0),
+            sin.stride(0),
             cp_rank,
             cp_size,
+            INVERSE=inverse,
+            REMOVE_INTERLEAVING=remove_interleaving,
         )
-        ctx.save_for_backward(cos, sin)
-        ctx.qk_head_dim = qk_head_dim
+        ctx.save_for_backward(cos, sin, *(() if position_ids is None else (position_ids,)))
+        ctx.has_position_ids = position_ids is not None
+        ctx.nope_dim = nope_dim
         ctx.emb_dim = emb_dim
         ctx.cu_seqlens_q = cu_seqlens_q
         ctx.rotary_interleaved = rotary_interleaved
+        ctx.inverse = inverse
+        ctx.remove_interleaving = remove_interleaving
         ctx.cp_rank = cp_rank
         ctx.cp_size = cp_size
         if cu_seqlens_q is None:
@@ -284,13 +349,17 @@ class ApplyMLARotaryEmbQ(torch.autograd.Function):
     @staticmethod
     def backward(ctx, grad):
         """
-        Backward function for ApplyMLARotaryEmbQ.
+        Backward function for _FusedMLARoPEInplace.
 
         Args:
-            grad: [seq_len, batch_size, head_num, qk_head_dim + emb_dim]
-                or [total_seq_len, head_num, qk_head_dim + emb_dim]
+            grad: [seq_len, batch_size, head_num, nope_dim + emb_dim]
+                or [total_seq_len, head_num, nope_dim + emb_dim]
         """
-        cos, sin = ctx.saved_tensors
+        if ctx.has_position_ids:
+            cos, sin, position_ids = ctx.saved_tensors
+        else:
+            cos, sin = ctx.saved_tensors
+            position_ids = None
         max_seqlen = None
         batch_size = None
         seq_num = None
@@ -300,65 +369,126 @@ class ApplyMLARotaryEmbQ(torch.autograd.Function):
             total_seqlen = grad.shape[0]
         else:
             seq_num = len(ctx.cu_seqlens_q) - 1
+            if ctx.has_position_ids:
+                grad = grad.contiguous()
             total_seqlen, nheads, headdim = grad.shape
         assert grad.stride(-1) == 1
 
         grid = lambda META: (total_seqlen, triton.cdiv(nheads, META["BLOCK_H"]))
-        rotary_bwd_q_kernel[grid](
+        _mla_rope_bwd_inplace_kernel[grid](
             grad,
             cos,
             sin,
-            ctx.qk_head_dim,
+            ctx.nope_dim,
             ctx.emb_dim,
             nheads,
             batch_size,
             seq_num,
             ctx.cu_seqlens_q,
+            position_ids,
             grad.stride(0),
             grad.stride(1),
+            cos.stride(0),
+            sin.stride(0),
             ctx.cp_rank,
             ctx.cp_size,
+            INVERSE=ctx.inverse,
+            REMOVE_INTERLEAVING=ctx.remove_interleaving,
         )
         if ctx.cu_seqlens_q is None:
             grad = grad.view(max_seqlen, batch_size, nheads, headdim)
-        return grad, None, None, None, None, None, None, None, None
+        return grad, None, None, None, None, None, None, None, None, None, None, None
 
 
-def fused_apply_mla_rope_for_q(
+def fused_mla_rope_inplace(
     t: torch.Tensor,
     cos: torch.Tensor,
     sin: torch.Tensor,
-    qk_head_dim: int,
+    nope_dim: int,
     emb_dim: int,
     cu_seqlens_q: Optional[torch.Tensor] = None,
     cp_rank: int = 0,
     cp_size: int = 1,
     rotary_interleaved: bool = False,
-):
+    inverse: bool = False,
+    remove_interleaving: bool = False,
+    position_ids: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
     """
-    Fused function for applying YARN RoPE to MLA's query.
-    This function inplace modifies the input tensor t.
-    Along the last dimension of t, the last emb_dim elements are applied with RoPE.
-    The first qk_head_dim elements are not modified.
-    It is an experimental feature and may change in future versions.
+    Fused RoPE applied inplace to the trailing emb_dim elements of a tensor,
+    leaving the first nope_dim elements unchanged.
     It supports both sbhd and thd input formats.
+
+    When ``inverse=True`` the rotation is reversed, which is useful for
+    undoing RoPE on the attention output.
 
     For the notations below, seq_len is the length of the sequence per batch for sbhd format,
     total_seq_len is the total length of the sequences for thd format.
     max_seq_len is the maximum length of the sequences in the input tensor.
 
     Args:
-        t: [seq_len, batch_size, head_num, qk_head_dim + emb_dim]
-            or [total_seq_len, head_num, qk_head_dim + emb_dim]
+        t: [seq_len, batch_size, head_num, nope_dim + emb_dim]
+            or [total_seq_len, head_num, nope_dim + emb_dim]
         cos/sin: [max_seq_len, 1, 1, emb_dim]
         cu_seqlens_q: [seq_num + 1] accumulated sequence lengths for thd format
         rotary_interleaved: whether to apply RoPE interleaved, only supports False for now
+        inverse: if True, apply the inverse rotation
+        remove_interleaving: if True, output RoPE dims in non-interleaved layout
+        position_ids: optional THD row positions. When supplied, these positions
+            replace the built-in CP row-to-position mapping.
 
     Returns:
         t: inplace modified input tensor
     """
-    return ApplyMLARotaryEmbQ.apply(
-        t, cos, sin, qk_head_dim, emb_dim, cu_seqlens_q, cp_rank, cp_size, rotary_interleaved
+    return _FusedMLARoPEInplace.apply(
+        t,
+        cos,
+        sin,
+        nope_dim,
+        emb_dim,
+        cu_seqlens_q,
+        cp_rank,
+        cp_size,
+        rotary_interleaved,
+        inverse,
+        remove_interleaving,
+        position_ids,
+    )
+
+
+def fused_mla_rope_out_of_place(
+    t: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    nope_dim: int,
+    emb_dim: int,
+    cu_seqlens_q: Optional[torch.Tensor] = None,
+    cp_rank: int = 0,
+    cp_size: int = 1,
+    rotary_interleaved: bool = False,
+    inverse: bool = False,
+    remove_interleaving: bool = False,
+    position_ids: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Apply the fused RoPE kernel without modifying the input tensor.
+
+    Use this wrapper when an upstream autograd function may have retained its
+    output for backward. The underlying kernel remains in-place, so a private
+    copy is required to keep the retained tensor unchanged.
+    """
+    return fused_mla_rope_inplace(
+        t.clone(),
+        cos,
+        sin,
+        nope_dim,
+        emb_dim,
+        cu_seqlens_q=cu_seqlens_q,
+        cp_rank=cp_rank,
+        cp_size=cp_size,
+        rotary_interleaved=rotary_interleaved,
+        inverse=inverse,
+        remove_interleaving=remove_interleaving,
+        position_ids=position_ids,
     )
 
 
@@ -376,7 +506,7 @@ def fused_apply_mla_rope_for_q(
     key=["emb_dim", "k_dim", "v_dim", "head_num"],
 )
 @triton.jit
-def rotary_fwd_kv_kernel(
+def _mla_rope_fwd_kv_split_kernel(
     KV,
     K_POS_EMB,
     O_KEY,
@@ -399,12 +529,12 @@ def rotary_fwd_kv_kernel(
     stride_v_nheads,
     cp_rank,
     cp_size,
+    REMOVE_INTERLEAVING: tl.constexpr,
     BLOCK_H: tl.constexpr,
 ):
     """
-    Triton kernel of the forward pass for applying YARN RoPE to MLA's key and value.
-    It splits the input tensor KV into key and value,
-    and concatenates the processed RoPE to the key.
+    Forward pass: split KV into key and value, apply RoPE to k_pos_emb,
+    and concatenate the result onto key.
 
     Input:
         KV: [seq_len, batch_size, head_num, k_dim + v_dim]
@@ -460,14 +590,24 @@ def rotary_fwd_kv_kernel(
     x_left = x_left.expand_dims(0).broadcast_to(BLOCK_H, emb_dim // 2)
     x_right = x_right.expand_dims(0).broadcast_to(BLOCK_H, emb_dim // 2)
 
-    x_left_off = (
-        tl.arange(0, BLOCK_H)[:, None] * stride_k_nheads
-        + k_dim
-        + tl.arange(0, emb_dim // 2)[None, :]
-    )
-    x_right_off = x_left_off + emb_dim // 2
-    tl.store(K_ptr + x_left_off, x_left, mask=mask)
-    tl.store(K_ptr + x_right_off, x_right, mask=mask)
+    if REMOVE_INTERLEAVING:
+        x_1_off = (
+            tl.arange(0, BLOCK_H)[:, None] * stride_k_nheads
+            + k_dim
+            + tl.arange(0, emb_dim // 2)[None, :] * 2
+        )
+        x_2_off = x_1_off + 1
+        tl.store(K_ptr + x_1_off, x_left, mask=mask)
+        tl.store(K_ptr + x_2_off, x_right, mask=mask)
+    else:
+        x_left_off = (
+            tl.arange(0, BLOCK_H)[:, None] * stride_k_nheads
+            + k_dim
+            + tl.arange(0, emb_dim // 2)[None, :]
+        )
+        x_right_off = x_left_off + emb_dim // 2
+        tl.store(K_ptr + x_left_off, x_left, mask=mask)
+        tl.store(K_ptr + x_right_off, x_right, mask=mask)
 
 
 @triton.autotune(
@@ -484,7 +624,7 @@ def rotary_fwd_kv_kernel(
     key=["emb_dim", "k_dim", "v_dim", "head_num"],
 )
 @triton.jit
-def rotary_bwd_kv_kernel(
+def _mla_rope_bwd_kv_split_kernel(
     dK,
     dV,
     dKV,
@@ -507,10 +647,11 @@ def rotary_bwd_kv_kernel(
     stride_demb_seq,
     cp_rank,
     cp_size,
+    REMOVE_INTERLEAVING: tl.constexpr,
     BLOCK_H: tl.constexpr,
 ):
     """
-    Triton kernel of the backward pass for applying YARN RoPE to MLA's key and value.
+    Backward pass for the KV-split RoPE.
 
     Input:
         dK: [seq_len, batch_size, head_num, emb_dim + k_dim]
@@ -555,10 +696,16 @@ def rotary_bwd_kv_kernel(
             dK_ptr = dK + pid_m * stride_dk_seq + i * BLOCK_H * stride_dk_nheads
             x_off = tl.arange(0, BLOCK_H)[:, None] * stride_dk_nheads + k_dim
             mask = x_off < head_num * stride_dk_nheads
-            x_left_off = x_off + tl.arange(0, emb_dim // 2)[None, :]
-            x_right_off = x_left_off + emb_dim // 2
-            x_left = tl.load(dK_ptr + x_left_off, mask=mask)
-            x_right = tl.load(dK_ptr + x_right_off, mask=mask)
+            if REMOVE_INTERLEAVING:
+                x_1_off = x_off + tl.arange(0, emb_dim // 2)[None, :] * 2
+                x_2_off = x_1_off + 1
+                x_left = tl.load(dK_ptr + x_1_off, mask=mask)
+                x_right = tl.load(dK_ptr + x_2_off, mask=mask)
+            else:
+                x_left_off = x_off + tl.arange(0, emb_dim // 2)[None, :]
+                x_right_off = x_left_off + emb_dim // 2
+                x_left = tl.load(dK_ptr + x_left_off, mask=mask)
+                x_right = tl.load(dK_ptr + x_right_off, mask=mask)
             x_left_accum += x_left
             x_right_accum += x_right
         x_left_accum = tl.sum(x_left_accum, axis=0)
@@ -578,9 +725,10 @@ def rotary_bwd_kv_kernel(
         tl.store(dEMB_ptr + tl.arange(0, emb_dim // 2) * 2 + 1, x_2)
 
 
-class ApplyMLARotaryEmbKV(torch.autograd.Function):
+class _FusedMLARoPEKVSplit(torch.autograd.Function):
     """
-    Autograd function for applying YARN RoPE to MLA's key and value.
+    Autograd function for applying RoPE to MLA's key and value.
+    Splits KV, applies RoPE to k_pos_emb, concatenates onto key.
     """
 
     @staticmethod
@@ -597,9 +745,10 @@ class ApplyMLARotaryEmbKV(torch.autograd.Function):
         cp_rank,
         cp_size,
         rotary_interleaved=False,
+        remove_interleaving=False,
     ):
         """
-        Forward function for ApplyMLARotaryEmbKV.
+        Forward function for _FusedMLARoPEKVSplit.
 
         Args:
             kv: [seq_len, batch_size, head_num, k_dim + v_dim]
@@ -634,7 +783,7 @@ class ApplyMLARotaryEmbKV(torch.autograd.Function):
         o_value = kv.new_empty(total_seqlen, nheads, v_dim)
 
         grid = lambda META: (total_seqlen, triton.cdiv(nheads, META["BLOCK_H"]))
-        rotary_fwd_kv_kernel[grid](
+        _mla_rope_fwd_kv_split_kernel[grid](
             kv,
             k_pos_emb,
             o_key,
@@ -657,8 +806,10 @@ class ApplyMLARotaryEmbKV(torch.autograd.Function):
             o_value.stride(1),
             cp_rank,
             cp_size,
+            REMOVE_INTERLEAVING=remove_interleaving,
         )
         ctx.save_for_backward(cos, sin)
+        ctx.remove_interleaving = remove_interleaving
         ctx.rotary_interleaved = rotary_interleaved
         ctx.emb_dim = emb_dim
         ctx.k_dim = k_dim
@@ -674,7 +825,7 @@ class ApplyMLARotaryEmbKV(torch.autograd.Function):
     @staticmethod
     def backward(ctx, dk, dv):
         """
-        Backward function for ApplyMLARotaryEmbKV.
+        Backward function for _FusedMLARoPEKVSplit.
 
         Args:
             dk: [seq_len, batch_size, head_num, emb_dim + k_dim]
@@ -702,7 +853,7 @@ class ApplyMLARotaryEmbKV(torch.autograd.Function):
         d_emb = dk.new_empty(total_seqlen, 1, ctx.emb_dim)
 
         grid = lambda META: (total_seqlen, triton.cdiv(nheads, META["BLOCK_H"]))
-        rotary_bwd_kv_kernel[grid](
+        _mla_rope_bwd_kv_split_kernel[grid](
             dk,
             dv,
             d_kv,
@@ -725,14 +876,15 @@ class ApplyMLARotaryEmbKV(torch.autograd.Function):
             d_emb.stride(0),
             ctx.cp_rank,
             ctx.cp_size,
+            REMOVE_INTERLEAVING=ctx.remove_interleaving,
         )
         if ctx.cu_seqlens_kv is None:
             d_kv = d_kv.view(max_seqlen, batch_size, nheads, ctx.k_dim + ctx.v_dim)
             d_emb = d_emb.view(max_seqlen, batch_size, 1, ctx.emb_dim)
-        return d_kv, d_emb, None, None, None, None, None, None, None, None, None
+        return d_kv, d_emb, None, None, None, None, None, None, None, None, None, None
 
 
-def fused_apply_mla_rope_for_kv(
+def fused_mla_rope_kv_split(
     kv: torch.Tensor,
     k_pos_emb: torch.Tensor,
     cos: torch.Tensor,
@@ -744,9 +896,10 @@ def fused_apply_mla_rope_for_kv(
     cp_rank: int = 0,
     cp_size: int = 1,
     rotary_interleaved: bool = False,
-):
+    remove_interleaving: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
     """
-    Fused function for applying YARN RoPE to MLA's key and value.
+    Fused function for applying RoPE to MLA's key and value.
     It splits the input tensor kv into key and value,
     and concatenates the processed RoPE to the key.
 
@@ -761,13 +914,14 @@ def fused_apply_mla_rope_for_kv(
         cos/sin: [max_seq_len, 1, 1, emb_dim]
         cu_seqlens_kv: [seq_num + 1] accumulated sequence lengths for thd format
         rotary_interleaved: whether to apply RoPE interleaved, only supports False for now
+        remove_interleaving: if True, output RoPE dims in non-interleaved layout
 
     Returns:
         key: [seq_len, batch_size, head_num, emb_dim + k_dim]
             or [total_seq_len, head_num, emb_dim + k_dim]
         value: [seq_len, batch_size, head_num, v_dim] or [total_seq_len, head_num, v_dim]
     """
-    return ApplyMLARotaryEmbKV.apply(
+    return _FusedMLARoPEKVSplit.apply(
         kv,
         k_pos_emb,
         cos,
@@ -779,4 +933,64 @@ def fused_apply_mla_rope_for_kv(
         cp_rank,
         cp_size,
         rotary_interleaved,
+        remove_interleaving,
+    )
+
+
+def fused_apply_mla_rope_for_q(
+    t: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    qk_head_dim: int,
+    emb_dim: int,
+    cu_seqlens_q: Optional[torch.Tensor] = None,
+    cp_rank: int = 0,
+    cp_size: int = 1,
+    rotary_interleaved: bool = False,
+) -> torch.Tensor:
+    """Backward-compatible in-place MLA query RoPE API.
+
+    New callers should choose :func:`fused_mla_rope_inplace` or
+    :func:`fused_mla_rope_out_of_place` explicitly. This legacy name keeps
+    its original mutation behavior and does not add a clone to the hot path.
+    """
+    return fused_mla_rope_inplace(
+        t,
+        cos,
+        sin,
+        qk_head_dim,
+        emb_dim,
+        cu_seqlens_q=cu_seqlens_q,
+        cp_rank=cp_rank,
+        cp_size=cp_size,
+        rotary_interleaved=rotary_interleaved,
+    )
+
+
+def fused_apply_mla_rope_for_kv(
+    kv: torch.Tensor,
+    k_pos_emb: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    emb_dim: int,
+    k_dim: int,
+    v_dim: int,
+    cu_seqlens_kv: Optional[torch.Tensor] = None,
+    cp_rank: int = 0,
+    cp_size: int = 1,
+    rotary_interleaved: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Backward-compatible name for the MLA key/value split RoPE API."""
+    return fused_mla_rope_kv_split(
+        kv,
+        k_pos_emb,
+        cos,
+        sin,
+        emb_dim,
+        k_dim,
+        v_dim,
+        cu_seqlens_kv=cu_seqlens_kv,
+        cp_rank=cp_rank,
+        cp_size=cp_size,
+        rotary_interleaved=rotary_interleaved,
     )

--- a/megatron/core/models/common/embeddings/rope_utils.py
+++ b/megatron/core/models/common/embeddings/rope_utils.py
@@ -95,6 +95,8 @@ def _apply_rotary_pos_emb_bshd(
     rotary_interleaved: bool = False,
     mla_rotary_interleaved: bool = False,
     mscale: float = 1.0,
+    inverse: bool = False,
+    mla_output_remove_interleaving: bool = False,
     multi_latent_attention: Optional[bool] = None,
 ) -> Tensor:
     """Apply rotary positional embedding to input tensor T.
@@ -118,6 +120,13 @@ def _apply_rotary_pos_emb_bshd(
         )
         mla_rotary_interleaved = multi_latent_attention
 
+    # Some callers may pass freqs with an extra singleton axis, e.g.
+    # t: [s, b, d] and freqs: [s, 1, 1, d]. In that case, broadcasting would
+    # accidentally expand to [s, s, b, d]. Squeeze the extra singleton axis to
+    # keep freqs rank aligned with t.
+    if freqs.dim() == t.dim() + 1 and freqs.size(-2) == 1:
+        freqs = freqs.squeeze(-2)
+
     rot_dim = freqs.shape[-1]
 
     # ideally t_pass is empty so rotary pos embedding is applied to all tensor t
@@ -132,8 +141,18 @@ def _apply_rotary_pos_emb_bshd(
     # second part is sine component, need to change signs with _rotate_half method
     cos_ = (torch.cos(freqs) * mscale).to(t.dtype)
     sin_ = (torch.sin(freqs) * mscale).to(t.dtype)
+    if inverse:
+        sin_ = -sin_
 
     t = (t * cos_) + (_rotate_half(t, rotary_interleaved) * sin_)
+
+    # Fallback to original permutation
+    # DSv4 applies rope on V and O, so we need to uninterleave the tensor.
+    # The existing MLA code is safe because the dot product is permutation-invariant.
+    if mla_rotary_interleaved and mla_output_remove_interleaving:
+        x1, x2 = torch.chunk(t, 2, dim=-1)
+        t = torch.stack((x1, x2), dim=-1).flatten(start_dim=-2)
+
     return torch.cat((t, t_pass), dim=-1)
 
 
@@ -193,20 +212,27 @@ def _apply_rotary_pos_emb_thd(
     rotary_interleaved: bool = False,
     mla_rotary_interleaved: bool = False,
     mscale: float = 1.0,
+    inverse: bool = False,
+    mla_output_remove_interleaving: bool = False,
     cp_group: torch.distributed.ProcessGroup = None,
     multi_latent_attention: Optional[bool] = None,
+    max_seqlen: Optional[int] = None,
 ) -> Tensor:
-    """A baseline implementation of applying RoPE for `thd` format.
+    """Apply RoPE for `thd` format using pure CUDA ops (CUDA Graph compatible).
+
+    Replaces the original Python-loop + .tolist() implementation with vectorized
+    CUDA operations. No GPU->CPU syncs, compatible with CUDA Graph capture.
 
     Args:
-        t (Tensor): Input tensor T is of shape [t, h, d]
-        cu_seqlens(Tensor):  Cumulative sum of sequence lengths in a batch for `t`,
-        with shape [b + 1] and dtype torch.int32.
-        freqs (Tensor): Rotary Positional embedding tensor freq is of shape [max_s, 1, 1, d]
-        cp_group (torch.distributed.ProcessGroup): The context parallel group
+        t (Tensor): Input tensor of shape [total_tokens, h, d]
+        cu_seqlens (Tensor): Cumulative sequence lengths, shape [num_seqs + 1], int32.
+        freqs (Tensor): RoPE frequencies, shape [max_s, 1, 1, d] or [total_tokens, 1, 1, d]
+        cp_group: Context parallel group
+        max_seqlen: Global max sequence length for this packed batch when known. Supplying it
+            avoids the compatibility-path host sync used by legacy callers.
 
     Returns:
-        Tensor: Shape [t, h, d]. The input tensor after applying RoPE.
+        Tensor: Shape [total_tokens, h, d]. Input with RoPE applied.
     """
     if multi_latent_attention is not None:
         warnings.warn(
@@ -219,53 +245,71 @@ def _apply_rotary_pos_emb_thd(
         raise ValueError("cp_group must be provided for THD format RoPE")
     cp_size = cp_group.size()
     cp_rank = cp_group.rank()
-    seqlens = ((cu_seqlens[1:] - cu_seqlens[:-1]) // cp_size).tolist()
-    sequence_splits = torch.split(t, seqlens)
-    total_seqlen = int(cu_seqlens[-1].item())
-    has_packed_freqs = freqs.dim() >= 1 and freqs.size(0) == total_seqlen
+    total_tokens = t.shape[0]
+    device = t.device
 
-    # Handle two different frequency tensor formats:
-    # 1. If freqs.size(0) == cu_seqlens[-1]: freqs contains positions for the whole packed
-    #    batch. Each sequence must therefore use its cu_seqlens offset when selecting the local CP
-    #    front/back slices. For example, with cu_seqlens=[0, 4, 8], cp_size=2, rank 0 should use
-    #    positions [0, 3, 4, 7], not [0, 3, 0, 3].
-    # 2. Otherwise: freqs contains only max sequence length positions. Each packed sequence should
-    #    reuse positions starting from 0, preserving the legacy THD behavior.
-    if has_packed_freqs:
-        # CASE 1: Exact mapping with offsets
-        local_freqs = []
-        for i, x in enumerate(sequence_splits):
-            # cu_seqlens[i] is the starting offset of this sequence in the original batch
-            seq_start_offset = cu_seqlens[i].item()
-            local_freqs.append(
-                _get_thd_freqs_on_this_cp_rank(cp_rank, cp_size, x, freqs, seq_start_offset)
-            )
-        freqs = torch.cat(local_freqs, dim=0)
-        return _apply_rotary_pos_emb_bshd(
-            t.unsqueeze(1),
-            freqs,
-            rotary_interleaved=rotary_interleaved,
-            mla_rotary_interleaved=mla_rotary_interleaved,
-            mscale=mscale,
-        ).squeeze(1)
+    token_pos = torch.arange(total_tokens, device=device, dtype=torch.int64)
 
-    # CASE 2: Traditional mapping without offsets. Apply RoPE one sequence at a time so the second
-    # and later packed sequences do not look like continuations of the first sequence.
-    output = torch.empty_like(t)
-    output_offset = 0
-    for x in sequence_splits:
-        freq_slice = _get_thd_freqs_on_this_cp_rank(cp_rank, cp_size, x, freqs)
-        output_slice = _apply_rotary_pos_emb_bshd(
-            x.unsqueeze(1),
-            freq_slice,
-            rotary_interleaved=rotary_interleaved,
-            mla_rotary_interleaved=mla_rotary_interleaved,
-            mscale=mscale,
-        ).squeeze(1)
-        output.narrow(0, output_offset, x.size(0)).copy_(output_slice)
-        output_offset += x.size(0)
+    # `cu_seqlens` describes the global packed sequence. With CP, `t` is already
+    # CP-partitioned, so build a local cumulative-length view before assigning
+    # local tokens to packed sequences.
+    cu_seqlens_i64 = cu_seqlens.to(torch.int64)
+    global_seq_lens = cu_seqlens_i64[1:] - cu_seqlens_i64[:-1]
+    local_seq_lens = global_seq_lens // cp_size if cp_size > 1 else global_seq_lens
+    local_cu_seqlens = torch.zeros_like(cu_seqlens_i64)
+    local_cu_seqlens[1:] = torch.cumsum(local_seq_lens, dim=0)
 
-    return output
+    # `searchsorted(..., right=True) - 1` returns the local sequence index. The
+    # clamp guards padded tokens that sit beyond the final real local token; they
+    # get a harmless frequency and are later masked out.
+    seq_idx = torch.searchsorted(local_cu_seqlens, token_pos, right=True) - 1
+    seq_idx = seq_idx.clamp(min=0, max=cu_seqlens.shape[0] - 2)
+
+    local_seq_start = local_cu_seqlens[seq_idx]
+    local_pos = token_pos - local_seq_start
+    local_seq_len = local_seq_lens[seq_idx]
+    global_seq_start = cu_seqlens_i64[seq_idx]
+
+    if cp_size > 1:
+        cp_seg = local_seq_len // 2
+        full_seqlen = local_seq_len * cp_size
+        is_first_half = local_pos < cp_seg
+        freq_pos = torch.where(
+            is_first_half,
+            cp_rank * cp_seg + local_pos,
+            full_seqlen - (cp_rank + 1) * cp_seg + (local_pos - cp_seg),
+        )
+    else:
+        freq_pos = local_pos.to(torch.int64)
+
+    if max_seqlen is None:
+        # Backward compatibility for callers that predate ``max_seqlen``. This retains
+        # the old packed-frequency semantics at the cost of a GPU-to-CPU sync. Updated
+        # training paths pass ``max_seqlen`` and stay CUDA-graph safe.
+        exact_packed_freqs = freqs.dim() >= 1 and freqs.size(0) == int(cu_seqlens[-1].item())
+    else:
+        exact_packed_freqs = freqs.dim() >= 1 and freqs.size(0) > max_seqlen
+    if exact_packed_freqs:
+        # `freqs` covers all positions across all sequences (used for non-1D
+        # RoPE / VLMs); shift by the per-sequence start offset so each token
+        # samples its absolute position. When `freqs` only spans one max-len
+        # sequence, no shift is needed.
+        freq_pos = freq_pos + global_seq_start
+
+    # Padded positions can sit outside the frequency table. Clamp them into
+    # range; downstream padding masks exclude those positions from the result.
+    freq_pos = freq_pos.clamp(min=0, max=freqs.shape[0] - 1)
+    freqs_packed = freqs[freq_pos]
+
+    return _apply_rotary_pos_emb_bshd(
+        t.unsqueeze(1),
+        freqs_packed,
+        rotary_interleaved=rotary_interleaved,
+        mla_rotary_interleaved=mla_rotary_interleaved,
+        mscale=mscale,
+        inverse=inverse,
+        mla_output_remove_interleaving=mla_output_remove_interleaving,
+    ).squeeze(1)
 
 
 def apply_rotary_pos_emb(
@@ -276,6 +320,9 @@ def apply_rotary_pos_emb(
     mscale: float = 1.0,
     cp_group: torch.distributed.ProcessGroup = None,
     mla_rotary_interleaved: bool = False,
+    inverse: bool = False,
+    mla_output_remove_interleaving: bool = False,
+    max_seqlen: Optional[int] = None,
 ):
     """
     Reroute to the appropriate apply_rotary_pos_emb function depending on
@@ -312,6 +359,12 @@ def apply_rotary_pos_emb(
                     "Using unfused implementation."
                 )
                 use_unfused = True
+            if inverse:
+                warnings.warn(
+                    "inverse RoPE is not supported by TE's fused RoPE. "
+                    "Using unfused implementation."
+                )
+                use_unfused = True
             if not use_unfused:
                 assert fused_apply_rotary_pos_emb is not None, "apply_rope_fusion is not available."
                 return fused_apply_rotary_pos_emb(t, freqs, interleaved=config.rotary_interleaved)
@@ -333,6 +386,8 @@ def apply_rotary_pos_emb(
             rotary_interleaved=config.rotary_interleaved,
             mla_rotary_interleaved=mla_rotary_interleaved,
             mscale=mscale,
+            inverse=inverse,
+            mla_output_remove_interleaving=mla_output_remove_interleaving,
         )
     else:
         return _apply_rotary_pos_emb_thd(
@@ -343,6 +398,9 @@ def apply_rotary_pos_emb(
             mla_rotary_interleaved=mla_rotary_interleaved,
             mscale=mscale,
             cp_group=cp_group,
+            inverse=inverse,
+            mla_output_remove_interleaving=mla_output_remove_interleaving,
+            max_seqlen=max_seqlen,
         )
 
 

--- a/megatron/core/models/common/embeddings/rope_utils.py
+++ b/megatron/core/models/common/embeddings/rope_utils.py
@@ -370,15 +370,37 @@ def apply_rotary_pos_emb(
                 assert fused_apply_rotary_pos_emb is not None, "apply_rope_fusion is not available."
                 return fused_apply_rotary_pos_emb(t, freqs, interleaved=config.rotary_interleaved)
         else:
-            assert fused_apply_rotary_pos_emb_thd is not None, "apply_rope_fusion is not available."
-            return fused_apply_rotary_pos_emb_thd(
-                t,
-                cu_seqlens,
-                freqs,
-                cp_size=cp_group.size(),
-                cp_rank=cp_group.rank(),
-                interleaved=config.rotary_interleaved,
-            )
+            use_unfused = False
+            if mscale != 1.0:
+                warnings.warn(
+                    f"mscale={mscale} is not supported by TE's fused RoPE. "
+                    "Using unfused implementation."
+                )
+                use_unfused = True
+            if mla_rotary_interleaved:
+                warnings.warn(
+                    "apply_rope_fusion does not support MLA-style interleaving in RoPE."
+                    "Using unfused implementation."
+                )
+                use_unfused = True
+            if inverse:
+                warnings.warn(
+                    "inverse RoPE is not supported by TE's fused RoPE. "
+                    "Using unfused implementation."
+                )
+                use_unfused = True
+            if not use_unfused:
+                assert (
+                    fused_apply_rotary_pos_emb_thd is not None
+                ), "apply_rope_fusion is not available."
+                return fused_apply_rotary_pos_emb_thd(
+                    t,
+                    cu_seqlens,
+                    freqs,
+                    cp_size=cp_group.size(),
+                    cp_rank=cp_group.rank(),
+                    interleaved=config.rotary_interleaved,
+                )
     # use unfused implementation
     if cu_seqlens is None:
         return _apply_rotary_pos_emb_bshd(

--- a/megatron/core/models/common/embeddings/rope_utils.py
+++ b/megatron/core/models/common/embeddings/rope_utils.py
@@ -218,10 +218,11 @@ def _apply_rotary_pos_emb_thd(
     multi_latent_attention: Optional[bool] = None,
     max_seqlen: Optional[int] = None,
 ) -> Tensor:
-    """Apply RoPE for `thd` format using pure CUDA ops (CUDA Graph compatible).
+    """Apply RoPE for `thd` format using vectorized CUDA operations.
 
-    Replaces the original Python-loop + .tolist() implementation with vectorized
-    CUDA operations. No GPU->CPU syncs, compatible with CUDA Graph capture.
+    When ``max_seqlen`` is supplied, this path performs no GPU-to-CPU sync and is
+    compatible with CUDA Graph capture. The compatibility path for legacy callers
+    that omit ``max_seqlen`` retains one GPU-to-CPU sync.
 
     Args:
         t (Tensor): Input tensor of shape [total_tokens, h, d]

--- a/megatron/core/models/common/embeddings/rotary_pos_embedding.py
+++ b/megatron/core/models/common/embeddings/rotary_pos_embedding.py
@@ -205,6 +205,47 @@ class RotaryEmbedding(nn.Module):
 
         return emb
 
+    def _set_cos_sin_cache(self, seq_len, offset, dtype, packed_seq=False, cp_group=None):
+        """Materialize cached cos/sin tensors for ``[seq_len, ..., dim]``."""
+        self.max_seq_len_cached = seq_len
+        self.offset_cached = offset
+        self.dtype_cached = dtype
+        self.packed_seq_cached = packed_seq
+
+        emb = self.forward(seq_len, offset, packed_seq=packed_seq, cp_group=cp_group)
+        self.register_buffer("cos_cached", emb.cos().to(dtype).contiguous(), persistent=False)
+        self.register_buffer("sin_cached", emb.sin().to(dtype).contiguous(), persistent=False)
+
+    def get_cached_cos_sin(
+        self,
+        seq_len,
+        offset=0,
+        dtype=torch.get_default_dtype(),
+        packed_seq=False,
+        cp_group=None,
+        mscale=None,
+    ):
+        """Get cached cos and sin values.
+
+        The cache is rebuilt on first use or whenever ``seq_len`` grows
+        beyond the cached length, or any of ``offset`` / ``dtype`` /
+        ``packed_seq`` changes from the previous call.
+        ``YarnRotaryEmbedding`` overrides this to also bake its
+        concentration factor into the cached cos/sin (controlled by
+        ``mscale``); for the base class without a concentration
+        factor the argument is accepted-and-ignored for API uniformity.
+        """
+        del mscale  # base class has no concentration factor
+        if (
+            not hasattr(self, "max_seq_len_cached")
+            or seq_len > self.max_seq_len_cached
+            or offset != self.offset_cached
+            or dtype != self.dtype_cached
+            or packed_seq != self.packed_seq_cached
+        ):
+            self._set_cos_sin_cache(seq_len, offset, dtype, packed_seq, cp_group)
+        return (self.cos_cached[:seq_len, ...], self.sin_cached[:seq_len, ...])
+
     def _load_from_state_dict(self, state_dict, prefix, *args, **kwargs):
         state_dict.pop(f'{prefix}inv_freq', None)
         return super()._load_from_state_dict(state_dict, prefix, *args, **kwargs)

--- a/megatron/core/models/common/embeddings/yarn_rotary_pos_embedding.py
+++ b/megatron/core/models/common/embeddings/yarn_rotary_pos_embedding.py
@@ -186,13 +186,18 @@ class YarnRotaryEmbedding(RotaryEmbedding):
             emb = get_pos_emb_on_this_cp_rank(emb, 0, cp_group)
         return emb, _mscale
 
-    def _set_cos_sin_cache(self, seq_len, offset, dtype, packed_seq=False):
+    def _set_cos_sin_cache(
+        self, seq_len, offset, dtype, packed_seq=False, cp_group=None, mscale=None
+    ):
         self.max_seq_len_cached = seq_len
         self.offset_cached = offset
         self.dtype_cached = dtype
         self.packed_seq_cached = packed_seq
+        self.mscale_cached = mscale
 
-        emb, _mscale = self.forward(seq_len, offset, packed_seq)
+        emb, _mscale = self.forward(seq_len, offset, packed_seq=packed_seq, cp_group=cp_group)
+        if mscale is not None:
+            _mscale = mscale
         self.register_buffer(
             "cos_cached", (emb.cos() * _mscale).to(dtype).contiguous(), persistent=False
         )
@@ -201,16 +206,34 @@ class YarnRotaryEmbedding(RotaryEmbedding):
         )
 
     def get_cached_cos_sin(
-        self, seq_len, offset=0, dtype=torch.get_default_dtype(), packed_seq=False
+        self,
+        seq_len,
+        offset=0,
+        dtype=torch.get_default_dtype(),
+        packed_seq=False,
+        cp_group=None,
+        mscale=None,
     ):
-        """Get cached cos and sin values."""
+        """Get cached cos and sin values.
+
+        Args:
+            mscale: when ``None`` (default), the cached cos/sin are
+                multiplied by yarn's internal concentration factor (the
+                normal long-context behaviour). When a float is supplied,
+                that value is used in place of the internal factor — e.g.
+                the DSv4 hybrid model passes ``mscale=1.0`` to enforce
+                its "pure rotation" contract and keep the fused /
+                unfused rope paths bit-equivalent.
+        """
         if (
-            seq_len > self.max_seq_len_cached
+            not hasattr(self, "max_seq_len_cached")
+            or seq_len > self.max_seq_len_cached
             or offset != self.offset_cached
             or dtype != self.dtype_cached
             or packed_seq != self.packed_seq_cached
+            or mscale != getattr(self, "mscale_cached", None)
         ):
-            self._set_cos_sin_cache(seq_len, offset, dtype, packed_seq)
+            self._set_cos_sin_cache(seq_len, offset, dtype, packed_seq, cp_group, mscale)
         return (self.cos_cached[:seq_len, ...], self.sin_cached[:seq_len, ...])
 
 

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -1463,8 +1463,11 @@ class Attention(MegatronModule, ABC):
                     cu_seqlens_kv = packed_seq_params.cu_seqlens_kv_padded
                 else:
                     cu_seqlens_kv = packed_seq_params.cu_seqlens_kv
+                rope_max_seqlen_q = packed_seq_params.max_seqlen_q
+                rope_max_seqlen_kv = packed_seq_params.max_seqlen_kv
             else:
                 cu_seqlens_q = cu_seqlens_kv = None
+                rope_max_seqlen_q = rope_max_seqlen_kv = None
 
             if split_qkv:
                 if q_pos_emb is not None:
@@ -1477,6 +1480,7 @@ class Attention(MegatronModule, ABC):
                             cu_seqlens=cu_seqlens_q,
                             mscale=self._yarn_concentration_factor,
                             cp_group=self.pg_collection.cp,
+                            max_seqlen=rope_max_seqlen_q,
                         )
                     else:
                         query = inference_context.apply_rotary_emb_query(
@@ -1495,6 +1499,7 @@ class Attention(MegatronModule, ABC):
                         cu_seqlens=cu_seqlens_kv,
                         mscale=self._yarn_concentration_factor,
                         cp_group=self.pg_collection.cp,
+                        max_seqlen=rope_max_seqlen_kv,
                     )
             else:
                 query, key, value = apply_fused_qkv_rotary_pos_emb(

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -1465,9 +1465,14 @@ class Attention(MegatronModule, ABC):
                     cu_seqlens_kv = packed_seq_params.cu_seqlens_kv
                 rope_max_seqlen_q = packed_seq_params.max_seqlen_q
                 rope_max_seqlen_kv = packed_seq_params.max_seqlen_kv
+                rope_freqs_max_seqlen = (
+                    max(rope_max_seqlen_q, rope_max_seqlen_kv)
+                    if rope_max_seqlen_q is not None and rope_max_seqlen_kv is not None
+                    else None
+                )
             else:
                 cu_seqlens_q = cu_seqlens_kv = None
-                rope_max_seqlen_q = rope_max_seqlen_kv = None
+                rope_freqs_max_seqlen = None
 
             if split_qkv:
                 if q_pos_emb is not None:
@@ -1480,7 +1485,7 @@ class Attention(MegatronModule, ABC):
                             cu_seqlens=cu_seqlens_q,
                             mscale=self._yarn_concentration_factor,
                             cp_group=self.pg_collection.cp,
-                            max_seqlen=rope_max_seqlen_q,
+                            max_seqlen=rope_freqs_max_seqlen,
                         )
                     else:
                         query = inference_context.apply_rotary_emb_query(
@@ -1499,7 +1504,7 @@ class Attention(MegatronModule, ABC):
                         cu_seqlens=cu_seqlens_kv,
                         mscale=self._yarn_concentration_factor,
                         cp_group=self.pg_collection.cp,
-                        max_seqlen=rope_max_seqlen_kv,
+                        max_seqlen=rope_freqs_max_seqlen,
                     )
             else:
                 query, key, value = apply_fused_qkv_rotary_pos_emb(

--- a/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
+++ b/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
@@ -442,8 +442,11 @@ class AbsorbedMLASelfAttention(Attention):
                 cu_seqlens_kv = packed_seq_params.cu_seqlens_kv_padded
             else:
                 cu_seqlens_kv = packed_seq_params.cu_seqlens_kv
+            rope_max_seqlen_q = packed_seq_params.max_seqlen_q
+            rope_max_seqlen_kv = packed_seq_params.max_seqlen_kv
         else:
             cu_seqlens_q = cu_seqlens_kv = None
+            rope_max_seqlen_q = rope_max_seqlen_kv = None
 
         # =========================================
         # Q down projection
@@ -631,6 +634,7 @@ class AbsorbedMLASelfAttention(Attention):
                     mscale=mscale,
                     cp_group=self.pg_collection.cp,
                     mla_rotary_interleaved=True,
+                    max_seqlen=rope_max_seqlen_q,
                 )
                 # k_pos_emb:[num_tokens, 1, qk_pos_emb_head_dim]
                 k_pos_emb = apply_rotary_pos_emb(
@@ -641,6 +645,7 @@ class AbsorbedMLASelfAttention(Attention):
                     mscale=mscale,
                     cp_group=self.pg_collection.cp,
                     mla_rotary_interleaved=True,
+                    max_seqlen=rope_max_seqlen_kv,
                 )
 
                 # query: [num_tokens, n, (kv_lora_rank + qk_pos_emb_head_dim)]

--- a/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
+++ b/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
@@ -444,9 +444,14 @@ class AbsorbedMLASelfAttention(Attention):
                 cu_seqlens_kv = packed_seq_params.cu_seqlens_kv
             rope_max_seqlen_q = packed_seq_params.max_seqlen_q
             rope_max_seqlen_kv = packed_seq_params.max_seqlen_kv
+            rope_freqs_max_seqlen = (
+                max(rope_max_seqlen_q, rope_max_seqlen_kv)
+                if rope_max_seqlen_q is not None and rope_max_seqlen_kv is not None
+                else None
+            )
         else:
             cu_seqlens_q = cu_seqlens_kv = None
-            rope_max_seqlen_q = rope_max_seqlen_kv = None
+            rope_freqs_max_seqlen = None
 
         # =========================================
         # Q down projection
@@ -634,7 +639,7 @@ class AbsorbedMLASelfAttention(Attention):
                     mscale=mscale,
                     cp_group=self.pg_collection.cp,
                     mla_rotary_interleaved=True,
-                    max_seqlen=rope_max_seqlen_q,
+                    max_seqlen=rope_freqs_max_seqlen,
                 )
                 # k_pos_emb:[num_tokens, 1, qk_pos_emb_head_dim]
                 k_pos_emb = apply_rotary_pos_emb(
@@ -645,7 +650,7 @@ class AbsorbedMLASelfAttention(Attention):
                     mscale=mscale,
                     cp_group=self.pg_collection.cp,
                     mla_rotary_interleaved=True,
-                    max_seqlen=rope_max_seqlen_kv,
+                    max_seqlen=rope_freqs_max_seqlen,
                 )
 
                 # query: [num_tokens, n, (kv_lora_rank + qk_pos_emb_head_dim)]

--- a/megatron/core/transformer/multi_latent_attention.py
+++ b/megatron/core/transformer/multi_latent_attention.py
@@ -716,8 +716,11 @@ class MLASelfAttention(MultiLatentAttention):
                 cu_seqlens_kv = packed_seq_params.cu_seqlens_kv_padded
             else:
                 cu_seqlens_kv = packed_seq_params.cu_seqlens_kv
+            rope_max_seqlen_q = packed_seq_params.max_seqlen_q
+            rope_max_seqlen_kv = packed_seq_params.max_seqlen_kv
         else:
             cu_seqlens_q = cu_seqlens_kv = None
+            rope_max_seqlen_q = rope_max_seqlen_kv = None
 
         # =========================================
         # QKV down projection and layernorm
@@ -929,6 +932,7 @@ class MLASelfAttention(MultiLatentAttention):
                     mscale=mscale,
                     cp_group=self.pg_collection.cp,
                     mla_rotary_interleaved=True,
+                    max_seqlen=rope_max_seqlen_q,
                 )
                 # k_pos_emb:[num_tokens, 1, qk_pos_emb_head_dim]
                 k_pos_emb = apply_rotary_pos_emb(
@@ -939,6 +943,7 @@ class MLASelfAttention(MultiLatentAttention):
                     mscale=mscale,
                     cp_group=self.pg_collection.cp,
                     mla_rotary_interleaved=True,
+                    max_seqlen=rope_max_seqlen_kv,
                 )
 
                 # query: [num_tokens, n, (qk_head_dim + v_head_dim)]

--- a/megatron/core/transformer/multi_latent_attention.py
+++ b/megatron/core/transformer/multi_latent_attention.py
@@ -718,9 +718,14 @@ class MLASelfAttention(MultiLatentAttention):
                 cu_seqlens_kv = packed_seq_params.cu_seqlens_kv
             rope_max_seqlen_q = packed_seq_params.max_seqlen_q
             rope_max_seqlen_kv = packed_seq_params.max_seqlen_kv
+            rope_freqs_max_seqlen = (
+                max(rope_max_seqlen_q, rope_max_seqlen_kv)
+                if rope_max_seqlen_q is not None and rope_max_seqlen_kv is not None
+                else None
+            )
         else:
             cu_seqlens_q = cu_seqlens_kv = None
-            rope_max_seqlen_q = rope_max_seqlen_kv = None
+            rope_freqs_max_seqlen = None
 
         # =========================================
         # QKV down projection and layernorm
@@ -932,7 +937,7 @@ class MLASelfAttention(MultiLatentAttention):
                     mscale=mscale,
                     cp_group=self.pg_collection.cp,
                     mla_rotary_interleaved=True,
-                    max_seqlen=rope_max_seqlen_q,
+                    max_seqlen=rope_freqs_max_seqlen,
                 )
                 # k_pos_emb:[num_tokens, 1, qk_pos_emb_head_dim]
                 k_pos_emb = apply_rotary_pos_emb(
@@ -943,7 +948,7 @@ class MLASelfAttention(MultiLatentAttention):
                     mscale=mscale,
                     cp_group=self.pg_collection.cp,
                     mla_rotary_interleaved=True,
-                    max_seqlen=rope_max_seqlen_kv,
+                    max_seqlen=rope_freqs_max_seqlen,
                 )
 
                 # query: [num_tokens, n, (qk_head_dim + v_head_dim)]

--- a/tests/unit_tests/fusions/test_mla_yarn_rope_apply.py
+++ b/tests/unit_tests/fusions/test_mla_yarn_rope_apply.py
@@ -16,12 +16,16 @@ from tests.unit_tests.test_utilities import Utils
 
 try:
     from megatron.core.fusions.fused_mla_yarn_rope_apply import (
-        fused_apply_mla_rope_for_kv,
         fused_apply_mla_rope_for_q,
+        fused_mla_rope_inplace,
+        fused_mla_rope_kv_split,
+        fused_mla_rope_out_of_place,
     )
-except:
-    fused_apply_mla_rope_for_kv = None
+except Exception:
     fused_apply_mla_rope_for_q = None
+    fused_mla_rope_inplace = None
+    fused_mla_rope_kv_split = None
+    fused_mla_rope_out_of_place = None
 
 
 def dtype_tols(dtype):
@@ -54,7 +58,9 @@ class TestApplyRotaryPosEmbTHD:
         t = torch.randn(4, 2, 8)
         freqs = torch.randn(8, 1, 1, 8)
 
-        out = rope_utils_module._apply_rotary_pos_emb_thd(t, cu_seqlens, freqs, cp_group=cp_group)
+        out = rope_utils_module._apply_rotary_pos_emb_thd(
+            t, cu_seqlens, freqs, cp_group=cp_group, max_seqlen=4
+        )
 
         expected_freqs = torch.cat([freqs[0:1], freqs[3:4], freqs[4:5], freqs[7:8]], dim=0)
         expected = rope_utils_module._apply_rotary_pos_emb_bshd(
@@ -69,7 +75,9 @@ class TestApplyRotaryPosEmbTHD:
         t = torch.randn(4, 2, 8)
         freqs = torch.randn(4, 1, 1, 8)
 
-        out = rope_utils_module._apply_rotary_pos_emb_thd(t, cu_seqlens, freqs, cp_group=cp_group)
+        out = rope_utils_module._apply_rotary_pos_emb_thd(
+            t, cu_seqlens, freqs, cp_group=cp_group, max_seqlen=4
+        )
 
         expected_freqs = torch.cat([freqs[1:2], freqs[2:3]], dim=0)
         expected_slices = []
@@ -83,9 +91,39 @@ class TestApplyRotaryPosEmbTHD:
 
         torch.testing.assert_close(out, expected)
 
+    def test_missing_max_seqlen_preserves_legacy_packed_freq_mapping(self):
+        cp_group = FakeCPGroup(size=2, rank=0)
+        cu_seqlens = torch.tensor([0, 4, 8], dtype=torch.int32)
+        t = torch.randn(4, 2, 8)
+        freqs = torch.randn(8, 1, 1, 8)
 
-def _test_fused_apply_mla_rope_for_q(input_format):
-    assert fused_apply_mla_rope_for_q is not None
+        legacy_out = rope_utils_module._apply_rotary_pos_emb_thd(
+            t, cu_seqlens, freqs, cp_group=cp_group
+        )
+        explicit_out = rope_utils_module._apply_rotary_pos_emb_thd(
+            t, cu_seqlens, freqs, cp_group=cp_group, max_seqlen=4
+        )
+
+        torch.testing.assert_close(legacy_out, explicit_out)
+
+
+class _SaveOutputForBackward(torch.autograd.Function):
+    """Minimal stand-in for a kernel whose backward consumes its output."""
+
+    @staticmethod
+    def forward(ctx, tensor):
+        output = tensor.clone()
+        ctx.save_for_backward(output)
+        return output
+
+    @staticmethod
+    def backward(ctx, _grad_output):
+        (saved_output,) = ctx.saved_tensors
+        return saved_output
+
+
+def _test_fused_mla_rope_inplace(input_format, inverse=False, remove_interleaving=False):
+    assert fused_mla_rope_inplace is not None
     num_heads = 32
     q_dim = 128
     emb_dim = 64
@@ -97,6 +135,7 @@ def _test_fused_apply_mla_rope_for_q(input_format):
         multi_latent_attention=True,
     )
 
+    max_seqlen = None
     if input_format == "sbhd":
         cu_seqlens = None
         seqlen = 1024
@@ -142,15 +181,25 @@ def _test_fused_apply_mla_rope_for_q(input_format):
         freqs,
         transformer_config,
         cu_seqlens=cu_seqlens,
+        max_seqlen=max_seqlen,
         mscale=mscale,
         cp_group=FakeCPGroup(),
         mla_rotary_interleaved=True,
+        inverse=inverse,
+        mla_output_remove_interleaving=remove_interleaving,
     )
     pytorch_output = torch.concat([no_pe, pe_output], dim=-1)
     pytorch_output.backward(pytorch_bwd_input, retain_graph=True)
 
-    fused_output = fused_apply_mla_rope_for_q(
-        fused_fwd_input, cos, sin, q_dim, emb_dim, cu_seqlens_q=cu_seqlens
+    fused_output = fused_mla_rope_inplace(
+        fused_fwd_input,
+        cos,
+        sin,
+        q_dim,
+        emb_dim,
+        cu_seqlens_q=cu_seqlens,
+        inverse=inverse,
+        remove_interleaving=remove_interleaving,
     )
     fused_output.backward(fused_bwd_input, retain_graph=True)
 
@@ -169,8 +218,8 @@ def _test_fused_apply_mla_rope_for_q(input_format):
     )
 
 
-def _test_fused_apply_mla_rope_for_kv(input_format):
-    assert fused_apply_mla_rope_for_kv is not None
+def _test_fused_mla_rope_kv_split(input_format, remove_interleaving=False):
+    assert fused_mla_rope_kv_split is not None
     num_heads = 32
     k_dim = 128
     v_dim = 128
@@ -183,6 +232,7 @@ def _test_fused_apply_mla_rope_for_kv(input_format):
         multi_latent_attention=True,
     )
 
+    max_seqlen = None
     if input_format == "sbhd":
         cu_seqlens = None
         seqlen = 1024
@@ -241,9 +291,11 @@ def _test_fused_apply_mla_rope_for_kv(input_format):
         freqs,
         transformer_config,
         cu_seqlens=cu_seqlens,
+        max_seqlen=max_seqlen,
         mscale=mscale,
         cp_group=FakeCPGroup(),
         mla_rotary_interleaved=True,
+        mla_output_remove_interleaving=remove_interleaving,
     )
     if input_format == "sbhd":
         pe_output = pe_output.expand(-1, -1, num_heads, -1)
@@ -255,7 +307,7 @@ def _test_fused_apply_mla_rope_for_kv(input_format):
         (pytorch_k_output, pytorch_v_output), (pytorch_bwd_k_input, pytorch_bwd_v_input)
     )
 
-    fused_k_output, fused_v_output = fused_apply_mla_rope_for_kv(
+    fused_k_output, fused_v_output = fused_mla_rope_kv_split(
         fused_fwd_kv_input,
         fused_fwd_emb_input,
         cos,
@@ -264,6 +316,7 @@ def _test_fused_apply_mla_rope_for_kv(input_format):
         k_dim,
         v_dim,
         cu_seqlens_kv=cu_seqlens,
+        remove_interleaving=remove_interleaving,
     )
     torch.autograd.backward(
         (fused_k_output, fused_v_output), (fused_bwd_k_input, fused_bwd_v_input)
@@ -301,13 +354,136 @@ def _test_fused_apply_mla_rope_for_kv(input_format):
 @pytest.mark.skipif(not is_torch_min_version("2.5.0"), reason="Requires PyTorch >= 2.5.0")
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.parametrize("input_format", ["sbhd", "thd"])
-class TestFusedApplyMLARope:
+class TestFusedMLARope:
     @pytest.mark.flaky_in_dev
-    def test_forward_backward_for_q(self, input_format):
-        _test_fused_apply_mla_rope_for_q(input_format)
+    @pytest.mark.parametrize("inverse", [False, True])
+    @pytest.mark.parametrize("remove_interleaving", [False, True])
+    def test_inplace_forward_backward(self, input_format, inverse, remove_interleaving):
+        _test_fused_mla_rope_inplace(
+            input_format, inverse=inverse, remove_interleaving=remove_interleaving
+        )
 
-    def test_forward_backward_for_kv(self, input_format):
-        _test_fused_apply_mla_rope_for_kv(input_format)
+    @pytest.mark.parametrize("remove_interleaving", [False, True])
+    def test_kv_split_forward_backward(self, input_format, remove_interleaving):
+        _test_fused_mla_rope_kv_split(input_format, remove_interleaving=remove_interleaving)
+
+
+@pytest.mark.experimental
+@pytest.mark.internal
+@pytest.mark.skipif(not is_torch_min_version("2.5.0"), reason="Requires PyTorch >= 2.5.0")
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.parametrize("input_format", ["sbhd", "thd"])
+def test_out_of_place_inverse_rope_preserves_upstream_saved_output(input_format):
+    """Post-attention inverse RoPE must not overwrite an output saved for backward."""
+    assert fused_mla_rope_out_of_place is not None
+    seqlen = 32
+    batch_size = 1
+    num_heads = 2
+    nope_dim = 16
+    emb_dim = 64
+    dtype = torch.bfloat16
+
+    yarn_rope = YarnRotaryEmbedding(emb_dim, original_max_position_embeddings=seqlen)
+    freqs, mscale = yarn_rope(seqlen, 0)
+    cos = (torch.cos(freqs) * mscale).to(dtype)
+    sin = (torch.sin(freqs) * mscale).to(dtype)
+
+    if input_format == "sbhd":
+        shape = (seqlen, batch_size, num_heads, nope_dim + emb_dim)
+        cu_seqlens = None
+    else:
+        shape = (2 * seqlen, num_heads, nope_dim + emb_dim)
+        cu_seqlens = torch.tensor([0, seqlen, 2 * seqlen], dtype=torch.int32, device="cuda")
+
+    unsafe_source = torch.randn(shape, dtype=dtype, device="cuda", requires_grad=True)
+    unsafe_attention_output = _SaveOutputForBackward.apply(unsafe_source)
+    unsafe_reference = unsafe_attention_output.detach().clone()
+    unsafe_inverse_output = fused_mla_rope_inplace(
+        unsafe_attention_output,
+        cos,
+        sin,
+        nope_dim,
+        emb_dim,
+        cu_seqlens_q=cu_seqlens,
+        inverse=True,
+        remove_interleaving=True,
+    )
+
+    assert unsafe_inverse_output.data_ptr() == unsafe_attention_output.data_ptr()
+    assert not torch.equal(unsafe_attention_output, unsafe_reference)
+
+    source = torch.randn(shape, dtype=dtype, device="cuda", requires_grad=True)
+    attention_output = _SaveOutputForBackward.apply(source)
+    saved_reference = attention_output.detach().clone()
+
+    inverse_output = fused_mla_rope_out_of_place(
+        attention_output,
+        cos,
+        sin,
+        nope_dim,
+        emb_dim,
+        cu_seqlens_q=cu_seqlens,
+        inverse=True,
+        remove_interleaving=True,
+    )
+    expected_inverse_output = fused_mla_rope_inplace(
+        saved_reference.clone(),
+        cos,
+        sin,
+        nope_dim,
+        emb_dim,
+        cu_seqlens_q=cu_seqlens,
+        inverse=True,
+        remove_interleaving=True,
+    )
+
+    assert inverse_output.data_ptr() != attention_output.data_ptr()
+    torch.testing.assert_close(attention_output, saved_reference, rtol=0, atol=0)
+    torch.testing.assert_close(inverse_output, expected_inverse_output, rtol=0, atol=0)
+
+    inverse_output.backward(torch.randn_like(inverse_output).contiguous())
+    torch.testing.assert_close(source.grad, saved_reference, rtol=0, atol=0)
+
+
+@pytest.mark.experimental
+@pytest.mark.internal
+@pytest.mark.skipif(not is_torch_min_version("2.5.0"), reason="Requires PyTorch >= 2.5.0")
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.parametrize("input_format", ["sbhd", "thd"])
+def test_legacy_query_api_remains_in_place(input_format):
+    """The legacy API keeps its original mutation behavior and allocation profile."""
+    assert fused_apply_mla_rope_for_q is not None
+    seqlen = 32
+    batch_size = 1
+    num_heads = 2
+    nope_dim = 16
+    emb_dim = 64
+    dtype = torch.bfloat16
+
+    yarn_rope = YarnRotaryEmbedding(emb_dim, original_max_position_embeddings=seqlen)
+    freqs, mscale = yarn_rope(seqlen, 0)
+    cos = (torch.cos(freqs) * mscale).to(dtype)
+    sin = (torch.sin(freqs) * mscale).to(dtype)
+
+    if input_format == "sbhd":
+        shape = (seqlen, batch_size, num_heads, nope_dim + emb_dim)
+        cu_seqlens = None
+    else:
+        shape = (2 * seqlen, num_heads, nope_dim + emb_dim)
+        cu_seqlens = torch.tensor([0, seqlen, 2 * seqlen], dtype=torch.int32, device="cuda")
+
+    query = torch.randn(shape, dtype=dtype, device="cuda")
+    reference = query.clone()
+    expected = fused_mla_rope_inplace(
+        reference.clone(), cos, sin, nope_dim, emb_dim, cu_seqlens_q=cu_seqlens
+    )
+    output = fused_apply_mla_rope_for_q(
+        query, cos, sin, qk_head_dim=nope_dim, emb_dim=emb_dim, cu_seqlens_q=cu_seqlens
+    )
+
+    assert output.data_ptr() == query.data_ptr()
+    assert not torch.equal(query, reference)
+    torch.testing.assert_close(output, expected, rtol=0, atol=0)
 
 
 class TestApplyRotaryPosEmbMlaFusionConflict:

--- a/tests/unit_tests/fusions/test_mla_yarn_rope_apply.py
+++ b/tests/unit_tests/fusions/test_mla_yarn_rope_apply.py
@@ -52,6 +52,47 @@ class FakeCPGroup:
 
 
 class TestApplyRotaryPosEmbTHD:
+    @pytest.mark.parametrize(
+        ("unsupported_kwargs", "warning_text"),
+        [
+            ({"inverse": True}, "inverse RoPE is not supported"),
+            (
+                {"mla_rotary_interleaved": True, "mla_output_remove_interleaving": True},
+                "MLA-style interleaving",
+            ),
+            ({"mscale": 2.0}, "mscale=2.0 is not supported"),
+        ],
+    )
+    def test_unsupported_fusion_options_use_unfused(self, unsupported_kwargs, warning_text):
+        cp_group = FakeCPGroup()
+        t = torch.randn(4, 2, 8)
+        freqs = torch.randn(2, 1, 1, 8)
+        cu_seqlens = torch.tensor([0, 2, 4], dtype=torch.int32)
+        config = TransformerConfig(
+            num_attention_heads=2, num_layers=1, apply_rope_fusion=True, rotary_interleaved=False
+        )
+        expected = rope_utils_module._apply_rotary_pos_emb_thd(
+            t, cu_seqlens, freqs, cp_group=cp_group, max_seqlen=2, **unsupported_kwargs
+        )
+
+        fused_mock = MagicMock(return_value=t.clone())
+        with (
+            patch.object(rope_utils_module, "fused_apply_rotary_pos_emb_thd", fused_mock),
+            pytest.warns(UserWarning, match=warning_text),
+        ):
+            output = apply_rotary_pos_emb(
+                t,
+                freqs,
+                config,
+                cu_seqlens=cu_seqlens,
+                cp_group=cp_group,
+                max_seqlen=2,
+                **unsupported_kwargs,
+            )
+
+        fused_mock.assert_not_called()
+        torch.testing.assert_close(output, expected)
+
     def test_packed_freqs_returns_offset_mapped_output_for_context_parallel(self):
         cp_group = FakeCPGroup(size=2, rank=0)
         cu_seqlens = torch.tensor([0, 4, 8], dtype=torch.int32)

--- a/tests/unit_tests/fusions/test_mla_yarn_rope_apply.py
+++ b/tests/unit_tests/fusions/test_mla_yarn_rope_apply.py
@@ -106,6 +106,31 @@ class TestApplyRotaryPosEmbTHD:
 
         torch.testing.assert_close(legacy_out, explicit_out)
 
+    def test_shared_max_seqlen_maps_asymmetric_query_sequences_from_zero(self):
+        cp_group = FakeCPGroup(size=1, rank=0)
+        cu_seqlens_q = torch.tensor([0, 3, 6], dtype=torch.int32)
+        t = torch.randn(6, 2, 8)
+        freqs = torch.randn(4, 1, 1, 8)
+
+        max_seqlen_q = 3
+        max_seqlen_kv = freqs.size(0)
+        assert max_seqlen_q < max_seqlen_kv < t.size(0)
+        combined_max_seqlen = max(max_seqlen_q, max_seqlen_kv)
+        out = rope_utils_module._apply_rotary_pos_emb_thd(
+            t, cu_seqlens_q, freqs, cp_group=cp_group, max_seqlen=combined_max_seqlen
+        )
+        compatibility_out = rope_utils_module._apply_rotary_pos_emb_thd(
+            t, cu_seqlens_q, freqs, cp_group=cp_group
+        )
+
+        expected_freqs = freqs[torch.tensor([0, 1, 2, 0, 1, 2])]
+        expected = rope_utils_module._apply_rotary_pos_emb_bshd(
+            t.unsqueeze(1), expected_freqs
+        ).squeeze(1)
+
+        torch.testing.assert_close(out, expected)
+        torch.testing.assert_close(out, compatibility_out)
+
 
 class _SaveOutputForBackward(torch.autograd.Function):
     """Minimal stand-in for a kernel whose backward consumes its output."""


### PR DESCRIPTION
# Explicit safe MLA RoPE primitives and consumers

## Summary

Expose explicit in-place and out-of-place MLA RoPE APIs, including inverse
rotation, KV-split output, and packed-position handling safe for graph capture
and fused backward.

## Scope and non-goals

- Support SBHD and THD position mapping and packed maximum-sequence handling.
- Use out-of-place inverse RoPE where saved tensors must remain unchanged.
- Preserve legacy-call safety without depending on #5412.
- Do not add CSA/DSA algorithms, DSv4 orchestration, or model construction.

## Provenance

This local recut is reconstructed from the frozen `main` baseline
`bb5647a9bdd0`, not a replay. It references #5795 and the complete API from
#5944, incorporating fixes represented by #5018 and #5526. #5412 is an
independent compatibility gate, not a dependency. Credit goes to the original
contributors: @hxbai in #5018/#5795, @kunlunl in #5526, and
@ShauryaaSharma in #5412.

## Dependencies

None beyond the frozen baseline used for this local recut. This is a reusable
prerequisite outside the nine-PR DSv4-specific series.

## Tests

- In-place/out-of-place forward and inverse parity.
- SBHD/THD mapping, KV-split output, and packed maximum-sequence behavior.
- CUDA-graph-safe metadata handling and fused-backward saved-tensor safety.

## Publication

Publish in the first prerequisite round on then-current `main`. This is not a
stacked-review PR.
