### PR TITLE
fix: pretrain_hybrid.py --help

### DIFF
--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -1275,7 +1275,7 @@ class TransformerConfig(ModelParallelConfig):
     """Scale factor for paged stash CUDA buffer allocation.
 
     Sign selects sizing: positive = avg-based, negative = actual-max. Magnitude is headroom
-    (e.g. 1.10 = 10%)."""
+    (e.g. 1.10 = 10%%)."""
 
     moe_paged_stash_buffer_size_factor_cpu: float = 0.0
     """Scale factor for paged stash host buffer. 0 disables host buffer.


### PR DESCRIPTION
Getting an error when trying to run the very basic:
```
 % python pretrain_hybrid.py --help
Traceback (most recent call last):
[...]
ValueError: unsupported format character ')' (0x29) at index 157
```

This is common issue when re-using docstring into argument parser help section, when the docstring contains % symbol. See for example: https://github.com/THUDM/SwissArmyTransformer/issues/124.

Works with the tiny hotfix.

Note: This PR was generated with Codex.
