### PR TITLE
route collectives through nccl2

### DIFF
--- a/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
+++ b/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
@@ -370,12 +370,10 @@ class FullyShardedDataParallel(_BaseDataParallel):
                 ep_group = getattr(pg_collection, 'ep', None)
 
         if tp_group is None:
-            single_rank_group = dist.new_group(ranks=[dist.get_rank()])
-            tp_group = single_rank_group
+            tp_group = _new_single_rank_group()
 
         if expt_tp_group is None:
-            single_rank_group = dist.new_group(ranks=[dist.get_rank()])
-            expt_tp_group = single_rank_group
+            expt_tp_group = _new_single_rank_group()
 
         # Extract AG groups from pg_collection for explicit passing
         dp_cp_ag = getattr(pg_collection, 'dp_cp_ag', None) if pg_collection is not None else None
@@ -465,6 +463,38 @@ class FullyShardedDataParallel(_BaseDataParallel):
             broadcast_list = [None]
         torch.distributed.broadcast_object_list(broadcast_list, group=self.tp_group, group_src=0)
         _load_rng_state_dict(broadcast_list[0])
+
+
+def _new_single_rank_group():
+    """Build a degenerate 1-rank process group containing only this rank.
+
+    Used as a stand-in when the caller supplies no TP / expert-TP group.
+
+    This is deliberately a *members-only* ``new_group`` rather than a
+    ``split_group``:
+
+    * Every rank passes a different ``ranks`` list (``[my_rank]``), so this is
+      not a covering-partition collective. Routing it through ``split_group``
+      would impose a new world-wide rendezvous that the current code does not
+      require, and would deadlock if ``tp_group``/``expt_tp_group`` were
+      populated on some ranks but not others.
+    * A 1-rank group gains nothing from ``ncclCommSplit``.
+    * ``use_local_synchronization=True`` is mandatory on an ``nccl2`` world:
+      without it ``new_group`` takes the eager no-color-split path
+      (``performNocolorSplit``), which ``nccl2`` does not implement. It also
+      switches the group name from the ``_world.group_count`` counter (which is
+      identical on every rank, so all the per-rank 1-rank groups would share a
+      single PrefixStore namespace) to a hash of ``[my_rank]``, which is unique
+      per rank.
+
+    The backend is inherited from the world PG, so this follows whichever cuda
+    backend the world was initialized with (stock ``nccl`` or ``nccl2``).
+    """
+    return parallel_state.create_group(
+        ranks=[dist.get_rank()],
+        use_local_synchronization=True,
+        group_desc="SINGLE_RANK_GROUP",
+    )
 
 
 def _get_hsdp_tp_mesh(outer_fsdp_dp_group, dp_cp_group, tp_group, ep_size=1):

--- a/megatron/core/hyper_comm_grid.py
+++ b/megatron/core/hyper_comm_grid.py
@@ -217,10 +217,11 @@ class HyperCommGrid:
             dims: Name of leading dimensions to create process group
             view: Optional registered rank view name. Defaults to the base view.
 
-        Keyword arguments are directly passed into new_subgroups_by_enumeration(). The docstring
-        is copied from new_subgroups_by_enumeration().
+        Keyword arguments are directly passed into
+        ``megatron.core.parallel_state.create_split_groups()`` (a ``split_group``-based
+        replacement for ``dist.new_subgroups_by_enumeration``).
 
-        Keyword args from `dist.new_subgroups_by_enumeration`:
+        Keyword args:
             timeout (timedelta, optional): see `init_process_group` for details and default value.
             pg_options (ProcessGroupOptions, optional): process group options
                 specifying what additional options need to be passed in during
@@ -256,7 +257,15 @@ class HyperCommGrid:
             )
 
         rank_enum = self._gen_rank_enum_for(enum_view.shape, enum_view.dim_names, enum_dims)
-        pg, _ = dist.new_subgroups_by_enumeration(rank_enum, backend=self.backend, **kwargs)
+        # Build every subgroup of the enumeration with one ``split_group``
+        # collective instead of one eager ``new_group`` per sublist:
+        # ``new_subgroups_by_enumeration`` makes non-member ranks call
+        # ``performNocolorSplit`` on the parent backend, which the ``nccl2``
+        # backend does not implement. Imported lazily to keep ``hyper_comm_grid``
+        # free of a module-level ``parallel_state`` dependency.
+        from megatron.core.parallel_state import create_split_groups
+
+        pg = create_split_groups(rank_enum, backend=self.backend, **kwargs)
 
         if dist.is_initialized() and dist.get_rank() == 0:
             if self._is_base_pg_key(unique_group_key):
@@ -331,7 +340,7 @@ class HyperCommGrid:
         return self._gen_rank_enum_for(view_spec.shape, view_spec.dim_names, ordered_dims)
 
     def _gen_rank_enum(self, dims: list[str]) -> list[list[int]]:
-        r"""Generate rank enumeration before calling new_subgroups_by_enumeration
+        r"""Generate rank enumeration before creating the process groups
 
         This function returns ranks grouped by the specified dimensions, but in REVERSE order
         of the input dimensions. For example, if you request dimensions ["a", "b"],

--- a/megatron/core/models/mimo/comm/colocated_communicator.py
+++ b/megatron/core/models/mimo/comm/colocated_communicator.py
@@ -9,6 +9,7 @@ import torch
 import torch.distributed as dist
 
 from megatron.core.hyper_comm_grid import HyperCommGrid
+from megatron.core.parallel_state import create_split_groups
 
 
 @dataclass
@@ -89,9 +90,10 @@ class ColocatedBridgeCommunicator:
                 scale=self.scale,
                 rank_to_pos=self.rank_to_src_pos,
             )
-            self.gather_pg, _ = dist.new_subgroups_by_enumeration(
-                self.gather_group_ranks, backend='nccl'
-            )
+            # Collective (all-gather) subgroups: one ``split_group`` over the
+            # world PG, inheriting the world's cuda backend. Do not hardcode
+            # "nccl" -- that would pin a stock-NCCL child under an nccl2 world.
+            self.gather_pg = create_split_groups(self.gather_group_ranks)
         elif self.dest_dp_size > self.src_dp_size:
             self.direction = BridgeDirection.FAN_OUT
             self.scale = self.dest_dp_size // self.src_dp_size
@@ -101,9 +103,7 @@ class ColocatedBridgeCommunicator:
                 scale=self.scale,
                 rank_to_pos=self.rank_to_dest_pos,
             )
-            self.gather_pg, _ = dist.new_subgroups_by_enumeration(
-                self.gather_group_ranks, backend='nccl'
-            )
+            self.gather_pg = create_split_groups(self.gather_group_ranks)
         else:
             self.direction = BridgeDirection.EQUAL
             self.scale = 1

--- a/megatron/core/parallel_state.py
+++ b/megatron/core/parallel_state.py
@@ -217,6 +217,7 @@ def create_group(
     pg_options=None,
     use_local_synchronization=False,
     group_desc=None,
+    device_id=None,
 ):
     """Creates a ProcessGroup."""
     kwargs = {
@@ -227,6 +228,8 @@ def create_group(
         "use_local_synchronization": use_local_synchronization,
         "group_desc": group_desc,
     }
+    if device_id is not None:
+        kwargs["device_id"] = device_id
     if not is_torch_min_version("2.4.0"):
         kwargs.pop("group_desc")
         if timeout is None:
@@ -244,6 +247,128 @@ def create_group(
         _global_process_group_list = [None]
     if torch.distributed.get_rank() in ranks:
         _global_process_group_list.append(group)
+    return group
+
+
+def is_fake_process_group():
+    """Whether the world PG is a torch ``FakeProcessGroup``.
+
+    ``--fake-process-group`` initializes the world PG with the ``fake`` backend,
+    which registers one no-op backend for every device type and performs no
+    communication at all. Group construction has to take a few different turns
+    in that mode (see ``_split_group_backend`` and the pipeline-parallel group
+    below), so give the check a single name.
+    """
+    return torch.distributed.is_initialized() and torch.distributed.get_backend() == "fake"
+
+
+def _split_group_backend(backend):
+    """Device-qualify the backend filter handed to ``split_group``.
+
+    The world PG carries both a cpu (gloo) and a cuda (nccl2) backend, so a
+    subgroup split from it inherits both unless the filter restricts it. Cuda
+    subgroups keep only the world PG's cuda backend. Gloo subgroups keep
+    ``cpu:gloo`` plus the parent's cuda backend: split_group requires the filter
+    to include the parent PG's default device type (cuda), so a cpu-only filter
+    is rejected. The resulting gloo group carries a redundant (but harmless)
+    cuda backend, as upstream vLLM's cpu group does. Returning ``None`` lets the
+    child inherit the full parent config (used when the cuda backend can't be
+    determined).
+
+    A fake world PG is the exception: it has one ``fake`` backend for every
+    device type, so there is nothing to filter, and it is also unfilterable --
+    ``split_group`` validates the filter against the parent's *registered*
+    backend string, which is the bare name ``"fake"`` rather than
+    ``"cuda:fake"``, so any device-qualified filter is rejected. Inherit the
+    parent config there; in a fake run the "gloo" groups are fake groups too,
+    which is what a no-communication run wants.
+    """
+    if is_fake_process_group():
+        return None
+    requested = str(backend or "").lower()
+    if requested not in ("", "nccl", "nccl2", "gloo"):
+        return backend
+    cuda_backend = None
+    world_config = torch.distributed.get_backend_config()
+    for part in world_config.split(","):
+        device, _, name = part.partition(":")
+        if device.strip() == "cuda" and name.strip():
+            cuda_backend = name.strip()
+            break
+    if requested == "gloo":
+        return f"cpu:gloo,cuda:{cuda_backend}" if cuda_backend else "cpu:gloo"
+    return f"cuda:{cuda_backend}" if cuda_backend else None
+
+
+def create_partition_groups(
+    ranks_list,
+    timeout=None,
+    backend=None,
+    pg_options=None,
+    group_desc=None,
+):
+    """Create every subgroup of a rank *partition*; return this rank's
+    ``(group, ranks)`` (``(None, None)`` if the rank is in no subgroup).
+
+    Both the cuda subgroups (backend None/"nccl") and the gloo subgroups
+    (``backend="gloo"``) are built with a single ``torch.distributed.split_group``
+    collective over the world PG. split_group is entered by every rank in the
+    parent group, is self-contained (it does not use ``new_group``'s eager
+    no-color-split path, which nccl2 does not implement) and uses hashed group
+    names, so it stays in lockstep across ranks. The gloo split requires the
+    world PG to carry a ``cpu:gloo`` backend (see ``initialize.py``).
+    """
+    rank = torch.distributed.get_rank()
+    ranks_list = [list(r) for r in ranks_list]
+    group = torch.distributed.split_group(
+        split_ranks=ranks_list,
+        timeout=timeout,
+        pg_options=pg_options,
+        group_desc=group_desc,
+        backend=_split_group_backend(backend),
+    )
+    if group is None or group == torch.distributed.GroupMember.NON_GROUP_MEMBER:
+        return None, None
+    global _global_process_group_list
+    if _global_process_group_list is None:
+        # None stands for the default process group
+        _global_process_group_list = [None]
+    _global_process_group_list.append(group)
+    for r in ranks_list:
+        if rank in r:
+            return group, r
+    return None, None
+
+
+def create_split_groups(
+    ranks_list,
+    timeout=None,
+    backend=None,
+    pg_options=None,
+    group_desc=None,
+):
+    """Drop-in replacement for ``torch.distributed.new_subgroups_by_enumeration``.
+
+    Creates every subgroup in ``ranks_list`` with a single
+    ``torch.distributed.split_group`` collective over the world PG and returns
+    this rank's subgroup (``None`` if the rank is in no subgroup).
+
+    ``ranks_list`` does *not* have to cover the world: ranks that appear in no
+    sublist simply take the no-color side of the split. Like
+    ``new_subgroups_by_enumeration`` -- and like every ``split_group`` -- this is
+    collective, so **every** rank of the world PG must call it with the same
+    ``ranks_list``. Unlike ``new_subgroups_by_enumeration`` (which issues one
+    eager ``new_group`` per sublist and therefore drives non-members through
+    ``performNocolorSplit``, which the ``nccl2`` backend does not implement),
+    a single ``split_group`` is self-contained and uses hashed group names.
+    """
+    group, _ = create_partition_groups(
+        ranks_list,
+        timeout=timeout,
+        backend=backend,
+        pg_options=pg_options,
+        group_desc=group_desc,
+    )
     return group
 
 
@@ -393,26 +518,26 @@ def create_hierarchical_groups(
             s=hierarchical_group_sizes[level],
             l=int(np.prod(hierarchical_group_sizes[level + 1 :])),
         ).tolist()
-        for sub_ranks in rearranged_ranks:
-            sub_group = create_group(
-                sub_ranks,
+        # The sub-groups at each level partition ``ranks`` (a subset of the
+        # world PG), so build them with one split_group collective per level.
+        sub_group, my_sub_ranks = create_partition_groups(
+            rearranged_ranks,
+            timeout=timeout,
+            pg_options=pg_options[level],
+            group_desc=f"HIERARCHICAL_{group_desc}_L{level}",
+        )
+        if create_gloo_process_groups:
+            sub_group_gloo, _ = create_partition_groups(
+                rearranged_ranks,
                 timeout=timeout,
-                pg_options=pg_options[level],
-                group_desc=f"HIERARCHICAL_{group_desc}_L{level}",
+                backend="gloo",
+                group_desc=f"HIERARCHICAL_{group_desc}_GLOO_L{level}",
             )
-            if create_gloo_process_groups:
-                sub_group_gloo = create_group(
-                    sub_ranks,
-                    timeout=timeout,
-                    backend="gloo",
-                    pg_options=pg_options[level],
-                    group_desc=f"HIERARCHICAL_{group_desc}_GLOO_L{level}",
-                )
-            else:
-                sub_group_gloo = None
-            if rank in sub_ranks:
-                hierarchical_groups.append(sub_group)
-                hierarchical_groups_gloo.append(sub_group_gloo)
+        else:
+            sub_group_gloo = None
+        if my_sub_ranks is not None:
+            hierarchical_groups.append(sub_group)
+            hierarchical_groups_gloo.append(sub_group_gloo)
     assert rank not in ranks or len(hierarchical_groups) == len(hierarchical_group_sizes)
     assert rank not in ranks or len(hierarchical_groups_gloo) == len(hierarchical_group_sizes)
     return hierarchical_groups, hierarchical_groups_gloo
@@ -429,17 +554,19 @@ def create_hybrid_dp_cp_groups(rank, ranks, pg_options):
     # We limit the allowed group sizes in order to avoid excessive overhead.
     group_sizes = [2**i for i in range(int(log2(len(ranks))))][1:]
     for group_size in group_sizes:
-        for i in range(0, len(ranks), group_size):
-            group = create_group(
-                ranks[i : i + group_size],
-                pg_options=pg_options,
-                group_desc=f"HYBRID_DP_CP_GROUP_{group_size}",
-            )
-            if rank in ranks[i : i + group_size]:
-                assert (
-                    group_size not in hybrid_dp_cp_groups
-                ), f"Rank {rank} appears in multiple Hybrid DP CP groups of size {group_size}"
-                hybrid_dp_cp_groups[group_size] = group
+        # The equal-sized slices at a given group_size partition ``ranks`` (a
+        # subset of the world PG), so build them with one split_group per size.
+        partition = [ranks[i : i + group_size] for i in range(0, len(ranks), group_size)]
+        group, my_ranks = create_partition_groups(
+            partition,
+            pg_options=pg_options,
+            group_desc=f"HYBRID_DP_CP_GROUP_{group_size}",
+        )
+        if my_ranks is not None:
+            assert (
+                group_size not in hybrid_dp_cp_groups
+            ), f"Rank {rank} appears in multiple Hybrid DP CP groups of size {group_size}"
+            hybrid_dp_cp_groups[group_size] = group
     return hybrid_dp_cp_groups
 
 
@@ -842,58 +969,62 @@ def initialize_model_parallel(
     # is eligible for using the NCCL COLLNET feature.
     # Therefore, dp-cp group, which potentially requires SHARP-enablement,
     # need to be created before all the other groups
-    for ranks_with_cp in decoder_rank_generator.get_ranks('dp-cp'):
-        group_with_cp = create_group(
-            ranks_with_cp,
+    group_with_cp, my_ranks_with_cp = create_partition_groups(
+        decoder_rank_generator.get_ranks('dp-cp'),
+        timeout=timeout,
+        pg_options=get_nccl_options("dp_cp", nccl_comm_cfgs),
+        group_desc="DATA_PARALLEL_GROUP_WITH_CP",
+    )
+    if create_gloo_process_groups:
+        group_with_cp_gloo, _ = create_partition_groups(
+            decoder_rank_generator.get_ranks('dp-cp'),
             timeout=timeout,
-            pg_options=get_nccl_options("dp_cp", nccl_comm_cfgs),
-            group_desc="DATA_PARALLEL_GROUP_WITH_CP",
+            backend="gloo",
+            group_desc="DATA_PARALLEL_GROUP_WITH_CP_GLOO",
+        )
+    else:
+        group_with_cp_gloo = None
+    if my_ranks_with_cp is not None:
+        _DATA_PARALLEL_GROUP_WITH_CP = group_with_cp
+        _DATA_PARALLEL_GROUP_WITH_CP_GLOO = group_with_cp_gloo
+        _DATA_PARALLEL_GLOBAL_RANKS_WITH_CP = my_ranks_with_cp
+
+    if num_distributed_optimizer_instances > 1:
+        # Intra-partial DP groups are equal slices of each dp-cp group; across
+        # all dp-cp groups they partition the world PG, so build them with a
+        # single split_group collective.
+        intra_partial_dp_partition_with_cp = [
+            ranks_with_cp[
+                (i * intra_partial_data_parallel_size) : (
+                    (i + 1) * intra_partial_data_parallel_size
+                )
+            ]
+            for ranks_with_cp in decoder_rank_generator.get_ranks('dp-cp')
+            for i in range(num_distributed_optimizer_instances)
+        ]
+        intra_partial_dp_group_with_cp, my_intra_ranks = create_partition_groups(
+            intra_partial_dp_partition_with_cp,
+            timeout=timeout,
+            pg_options=get_nccl_options("intra_dp_cp", nccl_comm_cfgs),
+            group_desc="INTRA_PARTIAL_DATA_PARALLEL_GROUP_WITH_CP",
         )
         if create_gloo_process_groups:
-            group_with_cp_gloo = create_group(
-                ranks_with_cp,
+            intra_partial_dp_group_with_cp_gloo, _ = create_partition_groups(
+                intra_partial_dp_partition_with_cp,
                 timeout=timeout,
                 backend="gloo",
-                group_desc="DATA_PARALLEL_GROUP_WITH_CP_GLOO",
+                group_desc="INTRA_PARTIAL_DATA_PARALLEL_GROUP_WITH_CP_GLOO",
             )
         else:
-            group_with_cp_gloo = None
-        if rank in ranks_with_cp:
-            _DATA_PARALLEL_GROUP_WITH_CP = group_with_cp
-            _DATA_PARALLEL_GROUP_WITH_CP_GLOO = group_with_cp_gloo
-            _DATA_PARALLEL_GLOBAL_RANKS_WITH_CP = ranks_with_cp
-
-        if num_distributed_optimizer_instances > 1:
-            # Create groups for intra-partial DP domain
-            for i in range(num_distributed_optimizer_instances):
-                intra_partial_dp_ranks_with_cp = ranks_with_cp[
-                    (i * intra_partial_data_parallel_size) : (
-                        (i + 1) * intra_partial_data_parallel_size
-                    )
-                ]
-                intra_partial_dp_group_with_cp = create_group(
-                    intra_partial_dp_ranks_with_cp,
-                    timeout=timeout,
-                    pg_options=get_nccl_options("intra_dp_cp", nccl_comm_cfgs),
-                    group_desc="INTRA_PARTIAL_DATA_PARALLEL_GROUP_WITH_CP",
-                )
-                if create_gloo_process_groups:
-                    intra_partial_dp_group_with_cp_gloo = create_group(
-                        intra_partial_dp_ranks_with_cp,
-                        timeout=timeout,
-                        backend="gloo",
-                        group_desc="INTRA_PARTIAL_DATA_PARALLEL_GROUP_WITH_CP_GLOO",
-                    )
-                else:
-                    intra_partial_dp_group_with_cp_gloo = None
-                if rank in intra_partial_dp_ranks_with_cp:
-                    _INTRA_PARTIAL_DATA_PARALLEL_GROUP_WITH_CP = intra_partial_dp_group_with_cp
-                    _INTRA_PARTIAL_DATA_PARALLEL_GROUP_WITH_CP_GLOO = (
-                        intra_partial_dp_group_with_cp_gloo
-                    )
-        else:
-            _INTRA_PARTIAL_DATA_PARALLEL_GROUP_WITH_CP = _DATA_PARALLEL_GROUP_WITH_CP
-            _INTRA_PARTIAL_DATA_PARALLEL_GROUP_WITH_CP_GLOO = _DATA_PARALLEL_GROUP_WITH_CP_GLOO
+            intra_partial_dp_group_with_cp_gloo = None
+        if my_intra_ranks is not None:
+            _INTRA_PARTIAL_DATA_PARALLEL_GROUP_WITH_CP = intra_partial_dp_group_with_cp
+            _INTRA_PARTIAL_DATA_PARALLEL_GROUP_WITH_CP_GLOO = (
+                intra_partial_dp_group_with_cp_gloo
+            )
+    else:
+        _INTRA_PARTIAL_DATA_PARALLEL_GROUP_WITH_CP = _DATA_PARALLEL_GROUP_WITH_CP
+        _INTRA_PARTIAL_DATA_PARALLEL_GROUP_WITH_CP_GLOO = _DATA_PARALLEL_GROUP_WITH_CP_GLOO
 
     # Apply SHARP to the dp group.
     if sharp_enabled_group == "dp":
@@ -932,41 +1063,45 @@ def initialize_model_parallel(
             )
         # TODO: Are gloo groups needed for hybrid cp?
 
-    for ranks in decoder_rank_generator.get_ranks('dp'):
-        group = create_group(
-            ranks,
+    group, my_ranks = create_partition_groups(
+        decoder_rank_generator.get_ranks('dp'),
+        timeout=timeout,
+        pg_options=get_nccl_options("dp", nccl_comm_cfgs),
+        group_desc="DATA_PARALLEL_GROUP",
+    )
+    if create_gloo_process_groups:
+        group_gloo, _ = create_partition_groups(
+            decoder_rank_generator.get_ranks('dp'),
             timeout=timeout,
-            pg_options=get_nccl_options("dp", nccl_comm_cfgs),
-            group_desc="DATA_PARALLEL_GROUP",
+            backend="gloo",
+            group_desc="DATA_PARALLEL_GROUP_GLOO",
         )
-        if create_gloo_process_groups:
-            group_gloo = create_group(
-                ranks, timeout=timeout, backend="gloo", group_desc="DATA_PARALLEL_GROUP_GLOO"
-            )
-        else:
-            group_gloo = None
-        if rank in ranks:
-            _DATA_PARALLEL_GROUP = group
-            _DATA_PARALLEL_GROUP_GLOO = group_gloo
-            _DATA_PARALLEL_GLOBAL_RANKS = ranks
+    else:
+        group_gloo = None
+    if my_ranks is not None:
+        _DATA_PARALLEL_GROUP = group
+        _DATA_PARALLEL_GROUP_GLOO = group_gloo
+        _DATA_PARALLEL_GLOBAL_RANKS = my_ranks
 
     # Build the context-parallel groups.
     global _CONTEXT_PARALLEL_GROUP
     global _CONTEXT_PARALLEL_GLOBAL_RANKS
     assert _CONTEXT_PARALLEL_GROUP is None, 'context parallel group is already initialized'
-    for ranks in decoder_rank_generator.get_ranks('cp'):
-        group = create_group(
-            ranks,
-            timeout=timeout,
-            pg_options=get_nccl_options("cp", nccl_comm_cfgs),
-            group_desc="CONTEXT_PARALLEL_GROUP",
-        )
-        if rank in ranks:
-            _CONTEXT_PARALLEL_GROUP = group
-            _CONTEXT_PARALLEL_GLOBAL_RANKS = ranks
-        if hierarchical_context_parallel_sizes:
-            assert np.prod(hierarchical_context_parallel_sizes) == context_parallel_size
-            global _HIERARCHICAL_CONTEXT_PARALLEL_GROUPS
+    group, my_ranks = create_partition_groups(
+        decoder_rank_generator.get_ranks('cp'),
+        timeout=timeout,
+        pg_options=get_nccl_options("cp", nccl_comm_cfgs),
+        group_desc="CONTEXT_PARALLEL_GROUP",
+    )
+    if my_ranks is not None:
+        _CONTEXT_PARALLEL_GROUP = group
+        _CONTEXT_PARALLEL_GLOBAL_RANKS = my_ranks
+    if hierarchical_context_parallel_sizes:
+        # Hierarchical CP builds nested subgroups per cp group; every rank must
+        # enter create_hierarchical_groups for each cp group, so keep the loop.
+        assert np.prod(hierarchical_context_parallel_sizes) == context_parallel_size
+        global _HIERARCHICAL_CONTEXT_PARALLEL_GROUPS
+        for ranks in decoder_rank_generator.get_ranks('cp'):
             hierarchical_groups, _ = create_hierarchical_groups(
                 rank,
                 ranks,
@@ -983,16 +1118,15 @@ def initialize_model_parallel(
     global _MODEL_PARALLEL_GROUP
     global _MODEL_PARALLEL_GLOBAL_RANKS
     assert _MODEL_PARALLEL_GROUP is None, 'model parallel group is already initialized'
-    for ranks in decoder_rank_generator.get_ranks('tp-pp'):
-        group = create_group(
-            ranks,
-            timeout=timeout,
-            pg_options=get_nccl_options("mp", nccl_comm_cfgs),
-            group_desc="MODEL_PARALLEL_GROUP",
-        )
-        if rank in ranks:
-            _MODEL_PARALLEL_GROUP = group
-            _MODEL_PARALLEL_GLOBAL_RANKS = ranks
+    group, my_ranks = create_partition_groups(
+        decoder_rank_generator.get_ranks('tp-pp'),
+        timeout=timeout,
+        pg_options=get_nccl_options("mp", nccl_comm_cfgs),
+        group_desc="MODEL_PARALLEL_GROUP",
+    )
+    if my_ranks is not None:
+        _MODEL_PARALLEL_GROUP = group
+        _MODEL_PARALLEL_GLOBAL_RANKS = my_ranks
 
     # Build the tensor model-parallel groups.
     global _TENSOR_MODEL_PARALLEL_GROUP
@@ -1000,16 +1134,15 @@ def initialize_model_parallel(
     assert (
         _TENSOR_MODEL_PARALLEL_GROUP is None
     ), 'tensor model parallel group is already initialized'
-    for ranks in decoder_rank_generator.get_ranks('tp'):
-        group = create_group(
-            ranks,
-            timeout=timeout,
-            pg_options=get_nccl_options("tp", nccl_comm_cfgs),
-            group_desc="TENSOR_MODEL_PARALLEL_GROUP",
-        )
-        if rank in ranks:
-            _TENSOR_MODEL_PARALLEL_GROUP = group
-            _TENSOR_MODEL_PARALLEL_GLOBAL_RANKS = ranks
+    group, my_ranks = create_partition_groups(
+        decoder_rank_generator.get_ranks('tp'),
+        timeout=timeout,
+        pg_options=get_nccl_options("tp", nccl_comm_cfgs),
+        group_desc="TENSOR_MODEL_PARALLEL_GROUP",
+    )
+    if my_ranks is not None:
+        _TENSOR_MODEL_PARALLEL_GROUP = group
+        _TENSOR_MODEL_PARALLEL_GLOBAL_RANKS = my_ranks
 
     # Build the pipeline model-parallel groups and embedding groups
     # (first and last rank in each pipeline model-parallel group).
@@ -1076,17 +1209,60 @@ def initialize_model_parallel(
         os.environ["UCX_NET_DEVICES"] = "all"
         os.environ["UCC_CL_BASIC_TLS"] = "^sharp,nccl"
 
-    for ranks in decoder_rank_generator.get_ranks('pp'):
+    pp_partitions = decoder_rank_generator.get_ranks('pp')
+    for ranks in pp_partitions:
+        # The PP device group is the ONLY new_group in the nccl2 path: it is a
+        # members-only ("use_local_synchronization=True") per-peer "nccl-lazy"
+        # ProcessGroup (a dedicated comm + stream per send/recv peer, like
+        # ProcessGroupNCCL) so concurrent P2P to different peers overlaps.
+        # Members-only is required because nccl2 does not implement new_group's
+        # eager no-color-split path, so non-member ranks must short-circuit.
+        # Bind to this rank's cuda device so a lazily initialized comm never
+        # infers the wrong device (e.g. non-contiguous PP groups recving on the
+        # wrong device). The "ucc" backend keeps the eager path.
+        #
+        # A fake world PG (--fake-process-group) takes neither path: asking for
+        # a real "nccl-lazy" backend there would build an actual NCCL
+        # communicator and rendezvous over the FakeStore, which hangs. Inherit
+        # the parent's fake backend instead -- nothing communicates anyway.
+        #
+        # An *explicit* pipeline_model_parallel_comm_backend="nccl" is honored as
+        # stock "nccl" (plain ProcessGroupNCCL, no per-peer lazy wrapper). Only an
+        # explicit request takes this path: the default (None) still gets
+        # "nccl-lazy", so no existing configuration changes behaviour. The assert
+        # below has always accepted "nccl", but the branch used to ignore it and
+        # silently upgrade the group to "nccl-lazy". Note this is only
+        # constructible over a stock-nccl world: over an nccl2 world, new_group
+        # hands the parent's splittable backend to the child as split_from and
+        # _create_nccl_process_group rejects a non-ProcessGroupNCCL split source
+        # (torch distributed_c10d.py:699-708), members-only or not. The remaining
+        # kwargs match the nccl-lazy branch so the two differ only in the backend
+        # name (a single-variable wrapper-vs-engine A/B); over a device-bound
+        # world new_group would inherit bound_device_id anyway
+        # (distributed_c10d.py:6926-6928).
+        pp_ucc = pipeline_model_parallel_comm_backend == "ucc"
+        pp_stock_nccl = pipeline_model_parallel_comm_backend == "nccl"
+        pp_fake = is_fake_process_group()
+        if pp_ucc:
+            pp_group_kwargs = {"backend": "ucc"}
+        elif pp_fake:
+            pp_group_kwargs = {"backend": None, "use_local_synchronization": True}
+        elif pp_stock_nccl:
+            pp_group_kwargs = {
+                "backend": "nccl",
+                "use_local_synchronization": True,
+                "device_id": torch.device(f"cuda:{torch.cuda.current_device()}"),
+                "pg_options": get_nccl_options("pp", nccl_comm_cfgs),
+            }
+        else:
+            pp_group_kwargs = {
+                "backend": "nccl-lazy",
+                "use_local_synchronization": True,
+                "device_id": torch.device(f"cuda:{torch.cuda.current_device()}"),
+                "pg_options": get_nccl_options("pp", nccl_comm_cfgs),
+            }
         group = create_group(
-            ranks,
-            timeout=timeout,
-            backend=pipeline_model_parallel_comm_backend,
-            pg_options=(
-                None
-                if pipeline_model_parallel_comm_backend == "ucc"
-                else get_nccl_options("pp", nccl_comm_cfgs)
-            ),
-            group_desc="PIPELINE_MODEL_PARALLEL_GROUP",
+            ranks, timeout=timeout, group_desc="PIPELINE_MODEL_PARALLEL_GROUP", **pp_group_kwargs
         )
         assert (
             pipeline_model_parallel_comm_backend == None
@@ -1105,27 +1281,32 @@ def initialize_model_parallel(
                 _PIPELINE_MODEL_PARALLEL_GROUP = [_PIPELINE_MODEL_PARALLEL_GROUP, group]
                 _PIPELINE_GLOBAL_RANKS = [_PIPELINE_GLOBAL_RANKS, ranks]
 
-        embedding_ranks = get_embedding_ranks(ranks)
-        group = create_group(
-            embedding_ranks,
-            timeout=timeout,
-            pg_options=get_nccl_options("embd", nccl_comm_cfgs),
-            group_desc="EMBEDDING_GROUP",
-        )
-        if rank in embedding_ranks:
-            _EMBEDDING_GROUP = group
-            _EMBEDDING_GLOBAL_RANKS = embedding_ranks
+    # Embedding and position-embedding groups are cuda subsets of the world PG
+    # (the first/last rank of each PP group), so build them via split_group over
+    # their partition lists rather than per-PP-group new_group.
+    embedding_partition = [get_embedding_ranks(ranks) for ranks in pp_partitions]
+    group, my_embedding_ranks = create_partition_groups(
+        embedding_partition,
+        timeout=timeout,
+        pg_options=get_nccl_options("embd", nccl_comm_cfgs),
+        group_desc="EMBEDDING_GROUP",
+    )
+    if my_embedding_ranks is not None:
+        _EMBEDDING_GROUP = group
+        _EMBEDDING_GLOBAL_RANKS = my_embedding_ranks
 
-        position_embedding_ranks = get_position_embedding_ranks(ranks)
-        group = create_group(
-            position_embedding_ranks,
-            timeout=timeout,
-            pg_options=get_nccl_options("pos_embd", nccl_comm_cfgs),
-            group_desc="POSITION_EMBEDDING_GROUP",
-        )
-        if rank in position_embedding_ranks:
-            _POSITION_EMBEDDING_GROUP = group
-            _POSITION_EMBEDDING_GLOBAL_RANKS = position_embedding_ranks
+    position_embedding_partition = [
+        get_position_embedding_ranks(ranks) for ranks in pp_partitions
+    ]
+    group, my_position_embedding_ranks = create_partition_groups(
+        position_embedding_partition,
+        timeout=timeout,
+        pg_options=get_nccl_options("pos_embd", nccl_comm_cfgs),
+        group_desc="POSITION_EMBEDDING_GROUP",
+    )
+    if my_position_embedding_ranks is not None:
+        _POSITION_EMBEDDING_GROUP = group
+        _POSITION_EMBEDDING_GLOBAL_RANKS = my_position_embedding_ranks
 
     # Build the tensor + data parallel groups.
     global _TENSOR_AND_DATA_PARALLEL_GROUP
@@ -1133,98 +1314,91 @@ def initialize_model_parallel(
     assert (
         _TENSOR_AND_DATA_PARALLEL_GROUP is None
     ), 'Tensor + data parallel group is already initialized'
-    for ranks in decoder_rank_generator.get_ranks('tp-dp-cp'):
-        group = create_group(
-            ranks,
-            timeout=timeout,
-            pg_options=get_nccl_options("tp_dp_cp", nccl_comm_cfgs),
-            group_desc="TENSOR_AND_DATA_PARALLEL_GROUP_WITH_CP",
-        )
-        if rank in ranks:
-            _TENSOR_AND_DATA_PARALLEL_GROUP_WITH_CP = group
-    for ranks in decoder_rank_generator.get_ranks('tp-dp'):
-        group = create_group(
-            ranks,
-            timeout=timeout,
-            pg_options=get_nccl_options("tp_dp", nccl_comm_cfgs),
-            group_desc="TENSOR_AND_DATA_PARALLEL_GROUP",
-        )
-        if rank in ranks:
-            _TENSOR_AND_DATA_PARALLEL_GROUP = group
+    group, my_ranks = create_partition_groups(
+        decoder_rank_generator.get_ranks('tp-dp-cp'),
+        timeout=timeout,
+        pg_options=get_nccl_options("tp_dp_cp", nccl_comm_cfgs),
+        group_desc="TENSOR_AND_DATA_PARALLEL_GROUP_WITH_CP",
+    )
+    if my_ranks is not None:
+        _TENSOR_AND_DATA_PARALLEL_GROUP_WITH_CP = group
+    group, my_ranks = create_partition_groups(
+        decoder_rank_generator.get_ranks('tp-dp'),
+        timeout=timeout,
+        pg_options=get_nccl_options("tp_dp", nccl_comm_cfgs),
+        group_desc="TENSOR_AND_DATA_PARALLEL_GROUP",
+    )
+    if my_ranks is not None:
+        _TENSOR_AND_DATA_PARALLEL_GROUP = group
 
     global _TENSOR_AND_CONTEXT_PARALLEL_GROUP
     assert (
         _TENSOR_AND_CONTEXT_PARALLEL_GROUP is None
     ), 'Tensor + context parallel group is already initialized'
-    for ranks in decoder_rank_generator.get_ranks('tp-cp'):
-        group = create_group(
-            ranks,
-            timeout=timeout,
-            pg_options=get_nccl_options("tp_cp", nccl_comm_cfgs),
-            group_desc="TENSOR_AND_CONTEXT_PARALLEL_GROUP",
-        )
-        if rank in ranks:
-            _TENSOR_AND_CONTEXT_PARALLEL_GROUP = group
+    group, my_ranks = create_partition_groups(
+        decoder_rank_generator.get_ranks('tp-cp'),
+        timeout=timeout,
+        pg_options=get_nccl_options("tp_cp", nccl_comm_cfgs),
+        group_desc="TENSOR_AND_CONTEXT_PARALLEL_GROUP",
+    )
+    if my_ranks is not None:
+        _TENSOR_AND_CONTEXT_PARALLEL_GROUP = group
 
     ### Expert-related parallel groups initialization
     # Build the expert model parallel group
     global _EXPERT_MODEL_PARALLEL_GROUP, _EXPERT_MODEL_PARALLEL_RANKS
     assert _EXPERT_MODEL_PARALLEL_GROUP is None, 'Expert parallel group is already initialized'
-    for ranks in expert_decoder_rank_generator.get_ranks('ep'):
-        group = create_group(
-            ranks,
-            timeout=timeout,
-            pg_options=get_nccl_options("ep", nccl_comm_cfgs),
-            group_desc="EXPERT_MODEL_PARALLEL_GROUP",
-        )
-        if rank in ranks:
-            _EXPERT_MODEL_PARALLEL_GROUP = group
-            _EXPERT_MODEL_PARALLEL_RANKS = ranks
+    group, my_ranks = create_partition_groups(
+        expert_decoder_rank_generator.get_ranks('ep'),
+        timeout=timeout,
+        pg_options=get_nccl_options("ep", nccl_comm_cfgs),
+        group_desc="EXPERT_MODEL_PARALLEL_GROUP",
+    )
+    if my_ranks is not None:
+        _EXPERT_MODEL_PARALLEL_GROUP = group
+        _EXPERT_MODEL_PARALLEL_RANKS = my_ranks
 
     # Build the expert tensor parallel group
     global _EXPERT_TENSOR_PARALLEL_GROUP
     assert (
         _EXPERT_TENSOR_PARALLEL_GROUP is None
     ), 'Expert tensor model parallel group is already initialized'
-    for ranks in expert_decoder_rank_generator.get_ranks('tp'):
-        group = create_group(
-            ranks,
-            timeout=timeout,
-            pg_options=get_nccl_options("ep_tp", nccl_comm_cfgs),
-            group_desc="EXPERT_TENSOR_PARALLEL_GROUP",
-        )
-        if rank in ranks:
-            _EXPERT_TENSOR_PARALLEL_GROUP = group
+    group, my_ranks = create_partition_groups(
+        expert_decoder_rank_generator.get_ranks('tp'),
+        timeout=timeout,
+        pg_options=get_nccl_options("ep_tp", nccl_comm_cfgs),
+        group_desc="EXPERT_TENSOR_PARALLEL_GROUP",
+    )
+    if my_ranks is not None:
+        _EXPERT_TENSOR_PARALLEL_GROUP = group
 
     # Build the tensor + expert parallel groups
     global _EXPERT_TENSOR_AND_MODEL_PARALLEL_GROUP
     assert (
         _EXPERT_TENSOR_AND_MODEL_PARALLEL_GROUP is None
     ), 'Expert tensor + model parallel group is already initialized'
-    for ranks in expert_decoder_rank_generator.get_ranks('tp-ep'):
-        group = create_group(
-            ranks,
-            timeout=timeout,
-            pg_options=get_nccl_options("tp_ep_mp", nccl_comm_cfgs),
-            group_desc="EXPERT_TENSOR_AND_MODEL_PARALLEL_GROUP",
-        )
-        if rank in ranks:
-            _EXPERT_TENSOR_AND_MODEL_PARALLEL_GROUP = group
+    group, my_ranks = create_partition_groups(
+        expert_decoder_rank_generator.get_ranks('tp-ep'),
+        timeout=timeout,
+        pg_options=get_nccl_options("tp_ep_mp", nccl_comm_cfgs),
+        group_desc="EXPERT_TENSOR_AND_MODEL_PARALLEL_GROUP",
+    )
+    if my_ranks is not None:
+        _EXPERT_TENSOR_AND_MODEL_PARALLEL_GROUP = group
 
     # Build the expert+tensor+pipeline parallel groups
     global _EXPERT_TENSOR_MODEL_PIPELINE_PARALLEL_GROUP
     assert (
         _EXPERT_TENSOR_MODEL_PIPELINE_PARALLEL_GROUP is None
     ), 'The expert_tensor_model_pipeline parallel group is already initialized'
-    for ranks in expert_decoder_rank_generator.get_ranks('tp-ep-pp'):
-        group = create_group(
-            ranks,
-            timeout=timeout,
-            pg_options=get_nccl_options("tp_ep_pp", nccl_comm_cfgs),
-            group_desc="EXPERT_TENSOR_MODEL_PIPELINE_PARALLEL_GROUP",
-        )
-        if rank in ranks:
-            _EXPERT_TENSOR_MODEL_PIPELINE_PARALLEL_GROUP = group
+    group, my_ranks = create_partition_groups(
+        expert_decoder_rank_generator.get_ranks('tp-ep-pp'),
+        timeout=timeout,
+        pg_options=get_nccl_options("tp_ep_pp", nccl_comm_cfgs),
+        group_desc="EXPERT_TENSOR_MODEL_PIPELINE_PARALLEL_GROUP",
+    )
+    if my_ranks is not None:
+        _EXPERT_TENSOR_MODEL_PIPELINE_PARALLEL_GROUP = group
 
     # Build the expert data parallel group
     global _EXPERT_DATA_PARALLEL_GROUP
@@ -1251,30 +1425,34 @@ def initialize_model_parallel(
         expert_data_parallel_size // num_distributed_optimizer_instances
     )
 
-    for ranks in expert_decoder_rank_generator.get_ranks('dp'):
-        group = create_group(
-            ranks,
-            timeout=timeout,
-            pg_options=get_nccl_options("ep_dp", nccl_comm_cfgs),
-            group_desc="EXPERT_DATA_PARALLEL_GROUP",
+    group, my_ranks = create_partition_groups(
+        expert_decoder_rank_generator.get_ranks('dp'),
+        timeout=timeout,
+        pg_options=get_nccl_options("ep_dp", nccl_comm_cfgs),
+        group_desc="EXPERT_DATA_PARALLEL_GROUP",
+    )
+    if create_gloo_process_groups:
+        group_gloo, _ = create_partition_groups(
+            expert_decoder_rank_generator.get_ranks('dp'),
+            backend="gloo",
+            group_desc="EXPERT_DATA_PARALLEL_GROUP_GLOO",
         )
-        if create_gloo_process_groups:
-            group_gloo = create_group(
-                ranks, backend="gloo", group_desc="EXPERT_DATA_PARALLEL_GROUP_GLOO"
-            )
-        else:
-            group_gloo = None
-        if rank in ranks:
-            _EXPERT_DATA_PARALLEL_GROUP = group
-            _EXPERT_DATA_PARALLEL_GROUP_GLOO = group_gloo
+    else:
+        group_gloo = None
+    if my_ranks is not None:
+        _EXPERT_DATA_PARALLEL_GROUP = group
+        _EXPERT_DATA_PARALLEL_GROUP_GLOO = group_gloo
 
-        if num_distributed_optimizer_instances > 1:
-            # Create groups for Partial DistOpt, one for intra-partial DP domain
-            # Another for inter-partial DP domain
+    if num_distributed_optimizer_instances > 1:
+        # Create groups for Partial DistOpt, one for intra-partial DP domain
+        # Another for inter-partial DP domain. These hierarchical groups are
+        # built per ep-dp group; every rank must enter create_hierarchical_groups
+        # for each, so keep the loop.
 
-            # Set NCCL_COLLNET_ENABLE to 1 to enable SHARP for the dp_replica group.
-            if sharp_enabled_group == "dp_replica":
-                os.environ["NCCL_COLLNET_ENABLE"] = "1"
+        # Set NCCL_COLLNET_ENABLE to 1 to enable SHARP for the dp_replica group.
+        if sharp_enabled_group == "dp_replica":
+            os.environ["NCCL_COLLNET_ENABLE"] = "1"
+        for ranks in expert_decoder_rank_generator.get_ranks('dp'):
             hierarchical_groups, hierarchical_groups_gloo = create_hierarchical_groups(
                 rank,
                 ranks,
@@ -1292,21 +1470,21 @@ def initialize_model_parallel(
                 _INTRA_PARTIAL_EXPERT_DATA_PARALLEL_GROUP_GLOO = hierarchical_groups_gloo[0]
                 _INTER_PARTIAL_EXPERT_DATA_PARALLEL_GROUP = hierarchical_groups[1]
 
-            if sharp_enabled_group == "dp_replica":
-                # PyTorch is performing lazy initialization of the communicator group.
-                # Therefore, we need to perform a nccl call to ensure that the communicator group is created.
-                if _INTER_PARTIAL_EXPERT_DATA_PARALLEL_GROUP is not None:
-                    torch.distributed.barrier(
-                        group=_INTER_PARTIAL_EXPERT_DATA_PARALLEL_GROUP,
-                        device_ids=[torch.cuda.current_device()],
-                    )
-                    torch.cuda.synchronize()
-                # Set NCCL_COLLNET_ENABLE to 0 to restrict SHARP application to the dp_replica group.
-                if "NCCL_COLLNET_ENABLE" in os.environ:
-                    del os.environ["NCCL_COLLNET_ENABLE"]
-        else:
-            _INTRA_PARTIAL_EXPERT_DATA_PARALLEL_GROUP = _EXPERT_DATA_PARALLEL_GROUP
-            _INTRA_PARTIAL_EXPERT_DATA_PARALLEL_GROUP_GLOO = _EXPERT_DATA_PARALLEL_GROUP_GLOO
+        if sharp_enabled_group == "dp_replica":
+            # PyTorch is performing lazy initialization of the communicator group.
+            # Therefore, we need to perform a nccl call to ensure that the communicator group is created.
+            if _INTER_PARTIAL_EXPERT_DATA_PARALLEL_GROUP is not None:
+                torch.distributed.barrier(
+                    group=_INTER_PARTIAL_EXPERT_DATA_PARALLEL_GROUP,
+                    device_ids=[torch.cuda.current_device()],
+                )
+                torch.cuda.synchronize()
+            # Set NCCL_COLLNET_ENABLE to 0 to restrict SHARP application to the dp_replica group.
+            if "NCCL_COLLNET_ENABLE" in os.environ:
+                del os.environ["NCCL_COLLNET_ENABLE"]
+    else:
+        _INTRA_PARTIAL_EXPERT_DATA_PARALLEL_GROUP = _EXPERT_DATA_PARALLEL_GROUP
+        _INTRA_PARTIAL_EXPERT_DATA_PARALLEL_GROUP_GLOO = _EXPERT_DATA_PARALLEL_GROUP_GLOO
     ### End of expert related parallel groups initialization
 
     # build the intra distributed optimizer instance group
@@ -1315,21 +1493,26 @@ def initialize_model_parallel(
         _INTRA_DISTRIBUTED_OPTIMIZER_INSTANCE_GROUP is None
     ), "Intra distributed optimizer instance group is already initialized"
 
+    # Each intra distributed-optimizer instance group is the union of a run of
+    # tp-ep-pp groups; across the world these partition it, so build them with a
+    # single split_group collective.
+    intra_dist_opt_partition = []
     model_parallel_group_id = 0
     intra_dist_opt_ranks = []
     for ranks in expert_decoder_rank_generator.get_ranks('tp-ep-pp'):
         model_parallel_group_id += 1
         intra_dist_opt_ranks.extend(ranks)
         if model_parallel_group_id % intra_partial_expert_data_parallel_size == 0:
-            intra_dist_opt_instance_group = create_group(
-                intra_dist_opt_ranks,
-                timeout=timeout,
-                pg_options=get_nccl_options("intra_dist_opt_instance", nccl_comm_cfgs),
-                group_desc="INTRA_DISTRIBUTED_OPTIMIZER_INSTANCE_GROUP",
-            )
-            if rank in intra_dist_opt_ranks:
-                _INTRA_DISTRIBUTED_OPTIMIZER_INSTANCE_GROUP = intra_dist_opt_instance_group
+            intra_dist_opt_partition.append(list(intra_dist_opt_ranks))
             intra_dist_opt_ranks = []
+    group, my_ranks = create_partition_groups(
+        intra_dist_opt_partition,
+        timeout=timeout,
+        pg_options=get_nccl_options("intra_dist_opt_instance", nccl_comm_cfgs),
+        group_desc="INTRA_DISTRIBUTED_OPTIMIZER_INSTANCE_GROUP",
+    )
+    if my_ranks is not None:
+        _INTRA_DISTRIBUTED_OPTIMIZER_INSTANCE_GROUP = group
 
     # Initialize global memory buffer
     # This isn't really "parallel state" but there isn't another good place to
@@ -1384,15 +1567,14 @@ def create_all_gather_groups(for_expert_parallelism=False, timeout=None, nccl_co
         tp=tp_size, ep=1, dp=dp_size, pp=pp_size, cp=cp_size, order='tp-cp-ep-dp-pp', rank_offset=0
     )
 
-    for ranks_with_cp in decoder_rank_gen.get_ranks('dp-cp'):
-        group_with_cp_ag = create_group(
-            ranks_with_cp,
-            timeout=timeout,
-            pg_options=get_nccl_options('dp_cp', nccl_comm_cfgs or {}),
-            group_desc='DATA_PARALLEL_GROUP_WITH_CP_AG',
-        )
-        if rank in ranks_with_cp:
-            dp_cp_ag_group = group_with_cp_ag
+    group_with_cp_ag, my_ranks_with_cp = create_partition_groups(
+        decoder_rank_gen.get_ranks('dp-cp'),
+        timeout=timeout,
+        pg_options=get_nccl_options('dp_cp', nccl_comm_cfgs or {}),
+        group_desc='DATA_PARALLEL_GROUP_WITH_CP_AG',
+    )
+    if my_ranks_with_cp is not None:
+        dp_cp_ag_group = group_with_cp_ag
 
     # Create expert DP all-gather group if requested
     expt_dp_ag_group = None
@@ -1410,15 +1592,14 @@ def create_all_gather_groups(for_expert_parallelism=False, timeout=None, nccl_co
             rank_offset=0,
         )
 
-        for expert_dp_ranks in expert_rank_gen.get_ranks('dp'):
-            expert_dp_ag = create_group(
-                expert_dp_ranks,
-                timeout=timeout,
-                pg_options=get_nccl_options("ep_dp", nccl_comm_cfgs or {}),
-                group_desc='EXPERT_DATA_PARALLEL_GROUP_AG',
-            )
-            if rank in expert_dp_ranks:
-                expt_dp_ag_group = expert_dp_ag
+        expert_dp_ag, my_expert_dp_ranks = create_partition_groups(
+            expert_rank_gen.get_ranks('dp'),
+            timeout=timeout,
+            pg_options=get_nccl_options("ep_dp", nccl_comm_cfgs or {}),
+            group_desc='EXPERT_DATA_PARALLEL_GROUP_AG',
+        )
+        if my_expert_dp_ranks is not None:
+            expt_dp_ag_group = expert_dp_ag
 
     return dp_cp_ag_group, expt_dp_ag_group
 

--- a/megatron/core/pipeline_parallel/bridge_communicator.py
+++ b/megatron/core/pipeline_parallel/bridge_communicator.py
@@ -9,6 +9,7 @@ import torch
 import torch.distributed as dist
 
 from megatron.core.hyper_comm_grid import HyperCommGrid
+from megatron.core.parallel_state import create_group, create_split_groups
 
 
 class CommRole(Enum):
@@ -63,7 +64,9 @@ class BridgeCommunicator:
     def destroy_bridge_pgs(cls):
         """Destroy all cached bridge process groups."""
         for pg in cls._bridge_pg_cache.values():
-            if pg is not None:
+            # ``new_group`` hands non-member ranks the NON_GROUP_MEMBER sentinel,
+            # which is not None and must not be passed to destroy_process_group.
+            if pg is not None and pg is not dist.GroupMember.NON_GROUP_MEMBER:
                 dist.destroy_process_group(pg)
         cls._bridge_pg_cache.clear()
 
@@ -196,7 +199,13 @@ class BridgeCommunicator:
         """Get or create a broadcast PG, caching to avoid duplicate NCCL communicators."""
         cache_key = str(sorted([tuple(r) for r in ranks_list]))
         if cache_key not in cls._broadcast_pg_cache:
-            pg, _ = dist.new_subgroups_by_enumeration(ranks_list, backend='nccl')
+            # Collective (broadcast) subgroups -> one ``split_group`` over the
+            # world PG, inheriting the world's cuda backend rather than pinning
+            # stock "nccl" (which would sit a stock-NCCL child under an nccl2
+            # world). ``new_subgroups_by_enumeration`` cannot be used: it drives
+            # non-member ranks through ``performNocolorSplit``, unimplemented in
+            # the nccl2 backend.
+            pg = create_split_groups(ranks_list)
             cls._broadcast_pg_cache[cache_key] = pg
         return cls._broadcast_pg_cache[cache_key]
 
@@ -206,7 +215,22 @@ class BridgeCommunicator:
         ranks = sorted(ranks)
         cache_key = str(ranks)
         if cache_key not in cls._bridge_pg_cache:
-            cls._bridge_pg_cache[cache_key] = dist.new_group(ranks, backend='nccl')
+            # The bridge PG carries only point-to-point traffic (send / recv /
+            # isend / irecv between src and dest grid leaders), so it uses the
+            # lazy per-peer backend, members-only. Members-only is required on
+            # an nccl2 world because non-member ranks must not take new_group's
+            # eager no-color-split path.
+            cls._bridge_pg_cache[cache_key] = create_group(
+                ranks,
+                backend="nccl-lazy",
+                use_local_synchronization=True,
+                device_id=(
+                    torch.device(f"cuda:{torch.cuda.current_device()}")
+                    if torch.cuda.is_available()
+                    else None
+                ),
+                group_desc="BRIDGE_P2P_GROUP",
+            )
         return cls._bridge_pg_cache[cache_key]
 
     def get_leader_rank(self, grid: HyperCommGrid, is_src: bool) -> List[int]:

--- a/megatron/core/process_groups_config.py
+++ b/megatron/core/process_groups_config.py
@@ -538,8 +538,9 @@ class ProcessGroupCollection:
                     "No expert data parallel group provided in pg_collection, "
                     "creating a new one with just the current rank",
                 )
-                result['expt_dp_group'] = torch.distributed.new_group(
-                    ranks=[torch.distributed.get_rank()]
+                result['expt_dp_group'] = parallel_state.create_group(
+                    ranks=[torch.distributed.get_rank()],
+                    group_desc='EXPT_DP_GROUP_SINGLETON',
                 )
 
             # 4. Handle intra groups based on optimizer instances

--- a/megatron/core/resharding/copy_services/gloo_copy_service.py
+++ b/megatron/core/resharding/copy_services/gloo_copy_service.py
@@ -7,6 +7,8 @@ from typing import List, Optional, Tuple
 import torch
 import torch.distributed as dist
 
+from megatron.core.parallel_state import create_split_groups
+
 from .base import CopyService, RecvOp, SendOp, match_local_ops_by_task_id
 
 logger = logging.getLogger(__name__)
@@ -23,7 +25,20 @@ class GlooCopyService(CopyService):
         if group is not None:
             self.gloo_pg = group
         else:
-            self.gloo_pg = dist.new_group(backend="gloo")
+            # A dedicated world-sized group so refit traffic does not interleave
+            # with the default PG. Built with ``split_group`` rather than
+            # ``new_group`` so it works uniformly under an ``nccl2`` world.
+            # ``backend="gloo"`` selects the parent's cpu/gloo backend; the
+            # split filter must also retain the parent's default (cuda) device,
+            # so the resulting group is a compound ``cpu:gloo,cuda:<world cuda>``
+            # group. That is fine here: this PG only ever carries CPU tensors
+            # (``isend``/``irecv`` on pinned CPU buffers), which dispatch to the
+            # gloo backend, and it is never handed to a GLOO-only API.
+            self.gloo_pg = create_split_groups(
+                [list(range(dist.get_world_size()))],
+                backend="gloo",
+                group_desc="REFIT_GLOO_GROUP",
+            )
         self.send_ops: List[SendOp] = []
         # Each recv op is paired with its GPU destination tensor; the SendOp/RecvOp
         # itself carries a pinned-CPU staging buffer for Gloo's CPU PG.

--- a/megatron/rl/parallel_utils.py
+++ b/megatron/rl/parallel_utils.py
@@ -6,10 +6,9 @@ Utilities for building process groups for RL inference models with custom parall
 
 from typing import Optional
 
-import torch.distributed as dist
-
 from megatron.core import mpu
 from megatron.core.hyper_comm_grid import HyperCommGrid
+from megatron.core.parallel_state import create_split_groups
 from megatron.core.process_groups_config import ProcessGroupCollection
 
 
@@ -70,8 +69,6 @@ def build_inference_pg_collection(
     assert expt_dp_size >= 1 and (expt_tp_size * ep_size * expt_dp_size * pp_size) == world_size, (
         f"World size ({world_size}) must be divisible by expt_tp*ep*pp ({expt_tp_size * ep_size * pp_size})"
     )
-
-    rank = dist.get_rank()
 
     # ====================
     # Create decoder grid for dense/attention layers
@@ -139,25 +136,22 @@ def build_inference_pg_collection(
     # ====================
     # Embedding groups (derived from PP groups)
     # ====================
-    embd_group = None
-    pos_embd_group = None
-
     pp_rank_enum = decoder_grid.get_rank_enum("pp")
-    for pp_ranks in pp_rank_enum:
-        # Embedding is on first and last PP stage
-        if len(pp_ranks) == 1:
-            embd_ranks = [pp_ranks[0]]
-        else:
-            embd_ranks = [pp_ranks[0], pp_ranks[-1]]
-        group = dist.new_group(ranks=embd_ranks)
-        if rank in embd_ranks:
-            embd_group = group
+    # Embedding is on the first and last PP stage; position embedding only on the
+    # first. Collect the full partitions first and build each family with a
+    # single ``split_group`` collective (mirrors ``parallel_state``): a per-PP-group
+    # eager ``new_group`` would drive non-member ranks through
+    # ``performNocolorSplit``, which the ``nccl2`` backend does not implement.
+    embedding_partition = [
+        [pp_ranks[0]] if len(pp_ranks) == 1 else [pp_ranks[0], pp_ranks[-1]]
+        for pp_ranks in pp_rank_enum
+    ]
+    position_embedding_partition = [[pp_ranks[0]] for pp_ranks in pp_rank_enum]
 
-        # Position embedding is only on first PP stage
-        pos_embd_ranks = [pp_ranks[0]]
-        group = dist.new_group(ranks=pos_embd_ranks)
-        if rank in pos_embd_ranks:
-            pos_embd_group = group
+    embd_group = create_split_groups(embedding_partition, group_desc="EMBEDDING_GROUP")
+    pos_embd_group = create_split_groups(
+        position_embedding_partition, group_desc="POSITION_EMBEDDING_GROUP"
+    )
 
     return ProcessGroupCollection(
         tp=tp_group,

--- a/megatron/training/config/common_config.py
+++ b/megatron/training/config/common_config.py
@@ -71,7 +71,7 @@ class ProfilingConfig:
 class DistributedInitConfig:
     """Configuration settings for distributed training initialization."""
 
-    distributed_backend: Literal["nccl", "gloo"] = "nccl"
+    distributed_backend: Literal["nccl2", "nccl", "gloo"] = "nccl2"
     """Which backend to use for distributed training."""
 
     distributed_timeout_minutes: int = 10

--- a/megatron/training/dist_signal_handler.py
+++ b/megatron/training/dist_signal_handler.py
@@ -11,18 +11,61 @@ def get_world_size():
     return world_size
 
 
-def get_device(local_rank=None):
-    backend = torch.distributed.get_backend()
-    if backend == 'nccl':
+def _get_device_backend_name(device_type, group=None):
+    """Name of the c10d backend registered for ``device_type``, or None if there is none.
+
+    ``torch.distributed.get_backend()`` returns the configuration string the process
+    group was created with, which may be device-qualified and compound (for example
+    ``'cpu:gloo,cuda:nccl2'``), so it cannot be compared against a single backend name.
+    Resolving the per-device backend object works for every world layout.
+
+    Args:
+        device_type: Device type to look up, e.g. ``'cpu'`` or ``'cuda'``.
+        group: Process group to inspect. Defaults to the world group.
+
+    Returns:
+        The backend name (e.g. ``'gloo'``, ``'nccl'``, ``'nccl2'``), or None if no
+        backend is registered for ``device_type``.
+    """
+    if group is None:
+        group = torch.distributed.distributed_c10d._get_default_group()
+    try:
+        backend = group._get_backend(torch.device(device_type))
+    except (RuntimeError, ValueError):
+        # No backend is registered for this device type on this process group.
+        return None
+    name = getattr(backend, 'name', None)
+    return name() if callable(name) else name
+
+
+def get_device(local_rank=None, group=None):
+    """Device that collectives issued for signal handling should run on.
+
+    Args:
+        local_rank: Local rank used to qualify the CUDA device. If None, an
+            unqualified ``cuda`` device (the current device) is used.
+        group: Process group the collective will run on. Defaults to the world group.
+
+    Returns:
+        The ``torch.device`` matching the backend the process group uses.
+
+    Raises:
+        RuntimeError: If the process group has no backend for cpu or cuda.
+    """
+    cuda_backend = _get_device_backend_name('cuda', group)
+    # Gloo registers itself for cuda too, but its collectives are meant to run on cpu
+    # tensors, so only a genuine device backend (nccl, nccl2, ...) selects cuda.
+    if cuda_backend is not None and cuda_backend != 'gloo':
         if local_rank is None:
-            device = torch.device('cuda')
-        else:
-            device = torch.device(f'cuda:{local_rank}')
-    elif backend == 'gloo':
-        device = torch.device('cpu')
-    else:
-        raise RuntimeError
-    return device
+            return torch.device('cuda')
+        return torch.device(f'cuda:{local_rank}')
+    if _get_device_backend_name('cpu', group) is not None:
+        return torch.device('cpu')
+    raise RuntimeError(
+        "Cannot pick a device for distributed signal handling: process group with "
+        f"backend '{torch.distributed.get_backend(group)}' has neither a cpu nor a "
+        "cuda backend."
+    )
 
 
 def all_gather_item(item, dtype, group=None, async_op=False, local_rank=None):
@@ -30,7 +73,7 @@ def all_gather_item(item, dtype, group=None, async_op=False, local_rank=None):
        not torch.distributed.is_initialized():
         return [item]
 
-    device = get_device(local_rank)
+    device = get_device(local_rank, group)
 
     if group is not None:
         group_size = group.size()

--- a/megatron/training/gpu_sniff_test.py
+++ b/megatron/training/gpu_sniff_test.py
@@ -30,6 +30,8 @@ import numpy as np
 import torch
 import torch.distributed as dist
 
+from megatron.core.parallel_state import create_split_groups
+
 logger = logging.getLogger(__name__)
 
 
@@ -443,43 +445,31 @@ def run_gpu_sniff_test(tag="", pg_collection=None):
 def _create_ep_groups(ep_size):
     """Create EP-style groups: consecutive blocks of *ep_size* ranks."""
     world = dist.get_world_size()
-    rank = dist.get_rank()
     assert world % ep_size == 0, f"world_size ({world}) not divisible by ep_size ({ep_size})"
-    my_group = None
-    for start in range(0, world, ep_size):
-        ranks = list(range(start, start + ep_size))
-        g = dist.new_group(ranks)
-        if rank in ranks:
-            my_group = g
-    return my_group
+    return create_split_groups(
+        [list(range(start, start + ep_size)) for start in range(0, world, ep_size)],
+        group_desc="SNIFF_EP_GROUP",
+    )
 
 
 def _create_dp_groups(ep_size):
     """Create DP-style groups: ranks sharing the same offset within EP blocks."""
     world = dist.get_world_size()
-    rank = dist.get_rank()
     assert world % ep_size == 0
-    my_group = None
-    for offset in range(ep_size):
-        ranks = list(range(offset, world, ep_size))
-        g = dist.new_group(ranks)
-        if rank in ranks:
-            my_group = g
-    return my_group
+    return create_split_groups(
+        [list(range(offset, world, ep_size)) for offset in range(ep_size)],
+        group_desc="SNIFF_DP_GROUP",
+    )
 
 
 def _create_tp_groups(tp_size):
     """Create TP-style groups: consecutive blocks of *tp_size* ranks."""
     world = dist.get_world_size()
-    rank = dist.get_rank()
     assert world % tp_size == 0, f"world_size ({world}) not divisible by tp_size ({tp_size})"
-    my_group = None
-    for start in range(0, world, tp_size):
-        ranks = list(range(start, start + tp_size))
-        g = dist.new_group(ranks)
-        if rank in ranks:
-            my_group = g
-    return my_group
+    return create_split_groups(
+        [list(range(start, start + tp_size)) for start in range(0, world, tp_size)],
+        group_desc="SNIFF_TP_GROUP",
+    )
 
 
 def main():
@@ -503,12 +493,24 @@ def main():
     p.add_argument("--skip-reducescatter", action="store_true")
     p.add_argument("--skip-alltoall", action="store_true")
     p.add_argument("--skip-sendrecv", action="store_true")
+    p.add_argument(
+        "--distributed-backend", type=str, default="nccl2", choices=["nccl2", "nccl"],
+        help="CUDA backend for the sniff-test world PG. 'nccl' selects the stock "
+             "ProcessGroupNCCL baseline; 'nccl2' (default) selects the in-tree nccl2 backend.",
+    )
     args = p.parse_args()
 
     logging.basicConfig(level=logging.INFO, format="%(message)s", stream=sys.stdout)
-    dist.init_process_group(backend="nccl")
     local_rank = int(os.environ.get("LOCAL_RANK", 0))
     torch.cuda.set_device(local_rank)
+    # Device-qualified and eagerly device-bound, mirroring
+    # megatron/training/initialize.py: the subgroups below are built with
+    # ``split_group``, which requires a device-bound parent, and the cpu:gloo
+    # backend gives any CPU collective somewhere to land.
+    dist.init_process_group(
+        backend=f"cpu:gloo,cuda:{args.distributed_backend}",
+        device_id=torch.device(f"cuda:{local_rank}"),
+    )
 
     world_size = dist.get_world_size()
     rank = dist.get_rank()

--- a/megatron/training/initialize.py
+++ b/megatron/training/initialize.py
@@ -312,8 +312,16 @@ def _initialize_distributed(get_embedding_ranks, get_position_embedding_ranks, s
             )
 
         # Call the init process
+        world_backend = args.distributed_backend
+        if world_backend in ("nccl", "nccl2"):
+            # Give the world PG a cpu:gloo backend alongside the cuda backend so
+            # gloo subgroups can be built with split_group. nccl2 has no eager
+            # no-color-split, so every subgroup (cuda and gloo) is a split_group
+            # of the world PG, and gloo split requires a gloo backend on the
+            # parent to filter for.
+            world_backend = f"cpu:gloo,cuda:{world_backend}"
         init_process_group_kwargs = {
-            'backend': args.distributed_backend,
+            'backend': world_backend,
             'store': store,
             'world_size': args.world_size,
             'rank': args.rank,
@@ -328,6 +336,12 @@ def _initialize_distributed(get_embedding_ranks, get_position_embedding_ranks, s
             store = FakeStore()
             init_process_group_kwargs['backend'] = 'fake'
             init_process_group_kwargs['store'] = store
+        if device_id is not None:
+            # Bind the world PG (nccl2, or fake) to this rank's cuda device.
+            # split_group refuses to split a parent that has no bound_device_id,
+            # so the fake world PG must be device-bound too -- FakeProcessGroup
+            # never communicates, so the binding is only a recorded device.
+            init_process_group_kwargs['device_id'] = device_id
 
         torch.distributed.init_process_group(**init_process_group_kwargs)
         inprocess_restart.maybe_force_nccl_backend_init(device_id)

--- a/tests/functional_tests/test_cases/bert/bert_mcore_tp1_pp2/model_config.yaml
+++ b/tests/functional_tests/test_cases/bert/bert_mcore_tp1_pp2/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --data-path: ${DATA_PATH}/text/common_pile/v01_filtered_data/my-bert_00_text_sentence
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/vocab.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.0001
   --min-lr: 0.00001
   --lr-warmup-fraction: 0.01

--- a/tests/functional_tests/test_cases/bert/bert_mcore_tp1_pp4_vp2/model_config.yaml
+++ b/tests/functional_tests/test_cases/bert/bert_mcore_tp1_pp4_vp2/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --data-path: ${DATA_PATH}/text/common_pile/v01_filtered_data/my-bert_00_text_sentence
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/vocab.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.0001
   --min-lr: 0.00001
   --lr-warmup-fraction: 0.01

--- a/tests/functional_tests/test_cases/bert/bert_mcore_tp2_pp2/model_config.yaml
+++ b/tests/functional_tests/test_cases/bert/bert_mcore_tp2_pp2/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --data-path: ${DATA_PATH}/text/common_pile/v01_filtered_data/my-bert_00_text_sentence
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/vocab.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.0001
   --min-lr: 0.00001
   --lr-warmup-fraction: 0.01

--- a/tests/functional_tests/test_cases/bert/bert_mcore_tp2_pp2_frozen_resume_torch_dist/model_config.yaml
+++ b/tests/functional_tests/test_cases/bert/bert_mcore_tp2_pp2_frozen_resume_torch_dist/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --data-path: ${DATA_PATH}/text/common_pile/v01_filtered_data/my-bert_00_text_sentence
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/vocab.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.0001
   --min-lr: 0.00001
   --lr-warmup-fraction: 0.01

--- a/tests/functional_tests/test_cases/bert/bert_mcore_tp2_pp2_local_spec/model_config.yaml
+++ b/tests/functional_tests/test_cases/bert/bert_mcore_tp2_pp2_local_spec/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --data-path: ${DATA_PATH}/text/common_pile/v01_filtered_data/my-bert_00_text_sentence
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/vocab.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.0001
   --min-lr: 0.00001
   --lr-warmup-fraction: 0.01

--- a/tests/functional_tests/test_cases/bert/bert_mcore_tp2_pp2_resume_torch_dist/model_config.yaml
+++ b/tests/functional_tests/test_cases/bert/bert_mcore_tp2_pp2_resume_torch_dist/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --data-path: ${DATA_PATH}/text/common_pile/v01_filtered_data/my-bert_00_text_sentence
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/vocab.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.0001
   --min-lr: 0.00001
   --lr-warmup-fraction: 0.01

--- a/tests/functional_tests/test_cases/bert/bert_mcore_tp2_pp2_resume_torch_dist_local_spec/model_config.yaml
+++ b/tests/functional_tests/test_cases/bert/bert_mcore_tp2_pp2_resume_torch_dist_local_spec/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --data-path: ${DATA_PATH}/text/common_pile/v01_filtered_data/my-bert_00_text_sentence
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/vocab.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.0001
   --min-lr: 0.00001
   --lr-warmup-fraction: 0.01

--- a/tests/functional_tests/test_cases/bert/bert_mcore_tp4_pp1/model_config.yaml
+++ b/tests/functional_tests/test_cases/bert/bert_mcore_tp4_pp1/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --data-path: ${DATA_PATH}/text/common_pile/v01_filtered_data/my-bert_00_text_sentence
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/vocab.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.0001
   --min-lr: 0.00001
   --lr-warmup-fraction: 0.01

--- a/tests/functional_tests/test_cases/gpt/gpt3_7b_tp1_pp4_memory_speed/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_7b_tp1_pp4_memory_speed/model_config.yaml
@@ -31,7 +31,7 @@ MODEL_ARGS:
   --vocab-size: 131073
   --mock-data: true
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_7b_tp4_pp1_memory_speed/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_7b_tp4_pp1_memory_speed/model_config.yaml
@@ -31,7 +31,7 @@ MODEL_ARGS:
   --vocab-size: 131073
   --mock-data: true
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_reruns_disable/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_reruns_disable/model_config.yaml
@@ -12,7 +12,7 @@ MODEL_ARGS:
   --eval-iters: 0
   --manual-gc: true
   --use-mcore-models: true
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   # parallelism settings
   --sequence-parallel: true
   --tensor-model-parallel-size: 1

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_reruns_enable/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_reruns_enable/model_config.yaml
@@ -12,7 +12,7 @@ MODEL_ARGS:
   --eval-iters: 0
   --manual-gc: true
   --use-mcore-models: true
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   # parallelism settings
   --sequence-parallel: true
   --tensor-model-parallel-size: 1

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_reruns_persistent_1/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_reruns_persistent_1/model_config.yaml
@@ -12,7 +12,7 @@ MODEL_ARGS:
   --eval-iters: 0
   --manual-gc: true
   --use-mcore-models: true
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   # parallelism settings
   --sequence-parallel: true
   --tensor-model-parallel-size: 1

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_reruns_persistent_1_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_reruns_persistent_1_1node/model_config.yaml
@@ -12,7 +12,7 @@ MODEL_ARGS:
   --eval-iters: 0
   --manual-gc: true
   --use-mcore-models: true
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   # parallelism settings
   --sequence-parallel: true
   --tensor-model-parallel-size: 1

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_reruns_persistent_2/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_reruns_persistent_2/model_config.yaml
@@ -12,7 +12,7 @@ MODEL_ARGS:
   --eval-iters: 0
   --manual-gc: true
   --use-mcore-models: true
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   # parallelism settings
   --sequence-parallel: true
   --tensor-model-parallel-size: 1

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_reruns_reshard/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_reruns_reshard/model_config.yaml
@@ -12,7 +12,7 @@ MODEL_ARGS:
   --eval-iters: 0
   --manual-gc: true
   --use-mcore-models: true
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   # parallelism settings
   --sequence-parallel: true
   --tensor-model-parallel-size: 2

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_reruns_resume/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_reruns_resume/model_config.yaml
@@ -12,7 +12,7 @@ MODEL_ARGS:
   --eval-iters: 0
   --manual-gc: true
   --use-mcore-models: true
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   # parallelism settings
   --sequence-parallel: true
   --tensor-model-parallel-size: 1

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_reruns_resume_check_grads/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_reruns_resume_check_grads/model_config.yaml
@@ -43,7 +43,7 @@ BASE_MODEL_ARGS: &BASE_MODEL_ARGS
   --eval-iters: 0
   --manual-gc: true
   --use-mcore-models: true
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   # parallelism settings
   --sequence-parallel: true
   # embedding settings

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_reruns_transient/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_reruns_transient/model_config.yaml
@@ -12,7 +12,7 @@ MODEL_ARGS:
   --eval-iters: 0
   --manual-gc: true
   --use-mcore-models: true
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   # parallelism settings
   --sequence-parallel: true
   --tensor-model-parallel-size: 1

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp1_dist_optimizer_fim_dataset/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp1_dist_optimizer_fim_dataset/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp1_dist_optimizer_fim_dataset_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp1_dist_optimizer_fim_dataset_1node/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp1_dist_optimizer_no_mmap_bin_files/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp1_dist_optimizer_no_mmap_bin_files/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp1_dist_optimizer_no_mmap_bin_files_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp1_dist_optimizer_no_mmap_bin_files_1node/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp1_frozen_resume_torch_dist_dist_optimizer/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp1_frozen_resume_torch_dist_dist_optimizer/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp1_mup/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp1_mup/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp1_resume_torch_dist_dist_optimizer/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp1_resume_torch_dist_dist_optimizer/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp1_resume_torch_dist_dist_optimizer_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp1_resume_torch_dist_dist_optimizer_1node/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp1_resume_torch_dist_dist_optimizer_no_mmap_bin_files/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp1_resume_torch_dist_dist_optimizer_no_mmap_bin_files/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp1_resume_torch_dist_uniform_full_recompute/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp1_resume_torch_dist_uniform_full_recompute/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp1_resume_torch_dist_uniform_full_recompute_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp1_resume_torch_dist_uniform_full_recompute_1node/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp1_uniform_full_recompute/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp1_uniform_full_recompute/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp2_cp4_a2a_p2p_nondeterministic/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp2_cp4_a2a_p2p_nondeterministic/model_config.yaml
@@ -23,7 +23,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp2_resume_torch_dist_cp4_a2a_p2p_nondeterministic/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp2_resume_torch_dist_cp4_a2a_p2p_nondeterministic/model_config.yaml
@@ -23,7 +23,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp2_resume_torch_dist_rope_embeddings/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp2_resume_torch_dist_rope_embeddings/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp2_resume_torch_dist_rope_embeddings_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp2_resume_torch_dist_rope_embeddings_1node/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp2_resume_torch_dist_rope_embeddings_interleaved_no_fusion/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp2_resume_torch_dist_rope_embeddings_interleaved_no_fusion/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp2_resume_torch_dist_rope_embeddings_interleaved_no_fusion_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp2_resume_torch_dist_rope_embeddings_interleaved_no_fusion_1node/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp2_rope_embeddings/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp2_rope_embeddings/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp2_rope_embeddings_interleaved_no_fusion/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp2_rope_embeddings_interleaved_no_fusion/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_disable_bias_linear/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_disable_bias_linear/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_frozen_resume_torch_dist_swiglu/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_frozen_resume_torch_dist_swiglu/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_persistent_ckpt_disable_bias_linear/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_persistent_ckpt_disable_bias_linear/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_resume_torch_dist_disable_bias_linear/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_resume_torch_dist_disable_bias_linear/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_resume_torch_dist_disable_bias_linear_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_resume_torch_dist_disable_bias_linear_1node/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_resume_torch_dist_persistent_disable_bias_linear/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_resume_torch_dist_persistent_disable_bias_linear/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_resume_torch_dist_persistent_disable_bias_linear_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_resume_torch_dist_persistent_disable_bias_linear_1node/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_resume_torch_dist_sequence_parallel/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_resume_torch_dist_sequence_parallel/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_resume_torch_dist_swiglu/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_resume_torch_dist_swiglu/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_resume_torch_dist_swiglu_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_resume_torch_dist_swiglu_1node/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_resume_torch_dist_untie_embeddings_and_outputs/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_resume_torch_dist_untie_embeddings_and_outputs/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_resume_torch_dist_untie_embeddings_and_outputs_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_resume_torch_dist_untie_embeddings_and_outputs_1node/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_sequence_parallel/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_sequence_parallel/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_swiglu/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_swiglu/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_untie_embeddings_and_outputs/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_untie_embeddings_and_outputs/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1/model_config.yaml
@@ -26,7 +26,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_1node/model_config.yaml
@@ -26,7 +26,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_calculate_per_token_loss/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_calculate_per_token_loss/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_decoupled_lr/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_decoupled_lr/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_dist_optimizer_overlap_grad_reduce/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_dist_optimizer_overlap_grad_reduce/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_dist_optimizer_overlap_grad_reduce_param_gather/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_dist_optimizer_overlap_grad_reduce_param_gather/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_dist_optimizer_overlap_grad_reduce_param_gather_overlap_optimizer/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_dist_optimizer_overlap_grad_reduce_param_gather_overlap_optimizer/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_dist_optimizer_overlap_grad_reduce_param_gather_overlap_optimizer_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_dist_optimizer_overlap_grad_reduce_param_gather_overlap_optimizer_1node/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_dist_optimizer_overlap_grad_reduce_untied/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_dist_optimizer_overlap_grad_reduce_untied/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_resume_torch_decoupled_lr/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_resume_torch_decoupled_lr/model_config.yaml
@@ -26,7 +26,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_resume_torch_decoupled_lr_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_resume_torch_decoupled_lr_1node/model_config.yaml
@@ -26,7 +26,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_resume_torch_dist/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_resume_torch_dist/model_config.yaml
@@ -26,7 +26,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_resume_torch_dist_calculate_per_token_loss/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_resume_torch_dist_calculate_per_token_loss/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_resume_torch_dist_calculate_per_token_loss_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_resume_torch_dist_calculate_per_token_loss_1node/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_resume_torch_dist_dist_optimizer_overlap_grad_reduce/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_resume_torch_dist_dist_optimizer_overlap_grad_reduce/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_resume_torch_dist_dist_optimizer_overlap_grad_reduce_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_resume_torch_dist_dist_optimizer_overlap_grad_reduce_1node/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_resume_torch_dist_dist_optimizer_overlap_grad_reduce_param_gather/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_resume_torch_dist_dist_optimizer_overlap_grad_reduce_param_gather/model_config.yaml
@@ -26,7 +26,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_resume_torch_dist_dist_optimizer_overlap_grad_reduce_untied/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_resume_torch_dist_dist_optimizer_overlap_grad_reduce_untied/model_config.yaml
@@ -26,7 +26,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_resume_torch_dist_tunable_overlap/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_resume_torch_dist_tunable_overlap/model_config.yaml
@@ -26,7 +26,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_tunable_overlap/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_tunable_overlap/model_config.yaml
@@ -26,7 +26,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_tunable_overlap_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_tunable_overlap_1node/model_config.yaml
@@ -26,7 +26,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_uneven_pipeline/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_uneven_pipeline/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_uneven_pipeline_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp1_uneven_pipeline_1node/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp2_account_for_embedding_loss_in_pipeline_split/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp2_account_for_embedding_loss_in_pipeline_split/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp2_account_for_embedding_loss_in_pipeline_split_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp1_pp4_vp2_account_for_embedding_loss_in_pipeline_split_1node/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp1_cp2_nondeterministic/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp1_cp2_nondeterministic/model_config.yaml
@@ -23,7 +23,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp1_frozen_resume_torch_dist_cp2_nondeterministic/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp1_frozen_resume_torch_dist_cp2_nondeterministic/model_config.yaml
@@ -23,7 +23,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp1_fsdp2_resume_torch_dist/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp1_fsdp2_resume_torch_dist/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp1_gdn/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp1_gdn/model_config.yaml
@@ -54,7 +54,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp1_gdn_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp1_gdn_1node/model_config.yaml
@@ -54,7 +54,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp1_gdn_no_nvrx_async/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp1_gdn_no_nvrx_async/model_config.yaml
@@ -57,7 +57,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp1_gdn_no_nvrx_async_mcore/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp1_gdn_no_nvrx_async_mcore/model_config.yaml
@@ -57,7 +57,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp1_gdn_no_nvrx_sync/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp1_gdn_no_nvrx_sync/model_config.yaml
@@ -57,7 +57,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp1_modelopt_distill_resume/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp1_modelopt_distill_resume/model_config.yaml
@@ -41,7 +41,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp1_modelopt_distill_resume_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp1_modelopt_distill_resume_1node/model_config.yaml
@@ -41,7 +41,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp1_multi_dist_optimizer_instances/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp1_multi_dist_optimizer_instances/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp1_resume_torch_dist_cp2_nondeterministic/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp1_resume_torch_dist_cp2_nondeterministic/model_config.yaml
@@ -23,7 +23,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp1_resume_torch_dist_cp2_nondeterministic_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp1_resume_torch_dist_cp2_nondeterministic_1node/model_config.yaml
@@ -23,7 +23,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp1_resume_torch_dist_multi_dist_optimizer_instances/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp1_resume_torch_dist_multi_dist_optimizer_instances/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp1_resume_torch_dist_multi_dist_optimizer_instances_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp1_resume_torch_dist_multi_dist_optimizer_instances_1node/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_cp2/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_cp2/model_config.yaml
@@ -23,7 +23,7 @@ MODEL_ARGS:
   --tokenizer-type: NullTokenizer
   --vocab-size: 50257
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_cp2_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_cp2_1node/model_config.yaml
@@ -23,7 +23,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_cp2_calculate_per_token_loss/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_cp2_calculate_per_token_loss/model_config.yaml
@@ -23,7 +23,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_cp2_calculate_per_token_loss_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_cp2_calculate_per_token_loss_1node/model_config.yaml
@@ -23,7 +23,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_cp2_calculate_per_token_loss_nondeterministic/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_cp2_calculate_per_token_loss_nondeterministic/model_config.yaml
@@ -23,7 +23,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_cp2_calculate_per_token_loss_nondeterministic_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_cp2_calculate_per_token_loss_nondeterministic_1node/model_config.yaml
@@ -23,7 +23,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_cp2_etp4_calculate_per_token_loss_dp_last/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_cp2_etp4_calculate_per_token_loss_dp_last/model_config.yaml
@@ -23,7 +23,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_cp2_etp4_calculate_per_token_loss_dp_last_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_cp2_etp4_calculate_per_token_loss_dp_last_1node/model_config.yaml
@@ -23,7 +23,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_cp2_etp4_calculate_per_token_loss_nondeterministic_dp_last/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_cp2_etp4_calculate_per_token_loss_nondeterministic_dp_last/model_config.yaml
@@ -23,7 +23,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_cp2_etp4_calculate_per_token_loss_nondeterministic_dp_last_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_cp2_etp4_calculate_per_token_loss_nondeterministic_dp_last_1node/model_config.yaml
@@ -23,7 +23,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_cp2_etp4_dp_last/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_cp2_etp4_dp_last/model_config.yaml
@@ -23,7 +23,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_cp2_etp4_dp_last_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_cp2_etp4_dp_last_1node/model_config.yaml
@@ -23,7 +23,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_cp2_etp4_nondeterministic_dp_last/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_cp2_etp4_nondeterministic_dp_last/model_config.yaml
@@ -23,7 +23,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_cp2_etp4_nondeterministic_dp_last_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_cp2_etp4_nondeterministic_dp_last_1node/model_config.yaml
@@ -23,7 +23,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_cp2_nondeterministic/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_cp2_nondeterministic/model_config.yaml
@@ -23,7 +23,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_cp2_nondeterministic_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_cp2_nondeterministic_1node/model_config.yaml
@@ -23,7 +23,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_cross_entropy_loss_fusion/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_cross_entropy_loss_fusion/model_config.yaml
@@ -23,7 +23,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_cross_entropy_loss_fusion_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_cross_entropy_loss_fusion_1node/model_config.yaml
@@ -23,7 +23,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_ddp_average_in_collective/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_ddp_average_in_collective/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_defer_embedding_wgrad_compute/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_defer_embedding_wgrad_compute/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_dsa/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_dsa/model_config.yaml
@@ -38,7 +38,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/the_pile/shard00/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/the_pile/shard00/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_mla/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_mla/model_config.yaml
@@ -31,7 +31,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_mla_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_mla_1node/model_config.yaml
@@ -31,7 +31,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_no_create_attention_mask_in_dataloader/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_no_create_attention_mask_in_dataloader/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_no_mmap_bin_files/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_no_mmap_bin_files/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_resume_torch_dist/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_resume_torch_dist/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_resume_torch_dist_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_resume_torch_dist_1node/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_resume_torch_dist_cp2_nondeterministic/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_resume_torch_dist_cp2_nondeterministic/model_config.yaml
@@ -23,7 +23,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_resume_torch_dist_cp2_nondeterministic_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_resume_torch_dist_cp2_nondeterministic_1node/model_config.yaml
@@ -23,7 +23,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_resume_torch_dist_cross_entropy_loss_fusion/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_resume_torch_dist_cross_entropy_loss_fusion/model_config.yaml
@@ -23,7 +23,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_resume_torch_dist_cross_entropy_loss_fusion_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_resume_torch_dist_cross_entropy_loss_fusion_1node/model_config.yaml
@@ -23,7 +23,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_resume_torch_dist_ddp_average_in_collective/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_resume_torch_dist_ddp_average_in_collective/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_resume_torch_dist_ddp_average_in_collective_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_resume_torch_dist_ddp_average_in_collective_1node/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_resume_torch_dist_defer_embedding_wgrad_compute/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_resume_torch_dist_defer_embedding_wgrad_compute/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_resume_torch_dist_defer_embedding_wgrad_compute_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_resume_torch_dist_defer_embedding_wgrad_compute_1node/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_resume_torch_dist_no_create_attention_mask_in_dataloader/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_resume_torch_dist_no_create_attention_mask_in_dataloader/model_config.yaml
@@ -26,7 +26,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_resume_torch_dist_no_mmap_bin_files/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_resume_torch_dist_no_mmap_bin_files/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_resume_torch_dist_reshard_1x4xNone/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_resume_torch_dist_reshard_1x4xNone/model_config.yaml
@@ -23,7 +23,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_resume_torch_dist_reshard_1x4xNone_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_pp2_resume_torch_dist_reshard_1x4xNone_1node/model_config.yaml
@@ -23,7 +23,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_zp_z3_resume_fsdp_dtensor/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_zp_z3_resume_fsdp_dtensor/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_zp_z3_resume_fsdp_dtensor_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp2_zp_z3_resume_fsdp_dtensor_1node/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp4_pp1_dist_optimizer_overlap_grad_reduce/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp4_pp1_dist_optimizer_overlap_grad_reduce/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp4_pp1_dist_optimizer_overlap_grad_reduce_param_gather/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp4_pp1_dist_optimizer_overlap_grad_reduce_param_gather/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp4_pp1_dist_optimizer_overlap_grad_reduce_param_gather_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp4_pp1_dist_optimizer_overlap_grad_reduce_param_gather_1node/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp4_pp1_qk_layernorm_test_mode/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp4_pp1_qk_layernorm_test_mode/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp4_pp1_resume_torch_dist_dist_optimizer_overlap_grad_reduce/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp4_pp1_resume_torch_dist_dist_optimizer_overlap_grad_reduce/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp4_pp1_resume_torch_dist_dist_optimizer_overlap_grad_reduce_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp4_pp1_resume_torch_dist_dist_optimizer_overlap_grad_reduce_1node/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp4_pp1_resume_torch_dist_dist_optimizer_overlap_grad_reduce_param_gather/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp4_pp1_resume_torch_dist_dist_optimizer_overlap_grad_reduce_param_gather/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp4_pp1_resume_torch_dist_dist_optimizer_overlap_grad_reduce_param_gather_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp4_pp1_resume_torch_dist_dist_optimizer_overlap_grad_reduce_param_gather_1node/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp4_pp1_resume_torch_dist_qk_layernorm_test_mode/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp4_pp1_resume_torch_dist_qk_layernorm_test_mode/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp4_pp1_resume_torch_dist_qk_layernorm_test_mode_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp4_pp1_resume_torch_dist_qk_layernorm_test_mode_1node/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp4_pp2_frozen_resume_torch_dist_reshard_8x1xNone/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp4_pp2_frozen_resume_torch_dist_reshard_8x1xNone/model_config.yaml
@@ -23,7 +23,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp4_pp2_resume_torch_dist_reshard_8x1xNone/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp4_pp2_resume_torch_dist_reshard_8x1xNone/model_config.yaml
@@ -23,7 +23,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp4_pp2_resume_torch_dist_reshard_8x1xNone_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_te_tp4_pp2_resume_torch_dist_reshard_8x1xNone_1node/model_config.yaml
@@ -23,7 +23,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_tp1_pp1_dist_optimizer_overlap_grad_reduce_param_gather/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_tp1_pp1_dist_optimizer_overlap_grad_reduce_param_gather/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_tp1_pp1_fsdp2_resume_torch_dist_te/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_tp1_pp1_fsdp2_resume_torch_dist_te/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_tp1_pp1_resume_torch_dist_dist_optimizer_overlap_grad_reduce_param_gather/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_tp1_pp1_resume_torch_dist_dist_optimizer_overlap_grad_reduce_param_gather/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_tp1_pp2/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_tp1_pp2/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_tp1_pp2_fp16/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_tp1_pp2_fp16/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_tp1_pp2_resume_torch_dist/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_tp1_pp2_resume_torch_dist/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_tp1_pp4/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_tp1_pp4/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_tp1_pp4_resume_torch_dist/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_tp1_pp4_resume_torch_dist/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_tp2_pp2_resume_torch_dist_uninstall_te/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_tp2_pp2_resume_torch_dist_uninstall_te/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_tp2_pp2_uninstall_te/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_tp2_pp2_uninstall_te/model_config.yaml
@@ -29,7 +29,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_tp2_pp2_uninstall_te_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_tp2_pp2_uninstall_te_1node/model_config.yaml
@@ -29,7 +29,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_tp4_pp1/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_tp4_pp1/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_tp4_pp1_resume_torch/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_tp4_pp1_resume_torch/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_mcore_tp4_pp1_resume_torch_dist/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_mcore_tp4_pp1_resume_torch_dist/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_weekly_mcore_tp2_pp2_current_scaling_native_fp8_tp_pp_sp_tp_overlap/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_weekly_mcore_tp2_pp2_current_scaling_native_fp8_tp_pp_sp_tp_overlap/model_config.yaml
@@ -26,7 +26,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt3_weekly_mcore_tp4_cp2_current_scaling_native_fp8_tp_sp_cp_tp_overlap/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt3_weekly_mcore_tp4_cp2_current_scaling_native_fp8_tp_sp_cp_tp_overlap/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp1_pp1_583m_chunked_prefill/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp1_pp1_583m_chunked_prefill/model_config.yaml
@@ -20,7 +20,7 @@ MODEL_ARGS:
   --no-use-tokenizer-model-from-checkpoint-args: true
   --timing-log-level: 0
   --load: ${CHECKPOINT_LOAD_PATH}/model/mcore_mistral/nemo_minitron-0.5b/v1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 1

--- a/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp1_pp1_583m_chunked_prefill_cuda_graphs/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp1_pp1_583m_chunked_prefill_cuda_graphs/model_config.yaml
@@ -20,7 +20,7 @@ MODEL_ARGS:
   --no-use-tokenizer-model-from-checkpoint-args: true
   --timing-log-level: 0
   --load: ${CHECKPOINT_LOAD_PATH}/model/mcore_mistral/nemo_minitron-0.5b/v1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 1

--- a/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp1_pp1_583m_cuda_graphs_fp8_logitsmatch/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp1_pp1_583m_cuda_graphs_fp8_logitsmatch/model_config.yaml
@@ -20,7 +20,7 @@ MODEL_ARGS:
   --no-use-tokenizer-model-from-checkpoint-args: true
   --timing-log-level: 0
   --load: ${CHECKPOINT_LOAD_PATH}/model/mcore_mistral/nemo_minitron-0.5b/v1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 1

--- a/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp1_pp1_583m_cuda_graphs_logitsmatch_decode_graphs_only/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp1_pp1_583m_cuda_graphs_logitsmatch_decode_graphs_only/model_config.yaml
@@ -20,7 +20,7 @@ MODEL_ARGS:
   --no-use-tokenizer-model-from-checkpoint-args: true
   --timing-log-level: 0
   --load: ${CHECKPOINT_LOAD_PATH}/model/mcore_mistral/nemo_minitron-0.5b/v1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 1

--- a/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp1_pp1_583m_flashinfer/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp1_pp1_583m_flashinfer/model_config.yaml
@@ -20,7 +20,7 @@ MODEL_ARGS:
   --no-use-tokenizer-model-from-checkpoint-args: true
   --timing-log-level: 0
   --load: ${CHECKPOINT_LOAD_PATH}/model/mcore_mistral/nemo_minitron-0.5b/v1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 1

--- a/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp1_pp1_583m_logitsmatch/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp1_pp1_583m_logitsmatch/model_config.yaml
@@ -20,7 +20,7 @@ MODEL_ARGS:
   --no-use-tokenizer-model-from-checkpoint-args: true
   --timing-log-level: 0
   --load: ${CHECKPOINT_LOAD_PATH}/model/mcore_mistral/nemo_minitron-0.5b/v1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 1

--- a/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp1_pp1_583m_prefix_caching/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp1_pp1_583m_prefix_caching/model_config.yaml
@@ -20,7 +20,7 @@ MODEL_ARGS:
   --no-use-tokenizer-model-from-checkpoint-args: true
   --timing-log-level: 0
   --load: ${CHECKPOINT_LOAD_PATH}/model/mcore_mistral/nemo_minitron-0.5b/v1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 1

--- a/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp1_pp1_583m_prefix_caching_chunked_prefill/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp1_pp1_583m_prefix_caching_chunked_prefill/model_config.yaml
@@ -20,7 +20,7 @@ MODEL_ARGS:
   --no-use-tokenizer-model-from-checkpoint-args: true
   --timing-log-level: 0
   --load: ${CHECKPOINT_LOAD_PATH}/model/mcore_mistral/nemo_minitron-0.5b/v1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 1

--- a/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp1_pp1_583m_prefix_caching_chunked_prefill_cuda_graphs/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp1_pp1_583m_prefix_caching_chunked_prefill_cuda_graphs/model_config.yaml
@@ -20,7 +20,7 @@ MODEL_ARGS:
   --no-use-tokenizer-model-from-checkpoint-args: true
   --timing-log-level: 0
   --load: ${CHECKPOINT_LOAD_PATH}/model/mcore_mistral/nemo_minitron-0.5b/v1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 1

--- a/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp1_pp1_583m_prefix_caching_chunked_prefill_flashinfer/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp1_pp1_583m_prefix_caching_chunked_prefill_flashinfer/model_config.yaml
@@ -20,7 +20,7 @@ MODEL_ARGS:
   --no-use-tokenizer-model-from-checkpoint-args: true
   --timing-log-level: 0
   --load: ${CHECKPOINT_LOAD_PATH}/model/mcore_mistral/nemo_minitron-0.5b/v1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 1

--- a/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp1_pp1_583m_prefix_caching_cuda_graphs/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp1_pp1_583m_prefix_caching_cuda_graphs/model_config.yaml
@@ -20,7 +20,7 @@ MODEL_ARGS:
   --no-use-tokenizer-model-from-checkpoint-args: true
   --timing-log-level: 0
   --load: ${CHECKPOINT_LOAD_PATH}/model/mcore_mistral/nemo_minitron-0.5b/v1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 1

--- a/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp1_pp1_583m_prefix_caching_lru/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp1_pp1_583m_prefix_caching_lru/model_config.yaml
@@ -20,7 +20,7 @@ MODEL_ARGS:
   --no-use-tokenizer-model-from-checkpoint-args: true
   --timing-log-level: 0
   --load: ${CHECKPOINT_LOAD_PATH}/model/mcore_mistral/nemo_minitron-0.5b/v1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 1

--- a/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp1_pp1_583m_stop_words/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp1_pp1_583m_stop_words/model_config.yaml
@@ -20,7 +20,7 @@ MODEL_ARGS:
   --no-use-tokenizer-model-from-checkpoint-args: true
   --timing-log-level: 0
   --load: ${CHECKPOINT_LOAD_PATH}/model/mcore_mistral/nemo_minitron-0.5b/v1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 1

--- a/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp1_pp1_583m_top_n_logprobs/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp1_pp1_583m_top_n_logprobs/model_config.yaml
@@ -20,7 +20,7 @@ MODEL_ARGS:
   --no-use-tokenizer-model-from-checkpoint-args: true
   --timing-log-level: 0
   --load: ${CHECKPOINT_LOAD_PATH}/model/mcore_mistral/nemo_minitron-0.5b/v1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 1

--- a/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp1_pp1_583m_top_p_sampling/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp1_pp1_583m_top_p_sampling/model_config.yaml
@@ -20,7 +20,7 @@ MODEL_ARGS:
   --no-use-tokenizer-model-from-checkpoint-args: true
   --timing-log-level: 0
   --load: ${CHECKPOINT_LOAD_PATH}/model/mcore_mistral/nemo_minitron-0.5b/v1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 1

--- a/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp1_pp1_583m_uvm_level1/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp1_pp1_583m_uvm_level1/model_config.yaml
@@ -20,7 +20,7 @@ MODEL_ARGS:
   --no-use-tokenizer-model-from-checkpoint-args: true
   --timing-log-level: 0
   --load: ${CHECKPOINT_LOAD_PATH}/model/mcore_mistral/nemo_minitron-0.5b/v1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 1

--- a/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp1_pp1_dp8_583m_logitsmatch_zmq/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp1_pp1_dp8_583m_logitsmatch_zmq/model_config.yaml
@@ -20,7 +20,7 @@ MODEL_ARGS:
   --no-use-tokenizer-model-from-checkpoint-args: true
   --timing-log-level: 0
   --load: ${CHECKPOINT_LOAD_PATH}/model/mcore_mistral/nemo_minitron-0.5b/v1/
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: inference_optimized
   --sequence-parallel: true

--- a/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp1_pp1_dp8_583m_prefix_caching_longest_prefix_zmq/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp1_pp1_dp8_583m_prefix_caching_longest_prefix_zmq/model_config.yaml
@@ -20,7 +20,7 @@ MODEL_ARGS:
   --no-use-tokenizer-model-from-checkpoint-args: true
   --timing-log-level: 0
   --load: ${CHECKPOINT_LOAD_PATH}/model/mcore_mistral/nemo_minitron-0.5b/v1/
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: inference_optimized
   --sequence-parallel: true

--- a/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp1_pp1_dp8_583m_prefix_caching_round_robin_zmq/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp1_pp1_dp8_583m_prefix_caching_round_robin_zmq/model_config.yaml
@@ -20,7 +20,7 @@ MODEL_ARGS:
   --no-use-tokenizer-model-from-checkpoint-args: true
   --timing-log-level: 0
   --load: ${CHECKPOINT_LOAD_PATH}/model/mcore_mistral/nemo_minitron-0.5b/v1/
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: inference_optimized
   --sequence-parallel: true

--- a/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp1_pp8_583m_prefix_caching/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp1_pp8_583m_prefix_caching/model_config.yaml
@@ -20,7 +20,7 @@ MODEL_ARGS:
   --no-use-tokenizer-model-from-checkpoint-args: true
   --timing-log-level: 0
   --load: ${CHECKPOINT_LOAD_PATH}/model/mcore_mistral/nemo_minitron-0.5b/v1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 1

--- a/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp1_pp8_dp1_583m_logitsmatch_zmq/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp1_pp8_dp1_583m_logitsmatch_zmq/model_config.yaml
@@ -20,7 +20,7 @@ MODEL_ARGS:
   --no-use-tokenizer-model-from-checkpoint-args: true
   --timing-log-level: 0
   --load: ${CHECKPOINT_LOAD_PATH}/model/mcore_mistral/nemo_minitron-0.5b/v1/
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: inference_optimized
   --sequence-parallel: true

--- a/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp2_pp2_583m_chunked_prefill/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp2_pp2_583m_chunked_prefill/model_config.yaml
@@ -20,7 +20,7 @@ MODEL_ARGS:
   --no-use-tokenizer-model-from-checkpoint-args: true
   --timing-log-level: 0
   --load: ${CHECKPOINT_LOAD_PATH}/model/mcore_mistral/nemo_minitron-0.5b/v1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 2

--- a/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp2_pp2_583m_cuda_graphs/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp2_pp2_583m_cuda_graphs/model_config.yaml
@@ -20,7 +20,7 @@ MODEL_ARGS:
   --no-use-tokenizer-model-from-checkpoint-args: true
   --timing-log-level: 0
   --load: ${CHECKPOINT_LOAD_PATH}/model/mcore_mistral/nemo_minitron-0.5b/v1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 2

--- a/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp2_pp2_583m_prefix_caching/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp2_pp2_583m_prefix_caching/model_config.yaml
@@ -20,7 +20,7 @@ MODEL_ARGS:
   --no-use-tokenizer-model-from-checkpoint-args: true
   --timing-log-level: 0
   --load: ${CHECKPOINT_LOAD_PATH}/model/mcore_mistral/nemo_minitron-0.5b/v1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 2

--- a/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp2_pp2_583m_prefix_caching_cuda_graphs/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp2_pp2_583m_prefix_caching_cuda_graphs/model_config.yaml
@@ -20,7 +20,7 @@ MODEL_ARGS:
   --no-use-tokenizer-model-from-checkpoint-args: true
   --timing-log-level: 0
   --load: ${CHECKPOINT_LOAD_PATH}/model/mcore_mistral/nemo_minitron-0.5b/v1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 2

--- a/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp2_pp2_dp2_583m_logitsmatch_zmq/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp2_pp2_dp2_583m_logitsmatch_zmq/model_config.yaml
@@ -20,7 +20,7 @@ MODEL_ARGS:
   --no-use-tokenizer-model-from-checkpoint-args: true
   --timing-log-level: 0
   --load: ${CHECKPOINT_LOAD_PATH}/model/mcore_mistral/nemo_minitron-0.5b/v1/
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: inference_optimized
   --inference-fuse-tp-communication: true

--- a/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp4_pp1_583m_flashinfer/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp4_pp1_583m_flashinfer/model_config.yaml
@@ -20,7 +20,7 @@ MODEL_ARGS:
   --no-use-tokenizer-model-from-checkpoint-args: true
   --timing-log-level: 0
   --load: ${CHECKPOINT_LOAD_PATH}/model/mcore_mistral/nemo_minitron-0.5b/v1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 4

--- a/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp8_pp1_583m_logitsmatch/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp8_pp1_583m_logitsmatch/model_config.yaml
@@ -20,7 +20,7 @@ MODEL_ARGS:
   --no-use-tokenizer-model-from-checkpoint-args: true
   --timing-log-level: 0
   --load: ${CHECKPOINT_LOAD_PATH}/model/mcore_mistral/nemo_minitron-0.5b/v1/
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 1

--- a/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp8_pp1_583m_prefix_caching/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp8_pp1_583m_prefix_caching/model_config.yaml
@@ -20,7 +20,7 @@ MODEL_ARGS:
   --no-use-tokenizer-model-from-checkpoint-args: true
   --timing-log-level: 0
   --load: ${CHECKPOINT_LOAD_PATH}/model/mcore_mistral/nemo_minitron-0.5b/v1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 8

--- a/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp8_pp1_dp1_583m_logitsmatch_zmq/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_dynamic_inference_tp8_pp1_dp1_583m_logitsmatch_zmq/model_config.yaml
@@ -20,7 +20,7 @@ MODEL_ARGS:
   --no-use-tokenizer-model-from-checkpoint-args: true
   --timing-log-level: 0
   --load: ${CHECKPOINT_LOAD_PATH}/model/mcore_mistral/nemo_minitron-0.5b/v1/
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: inference_optimized
   --inference-fuse-tp-communication: true

--- a/tests/functional_tests/test_cases/gpt/gpt_grpo_tp1tp2_pp1_dp8_583m_throughputtest/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_grpo_tp1tp2_pp1_dp8_583m_throughputtest/model_config.yaml
@@ -20,7 +20,7 @@ MODEL_ARGS:
   --no-load-optim: true
   --no-use-tokenizer-model-from-checkpoint-args: true
   --timing-log-level: 0
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --log-progress: true
   --transformer-impl: transformer_engine

--- a/tests/functional_tests/test_cases/gpt/gpt_grpo_tp1tp2_pp1_dp8_583m_throughputtest_github/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_grpo_tp1tp2_pp1_dp8_583m_throughputtest_github/model_config.yaml
@@ -20,7 +20,7 @@ MODEL_ARGS:
   --no-load-optim: true
   --no-use-tokenizer-model-from-checkpoint-args: true
   --timing-log-level: 0
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --log-progress: true
   --transformer-impl: transformer_engine

--- a/tests/functional_tests/test_cases/gpt/gpt_offline_inference_async_tp1_pp1_dp8_583m_logitsmatch_zmq/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_offline_inference_async_tp1_pp1_dp8_583m_logitsmatch_zmq/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --no-use-tokenizer-model-from-checkpoint-args: true
   --timing-log-level: 0
   --load: ${CHECKPOINT_LOAD_PATH}/model/mcore_mistral/nemo_minitron-0.5b/v1/
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: inference_optimized
   --sequence-parallel: true

--- a/tests/functional_tests/test_cases/gpt/gpt_offline_inference_sync_tp1_pp1_583m_logitsmatch/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_offline_inference_sync_tp1_pp1_583m_logitsmatch/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --no-use-tokenizer-model-from-checkpoint-args: true
   --timing-log-level: 0
   --load: ${CHECKPOINT_LOAD_PATH}/model/mcore_mistral/nemo_minitron-0.5b/v1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 1

--- a/tests/functional_tests/test_cases/gpt/gpt_offline_inference_sync_tp1_pp1_dp8_583m_logitsmatch_zmq/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_offline_inference_sync_tp1_pp1_dp8_583m_logitsmatch_zmq/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --no-use-tokenizer-model-from-checkpoint-args: true
   --timing-log-level: 0
   --load: ${CHECKPOINT_LOAD_PATH}/model/mcore_mistral/nemo_minitron-0.5b/v1/
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: inference_optimized
   --sequence-parallel: true

--- a/tests/functional_tests/test_cases/gpt/gpt_static_inference_tp1_pp1_16b_multiprompt_tokensmatch/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_static_inference_tp1_pp1_16b_multiprompt_tokensmatch/model_config.yaml
@@ -16,7 +16,7 @@ MODEL_ARGS:
   --tokenizer-model: ${CHECKPOINT_LOAD_PATH}/model/deepseek_16b_pyt/dcp/mcore-v1_bf16/multiMixV8.gpt4o_nc_sd.500000.128k.vocab.json
   --tokenizer-type: TikTokenizer
   --tiktoken-pattern: v2
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 1

--- a/tests/functional_tests/test_cases/gpt/gpt_static_inference_tp1_pp1_583m_cudagraphs/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_static_inference_tp1_pp1_583m_cudagraphs/model_config.yaml
@@ -20,7 +20,7 @@ MODEL_ARGS:
   --no-use-tokenizer-model-from-checkpoint-args: true
   --timing-log-level: 0
   --load: ${CHECKPOINT_LOAD_PATH}/model/mcore_mistral/nemo_minitron-0.5b/v1/
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 1

--- a/tests/functional_tests/test_cases/gpt/gpt_static_inference_tp1_pp1_583m_fp8_cudagraphs/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_static_inference_tp1_pp1_583m_fp8_cudagraphs/model_config.yaml
@@ -20,7 +20,7 @@ MODEL_ARGS:
   --no-use-tokenizer-model-from-checkpoint-args: true
   --timing-log-level: 0
   --load: ${CHECKPOINT_LOAD_PATH}/model/mcore_mistral/nemo_minitron-0.5b/v1/
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 1

--- a/tests/functional_tests/test_cases/gpt/gpt_static_inference_tp1_pp1_583m_logitsmatch/model_config.yaml
+++ b/tests/functional_tests/test_cases/gpt/gpt_static_inference_tp1_pp1_583m_logitsmatch/model_config.yaml
@@ -20,7 +20,7 @@ MODEL_ARGS:
   --no-use-tokenizer-model-from-checkpoint-args: true
   --timing-log-level: 0
   --load: ${CHECKPOINT_LOAD_PATH}/model/mcore_mistral/nemo_minitron-0.5b/v1/
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 1

--- a/tests/functional_tests/test_cases/hybrid/hybrid_dynamic_inference_tp1_ep8_nanov3_chunked_prefill/model_config.yaml
+++ b/tests/functional_tests/test_cases/hybrid/hybrid_dynamic_inference_tp1_ep8_nanov3_chunked_prefill/model_config.yaml
@@ -18,7 +18,7 @@ MODEL_ARGS:
   --tokenizer-model: ${CHECKPOINT_LOAD_PATH}/model/nemotron6/tokenizers/multiMixV8.gpt4o_nc_sd.500000.128k.vocab.json
   --tokenizer-type: TikTokenizer
   --tiktoken-pattern: v2
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --tensor-model-parallel-size: 1
   --pipeline-model-parallel-size: 1

--- a/tests/functional_tests/test_cases/hybrid/hybrid_dynamic_inference_tp1_pp1_dp8_583m/model_config.yaml
+++ b/tests/functional_tests/test_cases/hybrid/hybrid_dynamic_inference_tp1_pp1_dp8_583m/model_config.yaml
@@ -17,7 +17,7 @@ MODEL_ARGS:
   --tokenizer-model: ${CHECKPOINT_LOAD_PATH}/model/mamba_hybrid_2b/dcp/mcore-v1_bf16/multiMixV8.gpt4o_nc_sd.500000.128k.vocab.json
   --tokenizer-type: TikTokenizer
   --tiktoken-pattern: v2
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 1

--- a/tests/functional_tests/test_cases/hybrid/hybrid_dynamic_inference_tp1_pp1_dp8_583m_chunked_prefill/model_config.yaml
+++ b/tests/functional_tests/test_cases/hybrid/hybrid_dynamic_inference_tp1_pp1_dp8_583m_chunked_prefill/model_config.yaml
@@ -17,7 +17,7 @@ MODEL_ARGS:
   --tokenizer-model: ${CHECKPOINT_LOAD_PATH}/model/mamba_hybrid_2b/dcp/mcore-v1_bf16/multiMixV8.gpt4o_nc_sd.500000.128k.vocab.json
   --tokenizer-type: TikTokenizer
   --tiktoken-pattern: v2
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 1

--- a/tests/functional_tests/test_cases/hybrid/hybrid_dynamic_inference_tp1_pp1_dp8_583m_flashinfer/model_config.yaml
+++ b/tests/functional_tests/test_cases/hybrid/hybrid_dynamic_inference_tp1_pp1_dp8_583m_flashinfer/model_config.yaml
@@ -17,7 +17,7 @@ MODEL_ARGS:
   --tokenizer-model: ${CHECKPOINT_LOAD_PATH}/model/mamba_hybrid_2b/dcp/mcore-v1_bf16/multiMixV8.gpt4o_nc_sd.500000.128k.vocab.json
   --tokenizer-type: TikTokenizer
   --tiktoken-pattern: v2
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 1

--- a/tests/functional_tests/test_cases/hybrid/hybrid_dynamic_inference_tp1_pp1_dp8_583m_mamba_bf16_states/model_config.yaml
+++ b/tests/functional_tests/test_cases/hybrid/hybrid_dynamic_inference_tp1_pp1_dp8_583m_mamba_bf16_states/model_config.yaml
@@ -17,7 +17,7 @@ MODEL_ARGS:
   --tokenizer-model: ${CHECKPOINT_LOAD_PATH}/model/mamba_hybrid_2b/dcp/mcore-v1_bf16/multiMixV8.gpt4o_nc_sd.500000.128k.vocab.json
   --tokenizer-type: TikTokenizer
   --tiktoken-pattern: v2
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 1

--- a/tests/functional_tests/test_cases/hybrid/hybrid_flextron_nightly_tp2_pp1_ep2_dgx_h100_1N8G/model_config.yaml
+++ b/tests/functional_tests/test_cases/hybrid/hybrid_flextron_nightly_tp2_pp1_ep2_dgx_h100_1N8G/model_config.yaml
@@ -97,7 +97,7 @@ MODEL_ARGS:
   --transformer-impl: transformer_engine
   --export-default-te-spec: true
   --export-model-type: HybridModel
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --distributed-timeout-minutes: 20
   # ── Flextron (from train_flextron.sh flex_options, int-lists with ÷8) ─────
   --flextron: true

--- a/tests/functional_tests/test_cases/hybrid/hybrid_mr_mcore_te_tp1_pp1_cp1_dgx_a100_1N8G/model_config.yaml
+++ b/tests/functional_tests/test_cases/hybrid/hybrid_mr_mcore_te_tp1_pp1_cp1_dgx_a100_1N8G/model_config.yaml
@@ -28,7 +28,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/hybrid/hybrid_mr_mcore_te_tp1_pp2_vpp2_cp1_dgx_a100_1N8G/model_config.yaml
+++ b/tests/functional_tests/test_cases/hybrid/hybrid_mr_mcore_te_tp1_pp2_vpp2_cp1_dgx_a100_1N8G/model_config.yaml
@@ -28,7 +28,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/hybrid/hybrid_mr_mcore_te_tp1_pp4_cp1_dgx_a100_1N8G/model_config.yaml
+++ b/tests/functional_tests/test_cases/hybrid/hybrid_mr_mcore_te_tp1_pp4_cp1_dgx_a100_1N8G/model_config.yaml
@@ -28,7 +28,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/hybrid/hybrid_mr_mcore_te_tp2_pp1_cp1_dgx_a100_1N8G/model_config.yaml
+++ b/tests/functional_tests/test_cases/hybrid/hybrid_mr_mcore_te_tp2_pp1_cp1_dgx_a100_1N8G/model_config.yaml
@@ -28,7 +28,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/hybrid/hybrid_mr_mcore_te_tp2_pp1_cp4_dgx_a100_1N8G/model_config.yaml
+++ b/tests/functional_tests/test_cases/hybrid/hybrid_mr_mcore_te_tp2_pp1_cp4_dgx_a100_1N8G/model_config.yaml
@@ -28,7 +28,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/hybrid/hybrid_static_inference_tp1_pp1_2B_cudagraphs/model_config.yaml
+++ b/tests/functional_tests/test_cases/hybrid/hybrid_static_inference_tp1_pp1_2B_cudagraphs/model_config.yaml
@@ -15,7 +15,7 @@ MODEL_ARGS:
   --tokenizer-model: ${CHECKPOINT_LOAD_PATH}/model/mamba_hybrid_2b/dcp/mcore-v1_bf16/multiMixV8.gpt4o_nc_sd.500000.128k.vocab.json
   --tokenizer-type: TikTokenizer
   --tiktoken-pattern: v2
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 1

--- a/tests/functional_tests/test_cases/hybrid/hybrid_static_inference_tp1_pp1_2B_logitsmatch/model_config.yaml
+++ b/tests/functional_tests/test_cases/hybrid/hybrid_static_inference_tp1_pp1_2B_logitsmatch/model_config.yaml
@@ -15,7 +15,7 @@ MODEL_ARGS:
   --tokenizer-model: ${CHECKPOINT_LOAD_PATH}/model/mamba_hybrid_2b/dcp/mcore-v1_bf16/multiMixV8.gpt4o_nc_sd.500000.128k.vocab.json
   --tokenizer-type: TikTokenizer
   --tiktoken-pattern: v2
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 1

--- a/tests/functional_tests/test_cases/mimo/mimo_vlm_pretrain_convergence_tp1_pp1_cp1_dp8/model_config.yaml
+++ b/tests/functional_tests/test_cases/mimo/mimo_vlm_pretrain_convergence_tp1_pp1_cp1_dp8/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --load: ${CHECKPOINT_LOAD_PATH}
   --tokenizer-type: HuggingFaceTokenizer
   --tokenizer-model: llava-hf/llava-1.5-7b-hf
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.001
   --lr-decay-style: cosine
   --min-lr: 2.0e-5

--- a/tests/functional_tests/test_cases/mimo/mimo_vlm_pretrain_convergence_tp1_pp1_cp1_dp8_seq_packing/model_config.yaml
+++ b/tests/functional_tests/test_cases/mimo/mimo_vlm_pretrain_convergence_tp1_pp1_cp1_dp8_seq_packing/model_config.yaml
@@ -28,7 +28,7 @@ MODEL_ARGS:
   --load: ${CHECKPOINT_LOAD_PATH}
   --tokenizer-type: HuggingFaceTokenizer
   --tokenizer-model: llava-hf/llava-1.5-7b-hf
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.001
   --lr-decay-style: cosine
   --min-lr: 2.0e-5

--- a/tests/functional_tests/test_cases/mimo/mimo_vlm_pretrain_convergence_tp1_pp1_cp2_dp8/model_config.yaml
+++ b/tests/functional_tests/test_cases/mimo/mimo_vlm_pretrain_convergence_tp1_pp1_cp2_dp8/model_config.yaml
@@ -27,7 +27,7 @@ MODEL_ARGS:
   --load: ${CHECKPOINT_LOAD_PATH}
   --tokenizer-type: HuggingFaceTokenizer
   --tokenizer-model: llava-hf/llava-1.5-7b-hf
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.001
   --lr-decay-style: cosine
   --min-lr: 2.0e-5

--- a/tests/functional_tests/test_cases/moe/gpt3_mcore_cp2_pp2_ep2_te_4experts2parallel_nondeterministic/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_mcore_cp2_pp2_ep2_te_4experts2parallel_nondeterministic/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/moe/gpt3_mcore_cp2_pp2_ep2_te_4experts2parallel_nondeterministic_dp_last/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_mcore_cp2_pp2_ep2_te_4experts2parallel_nondeterministic_dp_last/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp1_pp1_te_4experts_groupedGEMM_op_fuser/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp1_pp1_te_4experts_groupedGEMM_op_fuser/model_config.yaml
@@ -29,7 +29,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp1_pp2_resume_torch_dist_reshard_2x1x4_te_8experts2parallel_dist_optimizer/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp1_pp2_resume_torch_dist_reshard_2x1x4_te_8experts2parallel_dist_optimizer/model_config.yaml
@@ -23,7 +23,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp1_pp2_resume_torch_dist_reshard_2x1x4_te_8experts2parallel_dist_optimizer_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp1_pp2_resume_torch_dist_reshard_2x1x4_te_8experts2parallel_dist_optimizer_1node/model_config.yaml
@@ -23,7 +23,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp2_pp1_frozen_resume_torch_dist_te_8experts2parallel_dist_optimizer/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp2_pp1_frozen_resume_torch_dist_te_8experts2parallel_dist_optimizer/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp2_pp1_frozen_resume_torch_dist_te_8experts2parallel_groupedGEMM/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp2_pp1_frozen_resume_torch_dist_te_8experts2parallel_groupedGEMM/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp2_pp1_resume_torch_dist_te_8experts2parallel_dist_optimizer/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp2_pp1_resume_torch_dist_te_8experts2parallel_dist_optimizer/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp2_pp1_resume_torch_dist_te_8experts2parallel_dist_optimizer_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp2_pp1_resume_torch_dist_te_8experts2parallel_dist_optimizer_1node/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp2_pp1_resume_torch_dist_te_8experts2parallel_groupedGEMM/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp2_pp1_resume_torch_dist_te_8experts2parallel_groupedGEMM/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp2_pp1_resume_torch_dist_te_8experts2parallel_multi_dist_optimizer_instances/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp2_pp1_resume_torch_dist_te_8experts2parallel_multi_dist_optimizer_instances/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp2_pp1_resume_torch_dist_te_8experts2parallel_multi_dist_optimizer_instances_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp2_pp1_resume_torch_dist_te_8experts2parallel_multi_dist_optimizer_instances_1node/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp2_pp1_resume_torch_dist_te_8experts2parallel_top2router/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp2_pp1_resume_torch_dist_te_8experts2parallel_top2router/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp2_pp1_te_8experts2parallel_ddp_average_in_collective/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp2_pp1_te_8experts2parallel_ddp_average_in_collective/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp2_pp1_te_8experts2parallel_ddp_average_in_collective_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp2_pp1_te_8experts2parallel_ddp_average_in_collective_1node/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp2_pp1_te_8experts2parallel_dist_optimizer/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp2_pp1_te_8experts2parallel_dist_optimizer/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp2_pp1_te_8experts2parallel_overlap_grad_reduce_param_gather_groupedGEMM/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp2_pp1_te_8experts2parallel_overlap_grad_reduce_param_gather_groupedGEMM/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp2_pp1_te_8experts2parallel_overlap_grad_reduce_param_gather_groupedGEMM_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp2_pp1_te_8experts2parallel_overlap_grad_reduce_param_gather_groupedGEMM_1node/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp2_pp1_te_8experts2parallel_top2router/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp2_pp1_te_8experts2parallel_top2router/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp2_pp1_te_8experts_etp1_ep4/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp2_pp1_te_8experts_etp1_ep4/model_config.yaml
@@ -26,7 +26,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp2_pp1_te_a2a_ovlp_8experts_etp1_ep4/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp2_pp1_te_a2a_ovlp_8experts_etp1_ep4/model_config.yaml
@@ -26,7 +26,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp2_pp1_te_a2a_ovlp_8experts_etp1_ep4_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp2_pp1_te_a2a_ovlp_8experts_etp1_ep4_1node/model_config.yaml
@@ -26,7 +26,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp2_zp_z3_resume_torch_dist_te_8experts2parallel_top2router/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_mcore_te_tp2_zp_z3_resume_torch_dist_te_8experts2parallel_top2router/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/moe/gpt3_mcore_tp2_cp2_pp2_ep2_te_4experts2parallel/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_mcore_tp2_cp2_pp2_ep2_te_4experts2parallel/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/moe/gpt3_mcore_tp2_cp2_pp2_ep2_te_4experts2parallel_dp_last/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_mcore_tp2_cp2_pp2_ep2_te_4experts2parallel_dp_last/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/moe/gpt3_mcore_tp2_pp2_ep2_etp2_te_4experts2parallel/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_mcore_tp2_pp2_ep2_etp2_te_4experts2parallel/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/moe/gpt3_mcore_tp2_pp2_ep2_etp2_te_4experts2parallel_dp_last/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_mcore_tp2_pp2_ep2_etp2_te_4experts2parallel_dp_last/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/moe/gpt3_mcore_tp2_pp2_ep2_resume_torch_dist_te_4experts2parallel/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_mcore_tp2_pp2_ep2_resume_torch_dist_te_4experts2parallel/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/moe/gpt3_mcore_tp2_pp2_ep2_te_4experts2parallel/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_mcore_tp2_pp2_ep2_te_4experts2parallel/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/moe/gpt3_mcore_tp2_pp2_resume_torch_dist_te_2experts/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_mcore_tp2_pp2_resume_torch_dist_te_2experts/model_config.yaml
@@ -25,7 +25,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/moe/gpt3_moe_mcore_te_ep8_resume_torch_dist_dist_muon/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_moe_mcore_te_ep8_resume_torch_dist_dist_muon/model_config.yaml
@@ -26,7 +26,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/moe/gpt3_moe_mcore_te_ep8_resume_torch_dist_dist_muon_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_moe_mcore_te_ep8_resume_torch_dist_dist_muon_1node/model_config.yaml
@@ -26,7 +26,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/moe/gpt3_moe_mcore_te_ep8_resume_torch_dist_dist_muon_param_layout/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_moe_mcore_te_ep8_resume_torch_dist_dist_muon_param_layout/model_config.yaml
@@ -26,7 +26,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/moe/gpt3_moe_mcore_te_ep8_resume_torch_dist_dist_muon_param_layout_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_moe_mcore_te_ep8_resume_torch_dist_dist_muon_param_layout_1node/model_config.yaml
@@ -26,7 +26,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/moe/gpt3_moe_mcore_te_ep8_resume_torch_dist_dist_optimizer/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_moe_mcore_te_ep8_resume_torch_dist_dist_optimizer/model_config.yaml
@@ -26,7 +26,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/moe/gpt3_moe_mcore_te_ep8_resume_torch_dist_dist_optimizer_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_moe_mcore_te_ep8_resume_torch_dist_dist_optimizer_1node/model_config.yaml
@@ -26,7 +26,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/moe/gpt3_moe_mcore_te_ep8_resume_torch_dist_muon/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_moe_mcore_te_ep8_resume_torch_dist_muon/model_config.yaml
@@ -26,7 +26,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/moe/gpt3_moe_mcore_te_ep8_resume_torch_dist_muon_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_moe_mcore_te_ep8_resume_torch_dist_muon_1node/model_config.yaml
@@ -26,7 +26,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/moe/gpt3_moe_mcore_te_tp4_ep2_etp2_pp2_resume_torch_dist_dist_optimizer/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_moe_mcore_te_tp4_ep2_etp2_pp2_resume_torch_dist_dist_optimizer/model_config.yaml
@@ -26,7 +26,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/moe/gpt3_moe_mcore_te_tp4_ep2_etp2_pp2_resume_torch_dist_dist_optimizer_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_moe_mcore_te_tp4_ep2_etp2_pp2_resume_torch_dist_dist_optimizer_1node/model_config.yaml
@@ -26,7 +26,7 @@ MODEL_ARGS:
   --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
   --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/moe/gpt3_moe_mcore_te_tp4_ep2_etp2_pp2_scoped_cudagraph/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_moe_mcore_te_tp4_ep2_etp2_pp2_scoped_cudagraph/model_config.yaml
@@ -21,7 +21,7 @@ MODEL_ARGS:
   --train-iters: 100
   --lr-decay-iters: 320000
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/moe/gpt3_moe_mcore_te_tp4_ep2_etp2_pp2_scoped_cudagraph_1node/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt3_moe_mcore_te_tp4_ep2_etp2_pp2_scoped_cudagraph_1node/model_config.yaml
@@ -21,7 +21,7 @@ MODEL_ARGS:
   --train-iters: 100
   --lr-decay-iters: 320000
   --split: 949,50,1
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/moe/gpt_dynamic_inference_cuda_graphs_pad_tp4_pp1_ep4_16B_logitsmatch/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt_dynamic_inference_cuda_graphs_pad_tp4_pp1_ep4_16B_logitsmatch/model_config.yaml
@@ -15,7 +15,7 @@ MODEL_ARGS:
   --tokenizer-model: ${CHECKPOINT_LOAD_PATH}/model/deepseek_16b_pyt/dcp/mcore-v1_bf16/multiMixV8.gpt4o_nc_sd.500000.128k.vocab.json
   --tokenizer-type: TikTokenizer
   --tiktoken-pattern: v2
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 4

--- a/tests/functional_tests/test_cases/moe/gpt_dynamic_inference_tp4_etp1_pp1_ep8_16B_logitsmatch_cudagraph_zmq/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt_dynamic_inference_tp4_etp1_pp1_ep8_16B_logitsmatch_cudagraph_zmq/model_config.yaml
@@ -15,7 +15,7 @@ MODEL_ARGS:
   --tokenizer-model: ${CHECKPOINT_LOAD_PATH}/model/deepseek_16b_pyt/dcp/mcore-v1_bf16/multiMixV8.gpt4o_nc_sd.500000.128k.vocab.json
   --tokenizer-type: TikTokenizer
   --tiktoken-pattern: v2
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 4

--- a/tests/functional_tests/test_cases/moe/gpt_dynamic_inference_tp4_etp1_pp1_ep8_16B_logitsmatch_zmq/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt_dynamic_inference_tp4_etp1_pp1_ep8_16B_logitsmatch_zmq/model_config.yaml
@@ -15,7 +15,7 @@ MODEL_ARGS:
   --tokenizer-model: ${CHECKPOINT_LOAD_PATH}/model/deepseek_16b_pyt/dcp/mcore-v1_bf16/multiMixV8.gpt4o_nc_sd.500000.128k.vocab.json
   --tokenizer-type: TikTokenizer
   --tiktoken-pattern: v2
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 4

--- a/tests/functional_tests/test_cases/moe/gpt_dynamic_inference_tp4_etp1_pp1_ep8_16B_logitsmatch_zmq_suspend_resume/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt_dynamic_inference_tp4_etp1_pp1_ep8_16B_logitsmatch_zmq_suspend_resume/model_config.yaml
@@ -15,7 +15,7 @@ MODEL_ARGS:
   --tokenizer-model: ${CHECKPOINT_LOAD_PATH}/model/deepseek_16b_pyt/dcp/mcore-v1_bf16/multiMixV8.gpt4o_nc_sd.500000.128k.vocab.json
   --tokenizer-type: TikTokenizer
   --tiktoken-pattern: v2
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 4

--- a/tests/functional_tests/test_cases/moe/gpt_dynamic_inference_tp4_pp1_ep4_16B_chunked_prefill/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt_dynamic_inference_tp4_pp1_ep4_16B_chunked_prefill/model_config.yaml
@@ -15,7 +15,7 @@ MODEL_ARGS:
   --tokenizer-model: ${CHECKPOINT_LOAD_PATH}/model/deepseek_16b_pyt/dcp/mcore-v1_bf16/multiMixV8.gpt4o_nc_sd.500000.128k.vocab.json
   --tokenizer-type: TikTokenizer
   --tiktoken-pattern: v2
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 4

--- a/tests/functional_tests/test_cases/moe/gpt_dynamic_inference_tp4_pp1_ep4_16B_logitsmatch/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt_dynamic_inference_tp4_pp1_ep4_16B_logitsmatch/model_config.yaml
@@ -15,7 +15,7 @@ MODEL_ARGS:
   --tokenizer-model: ${CHECKPOINT_LOAD_PATH}/model/deepseek_16b_pyt/dcp/mcore-v1_bf16/multiMixV8.gpt4o_nc_sd.500000.128k.vocab.json
   --tokenizer-type: TikTokenizer
   --tiktoken-pattern: v2
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 4

--- a/tests/functional_tests/test_cases/moe/gpt_dynamic_inference_tp4_pp1_ep4_16B_prefix_caching/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt_dynamic_inference_tp4_pp1_ep4_16B_prefix_caching/model_config.yaml
@@ -15,7 +15,7 @@ MODEL_ARGS:
   --tokenizer-model: ${CHECKPOINT_LOAD_PATH}/model/deepseek_16b_pyt/dcp/mcore-v1_bf16/multiMixV8.gpt4o_nc_sd.500000.128k.vocab.json
   --tokenizer-type: TikTokenizer
   --tiktoken-pattern: v2
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 4

--- a/tests/functional_tests/test_cases/moe/gpt_grpo_tp8tp4_pp1_ep8ep2_dp8_throughputtest/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt_grpo_tp8tp4_pp1_ep8ep2_dp8_throughputtest/model_config.yaml
@@ -77,7 +77,7 @@ MODEL_ARGS:
   --max-position-embeddings: 256
 
   # Training settings
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --transformer-impl: transformer_engine
   --bf16: true
   --attention-backend: flash

--- a/tests/functional_tests/test_cases/moe/gpt_static_inference_cuda_graphs_pad_tp4_pp1_ep4_16B_logitsmatch/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt_static_inference_cuda_graphs_pad_tp4_pp1_ep4_16B_logitsmatch/model_config.yaml
@@ -15,7 +15,7 @@ MODEL_ARGS:
   --tokenizer-model: ${CHECKPOINT_LOAD_PATH}/model/deepseek_16b_pyt/dcp/mcore-v1_bf16/multiMixV8.gpt4o_nc_sd.500000.128k.vocab.json
   --tokenizer-type: TikTokenizer
   --tiktoken-pattern: v2
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 4

--- a/tests/functional_tests/test_cases/moe/gpt_static_inference_tp1_pp1_ep1_16B_logitsmatch/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt_static_inference_tp1_pp1_ep1_16B_logitsmatch/model_config.yaml
@@ -15,7 +15,7 @@ MODEL_ARGS:
   --tokenizer-model: ${CHECKPOINT_LOAD_PATH}/model/deepseek_16b_pyt/dcp/mcore-v1_bf16/multiMixV8.gpt4o_nc_sd.500000.128k.vocab.json
   --tokenizer-type: TikTokenizer
   --tiktoken-pattern: v2
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 1

--- a/tests/functional_tests/test_cases/moe/gpt_static_inference_tp4_pp1_ep4_16B_logitsmatch/model_config.yaml
+++ b/tests/functional_tests/test_cases/moe/gpt_static_inference_tp4_pp1_ep4_16B_logitsmatch/model_config.yaml
@@ -15,7 +15,7 @@ MODEL_ARGS:
   --tokenizer-model: ${CHECKPOINT_LOAD_PATH}/model/deepseek_16b_pyt/dcp/mcore-v1_bf16/multiMixV8.gpt4o_nc_sd.500000.128k.vocab.json
   --tokenizer-type: TikTokenizer
   --tiktoken-pattern: v2
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --log-interval: 1
   --transformer-impl: transformer_engine
   --tensor-model-parallel-size: 4

--- a/tests/functional_tests/test_cases/multimodal-llava/multimodal_llava_mcore_te_tp1_pp1/model_config.yaml
+++ b/tests/functional_tests/test_cases/multimodal-llava/multimodal_llava_mcore_te_tp1_pp1/model_config.yaml
@@ -26,7 +26,7 @@ MODEL_ARGS:
   --split: 949,50,1
   --tokenizer-type: NullTokenizer
   --vocab-size: 8193
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/multimodal-llava/multimodal_llava_mcore_te_tp4_sp_cp2/model_config.yaml
+++ b/tests/functional_tests/test_cases/multimodal-llava/multimodal_llava_mcore_te_tp4_sp_cp2/model_config.yaml
@@ -28,7 +28,7 @@ MODEL_ARGS:
   --split: 949,50,1
   --tokenizer-type: NullTokenizer
   --vocab-size: 8193
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --lr: 0.00015
   --lr-decay-style: cosine
   --min-lr: 1.0e-5

--- a/tests/functional_tests/test_cases/t5/t5_11b_mcore_tp4_pp1/model_config.yaml
+++ b/tests/functional_tests/test_cases/t5/t5_11b_mcore_tp4_pp1/model_config.yaml
@@ -46,7 +46,7 @@ MODEL_ARGS:
   --save-interval: 10000
   --eval-interval: 1000
   --eval-iters: 10
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --data-cache-path: ${DATA_CACHE_PATH}
   --deterministic-mode: true
   --ckpt-format: torch_dist

--- a/tests/functional_tests/test_cases/t5/t5_mcore_te_tp1_pp1_vp1_resume_torch/model_config.yaml
+++ b/tests/functional_tests/test_cases/t5/t5_mcore_te_tp1_pp1_vp1_resume_torch/model_config.yaml
@@ -46,7 +46,7 @@ MODEL_ARGS:
   --save-interval: 50
   --eval-interval: 1000
   --eval-iters: 10
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --data-cache-path: ${DATA_CACHE_PATH}
   --deterministic-mode: true
   --attention-softmax-in-fp32: true

--- a/tests/functional_tests/test_cases/t5/t5_mcore_te_tp2_pp1_vp1/model_config.yaml
+++ b/tests/functional_tests/test_cases/t5/t5_mcore_te_tp2_pp1_vp1/model_config.yaml
@@ -46,7 +46,7 @@ MODEL_ARGS:
   --save-interval: 10000
   --eval-interval: 1000
   --eval-iters: 10
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --data-cache-path: ${DATA_CACHE_PATH}
   --deterministic-mode: true
   --attention-softmax-in-fp32: true

--- a/tests/functional_tests/test_cases/t5/t5_mcore_te_tp2_pp1_vp1_sequence_parallel/model_config.yaml
+++ b/tests/functional_tests/test_cases/t5/t5_mcore_te_tp2_pp1_vp1_sequence_parallel/model_config.yaml
@@ -46,7 +46,7 @@ MODEL_ARGS:
   --save-interval: 10000
   --eval-interval: 1000
   --eval-iters: 10
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --data-cache-path: ${DATA_CACHE_PATH}
   --sequence-parallel: true
   --deterministic-mode: true

--- a/tests/functional_tests/test_cases/t5/t5_mcore_te_tp4_pp1/model_config.yaml
+++ b/tests/functional_tests/test_cases/t5/t5_mcore_te_tp4_pp1/model_config.yaml
@@ -46,7 +46,7 @@ MODEL_ARGS:
   --save-interval: 10000
   --eval-interval: 1000
   --eval-iters: 10
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --data-cache-path: ${DATA_CACHE_PATH}
   --deterministic-mode: true
   --ckpt-format: torch_dist

--- a/tests/functional_tests/test_cases/t5/t5_mcore_te_tp4_pp1_resume_torch_dist/model_config.yaml
+++ b/tests/functional_tests/test_cases/t5/t5_mcore_te_tp4_pp1_resume_torch_dist/model_config.yaml
@@ -46,7 +46,7 @@ MODEL_ARGS:
   --save-interval: 50
   --eval-interval: 1000
   --eval-iters: 10
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --data-cache-path: ${DATA_CACHE_PATH}
   --deterministic-mode: true
   --ckpt-format: torch_dist

--- a/tests/functional_tests/test_cases/t5/t5_mcore_tp1_pp1_vp1/model_config.yaml
+++ b/tests/functional_tests/test_cases/t5/t5_mcore_tp1_pp1_vp1/model_config.yaml
@@ -46,7 +46,7 @@ MODEL_ARGS:
   --save-interval: 10000
   --eval-interval: 1000
   --eval-iters: 10
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --data-cache-path: ${DATA_CACHE_PATH}
   --deterministic-mode: true
   --ckpt-format: torch

--- a/tests/functional_tests/test_cases/t5/t5_mcore_tp1_pp1_vp1_resume_torch/model_config.yaml
+++ b/tests/functional_tests/test_cases/t5/t5_mcore_tp1_pp1_vp1_resume_torch/model_config.yaml
@@ -46,7 +46,7 @@ MODEL_ARGS:
   --save-interval: 50
   --eval-interval: 1000
   --eval-iters: 10
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --data-cache-path: ${DATA_CACHE_PATH}
   --deterministic-mode: true
   --ckpt-format: torch

--- a/tests/functional_tests/test_cases/t5/t5_mcore_tp2_pp1_vp1/model_config.yaml
+++ b/tests/functional_tests/test_cases/t5/t5_mcore_tp2_pp1_vp1/model_config.yaml
@@ -46,7 +46,7 @@ MODEL_ARGS:
   --save-interval: 10000
   --eval-interval: 1000
   --eval-iters: 10
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --data-cache-path: ${DATA_CACHE_PATH}
   --deterministic-mode: true
   --ckpt-format: torch

--- a/tests/functional_tests/test_cases/t5/t5_mcore_tp4_pp1/model_config.yaml
+++ b/tests/functional_tests/test_cases/t5/t5_mcore_tp4_pp1/model_config.yaml
@@ -46,7 +46,7 @@ MODEL_ARGS:
   --save-interval: 10000
   --eval-interval: 1000
   --eval-iters: 10
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --data-cache-path: ${DATA_CACHE_PATH}
   --deterministic-mode: true
   --ckpt-format: torch_dist

--- a/tests/functional_tests/test_cases/t5/t5_mcore_tp4_pp1_resume_torch_dist/model_config.yaml
+++ b/tests/functional_tests/test_cases/t5/t5_mcore_tp4_pp1_resume_torch_dist/model_config.yaml
@@ -46,7 +46,7 @@ MODEL_ARGS:
   --save-interval: 50
   --eval-interval: 1000
   --eval-iters: 10
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   --data-cache-path: ${DATA_CACHE_PATH}
   --deterministic-mode: true
   --ckpt-format: torch_dist

--- a/tests/functional_tests/test_cases/t5/t5_release/model_config.yaml
+++ b/tests/functional_tests/test_cases/t5/t5_release/model_config.yaml
@@ -29,7 +29,7 @@ MODEL_ARGS:
   --lr-decay-style: linear
   --min-lr: 1.0e-5
   --lr-warmup-fraction: .01
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   # Transformer Engine args
   --use-mcore-models: true
   --transformer-impl: transformer_engine

--- a/tests/functional_tests/test_cases/t5/t5_release_sm/model_config.yaml
+++ b/tests/functional_tests/test_cases/t5/t5_release_sm/model_config.yaml
@@ -29,7 +29,7 @@ MODEL_ARGS:
   --lr-decay-style: linear
   --min-lr: 1.0e-5
   --lr-warmup-fraction: .01
-  --distributed-backend: nccl
+  --distributed-backend: nccl2
   # Transformer Engine args
   --use-mcore-models: true
   --transformer-impl: transformer_engine

--- a/tests/unit_tests/a2a_overlap/utils.py
+++ b/tests/unit_tests/a2a_overlap/utils.py
@@ -354,7 +354,17 @@ def build_expert_device_mesh():
 
     expt_dp_group = parallel_state.get_expert_data_parallel_group()
     expt_dp_ranks = torch.distributed.get_process_group_ranks(expt_dp_group)
-    expt_tp_group = torch.distributed.new_group(ranks=[torch.distributed.get_rank()])
+    # Degenerate 1-rank placeholder TP group. Every rank passes a different
+    # ranks list, so this is a members-only new_group (no split_group): with
+    # use_local_synchronization=True there are no non-members to drive through
+    # new_group's eager no-color-split path, which nccl2 does not implement,
+    # and the group name is hashed from [my_rank] instead of the (rank-identical)
+    # _world.group_count, so the per-rank groups get distinct PrefixStores.
+    expt_tp_group = parallel_state.create_group(
+        ranks=[torch.distributed.get_rank()],
+        use_local_synchronization=True,
+        group_desc="SINGLE_RANK_GROUP",
+    )
     return DeviceMesh.from_group(
         [expt_dp_group, expt_tp_group],
         device_type="cuda",

--- a/tests/unit_tests/dist_checkpointing/test_replication.py
+++ b/tests/unit_tests/dist_checkpointing/test_replication.py
@@ -11,6 +11,7 @@ import pytest
 import torch
 import torch.distributed as dist
 
+import megatron.core.parallel_state as ps
 from megatron.training.arguments import parse_args
 
 nvidia_resiliency_ext = pytest.importorskip(
@@ -60,11 +61,16 @@ def test_all_gather_batch(tp, pp):
     t1 = torch.arange(6, device="cuda").reshape((3, 1, 2))
     t2 = torch.arange(12, device="cuda").reshape((2, 3, 2))
     test_ranks = [0, 3, 7]
-    test_group = GroupWrapper(dist.new_group(test_ranks))
+    # split_group, not new_group: test_ranks is a strict subset of the world, so
+    # an eager new_group would push the remaining ranks through
+    # performNocolorSplit, which the nccl2 backend does not implement. Every rank
+    # still enters the (collective) split; non-members get None back.
+    test_pg = ps.create_split_groups([test_ranks], group_desc="REPLICATION_TEST_GROUP")
     rank = dist.get_rank()
     if rank not in test_ranks:
         dist.barrier()
         return
+    test_group = GroupWrapper(test_pg)
     batch = [[t1, t2], [t0], []]
     pred_batch = test_group.all_gather_batch(batch[test_group.my_group_rank])
     assert equal_(batch, pred_batch)
@@ -108,7 +114,12 @@ class TestLocalCheckpointingReplication:
             mock_args.non_persistent_local_ckpt_algo = algo
             mock_args.async_save = async_save
             mock_args.ckpt_fully_parallel_save = True  # ensure proper sharding_type is set
-            repl_groups_init = [dist.new_group(g) for g in repl_groups]
+            # ``repl_groups`` is a covering partition of the world, so the whole
+            # family is built with a single split_group collective; this rank
+            # only ever needs a handle to the one group it belongs to.
+            repl_groups_init = [
+                ps.create_split_groups(repl_groups, group_desc="REPLICATION_GROUP")
+            ]
             my_process_group = GroupWrapper.from_list_of_groups(repl_groups_init)
             repl_strategy = CliqueReplicationStrategy(my_process_group, target_device="cpu")
             self.checkpointing_context = {

--- a/tests/unit_tests/distributed/megatron_fsdp/test_mcore_fully_sharded_data_parallel.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_mcore_fully_sharded_data_parallel.py
@@ -33,7 +33,7 @@ from tests.unit_tests.distributed.megatron_fsdp.utils import (
     pretrain_forward_backward,
     set_manual_seed,
 )
-from tests.unit_tests.test_utilities import Utils
+from tests.unit_tests.test_utilities import Utils, ensure_distributed_initialized
 
 
 # Test model for testing FSDP
@@ -198,8 +198,7 @@ class TestFullyShardedDataParallel:
             pytest.skip("Megatron FSDP requires torch >= 2.4.0")
 
         # Initialize torch.distributed if not already initialized
-        if not torch.distributed.is_initialized():
-            torch.distributed.init_process_group(backend='nccl')
+        ensure_distributed_initialized()
 
         # Skip test if we don't have enough GPUs
         world_size = torch.distributed.get_world_size()
@@ -502,8 +501,7 @@ class TestFullyShardedDataParallel:
             pytest.skip("nccl_ub requires PyTorch 2.7.0 or later")
 
         # Initialize torch.distributed if not already initialized
-        if not torch.distributed.is_initialized():
-            torch.distributed.init_process_group(backend='nccl')
+        ensure_distributed_initialized()
 
         # Skip test if we don't have enough GPUs
         world_size = torch.distributed.get_world_size()

--- a/tests/unit_tests/distributed/test_distributed_data_parallel.py
+++ b/tests/unit_tests/distributed/test_distributed_data_parallel.py
@@ -9,7 +9,7 @@ from megatron.core.distributed import DistributedDataParallel, DistributedDataPa
 from megatron.core.hyper_comm_grid import HyperCommGrid
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.transformer import TransformerConfig
-from tests.unit_tests.test_utilities import Utils
+from tests.unit_tests.test_utilities import Utils, ensure_distributed_initialized
 
 
 # Test model for testing DDP
@@ -74,8 +74,7 @@ class TestDistributedDataParallel:
         )
 
         # Initialize torch.distributed if not already initialized
-        if not torch.distributed.is_initialized():
-            torch.distributed.init_process_group(backend='nccl')
+        ensure_distributed_initialized()
 
         # Create HyperCommGrid with dimension ep, pp, dp (reversed from device mesh order)
         grid = HyperCommGrid([1, 1, 1, 1, dp_size], ["tp", "cp", "ep", "pp", "dp"])

--- a/tests/unit_tests/inference/test_communication_utils.py
+++ b/tests/unit_tests/inference/test_communication_utils.py
@@ -12,7 +12,7 @@ from megatron.core.inference.communication_utils import (
     send_to_next_pipeline_rank,
 )
 from megatron.core.utils import is_torch_min_version
-from tests.unit_tests.test_utilities import Utils
+from tests.unit_tests.test_utilities import Utils, ensure_distributed_initialized
 
 
 class TestCommunicationWithCustomPPGroup:
@@ -53,8 +53,7 @@ class TestCommunicationWithCustomPPGroup:
         )
 
         # Initialize torch.distributed if not already initialized
-        if not dist.is_initialized():
-            dist.init_process_group(backend='nccl')
+        ensure_distributed_initialized()
 
         # Note: HyperCommGrid uses minor-to-major order (tp, pp), which is reverse of device mesh
         grid = HyperCommGrid([tp_size, pp_size], ["tp", "pp"])
@@ -111,8 +110,7 @@ class TestCommunicationWithCustomPPGroup:
         dist.barrier()
 
         # Initialize torch.distributed if not already initialized
-        if not dist.is_initialized():
-            dist.init_process_group(backend='nccl')
+        ensure_distributed_initialized()
 
         # Note: HyperCommGrid uses minor-to-major order (tp, pp), which is reverse of device mesh
         grid = HyperCommGrid([tp_size, pp_size], ["tp", "pp"])

--- a/tests/unit_tests/models/mimo/test_mimo_1f1b_schedule.py
+++ b/tests/unit_tests/models/mimo/test_mimo_1f1b_schedule.py
@@ -38,7 +38,7 @@ from megatron.core.process_groups_config import (
 from megatron.core.transformer.mlp import MLP, MLPSubmodules
 from megatron.core.transformer.spec_utils import ModuleSpec
 from megatron.core.transformer.transformer_config import TransformerConfig
-from tests.unit_tests.test_utilities import Utils
+from tests.unit_tests.test_utilities import Utils, create_embedding_groups
 
 try:
     from megatron.core.extensions.transformer_engine import (
@@ -87,7 +87,6 @@ def create_hypercomm_grid(offset=0, tp=1, cp=1, pp=1, dp=1):
         shape=[tp, cp, pp, dp, 1, 1],  # [tp, cp, pp, dp, ep, expt_dp]
         dim_names=["tp", "cp", "pp", "dp", "ep", "expt_dp"],
         rank_offset=offset,
-        backend="nccl",
     )
     grid.create_pg(["tp"])
     grid.create_pg(["cp"])
@@ -128,12 +127,24 @@ def get_pg_collection(grid):
     return pg_collection
 
 
+def _embedding_cache_key(grid):
+    """Cache key for a grid's embedding groups: its whole PP partition.
+
+    Keyed on the full partition, not on this rank's slice, so the key is
+    identical on every rank and the create/hit sequence below stays in lockstep.
+    """
+    return tuple(tuple(r) for r in grid.get_rank_enum("pp"))
+
+
 def create_all_embedding_groups(grids):
     """Create embedding PGs for all grids upfront.
 
-    dist.new_group is a collective — ALL ranks must call it, even non-members.
+    Group creation is a collective — ALL ranks must call it, even non-members.
     We create all embedding groups in a consistent order across all ranks to
-    avoid hangs from asymmetric new_group calls.
+    avoid hangs from asymmetric calls. Each family is built with a single
+    ``split_group`` over the grid's full PP partition; a per-PP-group
+    ``new_group`` would instead drive non-member ranks through
+    ``performNocolorSplit``, which the ``nccl2`` backend does not implement.
 
     Args:
         grids: List of all HyperCommGrids that need embedding groups.
@@ -143,35 +154,27 @@ def create_all_embedding_groups(grids):
         if not pp_group:
             continue
 
-        pp_ranks = sorted(dist.get_process_group_ranks(pp_group))
-        cache_key = tuple(pp_ranks)
+        cache_key = _embedding_cache_key(grid)
 
         if cache_key not in _embedding_pg_cache:
-            pos_embd_ranks = [pp_ranks[0]]
-            embd_ranks = [pp_ranks[0]]
-            if pp_ranks[-1] != pp_ranks[0]:
-                embd_ranks.append(pp_ranks[-1])
-            _embedding_pg_cache[cache_key] = (
-                dist.new_group(ranks=pos_embd_ranks),
-                dist.new_group(ranks=embd_ranks),
-            )
+            embd_pg, pos_embd_pg = create_embedding_groups(grid)
+            _embedding_pg_cache[cache_key] = (pos_embd_pg, embd_pg)
 
 
-def add_embedding_groups(pg_collection, is_language_model=False):
+def add_embedding_groups(pg_collection, grid, is_language_model=False):
     """Add cached embedding groups to a process group collection.
 
     Must call create_all_embedding_groups() first to ensure PGs exist.
 
     Args:
         pg_collection: ProcessGroupCollection to add embedding groups to.
+        grid: The HyperCommGrid the collection was derived from.
         is_language_model: If True, set embd group for word embedding sync.
     """
     if not pg_collection.pp:
         return pg_collection
 
-    pp_ranks = sorted(dist.get_process_group_ranks(pg_collection.pp))
-    cache_key = tuple(pp_ranks)
-    pos_embd_pg, embd_pg = _embedding_pg_cache[cache_key]
+    pos_embd_pg, embd_pg = _embedding_pg_cache[_embedding_cache_key(grid)]
 
     pg_collection.pos_embd = pos_embd_pg if is_pp_first_stage(pg_collection.pp) else None
 
@@ -190,7 +193,7 @@ def add_embedding_groups(pg_collection, is_language_model=False):
 
 def get_pg_collection_with_embedding_groups(grid, is_language_model=False):
     """Get ProcessGroupCollection with embedding groups (PGs must be pre-created)."""
-    return add_embedding_groups(get_pg_collection(grid), is_language_model=is_language_model)
+    return add_embedding_groups(get_pg_collection(grid), grid, is_language_model=is_language_model)
 
 
 def is_rank_in_grid(grid):

--- a/tests/unit_tests/models/mimo/test_mimo_colocated_communicator.py
+++ b/tests/unit_tests/models/mimo/test_mimo_colocated_communicator.py
@@ -9,6 +9,7 @@ import torch.distributed as dist
 
 from megatron.core.hyper_comm_grid import HyperCommGrid
 from megatron.core.models.mimo.comm.colocated_communicator import ColocatedBridgeCommunicator
+from tests.unit_tests.test_utilities import ensure_distributed_initialized
 
 logging.basicConfig(level=logging.DEBUG, stream=sys.stderr)
 
@@ -21,7 +22,6 @@ def create_hypercomm_grid(offset=0, tp=1, cp=1, pp=1, dp=1):
         shape=[tp, cp, pp, dp],
         dim_names=["tp", "cp", "pp", "dp"],
         rank_offset=offset,
-        backend="nccl",
     )
     grid.create_pg(["tp"])
     grid.create_pg(["cp"])
@@ -56,8 +56,7 @@ class TestRankMappings:
 
     @classmethod
     def setup_class(cls):
-        if not dist.is_initialized():
-            dist.init_process_group(backend="nccl")
+        ensure_distributed_initialized()
         if torch.cuda.is_available():
             torch.cuda.set_device(int(os.environ.get("LOCAL_RANK", 0)))
 
@@ -154,8 +153,7 @@ class TestAllGatherGroups:
 
     @classmethod
     def setup_class(cls):
-        if not dist.is_initialized():
-            dist.init_process_group(backend="nccl")
+        ensure_distributed_initialized()
         if torch.cuda.is_available():
             torch.cuda.set_device(int(os.environ.get("LOCAL_RANK", 0)))
 
@@ -197,8 +195,7 @@ class TestValidateGrids:
 
     @classmethod
     def setup_class(cls):
-        if not dist.is_initialized():
-            dist.init_process_group(backend="nccl")
+        ensure_distributed_initialized()
         if torch.cuda.is_available():
             torch.cuda.set_device(int(os.environ.get("LOCAL_RANK", 0)))
 
@@ -207,7 +204,7 @@ class TestValidateGrids:
 
     def _grid_missing_tp(self, offset=0, dp=1):
         # Build a grid without a 'tp' dim to exercise the "missing 'tp'" raise.
-        grid = HyperCommGrid(shape=[dp], dim_names=["dp"], rank_offset=offset, backend="nccl")
+        grid = HyperCommGrid(shape=[dp], dim_names=["dp"], rank_offset=offset)
         grid.create_pg(["dp"])
         _active_grids.append(grid)
         return grid
@@ -255,12 +252,8 @@ class TestValidateGrids:
         # Fits inside an 8-rank world (HyperCommGrid enforces size <= world - offset).
         if dist.get_world_size() < 6:
             pytest.skip("requires at least 6 ranks")
-        src_grid = HyperCommGrid(
-            shape=[2, 1, 1, 3], dim_names=["tp", "cp", "pp", "dp"], backend="nccl"
-        )
-        dest_grid = HyperCommGrid(
-            shape=[3, 1, 1, 2], dim_names=["tp", "cp", "pp", "dp"], backend="nccl"
-        )
+        src_grid = HyperCommGrid(shape=[2, 1, 1, 3], dim_names=["tp", "cp", "pp", "dp"])
+        dest_grid = HyperCommGrid(shape=[3, 1, 1, 2], dim_names=["tp", "cp", "pp", "dp"])
         for g in (src_grid, dest_grid):
             _active_grids.append(g)
         with pytest.raises(ValueError, match="evenly divisible"):
@@ -275,8 +268,7 @@ class TestCommunicatePreconditions:
 
     @classmethod
     def setup_class(cls):
-        if not dist.is_initialized():
-            dist.init_process_group(backend="nccl")
+        ensure_distributed_initialized()
         if torch.cuda.is_available():
             torch.cuda.set_device(int(os.environ.get("LOCAL_RANK", 0)))
 
@@ -313,8 +305,7 @@ class TestDestroy:
 
     @classmethod
     def setup_class(cls):
-        if not dist.is_initialized():
-            dist.init_process_group(backend="nccl")
+        ensure_distributed_initialized()
         if torch.cuda.is_available():
             torch.cuda.set_device(int(os.environ.get("LOCAL_RANK", 0)))
 
@@ -394,8 +385,7 @@ class TestBridgeGradients:
 
     @classmethod
     def setup_class(cls):
-        if not dist.is_initialized():
-            dist.init_process_group(backend="nccl")
+        ensure_distributed_initialized()
         if torch.cuda.is_available():
             torch.cuda.set_device(int(os.environ.get("LOCAL_RANK", 0)))
 

--- a/tests/unit_tests/models/test_gpt_model.py
+++ b/tests/unit_tests/models/test_gpt_model.py
@@ -2,7 +2,6 @@
 
 import inspect
 import os
-from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -12,7 +11,6 @@ from packaging import version
 from pytest import approx
 from transformer_engine.pytorch.fp8 import check_fp8_support
 
-from megatron.core import parallel_state
 from megatron.core.hyper_comm_grid import HyperCommGrid
 from megatron.core.inference.config import InferenceConfig
 from megatron.core.inference.contexts.dynamic_context import DynamicInferenceContext
@@ -29,7 +27,7 @@ from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.module import Float16Module
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.utils import is_fa_min_version, is_te_min_version
-from tests.unit_tests.test_utilities import Utils
+from tests.unit_tests.test_utilities import Utils, create_embedding_groups
 
 
 class TestGPTModel:
@@ -400,12 +398,10 @@ class TestGPTModelWithCustomPG:
         cp_group = grid.create_pg("cp")
         pp_group = grid.create_pg("pp")
         ep_group = grid.create_pg("ep")
-        embd_group_ranks = parallel_state.default_embedding_ranks(
-            torch.distributed.get_process_group_ranks(pp_group)
-        )
-        embd_group = torch.distributed.new_group(
-            ranks=embd_group_ranks, timeout=timedelta(minutes=30)
-        )
+        # One split_group over the grid's full PP partition rather than a
+        # new_group over this rank's slice: an eager new_group would drive
+        # non-member ranks through performNocolorSplit, unimplemented in nccl2.
+        embd_group, _ = create_embedding_groups(grid)
         pg_collection = ProcessGroupCollection(
             tp=tp_group, cp=cp_group, pp=pp_group, ep=ep_group, embd=embd_group
         )

--- a/tests/unit_tests/models/test_hybrid_model.py
+++ b/tests/unit_tests/models/test_hybrid_model.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2024-2026, NVIDIA CORPORATION. All rights reserved.
 
 import os
-from datetime import timedelta
 from itertools import accumulate
 from types import SimpleNamespace
 
@@ -9,7 +8,6 @@ import pytest
 import torch
 from transformer_engine.pytorch.fp8 import check_fp8_support
 
-from megatron.core import parallel_state
 from megatron.core.hyper_comm_grid import HyperCommGrid
 from megatron.core.inference.config import InferenceConfig, MambaInferenceStateConfig
 from megatron.core.inference.contexts import BaseInferenceContext, StaticInferenceContext
@@ -26,7 +24,11 @@ from megatron.core.transformer import TransformerConfig
 from megatron.core.transformer.enums import AttnBackend
 from megatron.core.transformer.module import Float16Module
 from megatron.core.utils import divide, is_fa_min_version, is_torch_min_version
-from tests.unit_tests.test_utilities import Utils
+from tests.unit_tests.test_utilities import (
+    Utils,
+    create_embedding_groups,
+    ensure_distributed_initialized,
+)
 
 
 def test_hybrid_logging_process_groups_are_paired():
@@ -67,8 +69,7 @@ def test_hybrid_model_with_custom_process_groups(tmp_path, tp_size, cp_size, pp_
         assert torch.distributed.get_world_size() == 8, "Test requires 8 GPUs"
 
         # Initialize torch.distributed if not already initialized
-        if not torch.distributed.is_initialized():
-            torch.distributed.init_process_group(backend='nccl')
+        ensure_distributed_initialized()
 
         dp_size = 1
 
@@ -79,12 +80,10 @@ def test_hybrid_model_with_custom_process_groups(tmp_path, tp_size, cp_size, pp_
         cp_group = grid.create_pg("cp")
         tp_group = grid.create_pg("tp")
         dp_cp_group = grid.create_pg(["cp", "dp"])
-        embd_group_ranks = parallel_state.default_embedding_ranks(
-            torch.distributed.get_process_group_ranks(pp_group)
-        )
-        embd_group = torch.distributed.new_group(
-            ranks=embd_group_ranks, timeout=timedelta(minutes=30)
-        )
+        # One split_group over the grid's full PP partition rather than a
+        # new_group over this rank's slice: an eager new_group would drive
+        # non-member ranks through performNocolorSplit, unimplemented in nccl2.
+        embd_group, _ = create_embedding_groups(grid)
 
         # Create model with custom process groups
         from megatron.core.process_groups_config import ProcessGroupCollection

--- a/tests/unit_tests/pipeline_parallel/test_bridge_communicator.py
+++ b/tests/unit_tests/pipeline_parallel/test_bridge_communicator.py
@@ -23,7 +23,7 @@ from megatron.core.tensor_parallel.layers import ColumnParallelLinear, RowParall
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.transformer_block import TransformerBlock
 from megatron.core.transformer.transformer_config import TransformerConfig
-from tests.unit_tests.test_utilities import Utils
+from tests.unit_tests.test_utilities import Utils, ensure_distributed_initialized
 
 
 def _create_transformer_block(
@@ -126,7 +126,6 @@ def create_hypercomm_grid(offset=0, tp=1, cp=1, pp=1, dp=1):
         shape=[tp, cp, pp, dp],
         dim_names=["tp", "cp", "pp", "dp"],
         rank_offset=offset,
-        backend="nccl",
     )
     _ = grid.create_pg(["tp"])
     _ = grid.create_pg(["cp"])
@@ -275,8 +274,7 @@ class TestBridgeCommunicator:
     @classmethod
     def setup_class(cls):
         """Set up distributed environment for the entire test class."""
-        if not dist.is_initialized():
-            dist.init_process_group(backend="nccl")
+        ensure_distributed_initialized()
         if torch.cuda.is_available():
             torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
 

--- a/tests/unit_tests/pipeline_parallel/test_multimodule_communicator.py
+++ b/tests/unit_tests/pipeline_parallel/test_multimodule_communicator.py
@@ -21,7 +21,7 @@ from tests.unit_tests.pipeline_parallel.test_bridge_communicator import (
     destroy_all_grids,
     get_transformer_block_and_grid,
 )
-from tests.unit_tests.test_utilities import Utils
+from tests.unit_tests.test_utilities import Utils, ensure_distributed_initialized
 
 
 class TestMultiModulePipelineCommunicator:
@@ -29,8 +29,7 @@ class TestMultiModulePipelineCommunicator:
     @classmethod
     def setup_class(cls):
         """Set up distributed environment for the entire test class."""
-        if not dist.is_initialized():
-            dist.init_process_group(backend="nccl")
+        ensure_distributed_initialized()
         if torch.cuda.is_available():
             torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
 

--- a/tests/unit_tests/pipeline_parallel/test_multimodule_schedules.py
+++ b/tests/unit_tests/pipeline_parallel/test_multimodule_schedules.py
@@ -26,7 +26,7 @@ from megatron.core.process_groups_config import (
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.transformer_block import TransformerBlock
 from megatron.core.transformer.transformer_config import TransformerConfig
-from tests.unit_tests.test_utilities import Utils
+from tests.unit_tests.test_utilities import Utils, create_embedding_groups
 
 # ============================================================================
 # Helper Functions
@@ -42,7 +42,6 @@ def create_hypercomm_grid(offset=0, tp=1, pp=1, dp=1):
         shape=[tp, 1, pp, dp, 1, 1],  # [tp, cp, pp, dp, ep, expt_dp]
         dim_names=["tp", "cp", "pp", "dp", "ep", "expt_dp"],
         rank_offset=offset,
-        backend="nccl",
     )
     grid.create_pg(["tp"])
     grid.create_pg(["cp"])
@@ -80,23 +79,25 @@ def get_pg_collection(grid):
 _embedding_pg_cache: dict = {}
 
 
-def add_embedding_groups(pg_collection):
-    """Add embedding groups to process group collection."""
+def add_embedding_groups(pg_collection, grid):
+    """Add embedding groups to process group collection.
+
+    The embedding families are built from *grid*'s full PP partition with one
+    ``split_group`` collective each, not with a ``new_group`` per PP group: an
+    eager ``new_group`` sends non-member ranks through ``performNocolorSplit``,
+    which the ``nccl2`` backend does not implement. The cache is keyed on the
+    whole partition (identical on every rank), so the create/hit sequence stays
+    in lockstep across ranks.
+    """
     if not pg_collection.pp:
         return pg_collection
 
-    pp_ranks = sorted(dist.get_process_group_ranks(pg_collection.pp))
-    cache_key = tuple(pp_ranks)
+    pp_enum = grid.get_rank_enum("pp")
+    cache_key = tuple(tuple(r) for r in pp_enum)
 
     if cache_key not in _embedding_pg_cache:
-        pos_embd_ranks = [pp_ranks[0]]
-        embd_ranks = [pp_ranks[0]]
-        if pp_ranks[-1] != pp_ranks[0]:
-            embd_ranks.append(pp_ranks[-1])
-        _embedding_pg_cache[cache_key] = (
-            dist.new_group(ranks=pos_embd_ranks),
-            dist.new_group(ranks=embd_ranks),
-        )
+        embd, pos_embd = create_embedding_groups(grid)
+        _embedding_pg_cache[cache_key] = (pos_embd, embd)
 
     pos_embd_pg, embd_pg = _embedding_pg_cache[cache_key]
 
@@ -160,7 +161,7 @@ def create_module_with_grid(tp, pp, dp, grid_offset, hidden_size):
     grid = create_hypercomm_grid(offset=grid_offset, tp=tp, pp=pp, dp=dp)
 
     if grid.rank_offset <= rank < grid.rank_offset + grid.size:
-        pg_collection = add_embedding_groups(get_pg_collection(grid))
+        pg_collection = add_embedding_groups(get_pg_collection(grid), grid)
         module = create_transformer_block(hidden_size, pg_collection)
     else:
         pg_collection = None

--- a/tests/unit_tests/pipeline_parallel/test_schedules.py
+++ b/tests/unit_tests/pipeline_parallel/test_schedules.py
@@ -4,7 +4,6 @@ import os
 
 import pytest
 import torch
-import torch.distributed as dist
 from packaging import version
 from pytest_mock import mocker
 
@@ -19,24 +18,15 @@ from megatron.core.transformer.cuda_graphs import (
     convert_schedule_table_to_order,
     get_overlap_moe_expert_parallel_comm_order,
 )
-from tests.unit_tests.test_utilities import Utils
+from tests.unit_tests.test_utilities import Utils, create_embedding_groups
 
 rank = Utils.rank
 
 
-def _populate_embedding_and_position_groups(pp_group):
-    """Create *new* embedding-related process groups from *pp_group* ranks."""
+def _populate_embedding_and_position_groups(grid):
+    """Create *new* embedding-related process groups from *grid*'s PP partition."""
 
-    pp_ranks = sorted(dist.get_process_group_ranks(pp_group))
-
-    pos_embd_ranks = [pp_ranks[0]]
-    embd_ranks = [pp_ranks[0]]
-    if pp_ranks[-1] != pp_ranks[0]:
-        embd_ranks.append(pp_ranks[-1])
-
-    pos_embd_pg = dist.new_group(ranks=pos_embd_ranks)
-    embd_pg = dist.new_group(ranks=embd_ranks)
-
+    embd_pg, pos_embd_pg = create_embedding_groups(grid)
     return pos_embd_pg, embd_pg
 
 
@@ -575,7 +565,7 @@ def test_forward_backward_pipelining_without_interleaving_with_custom_pgs(mocker
 
     pp_group = grid.create_pg("pp")
     p2p_communicator = P2PCommunicator(pp_group=pp_group, config=config)
-    pos_embd_pg, embd_pg = _populate_embedding_and_position_groups(pp_group)
+    pos_embd_pg, embd_pg = _populate_embedding_and_position_groups(grid)
     pos_embd_pg = pos_embd_pg if is_pp_first_stage(pp_group) else None
     embd_pg = embd_pg if (is_pp_last_stage(pp_group) or is_pp_first_stage(pp_group)) else None
     dp_cp_group = grid.create_pg(["dp", "cp"])
@@ -671,7 +661,7 @@ def test_forward_backward_pipelining_with_interleaving_with_custom_pgs(mocker):
     grid = HyperCommGrid([1, 1, 4, 2], ["tp", "cp", "pp", "dp"])
     pp_group = grid.create_pg("pp")
     p2p_communicator = P2PCommunicator(pp_group=pp_group, config=config)
-    pos_embd_pg, embd_pg = _populate_embedding_and_position_groups(pp_group)
+    pos_embd_pg, embd_pg = _populate_embedding_and_position_groups(grid)
     pos_embd_pg = pos_embd_pg if is_pp_first_stage(pp_group) else None
     embd_pg = embd_pg if (is_pp_last_stage(pp_group) or is_pp_first_stage(pp_group)) else None
 
@@ -736,7 +726,7 @@ def test_forward_backward_no_pipelining_with_custom_pgs(mocker):
     pp_group = grid.create_pg("pp")
     tp_group = grid.create_pg("tp")
     cp_group = grid.create_pg("cp")
-    pos_embd_pg, embd_pg = _populate_embedding_and_position_groups(pp_group)
+    pos_embd_pg, embd_pg = _populate_embedding_and_position_groups(grid)
     dp_cp_group = grid.create_pg(["dp", "cp"])
 
     pg_collection = ProcessGroupCollection()

--- a/tests/unit_tests/resharding/test_model_swap.py
+++ b/tests/unit_tests/resharding/test_model_swap.py
@@ -25,7 +25,7 @@ from megatron.core.tensor_parallel.layers import ColumnParallelLinear, RowParall
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.cuda_graphs import CudaGraphManager, _CudagraphGlobalRecord
 from megatron.core.transformer.transformer_config import TransformerConfig
-from tests.unit_tests.test_utilities import Utils
+from tests.unit_tests.test_utilities import Utils, create_embedding_groups
 
 try:
     import nvshmem.core
@@ -70,12 +70,10 @@ def _build_pg_collection(
     tp_ep_pp_group = grid.create_pg(["tp", "ep", "pp"])
     dp_cp_group = grid.create_pg(["cp", "dp"])
     tp_dp_cp_group = grid.create_pg(["tp", "cp", "dp"])
-    embd_group_ranks = mpu.default_embedding_ranks(dist.get_process_group_ranks(pp_group))
-    embd_group = dist.new_group(ranks=embd_group_ranks)
-    pos_embd_group_ranks = mpu.default_position_embedding_ranks(
-        dist.get_process_group_ranks(pp_group)
-    )
-    pos_embd_group = dist.new_group(ranks=pos_embd_group_ranks)
+    # One split_group per family over the grid's full PP partition rather than a
+    # new_group over this rank's slice: an eager new_group would drive non-member
+    # ranks through performNocolorSplit, unimplemented in nccl2.
+    embd_group, pos_embd_group = create_embedding_groups(grid)
     return ProcessGroupCollection(
         tp=tp_group,
         cp=cp_group,

--- a/tests/unit_tests/test_hyper_comm_grid.py
+++ b/tests/unit_tests/test_hyper_comm_grid.py
@@ -9,6 +9,7 @@ import torch
 import torch.distributed as dist
 
 from megatron.core.hyper_comm_grid import HyperCommGrid
+from tests.unit_tests.test_utilities import ensure_distributed_initialized
 
 
 class TestHyperCommGrid:
@@ -120,11 +121,11 @@ class TestHyperCommGrid:
         expected = [[4, 5], [6, 7]]
         assert rank_enum == expected
 
-    @patch('torch.distributed.new_subgroups_by_enumeration')
-    def test_create_pg_single_dim(self, mock_new_subgroups):
+    @patch('megatron.core.parallel_state.create_split_groups')
+    def test_create_pg_single_dim(self, mock_create_split_groups):
         """Test create_pg for single dimension."""
         mock_pg = MagicMock(spec=dist.ProcessGroup)
-        mock_new_subgroups.return_value = (mock_pg, None)
+        mock_create_split_groups.return_value = mock_pg
 
         grid = HyperCommGrid([2, 4], ["tp", "dp"])
 
@@ -134,17 +135,17 @@ class TestHyperCommGrid:
         assert "tp" in grid._pgs
         assert grid._pgs["tp"] == mock_pg
 
-        # Verify the enumeration passed to new_subgroups_by_enumeration
-        args, kwargs = mock_new_subgroups.call_args
+        # Verify the enumeration passed to create_split_groups
+        args, kwargs = mock_create_split_groups.call_args
         expected_enum = [[0, 1], [2, 3], [4, 5], [6, 7]]
         assert args[0] == expected_enum
         assert kwargs["backend"] is None
 
-    @patch('torch.distributed.new_subgroups_by_enumeration')
-    def test_create_pg_multiple_dims(self, mock_new_subgroups):
+    @patch('megatron.core.parallel_state.create_split_groups')
+    def test_create_pg_multiple_dims(self, mock_create_split_groups):
         """Test create_pg for multiple dimensions."""
         mock_pg = MagicMock(spec=dist.ProcessGroup)
-        mock_new_subgroups.return_value = (mock_pg, None)
+        mock_create_split_groups.return_value = mock_pg
 
         grid = HyperCommGrid([2, 2, 2], ["tp", "cp", "dp"])
 
@@ -153,15 +154,15 @@ class TestHyperCommGrid:
         assert result == mock_pg
         assert "cp-tp" in grid._pgs
 
-        args, kwargs = mock_new_subgroups.call_args
+        args, kwargs = mock_create_split_groups.call_args
         expected_enum = [[0, 1, 2, 3], [4, 5, 6, 7]]
         assert args[0] == expected_enum
 
-    @patch('torch.distributed.new_subgroups_by_enumeration')
-    def test_create_pg_with_options(self, mock_new_subgroups):
+    @patch('megatron.core.parallel_state.create_split_groups')
+    def test_create_pg_with_options(self, mock_create_split_groups):
         """Test create_pg with additional options."""
         mock_pg = MagicMock(spec=dist.ProcessGroup)
-        mock_new_subgroups.return_value = (mock_pg, None)
+        mock_create_split_groups.return_value = mock_pg
 
         grid = HyperCommGrid([2, 4], ["tp", "dp"], backend="nccl")
 
@@ -172,15 +173,15 @@ class TestHyperCommGrid:
 
         assert result == mock_pg
 
-        args, kwargs = mock_new_subgroups.call_args
+        args, kwargs = mock_create_split_groups.call_args
         assert kwargs["backend"] == "nccl"
         assert kwargs["pg_options"] == mock_options
 
-    @patch('torch.distributed.new_subgroups_by_enumeration')
-    def test_create_pg_duplicate_error(self, mock_new_subgroups):
+    @patch('megatron.core.parallel_state.create_split_groups')
+    def test_create_pg_duplicate_error(self, mock_create_split_groups):
         """Test create_pg raises error when trying to recreate existing process group."""
         mock_pg = MagicMock(spec=dist.ProcessGroup)
-        mock_new_subgroups.return_value = (mock_pg, None)
+        mock_create_split_groups.return_value = mock_pg
 
         grid = HyperCommGrid([2, 4], ["tp", "dp"])
 
@@ -191,11 +192,11 @@ class TestHyperCommGrid:
         with pytest.raises(KeyError, match="Process group.*has already been created"):
             grid.create_pg("tp")
 
-    @patch('torch.distributed.new_subgroups_by_enumeration')
-    def test_get_pg_success(self, mock_new_subgroups):
+    @patch('megatron.core.parallel_state.create_split_groups')
+    def test_get_pg_success(self, mock_create_split_groups):
         """Test get_pg returns existing process group."""
         mock_pg = MagicMock(spec=dist.ProcessGroup)
-        mock_new_subgroups.return_value = (mock_pg, None)
+        mock_create_split_groups.return_value = mock_pg
 
         grid = HyperCommGrid([2, 4], ["tp", "dp"])
 
@@ -213,11 +214,11 @@ class TestHyperCommGrid:
         with pytest.raises(KeyError, match="Process group for.*hasn't been created"):
             grid.get_pg("tp")
 
-    @patch('torch.distributed.new_subgroups_by_enumeration')
-    def test_get_pg_multiple_dims(self, mock_new_subgroups):
+    @patch('megatron.core.parallel_state.create_split_groups')
+    def test_get_pg_multiple_dims(self, mock_create_split_groups):
         """Test get_pg with multiple dimensions."""
         mock_pg = MagicMock(spec=dist.ProcessGroup)
-        mock_new_subgroups.return_value = (mock_pg, None)
+        mock_create_split_groups.return_value = mock_pg
 
         grid = HyperCommGrid([2, 2, 2], ["tp", "cp", "dp"])
 
@@ -251,12 +252,12 @@ class TestHyperCommGrid:
         # Clean up
         os.environ["WORLD_SIZE"] = "8"
 
-    @patch('torch.distributed.new_subgroups_by_enumeration')
-    def test_end_to_end_workflow(self, mock_new_subgroups):
+    @patch('megatron.core.parallel_state.create_split_groups')
+    def test_end_to_end_workflow(self, mock_create_split_groups):
         """Test complete workflow: init -> create -> get."""
         mock_pg1 = MagicMock(spec=dist.ProcessGroup)
         mock_pg2 = MagicMock(spec=dist.ProcessGroup)
-        mock_new_subgroups.side_effect = [(mock_pg1, None), (mock_pg2, None)]
+        mock_create_split_groups.side_effect = [mock_pg1, mock_pg2]
 
         grid = HyperCommGrid([2, 2, 2], ["tp", "cp", "dp"])
 
@@ -448,11 +449,11 @@ class TestHyperCommGrid:
         with pytest.raises(KeyError, match="for view 'expert' hasn't been created"):
             grid.get_pg("ep", view="expert")
 
-    @patch('torch.distributed.new_subgroups_by_enumeration')
-    def test_create_pg_with_view_uses_view_rank_order(self, mock_new_subgroups):
+    @patch('megatron.core.parallel_state.create_split_groups')
+    def test_create_pg_with_view_uses_view_rank_order(self, mock_create_split_groups):
         """Test view-scoped create_pg uses the selected view's rank generation order."""
         mock_pg = MagicMock(spec=dist.ProcessGroup)
-        mock_new_subgroups.return_value = (mock_pg, None)
+        mock_create_split_groups.return_value = mock_pg
 
         grid = HyperCommGrid([2, 2, 2], ["tp", "dp", "pp"])
         grid.register_view("expert", [2, 2, 2], ["expt_tp", "ep", "pp"], shared_dims=["pp"])
@@ -461,14 +462,14 @@ class TestHyperCommGrid:
 
         assert result == mock_pg
         assert ("expert", ("ep", "expt_tp")) in grid._pgs
-        args, _ = mock_new_subgroups.call_args
+        args, _ = mock_create_split_groups.call_args
         assert args[0] == [[0, 1, 2, 3], [4, 5, 6, 7]]
 
-    @patch('torch.distributed.new_subgroups_by_enumeration')
-    def test_shared_view_dim_reuses_base_process_group(self, mock_new_subgroups):
+    @patch('megatron.core.parallel_state.create_split_groups')
+    def test_shared_view_dim_reuses_base_process_group(self, mock_create_split_groups):
         """Test fully-shared view dims canonicalize to the base process group."""
         base_pp = MagicMock(spec=dist.ProcessGroup)
-        mock_new_subgroups.return_value = (base_pp, None)
+        mock_create_split_groups.return_value = base_pp
 
         grid = HyperCommGrid([2, 2, 2], ["tp", "dp", "pp"])
         grid.register_view("expert", [2, 2, 2], ["expt_tp", "ep", "pp"], shared_dims=["pp"])
@@ -503,11 +504,13 @@ class TestHyperCommGrid:
         assert grid._pgs == {}
 
     @patch('torch.distributed.is_initialized', return_value=False)
-    @patch('torch.distributed.new_subgroups_by_enumeration')
-    def test_create_pg_skips_log_when_not_initialized(self, mock_new_subgroups, _mock_is_init):
+    @patch('megatron.core.parallel_state.create_split_groups')
+    def test_create_pg_skips_log_when_not_initialized(
+        self, mock_create_split_groups, _mock_is_init
+    ):
         """Test create_pg does not call get_rank when torch.distributed is not initialized."""
         mock_pg = MagicMock(spec=dist.ProcessGroup)
-        mock_new_subgroups.return_value = (mock_pg, None)
+        mock_create_split_groups.return_value = mock_pg
 
         grid = HyperCommGrid([2, 4], ["tp", "dp"])
 
@@ -526,7 +529,7 @@ class TestHyperCommGridIntegration:
             # Initialize PyTorch distributed with NCCL backend
             # This assumes proper environment variables are set (RANK, WORLD_SIZE, MASTER_ADDR, MASTER_PORT)
             try:
-                dist.init_process_group(backend="nccl")
+                ensure_distributed_initialized()
                 cls.distributed_initialized = True
             except Exception as e:
                 pytest.skip(f"Cannot initialize distributed: {e}")

--- a/tests/unit_tests/test_nccl_allocator.py
+++ b/tests/unit_tests/test_nccl_allocator.py
@@ -6,6 +6,7 @@ import torch
 from packaging import version
 
 import megatron.core.nccl_allocator as nccl_allocator
+import megatron.core.parallel_state as ps
 from tests.unit_tests.test_utilities import Utils
 
 
@@ -42,7 +43,12 @@ class TestNCCLAllocator:
         torch.cuda.set_device(device)
 
         # Default process group and backend
-        pg = torch.distributed.new_group(ranks=list(range(world_size)), backend="nccl")
+        # split_group over the world PG, inheriting the world's cuda backend.
+        # Do not hardcode "nccl": that would pin a stock ProcessGroupNCCL child
+        # under an nccl2 world and silently stop exercising nccl2 here.
+        pg = ps.create_split_groups(
+            [list(range(world_size))], group_desc="NCCL_ALLOCATOR_TEST_GROUP"
+        )
 
         nccl_allocator.init()
 
@@ -78,7 +84,12 @@ class TestNCCLAllocator:
         device = torch.device("cuda", torch.cuda.current_device())
         torch.cuda.set_device(device)
 
-        pg = torch.distributed.new_group(ranks=list(range(world_size)), backend="nccl")
+        # split_group over the world PG, inheriting the world's cuda backend.
+        # Do not hardcode "nccl": that would pin a stock ProcessGroupNCCL child
+        # under an nccl2 world and silently stop exercising nccl2 here.
+        pg = ps.create_split_groups(
+            [list(range(world_size))], group_desc="NCCL_ALLOCATOR_TEST_GROUP"
+        )
 
         nccl_allocator.init()
 

--- a/tests/unit_tests/test_optimizer.py
+++ b/tests/unit_tests/test_optimizer.py
@@ -12,6 +12,7 @@ from torch.optim import SGD, Adam
 # FP8 recipe will be used to test precision-aware-optimizer.
 from transformer_engine.pytorch.fp8 import fp8_autocast
 
+import megatron.core.parallel_state as ps
 from megatron.core.distributed import DistributedDataParallel, DistributedDataParallelConfig
 from megatron.core.optimizer import (
     ChainedOptimizer,
@@ -1240,7 +1241,9 @@ def test_get_megatron_optimizer_custom_process_groups_validation():
 
     # Test 3: Missing expt_dp attribute in pg_collection
     pg_collection_no_expt_dp = ProcessGroupCollection()
-    pg_collection_no_expt_dp.dp = torch.distributed.new_group()
+    pg_collection_no_expt_dp.dp = ps.create_split_groups(
+        [list(range(torch.distributed.get_world_size()))], group_desc="DUMMY_DP_GROUP"
+    )
     # Missing required 'expt_dp' attribute
 
     with pytest.raises(ValueError, match="expt_dp process group is required"):
@@ -1252,7 +1255,9 @@ def test_get_megatron_optimizer_custom_process_groups_validation():
 
     # Test 4: Missing intra_dist_opt and mp attribute in pg_collection
     pg_collection_complete = ProcessGroupCollection()
-    pg_collection_complete.dp = torch.distributed.new_group()
+    pg_collection_complete.dp = ps.create_split_groups(
+        [list(range(torch.distributed.get_world_size()))], group_desc="DUMMY_DP_GROUP"
+    )
     pg_collection_complete.expt_dp = None  # Explicitly set to None as allowed
 
     # Missing required 'intra_dist_opt' attribute

--- a/tests/unit_tests/test_parallel_state.py
+++ b/tests/unit_tests/test_parallel_state.py
@@ -567,9 +567,22 @@ def test_expert_all_gather_group():
     expt_dp_group = ps.get_expert_data_parallel_group()
     expt_dp_ranks = torch.distributed.get_process_group_ranks(expt_dp_group)
 
-    # Create AG groups for both regular and expert parameters
-    dp_cp_ag_group = torch.distributed.new_group(ranks=dp_cp_ranks, backend='nccl')
-    expt_dp_ag_group = torch.distributed.new_group(ranks=expt_dp_ranks, backend='nccl')
+    # Create AG groups for both regular and expert parameters. These are extra
+    # communicators over exactly the same ranks as their parent, so they are made
+    # by splitting the parent group with a single (full-size) colour rather than
+    # by an eager new_group: new_group over an nccl2 world drives non-member ranks
+    # through performNocolorSplit, which nccl2 does not implement, and hardcoding
+    # backend='nccl' would pin a stock ProcessGroupNCCL child under an nccl2 world.
+    dp_cp_ag_group = torch.distributed.split_group(
+        parent_pg=dp_cp_group,
+        split_ranks=[list(range(dp_cp_group.size()))],
+        group_desc="DATA_PARALLEL_GROUP_WITH_CP_AG",
+    )
+    expt_dp_ag_group = torch.distributed.split_group(
+        parent_pg=expt_dp_group,
+        split_ranks=[list(range(expt_dp_group.size()))],
+        group_desc="EXPERT_DATA_PARALLEL_GROUP_AG",
+    )
 
     # Create ProcessGroupCollection with AG groups
     pg_collection = ProcessGroupCollection.use_mpu_process_groups()

--- a/tests/unit_tests/test_utilities.py
+++ b/tests/unit_tests/test_utilities.py
@@ -33,12 +33,64 @@ def clear_nvte_env_vars():
     os.environ.pop('NVTE_UNFUSED_ATTN', None)
 
 
+def ensure_distributed_initialized():
+    """Initialize a device-qualified, device-bound world PG if there isn't one yet.
+
+    Test modules that stand up their own world (instead of going through
+    ``Utils.initialize_distributed``) must use this rather than a bare
+    ``init_process_group(backend='nccl')``. Subgroups are now built with
+    ``torch.distributed.split_group``, which requires the parent PG to be bound
+    to a device (``device_id=``), and gloo subgroups require the world to carry a
+    ``cpu:gloo`` backend to filter for. This mirrors
+    ``megatron/training/initialize.py``.
+
+    The cuda backend defaults to ``nccl2``; set ``MEGATRON_TEST_CUDA_BACKEND=nccl``
+    to run the stock baseline arm for an A/B.
+    """
+    if torch.distributed.is_initialized():
+        return
+    if not torch.cuda.is_available():
+        torch.distributed.init_process_group(backend='gloo')
+        return
+    local_rank = int(os.environ.get('LOCAL_RANK', '0')) % torch.cuda.device_count()
+    torch.cuda.set_device(local_rank)
+    cuda_backend = os.environ.get('MEGATRON_TEST_CUDA_BACKEND', 'nccl2')
+    torch.distributed.init_process_group(
+        backend=f'cpu:gloo,cuda:{cuda_backend}',
+        device_id=torch.device(f'cuda:{local_rank}'),
+    )
+
+
+def create_embedding_groups(grid, view=None):
+    """Build the embedding / position-embedding groups of a ``HyperCommGrid``.
+
+    Returns this rank's ``(embd_group, pos_embd_group)`` (``None`` for a family
+    this rank is not part of).
+
+    Both families are built from the grid's *full* PP partition with a single
+    ``torch.distributed.split_group`` collective each, mirroring
+    ``megatron.core.parallel_state``. Creating them with one ``new_group`` per PP
+    group instead would send non-member ranks down ``new_group``'s eager
+    no-color-split path (``performNocolorSplit``), which the ``nccl2`` backend
+    does not implement.
+    """
+    pp_enum = grid.get_rank_enum("pp", view=view)
+    embd_group = ps.create_split_groups(
+        [ps.default_embedding_ranks(pp_ranks) for pp_ranks in pp_enum],
+        group_desc="EMBEDDING_GROUP",
+    )
+    pos_embd_group = ps.create_split_groups(
+        [ps.default_position_embedding_ranks(pp_ranks) for pp_ranks in pp_enum],
+        group_desc="POSITION_EMBEDDING_GROUP",
+    )
+    return embd_group, pos_embd_group
+
+
 class Utils:
 
     world_size = int(os.environ.get('WORLD_SIZE', '1'))
     rank = int(os.environ.get('LOCAL_RANK', '0'))
     inited = False
-    store = None
 
     @staticmethod
     def initialize_distributed():
@@ -66,10 +118,19 @@ class Utils:
             # Use a PrefixStore to avoid accidental overrides of keys used by
             # different systems (e.g. RPC) in case the store is multi-tenant.
             store = PrefixStore("default_pg", store)
-            Utils.store = store
 
+            local_rank = Utils.rank % torch.cuda.device_count()
+            # Give the world PG a cpu:gloo backend alongside the cuda backend so
+            # gloo subgroups can be built with split_group (mirrors
+            # _initialize_distributed). Defaults to nccl2; set
+            # MEGATRON_TEST_CUDA_BACKEND=nccl for the stock baseline arm.
+            cuda_backend = os.environ.get('MEGATRON_TEST_CUDA_BACKEND', 'nccl2')
             torch.distributed.init_process_group(
-                backend='nccl', world_size=Utils.world_size, rank=Utils.rank, store=store
+                backend=f'cpu:gloo,cuda:{cuda_backend}',
+                world_size=Utils.world_size,
+                rank=Utils.rank,
+                store=store,
+                device_id=torch.device(f'cuda:{local_rank}'),
             )
 
             torch.distributed.barrier()

--- a/tests/unit_tests/training/test_dist_signal_handler.py
+++ b/tests/unit_tests/training/test_dist_signal_handler.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""get_device() resolves the device from the backend bound to the process group."""
+
+import os
+import signal
+
+import pytest
+import torch
+
+from megatron.training import dist_signal_handler
+from tests.unit_tests.test_utilities import Utils
+
+
+class _FakeBackend:
+    """Stand-in for a c10d backend object, which exposes its name via `name()`."""
+
+    def __init__(self, name):
+        self._name = name
+
+    def name(self):
+        return self._name
+
+
+class _FakeProcessGroup:
+    """Process group exposing only the per-device backend lookup `get_device` uses."""
+
+    def __init__(self, device_backends):
+        self._device_backends = device_backends
+
+    def _get_backend(self, device):
+        if device.type not in self._device_backends:
+            raise RuntimeError(f"No backend type associated with device type {device.type}")
+        return _FakeBackend(self._device_backends[device.type])
+
+
+# (device backends registered on the process group, local_rank, expected device)
+_BACKEND_CASES = [
+    # Device-qualified world built by megatron/training/initialize.py for nccl2.
+    ({'cpu': 'gloo', 'cuda': 'nccl2'}, None, 'cuda'),
+    ({'cpu': 'gloo', 'cuda': 'nccl2'}, 1, 'cuda:1'),
+    # Device-qualified world with stock nccl.
+    ({'cpu': 'gloo', 'cuda': 'nccl'}, None, 'cuda'),
+    ({'cpu': 'gloo', 'cuda': 'nccl'}, 0, 'cuda:0'),
+    # Lazily initialized per-peer backend used for pipeline-parallel groups.
+    ({'cpu': 'gloo', 'cuda': 'nccl-lazy'}, 3, 'cuda:3'),
+    # Plain nccl world: no cpu backend is registered at all.
+    ({'cuda': 'nccl'}, None, 'cuda'),
+    ({'cuda': 'nccl'}, 2, 'cuda:2'),
+    # Plain gloo world: gloo advertises cuda as well, but collectives run on cpu.
+    ({'cpu': 'gloo', 'cuda': 'gloo'}, None, 'cpu'),
+    ({'cpu': 'gloo', 'cuda': 'gloo'}, 1, 'cpu'),
+]
+
+
+@pytest.mark.parametrize("device_backends,local_rank,expected", _BACKEND_CASES)
+def test_get_device_uses_default_group_backend(device_backends, local_rank, expected, mocker):
+    mocker.patch.object(
+        torch.distributed.distributed_c10d,
+        "_get_default_group",
+        return_value=_FakeProcessGroup(device_backends),
+    )
+
+    assert dist_signal_handler.get_device(local_rank) == torch.device(expected)
+
+
+@pytest.mark.parametrize("device_backends,local_rank,expected", _BACKEND_CASES)
+def test_get_device_uses_explicit_group_backend(device_backends, local_rank, expected, mocker):
+    default_group = mocker.patch.object(torch.distributed.distributed_c10d, "_get_default_group")
+    group = _FakeProcessGroup(device_backends)
+
+    assert dist_signal_handler.get_device(local_rank, group) == torch.device(expected)
+    default_group.assert_not_called()
+
+
+def test_get_device_raises_without_cpu_or_cuda_backend(mocker):
+    mocker.patch.object(torch.distributed, "get_backend", return_value="mpi")
+
+    with pytest.raises(RuntimeError, match="Cannot pick a device"):
+        dist_signal_handler.get_device(group=_FakeProcessGroup({}))
+
+
+class TestDistSignalHandler:
+    """Exercise the real path against the device-qualified world PG used by mcore."""
+
+    def setup_method(self, method):
+        Utils.initialize_distributed()
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    def test_get_device(self):
+        assert dist_signal_handler.get_device() == torch.device('cuda')
+        assert dist_signal_handler.get_device(local_rank=Utils.rank) == torch.device(
+            f'cuda:{Utils.rank}'
+        )
+
+    def test_all_gather_item(self):
+        gathered = dist_signal_handler.all_gather_item(Utils.rank, dtype=torch.int32)
+
+        assert gathered == list(range(Utils.world_size))
+
+    def test_signals_received(self):
+        with dist_signal_handler.DistributedSignalHandler(signal.SIGTERM) as handler:
+            if torch.distributed.get_rank() == 0:
+                os.kill(os.getpid(), signal.SIGTERM)
+            received = handler.signals_received()
+
+        assert received == [1] + [0] * (Utils.world_size - 1)

--- a/tests/unit_tests/training/test_fake_process_group.py
+++ b/tests/unit_tests/training/test_fake_process_group.py
@@ -1,0 +1,210 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""``--fake-process-group`` builds the parallel groups without any real comms.
+
+The fake world PG replaces the process-wide default process group and is
+single-process by construction, so it cannot share the world PG the rest of the
+unit-test suite runs on. These cases therefore drive
+``megatron.training.initialize._initialize_distributed`` in a fresh subprocess,
+one per rank, each pinned to that rank's GPU.
+
+Regression coverage for the nccl2 group-construction wiring:
+  * the fake world PG must be device-bound, otherwise ``split_group`` raises
+    "No device associated with the default pg, not safe to split any process
+    groups";
+  * the split backend filter must not be device-qualified over a fake parent,
+    which registers the bare backend name ``fake`` for every device type;
+  * the pipeline-parallel group must inherit the fake backend instead of asking
+    for a real ``nccl-lazy`` one, which would rendezvous over the ``FakeStore``
+    and hang.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import torch
+
+import megatron.core.parallel_state as ps
+from tests.unit_tests.test_utilities import Utils
+
+# Runs in a subprocess: initialize the fake world exactly the way a
+# `--fake-process-group` training job does, then report the resulting groups.
+_FAKE_PG_DRIVER = textwrap.dedent(
+    '''
+    import json
+    import sys
+
+    import torch
+
+    sys.argv = ["fake_pg_driver"] + json.loads(sys.argv[1])
+
+    import torch.distributed as dist
+
+    from megatron.core import parallel_state as ps
+    from megatron.training.arguments import parse_args, validate_args
+    from megatron.training.global_vars import set_args
+    from megatron.training.initialize import _initialize_distributed
+
+    args = parse_args()
+    validate_args(args)
+    set_args(args)
+    _initialize_distributed(None, None, None)
+
+
+    def backend_of(group):
+        return type(group._get_backend(torch.device("cuda"))).__name__
+
+
+    result = {
+        "backend": dist.get_backend(),
+        "bound_device_id": str(dist.distributed_c10d._get_default_group().bound_device_id),
+        "tp_size": ps.get_tensor_model_parallel_world_size(),
+        "tp_ranks": dist.get_process_group_ranks(ps.get_tensor_model_parallel_group()),
+        "tp_backend": backend_of(ps.get_tensor_model_parallel_group()),
+        "pp_size": ps.get_pipeline_model_parallel_world_size(),
+        "pp_ranks": dist.get_process_group_ranks(ps.get_pipeline_model_parallel_group()),
+        "pp_backend": backend_of(ps.get_pipeline_model_parallel_group()),
+        "dp_size": ps.get_data_parallel_world_size(),
+        "dp_backend": backend_of(ps.get_data_parallel_group()),
+    }
+    print("FAKE_PG_RESULT " + json.dumps(result))
+    '''
+)
+
+_FAKE_WORLD_SIZE = 8
+_MODEL_ARGS = [
+    "--num-layers",
+    "4",
+    "--hidden-size",
+    "64",
+    "--num-attention-heads",
+    "4",
+    "--seq-length",
+    "16",
+    "--max-position-embeddings",
+    "16",
+    "--micro-batch-size",
+    "1",
+    "--global-batch-size",
+    "2",
+    "--train-iters",
+    "1",
+    "--lr",
+    "1e-4",
+    "--vocab-size",
+    "128",
+    "--tokenizer-type",
+    "NullTokenizer",
+    "--mock-data",
+]
+
+
+@pytest.fixture(scope="module")
+def fake_pg_groups(tmp_path_factory):
+    """Groups reported by a ``--fake-process-group`` init of an 8-rank world."""
+    if not torch.cuda.is_available():
+        pytest.skip("--fake-process-group binds a GPU")
+
+    driver = tmp_path_factory.mktemp("fake_pg") / "fake_pg_driver.py"
+    driver.write_text(_FAKE_PG_DRIVER)
+
+    argv = [
+        "--fake-process-group",
+        "--tensor-model-parallel-size",
+        "2",
+        "--pipeline-model-parallel-size",
+        "2",
+        *_MODEL_ARGS,
+    ]
+
+    local_rank = Utils.rank % torch.cuda.device_count()
+    env = dict(os.environ)
+    env.update(
+        {
+            # The fake world pretends to be 8 ranks; the subprocess is its rank
+            # 0 and uses this pytest rank's GPU.
+            "WORLD_SIZE": str(_FAKE_WORLD_SIZE),
+            "RANK": "0",
+            "LOCAL_RANK": str(local_rank),
+            "CUDA_DEVICE_MAX_CONNECTIONS": "1",
+        }
+    )
+    # The subprocess does not inherit the interpreter's sys.path. `megatron` is
+    # a namespace package (no __file__), so locate it via one of its modules:
+    # <root>/megatron/core/parallel_state.py -> <root>.
+    megatron_root = str(Path(ps.__file__).resolve().parents[2])
+    env["PYTHONPATH"] = os.pathsep.join(
+        [p for p in (megatron_root, env.get("PYTHONPATH", "")) if p]
+    )
+
+    completed = subprocess.run(
+        [sys.executable, str(driver), json.dumps(argv)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    assert completed.returncode == 0, (
+        f"fake process group init failed (rc={completed.returncode})\n"
+        f"--- stdout ---\n{completed.stdout}\n--- stderr ---\n{completed.stderr}"
+    )
+    for line in completed.stdout.splitlines():
+        if line.startswith("FAKE_PG_RESULT "):
+            return json.loads(line[len("FAKE_PG_RESULT ") :])
+    raise AssertionError(f"driver produced no result\n--- stdout ---\n{completed.stdout}")
+
+
+class TestFakeProcessGroupInitialization:
+    """``--fake-process-group`` builds every parallel group over a fake world PG."""
+
+    def test_world_is_a_device_bound_fake_process_group(self, fake_pg_groups):
+        assert fake_pg_groups["backend"] == "fake"
+        # split_group refuses to split a parent with no bound_device_id.
+        local_rank = Utils.rank % torch.cuda.device_count()
+        assert fake_pg_groups["bound_device_id"] == f"cuda:{local_rank}"
+
+    def test_parallel_groups_have_the_expected_ranks(self, fake_pg_groups):
+        assert fake_pg_groups["tp_size"] == 2
+        assert fake_pg_groups["tp_ranks"] == [0, 1]
+        assert fake_pg_groups["pp_size"] == 2
+        assert fake_pg_groups["pp_ranks"] == [0, 4]
+        assert fake_pg_groups["dp_size"] == 2
+
+    def test_no_real_backend_is_created(self, fake_pg_groups):
+        """Every group stays fake -- notably the pipeline-parallel one.
+
+        Asking for a real ``nccl-lazy`` pipeline group over a fake world builds
+        an actual NCCL communicator and rendezvouses over the ``FakeStore``,
+        which hangs.
+        """
+        assert fake_pg_groups["tp_backend"] == "FakeProcessGroup"
+        assert fake_pg_groups["pp_backend"] == "FakeProcessGroup"
+        assert fake_pg_groups["dp_backend"] == "FakeProcessGroup"
+
+
+class TestSplitGroupBackendFilter:
+    """``_split_group_backend`` only device-qualifies a real world PG."""
+
+    def test_fake_world_inherits_the_parent_backend(self):
+        # A fake parent registers the bare name "fake" for every device type, so
+        # there is nothing to filter, and split_group validates the filter
+        # against that bare name -- any device-qualified filter is rejected.
+        with patch.object(ps, "is_fake_process_group", return_value=True):
+            assert ps._split_group_backend(None) is None
+            assert ps._split_group_backend("nccl") is None
+            assert ps._split_group_backend("gloo") is None
+
+    def test_real_world_is_device_qualified(self):
+        Utils.initialize_distributed()
+        cuda_backend = dict(
+            part.split(":", 1) for part in torch.distributed.get_backend_config().split(",")
+        )["cuda"]
+
+        assert ps._split_group_backend(None) == f"cuda:{cuda_backend}"
+        assert ps._split_group_backend("gloo") == f"cpu:gloo,cuda:{cuda_backend}"

--- a/tests/unit_tests/transformer/test_attention.py
+++ b/tests/unit_tests/transformer/test_attention.py
@@ -32,7 +32,7 @@ from tests.unit_tests.dist_checkpointing import (
     init_basic_mock_args,
     init_checkpointing_mock_args,
 )
-from tests.unit_tests.test_utilities import Utils
+from tests.unit_tests.test_utilities import Utils, ensure_distributed_initialized
 from tests.unit_tests.transformer.test_multi_latent_attention import make_test_packed_seq_params
 
 try:
@@ -452,8 +452,7 @@ class TestSelfAttention:
         model_parallel_cuda_manual_seed(123)
 
         # Initialize torch.distributed if not already initialized
-        if not torch.distributed.is_initialized():
-            torch.distributed.init_process_group(backend='nccl')
+        ensure_distributed_initialized()
 
         # Create HyperCommGrid with dimensions cp, tp (reversed from device mesh order)
         grid = HyperCommGrid([cp_size, tp_size], ["cp", "tp"])

--- a/tests/unit_tests/transformer/test_transformer_block.py
+++ b/tests/unit_tests/transformer/test_transformer_block.py
@@ -20,7 +20,7 @@ from megatron.core.transformer.spec_utils import build_module
 from megatron.core.transformer.transformer_block import TransformerBlock, get_num_layers_to_build
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.transformer.transformer_layer import TransformerLayer
-from tests.unit_tests.test_utilities import Utils
+from tests.unit_tests.test_utilities import Utils, ensure_distributed_initialized
 
 
 class TestParallelTransformerBlock:
@@ -478,8 +478,7 @@ class TestProcessGroupTransformerBlock:
         model_parallel_cuda_manual_seed(123)
         if use_custom_pg:
             # Initialize torch.distributed if not already initialized
-            if not torch.distributed.is_initialized():
-                torch.distributed.init_process_group(backend='nccl')
+            ensure_distributed_initialized()
 
             # Create HyperCommGrid with dimensions cp, tp, dp (reversed from device mesh order)
             grid = HyperCommGrid([cp_size, tp_size, dp_size, 1], ["cp", "tp", "dp", "pp"])
@@ -565,7 +564,15 @@ class TestMixedProcessGroups:
             self.local_attn_config = copy.deepcopy(self.config)
             self.local_pgs = ProcessGroupCollection.use_mpu_process_groups()
             self.local_attn_config.context_parallel_size = 1
-            self.local_pgs.cp = torch.distributed.new_group(ranks=[torch.distributed.get_rank()])
+            # Degenerate 1-rank CP group. Members-only (not split_group): every
+            # rank passes a different ranks list, and use_local_synchronization
+            # keeps non-members out of new_group's eager no-color-split path,
+            # which the nccl2 backend does not implement.
+            self.local_pgs.cp = parallel_state.create_group(
+                ranks=[torch.distributed.get_rank()],
+                use_local_synchronization=True,
+                group_desc="SINGLE_RANK_GROUP",
+            )
 
             # offset is implicit in TransformerLayer
             self.layers = torch.nn.ModuleList(

--- a/tests/unit_tests/transformer/test_transformer_block_custom_pgs.py
+++ b/tests/unit_tests/transformer/test_transformer_block_custom_pgs.py
@@ -32,7 +32,7 @@ from megatron.core.transformer.spec_utils import ModuleSpec, build_module
 from megatron.core.transformer.transformer_block import TransformerBlock
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.transformer.transformer_layer import TransformerLayer, TransformerLayerSubmodules
-from tests.unit_tests.test_utilities import Utils
+from tests.unit_tests.test_utilities import Utils, ensure_distributed_initialized
 
 
 class HeterogenousTransformerLayer(TransformerLayer):
@@ -265,8 +265,7 @@ class TestTransformerBlockWithProcessGroups:
 
         # Create custom process groups
         # Initialize torch.distributed if not already initialized
-        if not torch.distributed.is_initialized():
-            torch.distributed.init_process_group(backend='nccl')
+        ensure_distributed_initialized()
 
         # Create HyperCommGrid with dimensions tp, cp, ep, pp, dp (reversed from device mesh order)
         grid = HyperCommGrid([tp_size, cp_size, 1, 1, dp_size], ["tp", "cp", "ep", "pp", "dp"])
@@ -412,8 +411,7 @@ class TestTransformerBlockWithProcessGroups:
 
         # Create custom process groups
         # Initialize torch.distributed if not already initialized
-        if not torch.distributed.is_initialized():
-            torch.distributed.init_process_group(backend='nccl')
+        ensure_distributed_initialized()
 
         # Create HyperCommGrid with dimensions mlp_tp, attn_cp, attn_tp (reversed from device mesh order)
         grid = HyperCommGrid(
@@ -626,8 +624,7 @@ class TestTransformerBlockWithProcessGroups:
         model_parallel_cuda_manual_seed(123)
 
         # Initialize torch.distributed if not already initialized
-        if not torch.distributed.is_initialized():
-            torch.distributed.init_process_group(backend='nccl')
+        ensure_distributed_initialized()
 
         if reverse_tp_dp_order:
             # Create HyperCommGrid with dimensions ep, pp, tp, dp (reversed from device mesh order)


### PR DESCRIPTION

Summary:
# Route Megatron-LM collectives through the in-tree nccl2 backend

## Summary

This makes Megatron-LM's distributed stack run over PyTorch's in-tree `nccl2`
backend. The world process group is initialized as an eagerly device-bound
`cpu:gloo,cuda:nccl2` group. All covering-partition subgroups -- the TP / DP /
CP / model-parallel families, their expert-parallel counterparts, the embedding
subgroups, and the gloo metadata groups -- are created with a single
`torch.distributed.split_group` collective over that world PG. The
pipeline-parallel groups are the sole exception: they use
`new_group(backend="nccl-lazy", ...)` for per-peer lazy point-to-point
communicators.

## Why this shape

`nccl2` is a faithful port of torchcomms: it supports comm-split
(`ncclCommSplit`) but not the stock eager-`new_group` no-color-split path. So
every subgroup that is a subset of the world PG is created via `split_group`,
which is collective and uses hashed group names -- self-contained, with no
dependence on `_world.group_count`, hence no members-only workarounds and no
deadlocks. The one exception is pipeline parallelism, which is pure
point-to-point (send/recv between stages): those groups use the `nccl-lazy`
backend so each peer pair gets its own lazily-created 2-rank communicator and
concurrent P2P to different stages can overlap.

## What changed

### `megatron/core/parallel_state.py`

`create_partition_groups` builds every cuda and gloo covering partition with one
`split_group(split_ranks=...)` call over the world PG, via a
`_split_group_backend` helper that device-qualifies the filter: `cuda:nccl2` for
cuda families, and `cpu:gloo,cuda:nccl2` for gloo (the split filter must include
the parent's default cuda device, so the gloo group carries a redundant cuda
backend -- the same shape vLLM uses). Embedding / position-embedding groups are
built the same way from their partition lists. The pipeline-parallel device
group is created via `new_group(backend="nccl-lazy",
use_local_synchronization=True, device_id=...)` (the ucc path stays eager);
`create_group` gains an optional `device_id` used only there.

### `megatron/training/initialize.py`

The world PG is initialized as `cpu:gloo,cuda:<backend>` and eagerly bound to
the rank's cuda device via `device_id`; `split_group` requires a device-bound
parent that carries a cpu:gloo backend for the gloo splits to filter.

### `megatron/training/config/common_config.py`

`distributed_backend` defaults to `nccl2` (choices: `nccl2`, `nccl`, `gloo`).

### `megatron/core/process_groups_config.py`

The singleton `expt_dp_group` fallback routes through
`parallel_state.create_group` so it shares the common group-creation path.

## Test Plan

Signed-off-by: Tushar Jain <tushar00jain@users.noreply.github.com>
