### PR TITLE
fix(ci): align workflow Python version with requires-python

### DIFF
--- a/.github/workflows/auto-reminder-bot.yml
+++ b/.github/workflows/auto-reminder-bot.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/auto-swap-labels.yml
+++ b/.github/workflows/auto-swap-labels.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.pr.outputs.number
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Install dependencies
         if: steps.pr.outputs.number

--- a/.github/workflows/oncall-assign.yml
+++ b/.github/workflows/oncall-assign.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: Install dependencies
         run: pip install requests slack-sdk

--- a/.github/workflows/oncall-rotation.yml
+++ b/.github/workflows/oncall-rotation.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Rotate Schedule
         env:

--- a/.github/workflows/sync-team-usergroups.yml
+++ b/.github/workflows/sync-team-usergroups.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Sync Teams to User Groups
         env:


### PR DESCRIPTION
## Why
Package metadata declares `requires-python` / `.python-version` as `>=3.12`, but CI workflows still pin `python-version` to a mismatched value.

That can make CI run on a runtime the project no longer supports (or skip the version the package actually targets).

## What changed
Update the affected workflow `python-version` pins so they satisfy `>=3.12` (using `3.12` where a concrete pin is needed).

- `.github/workflows/auto-reminder-bot.yml`
  - `python-version: "3.10"` → `python-version: "3.12"`
- `.github/workflows/auto-swap-labels.yml`
  - `python-version: "3.10"` → `python-version: "3.12"`
- `.github/workflows/oncall-assign.yml`
  - `python-version: '3.10'` → `python-version: '3.12'`
- `.github/workflows/oncall-rotation.yml`
  - `python-version: "3.10"` → `python-version: "3.12"`
- `.github/workflows/sync-team-usergroups.yml`
  - `python-version: "3.10"` → `python-version: "3.12"`

## Test plan
- [ ] Package `requires-python` / `.python-version` is still `>=3.12`
- [ ] Updated workflows now use versions consistent with that constraint
- [ ] Relevant CI jobs on this branch look healthy

Found while auditing CI/package version consistency across popular repos.
