### PR TITLE
Materialize MFSDP main gradients on reduce-scatter stream

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -115,6 +115,17 @@ class DBuffer:
         """Restore the local buffer's backing storage to its logical size."""
         self._resize_storage(self.local_buffer.numel())
 
+    @classmethod
+    def empty_like(cls, buffer: "DBuffer", device: torch.device) -> "DBuffer":
+        """Create an empty buffer with ``buffer``'s distributed layout."""
+        return cls(
+            mesh=buffer.mesh,
+            placements=buffer.placements,
+            tensor_shapes=buffer.layout.tensor_shapes,
+            dtype=buffer.dtype,
+            device=device,
+        )
+
     def release_storage(self) -> None:
         """Release local buffer storage without replacing the Storage object."""
         # Autograd may save views that share this Storage object. Resizing the

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -22,6 +22,7 @@ from torch import nn
 from torch.distributed import DeviceMesh
 
 from ..mixed_precision import MixedPrecisionPolicy
+from .dbuffer import DBuffer
 from .indexed_order import IndexedOrder
 from .parameter_group import FsdpParameterGroup, get_containing_parameter_group
 from .placement import Placements
@@ -169,6 +170,18 @@ class FsdpModule:
             submodule._context = context
             submodule._name = submodule_name
             context.forward_order.append(submodule)
+
+        # main_grad buffers start meta-backed because fully_shard() runs before
+        # a shared context (and its communication streams) exists. Materialize
+        # all trainable groups together on the reduce-scatter stream now that
+        # the final subtree context has been assigned.
+        with torch.cuda.stream(context.reduce_scatter_stream):
+            for submodule in context.forward_order:
+                for group in submodule._parameter_groups:
+                    if group.requires_grad:
+                        group.main_grad = DBuffer.empty_like(
+                            group.main_grad, group.main_weight.device
+                        )
 
         # Backward starts from the root pre-backward hook before visiting child
         # subtrees in reverse module order.

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -157,7 +157,9 @@ class FsdpParameterGroup:
                 placements=main_grad_placements,
                 tensor_shapes=self.main_weight.layout.tensor_shapes,
                 dtype=grad_dtype,
-                device=self.main_weight.device,
+                # The shared reduce-scatter stream is created during first-forward
+                # context initialization, so allocate storage only then.
+                device="meta",
             )
             assert self.main_grad.layout == self.main_weight.layout, (
                 "main_grad is built from main_weight tensor shapes on the same mesh, "

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -423,46 +423,8 @@ def test_forward_peak_memory_bounds_in_flight_child_all_gathers(distributed_setu
     )
 
 
-def test_root_forward_returns_to_resting_memory(distributed_setup):
-    """Root forward should release child all-gather storage before returning."""
-    rank = distributed_setup.rank
-    world_size = distributed_setup.world_size
-    device = distributed_setup.device
-    if world_size < 2:
-        pytest.skip("This test requires at least 2 ranks.")
-
-    mesh = init_device_mesh(device.type, (world_size,))
-    dim = 4096
-    dtype = torch.bfloat16
-    model = MultiChildModel(dim=dim, num_children=2).to(dtype=dtype, device=device)
-    placements = _flat_placements()
-    policy = MixedPrecisionPolicy(main_params_dtype=dtype, main_grads_dtype=dtype)
-    for layer in model.layers:
-        fully_shard(layer, mesh=mesh, placements=placements, mixed_precision_policy=policy)
-    fully_shard(model, mesh=mesh, placements=placements, mixed_precision_policy=policy)
-
-    x = torch.randn(2, dim, device=device, dtype=dtype)
-    torch.cuda.synchronize(device)
-    torch.cuda.empty_cache()
-    resting_allocated = torch.cuda.memory_allocated(device)
-
-    with torch.no_grad():
-        output = model(x)
-    del output
-    torch.cuda.synchronize(device)
-    allocated_after_forward = torch.cuda.memory_allocated(device)
-    extra_allocated = allocated_after_forward - resting_allocated
-    child_weight_nbytes = dim * dim * torch.empty((), dtype=dtype).element_size()
-
-    assert extra_allocated < child_weight_nbytes, (
-        "Root forward did not return to resting memory after draining child releases: "
-        f"rank={rank}, extra_allocated={_mb(extra_allocated)}, "
-        f"one_child_weight={_mb(child_weight_nbytes)}"
-    )
-
-
-def test_root_backward_returns_to_resting_memory(distributed_setup):
-    """Root backward should release child all-gather storage before returning."""
+def test_training_returns_to_resting_memory(distributed_setup):
+    """Forward and backward should release child all-gather storage."""
     rank = distributed_setup.rank
     world_size = distributed_setup.world_size
     device = distributed_setup.device
@@ -480,23 +442,35 @@ def test_root_backward_returns_to_resting_memory(distributed_setup):
     fully_shard(model, mesh=mesh, placements=placements, mixed_precision_policy=policy)
 
     x = torch.randn(2, dim, device=device, dtype=dtype, requires_grad=True)
-    output = model(x)
-    loss = output.float().square().mean()
+    loss = model(x).float().square().mean()
     torch.cuda.synchronize(device)
-    torch.cuda.empty_cache()
-    allocated_before_backward = torch.cuda.memory_allocated(device)
+
+    memory_slack = 1024**2
+    # Two child weight matrices and the root bias are Flat-sharded; both main
+    # weights and same-dtype main gradients retain one local shard.
+    parameter_nbytes = (2 * dim**2 + dim) * torch.empty((), dtype=dtype).element_size()
+    expected_persistent_nbytes = 2 * parameter_nbytes // world_size
+    expected_forward_nbytes = (
+        expected_persistent_nbytes + x.nbytes + torch.backends.cuda.cublas_workspace_size()
+    )
+    allocated_after_forward = torch.cuda.memory_allocated(device)
+    assert allocated_after_forward <= expected_forward_nbytes + memory_slack, (
+        "Forward retained more than its persistent FSDP buffers: "
+        f"rank={rank}, allocated={_mb(allocated_after_forward)}, "
+        f"expected={_mb(expected_forward_nbytes)}, slack={_mb(memory_slack)}"
+    )
 
     loss.backward()
-    del loss, output
+    del loss
     torch.cuda.synchronize(device)
     allocated_after_backward = torch.cuda.memory_allocated(device)
-    extra_allocated = allocated_after_backward - allocated_before_backward
-    child_weight_nbytes = dim * dim * torch.empty((), dtype=dtype).element_size()
-
-    assert extra_allocated < child_weight_nbytes, (
-        "Root backward did not return to resting memory after draining child releases: "
-        f"rank={rank}, extra_allocated={_mb(extra_allocated)}, "
-        f"one_child_weight={_mb(child_weight_nbytes)}"
+    expected_backward_nbytes = (
+        expected_forward_nbytes + x.grad.nbytes + torch.backends.cuda.cublas_workspace_size()
+    )
+    assert allocated_after_backward <= expected_backward_nbytes + memory_slack, (
+        "Backward retained more than its persistent FSDP buffers: "
+        f"rank={rank}, allocated={_mb(allocated_after_backward)}, "
+        f"expected={_mb(expected_backward_nbytes)}, slack={_mb(memory_slack)}"
     )
 
 


### PR DESCRIPTION
## Summary
- Construct trainable MFSDP main-gradient buffers on meta and materialize them once the shared reduce-scatter stream exists.
- Add `DBuffer.empty_like()` so materialization rebinds a new buffer instead of replacing local storage.
- Consolidate resting-memory coverage around the training path and account for persistent FSDP and cuBLAS storage.

## Validation
- `python -m torch.distributed.run --nproc-per-node 2 -m pytest -q tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py::test_training_returns_to_resting_memory tests/unit_tests/distributed/mfsdp_v2/test_cuda_graph.py`
- `black --check`, `ruff check`, and `git diff --check` on changed files.