### PR TITLE
Add construction-scoped MFSDP v2 fully shard options

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
@@ -27,11 +27,13 @@ from ..mixed_precision import MixedPrecisionPolicy
 from .module import FsdpContext, FsdpModule
 from .placement import MeshAxis, Placements
 
-_FSDP_CONTEXT = ContextVar[FsdpContext | None]("megatron_fsdp_context", default=None)
+_FSDP_CONTEXT = ContextVar[FsdpContext | None]("mfsdp_context", default=None)
 
 
 @contextmanager
-def fully_shard_context(device: torch.device | None = None) -> Iterator[FsdpContext]:
+def fully_shard_context(
+    device: torch.device | None = None, *, use_symmetric_memory: bool = False
+) -> Iterator[FsdpContext]:
     """Construct FSDP modules that share runtime streams and prefetch orders.
 
     Independent roots are ordered by their root-level ``fully_shard`` calls.
@@ -40,6 +42,8 @@ def fully_shard_context(device: torch.device | None = None) -> Iterator[FsdpCont
     Args:
         device: CUDA device on which to create communication streams. Defaults to
             the current CUDA device.
+        use_symmetric_memory: Allocate communication staging buffers from PyTorch's
+            NCCL symmetric-memory pool.
     """
     if _FSDP_CONTEXT.get() is not None:
         raise RuntimeError("fully_shard_context does not support nesting.")
@@ -48,7 +52,7 @@ def fully_shard_context(device: torch.device | None = None) -> Iterator[FsdpCont
     if device.type != "cuda":
         raise ValueError(f"fully_shard_context requires a CUDA device, got {device}.")
 
-    context = FsdpContext(device=device)
+    context = FsdpContext(device=device, use_symmetric_memory=use_symmetric_memory)
     token = _FSDP_CONTEXT.set(context)
     try:
         yield context
@@ -65,7 +69,6 @@ def fully_shard(
     mesh: DeviceMesh,
     placements: Placements,
     mixed_precision_policy: MixedPrecisionPolicy | None = None,
-    use_symm_mem: bool = False,
     grad_divisor: int = 1,
 ) -> None:
     """Apply FSDP to a module in place.
@@ -79,8 +82,6 @@ def fully_shard(
         placements: Parameter, gradient, and optimizer placements.
         mixed_precision_policy: Optional precision policy. Defaults to FP32 main weights
             and parameter-dtype main gradients.
-        use_symm_mem: Allocate all-gather and reduce-scatter staging buffers from
-            PyTorch's NCCL symmetric-memory pool.
         grad_divisor: Additional divisor applied to the reduced gradient, on top of the
             averaging the mesh already performs. Defaults to 1, which is correct whenever
             each mesh rank contributes exactly one term to the gradient.
@@ -117,8 +118,8 @@ def fully_shard(
             mesh=mesh,
             placements=placements,
             mixed_precision_policy=mixed_precision_policy,
-            use_symm_mem=use_symm_mem,
             grad_divisor=grad_divisor,
+            use_symmetric_memory=context.use_symmetric_memory,
         )
     except Exception:
         module.__class__ = original_cls

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
@@ -27,11 +27,13 @@ from ..mixed_precision import MixedPrecisionPolicy
 from .module import FsdpContext, FsdpModule
 from .placement import MeshAxis, Placements
 
-_FSDP_CONTEXT = ContextVar[FsdpContext | None]("megatron_fsdp_context", default=None)
+_FSDP_CONTEXT = ContextVar[FsdpContext | None]("mfsdp_context", default=None)
 
 
 @contextmanager
-def fully_shard_context(device: torch.device | None = None) -> Iterator[FsdpContext]:
+def fully_shard_context(
+    device: torch.device | None = None, *, use_symmetric_memory: bool = False
+) -> Iterator[FsdpContext]:
     """Construct FSDP modules that share runtime streams and prefetch orders.
 
     Independent roots are ordered by their root-level ``fully_shard`` calls.
@@ -40,6 +42,8 @@ def fully_shard_context(device: torch.device | None = None) -> Iterator[FsdpCont
     Args:
         device: CUDA device on which to create communication streams. Defaults to
             the current CUDA device.
+        use_symmetric_memory: Allocate communication staging buffers from PyTorch's
+            NCCL symmetric-memory pool.
     """
     if _FSDP_CONTEXT.get() is not None:
         raise RuntimeError("fully_shard_context does not support nesting.")
@@ -48,7 +52,7 @@ def fully_shard_context(device: torch.device | None = None) -> Iterator[FsdpCont
     if device.type != "cuda":
         raise ValueError(f"fully_shard_context requires a CUDA device, got {device}.")
 
-    context = FsdpContext(device=device)
+    context = FsdpContext(device=device, use_symmetric_memory=use_symmetric_memory)
     token = _FSDP_CONTEXT.set(context)
     try:
         yield context
@@ -65,7 +69,6 @@ def fully_shard(
     mesh: DeviceMesh,
     placements: Placements,
     mixed_precision_policy: MixedPrecisionPolicy | None = None,
-    use_symm_mem: bool = False,
 ) -> None:
     """Apply FSDP to a module in place.
 
@@ -78,8 +81,6 @@ def fully_shard(
         placements: Parameter, gradient, and optimizer placements.
         mixed_precision_policy: Optional precision policy. Defaults to FP32 main weights
             and parameter-dtype main gradients.
-        use_symm_mem: Allocate all-gather and reduce-scatter staging buffers from
-            PyTorch's NCCL symmetric-memory pool.
     """
     if isinstance(module, FsdpModule):
         raise ValueError("This module is already managed by FSDP.")
@@ -105,7 +106,7 @@ def fully_shard(
             mesh=mesh,
             placements=placements,
             mixed_precision_policy=mixed_precision_policy,
-            use_symm_mem=use_symm_mem,
+            use_symmetric_memory=context.use_symmetric_memory,
         )
     except Exception:
         module.__class__ = original_cls

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -43,19 +43,23 @@ class FsdpContext:
     # unnecessary because it can be detected when ``model_weight``, after syncing
     # from ``main_weight``, has placements different from ``Placements.optimizer``.
     is_last_microbatch: bool
+    use_symmetric_memory: bool
     # Static orders used to drive all-gather prefetch. We may want to switch to
     # capturing runtime order if static module order proves too fragile. Each
     # FsdpModule tracks its own materialized state via ``FsdpModule._unshard_event``.
     forward_order: IndexedOrder["FsdpModule"]
     backward_order: IndexedOrder["FsdpModule"]
 
-    def __init__(self, device: torch.device) -> None:
+    def __init__(self, device: torch.device, use_symmetric_memory: bool = False) -> None:
         """Create rank-local runtime state for FSDP modules on ``device``.
 
         Args:
             device: Device on which this context schedules communication.
+            use_symmetric_memory: Whether modules constructed in this context allocate
+                communication staging buffers from PyTorch's NCCL symmetric-memory pool.
         """
         self.is_last_microbatch = True
+        self.use_symmetric_memory = use_symmetric_memory
         self.forward_order = IndexedOrder()
         self.backward_order = IndexedOrder()
         # Construction-only; empty after finalization.
@@ -154,8 +158,8 @@ class FsdpModule:
         mesh: DeviceMesh,
         placements: Placements,
         mixed_precision_policy: MixedPrecisionPolicy,
-        use_symm_mem: bool = False,
         grad_divisor: int = 1,
+        use_symmetric_memory: bool = False,
     ) -> None:
         """Initialize FSDP runtime state on an already-constructed module."""
         self._context = context
@@ -177,8 +181,8 @@ class FsdpModule:
                 placements=placements,
                 mixed_precision_policy=mixed_precision_policy,
                 reduce_scatter_stream=context.reduce_scatter_stream,
-                use_symm_mem=use_symm_mem,
                 grad_divisor=grad_divisor,
+                use_symmetric_memory=use_symmetric_memory,
             )
             for group_parameters in _group_parameters(owned_parameters)
         ]

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -37,19 +37,23 @@ class FsdpContext:
     # unnecessary because it can be detected when ``model_weight``, after syncing
     # from ``main_weight``, has placements different from ``Placements.optimizer``.
     is_last_microbatch: bool
+    use_symmetric_memory: bool
     # Static orders used to drive all-gather prefetch. We may want to switch to
     # capturing runtime order if static module order proves too fragile. Each
     # FsdpModule tracks its own materialized state via ``FsdpModule._unshard_event``.
     forward_order: IndexedOrder["FsdpModule"]
     backward_order: IndexedOrder["FsdpModule"]
 
-    def __init__(self, device: torch.device) -> None:
+    def __init__(self, device: torch.device, use_symmetric_memory: bool = False) -> None:
         """Create rank-local runtime state for FSDP modules on ``device``.
 
         Args:
             device: Device on which this context schedules communication.
+            use_symmetric_memory: Whether modules constructed in this context allocate
+                communication staging buffers from PyTorch's NCCL symmetric-memory pool.
         """
         self.is_last_microbatch = True
+        self.use_symmetric_memory = use_symmetric_memory
         self.forward_order = IndexedOrder()
         self.backward_order = IndexedOrder()
         # Construction-only; empty after finalization.
@@ -138,7 +142,7 @@ class FsdpModule:
         mesh: DeviceMesh,
         placements: Placements,
         mixed_precision_policy: MixedPrecisionPolicy,
-        use_symm_mem: bool = False,
+        use_symmetric_memory: bool = False,
     ) -> None:
         """Initialize FSDP runtime state on an already-constructed module."""
         self._context = context
@@ -157,7 +161,7 @@ class FsdpModule:
                 placements=placements,
                 mixed_precision_policy=mixed_precision_policy,
                 reduce_scatter_stream=context.reduce_scatter_stream,
-                use_symm_mem=use_symm_mem,
+                use_symmetric_memory=use_symmetric_memory,
             )
             for group_parameters in _group_parameters(owned_parameters)
         ]

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -77,8 +77,8 @@ class FsdpParameterGroup:
         placements: Placements,
         mixed_precision_policy: MixedPrecisionPolicy,
         reduce_scatter_stream: torch.cuda.Stream,
-        use_symm_mem: bool = False,
         grad_divisor: int = 1,
+        use_symmetric_memory: bool = False,
     ) -> None:
         """Create persistent sharded buffers for a group of parameters.
 
@@ -89,14 +89,14 @@ class FsdpParameterGroup:
             placements: Parameter, gradient, and optimizer placements.
             mixed_precision_policy: Precision policy for main weights and gradients.
             reduce_scatter_stream: Stream on which to allocate the main-gradient buffer.
-            use_symm_mem: Allocate communication staging buffers from PyTorch's
+            use_symmetric_memory: Allocate communication staging buffers from PyTorch's
                 NCCL symmetric-memory pool.
             grad_divisor: Additional divisor applied on top of the mesh-size
                 averaging. See ``fully_shard``.
         """
         if not parameters:
             raise ValueError("FsdpParameterGroup requires at least one parameter.")
-        if use_symm_mem and not hasattr(symm_mem, "is_symm_mem_tensor"):
+        if use_symmetric_memory and not hasattr(symm_mem, "is_symm_mem_tensor"):
             raise RuntimeError("Symmetric-memory MFSDP requires PyTorch 2.12 or later.")
 
         parameter_to_fqns: dict[nn.Parameter, list[str]] = {}
@@ -135,7 +135,7 @@ class FsdpParameterGroup:
             placements=main_weight_placements,
         )
 
-        if use_symm_mem:
+        if use_symmetric_memory:
             # PyTorch caches this in C++ and returns early when the backend is already NCCL.
             symm_mem.set_backend("NCCL")
             self._symm_mem_pool = symm_mem.get_mem_pool(self.main_weight.device)

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -76,7 +76,7 @@ class FsdpParameterGroup:
         placements: Placements,
         mixed_precision_policy: MixedPrecisionPolicy,
         reduce_scatter_stream: torch.cuda.Stream,
-        use_symm_mem: bool = False,
+        use_symmetric_memory: bool = False,
     ) -> None:
         """Create persistent sharded buffers for a group of parameters.
 
@@ -87,7 +87,7 @@ class FsdpParameterGroup:
             placements: Parameter, gradient, and optimizer placements.
             mixed_precision_policy: Precision policy for main weights and gradients.
             reduce_scatter_stream: Stream on which to allocate the main-gradient buffer.
-            use_symm_mem: Allocate communication staging buffers from PyTorch's
+            use_symmetric_memory: Allocate communication staging buffers from PyTorch's
                 NCCL symmetric-memory pool.
         """
         if not parameters:
@@ -128,7 +128,7 @@ class FsdpParameterGroup:
             placements=main_weight_placements,
         )
 
-        if use_symm_mem:
+        if use_symmetric_memory:
             # PyTorch caches this in C++ and returns early when the backend is already NCCL.
             symm_mem.set_backend("NCCL")
             self._symm_mem_pool = symm_mem.get_mem_pool(self.main_weight.device)

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -594,8 +594,8 @@ def test_root_backward_returns_to_resting_memory(distributed_setup):
     )
 
 
-@pytest.mark.parametrize("use_symm_mem", [False, True], ids=["default", "symmetric_memory"])
-def test_overlaps_communication_and_compute(distributed_setup, use_symm_mem):
+@pytest.mark.parametrize("use_symmetric_memory", [False, True], ids=["default", "symmetric_memory"])
+def test_overlaps_communication_and_compute(distributed_setup, use_symmetric_memory):
     """Forward and backward communication should overlap GEMM compute."""
     world_size = distributed_setup.world_size
     device = distributed_setup.device
@@ -620,7 +620,7 @@ def test_overlaps_communication_and_compute(distributed_setup, use_symm_mem):
     if not dist.is_initialized():
         dist.init_process_group(backend="nccl")
 
-    if use_symm_mem:
+    if use_symmetric_memory:
         # Dedicated communicator with NCCL's zero-CTA policy. cta_policy is a
         # per-communicator property, so scoping it to this group leaves the rest of the
         # bucket on default-CTA symmetric-memory kernels (test_symmetric_memory.py asserts
@@ -642,15 +642,9 @@ def test_overlaps_communication_and_compute(distributed_setup, use_symm_mem):
     model = MultiChildModel(dim=dim, num_children=num_children).to(device=device, dtype=dtype)
     placements = _flat_placements()
     policy = MixedPrecisionPolicy(main_params_dtype=dtype, main_grads_dtype=dtype)
-    with fully_shard_context(device=device):
+    with fully_shard_context(device=device, use_symmetric_memory=use_symmetric_memory):
         for layer in model.layers:
-            fully_shard(
-                layer,
-                mesh=mesh,
-                placements=placements,
-                mixed_precision_policy=policy,
-                use_symm_mem=use_symm_mem,
-            )
+            fully_shard(layer, mesh=mesh, placements=placements, mixed_precision_policy=policy)
 
     x = torch.randn(4096, dim, device=device, dtype=dtype, requires_grad=True)
 
@@ -683,7 +677,7 @@ def test_overlaps_communication_and_compute(distributed_setup, use_symm_mem):
     # Each child layer does a forward and a backward all-gather and one
     # reduce-scatter. Zero-CTA moves the all-gather to copy-engine memcpys, so it
     # should not emit all-gather kernels.
-    expected_allgather_kernel_count = 0 if use_symm_mem else 2 * num_children
+    expected_allgather_kernel_count = 0 if use_symmetric_memory else 2 * num_children
     assert len(allgather_kernels) == expected_allgather_kernel_count, (
         f"Expected {expected_allgather_kernel_count} all-gather kernels, got "
         f"{len(allgather_kernels)}: {[kernel.name for kernel in allgather_kernels]}"
@@ -712,7 +706,7 @@ def test_overlaps_communication_and_compute(distributed_setup, use_symm_mem):
     )
     expected_allgather_overlap = 2 * (num_children - 1)
     expected_reduce_scatter_overlap = num_children - 1
-    if not use_symm_mem:
+    if not use_symmetric_memory:
         assert allgather_overlap_count >= expected_allgather_overlap, (
             f"Expected at least {expected_allgather_overlap} all-gathers to "
             f"overlap compute, got {allgather_overlap_count}/{len(allgather_kernels)}."

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -537,8 +537,8 @@ def test_root_backward_returns_to_resting_memory(distributed_setup):
     )
 
 
-@pytest.mark.parametrize("use_symm_mem", [False, True], ids=["default", "symmetric_memory"])
-def test_overlaps_communication_and_compute(distributed_setup, use_symm_mem):
+@pytest.mark.parametrize("use_symmetric_memory", [False, True], ids=["default", "symmetric_memory"])
+def test_overlaps_communication_and_compute(distributed_setup, use_symmetric_memory):
     """Forward and backward communication should overlap GEMM compute."""
     world_size = distributed_setup.world_size
     device = distributed_setup.device
@@ -563,7 +563,7 @@ def test_overlaps_communication_and_compute(distributed_setup, use_symm_mem):
     if not dist.is_initialized():
         dist.init_process_group(backend="nccl")
 
-    if use_symm_mem:
+    if use_symmetric_memory:
         # Dedicated communicator with NCCL's zero-CTA policy. cta_policy is a
         # per-communicator property, so scoping it to this group leaves the rest of the
         # bucket on default-CTA symmetric-memory kernels (test_symmetric_memory.py asserts
@@ -585,15 +585,9 @@ def test_overlaps_communication_and_compute(distributed_setup, use_symm_mem):
     model = MultiChildModel(dim=dim, num_children=num_children).to(device=device, dtype=dtype)
     placements = _flat_placements()
     policy = MixedPrecisionPolicy(main_params_dtype=dtype, main_grads_dtype=dtype)
-    with fully_shard_context(device=device):
+    with fully_shard_context(device=device, use_symmetric_memory=use_symmetric_memory):
         for layer in model.layers:
-            fully_shard(
-                layer,
-                mesh=mesh,
-                placements=placements,
-                mixed_precision_policy=policy,
-                use_symm_mem=use_symm_mem,
-            )
+            fully_shard(layer, mesh=mesh, placements=placements, mixed_precision_policy=policy)
 
     x = torch.randn(4096, dim, device=device, dtype=dtype, requires_grad=True)
 
@@ -626,7 +620,7 @@ def test_overlaps_communication_and_compute(distributed_setup, use_symm_mem):
     # Each child layer does a forward and a backward all-gather and one
     # reduce-scatter. Zero-CTA moves the all-gather to copy-engine memcpys, so it
     # should not emit all-gather kernels.
-    expected_allgather_kernel_count = 0 if use_symm_mem else 2 * num_children
+    expected_allgather_kernel_count = 0 if use_symmetric_memory else 2 * num_children
     assert len(allgather_kernels) == expected_allgather_kernel_count, (
         f"Expected {expected_allgather_kernel_count} all-gather kernels, got "
         f"{len(allgather_kernels)}: {[kernel.name for kernel in allgather_kernels]}"
@@ -655,7 +649,7 @@ def test_overlaps_communication_and_compute(distributed_setup, use_symm_mem):
     )
     expected_allgather_overlap = 2 * (num_children - 1)
     expected_reduce_scatter_overlap = num_children - 1
-    if not use_symm_mem:
+    if not use_symmetric_memory:
         assert allgather_overlap_count >= expected_allgather_overlap, (
             f"Expected at least {expected_allgather_overlap} all-gathers to "
             f"overlap compute, got {allgather_overlap_count}/{len(allgather_kernels)}."

--- a/tests/unit_tests/distributed/mfsdp_v2/test_symmetric_memory.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_symmetric_memory.py
@@ -59,24 +59,22 @@ def test_fully_shard_symmetric_memory_matches_default_and_profiles_nccl(
     mesh = init_device_mesh(device.type, (world_size,))
     num_training_steps = 5
 
-    def train(use_symm_mem: bool) -> list[torch.Tensor]:
+    def train(use_symmetric_memory: bool) -> list[torch.Tensor]:
         torch.manual_seed(1234)
         model = TinyModel().to(device=device, dtype=torch.bfloat16)
         mixed_precision_policy = MixedPrecisionPolicy(main_params_dtype=torch.float32)
-        with fully_shard_context(device=device):
+        with fully_shard_context(device=device, use_symmetric_memory=use_symmetric_memory):
             fully_shard(
                 model.fc1,
                 mesh=mesh,
                 placements=_flat_placements(),
                 mixed_precision_policy=mixed_precision_policy,
-                use_symm_mem=use_symm_mem,
             )
             fully_shard(
                 model.fc2,
                 mesh=mesh,
                 placements=_flat_placements(),
                 mixed_precision_policy=mixed_precision_policy,
-                use_symm_mem=use_symm_mem,
             )
         optimizer = torch.optim.SGD(model.parameters(), lr=0.05, foreach=False)
 
@@ -101,11 +99,11 @@ def test_fully_shard_symmetric_memory_matches_default_and_profiles_nccl(
         return losses
 
     with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]) as prof_without_symm_mem:
-        losses_without_symm_mem = train(use_symm_mem=False)
+        losses_without_symm_mem = train(use_symmetric_memory=False)
         torch.cuda.synchronize()
 
     with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]) as prof_with_symm_mem:
-        losses_with_symm_mem = train(use_symm_mem=True)
+        losses_with_symm_mem = train(use_symmetric_memory=True)
         torch.cuda.synchronize()
 
     torch.testing.assert_close(
@@ -188,20 +186,18 @@ def test_fully_shard_zero_cta_moves_all_gather_to_copy_engine(distributed_setup)
     num_training_steps = 5
     model = TinyModel().to(device=device, dtype=torch.bfloat16)
     mixed_precision_policy = MixedPrecisionPolicy(main_params_dtype=torch.float32)
-    with fully_shard_context(device=device):
+    with fully_shard_context(device=device, use_symmetric_memory=True):
         fully_shard(
             model.fc1,
             mesh=mesh,
             placements=_flat_placements(),
             mixed_precision_policy=mixed_precision_policy,
-            use_symm_mem=True,
         )
         fully_shard(
             model.fc2,
             mesh=mesh,
             placements=_flat_placements(),
             mixed_precision_policy=mixed_precision_policy,
-            use_symm_mem=True,
         )
     optimizer = torch.optim.SGD(model.parameters(), lr=0.05, foreach=False)
     x = torch.randn(2, _HIDDEN, device=device, dtype=torch.bfloat16)


### PR DESCRIPTION
# What does this PR do?

Add a construction-scoped `use_symmetric_memory` option to MFSDP v2's `fully_shard_context()`.

The symmetric-memory setting previously lived on each `fully_shard()` call. Callers now configure a group of module sharding operations with `fully_shard_context(..., use_symmetric_memory=...)`; every contained `fully_shard()` call inherits that setting during construction. The boolean is passed through `FsdpModule` to `FsdpParameterGroup`; no options object is retained.

The per-call `use_symm_mem` argument is removed without deprecation. Existing symmetric-memory parity, communication-overlap, zero-CTA, and NCCL symmetric-kernel assertions now configure the option through `fully_shard_context()`.

## Validation

- `python -m torch.distributed.run --nproc-per-node 2 -m pytest -q tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py tests/unit_tests/distributed/mfsdp_v2/test_symmetric_memory.py`
- `isort` on changed Python files.
- `git diff --check`.