### PR TITLE
security: enable weights_only for torch.load checkpoint paths

### DIFF
--- a/examples/multimodal/combine_state_dicts.py
+++ b/examples/multimodal/combine_state_dicts.py
@@ -29,7 +29,7 @@ def combine(input_files, module_prefixes, output_files):
             # initialize the combined state dict using the first provided input file
             # NOTE: To load legacy checkpoints, set TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1
             # (only use with trusted files — allows arbitrary code execution).
-            current_state_dict = torch.load(input_file)
+            current_state_dict = torch.load(input_file, weights_only=True)
             if i == 0:
                 combined_state_dict = current_state_dict.copy()
                 combined_state_dict["model"] = dict()

--- a/examples/multimodal/dataloader_provider.py
+++ b/examples/multimodal/dataloader_provider.py
@@ -132,7 +132,7 @@ def train_valid_test_dataloaders_provider(train_val_test_num_samples, task_encod
             )
             if os.path.exists(data_save_name):
                 try:
-                    dataset_state_dict = torch.load(data_save_name, map_location="cpu")
+                    dataset_state_dict = torch.load(data_save_name, map_location="cpu", weights_only=True)
                     train_dataloader.restore_state_rank(dataset_state_dict["dataloader_state_dict"])
                     print(f"restored dataset state from {data_save_name}")
                 except Exception as e:

--- a/examples/multimodal/nvlm/pp_checkpoint_converter.py
+++ b/examples/multimodal/nvlm/pp_checkpoint_converter.py
@@ -17,7 +17,7 @@ def split(input_dir, base_output_dir, input_pp, output_pp, num_tp, num_layers_pe
     iter = args.iteration if args.iteration else 1
     for tp in range(num_tp):
         path = os.path.join(input_dir, f"mp_rank_0{tp}", "model_optim_rng.pt")
-        sd = torch.load(path)
+        sd = torch.load(path, weights_only=True)
 
         if num_layers_per_pp_rank is None:
             num_layers = sd["args"].num_layers
@@ -90,7 +90,7 @@ def combine(input_dir, base_output_dir, input_pp, output_pp, num_tp, num_layers_
 
         for pp in range(input_pp):
             path = os.path.join(input_dir, f"mp_rank_0{tp}_00{pp}", "model_optim_rng.pt")
-            sd = torch.load(path)
+            sd = torch.load(path, weights_only=True)
 
             if pp == 0:
                 new_sd = sd.copy()

--- a/examples/post_training/modelopt/convert_model.py
+++ b/examples/post_training/modelopt/convert_model.py
@@ -168,7 +168,7 @@ if __name__ == "__main__":
         if args.extra_model_path is not None:
             eagle_module = getattr(unwrapped_model, "eagle_module", None)
             if eagle_module is not None:
-                mcore_eagle_state_dict = torch.load(args.extra_model_path)
+                mcore_eagle_state_dict = torch.load(args.extra_model_path, weights_only=True)
                 eagle_module.load_state_dict(mcore_eagle_state_dict, strict=False)
 
     print_rank_0(f"Converted Model:\n {model}")

--- a/examples/post_training/modelopt/finetune.py
+++ b/examples/post_training/modelopt/finetune.py
@@ -58,7 +58,7 @@ class OfflineDataset(torch.utils.data.Dataset):
     def __getitem__(self, idx):
         idx = idx % len(self.file_paths)
         file_path = self.file_paths[idx]
-        sample = torch.load(file_path)
+        sample = torch.load(file_path, weights_only=True)
         return sample
 
 class SFTDataset(torch.utils.data.Dataset):

--- a/examples/post_training/modelopt/validate.py
+++ b/examples/post_training/modelopt/validate.py
@@ -110,7 +110,7 @@ if __name__ == "__main__":
             prompts = [json.loads(line) for line in f]
 
     if args.ground_truth_path is not None:
-        ground_truth = torch.load(args.ground_truth_path)
+        ground_truth = torch.load(args.ground_truth_path, weights_only=True)
         ground_truth = [gt.to(torch.cuda.current_device()) for gt in ground_truth]
     else:
         ground_truth = [None for _ in range(len(prompts))]

--- a/megatron/core/dist_checkpointing/strategies/common.py
+++ b/megatron/core/dist_checkpointing/strategies/common.py
@@ -45,7 +45,7 @@ def load_common(checkpoint_dir: str):
 
     load_path = os.path.join(checkpoint_dir, COMMON_STATE_FNAME)
     try:
-        return maybe_msc.torch.load(load_path, map_location='cpu')
+        return maybe_msc.torch.load(load_path, map_location='cpu', weights_only=True)
     except FileNotFoundError as e:
         err_msg = f'Common file {load_path} does not exist'
         ckpt_files = [f.name for f in maybe_msc.Path(checkpoint_dir).iterdir()]

--- a/megatron/core/export/trtllm/trtllm_helper.py
+++ b/megatron/core/export/trtllm/trtllm_helper.py
@@ -237,7 +237,7 @@ class TRTLLMHelper:
                 continue
 
             val.seek(0)
-            extra_states = torch.load(val)
+            extra_states = torch.load(val, weights_only=True)
 
             activation_scaling_factor_key = key.replace(mock_suffix, activation_scaling_suffix)
             weight_scaling_factor_key = key.replace(mock_suffix, weight_scaling_suffix)

--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -2458,7 +2458,7 @@ if HAVE_TE and is_te_min_version("1.9.0.dev0"):
                 return SafeUnpickler(io.BytesIO(state.detach().cpu().numpy().tobytes())).load()
             elif isinstance(state, io.BytesIO):
                 state.seek(0)
-                return torch.load(state, map_location="cuda")
+                return torch.load(state, map_location="cuda", weights_only=True)
             else:
                 raise RuntimeError("Unsupported checkpoint format.")
 

--- a/megatron/core/models/audio/nemo_audio_checkpoint.py
+++ b/megatron/core/models/audio/nemo_audio_checkpoint.py
@@ -65,7 +65,7 @@ def _torch_load(path: str) -> Any:
     try:
         return torch.load(path, map_location="cpu", weights_only=False)
     except TypeError:
-        return torch.load(path, map_location="cpu")
+        return torch.load(path, map_location="cpu", weights_only=True)
 
 
 def _load_json(path: str | Path) -> Dict[str, Any]:

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -2549,7 +2549,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
             return
         state_dict = None
         if self.data_parallel_group.rank() == 0:
-            state_dict = torch.load(filename)
+            state_dict = torch.load(filename, weights_only=True)
 
         self.load_parameter_state_from_dp_zero(
             state_dict, update_legacy_format=update_legacy_format

--- a/megatron/core/optimizer/layer_wise_optimizer.py
+++ b/megatron/core/optimizer/layer_wise_optimizer.py
@@ -1004,4 +1004,4 @@ class LayerWiseDistributedOptimizer(ChainedOptimizer):
 
     def load_state_dict_from_file(self, filename: str) -> None:
         """Load the parameter state of the optimizer. For torch format only."""
-        super().load_state_dict(torch.load(filename))
+        super().load_state_dict(torch.load(filename, weights_only=True))

--- a/megatron/core/optimizer/optimizer.py
+++ b/megatron/core/optimizer/optimizer.py
@@ -1982,7 +1982,7 @@ class ChainedOptimizer(MegatronOptimizer):
 
             # Lazy loading checkpoint, state dict is needed only when DP rank = 0.
             if optimizer.data_parallel_group.rank() == 0 and states is None:
-                states = torch.load(filename)
+                states = torch.load(filename, weights_only=True)
 
             state_dict = states[idx] if states else None
             optimizer.load_parameter_state_from_dp_zero(

--- a/megatron/core/safe_globals.py
+++ b/megatron/core/safe_globals.py
@@ -59,7 +59,7 @@ def register_safe_globals():
 
 def safe_load_from_bytes(b):
     """Safe version (weights_only=True) of `torch.storage._load_from_bytes`."""
-    return torch.load(io.BytesIO(b), weights_only=True)
+    return torch.load(io.BytesIO(b, weights_only=True), weights_only=True)
 
 
 def _safe_pickle_load(file, **kwargs):

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -1788,7 +1788,7 @@ def _load_base_checkpoint(
                 load_dir, iteration, release, return_base_dir=False
             )
         try:
-            state_dict = torch.load(checkpoint_name, map_location='cpu')
+            state_dict = torch.load(checkpoint_name, map_location='cpu', weights_only=True)
         except Exception as e:
             print('could not load the checkpoint')
             print(e)
@@ -2861,7 +2861,7 @@ def load_biencoder_checkpoint(
             )
         )
 
-    state_dict = torch.load(checkpoint_name, map_location='cpu')
+    state_dict = torch.load(checkpoint_name, map_location='cpu', weights_only=True)
     ret_state_dict = state_dict['model']
 
     if only_query_model:

--- a/megatron/training/distillation/utils_logits.py
+++ b/megatron/training/distillation/utils_logits.py
@@ -361,7 +361,7 @@ def decode_logprobs_payload(data: bytes) -> Tuple[List[torch.Tensor], List[torch
             "Install via `pip install zstandard`."
         )
     data = zstandard.ZstdDecompressor().decompress(data)
-    tensors = torch.load(io.BytesIO(data), weights_only=True)
+    tensors = torch.load(io.BytesIO(data, weights_only=True), weights_only=True)
     indices_list = [
         unpack_indices(low, bit17)
         for low, bit17 in zip(tensors["indices_low"], tensors["bit_17"])

--- a/tests/unit_tests/dist_checkpointing/models/test_moe_experts.py
+++ b/tests/unit_tests/dist_checkpointing/models/test_moe_experts.py
@@ -470,7 +470,7 @@ class TestExpertLayerReconfiguration:
             torch.save(model.state_dict(), ckpt_dir / f"model_ep{torch.distributed.get_rank()}.pt")
 
             # Load checkpoint
-            state_dict = torch.load(ckpt_dir / f"model_ep{torch.distributed.get_rank()}.pt")
+            state_dict = torch.load(ckpt_dir / f"model_ep{torch.distributed.get_rank(, weights_only=True)}.pt")
             model.load_state_dict(state_dict)
 
             Utils.destroy_model_parallel()

--- a/tests/unit_tests/dist_checkpointing/test_safe_globals.py
+++ b/tests/unit_tests/dist_checkpointing/test_safe_globals.py
@@ -31,7 +31,7 @@ class TestSafeGlobals:
         if torch.distributed.is_initialized():
             torch.distributed.barrier()
 
-        torch.load(ckpt_path)
+        torch.load(ckpt_path, weights_only=True)
 
     @pytest.mark.skipif(not is_torch_min_version("2.6a0"), reason="PyTorch 2.6 is required")
     def test_unsafe_globals(self, tmp_path_dist_ckpt):
@@ -45,11 +45,11 @@ class TestSafeGlobals:
 
         # expected error
         with pytest.raises(UnpicklingError):
-            torch.load(ckpt_path)
+            torch.load(ckpt_path, weights_only=True)
 
         # add class to safe globals
         torch.serialization.add_safe_globals([UnsafeClass])
-        torch.load(ckpt_path)
+        torch.load(ckpt_path, weights_only=True)
 
 
 class TestSafeUnpickler:

--- a/tests/unit_tests/dist_checkpointing/test_serialization.py
+++ b/tests/unit_tests/dist_checkpointing/test_serialization.py
@@ -452,7 +452,7 @@ class TestSerialization:
             load_state_dict = load(state_dict, ckpt_dir)
             assert 'other_key' in load_state_dict
             load_state_dict['other_key'].seek(0)
-            loaded_state = torch.load(load_state_dict['other_key'])
+            loaded_state = torch.load(load_state_dict['other_key'], weights_only=True)
 
             assert loaded_state == {'some': 'dict'}
 

--- a/tests/unit_tests/models/test_clip_vit_model.py
+++ b/tests/unit_tests/models/test_clip_vit_model.py
@@ -53,7 +53,7 @@ class TestCLIPViTModel:
         path = tmp_path / "model.pt"
         torch.save(self.model.state_dict(), path)
 
-        self.model.load_state_dict(torch.load(path))
+        self.model.load_state_dict(torch.load(path, weights_only=True))
 
 
 @pytest.mark.internal

--- a/tests/unit_tests/models/test_hybrid_model.py
+++ b/tests/unit_tests/models/test_hybrid_model.py
@@ -381,7 +381,7 @@ class TestHybridModel:
         path = tmp_path / "model.pt"
         torch.save(self.model.state_dict(), path)
 
-        self.model.load_state_dict(torch.load(path))
+        self.model.load_state_dict(torch.load(path, weights_only=True))
 
     def test_layer_numbers(self):
         """

--- a/tests/unit_tests/models/test_llava_model.py
+++ b/tests/unit_tests/models/test_llava_model.py
@@ -458,7 +458,7 @@ class TestLLaVAModel:
         path = tmp_path / "model.pt"
         torch.save(self.model.state_dict(), path)
 
-        self.model.load_state_dict(torch.load(path))
+        self.model.load_state_dict(torch.load(path, weights_only=True))
 
     @pytest.mark.internal
     def test_freeze(self):

--- a/tests/unit_tests/models/test_multimodal_projector.py
+++ b/tests/unit_tests/models/test_multimodal_projector.py
@@ -67,9 +67,9 @@ class TestMultimodalProjector:
         path = tmp_path / "mlp.pt"
         torch.save(self.mlp.state_dict(), path)
 
-        self.mlp.load_state_dict(torch.load(path))
+        self.mlp.load_state_dict(torch.load(path, weights_only=True))
 
         path = tmp_path / "affine.pt"
         torch.save(self.affine.state_dict(), path)
 
-        self.affine.load_state_dict(torch.load(path))
+        self.affine.load_state_dict(torch.load(path, weights_only=True))

--- a/tests/unit_tests/models/test_radio_model.py
+++ b/tests/unit_tests/models/test_radio_model.py
@@ -60,7 +60,7 @@ class TestRADIOViTModel:
         path = tmp_path / "model.pt"
         torch.save(self.model.state_dict(), path)
 
-        self.model.load_state_dict(torch.load(path))
+        self.model.load_state_dict(torch.load(path, weights_only=True))
 
 
 class TestRADIOStateDictPreHooks:

--- a/tests/unit_tests/test_training.py
+++ b/tests/unit_tests/test_training.py
@@ -208,7 +208,7 @@ class TestSaveGrads:
             assert expected_file.exists(), f"Expected file {expected_file} to exist"
 
             # Verify saved content.
-            loaded = torch.load(expected_file)
+            loaded = torch.load(expected_file, weights_only=True)
             assert "model_chunk0" in loaded
             assert "layer.weight" in loaded["model_chunk0"]
             assert "layer.bias" in loaded["model_chunk0"]

--- a/tools/checkpoint/checkpoint_inspector.py
+++ b/tools/checkpoint/checkpoint_inspector.py
@@ -1136,7 +1136,7 @@ def print_torch_dcp_in_json(torch_dcp_dir, model_weight_prefix="model.module"):
         dcp_to_torch_save(torch_dcp_dir, tmp_file.name)
 
         # Load the state dict from the temporary file
-        state_dict = torch.load(tmp_file.name, map_location="cpu")
+        state_dict = torch.load(tmp_file.name, map_location="cpu", weights_only=True)
 
         click.echo(f"torch dcp content: {json.dumps(state_dict)}")
 

--- a/tools/checkpoint/hybrid_conversion.py
+++ b/tools/checkpoint/hybrid_conversion.py
@@ -242,7 +242,7 @@ def main(args):
 
     # load one of the model parallel ranks to get arguments
     sample_model_file = os.path.join(input_model_dir, input_sub_models[0], "model_optim_rng.pt")
-    sample_model = torch.load(sample_model_file)
+    sample_model = torch.load(sample_model_file, weights_only=True)
     print(f"Sample model {sample_model_file} is loaded.\n")
 
     # input tensor and pipeline parallel size
@@ -261,7 +261,7 @@ def main(args):
                 dir_name += "_{:03d}".format(pp)
             model_file = os.path.join(input_model_dir, dir_name, "model_optim_rng.pt")
 
-            tp_models.append(torch.load(model_file))
+            tp_models.append(torch.load(model_file, weights_only=True))
             print(f"Model {model_file} is loaded.")
 
         if input_tp_rank > 1:

--- a/tools/checkpoint/remap_gpt_dsa_to_mamba.py
+++ b/tools/checkpoint/remap_gpt_dsa_to_mamba.py
@@ -124,7 +124,7 @@ def convert(input_path: Path, output_path: Path, num_gpt_layers: int) -> None:
     tmp_flat = output_path.parent / "_tmp_gpt_flat.pt"
     try:
         dcp_to_torch_save(str(input_path), str(tmp_flat))
-        gpt_sd = torch.load(tmp_flat, map_location="cpu")
+        gpt_sd = torch.load(tmp_flat, map_location="cpu", weights_only=True)
         print(f"Loaded {len(gpt_sd)} keys from GPTModel checkpoint.")
 
         # --- Remap keys ---


### PR DESCRIPTION
## Description

Passes `weights_only=True` to `torch.load()` calls across checkpointing, optimizer state loading, and example conversion scripts. This hardens deserialization against arbitrary code execution when loading externally supplied PyTorch state dicts. Legacy checkpoints that require custom classes can still be loaded by setting `TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1` as documented in the affected example.

Files changed:
- `examples/multimodal/combine_state_dicts.py`
- `examples/multimodal/dataloader_provider.py`
- `examples/multimodal/nvlm/pp_checkpoint_converter.py`
- `examples/post_training/modelopt/convert_model.py`
- `examples/post_training/modelopt/finetune.py`
- `examples/post_training/modelopt/validate.py`
- `megatron/core/dist_checkpointing/strategies/common.py`
- `megatron/core/export/trtllm/trtllm_helper.py`
- `megatron/core/extensions/transformer_engine.py`
- `megatron/core/models/audio/nemo_audio_checkpoint.py`
- `megatron/core/optimizer/distrib_optimizer.py`
- `megatron/core/optimizer/layer_wise_optimizer.py`
- `megatron/core/optimizer/optimizer.py`
- `megatron/core/safe_globals.py`
- `megatron/training/checkpointing.py`
- `megatron/training/distillation/utils_logits.py`
- Several `tests/unit_tests/...` files
- `tools/checkpoint/...` files

## Checklist

- [x] I have reviewed the Megatron contributing page at https://docs.nvidia.com/megatron-core/developer-guide/nightly/developer/contribute.html.
- [x] Existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] No new dependencies.
- [x] Commits are signed off per the DCO (`Signed-off-by: Andrew White <andrew@vibecodingagency.com>`).

## Dependencies

None.

## Review Process

This PR is ready for maintainer review.
