### PR TITLE
fix(dsa): skip invalid slots in sparse indexer backward

### DIFF
--- a/megatron/core/transformer/experimental_attention_variant/dsa_cudnn_kernels.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa_cudnn_kernels.py
@@ -1525,8 +1525,6 @@ def _pad_sparse_backward_topk(
     attn_score: Tensor, index_score: Tensor, topk_indices: Tensor, block_size: int
 ) -> Tuple[Tensor, Tensor, Tensor]:
     """Pad sparse indexer-backward top-k tensors to cuDNN's block-size multiple."""
-    # The backward wrapper has no separate top-k length; zero-score slots still need valid indices.
-    topk_indices = topk_indices.clamp_min(0)
     topk = topk_indices.size(-1)
     padded_topk = round_up_to_nearest_multiple(topk, block_size)
     if padded_topk == topk:
@@ -1535,7 +1533,9 @@ def _pad_sparse_backward_topk(
     pad_width = padded_topk - topk
     attn_score = torch.nn.functional.pad(attn_score, (0, pad_width), value=0.0)
     index_score = torch.nn.functional.pad(index_score, (0, pad_width), value=0.0)
-    topk_indices = torch.nn.functional.pad(topk_indices, (0, pad_width), value=0)
+    # Negative indices are rejected by the kernel's bounds guard before K loads
+    # and dK atomics, so preserve the invalid-slot sentinel through padding.
+    topk_indices = torch.nn.functional.pad(topk_indices, (0, pad_width), value=-1)
     return attn_score.contiguous(), index_score.contiguous(), topk_indices.contiguous()
 
 
@@ -1859,13 +1859,16 @@ def _compute_sparse_indexer_loss_and_grads(
             .mul(skv)
         )
         topk_indices_for_bwd = topk_indices_for_bwd + batch_offsets
-    topk_indices_for_bwd = topk_indices_for_bwd.masked_fill(~valid_positions, 0)
+    topk_indices_for_bwd = topk_indices_for_bwd.masked_fill(~valid_positions, -1)
     attn_score_for_bwd = target
     # The cuDNN sparse indexer-backward score-grad kernel gates the KL gradient
     # on positive predicted probabilities. Preserve the mathematically correct
     # ``predict - target`` gradient for underflowed softmax entries by keeping
-    # selected probabilities nonzero before handing them to cuDNN.
-    index_score_for_bwd = predict.clamp_min(_CLIP_PROB_MIN)
+    # selected probabilities nonzero before handing them to cuDNN. Invalid slots
+    # stay zero and use negative indices so the main kernel skips their K/dK work.
+    index_score_for_bwd = torch.where(
+        valid_positions, predict.clamp_min(_CLIP_PROB_MIN), torch.zeros_like(predict)
+    )
     block_i = 128
     attn_score_for_bwd, index_score_for_bwd, topk_indices_for_bwd = _pad_sparse_backward_topk(
         attn_score_for_bwd, index_score_for_bwd, topk_indices_for_bwd, block_i

--- a/megatron/core/transformer/experimental_attention_variant/dsa_cudnn_kernels.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa_cudnn_kernels.py
@@ -1866,9 +1866,8 @@ def _compute_sparse_indexer_loss_and_grads(
     # ``predict - target`` gradient for underflowed softmax entries by keeping
     # selected probabilities nonzero before handing them to cuDNN. Invalid slots
     # stay zero and use negative indices so the main kernel skips their K/dK work.
-    index_score_for_bwd = torch.where(
-        valid_positions, predict.clamp_min(_CLIP_PROB_MIN), torch.zeros_like(predict)
-    )
+    index_score_for_bwd = predict.clamp_min(_CLIP_PROB_MIN)
+    index_score_for_bwd.masked_fill_(~valid_positions, 0.0)
     block_i = 128
     attn_score_for_bwd, index_score_for_bwd, topk_indices_for_bwd = _pad_sparse_backward_topk(
         attn_score_for_bwd, index_score_for_bwd, topk_indices_for_bwd, block_i

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_native_parity.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_native_parity.py
@@ -1884,8 +1884,7 @@ def test_cudnn_sparse_backward_uses_batch_major_topk_indices_for_batched_kv(monk
     )
 
     torch.testing.assert_close(
-        seen["topk_indices"][:, 0, :3],
-        torch.tensor([[3, 1, -1], [4, 6, -1]], dtype=torch.int32),
+        seen["topk_indices"][:, 0, :3], torch.tensor([[3, 1, -1], [4, 6, -1]], dtype=torch.int32)
     )
     torch.testing.assert_close(
         seen["topk_indices"][:, 0, 3:], torch.full((2, 125), -1, dtype=torch.int32)
@@ -2313,9 +2312,7 @@ def test_cudnn_sparse_backward_topk_padding_aligns_to_block_size():
     torch.testing.assert_close(padded_topk[..., :3], topk_indices)
     torch.testing.assert_close(padded_attn[..., 3], torch.zeros(1, 2))
     torch.testing.assert_close(padded_index[..., 3], torch.zeros(1, 2))
-    torch.testing.assert_close(
-        padded_topk[..., 3], torch.full((1, 2), -1, dtype=torch.int32)
-    )
+    torch.testing.assert_close(padded_topk[..., 3], torch.full((1, 2), -1, dtype=torch.int32))
 
 
 def test_cudnn_attn_target_pads_small_local_head_count(monkeypatch):

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_native_parity.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_native_parity.py
@@ -1737,14 +1737,17 @@ def test_cudnn_sparse_loss_masks_invalid_query_rows_for_backward(monkeypatch):
     )
 
     torch.testing.assert_close(
-        seen["topk_indices"][0, 0, :4], torch.tensor([3, 1, 2, 0], dtype=torch.int32)
+        seen["topk_indices"][0, 0, :4], torch.tensor([3, 1, 2, -1], dtype=torch.int32)
     )
-    torch.testing.assert_close(seen["topk_indices"][0, 1, :4], torch.zeros(4, dtype=torch.int32))
     torch.testing.assert_close(
-        seen["topk_indices"][0, :, 4:], torch.zeros((2, 124), dtype=torch.int32)
+        seen["topk_indices"][0, 1, :4], torch.full((4,), -1, dtype=torch.int32)
+    )
+    torch.testing.assert_close(
+        seen["topk_indices"][0, :, 4:], torch.full((2, 124), -1, dtype=torch.int32)
     )
     torch.testing.assert_close(seen["attn_score"][0, 1], torch.zeros(128))
     torch.testing.assert_close(seen["index_score"][0, 1], torch.zeros(128))
+    assert torch.count_nonzero(seen["index_score"][0, 1]) == 0
     assert seen["loss_coeff"] == 0.01
     torch.testing.assert_close(seen["grad_loss"], torch.tensor(2.0))
 
@@ -1881,10 +1884,11 @@ def test_cudnn_sparse_backward_uses_batch_major_topk_indices_for_batched_kv(monk
     )
 
     torch.testing.assert_close(
-        seen["topk_indices"][:, 0, :3], torch.tensor([[3, 1, 0], [4, 6, 0]], dtype=torch.int32)
+        seen["topk_indices"][:, 0, :3],
+        torch.tensor([[3, 1, -1], [4, 6, -1]], dtype=torch.int32),
     )
     torch.testing.assert_close(
-        seen["topk_indices"][:, 0, 3:], torch.zeros((2, 125), dtype=torch.int32)
+        seen["topk_indices"][:, 0, 3:], torch.full((2, 125), -1, dtype=torch.int32)
     )
     assert seen["loss_coeff"] == 0.01
     torch.testing.assert_close(seen["grad_loss"], torch.tensor(1.0))
@@ -2306,12 +2310,12 @@ def test_cudnn_sparse_backward_topk_padding_aligns_to_block_size():
     assert padded_topk.shape == (1, 2, 4)
     torch.testing.assert_close(padded_attn[..., :3], attn_score)
     torch.testing.assert_close(padded_index[..., :3], index_score)
-    torch.testing.assert_close(
-        padded_topk[..., :3], torch.tensor([[[0, 1, 2], [2, 1, 0]]], dtype=torch.int32)
-    )
+    torch.testing.assert_close(padded_topk[..., :3], topk_indices)
     torch.testing.assert_close(padded_attn[..., 3], torch.zeros(1, 2))
     torch.testing.assert_close(padded_index[..., 3], torch.zeros(1, 2))
-    torch.testing.assert_close(padded_topk[..., 3], torch.zeros((1, 2), dtype=torch.int32))
+    torch.testing.assert_close(
+        padded_topk[..., 3], torch.full((1, 2), -1, dtype=torch.int32)
+    )
 
 
 def test_cudnn_attn_target_pads_small_local_head_count(monkeypatch):


### PR DESCRIPTION
## Summary

This PR fixes severe atomic contention caused by padded slots in the cuDNN sparse indexer backward path.

It:

- Marks invalid/padded top-k indices with `-1`, allowing the kernel's bounds guard to skip their K/dK work.
- Keeps scores for invalid slots at zero, preserving the existing mathematical behavior.
- Replaces `torch.where(..., torch.zeros_like(predict))` with an out-of-place `clamp_min()` followed by an in-place `masked_fill_()`, avoiding unnecessary full-size temporary tensors.

## Problem

The caller previously assigned index `0` to invalid slots. Although their scores were zero, index `0` passed the kernel's bounds check, so the backward kernel still issued atomic dK updates to `dK[0, :]`.

When many padded slots shared index `0`, these atomics became heavily contended. 

## Fix

Invalid positions now use index `-1`. The sparse backward kernel rejects these positions through its existing bounds guard and therefore skips their K/dK updates.

Valid indices, scores, and gradients are unchanged. The new `masked_fill_()` operates on the output of `clamp_min()`, so the original `predict` tensor is not modified.

## Validation

Validated with the GLM-5.2 proxy model on 16 GB200 GPUs:

- Sequence length: 4096
- TP1 / PP1 / EP16 / CP1
- MXFP8
- 28 training iterations
- First 5 iterations excluded from performance statistics
- 0 skipped iterations
- 0 NaN iterations
- Loss and gradient norm remained aligned with the dev baseline

Rank-0 NSys results for the affected backward kernel:

- Before: approximately 12.824 ms per call
- After: approximately 1.273 ms per call
- Improvement: approximately 10x

End-to-end comparison using the same 4K recipe without NSys:

| Metric | Before |  After | Change |
|---|---:|---:|---:|
| Median iteration latency | 3109.9 ms | 2802.3 ms | -9.9% |
| Mean iteration latency | 3291.8 ms | 2994.3 ms | -9.0% |
| Median TFLOP/s/GPU | 453.1 | 502.8 | +11.0% |
| Mean TFLOP/s/GPU | 431.7 | 476.1 | +10.3% |
| Peak allocated memory | 129708.63 MB | 129708.63 MB | unchanged |
| Peak reserved memory | 132596 MB | 132636 MB | +40 MB |

The small reserved-memory difference is allocator-level run-to-run variation; peak allocated memory is unchanged.