### PR TITLE
fix(cuda-graphs): align eager DDP initialization stream

### DIFF
--- a/megatron/training/models/dist_utils.py
+++ b/megatron/training/models/dist_utils.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 
 import logging
+from contextlib import nullcontext
 from typing import Any, Callable
 
 import torch
@@ -26,7 +27,6 @@ from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.transformer import MegatronModule, TransformerConfig
 from megatron.core.transformer.module import Float16Module
 from megatron.core.utils import get_model_config, get_pg_rank
-
 
 try:
     from megatron.core.fp8_utils import correct_amax_history_if_needed
@@ -294,16 +294,26 @@ def _ddp_wrap(
         if not ddp_config.overlap_grad_reduce:
             ddp_config.bucket_size = None
 
-    if get_model_config(model[0]).cuda_graph_impl == "full_iteration":
+    cuda_graph_impl = get_model_config(model[0]).cuda_graph_impl
+    if cuda_graph_impl == "full_iteration":
         # DDP initialization must use the full-iteration capture stream so its retained
         # AccumulateGrad nodes do not reference a different, non-capturing stream.
         ddp_stream = get_shared_capture_stream()
+    elif cuda_graph_impl == "none":
+        # Eager forward/backward runs on the current stream. Initialize DDP there as well
+        # so its retained AccumulateGrad nodes do not reference a dedicated side stream.
+        ddp_stream = None
     else:
-        # Preserve a dedicated initialization stream for all other implementations.
+        # Preserve a dedicated initialization stream for local and TE CUDA graphs.
         ddp_stream = torch.cuda.Stream()
-    ddp_stream.wait_stream(torch.cuda.current_stream())
 
-    with torch.cuda.stream(ddp_stream):
+    if ddp_stream is None:
+        ddp_context = nullcontext()
+    else:
+        ddp_stream.wait_stream(torch.cuda.current_stream())
+        ddp_context = torch.cuda.stream(ddp_stream)
+
+    with ddp_context:
         dp_init_kwargs = {}
         if not use_torch_fsdp2:
             dp_init_kwargs["pg_collection"] = pg_collection
@@ -362,8 +372,9 @@ def _ddp_wrap(
             wrapped_model.append(wrapped_chunk)
         model = wrapped_model
 
-    # Ensure initialization-stream work completes before touching params on the default stream.
-    torch.cuda.current_stream().wait_stream(ddp_stream)
+    # Ensure side-stream work completes before touching params on the current stream.
+    if ddp_stream is not None:
+        torch.cuda.current_stream().wait_stream(ddp_stream)
 
     # Broadcast params from data parallel src rank to other data parallel ranks.
     if data_parallel_random_init:

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1871,12 +1871,21 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
             # DDP initialization must use the full-iteration capture stream so its retained
             # AccumulateGrad nodes do not reference a different, non-capturing stream.
             ddp_stream = get_shared_capture_stream()
+        elif config.cuda_graph_impl == "none":
+            # Eager forward/backward runs on the current stream. Initialize DDP there as well
+            # so its retained AccumulateGrad nodes do not reference a dedicated side stream.
+            ddp_stream = None
         else:
-            # Preserve a dedicated initialization stream for all other implementations.
+            # Preserve a dedicated initialization stream for local and TE CUDA graphs.
             ddp_stream = torch.cuda.Stream()
-        ddp_stream.wait_stream(torch.cuda.current_stream())
 
-        with torch.cuda.stream(ddp_stream):
+        if ddp_stream is None:
+            ddp_context = nullcontext()
+        else:
+            ddp_stream.wait_stream(torch.cuda.current_stream())
+            ddp_context = torch.cuda.stream(ddp_stream)
+
+        with ddp_context:
             model = wrap_model_chunks_with_ddp(
                 model,
                 config,
@@ -1892,8 +1901,9 @@ def get_model(model_provider_func, model_type=ModelType.encoder_or_decoder, wrap
                 bucket_sizes=per_chunk_bucket_sizes,
                 disable_bucketing_per_chunk=per_chunk_disable_bucketing,
             )
-        # Ensure initialization-stream work completes before touching params on the default stream.
-        torch.cuda.current_stream().wait_stream(ddp_stream)
+        # Ensure side-stream work completes before touching params on the current stream.
+        if ddp_stream is not None:
+            torch.cuda.current_stream().wait_stream(ddp_stream)
 
         # Broadcast params from data parallel src rank to other data parallel ranks.
         if args.data_parallel_random_init:

--- a/tests/unit_tests/training/models/test_dist_utils.py
+++ b/tests/unit_tests/training/models/test_dist_utils.py
@@ -522,14 +522,38 @@ class TestDdpWrap:
         mock_stream_context.assert_called_once_with(shared_stream)
         mock_current_stream.return_value.wait_stream.assert_called_once_with(shared_stream)
 
-    @pytest.mark.parametrize("cuda_graph_impl", ["none", "local", "transformer_engine"])
     @patch("megatron.training.models.dist_utils.DistributedDataParallel")
     @patch("megatron.training.models.dist_utils.get_model_config")
     @patch("torch.cuda.stream", new_callable=MagicMock)
     @patch("torch.cuda.current_stream")
     @patch("torch.cuda.Stream")
     @patch("megatron.training.models.dist_utils.get_shared_capture_stream")
-    def test_uses_dedicated_stream_for_other_cuda_graph_implementations(
+    def test_uses_current_stream_when_cuda_graphs_are_disabled(
+        self,
+        mock_shared_stream,
+        mock_stream,
+        mock_current_stream,
+        mock_stream_context,
+        mock_config,
+        mock_ddp,
+    ):
+        mock_config.return_value.cuda_graph_impl = "none"
+
+        _ddp_wrap(self.model, False, self.ddp_config, False, pg_collection=self.pg)
+
+        mock_shared_stream.assert_not_called()
+        mock_stream.assert_not_called()
+        mock_current_stream.assert_not_called()
+        mock_stream_context.assert_not_called()
+
+    @pytest.mark.parametrize("cuda_graph_impl", ["local", "transformer_engine"])
+    @patch("megatron.training.models.dist_utils.DistributedDataParallel")
+    @patch("megatron.training.models.dist_utils.get_model_config")
+    @patch("torch.cuda.stream", new_callable=MagicMock)
+    @patch("torch.cuda.current_stream")
+    @patch("torch.cuda.Stream")
+    @patch("megatron.training.models.dist_utils.get_shared_capture_stream")
+    def test_uses_dedicated_stream_for_graph_enabled_implementations(
         self,
         mock_shared_stream,
         mock_stream,


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
<!-- Add a one line overview of what this PR aims to accomplish. -->

 Initialize DDP on the current execution stream when CUDA graphs are disabled so retained AccumulateGrad nodes match the gradient producer stream.


## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
