### PR TITLE
fix: use one warp for fused MLA RoPE backward

### DIFF
--- a/megatron/core/fusions/fused_mla_yarn_rope_apply.py
+++ b/megatron/core/fusions/fused_mla_yarn_rope_apply.py
@@ -132,14 +132,16 @@ def rotary_fwd_q_kernel(
 
 @triton.autotune(
     configs=[
-        triton.Config({"BLOCK_H": 1}),
-        triton.Config({"BLOCK_H": 2}),
-        triton.Config({"BLOCK_H": 4}),
-        triton.Config({"BLOCK_H": 8}),
-        triton.Config({"BLOCK_H": 16}),
-        triton.Config({"BLOCK_H": 32}),
-        triton.Config({"BLOCK_H": 64}),
-        triton.Config({"BLOCK_H": 128}),
+        # DO is converted from split to interleaved layout in-place. Keep each program
+        # single-warp so every source load is issued before any overlapping destination store.
+        triton.Config({"BLOCK_H": 1}, num_warps=1),
+        triton.Config({"BLOCK_H": 2}, num_warps=1),
+        triton.Config({"BLOCK_H": 4}, num_warps=1),
+        triton.Config({"BLOCK_H": 8}, num_warps=1),
+        triton.Config({"BLOCK_H": 16}, num_warps=1),
+        triton.Config({"BLOCK_H": 32}, num_warps=1),
+        triton.Config({"BLOCK_H": 64}, num_warps=1),
+        triton.Config({"BLOCK_H": 128}, num_warps=1),
     ],
     key=["emb_dim", "head_num"],
     restore_value=["DO"],

--- a/tests/unit_tests/fusions/test_mla_yarn_rope_apply.py
+++ b/tests/unit_tests/fusions/test_mla_yarn_rope_apply.py
@@ -18,10 +18,12 @@ try:
     from megatron.core.fusions.fused_mla_yarn_rope_apply import (
         fused_apply_mla_rope_for_kv,
         fused_apply_mla_rope_for_q,
+        rotary_bwd_q_kernel,
     )
 except:
     fused_apply_mla_rope_for_kv = None
     fused_apply_mla_rope_for_q = None
+    rotary_bwd_q_kernel = None
 
 
 def dtype_tols(dtype):
@@ -300,9 +302,65 @@ def _test_fused_apply_mla_rope_for_kv(input_format):
 @pytest.mark.internal
 @pytest.mark.skipif(not is_torch_min_version("2.5.0"), reason="Requires PyTorch >= 2.5.0")
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_rotary_bwd_q_single_warp_configs_are_deterministic() -> None:
+    """Exercise every production config as an exact in-place layout permutation."""
+    import triton
+
+    num_heads = 32
+    q_dim = 128
+    emb_dim = 64
+    total_seqlen = 128
+    generator = torch.Generator(device="cuda").manual_seed(617)
+    before = torch.randn(
+        (total_seqlen, num_heads, q_dim + emb_dim),
+        dtype=torch.bfloat16,
+        device="cuda",
+        generator=generator,
+    )
+    cos = torch.ones((total_seqlen, 1, 1, emb_dim), dtype=torch.bfloat16, device="cuda")
+    sin = torch.zeros_like(cos)
+
+    torch_reference = before.clone()
+    half = emb_dim // 2
+    torch_reference[..., q_dim::2] = before[..., q_dim : q_dim + half]
+    torch_reference[..., q_dim + 1 :: 2] = before[..., q_dim + half :]
+
+    def launch(block_h: int, num_warps: int, num_stages: int) -> torch.Tensor:
+        result = before.clone()
+        rotary_bwd_q_kernel.fn[(total_seqlen, triton.cdiv(num_heads, block_h))](
+            result,
+            cos,
+            sin,
+            q_dim,
+            emb_dim,
+            num_heads,
+            1,
+            None,
+            None,
+            result.stride(0),
+            result.stride(1),
+            0,
+            1,
+            BLOCK_H=block_h,
+            num_warps=num_warps,
+            num_stages=num_stages,
+        )
+        return result
+
+    for config in rotary_bwd_q_kernel.configs:
+        assert config.num_warps == 1, "In-place backward layout conversion must be single-warp"
+        block_h = config.kwargs["BLOCK_H"]
+        for _ in range(100):
+            actual = launch(block_h, config.num_warps, config.num_stages)
+            assert torch.equal(actual, torch_reference)
+
+
+@pytest.mark.experimental
+@pytest.mark.internal
+@pytest.mark.skipif(not is_torch_min_version("2.5.0"), reason="Requires PyTorch >= 2.5.0")
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.parametrize("input_format", ["sbhd", "thd"])
 class TestFusedApplyMLARope:
-    @pytest.mark.flaky_in_dev
     def test_forward_backward_for_q(self, input_format):
         _test_fused_apply_mla_rope_for_q(input_format)
 


### PR DESCRIPTION

- [✔] I, the PR author, have personally reviewed every line of this PR.

## What does this PR do?

Fixes nondeterministic gradients in the fused MLA YaRN RoPE query backward kernel by making all backward autotune configurations single-warp

### Fix problem

`rotary_bwd_q_kernel` converts the RoPE gradient from split layout to interleaved layout in place. Because the source and destination regions overlap, a multi-warp program may write output before another warp has finished reading its source data, causing a race condition and intermittent gradient corruption.

This PR:

- Sets `num_warps=1` for every backward `BLOCK_H` autotune configuration.
- Retains autotuning across `BLOCK_H=1...128`.
- Leaves the forward kernel unchanged.
- Adds an exact, deterministic layout-permutation regression test covering every production configuration.
- Removes the `flaky_in_dev` marker from the Q forward/backward test.

### Test

Test environment:

- NVIDIA H200
- BF16
- PyTorch 2.9.1+cu128
- Triton 3.5.1

Correctness validation:

- Every production `BLOCK_H` configuration was launched 100 times and compared with an exact PyTorch permutation using `torch.equal`.
- Additional single-warp stress test: 10,000 iterations, 0 mismatches.
- SBHD and THD API tests: 25 iterations each, 0 mismatches.
- Targeted regression tests: 3 passed.
- Related fused MLA RoPE tests: 7 passed.
- Black, isort, Ruff, and `git diff --check` passed.

```bash
uv run --no-sync python -m torch.distributed.run \
  --nproc-per-node 1 \
  -m pytest -q \
  --experimental \
  -m "experimental and not flaky_in_dev" \
  tests/unit_tests/fusions/test_mla_yarn_rope_apply.py
```

### Performance impact

We benchmarked the BF16 backward kernel on an NVIDIA H200 with DeepSeek training
shapes using PyTorch 2.9.1 and Triton 3.5.1. H is the local head count after
TP, and D=192. All shapes selected BLOCK_H=4; timings are medians of seven
paired runs.

| Workload                | [S, B, H, D]        | 4 warps     | 1 warp      | Latency Δ           |
| ----------------------- | ------------------- | ----------- | ----------- | ------------------- |
| DeepSeek-V2-Lite, TP1   | [1024, 1, 16, 192]  | 8.096 µs    | 8.416 µs    | +0.320 µs (+3.95%)  |
| DeepSeek-V3/R1, TP1     | [4096, 1, 128, 192] | 85.600 µs   | 84.992 µs   | -0.608 µs (-0.71%)  |
| DeepSeek-V3 release, TP2| [4096, 1, 64, 192]  | 45.472 µs   | 45.440 µs   | -0.032 µs (-0.07%)  |
| DeepSeek-V3 release, TP2| [4096, 4, 64, 192]  | 165.216 µs  | 163.680 µs  | -1.536 µs (-0.93%)  |
| DeepSeek-V3 FSDP, TP1   | [4096, 4, 128, 192] | 323.584 µs  | 321.472 µs  | -2.112 µs (-0.65%)  |

Latency Δ = 1 warp - 4 warps; negative values are faster. DeepSeek-V3/R1
shapes show no material kernel-level regression. These are kernel-only results,
not end-to-end training measurements.

## Issue tracking

Fixes #4640
