### PR TITLE
Fix GTP prefetch parameter readiness

### DIFF
--- a/megatron/core/distributed/distributed_data_parallel.py
+++ b/megatron/core/distributed/distributed_data_parallel.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
 
 import logging
+import weakref
 from contextlib import contextmanager
 from typing import Optional
 
@@ -17,6 +18,26 @@ from .distributed_data_parallel_config import DistributedDataParallelConfig
 from .param_and_grad_buffer import _ParamAndGradBuffer, group_params_for_buffers, partition_buckets
 
 logger = logging.getLogger(__name__)
+
+
+class GTPParamSyncHandle:
+    """GTP-only readiness handle for one DDP parameter all-gather bucket group."""
+
+    def __init__(self, ddp, bucket_group) -> None:
+        self._ddp = weakref.ref(ddp)
+        self._bucket_group = bucket_group
+
+    def ensure_ready(self) -> None:
+        """Finish this bucket's parameter all-gather when forward hooks are active."""
+        ddp = self._ddp()
+        if ddp is None or is_graph_capturing() or not ddp.remove_forward_pre_hook_handles:
+            return
+        if (
+            self._bucket_group.param_gather_dispatched
+            and self._bucket_group.param_gather_handle is None
+        ):
+            return
+        ddp._finish_param_sync_for_bucket_group(self._bucket_group)
 
 
 class DistributedDataParallel(_BaseDataParallel):
@@ -338,6 +359,19 @@ class DistributedDataParallel(_BaseDataParallel):
                     for param in bucket.params_list:
                         self.param_to_bucket_group[param] = bucket_group
 
+        if self.ddp_config.overlap_param_gather:
+            # Only GTP parameters need a readiness handle: GTP prefetch may read them before
+            # their owning module's ordinary DDP pre-forward hook runs.
+            gtp_bucket_group_handles: dict[object, GTPParamSyncHandle] = {}
+            for param, bucket_group in self.param_to_bucket_group.items():
+                if not getattr(param, 'is_gtp_weight_remat', False):
+                    continue
+                handle = gtp_bucket_group_handles.get(bucket_group)
+                if handle is None:
+                    handle = GTPParamSyncHandle(self, bucket_group)
+                    gtp_bucket_group_handles[bucket_group] = handle
+                param._gtp_ddp_param_sync_handle = handle
+
         # Delete references to weight_tensor if they exist since we don't want two parameter copies
         # if we re-mapped parameters (which happens when we use the distributed optimizer).
         # This is a temporary workaround around a TE bug that is fixed with
@@ -455,20 +489,19 @@ class DistributedDataParallel(_BaseDataParallel):
                 if param not in self.param_to_bucket_group:
                     continue
                 assert param.requires_grad
-
-                # If aligning param all-gather across pipeline stages, all-gather is dispatched
-                # by start_param_sync calls in core/pipeline_parallelism/schedules.py.
-                # If overlapping param all-gather with optimizer step, then all-gather has
-                # already been dispatched in optimizer step.
-                skip_next_bucket_dispatch = (
-                    self.ddp_config.align_param_gather
-                    or self.overlap_param_gather_with_optimizer_step
-                )
-                self.param_to_bucket_group[param].finish_param_sync(
-                    skip_next_bucket_dispatch=skip_next_bucket_dispatch
-                )
+                self._finish_param_sync_for_bucket_group(self.param_to_bucket_group[param])
 
         return hook
+
+    def _finish_param_sync_for_bucket_group(self, bucket_group):
+        # If aligning param all-gather across pipeline stages, all-gather is dispatched
+        # by start_param_sync calls in core/pipeline_parallelism/schedules.py.
+        # If overlapping param all-gather with optimizer step, then all-gather has
+        # already been dispatched in optimizer step.
+        skip_next_bucket_dispatch = (
+            self.ddp_config.align_param_gather or self.overlap_param_gather_with_optimizer_step
+        )
+        bucket_group.finish_param_sync(skip_next_bucket_dispatch=skip_next_bucket_dispatch)
 
     def _make_backward_post_hook(self, param: torch.nn.Parameter):
         """

--- a/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
+++ b/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
@@ -31,7 +31,7 @@ from collections import defaultdict
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Callable, Dict, List, Optional
+from typing import Callable, Dict, Iterable, List, Optional
 
 import torch
 from packaging.version import Version
@@ -40,11 +40,37 @@ from megatron.core.tensor_parallel.gtp_cuda_graphs import (
     allocate_graph_wgrad_rings,
     cuda_graph_pool_allocation,
     register_capture_comm,
+    register_capture_gtp_param_sync,
     register_capture_wgrad_ring_slot,
 )
 from megatron.core.utils import log_single_rank
 
 logger = logging.getLogger(__name__)
+
+
+def finish_param_sync_for_gtp_weight_read(params: Iterable) -> None:
+    """Finish DDP parameter gathers before GTP reads local weight shards.
+
+    GTP may read a weight before its owning module executes, so the normal DDP module pre-hook
+    can run too late. During CUDA graph capture, record the dependency so replay can finish it
+    before launching the graph. Parameters in the same DDP bucket share a readiness handle.
+    """
+    handles = []
+    handle_ids = set()
+    for param in params:
+        handle = getattr(param, "_gtp_ddp_param_sync_handle", None)
+        if handle is None:
+            continue
+        handle_id = id(handle)
+        if handle_id in handle_ids:
+            continue
+        handle_ids.add(handle_id)
+        handles.append(handle)
+
+    register_capture_gtp_param_sync(handles)
+    for handle in handles:
+        handle.ensure_ready()
+
 
 _GTP_TE_MIN_VERSION = Version("2.19.0.dev0")
 
@@ -1209,6 +1235,8 @@ class GTPShardedParam(torch.nn.Parameter):
         nvtx_range_push(f"{nvtx_label}.all_gather_weight")
 
         weights = self._weights
+        if fwd:
+            finish_param_sync_for_gtp_weight_read(weights)
 
         # 1. Transition state for async gathers. Skip during recompute-forward: it gathers
         #    rowwise (_ag_ticket_fwd) while a bwd-chain prefetch may hold an in-flight columnwise

--- a/megatron/core/tensor_parallel/gtp_cuda_graphs.py
+++ b/megatron/core/tensor_parallel/gtp_cuda_graphs.py
@@ -36,16 +36,18 @@ class GraphWgradRingSlot:
 
 @dataclass
 class GTPCaptureCommState:
-    """Asynchronous GTP work issued while capturing one CUDA graph."""
+    """GTP work and readiness dependencies issued while capturing one CUDA graph."""
 
     params: list = field(default_factory=list)
     ag_streams: list = field(default_factory=list)
     rs_streams: list = field(default_factory=list)
     wgrad_ring_slots: list = field(default_factory=list)
+    gtp_param_sync_handles: list = field(default_factory=list)
     _param_ids: set = field(default_factory=set)
     _ag_stream_ids: set = field(default_factory=set)
     _rs_stream_ids: set = field(default_factory=set)
     _wgrad_ring_slot_params: dict = field(default_factory=dict)
+    _gtp_param_sync_handle_ids: set = field(default_factory=set)
 
     def register_comm(self, param, stream: torch.cuda.Stream, *, reduce_scatter: bool) -> None:
         """Record a parameter and side stream owned by this graph capture."""
@@ -75,6 +77,19 @@ class GTPCaptureCommState:
             self._wgrad_ring_slot_params[slot_id] = param_id
             self.wgrad_ring_slots.append(slot)
 
+    def register_gtp_param_sync(self, handles: Iterable) -> None:
+        """Record each DDP parameter-sync dependency once for this graph."""
+        for handle in handles:
+            handle_id = id(handle)
+            if handle_id not in self._gtp_param_sync_handle_ids:
+                self._gtp_param_sync_handle_ids.add(handle_id)
+                self.gtp_param_sync_handles.append(handle)
+
+    def ensure_param_sync_ready(self) -> None:
+        """Finish DDP parameter gathers required before replaying this graph."""
+        for handle in self.gtp_param_sync_handles:
+            handle.ensure_ready()
+
 
 _ACTIVE_CAPTURE_COMM_STATE: Optional[GTPCaptureCommState] = None
 
@@ -89,6 +104,12 @@ def register_capture_wgrad_ring_slot(slot: GraphWgradRingSlot, param) -> None:
     """Register a ring slot with the active capture, if one exists."""
     if _ACTIVE_CAPTURE_COMM_STATE is not None:
         _ACTIVE_CAPTURE_COMM_STATE.register_wgrad_ring_slot(slot, param)
+
+
+def register_capture_gtp_param_sync(handles: Iterable) -> None:
+    """Register DDP parameter-sync dependencies with the active graph capture."""
+    if _ACTIVE_CAPTURE_COMM_STATE is not None:
+        _ACTIVE_CAPTURE_COMM_STATE.register_gtp_param_sync(handles)
 
 
 @contextmanager

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -946,6 +946,8 @@ class _CudaGraphRunner(torch.nn.Module):
         # Persistent wgrad slots written by this graph. Replay waits for each slot's previous RS
         # reader before launching the graph.
         self._gtp_wgrad_ring_slots = []
+        # DDP parameter buckets read by this graph before their module pre-hooks run.
+        self._gtp_fwd_capture_comms = None
 
         self.grad_enabled = need_backward and torch.is_grad_enabled()
         self.func = super(MegatronModule, self.base_module).__call__ if func is None else func
@@ -1325,8 +1327,14 @@ class _CudaGraphRunner(torch.nn.Module):
                 if FREEZE_GC:
                     gc.freeze()
 
-                with torch.cuda.graph(
-                    self.fwd_graph, pool=self.mempool, capture_error_mode="thread_local"
+                capture_comm_context = (
+                    track_gtp_capture_comms() if self.gtp_remat else nullcontext(None)
+                )
+                with (
+                    capture_comm_context as capture_comms,
+                    torch.cuda.graph(
+                        self.fwd_graph, pool=self.mempool, capture_error_mode="thread_local"
+                    ),
                 ):
 
                     self._sync_against_side_streams(self.fwd_side_streams)
@@ -1344,6 +1352,9 @@ class _CudaGraphRunner(torch.nn.Module):
 
                     if self.use_stream:
                         self.fwd_completion_event.record()
+
+                if self.gtp_remat:
+                    self._gtp_fwd_capture_comms = capture_comms
 
                 # Unfreeze GC.
                 if FREEZE_GC:
@@ -1645,6 +1656,9 @@ class _CudaGraphRunner(torch.nn.Module):
         if mismatch_errors:
             error_msg = "CUDA graph argument mismatch:\n" + "\n".join(mismatch_errors)
             raise AssertionError(error_msg)
+
+        if self._gtp_fwd_capture_comms is not None:
+            self._gtp_fwd_capture_comms.ensure_param_sync_ready()
 
         inp_tensors = self.get_tensors(args, kwargs, check_types=False)
         if self.grad_enabled:

--- a/tests/unit_tests/distributed/test_distributed_data_parallel.py
+++ b/tests/unit_tests/distributed/test_distributed_data_parallel.py
@@ -1,11 +1,14 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 from packaging import version
 from torch import testing
 
 from megatron.core.distributed import DistributedDataParallel, DistributedDataParallelConfig
+from megatron.core.distributed.distributed_data_parallel import GTPParamSyncHandle
 from megatron.core.hyper_comm_grid import HyperCommGrid
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.transformer import TransformerConfig
@@ -35,6 +38,42 @@ class TestDistributedDataParallel:
     @classmethod
     def teardown_class(cls):
         Utils.destroy_model_parallel()
+
+    def test_gtp_parameter_sync_handle_matches_forward_pre_hook(self):
+        class BucketGroup:
+            def __init__(self):
+                self.calls = []
+                self.param_gather_dispatched = False
+                self.param_gather_handle = None
+
+            def finish_param_sync(self, skip_next_bucket_dispatch=False):
+                self.calls.append(skip_next_bucket_dispatch)
+                self.param_gather_dispatched = True
+
+        bucket_group = BucketGroup()
+        ddp = object.__new__(DistributedDataParallel)
+        ddp.ddp_config = SimpleNamespace(align_param_gather=False)
+        ddp.overlap_param_gather_with_optimizer_step = False
+        ddp.remove_forward_pre_hook_handles = {object(): object()}
+
+        handle = GTPParamSyncHandle(ddp, bucket_group)
+        handle.ensure_ready()
+        assert bucket_group.calls == [False]
+
+        # A completed gather is idempotent when the same bucket is prefetched again.
+        handle.ensure_ready()
+        assert bucket_group.calls == [False]
+
+        ddp.ddp_config.align_param_gather = True
+        bucket_group.param_gather_dispatched = False
+        handle.ensure_ready()
+        assert bucket_group.calls == [False, True]
+
+        # Disabling DDP's forward hooks also disables the GTP readiness handle.
+        ddp.remove_forward_pre_hook_handles = {}
+        bucket_group.param_gather_dispatched = False
+        handle.ensure_ready()
+        assert bucket_group.calls == [False, True]
 
     @pytest.mark.skipif(
         version.parse(torch.__version__) < version.parse('2.3.0'),

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
@@ -25,6 +25,7 @@ Test groups
 - TestGTPDDPGradReadyWiring  - GTP params drive DDP grad-ready via the manual hook, not autograd
 - TestGTPWeightCacheSchedulingDomain - cache reuse stays within one chain/process-group domain
 - TestGTPGraphWgradRing       - partial-CG wgrad ring ownership and RS-input correctness
+- TestGTPDDPParamSync         - DDP parameter readiness for eager reads and graph replay
 
 Multi-GPU tests skip when ``torch.distributed.get_world_size()`` != the required world size (4).
 """
@@ -1439,3 +1440,58 @@ class TestGTPGraphWgradRing:
         assert rs_input is weights[1]._gtp_graph_wgrad_ring_slot.tensor
         torch.testing.assert_close(rs_input[:4], wgrad)
         assert torch.count_nonzero(rs_input[4:]) == 0
+
+
+class TestGTPDDPParamSync:
+    def test_weight_read_finishes_each_bucket_sync_once(self):
+        class Handle:
+            def __init__(self, name, calls):
+                self.name = name
+                self.calls = calls
+
+            def ensure_ready(self):
+                self.calls.append(self.name)
+
+        first = nn.Parameter(torch.zeros(1))
+        second = nn.Parameter(torch.zeros(1))
+        third = nn.Parameter(torch.zeros(1))
+        calls = []
+        shared_handle = Handle("shared", calls)
+        third_handle = Handle("third", calls)
+        first._gtp_ddp_param_sync_handle = shared_handle
+        second._gtp_ddp_param_sync_handle = shared_handle
+        third._gtp_ddp_param_sync_handle = third_handle
+
+        gtp_module.finish_param_sync_for_gtp_weight_read((first, second, first, third))
+
+        assert calls == ["shared", "third"]
+
+    def test_capture_records_each_bucket_sync_once(self):
+        class Handle:
+            def ensure_ready(self):
+                pass
+
+        first = nn.Parameter(torch.zeros(1))
+        second = nn.Parameter(torch.zeros(1))
+        first_handle = Handle()
+        second_handle = Handle()
+        first._gtp_ddp_param_sync_handle = first_handle
+        second._gtp_ddp_param_sync_handle = second_handle
+
+        with gtp_cuda_graphs.track_gtp_capture_comms() as capture_comms:
+            gtp_module.finish_param_sync_for_gtp_weight_read((first, second, first))
+            gtp_module.finish_param_sync_for_gtp_weight_read((second, first))
+
+        assert capture_comms.gtp_param_sync_handles == [first_handle, second_handle]
+
+    def test_capture_state_is_isolated_per_graph(self):
+        handle = object()
+
+        with gtp_cuda_graphs.track_gtp_capture_comms() as first_graph:
+            gtp_cuda_graphs.register_capture_gtp_param_sync((handle,))
+        with gtp_cuda_graphs.track_gtp_capture_comms() as second_graph:
+            gtp_cuda_graphs.register_capture_gtp_param_sync((handle,))
+
+        assert first_graph is not second_graph
+        assert first_graph.gtp_param_sync_handles == [handle]
+        assert second_graph.gtp_param_sync_handles == [handle]


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

## Summary

- attach a GTP-only readiness handle to each DDP parameter-gather bucket used by GTP weights
- finish the required DDP gather before eager GTP weight reads
- record capture-local readiness dependencies in `gtp_cuda_graphs.py` and finish them before replaying each local forward CUDA graph
- keep the existing DDP pre-forward gather policy shared by both paths

## Root cause

GTP can prefetch the next module's local weight shard before that module executes. With overlapped DDP parameter gathering, the ordinary module pre-forward hook therefore runs too late: GTP may read the distributed-optimizer parameter buffer while its bucket all-gather is still in flight. CUDA graph capture also suppresses the DDP hook, so the dependency must be retained and replayed explicitly.

Each forward graph capture now creates its own `GTPCaptureCommState`. The transient active state is used only while capturing; the yielded state is stored on that graph's `_CudaGraphRunner`, preventing handle sets from aliasing across graph instances.

