### PR TITLE
Move FSDP model weight sync to optimizer post-step

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
@@ -68,7 +68,11 @@ def fully_shard(
 
 @contextmanager
 def microbatch(module: nn.Module, is_last: bool) -> Iterator[None]:
-    """Scope FSDP state to one microbatch.
+    """Mark an FSDP microbatch as the last accumulation microbatch.
+
+    At present, this is only needed for HSDP/HFSDP gradient accumulation, so
+    FSDP finalizes gradients only on the last backward. Plain all-Flat data
+    parallelism finalizes gradients on every backward and does not need it.
 
     Args:
         module: Module tree whose FSDP roots should use this microbatch state.

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -23,7 +23,7 @@ from torch.distributed import DeviceMesh
 
 from ..mixed_precision import MixedPrecisionPolicy
 from .indexed_order import IndexedOrder
-from .parameter_group import FsdpParameterGroup, contained_in_parameter_group
+from .parameter_group import FsdpParameterGroup, get_containing_parameter_group
 from .placement import MeshAxis, Placements
 
 
@@ -238,7 +238,7 @@ class FsdpModule:
         if self.is_root():
             allgather_stream.wait_stream(current_stream)
 
-        self._unshard_parameter_groups(sync_model_weight=True)
+        self._unshard_parameter_groups()
         assert self._unshard_event is not None
         # Compute waits only for this FsdpModule's all-gather (the prefetch below is
         # issued afterwards, so it is free to run concurrently with this FsdpModule).
@@ -246,9 +246,9 @@ class FsdpModule:
 
         next_module = context.forward_order.next_item(self)
         if next_module is not None:
-            next_module._unshard_parameter_groups(sync_model_weight=True)
+            next_module._unshard_parameter_groups()
 
-    def _unshard_parameter_groups(self, *, sync_model_weight: bool) -> None:
+    def _unshard_parameter_groups(self) -> None:
         """Unshard this FsdpModule's parameter groups on the all-gather stream.
 
         If ``_unshard_event`` is already set, this FsdpModule was already
@@ -262,10 +262,6 @@ class FsdpModule:
         allgather_stream = self.context.allgather_stream
         with torch.cuda.stream(allgather_stream):
             for group in self._parameter_groups:
-                if sync_model_weight:
-                    # TODO: After NVIDIA/Megatron-LM#5411 lands, move this sync to the
-                    # optimizer post-step hook instead of running it every microbatch.
-                    group.sync_model_weight_from_main_weight()
                 group.unshard_parameters()
             self._unshard_event = allgather_stream.record_event()
 
@@ -308,13 +304,13 @@ class FsdpModule:
             # fork each preceding module issues before its collective.
             context.reduce_scatter_stream.wait_stream(current_stream)
 
-        self._unshard_parameter_groups(sync_model_weight=False)
+        self._unshard_parameter_groups()
         assert self._unshard_event is not None
         current_stream.wait_event(self._unshard_event)
 
         next_module = context.backward_order.next_item(self)
         if next_module is not None:
-            next_module._unshard_parameter_groups(sync_model_weight=False)
+            next_module._unshard_parameter_groups()
 
     def post_backward(self) -> None:
         """Reduce gradients and return parameters to their sharded resting state."""
@@ -387,7 +383,7 @@ def _collect_owned_parameters(root_module: nn.Module) -> dict[str, nn.Parameter]
             parameter_fqn = (
                 f"{submodule_fqn}.{local_parameter_name}" if submodule_fqn else local_parameter_name
             )
-            if contained_in_parameter_group(parameter):
+            if get_containing_parameter_group(parameter) is not None:
                 raise ValueError(
                     f"Parameter {parameter_fqn!r} is already owned by another FsdpModule."
                 )

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/optimizer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/optimizer.py
@@ -19,15 +19,18 @@ from typing import Any, NamedTuple
 import torch
 from torch import nn
 
-from .parameter_group import contained_in_parameter_group
+from .parameter_group import FsdpParameterGroup, get_containing_parameter_group
 
 
-def fully_shard_optimizer(optimizer: torch.optim.Optimizer) -> None:
+def fully_shard_optimizer(
+    optimizer: torch.optim.Optimizer, *, precision_aware: bool = False
+) -> None:
     """Attach FSDP-aware step hooks to an optimizer instance.
 
-    The adapted optimizer preserves its existing parameter groups and only adds
-    temporary gradient casting around optimizer steps for FSDP sharded
-    parameters whose data dtype differs from their grad dtype.
+    The adapted optimizer preserves its existing parameter groups, temporarily
+    casts gradients around optimizer steps for FSDP sharded parameters whose
+    data dtype differs from their grad dtype unless the optimizer is precision
+    aware, and refreshes compute weights after each optimizer step.
 
     Alternatives considered:
         - Monkey-patching optimizer methods directly on the instance. This is
@@ -46,6 +49,8 @@ def fully_shard_optimizer(optimizer: torch.optim.Optimizer) -> None:
 
     Args:
         optimizer: Optimizer instance to adapt in place.
+        precision_aware: Whether the optimizer accepts FSDP's mixed-precision
+            gradients without temporary casting.
     """
 
     class CastedGrad(NamedTuple):
@@ -86,7 +91,7 @@ def fully_shard_optimizer(optimizer: torch.optim.Optimizer) -> None:
                         "fully_shard_optimizer expected optimizer param groups to contain "
                         f"nn.Parameter values, got {type(parameter)!r}."
                     )
-                if not contained_in_parameter_group(parameter):
+                if precision_aware or get_containing_parameter_group(parameter) is None:
                     continue
                 if parameter.grad is None:
                     continue
@@ -99,10 +104,21 @@ def fully_shard_optimizer(optimizer: torch.optim.Optimizer) -> None:
     def step_post_hook(
         hooked_optimizer: torch.optim.Optimizer, args: tuple[Any, ...], kwargs: dict[str, Any]
     ) -> None:
-        del hooked_optimizer, args, kwargs
+        del args, kwargs
         for parameter, original_grad in casted_grads:
             set_grad(parameter, original_grad)
         casted_grads.clear()
+
+        fsdp_parameter_groups: set[FsdpParameterGroup] = set()
+        for optimizer_group in hooked_optimizer.param_groups:
+            for parameter in optimizer_group["params"]:
+                parameter_group = get_containing_parameter_group(parameter)
+                if parameter_group is None:
+                    continue
+                fsdp_parameter_groups.add(parameter_group)
+
+        for parameter_group in fsdp_parameter_groups:
+            parameter_group.sync_model_weight_from_main_weight()
 
     optimizer.register_step_pre_hook(step_pre_hook)
     optimizer.register_step_post_hook(step_post_hook)

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -29,9 +29,9 @@ from .placement import Partial, Placements, Replicate, changed_mesh_axis
 _CONTAINING_PARAMETER_GROUP_ATTR = "_mfsdp_parameter_group"
 
 
-def contained_in_parameter_group(parameter: nn.Parameter) -> bool:
-    """Return whether a parameter is already owned by an FsdpParameterGroup."""
-    return hasattr(parameter, _CONTAINING_PARAMETER_GROUP_ATTR)
+def get_containing_parameter_group(parameter: nn.Parameter) -> "FsdpParameterGroup | None":
+    """Return the FSDP parameter group that owns ``parameter``, if any."""
+    return getattr(parameter, _CONTAINING_PARAMETER_GROUP_ATTR, None)
 
 
 class FsdpParameterGroup:
@@ -172,6 +172,9 @@ class FsdpParameterGroup:
         self.sharded_parameters = tuple(sharded_parameters)
         self.unsharded_parameters = tuple(unsharded_parameters)
 
+        # Compute weights must be initialized before the first forward; subsequent
+        # refreshes happen from the FSDP optimizer's post-step hook.
+        self.sync_model_weight_from_main_weight()
         self._switch_to_sharded_parameters()
         self._unsharded_model_weight.release_storage()
 

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -663,6 +663,7 @@ def test_next_forward_uses_optimizer_updated_weights(distributed_setup):
     # SGD's foreach/fused CUDA paths require matching parameter and gradient dtypes.
     # Use the scalar path to exercise FP32 main weights with default BF16 main grads.
     optimizer = torch.optim.SGD(model.parameters(), lr=0.25, foreach=False)
+    fully_shard_optimizer(optimizer)
     x = torch.ones(1, 1, device=device, dtype=torch.bfloat16)
 
     def train_iteration() -> torch.Tensor:
@@ -677,6 +678,48 @@ def test_next_forward_uses_optimizer_updated_weights(distributed_setup):
 
     with pytest.raises(AssertionError):
         torch.testing.assert_close(second_loss, first_loss)
+
+
+def test_optimizer_post_step_syncs_once_per_parameter_group(distributed_setup, monkeypatch):
+    """Optimizer synchronization should run once per group, not once per microbatch."""
+    world_size = distributed_setup.world_size
+    device = distributed_setup.device
+    if world_size < 2:
+        pytest.skip("This test requires at least 2 ranks.")
+
+    mesh = init_device_mesh(device.type, (world_size,))
+    model = TinyModel().to(device=device, dtype=torch.bfloat16)
+    fully_shard(model.fc1, mesh=mesh, placements=_flat_placements())
+    fully_shard(model.fc2, mesh=mesh, placements=_flat_placements())
+    parameter_groups = (*model.fc1.parameter_groups, *model.fc2.parameter_groups)
+    sync_counts = {parameter_group: 0 for parameter_group in parameter_groups}
+
+    def make_count_sync(parameter_group):
+        sync_model_weight = parameter_group.sync_model_weight_from_main_weight
+
+        def count_sync():
+            sync_counts[parameter_group] += 1
+            sync_model_weight()
+
+        return count_sync
+
+    for parameter_group in parameter_groups:
+        monkeypatch.setattr(
+            parameter_group, "sync_model_weight_from_main_weight", make_count_sync(parameter_group)
+        )
+
+    optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
+    fully_shard_optimizer(optimizer)
+    inputs = torch.randn(3, 2, 8, device=device, dtype=torch.bfloat16)
+
+    for step in range(3):
+        optimizer.zero_grad(set_to_none=True)
+        for microbatch_input in inputs:
+            (model(microbatch_input).sum() / len(inputs)).backward()
+
+        assert all(sync_count == step for sync_count in sync_counts.values())
+        optimizer.step()
+        assert all(sync_count == step + 1 for sync_count in sync_counts.values())
 
 
 def test_fully_shard_adam_mixed_precision_losses_match_baseline(distributed_setup):

--- a/tests/unit_tests/distributed/mfsdp_v2/test_optimizer.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_optimizer.py
@@ -12,6 +12,7 @@ from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
     Flat,
     Placements,
     fully_shard,
+    fully_shard_optimizer,
 )
 from megatron.core.distributed.fsdp.src.megatron_fsdp.mixed_precision import MixedPrecisionPolicy
 
@@ -54,8 +55,8 @@ def test_adam_without_adapter_raises_precision_error(distributed_setup):
         optimizer.step()
 
 
-def test_fused_adam_without_adapter_accepts_mismatched_grads(distributed_setup):
-    """TE FusedAdam should handle mixed-precision FSDP grads without the adapter."""
+def test_fused_adam_adapter_accepts_mismatched_grads(distributed_setup):
+    """TE FusedAdam should handle mixed-precision FSDP grads through the adapter."""
     world_size = distributed_setup.world_size
     device = distributed_setup.device
 
@@ -80,6 +81,7 @@ def test_fused_adam_without_adapter_accepts_mismatched_grads(distributed_setup):
         mixed_precision_policy=mixed_precision_policy,
     )
     optimizer = FusedAdam(model.parameters(), lr=0.01)
+    fully_shard_optimizer(optimizer, precision_aware=True)
 
     x = torch.randn(6, 8, device=device, dtype=torch.bfloat16)
     optimizer.zero_grad(set_to_none=True)


### PR DESCRIPTION
## Summary

- Move experimental FSDP main-weight to model-weight synchronization from forward hooks to the optimizer post-step hook, so it runs once per optimizer step instead of once per microbatch.
- Add `precision_aware=True` for optimizers, such as FusedAdam, that accept mixed-precision gradients without temporary casts.
- Initialize compute weights at FSDP setup and add multi-step synchronization coverage.

## Validation

- `python -m torch.distributed.run --nproc-per-node 2 -m pytest -q tests/unit_tests/distributed/mfsdp_v2/test_optimizer.py`
- Focused FSDP post-step synchronization, next-forward freshness, and mixed-precision Adam parity tests.
- Black, isort, Ruff, and `git diff --check`.
