### PR TITLE
Add configurable attention latent normalization epsilon

### DIFF
--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -1139,6 +1139,7 @@ class TELayerNormColumnParallelLinear(te.pytorch.LayerNormLinear):
         tp_group: Optional[torch.distributed.ProcessGroup] = None,
         stride: int = 1,
         name: str | None = None,
+        eps: float | None = None,
     ):
         """
         Args:
@@ -1262,7 +1263,7 @@ class TELayerNormColumnParallelLinear(te.pytorch.LayerNormLinear):
             super().__init__(
                 in_features=input_size,
                 out_features=gtp_output_size,
-                eps=self.config.layernorm_epsilon,
+                eps=self.config.layernorm_epsilon if eps is None else eps,
                 sequence_parallel=self.config.sequence_parallel,
                 fuse_wgrad_accumulation=self.config.gradient_accumulation_fusion,
                 tp_group=tp_group if torch.distributed.is_initialized() else None,

--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -1435,6 +1435,7 @@ class TELayerNormColumnParallelLinear(te.pytorch.LayerNormLinear):
         stride: int = 1,
         name: str | None = None,
         pg_collection: Optional[ProcessGroupCollection] = None,
+        eps: float | None = None,
     ):
         """
         Args:
@@ -1558,7 +1559,7 @@ class TELayerNormColumnParallelLinear(te.pytorch.LayerNormLinear):
             super().__init__(
                 in_features=input_size,
                 out_features=gtp_output_size,
-                eps=self.config.layernorm_epsilon,
+                eps=self.config.layernorm_epsilon if eps is None else eps,
                 sequence_parallel=self.config.sequence_parallel,
                 fuse_wgrad_accumulation=self.config.gradient_accumulation_fusion,
                 tp_group=tp_group if torch.distributed.is_initialized() else None,

--- a/megatron/core/tensor_parallel/inference_layers.py
+++ b/megatron/core/tensor_parallel/inference_layers.py
@@ -132,6 +132,7 @@ class InferenceLayerNormColumnParallelLinear(TELayerNormColumnParallelLinear):
         tp_comm_buffer_name: Optional[str] = None,
         tp_group: Optional[torch.distributed.ProcessGroup] = None,
         name: str | None = None,
+        eps: float | None = None,
     ):
         assert HAVE_TE, "--transformer-impl=inference_optimized requires transformer engine"
         super().__init__(
@@ -148,6 +149,7 @@ class InferenceLayerNormColumnParallelLinear(TELayerNormColumnParallelLinear):
             tp_comm_buffer_name=tp_comm_buffer_name,
             tp_group=tp_group,
             name=name,
+            eps=eps,
         )
         self.tp_group = get_tensor_model_parallel_group_if_none(tp_group, is_expert=is_expert)
         self.tp_size = dist.get_world_size(self.tp_group)
@@ -156,7 +158,7 @@ class InferenceLayerNormColumnParallelLinear(TELayerNormColumnParallelLinear):
             output_size % self.tp_size == 0
         ), f"output_size ({output_size}) must be divisible by tp_size ({self.tp_size})"
 
-        self.eps = config.layernorm_epsilon
+        self.eps = config.layernorm_epsilon if eps is None else eps
 
         if self.tp_size > 1:
             assert (

--- a/megatron/core/tensor_parallel/inference_layers.py
+++ b/megatron/core/tensor_parallel/inference_layers.py
@@ -148,6 +148,7 @@ class InferenceLayerNormColumnParallelLinear(TELayerNormColumnParallelLinear):
         tp_group: Optional[torch.distributed.ProcessGroup] = None,
         name: str | None = None,
         pg_collection: Optional[ProcessGroupCollection] = None,
+        eps: float | None = None,
     ):
         assert HAVE_TE, "--transformer-impl=inference_optimized requires transformer engine"
         super().__init__(
@@ -165,6 +166,7 @@ class InferenceLayerNormColumnParallelLinear(TELayerNormColumnParallelLinear):
             tp_group=tp_group,
             name=name,
             pg_collection=pg_collection,
+            eps=eps,
         )
         self.tp_group = get_tensor_model_parallel_group_if_none(tp_group, is_expert=is_expert)
         self.tp_size = dist.get_world_size(self.tp_group)
@@ -173,7 +175,7 @@ class InferenceLayerNormColumnParallelLinear(TELayerNormColumnParallelLinear):
             output_size % self.tp_size == 0
         ), f"output_size ({output_size}) must be divisible by tp_size ({self.tp_size})"
 
-        self.eps = config.layernorm_epsilon
+        self.eps = config.layernorm_epsilon if eps is None else eps
 
         if self.tp_size > 1:
             assert (

--- a/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
+++ b/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
@@ -377,14 +377,14 @@ class AbsorbedMLASelfAttention(Attention):
                 layer_classes["q_layernorm"],
                 hidden_size=self.config.q_lora_rank,
                 config=self.config,
-                eps=self.config.layernorm_epsilon,
+                eps=self.config.attention_latent_norm_epsilon,
             )
 
         self.kv_layernorm = build_module(
             layer_classes["kv_layernorm"],
             hidden_size=self.config.kv_lora_rank,
             config=self.config,
-            eps=self.config.layernorm_epsilon,
+            eps=self.config.attention_latent_norm_epsilon,
         )
 
     def get_query_key_value_tensors(

--- a/megatron/core/transformer/mla_qk_norm_config.py
+++ b/megatron/core/transformer/mla_qk_norm_config.py
@@ -4,6 +4,7 @@
 Resolve MLA and DSA Q/KV norm configuration from a layer specification.
 """
 
+from dataclasses import replace
 from typing import NoReturn
 
 from megatron.core.models.backends import get_backend
@@ -234,8 +235,21 @@ class QKNormConfigResolver:
     def _mla_fused_linear_or_default(self, module_spec, module_name):
         """Return a fused MLA projection, using the backend default when available."""
         if self._is_fused_norm_linear(module_spec):
-            return module_spec
-        return self._require_linear(self.fused_norm_linear_impl, module_name)
+            fused_linear = module_spec
+        else:
+            fused_linear = self._require_linear(self.fused_norm_linear_impl, module_name)
+        return self._with_attention_latent_norm_epsilon(fused_linear)
+
+    def _with_attention_latent_norm_epsilon(self, module_spec):
+        """Attach the attention latent-norm epsilon to a fused MLA projection."""
+        assert self.config.attention_latent_norm_epsilon is not None
+        params = {
+            **(module_spec.params if isinstance(module_spec, ModuleSpec) else {}),
+            "eps": self.config.attention_latent_norm_epsilon,
+        }
+        if isinstance(module_spec, ModuleSpec):
+            return replace(module_spec, params=params)
+        return ModuleSpec(module=module_spec, params=params)
 
     def _require_linear(self, module_spec, module_name):
         """Return a configured projection or report that no viable implementation exists."""

--- a/megatron/core/transformer/multi_latent_attention.py
+++ b/megatron/core/transformer/multi_latent_attention.py
@@ -619,13 +619,13 @@ class MLASelfAttention(MultiLatentAttention):
             self.q_layernorm = layer_classes["q_layernorm"](
                 hidden_size=self.config.q_lora_rank,
                 config=self.config,
-                eps=self.config.layernorm_epsilon,
+                eps=self.config.attention_latent_norm_epsilon,
             )
 
         self.kv_layernorm = layer_classes["kv_layernorm"](
             hidden_size=self.config.kv_lora_rank,
             config=self.config,
-            eps=self.config.layernorm_epsilon,
+            eps=self.config.attention_latent_norm_epsilon,
         )
 
     def _resolve_qk_norm_config(
@@ -1331,12 +1331,12 @@ class FusedMLASelfAttention(MLASelfAttention):
         self.q_layernorm = layer_classes["q_layernorm"](
             hidden_size=self.config.q_lora_rank,
             config=self.config,
-            eps=self.config.layernorm_epsilon,
+            eps=self.config.attention_latent_norm_epsilon,
         )
         self.kv_layernorm = layer_classes["kv_layernorm"](
             hidden_size=self.config.kv_lora_rank,
             config=self.config,
-            eps=self.config.layernorm_epsilon,
+            eps=self.config.attention_latent_norm_epsilon,
         )
 
     def _qkv_down_projection(self, hidden_states):

--- a/megatron/core/transformer/multi_latent_attention.py
+++ b/megatron/core/transformer/multi_latent_attention.py
@@ -697,13 +697,13 @@ class MLASelfAttention(MultiLatentAttention):
             self.q_layernorm = layer_classes["q_layernorm"](
                 hidden_size=self.config.q_lora_rank,
                 config=self.config,
-                eps=self.config.layernorm_epsilon,
+                eps=self.config.attention_latent_norm_epsilon,
             )
 
         self.kv_layernorm = layer_classes["kv_layernorm"](
             hidden_size=self.config.kv_lora_rank,
             config=self.config,
-            eps=self.config.layernorm_epsilon,
+            eps=self.config.attention_latent_norm_epsilon,
         )
 
     def _resolve_qk_norm_config(
@@ -1465,12 +1465,12 @@ class FusedMLASelfAttention(MLASelfAttention):
         self.q_layernorm = layer_classes["q_layernorm"](
             hidden_size=self.config.q_lora_rank,
             config=self.config,
-            eps=self.config.layernorm_epsilon,
+            eps=self.config.attention_latent_norm_epsilon,
         )
         self.kv_layernorm = layer_classes["kv_layernorm"](
             hidden_size=self.config.kv_lora_rank,
             config=self.config,
-            eps=self.config.layernorm_epsilon,
+            eps=self.config.attention_latent_norm_epsilon,
         )
 
     def _qkv_down_projection(self, hidden_states):

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -2912,6 +2912,10 @@ class MLATransformerConfig(TransformerConfig):
     kv_lora_rank: int = 512
     """Rank of Key and Value tensors' low rank representation."""
 
+    attention_latent_norm_epsilon: float | None = None
+    """Epsilon for the primary query and key-value latent norms in attention.
+       If unset, inherit ``layernorm_epsilon`` for backward compatibility."""
+
     qk_head_dim: int = 128
     """Dimension of the head in the QK projection. q_head_dim = qk_head_dim + qk_pos_emb_head_dim"""
 
@@ -2963,6 +2967,9 @@ class MLATransformerConfig(TransformerConfig):
 
     def __post_init__(self):
         super().__post_init__()
+        if self.attention_latent_norm_epsilon is None:
+            self.attention_latent_norm_epsilon = self.layernorm_epsilon
+
         if self.multi_latent_attention and self.apply_rope_fusion and self.rope_type != "yarn":
             raise ValueError("apply_rope_fusion for MLA only works with YARN RoPE.")
 

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -3551,6 +3551,10 @@ class MLATransformerConfig(TransformerConfig):
     kv_lora_rank: int = 512
     """Rank of Key and Value tensors' low rank representation."""
 
+    attention_latent_norm_epsilon: float | None = None
+    """Epsilon for the primary query and key-value latent norms in attention.
+       If unset, inherit ``layernorm_epsilon`` for backward compatibility."""
+
     qk_head_dim: int = 128
     """Dimension of the head in the QK projection. q_head_dim = qk_head_dim + qk_pos_emb_head_dim"""
 
@@ -3602,6 +3606,9 @@ class MLATransformerConfig(TransformerConfig):
 
     def __post_init__(self):
         super().__post_init__()
+        if self.attention_latent_norm_epsilon is None:
+            self.attention_latent_norm_epsilon = self.layernorm_epsilon
+
         if self.multi_latent_attention and self.apply_rope_fusion and self.rope_type != "yarn":
             raise ValueError("apply_rope_fusion for MLA only works with YARN RoPE.")
 

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -3382,6 +3382,13 @@ def _add_mla_args(parser):
                        help="Rank of Query tensor's low rank representation.")
     group.add_argument('--kv-lora-rank', type=int, default=32,
                        help="Rank of Key and Value tensors' low rank representation.")
+    group.add_argument(
+        '--attention-latent-norm-epsilon',
+        type=float,
+        default=None,
+        help="Epsilon for the primary query and key-value latent norms in attention. "
+             "Defaults to --norm-epsilon when unset.",
+    )
     group.add_argument('--qk-head-dim', type=int, default=128,
                        help="Dimension of the head in the QK projection. q_head_dim = qk_head_dim + qk_pos_emb_head_dim")
     group.add_argument('--qk-pos-emb-head-dim', type=int, default=64,

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -3662,6 +3662,13 @@ def _add_mla_args(parser):
                        help="Rank of Query tensor's low rank representation.")
     group.add_argument('--kv-lora-rank', type=int, default=32,
                        help="Rank of Key and Value tensors' low rank representation.")
+    group.add_argument(
+        '--attention-latent-norm-epsilon',
+        type=float,
+        default=None,
+        help="Epsilon for the primary query and key-value latent norms in attention. "
+             "Defaults to --norm-epsilon when unset.",
+    )
     group.add_argument('--qk-head-dim', type=int, default=128,
                        help="Dimension of the head in the QK projection. q_head_dim = qk_head_dim + qk_pos_emb_head_dim")
     group.add_argument('--qk-pos-emb-head-dim', type=int, default=64,

--- a/tests/unit_tests/transformer/experimental_attention_variant/dsa_native_parity_utils.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/dsa_native_parity_utils.py
@@ -80,7 +80,9 @@ def _make_config(
         add_bias_linear=False,
         bf16=True,
         params_dtype=torch.bfloat16,
-        layernorm_epsilon=1e-6,
+        layernorm_epsilon=1e-5,
+        attention_latent_norm_epsilon=1e-6,
+        dsa_indexer_k_norm_epsilon=1e-6,
         normalization="RMSNorm",
         qk_layernorm=True,
         layernorm_zero_centered_gamma=False,
@@ -191,7 +193,7 @@ class NativeIndexer(nn.Module):
         qk_pos_emb_head_dim: int,
         index_topk: int,
         use_sparse_loss: bool,
-        layernorm_epsilon: float,
+        dsa_indexer_k_norm_epsilon: float,
     ):
         super().__init__()
         self.hidden_size = hidden_size
@@ -207,7 +209,7 @@ class NativeIndexer(nn.Module):
             self.q_lora_rank, self.index_n_heads * self.index_head_dim, bias=False
         )
         self.linear_wk = nn.Linear(self.hidden_size, self.index_head_dim, bias=False)
-        self.k_norm = nn.LayerNorm(self.index_head_dim, eps=layernorm_epsilon)
+        self.k_norm = nn.LayerNorm(self.index_head_dim, eps=dsa_indexer_k_norm_epsilon)
         self.linear_weights_proj = nn.Linear(self.hidden_size, self.index_n_heads, bias=False)
 
     def forward(
@@ -258,7 +260,8 @@ class NativeDSA(nn.Module):
         dsa_indexer_head_dim: int,
         dsa_indexer_topk: int,
         dsa_indexer_use_sparse_loss: bool,
-        layernorm_epsilon: float,
+        attention_latent_norm_epsilon: float,
+        dsa_indexer_k_norm_epsilon: float,
         rotary_base: float,
         rotary_scaling_factor: float,
         original_max_position_embeddings: int,
@@ -291,14 +294,14 @@ class NativeDSA(nn.Module):
         self.softmax_scale = mscale * mscale / math.sqrt(self.q_head_dim)
 
         self.linear_q_down_proj = nn.Linear(self.hidden_size, self.q_lora_rank, bias=False)
-        self.q_layernorm = nn.RMSNorm(self.q_lora_rank, eps=layernorm_epsilon)
+        self.q_layernorm = nn.RMSNorm(self.q_lora_rank, eps=attention_latent_norm_epsilon)
         self.linear_q_up_proj = nn.Linear(
             self.q_lora_rank, self.num_heads * self.q_head_dim, bias=False
         )
         self.linear_kv_down_proj = nn.Linear(
             self.hidden_size, self.kv_lora_rank + self.qk_pos_emb_head_dim, bias=False
         )
-        self.kv_layernorm = nn.RMSNorm(self.kv_lora_rank, eps=layernorm_epsilon)
+        self.kv_layernorm = nn.RMSNorm(self.kv_lora_rank, eps=attention_latent_norm_epsilon)
         self.linear_kv_up_proj = nn.Linear(
             self.kv_lora_rank, self.num_heads * (self.qk_head_dim + self.v_head_dim), bias=False
         )
@@ -311,7 +314,7 @@ class NativeDSA(nn.Module):
             qk_pos_emb_head_dim=self.qk_pos_emb_head_dim,
             index_topk=dsa_indexer_topk,
             use_sparse_loss=dsa_indexer_use_sparse_loss,
-            layernorm_epsilon=layernorm_epsilon,
+            dsa_indexer_k_norm_epsilon=dsa_indexer_k_norm_epsilon,
         )
 
     def forward(
@@ -447,6 +450,8 @@ def run_absorbed_mla_dsa_parity(
         real_layer = build_module(
             spec, config=config, layer_number=1, cp_comm_type=None, pg_collection=None
         ).cuda()
+        assert config.attention_latent_norm_epsilon is not None
+        assert config.dsa_indexer_k_norm_epsilon is not None
         baseline = (
             NativeDSA(
                 hidden_size=config.hidden_size,
@@ -460,7 +465,8 @@ def run_absorbed_mla_dsa_parity(
                 dsa_indexer_head_dim=config.dsa_indexer_head_dim,
                 dsa_indexer_topk=config.dsa_indexer_topk,
                 dsa_indexer_use_sparse_loss=config.dsa_indexer_use_sparse_loss,
-                layernorm_epsilon=config.layernorm_epsilon,
+                attention_latent_norm_epsilon=config.attention_latent_norm_epsilon,
+                dsa_indexer_k_norm_epsilon=config.dsa_indexer_k_norm_epsilon,
                 rotary_base=config.rotary_base,
                 rotary_scaling_factor=config.rotary_scaling_factor,
                 original_max_position_embeddings=config.original_max_position_embeddings,

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_absorbed_mla.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_absorbed_mla.py
@@ -141,6 +141,7 @@ def get_mock_mla_config(
         bf16=True,
         params_dtype=torch.bfloat16,
         layernorm_epsilon=1e-5,
+        attention_latent_norm_epsilon=1e-6,
         normalization="RMSNorm",
         qk_layernorm=qk_layernorm,
         layernorm_zero_centered_gamma=False,
@@ -430,6 +431,11 @@ def test_functionality(tp_cp: List[int], qkv_format: str, down_proj_use_column_p
         cp_comm_type="all_gather" if cp_size > 1 else None,
         pg_collection=None,
     ).cuda()
+
+    assert absorbed_mla.q_layernorm.eps == pytest.approx(config.attention_latent_norm_epsilon)
+    assert absorbed_mla.kv_layernorm.eps == pytest.approx(config.attention_latent_norm_epsilon)
+    assert standard_mla.q_layernorm.eps == pytest.approx(config.attention_latent_norm_epsilon)
+    assert standard_mla.kv_layernorm.eps == pytest.approx(config.attention_latent_norm_epsilon)
 
     state_dict = standard_mla.state_dict()
     absorbed_mla.load_state_dict(state_dict)

--- a/tests/unit_tests/transformer/test_mla_qk_norm_config.py
+++ b/tests/unit_tests/transformer/test_mla_qk_norm_config.py
@@ -75,7 +75,11 @@ def _mock_backend(monkeypatch):
 @pytest.mark.parametrize("attention_latent_norm_epsilon", [None, 1.0e-6])
 def test_attention_latent_norm_epsilon_default(attention_latent_norm_epsilon):
     config = _make_config(attention_latent_norm_epsilon=attention_latent_norm_epsilon)
-    expected = config.layernorm_epsilon if attention_latent_norm_epsilon is None else attention_latent_norm_epsilon
+    expected = (
+        config.layernorm_epsilon
+        if attention_latent_norm_epsilon is None
+        else attention_latent_norm_epsilon
+    )
 
     assert config.attention_latent_norm_epsilon == expected
 

--- a/tests/unit_tests/transformer/test_mla_qk_norm_config.py
+++ b/tests/unit_tests/transformer/test_mla_qk_norm_config.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from argparse import ArgumentParser
+from types import SimpleNamespace
+
+import pytest
+
+import megatron.core.transformer.mla_qk_norm_config as qk_norm_config
+from megatron.core.transformer.enums import AttnBackend
+from megatron.core.transformer.identity_op import IdentityOp
+from megatron.core.transformer.mla_qk_norm_config import QKNormConfigResolver
+from megatron.core.transformer.spec_utils import ModuleSpec
+from megatron.core.transformer.transformer_config import MLATransformerConfig
+from megatron.training.arguments import _add_mla_args
+from tests.unit_tests.transformer.experimental_attention_variant.dsa_native_parity_utils import (
+    run_absorbed_mla_dsa_parity,
+)
+
+
+class _Linear:
+    pass
+
+
+class _FusedNormLinear:
+    pass
+
+
+class _Norm:
+    pass
+
+
+class _Backend:
+    @staticmethod
+    def layer_norm(**_kwargs):
+        return _Norm
+
+    @staticmethod
+    def column_parallel_linear():
+        return _Linear
+
+    @staticmethod
+    def column_parallel_layer_norm_linear():
+        return _FusedNormLinear
+
+
+def _make_config(*, q_lora_rank=32, attention_latent_norm_epsilon=1.0e-6):
+    return MLATransformerConfig(
+        num_layers=1,
+        hidden_size=128,
+        num_attention_heads=1,
+        q_lora_rank=q_lora_rank,
+        qk_layernorm=True,
+        layernorm_epsilon=1.0e-5,
+        attention_latent_norm_epsilon=attention_latent_norm_epsilon,
+    )
+
+
+def _make_submodules(**overrides):
+    values = dict(
+        linear_q_proj=None,
+        linear_q_up_proj=None,
+        linear_kv_up_proj=None,
+        q_layernorm=IdentityOp,
+        kv_layernorm=IdentityOp,
+    )
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+@pytest.fixture(autouse=True)
+def _mock_backend(monkeypatch):
+    monkeypatch.setattr(qk_norm_config, "get_backend", lambda _impl: _Backend())
+
+
+@pytest.mark.parametrize("attention_latent_norm_epsilon", [None, 1.0e-6])
+def test_attention_latent_norm_epsilon_default(attention_latent_norm_epsilon):
+    config = _make_config(attention_latent_norm_epsilon=attention_latent_norm_epsilon)
+    expected = config.layernorm_epsilon if attention_latent_norm_epsilon is None else attention_latent_norm_epsilon
+
+    assert config.attention_latent_norm_epsilon == expected
+
+
+def test_attention_latent_norm_epsilon_argument():
+    parser = ArgumentParser()
+    _add_mla_args(parser)
+
+    args = parser.parse_args(["--attention-latent-norm-epsilon", "1e-6"])
+
+    assert args.attention_latent_norm_epsilon == pytest.approx(1.0e-6)
+
+
+@pytest.mark.parametrize(
+    ("q_lora_rank", "q_projection"), [(None, "linear_q_proj"), (32, "linear_q_up_proj")]
+)
+def test_fused_norm_projections_carry_attention_latent_epsilon(q_lora_rank, q_projection):
+    config = _make_config(q_lora_rank=q_lora_rank)
+    submodules = _make_submodules(
+        linear_kv_up_proj=ModuleSpec(module=_FusedNormLinear, params={"custom": True})
+    )
+
+    resolved = QKNormConfigResolver(config, submodules).resolve()
+
+    q_spec = resolved[q_projection]
+    assert isinstance(q_spec, ModuleSpec)
+    assert q_spec.module is _FusedNormLinear
+    assert q_spec.params["eps"] == config.attention_latent_norm_epsilon
+
+    kv_spec = resolved["linear_kv_up_proj"]
+    assert isinstance(kv_spec, ModuleSpec)
+    assert kv_spec.module is _FusedNormLinear
+    assert kv_spec.params == {"custom": True, "eps": config.attention_latent_norm_epsilon}
+    assert submodules.linear_kv_up_proj.params == {"custom": True}
+
+
+def test_dsa_attention_latent_norm_epsilon_matches_native():
+    """Exercise distinct global, attention latent, and indexer norm epsilons in DSA."""
+    run_absorbed_mla_dsa_parity(
+        kernel_backend="none",
+        seqlen=64,
+        attention_backend=AttnBackend.unfused,
+        calculate_per_token_loss=True,
+        use_sparse_loss=False,
+        num_iterations=1,
+    )

--- a/tests/unit_tests/transformer/test_multi_latent_attention.py
+++ b/tests/unit_tests/transformer/test_multi_latent_attention.py
@@ -97,9 +97,9 @@ def make_test_packed_seq_params_with_padding(
     return packed_seq_params
 
 
-def get_mla_self_attn_submodules(linear_qkv_down_proj=None):
+def get_mla_self_attn_submodules(linear_qkv_down_proj=None, qk_layernorm=False):
     submodules = get_gpt_layer_with_transformer_engine_submodules(
-        multi_latent_attention=True
+        multi_latent_attention=True, qk_layernorm=qk_layernorm
     ).self_attention.submodules
     assert isinstance(submodules, MLASelfAttentionSubmodules)
     if linear_qkv_down_proj is not None:
@@ -108,10 +108,10 @@ def get_mla_self_attn_submodules(linear_qkv_down_proj=None):
     return submodules
 
 
-def get_fused_mla_submodules():
+def get_fused_mla_submodules(qk_layernorm=False):
     """Get submodules for FusedMLASelfAttention via the mla_down_proj_fusion spec path."""
     submodules = get_gpt_layer_with_transformer_engine_submodules(
-        multi_latent_attention=True, mla_down_proj_fusion=True
+        multi_latent_attention=True, mla_down_proj_fusion=True, qk_layernorm=qk_layernorm
     ).self_attention.submodules
     assert isinstance(submodules, MLASelfAttentionSubmodules)
     assert submodules.linear_qkv_down_proj is not None
@@ -172,6 +172,31 @@ class TestParallelMLAAttention:
 
         num_weights = sum([p.numel() for p in self.parallel_attention.parameters()])
         assert num_weights == 65036
+
+    def test_attention_latent_norm_epsilon_on_fused_projections(self):
+        config = MLATransformerConfig(
+            num_layers=2,
+            hidden_size=12,
+            num_attention_heads=4,
+            use_cpu_initialization=True,
+            q_lora_rank=32,
+            kv_lora_rank=32,
+            qk_head_dim=128,
+            v_head_dim=128,
+            qk_pos_emb_head_dim=64,
+            qk_layernorm=True,
+            layernorm_epsilon=1.0e-5,
+            attention_latent_norm_epsilon=1.0e-6,
+        )
+        attention = MLASelfAttention(
+            config,
+            get_mla_self_attn_submodules(qk_layernorm=True),
+            layer_number=1,
+            attn_mask_type=AttnMaskType.causal,
+        )
+
+        assert attention.linear_q_up_proj.eps == pytest.approx(1.0e-6)
+        assert attention.linear_kv_up_proj.eps == pytest.approx(1.0e-6)
 
     def test_cpu_forward(self):
         # we can't currently do this because the global memory buffer is on GPU
@@ -1650,6 +1675,31 @@ class TestFusedMLASelfAttention:
         assert isinstance(self.fused_attention, MLASelfAttention)
         assert self.fused_attention.layer_number == 1
         assert hasattr(self.fused_attention, 'linear_qkv_down_proj')
+
+    def test_attention_latent_norm_epsilon_on_fused_projections(self):
+        config = MLATransformerConfig(
+            num_layers=2,
+            hidden_size=12,
+            num_attention_heads=4,
+            use_cpu_initialization=True,
+            q_lora_rank=32,
+            kv_lora_rank=32,
+            qk_head_dim=128,
+            v_head_dim=128,
+            qk_pos_emb_head_dim=64,
+            qk_layernorm=True,
+            layernorm_epsilon=1.0e-5,
+            attention_latent_norm_epsilon=1.0e-6,
+        )
+        attention = FusedMLASelfAttention(
+            config,
+            get_fused_mla_submodules(qk_layernorm=True),
+            layer_number=1,
+            attn_mask_type=AttnMaskType.causal,
+        )
+
+        assert attention.linear_q_up_proj.eps == pytest.approx(1.0e-6)
+        assert attention.linear_kv_up_proj.eps == pytest.approx(1.0e-6)
 
     def test_fused_weight_shape(self):
         config = self.transformer_config

--- a/tests/unit_tests/transformer/test_multi_latent_attention.py
+++ b/tests/unit_tests/transformer/test_multi_latent_attention.py
@@ -99,9 +99,9 @@ def make_test_packed_seq_params_with_padding(
     return packed_seq_params
 
 
-def get_mla_self_attn_submodules(linear_qkv_down_proj=None):
+def get_mla_self_attn_submodules(linear_qkv_down_proj=None, qk_layernorm=False):
     submodules = get_gpt_layer_with_transformer_engine_submodules(
-        multi_latent_attention=True
+        multi_latent_attention=True, qk_layernorm=qk_layernorm
     ).self_attention.submodules
     assert isinstance(submodules, MLASelfAttentionSubmodules)
     if linear_qkv_down_proj is not None:
@@ -110,10 +110,10 @@ def get_mla_self_attn_submodules(linear_qkv_down_proj=None):
     return submodules
 
 
-def get_fused_mla_submodules():
+def get_fused_mla_submodules(qk_layernorm=False):
     """Get submodules for FusedMLASelfAttention via the mla_down_proj_fusion spec path."""
     submodules = get_gpt_layer_with_transformer_engine_submodules(
-        multi_latent_attention=True, mla_down_proj_fusion=True
+        multi_latent_attention=True, mla_down_proj_fusion=True, qk_layernorm=qk_layernorm
     ).self_attention.submodules
     assert isinstance(submodules, MLASelfAttentionSubmodules)
     assert submodules.linear_qkv_down_proj is not None
@@ -224,6 +224,31 @@ class TestParallelMLAAttention:
 
         num_weights = sum([p.numel() for p in self.parallel_attention.parameters()])
         assert num_weights == 65036
+
+    def test_attention_latent_norm_epsilon_on_fused_projections(self):
+        config = MLATransformerConfig(
+            num_layers=2,
+            hidden_size=12,
+            num_attention_heads=4,
+            use_cpu_initialization=True,
+            q_lora_rank=32,
+            kv_lora_rank=32,
+            qk_head_dim=128,
+            v_head_dim=128,
+            qk_pos_emb_head_dim=64,
+            qk_layernorm=True,
+            layernorm_epsilon=1.0e-5,
+            attention_latent_norm_epsilon=1.0e-6,
+        )
+        attention = MLASelfAttention(
+            config,
+            get_mla_self_attn_submodules(qk_layernorm=True),
+            layer_number=1,
+            attn_mask_type=AttnMaskType.causal,
+        )
+
+        assert attention.linear_q_up_proj.eps == pytest.approx(1.0e-6)
+        assert attention.linear_kv_up_proj.eps == pytest.approx(1.0e-6)
 
     def test_cpu_forward(self):
         # we can't currently do this because the global memory buffer is on GPU
@@ -1703,6 +1728,31 @@ class TestFusedMLASelfAttention:
         assert isinstance(self.fused_attention, MLASelfAttention)
         assert self.fused_attention.layer_number == 1
         assert hasattr(self.fused_attention, 'linear_qkv_down_proj')
+
+    def test_attention_latent_norm_epsilon_on_fused_projections(self):
+        config = MLATransformerConfig(
+            num_layers=2,
+            hidden_size=12,
+            num_attention_heads=4,
+            use_cpu_initialization=True,
+            q_lora_rank=32,
+            kv_lora_rank=32,
+            qk_head_dim=128,
+            v_head_dim=128,
+            qk_pos_emb_head_dim=64,
+            qk_layernorm=True,
+            layernorm_epsilon=1.0e-5,
+            attention_latent_norm_epsilon=1.0e-6,
+        )
+        attention = FusedMLASelfAttention(
+            config,
+            get_fused_mla_submodules(qk_layernorm=True),
+            layer_number=1,
+            attn_mask_type=AttnMaskType.causal,
+        )
+
+        assert attention.linear_q_up_proj.eps == pytest.approx(1.0e-6)
+        assert attention.linear_kv_up_proj.eps == pytest.approx(1.0e-6)
 
     def test_fused_weight_shape(self):
         config = self.transformer_config


### PR DESCRIPTION
(Dev PR: #6204)

## Summary

- add `attention_latent_norm_epsilon` to `MLATransformerConfig` with a matching `--attention-latent-norm-epsilon` argument, inheriting `layernorm_epsilon` when unset for backward compatibility
- apply the dedicated epsilon to primary query and key-value latent norms in standard, fused, absorbed, and inference-optimized MLA/DSA paths, independently of the RMSNorm/LayerNorm selection
- keep DSA indexer K normalization on its existing `dsa_indexer_k_norm_epsilon` control and cover distinct global, attention-latent, and indexer epsilons with resolver, module, and native-parity tests

## Test plan

- `tests/unit_tests/transformer/test_mla_qk_norm_config.py`: 6 passed
- `tests/unit_tests/transformer/test_multi_latent_attention.py`: H100 active shards 55 passed, 27 deselected
- `tests/unit_tests/transformer/experimental_attention_variant/test_absorbed_mla.py`: H100 active shards 64 passed
- DSA native parity: passed on H100 and GB200
