### PR TITLE
Roll packed MTP tensors using padded sequence boundaries

### DIFF
--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -246,7 +246,13 @@ def _roll_tensor_packed_seq(tensor, shifts, dims, packed_seq_params, cp_group=No
         dims == -1 or dims == tensor.dim() - 1
     ), "Packed sequence roll only supports the last dimension."
     assert shifts == -1, "Packed sequence roll only supports a single-token left shift."
-    cu_seqlens = packed_seq_params.cu_seqlens_q
+    # The physical THD tensor is laid out with the padded cumulative lengths, so roll it
+    # using the same boundaries. cu_seqlens_q_padded is None when the data path does not pad.
+    cu_seqlens = (
+        packed_seq_params.cu_seqlens_q_padded
+        if packed_seq_params.cu_seqlens_q_padded is not None
+        else packed_seq_params.cu_seqlens_q
+    )
     assert cu_seqlens is not None, "Packed sequence parameters must provide cu_seqlens_q."
 
     rolled_tensor = tensor.clone()

--- a/tests/unit_tests/transformer/test_multi_token_prediction.py
+++ b/tests/unit_tests/transformer/test_multi_token_prediction.py
@@ -1080,6 +1080,71 @@ class TestMultiTokenPrediction:
 
         Utils.destroy_model_parallel()
 
+    @pytest.mark.parametrize("cp", [1, 2])
+    def test_roll_tensor_packed_seq_uses_padded_boundaries(self, cp):
+        """Rolling a padded THD tensor must follow ``cu_seqlens_q_padded``.
+
+        When the data path pads each packed sequence, the physical tensor is laid out
+        with the padded cumulative lengths, and CP partitions it the same way. Rolling
+        with the unpadded ``cu_seqlens_q`` applies sequence boundaries at the wrong
+        offsets, shifting tokens across sequence boundaries.
+        """
+        Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=cp)
+        cp_group = get_context_parallel_group() if cp > 1 else None
+        cp_rank = torch.distributed.get_rank(group=cp_group) if cp_group is not None else 0
+
+        if cp == 1:
+            # Two sequences of 3 and 2 real tokens, each padded up to a length of 4.
+            #   seq1 = [1, 2, 3, pad]
+            #   seq2 = [11, 12, pad, pad]
+            tensor = torch.tensor([1, 2, 3, 0, 11, 12, 0, 0], dtype=torch.float32).cuda()
+            cu_seqlens = torch.tensor([0, 3, 5], dtype=torch.int32).cuda()
+            cu_seqlens_padded = torch.tensor([0, 4, 8], dtype=torch.int32).cuda()
+            # Each padded sequence is rolled within its own [0:4] / [4:8] window.
+            expected = torch.tensor([2, 3, 0, 0, 12, 0, 0, 0], dtype=torch.float32).cuda()
+            max_seqlen = 4
+        else:
+            # Same physical layout as test_roll_tensor_with_packed_sequences, but the
+            # boundaries [0, 8, 20] are now the padded ones: seq1 holds 6 real tokens
+            # padded to 8, seq2 holds 10 real tokens padded to 12.
+            if cp_rank == 0:
+                tensor = torch.tensor(
+                    [1, 2, 7, 8, 11, 12, 13, 20, 21, 22], dtype=torch.float32
+                ).cuda()
+                expected = torch.tensor(
+                    [2, 3, 8, 0, 12, 13, 14, 21, 22, 0], dtype=torch.float32
+                ).cuda()
+            else:
+                tensor = torch.tensor(
+                    [3, 4, 5, 6, 14, 15, 16, 17, 18, 19], dtype=torch.float32
+                ).cuda()
+                expected = torch.tensor(
+                    [4, 5, 6, 7, 15, 16, 17, 18, 19, 20], dtype=torch.float32
+                ).cuda()
+            cu_seqlens = torch.tensor([0, 6, 16], dtype=torch.int32).cuda()
+            cu_seqlens_padded = torch.tensor([0, 8, 20], dtype=torch.int32).cuda()
+            max_seqlen = 6
+
+        packed_seq_params = PackedSeqParams(
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_kv=cu_seqlens,
+            cu_seqlens_q_padded=cu_seqlens_padded,
+            cu_seqlens_kv_padded=cu_seqlens_padded,
+            max_seqlen_q=max_seqlen,
+            max_seqlen_kv=max_seqlen,
+            qkv_format='thd',
+        )
+
+        rolled, _ = roll_tensor(
+            tensor, shifts=-1, dims=0, cp_group=cp_group, packed_seq_params=packed_seq_params
+        )
+
+        assert torch.equal(
+            rolled, expected
+        ), f"CP rank {cp_rank}: expected {expected}, got {rolled}"
+
+        Utils.destroy_model_parallel()
+
 
 class TestMTPLossLoggingHelper:
     def setup_method(self, method):


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Fixes MTP's packed-sequence roll reading unpadded sequence boundaries while the tensor it rolls is laid out with padded ones, which silently corrupts the MTP loss under context parallelism.

`_roll_tensor_packed_seq` takes its boundaries from `packed_seq_params.cu_seqlens_q`:

https://github.com/NVIDIA/Megatron-LM/blob/42460a7af/megatron/core/transformer/multi_token_prediction.py#L249

When the data path pads each packed sequence, the physical THD tensor handed to this function is laid out with `cu_seqlens_q_padded`, and CP partitions it the same way — the function itself assumes this when it maps global to local offsets via `start_idx // cp_size`. Rolling that tensor with the unpadded boundaries applies the sequence boundaries at the wrong offsets, so tokens are shifted across sequence boundaries and the boundary fill lands in the wrong slot.

This PR reads `cu_seqlens_q_padded` when it is present, matching how `PackedSeqParams.__post_init__` already derives `seq_idx`. Runs that do not pad are unaffected, since `cu_seqlens_q_padded` is `None` there.

Only reachable with MTP + packed sequences + padding. The failure is silent — it produces a wrong loss rather than an error, which is why it went unnoticed.

Concretely, for two sequences of 3 and 2 real tokens each padded to 4, rolling `[1, 2, 3, pad, 11, 12, pad, pad]` left by one gives:

| | result |
|---|---|
| before | `[2, 3, 0, 11, 0, 12, 0, 0]` |
| after | `[2, 3, 0, 0, 12, 0, 0, 0]` |

## Issue tracking

Linked issue: n/a — small bug fix.

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

`test_roll_tensor_packed_seq_uses_padded_boundaries` covers CP=1 and CP=2 with padded boundaries. Both parametrizations fail on `main` and pass with this change.
