### PR TITLE
Use explicit process groups for dataloader checkpoints

### DIFF
--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -577,8 +577,15 @@ def save_checkpoint(iteration, model, optimizer, opt_param_scheduler, num_floati
     checkpoint_name = get_checkpoint_name(save_dir, iteration, release=release, pipeline_parallel=pipeline_parallel,
         tensor_rank=tensor_rank, pipeline_rank=pipeline_rank, expert_parallel=expert_parallel, expert_rank=expert_rank, return_base_dir=return_base_dir)
 
-    # Save dataloader state if the dataloader supports it (currently only Megatron Energon).
-    maybe_save_dataloader_state(train_data_iterator, iteration, getattr(args, "dataloader_save", None))
+    # Save dataloader state if the external dataloader supports it.
+    maybe_save_dataloader_state(
+        train_data_iterator,
+        iteration,
+        getattr(args, "dataloader_save", None),
+        tp_group=tp_group,
+        pp_group=pp_group,
+        dp_group=dp_group,
+    )
 
     # Save distributed optimizer's custom parameter state.
     if (
@@ -999,12 +1006,19 @@ def cleanup_old_non_persistent_checkpoint(save_dir, leave_ckpt_num=1, do_async=F
         remove_iter_ckpts(rm_iter_ckpts)
 
 
-def maybe_save_dataloader_state(train_iterator, iteration, dataloader_save_path):
+def maybe_save_dataloader_state(
+    train_iterator,
+    iteration,
+    dataloader_save_path,
+    *,
+    tp_group=None,
+    pp_group=None,
+    dp_group=None,
+):
     """Saves dataloader state if the dataloader supports it.
 
-    Currently, this is only used by Megatron Energon dataloader (multimodal) to store its state at a
-    specific iteration. The Megatron built-in dataloader (text-only) creates index files upfront
-    to track its state.
+    External dataloaders use this to store state at a specific iteration. The Megatron built-in
+    dataloader creates index files upfront to track its state.
 
     If the provided dataloader has `save_state` method, then it is called to save the state.
     Otherwise, no state is saved.
@@ -1013,6 +1027,9 @@ def maybe_save_dataloader_state(train_iterator, iteration, dataloader_save_path)
         train_iterator (iterable): Train dataloader.
         iteration (int): Current iteration.
         dataloader_save_path (str): Path where the dataloader state is saved.
+        tp_group (ProcessGroup): Tensor-parallel group, or MPU fallback when unset.
+        pp_group (ProcessGroup): Pipeline-parallel group, or MPU fallback when unset.
+        dp_group (ProcessGroup): Data-parallel group, or MPU fallback when unset.
     """
     # If no dataloader or saving path is provided, exit early, otherwise, raise an error.
     if train_iterator is None or dataloader_save_path is None or dataloader_save_path == "":
@@ -1023,25 +1040,48 @@ def maybe_save_dataloader_state(train_iterator, iteration, dataloader_save_path)
         raise RuntimeError(f"Could not find a save_state for the train_iterator of type {type(train_iterator)}")
 
     # Save dataloader state for each data parallel rank only once.
-    first_rank = mpu.is_pipeline_first_stage(ignore_virtual=True) and mpu.get_tensor_model_parallel_rank() == 0
+    first_rank = (
+        get_pg_rank(pp_group) == 0
+        if pp_group is not None
+        else mpu.is_pipeline_first_stage(ignore_virtual=True)
+    ) and (
+        get_pg_rank(tp_group) == 0
+        if tp_group is not None
+        else mpu.get_tensor_model_parallel_rank() == 0
+    )
     if not first_rank:
         return
 
-    dp_rank = mpu.get_data_parallel_rank()
+    dp_rank = get_pg_rank(dp_group) if dp_group is not None else mpu.get_data_parallel_rank()
+    train_dataloader_state_dict = train_iterator.iterable.save_state()
     if dp_rank == 0:
         print(f"saving dataloader checkpoint at iteration {iteration} to {dataloader_save_path}")
-    train_dataloader_state_dict = train_iterator.iterable.save_state()
     data_state_save_path = get_checkpoint_name(
-        dataloader_save_path, iteration,
-        basename=f'train_dataloader_dprank{dp_rank:03d}.pt'
+        dataloader_save_path,
+        iteration,
+        pipeline_parallel=(
+            get_pg_size(pp_group) > 1
+            if pp_group is not None
+            else mpu.get_pipeline_model_parallel_world_size() > 1
+        ),
+        # Dataloader state is sharded only by DP rank. Keep it in the canonical TP0/PP0 directory.
+        tensor_rank=0,
+        pipeline_rank=0,
+        expert_parallel=False,
+        expert_rank=0,
+        basename=f'train_dataloader_dprank{dp_rank:03d}.pt',
     )
 
-    torch.distributed.barrier(group=mpu.get_data_parallel_group())
+    data_parallel_group = dp_group if dp_group is not None else mpu.get_data_parallel_group()
+    torch.distributed.barrier(group=data_parallel_group)
 
-    if mpu.get_data_parallel_rank() == 0:
+    if dp_rank == 0:
         ensure_directory_exists(data_state_save_path)
 
-    torch.distributed.barrier(group=mpu.get_data_parallel_group())
+    torch.distributed.barrier(group=data_parallel_group)
+
+    if train_dataloader_state_dict is None:
+        return
 
     dataloader_save_dict = {}
     dataloader_save_dict['dataloader_state_dict'] = train_dataloader_state_dict

--- a/tests/unit_tests/test_checkpointing.py
+++ b/tests/unit_tests/test_checkpointing.py
@@ -25,6 +25,7 @@ from megatron.training.checkpointing import (
     _load_base_checkpoint,
     get_checkpoint_tracker_filename,
     load_checkpoint,
+    maybe_save_dataloader_state,
     read_metadata,
     save_checkpoint,
 )
@@ -72,6 +73,80 @@ class MockState:
     def sharded_state_dict(self, *args, metadata: Optional[dict] = None, **kwargs):
         self._called_metadata.append(metadata)
         return self.state_dict()
+
+
+def test_maybe_save_dataloader_state_uses_explicit_process_groups(tmp_path):
+    """Dataloader checkpoints use the supplied module groups and canonical model-parallel path."""
+    groups = {
+        "tp": SimpleNamespace(rank=0, size=2),
+        "pp": SimpleNamespace(rank=0, size=2),
+        "dp": SimpleNamespace(rank=3, size=4),
+    }
+    barriers = []
+    saved = []
+    iterator = SimpleNamespace(
+        iterable=SimpleNamespace(save_state=lambda: {"global_sequence_id": 16})
+    )
+
+    with (
+        mock.patch(
+            "megatron.training.checkpointing.get_pg_rank", side_effect=lambda group: group.rank
+        ),
+        mock.patch(
+            "megatron.training.checkpointing.get_pg_size", side_effect=lambda group: group.size
+        ),
+        mock.patch(
+            "megatron.training.checkpointing.torch.distributed.barrier",
+            side_effect=lambda group: barriers.append(group),
+        ),
+        mock.patch(
+            "megatron.training.checkpointing.torch.save",
+            side_effect=lambda state, path: saved.append((state, path)),
+        ),
+    ):
+        maybe_save_dataloader_state(
+            iterator,
+            2,
+            tmp_path,
+            tp_group=groups["tp"],
+            pp_group=groups["pp"],
+            dp_group=groups["dp"],
+        )
+
+    assert barriers == [groups["dp"], groups["dp"]]
+    assert saved[0][0] == {"dataloader_state_dict": {"global_sequence_id": 16}}
+    assert saved[0][1] == str(
+        tmp_path / "iter_0000002" / "mp_rank_00_000" / "train_dataloader_dprank003.pt"
+    )
+
+
+def test_maybe_save_dataloader_state_skips_empty_state_after_barriers(tmp_path):
+    """Ranks without dataloader state participate in barriers but do not write a file."""
+    group = SimpleNamespace(rank=0, size=1)
+    iterator = SimpleNamespace(iterable=SimpleNamespace(save_state=lambda: None))
+    barriers = []
+
+    with (
+        mock.patch(
+            "megatron.training.checkpointing.get_pg_rank",
+            side_effect=lambda process_group: process_group.rank,
+        ),
+        mock.patch(
+            "megatron.training.checkpointing.get_pg_size",
+            side_effect=lambda process_group: process_group.size,
+        ),
+        mock.patch(
+            "megatron.training.checkpointing.torch.distributed.barrier",
+            side_effect=lambda group: barriers.append(group),
+        ),
+        mock.patch("megatron.training.checkpointing.torch.save") as save,
+    ):
+        maybe_save_dataloader_state(
+            iterator, 2, tmp_path, tp_group=group, pp_group=group, dp_group=group
+        )
+
+    assert barriers == [group, group]
+    save.assert_not_called()
 
 
 def create_checkpoint(load_path, ckpt_format):


### PR DESCRIPTION
## Summary

- pass the checkpoint caller's tensor-, pipeline-, and data-parallel groups into external dataloader state saving
- select the single TP0/PP0 writer and run save barriers through those explicit module groups, while retaining MPU fallback behavior
- keep ranks whose `save_state()` returns `None` in both data-parallel barriers and skip only their file write

## Motivation

Heterogeneous training can use module-specific process groups that differ from the global MPU groups. Dataloader checkpoint saving needs to use the caller's groups both to select writers and to keep collectives scoped to the correct data-parallel group.

## Validation

- `isort` on both changed Python files
- Black check on the changed test file
- Ruff, `compileall`, and `git diff --check`
- OCI-HSG Slurm job `5570068`: `2 passed, 15 deselected`
