### PR TITLE
fix(mhc): update CUDA graph module API

### DIFF
--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -1722,13 +1722,13 @@ class HyperConnectionTransformerLayer(TransformerLayer):
         """
         submodules = super()._get_submodules_under_cudagraphs()
 
-        if not self.config.cuda_graph_scope:
+        if not self.config.cuda_graph_modules:
             return submodules
 
-        if CudaGraphScope.attn in self.config.cuda_graph_scope:
+        if CudaGraphModule.attn in self.config.cuda_graph_modules:
             submodules.append(self.self_attention_hyper_connection)
         # HC layer rejects MoE MLPs in __init__, so only the dense (mlp) scope applies.
-        if CudaGraphScope.mlp in self.config.cuda_graph_scope:
+        if CudaGraphModule.mlp in self.config.cuda_graph_modules:
             submodules.append(self.mlp_hyper_connection)
         return submodules
 

--- a/tests/unit_tests/transformer/test_transformer_layer.py
+++ b/tests/unit_tests/transformer/test_transformer_layer.py
@@ -21,7 +21,7 @@ from megatron.core.tensor_parallel.random import (
     model_parallel_cuda_manual_seed,
 )
 from megatron.core.transformer.cuda_graphs import CudaGraphManager, _CudagraphGlobalRecord
-from megatron.core.transformer.enums import InferenceCudaGraphScope
+from megatron.core.transformer.enums import CudaGraphModule, InferenceCudaGraphScope
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.transformer.transformer_layer import (
     HyperConnectionTransformerLayer,
@@ -794,18 +794,14 @@ class TestMHCWithCudaGraph:
         (mapping_proj, alpha_*, bias) will not get proper pre-forward hooks during
         graph replay, leading to stale parameter values.
         """
-        layer, config = self._create_mhc_layer()
+        layer, config = self._create_mhc_layer(
+            cuda_graph_modules=[CudaGraphModule.attn, CudaGraphModule.mlp]
+        )
 
         submodules = layer._get_submodules_under_cudagraphs()
 
-        hc_modules_found = any(
-            hasattr(m, 'mapping_proj') for submod in submodules for m in submod.modules()
-        )
-        assert hc_modules_found, (
-            "_get_submodules_under_cudagraphs does not include HyperConnectionModule. "
-            "Parameters like mapping_proj, alpha_pre/post/res will not be updated "
-            "during CUDA graph replay."
-        )
+        assert layer.self_attention_hyper_connection in submodules
+        assert layer.mlp_hyper_connection in submodules
 
     def test_forward_through_te_cuda_graph_capture_path(self):
         """_te_cuda_graph_capture must produce correct output shapes for mHC.


### PR DESCRIPTION
# fix(mhc): update CUDA graph module API

## Summary

Update `HyperConnectionTransformerLayer._get_submodules_under_cudagraphs()` to use the
current CUDA graph configuration API:

- `cuda_graph_modules` instead of the deprecated `cuda_graph_scope`
- `CudaGraphModule` instead of the removed `CudaGraphScope`

This is a compatibility-only follow-up. It does not add new mHC or DSv4 behavior.

## Stack

- Base: NVIDIA/Megatron-LM#4531 (`pull-request/4531`)
- Base commit: `f1df30c1db8c2ece4df1e0465b89f67f12337e7b`
- Related integration umbrella: NVIDIA/Megatron-LM#5795

This PR should merge after #4531. Before #4531 merges, retarget this PR to `main`
and refresh it against the merged result so GitHub does not automatically close
the dependent PR.

## Credit

The mHC implementation being updated was authored by @Connor-XY in
NVIDIA/Megatron-LM#4531. This follow-up only adapts that implementation to the
current CUDA graph module API needed by the #5795 integration.

## Validation

- `uv run ruff check megatron/core/transformer/transformer_layer.py`
- `uv run python -m py_compile megatron/core/transformer/transformer_layer.py`
- `git diff --check`
- Targeted pytest collection attempted:
  `tests/unit_tests/transformer/test_transformer_layer.py::TestMHCWithCudaGraph::test_submodules_under_cudagraphs_includes_hyper_connection`
  (blocked locally because the available environment does not include `torch`)

## Checklist

- [x] One compatibility fix in one production file
- [x] Original author and PR credited
- [x] #5795 referenced for integration context
- [x] Intended to be opened as a draft
