### PR TITLE
chore(skills): refresh mcore catalog signatures

### DIFF
--- a/skills/mcore-create-issue/SKILL.md
+++ b/skills/mcore-create-issue/SKILL.md
@@ -7,6 +7,7 @@ user_invocable: true
 argument: "GitHub Actions run or job URL"
 metadata:
   author: Oliver Koenig <okoenig@nvidia.com>
+  version: "1.0.1"
 ---
 
 # Triage CI Failure into a GitHub Issue

--- a/skills/mcore-linting-and-formatting/SKILL.md
+++ b/skills/mcore-linting-and-formatting/SKILL.md
@@ -5,6 +5,7 @@ license: Apache-2.0
 when_to_use: Running linting or autoformat; fixing style violations before a PR; 'pre-commit fails', 'ruff error', 'isort', 'mypy', 'style violation', 'how do I format', 'autoformat.sh'.
 metadata:
   author: Oliver Koenig <okoenig@nvidia.com>
+  version: "1.0.1"
 ---
 
 # Linting and Formatting

--- a/skills/mcore-run-on-slurm/SKILL.md
+++ b/skills/mcore-run-on-slurm/SKILL.md
@@ -5,6 +5,7 @@ license: Apache-2.0
 when_to_use: Submitting a SLURM job; writing or debugging an sbatch script; configuring multi-node distributed training; setting MASTER_ADDR / MASTER_PORT / WORLD_SIZE; diagnosing a SLURM job failure; 'how do I run on the cluster', 'sbatch', 'multi-node training'.
 metadata:
   author: Oliver Koenig <okoenig@nvidia.com>
+  version: "1.0.1"
 ---
 
 # Run Megatron-LM on SLURM

--- a/skills/mcore-split-pr/SKILL.md
+++ b/skills/mcore-split-pr/SKILL.md
@@ -7,6 +7,7 @@ user_invocable: true
 argument: "PR URL or number"
 metadata:
   author: Philip Petrakian <ppetrakian@nvidia.com>
+  version: "1.0.1"
 ---
 
 # Split PR by CODEOWNERS Groups

--- a/skills/mcore-testing/SKILL.md
+++ b/skills/mcore-testing/SKILL.md
@@ -5,6 +5,7 @@ license: Apache-2.0
 when_to_use: Adding or running a unit or functional test; understanding the test layout; writing a recipe YAML; downloading or updating golden values; reproducing a test failure locally; 'how do I add a test', 'run unit tests', 'pytest fails', 'test layout', 'golden values', 'recipe YAML', 'marker filter'.
 metadata:
   author: Oliver Koenig <okoenig@nvidia.com>
+  version: "1.0.1"
 ---
 
 # Testing Guide


### PR DESCRIPTION
## Summary

- bump the metadata version for five Megatron-Core catalog skills
- trigger fresh NVSkills signatures for their current source contents
- keep the change limited to the five `SKILL.md` files

## Background

The source content changed without matching `skill.oms.sig` refreshes, so catalog
syncs continue restoring the last signed copies. The signing pipeline only
processes skills changed by the triggering PR.

This clean replacement supersedes the signature-refresh portion of #5847 and
intentionally excludes its unrelated eval changes.

## Validation

- `CHECK_ONLY=true SKIP_DOCS=false BASE_REF=main bash tools/autoformat.sh`
- YAML frontmatter parse for all five skills
- `git diff --check`

The `/nvskills-ci` signature commit will add the refreshed signature files.
