### PR TITLE
Add tensor-parallel composability

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -468,7 +468,7 @@ class DBuffer:
         should build the full-mesh DTensor at the ``FsdpParameterGroup`` layer,
         which owns the full user-provided mesh.
         """
-        torch_placements = tuple(to_dtensor_placement(placement) for placement in self.placements)
+        dtensor_placements = tuple(to_dtensor_placement(placement) for placement in self.placements)
 
         local_tensor = self.get_local_tensor(index)
         tensor_shape = self.layout.tensor_shapes[index]
@@ -477,7 +477,7 @@ class DBuffer:
         return DTensor.from_local(
             local_tensor=local_tensor,
             device_mesh=self.mesh,
-            placements=torch_placements,
+            placements=dtensor_placements,
             run_check=False,
             shape=tensor_shape,
             stride=local_tensor.stride(),

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -20,12 +20,11 @@ from collections.abc import Iterable
 import torch
 import torch.distributed as dist
 import torch.distributed._symmetric_memory as symm_mem
-import torch.distributed.tensor as dist_tensor
 from torch.distributed import DeviceMesh
 from torch.distributed.tensor import DTensor
 
 from .layout import GlobalLayout, Shape, non_leading_numel
-from .placement import Flat, Partial, Placement, Replicate, changed_mesh_axis
+from .placement import Flat, Partial, Placement, Replicate, changed_mesh_axis, to_dtensor_placement
 
 
 @dataclasses.dataclass(frozen=True)
@@ -462,27 +461,14 @@ class DBuffer:
         ).view(local_shape)
 
     def get_dtensor(self, index: int) -> DTensor:
-        """Return logical tensor ``index`` as a DTensor."""
-        torch_placements = []
-        for placement in self.placements:
-            if isinstance(placement, Replicate):
-                torch_placements.append(dist_tensor.Replicate())
-            elif isinstance(placement, Flat):
-                torch_placements.append(dist_tensor.Shard(0))
-            elif isinstance(placement, Partial):
-                # main_grad backs .grad while it rests DP-outer-Partial between
-                # microbatches, so a Partial placement must round-trip to a DTensor.
-                if placement.reduce_op == dist.ReduceOp.AVG:
-                    reduce_op = "avg"
-                elif placement.reduce_op == dist.ReduceOp.SUM:
-                    reduce_op = "sum"
-                else:
-                    raise ValueError(
-                        f"Unsupported Partial reduce op for DTensor: {placement.reduce_op!r}."
-                    )
-                torch_placements.append(dist_tensor.Partial(reduce_op))
-            else:
-                raise TypeError(f"Unsupported placement for DTensor conversion: {placement!r}.")
+        """Return logical tensor ``index`` as a DTensor on this DP-only mesh.
+
+        This constructs a DTensor over the DBuffer's own mesh, which owns only
+        data-parallel axes. Callers that also need tensor-parallel placements
+        should build the full-mesh DTensor at the ``FsdpParameterGroup`` layer,
+        which owns the full user-provided mesh.
+        """
+        torch_placements = tuple(to_dtensor_placement(placement) for placement in self.placements)
 
         local_tensor = self.get_local_tensor(index)
         tensor_shape = self.layout.tensor_shapes[index]
@@ -491,7 +477,7 @@ class DBuffer:
         return DTensor.from_local(
             local_tensor=local_tensor,
             device_mesh=self.mesh,
-            placements=tuple(torch_placements),
+            placements=torch_placements,
             run_check=False,
             shape=tensor_shape,
             stride=local_tensor.stride(),

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
@@ -37,10 +37,19 @@ def fully_shard(
     This attaches the FSDP mixin to the original module instance, so parent
     modules do not need to replace existing child-module references.
 
+    Tensor-parallel placement is inferred from each parameter's own MCore /
+    Transformer Engine attributes (``tensor_model_parallel`` / ``partition_dim``),
+    so any mesh axis not named in ``placements.dp_axes`` is treated as the
+    tensor-parallel axis and no separate TP layout argument is required.
+
     Args:
         module: Module whose currently unowned parameters are managed by FSDP.
-        mesh: Device mesh used for sharding.
-        placements: Parameter, gradient, and optimizer placements.
+        mesh: Full device mesh used for sharding. Its axis order is the source of
+            truth for the emitted DTensor placement tuple order. Data-parallel
+            axes are named by ``placements.dp_axes``; any remaining axis is the
+            tensor-parallel axis.
+        placements: Parameter, gradient, and optimizer placements for the
+            data-parallel axes.
         mixed_precision_policy: Optional precision policy. Defaults to FP32 main weights
             and parameter-dtype main gradients.
         use_symm_mem: Allocate all-gather and reduce-scatter staging buffers from

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/layout.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/layout.py
@@ -247,5 +247,15 @@ def non_leading_numel(shape: torch.Size) -> int:
     return shape[1:].numel()
 
 
+def contiguous_stride(shape: torch.Size) -> tuple[int, ...]:
+    """Return the row-major contiguous stride for ``shape``."""
+    stride: list[int] = []
+    running = 1
+    for dim in reversed(shape):
+        stride.append(running)
+        running *= dim
+    return tuple(reversed(stride))
+
+
 def _pad_to_multiple(value: int, multiple: int) -> int:
     return ((value + multiple - 1) // multiple) * multiple

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/mesh_utils.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/mesh_utils.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Data-parallel submesh derivation for Megatron-FSDP.
+
+``DBuffer`` owns only the data-parallel (DP) submesh, while
+``FsdpParameterGroup`` owns the full user-provided mesh. This module derives the
+DP submesh from the full mesh so the parameter group can hand it to its
+DBuffers; the reverse mapping (lifting a DP DTensor back onto the full mesh) is
+recovered by name inside ``FsdpParameterGroup.get_dtensor``.
+"""
+
+from torch.distributed import DeviceMesh
+
+from .placement import MeshAxis
+
+
+def axis_index(mesh: DeviceMesh, axis: MeshAxis) -> int:
+    """Resolve a mesh axis (index or name) to a non-negative axis index."""
+    if isinstance(axis, int):
+        axis_number = axis
+        if axis_number < 0:
+            axis_number += mesh.ndim
+        if axis_number < 0 or axis_number >= mesh.ndim:
+            raise ValueError(f"Mesh axis {axis} is out of bounds for mesh ndim {mesh.ndim}.")
+        return axis_number
+
+    dim_names = mesh.mesh_dim_names
+    if dim_names is None or axis not in dim_names:
+        raise ValueError(f"Mesh axis {axis!r} is not present in mesh dim names {dim_names}.")
+    return dim_names.index(axis)
+
+
+def build_dp_mesh(full_mesh: DeviceMesh, dp_axes: list[MeshAxis]) -> DeviceMesh:
+    """Select the data-parallel submesh of ``full_mesh``.
+
+    The submesh axes follow ``dp_axes`` order. When the DP axes cover the whole
+    mesh in order, the full mesh is returned unchanged (this also preserves
+    behavior for meshes without dim names). Otherwise the submesh is selected by
+    name, so a mesh with non-DP (tensor-parallel) axes must have dim names.
+    """
+    if not dp_axes:
+        raise ValueError("FSDP requires at least one data-parallel mesh axis.")
+
+    dp_axis_indices = tuple(axis_index(full_mesh, axis) for axis in dp_axes)
+    seen_axis_indices: set[int] = set()
+    for dp_axis_index in dp_axis_indices:
+        if dp_axis_index in seen_axis_indices:
+            raise ValueError(
+                f"Duplicate data-parallel mesh axis {dp_axis_index} in dp_axes {dp_axes!r}."
+            )
+        seen_axis_indices.add(dp_axis_index)
+
+    if dp_axis_indices == tuple(range(full_mesh.ndim)):
+        return full_mesh
+
+    dim_names = full_mesh.mesh_dim_names
+    if dim_names is None:
+        raise ValueError(
+            "A mesh with non-data-parallel axes must have dim names so the "
+            "data-parallel submesh can be selected by name."
+        )
+    dp_axis_names = tuple(dim_names[axis] for axis in dp_axis_indices)
+    return full_mesh[dp_axis_names[0]] if len(dp_axis_names) == 1 else full_mesh[dp_axis_names]

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -24,7 +24,7 @@ from torch.distributed import DeviceMesh
 from ..mixed_precision import MixedPrecisionPolicy
 from .indexed_order import IndexedOrder
 from .parameter_group import FsdpParameterGroup, get_containing_parameter_group
-from .placement import MeshAxis, Placements
+from .placement import Placements
 
 
 class FsdpContext:
@@ -99,15 +99,29 @@ class FsdpModule:
         mixed_precision_policy: MixedPrecisionPolicy,
         use_symm_mem: bool = False,
     ) -> None:
-        """Initialize FSDP runtime state on an already-constructed module."""
+        """Initialize FSDP runtime state on an already-constructed module.
+
+        Tensor-parallel placement is inferred from each parameter's own MCore /
+        Transformer Engine attributes, so any mesh axis not named in
+        ``placements.dp_axes`` is treated as the tensor-parallel axis.
+
+        Args:
+            mesh: Full user-provided device mesh. Its axis order is the source of
+                truth for the emitted DTensor placement tuple order.
+            placements: Per-DP-axis parameter, gradient, and optimizer placements,
+                ordered to match ``placements.dp_axes``.
+            mixed_precision_policy: Precision policy for main weights and gradients.
+            use_symm_mem: Allocate communication staging buffers from PyTorch's
+                NCCL symmetric-memory pool.
+        """
         self._context = None
         self._name = None
         self._unshard_event = None
         owned_parameters = _collect_owned_parameters(self)
-        axis_indices = tuple(_axis_index(mesh, axis) for axis in placements.dp_axes)
-        assert axis_indices == tuple(
-            range(mesh.ndim)
-        ), "FSDP requires dp_axes to match every mesh axis in mesh order for now."
+
+        # Each group owns the full user-provided mesh and placements so it can
+        # build optimizer-facing full-mesh DTensors; it derives the DP submesh
+        # handed to its DBuffers internally.
         parameter_groups = [
             FsdpParameterGroup(
                 owning_module=self,
@@ -356,21 +370,6 @@ def _collect_backward_order(module: nn.Module, order: IndexedOrder["FsdpModule"]
 
     for child in reversed(list(module.children())):
         _collect_backward_order(child, order)
-
-
-def _axis_index(mesh: DeviceMesh, axis: MeshAxis) -> int:
-    if isinstance(axis, int):
-        axis_index = axis
-        if axis_index < 0:
-            axis_index += mesh.ndim
-        if axis_index < 0 or axis_index >= mesh.ndim:
-            raise ValueError(f"Mesh axis {axis} is out of bounds for mesh ndim {mesh.ndim}.")
-        return axis_index
-
-    dim_names = mesh.mesh_dim_names
-    if dim_names is None or axis not in dim_names:
-        raise ValueError(f"Mesh axis {axis!r} is not present in mesh dim names {dim_names}.")
-    return dim_names.index(axis)
 
 
 def _collect_owned_parameters(root_module: nn.Module) -> dict[str, nn.Parameter]:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -21,9 +21,16 @@ import torch.distributed as dist
 import torch.distributed._symmetric_memory as symm_mem
 from torch import nn
 from torch.distributed import DeviceMesh
+from torch.distributed.tensor import DTensor
+from torch.distributed.tensor import Placement as DTensorPlacement
+from torch.distributed.tensor import Replicate as DTensorReplicate
+from torch.distributed.tensor import Shard as DTensorShard
 
 from ..mixed_precision import MixedPrecisionPolicy
+from ..utils import get_mcore_tensor_parallel_partition_dim
 from .dbuffer import DBuffer
+from .layout import contiguous_stride
+from .mesh_utils import build_dp_mesh
 from .placement import Partial, Placements, Replicate, changed_mesh_axis
 
 _CONTAINING_PARAMETER_GROUP_ATTR = "_mfsdp_parameter_group"
@@ -41,6 +48,9 @@ class FsdpParameterGroup:
     parameter_names: tuple[str, ...]
     sharded_parameters: tuple[nn.Parameter, ...]
     unsharded_parameters: tuple[nn.Parameter, ...]
+    # Full user-provided mesh. The DP submesh handed to the DBuffers lives on the
+    # DBuffers themselves (``main_weight.mesh`` etc.); ``get_dtensor`` lifts a
+    # DP-only DTensor back onto this full mesh.
     mesh: DeviceMesh
     dtype: torch.dtype
     requires_grad: bool
@@ -61,11 +71,24 @@ class FsdpParameterGroup:
     ) -> None:
         """Create persistent sharded buffers for a group of parameters.
 
+        The group owns the full user-provided ``mesh`` and ``placements`` because
+        it builds the optimizer-facing full-mesh DTensors. It derives the DP
+        submesh handed to its DBuffers, so ``placements`` is expressed on the
+        full mesh via ``placements.dp_axes``.
+
+        Tensor-parallel placement is inferred from each parameter's own MCore /
+        Transformer Engine attributes (``tensor_model_parallel``,
+        ``partition_dim``, ``partition_stride``), so callers do not pass TP
+        layouts separately. Parameters without those attributes are replicated
+        over the tensor-parallel axis.
+
         Args:
             owning_module: Closest FSDP root module that owns this parameter group.
             parameters: Root-module-relative FQNs and their parameters.
-            mesh: Device mesh used for all DBuffer storage in this version.
-            placements: Parameter, gradient, and optimizer placements.
+            mesh: Full user-provided device mesh. Its axis order is the source of
+                truth for the emitted DTensor placement tuple order.
+            placements: Per-DP-axis parameter, gradient, and optimizer placements,
+                ordered to match ``placements.dp_axes``.
             mixed_precision_policy: Precision policy for main weights and gradients.
             use_symm_mem: Allocate communication staging buffers from PyTorch's
                 NCCL symmetric-memory pool.
@@ -73,15 +96,25 @@ class FsdpParameterGroup:
         if not parameters:
             raise ValueError("FsdpParameterGroup requires at least one parameter.")
 
+        # This group owns the full mesh; the DBuffers below own the DP submesh.
+        # The DP placement lists are already aligned with the DP submesh, whose
+        # axes follow dp_axes order.
+        self.owning_module = owning_module
+        self.mesh = mesh
+        dp_mesh = build_dp_mesh(mesh, placements.dp_axes)
         model_weight_placements = tuple(placements.parameter)
         main_grad_placements = tuple(placements.gradient)
         main_weight_placements = tuple(placements.optimizer)
 
         # Python dicts preserve insertion order, so parameter_names and
         # parameters.values() define the same stable DBuffer tensor order.
-        self.owning_module = owning_module
-        self.mesh = mesh
         self.parameter_names = tuple(parameters)
+        # Infer TP placements up front so unsupported layouts fail before any
+        # buffer is allocated. These are only needed to build the sharded
+        # parameters below, so keep them local instead of a persistent field.
+        parameter_tp_placements = [
+            self._tp_placement(name, parameter) for name, parameter in parameters.items()
+        ]
         first_parameter = next(iter(parameters.values()))
         self.dtype = first_parameter.dtype
         self.requires_grad = first_parameter.requires_grad
@@ -101,7 +134,7 @@ class FsdpParameterGroup:
         main_weight_dtype = mixed_precision_policy.main_params_dtype or torch.float32
         self.main_weight = DBuffer.distribute_tensors(
             (parameter.to(dtype=main_weight_dtype) for parameter in parameters.values()),
-            mesh=self.mesh,
+            mesh=dp_mesh,
             placements=main_weight_placements,
         )
 
@@ -114,8 +147,8 @@ class FsdpParameterGroup:
 
         with self._symmetric_memory_context():
             self._unsharded_model_weight = DBuffer(
-                mesh=self.mesh,
-                placements=[Replicate()] * self.mesh.ndim,
+                mesh=dp_mesh,
+                placements=[Replicate()] * dp_mesh.ndim,
                 tensor_shapes=tensor_shapes,
                 dtype=self.dtype,
                 device=self.main_weight.device,
@@ -124,7 +157,7 @@ class FsdpParameterGroup:
             self.model_weight = self.main_weight
         else:
             self.model_weight = DBuffer(
-                mesh=self.mesh,
+                mesh=dp_mesh,
                 placements=model_weight_placements,
                 tensor_shapes=tensor_shapes,
                 dtype=self.dtype,
@@ -140,7 +173,7 @@ class FsdpParameterGroup:
             # storage during forward. That requires a separate lifetime contract with
             # the optimizer, so this version keeps the simpler persistent buffer.
             self.main_grad = DBuffer(
-                mesh=self.mesh,
+                mesh=dp_mesh,
                 placements=main_grad_placements,
                 tensor_shapes=self.main_weight.layout.tensor_shapes,
                 dtype=grad_dtype,
@@ -163,7 +196,8 @@ class FsdpParameterGroup:
             unsharded_parameters.append(parameter)
 
             sharded_parameter = nn.Parameter(
-                self.main_weight.get_dtensor(index), requires_grad=parameter.requires_grad
+                self.get_dtensor(self.main_weight, index, parameter_tp_placements[index]),
+                requires_grad=parameter.requires_grad,
             )
             if main_grad_dtype:
                 sharded_parameter.grad_dtype = main_grad_dtype
@@ -177,6 +211,88 @@ class FsdpParameterGroup:
         self.sync_model_weight_from_main_weight()
         self._switch_to_sharded_parameters()
         self._unsharded_model_weight.release_storage()
+
+    def _tp_placement(self, name: str, parameter: nn.Parameter) -> DTensorPlacement:
+        """Infer a parameter's tensor-parallel placement from its MCore/TE attrs.
+
+        Classic MCore and TE parameters carry ``tensor_model_parallel`` /
+        ``partition_dim`` (``partition_dim`` 0 is column-parallel ``Shard(0)``, 1
+        is row-parallel ``Shard(1)``); parameters without those attributes are
+        replicated. This is the semantic TP layout only -- ``get_dtensor`` maps it
+        onto the actual tensor-parallel mesh axis.
+        """
+        partition_dim = get_mcore_tensor_parallel_partition_dim(parameter)
+        if partition_dim is None:
+            return DTensorReplicate()
+
+        partition_stride = int(getattr(parameter, "partition_stride", 1))
+        if partition_stride != 1:
+            # Strided tensor-parallel sharding (for example fused QKV) cannot be
+            # expressed as a canonical Shard without losing ordering information.
+            # Reject it rather than silently mislabel it; strided TP is a
+            # deliberately deferred follow-up.
+            raise NotImplementedError(
+                f"Strided tensor-parallel sharding is not supported yet: {name!r} has "
+                f"partition_stride={partition_stride}."
+            )
+        return DTensorShard(partition_dim)
+
+    def get_dtensor(self, buffer: DBuffer, index: int, tp_placement: DTensorPlacement) -> DTensor:
+        """Lift a DBuffer's DP-only DTensor onto this group's full mesh.
+
+        ``buffer.get_dtensor`` returns a DTensor on the DP submesh; this re-wraps
+        it on ``self.mesh``, splicing ``tp_placement`` onto the single non-DP
+        (tensor-parallel) axis and scaling the sharded dimension to the global
+        shape. A pure-data-parallel group has no TP axis, so the DP DTensor
+        already spans the full mesh and is returned unchanged.
+
+        This method is the only place that maps DP mesh axes to full-mesh axes; it
+        recovers the correspondence from the two meshes' dim names.
+        """
+        dp_dtensor = buffer.get_dtensor(index)
+        full_mesh = self.mesh
+        dp_mesh = dp_dtensor.device_mesh
+        if dp_mesh.ndim == full_mesh.ndim:
+            # DP spans the whole mesh; there is no tensor-parallel axis to add.
+            return dp_dtensor
+
+        full_dim_names = full_mesh.mesh_dim_names
+        dp_dim_names = dp_mesh.mesh_dim_names
+        full_placements: list[DTensorPlacement | None] = [None] * full_mesh.ndim
+        dp_full_axes: set[int] = set()
+        for dp_axis, dp_dim_name in enumerate(dp_dim_names):
+            full_axis = full_dim_names.index(dp_dim_name)
+            full_placements[full_axis] = dp_dtensor.placements[dp_axis]
+            dp_full_axes.add(full_axis)
+
+        tp_axes = [axis for axis in range(full_mesh.ndim) if axis not in dp_full_axes]
+        if len(tp_axes) != 1:
+            raise NotImplementedError(
+                f"Only a single tensor-parallel axis is supported, got {len(tp_axes)}."
+            )
+        (tp_axis,) = tp_axes
+        full_placements[tp_axis] = tp_placement
+
+        # dp_dtensor.shape is the TP-local global shape (DP sharding does not change
+        # it). Scale the tensor-parallel sharded dimension up to the global shape.
+        global_shape = list(dp_dtensor.shape)
+        if isinstance(tp_placement, DTensorShard):
+            if tp_placement.dim < 0 or tp_placement.dim >= len(global_shape):
+                raise ValueError(
+                    f"Tensor-parallel Shard dim {tp_placement.dim} is out of bounds for "
+                    f"shape {tuple(dp_dtensor.shape)}."
+                )
+            global_shape[tp_placement.dim] *= full_mesh.size(tp_axis)
+        global_shape = torch.Size(global_shape)
+
+        return DTensor.from_local(
+            dp_dtensor.to_local(),
+            device_mesh=full_mesh,
+            placements=tuple(full_placements),
+            run_check=False,
+            shape=global_shape,
+            stride=contiguous_stride(global_shape),
+        )
 
     def _symmetric_memory_context(self):
         if self._symm_mem_pool is None:
@@ -254,7 +370,13 @@ class FsdpParameterGroup:
         """Point each sharded parameter's grad at main_grad's current DTensor view."""
         assert self.main_grad is not None
         for index, sharded_parameter in enumerate(self.sharded_parameters):
-            sharded_parameter.grad = self.main_grad.get_dtensor(index)
+            # The gradient shares the parameter's TP placement (its DP placement
+            # follows main_grad, which get_dtensor reads off the buffer). Re-infer
+            # the TP placement from the parameter's attrs rather than storing it.
+            tp_placement = self._tp_placement(
+                self.parameter_names[index], self.unsharded_parameters[index]
+            )
+            sharded_parameter.grad = self.get_dtensor(self.main_grad, index, tp_placement)
 
     def allocate_partial_grad_buffer(self) -> DBuffer:
         """Allocate the unreduced reduce-scatter input buffer."""
@@ -268,10 +390,11 @@ class FsdpParameterGroup:
             if parameter.grad is None:
                 raise RuntimeError(f"Missing gradient for FSDP parameter {name!r}.")
             grads.append(parameter.grad)
+        dp_mesh = self.main_grad.mesh
         with self._symmetric_memory_context():
             return DBuffer(
-                mesh=self.mesh,
-                placements=[Partial(partial_op)] * self.mesh.ndim,
+                mesh=dp_mesh,
+                placements=[Partial(partial_op)] * dp_mesh.ndim,
                 tensor_shapes=tuple(grad.shape for grad in grads),
                 dtype=grads[0].dtype,
                 device=grads[0].device,
@@ -331,7 +454,9 @@ class FsdpParameterGroup:
         if reduce_axis is None:
             raise RuntimeError("FSDP gradient reduction requires a changed placement axis.")
         partial_reduce_op = partial_grad.placements[reduce_axis].reduce_op
-        grad_divisor = self.mesh.size(reduce_axis) if partial_reduce_op == dist.ReduceOp.SUM else 1
+        grad_divisor = (
+            self.main_grad.mesh.size(reduce_axis) if partial_reduce_op == dist.ReduceOp.SUM else 1
+        )
         if self._symm_mem_pool is not None:
             partial_grad.rendezvous(reduce_axis)
         if can_reduce_into_main_grad:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/placement.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/placement.py
@@ -33,6 +33,7 @@ import dataclasses
 from collections.abc import Iterable
 
 import torch.distributed as dist
+import torch.distributed.tensor as dist_tensor
 
 
 class Placement:
@@ -57,6 +58,28 @@ class Partial(Placement):
 @dataclasses.dataclass(frozen=True)
 class Flat(Placement):
     """Flat dim-0 sharded local buffer placement."""
+
+
+def to_dtensor_placement(placement: Placement) -> dist_tensor.Placement:
+    """Convert a DBuffer placement to its equivalent DTensor placement.
+
+    ``Flat`` shards dim 0 in the flattened local buffer, so it maps to
+    ``Shard(0)``. ``Replicate`` and ``Partial`` mirror the DTensor placements
+    of the same name.
+    """
+    if isinstance(placement, Replicate):
+        return dist_tensor.Replicate()
+    if isinstance(placement, Flat):
+        return dist_tensor.Shard(0)
+    if isinstance(placement, Partial):
+        # main_grad backs .grad while it rests DP-outer-Partial between
+        # microbatches, so a Partial placement must round-trip to a DTensor.
+        if placement.reduce_op == dist.ReduceOp.AVG:
+            return dist_tensor.Partial("avg")
+        if placement.reduce_op == dist.ReduceOp.SUM:
+            return dist_tensor.Partial("sum")
+        raise ValueError(f"Unsupported Partial reduce op for DTensor: {placement.reduce_op!r}.")
+    raise TypeError(f"Unsupported placement for DTensor conversion: {placement!r}.")
 
 
 def changed_mesh_axis(

--- a/tests/unit_tests/distributed/mfsdp_v2/test_tensor_parallel.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_tensor_parallel.py
@@ -17,6 +17,7 @@ Run under torchrun with four ranks, for example::
 
 import pytest
 import torch
+import torch.distributed as dist
 from torch import nn
 from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.tensor import DTensor, Replicate, Shard
@@ -26,7 +27,13 @@ from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
     Placements,
     fully_shard,
 )
-from megatron.core.tensor_parallel.layers import set_tensor_model_parallel_attributes
+from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.tensor_parallel.layers import (
+    ColumnParallelLinear,
+    RowParallelLinear,
+    set_tensor_model_parallel_attributes,
+)
+from megatron.core.transformer.transformer_config import TransformerConfig
 
 
 class TpModule(nn.Module):
@@ -198,3 +205,146 @@ def test_optimizer_state_lives_on_full_mesh(distributed_setup):
         after = parameter.to_local()
         assert not torch.equal(after, before_tensor)
         torch.testing.assert_close(after, reference_parameter.detach())
+
+
+class TpMlp(nn.Module):
+    """A column-parallel -> GELU -> row-parallel MLP of real MCore TP layers.
+
+    The tensor-parallel layers carry out their own TP collectives (column has no
+    forward all-reduce; row all-reduces its output), so this computes the same
+    function as the unsharded ``RefMlp`` below, which is what makes a loss-curve
+    comparison meaningful.
+    """
+
+    def __init__(self, config: TransformerConfig, tp_group, hidden: int, ffn: int) -> None:
+        super().__init__()
+        self.fc1 = ColumnParallelLinear(
+            input_size=hidden,
+            output_size=ffn,
+            config=config,
+            init_method=config.init_method,
+            bias=True,
+            gather_output=False,
+            skip_bias_add=False,
+            tp_group=tp_group,
+        )
+        self.fc2 = RowParallelLinear(
+            input_size=ffn,
+            output_size=hidden,
+            config=config,
+            init_method=config.init_method,
+            bias=True,
+            input_is_parallel=True,
+            skip_bias_add=False,
+            tp_group=tp_group,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the tensor-parallel MLP; the linears return ``(output, bias)``."""
+        hidden, _ = self.fc1(x)
+        hidden = torch.nn.functional.gelu(hidden)
+        output, _ = self.fc2(hidden)
+        return output
+
+
+class RefMlp(nn.Module):
+    """A plain, un-tensor-parallel MLP matching ``TpMlp``'s full weights."""
+
+    def __init__(self, hidden: int, ffn: int) -> None:
+        super().__init__()
+        self.fc1 = nn.Linear(hidden, ffn)
+        self.fc2 = nn.Linear(ffn, hidden)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the reference MLP."""
+        return self.fc2(torch.nn.functional.gelu(self.fc1(x)))
+
+
+def _all_gather_cat(local: torch.Tensor, group, dim: int) -> torch.Tensor:
+    """All-gather a tensor-parallel shard across ``group`` and concatenate on ``dim``."""
+    shards = [torch.empty_like(local) for _ in range(dist.get_world_size(group))]
+    dist.all_gather(shards, local.contiguous(), group=group)
+    return torch.cat(shards, dim=dim)
+
+
+def test_fsdp_tp_loss_curve_matches_unsharded(distributed_setup):
+    """FSDP+TP training should track an unsharded single-replica reference loss curve."""
+    if distributed_setup.world_size != 4:
+        pytest.skip("This test requires exactly 4 ranks for a DP=2, TP=2 mesh.")
+    device = distributed_setup.device
+    if device.type != "cuda":
+        pytest.skip("MCore tensor-parallel layers require CUDA ranks.")
+
+    tp_size, dp_size = 2, 2
+    hidden, ffn, batch, steps = 8, 16, 4, 5
+
+    # init_device_mesh lays ranks out row-major (tp innermost), so the tp axis is a
+    # contiguous 2-rank group -- exactly the tensor-parallel group the TP layers use.
+    # Pass those groups explicitly (via ProcessGroupCollection) instead of mutating
+    # global parallel_state, so this test never depends on MPU init.
+    mesh = init_device_mesh(device.type, (dp_size, tp_size), mesh_dim_names=("dp", "tp"))
+    pg_collection = ProcessGroupCollection()
+    pg_collection.tp = mesh.get_group("tp")
+    pg_collection.dp = mesh.get_group("dp")
+
+    # CPU initialization derives the shard rank/size from tp_group and needs no
+    # model-parallel RNG tracker. With the same seed on every rank, each rank builds
+    # the identical full master weight and keeps its own slice, so all-gathering the
+    # slices reconstructs the full weight for the reference.
+    config = TransformerConfig(
+        num_layers=1,
+        hidden_size=hidden,
+        num_attention_heads=1,
+        tensor_model_parallel_size=tp_size,
+        # FSDP tracks gradients through .grad, not a fused weight.main_grad.
+        gradient_accumulation_fusion=False,
+        sequence_parallel=False,
+        use_cpu_initialization=True,
+    )
+
+    torch.manual_seed(1234)
+    model = TpMlp(config, pg_collection.tp, hidden, ffn).to(device)
+
+    # Rebuild the full (un-TP-sharded) weights before FSDP shards across DP, and
+    # load them into the reference so both models start bit-identical.
+    reference = RefMlp(hidden, ffn).to(device)
+    with torch.no_grad():
+        reference.fc1.weight.copy_(_all_gather_cat(model.fc1.weight, pg_collection.tp, dim=0))
+        reference.fc1.bias.copy_(_all_gather_cat(model.fc1.bias, pg_collection.tp, dim=0))
+        reference.fc2.weight.copy_(_all_gather_cat(model.fc2.weight, pg_collection.tp, dim=1))
+        # Row-parallel bias is added after the output all-reduce, so it is replicated.
+        reference.fc2.bias.copy_(model.fc2.bias)
+
+    fully_shard(model.fc1, mesh=mesh, placements=_dp_placements())
+    fully_shard(model.fc2, mesh=mesh, placements=_dp_placements())
+
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+    reference_optimizer = torch.optim.SGD(reference.parameters(), lr=0.1)
+
+    # Every rank sees the same input: TP ranks must (TP replicates the input), and
+    # giving every DP rank the same data makes the DP-averaged gradient equal the
+    # single-replica gradient, so each step's loss matches the reference.
+    torch.manual_seed(2024)
+    x = torch.randn(steps, batch, hidden, device=device)
+    target = torch.randn(steps, batch, hidden, device=device)
+
+    def train(module, module_optimizer):
+        losses = []
+        for step in range(steps):
+            module_optimizer.zero_grad(set_to_none=True)
+            loss = torch.nn.functional.mse_loss(module(x[step]), target[step])
+            loss.backward()
+            module_optimizer.step()
+            losses.append(loss.detach())
+        return losses
+
+    reference_losses = train(reference, reference_optimizer)
+    fsdp_losses = train(model, optimizer)
+
+    torch.testing.assert_close(
+        torch.stack(fsdp_losses),
+        torch.stack(reference_losses),
+        rtol=1e-3,
+        atol=1e-4,
+        msg="FSDP+TP loss curve did not match the unsharded reference.",
+    )

--- a/tests/unit_tests/distributed/mfsdp_v2/test_tensor_parallel.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_tensor_parallel.py
@@ -1,0 +1,200 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Unit tests for Megatron-FSDP v2 tensor-parallel composability.
+
+These tests establish the DP+TP mesh-ownership contract on a DP=2, TP=2 mesh:
+
+- ``DBuffer`` owns only the data-parallel submesh.
+- ``FsdpParameterGroup`` owns the full user-provided mesh and builds
+  optimizer-facing DTensors that carry both DP and TP placements.
+- The emitted DTensor placement tuple follows the user-provided mesh-axis order.
+
+Run under torchrun with four ranks, for example::
+
+    torchrun --nproc-per-node 4 -m pytest -q \
+        tests/unit_tests/distributed/mfsdp_v2/test_tensor_parallel.py
+"""
+
+import pytest
+import torch
+from torch import nn
+from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.tensor import DTensor, Replicate, Shard
+
+from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
+    Flat,
+    Placements,
+    fully_shard,
+)
+from megatron.core.tensor_parallel.layers import set_tensor_model_parallel_attributes
+
+
+class TpModule(nn.Module):
+    """Module holding column-, row-, and replicated-parallel parameters.
+
+    Parameters are stored TP-local (as classic MCore / TE parameters are) and
+    carry the MCore tensor-parallel attributes that ``fully_shard`` infers
+    placement from. The module never runs forward; these tests only inspect the
+    sharded-parameter and optimizer-state metadata that ``fully_shard`` installs.
+    """
+
+    tp_size = 2
+    # Global (un-TP-sharded) parameter shapes.
+    global_shapes = {
+        "column_weight": torch.Size((16, 8)),  # column-parallel: shard out (dim 0)
+        "row_weight": torch.Size((8, 8)),  # row-parallel: shard in (dim 1)
+        "bias": torch.Size((8,)),  # replicated across TP
+    }
+
+    def __init__(self) -> None:
+        super().__init__()
+        column = self.global_shapes["column_weight"]
+        self.column_weight = nn.Parameter(torch.randn(column[0] // self.tp_size, column[1]))
+        set_tensor_model_parallel_attributes(self.column_weight, is_parallel=True, dim=0, stride=1)
+
+        row = self.global_shapes["row_weight"]
+        self.row_weight = nn.Parameter(torch.randn(row[0], row[1] // self.tp_size))
+        set_tensor_model_parallel_attributes(self.row_weight, is_parallel=True, dim=1, stride=1)
+
+        # bias carries no tensor-parallel attributes, so it is replicated over TP.
+        self.bias = nn.Parameter(torch.randn(self.global_shapes["bias"]))
+
+
+def _dp_placements() -> Placements:
+    return Placements(dp_axes=["dp"], parameter=[Flat()], gradient=[Flat()], optimizer=[Flat()])
+
+
+def _build_sharded_model(device, mesh_dim_names: tuple[str, str]) -> tuple[nn.Module, object]:
+    """Shard a fresh TpModule on a DP=2, TP=2 mesh with the given axis order."""
+    mesh = init_device_mesh(device.type, (2, 2), mesh_dim_names=mesh_dim_names)
+    torch.manual_seed(2026)
+    model = TpModule().to(device)
+    fully_shard(model, mesh=mesh, placements=_dp_placements())
+    return model, mesh
+
+
+def _sharded_parameter(model: nn.Module, name: str) -> nn.Parameter:
+    (group,) = model.parameter_groups
+    index = group.parameter_names.index(name)
+    return group.sharded_parameters[index]
+
+
+def _skip_unless_four_ranks(distributed_setup) -> None:
+    if distributed_setup.world_size != 4:
+        pytest.skip("This test requires exactly 4 ranks for a DP=2, TP=2 mesh.")
+    if distributed_setup.device.type != "cuda":
+        pytest.skip("DTensor.from_local for these tests requires CUDA ranks.")
+
+
+def test_dbuffer_mesh_is_dp_only(distributed_setup):
+    """The group owns the full mesh (4 ranks); its DBuffers own the DP submesh (2 ranks)."""
+    _skip_unless_four_ranks(distributed_setup)
+    device = distributed_setup.device
+
+    for mesh_dim_names in (("dp", "tp"), ("tp", "dp")):
+        model, mesh = _build_sharded_model(device, mesh_dim_names)
+        (group,) = model.parameter_groups
+
+        assert mesh.size() == 4
+        # The parameter group keeps the full user mesh.
+        assert group.mesh is mesh
+        # Every DBuffer owns only the DP submesh.
+        assert group.main_weight.mesh.ndim == 1
+        assert group.main_weight.mesh.size() == 2
+        assert group.main_grad is not None
+        assert group.main_grad.mesh.size() == 2
+
+
+def test_full_mesh_parameter_placements_dp_tp(distributed_setup):
+    """Sharded parameters carry both DP and TP placements in [dp, tp] mesh order."""
+    _skip_unless_four_ranks(distributed_setup)
+    device = distributed_setup.device
+    model, mesh = _build_sharded_model(device, ("dp", "tp"))
+
+    expected = {
+        # DP is axis 0, TP is axis 1.
+        "column_weight": (Shard(0), Shard(0)),  # DP shard(0), TP shard(0)
+        "row_weight": (Shard(0), Shard(1)),  # DP shard(0), TP shard(1)
+        "bias": (Shard(0), Replicate()),  # DP shard(0), TP replicate
+    }
+    for name, expected_placements in expected.items():
+        parameter = _sharded_parameter(model, name)
+        assert isinstance(parameter.data, DTensor)
+        assert parameter.device_mesh == mesh
+        assert parameter.placements == expected_placements, name
+
+
+def test_full_mesh_parameter_placements_tp_dp(distributed_setup):
+    """Reversing the mesh-axis order reverses the DTensor placement tuple."""
+    _skip_unless_four_ranks(distributed_setup)
+    device = distributed_setup.device
+    model, mesh = _build_sharded_model(device, ("tp", "dp"))
+
+    expected = {
+        # TP is axis 0, DP is axis 1.
+        "column_weight": (Shard(0), Shard(0)),
+        "row_weight": (Shard(1), Shard(0)),
+        "bias": (Replicate(), Shard(0)),
+    }
+    for name, expected_placements in expected.items():
+        parameter = _sharded_parameter(model, name)
+        assert parameter.device_mesh == mesh
+        assert parameter.placements == expected_placements, name
+
+
+def test_full_mesh_global_shape_and_stride(distributed_setup):
+    """Sharded parameters reconstruct the global shape and contiguous stride."""
+    _skip_unless_four_ranks(distributed_setup)
+    device = distributed_setup.device
+    model, _ = _build_sharded_model(device, ("dp", "tp"))
+
+    for name, global_shape in TpModule.global_shapes.items():
+        parameter = _sharded_parameter(model, name)
+        assert parameter.shape == global_shape, name
+        expected_stride = torch.empty(global_shape).stride()
+        assert parameter.stride() == expected_stride, name
+
+
+def test_optimizer_state_lives_on_full_mesh(distributed_setup):
+    """Adam state should inherit the parameter's full mesh and placements."""
+    _skip_unless_four_ranks(distributed_setup)
+    device = distributed_setup.device
+    model, mesh = _build_sharded_model(device, ("dp", "tp"))
+
+    parameters = list(model.parameters())
+    # No forward here; feed each sharded parameter a matching DTensor gradient so
+    # a single Adam step exercises optimizer-state materialization.
+    for parameter in parameters:
+        parameter.grad = torch.ones_like(parameter)
+
+    before = [parameter.to_local().detach().clone() for parameter in parameters]
+    reference = [tensor.clone() for tensor in before]
+
+    # foreach=False forces the per-parameter path so Adam never buckets sharded
+    # parameters with different TP placements into one _foreach call.
+    optimizer = torch.optim.Adam(parameters, lr=0.1, foreach=False)
+    optimizer.step()
+
+    for parameter in parameters:
+        state = optimizer.state[parameter]
+        for key in ("exp_avg", "exp_avg_sq"):
+            moment = state[key]
+            assert isinstance(moment, DTensor), key
+            assert moment.device_mesh == mesh
+            assert moment.placements == parameter.placements
+
+    # One elementwise Adam step on the DTensor must match the same step applied to
+    # a plain local tensor with an all-ones gradient (unsharded local reference).
+    reference_optimizer = torch.optim.Adam(
+        [torch.nn.Parameter(tensor) for tensor in reference], lr=0.1, foreach=False
+    )
+    for reference_parameter in reference_optimizer.param_groups[0]["params"]:
+        reference_parameter.grad = torch.ones_like(reference_parameter)
+    reference_optimizer.step()
+
+    for parameter, before_tensor, reference_parameter in zip(
+        parameters, before, reference_optimizer.param_groups[0]["params"]
+    ):
+        after = parameter.to_local()
+        assert not torch.equal(after, before_tensor)
+        torch.testing.assert_close(after, reference_parameter.detach())

--- a/tests/unit_tests/distributed/mfsdp_v2/test_tensor_parallel.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_tensor_parallel.py
@@ -297,7 +297,9 @@ def test_fsdp_tp_loss_curve_matches_unsharded(distributed_setup):
     config = TransformerConfig(
         num_layers=1,
         hidden_size=hidden,
-        num_attention_heads=1,
+        # This MLP has no attention, but TransformerConfig validates that heads
+        # divide tensor_model_parallel_size regardless, so keep it a multiple.
+        num_attention_heads=tp_size,
         tensor_model_parallel_size=tp_size,
         # FSDP tracks gradients through .grad, not a fused weight.main_grad.
         gradient_accumulation_fusion=False,

--- a/tests/unit_tests/distributed/mfsdp_v2/test_tensor_parallel.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_tensor_parallel.py
@@ -203,7 +203,10 @@ def test_optimizer_state_lives_on_full_mesh(distributed_setup):
         parameters, before, reference_optimizer.param_groups[0]["params"]
     ):
         after = parameter.to_local()
-        assert not torch.equal(after, before_tensor)
+        # Flat DP packing gives some ranks no shard of a given tensor (dp rank 0
+        # here owns only column_weight), and an empty shard has nothing to update.
+        if after.numel():
+            assert not torch.equal(after, before_tensor)
         torch.testing.assert_close(after, reference_parameter.detach())
 
 


### PR DESCRIPTION
## What

Adds data-parallel + tensor-parallel (DP+TP) composability to the experimental
Megatron-FSDP path (`megatron/core/distributed/fsdp/src/megatron_fsdp/experimental`),
implementing phases 1–3 of the design in
`docs/discussions/mfsdp-v2-tp-composability-plan.md` (included here).

Optimizer state and checkpoints now see full-mesh DTensors carrying both DP and
TP placements, while compute keeps ordinary TP-local parameters and FSDP never
gathers across the TP axis.

## Design

- **DBuffer** owns only the data-parallel submesh (storage, layouts,
  collectives) and constructs DP-only DTensors.
- **FsdpParameterGroup** owns the full user-provided mesh. Its `get_dtensor`
  lifts a DBuffer's DP-only DTensor onto the full mesh, splicing the
  tensor-parallel placement onto the single non-DP axis and scaling the sharded
  dimension to the global shape. This is the only place that maps DP mesh axes
  to full-mesh axes, recovering the correspondence from the two meshes' dim names.
- **TP placement is inferred** from each parameter's own MCore / Transformer
  Engine attributes (`tensor_model_parallel` / `partition_dim`), so callers pass
  no separate TP layout. The emitted DTensor placement tuple follows the
  user-provided mesh-axis order, so `[dp, tp]` and `[tp, dp]` place the same
  parameter symmetrically.
- `mesh_utils.build_dp_mesh` derives the DP submesh from the full mesh.

## Tests

`tests/unit_tests/distributed/mfsdp_v2/test_tensor_parallel.py` (4 ranks, DP=2 × TP=2):
- DP-only DBuffers, full-mesh placements in both axis orders, global
  shape/stride, and optimizer-state metadata.
- A loss-curve parity test: a real `ColumnParallelLinear` → GELU →
  `RowParallelLinear` MLP wrapped in `fully_shard` tracks an unsharded
  single-replica reference. Process groups are passed explicitly via
  `ProcessGroupCollection` (no global `parallel_state` mutation).

Requires a 4-GPU job.

## Out of scope (follow-ups)

TE/MCore adapter breadth, DCP resharding across a changed DP degree, HSDP+TP
composition, and strided (`partition_stride > 1`) TP layouts, which are rejected
for now.
