### PR TITLE
Encapsulate symmetric-memory AVG in DBuffer

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -397,7 +397,11 @@ class DBuffer:
         _validate_placements(placements)
         out = self._create_or_validate_out(out, placements=placements)
         reduce_op = partial_placement.reduce_op
-        is_symm_mem = symm_mem.is_symm_mem_tensor(self.local_buffer)
+        # Symmetric-memory MFSDP requires this detector, but ordinary DBuffer
+        # reductions remain supported on older PyTorch versions that lack it.
+        is_symm_mem = hasattr(symm_mem, "is_symm_mem_tensor") and symm_mem.is_symm_mem_tensor(
+            self.local_buffer
+        )
         if is_symm_mem:
             self.rendezvous(axis)
             # NCCL symmetric-memory reduce-scatter selects its symmetric kernel

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -396,12 +396,23 @@ class DBuffer:
         placements[axis] = new_placement
         _validate_placements(placements)
         out = self._create_or_validate_out(out, placements=placements)
+        reduce_op = partial_placement.reduce_op
+        is_symm_mem = symm_mem.is_symm_mem_tensor(self.local_buffer)
+        if is_symm_mem:
+            self.rendezvous(axis)
+            # NCCL symmetric-memory reduce-scatter selects its symmetric kernel
+            # for SUM. Preserve the placement's AVG semantics by scaling the
+            # SUM result after the collective.
+            if reduce_op == dist.ReduceOp.AVG:
+                reduce_op = dist.ReduceOp.SUM
         dist.reduce_scatter_tensor(
             output=out.local_buffer,
             input=self.local_buffer,
-            op=partial_placement.reduce_op,
+            op=reduce_op,
             group=self.mesh.get_group(axis),
         )
+        if is_symm_mem and partial_placement.reduce_op == dist.ReduceOp.AVG:
+            out.local_buffer.div_(self.mesh.size(axis))
         return out
 
     def scatter(

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -90,6 +90,8 @@ class FsdpParameterGroup:
         """
         if not parameters:
             raise ValueError("FsdpParameterGroup requires at least one parameter.")
+        if use_symm_mem and not hasattr(symm_mem, "is_symm_mem_tensor"):
+            raise RuntimeError("Symmetric-memory MFSDP requires PyTorch 2.12 or later.")
 
         parameter_to_fqns: dict[nn.Parameter, list[str]] = {}
         for fqn, parameter in parameters.items():

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -291,9 +291,6 @@ class FsdpParameterGroup:
         """Allocate the unreduced reduce-scatter input buffer."""
         assert self.main_grad is not None
 
-        # NCCL symmetric-memory reduce-scatter only selects the symmetric kernel for SUM today.
-        # Preserve AVG semantics by reducing SUM and scaling the output below.
-        partial_op = dist.ReduceOp.AVG if self._symm_mem_pool is None else dist.ReduceOp.SUM
         grads: list[torch.Tensor] = []
         for fsdp_parameter in self.fsdp_parameters:
             if fsdp_parameter.unsharded.grad is None:
@@ -302,7 +299,7 @@ class FsdpParameterGroup:
         with self._symmetric_memory_context():
             return DBuffer(
                 mesh=self.mesh,
-                placements=[Partial(partial_op)] * self.mesh.ndim,
+                placements=[Partial(dist.ReduceOp.AVG)] * self.mesh.ndim,
                 tensor_shapes=tuple(grad.shape for grad in grads),
                 dtype=grads[0].dtype,
                 device=grads[0].device,
@@ -359,18 +356,10 @@ class FsdpParameterGroup:
         reduce_axis = changed_mesh_axis(partial_grad.placements, self.main_grad.placements)
         if reduce_axis is None:
             raise RuntimeError("FSDP gradient reduction requires a changed placement axis.")
-        partial_reduce_op = partial_grad.placements[reduce_axis].reduce_op
-        grad_divisor = self.mesh.size(reduce_axis) if partial_reduce_op == dist.ReduceOp.SUM else 1
-        if self._symm_mem_pool is not None:
-            partial_grad.rendezvous(reduce_axis)
         if can_reduce_into_main_grad:
             partial_grad.redistribute(self.main_grad.placements, out=self.main_grad)
-            if grad_divisor != 1:
-                self.main_grad.local_buffer.div_(grad_divisor)
         else:
             reduced_grad = partial_grad.redistribute(self.main_grad.placements)
-            if grad_divisor != 1:
-                reduced_grad.local_buffer.div_(grad_divisor)
             if has_sharded_grads:
                 self.main_grad.local_buffer.add_(reduced_grad.local_buffer)
             else:

--- a/tests/unit_tests/distributed/mfsdp_v2/conftest.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/conftest.py
@@ -7,6 +7,7 @@ from collections.abc import Iterator
 import pytest
 import torch
 import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
 
 
 @dataclasses.dataclass(frozen=True)
@@ -38,6 +39,9 @@ def distributed_setup() -> Iterator[DistributedSetup]:
     if torch.cuda.is_available():
         torch.cuda.set_device(local_rank)
         device = torch.device(f"cuda:{local_rank}")
+        # is_symm_mem_tensor() marks the current symmetric-memory backend as in use,
+        # even for ordinary tensors, so select NCCL before any DBuffer test calls it.
+        symm_mem.set_backend("NCCL")
     else:
         device = torch.device("cpu")
 

--- a/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
@@ -474,6 +474,26 @@ def test_partial_reduce_scatter_to_flat_average(distributed_setup):
     _assert_dbuffer_local_tensors_close(replicated_buffer, expected_tensors)
 
 
+def test_partial_reduce_scatter_to_flat_average_without_symm_mem_detector(
+    distributed_setup, monkeypatch
+):
+    """Ordinary AVG remains available when PyTorch lacks the symmetric-memory detector."""
+    device, world_size = distributed_setup.device, distributed_setup.world_size
+    mesh = init_device_mesh(device.type, (world_size,))
+    monkeypatch.delattr(symm_mem, "is_symm_mem_tensor")
+    rank_scale = float(distributed_setup.rank + 1)
+    partial_buffer = DBuffer.distribute_tensors(
+        [torch.full((5, 3), rank_scale, dtype=torch.float32, device=device)],
+        mesh,
+        [Partial(reduce_op=dist.ReduceOp.AVG)],
+    )
+
+    replicated_buffer = partial_buffer.reduce_scatter(0, Flat()).allgather(0)
+
+    expected = torch.full((5, 3), (world_size + 1) / 2.0, dtype=torch.float32, device=device)
+    _assert_dbuffer_local_tensors_close(replicated_buffer, [expected])
+
+
 def test_symmetric_memory_partial_reduce_scatter_to_flat_average(distributed_setup):
     """Symmetric-memory reduce-scatter preserves AVG semantics."""
     device, world_size = distributed_setup.device, distributed_setup.world_size

--- a/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
@@ -7,6 +7,7 @@ from collections.abc import Iterable
 import pytest
 import torch
 import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
 from torch.distributed.device_mesh import init_device_mesh
 
 from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental.dbuffer import (
@@ -469,6 +470,62 @@ def test_partial_reduce_scatter_to_flat_average(distributed_setup):
     expected_tensors = [
         torch.full((5, 3), scale_average, dtype=torch.float32, device=distributed_setup.device),
         torch.full((4,), scale_average * 10, dtype=torch.float32, device=distributed_setup.device),
+    ]
+    _assert_dbuffer_local_tensors_close(replicated_buffer, expected_tensors)
+
+
+def test_symmetric_memory_partial_reduce_scatter_to_flat_average(distributed_setup):
+    """Symmetric-memory reduce-scatter preserves AVG semantics."""
+    device, world_size = distributed_setup.device, distributed_setup.world_size
+    mesh = init_device_mesh(device.type, (world_size,))
+    dist.barrier(device_ids=[device.index])
+    rank_scale = float(distributed_setup.rank + 1)
+    tensors = [
+        torch.full((5, 3), rank_scale, dtype=torch.float32, device=device),
+        torch.full((4,), rank_scale * 10, dtype=torch.float32, device=device),
+    ]
+    pool = symm_mem.get_mem_pool(device)
+    with torch.cuda.use_mem_pool(pool):
+        partial_buffer = DBuffer.distribute_tensors(
+            tensors, mesh, [Partial(reduce_op=dist.ReduceOp.AVG)]
+        )
+    assert symm_mem.is_symm_mem_tensor(partial_buffer.local_buffer)
+
+    sharded_buffer = partial_buffer.reduce_scatter(0, Flat())
+    replicated_buffer = sharded_buffer.allgather(0)
+
+    scale_average = (world_size + 1) / 2.0
+    expected_tensors = [
+        torch.full((5, 3), scale_average, dtype=torch.float32, device=device),
+        torch.full((4,), scale_average * 10, dtype=torch.float32, device=device),
+    ]
+    _assert_dbuffer_local_tensors_close(replicated_buffer, expected_tensors)
+
+
+def test_symmetric_memory_partial_reduce_scatter_to_flat_sum(distributed_setup):
+    """Symmetric-memory reduce-scatter preserves explicit SUM semantics."""
+    device, world_size = distributed_setup.device, distributed_setup.world_size
+    mesh = init_device_mesh(device.type, (world_size,))
+    dist.barrier(device_ids=[device.index])
+    rank_scale = float(distributed_setup.rank + 1)
+    tensors = [
+        torch.full((5, 3), rank_scale, dtype=torch.float32, device=device),
+        torch.full((4,), rank_scale * 10, dtype=torch.float32, device=device),
+    ]
+    pool = symm_mem.get_mem_pool(device)
+    with torch.cuda.use_mem_pool(pool):
+        partial_buffer = DBuffer.distribute_tensors(
+            tensors, mesh, [Partial(reduce_op=dist.ReduceOp.SUM)]
+        )
+    assert symm_mem.is_symm_mem_tensor(partial_buffer.local_buffer)
+
+    sharded_buffer = partial_buffer.reduce_scatter(0, Flat())
+    replicated_buffer = sharded_buffer.allgather(0)
+
+    scale_sum = float(world_size * (world_size + 1) // 2)
+    expected_tensors = [
+        torch.full((5, 3), scale_sum, dtype=torch.float32, device=device),
+        torch.full((4,), scale_sum * 10, dtype=torch.float32, device=device),
     ]
     _assert_dbuffer_local_tensors_close(replicated_buffer, expected_tensors)
 


### PR DESCRIPTION
## Summary

Addresses the DBuffer encapsulation proposed in [issue #5616](https://github.com/NVIDIA/Megatron-LM/issues/5616#issuecomment-5138732033).

- keep FSDP partial gradient buffers semantically `Partial(AVG)` regardless of allocator
- make `DBuffer.reduce_scatter()` handle NCCL symmetric-memory rendezvous and AVG emulation
- preserve explicit symmetric-memory `Partial(SUM)` semantics
- add direct DBuffer coverage for symmetric-memory AVG and SUM

## Why

NCCL currently selects its symmetric-memory reduce-scatter kernel for SUM. The allocator-specific SUM selection and output scaling previously lived in `FsdpParameterGroup`, which made the buffer placement describe the backend implementation rather than the logical reduction. Moving this behavior into `DBuffer` keeps placement semantics accurate and encapsulates collective details with the buffer that owns them.

## Rebase

Rebased onto current `main`. The current symmetric-memory FSDP tests already construct modules within `fully_shard_context`, so no additional context migration was required.

## Validation

- `python -m torch.distributed.run --nproc-per-node 2 -m pytest -q tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py tests/unit_tests/distributed/mfsdp_v2/test_symmetric_memory.py::test_fully_shard_symmetric_memory_matches_default_and_profiles_nccl`
  - 24 passed, 6 skipped on each rank
  - symmetric-memory loss parity preserved
  - reduce-scatter continued selecting `ncclSymk` kernels
- `isort --check-only` and `git diff --check` passed.