### PR TITLE
Add experimental NVSHMEM context-parallel attention backend

### DIFF
--- a/docs/developer/experimental_nvshmem_cp_backend.md
+++ b/docs/developer/experimental_nvshmem_cp_backend.md
@@ -1,0 +1,80 @@
+# Experimental NVSHMEM Context-Parallel Attention
+
+Megatron can select an opt-in NVSHMEM context-parallel attention backend with:
+
+```text
+--context-parallel-attention-backend nvshmem
+```
+
+The default remains unchanged. The experimental backend publishes K/V into
+NVSHMEM symmetric workspaces, consumes peer K/V from those workspaces, and
+returns remote K/V gradients to their owners. Workspaces are allocated
+collectively before pipeline execution so that allocation order cannot diverge
+between ranks.
+
+## Supported Contract
+
+The implementation fails closed outside the configuration that has been
+qualified:
+
+- context parallel size 4;
+- tensor parallel size 1;
+- `cp_comm_type=p2p` as the comparison contract;
+- multi-head attention with head dimension 128;
+- causal self-attention training;
+- one in-flight microbatch;
+- BF16 Q/K/V for the selected fused path.
+
+Inference, cross-attention, packed sequences, rotary embeddings at this
+boundary, attention output gates, activation offload, and overlapping pipeline
+microbatches are not supported yet.
+
+## Dependency Stack
+
+This Megatron integration depends on two experimental lower-level changes that
+are not part of this patch:
+
+1. Transformer Engine NVSHMEM workspace, synchronization, fused attention, and
+   owner-gradient-return primitives.
+2. FlashAttention 4 two-section causal backward with saved-state and direct
+   owner dK/dV return.
+
+The backend also requires `nvshmem4py-cu13`, `cuda-core`, CuPy, and an NVSHMEM
+runtime visible to the dynamic linker. Deployments must set an explicit
+`NVSHMEM_SYMMETRIC_SIZE` large enough for all per-layer K/V and gradient-return
+workspaces. CUDA VMM policy is deployment-specific and is deliberately not set
+by Megatron.
+
+Do not enable the selector against unmodified upstream Transformer Engine or
+FlashAttention builds. Missing extension symbols cause a fail-closed error.
+
+## Existing Four-GPU Evidence
+
+The research build was measured on four GB200 GPUs at TP=1, PP=1, DP=1, EP=1,
+CP=4, sequence length 262144, hidden size 2560, 20 heads, head dimension 128,
+four layers, vocabulary 157184, and global batch size 1.
+
+| Metric | TE p2p | NVSHMEM | Change |
+|---|---:|---:|---:|
+| Median training step | 1831.75 ms | 1416.00 ms | 22.68% faster |
+| Strict checkpoint comparison | reference | max abs 1.90735e-6 | 73 tensors passed |
+| Allocated memory | reference | approximately +9 GiB | requires reduction |
+
+The timing result is the median of four isolated counterbalanced pairs; each
+pair ran eight updates and used updates 4-7 as its steady window. The observed
+speedups ranged from 22.62% to 22.82%.
+
+This is production-shape sequence evidence, not production-topology evidence.
+It does not cover TP=1, PP=4, DP=8, EP=8, CP=4 on 128 GPUs. It was also produced
+from the research dependency stack; the reduced review branch must be rebuilt
+and rerun from clean dependency checkouts before the performance result can be
+attached to an upstream PR.
+
+## Review and Promotion Gates
+
+1. Review and pin the Transformer Engine and FlashAttention dependency changes.
+2. Build all three repositories from clean checkouts without path overrides.
+3. Run tiny deterministic forward/backward equivalence tests.
+4. Repeat the strict four-GPU long-sequence checkpoint and timing gate.
+5. Measure rank skew, attention phases, and peak memory.
+6. Qualify the full production topology when the required hardware is available.

--- a/docs/developer/experimental_nvshmem_cp_backend.md
+++ b/docs/developer/experimental_nvshmem_cp_backend.md
@@ -34,10 +34,14 @@ microbatches are not supported yet.
 This Megatron integration depends on two experimental lower-level changes that
 are not part of this patch:
 
-1. Transformer Engine NVSHMEM workspace, synchronization, fused attention, and
-   owner-gradient-return primitives.
-2. FlashAttention 4 two-section causal backward with saved-state and direct
-   owner dK/dV return.
+1. one Transformer Engine CP=4 global dK/dV owner-return primitive with a
+   stream-ordered epoch protocol;
+2. FlashAttention 4 two-section causal backward for two query sections that
+   share one K/V prefix.
+
+Megatron owns symmetric allocation, peer mappings, K/V publication, and backend
+selection. FlashAttention owns attention math, and Transformer Engine only
+performs the final symmetric owner-gradient return.
 
 The backend also requires `nvshmem4py-cu13`, `cuda-core`, CuPy, and an NVSHMEM
 runtime visible to the dynamic linker. Deployments must set an explicit
@@ -48,33 +52,48 @@ by Megatron.
 Do not enable the selector against unmodified upstream Transformer Engine or
 FlashAttention builds. Missing extension symbols cause a fail-closed error.
 
-## Existing Four-GPU Evidence
+## Four-GPU Evidence
 
-The research build was measured on four GB200 GPUs at TP=1, PP=1, DP=1, EP=1,
-CP=4, sequence length 262144, hidden size 2560, 20 heads, head dimension 128,
-four layers, vocabulary 157184, and global batch size 1.
+The backend was measured on four GB200 GPUs at TP=1, PP=1, DP=1, EP=1, CP=4,
+sequence length 262144, hidden size 2560, 20 heads, head dimension 128, four
+layers, vocabulary 157184, and global batch size 1.
+
+The initial research stack measured 1831.75 ms for TE p2p and 1416.00 ms for
+the candidate, or 22.68% lower iteration time over four counterbalanced pairs.
+That result motivated the dependency reduction, but it is not the clean-branch
+scoreboard.
+
+The reduced Megatron, Transformer Engine, and FlashAttention branches were then
+built from clean checkouts and rerun as one baseline/candidate pair:
 
 | Metric | TE p2p | NVSHMEM | Change |
 |---|---:|---:|---:|
-| Median training step | 1831.75 ms | 1416.00 ms | 22.68% faster |
-| Strict checkpoint comparison | reference | max abs 1.90735e-6 | 73 tensors passed |
-| Allocated memory | reference | approximately +9 GiB | requires reduction |
+| Median training step, iterations 4-7 | 1707.45 ms | 1413.65 ms | 17.21% lower |
+| Strict checkpoint comparison | reference | max abs 1.90735e-6 | 73/73 tensors passed |
+| Steady allocated memory | 23885.75 MiB | 33501.38 MiB | +9615.63 MiB |
+| Peak allocated memory | 104005.82 MiB | 112986.44 MiB | +8980.62 MiB |
 
-The timing result is the median of four isolated counterbalanced pairs; each
-pair ran eight updates and used updates 4-7 as its steady window. The observed
-speedups ranged from 22.62% to 22.82%.
+Both runs used eight optimizer updates, mock data, selective activation
+recompute, BF16, and identical seeds and optimizer settings. The clean result
+establishes training correctness and an integrated speedup, but a single pair
+is not sufficient for a final performance claim.
 
 This is production-shape sequence evidence, not production-topology evidence.
-It does not cover TP=1, PP=4, DP=8, EP=8, CP=4 on 128 GPUs. It was also produced
-from the research dependency stack; the reduced review branch must be rebuilt
-and rerun from clean dependency checkouts before the performance result can be
-attached to an upstream PR.
+It does not cover TP=1, PP=4, DP=8, EP=8, CP=4 on 128 GPUs.
 
 ## Review and Promotion Gates
 
-1. Review and pin the Transformer Engine and FlashAttention dependency changes.
-2. Build all three repositories from clean checkouts without path overrides.
-3. Run tiny deterministic forward/backward equivalence tests.
-4. Repeat the strict four-GPU long-sequence checkpoint and timing gate.
-5. Measure rank skew, attention phases, and peak memory.
-6. Qualify the full production topology when the required hardware is available.
+Completed review-branch gates:
+
+1. Reduced and pinned Transformer Engine and FlashAttention dependency branches.
+2. Built all three repositories from clean checkouts into isolated wheels/runtime trees.
+3. Passed a tiny deterministic two-update checkpoint comparison: 22/22 tensors,
+   worst max-abs 9.20e-8.
+4. Passed the strict four-GPU long-sequence gate reported above.
+
+Remaining promotion gates:
+
+1. Repeat the clean long-sequence pair in counterbalanced order.
+2. Reduce the approximately 9 GiB memory premium.
+3. Measure attention phases and rank skew without perturbing the clean scoreboard.
+4. Qualify the full production topology when the required hardware is available.

--- a/docs/index.md
+++ b/docs/index.md
@@ -88,6 +88,7 @@ developer/contribute
 developer/submit
 developer/oncall
 developer/generate_docs
+developer/experimental_nvshmem_cp_backend
 ```
 
 ```{toctree}

--- a/megatron/core/cp_timing.py
+++ b/megatron/core/cp_timing.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Small JSONL helpers for opt-in context-parallel timing instrumentation."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+import torch
+
+_COUNTERS: dict[str, int] = {}
+
+
+def cp_timing_enabled() -> bool:
+    return bool(os.getenv("MEGATRON_CP_TIMING_DIR"))
+
+
+def _rank() -> int:
+    if torch.distributed.is_available() and torch.distributed.is_initialized():
+        return torch.distributed.get_rank()
+    return 0
+
+
+def record_cp_timing(event: dict[str, Any]) -> None:
+    out_dir = os.getenv("MEGATRON_CP_TIMING_DIR")
+    if not out_dir:
+        return
+    path = Path(out_dir)
+    path.mkdir(parents=True, exist_ok=True)
+    event_name = str(event.get("event", "unknown"))
+    event["event_index"] = _COUNTERS.get(event_name, 0)
+    _COUNTERS[event_name] = event["event_index"] + 1
+    event.setdefault("rank", _rank())
+    event.setdefault("ts_ns", time.time_ns())
+    with (path / f"rank{event['rank']:05d}.jsonl").open("a", encoding="utf-8") as f:
+        f.write(json.dumps(event, sort_keys=True) + "\n")
+
+
+def tensor_meta(tensor: torch.Tensor | None) -> dict[str, Any] | None:
+    if tensor is None:
+        return None
+    return {
+        "shape": list(tensor.shape),
+        "dtype": str(tensor.dtype),
+        "numel": int(tensor.numel()),
+        "element_size": int(tensor.element_size()),
+        "bytes": int(tensor.numel() * tensor.element_size()),
+        "device": str(tensor.device),
+    }
+
+
+def classify_cp_comm(cp_comm_type: str | None) -> str:
+    if cp_comm_type == "p2p":
+        return "ring_p2p_multi_peer"
+    if cp_comm_type == "all_gather":
+        return "all_gather_full_kv"
+    if cp_comm_type == "a2a":
+        return "all_to_all_head_sequence_exchange"
+    if cp_comm_type == "a2a+p2p":
+        return "hybrid_hierarchical_a2a_p2p"
+    if cp_comm_type == "nvshmem_ring_p2p":
+        return "nvshmem_peer_read_ring_p2p_forward_only"
+    if cp_comm_type is None:
+        return "none"
+    return "unknown"

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -1326,6 +1326,26 @@ class Attention(MegatronModule, ABC):
         if rotary_pos_emb is not None and not isinstance(rotary_pos_emb, tuple):
             rotary_pos_emb = (rotary_pos_emb,) * 2
 
+        if self.config.context_parallel_attention_backend == 'nvshmem':
+            from megatron.core.transformer.nvshmem_cp_fa_owner import (
+                nvshmem_cp_symmetric_qkv_self_attention_forward,
+            )
+
+            return nvshmem_cp_symmetric_qkv_self_attention_forward(
+                module=self,
+                hidden_states=hidden_states,
+                attention_mask=attention_mask,
+                key_value_states=key_value_states,
+                inference_context=inference_context,
+                rotary_pos_emb=rotary_pos_emb,
+                rotary_pos_cos=rotary_pos_cos,
+                rotary_pos_sin=rotary_pos_sin,
+                rotary_pos_cos_sin=rotary_pos_cos_sin,
+                attention_bias=attention_bias,
+                packed_seq_params=packed_seq_params,
+                sequence_len_offset=sequence_len_offset,
+            )
+
         # =====================
         # Query, Key, and Value
         # =====================

--- a/megatron/core/transformer/nvshmem_cp_attention.py
+++ b/megatron/core/transformer/nvshmem_cp_attention.py
@@ -1,0 +1,635 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Lifecycle and symmetric workspace support for experimental NVSHMEM CP attention."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import torch
+
+from megatron.core import parallel_state
+
+_NVSHMEM_INITIALIZED = False
+_NVSHMEM_INITIALIZATION_ELAPSED_MS: float | None = None
+_NVSHMEM_WORKSPACES_FROZEN = False
+_WORKSPACES: Dict[Tuple[object, ...], "NvshmemCpWorkspace"] = {}
+
+_NVSHMEM_CP_BRANCH_B_PROFILE = {
+    "FLASH_ATTN_TWO_SECTION_DIRECT_OWNER_DKV": "1",
+    "FLASH_ATTN_UNSAFE_TWO_SECTION_CAUSAL_BWD": "1",
+    "MEGATRON_NVSHMEM_CP_BLOCK_READY_PROTOCOL": "1",
+    "MEGATRON_NVSHMEM_CP_BLOCK_READY_STREAM_WAIT": "0",
+    "MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_GLOBAL": "1",
+    "MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_GLOBAL_GRAD_RETURN": "1",
+    "MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_PREWARM": "1",
+    "MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_SHARED_KV_BATCH": "1",
+    "MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_TWO_SECTION_CAUSAL_BWD": "1",
+    "MEGATRON_NVSHMEM_CP_BRANCH_B_GRAD_EPOCH_STREAM_WAIT": "1",
+    "MEGATRON_NVSHMEM_CP_BRANCH_B_HOST_CALL_EPOCH": "1",
+    "MEGATRON_NVSHMEM_CP_BRANCH_B_SKIP_POST_NATIVE_BACKWARD_SYNC": "1",
+    "MEGATRON_NVSHMEM_CP_BRANCH_B_SKIP_PRE_GRAD_EPOCH_STREAM_SYNC": "1",
+    "MEGATRON_NVSHMEM_CP_BRANCH_B_STREAM_WRITE_GRAD_EPOCH": "1",
+    "MEGATRON_NVSHMEM_CP_CORE_ATTN_SAVED_STATE": "1",
+    "MEGATRON_NVSHMEM_CP_DIRECT_QKV_PRODUCER": "0",
+    "MEGATRON_NVSHMEM_CP_FA_OWNER_IO_V1_BACKWARD_IMPL": "block_ready_native_fused",
+    "MEGATRON_NVSHMEM_CP_GRAD_RETURN_DTYPE": "fp32",
+    "MEGATRON_NVSHMEM_CP_OWNER": "fa_owner_io_v1",
+    "MEGATRON_NVSHMEM_CP_SELF_ATTENTION_BACKEND": "symmetric_qkv_v0",
+}
+
+
+class NvshmemCpAttentionError(RuntimeError):
+    """Raised when the experimental NVSHMEM CP attention path cannot run."""
+
+
+def configure_nvshmem_cp_backend() -> dict[str, str]:
+    """Install the validated Branch-B profile behind the typed Megatron selector.
+
+    NVSHMEM runtime settings such as the symmetric heap and CUDA VMM policy remain deployment
+    concerns and are intentionally not changed here.
+    """
+
+    for name, value in _NVSHMEM_CP_BRANCH_B_PROFILE.items():
+        os.environ.setdefault(name, value)
+    return dict(_NVSHMEM_CP_BRANCH_B_PROFILE)
+
+
+class NvshmemCpWorkspace:
+    key: torch.Tensor
+    value: torch.Tensor
+    committed_epoch: torch.Tensor
+    block_ready_epoch: torch.Tensor
+    grad_key_return: torch.Tensor
+    grad_value_return: torch.Tensor
+    grad_committed_epoch: torch.Tensor
+    raw_key_return: torch.Tensor
+    raw_value_return: torch.Tensor
+    carrier_key_slots: torch.Tensor
+    carrier_value_slots: torch.Tensor
+    carrier_epoch: torch.Tensor
+    peer_keys: List[torch.Tensor]
+    peer_values: List[torch.Tensor]
+    peer_committed_epochs: List[torch.Tensor]
+    peer_block_ready_epochs: List[torch.Tensor]
+    peer_grad_key_returns: List[torch.Tensor]
+    peer_grad_value_returns: List[torch.Tensor]
+    peer_grad_committed_epochs: List[torch.Tensor]
+    peer_raw_key_returns: List[torch.Tensor]
+    peer_raw_value_returns: List[torch.Tensor]
+    peer_carrier_key_slots: List[torch.Tensor]
+    peer_carrier_value_slots: List[torch.Tensor]
+    peer_carrier_epochs: List[torch.Tensor]
+    cp_group_ranks: List[int]
+
+
+def _import_nvshmem():
+    try:
+        import cupy
+        import nvshmem
+        import nvshmem.core
+        try:
+            from cuda.core import Device
+        except ImportError:
+            from cuda.core.experimental import Device
+        from nvshmem import bindings as nvshmem_bindings
+        from nvshmem.core.interop import torch as nvshmem_torch
+        from nvshmem.core.interop.torch import get_peer_tensor
+    except Exception as err:
+        raise NvshmemCpAttentionError(
+            "Experimental NVSHMEM CP attention requires nvshmem4py-cu13, "
+            "cuda-core, and cupy in the active Megatron Python environment."
+        ) from err
+    return cupy, nvshmem, Device, nvshmem_bindings, nvshmem_torch, get_peer_tensor
+
+
+def _ensure_nvshmem_initialized() -> object:
+    global _NVSHMEM_INITIALIZED, _NVSHMEM_INITIALIZATION_ELAPSED_MS
+    cupy, nvshmem, Device, nvshmem_bindings, _, _ = _import_nvshmem()
+    if _NVSHMEM_INITIALIZED:
+        return nvshmem_bindings
+
+    init_start = time.perf_counter()
+
+    if not torch.distributed.is_available() or not torch.distributed.is_initialized():
+        raise NvshmemCpAttentionError("torch.distributed must be initialized before NVSHMEM.")
+
+    device = torch.cuda.current_device()
+    nv_device = Device(device)
+    nv_device.set_current()
+    cupy.cuda.Device(device).use()
+
+    rank = torch.distributed.get_rank()
+    world_size = torch.distributed.get_world_size()
+    uid_holder = [nvshmem.core.get_unique_id(empty=True)]
+    if rank == 0:
+        uid_holder[0] = nvshmem.core.get_unique_id()
+    torch.distributed.broadcast_object_list(uid_holder, src=0)
+    torch.distributed.barrier()
+
+    nvshmem.core.init(
+        device=nv_device,
+        uid=uid_holder[0],
+        rank=rank,
+        nranks=world_size,
+        initializer_method="uid",
+    )
+    _NVSHMEM_INITIALIZED = True
+    _NVSHMEM_INITIALIZATION_ELAPSED_MS = (time.perf_counter() - init_start) * 1000.0
+    return nvshmem_bindings
+
+
+def eager_initialize_nvshmem_cp_backend_if_enabled() -> bool:
+    """Initialize the world-scoped NVSHMEM runtime before pipeline execution."""
+
+    if os.getenv("MEGATRON_NVSHMEM_CP_SELF_ATTENTION_BACKEND") != "symmetric_qkv_v0":
+        return False
+
+    was_initialized = _NVSHMEM_INITIALIZED
+    _ensure_nvshmem_initialized()
+    return not was_initialized
+
+
+def validate_nvshmem_cp_microbatch_contract(num_microbatches: int) -> None:
+    """Reject workspace reuse that can overlap across pipeline microbatches."""
+
+    if os.getenv("MEGATRON_NVSHMEM_CP_SELF_ATTENTION_BACKEND") != "symmetric_qkv_v0":
+        return
+    if int(num_microbatches) != 1:
+        raise NvshmemCpAttentionError(
+            "The symmetric_qkv_v0 backend currently owns one workspace per layer and "
+            "requires exactly one pipeline microbatch; "
+            f"num_microbatches={num_microbatches}."
+        )
+
+
+def _workspace_allocation_manifest(
+    shape: Tuple[int, ...],
+    dtype: torch.dtype,
+    cp_size: int,
+) -> Dict[str, object]:
+    """Describe every symmetric allocation in its required collective order."""
+
+    grad_shape = (cp_size,) + tuple(shape)
+
+    allocations = [
+        {"name": "key", "shape": list(shape), "dtype": str(dtype)},
+        {"name": "value", "shape": list(shape), "dtype": str(dtype)},
+        {"name": "committed_epoch", "shape": [1], "dtype": str(torch.int32)},
+        {
+            "name": "block_ready_epoch",
+            "shape": [_ready_block_count(shape)],
+            "dtype": str(torch.int32),
+        },
+        {"name": "grad_key_return", "shape": list(grad_shape), "dtype": str(dtype)},
+        {"name": "grad_value_return", "shape": list(grad_shape), "dtype": str(dtype)},
+    ]
+    allocations.append(
+        {"name": "grad_committed_epoch", "shape": [cp_size], "dtype": str(torch.int32)}
+    )
+
+    return {
+        "shape": list(shape),
+        "dtype": str(dtype),
+        "cp_size": cp_size,
+        "ready_block_count": _ready_block_count(shape),
+        "abi": {
+            "raw_return_sideband": False,
+            "cross_rank_carrier": False,
+            "writer_indexed_carrier": False,
+            "carrier_slot_count": 0,
+        },
+        "allocations": allocations,
+    }
+
+
+def eager_allocate_nvshmem_cp_workspaces_if_enabled(
+    model,
+    *,
+    seq_length: int,
+    micro_batch_size: int,
+) -> int:
+    """Collectively allocate every local layer workspace before pipeline execution."""
+
+    global _NVSHMEM_WORKSPACES_FROZEN
+
+    if os.getenv("MEGATRON_NVSHMEM_CP_SELF_ATTENTION_BACKEND") != "symmetric_qkv_v0":
+        return 0
+    if not _NVSHMEM_INITIALIZED:
+        raise NvshmemCpAttentionError(
+            "NVSHMEM must be eagerly initialized before workspace allocation."
+        )
+
+    allocation_start = time.perf_counter()
+
+    roots = model if isinstance(model, (list, tuple)) else [model]
+    specs = []
+    local_signature = []
+    local_error = None
+    try:
+        attention_modules = []
+        seen = set()
+        for root in roots:
+            for module in root.modules():
+                if id(module) in seen or module.__class__.__name__ != "SelfAttention":
+                    continue
+                seen.add(id(module))
+                if not hasattr(module, "layer_number"):
+                    continue
+                attention_modules.append(module)
+        attention_modules.sort(key=lambda module: int(module.layer_number or 0))
+
+        if not attention_modules:
+            raise NvshmemCpAttentionError(
+                "The symmetric_qkv_v0 backend requires every pipeline rank to own "
+                "at least one SelfAttention layer."
+            )
+        layer_numbers = [int(module.layer_number or 0) for module in attention_modules]
+        duplicate_layers = sorted(
+            layer for layer in set(layer_numbers) if layer_numbers.count(layer) > 1
+        )
+        if duplicate_layers:
+            raise NvshmemCpAttentionError(
+                "The symmetric_qkv_v0 workspace cache requires unique local layer numbers; "
+                f"duplicates={duplicate_layers}."
+            )
+
+        for module in attention_modules:
+            cp_size = int(module.config.context_parallel_size)
+            if cp_size != 4 or seq_length % cp_size != 0:
+                raise NvshmemCpAttentionError(
+                    "The symmetric_qkv_v0 workspace preallocator requires CP=4 and "
+                    "a sequence length divisible by CP."
+                )
+            shape = (
+                int(seq_length) // cp_size,
+                int(micro_batch_size),
+                int(module.num_query_groups_per_partition),
+                int(module.hidden_size_per_attention_head),
+            )
+            dtype = module.config.params_dtype
+            specs.append((shape, dtype, int(module.layer_number or 0), cp_size))
+        local_signature = [
+            _workspace_allocation_manifest(shape, dtype, cp_size)
+            for shape, dtype, _, cp_size in specs
+        ]
+    except Exception as error:
+        local_error = f"{type(error).__name__}: {error}"
+
+    local_validation = {"error": local_error, "signature": local_signature}
+    world_validations = [None] * torch.distributed.get_world_size()
+    torch.distributed.all_gather_object(world_validations, local_validation)
+    rank_errors = {
+        rank: validation["error"]
+        for rank, validation in enumerate(world_validations)
+        if validation["error"] is not None
+    }
+    if rank_errors:
+        raise NvshmemCpAttentionError(
+            "NVSHMEM workspace validation failed before symmetric allocation; "
+            f"rank_errors={rank_errors}."
+        )
+
+    canonical_signature = world_validations[0]["signature"]
+    mismatched = [
+        rank
+        for rank, validation in enumerate(world_validations)
+        if validation["signature"] != canonical_signature
+    ]
+    if mismatched:
+        raise NvshmemCpAttentionError(
+            "NVSHMEM symmetric allocations must be collective and identically ordered; "
+            f"workspace signature differs on global ranks {mismatched}."
+        )
+
+    device = torch.device("cuda", torch.cuda.current_device())
+    for shape, dtype, layer_number, _ in specs:
+        _workspace(shape, dtype, device, layer_number)
+    torch.cuda.current_stream().synchronize()
+    torch.distributed.barrier()
+    _NVSHMEM_WORKSPACES_FROZEN = True
+    audit_dir = os.getenv("MEGATRON_NVSHMEM_CP_STARTUP_AUDIT_DIR")
+    if audit_dir:
+        global_rank = torch.distributed.get_rank()
+
+        def group_members(group, name: str) -> List[int]:
+            if isinstance(group, (list, tuple)):
+                raise NvshmemCpAttentionError(
+                    f"Startup receipt requires one {name} process group, got {type(group).__name__}."
+                )
+            return [int(rank) for rank in torch.distributed.get_process_group_ranks(group)]
+
+        tp_group_ranks = group_members(
+            parallel_state.get_tensor_model_parallel_group(), "TP"
+        )
+        cp_group_ranks = group_members(parallel_state.get_context_parallel_group(), "CP")
+        pp_group_ranks = group_members(
+            parallel_state.get_pipeline_model_parallel_group(), "PP"
+        )
+        dp_group_ranks = group_members(
+            parallel_state.get_data_parallel_group(
+                with_context_parallel=False, partial_data_parallel=False
+            ),
+            "dense DP",
+        )
+        ep_group_ranks = group_members(
+            parallel_state.get_expert_model_parallel_group(), "EP"
+        )
+        expert_dp_group_ranks = group_members(
+            parallel_state.get_expert_data_parallel_group(
+                partial_expert_data_parallel=False
+            ),
+            "expert DP",
+        )
+        parallel_state_path = Path(parallel_state.__file__).resolve()
+        parallel_state_sha256 = hashlib.sha256(parallel_state_path.read_bytes()).hexdigest()
+        payload = {
+            "schema_version": 2,
+            "backend": "symmetric_qkv_v0",
+            "global_rank": int(global_rank),
+            "world_size": int(torch.distributed.get_world_size()),
+            "local_device": int(torch.cuda.current_device()),
+            "rank_order": os.getenv("MEGATRON_NVSHMEM_CP_RANK_ORDER"),
+            "tp_size": len(tp_group_ranks),
+            "pp_size": len(pp_group_ranks),
+            "cp_size": len(cp_group_ranks),
+            "dense_dp_size": len(dp_group_ranks),
+            "ep_size": len(ep_group_ranks),
+            "expert_dp_size": len(expert_dp_group_ranks),
+            "tp_rank": tp_group_ranks.index(global_rank),
+            "tp_group_ranks": tp_group_ranks,
+            "cp_rank": cp_group_ranks.index(global_rank),
+            "cp_group_ranks": cp_group_ranks,
+            "pp_rank": pp_group_ranks.index(global_rank),
+            "pp_group_ranks": pp_group_ranks,
+            "dp_rank": dp_group_ranks.index(global_rank),
+            "dp_group_ranks": dp_group_ranks,
+            "ep_rank": ep_group_ranks.index(global_rank),
+            "ep_group_ranks": ep_group_ranks,
+            "expert_dp_rank": expert_dp_group_ranks.index(global_rank),
+            "expert_dp_group_ranks": expert_dp_group_ranks,
+            "parallel_state_source": str(parallel_state_path),
+            "parallel_state_source_sha256": parallel_state_sha256,
+            "nvshmem_initialized": bool(_NVSHMEM_INITIALIZED),
+            "nvshmem_initialization_elapsed_ms": _NVSHMEM_INITIALIZATION_ELAPSED_MS,
+            "workspace_preallocated": True,
+            "workspace_count": len(specs),
+            "workspace_signature": local_signature,
+            "workspace_preallocation_elapsed_ms": (
+                time.perf_counter() - allocation_start
+            )
+            * 1000.0,
+            "workspaces_frozen": bool(_NVSHMEM_WORKSPACES_FROZEN),
+            "nvshmem_disable_cuda_vmm": os.getenv("NVSHMEM_DISABLE_CUDA_VMM"),
+            "nvshmem_symmetric_size": os.getenv("NVSHMEM_SYMMETRIC_SIZE"),
+        }
+        audit_root = Path(audit_dir)
+        audit_root.mkdir(parents=True, exist_ok=True)
+        output = audit_root / f"rank{global_rank:05d}.json"
+        temporary = audit_root / f".{output.name}.{os.getpid()}.tmp"
+        temporary.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        temporary.replace(output)
+    return len(specs)
+
+
+def _cp_group_and_ranks() -> Tuple[torch.distributed.ProcessGroup, List[int], int]:
+    cp_group = parallel_state.get_context_parallel_group()
+    cp_group_ranks = torch.distributed.get_process_group_ranks(cp_group)
+    cp_rank = parallel_state.get_context_parallel_rank()
+    return cp_group, list(cp_group_ranks), int(cp_rank)
+
+
+def _workspace(
+    shape: Tuple[int, ...],
+    dtype: torch.dtype,
+    device: torch.device,
+    layer_number: int | None,
+) -> NvshmemCpWorkspace:
+    _, cp_group_ranks, _ = _cp_group_and_ranks()
+    _, _, _, _, nvshmem_torch, get_peer_tensor = _import_nvshmem()
+    cp_size = len(cp_group_ranks)
+    allocation_manifest = _workspace_allocation_manifest(shape, dtype, cp_size)
+    abi = allocation_manifest["abi"]
+    raw_return_abi = bool(abi["raw_return_sideband"])
+    key = (
+        shape,
+        str(dtype),
+        int(device.index or 0),
+        int(layer_number or 0),
+        json.dumps(allocation_manifest, sort_keys=True),
+    )
+    if key in _WORKSPACES:
+        return _WORKSPACES[key]
+    if _NVSHMEM_WORKSPACES_FROZEN:
+        raise NvshmemCpAttentionError(
+            "NVSHMEM CP workspace was requested after collective preallocation: "
+            f"shape={shape}, dtype={dtype}, device={device}, layer={layer_number}. "
+            "Refusing an unmatched symmetric allocation during pipeline execution."
+        )
+
+    sym_key = nvshmem_torch.tensor(shape, dtype=dtype)
+    sym_value = nvshmem_torch.tensor(shape, dtype=dtype)
+    committed_epoch = nvshmem_torch.tensor((1,), dtype=torch.int32)
+    committed_epoch.fill_(0)
+    block_ready_epoch = nvshmem_torch.tensor((_ready_block_count(shape),), dtype=torch.int32)
+    block_ready_epoch.fill_(0)
+    grad_shape = (cp_size,) + tuple(shape)
+    grad_key_return = nvshmem_torch.tensor(grad_shape, dtype=dtype)
+    grad_value_return = nvshmem_torch.tensor(grad_shape, dtype=dtype)
+    if raw_return_abi:
+        raw_key_return = nvshmem_torch.tensor(grad_shape, dtype=dtype)
+        raw_value_return = nvshmem_torch.tensor(grad_shape, dtype=dtype)
+    else:
+        raw_key_return = torch.empty((0,), dtype=dtype, device=device)
+        raw_value_return = torch.empty((0,), dtype=dtype, device=device)
+    grad_committed_epoch = nvshmem_torch.tensor((len(cp_group_ranks),), dtype=torch.int32)
+    grad_committed_epoch.fill_(0)
+    carrier_abi = bool(abi["cross_rank_carrier"])
+    if carrier_abi:
+        writer_indexed_carrier = bool(abi["writer_indexed_carrier"])
+        carrier_slot_count = int(abi["carrier_slot_count"])
+        carrier_shape = (
+            (cp_size, carrier_slot_count) + tuple(shape)
+            if writer_indexed_carrier
+            else (carrier_slot_count,) + tuple(shape)
+        )
+        carrier_key_slots = nvshmem_torch.tensor(carrier_shape, dtype=dtype)
+        carrier_value_slots = nvshmem_torch.tensor(carrier_shape, dtype=dtype)
+        carrier_epoch_shape = (
+            (cp_size, carrier_slot_count)
+            if writer_indexed_carrier
+            else (carrier_slot_count,)
+        )
+        carrier_epoch = nvshmem_torch.tensor(carrier_epoch_shape, dtype=torch.int32)
+        carrier_epoch.fill_(0)
+    else:
+        carrier_key_slots = torch.empty((0,), dtype=dtype, device=device)
+        carrier_value_slots = torch.empty((0,), dtype=dtype, device=device)
+        carrier_epoch = torch.empty((0,), dtype=torch.int32, device=device)
+    rank = torch.distributed.get_rank()
+    peer_keys = [sym_key if pe == rank else get_peer_tensor(sym_key, pe) for pe in cp_group_ranks]
+    peer_values = [
+        sym_value if pe == rank else get_peer_tensor(sym_value, pe) for pe in cp_group_ranks
+    ]
+    peer_committed_epochs = [
+        committed_epoch if pe == rank else get_peer_tensor(committed_epoch, pe)
+        for pe in cp_group_ranks
+    ]
+    peer_block_ready_epochs = [
+        block_ready_epoch if pe == rank else get_peer_tensor(block_ready_epoch, pe)
+        for pe in cp_group_ranks
+    ]
+    peer_grad_key_returns = [
+        grad_key_return if pe == rank else get_peer_tensor(grad_key_return, pe)
+        for pe in cp_group_ranks
+    ]
+    peer_grad_value_returns = [
+        grad_value_return if pe == rank else get_peer_tensor(grad_value_return, pe)
+        for pe in cp_group_ranks
+    ]
+    peer_grad_committed_epochs = [
+        grad_committed_epoch if pe == rank else get_peer_tensor(grad_committed_epoch, pe)
+        for pe in cp_group_ranks
+    ]
+    if raw_return_abi:
+        peer_raw_key_returns = [
+            raw_key_return if pe == rank else get_peer_tensor(raw_key_return, pe)
+            for pe in cp_group_ranks
+        ]
+        peer_raw_value_returns = [
+            raw_value_return if pe == rank else get_peer_tensor(raw_value_return, pe)
+            for pe in cp_group_ranks
+        ]
+    else:
+        peer_raw_key_returns = [raw_key_return for _ in cp_group_ranks]
+        peer_raw_value_returns = [raw_value_return for _ in cp_group_ranks]
+    if carrier_abi:
+        peer_carrier_key_slots = [
+            carrier_key_slots if pe == rank else get_peer_tensor(carrier_key_slots, pe)
+            for pe in cp_group_ranks
+        ]
+        peer_carrier_value_slots = [
+            carrier_value_slots if pe == rank else get_peer_tensor(carrier_value_slots, pe)
+            for pe in cp_group_ranks
+        ]
+        peer_carrier_epochs = [
+            carrier_epoch if pe == rank else get_peer_tensor(carrier_epoch, pe)
+            for pe in cp_group_ranks
+        ]
+    else:
+        peer_carrier_key_slots = [carrier_key_slots for _ in cp_group_ranks]
+        peer_carrier_value_slots = [carrier_value_slots for _ in cp_group_ranks]
+        peer_carrier_epochs = [carrier_epoch for _ in cp_group_ranks]
+    ws = NvshmemCpWorkspace(
+        key=sym_key,
+        value=sym_value,
+        committed_epoch=committed_epoch,
+        block_ready_epoch=block_ready_epoch,
+        grad_key_return=grad_key_return,
+        grad_value_return=grad_value_return,
+        grad_committed_epoch=grad_committed_epoch,
+        raw_key_return=raw_key_return,
+        raw_value_return=raw_value_return,
+        carrier_key_slots=carrier_key_slots,
+        carrier_value_slots=carrier_value_slots,
+        carrier_epoch=carrier_epoch,
+        peer_keys=peer_keys,
+        peer_values=peer_values,
+        peer_committed_epochs=peer_committed_epochs,
+        peer_block_ready_epochs=peer_block_ready_epochs,
+        peer_grad_key_returns=peer_grad_key_returns,
+        peer_grad_value_returns=peer_grad_value_returns,
+        peer_grad_committed_epochs=peer_grad_committed_epochs,
+        peer_raw_key_returns=peer_raw_key_returns,
+        peer_raw_value_returns=peer_raw_value_returns,
+        peer_carrier_key_slots=peer_carrier_key_slots,
+        peer_carrier_value_slots=peer_carrier_value_slots,
+        peer_carrier_epochs=peer_carrier_epochs,
+        cp_group_ranks=cp_group_ranks,
+    )
+    _WORKSPACES[key] = ws
+    return ws
+
+
+def _block_size(name: str, default: int) -> int:
+    value = int(os.getenv(name, str(default)))
+    if value <= 0:
+        raise NvshmemCpAttentionError(f"{name} must be positive, got {value}.")
+    return value
+
+
+def _ready_block_size() -> int:
+    return _block_size(
+        "MEGATRON_NVSHMEM_CP_READY_BLOCK_SIZE",
+        _block_size("MEGATRON_NVSHMEM_CP_FUSED_BLOCK_N", 64),
+    )
+
+
+def _ready_block_count(shape: Tuple[int, ...]) -> int:
+    if not shape:
+        return 1
+    return max(1, int(math.ceil(int(shape[0]) / float(_ready_block_size()))))
+
+
+def _publish_block_ready_epoch(ws: NvshmemCpWorkspace, epoch: int) -> None:
+    ws.block_ready_epoch[:].fill_(int(epoch))
+
+
+def _wait_for_block_ready_epoch(ws: NvshmemCpWorkspace, epoch: int, timeout: float) -> None:
+    block_count = int(ws.block_ready_epoch.numel())
+    deadline = time.perf_counter() + timeout
+    while True:
+        all_ready = True
+        for peer_rank, peer_epoch in zip(ws.cp_group_ranks, ws.peer_block_ready_epochs):
+            if bool((peer_epoch[:block_count] < int(epoch)).any().item()):
+                all_ready = False
+                break
+        if all_ready:
+            return
+        if time.perf_counter() >= deadline:
+            observed = [
+                [int(value) for value in peer_epoch[:block_count].detach().cpu().tolist()]
+                for peer_epoch in ws.peer_block_ready_epochs
+            ]
+            raise NvshmemCpAttentionError(
+                f"Timed out waiting for block_ready_epoch >= {epoch}; "
+                f"cp_group_ranks={ws.cp_group_ranks}, block_count={block_count}, "
+                f"observed={observed}."
+            )
+        time.sleep(0.00001)
+
+
+def _sync_timeout_seconds() -> float:
+    value = float(os.getenv("MEGATRON_NVSHMEM_CP_SYNC_TIMEOUT_SECONDS", "30"))
+    if value <= 0:
+        raise NvshmemCpAttentionError(
+            f"MEGATRON_NVSHMEM_CP_SYNC_TIMEOUT_SECONDS must be positive, got {value}."
+        )
+    return value
+
+
+def _wait_for_grad_committed_epoch(ws: NvshmemCpWorkspace, epoch: int, timeout: float) -> None:
+    deadline = time.perf_counter() + timeout
+    while True:
+        observed = [int(x) for x in ws.grad_committed_epoch.detach().cpu().tolist()]
+        if all(value >= epoch for value in observed):
+            return
+        if time.perf_counter() >= deadline:
+            raise NvshmemCpAttentionError(
+                f"Timed out waiting for grad_committed_epoch >= {epoch}; "
+                f"cp_group_ranks={ws.cp_group_ranks}, observed={observed}."
+            )
+        time.sleep(0.00001)
+
+
+def _next_grad_return_epoch(ws: NvshmemCpWorkspace) -> int:
+    return int(ws.grad_committed_epoch.min().item()) + 1

--- a/megatron/core/transformer/nvshmem_cp_attention.py
+++ b/megatron/core/transformer/nvshmem_cp_attention.py
@@ -23,8 +23,6 @@ _NVSHMEM_WORKSPACES_FROZEN = False
 _WORKSPACES: Dict[Tuple[object, ...], "NvshmemCpWorkspace"] = {}
 
 _NVSHMEM_CP_BRANCH_B_PROFILE = {
-    "FLASH_ATTN_TWO_SECTION_DIRECT_OWNER_DKV": "1",
-    "FLASH_ATTN_UNSAFE_TWO_SECTION_CAUSAL_BWD": "1",
     "MEGATRON_NVSHMEM_CP_BLOCK_READY_PROTOCOL": "1",
     "MEGATRON_NVSHMEM_CP_BLOCK_READY_STREAM_WAIT": "0",
     "MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_GLOBAL": "1",
@@ -62,6 +60,7 @@ def configure_nvshmem_cp_backend() -> dict[str, str]:
     return dict(_NVSHMEM_CP_BRANCH_B_PROFILE)
 
 
+@dataclass
 class NvshmemCpWorkspace:
     key: torch.Tensor
     value: torch.Tensor

--- a/megatron/core/transformer/nvshmem_cp_fa_owner.py
+++ b/megatron/core/transformer/nvshmem_cp_fa_owner.py
@@ -1,0 +1,2877 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Opt-in NVSHMEM saved-state attention backend for the validated CP=4 contract."""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import time
+
+import torch
+import torch.nn.functional as F
+
+_FA4_FWD = _FA4_BWD = _FA4_TWO_SECTION_BWD = None
+if os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_GLOBAL") == "1":
+    import cutlass as _fa4_cutlass
+    import cutlass.cute as _fa4_cute
+    from flash_attn.cute.interface import (
+        _flash_attn_bwd as _FA4_BWD,
+        _flash_attn_fwd as _FA4_FWD,
+    )
+    try:
+        from flash_attn.cute.interface import (
+            _flash_attn_bwd_two_section_causal as _FA4_TWO_SECTION_BWD,
+        )
+    except ImportError:
+        _FA4_TWO_SECTION_BWD = None
+
+from megatron.core.cp_timing import cp_timing_enabled, record_cp_timing, tensor_meta
+from megatron.core.transformer.enums import AttnMaskType
+from megatron.core.transformer.nvshmem_cp_attention import (
+    _ensure_nvshmem_initialized,
+    _next_grad_return_epoch,
+    _publish_block_ready_epoch,
+    _sync_timeout_seconds,
+    _wait_for_block_ready_epoch,
+    _wait_for_grad_committed_epoch,
+    _workspace,
+)
+from megatron.core.typed_torch import apply_module
+
+_NATIVE_FUSED_BACKWARD_CALL_COUNTERS: dict[tuple[int, int], int] = {}
+_BRANCH_B_PIPELINE_COPY_STREAMS: dict[tuple[int, int], torch.cuda.Stream] = {}
+_BRANCH_B_PIPELINE_COMPUTE_STREAMS: dict[tuple[int, int], torch.cuda.Stream] = {}
+_BRANCH_B_DUAL_SECTION_BWD_STREAMS: dict[tuple[int, int], torch.cuda.Stream] = {}
+_BRANCH_B_DEFERRED_PHASE_EVENTS: list[dict[str, object]] = []
+_BRANCH_B_DEFERRED_FORWARD_DETAIL_EVENTS: list[dict[str, object]] = []
+
+
+class NvshmemCpFaOwnerError(RuntimeError):
+    """Raised when the experimental FA-owner path cannot run."""
+
+
+def _import_te_for_native_fused_owner():
+    import transformer_engine_torch as tex
+
+    return tex
+
+
+def _fa_owner_io_v1_block_ready_native_fused(
+    *,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attn_mask_type: AttnMaskType,
+    layer_number: int | None,
+) -> torch.Tensor:
+    """Fail-closed route for the production Branch-B native fused owner.
+
+    The native owner consumes block-ready symmetric peer K/V and owns forward
+    attention, backward dQ/dK/dV, and remote K/V gradient return.
+    """
+
+    if os.getenv("MEGATRON_NVSHMEM_CP_BLOCK_READY_PROTOCOL") != "1":
+        raise NvshmemCpFaOwnerError(
+            "block_ready_native_fused requires MEGATRON_NVSHMEM_CP_BLOCK_READY_PROTOCOL=1."
+        )
+    if attn_mask_type != AttnMaskType.causal:
+        raise NvshmemCpFaOwnerError(
+            f"block_ready_native_fused currently targets causal CP attention, got {attn_mask_type}."
+        )
+    return _BlockReadyNativeFusedOwnerAutograd.apply(query, key, value, True, layer_number)
+
+
+def _branch_b_section_for_peer(peer: int, rank: int) -> str:
+    if peer == rank:
+        return "diagonal"
+    if peer < rank:
+        return "lower-triangle"
+    return "upper-triangle"
+
+
+def _branch_b_pipeline_copy_stream(
+    device: torch.device, lane: int = 0
+) -> torch.cuda.Stream:
+    device_index = int(device.index if device.index is not None else torch.cuda.current_device())
+    key = (device_index, int(lane))
+    stream = _BRANCH_B_PIPELINE_COPY_STREAMS.get(key)
+    if stream is None:
+        stream = torch.cuda.Stream(device=device)
+        _BRANCH_B_PIPELINE_COPY_STREAMS[key] = stream
+    return stream
+
+
+def _branch_b_pipeline_compute_stream(
+    device: torch.device, lane: int
+) -> torch.cuda.Stream:
+    device_index = int(device.index if device.index is not None else torch.cuda.current_device())
+    key = (device_index, int(lane))
+    stream = _BRANCH_B_PIPELINE_COMPUTE_STREAMS.get(key)
+    if stream is None:
+        stream = torch.cuda.Stream(device=device)
+        _BRANCH_B_PIPELINE_COMPUTE_STREAMS[key] = stream
+    return stream
+
+
+def _branch_b_dual_section_bwd_stream(
+    device: torch.device, lane: int
+) -> torch.cuda.Stream:
+    device_index = int(device.index if device.index is not None else torch.cuda.current_device())
+    key = (device_index, int(lane))
+    stream = _BRANCH_B_DUAL_SECTION_BWD_STREAMS.get(key)
+    if stream is None:
+        stream = torch.cuda.Stream(device=device)
+        _BRANCH_B_DUAL_SECTION_BWD_STREAMS[key] = stream
+    return stream
+
+
+def _branch_b_two_prefix_inputs(
+    query: torch.Tensor,
+    peer_keys: list[torch.Tensor],
+    peer_values: list[torch.Tensor],
+    cp_rank: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Pack the two global causal prefixes consumed by one native CP rank."""
+
+    if len(peer_keys) != 4 or len(peer_values) != 4 or not 0 <= cp_rank < 4:
+        raise NvshmemCpFaOwnerError("Two-prefix Branch-B currently requires CP=4.")
+    if int(query.shape[0]) % 2 != 0:
+        raise NvshmemCpFaOwnerError("Two-prefix Branch-B requires even local sequence length.")
+    half = int(query.shape[0]) // 2
+    q_first = query[:half].contiguous()
+    q_second = query[half:].contiguous()
+    first_k = torch.cat([peer_keys[owner][:half] for owner in range(cp_rank + 1)])
+    first_v = torch.cat([peer_values[owner][:half] for owner in range(cp_rank + 1)])
+    second_owners = list(range(3, cp_rank - 1, -1))
+    second_k = torch.cat(
+        [peer_keys[owner][:half] for owner in range(4)]
+        + [peer_keys[owner][half:] for owner in second_owners]
+    )
+    second_v = torch.cat(
+        [peer_values[owner][:half] for owner in range(4)]
+        + [peer_values[owner][half:] for owner in second_owners]
+    )
+    return q_first, q_second, first_k, first_v, second_k, second_v
+
+
+def _branch_b_grouped_sections_forward(
+    *,
+    tex,
+    query: torch.Tensor,
+    peer_keys: list[torch.Tensor],
+    peer_values: list[torch.Tensor],
+    cp_rank: int,
+) -> tuple[torch.Tensor, list[torch.Tensor]]:
+    """Batch independent same-shape peer sections without changing merge semantics."""
+
+    if len(peer_keys) != 4 or len(peer_values) != 4 or not 0 <= cp_rank < 4:
+        raise NvshmemCpFaOwnerError("Grouped-section Branch-B currently requires CP=4.")
+    half = int(query.shape[0]) // 2
+    scale = 1.0 / math.sqrt(float(query.shape[-1]))
+    layout = tex.NVTE_QKV_Layout.NVTE_SBHD_SBHD_SBHD
+    mask = tex.NVTE_Mask_Type.NVTE_CAUSAL_MASK
+    outputs: list[torch.Tensor | None] = [None] * 4
+    lses: list[torch.Tensor | None] = [None] * 4
+    rngs: list[torch.Tensor | None] = [None] * 4
+    sections = [_branch_b_section_for_peer(peer, cp_rank) for peer in range(4)]
+
+    diagonal = tex.nvshmem_cp_forward_section_fused_attn_execute(
+        query,
+        peer_keys[cp_rank],
+        peer_values[cp_rank],
+        int(query.shape[0]),
+        int(query.shape[0]),
+        cp_rank,
+        4,
+        cp_rank,
+        "sbhd",
+        "diagonal",
+        float(scale),
+        0.0,
+        layout,
+        mask,
+        query.dtype,
+        True,
+    )
+    outputs[cp_rank], lses[cp_rank], rngs[cp_rank] = diagonal[:3]
+
+    lower = list(range(cp_rank))
+    if lower:
+        grouped = tex.nvshmem_cp_grouped_noncausal_fused_attn_forward_execute(
+            torch.cat([query] * len(lower), dim=1),
+            torch.cat([peer_keys[peer][:half] for peer in lower], dim=1),
+            torch.cat([peer_values[peer][:half] for peer in lower], dim=1),
+            "sbhd",
+            float(scale),
+            query.dtype,
+            True,
+        )
+        for batch_index, peer in enumerate(lower):
+            outputs[peer] = grouped[0][:, batch_index : batch_index + 1]
+            lses[peer] = grouped[1][batch_index : batch_index + 1]
+            rngs[peer] = grouped[2]
+
+    upper = list(range(cp_rank + 1, 4))
+    if upper:
+        grouped = tex.nvshmem_cp_grouped_noncausal_fused_attn_forward_execute(
+            torch.cat([query[half:]] * len(upper), dim=1),
+            torch.cat([peer_keys[peer] for peer in upper], dim=1),
+            torch.cat([peer_values[peer] for peer in upper], dim=1),
+            "sbhd",
+            float(scale),
+            query.dtype,
+            True,
+        )
+        for batch_index, peer in enumerate(upper):
+            outputs[peer] = grouped[0][:, batch_index : batch_index + 1]
+            lses[peer] = grouped[1][batch_index : batch_index + 1]
+            rngs[peer] = grouped[2]
+
+    if any(item is None for item in (*outputs, *lses, *rngs)):
+        raise NvshmemCpFaOwnerError("Grouped-section Branch-B missed a peer result.")
+    merged = tex.nvshmem_cp_forward_lse_merge(
+        outputs, lses, sections, int(query.shape[0]), "sbhd"
+    )
+    forward_aux: list[torch.Tensor] = [merged[1]]
+    for peer in range(4):
+        forward_aux.extend((lses[peer], rngs[peer]))
+    return merged[0], forward_aux
+
+
+def _branch_b_two_prefix_backward(
+    *,
+    tex,
+    query: torch.Tensor,
+    peer_keys: list[torch.Tensor],
+    peer_values: list[torch.Tensor],
+    output: torch.Tensor,
+    grad_output: torch.Tensor,
+    forward_aux: list[torch.Tensor],
+    ws,
+    cp_rank: int,
+    softmax_scale: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Run two prefix backwards, scatter dK/dV by owner, and publish symmetric slots."""
+
+    if len(forward_aux) != 4:
+        raise NvshmemCpFaOwnerError(
+            f"Two-prefix Branch-B backward expects four aux tensors, got {len(forward_aux)}."
+        )
+    q_first, q_second, first_k, first_v, second_k, second_v = (
+        _branch_b_two_prefix_inputs(query, peer_keys, peer_values, cp_rank)
+    )
+    half = int(query.shape[0]) // 2
+    first = tex.nvshmem_cp_prefix_fused_attn_backward_execute(
+        q_first,
+        first_k,
+        first_v,
+        output[:half].contiguous(),
+        grad_output[:half].contiguous(),
+        forward_aux[0],
+        forward_aux[1],
+        "sbhd",
+        float(softmax_scale),
+        False,
+    )
+    second = tex.nvshmem_cp_prefix_fused_attn_backward_execute(
+        q_second,
+        second_k,
+        second_v,
+        output[half:].contiguous(),
+        grad_output[half:].contiguous(),
+        forward_aux[2],
+        forward_aux[3],
+        "sbhd",
+        float(softmax_scale),
+        False,
+    )
+    if len(first) < 3 or len(second) < 3:
+        raise NvshmemCpFaOwnerError("Two-prefix TE backward did not return dQ/dK/dV.")
+    dq = torch.cat((first[0], second[0]), dim=0)
+    dk_by_owner = [torch.zeros_like(query) for _ in range(4)]
+    dv_by_owner = [torch.zeros_like(query) for _ in range(4)]
+    for owner in range(cp_rank + 1):
+        start = owner * half
+        dk_by_owner[owner][:half].add_(first[1][start : start + half])
+        dv_by_owner[owner][:half].add_(first[2][start : start + half])
+    for owner in range(4):
+        start = owner * half
+        dk_by_owner[owner][:half].add_(second[1][start : start + half])
+        dv_by_owner[owner][:half].add_(second[2][start : start + half])
+    for index, owner in enumerate(range(3, cp_rank - 1, -1), start=4):
+        start = index * half
+        dk_by_owner[owner][half:].add_(second[1][start : start + half])
+        dv_by_owner[owner][half:].add_(second[2][start : start + half])
+    dk, dv = tex.nvshmem_cp_prefix_grad_return_execute(
+        dk_by_owner,
+        dv_by_owner,
+        peer_keys[cp_rank],
+        peer_values[cp_rank],
+        ws.grad_key_return,
+        ws.grad_value_return,
+        ws.grad_committed_epoch,
+        ws.peer_grad_key_returns,
+        ws.peer_grad_value_returns,
+        ws.peer_grad_committed_epochs,
+        4,
+        cp_rank,
+    )
+    return dq, dk, dv
+
+
+def _branch_b_concurrent_sections_backward(
+    *,
+    tex,
+    query: torch.Tensor,
+    peer_keys: list[torch.Tensor],
+    peer_values: list[torch.Tensor],
+    output: torch.Tensor,
+    grad_output: torch.Tensor,
+    forward_aux: list[torch.Tensor],
+    ws,
+    cp_rank: int,
+    softmax_scale: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Execute independent peer sections on separate streams, then assemble dQ/dKV."""
+
+    if len(forward_aux) != 9:
+        raise NvshmemCpFaOwnerError(
+            f"Concurrent Branch-B backward expects nine aux tensors, got {len(forward_aux)}."
+        )
+    if query.dtype != torch.bfloat16:
+        raise NvshmemCpFaOwnerError("Concurrent Branch-B backward currently requires bf16.")
+
+    current_stream = torch.cuda.current_stream(query.device)
+    inputs_ready = torch.cuda.Event(enable_timing=False)
+    inputs_ready.record(current_stream)
+    layout = tex.NVTE_QKV_Layout.NVTE_SBHD_SBHD_SBHD
+    mask = tex.NVTE_Mask_Type.NVTE_CAUSAL_MASK
+    results: list[tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None] = [None] * 4
+    done_events: list[torch.cuda.Event] = []
+
+    for peer in range(4):
+        section_stream = _branch_b_pipeline_compute_stream(query.device, peer)
+        section = _branch_b_section_for_peer(peer, cp_rank)
+        with torch.cuda.stream(section_stream):
+            section_stream.wait_event(inputs_ready)
+            native = tex.nvshmem_cp_block_ready_fused_backward_section_execute(
+                query,
+                peer_keys[peer],
+                peer_values[peer],
+                output,
+                grad_output,
+                forward_aux[0],
+                forward_aux[1 + 2 * peer + 1],
+                int(query.shape[0]),
+                int(query.shape[0]),
+                peer,
+                4,
+                cp_rank,
+                "sbhd",
+                section,
+                float(softmax_scale),
+                0.0,
+                layout,
+                mask,
+                query.dtype,
+                tex.DType.kBFloat16,
+                False,
+            )
+            result = (native[0], native[1], native[2])
+            for tensor in result:
+                tensor.record_stream(section_stream)
+            done = torch.cuda.Event(enable_timing=False)
+            done.record(section_stream)
+            done_events.append(done)
+            results[peer] = result
+
+    for done in done_events:
+        current_stream.wait_event(done)
+
+    dq = torch.zeros_like(query)
+    dk_by_owner = [torch.zeros_like(query) for _ in range(4)]
+    dv_by_owner = [torch.zeros_like(query) for _ in range(4)]
+    half = int(query.shape[0]) // 2
+    for peer, result in enumerate(results):
+        if result is None:
+            raise NvshmemCpFaOwnerError(f"Missing concurrent backward result for peer {peer}.")
+        section = _branch_b_section_for_peer(peer, cp_rank)
+        if section == "upper-triangle":
+            dq[half:].add_(result[0])
+        else:
+            dq.add_(result[0])
+        if section == "lower-triangle":
+            dk_by_owner[peer][:half].copy_(result[1])
+            dv_by_owner[peer][:half].copy_(result[2])
+        else:
+            dk_by_owner[peer].copy_(result[1])
+            dv_by_owner[peer].copy_(result[2])
+
+    dk, dv = tex.nvshmem_cp_prefix_grad_return_execute(
+        dk_by_owner,
+        dv_by_owner,
+        peer_keys[cp_rank],
+        peer_values[cp_rank],
+        ws.grad_key_return,
+        ws.grad_value_return,
+        ws.grad_committed_epoch,
+        ws.peer_grad_key_returns,
+        ws.peer_grad_value_returns,
+        ws.peer_grad_committed_epochs,
+        4,
+        cp_rank,
+    )
+    return dq, dk, dv
+
+
+def _branch_b_grouped_sections_backward(
+    *,
+    tex,
+    query: torch.Tensor,
+    peer_keys: list[torch.Tensor],
+    peer_values: list[torch.Tensor],
+    output: torch.Tensor,
+    grad_output: torch.Tensor,
+    forward_aux: list[torch.Tensor],
+    ws,
+    cp_rank: int,
+    softmax_scale: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Batch same-shape lower and upper peer sections during backward."""
+
+    if len(forward_aux) != 9 or query.dtype != torch.bfloat16:
+        raise NvshmemCpFaOwnerError(
+            "Grouped Branch-B backward requires bf16 and nine forward aux tensors."
+        )
+    half = int(query.shape[0]) // 2
+    merged_lse = forward_aux[0]
+    layout = tex.NVTE_QKV_Layout.NVTE_SBHD_SBHD_SBHD
+    mask = tex.NVTE_Mask_Type.NVTE_CAUSAL_MASK
+    dq = torch.zeros_like(query)
+    dk_by_owner = [torch.zeros_like(query) for _ in range(4)]
+    dv_by_owner = [torch.zeros_like(query) for _ in range(4)]
+    timing_meta = {
+        "cp_rank": int(cp_rank),
+        "cp_world_size": 4,
+        "query": tensor_meta(query),
+    }
+
+    if os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_TRUE_FUSED_BACKWARD_NO_TE_BWD") == "1":
+        helper = getattr(
+            tex,
+            "nvshmem_cp_branch_b_true_fused_backward_no_te_bwd_execute",
+            None,
+        )
+        if helper is None:
+            raise NvshmemCpFaOwnerError(
+                "Branch-B true fused backward selected, but TE does not expose "
+                "nvshmem_cp_branch_b_true_fused_backward_no_te_bwd_execute. "
+                "This path is intentionally fail-closed: the next production candidate "
+                "must avoid TE grouped/section backward calls rather than falling back to "
+                "grouped-call helpers."
+            )
+        fused = helper(
+            query,
+            peer_keys,
+            peer_values,
+            output,
+            grad_output,
+            forward_aux,
+            int(cp_rank),
+            "sbhd",
+            float(softmax_scale),
+            False,
+        )
+        if len(fused) != 9:
+            raise NvshmemCpFaOwnerError(
+                "Branch-B true fused backward TE helper must return "
+                "[dq, dk0, dk1, dk2, dk3, dv0, dv1, dv2, dv3]."
+            )
+        dq = fused[0]
+        dk_by_owner = list(fused[1:5])
+        dv_by_owner = list(fused[5:9])
+        dk, dv = tex.nvshmem_cp_prefix_grad_return_execute(
+            dk_by_owner,
+            dv_by_owner,
+            peer_keys[cp_rank],
+            peer_values[cp_rank],
+            ws.grad_key_return,
+            ws.grad_value_return,
+            ws.grad_committed_epoch,
+            ws.peer_grad_key_returns,
+            ws.peer_grad_value_returns,
+            ws.peer_grad_committed_epochs,
+            4,
+            cp_rank,
+        )
+        return dq, dk, dv
+
+    if os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_GROUPED_BACKWARD_NO_MATERIALIZE") == "1":
+        helper = getattr(
+            tex,
+            "nvshmem_cp_grouped_noncausal_fused_attn_backward_no_materialize_execute",
+            None,
+        )
+        if helper is None:
+            raise NvshmemCpFaOwnerError(
+                "Branch-B no-materialize grouped backward selected, but TE does not expose "
+                "nvshmem_cp_grouped_noncausal_fused_attn_backward_no_materialize_execute. "
+                "This path is intentionally fail-closed so it cannot fall back to the "
+                "falsified Python torch.cat materialization path."
+            )
+        grouped = helper(
+            query,
+            peer_keys,
+            peer_values,
+            output,
+            grad_output,
+            forward_aux,
+            int(cp_rank),
+            "sbhd",
+            float(softmax_scale),
+            False,
+        )
+        if len(grouped) != 9:
+            raise NvshmemCpFaOwnerError(
+                "Branch-B no-materialize grouped backward TE helper must return "
+                "[dq, dk0, dk1, dk2, dk3, dv0, dv1, dv2, dv3]."
+            )
+        dq = grouped[0]
+        dk_by_owner = list(grouped[1:5])
+        dv_by_owner = list(grouped[5:9])
+        dk, dv = tex.nvshmem_cp_prefix_grad_return_execute(
+            dk_by_owner,
+            dv_by_owner,
+            peer_keys[cp_rank],
+            peer_values[cp_rank],
+            ws.grad_key_return,
+            ws.grad_value_return,
+            ws.grad_committed_epoch,
+            ws.peer_grad_key_returns,
+            ws.peer_grad_value_returns,
+            ws.peer_grad_committed_epochs,
+            4,
+            cp_rank,
+        )
+        return dq, dk, dv
+
+    phase = _phase_start()
+    diagonal = tex.nvshmem_cp_block_ready_fused_backward_section_execute(
+        query,
+        peer_keys[cp_rank],
+        peer_values[cp_rank],
+        output,
+        grad_output,
+        merged_lse,
+        forward_aux[1 + 2 * cp_rank + 1],
+        int(query.shape[0]),
+        int(query.shape[0]),
+        cp_rank,
+        4,
+        cp_rank,
+        "sbhd",
+        "diagonal",
+        float(softmax_scale),
+        0.0,
+        layout,
+        mask,
+        query.dtype,
+        tex.DType.kBFloat16,
+        False,
+    )
+    _phase_end(
+        phase,
+        "branch_b_grouped_backward_diagonal_section",
+        section="diagonal",
+        **timing_meta,
+    )
+    phase = _phase_start()
+    dq.add_(diagonal[0])
+    dk_by_owner[cp_rank].copy_(diagonal[1])
+    dv_by_owner[cp_rank].copy_(diagonal[2])
+    _phase_end(
+        phase,
+        "branch_b_grouped_backward_diagonal_scatter",
+        section="diagonal",
+        **timing_meta,
+    )
+
+    lower = list(range(cp_rank))
+    if lower:
+        count = len(lower)
+        phase = _phase_start()
+        lower_q = torch.cat([query] * count, dim=1)
+        lower_k = torch.cat([peer_keys[peer][:half] for peer in lower], dim=1)
+        lower_v = torch.cat([peer_values[peer][:half] for peer in lower], dim=1)
+        lower_out = torch.cat([output] * count, dim=1)
+        lower_grad_output = torch.cat([grad_output] * count, dim=1)
+        lower_lse = torch.cat([merged_lse] * count, dim=0)
+        _phase_end(
+            phase,
+            "branch_b_grouped_backward_lower_materialize",
+            section="lower-triangle",
+            peer_count=int(count),
+            materialized_q=tensor_meta(lower_q),
+            materialized_k=tensor_meta(lower_k),
+            **timing_meta,
+        )
+        phase = _phase_start()
+        grouped = tex.nvshmem_cp_grouped_noncausal_fused_attn_backward_execute(
+            lower_q,
+            lower_k,
+            lower_v,
+            lower_out,
+            lower_grad_output,
+            lower_lse,
+            forward_aux[1 + 2 * lower[0] + 1],
+            "sbhd",
+            float(softmax_scale),
+            False,
+        )
+        _phase_end(
+            phase,
+            "branch_b_grouped_backward_lower_te_bwd",
+            section="lower-triangle",
+            peer_count=int(count),
+            **timing_meta,
+        )
+        phase = _phase_start()
+        dq.add_(grouped[0].sum(dim=1, keepdim=True))
+        for batch_index, peer in enumerate(lower):
+            dk_by_owner[peer][:half].copy_(grouped[1][:, batch_index : batch_index + 1])
+            dv_by_owner[peer][:half].copy_(grouped[2][:, batch_index : batch_index + 1])
+        _phase_end(
+            phase,
+            "branch_b_grouped_backward_lower_scatter",
+            section="lower-triangle",
+            peer_count=int(count),
+            **timing_meta,
+        )
+
+    upper = list(range(cp_rank + 1, 4))
+    if upper:
+        count = len(upper)
+        phase = _phase_start()
+        upper_q = torch.cat([query[half:]] * count, dim=1)
+        upper_k = torch.cat([peer_keys[peer] for peer in upper], dim=1)
+        upper_v = torch.cat([peer_values[peer] for peer in upper], dim=1)
+        upper_out = torch.cat([output[half:]] * count, dim=1)
+        upper_grad_output = torch.cat([grad_output[half:]] * count, dim=1)
+        upper_lse = torch.cat([merged_lse[:, :, half:]] * count, dim=0)
+        _phase_end(
+            phase,
+            "branch_b_grouped_backward_upper_materialize",
+            section="upper-triangle",
+            peer_count=int(count),
+            materialized_q=tensor_meta(upper_q),
+            materialized_k=tensor_meta(upper_k),
+            **timing_meta,
+        )
+        phase = _phase_start()
+        grouped = tex.nvshmem_cp_grouped_noncausal_fused_attn_backward_execute(
+            upper_q,
+            upper_k,
+            upper_v,
+            upper_out,
+            upper_grad_output,
+            upper_lse,
+            forward_aux[1 + 2 * upper[0] + 1],
+            "sbhd",
+            float(softmax_scale),
+            False,
+        )
+        _phase_end(
+            phase,
+            "branch_b_grouped_backward_upper_te_bwd",
+            section="upper-triangle",
+            peer_count=int(count),
+            **timing_meta,
+        )
+        phase = _phase_start()
+        dq[half:].add_(grouped[0].sum(dim=1, keepdim=True))
+        for batch_index, peer in enumerate(upper):
+            dk_by_owner[peer].copy_(grouped[1][:, batch_index : batch_index + 1])
+            dv_by_owner[peer].copy_(grouped[2][:, batch_index : batch_index + 1])
+        _phase_end(
+            phase,
+            "branch_b_grouped_backward_upper_scatter",
+            section="upper-triangle",
+            peer_count=int(count),
+            **timing_meta,
+        )
+
+    phase = _phase_start()
+    dk, dv = tex.nvshmem_cp_prefix_grad_return_execute(
+        dk_by_owner,
+        dv_by_owner,
+        peer_keys[cp_rank],
+        peer_values[cp_rank],
+        ws.grad_key_return,
+        ws.grad_value_return,
+        ws.grad_committed_epoch,
+        ws.peer_grad_key_returns,
+        ws.peer_grad_value_returns,
+        ws.peer_grad_committed_epochs,
+        4,
+        cp_rank,
+    )
+    _phase_end(phase, "branch_b_grouped_backward_grad_return", **timing_meta)
+    return dq, dk, dv
+
+
+def _branch_b_pipelined_stage_forward(
+    *,
+    tex,
+    query: torch.Tensor,
+    peer_keys: list[torch.Tensor],
+    peer_values: list[torch.Tensor],
+    peer_pes: list[int],
+    cp_rank: int,
+) -> tuple[
+    torch.Tensor,
+    list[torch.Tensor],
+    list[torch.Tensor],
+    list[torch.Tensor],
+    torch.Tensor,
+]:
+    """Pipeline remote K/V staging with TE fused per-peer forward sections."""
+
+    cp_size = len(peer_keys)
+    if cp_size != 4 or len(peer_values) != cp_size:
+        raise NvshmemCpFaOwnerError(
+            f"Pipelined Branch-B staging requires CP=4 peer K/V lists, got {cp_size}."
+        )
+    compute_stream = torch.cuda.current_stream(query.device)
+    copy_lanes = max(
+        1,
+        min(
+            cp_size - 1,
+            int(os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_PY_STAGE_COPY_STREAMS", "1")),
+        ),
+    )
+    # The fallback Megatron QKV producer returns Q as a strided view into the
+    # interleaved QKV tensor. TE's low-level fused-attention entrypoint treats
+    # separate SBHD inputs as dense. Materialize Q once for all four sections;
+    # upper-triangle happened to do this in section preparation already.
+    query_work = query.contiguous()
+    staged_keys = list(peer_keys)
+    staged_values = list(peer_values)
+    ready_events: list[torch.cuda.Event | None] = [None] * cp_size
+    peer_order = [(cp_rank - step) % cp_size for step in range(cp_size)]
+    section_aware_half_stage = (
+        os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_SECTION_AWARE_HALF_STAGE") == "1"
+    )
+    nvshmem_getmem_stage = (
+        os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_STAGE_GETMEM") == "1"
+    )
+    if len(peer_pes) != cp_size:
+        raise NvshmemCpFaOwnerError(
+            f"Pipelined Branch-B staging expects {cp_size} NVSHMEM PEs, got {len(peer_pes)}."
+        )
+    if nvshmem_getmem_stage and section_aware_half_stage:
+        raise NvshmemCpFaOwnerError(
+            "NVSHMEM getmem staging and section-aware half staging are separate experiments."
+        )
+    nvshmem_bindings = _ensure_nvshmem_initialized() if nvshmem_getmem_stage else None
+    half = int(query.shape[0]) // 2
+    if section_aware_half_stage and int(query.shape[0]) % 2 != 0:
+        raise NvshmemCpFaOwnerError(
+            "Section-aware Branch-B staging requires an even local sequence length."
+        )
+
+    # All remote copies are queued in peer order. The compute stream waits only
+    # when it reaches that peer, allowing later copies to overlap earlier TE
+    # fused-attention sections.
+    for copy_index, peer in enumerate(peer_order[1:]):
+        copy_stream = _branch_b_pipeline_copy_stream(
+            query.device, copy_index % copy_lanes
+        )
+        with torch.cuda.stream(copy_stream):
+            staged_key = torch.empty_like(peer_keys[peer], memory_format=torch.contiguous_format)
+            staged_value = torch.empty_like(
+                peer_values[peer], memory_format=torch.contiguous_format
+            )
+            if nvshmem_getmem_stage:
+                nvshmem_bindings.getmem_on_stream(
+                    int(staged_key.data_ptr()),
+                    int(peer_keys[cp_rank].data_ptr()),
+                    int(peer_keys[cp_rank].numel() * peer_keys[cp_rank].element_size()),
+                    int(peer_pes[peer]),
+                    int(copy_stream.cuda_stream),
+                )
+                nvshmem_bindings.getmem_on_stream(
+                    int(staged_value.data_ptr()),
+                    int(peer_values[cp_rank].data_ptr()),
+                    int(peer_values[cp_rank].numel() * peer_values[cp_rank].element_size()),
+                    int(peer_pes[peer]),
+                    int(copy_stream.cuda_stream),
+                )
+                nvshmem_bindings.quiet_on_stream(int(copy_stream.cuda_stream))
+            elif section_aware_half_stage and peer < cp_rank:
+                # A lower-triangle CP section can consume only the peer's first
+                # native chunk. Its second chunk is causally later than both
+                # local query chunks, so do not move bytes the TE section never
+                # reads. The full allocation preserves the TE SBHD ABI.
+                staged_key[:half].copy_(peer_keys[peer][:half], non_blocking=True)
+                staged_value[:half].copy_(peer_values[peer][:half], non_blocking=True)
+                # TE's section preparation is logically first-half-only, but
+                # call-reused allocator contents were observed to perturb its
+                # backward path. Keep the inactive tail deterministic without
+                # fetching it across the peer mapping.
+                staged_key[half:].zero_()
+                staged_value[half:].zero_()
+            else:
+                staged_key.copy_(peer_keys[peer], non_blocking=True)
+                staged_value.copy_(peer_values[peer], non_blocking=True)
+            staged_key.record_stream(copy_stream)
+            staged_value.record_stream(copy_stream)
+            ready = torch.cuda.Event(enable_timing=False)
+            ready.record(copy_stream)
+            staged_keys[peer] = staged_key
+            staged_values[peer] = staged_value
+            ready_events[peer] = ready
+
+    softmax_scale = 1.0 / math.sqrt(float(query.shape[-1]))
+    grouped_sections = (
+        os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_GROUPED_SECTIONS") == "1"
+    )
+    if grouped_sections:
+        for ready in ready_events:
+            if ready is not None:
+                compute_stream.wait_event(ready)
+        output, forward_aux = _branch_b_grouped_sections_forward(
+            tex=tex,
+            query=query_work,
+            peer_keys=staged_keys,
+            peer_values=staged_values,
+            cp_rank=cp_rank,
+        )
+        return output, forward_aux, staged_keys, staged_values, query_work
+
+    if os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_TWO_PREFIX_ATTENTION") == "1":
+        for ready in ready_events:
+            if ready is not None:
+                compute_stream.wait_event(ready)
+        q_first, q_second, first_k, first_v, second_k, second_v = (
+            _branch_b_two_prefix_inputs(
+                query_work, staged_keys, staged_values, cp_rank
+            )
+        )
+        first = tex.nvshmem_cp_prefix_fused_attn_forward_execute(
+            q_first, first_k, first_v, "sbhd", float(softmax_scale), query.dtype, True
+        )
+        second = tex.nvshmem_cp_prefix_fused_attn_forward_execute(
+            q_second, second_k, second_v, "sbhd", float(softmax_scale), query.dtype, True
+        )
+        if len(first) < 3 or len(second) < 3:
+            raise NvshmemCpFaOwnerError(
+                "Two-prefix Branch-B forward must return output, LSE, and RNG state."
+            )
+        output = torch.cat((first[0], second[0]), dim=0)
+        native_section_backward = (
+            os.getenv(
+                "MEGATRON_NVSHMEM_CP_BRANCH_B_TWO_PREFIX_NATIVE_SECTION_BACKWARD"
+            )
+            == "1"
+        )
+        if native_section_backward:
+            first_lse = first[1].squeeze(-1) if first[1].dim() == 4 else first[1]
+            second_lse = second[1].squeeze(-1) if second[1].dim() == 4 else second[1]
+            merged_lse = torch.cat((first_lse, second_lse), dim=2)
+            merged_lse_4d = merged_lse.unsqueeze(-1)
+            forward_aux = [merged_lse]
+            for peer in range(cp_size):
+                if peer > cp_rank:
+                    forward_aux.extend((second[1], second[2]))
+                else:
+                    forward_aux.extend((merged_lse_4d, first[2]))
+        else:
+            forward_aux = [first[1], first[2], second[1], second[2]]
+        return output, forward_aux, staged_keys, staged_values, query_work
+
+    out_by_peer: list[torch.Tensor | None] = [None] * cp_size
+    lse_by_peer: list[torch.Tensor | None] = [None] * cp_size
+    rng_by_peer: list[torch.Tensor | None] = [None] * cp_size
+    section_by_peer: list[str | None] = [None] * cp_size
+    qkv_layout = tex.NVTE_QKV_Layout.NVTE_SBHD_SBHD_SBHD
+    attn_mask_type = tex.NVTE_Mask_Type.NVTE_CAUSAL_MASK
+    concurrent_sections = (
+        os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_CONCURRENT_FORWARD_SECTIONS") == "1"
+    )
+    query_ready: torch.cuda.Event | None = None
+    section_done: list[torch.cuda.Event | None] = [None] * cp_size
+    if concurrent_sections:
+        query_ready = torch.cuda.Event(enable_timing=False)
+        query_ready.record(compute_stream)
+    for ring_step, peer in enumerate(peer_order):
+        ready = ready_events[peer]
+        section = _branch_b_section_for_peer(peer, cp_rank)
+        section_stream = (
+            _branch_b_pipeline_compute_stream(query.device, peer)
+            if concurrent_sections
+            else compute_stream
+        )
+        if ready is not None:
+            section_stream.wait_event(ready)
+        if query_ready is not None:
+            section_stream.wait_event(query_ready)
+        with torch.cuda.stream(section_stream):
+            native_outputs = tex.nvshmem_cp_forward_section_fused_attn_execute(
+                query_work,
+                staged_keys[peer],
+                staged_values[peer],
+                int(query_work.shape[0]),
+                int(query_work.shape[0]),
+                int(ring_step),
+                int(cp_size),
+                int(cp_rank),
+                "sbhd",
+                section,
+                float(softmax_scale),
+                0.0,
+                qkv_layout,
+                attn_mask_type,
+                query.dtype,
+                True,
+            )
+        if not isinstance(native_outputs, (list, tuple)) or len(native_outputs) < 3:
+            raise NvshmemCpFaOwnerError(
+                "Pipelined Branch-B section must return output, LSE, and RNG state."
+            )
+        out_step, softmax_lse_step, rng_state = native_outputs[:3]
+        out_by_peer[peer] = out_step
+        lse_by_peer[peer] = softmax_lse_step
+        rng_by_peer[peer] = rng_state
+        section_by_peer[peer] = section
+        if concurrent_sections:
+            out_step.record_stream(section_stream)
+            softmax_lse_step.record_stream(section_stream)
+            rng_state.record_stream(section_stream)
+            done = torch.cuda.Event(enable_timing=False)
+            done.record(section_stream)
+            section_done[peer] = done
+
+    if concurrent_sections:
+        for done in section_done:
+            if done is None:
+                raise NvshmemCpFaOwnerError("Missing concurrent Branch-B section event.")
+            compute_stream.wait_event(done)
+
+    if any(item is None for item in (*out_by_peer, *lse_by_peer, *section_by_peer)):
+        raise NvshmemCpFaOwnerError("Missing Branch-B per-peer forward merge state.")
+    merge_outputs = [item for item in out_by_peer if item is not None]
+    merge_lse = [item for item in lse_by_peer if item is not None]
+    merge_sections = [item for item in section_by_peer if item is not None]
+
+    merged = tex.nvshmem_cp_forward_lse_merge(
+        merge_outputs,
+        merge_lse,
+        merge_sections,
+        int(query.shape[0]),
+        "sbhd",
+    )
+    if not isinstance(merged, (list, tuple)) or len(merged) != 2:
+        raise NvshmemCpFaOwnerError(
+            "Pipelined Branch-B LSE merge must return output and merged LSE."
+        )
+    output, merged_softmax_lse = merged
+    forward_aux: list[torch.Tensor] = [merged_softmax_lse]
+    for peer in range(cp_size):
+        lse = lse_by_peer[peer]
+        rng = rng_by_peer[peer]
+        if lse is None or rng is None:
+            raise NvshmemCpFaOwnerError(
+                f"Missing Branch-B forward aux tensors for CP peer {peer}."
+            )
+        forward_aux.extend((lse, rng))
+    return output, forward_aux, staged_keys, staged_values, query_work
+
+
+def _branch_b_fa4_trace(cp_rank: int, step: str) -> None:
+    if os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_TRACE") == "1":
+        print(f"[branch-b-fa4 rank={cp_rank}] {step}", flush=True)
+
+
+def _branch_b_fa4_trace_sync() -> None:
+    """Synchronize only when a trace must describe completed GPU work."""
+    if os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_TRACE") == "1":
+        torch.cuda.current_stream().synchronize()
+
+
+def _branch_b_fa4_mask(cp_rank: int, half: int, cp_size: int):
+    """Compile/cache the native two-chunk causal mask for one CP rank."""
+    cache_key = (cp_rank, half, cp_size)
+    cached = _BRANCH_B_FA4_MASKS.get(cache_key)
+    if cached is not None:
+        return cached
+    cutlass = _fa4_cutlass
+    cute = _fa4_cute
+
+    @cute.jit
+    def native_cp_causal_mask(
+        batch: cute.TensorSSA,
+        head: cute.TensorSSA,
+        q_idx: cute.TensorSSA,
+        kv_idx: cute.TensorSSA,
+        seqlen_info,
+        aux_tensors,
+    ) -> cute.TensorSSA:
+        chunk = cutlass.Int32(half)
+        first_global_q = cp_rank * chunk + q_idx
+        second_global_q = (2 * cp_size - 1 - cp_rank) * chunk + (q_idx - chunk)
+        global_q = cute.where(q_idx < chunk, first_global_q, second_global_q)
+        return kv_idx <= global_q
+
+    _BRANCH_B_FA4_MASKS[cache_key] = native_cp_causal_mask
+    return native_cp_causal_mask
+
+
+def _branch_b_fa4_block_sparse(
+    cp_rank: int, local_seq: int, cp_size: int, device: torch.device
+):
+    if os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_BLOCK_SPARSE") != "1":
+        return None, None
+    cache_key = (cp_rank, local_seq, cp_size, device)
+    cached = _BRANCH_B_FA4_BLOCK_SPARSE.get(cache_key)
+    if cached is not None:
+        return cached
+    from flash_attn.cute.block_sparsity import BlockSparseTensorsTorch
+    from torch.nn.attention.flex_attention import create_block_mask
+
+    half = local_seq // 2
+    global_seq = local_seq * cp_size
+
+    def eager_mask(batch, head, q_idx, kv_idx):
+        del batch, head
+        global_q = torch.where(
+            q_idx < half,
+            cp_rank * half + q_idx,
+            (2 * cp_size - 1 - cp_rank) * half + (q_idx - half),
+        )
+        return kv_idx <= global_q
+
+    block_mask = create_block_mask(
+        eager_mask,
+        1,
+        1,
+        local_seq,
+        global_seq,
+        device=str(device),
+        BLOCK_SIZE=(256, 128),
+    )
+    (
+        _seq_q,
+        _seq_k,
+        kv_mask_cnt,
+        kv_mask_idx,
+        full_kv_cnt,
+        full_kv_idx,
+        q_mask_cnt,
+        q_mask_idx,
+        full_q_cnt,
+        full_q_idx,
+        *_,
+    ) = block_mask.as_tuple()
+    forward = BlockSparseTensorsTorch(
+        mask_block_cnt=kv_mask_cnt,
+        mask_block_idx=kv_mask_idx,
+        full_block_cnt=full_kv_cnt,
+        full_block_idx=full_kv_idx,
+        block_size=(256, 128),
+    )
+    backward = BlockSparseTensorsTorch(
+        mask_block_cnt=q_mask_cnt,
+        mask_block_idx=q_mask_idx,
+        full_block_cnt=full_q_cnt,
+        full_block_idx=full_q_idx,
+        block_size=(256, 128),
+    )
+    _BRANCH_B_FA4_BLOCK_SPARSE[cache_key] = (forward, backward)
+    return forward, backward
+
+
+def _branch_b_fa4_prewarm(query: torch.Tensor, cp_rank: int, cp_size: int) -> None:
+    if os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_PREWARM") != "1":
+        return
+    key = (query.device, tuple(query.shape), query.dtype, cp_rank, cp_size)
+    if key in _BRANCH_B_FA4_PREWARMED:
+        return
+    half = int(query.shape[0]) // 2
+    q = torch.zeros_like(query).transpose(0, 1).contiguous()
+    global_shape = (1, int(query.shape[0]) * cp_size, *query.shape[2:])
+    k = torch.zeros(global_shape, device=query.device, dtype=query.dtype)
+    v = torch.zeros_like(k)
+    softmax_scale = 1.0 / math.sqrt(float(query.shape[-1]))
+    _branch_b_fa4_trace(cp_rank, "P00 before_prewarm_fwd")
+    if os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_MULTIBASE") == "1":
+        peers_k = tuple(torch.zeros_like(q) for _ in range(4))
+        peers_v = tuple(torch.zeros_like(q) for _ in range(4))
+        _FA4_FWD(
+            q,
+            peers_k[0],
+            peers_v[0],
+            softmax_scale=softmax_scale,
+            mask_mod=_branch_b_fa4_mask(cp_rank, half, cp_size),
+            peer_k=peers_k,
+            peer_v=peers_v,
+        )
+    elif os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_PACKED_VARLEN") == "1":
+        prefix1 = (cp_rank + 1) * half
+        prefix2 = (2 * cp_size - cp_rank) * half
+        q_packed = q[0]
+        k_packed = torch.cat((k[0, :prefix1], k[0, :prefix2]), dim=0)
+        v_packed = torch.cat((v[0, :prefix1], v[0, :prefix2]), dim=0)
+        cu_q = torch.tensor([0, half, 2 * half], dtype=torch.int32, device=query.device)
+        cu_k = torch.tensor(
+            [0, prefix1, prefix1 + prefix2], dtype=torch.int32, device=query.device
+        )
+        _FA4_FWD(
+            q_packed, k_packed, v_packed,
+            cu_seqlens_q=cu_q, cu_seqlens_k=cu_k,
+            max_seqlen_q=half, max_seqlen_k=max(prefix1, prefix2),
+            softmax_scale=softmax_scale, causal=True,
+        )
+    elif os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_SHARED_KV_BATCH") == "1":
+        prefix1 = (cp_rank + 1) * half
+        prefix2 = (2 * cp_size - cp_rank) * half
+        q_batch = q.view(2, half, q.shape[2], q.shape[3])
+        k_batch = k[:, :prefix2].expand(2, -1, -1, -1)
+        v_batch = v[:, :prefix2].expand(2, -1, -1, -1)
+        seqused_q = torch.full((2,), half, dtype=torch.int32, device=query.device)
+        seqused_k = torch.tensor([prefix1, prefix2], dtype=torch.int32, device=query.device)
+        _FA4_FWD(
+            q_batch, k_batch, v_batch,
+            seqused_q=seqused_q, seqused_k=seqused_k,
+            softmax_scale=softmax_scale, causal=True,
+        )
+    elif os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_TWO_PREFIX") == "1":
+        for q_part, prefix_chunks in (
+            (q[:, :half], cp_rank + 1),
+            (q[:, half:], 2 * cp_size - cp_rank),
+        ):
+            prefix = prefix_chunks * half
+            _FA4_FWD(
+                q_part,
+                k[:, :prefix],
+                v[:, :prefix],
+                softmax_scale=softmax_scale,
+                causal=True,
+            )
+    else:
+        block_sparse_fwd, _ = _branch_b_fa4_block_sparse(
+            cp_rank, int(query.shape[0]), cp_size, query.device
+        )
+        _FA4_FWD(
+            q,
+            k,
+            v,
+            softmax_scale=softmax_scale,
+            mask_mod=_branch_b_fa4_mask(cp_rank, half, cp_size),
+            block_sparse_tensors=block_sparse_fwd,
+        )
+    torch.cuda.current_stream().synchronize()
+    _BRANCH_B_FA4_PREWARMED.add(key)
+    _branch_b_fa4_trace(cp_rank, "P10 after_prewarm_fwd")
+
+
+def _branch_b_fa4_global_forward(
+    query: torch.Tensor,
+    peer_keys: list[torch.Tensor],
+    peer_values: list[torch.Tensor],
+    cp_rank: int,
+    peer_pes: list[int] | None = None,
+    layer_number: int = 0,
+) -> tuple[torch.Tensor, tuple]:
+    """Run one FA4 graph over globally ordered K/V and native-split local Q."""
+    if len(peer_keys) != 4 or len(peer_values) != 4:
+        raise NvshmemCpFaOwnerError("FA4 Branch-B prototype currently requires CP=4.")
+    half = int(query.shape[0]) // 2
+    if os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_MULTIBASE") == "1":
+        q_fa4 = query.view(1, query.shape[0], query.shape[2], query.shape[3])
+        peer_k_fa4 = tuple(
+            item.view(1, item.shape[0], item.shape[2], item.shape[3])
+            for item in peer_keys
+        )
+        peer_v_fa4 = tuple(
+            item.view(1, item.shape[0], item.shape[2], item.shape[3])
+            for item in peer_values
+        )
+        softmax_scale = 1.0 / math.sqrt(float(query.shape[-1]))
+        mask_mod = _branch_b_fa4_mask(cp_rank, half, 4)
+        out_fa4, lse, _, _ = _FA4_FWD(
+            q_fa4,
+            peer_k_fa4[0],
+            peer_v_fa4[0],
+            softmax_scale=softmax_scale,
+            mask_mod=mask_mod,
+            peer_k=peer_k_fa4,
+            peer_v=peer_v_fa4,
+            return_lse=True,
+        )
+        state = (
+            "multibase", q_fa4, peer_k_fa4, peer_v_fa4, out_fa4, lse,
+            mask_mod, softmax_scale,
+        )
+        return out_fa4.view_as(query), state
+    deferred_detail = (
+        os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_DEFERRED_PHASE_EVENTS") == "1"
+        and query.is_cuda
+    )
+    materialization_start = materialization_end = None
+    if deferred_detail:
+        materialization_start = torch.cuda.Event(enable_timing=True)
+        materialization_end = torch.cuda.Event(enable_timing=True)
+        materialization_start.record()
+    _branch_b_fa4_trace(cp_rank, "F10 before_global_kv_cat")
+    if os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_GLOBAL_GETMEM") == "1":
+        if peer_pes is None or len(peer_pes) != 4:
+            raise NvshmemCpFaOwnerError("FA4 global getmem staging requires four NVSHMEM PEs.")
+        nvshmem = _ensure_nvshmem_initialized()
+        global_shape = (query.shape[0] * 4, *peer_keys[cp_rank].shape[1:])
+        global_key = torch.empty(global_shape, device=query.device, dtype=peer_keys[cp_rank].dtype)
+        global_value = torch.empty(
+            global_shape, device=query.device, dtype=peer_values[cp_rank].dtype
+        )
+        stream = torch.cuda.current_stream(query.device)
+        half_bytes = half * peer_keys[cp_rank][0].numel() * peer_keys[cp_rank].element_size()
+        key_base = int(peer_keys[cp_rank].data_ptr())
+        value_base = int(peer_values[cp_rank].data_ptr())
+        for owner in range(4):
+            pe = int(peer_pes[owner])
+            for source_half, chunk in ((0, owner), (1, 7 - owner)):
+                byte_offset = source_half * half_bytes
+                nvshmem.getmem_on_stream(
+                    int(global_key[chunk * half :].data_ptr()),
+                    key_base + byte_offset,
+                    half_bytes,
+                    pe,
+                    int(stream.cuda_stream),
+                )
+                nvshmem.getmem_on_stream(
+                    int(global_value[chunk * half :].data_ptr()),
+                    value_base + byte_offset,
+                    half_bytes,
+                    pe,
+                    int(stream.cuda_stream),
+                )
+        nvshmem.quiet_on_stream(int(stream.cuda_stream))
+    else:
+        global_key = torch.cat(
+            [item[:half] for item in peer_keys]
+            + [item[half:] for item in reversed(peer_keys)],
+            dim=0,
+        )
+        global_value = torch.cat(
+            [item[:half] for item in peer_values]
+            + [item[half:] for item in reversed(peer_values)],
+            dim=0,
+        )
+    _branch_b_fa4_trace_sync()
+    _branch_b_fa4_trace(cp_rank, "F20 after_global_kv_cat")
+    if query.shape[1] == 1:
+        q_fa4 = query.view(1, query.shape[0], query.shape[2], query.shape[3])
+        k_fa4 = global_key.view(1, global_key.shape[0], global_key.shape[2], global_key.shape[3])
+        v_fa4 = global_value.view(
+            1, global_value.shape[0], global_value.shape[2], global_value.shape[3]
+        )
+    else:
+        q_fa4 = query.transpose(0, 1).contiguous()
+        k_fa4 = global_key.transpose(0, 1).contiguous()
+        v_fa4 = global_value.transpose(0, 1).contiguous()
+    if materialization_end is not None:
+        materialization_end.record()
+    softmax_scale = 1.0 / math.sqrt(float(query.shape[-1]))
+    if os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_PACKED_VARLEN") == "1":
+        prefix1 = (cp_rank + 1) * half
+        prefix2 = (8 - cp_rank) * half
+        q_packed = q_fa4[0]
+        k_packed = torch.cat((k_fa4[0, :prefix1], k_fa4[0, :prefix2]), dim=0)
+        v_packed = torch.cat((v_fa4[0, :prefix1], v_fa4[0, :prefix2]), dim=0)
+        cu_q = torch.tensor([0, half, 2 * half], dtype=torch.int32, device=query.device)
+        cu_k = torch.tensor(
+            [0, prefix1, prefix1 + prefix2], dtype=torch.int32, device=query.device
+        )
+        packed_result = _FA4_FWD(
+            q_packed, k_packed, v_packed,
+            cu_seqlens_q=cu_q, cu_seqlens_k=cu_k,
+            max_seqlen_q=half, max_seqlen_k=max(prefix1, prefix2),
+            softmax_scale=softmax_scale, causal=True, return_lse=True,
+        )
+        out_fa4 = packed_result[0].unsqueeze(0)
+        state = (
+            "packed_varlen", q_packed, k_packed, v_packed, packed_result,
+            cu_q, cu_k, prefix1, prefix2, softmax_scale,
+        )
+        _branch_b_fa4_trace_sync()
+        _branch_b_fa4_trace(cp_rank, "F40 after_fa4_fwd")
+        return (
+            out_fa4.view_as(query)
+            if query.shape[1] == 1
+            else out_fa4.transpose(0, 1).contiguous()
+        ), state
+    if os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_SHARED_KV_BATCH") == "1":
+        prefix1 = (cp_rank + 1) * half
+        prefix2 = (8 - cp_rank) * half
+        q_batch = q_fa4.view(2, half, q_fa4.shape[2], q_fa4.shape[3])
+        k_batch = k_fa4[:, :prefix2].expand(2, -1, -1, -1)
+        v_batch = v_fa4[:, :prefix2].expand(2, -1, -1, -1)
+        seqused_q = torch.full((2,), half, dtype=torch.int32, device=query.device)
+        seqused_k = torch.tensor([prefix1, prefix2], dtype=torch.int32, device=query.device)
+        fa4_start = fa4_end = None
+        if deferred_detail:
+            fa4_start = torch.cuda.Event(enable_timing=True)
+            fa4_end = torch.cuda.Event(enable_timing=True)
+            fa4_start.record()
+        batch_result = _FA4_FWD(
+            q_batch, k_batch, v_batch,
+            seqused_q=seqused_q, seqused_k=seqused_k,
+            softmax_scale=softmax_scale, causal=True, return_lse=True,
+        )
+        if fa4_end is not None:
+            fa4_end.record()
+            _BRANCH_B_DEFERRED_FORWARD_DETAIL_EVENTS.append(
+                {
+                    "layer_number": int(layer_number),
+                    "cp_rank": int(cp_rank),
+                    "materialization_start": materialization_start,
+                    "materialization_end": materialization_end,
+                    "fa4_start": fa4_start,
+                    "fa4_end": fa4_end,
+                }
+            )
+        out_fa4 = torch.cat((batch_result[0][0:1], batch_result[0][1:2]), dim=1)
+        state = (
+            "shared_kv_batch", q_batch, k_batch, v_batch, batch_result,
+            seqused_q, seqused_k, prefix1, prefix2, softmax_scale,
+        )
+        _branch_b_fa4_trace_sync()
+        _branch_b_fa4_trace(cp_rank, "F40 after_fa4_fwd")
+        return (
+            out_fa4.view_as(query)
+            if query.shape[1] == 1
+            else out_fa4.transpose(0, 1).contiguous()
+        ), state
+    if os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_TWO_PREFIX") == "1":
+        prefix1 = (cp_rank + 1) * half
+        prefix2 = (8 - cp_rank) * half
+        result1 = _FA4_FWD(
+            q_fa4[:, :half],
+            k_fa4[:, :prefix1],
+            v_fa4[:, :prefix1],
+            softmax_scale=softmax_scale,
+            causal=True,
+            return_lse=True,
+        )
+        result2 = _FA4_FWD(
+            q_fa4[:, half:],
+            k_fa4[:, :prefix2],
+            v_fa4[:, :prefix2],
+            softmax_scale=softmax_scale,
+            causal=True,
+            return_lse=True,
+        )
+        out_fa4 = torch.cat((result1[0], result2[0]), dim=1)
+        state = (
+            "two_prefix", q_fa4, k_fa4, v_fa4, result1, result2,
+            prefix1, prefix2, softmax_scale,
+        )
+        _branch_b_fa4_trace_sync()
+        _branch_b_fa4_trace(cp_rank, "F40 after_fa4_fwd")
+        return (
+            out_fa4.view_as(query)
+            if query.shape[1] == 1
+            else out_fa4.transpose(0, 1).contiguous()
+        ), state
+    mask_mod = _branch_b_fa4_mask(cp_rank, half, 4)
+    block_sparse_fwd, block_sparse_bwd = _branch_b_fa4_block_sparse(
+        cp_rank, int(query.shape[0]), 4, query.device
+    )
+    _branch_b_fa4_trace(
+        cp_rank,
+        "F30 before_fa4_fwd "
+        f"q={tuple(q_fa4.shape)}/{q_fa4.dtype}/{q_fa4.stride()} "
+        f"k={tuple(k_fa4.shape)}/{k_fa4.dtype}/{k_fa4.stride()} "
+        f"v={tuple(v_fa4.shape)}/{v_fa4.dtype}/{v_fa4.stride()} "
+        f"stream={torch.cuda.current_stream().cuda_stream}",
+    )
+    out_fa4, lse, p, row_max = _FA4_FWD(
+        q_fa4,
+        k_fa4,
+        v_fa4,
+        softmax_scale=softmax_scale,
+        mask_mod=mask_mod,
+        block_sparse_tensors=block_sparse_fwd,
+        return_lse=True,
+    )
+    _branch_b_fa4_trace_sync()
+    _branch_b_fa4_trace(cp_rank, "F40 after_fa4_fwd")
+    state = (
+        q_fa4, k_fa4, v_fa4, out_fa4, lse, p, row_max, mask_mod,
+        softmax_scale, block_sparse_bwd,
+    )
+    return out_fa4.transpose(0, 1).contiguous(), state
+
+
+def _branch_b_fa4_global_backward(
+    tex,
+    fa4_state,
+    grad_output: torch.Tensor,
+    peer_keys: list[torch.Tensor],
+    peer_values: list[torch.Tensor],
+    ws,
+    cp_rank: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    phase_timing = os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_BWD_PHASE_TIMING") == "1"
+    phase_events: list[tuple[str, torch.cuda.Event]] = []
+
+    def record_phase(name: str) -> None:
+        if phase_timing:
+            event = torch.cuda.Event(enable_timing=True)
+            event.record()
+            phase_events.append((name, event))
+
+    def emit_phase_report(**extra: object) -> None:
+        if not phase_timing or not phase_events:
+            return
+        phase_events[-1][1].synchronize()
+        phases_ms = {
+            f"{left_name}_to_{right_name}_ms": left_event.elapsed_time(right_event)
+            for (left_name, left_event), (right_name, right_event) in zip(
+                phase_events, phase_events[1:]
+            )
+        }
+        payload = {"cp_rank": cp_rank, "phases_ms": phases_ms}
+        payload.update(extra)
+        print("[branch-b-fa4-bwd-phase] " + json.dumps(payload, sort_keys=True), flush=True)
+
+    def torch_global_grad_return(
+        dk_global_tensor: torch.Tensor,
+        dv_global_tensor: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Slow correctness oracle for global dK/dV owner return.
+
+        Each CP rank computes dK/dV contributions for its local Q against the
+        globally ordered K/V layout:
+        [chunk0, chunk1, chunk2, chunk3, chunk4, chunk5, chunk6, chunk7].
+        The local native CP owner layout is [chunk rank, chunk 7-rank].
+        """
+
+        from megatron.core import parallel_state
+
+        cp_group = parallel_state.get_context_parallel_group(check_initialized=False)
+        gathered_dk = [torch.empty_like(dk_global_tensor) for _ in range(4)]
+        gathered_dv = [torch.empty_like(dv_global_tensor) for _ in range(4)]
+        torch.distributed.all_gather(gathered_dk, dk_global_tensor.contiguous(), group=cp_group)
+        torch.distributed.all_gather(gathered_dv, dv_global_tensor.contiguous(), group=cp_group)
+        half_tokens = int(peer_keys[cp_rank].shape[0]) // 2
+
+        subset_return = (
+            os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_TORCH_TE_CP4_SUBSET_RETURN") == "1"
+        )
+        if subset_return and len(gathered_dk) != 4:
+            raise NvshmemCpFaOwnerError(
+                "MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_TORCH_TE_CP4_SUBSET_RETURN=1 "
+                f"requires CP=4, got {len(gathered_dk)}."
+            )
+
+        def te_cp4_sources(owner_rank: int, local_half: int) -> list[int]:
+            table = {
+                (0, 0): [0, 1, 2, 3],
+                (0, 1): [0],
+                (1, 0): [0, 1, 2, 3],
+                (1, 1): [0, 1],
+                (2, 0): [0, 1, 2],
+                (2, 1): [0, 1, 2],
+                (3, 0): [0, 1, 2, 3],
+                (3, 1): [0, 1, 2, 3],
+            }
+            return table[(owner_rank, local_half)]
+
+        def owner_sum(
+            chunks: list[torch.Tensor],
+            chunk_index: int,
+            *,
+            local_half: int,
+        ) -> torch.Tensor:
+            start = chunk_index * half_tokens
+            source_ranks = (
+                te_cp4_sources(cp_rank, local_half)
+                if subset_return
+                else range(len(chunks))
+            )
+            total = None
+            for source_rank in source_ranks:
+                item = chunks[int(source_rank)].narrow(0, start, half_tokens).float()
+                total = item if total is None else total + item
+            if total is None:
+                raise NvshmemCpFaOwnerError("empty K/V gradient source subset.")
+            return total.to(peer_keys[cp_rank].dtype)
+
+        dk_first = owner_sum(gathered_dk, cp_rank, local_half=0)
+        dk_second = owner_sum(gathered_dk, 7 - cp_rank, local_half=1)
+        dv_first = owner_sum(gathered_dv, cp_rank, local_half=0)
+        dv_second = owner_sum(gathered_dv, 7 - cp_rank, local_half=1)
+        return torch.cat((dk_first, dk_second), dim=0), torch.cat((dv_first, dv_second), dim=0)
+
+    record_phase("start")
+    if isinstance(fa4_state[0], str) and fa4_state[0] == "multibase":
+        (
+            _marker, q_fa4, peer_k_fa4, peer_v_fa4, out_fa4, lse,
+            mask_mod, softmax_scale,
+        ) = fa4_state
+        dq_fa4, dk_fa4, dv_fa4 = _FA4_BWD(
+            q_fa4,
+            peer_k_fa4[0],
+            peer_v_fa4[0],
+            out_fa4,
+            grad_output.view_as(out_fa4),
+            lse,
+            softmax_scale=softmax_scale,
+            mask_mod=mask_mod,
+            peer_k=peer_k_fa4,
+            peer_v=peer_v_fa4,
+        )
+    elif isinstance(fa4_state[0], str) and fa4_state[0] == "packed_varlen":
+        (
+            _marker, q_packed, k_packed, v_packed, packed_result,
+            cu_q, cu_k, prefix1, prefix2, softmax_scale,
+        ) = fa4_state
+        half = int(q_packed.shape[0]) // 2
+        dq_packed, dk_packed, dv_packed = _FA4_BWD(
+            q_packed, k_packed, v_packed, packed_result[0],
+            grad_output.transpose(0, 1).contiguous()[0], packed_result[1],
+            softmax_scale=softmax_scale, causal=True,
+            cu_seqlens_q=cu_q, cu_seqlens_k=cu_k,
+            max_seqlen_q=half, max_seqlen_k=max(prefix1, prefix2),
+        )
+        dq_fa4 = dq_packed.unsqueeze(0)
+        direct_owner_return = (
+            os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_DIRECT_OWNER_RETURN") == "1"
+            and os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_GLOBAL_GRAD_RETURN") == "1"
+        )
+        if direct_owner_return:
+            native_direct_return = (
+                os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_NATIVE_DIRECT_OWNER_RETURN") == "1"
+            )
+            if not native_direct_return:
+                raise NvshmemCpFaOwnerError(
+                    "FA4 packed-varlen direct owner return currently requires "
+                    "MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_NATIVE_DIRECT_OWNER_RETURN=1."
+                )
+            if int(prefix1) % int(half) != 0 or int(prefix2) % int(half) != 0:
+                raise NvshmemCpFaOwnerError(
+                    "FA4 packed-varlen direct owner return expects prefix lengths aligned "
+                    "to CP half chunks."
+                )
+            tex = _import_te_for_native_fused_owner()
+            native_return = getattr(
+                tex, "nvshmem_cp_two_prefix_direct_owner_grad_return_execute", None
+            )
+            if native_return is None:
+                raise NvshmemCpFaOwnerError(
+                    "FA4 packed-varlen direct owner return requires transformer_engine_torch."
+                    "nvshmem_cp_two_prefix_direct_owner_grad_return_execute."
+                )
+            dk1 = dk_packed[:prefix1].unsqueeze(0).contiguous()
+            dv1 = dv_packed[:prefix1].unsqueeze(0).contiguous()
+            dk2 = dk_packed[prefix1 : prefix1 + prefix2].unsqueeze(0).contiguous()
+            dv2 = dv_packed[prefix1 : prefix1 + prefix2].unsqueeze(0).contiguous()
+            dq = dq_fa4.view(dq_fa4.shape[1], 1, dq_fa4.shape[2], dq_fa4.shape[3])
+            dk, dv = native_return(
+                dk1,
+                dv1,
+                dk2,
+                dv2,
+                int(prefix1),
+                int(prefix2),
+                peer_keys[cp_rank],
+                peer_values[cp_rank],
+                ws.grad_key_return,
+                ws.grad_value_return,
+                ws.grad_committed_epoch,
+                ws.peer_grad_key_returns,
+                ws.peer_grad_value_returns,
+                ws.peer_grad_committed_epochs,
+                4,
+                cp_rank,
+            )
+            record_phase("after_packed_varlen_native_direct_owner_return")
+            if phase_timing:
+                phase_events[-1][1].synchronize()
+                phases_ms = {
+                    f"{left_name}_to_{right_name}_ms": left_event.elapsed_time(right_event)
+                    for (left_name, left_event), (right_name, right_event) in zip(
+                        phase_events, phase_events[1:]
+                    )
+                }
+                print(
+                    "[branch-b-fa4-bwd-phase] "
+                    + json.dumps(
+                        {
+                            "cp_rank": cp_rank,
+                            "direct_owner_return": True,
+                            "native_direct_owner_return": True,
+                            "packed_varlen": True,
+                            "phases_ms": phases_ms,
+                        },
+                        sort_keys=True,
+                    ),
+                    flush=True,
+                )
+            return dq, dk, dv
+        global_seq = int(peer_keys[cp_rank].shape[0]) * 4
+        dk_fa4 = torch.zeros(
+            (1, global_seq, *dk_packed.shape[1:]), device=dk_packed.device, dtype=dk_packed.dtype
+        )
+        dv_fa4 = torch.zeros(
+            (1, global_seq, *dv_packed.shape[1:]), device=dv_packed.device, dtype=dv_packed.dtype
+        )
+        dk_fa4[0, :prefix1].add_(dk_packed[:prefix1])
+        dk_fa4[0, :prefix2].add_(dk_packed[prefix1:])
+        dv_fa4[0, :prefix1].add_(dv_packed[:prefix1])
+        dv_fa4[0, :prefix2].add_(dv_packed[prefix1:])
+    elif isinstance(fa4_state[0], str) and fa4_state[0] == "shared_kv_batch":
+        (
+            _marker, q_batch, k_batch, v_batch, batch_result,
+            seqused_q, seqused_k, prefix1, prefix2, softmax_scale,
+        ) = fa4_state
+        half = int(q_batch.shape[1])
+        grad_bshd = (
+            grad_output.view(1, grad_output.shape[0], grad_output.shape[2], grad_output.shape[3])
+            if grad_output.shape[1] == 1
+            else grad_output.transpose(0, 1).contiguous()
+        )
+        dout_batch = grad_bshd.view(2, half, grad_bshd.shape[2], grad_bshd.shape[3])
+        two_section_tail_dq = (
+            os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_TWO_SECTION_TAIL_DQ_RECOMPUTE") == "1"
+        )
+        two_section_causal_bwd = (
+            os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_TWO_SECTION_CAUSAL_BWD") == "1"
+        )
+        dual_section_stream_bwd = (
+            os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_DUAL_SECTION_STREAM_BWD") == "1"
+        )
+        two_section_bwd = (
+            two_section_tail_dq or two_section_causal_bwd or dual_section_stream_bwd
+        )
+        direct_owner_return = (
+            os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_DIRECT_OWNER_RETURN") == "1"
+            and os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_GLOBAL_GRAD_RETURN") == "1"
+        )
+        if two_section_bwd:
+            if direct_owner_return:
+                raise NvshmemCpFaOwnerError(
+                    "FA4 two-section backward returns compact combined dK/dV; "
+                    "use global grad return, not direct owner return."
+                )
+            if dual_section_stream_bwd:
+                current_stream = torch.cuda.current_stream(q_batch.device)
+                section0_stream = _branch_b_dual_section_bwd_stream(q_batch.device, 0)
+                section1_stream = _branch_b_dual_section_bwd_stream(q_batch.device, 1)
+                section0_stream.wait_stream(current_stream)
+                section1_stream.wait_stream(current_stream)
+                with torch.cuda.stream(section0_stream):
+                    dq1, dk1, dv1 = _FA4_BWD(
+                        q_batch[0:1],
+                        k_batch[0:1, :prefix1],
+                        v_batch[0:1, :prefix1],
+                        batch_result[0][0:1],
+                        dout_batch[0:1],
+                        batch_result[1][0:1],
+                        softmax_scale=softmax_scale,
+                        causal=True,
+                    )
+                with torch.cuda.stream(section1_stream):
+                    dq2, dk2, dv2 = _FA4_BWD(
+                        q_batch[1:2],
+                        k_batch[0:1, :prefix2],
+                        v_batch[0:1, :prefix2],
+                        batch_result[0][1:2],
+                        dout_batch[1:2],
+                        batch_result[1][1:2],
+                        softmax_scale=softmax_scale,
+                        causal=True,
+                    )
+                current_stream.wait_stream(section0_stream)
+                current_stream.wait_stream(section1_stream)
+                dq_fa4 = torch.cat((dq1, dq2), dim=1)
+                global_seq = int(peer_keys[cp_rank].shape[0]) * 4
+                dk_fa4 = torch.zeros(
+                    (1, global_seq, *dk2.shape[2:]),
+                    device=dk2.device,
+                    dtype=dk2.dtype,
+                )
+                dv_fa4 = torch.zeros(
+                    (1, global_seq, *dv2.shape[2:]),
+                    device=dv2.device,
+                    dtype=dv2.dtype,
+                )
+                dk_fa4[:, :prefix1].add_(dk1)
+                dk_fa4[:, :prefix2].add_(dk2)
+                dv_fa4[:, :prefix1].add_(dv1)
+                dv_fa4[:, :prefix2].add_(dv2)
+                record_phase("after_shared_kv_dual_section_stream_bwd")
+            elif _FA4_TWO_SECTION_BWD is None:
+                raise NvshmemCpFaOwnerError(
+                    "FA4 two-section tail dQ recompute requires "
+                    "flash_attn.cute.interface._flash_attn_bwd_two_section_causal."
+                )
+            else:
+                dq1, dq2, dk_batch, dv_batch = _FA4_TWO_SECTION_BWD(
+                    q_batch[0:1],
+                    q_batch[1:2],
+                    k_batch[0:1],
+                    v_batch[0:1],
+                    batch_result[0][0:1],
+                    batch_result[0][1:2],
+                    dout_batch[0:1],
+                    dout_batch[1:2],
+                    batch_result[1][0:1],
+                    batch_result[1][1:2],
+                    int(prefix1),
+                    int(prefix2),
+                    softmax_scale=softmax_scale,
+                    tail_dq_recompute=two_section_tail_dq,
+                    overlap_dkv_recompute=(
+                        os.getenv(
+                            "MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_TWO_SECTION_OVERLAP_DKV_RECOMPUTE"
+                        )
+                        == "1"
+                    ),
+                    compact_grad_recompute=(
+                        os.getenv(
+                            "MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_TWO_SECTION_COMPACT_GRAD_RECOMPUTE"
+                        )
+                        == "1"
+                    ),
+                )
+                dq_fa4 = torch.cat((dq1, dq2), dim=1)
+                global_seq = int(peer_keys[cp_rank].shape[0]) * 4
+                if int(prefix2) == global_seq:
+                    dk_fa4 = dk_batch
+                    dv_fa4 = dv_batch
+                else:
+                    dk_fa4 = torch.zeros(
+                        (1, global_seq, *dk_batch.shape[2:]),
+                        device=dk_batch.device,
+                        dtype=dk_batch.dtype,
+                    )
+                    dv_fa4 = torch.zeros(
+                        (1, global_seq, *dv_batch.shape[2:]),
+                        device=dv_batch.device,
+                        dtype=dv_batch.dtype,
+                    )
+                    dk_fa4[:, :prefix2].copy_(dk_batch[:, :prefix2])
+                    dv_fa4[:, :prefix2].copy_(dv_batch[:, :prefix2])
+                record_phase(
+                    "after_shared_kv_two_section_tail_dq"
+                    if two_section_tail_dq
+                    else "after_shared_kv_two_section_causal_bwd"
+                )
+        else:
+            dq_batch, dk_batch, dv_batch = _FA4_BWD(
+                q_batch, k_batch, v_batch, batch_result[0], dout_batch, batch_result[1],
+                softmax_scale=softmax_scale, causal=True,
+                seqused_q=seqused_q, seqused_k=seqused_k,
+            )
+            dq_fa4 = torch.cat((dq_batch[0:1], dq_batch[1:2]), dim=1)
+        if direct_owner_return:
+            if int(prefix1) % int(half) != 0 or int(prefix2) % int(half) != 0:
+                raise NvshmemCpFaOwnerError(
+                    "FA4 shared-KV batch direct owner return expects prefix lengths "
+                    "aligned to CP half chunks."
+                )
+            native_direct_return = (
+                os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_NATIVE_DIRECT_OWNER_RETURN") == "1"
+            )
+            if not native_direct_return:
+                raise NvshmemCpFaOwnerError(
+                    "FA4 shared-KV batch direct owner return currently requires "
+                    "MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_NATIVE_DIRECT_OWNER_RETURN=1."
+                )
+            tex = _import_te_for_native_fused_owner()
+            native_return = getattr(
+                tex, "nvshmem_cp_two_prefix_direct_owner_grad_return_execute", None
+            )
+            if native_return is None:
+                available = [
+                    name
+                    for name in dir(tex)
+                    if "grad_return" in name or "two_prefix" in name
+                ]
+                raise NvshmemCpFaOwnerError(
+                    "FA4 shared-KV batch direct owner return requires transformer_engine_torch."
+                    "nvshmem_cp_two_prefix_direct_owner_grad_return_execute. "
+                    f"loaded_module={getattr(tex, '__file__', '<unknown>')} "
+                    f"available_related={available}"
+                )
+            dq = dq_fa4.view(dq_fa4.shape[1], 1, dq_fa4.shape[2], dq_fa4.shape[3])
+            dk, dv = native_return(
+                dk_batch[0:1, :prefix1].contiguous(),
+                dv_batch[0:1, :prefix1].contiguous(),
+                dk_batch[1:2, :prefix2].contiguous(),
+                dv_batch[1:2, :prefix2].contiguous(),
+                int(prefix1),
+                int(prefix2),
+                peer_keys[cp_rank],
+                peer_values[cp_rank],
+                ws.grad_key_return,
+                ws.grad_value_return,
+                ws.grad_committed_epoch,
+                ws.peer_grad_key_returns,
+                ws.peer_grad_value_returns,
+                ws.peer_grad_committed_epochs,
+                4,
+                cp_rank,
+            )
+            record_phase("after_shared_kv_batch_native_direct_owner_return")
+            if phase_timing:
+                phase_events[-1][1].synchronize()
+                phases_ms = {
+                    f"{left_name}_to_{right_name}_ms": left_event.elapsed_time(right_event)
+                    for (left_name, left_event), (right_name, right_event) in zip(
+                        phase_events, phase_events[1:]
+                    )
+                }
+                print(
+                    "[branch-b-fa4-bwd-phase] "
+                    + json.dumps(
+                        {
+                            "cp_rank": cp_rank,
+                            "direct_owner_return": True,
+                            "native_direct_owner_return": True,
+                            "shared_kv_batch": True,
+                            "phases_ms": phases_ms,
+                        },
+                        sort_keys=True,
+                    ),
+                    flush=True,
+            )
+            return dq, dk, dv
+        if not two_section_bwd:
+            global_seq = int(peer_keys[cp_rank].shape[0]) * 4
+            dk_fa4 = torch.zeros(
+                (1, global_seq, *dk_batch.shape[2:]), device=dk_batch.device, dtype=dk_batch.dtype
+            )
+            dv_fa4 = torch.zeros(
+                (1, global_seq, *dv_batch.shape[2:]), device=dv_batch.device, dtype=dv_batch.dtype
+            )
+            dk_fa4[:, :prefix1].add_(dk_batch[0:1, :prefix1])
+            dk_fa4[:, :prefix2].add_(dk_batch[1:2, :prefix2])
+            dv_fa4[:, :prefix1].add_(dv_batch[0:1, :prefix1])
+            dv_fa4[:, :prefix2].add_(dv_batch[1:2, :prefix2])
+    elif isinstance(fa4_state[0], str) and fa4_state[0] == "two_prefix":
+        (
+            _marker, q_fa4, k_fa4, v_fa4, result1, result2,
+            prefix1, prefix2, softmax_scale,
+        ) = fa4_state
+        grad_bshd = (
+            grad_output.view(1, grad_output.shape[0], grad_output.shape[2], grad_output.shape[3])
+            if grad_output.shape[1] == 1
+            else grad_output.transpose(0, 1).contiguous()
+        )
+        half = int(q_fa4.shape[1]) // 2
+        record_phase("before_prefix1")
+        dq1, dk1, dv1 = _FA4_BWD(
+            q_fa4[:, :half], k_fa4[:, :prefix1], v_fa4[:, :prefix1],
+            result1[0], grad_bshd[:, :half], result1[1],
+            softmax_scale=softmax_scale, causal=True,
+        )
+        record_phase("after_prefix1")
+        dq2, dk2, dv2 = _FA4_BWD(
+            q_fa4[:, half:], k_fa4[:, :prefix2], v_fa4[:, :prefix2],
+            result2[0], grad_bshd[:, half:], result2[1],
+            softmax_scale=softmax_scale, causal=True,
+        )
+        record_phase("after_prefix2")
+        dq_fa4 = torch.cat((dq1, dq2), dim=1)
+        direct_owner_return = (
+            os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_DIRECT_OWNER_RETURN") == "1"
+            and os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_GLOBAL_GRAD_RETURN") == "1"
+        )
+        if direct_owner_return:
+            if q_fa4.shape[0] != 1 or int(prefix1) % int(half) != 0 or int(prefix2) % int(half) != 0:
+                raise NvshmemCpFaOwnerError(
+                    "FA4 direct owner return currently expects B=1 and prefix lengths "
+                    "aligned to CP half chunks."
+                )
+            dq = dq_fa4.view(dq_fa4.shape[1], 1, dq_fa4.shape[2], dq_fa4.shape[3])
+            native_direct_return = (
+                os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_NATIVE_DIRECT_OWNER_RETURN") == "1"
+            )
+            if native_direct_return:
+                tex = _import_te_for_native_fused_owner()
+                native_return = getattr(
+                    tex, "nvshmem_cp_two_prefix_direct_owner_grad_return_execute", None
+                )
+                if native_return is None:
+                    available = [
+                        name
+                        for name in dir(tex)
+                        if "grad_return" in name or "two_prefix" in name
+                    ]
+                    raise NvshmemCpFaOwnerError(
+                        "MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_NATIVE_DIRECT_OWNER_RETURN=1 "
+                        "requires transformer_engine_torch."
+                        "nvshmem_cp_two_prefix_direct_owner_grad_return_execute. "
+                        f"loaded_module={getattr(tex, '__file__', '<unknown>')} "
+                        f"available_related={available}"
+                    )
+                dk, dv = native_return(
+                    dk1,
+                    dv1,
+                    dk2,
+                    dv2,
+                    int(prefix1),
+                    int(prefix2),
+                    peer_keys[cp_rank],
+                    peer_values[cp_rank],
+                    ws.grad_key_return,
+                    ws.grad_value_return,
+                    ws.grad_committed_epoch,
+                    ws.peer_grad_key_returns,
+                    ws.peer_grad_value_returns,
+                    ws.peer_grad_committed_epochs,
+                    4,
+                    cp_rank,
+                )
+                record_phase("after_native_direct_owner_return")
+                if phase_timing:
+                    phase_events[-1][1].synchronize()
+                    phases_ms = {
+                        f"{left_name}_to_{right_name}_ms": left_event.elapsed_time(right_event)
+                        for (left_name, left_event), (right_name, right_event) in zip(
+                            phase_events, phase_events[1:]
+                        )
+                    }
+                    print(
+                        "[branch-b-fa4-bwd-phase] "
+                        + json.dumps(
+                            {
+                                "cp_rank": cp_rank,
+                                "direct_owner_return": True,
+                                "native_direct_owner_return": True,
+                                "phases_ms": phases_ms,
+                            },
+                            sort_keys=True,
+                        ),
+                        flush=True,
+                    )
+                return dq, dk, dv
+            prefix1_chunks = int(prefix1) // int(half)
+            prefix2_chunks = int(prefix2) // int(half)
+
+            def _return_slot(tensor: torch.Tensor, owner: int) -> torch.Tensor:
+                if tensor.dim() == peer_keys[cp_rank].dim() + 1:
+                    return tensor[cp_rank]
+                return tensor
+
+            def _copy_chunk(
+                *,
+                dst: torch.Tensor,
+                src1: torch.Tensor,
+                src2: torch.Tensor,
+                chunk: int,
+                half_index: int,
+            ) -> None:
+                dst_half = dst.narrow(0, half_index * half, half)
+                dst_half.zero_()
+                if chunk < prefix2_chunks:
+                    src2_chunk = src2.narrow(1, chunk * half, half).view_as(dst_half)
+                    dst_half.copy_(src2_chunk)
+                if chunk < prefix1_chunks:
+                    src1_chunk = src1.narrow(1, chunk * half, half).view_as(dst_half)
+                    dst_half.add_(src1_chunk)
+
+            for owner in range(4):
+                key_slot = _return_slot(ws.peer_grad_key_returns[owner], owner)
+                value_slot = _return_slot(ws.peer_grad_value_returns[owner], owner)
+                _copy_chunk(dst=key_slot, src1=dk1, src2=dk2, chunk=owner, half_index=0)
+                _copy_chunk(dst=key_slot, src1=dk1, src2=dk2, chunk=7 - owner, half_index=1)
+                _copy_chunk(dst=value_slot, src1=dv1, src2=dv2, chunk=owner, half_index=0)
+                _copy_chunk(dst=value_slot, src1=dv1, src2=dv2, chunk=7 - owner, half_index=1)
+
+            if torch.cuda.is_available() and grad_output.is_cuda:
+                torch.cuda.current_stream().synchronize()
+            epoch = _next_grad_return_epoch(ws)
+            for owner in range(4):
+                peer_epoch = ws.peer_grad_committed_epochs[owner]
+                if peer_epoch.dim() >= 1 and peer_epoch.size(0) > cp_rank:
+                    peer_epoch[cp_rank] = epoch
+                else:
+                    peer_epoch.fill_(epoch)
+            _wait_for_grad_committed_epoch(ws, epoch, _sync_timeout_seconds())
+            dk = ws.grad_key_return.sum(dim=0).to(peer_keys[cp_rank].dtype)
+            dv = ws.grad_value_return.sum(dim=0).to(peer_values[cp_rank].dtype)
+            record_phase("after_direct_owner_return")
+            if phase_timing:
+                phase_events[-1][1].synchronize()
+                phases_ms = {
+                    f"{left_name}_to_{right_name}_ms": left_event.elapsed_time(right_event)
+                    for (left_name, left_event), (right_name, right_event) in zip(
+                        phase_events, phase_events[1:]
+                    )
+                }
+                print(
+                    "[branch-b-fa4-bwd-phase] "
+                    + json.dumps(
+                        {
+                            "cp_rank": cp_rank,
+                            "direct_owner_return": True,
+                            "phases_ms": phases_ms,
+                        },
+                        sort_keys=True,
+                    ),
+                    flush=True,
+                )
+            return dq, dk, dv
+        if prefix2 == k_fa4.shape[1]:
+            dk_fa4 = dk2
+            dv_fa4 = dv2
+        else:
+            dk_fa4 = torch.zeros_like(k_fa4)
+            dv_fa4 = torch.zeros_like(v_fa4)
+            dk_fa4[:, :prefix2].copy_(dk2)
+            dv_fa4[:, :prefix2].copy_(dv2)
+        dk_fa4[:, :prefix1].add_(dk1)
+        dv_fa4[:, :prefix1].add_(dv1)
+        record_phase("after_global_assembly")
+    else:
+        (
+            q_fa4, k_fa4, v_fa4, out_fa4, lse, p, row_max, mask_mod,
+            softmax_scale, block_sparse_bwd,
+        ) = fa4_state
+        dq_fa4, dk_fa4, dv_fa4 = _FA4_BWD(
+            q_fa4,
+            k_fa4,
+            v_fa4,
+            out_fa4,
+            grad_output.transpose(0, 1).contiguous(),
+            lse,
+            softmax_scale=softmax_scale,
+            mask_mod=mask_mod,
+            block_sparse_tensors=block_sparse_bwd,
+        )
+    if dq_fa4.shape[0] == 1:
+        dq = dq_fa4.view(dq_fa4.shape[1], 1, dq_fa4.shape[2], dq_fa4.shape[3])
+        dk_global = dk_fa4.view(
+            dk_fa4.shape[1], 1, dk_fa4.shape[2], dk_fa4.shape[3]
+        )
+        dv_global = dv_fa4.view(
+            dv_fa4.shape[1], 1, dv_fa4.shape[2], dv_fa4.shape[3]
+        )
+    else:
+        dq = dq_fa4.transpose(0, 1).contiguous()
+        dk_global = dk_fa4.transpose(0, 1).contiguous()
+        dv_global = dv_fa4.transpose(0, 1).contiguous()
+    if os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_GLOBAL_GRAD_RETURN") == "1":
+        if os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_TORCH_GLOBAL_GRAD_RETURN") == "1":
+            dk, dv = torch_global_grad_return(dk_global, dv_global)
+            record_phase("after_torch_global_grad_return")
+            return dq, dk, dv
+        if os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_NATIVE_TE_CP4_SUBSET_RETURN") == "1":
+            subset_return = getattr(tex, "nvshmem_cp_global_grad_return_subset_execute", None)
+            if subset_return is None:
+                raise NvshmemCpFaOwnerError(
+                    "MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_NATIVE_TE_CP4_SUBSET_RETURN=1 "
+                    "requires transformer_engine_torch."
+                    "nvshmem_cp_global_grad_return_subset_execute."
+                )
+            source_table = {
+                0: [[0, 1, 2, 3], [0]],
+                1: [[0, 1, 2, 3], [0, 1]],
+                2: [[0, 1, 2, 3], [0, 1, 2]],
+                3: [[0, 1, 2, 3], [0, 1, 2, 3]],
+            }
+            dk, dv = subset_return(
+                dk_global,
+                dv_global,
+                peer_keys[cp_rank],
+                peer_values[cp_rank],
+                ws.grad_key_return,
+                ws.grad_value_return,
+                ws.grad_committed_epoch,
+                ws.peer_grad_key_returns,
+                ws.peer_grad_value_returns,
+                ws.peer_grad_committed_epochs,
+                source_table[int(cp_rank)],
+                4,
+                cp_rank,
+            )
+            record_phase("after_native_te_cp4_subset_grad_return")
+            emit_phase_report(native_te_cp4_subset_return=True)
+            return dq, dk, dv
+        global_return = getattr(tex, "nvshmem_cp_global_grad_return_execute", None)
+        if global_return is None:
+            raise NvshmemCpFaOwnerError(
+                "MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_GLOBAL_GRAD_RETURN=1 requires "
+                "transformer_engine_torch.nvshmem_cp_global_grad_return_execute."
+            )
+        dk, dv = global_return(
+            dk_global,
+            dv_global,
+            peer_keys[cp_rank],
+            peer_values[cp_rank],
+            ws.grad_key_return,
+            ws.grad_value_return,
+            ws.grad_committed_epoch,
+            ws.peer_grad_key_returns,
+            ws.peer_grad_value_returns,
+            ws.peer_grad_committed_epochs,
+            4,
+            cp_rank,
+        )
+        record_phase("after_grad_return")
+        if phase_timing:
+            phase_events[-1][1].synchronize()
+            phases_ms = {
+                f"{left_name}_to_{right_name}_ms": left_event.elapsed_time(right_event)
+                for (left_name, left_event), (right_name, right_event) in zip(
+                    phase_events, phase_events[1:]
+                )
+            }
+            print(
+                "[branch-b-fa4-bwd-phase] "
+                + json.dumps({"cp_rank": cp_rank, "phases_ms": phases_ms}, sort_keys=True),
+                flush=True,
+            )
+        return dq, dk, dv
+    half = int(dq.shape[0]) // 2
+    dk_chunks = list(dk_global.split(half, dim=0))
+    dv_chunks = list(dv_global.split(half, dim=0))
+    dk_by_owner = [
+        torch.cat((dk_chunks[owner], dk_chunks[7 - owner]), dim=0)
+        for owner in range(4)
+    ]
+    dv_by_owner = [
+        torch.cat((dv_chunks[owner], dv_chunks[7 - owner]), dim=0)
+        for owner in range(4)
+    ]
+    dk, dv = tex.nvshmem_cp_prefix_grad_return_execute(
+        dk_by_owner,
+        dv_by_owner,
+        peer_keys[cp_rank],
+        peer_values[cp_rank],
+        ws.grad_key_return,
+        ws.grad_value_return,
+        ws.grad_committed_epoch,
+        ws.peer_grad_key_returns,
+        ws.peer_grad_value_returns,
+        ws.peer_grad_committed_epochs,
+        4,
+        cp_rank,
+    )
+    return dq, dk, dv
+
+
+class _BlockReadyNativeFusedOwnerAutograd(torch.autograd.Function):
+    """Training boundary for the production Branch-B native fused owner.
+
+    The forward native symbol must return attention output plus saved forward
+    aux tensors. The backward native symbol consumes those aux tensors and
+    grad_output, owns dQ and owner dK/dV computation, and returns remote K/V
+    gradients through NVSHMEM symmetric gradient-return buffers. This class
+    intentionally fails closed if either symbol or contract is missing.
+    """
+
+    @staticmethod
+    def forward(ctx, query: torch.Tensor, key: torch.Tensor, value: torch.Tensor, is_causal: bool, layer_number):
+        deferred_timing = (
+            os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_DEFERRED_PHASE_EVENTS") == "1"
+            and query.is_cuda
+        )
+        deferred_forward_start = deferred_forward_end = None
+        if deferred_timing:
+            deferred_forward_start = torch.cuda.Event(enable_timing=True)
+            deferred_forward_end = torch.cuda.Event(enable_timing=True)
+            deferred_forward_start.record()
+        try:
+            tex = _import_te_for_native_fused_owner()
+        except ImportError as exc:
+            raise NvshmemCpFaOwnerError(
+                "MEGATRON_NVSHMEM_CP_FA_OWNER_IO_V1_BACKWARD_IMPL="
+                "block_ready_native_fused requires transformer_engine_torch with "
+                "nvshmem_cp_block_ready_fused_owner_execute and "
+                "nvshmem_cp_block_ready_fused_owner_backward_execute."
+            ) from exc
+
+        native_owner = getattr(tex, "nvshmem_cp_block_ready_fused_owner_execute", None)
+        native_backward = getattr(tex, "nvshmem_cp_block_ready_fused_owner_backward_execute", None)
+        if native_owner is None or native_backward is None:
+            raise NvshmemCpFaOwnerError(
+                "MEGATRON_NVSHMEM_CP_FA_OWNER_IO_V1_BACKWARD_IMPL="
+                "block_ready_native_fused requires native fused Branch-B owner symbols "
+                "named nvshmem_cp_block_ready_fused_owner_execute and "
+                "nvshmem_cp_block_ready_fused_owner_backward_execute. The symbols must "
+                "consume symmetric peer K/V plus block-ready flags, save forward aux tensors, "
+                "compute memory-safe forward attention, implement backward dQ and owner dK/dV, "
+                "and return remote K/V gradients without Python-staged large buffers."
+            )
+
+        if os.getenv("MEGATRON_NVSHMEM_CP_BLOCK_READY_PROTOCOL") != "1":
+            raise NvshmemCpFaOwnerError(
+                "block_ready_native_fused requires MEGATRON_NVSHMEM_CP_BLOCK_READY_PROTOCOL=1."
+            )
+        if not bool(is_causal):
+            raise NvshmemCpFaOwnerError("block_ready_native_fused currently targets causal CP attention.")
+
+        if os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_GLOBAL") == "1":
+            from megatron.core import parallel_state
+
+            _branch_b_fa4_prewarm(
+                query,
+                int(parallel_state.get_context_parallel_rank()),
+                int(parallel_state.get_context_parallel_world_size()),
+            )
+        ws = _workspace(key.shape, key.dtype, key.device, layer_number)
+        cp_size = len(ws.cp_group_ranks)
+        rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
+        try:
+            cp_rank = ws.cp_group_ranks.index(int(rank))
+        except ValueError as exc:
+            raise NvshmemCpFaOwnerError(
+                f"Global rank {rank} is not in the NVSHMEM CP group {ws.cp_group_ranks}."
+            ) from exc
+
+        if os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_CLEAR_GRAD_RETURN_BEFORE_FORWARD") == "1":
+            with torch.no_grad():
+                ws.grad_key_return.zero_()
+                ws.grad_value_return.zero_()
+                if (
+                    os.getenv(
+                        "MEGATRON_NVSHMEM_CP_BRANCH_B_RESET_GRAD_EPOCH_BEFORE_FORWARD"
+                    )
+                    == "1"
+                ):
+                    ws.grad_committed_epoch.zero_()
+                if (
+                    os.getenv(
+                        "MEGATRON_NVSHMEM_CP_BRANCH_B_RESET_CARRIER_EPOCH_BEFORE_FORWARD"
+                    )
+                    == "1"
+                    and getattr(ws, "carrier_epoch", None) is not None
+                    and ws.carrier_epoch.numel() > 0
+                ):
+                    ws.carrier_epoch.zero_()
+            if torch.cuda.is_available() and query.is_cuda:
+                torch.cuda.current_stream().synchronize()
+        with torch.no_grad():
+            if ws.key.data_ptr() != key.data_ptr():
+                raise NvshmemCpFaOwnerError(
+                    "block_ready_native_fused requires K to already reside in the NVSHMEM symmetric workspace. "
+                    "Use a zero-copy producer; do not copy K here."
+                )
+            if ws.value.data_ptr() != value.data_ptr():
+                raise NvshmemCpFaOwnerError(
+                    "block_ready_native_fused requires V to already reside in the NVSHMEM symmetric workspace. "
+                    "Use a zero-copy producer; do not copy V here."
+                )
+        timing_on = cp_timing_enabled()
+        forward_total_t0 = time.perf_counter() if timing_on else None
+        publish_t0 = time.perf_counter() if timing_on else None
+        with torch.no_grad():
+            forward_epoch = int(ws.block_ready_epoch.detach().min().item()) + 1
+            _publish_block_ready_epoch(ws, forward_epoch)
+        publish_wall_ms = (
+            (time.perf_counter() - publish_t0) * 1000.0
+            if publish_t0 is not None
+            else None
+        )
+        skip_global_wait = (
+            os.getenv("MEGATRON_NVSHMEM_CP_BLOCK_READY_NATIVE_FUSED_SKIP_GLOBAL_WAIT") == "1"
+        )
+        native_peer_wait = (
+            os.getenv("MEGATRON_NVSHMEM_CP_BLOCK_READY_NATIVE_FUSED_PEER_WAIT") == "1"
+        )
+        stream_wait = os.getenv("MEGATRON_NVSHMEM_CP_BLOCK_READY_STREAM_WAIT") == "1"
+        if skip_global_wait and not native_peer_wait:
+            raise NvshmemCpFaOwnerError(
+                "MEGATRON_NVSHMEM_CP_BLOCK_READY_NATIVE_FUSED_SKIP_GLOBAL_WAIT=1 requires "
+                "MEGATRON_NVSHMEM_CP_BLOCK_READY_NATIVE_FUSED_PEER_WAIT=1 so peer K/V is "
+                "stream-waited in the native owner before consumption."
+            )
+        if stream_wait and native_peer_wait:
+            raise NvshmemCpFaOwnerError(
+                "MEGATRON_NVSHMEM_CP_BLOCK_READY_STREAM_WAIT=1 is a pre-owner block-ready "
+                "wait and must not be combined with per-section native peer wait."
+            )
+        wait_t0 = time.perf_counter() if timing_on else None
+        if not skip_global_wait:
+            if stream_wait:
+                stream_wait_fn = getattr(
+                    tex, "nvshmem_block_ready_wait_int32_on_current_stream", None
+                )
+                if stream_wait_fn is None:
+                    raise NvshmemCpFaOwnerError(
+                        "MEGATRON_NVSHMEM_CP_BLOCK_READY_STREAM_WAIT=1 requires a rebuilt "
+                        "transformer_engine_torch exposing "
+                        "nvshmem_block_ready_wait_int32_on_current_stream."
+                    )
+                for peer_epoch in ws.peer_block_ready_epochs:
+                    stream_wait_fn(peer_epoch, int(forward_epoch))
+            else:
+                if torch.cuda.is_available() and query.is_cuda:
+                    torch.cuda.current_stream().synchronize()
+                _wait_for_block_ready_epoch(ws, forward_epoch, _sync_timeout_seconds())
+        wait_wall_ms = (
+            (time.perf_counter() - wait_t0) * 1000.0 if wait_t0 is not None else None
+        )
+        native_start = native_end = None
+        if timing_on and torch.cuda.is_available() and query.is_cuda:
+            native_start = torch.cuda.Event(enable_timing=True)
+            native_end = torch.cuda.Event(enable_timing=True)
+            native_start.record()
+        native_peer_keys = list(ws.peer_keys)
+        native_peer_values = list(ws.peer_values)
+        reuse_staged_peer_kv = (
+            os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_PY_STAGE_REMOTE_KV_REUSE_BWD") == "1"
+        )
+        pipelined_stage = (
+            os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_PY_PIPELINED_STAGE") == "1"
+        )
+        if reuse_staged_peer_kv and not pipelined_stage:
+            # TE fused-attention kernels lose locality when they repeatedly load
+            # mapped peer memory. Stage only remote owners once and retain the
+            # local copies for backward; the local owner's symmetric tensors are
+            # already device-local and need no copy.
+            _branch_b_fa4_trace(cp_rank, "F01 before_peer_stage")
+            native_peer_keys = [
+                peer_key
+                if peer == cp_rank
+                else peer_key.clone(memory_format=torch.contiguous_format)
+                for peer, peer_key in enumerate(native_peer_keys)
+            ]
+            native_peer_values = [
+                peer_value
+                if peer == cp_rank
+                else peer_value.clone(memory_format=torch.contiguous_format)
+                for peer, peer_value in enumerate(native_peer_values)
+            ]
+            torch.cuda.current_stream().synchronize()
+            _branch_b_fa4_trace(cp_rank, "F02 after_peer_stage")
+
+        fa4_global = (
+            os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_GLOBAL") == "1"
+        )
+        fa4_state = None
+        if fa4_global:
+            _branch_b_fa4_trace(cp_rank, "F03 enter_fa4_branch")
+            native_query = query.contiguous()
+            output, fa4_state = _branch_b_fa4_global_forward(
+                native_query,
+                native_peer_keys,
+                native_peer_values,
+                cp_rank,
+                list(ws.cp_group_ranks),
+                int(layer_number or 0),
+            )
+            # The FA4 autograd graph owns its LSE and row-max state. Keep a
+            # tensor placeholder so the surrounding Branch-B save contract
+            # remains non-empty without exposing FA4 private auxiliaries.
+            forward_aux_tensors = [torch.empty(0, device=query.device)]
+            result = (output, forward_aux_tensors)
+        elif pipelined_stage:
+            (
+                output,
+                forward_aux_tensors,
+                native_peer_keys,
+                native_peer_values,
+                native_query,
+            ) = (
+                _branch_b_pipelined_stage_forward(
+                    tex=tex,
+                    query=query,
+                    peer_keys=native_peer_keys,
+                    peer_values=native_peer_values,
+                    peer_pes=list(ws.cp_group_ranks),
+                    cp_rank=cp_rank,
+                )
+            )
+            result = (output, forward_aux_tensors)
+            reuse_staged_peer_kv = True
+        else:
+            native_query = query.contiguous()
+            result = native_owner(
+                native_query,
+                key,
+                value,
+                native_peer_keys,
+                native_peer_values,
+                ws.block_ready_epoch,
+                ws.peer_block_ready_epochs,
+                ws.grad_key_return,
+                ws.grad_value_return,
+                ws.grad_committed_epoch,
+                ws.peer_grad_key_returns,
+                ws.peer_grad_value_returns,
+                ws.peer_grad_committed_epochs,
+                cp_size,
+                cp_rank,
+                "sbhd",
+                True,
+            )
+        native_forward_ms = None
+        if native_end is not None and native_start is not None:
+            native_end.record()
+            native_end.synchronize()
+            native_forward_ms = float(native_start.elapsed_time(native_end))
+        if not (isinstance(result, (list, tuple)) and len(result) == 2):
+            raise NvshmemCpFaOwnerError(
+                "nvshmem_cp_block_ready_fused_owner_execute must return "
+                "(attention_output, forward_aux_tensors). The saved forward aux tensors are "
+                "required for nvshmem_cp_block_ready_fused_owner_backward_execute."
+            )
+        output, forward_aux_tensors = result
+        if not isinstance(forward_aux_tensors, (list, tuple)) or not forward_aux_tensors:
+            raise NvshmemCpFaOwnerError(
+                "nvshmem_cp_block_ready_fused_owner_execute must return non-empty saved forward_aux_tensors "
+                "including softmax LSE/RNG state for the native fused backward."
+            )
+        if output.shape != query.shape:
+            raise NvshmemCpFaOwnerError(
+                f"nvshmem_cp_block_ready_fused_owner_execute returned output shape {list(output.shape)}, "
+                f"expected {list(query.shape)}."
+            )
+        if timing_on:
+            record_cp_timing(
+                {
+                    "event": "branch_b_native_fused_owner_forward",
+                    "layer_number": layer_number,
+                    "cp_rank": int(cp_rank),
+                    "cp_world_size": int(cp_size),
+                    "query": tensor_meta(query),
+                    "key": tensor_meta(key),
+                    "value": tensor_meta(value),
+                    "output": tensor_meta(output),
+                    "forward_aux_count": int(len(forward_aux_tensors)),
+                    "publish_wall_ms": publish_wall_ms,
+                    "block_ready_wait_wall_ms": wait_wall_ms,
+                    "native_forward_elapsed_ms": native_forward_ms,
+                    "elapsed_ms": (
+                        (time.perf_counter() - forward_total_t0) * 1000.0
+                        if forward_total_t0 is not None
+                        else None
+                    ),
+                    "skip_global_wait": bool(skip_global_wait),
+                    "native_peer_wait": bool(native_peer_wait),
+                    "block_ready_stream_wait": bool(stream_wait),
+                    "timing_scope": "Branch-B native fused owner forward; diagnostic timing may perturb runtime.",
+                }
+            )
+
+        ctx.ws = ws
+        ctx.cp_rank = cp_rank
+        ctx.cp_size = cp_size
+        ctx.layer_number = layer_number
+        ctx.native_backward = native_backward
+        ctx.forward_aux_tensors = list(forward_aux_tensors)
+        ctx.native_peer_keys = native_peer_keys
+        ctx.native_peer_values = native_peer_values
+        ctx.reuse_staged_peer_kv = reuse_staged_peer_kv
+        ctx.pipelined_stage = pipelined_stage
+        ctx.fa4_global = fa4_global
+        ctx.fa4_state = fa4_state
+        ctx.two_prefix_attention = (
+            pipelined_stage
+            and os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_TWO_PREFIX_ATTENTION") == "1"
+        )
+        ctx.two_prefix_native_section_backward = (
+            ctx.two_prefix_attention
+            and os.getenv(
+                "MEGATRON_NVSHMEM_CP_BRANCH_B_TWO_PREFIX_NATIVE_SECTION_BACKWARD"
+            )
+            == "1"
+        )
+        ctx.is_causal = bool(is_causal)
+        ctx.softmax_scale = 1.0 / math.sqrt(float(query.shape[-1]))
+        ctx.query_dtype = query.dtype
+        ctx.key_dtype = key.dtype
+        ctx.value_dtype = value.dtype
+        ctx.forward_aux_count = len(forward_aux_tensors)
+        if deferred_forward_end is not None:
+            deferred_forward_end.record()
+        ctx.deferred_forward_start = deferred_forward_start
+        ctx.deferred_forward_end = deferred_forward_end
+        ctx.save_for_backward(native_query, key, value, output, *forward_aux_tensors)
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        deferred_backward_start = deferred_backward_end = None
+        if ctx.deferred_forward_start is not None:
+            deferred_backward_start = torch.cuda.Event(enable_timing=True)
+            deferred_backward_end = torch.cuda.Event(enable_timing=True)
+            deferred_backward_start.record()
+        saved = ctx.saved_tensors
+        query, key, value, output = saved[:4]
+        forward_aux_tensors = list(saved[4 : 4 + ctx.forward_aux_count])
+        ws = ctx.ws
+        rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
+        layer_number = int(getattr(ctx, "layer_number", 0) or 0)
+        call_key = (int(rank), layer_number)
+        call_index = _NATIVE_FUSED_BACKWARD_CALL_COUNTERS.get(call_key, 0)
+        _NATIVE_FUSED_BACKWARD_CALL_COUNTERS[call_key] = call_index + 1
+        if os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_CLEAR_GRAD_RETURN_BEFORE_BACKWARD") == "1":
+            ws.grad_key_return.zero_()
+            ws.grad_value_return.zero_()
+            if getattr(ws, "raw_key_return", None) is not None and ws.raw_key_return.numel() > 0:
+                ws.raw_key_return.zero_()
+                ws.raw_value_return.zero_()
+            if torch.cuda.is_available() and grad_output.is_cuda:
+                torch.cuda.current_stream().synchronize()
+        timing_on = cp_timing_enabled()
+        backward_total_t0 = time.perf_counter() if timing_on else None
+        native_start = native_end = None
+        if timing_on and torch.cuda.is_available() and grad_output.is_cuda:
+            if (
+                os.getenv("MEGATRON_NVSHMEM_CP_BACKWARD_DEVICE_SYNC_TIMING") == "1"
+            ):
+                torch.cuda.synchronize(grad_output.device)
+            native_start = torch.cuda.Event(enable_timing=True)
+            native_end = torch.cuda.Event(enable_timing=True)
+            native_start.record()
+        native_peer_keys = (
+            ctx.native_peer_keys if ctx.reuse_staged_peer_kv else list(ws.peer_keys)
+        )
+        native_peer_values = (
+            ctx.native_peer_values if ctx.reuse_staged_peer_kv else list(ws.peer_values)
+        )
+        concurrent_sections_backward = (
+            os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_CONCURRENT_BACKWARD_SECTIONS") == "1"
+        )
+        grouped_sections_backward = (
+            os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_GROUPED_BACKWARD_SECTIONS") == "1"
+        )
+        true_fused_no_te_bwd = (
+            os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_TRUE_FUSED_BACKWARD_NO_TE_BWD") == "1"
+        )
+        if true_fused_no_te_bwd:
+            tex = _import_te_for_native_fused_owner()
+            helper = getattr(
+                tex,
+                "nvshmem_cp_branch_b_true_fused_backward_no_te_bwd_execute",
+                None,
+            )
+            if helper is None:
+                raise NvshmemCpFaOwnerError(
+                    "Branch-B true fused backward selected, but TE does not expose "
+                    "nvshmem_cp_branch_b_true_fused_backward_no_te_bwd_execute. "
+                    "This path is intentionally fail-closed: the next production candidate "
+                    "must avoid TE grouped/section backward calls rather than falling back to "
+                    "grouped-call helpers or the default native section loop."
+                )
+            fused = helper(
+                query,
+                native_peer_keys,
+                native_peer_values,
+                output,
+                grad_output,
+                forward_aux_tensors,
+                int(ctx.cp_rank),
+                "sbhd",
+                float(ctx.softmax_scale),
+                False,
+            )
+            if len(fused) != 9:
+                raise NvshmemCpFaOwnerError(
+                    "Branch-B true fused backward TE helper must return "
+                    "[dq, dk0, dk1, dk2, dk3, dv0, dv1, dv2, dv3]."
+                )
+            dq = fused[0]
+            dk_by_owner = list(fused[1:5])
+            dv_by_owner = list(fused[5:9])
+            dk, dv = tex.nvshmem_cp_prefix_grad_return_execute(
+                dk_by_owner,
+                dv_by_owner,
+                native_peer_keys[ctx.cp_rank],
+                native_peer_values[ctx.cp_rank],
+                ws.grad_key_return,
+                ws.grad_value_return,
+                ws.grad_committed_epoch,
+                ws.peer_grad_key_returns,
+                ws.peer_grad_value_returns,
+                ws.peer_grad_committed_epochs,
+                4,
+                ctx.cp_rank,
+            )
+            result = (dq, dk, dv)
+        elif ctx.fa4_global:
+            tex = _import_te_for_native_fused_owner()
+            result = _branch_b_fa4_global_backward(
+                tex=tex,
+                fa4_state=ctx.fa4_state,
+                grad_output=grad_output,
+                peer_keys=native_peer_keys,
+                peer_values=native_peer_values,
+                ws=ws,
+                cp_rank=ctx.cp_rank,
+            )
+        elif grouped_sections_backward:
+            tex = _import_te_for_native_fused_owner()
+            result = _branch_b_grouped_sections_backward(
+                tex=tex,
+                query=query,
+                peer_keys=native_peer_keys,
+                peer_values=native_peer_values,
+                output=output,
+                grad_output=grad_output,
+                forward_aux=forward_aux_tensors,
+                ws=ws,
+                cp_rank=ctx.cp_rank,
+                softmax_scale=ctx.softmax_scale,
+            )
+        elif concurrent_sections_backward:
+            tex = _import_te_for_native_fused_owner()
+            result = _branch_b_concurrent_sections_backward(
+                tex=tex,
+                query=query,
+                peer_keys=native_peer_keys,
+                peer_values=native_peer_values,
+                output=output,
+                grad_output=grad_output,
+                forward_aux=forward_aux_tensors,
+                ws=ws,
+                cp_rank=ctx.cp_rank,
+                softmax_scale=ctx.softmax_scale,
+            )
+        elif ctx.two_prefix_attention and not ctx.two_prefix_native_section_backward:
+            tex = _import_te_for_native_fused_owner()
+            result = _branch_b_two_prefix_backward(
+                tex=tex,
+                query=query,
+                peer_keys=native_peer_keys,
+                peer_values=native_peer_values,
+                output=output,
+                grad_output=grad_output,
+                forward_aux=forward_aux_tensors,
+                ws=ws,
+                cp_rank=ctx.cp_rank,
+                softmax_scale=ctx.softmax_scale,
+            )
+        else:
+            result = ctx.native_backward(
+                query,
+                key,
+                value,
+                native_peer_keys,
+                native_peer_values,
+                output,
+                grad_output,
+                forward_aux_tensors,
+                ws.block_ready_epoch,
+                ws.peer_block_ready_epochs,
+                ws.grad_key_return,
+                ws.grad_value_return,
+                ws.grad_committed_epoch,
+                ws.peer_grad_key_returns,
+                ws.peer_grad_value_returns,
+                ws.peer_grad_committed_epochs,
+                ws.raw_key_return,
+                ws.raw_value_return,
+                list(ws.peer_raw_key_returns),
+                list(ws.peer_raw_value_returns),
+                ws.carrier_key_slots,
+                ws.carrier_value_slots,
+                ws.carrier_epoch,
+                ws.peer_carrier_key_slots,
+                ws.peer_carrier_value_slots,
+                ws.peer_carrier_epochs,
+                ctx.cp_size,
+                ctx.cp_rank,
+                "sbhd",
+                ctx.is_causal,
+                float(ctx.softmax_scale),
+                0.0,
+            )
+        native_backward_ms = None
+        if native_end is not None and native_start is not None:
+            if (
+                os.getenv("MEGATRON_NVSHMEM_CP_BACKWARD_DEVICE_SYNC_TIMING") == "1"
+            ):
+                torch.cuda.synchronize(grad_output.device)
+            native_end.record()
+            native_end.synchronize()
+            native_backward_ms = float(native_start.elapsed_time(native_end))
+        if not (isinstance(result, (list, tuple)) and len(result) == 3):
+            raise NvshmemCpFaOwnerError(
+                "nvshmem_cp_block_ready_fused_owner_backward_execute must return "
+                "(grad_query, grad_key, grad_value) and own remote K/V gradient return internally."
+            )
+        dq, dk, dv = result
+        post_native_sync_t0 = time.perf_counter() if timing_on else None
+        skip_post_native_sync = (
+            os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_SKIP_POST_NATIVE_BACKWARD_SYNC") == "1"
+        )
+        if torch.cuda.is_available() and grad_output.is_cuda and not skip_post_native_sync:
+            torch.cuda.current_stream().synchronize()
+        post_native_sync_wall_ms = (
+            (time.perf_counter() - post_native_sync_t0) * 1000.0
+            if post_native_sync_t0 is not None
+            else None
+        )
+        if timing_on:
+            record_cp_timing(
+                {
+                    "event": "branch_b_native_fused_owner_backward",
+                    "layer_number": getattr(ctx, "layer_number", None),
+                    "call_index": int(call_index),
+                    "cp_rank": int(ctx.cp_rank),
+                    "cp_world_size": int(ctx.cp_size),
+                    "grad_output": tensor_meta(grad_output),
+                    "dq": tensor_meta(dq),
+                    "dk": tensor_meta(dk),
+                    "dv": tensor_meta(dv),
+                    "grad_key_return": tensor_meta(ws.grad_key_return),
+                    "grad_value_return": tensor_meta(ws.grad_value_return),
+                    "native_backward_elapsed_ms": native_backward_ms,
+                    "post_native_sync_wall_ms": post_native_sync_wall_ms,
+                    "elapsed_ms": (
+                        (time.perf_counter() - backward_total_t0) * 1000.0
+                        if backward_total_t0 is not None
+                        else None
+                    ),
+                    "skip_post_native_sync": bool(skip_post_native_sync),
+                    "timing_scope": "Branch-B native fused owner backward; diagnostic timing may perturb runtime.",
+                }
+            )
+        if os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_EVICT_WORKSPACE_AFTER_BACKWARD") == "1":
+            import megatron.core.transformer.nvshmem_cp_attention as nvshmem_cp_attention
+
+            ws_key = (
+                tuple(key.shape),
+                str(key.dtype),
+                int(key.device.index or 0),
+                int(getattr(ctx, "layer_number", None) or 0),
+            )
+            nvshmem_cp_attention._WORKSPACES.pop(ws_key, None)
+        if deferred_backward_end is not None:
+            deferred_backward_end.record()
+            _BRANCH_B_DEFERRED_PHASE_EVENTS.append(
+                {
+                    "layer_number": layer_number,
+                    "cp_rank": int(ctx.cp_rank),
+                    "forward_start": ctx.deferred_forward_start,
+                    "forward_end": ctx.deferred_forward_end,
+                    "backward_start": deferred_backward_start,
+                    "backward_end": deferred_backward_end,
+                }
+            )
+        return dq.to(ctx.query_dtype), dk.to(ctx.key_dtype), dv.to(ctx.value_dtype), None, None
+
+
+def _phase_timing_enabled() -> bool:
+    return cp_timing_enabled() and os.getenv("MEGATRON_NVSHMEM_CP_OWNER_PHASE_TIMING") == "1"
+
+
+def _phase_start():
+    if not _phase_timing_enabled():
+        return None
+    event = torch.cuda.Event(enable_timing=True)
+    event.record()
+    return event
+
+
+def _phase_end(start_event, event_name: str, **metadata) -> None:
+    if start_event is None:
+        return
+    end_event = torch.cuda.Event(enable_timing=True)
+    end_event.record()
+    end_event.synchronize()
+    record_cp_timing(
+        {
+            "event": event_name,
+            "elapsed_ms": float(start_event.elapsed_time(end_event)),
+            **metadata,
+        }
+    )
+
+
+class _PublishSymmetricKV(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, key: torch.Tensor, value: torch.Tensor, layer_number):
+        ws = _workspace(tuple(key.shape), key.dtype, key.device, layer_number)
+        ws.key.copy_(key)
+        ws.value.copy_(value)
+        return ws.key, ws.value
+
+    @staticmethod
+    def backward(ctx, grad_key, grad_value):
+        return grad_key, grad_value, None
+
+
+def _normal_qkv_publish(module, hidden_states):
+    query, key_normal, value_normal = module.get_query_key_value_tensors(hidden_states)
+    key, value = _PublishSymmetricKV.apply(key_normal, value_normal, module.layer_number)
+    return query, key, value, key_normal, value_normal
+
+
+def nvshmem_cp_symmetric_qkv_self_attention_forward(
+    *,
+    module,
+    hidden_states: torch.Tensor,
+    attention_mask: torch.Tensor,
+    key_value_states: torch.Tensor | None = None,
+    inference_context=None,
+    rotary_pos_emb=None,
+    rotary_pos_cos=None,
+    rotary_pos_sin=None,
+    rotary_pos_cos_sin=None,
+    attention_bias=None,
+    packed_seq_params=None,
+    sequence_len_offset: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Run the fail-closed symmetric-QKV backend at the Megatron attention boundary."""
+
+    unsupported = {
+        "key_value_states": key_value_states,
+        "inference_context": inference_context,
+        "rotary_pos_emb": rotary_pos_emb,
+        "rotary_pos_cos": rotary_pos_cos,
+        "rotary_pos_sin": rotary_pos_sin,
+        "rotary_pos_cos_sin": rotary_pos_cos_sin,
+        "attention_bias": attention_bias,
+        "packed_seq_params": packed_seq_params,
+        "sequence_len_offset": sequence_len_offset,
+    }
+    active = [name for name, value in unsupported.items() if value is not None]
+    if active:
+        raise NvshmemCpFaOwnerError(
+            f"The experimental NVSHMEM backend does not support: {', '.join(active)}."
+        )
+    if module.attention_type != "self":
+        raise NvshmemCpFaOwnerError("The experimental NVSHMEM backend supports self-attention only.")
+    if module.training is False:
+        raise NvshmemCpFaOwnerError("The experimental NVSHMEM backend currently targets training only.")
+    if getattr(module.config, "attention_output_gate", False):
+        raise NvshmemCpFaOwnerError("The experimental NVSHMEM backend does not support output gates.")
+    if getattr(module, "offload_qkv_linear", False) or getattr(module, "offload_core_attention", False):
+        raise NvshmemCpFaOwnerError("The experimental NVSHMEM backend does not support activation offload.")
+
+    bindings = _ensure_nvshmem_initialized()
+    phase = _phase_start()
+    query, key, value, _, _ = _normal_qkv_publish(module, hidden_states)
+    _phase_end(phase, "nvshmem_symmetric_qkv_producer", layer_number=module.layer_number)
+
+    try:
+        bindings.quiet_on_stream(torch.cuda.current_stream().cuda_stream)
+    except Exception:
+        torch.cuda.synchronize()
+    ws = _workspace(tuple(key.shape), key.dtype, key.device, module.layer_number)
+    epoch = int(ws.committed_epoch[0].item()) + 1
+    ws.committed_epoch[0] = epoch
+    _publish_block_ready_epoch(ws, epoch)
+    torch.cuda.current_stream().synchronize()
+    _wait_for_block_ready_epoch(ws, epoch, _sync_timeout_seconds())
+
+    core_attn_out = _fa_owner_io_v1_block_ready_native_fused(
+        query=query,
+        key=key,
+        value=value,
+        attn_mask_type=module.attn_mask_type,
+        layer_number=module.layer_number,
+    )
+    hidden_size = module.num_attention_heads_per_partition * module.hidden_size_per_attention_head
+    core_attn_out = core_attn_out.reshape(hidden_states.size(0), hidden_states.size(1), hidden_size)
+    return module.linear_proj(core_attn_out)

--- a/megatron/core/transformer/nvshmem_cp_fa_owner.py
+++ b/megatron/core/transformer/nvshmem_cp_fa_owner.py
@@ -46,6 +46,9 @@ _BRANCH_B_PIPELINE_COMPUTE_STREAMS: dict[tuple[int, int], torch.cuda.Stream] = {
 _BRANCH_B_DUAL_SECTION_BWD_STREAMS: dict[tuple[int, int], torch.cuda.Stream] = {}
 _BRANCH_B_DEFERRED_PHASE_EVENTS: list[dict[str, object]] = []
 _BRANCH_B_DEFERRED_FORWARD_DETAIL_EVENTS: list[dict[str, object]] = []
+_BRANCH_B_FA4_MASKS: dict[tuple[int, int, int], object] = {}
+_BRANCH_B_FA4_PREWARMED: set[tuple] = set()
+_BRANCH_B_FA4_BLOCK_SPARSE: dict[tuple, tuple] = {}
 
 
 class NvshmemCpFaOwnerError(RuntimeError):
@@ -1733,19 +1736,6 @@ def _branch_b_fa4_global_backward(
                     int(prefix1),
                     int(prefix2),
                     softmax_scale=softmax_scale,
-                    tail_dq_recompute=two_section_tail_dq,
-                    overlap_dkv_recompute=(
-                        os.getenv(
-                            "MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_TWO_SECTION_OVERLAP_DKV_RECOMPUTE"
-                        )
-                        == "1"
-                    ),
-                    compact_grad_recompute=(
-                        os.getenv(
-                            "MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_TWO_SECTION_COMPACT_GRAD_RECOMPUTE"
-                        )
-                        == "1"
-                    ),
                 )
                 dq_fa4 = torch.cat((dq1, dq2), dim=1)
                 global_seq = int(peer_keys[cp_rank].shape[0]) * 4
@@ -2187,19 +2177,25 @@ class _BlockReadyNativeFusedOwnerAutograd(torch.autograd.Function):
             deferred_forward_start = torch.cuda.Event(enable_timing=True)
             deferred_forward_end = torch.cuda.Event(enable_timing=True)
             deferred_forward_start.record()
+        fa4_global = os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_GLOBAL") == "1"
         try:
             tex = _import_te_for_native_fused_owner()
         except ImportError as exc:
             raise NvshmemCpFaOwnerError(
                 "MEGATRON_NVSHMEM_CP_FA_OWNER_IO_V1_BACKWARD_IMPL="
-                "block_ready_native_fused requires transformer_engine_torch with "
-                "nvshmem_cp_block_ready_fused_owner_execute and "
-                "nvshmem_cp_block_ready_fused_owner_backward_execute."
+                "block_ready_native_fused requires transformer_engine_torch with the "
+                "selected backend primitives."
             ) from exc
 
         native_owner = getattr(tex, "nvshmem_cp_block_ready_fused_owner_execute", None)
         native_backward = getattr(tex, "nvshmem_cp_block_ready_fused_owner_backward_execute", None)
-        if native_owner is None or native_backward is None:
+        global_grad_return = getattr(tex, "nvshmem_cp_global_grad_return_execute", None)
+        if fa4_global and global_grad_return is None:
+            raise NvshmemCpFaOwnerError(
+                "FA4-global Branch-B requires transformer_engine_torch."
+                "nvshmem_cp_global_grad_return_execute."
+            )
+        if not fa4_global and (native_owner is None or native_backward is None):
             raise NvshmemCpFaOwnerError(
                 "MEGATRON_NVSHMEM_CP_FA_OWNER_IO_V1_BACKWARD_IMPL="
                 "block_ready_native_fused requires native fused Branch-B owner symbols "
@@ -2217,7 +2213,7 @@ class _BlockReadyNativeFusedOwnerAutograd(torch.autograd.Function):
         if not bool(is_causal):
             raise NvshmemCpFaOwnerError("block_ready_native_fused currently targets causal CP attention.")
 
-        if os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_GLOBAL") == "1":
+        if fa4_global:
             from megatron.core import parallel_state
 
             _branch_b_fa4_prewarm(
@@ -2352,9 +2348,6 @@ class _BlockReadyNativeFusedOwnerAutograd(torch.autograd.Function):
             torch.cuda.current_stream().synchronize()
             _branch_b_fa4_trace(cp_rank, "F02 after_peer_stage")
 
-        fa4_global = (
-            os.getenv("MEGATRON_NVSHMEM_CP_BRANCH_B_FA4_GLOBAL") == "1"
-        )
         fa4_state = None
         if fa4_global:
             _branch_b_fa4_trace(cp_rank, "F03 enter_fa4_branch")

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -982,6 +982,13 @@ class TransformerConfig(ModelParallelConfig):
     and P2P communications in high-level CP groups (e.g., via IBLink).
     """
 
+    context_parallel_attention_backend: Literal['default', 'nvshmem'] = 'default'
+    """Context-parallel attention implementation.
+
+    ``default`` preserves the configured core-attention implementation. ``nvshmem`` enables the
+    experimental symmetric-QKV backend for its explicitly validated CP=4 training contract.
+    """
+
     ##################
     # Cuda Graphs
     ##################
@@ -2735,6 +2742,29 @@ class TransformerConfig(ModelParallelConfig):
                 assert isinstance(
                     self.cp_comm_type, str
                 ), "Unsupported communication type for context parallelism!"
+
+        if self.context_parallel_attention_backend == 'nvshmem':
+            assert self.context_parallel_size == 4, (
+                "The experimental NVSHMEM attention backend currently requires "
+                f"context_parallel_size=4, got {self.context_parallel_size}."
+            )
+            assert self.tensor_model_parallel_size == 1, (
+                "The experimental NVSHMEM attention backend currently requires "
+                f"tensor_model_parallel_size=1, got {self.tensor_model_parallel_size}."
+            )
+            assert self.cp_comm_type == 'p2p', (
+                "The experimental NVSHMEM attention backend uses p2p as its explicit baseline "
+                f"contract, got cp_comm_type={self.cp_comm_type!r}."
+            )
+            assert self.kv_channels == 128, (
+                "The experimental NVSHMEM attention backend currently requires head_dim=128, "
+                f"got kv_channels={self.kv_channels}."
+            )
+            assert self.num_query_groups == self.num_attention_heads, (
+                "The experimental NVSHMEM attention backend currently supports MHA only, got "
+                f"num_query_groups={self.num_query_groups} and "
+                f"num_attention_heads={self.num_attention_heads}."
+            )
 
         assert (
             self.pipeline_model_parallel_size > 0

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2908,13 +2908,6 @@ def _add_distributed_args(parser):
                        'all layers will share the same communication type. Users can also '
                        'specify separated types for each layer like '
                        '--cp-comm-type p2p p2p a2a a2a a2a+p2p a2a+p2p')
-    group.add_argument(
-        '--context-parallel-attention-backend',
-        choices=('default', 'nvshmem'),
-        default='default',
-        help='Select the context-parallel attention implementation. The NVSHMEM backend is '
-        'experimental, opt-in, and validated only for its fail-closed CP=4 contract.',
-    )
     group.add_argument('--fake-process-group', action='store_true', default=False,
                        help='If set, initialize with fake distributed process group and all distributed communication operations will be skipped. \
                        This is quite useful for profiling memory usage of distributed training with just one GPU. \

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2908,6 +2908,13 @@ def _add_distributed_args(parser):
                        'all layers will share the same communication type. Users can also '
                        'specify separated types for each layer like '
                        '--cp-comm-type p2p p2p a2a a2a a2a+p2p a2a+p2p')
+    group.add_argument(
+        '--context-parallel-attention-backend',
+        choices=('default', 'nvshmem'),
+        default='default',
+        help='Select the context-parallel attention implementation. The NVSHMEM backend is '
+        'experimental, opt-in, and validated only for its fail-closed CP=4 contract.',
+    )
     group.add_argument('--fake-process-group', action='store_true', default=False,
                        help='If set, initialize with fake distributed process group and all distributed communication operations will be skipped. \
                        This is quite useful for profiling memory usage of distributed training with just one GPU. \

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -2016,6 +2016,18 @@ def setup_model_and_optimizer(
     skip_optimizer = not (has_normal_optimizer or has_rl_optimizer)
     wrap_with_ddp = not skip_optimizer
 
+    if args.context_parallel_attention_backend == 'nvshmem':
+        from megatron.core.transformer.nvshmem_cp_attention import (
+            configure_nvshmem_cp_backend,
+            eager_initialize_nvshmem_cp_backend_if_enabled,
+            validate_nvshmem_cp_microbatch_contract,
+        )
+
+        configure_nvshmem_cp_backend()
+        validate_nvshmem_cp_microbatch_contract(get_num_microbatches())
+        if eager_initialize_nvshmem_cp_backend_if_enabled():
+            print_rank_0("Initialized experimental NVSHMEM CP backend before model construction")
+
     if has_nvidia_modelopt:
         maybe_enable_modelopt(args)
 
@@ -2043,6 +2055,19 @@ def setup_model_and_optimizer(
             return get_model(model_provider_func, model_type, wrap_with_ddp=wrap_with_ddp, pg_collection=pg_collection)
 
     model = _build_model_wrapper(wrap_with_ddp)
+    if args.context_parallel_attention_backend == 'nvshmem':
+        from megatron.core.transformer.nvshmem_cp_attention import (
+            eager_allocate_nvshmem_cp_workspaces_if_enabled,
+        )
+
+        workspace_count = eager_allocate_nvshmem_cp_workspaces_if_enabled(
+            model,
+            seq_length=args.seq_length,
+            micro_batch_size=args.micro_batch_size,
+        )
+        print_rank_0(
+            f"Collectively preallocated {workspace_count} experimental NVSHMEM CP workspaces"
+        )
     unwrapped_model = unwrap_model(model)
 
     if args.logits_save_dir is not None:

--- a/tests/unit_tests/transformer/test_nvshmem_cp_backend_config.py
+++ b/tests/unit_tests/transformer/test_nvshmem_cp_backend_config.py
@@ -1,8 +1,13 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
+from dataclasses import is_dataclass
+
 import pytest
 
-from megatron.core.transformer.nvshmem_cp_attention import configure_nvshmem_cp_backend
+from megatron.core.transformer.nvshmem_cp_attention import (
+    NvshmemCpWorkspace,
+    configure_nvshmem_cp_backend,
+)
 from megatron.core.transformer.transformer_config import TransformerConfig
 
 
@@ -27,6 +32,10 @@ def test_nvshmem_cp_backend_accepts_validated_contract():
     config = _valid_config()
 
     assert config.context_parallel_attention_backend == "nvshmem"
+
+
+def test_nvshmem_cp_workspace_has_generated_constructor():
+    assert is_dataclass(NvshmemCpWorkspace)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/transformer/test_nvshmem_cp_backend_config.py
+++ b/tests/unit_tests/transformer/test_nvshmem_cp_backend_config.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import pytest
+
+from megatron.core.transformer.nvshmem_cp_attention import configure_nvshmem_cp_backend
+from megatron.core.transformer.transformer_config import TransformerConfig
+
+
+def _valid_config(**overrides):
+    kwargs = {
+        "num_layers": 4,
+        "hidden_size": 2560,
+        "num_attention_heads": 20,
+        "num_query_groups": 20,
+        "kv_channels": 128,
+        "context_parallel_size": 4,
+        "tensor_model_parallel_size": 1,
+        "cp_comm_type": "p2p",
+        "context_parallel_attention_backend": "nvshmem",
+        "use_cpu_initialization": True,
+    }
+    kwargs.update(overrides)
+    return TransformerConfig(**kwargs)
+
+
+def test_nvshmem_cp_backend_accepts_validated_contract():
+    config = _valid_config()
+
+    assert config.context_parallel_attention_backend == "nvshmem"
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"context_parallel_size": 2}, "context_parallel_size=4"),
+        ({"tensor_model_parallel_size": 2}, "tensor_model_parallel_size=1"),
+        ({"cp_comm_type": "all_gather"}, "p2p"),
+        ({"kv_channels": 64}, "head_dim=128"),
+        ({"num_query_groups": 4}, "supports MHA only"),
+    ],
+)
+def test_nvshmem_cp_backend_rejects_unsupported_contract(overrides, message):
+    with pytest.raises(AssertionError, match=message):
+        _valid_config(**overrides)
+
+
+def test_nvshmem_cp_backend_profile_does_not_override_runtime_policy(monkeypatch):
+    monkeypatch.delenv("MEGATRON_NVSHMEM_CP_SELF_ATTENTION_BACKEND", raising=False)
+    monkeypatch.delenv("NVSHMEM_DISABLE_CUDA_VMM", raising=False)
+
+    profile = configure_nvshmem_cp_backend()
+
+    assert profile["MEGATRON_NVSHMEM_CP_SELF_ATTENTION_BACKEND"] == "symmetric_qkv_v0"
+    assert "NVSHMEM_DISABLE_CUDA_VMM" not in profile


### PR DESCRIPTION
# What does this PR do?

Add an experimental, opt-in NVSHMEM context-parallel attention backend for a
strict CP=4 long-sequence training contract.

The backend:

- exposes `--context-parallel-attention-backend nvshmem` while preserving the
  existing default path;
- initializes NVSHMEM before model construction;
- collectively preallocates symmetric K/V and gradient-return workspaces;
- publishes local K/V once and consumes peer K/V through the symmetric heap;
- implements remote K/V gradient return for training;
- fails closed for unsupported topology, attention, and microbatch settings;
- provides opt-in timing and startup receipts.

Megatron/TE context parallelism at CP=4 uses a multi-peer ring schedule. This
backend evaluates a different ownership model: symmetric K/V storage, owner
compute, and explicit owner-gradient return.

## Supported scope

- CP=4, TP=1
- causal self-attention training
- MHA, head dimension 128, BF16 Q/K/V
- one in-flight microbatch
- `cp_comm_type=p2p` as the comparison baseline

Unsupported configurations are rejected instead of silently falling back.

## Dependency stack

This is the Megatron-owned part of a three-PR stack. It requires:

- [NVIDIA/TransformerEngine#3235](https://github.com/NVIDIA/TransformerEngine/pull/3235)
  for stream-ordered CP owner-gradient return;
- [Dao-AILab/flash-attention#2722](https://github.com/Dao-AILab/flash-attention/pull/2722)
  for two-section causal backward over shared K/V.

The FlashAttention dependency is currently draft while its kernel is rebased
over newer SM100 block-sparse backward changes. This Megatron PR should remain
draft until that dependency is conflict-free and the four-GPU gate is rerun.

Megatron owns NVSHMEM initialization, symmetric workspaces, peer mappings, K/V
publication, and backend selection.

## Evidence

Four GB200 GPUs were tested at TP1/PP1/DP1/EP1/CP4, S=262144, H=2560, 20 heads,
head dimension 128, four layers, vocabulary 157184, and batch 1.

| Metric | TE p2p | NVSHMEM | Result |
|---|---:|---:|---:|
| Median iteration, updates 4-7 | 1707.45 ms | 1413.65 ms | 17.21% lower |
| Strict checkpoint comparison | reference | max abs 1.90735e-6 | 73/73 tensors passed |
| Steady allocated memory | 23885.75 MiB | 33501.38 MiB | +9615.63 MiB |
| Peak allocated memory | 104005.82 MiB | 112986.44 MiB | +8980.62 MiB |

This is one baseline/candidate pair of eight training updates. It establishes
training correctness and an integrated speedup but is not yet a repeated final
performance claim. The full TP1/PP4/CP4/DP8/EP8 world-128 production topology
has not been tested because only four GPUs are available.

## Validation

- rebased onto current Megatron `main` and passed all eight focused backend
  configuration tests there;
- the reduced Transformer Engine extension built and exported its new symbol;
- the reduced FlashAttention wheel passed its two-section backward test on
  GB200;
- tiny CP=4 two-update training passed 22/22 checkpoint tensors with worst
  max-absolute difference `9.1968e-8`;
- strict S=262144 four-GPU training passed 73/73 checkpoint tensors with worst
  max-absolute difference `1.9073486328125e-6`.

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [x] I have added relevant functional validation
- [x] New public interfaces include typing
- [x] I have added experimental-backend documentation
- [ ] I have run the full repository autoformatter and test suite

The PR is intentionally experimental and default-off. The main review points
are the typed selector, fail-closed contract, lifecycle ordering, collective
workspace allocation, and dependency boundary.