### PR TITLE
rl: dynamic inference-concurrency rebalancing across environments (opt-in)

### DIFF
--- a/megatron/rl/agent/api.py
+++ b/megatron/rl/agent/api.py
@@ -227,7 +227,12 @@ class _GranularityConfig(NamedTuple):
 
 
 class _SubmissionGate:
-    """Gate capacity is measured in units of the configured submission granularity."""
+    """Gate capacity is measured in units of the configured submission granularity.
+
+    Releases are keyed on (state, granularity) so release sites for different
+    granularities can coexist on the same code path (e.g. stage_consume's
+    reorder branch releases per group for G submission and per batch for B).
+    """
 
     def __init__(
         self,
@@ -256,8 +261,8 @@ class _SubmissionGate:
             self.held += 1
             self.acquire_calls += 1
 
-    def release_after(self, state: ReleaseState) -> None:
-        if self._release_on == state:
+    def release_after(self, state: ReleaseState, granularity: SubmissionGranularity) -> None:
+        if self._submission == granularity and self._release_on == state:
             self._sem.release()
             self.held -= 1
             self.release_calls += 1
@@ -401,7 +406,7 @@ class _RolloutPipeline:
             self.request, item.params.inference_request
         )
         inferred_at = time.monotonic()
-        self.gate.release_after("inferred")
+        self.gate.release_after("inferred", "R")
         if item.infer_dequeued_at:
             self.engine_dwell.append(inferred_at - item.infer_dequeued_at)
         self.inferred_count += 1
@@ -430,13 +435,19 @@ class _RolloutPipeline:
                 rollouts = await asyncio.gather(
                     *[item.item.params.build_rollout(item.response) for item in completed]
                 )
-                self.gate.release_after("assembled")
+                # No-op under the current map (G releases at "consumed"); kept so
+                # flipping RELEASE_STATE_BY_SUBMISSION["G"] back to "assembled"
+                # restores run-ahead-to-assembly for experiments.
+                self.gate.release_after("assembled", "G")
                 self.assembled_count += 1
                 # NOTE: this filter is currently non-functional dead code:
                 # _GranularityConfig._validate rejects filter_groups_with_same_reward
                 # at pipeline construction, so `keep` is always True. Kept for a
                 # future PR that regenerates dropped groups instead of
-                # under-delivering to the caller.
+                # under-delivering to the caller. That PR must also release the
+                # gate slot on the drop path: with G/B releasing at "consumed",
+                # a dropped group never reaches stage_consume, so its slot (and
+                # eventually its batch's) would leak permanently.
                 keep = (
                     not self.request.filter_groups_with_same_reward
                     or np.std([rollout.reward for rollout in rollouts]) > 1e-6
@@ -474,6 +485,7 @@ class _RolloutPipeline:
                     return
                 self._record_output_dwell(group)
                 yield group
+                self.gate.release_after("consumed", "G")
 
         next_batch_id = 0
         pending = self._consume_pending
@@ -493,7 +505,8 @@ class _RolloutPipeline:
                 next_batch_id += 1
                 for group in batch:
                     yield group
-                self.gate.release_after("consumed")
+                    self.gate.release_after("consumed", "G")
+                self.gate.release_after("consumed", "B")
 
 
 class GroupedRolloutGenerator(Agent, ABC):

--- a/megatron/rl/agent/api.py
+++ b/megatron/rl/agent/api.py
@@ -19,12 +19,7 @@ from ..inference import (
     LLMChatMessage,
     ReturnsRaw,
 )
-from ..rollout_granularity import (
-    RELEASE_STATE_BY_SUBMISSION,
-    ConsumptionGranularity,
-    ReleaseState,
-    SubmissionGranularity,
-)
+from ..rollout_granularity import ConsumptionGranularity, SubmissionGranularity
 
 
 class AgentBaseModel(BaseModel, extra='allow'):
@@ -229,9 +224,11 @@ class _GranularityConfig(NamedTuple):
 class _SubmissionGate:
     """Gate capacity is measured in units of the configured submission granularity.
 
-    Releases are keyed on (state, granularity) so release sites for different
-    granularities can coexist on the same code path (e.g. stage_consume's
-    reorder branch releases per group for G submission and per batch for B).
+    Each granularity has a single release point: R slots free when inference
+    completes, so the gate bounds engine concurrency in rollouts. G and B
+    slots free when the trainer consumes the group/batch, so the gate
+    enforces the --rl-generation-lag run-ahead cap in groups/batches
+    respectively.
     """
 
     def __init__(
@@ -242,7 +239,6 @@ class _SubmissionGate:
     ) -> None:
         self._sem = asyncio.Semaphore(capacity)
         self._submission = submission
-        self._release_on = RELEASE_STATE_BY_SUBMISSION[submission]
         self.capacity = capacity
         # Observability counters, updated only on the configured submission
         # granularity (the only path that touches the semaphore). `held`
@@ -261,8 +257,8 @@ class _SubmissionGate:
             self.held += 1
             self.acquire_calls += 1
 
-    def release_after(self, state: ReleaseState, granularity: SubmissionGranularity) -> None:
-        if self._submission == granularity and self._release_on == state:
+    def release_for(self, granularity: SubmissionGranularity) -> None:
+        if self._submission == granularity:
             self._sem.release()
             self.held -= 1
             self.release_calls += 1
@@ -406,7 +402,7 @@ class _RolloutPipeline:
             self.request, item.params.inference_request
         )
         inferred_at = time.monotonic()
-        self.gate.release_after("inferred", "R")
+        self.gate.release_for("R")
         if item.infer_dequeued_at:
             self.engine_dwell.append(inferred_at - item.infer_dequeued_at)
         self.inferred_count += 1
@@ -435,17 +431,13 @@ class _RolloutPipeline:
                 rollouts = await asyncio.gather(
                     *[item.item.params.build_rollout(item.response) for item in completed]
                 )
-                # No-op under the current map (G releases at "consumed"); kept so
-                # flipping RELEASE_STATE_BY_SUBMISSION["G"] back to "assembled"
-                # restores run-ahead-to-assembly for experiments.
-                self.gate.release_after("assembled", "G")
                 self.assembled_count += 1
                 # NOTE: this filter is currently non-functional dead code:
                 # _GranularityConfig._validate rejects filter_groups_with_same_reward
                 # at pipeline construction, so `keep` is always True. Kept for a
                 # future PR that regenerates dropped groups instead of
                 # under-delivering to the caller. That PR must also release the
-                # gate slot on the drop path: with G/B releasing at "consumed",
+                # gate slot on the drop path: G/B slots free on consumption, and
                 # a dropped group never reaches stage_consume, so its slot (and
                 # eventually its batch's) would leak permanently.
                 keep = (
@@ -485,7 +477,7 @@ class _RolloutPipeline:
                     return
                 self._record_output_dwell(group)
                 yield group
-                self.gate.release_after("consumed", "G")
+                self.gate.release_for("G")
 
         next_batch_id = 0
         pending = self._consume_pending
@@ -505,8 +497,8 @@ class _RolloutPipeline:
                 next_batch_id += 1
                 for group in batch:
                     yield group
-                    self.gate.release_after("consumed", "G")
-                self.gate.release_after("consumed", "B")
+                    self.gate.release_for("G")
+                self.gate.release_for("B")
 
 
 class GroupedRolloutGenerator(Agent, ABC):

--- a/megatron/rl/agent/api.py
+++ b/megatron/rl/agent/api.py
@@ -3,6 +3,7 @@
 import asyncio
 import time
 from abc import ABC, abstractmethod
+from collections import deque
 from typing import AsyncIterator, Awaitable, Callable, Generic, NamedTuple, TypeVar
 
 import numpy as np
@@ -229,6 +230,11 @@ class _SubmissionGate:
     slots free when the trainer consumes the group/batch, so the gate
     enforces the --rl-generation-lag run-ahead cap in groups/batches
     respectively.
+
+    Capacity is resizable at runtime (set_capacity): growing wakes blocked
+    acquirers; shrinking below `held` never revokes in-flight slots — new
+    acquires simply block until enough releases bring `held` under the new
+    capacity.
     """
 
     def __init__(
@@ -237,31 +243,69 @@ class _SubmissionGate:
         capacity: int,
         submission: SubmissionGranularity,
     ) -> None:
-        self._sem = asyncio.Semaphore(capacity)
         self._submission = submission
+        self._waiters: deque[asyncio.Future] = deque()
         self.capacity = capacity
         # Observability counters, updated only on the configured submission
-        # granularity (the only path that touches the semaphore). `held`
+        # granularity (the only path that touches the gate). `held`
         # counts slots currently held; `prepare_blocked_seconds` accumulates
-        # time stage_prepare spent waiting on the semaphore.
+        # time stage_prepare spent waiting for a free slot.
         self.held = 0
         self.prepare_blocked_seconds = 0.0
         self.acquire_calls = 0
         self.release_calls = 0
 
     async def acquire_for(self, granularity: SubmissionGranularity) -> None:
-        if self._submission == granularity:
-            start = time.monotonic()
-            await self._sem.acquire()
-            self.prepare_blocked_seconds += time.monotonic() - start
-            self.held += 1
-            self.acquire_calls += 1
+        if self._submission != granularity:
+            return
+        start = time.monotonic()
+        while self.held >= self.capacity:
+            waiter = asyncio.get_running_loop().create_future()
+            self._waiters.append(waiter)
+            try:
+                await waiter
+            except asyncio.CancelledError:
+                # Woken and cancelled in the same tick: pass the wake-up on
+                # so a release is never lost.
+                if waiter.done() and not waiter.cancelled():
+                    self._wake_next()
+                raise
+            finally:
+                if waiter in self._waiters:
+                    self._waiters.remove(waiter)
+        self.prepare_blocked_seconds += time.monotonic() - start
+        self.held += 1
+        self.acquire_calls += 1
 
     def release_for(self, granularity: SubmissionGranularity) -> None:
-        if self._submission == granularity:
-            self._sem.release()
-            self.held -= 1
-            self.release_calls += 1
+        if self._submission != granularity:
+            return
+        self.held -= 1
+        self.release_calls += 1
+        self._wake_next()
+
+    def set_capacity(self, capacity: int) -> None:
+        """Resize the gate. Growing wakes all waiters (each re-checks the
+        acquire loop, so overshoot is impossible); shrinking takes effect as
+        in-flight slots drain."""
+        capacity = max(1, int(capacity))
+        grew = capacity > self.capacity
+        self.capacity = capacity
+        if grew:
+            self._wake_all()
+
+    def _wake_next(self) -> None:
+        while self._waiters:
+            waiter = self._waiters.popleft()
+            if not waiter.done():
+                waiter.set_result(None)
+                return
+
+    def _wake_all(self) -> None:
+        while self._waiters:
+            waiter = self._waiters.popleft()
+            if not waiter.done():
+                waiter.set_result(None)
 
 
 class _InferWorkItem(NamedTuple):
@@ -297,6 +341,8 @@ class _RolloutPipeline:
         agent: "GroupedRolloutGenerator",
         request: GroupedRolloutRequest,
         parallel_generation_tasks: int,
+        max_parallel_generation_tasks: int | None = None,
+        engine_dwell_ema_alpha: float = 0.2,
     ) -> None:
         self.agent = agent
         self.request = request
@@ -310,7 +356,12 @@ class _RolloutPipeline:
             "G": request.rollouts_per_group,
             "B": self.gran_policy.num_groups_per_batch * request.rollouts_per_group,
         }[self.gran_policy.submission]
-        self.num_infer_workers = parallel_generation_tasks * rollouts_per_submission_unit
+        # Workers are created once in stage_infer, so size the pool for the
+        # largest capacity the gate may grow to (dynamic rebalancing); the
+        # gate remains the sole concurrency limit.
+        self.num_infer_workers = (
+            max_parallel_generation_tasks or parallel_generation_tasks
+        ) * rollouts_per_submission_unit
         if not request.streaming:
             self.num_infer_workers = min(
                 self.num_infer_workers, request.num_groups * request.rollouts_per_group
@@ -336,6 +387,13 @@ class _RolloutPipeline:
         self.engine_dwell: list[float] = []
         self.assemble_queue_dwell: list[float] = []
         self.output_queue_dwell: list[float] = []
+        # EMA of per-rollout engine service time. Unlike the engine_dwell
+        # list above (snapshot/reset by rl_utils during metric logging),
+        # these persist for the pipeline's lifetime; the pgt rebalancer in
+        # WeightedMultiTask reads them.
+        self.engine_dwell_ema: float | None = None
+        self.engine_dwell_sample_count = 0
+        self._engine_dwell_ema_alpha = engine_dwell_ema_alpha
         self.prepared_count = 0
         self.inferred_count = 0
         self.assembled_count = 0
@@ -404,7 +462,15 @@ class _RolloutPipeline:
         inferred_at = time.monotonic()
         self.gate.release_for("R")
         if item.infer_dequeued_at:
-            self.engine_dwell.append(inferred_at - item.infer_dequeued_at)
+            dwell = inferred_at - item.infer_dequeued_at
+            self.engine_dwell.append(dwell)
+            alpha = self._engine_dwell_ema_alpha
+            self.engine_dwell_ema = (
+                dwell
+                if self.engine_dwell_ema is None
+                else alpha * dwell + (1 - alpha) * self.engine_dwell_ema
+            )
+            self.engine_dwell_sample_count += 1
         self.inferred_count += 1
         await self.assemble_queue.put(
             _InferredItem(item=item, response=response, inferred_at=inferred_at)
@@ -505,6 +571,10 @@ class GroupedRolloutGenerator(Agent, ABC):
     """An interface to return grouped Rollout objects to support algorithms like GRPO."""
 
     parallel_generation_tasks: int = 512
+    # Ceiling for runtime gate growth; sized by WeightedMultiTask when
+    # dynamic pgt rebalancing is enabled. None = no rebalancing headroom.
+    max_parallel_generation_tasks: int | None = None
+    engine_dwell_ema_alpha: float = 0.2
 
     def __init__(self, *, parallel_generation_tasks: int | None = None, **kwargs):
         super().__init__(**kwargs)
@@ -534,6 +604,8 @@ class GroupedRolloutGenerator(Agent, ABC):
             agent=self,
             request=request,
             parallel_generation_tasks=self.parallel_generation_tasks,
+            max_parallel_generation_tasks=self.max_parallel_generation_tasks,
+            engine_dwell_ema_alpha=self.engine_dwell_ema_alpha,
         )
         # Expose the live pipeline for observability; rl_utils reads its
         # queue sizes, gate state, and timing accumulators during logging.

--- a/megatron/rl/agent/weighted_multi_task.py
+++ b/megatron/rl/agent/weighted_multi_task.py
@@ -2,11 +2,12 @@
 
 import asyncio
 import logging
+import time
+from dataclasses import dataclass
 from typing import Any, Optional, Type
 
 import numpy as np
 
-from .registry import get_agent_class
 from .api import (
     AgentBaseModel,
     ContrastiveRollout,
@@ -21,6 +22,7 @@ from .api import (
     RolloutGenerator,
     RolloutRequest,
 )
+from .registry import get_agent_class
 
 logger = logging.getLogger(__name__)
 
@@ -39,15 +41,96 @@ class AgentConfig(AgentBaseModel):
             raise ValueError("Agent weight must be non-negative")
 
 
+@dataclass
+class PgtRebalanceConfig:
+    """Knobs for dynamic per-env inference-concurrency rebalancing."""
+
+    ema_alpha: float = 0.2
+    min_interval_s: float = 30.0
+    min_samples_per_env: int = 8
+    max_step_fraction: float = 0.25
+
+
+class _PgtRebalancer:
+    """Periodically shifts submission-gate capacity toward slower envs.
+
+    The data mix (agent_groups / agent_slots) is untouched; only inference
+    concurrency moves. Scoped to a single get_grouped_rollouts call, like
+    _RolloutPipeline is for a single sub-agent."""
+
+    def __init__(
+        self,
+        config: PgtRebalanceConfig,
+        *,
+        agent_indices: list[int],
+        weights: list[float],
+        current_pgts: list[int],
+        min_pgts: list[int],
+    ) -> None:
+        self.config = config
+        self.agent_indices = agent_indices
+        self.weights = weights
+        self.current = list(current_pgts)
+        self.min_pgts = min_pgts
+        self.total_pgt = sum(current_pgts)
+        self.rebalance_count = 0
+        self.latest_emas: list[float | None] = [None] * len(agent_indices)
+        self._last_check = float("-inf")
+
+    def maybe_rebalance(self, agents: list) -> dict | None:
+        """Re-allocate gate capacity if the check interval elapsed and the
+        allocation would change. Returns an event dict for logging, or None."""
+        now = time.monotonic()
+        if now - self._last_check < self.config.min_interval_s:
+            return None
+        self._last_check = now
+
+        pipelines, durations = [], []
+        for idx in self.agent_indices:
+            pipeline = getattr(agents[idx], "_active_pipeline", None)
+            pipelines.append(pipeline)
+            if (
+                pipeline is None
+                or pipeline.engine_dwell_sample_count < self.config.min_samples_per_env
+            ):
+                durations.append(None)
+            else:
+                durations.append(pipeline.engine_dwell_ema)
+        self.latest_emas = durations
+
+        new = WeightedMultiTask._compute_pgt_allocation(
+            self.weights,
+            durations,
+            self.total_pgt,
+            self.current,
+            min_pgts=self.min_pgts,
+            max_step_fraction=self.config.max_step_fraction,
+        )
+        if new == self.current:
+            return None
+        old, self.current = self.current, new
+        self.rebalance_count += 1
+        for idx, pipeline, pgt in zip(self.agent_indices, pipelines, new):
+            agents[idx].parallel_generation_tasks = pgt
+            if pipeline is not None:
+                pipeline.gate.set_capacity(pgt)
+        return {"old": old, "new": new, "emas": durations}
+
+
 class WeightedMultiTask(
     RolloutGenerator, GroupedRolloutGenerator, ContrastiveRolloutGenerator, EvaluationAgent
 ):
     """An agent that manages multiple sub-agents and distributes rollouts according to weights."""
 
-    def __init__(self, agent_configs: list[AgentConfig]):
+    def __init__(
+        self,
+        agent_configs: list[AgentConfig],
+        pgt_rebalance: PgtRebalanceConfig | None = None,
+    ):
         super().__init__()
         if not agent_configs:
             raise ValueError("Must provide at least one agent configuration")
+        self.pgt_rebalance = pgt_rebalance
 
         # Initialize all sub-agents
         self.agents = []
@@ -71,7 +154,11 @@ class WeightedMultiTask(
 
     @classmethod
     def from_config(
-        cls, config: list[dict[str, Any]], *, parallel_generation_tasks: int | None = None
+        cls,
+        config: list[dict[str, Any]],
+        *,
+        parallel_generation_tasks: int | None = None,
+        pgt_rebalance: PgtRebalanceConfig | None = None,
     ) -> 'WeightedMultiTask':
         """Create a WeightedMultiTask from a config list.
 
@@ -101,7 +188,7 @@ class WeightedMultiTask(
                 )
             )
 
-        instance = cls(agent_configs)
+        instance = cls(agent_configs, pgt_rebalance=pgt_rebalance)
         if parallel_generation_tasks is not None:
             instance.parallel_generation_tasks = parallel_generation_tasks
         return instance
@@ -156,6 +243,63 @@ class WeightedMultiTask(
 
         return final_counts
 
+    @staticmethod
+    def _compute_pgt_allocation(
+        weights: list[float],
+        durations: list[float | None],
+        total_pgt: int,
+        current: list[int],
+        *,
+        min_pgts: list[int],
+        max_step_fraction: float,
+    ) -> list[int]:
+        """Helper method to distribute parallel generation tasks by measured speed.
+
+        The dynamic counterpart of _distribute_counts: allocates total_pgt so
+        each env's share is proportional to weight_i * duration_i, equalizing
+        per-env finish time for its share of the data mix. Envs without a
+        duration estimate use the weighted mean of known durations; with no
+        estimates at all, the current allocation is kept. Per-update movement
+        is clamped to max_step_fraction of the current value (hysteresis) and
+        floors are enforced; the result always sums to total_pgt.
+        """
+        known = [(w, d) for w, d in zip(weights, durations) if d is not None]
+        if not known:
+            return list(current)
+
+        # Mean of known durations for fallback
+        fallback = sum(w * d for w, d in known) / sum(w for w, _ in known)
+
+        # Calculate shares for each agent
+        shares = [w * (d if d is not None else fallback) for w, d in zip(weights, durations)]
+        if (total_share := sum(shares)) <= 0:
+            return list(current)
+
+        # Calculate exact pgt for each agent
+        exact = [total_pgt * s / total_share for s in shares]
+
+        # Largest-remainder rounding (same scheme as _distribute_counts).
+        target = [int(x) for x in exact]
+        order = sorted(range(len(exact)), key=lambda i: exact[i] - target[i], reverse=True)
+        for i in range(total_pgt - sum(target)):
+            target[order[i]] += 1
+
+        # Clamp per-update movement, then enforce floors.
+        new = []
+        for cur, tgt, floor in zip(current, target, min_pgts):
+            step = max(1, round(max_step_fraction * cur))
+            new.append(max(floor, min(max(tgt, cur - step), cur + step)))
+
+        # Repair the sum (clamping/floors can break it); floors stay respected.
+        diff = total_pgt - sum(new)
+        while diff != 0:
+            sign = 1 if diff > 0 else -1
+            candidates = [i for i in range(len(new)) if sign > 0 or new[i] - 1 >= min_pgts[i]]
+            i = max(candidates, key=lambda i: sign * (exact[i] - new[i]))
+            new[i] += sign
+            diff -= sign
+        return new
+
     async def prepare_group_rollout(
         self,
         request: GroupedRolloutRequest,
@@ -204,6 +348,44 @@ class WeightedMultiTask(
             agent_pgts = self._distribute_counts(self.parallel_generation_tasks)
         agent_slots = self._distribute_counts(request.num_groups, distribute_remainder=False)
         agent_slots = np.array(agent_slots) / np.gcd.reduce(agent_slots)
+
+        # Optional dynamic rebalancing of inference concurrency (gate
+        # capacity) toward slower envs. The data mix (agent_groups,
+        # agent_slots) always stays at the configured weights. Not
+        # applicable in B submission mode, where every active env already
+        # receives the full pgt.
+        rebalancer = None
+        if self.pgt_rebalance is not None and request.submission_granularity != "B":
+            active = [
+                i
+                for i, (groups, config) in enumerate(zip(agent_groups, self.agent_configs))
+                if groups > 0 and not config.evaluation_only
+            ]
+            if len(active) >= 2:
+                # G submission + B consumption releases slots only when a
+                # full local batch is consumed; below agent_groups[i] slots
+                # that batch can never complete, so it is the hard floor.
+                needs_batch_floor = (
+                    request.submission_granularity == "G"
+                    and request.consumption_granularity == "B"
+                )
+                min_pgts = [agent_groups[i] if needs_batch_floor else 1 for i in active]
+                total_active_pgt = sum(agent_pgts[i] for i in active)
+                for pos, i in enumerate(active):
+                    # Ceiling for this env's future growth: the total minus
+                    # what the other envs can never go below. Sizes the
+                    # fixed infer-worker pool in _RolloutPipeline.
+                    self.agents[i].max_parallel_generation_tasks = (
+                        total_active_pgt - sum(min_pgts) + min_pgts[pos]
+                    )
+                    self.agents[i].engine_dwell_ema_alpha = self.pgt_rebalance.ema_alpha
+                rebalancer = _PgtRebalancer(
+                    self.pgt_rebalance,
+                    agent_indices=active,
+                    weights=[self.weights[i] for i in active],
+                    current_pgts=[agent_pgts[i] for i in active],
+                    min_pgts=min_pgts,
+                )
 
         # Snapshot the distribution for observability. Read back by rl_utils
         # during per-iteration metric logging.
@@ -257,35 +439,66 @@ class WeightedMultiTask(
             else:
                 generators.append(None)
 
-        while any(generators):
-            balanced_rollouts = asyncio.Queue()
+        tasks = []
+        try:
+            while any(generators):
+                if rebalancer is not None and (event := rebalancer.maybe_rebalance(self.agents)):
+                    live_pgts = list(agent_pgts)
+                    duration_emas: list[float | None] = [None] * len(agent_pgts)
+                    for pos, i in enumerate(rebalancer.agent_indices):
+                        live_pgts[i] = rebalancer.current[pos]
+                        duration_emas[i] = rebalancer.latest_emas[pos]
+                    self.latest_distribution["live_pgts"] = live_pgts
+                    self.latest_distribution["duration_ema_s"] = duration_emas
+                    self.latest_distribution["rebalance_count"] = rebalancer.rebalance_count
+                    logger.info(
+                        "PGT rebalance #%d: %s -> %s (engine_dwell_ema=%s)",
+                        rebalancer.rebalance_count,
+                        event["old"],
+                        event["new"],
+                        event["emas"],
+                    )
+                balanced_rollouts = asyncio.Queue()
 
-            async def get_balanced_rollouts_if_remaining(agent_id):
-                generated_rollouts = 0
-                while generated_rollouts < agent_slots[agent_id]:
-                    if generators[agent_id] is None:
-                        return
+                async def get_balanced_rollouts_if_remaining(agent_id):
+                    generated_rollouts = 0
+                    while generated_rollouts < agent_slots[agent_id]:
+                        if generators[agent_id] is None:
+                            return
+                        try:
+                            await balanced_rollouts.put(await anext(generators[agent_id]))
+                            generated_rollouts += 1
+                        except StopAsyncIteration:
+                            await balanced_rollouts.put(None)
+                            generators[agent_id] = None
+                            return
+
+                tasks = [
+                    asyncio.create_task(get_balanced_rollouts_if_remaining(agent_id))
+                    for agent_id in range(len(generators))
+                ]
+
+                try:
+                    while balanced_rollouts.qsize() > 0 or not all(task.done() for task in tasks):
+                        rollout = await balanced_rollouts.get()
+                        if rollout is not None:
+                            yield rollout
+                finally:
+                    for task in tasks:
+                        task.cancel()
+        finally:
+            # When the consumer closes this generator early (streaming), shut
+            # the sub-agent generators down too so their pipelines cancel
+            # instead of leaking running tasks. The last round's puller tasks
+            # must settle first: a generator with a pending anext rejects
+            # aclose with "already running".
+            await asyncio.gather(*tasks, return_exceptions=True)
+            for generator in generators:
+                if generator is not None:
                     try:
-                        await balanced_rollouts.put(await anext(generators[agent_id]))
-                        generated_rollouts += 1
-                    except StopAsyncIteration:
-                        await balanced_rollouts.put(None)
-                        generators[agent_id] = None
-                        return
-
-            tasks = [
-                asyncio.create_task(get_balanced_rollouts_if_remaining(agent_id))
-                for agent_id in range(len(generators))
-            ]
-
-            try:
-                while balanced_rollouts.qsize() > 0 or not all(task.done() for task in tasks):
-                    rollout = await balanced_rollouts.get()
-                    if rollout is not None:
-                        yield rollout
-            finally:
-                for task in tasks:
-                    task.cancel()
+                        await generator.aclose()
+                    except RuntimeError:
+                        pass
 
     async def get_contrastive_rollouts(self, request: RolloutRequest) -> list[ContrastiveRollout]:
         """Distribute contrastive rollouts across sub-agents according to weights."""

--- a/megatron/rl/rl_utils.py
+++ b/megatron/rl/rl_utils.py
@@ -68,7 +68,7 @@ from megatron.rl.agent.api import (
     Rollouts,
     TokenRollout,
 )
-from megatron.rl.agent.weighted_multi_task import WeightedMultiTask
+from megatron.rl.agent.weighted_multi_task import PgtRebalanceConfig, WeightedMultiTask
 from megatron.rl.inference.megatron import MegatronLocal
 from megatron.rl.logging import LOG_DIR as lang_rl_log_dir
 from megatron.rl.logging import log as lang_rl_log
@@ -540,9 +540,17 @@ def get_agent(args, parallel_generation_tasks: int | None = None):
     with open(args.langrl_env_config, 'r') as f:
         config = yaml.safe_load(f)
 
+    pgt_rebalance = None
+    if getattr(args, 'rl_inference_rebalancing', False):
+        pgt_rebalance = PgtRebalanceConfig(
+            ema_alpha=args.rl_inference_rebalancing_ema_alpha,
+            min_interval_s=args.rl_inference_rebalancing_interval,
+            max_step_fraction=args.rl_inference_rebalancing_max_step,
+        )
     return WeightedMultiTask.from_config(
         config,
         parallel_generation_tasks=parallel_generation_tasks,
+        pgt_rebalance=pgt_rebalance,
     )
 
 
@@ -1143,6 +1151,10 @@ def _collect_rollout_pipeline_metrics() -> dict:
             f"{env_id}_pipeline_assembled_count": pipeline.assembled_count,
             f"{env_id}_pipeline_yielded_count": pipeline.yielded_count,
         })
+        # Lifetime EMA of per-rollout engine service time (not reset below;
+        # it drives --rl-inference-rebalancing).
+        if pipeline.engine_dwell_ema is not None:
+            metrics[f"{env_id}_engine_dwell_ema_s"] = pipeline.engine_dwell_ema
         for name, samples in (
             ("infer_queue_dwell", pipeline.infer_queue_dwell),
             ("engine_dwell", pipeline.engine_dwell),
@@ -1185,6 +1197,15 @@ def _collect_rollout_pipeline_metrics() -> dict:
             metrics[f"{env_id}_agent_pgts"] = pgt
             metrics[f"{env_id}_agent_slots"] = slots
         metrics["multitask_total_pgt"] = dist["total_pgt"]
+        # Live allocation under --rl-inference-rebalancing (same per-env
+        # summing as agent_pgts above, since env_ids can repeat).
+        if (live := dist.get("live_pgts")) is not None:
+            live_per_env: dict = {}
+            for env_id, pgt in zip(dist["env_ids"], live):
+                live_per_env[env_id] = live_per_env.get(env_id, 0) + pgt
+            for env_id, pgt in live_per_env.items():
+                metrics[f"{env_id}_agent_pgt_live"] = pgt
+        metrics["multitask_pgt_rebalance_count"] = dist.get("rebalance_count", 0)
     return metrics
 
 

--- a/megatron/rl/rollout_granularity.py
+++ b/megatron/rl/rollout_granularity.py
@@ -9,9 +9,15 @@ ConsumptionGranularity = Literal["G", "B"]
 ReleaseState = Literal["inferred", "assembled", "consumed"]
 
 
+# R releases its slot when inference completes: the gate bounds engine
+# concurrency in rollouts. G and B release when the trainer consumes the
+# group/batch: the gate enforces the --rl-generation-lag run-ahead cap in
+# groups/batches respectively. G previously released at "assembled", which
+# let submission outrun consumption without bound (in-flight backlog grew
+# past the lag cap since assembled-but-unconsumed groups held no slot).
 RELEASE_STATE_BY_SUBMISSION: dict[SubmissionGranularity, ReleaseState] = {
     "R": "inferred",
-    "G": "assembled",
+    "G": "consumed",
     "B": "consumed",
 }
 

--- a/megatron/rl/rollout_granularity.py
+++ b/megatron/rl/rollout_granularity.py
@@ -6,20 +6,6 @@ from typing import Literal
 
 SubmissionGranularity = Literal["R", "G", "B"]
 ConsumptionGranularity = Literal["G", "B"]
-ReleaseState = Literal["inferred", "assembled", "consumed"]
-
-
-# R releases its slot when inference completes: the gate bounds engine
-# concurrency in rollouts. G and B release when the trainer consumes the
-# group/batch: the gate enforces the --rl-generation-lag run-ahead cap in
-# groups/batches respectively. G previously released at "assembled", which
-# let submission outrun consumption without bound (in-flight backlog grew
-# past the lag cap since assembled-but-unconsumed groups held no slot).
-RELEASE_STATE_BY_SUBMISSION: dict[SubmissionGranularity, ReleaseState] = {
-    "R": "inferred",
-    "G": "consumed",
-    "B": "consumed",
-}
 
 
 def get_rl_parallel_generation_tasks(args) -> int:

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -6,15 +6,16 @@ import argparse
 import dataclasses
 import json
 import os
-from pathlib import Path
 import re
 import types
+import warnings
+from pathlib import Path
 
 import torch
 
+from megatron.core.msc_utils import MultiStorageClientFeature
 from megatron.core.rerun_state_machine import RerunStateMachine
 from megatron.core.transformer import TransformerConfig
-from megatron.core.transformer.pipeline_parallel_layer_layout import PipelineParallelLayerLayout
 from megatron.core.transformer.cuda_graph_config import (
     ALLOWED_INFERENCE_SCOPES,
     get_deprecated_cuda_graph_modules_migration,
@@ -23,23 +24,24 @@ from megatron.core.transformer.cuda_graph_config import (
     validate_deprecated_cuda_graph_modules_migration_inputs,
 )
 from megatron.core.transformer.enums import AttnBackend, CudaGraphModule, InferenceCudaGraphScope
+from megatron.core.transformer.pipeline_parallel_layer_layout import PipelineParallelLayerLayout
 from megatron.core.utils import (
     get_torch_version,
     is_flashinfer_min_version,
     is_te_min_version,
     is_torch_min_version,
 )
+from megatron.training.argument_utils import (  # noqa: F401 # pylint: disable=unused-import
+    ArgumentGroupFactory,
+    core_transformer_config_from_args,
+)
 from megatron.training.global_vars import set_global_variables
 from megatron.training.utils import (
     get_device_arch_version,
-    update_use_dist_ckpt,
     print_rank_0,
+    update_use_dist_ckpt,
     warn_rank_0,
 )
-from megatron.core.msc_utils import MultiStorageClientFeature
-
-from megatron.training.argument_utils import ArgumentGroupFactory, core_transformer_config_from_args  # noqa: F401 # pylint: disable=unused-import
-
 
 
 def add_megatron_arguments(parser: argparse.ArgumentParser):
@@ -398,8 +400,9 @@ def validate_args(args, defaults={}):
         'Currently only global and local checkpoints are supported'
     if args.non_persistent_ckpt_type == 'local':
         try:
-            from nvidia_resiliency_ext.checkpointing.local.ckpt_managers.local_manager import \
-                LocalCheckpointManager
+            from nvidia_resiliency_ext.checkpointing.local.ckpt_managers.local_manager import (
+                LocalCheckpointManager,
+            )
         except ModuleNotFoundError as e:
             raise RuntimeError('nvidia_resiliency_ext is required for local checkpointing') from e
 
@@ -518,6 +521,16 @@ def validate_args(args, defaults={}):
             args.rl_submission_granularity == "B"
             and args.rl_consumption_granularity == "G"
         ), "--rl-submission-granularity B with --rl-consumption-granularity G is not supported."
+        if args.rl_inference_rebalancing:
+            assert args.rl_submission_granularity != "B", (
+                "--rl-inference-rebalancing requires --rl-submission-granularity R or G "
+                "(in B mode every environment already gets the full gate capacity)."
+            )
+            if not args.rl_partial_rollouts:
+                warnings.warn(
+                    "--rl-inference-rebalancing without --rl-partial-rollouts has "
+                    "little effect: rollout generators are rebuilt every iteration."
+                )
 
         args.grpo_samples_per_iteration = args.grpo_prompts_per_step * args.grpo_group_size
 
@@ -719,8 +732,10 @@ def validate_args(args, defaults={}):
         )
 
     from megatron.core.models.hybrid.hybrid_layer_allocation import (
-        Symbols, parse_hybrid_pattern, get_hybrid_total_layer_count,
+        Symbols,
+        get_hybrid_total_layer_count,
         get_hybrid_total_pipeline_segment_count,
+        parse_hybrid_pattern,
     )
     sep = Symbols.MTP_SEPARATOR
 
@@ -2453,6 +2468,21 @@ def _add_rl_args(parser):
                        help="Filter groups with same reward.")
     group.add_argument('--langrl-env-config', type=str, default=None,
                        help="Path to YAML config file for RL environment configuration.")
+    group.add_argument('--rl-inference-rebalancing', action=argparse.BooleanOptionalAction,
+                       default=False,
+                       help='Dynamically shift per-environment inference concurrency '
+                            '(parallel generation tasks) toward slower environments in '
+                            'multi-env runs, driven by an EMA of per-rollout generation '
+                            'time. The training data mix is unchanged. Requires a '
+                            'multi-env --langrl-env-config and submission granularity '
+                            'R or G.')
+    group.add_argument('--rl-inference-rebalancing-ema-alpha', type=float, default=0.2,
+                       help='EMA smoothing factor for per-rollout generation time.')
+    group.add_argument('--rl-inference-rebalancing-interval', type=float, default=30.0,
+                       help='Minimum seconds between inference rebalancing updates.')
+    group.add_argument('--rl-inference-rebalancing-max-step', type=float, default=0.25,
+                       help='Maximum per-update change of an environment\'s allocation, '
+                            'as a fraction of its current value.')
     group.add_argument('--rl-default-temperature', type=float, default=1.0,
                        help="Default temperature for model inference.")
     group.add_argument('--rl-default-top-p', type=float, default=0,
@@ -2559,8 +2589,7 @@ def _add_rl_args(parser):
     return parser
 
 def _add_training_args(parser):
-    from megatron.training.config import TrainingConfig
-    from megatron.training.config import ProfilingConfig
+    from megatron.training.config import ProfilingConfig, TrainingConfig
 
     prof_factory = ArgumentGroupFactory(ProfilingConfig)
     prof_group = prof_factory.build_group(parser, "profiling")
@@ -3419,7 +3448,7 @@ def _add_kitchen_quantization_arguments(parser: argparse.ArgumentParser):
     If kitchen isn't available, nothing to do here, return unchanged parser
     """
     try:
-        from megatron.core.extensions.kitchen import KitchenSpecProvider, HAVE_KITCHEN
+        from megatron.core.extensions.kitchen import HAVE_KITCHEN, KitchenSpecProvider
 
     except (ImportError, ModuleNotFoundError):
         HAVE_KITCHEN = False

--- a/tests/unit_tests/rl/simulate_grouped_rollouts.py
+++ b/tests/unit_tests/rl/simulate_grouped_rollouts.py
@@ -1,0 +1,1600 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Standalone simulator for GroupedRolloutGenerator.get_grouped_rollouts.
+
+Drives the real _RolloutPipeline in megatron/rl/agent/api.py for each valid
+(submission, consumption) granularity combination with inference mocked as a
+uniform-random sleep (no network), then reports per-mode timings: overall
+get_grouped_rollouts wall time, per-rollout prepare-to-yield wall times, the
+sampled generation-latency distribution, per-training-step inference steps
+(engine decode steps, in tokens) versus each batch's max sequence length, and
+the pipeline's own queue-dwell and gate metrics.
+
+Run from the repo root:
+
+    uv run python tests/unit_tests/rl/simulate_grouped_rollouts.py
+"""
+
+import argparse
+import asyncio
+import html
+import math
+import random
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+from pydantic import PrivateAttr
+
+# Make megatron importable when this file is executed directly as a script
+# (sys.path[0] is then this directory, not the repo root).
+_REPO_ROOT = str(Path(__file__).resolve().parents[3])
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+if __name__ == "__main__":
+    print("importing megatron (takes ~10s)...", file=sys.stderr, flush=True)
+
+from megatron.rl.agent.api import (  # noqa: E402
+    GroupedRolloutGenerator,
+    GroupedRolloutRequest,
+    GroupRolloutParams,
+    Rollout,
+    RolloutGenerator,
+)
+from megatron.rl.agent.weighted_multi_task import (  # noqa: E402
+    AgentConfig,
+    PgtRebalanceConfig,
+    WeightedMultiTask,
+)
+from megatron.rl.inference import InferenceResponse, LLMChatMessage, ReturnsRaw  # noqa: E402
+from megatron.rl.rollout_granularity import get_rl_parallel_generation_tasks  # noqa: E402
+
+# All valid (submission, consumption) combinations. B/G is rejected by
+# _GranularityConfig._validate in megatron/rl/agent/api.py.
+MODES = [("B", "B"), ("G", "G"), ("G", "B"), ("R", "B"), ("R", "G")]
+
+
+class UniformLatencyInterface(ReturnsRaw):
+    """Mocked inference backend: each call sleeps uniform(lo, hi) seconds.
+
+    Stands in for the external HTTP inference server. Must never raise:
+    pipeline coroutines are wrapped in trace_async_exceptions, which calls
+    sys.exit(1) on any exception.
+    """
+
+    lo: float
+    hi: float
+    seed: int = 0
+    # Per-env latency ranges, keyed by the "{env}:" prompt prefix that
+    # SimAgent stamps on every prompt. Envs without an entry use (lo, hi).
+    # All envs share this one interface — i.e. one engine.
+    ranges: dict[str, tuple[float, float]] = {}
+    # Fixed number of engine slots (continuous-batching rows). None = unlimited:
+    # requests never queue, so slot-idle "gaps" cannot exist.
+    slots: int | None = None
+    # Current policy version (batches trained so far); bumped by the consumer
+    # after each simulated train step. Stamped into each response's
+    # policy_epoch, mirroring what the real engine records per rollout.
+    policy_version: int = 0
+    active_requests: int = 0
+    max_active_requests: int = 0
+    busy_seconds: float = 0.0
+    sampled_latencies: list[float] = []
+    # Sampled latencies keyed by prompt ("t{group_idx}"), so the consumer can
+    # recover each consumed group's rollout lengths.
+    delays_by_prompt: dict[str, list[float]] = {}
+    # Cumulative wall time with >=1 active request: a continuous-batching
+    # engine runs one decode step per token-time whenever any row is occupied,
+    # so this is the engine's decode-step clock.
+    engine_active_seconds: float = 0.0
+    # True while a colocated train step holds the GPUs: in-flight decodes make
+    # no progress until resume(). paused_seconds accumulates the frozen time.
+    paused: bool = False
+    paused_seconds: float = 0.0
+
+    _rng: random.Random | None = PrivateAttr(default=None)
+    _sem: asyncio.Semaphore | None = PrivateAttr(default=None)
+    _active_since: float | None = PrivateAttr(default=None)
+    _pause_event: asyncio.Event | None = PrivateAttr(default=None)
+    _resume_event: asyncio.Event | None = PrivateAttr(default=None)
+    _paused_since: float | None = PrivateAttr(default=None)
+
+    def engine_active_time(self):
+        """engine_active_seconds including the currently open active window."""
+        active = self.engine_active_seconds
+        if self._active_since is not None:
+            active += time.monotonic() - self._active_since
+        return active
+
+    def _ensure_pause_events(self):
+        if self._pause_event is None:
+            self._pause_event = asyncio.Event()
+            self._resume_event = asyncio.Event()
+            self._resume_event.set()
+
+    def pause(self):
+        """Freeze the engine (colocated train step): in-flight decodes stop."""
+        if self.paused:
+            return
+        self._ensure_pause_events()
+        self.paused = True
+        self._paused_since = time.monotonic()
+        if self._active_since is not None:
+            self.engine_active_seconds += self._paused_since - self._active_since
+            self._active_since = None
+        self._resume_event = asyncio.Event()
+        self._pause_event.set()
+
+    def resume(self):
+        """Unfreeze the engine: frozen decodes pick up where they stopped."""
+        if not self.paused:
+            return
+        self.paused = False
+        now = time.monotonic()
+        self.paused_seconds += now - self._paused_since
+        self._paused_since = None
+        if self.active_requests > 0:
+            self._active_since = now
+        self._pause_event = asyncio.Event()
+        self._resume_event.set()
+
+    async def _decode_sleep(self, delay):
+        """asyncio.sleep(delay) whose clock does not advance while paused."""
+        self._ensure_pause_events()
+        remaining = delay
+        while True:
+            if self.paused:
+                await self._resume_event.wait()
+            started = time.monotonic()
+            try:
+                # Wakes early when a pause begins mid-decode; only the wall
+                # time actually decoded is charged against `remaining`.
+                await asyncio.wait_for(self._pause_event.wait(), timeout=remaining)
+            except asyncio.TimeoutError:
+                return
+            remaining -= time.monotonic() - started
+
+    async def base_generate(self, request):
+        if self._rng is None:
+            self._rng = random.Random(self.seed)
+        if self.slots and self._sem is None:
+            self._sem = asyncio.Semaphore(self.slots)
+        prompt = request.prompt[0].content
+        env = prompt.split(":", 1)[0] if ":" in prompt else ""
+        lo, hi = self.ranges.get(env, (self.lo, self.hi))
+        delay = self._rng.uniform(lo, hi)
+        self.sampled_latencies.append(delay)
+        self.delays_by_prompt.setdefault(prompt, []).append(delay)
+        if self._sem is not None:
+            await self._sem.acquire()
+        self.active_requests += 1
+        if self.active_requests == 1 and not self.paused:
+            self._active_since = time.monotonic()
+        self.max_active_requests = max(self.max_active_requests, self.active_requests)
+        try:
+            await self._decode_sleep(delay)
+            self.busy_seconds += delay
+            version = self.policy_version
+            return InferenceResponse(
+                response=LLMChatMessage(role="assistant", content=prompt),
+                raw_text=prompt,
+                finish_reason="stop",
+                policy_epoch=[(version, version)],
+                kv_cache_epoch=[(0, 0)],
+                num_evictions=0,
+            )
+        finally:
+            self.active_requests -= 1
+            if self.active_requests == 0 and self._active_since is not None:
+                self.engine_active_seconds += time.monotonic() - self._active_since
+                self._active_since = None
+            if self._sem is not None:
+                self._sem.release()
+
+
+class SimAgent(RolloutGenerator, GroupedRolloutGenerator):
+    """Agent whose only per-rollout work is one mocked inference call.
+
+    Also nominally a RolloutGenerator so AgentConfig accepts it when the
+    multi-env simulation wraps SimAgents in a real WeightedMultiTask.
+    """
+
+    def __init__(self, env_name="sim", **kwargs):
+        super().__init__(**kwargs)
+        self.env_id = env_name
+        self.group_prepared_at = {}
+        self._group_count = 0
+        # Readahead window (prototype lag bound): when set, prepare may not
+        # run more than this many batches ahead of consumption. Wired up by
+        # run_mode from SimConfig.max_readahead_batches.
+        self._readahead_window = None
+        self._readahead_iface = None
+        self._groups_per_batch = None
+
+    async def get_reward_rollouts(self, request):
+        raise NotImplementedError
+
+    async def get_rollout_response(self, request, inference_request):
+        return await request.inference_interface.agenerate(inference_request)
+
+    async def prepare_group_rollout(self, request):
+        if self._readahead_window is not None:
+            # Awaiting here blocks stage_prepare, which is exactly the
+            # submission throttle point (called once per group).
+            limit = lambda: (
+                (self._readahead_iface.policy_version + self._readahead_window)
+                * self._groups_per_batch
+            )
+            while self._group_count >= limit():
+                await asyncio.sleep(0.001)
+        idx = self._group_count
+        self._group_count += 1
+        self.group_prepared_at[idx] = time.monotonic()
+        inference_request = request.inference_interface.prepare_request(
+            f"{self.env_id}:t{idx}", request.generation_args
+        )
+
+        async def build_rollout(response):
+            # problem_id carries the group index so the consumer can look up
+            # the group's prepare timestamp.
+            return Rollout(
+                trajectory=[response.raw_text],
+                reward=0.0,
+                env_id=self.env_id,
+                problem_id=str(idx),
+                policy_epoch=[response.policy_epoch],
+                kv_cache_epoch=[response.kv_cache_epoch],
+                num_evictions=[response.num_evictions],
+            )
+
+        return GroupRolloutParams(inference_request=inference_request, build_rollout=build_rollout)
+
+
+@dataclass
+class SimConfig:
+    num_groups: int = 8  # groups per batch
+    num_batches: int = 4
+    rollouts_per_group: int = 4
+    parallel_generation_tasks: int = 4
+    latency_lo: float = 0.01
+    latency_hi: float = 0.05
+    seed: int = 0
+    streaming: bool = True
+    # Simulated trainer pause after each completed batch; generation whose gate
+    # slots are already free keeps running during the pause.
+    train_time: float = 0.0
+    # Colocated trainer: the train step holds the GPUs, so the engine pauses
+    # for train_time and in-flight decodes freeze (False = disaggregated,
+    # generation keeps running through the pause).
+    colocated: bool = False
+    # Fixed engine slot count (None = unlimited, the pre-existing behavior).
+    engine_slots: int | None = None
+    # When set, gate capacity is derived per mode from the production formula
+    # (get_rl_parallel_generation_tasks) instead of parallel_generation_tasks.
+    generation_lag: int | None = None
+    # Prototype lag bound: prepare may not run more than this many batches
+    # ahead of consumption (None = current production behavior, unbounded
+    # for R submission).
+    max_readahead_batches: int | None = None
+    # Token clock: a rollout whose mocked latency is D seconds stands for a
+    # D / seconds_per_token-token generation. Converts engine-active time into
+    # inference steps (decode steps) and latencies into sequence lengths.
+    seconds_per_token: float = 0.001
+
+    def gate_capacity(self, submission):
+        if self.generation_lag is None:
+            return self.parallel_generation_tasks
+        return get_rl_parallel_generation_tasks(
+            SimpleNamespace(
+                rl_generation_lag=self.generation_lag,
+                rl_submission_granularity=submission,
+                grpo_prompts_per_step=self.num_groups,
+                grpo_group_size=self.rollouts_per_group,
+            )
+        )
+
+
+@dataclass
+class ModeResult:
+    mode: str
+    total_wall: float
+    num_groups: int
+    num_rollouts: int
+    rollout_walls: list[float]
+    sampled_latencies: list[float]
+    batch_done_at: list[tuple[int, float]]  # (batch_id, seconds since start)
+    # Readahead in batches at each batch completion: (groups prepared - groups
+    # yielded) / groups per batch. Proxy for policy staleness of in-flight work.
+    readahead_batches: list[float]
+    # Mean policy lag of each consumed batch's rollouts (policy version at
+    # training minus version stamped at generation) — the simulator twin of
+    # the mean_policy_staleness metric in W&B.
+    batch_mean_lag: list[float]
+    # Inference steps charged to each training step: engine-active time between
+    # consecutive batch completions / seconds_per_token, i.e. decode steps the
+    # trainer waited through (including readahead work for future batches).
+    batch_inference_steps: list[float]
+    # Longest rollout in each consumed batch, in tokens (max sampled latency /
+    # seconds_per_token). inference_steps == max_seq_len means the trainer
+    # waited only for the batch's longest rollout — the fully-parallel bound.
+    batch_max_seq_len: list[float]
+    engine_slots: int | None
+    engine_utilization: (
+        float | None
+    )  # busy slot-seconds / (slots * unpaused wall); None if unlimited
+    engine_paused_seconds: float  # wall time the engine spent frozen (colocated train steps)
+    max_active_requests: int
+    dwell: dict[str, list[float]]
+    counters: dict[str, int]
+    gate: dict[str, float]
+
+    @property
+    def batch_step_ratio(self):
+        """Inference steps per training step relative to the batch's max seq len."""
+        return [
+            steps / max_len
+            for steps, max_len in zip(self.batch_inference_steps, self.batch_max_seq_len)
+        ]
+
+
+async def run_mode(submission, consumption, cfg: SimConfig) -> ModeResult:
+    """Drive get_grouped_rollouts for one granularity mode and collect timings."""
+    iface = UniformLatencyInterface(
+        lo=cfg.latency_lo, hi=cfg.latency_hi, seed=cfg.seed, slots=cfg.engine_slots
+    )
+    agent = SimAgent(parallel_generation_tasks=cfg.gate_capacity(submission))
+    if cfg.max_readahead_batches is not None:
+        agent._readahead_window = cfg.max_readahead_batches
+        agent._readahead_iface = iface
+        agent._groups_per_batch = cfg.num_groups
+    request = GroupedRolloutRequest(
+        num_groups=cfg.num_groups,
+        rollouts_per_group=cfg.rollouts_per_group,
+        inference_interface=iface,
+        streaming=cfg.streaming,
+        submission_granularity=submission,
+        consumption_granularity=consumption,
+    )
+    # In streaming mode stage_prepare runs forever, so the consumer breaks
+    # after num_batches batches. Non-streaming generates exactly one batch.
+    target_groups = cfg.num_batches * cfg.num_groups if cfg.streaming else cfg.num_groups
+
+    pipeline = None
+    groups = []
+    rollout_walls = []
+    batch_group_counts = {}
+    batch_done_at = []
+    readahead_batches = []
+    batch_gen_versions = {}
+    batch_mean_lag = []
+    batch_max_delay = {}
+    batch_inference_steps = []
+    batch_max_seq_len = []
+    engine_steps_snapshot = 0.0
+    agen = agent.get_grouped_rollouts(request)
+    t0 = time.monotonic()
+    try:
+        async for group in agen:
+            if pipeline is None:
+                # Grab a reference before get_grouped_rollouts' finally block
+                # clears agent._active_pipeline.
+                pipeline = agent._active_pipeline
+            now = time.monotonic()
+            prepared_at = agent.group_prepared_at[int(group[0].problem_id)]
+            rollout_walls.extend([now - prepared_at] * len(group))
+            groups.append(group)
+            batch_group_counts[group.batch_id] = batch_group_counts.get(group.batch_id, 0) + 1
+            batch_gen_versions.setdefault(group.batch_id, []).extend(
+                rollout.policy_epoch[0][0][0] for rollout in group
+            )
+            group_delays = iface.delays_by_prompt[f"{agent.env_id}:t{int(group[0].problem_id)}"]
+            batch_max_delay[group.batch_id] = max(
+                batch_max_delay.get(group.batch_id, 0.0), max(group_delays)
+            )
+            batch_completed = batch_group_counts[group.batch_id] == cfg.num_groups
+            if batch_completed:
+                batch_done_at.append((group.batch_id, now - t0))
+                readahead_batches.append((agent._group_count - len(groups)) / cfg.num_groups)
+                gen_versions = batch_gen_versions.pop(group.batch_id)
+                batch_mean_lag.append(
+                    sum(iface.policy_version - v for v in gen_versions) / len(gen_versions)
+                )
+                engine_steps_now = iface.engine_active_time()
+                batch_inference_steps.append(
+                    (engine_steps_now - engine_steps_snapshot) / cfg.seconds_per_token
+                )
+                engine_steps_snapshot = engine_steps_now
+                batch_max_seq_len.append(
+                    batch_max_delay.pop(group.batch_id) / cfg.seconds_per_token
+                )
+            if cfg.streaming and len(groups) >= target_groups:
+                break
+            if batch_completed:
+                # The trainer runs its step. Disaggregated (default): the
+                # pipeline keeps whatever generation its gate slots allow
+                # running in the background. Colocated: the trainer holds the
+                # GPUs, so the engine pauses and in-flight decodes freeze.
+                # Afterwards the weights are refit: the policy version bumps.
+                if cfg.train_time:
+                    if cfg.colocated:
+                        iface.pause()
+                    try:
+                        await asyncio.sleep(cfg.train_time)
+                    finally:
+                        if cfg.colocated:
+                            iface.resume()
+                iface.policy_version += 1
+    finally:
+        # Break leaves the async generator suspended; close it so the pipeline
+        # tasks are cancelled inside the timed window and nothing leaks.
+        await agen.aclose()
+    total_wall = time.monotonic() - t0
+
+    if pipeline is None:
+        raise RuntimeError(f"{submission}/{consumption}: no groups were yielded")
+    gate = pipeline.gate
+    return ModeResult(
+        mode=f"{submission}/{consumption}",
+        total_wall=total_wall,
+        num_groups=len(groups),
+        num_rollouts=sum(len(group) for group in groups),
+        rollout_walls=rollout_walls,
+        sampled_latencies=list(iface.sampled_latencies),
+        batch_done_at=batch_done_at,
+        readahead_batches=readahead_batches,
+        batch_mean_lag=batch_mean_lag,
+        batch_inference_steps=batch_inference_steps,
+        batch_max_seq_len=batch_max_seq_len,
+        engine_slots=cfg.engine_slots,
+        engine_utilization=(
+            iface.busy_seconds / (cfg.engine_slots * (total_wall - iface.paused_seconds))
+            if cfg.engine_slots
+            else None
+        ),
+        engine_paused_seconds=iface.paused_seconds,
+        max_active_requests=iface.max_active_requests,
+        dwell={
+            "infer_queue_dwell": list(pipeline.infer_queue_dwell),
+            "engine_dwell": list(pipeline.engine_dwell),
+            "assemble_queue_dwell": list(pipeline.assemble_queue_dwell),
+            "output_queue_dwell": list(pipeline.output_queue_dwell),
+        },
+        counters={
+            "prepared": pipeline.prepared_count,
+            "inferred": pipeline.inferred_count,
+            "assembled": pipeline.assembled_count,
+            "yielded": pipeline.yielded_count,
+        },
+        gate={
+            "capacity": gate.capacity,
+            "held_at_end": gate.held,
+            "prepare_blocked_seconds": gate.prepare_blocked_seconds,
+            "acquire_calls": gate.acquire_calls,
+            "release_calls": gate.release_calls,
+        },
+    )
+
+
+@dataclass
+class EnvSpec:
+    """One simulated environment: its name, latency range, and data-mix weight."""
+
+    name: str
+    lo: float
+    hi: float
+    weight: float = 1.0
+
+
+@dataclass
+class MultiEnvResult:
+    mode: str
+    rebalanced: bool
+    total_wall: float
+    num_groups: int
+    groups_per_env: dict[str, int]
+    batch_done_at: list[float]  # seconds since start, one per completed mixed batch
+    # Each env's gate capacity sampled at every batch completion.
+    pgt_trajectory: dict[str, list[int]]
+    # Each env's engine_dwell EMA at the end of the run (None = no samples).
+    ema_per_env: dict[str, float | None]
+    engine_utilization: float | None
+    max_active_requests: int
+
+
+async def run_multi_env_mode(
+    submission,
+    consumption,
+    cfg: SimConfig,
+    envs: list[EnvSpec],
+    rebalance: PgtRebalanceConfig | None = None,
+) -> MultiEnvResult:
+    """Drive a real WeightedMultiTask over heterogeneous envs sharing one engine.
+
+    Mirrors production wiring: one SimAgent per env under WeightedMultiTask,
+    the request's num_groups is one trainer batch, and every cfg.num_groups
+    yielded (mixed) groups count as one consumed batch, after which the
+    policy version bumps (and the engine optionally pauses, colocated-style).
+    """
+    iface = UniformLatencyInterface(
+        lo=cfg.latency_lo,
+        hi=cfg.latency_hi,
+        seed=cfg.seed,
+        slots=cfg.engine_slots,
+        ranges={env.name: (env.lo, env.hi) for env in envs},
+    )
+    multi_task = WeightedMultiTask(
+        [
+            AgentConfig(agent_type=SimAgent, agent_args={"env_name": env.name}, weight=env.weight)
+            for env in envs
+        ],
+        pgt_rebalance=rebalance,
+    )
+    multi_task.parallel_generation_tasks = cfg.gate_capacity(submission)
+    request = GroupedRolloutRequest(
+        num_groups=cfg.num_groups,
+        rollouts_per_group=cfg.rollouts_per_group,
+        inference_interface=iface,
+        streaming=cfg.streaming,
+        submission_granularity=submission,
+        consumption_granularity=consumption,
+    )
+    target_groups = cfg.num_batches * cfg.num_groups if cfg.streaming else cfg.num_groups
+
+    groups_per_env = {env.name: 0 for env in envs}
+    pgt_trajectory = {env.name: [] for env in envs}
+    ema_per_env = {env.name: None for env in envs}
+    batch_done_at = []
+    consumed = 0
+    agen = multi_task.get_grouped_rollouts(request)
+    t0 = time.monotonic()
+    try:
+        async for group in agen:
+            consumed += 1
+            groups_per_env[group[0].env_id] += 1
+            if consumed % cfg.num_groups == 0:
+                batch_done_at.append(time.monotonic() - t0)
+                for agent in multi_task.agents:
+                    pipeline = getattr(agent, "_active_pipeline", None)
+                    if pipeline is not None:
+                        pgt_trajectory[agent.env_id].append(pipeline.gate.capacity)
+                        ema_per_env[agent.env_id] = pipeline.engine_dwell_ema
+                if consumed >= target_groups:
+                    break
+                if cfg.train_time:
+                    if cfg.colocated:
+                        iface.pause()
+                    try:
+                        await asyncio.sleep(cfg.train_time)
+                    finally:
+                        if cfg.colocated:
+                            iface.resume()
+                iface.policy_version += 1
+    finally:
+        await agen.aclose()
+    total_wall = time.monotonic() - t0
+
+    return MultiEnvResult(
+        mode=f"{submission}/{consumption}",
+        rebalanced=rebalance is not None,
+        total_wall=total_wall,
+        num_groups=consumed,
+        groups_per_env=groups_per_env,
+        batch_done_at=batch_done_at,
+        pgt_trajectory=pgt_trajectory,
+        ema_per_env=ema_per_env,
+        engine_utilization=(
+            iface.busy_seconds / (cfg.engine_slots * (total_wall - iface.paused_seconds))
+            if cfg.engine_slots
+            else None
+        ),
+        max_active_requests=iface.max_active_requests,
+    )
+
+
+def print_multi_env_report(result: MultiEnvResult) -> None:
+    kind = "rebalanced" if result.rebalanced else "static split"
+    print(f"\n=== mode {result.mode} multi-env ({kind}) ===")
+    print(f"  wall time: {result.total_wall:.3f}s  groups: {result.num_groups}")
+    mix = "  ".join(f"{env}={count}" for env, count in result.groups_per_env.items())
+    print(f"  data mix (groups per env): {mix}")
+    arrivals = "  ".join(f"b{i}={t:.2f}s" for i, t in enumerate(result.batch_done_at))
+    print(f"  batch completion (since start): {arrivals}")
+    for env, capacities in result.pgt_trajectory.items():
+        trail = " ".join(str(capacity) for capacity in capacities)
+        ema = result.ema_per_env[env]
+        ema_desc = f"{ema * 1000:.1f}ms" if ema is not None else "-"
+        print(f"  {env}: gate capacity per batch: {trail}  (engine_dwell EMA {ema_desc})")
+    if result.engine_utilization is not None:
+        print(f"  engine utilization: {result.engine_utilization:.0%}")
+
+
+def stats(samples):
+    """Distribution summary matching the rl_utils dwell-metric convention."""
+    if not samples:
+        return None
+    arr = np.asarray(samples, dtype=np.float64)
+    return {
+        "n": len(samples),
+        "mean": float(arr.mean()),
+        "min": float(arr.min()),
+        "max": float(arr.max()),
+        "p50": float(np.percentile(arr, 50)),
+        "p99": float(np.percentile(arr, 99)),
+    }
+
+
+def _stats_line(name, samples):
+    summary = stats(samples)
+    if summary is None:
+        return f"    {name:<22} (no samples)"
+    return (
+        f"    {name:<22} n={summary['n']:<5d}"
+        f" mean={summary['mean'] * 1000:8.2f}ms"
+        f" min={summary['min'] * 1000:8.2f}ms"
+        f" p50={summary['p50'] * 1000:8.2f}ms"
+        f" p99={summary['p99'] * 1000:8.2f}ms"
+        f" max={summary['max'] * 1000:8.2f}ms"
+    )
+
+
+def print_mode_report(result: ModeResult) -> None:
+    counters = result.counters
+    gate = result.gate
+    print(f"\n=== mode {result.mode} (submission/consumption) ===")
+    print(f"  get_grouped_rollouts wall time: {result.total_wall:.3f}s")
+    print(
+        f"  groups yielded: {result.num_groups}  rollouts: {result.num_rollouts}  "
+        f"max concurrent inference calls: {result.max_active_requests}"
+    )
+    print(
+        f"  pipeline counters: prepared={counters['prepared']} inferred={counters['inferred']} "
+        f"assembled={counters['assembled']} yielded={counters['yielded']}"
+    )
+    print(
+        f"  gate: capacity={gate['capacity']} held_at_end={gate['held_at_end']} "
+        f"prepare_blocked={gate['prepare_blocked_seconds']:.3f}s "
+        f"acquires={gate['acquire_calls']} releases={gate['release_calls']}"
+    )
+    arrivals = "  ".join(f"b{batch_id}={t:.2f}s" for batch_id, t in result.batch_done_at)
+    print(f"  batch completion (since start): {arrivals}")
+    if result.readahead_batches:
+        trail = "  ".join(f"{r:.1f}" for r in result.readahead_batches)
+        print(f"  readahead at each ship (batches, staleness proxy): {trail}")
+    if result.batch_mean_lag:
+        trail = "  ".join(f"{lag:.1f}" for lag in result.batch_mean_lag)
+        print(f"  mean rollout lag per iteration (policy versions): {trail}")
+    if result.batch_inference_steps:
+        trail = "  ".join(
+            f"b{batch_id}={steps:.0f}/{max_len:.0f}({steps / max_len:.1f}x)"
+            for (batch_id, _), steps, max_len in zip(
+                result.batch_done_at, result.batch_inference_steps, result.batch_max_seq_len
+            )
+        )
+        total_steps = sum(result.batch_inference_steps)
+        total_max = sum(result.batch_max_seq_len)
+        print(
+            f"  inference steps / batch max seq len (tokens): {trail}  "
+            f"total={total_steps:.0f}/{total_max:.0f}({total_steps / total_max:.1f}x)"
+        )
+    if result.engine_utilization is not None:
+        print(
+            f"  engine: {result.engine_slots} slots, "
+            f"utilization {result.engine_utilization:.0%} (idle slot time = white gaps)"
+        )
+    if result.engine_paused_seconds:
+        print(f"  engine paused for colocated train steps: {result.engine_paused_seconds:.3f}s")
+    print("  timings:")
+    print(_stats_line("generation latency", result.sampled_latencies))
+    print(_stats_line("rollout wall time", result.rollout_walls))
+    for name, samples in result.dwell.items():
+        print(_stats_line(name, samples))
+
+
+def print_summary(results: list[ModeResult]) -> None:
+    print("\n=== summary ===")
+    header = (
+        f"{'mode':<6} {'wall_s':>8} {'groups':>7} {'rollouts':>9} "
+        f"{'rollout_wall_mean_ms':>21} {'rollout_wall_p99_ms':>20} "
+        f"{'gen_lat_mean_ms':>16} {'max_conc':>9} {'util':>6} {'gate_blocked_s':>15}"
+    )
+    print(header)
+    for result in results:
+        walls = stats(result.rollout_walls)
+        lats = stats(result.sampled_latencies)
+        util = f"{result.engine_utilization:.0%}" if result.engine_utilization is not None else "-"
+        print(
+            f"{result.mode:<6} {result.total_wall:>8.3f} {result.num_groups:>7d} "
+            f"{result.num_rollouts:>9d} {walls['mean'] * 1000:>21.2f} "
+            f"{walls['p99'] * 1000:>20.2f} {lats['mean'] * 1000:>16.2f} "
+            f"{result.max_active_requests:>9d} {util:>6} "
+            f"{result.gate['prepare_blocked_seconds']:>15.3f}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# HTML report
+#
+# Self-contained inline-SVG charts, no plotting dependencies. Mode identity
+# keeps a fixed categorical color across every chart; the pipeline-stage
+# breakdown uses an ordinal single-hue ramp (stages are pipeline-ordered).
+# Palettes validated with the dataviz six-checks script (light + dark).
+# ---------------------------------------------------------------------------
+
+_PLOT_W = 640
+_STAGES = [
+    ("infer_queue_dwell", "infer queue"),
+    ("engine_dwell", "engine"),
+    ("assemble_queue_dwell", "assemble queue"),
+    ("output_queue_dwell", "output queue"),
+]
+
+
+def _fmt_ms(seconds):
+    ms = seconds * 1000
+    return f"{ms:,.2f} ms" if ms < 10 else f"{ms:,.1f} ms"
+
+
+def _nice_ticks(vmax, n=5):
+    """Round tick positions covering [0, vmax]."""
+    if vmax <= 0:
+        return [0.0]
+    raw = vmax / n
+    mag = 10 ** math.floor(math.log10(raw))
+    step = next(m * mag for m in (1, 2, 2.5, 5, 10) if m * mag >= raw)
+    return [i * step for i in range(int(math.ceil(vmax / step)) + 1)]
+
+
+def _hbar_path(x, y, w, h, r=4):
+    """Horizontal bar anchored flat at the left baseline, rounded data end."""
+    r = min(r, w / 2, h / 2)
+    return (
+        f"M{x:.1f},{y:.1f} H{x + w - r:.1f} Q{x + w:.1f},{y:.1f} {x + w:.1f},{y + r:.1f} "
+        f"V{y + h - r:.1f} Q{x + w:.1f},{y + h:.1f} {x + w - r:.1f},{y + h:.1f} "
+        f"H{x:.1f} Z"
+    )
+
+
+def _vbar_path(x, y, w, h, r=4):
+    """Vertical bar anchored flat at the bottom baseline, rounded top."""
+    r = min(r, w / 2, h / 2)
+    return (
+        f"M{x:.1f},{y + h:.1f} V{y + r:.1f} Q{x:.1f},{y:.1f} {x + r:.1f},{y:.1f} "
+        f"H{x + w - r:.1f} Q{x + w:.1f},{y:.1f} {x + w:.1f},{y + r:.1f} "
+        f"V{y + h:.1f} Z"
+    )
+
+
+def _legend(entries):
+    chips = "".join(
+        f'<span class="chip"><span class="swatch" style="background:{color}"></span>'
+        f"{html.escape(label)}</span>"
+        for label, color in entries
+    )
+    return f'<div class="legend">{chips}</div>'
+
+
+def _svg_wall_time_chart(results):
+    """Total get_grouped_rollouts wall time per mode: horizontal bars."""
+    row_h, bar_h, mleft, mtop = 32, 22, 64, 8
+    height = mtop + row_h * len(results) + 28
+    vmax = max(result.total_wall for result in results)
+    ticks = _nice_ticks(vmax)
+    scale = _PLOT_W / ticks[-1]
+    parts = []
+    axis_y = mtop + row_h * len(results)
+    for tick in ticks:
+        x = mleft + tick * scale
+        parts.append(f'<line class="grid" x1="{x:.1f}" y1="{mtop}" x2="{x:.1f}" y2="{axis_y}"/>')
+        parts.append(
+            f'<text class="tick" x="{x:.1f}" y="{axis_y + 16}" text-anchor="middle">{tick:g}s</text>'
+        )
+    for i, result in enumerate(results):
+        y = mtop + i * row_h + (row_h - bar_h) / 2
+        w = result.total_wall * scale
+        tip = f"{result.mode}: {result.total_wall:.3f}s total for {result.num_rollouts} rollouts"
+        parts.append(
+            f'<text class="label" x="{mleft - 8}" y="{y + bar_h / 2 + 4}" text-anchor="end">{result.mode}</text>'
+        )
+        parts.append(
+            f'<path d="{_hbar_path(mleft, y, w, bar_h)}" fill="var(--series-{i + 1})" data-tip="{tip}"/>'
+        )
+        parts.append(
+            f'<text class="value" x="{mleft + w + 6}" y="{y + bar_h / 2 + 4}">{result.total_wall:.3f}s</text>'
+        )
+    parts.append(
+        f'<line class="axis" x1="{mleft}" y1="{axis_y}" x2="{mleft + _PLOT_W}" y2="{axis_y}"/>'
+    )
+    return f'<svg viewBox="0 0 {mleft + _PLOT_W + 60} {height}">{"".join(parts)}</svg>'
+
+
+def _svg_ecdf_chart(results):
+    """Per-rollout prepare-to-yield wall time, cumulative distribution per mode."""
+    mleft, mtop, plot_h = 48, 8, 220
+    height = mtop + plot_h + 32
+    vmax = max(max(result.rollout_walls) for result in results)
+    ticks = _nice_ticks(vmax * 1000)
+    scale = _PLOT_W / (ticks[-1] / 1000)
+    parts = []
+    axis_y = mtop + plot_h
+    for tick in ticks:
+        x = mleft + (tick / 1000) * scale
+        parts.append(f'<line class="grid" x1="{x:.1f}" y1="{mtop}" x2="{x:.1f}" y2="{axis_y}"/>')
+        parts.append(
+            f'<text class="tick" x="{x:.1f}" y="{axis_y + 16}" text-anchor="middle">{tick:g}ms</text>'
+        )
+    for frac in (0, 0.25, 0.5, 0.75, 1.0):
+        y = axis_y - frac * plot_h
+        parts.append(
+            f'<line class="grid" x1="{mleft}" y1="{y:.1f}" x2="{mleft + _PLOT_W}" y2="{y:.1f}"/>'
+        )
+        parts.append(
+            f'<text class="tick" x="{mleft - 6}" y="{y + 4:.1f}" text-anchor="end">{frac:.0%}</text>'
+        )
+    for i, result in enumerate(results):
+        walls = sorted(result.rollout_walls)
+        n = len(walls)
+        pts = [(mleft + walls[j] * scale, axis_y - ((j + 1) / n) * plot_h) for j in range(n)]
+        path = "M" + " L".join(f"{x:.1f},{y:.1f}" for x, y in pts)
+        color = f"var(--series-{i + 1})"
+        parts.append(f'<path d="{path}" fill="none" stroke="{color}" stroke-width="2"/>')
+        for pct in (50, 90, 99):
+            value = walls[min(n - 1, int(round(pct / 100 * n)) - 1)]
+            x, y = mleft + value * scale, axis_y - (pct / 100) * plot_h
+            tip = f"{result.mode} p{pct}: {_fmt_ms(value)}"
+            parts.append(
+                f'<circle cx="{x:.1f}" cy="{y:.1f}" r="3.5" fill="{color}" stroke="var(--surface-1)" stroke-width="2"/>'
+            )
+            parts.append(
+                f'<circle cx="{x:.1f}" cy="{y:.1f}" r="9" fill="transparent" data-tip="{tip}"/>'
+            )
+    parts.append(
+        f'<line class="axis" x1="{mleft}" y1="{axis_y}" x2="{mleft + _PLOT_W}" y2="{axis_y}"/>'
+    )
+    return f'<svg viewBox="0 0 {mleft + _PLOT_W + 24} {height}">{"".join(parts)}</svg>'
+
+
+def _svg_stage_chart(results):
+    """Mean time per pipeline stage, stacked horizontal bar per mode (ordinal ramp)."""
+    row_h, bar_h, mleft, mtop = 32, 22, 64, 8
+    height = mtop + row_h * len(results) + 28
+    means = [
+        [
+            (sum(result.dwell[key]) / len(result.dwell[key]) if result.dwell[key] else 0.0)
+            for key, _ in _STAGES
+        ]
+        for result in results
+    ]
+    vmax = max(sum(row) for row in means)
+    ticks = _nice_ticks(vmax * 1000)
+    scale = _PLOT_W / (ticks[-1] / 1000)
+    parts = []
+    axis_y = mtop + row_h * len(results)
+    for tick in ticks:
+        x = mleft + (tick / 1000) * scale
+        parts.append(f'<line class="grid" x1="{x:.1f}" y1="{mtop}" x2="{x:.1f}" y2="{axis_y}"/>')
+        parts.append(
+            f'<text class="tick" x="{x:.1f}" y="{axis_y + 16}" text-anchor="middle">{tick:g}ms</text>'
+        )
+    for i, (result, row) in enumerate(zip(results, means)):
+        y = mtop + i * row_h + (row_h - bar_h) / 2
+        parts.append(
+            f'<text class="label" x="{mleft - 8}" y="{y + bar_h / 2 + 4}" text-anchor="end">{result.mode}</text>'
+        )
+        x = float(mleft)
+        breakdown = " · ".join(
+            f"{label} {_fmt_ms(value)}" for (_, label), value in zip(_STAGES, row)
+        )
+        for j, value in enumerate(row):
+            w = value * scale
+            if w >= 1:  # sub-pixel stages are in the tooltip and table, not drawn
+                parts.append(
+                    f'<rect x="{x:.1f}" y="{y}" width="{max(w - 2, 1):.1f}" height="{bar_h}" '
+                    f'fill="var(--ramp-{j + 1})" data-tip="{html.escape(f"{result.mode} — {breakdown}")}"/>'
+                )
+            x += w
+        parts.append(
+            f'<text class="value" x="{x + 6:.1f}" y="{y + bar_h / 2 + 4}">{_fmt_ms(sum(row))}</text>'
+        )
+    parts.append(
+        f'<line class="axis" x1="{mleft}" y1="{axis_y}" x2="{mleft + _PLOT_W}" y2="{axis_y}"/>'
+    )
+    return f'<svg viewBox="0 0 {mleft + _PLOT_W + 70} {height}">{"".join(parts)}</svg>'
+
+
+def _svg_latency_histogram(result, cfg):
+    """Sampled generation latencies for one mode: should read uniform."""
+    mleft, mtop, plot_h, bins = 48, 14, 180, 12
+    height = mtop + plot_h + 32
+    samples = result.sampled_latencies
+    lo, hi = cfg.latency_lo, cfg.latency_hi
+    counts = [0] * bins
+    span = hi - lo
+    for value in samples:
+        idx = min(bins - 1, int((value - lo) / span * bins)) if span else 0
+        counts[max(0, idx)] += 1
+    cmax = max(counts)
+    ticks = _nice_ticks(cmax, n=4)
+    yscale = plot_h / ticks[-1]
+    parts = []
+    axis_y = mtop + plot_h
+    for tick in ticks:
+        y = axis_y - tick * yscale
+        parts.append(
+            f'<line class="grid" x1="{mleft}" y1="{y:.1f}" x2="{mleft + _PLOT_W}" y2="{y:.1f}"/>'
+        )
+        parts.append(
+            f'<text class="tick" x="{mleft - 6}" y="{y + 4:.1f}" text-anchor="end">{tick:g}</text>'
+        )
+    bin_w = _PLOT_W / bins
+    for j, count in enumerate(counts):
+        x = mleft + j * bin_w
+        h = count * yscale
+        b_lo, b_hi = lo + j * (hi - lo) / bins, lo + (j + 1) * (hi - lo) / bins
+        tip = f"{_fmt_ms(b_lo)}–{_fmt_ms(b_hi)}: {count} calls"
+        parts.append(
+            f'<path d="{_vbar_path(x + 1, axis_y - h, bin_w - 2, h)}" fill="var(--seq)" data-tip="{tip}"/>'
+        )
+    expected_y = axis_y - (len(samples) / bins) * yscale
+    parts.append(
+        f'<line x1="{mleft}" y1="{expected_y:.1f}" x2="{mleft + _PLOT_W}" y2="{expected_y:.1f}" '
+        'stroke="var(--ink-muted)" stroke-width="1.5" stroke-dasharray="5 4"/>'
+    )
+    parts.append(
+        f'<text class="tick" x="{mleft + 6}" y="{expected_y - 5:.1f}" text-anchor="start">expected if uniform</text>'
+    )
+    for frac, label in ((0, _fmt_ms(lo)), (0.5, _fmt_ms((lo + hi) / 2)), (1, _fmt_ms(hi))):
+        x = mleft + frac * _PLOT_W
+        anchor = "start" if frac == 0 else ("end" if frac == 1 else "middle")
+        parts.append(
+            f'<text class="tick" x="{x:.1f}" y="{axis_y + 16}" text-anchor="{anchor}">{label}</text>'
+        )
+    parts.append(
+        f'<line class="axis" x1="{mleft}" y1="{axis_y}" x2="{mleft + _PLOT_W}" y2="{axis_y}"/>'
+    )
+    return f'<svg viewBox="0 0 {mleft + _PLOT_W + 24} {height}">{"".join(parts)}</svg>'
+
+
+def _svg_batch_timeline(results):
+    """Cumulative completed batches over time, step line per mode."""
+    mleft, mtop, plot_h = 48, 8, 200
+    height = mtop + plot_h + 32
+    tmax = max(t for result in results for _, t in result.batch_done_at)
+    num_batches = max(len(result.batch_done_at) for result in results)
+    ticks = _nice_ticks(tmax)
+    scale = _PLOT_W / ticks[-1]
+    parts = []
+    axis_y = mtop + plot_h
+    for tick in ticks:
+        x = mleft + tick * scale
+        parts.append(f'<line class="grid" x1="{x:.1f}" y1="{mtop}" x2="{x:.1f}" y2="{axis_y}"/>')
+        parts.append(
+            f'<text class="tick" x="{x:.1f}" y="{axis_y + 16}" text-anchor="middle">{tick:g}s</text>'
+        )
+    for count in range(num_batches + 1):
+        y = axis_y - count / num_batches * plot_h
+        parts.append(
+            f'<line class="grid" x1="{mleft}" y1="{y:.1f}" x2="{mleft + _PLOT_W}" y2="{y:.1f}"/>'
+        )
+        parts.append(
+            f'<text class="tick" x="{mleft - 6}" y="{y + 4:.1f}" text-anchor="end">{count}</text>'
+        )
+    for i, result in enumerate(results):
+        color = f"var(--series-{i + 1})"
+        path = [f"M{mleft},{axis_y}"]
+        for count, (batch_id, t) in enumerate(result.batch_done_at, start=1):
+            x = mleft + t * scale
+            y_prev = axis_y - (count - 1) / num_batches * plot_h
+            y = axis_y - count / num_batches * plot_h
+            path.append(f"H{x:.1f} V{y:.1f}")
+        parts.append(f'<path d="{" ".join(path)}" fill="none" stroke="{color}" stroke-width="2"/>')
+        for count, (batch_id, t) in enumerate(result.batch_done_at, start=1):
+            x = mleft + t * scale
+            y = axis_y - count / num_batches * plot_h
+            tip = f"{result.mode} batch {batch_id} done at {t:.2f}s"
+            parts.append(
+                f'<circle cx="{x:.1f}" cy="{y:.1f}" r="3.5" fill="{color}" '
+                'stroke="var(--surface-1)" stroke-width="2"/>'
+            )
+            parts.append(
+                f'<circle cx="{x:.1f}" cy="{y:.1f}" r="9" fill="transparent" data-tip="{tip}"/>'
+            )
+    parts.append(
+        f'<line class="axis" x1="{mleft}" y1="{axis_y}" x2="{mleft + _PLOT_W}" y2="{axis_y}"/>'
+    )
+    return f'<svg viewBox="0 0 {mleft + _PLOT_W + 24} {height}">{"".join(parts)}</svg>'
+
+
+def _svg_utilization_chart(results):
+    """Engine utilization per mode: horizontal bars, 0-100% axis."""
+    row_h, bar_h, mleft, mtop = 32, 22, 110, 8
+    height = mtop + row_h * len(results) + 28
+    scale = _PLOT_W / 1.0
+    parts = []
+    axis_y = mtop + row_h * len(results)
+    for frac in (0, 0.25, 0.5, 0.75, 1.0):
+        x = mleft + frac * scale
+        parts.append(f'<line class="grid" x1="{x:.1f}" y1="{mtop}" x2="{x:.1f}" y2="{axis_y}"/>')
+        parts.append(
+            f'<text class="tick" x="{x:.1f}" y="{axis_y + 16}" text-anchor="middle">{frac:.0%}</text>'
+        )
+    for i, result in enumerate(results):
+        util = result.engine_utilization or 0.0
+        y = mtop + i * row_h + (row_h - bar_h) / 2
+        w = util * scale
+        tip = f"{result.mode}: {util:.1%} of {result.engine_slots} slots busy over the run"
+        parts.append(
+            f'<text class="label" x="{mleft - 8}" y="{y + bar_h / 2 + 4}" text-anchor="end">'
+            f"{html.escape(result.mode)}</text>"
+        )
+        parts.append(
+            f'<path d="{_hbar_path(mleft, y, w, bar_h)}" fill="var(--series-{i + 1})" '
+            f'data-tip="{html.escape(tip)}"/>'
+        )
+        parts.append(
+            f'<text class="value" x="{mleft + w + 6}" y="{y + bar_h / 2 + 4}">{util:.0%}</text>'
+        )
+    parts.append(
+        f'<line class="axis" x1="{mleft}" y1="{axis_y}" x2="{mleft + _PLOT_W}" y2="{axis_y}"/>'
+    )
+    return f'<svg viewBox="0 0 {mleft + _PLOT_W + 60} {height}">{"".join(parts)}</svg>'
+
+
+def _svg_readahead_chart(results):
+    """Readahead (staleness proxy, in batches) at each batch completion, per mode."""
+    return _svg_per_batch_line_chart(
+        results, "readahead_batches", "{mode}: {value:.1f} batches ahead when batch {batch} shipped"
+    )
+
+
+def _svg_lag_chart(results):
+    """Mean policy lag of each consumed batch's rollouts, per mode."""
+    return _svg_per_batch_line_chart(
+        results,
+        "batch_mean_lag",
+        "{mode}: batch {batch} trained on rollouts {value:.1f} versions old on average",
+    )
+
+
+def _svg_inference_steps_chart(results):
+    """Inference steps per training step, relative to each batch's max seq len."""
+    return _svg_per_batch_line_chart(
+        results,
+        "batch_step_ratio",
+        "{mode}: batch {batch} took {value:.1f}x its max seq len in engine decode steps",
+        ref_line=(1.0, "fully parallel bound (1.0x)"),
+    )
+
+
+def _svg_per_batch_line_chart(results, values_attr, tip_fmt, ref_line=None):
+    """One value per completed batch over time, line + dots per mode.
+
+    `ref_line` is an optional (value, label) pair drawn as a dashed horizontal
+    reference (e.g. a theoretical bound).
+    """
+    mleft, mtop, plot_h = 48, 8, 200
+    height = mtop + plot_h + 32
+    tmax = max(t for result in results for _, t in result.batch_done_at)
+    vmax = max(max(getattr(result, values_attr), default=0.0) for result in results)
+    if ref_line is not None:
+        vmax = max(vmax, ref_line[0])
+    xticks = _nice_ticks(tmax)
+    yticks = _nice_ticks(max(vmax, 1.0), n=4)
+    xscale = _PLOT_W / xticks[-1]
+    yscale = plot_h / yticks[-1]
+    parts = []
+    axis_y = mtop + plot_h
+    for tick in xticks:
+        x = mleft + tick * xscale
+        parts.append(f'<line class="grid" x1="{x:.1f}" y1="{mtop}" x2="{x:.1f}" y2="{axis_y}"/>')
+        parts.append(
+            f'<text class="tick" x="{x:.1f}" y="{axis_y + 16}" text-anchor="middle">{tick:g}s</text>'
+        )
+    for tick in yticks:
+        y = axis_y - tick * yscale
+        parts.append(
+            f'<line class="grid" x1="{mleft}" y1="{y:.1f}" x2="{mleft + _PLOT_W}" y2="{y:.1f}"/>'
+        )
+        parts.append(
+            f'<text class="tick" x="{mleft - 6}" y="{y + 4:.1f}" text-anchor="end">{tick:g}</text>'
+        )
+    if ref_line is not None:
+        ref_value, ref_label = ref_line
+        y = axis_y - ref_value * yscale
+        parts.append(
+            f'<line x1="{mleft}" y1="{y:.1f}" x2="{mleft + _PLOT_W}" y2="{y:.1f}" '
+            'stroke="var(--ink-muted)" stroke-width="1.5" stroke-dasharray="5 4"/>'
+        )
+        parts.append(
+            f'<text class="tick" x="{mleft + 6}" y="{y - 5:.1f}" text-anchor="start">'
+            f"{html.escape(ref_label)}</text>"
+        )
+    for i, result in enumerate(results):
+        color = f"var(--series-{i + 1})"
+        values = getattr(result, values_attr)
+        pts = [
+            (mleft + t * xscale, axis_y - value * yscale)
+            for (_, t), value in zip(result.batch_done_at, values)
+        ]
+        if len(pts) > 1:
+            path = "M" + " L".join(f"{x:.1f},{y:.1f}" for x, y in pts)
+            parts.append(f'<path d="{path}" fill="none" stroke="{color}" stroke-width="2"/>')
+        for ((batch_id, t), value), (x, y) in zip(zip(result.batch_done_at, values), pts):
+            tip = tip_fmt.format(mode=result.mode, batch=batch_id, value=value)
+            parts.append(
+                f'<circle cx="{x:.1f}" cy="{y:.1f}" r="3.5" fill="{color}" '
+                'stroke="var(--surface-1)" stroke-width="2"/>'
+            )
+            parts.append(
+                f'<circle cx="{x:.1f}" cy="{y:.1f}" r="9" fill="transparent" '
+                f'data-tip="{html.escape(tip)}"/>'
+            )
+    parts.append(
+        f'<line class="axis" x1="{mleft}" y1="{axis_y}" x2="{mleft + _PLOT_W}" y2="{axis_y}"/>'
+    )
+    return f'<svg viewBox="0 0 {mleft + _PLOT_W + 24} {height}">{"".join(parts)}</svg>'
+
+
+def _summary_table(results):
+    head = (
+        "<tr><th>mode</th><th>wall (s)</th><th>groups</th><th>rollouts</th>"
+        "<th>rollout wall mean</th><th>p50</th><th>p99</th>"
+        "<th>gen latency mean</th><th>infer steps ×</th>"
+        "<th>max concurrency</th><th>gate blocked (s)</th></tr>"
+    )
+    rows = []
+    for i, result in enumerate(results):
+        walls, lats = stats(result.rollout_walls), stats(result.sampled_latencies)
+        steps_ratio = (
+            f"{sum(result.batch_inference_steps) / sum(result.batch_max_seq_len):.1f}×"
+            if result.batch_max_seq_len
+            else "-"
+        )
+        rows.append(
+            f'<tr><td><span class="swatch" style="background:var(--series-{i + 1})"></span>{result.mode}</td>'
+            f"<td>{result.total_wall:.3f}</td><td>{result.num_groups}</td><td>{result.num_rollouts}</td>"
+            f"<td>{_fmt_ms(walls['mean'])}</td><td>{_fmt_ms(walls['p50'])}</td><td>{_fmt_ms(walls['p99'])}</td>"
+            f"<td>{_fmt_ms(lats['mean'])}</td><td>{steps_ratio}</td><td>{result.max_active_requests}</td>"
+            f"<td>{result.gate['prepare_blocked_seconds']:.3f}</td></tr>"
+        )
+    return f'<table>{head}{"".join(rows)}</table>'
+
+
+def write_html_report(results, cfg: SimConfig, path, subtitle=None):
+    """Write a self-contained HTML timing report for the simulated modes.
+
+    `subtitle` overrides the default config line, for reports whose results
+    were produced with per-mode configs rather than a single shared one.
+    """
+    mode_entries = [(result.mode, f"var(--series-{i + 1})") for i, result in enumerate(results)]
+    stage_entries = [(label, f"var(--ramp-{j + 1})") for j, (_, label) in enumerate(_STAGES)]
+    tiles = [
+        ("rollouts / mode", f"{cfg.num_batches * cfg.num_groups * cfg.rollouts_per_group}"),
+        ("generation latency", f"{cfg.latency_lo * 1000:g}–{cfg.latency_hi * 1000:g} ms uniform"),
+        (
+            "gate capacity",
+            (
+                f"{cfg.parallel_generation_tasks} / submission unit"
+                if cfg.generation_lag is None
+                else f"lag {cfg.generation_lag} (production formula)"
+            ),
+        ),
+        ("streaming", "on" if cfg.streaming else "off"),
+    ]
+    tile_html = "".join(
+        f'<div class="tile"><div class="tile-label">{label}</div><div class="tile-value">{value}</div></div>'
+        for label, value in tiles
+    )
+    pause_kind = "colocated trainer pause (engine frozen)" if cfg.colocated else "trainer pause"
+    train_desc = f", {cfg.train_time:g}s {pause_kind} per batch" if cfg.train_time else ""
+    config_line = subtitle or (
+        f"{cfg.num_batches} batch(es) × {cfg.num_groups} groups × {cfg.rollouts_per_group} rollouts per mode, "
+        f"seed {cfg.seed}{train_desc} (all modes consume the identical latency sequence)"
+    )
+    utilization_card = ""
+    if any(result.engine_utilization is not None for result in results):
+        utilization_card = f"""
+<div class="card">
+  <h2>Engine utilization (busy slot-time / total slot-time)</h2>
+  <p class="note">An idle slot is the deck's "white gap": a decode pass running below full batch size.</p>
+  {_svg_utilization_chart(results)}
+</div>
+"""
+    inference_steps_card = ""
+    if any(result.batch_inference_steps for result in results):
+        inference_steps_card = f"""
+<div class="card">
+  <h2>Inference steps per training step (× batch max seq len)</h2>
+  <p class="note">Engine decode steps the trainer waited through for each batch, relative to that batch's
+     longest rollout. 1.0× is the fully-parallel bound — the trainer waited only for the longest sequence.
+     Higher means oversubscribed or serialized decoding; near 0× means the batch was consumed from readahead.</p>
+  {_legend(mode_entries)}
+  {_svg_inference_steps_chart(results)}
+</div>
+"""
+    readahead_card = ""
+    if any(result.readahead_batches for result in results):
+        readahead_card = f"""
+<div class="card">
+  <h2>Mean rollout lag per iteration (policy versions)</h2>
+  <p class="note">Average age of the rollouts each batch trained on: policy version at training minus the
+     version stamped when each rollout was generated — the simulator twin of W&amp;B's mean_policy_staleness.
+     Flat = the lag knob holds; climbing = generation decoupled from training.</p>
+  {_legend(mode_entries)}
+  {_svg_lag_chart(results)}
+</div>
+
+<div class="card">
+  <h2>Readahead when each batch ships (staleness proxy)</h2>
+  <p class="note">Batches of rollouts already prepared beyond what the trainer has consumed — the leading
+     indicator of the lag chart above (today's readahead is a future batch's lag).</p>
+  {_legend(mode_entries)}
+  {_svg_readahead_chart(results)}
+</div>
+"""
+    document = f"""<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>get_grouped_rollouts granularity timings</title>
+<style>
+  :root {{
+    --page: #f9f9f7; --surface-1: #fcfcfb; --ink: #0b0b0b; --ink-2: #52514e;
+    --ink-muted: #898781; --grid: #e1e0d9; --axis: #c3c2b7; --border: rgba(11,11,11,0.10);
+    --series-1: #2a78d6; --series-2: #1baf7a; --series-3: #eda100; --series-4: #008300; --series-5: #4a3aa7;
+    --ramp-1: #86b6ef; --ramp-2: #5598e7; --ramp-3: #2a78d6; --ramp-4: #184f95; --seq: #2a78d6;
+  }}
+  @media (prefers-color-scheme: dark) {{
+    :root {{
+      --page: #0d0d0d; --surface-1: #1a1a19; --ink: #ffffff; --ink-2: #c3c2b7;
+      --ink-muted: #898781; --grid: #2c2c2a; --axis: #383835; --border: rgba(255,255,255,0.10);
+      --series-1: #3987e5; --series-2: #199e70; --series-3: #c98500; --series-4: #008300; --series-5: #9085e9;
+      --ramp-1: #6da7ec; --ramp-2: #3987e5; --ramp-3: #256abf; --ramp-4: #184f95; --seq: #3987e5;
+    }}
+  }}
+  body {{ background: var(--page); color: var(--ink); margin: 24px auto; max-width: 860px;
+         font: 14px/1.45 system-ui, -apple-system, "Segoe UI", sans-serif; padding: 0 16px; }}
+  h1 {{ font-size: 20px; margin: 0 0 4px; }}
+  h2 {{ font-size: 15px; margin: 0 0 2px; }}
+  .sub {{ color: var(--ink-2); margin: 0 0 12px; }}
+  .note {{ color: var(--ink-2); font-size: 12.5px; margin: 2px 0 10px; }}
+  .card {{ background: var(--surface-1); border: 1px solid var(--border); border-radius: 10px;
+           padding: 16px 18px; margin: 16px 0; }}
+  .tiles {{ display: flex; gap: 12px; flex-wrap: wrap; margin: 16px 0; }}
+  .tile {{ background: var(--surface-1); border: 1px solid var(--border); border-radius: 10px;
+           padding: 10px 16px; flex: 1 1 140px; }}
+  .tile-label {{ color: var(--ink-2); font-size: 12px; }}
+  .tile-value {{ font-size: 20px; font-weight: 600; margin-top: 2px; }}
+  svg {{ width: 100%; height: auto; display: block; }}
+  svg text {{ font: 11px system-ui, -apple-system, "Segoe UI", sans-serif; fill: var(--ink-muted); }}
+  svg .label {{ fill: var(--ink-2); font-weight: 500; }}
+  svg .value {{ fill: var(--ink-2); font-variant-numeric: tabular-nums; }}
+  svg .tick {{ font-variant-numeric: tabular-nums; }}
+  svg .grid {{ stroke: var(--grid); stroke-width: 1; }}
+  svg .axis {{ stroke: var(--axis); stroke-width: 1; }}
+  .legend {{ display: flex; gap: 14px; flex-wrap: wrap; margin: 6px 0 10px; color: var(--ink-2);
+             font-size: 12.5px; }}
+  .chip {{ display: inline-flex; align-items: center; gap: 6px; }}
+  .swatch {{ width: 10px; height: 10px; border-radius: 3px; display: inline-block; }}
+  table {{ border-collapse: collapse; width: 100%; font-size: 13px; }}
+  th, td {{ text-align: right; padding: 6px 10px; border-bottom: 1px solid var(--grid);
+            font-variant-numeric: tabular-nums; }}
+  th {{ color: var(--ink-2); font-weight: 600; }}
+  th:first-child, td:first-child {{ text-align: left; }}
+  td .swatch {{ margin-right: 6px; }}
+  #tip {{ position: fixed; display: none; background: var(--ink); color: var(--page);
+          padding: 5px 9px; border-radius: 6px; font-size: 12px; pointer-events: none;
+          z-index: 10; max-width: 340px; }}
+</style></head><body>
+<h1>get_grouped_rollouts granularity timings</h1>
+<p class="sub">{html.escape(config_line)}</p>
+<div class="tiles">{tile_html}</div>
+
+<div class="card">
+  <h2>Total wall time per mode</h2>
+  <p class="note">Same workload and latency draws per mode; only the submission/consumption granularity changes.
+     Gate capacity is measured in units of the submission granularity, so B submission admits the most concurrent work.</p>
+  {_svg_wall_time_chart(results)}
+</div>
+
+<div class="card">
+  <h2>Batches completed over time</h2>
+  <p class="note">Each dot is a training batch becoming available to the trainer. Steeper is better;
+     a long flat start followed by a burst means the mode front-loads generation across future batches.</p>
+  {_legend(mode_entries)}
+  {_svg_batch_timeline(results)}
+</div>
+{utilization_card}{inference_steps_card}{readahead_card}
+<div class="card">
+  <h2>Per-rollout wall time (prepare → yield), cumulative distribution</h2>
+  <p class="note">Further left is faster. Dots mark p50 / p90 / p99 — hover them for values.</p>
+  {_legend(mode_entries)}
+  {_svg_ecdf_chart(results)}
+</div>
+
+<div class="card">
+  <h2>Where a rollout spends its time (mean per stage)</h2>
+  <p class="note">Stages in pipeline order. Queue dwells are typically sub-millisecond — segments thinner than
+     a pixel are omitted from the drawing but included in the hover tooltip and table.</p>
+  {_legend(stage_entries)}
+  {_svg_stage_chart(results)}
+</div>
+
+<div class="card">
+  <h2>Sampled generation latency ({html.escape(results[0].mode)}, n={len(results[0].sampled_latencies)})</h2>
+  <p class="note">Sanity check on the mocked inference backend: draws should be uniform between the configured bounds.</p>
+  {_svg_latency_histogram(results[0], cfg)}
+</div>
+
+<div class="card">
+  <h2>Summary</h2>
+  {_summary_table(results)}
+</div>
+
+<div id="tip"></div>
+<script>
+  const tip = document.getElementById('tip');
+  for (const el of document.querySelectorAll('[data-tip]')) {{
+    el.addEventListener('pointerenter', () => {{ tip.textContent = el.dataset.tip; tip.style.display = 'block'; }});
+    el.addEventListener('pointermove', (e) => {{
+      tip.style.left = Math.min(e.clientX + 12, window.innerWidth - 360) + 'px';
+      tip.style.top = (e.clientY + 14) + 'px';
+    }});
+    el.addEventListener('pointerleave', () => {{ tip.style.display = 'none'; }});
+  }}
+</script>
+</body></html>
+"""
+    Path(path).write_text(document)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument("--num-groups", type=int, default=8, help="groups per batch")
+    parser.add_argument(
+        "--num-batches", type=int, default=4, help="batches to consume (streaming mode only)"
+    )
+    parser.add_argument("--rollouts-per-group", type=int, default=4)
+    parser.add_argument(
+        "--parallel-generation-tasks",
+        type=int,
+        default=4,
+        help=(
+            "gate capacity, measured in units of the submission granularity: the same value "
+            "allows N batches (B), N groups (G), or N rollouts (R) in flight at once"
+        ),
+    )
+    parser.add_argument(
+        "--latency-lo", type=float, default=0.01, help="uniform latency lower bound (s)"
+    )
+    parser.add_argument(
+        "--latency-hi", type=float, default=0.05, help="uniform latency upper bound (s)"
+    )
+    parser.add_argument("--seed", type=int, default=0, help="RNG seed, shared across modes")
+    parser.add_argument(
+        "--no-streaming",
+        action="store_true",
+        help="use non-streaming requests (single batch; --num-batches is ignored)",
+    )
+    parser.add_argument(
+        "--modes",
+        default=",".join(f"{sub}/{cons}" for sub, cons in MODES),
+        help="comma-separated submission/consumption pairs to run",
+    )
+    parser.add_argument(
+        "--max-readahead-batches",
+        type=int,
+        default=None,
+        metavar="W",
+        help=(
+            "prototype lag bound: prepare may not run more than W batches ahead of "
+            "consumption (unset = current production behavior)"
+        ),
+    )
+    parser.add_argument(
+        "--engine-slots",
+        type=int,
+        default=None,
+        metavar="N",
+        help=(
+            "fixed engine slot count (continuous-batching rows); submissions beyond N queue. "
+            "Unset = unlimited slots, where slot-idle gaps cannot exist and R submission "
+            "shows only its costs"
+        ),
+    )
+    parser.add_argument(
+        "--train-time",
+        type=float,
+        default=0.0,
+        metavar="SECONDS",
+        help=(
+            "simulated trainer pause after each completed batch; generation keeps running "
+            "during the pause to the extent the submission granularity's gate allows"
+        ),
+    )
+    parser.add_argument(
+        "--colocated",
+        action="store_true",
+        help=(
+            "trainer and engine share the GPUs: the engine pauses during each "
+            "--train-time step and in-flight decodes freeze until the step ends "
+            "(default: disaggregated, generation keeps running through the pause)"
+        ),
+    )
+    parser.add_argument(
+        "--generation-lag",
+        type=int,
+        default=None,
+        metavar="LAG",
+        help=(
+            "derive gate capacity per mode from the production formula "
+            "(get_rl_parallel_generation_tasks with --rl-generation-lag LAG) instead of "
+            "--parallel-generation-tasks; lag 0 admits one training step of in-flight work"
+        ),
+    )
+    parser.add_argument(
+        "--seconds-per-token",
+        type=float,
+        default=0.001,
+        metavar="S",
+        help=(
+            "token clock: a rollout whose mocked latency is D seconds counts as D/S "
+            "generated tokens; engine-active time between batch completions / S is the "
+            "per-training-step inference step count"
+        ),
+    )
+    parser.add_argument(
+        "--envs",
+        default=None,
+        metavar="NAME:LO:HI[:WEIGHT],...",
+        help=(
+            "run a multi-env simulation under a real WeightedMultiTask: comma-separated "
+            "env specs, each name:latency_lo:latency_hi[:weight] "
+            "(e.g. fast:0.01:0.03:1,slow:0.05:0.10:1). All envs share one engine."
+        ),
+    )
+    parser.add_argument(
+        "--rebalance",
+        action="store_true",
+        help=(
+            "with --envs: also run each mode with dynamic pgt rebalancing "
+            "(--rl-inference-rebalancing) and print an A/B comparison against the static split"
+        ),
+    )
+    parser.add_argument(
+        "--rebalance-interval",
+        type=float,
+        default=0.0,
+        metavar="SECONDS",
+        help="min seconds between rebalance checks (production default is 30s; 0 suits sim scale)",
+    )
+    parser.add_argument(
+        "--rebalance-min-samples",
+        type=int,
+        default=4,
+        metavar="N",
+        help="per-env engine_dwell samples required before its EMA is trusted",
+    )
+    parser.add_argument(
+        "--rebalance-max-step",
+        type=float,
+        default=0.25,
+        metavar="FRACTION",
+        help="max per-update allocation change as a fraction of the current value",
+    )
+    parser.add_argument(
+        "--html",
+        default=None,
+        metavar="PATH",
+        help="also write a self-contained HTML report with charts to PATH",
+    )
+    return parser.parse_args()
+
+
+def parse_envs(spec: str) -> list[EnvSpec]:
+    envs = []
+    for entry in spec.split(","):
+        parts = entry.strip().split(":")
+        if len(parts) not in (3, 4):
+            raise SystemExit(f"invalid env spec {entry!r}; expected name:lo:hi[:weight]")
+        envs.append(
+            EnvSpec(
+                name=parts[0],
+                lo=float(parts[1]),
+                hi=float(parts[2]),
+                weight=float(parts[3]) if len(parts) == 4 else 1.0,
+            )
+        )
+    if len(envs) < 2:
+        raise SystemExit("--envs needs at least two environments")
+    return envs
+
+
+def main():
+    args = parse_args()
+
+    valid_modes = {f"{sub}/{cons}" for sub, cons in MODES}
+    modes = []
+    for mode in args.modes.split(","):
+        mode = mode.strip().upper()
+        if mode not in valid_modes:
+            raise SystemExit(f"invalid mode {mode!r}; valid modes: {sorted(valid_modes)}")
+        modes.append(tuple(mode.split("/")))
+
+    cfg = SimConfig(
+        num_groups=args.num_groups,
+        num_batches=1 if args.no_streaming else args.num_batches,
+        rollouts_per_group=args.rollouts_per_group,
+        parallel_generation_tasks=args.parallel_generation_tasks,
+        latency_lo=args.latency_lo,
+        latency_hi=args.latency_hi,
+        seed=args.seed,
+        streaming=not args.no_streaming,
+        train_time=args.train_time,
+        colocated=args.colocated,
+        engine_slots=args.engine_slots,
+        generation_lag=args.generation_lag,
+        max_readahead_batches=args.max_readahead_batches,
+        seconds_per_token=args.seconds_per_token,
+    )
+    if args.no_streaming and args.num_batches != 1:
+        print("note: --no-streaming generates a single batch; --num-batches is ignored")
+    if args.colocated and not args.train_time:
+        print("note: --colocated has no effect without --train-time")
+    total_rollouts = cfg.num_batches * cfg.num_groups * cfg.rollouts_per_group
+    if cfg.generation_lag is None:
+        capacity_desc = f"parallel_generation_tasks={cfg.parallel_generation_tasks}"
+    else:
+        per_mode = ", ".join(f"{sub}:{cfg.gate_capacity(sub)}" for sub in ("B", "G", "R"))
+        capacity_desc = f"generation_lag={cfg.generation_lag} (gate capacity {per_mode})"
+    print(
+        f"simulating {cfg.num_batches} batch(es) x {cfg.num_groups} groups x "
+        f"{cfg.rollouts_per_group} rollouts ({total_rollouts} rollouts/mode), "
+        f"latency ~ U({cfg.latency_lo}s, {cfg.latency_hi}s) = "
+        f"{cfg.latency_lo / cfg.seconds_per_token:g}-"
+        f"{cfg.latency_hi / cfg.seconds_per_token:g} tokens, "
+        f"{capacity_desc}, streaming={cfg.streaming}, "
+        f"train_time={cfg.train_time}s, colocated={cfg.colocated}, seed={cfg.seed}"
+    )
+
+    if args.envs:
+        envs = parse_envs(args.envs)
+        rebalance_cfg = PgtRebalanceConfig(
+            min_interval_s=args.rebalance_interval,
+            min_samples_per_env=args.rebalance_min_samples,
+            max_step_fraction=args.rebalance_max_step,
+        )
+        for submission, consumption in modes:
+            # One event loop per run so runs are fully isolated.
+            static = asyncio.run(run_multi_env_mode(submission, consumption, cfg, envs))
+            print_multi_env_report(static)
+            if args.rebalance:
+                rebalanced = asyncio.run(
+                    run_multi_env_mode(submission, consumption, cfg, envs, rebalance_cfg)
+                )
+                print_multi_env_report(rebalanced)
+                print(
+                    f"  A/B wall time ({static.mode}): static {static.total_wall:.3f}s vs "
+                    f"rebalanced {rebalanced.total_wall:.3f}s "
+                    f"({static.total_wall / rebalanced.total_wall:.2f}x speedup)"
+                )
+        return
+
+    results = []
+    for submission, consumption in modes:
+        # One event loop per mode so modes are fully isolated.
+        result = asyncio.run(run_mode(submission, consumption, cfg))
+        print_mode_report(result)
+        results.append(result)
+    print_summary(results)
+    if args.html:
+        write_html_report(results, cfg, args.html)
+        print(f"\nhtml report written to {args.html}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit_tests/rl/test_grouped_rollouts.py
+++ b/tests/unit_tests/rl/test_grouped_rollouts.py
@@ -19,7 +19,6 @@ from megatron.rl.agent.api import (
 from megatron.rl.agent.reward_only_agent import RewardOnlyAgent
 from megatron.rl.agent.weighted_multi_task import AgentConfig, WeightedMultiTask
 from megatron.rl.inference import InferenceResponse, LLMChatMessage, ReturnsRaw
-from megatron.rl.rollout_granularity import RELEASE_STATE_BY_SUBMISSION
 
 
 class MockInferenceInterface(ReturnsRaw):
@@ -112,24 +111,19 @@ async def _flush(rounds: int = 50):
 
 
 class TestSubmissionGate:
-    def test_release_state_map(self):
-        assert RELEASE_STATE_BY_SUBMISSION == {"R": "inferred", "G": "consumed", "B": "consumed"}
-
     @pytest.mark.asyncio
     @pytest.mark.parametrize("submission", ["R", "G", "B"])
-    async def test_release_requires_matching_state_and_granularity(self, submission):
+    async def test_release_requires_matching_granularity(self, submission):
         gate = _SubmissionGate(capacity=1, submission=submission)
         await gate.acquire_for(submission)
         assert gate.held == 1
-        release_on = RELEASE_STATE_BY_SUBMISSION[submission]
-        for state in ("inferred", "assembled", "consumed"):
-            for granularity in ("R", "G", "B"):
-                if state == release_on and granularity == submission:
-                    continue
-                gate.release_after(state, granularity)
+        for granularity in ("R", "G", "B"):
+            if granularity == submission:
+                continue
+            gate.release_for(granularity)
         assert gate.held == 1
         assert gate.release_calls == 0
-        gate.release_after(release_on, submission)
+        gate.release_for(submission)
         assert gate.held == 0
         assert gate.release_calls == 1
 

--- a/tests/unit_tests/rl/test_grouped_rollouts.py
+++ b/tests/unit_tests/rl/test_grouped_rollouts.py
@@ -14,10 +14,12 @@ from megatron.rl.agent.api import (
     Rollout,
     RolloutGenerator,
     RolloutRequest,
+    _SubmissionGate,
 )
 from megatron.rl.agent.reward_only_agent import RewardOnlyAgent
 from megatron.rl.agent.weighted_multi_task import AgentConfig, WeightedMultiTask
 from megatron.rl.inference import InferenceResponse, LLMChatMessage, ReturnsRaw
+from megatron.rl.rollout_granularity import RELEASE_STATE_BY_SUBMISSION
 
 
 class MockInferenceInterface(ReturnsRaw):
@@ -101,6 +103,106 @@ class CountingRewardAgent(RewardOnlyAgent):
 
     async def get_reward(self, response, golden, finish_reason):
         return float(int(response.removeprefix("t")) == golden["idx"])
+
+
+async def _flush(rounds: int = 50):
+    """Let pipeline stage tasks settle (mock inference is zero-delay)."""
+    for _ in range(rounds):
+        await asyncio.sleep(0)
+
+
+class TestSubmissionGate:
+    def test_release_state_map(self):
+        assert RELEASE_STATE_BY_SUBMISSION == {"R": "inferred", "G": "consumed", "B": "consumed"}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("submission", ["R", "G", "B"])
+    async def test_release_requires_matching_state_and_granularity(self, submission):
+        gate = _SubmissionGate(capacity=1, submission=submission)
+        await gate.acquire_for(submission)
+        assert gate.held == 1
+        release_on = RELEASE_STATE_BY_SUBMISSION[submission]
+        for state in ("inferred", "assembled", "consumed"):
+            for granularity in ("R", "G", "B"):
+                if state == release_on and granularity == submission:
+                    continue
+                gate.release_after(state, granularity)
+        assert gate.held == 1
+        assert gate.release_calls == 0
+        gate.release_after(release_on, submission)
+        assert gate.held == 0
+        assert gate.release_calls == 1
+
+
+class TestConsumptionRelease:
+    """G-submission gate slots must recycle on trainer consumption, not assembly."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "consumption_granularity, num_groups",
+        [
+            pytest.param("G", 1, id="group_consumption"),
+            pytest.param("B", 2, id="batch_consumption"),
+        ],
+    )
+    async def test_group_submission_stalls_until_consumption(
+        self, consumption_granularity, num_groups
+    ):
+        capacity = 4
+        gen = MockGenerator(parallel_generation_tasks=capacity)
+        request = GroupedRolloutRequest(
+            num_groups=num_groups,
+            rollouts_per_group=1,
+            inference_interface=MockInferenceInterface(),
+            streaming=True,
+            submission_granularity="G",
+            consumption_granularity=consumption_granularity,
+        )
+        it = gen.get_grouped_rollouts(request)
+        try:
+            for pulled in range(1, capacity + 3):
+                # wait_for turns the deadlock failure mode (a slot never freed)
+                # into a test failure instead of a hang.
+                await asyncio.wait_for(anext(it), timeout=10)
+                await _flush()
+                # Each yield frees exactly one group slot on the consumer's next
+                # resume, so submission tracks consumption with a one-slot skew
+                # (the release for the latest pull hasn't fired yet). On
+                # assembly-release semantics this runs away unbounded; if no
+                # consume-site release existed, the loop would deadlock at
+                # `pulled == capacity + 1`.
+                assert gen.prepare_group_rollout_calls == capacity + pulled - 1
+        finally:
+            await it.aclose()
+
+    @pytest.mark.asyncio
+    async def test_batch_submission_releases_once_per_batch(self):
+        gen = MockGenerator(parallel_generation_tasks=1)
+        request = GroupedRolloutRequest(
+            num_groups=2,
+            rollouts_per_group=1,
+            inference_interface=MockInferenceInterface(),
+            streaming=True,
+            submission_granularity="B",
+            consumption_granularity="B",
+        )
+        it = gen.get_grouped_rollouts(request)
+        try:
+            await asyncio.wait_for(anext(it), timeout=10)
+            await asyncio.wait_for(anext(it), timeout=10)
+            await _flush()
+            gate = gen._active_pipeline.gate
+            # Batch 0 fully yielded but the consumer hasn't come back yet: its
+            # single batch slot is still held (a per-group release here would
+            # show release_calls == 2 and prepared == 4).
+            assert gate.release_calls == 0
+            assert gen.prepare_group_rollout_calls == 2
+            await asyncio.wait_for(anext(it), timeout=10)
+            await _flush()
+            assert gate.release_calls == 1
+            assert gen.prepare_group_rollout_calls == 4
+        finally:
+            await it.aclose()
 
 
 class TestRewardRollouts:

--- a/tests/unit_tests/rl/test_grouped_rollouts.py
+++ b/tests/unit_tests/rl/test_grouped_rollouts.py
@@ -17,7 +17,12 @@ from megatron.rl.agent.api import (
     _SubmissionGate,
 )
 from megatron.rl.agent.reward_only_agent import RewardOnlyAgent
-from megatron.rl.agent.weighted_multi_task import AgentConfig, WeightedMultiTask
+from megatron.rl.agent.weighted_multi_task import (
+    AgentConfig,
+    PgtRebalanceConfig,
+    WeightedMultiTask,
+    _PgtRebalancer,
+)
 from megatron.rl.inference import InferenceResponse, LLMChatMessage, ReturnsRaw
 
 
@@ -126,6 +131,40 @@ class TestSubmissionGate:
         gate.release_for(submission)
         assert gate.held == 0
         assert gate.release_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_grow_wakes_blocked_acquirer(self):
+        gate = _SubmissionGate(capacity=1, submission="G")
+        await gate.acquire_for("G")
+        blocked = asyncio.create_task(gate.acquire_for("G"))
+        await _flush()
+        assert not blocked.done()
+        gate.set_capacity(2)
+        await asyncio.wait_for(blocked, timeout=5)
+        assert gate.held == 2
+
+    @pytest.mark.asyncio
+    async def test_shrink_below_held_never_revokes(self):
+        gate = _SubmissionGate(capacity=4, submission="G")
+        for _ in range(3):
+            await gate.acquire_for("G")
+        gate.set_capacity(2)
+        # In-flight slots are untouched; only new acquires block.
+        assert gate.held == 3
+        blocked = asyncio.create_task(gate.acquire_for("G"))
+        await _flush()
+        assert not blocked.done()
+        gate.release_for("G")  # held 2, still at the new capacity
+        await _flush()
+        assert not blocked.done()
+        gate.release_for("G")  # held 1 < 2: the waiter proceeds
+        await asyncio.wait_for(blocked, timeout=5)
+        assert gate.held == 2
+
+    def test_set_capacity_clamps_to_one(self):
+        gate = _SubmissionGate(capacity=4, submission="G")
+        gate.set_capacity(0)
+        assert gate.capacity == 1
 
 
 class TestConsumptionRelease:
@@ -444,3 +483,146 @@ class TestGroupedRollouts:
             assert min(agent_groups) == 0
             assert all(slots == 0 for slots in agent_slots)
             assert np.gcd.reduce(agent_slots) == 0
+
+
+class TestPgtAllocation:
+    def test_slower_env_gets_proportionally_more(self):
+        # Equal weights, 1.2 min vs 1.0 min: the slower env gets 1.2x slots.
+        new = WeightedMultiTask._compute_pgt_allocation(
+            [0.5, 0.5], [1.2, 1.0], 22, [11, 11], min_pgts=[1, 1], max_step_fraction=0.25
+        )
+        assert new == [12, 10]
+
+    def test_weight_and_duration_combine(self):
+        # weight 3:1, equal durations: allocation follows the weights.
+        new = WeightedMultiTask._compute_pgt_allocation(
+            [0.75, 0.25], [1.0, 1.0], 8, [6, 2], min_pgts=[1, 1], max_step_fraction=1.0
+        )
+        assert new == [6, 2]
+
+    @pytest.mark.parametrize("total", [7, 8, 23])
+    def test_sum_invariant_under_rounding(self, total):
+        current = [total // 2, total - total // 2]
+        new = WeightedMultiTask._compute_pgt_allocation(
+            [0.5, 0.5], [1.3, 0.7], total, current, min_pgts=[1, 1], max_step_fraction=1.0
+        )
+        assert sum(new) == total
+
+    def test_all_unknown_durations_keep_current(self):
+        assert WeightedMultiTask._compute_pgt_allocation(
+            [0.5, 0.5], [None, None], 8, [5, 3], min_pgts=[1, 1], max_step_fraction=1.0
+        ) == [5, 3]
+
+    def test_unknown_duration_falls_back_to_weighted_mean(self):
+        # An env with no estimate is treated as average-speed. Envs 0 and 1
+        # are known (3.0 vs 1.0 → mean 2.0); env 2 is unknown, so it lands
+        # between them instead of defaulting to fastest or slowest.
+        new = WeightedMultiTask._compute_pgt_allocation(
+            [1 / 3, 1 / 3, 1 / 3],
+            [3.0, 1.0, None],
+            12,
+            [4, 4, 4],
+            min_pgts=[1, 1, 1],
+            max_step_fraction=1.0,
+        )
+        assert new[0] > new[2] > new[1]
+        assert sum(new) == 12
+
+    def test_min_pgts_respected(self):
+        new = WeightedMultiTask._compute_pgt_allocation(
+            [0.5, 0.5], [100.0, 0.01], 8, [4, 4], min_pgts=[1, 3], max_step_fraction=1.0
+        )
+        assert new[1] >= 3
+        assert sum(new) == 8
+
+    def test_max_step_limits_movement(self):
+        # Extreme imbalance, but each update moves at most 25% of current.
+        new = WeightedMultiTask._compute_pgt_allocation(
+            [0.5, 0.5], [10.0, 0.1], 20, [10, 10], min_pgts=[1, 1], max_step_fraction=0.25
+        )
+        assert new == [12, 8]
+
+
+class _FakeGate:
+    def __init__(self):
+        self.capacity_history = []
+
+    def set_capacity(self, capacity):
+        self.capacity_history.append(capacity)
+
+
+class _FakePipeline:
+    def __init__(self, ema, samples):
+        self.engine_dwell_ema = ema
+        self.engine_dwell_sample_count = samples
+        self.gate = _FakeGate()
+
+
+class _FakeAgent:
+    def __init__(self, pipeline, pgt):
+        self._active_pipeline = pipeline
+        self.parallel_generation_tasks = pgt
+
+
+class TestPgtRebalancer:
+    def _make(self, emas, samples, pgts, interval=0.0, min_samples=1):
+        agents = [
+            _FakeAgent(_FakePipeline(ema, n), pgt) for ema, n, pgt in zip(emas, samples, pgts)
+        ]
+        rebalancer = _PgtRebalancer(
+            PgtRebalanceConfig(
+                min_interval_s=interval, min_samples_per_env=min_samples, max_step_fraction=1.0
+            ),
+            agent_indices=list(range(len(agents))),
+            weights=[1.0 / len(agents)] * len(agents),
+            current_pgts=list(pgts),
+            min_pgts=[1] * len(agents),
+        )
+        return agents, rebalancer
+
+    def test_shifts_capacity_toward_slow_env(self):
+        agents, rebalancer = self._make([3.0, 1.0], [10, 10], [8, 8])
+        event = rebalancer.maybe_rebalance(agents)
+        assert event is not None
+        assert event["new"] == [12, 4]
+        assert sum(event["new"]) == 16
+        assert agents[0]._active_pipeline.gate.capacity_history == [12]
+        assert agents[1]._active_pipeline.gate.capacity_history == [4]
+        assert [a.parallel_generation_tasks for a in agents] == [12, 4]
+
+    def test_interval_throttles_checks(self):
+        agents, rebalancer = self._make([3.0, 1.0], [10, 10], [8, 8], interval=1000.0)
+        assert rebalancer.maybe_rebalance(agents) is not None
+        # EMAs still differ, but the next check is inside the interval.
+        assert rebalancer.maybe_rebalance(agents) is None
+
+    def test_insufficient_samples_is_noop(self):
+        agents, rebalancer = self._make([3.0, 1.0], [0, 0], [8, 8], min_samples=5)
+        assert rebalancer.maybe_rebalance(agents) is None
+        assert [a.parallel_generation_tasks for a in agents] == [8, 8]
+
+
+class TestEngineDwellEma:
+    @pytest.mark.asyncio
+    async def test_ema_tracks_inferred_rollouts(self):
+        gen = MockGenerator(parallel_generation_tasks=2)
+        gen.max_parallel_generation_tasks = 5
+        request = GroupedRolloutRequest(
+            num_groups=1,
+            rollouts_per_group=1,
+            inference_interface=MockInferenceInterface(),
+            streaming=True,
+            submission_granularity="R",
+            consumption_granularity="B",
+        )
+        it = gen.get_grouped_rollouts(request)
+        try:
+            for _ in range(3):
+                await asyncio.wait_for(anext(it), timeout=10)
+            pipeline = gen._active_pipeline
+            # Workers are sized for the rebalancing ceiling, not the split.
+            assert pipeline.num_infer_workers == 5
+            assert pipeline.engine_dwell_ema is not None
+            assert pipeline.engine_dwell_sample_count >= 3
+        finally:
+            await it.aclose()

--- a/tests/unit_tests/rl/test_simulate_grouped_rollouts.py
+++ b/tests/unit_tests/rl/test_simulate_grouped_rollouts.py
@@ -1,0 +1,212 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Smoke test keeping simulate_grouped_rollouts.py in sync with the pipeline API."""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from megatron.rl.agent.weighted_multi_task import PgtRebalanceConfig
+from tests.unit_tests.rl.simulate_grouped_rollouts import (
+    MODES,
+    EnvSpec,
+    SimConfig,
+    UniformLatencyInterface,
+    run_mode,
+    run_multi_env_mode,
+    write_html_report,
+)
+
+TINY_CFG = SimConfig(
+    num_groups=2,
+    num_batches=2,
+    rollouts_per_group=2,
+    parallel_generation_tasks=2,
+    latency_lo=0.001,
+    latency_hi=0.002,
+    seed=0,
+)
+
+
+class TestSimulateGroupedRollouts:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("submission, consumption", MODES)
+    async def test_run_mode_smoke(self, submission, consumption):
+        result = await run_mode(submission, consumption, TINY_CFG)
+
+        expected_groups = TINY_CFG.num_batches * TINY_CFG.num_groups
+        assert result.num_groups == expected_groups
+        assert result.num_rollouts == expected_groups * TINY_CFG.rollouts_per_group
+        assert len(result.rollout_walls) == result.num_rollouts
+        assert result.total_wall > 0
+        assert all(wall > 0 for wall in result.rollout_walls)
+        assert len(result.sampled_latencies) >= result.num_rollouts
+        assert result.counters["yielded"] >= result.num_groups
+        assert (
+            result.counters["prepared"]
+            >= result.counters["inferred"]
+            >= result.counters["assembled"] * TINY_CFG.rollouts_per_group
+        )
+        assert len(result.batch_done_at) == TINY_CFG.num_batches
+        assert [t for _, t in result.batch_done_at] == sorted(t for _, t in result.batch_done_at)
+        assert len(result.batch_inference_steps) == TINY_CFG.num_batches
+        assert len(result.batch_max_seq_len) == TINY_CFG.num_batches
+        lo_tokens = TINY_CFG.latency_lo / TINY_CFG.seconds_per_token
+        hi_tokens = TINY_CFG.latency_hi / TINY_CFG.seconds_per_token
+        assert all(lo_tokens <= max_len <= hi_tokens for max_len in result.batch_max_seq_len)
+        # The first batch's longest rollout ran entirely inside the first
+        # engine-active window, so its inference steps bound its max seq len.
+        assert result.batch_inference_steps[0] >= result.batch_max_seq_len[0] * 0.99
+        for name in ("infer_queue_dwell", "engine_dwell", "assemble_queue_dwell"):
+            assert result.dwell[name], f"{name} collected no samples"
+        if submission == "R":
+            assert result.max_active_requests <= TINY_CFG.parallel_generation_tasks
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "submission, expected_capacity",
+        [("B", 1), ("G", 2), ("R", 4)],  # lag 0: 1 batch / num_groups / num_groups*rollouts
+    )
+    async def test_generation_lag_capacity(self, submission, expected_capacity):
+        cfg = SimConfig(
+            num_groups=2,
+            num_batches=2,
+            rollouts_per_group=2,
+            latency_lo=0.001,
+            latency_hi=0.002,
+            generation_lag=0,
+        )
+        result = await run_mode(submission, "B", cfg)
+        assert result.gate["capacity"] == expected_capacity
+        assert result.num_groups == cfg.num_batches * cfg.num_groups
+
+    @pytest.mark.asyncio
+    async def test_max_readahead_bounds_lag(self):
+        cfg = SimConfig(
+            num_groups=2,
+            num_batches=6,
+            rollouts_per_group=2,
+            latency_lo=0.001,
+            latency_hi=0.002,
+            generation_lag=0,
+            max_readahead_batches=2,
+        )
+        result = await run_mode("R", "G", cfg)
+        assert result.num_groups == cfg.num_batches * cfg.num_groups
+        assert max(result.readahead_batches) <= 2.0 + 1e-9
+        assert max(result.batch_mean_lag) <= 2.0 + 1e-9
+
+    @pytest.mark.asyncio
+    async def test_pause_freezes_inflight_decodes(self):
+        iface = UniformLatencyInterface(lo=0.02, hi=0.02, seed=0)
+        request = SimpleNamespace(prompt=[SimpleNamespace(content="p0")])
+        task = asyncio.create_task(iface.base_generate(request))
+        await asyncio.sleep(0)  # let the decode reach its timed wait
+        iface.pause()
+        # Well past the 0.02s decode latency: a paused decode cannot finish
+        # no matter how much wall time passes.
+        await asyncio.sleep(0.1)
+        assert not task.done(), "decode progressed while the engine was paused"
+        iface.resume()
+        response = await asyncio.wait_for(task, timeout=5)
+        assert response.raw_text == "p0"
+        assert iface.paused_seconds >= 0.1
+        # The frozen window is excluded from the decode-step clock.
+        assert iface.engine_active_time() < 0.1
+
+    @pytest.mark.asyncio
+    async def test_colocated_train_pause(self):
+        cfg = SimConfig(
+            num_groups=2,
+            num_batches=3,
+            rollouts_per_group=2,
+            parallel_generation_tasks=2,
+            latency_lo=0.001,
+            latency_hi=0.002,
+            train_time=0.05,
+            colocated=True,
+        )
+        result = await run_mode("G", "B", cfg)
+        assert result.num_groups == cfg.num_batches * cfg.num_groups
+        # The consumer pauses the engine for every train step except after the
+        # last batch (the loop breaks before that pause).
+        expected_paused = (cfg.num_batches - 1) * cfg.train_time
+        assert result.engine_paused_seconds >= expected_paused * 0.95
+        # Consecutive batches are separated by at least the frozen train step.
+        gaps = [t2 - t1 for (_, t1), (_, t2) in zip(result.batch_done_at, result.batch_done_at[1:])]
+        assert all(gap >= cfg.train_time * 0.95 for gap in gaps)
+
+    @pytest.mark.asyncio
+    async def test_write_html_report(self, tmp_path):
+        results = [await run_mode("G", "B", TINY_CFG)]
+        report_path = tmp_path / "report.html"
+        write_html_report(results, TINY_CFG, report_path)
+        report = report_path.read_text()
+        assert "<svg" in report and "G/B" in report and "data-tip" in report
+
+
+MULTI_ENV_CFG = SimConfig(
+    num_groups=4,
+    num_batches=8,
+    rollouts_per_group=2,
+    latency_lo=0.001,
+    latency_hi=0.002,
+    generation_lag=1,
+    seed=0,
+)
+
+# Same generation speed distribution shapes as the granularity runs: one env
+# is ~5x slower per rollout than the other, equal data-mix weights.
+FAST_SLOW = [EnvSpec(name="fast", lo=0.001, hi=0.003), EnvSpec(name="slow", lo=0.005, hi=0.010)]
+
+REBALANCE_CFG = PgtRebalanceConfig(
+    min_interval_s=0.0, min_samples_per_env=2, max_step_fraction=0.25
+)
+
+
+class TestMultiEnvSimulation:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("submission, consumption", [("R", "G"), ("G", "G")])
+    async def test_static_split_smoke(self, submission, consumption):
+        result = await run_multi_env_mode(submission, consumption, MULTI_ENV_CFG, FAST_SLOW)
+
+        expected_groups = MULTI_ENV_CFG.num_batches * MULTI_ENV_CFG.num_groups
+        assert result.num_groups == expected_groups
+        # Equal weights: the data mix splits evenly regardless of env speed.
+        assert result.groups_per_env == {"fast": expected_groups // 2, "slow": expected_groups // 2}
+        assert len(result.batch_done_at) == MULTI_ENV_CFG.num_batches
+        # No rebalancer: every sampled gate capacity stays at the static split.
+        for capacities in result.pgt_trajectory.values():
+            assert len(set(capacities)) == 1
+
+    @pytest.mark.asyncio
+    async def test_rebalancing_shifts_capacity_to_slow_env(self):
+        result = await run_multi_env_mode(
+            "R", "G", MULTI_ENV_CFG, FAST_SLOW, rebalance=REBALANCE_CFG
+        )
+
+        expected_groups = MULTI_ENV_CFG.num_batches * MULTI_ENV_CFG.num_groups
+        assert result.num_groups == expected_groups
+        # Rebalancing must not change the data mix.
+        assert result.groups_per_env == {"fast": expected_groups // 2, "slow": expected_groups // 2}
+        # The slow env's measured service time is higher...
+        assert result.ema_per_env["slow"] > result.ema_per_env["fast"]
+        # ...so capacity moves toward it while the total budget is conserved.
+        assert result.pgt_trajectory["slow"][-1] > result.pgt_trajectory["fast"][-1]
+        totals = {
+            fast + slow
+            for fast, slow in zip(result.pgt_trajectory["fast"], result.pgt_trajectory["slow"])
+        }
+        assert len(totals) == 1
+
+    @pytest.mark.asyncio
+    async def test_rebalancing_does_not_slow_the_run(self):
+        static = await run_multi_env_mode("R", "G", MULTI_ENV_CFG, FAST_SLOW)
+        rebalanced = await run_multi_env_mode(
+            "R", "G", MULTI_ENV_CFG, FAST_SLOW, rebalance=REBALANCE_CFG
+        )
+        # Loose CI bound: same seed and workload, so rebalancing should be at
+        # worst neutral. The decisive improvement claim lives in the manual
+        # simulator A/B run, not this smoke bound.
+        assert rebalanced.total_wall <= static.total_wall * 1.10


### PR DESCRIPTION
## What

Adds **opt-in dynamic rebalancing of inference concurrency across environments** in `WeightedMultiTask` (multi-env GRPO rollouts). When one environment's rollouts are slower to generate than another's, the faster env spends its share running ahead on its own future-batch rollouts while the slower env lags the current batch — leaving GPU idle relative to a balanced schedule. This change measures per-env generation time and shifts submission-gate capacity toward the slower environments so they finish their share of each batch at about the same time.

Enabled with `--rl-inference-rebalancing` (default **off** — behavior is unchanged when the flag is absent).

## How

- **Signal**: an EMA of per-rollout `engine_dwell` (dequeue→response service time) per env, captured in `_RolloutPipeline._infer_one`.
- **Policy** (`WeightedMultiTask._compute_pgt_allocation`, the dynamic counterpart of `_distribute_counts`): allocate the fixed total `parallel_generation_tasks` so each env's share is proportional to `weight_i x EMA_i`, with largest-remainder rounding, per-update hysteresis, and a per-env floor (for G-submission + B-consumption the floor is one local batch, to avoid a release deadlock). **The training data mix (`agent_groups` / `agent_slots`) is never changed** — only inference concurrency moves; the total is conserved.
- **Actuator**: `_SubmissionGate` is made resizable at runtime (`set_capacity`); shrinking never revokes in-flight slots.
- **Observability**: new per-env W&B metrics — `{env}_engine_dwell_ema_s`, `{env}_agent_pgt_live`, `multitask_pgt_rebalance_count`.

## Testing

- Unit tests for the resizable gate, allocation math (conservation / floors / hysteresis / the "1.2x slower → 1.2x slots" case), the rebalancer, and EMA capture (`tests/unit_tests/rl/test_grouped_rollouts.py`).
- A standalone multi-env simulator that drives the **real** `_RolloutPipeline` with mocked inference (`tests/unit_tests/rl/simulate_grouped_rollouts.py` + tests), used to validate the policy end-to-end.

## Status / caveats (draft)

- The mechanism is verified on real 8-node runs: capacity demonstrably shifts to the slow env, the data mix stays fixed, and per-env staleness spread tightens. **However, in a lag-5, inference-engine-saturated regime it has not shown a wall-clock win** — consistent with the simulator, which predicts the gain only when the per-env gate (not the shared engine) is the binding resource. The feature is expected to pay off in gate-bound configs (lower lag / more engine headroom); validation there is ongoing.
- **Known refinement (follow-up):** the fixed infer-worker pool is currently sized to each env's growth ceiling, which over-provisions coroutines; a cap at a small multiple of the configured share (with a matching allocation bound) is a straightforward improvement.
- Includes two prerequisite gate commits (release G/B slots on consumption). Can be split if reviewers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
