### PR TITLE
Handle padding-only distributed optimizer checkpoint shards

### DIFF
--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -75,6 +75,13 @@ from .param_layout import FullParamLayout, PerBufferParamLayout, pad_bucket_end,
 logger = getLogger(__name__)
 
 
+def _is_trailing_padding_only_shard(
+    data_parallel_rank: int, gbuf_local_numel: int, gbuf_world_numel_unpadded: int
+) -> bool:
+    """Whether a DP-local bucket shard starts after the checkpointed buffer payload."""
+    return data_parallel_rank * gbuf_local_numel >= gbuf_world_numel_unpadded
+
+
 class Range:
     """
     A range represents a start and end points for indexing a shard
@@ -1894,9 +1901,15 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                         f'.gbuf_idx_{gbuf_idx}.dtype_{dtype}.bucket_idx_{bucket_idx}'
                     )
 
-                    # The global ckpt tensors must be fully covered.
-                    # We add extra empty padding if necessary
-                    assert bucket_state, 'empty bucket encountered'
+                    # A highly padded bucket can assign a DP rank only trailing padding.
+                    # Trailing bucket padding is deliberately excluded from the checkpoint,
+                    # so that rank has no optimizer state to contribute. An empty shard that
+                    # intersects the unpadded payload is still a real coverage error.
+                    if not bucket_state:
+                        assert _is_trailing_padding_only_shard(
+                            data_parallel_rank, gbuf_local_numel, gbuf_world_numel_unpadded
+                        ), 'empty bucket intersects unpadded optimizer state'
+                        continue
 
                     # Insert padding between parameter tensors to ensure full coverage as needed.
                     all_pad_tensors = {}
@@ -2063,6 +2076,9 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
 
         Inverse of the `get_parameter_state_dp_reshardable` method.
         """
+        data_parallel_rank = self.data_parallel_group.rank()
+        data_parallel_world_size = self.data_parallel_group.size()
+
         if state_dict is not None and "per_bucket_numel_unpadded" in state_dict:
             per_bucket_numel_unpadded_in_checkpoint = state_dict["per_bucket_numel_unpadded"]
             assert self.per_bucket_numel_unpadded == per_bucket_numel_unpadded_in_checkpoint, (
@@ -2075,6 +2091,16 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
             assert len(gbuf_range_maps) == 1, "single dtype supported, for now."
             for dtype, gbuf_range_map_for_all_buckets in gbuf_range_maps.items():
                 for bucket_idx, gbuf_range_map in enumerate(gbuf_range_map_for_all_buckets):
+                    if not gbuf_range_map["param_map"]:
+                        bucket = self.buffers[gbuf_idx].buckets[bucket_idx]
+                        gbuf_world_numel = bucket.grad_data.numel()
+                        assert gbuf_world_numel % data_parallel_world_size == 0
+                        assert _is_trailing_padding_only_shard(
+                            data_parallel_rank,
+                            gbuf_world_numel // data_parallel_world_size,
+                            bucket.numel_unpadded,
+                        ), 'empty bucket intersects unpadded optimizer state'
+                        continue
                     bucket_state = state_dict[gbuf_idx][dtype][bucket_idx]
                     bucket_state = [
                         bucket_state_elem

--- a/tests/unit_tests/distributed/test_distrib_optimizer_checkpoint.py
+++ b/tests/unit_tests/distributed/test_distrib_optimizer_checkpoint.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Focused tests for DistributedOptimizer checkpoint shard coverage."""
+
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+import torch
+
+from megatron.core.optimizer.distrib_optimizer import (
+    DistributedOptimizer,
+    _is_trailing_padding_only_shard,
+)
+
+
+@pytest.mark.parametrize(
+    ('data_parallel_rank', 'local_numel', 'world_numel_unpadded', 'expected'),
+    [(0, 1024, 1024, False), (1, 1024, 1024, True), (1, 1024, 1500, False), (3, 1024, 1500, True)],
+)
+def test_trailing_padding_only_optimizer_shard(
+    data_parallel_rank, local_numel, world_numel_unpadded, expected
+):
+    assert (
+        _is_trailing_padding_only_shard(data_parallel_rank, local_numel, world_numel_unpadded)
+        is expected
+    )
+
+
+def _make_optimizer_with_empty_local_shard(data_parallel_rank, numel_unpadded):
+    dtype = torch.float32
+    optimizer = mock.Mock()
+    optimizer.data_parallel_group.rank.return_value = data_parallel_rank
+    optimizer.data_parallel_group.size.return_value = 4
+    optimizer.per_bucket_numel_unpadded = [[numel_unpadded]]
+    optimizer.gbuf_ranges = [{dtype: [{"param_map": {}}]}]
+    optimizer.buffers = [
+        SimpleNamespace(
+            buckets=[SimpleNamespace(grad_data=torch.empty(4096), numel_unpadded=numel_unpadded)]
+        )
+    ]
+    state_dict = {"per_bucket_numel_unpadded": [[numel_unpadded]]}
+    return optimizer, state_dict
+
+
+def _make_optimizer_for_empty_shard_save(data_parallel_rank, numel_unpadded):
+    optimizer, _ = _make_optimizer_with_empty_local_shard(data_parallel_rank, numel_unpadded)
+    optimizer.data_parallel_group_idx = 0
+    optimizer.distributed_optimizer_instance_id = 0
+    optimizer.get_parameter_state_dp_reshardable.return_value = {
+        "per_bucket_numel": [[4096]],
+        "per_bucket_numel_unpadded": [[numel_unpadded]],
+        0: {torch.float32: [[]]},
+    }
+    return optimizer
+
+
+def test_save_skips_trailing_padding_only_shard():
+    optimizer = _make_optimizer_for_empty_shard_save(data_parallel_rank=1, numel_unpadded=1024)
+
+    state = DistributedOptimizer.sharded_param_state_dp_reshardable(optimizer, {})
+
+    assert state[0][torch.float32][0] == []
+
+
+def test_save_rejects_empty_shard_that_intersects_optimizer_state():
+    optimizer = _make_optimizer_for_empty_shard_save(data_parallel_rank=1, numel_unpadded=1500)
+
+    with pytest.raises(AssertionError, match="empty bucket intersects unpadded optimizer state"):
+        DistributedOptimizer.sharded_param_state_dp_reshardable(optimizer, {})
+
+
+def test_load_skips_checkpoint_key_for_trailing_padding_only_shard():
+    optimizer, state_dict = _make_optimizer_with_empty_local_shard(
+        data_parallel_rank=1, numel_unpadded=1024
+    )
+
+    DistributedOptimizer.load_parameter_state_from_dp_reshardable(optimizer, state_dict)
+
+
+def test_load_rejects_empty_shard_that_intersects_optimizer_state():
+    optimizer, state_dict = _make_optimizer_with_empty_local_shard(
+        data_parallel_rank=1, numel_unpadded=1500
+    )
+
+    with pytest.raises(AssertionError, match="empty bucket intersects unpadded optimizer state"):
+        DistributedOptimizer.load_parameter_state_from_dp_reshardable(optimizer, state_dict)


### PR DESCRIPTION
## What

Allow DistributedOptimizer checkpoint save/load on data-parallel ranks whose local bucket shard contains only trailing alignment padding.

The checkpoint format intentionally excludes trailing padding. For a highly padded bucket, a valid DP rank can therefore have:

- an empty local optimizer-state list during save; and
- an empty local `param_map` with no corresponding checkpoint key during load.

The previous code treated both cases as corruption.

This change skips an empty shard only when its global start is at or beyond the unpadded bucket length. Empty shards that intersect real optimizer state still fail with an assertion.

## Validation

- OCI AGA Cog/Slurm job `335873`: 8 save/load regression tests passed on each of 4 distributed ranks.
- Coverage includes valid padding-only save and load, invalid empty-shard rejection on both paths, and boundary classification.
- Pinned isort, Black, Ruff, `py_compile`, and `git diff --check` passed.

This PR is independent of the MIMO layer-wise optimizer integration PR.