### PR TITLE
[Dev] Prefetch FSDP weights for selective MLA recompute

### DIFF
--- a/megatron/core/distributed/distributed_data_parallel_config.py
+++ b/megatron/core/distributed/distributed_data_parallel_config.py
@@ -229,7 +229,9 @@ class DistributedDataParallelConfig:
 
     megatron_fsdp_prefetch_recompute_forward_weights: bool = False
     """If set to True, Megatron-FSDP prefetches rowwise weights needed by activation
-      recomputation during backward before prefetching backward transpose weights.
+      recomputation during backward. Full-layer recomputation prefetches them from
+      the unit pre-backward hook; selective ``mla_up_proj`` recomputation prefetches
+      only the marked up-projection modules.
     """
 
     megatron_fsdp_cache_param_bucket_views: bool = False

--- a/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
+++ b/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -233,6 +233,9 @@ class FullyShardedDataParallel(_BaseDataParallel):
         self.zero_grad_buffer = self.module.zero_grad_buffer
         self.broadcast_params = self.module.broadcast_params
         self.synchronize_param_gather = self.module.synchronize_param_gather
+        self.prefetch_recompute_forward_parameters = (
+            self.module.prefetch_recompute_forward_parameters
+        )
         self.module.state_dict_for_save_checkpoint = self.module.state_dict
         self.state_dict_for_save_checkpoint = self.state_dict
         self.module.config = config

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/distributed_data_parallel_config.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/distributed_data_parallel_config.py
@@ -157,7 +157,9 @@ class DistributedDataParallelConfig:
 
     megatron_fsdp_prefetch_recompute_forward_weights: bool = False
     """If set to True, Megatron-FSDP prefetches rowwise weights needed by activation
-      recomputation during backward before prefetching backward transpose weights.
+      recomputation during backward. Full-layer recomputation prefetches them from
+      the unit pre-backward hook; selective ``mla_up_proj`` recomputation prefetches
+      only the marked up-projection modules.
     """
 
     megatron_fsdp_cache_param_bucket_views: bool = False

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/megatron_fsdp.py
@@ -270,6 +270,11 @@ class MegatronFSDP(torch.nn.Module):
         self.prefetch_recompute_forward_weights = (
             self.ddp_config.megatron_fsdp_prefetch_recompute_forward_weights
         )
+        self._selective_recompute_forward_weight_modules = [
+            submodule
+            for submodule in self.module.modules()
+            if getattr(submodule, "_fsdp_recompute_forward_weight", False)
+        ]
         recurse_types = fine_grained_recurse_module_types or ()
         self.fine_grained_recurse_module_types: Tuple[Type[nn.Module], ...] = recurse_types
         self.report_nan_in_param_grad = report_nan_in_param_grad
@@ -500,6 +505,37 @@ class MegatronFSDP(torch.nn.Module):
             # we want to overwrite the `main_grad` which is enabled by this
             # attribute.
             param.overwrite_main_grad = True
+
+    @torch.compiler.disable
+    def prefetch_recompute_forward_parameters(self, module: nn.Module):
+        """Asynchronously gather selective-recompute forward weights for ``module``.
+
+        Selective activation recomputation only replays a subset of a layer. The
+        replayed parameterized modules opt in with
+        ``_fsdp_recompute_forward_weight``. This method starts their rowwise
+        all-gather without waiting; their normal pre-forward hooks wait before
+        the recompute region consumes the weights.
+        """
+        if (
+            not self.prefetch_recompute_forward_weights
+            or not self._selective_recompute_forward_weight_modules
+        ):
+            return
+
+        module_set = set(module.modules())
+        params = []
+        seen_params = set()
+        for recompute_module in self._selective_recompute_forward_weight_modules:
+            if recompute_module not in module_set:
+                continue
+            for param in recompute_module.parameters():
+                if param not in seen_params:
+                    seen_params.add(param)
+                    params.append(param)
+
+        self.all_gather_and_wait_parameters_ready(
+            params=params, prefetch=False, wait_bucket_ready=False, bwd=False
+        )
 
     def _register_fsdp_hooks(self, root_module):
         """Register necessary hooks for Fully Sharded Data Parallel (FSDP) execution on the model.
@@ -897,7 +933,10 @@ class MegatronFSDP(torch.nn.Module):
             param_list = _param_list_for_submodule_unshard(module, "backward")
 
             # All-gather / unshard the module parameters before the backward pass.
-            if self.prefetch_recompute_forward_weights:
+            if (
+                self.prefetch_recompute_forward_weights
+                and not self._selective_recompute_forward_weight_modules
+            ):
                 self.all_gather_and_wait_parameters_ready(
                     param_list,
                     prefetch=False,
@@ -920,6 +959,17 @@ class MegatronFSDP(torch.nn.Module):
                 self.all_gather_and_wait_parameters_ready(
                     param_list, prefetch_order=PrefetchOrder.BACKWARD_PASS_ORDER, bwd=True
                 )
+                if (
+                    self.prefetch_recompute_forward_weights
+                    and self._selective_recompute_forward_weight_modules
+                    and not self.enable_fine_grained_param_gather_backward_hook
+                ):
+                    # The regular forward/backward schedule enters an FSDP unit through
+                    # this unit-level pre-backward hook. Start the selective-recompute
+                    # rowwise gather after its backward-layout weights are ready, leaving
+                    # the layer's MLP backward compute to hide the communication before
+                    # attention backward replays mla_up_proj.
+                    self.prefetch_recompute_forward_parameters(module)
 
         self._root_pre_backward_hook_issued = False
 

--- a/megatron/core/models/common/model_chunk_schedule_plan.py
+++ b/megatron/core/models/common/model_chunk_schedule_plan.py
@@ -81,6 +81,7 @@ class TransformerLayerSchedulePlan:
         self.event = event
         self.comp_stream = comp_stream
         self.comm_stream = comm_stream
+        self._fsdp_prefetch_recompute_forward_parameters = None
 
         # get callable nodes for transformer/mtp layer
         self._build_callable_nodes(event, comp_stream, comm_stream, extra_args)
@@ -110,6 +111,7 @@ class TransformerLayerSchedulePlan:
             self.layer_state = None
         if hasattr(self, 'layer'):
             del self.layer
+        self._fsdp_prefetch_recompute_forward_parameters = None
 
     def _build_callable_nodes(self, event, comp_stream, comm_stream, extra_args):
         """
@@ -282,6 +284,30 @@ class TransformerLayerSchedulePlan:
         if dispatcher is not None:
             dispatcher.reset_transient_forward_state()
 
+    def set_fsdp_recompute_prefetch_hook(
+        self, prefetch_recompute_forward_parameters: Callable[[torch.nn.Module], None]
+    ) -> None:
+        """Wire selective-recompute weight prefetch for the overlap schedule.
+
+        Args:
+            prefetch_recompute_forward_parameters: Callable that starts an asynchronous
+                rowwise all-gather for marked selective-recompute weights in this layer.
+        """
+        from megatron.core.transformer.multi_token_prediction import MultiTokenPredictionLayer
+        from megatron.core.transformer.transformer_layer import TransformerLayer
+
+        assert isinstance(self.layer, (TransformerLayer, MultiTokenPredictionLayer)), (
+            f"Megatron FSDP with EP Overlap only supports TransformerLayer, "
+            f"but got {type(self.layer).__name__}."
+        )
+
+        hook_module = (
+            self.layer if isinstance(self.layer, TransformerLayer) else self.layer.mtp_model_layer
+        )
+        self._fsdp_prefetch_recompute_forward_parameters = lambda: (
+            prefetch_recompute_forward_parameters(hook_module)
+        )
+
     def get_fp8_context(self):
         """
         Get the fp8 context for the transformer layer.
@@ -329,6 +355,8 @@ class TransformerLayerSchedulePlan:
             if b_layer.mhc_recompute is not None:
                 b_layer.mhc_recompute.forward()
             b_grad = b_layer.moe_combine.backward(b_grad)
+            if b_layer._fsdp_prefetch_recompute_forward_parameters is not None:
+                b_layer._fsdp_prefetch_recompute_forward_parameters()
 
         if f_layer is not None:
             with f_layer.get_fp8_context():

--- a/megatron/core/pipeline_parallel/combined_1f1b.py
+++ b/megatron/core/pipeline_parallel/combined_1f1b.py
@@ -422,6 +422,9 @@ def combined_forward_backward_step(
                     forward_fsdp_wrapper.post_forward_release_module,
                     forward_fsdp_wrapper.post_backward_release_module,
                 )
+                layer_plan.set_fsdp_recompute_prefetch_hook(
+                    forward_fsdp_wrapper.prefetch_recompute_forward_parameters
+                )
 
     # backward preprocess, the same as the backward_step()
     unwrap_input_tensor_grad = False

--- a/megatron/core/transformer/multi_latent_attention.py
+++ b/megatron/core/transformer/multi_latent_attention.py
@@ -630,6 +630,18 @@ class MLASelfAttention(MultiLatentAttention):
             name=(name + ".linear_kv_up_proj") if name is not None else None,
         )
 
+        if self.recompute_up_proj:
+            # These are the only parameterized modules replayed by the
+            # ``mla_up_proj`` selective-recompute region. Megatron-FSDP uses
+            # this marker to launch their rowwise weight all-gather early in
+            # the 1F1B EP-overlap schedule, then waits at the regular
+            # pre-forward hook immediately before the replay consumes them.
+            if self.config.q_lora_rank is not None:
+                self.linear_q_up_proj._fsdp_recompute_forward_weight = True
+            else:
+                self.linear_q_proj._fsdp_recompute_forward_weight = True
+            self.linear_kv_up_proj._fsdp_recompute_forward_weight = True
+
         if self.config.q_lora_rank is not None:
             self.q_layernorm = submodules.q_layernorm(
                 hidden_size=self.config.q_lora_rank,

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 """Megatron arguments."""
 
@@ -1256,14 +1256,30 @@ def validate_args(args, defaults={}):
                 "--megatron-fsdp-prefetch-recompute-forward-weights is only supported "
                 'with --data-parallel-sharding-strategy optim_grads_params.'
             )
-            assert args.recompute_granularity == "full", (
-                "--megatron-fsdp-prefetch-recompute-forward-weights is only supported "
-                "with full activation recomputation."
-            )
-            assert not args.overlap_moe_expert_parallel_comm, (
-                "--megatron-fsdp-prefetch-recompute-forward-weights is not supported "
-                "with --overlap-moe-expert-parallel-comm."
-            )
+            if args.recompute_granularity == "full":
+                assert not args.overlap_moe_expert_parallel_comm, (
+                    "--megatron-fsdp-prefetch-recompute-forward-weights with full "
+                    "activation recomputation is not supported with "
+                    "--overlap-moe-expert-parallel-comm."
+                )
+            else:
+                assert args.recompute_granularity == "selective", (
+                    "--megatron-fsdp-prefetch-recompute-forward-weights requires "
+                    "full activation recomputation, or selective recomputation of "
+                    "mla_up_proj."
+                )
+                assert "mla_up_proj" in (args.recompute_modules or []), (
+                    "Selective --megatron-fsdp-prefetch-recompute-forward-weights "
+                    "requires mla_up_proj in --recompute-modules."
+                )
+                assert (
+                    args.cuda_graph_impl != "full_iteration"
+                    or args.overlap_moe_expert_parallel_comm
+                ), (
+                    "Selective --megatron-fsdp-prefetch-recompute-forward-weights with "
+                    "full-iteration CUDA graphs requires "
+                    "--overlap-moe-expert-parallel-comm."
+                )
 
         if args.nccl_ub:
             # In Megatron-LM, required implementation for manual registration is already provided.

--- a/tests/unit_tests/a2a_overlap/test_fsdp_1f1b_overlap.py
+++ b/tests/unit_tests/a2a_overlap/test_fsdp_1f1b_overlap.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import gc
 
@@ -129,6 +129,9 @@ class TestFSDP1F1BOverlap:
                 overlap_grad_reduce=True,
                 overlap_param_gather=True,
                 megatron_fsdp_main_params_dtype=None,
+                megatron_fsdp_prefetch_recompute_forward_weights=bool(
+                    recompute_modules and "mla_up_proj" in recompute_modules
+                ),
             )
 
         with deterministic_mode():
@@ -145,6 +148,17 @@ class TestFSDP1F1BOverlap:
                 module=ref_model,
                 fsdp_unit_modules=[TransformerLayer],
             )
+            reference_selective_prefetch_calls = []
+            if ref_fsdp.ddp_config.megatron_fsdp_prefetch_recompute_forward_weights:
+                original_reference_prefetch = ref_fsdp.module.prefetch_recompute_forward_parameters
+
+                def _track_reference_selective_prefetch(module, **kwargs):
+                    reference_selective_prefetch_calls.append(module)
+                    return original_reference_prefetch(module, **kwargs)
+
+                ref_fsdp.module.prefetch_recompute_forward_parameters = (
+                    _track_reference_selective_prefetch
+                )
             ref_opt = torch.optim.SGD(ref_fsdp.parameters(), lr=LR)
             ref_opt = fully_shard_optimizer(optimizer=ref_opt)
 
@@ -160,6 +174,15 @@ class TestFSDP1F1BOverlap:
                 module=test_model,
                 fsdp_unit_modules=[TransformerLayer],
             )
+            selective_prefetch_calls = []
+            if test_fsdp.ddp_config.megatron_fsdp_prefetch_recompute_forward_weights:
+                original_prefetch = test_fsdp.module.prefetch_recompute_forward_parameters
+
+                def _track_selective_prefetch(module):
+                    selective_prefetch_calls.append(module)
+                    return original_prefetch(module)
+
+                test_fsdp.module.prefetch_recompute_forward_parameters = _track_selective_prefetch
             test_opt = torch.optim.SGD(test_fsdp.parameters(), lr=LR)
             test_opt = fully_shard_optimizer(optimizer=test_opt)
 
@@ -176,6 +199,9 @@ class TestFSDP1F1BOverlap:
                 )
 
             assert_models_equal(ref_fsdp, test_fsdp)
+            if test_fsdp.ddp_config.megatron_fsdp_prefetch_recompute_forward_weights:
+                assert len(reference_selective_prefetch_calls) == NUM_STEPS * num_layers
+                assert len(selective_prefetch_calls) == NUM_STEPS * num_layers
 
             del ref_fsdp, test_fsdp, ref_opt, test_opt
             gc.collect()


### PR DESCRIPTION
## Summary

- Extend `--megatron-fsdp-prefetch-recompute-forward-weights` to selective `mla_up_proj` activation recomputation.
- Mark only the MLA query/key-value up-projection modules replayed by selective recompute and asynchronously gather their rowwise weights before the replay consumes them.
- Launch the gather after MoE-combine backward in combined 1F1B, and from the FSDP unit pre-backward hook in the regular schedule.
- Preserve the existing full-layer recompute behavior and reject selective prefetch with full-iteration CUDA graphs when A2A overlap is disabled; that capture path is not currently graph-safe.

## Implementation details

Selective recompute needs the forward-layout weights again during backward. For MXFP8 these are distinct from the backward transpose weights, so the normal backward-order gather does not cover the replay. This change records the parameterized modules inside the `mla_up_proj` checkpoint region and starts a non-blocking rowwise all-gather early enough for MLP/MoE backward compute to hide it. The existing module pre-forward hooks remain the synchronization point.

The combined-1F1B callback uses a dedicated schedule-plan setter, keeping this change independent from other FSDP reshard-hook extensions.

## Test plan

- `CHECK_ONLY=true BASE_REF=dev ... bash tools/autoformat.sh`
  - Black, isort, Pylint (10.00/10), and Ruff passed.
- `python tools/check_copyright.py <changed core/test files>`
  - All changed core/test files passed.
- Lyris GB200, 4 GPUs: `test_fsdp_1f1b_memory_opt[offload_modules0-recompute_modules1]`
  - Toolkit job `20260731-073856-94c7`, SLURM `2545157`, exit 0 on all ranks.
  - Checks per-step loss, final parameter parity, and selective-prefetch call counts for regular FSDP and combined 1F1B.
- Lyris GB200, 4-GPU DeepSeek-V3 proxy with selective `mla_up_proj`, A2A overlap, and full-iteration CUDA graphs
  - Toolkit job `20260731-074259-db3d`, SLURM `2545167`, 10/10 iterations, exit 0.
  - Post-capture iterations reached approximately 400-408 TFLOP/s/GPU.

## Known prerequisite

The full-CG proxy disables MTP to isolate this change. Current `dev` has an independent Megatron-FSDP root-bucket finalization issue with MTP; its fix is intentionally not bundled into this PR.
