### PR TITLE
fix(tests): prefer staged release assets

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -591,6 +591,8 @@ jobs:
 
       - name: Download test data
         shell: bash
+        env:
+          NEMO_TEST_DATA_ROOT: /mnt/datadrive/TestData/nemo-fw/TestData
         run: |
           echo "::group::Download test data"
           for attempt in 1 2 3; do

--- a/tests/test_utils/python_scripts/download_unit_tests_dataset.py
+++ b/tests/test_utils/python_scripts/download_unit_tests_dataset.py
@@ -2,11 +2,11 @@
 
 #!/usr/bin/env python3
 """
-Script to fetch the oldest release of NVIDIA/Megatron-LM on GitHub and list its assets.
-Uses the PyGithub SDK to interact with the GitHub API.
+Populate unit-test data from staged or public NVIDIA/Megatron-LM v2.5 release assets.
 """
 
 import logging
+import os
 import tarfile
 import zipfile
 from pathlib import Path
@@ -17,6 +17,9 @@ import requests
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+DEFAULT_TEST_DATA_ROOT = Path("/home/TestData")
+TEST_DATA_ROOT_ENV = "NEMO_TEST_DATA_ROOT"
+STAGED_RELEASE_ASSET_DIR = Path("megatron-lm/release-assets/v2.5")
 ASSETS = [
     {
         "name": "datasets.zip",
@@ -29,55 +32,85 @@ ASSETS = [
 ]
 
 
-def download_and_extract_asset(assets_dir: Path) -> bool:
-    """
-    Download and extract an asset to the assets directory.
+def get_test_data_root() -> Path:
+    """Return the configured shared TestData root."""
+    return Path(os.environ.get(TEST_DATA_ROOT_ENV) or DEFAULT_TEST_DATA_ROOT)
+
+
+def extract_asset(asset_path: Path, assets_dir: Path) -> bool:
+    """Extract a release asset into the writable test data directory.
 
     Args:
-        asset_url: URL to download the asset from
-        asset_name: Name of the asset file
-        assets_dir: Directory to extract the asset to
+        asset_path: Release archive to extract.
+        assets_dir: Directory to extract the asset into.
 
     Returns:
-        bool: True if successful, False otherwise
+        True when extraction succeeds.
     """
-    for asset in ASSETS:
-        asset_name, asset_url = asset.values()
-        try:
-            # Download the asset
-            logger.info(f"  Downloading {asset_name}...")
-            response = requests.get(asset_url, stream=True)
-            response.raise_for_status()
+    try:
+        logger.info(f"  Extracting {asset_path.name} to {assets_dir}...")
 
-            # Save to temporary file
-            temp_file = assets_dir / asset_name
-            with open(temp_file, 'wb') as f:
-                for chunk in response.iter_content(chunk_size=8192):
-                    f.write(chunk)
+        if asset_path.name.endswith('.zip'):
+            with zipfile.ZipFile(asset_path, 'r') as zip_ref:
+                zip_ref.extractall(assets_dir)
+        elif asset_path.name.endswith(('.tar.gz', '.tgz')):
+            with tarfile.open(asset_path, 'r:gz') as tar_ref:
+                tar_ref.extractall(assets_dir)
+        elif asset_path.name.endswith('.tar'):
+            with tarfile.open(asset_path, 'r') as tar_ref:
+                tar_ref.extractall(assets_dir)
+        else:
+            logger.warning(
+                f"  Warning: Unknown file type for {asset_path.name}, skipping extraction"
+            )
+            return False
 
-            logger.info(f"  Extracting {asset_name} to {assets_dir}...")
+        logger.info(f"  Successfully extracted to {assets_dir}")
+        return True
+    except Exception as e:
+        logger.error(f"  Error extracting {asset_path.name}: {e}")
+        return False
 
-            # Extract based on file type
-            if asset_name.endswith('.zip'):
-                with zipfile.ZipFile(temp_file, 'r') as zip_ref:
-                    zip_ref.extractall(assets_dir)
-            elif asset_name.endswith(('.tar.gz', '.tgz')):
-                with tarfile.open(temp_file, 'r:gz') as tar_ref:
-                    tar_ref.extractall(assets_dir)
-            elif asset_name.endswith('.tar'):
-                with tarfile.open(temp_file, 'r') as tar_ref:
-                    tar_ref.extractall(assets_dir)
-            else:
-                logger.warning(
-                    f"  Warning: Unknown file type for {asset_name}, skipping extraction"
-                )
 
-            # Clean up temporary file
+def extract_staged_release_assets(assets_dir: Path) -> bool:
+    """Extract staged Megatron-LM v2.5 assets when all of them are available."""
+    staged_dir = get_test_data_root() / STAGED_RELEASE_ASSET_DIR
+    staged_assets = tuple(staged_dir / asset["name"] for asset in ASSETS)
+    if not all(asset_path.is_file() for asset_path in staged_assets):
+        return False
+
+    logger.info(f"Using staged release assets from {staged_dir}")
+    return all(extract_asset(asset_path, assets_dir) for asset_path in staged_assets)
+
+
+def download_release_asset(asset_url: str, asset_name: str, assets_dir: Path) -> bool:
+    """Download and extract one public GitHub release asset."""
+    temp_file = assets_dir / asset_name
+    try:
+        logger.info(f"  Downloading {asset_name}...")
+        response = requests.get(asset_url, stream=True, timeout=60)
+        response.raise_for_status()
+
+        with open(temp_file, 'wb') as f:
+            for chunk in response.iter_content(chunk_size=8192):
+                f.write(chunk)
+
+        return extract_asset(temp_file, assets_dir)
+    except Exception as e:
+        logger.error(f"  Error downloading/extracting {asset_name}: {e}")
+        return False
+    finally:
+        if temp_file.is_file():
             temp_file.unlink()
-            logger.info(f"  Successfully extracted to {assets_dir}")
 
-        except Exception as e:
-            logger.error(f"  Error downloading/extracting {asset_name}: {e}")
+
+def download_and_extract_asset(assets_dir: Path) -> bool:
+    """Use staged v2.5 assets first, then fall back to public GitHub downloads."""
+    assets_dir.mkdir(parents=True, exist_ok=True)
+    if extract_staged_release_assets(assets_dir):
+        return True
+
+    return all(download_release_asset(asset["url"], asset["name"], assets_dir) for asset in ASSETS)
 
 
 @click.command()
@@ -86,13 +119,12 @@ def download_and_extract_asset(assets_dir: Path) -> bool:
 )
 @click.option('--assets-dir', default='assets', help='Directory to extract assets to')
 def main(repo, assets_dir):
-    """Fetch the oldest release of a GitHub repository and download its assets."""
-    logger.info(f"Fetching oldest release of {repo}...")
+    """Populate unit-test data from staged or public release assets."""
+    logger.info(f"Preparing v2.5 release assets for {repo}...")
     logger.info("=" * 80)
 
-    Path(assets_dir).mkdir(parents=True, exist_ok=True)
-
-    download_and_extract_asset(Path(assets_dir))
+    if not download_and_extract_asset(Path(assets_dir)):
+        raise click.ClickException("Failed to download and extract release assets")
 
 
 if __name__ == "__main__":

--- a/tests/test_utils/python_scripts/test_download_unit_tests_dataset.py
+++ b/tests/test_utils/python_scripts/test_download_unit_tests_dataset.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import MagicMock, call
+from zipfile import ZipFile
+
+from tests.test_utils.python_scripts import download_unit_tests_dataset
+
+
+def _archive_bytes(directory: str, content: str) -> bytes:
+    buffer = BytesIO()
+    with ZipFile(buffer, "w") as archive:
+        archive.writestr(f"{directory}/fixture.txt", content)
+    return buffer.getvalue()
+
+
+def test_download_and_extract_asset_prefers_staged_assets(monkeypatch, tmp_path):
+    staged_root = tmp_path / "staged"
+    staged_dir = staged_root / download_unit_tests_dataset.STAGED_RELEASE_ASSET_DIR
+    staged_dir.mkdir(parents=True)
+    for asset in download_unit_tests_dataset.ASSETS:
+        asset_path = staged_dir / asset["name"]
+        asset_path.write_bytes(_archive_bytes(asset_path.stem, asset_path.name))
+
+    monkeypatch.setenv(download_unit_tests_dataset.TEST_DATA_ROOT_ENV, str(staged_root))
+    get = MagicMock(side_effect=AssertionError("GitHub fallback should not be used"))
+    monkeypatch.setattr(download_unit_tests_dataset.requests, "get", get)
+
+    output_dir = tmp_path / "output"
+    assert download_unit_tests_dataset.download_and_extract_asset(output_dir)
+    assert (output_dir / "datasets" / "fixture.txt").read_text() == "datasets.zip"
+    assert (output_dir / "tokenizers" / "fixture.txt").read_text() == "tokenizers.zip"
+    get.assert_not_called()
+
+
+def test_download_and_extract_asset_falls_back_without_github_token(monkeypatch, tmp_path):
+    archives = {
+        asset["url"]: _archive_bytes(Path(asset["name"]).stem, asset["name"])
+        for asset in download_unit_tests_dataset.ASSETS
+    }
+
+    class Response:
+        def __init__(self, content: bytes):
+            self.content = content
+
+        def raise_for_status(self):
+            return None
+
+        def iter_content(self, chunk_size: int):
+            yield self.content
+
+    get = MagicMock(side_effect=lambda url, **_: Response(archives[url]))
+    monkeypatch.setenv(download_unit_tests_dataset.TEST_DATA_ROOT_ENV, str(tmp_path / "missing"))
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.setattr(download_unit_tests_dataset.requests, "get", get)
+
+    output_dir = tmp_path / "output"
+    assert download_unit_tests_dataset.download_and_extract_asset(output_dir)
+    assert (output_dir / "datasets" / "fixture.txt").read_text() == "datasets.zip"
+    assert (output_dir / "tokenizers" / "fixture.txt").read_text() == "tokenizers.zip"
+    assert get.call_args_list == [
+        call(asset["url"], stream=True, timeout=60) for asset in download_unit_tests_dataset.ASSETS
+    ]


### PR DESCRIPTION
## Background

The CI container build downloads Megatron-LM v2.5 unit-test archives from GitHub even when the shared TestData mount already contains them. That adds avoidable egress and makes builds depend on GitHub release availability. The current `main` downloader already uses public release URLs directly, so `GH_TOKEN` should remain optional.

## What changed

- Resolve `datasets.zip` and `tokenizers.zip` from staged TestData before using GitHub.
- Keep the public v2.5 release URLs as the fallback when either staged archive is absent or unusable.
- Point the CI download step at `/mnt/datadrive/TestData/nemo-fw/TestData` through `NEMO_TEST_DATA_ROOT`.
- Return a non-zero CLI result when neither local extraction nor the public fallback succeeds.
- Add unit coverage for staged and unauthenticated fallback behavior.

## Details

The shared archive path is `megatron-lm/release-assets/v2.5/` relative to `NEMO_TEST_DATA_ROOT`. Both archives must exist before local mode is selected. Extraction still targets the writable `assets/` build context, so the Dockerfiles continue to copy the same `/opt/data` tree.

No GitHub token is read or required. When local data is unavailable, the downloader performs unauthenticated HTTPS requests to the existing public release URLs.

## Tested

- `UV_PROJECT_ENVIRONMENT=<shared-venv> uv run isort tests/test_utils/python_scripts/download_unit_tests_dataset.py tests/test_utils/python_scripts/test_download_unit_tests_dataset.py` — passed.
- `PATH=<shared-venv>/bin:$PATH BASE_REF=main CHECK_ONLY=true SKIP_DOCS=false bash tools/autoformat.sh` — exited 0; Black, isort, pylint, and Ruff passed for both changed Python files.
- `UV_PROJECT_ENVIRONMENT=<shared-venv> uv run python -m pytest -q tests/test_utils/python_scripts/test_download_unit_tests_dataset.py` — 2 passed.
- Real staged path: copied the two shared GCS objects into a temporary TestData root, forced HTTP(S) through an unreachable proxy, and ran the CLI — extracted 12 dataset files and 20 tokenizer files without egress.
- Real fallback: ran the CLI with `GH_TOKEN` unset and a missing TestData root — downloaded and extracted 12 dataset files and 20 tokenizer files.
- Independently streamed both staged objects from S3 and both GCS buckets; all six SHA-256 checks matched the GitHub release digests.

## Checklist

- [x] Commit is signed off.
- [x] Added focused unit coverage.
- [x] No public API or dependency changes.
- [x] Draft PR opened from the required personal fork.