### PR TITLE
Fix sequence-level MoE aux loss under sequence parallelism with packed sequences

### DIFF
--- a/megatron/core/transformer/moe/moe_layer.py
+++ b/megatron/core/transformer/moe/moe_layer.py
@@ -435,13 +435,18 @@ class MoELayer(BaseMoELayer):
             self._delayed_wgrad_stream = torch.cuda.Stream(device="cuda")
 
     @maybe_skip_or_early_return_by_cudagraph("route")
-    def route(self, hidden_states: torch.Tensor, padding_mask: Optional[torch.Tensor] = None):
+    def route(
+        self,
+        hidden_states: torch.Tensor,
+        padding_mask: Optional[torch.Tensor] = None,
+        moe_seq_idx: Optional[torch.Tensor] = None,
+    ):
         """Compute token routing for preprocessing.
 
         This method uses the router to determine which experts to send each token to,
         producing routing probabilities and a mapping.
         """
-        probs, routing_map = apply_module(self.router)(hidden_states, padding_mask)
+        probs, routing_map = apply_module(self.router)(hidden_states, padding_mask, moe_seq_idx)
         return probs, routing_map
 
     @maybe_skip_or_early_return_by_cudagraph("preprocess")
@@ -600,6 +605,7 @@ class MoELayer(BaseMoELayer):
         hidden_states: torch.Tensor,
         intermediate_tensors=None,
         padding_mask: Optional[torch.Tensor] = None,
+        moe_seq_idx: Optional[torch.Tensor] = None,
     ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
         """Forward pass for the MoE layer.
 
@@ -639,11 +645,13 @@ class MoELayer(BaseMoELayer):
             padding_mask = padding_mask.transpose(0, 1).bool()
 
         # MoE forward: route -> dispatch -> compute -> combine
-        def custom_forward(hidden_states, intermediate_tensors=None, padding_mask=None):
+        def custom_forward(
+            hidden_states, intermediate_tensors=None, padding_mask=None, moe_seq_idx=None
+        ):
             try:
                 if "route" in self.fwd_execution_map:
                     shared_expert_output = self.shared_experts_compute(hidden_states)
-                    probs, routing_map = self.route(hidden_states, padding_mask)
+                    probs, routing_map = self.route(hidden_states, padding_mask, moe_seq_idx)
                     hidden_states, probs = self.preprocess(hidden_states, probs, routing_map)
 
                     if intermediate_tensors is not None:
@@ -692,13 +700,19 @@ class MoELayer(BaseMoELayer):
                     hidden_states,
                     intermediate_tensors,
                     padding_mask,
+                    moe_seq_idx,
                 )
             else:
                 outputs = tensor_parallel.checkpoint(
-                    custom_forward, False, hidden_states, intermediate_tensors, padding_mask
+                    custom_forward,
+                    False,
+                    hidden_states,
+                    intermediate_tensors,
+                    padding_mask,
+                    moe_seq_idx,
                 )
         else:
-            outputs = custom_forward(hidden_states, intermediate_tensors, padding_mask)
+            outputs = custom_forward(hidden_states, intermediate_tensors, padding_mask, moe_seq_idx)
 
         return outputs
 

--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -452,6 +452,7 @@ class TopKRouter(Router):
         seq_length: int,
         bsz: int,
         with_padding_mask: bool = False,
+        moe_seq_idx: Optional[torch.Tensor] = None,
     ):
         """Apply the sequence-level auxiliary loss for the given scores and routing map.
 
@@ -459,13 +460,42 @@ class TopKRouter(Router):
         experts dimension. The resulted loss by switch_load_balancing_loss_func is equal
         to the sum of aux loss for each sequence in the batch. And then we divide the aux
         loss by the batch size to get averaged aux loss.
+
+        When ``moe_seq_idx`` is given the sequences are packed (inter-document masking
+        flattened the batch into [num_tokens, 1, H]), so the [seq, bsz] reshape cannot
+        group tokens by sample -- under sequence parallelism a contiguous shard can
+        straddle sample boundaries. Instead we scatter each token's expert vector into its
+        sample's column block, producing the same [rows, bsz*E] layout so the tp_cp
+        reduction below still recombines samples that were split across ranks.
         """
         seq_aux_loss_coeff = self.get_aux_loss_coeff("seq_aux_loss")
         if seq_aux_loss_coeff == 0:
             return probs
 
-        scores_for_aux_loss = scores_for_aux_loss.reshape(seq_length, -1)
-        routing_map = routing_map.reshape(seq_length, -1)
+        if moe_seq_idx is None:
+            scores_for_aux_loss = scores_for_aux_loss.reshape(seq_length, -1)
+            routing_map = routing_map.reshape(seq_length, -1)
+        else:
+            moe_seq_idx = moe_seq_idx.reshape(-1).long()
+            # Global sample count: SP may leave the tail sample only on the last rank.
+            bsz = moe_seq_idx.max() + 1
+            torch.distributed.all_reduce(
+                bsz, op=torch.distributed.ReduceOp.MAX, group=self.tp_cp_group
+            )
+            bsz = int(bsz.item())
+            num_experts = self.config.num_moe_experts
+            cols = moe_seq_idx[:, None] * num_experts + torch.arange(
+                num_experts, device=moe_seq_idx.device
+            )
+            scores_for_aux_loss = scores_for_aux_loss.new_zeros(
+                scores_for_aux_loss.shape[0], bsz * num_experts
+            ).scatter_(1, cols, scores_for_aux_loss)
+            routing_map = routing_map.new_zeros(
+                routing_map.shape[0], bsz * num_experts
+            ).scatter_(1, cols, routing_map)
+            # Force the valid-token-count path: it normalizes total_num_tokens per sample
+            # (dividing by bsz), which the else-branch's row-count path does not.
+            with_padding_mask = True
 
         global_tokens_per_expert, local_num_tokens, total_num_tokens = (
             get_tokens_per_expert_and_token_count(
@@ -738,7 +768,12 @@ class TopKRouter(Router):
                     routing_map = routing_map & (~padding_mask)
                 self.local_tokens_per_expert += routing_map.sum(dim=0)
 
-    def routing(self, logits: torch.Tensor, padding_mask: Optional[torch.Tensor] = None):
+    def routing(
+        self,
+        logits: torch.Tensor,
+        padding_mask: Optional[torch.Tensor] = None,
+        moe_seq_idx: Optional[torch.Tensor] = None,
+    ):
         """Top-k routing function
 
         Args:
@@ -746,6 +781,8 @@ class TopKRouter(Router):
             padding_mask (torch.Tensor, optional): Boolean mask indicating non-padding tokens.
                                                    Shape [seq_length, bsz]. True for valid tokens,
                                                    False for padding tokens. Defaults to None.
+            moe_seq_idx (torch.Tensor, optional): Per-token global sample index for packed
+                                                  sequences, used by seq_aux_loss. Defaults to None.
 
         Returns:
             probs (torch.Tensor): The probabilities of token to experts assignment.
@@ -818,6 +855,7 @@ class TopKRouter(Router):
                 seq_length,
                 bsz,
                 with_padding_mask=padding_mask is not None,
+                moe_seq_idx=moe_seq_idx,
             )
             probs = self._apply_global_aux_loss(
                 probs,
@@ -837,7 +875,12 @@ class TopKRouter(Router):
             self.global_tokens_per_expert.zero_()
             self.ga_steps.zero_()
 
-    def forward(self, input: torch.Tensor, padding_mask: Optional[torch.Tensor] = None):
+    def forward(
+        self,
+        input: torch.Tensor,
+        padding_mask: Optional[torch.Tensor] = None,
+        moe_seq_idx: Optional[torch.Tensor] = None,
+    ):
         """
         Forward pass of the router.
 
@@ -846,6 +889,8 @@ class TopKRouter(Router):
             padding_mask (torch.Tensor, optional): Boolean mask indicating non-padding tokens.
                                                    Shape [seq_length, bsz]. True for valid tokens,
                                                    False for padding tokens. Defaults to None.
+            moe_seq_idx (torch.Tensor, optional): Per-token global sample index for packed
+                                                  sequences, used by seq_aux_loss. Defaults to None.
         """
         self._maintain_float32_expert_bias()
 
@@ -863,7 +908,9 @@ class TopKRouter(Router):
                 logits, self.config.moe_router_force_biased, self.layer_number
             )
 
-        probs, routing_map = self.routing(logits, padding_mask=padding_mask)
+        probs, routing_map = self.routing(
+            logits, padding_mask=padding_mask, moe_seq_idx=moe_seq_idx
+        )
 
         return probs, routing_map
 

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -760,29 +760,50 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
 
         return pre_mlp_layernorm_output
 
-    def _maybe_unflatten_for_moe(self, hidden_states, padding_mask, packed_seq_params):
-        """Un-flatten packed sequences to restore the batch dimension for MoE.
+    def _maybe_unflatten_for_moe(
+        self, hidden_states, padding_mask, packed_seq_params, use_seq_idx=True
+    ):
+        """Recover per-sample structure for MoE seq_aux_loss on packed sequences.
 
-        When inter-document masking flattens MBS > 1 into [mbs*S, 1, H], the MoE
-        router sees bsz=1 and computes seq_aux_loss over the entire flattened
-        sequence instead of per sample. Un-flattening to [S, mbs, H] before the
-        MoE layer restores the correct per-sample structure.
+        When inter-document masking flattens MBS > 1 into [mbs*S, 1, H], the MoE router
+        sees bsz=1 and would compute seq_aux_loss over the entire flattened sequence.
+
+        Without context parallelism we hand the router a per-token global sample index
+        (``moe_seq_idx``) instead of reshaping: sequence parallelism splits the flattened
+        sequence into contiguous shards that can straddle sample boundaries, so a local
+        reshape to [S, mbs, H] is not possible, but a per-token index survives sharding.
+        With context parallelism (which reorders tokens) we fall back to the reshape path.
 
         Returns:
-            (hidden_states, padding_mask, mbs) where mbs is None if no
-            un-flattening was applied.
+            (hidden_states, padding_mask, mbs, moe_seq_idx). mbs is None unless the reshape
+            path ran; moe_seq_idx is None unless the sample-index path ran.
         """
         if (
             not self.is_moe_layer
             or packed_seq_params is None
             or getattr(packed_seq_params, 'tokens_per_sample', None) is None
         ):
-            return hidden_states, padding_mask, None
+            return hidden_states, padding_mask, None, None
 
         tokens_per_sample = packed_seq_params.tokens_per_sample
+
+        if use_seq_idx and self.config.context_parallel_size == 1:
+            # tokens_per_sample is the unsharded sample length; shape[0] is this rank's
+            # sequence-parallel shard. The shard holds contiguous global positions
+            # [sp_rank * n_local, (sp_rank + 1) * n_local), so token t belongs to sample
+            # (sp_rank * n_local + t) // tokens_per_sample. The router reduces these counts
+            # over tp_cp, recombining samples split across ranks.
+            sp_group = self.pg_collection.tp
+            n_local = hidden_states.shape[0]
+            global_pos = sp_group.rank() * n_local + torch.arange(
+                n_local, device=hidden_states.device
+            )
+            moe_seq_idx = global_pos // tokens_per_sample
+            return hidden_states, padding_mask, None, moe_seq_idx
+
         mbs = hidden_states.shape[0] // tokens_per_sample
         if mbs <= 1:
-            return hidden_states, padding_mask, None
+            return hidden_states, padding_mask, None, None
 
         # The flattened tensor has all tokens from sample 0, then all tokens
         # from sample 1, etc. A plain reshape would keep that ordering, but we
@@ -791,7 +812,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         hidden_states = hidden_states.view(mbs, tokens_per_sample, -1).transpose(0, 1).contiguous()
         if padding_mask is not None:
             padding_mask = padding_mask.view(mbs, tokens_per_sample)
-        return hidden_states, padding_mask, mbs
+        return hidden_states, padding_mask, mbs, None
 
     def _maybe_reflatten_from_moe(self, output, packed_seq_params, mbs):
         """Re-flatten MoE output back to [mbs*S, 1, H] for the residual add."""
@@ -841,9 +862,14 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         if self.config.fp32_residual_connection:
             residual = residual.float()
 
-        pre_mlp_layernorm_output, padding_mask, moe_unflatten_mbs = self._maybe_unflatten_for_moe(
-            pre_mlp_layernorm_output, padding_mask, packed_seq_params
+        pre_mlp_layernorm_output, padding_mask, moe_unflatten_mbs, moe_seq_idx = (
+            self._maybe_unflatten_for_moe(
+                pre_mlp_layernorm_output, padding_mask, packed_seq_params
+            )
         )
+        # Only MoE layers on the packed path produce moe_seq_idx; pass it through the same
+        # kwargs the MoE layer already threads to its router, and leave dense MLPs untouched.
+        moe_kwargs = {} if moe_seq_idx is None else {"moe_seq_idx": moe_seq_idx}
 
         nvtx_range_push(suffix="mlp")
         # Potentially chunk the MLP computation during prefill to minimize the peak activation size
@@ -877,10 +903,13 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
                     self.pg_collection.tp,
                     pre_mlp_layernorm_output,
                     padding_mask=padding_mask,
+                    **moe_kwargs,
                 )
             else:
                 mlp_output_with_bias = tensor_parallel.checkpoint(
-                    functools.partial(apply_module(self.mlp), padding_mask=padding_mask),
+                    functools.partial(
+                        apply_module(self.mlp), padding_mask=padding_mask, **moe_kwargs
+                    ),
                     False,
                     pre_mlp_layernorm_output,
                 )
@@ -912,7 +941,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
                 # operation in MLP's fc2.
                 self._set_fc2_residual(residual)
             mlp_output_with_bias = apply_module(self.mlp)(
-                pre_mlp_layernorm_output, padding_mask=padding_mask
+                pre_mlp_layernorm_output, padding_mask=padding_mask, **moe_kwargs
             )
 
         if moe_unflatten_mbs is not None:
@@ -1736,8 +1765,13 @@ class MoETransformerLayer(TransformerLayer):
             )
 
         if self.use_partial_cudagraphs:
-            hidden_states, padding_mask, moe_unflatten_mbs = self._maybe_unflatten_for_moe(
-                hidden_states, padding_mask, packed_seq_params
+            # TODO: route moe_seq_idx through the partial-cudagraph path so packed
+            # seq_aux_loss uses the sample-index path here too. For now use_seq_idx=False
+            # keeps the exact prior reshape behavior on this path.
+            hidden_states, padding_mask, moe_unflatten_mbs, _moe_seq_idx = (
+                self._maybe_unflatten_for_moe(
+                    hidden_states, padding_mask, packed_seq_params, use_seq_idx=False
+                )
             )
 
             if self.moe_layer_recompute:


### PR DESCRIPTION
## What

Fixes the sequence-level load balancing loss (`seq_aux_loss`) diverging when **inter-document masking** (packed/THD sequences) is combined with **sequence parallelism** (TP > 1) and **micro-batch size > 1**. All other combinations of these settings already match.

## Root cause

Packing flattens the micro-batch into `[mbs*S, 1, H]`, and sequence-parallel scatter (`_split_along_first_dim`) splits that flat sequence into contiguous shards that can straddle sample boundaries. `_maybe_unflatten_for_moe` tried to recover the `[S, mbs, H]` layout with a local reshape, but:

1. it computed `mbs = hidden_states.shape[0] // tokens_per_sample` from the **SP-sharded** `shape[0]` against the **unsharded** `tokens_per_sample`, collapsing to `<= 1` and silently skipping the un-flatten (so the router saw `bsz=1` and scored the whole pack as one sequence); and
2. even with the correct `mbs`, a purely local reshape cannot reconstruct a sample that SP has split across ranks.

This reproduces exactly: `tp=1` (any mbs) and `tp=2, mbs=1` are fine; `tp=2, mbs∈{2,3}` are wrong, independent of `--calculate-per-token-loss`.

## Fix

Instead of reshaping, attribute each local token to its **global sample index** and scatter each token's expert vector into that sample's column block. This produces the same `[rows, bsz*E]` layout the reshape produced, so the existing `tp_cp` reduction recombines samples split across ranks and **all downstream aux-loss math is unchanged** (the change is essentially the two `reshape` lines gaining a scatter alternative).

- For `tp=1` the result is numerically identical to the previous un-flatten path.
- For `tp>1` it is now correct and micro-batch-size invariant.

## Scope / follow-ups

- **Context parallelism** (`cp>1`) and the **partial-cudagraph** path retain the previous reshape behavior for now (gated by `use_seq_idx`), since CP reorders tokens and needs a CP-aware index.
- A regression test (packed variant of `test_seq_aux_loss_mbs_invariant_per_token_loss` asserting invariance across `tp∈{1,2}`) is still to be added.

> [!WARNING]
> Not yet run on GPU — needs functional/unit validation before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)