### PR TITLE
Fix multimodal MTP loss masking for modality tokens

### DIFF
--- a/megatron/core/models/mimo/model/base.py
+++ b/megatron/core/models/mimo/model/base.py
@@ -654,6 +654,7 @@ class MimoModel(MegatronModule):
                 position_ids=position_ids,
                 decoder_input=combined_embeddings,
                 labels=labels,
+                loss_mask=loss_mask,
                 attention_mask=attention_mask,
                 packed_seq_params=packed_seq_params,
             )
@@ -683,6 +684,7 @@ class MimoModel(MegatronModule):
                 position_ids=position_ids,
                 decoder_input=None,
                 labels=labels,
+                loss_mask=loss_mask,
                 attention_mask=attention_mask,
                 packed_seq_params=packed_seq_params,
             )
@@ -804,6 +806,7 @@ class MimoModel(MegatronModule):
             position_ids=position_ids,
             decoder_input=combined_embeddings,
             labels=labels,
+            loss_mask=loss_mask,
             attention_mask=None,
             packed_seq_params=packed_seq_params,
         )

--- a/megatron/core/models/multimodal/llava_model.py
+++ b/megatron/core/models/multimodal/llava_model.py
@@ -1270,6 +1270,7 @@ class LLaVAModel(MegatronModule):
             attention_mask=attention_mask,
             decoder_input=combined_embeddings,
             labels=new_labels,
+            loss_mask=new_loss_mask,
             inference_context=inference_context,
             runtime_gather_output=runtime_gather_output,
             packed_seq_params=packed_seq_params,

--- a/tests/unit_tests/models/mimo/test_mimo_model.py
+++ b/tests/unit_tests/models/mimo/test_mimo_model.py
@@ -270,6 +270,7 @@ class TestMimoModel:
         mimo_model = self._make_vlm()
         input_ids = self._make_input_ids()
         position_ids = self._make_position_ids()
+        loss_mask = torch.ones(self.batch_size, self.seq_len, device=self.device)
 
         captured = {}
 
@@ -277,10 +278,16 @@ class TestMimoModel:
             captured['input_ids'] = kwargs.get('input_ids')
             captured['position_ids'] = kwargs.get('position_ids')
             captured['decoder_input'] = kwargs.get('decoder_input')
+            captured['loss_mask'] = kwargs.get('loss_mask')
             return torch.zeros(self.batch_size, self.seq_len, self.vocab_size, device=self.device)
 
         with patch.object(mimo_model.language_model, 'forward', side_effect=capture_lm_forward):
-            mimo_model(input_ids=input_ids, position_ids=position_ids, modality_inputs=None)
+            mimo_model(
+                input_ids=input_ids,
+                position_ids=position_ids,
+                loss_mask=loss_mask,
+                modality_inputs=None,
+            )
 
         assert (
             captured['decoder_input'] is not None
@@ -292,6 +299,7 @@ class TestMimoModel:
             captured['position_ids'] is not None
         ), "MimoModel.forward must pass position_ids to the language model (got None)"
         torch.testing.assert_close(captured['position_ids'], position_ids)
+        assert captured['loss_mask'] is loss_mask
 
     def test_forward_with_image_modality(self):
         """Test forward pass with text and image input."""
@@ -479,6 +487,7 @@ class TestMimoModel:
 
         def capture_lm_forward(*args, **kwargs):
             captured['decoder_input'] = kwargs.get('decoder_input')
+            captured['loss_mask'] = kwargs.get('loss_mask')
             return torch.zeros(
                 self.batch_size, sharded_seq_len, self.vocab_size, device=self.device
             )
@@ -508,6 +517,7 @@ class TestMimoModel:
             self.batch_size,
             self.hidden_size,
         )
+        assert captured['loss_mask'] is sharded_loss_mask
         # forward() returns the (possibly sharded) loss mask from shard().
         assert out_loss_mask is sharded_loss_mask
 
@@ -752,6 +762,8 @@ class TestMimoModelNonColocated:
             0, self.vocab_size, (self.batch_size, self.seq_len), device=self.device
         )
         input_ids[:, 5 : 5 + img_seq_len] = 50257
+        loss_mask = torch.ones(self.batch_size, self.seq_len, device=self.device)
+        loss_mask[input_ids == 50257] = 0
         position_ids = (
             torch.arange(self.seq_len, device=self.device).unsqueeze(0).expand(self.batch_size, -1)
         )
@@ -761,9 +773,28 @@ class TestMimoModelNonColocated:
         )
         model.set_input_tensor({"images": encoder_embeddings})
 
-        outputs, _ = model(input_ids=input_ids, position_ids=position_ids, modality_inputs=None)
+        captured = {}
+
+        def capture_language_inputs(module, args, kwargs):
+            captured['loss_mask'] = kwargs.get('loss_mask')
+
+        hook = model.language_model.register_forward_pre_hook(
+            capture_language_inputs, with_kwargs=True
+        )
+        try:
+            outputs, out_loss_mask = model(
+                input_ids=input_ids,
+                position_ids=position_ids,
+                loss_mask=loss_mask,
+                modality_inputs=None,
+            )
+        finally:
+            hook.remove()
+
         assert isinstance(outputs, torch.Tensor)
         assert outputs.shape == (self.batch_size, self.seq_len, self.vocab_size)
+        assert captured['loss_mask'] is loss_mask
+        assert out_loss_mask is loss_mask
 
     def test_forward_language_module_non_first_stage_drops_input_ids(self):
         """Non-first PP stage in ``_forward_language_module`` must call the LM
@@ -782,6 +813,8 @@ class TestMimoModelNonColocated:
         hidden_states = torch.randn(
             self.seq_len, self.batch_size, self.hidden_size, device=self.device
         )
+        loss_mask = torch.ones(self.batch_size, self.seq_len, device=self.device)
+        loss_mask[:, : self.seq_len // 2] = 0
 
         captured = {}
 
@@ -798,13 +831,14 @@ class TestMimoModelNonColocated:
                 input_ids=input_ids,
                 position_ids=position_ids,
                 attention_mask=None,
-                loss_mask=None,
+                loss_mask=loss_mask,
                 labels=None,
                 input_tensors={MIMO_LANGUAGE_MODULE_KEY: hidden_states},
             )
 
         assert captured['input_ids'] is None
         assert captured['decoder_input'] is None
+        assert captured['loss_mask'] is loss_mask
         torch.testing.assert_close(captured['position_ids'], position_ids)
 
 

--- a/tests/unit_tests/models/test_llava_model.py
+++ b/tests/unit_tests/models/test_llava_model.py
@@ -487,9 +487,7 @@ class TestLLaVAModel:
         input_ids = torch.tensor(
             [[image_token_index, 20, 21, 22], [10, image_token_index, 11, 12]], device="cuda"
         )
-        loss_mask = torch.tensor(
-            [[1, 0, 0, 0], [1, 1, 1, 1]], dtype=torch.float, device="cuda"
-        )
+        loss_mask = torch.tensor([[1, 0, 0, 0], [1, 1, 1, 1]], dtype=torch.float, device="cuda")
         captured = {}
 
         def capture_language_inputs(module, args, kwargs):

--- a/tests/unit_tests/models/test_llava_model.py
+++ b/tests/unit_tests/models/test_llava_model.py
@@ -411,6 +411,42 @@ class TestLLaVAModel:
             )
 
     @pytest.mark.internal
+    def test_forward_passes_expanded_loss_mask_to_language_model(self):
+        """The decoder needs the expanded mask to exclude vision positions from MTP loss."""
+        self.model.cuda()
+
+        image_token_index = self.model.image_token_index
+        input_ids = torch.tensor([[10, image_token_index, 11, 12]], device="cuda")
+        position_ids = torch.arange(input_ids.shape[1], device="cuda").unsqueeze(0)
+        labels = torch.tensor([[image_token_index, 11, 12, 13]], device="cuda")
+        loss_mask = torch.ones_like(input_ids, dtype=torch.float)
+        captured = {}
+
+        def capture_language_inputs(module, args, kwargs):
+            captured["loss_mask"] = kwargs["loss_mask"]
+
+        hook = self.model.language_model.register_forward_pre_hook(
+            capture_language_inputs, with_kwargs=True
+        )
+        try:
+            output, expanded_loss_mask = self.model(
+                torch.randn((1, 3, 336, 336), device="cuda"),
+                input_ids,
+                position_ids,
+                attention_mask=None,
+                labels=labels,
+                loss_mask=loss_mask,
+                num_image_tiles=torch.ones(1, dtype=torch.int, device="cuda"),
+            )
+        finally:
+            hook.remove()
+
+        assert torch.equal(captured["loss_mask"], expanded_loss_mask)
+        assert output.shape == expanded_loss_mask.shape
+        assert torch.count_nonzero(expanded_loss_mask[0, : self.model.img_seq_len + 1]) == 0
+        assert torch.all(expanded_loss_mask[0, self.model.img_seq_len + 1 :] == 1)
+
+    @pytest.mark.internal
     def test_forward_fsdp(self):
         """Test FSDP workaround for text-only data.
 

--- a/tests/unit_tests/models/test_llava_model.py
+++ b/tests/unit_tests/models/test_llava_model.py
@@ -447,6 +447,77 @@ class TestLLaVAModel:
         assert torch.all(expanded_loss_mask[0, self.model.img_seq_len + 1 :] == 1)
 
     @pytest.mark.internal
+    def test_forward_masks_image_only_sequence(self):
+        """An image placeholder expands to visual embeddings with no supervised positions."""
+        self.model.cuda()
+
+        image_token_index = self.model.image_token_index
+        input_ids = torch.tensor([[image_token_index]], device="cuda")
+        captured = {}
+
+        def capture_language_inputs(module, args, kwargs):
+            captured["loss_mask"] = kwargs["loss_mask"]
+
+        hook = self.model.language_model.register_forward_pre_hook(
+            capture_language_inputs, with_kwargs=True
+        )
+        try:
+            output, expanded_loss_mask = self.model(
+                torch.randn((1, 3, 336, 336), device="cuda"),
+                input_ids,
+                torch.zeros_like(input_ids),
+                attention_mask=None,
+                labels=torch.full_like(input_ids, -100),
+                loss_mask=torch.ones_like(input_ids, dtype=torch.float),
+                num_image_tiles=torch.ones(1, dtype=torch.int, device="cuda"),
+            )
+        finally:
+            hook.remove()
+
+        assert torch.equal(captured["loss_mask"], expanded_loss_mask)
+        assert output.shape == expanded_loss_mask.shape == (1, self.model.img_seq_len)
+        assert torch.count_nonzero(expanded_loss_mask) == 0
+
+    @pytest.mark.internal
+    def test_forward_preserves_all_masked_sample_in_mixed_batch(self):
+        """A fully masked image sample stays masked beside a sample with valid text."""
+        self.model.cuda()
+
+        image_token_index = self.model.image_token_index
+        input_ids = torch.tensor(
+            [[image_token_index, 20, 21, 22], [10, image_token_index, 11, 12]], device="cuda"
+        )
+        loss_mask = torch.tensor(
+            [[1, 0, 0, 0], [1, 1, 1, 1]], dtype=torch.float, device="cuda"
+        )
+        captured = {}
+
+        def capture_language_inputs(module, args, kwargs):
+            captured["loss_mask"] = kwargs["loss_mask"]
+
+        hook = self.model.language_model.register_forward_pre_hook(
+            capture_language_inputs, with_kwargs=True
+        )
+        try:
+            _, expanded_loss_mask = self.model(
+                torch.randn((2, 3, 336, 336), device="cuda"),
+                input_ids,
+                torch.arange(input_ids.shape[1], device="cuda").expand_as(input_ids),
+                attention_mask=None,
+                labels=torch.tensor(
+                    [[20, 21, 22, -100], [image_token_index, 11, 12, 13]], device="cuda"
+                ),
+                loss_mask=loss_mask,
+                num_image_tiles=torch.ones(2, dtype=torch.int, device="cuda"),
+            )
+        finally:
+            hook.remove()
+
+        assert torch.equal(captured["loss_mask"], expanded_loss_mask)
+        assert torch.count_nonzero(expanded_loss_mask[0]) == 0
+        assert torch.count_nonzero(expanded_loss_mask[1]) == 2
+
+    @pytest.mark.internal
     def test_forward_fsdp(self):
         """Test FSDP workaround for text-only data.
 

--- a/tests/unit_tests/transformer/test_multi_token_prediction.py
+++ b/tests/unit_tests/transformer/test_multi_token_prediction.py
@@ -421,6 +421,48 @@ class TestMultiTokenPredictionLayer:
         else:
             assert output_weight.grad is not None
 
+    def test_process_mtp_loss_all_masked_positions_have_zero_gradient(self):
+        """An all-zero mask must make MTP a finite no-op, including after mask rolling."""
+        config = TransformerConfig(
+            mtp_num_layers=1,
+            num_layers=2,
+            hidden_size=8,
+            num_attention_heads=2,
+            use_cpu_initialization=True,
+        )
+        seq_len = 4
+        hidden_states = torch.randn(
+            (1 + config.mtp_num_layers) * seq_len,
+            1,
+            config.hidden_size,
+            requires_grad=True,
+        )
+        output_weight = torch.nn.Parameter(torch.randn(16, config.hidden_size))
+
+        def output_layer(hidden, weight=None, runtime_gather_output=None):
+            return torch.matmul(hidden, weight.t()), None
+
+        def compute_language_model_loss(labels, logits):
+            return logits.square().sum(dim=-1).transpose(0, 1)
+
+        result = process_mtp_loss(
+            hidden_states=hidden_states,
+            labels=torch.arange(seq_len).unsqueeze(0),
+            loss_mask=torch.zeros(1, seq_len),
+            output_layer=output_layer,
+            output_weight=output_weight,
+            runtime_gather_output=None,
+            is_training=False,
+            compute_language_model_loss=compute_language_model_loss,
+            config=config,
+        )
+        result.sum().backward()
+
+        assert torch.isfinite(result).all()
+        assert torch.count_nonzero(hidden_states.grad[seq_len:]) == 0
+        assert output_weight.grad is not None
+        assert torch.count_nonzero(output_weight.grad) == 0
+
 
 class TestMultiTokenPrediction:
     def setup_method(self, method):

--- a/tests/unit_tests/transformer/test_multi_token_prediction.py
+++ b/tests/unit_tests/transformer/test_multi_token_prediction.py
@@ -432,10 +432,7 @@ class TestMultiTokenPredictionLayer:
         )
         seq_len = 4
         hidden_states = torch.randn(
-            (1 + config.mtp_num_layers) * seq_len,
-            1,
-            config.hidden_size,
-            requires_grad=True,
+            (1 + config.mtp_num_layers) * seq_len, 1, config.hidden_size, requires_grad=True
         )
         output_weight = torch.nn.Parameter(torch.randn(16, config.hidden_size))
 


### PR DESCRIPTION
## Summary

- pass the expanded LLaVA loss mask into the language model so MTP excludes vision embedding positions
- pass MiMo loss masks through every language-model path, including colocated and non-colocated pipeline layouts
- preserve existing text, padding, pre-image, and partition-sharding mask behavior
- add regression coverage for mixed text/image inputs, image-only inputs, fully masked samples, all-masked MTP gradients, and each MiMo language-model path

## Why

The base language-model loss applies the multimodal mask outside the decoder. MTP loss is computed inside the decoder, so LLaVA and MiMo previously did not pass the mask to the component that needed it and MTP treated modality embedding positions as supervised targets.

## Testing

- HSG GB200 container: 4 focused LLaVA/MTP unit tests passed
- HSG GB200 container: 4 focused MiMo path unit tests passed
- `git diff --check`
- Python syntax compilation for the modified files
