### PR TITLE
Allocate main_grad on the reduce-scatter stream

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -156,6 +156,7 @@ class FsdpModule:
                 mesh=mesh,
                 placements=placements,
                 mixed_precision_policy=mixed_precision_policy,
+                reduce_scatter_stream=context.reduce_scatter_stream,
                 use_symm_mem=use_symm_mem,
             )
             for group_parameters in _group_parameters(owned_parameters)

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -75,6 +75,7 @@ class FsdpParameterGroup:
         mesh: DeviceMesh,
         placements: Placements,
         mixed_precision_policy: MixedPrecisionPolicy,
+        reduce_scatter_stream: torch.cuda.Stream,
         use_symm_mem: bool = False,
     ) -> None:
         """Create persistent sharded buffers for a group of parameters.
@@ -85,6 +86,7 @@ class FsdpParameterGroup:
             mesh: Device mesh used for all DBuffer storage in this version.
             placements: Parameter, gradient, and optimizer placements.
             mixed_precision_policy: Precision policy for main weights and gradients.
+            reduce_scatter_stream: Stream on which to allocate the main-gradient buffer.
             use_symm_mem: Allocate communication staging buffers from PyTorch's
                 NCCL symmetric-memory pool.
         """
@@ -160,13 +162,14 @@ class FsdpParameterGroup:
             # eagerly deallocated right after optimizer.step(), avoiding main_grad
             # storage during forward. That requires a separate lifetime contract with
             # the optimizer, so this version keeps the simpler persistent buffer.
-            self.main_grad = DBuffer(
-                mesh=self.mesh,
-                placements=main_grad_placements,
-                tensor_shapes=self.main_weight.layout.tensor_shapes,
-                dtype=grad_dtype,
-                device=self.main_weight.device,
-            )
+            with torch.cuda.stream(reduce_scatter_stream):
+                self.main_grad = DBuffer(
+                    mesh=self.mesh,
+                    placements=main_grad_placements,
+                    tensor_shapes=self.main_weight.layout.tensor_shapes,
+                    dtype=grad_dtype,
+                    device=self.main_weight.device,
+                )
             assert self.main_grad.layout == self.main_weight.layout, (
                 "main_grad is built from main_weight tensor shapes on the same mesh, "
                 "and DBuffer layouts are deterministic from those shapes and mesh size."


### PR DESCRIPTION
## Root cause

Related MFSDP v2 HSDP/HFSDP issue: #5616.

Root cause diagnosed by @Autumn1998 (Tong Liu) in [NVIDIA/Megatron-LM#6137, discussion r3688414858](https://github.com/NVIDIA/Megatron-LM/pull/6137#discussion_r3688414858).

`main_grad` was allocated while `fully_shard()` ran on the current stream (normally the default stream), but it is consumed and can be replaced during backward on the reduce-scatter stream. The allocator could therefore reuse the old storage for default-stream work before the asynchronous reduce-scatter completed, causing silent gradient corruption.

For allocator-stream background, see [FSDP & CUDACachingAllocator: an outsider newb perspective](https://dev-discuss.pytorch.org/t/fsdp-cudacachingallocator-an-outsider-newb-perspective/1486#p-2441-v3-stream-synchronization-5).

## Implementation

`FsdpModule` passes its existing `reduce_scatter_stream` to each `FsdpParameterGroup` during construction. Each trainable group's persistent `main_grad` `DBuffer` is allocated directly inside `torch.cuda.stream(reduce_scatter_stream)`.

The parameter group does not retain the stream or context. Gradient dtype, layout, placement, and reduction behavior are unchanged.

## Validation

All runs below on one 8xA100-80GB node.

### The fix is load-bearing

Unperturbed, `test_hsdp_losses_match_baseline` does not catch this race: it
passes on the unfixed parent commit. That matches the nature of the bug -- the
test compares a 5-step loss trajectory, so it only sees a heavily damped shadow
of the gradient error, and only when timing makes the allocator reuse collide.

Adding a timing perturbation makes it collide reliably. Two 1-element
`dist.all_reduce` calls on the mesh dim groups, inserted in
`test_hsdp_losses_match_baseline` immediately after the mesh is built:

```python
     mesh = init_device_mesh(
         device.type, (outer_size, inner_size), mesh_dim_names=("dp_outer", "dp_inner")
     )
+    for _dim_name in ("dp_outer", "dp_inner"):
+        dist.all_reduce(torch.ones(1, device=device), group=mesh[_dim_name].get_group())
```

This is a diagnostic, not part of the shipped test. Applied identically to both
arms, 10 alternating runs each at four ranks:

| arm | runs with failures |
| --- | --- |
| `origin/main` (no fix) | **10 / 10** |
| `origin/main` + this PR | **0 / 10** |

`[3-True]` failed in 10/10 unfixed runs and `[3-False]` in 7/10. Neither
`num_microbatches=1` case ever failed, which is consistent with the mechanism:
the initial `main_grad` is freed by the `redistribute` that finalizes it, and
multi-microbatch accumulation widens the window between that free and the
in-flight reduction still reading the old buffer.

### Caveat

Verified on A100 only. The original failures were observed on H100/H200.
