### PR TITLE
build: serialize uv dependency installation

### DIFF
--- a/docker/Dockerfile.ci.dev
+++ b/docker/Dockerfile.ci.dev
@@ -45,7 +45,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     export NVTE_CUDA_ARCHS="80;90;100"
     uv venv ${UV_PROJECT_ENVIRONMENT} --system-site-packages
     uv sync --only-group build
-    uv sync --extra ${IMAGE_TYPE} --extra mlm --group no_pypi_wheels --link-mode copy --locked \
+    # Prevent overlapping CUTLASS base and CUDA wheel payloads from interleaving.
+    UV_CONCURRENT_INSTALLS=1 uv sync --extra ${IMAGE_TYPE} --extra mlm --group no_pypi_wheels --link-mode copy --locked \
         --no-install-package torch \
         --no-install-package torchvision \
         --no-install-package triton \


### PR DESCRIPTION
## Summary

Serialize the locked development dependency installation in docker/Dockerfile.ci.dev by setting UV_CONCURRENT_INSTALLS=1 for the full uv sync.

The smaller build-only sync and later Docker stages remain unchanged.

## Why

The current lock selects both of these packages:

- nvidia-cutlass-dsl-libs-base==4.5.0
- nvidia-cutlass-dsl-libs-cu13==4.5.0

For the locked CPython 3.12 x86_64 wheels, their payloads contain 178 overlapping paths under nvidia_cutlass_dsl, and 98 of those paths have different contents. The cu13 package depends on the base package, so those overlapping payloads require a deterministic overlay order.

uv 0.7.2 installs wheels concurrently by default. With link mode copy, writes from these two distributions can interleave file by file, leaving an environment whose contents depend on thread scheduling. A mixed environment reproduced a CUTLASS DSL abort, while self-consistent overlays passed the same focused test.

This is nondeterministic: a compatible image can pass and then be reused from BuildKit cache, while a later cold build can produce a different mixture.

## Impact

The change serializes only the locked full dependency installation. It does not affect the build-only dependency sync, later DeepEP installation, container runtime, or test runtime. It may add a small amount of container build time in exchange for reproducible package contents.

## Validation

- Audited the two exact wheels selected by uv.lock: 178 overlapping paths, 98 with different contents.
- Reproduced with uv 0.7.2 and link mode copy. Three 12-worker installs produced mixed base/cu13 path counts of 35/63, 34/64, and 34/64; a one-worker install produced one self-consistent owner for all 98 differing paths.
- A serialized locked installation produced self-consistent CUTLASS files and passed the focused CUTLASS-dependent test.
