### PR TITLE
fix(core): replace hard assertion with warning for NVTE_* env conflicts

### DIFF
--- a/megatron/core/models/common/language_module/language_module.py
+++ b/megatron/core/models/common/language_module/language_module.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 import logging
 import os
+import warnings
 from typing import Optional, Tuple
 
 import torch
@@ -115,9 +116,14 @@ class LanguageModule(MegatronModule):
             env_variable_name: str, expected_value: int, attn_type: AttnBackend
         ) -> None:
             current_value = os.getenv(env_variable_name)
-            assert current_value is None or current_value == str(
-                expected_value
-            ), f'{env_variable_name} set to {current_value}, but expected {expected_value} for attention backend type {attn_type.name}. unset NVTE_FLASH_ATTN, NVTE_FUSED_ATTN and NVTE_UNFUSED_ATTN. Use the --attention-backend argument if you want to choose between (flash/fused/unfused/auto/local). Default is auto.'
+            if current_value is not None and current_value != str(expected_value):
+                warnings.warn(
+                    f"{env_variable_name} is set to {current_value}, but attention backend "
+                    f"{attn_type.name} expects {expected_value}. Overriding to {expected_value}. "
+                    f"To silence this warning, unset NVTE_FLASH_ATTN, NVTE_FUSED_ATTN, and "
+                    f"NVTE_UNFUSED_ATTN or use --attention-backend to match your environment.",
+                    stacklevel=3,
+                )
             os.environ[env_variable_name] = str(expected_value)
 
         if self.config.attention_backend == AttnBackend.local:


### PR DESCRIPTION
## Problem

When running inside Docker containers whose base images pre-set `NVTE_FLASH_ATTN`, `NVTE_FUSED_ATTN`, or `NVTE_UNFUSED_ATTN` environment variables (e.g., ROCm training images set `NVTE_FLASH_ATTN=0` and `NVTE_FUSED_ATTN=1` for their TransformerEngine CK backend), Megatron-Core raises an `AssertionError` during model initialization if the configured `attention_backend` (flash, auto, etc.) expects different values.

Users cannot modify the base image and have no clean way to unset Docker `ENV` variables at the image level (`docker exec` sessions also inherit them).

## Solution

Replace the hard `assert` in `check_and_set_env_variable()` with:
- A `warnings.warn()` that informs the user of the mismatch and the override.
- The existing `os.environ[...] = str(expected_value)` assignment that forces the correct value.

This preserves the intent of catching misconfigurations while avoiding crashes in containerized environments where users inherit env variables they did not explicitly set.

## Changes

- `megatron/core/models/common/language_module/language_module.py`: Replace `AssertionError` with `warnings.warn()` + override in `_set_attention_backend()`.

## Testing

Verified that:
1. `attention_backend=auto` works with pre-set `NVTE_FLASH_ATTN=0/NVTE_FUSED_ATTN=1` (previously crashed).
2. `attention_backend=flash` works with pre-set `NVTE_FUSED_ATTN=1` (previously crashed).
3. A warning is emitted when env vars are overridden.
4. No warning when env vars are unset or already match.