### PR TITLE
Move MFSDP placements to the API boundary

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/__init__.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/__init__.py
@@ -15,9 +15,9 @@
 """Experimental Megatron-FSDP implementation."""
 
 from .dbuffer import DBuffer
-from .fully_shard import fully_shard, microbatch
+from .fully_shard import Placements, fully_shard, microbatch
 from .optimizer import fully_shard_optimizer
-from .placement import Flat, Partial, Placement, Placements, Replicate
+from .placement import Flat, Partial, Placement, Replicate
 
 __all__ = [
     "DBuffer",

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/__init__.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/__init__.py
@@ -16,9 +16,9 @@
 
 from .checkpoint import load_checkpoint, save_checkpoint
 from .dbuffer import DBuffer
-from .fully_shard import fully_shard, fully_shard_context, microbatch
+from .fully_shard import Placements, fully_shard, fully_shard_context, microbatch
 from .optimizer import fully_shard_optimizer
-from .placement import Flat, Placements
+from .placement import Flat
 
 __all__ = [
     "DBuffer",

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
@@ -14,6 +14,7 @@
 
 """Minimal Megatron-FSDP fully_shard entrypoint."""
 
+import dataclasses
 from collections.abc import Iterator
 from contextlib import contextmanager
 
@@ -22,7 +23,34 @@ from torch.distributed import DeviceMesh
 
 from ..mixed_precision import MixedPrecisionPolicy
 from .module import FsdpContext, FsdpModule
-from .placement import Placements
+from .placement import Placement
+
+MeshAxis = int | str
+
+
+@dataclasses.dataclass(frozen=True)
+class Placements:
+    """Per-data-parallel-axis placements for FSDP buffers.
+
+    ``dp_axes`` identifies the axes of the parent mesh that form FSDP's
+    data-parallel mesh. Placement lists are ordered to match those axes.
+    """
+
+    dp_axes: list[MeshAxis]
+    parameter: list[Placement]
+    gradient: list[Placement]
+    optimizer: list[Placement]
+
+    def __post_init__(self) -> None:
+        """Validate placement list lengths."""
+        axis_count = len(self.dp_axes)
+        for name, placements in (
+            ("parameter", self.parameter),
+            ("gradient", self.gradient),
+            ("optimizer", self.optimizer),
+        ):
+            if len(placements) != axis_count:
+                raise ValueError(f"Expected {axis_count} {name} placements, got {len(placements)}.")
 
 
 def fully_shard(
@@ -39,7 +67,7 @@ def fully_shard(
 
     Args:
         module: Module whose currently unowned parameters are managed by FSDP.
-        mesh: Device mesh used for sharding.
+        mesh: Parent device mesh containing the data-parallel axes.
         placements: Parameter, gradient, and optimizer placements.
         mixed_precision_policy: Optional precision policy. Defaults to FP32 main weights
             and parameter-dtype main gradients.
@@ -49,6 +77,17 @@ def fully_shard(
     if isinstance(module, FsdpModule):
         raise ValueError("This module is already managed by FSDP.")
 
+    dp_axes = _normalize_dp_axes(mesh, placements.dp_axes)
+    model_weight_placements = tuple(placements.parameter)
+    main_grad_placements = tuple(placements.gradient)
+    main_weight_placements = tuple(placements.optimizer)
+    _validate_placement_tuples(
+        len(dp_axes),
+        model_weight_placements=model_weight_placements,
+        main_grad_placements=main_grad_placements,
+        main_weight_placements=main_weight_placements,
+    )
+
     mixed_precision_policy = mixed_precision_policy or MixedPrecisionPolicy()
     original_cls = module.__class__
     _attach_mixin(module)
@@ -57,7 +96,10 @@ def fully_shard(
         FsdpModule.__init__(
             module,
             mesh=mesh,
-            placements=placements,
+            dp_axes=dp_axes,
+            model_weight_placements=model_weight_placements,
+            main_grad_placements=main_grad_placements,
+            main_weight_placements=main_weight_placements,
             mixed_precision_policy=mixed_precision_policy,
             use_symm_mem=use_symm_mem,
         )
@@ -103,3 +145,57 @@ def _collect_fsdp_contexts(module: nn.Module, contexts: list[FsdpContext]) -> No
 
     for child in module.children():
         _collect_fsdp_contexts(child, contexts)
+
+
+def _normalize_dp_axes(mesh: DeviceMesh, dp_axes: list[MeshAxis]) -> tuple[int, ...]:
+    """Normalize and validate the data-parallel axes of a parent mesh.
+
+    Subset selection is not supported yet. Keeping normalized axes separate
+    from the parent mesh preserves the information needed to derive a DP
+    submesh and reconstruct composed DTensors later.
+    """
+    axis_indices = tuple(_axis_index(mesh, axis) for axis in dp_axes)
+    if len(set(axis_indices)) != len(axis_indices):
+        raise ValueError(f"Placements.dp_axes must reference distinct mesh axes, got {dp_axes}.")
+    if axis_indices != tuple(sorted(axis_indices)):
+        raise ValueError(f"Placements.dp_axes must be in mesh-axis order, got {dp_axes}.")
+    if axis_indices != tuple(range(mesh.ndim)):
+        raise NotImplementedError(
+            "FSDP requires Placements.dp_axes to select every parent-mesh axis for now."
+        )
+    return axis_indices
+
+
+def _axis_index(mesh: DeviceMesh, axis: MeshAxis) -> int:
+    """Normalize an integer or named parent-mesh axis to a non-negative index."""
+    if isinstance(axis, int):
+        axis_index = axis
+        if axis_index < 0:
+            axis_index += mesh.ndim
+        if axis_index < 0 or axis_index >= mesh.ndim:
+            raise ValueError(f"Mesh axis {axis} is out of bounds for mesh ndim {mesh.ndim}.")
+        return axis_index
+
+    dim_names = mesh.mesh_dim_names
+    if dim_names is None or axis not in dim_names:
+        raise ValueError(f"Mesh axis {axis!r} is not present in mesh dim names {dim_names}.")
+    return dim_names.index(axis)
+
+
+def _validate_placement_tuples(
+    dp_ndim: int,
+    *,
+    model_weight_placements: tuple[Placement, ...],
+    main_grad_placements: tuple[Placement, ...],
+    main_weight_placements: tuple[Placement, ...],
+) -> None:
+    """Require one placement per dimension of the selected DP mesh."""
+    for name, placements in (
+        ("model_weight", model_weight_placements),
+        ("main_grad", main_grad_placements),
+        ("main_weight", main_weight_placements),
+    ):
+        if len(placements) != dp_ndim:
+            raise ValueError(
+                f"Expected {dp_ndim} {name} placements for the DP mesh, got {len(placements)}."
+            )

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
@@ -15,19 +15,46 @@
 """Minimal Megatron-FSDP fully_shard entrypoint."""
 
 import dataclasses
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from contextvars import ContextVar
 
 import torch
 from torch import nn
 from torch.distributed import DeviceMesh
+from torch.distributed.tensor.placement_types import Placement
 
 from ..mixed_precision import MixedPrecisionPolicy
 from .module import FsdpContext, FsdpModule
-from .placement import MeshAxis, Placements
 
 _FSDP_CONTEXT = ContextVar[FsdpContext | None]("mfsdp_context", default=None)
+
+MeshAxis = int | str
+
+
+@dataclasses.dataclass(frozen=True)
+class Placements:
+    """Per-data-parallel-axis placements for MFSDP buffers.
+
+    ``dp_axes`` identifies the parent-mesh axes that form MFSDP's data-parallel
+    mesh. Placement sequences are ordered to match those axes.
+    """
+
+    dp_axes: Sequence[MeshAxis]
+    parameter: Sequence[Placement]
+    gradient: Sequence[Placement]
+    optimizer: Sequence[Placement]
+
+    def __post_init__(self) -> None:
+        """Validate placement sequence lengths."""
+        axis_count = len(self.dp_axes)
+        for name, placements in (
+            ("parameter", self.parameter),
+            ("gradient", self.gradient),
+            ("optimizer", self.optimizer),
+        ):
+            if len(placements) != axis_count:
+                raise ValueError(f"Expected {axis_count} {name} placements, got {len(placements)}.")
 
 
 @contextmanager
@@ -88,7 +115,7 @@ def fully_shard(
 
     Args:
         module: Module whose currently unowned parameters are managed by FSDP.
-        mesh: Device mesh used for sharding.
+        mesh: Parent device mesh containing the data-parallel axes.
         placements: Parameter, gradient, and optimizer placements.
         mixed_precision_policy: Optional precision policy. Defaults to FP32 main weights
             and parameter-dtype main gradients.
@@ -116,7 +143,7 @@ def fully_shard(
                 "fully_shard_context."
             )
 
-    placements = _normalize_placements(mesh, placements)
+    _validate_dp_axes(mesh, placements.dp_axes)
     mixed_precision_policy = mixed_precision_policy or MixedPrecisionPolicy()
     original_cls = module.__class__
     _attach_mixin(module)
@@ -126,7 +153,9 @@ def fully_shard(
             module,
             context=context,
             mesh=mesh,
-            placements=placements,
+            model_weight_placements=tuple(placements.parameter),
+            main_grad_placements=tuple(placements.gradient),
+            main_weight_placements=tuple(placements.optimizer),
             mixed_precision_policy=mixed_precision_policy,
             grad_divisor=grad_divisor,
             use_symmetric_memory=context.use_symmetric_memory,
@@ -136,10 +165,17 @@ def fully_shard(
         raise
 
 
-def _normalize_placements(mesh: DeviceMesh, placements: Placements) -> Placements:
-    """Return a copy with data-parallel mesh axes normalized to integer indices."""
-    dp_axes = tuple(_axis_index(mesh, axis) for axis in placements.dp_axes)
-    return dataclasses.replace(placements, dp_axes=dp_axes)
+def _validate_dp_axes(mesh: DeviceMesh, dp_axes: Sequence[MeshAxis]) -> None:
+    """Validate the parent mesh's data-parallel axes."""
+    normalized_dp_axes = tuple(_axis_index(mesh, axis) for axis in dp_axes)
+    if len(set(normalized_dp_axes)) != len(normalized_dp_axes):
+        raise ValueError(f"Data-parallel axes must be distinct, got {dp_axes!r}.")
+    if normalized_dp_axes != tuple(sorted(normalized_dp_axes)):
+        raise ValueError(f"Data-parallel axes must be in mesh-axis order, got {dp_axes!r}.")
+    if normalized_dp_axes != tuple(range(mesh.ndim)):
+        raise NotImplementedError(
+            "MFSDP currently requires dp_axes to match every mesh axis in mesh order."
+        )
 
 
 def _axis_index(mesh: DeviceMesh, axis: MeshAxis) -> int:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -24,7 +24,7 @@ from torch.distributed import DeviceMesh
 from ..mixed_precision import MixedPrecisionPolicy
 from .indexed_order import IndexedOrder
 from .parameter_group import FsdpParameterGroup, contained_in_parameter_group
-from .placement import MeshAxis, Placements
+from .placement import Placement
 
 
 class FsdpContext:
@@ -34,7 +34,7 @@ class FsdpContext:
     reduce_scatter_stream: torch.cuda.Stream
     # HFSDP/HSDP need explicit last-microbatch state. First-microbatch state is
     # unnecessary because it can be detected when ``model_weight``, after syncing
-    # from ``main_weight``, has placements different from ``Placements.optimizer``.
+    # from ``main_weight``, has placements different from the main-weight placements.
     is_last_microbatch: bool
     root_module: "FsdpModule"
     # Static orders used to drive all-gather prefetch. We may want to switch to
@@ -95,7 +95,10 @@ class FsdpModule:
     def __init__(
         self,
         mesh: DeviceMesh,
-        placements: Placements,
+        dp_axes: tuple[int, ...],
+        model_weight_placements: tuple[Placement, ...],
+        main_grad_placements: tuple[Placement, ...],
+        main_weight_placements: tuple[Placement, ...],
         mixed_precision_policy: MixedPrecisionPolicy,
         use_symm_mem: bool = False,
     ) -> None:
@@ -104,16 +107,15 @@ class FsdpModule:
         self._name = None
         self._unshard_event = None
         owned_parameters = _collect_owned_parameters(self)
-        axis_indices = tuple(_axis_index(mesh, axis) for axis in placements.dp_axes)
-        assert axis_indices == tuple(
-            range(mesh.ndim)
-        ), "FSDP requires dp_axes to match every mesh axis in mesh order for now."
         parameter_groups = [
             FsdpParameterGroup(
                 owning_module=self,
                 parameters=group_parameters,
                 mesh=mesh,
-                placements=placements,
+                dp_axes=dp_axes,
+                model_weight_placements=model_weight_placements,
+                main_grad_placements=main_grad_placements,
+                main_weight_placements=main_weight_placements,
                 mixed_precision_policy=mixed_precision_policy,
                 use_symm_mem=use_symm_mem,
             )
@@ -360,21 +362,6 @@ def _collect_backward_order(module: nn.Module, order: IndexedOrder["FsdpModule"]
 
     for child in reversed(list(module.children())):
         _collect_backward_order(child, order)
-
-
-def _axis_index(mesh: DeviceMesh, axis: MeshAxis) -> int:
-    if isinstance(axis, int):
-        axis_index = axis
-        if axis_index < 0:
-            axis_index += mesh.ndim
-        if axis_index < 0 or axis_index >= mesh.ndim:
-            raise ValueError(f"Mesh axis {axis} is out of bounds for mesh ndim {mesh.ndim}.")
-        return axis_index
-
-    dim_names = mesh.mesh_dim_names
-    if dim_names is None or axis not in dim_names:
-        raise ValueError(f"Mesh axis {axis!r} is not present in mesh dim names {dim_names}.")
-    return dim_names.index(axis)
 
 
 def _collect_owned_parameters(root_module: nn.Module) -> dict[str, nn.Parameter]:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -21,11 +21,11 @@ from weakref import ref
 import torch
 from torch import nn
 from torch.distributed import DeviceMesh
+from torch.distributed.tensor.placement_types import Placement
 
 from ..mixed_precision import MixedPrecisionPolicy
 from .indexed_order import IndexedOrder
 from .parameter_group import FsdpParameterGroup, get_containing_parameter_group
-from .placement import Placements
 
 
 def _is_in_backward() -> bool:
@@ -170,7 +170,9 @@ class FsdpModule:
         self,
         context: FsdpContext,
         mesh: DeviceMesh,
-        placements: Placements,
+        model_weight_placements: tuple[Placement, ...],
+        main_grad_placements: tuple[Placement, ...],
+        main_weight_placements: tuple[Placement, ...],
         mixed_precision_policy: MixedPrecisionPolicy,
         grad_divisor: int = 1,
         use_symmetric_memory: bool = False,
@@ -182,9 +184,6 @@ class FsdpModule:
         self._unshard_event = None
         self._phase = FsdpModule.Phase.RESTING
         owned_parameters = _collect_owned_parameters(self)
-        assert tuple(placements.dp_axes) == tuple(
-            range(mesh.ndim)
-        ), "FSDP requires dp_axes to match every mesh axis in mesh order for now."
         if grad_divisor <= 0:
             raise ValueError(f"grad_divisor must be positive, got {grad_divisor}.")
         parameter_groups = [
@@ -192,7 +191,9 @@ class FsdpModule:
                 owning_module=self,
                 parameters=group_parameters,
                 mesh=mesh,
-                placements=placements,
+                model_weight_placements=model_weight_placements,
+                main_grad_placements=main_grad_placements,
+                main_weight_placements=main_weight_placements,
                 mixed_precision_policy=mixed_precision_policy,
                 allgather_stream=context.allgather_stream,
                 reduce_scatter_stream=context.reduce_scatter_stream,

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -24,7 +24,7 @@ from torch.distributed import DeviceMesh
 
 from ..mixed_precision import MixedPrecisionPolicy
 from .dbuffer import DBuffer
-from .placement import Partial, Placements, Replicate, changed_mesh_axis
+from .placement import Partial, Placement, Replicate, changed_mesh_axis
 
 _CONTAINING_PARAMETER_GROUP_ATTR = "_mfsdp_parameter_group"
 
@@ -55,7 +55,10 @@ class FsdpParameterGroup:
         owning_module: nn.Module,
         parameters: dict[str, nn.Parameter],
         mesh: DeviceMesh,
-        placements: Placements,
+        dp_axes: tuple[int, ...],
+        model_weight_placements: tuple[Placement, ...],
+        main_grad_placements: tuple[Placement, ...],
+        main_weight_placements: tuple[Placement, ...],
         mixed_precision_policy: MixedPrecisionPolicy,
         use_symm_mem: bool = False,
     ) -> None:
@@ -64,8 +67,11 @@ class FsdpParameterGroup:
         Args:
             owning_module: Closest FSDP root module that owns this parameter group.
             parameters: Root-module-relative FQNs and their parameters.
-            mesh: Device mesh used for all DBuffer storage in this version.
-            placements: Parameter, gradient, and optimizer placements.
+            mesh: Parent device mesh used to reconstruct parameter and gradient DTensors.
+            dp_axes: Normalized parent-mesh axes that form the data-parallel mesh.
+            model_weight_placements: Placements for model-weight buffers.
+            main_grad_placements: Placements for main-gradient buffers.
+            main_weight_placements: Placements for main-weight buffers.
             mixed_precision_policy: Precision policy for main weights and gradients.
             use_symm_mem: Allocate communication staging buffers from PyTorch's
                 NCCL symmetric-memory pool.
@@ -73,9 +79,17 @@ class FsdpParameterGroup:
         if not parameters:
             raise ValueError("FsdpParameterGroup requires at least one parameter.")
 
-        model_weight_placements = tuple(placements.parameter)
-        main_grad_placements = tuple(placements.gradient)
-        main_weight_placements = tuple(placements.optimizer)
+        dp_mesh = _select_dp_mesh(mesh, dp_axes)
+        for name, placements in (
+            ("model_weight", model_weight_placements),
+            ("main_grad", main_grad_placements),
+            ("main_weight", main_weight_placements),
+        ):
+            if len(placements) != dp_mesh.ndim:
+                raise ValueError(
+                    f"Expected {dp_mesh.ndim} {name} placements for the DP mesh, "
+                    f"got {len(placements)}."
+                )
 
         # Python dicts preserve insertion order, so parameter_names and
         # parameters.values() define the same stable DBuffer tensor order.
@@ -101,7 +115,7 @@ class FsdpParameterGroup:
         main_weight_dtype = mixed_precision_policy.main_params_dtype or torch.float32
         self.main_weight = DBuffer.distribute_tensors(
             (parameter.to(dtype=main_weight_dtype) for parameter in parameters.values()),
-            mesh=self.mesh,
+            mesh=dp_mesh,
             placements=main_weight_placements,
         )
 
@@ -114,8 +128,8 @@ class FsdpParameterGroup:
 
         with self._symmetric_memory_context():
             self._unsharded_model_weight = DBuffer(
-                mesh=self.mesh,
-                placements=[Replicate()] * self.mesh.ndim,
+                mesh=dp_mesh,
+                placements=[Replicate()] * dp_mesh.ndim,
                 tensor_shapes=tensor_shapes,
                 dtype=self.dtype,
                 device=self.main_weight.device,
@@ -124,7 +138,7 @@ class FsdpParameterGroup:
             self.model_weight = self.main_weight
         else:
             self.model_weight = DBuffer(
-                mesh=self.mesh,
+                mesh=dp_mesh,
                 placements=model_weight_placements,
                 tensor_shapes=tensor_shapes,
                 dtype=self.dtype,
@@ -140,7 +154,7 @@ class FsdpParameterGroup:
             # storage during forward. That requires a separate lifetime contract with
             # the optimizer, so this version keeps the simpler persistent buffer.
             self.main_grad = DBuffer(
-                mesh=self.mesh,
+                mesh=dp_mesh,
                 placements=main_grad_placements,
                 tensor_shapes=self.main_weight.layout.tensor_shapes,
                 dtype=grad_dtype,
@@ -265,10 +279,11 @@ class FsdpParameterGroup:
             if parameter.grad is None:
                 raise RuntimeError(f"Missing gradient for FSDP parameter {name!r}.")
             grads.append(parameter.grad)
+        dp_mesh = self.main_grad.mesh
         with self._symmetric_memory_context():
             return DBuffer(
-                mesh=self.mesh,
-                placements=[Partial(partial_op)] * self.mesh.ndim,
+                mesh=dp_mesh,
+                placements=[Partial(partial_op)] * dp_mesh.ndim,
                 tensor_shapes=tuple(grad.shape for grad in grads),
                 dtype=grads[0].dtype,
                 device=grads[0].device,
@@ -328,7 +343,9 @@ class FsdpParameterGroup:
         if reduce_axis is None:
             raise RuntimeError("FSDP gradient reduction requires a changed placement axis.")
         partial_reduce_op = partial_grad.placements[reduce_axis].reduce_op
-        grad_divisor = self.mesh.size(reduce_axis) if partial_reduce_op == dist.ReduceOp.SUM else 1
+        grad_divisor = (
+            partial_grad.mesh.size(reduce_axis) if partial_reduce_op == dist.ReduceOp.SUM else 1
+        )
         if self._symm_mem_pool is not None:
             partial_grad.rendezvous(reduce_axis)
         if can_reduce_into_main_grad:
@@ -351,6 +368,20 @@ class FsdpParameterGroup:
             # reduce-scatter for HFSDP) and install the sharded parameter gradients.
             self.main_grad = self.main_grad.redistribute(self.main_weight.placements)
             self._install_sharded_grads()
+
+
+def _select_dp_mesh(mesh: DeviceMesh, dp_axes: tuple[int, ...]) -> DeviceMesh:
+    """Derive the data-parallel submesh from a parent mesh and normalized axes."""
+    if dp_axes == tuple(range(mesh.ndim)):
+        return mesh
+
+    dim_names = mesh.mesh_dim_names
+    if dim_names is None:
+        raise ValueError(
+            "Selecting a data-parallel submesh requires a DeviceMesh with mesh_dim_names."
+        )
+    selected_names = tuple(dim_names[axis] for axis in dp_axes)
+    return mesh[selected_names] if len(selected_names) > 1 else mesh[selected_names[0]]
 
 
 def _get_parameter_owner(module: nn.Module, name: str) -> tuple[nn.Module, str]:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -24,10 +24,11 @@ import torch.distributed._symmetric_memory as symm_mem
 from torch import nn
 from torch.distributed import DeviceMesh
 from torch.distributed.tensor import Partial, Replicate
+from torch.distributed.tensor.placement_types import Placement
 
 from ..mixed_precision import MixedPrecisionPolicy
 from .dbuffer import DBuffer
-from .placement import Placements, changed_mesh_axis
+from .placement import changed_mesh_axis
 
 _CONTAINING_PARAMETER_GROUP_ATTR = "_mfsdp_parameter_group"
 
@@ -91,7 +92,9 @@ class FsdpParameterGroup:
         owning_module: nn.Module,
         parameters: dict[str, nn.Parameter],
         mesh: DeviceMesh,
-        placements: Placements,
+        model_weight_placements: tuple[Placement, ...],
+        main_grad_placements: tuple[Placement, ...],
+        main_weight_placements: tuple[Placement, ...],
         mixed_precision_policy: MixedPrecisionPolicy,
         allgather_stream: torch.cuda.Stream,
         reduce_scatter_stream: torch.cuda.Stream,
@@ -103,8 +106,10 @@ class FsdpParameterGroup:
         Args:
             owning_module: Closest FSDP root module that owns this parameter group.
             parameters: Root-module-relative FQNs and their parameters.
-            mesh: Device mesh used for all DBuffer storage in this version.
-            placements: Parameter, gradient, and optimizer placements.
+            mesh: Parent device mesh containing the data-parallel axes.
+            model_weight_placements: Compute-weight buffer placements.
+            main_grad_placements: Main-gradient buffer placements.
+            main_weight_placements: Main-weight buffer placements.
             mixed_precision_policy: Precision policy for main weights and gradients.
             allgather_stream: Stream used to allocate model weights when a dtype cast is required.
             reduce_scatter_stream: Stream on which to allocate the main-gradient buffer.
@@ -122,9 +127,6 @@ class FsdpParameterGroup:
         for fqn, parameter in parameters.items():
             parameter_to_fqns.setdefault(parameter, []).append(fqn)
 
-        model_weight_placements = tuple(placements.parameter)
-        main_grad_placements = tuple(placements.gradient)
-        main_weight_placements = tuple(placements.optimizer)
         self._model_weight_placements = model_weight_placements
         # main_grad rests here (DP-outer-Partial for HSDP) between microbatches and
         # is finalized to main_weight's placements after the last microbatch.

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/placement.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/placement.py
@@ -39,9 +39,6 @@ class Placement:
     """Base class for DBuffer placements."""
 
 
-MeshAxis = int | str
-
-
 @dataclasses.dataclass(frozen=True)
 class Replicate(Placement):
     """Replicated local buffer placement."""
@@ -76,24 +73,3 @@ def changed_mesh_axis(
             )
         changed_axis = axis
     return changed_axis
-
-
-@dataclasses.dataclass(frozen=True)
-class Placements:
-    """Per-mesh-axis placements for parameter, gradient, and optimizer buffers."""
-
-    dp_axes: list[MeshAxis]
-    parameter: list[Placement]
-    gradient: list[Placement]
-    optimizer: list[Placement]
-
-    def __post_init__(self) -> None:
-        """Validate placement list lengths."""
-        axis_count = len(self.dp_axes)
-        for name, placements in (
-            ("parameter", self.parameter),
-            ("gradient", self.gradient),
-            ("optimizer", self.optimizer),
-        ):
-            if len(placements) != axis_count:
-                raise ValueError(f"Expected {axis_count} {name} placements, got {len(placements)}.")

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/placement.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/placement.py
@@ -28,15 +28,12 @@ sharded        ``Replicate``  ``allgather()``
 =============  =============  ====================
 """
 
-import dataclasses
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 
 from torch.distributed.tensor import Shard
 from torch.distributed.tensor.placement_types import Placement
 
-__all__ = ["Flat", "Placements", "changed_mesh_axis"]
-
-MeshAxis = int | str
+__all__ = ["Flat", "changed_mesh_axis"]
 
 
 class Flat(Shard):
@@ -63,24 +60,3 @@ def changed_mesh_axis(
             )
         changed_axis = axis
     return changed_axis
-
-
-@dataclasses.dataclass(frozen=True)
-class Placements:
-    """Per-mesh-axis placements for parameter, gradient, and optimizer buffers."""
-
-    dp_axes: Sequence[MeshAxis]
-    parameter: list[Placement]
-    gradient: list[Placement]
-    optimizer: list[Placement]
-
-    def __post_init__(self) -> None:
-        """Validate placement list lengths."""
-        axis_count = len(self.dp_axes)
-        for name, placements in (
-            ("parameter", self.parameter),
-            ("gradient", self.gradient),
-            ("optimizer", self.optimizer),
-        ):
-            if len(placements) != axis_count:
-                raise ValueError(f"Expected {axis_count} {name} placements, got {len(placements)}.")


### PR DESCRIPTION
## What

- Move `MeshAxis`, `Placements`, and DP-axis validation to the `fully_shard` API boundary.
- Pass immutable, buffer-specific placement tuples into the MFSDP runtime instead of the public configuration object.

## Why

The public placement configuration should not flow through the runtime as one opaque object. Separating the buffer placements makes their roles explicit while keeping the runtime independent of the public configuration type.

More importantly, this prepares MFSDP for MXFP8: different parameter groups in the same `FsdpModule` can use data-type-specific sharding placements, such as `Flat` for BF16 and `BlockAtomic` for MXFP8.

Related: #5615

## Validation

- `python -m compileall -q megatron/core/distributed/fsdp/src/megatron_fsdp/experimental`
- `/opt/venv/bin/python -m torch.distributed.run --nproc-per-node 2 -m pytest -q tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py` — 26 passed, 6 topology-dependent skips
