### PR TITLE
Release MFSDP storage after model deletion

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/indexed_order.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/indexed_order.py
@@ -22,12 +22,12 @@ T = TypeVar("T")
 
 
 class IndexedOrder(Generic[T]):
-    """Insertion order with constant-time successor lookup by item."""
+    """Insertion order with weakly held items and successor lookup."""
 
     def __init__(self) -> None:
-        """Create an empty indexed order."""
-        self._items: list[T] = []
-        self._index_by_item: dict[T, int] = {}
+        """Create an empty weak indexed order."""
+        self._items: list[ref[T]] = []
+        self._index_by_item: WeakKeyDictionary[T, int] = WeakKeyDictionary()
 
     def append(self, item: T) -> None:
         """Append ``item`` to the order.
@@ -40,32 +40,6 @@ class IndexedOrder(Generic[T]):
         """
         if item in self._index_by_item:
             raise ValueError("IndexedOrder does not support duplicate items.")
-        self._index_by_item[item] = len(self._items)
-        self._items.append(item)
-
-    def __iter__(self) -> Iterator[T]:
-        """Iterate over items in order."""
-        return iter(self._items)
-
-    def next_item(self, item: T) -> T | None:
-        """Return the item that follows ``item``, if any."""
-        index = self._index_by_item[item]
-        next_index = index + 1
-        return self._items[next_index] if next_index < len(self._items) else None
-
-
-class WeakIndexedOrder(Generic[T]):
-    """Insertion order with weakly held items and successor lookup."""
-
-    def __init__(self) -> None:
-        """Create an empty weak indexed order."""
-        self._items: list[ref[T]] = []
-        self._index_by_item: WeakKeyDictionary[T, int] = WeakKeyDictionary()
-
-    def append(self, item: T) -> None:
-        """Append ``item`` to the order."""
-        if item in self._index_by_item:
-            raise ValueError("WeakIndexedOrder does not support duplicate items.")
         self._index_by_item[item] = len(self._items)
         self._items.append(ref(item))
 

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/indexed_order.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/indexed_order.py
@@ -16,6 +16,7 @@
 
 from collections.abc import Iterator
 from typing import Generic, TypeVar
+from weakref import WeakKeyDictionary, ref
 
 T = TypeVar("T")
 
@@ -51,3 +52,34 @@ class IndexedOrder(Generic[T]):
         index = self._index_by_item[item]
         next_index = index + 1
         return self._items[next_index] if next_index < len(self._items) else None
+
+
+class WeakIndexedOrder(Generic[T]):
+    """Insertion order with weakly held items and successor lookup."""
+
+    def __init__(self) -> None:
+        """Create an empty weak indexed order."""
+        self._items: list[ref[T]] = []
+        self._index_by_item: WeakKeyDictionary[T, int] = WeakKeyDictionary()
+
+    def append(self, item: T) -> None:
+        """Append ``item`` to the order."""
+        if item in self._index_by_item:
+            raise ValueError("WeakIndexedOrder does not support duplicate items.")
+        self._index_by_item[item] = len(self._items)
+        self._items.append(ref(item))
+
+    def __iter__(self) -> Iterator[T]:
+        """Iterate over live items in order."""
+        for item_ref in self._items:
+            item = item_ref()
+            if item is not None:
+                yield item
+
+    def next_item(self, item: T) -> T | None:
+        """Return the live item that follows ``item``, if any."""
+        index = self._index_by_item[item]
+        next_index = index + 1
+        if next_index >= len(self._items):
+            return None
+        return self._items[next_index]()

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/indexed_order.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/indexed_order.py
@@ -25,7 +25,7 @@ class IndexedOrder(Generic[T]):
     """Insertion order with weakly held items and successor lookup."""
 
     def __init__(self) -> None:
-        """Create an empty weak indexed order."""
+        """Create an empty indexed order."""
         self._items: list[ref[T]] = []
         self._index_by_item: WeakKeyDictionary[T, int] = WeakKeyDictionary()
 

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -16,13 +16,14 @@
 
 from collections.abc import Callable
 from typing import Literal, cast
+from weakref import ReferenceType, ref
 
 import torch
 from torch import nn
 from torch.distributed import DeviceMesh
 
 from ..mixed_precision import MixedPrecisionPolicy
-from .indexed_order import IndexedOrder
+from .indexed_order import WeakIndexedOrder
 from .parameter_group import FsdpParameterGroup, get_containing_parameter_group
 from .placement import Placements
 
@@ -36,12 +37,12 @@ class FsdpContext:
     # unnecessary because it can be detected when ``model_weight``, after syncing
     # from ``main_weight``, has placements different from ``Placements.optimizer``.
     is_last_microbatch: bool
-    root_module: "FsdpModule"
+    _root_module: ReferenceType["FsdpModule"]
     # Static orders used to drive all-gather prefetch. We may want to switch to
     # capturing runtime order if static module order proves too fragile. Each
     # FsdpModule tracks its own materialized state via ``FsdpModule._unshard_event``.
-    forward_order: IndexedOrder["FsdpModule"]
-    backward_order: IndexedOrder["FsdpModule"]
+    forward_order: WeakIndexedOrder["FsdpModule"]
+    backward_order: WeakIndexedOrder["FsdpModule"]
 
     def __init__(self, device: torch.device, root_module: "FsdpModule") -> None:
         """Create rank-local runtime state for a root FSDP subtree.
@@ -50,10 +51,10 @@ class FsdpContext:
             device: Device on which this context schedules communication.
             root_module: Outermost module that owns this context.
         """
-        self.root_module = root_module
+        self._root_module = ref(root_module)
         self.is_last_microbatch = True
-        self.forward_order = IndexedOrder()
-        self.backward_order = IndexedOrder()
+        self.forward_order = WeakIndexedOrder()
+        self.backward_order = WeakIndexedOrder()
         with torch.cuda.device(device):
             self.allgather_stream = torch.cuda.Stream()
             self.reduce_scatter_stream = torch.cuda.Stream()
@@ -61,6 +62,14 @@ class FsdpContext:
     def current_stream(self) -> torch.cuda.Stream:
         """Current stream on this context's device."""
         return torch.cuda.current_stream(self.allgather_stream.device)
+
+    @property
+    def root_module(self) -> "FsdpModule":
+        """Return the root module while its FSDP context remains active."""
+        root_module = self._root_module()
+        if root_module is None:
+            raise RuntimeError("FSDP context outlived its root module.")
+        return root_module
 
     def register_post_backward_final_callback(self) -> None:
         """Register this root context's final callback for the current backward.
@@ -194,12 +203,22 @@ class FsdpModule:
 
     def _register_hooks(self) -> None:
         module = cast(nn.Module, self)
-        module.register_forward_pre_hook(lambda _module, _args: self.pre_forward())
-        module.register_forward_hook(lambda _module, _args, _output: self.post_forward())
-        module.register_full_backward_pre_hook(lambda _module, _grad_output: self.pre_backward())
+        # Use PyTorch's callback module argument instead of capturing self so
+        # these hooks do not retain a deleted FSDP module.
+        module.register_forward_pre_hook(
+            lambda hooked_module, _args: cast(FsdpModule, hooked_module).pre_forward()
+        )
+        module.register_forward_hook(
+            lambda hooked_module, _args, _output: cast(FsdpModule, hooked_module).post_forward()
+        )
+        module.register_full_backward_pre_hook(
+            lambda hooked_module, _grad_output: cast(FsdpModule, hooked_module).pre_backward()
+        )
         if self._num_trainable_parameters == 0:
             module.register_full_backward_hook(
-                lambda _module, _grad_input, _grad_output: self.post_backward()
+                lambda hooked_module, _grad_input, _grad_output: cast(
+                    FsdpModule, hooked_module
+                ).post_backward()
             )
             return
 
@@ -214,10 +233,15 @@ class FsdpModule:
                 fsdp_parameter.unsharded.register_post_accumulate_grad_hook(self._make_grad_hook())
 
     def _make_grad_hook(self) -> Callable[[nn.Parameter], None]:
+        module_ref = ref(self)
+
         def grad_hook(_parameter: nn.Parameter) -> None:
-            self._num_ready_grad_parameters += 1
-            if self._num_ready_grad_parameters == self._num_trainable_parameters:
-                self.post_backward()
+            module = module_ref()
+            if module is None:
+                return
+            module._num_ready_grad_parameters += 1
+            if module._num_ready_grad_parameters == module._num_trainable_parameters:
+                module.post_backward()
 
         return grad_hook
 
@@ -347,7 +371,7 @@ class FsdpModule:
         return f"MFSDP {name} {phase}"
 
 
-def _collect_backward_order(module: nn.Module, order: IndexedOrder["FsdpModule"]) -> None:
+def _collect_backward_order(module: nn.Module, order: WeakIndexedOrder["FsdpModule"]) -> None:
     """Collect FsdpModules in static backward prefetch order."""
     if isinstance(module, FsdpModule):
         order.append(module)

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -23,7 +23,7 @@ from torch import nn
 from torch.distributed import DeviceMesh
 
 from ..mixed_precision import MixedPrecisionPolicy
-from .indexed_order import WeakIndexedOrder
+from .indexed_order import IndexedOrder
 from .parameter_group import FsdpParameterGroup, get_containing_parameter_group
 from .placement import Placements
 
@@ -41,8 +41,8 @@ class FsdpContext:
     # Static orders used to drive all-gather prefetch. We may want to switch to
     # capturing runtime order if static module order proves too fragile. Each
     # FsdpModule tracks its own materialized state via ``FsdpModule._unshard_event``.
-    forward_order: WeakIndexedOrder["FsdpModule"]
-    backward_order: WeakIndexedOrder["FsdpModule"]
+    forward_order: IndexedOrder["FsdpModule"]
+    backward_order: IndexedOrder["FsdpModule"]
 
     def __init__(self, device: torch.device, root_module: "FsdpModule") -> None:
         """Create rank-local runtime state for a root FSDP subtree.
@@ -53,8 +53,8 @@ class FsdpContext:
         """
         self._root_module = ref(root_module)
         self.is_last_microbatch = True
-        self.forward_order = WeakIndexedOrder()
-        self.backward_order = WeakIndexedOrder()
+        self.forward_order = IndexedOrder()
+        self.backward_order = IndexedOrder()
         with torch.cuda.device(device):
             self.allgather_stream = torch.cuda.Stream()
             self.reduce_scatter_stream = torch.cuda.Stream()
@@ -371,7 +371,7 @@ class FsdpModule:
         return f"MFSDP {name} {phase}"
 
 
-def _collect_backward_order(module: nn.Module, order: WeakIndexedOrder["FsdpModule"]) -> None:
+def _collect_backward_order(module: nn.Module, order: IndexedOrder["FsdpModule"]) -> None:
     """Collect FsdpModules in static backward prefetch order."""
     if isinstance(module, FsdpModule):
         order.append(module)

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -37,6 +37,8 @@ class FsdpContext:
     # unnecessary because it can be detected when ``model_weight``, after syncing
     # from ``main_weight``, has placements different from ``Placements.optimizer``.
     is_last_microbatch: bool
+    # A context is owned by its FSDP module tree, so runtime backedges to modules
+    # must be weak; otherwise deleting the tree requires cyclic GC.
     _root_module: ReferenceType["FsdpModule"]
     # Static orders used to drive all-gather prefetch. We may want to switch to
     # capturing runtime order if static module order proves too fragile. Each

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -63,13 +63,9 @@ class FsdpContext:
         """Current stream on this context's device."""
         return torch.cuda.current_stream(self.allgather_stream.device)
 
-    @property
-    def root_module(self) -> "FsdpModule":
-        """Return the root module while its FSDP context remains active."""
-        root_module = self._root_module()
-        if root_module is None:
-            raise RuntimeError("FSDP context outlived its root module.")
-        return root_module
+    def is_module_root(self, module: "FsdpModule") -> bool:
+        """Return whether ``module`` is this context's root module."""
+        return self._root_module() is module
 
     def register_post_backward_final_callback(self) -> None:
         """Register this root context's final callback for the current backward.
@@ -199,7 +195,7 @@ class FsdpModule:
 
     def is_root(self) -> bool:
         """Return whether this module is the outermost FsdpModule in its context."""
-        return self.context.root_module is self
+        return self.context.is_module_root(self)
 
     def _register_hooks(self) -> None:
         module = cast(nn.Module, self)

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -34,7 +34,9 @@ _CONTAINING_PARAMETER_GROUP_ATTR = "_mfsdp_parameter_group"
 def get_containing_parameter_group(parameter: nn.Parameter) -> "FsdpParameterGroup | None":
     """Return the FSDP parameter group that owns ``parameter``, if any."""
     parameter_group_ref = getattr(parameter, _CONTAINING_PARAMETER_GROUP_ATTR, None)
-    return parameter_group_ref() if parameter_group_ref is not None else None
+    if parameter_group_ref is None:
+        return None
+    return parameter_group_ref()
 
 
 @dataclass(frozen=True, eq=False)
@@ -203,22 +205,17 @@ class FsdpParameterGroup:
         self._switch_to_sharded_parameters()
         self._unsharded_model_weight.release_storage()
 
-    @property
-    def owning_module(self) -> nn.Module:
-        """Return this group's module while it remains alive."""
-        owning_module = self._owning_module()
-        if owning_module is None:
-            raise RuntimeError("FSDP parameter group outlived its owning module.")
-        return owning_module
-
     def _symmetric_memory_context(self):
         if self._symm_mem_pool is None:
             return nullcontext()
         return torch.cuda.use_mem_pool(self._symm_mem_pool)
 
     def _set_module_parameter(self, fqns: tuple[str, ...], parameter: nn.Parameter) -> None:
+        owning_module = self._owning_module()
+        if owning_module is None:
+            raise RuntimeError("FSDP parameter group outlived its owning module.")
         for fqn in fqns:
-            module, parameter_name = _get_parameter_owner(self.owning_module, fqn)
+            module, parameter_name = _get_parameter_owner(owning_module, fqn)
             module._parameters[parameter_name] = parameter
 
     def _switch_to_sharded_parameters(self) -> None:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -16,6 +16,7 @@
 
 from contextlib import nullcontext
 from dataclasses import dataclass
+from weakref import ReferenceType, ref
 
 import torch
 import torch.distributed as dist
@@ -32,7 +33,8 @@ _CONTAINING_PARAMETER_GROUP_ATTR = "_mfsdp_parameter_group"
 
 def get_containing_parameter_group(parameter: nn.Parameter) -> "FsdpParameterGroup | None":
     """Return the FSDP parameter group that owns ``parameter``, if any."""
-    return getattr(parameter, _CONTAINING_PARAMETER_GROUP_ATTR, None)
+    parameter_group_ref = getattr(parameter, _CONTAINING_PARAMETER_GROUP_ATTR, None)
+    return parameter_group_ref() if parameter_group_ref is not None else None
 
 
 @dataclass(frozen=True, eq=False)
@@ -49,7 +51,7 @@ class FsdpParameter:
 class FsdpParameterGroup:
     """A dtype and requires-grad homogeneous group of FSDP-owned parameters."""
 
-    owning_module: nn.Module
+    _owning_module: ReferenceType[nn.Module]
     fsdp_parameters: tuple[FsdpParameter, ...]
     mesh: DeviceMesh
     dtype: torch.dtype
@@ -93,7 +95,7 @@ class FsdpParameterGroup:
 
         # Python dicts preserve insertion order, so parameter_to_fqns and
         # fsdp_parameters define the same stable DBuffer tensor order.
-        self.owning_module = owning_module
+        self._owning_module = ref(owning_module)
         self.mesh = mesh
         first_parameter = next(iter(parameter_to_fqns))
         self.dtype = first_parameter.dtype
@@ -182,14 +184,14 @@ class FsdpParameterGroup:
             else:
                 parameter.data = unsharded_tensor
                 parameter.grad = None
-            setattr(parameter, _CONTAINING_PARAMETER_GROUP_ATTR, self)
+            setattr(parameter, _CONTAINING_PARAMETER_GROUP_ATTR, ref(self))
 
             sharded_parameter = nn.Parameter(
                 self.main_weight.get_dtensor(index), requires_grad=parameter.requires_grad
             )
             if main_grad_dtype:
                 sharded_parameter.grad_dtype = main_grad_dtype
-            setattr(sharded_parameter, _CONTAINING_PARAMETER_GROUP_ATTR, self)
+            setattr(sharded_parameter, _CONTAINING_PARAMETER_GROUP_ATTR, ref(self))
             fsdp_parameters.append(
                 FsdpParameter(fqns=tuple(fqns), sharded=sharded_parameter, unsharded=parameter)
             )
@@ -200,6 +202,14 @@ class FsdpParameterGroup:
         self.sync_model_weight_from_main_weight()
         self._switch_to_sharded_parameters()
         self._unsharded_model_weight.release_storage()
+
+    @property
+    def owning_module(self) -> nn.Module:
+        """Return this group's module while it remains alive."""
+        owning_module = self._owning_module()
+        if owning_module is None:
+            raise RuntimeError("FSDP parameter group outlived its owning module.")
+        return owning_module
 
     def _symmetric_memory_context(self):
         if self._symm_mem_pool is None:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -33,6 +33,8 @@ _CONTAINING_PARAMETER_GROUP_ATTR = "_mfsdp_parameter_group"
 
 def get_containing_parameter_group(parameter: nn.Parameter) -> "FsdpParameterGroup | None":
     """Return the FSDP parameter group that owns ``parameter``, if any."""
+    # This parameter-owned backedge must be weak; otherwise it forms a reference
+    # cycle with the parameter group and delays releasing its CUDA storage.
     parameter_group_ref = getattr(parameter, _CONTAINING_PARAMETER_GROUP_ATTR, None)
     if parameter_group_ref is None:
         return None
@@ -53,6 +55,8 @@ class FsdpParameter:
 class FsdpParameterGroup:
     """A dtype and requires-grad homogeneous group of FSDP-owned parameters."""
 
+    # FsdpModule owns its parameter groups, so this backedge must be weak to avoid
+    # a reference cycle that delays releasing CUDA storage until cyclic GC.
     _owning_module: ReferenceType[nn.Module]
     fsdp_parameters: tuple[FsdpParameter, ...]
     mesh: DeviceMesh
@@ -186,6 +190,7 @@ class FsdpParameterGroup:
             else:
                 parameter.data = unsharded_tensor
                 parameter.grad = None
+            # Parameter-owned markers must not retain their FSDP module tree.
             setattr(parameter, _CONTAINING_PARAMETER_GROUP_ATTR, ref(self))
 
             sharded_parameter = nn.Parameter(

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -73,6 +73,18 @@ class MultiChildModel(nn.Module):
         return x
 
 
+class ElementwiseModel(nn.Module):
+    """Small activation path over a large FSDP-managed weight."""
+
+    def __init__(self, dim: int) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(dim, dim))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Apply the first weight row to an activation tensor."""
+        return torch.relu(x + self.weight[0])
+
+
 class TiedLM(nn.Module):
     """Tiny language model with shared input and output embedding weights."""
 
@@ -421,6 +433,26 @@ def test_forward_peak_memory_bounds_in_flight_child_all_gathers(distributed_setu
         f"rank={rank}, peak_delta={_mb(peak_delta)}, "
         f"three_child_weights={_mb(bound_nbytes)}"
     )
+
+
+def test_deleted_model_releases_fsdp_storage(distributed_setup):
+    """Deleting an FSDP model should release its persistent storage."""
+    world_size = distributed_setup.world_size
+    device = distributed_setup.device
+
+    mesh = init_device_mesh(device.type, (world_size,))
+    model = ElementwiseModel(dim=8192).to(dtype=torch.bfloat16, device=device)
+    fully_shard(model, mesh=mesh, placements=_flat_placements())
+
+    x = torch.ones(1, 8192, dtype=torch.bfloat16, device=device)
+    output = model(x)
+    torch.cuda.synchronize(device)
+    del output, x, model
+    torch.cuda.synchronize(device)
+
+    # This forward has no GEMM workspace. Retain at most negligible runtime
+    # bookkeeping, not the deleted model's persistent FSDP buffers.
+    assert torch.cuda.memory_allocated(device) < 1024**2
 
 
 def test_root_forward_returns_to_resting_memory(distributed_setup):

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -441,6 +441,10 @@ def test_deleted_model_releases_fsdp_storage(distributed_setup):
     device = distributed_setup.device
 
     mesh = init_device_mesh(device.type, (world_size,))
+    # Earlier tests may retain process-global CUDA allocations such as the
+    # CuBLAS workspace. Capture them before creating this model, so the test
+    # only detects storage retained by the deleted FSDP model itself.
+    allocated_before = torch.cuda.memory_allocated(device)
     model = ElementwiseModel(dim=8192).to(dtype=torch.bfloat16, device=device)
     fully_shard(model, mesh=mesh, placements=_flat_placements())
 
@@ -450,9 +454,7 @@ def test_deleted_model_releases_fsdp_storage(distributed_setup):
     del output, x, model
     torch.cuda.synchronize(device)
 
-    # This forward has no GEMM workspace. Retain at most negligible runtime
-    # bookkeeping, not the deleted model's persistent FSDP buffers.
-    assert torch.cuda.memory_allocated(device) < 1024**2
+    assert torch.cuda.memory_allocated(device) - allocated_before < 1024**2
 
 
 def test_root_forward_returns_to_resting_memory(distributed_setup):

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -450,7 +450,6 @@ def test_deleted_model_releases_fsdp_storage(distributed_setup):
 
     x = torch.ones(1, 8192, dtype=torch.bfloat16, device=device)
     output = model(x)
-    torch.cuda.synchronize(device)
     del output, x, model
     torch.cuda.synchronize(device)
 


### PR DESCRIPTION
MFSDP installed strong back-references from tensor-owned or runtime state to the module graph. Deleting a sharded model could therefore retain its persistent CUDA storage indefinitely.

Make the ownership graph acyclic: parameter ownership markers and post-accumulate hooks hold groups/modules weakly; parameter groups hold their owning modules weakly; the shared context holds its root and prefetch orders weakly; and module hooks dispatch from their runtime module argument rather than close over it. Internal APIs do not expose dereferenced owner or root modules, preventing accidental retention. Deleting a model now releases FSDP storage immediately, without explicit garbage collection or a teardown API.

Add an activation-path regression that runs a sharded model, deletes it, and requires device allocation to return below 1 MiB. It reproduces the leak on origin/main without the main-grad materialization changes.