### PR TITLE
[Dev] Keep the mHC mapping computation in fp32 on the fused cuTile path

### DIFF
--- a/megatron/core/fusions/fused_mhc_kernels.py
+++ b/megatron/core/fusions/fused_mhc_kernels.py
@@ -1076,7 +1076,9 @@ if _CUTILE_AVAILABLE:
             )
             gx_tile = go_expanded * h_expanded
             ct.store(gx, index=(pid, 0, ct_idx), tile=gx_tile.astype(gx.dtype))
-            gh_acc += ct.sum(go_expanded * x_tile, axis=2)
+            # Reduce in fp32: the torch reference evaluates this product in fp32
+            # under torch.compile, and a bf16 product makes grad_h ~3x noisier.
+            gh_acc += ct.sum(go_expanded.astype(ct.float32) * x_tile.astype(ct.float32), axis=2)
         ct.store(gh, index=(pid, 0), tile=gh_acc.astype(gh.dtype))
 
     def _cutile_h_aggregate_fwd(x: Tensor, h_pre: Tensor) -> Tensor:

--- a/megatron/core/fusions/fused_mhc_kernels.py
+++ b/megatron/core/fusions/fused_mhc_kernels.py
@@ -1472,7 +1472,10 @@ if _CUTILE_AVAILABLE:
             acc = ct.mma(
                 a_tile.astype(ct.tfloat32), b_tile.transpose().astype(ct.tfloat32), acc=acc
             )
-            sum_sq += ct.sum(a_tile * a_tile, axis=1, keepdims=True)
+            # Square in fp32: a bf16 square/reduction loses ~2e-3 relative on the
+            # RMS scale, which native (fp32) does not.
+            a_tile_f32 = a_tile.astype(ct.float32)
+            sum_sq += ct.sum(a_tile_f32 * a_tile_f32, axis=1, keepdims=True)
 
         bid_m_k = tile_m_id + split_k_id * num_m_tiles
         ct.store(PROJ, index=(bid_m_k, 0), tile=acc.astype(PROJ.dtype))
@@ -1622,7 +1625,9 @@ if _CUTILE_AVAILABLE:
             dr_tile = ct.load(
                 DR, index=(tile_m_id, 0), shape=(TILE_SIZE_M, 1), padding_mode=zero_pad
             )
-            accumulator_da = accumulator_da + _ct_rms_dnorm(a_tile, norm_tile, dr_tile, K, eps)
+            accumulator_da = accumulator_da + _ct_rms_dnorm(
+                a_tile.astype(ct.float32), norm_tile, dr_tile, K, eps
+            )
             b_tile = ct.load(
                 B, index=(0, tile_k_id), shape=(TILE_SIZE_N, TILE_SIZE_K), padding_mode=zero_pad
             )
@@ -1758,6 +1763,11 @@ if _CUTILE_AVAILABLE:
         N = weight.shape[0]
         TILE_N = _next_power_of_2(N)
         dev = x.device
+        # The mHC mapping is a keep_in_fp32 computation (see
+        # HyperConnectionModule._projection_and_get_norm): keep the split-K
+        # partials and the mapping outputs in fp32 even when the activations
+        # arrive in bf16, otherwise this path is ~170x less accurate than native.
+        acc_dtype = torch.float32
         stream = torch.cuda.current_stream()
 
         cache_key = (M, N, K)
@@ -1770,11 +1780,11 @@ if _CUTILE_AVAILABLE:
             else:
                 tm, tn, tk, split_k = _default_proj_rms_fwd_config(M, K, TILE_N)
 
-            proj = torch.empty(split_k * M, N, dtype=x.dtype, device=dev)
-            norm = torch.empty(split_k * M, 1, dtype=x.dtype, device=dev)
+            proj = torch.empty(split_k * M, N, dtype=acc_dtype, device=dev)
+            norm = torch.empty(split_k * M, 1, dtype=acc_dtype, device=dev)
             # _ct_proj_rms_fwd_kernel keeps R in its signature; r is computed
             # below from the reduced norm.
-            r = torch.empty(split_k * M, 1, dtype=x.dtype, device=dev)
+            r = torch.empty(split_k * M, 1, dtype=acc_dtype, device=dev)
 
             ct.launch(
                 stream,
@@ -1782,8 +1792,8 @@ if _CUTILE_AVAILABLE:
                 _ct_proj_rms_fwd_kernel,
                 (x, weight, proj, norm, r, M, N, K, eps, tm, tn, tk, split_k),
             )
-            proj = proj.view(split_k, M, N).to(torch.float32).sum(dim=0).to(dtype=x.dtype)
-            norm = norm.view(split_k, M, 1).to(torch.float32).sum(dim=0).to(dtype=x.dtype)
+            proj = proj.view(split_k, M, N).to(torch.float32).sum(dim=0).to(dtype=acc_dtype)
+            norm = norm.view(split_k, M, 1).to(torch.float32).sum(dim=0).to(dtype=acc_dtype)
         else:
             # Autotune on first call for this shape.
             from types import SimpleNamespace
@@ -1793,24 +1803,24 @@ if _CUTILE_AVAILABLE:
             configs = [cfg for cfg in configs if cfg.TILE_K <= K and M % cfg.TILE_M == 0]
             if len(configs) == 0:
                 tm, tn, tk, split_k = _default_proj_rms_fwd_config(M, K, TILE_N)
-                proj = torch.empty(split_k * M, N, dtype=x.dtype, device=dev)
-                norm = torch.empty(split_k * M, 1, dtype=x.dtype, device=dev)
+                proj = torch.empty(split_k * M, N, dtype=acc_dtype, device=dev)
+                norm = torch.empty(split_k * M, 1, dtype=acc_dtype, device=dev)
                 # Signature placeholder for the cuTile kernel; not read.
-                r = torch.empty(split_k * M, 1, dtype=x.dtype, device=dev)
+                r = torch.empty(split_k * M, 1, dtype=acc_dtype, device=dev)
                 ct.launch(
                     stream,
                     (math.ceil(M / tm), split_k),
                     _ct_proj_rms_fwd_kernel,
                     (x, weight, proj, norm, r, M, N, K, eps, tm, tn, tk, split_k),
                 )
-                proj = proj.view(split_k, M, N).to(torch.float32).sum(dim=0).to(dtype=x.dtype)
-                norm = norm.view(split_k, M, 1).to(torch.float32).sum(dim=0).to(dtype=x.dtype)
+                proj = proj.view(split_k, M, N).to(torch.float32).sum(dim=0).to(dtype=acc_dtype)
+                norm = norm.view(split_k, M, 1).to(torch.float32).sum(dim=0).to(dtype=acc_dtype)
             else:
                 mx_split_k = max(cfg.SPLIT_K for cfg in configs)
-                proj = torch.empty(mx_split_k * M, N, dtype=x.dtype, device=dev)
-                norm = torch.empty(mx_split_k * M, 1, dtype=x.dtype, device=dev)
+                proj = torch.empty(mx_split_k * M, N, dtype=acc_dtype, device=dev)
+                norm = torch.empty(mx_split_k * M, 1, dtype=acc_dtype, device=dev)
                 # Signature placeholder for autotune launches; not read.
-                r = torch.empty(mx_split_k * M, 1, dtype=x.dtype, device=dev)
+                r = torch.empty(mx_split_k * M, 1, dtype=acc_dtype, device=dev)
                 tuned = ct_experimental.autotune_launch(
                     stream,
                     grid_fn=lambda cfg: (math.ceil(M / cfg.TILE_M), cfg.SPLIT_K),
@@ -1839,10 +1849,10 @@ if _CUTILE_AVAILABLE:
                     best.TILE_K,
                     best.SPLIT_K,
                 )
-                proj = torch.empty(best.SPLIT_K * M, N, dtype=x.dtype, device=dev)
-                norm = torch.empty(best.SPLIT_K * M, 1, dtype=x.dtype, device=dev)
+                proj = torch.empty(best.SPLIT_K * M, N, dtype=acc_dtype, device=dev)
+                norm = torch.empty(best.SPLIT_K * M, 1, dtype=acc_dtype, device=dev)
                 # Signature placeholder for the cuTile kernel; not read.
-                r = torch.empty(best.SPLIT_K * M, 1, dtype=x.dtype, device=dev)
+                r = torch.empty(best.SPLIT_K * M, 1, dtype=acc_dtype, device=dev)
                 # Re-launch with best config for correct output.
                 ct.launch(
                     stream,
@@ -1865,11 +1875,16 @@ if _CUTILE_AVAILABLE:
                     ),
                 )
 
-                proj = proj.view(best.SPLIT_K, M, N).to(torch.float32).sum(dim=0).to(dtype=x.dtype)
-                norm = norm.view(best.SPLIT_K, M, 1).to(torch.float32).sum(dim=0).to(dtype=x.dtype)
+                sk = best.SPLIT_K
+                proj = proj.view(sk, M, N).to(torch.float32).sum(dim=0).to(dtype=acc_dtype)
+                norm = norm.view(sk, M, 1).to(torch.float32).sum(dim=0).to(dtype=acc_dtype)
         norm = torch.sqrt(norm)
         r = 1.0 / (norm / math.sqrt(K) + eps)
-        return proj, norm, r
+        # Match native_proj_rms's dtype contract: the result follows the
+        # promoted input/parameter dtype (fp32 in mHC, where the mapping
+        # parameters are keep_in_fp32). `norm` stays fp32 for the backward.
+        out_dtype = torch.promote_types(x.dtype, weight.dtype)
+        return proj.to(out_dtype), norm, r.to(out_dtype)
 
     # -- Reduce + compute_h launcher ------------------------------------------
 
@@ -1913,6 +1928,7 @@ if _CUTILE_AVAILABLE:
         _proj_tile_m: int,
         tile_n: int,
         split_k: int,
+        out_dtype: torch.dtype,
     ) -> Tuple[Tensor, Tensor, Tensor, Tensor, Tensor]:
         """Launch reduce split-K + compute_h kernel.
 
@@ -1928,10 +1944,13 @@ if _CUTILE_AVAILABLE:
 
         bias_2d = bias.unsqueeze(0).contiguous()  # [1, N]
 
-        h_pre_out = torch.empty(M, n, dtype=proj_acc.dtype, device=dev)
-        h_post_out = torch.empty(M, n, dtype=proj_acc.dtype, device=dev)
-        h_res_out = torch.empty(M, N - 2 * n, dtype=proj_acc.dtype, device=dev)
-        r_out = torch.empty(M, 1, dtype=proj_acc.dtype, device=dev)
+        # Mapping outputs follow the promoted input/parameter dtype (fp32 for
+        # mHC's keep_in_fp32 parameters); the reduced projection is kept in the
+        # fp32 accumulator dtype because the backward consumes it.
+        h_pre_out = torch.empty(M, n, dtype=out_dtype, device=dev)
+        h_post_out = torch.empty(M, n, dtype=out_dtype, device=dev)
+        h_res_out = torch.empty(M, N - 2 * n, dtype=out_dtype, device=dev)
+        r_out = torch.empty(M, 1, dtype=out_dtype, device=dev)
         proj_out = torch.empty(M, N, dtype=proj_acc.dtype, device=dev)
 
         default_tm = _default_reduce_compute_h_tile_m(M)
@@ -2013,6 +2032,11 @@ if _CUTILE_AVAILABLE:
         N = weight.shape[0]
         TILE_N = _next_power_of_2(N)
         dev = x.device
+        # The mHC mapping is a keep_in_fp32 computation (see
+        # HyperConnectionModule._projection_and_get_norm): keep the split-K
+        # partials and the mapping outputs in fp32 even when the activations
+        # arrive in bf16, otherwise this path is ~170x less accurate than native.
+        acc_dtype = torch.float32
         stream = torch.cuda.current_stream()
 
         cache_key = (M, N, K)
@@ -2024,11 +2048,11 @@ if _CUTILE_AVAILABLE:
             else:
                 tm, tn, tk, split_k = _default_proj_rms_fwd_config(M, K, TILE_N)
 
-            proj_acc = torch.empty(split_k * M, N, dtype=x.dtype, device=dev)
-            norm_acc = torch.empty(split_k * M, 1, dtype=x.dtype, device=dev)
+            proj_acc = torch.empty(split_k * M, N, dtype=acc_dtype, device=dev)
+            norm_acc = torch.empty(split_k * M, 1, dtype=acc_dtype, device=dev)
             # _ct_proj_rms_fwd_kernel keeps R in its signature; reduce_compute_h
             # computes r from norm_acc.
-            r_placeholder = torch.empty(split_k * M, 1, dtype=x.dtype, device=dev)
+            r_placeholder = torch.empty(split_k * M, 1, dtype=acc_dtype, device=dev)
 
             ct.launch(
                 stream,
@@ -2043,10 +2067,10 @@ if _CUTILE_AVAILABLE:
             configs = [cfg for cfg in configs if cfg.TILE_K <= K and M % cfg.TILE_M == 0]
             if len(configs) == 0:
                 tm, tn, tk, split_k = _default_proj_rms_fwd_config(M, K, TILE_N)
-                proj_acc = torch.empty(split_k * M, N, dtype=x.dtype, device=dev)
-                norm_acc = torch.empty(split_k * M, 1, dtype=x.dtype, device=dev)
+                proj_acc = torch.empty(split_k * M, N, dtype=acc_dtype, device=dev)
+                norm_acc = torch.empty(split_k * M, 1, dtype=acc_dtype, device=dev)
                 # Signature placeholder for the cuTile kernel; not read.
-                r_placeholder = torch.empty(split_k * M, 1, dtype=x.dtype, device=dev)
+                r_placeholder = torch.empty(split_k * M, 1, dtype=acc_dtype, device=dev)
                 ct.launch(
                     stream,
                     (math.ceil(M / tm), split_k),
@@ -2069,10 +2093,10 @@ if _CUTILE_AVAILABLE:
                 )
             else:
                 mx_split_k = max(cfg.SPLIT_K for cfg in configs)
-                proj_acc = torch.empty(mx_split_k * M, N, dtype=x.dtype, device=dev)
-                norm_acc = torch.empty(mx_split_k * M, 1, dtype=x.dtype, device=dev)
+                proj_acc = torch.empty(mx_split_k * M, N, dtype=acc_dtype, device=dev)
+                norm_acc = torch.empty(mx_split_k * M, 1, dtype=acc_dtype, device=dev)
                 # Signature placeholder for autotune launches; not read.
-                r_placeholder = torch.empty(mx_split_k * M, 1, dtype=x.dtype, device=dev)
+                r_placeholder = torch.empty(mx_split_k * M, 1, dtype=acc_dtype, device=dev)
                 tuned = ct_experimental.autotune_launch(
                     stream,
                     grid_fn=lambda cfg: (math.ceil(M / cfg.TILE_M), cfg.SPLIT_K),
@@ -2103,10 +2127,10 @@ if _CUTILE_AVAILABLE:
                 )
                 tm, tn, tk, split_k = best.TILE_M, best.TILE_N, best.TILE_K, best.SPLIT_K
 
-                proj_acc = torch.empty(split_k * M, N, dtype=x.dtype, device=dev)
-                norm_acc = torch.empty(split_k * M, 1, dtype=x.dtype, device=dev)
+                proj_acc = torch.empty(split_k * M, N, dtype=acc_dtype, device=dev)
+                norm_acc = torch.empty(split_k * M, 1, dtype=acc_dtype, device=dev)
                 # Signature placeholder for the cuTile kernel; not read.
-                r_placeholder = torch.empty(split_k * M, 1, dtype=x.dtype, device=dev)
+                r_placeholder = torch.empty(split_k * M, 1, dtype=acc_dtype, device=dev)
                 ct.launch(
                     stream,
                     (math.ceil(M / tm), split_k),
@@ -2145,6 +2169,7 @@ if _CUTILE_AVAILABLE:
             tm,
             TILE_N,
             split_k,
+            torch.promote_types(x.dtype, weight.dtype),
         )
         return h_pre, h_post, h_res, r, proj_reduced
 
@@ -3119,6 +3144,10 @@ def _torch_proj_rms_compute_h(
     eps: float,
     compute_h_eps: float = 1e-6,
 ) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
+    # compute_mappings() hands us activations in the activation dtype while the
+    # mapping parameters are keep_in_fp32, so matmul would reject the pair.
+    # Compute in the parameter dtype, matching the unfused path's fp32 upcast.
+    x = x.to(weight.dtype)
     proj = torch.matmul(x, weight.t())
     r = x.norm(dim=-1, keepdim=True) / math.sqrt(x.shape[-1])
     alpha = torch.cat(

--- a/megatron/core/fusions/fused_mhc_kernels.py
+++ b/megatron/core/fusions/fused_mhc_kernels.py
@@ -3148,8 +3148,9 @@ def _torch_proj_rms_compute_h(
 ) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
     # compute_mappings() hands us activations in the activation dtype while the
     # mapping parameters are keep_in_fp32, so matmul would reject the pair.
-    # Compute in the parameter dtype, matching the unfused path's fp32 upcast.
-    x = x.to(weight.dtype)
+    # Compute in the wider of the two, matching the unfused path's fp32 upcast
+    # without letting a lower-precision parameter downcast the activations.
+    x = x.to(torch.promote_types(x.dtype, weight.dtype))
     proj = torch.matmul(x, weight.t())
     r = x.norm(dim=-1, keepdim=True) / math.sqrt(x.shape[-1])
     alpha = torch.cat(
@@ -3401,13 +3402,17 @@ def fused_h_post_bda(
 def fused_proj_rms(x: Tensor, weight: Tensor, eps: float = 1e-6) -> Tuple[Tensor, Tensor]:
     """Projection + RMS normalization using cuTile, then torch."""
     _raise_mhc_backend_validation_error()
-    if x.dtype != weight.dtype:
-        # The mHC mapping parameters are keep_in_fp32 while activations arrive
-        # in the activation dtype. Normalize here so every backend consumes the
-        # same dtype and the native fallback's matmul does not reject the pair.
-        x = x.to(weight.dtype)
     if is_cutile_available():
+        # The cuTile kernels load and cast each tile independently, so they take
+        # the keep_in_fp32 weight against activation-dtype inputs directly.
+        # Upcasting x here would only materialize a full fp32 copy of the
+        # activations; bf16 -> fp32 is exact, so it would not buy any accuracy.
         return CutileProjRms.apply(x, weight, eps)
+    if x.dtype != weight.dtype:
+        # native_proj_rms's matmul does reject mixed dtypes, and the copy is
+        # unavoidable on this branch. Promote rather than adopt the weight
+        # dtype so a lower-precision parameter cannot downcast the activations.
+        x = x.to(torch.promote_types(x.dtype, weight.dtype))
     return native_proj_rms(x, weight, eps)
 
 

--- a/megatron/core/fusions/fused_mhc_kernels.py
+++ b/megatron/core/fusions/fused_mhc_kernels.py
@@ -8,10 +8,10 @@ live in ``megatron.core.transformer.hyper_connection`` and are used when fused
 kernels are unavailable or when the ``use_fused_mhc`` config flag is False.
 
 Four fused operations:
-  - sinkhorn:     Sinkhorn-Knopp projection to doubly stochastic matrix
-  - h_aggregate:  weighted n-stream -> 1-stream aggregation
-  - h_post_bda:   fused H_res.T @ residual + H_post * (x + bias)
-  - proj_rms:     fused projection + RMS normalization
+  - sinkhorn:            Sinkhorn-Knopp projection to doubly stochastic matrix
+  - h_aggregate:         weighted n-stream -> 1-stream aggregation
+  - h_post_bda:          fused H_res.T @ residual + H_post * (x + bias)
+  - proj_rms_compute_h:  fused projection + RMS normalization + compute_h
 """
 
 import logging
@@ -1427,14 +1427,6 @@ if _CUTILE_AVAILABLE:
 
     # -- Proj RMS kernels ----------------------------------------------------
 
-    @ct.function
-    def _ct_rms_dnorm(a_tile, norm_tile, dr_tile, K, eps=1e-6):
-        inv_norm = ct.where(norm_tile > 0, 1.0 / norm_tile, 0.0)
-        inv_sqrt_k = 1.0 / ct.sqrt(K)
-        u = norm_tile * inv_sqrt_k + eps
-        coeff = -(1.0 / (u * u)) * inv_sqrt_k
-        return dr_tile * coeff * a_tile * inv_norm
-
     @ct.kernel
     def _ct_proj_rms_fwd_kernel(
         A,
@@ -1592,135 +1584,6 @@ if _CUTILE_AVAILABLE:
             ct.store(PROJ_OUT, index=(bid_m, 2 + res_chunk), tile=res_accum.astype(PROJ_OUT.dtype))
             ct.store(H_RES, index=(bid_m, res_chunk), tile=h_res.astype(H_RES.dtype))
 
-    @ct.kernel
-    def _ct_proj_rms_bwd_kernel(
-        A,
-        B,
-        NORM,
-        DD,
-        DR,
-        DA,
-        DB,
-        M: int,
-        N: int,
-        K: int,
-        eps: float,
-        TILE_SIZE_M: ConstInt,
-        TILE_SIZE_N: ConstInt,
-        TILE_SIZE_K: ConstInt,
-    ):
-        zero_pad = ct.PaddingMode.ZERO
-        tile_k_id = ct.bid(0)
-        NUM_M_TILES = ct.cdiv(M, TILE_SIZE_M)
-        accumulator_db = ct.full((TILE_SIZE_K, TILE_SIZE_N), 0.0, dtype=ct.float32)
-        for tile_m_id in range(NUM_M_TILES):
-            accumulator_da = ct.full((TILE_SIZE_M, TILE_SIZE_K), 0.0, dtype=ct.float32)
-            a_tile = ct.load(
-                A,
-                index=(tile_m_id, tile_k_id),
-                shape=(TILE_SIZE_M, TILE_SIZE_K),
-                padding_mode=zero_pad,
-            )
-            norm_tile = ct.load(
-                NORM, index=(tile_m_id, 0), shape=(TILE_SIZE_M, 1), padding_mode=zero_pad
-            )
-            dr_tile = ct.load(
-                DR, index=(tile_m_id, 0), shape=(TILE_SIZE_M, 1), padding_mode=zero_pad
-            )
-            accumulator_da = accumulator_da + _ct_rms_dnorm(
-                a_tile.astype(ct.float32), norm_tile, dr_tile, K, eps
-            )
-            b_tile = ct.load(
-                B, index=(0, tile_k_id), shape=(TILE_SIZE_N, TILE_SIZE_K), padding_mode=zero_pad
-            )
-            dd_tile = ct.load(
-                DD, index=(tile_m_id, 0), shape=(TILE_SIZE_M, TILE_SIZE_N), padding_mode=zero_pad
-            )
-            dd_tile = ct.astype(dd_tile, ct.tfloat32)
-            accumulator_da = ct.mma(dd_tile, b_tile.astype(ct.tfloat32), acc=accumulator_da)
-            ct.store(DA, index=(tile_m_id, tile_k_id), tile=accumulator_da.astype(DA.dtype))
-            accumulator_db = ct.mma(
-                a_tile.transpose().astype(ct.tfloat32), dd_tile, acc=accumulator_db
-            )
-        ct.store(DB, index=(0, tile_k_id), tile=accumulator_db.transpose().astype(DB.dtype))
-
-    @ct.kernel
-    def _ct_proj_rms_bwd_small_k_kernel(
-        A, B, NORM, DD, DR, DA, DB, M: int, N: int, K: int, eps: float, TILE_N_SIZE: ConstInt
-    ):
-        zero_pad = ct.PaddingMode.ZERO
-        TILE_DB_SIZE_M = 128
-        TILE_DB_SIZE_K = 64
-        NUM_M_TILES = ct.cdiv(M, TILE_DB_SIZE_M)
-        NUM_K_TILES = ct.cdiv(K, TILE_DB_SIZE_K)
-        if ct.bid(1) == 0:
-            for tile_id in range(ct.bid(0), NUM_K_TILES, ct.num_blocks(0)):
-                accumulator_db = ct.full((TILE_DB_SIZE_K, TILE_N_SIZE), 0.0, dtype=ct.float32)
-                for m_tile in range(NUM_M_TILES):
-                    a_tile = ct.load(
-                        A,
-                        index=(m_tile, tile_id),
-                        shape=(TILE_DB_SIZE_M, TILE_DB_SIZE_K),
-                        padding_mode=zero_pad,
-                    )
-                    dd_tile = ct.load(
-                        DD,
-                        index=(m_tile, 0),
-                        shape=(TILE_DB_SIZE_M, TILE_N_SIZE),
-                        padding_mode=zero_pad,
-                    )
-                    accumulator_db = ct.mma(
-                        a_tile.transpose().astype(ct.tfloat32),
-                        dd_tile.astype(ct.tfloat32),
-                        acc=accumulator_db,
-                    )
-                ct.store(
-                    DB,
-                    index=(0, tile_id),
-                    tile=accumulator_db.transpose().astype(DB.dtype),
-                    allow_tma=False,
-                )
-        TILE_DA_SIZE_M = 128
-        TILE_DA_SIZE_K = 256
-        NUM_DA_TILES = ct.cdiv(M, TILE_DA_SIZE_M) * ct.cdiv(K, TILE_DA_SIZE_K)
-        NUM_DA_K_TILES = ct.cdiv(K, TILE_DA_SIZE_K)
-        if ct.bid(1) == 1:
-            for tile_id in range(ct.bid(0), NUM_DA_TILES, ct.num_blocks(0)):
-                b_tile_idx = tile_id % NUM_DA_K_TILES
-                dd_tile_idx = tile_id // NUM_DA_K_TILES
-                accumulator_da = ct.full((TILE_DA_SIZE_M, TILE_DA_SIZE_K), 0.0, dtype=ct.float32)
-                a_tile = ct.load(
-                    A,
-                    index=(dd_tile_idx, b_tile_idx),
-                    shape=(TILE_DA_SIZE_M, TILE_DA_SIZE_K),
-                    padding_mode=zero_pad,
-                )
-                norm_tile = ct.load(
-                    NORM, index=(dd_tile_idx, 0), shape=(TILE_DA_SIZE_M, 1), padding_mode=zero_pad
-                )
-                dr_tile = ct.load(
-                    DR, index=(dd_tile_idx, 0), shape=(TILE_DA_SIZE_M, 1), padding_mode=zero_pad
-                )
-                accumulator_da = accumulator_da + _ct_rms_dnorm(
-                    a_tile.astype(ct.float32), norm_tile, dr_tile, K, eps
-                )
-                b_tile = ct.load(
-                    B,
-                    index=(0, b_tile_idx),
-                    shape=(TILE_N_SIZE, TILE_DA_SIZE_K),
-                    padding_mode=zero_pad,
-                )
-                dd_tile = ct.load(
-                    DD,
-                    index=(dd_tile_idx, 0),
-                    shape=(TILE_DA_SIZE_M, TILE_N_SIZE),
-                    padding_mode=zero_pad,
-                )
-                accumulator_da = ct.mma(
-                    dd_tile.astype(ct.tfloat32), b_tile.astype(ct.tfloat32), acc=accumulator_da
-                )
-                ct.store(DA, index=(dd_tile_idx, b_tile_idx), tile=accumulator_da.astype(DA.dtype))
-
     def _next_power_of_2(n: int) -> int:
         n -= 1
         n |= n >> 1
@@ -1757,136 +1620,6 @@ if _CUTILE_AVAILABLE:
 
     # Cache the best config across calls (keyed by M, N, K).
     _proj_rms_fwd_best_cfg: dict = {}
-
-    def _cutile_proj_rms_fwd(
-        x: Tensor, weight: Tensor, eps: float = 1e-6
-    ) -> Tuple[Tensor, Tensor, Tensor]:
-        M, K = x.shape
-        N = weight.shape[0]
-        TILE_N = _next_power_of_2(N)
-        dev = x.device
-        # The mHC mapping is a keep_in_fp32 computation (see
-        # HyperConnectionModule._projection_and_get_norm): keep the split-K
-        # partials and the mapping outputs in fp32 even when the activations
-        # arrive in bf16, otherwise this path is ~170x less accurate than native.
-        acc_dtype = torch.float32
-        stream = torch.cuda.current_stream()
-
-        cache_key = (M, N, K)
-        cached = _proj_rms_fwd_best_cfg.get(cache_key)
-
-        if cached is not None or not _CUTILE_EXPERIMENTAL_AVAILABLE:
-            # Use cached best config, or fall back to default if no experimental.
-            if cached is not None:
-                tm, tn, tk, split_k = cached
-            else:
-                tm, tn, tk, split_k = _default_proj_rms_fwd_config(M, K, TILE_N)
-
-            proj = torch.empty(split_k * M, N, dtype=acc_dtype, device=dev)
-            norm = torch.empty(split_k * M, 1, dtype=acc_dtype, device=dev)
-            # _ct_proj_rms_fwd_kernel keeps R in its signature; r is computed
-            # below from the reduced norm.
-            r = torch.empty(split_k * M, 1, dtype=acc_dtype, device=dev)
-
-            ct.launch(
-                stream,
-                (math.ceil(M / tm), split_k),
-                _ct_proj_rms_fwd_kernel,
-                (x, weight, proj, norm, r, M, N, K, eps, tm, tn, tk, split_k),
-            )
-            proj = proj.view(split_k, M, N).to(torch.float32).sum(dim=0).to(dtype=acc_dtype)
-            norm = norm.view(split_k, M, 1).to(torch.float32).sum(dim=0).to(dtype=acc_dtype)
-        else:
-            # Autotune on first call for this shape.
-            from types import SimpleNamespace
-
-            configs = [SimpleNamespace(**c) for c in _proj_rms_fwd_autotune_configs(N)]
-            # filter out configs with TILE_K > K or TILE_M > M
-            configs = [cfg for cfg in configs if cfg.TILE_K <= K and M % cfg.TILE_M == 0]
-            if len(configs) == 0:
-                tm, tn, tk, split_k = _default_proj_rms_fwd_config(M, K, TILE_N)
-                proj = torch.empty(split_k * M, N, dtype=acc_dtype, device=dev)
-                norm = torch.empty(split_k * M, 1, dtype=acc_dtype, device=dev)
-                # Signature placeholder for the cuTile kernel; not read.
-                r = torch.empty(split_k * M, 1, dtype=acc_dtype, device=dev)
-                ct.launch(
-                    stream,
-                    (math.ceil(M / tm), split_k),
-                    _ct_proj_rms_fwd_kernel,
-                    (x, weight, proj, norm, r, M, N, K, eps, tm, tn, tk, split_k),
-                )
-                proj = proj.view(split_k, M, N).to(torch.float32).sum(dim=0).to(dtype=acc_dtype)
-                norm = norm.view(split_k, M, 1).to(torch.float32).sum(dim=0).to(dtype=acc_dtype)
-            else:
-                mx_split_k = max(cfg.SPLIT_K for cfg in configs)
-                proj = torch.empty(mx_split_k * M, N, dtype=acc_dtype, device=dev)
-                norm = torch.empty(mx_split_k * M, 1, dtype=acc_dtype, device=dev)
-                # Signature placeholder for autotune launches; not read.
-                r = torch.empty(mx_split_k * M, 1, dtype=acc_dtype, device=dev)
-                tuned = ct_experimental.autotune_launch(
-                    stream,
-                    grid_fn=lambda cfg: (math.ceil(M / cfg.TILE_M), cfg.SPLIT_K),
-                    kernel=_ct_proj_rms_fwd_kernel,
-                    args_fn=lambda cfg: (
-                        x,
-                        weight,
-                        proj,
-                        norm,
-                        r,
-                        M,
-                        N,
-                        K,
-                        eps,
-                        cfg.TILE_M,
-                        cfg.TILE_N,
-                        cfg.TILE_K,
-                        cfg.SPLIT_K,
-                    ),
-                    search_space=configs,
-                )
-                best = tuned.tuned_config
-                _proj_rms_fwd_best_cfg[cache_key] = (
-                    best.TILE_M,
-                    best.TILE_N,
-                    best.TILE_K,
-                    best.SPLIT_K,
-                )
-                proj = torch.empty(best.SPLIT_K * M, N, dtype=acc_dtype, device=dev)
-                norm = torch.empty(best.SPLIT_K * M, 1, dtype=acc_dtype, device=dev)
-                # Signature placeholder for the cuTile kernel; not read.
-                r = torch.empty(best.SPLIT_K * M, 1, dtype=acc_dtype, device=dev)
-                # Re-launch with best config for correct output.
-                ct.launch(
-                    stream,
-                    (math.ceil(M / best.TILE_M), best.SPLIT_K),
-                    _ct_proj_rms_fwd_kernel,
-                    (
-                        x,
-                        weight,
-                        proj,
-                        norm,
-                        r,
-                        M,
-                        N,
-                        K,
-                        eps,
-                        best.TILE_M,
-                        best.TILE_N,
-                        best.TILE_K,
-                        best.SPLIT_K,
-                    ),
-                )
-
-                sk = best.SPLIT_K
-                proj = proj.view(sk, M, N).to(torch.float32).sum(dim=0).to(dtype=acc_dtype)
-                norm = norm.view(sk, M, 1).to(torch.float32).sum(dim=0).to(dtype=acc_dtype)
-        norm = torch.sqrt(norm)
-        r = 1.0 / (norm / math.sqrt(K) + eps)
-        # Match native_proj_rms's dtype contract: the result follows the
-        # promoted input/parameter dtype (fp32 in mHC, where the mapping
-        # parameters are keep_in_fp32). `norm` stays fp32 for the backward.
-        out_dtype = torch.promote_types(x.dtype, weight.dtype)
-        return proj.to(out_dtype), norm, r.to(out_dtype)
 
     # -- Reduce + compute_h launcher ------------------------------------------
 
@@ -2174,112 +1907,6 @@ if _CUTILE_AVAILABLE:
             torch.promote_types(x.dtype, weight.dtype),
         )
         return h_pre, h_post, h_res, r, proj_reduced
-
-    def _proj_rms_bwd_autotune_configs(N):
-        """Generate autotune search space for proj_rms backward kernel (K >= 8192 path)."""
-        TILE_N = _next_power_of_2(N)
-        tile_ms = (32, 64, 128)
-        tile_ks = (32, 64, 128, 256)
-        for tile_m in tile_ms:
-            for tile_k in tile_ks:
-                yield {"TILE_SIZE_M": tile_m, "TILE_SIZE_N": TILE_N, "TILE_SIZE_K": tile_k}
-
-    _proj_rms_bwd_best_cfg: dict = {}
-
-    def _cutile_proj_rms_bwd(
-        grad_proj: Tensor,
-        grad_r: Tensor,
-        x: Tensor,
-        weight: Tensor,
-        norm: Tensor,
-        eps: float = 1e-6,
-    ) -> Tuple[Tensor, Tensor]:
-        M, K = x.shape
-        N = weight.shape[0]
-        da = torch.empty_like(x)
-        db = torch.empty_like(weight)
-        TILE_SIZE_N = _next_power_of_2(N)
-        assert TILE_SIZE_N <= 256, f"TILE_SIZE_N too large: {TILE_SIZE_N}"
-        stream = torch.cuda.current_stream()
-
-        if K >= 8192:
-            cache_key = (M, N, K)
-            cached = _proj_rms_bwd_best_cfg.get(cache_key)
-
-            if cached is not None or not _CUTILE_EXPERIMENTAL_AVAILABLE:
-                if cached is not None:
-                    tm, tn, tk = cached
-                else:
-                    tm, tn, tk = 128, TILE_SIZE_N, 128
-                ct.launch(
-                    stream,
-                    (math.ceil(K / tk), 1),
-                    _ct_proj_rms_bwd_kernel,
-                    (x, weight, norm, grad_proj, grad_r, da, db, M, N, K, eps, tm, tn, tk),
-                )
-            else:
-                from types import SimpleNamespace
-
-                configs = [SimpleNamespace(**c) for c in _proj_rms_bwd_autotune_configs(N)]
-                tuned = ct_experimental.autotune_launch(
-                    stream,
-                    grid_fn=lambda cfg: (math.ceil(K / cfg.TILE_SIZE_K), 1),
-                    kernel=_ct_proj_rms_bwd_kernel,
-                    args_fn=lambda cfg: (
-                        x,
-                        weight,
-                        norm,
-                        grad_proj,
-                        grad_r,
-                        da,
-                        db,
-                        M,
-                        N,
-                        K,
-                        eps,
-                        cfg.TILE_SIZE_M,
-                        cfg.TILE_SIZE_N,
-                        cfg.TILE_SIZE_K,
-                    ),
-                    search_space=configs,
-                )
-                best = tuned.tuned_config
-                _proj_rms_bwd_best_cfg[cache_key] = (
-                    best.TILE_SIZE_M,
-                    best.TILE_SIZE_N,
-                    best.TILE_SIZE_K,
-                )
-                ct.launch(
-                    stream,
-                    (math.ceil(K / best.TILE_SIZE_K), 1),
-                    _ct_proj_rms_bwd_kernel,
-                    (
-                        x,
-                        weight,
-                        norm,
-                        grad_proj,
-                        grad_r,
-                        da,
-                        db,
-                        M,
-                        N,
-                        K,
-                        eps,
-                        best.TILE_SIZE_M,
-                        best.TILE_SIZE_N,
-                        best.TILE_SIZE_K,
-                    ),
-                )
-        else:
-            num_sms = torch.cuda.get_device_properties("cuda").multi_processor_count
-            grid = (num_sms, 2, 1)
-            ct.launch(
-                stream,
-                grid,
-                _ct_proj_rms_bwd_small_k_kernel,
-                (x, weight, norm, grad_proj, grad_r, da, db, M, N, K, eps, TILE_SIZE_N),
-            )
-        return da, db
 
     # -- Fused compute_h + proj_rms backward kernels ----------------------------
 
@@ -2995,7 +2622,6 @@ from megatron.core.transformer.hyper_connection import (
     native_fused_add_3,
     native_h_aggregate,
     native_h_post_bda,
-    native_proj_rms,
     native_sinkhorn,
 )
 
@@ -3017,22 +2643,21 @@ def _mhc_backend_status() -> Tuple[str, bool]:
     h_aggregate_bwd = "cutile" if is_cutile_available() else "native"
     h_post_bda_fwd = _select_triton_cutile_native(_get_triton_h_post_bda_fwd())
     h_post_bda_bwd = _select_triton_cutile_native(_get_triton_h_post_bda_bwd())
-    proj_rms = "cutile" if is_cutile_available() else "native"
+    proj_rms_compute_h = "cutile" if is_cutile_available() else "native"
     selected = (
         sinkhorn,
         h_aggregate_fwd,
         h_aggregate_bwd,
         h_post_bda_fwd,
         h_post_bda_bwd,
-        proj_rms,
+        proj_rms_compute_h,
     )
     message = (
         f"MHC_FORCE_BACKEND={_MHC_FORCED_BACKEND}; "
         f"sinkhorn={sinkhorn}; "
         f"h_aggregate=fwd:{h_aggregate_fwd},bwd:{h_aggregate_bwd}; "
         f"h_post_bda=fwd:{h_post_bda_fwd},bwd:{h_post_bda_bwd}; "
-        f"proj_rms={proj_rms}; "
-        f"proj_rms_compute_h={proj_rms}"
+        f"proj_rms_compute_h={proj_rms_compute_h}"
     )
     return message, all(backend == "native" for backend in selected)
 
@@ -3200,24 +2825,6 @@ if _CUTILE_AVAILABLE:
             """Run cuTile h_aggregate backward."""
             x, h_pre = ctx.saved_tensors
             return _cutile_h_aggregate_bwd(grad_output, x, h_pre)
-
-    class CutileProjRms(torch.autograd.Function):
-        """cuTile projection + RMS normalization."""
-
-        @staticmethod
-        def forward(ctx, x: Tensor, weight: Tensor, eps: float = 1e-6):
-            """Run cuTile projection plus RMS normalization forward."""
-            proj, norm, r = _cutile_proj_rms_fwd(x, weight, eps)
-            ctx.save_for_backward(x, weight, norm)
-            ctx.eps = eps
-            return proj, r
-
-        @staticmethod
-        def backward(ctx, grad_proj, grad_r):
-            """Run cuTile projection plus RMS normalization backward."""
-            x, weight, norm = ctx.saved_tensors
-            grad_x, grad_weight = _cutile_proj_rms_bwd(grad_proj, grad_r, x, weight, norm, ctx.eps)
-            return grad_x, grad_weight, None
 
     class CutileProjRmsComputeH(torch.autograd.Function):
         """cuTile projection + RMS norm + compute_h activations."""
@@ -3397,23 +3004,6 @@ def fused_h_post_bda(
     if _TRITON_AVAILABLE or is_cutile_available():
         return FusedHPostBDA.apply(h_res, original_residual, h_post, x, bias)
     return native_h_post_bda(h_res, original_residual, h_post, x, bias)
-
-
-def fused_proj_rms(x: Tensor, weight: Tensor, eps: float = 1e-6) -> Tuple[Tensor, Tensor]:
-    """Projection + RMS normalization using cuTile, then torch."""
-    _raise_mhc_backend_validation_error()
-    if is_cutile_available():
-        # The cuTile kernels load and cast each tile independently, so they take
-        # the keep_in_fp32 weight against activation-dtype inputs directly.
-        # Upcasting x here would only materialize a full fp32 copy of the
-        # activations; bf16 -> fp32 is exact, so it would not buy any accuracy.
-        return CutileProjRms.apply(x, weight, eps)
-    if x.dtype != weight.dtype:
-        # native_proj_rms's matmul does reject mixed dtypes, and the copy is
-        # unavoidable on this branch. Promote rather than adopt the weight
-        # dtype so a lower-precision parameter cannot downcast the activations.
-        x = x.to(torch.promote_types(x.dtype, weight.dtype))
-    return native_proj_rms(x, weight, eps)
 
 
 def fused_proj_rms_compute_h(

--- a/megatron/core/fusions/fused_mhc_kernels.py
+++ b/megatron/core/fusions/fused_mhc_kernels.py
@@ -3401,6 +3401,11 @@ def fused_h_post_bda(
 def fused_proj_rms(x: Tensor, weight: Tensor, eps: float = 1e-6) -> Tuple[Tensor, Tensor]:
     """Projection + RMS normalization using cuTile, then torch."""
     _raise_mhc_backend_validation_error()
+    if x.dtype != weight.dtype:
+        # The mHC mapping parameters are keep_in_fp32 while activations arrive
+        # in the activation dtype. Normalize here so every backend consumes the
+        # same dtype and the native fallback's matmul does not reject the pair.
+        x = x.to(weight.dtype)
     if is_cutile_available():
         return CutileProjRms.apply(x, weight, eps)
     return native_proj_rms(x, weight, eps)

--- a/megatron/core/transformer/hyper_connection.py
+++ b/megatron/core/transformer/hyper_connection.py
@@ -216,11 +216,15 @@ class HyperConnectionModule(MegatronModule):
         # a trivial a+b+c) is not worth it for a pure memory-bound elementwise op.
         self._fused_add_3_op = native_fused_add_3
 
+        # The fused path computes the projection and compute_h in one op, so
+        # _projection_and_get_norm — and therefore _proj_rms_op — is only ever
+        # reached on the unfused path.
+        self._proj_rms_op = native_proj_rms
+
         if config.use_fused_mhc:
             from megatron.core.fusions.fused_mhc_kernels import (
                 fused_h_aggregate,
                 fused_h_post_bda,
-                fused_proj_rms,
                 fused_proj_rms_compute_h,
                 fused_sinkhorn,
                 log_fused_mhc_backend_once,
@@ -230,13 +234,11 @@ class HyperConnectionModule(MegatronModule):
             self._sinkhorn_op = fused_sinkhorn
             self._h_aggregate_op = fused_h_aggregate
             self._h_post_bda_op = fused_h_post_bda
-            self._proj_rms_op = fused_proj_rms
             self._proj_rms_compute_h_op = fused_proj_rms_compute_h
         else:
             self._sinkhorn_op = native_sinkhorn
             self._h_aggregate_op = native_h_aggregate
             self._h_post_bda_op = native_h_post_bda
-            self._proj_rms_op = native_proj_rms
             self._proj_rms_compute_h_op = None
 
         self._init_weights()

--- a/tests/unit_tests/fusions/test_fused_mhc_kernels.py
+++ b/tests/unit_tests/fusions/test_fused_mhc_kernels.py
@@ -1505,3 +1505,58 @@ class TestFusedProjRmsComputeHKeepFp32:
         h_pre, h_post, h_res, r = _torch_proj_rms_compute_h(x, w, one, one, one, bias, n, 1e-6)
         for t in (h_pre, h_post, h_res, r):
             assert torch.isfinite(t).all()
+
+
+class TestCutileHAggregateBackwardReduction:
+    """Regression: h_aggregate backward is the only other cuTile-only op.
+
+    `grad_h` is a reduction over the hidden dimension; evaluating the product
+    in bf16 before the fp32 accumulate made it ~2.5x noisier than the torch
+    reference at production widths.
+    """
+
+    @_require_cutile
+    @pytest.mark.parametrize("tokens,n,C", [(8192, 4, 1536), (2048, 4, 4096)])
+    def test_grad_h_reduction_not_worse_than_torch(self, tokens, n, C):
+        """cuTile grad_h must be at least as accurate as the torch reference."""
+        from megatron.core.fusions.fused_mhc_kernels import (
+            _cutile_h_aggregate_bwd,
+            _torch_h_aggregate_bwd,
+        )
+
+        _info()
+        s, b = 1, tokens
+        x = torch.randn(s, b, n, C, device=DEVICE, dtype=torch.float32).to(DTYPE)
+        h_pre = (torch.rand(s, b, n, device=DEVICE, dtype=torch.float32) + 0.5).to(DTYPE)
+        go = torch.randn(s, b, C, device=DEVICE, dtype=torch.float32).to(DTYPE)
+
+        goe = go.double().unsqueeze(2)
+        ref_gx = goe * h_pre.double().unsqueeze(-1)
+        ref_gh = (goe * x.double()).sum(-1)
+
+        def rel(a: Tensor, r: Tensor) -> float:
+            a, r = a.double().flatten(), r.double().flatten()
+            return ((a - r).pow(2).mean().sqrt() / r.pow(2).mean().sqrt()).item()
+
+        t_gx, t_gh = _torch_h_aggregate_bwd(go, x, h_pre)
+        c_gx, c_gh = _cutile_h_aggregate_bwd(go, x, h_pre)
+
+        # grad_x is a pure elementwise product — it must stay bit-identical.
+        assert torch.equal(c_gx, t_gx)
+        # A bf16 product before the fp32 accumulate showed up here as ~2.5x.
+        assert rel(c_gh, ref_gh) <= rel(t_gh, ref_gh) * 1.1
+
+
+class TestFusedProjRmsMixedDtype:
+    """Regression: every proj_rms backend must accept keep_in_fp32 parameters."""
+
+    @pytest.mark.parametrize("M,N,K", [(256, 24, 4096)])
+    def test_bf16_activations_fp32_weight(self, M, N, K):
+        """bf16 activations against an fp32 weight must not raise."""
+        from megatron.core.fusions.fused_mhc_kernels import fused_proj_rms
+
+        _info()
+        x = torch.randn(M, K, device=DEVICE, dtype=torch.bfloat16)
+        w = torch.randn(N, K, device=DEVICE, dtype=torch.float32) / math.sqrt(K)
+        proj, r = fused_proj_rms(x, w, 1e-6)
+        assert torch.isfinite(proj).all() and torch.isfinite(r).all()

--- a/tests/unit_tests/fusions/test_fused_mhc_kernels.py
+++ b/tests/unit_tests/fusions/test_fused_mhc_kernels.py
@@ -1426,3 +1426,82 @@ class TestEndToEndFusedBroadcast:
             COSINE_SIM_THRESH,
             msg="hidden_states grad (E2E backward, fused compute_h broadcast)",
         )
+
+
+class TestFusedProjRmsComputeHKeepFp32:
+    """Regression: the mHC mapping must stay fp32-accurate with bf16 activations.
+
+    HyperConnectionModule marks mapping_proj.weight / alpha_* / bias as
+    keep_in_fp32 and the unfused path upcasts the activations to fp32, so the
+    fused path must not silently degrade the mapping to the activation dtype.
+    Tolerances here are ~15x tighter than the module-level FWD_ATOL/RTOL: the
+    bug this guards against (bf16 split-K partials and bf16 mapping outputs)
+    cost 170x accuracy while staying well inside the loose tolerances.
+    """
+
+    # Native fp32 reference achieves ~8e-6 rms; the bf16-output bug gave ~1.5e-3.
+    MAPPING_RMS_TOL = 1e-4
+    # r is a pure reduction: native reaches ~5e-8, the bug gave ~2.7e-3.
+    R_RMS_TOL = 1e-5
+
+    @staticmethod
+    def _rms_rel(actual: Tensor, ref64: Tensor) -> float:
+        a = actual.detach().to(torch.float64)
+        r = ref64.detach().to(torch.float64)
+        return ((a - r).pow(2).mean().sqrt() / r.abs().max().clamp_min(1e-30)).item()
+
+    @pytest.mark.parametrize("M,n,hidden", [(256, 4, 4096), (128, 4, 1024)])
+    def test_bf16_activations_fp32_params(self, M, n, hidden):
+        """Fused mapping with production dtypes must match an fp64 reference."""
+        from megatron.core.fusions.fused_mhc_kernels import fused_proj_rms_compute_h
+
+        _info()
+        K = n * hidden
+        N = n * n + 2 * n
+        eps = compute_h_eps = 1e-6
+
+        # Activations arrive in bf16; the mapping parameters are keep_in_fp32.
+        x = torch.randn(M, K, device=DEVICE, dtype=torch.float32).to(torch.bfloat16)
+        w = torch.randn(N, K, device=DEVICE, dtype=torch.float32) / math.sqrt(K)
+        alpha_pre = torch.full((1,), 0.1, device=DEVICE, dtype=torch.float32)
+        alpha_post = torch.full((1,), 0.1, device=DEVICE, dtype=torch.float32)
+        alpha_res = torch.full((1,), 0.1, device=DEVICE, dtype=torch.float32)
+        bias = torch.randn(N, device=DEVICE, dtype=torch.float32) * 0.1
+
+        h_pre, h_post, h_res, r = fused_proj_rms_compute_h(
+            x, w, alpha_pre, alpha_post, alpha_res, bias, n, eps, compute_h_eps
+        )
+
+        # fp64 reference from the same input values.
+        x64, w64 = x.to(torch.float64), w.to(torch.float64)
+        proj64 = x64 @ w64.t()
+        r64 = x64.norm(dim=-1, keepdim=True) / math.sqrt(K)
+        alpha64 = torch.cat(
+            [
+                alpha_pre.to(torch.float64).expand(n),
+                alpha_post.to(torch.float64).expand(n),
+                alpha_res.to(torch.float64).expand(N - 2 * n),
+            ],
+            dim=-1,
+        )
+        h64 = proj64 * alpha64.unsqueeze(0) / (r64 + eps) + bias.to(torch.float64).unsqueeze(0)
+
+        assert self._rms_rel(h_pre, h64[..., :n].sigmoid() + compute_h_eps) < self.MAPPING_RMS_TOL
+        assert self._rms_rel(h_post, h64[..., n : 2 * n].sigmoid() * 2) < self.MAPPING_RMS_TOL
+        assert self._rms_rel(h_res, h64[..., 2 * n :]) < self.MAPPING_RMS_TOL
+        assert self._rms_rel(r, r64) < self.R_RMS_TOL
+
+    def test_native_fallback_accepts_mixed_dtypes(self):
+        """The native fallback must run with bf16 activations x fp32 parameters."""
+        from megatron.core.fusions.fused_mhc_kernels import _torch_proj_rms_compute_h
+
+        M, n, K = 64, 4, 512
+        N = n * n + 2 * n
+        x = torch.randn(M, K, device=DEVICE, dtype=torch.bfloat16)
+        w = torch.randn(N, K, device=DEVICE, dtype=torch.float32) / math.sqrt(K)
+        one = torch.full((1,), 0.1, device=DEVICE, dtype=torch.float32)
+        bias = torch.zeros(N, device=DEVICE, dtype=torch.float32)
+
+        h_pre, h_post, h_res, r = _torch_proj_rms_compute_h(x, w, one, one, one, bias, n, 1e-6)
+        for t in (h_pre, h_post, h_res, r):
+            assert torch.isfinite(t).all()

--- a/tests/unit_tests/fusions/test_fused_mhc_kernels.py
+++ b/tests/unit_tests/fusions/test_fused_mhc_kernels.py
@@ -527,7 +527,6 @@ class TestTritonHPostBDABwdE2EDebug:
             _triton_h_post_bda_bwd,
             fused_h_aggregate,
             fused_h_post_bda,
-            fused_proj_rms,
             fused_sinkhorn,
         )
 
@@ -544,7 +543,7 @@ class TestTritonHPostBDABwdE2EDebug:
         hs = hs_data.clone().requires_grad_(True)
         w = w_data.clone().requires_grad_(True)
         x_2d = hs.reshape(s * b, n * C)
-        proj, r = fused_proj_rms(x_2d, w, eps)
+        proj, r = native_proj_rms(x_2d, w, eps)
         proj = proj.view(s, b, -1)
         r = r.view(s, b, 1)
         h = r * proj
@@ -656,45 +655,6 @@ class TestNativeProjRms:
         proj_f, r_f = native_proj_rms(xf, wf, eps)
         (proj_f * grad_proj + r_f * grad_r).sum().backward()
 
-        xr = x_data.clone().requires_grad_(True)
-        wr = w_data.clone().requires_grad_(True)
-        proj_r, r_r = _ref_proj_rms(xr, wr, eps)
-        (proj_r * grad_proj + r_r * grad_r).sum().backward()
-
-        torch.testing.assert_close(proj_f, proj_r, atol=FWD_ATOL, rtol=FWD_RTOL)
-        torch.testing.assert_close(r_f, r_r, atol=FWD_ATOL, rtol=FWD_RTOL)
-        torch.testing.assert_close(
-            xf.grad, xr.grad, atol=BWD_ATOL, rtol=BWD_RTOL, msg="backward mismatch on x"
-        )
-        torch.testing.assert_close(
-            wf.grad, wr.grad, atol=BWD_ATOL, rtol=BWD_RTOL, msg="backward mismatch on weight"
-        )
-
-
-class TestFusedProjRms:
-    """Public fused proj_rms dispatch/fallback plus numerical correctness."""
-
-    @pytest.mark.flaky_in_dev
-    @_require_cutile
-    @pytest.mark.parametrize("M,N,K", [(256, 20, 4096), (64, 8, 512)])
-    def test_fwd_bwd_vs_reference(self, M, N, K):
-        """E2E: public fused fwd output and bwd grads must match the PyTorch reference."""
-        from megatron.core.fusions.fused_mhc_kernels import fused_proj_rms
-
-        _info()
-        eps = 1e-6
-        x_data = _rand(M, K)
-        w_data = _rand(N, K)
-        grad_proj = _rand(M, N)
-        grad_r = _rand(M, 1)
-
-        # -- fused path --
-        xf = x_data.clone().requires_grad_(True)
-        wf = w_data.clone().requires_grad_(True)
-        proj_f, r_f = fused_proj_rms(xf, wf, eps)
-        (proj_f * grad_proj + r_f * grad_r).sum().backward()
-
-        # -- reference path --
         xr = x_data.clone().requires_grad_(True)
         wr = w_data.clone().requires_grad_(True)
         proj_r, r_r = _ref_proj_rms(xr, wr, eps)
@@ -898,7 +858,6 @@ class TestEndToEndFused:
         from megatron.core.fusions.fused_mhc_kernels import (
             fused_h_aggregate,
             fused_h_post_bda,
-            fused_proj_rms,
             fused_sinkhorn,
         )
 
@@ -917,7 +876,7 @@ class TestEndToEndFused:
             w = w_data.clone().requires_grad_(True)
 
             x_2d = hs.reshape(s * b, n * C)
-            proj, r = fused_proj_rms(x_2d, w, eps)
+            proj, r = native_proj_rms(x_2d, w, eps)
             proj = proj.view(s, b, -1)
             r = r.view(s, b, 1)
 
@@ -1232,7 +1191,6 @@ class TestEndToEndFusedBroadcast:
             fused_add_3,
             fused_h_aggregate,
             fused_h_post_bda,
-            fused_proj_rms,
             fused_sinkhorn,
         )
         from megatron.core.transformer.hyper_connection import BroadcastTensorFused
@@ -1254,7 +1212,7 @@ class TestEndToEndFusedBroadcast:
             hs_map, hs_agg, hs_res = BroadcastTensorFused.apply(hs, fused_add_3)
 
             x_2d = hs_map.reshape(s * b, n * C)
-            proj, r = fused_proj_rms(x_2d, w, eps)
+            proj, r = native_proj_rms(x_2d, w, eps)
             proj = proj.view(s, b, -1)
             r = r.view(s, b, 1)
 
@@ -1506,6 +1464,36 @@ class TestFusedProjRmsComputeHKeepFp32:
         for t in (h_pre, h_post, h_res, r):
             assert torch.isfinite(t).all()
 
+    @_require_cutile
+    def test_no_fp32_activation_copy(self):
+        """cuTile must consume the bf16 activations, not an fp32 copy of them.
+
+        The kernels load and cast each tile independently, so normalizing the
+        activation dtype ahead of the launch would only cost memory.
+        """
+        from megatron.core.fusions.fused_mhc_kernels import fused_proj_rms_compute_h
+
+        _info()
+        M, n, hidden = 4096, 4, 4096
+        K, N = n * hidden, n * n + 2 * n
+        x = torch.randn(M, K, device=DEVICE, dtype=torch.bfloat16)
+        w = torch.randn(N, K, device=DEVICE, dtype=torch.float32) / math.sqrt(K)
+        one = torch.full((1,), 0.1, device=DEVICE, dtype=torch.float32)
+        bias = torch.zeros(N, device=DEVICE, dtype=torch.float32)
+
+        torch.cuda.synchronize()
+        torch.cuda.reset_peak_memory_stats()
+        before = torch.cuda.memory_allocated()
+        fused_proj_rms_compute_h(x, w, one, one, one, bias, n, 1e-6)
+        torch.cuda.synchronize()
+        peak = torch.cuda.max_memory_allocated() - before
+
+        fp32_activation_copy = M * K * 4
+        assert peak < fp32_activation_copy // 2, (
+            f"peak allocation {peak} suggests the activations were upcast "
+            f"(an fp32 copy of x is {fp32_activation_copy} bytes)"
+        )
+
     def test_public_entry_point_native_branch(self, monkeypatch):
         """The public op must also run natively — this is the forced-native path.
 
@@ -1568,61 +1556,3 @@ class TestCutileHAggregateBackwardReduction:
         assert torch.equal(c_gx, t_gx)
         # A bf16 product before the fp32 accumulate showed up here as ~2.5x.
         assert rel(c_gh, ref_gh) <= rel(t_gh, ref_gh) * 1.1
-
-
-class TestFusedProjRmsMixedDtype:
-    """Regression: every proj_rms backend must accept keep_in_fp32 parameters.
-
-    The standalone entry point is not on the training path (compute_mappings
-    uses the fused compute_h op), but it must still work with bf16 activations
-    against an fp32 weight, and it must not pay for that with a full fp32 copy
-    of the activations on the cuTile branch.
-    """
-
-    @pytest.mark.parametrize("M,N,K", [(4096, 24, 16384)])
-    def test_cutile_takes_mixed_dtypes_without_copying_activations(self, M, N, K):
-        """cuTile consumes bf16 activations directly, with no fp32 copy of x."""
-        from megatron.core.fusions.fused_mhc_kernels import fused_proj_rms, is_cutile_available
-
-        _info()
-        if not is_cutile_available():
-            pytest.skip("cuTile unavailable for current device")
-
-        x = torch.randn(M, K, device=DEVICE, dtype=torch.bfloat16)
-        w = torch.randn(N, K, device=DEVICE, dtype=torch.float32) / math.sqrt(K)
-
-        torch.cuda.synchronize()
-        torch.cuda.reset_peak_memory_stats()
-        before = torch.cuda.memory_allocated()
-        proj, r = fused_proj_rms(x, w, 1e-6)
-        torch.cuda.synchronize()
-        peak = torch.cuda.max_memory_allocated() - before
-
-        # An fp32 copy of x alone would be M * K * 4 bytes.
-        fp32_activation_copy = M * K * 4
-        assert peak < fp32_activation_copy // 2, (
-            f"peak allocation {peak} suggests the activations were upcast "
-            f"(an fp32 copy of x is {fp32_activation_copy} bytes)"
-        )
-
-        # Accuracy against an fp64 reference built from the same input values.
-        x64, w64 = x.to(torch.float64), w.to(torch.float64)
-        ref_proj = x64 @ w64.t()
-        ref_r = 1.0 / (x64.norm(dim=-1, keepdim=True) / math.sqrt(K) + 1e-6)
-        for got, ref, name in ((proj, ref_proj, "proj"), (r, ref_r, "r")):
-            got64, ref64 = got.to(torch.float64), ref
-            rms = ((got64 - ref64).pow(2).mean().sqrt() / ref64.abs().max().clamp_min(1e-30)).item()
-            assert rms < 1e-4, f"{name} rms rel err {rms:.3e}"
-
-    @pytest.mark.parametrize("M,N,K", [(256, 24, 4096)])
-    def test_native_branch_accepts_mixed_dtypes(self, M, N, K, monkeypatch):
-        """With cuTile unavailable the native branch must still run."""
-        from megatron.core.fusions import fused_mhc_kernels as fused_mod
-
-        _info()
-        monkeypatch.setattr(fused_mod, "is_cutile_available", lambda: False)
-
-        x = torch.randn(M, K, device=DEVICE, dtype=torch.bfloat16)
-        w = torch.randn(N, K, device=DEVICE, dtype=torch.float32) / math.sqrt(K)
-        proj, r = fused_mod.fused_proj_rms(x, w, 1e-6)
-        assert torch.isfinite(proj).all() and torch.isfinite(r).all()

--- a/tests/unit_tests/fusions/test_fused_mhc_kernels.py
+++ b/tests/unit_tests/fusions/test_fused_mhc_kernels.py
@@ -1506,6 +1506,29 @@ class TestFusedProjRmsComputeHKeepFp32:
         for t in (h_pre, h_post, h_res, r):
             assert torch.isfinite(t).all()
 
+    def test_public_entry_point_native_branch(self, monkeypatch):
+        """The public op must also run natively — this is the forced-native path.
+
+        MHC_FORCE_BACKEND=native and an auto run on a cuTile-less container both
+        land here, and the module always calls the public op when
+        use_fused_mhc=True, so this branch is what a real training job hits.
+        """
+        from megatron.core.fusions import fused_mhc_kernels as fused_mod
+
+        _info()
+        monkeypatch.setattr(fused_mod, "is_cutile_available", lambda: False)
+
+        M, n, K = 64, 4, 512
+        N = n * n + 2 * n
+        x = torch.randn(M, K, device=DEVICE, dtype=torch.bfloat16)
+        w = torch.randn(N, K, device=DEVICE, dtype=torch.float32) / math.sqrt(K)
+        one = torch.full((1,), 0.1, device=DEVICE, dtype=torch.float32)
+        bias = torch.zeros(N, device=DEVICE, dtype=torch.float32)
+
+        outs = fused_mod.fused_proj_rms_compute_h(x, w, one, one, one, bias, n, 1e-6)
+        for t in outs:
+            assert torch.isfinite(t).all()
+
 
 class TestCutileHAggregateBackwardReduction:
     """Regression: h_aggregate backward is the only other cuTile-only op.
@@ -1548,15 +1571,58 @@ class TestCutileHAggregateBackwardReduction:
 
 
 class TestFusedProjRmsMixedDtype:
-    """Regression: every proj_rms backend must accept keep_in_fp32 parameters."""
+    """Regression: every proj_rms backend must accept keep_in_fp32 parameters.
 
-    @pytest.mark.parametrize("M,N,K", [(256, 24, 4096)])
-    def test_bf16_activations_fp32_weight(self, M, N, K):
-        """bf16 activations against an fp32 weight must not raise."""
-        from megatron.core.fusions.fused_mhc_kernels import fused_proj_rms
+    The standalone entry point is not on the training path (compute_mappings
+    uses the fused compute_h op), but it must still work with bf16 activations
+    against an fp32 weight, and it must not pay for that with a full fp32 copy
+    of the activations on the cuTile branch.
+    """
+
+    @pytest.mark.parametrize("M,N,K", [(4096, 24, 16384)])
+    def test_cutile_takes_mixed_dtypes_without_copying_activations(self, M, N, K):
+        """cuTile consumes bf16 activations directly, with no fp32 copy of x."""
+        from megatron.core.fusions.fused_mhc_kernels import fused_proj_rms, is_cutile_available
 
         _info()
+        if not is_cutile_available():
+            pytest.skip("cuTile unavailable for current device")
+
         x = torch.randn(M, K, device=DEVICE, dtype=torch.bfloat16)
         w = torch.randn(N, K, device=DEVICE, dtype=torch.float32) / math.sqrt(K)
+
+        torch.cuda.synchronize()
+        torch.cuda.reset_peak_memory_stats()
+        before = torch.cuda.memory_allocated()
         proj, r = fused_proj_rms(x, w, 1e-6)
+        torch.cuda.synchronize()
+        peak = torch.cuda.max_memory_allocated() - before
+
+        # An fp32 copy of x alone would be M * K * 4 bytes.
+        fp32_activation_copy = M * K * 4
+        assert peak < fp32_activation_copy // 2, (
+            f"peak allocation {peak} suggests the activations were upcast "
+            f"(an fp32 copy of x is {fp32_activation_copy} bytes)"
+        )
+
+        # Accuracy against an fp64 reference built from the same input values.
+        x64, w64 = x.to(torch.float64), w.to(torch.float64)
+        ref_proj = x64 @ w64.t()
+        ref_r = 1.0 / (x64.norm(dim=-1, keepdim=True) / math.sqrt(K) + 1e-6)
+        for got, ref, name in ((proj, ref_proj, "proj"), (r, ref_r, "r")):
+            got64, ref64 = got.to(torch.float64), ref
+            rms = ((got64 - ref64).pow(2).mean().sqrt() / ref64.abs().max().clamp_min(1e-30)).item()
+            assert rms < 1e-4, f"{name} rms rel err {rms:.3e}"
+
+    @pytest.mark.parametrize("M,N,K", [(256, 24, 4096)])
+    def test_native_branch_accepts_mixed_dtypes(self, M, N, K, monkeypatch):
+        """With cuTile unavailable the native branch must still run."""
+        from megatron.core.fusions import fused_mhc_kernels as fused_mod
+
+        _info()
+        monkeypatch.setattr(fused_mod, "is_cutile_available", lambda: False)
+
+        x = torch.randn(M, K, device=DEVICE, dtype=torch.bfloat16)
+        w = torch.randn(N, K, device=DEVICE, dtype=torch.float32) / math.sqrt(K)
+        proj, r = fused_mod.fused_proj_rms(x, w, 1e-6)
         assert torch.isfinite(proj).all() and torch.isfinite(r).all()


### PR DESCRIPTION
## Summary

`HyperConnectionModule` treats the mHC mapping as an fp32 computation — `mapping_proj.weight`, `alpha_*` and `bias` are `mark_keep_in_fp32`, and the unfused path upcasts activations to fp32 in `_projection_and_get_norm`. The fused path (`compute_mappings`, taken whenever `use_fused_mhc=True`) does not upcast, and the cuTile launchers allocated every split-K partial and every mapping output as `x.dtype`. So `h_pre`, `h_post`, `h_res` and `r` were rounded to bf16, and `h_res` then entered Sinkhorn in bf16 where the iterative row/column normalization compounds the error.

Measured on GB200 (M=4096, n=4, hidden=7168, bf16 activations) against an fp64 reference computed from the *same* input values:

| metric | native path | cuTile before | cuTile after |
| --- | --- | --- | --- |
| `h_pre` rms rel err | 8.38e-06 | 1.56e-03 | 8.32e-06 |
| `h_res` after Sinkhorn | 1.10e-05 | 1.89e-03 | 1.09e-05 |
| Sinkhorn row-sum deviation from 1 | 9.21e-06 | 2.93e-03 | 9.25e-06 |
| `r` rms rel err | — | 2.74e-03 | 4.75e-08 |
| bwd `grad_bias` rms rel err | — | 1.00e-03 | 3.77e-07 |

The doubly-stochastic property of `h_res` is an mHC manifold constraint, so the 318x degradation there is a structural violation rather than ordinary drift. The error was flat across K (4096→28672), SPLIT_K (1/8/16), token count and input magnitude, which points at bf16 rounding rather than accumulation order. With fp32 inputs cuTile and native already agreed to the last digit, so the kernels themselves were sound.

Five commits:

1. **Mapping in fp32.** Split-K partials and mapping outputs are allocated in fp32; returned tensors follow `torch.promote_types(x.dtype, weight.dtype)`, so the public dtype contract is unchanged for an all-bf16 caller. Also squares in fp32 in `_ct_proj_rms_fwd_kernel` (a bf16 square left `r` at 2.7e-03 even once the outputs were widened), upcasts the A tile before `_ct_rms_dnorm` in `_ct_proj_rms_bwd_kernel` to match the small-K kernel, and upcasts `x` in `_torch_proj_rms_compute_h`. That last one is a separate runtime bug: the fused op has no Triton implementation, so without cuTile it fell back to a matmul of bf16 activations against the fp32 weight and raised `expected mat1 and mat2 to have the same dtype` — bf16 mHC could not run natively at all, which is also why the divergence went unnoticed.

2. **`h_aggregate` backward.** `grad_h` reduces over the hidden dimension; the product was evaluated in bf16 before the fp32 accumulate. At 8192 tokens × 1536, n=4: 0.581% off an fp64 reference versus 0.234% for the torch reference (2.5x). With the product in fp32 it is 0.166%. `grad_x` was and remains bit-identical.

3. **Remaining fallback + coverage.** `fused_proj_rms`'s native branch had the same mixed-dtype problem.

4. **No activation copy on the cuTile branch.** Commit 3 normalized dtypes *before* dispatch, which made the cuTile branch materialize a full fp32 copy of the activations it never needed — the cuTile kernels load and cast each tile independently, exactly as the fused compute_h op already does. The upcast now happens only on the native branch, where `torch.matmul` genuinely requires it. Both normalizations promote rather than adopt the weight dtype, so an fp32 activation against a lower-precision parameter cannot be silently downcast.

5. **Remove the unreachable `fused_proj_rms`.** Its only non-test reference was `self._proj_rms_op = fused_proj_rms`, and `_proj_rms_op` is invoked only from `_projection_and_get_norm`, which runs only when `_proj_rms_compute_h_op is None` — i.e. when `use_fused_mhc=False`, where `_proj_rms_op` is `native_proj_rms`. Neither configuration reaches it, because the fused path computes the projection and `compute_h` in one op. The entry point and everything that existed only to serve it — `CutileProjRms`, `_cutile_proj_rms_fwd`/`_bwd`, both `_ct_proj_rms_bwd` kernels, `_ct_rms_dnorm` and the backward autotune config/cache — are removed: 424 lines of cuTile code with no caller. `_ct_proj_rms_fwd_kernel` and its config/cache helpers stay (the fused compute_h forward shares them), as does `native_proj_rms` (still used by the unfused path). This also retires the redundant `.to(torch.float32).sum(dim=0).to(dtype=acc_dtype)` casts noted in review — they lived in the deleted launcher.

## Performance

The activations stay in bf16 — no fp32 copy of `x` on any cuTile path — so only the `[M, n²+2n]` and `[M, 1]` tensors widen. mHC runs inside a CUDA graph and these regions are ~0.1 ms of small kernels, so the benchmark captures each region as a graph and times back-to-back replays rather than using per-call CUDA events:

| region (M=4096, hidden=7168) | before | after |
| --- | --- | --- |
| `proj_rms_compute_h` fwd | 0.0985 ms | 0.0759 ms (−23%) |
| `proj_rms_compute_h` fwd+bwd | 0.3944 ms | 0.3495 ms (−11%) |
| `compute_mappings` chain incl. Sinkhorn | 0.1023 ms | 0.0840 ms (−18%) |

It is faster because the wider accumulators remove the fp32→bf16→fp32 round trips around the split-K reduction. Split-K partial buffers double, 3.6 MB → 7.3 MB at M=4096. E2E step time on a 4-GPU dev proxy: 655.5 ms vs 654.0 ms, i.e. neutral.

## Test plan

- `pytest tests/unit_tests/fusions/test_fused_mhc_kernels.py` on GB200: **68 passed** at the head of the branch (66 through commit 2, before the later additions and the removal of the tests that covered the deleted API). `tests/unit_tests/transformer/test_hyper_connection_recompute.py`: 8 passed, covering the module rewiring in commit 5.
- New regression tests, all run against the parent commit to confirm they are real guards — `TestFusedProjRmsComputeHKeepFp32::test_bf16_activations_fp32_params[256-4-4096]` and `TestCutileHAggregateBackwardReduction::test_grad_h_reduction_not_worse_than_torch[8192-4-1536]` both **fail** there:
  - fused mapping op with bf16 activations against fp32 parameters, at tolerances ~15x tighter than the module-level ones, against an fp64 reference;
  - `h_aggregate` backward at production widths (8192×1536 and 2048×4096), asserting cuTile's `grad_h` is no worse than the torch reference and that `grad_x` stays bit-identical;
  - `fused_proj_rms` on the cuTile branch with mixed dtypes, asserting accuracy *and* that peak allocation stays below half the size of an fp32 copy of `x`;
  - both public entry points with cuTile monkeypatched off — the forced-native path. The module always calls the public op when `use_fused_mhc=True`, so this is what `MHC_FORCE_BACKEND=native` and any cuTile-less container hit; testing `_torch_proj_rms_compute_h` directly was not enough.
- The removal in commit 5 is behavior-preserving on the executed path. 100-iteration 4-GPU DSv3-proxy runs with `use_fused_mhc=True`, before and after the commit, produce **bit-identical** loss curves on the cuTile backend and, in a same-node controlled comparison, on the forced-native backend as well. (A first native comparison across two different nodes differed at the 7th significant digit from iteration 3; re-running both trees on one node made them identical, and two runs of the same tree on one node are also identical, so that was `torch.compile` picking different kernels per machine, not the change.)
- E2E: DSv3 dev proxy, 4×GB200, `use_fused_mhc: true`, 100 iterations, three arms (patched cuTile / patched with `MHC_DISABLE_CUTILE=1` / unpatched cuTile). No NaNs, step time unchanged. The loss itself cannot discriminate at this scale — it is logged to ~1e-6 relative and the arms diverge chaotically on mock data from iteration ~6 — so this run bounds the blast radius rather than measuring it.

Existing coverage could not catch any of this: the module-level tolerances are `atol/rtol` 2e-2 forward and 5e-2 backward with `uniform(-0.1, 0.1)` inputs, and no test exercised bf16 activations against an fp32 weight or the native fallback through a public entry point.

## Open questions for reviewers

- **fp32 contract.** The cuTile projection uses TF32 MMA. For bf16 inputs that is lossless, and in the containers checked `torch.backends.cuda.matmul.allow_tf32=True` / `float32_matmul_precision=high`, so native matmul takes the same path — measured fp32-in/fp32-out agreement is exact. If mHC is meant to be strict IEEE fp32 rather than "fp32 tensors, TF32 tensor-core compute", that should be stated and the MMA changed accordingly.
- **Same values vs. same storage dtype.** cuTile consumes bf16 activations directly against the fp32 weight; bf16→fp32 is exact, so both backends see the same *numbers* even though the storage dtypes differ, and the measured outputs match the native path. Forcing identical storage dtypes would cost a full fp32 copy of `x` per layer. Happy to switch if reviewers prefer that.
- **`h_aggregate` bit-parity.** Casting the operands makes cuTile slightly *more* accurate than torch; casting only the product would instead reproduce torch bit-for-bit. This PR chose accuracy, and the test asserts "no worse than torch" rather than equality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
