### PR TITLE
Enforce that the number of optimizer shards used in layout computation is the same used during the training iteration

### DIFF
--- a/megatron/core/distributed/param_and_grad_buffer.py
+++ b/megatron/core/distributed/param_and_grad_buffer.py
@@ -1071,6 +1071,7 @@ class _ParamAndGradBuffer:
             param_layout = _compute_default_per_buffer_param_layout(self.params, bucket_size)
         self.param_index_map = param_layout.param_index_map
         self.bucket_indices = param_layout.bucket_indices
+        self.num_optimizer_shards = param_layout.num_optimizer_shards
         per_bucket_numel_unpadded = param_layout.per_bucket_numel_unpadded
 
         # Check if this buffer contains NVFP4 params.

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -211,6 +211,18 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
         data_parallel_rank = param_and_grad_buffer.data_parallel_group.rank()
         data_parallel_world_size = param_and_grad_buffer.data_parallel_group.size()
 
+        # The layout records how many shards it was built for. That count has to match the group
+        # the reduce-scatter and all-gather run over, which is the intra-instance group when
+        # there are several optimizer instances. If the layout was sized by a larger group, the
+        # trailing shards of every bucket belong to no rank: those params are never updated and
+        # drop out of grad-norm, num-zeros and params-norm, which sum over owned shards only.
+        num_optimizer_shards = param_and_grad_buffer.num_optimizer_shards
+        assert num_optimizer_shards is None or num_optimizer_shards == data_parallel_world_size, (
+            f"Parameter layout was built for {num_optimizer_shards} optimizer shards but the "
+            f"buffer's data-parallel group has {data_parallel_world_size} ranks. Size the layout "
+            f"by the group the optimizer shards over."
+        )
+
         bucket = param_and_grad_buffer.buckets[bucket_index]
         gbuf_size = bucket.grad_data.numel()
         assert (
@@ -572,6 +584,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
             bucket_indices=bucket_indices,
             per_bucket_numel_unpadded=per_bucket_numel_unpadded,
             param_indices=param_indices if param_indices is not None else [],
+            num_optimizer_shards=data_parallel_world_size,
         )
 
     @staticmethod

--- a/megatron/core/optimizer/layer_wise_optimizer.py
+++ b/megatron/core/optimizer/layer_wise_optimizer.py
@@ -445,6 +445,27 @@ class LayerWiseDistributedOptimizer(ChainedOptimizer):
 
         self.pg_collection = pg_collection
 
+        # The data-parallel groups this optimizer shards parameters over. Cached here so the
+        # sharding, all-gather and broadcast paths read one attribute instead of reaching back
+        # into pg_collection at every use.
+        self.dp_cp = getattr(pg_collection, 'dp_cp', None) if pg_collection is not None else None
+        self.expt_dp = (
+            getattr(pg_collection, 'expt_dp', None) if pg_collection is not None else None
+        )
+
+        # LayerWise assigns whole params to ranks of the full dp_cp group and all-gathers over
+        # that same group, so it has no notion of optimizer instances. With more than one
+        # instance, DDP reduce-scatters gradients over the smaller intra-instance group, so a
+        # rank would be asked to update params whose gradients it does not hold. Reject the
+        # combination instead of silently training on partial gradients.
+        intra_dp_cp = (
+            getattr(pg_collection, 'intra_dp_cp', None) if pg_collection is not None else None
+        )
+        assert intra_dp_cp is None or get_pg_size(intra_dp_cp) == get_pg_size(self.dp_cp), (
+            "LayerWiseDistributedOptimizer does not support "
+            "num_distributed_optimizer_instances > 1."
+        )
+
         full_param_layouts = None
         if model_chunks is not None:
             full_param_layouts = [
@@ -527,13 +548,13 @@ class LayerWiseDistributedOptimizer(ChainedOptimizer):
                 chunk).  ``None`` triggers the legacy fallback.
         """
         # Simplify when dp_cp group size is 1.
-        dp_cp_size = get_pg_size(self.pg_collection.dp_cp)
+        dp_cp_size = get_pg_size(self.dp_cp)
         if dp_cp_size == 1:
             self.dp_cp_params_list = None
             self.expt_dp_params_list = None
             return
 
-        expt_dp_size = get_pg_size(self.pg_collection.expt_dp)
+        expt_dp_size = get_pg_size(self.expt_dp)
 
         if full_param_layouts is not None:
             self._shard_params_from_layout(optimizers, full_param_layouts, dp_cp_size, expt_dp_size)
@@ -542,8 +563,8 @@ class LayerWiseDistributedOptimizer(ChainedOptimizer):
 
     def _shard_params_from_layout(self, optimizers, full_param_layouts, dp_cp_size, expt_dp_size):
         """Derive shard assignments from the param layout."""
-        dp_cp_rank = get_pg_rank(self.pg_collection.dp_cp)
-        expt_dp_rank = get_pg_rank(self.pg_collection.expt_dp)
+        dp_cp_rank = get_pg_rank(self.dp_cp)
+        expt_dp_rank = get_pg_rank(self.expt_dp)
 
         self.dp_cp_params_list = [[] for _ in range(dp_cp_size)]
         self.expt_dp_params_list = [[] for _ in range(expt_dp_size)]
@@ -641,12 +662,12 @@ class LayerWiseDistributedOptimizer(ChainedOptimizer):
         # Assign params to rank in ping-pong style loop.
         for p, group_index in param_list:
             if param_groups[group_index].get("is_expert_parallel", False):
-                if expt_dp_loop[expt_dp_idx] == get_pg_rank(self.pg_collection.expt_dp):
+                if expt_dp_loop[expt_dp_idx] == get_pg_rank(self.expt_dp):
                     param_groups_this_rank[group_index].append(p)
                 self.expt_dp_params_list[expt_dp_loop[expt_dp_idx]].append(p)
                 expt_dp_idx = (expt_dp_idx + 1) % len(expt_dp_loop)
             else:
-                if dp_cp_loop[dp_cp_idx] == get_pg_rank(self.pg_collection.dp_cp):
+                if dp_cp_loop[dp_cp_idx] == get_pg_rank(self.dp_cp):
                     param_groups_this_rank[group_index].append(p)
                 self.dp_cp_params_list[dp_cp_loop[dp_cp_idx]].append(p)
                 dp_cp_idx = (dp_cp_idx + 1) % len(dp_cp_loop)
@@ -680,9 +701,7 @@ class LayerWiseDistributedOptimizer(ChainedOptimizer):
                     if not _bucket_is_managed_by_layer_wise_optimizer(bucket):
                         continue
                     if self.dp_cp_params_list is not None:
-                        bucket_params_list = [
-                            [] for _ in range(get_pg_size(self.pg_collection.dp_cp))
-                        ]
+                        bucket_params_list = [[] for _ in range(get_pg_size(self.dp_cp))]
                         for bucket_list, full_params_list in zip(
                             bucket_params_list, self.dp_cp_params_list
                         ):
@@ -700,9 +719,7 @@ class LayerWiseDistributedOptimizer(ChainedOptimizer):
                     if not _bucket_is_managed_by_layer_wise_optimizer(bucket):
                         continue
                     if self.expt_dp_params_list is not None:
-                        bucket_params_list = [
-                            [] for _ in range(get_pg_size(self.pg_collection.expt_dp))
-                        ]
+                        bucket_params_list = [[] for _ in range(get_pg_size(self.expt_dp))]
                         for bucket_list, full_params_list in zip(
                             bucket_params_list, self.expt_dp_params_list
                         ):
@@ -765,9 +782,9 @@ class LayerWiseDistributedOptimizer(ChainedOptimizer):
         if self.pg_collection is None:
             return
         if self.dp_cp_params_list:
-            _allgather_helper(self.dp_cp_params_list, self.pg_collection.dp_cp)
+            _allgather_helper(self.dp_cp_params_list, self.dp_cp)
         if self.expt_dp_params_list:
-            _allgather_helper(self.expt_dp_params_list, self.pg_collection.expt_dp)
+            _allgather_helper(self.expt_dp_params_list, self.expt_dp)
 
     @torch.no_grad()
     def broadcast_params(self):
@@ -776,15 +793,15 @@ class LayerWiseDistributedOptimizer(ChainedOptimizer):
         if self.dp_cp_params_list is None:
             return
         for i, params in enumerate(self.dp_cp_params_list):
-            src_global_rank = torch.distributed.get_global_rank(self.pg_collection.dp_cp, i)
+            src_global_rank = torch.distributed.get_global_rank(self.dp_cp, i)
             for p in params:
-                torch.distributed.broadcast(p, src_global_rank, self.pg_collection.dp_cp)
+                torch.distributed.broadcast(p, src_global_rank, self.dp_cp)
         if self.expt_dp_params_list is None:
             return
         for i, params in enumerate(self.expt_dp_params_list):
-            src_global_rank = torch.distributed.get_global_rank(self.pg_collection.expt_dp, i)
+            src_global_rank = torch.distributed.get_global_rank(self.expt_dp, i)
             for p in params:
-                torch.distributed.broadcast(p, src_global_rank, self.pg_collection.expt_dp)
+                torch.distributed.broadcast(p, src_global_rank, self.expt_dp)
 
     @torch.no_grad()
     def get_grad_norm(self):

--- a/megatron/core/optimizer/param_layout.py
+++ b/megatron/core/optimizer/param_layout.py
@@ -79,9 +79,9 @@ class PerBufferParamLayout:
         param_indices: The index of each param among same-dtype params (using the "fake"
             high-precision dtype for FP8/NVFP4 params). Needed for loading non-native-fp8
             checkpoints in native-fp8 mode. Order matches param_index_map iteration order.
-        num_optimizer_shards: Number of shards the bucket boundaries were aligned to. Set only
-            by ``LayerWiseDistributedOptimizer``, to recover a param's shard index; ``None`` for
-            ``DistributedOptimizer``, which takes the count from the buffer's data_parallel_group.
+        num_optimizer_shards: Number of optimizer shards. Set by the distributed optimizer
+            that computes the layout so that shard assignment at runtime uses the same
+            value. ``None`` for non-distributed-optimizer layouts.
     """
 
     param_index_map: Dict[torch.nn.Parameter, Tuple[int, int, int]] = field(default_factory=dict)

--- a/megatron/training/models/dist_utils.py
+++ b/megatron/training/models/dist_utils.py
@@ -324,13 +324,27 @@ def _ddp_wrap(
                     if disable_bucketing or pp_rank > 0
                     else ddp_config.bucket_size
                 )
+                # Size the layout by the group the optimizer actually shards over, which is
+                # the intra-instance group when there are several optimizer instances. Using
+                # the full dp_cp would report more shards than the reduce-scatter uses and
+                # leave the trailing shard of every bucket owned by no rank.
+                intra_dp_cp_group = getattr(pg_collection, "intra_dp_cp", None)
+                intra_expt_dp_group = getattr(pg_collection, "intra_expt_dp", None)
                 chunk_kwargs["full_param_layout"] = (
                     DistributedOptimizer.compute_full_param_layout(
                         all_params,
                         effective_bucket_size,
-                        pg_collection.dp_cp.size(),
+                        (
+                            intra_dp_cp_group
+                            if intra_dp_cp_group is not None
+                            else pg_collection.dp_cp
+                        ).size(),
                         ddp_config,
-                        expert_data_parallel_world_size=pg_collection.expt_dp.size(),
+                        expert_data_parallel_world_size=(
+                            intra_expt_dp_group
+                            if intra_expt_dp_group is not None
+                            else pg_collection.expt_dp
+                        ).size(),
                     )
                 )
 

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1654,8 +1654,22 @@ def wrap_model_chunks_with_ddp(
                 "wrap_model_chunks_with_ddp requires a dp_cp process group to size "
                 "the distributed-optimizer parameter layout"
             )
-            data_parallel_world_size = get_pg_size(layout_pgs.dp_cp)
-            expert_data_parallel_world_size = get_pg_size(getattr(layout_pgs, "expt_dp", None))
+            # The distributed optimizer shards each bucket over the intra-instance group, which
+            # is what DDP hands to the buffer as its data_parallel_group. Size the layout by that
+            # same group, otherwise the layout reports more shards than the reduce-scatter uses
+            # and the trailing shards of every bucket end up owned by no rank. intra_dp_cp is
+            # the full dp_cp when num_distributed_optimizer_instances is 1, so this only differs
+            # when there are several instances.
+            intra_dp_cp_group = getattr(layout_pgs, "intra_dp_cp", None)
+            intra_expt_dp_group = getattr(layout_pgs, "intra_expt_dp", None)
+            data_parallel_world_size = get_pg_size(
+                intra_dp_cp_group if intra_dp_cp_group is not None else layout_pgs.dp_cp
+            )
+            expert_data_parallel_world_size = get_pg_size(
+                intra_expt_dp_group
+                if intra_expt_dp_group is not None
+                else getattr(layout_pgs, "expt_dp", None)
+            )
             for i, (chunk, bucket_size) in enumerate(zip(model_chunks, bucket_sizes)):
                 all_params = [p for p in chunk.parameters() if p.requires_grad]
                 per_chunk_layouts[i] = compute_layout(

--- a/tests/unit_tests/distributed/test_param_and_grad_buffer.py
+++ b/tests/unit_tests/distributed/test_param_and_grad_buffer.py
@@ -78,12 +78,19 @@ def get_model_and_buffers(
     # Wrap with DistributedDataParallel, and get underlying buffer.
     # Use dummy TransformerConfig with mostly default values. Avoid divide-by-zero
     # errors for num_attention_heads and num_layers.
-    # Pre-compute parameter layouts for the distributed optimizer.
+    # Pre-compute parameter layouts for the distributed optimizer. Size the layout by the group
+    # the optimizer shards over, which is the intra-instance group when there are several
+    # optimizer instances. This is the same group DDP hands to the buffer below.
     full_param_layout = None
     if use_distributed_optimizer:
         all_params = [p for p in model.parameters() if p.requires_grad]
         full_param_layout = DistributedOptimizer.compute_full_param_layout(
-            all_params, bucket_size, parallel_state.get_data_parallel_world_size(), ddp_config
+            all_params,
+            bucket_size,
+            parallel_state.get_data_parallel_world_size(
+                with_context_parallel=True, partial_data_parallel=True
+            ),
+            ddp_config,
         )
     model = DistributedDataParallel(
         TransformerConfig(num_attention_heads=1, num_layers=1),
@@ -1016,7 +1023,12 @@ def test_expert_parallel_params_get_separate_buffers(use_distributed_optimizer: 
     if use_distributed_optimizer:
         all_params = [p for p in model.parameters() if p.requires_grad]
         full_param_layout = DistributedOptimizer.compute_full_param_layout(
-            all_params, bucket_size, parallel_state.get_data_parallel_world_size(), ddp_config
+            all_params,
+            bucket_size,
+            parallel_state.get_data_parallel_world_size(
+                with_context_parallel=True, partial_data_parallel=True
+            ),
+            ddp_config,
         )
 
     ddp_model = DistributedDataParallel(

--- a/tests/unit_tests/training/models/test_dist_utils.py
+++ b/tests/unit_tests/training/models/test_dist_utils.py
@@ -33,6 +33,9 @@ def _make_pg():
     pg.pp.size.return_value = 1
     pg.dp_cp.size.return_value = 1
     pg.expt_dp.size.return_value = 1
+    # With a single optimizer instance the intra-instance groups are the full groups.
+    pg.intra_dp_cp.size.return_value = 1
+    pg.intra_expt_dp.size.return_value = 1
     return pg
 
 
@@ -617,6 +620,9 @@ class TestDdpWrapFullParamLayout:
         self.pg = _make_pg()
         self.pg.dp_cp.size.return_value = 4
         self.pg.expt_dp.size.return_value = 2
+        # Single optimizer instance, so the intra-instance groups match the full groups.
+        self.pg.intra_dp_cp.size.return_value = 4
+        self.pg.intra_expt_dp.size.return_value = 2
         self._opt_patcher = patch("megatron.training.models.dist_utils.DistributedOptimizer")
         self._opt = self._opt_patcher.start()
         self._opt.compute_full_param_layout.return_value = "LAYOUT"


### PR DESCRIPTION
# What does this PR do ?

Everything here is scoped to `--num-distributed-optimizer-instances > 1`. With a single instance, nothing in this PR changes behaviour.

With multiple instances, the optimizer shards each bucket over the **intra-instance** data-parallel group rather than the full `dp_cp`, because that is the group DDP reduce-scatters gradients over. Two places got that wrong:

1. `DistributedOptimizer` layouts were sized by the full `dp_cp`, so the layout recorded more shards than the collective used.
2. `LayerWiseDistributedOptimizer` shards over the full `dp_cp` unconditionally, and has no notion of instances at all.

The first is not a live failure — it was caught during the GTP merge and already fixed; this PR re-implements that fix differently. The second is a live bug.

## Background on (1)

`DistributedOptimizer._build_model_gbuf_range` splits each bucket into shards and gives rank `r` the r-th one, while the reduce-scatter and all-gather run over the buffer's `data_parallel_group`. With multiple optimizer instances, that group is the intra-instance group. When the layout is sized by the full `dp_cp` instead, the trailing shards of every bucket are owned by no rank: those parameters are never updated, and they drop out of grad-norm, num-zeros and params-norm, which sum over owned shards only.

`gpt3_mcore_te_tp2_pp1_resume_torch_dist_multi_dist_optimizer_instances` caught this during the GTP merge, and 19f8482766 fixed it by having core stop reading the layout's count and re-derive it from the group. `main` is green.

## What changes here

**Reverts 19f8482766, and takes the other side of the trade.** The layout's `num_optimizer_shards` stays authoritative; callers must size layouts by the group the optimizer shards over, and an assertion in `_build_model_gbuf_range` enforces it. A caller that gets it wrong fails loudly at startup, instead of silently dropping parameters. `test_optimizer_shards_cover_every_param` from that commit is kept, since it asserts the invariant without assuming where the count comes from.

**Brings the two training-side callers in line.** `wrap_model_chunks_with_ddp` (training.py) and `_ddp_wrap` (models/dist_utils.py) pass `intra_dp_cp` / `intra_expt_dp`. `intra_dp_cp` is `dp_cp` with a single optimizer instance, so no branch on the instance count is needed. DDP's own fallback layout at `distributed_data_parallel.py:143` already used these groups. The two layout helpers in `test_param_and_grad_buffer.py` pass `with_context_parallel=True, partial_data_parallel=True`, to request the same intra DP x CP group.

**Rejects multiple instances for LayerWiseDistributedOptimizer.** LayerWise assigns whole params to ranks of the full `dp_cp` group and all-gathers over that same group, so with more than one instance, a rank is asked to update params whose gradients DDP reduce-scattered to a different rank. Nothing rejected the combination, so muon with multiple instances trained on partial gradients silently. This adds an assertion. Supporting the combination properly would mean moving LayerWise onto the intra groups throughout, which is left as follow-up. With the assertion in place, `intra_dp_cp` is `dp_cp` whenever LayerWise runs, so the layout sizing above needs no special case for it.

LayerWise also now reads `dp_cp` and `expt_dp` once in `__init__` as `self.dp_cp` / `self.expt_dp`, instead of reaching into `pg_collection` at each of eleven call sites across sharding, all-gather and broadcast.

## Testing

- [x] `test_optimizer_shards_cover_every_param` (test added in `19f8482766`).
- [x] Muon unit tests that construct `LayerWiseDistributedOptimizer` directly.
- [ ] Functional tests that construct multiple distributed optimizer instances.

## Contribution process

- [x] I, the PR author, have personally reviewed every line of this PR.
