### PR TITLE
[Dev] Fix FSDP forward prefetch in combined 1F1B

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
@@ -501,6 +501,21 @@ class MegatronFSDP(torch.nn.Module):
             # attribute.
             param.overwrite_main_grad = True
 
+    @torch.compiler.disable
+    def prepare_forward_module(self, module: nn.Module) -> None:
+        """Prepare an FSDP unit for a genuine forward scheduled during backward.
+
+        The root pre-backward hook marks every submodule ``PRE_BACKWARD`` so
+        activation-recomputation forwards do not issue forward-order prefetches
+        or eagerly reshard their parameters. The EP-overlap 1F1B schedule also
+        executes a genuine forward for another microbatch inside that backward
+        window. Clear the marker only for that forward layer; recomputation in
+        the independently scheduled backward layer remains ``PRE_BACKWARD``.
+        """
+        for submodule in module.modules():
+            if submodule._training_state == TrainingState.PRE_BACKWARD:
+                submodule._training_state = TrainingState.IDLE
+
     def _register_fsdp_hooks(self, root_module):
         """Register necessary hooks for Fully Sharded Data Parallel (FSDP) execution on the model.
 

--- a/megatron/core/models/common/model_chunk_schedule_plan.py
+++ b/megatron/core/models/common/model_chunk_schedule_plan.py
@@ -81,6 +81,7 @@ class TransformerLayerSchedulePlan:
         self.event = event
         self.comp_stream = comp_stream
         self.comm_stream = comm_stream
+        self._fsdp_prepare_forward_module = None
 
         # get callable nodes for transformer/mtp layer
         self._build_callable_nodes(event, comp_stream, comm_stream, extra_args)
@@ -110,6 +111,7 @@ class TransformerLayerSchedulePlan:
             self.layer_state = None
         if hasattr(self, 'layer'):
             del self.layer
+        self._fsdp_prepare_forward_module = None
 
     def _build_callable_nodes(self, event, comp_stream, comm_stream, extra_args):
         """
@@ -196,7 +198,9 @@ class TransformerLayerSchedulePlan:
         else:
             self.mtp_post_process = NoopScheduleNode()
 
-    def set_fsdp_reshard_hooks(self, post_forward_hook, post_backward_hook):
+    def set_fsdp_reshard_hooks(
+        self, post_forward_hook, post_backward_hook, prepare_forward_module=None
+    ):
         """Wire FSDP parameter release callbacks for the fine-grained overlap schedule.
 
         The EP overlap schedule bypasses the normal FSDP forward/backward hooks
@@ -210,6 +214,8 @@ class TransformerLayerSchedulePlan:
                 (bwd=False). Typically ``fsdp_wrapper.post_forward_release_module``.
             post_backward_hook: Callable(module) that releases backward-pass params
                 (bwd=True). Typically ``fsdp_wrapper.post_backward_release_module``.
+            prepare_forward_module: Optional callable that clears the root
+                ``PRE_BACKWARD`` marker for this genuine-forward layer.
         """
         from megatron.core.transformer.multi_token_prediction import MultiTokenPredictionLayer
         from megatron.core.transformer.transformer_layer import TransformerLayer
@@ -223,6 +229,9 @@ class TransformerLayerSchedulePlan:
             hook_module = self.layer
         else:
             hook_module = self.layer.mtp_model_layer
+
+        if prepare_forward_module is not None:
+            self._fsdp_prepare_forward_module = lambda: prepare_forward_module(hook_module)
 
         # After the last backward op (attn), release backward-pass params.
         self.attn.set_post_backward_hook(lambda: post_backward_hook(hook_module))
@@ -331,6 +340,12 @@ class TransformerLayerSchedulePlan:
             b_grad = b_layer.moe_combine.backward(b_grad)
 
         if f_layer is not None:
+            # With an odd layer count, the middle unit can schedule forward and
+            # backward on the same underlying layer. Keep PRE_BACKWARD there so
+            # recompute weights remain lazily resharded until backward uses them.
+            same_underlying_layer = b_layer is not None and f_layer.layer is b_layer.layer
+            if f_layer._fsdp_prepare_forward_module is not None and not same_underlying_layer:
+                f_layer._fsdp_prepare_forward_module()
             with f_layer.get_fp8_context():
                 f_input = f_layer.attn.forward(f_input)
 

--- a/megatron/core/pipeline_parallel/combined_1f1b.py
+++ b/megatron/core/pipeline_parallel/combined_1f1b.py
@@ -421,6 +421,7 @@ def combined_forward_backward_step(
                 layer_plan.set_fsdp_reshard_hooks(
                     forward_fsdp_wrapper.post_forward_release_module,
                     forward_fsdp_wrapper.post_backward_release_module,
+                    forward_fsdp_wrapper.prepare_forward_module,
                 )
 
     # backward preprocess, the same as the backward_step()

--- a/tests/unit_tests/a2a_overlap/test_fsdp_1f1b_overlap.py
+++ b/tests/unit_tests/a2a_overlap/test_fsdp_1f1b_overlap.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import gc
 
@@ -9,6 +9,7 @@ import torch.nn.functional as F
 from megatron.core.distributed import DistributedDataParallelConfig
 from megatron.core.distributed.fsdp.mcore_fsdp_adapter import FullyShardedDataParallel
 from megatron.core.distributed.fsdp.src.megatron_fsdp.fully_shard import fully_shard_optimizer
+from megatron.core.distributed.fsdp.src.megatron_fsdp.megatron_fsdp import TrainingState
 from megatron.core.pipeline_parallel.utils import set_streams
 from megatron.core.transformer import TransformerLayer
 from megatron.core.utils import is_te_min_version
@@ -89,6 +90,110 @@ class TestFSDP1F1BOverlap:
             recompute_modules=recompute_modules,
             offload_modules=offload_modules,
         )
+
+    @pytest.mark.skipif(not is_te_min_version("2.3.0"), reason="Requires TE >= 2.3.0")
+    def test_fsdp_1f1b_genuine_forward_state(self):
+        """A genuine forward must leave PRE_BACKWARD without changing its peer layer."""
+        num_layers = 2
+        num_microbatches = 2
+        extra_kwargs = {"overlap_moe_expert_parallel_comm": True}
+        apply_flex_backend_kwargs(extra_kwargs, "alltoall", None)
+
+        def _make_ddp_config():
+            return DistributedDataParallelConfig(
+                use_megatron_fsdp=True,
+                data_parallel_sharding_strategy="optim_grads_params",
+                overlap_grad_reduce=True,
+                overlap_param_gather=True,
+                megatron_fsdp_main_params_dtype=None,
+            )
+
+        with deterministic_mode():
+            data = build_input_data(seq_len=SEQ_LEN, vocab_size=VOCAB_SIZE)
+
+            control_config = get_test_config(num_layers=num_layers, extra_kwargs=extra_kwargs)
+            control_model = build_gpt_model(control_config, vocab_size=VOCAB_SIZE)
+            init_params = reset_model(control_model)
+            control_fsdp = FullyShardedDataParallel(
+                config=control_config,
+                ddp_config=_make_ddp_config(),
+                module=control_model,
+                fsdp_unit_modules=[TransformerLayer],
+            )
+            # Reproduce the old behavior: genuine forwards inherit the root
+            # PRE_BACKWARD marker and therefore disable forward-order prefetch.
+            control_fsdp.module.prepare_forward_module = lambda module: None
+            control_opt = fully_shard_optimizer(
+                optimizer=torch.optim.SGD(control_fsdp.parameters(), lr=LR)
+            )
+
+            test_config = get_test_config(num_layers=num_layers, extra_kwargs=extra_kwargs)
+            test_model = build_gpt_model(test_config, vocab_size=VOCAB_SIZE)
+            reset_model(test_model, init_params)
+            test_fsdp = FullyShardedDataParallel(
+                config=test_config,
+                ddp_config=_make_ddp_config(),
+                module=test_model,
+                fsdp_unit_modules=[TransformerLayer],
+            )
+            genuine_forward_state_transitions = []
+            original_prepare_forward = test_fsdp.module.prepare_forward_module
+
+            def _track_prepare_forward(module):
+                before = tuple(submodule._training_state for submodule in module.modules())
+                peer_layers = [layer for layer in test_model.decoder.layers if layer is not module]
+                peer_states_before = tuple(
+                    tuple(submodule._training_state for submodule in layer.modules())
+                    for layer in peer_layers
+                )
+                result = original_prepare_forward(module)
+                after = tuple(submodule._training_state for submodule in module.modules())
+                peer_states_after = tuple(
+                    tuple(submodule._training_state for submodule in layer.modules())
+                    for layer in peer_layers
+                )
+                assert peer_states_after == peer_states_before
+                genuine_forward_state_transitions.append((before, after))
+                return result
+
+            test_fsdp.module.prepare_forward_module = _track_prepare_forward
+            test_opt = fully_shard_optimizer(
+                optimizer=torch.optim.SGD(test_fsdp.parameters(), lr=LR)
+            )
+
+            rank = torch.distributed.get_rank()
+            for step in range(NUM_STEPS):
+                control_loss = overlap_train_step(
+                    control_fsdp,
+                    control_opt,
+                    control_config,
+                    data,
+                    num_microbatches=num_microbatches,
+                )
+                test_loss = overlap_train_step(
+                    test_fsdp, test_opt, test_config, data, num_microbatches=num_microbatches
+                )
+                assert torch.equal(control_loss, test_loss), (
+                    f"[rank {rank}] Loss mismatch at step {step}: "
+                    f"control={control_loss.item()}, test={test_loss.item()}"
+                )
+
+            assert_models_equal(control_fsdp, test_fsdp)
+            assert len(genuine_forward_state_transitions) == (
+                NUM_STEPS * num_microbatches * num_layers
+            )
+            assert any(
+                TrainingState.PRE_BACKWARD in before
+                for before, _ in genuine_forward_state_transitions
+            )
+            assert all(
+                TrainingState.PRE_BACKWARD not in after
+                for _, after in genuine_forward_state_transitions
+            )
+
+            del control_fsdp, test_fsdp, control_opt, test_opt
+            gc.collect()
+            torch.cuda.empty_cache()
 
     def _run_test_helper(
         self,

--- a/tests/unit_tests/a2a_overlap/utils.py
+++ b/tests/unit_tests/a2a_overlap/utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 import os
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -352,10 +352,8 @@ def forward_step_func(data_iterator, model, return_schedule_plan=False):
     return output, loss_func
 
 
-def overlap_train_step(model, optimizer, config, data):
+def overlap_train_step(model, optimizer, config, data, num_microbatches=1):
     """One overlap forward-backward-optimizer step. Return scalar loss."""
-    from contextlib import nullcontext
-
     from megatron.core.pipeline_parallel.combined_1f1b import (
         combined_1f1b_schedule_for_no_pipelining,
     )
@@ -364,9 +362,9 @@ def overlap_train_step(model, optimizer, config, data):
     forward_data_store = []
     combined_1f1b_schedule_for_no_pipelining(
         forward_step_func=forward_step_func,
-        data_iterator=iter([data]),
+        data_iterator=iter([data] * num_microbatches),
         model=model,
-        num_microbatches=1,
+        num_microbatches=num_microbatches,
         input_tensor=None,
         output_tensor_grad=None,
         forward_data_store=forward_data_store,
@@ -374,12 +372,13 @@ def overlap_train_step(model, optimizer, config, data):
         collect_non_loss_data=False,
         first_val_step=None,
         forward_only=False,
-        no_sync_func=nullcontext,
+        no_sync_func=model.no_sync,
         total_num_tokens=torch.zeros([], dtype=torch.int, device="cuda"),
         check_first_val_step=lambda cond: cond,
     )
     torch.cuda.synchronize()
-    loss = forward_data_store[0]['lm loss'].detach().clone()
+    loss = sum(entry['lm loss'].detach().clone() for entry in forward_data_store)
+    loss /= num_microbatches
     optimizer.step()
     return loss
 


### PR DESCRIPTION
## Summary

- restore the normal FSDP forward state before a genuine forward that combined 1F1B schedules inside another microbatch's backward window
- scope the state reset to the forward layer, leaving the independently scheduled backward layer in `PRE_BACKWARD`
- preserve `PRE_BACKWARD` when forward and backward refer to the same underlying midpoint layer
- add a two-microbatch regression test that checks state isolation, numerical parity, and final parameter parity

## Root cause

The Megatron-FSDP root pre-backward hook marks every submodule `PRE_BACKWARD`. This is correct for activation-recomputation forwards, where forward-order parameter prefetch and eager resharding must be disabled. Combined 1F1B also runs a genuine forward for the next microbatch during this window, so that forward incorrectly inherited `PRE_BACKWARD`; `_pre_forward_param_unshard` consequently disabled forward-order prefetch before the schedule midpoint.

This change clears the marker only for the layer about to execute the genuine forward. The peer backward layer keeps its recomputation semantics.

## Test plan

- `CHECK_ONLY=true BASE_REF=dev bash tools/autoformat.sh` (Black, isort, Pylint, and Ruff passed)
- `python tools/check_copyright.py <changed files>` (5/5 passed)
- Lyris GB200, 4 distributed ranks, SLURM `2544709`:
  `python -m torch.distributed.run --nproc-per-node=4 -m pytest -q tests/unit_tests/a2a_overlap/test_fsdp_1f1b_overlap.py::TestFSDP1F1BOverlap::test_fsdp_1f1b_genuine_forward_state`
  (passed on all ranks)
- DeepSeek-V3 full-model validation on 256 GB200 GPUs, TP1/PP1/EP64 and Megatron-FSDP DOI=2:
  full-iteration CUDA graph SLURM `2542009` and eager/Nsys SLURM `2542527` both completed 11 iterations; the eager trace confirmed forward prefetch was restored before the midpoint
