### PR TITLE
[fix] Fix GTP full-iteration CUDA-graph capture regression

### DIFF
--- a/megatron/core/distributed/distributed_data_parallel.py
+++ b/megatron/core/distributed/distributed_data_parallel.py
@@ -373,28 +373,25 @@ class DistributedDataParallel(_BaseDataParallel):
                                         self._make_backward_post_hook(param)
                                     )
                                     break
-                elif getattr(param, 'is_gtp_weight_remat', False) and hasattr(
-                    param, 'register_grad_accum_hook'
-                ):
-                    # GTP_remat computes wgrad via an async reduce-scatter on a side stream, so
-                    # autograd's AccumulateGrad receives only a dummy; grad-ready is driven
-                    # manually from _handle_megatron_grad_accum after the RS finalize (passed as
-                    # the hook below). We materialize the AccumulateGrad node and hand it to
-                    # register_grad_accum_hook, which RETAINS it — keeping it live places it on
-                    # the capture stream like a normal param, so full-iteration CUDA-graph capture
-                    # doesn't trip on a leaf node stranded on the default/legacy stream. It is NOT
-                    # added to grad_accs (that list is for autograd-hooked nodes), and the DDP
-                    # post-hook is not registered on it (that would fire grad-ready early).
-                    param_tmp = param.expand_as(param)
-                    grad_acc = param_tmp.grad_fn.next_functions[0][0]
-                    param.register_grad_accum_hook(grad_acc, self._make_backward_post_hook(param))
                 else:
                     # Expand so we get access to grad_fn.
                     param_tmp = param.expand_as(param)
                     # Get the gradient accumulator function.
                     grad_acc = param_tmp.grad_fn.next_functions[0][0]
-                    grad_acc.register_hook(self._make_backward_post_hook(param))
-                    self.grad_accs.append(grad_acc)
+                    if getattr(param, 'is_gtp_weight_remat', False) and hasattr(
+                        param, 'register_grad_accum_hook'
+                    ):
+                        # GTP_remat computes wgrad via an async reduce-scatter, so autograd's
+                        # AccumulateGrad sees only a dummy: grad-ready is driven manually from
+                        # _handle_megatron_grad_accum (the hook passed here). RETAINING the node
+                        # keeps it on the capture stream for full-iteration CUDA-graph capture.
+                        # No autograd hook / grad_accs entry: that fires on a stale main_grad.
+                        param.register_grad_accum_hook(
+                            grad_acc, self._make_backward_post_hook(param)
+                        )
+                    else:
+                        grad_acc.register_hook(self._make_backward_post_hook(param))
+                        self.grad_accs.append(grad_acc)
 
         # Note: overlap_param_gather covers both the distributed optimizer and the
         # layer-wise optimizer cases; the latter sets overlap_param_gather=True

--- a/megatron/core/distributed/distributed_data_parallel.py
+++ b/megatron/core/distributed/distributed_data_parallel.py
@@ -376,10 +376,18 @@ class DistributedDataParallel(_BaseDataParallel):
                 elif getattr(param, 'is_gtp_weight_remat', False) and hasattr(
                     param, 'register_grad_accum_hook'
                 ):
-                    # GTP_remat defers the main_grad add to a later backward node, so drive the
-                    # post-hook from its manual call (_handle_megatron_grad_accum) rather than
-                    # autograd's AccumulateGrad, which would fire grad-ready on stale main_grad.
-                    param.register_grad_accum_hook(None, self._make_backward_post_hook(param))
+                    # GTP_remat computes wgrad via an async reduce-scatter on a side stream, so
+                    # autograd's AccumulateGrad receives only a dummy; grad-ready is driven
+                    # manually from _handle_megatron_grad_accum after the RS finalize (passed as
+                    # the hook below). We materialize the AccumulateGrad node and hand it to
+                    # register_grad_accum_hook, which RETAINS it — keeping it live places it on
+                    # the capture stream like a normal param, so full-iteration CUDA-graph capture
+                    # doesn't trip on a leaf node stranded on the default/legacy stream. It is NOT
+                    # added to grad_accs (that list is for autograd-hooked nodes), and the DDP
+                    # post-hook is not registered on it (that would fire grad-ready early).
+                    param_tmp = param.expand_as(param)
+                    grad_acc = param_tmp.grad_fn.next_functions[0][0]
+                    param.register_grad_accum_hook(grad_acc, self._make_backward_post_hook(param))
                 else:
                     # Expand so we get access to grad_fn.
                     param_tmp = param.expand_as(param)

--- a/megatron/core/distributed/distributed_data_parallel.py
+++ b/megatron/core/distributed/distributed_data_parallel.py
@@ -382,10 +382,10 @@ class DistributedDataParallel(_BaseDataParallel):
                         param, 'register_grad_accum_hook'
                     ):
                         # GTP_remat computes wgrad via an async reduce-scatter, so autograd's
-                        # AccumulateGrad sees only a dummy: grad-ready is driven manually from
+                        # AccumulateGrad sees only a dummy; grad-ready is driven manually from
                         # _handle_megatron_grad_accum (the hook passed here). RETAINING the node
                         # keeps it on the capture stream for full-iteration CUDA-graph capture.
-                        # No autograd hook / grad_accs entry: that fires on a stale main_grad.
+                        # No autograd hook or grad_accs entry: either would fire on a stale grad.
                         param.register_grad_accum_hook(
                             grad_acc, self._make_backward_post_hook(param)
                         )

--- a/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
+++ b/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
@@ -31,7 +31,7 @@ from collections import defaultdict
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Dict, List, Optional
+from typing import Callable, Dict, List, Optional
 
 import torch
 from packaging.version import Version
@@ -354,10 +354,22 @@ def wait_for_gtp_grad_reduction_on_current_stream() -> None:
     """
     wait_async_comms()
     cur = torch.cuda.current_stream()
+    # Join GTP's async AG/RS side streams back to the current stream. This is REQUIRED under
+    # full-iteration CUDA-graph capture: wait_async_comms() above runs real work on rs_stream
+    # (the RS wait, and main_grad.add_ via finalize_after_drain), forked from the capture stream
+    # via a recorded event. Without joining it back, capture_end sees an un-rejoined fork and
+    # fails with cudaErrorStreamCaptureUnjoined. The join is legal under capture — the per-layer
+    # CG path does the identical current_stream().wait_stream(side_stream) inside torch.cuda.graph()
+    # (see cuda_graphs._wait_side_streams) and captures fine.
     for s in _AG_STREAMS.values():
         cur.wait_stream(s)
     for s in _RS_STREAMS.values():
         cur.wait_stream(s)
+    # The per-layer CG runner replay streams only exist in the eager / per-layer-CG path; under
+    # whole-step capture there are no runners, and get_gtp_runner_streams is a per-layer concept,
+    # so stop here while capturing.
+    if torch.cuda.is_current_stream_capturing():
+        return
     # Local import: cuda_graphs imports this module, so a module-level import would be circular.
     from megatron.core.transformer.cuda_graphs import get_gtp_runner_streams
 
@@ -1446,16 +1458,22 @@ class GTPShardedParam(torch.nn.Parameter):
         """Pool-allocate a wgrad scratch tensor of unsharded shape for the bwd GEMM."""
         return _wgrad_pool_get(self._unsharded_shape, self.main_grad.dtype, self.device)
 
-    def register_grad_accum_hook(self, grad_accum_node, hook):
+    def register_grad_accum_hook(
+        self, grad_accum_node: torch.autograd.graph.Node | None, hook: Callable[..., None] | None
+    ) -> None:
         """Register a DDP backward hook to call after the wgrad RS finalize.
 
         For GTP params autograd may receive None (async RS), so the normal grad-accumulator
         hook never fires; the integrator (Graphed.backward for captured chains, or the eager
         chain-tail cascade) calls this hook explicitly after RS wait + accumulation, so DDP's
-        register_grad_ready fires at the right time. grad_accum_node is accepted for API
-        compatibility but not retained — only the hook callable.
+        register_grad_ready fires at the right time. We retain grad_accum_node (the weight's
+        AccumulateGrad) here: keeping a live strong reference across the warmup->capture
+        boundary is what places the node on the capture stream for full-iteration CG — an
+        un-retained node stays stranded on the default stream and trips capture. It is NOT put
+        in DDP's grad_accs (that list is for autograd-hooked nodes) and is never .register_hook'd
+        — grad-ready is fired manually via _grad_accum_hook, not by autograd.
         """
-        del grad_accum_node
+        self._grad_accum_node = grad_accum_node
         self._grad_accum_hook = hook
 
     @staticmethod

--- a/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
+++ b/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
@@ -355,13 +355,7 @@ def wait_for_gtp_grad_reduction_on_current_stream() -> None:
     """
     wait_async_comms()
     cur = torch.cuda.current_stream()
-    # Join GTP's async AG/RS side streams back to the current stream. This is REQUIRED under
-    # full-iteration CUDA-graph capture: wait_async_comms() above runs real work on rs_stream
-    # (the RS wait, and main_grad.add_ via finalize_after_drain), forked from the capture stream
-    # via a recorded event. Without joining it back, capture_end sees an un-rejoined fork and
-    # fails with cudaErrorStreamCaptureUnjoined. The join is legal under capture — the per-layer
-    # CG path does the identical current_stream().wait_stream(side_stream) inside torch.cuda.graph()
-    # (see cuda_graphs._wait_side_streams) and captures fine.
+    # Join the async AG/RS side streams for both eager and cuda-graph capture paths.
     for s in _AG_STREAMS.values():
         cur.wait_stream(s)
     for s in _RS_STREAMS.values():

--- a/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
+++ b/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
@@ -355,14 +355,13 @@ def wait_for_gtp_grad_reduction_on_current_stream() -> None:
     """
     wait_async_comms()
     cur = torch.cuda.current_stream()
-    # Join the async AG/RS side streams for both eager and cuda-graph capture paths.
+    # Join the async AG/RS side streams for both the eager and CUDA-graph capture paths.
     for s in _AG_STREAMS.values():
         cur.wait_stream(s)
     for s in _RS_STREAMS.values():
         cur.wait_stream(s)
-    # The per-layer CG runner replay streams only exist in the eager / per-layer-CG path; under
-    # whole-step capture there are no runners, and get_gtp_runner_streams is a per-layer concept,
-    # so stop here while capturing.
+    # The per-layer CG runner replay streams exist only in the eager / per-layer-CG path; under
+    # whole-step capture there are no runners, so stop here while capturing.
     if torch.cuda.is_current_stream_capturing():
         return
     # Local import: cuda_graphs imports this module, so a module-level import would be circular.
@@ -1465,11 +1464,11 @@ class GTPShardedParam(torch.nn.Parameter):
         hook never fires; the integrator (Graphed.backward for captured chains, or the eager
         chain-tail cascade) calls this hook explicitly after RS wait + accumulation, so DDP's
         register_grad_ready fires at the right time. We retain grad_accum_node (the weight's
-        AccumulateGrad) here: keeping a live strong reference across the warmup->capture
-        boundary is what places the node on the capture stream for full-iteration CG — an
-        un-retained node stays stranded on the default stream and trips capture. It is NOT put
-        in DDP's grad_accs (that list is for autograd-hooked nodes) and is never .register_hook'd
-        — grad-ready is fired manually via _grad_accum_hook, not by autograd.
+        AccumulateGrad) here. Keeping a live strong reference across the warmup->capture
+        boundary is what places the node on the capture stream for full-iteration CG; an
+        un-retained node stays stranded on the default stream and trips capture. The node is
+        not added to DDP's grad_accs (that list is for autograd-hooked nodes) and never gets
+        .register_hook'd, because grad-ready is fired manually via _grad_accum_hook.
         """
         self._grad_accum_node = grad_accum_node
         self._grad_accum_hook = hook

--- a/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
+++ b/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
@@ -349,8 +349,9 @@ def get_rs_stream(chain_id: str = GTPChain.GRAPHED.value, group=None) -> torch.c
 def wait_for_gtp_grad_reduction_on_current_stream() -> None:
     """Fence the current stream against all GTP backward grad work before the DP gradient sync.
 
-    Drains the eager AG/RS side streams, then waits on each CG runner's replay stream
-    (its tail = captured Phase 2 main_grad.add_). No-op when GTP is inactive.
+    Drains the eager AG/RS side streams, then — outside CUDA-graph capture — waits on each CG
+    runner's replay stream (its tail = captured Phase 2 main_grad.add_). Under whole-step capture
+    there are no per-layer runners, so that second wait is skipped. No-op when GTP is inactive.
     """
     wait_async_comms()
     cur = torch.cuda.current_stream()
@@ -800,6 +801,9 @@ def _init_gtp_runtime_attrs(obj):
     # DDP backward hook (set by register_grad_accum_hook); invoked after
     # the wgrad RS accumulation completes (Graphed.backward / chain cascade).
     obj._grad_accum_hook = None
+    # The weight's AccumulateGrad node (set by register_grad_accum_hook). Retained so the leaf
+    # lands on the capture stream for full-iteration CUDA-graph capture; None until DDP registers.
+    obj._grad_accum_node = None
     # Quantization. For native-FP8 GTP the reclass path overwrites _quantizer with the tensor's
     # own MXFP8 quantizer and points quantized at self; BF16 GTP leaves both unset.
     obj._quantizer = None

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
@@ -1194,18 +1194,14 @@ def _worker_gtp_ddp_grad_ready_wiring(rank, world_size, port):
             assert (
                 getattr(w, "_grad_accum_hook", None) is not None
             ), f"{name}.weight must have _grad_accum_hook set (manual grad-ready, not autograd)"
-            # The AccumulateGrad node must also be materialized and RETAINED. Keeping a live
-            # strong reference across the warmup->capture boundary is what places the node on
-            # the capture stream; an un-retained node stays stranded on the default/legacy
-            # stream and aborts full-iteration CUDA-graph capture with
-            # cudaErrorStreamCaptureImplicit.
+            # The node must also be RETAINED: a live strong reference across the
+            # warmup->capture boundary is what keeps the leaf on the capture stream.
             node = getattr(w, "_grad_accum_node", None)
             assert node is not None, (
                 f"{name}.weight must retain its AccumulateGrad node "
                 "(required for full-iteration CUDA-graph capture)"
             )
-            # Identity check: re-materializing must yield the same node, proving the retained
-            # reference is what keeps it alive (a dropped node would be recreated here).
+            # Identity, not just non-None: a dropped node would be recreated by expand_as here.
             assert (
                 node is w.expand_as(w).grad_fn.next_functions[0][0]
             ), f"{name}.weight retained a stale/foreign AccumulateGrad node"

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
@@ -1196,15 +1196,10 @@ def _worker_gtp_ddp_grad_ready_wiring(rank, world_size, port):
             ), f"{name}.weight must have _grad_accum_hook set (manual grad-ready, not autograd)"
             # The node must also be RETAINED: a live strong reference across the
             # warmup->capture boundary is what keeps the leaf on the capture stream.
-            node = getattr(w, "_grad_accum_node", None)
-            assert node is not None, (
-                f"{name}.weight must retain its AccumulateGrad node "
-                "(required for full-iteration CUDA-graph capture)"
-            )
-            # Identity, not just non-None: a dropped node would be recreated by expand_as here.
+            # Identity (not just non-None): a dropped node would be recreated by expand_as here.
             assert (
-                node is w.expand_as(w).grad_fn.next_functions[0][0]
-            ), f"{name}.weight retained a stale/foreign AccumulateGrad node"
+                getattr(w, "_grad_accum_node", None) is w.expand_as(w).grad_fn.next_functions[0][0]
+            ), f"{name}.weight must retain its AccumulateGrad node (full-iteration CG capture)"
 
         # bias=False -> all params are GTP_remat -> none took the autograd path.
         assert len(ddp_model.grad_accs) == 0, (

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
@@ -1152,6 +1152,10 @@ def _worker_gtp_ddp_grad_ready_wiring(rank, world_size, port):
     grad_data (corrupts reduce_scatter_with_fp32_accumulation). The fix routes grad-ready through
     register_grad_accum_hook (fired after the add) and skips the autograd hook. This pins that
     wiring: every GTP weight has _grad_accum_hook set and none falls through to the autograd list.
+
+    It also pins that the AccumulateGrad node is materialized and retained on the param: the
+    retained reference is what keeps the leaf on the capture stream for full-iteration
+    CUDA-graph capture.
     """
     from megatron.core import parallel_state as ps
     from megatron.core.distributed import DistributedDataParallel, DistributedDataParallelConfig
@@ -1190,6 +1194,21 @@ def _worker_gtp_ddp_grad_ready_wiring(rank, world_size, port):
             assert (
                 getattr(w, "_grad_accum_hook", None) is not None
             ), f"{name}.weight must have _grad_accum_hook set (manual grad-ready, not autograd)"
+            # The AccumulateGrad node must also be materialized and RETAINED. Keeping a live
+            # strong reference across the warmup->capture boundary is what places the node on
+            # the capture stream; an un-retained node stays stranded on the default/legacy
+            # stream and aborts full-iteration CUDA-graph capture with
+            # cudaErrorStreamCaptureImplicit.
+            node = getattr(w, "_grad_accum_node", None)
+            assert node is not None, (
+                f"{name}.weight must retain its AccumulateGrad node "
+                "(required for full-iteration CUDA-graph capture)"
+            )
+            # Identity check: re-materializing must yield the same node, proving the retained
+            # reference is what keeps it alive (a dropped node would be recreated here).
+            assert (
+                node is w.expand_as(w).grad_fn.next_functions[0][0]
+            ), f"{name}.weight retained a stale/foreign AccumulateGrad node"
 
         # bias=False -> all params are GTP_remat -> none took the autograd path.
         assert len(ddp_model.grad_accs) == 0, (

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
@@ -1153,9 +1153,9 @@ def _worker_gtp_ddp_grad_ready_wiring(rank, world_size, port):
     register_grad_accum_hook (fired after the add) and skips the autograd hook. This pins that
     wiring: every GTP weight has _grad_accum_hook set and none falls through to the autograd list.
 
-    It also pins that the AccumulateGrad node is materialized and retained on the param: the
-    retained reference is what keeps the leaf on the capture stream for full-iteration
-    CUDA-graph capture.
+    It also checks that the AccumulateGrad node is materialized and stored on the param. Holding
+    that reference is what keeps the leaf on the capture stream for full-iteration CUDA-graph
+    capture.
     """
     from megatron.core import parallel_state as ps
     from megatron.core.distributed import DistributedDataParallel, DistributedDataParallelConfig


### PR DESCRIPTION
Full-iteration CUDA-graph capture + GTP failed due to:
1. Leaf-node stream. GTP weight params were routed to register_grad_accum_hook
   without materializing their AccumulateGrad node, so the node stayed on the
   eager-warmup default/legacy stream and capture aborted with
   cudaErrorStreamCaptureImplicit. Materialize and retain the node (as the
   standard DDP path does) so it lands on the capture stream but no ddp hook
   is registered and grad-ready is GTP driven.
2. Unjoined async-RS side stream. wait_for_gtp_grad_reduction_on_current_stream
   skipped the AG/RS wait_stream join while capturing, leaving rs_stream work
   (RS wait + main_grad.add_) forked from the capture stream but never rejoined,
   so capture_end failed with cudaErrorStreamCaptureUnjoined. Perform the AG/RS
   join under capture (the per-layer CG path already does the identical join
   inside torch.cuda.graph); only the per-layer runner-stream waits remain gated
   to the non-capturing path.

- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
Fixing full-iteration CUDA-graph capture support with GTP

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [x] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [x] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR