### PR TITLE
Fix FlashInfer MoE backend for gated activations

### DIFF
--- a/megatron/core/transformer/moe/experts.py
+++ b/megatron/core/transformer/moe/experts.py
@@ -895,6 +895,25 @@ class TEGroupedMLP(MegatronModule):
         self.linear_fc1.backward_dw()
 
 
+def _swap_glu_halves(fc1_weight: torch.Tensor) -> torch.Tensor:
+    """Return a copy of a gated fc1 weight with its two halves swapped.
+
+    Converts between the ``[gate|up]`` concatenation Megatron and Transformer Engine
+    use and the ``[up|gate]`` order FlashInfer's grouped GEMM expects.
+
+    Args:
+        fc1_weight: ``[num_experts, 2 * ffn_hidden_size, in_features]``.
+    """
+    num_experts, fc1_out, in_features = fc1_weight.shape
+    assert fc1_out % 2 == 0, f"gated fc1 out_features must be even, got {fc1_out}"
+    return (
+        fc1_weight.view(num_experts, 2, fc1_out // 2, in_features)
+        .flip(dims=[1])
+        .reshape(num_experts, fc1_out, in_features)
+        .contiguous()
+    )
+
+
 class InferenceGroupedMLP(TEGroupedMLP):
     """Inference-optimized GroupedMLP with GPU-resident offsets.
 
@@ -939,6 +958,18 @@ class InferenceGroupedMLP(TEGroupedMLP):
             HAVE_FLASHINFER
         ), "flashinfer-python is required to resolve FlashInfer activation type."
         func = self.config.activation_func
+        if self.config.gated_linear_unit:
+            # A gated fc1 emits 2 * ffn_hidden_size, so the gated enum is required:
+            # the non-gated ones make FlashInfer expect fc1_out == fc2_in and fail its
+            # shape check (`fc1_expert_weights.size(1) == fc2_expert_weights.size(2)
+            # * mInnerDimMultiplier`).
+            if func == F.silu:
+                return ActivationType.Swiglu
+            elif func == F.gelu:
+                return ActivationType.Geglu
+            raise ValueError(
+                f"No gated FlashInfer ActivationType mapping for activation_func={func}"
+            )
         if func == F.silu:
             return ActivationType.Silu
         elif func == F.gelu:
@@ -1020,6 +1051,11 @@ class InferenceGroupedMLP(TEGroupedMLP):
         - TE's forward to work correctly (same Parameter objects, same internal state)
         - Training updates to flow through (param.data is a view into the big tensor)
         - torch.nn.functional.grouped_mm / FlashInfer to use the big tensor directly
+
+        The FlashInfer backend additionally needs a gated fc1 as ``[up|gate]``. Since
+        ``_fc1_weight`` shares storage with TE's ``[gate|up]`` parameters, the halves
+        cannot be swapped in place without corrupting the training path, so that
+        backend keeps a second, swapped copy of fc1 (one extra fc1 weight per layer).
         """
         # Get device/dtype from existing TE weights
         device = self.linear_fc1.weight0.device
@@ -1050,15 +1086,32 @@ class InferenceGroupedMLP(TEGroupedMLP):
         self.register_buffer('_fc1_weight', _fc1_weight, persistent=False)
         self.register_buffer('_fc2_weight', _fc2_weight, persistent=False)
 
+        if (
+            self.inference_grouped_gemm_backend == InferenceGroupedGemmBackend.FLASHINFER
+            and self.config.gated_linear_unit
+        ):
+            self.register_buffer(
+                '_fc1_weight_flashinfer', _swap_glu_halves(_fc1_weight), persistent=False
+            )
+
     def _flashinfer_forward(self, hidden_states, routing_map, probs):
         """FlashInfer fused MoE kernel for CUDA-graphed inference iterations."""
         assert HAVE_FLASHINFER, "flashinfer-python is required for FlashInfer forward path."
         assert probs.dtype == torch.float32, "FlashInfer forward path requires fp32 probabilities."
+        if self.config.gated_linear_unit:
+            fc1_weight = getattr(self, '_fc1_weight_flashinfer', None)
+            assert fc1_weight is not None, (
+                "FlashInfer needs a gated fc1 in [up|gate] order; the swapped buffer was "
+                "not built. _build_concatenated_weights() only builds it for the FlashInfer "
+                "backend, and the MXFP8 weight path does not support FlashInfer."
+            )
+        else:
+            fc1_weight = self._fc1_weight
         output = fused_moe.cutlass_fused_moe(
             hidden_states,
             routing_map.int(),
             probs,
-            self._fc1_weight,
+            fc1_weight,
             self._fc2_weight,
             hidden_states.dtype,
             quant_scales=None,


### PR DESCRIPTION
## Summary

`--inference-grouped-gemm-backend flashinfer` is currently unusable for any gated-activation MoE (SwiGLU / GeGLU). It fails in two independent ways, and the second one fails *silently*. Found while benchmarking the backend on Qwen3-30B-A3B (BF16, EP4, GB200).

**1. The activation enum ignores `gated_linear_unit` (hard failure).**

`_resolve_flashinfer_activation_type` maps `F.silu` straight to `ActivationType.Silu` without consulting `config.gated_linear_unit` — unlike `_resolve_mcore_activation_type` right below it, which does. A gated fc1 emits `2 * ffn_hidden_size`, so the non-gated enum makes FlashInfer expect `fc1_out == fc2_in` and trip its shape check:

```
fc1_expert_weights.size(1) == fc2_expert_weights.size(2) * mInnerDimMultiplier (1536 vs. 768)
```

Gated SiLU must map to `Swiglu` and gated GELU to `Geglu`. This — not any kernel limitation — is why the FlashInfer backend has a reputation for being "blocked for SwiGLU". The kernel supports BF16 gated SwiGLU fine.

**2. The gated fc1 halves are in the wrong order (silent numerical corruption).**

With the enum fixed, the kernel runs but returns wrong results. FlashInfer's grouped GEMM reads a gated fc1 as `[up|gate]`, while `_build_concatenated_weights` produces Transformer Engine's `[gate|up]`. Measured against the reference MoE at Qwen3-30B-A3B decode shapes (hidden 2048, moe_ffn 768, 32 local experts, top-8):

| fc1 order | max_abs | max_rel |
|---|---:|---:|
| `[gate\|up]` (current) | 7.14e-4 | **4.92** |
| `[up\|gate]` (fixed) | 3.87e-5 | 0.171 |

0.171 is bf16 rounding noise. The concerning part is that **both pass a loose `allclose(rtol=2e-2, atol=2e-2)`**, which is why this does not surface as an obvious failure. vLLM carries the same conversion for the same kernel family (`swap_w13_to_w31` in `vllm/model_executor/layers/quantization/utils/flashinfer_utils.py`), which independently corroborates the expected order.

`_fc1_weight` shares storage with TE's per-expert parameters, so the halves cannot be swapped in place without corrupting the training fallback path (`InferenceGroupedMLP.forward` delegates to `TEGroupedMLP` when `InferenceMode` is inactive). The FlashInfer backend therefore keeps a second, swapped copy of fc1, built once alongside the concatenated weights and only when that backend is selected. That costs one extra fc1 weight per layer; it is not allocated for the `vllm` or `torch` backends, or for non-gated activations.

## Scope

Correctness only — no intended performance change, and no change to the `vllm` / `torch` grouped-GEMM backends or to any training path. For the record, on Qwen3-30B-A3B decode the corrected FlashInfer path measured 90.81 µs versus 83.63 µs for the tuned Triton path under CUDA graphs, so this fix makes the backend *usable*, not faster.

## Test plan

- [ ] Numerics of the corrected enum + weight order verified against the reference MoE at production Qwen3-30B-A3B shapes (table above), via a standalone harness on GB200.
- [ ] `_swap_glu_halves` index math verified to map `[gate|up]` -> `[up|gate]` and to be involutive.
- [ ] Not yet exercised end-to-end through `InferenceGroupedMLP` with a real checkpoint — the two fixes were validated at kernel level. Marking this draft for that reason; happy to add an integration test if maintainers point me at the right harness.
- [ ] No coverage exists today for `inference_grouped_gemm_backend=flashinfer` with a gated activation, which is how both bugs survived. Worth adding.