### PR TITLE
[Dev] Account for Qwen3.5 vision encoder FLOPs

### DIFF
--- a/docs/models/multimodal.md
+++ b/docs/models/multimodal.md
@@ -40,6 +40,22 @@ See [examples/mimo](https://github.com/NVIDIA/Megatron-LM/tree/main/examples/mim
 | **CLIP ViT** | OpenAI's CLIP Vision Transformer | Image-text alignment, multiple scales (L/14@336px) |
 | **RADIO** | Resolution-Agnostic Dynamic Image Optimization | Flexible resolution handling, efficient vision encoding |
 
+## Training FLOPs Accounting
+
+Multimodal training entry points can add encoder work to Megatron's model FLOPs
+and throughput metrics by attaching a supported vision FLOPs variant and its
+architecture metadata to the training args. Qwen3.5-VL accounts for its patch
+projection, vision Transformer attention and MLP projections, and patch merger
+on top of the language decoder estimate.
+
+The `examples/multimodal_dev` path also accumulates the actual
+`image_grid_thw` shapes used in each training iteration. Variable-resolution
+inputs therefore scale the vision attention term with the packed
+per-temporal-frame sequence lengths and scale token-linear operations with the
+real number of patches and merged tokens. See
+`examples/multimodal_dev/README.md` for the registry contract and exact
+accounting behavior.
+
 ## Diffusion Models
 
 For multimodal diffusion models (image generation, text-to-image). Refer to [Nvidia Diffusion Models](https://github.com/NVIDIA-NeMo/DFM/ ). The Developer Program, NIM, and NeMo can offer production-ready implementations of:

--- a/examples/multimodal_dev/README.md
+++ b/examples/multimodal_dev/README.md
@@ -141,7 +141,7 @@ def post_language_config(language_config, args):
 def set_vision_flops_metadata(args, language_config, vision_config):
     """(Optional) Set vision FLOPs metadata on args."""
     args.count_vision_model_flops = True
-    args.vision_flops_variant = "llava_next"
+    args.vision_flops_variant = "llava_next"  # requires a matching core calculator
     # ... set dimension fields for FLOPs calculation
 
 def build_model(args, language_config, vision_config, **kwargs):
@@ -220,3 +220,30 @@ torchrun --nproc_per_node=8 multimodal_dev/pretrain_multimodal.py \
 | `post_language_config_fn` | No | `(language_config, args) -> None` |
 | `vision_flops_fn` | No | `(args, language_config, vision_config) -> None` |
 | `dataset_providers` | No | `Dict[str, str \| callable]` |
+
+## Vision FLOPs Accounting
+
+Training throughput uses `megatron.training.training.num_floating_point_operations`.
+Architectures opt in through `vision_flops_fn`, which sets a supported
+`vision_flops_variant` plus the vision model dimensions on the global args.
+Enabling an unknown variant or omitting required metadata is an error rather
+than silently reporting decoder-only FLOPs.
+
+For Qwen3.5-VL, the estimate includes the dominant training matrix operations
+from:
+
+- the Conv3d patch projection;
+- every vision Transformer layer's dense QKV/output projections, bidirectional
+  attention, and two-linear GELU MLP; and
+- both patch-merger projections.
+
+`forward_step` records the actual `(T, H, W)` values from every
+`image_grid_thw` microbatch. The training loop globally reduces three
+sufficient statistics: total input patches, the per-temporal-frame
+`sum(sequence_length^2)` used by packed vision attention, and the number of
+post-merger tokens. This makes variable-resolution and multi-image batches use
+their real vision work. If runtime grids are unavailable, the calculator falls
+back to the architecture's nominal `image_size` metadata.
+
+As in the language-model estimate, small elementwise work such as LayerNorm,
+GELU, RoPE, interpolation, and residual additions is intentionally omitted.

--- a/examples/multimodal_dev/README.md
+++ b/examples/multimodal_dev/README.md
@@ -199,10 +199,18 @@ def post_language_config(language_config, args):
     pass
 
 def set_vision_flops_metadata(args, language_config, vision_config):
-    """(Optional) Set vision FLOPs metadata on args."""
+    """(Optional) Set vision FLOPs metadata on args.
+
+    Omit this function entirely unless megatron.training.training implements
+    a FLOPs calculator for THIS architecture -- "qwen35_vl" is the only
+    variant today, and naming it from a different architecture would report
+    Qwen3.5-VL's formula for your model. An unrecognised variant is rejected
+    at model-construction time.
+    """
     args.count_vision_model_flops = True
-    args.vision_flops_variant = "llava_next"
-    # ... set dimension fields for FLOPs calculation
+    args.vision_flops_variant = "<variant implemented in megatron/training/training.py>"
+    # ... set the vision_* dimension fields that variant requires;
+    # see models/qwen35_vl/factory.py:set_vision_flops_metadata
 
 def build_model(args, language_config, vision_config, **kwargs):
     """(Required) Build and return the complete model instance."""
@@ -276,3 +284,41 @@ torchrun --nproc_per_node=8 multimodal_dev/pretrain_multimodal.py \
 | `post_language_config_fn` | No | `(language_config, args) -> None` |
 | `vision_flops_fn` | No | `(args, language_config, vision_config) -> None` |
 | `dataset_providers` | No | `Dict[str, str \| callable]` |
+
+## Vision FLOPs Accounting
+
+Training throughput uses `megatron.training.training.num_floating_point_operations`.
+Architectures opt in through `vision_flops_fn`, which sets a supported
+`vision_flops_variant` plus the vision model dimensions on the global args
+(see `qwen35_vl/factory.py:set_vision_flops_metadata`). `model_provider`
+validates the result centrally right after calling `vision_flops_fn`, via
+`megatron.training.training.validate_vision_flops_metadata(args)` --
+individual `vision_flops_fn` implementations do not need to call it
+themselves. Enabling an unknown variant or omitting required metadata is an
+error rather than silently reporting decoder-only FLOPs, raised at
+model-construction time rather than at the first training iteration.
+
+For Qwen3.5-VL, the estimate includes the dominant training matrix operations
+from:
+
+- the Conv3d patch projection;
+- every vision Transformer layer's dense QKV/output projections, bidirectional
+  attention, and two-linear GELU MLP; and
+- both patch-merger projections.
+
+`forward_step` records the actual `(T, H, W)` values from every
+`image_grid_thw` microbatch. The training loop globally reduces three
+sufficient statistics: total input patches, the per-temporal-frame
+`sum(sequence_length^2)` used by packed vision attention, and the number of
+post-merger tokens. This makes variable-resolution, multi-image, text-only and
+packed-sequence batches use their real vision work.
+
+The runtime statistics are the only input to the vision terms. An entry point
+that enables `count_vision_model_flops` without calling
+`update_vision_model_flops_stats` from its forward step gets decoder-only
+FLOPs plus a one-time warning, not an estimate synthesised from nominal
+architecture metadata — a fabricated-but-plausible figure would silently
+corrupt MFU comparisons and perf regression tracking.
+
+As in the language-model estimate, small elementwise work such as LayerNorm,
+GELU, RoPE, interpolation, and residual additions is intentionally omitted.

--- a/examples/multimodal_dev/forward_step.py
+++ b/examples/multimodal_dev/forward_step.py
@@ -18,6 +18,7 @@ from megatron.core.parallel_state import (
     get_tensor_model_parallel_src_rank,
 )
 from megatron.training import get_args
+from megatron.training.training import update_vision_model_flops_stats
 
 # -------------------------------------------------------------------
 # dtype <-> int mapping for cross-rank broadcast
@@ -400,6 +401,13 @@ def forward_step(data_iterator, model):
     if batch is None:
         return None, None
 
+    args = get_args()
+    image_grid_thw = batch.get("image_grid_thw", None)
+    if getattr(model, "training", True) and getattr(args, "count_vision_model_flops", False):
+        update_vision_model_flops_stats(
+            image_grid_thw, spatial_merge_size=args.vision_spatial_merge_size
+        )
+
     pixel_values = batch.get("pixel_values", None)
     if (
         pixel_values is not None
@@ -417,7 +425,7 @@ def forward_step(data_iterator, model):
         loss_mask=batch.get("loss_mask", None),
         padding_mask=batch.get("padding_mask", None),
         pixel_values=pixel_values,
-        image_grid_thw=batch.get("image_grid_thw", None),
+        image_grid_thw=image_grid_thw,
         packed_seq_params=batch.get("packed_seq_params", None),
     )
 

--- a/examples/multimodal_dev/forward_step.py
+++ b/examples/multimodal_dev/forward_step.py
@@ -17,7 +17,9 @@ from megatron.core.parallel_state import (
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_src_rank,
 )
+from megatron.core.rerun_state_machine import RerunState, get_rerun_state_machine
 from megatron.training import get_args
+from megatron.training.training import update_vision_model_flops_stats
 
 # -------------------------------------------------------------------
 # dtype <-> int mapping for cross-rank broadcast
@@ -393,9 +395,49 @@ def loss_func(loss_mask, output_tensor):
 # -------------------------------------------------------------------
 
 
+def record_vision_model_flops(args, model, batch):
+    """Report this microbatch's vision grids to the FLOPs accumulator.
+
+    Called from :func:`forward_step` BEFORE its ``batch is None``
+    early-return, so a rank whose data iterator ran dry still reports an
+    explicit zero (``grid_thw=None``) instead of silently dropping its share
+    of the global batch. Entering the collective in
+    ``consume_vision_model_flops_stats`` is keyed off
+    ``args.count_vision_model_flops`` alone, so a missed report here cannot
+    desync the job -- it would only skew the reported number.
+
+    Two executions of a microbatch must not both be counted:
+
+    * ``model.training`` excludes ``evaluate()``, which calls
+      ``model.eval()``. ``evaluate()`` reuses this same forward step but never
+      drains the accumulator, so anything it added would leak into the next
+      ``train()`` iteration.
+    * ``RerunState.RERUNNING_IN_PLACE`` excludes the rerun state machine's
+      in-place replay of the SAME microbatches (``--check-for-nan-in-loss`` /
+      ``--check-for-spiky-loss``), which re-executes with the model still in
+      train mode. The accepted execution is the initial run, whose
+      contribution is already in the accumulator; the replay must add nothing.
+      The other rerun states replay in a freshly restarted process, whose
+      accumulator starts empty.
+    """
+    if not getattr(args, "count_vision_model_flops", False):
+        return
+    if not getattr(model, "training", True):
+        return
+    if get_rerun_state_machine().state == RerunState.RERUNNING_IN_PLACE:
+        return
+    update_vision_model_flops_stats(
+        batch.get("image_grid_thw", None) if batch is not None else None,
+        spatial_merge_size=getattr(args, "vision_spatial_merge_size", None),
+    )
+
+
 def forward_step(data_iterator, model):
     """Forward step for multimodal_dev training."""
     batch = get_batch(data_iterator)
+
+    args = get_args()
+    record_vision_model_flops(args, model, batch)
 
     if batch is None:
         return None, None

--- a/examples/multimodal_dev/models/qwen35_vl/factory.py
+++ b/examples/multimodal_dev/models/qwen35_vl/factory.py
@@ -32,9 +32,19 @@ def post_language_config(language_config, args):
 
 
 def set_vision_flops_metadata(args, language_config, vision_config):
-    """Expose Qwen3.5-VL vision-model dimensions for FLOPs estimation."""
+    """Expose Qwen3.5-VL vision-model dimensions for FLOPs estimation.
+
+    ``pretrain_multimodal.py:model_provider`` calls
+    ``megatron.training.training.validate_vision_flops_metadata(args)`` right
+    after invoking this function, so the fields set here are validated (and
+    derived scalars precomputed) centrally -- this function does not need to
+    call it itself.
+    """
     args.count_vision_model_flops = True
-    args.vision_flops_variant = "qwen35_vl_v2"
+    # No "v1"/"v2" versioning exists for this variant; matches the
+    # "qwen35_vl" model-arch registry key used everywhere else in
+    # examples/multimodal_dev.
+    args.vision_flops_variant = "qwen35_vl"
     args.vision_num_layers = vision_config.num_layers
     args.vision_hidden_size = vision_config.hidden_size
     args.vision_ffn_hidden_size = vision_config.ffn_hidden_size

--- a/examples/multimodal_dev/pretrain_multimodal.py
+++ b/examples/multimodal_dev/pretrain_multimodal.py
@@ -38,6 +38,7 @@ from megatron.core.enums import ModelType
 from megatron.training import get_args, pretrain
 from megatron.training.argument_utils import pretrain_cfg_container_from_args
 from megatron.training.arguments import core_transformer_config_from_args, parse_and_validate_args
+from megatron.training.training import validate_vision_flops_metadata
 from megatron.training.utils import start_memory_history_recording
 
 
@@ -90,6 +91,13 @@ def model_provider(
     vision_flops_fn = registry.get("vision_flops_fn")
     if vision_flops_fn is not None:
         vision_flops_fn(args, language_config, vision_config)
+        # Validate centrally here (not left to each vision_flops_fn to
+        # remember) so a future architecture that sets
+        # count_vision_model_flops=True without calling this itself still
+        # gets an eager, actionable error instead of a confusing
+        # AttributeError the first time FLOPs are computed. Idempotent, so
+        # this is harmless if an implementation also calls it directly.
+        validate_vision_flops_metadata(args)
 
     # --- build model (fully delegated to the arch factory) ---
     model = registry["model_factory_fn"](

--- a/examples/multimodal_dev/tests/test_vision_flops_accounting.py
+++ b/examples/multimodal_dev/tests/test_vision_flops_accounting.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Tests for the ``forward_step`` side of vision FLOPs accounting.
+
+The FLOPs formula and the accumulator math live in
+``tests/unit_tests/test_num_floating_point_operations.py``. What is pinned
+here is the gate that decides WHETHER a microbatch is reported: only the
+accepted training execution may contribute, so a rerun-state-machine replay
+of the same microbatches must not double-count, and ``evaluate()`` must not
+contribute at all.
+
+CPU-only: no model, no process group.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import megatron.training.training as training_module
+from examples.multimodal_dev.forward_step import record_vision_model_flops
+from megatron.core.rerun_state_machine import RerunState
+from megatron.training.training import consume_vision_model_flops_stats
+
+# One image: T=1, H=4, W=4 with spatial_merge_size=2.
+_GRID = torch.tensor([[1, 4, 4]], dtype=torch.int64)
+_ONE_PASS = (16.0, 256.0, 4.0)
+
+
+@pytest.fixture
+def args():
+    return SimpleNamespace(count_vision_model_flops=True, vision_spatial_merge_size=2)
+
+
+@pytest.fixture(autouse=True)
+def reset_accumulator():
+    training_module._vision_flops_stats_in_iteration = None
+    yield
+    training_module._vision_flops_stats_in_iteration = None
+
+
+@pytest.fixture
+def rerun_state(monkeypatch):
+    """Drive ``get_rerun_state_machine().state`` without a real state machine."""
+    stub = SimpleNamespace(state=RerunState.INITIAL_RUN)
+    monkeypatch.setattr(
+        "examples.multimodal_dev.forward_step.get_rerun_state_machine", lambda: stub
+    )
+    return stub
+
+
+def test_initial_run_records_the_microbatch(args, rerun_state):
+    record_vision_model_flops(args, SimpleNamespace(training=True), {"image_grid_thw": _GRID})
+    assert consume_vision_model_flops_stats(True) == _ONE_PASS
+
+
+def test_in_place_rerun_does_not_double_count(args, rerun_state):
+    """Regression: one forced rerun must consume as a single logical pass.
+
+    ``--check-for-nan-in-loss`` / ``--check-for-spiky-loss`` re-execute
+    ``train_step`` on the SAME microbatches with the model still in train
+    mode, while ``consume_*`` still runs once per training iteration.
+    """
+    model = SimpleNamespace(training=True)
+    batch = {"image_grid_thw": _GRID}
+
+    # Initial run.
+    rerun_state.state = RerunState.INITIAL_RUN
+    record_vision_model_flops(args, model, batch)
+    # The state machine requests a rerun; the same microbatch is replayed.
+    rerun_state.state = RerunState.RERUNNING_IN_PLACE
+    record_vision_model_flops(args, model, batch)
+
+    # train() drains once for the whole iteration.
+    assert consume_vision_model_flops_stats(True) == _ONE_PASS
+
+
+def test_evaluation_does_not_contribute(args, rerun_state):
+    record_vision_model_flops(args, SimpleNamespace(training=False), {"image_grid_thw": _GRID})
+    # Nothing reported at all -> the caller omits the vision terms.
+    assert consume_vision_model_flops_stats(True) == (None, None, None)
+
+
+def test_exhausted_iterator_reports_an_explicit_zero(args, rerun_state):
+    """``batch is None`` must still report, so the rank is not silently dropped."""
+    record_vision_model_flops(args, SimpleNamespace(training=True), None)
+    assert consume_vision_model_flops_stats(True) == (0.0, 0.0, 0.0)
+
+
+def test_text_only_microbatch_reports_an_explicit_zero(args, rerun_state):
+    record_vision_model_flops(args, SimpleNamespace(training=True), {})
+    assert consume_vision_model_flops_stats(True) == (0.0, 0.0, 0.0)
+
+
+def test_disabled_feature_never_touches_the_accumulator(rerun_state):
+    args = SimpleNamespace(count_vision_model_flops=False)
+    record_vision_model_flops(args, SimpleNamespace(training=True), {"image_grid_thw": _GRID})
+    assert training_module._vision_flops_stats_in_iteration is None
+
+
+def test_missing_spatial_merge_size_fails_with_an_actionable_error(rerun_state):
+    """A registry that enables the flag without the merge size must not
+    ``AttributeError`` deep in the forward step."""
+    args = SimpleNamespace(count_vision_model_flops=True)
+    with pytest.raises(ValueError, match="spatial_merge_size must be positive"):
+        record_vision_model_flops(args, SimpleNamespace(training=True), {"image_grid_thw": _GRID})

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -253,6 +253,18 @@ stimer = StragglerDetector()
 _seqlen_stats_in_iteration: Optional[torch.Tensor] = None
 _seqlen_stats_active: bool = False
 
+# Per-iteration vision-work stats, accumulated from the actual ``grid_thw``
+# tensors consumed by multimodal forward steps:
+#   index 0 -> total input patches, ``sum_i(T_i * H_i * W_i)``
+#   index 1 -> bidirectional attention work, ``sum_i(T_i * (H_i * W_i) ** 2)``
+#   index 2 -> total output tokens after spatial patch merging
+#
+# As with language packed-sequence stats, every model-parallel rank sees the
+# same grids while data-parallel ranks see different samples. ``consume_*``
+# therefore all-reduces once and removes TP/CP/PP replication.
+_vision_flops_stats_in_iteration: Optional[torch.Tensor] = None
+_vision_flops_stats_active: bool = False
+
 # Only report memory for first 3 checkpoint saves.
 num_checkpoints_memory_reported = 0
 MAX_NUM_CHECKPOINTS_MEMORY_REPORTED = 3
@@ -384,6 +396,101 @@ def consume_seqlen_stats_in_iteration() -> Tuple[Optional[float], Optional[float
     return total_real_tokens / dedup, seqlen_squared_sum / dedup
 
 
+def update_vision_model_flops_stats(grid_thw: torch.Tensor | None, spatial_merge_size: int) -> None:
+    """Accumulate vision-token shape statistics for one microbatch.
+
+    Args:
+        grid_thw: ``[num_images_or_videos, 3]`` tensor containing the
+            post-patch-embedding ``(T, H, W)`` grid for each vision input.
+            ``None`` records an explicit text-only microbatch.
+        spatial_merge_size: Spatial patch-merger factor used by the vision
+            encoder.
+
+    The update stays on device and records the three sufficient statistics
+    needed by the Qwen3.5-VL FLOPs formula. Each temporal frame is a separate
+    bidirectional-attention sequence, matching the encoder's packed THD
+    ``cu_seqlens`` construction.
+    """
+    global _vision_flops_stats_active, _vision_flops_stats_in_iteration
+    if grid_thw is None or grid_thw.numel() == 0:
+        if _vision_flops_stats_in_iteration is None:
+            device = (
+                torch.device(f'cuda:{torch.cuda.current_device()}')
+                if torch.cuda.is_available()
+                else torch.device("cpu")
+            )
+            _vision_flops_stats_in_iteration = torch.zeros(3, dtype=torch.float64, device=device)
+        # Mark an explicit text-only microbatch as active so consume returns
+        # zeros. ``None`` remains reserved for call paths that never reported
+        # runtime vision stats and therefore need the nominal fallback.
+        _vision_flops_stats_active = True
+        return
+    if grid_thw.ndim != 2 or grid_thw.shape[1] != 3:
+        raise ValueError(
+            "vision grid_thw must have shape [num_images_or_videos, 3], "
+            f"got {tuple(grid_thw.shape)}"
+        )
+    if spatial_merge_size <= 0:
+        raise ValueError(f"vision spatial_merge_size must be positive, got {spatial_merge_size}")
+    # CPU callers (notably unit tests) get eager value validation. Production
+    # supplies CUDA grids; avoid a device-to-host sync in every microbatch and
+    # rely on the vision encoder's own shape checks for those trusted inputs.
+    if not grid_thw.is_cuda:
+        if torch.any(grid_thw <= 0):
+            raise ValueError("vision grid_thw values must all be positive")
+        if torch.any(grid_thw[:, 1:] % spatial_merge_size != 0):
+            raise ValueError(
+                "vision grid height and width must be divisible by "
+                f"spatial_merge_size={spatial_merge_size}"
+            )
+
+    if _vision_flops_stats_in_iteration is None:
+        device = (
+            torch.device(f'cuda:{torch.cuda.current_device()}')
+            if torch.cuda.is_available()
+            else grid_thw.device
+        )
+        _vision_flops_stats_in_iteration = torch.zeros(3, dtype=torch.float64, device=device)
+
+    grid = grid_thw.to(device=_vision_flops_stats_in_iteration.device, dtype=torch.float64)
+    temporal, height, width = grid.unbind(dim=1)
+    patches_per_frame = height * width
+    _vision_flops_stats_in_iteration[0] += (temporal * patches_per_frame).sum()
+    _vision_flops_stats_in_iteration[1] += (temporal * patches_per_frame * patches_per_frame).sum()
+    _vision_flops_stats_in_iteration[2] += (
+        temporal * (height / spatial_merge_size) * (width / spatial_merge_size)
+    ).sum()
+    _vision_flops_stats_active = True
+
+
+def consume_vision_model_flops_stats() -> Tuple[Optional[float], Optional[float], Optional[float]]:
+    """Read, reset, and globally reduce per-iteration vision shape stats.
+
+    Returns:
+        ``(total_patches, attention_seqlen_squared_sum, merged_tokens)`` for
+        the global batch. Returns ``(None, None, None)`` when no multimodal
+        forward step supplied a vision grid in this iteration.
+    """
+    global _vision_flops_stats_active, _vision_flops_stats_in_iteration
+    if not _vision_flops_stats_active:
+        return None, None, None
+
+    stats = _vision_flops_stats_in_iteration
+    if torch.distributed.is_initialized() and mpu.model_parallel_is_initialized():
+        torch.distributed.all_reduce(stats)
+        tp_size = max(mpu.get_tensor_model_parallel_world_size(), 1)
+        cp_size = max(mpu.get_context_parallel_world_size(), 1)
+        pp_size = max(mpu.get_pipeline_model_parallel_world_size(), 1)
+        dedup = tp_size * cp_size * pp_size
+    else:
+        dedup = 1
+
+    total_patches, attention_seqlen_squared_sum, merged_tokens = stats.tolist()
+    stats.zero_()
+    _vision_flops_stats_active = False
+    return (total_patches / dedup, attention_seqlen_squared_sum / dedup, merged_tokens / dedup)
+
+
 def _dsv4_hybrid_self_attention_flops(
     *,
     hidden_size,
@@ -494,8 +601,175 @@ def _dsv4_hybrid_self_attention_flops(
     return token_linear, core
 
 
+def _num_multimodal_extra_floating_point_operations(
+    args,
+    batch_size,
+    vision_total_tokens_in_batch=None,
+    vision_seqlen_squared_sum_in_batch=None,
+    vision_merged_tokens_in_batch=None,
+):
+    """Estimate training FLOPs outside the language decoder stack.
+
+    This follows the existing decoder convention: count the dominant
+    projections and attention matrix multiplications, including forward,
+    weight-gradient, and data-gradient work, while omitting comparatively
+    small elementwise operations such as normalization, GELU, RoPE, and
+    residual additions.
+    """
+    if not getattr(args, "count_vision_model_flops", False):
+        return 0
+
+    vision_flops_variant = getattr(args, "vision_flops_variant", None)
+    if vision_flops_variant != "qwen35_vl_v2":
+        raise ValueError(f"Unsupported vision FLOPs variant: {vision_flops_variant!r}")
+
+    required_fields = (
+        "vision_num_layers",
+        "vision_hidden_size",
+        "vision_ffn_hidden_size",
+        "vision_num_attention_heads",
+        "vision_patch_size",
+        "vision_temporal_patch_size",
+        "vision_spatial_merge_size",
+        "vision_in_channels",
+        "vision_out_hidden_size",
+    )
+    missing_fields = [field for field in required_fields if getattr(args, field, None) is None]
+    if missing_fields:
+        raise ValueError("Missing Qwen3.5-VL vision FLOPs metadata: " + ", ".join(missing_fields))
+
+    hidden_size = args.vision_hidden_size
+    ffn_hidden_size = args.vision_ffn_hidden_size
+    num_attention_heads = args.vision_num_attention_heads
+    spatial_merge_size = args.vision_spatial_merge_size
+    positive_fields = {
+        "vision_num_layers": args.vision_num_layers,
+        "vision_hidden_size": hidden_size,
+        "vision_ffn_hidden_size": ffn_hidden_size,
+        "vision_num_attention_heads": num_attention_heads,
+        "vision_patch_size": args.vision_patch_size,
+        "vision_temporal_patch_size": args.vision_temporal_patch_size,
+        "vision_spatial_merge_size": spatial_merge_size,
+        "vision_in_channels": args.vision_in_channels,
+        "vision_out_hidden_size": args.vision_out_hidden_size,
+    }
+    invalid_fields = [f"{field}={value}" for field, value in positive_fields.items() if value <= 0]
+    if invalid_fields:
+        raise ValueError(
+            "Qwen3.5-VL vision FLOPs metadata must be positive: " + ", ".join(invalid_fields)
+        )
+
+    kv_channels = getattr(args, "vision_kv_channels", None)
+    if kv_channels is None:
+        if hidden_size % num_attention_heads != 0:
+            raise ValueError(
+                "vision_hidden_size must be divisible by vision_num_attention_heads "
+                "when vision_kv_channels is unset"
+            )
+        kv_channels = hidden_size // num_attention_heads
+    elif kv_channels <= 0:
+        raise ValueError(f"vision_kv_channels must be positive, got {kv_channels}")
+    projection_size = kv_channels * num_attention_heads
+
+    vision_stats = (
+        vision_total_tokens_in_batch,
+        vision_seqlen_squared_sum_in_batch,
+        vision_merged_tokens_in_batch,
+    )
+    if any(value is not None for value in vision_stats) and not all(
+        value is not None for value in vision_stats
+    ):
+        raise ValueError(
+            "vision_total_tokens_in_batch, vision_seqlen_squared_sum_in_batch, "
+            "and vision_merged_tokens_in_batch must be provided together"
+        )
+    if all(value is not None for value in vision_stats) and any(
+        value < 0 for value in vision_stats
+    ):
+        raise ValueError(
+            "runtime vision FLOPs statistics must be non-negative, " f"got {vision_stats}"
+        )
+
+    if vision_total_tokens_in_batch is None:
+        image_size = getattr(args, "image_size", None)
+        if image_size is None:
+            raise ValueError(
+                "image_size is required when runtime vision grid statistics are unavailable"
+            )
+        patch_size = args.vision_patch_size
+        if image_size <= 0 or patch_size <= 0 or image_size % patch_size != 0:
+            raise ValueError(
+                "image_size must be positive and divisible by vision_patch_size, "
+                f"got image_size={image_size}, vision_patch_size={patch_size}"
+            )
+        grid_size = image_size // patch_size
+        if grid_size % spatial_merge_size != 0:
+            raise ValueError(
+                "vision patch grid must be divisible by vision_spatial_merge_size, "
+                f"got grid_size={grid_size}, "
+                f"spatial_merge_size={spatial_merge_size}"
+            )
+        temporal_grid_size = args.vision_temporal_patch_size
+        patches_per_frame = grid_size * grid_size
+        vision_total_tokens_in_batch = batch_size * temporal_grid_size * patches_per_frame
+        vision_seqlen_squared_sum_in_batch = (
+            batch_size * temporal_grid_size * patches_per_frame * patches_per_frame
+        )
+        vision_merged_tokens_in_batch = (
+            batch_size * temporal_grid_size * (grid_size // spatial_merge_size) ** 2
+        )
+
+    # Every weight-bearing matmul runs once in forward and twice in backward.
+    forward_backward_expansion_factor = 3
+    fma_expansion_factor = 2
+    training_matmul_factor = forward_backward_expansion_factor * fma_expansion_factor
+
+    patch_dim = (
+        args.vision_in_channels
+        * args.vision_temporal_patch_size
+        * args.vision_patch_size
+        * args.vision_patch_size
+    )
+    patch_embed_flops = (
+        training_matmul_factor * vision_total_tokens_in_batch * patch_dim * hidden_size
+    )
+
+    # Per layer: dense QKV + output projections, a two-linear GELU MLP, and
+    # bidirectional QK^T / attention-value matmuls over each temporal frame.
+    vision_projection_flops = (
+        training_matmul_factor
+        * vision_total_tokens_in_batch
+        * (
+            hidden_size * (3 * projection_size)
+            + projection_size * hidden_size
+            + hidden_size * ffn_hidden_size
+            + ffn_hidden_size * hidden_size
+        )
+    )
+    vision_core_attention_flops = (
+        forward_backward_expansion_factor * 4 * vision_seqlen_squared_sum_in_batch * projection_size
+    )
+    vision_transformer_flops = args.vision_num_layers * (
+        vision_projection_flops + vision_core_attention_flops
+    )
+
+    merge_dim = hidden_size * spatial_merge_size**2
+    patch_merger_flops = (
+        training_matmul_factor
+        * vision_merged_tokens_in_batch
+        * (merge_dim * merge_dim + merge_dim * args.vision_out_hidden_size)
+    )
+    return patch_embed_flops + vision_transformer_flops + patch_merger_flops
+
+
 def num_floating_point_operations(
-    args, batch_size, seqlen_squared_sum_in_batch=None, total_real_tokens_in_batch=None
+    args,
+    batch_size,
+    seqlen_squared_sum_in_batch=None,
+    total_real_tokens_in_batch=None,
+    vision_total_tokens_in_batch=None,
+    vision_seqlen_squared_sum_in_batch=None,
+    vision_merged_tokens_in_batch=None,
 ):
     """Compute the number of floating-point operations for one global batch.
 
@@ -520,6 +794,15 @@ def num_floating_point_operations(
             than ``batch_size * args.seq_length`` whenever the dataloader added
             CP-alignment padding or end-of-sequence padding, so neither kind of
             padding shows up in the reported FLOPs.
+        vision_total_tokens_in_batch: Total pre-merger vision patch tokens
+            from the actual ``grid_thw`` values in the global batch.
+        vision_seqlen_squared_sum_in_batch: ``sum_i(T_i * (H_i * W_i)^2)``
+            for bidirectional vision attention, where each temporal frame is
+            one packed attention sequence.
+        vision_merged_tokens_in_batch: Total vision tokens after spatial patch
+            merging. The three vision statistics must be supplied together.
+            When omitted, enabled vision variants use their nominal
+            ``image_size`` metadata as a fallback.
     """
     # Defaults: BSHD layout assumption (full causal mask, every sample length =
     # seq_length, no padding). For BSHD ``total_real_tokens = batch * s`` and
@@ -1206,8 +1489,8 @@ def num_floating_point_operations(
         mtp_num_layers = args.mtp_num_layers
         if mtp_num_layers is None:
             mtp_num_layers = 0
-        # Compute hybrid model FLOPs.
-        return hybrid_flops(
+        # Compute hybrid decoder FLOPs.
+        total_floating_point_operations = hybrid_flops(
             total_tokens=total_real_tokens_in_batch,
             seqlen_squared_sum=seqlen_squared_sum_in_batch,
             hidden_size=args.hidden_size,
@@ -1265,7 +1548,15 @@ def num_floating_point_operations(
         )
     else:
         # Compute standard Transformer model FLOPs.
-        return transformer_flops()
+        total_floating_point_operations = transformer_flops()
+
+    return total_floating_point_operations + _num_multimodal_extra_floating_point_operations(
+        args,
+        batch_size,
+        vision_total_tokens_in_batch=vision_total_tokens_in_batch,
+        vision_seqlen_squared_sum_in_batch=vision_seqlen_squared_sum_in_batch,
+        vision_merged_tokens_in_batch=vision_merged_tokens_in_batch,
+    )
 
 
 def get_start_time_from_progress_log():
@@ -3065,6 +3356,9 @@ def training_log(
     is_first_iteration=False,
     seqlen_squared_sum_in_batch: float | None = None,
     total_real_tokens_in_batch: float | None = None,
+    vision_total_tokens_in_batch: float | None = None,
+    vision_seqlen_squared_sum_in_batch: float | None = None,
+    vision_merged_tokens_in_batch: float | None = None,
     num_microbatches: int | None = None,
 ):
     """Log training information such as losses, timing, ...."""
@@ -3342,6 +3636,9 @@ def training_log(
             batch_size,
             seqlen_squared_sum_in_batch=seqlen_squared_sum_in_batch,
             total_real_tokens_in_batch=total_real_tokens_in_batch,
+            vision_total_tokens_in_batch=vision_total_tokens_in_batch,
+            vision_seqlen_squared_sum_in_batch=vision_seqlen_squared_sum_in_batch,
+            vision_merged_tokens_in_batch=vision_merged_tokens_in_batch,
         ) / (elapsed_time_per_iteration * 10**12 * args.world_size)
 
         one_logger_utils.track_e2e_metrics(args.log_throughput, throughput)
@@ -4470,11 +4767,19 @@ def train(
             total_real_tokens_in_batch, seqlen_squared_sum_in_batch = (
                 consume_seqlen_stats_in_iteration()
             )
+        (
+            vision_total_tokens_in_batch,
+            vision_seqlen_squared_sum_in_batch,
+            vision_merged_tokens_in_batch,
+        ) = consume_vision_model_flops_stats()
         num_floating_point_operations_in_batch = num_floating_point_operations(
             args,
             batch_size,
             seqlen_squared_sum_in_batch=seqlen_squared_sum_in_batch,
             total_real_tokens_in_batch=total_real_tokens_in_batch,
+            vision_total_tokens_in_batch=vision_total_tokens_in_batch,
+            vision_seqlen_squared_sum_in_batch=vision_seqlen_squared_sum_in_batch,
+            vision_merged_tokens_in_batch=vision_merged_tokens_in_batch,
         )
         num_floating_point_operations_so_far += num_floating_point_operations_in_batch
         num_floating_point_operations_since_last_log_event += num_floating_point_operations_in_batch
@@ -4508,6 +4813,9 @@ def train(
             is_first_iteration=is_first_iteration,
             seqlen_squared_sum_in_batch=seqlen_squared_sum_in_batch,
             total_real_tokens_in_batch=total_real_tokens_in_batch,
+            vision_total_tokens_in_batch=vision_total_tokens_in_batch,
+            vision_seqlen_squared_sum_in_batch=vision_seqlen_squared_sum_in_batch,
+            vision_merged_tokens_in_batch=vision_merged_tokens_in_batch,
             num_microbatches=num_microbatches,
         )
         is_first_iteration = False

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -259,6 +259,39 @@ stimer = StragglerDetector()
 _seqlen_stats_in_iteration: Optional[torch.Tensor] = None
 _seqlen_stats_active: bool = False
 
+# Per-iteration vision-work stats, accumulated from the actual ``grid_thw``
+# tensors consumed by multimodal forward steps:
+#   index 0 -> total input patches, ``sum_i(T_i * H_i * W_i)``
+#   index 1 -> bidirectional attention work, ``sum_i(T_i * (H_i * W_i) ** 2)``
+#   index 2 -> total output tokens after spatial patch merging
+#   index 3 -> "this rank saw runtime grid data" flag (0.0 / 1.0)
+#   index 4 -> count of malformed grid rows seen (see ``update_*``)
+#
+# Slots 3 and 4 ride along in the same tensor so the whole protocol costs one
+# all-reduce and one host sync per iteration. Slot 3 is summed and tested
+# ``> 0``: it distinguishes "some rank reported vision work" from "every
+# microbatch this iteration was text-only" (legitimately all-zero stats) and
+# from "nothing was ever reported".
+#
+# As with language packed-sequence stats, every model-parallel rank sees the
+# same grids while data-parallel ranks see different samples. ``consume_*``
+# therefore all-reduces once and removes TP/CP/PP replication. Unlike the
+# language decoder, the vision encoder itself is NOT partitioned by context
+# parallelism -- it runs before ``_cp_split_for_forward`` and is forced onto a
+# size-1 attention group, so every CP rank redundantly computes the entire
+# vision forward. Dividing by ``cp_size`` here is still correct for a MODEL
+# FLOPs metric (redundant compute is not useful work), it just means vision
+# and language replicate across CP for different reasons -- the vision
+# encoder isn't actually doing 1/cp_size of the work per rank the way the
+# decoder is.
+_VISION_FLOPS_STATS_SLOTS = 5
+_VISION_FLOPS_PATCHES_SLOT = 0
+_VISION_FLOPS_ATTN_SLOT = 1
+_VISION_FLOPS_MERGED_SLOT = 2
+_VISION_FLOPS_REPORTED_SLOT = 3
+_VISION_FLOPS_INVALID_SLOT = 4
+_vision_flops_stats_in_iteration: Optional[torch.Tensor] = None
+
 # Only report memory for first 3 checkpoint saves.
 num_checkpoints_memory_reported = 0
 MAX_NUM_CHECKPOINTS_MEMORY_REPORTED = 3
@@ -498,6 +531,141 @@ def _num_dsa_indexer_layers(num_layers, skip_topk_offset, topk_freq):
     )
 
 
+def _vision_flops_stats_tensor(reference: torch.Tensor | None = None) -> torch.Tensor:
+    """Return the per-iteration vision stats buffer, allocating it on first use."""
+    global _vision_flops_stats_in_iteration
+    if _vision_flops_stats_in_iteration is None:
+        if torch.cuda.is_available():
+            device = torch.device(f'cuda:{torch.cuda.current_device()}')
+        elif reference is not None:
+            device = reference.device
+        else:
+            device = torch.device("cpu")
+        _vision_flops_stats_in_iteration = torch.zeros(
+            _VISION_FLOPS_STATS_SLOTS, dtype=torch.float64, device=device
+        )
+    return _vision_flops_stats_in_iteration
+
+
+def update_vision_model_flops_stats(grid_thw: torch.Tensor | None, spatial_merge_size: int) -> None:
+    """Accumulate vision-token shape statistics for one microbatch.
+
+    Args:
+        grid_thw: ``[num_images_or_videos, 3]`` tensor containing the
+            post-patch-embedding ``(T, H, W)`` grid for each vision input.
+            ``None`` records an explicit text-only microbatch.
+        spatial_merge_size: Spatial patch-merger factor used by the vision
+            encoder.
+
+    Must be called by every rank on every microbatch whenever
+    ``args.count_vision_model_flops`` is set -- including for text-only or
+    empty microbatches, for which ``grid_thw=None`` records an explicit zero.
+    ``consume_vision_model_flops_stats`` decides whether to enter its
+    collective from that config flag alone, so a rank that silently skipped
+    the update would not desync the job, but it would drop its share of the
+    global batch from the reported FLOPs.
+
+    The update stays on device and records the three sufficient statistics
+    needed by the Qwen3.5-VL FLOPs formula. Each temporal frame is a separate
+    bidirectional-attention sequence, matching the encoder's packed THD
+    ``cu_seqlens`` construction. Malformed grid values are accumulated into a
+    device-side counter rather than checked eagerly, so production CUDA grids
+    are validated with the same strictness as CPU ones at no extra host sync;
+    ``consume_*`` raises on the reduced counter.
+    """
+    if spatial_merge_size is None or spatial_merge_size <= 0:
+        raise ValueError(f"vision spatial_merge_size must be positive, got {spatial_merge_size}")
+    stats = _vision_flops_stats_tensor(grid_thw)
+    if grid_thw is None or grid_thw.numel() == 0:
+        # An explicit text-only (or vision-free) microbatch still counts as a
+        # report: the iteration's vision work is genuinely zero, which is a
+        # different statement from "no runtime grids were ever available".
+        stats[_VISION_FLOPS_REPORTED_SLOT] += 1.0
+        return
+    if grid_thw.ndim != 2 or grid_thw.shape[1] != 3:
+        raise ValueError(
+            "vision grid_thw must have shape [num_images_or_videos, 3], "
+            f"got {tuple(grid_thw.shape)}"
+        )
+
+    grid = grid_thw.to(device=stats.device, dtype=torch.float64)
+    temporal, height, width = grid.unbind(dim=1)
+    # Device-side validation: non-positive extents, or an H/W that the patch
+    # merger's ``view(-1, merge_dim)`` reshape could not consume. Counted, not
+    # raised, to keep this path free of a device-to-host sync.
+    not_positive = (grid <= 0).any(dim=1)
+    not_mergeable = (torch.remainder(grid[:, 1:], spatial_merge_size) != 0).any(dim=1)
+    invalid = not_positive | not_mergeable
+    stats[_VISION_FLOPS_INVALID_SLOT] += invalid.to(torch.float64).sum()
+
+    patches_per_frame = height * width
+    merged_height = torch.div(height, spatial_merge_size, rounding_mode='floor')
+    merged_width = torch.div(width, spatial_merge_size, rounding_mode='floor')
+    stats[_VISION_FLOPS_PATCHES_SLOT] += (temporal * patches_per_frame).sum()
+    stats[_VISION_FLOPS_ATTN_SLOT] += (temporal * patches_per_frame * patches_per_frame).sum()
+    stats[_VISION_FLOPS_MERGED_SLOT] += (temporal * merged_height * merged_width).sum()
+    stats[_VISION_FLOPS_REPORTED_SLOT] += 1.0
+
+
+def consume_vision_model_flops_stats(
+    count_vision_model_flops: bool,
+) -> Tuple[Optional[float], Optional[float], Optional[float]]:
+    """Read, reset, and globally reduce per-iteration vision shape stats.
+
+    Args:
+        count_vision_model_flops: ``args.count_vision_model_flops`` -- a
+            config value identical on every rank. Whether to enter the
+            distributed all-reduce is decided by THIS value alone, never by
+            whether ``update_vision_model_flops_stats`` happened to be called
+            locally this iteration: a rank whose data iterator ran dry (or
+            whose model wrapper lacks a ``.training`` attribute) must still
+            enter the same collective its peers enter, or the job desyncs.
+            Ranks with nothing to report contribute a zero tensor, and the
+            "did anyone report" flag is reduced inside the same collective.
+
+    Returns:
+        ``(total_patches, attention_seqlen_squared_sum, merged_tokens)`` for
+        the global batch. Returns ``(None, None, None)`` when vision FLOPs
+        counting is disabled, or when it is enabled but no rank supplied any
+        runtime grid this iteration.
+
+    Raises:
+        ValueError: if any rank accumulated a malformed ``grid_thw`` row.
+    """
+    if not count_vision_model_flops:
+        return None, None, None
+
+    stats = _vision_flops_stats_tensor()
+    if torch.distributed.is_initialized() and mpu.model_parallel_is_initialized():
+        # Unconditional when the feature is on, so collective participation is
+        # a global invariant rather than a function of local activity.
+        torch.distributed.all_reduce(stats)
+        tp_size = max(mpu.get_tensor_model_parallel_world_size(), 1)
+        cp_size = max(mpu.get_context_parallel_world_size(), 1)
+        pp_size = max(mpu.get_pipeline_model_parallel_world_size(), 1)
+        dedup = tp_size * cp_size * pp_size
+    else:
+        # No model-parallel state -> single-rank path (standalone unit tests;
+        # production always initializes mpu).
+        dedup = 1
+
+    # Single host sync drains every slot at once.
+    total_patches, attention_seqlen_squared_sum, merged_tokens, num_reported, num_invalid = (
+        stats.tolist()
+    )
+    # Reset for the next iteration, keeping the tensor allocated.
+    stats.zero_()
+
+    if num_invalid > 0:
+        raise ValueError(
+            f"{int(num_invalid)} vision grid_thw row(s) this iteration had a non-positive "
+            "extent, or a height/width not divisible by vision_spatial_merge_size"
+        )
+    if num_reported == 0:
+        return None, None, None
+    return (total_patches / dedup, attention_seqlen_squared_sum / dedup, merged_tokens / dedup)
+
+
 def _dsv4_hybrid_self_attention_flops(
     *,
     hidden_size,
@@ -608,8 +776,221 @@ def _dsv4_hybrid_self_attention_flops(
     return token_linear, core
 
 
+_vision_flops_missing_runtime_stats_warned: bool = False
+
+
+def validate_vision_flops_metadata(args) -> None:
+    """Validate ``count_vision_model_flops`` metadata and precompute derived scalars.
+
+    Call this once, at model-construction time, right after a model
+    registry's ``vision_flops_fn`` sets ``args.count_vision_model_flops`` and
+    the ``vision_*`` fields (see
+    ``examples/multimodal_dev/pretrain_multimodal.py:model_provider``, which
+    calls this centrally right after ``vision_flops_fn`` -- individual
+    ``vision_flops_fn`` implementations, e.g.
+    ``examples/multimodal_dev/models/qwen35_vl/factory.py:set_vision_flops_metadata``,
+    do not need to call it themselves).
+    Doing this eagerly means a misconfigured variant or missing/invalid field
+    raises before the dataloader and optimizer are built, instead of at
+    iteration 1 inside the training loop. It also means
+    ``_num_multimodal_extra_floating_point_operations`` -- which runs every
+    iteration, from both the train loop and ``training_log``'s throughput
+    computation -- only has to do arithmetic on the precomputed scalars set
+    here, not re-validate config that cannot change after model construction.
+    """
+    if not getattr(args, "count_vision_model_flops", False):
+        return
+
+    vision_flops_variant = getattr(args, "vision_flops_variant", None)
+    if vision_flops_variant != "qwen35_vl":
+        raise ValueError(f"Unsupported vision FLOPs variant: {vision_flops_variant!r}")
+
+    required_fields = (
+        "vision_num_layers",
+        "vision_hidden_size",
+        "vision_ffn_hidden_size",
+        "vision_num_attention_heads",
+        "vision_patch_size",
+        "vision_temporal_patch_size",
+        "vision_spatial_merge_size",
+        "vision_in_channels",
+        "vision_out_hidden_size",
+    )
+    missing_fields = [field for field in required_fields if getattr(args, field, None) is None]
+    if missing_fields:
+        raise ValueError("Missing Qwen3.5-VL vision FLOPs metadata: " + ", ".join(missing_fields))
+
+    hidden_size = args.vision_hidden_size
+    num_attention_heads = args.vision_num_attention_heads
+    spatial_merge_size = args.vision_spatial_merge_size
+    positive_fields = {
+        "vision_num_layers": args.vision_num_layers,
+        "vision_hidden_size": hidden_size,
+        "vision_ffn_hidden_size": args.vision_ffn_hidden_size,
+        "vision_num_attention_heads": num_attention_heads,
+        "vision_patch_size": args.vision_patch_size,
+        "vision_temporal_patch_size": args.vision_temporal_patch_size,
+        "vision_spatial_merge_size": spatial_merge_size,
+        "vision_in_channels": args.vision_in_channels,
+        "vision_out_hidden_size": args.vision_out_hidden_size,
+    }
+    invalid_fields = [f"{field}={value}" for field, value in positive_fields.items() if value <= 0]
+    if invalid_fields:
+        raise ValueError(
+            "Qwen3.5-VL vision FLOPs metadata must be positive: " + ", ".join(invalid_fields)
+        )
+
+    kv_channels = getattr(args, "vision_kv_channels", None)
+    if kv_channels is None:
+        if hidden_size % num_attention_heads != 0:
+            raise ValueError(
+                "vision_hidden_size must be divisible by vision_num_attention_heads "
+                "when vision_kv_channels is unset"
+            )
+        kv_channels = hidden_size // num_attention_heads
+    elif kv_channels <= 0:
+        raise ValueError(f"vision_kv_channels must be positive, got {kv_channels}")
+
+    # Derived scalars fixed at model-construction time; the per-iteration
+    # path below reads these directly instead of recomputing them.
+    args.vision_projection_size = kv_channels * num_attention_heads
+    args.vision_patch_dim = (
+        args.vision_in_channels
+        * args.vision_temporal_patch_size
+        * args.vision_patch_size
+        * args.vision_patch_size
+    )
+    args.vision_merge_dim = hidden_size * spatial_merge_size**2
+
+
+def _num_multimodal_extra_floating_point_operations(
+    args,
+    vision_total_tokens_in_batch=None,
+    vision_seqlen_squared_sum_in_batch=None,
+    vision_merged_tokens_in_batch=None,
+):
+    """Estimate training FLOPs outside the language decoder stack.
+
+    This follows the existing decoder convention: count the dominant
+    projections and attention matrix multiplications, including forward,
+    weight-gradient, and data-gradient work, while omitting comparatively
+    small elementwise operations such as normalization, GELU, RoPE, and
+    residual additions.
+
+    Metadata validation and derived-scalar precomputation happen once, at
+    model-construction time, in ``validate_vision_flops_metadata`` -- see
+    there. This function assumes that already ran successfully whenever
+    ``count_vision_model_flops`` is set.
+
+    The vision terms are driven exclusively by the runtime ``grid_thw``
+    statistics the forward step reported. When an entry point does not report
+    them, the vision contribution is omitted (and a one-time warning is
+    logged) rather than synthesised from nominal architecture metadata: a
+    fabricated-but-plausible number would silently feed MFU comparisons and
+    perf regression tracking.
+    """
+    if not getattr(args, "count_vision_model_flops", False):
+        return 0
+
+    global _vision_flops_missing_runtime_stats_warned
+
+    projection_size = getattr(args, "vision_projection_size", None)
+    if projection_size is None:
+        # The derived scalars are only ever set by validate_vision_flops_metadata.
+        # An entry point that sets count_vision_model_flops itself, without
+        # routing through that validator, would otherwise fail here with a bare
+        # AttributeError at the first training iteration.
+        raise ValueError(
+            "count_vision_model_flops is set but the vision FLOPs metadata was never "
+            "validated. Call megatron.training.training.validate_vision_flops_metadata(args) "
+            "at model-construction time (see "
+            "examples/multimodal_dev/pretrain_multimodal.py:model_provider)."
+        )
+    hidden_size = args.vision_hidden_size
+    ffn_hidden_size = args.vision_ffn_hidden_size
+    patch_dim = args.vision_patch_dim
+    merge_dim = args.vision_merge_dim
+
+    vision_stats = (
+        vision_total_tokens_in_batch,
+        vision_seqlen_squared_sum_in_batch,
+        vision_merged_tokens_in_batch,
+    )
+    if any(value is not None for value in vision_stats) and not all(
+        value is not None for value in vision_stats
+    ):
+        raise ValueError(
+            "vision_total_tokens_in_batch, vision_seqlen_squared_sum_in_batch, "
+            "and vision_merged_tokens_in_batch must be provided together"
+        )
+    if all(value is not None for value in vision_stats) and any(
+        value < 0 for value in vision_stats
+    ):
+        raise ValueError(
+            "runtime vision FLOPs statistics must be non-negative, " f"got {vision_stats}"
+        )
+
+    if vision_total_tokens_in_batch is None:
+        if not _vision_flops_missing_runtime_stats_warned:
+            print_rank_0(
+                "[vision FLOPs] count_vision_model_flops is enabled but no runtime "
+                "image_grid_thw was reported, so vision-encoder work is EXCLUDED from "
+                "the reported FLOPs/TFLOP-per-s. Entry points must call "
+                "megatron.training.training.update_vision_model_flops_stats() from "
+                "their forward step (see examples/multimodal_dev/forward_step.py). "
+                "Logged once."
+            )
+            _vision_flops_missing_runtime_stats_warned = True
+        return 0
+
+    # Every weight-bearing matmul runs once in forward and twice in backward.
+    forward_backward_expansion_factor = 3
+    fma_expansion_factor = 2
+    training_matmul_factor = forward_backward_expansion_factor * fma_expansion_factor
+
+    # NOTE: uses the same forward+weight-grad+data-grad factor as the other
+    # terms even though pixel_values is a leaf input with no data-gradient
+    # (factor 4 would be exact here, not 6). Deliberate ~0.4% over-count for
+    # formula uniformity across terms; not worth a separate constant.
+    patch_embed_flops = (
+        training_matmul_factor * vision_total_tokens_in_batch * patch_dim * hidden_size
+    )
+
+    # Per layer: dense QKV + output projections, a two-linear GELU MLP, and
+    # bidirectional QK^T / attention-value matmuls over each temporal frame.
+    vision_projection_flops = (
+        training_matmul_factor
+        * vision_total_tokens_in_batch
+        * (
+            hidden_size * (3 * projection_size)
+            + projection_size * hidden_size
+            + hidden_size * ffn_hidden_size
+            + ffn_hidden_size * hidden_size
+        )
+    )
+    vision_core_attention_flops = (
+        forward_backward_expansion_factor * 4 * vision_seqlen_squared_sum_in_batch * projection_size
+    )
+    vision_transformer_flops = args.vision_num_layers * (
+        vision_projection_flops + vision_core_attention_flops
+    )
+
+    patch_merger_flops = (
+        training_matmul_factor
+        * vision_merged_tokens_in_batch
+        * (merge_dim * merge_dim + merge_dim * args.vision_out_hidden_size)
+    )
+    return patch_embed_flops + vision_transformer_flops + patch_merger_flops
+
+
 def num_floating_point_operations(
-    args, batch_size, seqlen_squared_sum_in_batch=None, total_real_tokens_in_batch=None
+    args,
+    batch_size,
+    seqlen_squared_sum_in_batch=None,
+    total_real_tokens_in_batch=None,
+    vision_total_tokens_in_batch=None,
+    vision_seqlen_squared_sum_in_batch=None,
+    vision_merged_tokens_in_batch=None,
 ):
     """Compute the number of floating-point operations for one global batch.
 
@@ -634,6 +1015,16 @@ def num_floating_point_operations(
             than ``batch_size * args.seq_length`` whenever the dataloader added
             CP-alignment padding or end-of-sequence padding, so neither kind of
             padding shows up in the reported FLOPs.
+        vision_total_tokens_in_batch: Total pre-merger vision patch tokens
+            from the actual ``grid_thw`` values in the global batch.
+        vision_seqlen_squared_sum_in_batch: ``sum_i(T_i * (H_i * W_i)^2)``
+            for bidirectional vision attention, where each temporal frame is
+            one packed attention sequence.
+        vision_merged_tokens_in_batch: Total vision tokens after spatial patch
+            merging. The three vision statistics must be supplied together.
+            When omitted, the vision-encoder contribution is excluded from the
+            result (with a one-time warning) rather than estimated from
+            nominal architecture metadata.
     """
     # Defaults: BSHD layout assumption (full causal mask, every sample length =
     # seq_length, no padding). For BSHD ``total_real_tokens = batch * s`` and
@@ -1501,7 +1892,8 @@ def num_floating_point_operations(
         if mtp_num_layers is None:
             mtp_num_layers = 0
 
-        return hybrid_flops(
+        # Compute hybrid decoder FLOPs.
+        total_floating_point_operations = hybrid_flops(
             total_tokens=total_real_tokens_in_batch,
             seqlen_squared_sum=seqlen_squared_sum_in_batch,
             hidden_size=args.hidden_size,
@@ -1569,7 +1961,14 @@ def num_floating_point_operations(
         )
     else:
         # Compute standard Transformer model FLOPs.
-        return transformer_flops()
+        total_floating_point_operations = transformer_flops()
+
+    return total_floating_point_operations + _num_multimodal_extra_floating_point_operations(
+        args,
+        vision_total_tokens_in_batch=vision_total_tokens_in_batch,
+        vision_seqlen_squared_sum_in_batch=vision_seqlen_squared_sum_in_batch,
+        vision_merged_tokens_in_batch=vision_merged_tokens_in_batch,
+    )
 
 
 def get_start_time_from_progress_log():
@@ -3423,6 +3822,9 @@ def training_log(
     is_first_iteration=False,
     seqlen_squared_sum_in_batch: float | None = None,
     total_real_tokens_in_batch: float | None = None,
+    vision_total_tokens_in_batch: float | None = None,
+    vision_seqlen_squared_sum_in_batch: float | None = None,
+    vision_merged_tokens_in_batch: float | None = None,
     num_microbatches: int | None = None,
 ):
     """Log training information such as losses, timing, ...."""
@@ -3704,6 +4106,9 @@ def training_log(
             batch_size,
             seqlen_squared_sum_in_batch=seqlen_squared_sum_in_batch,
             total_real_tokens_in_batch=total_real_tokens_in_batch,
+            vision_total_tokens_in_batch=vision_total_tokens_in_batch,
+            vision_seqlen_squared_sum_in_batch=vision_seqlen_squared_sum_in_batch,
+            vision_merged_tokens_in_batch=vision_merged_tokens_in_batch,
         ) / (elapsed_time_per_iteration * 10**12 * args.world_size)
 
         one_logger_utils.track_e2e_metrics(args.log_throughput, throughput)
@@ -4834,11 +5239,19 @@ def train(
             total_real_tokens_in_batch, seqlen_squared_sum_in_batch = (
                 consume_seqlen_stats_in_iteration()
             )
+        (
+            vision_total_tokens_in_batch,
+            vision_seqlen_squared_sum_in_batch,
+            vision_merged_tokens_in_batch,
+        ) = consume_vision_model_flops_stats(getattr(args, "count_vision_model_flops", False))
         num_floating_point_operations_in_batch = num_floating_point_operations(
             args,
             batch_size,
             seqlen_squared_sum_in_batch=seqlen_squared_sum_in_batch,
             total_real_tokens_in_batch=total_real_tokens_in_batch,
+            vision_total_tokens_in_batch=vision_total_tokens_in_batch,
+            vision_seqlen_squared_sum_in_batch=vision_seqlen_squared_sum_in_batch,
+            vision_merged_tokens_in_batch=vision_merged_tokens_in_batch,
         )
         num_floating_point_operations_so_far += num_floating_point_operations_in_batch
         num_floating_point_operations_since_last_log_event += num_floating_point_operations_in_batch
@@ -4872,6 +5285,9 @@ def train(
             is_first_iteration=is_first_iteration,
             seqlen_squared_sum_in_batch=seqlen_squared_sum_in_batch,
             total_real_tokens_in_batch=total_real_tokens_in_batch,
+            vision_total_tokens_in_batch=vision_total_tokens_in_batch,
+            vision_seqlen_squared_sum_in_batch=vision_seqlen_squared_sum_in_batch,
+            vision_merged_tokens_in_batch=vision_merged_tokens_in_batch,
             num_microbatches=num_microbatches,
         )
         is_first_iteration = False

--- a/tests/unit_tests/test_num_floating_point_operations.py
+++ b/tests/unit_tests/test_num_floating_point_operations.py
@@ -20,8 +20,10 @@ import torch
 import megatron.training.training as training_module
 from megatron.training.training import (
     consume_seqlen_stats_in_iteration,
+    consume_vision_model_flops_stats,
     num_floating_point_operations,
     update_seqlen_stats_from_cu_seqlens,
+    update_vision_model_flops_stats,
 )
 
 
@@ -29,6 +31,12 @@ def _reset_seqlen_accumulator():
     """Tear down the per-iteration accumulator between tests."""
     training_module._seqlen_stats_in_iteration = None
     training_module._seqlen_stats_active = False
+
+
+def _reset_vision_flops_accumulator():
+    """Tear down the per-iteration vision FLOPs accumulator between tests."""
+    training_module._vision_flops_stats_in_iteration = None
+    training_module._vision_flops_stats_active = False
 
 
 def _make_gpt_args(
@@ -99,6 +107,50 @@ def _make_hybrid_args(*, num_layers=4, hidden_size=512, num_attention_heads=8, s
     return args
 
 
+def _enable_qwen35_vision_flops(args):
+    """Attach a small Qwen3.5-VL vision configuration to decoder args."""
+    args.count_vision_model_flops = True
+    args.vision_flops_variant = "qwen35_vl_v2"
+    args.vision_num_layers = 2
+    args.vision_hidden_size = 8
+    args.vision_ffn_hidden_size = 16
+    args.vision_num_attention_heads = 2
+    args.vision_kv_channels = 4
+    args.vision_in_channels = 3
+    args.vision_patch_size = 2
+    args.vision_temporal_patch_size = 2
+    args.vision_spatial_merge_size = 2
+    args.vision_out_hidden_size = 12
+    args.image_size = 8
+    return args
+
+
+def _qwen35_vision_golden_flops(*, total_patches, attention_sum_sq, merged_tokens):
+    """Independent matrix-shape calculation for the tiny vision config above."""
+    training_matmul_factor = 3 * 2
+    hidden_size = 8
+    ffn_hidden_size = 16
+    projection_size = 2 * 4
+    patch_dim = 3 * 2 * 2 * 2
+    merge_dim = hidden_size * 2**2
+
+    patch_embed = training_matmul_factor * total_patches * patch_dim * hidden_size
+    per_layer_projections = (
+        training_matmul_factor
+        * total_patches
+        * (
+            hidden_size * (3 * projection_size)
+            + projection_size * hidden_size
+            + hidden_size * ffn_hidden_size
+            + ffn_hidden_size * hidden_size
+        )
+    )
+    per_layer_attention = 3 * 4 * attention_sum_sq * projection_size
+    transformer = 2 * (per_layer_projections + per_layer_attention)
+    merger = training_matmul_factor * merged_tokens * (merge_dim * merge_dim + merge_dim * 12)
+    return patch_embed + transformer + merger
+
+
 class TestBSHDBackwardCompat:
     """For unpacked BSHD, the new optional arg must not change the result."""
 
@@ -148,6 +200,87 @@ class TestBSHDBackwardCompat:
         )
 
         assert default_flops == explicit_flops
+
+
+class TestQwen35VisionFlops:
+    """Qwen3.5-VL vision work is additive to either decoder FLOPs path."""
+
+    @pytest.mark.parametrize(
+        "args",
+        [
+            pytest.param(_make_gpt_args(), id="standard-decoder"),
+            pytest.param(_make_hybrid_args(), id="hybrid-decoder"),
+        ],
+    )
+    def test_runtime_grid_stats_add_exact_vision_flops(self, args):
+        batch_size = 2
+        decoder_flops = num_floating_point_operations(args, batch_size)
+        _enable_qwen35_vision_flops(args)
+
+        # Equivalent to grids [[2, 4, 4], [1, 2, 4]]:
+        # patches = 2*16 + 1*8 = 40
+        # attention sumsq = 2*16^2 + 1*8^2 = 576
+        # merged tokens = 2*(2*2) + 1*(1*2) = 10
+        vision_stats = {
+            "vision_total_tokens_in_batch": 40,
+            "vision_seqlen_squared_sum_in_batch": 576,
+            "vision_merged_tokens_in_batch": 10,
+        }
+        multimodal_flops = num_floating_point_operations(args, batch_size, **vision_stats)
+
+        assert multimodal_flops - decoder_flops == _qwen35_vision_golden_flops(
+            total_patches=40, attention_sum_sq=576, merged_tokens=10
+        )
+
+    def test_nominal_image_size_fallback_matches_explicit_stats(self):
+        args = _enable_qwen35_vision_flops(_make_gpt_args())
+        batch_size = 3
+
+        # image_size=8, patch=2 -> 4x4 grid; nominal T=2, merge=2.
+        nominal_flops = num_floating_point_operations(args, batch_size)
+        explicit_flops = num_floating_point_operations(
+            args,
+            batch_size,
+            vision_total_tokens_in_batch=batch_size * 2 * 16,
+            vision_seqlen_squared_sum_in_batch=batch_size * 2 * 16**2,
+            vision_merged_tokens_in_batch=batch_size * 2 * 2 * 2,
+        )
+        assert nominal_flops == explicit_flops
+
+    def test_partial_runtime_stats_fail_loudly(self):
+        args = _enable_qwen35_vision_flops(_make_gpt_args())
+        with pytest.raises(ValueError, match="must be provided together"):
+            num_floating_point_operations(args, batch_size=2, vision_total_tokens_in_batch=40)
+
+    def test_invalid_vision_metadata_fails_loudly(self):
+        args = _enable_qwen35_vision_flops(_make_gpt_args())
+        args.vision_spatial_merge_size = 0
+        with pytest.raises(ValueError, match="metadata must be positive"):
+            num_floating_point_operations(args, batch_size=2)
+
+    def test_negative_runtime_stats_fail_loudly(self):
+        args = _enable_qwen35_vision_flops(_make_gpt_args())
+        with pytest.raises(ValueError, match="must be non-negative"):
+            num_floating_point_operations(
+                args,
+                batch_size=2,
+                vision_total_tokens_in_batch=-1,
+                vision_seqlen_squared_sum_in_batch=0,
+                vision_merged_tokens_in_batch=0,
+            )
+
+    def test_enabled_unknown_variant_fails_loudly(self):
+        args = _enable_qwen35_vision_flops(_make_gpt_args())
+        args.vision_flops_variant = "unknown"
+        with pytest.raises(ValueError, match="Unsupported vision FLOPs variant"):
+            num_floating_point_operations(args, batch_size=2)
+
+    def test_disabled_vision_preserves_decoder_only_result(self):
+        args = _make_gpt_args()
+        decoder_flops = num_floating_point_operations(args, batch_size=2)
+        args.count_vision_model_flops = False
+        args.vision_flops_variant = "unknown"
+        assert num_floating_point_operations(args, batch_size=2) == decoder_flops
 
 
 class TestTHDScaling:
@@ -595,6 +728,58 @@ class TestAccumulator:
         assert training_module._seqlen_stats_active is False
         assert training_module._seqlen_stats_in_iteration is not None
         assert training_module._seqlen_stats_in_iteration.tolist() == [0.0, 0.0]
+
+
+class TestVisionFlopsAccumulator:
+    """Actual per-microbatch vision grids feed the global FLOPs estimate."""
+
+    def setup_method(self):
+        _reset_vision_flops_accumulator()
+
+    def teardown_method(self):
+        _reset_vision_flops_accumulator()
+
+    def test_variable_grids_accumulate_exact_stats(self):
+        update_vision_model_flops_stats(
+            torch.tensor([[2, 4, 4], [1, 2, 4]], dtype=torch.int64), spatial_merge_size=2
+        )
+        update_vision_model_flops_stats(
+            torch.tensor([[1, 6, 2]], dtype=torch.int64), spatial_merge_size=2
+        )
+
+        total_patches, attention_sum_sq, merged_tokens = consume_vision_model_flops_stats()
+        assert total_patches == 40 + 12
+        assert attention_sum_sq == 576 + 12**2
+        assert merged_tokens == 10 + 3
+
+    def test_no_vision_inputs_returns_none(self):
+        assert consume_vision_model_flops_stats() == (None, None, None)
+        assert training_module._vision_flops_stats_in_iteration is None
+        assert training_module._vision_flops_stats_active is False
+
+    def test_explicit_text_only_microbatch_returns_zeros(self):
+        update_vision_model_flops_stats(None, spatial_merge_size=2)
+        assert consume_vision_model_flops_stats() == (0.0, 0.0, 0.0)
+
+    def test_consume_resets_accumulator(self):
+        update_vision_model_flops_stats(
+            torch.tensor([[1, 4, 4]], dtype=torch.int64), spatial_merge_size=2
+        )
+        consume_vision_model_flops_stats()
+        assert consume_vision_model_flops_stats() == (None, None, None)
+
+    @pytest.mark.parametrize(
+        "grid,merge,error",
+        [
+            (torch.tensor([1, 4, 4]), 2, "shape"),
+            (torch.tensor([[1, 3, 4]]), 2, "divisible"),
+            (torch.tensor([[0, 4, 4]]), 2, "positive"),
+            (torch.tensor([[1, 4, 4]]), 0, "positive"),
+        ],
+    )
+    def test_invalid_grid_metadata_fails_loudly(self, grid, merge, error):
+        with pytest.raises(ValueError, match=error):
+            update_vision_model_flops_stats(grid, spatial_merge_size=merge)
 
 
 class TestAccumulatorDistributed:

--- a/tests/unit_tests/test_num_floating_point_operations.py
+++ b/tests/unit_tests/test_num_floating_point_operations.py
@@ -20,8 +20,11 @@ import torch
 import megatron.training.training as training_module
 from megatron.training.training import (
     consume_seqlen_stats_in_iteration,
+    consume_vision_model_flops_stats,
     num_floating_point_operations,
     update_seqlen_stats_from_cu_seqlens,
+    update_vision_model_flops_stats,
+    validate_vision_flops_metadata,
 )
 
 
@@ -29,6 +32,12 @@ def _reset_seqlen_accumulator():
     """Tear down the per-iteration accumulator between tests."""
     training_module._seqlen_stats_in_iteration = None
     training_module._seqlen_stats_active = False
+
+
+def _reset_vision_flops_accumulator():
+    """Tear down the per-iteration vision FLOPs accumulator between tests."""
+    training_module._vision_flops_stats_in_iteration = None
+    training_module._vision_flops_missing_runtime_stats_warned = False
 
 
 def _make_gpt_args(
@@ -136,6 +145,33 @@ def test_situ_glu_counts_the_same_ffn_gemms_as_swiglu():
     ) == num_floating_point_operations(swiglu_args, batch_size=8)
 
 
+def _enable_qwen35_vision_flops(args, validate=True):
+    """Attach a small Qwen3.5-VL vision configuration to decoder args.
+
+    Mirrors what ``examples/multimodal_dev/models/qwen35_vl/factory.py:
+    set_vision_flops_metadata`` sets on ``args``, including calling
+    ``validate_vision_flops_metadata`` (unless ``validate=False``, used by
+    tests that want to construct an invalid config and validate it
+    themselves after further mutating a field).
+    """
+    args.count_vision_model_flops = True
+    args.vision_flops_variant = "qwen35_vl"
+    args.vision_num_layers = 2
+    args.vision_hidden_size = 8
+    args.vision_ffn_hidden_size = 16
+    args.vision_num_attention_heads = 2
+    args.vision_kv_channels = 4
+    args.vision_in_channels = 3
+    args.vision_patch_size = 2
+    args.vision_temporal_patch_size = 2
+    args.vision_spatial_merge_size = 2
+    args.vision_out_hidden_size = 12
+    args.image_size = 8
+    if validate:
+        validate_vision_flops_metadata(args)
+    return args
+
+
 class TestBSHDBackwardCompat:
     """For unpacked BSHD, the new optional arg must not change the result."""
 
@@ -185,6 +221,137 @@ class TestBSHDBackwardCompat:
         )
 
         assert default_flops == explicit_flops
+
+
+class TestQwen35VisionFlops:
+    """Qwen3.5-VL vision work is additive to either decoder FLOPs path."""
+
+    @pytest.mark.parametrize(
+        "args",
+        [
+            pytest.param(_make_gpt_args(), id="standard-decoder"),
+            pytest.param(_make_hybrid_args(), id="hybrid-decoder"),
+        ],
+    )
+    def test_runtime_grid_stats_add_exact_vision_flops(self, args):
+        batch_size = 2
+        decoder_flops = num_floating_point_operations(args, batch_size)
+        _enable_qwen35_vision_flops(args)
+
+        # Equivalent to grids [[2, 4, 4], [1, 2, 4]]:
+        # patches = 2*16 + 1*8 = 40
+        # attention sumsq = 2*16^2 + 1*8^2 = 576
+        # merged tokens = 2*(2*2) + 1*(1*2) = 10
+        vision_stats = {
+            "vision_total_tokens_in_batch": 40,
+            "vision_seqlen_squared_sum_in_batch": 576,
+            "vision_merged_tokens_in_batch": 10,
+        }
+        multimodal_flops = num_floating_point_operations(args, batch_size, **vision_stats)
+
+        # Hand-computed for the tiny config set by _enable_qwen35_vision_flops
+        # (hidden=8, ffn=16, heads=2, kv_channels=4, in_channels=3, patch=2,
+        # temporal_patch=2, spatial_merge=2, out_hidden=12, num_layers=2) --
+        # an independent oracle a wrong factor in the implementation cannot
+        # influence, unlike re-deriving the same formula here.
+        #   projection_size = kv_channels * heads = 4 * 2 = 8
+        #   patch_dim = in_channels * temporal_patch * patch * patch = 3*2*2*2 = 24
+        #   merge_dim = hidden * spatial_merge^2 = 8 * 2^2 = 32
+        #   matmul_factor = 3 (fwd+bwd) * 2 (fma) = 6
+        #   patch_embed = matmul_factor * total_patches * patch_dim * hidden
+        #               = 6 * 40 * 24 * 8 = 46080
+        #   per_layer_proj = matmul_factor * total_patches
+        #       * (hidden*3*projection_size + projection_size*hidden + hidden*ffn + ffn*hidden)
+        #       = 6 * 40 * (8*24 + 64 + 128 + 128) = 6 * 40 * 512 = 122880
+        #   per_layer_attn = 3 * 4 * attention_sum_sq * projection_size
+        #       = 12 * 576 * 8 = 55296
+        #   transformer = num_layers * (per_layer_proj + per_layer_attn)
+        #       = 2 * (122880 + 55296) = 356352
+        #   merger = matmul_factor * merged_tokens * (merge_dim*merge_dim + merge_dim*out_hidden)
+        #       = 6 * 10 * (1024 + 384) = 84480
+        #   total = patch_embed + transformer + merger = 46080 + 356352 + 84480 = 486912
+        assert multimodal_flops - decoder_flops == 486912
+
+    def test_missing_runtime_stats_omit_vision_flops(self):
+        # No nominal fallback: without runtime grid_thw statistics the vision
+        # contribution is excluded rather than synthesised from --image-size
+        # and vision_temporal_patch_size, which describe a patch kernel depth
+        # and a mock-data resolution, not the runtime (T, H, W) grid.
+        args = _make_gpt_args()
+        batch_size = 3
+        decoder_flops = num_floating_point_operations(args, batch_size)
+
+        _enable_qwen35_vision_flops(args)
+        assert num_floating_point_operations(args, batch_size) == decoder_flops
+
+    def test_temporal_extent_independent_of_temporal_patch_size(self):
+        # T is whatever the processor emitted, never vision_temporal_patch_size.
+        # Same total patch count, different temporal split -> same token-linear
+        # work but different per-frame attention work.
+        args = _enable_qwen35_vision_flops(_make_gpt_args())
+        common = dict(vision_total_tokens_in_batch=32, vision_merged_tokens_in_batch=8)
+
+        # T=1, 4x8 grid: one 32-long sequence -> sum(L^2) = 1024.
+        one_frame = num_floating_point_operations(
+            args, 2, vision_seqlen_squared_sum_in_batch=1024, **common
+        )
+        # T=4, 4x2 grid: four 8-long sequences -> sum(L^2) = 4 * 64 = 256.
+        four_frames = num_floating_point_operations(
+            args, 2, vision_seqlen_squared_sum_in_batch=256, **common
+        )
+        # Only the attention term differs: 2 layers * 3 * 4 * dsum * proj(=8).
+        assert one_frame - four_frames == 2 * 12 * (1024 - 256) * 8
+
+    def test_partial_runtime_stats_fail_loudly(self):
+        args = _enable_qwen35_vision_flops(_make_gpt_args())
+        with pytest.raises(ValueError, match="must be provided together"):
+            num_floating_point_operations(args, batch_size=2, vision_total_tokens_in_batch=40)
+
+    def test_invalid_vision_metadata_fails_loudly(self):
+        # Metadata is validated eagerly (at model-construction time), not
+        # inside num_floating_point_operations -- see validate_vision_flops_metadata.
+        args = _enable_qwen35_vision_flops(_make_gpt_args(), validate=False)
+        args.vision_spatial_merge_size = 0
+        with pytest.raises(ValueError, match="metadata must be positive"):
+            validate_vision_flops_metadata(args)
+
+    def test_negative_runtime_stats_fail_loudly(self):
+        args = _enable_qwen35_vision_flops(_make_gpt_args())
+        with pytest.raises(ValueError, match="must be non-negative"):
+            num_floating_point_operations(
+                args,
+                batch_size=2,
+                vision_total_tokens_in_batch=-1,
+                vision_seqlen_squared_sum_in_batch=0,
+                vision_merged_tokens_in_batch=0,
+            )
+
+    def test_unvalidated_metadata_fails_with_an_actionable_error(self):
+        # An entry point that sets count_vision_model_flops without routing
+        # through validate_vision_flops_metadata must get a pointer to the
+        # validator, not a bare AttributeError at iteration 1.
+        args = _enable_qwen35_vision_flops(_make_gpt_args(), validate=False)
+        with pytest.raises(ValueError, match="validate_vision_flops_metadata"):
+            num_floating_point_operations(
+                args,
+                batch_size=2,
+                vision_total_tokens_in_batch=40,
+                vision_seqlen_squared_sum_in_batch=576,
+                vision_merged_tokens_in_batch=10,
+            )
+
+    def test_enabled_unknown_variant_fails_loudly(self):
+        args = _enable_qwen35_vision_flops(_make_gpt_args(), validate=False)
+        args.vision_flops_variant = "unknown"
+        with pytest.raises(ValueError, match="Unsupported vision FLOPs variant"):
+            validate_vision_flops_metadata(args)
+
+    def test_disabled_vision_preserves_decoder_only_result(self):
+        args = _make_gpt_args()
+        decoder_flops = num_floating_point_operations(args, batch_size=2)
+        args.count_vision_model_flops = False
+        args.vision_flops_variant = "unknown"
+        assert num_floating_point_operations(args, batch_size=2) == decoder_flops
 
 
 class TestTHDScaling:
@@ -741,6 +908,106 @@ class TestAccumulator:
         assert training_module._seqlen_stats_in_iteration.tolist() == [0.0, 0.0]
 
 
+class TestVisionFlopsAccumulator:
+    """Actual per-microbatch vision grids feed the global FLOPs estimate."""
+
+    def setup_method(self):
+        _reset_vision_flops_accumulator()
+
+    def teardown_method(self):
+        _reset_vision_flops_accumulator()
+
+    def test_variable_grids_accumulate_exact_stats(self):
+        update_vision_model_flops_stats(
+            torch.tensor([[2, 4, 4], [1, 2, 4]], dtype=torch.int64), spatial_merge_size=2
+        )
+        update_vision_model_flops_stats(
+            torch.tensor([[1, 6, 2]], dtype=torch.int64), spatial_merge_size=2
+        )
+
+        total_patches, attention_sum_sq, merged_tokens = consume_vision_model_flops_stats(True)
+        assert total_patches == 40 + 12
+        assert attention_sum_sq == 576 + 12**2
+        assert merged_tokens == 10 + 3
+
+    def test_no_vision_inputs_returns_none(self):
+        assert consume_vision_model_flops_stats(True) == (None, None, None)
+
+    def test_disabled_returns_none_without_touching_state(self):
+        """count_vision_model_flops=False must short-circuit before touching
+        the accumulator, even if an update happened to land earlier (e.g. a
+        stale value from before the feature was toggled off)."""
+        update_vision_model_flops_stats(
+            torch.tensor([[1, 4, 4]], dtype=torch.int64), spatial_merge_size=2
+        )
+        assert consume_vision_model_flops_stats(False) == (None, None, None)
+        # The (still-active) accumulator is untouched -- draining it with the
+        # feature enabled recovers the same update.
+        assert consume_vision_model_flops_stats(True) == (16.0, 256.0, 4.0)
+
+    def test_explicit_text_only_microbatch_returns_zeros(self):
+        update_vision_model_flops_stats(None, spatial_merge_size=2)
+        assert consume_vision_model_flops_stats(True) == (0.0, 0.0, 0.0)
+
+    def test_consume_resets_accumulator(self):
+        update_vision_model_flops_stats(
+            torch.tensor([[1, 4, 4]], dtype=torch.int64), spatial_merge_size=2
+        )
+        consume_vision_model_flops_stats(True)
+        assert consume_vision_model_flops_stats(True) == (None, None, None)
+
+    def test_multi_image_microbatch_sums_every_grid_row(self):
+        # One microbatch carrying three images of different resolutions.
+        update_vision_model_flops_stats(
+            torch.tensor([[1, 4, 4], [1, 2, 6], [3, 2, 2]], dtype=torch.int64), spatial_merge_size=2
+        )
+        total_patches, attention_sum_sq, merged_tokens = consume_vision_model_flops_stats(True)
+        assert total_patches == 16 + 12 + 3 * 4
+        assert attention_sum_sq == 16**2 + 12**2 + 3 * 4**2
+        assert merged_tokens == (2 * 2) + (1 * 3) + 3 * (1 * 1)
+
+    def test_text_only_and_image_microbatches_mix(self):
+        update_vision_model_flops_stats(None, spatial_merge_size=2)
+        update_vision_model_flops_stats(
+            torch.tensor([[1, 4, 4]], dtype=torch.int64), spatial_merge_size=2
+        )
+        update_vision_model_flops_stats(
+            torch.empty((0, 3), dtype=torch.int64), spatial_merge_size=2
+        )
+        assert consume_vision_model_flops_stats(True) == (16.0, 256.0, 4.0)
+
+    @pytest.mark.parametrize(
+        "grid,merge,error",
+        [
+            (torch.tensor([1, 4, 4]), 2, "shape"),
+            (torch.tensor([[1, 4, 4]]), 0, "positive"),
+            (torch.tensor([[1, 4, 4]]), None, "positive"),
+        ],
+    )
+    def test_malformed_grid_shape_fails_eagerly(self, grid, merge, error):
+        with pytest.raises(ValueError, match=error):
+            update_vision_model_flops_stats(grid, spatial_merge_size=merge)
+
+    @pytest.mark.parametrize(
+        "grid",
+        [
+            pytest.param(torch.tensor([[1, 3, 4]]), id="height-not-divisible"),
+            pytest.param(torch.tensor([[1, 4, 5]]), id="width-not-divisible"),
+            pytest.param(torch.tensor([[0, 4, 4]]), id="zero-temporal"),
+            pytest.param(torch.tensor([[1, -4, 4]]), id="negative-height"),
+        ],
+    )
+    def test_invalid_grid_values_raise_at_consume(self, grid):
+        # Value validation is device-side and deferred to ``consume_*`` so that
+        # production CUDA grids get the same checking as CPU ones without
+        # paying a per-microbatch device-to-host sync.
+        update_vision_model_flops_stats(grid, spatial_merge_size=2)
+        with pytest.raises(ValueError, match="non-positive extent"):
+            consume_vision_model_flops_stats(True)
+        # ...and the error does not leak into the next iteration.
+        assert consume_vision_model_flops_stats(True) == (None, None, None)
+
+
 class TestAccumulatorDistributed:
     """All-reduce + ``TP*CP*PP`` deduplication.
 
@@ -829,6 +1096,124 @@ class TestAccumulatorDistributed:
         assert calls == [], "consume must not issue all_reduce when no update happened"
 
 
+class TestVisionFlopsAccumulatorDistributed:
+    """Vision FLOPs collective entry is gated on config, not on the local flag.
+
+    Regression coverage for the desync fix: entering the all-reduce in
+    ``consume_vision_model_flops_stats`` must depend ONLY on
+    ``count_vision_model_flops`` (identical on every rank), never on whether
+    THIS rank happened to call ``update_vision_model_flops_stats`` locally
+    this iteration (e.g. its data iterator ran dry). A regression here would
+    hang in production with >=2 ranks; run with ``torchrun --nproc_per_node=2``.
+    """
+
+    def setup_method(self):
+        _reset_vision_flops_accumulator()
+
+    def teardown_method(self):
+        from tests.unit_tests.test_utilities import Utils
+
+        _reset_vision_flops_accumulator()
+        Utils.destroy_model_parallel()
+
+    def test_enters_collective_even_when_this_rank_never_updated(self):
+        from tests.unit_tests.test_utilities import Utils
+
+        if Utils.world_size < 2:
+            pytest.skip("requires >= 2 ranks")
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=1, pipeline_model_parallel_size=1
+        )
+
+        # Only rank 0 reports a grid this iteration; every other rank's data
+        # iterator is simulated as exhausted (never calls update_*). Before
+        # the fix, only rank 0 would enter the all_reduce here -> hang.
+        if Utils.rank == 0:
+            update_vision_model_flops_stats(
+                torch.tensor([[1, 4, 4]], dtype=torch.int64, device='cuda'), spatial_merge_size=2
+            )
+
+        total_patches, attention_sum_sq, merged_tokens = consume_vision_model_flops_stats(True)
+        # Pure DP (TP=CP=PP=1): no dedup, sums across ranks. Only rank 0
+        # contributed, so the global sum equals rank 0's single update.
+        assert total_patches == 16
+        assert attention_sum_sq == 256
+        assert merged_tokens == 4
+
+    def test_no_updates_anywhere_still_returns_none(self):
+        from tests.unit_tests.test_utilities import Utils
+
+        if Utils.world_size < 2:
+            pytest.skip("requires >= 2 ranks")
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=1, pipeline_model_parallel_size=1
+        )
+
+        # No rank calls update_* this iteration -- must still enter the
+        # (cheap) collective without hanging, and report that nothing was
+        # collected so the caller omits the vision terms entirely.
+        assert consume_vision_model_flops_stats(True) == (None, None, None)
+
+    def test_differing_activity_across_ranks_still_deduplicates(self):
+        """Activity differs across ranks AND model parallelism is on.
+
+        Rank 0 of each TP group reports a grid while the others never call
+        ``update_*``. Consumption must complete (no hang) and the ``TP*CP*PP``
+        dedup must still be applied to whatever was reported.
+        """
+        from megatron.core import mpu
+        from tests.unit_tests.test_utilities import Utils
+
+        if Utils.world_size < 2:
+            pytest.skip("requires >= 2 ranks")
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=Utils.world_size, pipeline_model_parallel_size=1
+        )
+
+        # Only the first rank in the TP group has runtime data. The world sum
+        # is therefore ONE grid, but consume divides by tp_size -- so the
+        # reported value is deliberately 1/tp of a grid. This pins the
+        # contract that dedup is unconditional, and documents why every rank
+        # in a model-parallel group is expected to report the same grids.
+        tp_size = mpu.get_tensor_model_parallel_world_size()
+        if mpu.get_tensor_model_parallel_rank() == 0:
+            update_vision_model_flops_stats(
+                torch.tensor([[1, 4, 4]], dtype=torch.int64, device='cuda'), spatial_merge_size=2
+            )
+
+        total_patches, attention_sum_sq, merged_tokens = consume_vision_model_flops_stats(True)
+        assert total_patches == pytest.approx(16 / tp_size)
+        assert attention_sum_sq == pytest.approx(256 / tp_size)
+        assert merged_tokens == pytest.approx(4 / tp_size)
+
+    def test_invalid_grid_on_one_rank_raises_on_all_ranks(self):
+        """A bad grid anywhere must surface everywhere, not just on its rank.
+
+        The malformed-row counter rides in the all-reduced tensor, so every
+        rank raises. A rank-local raise would leave the peers waiting in the
+        next collective.
+        """
+        from tests.unit_tests.test_utilities import Utils
+
+        if Utils.world_size < 2:
+            pytest.skip("requires >= 2 ranks")
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=1, pipeline_model_parallel_size=1
+        )
+
+        if Utils.rank == 0:
+            update_vision_model_flops_stats(
+                torch.tensor([[1, 3, 4]], dtype=torch.int64, device='cuda'), spatial_merge_size=2
+            )
+        else:
+            update_vision_model_flops_stats(
+                torch.tensor([[1, 4, 4]], dtype=torch.int64, device='cuda'), spatial_merge_size=2
+            )
+
+        with pytest.raises(ValueError, match="non-positive extent"):
+            consume_vision_model_flops_stats(True)
+
+
 # 8-GPU topology matrix. Each tuple is ``(tp, cp, pp)`` with ``dp = 8 / (tp*cp*pp)``.
 # The matrix covers every model-parallel dim in isolation and the pairwise /
 # three-way combinations that fit in 8 GPUs. This pins the contract that:
@@ -913,6 +1298,64 @@ class TestAccumulatorTopology:
             f"topology tp={tp} cp={cp} pp={pp} dp={dp_size}: "
             f"got seqlen_squared_sum={seqlen_squared_sum}, expected {expected_sum_sq}"
         )
+
+
+class TestVisionFlopsAccumulatorTopology:
+    """``TP*CP*PP`` dedup for the vision accumulator across the 8-GPU matrix.
+
+    Same production invariant as :class:`TestAccumulatorTopology`: every rank
+    within a DP group sees the SAME ``image_grid_thw`` (it is broadcast across
+    the model-parallel dims, and the vision encoder is additionally replicated
+    across CP by design), while DP groups see different samples.
+
+    Skipped unless launched with ``torchrun --nproc_per_node 8``.
+    """
+
+    def setup_method(self):
+        _reset_vision_flops_accumulator()
+
+    def teardown_method(self):
+        from tests.unit_tests.test_utilities import Utils
+
+        _reset_vision_flops_accumulator()
+        Utils.destroy_model_parallel()
+
+    @pytest.mark.parametrize("tp,cp,pp", _TOPOLOGY_8GPU_PARAMS)
+    def test_dedup_across_topology(self, tp, cp, pp):
+        from megatron.core import mpu
+        from tests.unit_tests.test_utilities import Utils
+
+        if Utils.world_size != 8:
+            pytest.skip(f"requires exactly 8 ranks; got {Utils.world_size}")
+
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=tp, pipeline_model_parallel_size=pp, context_parallel_size=cp
+        )
+
+        dp_size = Utils.world_size // (tp * cp * pp)
+        assert dp_size == mpu.get_data_parallel_world_size()
+        dp_rank = mpu.get_data_parallel_rank()
+
+        # Per-DP-group grid: a 2-image microbatch whose extents grow with the
+        # DP rank so every DP group contributes a different amount to all
+        # three statistics.
+        scale = dp_rank + 1
+        grid = torch.tensor(
+            [[1, 2 * scale, 2 * scale], [2, 2, 4 * scale]], dtype=torch.int64, device='cuda'
+        )
+        update_vision_model_flops_stats(grid, spatial_merge_size=2)
+
+        expected_patches = sum((2 * (r + 1)) ** 2 + 2 * (2 * 4 * (r + 1)) for r in range(dp_size))
+        expected_sum_sq = sum(
+            ((2 * (r + 1)) ** 2) ** 2 + 2 * (2 * 4 * (r + 1)) ** 2 for r in range(dp_size)
+        )
+        expected_merged = sum((r + 1) ** 2 + 2 * (1 * 2 * (r + 1)) for r in range(dp_size))
+
+        total_patches, attention_sum_sq, merged_tokens = consume_vision_model_flops_stats(True)
+        context = f"topology tp={tp} cp={cp} pp={pp} dp={dp_size}"
+        assert total_patches == pytest.approx(expected_patches), context
+        assert attention_sum_sq == pytest.approx(expected_sum_sq), context
+        assert merged_tokens == pytest.approx(expected_merged), context
 
 
 def _make_dsv4_args():


### PR DESCRIPTION
## Summary

- add Qwen3.5-VL vision encoder work to Megatron's model FLOPs and throughput metrics
- account for Conv3d patch projection, dense vision attention and MLP projections, bidirectional attention, and patch-merger projections
- aggregate actual `image_grid_thw` statistics across microbatches and distributed ranks so variable-resolution, multi-image, text-only and packed-sequence inputs use their real patch and attention sizes
- preserve decoder-only behavior for non-multimodal models
- validate the vision metadata once at model-construction time, so a misconfiguration fails before the dataloader is built instead of at iteration 1
- document the accounting contract and add exact-formula, validation, rerun, and distributed accumulator tests

## Root cause

The Qwen3.5-VL model factory already registered the vision architecture metadata, but the core `num_floating_point_operations` path did not consume it. Reported TFLOP/s therefore included only the language decoder.

## Review changes since the last push

Rebased onto current `dev` (`0cd11658f`), which includes #6315 (HybridModel migration). The three blockers from @FDecaYed's review are addressed:

**1. Rank-local flag gating a world `all_reduce`** ([thread](https://github.com/NVIDIA/Megatron-LM/pull/6173#discussion_r3774097634))

Collective participation is now a global invariant: whether `consume_vision_model_flops_stats` enters the all-reduce is decided by `args.count_vision_model_flops` alone — a config value identical on every rank — never by whether this rank happened to call `update_*`. Ranks with nothing to report contribute a zero tensor, and the "did any rank report runtime data" flag is reduced inside that same collective (it rides in the stats tensor, so the protocol is still one all-reduce and one host sync per iteration).

Covered by `TestVisionFlopsAccumulatorDistributed`, including `test_differing_activity_across_ranks_still_deduplicates` (activity differs across ranks with TP>1; consumption completes and the dedup is still applied) and `test_invalid_grid_on_one_rank_raises_on_all_ranks`. The `TP*CP*PP` dedup, previously only asserted in a docstring, is now pinned by `TestVisionFlopsAccumulatorTopology` over the existing `_TOPOLOGY_8GPU_PARAMS` matrix.

**2. Nominal fallback conflating temporal patch depth with the runtime grid count** ([thread](https://github.com/NVIDIA/Megatron-LM/pull/6173#discussion_r3774097525))

Took the "omit" option. The fallback is deleted outright — no `temporal_grid_size = args.vision_temporal_patch_size`, no `args.image_size` read from core code, no one-image-per-sequence assumption. The vision terms are driven exclusively by statistics a forward step actually reported; when none were reported the vision contribution is excluded and a one-time warning names the hook the entry point failed to call. `examples/multimodal_dev/arguments.py` is untouched again.

Tests cover a temporal extent different from `vision_temporal_patch_size`, multi-image microbatches, text-only microbatches, and the omit path.

**3. Rerun replays double-counting** ([thread](https://github.com/NVIDIA/Megatron-LM/pull/6173#discussion_r3774097741))

The hook is now `record_vision_model_flops(args, model, batch)`, which skips when the rerun state machine is in `RERUNNING_IN_PLACE` — the only state that replays in-process; the checkpoint-restart states replay in a fresh process with an empty accumulator. `examples/multimodal_dev/tests/test_vision_flops_accounting.py::test_in_place_rerun_does_not_double_count` forces one replay and asserts the consumed statistics equal a single logical pass.

Also addressed from the earlier `/claude strict-review`: metadata validation and derived-scalar precomputation hoisted out of the per-iteration path into `validate_vision_flops_metadata`; grid value validation made device-agnostic (malformed rows accumulate into a reduced counter instead of being checked only on CPU tensors, so production CUDA grids get the same strictness at no extra host sync); merged-token count uses floor division to match the merger's `view(-1, merge_dim)`; the exact-formula test anchored to a hand-computed integer instead of transcribing the implementation; variant renamed `qwen35_vl_v2` → `qwen35_vl`; the `README.md` registry template no longer names a variant that would apply Qwen3.5-VL's formula to a different architecture.

## Test plan

Run in the CI container image on 1x and 8x H100:

- `pytest tests/unit_tests/test_num_floating_point_operations.py` — 75 passed, 23 skipped (skips are the >=2-rank and 8-rank cases)
- `torchrun --nproc_per_node=8 -m pytest tests/unit_tests/test_num_floating_point_operations.py -k 'Distributed or Topology'` — 23 passed, covering all 8 `(TP, CP, PP)` topologies for both accumulators
- `pytest examples/multimodal_dev/tests/test_vision_flops_accounting.py` — 7 passed
- `black==26.3.0`, `isort`, `ruff` clean on every line this PR adds

(The previous revision's test plan noted pytest had never executed, blocked on container registry credentials. That is resolved; the numbers above are from real runs.)

## Sequencing

@FDecaYed asked to land this after #6315 and #6081. #6315 is merged and is in this base; #6081 is still open. Happy to rebase again onto the then-current `dev` once it lands.
