### PR TITLE
[Dev] Add configurable attention latent normalization epsilon

### DIFF
--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -1009,6 +1009,7 @@ class TELayerNormColumnParallelLinear(te.pytorch.LayerNormLinear):
         tp_group: Optional[torch.distributed.ProcessGroup] = None,
         stride: int = 1,
         name: str | None = None,
+        eps: float | None = None,
     ):
         """
         Args:
@@ -1117,7 +1118,7 @@ class TELayerNormColumnParallelLinear(te.pytorch.LayerNormLinear):
             super().__init__(
                 in_features=input_size,
                 out_features=output_size,
-                eps=self.config.layernorm_epsilon,
+                eps=self.config.layernorm_epsilon if eps is None else eps,
                 sequence_parallel=self.config.sequence_parallel,
                 fuse_wgrad_accumulation=self.config.gradient_accumulation_fusion,
                 tp_group=tp_group if torch.distributed.is_initialized() else None,

--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -1009,10 +1009,13 @@ class TELayerNormColumnParallelLinear(te.pytorch.LayerNormLinear):
         tp_group: Optional[torch.distributed.ProcessGroup] = None,
         stride: int = 1,
         name: str | None = None,
+        eps: float | None = None,
     ):
         """
         Args:
             name (str | None): module instance name passed top-down from its paranet module
+            eps (float | None): Epsilon for the fused layer norm. Defaults to
+                ``config.layernorm_epsilon`` when ``None``.
         """
         if not HAVE_TE:
             raise ImportError(
@@ -1117,7 +1120,7 @@ class TELayerNormColumnParallelLinear(te.pytorch.LayerNormLinear):
             super().__init__(
                 in_features=input_size,
                 out_features=output_size,
-                eps=self.config.layernorm_epsilon,
+                eps=self.config.layernorm_epsilon if eps is None else eps,
                 sequence_parallel=self.config.sequence_parallel,
                 fuse_wgrad_accumulation=self.config.gradient_accumulation_fusion,
                 tp_group=tp_group if torch.distributed.is_initialized() else None,

--- a/megatron/core/models/backends.py
+++ b/megatron/core/models/backends.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import warnings
 from abc import abstractmethod
 from functools import partial
-from typing import Optional, Protocol, cast
+from typing import Literal, Optional, Protocol, cast
 
 from megatron.core.extensions.transformer_engine import (
     TEColumnParallelGroupedLinear,
@@ -200,3 +200,19 @@ class InferenceSpecProvider(BackendSpecProvider):
                 activation_func=self.activation_func(),
             ),
         )
+
+
+def get_backend(
+    transformer_impl: Literal["local", "transformer_engine", "inference_optimized"]
+) -> BackendSpecProvider:
+    """Return the backend that's selected with the given `transformer_impl`."""
+    if transformer_impl == "transformer_engine":
+        from megatron.core.extensions.transformer_engine_spec_provider import TESpecProvider
+
+        return TESpecProvider()
+    elif transformer_impl == "inference_optimized":
+        return InferenceSpecProvider()
+    elif transformer_impl == "local":
+        return LocalSpecProvider()
+    else:
+        raise ValueError(f"unknown transformer_impl='{transformer_impl}'")

--- a/megatron/core/models/backends.py
+++ b/megatron/core/models/backends.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import warnings
 from abc import abstractmethod
 from functools import partial
-from typing import Optional, Protocol, cast
+from typing import Literal, Optional, Protocol, cast
 
 from megatron.core.extensions.transformer_engine import (
     TEColumnParallelGroupedLinear,
@@ -200,3 +200,19 @@ class InferenceSpecProvider(BackendSpecProvider):
                 activation_func=self.activation_func(),
             ),
         )
+
+
+def get_backend(
+    transformer_impl: Literal["local", "transformer_engine", "inference_optimized"],
+) -> BackendSpecProvider:
+    """Return the backend that's selected with the given `transformer_impl`."""
+    if transformer_impl == "transformer_engine":
+        from megatron.core.extensions.transformer_engine_spec_provider import TESpecProvider
+
+        return TESpecProvider()
+    elif transformer_impl == "inference_optimized":
+        return InferenceSpecProvider()
+    elif transformer_impl == "local":
+        return LocalSpecProvider()
+    else:
+        raise ValueError(f"unknown transformer_impl='{transformer_impl}'")

--- a/megatron/core/models/hybrid/hybrid_block.py
+++ b/megatron/core/models/hybrid/hybrid_block.py
@@ -5,6 +5,7 @@
 # This source code is licensed under the Apache license found in the
 # LICENSE file in the root directory of this source tree.
 
+import copy
 from contextlib import nullcontext
 from dataclasses import dataclass
 from typing import List, Optional, Tuple, Union
@@ -15,7 +16,7 @@ from torch import Tensor, nn
 from megatron.core.dist_checkpointing.mapping import ShardedStateDict
 from megatron.core.dist_checkpointing.utils import replace_prefix_for_sharding
 from megatron.core.enums import Fp8Recipe
-from megatron.core.extensions.transformer_engine import TENorm
+from megatron.core.extensions.transformer_engine import TELayerNormColumnParallelLinear, TENorm
 from megatron.core.fp4_utils import get_fp4_context
 from megatron.core.fp8_utils import get_fp8_context
 from megatron.core.inference.contexts import BaseInferenceContext
@@ -39,6 +40,7 @@ from megatron.core.transformer.module import (
     convert_module_to_dtype_except_fp32_marked,
     mark_keep_in_fp32,
 )
+from megatron.core.transformer.multi_latent_attention import FusedMLASelfAttention
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
 from megatron.core.transformer.transformer_layer import TransformerLayer
 from megatron.core.transformer.utils import (
@@ -59,6 +61,7 @@ class HybridStackSubmodules:
     gdn_layer: Union[ModuleSpec, type] = IdentityOp
     attention_layer: Union[ModuleSpec, type] = IdentityOp
     dsa_layer: Union[ModuleSpec, type] = IdentityOp
+    mla_layer: Union[ModuleSpec, type] = IdentityOp
     csa_layer: Union[ModuleSpec, type] = IdentityOp
     hca_layer: Union[ModuleSpec, type] = IdentityOp
     window_layer: Union[ModuleSpec, type] = IdentityOp
@@ -594,6 +597,9 @@ class HybridStack(MegatronModule):
         )
         self.layer_type_list = layer_type_list
 
+        if getattr(self.config, "mla_down_proj_fusion", False):
+            submodules = self._fuse_mla_down_proj(submodules)
+
         # Build layers from the pre-selected segment
         self.layers = nn.ModuleList()
         for i, layer_type in enumerate(self.layer_type_list):
@@ -628,6 +634,17 @@ class HybridStack(MegatronModule):
                 elif layer_type == LayerSymbols.DS_ATTENTION:
                     layer = build_module(
                         submodules.dsa_layer,
+                        config=self.config,
+                        layer_number=layer_number,
+                        pg_collection=pg_collection,
+                        is_mtp_layer=is_mtp_layer,
+                        add_layer_offset=False,
+                        pp_layer_offset=pp_layer_offset,
+                        name=(name + f".layers.{i}") if name is not None else None,
+                    )
+                elif layer_type == LayerSymbols.MLA:
+                    layer = build_module(
+                        submodules.mla_layer,
                         config=self.config,
                         layer_number=layer_number,
                         pg_collection=pg_collection,
@@ -736,6 +753,26 @@ class HybridStack(MegatronModule):
                 setattr(self.hc_head_fn, 'sequence_parallel', True)
                 setattr(self.hc_head_base, 'sequence_parallel', True)
                 setattr(self.hc_head_scale, 'sequence_parallel', True)
+
+    def _fuse_mla_down_proj(self, submodules: HybridStackSubmodules) -> HybridStackSubmodules:
+        # Avoid modifying the original object so users don't get surprised about their `submodules`
+        # being modified underneath them.
+        submodules = copy.deepcopy(submodules)
+        mla_spec = submodules.mla_layer
+        # We always fuse the input layernorm because Hybrid always uses TransformerEngine.
+        mla_spec.submodules.input_layernorm = IdentityOp
+        mla_spec.submodules.self_attention.module = FusedMLASelfAttention
+        mla_spec.submodules.self_attention.submodules.linear_qkv_down_proj = (
+            TELayerNormColumnParallelLinear
+        )
+        mla_spec.submodules.self_attention.submodules.linear_q_down_proj = None
+        mla_spec.submodules.self_attention.submodules.linear_kv_down_proj = None
+        mla_spec.submodules.sharded_state_dict_keys_map = {
+            "self_attention.linear_q_down_proj.layer_norm_": "input_layernorm.",
+            "self_attention.linear_kv_down_proj.layer_norm_": "input_layernorm.",
+            "self_attention.linear_qkv_down_proj.layer_norm_": "input_layernorm.",
+        }
+        return submodules
 
     @staticmethod
     def _set_mtp_layer_number_for_moe_metrics(

--- a/megatron/core/models/hybrid/hybrid_block.py
+++ b/megatron/core/models/hybrid/hybrid_block.py
@@ -5,6 +5,7 @@
 # This source code is licensed under the Apache license found in the
 # LICENSE file in the root directory of this source tree.
 
+import copy
 import warnings
 from contextlib import nullcontext
 from dataclasses import dataclass
@@ -16,7 +17,7 @@ from torch import Tensor, nn
 from megatron.core.dist_checkpointing.mapping import ShardedStateDict
 from megatron.core.dist_checkpointing.utils import replace_prefix_for_sharding
 from megatron.core.enums import Fp8Recipe
-from megatron.core.extensions.transformer_engine import TENorm
+from megatron.core.extensions.transformer_engine import TELayerNormColumnParallelLinear, TENorm
 from megatron.core.fp4_utils import get_fp4_context
 from megatron.core.fp8_utils import get_fp8_context
 from megatron.core.inference.contexts import BaseInferenceContext
@@ -40,6 +41,7 @@ from megatron.core.transformer.module import (
     convert_module_to_dtype_except_fp32_marked,
     mark_keep_in_fp32,
 )
+from megatron.core.transformer.multi_latent_attention import FusedMLASelfAttention
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
 from megatron.core.transformer.transformer_layer import TransformerLayer
 from megatron.core.transformer.utils import (
@@ -624,6 +626,9 @@ class HybridStack(MegatronModule):
         )
         self.layer_type_list = layer_type_list
 
+        if getattr(self.config, "mla_down_proj_fusion", False):
+            submodules = self._fuse_mla_down_proj(submodules)
+
         # Build layers from the pre-selected segment
         self.layers = nn.ModuleList()
         for i, layer_type in enumerate(self.layer_type_list):
@@ -786,6 +791,26 @@ class HybridStack(MegatronModule):
                 setattr(self.hc_head_fn, 'sequence_parallel', True)
                 setattr(self.hc_head_base, 'sequence_parallel', True)
                 setattr(self.hc_head_scale, 'sequence_parallel', True)
+
+    def _fuse_mla_down_proj(self, submodules: HybridStackSubmodules) -> HybridStackSubmodules:
+        # Avoid modifying the original object so users don't get surprised about their `submodules`
+        # being modified underneath them.
+        submodules = copy.deepcopy(submodules)
+        mla_spec = submodules.mla_layer
+        # We always fuse the input layernorm because Hybrid always uses TransformerEngine.
+        mla_spec.submodules.input_layernorm = IdentityOp
+        mla_spec.submodules.self_attention.module = FusedMLASelfAttention
+        mla_spec.submodules.self_attention.submodules.linear_qkv_down_proj = (
+            TELayerNormColumnParallelLinear
+        )
+        mla_spec.submodules.self_attention.submodules.linear_q_down_proj = None
+        mla_spec.submodules.self_attention.submodules.linear_kv_down_proj = None
+        mla_spec.submodules.sharded_state_dict_keys_map = {
+            "self_attention.linear_q_down_proj.layer_norm_": "input_layernorm.",
+            "self_attention.linear_kv_down_proj.layer_norm_": "input_layernorm.",
+            "self_attention.linear_qkv_down_proj.layer_norm_": "input_layernorm.",
+        }
+        return submodules
 
     @staticmethod
     def _set_mtp_layer_number_for_moe_metrics(

--- a/megatron/core/models/hybrid/hybrid_layer_allocation.py
+++ b/megatron/core/models/hybrid/hybrid_layer_allocation.py
@@ -18,6 +18,7 @@ class Symbols:
     GDN = 'G'
     ATTENTION = "*"
     DS_ATTENTION = "D"
+    MLA = "+"
     CSA = "C"  # DSv4 Compressed Sparse Attention (compress_ratio=4)
     HCA = "H"  # DSv4 Heavily Compressed Attention (compress_ratio=128)
     WINDOW = "W"  # DSv4 sliding-window-only attention (compress_ratio=0; no compressor/indexer)
@@ -25,9 +26,9 @@ class Symbols:
     MOE = 'E'
     PIPE = '|'
     MTP_SEPARATOR = "/"
-    VALID_LAYERS = {MAMBA, GDN, ATTENTION, DS_ATTENTION, CSA, HCA, WINDOW, MLP, MOE}
+    VALID_LAYERS = {MAMBA, GDN, ATTENTION, DS_ATTENTION, MLA, CSA, HCA, WINDOW, MLP, MOE}
     # MLA-based attention layers (incompatible with standard '*' attention in one model).
-    MLA_ATTENTION = {DS_ATTENTION, CSA, HCA, WINDOW}
+    MLA_ATTENTION = {DS_ATTENTION, MLA, CSA, HCA, WINDOW}
 
     @classmethod
     def name_sorted_valid_layer_symbols(cls) -> list[str]:

--- a/megatron/core/models/hybrid/hybrid_layer_specs.py
+++ b/megatron/core/models/hybrid/hybrid_layer_specs.py
@@ -174,6 +174,28 @@ hybrid_stack_spec = ModuleSpec(
                 self_attn_bda=get_bias_dropout_add,
             ),
         ),
+        mla_layer=ModuleSpec(
+            module=TransformerLayer,
+            submodules=TransformerLayerSubmodules(
+                input_layernorm=TENorm,
+                self_attention=ModuleSpec(
+                    module=MLASelfAttention,
+                    params={"attn_mask_type": AttnMaskType.causal},
+                    submodules=MLASelfAttentionSubmodules(
+                        linear_q_proj=TEColumnParallelLinear,
+                        linear_q_down_proj=TELinear,
+                        linear_q_up_proj=TEColumnParallelLinear,
+                        linear_kv_down_proj=TELinear,
+                        linear_kv_up_proj=TEColumnParallelLinear,
+                        core_attention=TEDotProductAttention,
+                        linear_proj=TERowParallelLinear,
+                        q_layernorm=IdentityOp,
+                        kv_layernorm=IdentityOp,
+                    ),
+                ),
+                self_attn_bda=get_bias_dropout_add,
+            ),
+        ),
         # Started with spec from gpt_layer_specs.py
         # Using the TE spec because we had problems getting the non-TE spec
         # working
@@ -261,6 +283,28 @@ hybrid_inference_stack_spec = ModuleSpec(
                                 )
                             ),
                         ),
+                        linear_proj=InferenceRowParallelLinear,
+                        q_layernorm=IdentityOp,
+                        kv_layernorm=IdentityOp,
+                    ),
+                ),
+                self_attn_bda=get_bias_dropout_add,
+            ),
+        ),
+        mla_layer=ModuleSpec(
+            module=TransformerLayer,
+            submodules=TransformerLayerSubmodules(
+                input_layernorm=TENorm,
+                self_attention=ModuleSpec(
+                    module=MLASelfAttention,
+                    params={"attn_mask_type": AttnMaskType.causal},
+                    submodules=MLASelfAttentionSubmodules(
+                        linear_q_proj=TEColumnParallelLinear,
+                        linear_q_down_proj=TELinear,
+                        linear_q_up_proj=TEColumnParallelLinear,
+                        linear_kv_down_proj=TELinear,
+                        linear_kv_up_proj=TEColumnParallelLinear,
+                        core_attention=TEDotProductAttention,
                         linear_proj=InferenceRowParallelLinear,
                         q_layernorm=IdentityOp,
                         kv_layernorm=IdentityOp,

--- a/megatron/core/models/hybrid/hybrid_layer_specs.py
+++ b/megatron/core/models/hybrid/hybrid_layer_specs.py
@@ -313,6 +313,28 @@ hybrid_inference_stack_spec = ModuleSpec(
                 self_attn_bda=get_bias_dropout_add,
             ),
         ),
+        mla_layer=ModuleSpec(
+            module=TransformerLayer,
+            submodules=TransformerLayerSubmodules(
+                input_layernorm=TENorm,
+                self_attention=ModuleSpec(
+                    module=MLASelfAttention,
+                    params={"attn_mask_type": AttnMaskType.causal},
+                    submodules=MLASelfAttentionSubmodules(
+                        linear_q_proj=TEColumnParallelLinear,
+                        linear_q_down_proj=TELinear,
+                        linear_q_up_proj=TEColumnParallelLinear,
+                        linear_kv_down_proj=TELinear,
+                        linear_kv_up_proj=TEColumnParallelLinear,
+                        core_attention=TEDotProductAttention,
+                        linear_proj=InferenceRowParallelLinear,
+                        q_layernorm=IdentityOp,
+                        kv_layernorm=IdentityOp,
+                    ),
+                ),
+                self_attn_bda=get_bias_dropout_add,
+            ),
+        ),
         # Started with spec from gpt_layer_specs.py
         # Using the TE spec because we had problems getting the non-TE spec
         # working

--- a/megatron/core/tensor_parallel/inference_layers.py
+++ b/megatron/core/tensor_parallel/inference_layers.py
@@ -132,6 +132,7 @@ class InferenceLayerNormColumnParallelLinear(TELayerNormColumnParallelLinear):
         tp_comm_buffer_name: Optional[str] = None,
         tp_group: Optional[torch.distributed.ProcessGroup] = None,
         name: str | None = None,
+        eps: float | None = None,
     ):
         assert HAVE_TE, "--transformer-impl=inference_optimized requires transformer engine"
         super().__init__(
@@ -148,6 +149,7 @@ class InferenceLayerNormColumnParallelLinear(TELayerNormColumnParallelLinear):
             tp_comm_buffer_name=tp_comm_buffer_name,
             tp_group=tp_group,
             name=name,
+            eps=eps,
         )
         self.tp_group = get_tensor_model_parallel_group_if_none(tp_group, is_expert=is_expert)
         self.tp_size = dist.get_world_size(self.tp_group)
@@ -156,7 +158,7 @@ class InferenceLayerNormColumnParallelLinear(TELayerNormColumnParallelLinear):
             output_size % self.tp_size == 0
         ), f"output_size ({output_size}) must be divisible by tp_size ({self.tp_size})"
 
-        self.eps = config.layernorm_epsilon
+        self.eps = config.layernorm_epsilon if eps is None else eps
 
         if self.tp_size > 1:
             assert (

--- a/megatron/core/tensor_parallel/inference_layers.py
+++ b/megatron/core/tensor_parallel/inference_layers.py
@@ -132,7 +132,14 @@ class InferenceLayerNormColumnParallelLinear(TELayerNormColumnParallelLinear):
         tp_comm_buffer_name: Optional[str] = None,
         tp_group: Optional[torch.distributed.ProcessGroup] = None,
         name: str | None = None,
+        eps: float | None = None,
     ):
+        """Initialize the inference-optimized fused layer norm and linear.
+
+        Args:
+            eps (float | None): Epsilon for the fused layer norm. Defaults to
+                ``config.layernorm_epsilon`` when ``None``.
+        """
         assert HAVE_TE, "--transformer-impl=inference_optimized requires transformer engine"
         super().__init__(
             input_size,
@@ -148,6 +155,7 @@ class InferenceLayerNormColumnParallelLinear(TELayerNormColumnParallelLinear):
             tp_comm_buffer_name=tp_comm_buffer_name,
             tp_group=tp_group,
             name=name,
+            eps=eps,
         )
         self.tp_group = get_tensor_model_parallel_group_if_none(tp_group, is_expert=is_expert)
         self.tp_size = dist.get_world_size(self.tp_group)
@@ -156,7 +164,7 @@ class InferenceLayerNormColumnParallelLinear(TELayerNormColumnParallelLinear):
             output_size % self.tp_size == 0
         ), f"output_size ({output_size}) must be divisible by tp_size ({self.tp_size})"
 
-        self.eps = config.layernorm_epsilon
+        self.eps = config.layernorm_epsilon if eps is None else eps
 
         if self.tp_size > 1:
             assert (

--- a/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
+++ b/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
@@ -422,14 +422,14 @@ class AbsorbedMLASelfAttention(Attention):
                 layer_classes["q_layernorm"],
                 hidden_size=self.config.q_lora_rank,
                 config=self.config,
-                eps=self.config.layernorm_epsilon,
+                eps=self.config.attention_latent_norm_epsilon,
             )
 
         self.kv_layernorm = build_module(
             layer_classes["kv_layernorm"],
             hidden_size=self.config.kv_lora_rank,
             config=self.config,
-            eps=self.config.layernorm_epsilon,
+            eps=self.config.attention_latent_norm_epsilon,
         )
 
     def get_query_key_value_tensors(

--- a/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
+++ b/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
@@ -37,6 +37,7 @@ from megatron.core.tensor_parallel.mappings import (
 )
 from megatron.core.transformer.attention import Attention
 from megatron.core.transformer.enums import AttnMaskType
+from megatron.core.transformer.mla_qk_norm_config import QKNormConfigResolver
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
 from megatron.core.transformer.transformer_config import MLATransformerConfig
 from megatron.core.utils import deprecate_inference_params, get_pg_size, is_te_min_version
@@ -164,6 +165,8 @@ class AbsorbedMLASelfAttention(Attention):
             name=name,
         )
 
+        layer_classes = QKNormConfigResolver(self.config, submodules).resolve()
+
         assert not config.add_bias_linear, "add_bias_linear is not supported for AbsorbedMLA"
         assert not (
             config.tensor_model_parallel_size > 1 and not config.sequence_parallel
@@ -263,7 +266,7 @@ class AbsorbedMLASelfAttention(Attention):
         if self.config.q_lora_rank is None:
             # Not projecting query
             self.linear_q_proj = build_module(
-                submodules.linear_q_proj,
+                layer_classes["linear_q_proj"],
                 self.config.hidden_size,
                 self.config.num_attention_heads * self.q_head_dim,
                 config=self.config,
@@ -309,7 +312,7 @@ class AbsorbedMLASelfAttention(Attention):
             )
 
             self.linear_q_up_proj = build_module(
-                submodules.linear_q_up_proj,
+                layer_classes["linear_q_up_proj"],
                 self.config.q_lora_rank,
                 self.config.num_attention_heads * self.q_head_dim,
                 config=self.config,
@@ -370,7 +373,7 @@ class AbsorbedMLASelfAttention(Attention):
 
         if self._uses_combined_kv_up_projection:
             self.linear_kv_up_proj = build_module(
-                submodules.linear_kv_up_proj,
+                layer_classes["linear_kv_up_proj"],
                 self.config.kv_lora_rank,
                 self.config.num_attention_heads
                 * (self.config.qk_head_dim + self.config.v_head_dim),
@@ -416,14 +419,14 @@ class AbsorbedMLASelfAttention(Attention):
 
         if self.config.q_lora_rank is not None:
             self.q_layernorm = build_module(
-                submodules.q_layernorm,
+                layer_classes["q_layernorm"],
                 hidden_size=self.config.q_lora_rank,
                 config=self.config,
                 eps=self.config.layernorm_epsilon,
             )
 
         self.kv_layernorm = build_module(
-            submodules.kv_layernorm,
+            layer_classes["kv_layernorm"],
             hidden_size=self.config.kv_lora_rank,
             config=self.config,
             eps=self.config.layernorm_epsilon,

--- a/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
+++ b/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
@@ -36,6 +36,7 @@ from megatron.core.tensor_parallel.mappings import (
 )
 from megatron.core.transformer.attention import Attention
 from megatron.core.transformer.enums import AttnMaskType
+from megatron.core.transformer.mla_qk_norm_config import QKNormConfigResolver
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
 from megatron.core.transformer.transformer_config import MLATransformerConfig
 from megatron.core.utils import deprecate_inference_params, get_pg_size, is_te_min_version
@@ -170,6 +171,8 @@ class AbsorbedMLASelfAttention(Attention):
             name=name,
         )
 
+        layer_classes = QKNormConfigResolver(self.config, submodules).resolve()
+
         assert not config.add_bias_linear, "add_bias_linear is not supported for AbsorbedMLA"
         assert not (
             config.tensor_model_parallel_size > 1 and not config.sequence_parallel
@@ -269,7 +272,7 @@ class AbsorbedMLASelfAttention(Attention):
         if self.config.q_lora_rank is None:
             # Not projecting query
             self.linear_q_proj = build_module(
-                submodules.linear_q_proj,
+                layer_classes["linear_q_proj"],
                 self.config.hidden_size,
                 self.config.num_attention_heads * self.q_head_dim,
                 config=self.config,
@@ -315,7 +318,7 @@ class AbsorbedMLASelfAttention(Attention):
             )
 
             self.linear_q_up_proj = build_module(
-                submodules.linear_q_up_proj,
+                layer_classes["linear_q_up_proj"],
                 self.config.q_lora_rank,
                 self.config.num_attention_heads * self.q_head_dim,
                 config=self.config,
@@ -376,7 +379,7 @@ class AbsorbedMLASelfAttention(Attention):
 
         if self._uses_combined_kv_up_projection:
             self.linear_kv_up_proj = build_module(
-                submodules.linear_kv_up_proj,
+                layer_classes["linear_kv_up_proj"],
                 self.config.kv_lora_rank,
                 self.config.num_attention_heads
                 * (self.config.qk_head_dim + self.config.v_head_dim),
@@ -422,14 +425,14 @@ class AbsorbedMLASelfAttention(Attention):
 
         if self.config.q_lora_rank is not None:
             self.q_layernorm = build_module(
-                submodules.q_layernorm,
+                layer_classes["q_layernorm"],
                 hidden_size=self.config.q_lora_rank,
                 config=self.config,
                 eps=self.config.layernorm_epsilon,
             )
 
         self.kv_layernorm = build_module(
-            submodules.kv_layernorm,
+            layer_classes["kv_layernorm"],
             hidden_size=self.config.kv_lora_rank,
             config=self.config,
             eps=self.config.layernorm_epsilon,

--- a/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
+++ b/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
@@ -428,14 +428,14 @@ class AbsorbedMLASelfAttention(Attention):
                 layer_classes["q_layernorm"],
                 hidden_size=self.config.q_lora_rank,
                 config=self.config,
-                eps=self.config.layernorm_epsilon,
+                eps=self.config.attention_latent_norm_epsilon,
             )
 
         self.kv_layernorm = build_module(
             layer_classes["kv_layernorm"],
             hidden_size=self.config.kv_lora_rank,
             config=self.config,
-            eps=self.config.layernorm_epsilon,
+            eps=self.config.attention_latent_norm_epsilon,
         )
 
     def get_query_key_value_tensors(

--- a/megatron/core/transformer/experimental_attention_variant/deepseek_v4_hybrid_attention.py
+++ b/megatron/core/transformer/experimental_attention_variant/deepseek_v4_hybrid_attention.py
@@ -571,13 +571,13 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
         self.kv_layernorm = submodules.kv_layernorm(
             hidden_size=self.config.v_head_dim,
             config=self.config,
-            eps=self.config.layernorm_epsilon,
+            eps=self.config.attention_latent_norm_epsilon,
         )
 
         self.q_layernorm = submodules.q_layernorm(
             hidden_size=self.config.q_lora_rank,
             config=self.config,
-            eps=self.config.layernorm_epsilon,
+            eps=self.config.attention_latent_norm_epsilon,
         )
 
     def get_query_key_value_tensors(

--- a/megatron/core/transformer/experimental_attention_variant/deepseek_v4_hybrid_attention.py
+++ b/megatron/core/transformer/experimental_attention_variant/deepseek_v4_hybrid_attention.py
@@ -33,7 +33,7 @@ from megatron.core.utils import get_pg_size, is_te_min_version
 if HAVE_TE:
     from megatron.core.extensions.transformer_engine import TELinear, set_save_original_input
 else:
-    (TEColumnParallelLinear, TELinear, set_save_original_input) = (None, None, None)
+    TEColumnParallelLinear, TELinear, set_save_original_input = (None, None, None)
 
 
 @torch.compile
@@ -571,13 +571,13 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
         self.kv_layernorm = submodules.kv_layernorm(
             hidden_size=self.config.v_head_dim,
             config=self.config,
-            eps=self.config.layernorm_epsilon,
+            eps=self.config.attention_latent_norm_epsilon,
         )
 
         self.q_layernorm = submodules.q_layernorm(
             hidden_size=self.config.q_lora_rank,
             config=self.config,
-            eps=self.config.layernorm_epsilon,
+            eps=self.config.attention_latent_norm_epsilon,
         )
 
     def get_query_key_value_tensors(

--- a/megatron/core/transformer/mla_qk_norm_config.py
+++ b/megatron/core/transformer/mla_qk_norm_config.py
@@ -1,0 +1,293 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""
+Resolve MLA and DSA Q/KV norm configuration from a layer specification.
+"""
+
+from typing import NoReturn
+
+from megatron.core.models.backends import get_backend
+from megatron.core.transformer.identity_op import IdentityOp
+from megatron.core.transformer.spec_utils import ModuleSpec
+from megatron.core.transformer.torch_norm import LayerNormBuilder
+from megatron.core.transformer.transformer_config import MLATransformerConfig
+
+__all__ = []
+
+_QKNormResolvedConfig = dict[str, ModuleSpec | type | LayerNormBuilder]
+
+
+class QKNormConfigResolver:
+    """Validate and resolve Q/KV norm placement for MLA and DSA.
+
+    Q/KV norm can be represented either by a standalone norm module or by
+    a fused norm+linear projection. MLA can use the fused form; DSA cannot
+    because it needs the normalized Q/KV values outside the projection.
+
+    Constraints:
+    - `qk_l2_norm` is unsupported for MLA/DSA.
+    - A standalone Q norm is only usable when `q_lora_rank` is set.
+    - Explicit norm modules cannot be paired with fused norm+linear projections.
+    - Disabled QK norm rejects both explicit norms and fused norm+linear projections.
+    - DSA with QK norm requires non-fused projections and standalone Q/KV norms.
+    """
+
+    def __init__(self, config: MLATransformerConfig, submodules) -> None:
+        """Capture the configuration, requested modules, and backend implementations."""
+        self.config = config
+        self.submodules = submodules
+        self.has_q_lora = config.q_lora_rank is not None
+        self.is_dsa = config.experimental_attention_variant == "dsa"
+        self.variant_str = "DSA" if self.is_dsa else "MLA"
+
+        backend = get_backend(config.transformer_impl)
+        self.qk_norm_impl = backend.layer_norm(
+            rms_norm=config.normalization == "RMSNorm", for_qk=True
+        )
+        self.linear_impl = backend.column_parallel_linear()
+        self.fused_norm_linear_impl = backend.column_parallel_layer_norm_linear()
+
+    def resolve(self) -> _QKNormResolvedConfig:
+        """Validate the specification and return the modules to instantiate.
+
+        Returns:
+            The Q/KV norms and projections after applying the MLA or DSA constraints.
+
+        Raises:
+            ValueError: If the requested norm placement is unsupported or conflicting.
+        """
+        if self.config.qk_l2_norm:
+            raise ValueError(f"qk_l2_norm is not supported with {self.variant_str}.")
+
+        self._reject_common_spec_conflicts()
+        if not self.config.qk_layernorm:
+            return self._resolve_disabled_qk_layernorm()
+        if self.is_dsa:
+            return self._resolve_dsa_qk_layernorm()
+        return self._resolve_mla_qk_layernorm()
+
+    def _resolve_disabled_qk_layernorm(self) -> _QKNormResolvedConfig:
+        """Resolve projections when Q/KV normalization is disabled.
+
+        Explicit norm modules and fused norm-linear projections are rejected because
+        they would still introduce Q/KV normalization.
+        """
+        linear_q_proj_cls = IdentityOp
+        linear_q_up_proj_cls = IdentityOp
+
+        if self.has_q_lora:
+            self._reject_disabled_norm(
+                self.submodules.linear_q_up_proj,
+                self.submodules.q_layernorm,
+                "linear_q_up_proj",
+                "q_layernorm",
+            )
+            linear_q_up_proj_cls = self.submodules.linear_q_up_proj or self.linear_impl
+        else:
+            if self._is_fused_norm_linear(self.submodules.linear_q_proj):
+                raise ValueError(
+                    f"spec sets linear_q_proj={self.submodules.linear_q_proj}, but "
+                    "qk_layernorm/qk_l2_norm are supposed to be disabled"
+                )
+            linear_q_proj_cls = self.submodules.linear_q_proj or self.linear_impl
+
+        self._reject_disabled_norm(
+            self.submodules.linear_kv_up_proj,
+            self.submodules.kv_layernorm,
+            "linear_kv_up_proj",
+            "kv_layernorm",
+        )
+        return self._result(
+            linear_q_proj=linear_q_proj_cls,
+            linear_q_up_proj=linear_q_up_proj_cls,
+            linear_kv_up_proj=self.submodules.linear_kv_up_proj or self.linear_impl,
+            q_layernorm=IdentityOp,
+            kv_layernorm=IdentityOp,
+        )
+
+    def _resolve_dsa_qk_layernorm(self) -> _QKNormResolvedConfig:
+        """Resolve DSA's standalone Q/KV norms and non-fused projections.
+
+        DSA consumes the normalized Q/KV values outside the projection, so it cannot
+        use fused norm-linear projections.
+        """
+        if not self.has_q_lora:
+            raise ValueError(
+                "`qk_layernorm=True` with `q_lora_rank is None` is not supported for DSA "
+                "because DSA cannot fuse Q norm into `linear_q_proj`."
+            )
+
+        return self._result(
+            linear_q_proj=IdentityOp,
+            linear_q_up_proj=self._dsa_linear_or_default(
+                self.submodules.linear_q_up_proj, "linear_q_up_proj"
+            ),
+            linear_kv_up_proj=self._dsa_linear_or_default(
+                self.submodules.linear_kv_up_proj, "linear_kv_up_proj"
+            ),
+            q_layernorm=self._default_if_trivial(self.submodules.q_layernorm, self.qk_norm_impl),
+            kv_layernorm=self._default_if_trivial(self.submodules.kv_layernorm, self.qk_norm_impl),
+        )
+
+    def _resolve_mla_qk_layernorm(self) -> _QKNormResolvedConfig:
+        """Resolve MLA norms, fusing them into projections when no norm is explicit."""
+        q_norm_cls = self.submodules.q_layernorm or IdentityOp
+        linear_q_proj_cls = IdentityOp
+        linear_q_up_proj_cls = IdentityOp
+
+        if self.has_q_lora:
+            if self._is_trivial(q_norm_cls):
+                linear_q_up_proj_cls = self._mla_fused_linear_or_default(
+                    self.submodules.linear_q_up_proj, "linear_q_up_proj"
+                )
+            else:
+                linear_q_up_proj_cls = self._non_fused_or_default(
+                    self.submodules.linear_q_up_proj, "linear_q_up_proj"
+                )
+        else:
+            linear_q_proj_cls = self._mla_fused_linear_or_default(
+                self.submodules.linear_q_proj, "linear_q_proj"
+            )
+
+        kv_norm_cls = self.submodules.kv_layernorm or IdentityOp
+        if self._is_trivial(kv_norm_cls):
+            linear_kv_up_proj_cls = self._mla_fused_linear_or_default(
+                self.submodules.linear_kv_up_proj, "linear_kv_up_proj"
+            )
+        else:
+            linear_kv_up_proj_cls = self._non_fused_or_default(
+                self.submodules.linear_kv_up_proj, "linear_kv_up_proj"
+            )
+
+        return self._result(
+            linear_q_proj=linear_q_proj_cls,
+            linear_q_up_proj=linear_q_up_proj_cls,
+            linear_kv_up_proj=linear_kv_up_proj_cls,
+            q_layernorm=q_norm_cls,
+            kv_layernorm=kv_norm_cls,
+        )
+
+    def _reject_common_spec_conflicts(self) -> None:
+        """Reject conflicts that apply regardless of the selected attention variant."""
+        if not self.has_q_lora and not self._is_trivial(self.submodules.q_layernorm):
+            self._raise_unused_q_norm()
+        if self.has_q_lora:
+            self._reject_explicit_norm_with_fused_linear(
+                self.submodules.linear_q_up_proj,
+                self.submodules.q_layernorm,
+                "linear_q_up_proj",
+                "q_layernorm",
+            )
+        self._reject_explicit_norm_with_fused_linear(
+            self.submodules.linear_kv_up_proj,
+            self.submodules.kv_layernorm,
+            "linear_kv_up_proj",
+            "kv_layernorm",
+        )
+
+    def _reject_disabled_norm(self, module_spec, norm_spec, module_name, norm_name) -> None:
+        """Reject a norm module or fused projection when Q/KV norm is disabled."""
+        if self._is_fused_norm_linear(module_spec) or not self._is_trivial(norm_spec):
+            raise ValueError(
+                f"spec sets {module_name}={module_spec} and "
+                f"{norm_name}={norm_spec}, but "
+                "qk_layernorm/qk_l2_norm are supposed to be disabled"
+            )
+
+    def _reject_explicit_norm_with_fused_linear(
+        self, module_spec, norm_spec, module_name, norm_name
+    ) -> None:
+        """Reject specifying the same norm both explicitly and inside a projection."""
+        if not self._is_trivial(norm_spec) and self._is_fused_norm_linear(module_spec):
+            raise ValueError(
+                f"`{norm_name}={norm_spec}` is non-trivial "
+                f"and `{module_name}={module_spec}` is a "
+                f"fused norm+linear; either unset `{norm_name}` or use a "
+                f"linear layer without norm fusion for `{module_name}`"
+            )
+
+    def _non_fused_or_default(self, module_spec, module_name):
+        """Return a linear implementation, requiring it not to fuse normalization."""
+        linear_cls = module_spec or self.linear_impl
+        self._require_linear(linear_cls, module_name)
+        if self._is_fused_norm_linear(linear_cls):
+            raise ValueError(
+                f"`{module_name}={module_spec}` is fused norm+linear, but a non-fused linear "
+                f"is required"
+            )
+        return linear_cls
+
+    def _dsa_linear_or_default(self, module_spec, module_name):
+        """Return DSA's non-fused projection implementation.
+
+        This uses a DSA-specific diagnostic so the rejected constraint is clear.
+        """
+        linear_cls = module_spec or self.linear_impl
+        self._require_linear(linear_cls, module_name)
+        if self._is_fused_norm_linear(linear_cls):
+            raise ValueError(
+                f"`{module_name}={module_spec}` is fused norm+linear, "
+                f"which is not supported for DSA."
+            )
+        return linear_cls
+
+    def _mla_fused_linear_or_default(self, module_spec, module_name):
+        """Return a fused MLA projection, using the backend default when available."""
+        if self._is_fused_norm_linear(module_spec):
+            return module_spec
+        return self._require_linear(self.fused_norm_linear_impl, module_name)
+
+    def _require_linear(self, module_spec, module_name):
+        """Return a configured projection or report that no viable implementation exists."""
+        if module_spec is None:
+            raise RuntimeError(
+                "qk_layernorm requires TransformerEngine or "
+                "q_layernorm/kv_layernorm to be set in the spec "
+                f"to build `{module_name}`."
+            )
+        return module_spec
+
+    def _raise_unused_q_norm(self) -> NoReturn:
+        """Report an explicit Q norm that has no Q-LoRA projection to consume it."""
+        help_msg = ""
+        if not self._is_fused_norm_linear(self.submodules.linear_q_proj):
+            help_msg = (
+                f"Please use a fused norm+linear for "
+                f"`linear_q_proj={self.submodules.linear_q_proj}` if "
+                f"you intend to have a Q-norm."
+            )
+        raise ValueError(
+            f"`q_layernorm={self.submodules.q_layernorm}` is non-trivial, "
+            f"but `q_lora_rank is None`, meaning it will not be used."
+            f"{help_msg}"
+        )
+
+    def _is_fused_norm_linear(self, module_spec) -> bool:
+        """Return whether a module specification selects the backend fused projection."""
+        module_cls = module_spec.module if isinstance(module_spec, ModuleSpec) else module_spec
+        return self.fused_norm_linear_impl is not None and module_cls is self.fused_norm_linear_impl
+
+    @staticmethod
+    def _is_trivial(module_spec) -> bool:
+        """Return whether a norm slot is unset or explicitly an identity operation."""
+        return module_spec in (None, IdentityOp)
+
+    @classmethod
+    def _default_if_trivial(cls, module_spec, default):
+        """Replace an unset or identity specification with the supplied default."""
+        if cls._is_trivial(module_spec):
+            return default
+        return module_spec
+
+    @staticmethod
+    def _result(
+        *, linear_q_proj, linear_q_up_proj, linear_kv_up_proj, q_layernorm, kv_layernorm
+    ) -> _QKNormResolvedConfig:
+        """Package the resolved Q/KV norms and projections in the caller's schema."""
+        return dict(
+            linear_q_proj=linear_q_proj,
+            linear_q_up_proj=linear_q_up_proj,
+            linear_kv_up_proj=linear_kv_up_proj,
+            q_layernorm=q_layernorm,
+            kv_layernorm=kv_layernorm,
+        )

--- a/megatron/core/transformer/mla_qk_norm_config.py
+++ b/megatron/core/transformer/mla_qk_norm_config.py
@@ -4,6 +4,7 @@
 Resolve MLA and DSA Q/KV norm configuration from a layer specification.
 """
 
+from dataclasses import replace
 from typing import NoReturn
 
 from megatron.core.models.backends import get_backend
@@ -234,8 +235,21 @@ class QKNormConfigResolver:
     def _mla_fused_linear_or_default(self, module_spec, module_name):
         """Return a fused MLA projection, using the backend default when available."""
         if self._is_fused_norm_linear(module_spec):
-            return module_spec
-        return self._require_linear(self.fused_norm_linear_impl, module_name)
+            fused_linear = module_spec
+        else:
+            fused_linear = self._require_linear(self.fused_norm_linear_impl, module_name)
+        return self._with_attention_latent_norm_epsilon(fused_linear)
+
+    def _with_attention_latent_norm_epsilon(self, module_spec):
+        """Attach the attention latent-norm epsilon to a fused MLA projection."""
+        assert self.config.attention_latent_norm_epsilon is not None
+        params = {
+            **(module_spec.params if isinstance(module_spec, ModuleSpec) else {}),
+            "eps": self.config.attention_latent_norm_epsilon,
+        }
+        if isinstance(module_spec, ModuleSpec):
+            return replace(module_spec, params=params)
+        return ModuleSpec(module=module_spec, params=params)
 
     def _require_linear(self, module_spec, module_name):
         """Return a configured projection or report that no viable implementation exists."""

--- a/megatron/core/transformer/multi_latent_attention.py
+++ b/megatron/core/transformer/multi_latent_attention.py
@@ -39,6 +39,7 @@ from megatron.core.tensor_parallel.mappings import (
 )
 from megatron.core.transformer.attention import Attention, LinearProjBuilder
 from megatron.core.transformer.enums import AttnMaskType
+from megatron.core.transformer.mla_qk_norm_config import QKNormConfigResolver
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
 from megatron.core.transformer.torch_norm import LayerNormBuilder
 from megatron.core.transformer.transformer_config import MLATransformerConfig
@@ -622,10 +623,14 @@ class MLASelfAttention(MultiLatentAttention):
             name=name,
         )
 
+        # Resolve which classes to use for Q and KV linear up projections and norms, based on
+        # QK-norm selection.
+        layer_classes = self._resolve_qk_norm_config(submodules)
+
         if self.config.q_lora_rank is None:
             # Not projecting query
             self.linear_q_proj = build_module(
-                submodules.linear_q_proj,
+                layer_classes["linear_q_proj"],
                 self.config.hidden_size,
                 self.config.num_attention_heads * self.q_head_dim,
                 config=self.config,
@@ -672,7 +677,7 @@ class MLASelfAttention(MultiLatentAttention):
             )
 
             self.linear_q_up_proj = build_module(
-                submodules.linear_q_up_proj,
+                layer_classes["linear_q_up_proj"],
                 self.config.q_lora_rank,
                 self.config.num_attention_heads * self.q_head_dim,
                 config=self.config,
@@ -719,7 +724,7 @@ class MLASelfAttention(MultiLatentAttention):
         )
 
         self.linear_kv_up_proj = build_module(
-            submodules.linear_kv_up_proj,
+            layer_classes["linear_kv_up_proj"],
             self.config.kv_lora_rank,
             self.config.num_attention_heads * (self.config.qk_head_dim + self.config.v_head_dim),
             config=self.config,
@@ -734,17 +739,23 @@ class MLASelfAttention(MultiLatentAttention):
         )
 
         if self.config.q_lora_rank is not None:
-            self.q_layernorm = submodules.q_layernorm(
+            self.q_layernorm = layer_classes["q_layernorm"](
                 hidden_size=self.config.q_lora_rank,
                 config=self.config,
                 eps=self.config.layernorm_epsilon,
             )
 
-        self.kv_layernorm = submodules.kv_layernorm(
+        self.kv_layernorm = layer_classes["kv_layernorm"](
             hidden_size=self.config.kv_lora_rank,
             config=self.config,
             eps=self.config.layernorm_epsilon,
         )
+
+    def _resolve_qk_norm_config(
+        self, submodules
+    ) -> dict[str, ModuleSpec | type | LayerNormBuilder]:
+        """Resolve which Q/KV norm and up-projection implementations to build."""
+        return QKNormConfigResolver(self.config, submodules).resolve()
 
     def _qkv_down_projection(self, hidden_states):
         """Unfused q/kv down projection path."""
@@ -1381,6 +1392,9 @@ class FusedMLASelfAttention(MLASelfAttention):
             "FusedMLASelfAttention requires q_lora_rank to be set; "
             "fallback to MLASelfAttention for q_lora_rank=None."
         )
+        # Resolve which linear class to use for Q and KV up projections,
+        # based on QK-norm selection.
+        layer_classes = self._resolve_qk_norm_config(submodules)
 
         qkv_down_proj_kwargs = {}
         if submodules.linear_qkv_down_proj in [TELinear]:
@@ -1416,7 +1430,7 @@ class FusedMLASelfAttention(MLASelfAttention):
         )
 
         self.linear_q_up_proj = build_module(
-            submodules.linear_q_up_proj,
+            layer_classes["linear_q_up_proj"],
             self.config.q_lora_rank,
             self.config.num_attention_heads * self.q_head_dim,
             config=self.config,
@@ -1431,7 +1445,7 @@ class FusedMLASelfAttention(MLASelfAttention):
         )
 
         self.linear_kv_up_proj = build_module(
-            submodules.linear_kv_up_proj,
+            layer_classes["linear_kv_up_proj"],
             self.config.kv_lora_rank,
             self.config.num_attention_heads * (self.config.qk_head_dim + self.config.v_head_dim),
             config=self.config,
@@ -1445,12 +1459,12 @@ class FusedMLASelfAttention(MLASelfAttention):
             name=(name + ".linear_kv_up_proj") if name is not None else None,
         )
 
-        self.q_layernorm = submodules.q_layernorm(
+        self.q_layernorm = layer_classes["q_layernorm"](
             hidden_size=self.config.q_lora_rank,
             config=self.config,
             eps=self.config.layernorm_epsilon,
         )
-        self.kv_layernorm = submodules.kv_layernorm(
+        self.kv_layernorm = layer_classes["kv_layernorm"](
             hidden_size=self.config.kv_lora_rank,
             config=self.config,
             eps=self.config.layernorm_epsilon,

--- a/megatron/core/transformer/multi_latent_attention.py
+++ b/megatron/core/transformer/multi_latent_attention.py
@@ -742,13 +742,13 @@ class MLASelfAttention(MultiLatentAttention):
             self.q_layernorm = layer_classes["q_layernorm"](
                 hidden_size=self.config.q_lora_rank,
                 config=self.config,
-                eps=self.config.layernorm_epsilon,
+                eps=self.config.attention_latent_norm_epsilon,
             )
 
         self.kv_layernorm = layer_classes["kv_layernorm"](
             hidden_size=self.config.kv_lora_rank,
             config=self.config,
-            eps=self.config.layernorm_epsilon,
+            eps=self.config.attention_latent_norm_epsilon,
         )
 
     def _resolve_qk_norm_config(
@@ -1462,12 +1462,12 @@ class FusedMLASelfAttention(MLASelfAttention):
         self.q_layernorm = layer_classes["q_layernorm"](
             hidden_size=self.config.q_lora_rank,
             config=self.config,
-            eps=self.config.layernorm_epsilon,
+            eps=self.config.attention_latent_norm_epsilon,
         )
         self.kv_layernorm = layer_classes["kv_layernorm"](
             hidden_size=self.config.kv_lora_rank,
             config=self.config,
-            eps=self.config.layernorm_epsilon,
+            eps=self.config.attention_latent_norm_epsilon,
         )
 
     def _qkv_down_projection(self, hidden_states):

--- a/megatron/core/transformer/multi_latent_attention.py
+++ b/megatron/core/transformer/multi_latent_attention.py
@@ -37,6 +37,7 @@ from megatron.core.tensor_parallel.mappings import (
 )
 from megatron.core.transformer.attention import Attention, LinearProjBuilder
 from megatron.core.transformer.enums import AttnMaskType
+from megatron.core.transformer.mla_qk_norm_config import QKNormConfigResolver
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
 from megatron.core.transformer.torch_norm import LayerNormBuilder
 from megatron.core.transformer.transformer_config import MLATransformerConfig
@@ -519,10 +520,14 @@ class MLASelfAttention(MultiLatentAttention):
             name=name,
         )
 
+        # Resolve which classes to use for Q and KV linear up projections and norms, based on
+        # QK-norm selection.
+        layer_classes = self._resolve_qk_norm_config(submodules)
+
         if self.config.q_lora_rank is None:
             # Not projecting query
             self.linear_q_proj = build_module(
-                submodules.linear_q_proj,
+                layer_classes["linear_q_proj"],
                 self.config.hidden_size,
                 self.config.num_attention_heads * self.q_head_dim,
                 config=self.config,
@@ -569,7 +574,7 @@ class MLASelfAttention(MultiLatentAttention):
             )
 
             self.linear_q_up_proj = build_module(
-                submodules.linear_q_up_proj,
+                layer_classes["linear_q_up_proj"],
                 self.config.q_lora_rank,
                 self.config.num_attention_heads * self.q_head_dim,
                 config=self.config,
@@ -616,7 +621,7 @@ class MLASelfAttention(MultiLatentAttention):
         )
 
         self.linear_kv_up_proj = build_module(
-            submodules.linear_kv_up_proj,
+            layer_classes["linear_kv_up_proj"],
             self.config.kv_lora_rank,
             self.config.num_attention_heads * (self.config.qk_head_dim + self.config.v_head_dim),
             config=self.config,
@@ -631,17 +636,23 @@ class MLASelfAttention(MultiLatentAttention):
         )
 
         if self.config.q_lora_rank is not None:
-            self.q_layernorm = submodules.q_layernorm(
+            self.q_layernorm = layer_classes["q_layernorm"](
                 hidden_size=self.config.q_lora_rank,
                 config=self.config,
                 eps=self.config.layernorm_epsilon,
             )
 
-        self.kv_layernorm = submodules.kv_layernorm(
+        self.kv_layernorm = layer_classes["kv_layernorm"](
             hidden_size=self.config.kv_lora_rank,
             config=self.config,
             eps=self.config.layernorm_epsilon,
         )
+
+    def _resolve_qk_norm_config(
+        self, submodules
+    ) -> dict[str, ModuleSpec | type | LayerNormBuilder]:
+        """Resolve which Q/KV norm and up-projection implementations to build."""
+        return QKNormConfigResolver(self.config, submodules).resolve()
 
     def _qkv_down_projection(self, hidden_states):
         """Unfused q/kv down projection path."""
@@ -1279,6 +1290,9 @@ class FusedMLASelfAttention(MLASelfAttention):
             "FusedMLASelfAttention requires q_lora_rank to be set; "
             "fallback to MLASelfAttention for q_lora_rank=None."
         )
+        # Resolve which linear class to use for Q and KV up projections,
+        # based on QK-norm selection.
+        layer_classes = self._resolve_qk_norm_config(submodules)
 
         qkv_down_proj_kwargs = {}
         if submodules.linear_qkv_down_proj in [TELinear]:
@@ -1314,7 +1328,7 @@ class FusedMLASelfAttention(MLASelfAttention):
         )
 
         self.linear_q_up_proj = build_module(
-            submodules.linear_q_up_proj,
+            layer_classes["linear_q_up_proj"],
             self.config.q_lora_rank,
             self.config.num_attention_heads * self.q_head_dim,
             config=self.config,
@@ -1329,7 +1343,7 @@ class FusedMLASelfAttention(MLASelfAttention):
         )
 
         self.linear_kv_up_proj = build_module(
-            submodules.linear_kv_up_proj,
+            layer_classes["linear_kv_up_proj"],
             self.config.kv_lora_rank,
             self.config.num_attention_heads * (self.config.qk_head_dim + self.config.v_head_dim),
             config=self.config,
@@ -1343,12 +1357,12 @@ class FusedMLASelfAttention(MLASelfAttention):
             name=(name + ".linear_kv_up_proj") if name is not None else None,
         )
 
-        self.q_layernorm = submodules.q_layernorm(
+        self.q_layernorm = layer_classes["q_layernorm"](
             hidden_size=self.config.q_lora_rank,
             config=self.config,
             eps=self.config.layernorm_epsilon,
         )
-        self.kv_layernorm = submodules.kv_layernorm(
+        self.kv_layernorm = layer_classes["kv_layernorm"](
             hidden_size=self.config.kv_lora_rank,
             config=self.config,
             eps=self.config.layernorm_epsilon,

--- a/megatron/core/transformer/multi_latent_attention.py
+++ b/megatron/core/transformer/multi_latent_attention.py
@@ -639,13 +639,13 @@ class MLASelfAttention(MultiLatentAttention):
             self.q_layernorm = layer_classes["q_layernorm"](
                 hidden_size=self.config.q_lora_rank,
                 config=self.config,
-                eps=self.config.layernorm_epsilon,
+                eps=self.config.attention_latent_norm_epsilon,
             )
 
         self.kv_layernorm = layer_classes["kv_layernorm"](
             hidden_size=self.config.kv_lora_rank,
             config=self.config,
-            eps=self.config.layernorm_epsilon,
+            eps=self.config.attention_latent_norm_epsilon,
         )
 
     def _resolve_qk_norm_config(
@@ -1360,12 +1360,12 @@ class FusedMLASelfAttention(MLASelfAttention):
         self.q_layernorm = layer_classes["q_layernorm"](
             hidden_size=self.config.q_lora_rank,
             config=self.config,
-            eps=self.config.layernorm_epsilon,
+            eps=self.config.attention_latent_norm_epsilon,
         )
         self.kv_layernorm = layer_classes["kv_layernorm"](
             hidden_size=self.config.kv_lora_rank,
             config=self.config,
-            eps=self.config.layernorm_epsilon,
+            eps=self.config.attention_latent_norm_epsilon,
         )
 
     def _qkv_down_projection(self, hidden_states):

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -3850,6 +3850,10 @@ class MLATransformerConfig(TransformerConfig):
     """Rank of Key and Value tensors' low rank representation.
        This is not used for DSv4 Hybrid Attention and will be overridden automatically."""
 
+    attention_latent_norm_epsilon: float | None = None
+    """Epsilon for the primary query and key-value latent norms in attention.
+       If unset, inherit ``layernorm_epsilon`` for backward compatibility."""
+
     qk_head_dim: int = 128
     """Dimension of the head in the QK projection. q_head_dim = qk_head_dim + qk_pos_emb_head_dim
        This is not used for DSv4 Hybrid Attention and will be overridden automatically."""
@@ -3908,6 +3912,8 @@ class MLATransformerConfig(TransformerConfig):
 
     def __post_init__(self):
         super().__post_init__()
+        if self.attention_latent_norm_epsilon is None:
+            self.attention_latent_norm_epsilon = self.layernorm_epsilon
 
         if self.attention_output_gate and self.mla_down_proj_fusion:
             # Fused MLA hides the post-input-LayerNorm activation inside the fused

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -3533,6 +3533,10 @@ class MLATransformerConfig(TransformerConfig):
     """Rank of Key and Value tensors' low rank representation.
        This is not used for DSv4 Hybrid Attention and will be overridden automatically."""
 
+    attention_latent_norm_epsilon: float | None = None
+    """Epsilon for the primary query and key-value latent norms in attention.
+       If unset, inherit ``layernorm_epsilon`` for backward compatibility."""
+
     qk_head_dim: int = 128
     """Dimension of the head in the QK projection. q_head_dim = qk_head_dim + qk_pos_emb_head_dim
        This is not used for DSv4 Hybrid Attention and will be overridden automatically."""
@@ -3591,6 +3595,9 @@ class MLATransformerConfig(TransformerConfig):
 
     def __post_init__(self):
         super().__post_init__()
+        if self.attention_latent_norm_epsilon is None:
+            self.attention_latent_norm_epsilon = self.layernorm_epsilon
+
         if (
             self.multi_latent_attention
             and self.apply_rope_fusion

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -4897,6 +4897,13 @@ def _add_mla_args(parser):
         help="Rank of Key and Value tensors' low rank representation.",
     )
     group.add_argument(
+        '--attention-latent-norm-epsilon',
+        type=float,
+        default=None,
+        help="Epsilon for the primary query and key-value latent norms in attention. "
+        "Defaults to --norm-epsilon when unset.",
+    )
+    group.add_argument(
         '--qk-head-dim',
         type=int,
         default=128,

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -946,7 +946,10 @@ def validate_args(args, defaults={}):
             )
 
     # Infer use of MLA from unified pattern
-    if args.hybrid_layer_pattern and Symbols.DS_ATTENTION in args.hybrid_layer_pattern:
+    if args.hybrid_layer_pattern and (
+            Symbols.MLA in args.hybrid_layer_pattern
+            or Symbols.DS_ATTENTION in args.hybrid_layer_pattern
+    ):
         args.multi_latent_attention = True
 
     # === End of hybrid layer pattern: deprecation handling and validation ===

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -4813,6 +4813,13 @@ def _add_mla_args(parser):
         help="Rank of Key and Value tensors' low rank representation.",
     )
     group.add_argument(
+        '--attention-latent-norm-epsilon',
+        type=float,
+        default=None,
+        help="Epsilon for the primary query and key-value latent norms in attention. "
+        "Defaults to --norm-epsilon when unset.",
+    )
+    group.add_argument(
         '--qk-head-dim',
         type=int,
         default=128,

--- a/tests/unit_tests/a2a_overlap/test_schedule_layer_1f1b.py
+++ b/tests/unit_tests/a2a_overlap/test_schedule_layer_1f1b.py
@@ -450,7 +450,12 @@ class TestA2AOverlap:
         Verifies all-to-all overlap optimization in MTP layer produces
         the same results as the reference implementation.
         """
-        extra_kwargs = {"mtp_num_layers": 1, "mtp_loss_scaling_factor": 1.1}
+        qk_layernorm = True
+        extra_kwargs = {
+            "mtp_num_layers": 1,
+            "mtp_loss_scaling_factor": 1.1,
+            "qk_layernorm": qk_layernorm,
+        }
         apply_flex_backend_kwargs(extra_kwargs, dispatcher_type, flex_backend)
         if fp8_flag is not None:
             extra_kwargs["fp8_recipe"] = fp8_flag[1]
@@ -463,7 +468,7 @@ class TestA2AOverlap:
             transformer_layer_spec = get_gpt_layer_with_transformer_engine_spec(
                 num_experts=16,
                 moe_grouped_gemm=True,
-                qk_layernorm=True,
+                qk_layernorm=qk_layernorm,
                 multi_latent_attention=True,
             )
             mtp_block_spec = get_gpt_mtp_block_spec(config, transformer_layer_spec, True)

--- a/tests/unit_tests/distributed/test_finalize_model_grads.py
+++ b/tests/unit_tests/distributed/test_finalize_model_grads.py
@@ -120,6 +120,7 @@ class TestFinalizeModelGradsMoEExpertBias:
 class TestAllReduceLNGrads:
 
     def init_model(self, share_embeddings_and_output_weights: bool = False):
+        qk_layernorm = True
         self.transformer_config = TransformerConfig(
             num_layers=2,
             hidden_size=12,
@@ -127,13 +128,15 @@ class TestAllReduceLNGrads:
             use_cpu_initialization=True,
             tensor_model_parallel_size=self.tp_size,
             pipeline_model_parallel_size=self.pp_size,
-            qk_layernorm=True,
+            qk_layernorm=qk_layernorm,
             pipeline_dtype=torch.float32,
         )
 
         self.model = GPTModel(
             config=self.transformer_config,
-            transformer_layer_spec=get_gpt_layer_with_transformer_engine_spec(qk_layernorm=True),
+            transformer_layer_spec=get_gpt_layer_with_transformer_engine_spec(
+                qk_layernorm=qk_layernorm
+            ),
             vocab_size=100,
             max_sequence_length=4,
             share_embeddings_and_output_weights=share_embeddings_and_output_weights,

--- a/tests/unit_tests/models/test_hybrid_model.py
+++ b/tests/unit_tests/models/test_hybrid_model.py
@@ -1,9 +1,12 @@
 # Copyright (c) 2024-2026, NVIDIA CORPORATION. All rights reserved.
 
+import dataclasses
+import functools
 import os
 from datetime import timedelta
 from itertools import accumulate
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 import torch
@@ -27,12 +30,75 @@ from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_stack_spec
 from megatron.core.models.hybrid.hybrid_model import HybridModel, _hybrid_logging_pg_kwargs
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
-from megatron.core.transformer import TransformerConfig
+from megatron.core.transformer import MLATransformerConfig, TransformerConfig
 from megatron.core.transformer.enums import AttnBackend
 from megatron.core.transformer.module import Float16Module, MegatronModule
 from megatron.core.transformer.spec_utils import ModuleSpec
 from megatron.core.utils import divide, is_fa_min_version, is_torch_min_version
 from tests.unit_tests.test_utilities import Utils
+
+try:
+    from fast_hadamard_transform import hadamard_transform as _hadamard_transform
+
+    _HAVE_HADAMARD = True
+except ImportError:
+    _HAVE_HADAMARD = False
+    _hadamard_transform = None
+
+
+def _mock_hadamard_transform(x: torch.Tensor, scale: float = 1.0) -> torch.Tensor:
+    """Identity-with-scale stand-in for `fast_hadamard_transform.hadamard_transform`.
+
+    Mirrors the helper in `tests/unit_tests/transformer/experimental_attention_variant/
+    test_attention_variant_dsa.py` so that DSA forward tests run in containers that
+    don't ship the upstream library.
+    """
+    return x * scale
+
+
+def _is_dataclass_instance(value):
+    return dataclasses.is_dataclass(value) and not isinstance(value, type)
+
+
+def _assert_equal_with_partial_contents(left, right, path="root"):
+    """Assert recursive equality while comparing `partial` objects structurally."""
+    if isinstance(left, functools.partial) or isinstance(right, functools.partial):
+        assert isinstance(left, functools.partial), f"{path}: left is not `partial`"
+        assert isinstance(right, functools.partial), f"{path}: right is not `partial`"
+        _assert_equal_with_partial_contents(left.func, right.func, f"{path}.func")
+        _assert_equal_with_partial_contents(left.args, right.args, f"{path}.args")
+        _assert_equal_with_partial_contents(
+            left.keywords or {}, right.keywords or {}, f"{path}.keywords"
+        )
+        return
+
+    if _is_dataclass_instance(left) or _is_dataclass_instance(right):
+        assert _is_dataclass_instance(left), f"{path}: left is not a dataclass"
+        assert _is_dataclass_instance(right), f"{path}: right is not a dataclass"
+        assert type(left) is type(right), f"{path}: dataclass types differ"
+        for field in dataclasses.fields(left):
+            if field.compare:
+                _assert_equal_with_partial_contents(
+                    getattr(left, field.name), getattr(right, field.name), f"{path}.{field.name}"
+                )
+        return
+
+    if isinstance(left, dict) or isinstance(right, dict):
+        assert isinstance(left, dict), f"{path}: left is not a dict"
+        assert isinstance(right, dict), f"{path}: right is not a dict"
+        assert left.keys() == right.keys(), f"{path}: dict keys differ"
+        for key in left:
+            _assert_equal_with_partial_contents(left[key], right[key], f"{path}[{key!r}]")
+        return
+
+    if isinstance(left, (list, tuple)) or isinstance(right, (list, tuple)):
+        assert type(left) is type(right), f"{path}: sequence types differ"
+        assert len(left) == len(right), f"{path}: sequence lengths differ"
+        for index, (left_item, right_item) in enumerate(zip(left, right)):
+            _assert_equal_with_partial_contents(left_item, right_item, f"{path}[{index}]")
+        return
+
+    assert left == right, f"{path}: values differ"
 
 
 class _DummyHybridLayer(MegatronModule):
@@ -543,6 +609,12 @@ class TestHybridModel:
 
 class TestHybridQKLayernorm:
 
+    # Subclasses override these to retarget the same tests at MLA's
+    # `mla_layer.kv_layernorm` or DSA's `dsa_layer.kv_layernorm`. The base class
+    # exercises the SelfAttention path with `attention_layer.k_layernorm`.
+    _attention_layer_attr = 'attention_layer'
+    _k_norm_attr = 'k_layernorm'
+
     def setup_method(self, method):
         Utils.initialize_model_parallel(1, 1)
         model_parallel_cuda_manual_seed(123)
@@ -550,7 +622,9 @@ class TestHybridQKLayernorm:
     def teardown_method(self, method):
         Utils.destroy_model_parallel()
 
-    def _build_model(self, **config_overrides):
+    def _build_model(self, spec=None, **config_overrides):
+        if spec is None:
+            spec = hybrid_stack_spec
         config = TransformerConfig(
             num_layers=3,
             hidden_size=256,
@@ -560,26 +634,32 @@ class TestHybridQKLayernorm:
         )
         return HybridModel(
             config=config,
-            hybrid_stack_spec=hybrid_stack_spec,
+            hybrid_stack_spec=spec,
             vocab_size=100,
             max_sequence_length=4,
             hybrid_layer_pattern="M*-",
         )
 
     def _get_attention_layer(self, model):
-        """Return the SelfAttention submodule from the attention layer."""
+        """Return the self-attention submodule that owns a `q_layernorm`."""
         for layer in model.decoder.layers:
             if hasattr(layer, 'self_attention') and hasattr(layer.self_attention, 'q_layernorm'):
                 return layer.self_attention
         return None
 
-    def test_no_qk_norm_by_default(self):
-        """Without qk_layernorm, attention has no q/k layernorm."""
+    def _get_k_norm(self, attn):
+        return getattr(attn, self._k_norm_attr)
+
+    def test_trivial_qk_norm_by_default(self):
+        """Without qk_layernorm, attention has trivial q/k layernorm."""
+        from megatron.core.transformer.identity_op import IdentityOp
+
         model = self._build_model()
         attn = self._get_attention_layer(model)
         assert attn is not None
-        assert attn.q_layernorm is None
-        assert attn.k_layernorm is None
+        assert attn.q_layernorm is None or isinstance(attn.q_layernorm, IdentityOp)
+        k_norm = self._get_k_norm(attn)
+        assert k_norm is None or isinstance(k_norm, IdentityOp)
 
     def test_qk_layernorm_from_config(self):
         """config.qk_layernorm=True creates q/k layernorm even with static spec."""
@@ -589,7 +669,7 @@ class TestHybridQKLayernorm:
         # TENorm is a factory (__new__ returns a TE LayerNorm/RMSNorm), so we
         # verify the norm was created rather than checking for a specific type.
         assert attn.q_layernorm is not None
-        assert attn.k_layernorm is not None
+        assert self._get_k_norm(attn) is not None
 
     def test_qk_l2_norm_from_config(self):
         """config.qk_l2_norm=True creates L2Norm q/k layernorm."""
@@ -599,57 +679,649 @@ class TestHybridQKLayernorm:
         attn = self._get_attention_layer(model)
         assert attn is not None
         assert isinstance(attn.q_layernorm, L2Norm)
-        assert isinstance(attn.k_layernorm, L2Norm)
+        assert isinstance(self._get_k_norm(attn), L2Norm)
 
     def test_spec_provided_norm_not_overwritten(self):
         """When the spec already provides q/k layernorm, config doesn't override it."""
         import copy
 
-        from megatron.core.extensions.transformer_engine import (
-            TEDotProductAttention,
-            TELayerNormColumnParallelLinear,
-            TERowParallelLinear,
-        )
-        from megatron.core.transformer.attention import SelfAttention, SelfAttentionSubmodules
-        from megatron.core.transformer.enums import AttnMaskType
         from megatron.core.transformer.identity_op import IdentityOp
-        from megatron.core.transformer.spec_utils import ModuleSpec
-        from megatron.core.transformer.transformer_layer import (
-            TransformerLayer,
-            TransformerLayerSubmodules,
-        )
 
-        # Build a spec that explicitly sets q/k layernorm to IdentityOp
+        # Build a spec that explicitly sets q/k layernorm to IdentityOp on the
+        # attention layer that this subclass exercises.
         spec = copy.deepcopy(hybrid_stack_spec)
-        spec.submodules.attention_layer.submodules.self_attention.submodules.q_layernorm = (
-            IdentityOp
-        )
-        spec.submodules.attention_layer.submodules.self_attention.submodules.k_layernorm = (
-            IdentityOp
-        )
+        attn_submodules = getattr(
+            spec.submodules, self._attention_layer_attr
+        ).submodules.self_attention.submodules
+        attn_submodules.q_layernorm = IdentityOp
+        setattr(attn_submodules, self._k_norm_attr, IdentityOp)
 
-        config = TransformerConfig(
-            num_layers=3,
-            hidden_size=256,
-            num_attention_heads=4,
-            use_cpu_initialization=True,
-            qk_layernorm=True,
-        )
-        model = HybridModel(
-            config=config,
-            hybrid_stack_spec=spec,
-            vocab_size=100,
-            max_sequence_length=4,
-            hybrid_layer_pattern="M*-",
-        )
+        model = self._build_model(spec=spec, qk_layernorm=True)
         attn = self._get_attention_layer(model)
         assert attn is not None
         assert isinstance(attn.q_layernorm, IdentityOp)
-        assert isinstance(attn.k_layernorm, IdentityOp)
+        assert isinstance(self._get_k_norm(attn), IdentityOp)
 
     def test_forward_with_qk_layernorm(self):
         """HybridModel forward pass works with qk_layernorm enabled."""
         model = self._build_model(qk_layernorm=True)
+        model.cuda()
+
+        sequence_length = 4
+        micro_batch_size = 2
+        data = list(range(sequence_length))
+        input_ids = torch.tensor(data, dtype=torch.int64).repeat((micro_batch_size, 1)).cuda()
+        position_ids = torch.tensor(data, dtype=torch.int64).repeat((micro_batch_size, 1)).cuda()
+        attention_mask = torch.ones(
+            (micro_batch_size, 1, sequence_length, sequence_length), dtype=bool
+        ).cuda()
+
+        logits = model.forward(
+            input_ids=input_ids, position_ids=position_ids, attention_mask=attention_mask
+        )
+
+        assert logits.shape[0] == micro_batch_size
+        assert logits.shape[1] == sequence_length
+        assert logits.shape[2] == 100
+
+
+class TestHybridMLAQKLayernorm(TestHybridQKLayernorm):
+    """Tests QK norm configuration of HybridModel with MLA."""
+
+    _attention_layer_attr = 'mla_layer'
+    _k_norm_attr = 'kv_layernorm'
+
+    def _build_model(self, spec=None, **config_overrides):
+        if spec is None:
+            spec = hybrid_stack_spec
+        config = MLATransformerConfig(
+            num_layers=3,
+            hidden_size=256,
+            num_attention_heads=4,
+            use_cpu_initialization=True,
+            **config_overrides,
+        )
+        return HybridModel(
+            config=config,
+            hybrid_stack_spec=spec,
+            vocab_size=100,
+            max_sequence_length=4,
+            hybrid_layer_pattern="M+-",
+        )
+
+    def test_qk_l2_norm_from_config(self):
+        with pytest.raises(ValueError, match="qk_l2_norm is not supported"):
+            super().test_qk_l2_norm_from_config()
+
+
+class TestHybridDSAQKLayernorm(TestHybridQKLayernorm):
+    """Tests QK norm configuration of HybridModel with DSA."""
+
+    _attention_layer_attr = 'dsa_layer'
+    _k_norm_attr = 'kv_layernorm'
+
+    @pytest.fixture(autouse=True)
+    def _patch_hadamard_if_needed(self):
+        if not _HAVE_HADAMARD:
+            with patch(
+                'megatron.core.transformer.experimental_attention_variant.dsa.hadamard_transform',
+                _mock_hadamard_transform,
+            ):
+                yield
+        else:
+            yield
+
+    def test_spec_provided_norm_not_overwritten(self):
+        # DSA cannot fuse the QK norm into the up-projection, so a trivial
+        # `IdentityOp` spec is auto-promoted to `TENorm` when `qk_layernorm=True`.
+        # Finer-grained spec-respect behavior is covered by TestDSAQKNormResolution.
+        pytest.skip("DSA auto-promotes IdentityOp to TENorm; covered by TestDSAQKNormResolution.")
+
+    def _build_model(self, spec=None, **config_overrides):
+        if spec is None:
+            spec = hybrid_stack_spec
+        config_kwargs = dict(
+            num_layers=3,
+            hidden_size=256,
+            num_attention_heads=4,
+            use_cpu_initialization=True,
+            add_bias_linear=False,
+            # AbsorbedMLASelfAttention forwards `x` and `qr` to the DSA core attention; without
+            # this, the DSA core attention's forward fails on missing positional arguments.
+            experimental_attention_variant="dsa",
+            # DSA-specific settings; defaults are None and DSAIndexer requires them.
+            dsa_indexer_n_heads=8,
+            dsa_indexer_head_dim=64,
+            dsa_indexer_topk=32,
+            # The indexer-loss path runs in training mode and multiplies by this coefficient;
+            # leaving it at the default `None` raises `TypeError: ... 'Tensor' and 'NoneType'`.
+            dsa_indexer_loss_coeff=1.0,
+            # DSA's `rotate_activation` (Hadamard rotation) only supports bf16 input.
+            bf16=True,
+            params_dtype=torch.bfloat16,
+        )
+        config_kwargs.update(config_overrides)
+        config = MLATransformerConfig(**config_kwargs)
+        return HybridModel(
+            config=config,
+            hybrid_stack_spec=spec,
+            vocab_size=100,
+            max_sequence_length=4,
+            hybrid_layer_pattern="MD-",
+        )
+
+    def test_qk_l2_norm_from_config(self):
+        with pytest.raises(ValueError, match="qk_l2_norm is not supported"):
+            super().test_qk_l2_norm_from_config()
+
+
+class _MLAQKNormTestBase:
+    """Common machinery for MLA/DSA QK-norm spec tests.
+
+    Subclasses override `experimental_attention_variant` and
+    `hybrid_layer_pattern` to target the MLA vs. DSA code path.
+    """
+
+    experimental_attention_variant = None
+    hybrid_layer_pattern = "M+-"
+    mla_layer_attr = "mla_layer"
+
+    def setup_method(self, method):
+        Utils.initialize_model_parallel(1, 1)
+        model_parallel_cuda_manual_seed(123)
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    def _make_spec(self, **submodule_overrides):
+        """Return a copy of `hybrid_stack_spec` with MLA/DSA submodule overrides."""
+        import copy
+
+        spec = copy.deepcopy(hybrid_stack_spec)
+        mla_submodules = getattr(
+            spec.submodules, self.mla_layer_attr
+        ).submodules.self_attention.submodules
+        for key, value in submodule_overrides.items():
+            setattr(mla_submodules, key, value)
+        return spec
+
+    def _build_model(self, spec=None, **config_overrides):
+        if spec is None:
+            spec = hybrid_stack_spec
+        config_kwargs = dict(
+            num_layers=3, hidden_size=256, num_attention_heads=4, use_cpu_initialization=True
+        )
+        if self.experimental_attention_variant is not None:
+            config_kwargs["experimental_attention_variant"] = self.experimental_attention_variant
+            if self.experimental_attention_variant == "dsa":
+                # Must not be True for DSA.
+                config_kwargs.setdefault("add_bias_linear", False)
+                # DSAIndexer requires these; their config defaults are None.
+                config_kwargs.setdefault("dsa_indexer_n_heads", 8)
+                config_kwargs.setdefault("dsa_indexer_head_dim", 64)
+                config_kwargs.setdefault("dsa_indexer_topk", 32)
+
+        config_kwargs.update(config_overrides)
+        config = MLATransformerConfig(**config_kwargs)
+        return HybridModel(
+            config=config,
+            hybrid_stack_spec=spec,
+            vocab_size=100,
+            max_sequence_length=4,
+            hybrid_layer_pattern=self.hybrid_layer_pattern,
+        )
+
+    def _get_mla_attention(self, model):
+        """Return the attention submodule for the selected MLA variant, or None."""
+        if self.experimental_attention_variant == "dsa":
+            from megatron.core.transformer.experimental_attention_variant.absorbed_mla import (
+                AbsorbedMLASelfAttention,
+            )
+
+            attention_cls = AbsorbedMLASelfAttention
+        else:
+            from megatron.core.transformer.multi_latent_attention import MLASelfAttention
+
+            attention_cls = MLASelfAttention
+
+        for layer in model.decoder.layers:
+            if hasattr(layer, 'self_attention') and isinstance(layer.self_attention, attention_cls):
+                return layer.self_attention
+        return None
+
+
+class TestMLAQKNormSpecValidation(_MLAQKNormTestBase):
+    """Tests QK norm spec validation in `MLASelfAttention`.
+
+    These errors guard against silently ignoring a configured norm or
+    double-applying one through a fused norm+linear.
+    """
+
+    experimental_attention_variant = None
+    hybrid_layer_pattern = "M+-"
+    mla_layer_attr = "mla_layer"
+
+    def test_q_norm_without_q_lora_rank_raises(self):
+        """When `q_lora_rank is None`, a non-trivial `q_layernorm` would
+        never be reached and must error out.
+        """
+        from megatron.core.extensions.transformer_engine import TENorm
+
+        spec = self._make_spec(q_layernorm=TENorm)
+        with pytest.raises(ValueError, match=r"q_lora_rank is None"):
+            self._build_model(spec=spec, q_lora_rank=None)
+
+    def test_q_norm_without_q_lora_rank_hint_for_non_fused_linear(self):
+        """Error message hints at fused linear when `linear_q_proj` is non-fused."""
+        from megatron.core.extensions.transformer_engine import TENorm
+
+        spec = self._make_spec(q_layernorm=TENorm)
+        with pytest.raises(ValueError, match=r"fused norm\+linear for"):
+            self._build_model(spec=spec, q_lora_rank=None)
+
+    def test_fused_linear_q_up_with_q_norm_raises(self):
+        """Non-trivial `q_layernorm` combined with a fused `linear_q_up_proj`
+        would apply the norm twice.
+        """
+        from megatron.core.extensions.transformer_engine import (
+            TELayerNormColumnParallelLinear,
+            TENorm,
+        )
+
+        spec = self._make_spec(q_layernorm=TENorm, linear_q_up_proj=TELayerNormColumnParallelLinear)
+        with pytest.raises(ValueError, match=r"fused norm\+linear"):
+            self._build_model(spec=spec)
+
+    def test_fused_linear_kv_up_with_kv_norm_raises(self):
+        """Non-trivial `kv_layernorm` combined with a fused `linear_kv_up_proj`
+        would apply the norm twice.
+        """
+        from megatron.core.extensions.transformer_engine import (
+            TELayerNormColumnParallelLinear,
+            TENorm,
+        )
+
+        spec = self._make_spec(
+            kv_layernorm=TENorm, linear_kv_up_proj=TELayerNormColumnParallelLinear
+        )
+        with pytest.raises(ValueError, match=r"fused norm\+linear"):
+            self._build_model(spec=spec)
+
+
+class TestMLAQKNormResolution(_MLAQKNormTestBase):
+    """Tests `_resolve_qk_norm_config` for MLA.
+
+    Covers fusion auto-selection, spec overrides, and the "disabled"-path
+    guards that reject fused/explicit norms when `qk_layernorm` is off.
+    """
+
+    experimental_attention_variant = None
+    hybrid_layer_pattern = "M+-"
+    mla_layer_attr = "mla_layer"
+
+    def test_qk_layernorm_fuses_kv_up_by_default(self):
+        """With default (trivial) `kv_layernorm`, enabling `qk_layernorm`
+        auto-selects the fused `TELayerNormColumnParallelLinear` for KV up.
+        """
+        from megatron.core.extensions.transformer_engine import TELayerNormColumnParallelLinear
+        from megatron.core.transformer.identity_op import IdentityOp
+
+        model = self._build_model(qk_layernorm=True)
+        attn = self._get_mla_attention(model)
+        assert attn is not None
+        assert isinstance(attn.linear_kv_up_proj, TELayerNormColumnParallelLinear)
+        assert isinstance(attn.kv_layernorm, IdentityOp)
+
+    def test_spec_q_norm_disables_q_up_fusion(self):
+        """A non-trivial `q_layernorm` from the spec must force a non-fused
+        `linear_q_up_proj` so the norm isn't applied on top of a fused one.
+        """
+        from megatron.core.extensions.transformer_engine import (
+            TEColumnParallelLinear,
+            TELayerNormColumnParallelLinear,
+            TENorm,
+        )
+
+        spec = self._make_spec(q_layernorm=TENorm)
+        model = self._build_model(spec=spec, qk_layernorm=True)
+        attn = self._get_mla_attention(model)
+        assert attn is not None
+        assert isinstance(attn.linear_q_up_proj, TEColumnParallelLinear)
+        assert not isinstance(attn.linear_q_up_proj, TELayerNormColumnParallelLinear)
+        # The spec's norm is actually used; it's not reset to IdentityOp.
+        assert attn.q_layernorm is not None
+        from megatron.core.transformer.identity_op import IdentityOp
+
+        assert not isinstance(attn.q_layernorm, IdentityOp)
+
+    def test_spec_kv_norm_disables_kv_up_fusion(self):
+        """Mirror of `test_spec_q_norm_disables_q_up_fusion` for KV."""
+        from megatron.core.extensions.transformer_engine import (
+            TEColumnParallelLinear,
+            TELayerNormColumnParallelLinear,
+            TENorm,
+        )
+
+        spec = self._make_spec(kv_layernorm=TENorm)
+        model = self._build_model(spec=spec, qk_layernorm=True)
+        attn = self._get_mla_attention(model)
+        assert attn is not None
+        assert isinstance(attn.linear_kv_up_proj, TEColumnParallelLinear)
+        assert not isinstance(attn.linear_kv_up_proj, TELayerNormColumnParallelLinear)
+        from megatron.core.transformer.identity_op import IdentityOp
+
+        assert not isinstance(attn.kv_layernorm, IdentityOp)
+
+    def test_disabled_qk_layernorm_rejects_fused_linear_q_up(self):
+        """When `qk_layernorm` is off, spec must not force fused linear_q_up_proj."""
+        from megatron.core.extensions.transformer_engine import TELayerNormColumnParallelLinear
+
+        spec = self._make_spec(linear_q_up_proj=TELayerNormColumnParallelLinear)
+        with pytest.raises(ValueError, match=r"supposed to be disabled"):
+            self._build_model(spec=spec)
+
+    def test_disabled_qk_layernorm_rejects_fused_linear_kv_up(self):
+        """When `qk_layernorm` is off, spec must not force fused linear_kv_up_proj."""
+        from megatron.core.extensions.transformer_engine import TELayerNormColumnParallelLinear
+
+        spec = self._make_spec(linear_kv_up_proj=TELayerNormColumnParallelLinear)
+        with pytest.raises(ValueError, match=r"supposed to be disabled"):
+            self._build_model(spec=spec)
+
+    def test_disabled_qk_layernorm_rejects_spec_norms(self):
+        """When `qk_layernorm` is off, spec must not carry explicit q/kv layernorms."""
+        from megatron.core.extensions.transformer_engine import TENorm
+
+        for overrides in (
+            {"q_layernorm": TENorm},
+            {"kv_layernorm": TENorm},
+            {"q_layernorm": TENorm, "kv_layernorm": TENorm},
+        ):
+            spec = self._make_spec(**overrides)
+            with pytest.raises(ValueError, match=r"supposed to be disabled"):
+                self._build_model(spec=spec)
+
+
+class TestDSAQKNormResolution(_MLAQKNormTestBase):
+    """Tests `_resolve_qk_norm_config` for DSA.
+
+    DSA requires non-fused Q/KV up projections and explicit norms;
+    the fused optimization valid for MLA must be rejected here.
+    """
+
+    experimental_attention_variant = "dsa"
+    hybrid_layer_pattern = "MD-"
+    mla_layer_attr = "dsa_layer"
+
+    def test_qk_layernorm_uses_unfused_linear_and_te_norm(self):
+        """With default spec, DSA + `qk_layernorm=True` uses non-fused
+        `TEColumnParallelLinear` and `TENorm` for Q/KV.
+        """
+        from megatron.core.extensions.transformer_engine import (
+            TEColumnParallelLinear,
+            TELayerNormColumnParallelLinear,
+        )
+        from megatron.core.transformer.identity_op import IdentityOp
+
+        model = self._build_model(qk_layernorm=True)
+        attn = self._get_mla_attention(model)
+        assert attn is not None
+        assert isinstance(attn.linear_q_up_proj, TEColumnParallelLinear)
+        assert not isinstance(attn.linear_q_up_proj, TELayerNormColumnParallelLinear)
+        assert isinstance(attn.linear_kv_up_proj, TEColumnParallelLinear)
+        assert not isinstance(attn.linear_kv_up_proj, TELayerNormColumnParallelLinear)
+        assert not isinstance(attn.q_layernorm, IdentityOp)
+        assert not isinstance(attn.kv_layernorm, IdentityOp)
+
+    def test_qk_layernorm_without_q_lora_rank_raises(self):
+        """DSA cannot apply Q norm when `q_lora_rank is None`."""
+        with pytest.raises(ValueError, match=r"q_lora_rank is None.*not supported for DSA"):
+            self._build_model(qk_layernorm=True, q_lora_rank=None)
+
+    def test_qk_layernorm_rejects_fused_linear_q_up(self):
+        """DSA does not support the fused norm+linear optimization."""
+        from megatron.core.extensions.transformer_engine import TELayerNormColumnParallelLinear
+
+        spec = self._make_spec(linear_q_up_proj=TELayerNormColumnParallelLinear)
+        with pytest.raises(ValueError, match=r"not supported for DSA"):
+            self._build_model(spec=spec, qk_layernorm=True)
+
+    def test_qk_layernorm_without_q_lora_rejects_fused_linear_q(self):
+        """DSA does not support fused `linear_q_proj` when `q_lora_rank=None`."""
+        from megatron.core.extensions.transformer_engine import TELayerNormColumnParallelLinear
+
+        spec = self._make_spec(linear_q_proj=TELayerNormColumnParallelLinear)
+        with pytest.raises(ValueError, match=r"not supported for DSA"):
+            self._build_model(spec=spec, qk_layernorm=True, q_lora_rank=None)
+
+    def test_disabled_qk_layernorm_rejects_fused_linear_kv_up(self):
+        """When `qk_layernorm` is off, spec must not force fused linear_kv_up_proj."""
+        from megatron.core.extensions.transformer_engine import TELayerNormColumnParallelLinear
+
+        spec = self._make_spec(linear_kv_up_proj=TELayerNormColumnParallelLinear)
+        with pytest.raises(ValueError, match=r"supposed to be disabled"):
+            self._build_model(spec=spec)
+
+    def test_disabled_qk_layernorm_rejects_spec_norms(self):
+        """When `qk_layernorm` is off, spec must not carry explicit q/kv layernorms."""
+        from megatron.core.extensions.transformer_engine import TENorm
+
+        for overrides in (
+            {"q_layernorm": TENorm},
+            {"kv_layernorm": TENorm},
+            {"q_layernorm": TENorm, "kv_layernorm": TENorm},
+        ):
+            spec = self._make_spec(**overrides)
+            with pytest.raises(ValueError, match=r"supposed to be disabled"):
+                self._build_model(spec=spec)
+
+
+class TestMLADownProjFusion:
+    """Tests `HybridStack._fuse_mla_down_proj`.
+
+    The method rewrites the MLA `ModuleSpec` in place on a deep-copied
+    `HybridStackSubmodules` when `config.mla_down_proj_fusion=True`, swapping
+    the self-attention module to `FusedMLASelfAttention` and collapsing the
+    separate q/kv down projections into a single fused `linear_qkv_down_proj`
+    that also absorbs the input layernorm.
+    """
+
+    def setup_method(self, method):
+        Utils.initialize_model_parallel(1, 1)
+        model_parallel_cuda_manual_seed(123)
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    def _fresh_submodules(self):
+        """Return a deep copy of `hybrid_stack_spec.submodules` so tests don't
+        share state through `hybrid_stack_spec`.
+        """
+        import copy
+
+        return copy.deepcopy(hybrid_stack_spec.submodules)
+
+    def _call_fuse(self, submodules, *, mla_down_proj_fusion):
+        """Invoke `_fuse_mla_down_proj` as an unbound method with a minimal
+        stub for `self`. The method only reads `self.config`, so we can avoid
+        constructing a full `HybridStack`.
+        """
+        from megatron.core.models.hybrid.hybrid_block import HybridStack
+
+        stub = SimpleNamespace(config=SimpleNamespace(mla_down_proj_fusion=mla_down_proj_fusion))
+        # Mimic the call-site check in `HybridStack.__init__`.
+        if getattr(stub.config, "mla_down_proj_fusion", False):
+            submodules = HybridStack._fuse_mla_down_proj(stub, submodules)
+        return submodules
+
+    def _build_model(self, pattern="M+-", **config_overrides):
+        config_kwargs = dict(
+            num_layers=3, hidden_size=256, num_attention_heads=4, use_cpu_initialization=True
+        )
+        config_kwargs.update(config_overrides)
+        config = MLATransformerConfig(**config_kwargs)
+        return HybridModel(
+            config=config,
+            hybrid_stack_spec=hybrid_stack_spec,
+            vocab_size=100,
+            max_sequence_length=4,
+            hybrid_layer_pattern=pattern,
+        )
+
+    def _get_layer_with_mla(self, model):
+        """Return the layer whose self-attention is an `MLASelfAttention`
+        (which includes its `FusedMLASelfAttention` subclass).
+        """
+        from megatron.core.transformer.multi_latent_attention import MLASelfAttention
+
+        for layer in model.decoder.layers:
+            if hasattr(layer, 'self_attention') and isinstance(
+                layer.self_attention, MLASelfAttention
+            ):
+                return layer
+        return None
+
+    def test_disabled_returns_spec_unchanged(self):
+        """Flag off: method returns the same object, no copying or rewriting."""
+        submodules = self._fresh_submodules()
+        result = self._call_fuse(submodules, mla_down_proj_fusion=False)
+        assert result is submodules
+
+    def test_enabled_rewrites_mla_spec(self):
+        """Flag on: MLA spec is swapped to the fused module and fused linear."""
+        from megatron.core.extensions.transformer_engine import TELayerNormColumnParallelLinear
+        from megatron.core.transformer.identity_op import IdentityOp
+        from megatron.core.transformer.multi_latent_attention import FusedMLASelfAttention
+
+        submodules = self._fresh_submodules()
+        result = self._call_fuse(submodules, mla_down_proj_fusion=True)
+
+        mla_spec = result.mla_layer
+        assert mla_spec.submodules.input_layernorm is IdentityOp
+        assert mla_spec.submodules.self_attention.module is FusedMLASelfAttention
+
+        attn_submodules = mla_spec.submodules.self_attention.submodules
+        assert attn_submodules.linear_qkv_down_proj is TELayerNormColumnParallelLinear
+        assert attn_submodules.linear_q_down_proj is None
+        assert attn_submodules.linear_kv_down_proj is None
+
+    def test_enabled_sets_sharded_state_dict_keys_map(self):
+        """The keys map is written on the MLA layer submodules for checkpoint
+        compatibility with pre-fusion checkpoints.
+        """
+        submodules = self._fresh_submodules()
+        result = self._call_fuse(submodules, mla_down_proj_fusion=True)
+
+        keys_map = result.mla_layer.submodules.sharded_state_dict_keys_map
+        assert keys_map == {
+            "self_attention.linear_q_down_proj.layer_norm_": "input_layernorm.",
+            "self_attention.linear_kv_down_proj.layer_norm_": "input_layernorm.",
+            "self_attention.linear_qkv_down_proj.layer_norm_": "input_layernorm.",
+        }
+
+    def test_enabled_deep_copies_input_submodules(self):
+        """The caller's submodules object must not be mutated – the method
+        deep-copies before rewriting, so callers can safely reuse their spec.
+        """
+        from megatron.core.transformer.multi_latent_attention import (
+            FusedMLASelfAttention,
+            MLASelfAttention,
+        )
+
+        submodules = self._fresh_submodules()
+        original_mla_module = submodules.mla_layer.submodules.self_attention.module
+        original_q_down_proj = (
+            submodules.mla_layer.submodules.self_attention.submodules.linear_q_down_proj
+        )
+        assert original_mla_module is MLASelfAttention  # sanity check of baseline
+
+        result = self._call_fuse(submodules, mla_down_proj_fusion=True)
+
+        # Original is unchanged.
+        assert submodules.mla_layer.submodules.self_attention.module is original_mla_module
+        assert (
+            submodules.mla_layer.submodules.self_attention.submodules.linear_q_down_proj
+            is original_q_down_proj
+        )
+        # And result is a different object than the input.
+        assert result is not submodules
+        assert result.mla_layer is not submodules.mla_layer
+        # Plus the fused module only shows up on the returned copy.
+        assert result.mla_layer.submodules.self_attention.module is FusedMLASelfAttention
+
+    def test_enabled_leaves_dsa_layer_alone(self):
+        """MLA fusion must not rewrite the absorbed DSA attention specification."""
+        from megatron.core.transformer.experimental_attention_variant.absorbed_mla import (
+            AbsorbedMLASelfAttention,
+        )
+        from megatron.core.transformer.multi_latent_attention import FusedMLASelfAttention
+
+        submodules = self._fresh_submodules()
+        result = self._call_fuse(submodules, mla_down_proj_fusion=True)
+
+        assert result.dsa_layer.submodules.self_attention.module is AbsorbedMLASelfAttention
+        assert result.dsa_layer.submodules.self_attention.module is not FusedMLASelfAttention
+        # DSA's down projections must remain non-`None` (they're still used
+        # via the unfused path).
+        assert result.dsa_layer.submodules.self_attention.submodules.linear_q_down_proj is not None
+        assert result.dsa_layer.submodules.self_attention.submodules.linear_kv_down_proj is not None
+
+    def test_enabled_leaves_non_mla_layers_alone(self):
+        """Unrelated layer specs (mamba, attention, mlp) must survive unchanged."""
+        submodules = self._fresh_submodules()
+        original_mamba = submodules.mamba_layer
+        original_attention = submodules.attention_layer
+        original_mlp = submodules.mlp_layer
+
+        result = self._call_fuse(submodules, mla_down_proj_fusion=True)
+
+        _assert_equal_with_partial_contents(result.mamba_layer, original_mamba)
+        _assert_equal_with_partial_contents(result.attention_layer, original_attention)
+        _assert_equal_with_partial_contents(result.mlp_layer, original_mlp)
+
+    def test_model_uses_fused_mla_when_enabled(self):
+        """Integration: a full HybridModel built with the flag uses
+        `FusedMLASelfAttention`.
+        """
+        from megatron.core.transformer.multi_latent_attention import FusedMLASelfAttention
+
+        model = self._build_model(mla_down_proj_fusion=True)
+        layer = self._get_layer_with_mla(model)
+        assert layer is not None
+        assert isinstance(layer.self_attention, FusedMLASelfAttention)
+        # And the fused down projection is present on the attention module.
+        assert hasattr(layer.self_attention, "linear_qkv_down_proj")
+
+    def test_model_uses_unfused_mla_when_disabled(self):
+        """Integration: with the flag off, MLA layers use the standard
+        `MLASelfAttention` (never the fused subclass).
+        """
+        from megatron.core.transformer.multi_latent_attention import (
+            FusedMLASelfAttention,
+            MLASelfAttention,
+        )
+
+        model = self._build_model(mla_down_proj_fusion=False)
+        layer = self._get_layer_with_mla(model)
+        assert layer is not None
+        assert isinstance(layer.self_attention, MLASelfAttention)
+        assert not isinstance(layer.self_attention, FusedMLASelfAttention)
+
+    def test_enabled_replaces_input_layernorm_with_identity(self):
+        """Integration: because the fused down-proj absorbs the input
+        layernorm, the transformer layer's own `input_layernorm` must be
+        `IdentityOp`.
+        """
+        from megatron.core.transformer.identity_op import IdentityOp
+
+        model = self._build_model(mla_down_proj_fusion=True)
+        layer = self._get_layer_with_mla(model)
+        assert layer is not None
+        assert isinstance(layer.input_layernorm, IdentityOp)
+
+    def test_forward_with_fused_mla(self):
+        """Integration: forward pass works with `mla_down_proj_fusion=True`."""
+        model = self._build_model(mla_down_proj_fusion=True)
         model.cuda()
 
         sequence_length = 4

--- a/tests/unit_tests/ssm/test_hybrid_block.py
+++ b/tests/unit_tests/ssm/test_hybrid_block.py
@@ -3,6 +3,7 @@
 import pytest
 import torch
 
+from megatron.core.extensions.transformer_engine import TEDotProductAttention
 from megatron.core.models.hybrid.hybrid_block import HybridStack, HyperConnectionHybridLayer
 from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols, validate_segment_layers
 from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_stack_spec
@@ -17,6 +18,7 @@ from megatron.core.transformer.experimental_attention_variant.absorbed_mla impor
 )
 from megatron.core.transformer.experimental_attention_variant.dsa import DSAttention
 from megatron.core.transformer.mlp import MLP
+from megatron.core.transformer.multi_latent_attention import MLASelfAttention
 from megatron.core.transformer.transformer_config import MLATransformerConfig
 from megatron.core.transformer.transformer_layer import TransformerLayer
 from tests.unit_tests.test_utilities import Utils
@@ -111,6 +113,32 @@ class TestHybridBlock:
         return HybridStack(
             transformer_config,
             modules,
+            layer_type_list=layer_type_list,
+            pp_layer_offset=0,
+            pg_collection=self.get_pg_collection(),
+        )
+
+    def get_mla_hybrid_block(self, layer_pattern):
+        layer_type_list = validate_segment_layers(layer_pattern)
+        transformer_config = MLATransformerConfig(
+            hidden_size=256,
+            num_layers=len(layer_type_list),
+            num_attention_heads=16,
+            use_cpu_initialization=True,
+            bf16=True,
+            params_dtype=torch.bfloat16,
+            q_lora_rank=64,
+            kv_lora_rank=64,
+            qk_head_dim=64,
+            qk_pos_emb_head_dim=32,
+            v_head_dim=64,
+            rope_type='rope',
+            rotary_base=10000,
+            rotary_percent=1.0,
+        )
+        return HybridStack(
+            transformer_config,
+            hybrid_stack_spec.submodules,
             layer_type_list=layer_type_list,
             pp_layer_offset=0,
             pg_collection=self.get_pg_collection(),
@@ -399,7 +427,7 @@ class TestHybridBlock:
         assert output.shape == (sequence_length, micro_batch_size, transformer_config.hidden_size)
 
     def test_invalid_layer_types_cause_failure(self):
-        invalid_symbol = '+'
+        invalid_symbol = 'X'
         assert invalid_symbol not in Symbols.VALID_LAYERS  # sanity check.
         layer_pattern = Symbols.MAMBA + Symbols.ATTENTION + Symbols.MLP + invalid_symbol
         # validate_segment_layers() in hybrid_layer_allocation.py throws a ValueError.
@@ -470,3 +498,20 @@ class TestHybridBlock:
         layer_pattern = Symbols.MAMBA + Symbols.ATTENTION + Symbols.DS_ATTENTION + Symbols.MAMBA
         with pytest.raises(ValueError):
             block = self.get_dsa_mamba_block(layer_pattern)
+
+    def test_mla_layer_types(self):
+        """+ builds standard MLA rather than DSA."""
+        layer_pattern = Symbols.MAMBA + Symbols.MLA + Symbols.MAMBA
+        block = self.get_mla_hybrid_block(layer_pattern)
+        layers = block.layers
+        assert isinstance(layers[0], MambaLayer)
+        assert isinstance(layers[1], TransformerLayer)
+        assert isinstance(layers[1].self_attention, MLASelfAttention)
+        assert isinstance(layers[1].self_attention.core_attention, TEDotProductAttention)
+        assert isinstance(layers[2], MambaLayer)
+
+    def test_mixed_attention_and_mla_layer_types(self):
+        """* and + in the same block fail."""
+        layer_pattern = Symbols.MAMBA + Symbols.ATTENTION + Symbols.MLA + Symbols.MAMBA
+        with pytest.raises(ValueError):
+            self.get_mla_hybrid_block(layer_pattern)

--- a/tests/unit_tests/ssm/test_hybrid_block.py
+++ b/tests/unit_tests/ssm/test_hybrid_block.py
@@ -3,6 +3,7 @@
 import pytest
 import torch
 
+from megatron.core.extensions.transformer_engine import TEDotProductAttention
 from megatron.core.models.hybrid.hybrid_block import HybridStack, HyperConnectionHybridLayer
 from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols, validate_segment_layers
 from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_stack_spec
@@ -17,6 +18,7 @@ from megatron.core.transformer.experimental_attention_variant.absorbed_mla impor
 )
 from megatron.core.transformer.experimental_attention_variant.dsa import DSAttention
 from megatron.core.transformer.mlp import MLP
+from megatron.core.transformer.multi_latent_attention import MLASelfAttention
 from megatron.core.transformer.transformer_config import MLATransformerConfig
 from megatron.core.transformer.transformer_layer import TransformerLayer
 from tests.unit_tests.test_utilities import Utils
@@ -111,6 +113,32 @@ class TestHybridBlock:
         return HybridStack(
             transformer_config,
             modules,
+            layer_type_list=layer_type_list,
+            pp_layer_offset=0,
+            pg_collection=self.get_pg_collection(),
+        )
+
+    def get_mla_hybrid_block(self, layer_pattern):
+        layer_type_list = validate_segment_layers(layer_pattern)
+        transformer_config = MLATransformerConfig(
+            hidden_size=256,
+            num_layers=len(layer_type_list),
+            num_attention_heads=16,
+            use_cpu_initialization=True,
+            bf16=True,
+            params_dtype=torch.bfloat16,
+            q_lora_rank=64,
+            kv_lora_rank=64,
+            qk_head_dim=64,
+            qk_pos_emb_head_dim=32,
+            v_head_dim=64,
+            rope_type='rope',
+            rotary_base=10000,
+            rotary_percent=1.0,
+        )
+        return HybridStack(
+            transformer_config,
+            hybrid_stack_spec.submodules,
             layer_type_list=layer_type_list,
             pp_layer_offset=0,
             pg_collection=self.get_pg_collection(),
@@ -485,3 +513,20 @@ class TestHybridBlock:
         layer_pattern = Symbols.MAMBA + Symbols.ATTENTION + Symbols.DS_ATTENTION + Symbols.MAMBA
         with pytest.raises(ValueError):
             block = self.get_dsa_mamba_block(layer_pattern)
+
+    def test_mla_layer_types(self):
+        """+ builds standard MLA rather than DSA."""
+        layer_pattern = Symbols.MAMBA + Symbols.MLA + Symbols.MAMBA
+        block = self.get_mla_hybrid_block(layer_pattern)
+        layers = block.layers
+        assert isinstance(layers[0], MambaLayer)
+        assert isinstance(layers[1], TransformerLayer)
+        assert isinstance(layers[1].self_attention, MLASelfAttention)
+        assert isinstance(layers[1].self_attention.core_attention, TEDotProductAttention)
+        assert isinstance(layers[2], MambaLayer)
+
+    def test_mixed_attention_and_mla_layer_types(self):
+        """* and + in the same block fail."""
+        layer_pattern = Symbols.MAMBA + Symbols.ATTENTION + Symbols.MLA + Symbols.MAMBA
+        with pytest.raises(ValueError):
+            self.get_mla_hybrid_block(layer_pattern)

--- a/tests/unit_tests/ssm/test_hybrid_layer_allocation.py
+++ b/tests/unit_tests/ssm/test_hybrid_layer_allocation.py
@@ -78,6 +78,7 @@ class TestValidateSegmentLayers:
             ("GGG*GGG*", ['G', 'G', 'G', '*', 'G', 'G', 'G', '*']),
             ("GEGEGE*E", ['G', 'E', 'G', 'E', 'G', 'E', '*', 'E']),
             ("MDMD", ['M', 'D', 'M', 'D']),
+            ("M+M+", ['M', '+', 'M', '+']),
         ]
         for pattern, expected in test_cases:
             result = validate_segment_layers(pattern)
@@ -101,6 +102,8 @@ class TestValidateSegmentLayers:
         with pytest.raises(ValueError):
             # Not allowed to have both standard Attention and MLA/DSA
             validate_segment_layers("MDM*-")
+        with pytest.raises(ValueError):
+            validate_segment_layers("M+M*-")
 
     def test_window_symbol(self):
         """'W' (sliding-window-only DSv4 attention) is a first-class MLA layer symbol."""
@@ -177,6 +180,8 @@ class TestParseHybridPattern:
             ("GEGEGE*E", "GEGEGE*E"),
             ("MDMD", "MDMD"),
             ("DM", "DM"),
+            ("M+M+", "M+M+"),
+            ("+M", "+M"),
         ]
         for pattern, expected_main in test_cases:
             result = parse_hybrid_pattern(pattern)
@@ -301,6 +306,8 @@ class TestParseHybridPattern:
             ("GEGEGE*E/GG/GG", "GEGEGE*E", "GG", 2),
             # DSA in main pattern with MTP
             ("MDMD/MD/MD", "MDMD", "MD", 2),
+            # MLA in main pattern with MTP
+            ("M+M+/M+/M+", "M+M+", "M+", 2),
         ]
         for pattern, expected_main, expected_mtp, expected_depths in test_cases:
             result = parse_hybrid_pattern(pattern)
@@ -327,6 +334,7 @@ class TestGetHybridLayerCounts:
             'D': 0,
             'G': 0,
             'M': 2,
+            '+': 0,
             '-': 0,
             'E': 0,
         }
@@ -341,6 +349,7 @@ class TestGetHybridLayerCounts:
             'D': 0,
             'G': 1,
             'M': 1,
+            '+': 0,
             '-': 1,
             'E': 1,
         }
@@ -352,6 +361,19 @@ class TestGetHybridLayerCounts:
             'D': 1,
             'G': 1,
             'M': 1,
+            '+': 0,
+            '-': 1,
+            'E': 1,
+        }
+        assert get_hybrid_layer_counts("MG+-E") == {
+            'C': 0,
+            'H': 0,
+            'W': 0,
+            '*': 0,
+            'D': 0,
+            'G': 1,
+            'M': 1,
+            '+': 1,
             '-': 1,
             'E': 1,
         }
@@ -366,6 +388,7 @@ class TestGetHybridLayerCounts:
             'D': 0,
             'G': 0,
             'M': 2,
+            '+': 0,
             '-': 0,
             'E': 0,
         }
@@ -377,6 +400,7 @@ class TestGetHybridLayerCounts:
             'D': 0,
             'G': 0,
             'M': 4,
+            '+': 0,
             '-': 4,
             'E': 0,
         }
@@ -391,6 +415,7 @@ class TestGetHybridLayerCounts:
             'D': 0,
             'G': 0,
             'M': 6,
+            '+': 0,
             '-': 0,
             'E': 0,
         }
@@ -406,6 +431,7 @@ class TestGetHybridLayerCounts:
             'D': 0,
             'G': 0,
             'M': 8,
+            '+': 0,
             '-': 4,
             'E': 0,
         }
@@ -419,6 +445,7 @@ class TestGetHybridLayerCounts:
             'D': 0,
             'G': 0,
             'M': 2,
+            '+': 0,
             '-': 0,
             'E': 2,
         }
@@ -433,6 +460,7 @@ class TestGetHybridLayerCounts:
             'D': 0,
             'G': 0,
             'M': 7,
+            '+': 0,
             '-': 0,
             'E': 0,
         }
@@ -446,6 +474,7 @@ class TestGetHybridLayerCounts:
             'D': 0,
             'G': 2,
             'M': 2,
+            '+': 0,
             '-': 0,
             'E': 0,
         }
@@ -460,6 +489,7 @@ class TestGetHybridLayerCounts:
             'D': 0,
             'G': 2,
             'M': 1,
+            '+': 0,
             '-': 0,
             'E': 0,
         }
@@ -473,6 +503,21 @@ class TestGetHybridLayerCounts:
             'D': 2,
             'G': 0,
             'M': 2,
+            '+': 0,
+            '-': 0,
+            'E': 0,
+        }
+
+    def test_mla_pattern(self):
+        assert get_hybrid_layer_counts("+M+M") == {
+            'C': 0,
+            'H': 0,
+            'W': 0,
+            '*': 0,
+            'D': 0,
+            'G': 0,
+            'M': 2,
+            '+': 2,
             '-': 0,
             'E': 0,
         }
@@ -486,6 +531,7 @@ class TestGetHybridLayerCounts:
             'D': 0,
             'G': 0,
             'M': 0,
+            '+': 0,
             '-': 0,
             'E': 0,
         }
@@ -813,4 +859,40 @@ class TestGetLayerMapsFromLayerTypeList:
         assert attention_map == {}
         assert mamba_map == {0: 0, 1: 1, 2: 2}
         assert mlp_map == {}
+        assert moe_map == {}
+
+    def test_mla(self):
+        """+ layers are mapped independently of other attention types."""
+        maps = get_layer_maps_from_layer_type_list(["+", "M", "+", "M"])
+        attention_map, dsa_map, mamba_map, mla_map, mlp_map, moe_map = operator.itemgetter(
+            Symbols.ATTENTION,
+            Symbols.DS_ATTENTION,
+            Symbols.MAMBA,
+            Symbols.MLA,
+            Symbols.MLP,
+            Symbols.MOE,
+        )(maps)
+        assert attention_map == {}
+        assert dsa_map == {}
+        assert mla_map == {0: 0, 2: 1}
+        assert mamba_map == {1: 0, 3: 1}
+        assert mlp_map == {}
+        assert moe_map == {}
+
+    def test_mixed_dsa_and_mla(self):
+        """D and + can coexist because both use decoupled RoPE."""
+        maps = get_layer_maps_from_layer_type_list(["D", "+", "M", "-"])
+        attention_map, dsa_map, mamba_map, mla_map, mlp_map, moe_map = operator.itemgetter(
+            Symbols.ATTENTION,
+            Symbols.DS_ATTENTION,
+            Symbols.MAMBA,
+            Symbols.MLA,
+            Symbols.MLP,
+            Symbols.MOE,
+        )(maps)
+        assert attention_map == {}
+        assert dsa_map == {0: 0}
+        assert mla_map == {1: 0}
+        assert mamba_map == {2: 0}
+        assert mlp_map == {3: 0}
         assert moe_map == {}

--- a/tests/unit_tests/ssm/test_hybrid_layer_allocation.py
+++ b/tests/unit_tests/ssm/test_hybrid_layer_allocation.py
@@ -103,6 +103,8 @@ class TestValidateSegmentLayers:
         with pytest.raises(ValueError):
             # Not allowed to have both standard Attention and MLA/DSA
             validate_segment_layers("MDM*-")
+        with pytest.raises(ValueError):
+            validate_segment_layers("M+M*-")
 
     def test_window_symbol(self):
         """'W' (sliding-window-only DSv4 attention) is a first-class MLA layer symbol."""
@@ -179,6 +181,8 @@ class TestParseHybridPattern:
             ("GEGEGE*E", "GEGEGE*E"),
             ("MDMD", "MDMD"),
             ("DM", "DM"),
+            ("M+M+", "M+M+"),
+            ("+M", "+M"),
         ]
         for pattern, expected_main in test_cases:
             result = parse_hybrid_pattern(pattern)
@@ -303,6 +307,8 @@ class TestParseHybridPattern:
             ("GEGEGE*E/GG/GG", "GEGEGE*E", "GG", 2),
             # DSA in main pattern with MTP
             ("MDMD/MD/MD", "MDMD", "MD", 2),
+            # MLA in main pattern with MTP
+            ("M+M+/M+/M+", "M+M+", "M+", 2),
         ]
         for pattern, expected_main, expected_mtp, expected_depths in test_cases:
             result = parse_hybrid_pattern(pattern)
@@ -360,6 +366,19 @@ class TestGetHybridLayerCounts:
             'K': 0,
             'M': 1,
             '+': 0,
+            '-': 1,
+            'E': 1,
+        }
+        assert get_hybrid_layer_counts("MG+-E") == {
+            'C': 0,
+            'H': 0,
+            'W': 0,
+            '*': 0,
+            'D': 0,
+            'G': 1,
+            'K': 0,
+            '+': 1,
+            'M': 1,
             '-': 1,
             'E': 1,
         }
@@ -878,4 +897,40 @@ class TestGetLayerMapsFromLayerTypeList:
         assert attention_map == {}
         assert mamba_map == {0: 0, 1: 1, 2: 2}
         assert mlp_map == {}
+        assert moe_map == {}
+
+    def test_mla(self):
+        """+ layers are mapped independently of other attention types."""
+        maps = get_layer_maps_from_layer_type_list(["+", "M", "+", "M"])
+        attention_map, dsa_map, mamba_map, mla_map, mlp_map, moe_map = operator.itemgetter(
+            Symbols.ATTENTION,
+            Symbols.DS_ATTENTION,
+            Symbols.MAMBA,
+            Symbols.MLA,
+            Symbols.MLP,
+            Symbols.MOE,
+        )(maps)
+        assert attention_map == {}
+        assert dsa_map == {}
+        assert mla_map == {0: 0, 2: 1}
+        assert mamba_map == {1: 0, 3: 1}
+        assert mlp_map == {}
+        assert moe_map == {}
+
+    def test_mixed_dsa_and_mla(self):
+        """D and + can coexist because both use decoupled RoPE."""
+        maps = get_layer_maps_from_layer_type_list(["D", "+", "M", "-"])
+        attention_map, dsa_map, mamba_map, mla_map, mlp_map, moe_map = operator.itemgetter(
+            Symbols.ATTENTION,
+            Symbols.DS_ATTENTION,
+            Symbols.MAMBA,
+            Symbols.MLA,
+            Symbols.MLP,
+            Symbols.MOE,
+        )(maps)
+        assert attention_map == {}
+        assert dsa_map == {0: 0}
+        assert mla_map == {1: 0}
+        assert mamba_map == {2: 0}
+        assert mlp_map == {3: 0}
         assert moe_map == {}

--- a/tests/unit_tests/transformer/experimental_attention_variant/dsa_native_parity_utils.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/dsa_native_parity_utils.py
@@ -80,7 +80,9 @@ def _make_config(
         add_bias_linear=False,
         bf16=True,
         params_dtype=torch.bfloat16,
-        layernorm_epsilon=1e-6,
+        layernorm_epsilon=1e-5,
+        attention_latent_norm_epsilon=1e-6,
+        dsa_indexer_k_norm_epsilon=1e-6,
         normalization="RMSNorm",
         qk_layernorm=True,
         layernorm_zero_centered_gamma=False,
@@ -191,7 +193,7 @@ class NativeIndexer(nn.Module):
         qk_pos_emb_head_dim: int,
         index_topk: int,
         use_sparse_loss: bool,
-        layernorm_epsilon: float,
+        dsa_indexer_k_norm_epsilon: float,
     ):
         super().__init__()
         self.hidden_size = hidden_size
@@ -207,7 +209,7 @@ class NativeIndexer(nn.Module):
             self.q_lora_rank, self.index_n_heads * self.index_head_dim, bias=False
         )
         self.linear_wk = nn.Linear(self.hidden_size, self.index_head_dim, bias=False)
-        self.k_norm = nn.LayerNorm(self.index_head_dim, eps=layernorm_epsilon)
+        self.k_norm = nn.LayerNorm(self.index_head_dim, eps=dsa_indexer_k_norm_epsilon)
         self.linear_weights_proj = nn.Linear(self.hidden_size, self.index_n_heads, bias=False)
 
     def forward(
@@ -258,7 +260,8 @@ class NativeDSA(nn.Module):
         dsa_indexer_head_dim: int,
         dsa_indexer_topk: int,
         dsa_indexer_use_sparse_loss: bool,
-        layernorm_epsilon: float,
+        attention_latent_norm_epsilon: float,
+        dsa_indexer_k_norm_epsilon: float,
         rotary_base: float,
         rotary_scaling_factor: float,
         original_max_position_embeddings: int,
@@ -291,14 +294,14 @@ class NativeDSA(nn.Module):
         self.softmax_scale = mscale * mscale / math.sqrt(self.q_head_dim)
 
         self.linear_q_down_proj = nn.Linear(self.hidden_size, self.q_lora_rank, bias=False)
-        self.q_layernorm = nn.RMSNorm(self.q_lora_rank, eps=layernorm_epsilon)
+        self.q_layernorm = nn.RMSNorm(self.q_lora_rank, eps=attention_latent_norm_epsilon)
         self.linear_q_up_proj = nn.Linear(
             self.q_lora_rank, self.num_heads * self.q_head_dim, bias=False
         )
         self.linear_kv_down_proj = nn.Linear(
             self.hidden_size, self.kv_lora_rank + self.qk_pos_emb_head_dim, bias=False
         )
-        self.kv_layernorm = nn.RMSNorm(self.kv_lora_rank, eps=layernorm_epsilon)
+        self.kv_layernorm = nn.RMSNorm(self.kv_lora_rank, eps=attention_latent_norm_epsilon)
         self.linear_kv_up_proj = nn.Linear(
             self.kv_lora_rank, self.num_heads * (self.qk_head_dim + self.v_head_dim), bias=False
         )
@@ -311,7 +314,7 @@ class NativeDSA(nn.Module):
             qk_pos_emb_head_dim=self.qk_pos_emb_head_dim,
             index_topk=dsa_indexer_topk,
             use_sparse_loss=dsa_indexer_use_sparse_loss,
-            layernorm_epsilon=layernorm_epsilon,
+            dsa_indexer_k_norm_epsilon=dsa_indexer_k_norm_epsilon,
         )
 
     def forward(
@@ -447,6 +450,8 @@ def run_absorbed_mla_dsa_parity(
         real_layer = build_module(
             spec, config=config, layer_number=1, cp_comm_type=None, pg_collection=None
         ).cuda()
+        assert config.attention_latent_norm_epsilon is not None
+        assert config.dsa_indexer_k_norm_epsilon is not None
         baseline = (
             NativeDSA(
                 hidden_size=config.hidden_size,
@@ -460,7 +465,8 @@ def run_absorbed_mla_dsa_parity(
                 dsa_indexer_head_dim=config.dsa_indexer_head_dim,
                 dsa_indexer_topk=config.dsa_indexer_topk,
                 dsa_indexer_use_sparse_loss=config.dsa_indexer_use_sparse_loss,
-                layernorm_epsilon=config.layernorm_epsilon,
+                attention_latent_norm_epsilon=config.attention_latent_norm_epsilon,
+                dsa_indexer_k_norm_epsilon=config.dsa_indexer_k_norm_epsilon,
                 rotary_base=config.rotary_base,
                 rotary_scaling_factor=config.rotary_scaling_factor,
                 original_max_position_embeddings=config.original_max_position_embeddings,

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_absorbed_mla.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_absorbed_mla.py
@@ -198,6 +198,7 @@ def get_mock_mla_config(
         bf16=True,
         params_dtype=torch.bfloat16,
         layernorm_epsilon=1e-5,
+        attention_latent_norm_epsilon=1e-6,
         normalization="RMSNorm",
         qk_layernorm=qk_layernorm,
         layernorm_zero_centered_gamma=False,
@@ -361,6 +362,11 @@ def _run_functionality(
         cp_comm_type="all_gather" if cp_size > 1 else None,
         pg_collection=None,
     ).cuda()
+
+    assert absorbed_mla.q_layernorm.eps == pytest.approx(config.attention_latent_norm_epsilon)
+    assert absorbed_mla.kv_layernorm.eps == pytest.approx(config.attention_latent_norm_epsilon)
+    assert standard_mla.q_layernorm.eps == pytest.approx(config.attention_latent_norm_epsilon)
+    assert standard_mla.kv_layernorm.eps == pytest.approx(config.attention_latent_norm_epsilon)
 
     state_dict = standard_mla.state_dict()
     absorbed_mla.load_state_dict(state_dict)

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_absorbed_mla.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_absorbed_mla.py
@@ -182,6 +182,7 @@ def get_mock_mla_config(
     apply_rope_fusion: bool = False,
     rope_type: str = "yarn",
     rotary_percent: float = 1.0,
+    qk_layernorm: bool = True,
 ) -> MLATransformerConfig:
     """Create test config with all attributes used in MLA."""
     return MLATransformerConfig(
@@ -198,6 +199,7 @@ def get_mock_mla_config(
         params_dtype=torch.bfloat16,
         layernorm_epsilon=1e-5,
         normalization="RMSNorm",
+        qk_layernorm=qk_layernorm,
         layernorm_zero_centered_gamma=False,
         expert_model_parallel_size=1,
         tensor_model_parallel_size=tensor_model_parallel_size,

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_absorbed_mla.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_absorbed_mla.py
@@ -141,6 +141,7 @@ def get_mock_mla_config(
         bf16=True,
         params_dtype=torch.bfloat16,
         layernorm_epsilon=1e-5,
+        attention_latent_norm_epsilon=1e-6,
         normalization="RMSNorm",
         qk_layernorm=qk_layernorm,
         layernorm_zero_centered_gamma=False,
@@ -301,6 +302,11 @@ def test_functionality(
         cp_comm_type="all_gather" if cp_size > 1 else None,
         pg_collection=None,
     ).cuda()
+
+    assert absorbed_mla.q_layernorm.eps == pytest.approx(config.attention_latent_norm_epsilon)
+    assert absorbed_mla.kv_layernorm.eps == pytest.approx(config.attention_latent_norm_epsilon)
+    assert standard_mla.q_layernorm.eps == pytest.approx(config.attention_latent_norm_epsilon)
+    assert standard_mla.kv_layernorm.eps == pytest.approx(config.attention_latent_norm_epsilon)
 
     state_dict = standard_mla.state_dict()
     absorbed_mla.load_state_dict(state_dict)

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_absorbed_mla.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_absorbed_mla.py
@@ -125,6 +125,7 @@ def get_mock_mla_config(
     context_parallel_size: int,
     sequence_parallel: bool,
     recompute_mla_up_proj: bool,
+    qk_layernorm: bool = True,
 ) -> MLATransformerConfig:
     """Create test config with all attributes used in MLA."""
     return MLATransformerConfig(
@@ -141,6 +142,7 @@ def get_mock_mla_config(
         params_dtype=torch.bfloat16,
         layernorm_epsilon=1e-5,
         normalization="RMSNorm",
+        qk_layernorm=qk_layernorm,
         layernorm_zero_centered_gamma=False,
         expert_model_parallel_size=1,
         tensor_model_parallel_size=tensor_model_parallel_size,

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_dsv4_hybrid_native_parity.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_dsv4_hybrid_native_parity.py
@@ -157,7 +157,8 @@ def _make_config(
         add_bias_linear=False,
         bf16=True,
         params_dtype=torch.bfloat16,
-        layernorm_epsilon=1e-6,
+        layernorm_epsilon=1e-5,
+        attention_latent_norm_epsilon=1e-6,
         normalization="RMSNorm",
         qk_layernorm=True,
         layernorm_zero_centered_gamma=False,
@@ -754,12 +755,12 @@ class NativeDSv4HybridAttention(nn.Module):
             self._rope_yarn_kwargs = dict()
 
         self.linear_q_down_proj = nn.Linear(config.hidden_size, config.q_lora_rank, bias=False)
-        self.q_layernorm = nn.RMSNorm(config.q_lora_rank, eps=config.layernorm_epsilon)
+        self.q_layernorm = nn.RMSNorm(config.q_lora_rank, eps=config.attention_latent_norm_epsilon)
         self.linear_q_up_proj = nn.Linear(
             config.q_lora_rank, config.num_attention_heads * config.v_head_dim, bias=False
         )
         self.linear_kv_proj = nn.Linear(config.hidden_size, config.v_head_dim, bias=False)
-        self.kv_layernorm = nn.RMSNorm(config.v_head_dim, eps=config.layernorm_epsilon)
+        self.kv_layernorm = nn.RMSNorm(config.v_head_dim, eps=config.attention_latent_norm_epsilon)
         self.core_attention = NativeCompressedSparseAttention(config, compress_ratio)
         group_in = (config.num_attention_heads * config.v_head_dim) // config.o_groups
         self.linear_o_group_proj = nn.Parameter(
@@ -1008,6 +1009,7 @@ class TestDSv4HybridNativeParity:
         use_fused_kernels: bool,
         calculate_per_token_loss: bool,
         dsa_indexer_use_sparse_loss: bool,
+        monkeypatch,
     ):
         if use_fused_kernels:
             _skip_if_real_kernels_unavailable(need_flash_mla=True)
@@ -1039,6 +1041,27 @@ class TestDSv4HybridNativeParity:
             spec, config=config, layer_number=1, cp_comm_type=None, pg_collection=pg_collection
         ).cuda()
         native_layer = NativeDSv4HybridAttention(config, mcore_ratio).cuda()
+
+        native_q_rms_norm_eps = []
+        native_q_rms_norm = _native_q_rms_norm
+
+        def _tracked_native_q_rms_norm(query, eps):
+            native_q_rms_norm_eps.append(eps)
+            return native_q_rms_norm(query, eps)
+
+        monkeypatch.setattr(sys.modules[__name__], "_native_q_rms_norm", _tracked_native_q_rms_norm)
+
+        for layer in (real_layer, native_layer):
+            assert layer.q_layernorm.eps == pytest.approx(config.attention_latent_norm_epsilon)
+            assert layer.kv_layernorm.eps == pytest.approx(config.attention_latent_norm_epsilon)
+        if compress_ratio > 1:
+            assert real_layer.core_attention.compressor.norm.eps == pytest.approx(
+                config.layernorm_epsilon
+            )
+            assert native_layer.core_attention.compressor.norm.eps == pytest.approx(
+                config.layernorm_epsilon
+            )
+
         real_params = _copy_real_params_to_native(real_layer, native_layer)
 
         bsz = 1
@@ -1056,6 +1079,7 @@ class TestDSv4HybridNativeParity:
 
             real_out, _ = real_layer(hidden_states=hidden_states, attention_mask=None)
             native_out, native_indexer_loss = native_layer(hidden_states_native, pg_collection)
+            assert native_q_rms_norm_eps == [config.layernorm_epsilon]
 
             _assert_similarity(
                 real_out.detach(),

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_dsv4_hybrid_native_parity.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_dsv4_hybrid_native_parity.py
@@ -157,7 +157,8 @@ def _make_config(
         add_bias_linear=False,
         bf16=True,
         params_dtype=torch.bfloat16,
-        layernorm_epsilon=1e-6,
+        layernorm_epsilon=1e-5,
+        attention_latent_norm_epsilon=1e-6,
         normalization="RMSNorm",
         qk_layernorm=True,
         layernorm_zero_centered_gamma=False,
@@ -769,12 +770,12 @@ class NativeDSv4HybridAttention(nn.Module):
             self._rope_yarn_kwargs = dict()
 
         self.linear_q_down_proj = nn.Linear(config.hidden_size, config.q_lora_rank, bias=False)
-        self.q_layernorm = nn.RMSNorm(config.q_lora_rank, eps=config.layernorm_epsilon)
+        self.q_layernorm = nn.RMSNorm(config.q_lora_rank, eps=config.attention_latent_norm_epsilon)
         self.linear_q_up_proj = nn.Linear(
             config.q_lora_rank, config.num_attention_heads * config.v_head_dim, bias=False
         )
         self.linear_kv_proj = nn.Linear(config.hidden_size, config.v_head_dim, bias=False)
-        self.kv_layernorm = nn.RMSNorm(config.v_head_dim, eps=config.layernorm_epsilon)
+        self.kv_layernorm = nn.RMSNorm(config.v_head_dim, eps=config.attention_latent_norm_epsilon)
         self.core_attention = NativeCompressedSparseAttention(config, compress_ratio)
         group_in = (config.num_attention_heads * config.v_head_dim) // config.o_groups
         self.linear_o_group_proj = nn.Parameter(
@@ -1000,6 +1001,22 @@ class TestDSv4HybridNativeParity:
     def teardown_method(self):
         gc.collect()
         torch.cuda.empty_cache()
+
+    @pytest.mark.launch_on_gb200
+    @pytest.mark.parametrize(("backend", "use_fused_kernels"), _DSA_BACKENDS)
+    def test_attention_latent_norm_epsilon_matches_native_reference(
+        self, backend: str, use_fused_kernels: bool
+    ):
+        """Exercise distinct global and attention latent norm epsilons on DSv4."""
+        self.test_attention_matches_native_reference(
+            variant="flash",
+            compress_ratio=4,
+            seqlen=512,
+            backend=backend,
+            use_fused_kernels=use_fused_kernels,
+            calculate_per_token_loss=True,
+            dsa_indexer_use_sparse_loss=True,
+        )
 
     @pytest.mark.parametrize(("backend", "use_fused_kernels"), _DSA_BACKENDS)
     @pytest.mark.parametrize("variant", ["flash", "pro"])

--- a/tests/unit_tests/transformer/test_mla_qk_norm_config.py
+++ b/tests/unit_tests/transformer/test_mla_qk_norm_config.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from argparse import ArgumentParser
+from types import SimpleNamespace
+
+import pytest
+
+import megatron.core.transformer.mla_qk_norm_config as qk_norm_config
+from megatron.core.transformer.enums import AttnBackend
+from megatron.core.transformer.identity_op import IdentityOp
+from megatron.core.transformer.mla_qk_norm_config import QKNormConfigResolver
+from megatron.core.transformer.spec_utils import ModuleSpec
+from megatron.core.transformer.transformer_config import MLATransformerConfig
+from megatron.training.arguments import _add_mla_args
+from tests.unit_tests.transformer.experimental_attention_variant.dsa_native_parity_utils import (
+    run_absorbed_mla_dsa_parity,
+)
+
+
+class _Linear:
+    pass
+
+
+class _FusedNormLinear:
+    pass
+
+
+class _Norm:
+    pass
+
+
+class _Backend:
+    @staticmethod
+    def layer_norm(**_kwargs):
+        return _Norm
+
+    @staticmethod
+    def column_parallel_linear():
+        return _Linear
+
+    @staticmethod
+    def column_parallel_layer_norm_linear():
+        return _FusedNormLinear
+
+
+def _make_config(*, q_lora_rank=32, attention_latent_norm_epsilon=1.0e-6):
+    return MLATransformerConfig(
+        num_layers=1,
+        hidden_size=128,
+        num_attention_heads=1,
+        q_lora_rank=q_lora_rank,
+        qk_layernorm=True,
+        layernorm_epsilon=1.0e-5,
+        attention_latent_norm_epsilon=attention_latent_norm_epsilon,
+    )
+
+
+def _make_submodules(**overrides):
+    values = dict(
+        linear_q_proj=None,
+        linear_q_up_proj=None,
+        linear_kv_up_proj=None,
+        q_layernorm=IdentityOp,
+        kv_layernorm=IdentityOp,
+    )
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+@pytest.fixture(autouse=True)
+def _mock_backend(monkeypatch):
+    monkeypatch.setattr(qk_norm_config, "get_backend", lambda _impl: _Backend())
+
+
+@pytest.mark.parametrize("attention_latent_norm_epsilon", [None, 1.0e-6])
+def test_attention_latent_norm_epsilon_default(attention_latent_norm_epsilon):
+    config = _make_config(attention_latent_norm_epsilon=attention_latent_norm_epsilon)
+    expected = (
+        config.layernorm_epsilon
+        if attention_latent_norm_epsilon is None
+        else attention_latent_norm_epsilon
+    )
+
+    assert config.attention_latent_norm_epsilon == expected
+
+
+def test_attention_latent_norm_epsilon_argument():
+    parser = ArgumentParser()
+    _add_mla_args(parser)
+
+    args = parser.parse_args(["--attention-latent-norm-epsilon", "1e-6"])
+
+    assert args.attention_latent_norm_epsilon == pytest.approx(1.0e-6)
+
+
+@pytest.mark.parametrize(
+    ("q_lora_rank", "q_projection"), [(None, "linear_q_proj"), (32, "linear_q_up_proj")]
+)
+def test_fused_norm_projections_carry_attention_latent_epsilon(q_lora_rank, q_projection):
+    config = _make_config(q_lora_rank=q_lora_rank)
+    submodules = _make_submodules(
+        linear_kv_up_proj=ModuleSpec(module=_FusedNormLinear, params={"custom": True})
+    )
+
+    resolved = QKNormConfigResolver(config, submodules).resolve()
+
+    q_spec = resolved[q_projection]
+    assert isinstance(q_spec, ModuleSpec)
+    assert q_spec.module is _FusedNormLinear
+    assert q_spec.params["eps"] == config.attention_latent_norm_epsilon
+
+    kv_spec = resolved["linear_kv_up_proj"]
+    assert isinstance(kv_spec, ModuleSpec)
+    assert kv_spec.module is _FusedNormLinear
+    assert kv_spec.params == {"custom": True, "eps": config.attention_latent_norm_epsilon}
+    assert submodules.linear_kv_up_proj.params == {"custom": True}
+
+
+def test_dsa_attention_latent_norm_epsilon_matches_native():
+    """Exercise distinct global, attention latent, and indexer norm epsilons in DSA."""
+    run_absorbed_mla_dsa_parity(
+        kernel_backend="none",
+        seqlen=64,
+        attention_backend=AttnBackend.unfused,
+        calculate_per_token_loss=True,
+        use_sparse_loss=False,
+        num_iterations=1,
+    )

--- a/tests/unit_tests/transformer/test_mla_qk_norm_config.py
+++ b/tests/unit_tests/transformer/test_mla_qk_norm_config.py
@@ -116,6 +116,7 @@ def test_fused_norm_projections_carry_attention_latent_epsilon(q_lora_rank, q_pr
     assert submodules.linear_kv_up_proj.params == {"custom": True}
 
 
+@pytest.mark.launch_on_gb200
 def test_dsa_attention_latent_norm_epsilon_matches_native():
     """Exercise distinct global, attention latent, and indexer norm epsilons in DSA."""
     run_absorbed_mla_dsa_parity(

--- a/tests/unit_tests/transformer/test_multi_latent_attention.py
+++ b/tests/unit_tests/transformer/test_multi_latent_attention.py
@@ -96,9 +96,9 @@ def make_test_packed_seq_params_with_padding(
     return packed_seq_params
 
 
-def get_mla_self_attn_submodules(linear_qkv_down_proj=None):
+def get_mla_self_attn_submodules(linear_qkv_down_proj=None, qk_layernorm=False):
     submodules = get_gpt_layer_with_transformer_engine_submodules(
-        multi_latent_attention=True
+        multi_latent_attention=True, qk_layernorm=qk_layernorm
     ).self_attention.submodules
     assert isinstance(submodules, MLASelfAttentionSubmodules)
     if linear_qkv_down_proj is not None:
@@ -107,10 +107,10 @@ def get_mla_self_attn_submodules(linear_qkv_down_proj=None):
     return submodules
 
 
-def get_fused_mla_submodules():
+def get_fused_mla_submodules(qk_layernorm=False):
     """Get submodules for FusedMLASelfAttention via the mla_down_proj_fusion spec path."""
     submodules = get_gpt_layer_with_transformer_engine_submodules(
-        multi_latent_attention=True, mla_down_proj_fusion=True
+        multi_latent_attention=True, mla_down_proj_fusion=True, qk_layernorm=qk_layernorm
     ).self_attention.submodules
     assert isinstance(submodules, MLASelfAttentionSubmodules)
     assert submodules.linear_qkv_down_proj is not None
@@ -171,6 +171,31 @@ class TestParallelMLAAttention:
 
         num_weights = sum([p.numel() for p in self.parallel_attention.parameters()])
         assert num_weights == 65036
+
+    def test_attention_latent_norm_epsilon_on_fused_projections(self):
+        config = MLATransformerConfig(
+            num_layers=2,
+            hidden_size=12,
+            num_attention_heads=4,
+            use_cpu_initialization=True,
+            q_lora_rank=32,
+            kv_lora_rank=32,
+            qk_head_dim=128,
+            v_head_dim=128,
+            qk_pos_emb_head_dim=64,
+            qk_layernorm=True,
+            layernorm_epsilon=1.0e-5,
+            attention_latent_norm_epsilon=1.0e-6,
+        )
+        attention = MLASelfAttention(
+            config,
+            get_mla_self_attn_submodules(qk_layernorm=True),
+            layer_number=1,
+            attn_mask_type=AttnMaskType.causal,
+        )
+
+        assert attention.linear_q_up_proj.eps == pytest.approx(1.0e-6)
+        assert attention.linear_kv_up_proj.eps == pytest.approx(1.0e-6)
 
     def test_cpu_forward(self):
         # we can't currently do this because the global memory buffer is on GPU
@@ -1649,6 +1674,31 @@ class TestFusedMLASelfAttention:
         assert isinstance(self.fused_attention, MLASelfAttention)
         assert self.fused_attention.layer_number == 1
         assert hasattr(self.fused_attention, 'linear_qkv_down_proj')
+
+    def test_attention_latent_norm_epsilon_on_fused_projections(self):
+        config = MLATransformerConfig(
+            num_layers=2,
+            hidden_size=12,
+            num_attention_heads=4,
+            use_cpu_initialization=True,
+            q_lora_rank=32,
+            kv_lora_rank=32,
+            qk_head_dim=128,
+            v_head_dim=128,
+            qk_pos_emb_head_dim=64,
+            qk_layernorm=True,
+            layernorm_epsilon=1.0e-5,
+            attention_latent_norm_epsilon=1.0e-6,
+        )
+        attention = FusedMLASelfAttention(
+            config,
+            get_fused_mla_submodules(qk_layernorm=True),
+            layer_number=1,
+            attn_mask_type=AttnMaskType.causal,
+        )
+
+        assert attention.linear_q_up_proj.eps == pytest.approx(1.0e-6)
+        assert attention.linear_kv_up_proj.eps == pytest.approx(1.0e-6)
 
     def test_fused_weight_shape(self):
         config = self.transformer_config

--- a/tests/unit_tests/transformer/test_multi_latent_attention.py
+++ b/tests/unit_tests/transformer/test_multi_latent_attention.py
@@ -96,9 +96,9 @@ def make_test_packed_seq_params_with_padding(
     return packed_seq_params
 
 
-def get_mla_self_attn_submodules(linear_qkv_down_proj=None):
+def get_mla_self_attn_submodules(linear_qkv_down_proj=None, qk_layernorm=False):
     submodules = get_gpt_layer_with_transformer_engine_submodules(
-        multi_latent_attention=True
+        multi_latent_attention=True, qk_layernorm=qk_layernorm
     ).self_attention.submodules
     assert isinstance(submodules, MLASelfAttentionSubmodules)
     if linear_qkv_down_proj is not None:
@@ -107,10 +107,10 @@ def get_mla_self_attn_submodules(linear_qkv_down_proj=None):
     return submodules
 
 
-def get_fused_mla_submodules():
+def get_fused_mla_submodules(qk_layernorm=False):
     """Get submodules for FusedMLASelfAttention via the mla_down_proj_fusion spec path."""
     submodules = get_gpt_layer_with_transformer_engine_submodules(
-        multi_latent_attention=True, mla_down_proj_fusion=True
+        multi_latent_attention=True, mla_down_proj_fusion=True, qk_layernorm=qk_layernorm
     ).self_attention.submodules
     assert isinstance(submodules, MLASelfAttentionSubmodules)
     assert submodules.linear_qkv_down_proj is not None
@@ -171,6 +171,31 @@ class TestParallelMLAAttention:
 
         num_weights = sum([p.numel() for p in self.parallel_attention.parameters()])
         assert num_weights == 65036
+
+    def test_attention_latent_norm_epsilon_on_fused_projections(self):
+        config = MLATransformerConfig(
+            num_layers=2,
+            hidden_size=12,
+            num_attention_heads=4,
+            use_cpu_initialization=True,
+            q_lora_rank=32,
+            kv_lora_rank=32,
+            qk_head_dim=128,
+            v_head_dim=128,
+            qk_pos_emb_head_dim=64,
+            qk_layernorm=True,
+            layernorm_epsilon=1.0e-5,
+            attention_latent_norm_epsilon=1.0e-6,
+        )
+        attention = MLASelfAttention(
+            config,
+            get_mla_self_attn_submodules(qk_layernorm=True),
+            layer_number=1,
+            attn_mask_type=AttnMaskType.causal,
+        )
+
+        assert attention.linear_q_up_proj.eps == pytest.approx(1.0e-6)
+        assert attention.linear_kv_up_proj.eps == pytest.approx(1.0e-6)
 
     def test_cpu_forward(self):
         # we can't currently do this because the global memory buffer is on GPU
@@ -1828,6 +1853,31 @@ class TestFusedMLASelfAttention:
         assert isinstance(self.fused_attention, MLASelfAttention)
         assert self.fused_attention.layer_number == 1
         assert hasattr(self.fused_attention, 'linear_qkv_down_proj')
+
+    def test_attention_latent_norm_epsilon_on_fused_projections(self):
+        config = MLATransformerConfig(
+            num_layers=2,
+            hidden_size=12,
+            num_attention_heads=4,
+            use_cpu_initialization=True,
+            q_lora_rank=32,
+            kv_lora_rank=32,
+            qk_head_dim=128,
+            v_head_dim=128,
+            qk_pos_emb_head_dim=64,
+            qk_layernorm=True,
+            layernorm_epsilon=1.0e-5,
+            attention_latent_norm_epsilon=1.0e-6,
+        )
+        attention = FusedMLASelfAttention(
+            config,
+            get_fused_mla_submodules(qk_layernorm=True),
+            layer_number=1,
+            attn_mask_type=AttnMaskType.causal,
+        )
+
+        assert attention.linear_q_up_proj.eps == pytest.approx(1.0e-6)
+        assert attention.linear_kv_up_proj.eps == pytest.approx(1.0e-6)
 
     def test_fused_weight_shape(self):
         config = self.transformer_config

--- a/tests/unit_tests/transformer/test_submodule_callables.py
+++ b/tests/unit_tests/transformer/test_submodule_callables.py
@@ -137,9 +137,11 @@ class TestTransformerLayerSubmoduleCallables:
             expert_model_parallel_size=2,
             virtual_pipeline_model_parallel_size=2,
         )
+        qk_layernorm = True
         extra_kwargs = {
             "moe_token_dispatcher_type": dispatcher_type,
             "moe_permute_fusion": permute_fusion,
+            "qk_layernorm": qk_layernorm,
         }
         if dispatcher_type == "flex":
             extra_kwargs["moe_flex_dispatcher_backend"] = "deepep"
@@ -149,7 +151,7 @@ class TestTransformerLayerSubmoduleCallables:
             transformer_layer_submodules = get_gpt_layer_with_transformer_engine_submodules(
                 num_experts=8,
                 moe_grouped_gemm=grouped_gemm,
-                qk_layernorm=True,
+                qk_layernorm=qk_layernorm,
                 multi_latent_attention=True,
             )
             model = TransformerLayer(config, transformer_layer_submodules)

--- a/tests/unit_tests/transformer/test_submodule_callables.py
+++ b/tests/unit_tests/transformer/test_submodule_callables.py
@@ -133,9 +133,11 @@ class TestTransformerLayerSubmoduleCallables:
             expert_model_parallel_size=2,
             virtual_pipeline_model_parallel_size=2,
         )
+        qk_layernorm = True
         extra_kwargs = {
             "moe_token_dispatcher_type": dispatcher_type,
             "moe_permute_fusion": permute_fusion,
+            "qk_layernorm": qk_layernorm,
         }
         if dispatcher_type == "flex":
             extra_kwargs["moe_flex_dispatcher_backend"] = "deepep"
@@ -145,7 +147,7 @@ class TestTransformerLayerSubmoduleCallables:
             transformer_layer_submodules = get_gpt_layer_with_transformer_engine_submodules(
                 num_experts=8,
                 moe_grouped_gemm=grouped_gemm,
-                qk_layernorm=True,
+                qk_layernorm=qk_layernorm,
                 multi_latent_attention=True,
             )
             model = TransformerLayer(config, transformer_layer_submodules)


### PR DESCRIPTION
(Main PR: #6122)

## What

- Port Multi-Latent Attention support to `HybridModel` as the prerequisite already used on `main`.
- Add `MLATransformerConfig.attention_latent_norm_epsilon` and `--attention-latent-norm-epsilon`.
- Default the new option to `layernorm_epsilon` when it is unset.
- Apply the option to standard MLA/DSA, absorbed MLA, and the primary DSv4 Q/KV latent norms.

This is the dev-targeted counterpart of #6122. The main PR remains open and unchanged.

## Scope

The option only selects epsilon; `normalization` still selects RMSNorm versus LayerNorm. It does not change DSA indexer K normalization, CSA/HCA compressors, DSv4 post-up Q normalization, or the model-wide input/pre-MLP/final norms.

The commits are intentionally split into:

1. the main HybridModel/MLA prerequisite;
2. the generic MLA/DSA option;
3. dev-only DSv4 integration and parity coverage.

## Testing

- Black, isort, pylint, and ruff passed through `tools/autoformat.sh` in check-only mode.
- On one OCI-HSG node (4x GB200), using the CI-dev image:
  - `test_mla_qk_norm_config.py`: 6 passed per effective rank.
  - `test_absorbed_mla.py`: 64 passed per effective rank.
  - `test_dsv4_hybrid_native_parity.py`: 78 passed, 70 skipped per effective rank; fused DSv4 cases retain their existing GB200 skip condition, while the new unfused epsilon parity case passed.
- `test_multi_latent_attention.py` passed the two new epsilon cases, then hit the existing GB200/TE failure in `test_gpu_forward_thd_padded[yarn]` (`No dot product attention backend is available`). Latest `origin/dev` reproduced the same test and exception on the same node and image, so this is not a regression from this PR.
