### PR TITLE
Normalize MFSDP data-parallel axes at fully_shard

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
@@ -14,6 +14,7 @@
 
 """Minimal Megatron-FSDP fully_shard entrypoint."""
 
+import dataclasses
 from collections.abc import Iterator
 from contextlib import contextmanager
 
@@ -22,7 +23,7 @@ from torch.distributed import DeviceMesh
 
 from ..mixed_precision import MixedPrecisionPolicy
 from .module import FsdpContext, FsdpModule
-from .placement import Placements
+from .placement import MeshAxis, Placements
 
 
 def fully_shard(
@@ -49,6 +50,7 @@ def fully_shard(
     if isinstance(module, FsdpModule):
         raise ValueError("This module is already managed by FSDP.")
 
+    placements = _normalize_placements(mesh, placements)
     mixed_precision_policy = mixed_precision_policy or MixedPrecisionPolicy()
     original_cls = module.__class__
     _attach_mixin(module)
@@ -64,6 +66,27 @@ def fully_shard(
     except Exception:
         module.__class__ = original_cls
         raise
+
+
+def _normalize_placements(mesh: DeviceMesh, placements: Placements) -> Placements:
+    """Return a copy with data-parallel mesh axes normalized to integer indices."""
+    dp_axes = tuple(_axis_index(mesh, axis) for axis in placements.dp_axes)
+    return dataclasses.replace(placements, dp_axes=dp_axes)
+
+
+def _axis_index(mesh: DeviceMesh, axis: MeshAxis) -> int:
+    if isinstance(axis, int):
+        axis_index = axis
+        if axis_index < 0:
+            axis_index += mesh.ndim
+        if axis_index < 0 or axis_index >= mesh.ndim:
+            raise ValueError(f"Mesh axis {axis} is out of bounds for mesh ndim {mesh.ndim}.")
+        return axis_index
+
+    dim_names = mesh.mesh_dim_names
+    if dim_names is None or axis not in dim_names:
+        raise ValueError(f"Mesh axis {axis!r} is not present in mesh dim names {dim_names}.")
+    return dim_names.index(axis)
 
 
 @contextmanager

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -24,7 +24,7 @@ from torch.distributed import DeviceMesh
 from ..mixed_precision import MixedPrecisionPolicy
 from .indexed_order import IndexedOrder
 from .parameter_group import FsdpParameterGroup, get_containing_parameter_group
-from .placement import MeshAxis, Placements
+from .placement import Placements
 
 
 class FsdpContext:
@@ -104,8 +104,7 @@ class FsdpModule:
         self._name = None
         self._unshard_event = None
         owned_parameters = _collect_owned_parameters(self)
-        axis_indices = tuple(_axis_index(mesh, axis) for axis in placements.dp_axes)
-        assert axis_indices == tuple(
+        assert tuple(placements.dp_axes) == tuple(
             range(mesh.ndim)
         ), "FSDP requires dp_axes to match every mesh axis in mesh order for now."
         parameter_groups = [
@@ -356,21 +355,6 @@ def _collect_backward_order(module: nn.Module, order: IndexedOrder["FsdpModule"]
 
     for child in reversed(list(module.children())):
         _collect_backward_order(child, order)
-
-
-def _axis_index(mesh: DeviceMesh, axis: MeshAxis) -> int:
-    if isinstance(axis, int):
-        axis_index = axis
-        if axis_index < 0:
-            axis_index += mesh.ndim
-        if axis_index < 0 or axis_index >= mesh.ndim:
-            raise ValueError(f"Mesh axis {axis} is out of bounds for mesh ndim {mesh.ndim}.")
-        return axis_index
-
-    dim_names = mesh.mesh_dim_names
-    if dim_names is None or axis not in dim_names:
-        raise ValueError(f"Mesh axis {axis!r} is not present in mesh dim names {dim_names}.")
-    return dim_names.index(axis)
 
 
 def _collect_owned_parameters(root_module: nn.Module) -> dict[str, nn.Parameter]:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/placement.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/placement.py
@@ -30,7 +30,7 @@ sharded        ``Replicate``  ``allgather()``
 """
 
 import dataclasses
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 
 import torch.distributed as dist
 
@@ -82,7 +82,7 @@ def changed_mesh_axis(
 class Placements:
     """Per-mesh-axis placements for parameter, gradient, and optimizer buffers."""
 
-    dp_axes: list[MeshAxis]
+    dp_axes: Sequence[MeshAxis]
     parameter: list[Placement]
     gradient: list[Placement]
     optimizer: list[Placement]


### PR DESCRIPTION
This way, the internal code can assume `dp_axes` is simply a list of integers. 

Looking ahead, **if** needed, #5971 can further tighten the internal contract by restricting the Placements class to the user-facing API.