### PR TITLE
[Dev] Skip no-op BSHD padding masks in Qwen3.5-VL

### DIFF
--- a/examples/multimodal_dev/forward_step.py
+++ b/examples/multimodal_dev/forward_step.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 """Forward step, TP broadcast, and loss for multimodal_dev training."""
 
@@ -309,8 +309,11 @@ def pack_or_pad_batch(
         padded_batch["loss_mask"] = torch.concat(
             [x["loss_mask"].unsqueeze(0) for x in batch], dim=0
         )
-        positions = torch.arange(target_seqlens).unsqueeze(0)
-        padded_batch["padding_mask"] = positions >= torch.tensor(real_seqlens).unsqueeze(1)
+        # Keep None as the known-no-padding fast path for MoE routing.
+        has_padding = any(real_seqlen < target_seqlens for real_seqlen in real_seqlens)
+        if has_padding:
+            positions = torch.arange(target_seqlens).unsqueeze(0)
+            padded_batch["padding_mask"] = positions >= torch.tensor(real_seqlens).unsqueeze(1)
         padded_batch["pixel_values"] = torch.concat([x["pixel_values"] for x in batch])
         padded_batch["image_grid_thw"] = torch.concat([x["image_grid_thw"] for x in batch])
 

--- a/examples/multimodal_dev/tests/test_thd_e2e.py
+++ b/examples/multimodal_dev/tests/test_thd_e2e.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 """Tests for THD / padded batch construction in multimodal_dev.
 
@@ -196,6 +196,7 @@ class TestPackOrPadBatchPadded:
         assert padded["input_ids"].shape == (2, S)
         assert padded["labels"].shape == (2, S)
         assert padded["loss_mask"].shape == (2, S)
+        assert "padding_mask" not in padded
         # Sample-0 content is preserved verbatim.
         assert padded["input_ids"][0].tolist() == list(range(S))
 
@@ -213,6 +214,11 @@ class TestPackOrPadBatchPadded:
         assert padded["labels"][1].tolist() == [110, 111, 112, -100, -100, -100, -100]
         # loss_mask pads with 0.
         assert padded["loss_mask"][1].tolist() == [1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0]
+        assert padded["padding_mask"].dtype == torch.bool
+        assert padded["padding_mask"].tolist() == [
+            [False, False, False, False, False, False, False],
+            [False, False, False, True, True, True, True],
+        ]
 
     def test_seq_length_required(self):
         """``seq_length`` must be provided in padded mode."""
@@ -312,3 +318,7 @@ class TestPackOrPadBatchDivisibleBy4:
         assert padded["input_ids"][1].tolist() == [10, 11, 12, 0, 0, 0, 0, 0]
         assert padded["labels"][1].tolist() == [110, 111, 112, -100, -100, -100, -100, -100]
         assert padded["loss_mask"][1].tolist() == [1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        assert padded["padding_mask"].tolist() == [
+            [False, False, False, False, False, True, True, True],
+            [False, False, False, True, True, True, True, True],
+        ]


### PR DESCRIPTION
## Summary

For Qwen3.5-VL BSHD batches, only construct a padding mask when at least one sample is shorter than the padded target sequence length.

Previously, an all-False padding mask was created even when no padding existed. This bypassed the known-no-padding (`padding_mask=None`) fast path and introduced unnecessary masked-routing work in downstream MoE layers.

This change preserves the existing behavior when padding is required by:

- Variable sample sequence lengths.
- CP/SP sequence alignment.

THD behavior is unchanged.

## Test plan

- Added focused coverage for:
  - Equal-length BSHD batches without padding.
  - Variable-length BSHD batches.
  - BSHD batches requiring sequence-alignment padding.
- Ran `examples/multimodal_dev/tests/test_thd_e2e.py` on OCI: `20 passed`.
- Black, isort, Ruff, copyright, and `git diff --check` passed.