### PR TITLE
[Dev] Add pipeline-parallel support to multimodal training in multimodal_dev code path

### DIFF
--- a/examples/multimodal_dev/data/mock.py
+++ b/examples/multimodal_dev/data/mock.py
@@ -125,6 +125,10 @@ class MockQwen35VLDataset(Dataset):
         # data_parallel_random_init is set, so ambient-RNG draws collapse a global batch's
         # distinct samples to the per-rank microbatch count — a number that changes with the
         # parallel layout, so two configurations being compared see different data.
+        # Indexing also keeps pipeline stages in agreement: Megatron gives each stage a
+        # different global seed (initialize._set_random_seed adds 100 * pp_rank) and every
+        # PP rank builds its own dataset, so a globally-drawn sample would differ between
+        # stages of the same job.
         generator = torch.Generator().manual_seed(
             _sample_seed(self.seed, self.split, idx)
         )

--- a/examples/multimodal_dev/forward_step.py
+++ b/examples/multimodal_dev/forward_step.py
@@ -13,10 +13,14 @@ import torch.nn.functional as F
 from megatron.core import mpu
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.parallel_state import (
+    get_pipeline_model_parallel_world_size,
     get_tensor_model_parallel_group,
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_src_rank,
+    is_pipeline_first_stage,
+    is_pipeline_last_stage,
 )
+from megatron.core.utils import get_attr_wrapped_model
 from megatron.training import get_args
 
 # -------------------------------------------------------------------
@@ -168,11 +172,24 @@ def _build_packed_seq_params_from_cu_seqlens(
     )
 
 
+def seqlen_alignment_factor(tp_size: int, cp_size: int, sequence_parallel: bool) -> int:
+    """Return the factor a batched sequence length must be divisible by.
+
+    CP splits the sequence into ``2 * cp_size`` chunks (load-balanced
+    ordering), and SP splits each rank's shard across TP ranks on top of
+    that.  Without CP, only the SP split constrains the length.
+    """
+    if cp_size > 1:
+        return (tp_size * cp_size * 2) if sequence_parallel else (cp_size * 2)
+    return tp_size if sequence_parallel else 1
+
+
 def pack_or_pad_batch(
     batch: Optional[list[Dict[str, Any]]],
     use_packed_sequence: bool = False,
     seq_length: Optional[int] = None,
     device="cuda",
+    include_pixel_values: bool = True,
 ) -> Dict[str, Any]:
     """Pack or pad a ``[B, S]`` batch into ``[1, T]`` THD or ``[B, S]`` BSHD.
 
@@ -183,6 +200,12 @@ def pack_or_pad_batch(
     ``PackedSeqParams`` (``cu_seqlens``, ``cu_seqlens_padded``,
     ``max_seqlen``, ``total_tokens``) is broadcast alongside the data, so
     every rank can build an identical ``PackedSeqParams`` on its own.
+
+    ``include_pixel_values`` must be False on non-first pipeline stages:
+    only the first stage holds the vision encoder, so collating and
+    broadcasting ``pixel_values`` elsewhere is pure overhead.
+    ``input_ids`` and ``image_grid_thw`` are still needed on every stage
+    for MRoPE position construction.
     """
     tp_size = mpu.get_tensor_model_parallel_world_size()
     cp_size = mpu.get_context_parallel_world_size()
@@ -196,10 +219,7 @@ def pack_or_pad_batch(
     except AssertionError:
         has_sp = False
 
-    if cp_size > 1:
-        divisible_by = (tp_size * cp_size * 2) if has_sp else (cp_size * 2)
-    else:
-        divisible_by = tp_size if has_sp else 1
+    divisible_by = seqlen_alignment_factor(tp_size, cp_size, has_sp)
 
     if use_packed_sequence:
         packed_batch: Dict[str, Any] = {}
@@ -221,7 +241,8 @@ def pack_or_pad_batch(
                 loss_mask_list.append(F.pad(sample["loss_mask"], (0, target_len - seqlen), value=0))
                 seqlens_list.append(seqlen)
                 seqlens_padded_list.append(target_len)
-                pixel_values_list.append(sample["pixel_values"])
+                if include_pixel_values:
+                    pixel_values_list.append(sample["pixel_values"])
                 image_grid_thw_list.append(sample["image_grid_thw"])
 
             cu_seqlens = list(accumulate(seqlens_list, initial=0))
@@ -244,7 +265,8 @@ def pack_or_pad_batch(
             packed_batch["labels"] = torch.concat(labels_list, dim=0).unsqueeze(0)
             packed_batch["loss_mask"] = torch.concat(loss_mask_list, dim=0).unsqueeze(0)
             packed_batch["padding_mask"] = padding_mask_thd.unsqueeze(0)
-            packed_batch["pixel_values"] = torch.concat(pixel_values_list)
+            if include_pixel_values:
+                packed_batch["pixel_values"] = torch.concat(pixel_values_list)
             packed_batch["image_grid_thw"] = torch.concat(image_grid_thw_list)
             # cu_seqlens / cu_seqlens_padded need to reach non-source TP ranks
             # so each rank can build an identical PackedSeqParams.
@@ -281,7 +303,18 @@ def pack_or_pad_batch(
     if is_src:
         assert batch is not None, "source TP rank must provide a batch"
         max_seqlens = max(x["input_ids"].shape[0] for x in batch)
-        target_seqlens = min(max_seqlens, seq_length)
+        if get_pipeline_model_parallel_world_size() > 1:
+            # The PP scheduler sizes its P2P recv buffers from --seq-length
+            # (this BSHD path leaves ``variable_seq_lengths`` unset), so the
+            # padded length must be static rather than the per-microbatch max.
+            assert max_seqlens <= seq_length, (
+                f"sample length {max_seqlens} exceeds --seq-length {seq_length}; "
+                "under PP>1 the batch is padded to a static --seq-length and "
+                "longer samples cannot be represented"
+            )
+            target_seqlens = seq_length
+        else:
+            target_seqlens = min(max_seqlens, seq_length)
         # Round target seqlen up to the parallelism alignment factor so the
         # batched tensor is divisible for CP (+SP) splitting downstream.
         if divisible_by > 1:
@@ -314,7 +347,8 @@ def pack_or_pad_batch(
         if has_padding:
             positions = torch.arange(target_seqlens).unsqueeze(0)
             padded_batch["padding_mask"] = positions >= torch.tensor(real_seqlens).unsqueeze(1)
-        padded_batch["pixel_values"] = torch.concat([x["pixel_values"] for x in batch])
+        if include_pixel_values:
+            padded_batch["pixel_values"] = torch.concat([x["pixel_values"] for x in batch])
         padded_batch["image_grid_thw"] = torch.concat([x["image_grid_thw"] for x in batch])
 
     return broadcast_data_batch(padded_batch, device=device)
@@ -325,10 +359,11 @@ def pack_or_pad_batch(
 # -------------------------------------------------------------------
 
 
-def get_batch(data_iterator: Iterator[list[Dict[str, Any]]]):
+def get_batch(data_iterator: Iterator[list[Dict[str, Any]]], vp_stage: Optional[int] = None):
     """Get a batch from *data_iterator* and broadcast across TP ranks."""
     device = "cuda"
     args = get_args()
+    include_pixel_values = is_pipeline_first_stage(ignore_virtual=False, vp_stage=vp_stage)
 
     if get_tensor_model_parallel_rank() == 0:
         try:
@@ -349,7 +384,13 @@ def get_batch(data_iterator: Iterator[list[Dict[str, Any]]]):
         return None
 
     # Because broadcast will not broadcast packed_seq_params, we move it into pack_or_pad_batch
-    batch = pack_or_pad_batch(data, args.use_packed_sequence, args.seq_length, device=device)
+    batch = pack_or_pad_batch(
+        data,
+        args.use_packed_sequence,
+        args.seq_length,
+        device=device,
+        include_pixel_values=include_pixel_values,
+    )
 
     # Fix shapes produced by default_collate.
     if "position_ids" in batch and batch["position_ids"] is not None:
@@ -395,11 +436,13 @@ def loss_func(loss_mask, output_tensor):
 
 def forward_step(data_iterator, model):
     """Forward step for multimodal_dev training."""
-    batch = get_batch(data_iterator)
+    vp_stage = get_attr_wrapped_model(model, "vp_stage")
+    batch = get_batch(data_iterator, vp_stage=vp_stage)
 
     if batch is None:
         return None, None
 
+    # ``pixel_values`` is absent here on non-first stages (see pack_or_pad_batch).
     pixel_values = batch.get("pixel_values", None)
     if (
         pixel_values is not None
@@ -427,9 +470,13 @@ def forward_step(data_iterator, model):
 
     # Slice loss_mask the same way the model sliced its inputs, so the
     # mask aligns with the CP-shard output.  Delegated to MultimodalModel
-    # so the slicing rule lives in one place.
-    from examples.multimodal_dev.models.base import MultimodalModel
+    # so the slicing rule lives in one place.  Only the last PP stage runs
+    # the loss closure, so other stages leave the mask untouched.
+    if is_pipeline_last_stage(ignore_virtual=False, vp_stage=vp_stage):
+        from examples.multimodal_dev.models.base import MultimodalModel
 
-    loss_mask = MultimodalModel.cp_split_loss_mask(loss_mask, batch.get("packed_seq_params", None))
+        loss_mask = MultimodalModel.cp_split_loss_mask(
+            loss_mask, batch.get("packed_seq_params", None)
+        )
 
     return output_tensor, partial(loss_func, loss_mask)

--- a/examples/multimodal_dev/forward_step.py
+++ b/examples/multimodal_dev/forward_step.py
@@ -16,6 +16,8 @@ from megatron.core.parallel_state import (
     get_tensor_model_parallel_group,
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_src_rank,
+    is_pipeline_first_stage,
+    is_pipeline_last_stage,
 )
 from megatron.training import get_args
 
@@ -400,7 +402,15 @@ def forward_step(data_iterator, model):
     if batch is None:
         return None, None
 
-    pixel_values = batch.get("pixel_values", None)
+    # ``pixel_values`` is the heavy vision tensor and is only consumed
+    # on the first PP stage; drop it elsewhere.  ``image_grid_thw`` is
+    # small and is needed on every PP stage by ``compute_position_ids``
+    # (MRoPE freqs are computed per-stage from position_ids).
+    is_first = is_pipeline_first_stage()
+    is_last = is_pipeline_last_stage()
+
+    pixel_values = batch.get("pixel_values", None) if is_first else None
+    image_grid_thw = batch.get("image_grid_thw", None)
     if (
         pixel_values is not None
         and pixel_values.is_floating_point()
@@ -417,7 +427,7 @@ def forward_step(data_iterator, model):
         loss_mask=batch.get("loss_mask", None),
         padding_mask=batch.get("padding_mask", None),
         pixel_values=pixel_values,
-        image_grid_thw=batch.get("image_grid_thw", None),
+        image_grid_thw=image_grid_thw,
         packed_seq_params=batch.get("packed_seq_params", None),
     )
 
@@ -427,9 +437,14 @@ def forward_step(data_iterator, model):
 
     # Slice loss_mask the same way the model sliced its inputs, so the
     # mask aligns with the CP-shard output.  Delegated to MultimodalModel
-    # so the slicing rule lives in one place.
-    from examples.multimodal_dev.models.base import MultimodalModel
+    # so the slicing rule lives in one place.  The PP scheduler only
+    # invokes the loss closure on the last PP stage, so on non-last
+    # stages the mask is left untouched.
+    if is_last:
+        from examples.multimodal_dev.models.base import MultimodalModel
 
-    loss_mask = MultimodalModel.cp_split_loss_mask(loss_mask, batch.get("packed_seq_params", None))
+        loss_mask = MultimodalModel.cp_split_loss_mask(
+            loss_mask, batch.get("packed_seq_params", None)
+        )
 
     return output_tensor, partial(loss_func, loss_mask)

--- a/examples/multimodal_dev/models/base.py
+++ b/examples/multimodal_dev/models/base.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 
-"""Base multimodal model for FSDP + EP training.
+"""Base multimodal model for FSDP + EP and PP training.
 
-Composes a vision encoder and a ``GPTModel`` language decoder.  Designed
-for FSDP + EP: always builds the **full** model on every rank (no PP
-flags).  PP support is only available through the MIMO ``MimoModel``
-assembly path.
+Composes a vision encoder and a ``GPTModel`` language decoder.  The
+vision encoder is built only on the first PP stage; the language
+decoder spans all PP stages following standard Megatron PP layout
+flags.
 
 Subclasses override ``compute_position_ids()`` for model-specific
 position encoding (e.g. MRoPE for Qwen3.5-VL).
@@ -83,13 +83,15 @@ class MultimodalModel(MegatronModule):
     """Base class for multimodal vision-language models.
 
     Composes a pre-constructed vision encoder and a ``GPTModel`` language
-    decoder.  Designed for FSDP + EP; always builds the full model on
-    every rank.
+    decoder.  Supports pipeline parallelism: the vision encoder is built
+    only on the first PP stage, while the language decoder spans all PP
+    stages following standard Megatron PP layout flags.
 
     Args:
         language_config: ``TransformerConfig`` for the language decoder.
         language_spec: ``ModuleSpec`` for decoder transformer layers.
-        vision_encoder: Pre-constructed vision encoder module.
+        vision_encoder: Pre-constructed vision encoder module (or ``None``
+            on non-first PP stages).
         vocab_size: Language model vocabulary size.
         max_sequence_length: Maximum sequence length.
         image_token_id: Token ID for image placeholder tokens.
@@ -100,13 +102,18 @@ class MultimodalModel(MegatronModule):
         mtp_block_spec: Optional MTP block spec.
         parallel_output: Keep outputs split across TP ranks.
         share_embeddings_and_output_weights: Tie input/output embeddings.
+        pre_process: First PP stage flag — when True, build embedding +
+            run vision encoder + scatter image embeddings.
+        post_process: Last PP stage flag — when True, build output layer +
+            compute loss inside ``GPTModel``.
+        vp_stage: Virtual pipeline stage (forwarded to ``GPTModel``).
     """
 
     def __init__(
         self,
         language_config: TransformerConfig,
         language_spec: ModuleSpec,
-        vision_encoder: MegatronModule,
+        vision_encoder: Optional[MegatronModule],
         vocab_size: int,
         max_sequence_length: int,
         image_token_id: int,
@@ -117,19 +124,31 @@ class MultimodalModel(MegatronModule):
         mtp_block_spec: Optional[ModuleSpec] = None,
         parallel_output: bool = True,
         share_embeddings_and_output_weights: bool = False,
+        pre_process: bool = True,
+        post_process: bool = True,
+        vp_stage: Optional[int] = None,
     ):
         super().__init__(config=language_config)
 
         self.image_token_id = image_token_id
+        self.pre_process = pre_process
+        self.post_process = post_process
+        self.vp_stage = vp_stage
+        # Surfaced for ``finalize_model_grads._allreduce_word_embedding_grads``
+        # which inspects the outer module (not the wrapped GPTModel) when
+        # PP > 1 and either tied embeddings or MTP layers are in use.
+        self.share_embeddings_and_output_weights = share_embeddings_and_output_weights
 
-        self.vision_model = vision_encoder
+        # Vision encoder lives only on the first PP stage.
+        self.vision_model = vision_encoder if pre_process else None
         self.language_model = GPTModel(
             config=language_config,
             transformer_layer_spec=language_spec,
             vocab_size=vocab_size,
             max_sequence_length=max_sequence_length,
-            pre_process=True,
-            post_process=True,
+            pre_process=pre_process,
+            post_process=post_process,
+            vp_stage=vp_stage,
             parallel_output=parallel_output,
             share_embeddings_and_output_weights=(share_embeddings_and_output_weights),
             position_embedding_type=position_embedding_type,
@@ -138,8 +157,19 @@ class MultimodalModel(MegatronModule):
             mtp_block_spec=mtp_block_spec,
         )
 
+    def shared_embedding_or_output_weight(self):
+        """Surface the wrapped language model's shared embedding / output
+        weight to the PP grad-finalize step (mirrors the LLaVA wrapper).
+        Needed when PP>1 and embeddings are tied or MTP is enabled.
+        """
+        return self.language_model.shared_embedding_or_output_weight()
+
     def set_input_tensor(self, input_tensor):
-        """Route input tensors (simplified, no PP routing)."""
+        """Forward the activation from the previous PP stage into
+        ``GPTModel``.  No PP-specific routing is needed here:
+        ``GPTModel.set_input_tensor`` already handles the case based on
+        its own ``pre_process`` flag.
+        """
         if not isinstance(input_tensor, list):
             input_tensor = [input_tensor]
         assert len(input_tensor) == 1
@@ -340,6 +370,8 @@ class MultimodalModel(MegatronModule):
         Returns:
             Loss tensor (post_process=True) or hidden states.
         """
+        # MRoPE freqs are computed per PP stage from position_ids inside
+        # GPTModel, so position_ids must be available on every stage.
         if position_ids is None:
             position_ids = self.compute_position_ids(
                 input_ids=input_ids,
@@ -347,19 +379,28 @@ class MultimodalModel(MegatronModule):
                 packed_seq_params=packed_seq_params,
             )
 
-        vision_embeddings = None
-        if self.vision_model is not None and pixel_values is not None:
-            vision_embeddings = self.vision_model(pixel_values, image_grid_thw)
+        if self.pre_process:
+            vision_embeddings = None
+            if self.vision_model is not None and pixel_values is not None:
+                vision_embeddings = self.vision_model(pixel_values, image_grid_thw)
 
-        if decoder_input is None and self.language_model is not None:
-            text_embeddings = self.language_model.embedding(input_ids=input_ids, position_ids=None)
-
-            if vision_embeddings is not None:
-                decoder_input = self._scatter_vision_embeddings(
-                    input_ids, text_embeddings, vision_embeddings
+            if decoder_input is None and self.language_model is not None:
+                text_embeddings = self.language_model.embedding(
+                    input_ids=input_ids, position_ids=None
                 )
-            else:
-                decoder_input = text_embeddings
+
+                if vision_embeddings is not None:
+                    decoder_input = self._scatter_vision_embeddings(
+                        input_ids, text_embeddings, vision_embeddings
+                    )
+                else:
+                    decoder_input = text_embeddings
+        else:
+            # Non-first PP stage: the activation arrives via
+            # set_input_tensor on GPTModel.  Don't run vision encoder,
+            # don't run embedding, and don't pass a decoder_input here
+            # so the CP-split helper leaves it as None.
+            decoder_input = None
 
         (
             decoder_input, input_ids, labels, loss_mask,

--- a/examples/multimodal_dev/models/base.py
+++ b/examples/multimodal_dev/models/base.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 
-"""Base multimodal model for FSDP + EP training.
+"""Base multimodal model for FSDP + EP and PP training.
 
-Composes a vision encoder and a ``HybridModel`` language decoder.  Designed
-for FSDP + EP: always builds the **full** model on every rank (no PP
-flags).  PP support is only available through the MIMO ``MimoModel``
-assembly path.
+Composes a vision encoder and a ``HybridModel`` language decoder.  The
+vision encoder is built only on the first PP stage; the language
+decoder spans all PP stages following standard Megatron PP layout
+flags.
 
 Subclasses override ``compute_position_ids()`` for model-specific
 position encoding (e.g. MRoPE for Qwen3.5-VL).
@@ -83,14 +83,16 @@ class MultimodalModel(MegatronModule):
     """Base class for multimodal vision-language models.
 
     Composes a pre-constructed vision encoder and a ``HybridModel`` language
-    decoder.  Designed for FSDP + EP; always builds the full model on
-    every rank.
+    decoder.  Supports pipeline parallelism: the vision encoder is built
+    only on the first PP stage, while the language decoder spans all PP
+    stages following standard Megatron PP layout flags.
 
     Args:
         language_config: ``TransformerConfig`` for the language decoder.
         hybrid_stack_spec: ``ModuleSpec`` defining HybridModel layer families.
         hybrid_layer_pattern: Ordered HybridModel decoder and MTP layer pattern.
-        vision_encoder: Pre-constructed vision encoder module.
+        vision_encoder: Pre-constructed vision encoder module (or ``None``
+            on non-first PP stages).
         vocab_size: Language model vocabulary size.
         max_sequence_length: Maximum sequence length.
         image_token_id: Token ID for image placeholder tokens.
@@ -99,6 +101,11 @@ class MultimodalModel(MegatronModule):
         rotary_base: Base frequency for RoPE.
         parallel_output: Keep outputs split across TP ranks.
         share_embeddings_and_output_weights: Tie input/output embeddings.
+        pre_process: First PP stage flag — when True, build embedding +
+            run vision encoder + scatter image embeddings.
+        post_process: Last PP stage flag — when True, build output layer +
+            compute loss inside ``HybridModel``.
+        vp_stage: Virtual pipeline stage (forwarded to ``HybridModel``).
     """
 
     def __init__(
@@ -106,7 +113,7 @@ class MultimodalModel(MegatronModule):
         language_config: TransformerConfig,
         hybrid_stack_spec: ModuleSpec,
         hybrid_layer_pattern: str,
-        vision_encoder: MegatronModule,
+        vision_encoder: Optional[MegatronModule],
         vocab_size: int,
         max_sequence_length: int,
         image_token_id: int,
@@ -115,20 +122,35 @@ class MultimodalModel(MegatronModule):
         rotary_base: int = 10000,
         parallel_output: bool = True,
         share_embeddings_and_output_weights: bool = False,
+        pre_process: bool = True,
+        post_process: bool = True,
+        vp_stage: Optional[int] = None,
     ):
         super().__init__(config=language_config)
 
         self.image_token_id = image_token_id
+        self.pre_process = pre_process
+        self.vp_stage = vp_stage
+        # ``post_process`` is deliberately not stored: nothing reads it off this
+        # wrapper, and ``get_attr_wrapped_model(model, 'post_process', ...)``
+        # (schedules.clear_embedding_activation_buffer) must keep resolving to
+        # the HybridModel that owns ``embedding_activation_buffer``.
+        # Surfaced for ``finalize_model_grads._allreduce_word_embedding_grads``
+        # which inspects the outer module (not the wrapped HybridModel) when
+        # PP > 1 and either tied embeddings or MTP layers are in use.
+        self.share_embeddings_and_output_weights = share_embeddings_and_output_weights
 
-        self.vision_model = vision_encoder
+        # Vision encoder lives only on the first PP stage.
+        self.vision_model = vision_encoder if pre_process else None
         self.language_model = HybridModel(
             config=language_config,
             hybrid_stack_spec=hybrid_stack_spec,
             vocab_size=vocab_size,
             max_sequence_length=max_sequence_length,
             hybrid_layer_pattern=hybrid_layer_pattern,
-            pre_process=True,
-            post_process=True,
+            pre_process=pre_process,
+            post_process=post_process,
+            vp_stage=vp_stage,
             parallel_output=parallel_output,
             share_embeddings_and_output_weights=(share_embeddings_and_output_weights),
             position_embedding_type=position_embedding_type,
@@ -136,8 +158,17 @@ class MultimodalModel(MegatronModule):
             rotary_base=rotary_base,
         )
 
+    def shared_embedding_or_output_weight(self):
+        """Surface the wrapped language model's shared embedding / output
+        weight to the PP grad-finalize step (mirrors the LLaVA wrapper).
+        Needed when PP>1 and embeddings are tied or MTP is enabled.
+        """
+        return self.language_model.shared_embedding_or_output_weight()
+
     def set_input_tensor(self, input_tensor):
-        """Route input tensors (simplified, no PP routing)."""
+        """Forward the previous PP stage's activation into ``HybridModel``,
+        which routes it according to its own ``pre_process`` flag.
+        """
         if not isinstance(input_tensor, list):
             input_tensor = [input_tensor]
         assert len(input_tensor) == 1
@@ -332,12 +363,16 @@ class MultimodalModel(MegatronModule):
                 ``loss_mask``: only true padding, not SFT prompt tokens.
             pixel_values: Preprocessed image pixels.
             image_grid_thw: ``[num_images, 3]`` grid dimensions.
-            decoder_input: Pre-computed decoder input (skip embed).
+            decoder_input: Pre-computed decoder input (skip embed). Only
+                honored on the first pipeline stage; later stages take
+                their activation from ``set_input_tensor``.
             packed_seq_params: ``PackedSeqParams`` for THD attention.
 
         Returns:
             Loss tensor (post_process=True) or hidden states.
         """
+        # MRoPE freqs are computed per PP stage from position_ids inside
+        # HybridModel, so position_ids must be available on every stage.
         if position_ids is None:
             position_ids = self.compute_position_ids(
                 input_ids=input_ids,
@@ -345,19 +380,29 @@ class MultimodalModel(MegatronModule):
                 packed_seq_params=packed_seq_params,
             )
 
-        vision_embeddings = None
-        if self.vision_model is not None and pixel_values is not None:
-            vision_embeddings = self.vision_model(pixel_values, image_grid_thw)
+        if self.pre_process:
+            vision_embeddings = None
+            if self.vision_model is not None and pixel_values is not None:
+                vision_embeddings = self.vision_model(pixel_values, image_grid_thw)
 
-        if decoder_input is None and self.language_model is not None:
-            text_embeddings = self.language_model.embedding(input_ids=input_ids, position_ids=None)
-
-            if vision_embeddings is not None:
-                decoder_input = self._scatter_vision_embeddings(
-                    input_ids, text_embeddings, vision_embeddings
+            if decoder_input is None and self.language_model is not None:
+                text_embeddings = self.language_model.embedding(
+                    input_ids=input_ids, position_ids=None
                 )
-            else:
-                decoder_input = text_embeddings
+
+                if vision_embeddings is not None:
+                    decoder_input = self._scatter_vision_embeddings(
+                        input_ids, text_embeddings, vision_embeddings
+                    )
+                else:
+                    decoder_input = text_embeddings
+        else:
+            # Non-first PP stage: no vision encoder, no embedding; the
+            # activation arrives via HybridModel.set_input_tensor.
+            assert decoder_input is None, (
+                "decoder_input is only honored on the first pipeline stage; "
+                "later stages take their activation from set_input_tensor."
+            )
 
         (
             decoder_input, input_ids, labels, loss_mask,

--- a/examples/multimodal_dev/models/qwen35_vl/factory.py
+++ b/examples/multimodal_dev/models/qwen35_vl/factory.py
@@ -38,7 +38,14 @@ def set_vision_flops_metadata(args, language_config, vision_config):
     args.vision_out_hidden_size = language_config.hidden_size
 
 
-def build_model(args, language_config, vision_config, **kwargs):
+def build_model(
+    args,
+    language_config,
+    vision_config,
+    pre_process: bool = True,
+    post_process: bool = True,
+    **kwargs,
+):
     """Build a complete Qwen3.5-VL model instance.
 
     Handles language spec construction, optional MTP block spec, and
@@ -49,24 +56,29 @@ def build_model(args, language_config, vision_config, **kwargs):
         language_config: ``TransformerConfig`` for the language decoder
             (already post-processed by :func:`post_language_config`).
         vision_config: ``TransformerConfig`` for the vision encoder.
+        pre_process: First PP stage flag — vision encoder + embedding live here.
+        post_process: Last PP stage flag — output projection + loss live here.
         **kwargs: Extra keyword arguments (e.g. ``vp_stage``).
 
     Returns:
         A :class:`Qwen35VLModel` instance.
     """
-    from megatron.core.models.gpt.gpt_layer_specs import (
-        get_gpt_mtp_block_spec,
-    )
-
     from examples.multimodal_dev.models.qwen35_vl.model import Qwen35VLModel
     from examples.multimodal_dev.models.qwen35_vl.specs import (
         get_qwen35_vl_language_spec,
     )
+    from megatron.core import parallel_state
+    from megatron.core.models.gpt.gpt_layer_specs import (
+        get_gpt_mtp_block_spec,
+    )
+
+    vp_stage = kwargs.get("vp_stage", None)
+    pp_rank = parallel_state.get_pipeline_model_parallel_rank()
 
     language_spec = get_qwen35_vl_language_spec(
         config=language_config,
-        vp_stage=kwargs.get("vp_stage", None),
-        pp_rank=None,
+        vp_stage=vp_stage,
+        pp_rank=pp_rank,
     )
 
     mtp_block_spec = None
@@ -77,8 +89,8 @@ def build_model(args, language_config, vision_config, **kwargs):
             use_transformer_engine=(
                 args.transformer_impl == "transformer_engine"
             ),
-            vp_stage=kwargs.get("vp_stage", None),
-            pp_rank=None,
+            vp_stage=vp_stage,
+            pp_rank=pp_rank,
         )
 
     # When --untie-embeddings-and-output-weights is NOT passed, Megatron
@@ -98,4 +110,7 @@ def build_model(args, language_config, vision_config, **kwargs):
         mtp_block_spec=mtp_block_spec,
         parallel_output=True,
         share_embeddings_and_output_weights=share_embeddings,
+        pre_process=pre_process,
+        post_process=post_process,
+        vp_stage=vp_stage,
     )

--- a/examples/multimodal_dev/models/qwen35_vl/factory.py
+++ b/examples/multimodal_dev/models/qwen35_vl/factory.py
@@ -47,7 +47,14 @@ def set_vision_flops_metadata(args, language_config, vision_config):
     args.vision_out_hidden_size = language_config.hidden_size
 
 
-def build_model(args, language_config, vision_config, **kwargs):
+def build_model(
+    args,
+    language_config,
+    vision_config,
+    pre_process: bool = True,
+    post_process: bool = True,
+    **kwargs,
+):
     """Build a complete Qwen3.5-VL model instance.
 
     Selects the HybridModel stack spec and instantiates the model with the
@@ -58,11 +65,15 @@ def build_model(args, language_config, vision_config, **kwargs):
         language_config: ``TransformerConfig`` for the language decoder
             (already post-processed by :func:`post_language_config`).
         vision_config: ``TransformerConfig`` for the vision encoder.
+        pre_process: First PP stage flag — vision encoder + embedding live here.
+        post_process: Last PP stage flag — output projection + loss live here.
         **kwargs: Extra keyword arguments (e.g. ``vp_stage``).
 
     Returns:
         A :class:`Qwen35VLModel` instance.
     """
+    vp_stage = kwargs.get("vp_stage", None)
+
     hybrid_layer_pattern = getattr(args, "hybrid_layer_pattern", None)
     if hybrid_layer_pattern is None:
         raise ValueError(
@@ -104,4 +115,7 @@ def build_model(args, language_config, vision_config, **kwargs):
         position_embedding_type=args.position_embedding_type,
         parallel_output=True,
         share_embeddings_and_output_weights=share_embeddings,
+        pre_process=pre_process,
+        post_process=post_process,
+        vp_stage=vp_stage,
     )

--- a/examples/multimodal_dev/models/qwen35_vl/model.py
+++ b/examples/multimodal_dev/models/qwen35_vl/model.py
@@ -60,6 +60,9 @@ class Qwen35VLModel(MultimodalModel):
         mtp_block_spec: ModuleSpec = None,
         parallel_output: bool = True,
         share_embeddings_and_output_weights: bool = False,
+        pre_process: bool = True,
+        post_process: bool = True,
+        vp_stage: Optional[int] = None,
     ):
         if vision_spec is None:
             vision_spec = get_qwen35_vl_vision_spec()
@@ -68,20 +71,24 @@ class Qwen35VLModel(MultimodalModel):
         self.vision_start_token_id = vision_start_token_id
         self.spatial_merge_size = spatial_merge_size
 
-        vkw = dict(VISION_KWARGS)
-        vkw["spatial_merge_size"] = spatial_merge_size
-        vkw["out_hidden_size"] = language_config.hidden_size
+        # Vision encoder lives on the first PP stage only.
+        if pre_process:
+            vkw = dict(VISION_KWARGS)
+            vkw["spatial_merge_size"] = spatial_merge_size
+            vkw["out_hidden_size"] = language_config.hidden_size
 
-        vision_encoder = Qwen35VLVisionEncoder(
-            config=vision_config,
-            transformer_layer_spec=vision_spec,
-            in_channels=vkw["in_channels"],
-            patch_size=vkw["patch_size"],
-            temporal_patch_size=vkw["temporal_patch_size"],
-            spatial_merge_size=vkw["spatial_merge_size"],
-            out_hidden_size=vkw["out_hidden_size"],
-            max_num_positions=vkw["max_num_positions"],
-        )
+            vision_encoder = Qwen35VLVisionEncoder(
+                config=vision_config,
+                transformer_layer_spec=vision_spec,
+                in_channels=vkw["in_channels"],
+                patch_size=vkw["patch_size"],
+                temporal_patch_size=vkw["temporal_patch_size"],
+                spatial_merge_size=vkw["spatial_merge_size"],
+                out_hidden_size=vkw["out_hidden_size"],
+                max_num_positions=vkw["max_num_positions"],
+            )
+        else:
+            vision_encoder = None
 
         super().__init__(
             language_config=language_config,
@@ -99,6 +106,9 @@ class Qwen35VLModel(MultimodalModel):
             share_embeddings_and_output_weights=(
                 share_embeddings_and_output_weights
             ),
+            pre_process=pre_process,
+            post_process=post_process,
+            vp_stage=vp_stage,
         )
 
     def compute_position_ids(

--- a/examples/multimodal_dev/models/qwen35_vl/model.py
+++ b/examples/multimodal_dev/models/qwen35_vl/model.py
@@ -46,6 +46,12 @@ class Qwen35VLModel(MultimodalModel):
             model and the parsed CLI args describe the same decoder.
         parallel_output: Keep outputs split across TP.
         share_embeddings_and_output_weights: Tie embeddings.
+        pre_process: First PP stage flag — build the embedding and the
+            vision encoder here.
+        post_process: Last PP stage flag — build the output layer and
+            compute loss here.
+        vp_stage: Virtual pipeline stage index, or ``None`` when VPP is
+            disabled (selects the non-VPP ``is_pipeline_*_stage`` path).
     """
 
     def __init__(
@@ -64,6 +70,9 @@ class Qwen35VLModel(MultimodalModel):
         position_embedding_type: str = "mrope",
         parallel_output: bool = True,
         share_embeddings_and_output_weights: bool = False,
+        pre_process: bool = True,
+        post_process: bool = True,
+        vp_stage: Optional[int] = None,
     ):
         if position_embedding_type != "mrope":
             raise ValueError(
@@ -80,20 +89,24 @@ class Qwen35VLModel(MultimodalModel):
         self.vision_start_token_id = vision_start_token_id
         self.spatial_merge_size = spatial_merge_size
 
-        vkw = dict(VISION_KWARGS)
-        vkw["spatial_merge_size"] = spatial_merge_size
-        vkw["out_hidden_size"] = language_config.hidden_size
+        # Vision encoder lives on the first PP stage only.
+        if pre_process:
+            vkw = dict(VISION_KWARGS)
+            vkw["spatial_merge_size"] = spatial_merge_size
+            vkw["out_hidden_size"] = language_config.hidden_size
 
-        vision_encoder = Qwen35VLVisionEncoder(
-            config=vision_config,
-            transformer_layer_spec=vision_spec,
-            in_channels=vkw["in_channels"],
-            patch_size=vkw["patch_size"],
-            temporal_patch_size=vkw["temporal_patch_size"],
-            spatial_merge_size=vkw["spatial_merge_size"],
-            out_hidden_size=vkw["out_hidden_size"],
-            max_num_positions=vkw["max_num_positions"],
-        )
+            vision_encoder = Qwen35VLVisionEncoder(
+                config=vision_config,
+                transformer_layer_spec=vision_spec,
+                in_channels=vkw["in_channels"],
+                patch_size=vkw["patch_size"],
+                temporal_patch_size=vkw["temporal_patch_size"],
+                spatial_merge_size=vkw["spatial_merge_size"],
+                out_hidden_size=vkw["out_hidden_size"],
+                max_num_positions=vkw["max_num_positions"],
+            )
+        else:
+            vision_encoder = None
 
         super().__init__(
             language_config=language_config,
@@ -110,6 +123,9 @@ class Qwen35VLModel(MultimodalModel):
             share_embeddings_and_output_weights=(
                 share_embeddings_and_output_weights
             ),
+            pre_process=pre_process,
+            post_process=post_process,
+            vp_stage=vp_stage,
         )
 
     def compute_position_ids(

--- a/examples/multimodal_dev/pretrain_multimodal.py
+++ b/examples/multimodal_dev/pretrain_multimodal.py
@@ -33,7 +33,7 @@ sys.path.insert(
 )
 
 from examples.multimodal_dev.arguments import add_multimodal_args
-from examples.multimodal_dev.forward_step import forward_step
+from examples.multimodal_dev.forward_step import forward_step, seqlen_alignment_factor
 from megatron.core.enums import ModelType
 from megatron.training import get_args, pretrain
 from megatron.training.argument_utils import pretrain_cfg_container_from_args
@@ -68,6 +68,22 @@ def model_provider(
 
     # --- language config (generic + model-specific post-processing) ---
     language_config = core_transformer_config_from_args(args)
+    if getattr(args, "use_packed_sequence", False) and args.pipeline_model_parallel_size > 1:
+        # THD activation length varies per microbatch, so the pipeline
+        # scheduler must negotiate shapes at each send/recv instead of sizing
+        # its P2P buffers from --seq-length.  Assigned after
+        # TransformerConfig.__post_init__, hence the repeated dispatcher check.
+        language_config.variable_seq_lengths = True
+        if (
+            language_config.num_moe_experts is not None
+            and language_config.moe_token_dispatcher_type == "allgather"
+        ):
+            raise ValueError(
+                "--use-packed-sequence with pipeline_model_parallel_size > 1 "
+                "requires an alltoall MoE token dispatcher; the allgather "
+                "dispatcher does not support the variable sequence lengths "
+                "the pipeline scheduler needs to negotiate THD shapes."
+            )
     post_language_config_fn = registry.get("post_language_config_fn")
     if post_language_config_fn is not None:
         post_language_config_fn(language_config, args)
@@ -96,6 +112,8 @@ def model_provider(
         args=args,
         language_config=language_config,
         vision_config=vision_config,
+        pre_process=pre_process,
+        post_process=post_process,
         **kwargs,
     )
 
@@ -112,12 +130,15 @@ def _resolve_provider_fn(provider_fn):
     return provider_fn
 
 
-def datasets_provider(train_val_test_num_samples):
+def datasets_provider(train_val_test_num_samples, vp_stage=None):
     """Dataset provider dispatcher.
 
     Routes to the dataset factory registered for the current
-    ``(--model-arch, --dataset-provider)`` combination.
+    ``(--model-arch, --dataset-provider)`` combination. ``vp_stage`` is
+    accepted for the virtual-pipeline dataset-provider contract; the
+    registered datasets are stage-independent.
     """
+    del vp_stage
     args = get_args()
     model_arch = getattr(args, "model_arch", "qwen35_vl")
     provider = getattr(args, "dataset_provider", "mock")
@@ -150,16 +171,25 @@ if __name__ == "__main__":
         extra_args_provider=add_multimodal_args,
         args_defaults={},
     )
-    # multimodal_dev's model_provider builds the full model on every rank and
-    # does not honor pre_process / post_process pipeline-stage flags. PP>1
-    # would silently violate Megatron's pipeline-parallel contract.
-    if args.pipeline_model_parallel_size > 1:
-        raise ValueError(
-            "multimodal_dev does not support pipeline_model_parallel_size > 1 "
-            f"(got {args.pipeline_model_parallel_size}). The model provider "
-            "builds the full model on every rank; pipeline-stage splitting is "
-            "not wired through. Run with --pipeline-model-parallel-size 1."
+    if args.pipeline_model_parallel_size > 1 and not args.use_packed_sequence:
+        # The BSHD collate pads to --seq-length and rounds *up* to the CP/SP
+        # alignment factor, while the pipeline scheduler sizes its static P2P
+        # buffers from --seq-length with floor division.  An unaligned
+        # --seq-length would make the two disagree and hang at the first
+        # cross-stage send.  The packed/THD path is exempt: it sets
+        # ``variable_seq_lengths`` and negotiates shapes instead.
+        alignment = seqlen_alignment_factor(
+            args.tensor_model_parallel_size,
+            args.context_parallel_size,
+            args.sequence_parallel,
         )
+        if args.seq_length % alignment != 0:
+            raise ValueError(
+                f"--seq-length ({args.seq_length}) must be divisible by {alignment} "
+                f"when pipeline_model_parallel_size > 1: the pipeline scheduler "
+                f"sizes its static P2P buffers with floor division, so the padded "
+                f"activation length would not match them."
+            )
     full_config = pretrain_cfg_container_from_args(args)
     # training.py enables allocator history only on the config-container MODEL
     # flow; this entry uses model_provider, so it enables recording itself, and

--- a/examples/multimodal_dev/pretrain_multimodal.py
+++ b/examples/multimodal_dev/pretrain_multimodal.py
@@ -95,6 +95,8 @@ def model_provider(
         args=args,
         language_config=language_config,
         vision_config=vision_config,
+        pre_process=pre_process,
+        post_process=post_process,
         **kwargs,
     )
 
@@ -149,16 +151,6 @@ if __name__ == "__main__":
         extra_args_provider=add_multimodal_args,
         args_defaults={},
     )
-    # multimodal_dev's model_provider builds the full model on every rank and
-    # does not honor pre_process / post_process pipeline-stage flags. PP>1
-    # would silently violate Megatron's pipeline-parallel contract.
-    if args.pipeline_model_parallel_size > 1:
-        raise ValueError(
-            "multimodal_dev does not support pipeline_model_parallel_size > 1 "
-            f"(got {args.pipeline_model_parallel_size}). The model provider "
-            "builds the full model on every rank; pipeline-stage splitting is "
-            "not wired through. Run with --pipeline-model-parallel-size 1."
-        )
     full_config = pretrain_cfg_container_from_args(args)
     pretrain(
         full_config,

--- a/examples/multimodal_dev/scripts/run_qwen35_vl.sh
+++ b/examples/multimodal_dev/scripts/run_qwen35_vl.sh
@@ -6,13 +6,17 @@
 #   ./examples/multimodal_dev/scripts/run_qwen35_vl.sh
 #
 # Environment variables:
-#   MODEL_VARIANT: proxy (default), 0.8b, 2b, 4b, 9b, 27b, 35b_a3b, 122b_a10b, 397b_a17b, 35b_a3b_light
+#   MODEL_VARIANT: proxy (default), pp_proxy, 0.8b, 2b, 4b, 9b, 27b, 35b_a3b, 122b_a10b, 397b_a17b, 35b_a3b_light
 #   CKPT_LOAD: path to a pre-converted checkpoint to load (enables --load + --finetune)
 #   CKPT_FORMAT: checkpoint format override (e.g. torch_dist); auto-detected when empty
-#   TP, EP, PP: parallelism sizes (PP must stay 1; multimodal_dev does not
-#               support pipeline parallelism)
+#   TP, EP, PP: parallelism sizes (PP>1 forces USE_FSDP=0)
 #   MBS, GBS: micro/global batch sizes
 #   NUM_LAYERS, NUM_EXPERTS: override for proxy testing
+#   DATASET_PROVIDER: cord_v2 (default) or mock
+#   TOKENIZER_TYPE: HuggingFaceTokenizer (default) or NullTokenizer
+#   VOCAB_SIZE: required for NullTokenizer
+#   MTP_NUM_LAYERS: set to 0 to disable MTP (default 1)
+#   SAVE_CHECKPOINT: set to 0 to skip --save/--save-interval
 #   FORCE_LOAD_BALANCING: set to 1 to enable --moe-router-force-load-balancing
 #                         (perf / mock-data only; OFF for real finetuning)
 #   LAUNCHER: torchrun (default) or python
@@ -44,6 +48,16 @@ LAUNCHER=${LAUNCHER:-torchrun}
 
 MODEL_VARIANT=${MODEL_VARIANT:-proxy}
 VISION_NUM_LAYERS=${VISION_NUM_LAYERS:-}
+
+# PP proxy-run knobs: let a tiny PP job run offline against mock data
+# without a HF tokenizer/processor download, and without MTP or
+# checkpoint writes.
+DATASET_PROVIDER=${DATASET_PROVIDER:-cord_v2}
+TOKENIZER_TYPE=${TOKENIZER_TYPE:-HuggingFaceTokenizer}
+VOCAB_SIZE=${VOCAB_SIZE:-}
+MTP_NUM_LAYERS=${MTP_NUM_LAYERS:-1}
+MTP_LOSS_SCALING_FACTOR=${MTP_LOSS_SCALING_FACTOR:-0.1}
+SAVE_CHECKPOINT=${SAVE_CHECKPOINT:-1}
 
 # Batch sizes
 MBS=${MBS:-2}
@@ -105,6 +119,18 @@ case "$MODEL_VARIANT" in
         NUM_QUERY_GROUPS=2
         LINEAR_NUM_VALUE_HEADS=64
         VISION_NUM_LAYERS=${VISION_NUM_LAYERS:-2}
+        ;;
+    pp_proxy)
+        # Minimal variant for pipeline-parallel smoke / parity runs.
+        NUM_LAYERS=${NUM_LAYERS:-4}
+        NUM_EXPERTS=${NUM_EXPERTS:-4}
+        HIDDEN_SIZE=${HIDDEN_SIZE:-512}
+        FFN_HIDDEN_SIZE=${FFN_HIDDEN_SIZE:-2048}
+        NUM_ATTN_HEADS=${NUM_ATTN_HEADS:-2}
+        NUM_QUERY_GROUPS=${NUM_QUERY_GROUPS:-1}
+        LINEAR_NUM_KEY_HEADS=${LINEAR_NUM_KEY_HEADS:-2}
+        LINEAR_NUM_VALUE_HEADS=${LINEAR_NUM_VALUE_HEADS:-4}
+        VISION_NUM_LAYERS=${VISION_NUM_LAYERS:-1}
         ;;
     9b)
         NUM_LAYERS=${NUM_LAYERS:-32}
@@ -177,6 +203,8 @@ case "$MODEL_VARIANT" in
         VISION_NUM_LAYERS=${VISION_NUM_LAYERS:-27}
         ;;
 esac
+# Upstream default for every variant except the PP proxy, which shrinks it.
+LINEAR_NUM_KEY_HEADS=${LINEAR_NUM_KEY_HEADS:-16}
 
 # Fail fast on inconsistent expert-parallelism configuration. Dense variants
 # (NUM_EXPERTS=0) do not emit any --num-experts / MoE args, so forwarding
@@ -260,13 +288,18 @@ TRAINING_ARGS=(
     --enable-experimental
     --manual-gc
     --manual-gc-interval 50
-    --mtp-num-layers 1
-    --mtp-loss-scaling-factor 0.1
     --sft
     --use-flash-attn
     # --attention-backend flash
     --calculate-per-token-loss
 )
+# MTP_NUM_LAYERS=0 disables MTP (useful to isolate PP from MTP behaviour).
+if [ "$MTP_NUM_LAYERS" -gt 0 ]; then
+    TRAINING_ARGS+=(
+        --mtp-num-layers "$MTP_NUM_LAYERS"
+        --mtp-loss-scaling-factor "$MTP_LOSS_SCALING_FACTOR"
+    )
+fi
 
 PROFILE_ARGS=()
 NSYS_CMD=()
@@ -296,9 +329,7 @@ fi
 SAVE_INTERVAL=${SAVE_INTERVAL:-500}
 EVAL_AND_LOGGING_ARGS=(
     --log-interval 1
-    --save-interval "$SAVE_INTERVAL"
     --eval-interval 500
-    --save "$CHECKPOINT_STORE_PATH"
     --eval-iters 10
     --tensorboard-dir "$TENSORBOARD_LOGS_PATH"
     --wandb-project "$WANDB_PROJECT"
@@ -308,20 +339,30 @@ EVAL_AND_LOGGING_ARGS=(
     --log-timers-to-tensorboard
     --log-params-norm
 )
+if [ "$SAVE_CHECKPOINT" -eq 1 ]; then
+    EVAL_AND_LOGGING_ARGS+=(
+        --save-interval "$SAVE_INTERVAL"
+        --save "$CHECKPOINT_STORE_PATH"
+    )
+fi
 
 # --- Tokenizer ---
 TOKENIZER_MODEL=${TOKENIZER_MODEL:-Qwen/Qwen3.5-397B-A17B}
 TOKENIZER_ARGS=(
-    --tokenizer-type HuggingFaceTokenizer
-    --tokenizer-model "$TOKENIZER_MODEL"
+    --tokenizer-type "$TOKENIZER_TYPE"
 )
+if [ "$TOKENIZER_TYPE" = "NullTokenizer" ] || [ "$TOKENIZER_TYPE" = "NullMultimodalTokenizer" ]; then
+    : "${VOCAB_SIZE:?VOCAB_SIZE must be set when TOKENIZER_TYPE=$TOKENIZER_TYPE}"
+    TOKENIZER_ARGS+=( --vocab-size "$VOCAB_SIZE" )
+else
+    TOKENIZER_ARGS+=( --tokenizer-model "$TOKENIZER_MODEL" )
+fi
 
 # --- Multimodal-specific ---
 MULTIMODAL_ARGS=(
     --model-arch qwen35_vl
     --model-variant "$MODEL_VARIANT"
-    --dataset-provider cord_v2
-    --hf-processor-path Qwen/Qwen3.5-397B-A17B
+    --dataset-provider "$DATASET_PROVIDER"
     --use-vanilla-collate-fn
     --image-token-id 248056
     --image-size 224
@@ -329,6 +370,15 @@ MULTIMODAL_ARGS=(
     --image-seq-length 256
     --vision-num-layers "$VISION_NUM_LAYERS"
 )
+# The HF processor is only needed by the real (cord_v2) dataset path;
+# the mock provider generates tensors directly.
+HF_PROCESSOR_PATH=${HF_PROCESSOR_PATH:-}
+if [ -z "$HF_PROCESSOR_PATH" ] && [ "$DATASET_PROVIDER" = "cord_v2" ]; then
+    HF_PROCESSOR_PATH=Qwen/Qwen3.5-397B-A17B
+fi
+if [ -n "$HF_PROCESSOR_PATH" ]; then
+    MULTIMODAL_ARGS+=( --hf-processor-path "$HF_PROCESSOR_PATH" )
+fi
 
 if [ "$USE_PACKED_SEQUENCE" -eq 1 ]; then
     MULTIMODAL_ARGS+=( --use-packed-sequence )
@@ -364,7 +414,7 @@ GPT_MODEL_ARGS=(
     --linear-conv-kernel-dim 4
     --linear-key-head-dim 128
     --linear-value-head-dim 128
-    --linear-num-key-heads 16
+    --linear-num-key-heads "$LINEAR_NUM_KEY_HEADS"
     --linear-num-value-heads "$LINEAR_NUM_VALUE_HEADS"
     --make-vocab-size-divisible-by 485
 )
@@ -381,6 +431,11 @@ MOE_ARGS=()
 case "$MODEL_VARIANT" in
     proxy)
         MOE_TOPK=2; MOE_FFN_HIDDEN=1024; MOE_SHARED_HIDDEN=1024
+        ;;
+    pp_proxy)
+        MOE_TOPK=${MOE_TOPK:-2}
+        MOE_FFN_HIDDEN=${MOE_FFN_HIDDEN:-256}
+        MOE_SHARED_HIDDEN=${MOE_SHARED_HIDDEN:-256}
         ;;
     35b_a3b|35b_a3b_light)
         MOE_TOPK=8; MOE_FFN_HIDDEN=512;  MOE_SHARED_HIDDEN=512
@@ -459,6 +514,11 @@ fi
 
 # --- FSDP ---
 USE_FSDP=${USE_FSDP:-1}
+# FSDP and PP are mutually exclusive in Megatron's standard path.
+if [ "$PP" -gt 1 ] && [ "$USE_FSDP" -eq 1 ]; then
+    echo "[run_qwen35_vl] PP=${PP} > 1 -> forcing USE_FSDP=0"
+    USE_FSDP=0
+fi
 if [ "$USE_FSDP" -eq 1 ]; then
     FSDP_ARGS=(
         --use-megatron-fsdp

--- a/examples/multimodal_dev/scripts/run_qwen35_vl.sh
+++ b/examples/multimodal_dev/scripts/run_qwen35_vl.sh
@@ -9,8 +9,9 @@
 #   MODEL_VARIANT: proxy (default), 0.8b, 2b, 4b, 9b, 27b, 35b_a3b, 122b_a10b, 397b_a17b, 35b_a3b_light
 #   CKPT_LOAD: path to a pre-converted checkpoint to load (enables --load + --finetune)
 #   CKPT_FORMAT: checkpoint format override (e.g. torch_dist); auto-detected when empty
-#   TP, EP, PP: parallelism sizes (PP>1 forces USE_FSDP=0; FSDP and PP are
-#               mutually exclusive on the standard path)
+#   TP, EP, PP: parallelism sizes (FSDP and PP are mutually exclusive on the
+#               standard path, so PP>1 defaults USE_FSDP to 0; an explicit
+#               USE_FSDP=1 with PP>1 is rejected rather than downgraded)
 #   SAVE_CHECKPOINT: set to 0 to skip --save/--save-interval (default 1)
 #   MBS, GBS: micro/global batch sizes
 #   NUM_LAYERS, NUM_EXPERTS: override for proxy testing
@@ -529,10 +530,29 @@ if [ -n "$CKPT_LOAD" ]; then
 fi
 
 # --- FSDP ---
+# Probe with ':+' rather than '+' so that USE_FSDP= (empty) is treated the same
+# way the ':-' default below treats it -- as "not set" -- instead of counting as
+# an explicit request for FSDP and hard-failing.
+USE_FSDP_WAS_SET=${USE_FSDP:+x}
 USE_FSDP=${USE_FSDP:-1}
-# FSDP and PP are mutually exclusive on Megatron's standard path.
+# FSDP and PP are mutually exclusive on Megatron's standard path. Downgrading an
+# explicit USE_FSDP=1 would drop --use-megatron-fsdp,
+# --data-parallel-sharding-strategy, --init-model-with-meta-device and
+# --ckpt-format fsdp_dtensor, so the job would still run but would no longer be
+# the FSDP configuration the caller asked to validate -- fail instead of
+# silently rewriting the requested mode. The implicit default (USE_FSDP unset)
+# is still auto-downgraded so that plain PP smoke runs work out of the box.
 if [ "$PP" -gt 1 ] && [ "$USE_FSDP" -eq 1 ]; then
-    echo "[run_qwen35_vl] PP=${PP} > 1 -> forcing USE_FSDP=0"
+    if [ -n "$USE_FSDP_WAS_SET" ]; then
+        echo "[run_qwen35_vl] ERROR: USE_FSDP=1 was explicitly requested with PP=${PP} > 1." >&2
+        echo "  FSDP and PP are mutually exclusive on the standard path; continuing would" >&2
+        echo "  drop --use-megatron-fsdp, --data-parallel-sharding-strategy," >&2
+        echo "  --init-model-with-meta-device and --ckpt-format fsdp_dtensor, so the run" >&2
+        echo "  would not be the FSDP configuration you asked for." >&2
+        echo "  Set USE_FSDP=0 (or leave it unset) to run with PP>1." >&2
+        exit 1
+    fi
+    echo "[run_qwen35_vl] PP=${PP} > 1 -> defaulting USE_FSDP=0"
     USE_FSDP=0
 fi
 if [ "$USE_FSDP" -eq 1 ]; then

--- a/examples/multimodal_dev/scripts/run_qwen35_vl.sh
+++ b/examples/multimodal_dev/scripts/run_qwen35_vl.sh
@@ -9,8 +9,9 @@
 #   MODEL_VARIANT: proxy (default), 0.8b, 2b, 4b, 9b, 27b, 35b_a3b, 122b_a10b, 397b_a17b, 35b_a3b_light
 #   CKPT_LOAD: path to a pre-converted checkpoint to load (enables --load + --finetune)
 #   CKPT_FORMAT: checkpoint format override (e.g. torch_dist); auto-detected when empty
-#   TP, EP, PP: parallelism sizes (PP must stay 1; multimodal_dev does not
-#               support pipeline parallelism)
+#   TP, EP, PP: parallelism sizes (PP>1 forces USE_FSDP=0; FSDP and PP are
+#               mutually exclusive on the standard path)
+#   SAVE_CHECKPOINT: set to 0 to skip --save/--save-interval (default 1)
 #   MBS, GBS: micro/global batch sizes
 #   NUM_LAYERS, NUM_EXPERTS: override for proxy testing
 #   ATTN_CADENCE: one period of the decoder attention layout, one symbol per
@@ -315,11 +316,10 @@ fi
 
 # --- Logging & Checkpointing ---
 SAVE_INTERVAL=${SAVE_INTERVAL:-500}
+SAVE_CHECKPOINT=${SAVE_CHECKPOINT:-1}
 EVAL_AND_LOGGING_ARGS=(
     --log-interval 1
-    --save-interval "$SAVE_INTERVAL"
     --eval-interval 500
-    --save "$CHECKPOINT_STORE_PATH"
     --eval-iters 10
     --tensorboard-dir "$TENSORBOARD_LOGS_PATH"
     --wandb-project "$WANDB_PROJECT"
@@ -329,6 +329,13 @@ EVAL_AND_LOGGING_ARGS=(
     --log-timers-to-tensorboard
     --log-params-norm
 )
+# Smoke / perf runs do not need the end-of-training checkpoint write.
+if [ "$SAVE_CHECKPOINT" -eq 1 ]; then
+    EVAL_AND_LOGGING_ARGS+=(
+        --save-interval "$SAVE_INTERVAL"
+        --save "$CHECKPOINT_STORE_PATH"
+    )
+fi
 
 # --- Tokenizer ---
 TOKENIZER_MODEL=${TOKENIZER_MODEL:-Qwen/Qwen3.5-397B-A17B}
@@ -523,6 +530,11 @@ fi
 
 # --- FSDP ---
 USE_FSDP=${USE_FSDP:-1}
+# FSDP and PP are mutually exclusive on Megatron's standard path.
+if [ "$PP" -gt 1 ] && [ "$USE_FSDP" -eq 1 ]; then
+    echo "[run_qwen35_vl] PP=${PP} > 1 -> forcing USE_FSDP=0"
+    USE_FSDP=0
+fi
 if [ "$USE_FSDP" -eq 1 ]; then
     FSDP_ARGS=(
         --use-megatron-fsdp

--- a/examples/multimodal_dev/tests/conftest.py
+++ b/examples/multimodal_dev/tests/conftest.py
@@ -82,6 +82,26 @@ def cleanup():
         torch.distributed.destroy_process_group()
 
 
+# Tests that must actually execute -- not merely be collected -- whenever the
+# world size allows it.  Keyed by the module basename, valued by the minimum
+# world size the module needs.
+_MUST_RUN_MODULES = {"test_pp_support.py": 2}
+
+_skipped_must_run = []
+
+
+def pytest_runtest_logreport(report):
+    """Record skips from modules that are required to run in this topology."""
+    if report.when != "setup" or not report.skipped:
+        return
+    module = os.path.basename(report.nodeid.split("::")[0])
+    min_world_size = _MUST_RUN_MODULES.get(module)
+    if min_world_size is None:
+        return
+    if int(os.environ.get("WORLD_SIZE", "1")) >= min_world_size:
+        _skipped_must_run.append(report.nodeid)
+
+
 def pytest_sessionfinish(session, exitstatus):
     """Treat "no tests collected" as success for the ``--experimental`` pass only.
 
@@ -99,3 +119,17 @@ def pytest_sessionfinish(session, exitstatus):
     """
     if exitstatus == 5 and session.config.getoption("--experimental"):
         session.exitstatus = 0
+
+    # A skip is invisible in a green run, so a guard that silently stops
+    # matching the CI topology (an "== 2 ranks" check under an 8-rank runner,
+    # say) would take the pipeline-parallel coverage to zero without anything
+    # going red. Fail loudly instead: if the world size was large enough for
+    # these tests to run and they skipped anyway, the bucket is not testing
+    # what it claims to.
+    if _skipped_must_run:
+        print(
+            "\nERROR: tests that must run in this topology were skipped "
+            f"(WORLD_SIZE={os.environ.get('WORLD_SIZE', '1')}):\n  "
+            + "\n  ".join(_skipped_must_run)
+        )
+        session.exitstatus = 1

--- a/examples/multimodal_dev/tests/test_mrope_parity.py
+++ b/examples/multimodal_dev/tests/test_mrope_parity.py
@@ -667,6 +667,12 @@ def test_vision_rope_wrapper_forwards_max_seqlen_to_thd(monkeypatch):
     config = SimpleNamespace(
         rotary_interleaved=False,
         multi_latent_attention=False,
+        # apply_rotary_pos_emb now probes these on the common path
+        # (_is_raw_mrope_freqs_thd and the fused-kernel dispatch), so the
+        # stub must honour the TransformerConfig contract, where both
+        # default to None / False.
+        mrope_section=None,
+        apply_rope_fusion=False,
     )
     t = torch.zeros(6, 2, 8, dtype=torch.bfloat16)
     freqs = torch.zeros(3, 1, 1, 8, dtype=torch.float32)

--- a/examples/multimodal_dev/tests/test_pp_support.py
+++ b/examples/multimodal_dev/tests/test_pp_support.py
@@ -1,0 +1,401 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Unit tests for pipeline parallelism (PP) support in multimodal_dev.
+
+Covers the PP plumbing added to :class:`MultimodalModel`:
+
+  1. The vision encoder is built on the first PP stage only.
+  2. ``pre_process`` / ``post_process`` / ``vp_stage`` reach the wrapped
+     ``GPTModel``, and ``shared_embedding_or_output_weight`` is surfaced
+     on the outer module for ``finalize_model_grads``.
+  3. A real two-stage forward + backward: stage 0 embeds text, runs the
+     vision encoder and scatters image embeddings; stage 1 consumes the
+     activation via ``set_input_tensor`` and computes the loss.  The
+     activation gradient is sent back so stage 0's backward runs too,
+     which is what proves the vision encoder is actually in the graph.
+
+These need exactly 2 ranks (PP=2).  Run with::
+
+    torchrun --nproc-per-node 2 -m pytest -q \\
+        examples/multimodal_dev/tests/test_pp_support.py
+"""
+
+import os
+import re
+import sys
+
+import pytest
+import torch
+import torch.distributed as dist
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from examples.multimodal_dev.models.base import MultimodalModel
+from megatron.core import parallel_state as ps
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_with_transformer_engine_spec
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.transformer.module import MegatronModule
+from megatron.core.transformer.transformer_config import TransformerConfig
+from tests.unit_tests.test_utilities import Utils
+
+PP_SIZE = 2
+NUM_LAYERS = 2
+HIDDEN = 128
+HEADS = 4
+VOCAB = 128
+SEQ = 32
+BATCH = 2
+IMAGE_TOKEN_ID = 7
+# Image-token positions per sample; total visual tokens = BATCH * len(...).
+IMAGE_POSITIONS = (0, 1, 2, 3)
+NUM_VISUAL_TOKENS = BATCH * len(IMAGE_POSITIONS)
+
+
+class _CountingVisionEncoder(MegatronModule):
+    """Minimal trainable stand-in for the real vision encoder.
+
+    Projects ``pixel_values`` ``[num_visual_tokens, H]`` to embeddings of
+    the same shape and records how many times it ran, so a test can
+    assert it never executes off the first PP stage.
+    """
+
+    def __init__(self, config, hidden_size, dtype=torch.bfloat16):
+        """Build the stub with a single square projection."""
+        super().__init__(config=config)
+        # Must match params_dtype: the surrounding TE layers and the
+        # incoming pixel_values share it, and .cuda() does not cast.
+        self.proj = torch.nn.Linear(hidden_size, hidden_size, bias=False, dtype=dtype)
+        self.calls = 0
+
+    def forward(self, pixel_values, image_grid_thw):
+        """Project pixel features and count the invocation."""
+        self.calls += 1
+        return self.proj(pixel_values)
+
+
+def _make_config(pp_size=PP_SIZE, dtype=torch.bfloat16):
+    return TransformerConfig(
+        num_layers=NUM_LAYERS,
+        hidden_size=HIDDEN,
+        ffn_hidden_size=4 * HIDDEN,
+        num_attention_heads=HEADS,
+        num_query_groups=HEADS,
+        bf16=(dtype is torch.bfloat16),
+        params_dtype=dtype,
+        pipeline_dtype=dtype,
+        hidden_dropout=0.0,
+        attention_dropout=0.0,
+        tensor_model_parallel_size=1,
+        pipeline_model_parallel_size=pp_size,
+        sequence_parallel=False,
+    )
+
+
+def _build_model(pre_process, post_process, vp_stage=None, pp_size=PP_SIZE, dtype=torch.bfloat16):
+    """Build a PP-stage-aware ``MultimodalModel`` on the current rank."""
+    config = _make_config(pp_size, dtype)
+    # model_parallel_cuda_manual_seed only seeds the CUDA RNG tracker, but
+    # the stub's nn.Linear initialises on CPU from the global RNG.  Without
+    # this every rank would build a different vision encoder.
+    torch.manual_seed(1234)
+    vision = _CountingVisionEncoder(config, HIDDEN, dtype)
+    model = MultimodalModel(
+        language_config=config,
+        language_spec=get_gpt_layer_with_transformer_engine_spec(),
+        vision_encoder=vision,
+        vocab_size=VOCAB,
+        max_sequence_length=SEQ,
+        image_token_id=IMAGE_TOKEN_ID,
+        position_embedding_type="rope",
+        parallel_output=False,
+        pre_process=pre_process,
+        post_process=post_process,
+        vp_stage=vp_stage,
+    )
+    return model.cuda()
+
+
+def _make_batch(seed=1234, dtype=torch.bfloat16):
+    """Deterministic batch, identical on every rank."""
+    g = torch.Generator(device="cuda")
+    g.manual_seed(seed)
+    input_ids = torch.randint(0, VOCAB, (BATCH, SEQ), generator=g, device="cuda")
+    # Keep image tokens exactly where we want them.
+    input_ids[input_ids == IMAGE_TOKEN_ID] = (IMAGE_TOKEN_ID + 1) % VOCAB
+    for pos in IMAGE_POSITIONS:
+        input_ids[:, pos] = IMAGE_TOKEN_ID
+    labels = torch.randint(0, VOCAB, (BATCH, SEQ), generator=g, device="cuda")
+    loss_mask = torch.ones(BATCH, SEQ, device="cuda")
+    position_ids = torch.arange(SEQ, device="cuda").unsqueeze(0).expand(BATCH, -1).contiguous()
+    pixel_values = torch.randn(NUM_VISUAL_TOKENS, HIDDEN, generator=g, device="cuda", dtype=dtype)
+    image_grid_thw = torch.tensor([[1, 2, 2]] * BATCH, device="cuda")
+    return input_ids, labels, loss_mask, position_ids, pixel_values, image_grid_thw
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _init_pp():
+    """Initialise PP=2 model-parallel groups for the whole module."""
+    Utils.initialize_model_parallel(
+        tensor_model_parallel_size=1, pipeline_model_parallel_size=PP_SIZE
+    )
+    model_parallel_cuda_manual_seed(1234)
+    yield
+    Utils.destroy_model_parallel()
+
+
+@pytest.fixture(scope="module")
+def stage_flags():
+    """``(is_first, is_last)`` for this rank's PP stage."""
+    if torch.distributed.get_world_size() != PP_SIZE:
+        pytest.skip(f"needs exactly {PP_SIZE} ranks (PP={PP_SIZE})")
+    return ps.is_pipeline_first_stage(), ps.is_pipeline_last_stage()
+
+
+def test_vision_encoder_only_on_first_stage(stage_flags):
+    """The vision encoder is retained on stage 0 and dropped elsewhere."""
+    is_first, is_last = stage_flags
+    model = _build_model(pre_process=is_first, post_process=is_last)
+
+    if is_first:
+        assert model.vision_model is not None, "stage 0 must own the vision encoder"
+        assert any(p.requires_grad for p in model.vision_model.parameters())
+    else:
+        assert model.vision_model is None, "non-first stages must not hold a vision encoder"
+
+    # No rank should carry vision params it does not own.
+    vision_param_names = [n for n, _ in model.named_parameters() if n.startswith("vision_model")]
+    assert bool(vision_param_names) == is_first
+
+
+def test_pp_flags_reach_language_model(stage_flags):
+    """``pre_process`` / ``post_process`` / ``vp_stage`` are threaded through."""
+    is_first, is_last = stage_flags
+    model = _build_model(pre_process=is_first, post_process=is_last, vp_stage=0)
+
+    assert model.pre_process is is_first
+    assert model.post_process is is_last
+    assert model.vp_stage == 0
+
+    assert model.language_model.pre_process is is_first
+    assert model.language_model.post_process is is_last
+    assert model.language_model.vp_stage == 0
+
+    # Only the first stage builds an embedding; only the last an output layer.
+    assert hasattr(model.language_model, "embedding") is is_first
+    assert hasattr(model.language_model, "output_layer") is is_last
+
+    # finalize_model_grads inspects the OUTER module for these two.
+    assert hasattr(model, "share_embeddings_and_output_weights")
+    assert callable(model.shared_embedding_or_output_weight)
+
+
+def test_pp_two_stage_forward_backward(stage_flags):
+    """A real PP=2 forward + backward produces finite loss and grads."""
+    is_first, is_last = stage_flags
+    model = _build_model(pre_process=is_first, post_process=is_last)
+    input_ids, labels, loss_mask, position_ids, pixel_values, image_grid_thw = _make_batch()
+
+    if is_first:
+        hidden = model(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            attention_mask=None,
+            labels=None,
+            loss_mask=None,
+            pixel_values=pixel_values,
+            image_grid_thw=image_grid_thw,
+        )
+        # Non-last stage returns hidden states in [S, B, H].
+        assert hidden.shape == (SEQ, BATCH, HIDDEN), hidden.shape
+        assert model.vision_model.calls == 1, "vision encoder must run exactly once on stage 0"
+
+        dist.send(hidden.detach().contiguous(), dst=1)
+        grad = torch.empty_like(hidden)
+        dist.recv(grad, src=1)
+        hidden.backward(grad)
+
+        vision_grads = [p.grad for p in model.vision_model.parameters() if p.grad is not None]
+        assert vision_grads, "vision encoder received no gradient — it is not in the graph"
+        assert all(torch.isfinite(g).all() for g in vision_grads)
+        assert any(g.abs().sum() > 0 for g in vision_grads)
+    else:
+        recvd = torch.empty(SEQ, BATCH, HIDDEN, dtype=torch.bfloat16, device="cuda")
+        dist.recv(recvd, src=0)
+        activation = recvd.clone().requires_grad_(True)
+        model.set_input_tensor(activation)
+
+        # Matches forward_step: pixel_values is dropped off the first stage.
+        output = model(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            attention_mask=None,
+            labels=labels,
+            loss_mask=loss_mask,
+            pixel_values=None,
+            image_grid_thw=image_grid_thw,
+        )
+        # Last stage returns per-token loss [B, S].
+        assert output.shape == (BATCH, SEQ), output.shape
+        loss = (output.float() * loss_mask).sum() / loss_mask.sum()
+        assert torch.isfinite(loss), f"non-finite loss: {loss}"
+
+        loss.backward()
+        assert activation.grad is not None, "no gradient flowed back to the stage input"
+        assert torch.isfinite(activation.grad).all()
+        dist.send(activation.grad.to(torch.bfloat16).contiguous(), dst=0)
+
+        decoder_grads = [p.grad for p in model.language_model.parameters() if p.grad is not None]
+        assert decoder_grads, "last stage produced no parameter gradients"
+        assert all(torch.isfinite(g).all() for g in decoder_grads)
+
+    dist.barrier()
+
+
+def _reinit(pp_size):
+    """Re-initialise model-parallel groups with a given PP size."""
+    ps.destroy_model_parallel()
+    ps.initialize_model_parallel(tensor_model_parallel_size=1, pipeline_model_parallel_size=pp_size)
+    model_parallel_cuda_manual_seed(1234)
+
+
+def _remap_to_stage(ref_state, stage_model, layers_per_stage):
+    """Pick this PP stage's slice out of a full (PP=1) state dict.
+
+    Local decoder layer ``i`` on stage ``r`` is global layer
+    ``i + r * layers_per_stage``; every other key maps one-to-one.
+    """
+    offset = ps.get_pipeline_model_parallel_rank() * layers_per_stage
+    mapped, missing = {}, []
+    for key in stage_model.state_dict():
+        if "_extra_state" in key:  # TE bookkeeping, not a real weight
+            continue
+        src = key
+        m = re.match(r"(.*decoder\.layers\.)(\d+)(\..*)", key)
+        if m:
+            src = f"{m.group(1)}{int(m.group(2)) + offset}{m.group(3)}"
+        if src in ref_state:
+            mapped[key] = ref_state[src]
+        else:
+            missing.append((key, src))
+    assert not missing, f"unmapped stage params: {missing[:5]}"
+    return mapped
+
+
+@pytest.mark.parametrize(
+    "dtype,rtol",
+    [
+        # Both layouts perform the same ops in the same order on the same
+        # weights, so in practice this is bit-identical (observed rel diff
+        # 0.0 for both dtypes on H100).  The bounds below are headroom for
+        # other hardware / kernel selections, not an expected error budget.
+        (torch.float32, 1e-5),
+        # bf16 keeps ~3.9e-3 relative precision and the stage boundary adds
+        # one more rounding of the activation, hence the looser bound.
+        (torch.bfloat16, 5e-3),
+    ],
+    ids=["fp32", "bf16"],
+)
+def test_pp2_matches_pp1_with_identical_weights(stage_flags, dtype, rtol):
+    """PP=2 reproduces the PP=1 loss when both use the same weights.
+
+    This is the parity check that the end-to-end mock-data run cannot
+    give: ``MockQwen35VLDataset.__getitem__`` draws from the global RNG
+    rather than seeding per index, so a PP=1 job and a PP=2 job do not
+    even consume the same samples.  Here the batch is fixed and the PP=2
+    stages are loaded from the PP=1 model, so any loss gap is the PP
+    plumbing itself.
+    """
+    # TF32 has only a 10-bit mantissa, so an "fp32" run still rounds every
+    # matmul to ~1e-3 relative and the two pipeline layouts issue different
+    # GEMM shapes.  Turn it off so the fp32 case really does isolate the PP
+    # plumbing rather than measuring TF32 noise.
+    prev_matmul_tf32 = torch.backends.cuda.matmul.allow_tf32
+    prev_cudnn_tf32 = torch.backends.cudnn.allow_tf32
+    if dtype is torch.float32:
+        torch.backends.cuda.matmul.allow_tf32 = False
+        torch.backends.cudnn.allow_tf32 = False
+    try:
+        _pp_parity_body(stage_flags, dtype, rtol)
+    finally:
+        torch.backends.cuda.matmul.allow_tf32 = prev_matmul_tf32
+        torch.backends.cudnn.allow_tf32 = prev_cudnn_tf32
+
+
+def _pp_parity_body(stage_flags, dtype, rtol):
+    """Body of the PP=1 vs PP=2 parity check (see the test above)."""
+    batch = _make_batch(seed=99, dtype=dtype)
+    input_ids, labels, loss_mask, position_ids, pixel_values, image_grid_thw = batch
+
+    # --- Phase 1: PP=1 reference (world becomes pure DP, so every rank
+    # builds the identical full model and computes the same loss). ---
+    _reinit(pp_size=1)
+    ref_model = _build_model(pre_process=True, post_process=True, pp_size=1, dtype=dtype)
+    with torch.no_grad():
+        ref_out = ref_model(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            attention_mask=None,
+            labels=labels,
+            loss_mask=loss_mask,
+            pixel_values=pixel_values,
+            image_grid_thw=image_grid_thw,
+        )
+    ref_loss = ((ref_out.float() * loss_mask).sum() / loss_mask.sum()).item()
+    # TE stores `_extra_state` entries that may be None; keep real tensors only.
+    ref_state = {
+        k: v.detach().clone()
+        for k, v in ref_model.state_dict().items()
+        if isinstance(v, torch.Tensor)
+    }
+    del ref_model
+    torch.cuda.empty_cache()
+
+    # --- Phase 2: PP=2, same weights, same batch. ---
+    _reinit(pp_size=PP_SIZE)
+    is_first, is_last = ps.is_pipeline_first_stage(), ps.is_pipeline_last_stage()
+    stage = _build_model(pre_process=is_first, post_process=is_last, dtype=dtype)
+    mapped = _remap_to_stage(ref_state, stage, NUM_LAYERS // PP_SIZE)
+    stage.load_state_dict(mapped, strict=False)
+
+    # The whole test is meaningless unless the stage really did adopt the
+    # reference weights, so prove it rather than assume it.
+    loaded = stage.state_dict()
+    bad = [k for k, v in mapped.items() if not torch.equal(loaded[k].to(v.dtype).cpu(), v.cpu())]
+    assert not bad, f"{len(bad)}/{len(mapped)} params did not take the reference value: {bad[:5]}"
+
+    with torch.no_grad():
+        if is_first:
+            hidden = stage(
+                input_ids=input_ids,
+                position_ids=position_ids,
+                attention_mask=None,
+                labels=None,
+                loss_mask=None,
+                pixel_values=pixel_values,
+                image_grid_thw=image_grid_thw,
+            )
+            dist.send(hidden.contiguous(), dst=1)
+        else:
+            recvd = torch.empty(SEQ, BATCH, HIDDEN, dtype=dtype, device="cuda")
+            dist.recv(recvd, src=0)
+            stage.set_input_tensor(recvd)
+            out = stage(
+                input_ids=input_ids,
+                position_ids=position_ids,
+                attention_mask=None,
+                labels=labels,
+                loss_mask=loss_mask,
+                pixel_values=None,
+                image_grid_thw=image_grid_thw,
+            )
+            pp_loss = ((out.float() * loss_mask).sum() / loss_mask.sum()).item()
+            rel = abs(pp_loss - ref_loss) / max(abs(ref_loss), 1e-12)
+            print(
+                f"\n[{dtype}] PP=1 loss {ref_loss:.8f} | "
+                f"PP=2 loss {pp_loss:.8f} | rel {rel:.3E}"
+            )
+            assert rel < rtol, f"PP=2 loss {pp_loss} != PP=1 loss {ref_loss} (rel {rel:.3E})"
+
+    dist.barrier()

--- a/examples/multimodal_dev/tests/test_pp_support.py
+++ b/examples/multimodal_dev/tests/test_pp_support.py
@@ -1,0 +1,409 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Unit tests for pipeline parallelism (PP) support in multimodal_dev.
+
+Covers the PP plumbing added to :class:`MultimodalModel`:
+
+  1. The vision encoder is built on the first PP stage only.
+  2. ``pre_process`` / ``post_process`` / ``vp_stage`` reach the wrapped
+     ``GPTModel``, and ``shared_embedding_or_output_weight`` is surfaced
+     on the outer module for ``finalize_model_grads``.
+  3. A real two-stage forward + backward: stage 0 embeds text, runs the
+     vision encoder and scatters image embeddings; stage 1 consumes the
+     activation via ``set_input_tensor`` and computes the loss.  The
+     activation gradient is sent back so stage 0's backward runs too,
+     which is what proves the vision encoder is actually in the graph.
+
+These need exactly 2 ranks (PP=2).  Run with::
+
+    torchrun --nproc-per-node 2 -m pytest -q \\
+        examples/multimodal_dev/tests/test_pp_support.py
+"""
+
+import os
+import re
+import sys
+
+import pytest
+import torch
+import torch.distributed as dist
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from examples.multimodal_dev.models.base import MultimodalModel
+from megatron.core import parallel_state as ps
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_with_transformer_engine_spec
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.transformer.module import MegatronModule
+from megatron.core.transformer.transformer_config import TransformerConfig
+from tests.unit_tests.test_utilities import Utils
+
+PP_SIZE = 2
+NUM_LAYERS = 2
+HIDDEN = 128
+HEADS = 4
+VOCAB = 128
+SEQ = 32
+BATCH = 2
+IMAGE_TOKEN_ID = 7
+# Image-token positions per sample; total visual tokens = BATCH * len(...).
+IMAGE_POSITIONS = (0, 1, 2, 3)
+NUM_VISUAL_TOKENS = BATCH * len(IMAGE_POSITIONS)
+
+
+class _CountingVisionEncoder(MegatronModule):
+    """Minimal trainable stand-in for the real vision encoder.
+
+    Projects ``pixel_values`` ``[num_visual_tokens, H]`` to embeddings of
+    the same shape and records how many times it ran, so a test can
+    assert it never executes off the first PP stage.
+    """
+
+    def __init__(self, config, hidden_size, dtype=torch.bfloat16):
+        """Build the stub with a single square projection."""
+        super().__init__(config=config)
+        # Must match params_dtype: the surrounding TE layers and the
+        # incoming pixel_values share it, and .cuda() does not cast.
+        self.proj = torch.nn.Linear(hidden_size, hidden_size, bias=False, dtype=dtype)
+        self.calls = 0
+
+    def forward(self, pixel_values, image_grid_thw):
+        """Project pixel features and count the invocation."""
+        self.calls += 1
+        return self.proj(pixel_values)
+
+
+def _make_config(pp_size=PP_SIZE, dtype=torch.bfloat16):
+    return TransformerConfig(
+        num_layers=NUM_LAYERS,
+        hidden_size=HIDDEN,
+        ffn_hidden_size=4 * HIDDEN,
+        num_attention_heads=HEADS,
+        num_query_groups=HEADS,
+        bf16=(dtype is torch.bfloat16),
+        params_dtype=dtype,
+        pipeline_dtype=dtype,
+        hidden_dropout=0.0,
+        attention_dropout=0.0,
+        tensor_model_parallel_size=1,
+        pipeline_model_parallel_size=pp_size,
+        sequence_parallel=False,
+    )
+
+
+def _build_model(pre_process, post_process, vp_stage=None, pp_size=PP_SIZE, dtype=torch.bfloat16):
+    """Build a PP-stage-aware ``MultimodalModel`` on the current rank."""
+    config = _make_config(pp_size, dtype)
+    # model_parallel_cuda_manual_seed only seeds the CUDA RNG tracker, but
+    # the stub's nn.Linear initialises on CPU from the global RNG.  Without
+    # this every rank would build a different vision encoder.
+    torch.manual_seed(1234)
+    vision = _CountingVisionEncoder(config, HIDDEN, dtype)
+    model = MultimodalModel(
+        language_config=config,
+        language_spec=get_gpt_layer_with_transformer_engine_spec(),
+        vision_encoder=vision,
+        vocab_size=VOCAB,
+        max_sequence_length=SEQ,
+        image_token_id=IMAGE_TOKEN_ID,
+        position_embedding_type="rope",
+        parallel_output=False,
+        pre_process=pre_process,
+        post_process=post_process,
+        vp_stage=vp_stage,
+    )
+    return model.cuda()
+
+
+def _make_batch(seed=1234, dtype=torch.bfloat16):
+    """Deterministic batch, identical on every rank."""
+    g = torch.Generator(device="cuda")
+    g.manual_seed(seed)
+    input_ids = torch.randint(0, VOCAB, (BATCH, SEQ), generator=g, device="cuda")
+    # Keep image tokens exactly where we want them.
+    input_ids[input_ids == IMAGE_TOKEN_ID] = (IMAGE_TOKEN_ID + 1) % VOCAB
+    for pos in IMAGE_POSITIONS:
+        input_ids[:, pos] = IMAGE_TOKEN_ID
+    labels = torch.randint(0, VOCAB, (BATCH, SEQ), generator=g, device="cuda")
+    loss_mask = torch.ones(BATCH, SEQ, device="cuda")
+    position_ids = torch.arange(SEQ, device="cuda").unsqueeze(0).expand(BATCH, -1).contiguous()
+    pixel_values = torch.randn(NUM_VISUAL_TOKENS, HIDDEN, generator=g, device="cuda", dtype=dtype)
+    image_grid_thw = torch.tensor([[1, 2, 2]] * BATCH, device="cuda")
+    return input_ids, labels, loss_mask, position_ids, pixel_values, image_grid_thw
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _init_pp():
+    """Initialise PP=2 model-parallel groups for the whole module."""
+    # Guard before initialising: Utils.initialize_model_parallel raises on a
+    # world size that is not a multiple of PP_SIZE, and this fixture is
+    # autouse, so checking any later would turn the intended skip into a
+    # collection-time error under the documented 1-rank invocation.
+    if Utils.world_size != PP_SIZE:
+        pytest.skip(f"needs exactly {PP_SIZE} ranks (PP={PP_SIZE})")
+    Utils.initialize_model_parallel(
+        tensor_model_parallel_size=1, pipeline_model_parallel_size=PP_SIZE
+    )
+    model_parallel_cuda_manual_seed(1234)
+    yield
+    Utils.destroy_model_parallel()
+
+
+@pytest.fixture(scope="module")
+def stage_flags():
+    """``(is_first, is_last)`` for this rank's PP stage."""
+    return ps.is_pipeline_first_stage(), ps.is_pipeline_last_stage()
+
+
+def test_vision_encoder_only_on_first_stage(stage_flags):
+    """The vision encoder is retained on stage 0 and dropped elsewhere."""
+    is_first, is_last = stage_flags
+    model = _build_model(pre_process=is_first, post_process=is_last)
+
+    if is_first:
+        assert model.vision_model is not None, "stage 0 must own the vision encoder"
+        assert any(p.requires_grad for p in model.vision_model.parameters())
+    else:
+        assert model.vision_model is None, "non-first stages must not hold a vision encoder"
+
+    # No rank should carry vision params it does not own.
+    vision_param_names = [n for n, _ in model.named_parameters() if n.startswith("vision_model")]
+    assert bool(vision_param_names) == is_first
+
+
+def test_pp_flags_reach_language_model(stage_flags):
+    """``pre_process`` / ``post_process`` / ``vp_stage`` are threaded through."""
+    is_first, is_last = stage_flags
+    model = _build_model(pre_process=is_first, post_process=is_last, vp_stage=0)
+
+    assert model.pre_process is is_first
+    assert model.vp_stage == 0
+    # post_process is intentionally not stored on the wrapper (see base.py),
+    # so it is only observable on the wrapped GPTModel below.
+    assert not hasattr(model, "post_process")
+
+    assert model.language_model.pre_process is is_first
+    assert model.language_model.post_process is is_last
+    assert model.language_model.vp_stage == 0
+
+    # Only the first stage builds an embedding; only the last an output layer.
+    assert hasattr(model.language_model, "embedding") is is_first
+    assert hasattr(model.language_model, "output_layer") is is_last
+
+    # finalize_model_grads inspects the OUTER module for these two.
+    assert hasattr(model, "share_embeddings_and_output_weights")
+    assert callable(model.shared_embedding_or_output_weight)
+
+
+def test_pp_two_stage_forward_backward(stage_flags):
+    """A real PP=2 forward + backward produces finite loss and grads."""
+    is_first, is_last = stage_flags
+    model = _build_model(pre_process=is_first, post_process=is_last)
+    input_ids, labels, loss_mask, position_ids, pixel_values, image_grid_thw = _make_batch()
+
+    if is_first:
+        hidden = model(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            attention_mask=None,
+            labels=None,
+            loss_mask=None,
+            pixel_values=pixel_values,
+            image_grid_thw=image_grid_thw,
+        )
+        # Non-last stage returns hidden states in [S, B, H].
+        assert hidden.shape == (SEQ, BATCH, HIDDEN), hidden.shape
+        assert model.vision_model.calls == 1, "vision encoder must run exactly once on stage 0"
+
+        dist.send(hidden.detach().contiguous(), dst=1)
+        grad = torch.empty_like(hidden)
+        dist.recv(grad, src=1)
+        hidden.backward(grad)
+
+        vision_grads = [p.grad for p in model.vision_model.parameters() if p.grad is not None]
+        assert vision_grads, "vision encoder received no gradient — it is not in the graph"
+        assert all(torch.isfinite(g).all() for g in vision_grads)
+        assert any(g.abs().sum() > 0 for g in vision_grads)
+    else:
+        recvd = torch.empty(SEQ, BATCH, HIDDEN, dtype=torch.bfloat16, device="cuda")
+        dist.recv(recvd, src=0)
+        activation = recvd.clone().requires_grad_(True)
+        model.set_input_tensor(activation)
+
+        # Matches forward_step: pixel_values is dropped off the first stage.
+        output = model(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            attention_mask=None,
+            labels=labels,
+            loss_mask=loss_mask,
+            pixel_values=None,
+            image_grid_thw=image_grid_thw,
+        )
+        # Last stage returns per-token loss [B, S].
+        assert output.shape == (BATCH, SEQ), output.shape
+        loss = (output.float() * loss_mask).sum() / loss_mask.sum()
+        assert torch.isfinite(loss), f"non-finite loss: {loss}"
+
+        loss.backward()
+        assert activation.grad is not None, "no gradient flowed back to the stage input"
+        assert torch.isfinite(activation.grad).all()
+        dist.send(activation.grad.to(torch.bfloat16).contiguous(), dst=0)
+
+        decoder_grads = [p.grad for p in model.language_model.parameters() if p.grad is not None]
+        assert decoder_grads, "last stage produced no parameter gradients"
+        assert all(torch.isfinite(g).all() for g in decoder_grads)
+
+    dist.barrier()
+
+
+def _reinit(pp_size):
+    """Re-initialise model-parallel groups with a given PP size."""
+    ps.destroy_model_parallel()
+    ps.initialize_model_parallel(tensor_model_parallel_size=1, pipeline_model_parallel_size=pp_size)
+    model_parallel_cuda_manual_seed(1234)
+
+
+def _remap_to_stage(ref_state, stage_model, layers_per_stage):
+    """Pick this PP stage's slice out of a full (PP=1) state dict.
+
+    Local decoder layer ``i`` on stage ``r`` is global layer
+    ``i + r * layers_per_stage``; every other key maps one-to-one.
+    """
+    offset = ps.get_pipeline_model_parallel_rank() * layers_per_stage
+    mapped, missing = {}, []
+    for key in stage_model.state_dict():
+        if "_extra_state" in key:  # TE bookkeeping, not a real weight
+            continue
+        src = key
+        m = re.match(r"(.*decoder\.layers\.)(\d+)(\..*)", key)
+        if m:
+            src = f"{m.group(1)}{int(m.group(2)) + offset}{m.group(3)}"
+        if src in ref_state:
+            mapped[key] = ref_state[src]
+        else:
+            missing.append((key, src))
+    assert not missing, f"unmapped stage params: {missing[:5]}"
+    return mapped
+
+
+@pytest.mark.parametrize(
+    "dtype,rtol",
+    [
+        # Both layouts perform the same ops in the same order on the same
+        # weights, so in practice this is bit-identical (observed rel diff
+        # 0.0 for both dtypes on H100).  The bounds below are headroom for
+        # other hardware / kernel selections, not an expected error budget.
+        (torch.float32, 1e-5),
+        # bf16 keeps ~3.9e-3 relative precision and the stage boundary adds
+        # one more rounding of the activation, hence the looser bound.
+        (torch.bfloat16, 5e-3),
+    ],
+    ids=["fp32", "bf16"],
+)
+def test_pp2_matches_pp1_with_identical_weights(dtype, rtol):
+    """PP=2 reproduces the PP=1 loss when both use the same weights.
+
+    This is the parity check that the end-to-end mock-data run cannot
+    give: ``MockQwen35VLDataset.__getitem__`` draws from the global RNG
+    rather than seeding per index, so a PP=1 job and a PP=2 job do not
+    even consume the same samples.  Here the batch is fixed and the PP=2
+    stages are loaded from the PP=1 model, so any loss gap is the PP
+    plumbing itself.
+    """
+    # TF32 has only a 10-bit mantissa, so an "fp32" run still rounds every
+    # matmul to ~1e-3 relative and the two pipeline layouts issue different
+    # GEMM shapes.  Turn it off so the fp32 case really does isolate the PP
+    # plumbing rather than measuring TF32 noise.
+    prev_matmul_tf32 = torch.backends.cuda.matmul.allow_tf32
+    prev_cudnn_tf32 = torch.backends.cudnn.allow_tf32
+    if dtype is torch.float32:
+        torch.backends.cuda.matmul.allow_tf32 = False
+        torch.backends.cudnn.allow_tf32 = False
+    try:
+        _pp_parity_body(dtype, rtol)
+    finally:
+        torch.backends.cuda.matmul.allow_tf32 = prev_matmul_tf32
+        torch.backends.cudnn.allow_tf32 = prev_cudnn_tf32
+
+
+def _pp_parity_body(dtype, rtol):
+    """Body of the PP=1 vs PP=2 parity check (see the test above)."""
+    batch = _make_batch(seed=99, dtype=dtype)
+    input_ids, labels, loss_mask, position_ids, pixel_values, image_grid_thw = batch
+
+    # --- Phase 1: PP=1 reference (world becomes pure DP, so every rank
+    # builds the identical full model and computes the same loss). ---
+    _reinit(pp_size=1)
+    ref_model = _build_model(pre_process=True, post_process=True, pp_size=1, dtype=dtype)
+    with torch.no_grad():
+        ref_out = ref_model(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            attention_mask=None,
+            labels=labels,
+            loss_mask=loss_mask,
+            pixel_values=pixel_values,
+            image_grid_thw=image_grid_thw,
+        )
+    ref_loss = ((ref_out.float() * loss_mask).sum() / loss_mask.sum()).item()
+    # TE stores `_extra_state` entries that may be None; keep real tensors only.
+    ref_state = {
+        k: v.detach().clone()
+        for k, v in ref_model.state_dict().items()
+        if isinstance(v, torch.Tensor)
+    }
+    del ref_model
+    torch.cuda.empty_cache()
+
+    # --- Phase 2: PP=2, same weights, same batch. ---
+    _reinit(pp_size=PP_SIZE)
+    # _reinit() rebuilt the process groups, so the stage flags must be derived
+    # here -- the module-scoped ``stage_flags`` fixture is stale after this.
+    is_first, is_last = ps.is_pipeline_first_stage(), ps.is_pipeline_last_stage()
+    stage = _build_model(pre_process=is_first, post_process=is_last, dtype=dtype)
+    mapped = _remap_to_stage(ref_state, stage, NUM_LAYERS // PP_SIZE)
+    stage.load_state_dict(mapped, strict=False)
+
+    # The whole test is meaningless unless the stage really did adopt the
+    # reference weights, so prove it rather than assume it.
+    loaded = stage.state_dict()
+    bad = [k for k, v in mapped.items() if not torch.equal(loaded[k].to(v.dtype).cpu(), v.cpu())]
+    assert not bad, f"{len(bad)}/{len(mapped)} params did not take the reference value: {bad[:5]}"
+
+    with torch.no_grad():
+        if is_first:
+            hidden = stage(
+                input_ids=input_ids,
+                position_ids=position_ids,
+                attention_mask=None,
+                labels=None,
+                loss_mask=None,
+                pixel_values=pixel_values,
+                image_grid_thw=image_grid_thw,
+            )
+            dist.send(hidden.contiguous(), dst=1)
+        else:
+            recvd = torch.empty(SEQ, BATCH, HIDDEN, dtype=dtype, device="cuda")
+            dist.recv(recvd, src=0)
+            stage.set_input_tensor(recvd)
+            out = stage(
+                input_ids=input_ids,
+                position_ids=position_ids,
+                attention_mask=None,
+                labels=labels,
+                loss_mask=loss_mask,
+                pixel_values=None,
+                image_grid_thw=image_grid_thw,
+            )
+            pp_loss = ((out.float() * loss_mask).sum() / loss_mask.sum()).item()
+            rel = abs(pp_loss - ref_loss) / max(abs(ref_loss), 1e-12)
+            print(
+                f"\n[{dtype}] PP=1 loss {ref_loss:.8f} | "
+                f"PP=2 loss {pp_loss:.8f} | rel {rel:.3E}"
+            )
+            assert rel < rtol, f"PP=2 loss {pp_loss} != PP=1 loss {ref_loss} (rel {rel:.3E})"
+
+    dist.barrier()

--- a/examples/multimodal_dev/tests/test_pp_support.py
+++ b/examples/multimodal_dev/tests/test_pp_support.py
@@ -6,15 +6,20 @@ Covers the PP plumbing added to :class:`MultimodalModel`:
 
   1. The vision encoder is built on the first PP stage only.
   2. ``pre_process`` / ``post_process`` / ``vp_stage`` reach the wrapped
-     ``GPTModel``, and ``shared_embedding_or_output_weight`` is surfaced
+     ``HybridModel``, and ``shared_embedding_or_output_weight`` is surfaced
      on the outer module for ``finalize_model_grads``.
   3. A real two-stage forward + backward: stage 0 embeds text, runs the
      vision encoder and scatters image embeddings; stage 1 consumes the
      activation via ``set_input_tensor`` and computes the loss.  The
      activation gradient is sent back so stage 0's backward runs too,
      which is what proves the vision encoder is actually in the graph.
+  4. With tied embeddings, the real ``_allreduce_word_embedding_grads``
+     path synchronises the first stage's embedding weight with the last
+     stage's output-layer weight.
 
-These need exactly 2 ranks (PP=2).  Run with::
+These run at any world size that is a multiple of ``PP_SIZE``; the extra
+ranks form data-parallel replicas, which is what the CI unit-test bucket
+supplies (``torchrun --nproc_per_node 8``).  Run locally with::
 
     torchrun --nproc-per-node 2 -m pytest -q \\
         examples/multimodal_dev/tests/test_pp_support.py
@@ -34,14 +39,24 @@ if _REPO_ROOT not in sys.path:
 
 from examples.multimodal_dev.models.base import MultimodalModel
 from megatron.core import parallel_state as ps
-from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_with_transformer_engine_spec
+from megatron.core.distributed.distributed_data_parallel_config import DistributedDataParallelConfig
+from megatron.core.distributed.finalize_model_grads import _allreduce_word_embedding_grads
+from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_stack_spec
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.transformer_config import TransformerConfig
 from tests.unit_tests.test_utilities import Utils
 
 PP_SIZE = 2
-NUM_LAYERS = 2
+# One character per layer: '*' is a standard attention layer, '-' a dense MLP
+# layer.  Four layers split evenly into two attention+MLP pairs, one per stage.
+LAYER_PATTERN = "*-*-"
+# HybridModel refuses vp_stage != None unless the pattern names its pipeline
+# stages explicitly with '|'.  Same four layers, split one attention+MLP pair
+# per stage, so the model is identical to LAYER_PATTERN apart from the
+# stage boundary being written down.
+VPP_LAYER_PATTERN = "*-|*-"
+NUM_LAYERS = len(LAYER_PATTERN)
 HIDDEN = 128
 HEADS = 4
 VOCAB = 128
@@ -93,7 +108,15 @@ def _make_config(pp_size=PP_SIZE, dtype=torch.bfloat16):
     )
 
 
-def _build_model(pre_process, post_process, vp_stage=None, pp_size=PP_SIZE, dtype=torch.bfloat16):
+def _build_model(
+    pre_process,
+    post_process,
+    vp_stage=None,
+    pp_size=PP_SIZE,
+    dtype=torch.bfloat16,
+    share_embeddings_and_output_weights=False,
+    layer_pattern=LAYER_PATTERN,
+):
     """Build a PP-stage-aware ``MultimodalModel`` on the current rank."""
     config = _make_config(pp_size, dtype)
     # model_parallel_cuda_manual_seed only seeds the CUDA RNG tracker, but
@@ -103,13 +126,15 @@ def _build_model(pre_process, post_process, vp_stage=None, pp_size=PP_SIZE, dtyp
     vision = _CountingVisionEncoder(config, HIDDEN, dtype)
     model = MultimodalModel(
         language_config=config,
-        language_spec=get_gpt_layer_with_transformer_engine_spec(),
+        hybrid_stack_spec=hybrid_stack_spec,
+        hybrid_layer_pattern=layer_pattern,
         vision_encoder=vision,
         vocab_size=VOCAB,
         max_sequence_length=SEQ,
         image_token_id=IMAGE_TOKEN_ID,
         position_embedding_type="rope",
         parallel_output=False,
+        share_embeddings_and_output_weights=share_embeddings_and_output_weights,
         pre_process=pre_process,
         post_process=post_process,
         vp_stage=vp_stage,
@@ -136,19 +161,37 @@ def _make_batch(seed=1234, dtype=torch.bfloat16):
 
 @pytest.fixture(scope="module", autouse=True)
 def _init_pp():
-    """Initialise PP=2 model-parallel groups for the whole module."""
+    """Initialise PP=PP_SIZE model-parallel groups for the whole module.
+
+    Any world size that is a multiple of ``PP_SIZE`` works: the remaining
+    ranks become data-parallel replicas.  That is what makes this module
+    execute under the CI unit-test bucket, which runs
+    ``torchrun --nproc_per_node 8`` -- an ``== PP_SIZE`` guard here would
+    skip every test in the bucket and report green with zero PP coverage.
+    """
     # Guard before initialising: Utils.initialize_model_parallel raises on a
     # world size that is not a multiple of PP_SIZE, and this fixture is
     # autouse, so checking any later would turn the intended skip into a
-    # collection-time error under the documented 1-rank invocation.
-    if Utils.world_size != PP_SIZE:
-        pytest.skip(f"needs exactly {PP_SIZE} ranks (PP={PP_SIZE})")
+    # collection-time error on a 1-rank invocation.
+    if Utils.world_size < PP_SIZE or Utils.world_size % PP_SIZE != 0:
+        pytest.skip(f"needs a world size that is a multiple of {PP_SIZE} (PP={PP_SIZE})")
     Utils.initialize_model_parallel(
         tensor_model_parallel_size=1, pipeline_model_parallel_size=PP_SIZE
     )
     model_parallel_cuda_manual_seed(1234)
     yield
     Utils.destroy_model_parallel()
+
+
+def _pp_peer_ranks():
+    """``(first_stage_rank, last_stage_rank)`` global ranks for this PP group.
+
+    The stages of a PP group are not global ranks 0 and 1 once the world is
+    larger than ``PP_SIZE``: each data-parallel replica owns its own pair, so
+    point-to-point sends must target this rank's own group members.
+    """
+    pp_ranks = dist.get_process_group_ranks(ps.get_pipeline_model_parallel_group())
+    return pp_ranks[0], pp_ranks[-1]
 
 
 @pytest.fixture(scope="module")
@@ -176,12 +219,14 @@ def test_vision_encoder_only_on_first_stage(stage_flags):
 def test_pp_flags_reach_language_model(stage_flags):
     """``pre_process`` / ``post_process`` / ``vp_stage`` are threaded through."""
     is_first, is_last = stage_flags
-    model = _build_model(pre_process=is_first, post_process=is_last, vp_stage=0)
+    model = _build_model(
+        pre_process=is_first, post_process=is_last, vp_stage=0, layer_pattern=VPP_LAYER_PATTERN
+    )
 
     assert model.pre_process is is_first
     assert model.vp_stage == 0
     # post_process is intentionally not stored on the wrapper (see base.py),
-    # so it is only observable on the wrapped GPTModel below.
+    # so it is only observable on the wrapped HybridModel below.
     assert not hasattr(model, "post_process")
 
     assert model.language_model.pre_process is is_first
@@ -200,6 +245,7 @@ def test_pp_flags_reach_language_model(stage_flags):
 def test_pp_two_stage_forward_backward(stage_flags):
     """A real PP=2 forward + backward produces finite loss and grads."""
     is_first, is_last = stage_flags
+    first_rank, last_rank = _pp_peer_ranks()
     model = _build_model(pre_process=is_first, post_process=is_last)
     input_ids, labels, loss_mask, position_ids, pixel_values, image_grid_thw = _make_batch()
 
@@ -217,9 +263,9 @@ def test_pp_two_stage_forward_backward(stage_flags):
         assert hidden.shape == (SEQ, BATCH, HIDDEN), hidden.shape
         assert model.vision_model.calls == 1, "vision encoder must run exactly once on stage 0"
 
-        dist.send(hidden.detach().contiguous(), dst=1)
+        dist.send(hidden.detach().contiguous(), dst=last_rank)
         grad = torch.empty_like(hidden)
-        dist.recv(grad, src=1)
+        dist.recv(grad, src=last_rank)
         hidden.backward(grad)
 
         vision_grads = [p.grad for p in model.vision_model.parameters() if p.grad is not None]
@@ -228,7 +274,7 @@ def test_pp_two_stage_forward_backward(stage_flags):
         assert any(g.abs().sum() > 0 for g in vision_grads)
     else:
         recvd = torch.empty(SEQ, BATCH, HIDDEN, dtype=torch.bfloat16, device="cuda")
-        dist.recv(recvd, src=0)
+        dist.recv(recvd, src=first_rank)
         activation = recvd.clone().requires_grad_(True)
         model.set_input_tensor(activation)
 
@@ -250,11 +296,108 @@ def test_pp_two_stage_forward_backward(stage_flags):
         loss.backward()
         assert activation.grad is not None, "no gradient flowed back to the stage input"
         assert torch.isfinite(activation.grad).all()
-        dist.send(activation.grad.to(torch.bfloat16).contiguous(), dst=0)
+        dist.send(activation.grad.to(torch.bfloat16).contiguous(), dst=first_rank)
 
         decoder_grads = [p.grad for p in model.language_model.parameters() if p.grad is not None]
         assert decoder_grads, "last stage produced no parameter gradients"
         assert all(torch.isfinite(g).all() for g in decoder_grads)
+
+    dist.barrier()
+
+
+def test_tied_embedding_grads_sync_across_stages(stage_flags):
+    """Tied embeddings really are all-reduced between the first and last stage.
+
+    ``MultimodalModel`` surfaces ``share_embeddings_and_output_weights`` and
+    ``shared_embedding_or_output_weight()`` precisely so that
+    ``finalize_model_grads._allreduce_word_embedding_grads`` can find them:
+    it resolves the module with
+    ``get_attr_wrapped_model(chunk, 'pre_process', return_model_obj=True)``,
+    which now stops at the wrapper rather than the inner ``HybridModel``.
+    Asserting only that the two names exist would still pass if the flag were
+    wrong, the wrong parameter were returned, or the reduction never ran --
+    each of which silently desynchronises the embedding across stages and
+    shows up much later as an unexplained accuracy loss.  So drive the real
+    reduction and check the resulting gradient.
+    """
+    is_first, is_last = stage_flags
+    first_rank, last_rank = _pp_peer_ranks()
+    model = _build_model(
+        pre_process=is_first, post_process=is_last, share_embeddings_and_output_weights=True
+    )
+    input_ids, labels, loss_mask, position_ids, pixel_values, image_grid_thw = _make_batch()
+
+    # The flag itself is what _get_shared_word_embedding_weight branches on.
+    assert model.share_embeddings_and_output_weights is True
+
+    # The wrapper must hand back the stage-appropriate tensor, not just *a*
+    # tensor: the embedding on the first stage, the output layer on the last.
+    weight = model.shared_embedding_or_output_weight()
+    assert weight is not None
+    if is_first:
+        assert weight is model.language_model.embedding.word_embeddings.weight
+    else:
+        assert weight is model.language_model.output_layer.weight
+
+    if is_first:
+        hidden = model(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            attention_mask=None,
+            labels=None,
+            loss_mask=None,
+            pixel_values=pixel_values,
+            image_grid_thw=image_grid_thw,
+        )
+        dist.send(hidden.detach().contiguous(), dst=last_rank)
+        grad = torch.empty_like(hidden)
+        dist.recv(grad, src=last_rank)
+        hidden.backward(grad)
+    else:
+        recvd = torch.empty(SEQ, BATCH, HIDDEN, dtype=torch.bfloat16, device="cuda")
+        dist.recv(recvd, src=first_rank)
+        activation = recvd.clone().requires_grad_(True)
+        model.set_input_tensor(activation)
+        output = model(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            attention_mask=None,
+            labels=labels,
+            loss_mask=loss_mask,
+            pixel_values=None,
+            image_grid_thw=image_grid_thw,
+        )
+        loss = (output.float() * loss_mask).sum() / loss_mask.sum()
+        loss.backward()
+        dist.send(activation.grad.to(torch.bfloat16).contiguous(), dst=first_rank)
+
+    assert weight.grad is not None, "tied weight received no gradient on this stage"
+    local_grad = weight.grad.detach().clone()
+
+    # _allreduce_embedding_grad reads ddp_config off the chunk before
+    # unwrapping it; these models are not DDP-wrapped, so supply the plain
+    # config it expects (no Megatron-FSDP, so grads stay ordinary tensors).
+    model.ddp_config = DistributedDataParallelConfig()
+    _allreduce_word_embedding_grads([model], model.config)
+
+    # Exchange the pre-reduction gradients so both stages can check the
+    # reduction against the expected sum.  Order the sends to avoid a deadlock.
+    peer_grad = torch.empty_like(local_grad)
+    if is_first:
+        dist.send(local_grad.contiguous(), dst=last_rank)
+        dist.recv(peer_grad, src=last_rank)
+    else:
+        dist.recv(peer_grad, src=first_rank)
+        dist.send(local_grad.contiguous(), dst=first_rank)
+
+    expected = local_grad.float() + peer_grad.float()
+    assert torch.allclose(weight.grad.float(), expected, rtol=1e-2, atol=1e-2), (
+        "tied embedding gradient was not all-reduced across the first and last "
+        "pipeline stages"
+    )
+    # A no-op reduction would trivially satisfy an "is finite" style check, so
+    # require that the peer actually contributed something.
+    assert peer_grad.abs().sum() > 0, "peer stage contributed a zero gradient"
 
     dist.barrier()
 
@@ -363,6 +506,7 @@ def _pp_parity_body(dtype, rtol):
     # _reinit() rebuilt the process groups, so the stage flags must be derived
     # here -- the module-scoped ``stage_flags`` fixture is stale after this.
     is_first, is_last = ps.is_pipeline_first_stage(), ps.is_pipeline_last_stage()
+    first_rank, last_rank = _pp_peer_ranks()
     stage = _build_model(pre_process=is_first, post_process=is_last, dtype=dtype)
     mapped = _remap_to_stage(ref_state, stage, NUM_LAYERS // PP_SIZE)
     stage.load_state_dict(mapped, strict=False)
@@ -384,10 +528,10 @@ def _pp_parity_body(dtype, rtol):
                 pixel_values=pixel_values,
                 image_grid_thw=image_grid_thw,
             )
-            dist.send(hidden.contiguous(), dst=1)
+            dist.send(hidden.contiguous(), dst=last_rank)
         else:
             recvd = torch.empty(SEQ, BATCH, HIDDEN, dtype=dtype, device="cuda")
-            dist.recv(recvd, src=0)
+            dist.recv(recvd, src=first_rank)
             stage.set_input_tensor(recvd)
             out = stage(
                 input_ids=input_ids,

--- a/examples/multimodal_dev/tests/test_run_script_fsdp_pp.py
+++ b/examples/multimodal_dev/tests/test_run_script_fsdp_pp.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Launcher tests for the FSDP/PP interaction in ``run_qwen35_vl.sh``.
+
+FSDP and pipeline parallelism are mutually exclusive on Megatron's standard
+path, so the script has to decide what to do when both are requested.  The
+contract these tests pin down is:
+
+* ``USE_FSDP`` unset and ``PP>1`` -- default it to 0 so a plain PP smoke run
+  works out of the box;
+* ``USE_FSDP=0`` and ``PP>1`` -- run without FSDP, no complaints;
+* ``USE_FSDP=1`` and ``PP>1`` -- fail, rather than quietly downgrading to a
+  non-FSDP run that the caller could mistake for the FSDP+PP validation they
+  asked for;
+* ``PP=1`` -- FSDP stays on, which is the script's long-standing default.
+
+These run the script with ``DRY_RUN=1``, which assembles the full torchrun
+command line, echoes it and exits before launching anything, so no GPU or
+dataset is required.
+"""
+
+import os
+import subprocess
+
+import pytest
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
+_SCRIPT = os.path.join(_REPO_ROOT, "examples/multimodal_dev/scripts/run_qwen35_vl.sh")
+
+# Present only when FSDP is actually enabled; --use-distributed-optimizer is
+# emitted unconditionally elsewhere in the script, so it cannot be used as the
+# probe here.
+FSDP_FLAG = "--use-megatron-fsdp"
+
+
+def _run(tmp_path, **env_overrides):
+    """Dry-run the launcher and return the completed process."""
+    env = dict(os.environ)
+    env.update(
+        {
+            "DRY_RUN": "1",
+            "MODEL_VARIANT": "proxy",
+            # Keep the script's mkdir side effects inside the test's tmpdir.
+            "ROOT_DIR": f"{tmp_path}/root/",
+            "TENSORBOARD_LOGS_PATH": f"{tmp_path}/tb",
+        }
+    )
+    # Let each case decide whether USE_FSDP is set at all -- the unset case is
+    # exactly what distinguishes the default from an explicit request.
+    env.pop("USE_FSDP", None)
+    env.update(env_overrides)
+    return subprocess.run(
+        ["bash", _SCRIPT], env=env, capture_output=True, text=True, cwd=_REPO_ROOT
+    )
+
+
+@pytest.mark.skipif(not os.path.exists(_SCRIPT), reason="launcher script not found")
+@pytest.mark.parametrize(
+    "use_fsdp",
+    [
+        pytest.param(None, id="unset"),
+        # USE_FSDP= (empty) is a natural way to say "no FSDP"; the script probes
+        # with ${USE_FSDP:+x} so it is treated as unset rather than as an
+        # explicit request for FSDP.
+        pytest.param("", id="empty"),
+        pytest.param("0", id="explicit-0"),
+    ],
+)
+def test_pp_gt_1_runs_without_fsdp(tmp_path, use_fsdp):
+    """PP>1 proceeds without FSDP when FSDP was not explicitly requested."""
+    overrides = {"PP": "2"}
+    if use_fsdp is not None:
+        overrides["USE_FSDP"] = use_fsdp
+    proc = _run(tmp_path, **overrides)
+
+    assert proc.returncode == 0, f"launcher failed:\n{proc.stdout}\n{proc.stderr}"
+    assert FSDP_FLAG not in proc.stdout, "PP>1 must not emit FSDP flags"
+
+
+@pytest.mark.skipif(not os.path.exists(_SCRIPT), reason="launcher script not found")
+def test_explicit_fsdp_with_pp_is_rejected(tmp_path):
+    """An explicit USE_FSDP=1 with PP>1 fails instead of being downgraded."""
+    proc = _run(tmp_path, PP="2", USE_FSDP="1")
+
+    assert proc.returncode != 0, (
+        "explicitly requesting FSDP with PP>1 must fail rather than silently "
+        f"running without FSDP:\n{proc.stdout}"
+    )
+    # The caller needs to learn which mode was refused, not just that something
+    # went wrong.
+    assert "USE_FSDP=1" in proc.stderr
+    assert FSDP_FLAG not in proc.stdout, "the rejected run must not launch"
+
+
+@pytest.mark.skipif(not os.path.exists(_SCRIPT), reason="launcher script not found")
+def test_pp_1_still_defaults_to_fsdp(tmp_path):
+    """The PP>1 guard does not disturb the ordinary PP=1 FSDP default."""
+    proc = _run(tmp_path, PP="1")
+
+    assert proc.returncode == 0, f"launcher failed:\n{proc.stdout}\n{proc.stderr}"
+    assert FSDP_FLAG in proc.stdout, "PP=1 must keep FSDP enabled by default"


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Adds pipeline-parallel (PP) support to the `examples/multimodal_dev` training path and its Qwen3.5-VL model, which previously built the full model on every rank and rejected `--pipeline-model-parallel-size > 1` outright.

Rebased onto current `dev`, which now includes #6315 (Qwen3.5-VL migrated to `HybridModel`). The PP plumbing is threaded through `HybridModel`'s native `pre_process` / `post_process` / `vp_stage` parameters.

## Issue tracking

Linked issue: N/A (example-only change, no `megatron/core` modifications)

## Summary

**Model / stage splitting**
- `MultimodalModel` accepts `pre_process` / `post_process` / `vp_stage` and forwards them to the wrapped `HybridModel`; the vision encoder is built on the **first PP stage only**.
- Surfaces `share_embeddings_and_output_weights` and `shared_embedding_or_output_weight()` on the outer module. `finalize_model_grads._allreduce_embedding_grad` resolves the module with `get_attr_wrapped_model(model_module, 'pre_process', return_model_obj=True)`, which now stops at `MultimodalModel`, and then reads *both* names off it. `Float16Module` proxies neither, so without this the tied-embedding / MTP grad all-reduce would `AttributeError`.
- `post_process` is deliberately **not** stored on the wrapper. Nothing reads it there, and storing it would make `get_attr_wrapped_model(model, 'post_process', return_model_obj=True)` — used by `schedules.clear_embedding_activation_buffer` — resolve to `MultimodalModel` instead of the `HybridModel` that owns `embedding_activation_buffer`.
- `Qwen35VLModel` skips vision-encoder construction when `pre_process=False`.
- `pretrain_multimodal.model_provider` forwards the stage flags to the registry factory, and the `PP > 1` guard is removed now that stage splitting is actually wired through.

**forward_step**
- Drops `pixel_values` off the first stage; keeps `image_grid_thw` on every stage, since MRoPE freqs are computed per stage inside `HybridModel`.
- Only CP-splits `loss_mask` on the last stage, where the pipeline scheduler invokes the loss closure.

**Static sequence length under PP**
- BSHD batches pad to `args.seq_length` when PP > 1. The non-packed branch of `pack_or_pad_batch` otherwise pads each microbatch to the per-microbatch maximum sample length, which does not match the PP scheduler's static P2P buffers. PP = 1 keeps the previous per-microbatch padding.
- Two guards make the resulting invariants explicit instead of failing deep in a P2P send:
  - `--seq-length` must be divisible by the CP/SP alignment factor under PP > 1. `pack_or_pad_batch` rounds *up* to that factor while `schedules.get_tensor_shapes` sizes the static buffers with floor division, so an unaligned length would mismatch them.
  - No sample may exceed `--seq-length` under PP > 1, since the batch is padded to a static length there.
- `--use-packed-sequence` with PP > 1 sets `config.variable_seq_lengths`, so THD activations (`[total_padded_tokens, 1, H]`) negotiate their shapes at each send/recv. The allgather-dispatcher check is repeated locally because the field is assigned after `__post_init__` has run. PP = 1 has no send/recv, so neither the flag nor the dispatcher restriction is imposed there.

**Launcher**
- `PP > 1` defaults `USE_FSDP` to 0 (FSDP and PP are mutually exclusive on the standard path), but an **explicit** `USE_FSDP=1` with `PP > 1` is now rejected rather than silently downgraded — otherwise the run proceeds without `--use-megatron-fsdp`, `--data-parallel-sharding-strategy`, `--init-model-with-meta-device` and `--ckpt-format fsdp_dtensor`, and could be mistaken for the FSDP+PP validation the caller asked for. The was-set probe uses `${USE_FSDP:+x}` so an empty `USE_FSDP=` is treated as unset, matching the `${USE_FSDP:-1}` default beside it.
- Adds `SAVE_CHECKPOINT=0` to skip `--save` / `--save-interval`. With the defaults `TRAIN_ITERS=500` and `SAVE_INTERVAL=500`, every plain run writes a full checkpoint at the end whether or not it wanted one.

## Review feedback addressed

**PP tests were invisible to CI.** The suite required a world size of exactly 2, but the unit-test bucket runs `torchrun --nproc_per_node 8`, so every test in the module skipped and the bucket reported green with zero PP coverage. The fixture now initialises `PP=PP_SIZE` and lets the remaining ranks form data-parallel replicas, so any world size that is a multiple of `PP_SIZE` executes the suite. Point-to-point sends target this rank's own pipeline group instead of the hard-coded global ranks 0 and 1, which are no longer the stage peers once the world is larger than `PP_SIZE`.

To keep this from regressing silently, `examples/multimodal_dev/tests/conftest.py` gains a bucket-level guard that fails the session if a module listed in `_MUST_RUN_MODULES` skipped while the world size was large enough to run it.

**Tied embeddings were only checked for shape, not behaviour.** The previous assertions verified that `share_embeddings_and_output_weights` and `shared_embedding_or_output_weight` merely *exist*, which would still pass with a wrong flag, a wrong parameter, or no cross-stage reduction at all. `test_tied_embedding_grads_sync_across_stages` now builds a tied model, runs a two-stage forward/backward, drives the real `_allreduce_word_embedding_grads` path, and asserts the resulting gradient equals the sum of both stages' contributions.

**Launcher mode rewriting.** Covered above; `examples/multimodal_dev/tests/test_run_script_fsdp_pp.py` exercises the unset, empty, explicit-`0`, explicit-`1` and `PP=1` cases against the script's dry-run path.

## Testing

### Re-verified after the rebase onto `HybridModel`

Full `examples/multimodal_dev` CI bucket, single node, 8×H100, run the way CI runs it (`torch.distributed.run --nproc_per_node 8`, markers `not experimental and not flaky_in_dev`):

**76 passed.**

The PP tests are reported as PASSED rather than skipped at world size 8, which is the acceptance criterion requested in review. PP=1 vs PP=2 loss parity on identical weights is bit-identical:

```
[fp32]     PP=1 4.88800621 | PP=2 4.88800621 | rel 0.000E+00
[bfloat16] PP=1 4.87177610 | PP=2 4.87177610 | rel 0.000E+00
```

`test_pp_support.py` covers stage construction (vision encoder on stage 0 only), flag threading into `HybridModel`, a real two-stage forward + backward including the vision-encoder gradient path, the tied-embedding gradient synchronisation described above, and the PP=1 vs PP=2 parity check.

### Verified before the rebase, not yet re-run

These were run against the pre-rebase revision (when the decoder was still `GPTModel`) and have **not** been repeated on the current `HybridModel` base:

- End-to-end PP = 2 on mock data, MoE (16 experts, top-2, grouped GEMM, alltoall) + MTP (1 layer) + vision encoder through the real 1F1B scheduler: 10 iterations, no NaN.
- TP = 2 + `--sequence-parallel` + PP = 2, 3 iterations.
- THD + PP = 2 through the real 1F1B scheduler with microbatches packing to 48, 30 and 61 tokens against `--seq-length 64`, so no microbatch matches the static P2P buffer size. The same workload with `variable_seq_lengths` left unset hangs, which is the failure mode the change removes.
- Both `__main__` guards firing with their intended messages, and not firing at PP = 1.

**Not covered** (called out for reviewers): VPP, PP > 2, CP > 1 or EP > 1 combined with PP, GatedDeltaNet + PP, checkpoint resharding across PP, multi-node, and MTP combined with PP > 1 in the unit suite (the launcher defaults `MTP_NUM_LAYERS=1`, so the MTP branch of `_get_shared_word_embedding_weight` is reachable in a default run but is exercised only by the end-to-end run above, not by a unit test).

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code
- [ ] I have added relevant documentation
- [x] I have run the autoformatter on my PR
