### PR TITLE
Support FP4 in 1F1B A2A overlap

### DIFF
--- a/megatron/core/models/common/model_chunk_schedule_plan.py
+++ b/megatron/core/models/common/model_chunk_schedule_plan.py
@@ -1,14 +1,10 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 
-from contextlib import nullcontext
 from typing import Any, Callable, Optional
 
 import torch
 from torch import Tensor
 
-from megatron.core.enums import Fp8Recipe
-from megatron.core.fp4_utils import get_fp4_context
-from megatron.core.fp8_utils import get_fp8_context
 from megatron.core.pipeline_parallel.utils import (
     AbstractSchedulePlan,
     NoopScheduleNode,
@@ -222,20 +218,7 @@ class TransformerLayerSchedulePlan:
 
     def get_low_precision_context(self):
         """Get the low-precision context for the transformer layer."""
-        from megatron.core.transformer.multi_token_prediction import MultiTokenPredictionLayer
-
-        use_inner_fp8_context = (
-            self.layer.config.fp8 and self.layer.config.fp8_recipe != Fp8Recipe.delayed
-        )
-        use_inner_fp4_context = self.layer.config.fp4 and not isinstance(
-            self.layer, MultiTokenPredictionLayer
-        )
-
-        if use_inner_fp8_context:
-            return get_fp8_context(self.layer.config, self.layer.layer_number - 1)
-        if use_inner_fp4_context:
-            return get_fp4_context(self.layer.config, self.layer.layer_number - 1)
-        return nullcontext()
+        return self.layer.get_inner_quantization_context()
 
     @staticmethod
     def run(f_layer, b_layer, f_input=None, b_grad=None, is_last_layer_in_bwd=False):

--- a/megatron/core/models/common/model_chunk_schedule_plan.py
+++ b/megatron/core/models/common/model_chunk_schedule_plan.py
@@ -7,6 +7,7 @@ import torch
 from torch import Tensor
 
 from megatron.core.enums import Fp8Recipe
+from megatron.core.fp4_utils import get_fp4_context
 from megatron.core.fp8_utils import get_fp8_context
 from megatron.core.pipeline_parallel.utils import (
     AbstractSchedulePlan,
@@ -219,18 +220,22 @@ class TransformerLayerSchedulePlan:
         # After the last forward op, release forward-pass params.
         last_fwd_node.set_post_forward_hook(lambda: post_forward_hook(hook_module))
 
-    def get_fp8_context(self):
-        """
-        Get the fp8 context for the transformer layer.
-        """
+    def get_low_precision_context(self):
+        """Get the low-precision context for the transformer layer."""
+        from megatron.core.transformer.multi_token_prediction import MultiTokenPredictionLayer
+
         use_inner_fp8_context = (
             self.layer.config.fp8 and self.layer.config.fp8_recipe != Fp8Recipe.delayed
         )
-        return (
-            get_fp8_context(self.layer.config, self.layer.layer_number - 1)
-            if use_inner_fp8_context
-            else nullcontext()
+        use_inner_fp4_context = self.layer.config.fp4 and not isinstance(
+            self.layer, MultiTokenPredictionLayer
         )
+
+        if use_inner_fp8_context:
+            return get_fp8_context(self.layer.config, self.layer.layer_number - 1)
+        if use_inner_fp4_context:
+            return get_fp4_context(self.layer.config, self.layer.layer_number - 1)
+        return nullcontext()
 
     @staticmethod
     def run(f_layer, b_layer, f_input=None, b_grad=None, is_last_layer_in_bwd=False):
@@ -263,14 +268,14 @@ class TransformerLayerSchedulePlan:
             b_grad = b_layer.moe_combine.backward(b_grad)
 
         if f_layer is not None:
-            with f_layer.get_fp8_context():
+            with f_layer.get_low_precision_context():
                 f_input = f_layer.pre_dispatch_computation.forward(f_input)
 
         if b_layer is not None:
             b_grad = b_layer.mlp.backward(b_grad)
 
         if f_layer is not None:
-            with f_layer.get_fp8_context():
+            with f_layer.get_low_precision_context():
                 f_input = f_layer.moe_dispatch.forward(f_input)
 
         if b_layer is not None:
@@ -281,18 +286,18 @@ class TransformerLayerSchedulePlan:
             b_grad = b_layer.pre_dispatch_computation.backward(b_grad)
 
         if f_layer is not None:
-            with f_layer.get_fp8_context():
+            with f_layer.get_low_precision_context():
                 f_input = f_layer.mlp.forward(f_input)
 
         if f_layer is not None:
-            with f_layer.get_fp8_context():
+            with f_layer.get_low_precision_context():
                 f_input = f_layer.moe_combine.forward(f_input)
 
         if b_layer is not None and not b_layer.config.ep_overlap_early_attn_memory_release:
             b_grad = b_layer.pre_dispatch_computation.backward(b_grad)
 
         if f_layer is not None:
-            with f_layer.get_fp8_context():
+            with f_layer.get_low_precision_context():
                 f_input = f_layer.mtp_post_process.forward(f_input)
 
         # Delay the last pre_dispatch_computation wgrad in backward pass (wgrad

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -1254,7 +1254,7 @@ class MultiTokenPredictionLayer(MegatronModule):
     def get_inner_quantization_context(self) -> AbstractContextManager:
         """Return the quantization context for fine-grained MTP execution."""
         if self.config.fp8 and self.config.fp8_recipe != Fp8Recipe.delayed:
-            return get_fp8_context(self.config, self.layer_number - 1)
+            return get_fp8_context(self.config)
 
         # FP4 in MTP layers still needs numerical validation.
         return nullcontext()

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import warnings
-from contextlib import nullcontext
+from contextlib import AbstractContextManager, nullcontext
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Callable, List, Optional, Union
 
@@ -1250,6 +1250,14 @@ class MultiTokenPredictionLayer(MegatronModule):
             eps=self.config.layernorm_epsilon,
         )
         self.offload_context = nullcontext()
+
+    def get_inner_quantization_context(self) -> AbstractContextManager:
+        """Return the quantization context for fine-grained MTP execution."""
+        if self.config.fp8 and self.config.fp8_recipe != Fp8Recipe.delayed:
+            return get_fp8_context(self.config, self.layer_number - 1)
+
+        # FP4 in MTP layers still needs numerical validation.
+        return nullcontext()
 
     def _get_embeddings(
         self,

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -5,6 +5,7 @@ import functools
 import logging
 import warnings
 from abc import ABC
+from contextlib import AbstractContextManager, nullcontext
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Dict, Optional, Protocol, Union
 
@@ -23,6 +24,9 @@ except ImportError:
 from megatron.core import parallel_state, tensor_parallel
 from megatron.core.dist_checkpointing.mapping import ShardedStateDict
 from megatron.core.dist_checkpointing.utils import apply_prefix_mapping
+from megatron.core.enums import Fp8Recipe
+from megatron.core.fp4_utils import get_fp4_context
+from megatron.core.fp8_utils import get_fp8_context
 from megatron.core.inference.utils import InferenceMode
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.process_groups_config import ProcessGroupCollection
@@ -569,6 +573,14 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
             if "_forward_post_mlp" in vars(klass):
                 self._legacy_forward_post_mlp = klass._forward_post_mlp
                 break
+
+    def get_inner_quantization_context(self) -> AbstractContextManager:
+        """Return the quantization context for fine-grained layer execution."""
+        if self.config.fp8 and self.config.fp8_recipe != Fp8Recipe.delayed:
+            return get_fp8_context(self.config, self.layer_number - 1)
+        if self.config.fp4:
+            return get_fp4_context(self.config, self.layer_number - 1)
+        return nullcontext()
 
     def create_mcore_cudagraph_manager(self, config):
         """Register the transformer layer for cudagraphs."""

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -25,8 +25,6 @@ from megatron.core import parallel_state, tensor_parallel
 from megatron.core.dist_checkpointing.mapping import ShardedStateDict
 from megatron.core.dist_checkpointing.utils import apply_prefix_mapping
 from megatron.core.enums import Fp8Recipe
-from megatron.core.fp4_utils import get_fp4_context
-from megatron.core.fp8_utils import get_fp8_context
 from megatron.core.inference.utils import InferenceMode
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.process_groups_config import ProcessGroupCollection
@@ -577,8 +575,12 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
     def get_inner_quantization_context(self) -> AbstractContextManager:
         """Return the quantization context for fine-grained layer execution."""
         if self.config.fp8 and self.config.fp8_recipe != Fp8Recipe.delayed:
+            from megatron.core.fp8_utils import get_fp8_context  # to avoid circular import
+
             return get_fp8_context(self.config, self.layer_number - 1)
         if self.config.fp4:
+            from megatron.core.fp4_utils import get_fp4_context  # to avoid circular import
+
             return get_fp4_context(self.config, self.layer_number - 1)
         return nullcontext()
 

--- a/tests/unit_tests/a2a_overlap/test_schedule_quantization_context.py
+++ b/tests/unit_tests/a2a_overlap/test_schedule_quantization_context.py
@@ -45,6 +45,24 @@ def test_transformer_layer_uses_fp4_context():
     get_fp4_context.assert_called_once_with(config, 2)
 
 
+def test_mtp_layer_uses_global_fp8_context():
+    config = SimpleNamespace(fp8="e4m3", fp8_recipe=Fp8Recipe.tensorwise, fp4=None)
+    layer = MultiTokenPredictionLayer.__new__(MultiTokenPredictionLayer)
+    torch.nn.Module.__init__(layer)
+    layer.config = config
+    layer.layer_number = 1
+    expected_context = nullcontext()
+
+    with patch(
+        "megatron.core.transformer.multi_token_prediction.get_fp8_context",
+        return_value=expected_context,
+    ) as get_fp8_context:
+        context = layer.get_inner_quantization_context()
+
+    assert context is expected_context
+    get_fp8_context.assert_called_once_with(config)
+
+
 def test_mtp_layer_does_not_use_fp4_context():
     config = SimpleNamespace(fp8=None, fp8_recipe=Fp8Recipe.delayed, fp4="e2m1")
     layer = MultiTokenPredictionLayer.__new__(MultiTokenPredictionLayer)

--- a/tests/unit_tests/a2a_overlap/test_schedule_quantization_context.py
+++ b/tests/unit_tests/a2a_overlap/test_schedule_quantization_context.py
@@ -2,13 +2,14 @@
 
 from contextlib import nullcontext
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import torch
 
 from megatron.core.enums import Fp8Recipe
 from megatron.core.models.common.model_chunk_schedule_plan import TransformerLayerSchedulePlan
 from megatron.core.transformer.multi_token_prediction import MultiTokenPredictionLayer
+from megatron.core.transformer.transformer_layer import TransformerLayer
 
 
 def _schedule_plan(layer):
@@ -17,31 +18,39 @@ def _schedule_plan(layer):
     return plan
 
 
-def test_fp4_context_is_used_for_transformer_layer():
+def test_schedule_uses_layer_quantization_context():
+    expected_context = nullcontext()
+    layer = SimpleNamespace(get_inner_quantization_context=Mock(return_value=expected_context))
+
+    context = _schedule_plan(layer).get_low_precision_context()
+
+    assert context is expected_context
+    layer.get_inner_quantization_context.assert_called_once_with()
+
+
+def test_transformer_layer_uses_fp4_context():
     config = SimpleNamespace(fp8=None, fp8_recipe=Fp8Recipe.delayed, fp4="e2m1")
-    layer = SimpleNamespace(config=config, layer_number=3)
+    layer = TransformerLayer.__new__(TransformerLayer)
+    torch.nn.Module.__init__(layer)
+    layer.config = config
+    layer.layer_number = 3
     expected_context = nullcontext()
 
     with patch(
-        "megatron.core.models.common.model_chunk_schedule_plan.get_fp4_context",
-        return_value=expected_context,
+        "megatron.core.transformer.transformer_layer.get_fp4_context", return_value=expected_context
     ) as get_fp4_context:
-        context = _schedule_plan(layer).get_low_precision_context()
+        context = layer.get_inner_quantization_context()
 
     assert context is expected_context
     get_fp4_context.assert_called_once_with(config, 2)
 
 
-def test_fp4_context_is_not_used_for_mtp_layer():
+def test_mtp_layer_does_not_use_fp4_context():
     config = SimpleNamespace(fp8=None, fp8_recipe=Fp8Recipe.delayed, fp4="e2m1")
     layer = MultiTokenPredictionLayer.__new__(MultiTokenPredictionLayer)
     torch.nn.Module.__init__(layer)
     layer.config = config
 
-    with patch(
-        "megatron.core.models.common.model_chunk_schedule_plan.get_fp4_context"
-    ) as get_fp4_context:
-        with _schedule_plan(layer).get_low_precision_context():
-            pass
+    context = layer.get_inner_quantization_context()
 
-    get_fp4_context.assert_not_called()
+    assert isinstance(context, nullcontext)

--- a/tests/unit_tests/a2a_overlap/test_schedule_quantization_context.py
+++ b/tests/unit_tests/a2a_overlap/test_schedule_quantization_context.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from megatron.core.enums import Fp8Recipe
+from megatron.core.models.common.model_chunk_schedule_plan import TransformerLayerSchedulePlan
+from megatron.core.transformer.multi_token_prediction import MultiTokenPredictionLayer
+
+
+def _schedule_plan(layer):
+    plan = TransformerLayerSchedulePlan.__new__(TransformerLayerSchedulePlan)
+    plan.layer = layer
+    return plan
+
+
+def test_fp4_context_is_used_for_transformer_layer():
+    config = SimpleNamespace(fp8=None, fp8_recipe=Fp8Recipe.delayed, fp4="e2m1")
+    layer = SimpleNamespace(config=config, layer_number=3)
+    expected_context = nullcontext()
+
+    with patch(
+        "megatron.core.models.common.model_chunk_schedule_plan.get_fp4_context",
+        return_value=expected_context,
+    ) as get_fp4_context:
+        context = _schedule_plan(layer).get_low_precision_context()
+
+    assert context is expected_context
+    get_fp4_context.assert_called_once_with(config, 2)
+
+
+def test_fp4_context_is_not_used_for_mtp_layer():
+    config = SimpleNamespace(fp8=None, fp8_recipe=Fp8Recipe.delayed, fp4="e2m1")
+    layer = MultiTokenPredictionLayer.__new__(MultiTokenPredictionLayer)
+    torch.nn.Module.__init__(layer)
+    layer.config = config
+
+    with patch(
+        "megatron.core.models.common.model_chunk_schedule_plan.get_fp4_context"
+    ) as get_fp4_context:
+        with _schedule_plan(layer).get_low_precision_context():
+            pass
+
+    get_fp4_context.assert_not_called()

--- a/tests/unit_tests/a2a_overlap/test_schedule_quantization_context.py
+++ b/tests/unit_tests/a2a_overlap/test_schedule_quantization_context.py
@@ -37,12 +37,29 @@ def test_transformer_layer_uses_fp4_context():
     expected_context = nullcontext()
 
     with patch(
-        "megatron.core.transformer.transformer_layer.get_fp4_context", return_value=expected_context
+        "megatron.core.fp4_utils.get_fp4_context", return_value=expected_context
     ) as get_fp4_context:
         context = layer.get_inner_quantization_context()
 
     assert context is expected_context
     get_fp4_context.assert_called_once_with(config, 2)
+
+
+def test_transformer_layer_uses_fp8_context():
+    config = SimpleNamespace(fp8="e4m3", fp8_recipe=Fp8Recipe.tensorwise, fp4=None)
+    layer = TransformerLayer.__new__(TransformerLayer)
+    torch.nn.Module.__init__(layer)
+    layer.config = config
+    layer.layer_number = 3
+    expected_context = nullcontext()
+
+    with patch(
+        "megatron.core.fp8_utils.get_fp8_context", return_value=expected_context
+    ) as get_fp8_context:
+        context = layer.get_inner_quantization_context()
+
+    assert context is expected_context
+    get_fp8_context.assert_called_once_with(config, 2)
 
 
 def test_mtp_layer_uses_global_fp8_context():


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Adds FP4 quantization-context handling to the combined 1F1B schedule used for expert-parallel all-to-all overlap.

The schedule previously entered an inner context only for non-delayed FP8 recipes. NVFP4 layers therefore executed the fine-grained forward nodes outside `get_fp4_context()`, unlike the standard `TransformerBlock` path.

This change generalizes the schedule helper to select the appropriate FP8 or FP4 context and applies it to every fine-grained forward node. MTP layers continue to run outside the FP4 context, matching the existing policy while FP4 MTP awaits numerical validation.

This is based on Selvaraj Anandaraj's original implementation:
https://github.com/sanandaraj5597/Megatron-LM/commit/5367074e4ea0504275d43dac5d0cc8569aa90f56

It also incorporates the follow-up `nullcontext` correction:
https://github.com/sanandaraj5597/Megatron-LM/commit/5eee9144605f96abccb20a2a52e16b162f5d0859

## Issue tracking

Linked issue: N/A (small compatibility fix)

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

## Tests

- Added focused unit coverage for selecting the FP4 context on transformer layers.
- Added coverage confirming MTP remains outside the FP4 context.
- `isort==5.13.2 --check-only --diff` (changed files)
- `black==24.4.2 --check` (changed files)
- `ruff==0.9.10 check` (changed files)
- `python3 -m py_compile` (changed files)

GPU pytest was not run locally because the locked development environment depends on Linux CUDA packages unavailable on macOS; the focused tests are included for Linux/CUDA CI.
