### PR TITLE
[feat] Add reduce-scatter-with-fp32-accumulation support for GTP

### DIFF
--- a/docs/api-guide/core/generalized_tensor_parallel.md
+++ b/docs/api-guide/core/generalized_tensor_parallel.md
@@ -274,7 +274,8 @@ At iter-0 you'll see one rank-0 log line confirming the active config:
 
 ```
 GTP_remat enabled. GTPRematConfig(pad_for_alignment=16, check_param_states=False,
-  weight_prefetch=True, async_reduction=True, calculate_per_token_loss=False)
+  weight_prefetch=True, async_reduction=True, calculate_per_token_loss=False,
+  reduce_scatter_with_fp32_accumulation=False)
 ```
 
 ### 2.4 Tuning knobs
@@ -287,12 +288,37 @@ update_gtp_config(
     weight_prefetch=True,         # Disable to debug the cold-start path
     async_reduction=True,         # Whether to perform GTP_remat gradient reduction asynchronously
     calculate_per_token_loss=False,  # Mirror config.calculate_per_token_loss (SUM vs MEAN RS)
+    reduce_scatter_with_fp32_accumulation=False,  # wgrad RS: BF16 all-to-all + FP32 sum (§2.5)
 )
 ```
 
 `training.py` auto-tunes `pad_for_alignment` based on the quantization recipe (`--fp4`, `--fp8-recipe=mxfp8`, etc.) before model construction. The other knobs are usually left at defaults.
 
 > **CUDA-graph warmup under GTP_remat.** When CUDA graphs are enabled, GTP_remat forces a minimum of **2** per-graph warmup steps regardless of `--cuda-graph-warmup-steps` (e.g. a user-set `0` is bumped to `2`): the first warmup builds the weight-prefetch chain and the second exercises the prefetch path before capture.
+
+### 2.5 FP32-accumulation wgrad reduce-scatter (optional)
+
+```bash
+--gtp-remat-reduce-scatter-with-fp32-accumulation      # default: off
+```
+
+**A ring reduce-scatter rounds the partial sum at every one of its `N-1` hops, so BF16 gradient error compounds with the axis size (≈`√N` for gradient-like data, worse when contributions share a sign). This flag replaces it with an all-to-all plus one local FP32 sum, eliminating that accumulation error for the same bytes on the wire.**
+
+| | |
+|---|---|
+| **Use when** | wgrads are BF16 (the default) **and** the gtp_remat axis is ≥ 4 |
+| **Skip when** | `--accumulate-allreduce-grads-in-fp32` is set, which already makes the wire and the accumulation FP32; or the axis is ≤ 2, where it is auto-bypassed |
+| **Gain** | the `N-1` intermediate roundings disappear, leaving only the final downcast — so the error stops growing with the axis, and the benefit grows with it |
+| **Cost** | one unsharded-wgrad-sized scratch buffer per in-flight reduce-scatter, plus a local FP32 sum and downcast at `wait()` time |
+
+Only the *accumulation* dtype changes: the all-to-all carries the same wgrad dtype and the same byte volume as the ring reduce-scatter it replaces, but the `gtp_remat_size` received contributions are summed in FP32 instead of being rounded back to BF16 after every addition. Implemented in `megatron/core/distributed/reduce_scatter_with_fp32_accumulation.py`. This is the gtp_remat-axis analogue of `--ddp-reduce-scatter-with-fp32-accumulation` and **independent of it** — a different collective over a different process group, so enable either, both, or neither.
+
+**Behaviour notes**
+
+- **Where the mean goes.** Off: `1/gtp_remat` is a pre-scale on the wgrad before a SUM collective (§3.2 table). On: the pre-scale is skipped and the factor is handed to the collective (`scale`) so it lands on the FP32 sum — pre-scaling in BF16 would round every contribution on the way in, discarding the precision this flag exists to preserve. Under `calculate_per_token_loss` the axis SUMs and no factor applies either way.
+- **Auto-bypass at axis size ≤ 2.** Two addends is a single addition, and rounding its exact FP32 result gives the same bits as accumulating in BF16 — so at size 2 the flag cannot change the result, only add the scratch buffer's cost. The gate reads the per-chain group, so each axis decides independently: a `GTP_remat=8 × EGTP_remat=2` run gets FP32 accumulation on the dense weights and the plain reduce-scatter on the experts.
+- **Scratch lifetime.** The buffer comes from GTP's wgrad pool rather than a fresh `empty_like` — GTP keeps several reduce-scatters in flight, and per-RS allocation would add that much peak memory. It is the *input* to the deferred FP32 sum, so it is returned only after the handle is waited: in `_wait_reduce_scatter` for an async RS, immediately after the wait for a sync one.
+- **Batched (grouped / routed-expert) path.** The all-to-alls are grouped in a `_coalescing_manager` just like the plain batched reduce-scatter — one `ncclGroupStart/End` instead of one launch per weight. Only the handle differs: the manager waits solely the NCCL work it collects, while each fp32-accum handle still owes a local FP32 sum, so the sums are deferred behind the manager's work in one composite handle. Hence the all-to-alls must be issued with `async_op=True` — for this primitive that flag is what defers the sum, not merely what returns a handle. (DDP's own fp32-accumulation flag sidesteps all of this by asserting a single bucket.)
 
 ---
 
@@ -430,6 +456,7 @@ The DP collective only covers the replicate axis; the gtp_remat axis is complete
 | final normalization | net grad = full `(replicate × gtp_remat)` **mean** | grads summed over all axes, then `÷ total_global_tokens` in `finalize_model_grads` |
 
 - **Default (mean) path** decouples gradient scaling from the gtp_remat degree: the DP `1/replicate` mean × the reduce-scatter `1/gtp_remat` mean (sharded weights) — or × the finalize AVG (replicated params) — equals the exact full mean, independent of the gtp_remat axis size.
+- **`--gtp-remat-reduce-scatter-with-fp32-accumulation` moves the mean** from a BF16 pre-scale on the wgrad to the FP32 sum inside the collective. The net scaling in the table is unchanged — only the precision at which the factor is applied (§2.5).
 - **Per-token-loss path** must SUM over gtp_remat (like the DP axis): `total_global_tokens` already counts the gtp_remat peers' distinct tokens, so the single `÷ total_global_tokens` does all normalization. A `1/gtp_remat` mean here would shrink every gtp_remat gradient by `1/gtp_remat` (grad-norm mismatch + divergence), so the reduce-scatter mean and finalize AVG are both gated on `not calculate_per_token_loss`.
 
 > **`average_in_collective` must be off (the default).** The default-path scaling is a *pre-scale* applied before a SUM collective. `average_in_collective=True` instead uses NCCL AVG over the collective's own (replicate) group, which interacts incorrectly with the gtp_remat completion. Asserted via `ProcessGroupCollection.is_gtp_remat_active` in both `arguments.py` (training) and `DistributedDataParallel.__init__` (direct megatron-core users). (Independently, `calculate_per_token_loss` already forbids `average_in_collective`.)
@@ -551,10 +578,12 @@ torchrun --nproc-per-node 4 -m pytest tests/unit_tests/generalized_tensor_parall
 | `test_tp_gtp.py` | GTP_remat composed with tensor parallelism (`tp_group × gtp_remat_group`). |
 | `test_moe_egtp.py` | EGTP_remat on MoE routed-expert weights. |
 | `test_gtp_loss_correctness.py` | End-to-end: GTP_remat per-step loss trajectory matches a no-GTP_remat baseline. |
-| `test_gtp_grad_correctness.py` | Gradient + dist-opt + grad-norm numeric parity vs a DP baseline at replicate (DP) > 1. |
+| `test_gtp_grad_correctness.py` | Gradient + dist-opt + grad-norm numeric parity vs a DP baseline at replicate (DP) > 1. Also the fp32-accumulation reduce-scatter (§2.5): gtp_remat-axis and DDP-axis parity, plus the size-2 bypass. |
 | `test_gtp_cudagraph_grad.py` | Capture-step grad-norm guard (§1.2): `_backup_grads_before_capture`/`_restore_grads_after_capture` keep a graph capture from clobbering finalized `main_grad` (own params + cross-graph `next_w`, incl. routed-expert `weight_list`). |
 | `test_gtp_dcp.py` | DCP sharding metadata (§3.3): TP×GTP_remat offsets, pad reshard, `replica_id`, native-FP8 save/load. |
 | `test_gtp_muon_dcp.py` | Muon optimizer-state DCP roundtrip (§1.6): `replica_id` fold + native-FP8 backfill matching. |
 | `test_gtp_fp8_param_gather.py` | Native-FP8 GTP_remat (§1.3): fp8-vs-BF16 loss parity (TP1/TP2, MoE), post-save-spike guard. |
+
+The fp32-accumulation primitive itself is covered outside this suite, by `tests/unit_tests/distributed/test_reduce_scatter_with_fp32_accumulation.py`, which does not require GTP_remat.
 
 All tests require ≥ 4 GPUs and TransformerEngine >= 2.19; they self-skip when those are unavailable. A green run (skips for unmet hardware/config are acceptable) is the minimum bar for any GTP_remat change.

--- a/docs/api-guide/core/generalized_tensor_parallel.md
+++ b/docs/api-guide/core/generalized_tensor_parallel.md
@@ -311,14 +311,26 @@ update_gtp_config(
 | **Gain** | the `N-1` intermediate roundings disappear, leaving only the final downcast — so the error stops growing with the axis, and the benefit grows with it |
 | **Cost** | one unsharded-wgrad-sized scratch buffer per in-flight reduce-scatter, plus a local FP32 sum and downcast at `wait()` time |
 
-Only the *accumulation* dtype changes: the all-to-all carries the same wgrad dtype and the same byte volume as the ring reduce-scatter it replaces, but the `gtp_remat_size` received contributions are summed in FP32 instead of being rounded back to BF16 after every addition. Implemented in `megatron/core/distributed/reduce_scatter_with_fp32_accumulation.py`. This is the gtp_remat-axis analogue of `--ddp-reduce-scatter-with-fp32-accumulation` and **independent of it** — a different collective over a different process group, so enable either, both, or neither.
+Implemented in `megatron/core/distributed/reduce_scatter_with_fp32_accumulation.py`. This is the
+gtp_remat-axis analogue of `--ddp-reduce-scatter-with-fp32-accumulation` and **independent of
+it** — a different collective over a different process group, so enable either, both, or neither.
 
 **Behaviour notes**
 
-- **Where the mean goes.** Off: `1/gtp_remat` is a pre-scale on the wgrad before a SUM collective (§3.2 table). On: the pre-scale is skipped and the factor is handed to the collective (`scale`) so it lands on the FP32 sum — pre-scaling in BF16 would round every contribution on the way in, discarding the precision this flag exists to preserve. Under `calculate_per_token_loss` the axis SUMs and no factor applies either way.
-- **Auto-bypass at axis size ≤ 2.** Two addends is a single addition, and rounding its exact FP32 result gives the same bits as accumulating in BF16 — so at size 2 the flag cannot change the result, only add the scratch buffer's cost. The gate reads the per-chain group, so each axis decides independently: a `GTP_remat=8 × EGTP_remat=2` run gets FP32 accumulation on the dense weights and the plain reduce-scatter on the experts.
-- **Scratch lifetime.** The buffer comes from GTP's wgrad pool rather than a fresh `empty_like` — GTP keeps several reduce-scatters in flight, and per-RS allocation would add that much peak memory. It is the *input* to the deferred FP32 sum, so it is returned only after the handle is waited: in `_wait_reduce_scatter` for an async RS, immediately after the wait for a sync one.
-- **Batched (grouped / routed-expert) path.** The all-to-alls are grouped in a `_coalescing_manager` just like the plain batched reduce-scatter — one `ncclGroupStart/End` instead of one launch per weight. Only the handle differs: the manager waits solely the NCCL work it collects, while each fp32-accum handle still owes a local FP32 sum, so the sums are deferred behind the manager's work in one composite handle. Hence the all-to-alls must be issued with `async_op=True` — for this primitive that flag is what defers the sum, not merely what returns a handle. (DDP's own fp32-accumulation flag sidesteps all of this by asserting a single bucket.)
+- **The mean stays a pre-scale.** Both paths apply `1/gtp_remat` to the wgrad before the
+  collective (§3.2 table); under `calculate_per_token_loss` the axis SUMs and no factor
+  applies either way.
+- **Auto-bypass at axis size ≤ 2.** The gate reads the per-chain group, so each axis decides
+  independently: a `GTP_remat=8 × EGTP_remat=2` run gets FP32 accumulation on the dense weights
+  and the plain reduce-scatter on the experts.
+- **Scratch lifetime.** The buffer comes from GTP's wgrad pool rather than a fresh `empty_like`,
+  and is returned only once the handle is waited — it is the *input* to the deferred FP32 sum.
+- **Batched (grouped / routed-expert) path.** The all-to-alls share one `ncclGroupStart/End` via
+  `_coalescing_manager`, but the manager cannot serve as the handle: it waits only the NCCL work
+  it collects, while each fp32-accum handle still owes a local FP32 sum. The sums are deferred
+  behind it in one composite handle — which is why the all-to-alls are issued with
+  `async_op=True`: for this primitive that flag defers the sum, it does not merely return a
+  handle. (DDP's own flag sidesteps all this by asserting a single bucket.)
 
 ---
 
@@ -456,7 +468,8 @@ The DP collective only covers the replicate axis; the gtp_remat axis is complete
 | final normalization | net grad = full `(replicate × gtp_remat)` **mean** | grads summed over all axes, then `÷ total_global_tokens` in `finalize_model_grads` |
 
 - **Default (mean) path** decouples gradient scaling from the gtp_remat degree: the DP `1/replicate` mean × the reduce-scatter `1/gtp_remat` mean (sharded weights) — or × the finalize AVG (replicated params) — equals the exact full mean, independent of the gtp_remat axis size.
-- **`--gtp-remat-reduce-scatter-with-fp32-accumulation` moves the mean** from a BF16 pre-scale on the wgrad to the FP32 sum inside the collective. The net scaling in the table is unchanged — only the precision at which the factor is applied (§2.5).
+- **`--gtp-remat-reduce-scatter-with-fp32-accumulation` swaps the collective, not the scaling**
+  — this table applies unchanged (§2.5).
 - **Per-token-loss path** must SUM over gtp_remat (like the DP axis): `total_global_tokens` already counts the gtp_remat peers' distinct tokens, so the single `÷ total_global_tokens` does all normalization. A `1/gtp_remat` mean here would shrink every gtp_remat gradient by `1/gtp_remat` (grad-norm mismatch + divergence), so the reduce-scatter mean and finalize AVG are both gated on `not calculate_per_token_loss`.
 
 > **`average_in_collective` must be off (the default).** The default-path scaling is a *pre-scale* applied before a SUM collective. `average_in_collective=True` instead uses NCCL AVG over the collective's own (replicate) group, which interacts incorrectly with the gtp_remat completion. Asserted via `ProcessGroupCollection.is_gtp_remat_active` in both `arguments.py` (training) and `DistributedDataParallel.__init__` (direct megatron-core users). (Independently, `calculate_per_token_loss` already forbids `average_in_collective`.)

--- a/megatron/core/distributed/reduce_scatter_with_fp32_accumulation.py
+++ b/megatron/core/distributed/reduce_scatter_with_fp32_accumulation.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 
 
-from typing import Any
+from typing import Any, Optional
 
 import torch
 
@@ -16,12 +16,14 @@ class _ReduceScatterWithFP32AccumulationWorkHandle:
         all_to_all_output_tensor: torch.Tensor,
         output_tensor: torch.Tensor,
         world_size: int,
+        scale: Optional[float] = None,
     ):
         """Initialize WorkHandle object."""
         self.all_to_all_handle = all_to_all_handle
         self.all_to_all_output_tensor = all_to_all_output_tensor
         self.output_tensor = output_tensor
         self.world_size = world_size
+        self.scale = scale
 
     def wait(self):
         """Wait until communication (and associated computation) is completed."""
@@ -35,8 +37,13 @@ class _ReduceScatterWithFP32AccumulationWorkHandle:
         )
         assert output_tensor_in_fp32.dtype == torch.float32
 
+        # Apply the mean/normalization factor while still in fp32; scaling the low-precision
+        # input beforehand would round away the precision this implementation preserves.
+        if self.scale is not None:
+            output_tensor_in_fp32 *= self.scale
+
         # Copy downcasted sum into output_tensor.
-        self.output_tensor.copy_(output_tensor_in_fp32)
+        self.output_tensor.copy_(output_tensor_in_fp32.view(self.output_tensor.shape))
 
 
 def reduce_scatter_with_fp32_accumulation(
@@ -45,6 +52,8 @@ def reduce_scatter_with_fp32_accumulation(
     op: torch.distributed.ReduceOp,
     group: torch.distributed.ProcessGroup,
     async_op: bool,
+    scale: Optional[float] = None,
+    all_to_all_output_tensor: Optional[torch.Tensor] = None,
 ):
     """Reduce-scatter with FP32 accumulation.
 
@@ -58,6 +67,11 @@ def reduce_scatter_with_fp32_accumulation(
         op (torch.distributed.ReduceOp): Only torch.distributed.ReduceOp.SUM is supported.
         group (torch.distributed.ProcessGroup): Process group to use for reduce-scatter.
         async_op (bool): Only False is supported right now.
+        scale (float, optional): Factor applied to the FP32 sum before the downcast. Use this
+            for a mean-reduction rather than pre-scaling input_tensor, which rounds on the way in.
+        all_to_all_output_tensor (torch.Tensor, optional): Caller-provided scratch matching
+            input_tensor's shape and dtype, for callers with their own buffer pool. Allocated
+            internally when omitted; must stay alive until .wait() returns.
     """
     # Make sure arguments conform to the implementation.
     assert op == torch.distributed.ReduceOp.SUM
@@ -74,14 +88,21 @@ def reduce_scatter_with_fp32_accumulation(
     # Call all_to_all (every rank should have their respective gradient shards collected from
     # all ranks). We also create a tensor for the all-to-all output (the all-to-all collective
     # cannot be performed in-place).
-    all_to_all_output_tensor = torch.empty_like(input_tensor)
+    if all_to_all_output_tensor is None:
+        all_to_all_output_tensor = torch.empty_like(input_tensor)
+    else:
+        assert all_to_all_output_tensor.shape == input_tensor.shape, (
+            f"all_to_all_output_tensor shape {tuple(all_to_all_output_tensor.shape)} does not "
+            f"match input_tensor shape {tuple(input_tensor.shape)}"
+        )
+        assert all_to_all_output_tensor.dtype == input_tensor.dtype
     all_to_all_handle = torch.distributed.all_to_all_single(
         output=all_to_all_output_tensor, input=input_tensor, group=group, async_op=async_op
     )
 
     # Create a work handle to finish communication and reduction.
     reduce_scatter_handle = _ReduceScatterWithFP32AccumulationWorkHandle(
-        all_to_all_handle, all_to_all_output_tensor, output_tensor, world_size
+        all_to_all_handle, all_to_all_output_tensor, output_tensor, world_size, scale=scale
     )
     if async_op:
         # Return work handle; consumers can call .wait() to ensure communication and associated

--- a/megatron/core/distributed/reduce_scatter_with_fp32_accumulation.py
+++ b/megatron/core/distributed/reduce_scatter_with_fp32_accumulation.py
@@ -16,14 +16,12 @@ class _ReduceScatterWithFP32AccumulationWorkHandle:
         all_to_all_output_tensor: torch.Tensor,
         output_tensor: torch.Tensor,
         world_size: int,
-        scale: Optional[float] = None,
     ):
         """Initialize WorkHandle object."""
         self.all_to_all_handle = all_to_all_handle
         self.all_to_all_output_tensor = all_to_all_output_tensor
         self.output_tensor = output_tensor
         self.world_size = world_size
-        self.scale = scale
 
     def wait(self):
         """Wait until communication (and associated computation) is completed."""
@@ -37,11 +35,6 @@ class _ReduceScatterWithFP32AccumulationWorkHandle:
         )
         assert output_tensor_in_fp32.dtype == torch.float32
 
-        # Apply the mean/normalization factor while still in fp32; scaling the low-precision
-        # input beforehand would round away the precision this implementation preserves.
-        if self.scale is not None:
-            output_tensor_in_fp32 *= self.scale
-
         # Copy downcasted sum into output_tensor.
         self.output_tensor.copy_(output_tensor_in_fp32.view(self.output_tensor.shape))
 
@@ -52,7 +45,6 @@ def reduce_scatter_with_fp32_accumulation(
     op: torch.distributed.ReduceOp,
     group: torch.distributed.ProcessGroup,
     async_op: bool,
-    scale: Optional[float] = None,
     all_to_all_output_tensor: Optional[torch.Tensor] = None,
 ):
     """Reduce-scatter with FP32 accumulation.
@@ -67,8 +59,6 @@ def reduce_scatter_with_fp32_accumulation(
         op (torch.distributed.ReduceOp): Only torch.distributed.ReduceOp.SUM is supported.
         group (torch.distributed.ProcessGroup): Process group to use for reduce-scatter.
         async_op (bool): Only False is supported right now.
-        scale (float, optional): Factor applied to the FP32 sum before the downcast. Use this
-            for a mean-reduction rather than pre-scaling input_tensor, which rounds on the way in.
         all_to_all_output_tensor (torch.Tensor, optional): Caller-provided scratch matching
             input_tensor's shape and dtype, for callers with their own buffer pool. Allocated
             internally when omitted; must stay alive until .wait() returns.
@@ -102,7 +92,7 @@ def reduce_scatter_with_fp32_accumulation(
 
     # Create a work handle to finish communication and reduction.
     reduce_scatter_handle = _ReduceScatterWithFP32AccumulationWorkHandle(
-        all_to_all_handle, all_to_all_output_tensor, output_tensor, world_size, scale=scale
+        all_to_all_handle, all_to_all_output_tensor, output_tensor, world_size
     )
     if async_op:
         # Return work handle; consumers can call .wait() to ensure communication and associated

--- a/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
+++ b/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
@@ -1551,7 +1551,7 @@ class GTPShardedParam(torch.nn.Parameter):
         """Release the buffers a finished RS was reading.
 
         Its wgrad inputs, and the fp32-accum all-to-all scratch (input to the deferred FP32 sum,
-        so only free once the handle has been waited). UNGRAPHED buffers go back to the pool;
+        so only free once the handle has been waited on). UNGRAPHED buffers go back to the pool;
         GRAPHED just drops Python refs (addresses must stay stable for CG).
         """
         for attr in attrs:
@@ -1664,9 +1664,9 @@ class GTPShardedParam(torch.nn.Parameter):
                 if len(wgrads) > 1:
                     # Batched: group the all-to-alls into one ncclGroupStart/End, exactly like
                     # the plain batched RS below. Unlike that path we cannot hand the manager
-                    # back as the handle: the manager waits only the NCCL work it collects, and
-                    # each fp32-accum handle still owes a local FP32 sum. So the sums are
-                    # deferred behind the manager's work in one composite handle.
+                    # back as the handle: the manager waits only on the underlying NCCL collective
+                    # to complete, and each fp32-accum handle still owes a local FP32 sum. So the
+                    # sums are deferred behind the manager's work in one composite handle.
                     with torch.distributed._coalescing_manager(
                         group=self.group, device=wgrads[0].device, async_ops=True
                     ) as cm:

--- a/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
+++ b/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
@@ -316,6 +316,18 @@ def _wgrad_pool_put(buf: torch.Tensor):
     _wgrad_buf_pool[key].append(buf)
 
 
+class _GTPCompositeWorkHandle:
+    """Waits on several collective handles as one, so GTPShardHandle still sees one handle."""
+
+    def __init__(self, handles):
+        self.handles = [h for h in handles if h is not None]
+
+    def wait(self):
+        """Wait on every underlying handle, in issue order."""
+        for handle in self.handles:
+            handle.wait()
+
+
 def _stream_key(chain_id: str, group) -> tuple:
     """Key for the per-(chain, group) AG/RS stream dicts.
 
@@ -389,6 +401,10 @@ class GTPRematConfig:
     # normalization. When False, the gtp_remat reduce-scatter takes the MEAN so it composes with
     # DDP's 1/replicate scaling to yield the full (replicate x gtp) mean.
     calculate_per_token_loss: bool = False
+    # Run the gtp_remat wgrad reduce-scatter as all-to-all + local FP32 sum: same bytes on the
+    # wire, but accumulation no longer loses precision as the axis grows. Bypassed at axis size
+    # <= 2. Independent of the DDP-axis --ddp-reduce-scatter-with-fp32-accumulation.
+    reduce_scatter_with_fp32_accumulation: bool = False
 
 
 GTP_CONFIG = GTPRematConfig()
@@ -414,7 +430,12 @@ def tag_gtp_params_with_names(model):
 
 
 def configure_gtp_remat_from_recipe(
-    *, fp4=False, fp8_recipe=None, fp8=False, calculate_per_token_loss=False
+    *,
+    fp4=False,
+    fp8_recipe=None,
+    fp8=False,
+    calculate_per_token_loss=False,
+    reduce_scatter_with_fp32_accumulation=False,
 ):
     """
     Configure GTP weight-remat (padding + loss reduction) from the quantization recipe.
@@ -423,7 +444,11 @@ def configure_gtp_remat_from_recipe(
     # gtp_remat grad reduction SUMs (not means) the gtp_remat axis under per-token-loss.
     # check_param_states=False: GTP buffer reuse (notably under CUDA-graph capture) trips the
     # param-state debug asserts, so keep them off for GTP runs.
-    update_gtp_config(calculate_per_token_loss=calculate_per_token_loss, check_param_states=False)
+    update_gtp_config(
+        calculate_per_token_loss=calculate_per_token_loss,
+        check_param_states=False,
+        reduce_scatter_with_fp32_accumulation=reduce_scatter_with_fp32_accumulation,
+    )
     if fp4:
         update_gtp_config(pad_for_alignment=16)
     elif fp8_recipe == "mxfp8":
@@ -829,6 +854,7 @@ def _init_gtp_runtime_attrs(obj):
     obj._wgrad_rs_handle = None
     obj.rs_event = torch.cuda.Event(external=True)
     obj._rs_ticket = None
+    obj._rs_a2a_bufs = None  # all-to-all scratch held by an in-flight fp32-accum RS
     # Padding
     obj.pad_length = 0
     # Debug
@@ -1519,13 +1545,23 @@ class GTPShardedParam(torch.nn.Parameter):
                     for w in self._weights:
                         self._handle_megatron_grad_accum(w)
                     self._already_finalized = True
-        # Release stashed wgrad inputs: UNGRAPHED buffers go back to the pool;
-        # GRAPHED just drops Python refs (addresses must stay stable for CG).
-        if getattr(self, "_wgrad_input_bufs", None) is not None:
+        self._release_comm_scratch()
+
+    def _release_comm_scratch(self, attrs=("_wgrad_input_bufs", "_rs_a2a_bufs")):
+        """Release the buffers a finished RS was reading.
+
+        Its wgrad inputs, and the fp32-accum all-to-all scratch (input to the deferred FP32 sum,
+        so only free once the handle has been waited). UNGRAPHED buffers go back to the pool;
+        GRAPHED just drops Python refs (addresses must stay stable for CG).
+        """
+        for attr in attrs:
+            bufs = getattr(self, attr, None)
+            if bufs is None:
+                continue
             if not _chain_is_graphed(self.chain_id):
-                for buf in self._wgrad_input_bufs:
+                for buf in bufs:
                     _wgrad_pool_put(buf)
-            self._wgrad_input_bufs = None
+            setattr(self, attr, None)
 
     def _prescale_wgrads_for_mean_rs(self, wgrads):
         """Pre-scale wgrad by 1/gtp_remat so the SUM reduce-scatter yields the gtp_remat mean.
@@ -1536,9 +1572,51 @@ class GTPShardedParam(torch.nn.Parameter):
         counts gtp_remat peers' tokens) normalizes instead — there the gtp_remat axis must SUM
         like the DP axis (a 1/gtp_remat mean would shrink every gtp_remat grad).
         """
+        scale = self._mean_rs_scale()
+        if scale is not None:
+            torch._foreach_mul_(list(wgrads), scale)
+
+    def _mean_rs_scale(self):
+        """The 1/gtp_remat mean factor for the wgrad RS, or None when the axis must SUM."""
         gtp_remat_size = self.group.size()
         if gtp_remat_size > 1 and not GTP_CONFIG.calculate_per_token_loss:
-            torch._foreach_mul_(list(wgrads), 1.0 / gtp_remat_size)
+            return 1.0 / gtp_remat_size
+        return None
+
+    def _reduce_scatter_fp32_accum(self, tensor, out_buffer, scale):
+        """Issue one fp32-accum reduce-scatter (all-to-all now, FP32 sum at wait) -> (out, handle).
+
+        Always issued async, even for a sync RS: under a coalescing manager the all-to-all is
+        only enqueued at context exit, so the handle's FP32 sum must never run inline here. The
+        caller waits the handle (immediately when sync) and then releases the scratch.
+
+        The all-to-all scratch is unsharded-sized, so it comes from the wgrad pool: GTP keeps
+        several RS in flight and an empty_like each would add that much peak memory.
+        """
+        # Local import: tensor_parallel has no top-level dependency on core.distributed.
+        from megatron.core.distributed.reduce_scatter_with_fp32_accumulation import (
+            reduce_scatter_with_fp32_accumulation,
+        )
+
+        tensor = tensor.contiguous()
+        if out_buffer is None:
+            out_shape = [tensor.shape[0] // self.group.size(), *tensor.shape[1:]]
+            out_buffer = torch.empty(out_shape, dtype=tensor.dtype, device=tensor.device)
+
+        a2a_buf = _wgrad_pool_get(tuple(tensor.shape), tensor.dtype, tensor.device)
+        handle = reduce_scatter_with_fp32_accumulation(
+            out_buffer,
+            tensor,
+            op=torch.distributed.ReduceOp.SUM,
+            group=self.group,
+            async_op=True,
+            scale=scale,
+            all_to_all_output_tensor=a2a_buf,
+        )
+        # Input to the deferred FP32 sum: held until the handle is waited on, then released by
+        # _release_comm_scratch (from _wait_reduce_scatter, or inline on the sync path).
+        self._rs_a2a_bufs = (self._rs_a2a_bufs or []) + [a2a_buf]
+        return out_buffer, handle
 
     def _reduce_scatter(self, wgrads, async_op, nvtx_label=None):
         """Reduce-scatter one or more wgrads → (outputs, handle). Single tensor: plain RS;
@@ -1546,8 +1624,18 @@ class GTPShardedParam(torch.nn.Parameter):
         if nvtx_label is None:
             nvtx_label = self._debug_name + ".bwd" + (".async" if async_op else ".sync")
 
-        # MEAN reduce-scatter: pre-scale wgrad so the SUM collective yields the gtp_remat mean.
-        self._prescale_wgrads_for_mean_rs(wgrads)
+        # Size <= 2 bypasses fp32-accum: one addition rounds the same either way, so it would
+        # buy nothing and still cost the all-to-all scratch. self.group is per chain, so each
+        # axis decides on its own (GTP_remat=8 x EGTP_remat=2 -> fp32-accum on dense only).
+        use_fp32_accum = GTP_CONFIG.reduce_scatter_with_fp32_accumulation and self.group.size() > 2
+        if use_fp32_accum:
+            # Pass the mean to the collective so it lands on the FP32 sum; pre-scaling the
+            # low-precision wgrad here would round away what fp32-accum is meant to preserve.
+            rs_scale = self._mean_rs_scale()
+        else:
+            rs_scale = None
+            # MEAN reduce-scatter: pre-scale wgrad so the SUM collective yields the gtp_remat mean.
+            self._prescale_wgrads_for_mean_rs(wgrads)
 
         if GTP_CONFIG.check_param_states:
             new_rs_state = GTPWeightState.ASYNC_WAIT if async_op else GTPWeightState.DATA_READY_SYNC
@@ -1586,6 +1674,42 @@ class GTPShardedParam(torch.nn.Parameter):
             rs_ctx = nullcontext()
 
         with rs_ctx:
+            if use_fp32_accum:
+                nvtx_range_push(f"{nvtx_label}.gtp_rs_fp32accum")
+                outputs, sum_handles = [], []
+                if len(wgrads) > 1:
+                    # Batched: group the all-to-alls into one ncclGroupStart/End, exactly like
+                    # the plain batched RS below. Unlike that path we cannot hand the manager
+                    # back as the handle: the manager waits only the NCCL work it collects, and
+                    # each fp32-accum handle still owes a local FP32 sum. So the sums are
+                    # deferred behind the manager's work in one composite handle.
+                    with torch.distributed._coalescing_manager(
+                        group=self.group, device=wgrads[0].device, async_ops=True
+                    ) as cm:
+                        for out_buffer, tensor in zip(out_buffers, wgrads):
+                            out, h = self._reduce_scatter_fp32_accum(tensor, out_buffer, rs_scale)
+                            outputs.append(out)
+                            sum_handles.append(h)
+                    # The grouped work from _end_coalescing is the real completion; the per-op
+                    # handles returned inside the region are not, so drop them and let cm wait.
+                    for h in sum_handles:
+                        h.all_to_all_handle = None
+                    handle = _GTPCompositeWorkHandle([cm, *sum_handles])
+                else:
+                    out, handle = self._reduce_scatter_fp32_accum(
+                        wgrads[0], out_buffers[0], rs_scale
+                    )
+                    outputs.append(out)
+                nvtx_range_pop(f"{nvtx_label}.gtp_rs_fp32accum")
+                if async_op:
+                    return outputs, handle
+                # Sync RS: the FP32 sums were deferred out of the issue loop, so finish here.
+                # Only the a2a scratch is ours to release — the wgrad inputs belong to the
+                # caller on this path (recycled in wgrad_reduce_scatter).
+                handle.wait()
+                self._release_comm_scratch(("_rs_a2a_bufs",))
+                return outputs, None
+
             if len(wgrads) == 1:
                 nvtx_range_push(f"{nvtx_label}.gtp_rs")
                 out, handle = reduce_scatter_along_first_dim(

--- a/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
+++ b/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
@@ -1572,18 +1572,11 @@ class GTPShardedParam(torch.nn.Parameter):
         counts gtp_remat peers' tokens) normalizes instead — there the gtp_remat axis must SUM
         like the DP axis (a 1/gtp_remat mean would shrink every gtp_remat grad).
         """
-        scale = self._mean_rs_scale()
-        if scale is not None:
-            torch._foreach_mul_(list(wgrads), scale)
-
-    def _mean_rs_scale(self):
-        """The 1/gtp_remat mean factor for the wgrad RS, or None when the axis must SUM."""
         gtp_remat_size = self.group.size()
         if gtp_remat_size > 1 and not GTP_CONFIG.calculate_per_token_loss:
-            return 1.0 / gtp_remat_size
-        return None
+            torch._foreach_mul_(list(wgrads), 1.0 / gtp_remat_size)
 
-    def _reduce_scatter_fp32_accum(self, tensor, out_buffer, scale):
+    def _reduce_scatter_fp32_accum(self, tensor, out_buffer):
         """Issue one fp32-accum reduce-scatter (all-to-all now, FP32 sum at wait) -> (out, handle).
 
         Always issued async, even for a sync RS: under a coalescing manager the all-to-all is
@@ -1610,7 +1603,6 @@ class GTPShardedParam(torch.nn.Parameter):
             op=torch.distributed.ReduceOp.SUM,
             group=self.group,
             async_op=True,
-            scale=scale,
             all_to_all_output_tensor=a2a_buf,
         )
         # Input to the deferred FP32 sum: held until the handle is waited on, then released by
@@ -1624,18 +1616,8 @@ class GTPShardedParam(torch.nn.Parameter):
         if nvtx_label is None:
             nvtx_label = self._debug_name + ".bwd" + (".async" if async_op else ".sync")
 
-        # Size <= 2 bypasses fp32-accum: one addition rounds the same either way, so it would
-        # buy nothing and still cost the all-to-all scratch. self.group is per chain, so each
-        # axis decides on its own (GTP_remat=8 x EGTP_remat=2 -> fp32-accum on dense only).
-        use_fp32_accum = GTP_CONFIG.reduce_scatter_with_fp32_accumulation and self.group.size() > 2
-        if use_fp32_accum:
-            # Pass the mean to the collective so it lands on the FP32 sum; pre-scaling the
-            # low-precision wgrad here would round away what fp32-accum is meant to preserve.
-            rs_scale = self._mean_rs_scale()
-        else:
-            rs_scale = None
-            # MEAN reduce-scatter: pre-scale wgrad so the SUM collective yields the gtp_remat mean.
-            self._prescale_wgrads_for_mean_rs(wgrads)
+        # MEAN reduce-scatter: pre-scale wgrad so the SUM collective yields the gtp_remat mean.
+        self._prescale_wgrads_for_mean_rs(wgrads)
 
         if GTP_CONFIG.check_param_states:
             new_rs_state = GTPWeightState.ASYNC_WAIT if async_op else GTPWeightState.DATA_READY_SYNC
@@ -1674,7 +1656,9 @@ class GTPShardedParam(torch.nn.Parameter):
             rs_ctx = nullcontext()
 
         with rs_ctx:
-            if use_fp32_accum:
+            # Size <= 2 gains nothing (one addition) and still costs the scratch, so it bypasses.
+            # self.group is per chain, so each axis decides on its own.
+            if GTP_CONFIG.reduce_scatter_with_fp32_accumulation and self.group.size() > 2:
                 nvtx_range_push(f"{nvtx_label}.gtp_rs_fp32accum")
                 outputs, sum_handles = [], []
                 if len(wgrads) > 1:
@@ -1687,7 +1671,7 @@ class GTPShardedParam(torch.nn.Parameter):
                         group=self.group, device=wgrads[0].device, async_ops=True
                     ) as cm:
                         for out_buffer, tensor in zip(out_buffers, wgrads):
-                            out, h = self._reduce_scatter_fp32_accum(tensor, out_buffer, rs_scale)
+                            out, h = self._reduce_scatter_fp32_accum(tensor, out_buffer)
                             outputs.append(out)
                             sum_handles.append(h)
                     # The grouped work from _end_coalescing is the real completion; the per-op
@@ -1696,9 +1680,7 @@ class GTPShardedParam(torch.nn.Parameter):
                         h.all_to_all_handle = None
                     handle = _GTPCompositeWorkHandle([cm, *sum_handles])
                 else:
-                    out, handle = self._reduce_scatter_fp32_accum(
-                        wgrads[0], out_buffers[0], rs_scale
-                    )
+                    out, handle = self._reduce_scatter_fp32_accum(wgrads[0], out_buffers[0])
                     outputs.append(out)
                 nvtx_range_pop(f"{nvtx_label}.gtp_rs_fp32accum")
                 if async_op:

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2994,6 +2994,12 @@ def _add_distributed_args(parser):
                        default=False, help='If set, use a reduce-scatter implementation which sends lower-precision '
                        'values over the wire (using an all-to-all to keep total communication overhead in line '
                        'with the standard ring implementation) but performs accumulation locally in FP32.')
+    group.add_argument('--gtp-remat-reduce-scatter-with-fp32-accumulation', action='store_true',
+                       default=False, help='Same trade as --ddp-reduce-scatter-with-fp32-accumulation, but for '
+                       'the wgrad reduce-scatter GTP weight-remat performs over the gtp_remat axis: send '
+                       'low-precision values over the wire via an all-to-all and accumulate locally in FP32. '
+                       'Independent of the DDP flag (different collective, different process group). Costs one '
+                       'extra unsharded-wgrad-sized scratch buffer per in-flight reduce-scatter.')
     group.add_argument('--ddp-param-name-patterns-for-fp32-local-accumulation', nargs='+', default=[],
                        help='List of param_name patterns (in Python\'s fnmatch format) to match against '
                        'to do local gradient accumulation in FP32. The special pattern \'all\' matches '

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -2103,6 +2103,9 @@ def setup_model_and_optimizer(
             fp8_recipe=getattr(args, 'fp8_recipe', None),
             fp8=getattr(args, 'fp8', None) is not None,
             calculate_per_token_loss=getattr(args, 'calculate_per_token_loss', False),
+            reduce_scatter_with_fp32_accumulation=getattr(
+                args, 'gtp_remat_reduce_scatter_with_fp32_accumulation', False
+            ),
         )
 
     model = _build_model_wrapper(wrap_with_ddp)

--- a/tests/unit_tests/distributed/test_reduce_scatter_with_fp32_accumulation.py
+++ b/tests/unit_tests/distributed/test_reduce_scatter_with_fp32_accumulation.py
@@ -77,35 +77,20 @@ class TestReduceScatterWithFP32Accumulation:
                 torch.allclose(tensor1_shard, tensor2_shard) == baseline_reduce_scatter_in_fp32
             ), f"{get_non_matching_values(tensor1_shard, tensor2_shard)}"
 
-    @pytest.mark.parametrize("async_op", [True, False])
-    def test_scale_is_folded_into_the_fp32_sum(self, async_op: bool):
-        """`scale` must be applied to the FP32 sum, not to the low-precision input.
+    @pytest.mark.parametrize("axis_size", [2, 4, 8, 16])
+    def test_power_of_two_prescale_equals_scaling_the_fp32_sum(self, axis_size: int):
+        """Pre-scaling BF16 by 1/2^k is exact, which is why GTP pre-scales its 1/gtp_remat mean
+        onto the wgrad instead of accumulating it here. Local arithmetic only, no collective."""
+        scale = 1.0 / axis_size
+        contributions = (torch.randn(axis_size, 100000, device='cuda') * 1e-3).bfloat16()
 
-        Pre-scaling the BF16 input and SUMming would round every contribution on the way in, so
-        the result must match an FP32 reduce-scatter scaled in FP32.
-        """
-        rank, world_size = Utils.rank, Utils.world_size
-        # Deliberately NOT 1/world_size: that is a power of two, so pre-scaling BF16 would be
-        # exact and the anti-pattern this test exists to catch would slip through.
-        scale = 1.0 / 3.0
-        tensor = torch.rand(100000, device='cuda', dtype=torch.bfloat16)
-        kwargs = {"op": torch.distributed.ReduceOp.SUM, "group": None, "async_op": async_op}
-        # Snapshot before the call: the output tensor is a view into the input, as above.
-        reference = tensor.float()
+        prescaled = (contributions * scale).sum(dim=0, dtype=torch.float32).bfloat16()
+        scaled_sum = (contributions.sum(dim=0, dtype=torch.float32) * scale).bfloat16()
 
-        handle = reduce_scatter_with_fp32_accumulation(
-            shard_buffer(tensor, world_size)[rank], tensor, scale=scale, **kwargs
+        assert torch.equal(prescaled, scaled_sum), (
+            f"1/{axis_size} pre-scale is not exact: "
+            f"{(prescaled != scaled_sum).sum().item()} elements differ"
         )
-        if async_op:
-            handle.wait()
-
-        torch.distributed.reduce_scatter_tensor(
-            shard_buffer(reference, world_size)[rank], reference, op=kwargs["op"]
-        )
-        expected = (shard_buffer(reference, world_size)[rank] * scale).bfloat16()
-
-        got = shard_buffer(tensor, world_size)[rank]
-        assert torch.allclose(got, expected), f"{get_non_matching_values(got, expected)}"
 
     def test_caller_provided_all_to_all_output_tensor(self):
         """A caller-supplied scratch (GTP passes one from its wgrad pool) must be honored.

--- a/tests/unit_tests/distributed/test_reduce_scatter_with_fp32_accumulation.py
+++ b/tests/unit_tests/distributed/test_reduce_scatter_with_fp32_accumulation.py
@@ -76,3 +76,69 @@ class TestReduceScatterWithFP32Accumulation:
             assert (
                 torch.allclose(tensor1_shard, tensor2_shard) == baseline_reduce_scatter_in_fp32
             ), f"{get_non_matching_values(tensor1_shard, tensor2_shard)}"
+
+    @pytest.mark.parametrize("async_op", [True, False])
+    def test_scale_is_folded_into_the_fp32_sum(self, async_op: bool):
+        """`scale` must be applied to the FP32 sum, not to the low-precision input.
+
+        Pre-scaling the BF16 input and SUMming would round every contribution on the way in, so
+        the result must match an FP32 reduce-scatter scaled in FP32.
+        """
+        rank, world_size = Utils.rank, Utils.world_size
+        # Deliberately NOT 1/world_size: that is a power of two, so pre-scaling BF16 would be
+        # exact and the anti-pattern this test exists to catch would slip through.
+        scale = 1.0 / 3.0
+        tensor = torch.rand(100000, device='cuda', dtype=torch.bfloat16)
+        kwargs = {"op": torch.distributed.ReduceOp.SUM, "group": None, "async_op": async_op}
+        # Snapshot before the call: the output tensor is a view into the input, as above.
+        reference = tensor.float()
+
+        handle = reduce_scatter_with_fp32_accumulation(
+            shard_buffer(tensor, world_size)[rank], tensor, scale=scale, **kwargs
+        )
+        if async_op:
+            handle.wait()
+
+        torch.distributed.reduce_scatter_tensor(
+            shard_buffer(reference, world_size)[rank], reference, op=kwargs["op"]
+        )
+        expected = (shard_buffer(reference, world_size)[rank] * scale).bfloat16()
+
+        got = shard_buffer(tensor, world_size)[rank]
+        assert torch.allclose(got, expected), f"{get_non_matching_values(got, expected)}"
+
+    def test_caller_provided_all_to_all_output_tensor(self):
+        """A caller-supplied scratch (GTP passes one from its wgrad pool) must be honored.
+
+        A mis-sized one must be rejected before the all-to-all: bailing out mid-flight
+        desynchronizes the group.
+        """
+        rank, world_size = Utils.rank, Utils.world_size
+        kwargs = {"op": torch.distributed.ReduceOp.SUM, "group": None, "async_op": False}
+        tensor = torch.rand(100000, device='cuda', dtype=torch.bfloat16)
+
+        internal = tensor.clone()
+        reduce_scatter_with_fp32_accumulation(
+            shard_buffer(internal, world_size)[rank], internal, **kwargs
+        )
+        provided = tensor.clone()
+        reduce_scatter_with_fp32_accumulation(
+            shard_buffer(provided, world_size)[rank],
+            provided,
+            all_to_all_output_tensor=torch.empty_like(tensor),
+            **kwargs,
+        )
+        torch.testing.assert_close(
+            shard_buffer(provided, world_size)[rank],
+            shard_buffer(internal, world_size)[rank],
+            rtol=0,
+            atol=0,
+        )
+
+        with pytest.raises(AssertionError):
+            reduce_scatter_with_fp32_accumulation(
+                shard_buffer(tensor, world_size)[rank],
+                tensor,
+                all_to_all_output_tensor=torch.empty_like(tensor)[:-world_size],
+                **kwargs,
+            )

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_grad_correctness.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_grad_correctness.py
@@ -21,6 +21,8 @@ Decisive choices:
     weights and grad-norm -- must match.
 """
 
+import contextlib
+
 import pytest
 import torch
 import torch.distributed as dist
@@ -122,8 +124,9 @@ def _run_one_backward(ddp_model, rank, calculate_per_token_loss=False):
 def _full_main_grads(stack):
     """Reconstruct full (unsharded) reduced gradients keyed by param name.
 
-    GTPShardedParam.main_grad is the local gtp_remat shard -> all-gather over the gtp_remat
-    group. Non-GTP_remat params are replicated -> take the local (already gtp_remat-summed) copy.
+    GTPShardedParam.main_grad is the local shard -> all-gather over its own axis (expert params
+    shard over egtp_remat, dense over gtp_remat). Non-GTP_remat params are replicated -> take
+    the local (already gtp_remat-summed) copy.
     """
     from megatron.core import parallel_state as ps
 
@@ -133,13 +136,33 @@ def _full_main_grads(stack):
             g_attr = 'main_grad' if hasattr(p, 'main_grad') else 'grad'
             mg = getattr(p, g_attr)
             if isinstance(p, GTPShardedParam):
-                g = ps.get_gtp_weight_remat_group()
+                g = (
+                    ps.get_expert_gtp_weight_remat_group()
+                    if _is_expert_param(name, p)
+                    else ps.get_gtp_weight_remat_group()
+                )
                 shards = [torch.empty_like(mg) for _ in range(g.size())]
                 dist.all_gather(shards, mg.contiguous(), group=g)
                 out[name] = torch.cat(shards, dim=0).float().cpu()
             else:
                 out[name] = mg.detach().float().cpu()
     return out
+
+
+def _load_gtp_shards(stack, saved, moe=False):
+    """Copy each param's own shard of the unsharded `saved` weights into `stack`."""
+    from megatron.core import parallel_state as ps
+
+    gtp_rank = ps.get_gtp_weight_remat_group().rank()
+    egtp_rank = ps.get_expert_gtp_weight_remat_group().rank() if moe else 0
+    for name, p in stack.named_parameters():
+        full = saved[name]
+        if isinstance(p, GTPShardedParam):
+            r = egtp_rank if _is_expert_param(name, p) else gtp_rank
+            ss = p.shape[0]
+            p.data.copy_(full[r * ss : (r + 1) * ss])
+        else:
+            p.data.copy_(full)
 
 
 def _worker(rank, world_size, port, calculate_per_token_loss=False):
@@ -231,14 +254,24 @@ def _worker(rank, world_size, port, calculate_per_token_loss=False):
 # ---------------------------------------------------------------------------
 
 
-def _build_ddp_distopt_and_optim(stack):
+def _build_ddp_distopt_and_optim(
+    stack,
+    overlap_grad_reduce=False,
+    bucket_size=None,
+    reduce_scatter_with_fp32_accumulation=False,
+    grad_reduce_in_fp32=True,
+):
     """Real distributed-optimizer setup (Adam), matching the 64-GPU production path."""
     from megatron.core.distributed import DistributedDataParallel, DistributedDataParallelConfig
     from megatron.core.optimizer import OptimizerConfig, get_megatron_optimizer
 
     config = _make_config()
     ddp_config = DistributedDataParallelConfig(
-        use_distributed_optimizer=True, overlap_grad_reduce=False
+        use_distributed_optimizer=True,
+        overlap_grad_reduce=overlap_grad_reduce,
+        bucket_size=bucket_size,
+        grad_reduce_in_fp32=grad_reduce_in_fp32,
+        reduce_scatter_with_fp32_accumulation=reduce_scatter_with_fp32_accumulation,
     )
     module = torch.nn.Sequential()
     for i, layer in enumerate(stack):
@@ -397,7 +430,11 @@ def _worker_moe_distopt(rank, world_size, port):
     from megatron.core.process_groups_config import ProcessGroupCollection
     from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 
-    pgs = ['tp', 'cp', 'gtp_remat', 'ep']
+    # None => pull every group from the MPU globals. An explicit list is a trap here: the MoE
+    # token dispatcher reads pg_collection.tp_ep, and an omitted group comes back as None rather
+    # than raising, so the dispatcher silently gathers over a size-1 group and blows up in
+    # preprocess() with "shape '[ep,tp,num_experts]' is invalid".
+    pgs = None
 
     # ---------- Phase A: baseline GTP1/EGTP1, EP2 (DP2 dense / expert_dp2) ----------
     ps.destroy_model_parallel()
@@ -476,6 +513,315 @@ def _worker_moe_distopt(rank, world_size, port):
         torch.testing.assert_close(torch.tensor(moe_gn), torch.tensor(base_gn), atol=0, rtol=3e-2)
 
 
+# ---------------------------------------------------------------------------
+# GTP_remat + reduce_scatter_with_fp32_accumulation
+# ---------------------------------------------------------------------------
+
+# Small enough to split the stack into several bucket groups: with one big bucket every wgrad
+# has landed before the single dispatch, hiding a grad-ready ordering bug.
+FP32ACCUM_BUCKET_SIZE = 20000
+FP32ACCUM_STEPS = 3
+
+
+def _reset_dist_reduce_scatter_func():
+    """Undo param_and_grad_buffer's sticky module-level ``dist_reduce_scatter_func``.
+
+    It is set (never reset) by the first fp32-accum DDP, so without this a later plain-RS phase
+    keeps using fp32-accum and the comparison passes vacuously.
+    """
+    import megatron.core.distributed.param_and_grad_buffer as pgb
+
+    pgb.dist_reduce_scatter_func = torch.distributed._reduce_scatter_base
+
+
+def _run_gtp2_phase(rank, saved, fp32_accum):
+    """GTP_remat=2 dist-opt run with overlapped grad reduce; returns per-step grad-norms."""
+    from megatron.core import parallel_state as ps
+    from megatron.core.process_groups_config import ProcessGroupCollection
+    from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+
+    ps.destroy_model_parallel()
+    ps.initialize_model_parallel(
+        tensor_model_parallel_size=1, pipeline_model_parallel_size=1, gtp_remat_size=2
+    )
+    model_parallel_cuda_manual_seed(42)
+    pgc = ProcessGroupCollection.use_mpu_process_groups(required_pgs=['tp', 'cp', 'gtp_remat'])
+    stack = _make_stack(_make_config(), pgc)
+    for layer in stack:
+        layer.cuda()
+    gtp_rank = ps.get_gtp_weight_remat_group().rank()
+    for name, p in stack.named_parameters():
+        full = saved[name]
+        if isinstance(p, GTPShardedParam):
+            ss = p.shape[0]
+            p.data.copy_(full[gtp_rank * ss : (gtp_rank + 1) * ss])
+        else:
+            p.data.copy_(full)
+
+    _reset_dist_reduce_scatter_func()
+    ddp_model, optim = _build_ddp_distopt_and_optim(
+        stack,
+        overlap_grad_reduce=True,
+        bucket_size=FP32ACCUM_BUCKET_SIZE,
+        reduce_scatter_with_fp32_accumulation=fp32_accum,
+        grad_reduce_in_fp32=False,  # bf16 on the wire: the regime fp32-accum exists for
+    )
+    assert len(ddp_model.bucket_groups) > 1, (
+        f"expected >1 bucket group at bucket_size={FP32ACCUM_BUCKET_SIZE}, "
+        f"got {len(ddp_model.bucket_groups)} -- test would not cover the dispatch-ordering hazard"
+    )
+    grad_norms = [
+        _run_step_distopt(ddp_model, optim, rank + 17 * it) for it in range(FP32ACCUM_STEPS)
+    ]
+
+    ps.destroy_model_parallel()
+    GTPShardedParam._chain_state = {}
+    return grad_norms
+
+
+def _worker_fp32accum(rank, world_size, port):
+    """GTP_remat=2 grad-norms must be identical with and without fp32-accumulation RS.
+
+    fp32-accum reads grad_data through an all-to-all at dispatch time, while GTP defers its
+    wgrad ``main_grad.add_`` to a later backward node. If grad-ready fires from autograd instead
+    of GTP's manual hook, the all-to-all reads grad_data before the add lands. Both phases share
+    weights and data, so any difference is that staleness.
+    """
+    from megatron.core import parallel_state as ps
+    from megatron.core.process_groups_config import ProcessGroupCollection
+    from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+
+    # Common (unsharded) init weights from a GTP_remat=1 build.
+    ps.destroy_model_parallel()
+    ps.initialize_model_parallel(
+        tensor_model_parallel_size=1, pipeline_model_parallel_size=1, gtp_remat_size=1
+    )
+    model_parallel_cuda_manual_seed(42)
+    pgc = ProcessGroupCollection.use_mpu_process_groups(required_pgs=['tp', 'cp', 'gtp_remat'])
+    ref_stack = _make_stack(_make_config(), pgc)
+    for layer in ref_stack:
+        layer.cuda()
+    for p in ref_stack.parameters():
+        dist.broadcast(p.data, src=0)
+    saved = {n: p.data.clone() for n, p in ref_stack.named_parameters()}
+    del ref_stack
+    ps.destroy_model_parallel()
+    GTPShardedParam._chain_state = {}
+
+    plain_gns = _run_gtp2_phase(rank, saved, fp32_accum=False)
+    fp32_gns = _run_gtp2_phase(rank, saved, fp32_accum=True)
+    _reset_dist_reduce_scatter_func()  # don't leak fp32-accum into later tests
+
+    if rank == 0:
+        for step, (pg, fg) in enumerate(zip(plain_gns, fp32_gns)):
+            print(
+                f"[fp32accum] step {step}: grad_norm plainRS={pg:.6f} fp32accum={fg:.6f}",
+                flush=True,
+            )
+        torch.testing.assert_close(
+            torch.tensor(fp32_gns), torch.tensor(plain_gns), atol=0, rtol=1e-3
+        )
+
+
+# ---------------------------------------------------------------------------
+# GTP_remat wgrad reduce-scatter via FP32 accumulation
+# (--gtp-remat-reduce-scatter-with-fp32-accumulation)
+# ---------------------------------------------------------------------------
+
+
+def _reset_gtp_global_state():
+    """Drop GTP process-globals sized against the current layout.
+
+    The weight cache and wgrad pool are keyed by shape and outlive `destroy_model_parallel()`,
+    so a phase that changes the gtp_remat degree would be handed a stale-sized buffer.
+    """
+    import megatron.core.tensor_parallel.generalized_tensor_parallelism as gtp_module
+
+    GTPShardedParam._chain_state = {}
+    gtp_module.get_global_GTP_cache().clear()
+    gtp_module._wgrad_buf_pool.clear()
+    gtp_module._inflight_comm_params.clear()
+
+
+def _gtp_rs_phase(rank, saved, fp32_accum, moe=False, gtp_size=4):
+    """One GTP_remat backward; returns the full (gathered) reduced gradients per param.
+
+    `saved` may be None when only the dispatch counts matter. gtp_size defaults to 4 because
+    size <= 2 is bypassed -- which the bypass test asserts and which would otherwise make the
+    gradient comparison vacuous.
+    """
+    import megatron.core.tensor_parallel.generalized_tensor_parallelism as gtp_module
+    from megatron.core import parallel_state as ps
+    from megatron.core.process_groups_config import ProcessGroupCollection
+    from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+
+    ps.destroy_model_parallel()
+    init_kwargs = dict(
+        tensor_model_parallel_size=1, pipeline_model_parallel_size=1, gtp_remat_size=gtp_size
+    )
+    if moe:
+        # EP=1 (not 2) so all 4 ranks form ONE expert-GTP group: EP=2 would cap EGTP_remat at 2
+        # on a 4-GPU run, which the size-<=2 bypass turns back into a plain reduce-scatter.
+        init_kwargs.update(expert_model_parallel_size=1, expert_gtp_remat_size=gtp_size)
+    ps.initialize_model_parallel(**init_kwargs)
+    model_parallel_cuda_manual_seed(42)
+    # None => every group; the MoE dispatcher needs tp_ep (see _worker_moe_distopt).
+    pgc = ProcessGroupCollection.use_mpu_process_groups()
+    stack = (_make_moe_stack if moe else _make_stack)(
+        _make_moe_config() if moe else _make_config(), pgc
+    )
+    for layer in stack:
+        layer.cuda()
+    assert ps.get_gtp_weight_remat_group().size() == gtp_size
+    if saved is not None:
+        _load_gtp_shards(stack, saved, moe)
+
+    gtp_module.update_gtp_config(reduce_scatter_with_fp32_accumulation=fp32_accum)
+    try:
+        # Non-dist-opt DDP so main_grad holds the full reduced gradient and can be compared
+        # directly (the dist-opt buffer only has this rank's reduce-scattered slice).
+        _run_one_backward(_build_ddp(stack), rank)
+        grads = _full_main_grads(stack)
+    finally:
+        gtp_module.update_gtp_config(reduce_scatter_with_fp32_accumulation=False)
+
+    ps.destroy_model_parallel()
+    _reset_gtp_global_state()
+    return grads
+
+
+@contextlib.contextmanager
+def _fp32accum_probe():
+    """Count fp32-accum dispatches and coalesced batched composites; yields the counter dict.
+
+    Both counters guard against a vacuous pass -- a flag that never switched the collective, or
+    a batched path that regressed to one launch per weight. Patching the module attribute works
+    because ``_reduce_scatter_fp32_accum`` imports the primitive at call time.
+    """
+    import megatron.core.distributed.reduce_scatter_with_fp32_accumulation as rs_fp32_module
+    import megatron.core.tensor_parallel.generalized_tensor_parallelism as gtp_module
+
+    counts = {"dispatches": 0, "coalesced_composites": 0}
+    orig_rs = rs_fp32_module.reduce_scatter_with_fp32_accumulation
+    orig_init = gtp_module._GTPCompositeWorkHandle.__init__
+
+    def _counting_rs(*args, **kwargs):
+        counts["dispatches"] += 1
+        return orig_rs(*args, **kwargs)
+
+    def _counting_init(self, handles):
+        # The batched path builds _GTPCompositeWorkHandle([cm, *sum_handles]): a coalescing
+        # manager first, then the deferred FP32 sums.
+        if handles and isinstance(handles[0], dist.distributed_c10d._CoalescingManager):
+            counts["coalesced_composites"] += 1
+        orig_init(self, handles)
+
+    rs_fp32_module.reduce_scatter_with_fp32_accumulation = _counting_rs
+    gtp_module._GTPCompositeWorkHandle.__init__ = _counting_init
+    try:
+        yield counts
+    finally:
+        rs_fp32_module.reduce_scatter_with_fp32_accumulation = orig_rs
+        gtp_module._GTPCompositeWorkHandle.__init__ = orig_init
+
+
+def _saved_unsharded_weights(moe=False):
+    """Unsharded init weights from a GTP_remat=1 build, so every phase starts identically.
+
+    EP=1, so expert weights are DP replicas rather than EP-local and every param can be
+    broadcast.
+    """
+    from megatron.core import parallel_state as ps
+    from megatron.core.process_groups_config import ProcessGroupCollection
+    from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+
+    ps.destroy_model_parallel()
+    init_kwargs = dict(
+        tensor_model_parallel_size=1, pipeline_model_parallel_size=1, gtp_remat_size=1
+    )
+    if moe:
+        init_kwargs.update(expert_model_parallel_size=1, expert_gtp_remat_size=1)
+    ps.initialize_model_parallel(**init_kwargs)
+    model_parallel_cuda_manual_seed(42)
+    pgc = ProcessGroupCollection.use_mpu_process_groups()
+    ref_stack = (_make_moe_stack if moe else _make_stack)(
+        _make_moe_config() if moe else _make_config(), pgc
+    )
+    for layer in ref_stack:
+        layer.cuda()
+    for _name, p in ref_stack.named_parameters():
+        dist.broadcast(p.data, src=0)
+    saved = {n: p.data.clone() for n, p in ref_stack.named_parameters()}
+    del ref_stack
+    ps.destroy_model_parallel()
+    _reset_gtp_global_state()
+    return saved
+
+
+def _worker_gtp_rs_fp32accum(rank, world_size, port, moe):
+    """FP32 accumulation changes the gtp_remat RS's summation precision, never its math, so the
+    reduced gradients must still agree. Guards the integration: the mean moving onto the FP32
+    sum, the pooled scratch, and (moe=True) the batched grouped path."""
+    saved = _saved_unsharded_weights(moe)
+
+    with _fp32accum_probe() as counts:
+        plain = _gtp_rs_phase(rank, saved, fp32_accum=False, moe=moe)
+        n_plain = counts["dispatches"]
+        fp32 = _gtp_rs_phase(rank, saved, fp32_accum=True, moe=moe)
+        n_fp32 = counts["dispatches"] - n_plain
+        n_coalesced = counts["coalesced_composites"]
+
+    assert n_plain == 0, f"FP32-accum RS ran with the flag off ({n_plain} dispatches)"
+    assert n_fp32 > 0, "FP32-accum RS never ran with the flag on -- test would be vacuous"
+    if moe:
+        # Only grouped expert chains carry several wgrads per RS, so only they build a composite.
+        assert n_coalesced > 0, (
+            "batched grouped RS did not coalesce its all-to-alls -- regressed to one "
+            "ncclGroupStart/End per weight"
+        )
+
+    if rank == 0:
+        worst, worst_name = 0.0, None
+        for name, ref_grad in plain.items():
+            # Relative, not absolute: max|grad| is ~1e-4 here, so an absolute bound would read
+            # benign rounding as a huge error.
+            denom = ref_grad.abs().max().item()
+            if denom < 1e-30:
+                continue
+            rel = (ref_grad - fp32[name]).abs().max().item() / denom
+            if rel > worst:
+                worst, worst_name = rel, name
+        print(
+            f"[gtp-rs-fp32accum moe={moe}] dispatches={n_fp32} "
+            f"max rel grad diff={worst:.3e} ({worst_name})",
+            flush=True,
+        )
+        # Tolerance, not equality: the paths legitimately differ by the rounding fp32-accum
+        # removes. Structural breakage (dropped mean, unwaited handle) lands near 1.0.
+        assert worst < 2e-2, (
+            f"GTP FP32-accumulation reduce-scatter changed the reduced gradient "
+            f"(max rel diff {worst:.3e} on {worst_name})"
+        )
+
+
+def _worker_gtp_rs_fp32accum_bypassed_at_size_2(rank, world_size, port):
+    """A gtp_remat axis of size 2 must fall back to the plain reduce-scatter, flag or not.
+
+    One addition rounds the same either way, so fp32-accum cannot change the result at size 2
+    while still costing the all-to-all scratch. Enabling the flag there must issue zero
+    fp32-accum collectives.
+    """
+    with _fp32accum_probe() as counts:
+        # saved=None: only the dispatch count matters here, not the gradient values.
+        _gtp_rs_phase(rank, saved=None, fp32_accum=True, gtp_size=2)
+
+    assert counts["dispatches"] == 0, (
+        f"gtp_remat=2 issued {counts['dispatches']} FP32-accumulation reduce-scatters; the "
+        "size-<=2 bypass is not firing, so the run pays the extra all-to-all buffer for no "
+        "precision gain"
+    )
+
+
 def _worker_idog_span(rank, world_size, port):
     """Dist-opt grad-stats group (intra_dist_opt) must span the FULL world for both
     dense-only and MoE(EP2/EGTP2) configs. A naive build collapses the MoE case to a sub-world
@@ -540,18 +886,41 @@ class TestGTPGradCorrectness:
         finally:
             update_gtp_config(calculate_per_token_loss=False)
 
+    @pytest.mark.parametrize("moe", [False, True])
+    def test_gtp_remat_rs_fp32_accumulation_preserves_grads(self, moe):
+        """--gtp-remat-reduce-scatter-with-fp32-accumulation must not change the gradients.
+
+        moe=False covers the single-tensor RS; moe=True covers the batched grouped/expert RS,
+        whose coalesced all-to-alls and deferred FP32 sums are joined under one composite
+        handle -- asserted, not just exercised, so a regression to per-weight launches fails.
+        """
+        if torch.cuda.device_count() < 4:
+            pytest.skip("Requires 4 CUDA devices")
+        _run_distributed(_worker_gtp_rs_fp32accum, 4, moe)
+
+    def test_gtp_remat_rs_fp32_accumulation_bypassed_at_size_2(self):
+        """A size-2 gtp_remat axis must ignore the flag (no gain, real memory cost)."""
+        if torch.cuda.device_count() < 4:
+            pytest.skip("Requires 4 CUDA devices")
+        _run_distributed(_worker_gtp_rs_fp32accum_bypassed_at_size_2, 4)
+
+    def test_gtp2_fp32accum_rs_grad_norm_matches_plain_rs(self):
+        """GTP_remat + --ddp-reduce-scatter-with-fp32-accumulation must match plain RS.
+
+        Regression guard for the dispatch-ordering hazard: the fp32-accum all-to-all reads
+        grad_data at dispatch, so DDP grad-ready has to fire from GTP's manual post-add hook,
+        not from autograd. Needs >1 bucket group (small bucket_size) to be sensitive.
+        """
+        if torch.cuda.device_count() < 4:
+            pytest.skip("Requires 4 CUDA devices")
+        _run_distributed(_worker_fp32accum, 4)
+
     def test_gtp2_dp2_distopt_grad_norm_matches_dp4_baseline(self):
         """GTP2xDP2 dist-opt grad-norm must match no-GTP_remat DP4 (the 64-GPU path)."""
         if torch.cuda.device_count() < 4:
             pytest.skip("Requires 4 CUDA devices")
         _run_distributed(_worker_distopt, 4)
 
-    @pytest.mark.skip(
-        reason="EP=2 (engages EGTP_remat) but the minimal test dims (SEQ16 BATCH1 hidden256) hit a "
-        "token-dispatcher shape error in the alltoall path (RuntimeError shape [2,1,4]). Needs a "
-        "larger MoE config to run; left as a stub. The real EGTP_remat path is validated at scale "
-        "(loss matches the GTP1/EGTP1 baseline after the is_gtp/allreduce master-param fix)."
-    )
     def test_moe_egtp_distopt_grad_norm_matches_baseline(self):
         """GTP2/EGTP2 MoE dist-opt grad-norm must match GTP1/EGTP1 baseline (EP=2 both)."""
         if torch.cuda.device_count() < 4:

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_grad_correctness.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_grad_correctness.py
@@ -758,10 +758,30 @@ def _saved_unsharded_weights(moe=False):
     return saved
 
 
+def _max_rel_grad_diff(reference, other):
+    """Largest per-param relative gradient difference -> (value, param name).
+
+    Relative, not absolute: max|grad| is ~1e-4 on this micro-model, so an absolute bound would
+    read benign rounding as a huge error. All-zero params are skipped.
+    """
+    worst, worst_name = 0.0, None
+    for name, ref_grad in reference.items():
+        denom = ref_grad.abs().max().item()
+        if denom < 1e-30:
+            continue
+        rel = (ref_grad - other[name]).abs().max().item() / denom
+        if rel > worst:
+            worst, worst_name = rel, name
+    return worst, worst_name
+
+
 def _worker_gtp_rs_fp32accum(rank, world_size, port, moe):
-    """FP32 accumulation changes the gtp_remat RS's summation precision, never its math, so the
-    reduced gradients must still agree. Guards the integration: the mean moving onto the FP32
-    sum, the pooled scratch, and (moe=True) the batched grouped path."""
+    """FP32 accumulation must not change the reduced gradients.
+
+    It alters only the summation precision of the gtp_remat reduce-scatter, never its math.
+    Guards the integration: the pooled all-to-all scratch, the deferred FP32 sums, and
+    (moe=True) the batched grouped path.
+    """
     saved = _saved_unsharded_weights(moe)
 
     with _fp32accum_probe() as counts:
@@ -781,16 +801,7 @@ def _worker_gtp_rs_fp32accum(rank, world_size, port, moe):
         )
 
     if rank == 0:
-        worst, worst_name = 0.0, None
-        for name, ref_grad in plain.items():
-            # Relative, not absolute: max|grad| is ~1e-4 here, so an absolute bound would read
-            # benign rounding as a huge error.
-            denom = ref_grad.abs().max().item()
-            if denom < 1e-30:
-                continue
-            rel = (ref_grad - fp32[name]).abs().max().item() / denom
-            if rel > worst:
-                worst, worst_name = rel, name
+        worst, worst_name = _max_rel_grad_diff(plain, fp32)
         print(
             f"[gtp-rs-fp32accum moe={moe}] dispatches={n_fp32} "
             f"max rel grad diff={worst:.3e} ({worst_name})",


### PR DESCRIPTION

- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
Add `resuce-scatter-with-fp32-accumulation` support for GTP.

# Details
New flag `--gtp-remat-reduce-scatter-with-fp32-accumulation` (default OFF), independent of the DDP flag.

Shared primitive gains two optional arguments:
        * scale -- **applies the 1/gtp_remat mean to the FP32 sum** instead of pre-scaling the BF16 wgrad, which would round away exactly the precision this change exists to preserve.
        * all_to_all_output_tensor -- lets the caller supply the scratch, so GTP draws it from its `wgrad pool` instead of allocating one per in-flight reduce-scatter.

**Auto-bypassed at axis size <= 2**, where one addition rounds the same either way and the scratch buffer would be pure cost. The gate reads the per-chain group, so GTP_remat=8 x EGTP_remat=2 gets FP32 accumulation on the dense weights and the plain reduce-scatter on the experts.

 **Batched (grouped / routed-expert) all-to-alls are coalesced**, as the plain batched reduce-scatter already is. The manager cannot BE the  handle -- it waits only the NCCL work it collects, while each fp32-accum handle still owes a local FP32 sum -- so the sums are deferred behind it in one composite handle." is still too long

## Convergence Test

Model: 1/4 of NT3 Ultra
Parallelism: GTP16DP2EP16EGTP2_mb1gb32
Dataset: `1T-phase1var-moresft.json`
Training from scratch for ~10k steps.

Ablation experiments: w/ and w/o `--gtp-remat-reduce-scatter-with-fp32-accumulation`

**Results**: both lm loss and validation loss matches well; also match the loss curve from 3D parallelism.


<img width="1530" height="466" alt="image" src="https://github.com/user-attachments/assets/132c6360-6920-485d-97c4-d52f0c328781" />


## Issue tracking

Linked issue: Fixes #6199 

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [x] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [x] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR