### PR TITLE
Harden dynamic prefix cache allocation - mamba mostly

### DIFF
--- a/megatron/core/inference/contexts/kv_block_allocator.py
+++ b/megatron/core/inference/contexts/kv_block_allocator.py
@@ -269,7 +269,9 @@ class KVBlockAllocator:
         # Without resetting the block bag, context request memory will clash and
         # requests will point to each other's memory blocks, resulting in faulty
         # generations.
-        self.block_bag = torch.arange(self.total_count, dtype=torch.int32, device='cpu')
+        # Refill the existing buffer so it remains mutable when reset runs under
+        # torch.inference_mode(), such as during CUDA graph setup.
+        torch.arange(self.total_count, out=self.block_bag)
 
         self.total_avail = self.total_count - 1
 

--- a/megatron/core/inference/contexts/mamba_slot_allocator.py
+++ b/megatron/core/inference/contexts/mamba_slot_allocator.py
@@ -562,14 +562,36 @@ class MambaSlotAllocator:
         # These snapshots only improve future cache hits; the active requests
         # continue from their live Mamba state if durable capacity is exhausted.
         all_bids = intermediate_bids + eos_bids
+        n_intermediate = len(intermediate_bids)
         try:
             all_slots = self.allocate_slots_batch(all_bids)
-        except MambaSlotCapacityError:
-            self._clear_intermediate_state()
-            return
+        except MambaSlotCapacityError as error:
+            existing_slots = self.block_to_slot[all_bids].tolist()
+            kept_indices = []
+            kept_new_bids = set()
+            for index, (block_id, slot) in enumerate(zip(all_bids, existing_slots)):
+                if slot >= 0 or block_id in kept_new_bids:
+                    kept_indices.append(index)
+                elif len(kept_new_bids) < error.available:
+                    kept_new_bids.add(block_id)
+                    kept_indices.append(index)
+
+            if not kept_indices:
+                self._clear_intermediate_state()
+                return
+
+            all_bids = [all_bids[index] for index in kept_indices]
+            all_hashes = [all_hashes[index] for index in kept_indices]
+            src_offsets = [src_offsets[index] for index in kept_indices if index < n_intermediate]
+            eos_ctx_indices = [
+                eos_ctx_indices[index - n_intermediate]
+                for index in kept_indices
+                if index >= n_intermediate
+            ]
+            all_slots = self.allocate_slots_batch(all_bids)
+            n_intermediate = len(src_offsets)
 
         # Copy intermediate states from output buffers to cache
-        n_intermediate = len(intermediate_bids)
         self._copy_intermediate_to_cache(src_offsets, all_slots[:n_intermediate])
 
         # Copy EOS states from live buffers to cache

--- a/megatron/core/inference/contexts/mamba_slot_allocator.py
+++ b/megatron/core/inference/contexts/mamba_slot_allocator.py
@@ -16,6 +16,18 @@ if TYPE_CHECKING:
 MAX_INTERMEDIATE_OFFSETS_PER_REQUEST = 3
 
 
+class MambaSlotCapacityError(RuntimeError):
+    """Raised when the durable Mamba cache cannot satisfy an allocation."""
+
+    def __init__(self, required: int, available: int):
+        self.required = required
+        self.available = available
+        super().__init__(
+            f"Mamba cache requires {required} new durable slots, but only "
+            f"{available} free or evictable slots are available"
+        )
+
+
 class MambaSlotAllocator:
     """Manages Mamba state caching for prefix caching in hybrid models.
 
@@ -159,6 +171,18 @@ class MambaSlotAllocator:
         if num_new == 0:
             return existing_slots
 
+        # Reserve the full batch atomically. A failed eviction must not consume
+        # the free portion of the request.
+        need_evict = max(0, num_new - self.free_count)
+        evictable_block_ids = (
+            self._evictable_block_ids()
+            if need_evict > 0
+            else torch.empty(0, dtype=torch.int64, device=device)
+        )
+        available = self.free_count + evictable_block_ids.numel()
+        if available < num_new:
+            raise MambaSlotCapacityError(required=num_new, available=available)
+
         # Phase 3: Get slots from free pool, evicting if necessary
         from_free = min(num_new, self.free_count)
         new_slots = []
@@ -169,7 +193,7 @@ class MambaSlotAllocator:
 
         need_evict = num_new - from_free
         if need_evict > 0:
-            new_slots.extend(self._evict_lru_slots_batch(need_evict))
+            new_slots.extend(self._evict_lru_slots_batch(need_evict, evictable_block_ids))
 
         # Phase 4: Batch GPU writes for new mappings
         new_bid_tensor = torch.tensor(new_bids, dtype=torch.int64, device=device)
@@ -188,32 +212,34 @@ class MambaSlotAllocator:
                 result.append(alloc_bid_to_slot[bid])
         return result
 
-    def _evict_lru_slots_batch(self, num_needed: int) -> list:
+    def _evictable_block_ids(self) -> Tensor:
+        """Return blocks whose durable Mamba slots have no live KV owner."""
+
+        kv_alloc = self.context.kv_block_allocator
+        has_slot_mask = self.block_to_slot[: kv_alloc.total_count] >= 0
+        ref_zero_mask = kv_alloc.block_ref_counts[: kv_alloc.total_count] == 0
+        return torch.nonzero(has_slot_mask & ref_zero_mask, as_tuple=True)[0]
+
+    def _evict_lru_slots_batch(self, num_needed: int, candidate_ids: Tensor) -> list:
         """Evict the least recently used Mamba cache slots.
 
         Does NOT return slots to the free pool — caller takes ownership.
 
         Args:
             num_needed: Number of slots to evict.
+            candidate_ids: Blocks confirmed to be evictable for this allocation.
 
         Returns:
             List of freed slot indices.
         """
         kv_alloc = self.context.kv_block_allocator
-        # Find blocks that have mamba slots and ref_count == 0
-        has_slot_mask = self.block_to_slot[: kv_alloc.total_count] >= 0
-        ref_zero_mask = kv_alloc.block_ref_counts[: kv_alloc.total_count] == 0
-        candidates = has_slot_mask & ref_zero_mask
-        candidate_ids = torch.nonzero(candidates, as_tuple=True)[0]
-
-        if candidate_ids.numel() < num_needed:
-            raise RuntimeError("No evictable Mamba cache slots available")
+        assert candidate_ids.numel() >= num_needed
 
         # Pick oldest blocks by timestamp (LRU) or first N (REF_ZERO)
         if self.context.prefix_caching_eviction_policy == PrefixCachingEvictionPolicy.LRU:
             timestamps = kv_alloc.block_timestamps[candidate_ids]
-            sorted_indices = torch.argsort(timestamps)[:num_needed]
-            evict_ids = candidate_ids[sorted_indices]
+            _, oldest_indices = torch.topk(timestamps, k=num_needed, largest=False, sorted=False)
+            evict_ids = candidate_ids[oldest_indices]
         else:
             evict_ids = candidate_ids[:num_needed]
 
@@ -533,9 +559,14 @@ class MambaSlotAllocator:
             return
         intermediate_bids, src_offsets, eos_bids, eos_ctx_indices, all_hashes = collected
 
-        # Allocate all slots in one batch (intermediates + EOS)
+        # These snapshots only improve future cache hits; the active requests
+        # continue from their live Mamba state if durable capacity is exhausted.
         all_bids = intermediate_bids + eos_bids
-        all_slots = self.allocate_slots_batch(all_bids)
+        try:
+            all_slots = self.allocate_slots_batch(all_bids)
+        except MambaSlotCapacityError:
+            self._clear_intermediate_state()
+            return
 
         # Copy intermediate states from output buffers to cache
         n_intermediate = len(intermediate_bids)

--- a/megatron/core/inference/contexts/mamba_slot_allocator.py
+++ b/megatron/core/inference/contexts/mamba_slot_allocator.py
@@ -682,7 +682,7 @@ class MambaSlotAllocator:
         """Reset all state (mappings, free pool, cache, intermediate tracking)."""
         self.block_to_slot.fill_(-1)
         self.slot_to_block.fill_(-1)
-        self.free_slots = torch.arange(self.max_slots, dtype=torch.int32, device='cpu')
+        torch.arange(self.max_slots, out=self.free_slots)
         self.free_count = self.max_slots
         self.hash_to_block_id.clear()
         self.intermediate_ssm_out.zero_()

--- a/tests/unit_tests/inference/contexts/test_dynamic_prefix_caching.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_prefix_caching.py
@@ -1310,28 +1310,26 @@ def test_mamba_lru_eviction_selects_only_requested_oldest_slots(monkeypatch):
     assert allocator.block_to_slot.tolist()[3] == -1
 
 
-def test_optional_mamba_checkpoint_commit_skips_at_capacity():
-    allocator = object.__new__(MambaSlotAllocator)
-    allocator._collect_commit_data = lambda: ([11], [0], [12], [0], [101, 102])
-
-    def raise_capacity(_):
-        raise MambaSlotCapacityError(required=2, available=0)
-
-    allocator.allocate_slots_batch = raise_capacity
-    allocator._copy_intermediate_to_cache = lambda *_: pytest.fail(
-        "state copy must not run without durable capacity"
-    )
-    allocator.store_from_live_batch = lambda *_: pytest.fail(
-        "live-state copy must not run without durable capacity"
-    )
-    allocator.register_block_hashes_batch = lambda *_: pytest.fail(
-        "hash registration must not run without durable capacity"
-    )
+@pytest.mark.parametrize("max_slots", [0, 1])
+def test_optional_mamba_checkpoint_commit_uses_available_capacity(monkeypatch, max_slots):
+    allocator = _make_cpu_mamba_slot_allocator(monkeypatch, total_blocks=3, max_slots=max_slots)
+    allocator._collect_commit_data = lambda: ([1], [0], [2], [0], [101, 102])
+    copy_calls = []
+    store_calls = []
+    register_calls = []
     clear_calls = []
+    allocator._copy_intermediate_to_cache = lambda *args: copy_calls.append(args)
+    allocator.store_from_live_batch = lambda *args: store_calls.append(args)
+    allocator.register_block_hashes_batch = lambda *args: register_calls.append(args)
     allocator._clear_intermediate_state = lambda: clear_calls.append(True)
 
     allocator.commit_intermediate_states()
 
+    expected_slot = 0 if max_slots else -1
+    assert allocator.block_to_slot.tolist() == [-1, expected_slot, -1]
+    assert copy_calls == ([([0], [0])] if max_slots else [])
+    assert store_calls == ([([], [])] if max_slots else [])
+    assert register_calls == ([([1], [101])] if max_slots else [])
     assert clear_calls == [True]
 
 

--- a/tests/unit_tests/inference/contexts/test_dynamic_prefix_caching.py
+++ b/tests/unit_tests/inference/contexts/test_dynamic_prefix_caching.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from collections import deque
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -9,6 +10,10 @@ import torch
 
 from megatron.core.inference.config import InferenceConfig, PrefixCachingEvictionPolicy
 from megatron.core.inference.contexts.dynamic_context import DynamicInferenceContext
+from megatron.core.inference.contexts.mamba_slot_allocator import (
+    MambaSlotAllocator,
+    MambaSlotCapacityError,
+)
 from megatron.core.inference.engines.dynamic_engine import DynamicInferenceEngine
 from megatron.core.inference.inference_request import (
     DynamicInferenceRequest,
@@ -1247,6 +1252,87 @@ class TestMixedCachedAndFreshPrefill(PrefixCachingTestBase):
         assert len(log_probs_list[2]) == fresh_ql
         assert len(log_probs_list[3]) == cached_ql
         assert len(log_probs_list[4]) == fresh_ql
+
+
+def _make_cpu_mamba_slot_allocator(
+    monkeypatch, *, total_blocks: int, max_slots: int
+) -> MambaSlotAllocator:
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: "cpu")
+    kv_allocator = SimpleNamespace(
+        total_count=total_blocks,
+        block_ref_counts=torch.ones(total_blocks, dtype=torch.int32),
+        block_timestamps=torch.zeros(total_blocks, dtype=torch.int64),
+        block_hashes=torch.full((total_blocks,), -1, dtype=torch.int64),
+    )
+    context = SimpleNamespace(
+        max_requests=1,
+        max_mamba_intermediate_states_per_step=1,
+        prefix_caching_eviction_policy=PrefixCachingEvictionPolicy.LRU,
+        kv_block_allocator=kv_allocator,
+    )
+    return MambaSlotAllocator(
+        context=context,
+        max_slots=max_slots,
+        num_mamba_layers=1,
+        conv_states_shape=(1,),
+        ssm_states_shape=(1,),
+        conv_states_dtype=torch.float32,
+        ssm_states_dtype=torch.float32,
+    )
+
+
+def test_mamba_slot_allocation_failure_is_atomic(monkeypatch):
+    allocator = _make_cpu_mamba_slot_allocator(monkeypatch, total_blocks=3, max_slots=2)
+    allocator.allocate_slots_batch([0])
+    block_to_slot_before = allocator.block_to_slot.clone()
+    slot_to_block_before = allocator.slot_to_block.clone()
+    free_count_before = allocator.free_count
+
+    with pytest.raises(MambaSlotCapacityError, match="only 1 free or evictable"):
+        allocator.allocate_slots_batch([1, 2])
+
+    assert allocator.free_count == free_count_before
+    assert torch.equal(allocator.block_to_slot, block_to_slot_before)
+    assert torch.equal(allocator.slot_to_block, slot_to_block_before)
+
+
+def test_mamba_lru_eviction_selects_only_requested_oldest_slots(monkeypatch):
+    allocator = _make_cpu_mamba_slot_allocator(monkeypatch, total_blocks=6, max_slots=4)
+    allocator.allocate_slots_batch([0, 1, 2, 3])
+    allocator.context.kv_block_allocator.block_ref_counts[:4] = 0
+    allocator.context.kv_block_allocator.block_timestamps[:4] = torch.tensor([40, 10, 30, 20])
+    allocator.context.kv_block_allocator.block_hashes[:4] = torch.tensor([100, 101, 102, 103])
+    allocator.register_block_hashes_batch([0, 1, 2, 3], [100, 101, 102, 103])
+
+    allocator.allocate_slots_batch([4, 5])
+
+    assert allocator.block_to_slot.tolist()[1] == -1
+    assert allocator.block_to_slot.tolist()[3] == -1
+
+
+def test_optional_mamba_checkpoint_commit_skips_at_capacity():
+    allocator = object.__new__(MambaSlotAllocator)
+    allocator._collect_commit_data = lambda: ([11], [0], [12], [0], [101, 102])
+
+    def raise_capacity(_):
+        raise MambaSlotCapacityError(required=2, available=0)
+
+    allocator.allocate_slots_batch = raise_capacity
+    allocator._copy_intermediate_to_cache = lambda *_: pytest.fail(
+        "state copy must not run without durable capacity"
+    )
+    allocator.store_from_live_batch = lambda *_: pytest.fail(
+        "live-state copy must not run without durable capacity"
+    )
+    allocator.register_block_hashes_batch = lambda *_: pytest.fail(
+        "hash registration must not run without durable capacity"
+    )
+    clear_calls = []
+    allocator._clear_intermediate_state = lambda: clear_calls.append(True)
+
+    allocator.commit_intermediate_states()
+
+    assert clear_calls == [True]
 
 
 class TestMambaSlotAllocator(PrefixCachingTestBase):

--- a/tests/unit_tests/inference/contexts/test_kv_block_allocator.py
+++ b/tests/unit_tests/inference/contexts/test_kv_block_allocator.py
@@ -83,6 +83,20 @@ def test_allocate_release_reset_round_trip_no_prefix_caching():
     assert a.block_routing == {}
 
 
+def test_reset_under_inference_mode_preserves_mutable_block_bag():
+    allocator = KVBlockAllocator(_make_context(), total_count=8, paused_count=0)
+    original_block_bag = allocator.block_bag
+
+    with torch.inference_mode():
+        allocator.reset()
+
+    blocks = allocator.allocate_memory_blocks(1)
+    allocator.release_memory_blocks(blocks)
+
+    assert allocator.block_bag is original_block_bag
+    assert allocator.total_avail == 7
+
+
 @pytest.mark.parametrize(
     "scope,paused,total,counts,expected_active,expected_paused",
     [


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

- rewrite the rest of block bag so we dont get those annoying inference mode tensor errors.
  - Make Mamba slot allocation atomic when cache capacity is hit.   We were hitting like semi broken states before without making this atomic.
  - Add a Mamba capacity error. This is useful for future disag debugging and we actually produce real errors.
  - Reuse precomputed eviction candidates and use topk instead of a full LRU sort.
  - Skip optional Mamba prefix snapshots when the durable cache is full.

# What does this PR do?
<!-- Add a one line overview of what this PR aims to accomplish. -->

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
