### PR TITLE
Handle checkpoint and text-only batches in MIMO encoder prefetch

### DIFF
--- a/examples/mimo/training/encoder_prefetch.py
+++ b/examples/mimo/training/encoder_prefetch.py
@@ -278,8 +278,8 @@ class EncoderPrefetchLoader:
                 self._condition.notify_all()
                 terminate = source_exhausted or source_error is not None
             if self._debug:
-                assert encode_start is not None
-                _log_producer_debug(batch_id, data_fetch_ms, encode_start, completion_event)
+                if encode_start is not None:
+                    _log_producer_debug(batch_id, data_fetch_ms, encode_start, completion_event)
                 self._drain_encoder_wait_timings()
                 self._drain_projection_timings()
             if terminate:
@@ -292,20 +292,20 @@ class EncoderPrefetchLoader:
         if not isinstance(batch, dict):
             raise TypeError("encoder prefetch source must return a batch dictionary")
         modality_inputs = batch.get("modality_inputs")
-        if not isinstance(modality_inputs, dict) or self._encoder_name not in modality_inputs:
-            raise ValueError(f"batch has no inputs for encoder {self._encoder_name!r}")
 
         with torch.cuda.device(self._device), torch.cuda.stream(self._stream):
             # Encoder ranks intentionally retain only fields consumed by their forward step.
             output_batch = {"input_ids": batch["input_ids"]}
-            encoder_inputs = move_batch_to_cuda(modality_inputs[self._encoder_name])
-            encode_start = torch.cuda.Event(enable_timing=True) if self._debug else None
-            if encode_start is not None:
-                encode_start.record(self._stream)
-            encoded = self._feature_producer(encoder_inputs)
-            if not isinstance(encoded, torch.Tensor):
-                raise TypeError("feature_producer must return one combined tensor")
-            output_batch[PREFETCHED_FEATURES_KEY] = {self._encoder_name: encoded}
+            encode_start = None
+            if modality_inputs:
+                encoder_inputs = move_batch_to_cuda(modality_inputs[self._encoder_name])
+                encode_start = torch.cuda.Event(enable_timing=True) if self._debug else None
+                if encode_start is not None:
+                    encode_start.record(self._stream)
+                encoded = self._feature_producer(encoder_inputs)
+                if not isinstance(encoded, torch.Tensor):
+                    raise TypeError("feature_producer must return one combined tensor")
+                output_batch[PREFETCHED_FEATURES_KEY] = {self._encoder_name: encoded}
             completion_event = torch.cuda.Event(enable_timing=self._debug)
             completion_event.record(self._stream)
         return output_batch, completion_event, encode_start
@@ -353,9 +353,12 @@ class EncoderPrefetchLoader:
             if wait_end_event is not None:
                 wait_end_event.record(current_stream)
                 self._queue_encoder_wait_timing(batch_id, wait_start_event, wait_end_event)
-        _record_feature_streams(item[PREFETCHED_FEATURES_KEY], current_stream)
+        features = item.get(PREFETCHED_FEATURES_KEY)
+        if features is not None:
+            _record_feature_streams(features, current_stream)
+            if self._debug:
+                item[PROJECTION_TIMER_KEY] = _ProjectionTimer(self, batch_id)
         if self._debug:
-            item[PROJECTION_TIMER_KEY] = _ProjectionTimer(self, batch_id)
             _log_consumer_debug(
                 batch_id, ready_at_request, self._depth, completion_event is not None, wait_start
             )

--- a/examples/mimo/training/encoder_prefetch.py
+++ b/examples/mimo/training/encoder_prefetch.py
@@ -187,6 +187,10 @@ class EncoderPrefetchLoader:
         """Return this loader as its own iterator."""
         return self
 
+    def save_state(self) -> None:
+        """Keep encoder lookahead derived from the canonical language-loader state."""
+        return None
+
     def start(self) -> None:
         """Initialize CUDA stream state and start the producer thread."""
         with self._condition:

--- a/tests/unit_tests/models/mimo/test_mimo_encoder_prefetch.py
+++ b/tests/unit_tests/models/mimo/test_mimo_encoder_prefetch.py
@@ -159,6 +159,17 @@ class _Source:
         }
 
 
+def test_prefetch_state_is_not_authoritative():
+    loader = EncoderPrefetchLoader(
+        source=_Source(1),
+        encoder_name=ENCODER,
+        feature_producer=lambda _inputs: torch.empty(0),
+        depth=1,
+    )
+
+    assert loader.save_state() is None
+
+
 def _wait_until(predicate):
     deadline = time.monotonic() + 2
     while not predicate():

--- a/tests/unit_tests/models/mimo/test_mimo_encoder_prefetch.py
+++ b/tests/unit_tests/models/mimo/test_mimo_encoder_prefetch.py
@@ -307,6 +307,26 @@ def test_prefetch_keeps_input_ids_on_cpu_path(fake_cuda, monkeypatch):
     assert moved[0] is encoder_inputs
 
 
+def test_prefetch_passes_through_text_only_batches(fake_cuda):
+    input_ids = torch.tensor([[1, 2]])
+    loader = EncoderPrefetchLoader(
+        source=[{"input_ids": input_ids}],
+        encoder_name=ENCODER,
+        feature_producer=lambda _inputs: pytest.fail("text-only batches must not run the encoder"),
+        depth=1,
+        stream=fake_cuda.producer,
+        debug=True,
+    )
+    loader.start()
+    _wait_until(lambda: len(loader._ready) == 1)
+
+    batch = next(loader)
+    loader.close()
+
+    assert set(batch) == {"input_ids"}
+    assert batch["input_ids"] is input_ids
+
+
 def test_debug_logs_prefetch_timing_and_queue_state(fake_cuda, caplog):
     module_logger_level = encoder_prefetch.logger.level
     caplog.set_level("INFO", logger=f"{encoder_prefetch.__name__}.debug")


### PR DESCRIPTION
## What changed

- expose `EncoderPrefetchLoader.save_state() -> None` so checkpointing can treat encoder lookahead as derived state while the canonical language-loader cursor remains authoritative.
- allow text-only MIMO microbatches to pass through encoder prefetch without invoking the image encoder.
- guard CUDA stream and debug-timing bookkeeping when a batch produces no encoder features.

## Why

Encoder prefetch from #5833 can wrap a checkpointable data iterator and can receive image-sparse batches from heterogeneous multimodal datasets. The outer wrapper must participate in the checkpoint interface without persisting its speculative queue, and batches without images must preserve schedule progress without manufacturing encoder work.

The model still validates missing inputs when matching modality tokens are present; this only permits genuinely text-only batches.

## Validation

- `python3 -m py_compile examples/mimo/training/encoder_prefetch.py tests/unit_tests/models/mimo/test_mimo_encoder_prefetch.py`
- OCI-HSG 5-node Mistral VLM smoke job `5590459`: 200 iterations completed with both patches in the staging branch.
- focused regression coverage added for non-authoritative prefetch state and text-only batch pass-through.

Local pytest was not rerun on the Codex host because that host does not provide `uv` or Torch; CI should run the focused tests in the supported container.