### PR TITLE
Apply black 26.3.0 formatting to four files it now reformats

### DIFF
--- a/megatron/core/models/vision/radio.py
+++ b/megatron/core/models/vision/radio.py
@@ -610,11 +610,11 @@ class RADIOViTModel(VisionModule):
             return pos_embed
 
         def aspect_ratio_select(pos_embed):
-            (pos_H, pos_W) = pos_embed.shape[-2:]
-            (input_H, input_W) = input_dims
+            pos_H, pos_W = pos_embed.shape[-2:]
+            input_H, input_W = input_dims
             if input_H == input_W:
                 return pos_embed
-            (crop_H, crop_W) = (pos_H, pos_W)
+            crop_H, crop_W = (pos_H, pos_W)
             if input_W < input_H:
                 crop_W = min(pos_W, math.ceil(pos_W * (input_W / input_H)))
             else:
@@ -676,7 +676,7 @@ class RADIOViTModel(VisionModule):
             else:
                 max_dim = max(input_dims)
 
-                (B, C, _H, _W) = pos_embed.shape
+                B, C, _H, _W = pos_embed.shape
                 aspect_ratio_select_required = B * C * max_dim**2 >= torch.iinfo(torch.int32).max
                 if aspect_ratio_select_required or self.cpe_aspect_ratio_select:
                     pos_embed = aspect_ratio_select(pos_embed)

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -468,7 +468,7 @@ class Attention(MegatronModule, ABC):
                 checkpoint_inputs.append(kwarg_value)
 
         def custom_forward(*inputs):
-            (query, key, value, attention_mask, _, attn_mask_type, *tensor_kwarg_values) = inputs
+            query, key, value, attention_mask, _, attn_mask_type, *tensor_kwarg_values = inputs
             attn_mask_type = AttnMaskType(attn_mask_type.item())
             extra_kwargs = dict(core_attention_extra_kwargs)
             for name, kwarg_value in zip(tensor_kwarg_names, tensor_kwarg_values):
@@ -1881,9 +1881,9 @@ class SelfAttention(Attention):
             ]
 
             if SplitAlongDim is not None:
-                (query, gate, key, value) = SplitAlongDim(mixed_qkv, 3, split_arg_list)
+                query, gate, key, value = SplitAlongDim(mixed_qkv, 3, split_arg_list)
             else:
-                (query, gate, key, value) = torch.split(mixed_qkv, split_arg_list, dim=3)
+                query, gate, key, value = torch.split(mixed_qkv, split_arg_list, dim=3)
         else:
             # If no output gate: [sq, b, ng, (np/ng + 2) * hn]
             # --> [sq, b, ng, np/ng * hn], None, [sq, b, ng, hn], [sq, b, ng, hn]
@@ -1898,9 +1898,9 @@ class SelfAttention(Attention):
                 return mixed_qkv, split_arg_list
 
             if SplitAlongDim is not None:
-                (query, key, value) = SplitAlongDim(mixed_qkv, 3, split_arg_list)
+                query, key, value = SplitAlongDim(mixed_qkv, 3, split_arg_list)
             else:
-                (query, key, value) = torch.split(mixed_qkv, split_arg_list, dim=3)
+                query, key, value = torch.split(mixed_qkv, split_arg_list, dim=3)
 
         # Query [sq, b, ng, np/ng * hn] -> [sq, b, np, hn]
         query = query.reshape(query.size(0), query.size(1), -1, self.hidden_size_per_attention_head)
@@ -2144,7 +2144,7 @@ class CrossAttention(Attention):
         mixed_kv = mixed_kv.view(*new_tensor_shape)
 
         # [sk, b, np, 2 * hn] --> 2 [sk, b, np, hn]
-        (key, value) = tensor_parallel.split_tensor_along_last_dim(mixed_kv, 2)
+        key, value = tensor_parallel.split_tensor_along_last_dim(mixed_kv, 2)
 
         # Attention head [sq, b, h] --> [sq, b, hp]
         query, _ = apply_module(self.linear_q)(hidden_states)

--- a/megatron/core/transformer/mlp.py
+++ b/megatron/core/transformer/mlp.py
@@ -193,12 +193,8 @@ class MLP(MegatronModule):
         if ffn_hidden_size is None:
             if is_expert:
                 raise ValueError("MoE MLP requires `ffn_hidden_size`, but it was not provided.")
-            warnings.warn(
-                "MLP requires ffn_hidden_size, but it was not provided. Using \
-                    config.ffn_hidden_size by default.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+            warnings.warn("MLP requires ffn_hidden_size, but it was not provided. Using \
+                    config.ffn_hidden_size by default.", DeprecationWarning, stacklevel=2)
             ffn_hidden_size = not_none(self.config.ffn_hidden_size)
 
         # If this is a gated linear unit we double the output width

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -1246,9 +1246,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
             # CUDA Graph captures the whole MLP/MoE part. CUDA Graph output is the layer output.
             assert len(cuda_graph_output) == 1, "CUDA Graph output should be the layer output."
             output = cuda_graph_output.pop()
-            assert (
-                not self.config.overlap_moe_expert_parallel_comm
-            ), "EP overlap must be \
+            assert not self.config.overlap_moe_expert_parallel_comm, "EP overlap must be \
                 disabled when CUDA graph captures the whole MLP/MoE part."
         elif self.is_moe_layer and CudaGraphModule.moe_router in self.config.cuda_graph_modules:
             # CUDA Graph partially captures the MoE.


### PR DESCRIPTION
## Summary

#6180 bumped `black` from 24.4.2 to 26.3.0 but did not reformat the tree. Black 26 strips redundant parentheses around assignment targets and re-joins calls that black 24 had exploded, so files predating the bump no longer satisfy `black --check`.

`tools/autoformat.sh` lints only the files that differ from `main`, so a PR hits the violation only if it happens to touch such a file. That keeps the debt invisible here — and surfaces it all at once in downstream forks, whose diff against `main` is their entire delta. That is how these four surfaced.

This is purely the output of running the pinned black over them. No behavioural change.

- `megatron/core/models/vision/radio.py` — `(pos_H, pos_W) = ...` → `pos_H, pos_W = ...`
- `megatron/core/transformer/attention.py` — same paren-stripping on tuple unpacking
- `megatron/core/transformer/mlp.py` — re-join the `warnings.warn(...)` call
- `megatron/core/transformer/transformer_layer.py` — re-join the `assert ..., "EP overlap..."`

## Scope

117 files under `megatron/` are affected repo-wide. This PR is deliberately limited to the four that are blocking, to keep the diff reviewable and avoid conflicting with work in flight. Happy to widen it to the full set if you would rather clear the backlog in one pass — or to close this if the intent is to let files get reformatted as they are touched.

## Test plan

- [x] `black==26.3.0 --skip-magic-trailing-comma --skip-string-normalization --check` passes on all four
- [x] `isort==5.13.2`, `ruff~=0.9.0`, `pylint==3.2.6` clean on all four (pylint 10.00/10)
- [x] `python -m py_compile` succeeds on all four
- [x] CI status checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)