### PR TITLE
Support MFSDP v2 with expert parallelism

### DIFF
--- a/examples/megatron_fsdp/README.md
+++ b/examples/megatron_fsdp/README.md
@@ -4,6 +4,33 @@ Example scripts for training and checkpoint conversion using [Megatron-FSDP](../
 
 ## Scripts
 
+### `train_mfsdp_v2_ep2.sh`
+
+Two-GPU smoke example for experimental MFSDP v2 with expert parallelism. It runs
+`pretrain_hybrid.py` with the two-layer `ME` hybrid pattern, two routed experts,
+EP=2, expert TP=1, and ZeRO-3 sharding. Routed experts are already partitioned
+by EP and are owned by singleton expert-DP meshes; router, norms, embeddings,
+output weights, and all Mamba/dense parameters are fully sharded over both GPUs.
+
+Run it from the repository root:
+
+```bash
+bash examples/megatron_fsdp/train_mfsdp_v2_ep2.sh
+```
+
+The startup log should contain:
+
+```text
+dense MFSDP size = 2
+EP size = 2
+expert-DP size = 1
+```
+
+The example runs five iterations with mock data and a null tokenizer. Every
+reported training loss should be finite. It intentionally has no checkpoint
+save/load, communication overlap, FP8, CUDA graphs, or fused gradient
+accumulation. The script unsets `CUDA_DEVICE_MAX_CONNECTIONS`, as MFSDP requires.
+
 ### `train_llama3_8b_fsdp_h100_fp8.sh`
 
 Single-node training script for **Llama 3 8B** using Megatron-FSDP with FP8 precision on H100 GPUs. Uses `torchrun` for local distributed training and supports both mock data (for benchmarking) and real datasets.

--- a/examples/megatron_fsdp/train_mfsdp_v2_ep2.sh
+++ b/examples/megatron_fsdp/train_mfsdp_v2_ep2.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Two-GPU MFSDP v2 + expert-parallel smoke example. Routed experts are
+# partitioned by EP and use singleton expert-DP meshes; all other parameters
+# are fully sharded over the two-rank dense DP mesh.
+set -euo pipefail
+
+unset CUDA_DEVICE_MAX_CONNECTIONS
+
+"${PYTHON:-python}" -m torch.distributed.run --standalone --nproc-per-node 2 pretrain_hybrid.py \
+    --spec megatron.core.models.hybrid.hybrid_layer_specs hybrid_stack_spec \
+    --hybrid-layer-pattern ME \
+    --num-layers 2 \
+    --hidden-size 128 \
+    --ffn-hidden-size 256 \
+    --moe-ffn-hidden-size 256 \
+    --num-attention-heads 2 \
+    --mamba-num-heads 2 \
+    --mamba-head-dim 64 \
+    --mamba-num-groups 1 \
+    --mamba-state-dim 64 \
+    --position-embedding-type none \
+    --normalization RMSNorm \
+    --swiglu \
+    --disable-bias-linear \
+    --untie-embeddings-and-output-weights \
+    --attention-dropout 0.0 \
+    --hidden-dropout 0.0 \
+    --num-experts 2 \
+    --moe-router-topk 1 \
+    --moe-router-pre-softmax \
+    --moe-router-load-balancing-type aux_loss \
+    --moe-aux-loss-coeff 1.0e-2 \
+    --moe-token-dispatcher-type alltoall \
+    --moe-grouped-gemm \
+    --tensor-model-parallel-size 1 \
+    --pipeline-model-parallel-size 1 \
+    --context-parallel-size 1 \
+    --expert-model-parallel-size 2 \
+    --expert-tensor-parallel-size 1 \
+    --use-megatron-fsdp \
+    --megatron-fsdp-version 2 \
+    --use-distributed-optimizer \
+    --data-parallel-sharding-strategy optim_grads_params \
+    --outer-dp-sharding-strategy no_shard \
+    --ckpt-format fsdp_dtensor \
+    --no-gradient-accumulation-fusion \
+    --bf16 \
+    --micro-batch-size 1 \
+    --global-batch-size 2 \
+    --seq-length 128 \
+    --max-position-embeddings 128 \
+    --train-iters 5 \
+    --lr 1.0e-4 \
+    --min-lr 1.0e-5 \
+    --lr-decay-style cosine \
+    --lr-warmup-fraction 0.01 \
+    --weight-decay 0.0 \
+    --clip-grad 1.0 \
+    --mock-data \
+    --tokenizer-type NullTokenizer \
+    --vocab-size 1024 \
+    --split 99,1,0 \
+    --num-workers 1 \
+    --no-create-attention-mask-in-dataloader \
+    --eval-iters 0 \
+    --eval-interval 100 \
+    --log-interval 1 \
+    --distributed-backend nccl

--- a/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
+++ b/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
@@ -43,6 +43,7 @@ from megatron.core.distributed.data_parallel_base import _BaseDataParallel
 from megatron.core.distributed.distributed_data_parallel_config import DistributedDataParallelConfig
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.ssm.mamba_layer import MambaLayer
+from megatron.core.transformer.moe.moe_layer import BaseMoELayer
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.transformer.transformer_layer import MoETransformerLayer, TransformerLayer
 from megatron.core.utils import is_te_min_version, log_single_rank
@@ -58,6 +59,7 @@ try:
         Placements,
         fully_shard,
     )
+    from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.module import FsdpModule
 
     HAVE_MEGATRON_FSDP = True
 except ImportError as import_megatron_fsdp_error:
@@ -532,12 +534,49 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
             self.mp_policy,
         )
 
+        routed_expert_parameters = self._get_routed_expert_parameters(module)
+        routed_expert_parameter_ids = {
+            id(parameter) for parameter in routed_expert_parameters.values()
+        }
+        expert_parameter_count = sum(
+            parameter.numel() for parameter in routed_expert_parameters.values()
+        )
+        dense_parameter_count = sum(
+            parameter.numel()
+            for parameter in module.parameters()
+            if id(parameter) not in routed_expert_parameter_ids
+        )
+
         dp_group = pg_collection.dp_cp
         device_type = device.type if device is not None else "cuda"
-        mesh = DeviceMesh.from_group(dp_group, device_type=device_type, mesh_dim_names=("dp",))
+        dense_mesh = DeviceMesh.from_group(
+            dp_group, device_type=device_type, mesh_dim_names=("dp",)
+        )
+        singleton_expert_mesh = None
+        if routed_expert_parameters:
+            singleton_expert_mesh = DeviceMesh.from_group(
+                pg_collection.expt_dp, device_type=device_type, mesh_dim_names=("expt_dp",)
+            )
         placements = Placements(
             dp_axes=[0], parameter=[Flat()], gradient=[Flat()], optimizer=[Flat()]
         )
+
+        # EP has already partitioned the routed experts before this adapter is entered.
+        # Register each local expert subtree with its singleton expert-DP mesh only to
+        # establish MFSDP/optimizer ownership. A size-one mesh does not further shard
+        # expert tensors or communicate; it prevents dense dp_cp units from claiming them.
+        expert_owned_fsdp_modules = []
+        for submodule in module.modules():
+            if isinstance(submodule, BaseMoELayer) and submodule.experts is not None:
+                assert singleton_expert_mesh is not None
+                fully_shard(
+                    submodule.experts,
+                    mesh=singleton_expert_mesh,
+                    placements=placements,
+                    mixed_precision_policy=self.mp_policy,
+                )
+                expert_owned_fsdp_modules.append(submodule.experts)
+
         for submodule in reversed(list(module.modules())):
             if submodule is module:
                 # The root is always sharded after selected child units so it is not
@@ -546,12 +585,71 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
             if any(isinstance(submodule, module_type) for module_type in fsdp_unit_modules):
                 fully_shard(
                     submodule,
-                    mesh=mesh,
+                    mesh=dense_mesh,
                     placements=placements,
                     mixed_precision_policy=self.mp_policy,
                 )
-        fully_shard(module, mesh=mesh, placements=placements, mixed_precision_policy=self.mp_policy)
+        fully_shard(
+            module, mesh=dense_mesh, placements=placements, mixed_precision_policy=self.mp_policy
+        )
+
+        expert_owned_parameter_ids = {
+            id(parameter)
+            for expert_module in expert_owned_fsdp_modules
+            for group in expert_module.parameter_groups
+            for parameter in group.unsharded_parameters
+        }
+        dense_owned_parameter_ids = {
+            id(parameter)
+            for fsdp_module in module.modules()
+            if isinstance(fsdp_module, FsdpModule) and fsdp_module not in expert_owned_fsdp_modules
+            for group in fsdp_module.parameter_groups
+            for parameter in group.unsharded_parameters
+        }
+        if expert_owned_parameter_ids != routed_expert_parameter_ids:
+            raise RuntimeError("MFSDP v2 failed to assign every routed-expert parameter.")
+        if routed_expert_parameter_ids & dense_owned_parameter_ids:
+            raise RuntimeError("MFSDP v2 assigned a routed-expert parameter to a dense group.")
+
+        log_single_rank(
+            logger,
+            logging.INFO,
+            "MFSDP v2 + EP startup: EP size = %d, dense MFSDP size = %d, "
+            "expert-DP size = %d, dense parameter count = %d, expert parameter count = %d",
+            pg_collection.ep.size(),
+            dense_mesh.size(),
+            pg_collection.expt_dp.size(),
+            dense_parameter_count,
+            expert_parameter_count,
+        )
         super().__init__(config=config, module=module)
+
+    @staticmethod
+    def _get_routed_expert_parameters(module: torch.nn.Module) -> Dict[str, torch.nn.Parameter]:
+        """Return parameters below recognized ``BaseMoELayer.experts`` containers."""
+        routed_parameter_ids = {
+            id(parameter)
+            for submodule in module.modules()
+            if isinstance(submodule, BaseMoELayer) and submodule.experts is not None
+            for parameter in submodule.experts.parameters()
+        }
+        routed_parameters = {
+            name: parameter
+            for name, parameter in module.named_parameters()
+            if id(parameter) in routed_parameter_ids
+        }
+        marked_outside_routed_experts = [
+            name
+            for name, parameter in module.named_parameters()
+            if not getattr(parameter, "allreduce", True)
+            and id(parameter) not in routed_parameter_ids
+        ]
+        if marked_outside_routed_experts:
+            raise ValueError(
+                "MFSDP v2 found expert-marked parameters outside recognized routed-expert "
+                f"containers: {', '.join(marked_outside_routed_experts)}"
+            )
+        return routed_parameters
 
     @staticmethod
     def _validate_config(
@@ -571,7 +669,6 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
             "tensor_model_parallel_size",
             "pipeline_model_parallel_size",
             "context_parallel_size",
-            "expert_model_parallel_size",
         ]
         if any(getattr(config, parallelism) != 1 for parallelism in unsupported_parallelisms):
             raise ValueError(
@@ -584,7 +681,7 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
 
         # The config validates the requested topology, while these checks validate the
         # materialized topology supplied by the caller's process-group collection.
-        for group_name in ("tp", "pp", "cp", "ep"):
+        for group_name in ("tp", "pp", "cp"):
             group = getattr(pg_collection, group_name, None)
             if group is not None and group.size() != 1:
                 raise ValueError(
@@ -592,10 +689,15 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
                     f"got {group.size()}."
                 )
 
-        if getattr(config, "num_moe_experts", None) is not None or any(
-            not getattr(parameter, "allreduce", True) for parameter in module.parameters()
-        ):
-            raise ValueError("MFSDP v2 does not currently support expert parameters.")
+        routed_expert_parameters = FullyShardedDataParallelV2._get_routed_expert_parameters(module)
+        if routed_expert_parameters:
+            if not hasattr(pg_collection, "expt_dp"):
+                raise ValueError("MFSDP v2 + EP requires an explicit expt_dp process group.")
+            if pg_collection.expt_dp.size() != 1:
+                raise ValueError(
+                    "MFSDP v2 + EP currently requires expert-DP size 1, "
+                    f"got {pg_collection.expt_dp.size()}."
+                )
         if ddp_config.data_parallel_sharding_strategy != "optim_grads_params":
             raise ValueError(
                 "MFSDP v2 requires data_parallel_sharding_strategy='optim_grads_params'."

--- a/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
+++ b/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
@@ -506,7 +506,7 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
         if not HAVE_MEGATRON_FSDP:
             raise IMPORT_MEGATRON_FSDP_ERROR
         if pg_collection is None:
-            pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+            raise ValueError("MFSDP v2 requires an explicit ProcessGroupCollection.")
         self._validate_config(config, ddp_config, module, pg_collection, disable_bucketing)
 
         if has_config_logger_enabled(config):
@@ -518,7 +518,7 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
             fsdp_unit_modules = [TransformerLayer, MoETransformerLayer, MambaLayer]
 
         log_single_rank(
-            logger, logging.INFO, f'Setting up DistributedDataParallel with config {ddp_config}'
+            logger, logging.INFO, "Setting up FullyShardedDataParallelV2 with config %s", ddp_config
         )
         self.mp_policy = MixedPrecisionPolicy(
             main_params_dtype=ddp_config.megatron_fsdp_main_params_dtype,
@@ -528,13 +528,13 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
         log_single_rank(
             logger,
             logging.INFO,
-            f'Setting up Megatron-FSDP MixedPrecisionPolicy with config {self.mp_policy}',
+            "Setting up Megatron-FSDP MixedPrecisionPolicy with config %s",
+            self.mp_policy,
         )
 
-        if device is None:
-            device = next(module.parameters()).device
         dp_group = pg_collection.dp_cp
-        mesh = DeviceMesh.from_group(dp_group, device_type=device.type, mesh_dim_names=("dp",))
+        device_type = device.type if device is not None else "cuda"
+        mesh = DeviceMesh.from_group(dp_group, device_type=device_type, mesh_dim_names=("dp",))
         placements = Placements(
             dp_axes=[0], parameter=[Flat()], gradient=[Flat()], optimizer=[Flat()]
         )
@@ -582,6 +582,8 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
                 )
             )
 
+        # The config validates the requested topology, while these checks validate the
+        # materialized topology supplied by the caller's process-group collection.
         for group_name in ("tp", "pp", "cp", "ep"):
             group = getattr(pg_collection, group_name, None)
             if group is not None and group.size() != 1:
@@ -671,7 +673,11 @@ def FullyShardedDataParallel(
     device: Optional[torch.device] = None,
     pg_collection: Optional[ProcessGroupCollection] = None,
 ) -> _BaseDataParallel:
-    """Construct the configured Megatron-FSDP implementation."""
+    """Construct the configured Megatron-FSDP implementation.
+
+    This is a factory function, not a wrapper type. Use the explicit V1 or V2
+    implementation classes for type checks.
+    """
     fsdp_class = (
         FullyShardedDataParallelV2
         if ddp_config.megatron_fsdp_version == 2

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -165,6 +165,8 @@ class FsdpParameterGroup:
             sharded_parameter = nn.Parameter(
                 self.main_weight.get_dtensor(index), requires_grad=parameter.requires_grad
             )
+            if hasattr(parameter, "allreduce"):
+                sharded_parameter.allreduce = parameter.allreduce
             if main_grad_dtype:
                 sharded_parameter.grad_dtype = main_grad_dtype
             setattr(sharded_parameter, _CONTAINING_PARAMETER_GROUP_ATTR, self)

--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -759,7 +759,7 @@ def _get_megatron_emerging_optimizer(
         use_layer_wise = True
 
     if isinstance(model_chunks[0], FullyShardedDataParallelV2):
-        raise ValueError("MFSDP v2 with emerging optimizers is not currently validated.")
+        raise NotImplementedError("MFSDP v2 with emerging optimizers is not currently validated.")
 
     if not HAVE_EMERGING_OPTIMIZERS:
         raise ImportError(

--- a/megatron/core/optimizer/fully_sharded_optimizer.py
+++ b/megatron/core/optimizer/fully_sharded_optimizer.py
@@ -42,7 +42,7 @@ class FullyShardedOptimizer(MixedPrecisionOptimizer):
             init_state_fn: Function used to initialize optimizer state.
             model_chunks: MFSDP v2 model chunks optimized by this wrapper.
         """
-        self.validate_config(config, model_chunks)
+        self._validate_config(config, model_chunks)
         if has_config_logger_enabled(config):
             log_config_to_disk(config, locals(), prefix=type(self).__name__)
         if grad_scaler is not None:
@@ -52,11 +52,12 @@ class FullyShardedOptimizer(MixedPrecisionOptimizer):
         self.model_chunks = model_chunks
         self.ddp_config = self.model_chunks[0].ddp_config
         for model_chunk in self.model_chunks:
-            assert self.ddp_config == model_chunk.ddp_config
+            if self.ddp_config != model_chunk.ddp_config:
+                raise ValueError("All MFSDP v2 model chunks must share the same ddp_config.")
         self.is_stub_optimizer = optimizer is None
 
     @staticmethod
-    def validate_config(config: OptimizerConfig, model_chunks: List[MegatronModule]) -> None:
+    def _validate_config(config: OptimizerConfig, model_chunks: List[MegatronModule]) -> None:
         """Validate the MFSDP v2 optimizer support contract."""
         if len(model_chunks) != 1:
             raise ValueError("MFSDP v2 currently supports exactly one model chunk.")

--- a/megatron/core/optimizer/fully_sharded_optimizer.py
+++ b/megatron/core/optimizer/fully_sharded_optimizer.py
@@ -9,6 +9,7 @@ import torch
 from ..config_logger import has_config_logger_enabled, log_config_to_disk
 from ..dist_checkpointing.mapping import ShardedStateDict
 from ..transformer.module import MegatronModule
+from ..utils import to_local_if_dtensor
 from .grad_scaler import MegatronGradScaler
 from .optimizer import MixedPrecisionOptimizer
 from .optimizer_config import OptimizerConfig
@@ -124,3 +125,32 @@ class FullyShardedOptimizer(MixedPrecisionOptimizer):
 
     def _copy_model_params_to_main_params(self, state_dict=None) -> None:
         """No-op: model loads already write into MFSDP v2's main weights."""
+
+    @torch.no_grad()
+    def get_grad_norm(self) -> float:
+        """Return the L2 norm over uniquely owned dense and EP-local gradient shards.
+
+        MFSDP v2 + EP can place optimizer-visible DTensors on two different meshes:
+        dense parameters use ``dp_cp`` while routed experts use singleton ``expt_dp``.
+        Under the currently supported topology (TP=PP=CP=1 and expert-DP=1), every
+        local gradient shard is uniquely owned and one world sum produces the global
+        dense-plus-expert norm without double counting either mesh.
+        """
+        local_squared_norm = torch.zeros(1, dtype=torch.float32, device="cuda")
+        for grad in self.get_grads_for_grad_norm():
+            local_grad = to_local_if_dtensor(grad).detach().float()
+            local_squared_norm += torch.sum(local_grad * local_grad)
+        torch.distributed.all_reduce(local_squared_norm, op=torch.distributed.ReduceOp.SUM)
+        return local_squared_norm.sqrt().item()
+
+    @torch.no_grad()
+    def clip_grad_norm(self, clip_grad: float) -> float:
+        """Clip mixed-mesh MFSDP gradients using their global unique-shard norm."""
+        grad_norm = self.get_grad_norm()
+        if clip_grad > 0.0:
+            clip_coefficient = min(clip_grad / (grad_norm + 1.0e-6), 1.0)
+            if clip_coefficient < 1.0:
+                for parameter in self.get_parameters():
+                    if parameter.grad is not None:
+                        to_local_if_dtensor(parameter.grad).mul_(clip_coefficient)
+        return grad_norm

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -50,9 +50,7 @@ from megatron.core.distributed import (
     finalize_model_grads,
 )
 from megatron.core.distributed.fsdp.mcore_fsdp_adapter import (
-    FullyShardedDataParallel as megatron_FSDP,
-)
-from megatron.core.distributed.fsdp.mcore_fsdp_adapter import (
+    FullyShardedDataParallel,
     FullyShardedDataParallelV1,
     FullyShardedDataParallelV2,
 )
@@ -1826,7 +1824,7 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
             assert HAVE_FSDP2, "Torch FSDP2 requires torch>=2.4.0"
             DP = torch_FSDP
         elif args.use_megatron_fsdp:
-            DP = megatron_FSDP
+            DP = FullyShardedDataParallel
         else:
             DP = DDP
 

--- a/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
@@ -13,6 +13,7 @@ from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.module import
 from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec
 from megatron.core.optimizer import OptimizerConfig, get_megatron_optimizer
 from megatron.core.optimizer.fully_sharded_optimizer import FullyShardedOptimizer
+from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.transformer_block import TransformerBlock
 from megatron.core.transformer.transformer_config import TransformerConfig
@@ -42,6 +43,7 @@ class TestMcoreAdapter:
         Utils.initialize_model_parallel(1, 1)
         if torch.distributed.get_world_size() < 2:
             pytest.skip("MFSDP v2 MCore integration test requires at least two ranks.")
+        self.pg_collection = ProcessGroupCollection.use_mpu_process_groups()
         model_parallel_cuda_manual_seed(1234)
 
     def teardown_method(self):
@@ -75,6 +77,7 @@ class TestMcoreAdapter:
             ),
             module=model,
             fsdp_unit_modules=[TransformerLayer],
+            pg_collection=self.pg_collection,
         )
 
         assert isinstance(wrapped.module, FsdpModule)
@@ -122,6 +125,7 @@ class TestMcoreAdapter:
                 fsdp_all_gather_in_start_param_sync=False,
             ),
             module=model,
+            pg_collection=self.pg_collection,
         )
 
         reference_optimizer_config = OptimizerConfig(
@@ -137,10 +141,6 @@ class TestMcoreAdapter:
         reference_optimizer = get_megatron_optimizer(
             reference_optimizer_config, [reference_model], use_gloo_process_groups=False
         )
-        with pytest.raises(ValueError, match="precision-aware optimizer"):
-            FullyShardedOptimizer.validate_config(
-                replace(optimizer_config, use_precision_aware_optimizer=True), [model]
-            )
         optimizer = get_megatron_optimizer(optimizer_config, [model], use_gloo_process_groups=False)
         assert isinstance(optimizer, FullyShardedOptimizer)
         optimizer.reload_model_params()
@@ -184,4 +184,4 @@ class TestMcoreAdapter:
         reference_losses = torch.stack(reference_losses)
         assert torch.isfinite(losses).all()
         assert torch.isfinite(reference_losses).all()
-        torch.testing.assert_close(losses, reference_losses, rtol=1e-3, atol=1e-3)
+        torch.testing.assert_close(losses, reference_losses, rtol=1e-3, atol=0)

--- a/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
@@ -2,6 +2,8 @@
 
 """MCore adapter and optimizer integration tests for experimental MFSDP v2."""
 
+import os
+from copy import copy
 from dataclasses import replace
 
 import pytest
@@ -15,6 +17,7 @@ from megatron.core.optimizer import OptimizerConfig, get_megatron_optimizer
 from megatron.core.optimizer.fully_sharded_optimizer import FullyShardedOptimizer
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.transformer.moe.moe_layer import BaseMoELayer
 from megatron.core.transformer.transformer_block import TransformerBlock
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.transformer.transformer_layer import TransformerLayer
@@ -34,6 +37,33 @@ def _build_block(config: TransformerConfig) -> TransformerBlock:
     return TransformerBlock(config=config, spec=get_gpt_layer_local_spec()).to(
         device="cuda", dtype=config.params_dtype
     )
+
+
+def _mfsdp_v2_config() -> DistributedDataParallelConfig:
+    return DistributedDataParallelConfig(
+        use_megatron_fsdp=True,
+        megatron_fsdp_version=2,
+        use_distributed_optimizer=True,
+        data_parallel_sharding_strategy="optim_grads_params",
+        megatron_fsdp_main_params_dtype=torch.float32,
+        megatron_fsdp_main_grads_dtype=torch.float32,
+        fsdp_all_gather_in_start_param_sync=False,
+    )
+
+
+class _ToyMoELayer(BaseMoELayer):
+    """Minimal ownership-only MoE layer with routed and dense subtrees."""
+
+    def __init__(self, hidden_size: int):
+        torch.nn.Module.__init__(self)
+        self.experts = torch.nn.Sequential(torch.nn.Linear(hidden_size, hidden_size, bias=False))
+        for parameter in self.experts.parameters():
+            parameter.allreduce = False
+        self.router = torch.nn.Linear(hidden_size, 2, bias=False)
+        self.shared_experts = torch.nn.Linear(hidden_size, hidden_size, bias=False)
+
+    def forward(self, hidden_states):
+        return self.experts(hidden_states) + self.shared_experts(hidden_states)
 
 
 class TestMcoreAdapter:
@@ -185,3 +215,86 @@ class TestMcoreAdapter:
         assert torch.isfinite(losses).all()
         assert torch.isfinite(reference_losses).all()
         torch.testing.assert_close(losses, reference_losses, rtol=1e-3, atol=0)
+
+
+class TestMcoreAdapterExpertParallel:
+    """Exercise separate dense and routed-expert ownership with EP=world size."""
+
+    def setup_method(self):
+        world_size = int(os.environ.get("WORLD_SIZE", "1"))
+        if world_size < 2:
+            pytest.skip("MFSDP v2 + EP integration tests require at least two ranks.")
+        Utils.initialize_model_parallel(1, 1, expert_model_parallel_size=world_size)
+        self.world_size = world_size
+        self.pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+
+    def teardown_method(self):
+        Utils.destroy_model_parallel()
+
+    def _config(self) -> TransformerConfig:
+        return TransformerConfig(
+            num_layers=1,
+            hidden_size=16,
+            num_attention_heads=4,
+            ffn_hidden_size=32,
+            num_moe_experts=self.world_size,
+            expert_model_parallel_size=self.world_size,
+            bf16=True,
+            params_dtype=torch.bfloat16,
+            gradient_accumulation_fusion=False,
+        )
+
+    def test_routes_experts_to_singleton_mesh_and_preserves_marker(self):
+        model = torch.nn.Sequential(_ToyMoELayer(16), torch.nn.Linear(16, 16, bias=False)).to(
+            device="cuda", dtype=torch.bfloat16
+        )
+
+        wrapped = FullyShardedDataParallel(
+            config=self._config(),
+            ddp_config=_mfsdp_v2_config(),
+            module=model,
+            pg_collection=self.pg_collection,
+        )
+
+        expert_groups = wrapped.module[0].experts.parameter_groups
+        assert expert_groups
+        assert all(group.mesh.size() == 1 for group in expert_groups)
+        assert all(
+            getattr(parameter, "allreduce", True) is False
+            for group in expert_groups
+            for parameter in group.sharded_parameters
+        )
+
+        dense_groups = [
+            group
+            for fsdp_module in wrapped.module.modules()
+            if isinstance(fsdp_module, FsdpModule) and fsdp_module is not wrapped.module[0].experts
+            for group in fsdp_module.parameter_groups
+        ]
+        assert dense_groups
+        assert all(group.mesh.size() == self.world_size for group in dense_groups)
+
+    def test_rejects_replicated_experts(self):
+        model = _ToyMoELayer(16).to(device="cuda", dtype=torch.bfloat16)
+        replicated_expert_pg_collection = copy(self.pg_collection)
+        replicated_expert_pg_collection.expt_dp = self.pg_collection.dp_cp
+
+        with pytest.raises(ValueError, match=r"MFSDP v2 \+ EP currently requires expert-DP size 1"):
+            FullyShardedDataParallel(
+                config=self._config(),
+                ddp_config=_mfsdp_v2_config(),
+                module=model,
+                pg_collection=replicated_expert_pg_collection,
+            )
+
+    def test_rejects_expert_marker_outside_routed_container(self):
+        model = torch.nn.Linear(16, 16, bias=False).to(device="cuda", dtype=torch.bfloat16)
+        model.weight.allreduce = False
+
+        with pytest.raises(ValueError, match="outside recognized routed-expert containers"):
+            FullyShardedDataParallel(
+                config=self._config(),
+                ddp_config=_mfsdp_v2_config(),
+                module=model,
+                pg_collection=self.pg_collection,
+            )


### PR DESCRIPTION
## What changed

- allow MFSDP v2 with expert parallelism while retaining the existing TP, PP, CP, HSDP, overlap, FP8, and CUDA graph restrictions
- fully shard dense parameters over `dp_cp` and register routed-expert subtrees on singleton `expt_dp` meshes
- preserve the `allreduce=False` expert marker on optimizer-visible sharded parameters
- validate routed-expert ownership and reject expert-DP sizes greater than one
- compute and clip gradient norms across the mixed dense and singleton-expert DTensor meshes
- add two-rank adapter regression coverage and a runnable `pretrain_hybrid.py` smoke example

## Why

MFSDP v2 previously rejected every expert-parallel configuration. Dense parameters should still receive ZeRO-3 sharding across data parallel ranks, while routed experts are already partitioned by EP and must not be claimed by the dense MFSDP mesh. For the initial implementation, each EP-local expert is therefore registered with MFSDP through a singleton expert-DP mesh, which establishes optimizer ownership without further expert sharding or communication.

This is a stacked PR based on #5865 via `pull-request/5865`.

## Validation

- `python -m torch.distributed.run --standalone --nproc-per-node 2 -m pytest -q tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py` — 5 passed
- `bash examples/megatron_fsdp/train_mfsdp_v2_ep2.sh` — completed 5 iterations with finite losses and gradient norms
- `ruff check` on changed Python files
- `black` and `isort` on changed Python files
- Python compilation, shell syntax, and `git diff --check`
