### PR TITLE
feat(inference): Nemotron Omni multimodal support on the dynamic path

### DIFF
--- a/docs/inference/nemotron_omni/README.md
+++ b/docs/inference/nemotron_omni/README.md
@@ -1,0 +1,199 @@
+# Nemotron Omni on Megatron-Core inference — handoff
+
+**Status: unvalidated draft. None of this code has ever been executed.**
+
+The machine it was written on has no `torch` and no GPU, so nothing here has
+been imported, unit-tested, or run against a checkpoint. It is lint-clean and
+format-clean, and that is the entire extent of the verification. Treat every
+file as a reviewed-by-eye first draft, not as working code. The first task for
+whoever picks this up is to get it to *import*, then to get
+`tests/unit_tests/inference/multimodal/` to pass, and only then to think about
+numerics.
+
+## The documents in this directory
+
+| File | What it is | Who wrote it |
+| --- | --- | --- |
+| `mcore-inference-design.md` | The implementation design this branch follows. Section numbers referenced below all point here. | Written for this task |
+| `vllm-reference.md` | Behavioural reference for the existing vLLM Nemotron Omni support. The source of truth for *what the model does*. | Pre-existing |
+| `checkpoint-config.md` | The resolved checkpoint configuration — actual layer counts, hidden sizes, token ids. The source of truth for *numbers*. | Pre-existing |
+
+Read the design doc's §0 (TL;DR) and §3 (chosen architecture) first; they are
+about six pages together and everything else is reference material.
+
+`checkpoint-config.md` opens by citing a doc called
+`NEMOTRON_OMNI_MULTIMODAL_DESIGN.md`, which does not exist in this repo — it is
+an external document that came with the config. Its §3.4 is cited again around
+line 316. If you can find that document, it may answer some of the open
+questions below.
+
+## The one idea you need
+
+The dynamic inference path is built around integer token ids: a request is a
+list of ids, the model looks them up in an embedding table, and the KV cache is
+addressed by token position. Multimodal embeddings do not fit that — they are
+dense rows produced by an encoder, with no token id that maps to them.
+
+The approach taken here is a **masked overwrite into fixed-address buffers**.
+`DynamicInferenceContext` allocates two buffers up front,
+`token_to_mm_embedding` of shape `[max_tokens, 1, hidden]` and a parallel bool
+mask `token_to_is_mm`. Immediately after the embedding lookup, the model calls
+`inference_context.apply_multimodal_embeddings(decoder_input)`, which is a
+single `torch.where` selecting the encoder row wherever the mask is set.
+
+Two properties make this work under CUDA graphs, and both are easy to break:
+
+1. **The buffers are allocated once and never reallocated.** Graph replay reads
+   the addresses captured at capture time, so a reallocation silently makes the
+   graph read stale memory.
+2. **The overwrite is unconditional.** It is deliberately *not* guarded by "does
+   this step have multimodal tokens". A host-side branch there gets resolved
+   once during capture and frozen for every replay, so a step captured without
+   multimodal tokens would skip injection forever after. An all-`False` mask
+   makes the op an identity instead, and the cost is one elementwise pass.
+
+If you find yourself wanting to add an `if` around the injection for
+performance, re-read §3.2 first.
+
+The corresponding write side is
+`DynamicInferenceContext.scatter_multimodal_embeddings`, which is chunk-aware:
+under chunked prefill an image span can straddle a chunk boundary, so it
+bisects the request's `mm_embed_positions` (kept on CPU precisely so this
+bisect does not force a device sync) to find the rows belonging to the current
+chunk.
+
+## What is where
+
+Engine-side plumbing, modality-agnostic:
+
+- `megatron/core/inference/config.py` — the `enable_multimodal` flag. Off by
+  default; when off, nothing is allocated and the embedding path is unchanged.
+- `megatron/core/inference/contexts/dynamic_context.py` — the buffers, the
+  scatter, the masked overwrite, mask clearing per step.
+- `megatron/core/inference/contexts/base_context.py` — identity default so
+  static contexts are unaffected.
+- `megatron/core/inference/inference_request.py` — `mm_embeddings`,
+  `mm_embed_positions`, `mm_content_hash` on the request.
+- `megatron/core/inference/engines/dynamic_engine.py` — the optional
+  `multimodal_encoder` hook and admission-time encoding.
+- `megatron/core/models/hybrid/hybrid_model.py`,
+  `megatron/core/models/gpt/gpt_model.py` — the one-line injection call.
+- `megatron/core/inference/multimodal/types.py` — the
+  `MultimodalEmbeddingProvider` interface. **The engine knows only this file.**
+  Everything model-specific sits behind it, so a second multimodal model should
+  need no engine change.
+
+Nemotron Omni specifics, all under
+`megatron/core/inference/multimodal/nemotron_omni/`: `config.py`,
+`image_processor.py` (the dynamic-resolution tiler), `video_processor.py`,
+`audio_processor.py` (log-mel front-end), `prompt.py` (placeholder expansion),
+`encoder_stack.py`, `checkpoint.py` (HF weight mapping), `provider.py`,
+`builder.py`.
+
+Shared model code promoted out of examples: `megatron/core/models/vision/
+pixel_shuffle.py`, `megatron/core/models/vision/evs.py`,
+`megatron/core/models/audio/parakeet_model.py`.
+
+## Things that will bite you
+
+**The token-count contract is the whole game.** The host expands placeholder
+spans into real token ids; the device produces encoder rows. If those two counts
+disagree by even one, you get a shape mismatch far away from the cause. Design
+doc §6.1 has the per-modality table. Port and test that before touching
+anything else — most of the "copy bit-for-bit" behaviours in §5.4 exist only
+because they change a token count.
+
+**`class_token_len` is 10, not 8.** This checkpoint has 4 class tokens plus 6
+registers. mcore's default is 8. Getting it wrong strips the wrong number of
+tokens per image and degrades output *silently* — no crash. This is the kind of
+bug that costs a week.
+
+**There are two incompatible pixel shuffles in this tree** and they are
+genuinely different operations, not two spellings of the same one. The one in
+`llava_model.py`'s `h`/`w` branch folds 4 horizontally adjacent patches; the one
+promoted to `megatron/core/models/vision/pixel_shuffle.py` folds a 2×2 spatial
+block. This branch uses the 2×2 version because that is what vLLM does. See
+open question Q1 — this is unresolved and a wrong choice produces
+plausible-looking but degraded output.
+
+**Mamba needs `mamba_num_heads=64` set explicitly.** Otherwise it gets derived
+from `expand: 2` and you get the wrong head count.
+
+**Encoders run at request admission, not per step.** This is deliberate (§3.1):
+encoder output shape varies per request, so running a tower inside the step
+would break graph capture and would re-run the tower once per prefill chunk.
+The cost is no cross-request encoder cache in v1, where vLLM has one.
+
+## Deliberate divergences from vLLM
+
+Documented in full in §5. The ones that are choices rather than consequences:
+
+- **Batched video encoding.** vLLM sets
+  `requires_sequential_video_encoding = True` and encodes videos one at a time,
+  purely because batched dynamic-resolution video is unimplemented there.
+  mcore's `_apply_temporal_grouping` already handles mixed image/video items in
+  one packed batch. Numerically identical, materially faster.
+- **LayerScale.** vLLM skips it, and mcore's RADIO has no LayerScale at all, so
+  vLLM parity holds for free. Both may differ from the HF reference, which does
+  apply it. The mapper warns rather than silently dropping. See Q2.
+- **Mamba SSM state forced to fp32.**
+- **Prefix caching disabled for multimodal requests.** Identical prompts with
+  different images would otherwise collide on placeholder token ids and produce
+  a false cache hit. Content-hash chaining into the block hashes is the real
+  fix and is deferred; `mm_content_hash` is already plumbed through the request
+  for it.
+- **PP is asserted to 1** for multimodal. Matches vLLM. Injection happens on the
+  first pipeline stage only and is not forwarded.
+
+## Known gaps
+
+**The chat completions endpoint rejects multimodal requests with a 400.** This
+is the largest functional gap. The endpoint tokenizes locally and ships token
+ids over ZMQ, which cannot carry raw media, so there is currently no HTTP path
+for a multimodal request. In-process `engine.add_request` works. Fixing this
+needs a transport decision — shared memory, a side-channel upload, or encoding
+before the ZMQ hop — and that decision was not made here.
+
+**The Parakeet subsampling length formula was reconstructed from first
+principles**, not verified against `transformers`, because the library was not
+installable on the authoring machine. Check it early; an off-by-N here breaks
+audio token counts.
+
+**`transformers >= 5.5.3` is required** for `ParakeetEncoder`, and
+`pyproject.toml` pins nothing. If the CI container ships 4.x this becomes a
+dependency bump. Untested.
+
+**Test coverage is one file** covering the token-count contract and chunk-aware
+injection, against a fake tokenizer. §6.2 lists the seven tests that should
+exist; five of them do not.
+
+## Open questions, in priority order
+
+These are in §7.2 with full context. Q1 is the one that blocks correctness.
+
+1. **Q1 — Which pixel shuffle did the checkpoint train with?** Both are live in
+   the tree for dynamic resolution. vLLM agrees with the 2×2 version, which is
+   what this branch uses, but if Omni was trained through `LLaVAModel` that is
+   wrong and vLLM has a latent bug. The config cannot answer this; you need the
+   training recipe owner.
+2. **Q2 — Are the checkpoint's `ls1`/`ls2` ≈ 1.0?** Needs a `state_dict` dump.
+   Determines whether an HF-reference mismatch is expected or a bug.
+3. **Q3 — `video_pruning_rate`: config's `0.7` or vLLM's `None` default?** This
+   branch follows the config, which is a deliberate divergence.
+4. **Q4 — Image token budget from engine `max_model_len` or the HF `262144`?**
+   Following vLLM makes image *resolution* depend on a deployment flag.
+5. **Q5 — What `transformers` version does the CI container ship?**
+6. **Q6 — Is `sound_timestamps` a real feature?** mcore's `LLaVAModel` threads
+   it with no vLLM counterpart.
+
+## Suggested first week
+
+1. Get it to import in the CI container. Expect real breakage; nothing has run.
+2. Run and fix `tests/unit_tests/inference/multimodal/`.
+3. Port the tiler-parity fixture from
+   `vllm/transformers_utils/processors/nano_nemotron_vl.py:290-327` — it is a
+   ready-made doctest that pins the token-count contract.
+4. Load a real checkpoint through `checkpoint.py` and diff the resulting
+   `state_dict` keys against the HF file. Key mismatches surface here cheaply.
+5. Get Q1 answered before spending time on numerics.
+6. Then chase the oracle cut points in §6.3, in order (a) → (d).

--- a/docs/inference/nemotron_omni/checkpoint-config.md
+++ b/docs/inference/nemotron_omni/checkpoint-config.md
@@ -1,0 +1,553 @@
+# Nemotron 3 Nano Omni — Checkpoint Configuration Reference
+
+> Companion to `NEMOTRON_OMNI_MULTIMODAL_DESIGN.md`. That document describes the
+> *pipeline*; this one pins down the *actual numbers* from the released
+> checkpoint and states, field by field, which ones vLLM reads and where.
+
+## 0. Is there a config file in this repo?
+
+**No.** vLLM does not ship model configs — it reads `config.json` from the
+checkpoint at load time (with `--trust-remote-code`, because Omni's config class
+lives in the checkpoint repo). The only Omni-related config material inside this
+tree is the CI shrink-down override in `tests/models/registry.py:1182-1206`,
+which is *not* the real config.
+
+The config transcribed below was fetched from the canonical checkpoint:
+
+```bash
+curl -sL https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16/raw/main/config.json
+curl -sL https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16/raw/main/configuration.py
+```
+
+Everything in this file is verbatim from the BF16 checkpoint unless marked
+otherwise. FP8 / NVFP4 variants differ only by an added `quantization_config`
+(§8).
+
+### Files in the checkpoint repo
+
+Config/code (all needed with `--trust-remote-code`):
+
+| File | Role |
+| --- | --- |
+| `config.json` | the composite config (§2) |
+| `configuration.py` | `NemotronH_Nano_Omni_Reasoning_V3_Config` (§1) |
+| `configuration_nemotron_h.py`, `configuration_radio.py` | sub-configs |
+| `modeling.py`, `modeling_nemotron_h.py`, `audio_model.py` | HF reference implementation |
+| `processing.py`, `processing_utils.py`, `image_processing.py`, `video_processing.py`, `video_io.py`, `evs.py` | HF reference preprocessing — **the parity oracle for a port** |
+| `preprocessor_config.json` | HF processor defaults (§6) |
+| `generation_config.json` | sampling defaults (§7) |
+| `chat_template.jinja`, `tokenizer.json`, `tokenizer_config.json`, `special_tokens_map.json` | prompt/tokenizer |
+| 17 × `model-*.safetensors` + `model.safetensors.index.json` | weights |
+
+`image_processing.py` / `video_processing.py` / `evs.py` in the checkpoint are
+the same logic vLLM reimplements in
+`vllm/transformers_utils/processors/nano_nemotron_vl.py` and
+`vllm/multimodal/evs.py`. When porting, diff against both.
+
+---
+
+## 1. Config class shape (and the `llm_config` → `text_config` alias)
+
+`configuration.py` defines `NemotronH_Nano_Omni_Reasoning_V3_Config`
+(`is_composition = True`) with three sub-configs: `vision_config` (`RADIOConfig`),
+`llm_config` (`NemotronHConfig`), `sound_config` (`SoundConfig`, optional).
+
+The important detail for vLLM: the on-disk key is **`llm_config`**, but vLLM's
+`NemotronH_Nano_VL_V2` reads **`config.text_config`**
+(`vllm/model_executor/models/nano_nemotron_vl.py:948, 961, 1141, 1614`). The
+checkpoint bridges this with an explicit property alias:
+
+```python
+# configuration.py:118-123 (verbatim, comment included)
+# vLLM's `NemotronH_Nano_VL_V2` implementation reads the language-model sub-config as
+# `config.text_config`. Our HF config stores it as `config.llm_config`; expose an alias so the
+# same config object loads under both loaders without having to duplicate the dict on disk.
+@property
+def text_config(self):
+    return self.llm_config
+```
+
+**Port implication:** if your backend parses `config.json` directly rather than
+through the remote config class, read `llm_config`. `text_config` does not exist
+on disk. Likewise `sound_config` is `None` when absent, and that absence is the
+only switch that disables the audio tower.
+
+Also set by the config class at construction time
+(`configuration.py:114-116`): `vision_config.use_flash_attn` is derived from
+`attn_implementation` (default `"flash_attention_2"`), and
+`llm_config._attn_implementation` is propagated. vLLM ignores both and uses its
+own attention backends.
+
+---
+
+## 2. Top-level fields
+
+| Field | Value | Read by vLLM? | Where |
+| --- | --- | --- | --- |
+| `architectures` | `["NemotronH_Nano_Omni_Reasoning_V3"]` | yes | `models/registry.py:514` |
+| `model_type` | `"NemotronH_Nano_Omni_Reasoning_V3"` | yes (HF dispatch) | — |
+| `auto_map` | `configuration.…_Config`, `modeling.…` | yes (`trust_remote_code`) | — |
+| `torch_dtype` | `bfloat16` | yes | also becomes the processor output dtype (`processors/nano_nemotron_vl.py:619`) |
+| `max_sequence_length` | `131072` | **no** | vLLM uses `--max-model-len` / `llm_config.max_position_embeddings` |
+| `force_image_size` | `512` | yes | `nano_nemotron_vl.py:928`, `processors/…:596` |
+| `patch_size` | `16` | yes | `nano_nemotron_vl.py:929`, `processors/…:597` |
+| `downsample_ratio` | `0.5` | yes | pixel-shuffle factor; the dynamic tiler asserts exactly `0.5` (`processors/…:277-283`) |
+| `use_thumbnail` | `true` | yes, but **inert for Omni** | only the fixed-tile path uses it; Omni takes the dynamic-resolution path (§3.2) |
+| `ps_version` | `"v2"` | yes | `nano_nemotron_vl.py:936`; `"v1"` would trigger the legacy transposed-shuffle warning |
+| `template` | `"n5h_5p5_nanov2"` | stored, unused | `nano_nemotron_vl.py:931` |
+| `image_tag_type` | `"internvl"` | stored, unused | `nano_nemotron_vl.py:937` |
+| `vit_hidden_size` | `1280` | yes | sizes `mlp1` input (`nano_nemotron_vl.py:960`) |
+| `projector_hidden_size` | `20480` | yes | `mlp1` hidden width (`nano_nemotron_vl.py:961`) |
+| `norm_mean` | `[0.48145466, 0.4578275, 0.40821073]` | yes | OpenAI-CLIP stats; applied **in the processor** |
+| `norm_std` | `[0.26862954, 0.26130258, 0.27577711]` | yes | ″ |
+| `video_pruning_rate` | `0.7` | **no** | see §9.1 — vLLM only honours the CLI flag |
+| `video_temporal_patch_size` | `2` | no (top-level copy) | vLLM reads the `vision_config` copy (also `2`) |
+| `eos_token_id` | `11` | yes | `generation_config.json` widens this to `[2, 11]` |
+| `img_context_token` / `_id` | `"<image>"` / `18` | token **string** yes, id **no** | vLLM re-tokenizes the strings (`nano_nemotron_vl.py:996-1004`) |
+| `video_context_token` / `_id` | `"<video>"` / `131081` | string yes, id no | `<video>` is only a user-facing marker; per-token placeholder is `<image>` |
+| `img_start_token` / `img_end_token` | `"<img>"` / `"</img>"` | yes (hard-coded constants in vLLM) | `processors/…:36-38` |
+| `sound_context_token` / `_id` | `"<so_embedding>"` / `27` | string yes, id no | `processors/…:41`; `<so_start>`/`<so_end>` are vLLM constants |
+
+Note the asymmetry: vLLM hard-codes the special-token *strings* and resolves ids
+through the tokenizer, so a checkpoint that renamed these tokens would break
+vLLM even though the ids are in the config. Keep the strings identical.
+
+---
+
+## 3. `vision_config` — C-RADIOv4-H
+
+Metadata: `version: "c-radio_v4-h"`, `architectures: ["RADIOModel"]`,
+`auto_map` pointing at `nvidia/C-RADIOv4-H--hf_model.RADIOConfig`.
+
+### 3.1 Fields vLLM reads
+
+| Field | Value | Use |
+| --- | --- | --- |
+| `args["model"]` | `"vit_huge_patch16_224"` | selects `(hidden=1280, layers=32, heads=16, ffn=5120)` from the hard-coded table `vllm/transformers_utils/configs/radio.py:12-17` |
+| `patch_size` | `16` | ViT patch size (`nano_nemotron_vl.py:1578`) |
+| `preferred_resolution` | `[768, 768]` | → `RadioConfig.image_size = 768` (`nano_nemotron_vl.py:1576-1577`) |
+| `args["cpe_max_size"]` | `2048` | learned pos-embed grid = `2048/16 = 128 × 128 = 16384` entries |
+| `args["register_multiple"]` | `10` | register-token count |
+| `args["cls_token_per_teacher"]` | `true` | one CLS token per unique teacher |
+| `args["teachers"]` | 4 entries: `clip`, `siglip`, `dino_v2`, `sam` | → `num_cls_tokens = 4`; `use_summary` true for the first three, false for `sam` → `summary_idxs = [0,1,2]` (summaries are computed then **discarded**, `nano_nemotron_vl.py:1056`) |
+| `args["min_num_patches"]` | `1024` | **presence enables dynamic-resolution images** (`processors/…:621-623`) |
+| `args["max_num_patches"]` | `13312` | per-image patch ceiling |
+| `video_target_num_patches` | `1024` | per-frame patch budget (`processors/…:798`) |
+| `video_maintain_aspect_ratio` | `true` | aspect-preserving frame resize (`processors/…:791-793`) |
+| `video_temporal_patch_size` | `2` | **T** — tubelet depth (`nano_nemotron_vl.py:1582-1584`) |
+| `separate_video_embedder` | `true` | dedicated `Linear(3·T·P² → 1280)` video embedder; `false` is unsupported (`radio.py:166-178`) |
+
+Derived token geometry:
+
+- CLS + registers stripped per item: `num_registers = 10 - (4 % 10) = 6`, so
+  **`num_skip = 4 + 6 = 10`** tokens dropped after the tower
+  (`radio.py:73-91, 319-332, 797-801`).
+- Image tokens per item = `patches / 4` (pixel-shuffle), so the budget
+  `[1024, 13312]` patches ⇒ **`[256, 3328]` tokens per image**.
+- 13312 patches ≈ a 115×115 grid ≈ 1840×1840 px, comfortably inside the
+  128×128 pos-embed grid — the two limits are consistent by design.
+- Video: 1024 patches/frame ⇒ ~32×32 grid ⇒ **256 tokens per tubelet**
+  (= 2 frames), i.e. 128 tokens/frame effective.
+
+### 3.2 Not read by vLLM
+
+`max_resolution: 2048`, `vitdet_window_size: null`, `video_prompt_version: 2`,
+`feature_normalizer_config`, `inter_feature_normalizer_config`,
+`adaptor_configs`, `adaptor_names`, and the duplicated top-level
+`min_num_patches`/`max_num_patches` (vLLM reads the copies inside `args`).
+
+`args` has **156 keys, of which vLLM uses 7** (listed above). The other 149 are
+timm training arguments serialized into the checkpoint — optimizer/schedule
+(`lr_base`, `sched`, `decay_epochs`), augmentation (`mixup`, `cutmix`, `hflip`,
+`color_jitter`), distillation bookkeeping (`fd_loss_fn`, `crd_loss`,
+`stream_teachers`), logging (`wandb_*`, `log_interval`), distributed
+(`world_size: 256`, `rank`, `fsdp`), and unused arch knobs (`mlp_hidden_size`,
+`mlp_version`, `vitdet_version`, `spectral_reparam`). Ignore all of them; the
+full list is in Appendix A.
+
+Values that come from `RadioConfig` **defaults**, not the checkpoint
+(`configs/radio.py:62-82`) — worth pinning explicitly in a port:
+`qkv_bias=True`, `qk_normalization=False`, `norm_type="layer_norm"`,
+`layer_norm_eps=1e-6`, `hidden_act="gelu"`, `initializer_factor=1.0`
+(→ layer scale = 1.0, and checkpoint `ls1`/`ls2` are skipped at load,
+`radio.py:780-782`).
+
+---
+
+## 4. `sound_config` — Parakeet (this block is what makes it "Omni")
+
+```json
+{
+  "model_type": "parakeet",
+  "hidden_size": 1024,
+  "num_attention_heads": 8,
+  "num_hidden_layers": 24,
+  "intermediate_size": 4096,
+  "conv_kernel_size": 9,
+  "convolution_bias": false,
+  "subsampling_conv_channels": 256,
+  "subsampling_conv_kernel_size": 3,
+  "subsampling_conv_stride": 2,
+  "subsampling_factor": 8,
+  "num_mel_bins": 128,
+  "projection_hidden_size": 4096,
+  "projection_bias": false,
+  "sampling_rate": 16000
+}
+```
+
+| Group | Values |
+| --- | --- |
+| Conformer encoder | 24 layers, `d=1024`, 8 heads (head_dim 128), FFN 4096, depthwise conv kernel 9, **no conv bias** |
+| Subsampling front-end | 3 stacked convs, 256 channels, kernel 3, stride 2 → `subsampling_factor = 8` |
+| Mel front-end | 128 mel bins @ 16 kHz; `hop_length=160`, `win_length=400`, `n_fft=512`, `preemphasis=0.97` come from `ExtractorConfig` defaults (`configs/parakeet.py:40-72`) since the checkpoint doesn't override them |
+| Projection | `RMSNorm(1024, eps=1e-5) → Linear(1024→4096) → ReLU² → Linear(4096→2688)`, no bias (`parakeet.py:27-45`) |
+
+Token rate: `hop_length=160` @ 16 kHz = **10 ms per mel frame**;
+`subsampling_factor=8` ⇒ **80 ms per audio token ⇒ 12.5 tokens/second**. A full
+30 s clip (`clip_duration_s=30`, an `ExtractorConfig` default) yields ~375
+tokens. Exact counts must come from `ParakeetExtractor.audio_token_count`
+(`parakeet.py:261-269`), which calls HF's `_get_subsampling_output_length`.
+
+Two traps:
+
+- `convolution_bias: false` combined with transformers v5 means the conv bias
+  params are never registered, yet the checkpoint may still contain those
+  tensors; vLLM tolerates this by name-skipping (`parakeet.py:112-131`).
+- The remote `SoundConfig` declares `feat_in: int = 80` as a default
+  (`configuration.py:34`) and the checkpoint does **not** set it, so `feat_in`
+  stays 80 while the real mel width is `num_mel_bins = 128`. vLLM correctly uses
+  `num_mel_bins` (`configs/parakeet.py:66`). Do not wire `feat_in` to anything.
+  Similarly `SoundConfig`'s defaults `conv_kernel_size=31`,
+  `projection_hidden_size=20480`, `projection_bias=True` are all overridden by
+  the checkpoint — never rely on the class defaults.
+
+---
+
+## 5. `llm_config` — Nemotron-H hybrid MoE (the "30B-A3B")
+
+```json
+{
+  "model_type": "nemotron_h",
+  "hidden_size": 2688,
+  "num_hidden_layers": 52,
+  "vocab_size": 131072,
+  "tie_word_embeddings": false,
+  "hybrid_override_pattern": "MEMEM*EMEMEM*EMEMEM*EMEMEM*EMEMEM*EMEMEMEM*EMEMEMEME",
+  "num_attention_heads": 32, "num_key_value_heads": 2, "head_dim": 128,
+  "rope_theta": 10000, "partial_rotary_factor": 1.0,
+  "max_position_embeddings": 262144, "sliding_window": null,
+  "mamba_num_heads": 64, "mamba_head_dim": 64, "n_groups": 8,
+  "ssm_state_size": 128, "conv_kernel": 4, "expand": 2, "chunk_size": 128,
+  "use_conv_bias": true, "mamba_proj_bias": false, "mamba_hidden_act": "silu",
+  "time_step_min": 0.001, "time_step_max": 0.1, "time_step_floor": 0.0001,
+  "time_step_limit": [0.0, 1e30],
+  "n_routed_experts": 128, "num_experts_per_tok": 6, "moe_intermediate_size": 1856,
+  "n_shared_experts": 1, "moe_shared_expert_intermediate_size": 3712,
+  "norm_topk_prob": true, "routed_scaling_factor": 2.5,
+  "n_group": 1, "topk_group": 1,
+  "intermediate_size": 1856, "mlp_hidden_act": "relu2", "mlp_bias": false,
+  "norm_eps": 1e-05, "layer_norm_epsilon": 1e-05,
+  "residual_in_fp32": false, "rescale_prenorm_residual": true,
+  "attention_bias": false, "attention_dropout": 0.0, "hidden_dropout": 0.0,
+  "use_mamba_kernels": true, "use_cache": true, "use_bias": false,
+  "bos_token_id": 1, "eos_token_id": 11, "pad_token_id": 0,
+  "initializer_range": 0.02, "num_logits_to_keep": 1
+}
+```
+
+### 5.1 Layer composition
+
+`hybrid_override_pattern` is one character per layer
+(`vllm/model_executor/models/nemotron_h.py:531-536, 574-596`):
+
+| Char | Layer type |
+| --- | --- |
+| `M` | `NemotronHMambaDecoderLayer` (Mamba-2) |
+| `*` | `NemotronHAttentionDecoderLayer` |
+| `E` | `NemotronHMoEDecoderLayer` |
+| `-` | `NemotronHMLPDecoderLayer` (dense MLP) |
+
+For this checkpoint the pattern has length **52** and decomposes as:
+
+- **23 × `M`** (Mamba-2)
+- **23 × `E`** (MoE)
+- **6 × `*`** (attention), at layer indices **5, 12, 19, 26, 33, 42**
+- **0 × `-`** — there are no dense MLP layers, so `intermediate_size: 1856` is
+  effectively unused (it only feeds `NemotronHMLP` defaults).
+
+`num_hidden_layers: 52` agrees with `len(pattern)`; vLLM builds layers from the
+pattern length, not from `num_hidden_layers` (`nemotron_h.py:594-596`).
+
+### 5.2 Derived shapes
+
+| Quantity | Value |
+| --- | --- |
+| Attention | Q `32×128 = 4096`, KV `2×128 = 256` (GQA 16:1), RoPE θ=10000, fully rotary |
+| Mamba-2 inner | `mamba_num_heads × mamba_head_dim = 64 × 64 = 4096` (`nemotron_h.py:377, 780`); 8 groups, state size 128, conv width 4, chunk 128. **`expand: 2` is stored but unused** — vLLM never derives the inner size from it, so do not compute `2 × 2688 = 5376` |
+| MoE | 128 routed experts, top-6, `d_ff = 1856` each; 1 shared expert with `d_ff = 3712`; sigmoid routing with `e_score_correction_bias`, `norm_topk_prob=true`, output scaled by 2.5 (`nemotron_h.py:150-236`) |
+| Activation | `relu2` (ReLU²) everywhere in MLP/MoE |
+| Embedding | 131072 × 2688, untied LM head |
+| Context | `max_position_embeddings: 262144` (checkpoint card advertises 131072 usable) |
+
+### 5.3 Key names: read the JSON literally
+
+`NemotronHConfig.__init__` takes the Mamba knobs under `mamba_*` aliases and
+re-exports them under different attribute names
+(`mamba_n_groups → n_groups`, `mamba_d_conv → conv_kernel`,
+`mamba_expand → expand`, `mamba_dt_min → time_step_min`,
+`mamba_conv_bias → use_conv_bias`, `mamba_chunk_size → chunk_size`;
+`configs/nemotron_h.py:242-255`). The checkpoint stores the **post-mapping**
+names, so those keys arrive as generic `**kwargs`. Because
+`super().__init__(**kwargs)` runs *after* the aliased assignments
+(`configs/nemotron_h.py:268-274`), the JSON values overwrite the alias defaults
+and win. Net effect: the literal JSON keys are the effective values — but a
+checkpoint that set, say, `n_groups` to something other than the
+`mamba_n_groups` default would depend on that ordering to take effect. Read the
+JSON keys as-is and don't re-derive them from the `mamba_*` aliases.
+
+### 5.4 SSM state cache dtype
+
+`residual_in_fp32: false`, and there is **no `mamba_ssm_cache_dtype` key**. vLLM's
+Nemotron-H default is `float32` when unset
+(`vllm/model_executor/models/config.py:605-625`), but the hook that applies it is
+registered only for the `"NemotronH_Nano_VL_V2"` architecture string
+(`config.py:857`), so it does **not** fire for the Omni architecture (see
+`NEMOTRON_OMNI_MULTIMODAL_DESIGN.md` §3.4). Use **fp32 SSM state** in a port.
+
+---
+
+## 6. `preprocessor_config.json`
+
+```json
+{
+  "image_processor_type": "NemotronH_Nano_Omni_Reasoning_V3ImageProcessor",
+  "auto_map": {
+    "AutoImageProcessor": "image_processing.NemotronH_Nano_Omni_Reasoning_V3ImageProcessor",
+    "AutoVideoProcessor": "video_processing.NemotronH_Nano_Omni_Reasoning_V3VideoProcessor",
+    "AutoProcessor": "processing.NemotronH_Nano_Omni_Reasoning_V3Processor"
+  },
+  "patch_size": 16,
+  "downsample_ratio": 0.5,
+  "norm_mean": [0.48145466, 0.4578275, 0.40821073],
+  "norm_std": [0.26862954, 0.26130258, 0.27577711],
+  "min_num_patches": 1024,
+  "max_num_patches": 13312,
+  "max_model_len": 16384
+}
+```
+
+vLLM does **not** use this file for these values — it builds its own processor
+from `config.json` plus the engine's `max_model_len`
+(`nano_nemotron_vl.py:200-209`). Note `max_model_len: 16384` here is only the HF
+processor's default token budget for dynamic-resolution tiling; under vLLM the
+image token budget scales with whatever `--max-model-len` you serve with, so
+**image resolution is a function of the served context length** (see
+`DynamicResolutionImageTiler.max_num_tokens_available`,
+`processors/nano_nemotron_vl.py:329-330`). Two deployments with different
+`--max-model-len` will tile the same image differently. A port must decide
+deliberately whether to follow vLLM (engine `max_model_len`) or HF (fixed
+16384); they disagree.
+
+---
+
+## 7. `generation_config.json`
+
+```json
+{
+  "bos_token_id": 1, "eos_token_id": [2, 11], "pad_token_id": 0,
+  "do_sample": true, "temperature": 0.6, "top_p": 0.95,
+  "max_new_tokens": 16384,
+  "reasoning_budget": 16384, "reasoning_grace": 512,
+  "repetition_penalty": 1.0
+}
+```
+
+`reasoning_budget` / `reasoning_grace` are Nemotron-V3 reasoning-parser
+concepts, not standard HF fields; they pair with
+`--reasoning-parser nemotron_v3` (`vllm/reasoning/nemotron_v3_engine_reasoning_parser.py`,
+`vllm/parser/nemotron_v3.py`). Note `eos_token_id` is a **list** here versus the
+scalar `11` in `config.json`.
+
+---
+
+## 8. Quantized variants (FP8 / NVFP4)
+
+Diffing the NVFP4 checkpoint's `config.json` against BF16: the **only**
+difference is an added top-level `quantization_config`. Every architectural
+field is identical.
+
+```json
+"quantization_config": {
+  "quant_method": "modelopt",
+  "quant_algo": "MIXED_PRECISION",
+  "kv_cache_scheme": {"dynamic": false, "num_bits": 8, "type": "float"},
+  "producer": {"name": "modelopt", "version": "0.43.0rc2.dev…"},
+  "config_groups": { … },
+  "quantized_layers": { … },
+  "ignore": []
+}
+```
+
+Empirically, from `quantized_layers` (5986 entries):
+
+| Fact | Value |
+| --- | --- |
+| Modules quantized | **`language_model.*` only** — zero entries under `vision_model.*`, `sound_encoder.*`, `sound_projection.*`, `mlp1.*` |
+| NVFP4 (group_size 16) | 5888 layers — the routed MoE experts (`…mixer.experts.N.{up,down}_proj`) |
+| FP8 | 98 layers — Mamba `in_proj`/`out_proj` and MoE `shared_experts` |
+| KV cache | FP8 (hence `--kv-cache-dtype fp8` in NVIDIA's serve command) |
+
+This is direct confirmation of the design-doc claim (§7.5): **the vision and
+audio towers and both projectors stay bf16 regardless of variant.** Budget
+tower memory as bf16 and don't look for tower scale tensors.
+
+---
+
+## 9. Config-level gotchas
+
+### 9.1 `video_pruning_rate: 0.7` in the config is ignored by vLLM
+
+The checkpoint requests 70 % video-token pruning, and the HF reference
+implementation honours it. vLLM reads the pruning rate **only** from engine
+config (`--video-pruning-rate`):
+
+```python
+# vllm/model_executor/models/nano_nemotron_vl.py:226-227
+def get_video_pruning_rate(self) -> float | None:
+    return self.ctx.get_mm_config().video_pruning_rate
+```
+
+`MultiModalConfig.video_pruning_rate` defaults to `None`
+(`vllm/config/multimodal.py:191-195`). So serving without the flag runs video
+**unpruned**, which is both slower and off-distribution relative to how the
+model was trained/tuned. NVIDIA's published command passes
+`--video-pruning-rate 0.5`. A port should decide explicitly: honour the config
+value, the CLI, or CLI-overrides-config — and document it.
+
+Concretely, with `video_target_num_patches: 1024`, `T=2`, 256 sampled frames:
+128 tubelets × 256 tokens = **32768 video tokens unpruned**, → 16384 at q=0.5,
+→ 9830 at q=0.7. On a 131072 context this is the difference between a workable
+and an unusable video prompt.
+
+### 9.2 Two different "image sizes"
+
+`force_image_size: 512` (top level) and `preferred_resolution: [768, 768]`
+(vision_config) are both live but feed different things:
+
+- `512` → the processor's `image_size` and `num_image_token = (512/16)²·0.25 =
+  256` (`processors/…:596-602`). Because Omni takes the dynamic-resolution path,
+  `num_image_token` is **not** used for images; it survives only as a fallback
+  for video token counting and dummy-data sizing.
+- `768` → `RadioConfig.image_size`, i.e. the ViT's nominal `input_dims` used when
+  no explicit size is given (`nano_nemotron_vl.py:1576-1577`).
+
+Neither bounds the actual image resolution — that comes from
+`min_num_patches`/`max_num_patches` and the context budget. Don't "simplify" by
+collapsing these.
+
+### 9.3 `use_thumbnail: true` is inert
+
+The dynamic tiler is constructed without `use_thumbnail` and asserts it is False
+(`processors/…:269, 610-618`); thumbnails only exist in the fixed-tile
+(`dynamic_preprocess`) path, which Omni does not take. Do not add a thumbnail
+tile.
+
+### 9.4 Duplicated fields that must stay consistent
+
+`video_temporal_patch_size` appears at the top level (HF modeling reads it) and
+in `vision_config` (vLLM reads it); both are `2`.
+`min_num_patches`/`max_num_patches` appear both in `vision_config` and in
+`vision_config.args`; vLLM reads the `args` copies. If a future checkpoint
+desynchronizes these, HF and vLLM will silently disagree.
+
+### 9.5 CI overrides are not real values
+
+`tests/models/registry.py:1188-1202` overrides `min_num_patches: 1`,
+`max_num_patches: 12`, `num_hidden_layers: 2`,
+`hybrid_override_pattern: "M*"`, and forces
+`video_maintain_aspect_ratio: false` (with a TODO noting a known mixed-resolution
+processor bug when it is `true` — the real checkpoint sets `true`). Never treat
+those as checkpoint values.
+
+---
+
+## 10. Quick reference card
+
+```text
+Total / active params ....... ~30B / ~3B (A3B)
+LM .......................... Nemotron-H hybrid, 52 layers = 23 Mamba2 + 23 MoE + 6 attention
+                              d=2688, vocab=131072, GQA 32/2 heads (head_dim 128), RoPE θ=1e4
+                              MoE: 128 experts, top-6, d_ff=1856, +1 shared expert d_ff=3712
+                              Mamba2: 64 heads × 64, 8 groups, state 128, conv 4, chunk 128
+Vision tower ................ C-RADIOv4-H = ViT-H/16: d=1280, 32 layers, 16 heads, ffn=5120
+                              4 CLS + 6 register tokens (num_skip=10), pos-embed grid 128×128
+                              image tokens/item ∈ [256, 3328]; video 256 tokens per 2-frame tubelet
+Vision projector (mlp1) ..... RMSNorm(5120) → 5120→20480 → ReLU² → 20480→2688 (no bias)
+Audio tower ................. Parakeet Conformer: d=1024, 24 layers, 8 heads, ffn=4096, conv k=9
+                              128 mel bins @16kHz, 8× subsampling ⇒ 12.5 tokens/s (80 ms/token)
+Audio projector ............. RMSNorm(1024) → 1024→4096 → ReLU² → 4096→2688 (no bias)
+Special tokens .............. <img> </img> <image>(18) | <video>(131081) | <so_start> <so_embedding>(27) <so_end>
+Precision ................... bf16 everywhere; FP8/NVFP4 variants quantize the LM only
+Serving flags ............... --trust-remote-code --reasoning-parser nemotron_v3
+                              --tool-call-parser qwen3_coder --video-pruning-rate 0.5
+                              --media-io-kwargs '{"video":{"fps":2,"num_frames":256}}'
+                              --kv-cache-dtype fp8 (quantized variants only)
+```
+
+---
+
+## Appendix A — `vision_config.args` keys ignored by vLLM (149 of 156)
+
+Kept for completeness so a port can confirm nothing was missed. None of these
+affect inference:
+
+```text
+aa, amp, amp_dtype, amp_impl, aug_repeats, aug_splits, bn_eps, bn_momentum,
+cache_dir, channels_last, checkpoint_hist, chk_keep_forever, class_map,
+clip_grad, clip_mode, coco_annotations_file, coco_image_dir, color_jitter,
+cooldown_epochs, crd_loss, crd_loss_weight, crop_pct, cutmix, cutmix_minmax,
+dataset_download, debug_full_knn, decay_epochs, decay_milestones, decay_rate,
+depchain, dist_bn, dist_norm_weight, distributed, drop, drop_block,
+drop_connect, drop_path, dtype, epoch_repeats, eval, eval_metric, eval_teacher,
+eval_teacher_only, eval_throughput, fast_norm, fd_loss_fn,
+feature_normalization, feature_summarizer, feature_upscale_factor,
+force_new_wandb_id, force_spectral_reparam, freeze_bn, fsdp, fuser, gp,
+grad_accum_steps, grad_checkpointing, head_init_bias, head_init_scale,
+head_warmup, head_weight_decay, hflip, img_size, in_chans, initial_checkpoint,
+input_size, interpolation, layer_decay, local_rank, log_interval, log_mlflow,
+log_wandb, loss_auto_balance, lr_base, lr_base_scale, lr_base_size,
+lr_cycle_decay, lr_cycle_limit, lr_cycle_mul, lr_k_decay, lr_noise,
+lr_noise_pct, lr_noise_std, mean, mesa, min_lr, mixup, mixup_mode,
+mixup_off_epoch, mixup_prob, mixup_switch_prob, mlp_hidden_size, mlp_num_inner,
+mlp_version, model_kwargs, model_norm, momentum, no_aug, no_ddp_bb,
+no_prefetcher, no_resume_opt, num_classes, opt_betas, opt_eps, patience_epochs,
+pin_mem, prefetcher, pretrained, rank, ratio, recount, recovery_interval,
+remode, reprob, reset_loss_state, resplit, save_images, scale, sched, seed,
+smoothing, spectral_heads, spectral_reparam, split_bn, start_epoch, std,
+stream_teachers, sync_bn, synchronize_step, torchcompile, torchscript,
+train_interpolation, train_split, tta, use_coco, use_multi_epochs_loader,
+val_ema_only, val_split, vflip, vitdet_version, wandb_entity, wandb_job_type,
+wandb_name, wandb_project, warmup_lr, warmup_prefix, worker_seeding, workers,
+world_size
+```
+
+Two that look meaningful but are not: `args["dtype"] = "bfloat16"` /
+`args["amp_dtype"]` are timm training settings — the runtime dtype comes from
+the top-level `torch_dtype` and the LM's dtype. And `args["mlp_hidden_size"]
+= 1520` / `mlp_version = "v2"` describe RADIO's *distillation heads*, not the
+ViT FFN (which is 5120, from the timm name table).
+
+## Appendix B — `teachers` block verbatim
+
+Only `name` and `use_summary` matter to vLLM (CLS-token count and summary
+selection); the rest documents how C-RADIOv4-H was distilled.
+
+```json
+[
+  {"name": "clip",    "model": "ViT-H-14-378-quickgelu",   "type": "open_clip", "pretrained": "dfn5b", "input_size": 378,  "feature_distillation": true, "fd_normalize": false, "use_summary": true},
+  {"name": "siglip",  "model": "ViT-SO400M-14-SigLIP-384", "type": "open_clip", "pretrained": "webli", "input_size": 378,  "feature_distillation": true, "fd_normalize": false, "use_summary": true},
+  {"name": "dino_v2", "model": "dinov2_vitg14_reg",        "type": "dino_v2",                          "input_size": 378,  "feature_distillation": true, "fd_normalize": false, "use_summary": true},
+  {"name": "sam",     "model": "vit-h",                    "type": "sam",                              "input_size": 1024, "feature_distillation": true, "fd_normalize": false, "use_summary": false}
+]
+```

--- a/docs/inference/nemotron_omni/mcore-inference-design.md
+++ b/docs/inference/nemotron_omni/mcore-inference-design.md
@@ -1,0 +1,700 @@
+# Nemotron Omni on Megatron-Core Inference — Design (DYNAMIC path)
+
+> **Goal.** End-to-end Nemotron 3 Nano/Super Omni (text + image + video + audio)
+> serving on `DynamicInferenceEngine`, with paged KV, chunked prefill, CUDA
+> graphs, TP/EP, and the `inference_optimized` MoE + Mamba stack intact.
+>
+> **Companion doc.** [`vllm-reference.md`](vllm-reference.md)
+> is the vLLM-side reference. This document does not repeat it; it maps that
+> behaviour onto Megatron-Core and records every place the two must or will
+> differ.
+>
+> **Reading order.** §1 (what already exists, incl. §1.4 the resolved
+> checkpoint config) → §2 (the one hard problem) → §3 (chosen architecture) →
+> §4 (file-by-file plan). §5 is the vLLM-divergence log. §7 records what is
+> settled and what I still need answered.
+
+---
+
+## 0. TL;DR
+
+The model is *almost entirely already in this repo*. What is missing is the
+inference plumbing.
+
+| | Status |
+| --- | --- |
+| RADIO vision tower (dynamic resolution, CPE, video tubelets, separate video embedder) | **Exists**, production, mcore-native: `megatron/core/models/vision/radio.py` |
+| Nemotron-H hybrid LM (Mamba2 + attention + MoE), accepts precomputed embeddings | **Exists**: `megatron/core/models/hybrid/hybrid_model.py:415` |
+| Pixel shuffle (dynamic-res variant that matches vLLM bit-for-bit) | **Exists**: `examples/mimo/model_providers/radio_encoder.py:121` |
+| Vision projector | **Exists but is missing the leading `RMSNorm`** the checkpoint requires (§7.1): `megatron/core/models/vision/multimodal_projector.py` |
+| RADIO + hybrid VLM, assembled and trained | **Exists**: `examples/mimo/model_providers/nemotron_moe_vlm.py`, and `megatron/core/models/multimodal/llava_model.py:223` |
+| Parakeet audio tower | **Partial**: `megatron/core/models/huggingface/fastconformer_model.py` loads a *separate* HF/NeMo checkpoint, not the Omni checkpoint's `sound_encoder.*` weights |
+| Host preprocessing (dynamic tiler, mel front-end, placeholder expansion) | **Missing** the Omni-specific budgeting; adjacent pieces exist in `examples/` |
+| EVS video pruning | **Missing** |
+| **Multimodal support in the dynamic inference path** | **Missing entirely** — this is the real work |
+
+The only multimodal inference in the tree is static-batch, batch-size-1, and
+architecturally unreusable: `VLMInferenceWrapper` + `VLMTextGenerationController`
++ `VLMInferenceRequest`, driven from `examples/multimodal/run_text_generation.py`
+with `legacy=True`. It handles image-token expansion by fudging a scalar
+`sequence_len_offset`
+(`megatron/core/inference/model_inference_wrappers/multimodal/vlm_inference_wrapper.py:199-214`).
+The dynamic path has no such scalar — it has per-token position/block tables and
+per-request prefix-cache hashes — so **none of that technique transfers.**
+
+Estimated work: ~2,600 new lines, ~120 modified lines across 11 existing files,
+in 6 landable phases. The two riskiest items are the host-side token-count
+contract (§6.1) and the pixel-shuffle ordering ambiguity (§7.2, Q1) — both are
+correctness cliffs, not performance work.
+
+The real checkpoint config is available and fully transcribed in §1.4, so no
+model dimension is a guess. Three of its values are traps that produce silent
+wrongness rather than a load error: `class_token_len=10` (mcore defaults to 8),
+`mamba_num_heads=64` (must be set explicitly, or `expand: 2` derives 5376
+instead of 4096), and `projector_hidden_size=20480` (4× the LM's own `d_ff`).
+
+---
+
+## 1. Starting position
+
+### 1.1 mcore RADIO is a superset of vLLM RADIO
+
+This is the single most important fact in the port. `RADIOViTModel`
+(`megatron/core/models/vision/radio.py:32`) already implements everything the
+vLLM tower does, and in one place rather than three:
+
+| Concern | vLLM | mcore |
+| --- | --- | --- |
+| Patch embed from pre-flattened `3·P²` vectors | `ViTPatchLinear`, `radio.py:496` | `self.embedder` = `ColumnParallelLinear(3·T·P² → hidden)`, `radio.py:169-199` |
+| Dynamic-resolution packed sequence, per-image pos-enc | `apply_pos_enc_dynamic`, `radio.py:265` | `forward` dynamic branch, `radio.py:381-396` |
+| CLS/register tokens prepended **per image** inside the packed sequence | `cls_token_dynamic`, `radio.py:295` | `forward`, `radio.py:400-425` |
+| Video tubelets, last-frame-repeat padding, separate video embedder | `forward_video`, `radio.py:216` | `_apply_temporal_grouping`, `radio.py:449` |
+| CPE position-embedding interpolation | `_get_pos_embeddings`, `radio.py:434` | `_get_pos_embeddings`, `radio.py:596` |
+| Varlen attention across packed items | `MaskMetadata(cu_seqlens, max_seqlen)` → `flash_attn_varlen_func` | `PackedSeqParams(qkv_format='thd')` → mcore `TransformerBlock` |
+| TP sharding of attention/MLP | `QKVParallelLinear` + `RowParallelLinear` | standard mcore `TransformerBlock` with TE specs |
+
+Three places mcore is strictly *more* capable, which we should keep:
+
+- **Mixed image+video in one encoder call.** mcore's `_apply_temporal_grouping`
+  handles `num_frames == 1` (image) and `num_frames > 1` (video) items in the
+  same packed batch. vLLM cannot, which is exactly why it sets
+  `requires_sequential_video_encoding = True` and encodes videos one at a time
+  (`gpu_model_runner.py:3143-3171`). **We do not need that limitation.**
+- **Pos-embed fast paths** for the int32-overflow case and aspect-ratio select
+  (`radio.py:680-696`), absent in vLLM.
+- **FP8 class-token padding hook** (`radio.py:716`).
+
+**Implication:** vLLM is *not* the source of truth for the tower. mcore is —
+vLLM's own comments say so (`radio.py:242` "order follows Megatron training";
+`processors/nano_nemotron_vl.py:145-180` "mirrors Megatron-LM's
+`image_processing.py`"). Where the two disagree numerically, suspect vLLM first
+(see §5.1 on LayerScale).
+
+### 1.2 The LM already accepts precomputed embeddings
+
+`HybridModel.forward` (`megatron/core/models/hybrid/hybrid_model.py:415-429`)
+takes `decoder_input`, and `:453-473` bypasses the embedding layer when it is
+provided. The comment at `:468-470` says out loud that this is for VLM wrappers.
+No model-side change is needed to *feed* embeddings — only to *inject* them
+(§3.2).
+
+### 1.3 What the dynamic path looks like today
+
+Two facts define the problem:
+
+**Token storage is a single flat `int64` buffer.** `DynamicInferenceContext`
+keeps one coalesced pinned CPU `uint8` buffer with typed views
+(`dynamic_context.py:1035-1047`), mirrored on GPU by `ContextGPUView`
+(`gpu_view.py:127-175`), transferred in one `cudaMemcpyAsync` per step. Every
+token-level field is an integer type. There is no float, hidden-size-wide buffer
+anywhere. All addresses are fixed for CUDA-graph replay.
+
+**The forward call is a hard-coded three-key dict.**
+
+```810:828:megatron/core/inference/text_generation_controllers/text_generation_controller.py
+    def _dynamic_step_forward_logits(self, input_ids: Tensor, position_ids: Tensor):
+        context = self.inference_wrapped_model.inference_context
+        if context.config.materialize_only_last_token_logits:
+            logits_seq_len = context.num_last_token_logits
+        else:
+            logits_seq_len = context.padded_active_token_count
+
+        with torch.inference_mode():
+            logits = self.inference_wrapped_model.run_one_forward_step(
+                {"tokens": input_ids, "position_ids": position_ids, "attention_mask": None}
+            )
+```
+
+`input_ids` is `[1, num_tokens]` — batch dim is always 1, all requests packed
+flat along the token axis (THD style). `AbstractModelInferenceWrapper._forward`
+(`abstract_model_inference_wrapper.py:109-127`) never passes `decoder_input`.
+
+### 1.4 The checkpoint, resolved
+
+Real values from `nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16`, transcribed
+in [`checkpoint-config.md`](checkpoint-config.md). Everything below is settled —
+do **not** use the CI-shrunk fixtures in `vllm/tests/models/registry.py`.
+
+**Vision tower is C-RADIOv4-H.** Direct mapping onto `RADIOViTModel`:
+
+| HF field | Value | `RADIOViTModel` arg |
+| --- | --- | --- |
+| `args["model"] = "vit_huge_patch16_224"` | `(1280, 32, 16, 5120)` | `TransformerConfig`: `hidden_size=1280, num_layers=32, num_attention_heads=16, kv_channels=80, ffn_hidden_size=5120` — exactly what `examples/mimo/model_providers/radio_encoder.py:90-95` already builds |
+| `patch_size` | 16 | `patch_dim=16` |
+| `preferred_resolution` | `[768, 768]` | `img_h=img_w=768` |
+| `args["cpe_max_size"]` | 2048 | `max_img_h=max_img_w=2048` → `max_num_rows=max_num_cols=128`, pos-embed grid 16384 (mcore's defaults already are 2048) |
+| `args["teachers"]` (4 unique) + `cls_token_per_teacher` | `num_cls_tokens=4` | — |
+| `args["register_multiple"] = 10` | `num_registers = 10 − (4 % 10) = 6` | — |
+| **combined** | **`num_skip = 4 + 6 = 10`** | **`class_token_len=10`** |
+| `video_temporal_patch_size` | 2 | `temporal_patch_dim=2` |
+| `separate_video_embedder` | `true` | `separate_video_embedder=True` |
+| `args["min_num_patches"]`, `args["max_num_patches"]` | 1024, 13312 | processor only (§4.2) ⇒ **256–3328 tokens per image** |
+| `video_target_num_patches`, `video_maintain_aspect_ratio` | 1024, `true` | processor only ⇒ 256 tokens per 2-frame tubelet |
+| defaults, pin explicitly | `qkv_bias=True`, `qk_normalization=False`, LayerNorm `eps=1e-6`, `hidden_act=gelu` | matches `radio_encoder.py:96-107` |
+
+> **`class_token_len` must be 10, not the mcore default of 8.** mcore stores one
+> combined `class_token` parameter `[class_token_len, hidden]`; vLLM splits it
+> into CLS + registers but concatenates them identically, and the converter maps
+> `patch_generator.*cls_token → class_token`. Getting this wrong is a silent
+> off-by-10-tokens-per-image error.
+
+**Projectors.** Both are `RMSNorm → Linear → ReLU² → Linear`, no bias:
+
+- vision `mlp1`: `RMSNorm(5120, eps=1e-5) → 5120→20480 → ReLU² → 20480→2688`
+- audio: `RMSNorm(1024, eps=1e-5) → 1024→4096 → ReLU² → 4096→2688`
+
+`projector_hidden_size = 20480` is large — 4× the LM's own `d_ff`. Do not assume
+it is small.
+
+**Audio tower.** Parakeet Conformer: 24 layers, `d=1024`, 8 heads (head_dim 128),
+FFN 4096, depthwise conv kernel 9, `convolution_bias=false`. 128 mel bins @
+16 kHz, `subsampling_factor=8` ⇒ **80 ms per audio token, 12.5 tokens/second**.
+Note `SoundConfig.feat_in` defaults to 80 and the checkpoint does not override
+it — the real mel width is `num_mel_bins=128`. **Do not wire `feat_in` to
+anything.**
+
+**Language model.** Two findings that make the LM side nearly free:
+
+1. **`hybrid_override_pattern` transfers verbatim.** The checkpoint's
+   `"MEMEM*EMEMEM*EMEMEM*EMEMEM*EMEMEM*EMEMEMEM*EMEMEMEME"` (52 chars = 23 `M`
+   + 23 `E` + 6 `*`) uses exactly mcore's symbol set — `Symbols.MAMBA = "M"`,
+   `Symbols.MOE = 'E'`, `Symbols.ATTENTION = "*"`
+   (`megatron/core/models/hybrid/hybrid_layer_allocation.py:17-26`). No
+   translation layer needed. Attention layers land at indices 5, 12, 19, 26, 33,
+   42. There are **no** dense MLP layers, so `intermediate_size: 1856` is inert.
+2. **`expand: 2` is stored but unused** — the real Mamba inner size is
+   `mamba_num_heads × mamba_head_dim = 64 × 64 = 4096`, **not**
+   `2 × 2688 = 5376`. mcore derives `mamba_num_heads` from
+   `hidden_size * expand // mamba_head_dim` only when it is `None`
+   (`transformer_config.py:1188-1190`), so set it explicitly:
+   `mamba_num_heads=64, mamba_head_dim=64, mamba_state_dim=128,
+   mamba_num_groups=8`. Leaving it unset silently builds a 5376-wide mixer that
+   will not load.
+
+Remaining LM shapes: `hidden_size=2688`, `vocab_size=131072` (untied),
+GQA 32/2 heads with `head_dim=128`, RoPE θ=1e4 fully rotary, 128 routed experts
+top-6 with `d_ff=1856` plus 1 shared expert `d_ff=3712`, sigmoid routing with
+`norm_topk_prob` and `routed_scaling_factor=2.5`, `relu2` activation throughout.
+
+**Quantization, settled empirically.** The NVFP4 variant's `quantized_layers`
+(5986 entries) contains **zero** entries under `vision_model.*`,
+`sound_encoder.*`, `sound_projection.*`, or `mlp1.*`. Only the LM is quantized
+(NVFP4 routed experts, FP8 Mamba `in_proj`/`out_proj` and shared experts, FP8 KV
+cache). Budget both towers and both projectors as bf16 and do not look for tower
+scale tensors.
+
+**Special tokens.** `<img>` / `</img>` / `<image>`(18) / `<video>`(131081) /
+`<so_start>` / `<so_embedding>`(27) / `<so_end>`. vLLM hard-codes the *strings*
+and resolves ids through the tokenizer; keep the strings identical.
+
+---
+
+## 2. The one hard problem
+
+Everything else is porting. This is design.
+
+A multimodal request's prompt contains placeholder spans (`<image>`×N,
+`<so_embedding>`×N, per-tubelet video spans). Those positions must receive
+**encoder-produced embedding rows** instead of embedding-table lookups. In the
+dynamic path this collides with five subsystems at once:
+
+1. **CUDA graphs.** The graphed region for hybrid models is owned by
+   `HybridModel` at `inference_cuda_graph_scope=block`, and *includes the
+   embedding layer* (`hybrid_model.py:379-413`). Any injection must be inside
+   that capture, with fixed tensor addresses and a static grid — the
+   `optimize-inference-siddharth` hard rules #1 and #3.
+2. **Chunked prefill.** A chunk boundary can land in the middle of an image's
+   token span (`dynamic_engine.py:1858-2031`). Injection must be indexed by
+   `finished_chunk_token_count`, never by whole-prompt offset.
+3. **Prefix caching.** `compute_block_hashes_batched`
+   (`inference_request.py:91-129`) hashes **raw token ids**. Two different
+   images expand to *identical* placeholder ids, so two different images produce
+   the same block hash → **false cache hit → wrong output.** This is a
+   correctness bug, not a perf issue.
+4. **Token accounting.** `_add_request` derives `num_tokens_to_generate`,
+   block counts, and cache keys from `len(request.prompt_tokens)`
+   (`dynamic_engine.py:1100-1149`). Expansion must therefore happen *before*
+   `_add_request`, not inside the step loop.
+5. **Sequence parallelism.** Embeddings are SP-scattered after the embedding
+   layer (`hybrid_model.py:468-473`); injection must happen on the full
+   sequence, before that scatter.
+
+### 2.1 Options considered
+
+| Option | Verdict |
+| --- | --- |
+| **(A) Run the encoders inline in the LM forward**, as `LLaVAModel` does for training and as `VLMInferenceWrapper` does for static inference | **Rejected.** Encoder output shape varies per request → breaks CUDA-graph capture. Chunked prefill would re-run the tower once per chunk. The tower would sit inside the graphed block. |
+| **(B) Pre-embed the whole prompt on the host**, pass a fully-formed `decoder_input` | **Rejected.** Requires the wrapper to call `model.embedding` itself, duplicating the SP-scatter and quantization-padding logic, and moves the embedding layer *out* of the block-scope graph — undoing a measured win (see `skills/optimize-inference-siddharth/references/cuda-graphs.md`). |
+| **(C) Run encoders once at admission; scatter rows into a fixed-address GPU buffer; masked-overwrite inside the LM after the embedding layer** | **Chosen.** |
+
+---
+
+## 3. Chosen architecture
+
+Three stages, mirroring vLLM's host/device split (which is a good split — the
+host stage is tokenizer-bound and cacheable, the device stage is pure tensor
+work), but with the encoder pulled *out* of the graphed step.
+
+```
+add_request(request_id, prompt, sampling_params, multimodal_data=…)
+│
+│  STAGE 1 — HOST (CPU, per request, cacheable)
+├─ NemotronOmniProcessor(prompt_text, images, videos, audios)
+│    ├─ images → dynamic tiler → pre-patchified [1, ΣPᵢ, 3·P²] + imgs_sizes + num_tokens_per_image
+│    ├─ video  → resized frames + frames_indices + frame_duration_ms (INTEGER, §5.4)
+│    ├─ audio  → 30 s clips → log-mel [clips, T, mel] + attention mask + audio_num_clips
+│    └─ prompt text → EXPANDED token ids  +  mm_embed_positions (which positions get rows)
+│
+│  STAGE 2 — DEVICE, eager, outside the graphed step
+├─ NemotronOmniEncoderStack.encode(...)
+│    ├─ RADIOViTModel(dynamic)  → strip CLS/registers → pixel_shuffle_dyn → vision_projection
+│    ├─ RADIOViTModel(temporal) → pixel_shuffle → projection → EVS → hybrid text+vision assembly
+│    └─ ParakeetEncoder → ParakeetProjection → per-clip trim → concat per item
+│    ⇒ mm_embeddings [Σ N_mm, hidden]  (bf16, GPU)
+│
+└─ DynamicInferenceRequest(prompt_tokens=<expanded>,
+                           mm_embeddings=…, mm_embed_positions=…)
+   → _add_request()   ← unchanged accounting, now over the EXPANDED length
+
+PER STEP (unchanged control flow)
+│
+├─ context.add_request(req, prefill_chunk_length)
+│    token_to_input_ids[a:b] = this_round_tokens                    (existing)
+│    NEW: rows whose position ∈ [a,b) → token_to_mm_embedding[…]
+│    NEW: token_to_is_mm[…] = True
+│
+└─ HybridModel.forward(..., inference_context=ctx)
+     decoder_input = self.embedding(input_ids, position_ids)        (existing)
+     NEW: decoder_input = ctx.apply_multimodal_embeddings(decoder_input)
+          → torch.where(is_mm, mm_buf, decoder_input)               ← graph-safe
+     ...SP scatter, quantization padding zero, decoder...           (existing)
+```
+
+### 3.1 Why admission-time encoding
+
+Running the towers at `add_request` keeps the per-step host critical section
+(`bookkeeping` → `detokenization` → `coordinator_communication`) untouched, and
+keeps the graphed region pure. The cost is that a large media payload adds
+encoder latency to the admitting call, which for a batch of long videos is
+seconds.
+
+**v1:** encode at admission, synchronously. Simple, correct, easy to validate
+against vLLM.
+
+**v2 (follow-up, not in scope):** move Stage 2 to a dedicated CUDA stream with
+a content-hash encoder cache, mirroring
+`gpu_model_runner.py:3203-3211`, and let the scheduler admit a request whose
+encoder work has not finished yet. Design the request fields (§4.3) so this is
+a scheduler change only, not a data-model change.
+
+### 3.2 Why a masked overwrite is graph-safe
+
+Two preallocated, fixed-address GPU buffers:
+
+```python
+# megatron/core/inference/contexts/dynamic_context.py (new, allocated once)
+self.token_to_mm_embedding  # [max_tokens, 1, hidden]  params_dtype
+self.token_to_is_mm         # [max_tokens, 1, 1]       bool
+```
+
+Injection is then
+
+```python
+decoder_input = torch.where(self.token_to_is_mm[:n], self.token_to_mm_embedding[:n], decoder_input)
+```
+
+Fixed shapes for a given graph bucket, fixed addresses, values change between
+replays. This is precisely the pattern hard rule #1 prescribes: "`fill_` it into
+a preallocated, fixed-address GPU tensor and read it inside the kernel." Padding
+rows have `is_mm == False`, so §5 hard rule #5 ("padding must not do real work")
+is satisfied without a zeroing pass.
+
+Note the orientation: mcore's embedding returns `[s, b, h]` with `b == 1`, so
+the buffers are `[max_tokens, 1, hidden]`, not `[max_tokens, hidden]`.
+
+**Memory cost.** `max_tokens × hidden × 2 bytes`. This is the *per-step* token
+budget, not `max_sequence_length` — e.g. 8192 tokens × 4096 hidden × 2 = 64 MiB.
+Gate the allocation on a config flag so text-only deployments pay nothing.
+
+### 3.3 Placement of the injection call
+
+Immediately after `decoder_input = self.embedding(...)` in
+`hybrid_model.py:456`, and **before** both the quantization padding zero
+(`:460-466`) and the SP scatter (`:468-473`). Order matters:
+
+- before SP scatter, because the mm buffer is indexed by global token position;
+- before the padding zero, so the padding zero still wins on padded rows.
+
+---
+
+## 4. File-by-file change plan
+
+Six phases. Each is independently landable and testable. Phase 0–2 give
+image-only single-request inference; that is the right first milestone.
+
+### Phase 0 — Embedding injection into the dynamic path (no multimodal yet)
+
+The enabling change. Testable on its own with a synthetic embedding buffer.
+
+| # | File | Change |
+| --- | --- | --- |
+| 0.1 | `megatron/core/inference/config.py` | Add `enable_multimodal: bool = False` and `multimodal_hidden_size: Optional[int]`. Gates the buffer allocation. |
+| 0.2 | `megatron/core/inference/contexts/dynamic_context.py` | Allocate `token_to_mm_embedding` `[max_tokens, 1, hidden]` and `token_to_is_mm` `[max_tokens, 1, 1]` in `__init__`. **Keep them out of the coalesced `_cpu_bookkeeping_buf`** (`:1123-1129`) — embeddings are produced on GPU and never need the pinned H2D mirror; folding them in would dominate the single per-step `cudaMemcpyAsync` (`:2562`). |
+| 0.3 | same | Add `apply_multimodal_embeddings(decoder_input)`, and `has_multimodal_embeddings()` (cheap host-side bool, refreshed once per step from a counter — **not** a `.item()`). |
+| 0.4 | same, `reset_tensors` (`:2642`) | `token_to_is_mm.fill_(False)`. Do **not** zero `token_to_mm_embedding` — nothing reads it where the mask is False (hard rule #5). |
+| 0.5 | `megatron/core/models/hybrid/hybrid_model.py:456` | Insert the injection between the embedding call and the SP scatter (§3.3). |
+| 0.6 | `megatron/core/models/gpt/gpt_model.py:331-345` | Same insertion, for symmetry / non-hybrid Omni variants. Optional for v1. |
+
+**Risk:** the CUDA-graph capture must see the injection. Verify
+`num_cuda_graphs` still reports the expected bucket count and that a mm step
+does not silently fall back to eager (see `cuda-graphs.md`).
+
+### Phase 1 — Request-level multimodal payload
+
+| # | File | Change |
+| --- | --- | --- |
+| 1.1 | `megatron/core/inference/inference_request.py:359-427` | Add to `DynamicInferenceRequest`: `mm_embeddings: Optional[Tensor]` `[N_mm, hidden]`, `mm_embed_positions: Optional[Tensor]` `[N_mm]` (int32, positions within the expanded prompt), `mm_content_hash: Optional[int]`. |
+| 1.2 | same, `serialize` (`:172-198`) | `serialize()` converts every tensor attribute via `.cpu().tolist()`. Explicitly exclude `mm_embeddings` — serializing a few-MB bf16 tensor per request over the coordinator IPC would wreck the host path. |
+| 1.3 | same, `DynamicInferenceRequestRecord.merge` (`:714-772`) | Field list is explicit; new fields drop silently otherwise. |
+| 1.4 | same, `__post_init__` → `_compute_block_hashes` (`:392-415`) | **Correctness-critical.** Either (a) fold `mm_content_hash` into the parent digest chain of `compute_block_hashes_batched`, or (b) set `enable_prefix_caching = False` whenever `mm_embeddings is not None`. **v1: (b).** It is two lines and cannot be wrong. (a) is the right long-term answer and is a clean follow-up. |
+| 1.5 | `megatron/core/inference/contexts/dynamic_context.py:3182-3196` | In `add_request`, after the existing `token_to_input_ids` write, scatter mm rows for positions in `[prefix_skip_tokens, prefill_chunk_length)` into `token_to_mm_embedding[active_token_count + (pos - a)]` and set `token_to_is_mm`. Index off `req.finished_chunk_token_count` so chunked prefill is handled by construction. |
+| 1.6 | `megatron/core/inference/engines/dynamic_engine.py:1166-1223` | Widen `add_request` with `multimodal_data: Optional[MultimodalData] = None`. Run Stage 1 + Stage 2 and set the expanded `prompt_tokens` **before** calling `_add_request` (§2, item 4). |
+
+### Phase 2 — Vision path
+
+| # | File | Change |
+| --- | --- | --- |
+| 2.1 | `megatron/core/inference/multimodal/nemotron_omni/config.py` **(new)** | Parse the composite HF `config.json` into `NemotronOmniConfig` + `RadioVisionConfig` + `SoundConfig`. Mirror vLLM's field reads (`nano_nemotron_vl.py:923-1012`) but resolve the RADIO dims from the `vit_huge_patch16_224` → `(1280, 32, 16, 5120)` table (`vllm/transformers_utils/configs/radio.py:12-20`) into a `TransformerConfig`, reusing `examples/mimo/model_providers/radio_encoder.py:86` `radio_vision_config` as the template. |
+| 2.2 | `.../nemotron_omni/image_processor.py` **(new, ~350 lines)** | Port `DynamicResolutionImageTiler` (`vllm/transformers_utils/processors/nano_nemotron_vl.py:251-569`) verbatim-in-behaviour: the `×4` token→patch budget conversion, the `[min_num_patches, max_num_patches]` clip, the 10-round proportional scale-down, `round(dim/patch + 0.5)` (**not** `math.ceil`), `factor = min(…, 1.0)` never-upscale, round-to-multiple-of-2 preferring up, and `stack()` producing `[1, ΣPᵢ, 3·P²]`. Resize is bicubic `antialias=True, align_corners=False`, fp32, then `(x/255 − mean)/std`. |
+| 2.3 | `.../nemotron_omni/encoder_stack.py` **(new)** | `NemotronOmniEncoderStack`: owns `RADIOViTModel`, the vision projector, and (Phase 4) the audio tower. `encode_images()` = RADIO(dynamic) → strip `class_token_len` per image → `_pixel_shuffle_dynamic_res` → projector → split by `num_tokens_per_image`. Build `PackedSeqParams(qkv_format='thd')` from `imgs_sizes`; note `RADIOViTModel.forward` **mutates `packed_seq_params` in place** when adding class tokens (`radio.py:411-423`), so pass a fresh object per call. |
+| 2.4 | `megatron/core/models/vision/pixel_shuffle.py` **(new, ~30 lines)** | Promote `_pixel_shuffle_dynamic_res` out of `examples/mimo/model_providers/radio_encoder.py:121` into core, unchanged. It is the version that matches vLLM (verified — see §5.2). Have both `examples/mimo` and the new encoder stack import it. |
+| 2.5 | `megatron/core/inference/multimodal/nemotron_omni/prompt.py` **(new)** | Placeholder expansion + the token-count contract of §6.1. Tokenize each span component independently (`<img>`, `<image>`×k, `</img>`) — never the joined string. |
+
+### Phase 3 — Video path
+
+| # | File | Change |
+| --- | --- | --- |
+| 3.1 | `.../nemotron_omni/video_processor.py` **(new)** | Frame resize to a common target from `video_target_num_patches`, aspect-preserving mode snapping both sides to multiples of 2. Cross-check against `examples/multimodal/image_processing.py:47` `find_closest_area_weighted_aspect_ratio` — vLLM says its version mirrors that file, so that is the oracle, not vLLM. `frame_duration_ms = int(1000.0 / fps)`, integer, non-negotiable (§5.4). |
+| 3.2 | `megatron/core/models/vision/evs.py` **(new, ~80 lines)** | Direct port of `compute_retained_tokens_count` + `compute_retention_mask` (`vllm/multimodal/evs.py:16-92`). Load-bearing details: the literal `255` sentinel (not `+inf`) for frame 0, `stable=True` descending argsort, `spatial_merge_size=1`, applied **after** the projector on LM-dim embeddings. Skip the M-RoPE half of that file — Nemotron-H does not use M-RoPE. |
+| 3.3 | `.../nemotron_omni/encoder_stack.py` | `encode_videos()`: one `RADIOViTModel` call with `num_frames=[…]` and `temporal_patch_dim=T`. **We can batch videos and images together** — mcore's `_apply_temporal_grouping` supports mixed items, so vLLM's `requires_sequential_video_encoding` workaround is unnecessary (§5.3). |
+| 3.4 | same | `_create_final_video_embeddings` equivalent: re-derive the per-tubelet separator token ids from the *actual* retained counts, embed them through the LM embedding table, and scatter vision rows into the `<image>` positions. This makes the video encoder output depend on the tokenizer and the LM embedding table — an unusual coupling, faithfully reproduced (§5.5). |
+
+### Phase 4 — Audio path
+
+| # | File | Change |
+| --- | --- | --- |
+| 4.1 | `.../nemotron_omni/audio_processor.py` **(new, ~220 lines)** | Port `ParakeetExtractor` (`vllm/model_executor/models/parakeet.py:138-335`): mono by channel mean; 30 s clip split with a ≥0.1 s tail; right-pad to batch max; pre-emphasis `x[t] − 0.97·x[t−1]` with valid-length masking; STFT `n_fft=512, hop=160, win=400`, Hann `periodic=False`, `pad_mode="constant"`; slaney mel filterbank; `log(mel + 2⁻²⁴)`; per-clip normalization over valid frames with **sample** variance `/(n−1)`. All fp32. Cross-check the mel filterbank against the vendored `megatron/core/models/audio/nemo_audio_preprocessing.py:111` `_create_mel_filterbank` rather than pulling in `transformers.audio_utils`. |
+| 4.2 | `megatron/core/models/audio/parakeet_model.py` **(new)** | `ProjectedParakeet` equivalent: HF `transformers.ParakeetEncoder` + `ParakeetProjection` (`RMSNorm → Linear → ReLU² → Linear`). Replicated, unquantized, `llm_dtype` in, bf16 out before projection. **Do not** reuse `ParakeetHuggingFaceModel` (`megatron/core/models/huggingface/fastconformer_model.py:28`) as-is: it loads a *separate* `hf://`/`nemo://` checkpoint via `AutoModel.from_pretrained`, whereas we must load `sound_encoder.*` out of the Omni checkpoint. Reuse its dtype/sampling-rate helpers only. |
+| 4.3 | same | Expose `_get_subsampling_output_length`. It is called from three places (host token count, device trim, dummy-input sizing) and must agree with the host extractor exactly. |
+| 4.4 | `.../nemotron_omni/encoder_stack.py` | `encode_audio()`: encode all clips, trim each to `_get_subsampling_output_length(mask.sum(1))`, concatenate clips belonging to one audio item. Assert the result length equals the host's `audio_token_count` (§6.1). |
+
+**Dependency risk.** `transformers` is unpinned in `pyproject.toml:76,87`, and
+`ParakeetEncoder` / `ParakeetEncoderConfig` require **transformers ≥ 5.5.3**
+(vLLM's own pin). Verify the CI container ships that; if not, this becomes a
+`mcore-build-and-dependency` task or forces a native conformer reimplementation
+(≈600 lines). See §7.2, Q5. Fixed shapes from §1.4: 24 layers, `d=1024`, 8 heads,
+FFN 4096, conv kernel 9, no conv bias, 128 mel bins, `subsampling_factor=8`
+(80 ms per audio token). Ignore `SoundConfig.feat_in`, which is a stale default
+of 80 and is not overridden by the checkpoint.
+
+### Phase 5 — Checkpoint loading
+
+| # | File | Change |
+| --- | --- | --- |
+| 5.1 | `tools/checkpoint/` or a new `.../nemotron_omni/checkpoint.py` | HF → mcore mapping. No single path exists today: `megatron/core/export/` is TRT-LLM only, and `tools/checkpoint/loader_llava.py` reads RADIO but sources vision weights from `torch.hub` (`examples/multimodal/model_converter/radio_converter.py`), not HF safetensors. |
+| 5.2 | same | Four prefix classes, mirroring `nano_nemotron_vl.py:1509-1568`: `language_model.backbone.*` → hybrid LM; `mlp1.*` → vision projector; `vision_model.radio_model.*` → `RADIOViTModel`; `sound_encoder.*` / `sound_projection.*` → audio tower. Skip `input_conditioner.*` (normalization lives in the processor) and `summary_idxs`. Reuse the QKV head-interleave reindex from `radio_converter.py:42-95`. |
+| 5.3 | same | **Do not** skip `ls1`/`ls2` the way vLLM does (§5.1). Load them if present; assert-warn if they are not ~1.0. |
+| 5.4 | same | Mamba SSM state dtype: force **fp32**. vLLM's own config hook for this is keyed to the non-Omni architecture string and therefore never fires for Omni checkpoints (`vllm/model_executor/models/config.py:857`) — a vLLM bug we must not copy. |
+
+### Phase 6 — Serving surface and tests
+
+| # | File | Change |
+| --- | --- | --- |
+| 6.1 | `.../dynamic_text_gen_server/endpoints/chat_completions.py:258-270` | Today OpenAI multimodal content blocks are **flattened to text and images discarded**. Route `image_url` / `input_audio` / video parts into `multimodal_data` instead. |
+| 6.2 | `megatron/core/inference/text_generation_controllers/text_generation_controller.py` | No change expected — the controller stays modality-agnostic because injection is context-mediated. Confirm `_dynamic_step_context_init` (`:717`) needs nothing. |
+| 6.3 | `tests/unit_tests/inference/multimodal/` **(new)** | See §6.2. |
+| 6.4 | `tests/functional_tests/` | Add an Omni recipe via `skills/add-inference-functional-tests`. |
+
+### Files touched, at a glance
+
+**Modified (11):** `inference/config.py`, `inference/contexts/dynamic_context.py`,
+`inference/contexts/gpu_view.py` (only if buffers are folded in — recommended
+not), `inference/inference_request.py`, `inference/engines/dynamic_engine.py`,
+`models/hybrid/hybrid_model.py`, `models/gpt/gpt_model.py`,
+`.../endpoints/chat_completions.py`, `examples/mimo/model_providers/radio_encoder.py`
+(import moved), `pyproject.toml` (maybe), `tools/checkpoint/…`.
+
+**New (~10):** `megatron/core/inference/multimodal/nemotron_omni/{config,image_processor,video_processor,audio_processor,prompt,encoder_stack,checkpoint}.py`,
+`megatron/core/models/vision/{pixel_shuffle,evs}.py`,
+`megatron/core/models/audio/parakeet_model.py`.
+
+Notably **not** touched: `RADIOViTModel`, `HybridStack`, the MoE stack, the KV
+block allocator, the attention metadata, the sampling path.
+
+---
+
+## 5. Divergences from the vLLM implementation
+
+The task asked for this explicitly. Divergences split into three kinds:
+**vLLM bugs we should not copy**, **vLLM limitations we can beat**, and
+**forced differences** from mcore's architecture.
+
+### 5.1 Both vLLM and mcore discard LayerScale — the risk is against HF, not vLLM
+
+`RadioModel.load_weights` explicitly `continue`s on any `ls1`/`ls2` key
+(`radio.py:780-782`); `InternVisionEncoderLayer.__init__` then initializes them
+to `initializer_factor * ones` = 1.0 and multiplies by them in forward. So in
+vLLM **layer scale is identity**. The skip branch only exists because the
+checkpoint *does* carry those tensors.
+
+`megatron/core/models/vision/radio.py` has no LayerScale at all — grep for
+`ls1`/`ls2`/`layer_scale` returns nothing. So **mcore already matches vLLM here
+for free**, and cut point (b) parity is unaffected. The exposure is that *both*
+may differ from the HF reference implementation, which does apply them.
+
+**Action:** dump `blocks.*.ls{1,2}` from the checkpoint and check ≈1.0. If they
+are non-unit, both engines are dropping a real transform, and mcore's radio-g
+converter (`examples/multimodal/model_converter/radio_converter.py`, which maps
+`blocks.N.ls{1,2}.grandma → decoder.layers.N.ls{1,2}`) shows the shape of the
+fix. Track as a correctness bug against HF, not as a port bug.
+
+### 5.2 Pixel shuffle: mcore has two mutually incompatible versions
+
+Verified by hand-deriving the index maps:
+
+| Implementation | Behaviour |
+| --- | --- |
+| `examples/mimo/model_providers/radio_encoder.py:121` `_pixel_shuffle_dynamic_res` | Folds a **2×2 spatial neighbourhood** into channels; 4c layout `[h-parity, w-parity, channel]`. **Identical to vLLM's `pixel_shuffle_dynamic_res`.** |
+| `megatron/core/models/multimodal/llava_model.py:1342-1347` — the `h`/`w`-provided branch | `x.reshape(n, patches // 4, c*4)`. A **plain reshape**, grouping 4 *horizontally adjacent* patches (a 1×4 strip). **Not equivalent.** |
+| `llava_model.py:1348-1366` — the square branch | Verified identical to both mimo's and vLLM's. Only the local variable naming differs (`n, w, h, c = x.size()` on a `(n, d1, d2, c)` tensor). |
+
+`LLaVAModel`'s packed dynamic-res path calls the non-equivalent branch
+(`llava_model.py:1112`), while the MIMO provider deliberately does not — its
+docstring says *"Element ordering intentionally differs from core `pixel_shuffle`
+(e2e-validated); do not swap to match it."*
+
+**Action:** use the mimo/vLLM semantics (Phase 2.4), and raise the `LLaVAModel`
+discrepancy with the training owners (§7.2, Q1). One of the two training paths is
+producing checkpoints the other cannot serve.
+
+### 5.3 We can beat vLLM on video encoding
+
+vLLM declares `requires_sequential_video_encoding = True`
+(`nano_nemotron_vl.py:904`) and encodes videos one at a time
+(`gpu_model_runner.py:3143-3171`) purely because batched dynamic-resolution
+video is unimplemented there. mcore's `_apply_temporal_grouping`
+(`radio.py:449-550`) already handles mixed image/video items in one packed
+batch. **Deliberate divergence: batch them.** Numerically identical (the tubelet
+grouping and last-frame padding are per-item), materially faster.
+
+Similarly, vLLM has **no batch-level encoder data parallelism** for this model
+(`supports_encoder_tp_data` is not set, so `--mm-encoder-tp-mode data` is
+downgraded with a warning). Nothing in the math forbids sharding the media batch
+across ranks in mcore; the replicated audio tower in particular would benefit.
+Out of scope for v1, worth noting as headroom.
+
+### 5.4 Behaviours that must be copied bit-for-bit
+
+Each of these has a specific failure mode; none are stylistic.
+
+| Behaviour | Why | Failure if wrong |
+| --- | --- | --- |
+| `frame_duration_ms = int(1000.0 / fps)`, integer | Timestamps are re-rendered inside the model in bf16 context; float fps made host and device disagree | Different timestamp strings → different separator token counts → shape mismatch |
+| Tokenize span components **independently** | `separator`, `<img>`, `<image>`×k, `</img>` concatenated, never joined-then-tokenized | Token merging across boundaries changes the count |
+| EVS: `255` sentinel, `stable=True` argsort, `kept = max(tokens_per_frame, int(total·(1−q)))`, pruning after the projector | Reproducibility | Non-deterministic retention set |
+| Tubelet padding by **last-frame repetition**, einops order `(tubelets frames) spatial feat -> tubelets spatial (frames feat)` | Matches training | Garbage video features |
+| Dynamic tiler: `round(dim/P + 0.5)`, `factor = min(…, 1.0)`, round grids to multiples of 2 preferring up, 10-round budget loop | Token-count parity | Shape mismatch |
+| Audio: 30 s clips + ≥0.1 s tail, per-clip normalization with **sample** variance, token count floored at 1 | Token-count parity | Off-by-N audio tokens |
+| Image token budget depends on **prompt length**: `max_model_len − text_prompt_length − 4` | Image resolution varies with prompt | Different resolution than the checkpoint expects |
+| CLS/register stripping: `num_skip` tokens **per item** | mcore's `class_token_len` must equal vLLM's `num_cls_tokens + num_registers`; for this checkpoint that is `4 + 6 = 10`, **not** mcore's default of 8 (§1.4) | Off-by-10 per image, silently |
+| Encoders unquantized even for FP8/NVFP4 checkpoints | vLLM never passes `quant_config` to the towers | Failed scale loads |
+
+### 5.5 Forced architectural differences
+
+| vLLM | mcore | Consequence |
+| --- | --- | --- |
+| `MaskMetadata(cu_seqlens, max_seqlen)` threaded 5 levels into `MMEncoderAttention` → `flash_attn_varlen_func` | `PackedSeqParams(qkv_format='thd')` into `TransformerBlock` | Equivalent varlen attention. Watch the in-place `packed_seq_params` mutation at `radio.py:411-423` |
+| `embed_multimodal` called by the runner per step, with a content-hash encoder cache | Encoders run at admission (§3.1) | Different latency profile; no cross-request reuse in v1 |
+| Video embeddings returned as the *full* replacement span (separators embedded via the LM table) | Same, faithfully reproduced | Encoder output couples to tokenizer + embedding table |
+| `is_embed` mask machinery in the multimodal registry | `mm_embed_positions` on the request + `token_to_is_mm` in the context | Same semantics, simpler |
+| No pipeline parallelism (`SupportsPP` absent) | PP is available, but `_allocate_recv_buffer` (`abstract_model_inference_wrapper.py:148-158`) divides `seq_len` by `tp_size` for SP | PP+multimodal needs explicit validation; consider gating it off in v1 |
+| Encoder runs eagerly; `SupportsEncoderCudaGraph` absent | Same — encoders stay outside the graph | Matches |
+| `torch.compile` on the host resize/mel ops and per ViT layer | Not replicated | Perf only, no semantic change |
+
+---
+
+## 6. Correctness contract and validation
+
+### 6.1 The token-count contract — port this first
+
+Before any kernel work, assert that host-side placeholder counts equal
+device-side embedding rows.
+
+| Modality | Expanded span | Count | Which positions get rows |
+| --- | --- | --- | --- |
+| Image | `<img>` + `<image>`×F + `</img>` | `F = grid_h·grid_w / 4` (dynamic path) | only `<image>` positions |
+| Audio | `<so_start>` + `<so_embedding>`×N + `<so_end>` | `N = Σ` subsampled clip lengths, ≥1 | only `<so_embedding>` positions |
+| Video | per tubelet: separator + `<img>` + `<image>`×k + `</img>` | `Σk = frames·tokens_per_frame`, or EVS `kept` | **all positions in the span** |
+
+The video row is the subtle one, and the reason for Phase 3.4.
+
+Add a debug assertion in `add_request` that
+`mm_embeddings.shape[0] == mm_embed_positions.numel()` and that every position is
+within the expanded prompt. Keep it behind a flag; it is a host-side check but
+runs once per request, not per step.
+
+### 6.2 Test matrix
+
+Unit tests (`tests/unit_tests/inference/multimodal/`), following the reference-
+implementation pattern from `skills/add-inference-unit-tests`:
+
+1. **Tiler parity** — the doctest in
+   `vllm/transformers_utils/processors/nano_nemotron_vl.py:290-327` is a ready-made
+   fixture: `patch=16, ds=0.5, max_model_len=16384, target=8192` → `(2880, 2880)`
+   → 8100 tokens post-shuffle.
+2. **Token-count parity** across: single image; multi-image under a tight
+   dynamic budget; 1-frame video; `T` not dividing the frame count; EVS on/off;
+   single- and multi-clip audio.
+3. **Pixel-shuffle equivalence** — assert the promoted core function matches an
+   explicit 2×2-fold reference on non-square grids, and *differs* from
+   `llava_model.pixel_shuffle(h=,w=)` (a regression guard so the two are never
+   silently swapped).
+4. **EVS gating** — first frame fully retained; `stable=True` tie-breaking;
+   re-derive `kept` independently in the test so a changed bound fails loudly.
+5. **Injection graph-safety** — capture a CUDA graph over a mm step, replay with
+   different embedding *values* at the same addresses, assert the output changes;
+   assert padded rows are untouched by prefilling the buffer with a sentinel.
+6. **Chunked-prefill boundary** — force a chunk boundary inside an image span,
+   assert `decoder_input` equals the unchunked result.
+7. **Prefix-cache safety** — two requests, identical prompts, *different*
+   images: assert no false cache hit (i.e. that Phase 1.4 fires).
+
+### 6.3 Oracle comparison
+
+Run vLLM with a fixed seed and dump four cut points; compare against mcore.
+
+| Cut point | Tolerance |
+| --- | --- |
+| (a) processor outputs: `pixel_values_flat`, `input_audio_features`, expanded token ids | **exact** (integers and fp32 math) |
+| (b) raw tower output before pixel-shuffle/projection | bf16 tolerance — **expect a delta if LayerScale ≠ 1** (§5.1) |
+| (c) per-item embeddings from `embed_multimodal` | bf16 tolerance |
+| (d) final `inputs_embeds` / `decoder_input` | bf16 tolerance |
+
+Getting (a) and the token counts exact is what prevents the long tail of
+shape-mismatch bugs. Everything else is a numerics conversation.
+
+---
+
+## 7. Decisions taken, and what is still open
+
+### 7.1 Settled
+
+| Decision | Resolution |
+| --- | --- |
+| **v1 scope** | Image-first. Phases 0–2 land images; video and audio follow. |
+| **Prefix caching** | Multimodal requests bypass the prefix cache in v1 (Phase 1.4b). Content-hash chaining is deferred. |
+| **Pipeline parallelism** | Assert `PP == 1` for multimodal requests. Matches vLLM, avoids the `_allocate_recv_buffer` SP-division interaction (`abstract_model_inference_wrapper.py:148-158`) and the dead PP paths in `vlm_inference_wrapper.py:50,53`. |
+| **Reference config** | Available — [`checkpoint-config.md`](checkpoint-config.md), transcribed in §1.4. Phase 2.1 is unblocked. The CI-shrunk fixtures at `vllm/tests/models/registry.py:1182-1206` are not to be used. |
+| **`video_maintain_aspect_ratio`** | Implement against `true` (the checkpoint's value), not the fixture's `false`. |
+| **Vision projector norm** | Confirmed: `mlp1` starts with `RMSNorm(5120, eps=1e-5)`. mcore's `MultimodalProjector` with `linear_fc1=ColumnParallelLinear` (`nemotron_moe_vlm.py:85-94`) has no norm, so Phase 2.3 must either swap in `TELayerNormColumnParallelLinear` or add an explicit leading `RMSNorm`. Same for the audio projector at `RMSNorm(1024, eps=1e-5)`. |
+| **Tower quantization** | Confirmed unquantized: the NVFP4 variant's 5986 `quantized_layers` entries contain nothing under `vision_model.*`, `sound_encoder.*`, `sound_projection.*`, or `mlp1.*`. Budget both towers and both projectors as bf16. |
+| **LayerScale parity** | mcore's RADIO has no LayerScale either, so vLLM parity holds for free (§5.1). Only HF-reference parity is at risk. |
+| **LM config** | `hybrid_override_pattern` transfers verbatim; `mamba_num_heads=64` must be set explicitly to override the `expand: 2` derivation (§1.4). |
+
+### 7.2 Still open
+
+**Q1 — Which pixel shuffle did the Nemotron Omni checkpoint train with?**
+`examples/mimo/.../radio_encoder.py:121` (2×2 spatial fold, matches vLLM) and
+`llava_model.py:1342-1347` (plain reshape, 1×4 strip) are genuinely different
+operations, and both are live in the tree for dynamic resolution. vLLM agrees
+with the MIMO one, so I plan to use it — but if Omni was trained through
+`LLaVAModel`, that is wrong and vLLM has a latent bug. **Who owns the Omni
+training recipe, and which path did it run?** This is now the top blocking
+question: the config cannot answer it, and a wrong choice produces plausible-
+looking but degraded output rather than a crash.
+
+**Q2 — Are the checkpoint's `ls1`/`ls2` ≈ 1.0?**
+Needs a `state_dict` key/value dump, not the config. If non-unit, vLLM *and*
+mcore are both dropping a real transform (§5.1). Determines whether an
+HF-reference mismatch at cut point (b) is expected.
+
+**Q3 — `video_pruning_rate`: follow the config or the CLI?**
+The checkpoint asks for `0.7` and the HF reference honours it; vLLM reads it
+**only** from `--video-pruning-rate`, defaulting to `None`, so out of the box
+vLLM does no EVS pruning at all. Matching vLLM's default means ignoring an
+explicit checkpoint request. My inclination is to default to the config's `0.7`
+and let a CLI flag override, which is a deliberate divergence — **confirm?**
+
+**Q4 — Image token budget: engine `max_model_len` or the HF `262144`?**
+vLLM computes the per-image patch budget from
+`max_model_len − text_prompt_length − 4`, so image *resolution* changes with the
+serving flag. The HF processor config carries a fixed `max_model_len: 16384`.
+Following vLLM makes output depend on a deployment flag; following HF pins it.
+Recommend pinning to 16384 for reproducibility, with vLLM-compatible behaviour
+behind a flag — **confirm?**
+
+**Q5 — Which `transformers` version does the CI container ship?**
+`ParakeetEncoder` needs ≥ 5.5.3, and `pyproject.toml:76,87` pins nothing. If the
+container is on 4.x, Phase 4 either becomes a dependency bump or a ~600-line
+native conformer. Related: vLLM tolerates a v4↔v5 `convolution_bias=False`
+difference where conv bias params are unregistered but may exist in the
+checkpoint (`parakeet.py:112-131`); I will need the same tolerance. Not blocking
+until Phase 4.
+
+**Q6 — Is `sound_timestamps` a real feature?**
+mcore's `LLaVAModel` threads a `sound_timestamps` argument
+(`llava_model.py:946, 1257`) with **no vLLM counterpart**. Nemotron Omni feature
+that vLLM is missing, or dead code from another model? Affects Phase 4's
+interface only.
+
+---
+
+## 8. Sequencing
+
+| Phase | Deliverable | Gate |
+| --- | --- | --- |
+| 0 | Embedding injection, synthetic buffer | Graph-safety test (6.2.5) passes; text-only perf unchanged |
+| 1 | Request payload + context scatter | Chunked-prefill test (6.2.6) and prefix-cache test (6.2.7) pass |
+| 2 | **Image-only Omni inference works** | Token-count parity (6.2.2) + oracle cut points (a)/(d) for images |
+| 3 | Video + EVS | Oracle parity for `T`-not-dividing and EVS on/off |
+| 4 | Audio | Oracle parity for multi-clip audio |
+| 5 | HF checkpoint load (config mapping per §1.4) | Real checkpoint produces sane generations |
+| 6 | Server surface + functional test recipe | `run-inference-functional-tests` green |
+
+Phase 2 is the milestone that proves the architecture. Everything after it is
+additive.
+
+---
+
+## 9. Cross-references
+
+- Inference optimization rules this design obeys (fixed addresses, no per-step
+  host sync, padding does no work, graph scope):
+  `skills/optimize-inference-siddharth/SKILL.md` and
+  `references/cuda-graphs.md`
+- Test authoring: `skills/add-inference-unit-tests`,
+  `skills/add-inference-functional-tests`
+- The resolved checkpoint config: [`checkpoint-config.md`](checkpoint-config.md)
+- Dependency / container changes (§7.2, Q5):
+  `.claude/skills/mcore-build-and-dependency/SKILL.md`
+- vLLM behavioural reference: [`vllm-reference.md`](vllm-reference.md)

--- a/docs/inference/nemotron_omni/vllm-reference.md
+++ b/docs/inference/nemotron_omni/vllm-reference.md
@@ -1,0 +1,895 @@
+# Nemotron 3 Nano/Super Omni — Multimodal Preprocessing & Encoder Design
+
+> **Purpose.** This is an implementation-oriented reference for the vLLM
+> implementation of NVIDIA Nemotron Omni (audio + video + image + text), written
+> so that it can be used to port the model to another inference backend
+> (specifically **Megatron-Core inference**). Every non-obvious behaviour is
+> traced to a file and line range in this repository so the port can be verified
+> against the source of truth.
+>
+> **Audience.** An engineer/agent that has this repository checked out and needs
+> to reproduce Nemotron Omni's input pipeline and encoders exactly (bit-for-bit
+> where practical, token-count-for-token-count always).
+>
+> Line numbers refer to the state of the tree at the time of writing. If a range
+> looks off by a few lines, search for the named symbol instead.
+
+---
+
+## 1. Model identity and registration
+
+Nemotron Omni is not a separate model class in vLLM. Three HF architecture
+strings all resolve to the same implementation class:
+
+```text
+vllm/model_executor/models/registry.py:513-515
+    "NemotronH_Nano_VL_V2":             ("nano_nemotron_vl", "NemotronH_Nano_VL_V2"),
+    "NemotronH_Nano_Omni_Reasoning_V3": ("nano_nemotron_vl", "NemotronH_Nano_VL_V2"),
+    "NemotronH_Super_Omni_Reasoning_V3":("nano_nemotron_vl", "NemotronH_Nano_VL_V2"),
+```
+
+The implementing class is `NemotronH_Nano_VL_V2`
+(`vllm/model_executor/models/nano_nemotron_vl.py:901`). "Omni" vs "VL" is decided
+purely by **whether the checkpoint config contains a `sound_config` block**; if
+it does, an audio tower is constructed (`nano_nemotron_vl.py:979-990`). There is
+no other behavioural difference keyed off the architecture name.
+
+Reference checkpoints (from `tests/models/registry.py:1182-1206`):
+
+| Architecture | Example HF id |
+| --- | --- |
+| `NemotronH_Nano_Omni_Reasoning_V3` | `nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16` |
+| `NemotronH_Super_Omni_Reasoning_V3` | (same family, larger; not available online in tests) |
+
+Interfaces implemented (`nano_nemotron_vl.py:901-905`):
+
+```python
+class NemotronH_Nano_VL_V2(
+    nn.Module, HasInnerState, IsHybrid, SupportsMultiModal, SupportsMultiModalPruning
+):
+    requires_sequential_video_encoding = True
+```
+
+Notable **absences**, which are real constraints in vLLM today:
+
+- No `SupportsPP` → **no pipeline parallelism**.
+- No `supports_encoder_tp_data = True` → **no batch-level encoder data
+  parallelism** (see §7.4).
+- No `SupportsEncoderCudaGraph` → encoder is always run eagerly (the CUDA-graph
+  manager in the runner skips it).
+- `SupportsMultiModalPruning` is declared, but `recompute_mrope_positions` is
+  **not** implemented — it is never called because Nemotron-H does not use
+  M-RoPE (the runner guards with `self.uses_mrope`,
+  `vllm/v1/worker/gpu_model_runner.py:3304`). The marker's only practical effect
+  for this model is enabling per-video sequential encoding
+  (`gpu_model_runner.py:3143-3171`).
+
+---
+
+## 2. File index (start here)
+
+| Concern | Path |
+| --- | --- |
+| Model + encoders + embedding assembly | `vllm/model_executor/models/nano_nemotron_vl.py` |
+| Host-side processor (images/video/audio → tensors + prompt text) | `vllm/transformers_utils/processors/nano_nemotron_vl.py` |
+| RADIO vision tower | `vllm/model_executor/models/radio.py` |
+| Shared ViT blocks (attention/MLP, TP layers) | `vllm/model_executor/models/intern_vit.py` |
+| Parakeet audio tower + mel front-end | `vllm/model_executor/models/parakeet.py` |
+| RADIO config synthesis | `vllm/transformers_utils/configs/radio.py` |
+| Parakeet config + extractor config | `vllm/transformers_utils/configs/parakeet.py` |
+| Nemotron-H LM config | `vllm/transformers_utils/configs/nemotron_h.py` |
+| Nemotron-H LM (Mamba2 + attention + MoE) | `vllm/model_executor/models/nemotron_h.py` |
+| EVS video token pruning | `vllm/multimodal/evs.py` |
+| ViT TP/DP mode helper | `vllm/model_executor/models/vision.py:142-159` |
+| Runtime config hooks (mamba cache dtype) | `vllm/model_executor/models/config.py:605-641, 857` |
+| Encoder execution / caching / merge | `vllm/v1/worker/gpu_model_runner.py:3123-3213, 3260-3330` |
+| Multimodal contribution guide (framework concepts) | `docs/contributing/model/multimodal.md` |
+| Encoder TP/DP documentation | `docs/configuration/optimization.md:255-275` |
+| Unit test (weight-skipping behaviour) | `tests/models/multimodal/test_nano_nemotron_vl.py` |
+
+---
+
+## 3. Config surface
+
+The HF `config.json` is a composite. vLLM reads it as follows.
+
+### 3.1 Top-level (vision/adapter-related)
+
+Consumed in `nano_nemotron_vl.py:923-1012` and
+`processors/nano_nemotron_vl.py:581-623`:
+
+| Field | Use |
+| --- | --- |
+| `force_image_size` | Base tile size in pixels (`image_size`) |
+| `patch_size` | ViT patch size (pixels) |
+| `downsample_ratio` | Pixel-shuffle factor; must be `0.5` (asserted for the dynamic tiler, `processors/...:277-283`) |
+| `use_thumbnail` | Whether the fixed-tile path appends a thumbnail tile |
+| `norm_mean`, `norm_std` | RGB normalization, applied **in the processor**, not in the model |
+| `vit_hidden_size` | RADIO hidden size, used to size `mlp1` |
+| `projector_hidden_size` | `mlp1` intermediate size |
+| `template`, `image_tag_type`, `ps_version` | Prompt/format metadata; `ps_version != "v1"` is the supported layout |
+| `vision_config` | RADIO settings (see below) |
+| `text_config` | Nemotron-H LM config |
+| `sound_config` | Parakeet audio settings; **presence enables audio** |
+
+### 3.2 `vision_config` → `RadioConfig`
+
+Synthesized in `nano_nemotron_vl.py:1570-1600`; the config class is
+`vllm/transformers_utils/configs/radio.py:23-110`. Important:
+
+- `vision_config.args["model"]` is a timm name; hidden size / depth / heads /
+  FFN size come from a **hard-coded table**
+  (`configs/radio.py:12-17`). Nemotron Omni uses `vit_huge_patch16_224` →
+  `(hidden=1280, layers=32, heads=16, ffn=5120)`.
+- `preferred_resolution[0]` → `image_size` (default 224 if absent).
+- `video_temporal_patch_size` (call it **T**) and `separate_video_embedder` are
+  read from the *top level of* `vision_config`, not from `args`
+  (`nano_nemotron_vl.py:1580-1587`).
+- `vision_config.args` also carries `min_num_patches` / `max_num_patches`, and
+  **their presence is the switch for dynamic-resolution images**
+  (`processors/nano_nemotron_vl.py:621-623`). Nemotron Omni checkpoints set
+  them, so Omni uses the dynamic-resolution image path.
+- `cpe_max_size` controls the size of the learned position-embedding grid that
+  gets interpolated/windowed for arbitrary input sizes.
+- `teachers` (RADIO distillation teachers) only determines the **number of CLS
+  tokens** (`num_cls_tokens = len(set(t["name"] for t in teachers))` when
+  `cls_token_per_teacher`) and which summaries are selected. Summaries are
+  computed but **discarded** by this model.
+
+### 3.3 `sound_config` → `ParakeetConfig` / `ExtractorConfig`
+
+`vllm/transformers_utils/configs/parakeet.py`:
+
+- `ParakeetConfig.from_hf_config` (lines 25-37) forwards the whole sound config
+  into HF's `ParakeetEncoderConfig`, forcing `scale_input=False`,
+  `attention_bias=False`, and `max_position_embeddings = max_model_len + 1`,
+  and attaching `llm_hidden_size`.
+- `ExtractorConfig.from_hf_config` (lines 57-72) pulls the mel front-end
+  parameters: `num_mel_bins → feature_size`, `sampling_rate`,
+  `subsampling_factor`, `subsampling_conv_kernel_size`,
+  `subsampling_conv_stride`, plus optional overrides for `hop_length` (160),
+  `win_length` (400), `preemphasis` (0.97), `n_fft` (512), `padding_value` (0).
+  Clip windowing defaults: `clip_duration_s = 30`, `clip_min_duration_s = 0.1`.
+- Projection sizing: `projection_hidden_size`, `projection_bias`,
+  `projection_eps` (default 1e-5).
+
+### 3.4 Runtime config hook (Mamba state cache dtype)
+
+`vllm/model_executor/models/config.py:635-641` defines `NemotronHNanoVLV2Config`
+which forces the **SSM state cache to the dtype declared in `text_config`, or
+`float32` by default** (`config.py:605-625`). It is registered only for the
+`"NemotronH_Nano_VL_V2"` architecture string (`config.py:857`), and
+`MODELS_CONFIG_MAP` is keyed by architecture
+(`vllm/config/vllm.py:2040-2050`), so **the Omni architecture names do not get
+this hook**. Port implication: do not infer the SSM state dtype from vLLM's
+runtime behaviour on Omni checkpoints — **use fp32 Mamba SSM state**, which is
+the documented safe default for Nemotron-H ("Only `float32` is known to have no
+accuracy issues by default", `config.py:606-607`).
+
+---
+
+## 4. Two-stage architecture
+
+```
+                 HOST (CPU, per request, cacheable)                    DEVICE (per forward)
+ ┌───────────────────────────────────────────────────────┐   ┌──────────────────────────────────────┐
+ │ NanoNemotronVLProcessor.__call__                      │   │ NemotronH_Nano_VL_V2.embed_multimodal│
+ │   images → tiles/patch-vectors + norm                 │   │   images → RADIO → pixel-shuffle→mlp1│
+ │   video  → resized frames + frame metadata            │   │   video  → RADIO(tubelets) → EVS →   │
+ │   audio  → log-mel features + attention mask          │──►│            hybrid text+vision embeds │
+ │   text   → prompt with expanded placeholder spans     │   │   audio  → Parakeet → projection     │
+ │ + token-count bookkeeping (must match encoder output) │   │                                      │
+ └───────────────────────────────────────────────────────┘   └──────────────────┬───────────────────┘
+                                                                               │  per-item tensors
+                                                            ┌──────────────────▼───────────────────┐
+                                                            │ scatter into inputs_embeds at         │
+                                                            │ placeholder positions, then           │
+                                                            │ Nemotron-H LM forward (text-only)     │
+                                                            └───────────────────────────────────────┘
+```
+
+The **contract between the two stages** is the token count: the host stage
+expands each media placeholder into exactly as many token ids as the device
+stage will produce embedding rows for. Any mismatch is a hard failure. This is
+the single most important thing to get right in a port (§6).
+
+Encoder outputs are cached per media item by content hash
+(`gpu_model_runner.py:3203-3211`), so the encoder runs once per unique item even
+across requests/chunks.
+
+---
+
+## 5. Host stage: preprocessing
+
+Entry point: `NanoNemotronVLProcessor.__call__`
+(`processors/nano_nemotron_vl.py:1009-1074`). Order matters: images, then video,
+then audio, then tokenize (lines 1031-1047). Each `_preprocess_*` both returns
+tensors **and rewrites the prompt text**, expanding placeholders in place.
+
+Special tokens (`processors/nano_nemotron_vl.py:36-41`):
+
+```python
+IMG_START = "<img>";        IMG_END = "</img>";        IMG_CONTEXT = "<image>"
+AUDIO_START = "<so_start>"; AUDIO_END = "<so_end>";    AUDIO_CONTEXT = "<so_embedding>"
+```
+
+Video uses `<video>` as the user-facing placeholder and `IMG_CONTEXT` as the
+per-token embedding placeholder (there is no dedicated video token;
+`NanoNemotronVLProcessingInfo.get_video_token` returns `IMG_CONTEXT`,
+`nano_nemotron_vl.py:223-224`).
+
+### 5.1 Images — fixed-tile path (InternVL-style)
+
+Used when `vision_config.args` has **no** `min_num_patches`.
+`dynamic_preprocess` (`processors/nano_nemotron_vl.py:93-142`):
+
+1. Choose a tile grid from InternVL target ratios for `max_num_tiles`
+   (default `DEFAULT_NUM_TILES = 12`, line 45) via
+   `get_internvl_target_ratios` / `calculate_internvl_targets` (imported from
+   `processors/internvl.py`).
+2. Bicubic resize (antialias, `align_corners=False`) to `(target_h, target_w)`,
+   fused with `x/255` and `(x-mean)/std` in one compiled op
+   (`_bicubic_resize_and_normalize`, lines 59-82; `@torch.compile(dynamic=True)`).
+3. Cut into `image_size × image_size` tiles by reshape/permute (lines 124-130).
+4. If `use_thumbnail` and more than one tile, append a whole-image thumbnail
+   resized to `image_size²` (lines 132-140).
+
+Output: `pixel_values_flat` `[sum_tiles, 3, image_size, image_size]` and
+`image_num_patches` (tiles per image, including thumbnail)
+(`processors/...:702-716`).
+
+Tokens per image: `num_patches * num_image_token`, where
+
+```
+num_image_token = (image_size / patch_size)² * downsample_ratio²
+                 (processors/nano_nemotron_vl.py:600-602)
+```
+
+i.e. 256 for `image_size=512, patch_size=16, downsample_ratio=0.5`.
+
+### 5.2 Images — dynamic-resolution path (what Omni actually uses)
+
+Class `DynamicResolutionImageTiler` (`processors/nano_nemotron_vl.py:251-569`).
+Each image becomes **one** variable-size "tile" whose patch grid is budgeted
+against the remaining context length:
+
+1. Token budget: `max_model_len - text_prompt_length - 4`
+   (`max_num_tokens_available`, lines 329-330). `text_prompt_length` is the
+   token length of the prompt with `<image>` markers removed
+   (`processors/...:686-689`).
+2. `compute_params` (lines 463-548) converts the post-shuffle token budget into
+   a patch budget (`×4` because pixel-shuffle merges 2×2 patches → 1 token),
+   clips per-image budget to `[min_num_patches, max_num_patches]`, then runs up
+   to 10 rounds of proportional scale-down until the total fits.
+3. `process_media` (lines 376-461) computes the target patch grid from the
+   original aspect ratio (`round(dim/patch + 0.5)`, scaled by
+   `factor = min(sqrt(budget/patches), 1.0)` — i.e. **never upscales**), bumps
+   it up to `min_num_patches` if needed, and rounds each side to a multiple of 2
+   (pixel-shuffle divisor), preferring to round **up** if it still fits, else
+   down (never below 2).
+4. `apply_params` (lines 357-374) resizes + normalizes to
+   `(grid_h*patch, grid_w*patch)`.
+5. `stack` (lines 550-569) **pre-patchifies on the host**: each image
+   `[3, H, W]` is rearranged to `[(H/P)*(W/P), 3*P*P]` and all images are
+   concatenated into one sequence, then unsqueezed to `[1, total_patches, 3*P*P]`.
+
+Consequences for a port:
+
+- In this path the model receives **flattened patch vectors**, not pixels; the
+  ViT's patch embedder is a plain `Linear(3*P*P → hidden)` applied to them
+  (`radio.py:496-509`, used at `radio.py:201-206`).
+- Per-image token count is `(grid_h*grid_w)/4` (`_get_num_embeddings`, lines
+  285-288) and is carried explicitly as `num_tokens_per_image`.
+- `imgs_sizes` (per-image `(H, W)` in pixels) is carried so the tower can
+  rebuild per-image boundaries for position embeddings, CLS insertion, and
+  varlen attention.
+
+### 5.3 Video
+
+`_preprocess_video` (`processors/nano_nemotron_vl.py:883-979`).
+
+**Frame resize.** `video_to_pixel_values` (lines 217-248) resizes every frame to
+a common target derived from `vision_config.video_target_num_patches` (or
+`video_target_img_size`, converted at lines 798-811). Two modes
+(`get_video_target_size_and_feature_size`, lines 183-214):
+
+- `video_maintain_aspect_ratio=True` → distribute the patch-area budget by
+  aspect ratio, snap both sides to multiples of 2
+  (`_compute_aspect_preserving_size`, lines 145-180). The comment notes this
+  mirrors Megatron-LM's `image_processing.py` — **use the Megatron original as
+  the cross-check when porting**.
+- else → square grid, `side = floor(sqrt(budget)/2)*2`.
+
+`feature_size` (tokens per frame *before* temporal grouping) is
+`(target_h/patch * ds) * (target_w/patch * ds)`.
+
+**Temporal grouping.** With `T = video_temporal_patch_size > 1`, frames are
+grouped into tubelets; the number of token-bearing units is
+`num_tubelets = ceil(num_frames / T)` (line 942). Tokens per tubelet equals
+tokens per frame (the temporal dimension is folded into the embedder's input
+dimension, not into the token count).
+
+**Metadata carried to the device stage** (lines 919-924):
+`pixel_values_flat_video` `[sum_frames, 3, H, W]`, `video_num_patches`
+(frames per video), `frames_indices` (original frame indices, one per frame),
+`frame_duration_ms`.
+
+`frame_duration_ms = int(1000.0 / fps)` — an **integer** on purpose
+(lines 899-907): timestamps are recomputed inside the model in bf16 context, and
+float fps caused timestamp strings to differ between host and device, changing
+the tokenized separator length. Reproduce this integer rounding exactly.
+
+**Frame separator text.** `get_video_repl`
+(`processors/nano_nemotron_vl.py:1095-1201`) builds the replacement token ids:
+
+- `T == 1`, timestamps known:
+  `"\n"(if i>0) + f"Frame {i+1} sampled at {ts:.2f} seconds: "`
+- `T > 1`: one separator per tubelet, joining the frames in the group with
+  `" and "`, first frame capitalized `Frame`, subsequent lowercase `frame`,
+  then `": "`, with a leading `"\n"` for groups after the first, e.g.
+  `"\nFrame 3 sampled at 1.00 seconds and frame 4 sampled at 1.50 seconds: "`
+- no timestamps: `"\n"(if i>0) + f"Frame {i+1}: "`
+
+Then, per tubelet: `separator_tokens + <img> + <image>*tokens + </img>`
+(lines 1194-1199). Separators are batch-tokenized and each component is
+tokenized **independently** so that token counts never change due to merging
+across boundaries — this is a correctness requirement, not an optimization.
+
+`ts = frame_index * frame_duration_ms / 1000.0` (lines 48-56); note the index
+used is the **original** frame index from `frames_indices`, so timestamps
+survive frame subsampling.
+
+**EVS budget (host side).** If `--video-pruning-rate q > 0`
+(`vllm/config/multimodal.py:191-195`), the *total* token count for the video is
+`compute_retained_tokens_count(tokens_per_frame, num_tubelets, q)`
+(`vllm/multimodal/evs.py:16-35`):
+
+```
+total  = tokens_per_frame * num_frames
+kept   = max(tokens_per_frame, int(total * (1 - q)))   # first frame always survives
+```
+
+The host then assigns *all* kept tokens to the first tubelet and 0 to the rest
+(`processors/...:944-957`) — only the total matters, because the device stage
+rebuilds the actual distribution (§6.3).
+
+### 5.4 Audio
+
+Front-end: `ParakeetExtractor` (`vllm/model_executor/models/parakeet.py:138-335`),
+instantiated by the processor when `sound_config` exists
+(`processors/nano_nemotron_vl.py:813-816`) and invoked at line 1006. Note that
+this class lives in the *model* file but runs on the **host** (default
+`device="cpu"`, line 290) — it is preprocessing, not part of the model graph.
+
+Pipeline (`__call__`, lines 286-330):
+
+1. Force mono by channel mean (warns) — lines 297-304.
+2. **Clip splitting** (`_clip_sizes`, lines 253-259; `split_audio_into_clips`,
+   271-284): full 30 s clips (`clip_duration_s * sampling_rate` samples) plus a
+   remainder clip padded up to at least `clip_min_duration_s = 0.1 s`. Total
+   audio is zero-padded to the sum of clip sizes. Clips become the batch
+   dimension of the encoder.
+3. Right-pad all clips to the batch max with `padding_value` (`_pad_raw_speech`,
+   lines 238-251).
+4. **Pre-emphasis** with per-clip valid-length masking: `x[t] - 0.97*x[t-1]`,
+   first sample untouched, positions beyond the valid length zeroed
+   (lines 198-214).
+5. **STFT** `n_fft=512, hop=160, win=400`, Hann window `periodic=False`,
+   `pad_mode="constant"` (lines 170-187).
+6. **Mel filterbank** `mel_filter_bank(..., norm="slaney", mel_scale="slaney")`
+   over `n_fft//2+1` bins → `num_mel_bins`; power spectrum
+   (`real² + imag²`), then `log(mel + 2^-24)` and transpose to
+   `[batch, time, mel]` (lines 154-196).
+7. **Per-clip normalization** over valid frames only, using
+   `features_length = (samples + n_fft//2*2 - n_fft) // hop_length`, with
+   sample variance (`/(n-1)`) and `(x-mean)/(std+1e-5)`, then re-masked
+   (lines 216-236).
+
+Outputs: `input_audio_features [num_clips, time, mel]`,
+`feature_attention_mask [num_clips, time]`, `audio_num_clips` (clips per audio
+item).
+
+**Token count** (`audio_token_count`, lines 261-269): for each clip,
+`num_frames = clip_samples // hop_length`, then HF's
+`ParakeetEncoder._get_subsampling_output_length(num_frames)`; sum over clips,
+floored at 1. Replacement text:
+`<so_start> + <so_embedding> * n + <so_end>` (lines 1086-1093).
+
+### 5.5 Token / placeholder accounting contract
+
+This table is the porting contract. `is_embed` marks which positions of the
+expanded span receive encoder embeddings.
+
+| Modality | Expanded span | Token count | `is_embed` |
+| --- | --- | --- | --- |
+| Image | `<img>` + `<image>`×F + `</img>` | F = `num_patches × num_image_token` (fixed-tile) or `grid_h*grid_w/4` (dynamic) | only `<image>` positions (`select_text`, `processors/...:1076-1084`) |
+| Audio | `<so_start>` + `<so_embedding>`×N + `<so_end>` | N = Σ subsampled clip lengths, ≥1 | only `<so_embedding>` positions (`processors/...:1086-1093`) |
+| Video | per tubelet: separator text + `<img>` + `<image>`×k + `</img>` | Σk = frames×tokens_per_frame, or EVS `kept` | **all positions in the span** (`PromptUpdateDetails.from_seq`, `processors/...:1201`) |
+
+The video case is the subtle one. `from_seq` leaves `is_embed=None`, which the
+framework interprets as "assign embeddings to every position"
+(`vllm/multimodal/processing/processor.py:212-226`). Therefore the model must
+emit embeddings for the separator and marker tokens too — it does so by
+embedding those token ids through the LM embedding table and interleaving
+(§6.4). A port that instead keeps text tokens as text must make sure the same
+final `inputs_embeds` results; the vLLM behaviour is equivalent as long as the
+same token ids are embedded with the same embedding table.
+
+Duplicated logic warning: video/audio/image replacement counts are computed in
+**two** places — inside the HF-processor emulation
+(`processors/...:944-977`, `981-1007`) and again in the framework-level prompt
+update callbacks (`nano_nemotron_vl.py:432-596`). Both must agree.
+
+### 5.6 `use_audio_in_video`
+
+`NanoNemotronVLMultiModalProcessor.apply`
+(`nano_nemotron_vl.py:658-760`) implements "take the audio track from the
+video": it either consumes audio items already supplied upstream, or extracts
+them from `original_video_bytes` with `load_audio_pyav`
+(`_extract_audio_from_videos`, lines 598-656), then injects one
+`<so_embedding>` marker immediately after each `<video>` marker **that actually
+had an audio stream** (lines 714-726). Videos without audio are skipped, so
+video↔audio pairing is preserved. Requires the video loader to keep raw bytes.
+
+### 5.7 Memory profiling / dummy inputs
+
+`NanoNemotronVLDummyInputsBuilder` (`nano_nemotron_vl.py:763-893`) synthesizes
+worst-case media for startup profiling: largest image size, `num_frames` from
+`--media-io-kwargs`, and dummy audio length
+`min(10 min, ParakeetExtractor.audio_length(sound_config, tokens_per_audio))`
+(lines 874-889; `MAX_AUDIO_LEN_S` at line 98). `ParakeetExtractor.audio_length`
+(`parakeet.py:332-335`) inverts the token count:
+`tokens * subsampling_factor * hop_length`. A Megatron port needs an equivalent
+upper-bound estimator to size activation memory, since the encoders' activation
+peak (especially long video) dominates.
+
+---
+
+## 6. Device stage: encoders and embedding assembly
+
+Dispatch: `embed_multimodal` (`nano_nemotron_vl.py:1430-1462`) iterates
+modalities in `kwargs` insertion order and concatenates per-item tensors.
+Parsing/validation of the kwargs into typed schemas happens in
+`_parse_and_validate_multimodal_inputs` (lines 1403-1428); the schemas
+themselves (with documented dimensions) are at lines 101-196 and are a compact
+spec of the encoder input formats.
+
+The runner calls `embed_multimodal` **once per modality group per step**
+(`gpu_model_runner.py:3126-3199`), with the exception that video items are
+encoded **one at a time** when EVS or `requires_sequential_video_encoding` is
+set (lines 3143-3171) — a memory-safety hack because video batching isn't
+supported for the dynamic-resolution/conv3d path yet.
+
+### 6.1 RADIO vision tower
+
+Construction: `get_vit_model_from_radio_config` (`nano_nemotron_vl.py:1570-1600`)
+builds `RadioModel` (`radio.py:695-742`) → `RadioInternVisionModel`
+(`radio.py:571-692`) → `RadioVisionEncoder` (32 × `RadioVisionEncoderLayer`).
+Note it is constructed **without `quant_config`** (line 1600) — the vision tower
+is always unquantized (§7.5) — and cast to the LM dtype
+(`nano_nemotron_vl.py:955-957`).
+
+Forward path for a batch of tiles/frames (`radio.py:654-692`):
+
+1. **Patchify + embed.**
+   - Fixed-size input: `Im2Patches` rearranges `[N,3,H,W]` →
+     `[N, (H/P)(W/P), 3P²]` (`radio.py:472-493`), then
+     `embedder: Linear(3P² → hidden)` (`ViTPatchLinear`, lines 496-509).
+   - Dynamic-resolution input: patches arrive pre-flattened from the host, so
+     only `embedder` runs (`radio.py:201-206`).
+   - Video with `T > 1`: `forward_video` (`radio.py:216-263`) pads the frame
+     count up to a multiple of T **by repeating the last frame**, groups
+     `(tubelets frames) spatial feat → tubelets spatial (frames feat)`, and
+     applies a **separate** `video_embedder: Linear(3·T·P² → hidden)`
+     (constructed at `radio.py:166-178`; `separate_video_embedder=False` is
+     explicitly unsupported). The einops grouping order is stated to follow
+     Megatron training — match it exactly.
+2. **Position embeddings.** Learned grid `pos_embed [1, num_rows*num_cols, hidden]`
+   sized by `cpe_max_size`, then window-selected and/or bilinearly interpolated
+   to the actual patch grid (`_get_pos_embeddings`, `radio.py:434-469`). In CPE
+   mode it first interpolates to a square `max(input_dims)` grid, then windows.
+   Dynamic resolution applies this per image inside the packed sequence
+   (`apply_pos_enc_dynamic`, lines 265-293).
+3. **CLS + register tokens** prepended per image (`ClsToken`, `radio.py:60-106`;
+   packed variant `cls_token_dynamic`, lines 295-312). Count:
+   `num_cls_tokens` (from unique teachers) + `num_registers`
+   (`register_multiple - num_tokens % register_multiple`).
+4. **32 transformer blocks** (`radio.py:537-553`, base at
+   `intern_vit.py:292-349`): pre-norm residual with per-branch layer scale,
+   `x = x + attn(norm1(x))*ls1`, `x = x + mlp(norm2(x))*ls2`. MLP is
+   `Linear → act (gelu) → Linear` (`intern_vit.py:250-284`). Optional QK-norm
+   (`RadioConfig.qk_normalization`, default False).
+   **`ls1`/`ls2` are initialized to `initializer_factor * ones` (= 1.0) and the
+   checkpoint's layer-scale tensors are deliberately skipped when loading**
+   (`radio.py:780-782`), i.e. layer scale is identity in vLLM. Verify against
+   the checkpoint before replicating; if the checkpoint has meaningful
+   layerscale, vLLM would be ignoring it.
+5. **Varlen attention.** When several differently-sized images (or several
+   tubelets) share one packed sequence, `MaskMetadata(cu_seqlens, max_seqlen)`
+   is built (`radio.py:627-652`) and threaded into the attention op so items
+   don't attend across boundaries (`radio.py:518-534`). `max_seqlen` is kept on
+   **CPU** to avoid a device sync. For the video path, all tubelets have equal
+   length and the batch is flattened to `[1, total, hidden]` then unflattened
+   after the encoder (`radio.py:666-690`).
+6. **Strip CLS/registers, split per image.** `_extract_final`
+   (`radio.py:793-822`) drops the first `num_skip` tokens of each item and
+   returns `(summary, features)`. The model uses only `features`
+   (`nano_nemotron_vl.py:1056`, `1086-1088`).
+
+### 6.2 Pixel shuffle and projector (`mlp1`)
+
+`extract_feature` (`nano_nemotron_vl.py:1062-1103`):
+
+- Micro-batches at most `128 - (128 % T)` frames per ViT call to cap activation
+  memory (lines 1067-1077). Chunk boundaries must not split a tubelet.
+- Casts ViT output to **bf16** unconditionally (line 1089).
+- `pixel_shuffle` (lines 1014-1031): reshape to `[N, H/P, W/P, C]`, fold each
+  2×2 spatial neighbourhood into the channel dim → `[N, h/2, w/2, 4C]`. The
+  `ps_version == "v1"` branch exists only to warn about a transposed legacy
+  layout; the supported path permutes `(0,1,3,2,4,5)`.
+- Dynamic resolution variant `pixel_shuffle_dynamic_res` (lines 1033-1050)
+  splits the packed sequence by per-image patch counts first.
+- `mlp1` (constructed at lines 964-978): `RMSNorm(4·vit_hidden, eps=1e-5) →
+  Linear(4·vit_hidden → projector_hidden, no bias) → ReLU² → Linear(projector_hidden
+  → llm_hidden, no bias)`. `ReLUSquaredActivation` = `relu(x)²`.
+
+Per-image splitting into a tuple of tensors: `_process_image_input`
+(lines 1146-1163, split by `num_patches * feature_size`) and
+`_process_image_input_dynamic` (lines 1132-1144, split by
+`num_tokens_per_image`).
+
+### 6.3 EVS (Efficient Video Sampling) pruning
+
+`compute_retention_mask` (`vllm/multimodal/evs.py:38-92`), called from
+`_process_video_input` (`nano_nemotron_vl.py:1198-1215`):
+
+1. Reshape embeddings to `[T_units, rows, cols, hidden]` where
+   `rows = frame_h*ds/patch`, `cols = frame_w*ds/patch` (post-shuffle grid,
+   `nano_nemotron_vl.py:1179-1184`), `spatial_merge_size=1`.
+2. Dissimilarity per token = `1 - cosine_similarity(frame_t, frame_{t-1})`.
+3. Frame 0 gets sentinel dissimilarity `255` so it is always fully retained.
+4. `argsort(descending=True, stable=True)` over the flattened dissimilarity;
+   keep the top `compute_retained_tokens_count(...)` indices; build a boolean
+   mask.
+5. The mask is applied, and the **actual retained tokens per frame** is
+   `mask.reshape(T,rows,cols).sum((1,2))` (`nano_nemotron_vl.py:1210-1214`).
+
+The stable sort and the `255` sentinel are load-bearing for reproducibility.
+Note the pruning is applied **after** the projector, on LM-dimension embeddings.
+
+### 6.4 Video embedding assembly (hybrid text + vision)
+
+`_create_final_video_embeddings` (`nano_nemotron_vl.py:1287-1342`):
+
+1. Re-run `NanoNemotronVLProcessor.get_video_repl` **on device-side counts**,
+   with the real per-frame retained counts, pre-tokenized marker ids, and the
+   same timestamps. This yields the exact token-id sequence for the video span.
+2. `is_video_embed = isin(repl_token_ids, img_context_token_ids)`.
+3. `text_embeddings = LM.embed_input_ids(repl_token_ids)` — the separator and
+   `<img>`/`</img>` tokens are embedded with the LM embedding table.
+4. `_merge_multimodal_embeddings` scatters the vision rows into the
+   `is_video_embed` positions.
+
+Result: one dense tensor per video covering the entire span, matching the token
+count allocated on the host (§5.5). Because host and device compute the span
+independently, the tokenizer, timestamp formatting, and integer
+`frame_duration_ms` must be identical on both sides.
+
+For the temporal path, per-video extraction happens in
+`_extract_video_embeddings_temporal` (lines 1232-1254) — one `extract_feature`
+call per video with `num_frames=nf`, which selects the conv3d/tubelet route and
+the no-mask flash-attention path.
+
+### 6.5 Audio encoder
+
+`_process_audio_input` (`nano_nemotron_vl.py:1256-1285`):
+
+1. Move features to the tower's device, cast to `llm_dtype`.
+2. `ProjectedParakeet.forward` (`parakeet.py:66-75`): HF `ParakeetEncoder`
+   (Conformer: subsampling conv front-end + conformer blocks) → cast to bf16 →
+   `ParakeetProjection` = `RMSNorm → Linear → ReLU² → Linear(→ llm_hidden)`
+   (`parakeet.py:27-45`).
+3. Trim padding: valid output length per clip via
+   `encoder._get_subsampling_output_length(mask.sum(dim=1))`, then slice
+   `sound_embeds[clip, :valid_len]`.
+4. Concatenate the clips belonging to the same audio item
+   (`audio_num_clips`) into one tensor per item.
+
+Step 3/4 is exactly the inverse of the host-side clip splitting, and its result
+must equal `audio_token_count` from §5.4.
+
+### 6.6 Merging into `inputs_embeds` and the LM
+
+The generic framework path applies:
+`SupportsMultiModal.get_input_embeddings` (`interfaces.py:386-415`) embeds text
+ids then calls `_merge_multimodal_embeddings` with the `is_multimodal` mask
+built from placeholder ranges (`gpu_model_runner.py:3260-3330`). The model's own
+`forward` (`nano_nemotron_vl.py:1464-1483`) is then a pure pass-through to the
+Nemotron-H LM with `inputs_embeds`; there is no cross-attention and no
+vision-specific rope.
+
+LM side (for context): `NemotronHForCausalLM`
+(`vllm/model_executor/models/nemotron_h.py`) is a hybrid Mamba2 + attention
+stack whose layer order comes from `hybrid_override_pattern` in `text_config`,
+with MoE layers (`NemotronHMoE`, `nemotron_h.py:126-236`). Mamba state shapes
+and dtypes are delegated from the multimodal wrapper
+(`nano_nemotron_vl.py:1612-1626`).
+
+---
+
+## 7. Parallelism, replication, and "frozen"-ness
+
+### 7.1 Summary table
+
+| Component | Module / file | Under TP=N | Mechanism |
+| --- | --- | --- | --- |
+| RADIO attention (QKV, out-proj) | `intern_vit.py:186-216` via `radio.py:518` | **Sharded** (head-parallel) | `QKVParallelLinear` + `RowParallelLinear` (all-reduce at out-proj) |
+| RADIO MLP (fc1/fc2) | `intern_vit.py:250-284` | **Sharded** | `ColumnParallelLinear` + `RowParallelLinear` |
+| RADIO patch embedder / pos-embed / CLS / registers / layer norms | `radio.py:109-509` | Replicated | plain `nn.Linear` / `nn.Parameter` |
+| Vision projector `mlp1` | `nano_nemotron_vl.py:964-978` | Replicated | plain `nn.Linear` + `RMSNorm` |
+| Parakeet audio encoder | `parakeet.py:61-62` (HF module) | Replicated | plain HF `nn.Linear`/conv |
+| Parakeet projection | `parakeet.py:27-45` | Replicated | plain `nn.Linear` |
+| Nemotron-H LM (attention, Mamba2, dense MLP) | `nemotron_h.py` | Sharded (TP) | vLLM parallel layers |
+| Nemotron-H MoE experts | `nemotron_h.py:212-236` | Sharded (TP and/or **EP**) | `FusedMoE`, `enable_eplb` |
+
+Activation-wise, **all TP ranks execute the whole encoder graph on the same
+inputs**; TP splits weights and reduces partial results, it does not split the
+media batch.
+
+### 7.2 How the ViT TP decision is made
+
+`InternParallelAttention.__init__` (`intern_vit.py:169-183`):
+
+```python
+use_data_parallel = is_vit_use_data_parallel()
+tp_size = 1 if use_data_parallel else get_tensor_model_parallel_world_size()
+use_data_parallel = use_data_parallel or (num_heads + num_dummy_heads) % tp_size != 0
+self.tp_size = 1 if use_data_parallel else tp_size
+```
+
+and the linears receive `disable_tp=use_data_parallel`
+(`intern_vit.py:193, 215, 268, 276`). `is_vit_use_data_parallel`
+(`vision.py:142-159`) returns True when `mm_encoder_tp_mode == "data"`.
+
+Practical consequence for Nemotron Omni: RADIO `vit_huge` has **16 heads**, so
+TP ∈ {1,2,4,8,16} shards cleanly; any TP size that does not divide 16 silently
+falls back to a fully replicated vision encoder (with a warning).
+
+If QK-norm were enabled, `_apply_qk_norm` (`intern_vit.py:225-235`) adds an
+all-gather + re-split around the norms; with the default
+`qk_normalization=False` this does not occur.
+
+### 7.3 Communication points per ViT block (TP > 1)
+
+1. `qkv` — column-parallel, no comm.
+2. attention — local heads only.
+3. `proj` — row-parallel → **all-reduce**.
+4. `fc1` — column-parallel, no comm.
+5. `fc2` — row-parallel → **all-reduce**.
+
+So 2 all-reduces per block × 32 blocks. Everything after the tower
+(pixel-shuffle, `mlp1`, EVS, embedding assembly) is replicated dense compute on
+identical inputs, hence identical outputs on all ranks — no comm needed.
+
+### 7.4 Encoder data parallelism is *not* available
+
+Batch-level encoder DP (each rank encodes a different subset of items with
+replicated weights) requires the model to opt in with
+`supports_encoder_tp_data = True` (`interfaces.py:119-123`,
+`docs/configuration/optimization.md:255-275`). `NemotronH_Nano_VL_V2` does not,
+so `--mm-encoder-tp-mode data` is downgraded with a warning
+(`vllm/config/model.py:705-714`). A Megatron-Core port is free to shard the
+media batch across ranks instead; nothing in the math forbids it, and the
+replicated audio tower in particular would benefit.
+
+### 7.5 Quantization
+
+`get_vit_model_from_radio_config` (`nano_nemotron_vl.py:1570-1600`) never passes
+`quant_config` to `RadioModel`, and `ProjectedParakeet` builds raw HF modules.
+Therefore, for FP8 / NVFP4 Nemotron Omni checkpoints, **only the language model
+is quantized; both encoders and both projectors run in the LM's bf16 dtype**.
+Plan the port's memory budget accordingly, and don't attempt to load
+quantization scales for tower weights.
+
+### 7.6 Expert parallelism
+
+EP (and EPLB) applies exclusively to `FusedMoE` inside the Nemotron-H LM
+(`nemotron_h.py:135-236`: `get_ep_group()`, `enable_eplb`,
+`num_redundant_experts`, `is_sequence_parallel`). Neither encoder contains MoE
+layers, so `--enable-expert-parallel` has no effect on media encoding.
+
+### 7.7 "Frozen"? — inference-only semantics
+
+- vLLM is inference-only: no autograd, no optimizer, `torch.inference_mode` at
+  the worker level. Encoder weights are loaded once and never updated. In the
+  training sense, everything is frozen.
+- Training-only code paths are inert: e.g. `pos_dropout` in the patch generator
+  is gated on `self.training` (`radio.py:398-405`) and never fires.
+- Some tensors are **buffers, not parameters**: `summary_idxs`
+  (`radio.py:720-727`, skipped at load), the mel filterbank and Hann window
+  (`@cache`d in `ParakeetExtractor`, `parakeet.py:149-168`), and the Parakeet
+  feature-extractor buffers, which are explicitly **not** loaded into the model
+  because the host-side extractor owns that computation
+  (`parakeet.py:88-90`).
+- LoRA: `get_mm_mapping` (`nano_nemotron_vl.py:1485-1493`) declares
+  `language_model` / connector (`mlp1`, `sound_encoder.projection`) /
+  tower (`vision_model`, `sound_encoder.encoder`) groups, which is how adapters
+  are scoped. Towers are not LoRA targets by default.
+
+### 7.8 Conditional construction (skipping towers)
+
+`_mark_language_model` / `_mark_tower_model`
+(`interfaces.py:221-298`) are context managers used in `__init__`
+(`nano_nemotron_vl.py:945-990`) to tag submodules. Effects:
+
+- All modalities limited to 0 (`--limit-mm-per-prompt`) → towers are not
+  materialized, and `load_weights` skips their tensors
+  (`nano_nemotron_vl.py:1501-1568`; unit-tested in
+  `tests/models/multimodal/test_nano_nemotron_vl.py`).
+- `--mm-encoder-only` → the LM is skipped (disaggregated encoder serving).
+
+A port should preserve the ability to build tower-only or LM-only instances if
+it wants encoder disaggregation.
+
+---
+
+## 8. Weight loading and checkpoint mapping
+
+`NemotronH_Nano_VL_V2.load_weights` (`nano_nemotron_vl.py:1501-1568`) plus
+`WeightsMapper` (lines 907-911). Checkpoint → runtime mapping:
+
+| Checkpoint prefix | Destination | Notes |
+| --- | --- | --- |
+| `language_model.backbone.*` | `language_model.model.*` | via `hf_to_vllm_mapper`; then the leading component is stripped before handing to `NemotronHForCausalLM.load_weights` (line 1535) |
+| `mlp1.*` | `mlp1.*` | loaded directly with `default_weight_loader` (lines 1561-1565) |
+| `vision_model.radio_model.*` | RADIO | prefix `vision_model.` stripped (line 1545), then remapped in `RadioModel.load_weights` |
+| `…radio_model.model.blocks.{i}.*` | `model.encoder.layers.{i}.*` | `radio.py:773-783` |
+| `…radio_model.model.patch_generator.*` | `model.patch_generator.*` | `radio.py:769-770` |
+| `…blocks.{i}.ls1/ls2` | **skipped** | `radio.py:780-782` — layer scale stays at 1.0 |
+| `…radio_model.input_conditioner.*` | **skipped** | normalization happens in the processor (`radio.py:763-766`) |
+| `…radio_model.summary_idxs` | **skipped** | buffer rebuilt from config (`radio.py:761-762`) |
+| `sound_encoder.*` | `sound_encoder.encoder.*` | `parakeet.py:91-92` |
+| `sound_projection.*` | `sound_encoder.projection.*` | `parakeet.py:93-94` |
+| `sound_encoder.encoder.feature_extractor.*` | **skipped** | host-side extractor owns it (`parakeet.py:88-90`) |
+
+Additional details worth copying:
+
+- Conv bias tolerance: with `convolution_bias=False`, transformers v5 does not
+  register conv bias params, but checkpoints may still contain them; those
+  specific names are skipped (`parakeet.py:112-131`).
+- Load ordering: LM weights are streamed lazily through a generator while the
+  smaller tower/adapter tensors are `detach().clone()`d into lists and loaded
+  afterwards, to stay safe with reusable-buffer weight streamers
+  (`nano_nemotron_vl.py:1521-1558`). Relevant only if your loader reuses
+  buffers.
+- Packed QKV: RADIO declares `packed_modules_mapping = {"qkv": ["qkv"]}`
+  (`radio.py:572-574, 696-698`) because the checkpoint already stores a fused
+  QKV tensor; the TP loader shards it by head.
+
+---
+
+## 9. Numerics and dtype map
+
+| Stage | dtype |
+| --- | --- |
+| Host image/video resize + normalize | fp32 compute, cast to `config.dtype` at the end (`processors/...:59-82`) |
+| Host mel front-end | fp32 throughout (`parakeet.py:170-236`) |
+| RADIO tower weights/activations | LM dtype (bf16) — `.to(llm_dtype)` at `nano_nemotron_vl.py:955` |
+| ViT output before pixel shuffle | hard cast to **bf16** (`nano_nemotron_vl.py:1057, 1089`) |
+| `mlp1` | bf16 (`nano_nemotron_vl.py:978`) |
+| Parakeet encoder | `llm_dtype` in, output hard cast to bf16 before projection (`parakeet.py:72-74`) |
+| Position-embedding interpolation | fp32 internally, cast back (`radio.py:451-465`) |
+| Mamba SSM state cache | fp32 recommended (`config.py:605-625`) |
+
+`torch.compile` is used in three places that a port should be aware of (they
+change nothing semantically but explain graph-break-avoiding code shapes):
+host-side resize/normalize and mel ops (`processors/...:59`, `parakeet.py:189,
+198, 216`), and the ViT encoder layer via
+`@support_torch_compile(..., enable_if=should_torch_compile_mm_encoder,
+is_encoder=True)` (`intern_vit.py:287-291`), gated on
+`compilation_config.compile_mm_encoder`.
+
+---
+
+## 10. Porting checklist and known pitfalls
+
+Ordered roughly by how likely each one is to bite.
+
+1. **Token-count parity first.** Before touching kernels, port §5.5 and assert
+   that host-side placeholder counts equal device-side embedding rows for:
+   single image, multi-image (dynamic budget), 1-frame video, T-not-dividing
+   frame count, EVS on/off, single/multi-clip audio.
+2. **Integer `frame_duration_ms`.** `int(1000.0 / fps)`. Using float fps
+   produces different timestamp strings → different separator token counts →
+   shape mismatch (`processors/...:899-907`).
+3. **Tokenize span components independently.** Separator, `<img>`,
+   `<image>`×k, `</img>` are tokenized separately and concatenated
+   (`processors/...:1191-1199`). Tokenizing the joined string can merge tokens
+   across boundaries.
+4. **Video span is fully "embedded".** All positions, including separators, get
+   embeddings from the model (§5.5/§6.4). Either replicate the hybrid assembly
+   or make sure your equivalent produces identical `inputs_embeds`.
+5. **EVS details:** first frame always fully retained via the `255` sentinel;
+   `kept = max(tokens_per_frame, int(total*(1-q)))`; `stable=True` argsort;
+   pruning applied *after* the projector on LM-dim embeddings; host allocates
+   the total, device decides the distribution.
+6. **Tubelet padding by last-frame repetition**, not zeros, and the exact einops
+   grouping order `(tubelets frames) spatial feat -> tubelets spatial (frames feat)`
+   (`radio.py:234-252`).
+7. **Dynamic-resolution images are pre-patchified on the host** and packed into
+   one sequence with per-image `cu_seqlens`; the ViT embedder is a Linear over
+   `3·P²` vectors. Don't assume a conv patch embed
+   (`processors/...:550-569`, `radio.py:201-206`).
+8. **Never upscale** in the dynamic tiler (`factor = min(..., 1.0)`), round patch
+   grids to multiples of 2, respect `min_num_patches`/`max_num_patches`, and the
+   10-iteration budget loop (`processors/...:376-548`).
+9. **Audio clipping:** 30 s clips + ≥0.1 s tail, zero-padded to the clip sum;
+   per-clip normalization over valid frames with sample variance; token count
+   floored at 1 (`parakeet.py:253-330`).
+10. **CLS/register stripping.** `num_skip = num_cls_tokens + num_registers`
+    tokens are removed *per item* after the tower (`radio.py:793-822`), and
+    register count derives from `register_multiple`.
+11. **Layer scale is identity in vLLM** (`radio.py:780-782`). Check whether the
+    checkpoint actually contains meaningful `ls1/ls2`; if it does, vLLM and a
+    faithful Megatron port would disagree, and the vLLM side is the suspect.
+12. **`input_conditioner` lives in the processor.** Normalization stats come
+    from `config.norm_mean/norm_std`, not from checkpoint weights
+    (`radio.py:763-766`).
+13. **Micro-batching of 128 frames** in `extract_feature` is memory hygiene, but
+    the batch size must stay a multiple of T (`nano_nemotron_vl.py:1067-1077`).
+14. **Encoders are unquantized** even for FP8/NVFP4 checkpoints (§7.5).
+15. **Mamba SSM state in fp32** (§3.4) — and be aware vLLM's own config hook is
+    keyed to the non-Omni architecture name.
+16. Known limitations recorded in this tree, useful as expectation-setting:
+    `requires_sequential_video_encoding` exists because batched dynamic-res
+    video is unsupported (`nano_nemotron_vl.py:904-905`,
+    `gpu_model_runner.py:3131-3150`), and the test registry disables
+    `video_maintain_aspect_ratio` due to a mixed-resolution processor bug
+    (`tests/models/registry.py:1194-1199`).
+
+---
+
+## 11. Suggested Megatron-Core inference decomposition
+
+A mapping that keeps the vLLM boundaries (they are good boundaries — the host
+stage is CPU/tokenizer-bound and cacheable, the device stage is pure tensor
+work):
+
+| Responsibility | vLLM home | Suggested Megatron-Core home |
+| --- | --- | --- |
+| Media decode + resize/normalize + clip split + mel | `processors/nano_nemotron_vl.py`, `parakeet.py:138-335` | request-preprocessing / dataloader-side module, reusing Megatron-LM's `image_processing.py` where it already exists |
+| Placeholder expansion + token accounting | `processors/...` + `nano_nemotron_vl.py:432-596` | prompt-builder utility; must be shared with whatever computes the final embedding span |
+| Vision tower | `radio.py` + `intern_vit.py` | Megatron ViT/`TransformerBlock` with column/row-parallel linears; varlen attention via `cu_seqlens` |
+| Audio tower | `parakeet.py:48-75` | Conformer encoder; start replicated, consider batch sharding later |
+| Projectors | `nano_nemotron_vl.py:964-978`, `parakeet.py:27-45` | replicated MLPs |
+| EVS pruning | `vllm/multimodal/evs.py` | direct port; pure tensor code, no comm |
+| Embedding scatter | `interfaces.py:386-415`, `models/utils.py::_merge_multimodal_embeddings` | inference-engine input-embedding assembly |
+| LM | `nemotron_h.py` | existing Megatron Nemotron-H hybrid + MoE |
+
+Validation strategy: run vLLM as the oracle with a fixed seed and dump
+intermediate tensors at four cut points — (a) processor outputs
+(`pixel_values_flat*`, `input_audio_features`, expanded token ids), (b) raw tower
+outputs before pixel-shuffle/projection, (c) per-item embeddings returned by
+`embed_multimodal`, (d) final `inputs_embeds`. Compare (a) exactly (integers and
+fp32 math), (b)-(d) with a bf16-appropriate tolerance. Getting (a) and the token
+counts identical is what prevents the long tail of shape-mismatch bugs.
+
+---
+
+## 12. Reference material
+
+- `docs/contributing/model/multimodal.md` — framework concepts: processing info,
+  dummy inputs, prompt updates, field configs. Read this to understand *why* the
+  host stage is split the way it is.
+- `docs/contributing/model/basic.md:120-148` — hybrid Mamba/attention model
+  requirements (`IsHybrid`, state shape/dtype hooks, `MODELS_CONFIG_MAP`).
+- `docs/configuration/optimization.md:230-280` — encoder TP `weights` vs `data`
+  modes and which models support batch-level DP.
+- `tests/models/registry.py:1182-1206` — the canonical test configuration for
+  Omni, including the `hf_overrides` needed to shrink the model for CI.
+- `tests/models/multimodal/test_nano_nemotron_vl.py` — behaviour of
+  `load_weights` in text-only / image-only modes.
+- Upstream: NVIDIA model card for `nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-*`
+  and the vLLM blog post on Nemotron 3 Nano Omni for the serving-flag surface
+  (`--reasoning-parser nemotron_v3`, `--tool-call-parser qwen3_coder`,
+  `--video-pruning-rate`, `--media-io-kwargs`).

--- a/examples/mimo/model_providers/radio_encoder.py
+++ b/examples/mimo/model_providers/radio_encoder.py
@@ -13,6 +13,7 @@ import torch
 
 from megatron.core.activations import fast_gelu
 from megatron.core.models.multimodal.llava_model import pixel_shuffle
+from megatron.core.models.vision.pixel_shuffle import pixel_shuffle_dynamic_res
 from megatron.core.models.vision.radio import RADIOViTModel
 from megatron.core.models.vision.vit_layer_specs import get_vit_layer_with_transformer_engine_spec
 from megatron.core.process_groups_config import ProcessGroupCollection
@@ -118,38 +119,6 @@ def radio_vision_config(args: argparse.Namespace, tp_size: int, pp_size: int) ->
     return config
 
 
-def _pixel_shuffle_dynamic_res(x, imgs_sizes, patch_dim, scale_factor=0.5, version=2):
-    """Pixel shuffle for dynamic resolution (variable tile sizes).
-
-    Splits the packed sequence by per-tile lengths, applies pixel shuffle to each
-    tile, then re-concatenates. Element ordering intentionally differs from core
-    ``pixel_shuffle`` (e2e-validated); do not swap to match it.
-    """
-    seq_lens = torch.prod(imgs_sizes // patch_dim, dim=-1)
-    splits = torch.split(x, seq_lens.tolist(), dim=-2)
-
-    out = []
-    for i, sv in enumerate(splits):
-        h = imgs_sizes[i][0] // patch_dim
-        w = imgs_sizes[i][1] // patch_dim
-        sv = sv.reshape(sv.shape[0], h, w, -1)
-
-        n, h, w, c = sv.size()
-        sv = sv.view(n, h, int(w * scale_factor), int(c / scale_factor))
-        sv = sv.permute(0, 2, 1, 3).contiguous()
-        sv = sv.view(
-            n, int(w * scale_factor), int(h * scale_factor), int(c / (scale_factor * scale_factor))
-        )
-
-        if version == 2:
-            sv = sv.permute(0, 2, 1, 3).contiguous()
-
-        sv = sv.reshape(sv.shape[0], -1, sv.shape[-1])
-        out.append(sv)
-
-    return torch.cat(out, dim=-2)
-
-
 class RADIOEncoderWrapper(MegatronModule):
     """RADIO encoder wrapper matching the Nemotron6-MoE VLM provider."""
 
@@ -222,7 +191,7 @@ class RADIOEncoderWrapper(MegatronModule):
                 embeddings = embeddings[:, self.class_token_len :, :]
         if self.apply_pixel_shuffle:
             if self.dynamic_resolution and imgs_sizes is not None:
-                embeddings = _pixel_shuffle_dynamic_res(
+                embeddings = pixel_shuffle_dynamic_res(
                     embeddings, imgs_sizes, self.radio_model.patch_dim
                 )
             else:

--- a/megatron/core/inference/config.py
+++ b/megatron/core/inference/config.py
@@ -300,6 +300,21 @@ class InferenceConfig:
     enable_prefix_caching: bool = False
     """Whether to enable prefix caching for KV cache block sharing."""
 
+    enable_multimodal: bool = False
+    """Whether to reserve the per-token multimodal embedding buffers in the dynamic context.
+
+    When True, `DynamicInferenceContext` allocates `token_to_mm_embedding`
+    (`[max_tokens, 1, hidden_size]`, params_dtype) plus a `[max_tokens, 1, 1]` bool mask, and
+    the model's embedding output is passed through a masked overwrite on every step. The
+    overwrite is unconditional by design: branching on "does this step carry multimodal
+    tokens" would bake the branch into a CUDA graph capture and silently skip injection on
+    replay. Leave this False for text-only deployments, which then allocate nothing and run
+    the embedding path unchanged.
+
+    Requires pipeline parallelism of 1; multimodal embeddings are injected on the first
+    pipeline stage only and are not forwarded across stages.
+    """
+
     prefix_caching_eviction_policy: PrefixCachingEvictionPolicy = (
         PrefixCachingEvictionPolicy.REF_ZERO
     )

--- a/megatron/core/inference/contexts/base_context.py
+++ b/megatron/core/inference/contexts/base_context.py
@@ -27,6 +27,13 @@ class BaseInferenceContext(abc.ABC):
         """Return `True` if context uses dynamic batching."""
         return not self.is_static_batching()
 
+    def apply_multimodal_embeddings(self, decoder_input):
+        """Overwrite embedding rows at multimodal placeholder positions.
+
+        Identity by default; only `DynamicInferenceContext` stages multimodal embeddings.
+        """
+        return decoder_input
+
     def increment_sequence_len_offset(self, increment: int) -> None:
         """Update sequence length offset. No-op for dynamic batching."""
         if self.is_static_batching():

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -270,6 +270,9 @@ class DynamicInferenceContext(BaseInferenceContext):
         # Hyperparameter for choosing to prioritize prefix hit matches vs minimizing idle load
         self.prefix_caching_routing_alpha = inference_config.prefix_caching_routing_alpha
 
+        # Multimodal configuration. Gates allocation of the per-token embedding buffers.
+        self.enable_multimodal = inference_config.enable_multimodal
+
         # Monotonic clock for prefix caching LRU eviction ordering.
         # Incremented each engine step but kept independent so the engine step
         # counter is not overloaded with cache-eviction semantics.
@@ -1379,6 +1382,31 @@ class DynamicInferenceContext(BaseInferenceContext):
                 device=torch.cuda.current_device(),
                 dtype=self.params_dtype,
             )
+
+        # Multimodal embedding injection buffers. Deliberately kept out of the coalesced
+        # `_cpu_bookkeeping_buf`: encoder output is produced on GPU and never needs a pinned
+        # H2D mirror, and folding `max_tokens * hidden_size * 2` bytes into the single
+        # per-step `cudaMemcpyAsync` would dominate it. Allocated once here so the addresses
+        # are stable across CUDA graph capture and replay.
+        self.token_to_mm_embedding: Optional[Tensor] = None
+        self.token_to_is_mm: Optional[Tensor] = None
+        if self.enable_multimodal:
+            self.token_to_mm_embedding = torch.empty(
+                self.max_tokens,
+                1,
+                self.hidden_size,
+                device=torch.cuda.current_device(),
+                dtype=self.params_dtype,
+            )
+            # Broadcasts against `[tokens, 1, hidden]` in the masked overwrite, so one bool
+            # per token rather than per element.
+            self.token_to_is_mm = torch.zeros(
+                self.max_tokens, 1, 1, device=torch.cuda.current_device(), dtype=torch.bool
+            )
+
+        # Number of multimodal rows scattered for the current step. Host-side only; used for
+        # metrics and assertions, never to branch inside the graphed region.
+        self.mm_token_count = 0
 
         # Reset tensor-related metadata.
         self.reset_metadata()
@@ -2645,6 +2673,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         self.token_to_position_in_request.fill_(0)
         self.token_to_block_idx.fill_(-1)
         self.token_to_local_position_within_kv_block.fill_(0)
+        self.clear_multimodal_mask()
 
     def reset_metadata(
         self, preserve_prefix_cache: bool = False, *, preserve_counters: bool = False
@@ -2764,6 +2793,88 @@ class DynamicInferenceContext(BaseInferenceContext):
         cached = (input_ids, pos_ids)
         self._input_position_views[num_tokens] = cached
         return cached
+
+    def apply_multimodal_embeddings(self, decoder_input: Tensor) -> Tensor:
+        """Overwrite embedding-table rows with encoder-produced multimodal rows.
+
+        Called by the model immediately after the embedding layer, before the sequence-parallel
+        scatter and before the quantization padding zero (both of which must still win).
+
+        The overwrite is unconditional whenever multimodal is enabled -- it is *not* gated on
+        whether this step actually carries multimodal tokens. A host-side branch here would be
+        resolved once at CUDA graph capture time and then frozen for every replay, so a step
+        that captured without multimodal tokens would silently skip injection for a later step
+        that has them. An all-False mask makes the overwrite an identity op instead, at the cost
+        of one elementwise pass over `[num_tokens, 1, hidden]`.
+
+        Args:
+            decoder_input (Tensor): Embedding output, `[num_tokens, 1, hidden_size]`.
+
+        Return:
+            (Tensor) `decoder_input` with multimodal positions replaced.
+        """
+        if not self.enable_multimodal:
+            return decoder_input
+
+        # Static under graph capture: the bucket fixes num_tokens, and both buffers were
+        # allocated once in __init__, so every replay reads the same addresses.
+        num_tokens = decoder_input.shape[0]
+        return torch.where(
+            self.token_to_is_mm[:num_tokens], self.token_to_mm_embedding[:num_tokens], decoder_input
+        )
+
+    def clear_multimodal_mask(self) -> None:
+        """Invalidate the multimodal mask for the upcoming step.
+
+        Token slots are recycled every step -- decode tokens occupy `[0, active_token_count)`
+        and prefill chunks are appended after them -- so a slot that held an image row on one
+        step may hold a sampled token on the next. Clearing the whole mask (a few thousand
+        bools) is cheaper than tracking which slots were dirtied, and it also covers the
+        padding range, which `scatter_multimodal_embeddings` never writes.
+
+        The companion embedding buffer is deliberately left untouched: nothing reads it where
+        the mask is False, so zeroing it would be pure bandwidth spent on padding.
+        """
+        if not self.enable_multimodal:
+            return
+        self.token_to_is_mm.zero_()
+        self.mm_token_count = 0
+
+    def scatter_multimodal_embeddings(
+        self, req: "DynamicInferenceRequest", chunk_start: int, chunk_length: int
+    ) -> None:
+        """Copy a request's multimodal rows into the token slots of the current prefill chunk.
+
+        Indexed by absolute position within the expanded prompt, so a chunk boundary landing
+        in the middle of an image's token span is handled by construction: each chunk picks up
+        exactly the rows whose positions fall inside it.
+
+        Args:
+            req (DynamicInferenceRequest): Request being added, carrying `mm_embeddings` on GPU
+                and `mm_embed_positions` on CPU.
+            chunk_start (int): Absolute position within the expanded prompt of the first token
+                written this round (i.e. past any prefix-cache skip).
+            chunk_length (int): Number of tokens written this round.
+        """
+        if not self.enable_multimodal or req.mm_embeddings is None:
+            return
+
+        positions = req.mm_embed_positions
+        # Positions are sorted, so the rows belonging to this chunk form a contiguous range.
+        # searchsorted on the CPU copy keeps the lookup off the device.
+        lo = int(torch.searchsorted(positions, chunk_start, right=False))
+        hi = int(torch.searchsorted(positions, chunk_start + chunk_length, right=False))
+        if lo == hi:
+            return
+
+        # Pageable H2D, so this blocks the host briefly. It only runs on prefill chunks that
+        # carry media, never on decode steps, so it stays out of the per-step critical path.
+        dst_idxs = (positions[lo:hi] - chunk_start + self.active_token_count).to(
+            device=self.token_to_is_mm.device, non_blocking=True
+        )
+        self.token_to_mm_embedding.index_copy_(0, dst_idxs, req.mm_embeddings[lo:hi].unsqueeze(1))
+        self.token_to_is_mm.index_fill_(0, dst_idxs, True)
+        self.mm_token_count += hi - lo
 
     def speculative_required_logit_indices(self) -> Tensor:
         """Token-level indices needed for speculative decode verification.
@@ -3182,6 +3293,11 @@ class DynamicInferenceContext(BaseInferenceContext):
         self.token_to_input_ids[
             self.active_token_count : self.active_token_count + effective_prefill_chunk_length
         ] = this_round_tokens
+        # effective_kv_offset is the absolute position within the expanded prompt of the first
+        # token written this round, so this is chunk- and prefix-skip-aware by construction.
+        self.scatter_multimodal_embeddings(
+            req, chunk_start=effective_kv_offset, chunk_length=effective_prefill_chunk_length
+        )
         self.token_to_request_idx[
             self.active_token_count : self.active_token_count + effective_prefill_chunk_length
         ] = current_id
@@ -4163,6 +4279,11 @@ class DynamicInferenceContext(BaseInferenceContext):
 
         self.active_token_count = active_request_count * num_generated_tokens
         sampled_tokens = next_tokens[self.paused_request_count : self.total_request_count]
+
+        # The decode tokens written just below, and any prefill chunk appended after them,
+        # reuse slots that may have held multimodal rows on the previous step. Invalidate the
+        # mask now, before the next step's `add_request` calls re-scatter into it.
+        self.clear_multimodal_mask()
 
         if self.num_speculative_tokens > 0:
             # new_speculative_tokens has shape [num_spec_tokens, num_requests],

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -42,6 +42,7 @@ from megatron.core.inference.inference_request import (
     DynamicInferenceRequestRecord,
     Status,
 )
+from megatron.core.inference.multimodal.types import MultimodalData, MultimodalEmbeddingProvider
 from megatron.core.inference.sampling_params import SamplingParams
 from megatron.core.inference.text_generation_controllers.text_generation_controller import (
     DecodeOnly,
@@ -251,7 +252,12 @@ class DynamicInferenceEngine(AbstractEngine):
         *DEPRECATED_ARGS,
         message="Argument `{name}` has been deprecated. Only pass `controller` and `context`",
     )
-    def __init__(self, controller: TextGenerationController, context: DynamicInferenceContext):
+    def __init__(
+        self,
+        controller: TextGenerationController,
+        context: DynamicInferenceContext,
+        multimodal_encoder: Optional[MultimodalEmbeddingProvider] = None,
+    ):
 
         assert isinstance(
             controller, TextGenerationController
@@ -271,6 +277,24 @@ class DynamicInferenceEngine(AbstractEngine):
         # Initialization options.
         self.controller = controller
         self.context = context
+
+        self.multimodal_encoder = multimodal_encoder
+        if multimodal_encoder is not None:
+            assert inference_config.enable_multimodal, (
+                "A multimodal_encoder was passed but InferenceConfig.enable_multimodal is False, "
+                "so the context has no embedding buffers to scatter into."
+            )
+            assert multimodal_encoder.hidden_size == model_config.hidden_size, (
+                f"multimodal encoder projects to {multimodal_encoder.hidden_size} but the "
+                f"language model has hidden_size {model_config.hidden_size}"
+            )
+            # Multimodal rows are injected after the embedding layer on the first pipeline
+            # stage and are never forwarded to later stages, so PP > 1 would silently drop
+            # them. See the design doc's PP decision.
+            assert self.pg_collection.pp is None or self.pg_collection.pp.size() == 1, (
+                "Multimodal inference requires pipeline_model_parallel_size == 1, got "
+                f"{self.pg_collection.pp.size()}"
+            )
 
         self.num_speculative_tokens = inference_config.num_speculative_tokens
         self.materialize_only_last_token_logits = (
@@ -1168,6 +1192,7 @@ class DynamicInferenceEngine(AbstractEngine):
         request_id: int,
         prompt: Union[str, List[int], Tensor],
         sampling_params: Optional[SamplingParams] = None,
+        multimodal_data: Optional[MultimodalData] = None,
     ) -> asyncio.Future[DynamicInferenceRequest]:
         """Add request to inference context.
 
@@ -1175,10 +1200,19 @@ class DynamicInferenceEngine(AbstractEngine):
             request_id (int): Unique ID of request.
             prompt (Union[str, Tensor]): Prompt as either a text string or token IDs.
             sampling_params (Optional[SamplingParams]): Sampling parameters for the request.
+            multimodal_data (Optional[MultimodalData]): Images, videos, and/or audio to attach
+                to the request. Requires the engine to have been built with a
+                `multimodal_encoder`, and `prompt` to be text (placeholder expansion is
+                tokenizer-driven).
 
         Return:
             Returns an asyncio `Future[DynamicInferenceRequest]` for the user to wait on.
         """
+        if multimodal_data is not None and not multimodal_data.is_empty():
+            return self._add_multimodal_request(
+                request_id, prompt, sampling_params, multimodal_data
+            )
+
         prompt_str = None
         # Tokenize prompt if text.
         if isinstance(prompt, str):
@@ -1220,6 +1254,47 @@ class DynamicInferenceEngine(AbstractEngine):
         )
 
         # Add request.
+        return self._add_request(request)
+
+    def _add_multimodal_request(
+        self,
+        request_id: int,
+        prompt: Union[str, List[int], Tensor],
+        sampling_params: Optional[SamplingParams],
+        multimodal_data: MultimodalData,
+    ) -> asyncio.Future[DynamicInferenceRequest]:
+        """Expand and encode a multimodal prompt, then admit it as a normal request.
+
+        Placeholder expansion and encoding both happen here, before `_add_request`, because
+        every downstream accounting decision -- block count, chunk lengths,
+        `num_tokens_to_generate`, the max-sequence-length check -- is derived from
+        `len(prompt_tokens)` and must see the expanded length.
+        """
+        assert self.multimodal_encoder is not None, (
+            f"Request {request_id} carries multimodal data but the engine was built without a "
+            "multimodal_encoder."
+        )
+        assert isinstance(prompt, str), (
+            "Multimodal requests require a text prompt; placeholder expansion needs the "
+            f"tokenizer, got {type(prompt).__name__}."
+        )
+
+        processed = self.multimodal_encoder.encode(prompt, multimodal_data)
+
+        request = DynamicInferenceRequest(
+            request_id=request_id,
+            prompt=prompt,
+            prompt_tokens=processed.prompt_tokens,
+            sampling_params=sampling_params,
+            block_size_tokens=self.context.block_size_tokens,
+            # DynamicInferenceRequest.__post_init__ forces this off for multimodal requests;
+            # passing the engine's setting keeps the intent visible at the call site.
+            enable_prefix_caching=self.context.enable_prefix_caching,
+            mm_embeddings=processed.mm_embeddings,
+            mm_embed_positions=processed.mm_embed_positions,
+            mm_content_hash=processed.content_hash,
+        )
+
         return self._add_request(request)
 
     def post_process_requests(

--- a/megatron/core/inference/inference_request.py
+++ b/megatron/core/inference/inference_request.py
@@ -389,10 +389,35 @@ class DynamicInferenceRequest(InferenceRequest):
     # Computed field - not passed by caller
     precomputed_block_hashes: List[int] = field(default_factory=list)
 
+    # Multimodal fields. `prompt_tokens` is already the *expanded* prompt (placeholder spans
+    # materialized), so all the usual token accounting works unchanged.
+    #   mm_embeddings:       [N_mm, hidden_size], params_dtype, on GPU. Encoder output, in the
+    #                        same order as mm_embed_positions.
+    #   mm_embed_positions:  [N_mm], int64, on CPU, sorted ascending. Positions within the
+    #                        expanded prompt that receive an encoder row instead of an
+    #                        embedding-table lookup.
+    #   mm_content_hash:     Digest of the decoded media, for a future prefix-cache extension.
+    mm_embeddings: Optional[torch.Tensor] = None
+    mm_embed_positions: Optional[torch.Tensor] = None
+    mm_content_hash: Optional[int] = None
+
     def __post_init__(self):
         self.sampling_params = copy.deepcopy(self.sampling_params)
         if self.prompt_tokens is not None:
             self.remaining_prompt_tokens = self.prompt_tokens
+
+        if self.mm_embeddings is not None:
+            assert self.mm_embed_positions is not None, "mm_embeddings requires mm_embed_positions"
+            assert len(self.mm_embeddings) == len(self.mm_embed_positions), (
+                f"mm_embeddings has {len(self.mm_embeddings)} rows but "
+                f"{len(self.mm_embed_positions)} positions"
+            )
+            # Prefix caching hashes raw token ids, and two different images expand to
+            # identical placeholder ids -- so a cache hit on a multimodal prefix would
+            # serve one image's KV for another. Correctness bug, not a perf issue. The
+            # long-term fix is to chain mm_content_hash into the block digests; until then
+            # multimodal requests bypass the cache entirely.
+            self.enable_prefix_caching = False
 
         # Compute block hashes for prefix matching (skip if already provided, e.g. from `merge`).
         if (
@@ -462,6 +487,13 @@ class DynamicInferenceRequest(InferenceRequest):
             saved_prompt_tokens = self.prompt_tokens
             self.prompt_tokens = None
 
+        # Multimodal embeddings are megabytes of bf16 per request and are consumed on the
+        # engine that produced them. `super().serialize()` would convert them via
+        # `.cpu().tolist()`, which would dominate the engine->coordinator->API host path.
+        saved_mm = (self.mm_embeddings, self.mm_embed_positions)
+        self.mm_embeddings = None
+        self.mm_embed_positions = None
+
         obj = super().serialize()
         obj["events"] = [e.serialize() for e in self.events]
         obj.pop("event_add_engine", None)
@@ -479,6 +511,7 @@ class DynamicInferenceRequest(InferenceRequest):
 
         if drop_prompt:
             self.prompt_tokens = saved_prompt_tokens
+        self.mm_embeddings, self.mm_embed_positions = saved_mm
 
         nvtx_range_pop("DynamicInferenceRequest.serialize")
         return obj
@@ -695,13 +728,19 @@ class DynamicInferenceRequestRecord:
             }
         )
 
-        # New request.
+        # New request. Multimodal state carries forward unchanged: the checkpointed prompt
+        # appends generated tokens after the original prompt, so every mm_embed_position still
+        # refers to the same token. Dropping it here would silently re-prefill an evicted
+        # multimodal request with bare placeholder ids.
         new_request = DynamicInferenceRequest(
             request_id=old_request.request_id,
             prompt_tokens=new_prompt_tokens,
             sampling_params=new_sampling_params,
             policy_epoch=policy_epoch,
             kv_cache_epoch=kv_cache_epoch,
+            mm_embeddings=old_request.mm_embeddings,
+            mm_embed_positions=old_request.mm_embed_positions,
+            mm_content_hash=old_request.mm_content_hash,
         )
         # Preserve event_add_engine from old request if it exists, otherwise set it.
         # This ensures TTFT calculation works correctly for evicted/resumed requests.
@@ -767,6 +806,10 @@ class DynamicInferenceRequestRecord:
             enable_prefix_caching=self.requests[0].enable_prefix_caching,
             precomputed_block_hashes=self.requests[0].precomputed_block_hashes,
             num_cached_tokens=self.requests[0].num_cached_tokens,
+            # mm_embeddings are deliberately not carried into the merged result: they are
+            # consumed during prefill and holding them would pin encoder output on the GPU
+            # for the lifetime of the result object.
+            mm_content_hash=self.requests[0].mm_content_hash,
         )
 
         return request

--- a/megatron/core/inference/multimodal/__init__.py
+++ b/megatron/core/inference/multimodal/__init__.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+from megatron.core.inference.multimodal.openai_content import (
+    ExtractedContent,
+    extract_media_from_content,
+    extract_media_from_messages,
+)
+from megatron.core.inference.multimodal.types import (
+    MultimodalData,
+    MultimodalEmbeddingProvider,
+    ProcessedMultimodalPrompt,
+)
+
+__all__ = [
+    "ExtractedContent",
+    "MultimodalData",
+    "MultimodalEmbeddingProvider",
+    "ProcessedMultimodalPrompt",
+    "extract_media_from_content",
+    "extract_media_from_messages",
+]

--- a/megatron/core/inference/multimodal/nemotron_omni/__init__.py
+++ b/megatron/core/inference/multimodal/nemotron_omni/__init__.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+from megatron.core.inference.multimodal.nemotron_omni.config import (
+    NemotronOmniConfig,
+    RadioVisionConfig,
+    SoundConfig,
+)
+from megatron.core.inference.multimodal.nemotron_omni.encoder_stack import (
+    EncodedMedia,
+    NemotronOmniEncoderStack,
+)
+from megatron.core.inference.multimodal.nemotron_omni.provider import NemotronOmniEmbeddingProvider
+
+__all__ = [
+    "EncodedMedia",
+    "NemotronOmniConfig",
+    "NemotronOmniEmbeddingProvider",
+    "NemotronOmniEncoderStack",
+    "RadioVisionConfig",
+    "SoundConfig",
+]

--- a/megatron/core/inference/multimodal/nemotron_omni/audio_processor.py
+++ b/megatron/core/inference/multimodal/nemotron_omni/audio_processor.py
@@ -1,0 +1,272 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+"""Host-side log-mel front-end for the Parakeet audio tower.
+
+The whole pipeline runs in fp32 -- pre-emphasis, STFT, mel projection, log, and normalization.
+Downcasting anywhere before the tower changes the normalized features enough to shift token
+content.
+
+`subsampling_output_length` is the contract point: the host token count, the device-side
+per-clip trim, and the dummy-input sizing all call it, and they must agree exactly or the
+prompt's `<so_embedding>` slot count will not match the encoder's row count.
+"""
+
+import math
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Any, List, Sequence, Tuple
+
+import torch
+
+from megatron.core.inference.multimodal.nemotron_omni.config import SoundConfig
+
+# Log-domain floor. 2**-24, matching the reference implementation exactly; a different guard
+# shifts every mel bin in near-silent frames.
+LOG_ZERO_GUARD_VALUE = 2.0**-24
+NORMALIZE_EPSILON = 1e-5
+
+
+@dataclass
+class ProcessedAudio:
+    """Mel features for a batch of clips, grouped back to items by `clips_per_item`."""
+
+    mel_features: torch.Tensor
+    """`[total_clips, max_frames, num_mel_bins]`, normalized."""
+
+    attention_mask: torch.Tensor
+    """`[total_clips, max_frames]` bool, True on valid frames."""
+
+    clips_per_item: List[int]
+    """Clips belonging to each input audio item, in order."""
+
+    token_counts: List[int]
+    """Encoder row count per input audio item."""
+
+
+@lru_cache(maxsize=8)
+def _hann_window(win_length: int, device: str) -> torch.Tensor:
+    """Symmetric (non-periodic) Hann window."""
+    return torch.hann_window(win_length, periodic=False, device=device)
+
+
+@lru_cache(maxsize=8)
+def _mel_filters(num_mel_bins: int, sampling_rate: int, n_fft: int, device: str) -> torch.Tensor:
+    """Slaney-normalized, Slaney-scaled mel filterbank, `[num_mel_bins, n_fft // 2 + 1]`.
+
+    Built here rather than pulled from `transformers.audio_utils` so the audio front-end does
+    not add a transformers import to the host path, and cross-checked against the filterbank
+    vendored at `megatron/core/models/audio/nemo_audio_preprocessing.py`.
+    """
+
+    def hz_to_mel(freq: float) -> float:
+        # Slaney scale: linear below 1 kHz, logarithmic above.
+        min_log_hz = 1000.0
+        min_log_mel = min_log_hz / (200.0 / 3)
+        logstep = math.log(6.4) / 27.0
+        if freq >= min_log_hz:
+            return min_log_mel + math.log(freq / min_log_hz) / logstep
+        return freq / (200.0 / 3)
+
+    def mel_to_hz(mel: torch.Tensor) -> torch.Tensor:
+        min_log_hz = 1000.0
+        min_log_mel = min_log_hz / (200.0 / 3)
+        logstep = math.log(6.4) / 27.0
+        linear = mel * (200.0 / 3)
+        log_region = min_log_hz * torch.exp(logstep * (mel - min_log_mel))
+        return torch.where(mel >= min_log_mel, log_region, linear)
+
+    num_frequency_bins = n_fft // 2 + 1
+    max_frequency = sampling_rate / 2.0
+    mel_points = torch.linspace(
+        hz_to_mel(0.0), hz_to_mel(max_frequency), num_mel_bins + 2, dtype=torch.float64
+    )
+    hz_points = mel_to_hz(mel_points)
+    fft_freqs = torch.linspace(0.0, max_frequency, num_frequency_bins, dtype=torch.float64)
+
+    filters = torch.zeros(num_mel_bins, num_frequency_bins, dtype=torch.float64)
+    diff = hz_points[1:] - hz_points[:-1]
+    ramps = hz_points.unsqueeze(-1) - fft_freqs.unsqueeze(0)
+    for i in range(num_mel_bins):
+        lower = -ramps[i] / diff[i]
+        upper = ramps[i + 2] / diff[i + 1]
+        filters[i] = torch.clamp(torch.minimum(lower, upper), min=0.0)
+
+    # Slaney normalization: unit area per filter.
+    enorm = 2.0 / (hz_points[2 : num_mel_bins + 2] - hz_points[:num_mel_bins])
+    filters *= enorm.unsqueeze(-1)
+
+    return filters.to(device=device, dtype=torch.float32)
+
+
+class ParakeetAudioProcessor:
+    """Splits audio into clips and produces normalized log-mel features."""
+
+    def __init__(self, config: SoundConfig) -> None:
+        self.config = config
+        self._clip_target_samples = int(round(config.clip_seconds * config.sampling_rate))
+        # A trailing fragment shorter than this is padded up rather than dropped, so a 30.05 s
+        # input still produces two clips.
+        self._tail_min_samples = int(round(0.1 * config.sampling_rate))
+
+    def subsampling_output_length(self, num_frames: int) -> int:
+        """Encoder rows produced from `num_frames` mel frames.
+
+        The subsampling stack is `log2(subsampling_factor)` strided convolutions, each with
+        stride 2, kernel `subsampling_conv_kernel_size`, and symmetric padding
+        `(kernel - 1) // 2`. Applied sequentially, since flooring at each layer is not the same
+        as one division by the total factor.
+        """
+        cfg = self.config
+        kernel = cfg.subsampling_conv_kernel_size
+        padding = (kernel - 1) // 2
+        num_layers = int(round(math.log2(cfg.subsampling_factor)))
+
+        length = num_frames
+        for _ in range(num_layers):
+            length = (length + 2 * padding - kernel) // 2 + 1
+        return max(int(length), 0)
+
+    def clip_sizes(self, num_samples: int) -> List[int]:
+        """Split an audio length into 30 s clips plus a padded-up tail."""
+        num_samples = max(num_samples, self._tail_min_samples)
+        num_full_clips, remainder = divmod(num_samples, self._clip_target_samples)
+        sizes = [self._clip_target_samples] * num_full_clips
+        if remainder > 0:
+            sizes.append(max(remainder, self._tail_min_samples))
+        return sizes
+
+    def token_count(self, num_samples: int) -> int:
+        """Encoder rows an audio item of `num_samples` will produce.
+
+        Floored at 1: an audio item always occupies at least one placeholder slot, so a
+        near-silent fragment cannot produce a zero-length span.
+        """
+        total = 0
+        for clip_size in self.clip_sizes(num_samples):
+            total += self.subsampling_output_length(clip_size // self.config.hop_length)
+        return max(1, total)
+
+    def _split(self, waveform: torch.Tensor) -> List[torch.Tensor]:
+        """Cut one waveform into clips, right-padding the tail to its nominal size."""
+        assert waveform.ndim == 1, f"expected mono 1-D audio, got shape {tuple(waveform.shape)}"
+        sizes = self.clip_sizes(int(waveform.shape[0]))
+        target_len = sum(sizes)
+        if waveform.shape[0] < target_len:
+            waveform = torch.nn.functional.pad(waveform, (0, target_len - waveform.shape[0]))
+
+        clips = []
+        offset = 0
+        for size in sizes:
+            clips.append(waveform[offset : offset + size])
+            offset += size
+        return clips
+
+    def _preemphasis(self, waveforms: torch.Tensor, lengths: torch.Tensor) -> torch.Tensor:
+        """First-order high-pass, `x[t] - 0.97 * x[t-1]`, zeroed past each clip's valid length.
+
+        The masking matters: without it the padded tail leaks a non-zero sample at the
+        boundary, which the STFT then spreads across the final frames.
+        """
+        time_mask = torch.arange(waveforms.shape[1], device=waveforms.device).unsqueeze(
+            0
+        ) < lengths.unsqueeze(1)
+        emphasized = torch.cat(
+            [waveforms[:, :1], waveforms[:, 1:] - self.config.preemphasis * waveforms[:, :-1]],
+            dim=1,
+        )
+        return emphasized.masked_fill(~time_mask, 0.0)
+
+    def _log_mel(self, waveforms: torch.Tensor) -> torch.Tensor:
+        """STFT power spectrum through the mel filterbank, in the log domain."""
+        cfg = self.config
+        device = str(waveforms.device)
+        stft = torch.stft(
+            waveforms,
+            cfg.n_fft,
+            hop_length=cfg.hop_length,
+            win_length=cfg.win_length,
+            window=_hann_window(cfg.win_length, device),
+            return_complex=True,
+            pad_mode="constant",
+        )
+        magnitudes = stft.real.square() + stft.imag.square()
+        mel_spec = _mel_filters(cfg.num_mel_bins, cfg.sampling_rate, cfg.n_fft, device) @ magnitudes
+        return torch.log(mel_spec + LOG_ZERO_GUARD_VALUE).permute(0, 2, 1)
+
+    def _normalize(
+        self, mel_features: torch.Tensor, sample_lengths: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Per-clip mean/variance normalization over valid frames only.
+
+        Uses the *sample* variance (divide by `n - 1`), not the population variance. The
+        difference is small but systematic, and it propagates through the whole tower.
+        """
+        cfg = self.config
+        # Frame count implied by torch.stft's centered padding.
+        frame_lengths = torch.floor_divide(
+            sample_lengths + (cfg.n_fft // 2) * 2 - cfg.n_fft, cfg.hop_length
+        )
+        attention_mask = (
+            torch.arange(mel_features.shape[1], device=mel_features.device)[None, :]
+            < frame_lengths[:, None]
+        )
+        mask = attention_mask.unsqueeze(-1)
+        valid_counts = attention_mask.sum(dim=1)
+
+        masked = mel_features * mask
+        mean = (masked.sum(dim=1) / valid_counts.unsqueeze(-1)).unsqueeze(1)
+        variance = ((masked - mean) ** 2 * mask).sum(dim=1) / (valid_counts - 1).unsqueeze(-1)
+        std = torch.sqrt(variance).unsqueeze(1)
+        return (mel_features - mean) / (std + NORMALIZE_EPSILON) * mask, attention_mask
+
+    def process(self, audios: Sequence[Any], device: str = "cpu") -> ProcessedAudio:
+        """Turn raw waveforms into padded, normalized log-mel features.
+
+        Args:
+            audios (Sequence[Any]): One entry per audio item: a 1-D waveform, or a
+                `(waveform, sample_rate)` pair. Multi-channel input is averaged to mono.
+            device (str): Device to run the front-end on.
+
+        Return:
+            (ProcessedAudio) Clip-batched features plus the per-item grouping and token counts.
+        """
+        waveforms: List[torch.Tensor] = []
+        for audio in audios:
+            if isinstance(audio, tuple):
+                audio, sample_rate = audio
+                assert sample_rate == self.config.sampling_rate, (
+                    f"audio must be resampled to {self.config.sampling_rate} Hz on the host, "
+                    f"got {sample_rate}"
+                )
+            tensor = torch.as_tensor(audio, device=device, dtype=torch.float32)
+            if tensor.ndim > 1:
+                tensor = tensor.mean(-1)
+            waveforms.append(tensor)
+
+        clips: List[torch.Tensor] = []
+        clips_per_item: List[int] = []
+        token_counts: List[int] = []
+        for waveform in waveforms:
+            item_clips = self._split(waveform)
+            clips.extend(item_clips)
+            clips_per_item.append(len(item_clips))
+            token_counts.append(self.token_count(int(waveform.shape[0])))
+
+        sample_lengths = torch.tensor(
+            [clip.shape[0] for clip in clips], dtype=torch.long, device=device
+        )
+        max_length = int(sample_lengths.max())
+        padded = torch.zeros(len(clips), max_length, dtype=torch.float32, device=device)
+        for i, clip in enumerate(clips):
+            padded[i, : clip.shape[0]] = clip
+
+        padded = self._preemphasis(padded, sample_lengths)
+        mel_features = self._log_mel(padded)
+        mel_features, attention_mask = self._normalize(mel_features, sample_lengths)
+
+        return ProcessedAudio(
+            mel_features=mel_features,
+            attention_mask=attention_mask,
+            clips_per_item=clips_per_item,
+            token_counts=token_counts,
+        )

--- a/megatron/core/inference/multimodal/nemotron_omni/builder.py
+++ b/megatron/core/inference/multimodal/nemotron_omni/builder.py
@@ -1,0 +1,148 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+"""Assemble the Nemotron Omni encoder stack and provider from a config and a checkpoint."""
+
+import json
+import os
+from typing import Any, Optional
+
+import torch
+
+from megatron.core.inference.multimodal.nemotron_omni.checkpoint import NemotronOmniWeightMapper
+from megatron.core.inference.multimodal.nemotron_omni.config import NemotronOmniConfig
+from megatron.core.inference.multimodal.nemotron_omni.encoder_stack import NemotronOmniEncoderStack
+from megatron.core.inference.multimodal.nemotron_omni.provider import NemotronOmniEmbeddingProvider
+from megatron.core.models.vision.multimodal_projector import MultimodalProjector
+from megatron.core.models.vision.radio import RADIOViTModel
+from megatron.core.models.vision.vit_layer_specs import get_vit_layer_with_transformer_engine_spec
+from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.transformer.mlp import MLPSubmodules
+from megatron.core.transformer.transformer_config import TransformerConfig
+
+
+def load_omni_config(path: str) -> NemotronOmniConfig:
+    """Read a Nemotron Omni `config.json` (file or directory) into a `NemotronOmniConfig`."""
+    if os.path.isdir(path):
+        path = os.path.join(path, "config.json")
+    with open(path, "r", encoding="utf-8") as handle:
+        return NemotronOmniConfig.from_hf(json.load(handle))
+
+
+def build_vision_tower(
+    config: NemotronOmniConfig,
+    base_config: TransformerConfig,
+    pg_collection: Optional[ProcessGroupCollection] = None,
+) -> RADIOViTModel:
+    """Build the RADIO tower with the Omni checkpoint's geometry.
+
+    `class_token_len` is the trap here: it must be `num_cls_tokens + num_registers` (10 for the
+    shipped checkpoint), not `RADIOViTModel`'s default of 8. A wrong value strips the wrong
+    number of rows per tile and shifts every image's embeddings without raising.
+    """
+    vision = config.vision
+    return RADIOViTModel(
+        transformer_config=vision.to_transformer_config(base_config),
+        transformer_layer_spec=get_vit_layer_with_transformer_engine_spec(),
+        patch_dim=vision.patch_size,
+        img_h=vision.preferred_resolution[0],
+        img_w=vision.preferred_resolution[1],
+        class_token_len=vision.class_token_len,
+        add_class_token=True,
+        max_img_h=vision.max_img_h,
+        max_img_w=vision.max_img_w,
+        has_cpe=True,
+        embedder_bias=False,
+        dynamic_resolution=True,
+        temporal_patch_dim=vision.video_temporal_patch_size,
+        separate_video_embedder=vision.separate_video_embedder,
+        force_eval_mode=True,
+        pg_collection=pg_collection,
+    )
+
+
+def build_vision_projector(
+    config: NemotronOmniConfig,
+    base_config: TransformerConfig,
+    pg_collection: Optional[ProcessGroupCollection] = None,
+) -> MultimodalProjector:
+    """Build the `RMSNorm -> Linear -> ReLU^2 -> Linear` vision projector.
+
+    The leading RMSNorm is folded into fc1 via `TELayerNormColumnParallelLinear`;
+    `MultimodalProjector`'s usual `ColumnParallelLinear` fc1 carries no norm, and the checkpoint
+    has one (`mlp1.0.weight`).
+    """
+    from megatron.core.extensions.transformer_engine import (
+        TELayerNormColumnParallelLinear,
+        TERowParallelLinear,
+    )
+
+    input_size = config.vision.projector_input_size
+    return MultimodalProjector(
+        config=config.projector_transformer_config(base_config, input_size),
+        submodules=MLPSubmodules(
+            linear_fc1=TELayerNormColumnParallelLinear, linear_fc2=TERowParallelLinear
+        ),
+        projector_type="mlp",
+        input_size=input_size,
+        pg_collection=pg_collection,
+    )
+
+
+def build_provider(
+    config: NemotronOmniConfig,
+    base_config: TransformerConfig,
+    tokenizer: Any,
+    checkpoint_weights: Optional[Any] = None,
+    pg_collection: Optional[ProcessGroupCollection] = None,
+    with_audio: bool = False,
+) -> NemotronOmniEmbeddingProvider:
+    """Build a ready-to-serve `NemotronOmniEmbeddingProvider`.
+
+    Args:
+        config (NemotronOmniConfig): Resolved model configuration.
+        base_config (TransformerConfig): Language model config, for dtype and parallelism.
+        tokenizer: Tokenizer used for placeholder expansion.
+        checkpoint_weights (Optional[Any]): Iterable of `(key, tensor)` pairs from the HF
+            checkpoint. When None the towers are left randomly initialized, which is only
+            useful for shape and graph-safety tests.
+        pg_collection (Optional[ProcessGroupCollection]): Process groups for the towers.
+        with_audio (bool): Whether to build the Parakeet tower. Requires
+            transformers >= 5.5.3.
+
+    Return:
+        (NemotronOmniEmbeddingProvider) Provider to pass to `DynamicInferenceEngine`.
+    """
+    vision_model = build_vision_tower(config, base_config, pg_collection)
+    vision_projection = build_vision_projector(config, base_config, pg_collection)
+
+    audio_model = None
+    if with_audio:
+        from megatron.core.models.audio.parakeet_model import ProjectedParakeet
+
+        audio_model = ProjectedParakeet(
+            config=config.sound,
+            llm_hidden_size=config.hidden_size,
+            projector_hidden_size=config.projector_hidden_size,
+            dtype=base_config.params_dtype,
+            projector_norm_eps=config.projector_norm_eps,
+        )
+
+    if checkpoint_weights is not None:
+        mapper = NemotronOmniWeightMapper(config)
+        state_dicts = mapper.convert(checkpoint_weights)
+        vision_model.load_state_dict(state_dicts["vision_model"], strict=False)
+        vision_projection.load_state_dict(state_dicts["vision_projection"], strict=False)
+        if audio_model is not None:
+            audio_model.load_state_dict(state_dicts["audio_model"], strict=False)
+
+    device = torch.cuda.current_device()
+    encoder_stack = NemotronOmniEncoderStack(
+        config=config,
+        vision_model=vision_model.to(device).eval(),
+        vision_projection=vision_projection.to(device).eval(),
+        audio_model=audio_model.to(device).eval() if audio_model is not None else None,
+    )
+
+    return NemotronOmniEmbeddingProvider(
+        config=config, encoder_stack=encoder_stack, tokenizer=tokenizer
+    )

--- a/megatron/core/inference/multimodal/nemotron_omni/checkpoint.py
+++ b/megatron/core/inference/multimodal/nemotron_omni/checkpoint.py
@@ -1,0 +1,250 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+"""HF safetensors to mcore weight mapping for Nemotron Omni.
+
+No existing path covers this: `megatron/core/export/` targets TRT-LLM, and
+`tools/checkpoint/loader_llava.py` reads RADIO but sources vision weights from `torch.hub`
+rather than HF safetensors. The four prefix classes in the checkpoint are:
+
+    language_model.backbone.*                 -> hybrid language model
+    mlp1.*                                    -> vision projector
+    vision_model.radio_model.*                -> RADIOViTModel
+    sound_encoder.* / sound_projection.*      -> audio tower
+
+Two entries are dropped rather than mapped: `input_conditioner.*` (image normalization runs on
+the host, in the processor) and `summary_idxs` (a teacher-selection index, unused at inference).
+
+Two divergences from the reference implementation, both deliberate:
+
+1. `ls1` / `ls2` (LayerScale) are *not* silently skipped. The reference loader `continue`s past
+   them, which means it drops them if they are non-unit. mcore's RADIO has no LayerScale
+   either, so this loader warns instead of hiding the difference.
+2. Mamba SSM states are forced to fp32. The reference's config hook for this is keyed to a
+   non-Omni architecture string and therefore never fires for Omni checkpoints.
+"""
+
+import logging
+from typing import Dict, Iterable, List, Optional, Tuple
+
+import torch
+
+from megatron.core.inference.multimodal.nemotron_omni.config import NemotronOmniConfig
+
+logger = logging.getLogger(__name__)
+
+LANGUAGE_MODEL_PREFIX = "language_model."
+VISION_PREFIX = "vision_model.radio_model."
+VISION_PROJECTOR_PREFIX = "mlp1."
+AUDIO_ENCODER_PREFIX = "sound_encoder."
+AUDIO_PROJECTOR_PREFIX = "sound_projection."
+
+# Checkpoint entries with no mcore counterpart.
+DROPPED_SUBSTRINGS = ("input_conditioner.", "summary_idxs")
+
+
+def qkv_interleave_indices(hidden_size: int, num_heads: int, kv_channels: int) -> torch.Tensor:
+    """Row permutation from PyTorch's fused QKV layout to mcore's.
+
+    PyTorch multi-head attention stores QKV as three contiguous `[hidden, hidden]` blocks;
+    mcore interleaves them per head as `[q_head_0, k_head_0, v_head_0, q_head_1, ...]`. Without
+    this permutation the tower loads without error and produces garbage.
+
+    Args:
+        hidden_size (int): Attention hidden size.
+        num_heads (int): Attention head count.
+        kv_channels (int): Channels per head.
+
+    Return:
+        (torch.Tensor) int64 index tensor of length `3 * hidden_size`.
+    """
+    indices: List[torch.Tensor] = []
+    for head in range(num_heads):
+        lower = head * kv_channels
+        upper = (head + 1) * kv_channels
+        indices.append(torch.arange(lower, upper, dtype=torch.int64))
+        indices.append(torch.arange(hidden_size + lower, hidden_size + upper, dtype=torch.int64))
+        indices.append(
+            torch.arange(2 * hidden_size + lower, 2 * hidden_size + upper, dtype=torch.int64)
+        )
+    return torch.cat(indices)
+
+
+def map_radio_key(hf_key: str, use_te: bool = True) -> Optional[str]:
+    """Map one RADIO checkpoint key to its `RADIOViTModel` name.
+
+    Args:
+        hf_key (str): Key with the `vision_model.radio_model.` prefix already stripped.
+        use_te (bool): Whether the tower is built with Transformer Engine fused layers, which
+            absorb the pre-attention and pre-MLP norms into the linear modules.
+
+    Return:
+        (Optional[str]) mcore parameter name, or None if the entry should be dropped.
+    """
+    if any(dropped in hf_key for dropped in DROPPED_SUBSTRINGS):
+        return None
+
+    if "patch_generator" in hf_key:
+        if "embedder" in hf_key:
+            return "embedder.weight"
+        if "video_embedder" in hf_key:
+            return "video_embedder.weight"
+        if "cls_token" in hf_key:
+            # mcore stores CLS and register tokens as one [class_token_len, hidden] parameter.
+            return "class_token"
+        if "pos_embed" in hf_key:
+            return "position_embeddings"
+        return None
+
+    if ".blocks." not in hf_key and not hf_key.startswith("blocks."):
+        return None
+
+    parts = hf_key.split(".")
+    layer_idx = parts[parts.index("blocks") + 1]
+    base = f"decoder.layers.{layer_idx}"
+    suffix = ".".join(parts[parts.index("blocks") + 2 :])
+
+    fused_norms = {
+        "norm1.weight": f"{base}.self_attention.linear_qkv.layer_norm_weight",
+        "norm1.bias": f"{base}.self_attention.linear_qkv.layer_norm_bias",
+        "norm2.weight": f"{base}.mlp.linear_fc1.layer_norm_weight",
+        "norm2.bias": f"{base}.mlp.linear_fc1.layer_norm_bias",
+    }
+    separate_norms = {
+        "norm1.weight": f"{base}.input_layernorm.weight",
+        "norm1.bias": f"{base}.input_layernorm.bias",
+        "norm2.weight": f"{base}.pre_mlp_layernorm.weight",
+        "norm2.bias": f"{base}.pre_mlp_layernorm.bias",
+    }
+    mapping = {
+        "attn.qkv.weight": f"{base}.self_attention.linear_qkv.weight",
+        "attn.qkv.bias": f"{base}.self_attention.linear_qkv.bias",
+        "attn.proj.weight": f"{base}.self_attention.linear_proj.weight",
+        "attn.proj.bias": f"{base}.self_attention.linear_proj.bias",
+        "mlp.fc1.weight": f"{base}.mlp.linear_fc1.weight",
+        "mlp.fc1.bias": f"{base}.mlp.linear_fc1.bias",
+        "mlp.fc2.weight": f"{base}.mlp.linear_fc2.weight",
+        "mlp.fc2.bias": f"{base}.mlp.linear_fc2.bias",
+    }
+    mapping.update(fused_norms if use_te else separate_norms)
+    return mapping.get(suffix)
+
+
+def map_projector_key(hf_key: str) -> Optional[str]:
+    """Map one `mlp1.*` key to the `MultimodalProjector` name.
+
+    The HF projector is a `nn.Sequential`: index 0 is the RMSNorm, 1 the first Linear, and 3
+    the second Linear (index 2 is the activation). mcore folds the norm into fc1 via
+    `TELayerNormColumnParallelLinear`.
+    """
+    suffix = (
+        hf_key[len(VISION_PROJECTOR_PREFIX) :]
+        if hf_key.startswith(VISION_PROJECTOR_PREFIX)
+        else hf_key
+    )
+    return {
+        "0.weight": "encoder.linear_fc1.layer_norm_weight",
+        "1.weight": "encoder.linear_fc1.weight",
+        "3.weight": "encoder.linear_fc2.weight",
+    }.get(suffix)
+
+
+class NemotronOmniWeightMapper:
+    """Rewrites a stream of HF checkpoint tensors into mcore-shaped, mcore-named tensors.
+
+    Args:
+        config (NemotronOmniConfig): Resolved model configuration.
+        use_te (bool): Whether the vision tower uses Transformer Engine fused layers.
+    """
+
+    def __init__(self, config: NemotronOmniConfig, use_te: bool = True) -> None:
+        self.config = config
+        self.use_te = use_te
+        hidden = config.vision.hidden_size
+        _, _, num_heads, _ = config.vision.dims
+        self._qkv_indices = qkv_interleave_indices(hidden, num_heads, hidden // num_heads)
+        self._layer_scale_keys: List[str] = []
+
+    def check_layer_scale(self) -> None:
+        """Warn if the checkpoint carried LayerScale tensors that nothing consumes.
+
+        `mcore`'s RADIO has no LayerScale, matching the reference implementation, so parity
+        between the two engines holds. But if these tensors are non-unit, *both* are dropping a
+        real transform relative to the HF reference implementation, and vision features will
+        differ from it. Surfaced rather than swallowed.
+        """
+        if self._layer_scale_keys:
+            logger.warning(
+                "Checkpoint contains %d LayerScale tensor(s) (e.g. %s) that mcore's RADIO does "
+                "not model. This matches the reference vLLM implementation, which also skips "
+                "them, but if they are not ~1.0 both engines differ from the HF reference. "
+                "Verify before trusting vision-feature parity against HF.",
+                len(self._layer_scale_keys),
+                self._layer_scale_keys[0],
+            )
+
+    def convert(
+        self, weights: Iterable[Tuple[str, torch.Tensor]]
+    ) -> Dict[str, Dict[str, torch.Tensor]]:
+        """Split and rename a checkpoint into per-submodule state dicts.
+
+        Args:
+            weights (Iterable[Tuple[str, torch.Tensor]]): `(key, tensor)` pairs, e.g. from
+                `safetensors.safe_open`.
+
+        Return:
+            (Dict[str, Dict[str, torch.Tensor]]) State dicts keyed by
+            "language_model", "vision_model", "vision_projection", "audio_model".
+        """
+        out: Dict[str, Dict[str, torch.Tensor]] = {
+            "language_model": {},
+            "vision_model": {},
+            "vision_projection": {},
+            "audio_model": {},
+        }
+
+        for key, tensor in weights:
+            if any(dropped in key for dropped in DROPPED_SUBSTRINGS):
+                continue
+
+            if key.startswith(LANGUAGE_MODEL_PREFIX):
+                out["language_model"][key[len(LANGUAGE_MODEL_PREFIX) :]] = tensor
+
+            elif key.startswith(VISION_PREFIX):
+                radio_key = key[len(VISION_PREFIX) :]
+                if (
+                    radio_key.endswith(("ls1", "ls2"))
+                    or ".ls1." in radio_key
+                    or (".ls2." in radio_key)
+                ):
+                    self._layer_scale_keys.append(key)
+                    continue
+                mapped = map_radio_key(radio_key, use_te=self.use_te)
+                if mapped is None:
+                    continue
+                if mapped.endswith("linear_qkv.weight") or mapped.endswith("linear_qkv.bias"):
+                    tensor = tensor[self._qkv_indices]
+                out["vision_model"][mapped] = tensor
+
+            elif key.startswith(VISION_PROJECTOR_PREFIX):
+                mapped = map_projector_key(key)
+                if mapped is not None:
+                    out["vision_projection"][mapped] = tensor
+
+            elif key.startswith(AUDIO_ENCODER_PREFIX):
+                if "encoder.feature_extractor." in key:
+                    # Mel-filterbank buffers; the host front-end builds its own.
+                    continue
+                out["audio_model"][key[len(AUDIO_ENCODER_PREFIX) :]] = tensor
+
+            elif key.startswith(AUDIO_PROJECTOR_PREFIX):
+                suffix = key[len(AUDIO_PROJECTOR_PREFIX) :]
+                mapped = {
+                    "0.weight": "projection.norm.weight",
+                    "1.weight": "projection.fc1.weight",
+                    "3.weight": "projection.fc2.weight",
+                }.get(suffix)
+                if mapped is not None:
+                    out["audio_model"][mapped] = tensor
+
+        self.check_layer_scale()
+        return out

--- a/megatron/core/inference/multimodal/nemotron_omni/config.py
+++ b/megatron/core/inference/multimodal/nemotron_omni/config.py
@@ -1,0 +1,395 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+"""Nemotron Omni configuration: HF `config.json` -> mcore configs.
+
+Three traps in this checkpoint fail silently rather than loudly, so they are handled
+explicitly here rather than left to defaults:
+
+1. `class_token_len` is `num_cls_tokens + num_registers` = 10, not mcore's default of 8.
+   Getting it wrong drops or keeps 10 extra rows per image with no error.
+2. The language model's `expand: 2` is stored but unused -- the real Mamba inner size is
+   `mamba_num_heads * mamba_head_dim` = 4096, not `expand * hidden_size` = 5376. mcore only
+   derives `mamba_num_heads` when it is left as None, so it is always set explicitly.
+3. `projector_hidden_size` is 20480, four times the language model's own `d_ff`.
+
+The RADIO tower's `args` blob in the checkpoint is serialized timm *training* state
+(optimizer, augmentation, distillation bookkeeping). Only the handful of fields read below
+are meaningful; everything else there is inert.
+"""
+
+from copy import deepcopy
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional, Tuple
+
+import torch
+
+from megatron.core.activations import squared_relu
+from megatron.core.transformer.transformer_config import TransformerConfig
+
+# timm architecture name -> (hidden_size, num_layers, num_heads, ffn_hidden_size).
+# C-RADIOv4-H is vit_huge_patch16_224.
+_TIMM_VIT_DIMS: Dict[str, Tuple[int, int, int, int]] = {
+    "vit_base_patch16_224": (768, 12, 12, 3072),
+    "vit_large_patch16_224": (1024, 24, 16, 4096),
+    "vit_huge_patch16_224": (1280, 32, 16, 5120),
+}
+
+# RADIO input conditioner values. Applied on the host during preprocessing rather than as a
+# device module, which is why `input_conditioner.*` checkpoint entries are skipped on load.
+OPENAI_CLIP_MEAN = (0.4815, 0.4578, 0.4082)
+OPENAI_CLIP_STD = (0.2686, 0.2613, 0.2758)
+
+
+@dataclass
+class RadioVisionConfig:
+    """RADIO vision tower geometry, resolved from the HF `vision_config` block."""
+
+    timm_model: str = "vit_huge_patch16_224"
+    patch_size: int = 16
+    preferred_resolution: Tuple[int, int] = (768, 768)
+    cpe_max_size: int = 2048
+
+    # Cropped positional embedding grid. mcore derives max_num_rows/cols from these.
+    max_img_h: int = 2048
+    max_img_w: int = 2048
+
+    # num_cls_tokens comes from the number of distinct teachers; num_registers is padded so
+    # that (num_cls_tokens + num_registers) is a multiple of `register_multiple`.
+    num_cls_tokens: int = 4
+    register_multiple: int = 10
+
+    # Video tubelet depth. > 1 activates RADIOViTModel's temporal grouping path, which also
+    # changes forward() to return (features, imgs_sizes, num_frames).
+    video_temporal_patch_size: int = 2
+    separate_video_embedder: bool = True
+
+    # Host-side tiling budget, in *patches* (4 patches per post-shuffle token).
+    min_num_patches: int = 1024
+    max_num_patches: int = 13312
+
+    # Video framing.
+    video_target_num_patches: int = 1024
+    video_maintain_aspect_ratio: bool = True
+
+    # RadioConfig defaults that the checkpoint does not override. Pinned so a future default
+    # change upstream cannot silently alter numerics.
+    qkv_bias: bool = True
+    qk_normalization: bool = False
+    layer_norm_eps: float = 1.0e-6
+
+    norm_mean: Tuple[float, float, float] = OPENAI_CLIP_MEAN
+    norm_std: Tuple[float, float, float] = OPENAI_CLIP_STD
+
+    @property
+    def num_registers(self) -> int:
+        """Register tokens appended after the CLS tokens.
+
+        Padded so the combined prefix is a multiple of `register_multiple`; for the shipped
+        checkpoint that is `10 - (4 % 10) = 6`.
+        """
+        remainder = self.num_cls_tokens % self.register_multiple
+        return self.register_multiple - remainder if remainder else 0
+
+    @property
+    def class_token_len(self) -> int:
+        """Total non-patch prefix tokens per tile, i.e. mcore's `class_token_len`.
+
+        mcore stores CLS and register tokens as one `[class_token_len, hidden]` parameter; the
+        reference implementation splits them but concatenates in the same order.
+        """
+        return self.num_cls_tokens + self.num_registers
+
+    @property
+    def downsample_ratio(self) -> float:
+        """Spatial reduction applied by pixel shuffle, per axis."""
+        return 0.5
+
+    @property
+    def dims(self) -> Tuple[int, int, int, int]:
+        """(hidden_size, num_layers, num_heads, ffn_hidden_size) for the timm architecture."""
+        assert (
+            self.timm_model in _TIMM_VIT_DIMS
+        ), f"unknown RADIO timm model {self.timm_model!r}; known: {sorted(_TIMM_VIT_DIMS)}"
+        return _TIMM_VIT_DIMS[self.timm_model]
+
+    @property
+    def hidden_size(self) -> int:
+        """Vision tower hidden size."""
+        return self.dims[0]
+
+    @property
+    def projector_input_size(self) -> int:
+        """Vision projector input width.
+
+        Pixel shuffle folds a 2x2 patch neighbourhood into channels, so the projector sees
+        four times the tower's hidden size.
+        """
+        return self.hidden_size * 4
+
+    @classmethod
+    def from_hf(cls, vision_config: Dict[str, Any]) -> "RadioVisionConfig":
+        """Build from an HF `vision_config` dict."""
+        args = vision_config.get("args", {})
+        teachers = args.get("teachers", [])
+        # One CLS token per distinct teacher when cls_token_per_teacher is set.
+        num_cls_tokens = 1
+        if args.get("cls_token_per_teacher", False) and teachers:
+            num_cls_tokens = len({t.get("name", i) for i, t in enumerate(teachers)})
+
+        resolution = vision_config.get("preferred_resolution", [768, 768])
+        cpe_max_size = args.get("cpe_max_size", 2048)
+
+        return cls(
+            timm_model=args.get("model", "vit_huge_patch16_224"),
+            patch_size=vision_config.get("patch_size", 16),
+            preferred_resolution=(int(resolution[0]), int(resolution[1])),
+            cpe_max_size=cpe_max_size,
+            max_img_h=cpe_max_size,
+            max_img_w=cpe_max_size,
+            num_cls_tokens=num_cls_tokens,
+            register_multiple=args.get("register_multiple", 10),
+            video_temporal_patch_size=vision_config.get("video_temporal_patch_size", 2),
+            separate_video_embedder=vision_config.get("separate_video_embedder", True),
+            min_num_patches=args.get("min_num_patches", 1024),
+            max_num_patches=args.get("max_num_patches", 13312),
+            video_target_num_patches=vision_config.get("video_target_num_patches", 1024),
+            video_maintain_aspect_ratio=vision_config.get("video_maintain_aspect_ratio", True),
+            qkv_bias=vision_config.get("qkv_bias", True),
+            qk_normalization=vision_config.get("qk_normalization", False),
+            layer_norm_eps=vision_config.get("layer_norm_eps", 1.0e-6),
+        )
+
+    def to_transformer_config(self, base: TransformerConfig) -> TransformerConfig:
+        """Derive the ViT `TransformerConfig` from the language model's config.
+
+        Args:
+            base (TransformerConfig): Language model config, used only for dtype and
+                parallelism; every architectural field is overridden.
+
+        Return:
+            (TransformerConfig) Config for `RADIOViTModel`.
+        """
+        from megatron.core.activations import fast_gelu
+
+        hidden, layers, heads, ffn = self.dims
+        config = deepcopy(base)
+        config.num_layers = layers
+        config.hidden_size = hidden
+        config.num_attention_heads = heads
+        config.num_query_groups = heads
+        config.kv_channels = hidden // heads
+        config.ffn_hidden_size = ffn
+        config.gated_linear_unit = False
+        config.activation_func = fast_gelu
+        config.add_bias_linear = True
+        config.add_qkv_bias = self.qkv_bias
+        config.qk_layernorm = self.qk_normalization
+        config.normalization = "LayerNorm"
+        config.layernorm_epsilon = self.layer_norm_eps
+        config.layernorm_zero_centered_gamma = False
+        config.apply_rope_fusion = False
+        config.bias_activation_fusion = False
+        config.bias_dropout_fusion = False
+        config.attention_softmax_in_fp32 = True
+        config.attention_dropout = 0.0
+        config.hidden_dropout = 0.0
+        # Triggers TransformerBlock's final_layernorm allocation.
+        config.mtp_num_layers = 0
+        # The tower inherits none of the language model's MoE / Mamba / hybrid settings.
+        config.num_moe_experts = None
+        config.moe_ffn_hidden_size = None
+        config.moe_shared_expert_intermediate_size = None
+        config.moe_grouped_gemm = False
+        config.moe_router_fusion = False
+        config.moe_permute_fusion = False
+        config.moe_shared_expert_overlap = False
+        config.is_hybrid_model = False
+        config.use_fused_weighted_squared_relu = False
+        config.hybrid_override_pattern = None
+        # The tower runs on a packed variable-length sequence; SP would shard it against the
+        # cu_seqlens the varlen attention kernel is given.
+        config.sequence_parallel = False
+        config.variable_seq_lengths = True
+        # The checkpoint quantizes only the language model: the NVFP4 variant's
+        # quantized_layers list has no entry under vision_model.*, sound_encoder.*,
+        # sound_projection.*, or mlp1.*. Keep the towers in params_dtype.
+        config.fp8 = None
+        config.fp4 = None
+        return config
+
+
+@dataclass
+class SoundConfig:
+    """Parakeet Conformer audio tower geometry, from the HF `sound_config` block."""
+
+    hidden_size: int = 1024
+    num_attention_heads: int = 8
+    num_hidden_layers: int = 24
+    intermediate_size: int = 4096
+    conv_kernel_size: int = 9
+    convolution_bias: bool = False
+    subsampling_conv_channels: int = 256
+    subsampling_conv_kernel_size: int = 3
+    subsampling_factor: int = 8
+
+    # Mel front-end. `feat_in` in the checkpoint is a stale default of 80 and is deliberately
+    # not read: the real filterbank width is num_mel_bins.
+    num_mel_bins: int = 128
+    sampling_rate: int = 16000
+    hop_length: int = 160
+    win_length: int = 400
+    n_fft: int = 512
+    preemphasis: float = 0.97
+    clip_seconds: float = 30.0
+
+    @property
+    def ms_per_audio_token(self) -> float:
+        """Audio duration each encoder output row covers.
+
+        `hop_length / sampling_rate * subsampling_factor` = 80 ms, i.e. 12.5 tokens/second.
+        """
+        return 1000.0 * self.hop_length * self.subsampling_factor / self.sampling_rate
+
+    @classmethod
+    def from_hf(cls, sound_config: Dict[str, Any]) -> "SoundConfig":
+        """Build from an HF `sound_config` dict."""
+        return cls(
+            hidden_size=sound_config.get("hidden_size", 1024),
+            num_attention_heads=sound_config.get("num_attention_heads", 8),
+            num_hidden_layers=sound_config.get("num_hidden_layers", 24),
+            intermediate_size=sound_config.get("intermediate_size", 4096),
+            conv_kernel_size=sound_config.get("conv_kernel_size", 9),
+            convolution_bias=sound_config.get("convolution_bias", False),
+            subsampling_conv_channels=sound_config.get("subsampling_conv_channels", 256),
+            subsampling_conv_kernel_size=sound_config.get("subsampling_conv_kernel_size", 3),
+            subsampling_factor=sound_config.get("subsampling_factor", 8),
+            num_mel_bins=sound_config.get("num_mel_bins", 128),
+            sampling_rate=sound_config.get("sampling_rate", 16000),
+        )
+
+
+@dataclass
+class NemotronOmniConfig:
+    """Top-level Nemotron Omni configuration.
+
+    Holds the two tower configs, the projector widths, the placeholder token strings, and the
+    handful of policy knobs where this port deliberately diverges from vLLM.
+    """
+
+    vision: RadioVisionConfig = field(default_factory=RadioVisionConfig)
+    sound: SoundConfig = field(default_factory=SoundConfig)
+
+    # Language model.
+    hidden_size: int = 2688
+    max_sequence_length: int = 131072
+
+    # Both projectors are RMSNorm -> Linear -> ReLU^2 -> Linear, bias-free. 20480 is 4x the
+    # language model's own d_ff, so do not assume it is small.
+    projector_hidden_size: int = 20480
+    projector_norm_eps: float = 1.0e-5
+
+    # Placeholder markers. The reference implementation hard-codes these strings and resolves
+    # ids through the tokenizer, so the strings -- not the ids -- are the contract.
+    img_start_token: str = "<img>"
+    img_end_token: str = "</img>"
+    img_context_token: str = "<image>"
+    video_token: str = "<video>"
+    audio_start_token: str = "<so_start>"
+    audio_context_token: str = "<so_embedding>"
+    audio_end_token: str = "<so_end>"
+
+    # Image token budget. The reference implementation derives the per-image patch budget from
+    # the engine's max_model_len, which makes image *resolution* a function of a serving flag.
+    # Pinning it to the processor's value instead keeps output reproducible across
+    # deployments; set to None to recover the flag-dependent behaviour.
+    image_budget_sequence_length: Optional[int] = 16384
+
+    # Fraction of video tokens to prune via efficient video sampling. The checkpoint requests
+    # 0.7 and the HF reference honours it, while vLLM reads it only from a CLI flag and
+    # therefore defaults to no pruning at all. Honouring the checkpoint is the divergence.
+    video_pruning_rate: Optional[float] = 0.7
+
+    @classmethod
+    def from_hf(cls, hf_config: Dict[str, Any]) -> "NemotronOmniConfig":
+        """Build from a parsed Nemotron Omni HF `config.json`.
+
+        Args:
+            hf_config (Dict[str, Any]): Parsed top-level `config.json`.
+
+        Return:
+            (NemotronOmniConfig) Resolved configuration.
+        """
+        text_config = hf_config.get("text_config") or hf_config.get("llm_config") or {}
+        vision = RadioVisionConfig.from_hf(hf_config.get("vision_config", {}))
+        sound = SoundConfig.from_hf(hf_config.get("sound_config", {}))
+
+        return cls(
+            vision=vision,
+            sound=sound,
+            hidden_size=text_config.get("hidden_size", 2688),
+            max_sequence_length=hf_config.get("max_sequence_length", 131072),
+            projector_hidden_size=hf_config.get(
+                "projector_hidden_size", vision.projector_input_size * 4
+            ),
+            video_pruning_rate=hf_config.get("video_pruning_rate", 0.7),
+        )
+
+    def projector_transformer_config(
+        self, base: TransformerConfig, input_size: int
+    ) -> TransformerConfig:
+        """Config for one of the two `RMSNorm -> Linear -> ReLU^2 -> Linear` projectors.
+
+        The norm is folded into fc1 via `TELayerNormColumnParallelLinear`, which is why
+        `normalization` is set here even though the projector has no attention.
+
+        Args:
+            base (TransformerConfig): Language model config, for dtype and parallelism.
+            input_size (int): Projector input width (`vision.projector_input_size` for the
+                vision projector, `sound.hidden_size` for the audio projector).
+
+        Return:
+            (TransformerConfig) Config to pass to `MultimodalProjector`.
+        """
+        config = deepcopy(base)
+        config.hidden_size = self.hidden_size
+        config.ffn_hidden_size = self.projector_hidden_size
+        config.gated_linear_unit = False
+        config.activation_func = squared_relu
+        config.add_bias_linear = False
+        config.add_qkv_bias = False
+        config.normalization = "RMSNorm"
+        config.layernorm_epsilon = self.projector_norm_eps
+        config.num_moe_experts = None
+        config.moe_ffn_hidden_size = None
+        config.moe_shared_expert_intermediate_size = None
+        config.moe_grouped_gemm = False
+        config.is_hybrid_model = False
+        config.hybrid_override_pattern = None
+        config.sequence_parallel = False
+        config.fp8 = None
+        config.fp4 = None
+        # Unused by the projector but read during MLP construction.
+        config.num_layers = 1
+        return config
+
+    def language_model_overrides(self) -> Dict[str, Any]:
+        """Mamba/MoE fields that must be set explicitly on the language model config.
+
+        `expand: 2` in the checkpoint is inert: the real inner size is
+        `mamba_num_heads * mamba_head_dim` = 4096, whereas mcore's fallback derivation
+        (`hidden_size * expand // mamba_head_dim`, used only when `mamba_num_heads is None`)
+        would build a 5376-wide mixer that cannot load the checkpoint.
+
+        The `hybrid_override_pattern` string transfers verbatim -- mcore already defines
+        `M` (Mamba), `E` (MoE), and `*` (attention) in
+        `megatron.core.models.hybrid.hybrid_layer_allocation.Symbols`.
+        """
+        return {
+            "mamba_num_heads": 64,
+            "mamba_head_dim": 64,
+            "mamba_state_dim": 128,
+            "mamba_num_groups": 8,
+            # vLLM's fp32-SSM-state config hook is keyed to a non-Omni architecture string and
+            # never fires for this checkpoint. Force it here rather than inheriting that bug.
+            "mamba_training_ssm_states_dtype": torch.float32,
+        }

--- a/megatron/core/inference/multimodal/nemotron_omni/encoder_stack.py
+++ b/megatron/core/inference/multimodal/nemotron_omni/encoder_stack.py
@@ -1,0 +1,257 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+"""Device-side encoder stack for Nemotron Omni.
+
+Runs at request admission, deliberately outside the graphed per-step region: encoder output
+shape varies per request, so capturing a tower inside the step would freeze one request's
+shapes into the graph, and chunked prefill would re-run the tower once per chunk.
+
+Images and videos are encoded in a *single* batched RADIO call. The reference vLLM
+implementation sets `requires_sequential_video_encoding = True` and encodes videos one at a
+time, but only because batched dynamic-resolution video is unimplemented there; mcore's
+`RADIOViTModel._apply_temporal_grouping` already handles mixed image/video items in one packed
+batch. The tubelet grouping and last-frame padding are per-item, so batching is numerically
+identical and materially faster.
+"""
+
+import math
+from dataclasses import dataclass
+from typing import List, Optional, Sequence, Tuple
+
+import torch
+
+from megatron.core.inference.multimodal.nemotron_omni.config import NemotronOmniConfig
+from megatron.core.models.vision.evs import compute_retention_mask
+from megatron.core.models.vision.pixel_shuffle import pixel_shuffle_dynamic_res
+from megatron.core.packed_seq_params import PackedSeqParams
+
+
+@dataclass
+class EncodedMedia:
+    """Encoder rows for one media item, projected to the language model's hidden size."""
+
+    embeddings: torch.Tensor
+    """`[num_tokens, hidden_size]`."""
+
+    tokens_per_tubelet: List[int]
+    """Row count per tubelet. Single-element for images."""
+
+
+def _build_packed_seq_params(seq_lens: Sequence[int], device: torch.device) -> PackedSeqParams:
+    """Build `thd` varlen attention params for a packed, per-tile sequence.
+
+    A fresh object per call is mandatory: `RADIOViTModel.forward` *mutates*
+    `packed_seq_params.cu_seqlens_q/kv` and `max_seqlen_q/kv` in place when it prepends class
+    tokens, so a reused instance would accumulate the class-token offset on every call.
+    """
+    cu_seqlens = torch.tensor(
+        [0] + list(torch.cumsum(torch.tensor(list(seq_lens)), dim=0).tolist()),
+        dtype=torch.int32,
+        device=device,
+    )
+    max_seqlen = torch.tensor(max(seq_lens) if seq_lens else 0, dtype=torch.int32, device=device)
+    return PackedSeqParams(
+        qkv_format="thd",
+        cu_seqlens_q=cu_seqlens,
+        cu_seqlens_kv=cu_seqlens,
+        max_seqlen_q=max_seqlen,
+        max_seqlen_kv=max_seqlen,
+    )
+
+
+class NemotronOmniEncoderStack(torch.nn.Module):
+    """Owns the vision tower, the two projectors, and the audio tower.
+
+    Args:
+        config (NemotronOmniConfig): Resolved model configuration.
+        vision_model: `RADIOViTModel` instance.
+        vision_projection: Vision projector, `4 * vit_hidden -> hidden_size`.
+        audio_model: Optional projected Parakeet tower.
+    """
+
+    def __init__(
+        self,
+        config: NemotronOmniConfig,
+        vision_model: torch.nn.Module,
+        vision_projection: torch.nn.Module,
+        audio_model: Optional[torch.nn.Module] = None,
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.vision_model = vision_model
+        self.vision_projection = vision_projection
+        self.audio_model = audio_model
+
+    @property
+    def patch_dim(self) -> int:
+        """Vision patch size in pixels."""
+        return self.config.vision.patch_size
+
+    @property
+    def class_token_len(self) -> int:
+        """Non-patch prefix tokens RADIO prepends per tile."""
+        return self.config.vision.class_token_len
+
+    def _strip_class_tokens(
+        self, features: torch.Tensor, tile_seq_lens: Sequence[int]
+    ) -> torch.Tensor:
+        """Drop the CLS + register prefix that RADIO prepends to every tile.
+
+        In the dynamic-resolution path the prefixes are *interleaved* between tiles rather than
+        sitting at the front of the sequence, so this builds a keep-mask instead of slicing.
+        """
+        if self.class_token_len == 0:
+            return features
+
+        keep = torch.ones(features.shape[-2], dtype=torch.bool, device=features.device)
+        cursor = 0
+        for seq_len in tile_seq_lens:
+            keep[cursor : cursor + self.class_token_len] = False
+            cursor += int(seq_len) + self.class_token_len
+        assert cursor == features.shape[-2], (
+            f"class-token stripping covered {cursor} of {features.shape[-2]} tokens; "
+            f"class_token_len={self.class_token_len} is probably wrong"
+        )
+        return features[:, keep, :]
+
+    def _tile_seq_lens(self, imgs_sizes: torch.Tensor) -> List[int]:
+        """Patch count per tile, from pixel `(height, width)` pairs."""
+        return torch.prod(imgs_sizes // self.patch_dim, dim=-1).tolist()
+
+    @torch.inference_mode()
+    def encode_visual(
+        self, pixel_values: torch.Tensor, imgs_sizes: torch.Tensor, num_frames: Sequence[int]
+    ) -> List[EncodedMedia]:
+        """Encode images and videos in one batched RADIO call.
+
+        Args:
+            pixel_values (torch.Tensor): `[1, total_patches, 3 * patch**2]`, patchified frames
+                for every item concatenated in prompt order.
+            imgs_sizes (torch.Tensor): `[total_frames, 2]` pixel `(height, width)`, one row per
+                *frame* (before tubelet grouping).
+            num_frames (Sequence[int]): Frames per media item; 1 marks a still image.
+
+        Return:
+            (List[EncodedMedia]) One entry per media item, in the input order.
+        """
+        device = next(self.vision_model.parameters()).device
+        dtype = self.vision_model.embedder.weight.dtype
+        pixel_values = pixel_values.to(device=device, dtype=dtype)
+        imgs_sizes = imgs_sizes.to(device=device)
+
+        packed_seq_params = _build_packed_seq_params(self._tile_seq_lens(imgs_sizes), device)
+
+        # temporal_patch_dim > 1 makes forward() return the regrouped sizes and per-item
+        # tubelet counts alongside the features.
+        features, grouped_sizes, tubelets_per_item = self.vision_model(
+            pixel_values,
+            imgs_sizes=imgs_sizes,
+            packed_seq_params=packed_seq_params,
+            num_frames=list(num_frames),
+        )
+
+        tubelet_seq_lens = self._tile_seq_lens(grouped_sizes)
+        features = self._strip_class_tokens(features, tubelet_seq_lens)
+        features = pixel_shuffle_dynamic_res(features, grouped_sizes, self.patch_dim)
+        features = self.vision_projection(features)
+
+        # Post-shuffle token count per tubelet: patches // 4.
+        tokens_per_tubelet = [seq_len // 4 for seq_len in tubelet_seq_lens]
+        rows = features[0]
+        assert rows.shape[0] == sum(tokens_per_tubelet), (
+            f"projector produced {rows.shape[0]} rows but the tubelet grid implies "
+            f"{sum(tokens_per_tubelet)}"
+        )
+
+        encoded: List[EncodedMedia] = []
+        row_cursor = 0
+        tubelet_cursor = 0
+        for item_frames, item_tubelets in zip(num_frames, tubelets_per_item):
+            item_counts = tokens_per_tubelet[tubelet_cursor : tubelet_cursor + item_tubelets]
+            num_rows = sum(item_counts)
+            item_rows = rows[row_cursor : row_cursor + num_rows]
+
+            if item_frames > 1 and self.config.video_pruning_rate:
+                item_rows, item_counts = self._prune_video(
+                    item_rows, tokens_per_tubelet=item_counts, grid=grouped_sizes[tubelet_cursor]
+                )
+
+            encoded.append(EncodedMedia(embeddings=item_rows, tokens_per_tubelet=item_counts))
+            row_cursor += num_rows
+            tubelet_cursor += item_tubelets
+
+        assert (
+            row_cursor == rows.shape[0]
+        ), f"consumed {row_cursor} of {rows.shape[0]} projected rows"
+        return encoded
+
+    def _prune_video(
+        self, rows: torch.Tensor, tokens_per_tubelet: Sequence[int], grid: torch.Tensor
+    ) -> Tuple[torch.Tensor, List[int]]:
+        """Apply EVS to one video's projected rows.
+
+        Every tubelet of a video shares one spatial grid (all frames were resized to a common
+        target), which is what lets the rows be viewed as `[T, H, W, hidden]`.
+
+        Return:
+            (Tuple[torch.Tensor, List[int]]) Retained rows and the per-tubelet counts after
+            pruning. The counts are re-derived from the mask rather than predicted, because the
+            prompt's separator tokens must be re-rendered against the actual retention.
+        """
+        num_tubelets = len(tokens_per_tubelet)
+        token_h = int(grid[0]) // self.patch_dim // 2
+        token_w = int(grid[1]) // self.patch_dim // 2
+
+        mask = compute_retention_mask(
+            rows,
+            video_size_thw=(num_tubelets, token_h, token_w),
+            q=float(self.config.video_pruning_rate),
+        )
+        retained_per_tubelet = mask.view(num_tubelets, -1).sum(dim=-1).tolist()
+        return rows[mask], [int(count) for count in retained_per_tubelet]
+
+    @torch.inference_mode()
+    def encode_audio(
+        self,
+        mel_features: torch.Tensor,
+        attention_mask: torch.Tensor,
+        clips_per_item: Sequence[int],
+    ) -> List[EncodedMedia]:
+        """Encode audio clips and regroup them into per-item row blocks.
+
+        Args:
+            mel_features (torch.Tensor): `[total_clips, max_frames, num_mel_bins]`.
+            attention_mask (torch.Tensor): `[total_clips, max_frames]` bool, True on valid
+                frames. The tower trims each clip's output to the matching row count.
+            clips_per_item (Sequence[int]): Clips belonging to each audio item, in order.
+
+        Return:
+            (List[EncodedMedia]) One entry per audio item.
+        """
+        assert self.audio_model is not None, "encode_audio requires an audio tower"
+        device = next(self.audio_model.parameters()).device
+        dtype = self.audio_model.projection.fc1.weight.dtype
+        rows_per_clip = self.audio_model(
+            mel_features.to(device=device, dtype=dtype), attention_mask.to(device=device)
+        )
+
+        encoded: List[EncodedMedia] = []
+        cursor = 0
+        for num_clips in clips_per_item:
+            item_rows = torch.cat(rows_per_clip[cursor : cursor + num_clips], dim=0)
+            encoded.append(
+                EncodedMedia(embeddings=item_rows, tokens_per_tubelet=[item_rows.shape[0]])
+            )
+            cursor += num_clips
+        return encoded
+
+    def num_tubelets(self, num_frames: int) -> int:
+        """Tubelet count for a video with `num_frames` frames.
+
+        The tail tubelet is padded by repeating the last frame, so a frame count that does not
+        divide the temporal patch size still yields a whole tubelet.
+        """
+        temporal = self.config.vision.video_temporal_patch_size
+        if num_frames == 1 or temporal <= 1:
+            return 1
+        return math.ceil(num_frames / temporal)

--- a/megatron/core/inference/multimodal/nemotron_omni/image_processor.py
+++ b/megatron/core/inference/multimodal/nemotron_omni/image_processor.py
@@ -1,0 +1,287 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+"""Host-side dynamic-resolution image preprocessing for Nemotron Omni.
+
+Every arithmetic detail here is load-bearing for token-count parity with the reference
+implementation. The ones that look like typos but are not:
+
+- `round(dim / patch + 0.5)`, *not* `math.ceil`. They differ for exact multiples: a 512px side
+  with patch 16 gives 33 here and 32 from ceil.
+- `factor = min(sqrt(budget / patches), 1.0)`, so an image is never upscaled.
+- The budget is in *patches*, four per post-shuffle token, hence the x4 conversion.
+- Patch grids are snapped to a multiple of 2 preferring *up*, but only when rounding up still
+  fits the budget; otherwise down, floored at 2.
+- The rebalancing loop runs at most 10 times and then gives up on the min-patches floor.
+"""
+
+import math
+from dataclasses import dataclass
+from typing import Any, List, Optional, Sequence, Tuple
+
+import torch
+
+try:
+    import einops
+
+    HAVE_EINOPS = True
+except ImportError:
+    HAVE_EINOPS = False
+
+try:
+    import numpy as np
+    from PIL import Image
+
+    HAVE_PIL = True
+except ImportError:
+    HAVE_PIL = False
+
+
+@dataclass
+class TiledImage:
+    """One image resized to a patch grid, with the token count it will produce."""
+
+    pixel_values: torch.Tensor
+    """`[3, height, width]`, normalized, fp32 by default."""
+
+    patch_grid: Tuple[int, int]
+    """`(patch_width, patch_height)`."""
+
+    num_tokens: int
+    """Post-pixel-shuffle token count, i.e. `patches // 4`."""
+
+    @property
+    def size_hw(self) -> Tuple[int, int]:
+        """Pixel `(height, width)`, the order `RADIOViTModel` expects in `imgs_sizes`."""
+        return (self.pixel_values.shape[-2], self.pixel_values.shape[-1])
+
+
+def _to_nhwc_uint8(image: Any) -> torch.Tensor:
+    """Coerce a PIL image, numpy array, or path into a `[1, H, W, 3]` uint8 tensor."""
+    if not HAVE_PIL:
+        raise ImportError("Pillow and numpy are required for Nemotron Omni image preprocessing")
+    if isinstance(image, str):
+        image = Image.open(image)
+    if isinstance(image, Image.Image):
+        array = np.asarray(image if image.mode == "RGB" else image.convert("RGB"), dtype=np.uint8)
+    elif isinstance(image, np.ndarray):
+        array = image.astype(np.uint8, copy=False)
+    elif torch.is_tensor(image):
+        array = image.to(torch.uint8).cpu().numpy()
+    else:
+        raise TypeError(f"unsupported image type {type(image).__name__}")
+    assert array.ndim == 3 and array.shape[-1] == 3, f"expected HWC RGB, got {array.shape}"
+    return torch.from_numpy(np.expand_dims(array, axis=0))
+
+
+def bicubic_resize_and_normalize(
+    tensor: torch.Tensor,
+    size: Optional[Tuple[int, int]],
+    norm_mean: torch.Tensor,
+    norm_std: torch.Tensor,
+    dtype: torch.dtype = torch.float32,
+) -> torch.Tensor:
+    """Permute NHWC to NCHW, bicubic resize, then rescale and normalize.
+
+    Args:
+        tensor (torch.Tensor): `[N, H, W, C]` uint8.
+        size (Optional[Tuple[int, int]]): Target `(height, width)`; skips resize when None.
+        norm_mean (torch.Tensor): `[3, 1, 1]` mean, in 0-1 units.
+        norm_std (torch.Tensor): `[3, 1, 1]` std, in 0-1 units.
+        dtype (torch.dtype): Output dtype.
+
+    Return:
+        (torch.Tensor) `[N, C, H, W]` normalized.
+    """
+    tensor = tensor.permute(0, 3, 1, 2).to(dtype=torch.float32)
+    if size is not None:
+        tensor = torch.nn.functional.interpolate(
+            tensor, size=size, mode="bicubic", align_corners=False, antialias=True
+        )
+    return ((tensor / 255.0 - norm_mean) / norm_std).to(dtype=dtype).contiguous()
+
+
+def patchify(images: Sequence[torch.Tensor], patch_size: int) -> torch.Tensor:
+    """Flatten resized images into the packed patch sequence `RADIOViTModel` consumes.
+
+    Args:
+        images (Sequence[torch.Tensor]): Each `[3, H, W]`, with H and W multiples of
+            `patch_size`.
+        patch_size (int): Patch side in pixels.
+
+    Return:
+        (torch.Tensor) `[1, total_patches, 3 * patch_size**2]`.
+    """
+    if not HAVE_EINOPS:
+        raise ImportError("einops is required for Nemotron Omni image preprocessing")
+
+    flattened = []
+    for img in images:
+        py = img.shape[-2] // patch_size
+        px = img.shape[-1] // patch_size
+        flattened.append(
+            einops.rearrange(
+                img,
+                "c (py yy) (px xx) -> (py px) (c yy xx)",
+                py=py,
+                yy=patch_size,
+                px=px,
+                xx=patch_size,
+            )
+        )
+    return torch.cat(flattened, dim=0).unsqueeze(0)
+
+
+class DynamicResolutionImageTiler:
+    """Chooses a patch grid per image under a shared token budget, then resizes.
+
+    Unlike fixed-tile preprocessors, every image keeps its native aspect ratio and the budget
+    is shared across all images in the request, so adding a second image shrinks the first.
+    """
+
+    # Pixel shuffle folds 2x2 patch neighbourhoods, so 4 patches produce 1 token.
+    PATCHES_PER_TOKEN = 4
+    # Patch grids must be even on both axes for the 2x2 fold to tile exactly.
+    REQUIRED_DIVISOR = 2
+
+    def __init__(
+        self,
+        *,
+        patch_size: int,
+        min_num_patches: int,
+        max_num_patches: int,
+        norm_mean: Sequence[float],
+        norm_std: Sequence[float],
+        factor_max: float = 1.0,
+    ) -> None:
+        self.patch_size = patch_size
+        self.min_num_patches = min_num_patches
+        self.max_num_patches = max_num_patches if max_num_patches > 0 else math.inf
+        self.factor_max = factor_max
+        self.norm_mean = torch.tensor(norm_mean).reshape(3, 1, 1)
+        self.norm_std = torch.tensor(norm_std).reshape(3, 1, 1)
+
+    def num_tokens_for_grid(self, patch_width: int, patch_height: int) -> int:
+        """Post-shuffle token count for a patch grid."""
+        return (patch_width * patch_height) // self.PATCHES_PER_TOKEN
+
+    def _choose_grid(self, width: int, height: int, patch_budget: int) -> Tuple[int, int]:
+        """Pick `(patch_width, patch_height)` for one image under a patch budget.
+
+        Return:
+            (Tuple[int, int]) Patch grid, both axes even.
+        """
+        # +0.5 then round, which is not ceil: an exact multiple of patch_size rounds *up* to
+        # one extra patch here. Reproduced deliberately.
+        closest_patch_height = round(height / self.patch_size + 0.5)
+        closest_patch_width = round(width / self.patch_size + 0.5)
+        patches = closest_patch_height * closest_patch_width
+
+        # min(..., 1.0) means images are downscaled to fit but never upscaled to fill.
+        factor = min(math.sqrt(patch_budget / patches), self.factor_max)
+        target_h = math.floor(factor * closest_patch_height)
+        target_w = math.floor(factor * closest_patch_width)
+
+        # Pull tiny images back up to the floor, but only if the floor itself fits.
+        if patch_budget > self.min_num_patches and target_h * target_w < self.min_num_patches:
+            up_factor = math.sqrt(self.min_num_patches / max(target_h * target_w, 1))
+            target_h = math.ceil(up_factor * target_h)
+            target_w = math.ceil(up_factor * target_w)
+
+        divisor = self.REQUIRED_DIVISOR
+        rem_h = target_h % divisor
+        if rem_h != 0:
+            inc_h = divisor - rem_h
+            if (target_h + inc_h) * target_w <= patch_budget:
+                target_h += inc_h
+            else:
+                target_h = max(divisor, target_h - rem_h)
+
+        rem_w = target_w % divisor
+        if rem_w != 0:
+            inc_w = divisor - rem_w
+            if target_h * (target_w + inc_w) <= patch_budget:
+                target_w += inc_w
+            else:
+                target_w = max(divisor, target_w - rem_w)
+
+        return target_w, target_h
+
+    def compute_grids(
+        self, sizes: Sequence[Tuple[int, int]], token_budget: int
+    ) -> List[Tuple[int, int]]:
+        """Allocate the shared budget across images and return one patch grid each.
+
+        Args:
+            sizes (Sequence[Tuple[int, int]]): Original `(width, height)` per image.
+            token_budget (int): Post-shuffle tokens available for all images combined.
+
+        Return:
+            (List[Tuple[int, int]]) `(patch_width, patch_height)` per image.
+        """
+        assert sizes, "no images to tile"
+
+        patch_budget = token_budget * self.PATCHES_PER_TOKEN
+        # A budget too small for even the floor is allowed; the prompt gets truncated instead
+        # of the request being rejected.
+        patch_budget = max(patch_budget, self.min_num_patches * len(sizes))
+
+        per_image_budget = [
+            int(max(min(patch_budget, self.max_num_patches), self.min_num_patches)) for _ in sizes
+        ]
+
+        # Each round re-slices the budget proportionally to what the previous round asked for.
+        # Bounded at 10 rounds; the reference implementation raises past that, and so do we,
+        # because silently over-budget grids would desync the host token count from the
+        # encoder output length.
+        for _ in range(10):
+            grids = [
+                self._choose_grid(w, h, budget) for (w, h), budget in zip(sizes, per_image_budget)
+            ]
+            patch_counts = [pw * ph for pw, ph in grids]
+            total = sum(patch_counts)
+            if total <= patch_budget:
+                return grids
+
+            scaling = patch_budget / total
+            scaled = [max(self.min_num_patches, int(count * scaling)) for count in patch_counts]
+            if any(scaled[i] < per_image_budget[i] for i in range(len(scaled))):
+                per_image_budget = scaled
+            else:
+                # No further reduction possible; pin everything to the floor and retry once.
+                per_image_budget = [self.min_num_patches] * len(sizes)
+
+        raise ValueError(
+            f"failed to fit {len(sizes)} images into {patch_budget} patches after 10 rounds"
+        )
+
+    def process(
+        self, images: Sequence[Any], token_budget: int, dtype: torch.dtype = torch.float32
+    ) -> List[TiledImage]:
+        """Resize and normalize every image under a shared token budget.
+
+        Args:
+            images (Sequence[Any]): PIL images, numpy arrays, or paths.
+            token_budget (int): Post-shuffle tokens available for all images combined.
+            dtype (torch.dtype): Output dtype for the pixel values.
+
+        Return:
+            (List[TiledImage]) One entry per input image, in order.
+        """
+        raw = [_to_nhwc_uint8(image) for image in images]
+        sizes = [(t.shape[2], t.shape[1]) for t in raw]  # (width, height)
+        grids = self.compute_grids(sizes, token_budget)
+
+        tiled = []
+        for tensor, (patch_w, patch_h) in zip(raw, grids):
+            target = (patch_h * self.patch_size, patch_w * self.patch_size)
+            pixel_values = bicubic_resize_and_normalize(
+                tensor, target, self.norm_mean, self.norm_std, dtype
+            )
+            tiled.append(
+                TiledImage(
+                    pixel_values=pixel_values[0],
+                    patch_grid=(patch_w, patch_h),
+                    num_tokens=self.num_tokens_for_grid(patch_w, patch_h),
+                )
+            )
+        return tiled

--- a/megatron/core/inference/multimodal/nemotron_omni/prompt.py
+++ b/megatron/core/inference/multimodal/nemotron_omni/prompt.py
@@ -1,0 +1,300 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+"""Placeholder expansion for Nemotron Omni prompts.
+
+This module owns the token-count contract: the number of `<image>` / `<so_embedding>` slots it
+reserves must equal, exactly, the number of embedding rows the encoders produce. A mismatch is
+not a graceful degradation -- it shifts every subsequent position, so the language model reads
+image rows at text positions and vice versa. Both sides therefore derive their counts from the
+same functions here, and `NemotronOmniEncoderStack` asserts the equality.
+
+Two rules keep tokenization stable:
+
+1. Every span component is tokenized independently -- the separator, `<img>`, each `<image>`,
+   and `</img>` -- and the id lists are concatenated. Tokenizing the joined string instead
+   would let the tokenizer merge across boundaries and silently change the count depending on
+   how many `<image>` repetitions happened to be adjacent.
+2. Frame timestamps use integer millisecond arithmetic (`int(1000.0 / fps)`). A float frame
+   duration makes the rendered timestamp string differ between the host count and the device
+   re-render, which changes the separator token count and produces a shape mismatch.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from megatron.core.inference.multimodal.nemotron_omni.config import NemotronOmniConfig
+
+
+@dataclass
+class MediaSpan:
+    """One expanded placeholder span within the prompt.
+
+    Attributes:
+        modality: "image", "video", or "audio".
+        item_index: Index of the media item within its modality list.
+        embed_positions: Absolute positions in the expanded prompt that receive encoder rows.
+    """
+
+    modality: str
+    item_index: int
+    embed_positions: List[int] = field(default_factory=list)
+
+
+@dataclass
+class ExpandedPrompt:
+    """Result of placeholder expansion."""
+
+    token_ids: List[int]
+    spans: List[MediaSpan]
+
+    @property
+    def embed_positions(self) -> List[int]:
+        """All encoder-row positions, ascending.
+
+        Spans are appended in prompt order and positions within a span are ascending, so a
+        plain concatenation is already sorted. The context relies on that ordering to bisect
+        for a prefill chunk's slice.
+        """
+        return [pos for span in self.spans for pos in span.embed_positions]
+
+
+def calculate_timestamps(frame_indices: Sequence[int], frame_duration_ms: int) -> List[float]:
+    """Frame timestamps in seconds.
+
+    `frame_duration_ms` must already be the integer `int(1000.0 / fps)`; passing a float here
+    reintroduces the host/device string mismatch this function exists to avoid.
+    """
+    return [int(i) * frame_duration_ms / 1000.0 for i in frame_indices]
+
+
+def video_frame_separators(
+    frame_indices: Sequence[int], frame_duration_ms: Optional[int], temporal_patch_size: int
+) -> List[str]:
+    """Build the human-readable separator that precedes each video tubelet.
+
+    Tubelets group `temporal_patch_size` consecutive frames, and the separator names every
+    frame in the group: "Frame 1 sampled at 0.00 seconds and frame 2 sampled at 0.50 seconds: ".
+    The first frame of a group is capitalized and later ones are not, and every group after the
+    first is prefixed with a newline -- both match the training format.
+
+    Args:
+        frame_indices (Sequence[int]): Original frame indices, before tubelet grouping.
+        frame_duration_ms (Optional[int]): Integer ms per frame, or None to omit timestamps.
+        temporal_patch_size (int): Frames per tubelet.
+
+    Return:
+        (List[str]) One separator per tubelet.
+    """
+    num_frames = len(frame_indices)
+    step = max(temporal_patch_size, 1)
+
+    if frame_duration_ms is None:
+        return [
+            ("\n" if group_idx > 0 else "") + f"Frame {group_idx + 1}: "
+            for group_idx in range(0, (num_frames + step - 1) // step)
+        ]
+
+    timestamps = calculate_timestamps(frame_indices, frame_duration_ms)
+    separators = []
+    for group_idx, start in enumerate(range(0, num_frames, step)):
+        parts = []
+        for offset in range(step):
+            frame_idx = start + offset
+            if frame_idx >= num_frames:
+                # Padding frames (the tail tubelet repeats the last frame) are not named.
+                break
+            label = "Frame" if offset == 0 else "frame"
+            parts.append(f"{label} {frame_idx + 1} sampled at {timestamps[frame_idx]:.2f} seconds")
+        if parts:
+            separator = " and ".join(parts) + ": "
+            separators.append(("\n" if group_idx > 0 else "") + separator)
+    return separators
+
+
+class NemotronOmniPromptExpander:
+    """Expands media placeholders in a prompt into concrete token spans."""
+
+    def __init__(self, tokenizer: Any, config: NemotronOmniConfig) -> None:
+        self.tokenizer = tokenizer
+        self.config = config
+
+        self._img_start = self._encode(config.img_start_token)
+        self._img_end = self._encode(config.img_end_token)
+        self._img_context = self._encode(config.img_context_token)
+        self._audio_start = self._encode(config.audio_start_token)
+        self._audio_end = self._encode(config.audio_end_token)
+        self._audio_context = self._encode(config.audio_context_token)
+
+        assert (
+            len(self._img_context) == 1
+        ), f"{config.img_context_token!r} must be a single token, got {self._img_context}"
+        assert (
+            len(self._audio_context) == 1
+        ), f"{config.audio_context_token!r} must be a single token, got {self._audio_context}"
+
+    def _encode(self, text: str) -> List[int]:
+        """Tokenize without special-token insertion."""
+        try:
+            return self.tokenizer.encode(text, add_special_tokens=False)
+        except TypeError:
+            # Megatron tokenizers do not accept add_special_tokens.
+            return self.tokenizer.tokenize(text)
+
+    def _image_span(
+        self, num_tokens: int, start: int, item_index: int
+    ) -> Tuple[List[int], MediaSpan]:
+        """`<img>` + `<image>` * num_tokens + `</img>`, with the context positions recorded."""
+        token_ids = list(self._img_start)
+        offset = start + len(token_ids)
+        token_ids.extend(self._img_context * num_tokens)
+        span = MediaSpan(
+            modality="image",
+            item_index=item_index,
+            embed_positions=list(range(offset, offset + num_tokens)),
+        )
+        token_ids.extend(self._img_end)
+        return token_ids, span
+
+    def _audio_span(
+        self, num_tokens: int, start: int, item_index: int
+    ) -> Tuple[List[int], MediaSpan]:
+        """`<so_start>` + `<so_embedding>` * num_tokens + `<so_end>`."""
+        token_ids = list(self._audio_start)
+        offset = start + len(token_ids)
+        token_ids.extend(self._audio_context * num_tokens)
+        span = MediaSpan(
+            modality="audio",
+            item_index=item_index,
+            embed_positions=list(range(offset, offset + num_tokens)),
+        )
+        token_ids.extend(self._audio_end)
+        return token_ids, span
+
+    def _video_span(
+        self,
+        tokens_per_tubelet: Sequence[int],
+        separators: Sequence[str],
+        start: int,
+        item_index: int,
+    ) -> Tuple[List[int], MediaSpan]:
+        """Separator + image span, repeated once per tubelet.
+
+        The separators are ordinary text and are embedded through the language model's own
+        table; only the `<image>` runs receive encoder rows.
+        """
+        assert len(separators) == len(
+            tokens_per_tubelet
+        ), f"{len(separators)} separators for {len(tokens_per_tubelet)} tubelets"
+        # Batch-encode: the fast tokenizers' Rust backend parallelizes across the batch.
+        try:
+            encoded = self.tokenizer(
+                list(separators), add_special_tokens=False, return_attention_mask=False
+            )["input_ids"]
+        except (TypeError, KeyError):
+            encoded = [self._encode(sep) for sep in separators]
+
+        token_ids: List[int] = []
+        span = MediaSpan(modality="video", item_index=item_index)
+        for separator_ids, num_tokens in zip(encoded, tokens_per_tubelet):
+            token_ids.extend(separator_ids)
+            token_ids.extend(self._img_start)
+            offset = start + len(token_ids)
+            token_ids.extend(self._img_context * num_tokens)
+            span.embed_positions.extend(range(offset, offset + num_tokens))
+            token_ids.extend(self._img_end)
+        return token_ids, span
+
+    def expand(
+        self,
+        prompt: str,
+        image_token_counts: Sequence[int] = (),
+        audio_token_counts: Sequence[int] = (),
+        video_plans: Sequence[Dict[str, Any]] = (),
+        add_bos: bool = False,
+    ) -> ExpandedPrompt:
+        """Replace each placeholder marker with its expanded span.
+
+        Markers are consumed left to right across all modalities at once, so interleaved
+        prompts ("<image> then <video> then <image>") keep their positional order.
+
+        Args:
+            prompt (str): Prompt text containing the placeholder markers.
+            image_token_counts (Sequence[int]): Post-shuffle token count per image, in order.
+            audio_token_counts (Sequence[int]): Encoder row count per audio item, in order.
+            video_plans (Sequence[Dict[str, Any]]): Per video, a dict with
+                `tokens_per_tubelet` and `separators`.
+            add_bos (bool): Whether to prepend the tokenizer's BOS id.
+
+        Return:
+            (ExpandedPrompt) Expanded token ids plus the span metadata.
+        """
+        markers = {
+            self.config.img_context_token: "image",
+            self.config.video_token: "video",
+            self.config.audio_context_token: "audio",
+        }
+
+        token_ids: List[int] = []
+        if add_bos:
+            token_ids.append(self.tokenizer.bos)
+
+        spans: List[MediaSpan] = []
+        counters = {"image": 0, "video": 0, "audio": 0}
+        cursor = 0
+
+        while cursor < len(prompt):
+            # Find the earliest marker of any modality.
+            next_pos = len(prompt)
+            next_marker = None
+            for marker in markers:
+                found = prompt.find(marker, cursor)
+                if found != -1 and found < next_pos:
+                    next_pos, next_marker = found, marker
+
+            if next_marker is None:
+                token_ids.extend(self._encode(prompt[cursor:]))
+                break
+
+            if next_pos > cursor:
+                token_ids.extend(self._encode(prompt[cursor:next_pos]))
+
+            modality = markers[next_marker]
+            index = counters[modality]
+            counters[modality] += 1
+
+            if modality == "image":
+                assert index < len(image_token_counts), (
+                    f"prompt has more {next_marker!r} markers than images "
+                    f"({len(image_token_counts)})"
+                )
+                span_ids, span = self._image_span(image_token_counts[index], len(token_ids), index)
+            elif modality == "audio":
+                assert index < len(audio_token_counts), (
+                    f"prompt has more {next_marker!r} markers than audio items "
+                    f"({len(audio_token_counts)})"
+                )
+                span_ids, span = self._audio_span(audio_token_counts[index], len(token_ids), index)
+            else:
+                assert index < len(video_plans), (
+                    f"prompt has more {next_marker!r} markers than videos " f"({len(video_plans)})"
+                )
+                plan = video_plans[index]
+                span_ids, span = self._video_span(
+                    plan["tokens_per_tubelet"], plan["separators"], len(token_ids), index
+                )
+
+            token_ids.extend(span_ids)
+            spans.append(span)
+            cursor = next_pos + len(next_marker)
+
+        for modality, expected in (
+            ("image", len(image_token_counts)),
+            ("audio", len(audio_token_counts)),
+            ("video", len(video_plans)),
+        ):
+            assert counters[modality] == expected, (
+                f"{expected} {modality} item(s) supplied but the prompt has "
+                f"{counters[modality]} placeholder(s)"
+            )
+
+        return ExpandedPrompt(token_ids=token_ids, spans=spans)

--- a/megatron/core/inference/multimodal/nemotron_omni/provider.py
+++ b/megatron/core/inference/multimodal/nemotron_omni/provider.py
@@ -1,0 +1,283 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+"""Nemotron Omni implementation of `MultimodalEmbeddingProvider`.
+
+Ties the three stages together for one request:
+
+1. Host preprocessing -- dynamic tiling, frame resizing, mel extraction. CPU-bound, cacheable.
+2. Prompt expansion -- placeholder spans materialized at exactly the token counts stage 3 will
+   produce.
+3. Device encoding -- one batched RADIO call for images and videos, one Parakeet call for audio.
+
+Stage 2 sits between the other two because video token counts depend on the encoder: EVS
+pruning is data-dependent, so the retained count per tubelet is only known after the tower and
+projector have run. Video therefore encodes *before* expansion, while images and audio can have
+their counts predicted from geometry alone.
+"""
+
+import hashlib
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import torch
+
+from megatron.core.inference.multimodal.nemotron_omni.audio_processor import ParakeetAudioProcessor
+from megatron.core.inference.multimodal.nemotron_omni.config import NemotronOmniConfig
+from megatron.core.inference.multimodal.nemotron_omni.encoder_stack import (
+    EncodedMedia,
+    NemotronOmniEncoderStack,
+)
+from megatron.core.inference.multimodal.nemotron_omni.image_processor import (
+    DynamicResolutionImageTiler,
+    TiledImage,
+    patchify,
+)
+from megatron.core.inference.multimodal.nemotron_omni.prompt import (
+    NemotronOmniPromptExpander,
+    video_frame_separators,
+)
+from megatron.core.inference.multimodal.nemotron_omni.video_processor import (
+    NemotronOmniVideoProcessor,
+    ProcessedVideo,
+)
+from megatron.core.inference.multimodal.types import (
+    MultimodalData,
+    MultimodalEmbeddingProvider,
+    ProcessedMultimodalPrompt,
+)
+
+
+class NemotronOmniEmbeddingProvider(MultimodalEmbeddingProvider):
+    """Expands and encodes Nemotron Omni prompts at request admission.
+
+    Args:
+        config (NemotronOmniConfig): Resolved model configuration.
+        encoder_stack (NemotronOmniEncoderStack): Vision tower, projectors, audio tower.
+        tokenizer: Tokenizer used for placeholder expansion.
+        device (Optional[torch.device]): Device for the returned embeddings. Defaults to the
+            vision tower's device.
+    """
+
+    def __init__(
+        self,
+        config: NemotronOmniConfig,
+        encoder_stack: NemotronOmniEncoderStack,
+        tokenizer: Any,
+        device: Optional[torch.device] = None,
+    ) -> None:
+        self.config = config
+        self.encoder_stack = encoder_stack
+        self.tokenizer = tokenizer
+        self.expander = NemotronOmniPromptExpander(tokenizer, config)
+        self._device = device
+
+        vision = config.vision
+        self.image_tiler = DynamicResolutionImageTiler(
+            patch_size=vision.patch_size,
+            min_num_patches=vision.min_num_patches,
+            max_num_patches=vision.max_num_patches,
+            norm_mean=vision.norm_mean,
+            norm_std=vision.norm_std,
+        )
+        self.video_processor = NemotronOmniVideoProcessor(
+            patch_size=vision.patch_size,
+            target_num_patches=vision.video_target_num_patches,
+            maintain_aspect_ratio=vision.video_maintain_aspect_ratio,
+            norm_mean=vision.norm_mean,
+            norm_std=vision.norm_std,
+        )
+        self.audio_processor = ParakeetAudioProcessor(config.sound)
+
+    @property
+    def hidden_size(self) -> int:
+        """Language model hidden size the encoder rows are projected to."""
+        return self.config.hidden_size
+
+    @property
+    def device(self) -> torch.device:
+        """Device the encoder rows are returned on."""
+        if self._device is not None:
+            return self._device
+        return next(self.encoder_stack.vision_model.parameters()).device
+
+    def _image_token_budget(self, prompt: str) -> int:
+        """Post-shuffle tokens available to share across this request's images.
+
+        The reference implementation computes this from the engine's `max_model_len`, which
+        makes image *resolution* depend on a serving flag. Pinning it to the processor's own
+        sequence length keeps output reproducible across deployments; set
+        `image_budget_sequence_length` to None to recover the flag-dependent behaviour.
+        """
+        budget_length = self.config.image_budget_sequence_length or self.config.max_sequence_length
+        text_length = len(self.expander._encode(prompt))
+        # The -4 reserves the span's own <img> / </img> markers.
+        return max(budget_length - text_length - 4, self.config.vision.min_num_patches // 4)
+
+    def _content_hash(self, multimodal_data: MultimodalData) -> int:
+        """Stable digest over the decoded media.
+
+        Not used for cache lookups yet -- multimodal requests bypass the prefix cache because
+        placeholder ids are identical across different images. Recorded so that folding it into
+        the block hash chain later is a scheduler change rather than a data-model change.
+        """
+        digest = hashlib.blake2b(digest_size=8)
+        for group, items in (
+            ("image", multimodal_data.images),
+            ("video", multimodal_data.videos),
+            ("audio", multimodal_data.audios),
+        ):
+            digest.update(group.encode())
+            for item in items:
+                array = item
+                if isinstance(array, tuple):
+                    array = array[0]
+                if torch.is_tensor(array):
+                    array = array.detach().cpu().numpy()
+                try:
+                    digest.update(memoryview(array).cast("B"))
+                except (TypeError, ValueError):
+                    digest.update(repr(array).encode())
+        return int.from_bytes(digest.digest(), "big")
+
+    def _prepare_visual_inputs(
+        self, tiled: Sequence[TiledImage], videos: Sequence[ProcessedVideo]
+    ) -> Tuple[torch.Tensor, torch.Tensor, List[int]]:
+        """Patchify images and video frames into one packed RADIO input.
+
+        Images come first, then videos, matching the order `encode_visual` unpacks. Note this
+        is *not* prompt order when the two are interleaved; `encode` re-associates by item
+        index rather than by position.
+
+        Return:
+            (Tuple[torch.Tensor, torch.Tensor, List[int]]) Packed patches
+            `[1, total_patches, 3 * patch**2]`, per-frame pixel sizes `[total_frames, 2]`, and
+            frames per item.
+        """
+        patch_size = self.config.vision.patch_size
+        frames: List[torch.Tensor] = []
+        sizes: List[Tuple[int, int]] = []
+        num_frames: List[int] = []
+
+        for image in tiled:
+            frames.append(image.pixel_values)
+            sizes.append(image.size_hw)
+            num_frames.append(1)
+
+        for video in videos:
+            for frame_idx in range(video.num_frames):
+                frames.append(video.pixel_values[frame_idx])
+                sizes.append(video.size_hw)
+            num_frames.append(video.num_frames)
+
+        pixel_values = patchify(frames, patch_size)
+        imgs_sizes = torch.tensor(sizes, dtype=torch.long)
+        return pixel_values, imgs_sizes, num_frames
+
+    def encode(self, prompt: str, multimodal_data: MultimodalData) -> ProcessedMultimodalPrompt:
+        """Expand placeholders and run the encoders for one request.
+
+        Args:
+            prompt (str): Prompt text containing `<image>` / `<video>` / `<so_embedding>`
+                markers.
+            multimodal_data (MultimodalData): Media for this request.
+
+        Return:
+            (ProcessedMultimodalPrompt) Expanded token ids plus the encoder rows they need.
+        """
+        images = list(multimodal_data.images)
+        videos = list(multimodal_data.videos)
+        audios = list(multimodal_data.audios)
+
+        # --- Stage 1: host preprocessing -------------------------------------------------
+        tiled: List[TiledImage] = []
+        if images:
+            tiled = self.image_tiler.process(images, self._image_token_budget(prompt))
+
+        processed_videos: List[ProcessedVideo] = []
+        for video in videos:
+            frames, fps, frame_indices = video, None, None
+            if isinstance(video, dict):
+                frames = video["frames"]
+                fps = video.get("fps")
+                frame_indices = video.get("frame_indices")
+            processed_videos.append(
+                self.video_processor.process(frames, fps=fps, frame_indices=frame_indices)
+            )
+
+        processed_audio = self.audio_processor.process(audios) if audios else None
+
+        # --- Stage 2/3 interleaved: encode, then expand ----------------------------------
+        # Videos have to be encoded before expansion: EVS retention is data-dependent, so the
+        # per-tubelet token counts are only known once the tower and projector have run.
+        visual_encoded: List[EncodedMedia] = []
+        if tiled or processed_videos:
+            pixel_values, imgs_sizes, num_frames = self._prepare_visual_inputs(
+                tiled, processed_videos
+            )
+            visual_encoded = self.encoder_stack.encode_visual(pixel_values, imgs_sizes, num_frames)
+
+        image_encoded = visual_encoded[: len(tiled)]
+        video_encoded = visual_encoded[len(tiled) :]
+
+        audio_encoded: List[EncodedMedia] = []
+        if processed_audio is not None:
+            audio_encoded = self.encoder_stack.encode_audio(
+                processed_audio.mel_features,
+                processed_audio.attention_mask,
+                processed_audio.clips_per_item,
+            )
+
+        image_token_counts = [encoded.embeddings.shape[0] for encoded in image_encoded]
+        for predicted, encoded in zip(tiled, image_encoded):
+            assert predicted.num_tokens == encoded.embeddings.shape[0], (
+                f"host predicted {predicted.num_tokens} tokens for a "
+                f"{predicted.patch_grid} patch grid but the encoder produced "
+                f"{encoded.embeddings.shape[0]} rows"
+            )
+
+        audio_token_counts = [encoded.embeddings.shape[0] for encoded in audio_encoded]
+        if processed_audio is not None:
+            assert audio_token_counts == processed_audio.token_counts, (
+                f"host predicted {processed_audio.token_counts} audio tokens but the encoder "
+                f"produced {audio_token_counts}"
+            )
+
+        video_plans: List[Dict[str, Any]] = []
+        for processed, encoded in zip(processed_videos, video_encoded):
+            separators = video_frame_separators(
+                processed.frame_indices,
+                processed.frame_duration_ms,
+                self.config.vision.video_temporal_patch_size,
+            )
+            assert len(separators) == len(encoded.tokens_per_tubelet), (
+                f"{len(separators)} tubelet separators for "
+                f"{len(encoded.tokens_per_tubelet)} encoded tubelets"
+            )
+            video_plans.append(
+                {"tokens_per_tubelet": encoded.tokens_per_tubelet, "separators": separators}
+            )
+
+        expanded = self.expander.expand(
+            prompt,
+            image_token_counts=image_token_counts,
+            audio_token_counts=audio_token_counts,
+            video_plans=video_plans,
+        )
+
+        # --- Assemble: concatenate rows in prompt order ---------------------------------
+        by_modality = {"image": image_encoded, "video": video_encoded, "audio": audio_encoded}
+        rows = [by_modality[span.modality][span.item_index].embeddings for span in expanded.spans]
+        mm_embeddings = (
+            torch.cat(rows, dim=0) if rows else torch.empty(0, self.hidden_size, device=self.device)
+        )
+
+        positions = expanded.embed_positions
+        assert mm_embeddings.shape[0] == len(
+            positions
+        ), f"{mm_embeddings.shape[0]} encoder rows for {len(positions)} placeholder slots"
+
+        return ProcessedMultimodalPrompt(
+            prompt_tokens=torch.tensor(expanded.token_ids, dtype=torch.int64, device=self.device),
+            mm_embeddings=mm_embeddings.contiguous(),
+            mm_embed_positions=torch.tensor(positions, dtype=torch.int64, device="cpu"),
+            content_hash=self._content_hash(multimodal_data),
+        )

--- a/megatron/core/inference/multimodal/nemotron_omni/video_processor.py
+++ b/megatron/core/inference/multimodal/nemotron_omni/video_processor.py
@@ -1,0 +1,206 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+"""Host-side video preprocessing for Nemotron Omni.
+
+Unlike images, every frame of a video is resized to one *common* target, because the tubelet
+grouping concatenates frames along the channel axis and pixel shuffle later views the whole
+video as a `[T, H, W, hidden]` block. Per-frame resolution would break both.
+
+Note on provenance: the reference implementation's aspect-preserving resize claims in a comment
+to mirror `examples/multimodal/image_processing.py`, but that file's
+`find_closest_area_weighted_aspect_ratio` selects a *tile count* for fixed-tile processing and
+is a different computation entirely. The logic below follows the reference implementation's
+actual code -- distribute the target patch area by aspect ratio, then snap both axes to a
+multiple of 2 -- since that is what produced the checkpoint's behaviour.
+"""
+
+import math
+from dataclasses import dataclass
+from typing import Any, List, Optional, Sequence, Tuple
+
+import torch
+
+from megatron.core.inference.multimodal.nemotron_omni.image_processor import (
+    bicubic_resize_and_normalize,
+)
+
+
+@dataclass
+class ProcessedVideo:
+    """One video resized to a common frame geometry."""
+
+    pixel_values: torch.Tensor
+    """`[num_frames, 3, height, width]`, normalized."""
+
+    frame_indices: List[int]
+    """Original indices of the sampled frames, used to render timestamps."""
+
+    frame_duration_ms: Optional[int]
+    """Integer ms per frame. Integer by contract -- see `prompt.py`."""
+
+    tokens_per_frame: int
+    """Post-pixel-shuffle token count for one frame's grid."""
+
+    @property
+    def num_frames(self) -> int:
+        """Sampled frame count."""
+        return self.pixel_values.shape[0]
+
+    @property
+    def size_hw(self) -> Tuple[int, int]:
+        """Pixel `(height, width)` shared by every frame."""
+        return (self.pixel_values.shape[-2], self.pixel_values.shape[-1])
+
+
+def compute_aspect_preserving_size(
+    orig_w: int, orig_h: int, target_num_patches: int, patch_size: int
+) -> Tuple[int, int]:
+    """Distribute a patch-area budget across the two axes at the source aspect ratio.
+
+    Snaps both axes to a multiple of 2 (required by the 2x2 pixel-shuffle fold), preferring to
+    round *up* when the enlarged grid still fits the budget.
+
+    Args:
+        orig_w (int): Source width in pixels.
+        orig_h (int): Source height in pixels.
+        target_num_patches (int): Patch-area budget.
+        patch_size (int): Patch side in pixels.
+
+    Return:
+        (Tuple[int, int]) Target `(width, height)` in pixels.
+    """
+    aspect_wh = orig_w / max(orig_h, 1)
+    patch_h = max(round(math.sqrt(target_num_patches / aspect_wh)), 1)
+    patch_w = max(round(math.sqrt(target_num_patches * aspect_wh)), 1)
+
+    divisor = 2
+    rem_h = patch_h % divisor
+    rem_w = patch_w % divisor
+    up_h = patch_h + (divisor - rem_h if rem_h else 0)
+    up_w = patch_w + (divisor - rem_w if rem_w else 0)
+    if up_h * up_w <= target_num_patches:
+        patch_h, patch_w = up_h, up_w
+    else:
+        patch_h = max(divisor, patch_h - rem_h)
+        patch_w = max(divisor, patch_w - rem_w)
+
+    return patch_w * patch_size, patch_h * patch_size
+
+
+def compute_video_geometry(
+    orig_w: int, orig_h: int, target_num_patches: int, maintain_aspect_ratio: bool, patch_size: int
+) -> Tuple[int, int, int]:
+    """Target frame size and the token count it produces.
+
+    Args:
+        orig_w (int): Source width in pixels.
+        orig_h (int): Source height in pixels.
+        target_num_patches (int): Patch-area budget per frame.
+        maintain_aspect_ratio (bool): Whether to preserve the source aspect ratio.
+        patch_size (int): Patch side in pixels.
+
+    Return:
+        (Tuple[int, int, int]) `(width, height, tokens_per_frame)`.
+    """
+    if maintain_aspect_ratio:
+        target_w, target_h = compute_aspect_preserving_size(
+            orig_w, orig_h, target_num_patches, patch_size
+        )
+    else:
+        side = int(math.sqrt(target_num_patches))
+        side = max(2, (side // 2) * 2)
+        target_w = target_h = side * patch_size
+
+    # Two independent halvings, floored separately -- matching the reference's
+    # `int(h * ratio) * int(w * ratio)` rather than halving the product.
+    tokens_per_frame = (target_h // patch_size // 2) * (target_w // patch_size // 2)
+    return target_w, target_h, tokens_per_frame
+
+
+def _frames_to_nfhwc(video: Any) -> Tuple[torch.Tensor, int, int]:
+    """Coerce a video into a `[T, H, W, 3]` uint8 tensor."""
+    try:
+        import numpy as np
+        from PIL import Image
+    except ImportError as exc:  # pragma: no cover - dependency guard
+        raise ImportError("Pillow and numpy are required for video preprocessing") from exc
+
+    if isinstance(video, (list, tuple)):
+        frames = []
+        for frame in video:
+            if isinstance(frame, Image.Image):
+                frame = np.asarray(
+                    frame if frame.mode == "RGB" else frame.convert("RGB"), dtype=np.uint8
+                )
+            elif torch.is_tensor(frame):
+                frame = frame.to(torch.uint8).cpu().numpy()
+            frames.append(np.asarray(frame, dtype=np.uint8))
+        array = np.stack(frames, axis=0)
+    elif torch.is_tensor(video):
+        array = video.to(torch.uint8).cpu().numpy()
+    else:
+        array = np.asarray(video, dtype=np.uint8)
+
+    assert array.ndim == 4 and array.shape[-1] == 3, f"expected THWC RGB, got {array.shape}"
+    return torch.from_numpy(array), array.shape[2], array.shape[1]
+
+
+class NemotronOmniVideoProcessor:
+    """Resizes and normalizes sampled video frames to a common geometry."""
+
+    def __init__(
+        self,
+        *,
+        patch_size: int,
+        target_num_patches: int,
+        maintain_aspect_ratio: bool,
+        norm_mean: Sequence[float],
+        norm_std: Sequence[float],
+    ) -> None:
+        self.patch_size = patch_size
+        self.target_num_patches = target_num_patches
+        self.maintain_aspect_ratio = maintain_aspect_ratio
+        self.norm_mean = torch.tensor(norm_mean).reshape(3, 1, 1)
+        self.norm_std = torch.tensor(norm_std).reshape(3, 1, 1)
+
+    def process(
+        self,
+        video: Any,
+        fps: Optional[float] = None,
+        frame_indices: Optional[Sequence[int]] = None,
+        dtype: torch.dtype = torch.float32,
+    ) -> ProcessedVideo:
+        """Resize every frame to the shared target geometry.
+
+        Args:
+            video (Any): Frames as a `[T, H, W, 3]` array/tensor or a list of PIL images.
+            fps (Optional[float]): Sampling rate, used only to render timestamps.
+            frame_indices (Optional[Sequence[int]]): Original frame indices; defaults to
+                `range(T)`.
+            dtype (torch.dtype): Output dtype for the pixel values.
+
+        Return:
+            (ProcessedVideo) Resized frames plus the metadata the prompt expander needs.
+        """
+        frames, orig_w, orig_h = _frames_to_nfhwc(video)
+        target_w, target_h, tokens_per_frame = compute_video_geometry(
+            orig_w=orig_w,
+            orig_h=orig_h,
+            target_num_patches=self.target_num_patches,
+            maintain_aspect_ratio=self.maintain_aspect_ratio,
+            patch_size=self.patch_size,
+        )
+        pixel_values = bicubic_resize_and_normalize(
+            frames, (target_h, target_w), self.norm_mean, self.norm_std, dtype
+        )
+
+        # Integer division, not float: a float frame duration makes the host-rendered timestamp
+        # string differ from the device-rendered one, which changes the separator token count.
+        frame_duration_ms = int(1000.0 / fps) if fps else None
+
+        return ProcessedVideo(
+            pixel_values=pixel_values,
+            frame_indices=list(frame_indices) if frame_indices else list(range(frames.shape[0])),
+            frame_duration_ms=frame_duration_ms,
+            tokens_per_frame=tokens_per_frame,
+        )

--- a/megatron/core/inference/multimodal/openai_content.py
+++ b/megatron/core/inference/multimodal/openai_content.py
@@ -1,0 +1,202 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+"""Extract media from OpenAI-style chat content blocks.
+
+The chat endpoint currently flattens multimodal content to text and drops the media, because
+HF/Jinja chat templates want a plain string. This module splits that into two results instead:
+the flattened text, with each media block replaced by the model's placeholder marker, and the
+decoded media itself.
+
+Kept model-agnostic -- the caller supplies the marker strings -- so a second multimodal model
+reuses it without change.
+"""
+
+import base64
+import io
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Sequence, Tuple
+
+from megatron.core.inference.multimodal.types import MultimodalData
+
+_DATA_URL_RE = re.compile(r"^data:(?P<mime>[^;,]+)?(?P<b64>;base64)?,(?P<payload>.*)$", re.S)
+
+
+@dataclass
+class ExtractedContent:
+    """Flattened prompt text plus the media it refers to."""
+
+    text: str
+    multimodal_data: MultimodalData = field(default_factory=MultimodalData)
+
+    def is_multimodal(self) -> bool:
+        """Whether any media was extracted."""
+        return not self.multimodal_data.is_empty()
+
+
+def _decode_data_url(url: str) -> bytes:
+    """Decode a `data:` URL payload to raw bytes."""
+    match = _DATA_URL_RE.match(url)
+    if match is None:
+        raise ValueError(
+            "only inline data: URLs are supported for media; fetching remote URLs is the "
+            "caller's responsibility"
+        )
+    payload = match.group("payload")
+    if match.group("b64"):
+        return base64.b64decode(payload)
+    return payload.encode()
+
+
+def _load_image(url: str) -> Any:
+    """Decode an image `data:` URL into a PIL image."""
+    try:
+        from PIL import Image
+    except ImportError as exc:  # pragma: no cover - dependency guard
+        raise ImportError("Pillow is required to decode image content blocks") from exc
+    return Image.open(io.BytesIO(_decode_data_url(url)))
+
+
+def _load_audio(block: Dict[str, Any], target_sample_rate: int) -> Tuple[Any, int]:
+    """Decode an `input_audio` block into a `(waveform, sample_rate)` pair.
+
+    Resampling happens here rather than in the audio front-end, which asserts the rate instead:
+    a silent resample deep in the mel pipeline would change token counts without any signal at
+    the API boundary.
+    """
+    try:
+        import numpy as np
+        import soundfile
+    except ImportError as exc:  # pragma: no cover - dependency guard
+        raise ImportError(
+            "soundfile and numpy are required to decode audio content blocks"
+        ) from exc
+
+    audio = block.get("input_audio", block)
+    data = audio.get("data")
+    assert data is not None, "input_audio block has no 'data' field"
+    raw = base64.b64decode(data) if isinstance(data, str) else data
+
+    waveform, sample_rate = soundfile.read(io.BytesIO(raw), dtype="float32", always_2d=False)
+    if waveform.ndim > 1:
+        waveform = waveform.mean(axis=-1)
+
+    if sample_rate != target_sample_rate:
+        # Linear resample. Adequate for speech at these rates; swap in a polyphase filter if
+        # transcription quality on downsampled input turns out to matter.
+        duration = waveform.shape[0] / sample_rate
+        num_target = int(round(duration * target_sample_rate))
+        source_positions = np.linspace(0, waveform.shape[0] - 1, num=num_target)
+        waveform = np.interp(source_positions, np.arange(waveform.shape[0]), waveform).astype(
+            "float32"
+        )
+        sample_rate = target_sample_rate
+
+    return waveform, sample_rate
+
+
+def extract_media_from_content(
+    content: Any,
+    *,
+    image_marker: str,
+    video_marker: str,
+    audio_marker: str,
+    audio_sample_rate: int = 16000,
+) -> ExtractedContent:
+    """Flatten one message's content, substituting placeholder markers for media.
+
+    Args:
+        content (Any): A string, a dict, or a list of OpenAI content blocks.
+        image_marker (str): Marker to substitute for each image, e.g. `"<image>"`.
+        video_marker (str): Marker to substitute for each video.
+        audio_marker (str): Marker to substitute for each audio clip.
+        audio_sample_rate (int): Rate to resample audio to.
+
+    Return:
+        (ExtractedContent) Flattened text and the decoded media, in prompt order.
+    """
+    if isinstance(content, str):
+        return ExtractedContent(text=content)
+    if isinstance(content, dict):
+        return ExtractedContent(text=str(content.get("text", "")))
+    if not isinstance(content, (list, tuple)):
+        return ExtractedContent(text="" if content is None else str(content))
+
+    data = MultimodalData()
+    parts: List[str] = []
+
+    for block in content:
+        if isinstance(block, str):
+            parts.append(block)
+            continue
+        if not isinstance(block, dict):
+            continue
+
+        block_type = block.get("type")
+        if block_type == "text" or (block_type is None and "text" in block):
+            parts.append(str(block.get("text", "")))
+        elif block_type == "image_url":
+            url = (block.get("image_url") or {}).get("url", "")
+            data.images.append(_load_image(url))
+            parts.append(image_marker)
+        elif block_type == "video_url":
+            url = (block.get("video_url") or {}).get("url", "")
+            # Videos need frame sampling and an fps, which the decoder here does not do.
+            # Pass the raw bytes through and let the provider's video path own decoding.
+            data.videos.append({"bytes": _decode_data_url(url)})
+            parts.append(video_marker)
+        elif block_type == "input_audio":
+            data.audios.append(_load_audio(block, audio_sample_rate))
+            parts.append(audio_marker)
+
+    return ExtractedContent(text="".join(parts), multimodal_data=data)
+
+
+def extract_media_from_messages(
+    messages: Sequence[Dict[str, Any]],
+    *,
+    image_marker: str,
+    video_marker: str,
+    audio_marker: str,
+    audio_sample_rate: int = 16000,
+) -> Tuple[List[Dict[str, Any]], MultimodalData]:
+    """Flatten a whole conversation, accumulating media across messages.
+
+    Media order follows message order, then block order within a message, which is the order
+    the placeholder markers appear in the rendered prompt. The provider pairs the two by
+    position, so this ordering is the contract.
+
+    Args:
+        messages (Sequence[Dict[str, Any]]): Chat messages.
+        image_marker (str): Marker to substitute for each image.
+        video_marker (str): Marker to substitute for each video.
+        audio_marker (str): Marker to substitute for each audio clip.
+        audio_sample_rate (int): Rate to resample audio to.
+
+    Return:
+        (Tuple[List[Dict[str, Any]], MultimodalData]) Messages with string content, and the
+        accumulated media.
+    """
+    combined = MultimodalData()
+    flattened: List[Dict[str, Any]] = []
+
+    for message in messages:
+        if not isinstance(message, dict):
+            flattened.append(message)
+            continue
+        extracted = extract_media_from_content(
+            message.get("content"),
+            image_marker=image_marker,
+            video_marker=video_marker,
+            audio_marker=audio_marker,
+            audio_sample_rate=audio_sample_rate,
+        )
+        message_copy = dict(message)
+        message_copy["content"] = extracted.text
+        flattened.append(message_copy)
+
+        combined.images.extend(extracted.multimodal_data.images)
+        combined.videos.extend(extracted.multimodal_data.videos)
+        combined.audios.extend(extracted.multimodal_data.audios)
+
+    return flattened, combined

--- a/megatron/core/inference/multimodal/types.py
+++ b/megatron/core/inference/multimodal/types.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+"""Modality-agnostic contract between the dynamic engine and a multimodal model.
+
+The engine knows only these three types. Everything model-specific -- how images are tiled,
+which vision tower runs, how placeholder spans are laid out -- lives behind
+`MultimodalEmbeddingProvider`, so adding a second multimodal model requires no engine change.
+"""
+
+import abc
+from dataclasses import dataclass, field
+from typing import Any, List, Optional
+
+import torch
+
+
+@dataclass
+class MultimodalData:
+    """Raw, undecoded media attached to a request.
+
+    Element types are provider-defined; the Nemotron Omni provider accepts PIL images, numpy
+    arrays, or file paths for `images`, a list of frames or a video path for each entry of
+    `videos`, and `(waveform, sample_rate)` pairs for `audios`.
+    """
+
+    images: List[Any] = field(default_factory=list)
+    videos: List[Any] = field(default_factory=list)
+    audios: List[Any] = field(default_factory=list)
+
+    def is_empty(self) -> bool:
+        """Whether any media is attached."""
+        return not (self.images or self.videos or self.audios)
+
+
+@dataclass
+class ProcessedMultimodalPrompt:
+    """A prompt whose placeholder spans have been expanded and encoded.
+
+    Attributes:
+        prompt_tokens: Expanded prompt, int64, on GPU. Placeholder spans are materialized as
+            real token ids, so all downstream token accounting (block counts, chunk lengths,
+            `num_tokens_to_generate`) works unchanged.
+        mm_embeddings: `[N_mm, hidden_size]`, params_dtype, on GPU. Encoder rows in the same
+            order as `mm_embed_positions`.
+        mm_embed_positions: `[N_mm]`, int64, on CPU, sorted ascending. Indices into
+            `prompt_tokens` that must receive an encoder row instead of an embedding-table
+            lookup. Kept on CPU so the context can bisect it without a device sync.
+        content_hash: Digest over the decoded media, stable across processes. Reserved for a
+            future prefix-cache extension that chains it into the block hashes.
+    """
+
+    prompt_tokens: torch.Tensor
+    mm_embeddings: torch.Tensor
+    mm_embed_positions: torch.Tensor
+    content_hash: Optional[int] = None
+
+    def __post_init__(self):
+        assert self.mm_embeddings.shape[0] == self.mm_embed_positions.shape[0], (
+            f"{self.mm_embeddings.shape[0]} embedding rows for "
+            f"{self.mm_embed_positions.shape[0]} positions"
+        )
+        assert (
+            self.mm_embed_positions.device.type == "cpu"
+        ), "mm_embed_positions must stay on CPU; the context bisects it on the host"
+        if self.mm_embed_positions.numel() > 0:
+            assert int(self.mm_embed_positions[-1]) < self.prompt_tokens.shape[0], (
+                f"position {int(self.mm_embed_positions[-1])} is past the end of a "
+                f"{self.prompt_tokens.shape[0]}-token prompt"
+            )
+
+
+class MultimodalEmbeddingProvider(abc.ABC):
+    """Turns a text prompt plus raw media into an expanded, encoded prompt.
+
+    Implementations run at request admission, outside the graphed per-step region: encoder
+    output shape varies per request, so running a tower inside the step would break CUDA graph
+    capture and would re-run the tower once per prefill chunk.
+    """
+
+    @abc.abstractmethod
+    def encode(self, prompt: str, multimodal_data: MultimodalData) -> ProcessedMultimodalPrompt:
+        """Expand placeholder spans and run the encoders.
+
+        Args:
+            prompt (str): Raw prompt text, containing the model's media placeholder markers.
+            multimodal_data (MultimodalData): Undecoded media for this request.
+
+        Return:
+            (ProcessedMultimodalPrompt) Expanded tokens plus the encoder rows they need.
+        """
+
+    @property
+    @abc.abstractmethod
+    def hidden_size(self) -> int:
+        """Language-model hidden size the encoder rows are projected to."""

--- a/megatron/core/inference/text_generation_server/dynamic_text_gen_server/endpoints/chat_completions.py
+++ b/megatron/core/inference/text_generation_server/dynamic_text_gen_server/endpoints/chat_completions.py
@@ -231,6 +231,36 @@ def _coerce_arguments_mapping(arguments):
     return {}
 
 
+#: OpenAI content block types that carry media rather than text.
+_MEDIA_BLOCK_TYPES = ("image_url", "video_url", "input_audio")
+
+
+def _find_media_block_types(messages):
+    """Media block types present in a conversation, in first-seen order.
+
+    Used to reject multimodal requests explicitly. `_sanitize_messages_for_template` below
+    flattens content blocks to text and discards media, which for a multimodal model means the
+    request quietly answers about nothing. A 400 is the honest response until media has a
+    transport to the engine: this endpoint tokenizes locally and sends token ids over the
+    coordinator, while placeholder expansion needs the encoder towers, which live engine-side.
+    Callers embedding the engine in-process can pass `multimodal_data` to
+    `DynamicInferenceEngine.add_request` directly.
+    """
+    found = []
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content")
+        if not isinstance(content, (list, tuple)):
+            continue
+        for block in content:
+            if isinstance(block, dict):
+                block_type = block.get("type")
+                if block_type in _MEDIA_BLOCK_TYPES and block_type not in found:
+                    found.append(block_type)
+    return found
+
+
 def _sanitize_messages_for_template(messages):
     """Prepare messages so tokenizer chat templates can safely consume them.
 
@@ -449,6 +479,14 @@ try:
             return Response("Missing 'messages' field", status=400)
         if not isinstance(messages, list):
             return Response("'messages' must be a list", status=400)
+        media_types = _find_media_block_types(messages)
+        if media_types:
+            return Response(
+                f"Multimodal content blocks ({', '.join(media_types)}) are not supported over "
+                "this endpoint: media cannot yet be routed to the engine's encoder towers. Use "
+                "DynamicInferenceEngine.add_request(multimodal_data=...) in-process instead.",
+                status=400,
+            )
         template_messages = _sanitize_messages_for_template(messages)
         template_tools = _sanitize_tools_for_template(tools)
 

--- a/megatron/core/models/audio/parakeet_model.py
+++ b/megatron/core/models/audio/parakeet_model.py
@@ -1,0 +1,137 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+"""Parakeet Conformer audio tower plus its projector, loaded from an Omni checkpoint.
+
+Deliberately not built on `ParakeetHuggingFaceModel`
+(`megatron/core/models/huggingface/fastconformer_model.py`): that wrapper calls
+`AutoModel.from_pretrained` on a *separate* `hf://` or `nemo://` checkpoint, whereas the tower
+here has to be constructed empty and then filled from the Omni checkpoint's `sound_encoder.*`
+tensors. Only the dtype and sampling-rate conventions are shared.
+
+The tower is replicated, not tensor-parallel: it is small relative to the language model, runs
+once per request at admission rather than once per step, and replicating it avoids an
+all-gather on the encoder output.
+"""
+
+from typing import List, Optional
+
+import torch
+
+from megatron.core.inference.multimodal.nemotron_omni.config import SoundConfig
+
+# `transformers.ParakeetEncoder` landed in transformers 5.5.3.
+MIN_TRANSFORMERS_VERSION = "5.5.3"
+
+
+def _build_hf_encoder(config: SoundConfig, dtype: torch.dtype) -> torch.nn.Module:
+    """Instantiate an empty `transformers.ParakeetEncoder` from a `SoundConfig`."""
+    try:
+        from transformers import ParakeetEncoder, ParakeetEncoderConfig
+    except ImportError as exc:
+        import transformers
+
+        raise ImportError(
+            f"Nemotron Omni audio support needs transformers >= {MIN_TRANSFORMERS_VERSION} for "
+            f"ParakeetEncoder; found {getattr(transformers, '__version__', 'unknown')}. Either "
+            "bump the container (see the mcore-build-and-dependency skill) or run the model "
+            "without audio."
+        ) from exc
+
+    hf_config = ParakeetEncoderConfig(
+        hidden_size=config.hidden_size,
+        num_attention_heads=config.num_attention_heads,
+        num_hidden_layers=config.num_hidden_layers,
+        intermediate_size=config.intermediate_size,
+        conv_kernel_size=config.conv_kernel_size,
+        convolution_bias=config.convolution_bias,
+        subsampling_conv_channels=config.subsampling_conv_channels,
+        subsampling_conv_kernel_size=config.subsampling_conv_kernel_size,
+        subsampling_factor=config.subsampling_factor,
+        num_mel_bins=config.num_mel_bins,
+    )
+    return ParakeetEncoder(hf_config).to(dtype)
+
+
+class ParakeetProjection(torch.nn.Module):
+    """`RMSNorm -> Linear -> ReLU^2 -> Linear`, bias-free.
+
+    Replicated rather than tensor-parallel, matching the tower. Kept as plain torch modules so
+    the checkpoint's `sound_projection.*` keys map across without a parallel-layout reindex.
+    """
+
+    def __init__(
+        self, input_size: int, hidden_size: int, output_size: int, eps: float = 1e-5
+    ) -> None:
+        super().__init__()
+        self.norm = torch.nn.RMSNorm(input_size, eps=eps)
+        self.fc1 = torch.nn.Linear(input_size, hidden_size, bias=False)
+        self.fc2 = torch.nn.Linear(hidden_size, output_size, bias=False)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Project encoder output to the language model's hidden size."""
+        hidden_states = self.norm(hidden_states)
+        hidden_states = self.fc1(hidden_states)
+        hidden_states = torch.nn.functional.relu(hidden_states).square()
+        return self.fc2(hidden_states)
+
+
+class ProjectedParakeet(torch.nn.Module):
+    """Parakeet encoder plus projection, trimming each clip to its valid length.
+
+    Args:
+        config (SoundConfig): Audio tower geometry.
+        llm_hidden_size (int): Language model hidden size to project to.
+        projector_hidden_size (int): Projector inner width.
+        dtype (torch.dtype): Parameter dtype. The towers are unquantized even for FP8/NVFP4
+            checkpoints -- the quantized-layer manifest contains no `sound_encoder.*` entries.
+        projector_norm_eps (float): RMSNorm epsilon for the projector.
+    """
+
+    def __init__(
+        self,
+        config: SoundConfig,
+        llm_hidden_size: int,
+        projector_hidden_size: int,
+        dtype: torch.dtype = torch.bfloat16,
+        projector_norm_eps: float = 1e-5,
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.encoder = _build_hf_encoder(config, dtype)
+        self.projection = ParakeetProjection(
+            input_size=config.hidden_size,
+            hidden_size=projector_hidden_size,
+            output_size=llm_hidden_size,
+            eps=projector_norm_eps,
+        ).to(dtype)
+
+    def subsampling_output_length(self, num_frames: torch.Tensor) -> torch.Tensor:
+        """Encoder rows produced from a batch of mel frame counts.
+
+        Delegates to the HF encoder so the device-side trim cannot drift from the host-side
+        token count that `ParakeetAudioProcessor` computed.
+        """
+        return self.encoder._get_subsampling_output_length(num_frames.to(torch.float))
+
+    def forward(
+        self, mel_features: torch.Tensor, attention_mask: Optional[torch.Tensor] = None
+    ) -> List[torch.Tensor]:
+        """Encode a batch of clips and trim each to its valid row count.
+
+        Args:
+            mel_features (torch.Tensor): `[num_clips, max_frames, num_mel_bins]`.
+            attention_mask (Optional[torch.Tensor]): `[num_clips, max_frames]` bool.
+
+        Return:
+            (List[torch.Tensor]) One `[rows, llm_hidden_size]` tensor per clip. Returned
+            unconcatenated because the caller groups clips back into items.
+        """
+        outputs = self.encoder(input_features=mel_features, attention_mask=attention_mask)
+        hidden_states = outputs.last_hidden_state
+        hidden_states = self.projection(hidden_states.to(dtype=self.projection.fc1.weight.dtype))
+
+        if attention_mask is None:
+            return list(hidden_states)
+
+        valid_lengths = self.subsampling_output_length(attention_mask.sum(dim=1))
+        return [hidden_states[i, : int(valid_lengths[i])] for i in range(hidden_states.shape[0])]

--- a/megatron/core/models/gpt/gpt_model.py
+++ b/megatron/core/models/gpt/gpt_model.py
@@ -343,6 +343,15 @@ class GPTModel(LanguageModule):
                     f"input_ids shape {input_ids.shape}"
                 )
             decoder_input = self.embedding(input_ids=input_ids, position_ids=position_ids)
+            # Replace embedding-table rows at multimodal placeholder positions with the
+            # encoder-produced rows staged in the context, before the SP scatter (the staged
+            # rows are indexed by global token position).
+            if (
+                in_inference_mode
+                and inference_context is not None
+                and inference_context.is_dynamic_batching()
+            ):
+                decoder_input = inference_context.apply_multimodal_embeddings(decoder_input)
             if self.config.sequence_parallel and not self.embedding.scatter_to_sequence_parallel:
                 # The embedding skips SP scatter for models whose outer wrapper scatters instead
                 # (e.g. VLM LMs); scatter here so a standalone LM forward isn't double-gathered.

--- a/megatron/core/models/hybrid/hybrid_model.py
+++ b/megatron/core/models/hybrid/hybrid_model.py
@@ -455,6 +455,17 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
         elif self.pre_process:
             decoder_input = self.embedding(input_ids=input_ids, position_ids=position_ids)
 
+            # Replace embedding-table rows at multimodal placeholder positions with the
+            # encoder-produced rows staged in the context. Must run before the padding zero
+            # below (so padding still wins) and before the sequence-parallel scatter (the
+            # staged rows are indexed by global token position).
+            if (
+                in_inference_mode
+                and inference_context is not None
+                and inference_context.is_dynamic_batching()
+            ):
+                decoder_input = inference_context.apply_multimodal_embeddings(decoder_input)
+
             # Clear the outputs for padding tokens when using dynamic batching with
             # quantization scales to avoid corrupting amax calculations
             if (

--- a/megatron/core/models/vision/evs.py
+++ b/megatron/core/models/vision/evs.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+"""Efficient Video Sampling: prune video tokens that repeat the previous frame.
+
+Scores every token by how much it differs from the token at the same spatial position in the
+previous frame, then keeps the most-changed ones. Static regions of a video collapse to a few
+tokens while moving regions survive.
+
+Three details are load-bearing for reproducibility against the reference implementation:
+
+- The first frame's dissimilarity is the literal sentinel `255`, not `+inf`. With `+inf` the
+  stable sort's tie-breaking among first-frame tokens changes, so the retained set differs.
+- The sort is `stable=True` descending. Ties are extremely common (identical static regions),
+  so an unstable sort makes the retained set non-deterministic.
+- Pruning runs *after* the projector, on language-model-dimension embeddings, not on tower
+  features.
+"""
+
+from typing import Tuple, Union
+
+import torch
+
+
+def compute_retained_tokens_count(tokens_per_frame: int, num_frames: int, q: float) -> int:
+    """Number of video tokens to keep.
+
+    Floored at one full frame's worth, so the first frame always survives intact regardless of
+    how aggressive the pruning rate is.
+
+    Args:
+        tokens_per_frame (int): Tokens per frame (or per tubelet).
+        num_frames (int): Number of frames (or tubelets).
+        q (float): Pruning rate in [0, 1); 0.7 discards ~70% of tokens.
+
+    Return:
+        (int) Retained token count.
+    """
+    total_tokens = tokens_per_frame * num_frames
+    return max(tokens_per_frame, int(total_tokens * (1 - q)))
+
+
+def compute_retention_mask(
+    video_embeds: torch.Tensor,
+    video_size_thw: Union[torch.Tensor, Tuple[int, int, int]],
+    q: float,
+    spatial_merge_size: int = 1,
+) -> torch.Tensor:
+    """Select which video tokens to keep.
+
+    Args:
+        video_embeds (torch.Tensor): `[T * H * W // spatial_merge_size**2, hidden]`, already
+            projected to the language model's hidden size.
+        video_size_thw: `(T, H, W)` in post-pixel-shuffle token units.
+        q (float): Pruning rate in [0, 1).
+        spatial_merge_size (int): Further spatial reduction. 1 for Nemotron Omni, whose
+            reduction already happened in pixel shuffle.
+
+    Return:
+        (torch.Tensor) Bool mask over the flattened token axis, True where retained.
+    """
+    num_frames, height, width = (int(v) for v in video_size_thw)
+
+    # reshape rather than einops: this runs under torch.compile in some callers, and einops
+    # forces a graph break.
+    video_embeds = video_embeds.reshape(
+        num_frames, height // spatial_merge_size, width // spatial_merge_size, video_embeds.size(-1)
+    )
+    tokens_per_frame = (height // spatial_merge_size) * (width // spatial_merge_size)
+
+    similarity = torch.nn.functional.cosine_similarity(
+        video_embeds[1:, ...], video_embeds[:-1, ...], dim=-1
+    )
+    dissimilarity = 1 - similarity
+
+    # Sentinel, not infinity -- see the module docstring.
+    dissimilarity = torch.cat(
+        [255 * torch.ones_like(video_embeds[:1, :, :, 0]), dissimilarity], dim=0
+    )
+
+    dissimilarity_flat = dissimilarity.view(-1)
+    order = torch.argsort(dissimilarity_flat, dim=-1, descending=True, stable=True)
+    retain_num_tokens = compute_retained_tokens_count(
+        tokens_per_frame=tokens_per_frame, num_frames=num_frames, q=q
+    )
+
+    retention_mask = torch.zeros_like(dissimilarity_flat, dtype=torch.bool)
+    retention_mask.index_fill_(0, order[:retain_num_tokens], True)
+    return retention_mask

--- a/megatron/core/models/vision/pixel_shuffle.py
+++ b/megatron/core/models/vision/pixel_shuffle.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+"""Pixel shuffle for dynamic-resolution vision features.
+
+Folds a 2x2 spatial neighbourhood of patches into the channel dimension, quartering the token
+count. Element ordering intentionally differs from `llava_model.pixel_shuffle`'s packed
+dynamic-resolution branch, which reshapes 4 horizontally adjacent patches into one token
+instead of a 2x2 block -- a different operation, not a different spelling of the same one.
+This is the version that matches the reference Nemotron Omni implementation and is
+e2e-validated; do not "fix" it to agree with the other one.
+"""
+
+from typing import List, Tuple, Union
+
+import torch
+
+
+def pixel_shuffle_dynamic_res(
+    x: torch.Tensor,
+    imgs_sizes: Union[torch.Tensor, List[Tuple[int, int]]],
+    patch_dim: int,
+    scale_factor: float = 0.5,
+    version: int = 2,
+) -> torch.Tensor:
+    """Apply pixel shuffle per tile across a packed, variable-length sequence.
+
+    Args:
+        x (torch.Tensor): Packed features, `[b, total_patches, hidden]`, class tokens already
+            removed.
+        imgs_sizes: Per-tile `(height, width)` in pixels. Tensor `[num_tiles, 2]` or a list of
+            pairs.
+        patch_dim (int): Patch size in pixels.
+        scale_factor (float): Spatial reduction per axis. 0.5 quarters the token count.
+        version (int): 2 restores row-major ordering after the fold; 1 leaves it transposed.
+
+    Return:
+        (torch.Tensor) `[b, total_patches * scale_factor**2, hidden / scale_factor**2]`.
+    """
+    if not torch.is_tensor(imgs_sizes):
+        imgs_sizes = torch.tensor(imgs_sizes, dtype=torch.long, device=x.device)
+
+    seq_lens = torch.prod(imgs_sizes // patch_dim, dim=-1)
+    splits = torch.split(x, seq_lens.tolist(), dim=-2)
+
+    out = []
+    for i, sv in enumerate(splits):
+        h = int(imgs_sizes[i][0]) // patch_dim
+        w = int(imgs_sizes[i][1]) // patch_dim
+        sv = sv.reshape(sv.shape[0], h, w, -1)
+
+        n, h, w, c = sv.size()
+        sv = sv.view(n, h, int(w * scale_factor), int(c / scale_factor))
+        sv = sv.permute(0, 2, 1, 3).contiguous()
+        sv = sv.view(
+            n, int(w * scale_factor), int(h * scale_factor), int(c / (scale_factor * scale_factor))
+        )
+
+        if version == 2:
+            sv = sv.permute(0, 2, 1, 3).contiguous()
+
+        sv = sv.reshape(sv.shape[0], -1, sv.shape[-1])
+        out.append(sv)
+
+    return torch.cat(out, dim=-2)

--- a/tests/unit_tests/inference/multimodal/__init__.py
+++ b/tests/unit_tests/inference/multimodal/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.

--- a/tests/unit_tests/inference/multimodal/test_multimodal_embedding_contract.py
+++ b/tests/unit_tests/inference/multimodal/test_multimodal_embedding_contract.py
@@ -1,0 +1,281 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+"""The two contracts that make multimodal dynamic inference correct or silently wrong.
+
+1. **Token-count contract.** The host reserves N placeholder slots; the encoders produce N
+   rows. Off by one and every subsequent position shifts, so the language model reads image
+   rows at text positions. Nothing raises -- output just degrades. Covered by driving the
+   tiler and the prompt expander together, which is how they are used.
+
+2. **Chunk-aware injection.** A prefill chunk boundary can land in the middle of an image's
+   token span, and prefix-cache skipping can drop the front of a chunk. The context must pick
+   up exactly the rows whose positions fall in the window it is writing. Covered by scattering
+   across chunk boundaries and checking which rows land where.
+
+Both run on CPU: they are pure index arithmetic, and the point is to catch the arithmetic.
+"""
+
+import pytest
+import torch
+
+from megatron.core.inference.contexts.dynamic_context import DynamicInferenceContext
+from megatron.core.inference.multimodal.nemotron_omni.config import NemotronOmniConfig
+from megatron.core.inference.multimodal.nemotron_omni.image_processor import (
+    DynamicResolutionImageTiler,
+)
+from megatron.core.inference.multimodal.nemotron_omni.prompt import (
+    NemotronOmniPromptExpander,
+    video_frame_separators,
+)
+from megatron.core.models.vision.evs import compute_retained_tokens_count
+
+
+class _FakeTokenizer:
+    """Whitespace tokenizer with reserved ids for the media markers.
+
+    Deliberately merges nothing across boundaries, so any count mismatch the test catches comes
+    from the expander's arithmetic rather than from tokenizer behaviour.
+    """
+
+    SPECIALS = {
+        "<img>": 1,
+        "</img>": 2,
+        "<image>": 3,
+        "<so_start>": 4,
+        "<so_embedding>": 5,
+        "<so_end>": 6,
+    }
+
+    def encode(self, text, add_special_tokens=False):
+        """Map reserved markers to their ids and every other word to a stable hash."""
+        if text in self.SPECIALS:
+            return [self.SPECIALS[text]]
+        return [100 + (hash(word) % 1000) for word in text.split()]
+
+
+@pytest.fixture(name="config")
+def _config():
+    return NemotronOmniConfig()
+
+
+@pytest.fixture(name="expander")
+def _expander(config):
+    return NemotronOmniPromptExpander(_FakeTokenizer(), config)
+
+
+class TestTokenCountContract:
+    """Host-reserved placeholder slots must equal the encoder's row count."""
+
+    @pytest.mark.parametrize(
+        "width, height", [(1024, 768), (768, 1024), (4096, 512), (37, 37), (16, 16), (3000, 2000)]
+    )
+    def test_tiler_grid_is_even_and_within_budget(self, config, width, height):
+        """Every grid tiles exactly under pixel shuffle and respects the shared budget."""
+        tiler = DynamicResolutionImageTiler(
+            patch_size=config.vision.patch_size,
+            min_num_patches=config.vision.min_num_patches,
+            max_num_patches=config.vision.max_num_patches,
+            norm_mean=config.vision.norm_mean,
+            norm_std=config.vision.norm_std,
+        )
+        token_budget = 4096
+        (patch_w, patch_h) = tiler.compute_grids([(width, height)], token_budget)[0]
+
+        # Odd axes would make the 2x2 fold drop a row or column of patches.
+        assert patch_w % 2 == 0 and patch_h % 2 == 0
+        assert patch_w * patch_h <= token_budget * tiler.PATCHES_PER_TOKEN
+        # Never upscaled beyond the source's own patch grid, plus the +0.5 rounding slack.
+        assert patch_w <= round(width / config.vision.patch_size + 0.5)
+        assert patch_h <= round(height / config.vision.patch_size + 0.5)
+
+    def test_shared_budget_shrinks_each_image(self, config):
+        """Adding images reduces the per-image grid rather than overflowing the budget."""
+        tiler = DynamicResolutionImageTiler(
+            patch_size=config.vision.patch_size,
+            min_num_patches=64,
+            max_num_patches=config.vision.max_num_patches,
+            norm_mean=config.vision.norm_mean,
+            norm_std=config.vision.norm_std,
+        )
+        token_budget = 2048
+        sizes = [(1024, 1024)] * 4
+        grids = tiler.compute_grids(sizes, token_budget)
+
+        total_patches = sum(w * h for w, h in grids)
+        assert total_patches <= token_budget * tiler.PATCHES_PER_TOKEN
+
+        solo = tiler.compute_grids([(1024, 1024)], token_budget)[0]
+        assert grids[0][0] * grids[0][1] < solo[0] * solo[1]
+
+    def test_image_span_reserves_exactly_the_encoder_row_count(self, expander, config):
+        """Placeholder slots equal the predicted token count, and land inside the markers."""
+        counts = [12, 5]
+        expanded = expander.expand(
+            "look at <image> and also <image> please", image_token_counts=counts
+        )
+
+        assert len(expanded.embed_positions) == sum(counts)
+        assert expanded.embed_positions == sorted(expanded.embed_positions)
+
+        specials = _FakeTokenizer.SPECIALS
+        for span, count in zip(expanded.spans, counts):
+            assert len(span.embed_positions) == count
+            # Every reserved slot holds the context token, bracketed by the span markers.
+            for pos in span.embed_positions:
+                assert expanded.token_ids[pos] == specials["<image>"]
+            assert expanded.token_ids[span.embed_positions[0] - 1] == specials["<img>"]
+            assert expanded.token_ids[span.embed_positions[-1] + 1] == specials["</img>"]
+
+    def test_interleaved_modalities_keep_prompt_order(self, expander):
+        """Markers are consumed left to right across modalities, not modality by modality."""
+        expanded = expander.expand(
+            "a <so_embedding> b <image> c", image_token_counts=[4], audio_token_counts=[7]
+        )
+
+        assert [span.modality for span in expanded.spans] == ["audio", "image"]
+        assert expanded.embed_positions == sorted(expanded.embed_positions)
+        assert len(expanded.embed_positions) == 11
+
+    def test_placeholder_count_mismatch_is_rejected(self, expander):
+        """A prompt with fewer markers than media items fails loudly, not silently."""
+        with pytest.raises(AssertionError, match="placeholder"):
+            expander.expand("only one <image> here", image_token_counts=[4, 4])
+
+    def test_video_separators_match_tubelet_count(self, config):
+        """One separator per tubelet, including the padded tail tubelet."""
+        temporal = config.vision.video_temporal_patch_size
+        # 5 frames at temporal patch size 2 -> 3 tubelets, the last padded by frame repetition.
+        separators = video_frame_separators(
+            list(range(5)), frame_duration_ms=33, temporal_patch_size=temporal
+        )
+
+        assert len(separators) == 3
+        # Groups after the first are newline-prefixed to match the training format.
+        assert not separators[0].startswith("\n")
+        assert all(sep.startswith("\n") for sep in separators[1:])
+        # Frames within a tubelet are joined, and only the first is capitalized.
+        assert " and frame 2 sampled at" in separators[0]
+
+    def test_video_span_reserves_evs_pruned_counts(self, expander):
+        """After EVS the span must reserve the *retained* counts, not the pre-pruning ones."""
+        tokens_per_frame, num_tubelets, pruning_rate = 256, 8, 0.7
+        retained = compute_retained_tokens_count(tokens_per_frame, num_tubelets, pruning_rate)
+        # EVS keeps at least one full frame, so the first tubelet survives intact.
+        assert retained >= tokens_per_frame
+
+        per_tubelet = [retained - (num_tubelets - 1)] + [1] * (num_tubelets - 1)
+        expanded = expander.expand(
+            "watch <video>",
+            video_plans=[
+                {
+                    "tokens_per_tubelet": per_tubelet,
+                    "separators": [f"Frame {i}: " for i in range(num_tubelets)],
+                }
+            ],
+        )
+
+        assert len(expanded.embed_positions) == retained
+
+
+class TestChunkAwareInjection:
+    """Scatter must select rows by absolute prompt position, not by chunk-relative offset."""
+
+    HIDDEN = 8
+    MAX_TOKENS = 64
+
+    def _context(self):
+        """A context with only the multimodal buffers wired up.
+
+        Bypasses `__init__` deliberately: a real context needs a KV cache, a block allocator,
+        and a distributed group, none of which the scatter arithmetic touches.
+        """
+        context = DynamicInferenceContext.__new__(DynamicInferenceContext)
+        context.enable_multimodal = True
+        context.active_token_count = 0
+        context.mm_token_count = 0
+        context.token_to_mm_embedding = torch.zeros(self.MAX_TOKENS, 1, self.HIDDEN)
+        context.token_to_is_mm = torch.zeros(self.MAX_TOKENS, 1, 1, dtype=torch.bool)
+        return context
+
+    def _request(self, positions):
+        """A stand-in request whose row `i` is filled with the value `i + 1`."""
+        rows = torch.arange(1, len(positions) + 1, dtype=torch.float32)
+        return type(
+            "_Req",
+            (),
+            {
+                "mm_embeddings": rows.unsqueeze(-1).expand(len(positions), self.HIDDEN),
+                "mm_embed_positions": torch.tensor(positions, dtype=torch.int64),
+            },
+        )()
+
+    def test_chunk_boundary_inside_an_image_span(self):
+        """An image split across two chunks contributes its rows to both, in order."""
+        # Rows at prompt positions 4..11; chunks are [0, 8) then [8, 16).
+        positions = list(range(4, 12))
+        request = self._request(positions)
+        context = self._context()
+
+        context.scatter_multimodal_embeddings(request, chunk_start=0, chunk_length=8)
+        assert context.mm_token_count == 4
+        # Positions 4..7 land at slots 4..7 of the first chunk.
+        assert context.token_to_is_mm[:, 0, 0].tolist()[:8] == [False] * 4 + [True] * 4
+        assert context.token_to_mm_embedding[4, 0, 0].item() == 1.0
+        assert context.token_to_mm_embedding[7, 0, 0].item() == 4.0
+
+        # Second chunk: token slots restart at 0 while prompt positions continue at 8.
+        context.clear_multimodal_mask()
+        context.active_token_count = 0
+        context.scatter_multimodal_embeddings(request, chunk_start=8, chunk_length=8)
+        assert context.mm_token_count == 4
+        assert context.token_to_is_mm[:4, 0, 0].tolist() == [True] * 4
+        assert context.token_to_mm_embedding[0, 0, 0].item() == 5.0
+        assert context.token_to_mm_embedding[3, 0, 0].item() == 8.0
+
+    def test_rows_are_offset_by_active_token_count(self):
+        """A prefill chunk appended after decode tokens writes past them."""
+        context = self._context()
+        context.active_token_count = 10
+        request = self._request([0, 1, 2])
+
+        context.scatter_multimodal_embeddings(request, chunk_start=0, chunk_length=4)
+
+        assert context.token_to_is_mm[:10, 0, 0].tolist() == [False] * 10
+        assert context.token_to_is_mm[10:13, 0, 0].tolist() == [True] * 3
+
+    def test_prefix_skip_window_selects_no_rows(self):
+        """A chunk whose window contains no media positions is a no-op."""
+        context = self._context()
+        request = self._request([0, 1, 2])
+
+        context.scatter_multimodal_embeddings(request, chunk_start=8, chunk_length=8)
+
+        assert context.mm_token_count == 0
+        assert not context.token_to_is_mm.any()
+
+    def test_apply_is_identity_when_no_media_is_staged(self):
+        """The masked overwrite runs unconditionally, so an empty mask must not perturb input.
+
+        Guards the CUDA-graph decision: injection is never branched on at the Python level,
+        because a branch resolved at capture time would be frozen for every replay.
+        """
+        context = self._context()
+        decoder_input = torch.randn(16, 1, self.HIDDEN)
+
+        result = context.apply_multimodal_embeddings(decoder_input.clone())
+
+        torch.testing.assert_close(result, decoder_input)
+
+    def test_apply_overwrites_only_masked_rows(self):
+        """Staged rows replace the embedding output exactly at their own positions."""
+        context = self._context()
+        request = self._request([2, 5])
+        context.scatter_multimodal_embeddings(request, chunk_start=0, chunk_length=8)
+
+        decoder_input = torch.zeros(8, 1, self.HIDDEN)
+        result = context.apply_multimodal_embeddings(decoder_input)
+
+        assert result[2, 0, 0].item() == 1.0
+        assert result[5, 0, 0].item() == 2.0
+        untouched = [i for i in range(8) if i not in (2, 5)]
+        assert result[untouched].abs().sum().item() == 0.0


### PR DESCRIPTION
## Read this first

**This code has never been executed.** It was authored on a machine with no
`torch` and no GPU. It is lint-clean and format-clean, and that is the entire
extent of the verification — nothing has been imported, unit-tested, or run
against a checkpoint. Treat every file as a reviewed-by-eye first draft.

This PR is a **handoff**, not a merge candidate. I am moving off this task and
someone else is picking it up. The intent is that the design, the code sketch,
and everything I learned live in one reviewable place rather than in my head.

**Start at [`docs/inference/nemotron_omni/README.md`](docs/inference/nemotron_omni/README.md).**
It is written for exactly this handoff and goes deeper than this description.

## What this adds

Image, video and audio support for Nemotron Omni on `DynamicInferenceEngine` —
paged KV, chunked prefill, CUDA graphs, TP/EP, and the `inference_optimized`
MoE + Mamba stack all intact.

Off by default behind `InferenceConfig.enable_multimodal`. When off, nothing is
allocated and the embedding path is byte-for-byte unchanged, so text-only
deployments are unaffected.

## The core idea

The dynamic path is built around integer token ids. Multimodal embeddings are
dense encoder rows with no token id to look up, which is the whole problem.

The approach is a **masked overwrite into fixed-address buffers**.
`DynamicInferenceContext` allocates `token_to_mm_embedding`
(`[max_tokens, 1, hidden]`) and a parallel bool mask `token_to_is_mm` once, up
front. Right after the embedding lookup the model calls
`inference_context.apply_multimodal_embeddings(decoder_input)` — a single
`torch.where`.

Two properties keep this CUDA-graph-safe, and both are easy to break by
accident:

1. **Buffers are allocated once, never reallocated.** Replay reads
   capture-time addresses.
2. **The overwrite is unconditional** — deliberately *not* guarded on "does
   this step carry multimodal tokens". That branch would be resolved once at
   capture and frozen for every replay, so a step captured without multimodal
   tokens would silently skip injection forever. An all-`False` mask makes it
   an identity op instead. If you want to add an `if` here for performance,
   read §3.2 of the design doc first.

The write side, `scatter_multimodal_embeddings`, is chunk-aware: an image span
can straddle a chunked-prefill boundary, so it bisects the request's
`mm_embed_positions`, which is kept on CPU precisely so that bisect does not
force a device sync.

Encoders run at **request admission**, not per step (§3.1). Encoder output
shape varies per request, so running a tower inside the step would break graph
capture and re-run the tower once per prefill chunk.

The engine depends only on the `MultimodalEmbeddingProvider` interface in
`megatron/core/inference/multimodal/types.py`. Everything Nemotron-Omni-specific
sits behind it, so a second multimodal model should need no engine change.

## Deliberate divergences from vLLM

Full detail in §5 of the design doc. The ones that are *choices*:

| Divergence | Why |
| --- | --- |
| **Batched video encoding** | vLLM sets `requires_sequential_video_encoding = True` and encodes videos one at a time purely because batched dynamic-res video is unimplemented there. mcore's `_apply_temporal_grouping` already handles mixed image/video items in one packed batch. Numerically identical, materially faster. |
| **Prefix caching disabled for multimodal** | Identical prompts with different images would collide on placeholder token ids and produce a false cache hit. Content-hash chaining into block hashes is the real fix; `mm_content_hash` is already plumbed through the request for it. |
| **`video_pruning_rate` follows the checkpoint's `0.7`** | vLLM reads it only from a CLI flag and defaults to `None`, so out of the box vLLM does no EVS pruning at all — ignoring an explicit checkpoint request. See Q3. |
| **LayerScale warns instead of silently dropping** | vLLM `continue`s past `ls1`/`ls2`. mcore's RADIO has no LayerScale at all, so vLLM parity holds for free; both may differ from the HF reference. See Q2. |
| **Mamba SSM state forced to fp32** | |
| **PP asserted to 1** for multimodal | Matches vLLM. Injection is first-pipeline-stage only, not forwarded. |

## Things that will bite whoever picks this up

- **The token-count contract is the whole game.** The host expands placeholder
  spans into token ids; the device produces encoder rows. A disagreement of one
  gives you a shape mismatch far from the cause. §6.1 has the per-modality
  table. Port and test it before anything else.
- **`class_token_len` is 10, not 8** — 4 class tokens + 6 registers, against
  mcore's default of 8. Wrong value strips the wrong number of tokens per image
  and degrades output *silently*. No crash.
- **Two incompatible pixel shuffles exist in this tree.** `llava_model.py`'s
  `h`/`w` branch folds 4 horizontally adjacent patches; the version promoted to
  `megatron/core/models/vision/pixel_shuffle.py` folds a 2×2 spatial block.
  Genuinely different operations. This branch uses 2×2 because vLLM does — but
  see Q1, it is unresolved.
- **Mamba needs `mamba_num_heads=64` set explicitly**, else it is derived from
  `expand: 2`.

## Known gaps

- **The chat completions endpoint returns 400 for multimodal requests.**
  Largest functional gap. The endpoint tokenizes locally and ships token ids
  over ZMQ, which cannot carry raw media, so there is no HTTP path for a
  multimodal request today. In-process `engine.add_request` works. Fixing it
  needs a transport decision (shared memory, side-channel upload, or encoding
  before the ZMQ hop) that I did not make.
- **The Parakeet subsampling length formula was reconstructed from first
  principles**, not verified against `transformers` — the library would not
  install locally. An off-by-N here breaks audio token counts.
- **`transformers >= 5.5.3` required** for `ParakeetEncoder`; `pyproject.toml`
  pins nothing. May be a dependency bump. See Q5.
- **Test coverage is one file** (token-count contract + chunk-aware injection,
  against a fake tokenizer). §6.2 lists seven tests that should exist; five do
  not.

## Open questions

§7.2 has full context. **Q1 blocks correctness** — the rest are smaller.

1. **Q1 — Which pixel shuffle did the checkpoint train with?** vLLM agrees with
   the 2×2 version used here, but if Omni was trained through `LLaVAModel` that
   is wrong and vLLM has a latent bug. The config cannot answer this; it needs
   the training recipe owner. A wrong choice produces plausible-looking but
   degraded output rather than a crash.
2. **Q2 — Are the checkpoint's `ls1`/`ls2` ≈ 1.0?** Needs a `state_dict` dump.
3. **Q3 — `video_pruning_rate`: config's `0.7` or vLLM's `None`?**
4. **Q4 — Image token budget from engine `max_model_len` or HF's `262144`?**
   Following vLLM makes image *resolution* depend on a deployment flag.
5. **Q5 — What `transformers` version does the CI container ship?**
6. **Q6 — Is `sound_timestamps` a real feature?** mcore's `LLaVAModel` threads
   it with no vLLM counterpart.

## Suggested first week

1. Get it to import in the CI container. Expect real breakage.
2. Run and fix `tests/unit_tests/inference/multimodal/`.
3. Port the tiler-parity doctest from
   `vllm/transformers_utils/processors/nano_nemotron_vl.py:290-327` — a
   ready-made fixture that pins the token-count contract.
4. Load a real checkpoint through `checkpoint.py` and diff `state_dict` keys
   against the HF file. Key mismatches surface cheaply here.
5. Get Q1 answered before spending time on numerics.
6. Then chase the oracle cut points in §6.3 in order, (a) → (d).

## Documents included

Under `docs/inference/nemotron_omni/`:

| File | What it is |
| --- | --- |
| `README.md` | The handoff. Start here. |
| `mcore-inference-design.md` | The design this branch implements. All § references above point here. |
| `vllm-reference.md` | Behavioural reference for vLLM's existing Omni support — source of truth for *what the model does*. |
| `checkpoint-config.md` | Resolved checkpoint configuration — source of truth for *numbers*. |

`checkpoint-config.md` cites an external `NEMOTRON_OMNI_MULTIMODAL_DESIGN.md`
that is not in this repo; if you can find it, it may answer some open questions.

## Changes at a glance

Engine-side, modality-agnostic: `config.py` (the `enable_multimodal` flag),
`contexts/dynamic_context.py` (buffers, scatter, masked overwrite),
`contexts/base_context.py` (identity default), `inference_request.py` (the
multimodal payload fields), `engines/dynamic_engine.py` (the encoder hook),
`models/hybrid/hybrid_model.py` and `models/gpt/gpt_model.py` (the one-line
injection call).

Nemotron Omni specifics under
`megatron/core/inference/multimodal/nemotron_omni/`. Shared model code promoted
out of examples into `models/vision/pixel_shuffle.py`, `models/vision/evs.py`,
`models/audio/parakeet_model.py`.

## Test plan

Nothing below has been run. This is the plan, not a record.

- [ ] Imports cleanly in the CI container
- [ ] `tests/unit_tests/inference/multimodal/` passes
- [ ] Text-only dynamic inference unchanged with `enable_multimodal=False`
- [ ] Text-only dynamic inference unchanged with `enable_multimodal=True` (mask all-`False`)
- [ ] CUDA graph capture + replay with differing embedding values at the same addresses
- [ ] Chunked-prefill boundary inside an image span matches the unchunked result
- [ ] Token-count parity against the vLLM tiler doctest
- [ ] Real checkpoint loads and produces sane generations
- [ ] Oracle cut points (a) → (d) against vLLM at a fixed seed