### PR TITLE
[dev] [fix] propagate LayerWise optimizer flag through model builders

### DIFF
--- a/examples/mimo/training/builder.py
+++ b/examples/mimo/training/builder.py
@@ -97,9 +97,7 @@ class MimoModelBuilder(ModelBuilder[MimoModel, MimoBuildConfig]):
 
         mimo_config = MimoModelConfig(
             language_model_spec=provider.language_spec(
-                args,
-                active_pg if is_language else None,
-                topology.grids[MIMO_LANGUAGE_MODULE_KEY],
+                args, active_pg if is_language else None, topology.grids[MIMO_LANGUAGE_MODULE_KEY]
             ),
             modality_submodules_spec=modality_submodules_spec,
             special_token_ids=special_token_ids,
@@ -124,6 +122,7 @@ class MimoModelBuilder(ModelBuilder[MimoModel, MimoBuildConfig]):
             Callable[[Any, MegatronModule], MegatronModule] | None
         ) = Float16Module,
         model_type: ModelType = ModelType.encoder_or_decoder,
+        use_layer_wise_distributed_optimizer: bool = False,
     ) -> list[MimoModel]:
         """Seed, build, prepare, and configure the active rank-local MIMO model."""
         if wrap_with_ddp and ddp_config is None:
@@ -157,7 +156,13 @@ class MimoModelBuilder(ModelBuilder[MimoModel, MimoBuildConfig]):
             )
         mimo_model = model_list[0]
 
-        wrap_active_modules_with_ddp(args, mimo_model, topology, data_parallel_random_init)
+        wrap_active_modules_with_ddp(
+            args,
+            mimo_model,
+            topology,
+            data_parallel_random_init,
+            use_layer_wise_distributed_optimizer,
+        )
         configure_grad_sync(args, mimo_model, topology)
         mimo_model.pg_collection = module_pg
         mimo_model.rng_state_key_prefix = rng_state_key_prefix

--- a/examples/mimo/training/runtime.py
+++ b/examples/mimo/training/runtime.py
@@ -96,6 +96,7 @@ def wrap_active_modules_with_ddp(
     mimo_model: MimoModel,
     topology: HeteroTopology,
     data_parallel_random_init: bool = False,
+    use_layer_wise_distributed_optimizer: bool = False,
 ) -> None:
     """Freeze (per --freeze-* flags), Float16Module-wrap, and DDP-wrap each active module."""
     if mimo_model.language_model is not None:
@@ -110,6 +111,7 @@ def wrap_active_modules_with_ddp(
             ddp_config=_ddp_config_from_args(args, enable_overlap=True),
             data_parallel_random_init=data_parallel_random_init,
             mixed_precision_wrapper=Float16Module,
+            use_layer_wise_distributed_optimizer=use_layer_wise_distributed_optimizer,
         )[0]
 
     for name, submodule in mimo_model.modality_submodules.items():
@@ -126,5 +128,6 @@ def wrap_active_modules_with_ddp(
                 ddp_config=_ddp_config_from_args(args, enable_overlap=False),
                 data_parallel_random_init=data_parallel_random_init,
                 mixed_precision_wrapper=_EncoderFloat16Module,
+                use_layer_wise_distributed_optimizer=use_layer_wise_distributed_optimizer,
             )[0]
         )

--- a/megatron/training/models/base.py
+++ b/megatron/training/models/base.py
@@ -233,6 +233,7 @@ class ModelBuilder(abc.ABC, Generic[ModelT, BuildConfigT]):
             Callable[[Any, MegatronModule], MegatronModule] | None
         ) = Float16Module,
         model_type: ModelType = ModelType.encoder_or_decoder,
+        use_layer_wise_distributed_optimizer: bool = False,
     ) -> list[ModelT]:
         """Build model stages and wrap for distributed training.
 
@@ -246,6 +247,8 @@ class ModelBuilder(abc.ABC, Generic[ModelT, BuildConfigT]):
             data_parallel_random_init: Whether to use data parallel random initialization
             mixed_precision_wrapper: Mixed precision wrapper, e.g. ``Float16Module``
             model_type: Deprecated flag, only used for backwards compatibility.
+            use_layer_wise_distributed_optimizer: Whether DDP should route and lay out
+                parameters for the layer-wise distributed optimizer.
 
         Returns:
             List of model stages. If the model does not support virtual pipeline parallelism,

--- a/megatron/training/models/dist_utils.py
+++ b/megatron/training/models/dist_utils.py
@@ -15,6 +15,10 @@ from megatron.core.distributed import (
     FullyShardedDataParallel,
 )
 from megatron.core.optimizer.distrib_optimizer import DistributedOptimizer
+from megatron.core.optimizer.layer_wise_optimizer import (
+    LayerWiseDistributedOptimizer,
+    tag_params_for_buffer_routing,
+)
 
 try:
     from megatron.core.distributed import TorchFullyShardedDataParallel
@@ -48,6 +52,7 @@ def unimodal_build_distributed_models(
     mixed_precision_wrapper: Callable[[Any, MegatronModule], MegatronModule] | None = Float16Module,
     pre_wrap_hook: Callable[[list[MegatronModule]], list[MegatronModule]] | None = None,
     model_type: ModelType = ModelType.encoder_or_decoder,
+    use_layer_wise_distributed_optimizer: bool = False,
 ) -> list[MegatronModule]:
     """Build model stages and wrap for distributed training.
 
@@ -76,6 +81,8 @@ def unimodal_build_distributed_models(
             Pass ``None`` to skip.
         pre_wrap_hook: Hook applied to the model stage list before any wrapping.
         model_type: Deprecated flag, only used for backwards compatibility.
+        use_layer_wise_distributed_optimizer: Whether DDP should route and lay out
+            parameters for the layer-wise distributed optimizer.
 
     Returns:
         List of model stages, wrapped and ready for distributed training.
@@ -116,6 +123,7 @@ def unimodal_build_distributed_models(
         wrap_with_ddp=wrap_with_ddp,
         data_parallel_random_init=data_parallel_random_init,
         mixed_precision_wrapper=mixed_precision_wrapper,
+        use_layer_wise_distributed_optimizer=use_layer_wise_distributed_optimizer,
     )
 
 
@@ -130,6 +138,7 @@ def prepare_existing_model_chunks_for_distributed_training(
     wrap_with_ddp: bool = True,
     data_parallel_random_init: bool = False,
     mixed_precision_wrapper: Callable[[Any, MegatronModule], MegatronModule] | None = Float16Module,
+    use_layer_wise_distributed_optimizer: bool = False,
 ) -> list[MegatronModule]:
     """Apply the shared post-build distributed lifecycle to already-built model chunks.
 
@@ -148,6 +157,8 @@ def prepare_existing_model_chunks_for_distributed_training(
         data_parallel_random_init: Whether to broadcast parameters from data-parallel rank 0.
         mixed_precision_wrapper: Mixed precision wrapper applied per model stage, e.g. ``Float16Module``.
             Pass ``None`` to skip.
+        use_layer_wise_distributed_optimizer: Whether DDP should route and lay out
+            parameters for the layer-wise distributed optimizer.
 
     Returns:
         List of model chunks, wrapped and ready for distributed training.
@@ -196,6 +207,7 @@ def prepare_existing_model_chunks_for_distributed_training(
             use_megatron_fsdp=use_megatron_fsdp,
             use_torch_fsdp2=use_torch_fsdp2,
             pg_collection=pg_collection,
+            use_layer_wise_distributed_optimizer=use_layer_wise_distributed_optimizer,
         )
 
     return model_list
@@ -257,6 +269,7 @@ def _ddp_wrap(
     use_torch_fsdp2: bool = False,
     *,
     pg_collection: ProcessGroupCollection,
+    use_layer_wise_distributed_optimizer: bool = False,
 ) -> list[MegatronModule]:
     """Wrap model with Distributed Data Parallel (DDP) or Fully Sharded Data Parallel (FSDP).
 
@@ -269,6 +282,8 @@ def _ddp_wrap(
         use_megatron_fsdp: Whether to use Megatron FSDP.
         use_torch_fsdp2: Whether to use PyTorch FSDP v2 instead of DDP
         pg_collection: Model communication process groups.
+        use_layer_wise_distributed_optimizer: Whether to use the layer-wise
+            distributed optimizer parameter routing and layout.
 
     Returns:
         list[MegatronModule]: List of DDP/FSDP wrapped model modules
@@ -284,6 +299,19 @@ def _ddp_wrap(
         DP = TorchFullyShardedDataParallel
     else:
         DP = DistributedDataParallel
+
+    compute_layout = None
+    if DP is DistributedDataParallel:
+        if use_layer_wise_distributed_optimizer:
+            # LayerWise (Muon) manages matrix parameters as whole tensors while
+            # sibling Adam parameters use byte-sharded DistOpt buffers. Tag before
+            # DDP groups parameters into buffers and force reduce-scatter for the
+            # sibling DistOpt buffers.
+            ddp_config.use_distributed_optimizer = True
+            tag_params_for_buffer_routing(model)
+            compute_layout = LayerWiseDistributedOptimizer.compute_full_param_layout
+        elif ddp_config.use_distributed_optimizer:
+            compute_layout = DistributedOptimizer.compute_full_param_layout
 
     if not use_torch_fsdp2:
         if ddp_config.num_buckets is not None:
@@ -320,13 +348,13 @@ def _ddp_wrap(
 
             # Pre-compute parameter layouts for the distributed optimizer.
             # Only pass to DDP; FSDP variants don't accept full_param_layout.
-            if ddp_config.use_distributed_optimizer and DP is DistributedDataParallel:
+            if compute_layout is not None:
                 all_params = [p for p in model_chunk.parameters() if p.requires_grad]
                 pp_rank = pg_collection.pp.rank()
                 effective_bucket_size = (
                     None if disable_bucketing or pp_rank > 0 else ddp_config.bucket_size
                 )
-                chunk_kwargs["full_param_layout"] = DistributedOptimizer.compute_full_param_layout(
+                chunk_kwargs["full_param_layout"] = compute_layout(
                     all_params,
                     effective_bucket_size,
                     pg_collection.dp_cp.size(),

--- a/megatron/training/models/gpt.py
+++ b/megatron/training/models/gpt.py
@@ -371,6 +371,7 @@ class GPTModelBuilder(ModelBuilder[GPTModel, GPTModelConfig]):
             Callable[[Any, MegatronModule], MegatronModule] | None
         ) = Float16Module,
         model_type: ModelType = ModelType.encoder_or_decoder,
+        use_layer_wise_distributed_optimizer: bool = False,
     ) -> list[GPTModel]:
         """Build model stages and wrap for distributed training.
 
@@ -385,6 +386,8 @@ class GPTModelBuilder(ModelBuilder[GPTModel, GPTModelConfig]):
             data_parallel_random_init: Whether to use data parallel random initialization
             mixed_precision_wrapper: Mixed precision wrapper, e.g. ``Float16Module``
             model_type: Deprecated flag, only used for backwards compatibility.
+            use_layer_wise_distributed_optimizer: Whether DDP should route and lay out
+                parameters for the layer-wise distributed optimizer.
 
         Returns:
             List of model stages.
@@ -404,6 +407,7 @@ class GPTModelBuilder(ModelBuilder[GPTModel, GPTModelConfig]):
             mixed_precision_wrapper,
             composed_pre_wrap_hook,
             model_type,
+            use_layer_wise_distributed_optimizer=use_layer_wise_distributed_optimizer,
         )
 
         composed_post_wrap_hook = compose_hooks(self._model_config.post_wrap_hooks)

--- a/megatron/training/models/hybrid.py
+++ b/megatron/training/models/hybrid.py
@@ -207,6 +207,7 @@ class HybridModelBuilder(ModelBuilder[HybridModel, HybridModelConfig]):
             Callable[[Any, MegatronModule], MegatronModule] | None
         ) = Float16Module,
         model_type: ModelType = ModelType.encoder_or_decoder,
+        use_layer_wise_distributed_optimizer: bool = False,
     ) -> list[HybridModel]:
         """Build model stages and wrap for distributed training.
 
@@ -221,6 +222,8 @@ class HybridModelBuilder(ModelBuilder[HybridModel, HybridModelConfig]):
             data_parallel_random_init: Whether to use data parallel random initialization
             mixed_precision_wrapper: Mixed precision wrapper, e.g. ``Float16Module``
             model_type: Deprecated flag, only used for backwards compatibility.
+            use_layer_wise_distributed_optimizer: Whether DDP should route and lay out
+                parameters for the layer-wise distributed optimizer.
 
         Returns:
             List of model stages.
@@ -240,6 +243,7 @@ class HybridModelBuilder(ModelBuilder[HybridModel, HybridModelConfig]):
             mixed_precision_wrapper,
             composed_pre_wrap_hook,
             model_type,
+            use_layer_wise_distributed_optimizer=use_layer_wise_distributed_optimizer,
         )
 
         composed_post_wrap_hook = compose_hooks(self._model_config.post_wrap_hooks)

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -2454,6 +2454,7 @@ def setup_model_and_optimizer(
                 use_torch_fsdp2=cfg.dist.use_torch_fsdp2,
                 wrap_with_ddp=wrap_with_ddp,
                 data_parallel_random_init=cfg.rng.data_parallel_random_init,
+                use_layer_wise_distributed_optimizer=cfg.optimizer.use_layer_wise_distributed_optimizer,
             )
         else:
             assert (

--- a/tests/unit_tests/models/mimo/test_mimo_hetero_runtime.py
+++ b/tests/unit_tests/models/mimo/test_mimo_hetero_runtime.py
@@ -102,12 +102,15 @@ def test_builder_seeds_per_role_meta_builds_and_sets_contract(mocker):
     seed = mocker.patch("examples.mimo.training.builder.configure_module_rng")
 
     assert builder.build_distributed_models(
-        mocker.Mock(), ddp_config=DistributedDataParallelConfig(), data_parallel_random_init=True
+        mocker.Mock(),
+        ddp_config=DistributedDataParallelConfig(),
+        data_parallel_random_init=True,
+        use_layer_wise_distributed_optimizer=True,
     ) == [model]
 
     torch_device.assert_called_once_with("meta")
     seed.assert_called_once_with(args, groups, _LANGUAGE_SEED_OFFSET, True)
-    wrap.assert_called_once_with(args, model, topology, True)
+    wrap.assert_called_once_with(args, model, topology, True, True)
     grad_sync.assert_called_once_with(args, model, topology)
     # Load-bearing contract for Increments 2/4: own module PGC and role prefix on the model.
     assert model.pg_collection is groups

--- a/tests/unit_tests/training/models/test_dist_utils.py
+++ b/tests/unit_tests/training/models/test_dist_utils.py
@@ -682,6 +682,48 @@ class TestDdpWrapFullParamLayout:
         self._opt.compute_full_param_layout.assert_not_called()
         assert "full_param_layout" not in mock_ddp.call_args.kwargs
 
+    @patch("megatron.training.models.dist_utils.DistributedDataParallel")
+    @patch("megatron.training.models.dist_utils.get_model_config")
+    @patch("torch.cuda.stream", new_callable=MagicMock)
+    @patch("torch.cuda.current_stream")
+    @patch("torch.cuda.Stream")
+    def test_layer_wise_optimizer_tags_params_and_uses_layer_wise_layout(
+        self, mock_stream, mock_curr, mock_ctx, mock_cfg, mock_ddp
+    ):
+        mock_ctx.return_value.__enter__ = Mock(return_value=None)
+        mock_ctx.return_value.__exit__ = Mock(return_value=False)
+        chunk, param = self._make_chunk_with_params()
+        ddp_config = self._ddp_config(use_distributed_optimizer=False)
+
+        with (
+            patch(
+                "megatron.training.models.dist_utils.LayerWiseDistributedOptimizer"
+            ) as mock_layer_wise_optimizer,
+            patch(
+                "megatron.training.models.dist_utils.tag_params_for_buffer_routing"
+            ) as mock_tag_params,
+        ):
+            mock_layer_wise_optimizer.compute_full_param_layout.return_value = "LAYERWISE_LAYOUT"
+            _ddp_wrap(
+                [chunk],
+                False,
+                ddp_config,
+                False,
+                pg_collection=self.pg,
+                use_layer_wise_distributed_optimizer=True,
+            )
+
+        assert ddp_config.use_distributed_optimizer is True
+        mock_tag_params.assert_called_once_with([chunk])
+        self._opt.compute_full_param_layout.assert_not_called()
+        mock_layer_wise_optimizer.compute_full_param_layout.assert_called_once()
+        layout_call = mock_layer_wise_optimizer.compute_full_param_layout.call_args
+        assert layout_call.args[0] == [param]
+        assert layout_call.args[2] == 4
+        assert layout_call.args[3] is ddp_config
+        assert layout_call.kwargs["expert_data_parallel_world_size"] == 2
+        assert mock_ddp.call_args.kwargs["full_param_layout"] == "LAYERWISE_LAYOUT"
+
     @patch("megatron.training.models.dist_utils.FullyShardedDataParallel")
     @patch("megatron.training.models.dist_utils.get_model_config")
     @patch("torch.cuda.stream", new_callable=MagicMock)
@@ -1085,6 +1127,22 @@ class TestUnimodalBuildDistributedModels:
                 Mock(), self.transformer_config, self.pg, ddp_config=ddp_config, wrap_with_ddp=True
             )
             mocks["ddp"].assert_called_once()
+        finally:
+            self._stop_patches()
+
+    def test_layer_wise_optimizer_flag_forwarded_to_ddp_wrap(self):
+        mocks = self._standard_patches()
+        try:
+            ddp_config = Mock()
+            unimodal_build_distributed_models(
+                Mock(),
+                self.transformer_config,
+                self.pg,
+                ddp_config=ddp_config,
+                wrap_with_ddp=True,
+                use_layer_wise_distributed_optimizer=True,
+            )
+            assert mocks["ddp"].call_args.kwargs["use_layer_wise_distributed_optimizer"] is True
         finally:
             self._stop_patches()
 

--- a/tests/unit_tests/training/models/test_gpt_builder.py
+++ b/tests/unit_tests/training/models/test_gpt_builder.py
@@ -792,6 +792,16 @@ class TestGPTModelBuilderBuildDistributedModels:
 
     @patch("megatron.training.models.gpt.compose_hooks")
     @patch("megatron.training.models.gpt.unimodal_build_distributed_models")
+    def test_layer_wise_optimizer_flag_forwarded(self, mock_unimodal, mock_compose):
+        mock_unimodal.return_value = [Mock()]
+        mock_compose.return_value = Mock(return_value=None)
+
+        self.builder.build_distributed_models(self.pg, use_layer_wise_distributed_optimizer=True)
+
+        assert mock_unimodal.call_args.kwargs["use_layer_wise_distributed_optimizer"] is True
+
+    @patch("megatron.training.models.gpt.compose_hooks")
+    @patch("megatron.training.models.gpt.unimodal_build_distributed_models")
     def test_default_parameters_forwarded(self, mock_unimodal, mock_compose):
         from megatron.core.enums import ModelType
         from megatron.core.transformer.module import Float16Module

--- a/tests/unit_tests/training/models/test_hybrid_builder.py
+++ b/tests/unit_tests/training/models/test_hybrid_builder.py
@@ -433,6 +433,16 @@ class TestHybridModelBuilderBuildDistributedModels:
 
     @patch("megatron.training.models.hybrid.compose_hooks")
     @patch("megatron.training.models.hybrid.unimodal_build_distributed_models")
+    def test_layer_wise_optimizer_flag_forwarded(self, mock_unimodal, mock_compose):
+        mock_unimodal.return_value = [Mock()]
+        mock_compose.return_value = Mock(return_value=None)
+
+        self.builder.build_distributed_models(self.pg, use_layer_wise_distributed_optimizer=True)
+
+        assert mock_unimodal.call_args.kwargs["use_layer_wise_distributed_optimizer"] is True
+
+    @patch("megatron.training.models.hybrid.compose_hooks")
+    @patch("megatron.training.models.hybrid.unimodal_build_distributed_models")
     def test_default_parameters_forwarded(self, mock_unimodal, mock_compose):
         from megatron.core.enums import ModelType
         from megatron.core.transformer.module import Float16Module

--- a/tests/unit_tests/training/test_train_step_schedule_plumbing.py
+++ b/tests/unit_tests/training/test_train_step_schedule_plumbing.py
@@ -6,6 +6,7 @@ import inspect
 from types import SimpleNamespace
 from unittest import mock
 
+from megatron.core.enums import ModelType
 from megatron.training import training as training_mod
 
 
@@ -211,6 +212,72 @@ def test_train_step_wraps_sequence_packing_after_rerun_check():
     assert forwarded_iterators == [packed_iterator, packed_iterator]
     assert captured["num_microbatches"] == 3
     assert result[-3:] == (3, 12.0, 34.0)
+
+
+def test_config_container_forwards_layer_wise_optimizer_to_model_builder():
+    """The config-container path must preserve Muon's layer-wise DDP routing flag."""
+    args = SimpleNamespace(
+        skip_train=True,
+        perform_rl_step=False,
+        no_load_optim=True,
+        logits_save_dir=None,
+        logits_load_dir=None,
+        moe_use_upcycling=False,
+        load=None,
+        pretrained_checkpoint=None,
+        data_parallel_size=1,
+        micro_batch_size=1,
+        fp16=False,
+        ckpt_convert_format=None,
+    )
+    builder = mock.Mock()
+    wrapped_model = mock.Mock()
+    unwrapped_model = SimpleNamespace()
+    builder.build_distributed_models.return_value = [wrapped_model]
+    builder_cls = mock.Mock(return_value=builder)
+    model_config = mock.Mock()
+    model_config.get_builder_cls.return_value = builder_cls
+    cfg = SimpleNamespace(
+        model=model_config,
+        profiling=mock.Mock(),
+        ddp=mock.Mock(),
+        optimizer=SimpleNamespace(
+            overlap_param_gather_with_optimizer_step=False,
+            use_layer_wise_distributed_optimizer=True,
+        ),
+        dist=SimpleNamespace(use_megatron_fsdp=False, use_torch_fsdp2=False),
+        rng=SimpleNamespace(data_parallel_random_init=False),
+    )
+    pg_collection = mock.Mock()
+
+    with (
+        mock.patch.object(training_mod, "get_args", return_value=args),
+        mock.patch.object(training_mod, "get_timers", return_value=mock.Mock()),
+        mock.patch.object(training_mod, "get_one_logger", return_value=None),
+        mock.patch.object(training_mod, "unwrap_model", return_value=[unwrapped_model]),
+        mock.patch.object(training_mod, "get_num_microbatches", return_value=1),
+        mock.patch.object(training_mod, "get_current_global_batch_size", return_value=1),
+        mock.patch.object(training_mod.mpu, "model_parallel_is_initialized", return_value=False),
+        mock.patch("megatron.training.utils.start_memory_history_recording"),
+    ):
+        model, optimizer, scheduler = training_mod.setup_model_and_optimizer(
+            ModelType.encoder_or_decoder, cfg_container=cfg, pg_collection=pg_collection
+        )
+
+    assert model == [wrapped_model]
+    assert optimizer is None
+    assert scheduler is None
+    builder_cls.assert_called_once_with(model_config)
+    builder.build_distributed_models.assert_called_once_with(
+        pg_collection=pg_collection,
+        ddp_config=cfg.ddp,
+        overlap_param_gather_with_optimizer_step=False,
+        use_megatron_fsdp=False,
+        use_torch_fsdp2=False,
+        wrap_with_ddp=False,
+        data_parallel_random_init=False,
+        use_layer_wise_distributed_optimizer=True,
+    )
 
 
 def test_layerwise_wrapper_uses_ddp_config_as_single_layout_source():


### PR DESCRIPTION
- [ ] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
Propagate `use_layer_wise_distributed_optimizer` through the config-container model construction path for GPT, Hybrid, and MIMO models.

## Problem

`setup_model_and_optimizer()` preserved the LayerWise optimizer flag on the legacy path but dropped it when using `cfg_container`. As a result, Muon runs could enable the LayerWise optimizer while model wrapping still used the standard distributed-optimizer layout, causing inconsistent behavior and degraded performance.

## Changes

- Forward the LayerWise optimizer flag from `cfg_container.optimizer`.
- Thread it through the common model-builder interfaces.
- Propagate it through GPT, Hybrid, and MIMO builder paths.
- Pass it into distributed model/DDP wrapping.
- Preserve existing behavior by defaulting the new argument to `False`.
- Add regression coverage for the config-container, builder, and DDP paths.

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
