### PR TITLE
Fix GTP embedding prefetch buffer reuse ordering

### DIFF
--- a/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
+++ b/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
@@ -1231,6 +1231,35 @@ class GTPShardedParam(torch.nn.Parameter):
         result = [r.detach().requires_grad_(w.requires_grad) for r, w in zip(result, self._weights)]
         return result if self.is_routed_expert else result[0]
 
+    def _prefetch_next(self, fwd: bool, nvtx_label: Optional[str] = None) -> None:
+        """Start the next weight's ordinary forward/backward prefetch."""
+        assert self.next_w is not None
+        _, handle = self.next_w._all_gather_weight(async_op=True, fwd=fwd, nvtx_label=nvtx_label)
+        self.next_w._prefetch_handle = handle
+
+    def _next_prefetch_reuses_current_buffer(self) -> bool:
+        """Return whether the next forward prefetch aliases this weight's gather buffer."""
+        if self.next_w is None:
+            return False
+
+        cache = get_global_GTP_cache()
+        return any(
+            cache.tickets_share_buffer(current._ag_ticket_fwd, following._ag_ticket_fwd)
+            for current in self._weights
+            for following in self.next_w._weights
+        )
+
+    def all_gather_and_prefetch_post_embedding(self, nvtx_label: Optional[str] = None) -> None:
+        """Start a reused-buffer prefetch after the embedding lookup has been enqueued."""
+        if (
+            in_fp8_activation_recompute_phase()
+            or not GTP_CONFIG.weight_prefetch
+            or not self._next_prefetch_reuses_current_buffer()
+            or not self.next_w._need_weight_prefetch
+        ):
+            return
+        self._prefetch_next(fwd=True, nvtx_label=nvtx_label)
+
     def _get_prefetched_weight(self, fwd):
         # Stale-read guard: state must reflect an AG issued for this cycle;
         # otherwise cache.get() would return the prior iter's AG buffer.
@@ -1364,6 +1393,9 @@ class GTPShardedParam(torch.nn.Parameter):
         # (see __init__) instead of the fwd/bwd chains; lazy-built below.
         in_recompute = in_fp8_activation_recompute_phase()
         use_recompute_chain = in_recompute and GTP_CONFIG.weight_prefetch
+        defer_next_prefetch = (
+            not in_recompute and fwd and self._next_prefetch_reuses_current_buffer()
+        )
 
         # Consume current weight.
         if use_recompute_chain and self._recompute_prev is not None:
@@ -1386,13 +1418,11 @@ class GTPShardedParam(torch.nn.Parameter):
             and GTP_CONFIG.weight_prefetch
             and self.next_w is not None
             and self.next_w._need_weight_prefetch
+            and not defer_next_prefetch
         ):
             # Pre-AG work on caller; NCCL wrap lives at the collective site
             # inside _all_gather_weight. See all_gather_and_prefetch_bwd.
-            _, handle = self.next_w._all_gather_weight(
-                async_op=True, fwd=fwd, nvtx_label=nvtx_label
-            )
-            self.next_w._prefetch_handle = handle
+            self._prefetch_next(fwd=fwd, nvtx_label=nvtx_label)
 
         # Unsharded tensor returned, no pending work → reset state to NONE. Skip during recompute:
         # a bwd-chain prefetch may hold an in-flight AG state this weight's later dgrad needs.
@@ -1888,6 +1918,16 @@ class GTPWeightCache:
             )
 
         return slot.buf
+
+    def tickets_share_buffer(
+        self, first_ticket: Optional[int], second_ticket: Optional[int]
+    ) -> bool:
+        """Check allocated ticket-buffer identity without changing ownership."""
+        if first_ticket is None or second_ticket is None:
+            return False
+        first = self._slots[first_ticket].buf
+        second = self._slots[second_ticket].buf
+        return first is not None and first is second
 
     def release(self, ticket: int):
         """Return the buffer to the pool (ticket stays valid).

--- a/megatron/core/tensor_parallel/layers.py
+++ b/megatron/core/tensor_parallel/layers.py
@@ -261,7 +261,7 @@ class VocabParallelEmbedding(torch.nn.Module):
 
         self.tp_group = get_tensor_model_parallel_group_if_none(self.tp_group)
 
-        (self.vocab_start_index, self.vocab_end_index) = (
+        self.vocab_start_index, self.vocab_end_index = (
             VocabUtility.vocab_range_from_global_vocab_size(
                 self.num_embeddings, get_pg_rank(self.tp_group), get_pg_size(self.tp_group)
             )
@@ -354,6 +354,9 @@ class VocabParallelEmbedding(torch.nn.Module):
         else:
             # F.embedding currently has a non-deterministic backward function
             output_parallel = F.embedding(masked_input, weight)
+        if self.gtp_remat_size > 1:
+            # Release a next-weight prefetch deferred because it reuses the embedding buffer.
+            self.weight.all_gather_and_prefetch_post_embedding()
         # Mask the output embedding.
         if self.tp_group.size() > 1:
             output_parallel[input_mask, :] = 0.0

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
@@ -46,6 +46,7 @@ from megatron.core import parallel_state
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.generalized_tensor_parallelism import (
     GTPShardedParam,
+    GTPWeightCache,
     wrap_module_params_gtp,
 )
 from tests.unit_tests.generalized_tensor_parallel.gtp_test_utils import (
@@ -405,6 +406,61 @@ def _worker_chain_async_prefetch(rank, world_size, port):
     assert torch.isfinite(out).all(), "Non-finite output on second pass"
 
 
+def _worker_embedding_output_prefetch_accuracy(rank, world_size, port):
+    """A deferred output-weight prefetch must not overwrite the embedding lookup input."""
+    del rank, port
+    dtype = torch.bfloat16
+    vocab_size = 16 * world_size
+    hidden_size = 1024
+    gtp_remat_group = dist.new_group(list(range(world_size)))
+
+    values = torch.arange(vocab_size * hidden_size, dtype=torch.float32, device="cuda").reshape(
+        vocab_size, hidden_size
+    )
+    embedding_full = values.remainder(113).to(dtype)
+    output_full = -(values.remainder(113) + 1).to(dtype)
+
+    embedding = nn.Module()
+    embedding.weight = nn.Parameter(embedding_full.clone())
+    output = nn.Module()
+    output.weight = nn.Parameter(output_full.clone())
+    wrap_module_params_gtp(embedding, ["weight"], gtp_remat_group)
+    wrap_module_params_gtp(output, ["weight"], gtp_remat_group)
+    embedding.weight._debug_name = "embedding.weight"
+    output.weight._debug_name = "output_layer.weight"
+    embedding.weight._need_weight_prefetch = False
+
+    indices = torch.arange(vocab_size * 64 - 1, -1, -1, dtype=torch.long, device="cuda").remainder(
+        vocab_size
+    )
+    expected_lookup = torch.nn.functional.embedding(indices, embedding_full)
+
+    # The first pass lazily creates the chain and assigns both same-shaped weights
+    # to the same reusable gather buffer.
+    gathered_embedding = embedding.weight.all_gather_and_prefetch(fwd=True)
+    first_lookup = torch.nn.functional.embedding(indices, gathered_embedding)
+    embedding.weight.all_gather_and_prefetch_post_embedding()
+    gathered_output = output.weight.all_gather_and_prefetch(fwd=True)
+    torch.testing.assert_close(first_lookup, expected_lookup, rtol=0, atol=0)
+    torch.testing.assert_close(gathered_output, output_full, rtol=0, atol=0)
+
+    cache = gtp_module.get_global_GTP_cache()
+    assert embedding.weight.next_w is output.weight
+    assert cache.tickets_share_buffer(embedding.weight._ag_ticket_fwd, output.weight._ag_ticket_fwd)
+
+    # Delay the lookup stream so an unordered AG on the separate prefetch stream
+    # would reliably overwrite the aliased buffer before the lookup consumes it.
+    gathered_embedding = embedding.weight.all_gather_and_prefetch(fwd=True)
+    torch.cuda._sleep(5_000_000)
+    lookup = torch.nn.functional.embedding(indices, gathered_embedding)
+    embedding.weight.all_gather_and_prefetch_post_embedding()
+    assert output.weight._prefetch_handle is not None
+    gathered_output = output.weight.all_gather_and_prefetch(fwd=True)
+
+    torch.testing.assert_close(lookup, expected_lookup, rtol=0, atol=0)
+    torch.testing.assert_close(gathered_output, output_full, rtol=0, atol=0)
+
+
 class TestGTPPrefetchChain:
     def test_chain_wired_after_first_pass(self):
         _requires_multi_gpu(4)
@@ -413,6 +469,14 @@ class TestGTPPrefetchChain:
     def test_async_prefetch_second_pass(self):
         _requires_multi_gpu(4)
         _run_distributed(_worker_chain_async_prefetch, 4)
+
+    def test_embedding_output_prefetch_accuracy(self, monkeypatch):
+        _requires_multi_gpu(4)
+        monkeypatch.setattr(gtp_module.GTP_CONFIG, "weight_prefetch", True)
+        monkeypatch.setattr(gtp_module.GTP_CONFIG, "check_param_states", False)
+        monkeypatch.setattr(gtp_module, "_GTP_CACHE", GTPWeightCache())
+        monkeypatch.setattr(GTPShardedParam, "_chain_state", {})
+        _run_distributed(_worker_embedding_output_prefetch_accuracy, 4)
 
 
 class TestGroupedExpertChainClassification:


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

## Summary

- Detect when the next GTP weight prefetch aliases the current weight's all-gather buffer.
- Defer the aliased output-layer all-gather until the embedding lookup has been enqueued.
- Preserve the existing immediate-prefetch path when the two weights use distinct buffers.
- Add a distributed regression test that validates both embedding and output-weight values exactly.

## Problem

With partial CUDA graphs, the embedding and output layer remain in the ungraphed GTP chain. Their same-shaped all-gather tickets can be assigned the same reusable cache buffer.

The existing one-weight-ahead schedule starts the output-weight all-gather while the embedding lookup is still consuming that buffer. Because the lookup and all-gather run on different CUDA streams, CPU launch order alone does not prevent the output gather from overwriting the embedding weight.

## Fix

The current weight checks whether its next weight uses the same allocated gather buffer. For this aliasing case, the ordinary prefetch is suppressed. `VocabParallelEmbedding` releases that prefetch immediately after `F.embedding` has been enqueued, allowing the existing stream event in the all-gather path to order the output gather after the embedding read.

This is limited to the buffer-alias case; unrelated GTP prefetch behavior is unchanged.

## Testing

```text
python -m torch.distributed.run --standalone --nproc-per-node=4 \
  -m pytest -v tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
```

All four ranks: `37 passed`. The new regression test forces a long embedding-stream delay and checks the gathered embedding and output weights with `rtol=0, atol=0`.