### PR TITLE
Fix tied parameters

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -85,7 +85,7 @@ class FsdpModule:
     _name: str | None
     _parameter_groups: tuple[FsdpParameterGroup, ...]
     _context: FsdpContext | None
-    _ready_grad_parameters: set[nn.Parameter]
+    _num_ready_grad_parameters: int
     _num_trainable_parameters: int
     # Event recorded after this FsdpModule's full parameters are materialized.
     # ``None`` lets pre_forward enqueue an all-gather unless an earlier FsdpModule
@@ -119,7 +119,7 @@ class FsdpModule:
             for group_parameters in _group_parameters(owned_parameters)
         ]
         self._parameter_groups = tuple(parameter_groups)
-        self._ready_grad_parameters = set()
+        self._num_ready_grad_parameters = 0
         self._num_trainable_parameters = sum(
             len(group.sharded_parameters) for group in self._parameter_groups if group.requires_grad
         )
@@ -211,12 +211,12 @@ class FsdpModule:
             if not group.requires_grad:
                 continue
             for parameter in group.unsharded_parameters:
-                parameter.register_post_accumulate_grad_hook(self._make_grad_hook(parameter))
+                parameter.register_post_accumulate_grad_hook(self._make_grad_hook())
 
-    def _make_grad_hook(self, parameter: nn.Parameter) -> Callable[[nn.Parameter], None]:
+    def _make_grad_hook(self) -> Callable[[nn.Parameter], None]:
         def grad_hook(_parameter: nn.Parameter) -> None:
-            self._ready_grad_parameters.add(parameter)
-            if len(self._ready_grad_parameters) == self._num_trainable_parameters:
+            self._num_ready_grad_parameters += 1
+            if self._num_ready_grad_parameters == self._num_trainable_parameters:
                 self.post_backward()
 
         return grad_hook
@@ -229,7 +229,7 @@ class FsdpModule:
         """
         self._lazy_init_context()
         torch.cuda.nvtx.range_push(self._nvtx_label("forward"))
-        self._ready_grad_parameters.clear()
+        self._num_ready_grad_parameters = 0
         context = self.context
         allgather_stream = context.allgather_stream
         current_stream = context.current_stream()
@@ -315,7 +315,6 @@ class FsdpModule:
         """Reduce gradients and return parameters to their sharded resting state."""
         self._reduce_gradient_groups()
         self._reshard_parameter_groups()
-        self._ready_grad_parameters.clear()
         torch.cuda.nvtx.range_pop()
 
     def _reduce_gradient_groups(self) -> None:
@@ -361,7 +360,7 @@ def _collect_owned_parameters(root_module: nn.Module) -> dict[str, nn.Parameter]
     parameters: dict[str, nn.Parameter] = {}
 
     def visit(submodule: nn.Module, submodule_fqn: str) -> None:
-        direct_parameters = list(submodule.named_parameters(recurse=False))
+        direct_parameters = submodule.named_parameters(recurse=False, remove_duplicate=False)
 
         for local_parameter_name, parameter in direct_parameters:
             parameter_fqn = (

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -121,7 +121,7 @@ class FsdpModule:
         self._parameter_groups = tuple(parameter_groups)
         self._num_ready_grad_parameters = 0
         self._num_trainable_parameters = sum(
-            len(group.sharded_parameters) for group in self._parameter_groups if group.requires_grad
+            len(group.fsdp_parameters) for group in self._parameter_groups if group.requires_grad
         )
         self._register_hooks()
 
@@ -210,8 +210,8 @@ class FsdpModule:
         for group in self._parameter_groups:
             if not group.requires_grad:
                 continue
-            for parameter in group.unsharded_parameters:
-                parameter.register_post_accumulate_grad_hook(self._make_grad_hook())
+            for fsdp_parameter in group.fsdp_parameters:
+                fsdp_parameter.unsharded.register_post_accumulate_grad_hook(self._make_grad_hook())
 
     def _make_grad_hook(self) -> Callable[[nn.Parameter], None]:
         def grad_hook(_parameter: nn.Parameter) -> None:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -38,7 +38,8 @@ class FsdpParameterGroup:
     """A dtype and requires-grad homogeneous group of FSDP-owned parameters."""
 
     owning_module: nn.Module
-    parameter_names: tuple[str, ...]
+    # Each tuple contains every FQN for one physical parameter, relative to owning_module.
+    parameter_fqns: tuple[tuple[str, ...], ...]
     sharded_parameters: tuple[nn.Parameter, ...]
     unsharded_parameters: tuple[nn.Parameter, ...]
     mesh: DeviceMesh
@@ -73,34 +74,38 @@ class FsdpParameterGroup:
         if not parameters:
             raise ValueError("FsdpParameterGroup requires at least one parameter.")
 
+        parameter_to_fqns: dict[nn.Parameter, list[str]] = {}
+        for fqn, parameter in parameters.items():
+            parameter_to_fqns.setdefault(parameter, []).append(fqn)
+
         model_weight_placements = tuple(placements.parameter)
         main_grad_placements = tuple(placements.gradient)
         main_weight_placements = tuple(placements.optimizer)
 
-        # Python dicts preserve insertion order, so parameter_names and
-        # parameters.values() define the same stable DBuffer tensor order.
+        # Python dicts preserve insertion order, so parameter_to_fqns.keys() and
+        # parameter_to_fqns.values() define the same stable DBuffer tensor order.
         self.owning_module = owning_module
         self.mesh = mesh
-        self.parameter_names = tuple(parameters)
-        first_parameter = next(iter(parameters.values()))
+        self.parameter_fqns = tuple(tuple(fqns) for fqns in parameter_to_fqns.values())
+        first_parameter = next(iter(parameter_to_fqns))
         self.dtype = first_parameter.dtype
         self.requires_grad = first_parameter.requires_grad
-        for name, parameter in parameters.items():
+        for parameter, fqns in parameter_to_fqns.items():
             if parameter.dtype != self.dtype:
                 raise ValueError(
-                    f"Expected parameter {name!r} to have dtype {self.dtype}, "
+                    f"Expected parameter {fqns!r} to have dtype {self.dtype}, "
                     f"got {parameter.dtype}."
                 )
             if parameter.requires_grad != self.requires_grad:
                 raise ValueError(
-                    f"Expected parameter {name!r} to have requires_grad={self.requires_grad}, "
+                    f"Expected parameter {fqns!r} to have requires_grad={self.requires_grad}, "
                     f"got {parameter.requires_grad}."
                 )
 
-        tensor_shapes = tuple(parameter.shape for parameter in parameters.values())
+        tensor_shapes = tuple(parameter.shape for parameter in parameter_to_fqns)
         main_weight_dtype = mixed_precision_policy.main_params_dtype or torch.float32
         self.main_weight = DBuffer.distribute_tensors(
-            (parameter.to(dtype=main_weight_dtype) for parameter in parameters.values()),
+            (parameter.to(dtype=main_weight_dtype) for parameter in parameter_to_fqns),
             mesh=self.mesh,
             placements=main_weight_placements,
         )
@@ -156,7 +161,7 @@ class FsdpParameterGroup:
         sharded_parameters: list[nn.Parameter] = []
         unsharded_parameters: list[nn.Parameter] = []
         main_grad_dtype = self.main_grad.dtype if self.main_grad is not None else None
-        for index, parameter in enumerate(parameters.values()):
+        for index, parameter in enumerate(parameter_to_fqns):
             parameter.data = self._unsharded_model_weight.get_local_tensor(index)
             parameter.grad = None
             setattr(parameter, _CONTAINING_PARAMETER_GROUP_ATTR, self)
@@ -184,9 +189,10 @@ class FsdpParameterGroup:
         return torch.cuda.use_mem_pool(self._symm_mem_pool)
 
     def _set_module_parameters(self, parameters: tuple[nn.Parameter, ...]) -> None:
-        for name, parameter in zip(self.parameter_names, parameters, strict=True):
-            module, parameter_name = _get_parameter_owner(self.owning_module, name)
-            module._parameters[parameter_name] = parameter
+        for fqns, parameter in zip(self.parameter_fqns, parameters, strict=True):
+            for fqn in fqns:
+                module, parameter_name = _get_parameter_owner(self.owning_module, fqn)
+                module._parameters[parameter_name] = parameter
 
     def _switch_to_sharded_parameters(self) -> None:
         self._set_module_parameters(self.sharded_parameters)
@@ -258,9 +264,9 @@ class FsdpParameterGroup:
         # Preserve AVG semantics by reducing SUM and scaling the output below.
         partial_op = dist.ReduceOp.AVG if self._symm_mem_pool is None else dist.ReduceOp.SUM
         grads: list[torch.Tensor] = []
-        for name, parameter in zip(self.parameter_names, self.unsharded_parameters, strict=True):
+        for fqns, parameter in zip(self.parameter_fqns, self.unsharded_parameters, strict=True):
             if parameter.grad is None:
-                raise RuntimeError(f"Missing gradient for FSDP parameter {name!r}.")
+                raise RuntimeError(f"Missing gradient for FSDP parameter {fqns!r}.")
             grads.append(parameter.grad)
         with self._symmetric_memory_context():
             return DBuffer(

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -15,6 +15,7 @@
 """Parameter-group runtime state for the minimal Megatron-FSDP path."""
 
 from contextlib import nullcontext
+from dataclasses import dataclass
 
 import torch
 import torch.distributed as dist
@@ -34,14 +35,22 @@ def get_containing_parameter_group(parameter: nn.Parameter) -> "FsdpParameterGro
     return getattr(parameter, _CONTAINING_PARAMETER_GROUP_ATTR, None)
 
 
+@dataclass(frozen=True, eq=False)
+class FsdpParameter:
+    """One physical parameter and its FSDP runtime representations."""
+
+    # Tied weights register one physical parameter under multiple FQNs, all relative
+    # to the containing group's owning_module.
+    fqns: tuple[str, ...]
+    sharded: nn.Parameter
+    unsharded: nn.Parameter
+
+
 class FsdpParameterGroup:
     """A dtype and requires-grad homogeneous group of FSDP-owned parameters."""
 
     owning_module: nn.Module
-    # Each tuple contains every FQN for one physical parameter, relative to owning_module.
-    parameter_fqns: tuple[tuple[str, ...], ...]
-    sharded_parameters: tuple[nn.Parameter, ...]
-    unsharded_parameters: tuple[nn.Parameter, ...]
+    fsdp_parameters: tuple[FsdpParameter, ...]
     mesh: DeviceMesh
     dtype: torch.dtype
     requires_grad: bool
@@ -82,11 +91,10 @@ class FsdpParameterGroup:
         main_grad_placements = tuple(placements.gradient)
         main_weight_placements = tuple(placements.optimizer)
 
-        # Python dicts preserve insertion order, so parameter_to_fqns.keys() and
-        # parameter_to_fqns.values() define the same stable DBuffer tensor order.
+        # Python dicts preserve insertion order, so parameter_to_fqns and
+        # fsdp_parameters define the same stable DBuffer tensor order.
         self.owning_module = owning_module
         self.mesh = mesh
-        self.parameter_fqns = tuple(tuple(fqns) for fqns in parameter_to_fqns.values())
         first_parameter = next(iter(parameter_to_fqns))
         self.dtype = first_parameter.dtype
         self.requires_grad = first_parameter.requires_grad
@@ -158,14 +166,12 @@ class FsdpParameterGroup:
             # main_grad rests here (DP-outer-Partial for HSDP) between microbatches and
             # is finalized to main_weight's placements after the last microbatch.
             self._accumulation_placements = main_grad_placements
-        sharded_parameters: list[nn.Parameter] = []
-        unsharded_parameters: list[nn.Parameter] = []
+        fsdp_parameters: list[FsdpParameter] = []
         main_grad_dtype = self.main_grad.dtype if self.main_grad is not None else None
-        for index, parameter in enumerate(parameter_to_fqns):
+        for index, (parameter, fqns) in enumerate(parameter_to_fqns.items()):
             parameter.data = self._unsharded_model_weight.get_local_tensor(index)
             parameter.grad = None
             setattr(parameter, _CONTAINING_PARAMETER_GROUP_ATTR, self)
-            unsharded_parameters.append(parameter)
 
             sharded_parameter = nn.Parameter(
                 self.main_weight.get_dtensor(index), requires_grad=parameter.requires_grad
@@ -173,9 +179,10 @@ class FsdpParameterGroup:
             if main_grad_dtype:
                 sharded_parameter.grad_dtype = main_grad_dtype
             setattr(sharded_parameter, _CONTAINING_PARAMETER_GROUP_ATTR, self)
-            sharded_parameters.append(sharded_parameter)
-        self.sharded_parameters = tuple(sharded_parameters)
-        self.unsharded_parameters = tuple(unsharded_parameters)
+            fsdp_parameters.append(
+                FsdpParameter(fqns=tuple(fqns), sharded=sharded_parameter, unsharded=parameter)
+            )
+        self.fsdp_parameters = tuple(fsdp_parameters)
 
         # Compute weights must be initialized before the first forward; subsequent
         # refreshes happen from the FSDP optimizer's post-step hook.
@@ -188,17 +195,18 @@ class FsdpParameterGroup:
             return nullcontext()
         return torch.cuda.use_mem_pool(self._symm_mem_pool)
 
-    def _set_module_parameters(self, parameters: tuple[nn.Parameter, ...]) -> None:
-        for fqns, parameter in zip(self.parameter_fqns, parameters, strict=True):
-            for fqn in fqns:
-                module, parameter_name = _get_parameter_owner(self.owning_module, fqn)
-                module._parameters[parameter_name] = parameter
+    def _set_module_parameter(self, fqns: tuple[str, ...], parameter: nn.Parameter) -> None:
+        for fqn in fqns:
+            module, parameter_name = _get_parameter_owner(self.owning_module, fqn)
+            module._parameters[parameter_name] = parameter
 
     def _switch_to_sharded_parameters(self) -> None:
-        self._set_module_parameters(self.sharded_parameters)
+        for fsdp_parameter in self.fsdp_parameters:
+            self._set_module_parameter(fsdp_parameter.fqns, fsdp_parameter.sharded)
 
     def _switch_to_unsharded_parameters(self) -> None:
-        self._set_module_parameters(self.unsharded_parameters)
+        for fsdp_parameter in self.fsdp_parameters:
+            self._set_module_parameter(fsdp_parameter.fqns, fsdp_parameter.unsharded)
 
     def sync_model_weight_from_main_weight(self) -> None:
         """Refresh compute weights from optimizer weights."""
@@ -264,10 +272,10 @@ class FsdpParameterGroup:
         # Preserve AVG semantics by reducing SUM and scaling the output below.
         partial_op = dist.ReduceOp.AVG if self._symm_mem_pool is None else dist.ReduceOp.SUM
         grads: list[torch.Tensor] = []
-        for fqns, parameter in zip(self.parameter_fqns, self.unsharded_parameters, strict=True):
-            if parameter.grad is None:
-                raise RuntimeError(f"Missing gradient for FSDP parameter {fqns!r}.")
-            grads.append(parameter.grad)
+        for fsdp_parameter in self.fsdp_parameters:
+            if fsdp_parameter.unsharded.grad is None:
+                raise RuntimeError(f"Missing gradient for FSDP parameter {fsdp_parameter.fqns!r}.")
+            grads.append(fsdp_parameter.unsharded.grad)
         with self._symmetric_memory_context():
             return DBuffer(
                 mesh=self.mesh,
@@ -280,9 +288,21 @@ class FsdpParameterGroup:
     def copy_gradients_to_partial_buffer(self, partial_grad: DBuffer) -> None:
         """Pack full local gradients into an existing reduce-scatter input buffer."""
         # A future fused-wgrad path can write directly into these buffer views.
-        for index, parameter in enumerate(self.unsharded_parameters):
-            partial_grad.get_local_tensor(index).copy_(parameter.grad)
-            parameter.grad = None
+        for index, fsdp_parameter in enumerate(self.fsdp_parameters):
+            partial_grad.get_local_tensor(index).copy_(fsdp_parameter.unsharded.grad)
+            fsdp_parameter.unsharded.grad = None
+
+    def _has_sharded_grads(self) -> bool:
+        has_any_grad = False
+        has_any_missing_grad = False
+        for fsdp_parameter in self.fsdp_parameters:
+            if fsdp_parameter.sharded.grad is None:
+                has_any_missing_grad = True
+            else:
+                has_any_grad = True
+        if has_any_grad and has_any_missing_grad:
+            raise RuntimeError("FSDP sharded gradients must be either all set or all None.")
+        return has_any_grad
 
     def reduce_partial_gradients(
         self, partial_grad: DBuffer, is_last_microbatch: bool = True
@@ -298,22 +318,10 @@ class FsdpParameterGroup:
         """
         assert self.main_grad is not None
 
-        def has_grad(parameters: tuple[nn.Parameter, ...]) -> bool:
-            has_any_grad = False
-            has_any_missing_grad = False
-            for parameter in parameters:
-                if parameter.grad is None:
-                    has_any_missing_grad = True
-                else:
-                    has_any_grad = True
-            if has_any_grad and has_any_missing_grad:
-                raise RuntimeError("FSDP sharded gradients must be either all set or all None.")
-            return has_any_grad
-
         # zero_grad(set_to_none=True) clears sharded parameter grads, so this
         # backward can reduce directly into main_grad. zero_grad(set_to_none=False)
         # leaves sharded grads installed, so this backward accumulates into main_grad.
-        has_sharded_grads = has_grad(self.sharded_parameters)
+        has_sharded_grads = self._has_sharded_grads()
 
         # A non-accumulation main_grad means the previous step finalized it; this
         # only happens on the first microbatch. Redistribute it back to the
@@ -351,8 +359,8 @@ class FsdpParameterGroup:
             self.main_grad = self.main_grad.redistribute(self.main_weight.placements)
 
         # Make each sharded parameter's .grad consistent with the final main_grad.
-        for index, sharded_parameter in enumerate(self.sharded_parameters):
-            sharded_parameter.grad = self.main_grad.get_dtensor(index)
+        for index, fsdp_parameter in enumerate(self.fsdp_parameters):
+            fsdp_parameter.sharded.grad = self.main_grad.get_dtensor(index)
 
 
 def _get_parameter_owner(module: nn.Module, name: str) -> tuple[nn.Module, str]:

--- a/tests/unit_tests/distributed/mfsdp_v2/test_annotation.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_annotation.py
@@ -49,6 +49,19 @@ class FrozenFirstLayerModel(nn.Module):
         return torch.relu(self.layers[1](x + self.bias))
 
 
+class TiedLM(nn.Module):
+    """Tiny language model with shared input and output embedding weights."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.embed_tokens = nn.Embedding(8, 4, dtype=torch.bfloat16)
+        self.lm_head = nn.Linear(4, 8, bias=False, dtype=torch.bfloat16)
+        self.lm_head.weight = self.embed_tokens.weight
+
+    def forward(self, token_ids: torch.Tensor) -> torch.Tensor:
+        return self.lm_head(self.embed_tokens(token_ids)).float().sum()
+
+
 def _flat_placements() -> Placements:
     return Placements(dp_axes=[0], parameter=[Flat()], gradient=[Flat()], optimizer=[Flat()])
 
@@ -174,5 +187,30 @@ def test_fsdp_frozen_child_without_grad_inputs_skips_backward_nvtx_range(
         ("push", "<root>", "backward"),
         ("push", "layers.1", "backward"),
         ("pop", "layers.1", "backward"),
+        ("pop", "<root>", "backward"),
+    ]
+
+
+def test_tied_child_parameters_complete_backward_once_per_cycle(distributed_setup, monkeypatch):
+    """Tied parameters should complete balanced backward ranges across training cycles."""
+    events: list[NvtxEvent] = []
+    _setup_nvtx_recording(monkeypatch, events)
+    model = TiedLM()
+    mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))
+    fully_shard(model, mesh=mesh, placements=_flat_placements())
+
+    token_ids = torch.arange(8, device=distributed_setup.device).reshape(2, 4)
+    for _ in range(2):
+        model.zero_grad(set_to_none=True)
+        model(token_ids).backward()
+
+    assert [(event.kind, event.name, event.phase) for event in events] == [
+        ("push", "<root>", "forward"),
+        ("pop", "<root>", "forward"),
+        ("push", "<root>", "backward"),
+        ("pop", "<root>", "backward"),
+        ("push", "<root>", "forward"),
+        ("pop", "<root>", "forward"),
+        ("push", "<root>", "backward"),
         ("pop", "<root>", "backward"),
     ]

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -356,11 +356,11 @@ def test_nested_fully_shard_excludes_child_owned_parameters(distributed_setup):
     fully_shard(model.inner, mesh=mesh, placements=_flat_placements())
     fully_shard(model, mesh=mesh, placements=_flat_placements())
 
-    inner_fqns = [group.parameter_fqns for group in model.inner.parameter_groups]
-    outer_fqns = [group.parameter_fqns for group in model.parameter_groups]
+    (inner_group,) = model.inner.parameter_groups
+    (outer_group,) = model.parameter_groups
 
-    assert inner_fqns == [(("weight",),)]
-    assert outer_fqns == [(("bias",),)]
+    assert [parameter.fqns for parameter in inner_group.fsdp_parameters] == [("weight",)]
+    assert [parameter.fqns for parameter in outer_group.fsdp_parameters] == [("bias",)]
 
 
 def test_tied_child_parameters_allocate_one_physical_weight(distributed_setup):
@@ -370,9 +370,10 @@ def test_tied_child_parameters_allocate_one_physical_weight(distributed_setup):
     fully_shard(model, mesh=mesh, placements=_flat_placements())
 
     (parameter_group,) = model.parameter_groups
-    assert parameter_group.parameter_fqns == (("embed_tokens.weight", "lm_head.weight"),)
-    assert parameter_group.main_weight.layout.tensor_shapes == (torch.Size((8, 4)),)
+    (parameter,) = parameter_group.fsdp_parameters
+    assert parameter.fqns == ("embed_tokens.weight", "lm_head.weight")
     assert parameter_group.main_weight.layout.size == 8 * 4
+    # Both aliases must expose the same optimizer-visible sharded parameter.
     assert len(list(model.parameters())) == 1
 
 

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -73,6 +73,20 @@ class MultiChildModel(nn.Module):
         return x
 
 
+class TiedLM(nn.Module):
+    """Tiny language model with shared input and output embedding weights."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.embed_tokens = nn.Embedding(8, 4, dtype=torch.bfloat16)
+        self.lm_head = nn.Linear(4, 8, bias=False, dtype=torch.bfloat16)
+        self.lm_head.weight = self.embed_tokens.weight
+
+    def forward(self, token_ids: torch.Tensor) -> torch.Tensor:
+        """Compute a scalar loss using both aliases of the shared weight."""
+        return self.lm_head(self.embed_tokens(token_ids)).float().sum()
+
+
 class SaveNonLeafWeightView(torch.autograd.Function):
     """Autograd function that saves a non-leaf parameter view for backward."""
 
@@ -342,11 +356,24 @@ def test_nested_fully_shard_excludes_child_owned_parameters(distributed_setup):
     fully_shard(model.inner, mesh=mesh, placements=_flat_placements())
     fully_shard(model, mesh=mesh, placements=_flat_placements())
 
-    inner_names = [name for group in model.inner.parameter_groups for name in group.parameter_names]
-    outer_names = [name for group in model.parameter_groups for name in group.parameter_names]
+    inner_fqns = [group.parameter_fqns for group in model.inner.parameter_groups]
+    outer_fqns = [group.parameter_fqns for group in model.parameter_groups]
 
-    assert inner_names == ["weight"]
-    assert outer_names == ["bias"]
+    assert inner_fqns == [(("weight",),)]
+    assert outer_fqns == [(("bias",),)]
+
+
+def test_tied_child_parameters_allocate_one_physical_weight(distributed_setup):
+    """Tied registrations should allocate one DBuffer entry and optimizer parameter."""
+    model = TiedLM()
+    mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))
+    fully_shard(model, mesh=mesh, placements=_flat_placements())
+
+    (parameter_group,) = model.parameter_groups
+    assert parameter_group.parameter_fqns == (("embed_tokens.weight", "lm_head.weight"),)
+    assert parameter_group.main_weight.layout.tensor_shapes == (torch.Size((8, 4)),)
+    assert parameter_group.main_weight.layout.size == 8 * 4
+    assert len(list(model.parameters())) == 1
 
 
 def test_forward_peak_memory_bounds_in_flight_child_all_gathers(distributed_setup):

--- a/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
@@ -86,10 +86,16 @@ class TestMcoreAdapter:
         # Post-order wrapping gives the selected TransformerLayer its own parameter group;
         # the root FSDP unit should own only the parameters of the remaining Linear module.
         child_parameter_names = {
-            name for group in wrapped.module[0].parameter_groups for name in group.parameter_names
+            name
+            for group in wrapped.module[0].parameter_groups
+            for parameter in group.fsdp_parameters
+            for name in parameter.fqns
         }
         root_parameter_names = {
-            name for group in wrapped.module.parameter_groups for name in group.parameter_names
+            name
+            for group in wrapped.module.parameter_groups
+            for parameter in group.fsdp_parameters
+            for name in parameter.fqns
         }
         assert child_parameter_names
         assert root_parameter_names == {"1.weight", "1.bias"}


### PR DESCRIPTION
## What changed

- collect MFSDP v2 parameter registrations without deduplicating names, while representing each physical `Parameter` once
- retain every owning-module-relative FQN and use the complete tuple when swapping sharded and unsharded parameter replacements
- register one gradient hook per physical trainable parameter and track backward readiness with a resettable counter
- add a tied-embedding regression test covering two forward/backward cycles, balanced annotations, DBuffer size, and optimizer-visible parameter count

## Why

PyTorch's default parameter enumeration deduplicates tied parameters by object identity. MFSDP v2 instead collected registrations by FQN, so the same physical parameter could receive multiple buffer entries and replacement objects. That broke weight identity and prevented the ready-parameter set from reaching the duplicated trainable-parameter count during backward.

## Impact

MFSDP v2 now preserves tied parameter aliases while allocating, sharding, reducing, and exposing only one physical optimizer parameter.

## Validation

- `ruff check` on all changed Python files
- Black check on all changed Python files
- Python bytecode compilation on all changed Python files
- `python -m torch.distributed.run --nproc-per-node 2 -m pytest -q tests/unit_tests/distributed/mfsdp_v2`
  - 53 passed
  - 11 skipped because they require 4-5 ranks

## Related issue

Related to #6139.
