### PR TITLE
ci: build CI image against nvidia-resiliency-ext main

### DIFF
--- a/docker/Dockerfile.ci.dev
+++ b/docker/Dockerfile.ci.dev
@@ -126,6 +126,40 @@ EOF
 COPY assets/ /opt/data/
 ENV UV_PYTHON=$UV_PROJECT_ENVIRONMENT/bin/python
 
+# EXPERIMENT ONLY -- DO NOT MERGE.
+# Replace the locked nvidia-resiliency-ext release with upstream NVRx main so CI
+# exercises the latest NVRx. Installed imperatively rather than via pyproject.toml
+# + uv.lock so that every `uv sync --locked` gate in this repo stays satisfied.
+ARG NVRX_REF=main
+ENV NVRX_REF=${NVRX_REF}
+RUN bash -ex <<"EOF"
+    # NVRx main adds langchain-core/langchain-openai, mcp, logsage, setproctitle,
+    # uvicorn, slowapi and slack-bolt/slack-sdk on top of the pinned 0.6.0, so
+    # --no-deps would leave the package un-importable. Install with deps and reuse
+    # the override trick from pyproject.toml's [tool.uv].override-dependencies to
+    # keep the base image's torch/torchvision/triton untouched.
+    cat >/tmp/nvrx-overrides.txt <<'OVERRIDES'
+torch; sys_platform == 'never'
+torchvision; sys_platform == 'never'
+triton; sys_platform == 'never'
+OVERRIDES
+    # pydantic 2.14 breaks langchain_core's module-level RunnablePassthrough()
+    # instantiation, which NVRx main now imports directly. Same cap the
+    # transformer-engine dependency-metadata entry applies.
+    echo "pydantic<2.14" >/tmp/nvrx-constraints.txt
+
+    uv pip install \
+        --reinstall-package nvidia-resiliency-ext \
+        --overrides /tmp/nvrx-overrides.txt \
+        --constraints /tmp/nvrx-constraints.txt \
+        "nvidia-resiliency-ext @ git+https://github.com/NVIDIA/nvidia-resiliency-ext.git@${NVRX_REF}"
+
+    # Record the resolved commit -- `main` floats, so the build log is the only
+    # record of what was actually tested.
+    uv pip freeze | grep -i resiliency
+    python -c "import nvidia_resiliency_ext; print('NVRx import OK')"
+EOF
+
 ##### For NVIDIANS only #####
 FROM main AS jet
 ARG JET_API_VERSION


### PR DESCRIPTION
## What

Builds the CI image against **upstream `nvidia-resiliency-ext` main** instead of the locked `0.6.0` PyPI wheel, so the full CI suite runs against the latest NVRx.

**Experiment only — not intended to merge.**

## How

A single `uv pip install` layer appended to the `main` stage of `docker/Dockerfile.ci.dev`.

This is deliberately *not* done via `pyproject.toml` + `uv.lock`. Every `uv sync` in this repo passes `--locked` (`Dockerfile.ci.dev:65`, `Dockerfile.ci.lts:51`, `docker/common/install.sh:141`, and `cicd-main.yml:355` in the linting job), which rejects a `pyproject.toml` change without a matching relock. An imperative install sidesteps all four gates.

Overridable via `--build-arg NVRX_REF=<sha|branch|tag>`; defaults to `main`.

## Why install with dependencies

NVRx `main` adds a substantial set of runtime dependencies over the pinned `0.6.0`:

`langchain-core`, `langchain-openai`, `mcp`, `logsage`, `setproctitle`, `uvicorn[standard]`, `pydantic-settings`, `slowapi`, `slack-bolt`, `slack-sdk`, `fastapi`

`--no-deps` would install NVRx main and leave it un-importable, so the layer installs with dependencies and guards the two known hazards:

- **torch** — reuses the `override-dependencies` trick from `pyproject.toml:194-198` (`torch; sys_platform == 'never'`, plus `torchvision`/`triton`) so NVRx's `torch>=2.3.0` cannot pull a PyPI CPU wheel over the base image's CUDA build.
- **pydantic** — constrained to `<2.14`. Per the note at `pyproject.toml:209-212`, pydantic 2.14 breaks `langchain_core`'s module-level `RunnablePassthrough()` instantiation. That was previously a transitive concern; NVRx main depends on `langchain-core` directly, making it an import-time failure.

The layer ends with `uv pip freeze | grep -i resiliency` and an import smoke test. Since `main` floats, **the container build log is the only record of which NVRx commit was actually tested.**

## Test plan

Labelled `Run functional tests` (`scope=mr-github`, `n_repeat=5`, golden-value comparison) rather than `Run tests`. NVRx owns the async-checkpoint and in-process-restart paths, and this jumps a dozen dependency versions — the lightweight 4-step lane would not surface a numerics or checkpointing regression.

Existing `gpt3_mcore_te_tp2_pp1_gdn_no_nvrx_{sync,async,async_mcore}` cases uninstall NVRx in their `BEFORE_SCRIPT` and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
