### PR TITLE
[dev] moe(fix): Restore per-token MTP loss logging

### DIFF
--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -497,9 +497,9 @@ class MTPLossLoggingHelper:
             if calculate_per_token_loss:
                 tracker["num_tokens"] = torch.zeros(num_layers, device=torch.cuda.current_device())
         else:
-            assert tracker.get("calculate_per_token_loss") == calculate_per_token_loss, (
-                "MTP loss tracker cannot mix per-token and microbatch-normalized logging modes."
-            )
+            assert (
+                tracker.get("calculate_per_token_loss") == calculate_per_token_loss
+            ), "MTP loss tracker cannot mix per-token and microbatch-normalized logging modes."
 
         if calculate_per_token_loss:
             tracker["loss_sums"][layer_number] += loss_sum.detach()

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -467,13 +467,13 @@ class MTPLossLoggingHelper:
         total: Optional[torch.Tensor] = None,
         reduce_group: Optional[torch.distributed.ProcessGroup] = None,
         avg_group: Optional[torch.distributed.ProcessGroup] = None,
+        calculate_per_token_loss: bool = False,
     ):
-        """Normalize and accumulate a local MTP loss for logging.
+        """Accumulate MTP loss for logging.
 
-        MTP is normalized independently for each microbatch. The tracker
-        accumulates those normalized losses, then reduction combines the sums
-        across ranks. This intentionally preserves sequence-packing semantics
-        instead of changing the metric to global ``sum(loss) / sum(tokens)``.
+        With per-token loss normalization, store raw loss sums and token
+        counts so logging reports ``sum(loss) / sum(tokens)``. Otherwise,
+        preserve the legacy microbatch-normalized logging contract.
 
         Args:
             loss_sum (torch.Tensor): Sum of per-element losses on this rank.
@@ -484,6 +484,8 @@ class MTPLossLoggingHelper:
             total (Optional[torch.Tensor]): Total number of MTP predictions.
             reduce_group (torch.distributed.ProcessGroup): Group for summing losses.
             avg_group (torch.distributed.ProcessGroup): Group for averaging losses.
+            calculate_per_token_loss (bool): Whether the main training path uses
+                per-token loss normalization.
         """
         if layer_number is None:
             return
@@ -491,8 +493,20 @@ class MTPLossLoggingHelper:
         tracker = MTPLossLoggingHelper.tracker
         if "loss_sums" not in tracker:
             tracker["loss_sums"] = torch.zeros(num_layers, device=torch.cuda.current_device())
-        loss_sum = (loss_sum * (num_tokens > 0).to(loss_sum.dtype)) / num_tokens.clamp(min=1)
-        tracker["loss_sums"][layer_number] += loss_sum.detach()
+            tracker["calculate_per_token_loss"] = calculate_per_token_loss
+            if calculate_per_token_loss:
+                tracker["num_tokens"] = torch.zeros(num_layers, device=torch.cuda.current_device())
+        else:
+            assert tracker.get("calculate_per_token_loss") == calculate_per_token_loss, (
+                "MTP loss tracker cannot mix per-token and microbatch-normalized logging modes."
+            )
+
+        if calculate_per_token_loss:
+            tracker["loss_sums"][layer_number] += loss_sum.detach()
+            tracker["num_tokens"][layer_number] += num_tokens.detach()
+        else:
+            loss_sum = (loss_sum * (num_tokens > 0).to(loss_sum.dtype)) / num_tokens.clamp(min=1)
+            tracker["loss_sums"][layer_number] += loss_sum.detach()
         if correct is not None and total is not None:
             if "correct_values" not in tracker:
                 tracker["correct_values"] = torch.zeros(
@@ -551,6 +565,8 @@ class MTPLossLoggingHelper:
         tracker = MTPLossLoggingHelper.tracker
         if "loss_sums" in tracker:
             tracker["loss_sums"].zero_()
+        if "num_tokens" in tracker:
+            tracker["num_tokens"].zero_()
         if "values" in tracker:
             tracker["values"].zero_()
         if "correct_values" in tracker:
@@ -564,13 +580,22 @@ class MTPLossLoggingHelper:
     def reduce_loss_in_tracker():
         """Collect and reduce the mtp losses across ranks.
 
-        Each element is already a sum of normalized microbatch losses. Sum
-        reductions preserve additive groups, while the DP+CP average keeps the
-        legacy logging contract.
+        Per-token mode reduces raw numerators and denominators before dividing.
+        Legacy mode reduces already-normalized microbatch losses.
         """
         tracker = MTPLossLoggingHelper.tracker
         if "loss_sums" not in tracker:
             return
+        if tracker.get("calculate_per_token_loss", False):
+            packed = torch.cat([tracker["loss_sums"], tracker["num_tokens"]])
+            for group_key in ('reduce_group', 'avg_group'):
+                group = tracker.get(group_key)
+                if group is not None:
+                    torch.distributed.all_reduce(packed, group=group)
+            loss_sums, num_tokens = packed.chunk(2)
+            tracker["values"] = loss_sums / num_tokens.clamp(min=1)
+            return
+
         values = tracker["loss_sums"]
         if tracker.get('reduce_group') is not None:
             torch.distributed.all_reduce(values, group=tracker['reduce_group'])
@@ -1079,6 +1104,7 @@ def process_mtp_loss(
                 correct=correct,
                 total=total,
                 avg_group=parallel_state.get_data_parallel_group(with_context_parallel=True),
+                calculate_per_token_loss=config.calculate_per_token_loss,
             )
         mtp_loss_scale = config.mtp_loss_scaling_factor / config.mtp_num_layers
         if config.calculate_per_token_loss:

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -3254,9 +3254,14 @@ def training_log(
 
     # Log MTP metrics.
     if args.mtp_num_layers is not None:
-        # Sequence-packing schedulers may change the number of microbatches for
-        # this step, so scale by the count returned from train_step.
-        mtp_loss_scale = 1 / (num_microbatches or get_num_microbatches())
+        if args.calculate_per_token_loss:
+            # The tracker already reduces raw loss sums and token counts into a
+            # per-token loss, matching the main loss normalization path.
+            mtp_loss_scale = 1.0
+        else:
+            # Legacy mode accumulates microbatch-normalized losses, so average
+            # by the scheduled microbatch count for this step.
+            mtp_loss_scale = 1 / (num_microbatches or get_num_microbatches())
         MTPLossLoggingHelper.track_mtp_metrics(
             mtp_loss_scale, iteration, writer, wandb_writer, total_loss_dict
         )

--- a/tests/unit_tests/transformer/test_multi_token_prediction.py
+++ b/tests/unit_tests/transformer/test_multi_token_prediction.py
@@ -1324,7 +1324,7 @@ class TestMTPLossLoggingHelper:
         assert tracker["avg_group"] is None
 
     def test_save_loss_to_tracker(self):
-        """Test saving a normalized loss to the tracker."""
+        """Test saving a legacy normalized loss to the tracker."""
         loss_sum = torch.tensor(1.3)
         num_tokens = torch.tensor(5.0)
         layer_number = 2
@@ -1344,6 +1344,30 @@ class TestMTPLossLoggingHelper:
         )
         assert MTPLossLoggingHelper.tracker["reduce_group"] is None
         assert MTPLossLoggingHelper.tracker["avg_group"] is None
+
+    def test_save_loss_to_tracker_per_token_stores_raw_loss_and_tokens(self):
+        """Per-token logging keeps raw sums so reduction can weight by tokens."""
+        loss_sum = torch.tensor(1.3)
+        num_tokens = torch.tensor(5.0)
+        layer_number = 2
+        num_layers = self.num_layers
+
+        MTPLossLoggingHelper.save_loss_to_tracker(
+            loss_sum=loss_sum,
+            num_tokens=num_tokens,
+            layer_number=layer_number,
+            num_layers=num_layers,
+            calculate_per_token_loss=True,
+        )
+
+        tracker = MTPLossLoggingHelper.tracker
+        assert "loss_sums" in tracker
+        assert "num_tokens" in tracker
+        assert tracker["calculate_per_token_loss"] is True
+        assert torch.isclose(tracker["loss_sums"][layer_number], loss_sum)
+        assert torch.isclose(tracker["num_tokens"][layer_number], num_tokens)
+        assert tracker["reduce_group"] is None
+        assert tracker["avg_group"] is None
 
     def test_mtp_logits_are_vocab_sharded(self):
         """Test detection for vocab-sharded versus gathered MTP logits."""
@@ -1487,6 +1511,41 @@ class TestMTPLossLoggingHelper:
         global_token_weighted = torch.tensor((8.0 + 4.0) / (2.0 + 4.0))
         assert torch.isclose(logged_loss, microbatch_mean_average)
         assert not torch.isclose(logged_loss, global_token_weighted)
+
+    def test_per_token_loss_is_globally_token_weighted(self):
+        """Per-token MTP logging must match calculate-per-token-loss semantics."""
+        MTPLossLoggingHelper.save_loss_to_tracker(
+            loss_sum=torch.tensor(8.0),
+            num_tokens=torch.tensor(2.0),
+            layer_number=0,
+            num_layers=1,
+            calculate_per_token_loss=True,
+        )
+        MTPLossLoggingHelper.save_loss_to_tracker(
+            loss_sum=torch.tensor(4.0),
+            num_tokens=torch.tensor(4.0),
+            layer_number=0,
+            num_layers=1,
+            calculate_per_token_loss=True,
+        )
+
+        class DummyWriter:
+            def __init__(self):
+                self.scalars = {}
+
+            def add_scalar(self, name, value, iteration):
+                self.scalars[name] = value
+
+        writer = DummyWriter()
+        MTPLossLoggingHelper.track_mtp_metrics(
+            loss_scale=1.0, iteration=1, writer=writer, total_loss_dict={}
+        )
+
+        logged_loss = torch.as_tensor(writer.scalars["mtp_1 loss"])
+        microbatch_mean_average = torch.tensor(((8.0 / 2.0) + (4.0 / 4.0)) / 2.0)
+        global_token_weighted = torch.tensor((8.0 + 4.0) / (2.0 + 4.0))
+        assert torch.isclose(logged_loss, global_token_weighted)
+        assert not torch.isclose(logged_loss, microbatch_mean_average)
 
     def test_track_mtp_loss_preserves_legacy_normalized_loss_semantics(self):
         """MTP loss logging should not become token-weighted when acceptance counters are added."""


### PR DESCRIPTION
- [ ] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
<!-- Add a one line overview of what this PR aims to accomplish. -->

[[codex] Restore per-microbatch MTP loss logging by xiaoyao0115 · Pull Request #5543 · NVIDIA/Megatron-LM](https://github.com/NVIDIA/Megatron-LM/pull/5543) breaks the MTP loss logging of per-token path. Fix it in this PR.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
