### PR TITLE
docs(skills): clarify container::lts is the older LTS PyTorch base

### DIFF
--- a/skills/mcore-build-and-dependency/SKILL.md
+++ b/skills/mcore-build-and-dependency/SKILL.md
@@ -51,12 +51,16 @@ dependency.
 ## dev vs lts
 
 Two image variants exist, each with its own Dockerfile, selected by the
-`container::lts` PR label:
+`container::lts` PR label. The defining difference is the **base container**:
+`dev` tracks the latest NGC PyTorch release, while `lts` ("long-term support")
+pins the previous, still-supported NGC PyTorch/CUDA release. `container::lts`
+exists to verify a change still works on that older base — the dependency
+differences below follow from it, they are not the point.
 
 | Variant | Base image pin | Dockerfile | Where deps live | When used |
 |---------|---------------|------------|-----------------|-----------|
-| **`dev`** | `docker/.ngc_version.dev` | `docker/Dockerfile.ci.dev` | `pyproject.toml` `dev` extra (uv-resolved) | Default — CI, local development, most PRs |
-| **`lts`** | `docker/.ngc_version.lts` | `docker/Dockerfile.ci.lts` | `docker/lts/requirements.txt` (pinned, sourced from main's `uv.lock` at AUT-479) | Stability testing; excludes ModelOpt and other bleeding-edge extras |
+| **`dev`** | `docker/.ngc_version.dev` (latest NGC release) | `docker/Dockerfile.ci.dev` | `pyproject.toml` `dev` extra (uv-resolved) | Default — CI, local development, most PRs |
+| **`lts`** | `docker/.ngc_version.lts` (older long-term-support release) | `docker/Dockerfile.ci.lts` | `docker/lts/requirements.txt` (pinned, sourced from main's `uv.lock` at AUT-479) | Backward-compat lane — verify the change still runs on the older NGC base; extras not carried on it (ModelOpt, the CUDA-13 TransformerEngine build) are dropped |
 
 > LTS deps used to live in `[project.optional-dependencies].lts` in
 > `pyproject.toml`. They were moved into `docker/lts/requirements.txt` so
@@ -66,8 +70,8 @@ Two image variants exist, each with its own Dockerfile, selected by the
 
 **Use `dev` for everything unless you have a specific reason to test `lts`.**
 CI runs `dev` by default; attach `container::lts` to a PR only when verifying
-compatibility with the stable stack (e.g. a dependency upgrade that must not
-break LTS users). The `@pytest.mark.flaky_in_dev` marker skips tests in the
+that a change still works on the older long-term-support PyTorch/CUDA base that
+LTS users run (e.g. a container or dependency upgrade). The `@pytest.mark.flaky_in_dev` marker skips tests in the
 `dev` environment; `@pytest.mark.flaky` skips them in `lts`.
 
 ---

--- a/skills/mcore-build-and-dependency/SKILL.md
+++ b/skills/mcore-build-and-dependency/SKILL.md
@@ -23,6 +23,10 @@ up front before the longer workflow:
 - Default `dev` uses `docker/.ngc_version.dev` and the `dev` uv group; `lts`
   uses `docker/.ngc_version.lts` and the `lts` uv group. The `container::lts`
   PR label selects the LTS path; otherwise CI uses `dev`.
+- **`lts` is opt-in only when the user explicitly asks for it.** It is the older
+  long-term-support base, not a routine second lane — never attach
+  `container::lts`, build the LTS image, or run the `lts` uv group on your own
+  initiative, not even for a container or dependency change.
 - Install commands inside the container: `uv sync --locked --group dev --group test`,
   `uv sync --locked --only-group linting`, or
   `uv sync --locked --group lts --group test`.
@@ -68,11 +72,15 @@ differences below follow from it, they are not the point.
 > with the LTS pin set. To bump an LTS dependency, edit the version in
 > `docker/lts/requirements.txt` and rebuild `docker/Dockerfile.ci.lts`.
 
-**Use `dev` for everything unless you have a specific reason to test `lts`.**
-CI runs `dev` by default; attach `container::lts` to a PR only when verifying
-that a change still works on the older long-term-support PyTorch/CUDA base that
-LTS users run (e.g. a container or dependency upgrade). The `@pytest.mark.flaky_in_dev` marker skips tests in the
-`dev` environment; `@pytest.mark.flaky` skips them in `lts`.
+**Use `dev` for everything. `lts` is off-limits unless the user explicitly asks
+for it.** CI runs `dev` by default, and that is the only variant you touch on
+your own initiative. Treat `container::lts` as a high barrier, not a fallback: do
+**not** attach the label, build `docker/Dockerfile.ci.lts`, or run the `lts` uv
+group unless the user has explicitly requested LTS validation — not even for a
+container or dependency change. When they do ask, `container::lts` verifies the
+change still works on the older long-term-support PyTorch/CUDA base that LTS
+users run. The `@pytest.mark.flaky_in_dev` marker skips tests in the `dev`
+environment; `@pytest.mark.flaky` skips them in `lts`.
 
 ---
 

--- a/skills/mcore-cicd/SKILL.md
+++ b/skills/mcore-cicd/SKILL.md
@@ -19,7 +19,9 @@ For PR-label or trigger questions, lead with the exact values:
 - `Run tests`: `scope=mr-github`, `n_repeat=1`, `lightweight=true`.
 - `Run functional tests`: `scope=mr-github`, `n_repeat=5`, `lightweight=false`.
 - `container::lts` only switches the container image path to LTS and combines
-  with any scope label.
+  with any scope label. **Opt-in only — attach it solely when the user
+  explicitly asks for LTS validation; never add it on your own initiative, even
+  for a container or dependency change.**
 - `Run MBridge tests` additionally triggers the MBridge L1 suite.
 - ⚠️ **WARNING — destructive remote write.** `tools/trigger_internal_ci.py`
   **force-pushes the current branch** to the internal GitLab remote as
@@ -88,7 +90,7 @@ The CI pipeline reads PR labels to decide test scope, n_repeat, and container im
 | **Re-enabling a disabled test** (scope `-broken` → active) | `Run functional tests` |
 | Non-numerical library code (logging, error handling, CLI flags, refactors) | `Run tests` |
 | Could affect training numerics (model arch, attention, optimizer, distributed, MoE routing) | `Run functional tests` |
-| Container or dependency changes (`docker/`, `pyproject.toml`, `uv.lock`) | `Run tests` + `container::lts` |
+| Container or dependency changes (`docker/`, `pyproject.toml`, `uv.lock`) | `Run tests` (add `container::lts` **only if the user explicitly asks** to validate LTS) |
 | Touches MBridge integration | add `Run MBridge tests` |
 
 **Rule of thumb:** default to `Run tests`. Always use `Run functional tests` when the PR adds new test cases (golden values must be generated) or when the change could plausibly shift loss curves.

--- a/skills/mcore-cicd/SKILL.md
+++ b/skills/mcore-cicd/SKILL.md
@@ -74,7 +74,7 @@ The CI pipeline reads PR labels to decide test scope, n_repeat, and container im
 
 | Label | Effect |
 |-------|--------|
-| **`container::lts`** | Use the LTS base image instead of `dev` (combinable with any scope label) |
+| **`container::lts`** | Build on the older long-term-support NGC PyTorch base instead of `dev`'s latest — a backward-compat check, not a different test set (combinable with any scope label) |
 | **`Run MBridge tests`** | Also triggers the MBridge L1 test suite |
 
 ### Which label to attach when opening a PR


### PR DESCRIPTION
## Background / motivation

`dev`-branch counterpart of #6008 (same change, based on `dev`).

The `mcore-build-and-dependency` and `mcore-cicd` skills described `container::lts`
as "stability testing" that "excludes ModelOpt and other bleeding-edge extras" /
"use the LTS base image". That buries the defining fact and reads as if `lts` is a
curated stable *dependency subset*. It isn't — `lts` is the **older,
long-term-support NGC PyTorch/CUDA base image**; the dropped extras are a
*consequence* of that older base, not the reason the lane exists. The old wording
also let an agent auto-attach `container::lts` for any container/dep change, which
is wrong: LTS validation should require an explicit request.

Evidence (this branch):

- `docker/.ngc_version.dev` → `nvcr.io/nvidia/pytorch:26.06-py3` (latest)
- `docker/.ngc_version.lts` → `nvcr.io/nvidia/pytorch:25.09-py3` (older / long-term support)

## What changed

- `skills/mcore-build-and-dependency/SKILL.md` — lead the "dev vs lts" section with
  the base-container difference; reframe the `lts` "when used" cell as a
  backward-compat lane; annotate the pins as latest vs older.
- **Gate `container::lts` behind an explicit user request** — add an Answer-First
  constant and rewrite the "use dev" guidance so `lts` is a hard opt-in: never
  attach the label, build the LTS image, or run the `lts` uv group on your own
  initiative, not even for a container/dependency change.
- `skills/mcore-cicd/SKILL.md` — rewrite the `container::lts` label cell for the
  backward-compat intent, add the opt-in-only caveat to the Answer-First facts, and
  drop the auto-`container::lts` recommendation from the "which label to attach"
  table (add it only on explicit request).

## Details

- The `@pytest.mark.flaky` / `flaky_in_dev` marker sentence was already correct
  (`tests/unit_tests/run_ci_test.sh` gates `not flaky` in the lts env and
  `not flaky_in_dev` in the dev env) — left unchanged.
- `nvidia-resiliency-ext` *is* present in `docker/lts/requirements.txt`, so it is
  deliberately **not** listed among the dropped extras; only ModelOpt and the
  CUDA-13 TransformerEngine build are called out.
- Doc-only. The stale `skill.oms.sig` will be re-attached by `nv-skills-ci[bot]`
  via `/nvskills-ci`.
- Opened alongside the `main` PR because it was explicitly requested on both
  branches; `main` and `dev` were byte-identical for these two files at branch time.

## Tested

- Cross-checked the pins and lts dep set against this branch's
  `docker/.ngc_version.*` and `docker/lts/requirements.txt`.
- Markdown-only change; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
