### PR TITLE
Enable DDP communication overlap for MIMO training

### DIFF
--- a/examples/mimo/scripts/run_hetero_nemotron_20l_mock_train.sh
+++ b/examples/mimo/scripts/run_hetero_nemotron_20l_mock_train.sh
@@ -96,7 +96,9 @@ uv run --extra ssm python -m torch.distributed.run \
   --adam-beta2 0.95 \
   --clip-grad 1.0 \
   --use-distributed-optimizer \
-  --ddp-bucket-size 0 \
+  --overlap-grad-reduce \
+  --overlap-param-gather \
+  --encoder-ddp-overlap \
   --train-iters "${TRAIN_ITERS}" \
   --eval-interval "${EVAL_INTERVAL}" \
   --eval-iters "${EVAL_ITERS}" \

--- a/examples/mimo/training/args.py
+++ b/examples/mimo/training/args.py
@@ -48,6 +48,14 @@ def add_hetero_grid_args(parser: argparse.ArgumentParser) -> argparse.ArgumentPa
             "requires --llm-offset 0 so the language grid covers WORLD_SIZE."
         ),
     )
+    grid.add_argument(
+        "--encoder-ddp-overlap",
+        action="store_true",
+        help=(
+            "Apply the global grad-reduce and param-gather overlap settings to encoder DDP. "
+            "Requires every encoder DP rank to execute encoder backward on every microbatch."
+        ),
+    )
     return parser
 
 
@@ -55,6 +63,11 @@ def validate_hetero_grid_args(args: argparse.Namespace, world_size: int) -> tupl
     """Validate the disjoint hetero grid layout; returns ``(encoder_size, llm_size)``."""
     if args.llm_cp != 1:
         raise ValueError("hetero MIMO training currently supports CP=1 only")
+
+    if getattr(args, "encoder_ddp_overlap", False) and not getattr(
+        args, "overlap_grad_reduce", False
+    ):
+        raise ValueError("--encoder-ddp-overlap requires --overlap-grad-reduce")
 
     # MoE expert count must divide evenly across the language grid's expert parallelism.
     num_experts = _num_experts(args)
@@ -66,6 +79,8 @@ def validate_hetero_grid_args(args: argparse.Namespace, world_size: int) -> tupl
     llm_size = args.llm_tp * args.llm_cp * args.llm_pp * args.llm_dp
 
     if args.llm_only:
+        if getattr(args, "encoder_ddp_overlap", False):
+            raise ValueError("--encoder-ddp-overlap cannot be used with --llm-only")
         if args.llm_offset != 0:
             raise ValueError(
                 "--llm-only requires --llm-offset 0 so language ranks cover WORLD_SIZE"

--- a/examples/mimo/training/grad_sync.py
+++ b/examples/mimo/training/grad_sync.py
@@ -191,3 +191,12 @@ def configure_grad_sync(args, mimo_model: MimoModel, topology: HeteroTopology) -
     # The schedule always calls grad_scale_func with a Tensor loss; the per-token
     # mean is applied in finalize_grads_func, so no extra scaling is needed here.
     mimo_model.config.grad_scale_func = lambda loss: loss
+
+    if getattr(args, "overlap_grad_reduce", False):
+        assert mimo_model.config.no_sync_func is None, (
+            "MIMO overlap owns config.no_sync_func; a second synchronization context "
+            "cannot be composed safely"
+        )
+        mimo_model.config.no_sync_func = mimo_model.no_sync
+        if getattr(args, "align_grad_reduce", False):
+            mimo_model.config.grad_sync_func = mimo_model.start_grad_sync

--- a/examples/mimo/training/runtime.py
+++ b/examples/mimo/training/runtime.py
@@ -123,7 +123,9 @@ def wrap_active_modules_with_ddp(
                 [submodule],
                 enc_config,
                 topology.module_pgs[name],
-                ddp_config=_ddp_config_from_args(args, enable_overlap=False),
+                ddp_config=_ddp_config_from_args(
+                    args, enable_overlap=getattr(args, "encoder_ddp_overlap", False)
+                ),
                 data_parallel_random_init=data_parallel_random_init,
                 mixed_precision_wrapper=_EncoderFloat16Module,
             )[0]

--- a/megatron/core/models/mimo/model/base.py
+++ b/megatron/core/models/mimo/model/base.py
@@ -2,6 +2,7 @@
 
 import logging
 import warnings
+from contextlib import ExitStack, contextmanager
 from typing import Any, Dict, Optional, Tuple
 
 import torch
@@ -291,6 +292,51 @@ class MimoModel(MegatronModule):
         for submodule in self.modality_submodules.values():
             if submodule is not None:
                 yield submodule
+
+    def _active_ddp_modules(self):
+        """Yield this rank's active DDP-wrapped submodules."""
+        for module in self._active_submodules():
+            if isinstance(module, DistributedDataParallel):
+                yield module
+
+    @contextmanager
+    def no_sync(self):
+        """Disable grad-ready registration on overlapped inner DDP modules."""
+        with ExitStack() as stack:
+            for module in self._active_ddp_modules():
+                if module.ddp_config.overlap_grad_reduce:
+                    stack.enter_context(module.no_sync())
+            yield
+
+    def enable_forward_pre_hook(self):
+        """Enable parameter-gather pre-hooks on overlapped inner DDP modules."""
+        for module in self._active_ddp_modules():
+            if module.ddp_config.overlap_param_gather:
+                module.enable_forward_pre_hook()
+
+    def disable_forward_pre_hook(self, param_sync: bool = True):
+        """Disable parameter-gather pre-hooks on overlapped inner DDP modules."""
+        for module in self._active_ddp_modules():
+            if module.ddp_config.overlap_param_gather:
+                module.disable_forward_pre_hook(param_sync=param_sync)
+
+    def start_param_sync(self, *unused, force_sync: bool = False, force_dispatch: bool = False):
+        """Start parameter synchronization on overlapped inner DDP modules."""
+        for module in self._active_ddp_modules():
+            if module.ddp_config.overlap_param_gather:
+                module.start_param_sync(force_sync=force_sync, force_dispatch=force_dispatch)
+
+    def start_grad_sync(self, *unused):
+        """Start gradient synchronization on overlapped inner DDP modules."""
+        for module in self._active_ddp_modules():
+            if module.ddp_config.overlap_grad_reduce:
+                module.start_grad_sync()
+
+    def free_overlap_buffers(self):
+        """Release parameter-gather buffers owned by overlapped inner DDP modules."""
+        for module in self._active_ddp_modules():
+            if module.ddp_config.overlap_param_gather:
+                module.free_overlap_buffers()
 
     def zero_grad_buffer(self):
         """Zero each active submodule's DDP grad buffer."""

--- a/megatron/core/models/mimo/optimizer.py
+++ b/megatron/core/models/mimo/optimizer.py
@@ -118,6 +118,11 @@ class MimoOptimizer(MegatronOptimizer):
         for opt in self._active_optimizers:
             opt.zero_grad(set_to_none)
 
+    def prepare_model_params_for_param_sync(self) -> None:
+        """Stage parameters for explicit synchronization in all active module optimizers."""
+        for opt in self._active_optimizers:
+            opt.prepare_model_params_for_param_sync()
+
     def get_loss_scale(self) -> torch.Tensor:
         """Return the loss scale tensor from the first active optimizer."""
         if self._active_optimizers:

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -2922,9 +2922,29 @@ def compute_throughputs_and_append_to_progress_log(iteration, num_floating_point
     )
 
 
+def _assert_param_gather_overlap_model(model_chunk):
+    """Assert that a model chunk implements the parameter-gather overlap lifecycle."""
+    # MimoModel is a composite wrapper rather than a DDP instance, but delegates this
+    # interface to its active inner DDP modules.
+    required_methods = (
+        'enable_forward_pre_hook',
+        'disable_forward_pre_hook',
+        'start_param_sync',
+    )
+    missing_methods = [
+        method_name
+        for method_name in required_methods
+        if not callable(getattr(model_chunk, method_name, None))
+    ]
+    assert not missing_methods, (
+        f'{type(model_chunk).__name__} does not support parameter-gather overlap; '
+        f'missing callable methods: {", ".join(missing_methods)}'
+    )
+
+
 def enable_forward_pre_hook(model_chunks):
     for model_chunk in model_chunks:
-        assert isinstance(model_chunk, DDP)
+        _assert_param_gather_overlap_model(model_chunk)
         model_chunk.enable_forward_pre_hook()
 
 
@@ -2932,15 +2952,15 @@ def disable_forward_pre_hook(model_chunks, optimizer=None, param_sync=True):
     if param_sync and optimizer is not None:
         optimizer.prepare_model_params_for_param_sync()
     for model_chunk in model_chunks:
-        assert isinstance(model_chunk, DDP)
+        _assert_param_gather_overlap_model(model_chunk)
         model_chunk.disable_forward_pre_hook(param_sync=param_sync)
 
 
-def force_param_sync(model_chunks: list[DDP], optimizer=None) -> None:
+def force_param_sync(model_chunks, optimizer=None) -> None:
     if optimizer is not None:
         optimizer.prepare_model_params_for_param_sync()
     for model_chunk in model_chunks:
-        assert isinstance(model_chunk, DDP)
+        _assert_param_gather_overlap_model(model_chunk)
         model_chunk.start_param_sync(force_sync=True)
 
 

--- a/tests/unit_tests/models/mimo/test_mimo_1f1b_schedule.py
+++ b/tests/unit_tests/models/mimo/test_mimo_1f1b_schedule.py
@@ -7,7 +7,6 @@ Run with:
 """
 
 import logging
-from contextlib import ExitStack, contextmanager
 from functools import partial
 from types import SimpleNamespace
 
@@ -59,27 +58,6 @@ logger = logging.getLogger(__name__)
 
 _active_grids: list = []
 _embedding_pg_cache: dict = {}
-
-
-def build_no_sync_func(mimo_model):
-    """Build a no_sync_func that stacks DDP no_sync over each sub-module.
-
-    Shared by 1F1B pipeline tests and colocated-correctness tests — both need
-    DDP's gradient sync disabled during microbatches and resumed via the
-    schedule's finalize_grads_func.
-    """
-
-    @contextmanager
-    def no_sync_func():
-        with ExitStack() as stack:
-            if mimo_model.language_model is not None:
-                stack.enter_context(mimo_model.language_model.no_sync())
-            for submodule in mimo_model.modality_submodules.values():
-                if submodule is not None:
-                    stack.enter_context(submodule.no_sync())
-            yield
-
-    return no_sync_func
 
 
 def create_hypercomm_grid(offset=0, tp=1, cp=1, pp=1, dp=1):
@@ -623,8 +601,6 @@ def run_mimo_1f1b_test(
         per_token_loss=True,
     )
 
-    mimo_model.config.no_sync_func = build_no_sync_func(mimo_model)
-
     # Use the production grad-sync hook (finalize per module over its own groups +
     # cross-grid N_global per-token mean) for every config.
     grad_sync_topology = SimpleNamespace(
@@ -634,7 +610,11 @@ def run_mimo_1f1b_test(
             **{name: vision_pg for name in mimo_model.modality_submodules},
         },
     )
-    configure_grad_sync(SimpleNamespace(), mimo_model, grad_sync_topology)
+    configure_grad_sync(
+        SimpleNamespace(overlap_grad_reduce=True, align_grad_reduce=False),
+        mimo_model,
+        grad_sync_topology,
+    )
 
     # Create optimizer
     opt_config = OptimizerConfig(

--- a/tests/unit_tests/models/mimo/test_mimo_colocated_correctness.py
+++ b/tests/unit_tests/models/mimo/test_mimo_colocated_correctness.py
@@ -68,7 +68,6 @@ from megatron.core.optimizer.optimizer_config import OptimizerConfig
 from megatron.core.transformer.enums import ModelType
 from megatron.core.utils import unwrap_model
 from tests.unit_tests.models.mimo.test_mimo_1f1b_schedule import (
-    build_no_sync_func,
     create_all_embedding_groups,
     create_hypercomm_grid,
     destroy_all_grids,
@@ -167,7 +166,7 @@ def _set_deterministic_env():
 
 
 def _wire_training_hooks(mimo_model, module_to_grid_map, language_pg, vision_pg):
-    """Attach no_sync plus the production grad-sync hooks to a MimoModel.
+    """Attach the production no-sync and grad-sync hooks to a MimoModel.
 
     Delegates the finalize/grad-scale wiring to ``configure_grad_sync`` (the real
     examples/mimo path), so this test's dp1-reference assertions validate that
@@ -175,7 +174,6 @@ def _wire_training_hooks(mimo_model, module_to_grid_map, language_pg, vision_pg)
     mean: all-reduce ``total_num_tokens`` over the LLM DP group to get ``N_global``,
     finalize each submodule over its own group, then ``scale_gradients(1/N_global)``.
     """
-    mimo_model.config.no_sync_func = build_no_sync_func(mimo_model)
     topology = SimpleNamespace(
         grids=module_to_grid_map,
         module_pgs={
@@ -183,7 +181,9 @@ def _wire_training_hooks(mimo_model, module_to_grid_map, language_pg, vision_pg)
             **{name: vision_pg for name in mimo_model.modality_submodules},
         },
     )
-    configure_grad_sync(SimpleNamespace(), mimo_model, topology)
+    configure_grad_sync(
+        SimpleNamespace(overlap_grad_reduce=True, align_grad_reduce=False), mimo_model, topology
+    )
 
 
 def _generate_and_broadcast_global_batches(

--- a/tests/unit_tests/models/mimo/test_mimo_grad_sync.py
+++ b/tests/unit_tests/models/mimo/test_mimo_grad_sync.py
@@ -16,14 +16,42 @@ import torch.distributed as dist
 
 from examples.mimo.training.grad_sync import (
     _vision_participation_count,
+    configure_grad_sync,
     mark_modality_participation,
     reset_modality_participation,
 )
+from megatron.core.models.mimo.config.role import MIMO_LANGUAGE_MODULE_KEY
 from tests.unit_tests.models.mimo.test_mimo_1f1b_schedule import (
     create_hypercomm_grid,
     destroy_all_grids,
 )
 from tests.unit_tests.test_utilities import Utils
+
+
+def test_configure_grad_sync_installs_production_overlap_hooks():
+    def no_sync():
+        return None
+
+    def start_grad_sync(*_unused):
+        return None
+
+    config = SimpleNamespace(no_sync_func=None, grad_sync_func=None)
+    model = SimpleNamespace(
+        config=config,
+        no_sync=no_sync,
+        start_grad_sync=start_grad_sync,
+        language_model=None,
+        modality_submodules={},
+    )
+    language_grid = SimpleNamespace(get_rank_enum=lambda _name: [[0]])
+    topology = SimpleNamespace(grids={MIMO_LANGUAGE_MODULE_KEY: language_grid}, module_pgs={})
+
+    configure_grad_sync(
+        SimpleNamespace(overlap_grad_reduce=True, align_grad_reduce=True), model, topology
+    )
+
+    assert config.no_sync_func is no_sync
+    assert config.grad_sync_func is start_grad_sync
 
 
 class TestVisionParticipation:

--- a/tests/unit_tests/models/mimo/test_mimo_hetero_grid_args.py
+++ b/tests/unit_tests/models/mimo/test_mimo_hetero_grid_args.py
@@ -103,10 +103,29 @@ def test_llm_cp_must_be_one():
         validate_hetero_grid_args(args, WORLD_SIZE_8)
 
 
+def test_encoder_overlap_requires_grad_reduce():
+    args = _layout_8gpu_20l(encoder_ddp_overlap=True, overlap_grad_reduce=False)
+    with pytest.raises(ValueError, match="requires --overlap-grad-reduce"):
+        validate_hetero_grid_args(args, WORLD_SIZE_8)
+
+
+def test_encoder_overlap_accepts_uniform_participation_opt_in():
+    args = _layout_8gpu_20l(encoder_ddp_overlap=True, overlap_grad_reduce=True)
+    assert validate_hetero_grid_args(args, WORLD_SIZE_8) == (4, 4)
+
+
 def test_llm_only_requires_offset_zero():
     args = _layout_8gpu_20l(llm_only=True, llm_offset=4)
     with pytest.raises(ValueError, match="--llm-only requires --llm-offset 0"):
         validate_hetero_grid_args(args, WORLD_SIZE_8)
+
+
+def test_llm_only_rejects_encoder_overlap():
+    args = _layout_8gpu_20l(
+        llm_only=True, llm_offset=0, llm_ep=2, encoder_ddp_overlap=True, overlap_grad_reduce=True
+    )
+    with pytest.raises(ValueError, match="cannot be used with --llm-only"):
+        validate_hetero_grid_args(args, 4)
 
 
 def test_llm_only_covers_world():

--- a/tests/unit_tests/models/mimo/test_mimo_hetero_runtime.py
+++ b/tests/unit_tests/models/mimo/test_mimo_hetero_runtime.py
@@ -8,7 +8,11 @@ from types import SimpleNamespace
 import pytest
 import torch
 
-from examples.mimo.training.runtime import configure_module_rng, wrap_active_modules_with_ddp
+from examples.mimo.training.runtime import (
+    _ddp_config_from_args,
+    configure_module_rng,
+    wrap_active_modules_with_ddp,
+)
 from examples.mimo.training.topology import ModuleGridSpec, create_topology
 from megatron.core.distributed import DistributedDataParallel, DistributedDataParallelConfig
 from megatron.core.enums import ModelType
@@ -63,6 +67,43 @@ def _build_unwrapped_mimo_model(topo, bf16=False):
     mimo_model = MimoModel(mimo_config)
     mimo_model.to(torch.device("cuda"))
     return mimo_model
+
+
+def test_ddp_overlap_config_is_selected_per_module_role():
+    args = _args(overlap_grad_reduce=True, overlap_param_gather=True)
+
+    enabled = _ddp_config_from_args(args, enable_overlap=True)
+    disabled = _ddp_config_from_args(args, enable_overlap=False)
+
+    assert enabled.overlap_grad_reduce
+    assert enabled.overlap_param_gather
+    assert not disabled.overlap_grad_reduce
+    assert not disabled.overlap_param_gather
+
+
+def test_encoder_overlap_opt_in_reaches_encoder_ddp_config(mocker):
+    encoder = mocker.MagicMock()
+    wrapped_encoder = mocker.MagicMock()
+    mimo_model = SimpleNamespace(language_model=None, modality_submodules={ENCODER: encoder})
+    topology = SimpleNamespace(module_pgs={ENCODER: mocker.MagicMock()})
+    prepare = mocker.patch(
+        "examples.mimo.training.runtime.prepare_existing_model_chunks_for_distributed_training",
+        return_value=[wrapped_encoder],
+    )
+    mocker.patch("examples.mimo.training.runtime._freeze_modality_submodule")
+    mocker.patch("examples.mimo.training.runtime._module_config", return_value=mocker.MagicMock())
+    mocker.patch("examples.mimo.training.runtime.print_rank_0")
+
+    wrap_active_modules_with_ddp(
+        _args(encoder_ddp_overlap=True, overlap_grad_reduce=True, overlap_param_gather=True),
+        mimo_model,
+        topology,
+    )
+
+    ddp_config = prepare.call_args.kwargs["ddp_config"]
+    assert ddp_config.overlap_grad_reduce
+    assert ddp_config.overlap_param_gather
+    assert mimo_model.modality_submodules[ENCODER] is wrapped_encoder
 
 
 def _eight_gpu_topology():

--- a/tests/unit_tests/models/mimo/test_mimo_overlap_lifecycle.py
+++ b/tests/unit_tests/models/mimo/test_mimo_overlap_lifecycle.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""CPU-only tests for MIMO's nested DDP overlap lifecycle."""
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from megatron.core.models.mimo.model.base import MimoModel
+from megatron.core.models.mimo.optimizer import MimoOptimizer
+
+
+def _overlap_stub(modules):
+    stub = SimpleNamespace()
+    stub._active_ddp_modules = lambda: iter(modules)
+    for name in (
+        "no_sync",
+        "enable_forward_pre_hook",
+        "disable_forward_pre_hook",
+        "start_param_sync",
+        "start_grad_sync",
+        "free_overlap_buffers",
+    ):
+        setattr(stub, name, getattr(MimoModel, name).__get__(stub))
+    return stub
+
+
+def _ddp(*, grad_overlap, param_overlap, events, name):
+    module = MagicMock()
+    module.ddp_config = SimpleNamespace(
+        overlap_grad_reduce=grad_overlap, overlap_param_gather=param_overlap
+    )
+
+    @contextmanager
+    def no_sync():
+        events.append(f"{name}:enter")
+        try:
+            yield
+        finally:
+            events.append(f"{name}:exit")
+
+    module.no_sync.side_effect = no_sync
+    return module
+
+
+def test_nested_overlap_lifecycle_routes_only_to_enabled_modules():
+    events = []
+    language = _ddp(grad_overlap=True, param_overlap=True, events=events, name="language")
+    encoder = _ddp(grad_overlap=True, param_overlap=False, events=events, name="encoder")
+    inactive = _ddp(grad_overlap=False, param_overlap=False, events=events, name="inactive")
+    model = _overlap_stub([language, encoder, inactive])
+
+    with model.no_sync():
+        events.append("body")
+
+    assert events == ["language:enter", "encoder:enter", "body", "encoder:exit", "language:exit"]
+    inactive.no_sync.assert_not_called()
+
+    model.enable_forward_pre_hook()
+    model.disable_forward_pre_hook(param_sync=False)
+    model.start_param_sync(force_sync=True, force_dispatch=True)
+    model.start_grad_sync()
+    model.free_overlap_buffers()
+
+    language.enable_forward_pre_hook.assert_called_once_with()
+    language.disable_forward_pre_hook.assert_called_once_with(param_sync=False)
+    language.start_param_sync.assert_called_once_with(force_sync=True, force_dispatch=True)
+    language.start_grad_sync.assert_called_once_with()
+    language.free_overlap_buffers.assert_called_once_with()
+
+    encoder.enable_forward_pre_hook.assert_not_called()
+    encoder.start_param_sync.assert_not_called()
+    encoder.start_grad_sync.assert_called_once_with()
+    inactive.start_grad_sync.assert_not_called()
+
+
+def test_mimo_optimizer_stages_each_active_optimizer_before_param_sync():
+    language_optimizer = MagicMock()
+    encoder_optimizer = MagicMock()
+    optimizer = SimpleNamespace(_active_optimizers=[language_optimizer, encoder_optimizer])
+
+    MimoOptimizer.prepare_model_params_for_param_sync(optimizer)
+
+    language_optimizer.prepare_model_params_for_param_sync.assert_called_once_with()
+    encoder_optimizer.prepare_model_params_for_param_sync.assert_called_once_with()


### PR DESCRIPTION
## Summary

- expose the inner MIMO DDP overlap lifecycle through `MimoModel` and `MimoOptimizer`
- install the `no_sync` hook for gradient accumulation and support aligned grad/parameter synchronization
- enable LLM overlap in the heterogeneous mock launcher and add an explicit encoder DDP overlap opt-in


## Why

MIMO wraps the independently distributed language and encoder modules in an outer model. The stock training loop therefore could not reach the inner DDP `no_sync`, parameter-gather pre-hook, forced synchronization, or checkpoint cleanup lifecycle. Enabling the overlap arguments alone did not provide the normal DDP schedule contract for accumulated microbatches and evaluation/checkpoint transitions.


