### PR TITLE
[Inference] Set different random seeds for each DP rank for generation.

### DIFF
--- a/megatron/core/inference/config.py
+++ b/megatron/core/inference/config.py
@@ -369,6 +369,15 @@ class InferenceConfig:
     sampling_backend: Literal['torch', 'flashinfer'] = 'torch'
     """Which sampling kernels to use during inference."""
 
+    offset_sampling_seed_by_dp_rank: bool = True
+    """
+    If True, offset `inference_sampling_seed` by the data-parallel rank when seeding the
+    sampling RNG. This gives each DP rank a unique generation seed so that the same prompt
+    routed to different ranks produces different samples (important for RL training).
+    If False (or `ModelParallelConfig.deterministic_mode` / `--deterministic-mode` is
+    enabled), then all DP ranks share the same sampling / generation seed.
+    """
+
     async_sched_mode: AsyncScheduleMode = AsyncScheduleMode.LEGACY
     """Mode used to schedule dynamic batching inference work."""
 

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -2908,11 +2908,11 @@ class TextGenerationController:
 
             request.status = Status.COMPLETED
 
+            # Detokenize up to input_prompt_length + required_sequence_length for this idx.
+            sequence_length = input_prompt_length + required_sequence_length
             text, segments = self.detokenize_generations(
-                batch_prompt_tokens_with_generations[
-                    idx, : (input_prompt_length + required_sequence_length)
-                ],
-                input_prompt_length + generated_sequence_lengths,
+                batch_prompt_tokens_with_generations[idx, :sequence_length],
+                torch.tensor([sequence_length], device=batch_prompt_tokens_with_generations.device),
                 sampling_params.return_segments,
             )
             request.text = text  # Inference server returns prompts & generations together

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -157,13 +157,20 @@ class TextGenerationController:
         else:
             self.vocab_size = unwrapped_model.vocab_size
 
+        # Build and seed sampling RNG. Optionally offset by DP rank so each rank gets a
+        # unique generation seed (avoids identical samples when the same prompt is
+        # assigned to multiple DP ranks, which can corrupt RL training). Controlled by
+        # InferenceConfig.offset_sampling_seed_by_dp_rank, but deactivated when enabling
+        # --deterministic-mode (model_config.deterministic_mode).
         self.sampling_rng = torch.Generator(device=torch.cuda.current_device())
-        # Set a unique generation seed for each DP rank. If the DP coordinator is random,
-        # then sending requests to different DP ranks will produce different output.
-        # Necessary to avoid generating the same output when a request / prompt is
-        # assigned to multiple DP ranks, which can corrupt RL training.
-        dp_rank = torch.distributed.get_rank(group=self.dp_group)
-        self.sampling_rng.manual_seed(self.model_config.inference_sampling_seed + dp_rank)
+        seed = self.model_config.inference_sampling_seed
+        offset_by_dp = (
+            inference_config.offset_sampling_seed_by_dp_rank
+            and not self.model_config.deterministic_mode
+        )
+        if offset_by_dp:
+            seed += torch.distributed.get_rank(group=self.dp_group)
+        self.sampling_rng.manual_seed(seed)
 
         if not self.num_speculative_tokens:
             self.num_mtp_depths = 0

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -142,8 +142,10 @@ class TextGenerationController:
         pg_collection = inference_config.pg_collection
         if pg_collection is not None:
             self.pp_group = pg_collection.pp
+            self.dp_group = pg_collection.dp
         else:
             self.pp_group = parallel_state.get_pipeline_model_parallel_group()
+            self.dp_group = parallel_state.get_data_parallel_group()
 
         self.model_is_pipeline_parallel = self.model_config.pipeline_model_parallel_size > 1
 
@@ -156,7 +158,12 @@ class TextGenerationController:
             self.vocab_size = unwrapped_model.vocab_size
 
         self.sampling_rng = torch.Generator(device=torch.cuda.current_device())
-        self.sampling_rng.manual_seed(self.model_config.inference_sampling_seed)
+        # Set a unique generation seed for each DP rank. If the DP coordinator is random,
+        # then sending requests to different DP ranks will produce different output.
+        # Necessary to avoid generating the same output when a request / prompt is
+        # assigned to multiple DP ranks, which can corrupt RL training.
+        dp_rank = torch.distributed.get_rank(group=self.dp_group)
+        self.sampling_rng.manual_seed(self.model_config.inference_sampling_seed + dp_rank)
 
         if not self.num_speculative_tokens:
             self.num_mtp_depths = 0

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2013,6 +2013,11 @@ def _add_inference_args(parser):
                        help='Which sampling kernels to use during inference. '
                             'Falls back to "torch" with a warning if "flashinfer" '
                             'is requested but the package is not installed.')
+    group.add_argument('--use-same-sampling-seed-across-dp-ranks',
+                       action='store_false', dest='offset_sampling_seed_by_dp_rank',
+                       default=True,
+                       help='Use the same inference sampling seed on every data-parallel rank. '
+                            '--deterministic-mode also uses the same seed on every DP rank.')
     group.add_argument('--inference-dynamic-batching-async-sched-mode',
                        type=str, default='legacy',
                        choices=['legacy', 'serial', 'overlap'],

--- a/megatron/training/config/inference_config.py
+++ b/megatron/training/config/inference_config.py
@@ -136,6 +136,11 @@ class InferenceSetupConfig:
     """Which sampling kernels to use during inference. Falls back to "torch" with a warning if
     "flashinfer" is requested but the package is not installed."""
 
+    offset_sampling_seed_by_dp_rank: bool = True
+    """Offset the inference sampling seed by the data-parallel rank so each DP rank gets a unique
+    generation seed. Disable with --use-same-sampling-seed-across-dp-ranks. Also forced off when
+    --deterministic-mode is enabled."""
+
     inference_dynamic_batching_async_sched_mode: Literal["legacy", "serial", "overlap"] = "legacy"
     """Async scheduling mode for dynamic batching. "legacy" (default) preserves the
     existing resolve-before-prepare path. "serial" speculatively prepares and forwards decode-only
@@ -373,6 +378,7 @@ class InferenceSetupConfig:
             use_synchronous_zmq_collectives=self.inference_use_synchronous_zmq_collectives,
             disable_ep_consensus=self.inference_disable_ep_consensus,
             sampling_backend=self.inference_dynamic_batching_sampling_backend,
+            offset_sampling_seed_by_dp_rank=self.offset_sampling_seed_by_dp_rank,
             async_sched_mode=AsyncScheduleMode(
                 self.inference_dynamic_batching_async_sched_mode
             ),

--- a/tests/unit_tests/inference/engines/test_dynamic_engine.py
+++ b/tests/unit_tests/inference/engines/test_dynamic_engine.py
@@ -681,48 +681,56 @@ class TestDynamicInferenceEngine(DynamicInferenceEngineTestBase):
                 for layer in model.decoder.layers:
                     assert layer.cudagraph_manager.cudagraph_runners
 
-        # Validate generated tokens.
-        gpt_expected_generated_tokens = [
-            [69, 85, 55, 74, 56, 89, 64, 59, 55, 67, 15, 58, 6, 37, 54, 47],
-            [29, 54, 33, 72, 45, 76, 41, 56, 28, 25, 17, 2, 61, 6, 98, 76],
-            [35, 78, 54, 16, 79, 98, 22, 5, 60, 0, 1, 76, 77, 11, 25, 7],
-            [25, 75, 57, 85, 81, 37, 88, 17, 71, 15, 70, 64, 50, 0, 64, 45],
-            [32, 5, 85, 75, 30, 68, 23, 33, 20, 26, 89, 20, 49, 28, 38, 81],
-            [33, 69, 32, 49, 93, 24, 33, 6, 54, 89, 92, 97, 42, 80, 50, 53],
-            [82, 78, 78, 65, 26, 5, 69, 36, 37, 99],
-            [51, 70, 22, 1, 87, 42, 36, 26, 27, 56, 82, 32, 8, 80, 20, 43],
-        ]
+        # Because the TextGenerationController produces different outputs on different DP ranks,
+        # only verify the accuracy of the output on DP rank 0.
+        if parallel_state.get_data_parallel_rank() == 0:
 
-        mamba_expected_generated_tokens = [
-            [69, 85, 55, 74, 85, 89, 64, 59, 55, 67, 15, 58, 6, 37, 34, 47],
-            [29, 16, 33, 30, 45, 76, 41, 46, 82, 17, 17, 2, 61, 6, 98, 76],
-            [35, 78, 54, 16, 79, 98, 22, 5, 37, 30, 1, 76, 5, 11, 25, 86],
-            [25, 75, 57, 85, 81, 59, 88, 38, 71, 15, 70, 64, 50, 0, 64, 45],
-            [32, 5, 85, 75, 30, 68, 23, 33, 20, 26, 35, 20, 49, 28, 34, 81],
-            [87, 69, 32, 49, 93, 24, 33, 6, 54, 89, 92, 97, 42, 80, 50, 53],
-            [82, 78, 78, 19, 70, 5, 97, 36, 37, 99],
-            [51, 70, 22, 1, 87, 42, 36, 26, 27, 56, 82, 32, 8, 20, 20, 43],
-        ]
+            # Validate generated tokens.
+            gpt_expected_generated_tokens = [
+                [69, 85, 55, 74, 56, 89, 64, 59, 55, 67, 15, 58, 6, 37, 54, 47],
+                [29, 54, 33, 72, 45, 76, 41, 56, 28, 25, 17, 2, 61, 6, 98, 76],
+                [35, 78, 54, 16, 79, 98, 22, 5, 60, 0, 1, 76, 77, 11, 25, 7],
+                [25, 75, 57, 85, 81, 37, 88, 17, 71, 15, 70, 64, 50, 0, 64, 45],
+                [32, 5, 85, 75, 30, 68, 23, 33, 20, 26, 89, 20, 49, 28, 38, 81],
+                [33, 69, 32, 49, 93, 24, 33, 6, 54, 89, 92, 97, 42, 80, 50, 53],
+                [82, 78, 78, 65, 26, 5, 69, 36, 37, 99],
+                [51, 70, 22, 1, 87, 42, 36, 26, 27, 56, 82, 32, 8, 80, 20, 43],
+            ]
 
-        if model_provider == "gpt":
-            expected_generated_tokens_list = gpt_expected_generated_tokens
-        elif model_provider == "hybrid":
-            expected_generated_tokens_list = mamba_expected_generated_tokens
-        else:
-            raise ValueError(f"Invalid model_provider {model_provider}")
+            mamba_expected_generated_tokens = [
+                [69, 85, 55, 74, 85, 89, 64, 59, 55, 67, 15, 58, 6, 37, 34, 47],
+                [29, 16, 33, 30, 45, 76, 41, 46, 82, 17, 17, 2, 61, 6, 98, 76],
+                [35, 78, 54, 16, 79, 98, 22, 5, 37, 30, 1, 76, 5, 11, 25, 86],
+                [25, 75, 57, 85, 81, 59, 88, 38, 71, 15, 70, 64, 50, 0, 64, 45],
+                [32, 5, 85, 75, 30, 68, 23, 33, 20, 26, 35, 20, 49, 28, 34, 81],
+                [87, 69, 32, 49, 93, 24, 33, 6, 54, 89, 92, 97, 42, 80, 50, 53],
+                [82, 78, 78, 19, 70, 5, 97, 36, 37, 99],
+                [51, 70, 22, 1, 87, 42, 36, 26, 27, 56, 82, 32, 8, 20, 20, 43],
+            ]
 
-        print(f"Validating {len(env.requests)} requests.")
-        print(f"Expected generated tokens: {expected_generated_tokens_list}")
-        print(f"Actual generated tokens: {[request.generated_tokens for request in env.requests]}")
+            if model_provider == "gpt":
+                expected_generated_tokens_list = gpt_expected_generated_tokens
+            elif model_provider == "hybrid":
+                expected_generated_tokens_list = mamba_expected_generated_tokens
+            else:
+                raise ValueError(f"Invalid model_provider {model_provider}")
 
-        assert len(env.requests) == len(expected_generated_tokens_list)
-
-        for request, expected_generated_tokens in zip(env.requests, expected_generated_tokens_list):
-            assert request.generated_tokens == expected_generated_tokens, (
-                f"request {request.request_id}, "
-                f"result ({request.generated_tokens}) != "
-                f"expected ({expected_generated_tokens})."
+            print(f"Validating {len(env.requests)} requests.")
+            print(f"Expected generated tokens: {expected_generated_tokens_list}")
+            print(
+                f"Actual generated tokens: {[request.generated_tokens for request in env.requests]}"
             )
+
+            assert len(env.requests) == len(expected_generated_tokens_list)
+
+            for request, expected_generated_tokens in zip(
+                env.requests, expected_generated_tokens_list
+            ):
+                assert request.generated_tokens == expected_generated_tokens, (
+                    f"request {request.request_id}, "
+                    f"result ({request.generated_tokens}) != "
+                    f"expected ({expected_generated_tokens})."
+                )
 
     @pytest.mark.internal
     @pytest.mark.skipif(
@@ -2429,15 +2437,20 @@ class TestDynamicInferenceEngine(DynamicInferenceEngineTestBase):
         context = env.engine.context
         if max_requests is None:
             assert context.max_requests == 816
-            assert step_count == 23
         else:
             assert max_requests < len(env.requests), (
                 f"Test is only useful if max_requests ({max_requests}) < "
                 f"num_requests ({len(env.requests)})."
             )
             assert context.max_requests == 4
-            assert step_count == 35
-        assert context.kv_block_allocator.active_count == 655
+        # Exact step counts and KV occupancy depend on sampled token sequences.
+        # With DP-offset sampling seeds, only DP rank 0 matches the golden seed.
+        if parallel_state.get_data_parallel_rank() == 0:
+            if max_requests is None:
+                assert step_count == 23
+            else:
+                assert step_count == 35
+            assert context.kv_block_allocator.active_count == 655
 
     @pytest.mark.internal
     @pytest.mark.skipif(
@@ -4226,8 +4239,8 @@ class TestDynamicInferenceEngine(DynamicInferenceEngineTestBase):
 
         env.engine.controller.tokenizer.detokenize = lambda tokens, **kw: f"tok_{tokens[0]}"
 
-        # top_n must be >= top_k so the sampled token is guaranteed to appear
-        # in the top-n dict for the consistency check below.
+        # top_n must be >= top_k so the top_k-sampled token is guaranteed to
+        # have a higher probability than the least probable token in top_n.
         top_n = 10
         num_requests = 3
         prompt_lengths = [4, 6, 8]
@@ -4266,20 +4279,30 @@ class TestDynamicInferenceEngine(DynamicInferenceEngineTestBase):
                 assert isinstance(top_n_dict, dict)
                 assert 0 < len(top_n_dict) <= top_n
 
-            # Consistency: selected token's log prob should appear in top-n.
+            # Consistency: selected token's log prob should appear in top-n when the
+            # sampled token is among the strict top-n indices. With nearly-tied logits
+            # (random models), top-k filtering keeps all ties at the cutoff, so a sampled
+            # token can fall outside a separate top-n index list. In that case the
+            # selected logprob must still be no worse than the weakest top-n entry.
             if req.generated_log_probs is not None:
                 for j, (lp, top_n_dict, token_id) in enumerate(
                     zip(req.generated_log_probs, req.generated_top_n_logprobs, req.generated_tokens)
                 ):
                     token_str = env.engine.controller.tokenizer.detokenize([token_id])
-                    assert token_str in top_n_dict, (
-                        f"Request {req.request_id}, token {j}: "
-                        f"selected token '{token_str}' not in top-n"
-                    )
-                    assert abs(lp - top_n_dict[token_str]) < 0.01, (
-                        f"Request {req.request_id}, token {j}: "
-                        f"log_prob {lp} vs top-n {top_n_dict[token_str]}"
-                    )
+                    if token_str in top_n_dict:
+                        # Sampled token is in Top N.
+                        assert abs(lp - top_n_dict[token_str]) < 0.01, (
+                            f"Request {req.request_id}, token {j}: "
+                            f"log_prob {lp} vs top-n {top_n_dict[token_str]}"
+                        )
+                    else:
+                        # Sampled token is not in the Top N. It must be a tie.
+                        # Check that it is at least as probable as Top N tokens.
+                        assert lp + 0.01 >= min(top_n_dict.values()), (
+                            f"Request {req.request_id}, token {j}: "
+                            f"selected token '{token_str}' log_prob {lp} is worse than "
+                            f"top-n minimum {min(top_n_dict.values())}"
+                        )
 
     @pytest.mark.internal
     @pytest.mark.skipif(

--- a/tests/unit_tests/inference/engines/test_static_engine.py
+++ b/tests/unit_tests/inference/engines/test_static_engine.py
@@ -212,6 +212,10 @@ class TestStaticInferenceEngine(StaticInferenceEngineTestHarness):
     async def test_streaming(self):
         self.setup_engine(legacy=True)
 
+        # Possible for a rank to not generate any tokens, i.e. EOD only.
+        # Make that impossible when testing streaming.
+        self.mock_tokenizer.eod = self.vocab_size
+
         async def collect_stream(stream_generator, num_tokens_to_generate):
             prev_log_probs = None
             prev_text = ""

--- a/tests/unit_tests/inference/test_inference_config.py
+++ b/tests/unit_tests/inference/test_inference_config.py
@@ -67,3 +67,32 @@ class TestInferenceConfig:
         )
 
         assert inference_config.async_sched_mode == AsyncScheduleMode.OVERLAP
+
+    def test_offset_sampling_seed_argparse_plumbing(self):
+        """Ensure the CLI can select a shared sampling seed across DP ranks."""
+        parser = _add_inference_args(ArgumentParser())
+        default_args = parser.parse_args([])
+        assert default_args.offset_sampling_seed_by_dp_rank is True
+
+        disabled_args = parser.parse_args(["--use-same-sampling-seed-across-dp-ranks"])
+        assert disabled_args.offset_sampling_seed_by_dp_rank is False
+
+    def test_inference_setup_config_maps_offset_sampling_seed_by_dp_rank(self):
+        """Ensure declarative inference config maps DP seed offset to runtime config."""
+        model = SimpleNamespace(
+            position_embedding_type="rope",
+            max_sequence_length=4096,
+            pg_collection="pg",
+            decoder=SimpleNamespace(layer_type_list=None),
+        )
+        setup_config = InferenceSetupConfig(offset_sampling_seed_by_dp_rank=False)
+
+        inference_config = setup_config.to_inference_config(
+            model=model,
+            kv_cache_management_mode="persist",
+            static_kv_memory_pointers=False,
+            enable_cuda_graphs=False,
+            verbose=False,
+        )
+
+        assert inference_config.offset_sampling_seed_by_dp_rank is False

--- a/tests/unit_tests/inference/text_generation_controllers/test_text_generation_controller.py
+++ b/tests/unit_tests/inference/text_generation_controllers/test_text_generation_controller.py
@@ -1153,7 +1153,7 @@ class TestTextGenerationController(TextGenerationControllerTestBase):
             assert (
                 len(request.segments)
                 == len(request.prompt_log_probs) + len(request.generated_log_probs) + 1
-            ), "Segments should be returned for both prompt and generated tokens"
+            ), f"Segments should be returned for both prompt and generated tokens: {request}"
             assert len(request.prompt) + len(request.generated_text) == len(
                 request.text
             ), "Output text should include prompts and generations"
@@ -2352,6 +2352,7 @@ class TestTextGenerationControllerParallel(TextGenerationControllerTestBase):
         Utils.initialize_model_parallel(
             tensor_model_parallel_size=tensor_model_parallel_size,
             pipeline_model_parallel_size=pipeline_model_parallel_size,
+            expert_model_parallel_size=expert_model_parallel_size,
         )
         super().setup_model(
             dtype,
@@ -2521,3 +2522,121 @@ class TestTextGenerationControllerParallel(TextGenerationControllerTestBase):
                 assert (
                     expected == actual
                 ), f"Rank {i} tokens differ from rank {local_rank} tokens for request {j}"
+
+    @pytest.mark.parametrize("static", [True, False])
+    @pytest.mark.parametrize("enable_prefix_caching", [True, False])
+    def test_sampled_tokens_dp_mismatch(self, static, enable_prefix_caching):
+        """
+        TextGenerationController should generate different tokens
+        on every DP rank given the same prompt / request.
+        """
+        if not static and not is_fa_min_version("2.7.3"):
+            pytest.skip(reason="Need latest flash attn for dynamic batching")
+
+        self.setup_model(
+            dtype=torch.bfloat16,
+            # Set all model parallelisms to 1.
+            # No rank should shard the model.
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+            expert_model_parallel_size=1,
+            # Test all batching and balancing strategies.
+            static=static,
+            enable_prefix_caching=enable_prefix_caching,
+            # Set a random seed for generation, so we can
+            # verify that different DP ranks produce disparate
+            # generations given the DP rank seed offset.
+            # Without this, generations will always be random
+            # and we don't be able to verify DP disparity.
+            use_training_random_init=True,
+        )
+        # Ensure only data parallelism is used. This is critical since
+        # we expect generation parity across model parallel ranks.
+        dp_size = parallel_state.get_data_parallel_group().size()
+        assert (
+            dp_size == torch.distributed.get_world_size()
+        ), "[test_sampled_tokens_dp_mismatch] Expected DP size to match WORLD size for this DP disparity test."
+
+        # Prepare requests.
+        active_requests: Dict[str, InferenceRequest] = OrderedDict()
+        for i in range(self.batch_size):
+            # Create a batch of constant prompts to test DP disparity.
+            # Same inputs should produce different outputs.
+            prompt = "sample" * (i + 1)
+            prompt_tokens = [1] * (i + 1)
+            request_id = str(i)
+            inference_request = InferenceRequest(
+                request_id=request_id,
+                prompt=prompt,
+                sampling_params=SamplingParams(
+                    top_k=10, num_tokens_to_generate=25, return_log_probs=True
+                ),
+                arrival_time=time.time(),
+                prompt_tokens=prompt_tokens,
+                status=Status.ACTIVE_BUT_NOT_GENERATING_TOKENS,
+            )
+            active_requests[request_id] = inference_request
+
+        # Generate tokens for each sample of the batch.
+        if static:
+            # Static batching requires dummy metadata and functions.
+            self.mock_tokenizer.vocab_size = self.vocab_size
+            self.mock_tokenizer.eod = self.vocab_size - 1
+            self.mock_tokenizer.detokenize.side_effect = (
+                lambda x, skip_special_tokens=False: ' '.join(
+                    [
+                        ''.join(random.choices(string.ascii_letters, k=random.randint(4, 10)))
+                        for _ in range(len(x))
+                    ]
+                )
+            )
+            self.mock_tokenizer.offsets.side_effect = lambda _, s: [
+                i for i, c in enumerate(s) if c == ' '
+            ] + [len(s)]
+
+            # Generate.
+            requests = self.text_generation_controller.generate_all_output_tokens_static_batch(
+                active_requests
+            )
+            all_generated_tokens = [req.generated_tokens.tolist() for req in requests.values()]
+        else:
+            all_generated_tokens = [[] for _ in range(len(active_requests))]
+            context = self.text_generation_controller.inference_wrapped_model.inference_context
+            for request_id, request in active_requests.items():
+                context.add_request(
+                    DynamicInferenceRequest(
+                        request_id=int(request_id),
+                        prompt_tokens=torch.tensor(
+                            request.prompt_tokens,
+                            dtype=torch.long,
+                            device=torch.cuda.current_device(),
+                        ),
+                        sampling_params=SamplingParams(
+                            top_k=10, return_log_probs=True, num_tokens_to_generate=25
+                        ),
+                    )
+                )
+            expected_active_requests = set(int(x) for x in active_requests.keys())
+            while context.has_unfinished_requests():
+                result = self.text_generation_controller.generate_output_tokens_dynamic_batch()
+                new_tokens = result["sample"]
+                active_ids = result["active_request_ids"].tolist()
+                finished_ids = result["finished_request_ids"].tolist()
+                assert len(new_tokens) == len(expected_active_requests)
+                assert set(active_ids) == expected_active_requests
+                expected_active_requests -= set(finished_ids)
+                for i, token in enumerate(new_tokens.tolist()):
+                    all_generated_tokens[i].append(token)
+
+            # Wait for all requests on all host ranks to complete before proceeding.
+            torch.distributed.barrier()
+
+        # All-gather the generated tokens on every DP rank.
+        all_dp_generated_tokens = [None] * dp_size
+        torch.distributed.all_gather_object(all_dp_generated_tokens, all_generated_tokens)
+        for i in range(self.batch_size):
+            # Get the i-th generation for each DP rank.
+            dp_batch = [tuple(batch[i]) for batch in all_dp_generated_tokens]
+            assert len(set(dp_batch)) == len(
+                dp_batch
+            ), "Detected duplicate generations across DP ranks."


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
<!-- Add a one line overview of what this PR aims to accomplish. -->

- When `enable_prefix_caching=False`, there is a large generation disparity between Megatron-LLM inference and vLLM in the synchronous co-located setup for NeMo-RL, where the same prompt is load-balanced across multiple DP ranks with the exact same seed for the RNG. This PR proposes adding a `seed + dp_rank` offset to ensure that DP ranks do not generate identical output when the same prompt is assigned to multiple DP ranks.
  - Controlled by `InferenceConfig.offset_sampling_seed_by_dp_rank=True`, and deactivated when using `--use-same-sampling-seed-across-dp-ranks` or `ModelParallelConfig.deterministic_mode=True`, to support both determinism and RL training.
    - vLLM fixes the same random seed across generation workers, so multiple workers will generate the same output for the same prompt. However, vLLM supports per-request seeding, which allows users to intentionally diversify the output of each worker on a per-request basis. This might require more work to implement.
    - If the coordinator is random, then the output will not only depend on the fixed seed, but also which DP rank the prompt is sent to, which can make debugging and determinism slightly more complex. An alternative solution is to add affinity to the coordinator's assignments to always assign unique prompts to specific DP ranks, but in any case this can potentially cause drastic load imbalances in production where one DP rank must process all instances of the same prompt.
- Fix a bug with `TextGenerationController.generate_all_output_tokens_static_batch` which truncated the de-tokenized words / segments by the generation length of the wrong sample, instead of the minimum of the generated length and num-tokens-to-generate of the right sample.

# Testing

```
python -m torch.distributed.run --nproc-per-node 8 -m pytest -vvs tests/unit_tests/inference
==== 2201 passed, 105 skipped, 2577 warnings in 624.96s (0:10:24) ====
```
Note: I ran this entire test suite thrice, but there is no hard guarantee I have found every source of randomness and made it test-deterministic. Please ping @cspades on Slack or GitHub if you hit any random failures in the next few weeks. Thanks!

- 🍀 `TestTextGenerationControllerParallel::test_sampled_tokens_dp_mismatch` in `tests/unit_tests/inference/text_generation_controllers/test_text_generation_controller.py` fails when I remove `... + dp_rank` and passes with my fix. It ensures that we have DP disparity for every sample on every DP rank with the same prompt per sample.
- `TestDynamicInferenceEngine::{test_simple, test_max_requests}` in `tests/unit_tests/inference/engines/test_dynamic_engine.py` have golden values calibrated to the RNG seed set before the DP rank offset. Adjusted the golden value assertions to only run on DP rank 0, saves me the hassle of generating golden values for all DP ranks, and I think this is the general pattern for debugging this DP-variant inference engine.
- `TestDynamicInferenceEngine::test_speculative_decoding_non_greedy_with_top_n_logprobs` in `tests/unit_tests/inference/engines/test_dynamic_engine.py` entertains the possibility of sampling a Top K token that is not included in the Top N list due to log-prob ties. Relaxed the probability check to make sure it is at least as probable as the chosen Top N representatives.
- `tests/unit_tests/inference/engines/test_static_engine.py::TestStaticInferenceEngine::test_streaming` has a non-trivial probability to generate no tokens after adding my seed offset. Removed `EOD` as a possibility.
- `tests/unit_tests/inference/test_inference_config.py` - Make sure the CLI argument to turn off the offset works.

# Details

- Code
  - https://github.com/cspades/RL/tree/cye/nemo-rl-mllm-dev
  - https://github.com/cspades/Megatron-Bridge/tree/cye/mbridge-nemo-rl-mllm-dev
  - https://github.com/cspades/Megatron-LM/tree/cye/enable-inference-optimized-qwen-moe

- May be significantly less problematic in the case of `enable_prefix_caching=True` since `prefix_caching_routing_alpha` places a non-trivial convex weight on prompt rank assignments versus load-balancing. So sometimes prompts will find matching DP ranks, while other times prompts will find free GPUs.

- Found this issue by debugging a completely broken `grad_norm` when using co-located RL. It is a discrepancy caused by changing non-colocated (DP2) into co-located (DP4) generation, so the impact of replicate generations is quadratically worse (double the gradients, half of the generations per DP rank, for a fixed number of prompts and number of generations per prompt). Duplicate outputs causes duplicate training samples which blows up the gradient and diverges RL training for the rest of the loop.

<img width="1212" height="782" alt="Screenshot 2026-07-22 at 7 34 06 PM" src="https://github.com/user-attachments/assets/8408789c-fecb-4aff-83e6-aa798c77653c" />

- After adding a DP rank offset to the generation controller seeds, this completely fixed the gradient disparity ([`mcore_sync_colocate_dp4_rng_offset`](https://wandb.ai/adlr/mllm-rl-dev/runs/lbb4tmcv?nw=nwusercye_nv) compared to the original broken [`mcore_sync_colocate_inference_optim`](https://wandb.ai/adlr/mllm-rl-dev/runs/j56cv85v?nw=nwusercye_nv)), and produced even more accurate loss, reward, and validation curves aligned with the non-colocated and async cases that I was also testing.

<img width="400" height="635" alt="Screenshot 2026-07-22 at 7 40 07 PM" src="https://github.com/user-attachments/assets/84a7ec26-76e9-4c77-9307-4af24f583310" />

<img width="593" height="317" alt="Screenshot 2026-07-22 at 7 40 33 PM" src="https://github.com/user-attachments/assets/438b5548-bc80-4b7e-8663-50b3b9208981" />

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
