### PR TITLE
[DO NOT MERGE] Heterogeneous Hybrid Model

### DIFF
--- a/examples/nemotron3/__init__.py
+++ b/examples/nemotron3/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Direct HybridModel architecture examples for Nemotron 3 models."""
+
+from .nemotron_3_5_nano_30b_a3b import make_model_config as make_nano_model_config
+from .nemotron_labs_3_puzzle_75b_a9b import make_model_config as make_puzzle_model_config
+
+__all__ = ["make_nano_model_config", "make_puzzle_model_config"]

--- a/examples/nemotron3/nemotron_3_5_nano_30b_a3b.py
+++ b/examples/nemotron3/nemotron_3_5_nano_30b_a3b.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Architecture-only Nemotron 3.5 Nano 30B-A3B HybridModel example.
+
+The direct layer definition intentionally reuses one configuration per layer
+family. Nemotron 3.5 Nano is therefore a compatibility example for the direct
+API, not an example of occurrence-specific layer heterogeneity.
+
+Model dimensions are based on:
+https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16/blob/main/config.json
+"""
+
+from copy import deepcopy
+
+import torch
+
+from megatron.core.activations import squared_relu
+from megatron.core.models.hybrid.hybrid_architecture import HybridLayerSpec, PipelineSplit
+from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_stack_spec
+from megatron.core.transformer import TransformerConfig
+from megatron.training.models.hybrid import HybridModelConfig
+
+
+def _transformer_config() -> TransformerConfig:
+    """Return the model-wide Nano transformer configuration."""
+
+    return TransformerConfig(
+        num_layers=52,
+        hidden_size=2688,
+        num_attention_heads=32,
+        num_query_groups=2,
+        kv_channels=128,
+        ffn_hidden_size=1856,
+        moe_ffn_hidden_size=1856,
+        num_moe_experts=128,
+        moe_router_topk=6,
+        moe_router_num_groups=1,
+        moe_router_group_topk=1,
+        moe_router_topk_scaling_factor=2.5,
+        moe_router_score_function="sigmoid",
+        moe_router_enable_expert_bias=True,
+        moe_router_load_balancing_type="seq_aux_loss",
+        moe_shared_expert_intermediate_size=3712,
+        moe_token_dispatcher_type="alltoall",
+        moe_grouped_gemm=True,
+        mamba_state_dim=128,
+        mamba_head_dim=64,
+        mamba_num_heads=64,
+        mamba_num_groups=8,
+        mtp_num_layers=2,
+        mtp_use_repeated_layer=True,
+        activation_func=squared_relu,
+        gated_linear_unit=False,
+        add_bias_linear=False,
+        add_qkv_bias=False,
+        normalization="RMSNorm",
+        layernorm_epsilon=1.0e-5,
+        attention_dropout=0.0,
+        hidden_dropout=0.0,
+        init_method_std=0.02,
+        is_hybrid_model=True,
+        bf16=True,
+        params_dtype=torch.bfloat16,
+        pipeline_dtype=torch.bfloat16,
+        pipeline_model_parallel_size=2,
+    )
+
+
+def make_model_config() -> HybridModelConfig:
+    """Define Nano with direct specs split into PP2/VPP2 logical chunks."""
+
+    transformer = _transformer_config()
+    submodules = hybrid_stack_spec.submodules
+
+    # Aliases make the family-uniform nature of Nano explicit. The architecture
+    # resolver isolates the configuration of every resolved occurrence.
+    mamba = HybridLayerSpec(module_spec=submodules.mamba_layer, config=deepcopy(transformer))
+    attention = HybridLayerSpec(
+        module_spec=submodules.attention_layer, config=deepcopy(transformer)
+    )
+    moe = HybridLayerSpec(module_spec=submodules.moe_layer, config=deepcopy(transformer))
+
+    # Chunks are VPP-major then PP-rank: (vp0, pp0), (vp0, pp1),
+    # (vp1, pp0), (vp1, pp1). Each chunk contains exactly 13 layers.
+    chunk_0 = [mamba, moe] * 2 + [mamba, attention, moe] + [mamba, moe] * 2 + [mamba, attention]
+    chunk_1 = [moe, mamba] * 3 + [attention] + [moe, mamba] * 3
+    chunk_2 = [attention] + [moe, mamba] * 3 + [attention] + [moe, mamba] * 2 + [moe]
+    chunk_3 = [mamba, moe, mamba, attention, moe] + [mamba, moe] * 4
+
+    layer_specs = [
+        chunk_0,
+        PipelineSplit(),
+        chunk_1,
+        PipelineSplit(),
+        chunk_2,
+        PipelineSplit(),
+        chunk_3,
+    ]
+
+    mtp_attention = HybridLayerSpec(
+        module_spec=submodules.attention_layer, config=deepcopy(transformer)
+    )
+    mtp_moe = HybridLayerSpec(module_spec=submodules.moe_layer, config=deepcopy(transformer))
+
+    return HybridModelConfig(
+        transformer=transformer,
+        layer_specs=layer_specs,
+        mtp_layer_specs=[mtp_attention, mtp_moe],
+        vocab_size=131072,
+        seq_length=262144,
+        position_embedding_type="none",
+        parallel_output=True,
+        share_embeddings_and_output_weights=False,
+    )
+
+
+__all__ = ["make_model_config"]

--- a/examples/nemotron3/nemotron_labs_3_puzzle_75b_a9b.py
+++ b/examples/nemotron3/nemotron_labs_3_puzzle_75b_a9b.py
@@ -1,0 +1,218 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Architecture-only NVIDIA Nemotron Labs 3 Puzzle 75B-A9B example.
+
+Unlike Nano, Puzzle is heterogeneous within the MoE family: every MoE
+occurrence carries the expert width and router top-k published for that block.
+
+Model dimensions and ordered block configurations are based on:
+https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Puzzle-75B-A9B-BF16/blob/main/config.json
+"""
+
+from copy import deepcopy
+
+import torch
+
+from megatron.core.activations import squared_relu
+from megatron.core.models.hybrid.hybrid_architecture import HybridLayerSpec, PipelineSplit
+from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_stack_spec
+from megatron.core.transformer import TransformerConfig
+from megatron.training.models.hybrid import HybridModelConfig
+
+
+def _transformer_config() -> TransformerConfig:
+    """Return the model-wide Puzzle transformer configuration."""
+
+    return TransformerConfig(
+        num_layers=88,
+        hidden_size=4096,
+        num_attention_heads=32,
+        num_query_groups=2,
+        kv_channels=128,
+        ffn_hidden_size=21504,
+        moe_ffn_hidden_size=1280,
+        num_moe_experts=512,
+        moe_router_topk=4,
+        moe_router_num_groups=1,
+        moe_router_group_topk=1,
+        moe_router_topk_scaling_factor=5.0,
+        moe_router_score_function="sigmoid",
+        moe_router_enable_expert_bias=True,
+        moe_router_load_balancing_type="seq_aux_loss",
+        moe_shared_expert_intermediate_size=5376,
+        moe_shared_expert_overlap=True,
+        moe_latent_size=1024,
+        moe_token_dispatcher_type="alltoall",
+        moe_grouped_gemm=True,
+        mamba_state_dim=96,
+        mamba_head_dim=64,
+        mamba_num_heads=128,
+        mamba_num_groups=8,
+        mtp_num_layers=1,
+        mtp_use_repeated_layer=False,
+        activation_func=squared_relu,
+        gated_linear_unit=False,
+        add_bias_linear=False,
+        add_qkv_bias=False,
+        normalization="RMSNorm",
+        layernorm_epsilon=1.0e-5,
+        attention_dropout=0.0,
+        hidden_dropout=0.0,
+        init_method_std=0.02,
+        is_hybrid_model=True,
+        bf16=True,
+        params_dtype=torch.bfloat16,
+        pipeline_dtype=torch.bfloat16,
+        pipeline_model_parallel_size=2,
+    )
+
+
+def _moe_layer(base_config: TransformerConfig, width: int, topk: int) -> HybridLayerSpec:
+    """Create one occurrence-specific stock MoE layer."""
+
+    config = deepcopy(base_config)
+    config.moe_ffn_hidden_size = width
+    config.moe_router_topk = topk
+    return HybridLayerSpec(module_spec=hybrid_stack_spec.submodules.moe_layer, config=config)
+
+
+def make_model_config() -> HybridModelConfig:
+    """Define Puzzle with direct specs split into PP2/VPP2 logical chunks."""
+
+    transformer = _transformer_config()
+    submodules = hybrid_stack_spec.submodules
+    mamba = HybridLayerSpec(module_spec=submodules.mamba_layer, config=deepcopy(transformer))
+    attention = HybridLayerSpec(
+        module_spec=submodules.attention_layer, config=deepcopy(transformer)
+    )
+
+    def moe(width: int, topk: int) -> HybridLayerSpec:
+        return _moe_layer(transformer, width, topk)
+
+    # Chunks are VPP-major then PP-rank. The inline MoE arguments are the
+    # published blockwise (expert width, active experts) values.
+    chunk_0 = [
+        mamba,
+        moe(1280, 4),
+        mamba,
+        moe(1280, 8),
+        mamba,
+        moe(1280, 10),
+        mamba,
+        attention,
+        moe(1280, 8),
+        mamba,
+        moe(1280, 8),
+        mamba,
+        moe(1280, 8),
+        mamba,
+        moe(1280, 12),
+        mamba,
+        attention,
+        moe(1280, 8),
+        mamba,
+        moe(1280, 10),
+        mamba,
+        moe(1280, 8),
+    ]
+    chunk_1 = [
+        mamba,
+        moe(2688, 12),
+        mamba,
+        attention,
+        moe(1536, 14),
+        mamba,
+        moe(2688, 12),
+        mamba,
+        moe(1536, 12),
+        mamba,
+        moe(1536, 12),
+        mamba,
+        moe(2688, 12),
+        mamba,
+        attention,
+        moe(2688, 12),
+        mamba,
+        moe(2688, 12),
+        mamba,
+        moe(1536, 10),
+        mamba,
+        moe(2688, 12),
+    ]
+    chunk_2 = [
+        mamba,
+        moe(2688, 12),
+        mamba,
+        attention,
+        moe(1792, 12),
+        mamba,
+        moe(1792, 14),
+        mamba,
+        moe(1280, 10),
+        mamba,
+        moe(1280, 10),
+        mamba,
+        moe(1280, 12),
+        mamba,
+        attention,
+        moe(1280, 8),
+        mamba,
+        moe(1280, 12),
+        mamba,
+        moe(1280, 10),
+        mamba,
+        moe(1280, 8),
+    ]
+    chunk_3 = [
+        mamba,
+        moe(1280, 8),
+        mamba,
+        attention,
+        moe(1280, 10),
+        mamba,
+        moe(1280, 10),
+        mamba,
+        moe(1280, 10),
+        mamba,
+        moe(1280, 12),
+        mamba,
+        attention,
+        moe(1280, 12),
+        mamba,
+        moe(1280, 14),
+        mamba,
+        moe(1280, 16),
+        mamba,
+        moe(1792, 18),
+        mamba,
+        moe(2048, 18),
+    ]
+
+    layer_specs = [
+        chunk_0,
+        PipelineSplit(),
+        chunk_1,
+        PipelineSplit(),
+        chunk_2,
+        PipelineSplit(),
+        chunk_3,
+    ]
+
+    mtp_attention = HybridLayerSpec(
+        module_spec=submodules.attention_layer, config=deepcopy(transformer)
+    )
+    mtp_moe = _moe_layer(transformer, width=2688, topk=22)
+
+    return HybridModelConfig(
+        transformer=transformer,
+        layer_specs=layer_specs,
+        mtp_layer_specs=[mtp_attention, mtp_moe],
+        vocab_size=131072,
+        seq_length=262144,
+        position_embedding_type="none",
+        parallel_output=True,
+        share_embeddings_and_output_weights=False,
+    )
+
+
+__all__ = ["make_model_config"]

--- a/megatron/core/inference/apis/_llm_base.py
+++ b/megatron/core/inference/apis/_llm_base.py
@@ -17,7 +17,7 @@ from typing import Coroutine, List, Optional, Tuple, Union
 
 import torch.distributed as dist
 
-from megatron.core.inference.config import InferenceConfig
+from megatron.core.inference.config import InferenceConfig, validate_dynamic_inference_model
 from megatron.core.inference.contexts.dynamic_context import DynamicInferenceContext
 from megatron.core.inference.engines.dynamic_engine import DynamicInferenceEngine, EngineState
 from megatron.core.inference.inference_request import DynamicInferenceRequest
@@ -279,6 +279,7 @@ class _MegatronLLMBase:
             inference_config = InferenceConfig()
 
         # Build the engine pipeline. Mirrors examples/inference/gpt/gpt_dynamic_inference.py.
+        validate_dynamic_inference_model(model)
         context = DynamicInferenceContext(model.config, inference_config)
         wrapper = GPTInferenceWrapper(model, context)
         controller = TextGenerationController(inference_wrapped_model=wrapper, tokenizer=tokenizer)

--- a/megatron/core/inference/config.py
+++ b/megatron/core/inference/config.py
@@ -12,6 +12,29 @@ from megatron.core.transformer.module import MegatronModule
 from megatron.core.utils import get_attr_wrapped_model
 
 
+def validate_dynamic_inference_model(model: MegatronModule) -> None:
+    """Reject incompatible direct specs before model-global inference buffers are allocated."""
+
+    from megatron.core.models.hybrid.hybrid_architecture import ResolvedHybridArchitecture
+
+    try:
+        architecture = get_attr_wrapped_model(model, "resolved_hybrid_architecture")
+    except RuntimeError:
+        return
+    if not isinstance(architecture, ResolvedHybridArchitecture):
+        return
+    if architecture.source != "direct":
+        return
+
+    model_config = get_attr_wrapped_model(model, "config", allow_none=False)
+    if architecture.has_incompatible_dynamic_inference_shapes(model_config):
+        raise NotImplementedError(
+            "Direct HybridModel occurrence configurations are incompatible with dynamic "
+            "inference's model-global cache or runtime buffers (Mamba state/cache dimensions, "
+            "attention KV dimensions, or MoE router top-k values)."
+        )
+
+
 @dataclass
 class MambaInferenceStateConfig:
     """
@@ -49,14 +72,41 @@ class MambaInferenceStateConfig:
         model: MegatronModule,
         conv_states_dtype: Optional[torch.dtype] = None,
         ssm_states_dtype: Optional[torch.dtype] = None,
+        *,
+        validate_dynamic_inference: bool = True,
     ) -> Optional["MambaInferenceStateConfig"]:
-        """Returns Mamba inference state config from the model if it is a hybrid model."""
+        """Returns Mamba inference state config from the model if it is a hybrid model.
+
+        Args:
+            validate_dynamic_inference: Validate direct specs against the model-global buffers
+                used by dynamic inference. The explicit legacy static engine disables this
+                because its Mamba, attention, and MoE state is allocated by each layer.
+        """
         from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols
 
+        if validate_dynamic_inference:
+            validate_dynamic_inference_model(model)
         decoder = get_attr_wrapped_model(model, "decoder")
         layer_type_list = getattr(decoder, "layer_type_list", None)
+        # HybridStack's first-class API exposes stable semantic names, while
+        # dynamic inference's layer maps intentionally retain legacy symbols.
+        semantic_to_symbol = {
+            "mamba": Symbols.MAMBA,
+            "gdn": Symbols.GDN,
+            "attention": Symbols.ATTENTION,
+            "dsa": Symbols.DS_ATTENTION,
+            "mla": Symbols.MLA,
+            "mlp": Symbols.MLP,
+            "moe": Symbols.MOE,
+        }
+        if layer_type_list is not None and any(
+            layer_type in semantic_to_symbol for layer_type in layer_type_list
+        ):
+            layer_type_list = [
+                semantic_to_symbol.get(layer_type, layer_type) for layer_type in layer_type_list
+            ]
         if layer_type_list is not None and Symbols.MAMBA in layer_type_list:
-            (mamba_conv_states_shape, mamba_ssm_states_shape) = (
+            mamba_conv_states_shape, mamba_ssm_states_shape = (
                 decoder.mamba_state_shapes_per_request()
             )
             if conv_states_dtype is None:
@@ -73,7 +123,7 @@ class MambaInferenceStateConfig:
             elif ssm_states_dtype is None:
                 ssm_states_dtype = model.config.params_dtype
             mamba_chunk_size = 128
-            for layer_type, layer in zip(decoder.layer_type_list, decoder.layers):
+            for layer_type, layer in zip(layer_type_list, decoder.layers):
                 if layer_type == Symbols.MAMBA and hasattr(layer, 'mixer'):
                     mamba_chunk_size = layer.mixer.chunk_size
                     break

--- a/megatron/core/inference/engines/static_engine.py
+++ b/megatron/core/inference/engines/static_engine.py
@@ -94,7 +94,7 @@ class StaticInferenceEngine(AbstractEngine):
         self.scheduler = Scheduler(max_batch_size=max_batch_size)
 
         mamba_inference_state_config = MambaInferenceStateConfig.from_model(
-            self.inference_wrapped_model.model
+            self.inference_wrapped_model.model, validate_dynamic_inference=not legacy
         )
 
         try:

--- a/megatron/core/models/hybrid/__init__.py
+++ b/megatron/core/models/hybrid/__init__.py
@@ -1,1 +1,19 @@
 # Copyright (c) 2024-2026, NVIDIA CORPORATION. All rights reserved.
+
+from megatron.core.models.hybrid.hybrid_architecture import (
+    HybridLayerPattern,
+    HybridLayerSpec,
+    PipelineSplit,
+    ResolvedHybridArchitecture,
+    flatten_hybrid_layer_pattern,
+    resolve_hybrid_architecture,
+)
+
+__all__ = [
+    "HybridLayerPattern",
+    "HybridLayerSpec",
+    "PipelineSplit",
+    "ResolvedHybridArchitecture",
+    "flatten_hybrid_layer_pattern",
+    "resolve_hybrid_architecture",
+]

--- a/megatron/core/models/hybrid/hybrid_architecture.py
+++ b/megatron/core/models/hybrid/hybrid_architecture.py
@@ -1,0 +1,535 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""First-class architecture descriptions for :class:`HybridModel`.
+
+This module deliberately keeps the public surface small.  A layer occurrence is
+an existing :class:`~megatron.core.transformer.spec_utils.ModuleSpec` paired with
+the :class:`~megatron.core.transformer.transformer_config.TransformerConfig`
+that should be passed to that layer.  Nested Python lists provide composition,
+and :class:`PipelineSplit` provides explicit PP/VPP chunk boundaries.
+"""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+from typing import Any, Sequence, TypeAlias
+
+from megatron.core.models.hybrid.hybrid_layer_allocation import (
+    Symbols,
+    parse_hybrid_pattern,
+    validate_segment_layers,
+)
+from megatron.core.transformer.spec_utils import ModuleSpec
+from megatron.core.transformer.transformer_config import TransformerConfig
+
+HYBRID_LAYER_TYPE = "hybrid_layer_type"
+VALID_HYBRID_LAYER_TYPES = frozenset({"mamba", "gdn", "attention", "dsa", "mla", "mlp", "moe"})
+
+
+@dataclass(frozen=True, slots=True)
+class PipelineSplit:
+    """A boundary between two physical or virtual pipeline model chunks."""
+
+
+@dataclass(frozen=True, slots=True)
+class HybridLayerSpec:
+    """An existing layer spec paired with its per-occurrence configuration.
+
+    Args:
+        module_spec: Specification for an existing Megatron Core layer class.
+        config: Complete transformer configuration to pass to this occurrence.
+    """
+
+    module_spec: ModuleSpec
+    config: TransformerConfig
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.module_spec, ModuleSpec):
+            raise TypeError(
+                f"module_spec must be a ModuleSpec, got {type(self.module_spec).__name__}."
+            )
+        if not isinstance(self.config, TransformerConfig):
+            raise TypeError(
+                f"config must be a TransformerConfig, got {type(self.config).__name__}."
+            )
+        # Resolve eagerly so malformed public descriptors fail at recipe construction.
+        _get_layer_type(self.module_spec)
+
+    @property
+    def layer_type(self) -> str:
+        """Return the stable semantic type carried by ``ModuleSpec.metainfo``."""
+
+        return _get_layer_type(self.module_spec)
+
+
+HybridLayerPattern: TypeAlias = Sequence["HybridLayerSpec | PipelineSplit | HybridLayerPattern"]
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedHybridArchitecture:
+    """A validated global hybrid architecture shared by every PP/VPP chunk."""
+
+    segments: tuple[tuple[HybridLayerSpec, ...], ...]
+    mtp_layers: tuple[HybridLayerSpec, ...] = ()
+    mtp_num_layers: int = 0
+    source: str = "direct"
+
+    @property
+    def main_layers(self) -> tuple[HybridLayerSpec, ...]:
+        """Return decoder occurrences in global model order."""
+
+        return tuple(layer for segment in self.segments for layer in segment)
+
+    @property
+    def metric_num_layers(self) -> int:
+        """Return the number of explicit layer slots used by MoE metrics."""
+
+        return len(self.main_layers) + self.mtp_num_layers * len(self.mtp_layers)
+
+    def select_segment(
+        self, *, pp_rank: int, pp_size: int, vp_stage: int | None
+    ) -> tuple[tuple[HybridLayerSpec, ...], int]:
+        """Select a local chunk and its global decoder-layer offset.
+
+        Segments use the same VPP-major ordering as the legacy ``|`` syntax:
+        ``segment_index = vp_stage * pp_size + pp_rank``.
+        """
+
+        vp_rank = 0 if vp_stage is None else vp_stage
+        segment_index = vp_rank * pp_size + pp_rank
+        if segment_index >= len(self.segments):
+            raise ValueError(
+                f"Pipeline segment index {segment_index} is out of range for "
+                f"{len(self.segments)} resolved segments (pp_rank={pp_rank}, "
+                f"pp_size={pp_size}, vp_stage={vp_stage})."
+            )
+        offset = sum(len(segment) for segment in self.segments[:segment_index])
+        return self.segments[segment_index], offset
+
+    @property
+    def has_heterogeneous_inference_shapes(self) -> bool:
+        """Whether dynamic inference would need non-uniform cache/buffer shapes."""
+
+        layers = self.main_layers + self.mtp_layers
+        signatures: dict[str, set[tuple[Any, ...]]] = {
+            "mamba": set(),
+            "attention": set(),
+            "moe": set(),
+        }
+        for layer in layers:
+            config = layer.config
+            if layer.layer_type == "mamba":
+                signatures["mamba"].add(
+                    (
+                        config.mamba_state_dim,
+                        config.mamba_head_dim,
+                        config.mamba_num_heads,
+                        config.mamba_num_groups,
+                    )
+                )
+            elif layer.layer_type == "attention":
+                signatures["attention"].add(
+                    (config.num_query_groups or config.num_attention_heads, config.kv_channels)
+                )
+            elif layer.layer_type == "moe":
+                signatures["moe"].add((config.moe_router_topk,))
+        return any(len(values) > 1 for values in signatures.values())
+
+    def has_incompatible_dynamic_inference_shapes(self, base_config: TransformerConfig) -> bool:
+        """Whether dynamic inference's model-global buffers fit every occurrence.
+
+        Dynamic inference currently allocates attention KV and MoE routing buffers
+        from the model-wide config.  Even a family-uniform direct override is
+        incompatible when it differs from that allocation source.  Mamba state
+        shapes are discovered from the built layer, so only differing Mamba
+        occurrences are rejected.
+        """
+
+        if self.has_heterogeneous_inference_shapes:
+            return True
+
+        base_attention_signature = (
+            base_config.num_query_groups or base_config.num_attention_heads,
+            base_config.kv_channels,
+        )
+        layers = self.main_layers + self.mtp_layers
+        for layer in layers:
+            if layer.layer_type == "attention":
+                occurrence_signature = (
+                    layer.config.num_query_groups or layer.config.num_attention_heads,
+                    layer.config.kv_channels,
+                )
+                if occurrence_signature != base_attention_signature:
+                    return True
+            elif (
+                layer.layer_type == "moe"
+                and layer.config.moe_router_topk != base_config.moe_router_topk
+            ):
+                return True
+        return False
+
+
+def flatten_hybrid_layer_pattern(
+    pattern: HybridLayerPattern, *, allow_splits: bool = True
+) -> tuple[tuple[HybridLayerSpec, ...], ...]:
+    """Recursively flatten a direct Python pattern while preserving split nodes.
+
+    Args:
+        pattern: Nested lists or tuples containing layer descriptors and split nodes.
+        allow_splits: If false, encountering :class:`PipelineSplit` is an error.
+
+    Returns:
+        A tuple of flat pipeline segments. Empty segments are intentionally retained.
+    """
+
+    segments: list[list[HybridLayerSpec]] = [[]]
+
+    def visit(node: Any, path: tuple[int, ...]) -> None:
+        if isinstance(node, HybridLayerSpec):
+            segments[-1].append(node)
+            return
+        if isinstance(node, PipelineSplit):
+            if not allow_splits:
+                raise ValueError(
+                    f"PipelineSplit at path {list(path)} is not allowed in an MTP pattern."
+                )
+            segments.append([])
+            return
+        if isinstance(node, (list, tuple)):
+            for index, child in enumerate(node):
+                visit(child, path + (index,))
+            return
+        raise TypeError(
+            f"Hybrid layer pattern leaf at path {list(path)} has unsupported type "
+            f"{type(node).__name__}; expected HybridLayerSpec, PipelineSplit, list, or tuple."
+        )
+
+    visit(pattern, ())
+    return tuple(tuple(segment) for segment in segments)
+
+
+def resolve_hybrid_architecture(
+    *,
+    config: TransformerConfig,
+    hybrid_stack_spec: ModuleSpec,
+    layer_specs: HybridLayerPattern | None = None,
+    mtp_layer_specs: HybridLayerPattern | None = None,
+    hybrid_layer_pattern: str | None = None,
+) -> ResolvedHybridArchitecture:
+    """Resolve direct descriptors or a legacy string into one global architecture.
+
+    Direct split nodes are authoritative for PP/VPP chunking.  Legacy strings retain
+    their existing pipe-free even/uneven PP compatibility behavior.
+    """
+
+    if layer_specs is not None and hybrid_layer_pattern is not None:
+        raise ValueError("layer_specs and hybrid_layer_pattern are mutually exclusive.")
+    if layer_specs is None and hybrid_layer_pattern is None:
+        raise ValueError("Exactly one of layer_specs or hybrid_layer_pattern must be provided.")
+    if mtp_layer_specs is not None and layer_specs is None:
+        raise ValueError("mtp_layer_specs requires direct layer_specs.")
+
+    if layer_specs is not None:
+        if config.mtp_standalone:
+            raise ValueError("Direct hybrid architectures do not support standalone MTP placement.")
+        raw_segments = flatten_hybrid_layer_pattern(layer_specs)
+        _validate_direct_pipeline(config, raw_segments)
+        raw_mtp_segments = (
+            flatten_hybrid_layer_pattern(mtp_layer_specs, allow_splits=False)
+            if mtp_layer_specs is not None
+            else ((),)
+        )
+        raw_mtp_layers = raw_mtp_segments[0]
+        mtp_num_layers = config.mtp_num_layers or 0
+        if raw_mtp_layers and mtp_num_layers <= 0:
+            raise ValueError("mtp_layer_specs requires config.mtp_num_layers > 0.")
+        if mtp_num_layers > 0 and not raw_mtp_layers:
+            raise ValueError("config.mtp_num_layers > 0 requires mtp_layer_specs.")
+
+        segments = tuple(
+            tuple(_materialize_layer(layer, config) for layer in segment)
+            for segment in raw_segments
+        )
+        mtp_layers = tuple(_materialize_layer(layer, config) for layer in raw_mtp_layers)
+        architecture = ResolvedHybridArchitecture(
+            segments=segments, mtp_layers=mtp_layers, mtp_num_layers=mtp_num_layers, source="direct"
+        )
+        _validate_mtp_placement(architecture)
+        _validate_uniform_expert_count(architecture, config)
+        return architecture
+
+    return _resolve_legacy_architecture(config, hybrid_stack_spec, hybrid_layer_pattern)
+
+
+def _validate_direct_pipeline(
+    config: TransformerConfig, segments: tuple[tuple[HybridLayerSpec, ...], ...]
+) -> None:
+    pp_size = config.pipeline_model_parallel_size
+    num_segments = len(segments)
+    num_layers = sum(len(segment) for segment in segments)
+
+    if num_layers != config.num_layers:
+        raise ValueError(
+            f"Direct layer_specs contains {num_layers} decoder layers, but "
+            f"TransformerConfig.num_layers is {config.num_layers}."
+        )
+    if pp_size <= 0:
+        raise ValueError(f"pipeline_model_parallel_size must be positive, got {pp_size}.")
+    if pp_size > 1 and num_segments == 1:
+        raise ValueError(
+            "Direct layer_specs with pipeline_model_parallel_size > 1 must contain "
+            "explicit PipelineSplit() boundaries."
+        )
+    if num_segments % pp_size != 0:
+        raise ValueError(
+            f"Direct layer_specs defines {num_segments} pipeline segments, which is not "
+            f"divisible by pipeline_model_parallel_size={pp_size}."
+        )
+
+    inferred_vp_size = num_segments // pp_size
+    if pp_size == 1 and inferred_vp_size > 1:
+        raise ValueError("Virtual pipeline parallelism requires pipeline_model_parallel_size > 1.")
+    configured_vp_size = config.virtual_pipeline_model_parallel_size
+    if configured_vp_size is not None and configured_vp_size != inferred_vp_size:
+        raise ValueError(
+            f"PipelineSplit() nodes imply virtual_pipeline_model_parallel_size="
+            f"{inferred_vp_size}, but the config specifies {configured_vp_size}."
+        )
+
+    if num_segments > 1:
+        conflicts = {
+            "pipeline_model_parallel_layout": config.pipeline_model_parallel_layout,
+            "num_layers_in_first_pipeline_stage": config.num_layers_in_first_pipeline_stage,
+            "num_layers_in_last_pipeline_stage": config.num_layers_in_last_pipeline_stage,
+            "account_for_embedding_in_pipeline_split": (
+                config.account_for_embedding_in_pipeline_split
+            ),
+            "account_for_loss_in_pipeline_split": config.account_for_loss_in_pipeline_split,
+        }
+        active_conflicts = [name for name, value in conflicts.items() if value not in (None, False)]
+        if active_conflicts:
+            raise ValueError(
+                "PipelineSplit() already defines pipeline ownership and cannot be combined with: "
+                + ", ".join(active_conflicts)
+            )
+
+    config.virtual_pipeline_model_parallel_size = inferred_vp_size if inferred_vp_size > 1 else None
+
+
+def _resolve_legacy_architecture(
+    config: TransformerConfig, hybrid_stack_spec: ModuleSpec, hybrid_layer_pattern: str | None
+) -> ResolvedHybridArchitecture:
+    parsed = parse_hybrid_pattern(hybrid_layer_pattern)
+    submodules = hybrid_stack_spec.submodules
+    symbol_fields = {
+        Symbols.MAMBA: ("mamba", "mamba_layer"),
+        Symbols.GDN: ("gdn", "gdn_layer"),
+        Symbols.ATTENTION: ("attention", "attention_layer"),
+        Symbols.DS_ATTENTION: ("dsa", "dsa_layer"),
+        Symbols.MLA: ("mla", "mla_layer"),
+        Symbols.MLP: ("mlp", "mlp_layer"),
+        Symbols.MOE: ("moe", "moe_layer"),
+    }
+
+    def descriptor(symbol: str) -> HybridLayerSpec:
+        layer_type, field_name = symbol_fields[symbol]
+        return HybridLayerSpec(
+            module_spec=_legacy_module_spec(getattr(submodules, field_name), layer_type),
+            config=config,
+        )
+
+    main_pattern = parsed.main_pattern or ""
+    # This is a read-only summary of the legacy pattern, not a replacement for
+    # select_pipeline_segment().  In particular, do not infer or mutate PP/VPP
+    # settings, or add validation that existing HybridModel callers did not see.
+    pattern_segments = main_pattern.split(Symbols.PIPE)
+
+    segments = tuple(
+        tuple(descriptor(symbol) for symbol in validate_segment_layers(segment))
+        for segment in pattern_segments
+    )
+
+    mtp_layers: tuple[HybridLayerSpec, ...] = ()
+    if parsed.mtp_pattern:
+        mtp_layers = tuple(
+            descriptor(symbol) for symbol in validate_segment_layers(parsed.mtp_pattern)
+        )
+    return ResolvedHybridArchitecture(
+        segments=segments,
+        mtp_layers=mtp_layers,
+        mtp_num_layers=parsed.mtp_num_depths,
+        source="legacy",
+    )
+
+
+_UNIFORM_CONFIG_FIELDS = (
+    "hidden_size",
+    "params_dtype",
+    "pipeline_dtype",
+    "fp16",
+    "bf16",
+    "fp32_residual_connection",
+    "enable_autocast",
+    "autocast_dtype",
+    "apply_query_key_layer_scaling",
+    "attention_softmax_in_fp32",
+    "disable_bf16_reduced_precision_matmul",
+    "dsa_indexer_k_norm_fp32",
+    "fp8",
+    "fp8_recipe",
+    "fp8_param",
+    "fp8_quantizer_factory",
+    "fp8_margin",
+    "fp8_interval",
+    "fp8_amax_history_len",
+    "fp8_amax_compute_algo",
+    "fp8_wgrad",
+    "fp8_output_proj",
+    "fp8_dot_product_attention",
+    "fp8_multi_head_attention",
+    "tp_only_amax_red",
+    "activation_func_fp8_input_store",
+    "first_last_layers_bf16",
+    "num_layers_at_start_in_bf16",
+    "num_layers_at_end_in_bf16",
+    "moe_router_dtype",
+    "mamba_training_ssm_states_dtype",
+    "fp4",
+    "fp4_recipe",
+    "fp4_param",
+    "fp4_quantizer_factory",
+    "quant_recipe",
+    "normalization",
+    "layernorm_epsilon",
+    "layernorm_zero_centered_gamma",
+    "tensor_model_parallel_size",
+    "tensor_parallel_num_weight_shards",
+    "gtp_weight_remat_size",
+    "pipeline_model_parallel_size",
+    "pipeline_model_parallel_comm_backend",
+    "context_parallel_size",
+    "hierarchical_context_parallel_sizes",
+    "max_seqlen_per_dp_cp_rank",
+    "hybrid_context_parallel",
+    "expert_model_parallel_size",
+    "expert_tensor_parallel_size",
+    "expert_tensor_parallel_num_weight_shards",
+    "expert_gtp_weight_remat_size",
+    "sequence_parallel",
+)
+
+_TOPOLOGY_CONFIG_FIELDS = (
+    "num_layers",
+    "pipeline_model_parallel_size",
+    "virtual_pipeline_model_parallel_size",
+    "pipeline_model_parallel_layout",
+    "num_layers_in_first_pipeline_stage",
+    "num_layers_in_last_pipeline_stage",
+    "account_for_embedding_in_pipeline_split",
+    "account_for_loss_in_pipeline_split",
+    "mtp_num_layers",
+    "mtp_use_repeated_layer",
+    "mtp_standalone",
+)
+
+
+def _materialize_layer(layer: HybridLayerSpec, base_config: TransformerConfig) -> HybridLayerSpec:
+    for field_name in _UNIFORM_CONFIG_FIELDS:
+        layer_value = getattr(layer.config, field_name)
+        base_value = getattr(base_config, field_name)
+        if layer_value != base_value:
+            raise ValueError(
+                f"Per-layer config for {layer.layer_type!r} changes model-wide field "
+                f"{field_name!r}: {layer_value!r} != {base_value!r}."
+            )
+    return HybridLayerSpec(
+        module_spec=layer.module_spec, config=_materialize_config(layer.config, base_config)
+    )
+
+
+def _materialize_config(
+    layer_config: TransformerConfig, base_config: TransformerConfig
+) -> TransformerConfig:
+    materialized = copy.deepcopy(layer_config)
+    for field_name in _TOPOLOGY_CONFIG_FIELDS:
+        setattr(materialized, field_name, getattr(base_config, field_name))
+    return materialized
+
+
+def _validate_mtp_placement(architecture: ResolvedHybridArchitecture) -> None:
+    """Reject a prediction block on a logical chunk with no decoder layers."""
+
+    if (
+        architecture.mtp_layers
+        and architecture.mtp_num_layers > 0
+        and not architecture.segments[-1]
+    ):
+        raise ValueError(
+            "MTP must share the final logical PP/VPP chunk with at least one decoder layer; "
+            "standalone MTP placement is not supported."
+        )
+
+
+def _validate_uniform_expert_count(
+    architecture: ResolvedHybridArchitecture, base_config: TransformerConfig
+) -> None:
+    expert_counts = {
+        layer.config.num_moe_experts
+        for layer in architecture.main_layers + architecture.mtp_layers
+        if layer.layer_type == "moe"
+    }
+    if len(expert_counts) > 1:
+        raise ValueError(
+            "All MoE occurrences must use one uniform num_moe_experts value; got "
+            f"{sorted(expert_counts)}."
+        )
+    if expert_counts and next(iter(expert_counts)) != base_config.num_moe_experts:
+        occurrence_count = next(iter(expert_counts))
+        raise ValueError(
+            "MoE occurrence num_moe_experts must match the model-wide config; "
+            f"got {occurrence_count!r} != {base_config.num_moe_experts!r}."
+        )
+
+
+def _get_layer_type(module_spec: ModuleSpec) -> str:
+    layer_type = module_spec.metainfo.get(HYBRID_LAYER_TYPE)
+    if layer_type not in VALID_HYBRID_LAYER_TYPES:
+        raise ValueError(
+            f"ModuleSpec.metainfo[{HYBRID_LAYER_TYPE!r}] must be one of "
+            f"{sorted(VALID_HYBRID_LAYER_TYPES)}, got {layer_type!r}."
+        )
+    return layer_type
+
+
+def _with_layer_type(module_spec: ModuleSpec, layer_type: str) -> ModuleSpec:
+    if not isinstance(module_spec, ModuleSpec):
+        raise TypeError(
+            f"Hybrid stack entry for {layer_type!r} must be a ModuleSpec, got "
+            f"{type(module_spec).__name__}."
+        )
+    if module_spec.metainfo.get(HYBRID_LAYER_TYPE) == layer_type:
+        return module_spec
+    tagged = copy.copy(module_spec)
+    tagged.metainfo = dict(module_spec.metainfo)
+    tagged.metainfo[HYBRID_LAYER_TYPE] = layer_type
+    return tagged
+
+
+def _legacy_module_spec(module_spec: ModuleSpec | type, layer_type: str) -> ModuleSpec:
+    """Tag a legacy stack entry without narrowing its historical accepted types."""
+
+    if isinstance(module_spec, ModuleSpec):
+        return _with_layer_type(module_spec, layer_type)
+    return ModuleSpec(module=module_spec, metainfo={HYBRID_LAYER_TYPE: layer_type})
+
+
+__all__ = [
+    "HYBRID_LAYER_TYPE",
+    "HybridLayerPattern",
+    "HybridLayerSpec",
+    "PipelineSplit",
+    "ResolvedHybridArchitecture",
+    "flatten_hybrid_layer_pattern",
+    "resolve_hybrid_architecture",
+]

--- a/megatron/core/models/hybrid/hybrid_block.py
+++ b/megatron/core/models/hybrid/hybrid_block.py
@@ -8,7 +8,7 @@
 import copy
 from contextlib import nullcontext
 from dataclasses import dataclass
-from typing import Optional, Tuple, Union
+from typing import Optional, Sequence, Tuple, Union
 
 import torch
 from torch import Tensor, nn
@@ -21,6 +21,7 @@ from megatron.core.fp4_utils import get_fp4_context
 from megatron.core.fp8_utils import get_fp8_context
 from megatron.core.inference.contexts import BaseInferenceContext
 from megatron.core.inference.utils import InferenceMode
+from megatron.core.models.hybrid.hybrid_architecture import HybridLayerSpec
 from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols as LayerSymbols
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.process_groups_config import ProcessGroupCollection
@@ -91,6 +92,9 @@ class HybridStack(MegatronModule):
         pg_collection: ProcessGroupCollection = None,
         is_mtp_layer: bool = False,
         name: str | None = None,
+        layer_specs: Optional[Sequence[HybridLayerSpec]] = None,
+        moe_metric_layer_offset: int | None = None,
+        moe_metric_num_layers: int | None = None,
     ) -> None:
         """
         Args:
@@ -111,18 +115,75 @@ class HybridStack(MegatronModule):
         self.input_tensor = None
         self.pg_collection = pg_collection
 
-        assert layer_type_list is not None, (
-            "layer_type_list must be provided. It should be pre-computed from "
-            "--hybrid-layer-pattern by HybridModel."
-        )
-        self.layer_type_list = layer_type_list
+        if layer_specs is None:
+            assert layer_type_list is not None, (
+                "layer_type_list must be provided. It should be pre-computed from "
+                "--hybrid-layer-pattern by HybridModel."
+            )
+            self.layer_type_list = layer_type_list
+            if getattr(self.config, "mla_down_proj_fusion", False):
+                submodules = self._fuse_mla_down_proj(submodules)
+            self.layers = self._build_legacy_layers(
+                submodules=submodules,
+                layer_type_list=layer_type_list,
+                pp_layer_offset=pp_layer_offset,
+                pg_collection=pg_collection,
+                is_mtp_layer=is_mtp_layer,
+                name=name,
+            )
+        else:
+            if layer_type_list is not None:
+                raise ValueError("Specify layer_specs or layer_type_list, not both.")
+            layer_specs = list(layer_specs)
+            if getattr(self.config, "mla_down_proj_fusion", False):
+                layer_specs = [
+                    (
+                        HybridLayerSpec(self._fuse_mla_layer_spec(spec.module_spec), spec.config)
+                        if spec.layer_type == "mla"
+                        else spec
+                    )
+                    for spec in layer_specs
+                ]
+            self.layer_specs = layer_specs
+            self.layer_type_list = [layer.layer_type for layer in layer_specs]
+            self.layers = self._build_direct_layers(
+                layer_specs=layer_specs,
+                pp_layer_offset=pp_layer_offset,
+                pg_collection=pg_collection,
+                is_mtp_layer=is_mtp_layer,
+                name=name,
+                moe_metric_layer_offset=moe_metric_layer_offset,
+                moe_metric_num_layers=moe_metric_num_layers,
+            )
 
-        if getattr(self.config, "mla_down_proj_fusion", False):
-            submodules = self._fuse_mla_down_proj(submodules)
+        if self.config.cuda_graph_impl == "local":
+            annotate_first_last_layer(self.layers)
 
-        # Build layers from the pre-selected segment
-        self.layers = nn.ModuleList()
-        for i, layer_type in enumerate(self.layer_type_list):
+        # Required for activation recomputation
+        self.num_layers_per_pipeline_rank = len(self.layers)
+
+        if self.post_process and self.post_layer_norm:
+            # Final layer norm before output.
+            self.final_norm = TENorm(
+                config=self.config,
+                hidden_size=self.config.hidden_size,
+                eps=self.config.layernorm_epsilon,
+            )
+
+    def _build_legacy_layers(
+        self,
+        *,
+        submodules: HybridStackSubmodules,
+        layer_type_list: list[str],
+        pp_layer_offset: int,
+        pg_collection: ProcessGroupCollection,
+        is_mtp_layer: bool,
+        name: str | None,
+    ) -> nn.ModuleList:
+        """Build the legacy symbol API with its historical per-family kwargs."""
+
+        layers = nn.ModuleList()
+        for i, layer_type in enumerate(layer_type_list):
             layer_number = i + 1 + pp_layer_offset
             if self.config.fp8:
                 quant_init_context = get_fp8_context(self.config, i + pp_layer_offset, is_init=True)
@@ -196,33 +257,89 @@ class HybridStack(MegatronModule):
                         config=self.config,
                         layer_number=layer_number,
                         pg_collection=pg_collection,
-                        # Set to False as we do not want to change offset.
                         add_layer_offset=False,
                         name=(name + f".layers.{i}") if name is not None else None,
                     )
                 else:
                     raise ValueError("unexpected layer_type")
-            self.layers.append(layer)
+            layers.append(layer)
+        return layers
 
-        if self.config.cuda_graph_impl == "local":
-            annotate_first_last_layer(self.layers)
+    def _build_direct_layers(
+        self,
+        *,
+        layer_specs: Sequence[HybridLayerSpec],
+        pp_layer_offset: int,
+        pg_collection: ProcessGroupCollection,
+        is_mtp_layer: bool,
+        name: str | None,
+        moe_metric_layer_offset: int | None,
+        moe_metric_num_layers: int | None,
+    ) -> nn.ModuleList:
+        """Build occurrence-specific existing layer specs."""
 
-        # Required for activation recomputation
-        self.num_layers_per_pipeline_rank = len(self.layers)
+        layers = nn.ModuleList()
+        for i, layer_spec in enumerate(layer_specs):
+            layer_type = layer_spec.layer_type
+            layer_config = layer_spec.config
+            layer_number = i + 1 + pp_layer_offset
+            if layer_config.fp8:
+                quant_init_context = get_fp8_context(
+                    layer_config, i + pp_layer_offset, is_init=True
+                )
+            elif layer_config.fp4:
+                quant_init_context = get_fp4_context(
+                    layer_config, i + pp_layer_offset, is_init=True
+                )
+            else:
+                quant_init_context = nullcontext()
+            with quant_init_context:
+                build_kwargs = {
+                    "config": layer_config,
+                    "layer_number": layer_number,
+                    "pg_collection": pg_collection,
+                    "name": (name + f".layers.{i}") if name is not None else None,
+                }
+                if layer_type == "mamba":
+                    build_kwargs["pp_layer_offset"] = pp_layer_offset
+                else:
+                    build_kwargs["add_layer_offset"] = False
+                    if layer_type != "mlp":
+                        build_kwargs["is_mtp_layer"] = is_mtp_layer
+                    if layer_type in {"attention", "dsa", "mla"}:
+                        build_kwargs["pp_layer_offset"] = pp_layer_offset
+                layer = build_module(layer_spec.module_spec, **build_kwargs)
 
-        if self.post_process and self.post_layer_norm:
-            # Final layer norm before output.
-            self.final_norm = TENorm(
-                config=self.config,
-                hidden_size=self.config.hidden_size,
-                eps=self.config.layernorm_epsilon,
-            )
+            if layer_type == "moe" and moe_metric_layer_offset is not None:
+                metric_layer_number = moe_metric_layer_offset + i + 1
+                if hasattr(layer, "mlp") and hasattr(layer.mlp, "set_metric_layer_number"):
+                    layer.mlp.set_metric_layer_number(metric_layer_number, moe_metric_num_layers)
+            layers.append(layer)
+        return layers
+
+    def set_moe_metric_layer_offset(self, layer_offset: int, num_layers: int | None = None) -> None:
+        """Retarget MoE metric slots without changing model/checkpoint layer numbers."""
+
+        layer_specs = getattr(self, "layer_specs", None)
+        if layer_specs is None:
+            return
+        for index, (layer_spec, layer) in enumerate(zip(layer_specs, self.layers)):
+            if layer_spec.layer_type != "moe":
+                continue
+            if hasattr(layer, "mlp") and hasattr(layer.mlp, "set_metric_layer_number"):
+                layer.mlp.set_metric_layer_number(layer_offset + index + 1, num_layers)
 
     def _fuse_mla_down_proj(self, submodules: HybridStackSubmodules) -> HybridStackSubmodules:
         # Avoid modifying the original object so users don't get surprised about their `submodules`
         # being modified underneath them.
         submodules = copy.deepcopy(submodules)
-        mla_spec = submodules.mla_layer
+        submodules.mla_layer = self._fuse_mla_layer_spec(submodules.mla_layer)
+        return submodules
+
+    def _fuse_mla_layer_spec(self, mla_spec: ModuleSpec) -> ModuleSpec:
+        """Return a private MLA spec with fused down projections enabled."""
+
+        mla_spec = copy.deepcopy(mla_spec)
         # We always fuse the input layernorm because Hybrid always uses TransformerEngine.
         mla_spec.submodules.input_layernorm = IdentityOp
         mla_spec.submodules.self_attention.module = FusedMLASelfAttention
@@ -236,7 +353,7 @@ class HybridStack(MegatronModule):
             "self_attention.linear_kv_down_proj.layer_norm_": "input_layernorm.",
             "self_attention.linear_qkv_down_proj.layer_norm_": "input_layernorm.",
         }
-        return submodules
+        return mla_spec
 
     def set_input_tensor(self, input_tensor: Tensor):
         """Set input tensor to be used instead of forward()'s input.
@@ -254,7 +371,7 @@ class HybridStack(MegatronModule):
         if this block contains Mamba layers (this may not be the case with PP > 1).
         """
         for layer_type, layer in zip(self.layer_type_list, self.layers):
-            if layer_type == LayerSymbols.MAMBA:
+            if layer_type in {LayerSymbols.MAMBA, "mamba"}:
                 return layer.mamba_state_shapes_per_request()
         return None
 
@@ -359,18 +476,29 @@ class HybridStack(MegatronModule):
                     use_inner_quantization_context=(use_inner_fp8_context or use_fp4_context),
                 )
             else:
-                for layer in self.layers:
+                layer_specs = getattr(self, "layer_specs", None)
+                for index, layer in enumerate(self.layers):
+                    layer_spec = layer_specs[index] if layer_specs is not None else None
+                    layer_config = layer_spec.config if layer_spec is not None else self.config
                     # Layers have 1-indexed layer numbers attribute.
                     inner_quant_context = get_inner_quant_context(
-                        self.config, layer.layer_number - 1
+                        layer_config, layer.layer_number - 1
                     )
+                    layer_rotary_pos_emb = rotary_pos_emb
+                    if isinstance(rotary_pos_emb, dict):
+                        assert layer_spec is not None
+                        layer_rotary_pos_emb = (
+                            rotary_pos_emb.get(layer_spec.config.kv_channels)
+                            if layer_spec.layer_type == "attention"
+                            else None
+                        )
                     with inner_quant_context:
                         if isinstance(layer, TransformerLayer):
                             hidden_states, _ = layer(
                                 hidden_states=hidden_states,
                                 attention_mask=attention_mask,
                                 inference_context=inference_context,
-                                rotary_pos_emb=rotary_pos_emb,
+                                rotary_pos_emb=layer_rotary_pos_emb,
                                 sequence_len_offset=sequence_len_offset,
                                 packed_seq_params=packed_seq_params,
                                 padding_mask=padding_mask,

--- a/megatron/core/models/hybrid/hybrid_layer_specs.py
+++ b/megatron/core/models/hybrid/hybrid_layer_specs.py
@@ -14,6 +14,7 @@ from megatron.core.models.gpt.moe_module_specs import (
     get_inference_optimized_moe_spec,
     get_moe_module_spec,
 )
+from megatron.core.models.hybrid.hybrid_architecture import HYBRID_LAYER_TYPE
 from megatron.core.models.hybrid.hybrid_block import HybridStack, HybridStackSubmodules
 from megatron.core.ssm.gated_delta_net import GatedDeltaNet, GatedDeltaNetSubmodules
 from megatron.core.ssm.mamba_layer import MambaLayer, MambaLayerSubmodules
@@ -92,6 +93,7 @@ hybrid_stack_spec = ModuleSpec(
     submodules=HybridStackSubmodules(
         mamba_layer=ModuleSpec(
             module=MambaLayer,
+            metainfo={HYBRID_LAYER_TYPE: "mamba"},
             submodules=MambaLayerSubmodules(
                 mixer=ModuleSpec(
                     module=MambaMixer,
@@ -104,6 +106,7 @@ hybrid_stack_spec = ModuleSpec(
         ),
         gdn_layer=ModuleSpec(
             module=TransformerLayer,
+            metainfo={HYBRID_LAYER_TYPE: "gdn"},
             submodules=TransformerLayerSubmodules(
                 self_attention=ModuleSpec(
                     module=GatedDeltaNet,
@@ -121,6 +124,7 @@ hybrid_stack_spec = ModuleSpec(
         # working
         attention_layer=ModuleSpec(
             module=TransformerLayer,
+            metainfo={HYBRID_LAYER_TYPE: "attention"},
             submodules=TransformerLayerSubmodules(
                 self_attention=ModuleSpec(
                     module=SelfAttention,
@@ -136,6 +140,7 @@ hybrid_stack_spec = ModuleSpec(
         ),
         dsa_layer=ModuleSpec(
             module=TransformerLayer,
+            metainfo={HYBRID_LAYER_TYPE: "dsa"},
             submodules=TransformerLayerSubmodules(
                 input_layernorm=TENorm,
                 self_attention=ModuleSpec(
@@ -171,6 +176,7 @@ hybrid_stack_spec = ModuleSpec(
         ),
         mla_layer=ModuleSpec(
             module=TransformerLayer,
+            metainfo={HYBRID_LAYER_TYPE: "mla"},
             submodules=TransformerLayerSubmodules(
                 input_layernorm=TENorm,
                 self_attention=ModuleSpec(
@@ -196,6 +202,7 @@ hybrid_stack_spec = ModuleSpec(
         # working
         mlp_layer=ModuleSpec(
             module=MLPLayer,
+            metainfo={HYBRID_LAYER_TYPE: "mlp"},
             submodules=TransformerLayerSubmodules(
                 mlp=partial(
                     MLP.as_mlp_submodule,
@@ -208,6 +215,7 @@ hybrid_stack_spec = ModuleSpec(
         ),
         moe_layer=ModuleSpec(
             module=MoETransformerLayer,
+            metainfo={HYBRID_LAYER_TYPE: "moe"},
             submodules=TransformerLayerSubmodules(
                 pre_mlp_layernorm=TENorm, mlp=moe, mlp_bda=get_bias_dropout_add
             ),
@@ -222,6 +230,7 @@ hybrid_inference_stack_spec = ModuleSpec(
     submodules=HybridStackSubmodules(
         mamba_layer=ModuleSpec(
             module=MambaLayer,
+            metainfo={HYBRID_LAYER_TYPE: "mamba"},
             submodules=MambaLayerSubmodules(
                 mixer=ModuleSpec(
                     module=MambaMixer,
@@ -238,6 +247,7 @@ hybrid_inference_stack_spec = ModuleSpec(
         # working
         attention_layer=ModuleSpec(
             module=TransformerLayer,
+            metainfo={HYBRID_LAYER_TYPE: "attention"},
             submodules=TransformerLayerSubmodules(
                 self_attention=ModuleSpec(
                     module=SelfAttention,
@@ -253,6 +263,7 @@ hybrid_inference_stack_spec = ModuleSpec(
         ),
         dsa_layer=ModuleSpec(
             module=TransformerLayer,
+            metainfo={HYBRID_LAYER_TYPE: "dsa"},
             submodules=TransformerLayerSubmodules(
                 input_layernorm=TENorm,
                 self_attention=ModuleSpec(
@@ -288,6 +299,7 @@ hybrid_inference_stack_spec = ModuleSpec(
         ),
         mla_layer=ModuleSpec(
             module=TransformerLayer,
+            metainfo={HYBRID_LAYER_TYPE: "mla"},
             submodules=TransformerLayerSubmodules(
                 input_layernorm=TENorm,
                 self_attention=ModuleSpec(
@@ -313,6 +325,7 @@ hybrid_inference_stack_spec = ModuleSpec(
         # working
         mlp_layer=ModuleSpec(
             module=MLPLayer,
+            metainfo={HYBRID_LAYER_TYPE: "mlp"},
             submodules=TransformerLayerSubmodules(
                 mlp=partial(
                     MLP.as_mlp_submodule,
@@ -327,6 +340,7 @@ hybrid_inference_stack_spec = ModuleSpec(
         moe_layer=ModuleSpec(
             # Use inference-optimized MoE layer for end-to-end CUDA graph support
             module=TransformerLayer,
+            metainfo={HYBRID_LAYER_TYPE: "moe"},
             submodules=TransformerLayerSubmodules(
                 pre_mlp_layernorm=TENorm, mlp=moe_inference, mlp_bda=get_bias_dropout_add
             ),

--- a/megatron/core/models/hybrid/hybrid_model.py
+++ b/megatron/core/models/hybrid/hybrid_model.py
@@ -3,6 +3,7 @@
 import logging
 from typing import Literal, Optional
 
+import torch
 from torch import Tensor
 
 from megatron.core import tensor_parallel
@@ -13,6 +14,11 @@ from megatron.core.models.common.embeddings.language_model_embedding import Lang
 from megatron.core.models.common.embeddings.rotary_pos_embedding import RotaryEmbedding
 from megatron.core.models.common.embeddings.yarn_rotary_pos_embedding import YarnRotaryEmbedding
 from megatron.core.models.common.language_module.language_module import LanguageModule
+from megatron.core.models.hybrid.hybrid_architecture import (
+    HybridLayerPattern,
+    ResolvedHybridArchitecture,
+    resolve_hybrid_architecture,
+)
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
     FineGrainedActivationOffloadingInterface as off_interface,
@@ -33,6 +39,8 @@ from megatron.core.transformer.spec_utils import ModuleSpec, build_module
 from megatron.core.utils import (
     WrappedTensor,
     deprecate_inference_params,
+    get_pg_rank,
+    get_pg_size,
     is_using_quantization_scales,
     log_single_rank,
 )
@@ -41,6 +49,8 @@ logger = logging.getLogger(__name__)
 
 
 def _hybrid_logging_pg_kwargs(pg_collection: ProcessGroupCollection) -> dict:
+    """Return paired process groups used by legacy per-stage logging."""
+
     tp_group = getattr(pg_collection, 'tp', None)
     dp_cp_group = getattr(pg_collection, 'dp_cp', None)
     if (tp_group is None) != (dp_cp_group is None):
@@ -61,6 +71,13 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
         vocab_size (int): Vocabulary size
         max_sequence_length (int): maximum size of sequence.
             This is used for positional embedding
+        layer_specs (HybridLayerPattern, optional): Preferred direct decoder architecture.
+            Existing layer ``ModuleSpec`` objects are paired with per-occurrence configs, and
+            ``PipelineSplit`` nodes define PP/VPP chunks.
+        mtp_layer_specs (HybridLayerPattern, optional): Direct template for one MTP prediction
+            depth. ``config.mtp_num_layers`` controls repetition.
+        resolved_hybrid_architecture (ResolvedHybridArchitecture, optional): Internal global
+            architecture supplied by ``HybridModelBuilder`` after validation.
         hybrid_layer_pattern (str): Unified hybrid layer pattern with optional MTP and
             pipeline stage boundaries.
             Format: "<main_pattern>/<mtp_pattern>/<mtp_pattern>/..."
@@ -78,10 +95,12 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
         hybrid_override_pattern (str, optional): Deprecated. Use hybrid_layer_pattern instead.
             If set and hybrid_layer_pattern is None, the value is copied to hybrid_layer_pattern
             with a deprecation warning.
-        pre_process (bool, optional): Include embedding layer
-            (used with pipeline parallelism). Defaults to True.
+        pre_process (bool, optional): Include embedding layer (used with pipeline parallelism).
+            Legacy patterns retain the historical True default. Direct architectures constrain
+            ownership to the first logical PP/VPP chunk.
         post_process (bool, optional): Include an output layer (used with pipeline parallelism).
-            Defaults to True.
+            Legacy patterns retain the historical True default. Direct architectures constrain
+            ownership to the final logical PP/VPP chunk.
         fp16_lm_cross_entropy (bool, optional): Defaults to False.
         parallel_output (bool, optional): Do not gather the outputs, keep them split across tensor
             parallel ranks. Defaults to True.
@@ -123,11 +142,27 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
         seq_len_interpolation_factor: Optional[float] = None,
         pg_collection: Optional[ProcessGroupCollection] = None,
         vp_stage: Optional[int] = None,
+        layer_specs: HybridLayerPattern | None = None,
+        mtp_layer_specs: HybridLayerPattern | None = None,
+        resolved_hybrid_architecture: ResolvedHybridArchitecture | None = None,
     ) -> None:
         super().__init__(config=config, pg_collection=pg_collection)
 
+        has_direct_architecture = (
+            layer_specs is not None
+            or mtp_layer_specs is not None
+            or (
+                resolved_hybrid_architecture is not None
+                and resolved_hybrid_architecture.source == "direct"
+            )
+        )
         if has_config_logger_enabled(config):
-            log_config_to_disk(config, locals(), prefix=type(self).__name__)
+            config_logger_args = dict(locals())
+            config_logger_args.pop("layer_specs", None)
+            config_logger_args.pop("mtp_layer_specs", None)
+            config_logger_args.pop("resolved_hybrid_architecture", None)
+            config_logger_args.pop("has_direct_architecture", None)
+            log_config_to_disk(config, config_logger_args, prefix=type(self).__name__)
 
         if self.config.use_mup and not getattr(HybridModel, "mup_warning_printed", False):
             log_single_rank(
@@ -141,16 +176,24 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
         self.vocab_size = vocab_size
         self.max_sequence_length = max_sequence_length
         self.hybrid_layer_pattern = hybrid_layer_pattern
-        self.pre_process = pre_process
-        self.post_process = post_process
+        self.vp_stage = vp_stage
         self.fp16_lm_cross_entropy = fp16_lm_cross_entropy
         self.parallel_output = parallel_output
         self.share_embeddings_and_output_weights = share_embeddings_and_output_weights
         self.position_embedding_type = position_embedding_type
-        self.vp_stage = vp_stage
         self.disable_param_offloading = True
 
         # Backward compatibility for deprecated hybrid parameters
+        if has_direct_architecture and hybrid_override_pattern is not None:
+            raise ValueError("hybrid_override_pattern cannot be combined with direct layer_specs.")
+        if has_direct_architecture and (
+            (hybrid_attention_ratio is not None and hybrid_attention_ratio > 0.0)
+            or (hybrid_mlp_ratio is not None and hybrid_mlp_ratio > 0.0)
+        ):
+            raise ValueError(
+                "hybrid_attention_ratio and hybrid_mlp_ratio cannot be combined with "
+                "direct layer_specs."
+            )
         if hybrid_override_pattern is not None:
             if self.hybrid_layer_pattern is None:
                 log_single_rank(
@@ -189,43 +232,94 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
                     config.num_layers, attn_ratio, mlp_ratio
                 )
 
-        # Parse unified pattern to extract main and MTP components, and
-        # determine the pipeline segment for this model instance.
+        if resolved_hybrid_architecture is None and (
+            layer_specs is not None or mtp_layer_specs is not None
+        ):
+            resolved_hybrid_architecture = resolve_hybrid_architecture(
+                config=self.config,
+                hybrid_stack_spec=hybrid_stack_spec,
+                layer_specs=layer_specs,
+                mtp_layer_specs=mtp_layer_specs,
+                hybrid_layer_pattern=self.hybrid_layer_pattern,
+            )
+        elif layer_specs is not None or mtp_layer_specs is not None:
+            raise ValueError(
+                "resolved_hybrid_architecture cannot be combined with unresolved direct specs."
+            )
+
+        is_direct_architecture = (
+            resolved_hybrid_architecture is not None
+            and resolved_hybrid_architecture.source == "direct"
+        )
+
         from megatron.core.models.hybrid.hybrid_layer_allocation import (
             parse_hybrid_pattern,
             select_pipeline_segment,
         )
 
         parsed = parse_hybrid_pattern(self.hybrid_layer_pattern)
-        self.mtp_pattern = parsed.mtp_pattern
-        self.mtp_num_depths = parsed.mtp_num_depths
 
-        logging_pg_kwargs = _hybrid_logging_pg_kwargs(self.pg_collection)
-
-        layer_type_list, layer_offset = select_pipeline_segment(
-            parsed.main_pattern or '',
-            self.pg_collection.pp,
-            vp_stage,
-            first_stage_layers=self.config.num_layers_in_first_pipeline_stage,
-            last_stage_layers=self.config.num_layers_in_last_pipeline_stage,
-            **logging_pg_kwargs,
-        )
-
-        # Determine if MTP is needed (based on pattern parsing)
-        self.mtp_process = (
-            self.mtp_pattern is not None
-            and self.mtp_num_depths > 0
-            # The following forces MTP to be on the final pipeline stage. It might be more optimal
-            # to split the hybrid layer pattern into pipeline stages before parsing the pattern for
-            # the current pipeline stage. This could also enable MTP standalone (MTP in a pipeline
-            # stage separate from loss) to be supported in the hybrid model.
-            and mtp_on_this_rank(
-                layout=self.config.pipeline_model_parallel_layout,
-                mtp_num_layers=self.config.mtp_num_layers,
-                ignore_virtual=False,
-                vp_stage=self.vp_stage,
+        if not is_direct_architecture:
+            # Preserve the legacy selector, shared config, symbol API, and constructor defaults.
+            self.pre_process = pre_process
+            self.post_process = post_process
+            logging_pg_kwargs = _hybrid_logging_pg_kwargs(self.pg_collection)
+            layer_type_list, layer_offset = select_pipeline_segment(
+                parsed.main_pattern or '',
+                self.pg_collection.pp,
+                vp_stage,
+                first_stage_layers=self.config.num_layers_in_first_pipeline_stage,
+                last_stage_layers=self.config.num_layers_in_last_pipeline_stage,
+                **logging_pg_kwargs,
             )
-        )
+            local_layer_specs = None
+            self.mtp_pattern = parsed.mtp_pattern
+            self.mtp_num_depths = parsed.mtp_num_depths
+            self.mtp_process = (
+                self.mtp_pattern is not None
+                and self.mtp_num_depths > 0
+                and mtp_on_this_rank(
+                    layout=self.config.pipeline_model_parallel_layout,
+                    mtp_num_layers=self.config.mtp_num_layers,
+                    ignore_virtual=False,
+                    vp_stage=self.vp_stage,
+                )
+            )
+        else:
+            # Every physical/virtual chunk intentionally keeps the same global summary.
+            self.resolved_hybrid_architecture = resolved_hybrid_architecture
+            self.vp_size = self.config.virtual_pipeline_model_parallel_size
+            # Raw direct callers resolve split nodes here rather than in the builder, so derive
+            # ownership only after resolution has inferred VPP.
+            pp_size = self.config.pipeline_model_parallel_size
+            pp_rank = get_pg_rank(self.pg_collection.pp)
+            if torch.distributed.is_initialized():
+                actual_pp_size = get_pg_size(self.pg_collection.pp)
+                if actual_pp_size != pp_size:
+                    raise ValueError(
+                        "TransformerConfig.pipeline_model_parallel_size must match the supplied "
+                        f"PP process group; got {pp_size} != {actual_pp_size}."
+                    )
+            vp_rank = 0 if vp_stage is None else vp_stage
+            owns_pre_process = pp_rank == 0 and vp_rank == 0
+            owns_post_process = pp_rank == pp_size - 1 and (
+                self.vp_size is None or vp_rank == self.vp_size - 1
+            )
+            self.pre_process = owns_pre_process if pre_process is not False else False
+            self.post_process = owns_post_process if post_process is not False else False
+            local_layer_specs, layer_offset = resolved_hybrid_architecture.select_segment(
+                pp_rank=pp_rank, pp_size=pp_size, vp_stage=vp_stage
+            )
+            layer_type_list = None
+            segment_index = vp_rank * pp_size + pp_rank
+            is_final_segment = segment_index == len(resolved_hybrid_architecture.segments) - 1
+            self.mtp_pattern = None
+            self.mtp_num_depths = resolved_hybrid_architecture.mtp_num_layers
+            self.mtp_process = bool(
+                resolved_hybrid_architecture.mtp_layers
+                and self.mtp_num_depths > 0
+                and is_final_segment
+            )
 
         # megatron core pipelining currently depends on model type
         # TODO: remove this dependency ?
@@ -242,47 +336,117 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
                 pg_collection=self.pg_collection,
             )
 
-        # MLA (also used by DeepSeek Sparse Attention) uses its own decoupled RoPE, therefore we do
-        # not build standard RoPE here when using MLA.
-        if self.position_embedding_type == 'rope' and not self.config.multi_latent_attention:
-            self.rotary_pos_emb = RotaryEmbedding(
-                kv_channels=self.config.kv_channels,
-                rotary_percent=rotary_percent,
-                seq_len_interpolation_factor=seq_len_interpolation_factor,
-                rotary_base=rotary_base,
-                use_cpu_initialization=self.config.use_cpu_initialization,
-                cp_group=self.pg_collection.cp,
-            )
-        elif self.position_embedding_type == 'yarn':
-            self.rotary_pos_emb = YarnRotaryEmbedding(
-                kv_channels=self.config.kv_channels,
-                rotary_percent=rotary_percent,
-                seq_len_interpolation_factor=seq_len_interpolation_factor,
-                rotary_base=rotary_base,
-                scaling_factor=getattr(self.config, "yarn_rotary_scaling_factor"),
-                original_max_position_embeddings=getattr(
-                    self.config, "yarn_original_max_position_embeddings"
-                ),
-                beta_fast=getattr(self.config, "yarn_beta_fast"),
-                beta_slow=getattr(self.config, "yarn_beta_slow"),
-                mscale=getattr(self.config, "yarn_mscale"),
-                mscale_all_dim=getattr(self.config, "yarn_mscale_all_dim"),
-                correction_range_round_to_int=getattr(
-                    self.config, "yarn_correction_range_round_to_int"
-                ),
-                use_cpu_initialization=self.config.use_cpu_initialization,
-                cp_group=self.pg_collection.cp,
-            )
+        if not is_direct_architecture:
+            # Preserve the legacy model-global RoPE/Yarn construction exactly.
+            if self.position_embedding_type == 'rope' and not self.config.multi_latent_attention:
+                self.rotary_pos_emb = RotaryEmbedding(
+                    kv_channels=self.config.kv_channels,
+                    rotary_percent=rotary_percent,
+                    seq_len_interpolation_factor=seq_len_interpolation_factor,
+                    rotary_base=rotary_base,
+                    use_cpu_initialization=self.config.use_cpu_initialization,
+                    cp_group=self.pg_collection.cp,
+                )
+            elif self.position_embedding_type == 'yarn':
+                self.rotary_pos_emb = YarnRotaryEmbedding(
+                    kv_channels=self.config.kv_channels,
+                    rotary_percent=rotary_percent,
+                    seq_len_interpolation_factor=seq_len_interpolation_factor,
+                    rotary_base=rotary_base,
+                    scaling_factor=getattr(self.config, "yarn_rotary_scaling_factor"),
+                    original_max_position_embeddings=getattr(
+                        self.config, "yarn_original_max_position_embeddings"
+                    ),
+                    beta_fast=getattr(self.config, "yarn_beta_fast"),
+                    beta_slow=getattr(self.config, "yarn_beta_slow"),
+                    mscale=getattr(self.config, "yarn_mscale"),
+                    mscale_all_dim=getattr(self.config, "yarn_mscale_all_dim"),
+                    correction_range_round_to_int=getattr(
+                        self.config, "yarn_correction_range_round_to_int"
+                    ),
+                    use_cpu_initialization=self.config.use_cpu_initialization,
+                    cp_group=self.pg_collection.cp,
+                )
+        else:
+            # Standard attention occurrences may use different KV widths. Keep one RoPE
+            # module/input per width; MLA and DSA continue to own their decoupled RoPE.
+            rotary_layers = list(local_layer_specs)
+            if self.mtp_process:
+                rotary_layers.extend(resolved_hybrid_architecture.mtp_layers)
+            rotary_configs = {
+                layer.config.kv_channels: layer.config
+                for layer in rotary_layers
+                if layer.layer_type == "attention"
+            }
+            if not rotary_configs:
+                rotary_configs = {self.config.kv_channels: self.config}
+            self._rotary_configs_by_kv = rotary_configs
+
+            def build_rotary_embedding(rotary_config: TransformerConfig):
+                if self.position_embedding_type == 'rope':
+                    return RotaryEmbedding(
+                        kv_channels=rotary_config.kv_channels,
+                        rotary_percent=rotary_percent,
+                        seq_len_interpolation_factor=seq_len_interpolation_factor,
+                        rotary_base=rotary_base,
+                        use_cpu_initialization=rotary_config.use_cpu_initialization,
+                        cp_group=self.pg_collection.cp,
+                    )
+                return YarnRotaryEmbedding(
+                    kv_channels=rotary_config.kv_channels,
+                    rotary_percent=rotary_percent,
+                    seq_len_interpolation_factor=seq_len_interpolation_factor,
+                    rotary_base=rotary_base,
+                    scaling_factor=getattr(rotary_config, "yarn_rotary_scaling_factor"),
+                    original_max_position_embeddings=getattr(
+                        rotary_config, "yarn_original_max_position_embeddings"
+                    ),
+                    beta_fast=getattr(rotary_config, "yarn_beta_fast"),
+                    beta_slow=getattr(rotary_config, "yarn_beta_slow"),
+                    mscale=getattr(rotary_config, "yarn_mscale"),
+                    mscale_all_dim=getattr(rotary_config, "yarn_mscale_all_dim"),
+                    correction_range_round_to_int=getattr(
+                        rotary_config, "yarn_correction_range_round_to_int"
+                    ),
+                    use_cpu_initialization=rotary_config.use_cpu_initialization,
+                    cp_group=self.pg_collection.cp,
+                )
+
+            if (
+                self.position_embedding_type in {'rope', 'yarn'}
+                and not self.config.multi_latent_attention
+            ):
+                if len(rotary_configs) == 1:
+                    self.rotary_pos_emb = build_rotary_embedding(
+                        next(iter(rotary_configs.values()))
+                    )
+                else:
+                    self.rotary_pos_emb_by_kv = torch.nn.ModuleDict(
+                        {
+                            str(kv_channels): build_rotary_embedding(rotary_config)
+                            for kv_channels, rotary_config in rotary_configs.items()
+                        }
+                    )
+
+        decoder_architecture_kwargs = (
+            {"layer_type_list": layer_type_list}
+            if not is_direct_architecture
+            else {
+                "layer_specs": local_layer_specs,
+                "moe_metric_layer_offset": layer_offset,
+                "moe_metric_num_layers": resolved_hybrid_architecture.metric_num_layers,
+            }
+        )
         self.decoder = build_module(
             hybrid_stack_spec,
             self.config,
             pre_process=self.pre_process,
-            layer_type_list=layer_type_list,
             pp_layer_offset=layer_offset,
             post_process=self.post_process,
             dtype=config.params_dtype,
             pg_collection=self.pg_collection,
             name="decoder",
+            **decoder_architecture_kwargs,
         )
 
         # MTP block - uses mtp_block_spec from hybrid_stack_spec.submodules
@@ -294,20 +458,28 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
                 "Ensure hybrid_stack_spec includes mtp_block_spec for MTP support."
             )
 
+            mtp_architecture_kwargs = (
+                {"mtp_layer_pattern": self.mtp_pattern}
+                if not is_direct_architecture
+                else {
+                    "mtp_layer_specs": resolved_hybrid_architecture.mtp_layers,
+                    "moe_metric_num_layers": resolved_hybrid_architecture.metric_num_layers,
+                }
+            )
             self.mtp = MultiTokenPredictionBlock(
                 config=self.config,
                 spec=mtp_block_spec,
                 pg_collection=self.pg_collection,
                 vp_stage=self.vp_stage,
-                mtp_layer_pattern=self.mtp_pattern,
                 mtp_num_depths=self.mtp_num_depths,
                 hybrid_submodules=hybrid_submodules,
                 name="mtp",
+                **mtp_architecture_kwargs,
             )
             self._setup_mtp_cuda_graphs()
 
         # Output
-        if post_process or self.mtp_process:
+        if self.post_process or self.mtp_process:
             self.output_layer = tensor_parallel.ColumnParallelLinear(
                 config.hidden_size,
                 self.vocab_size,
@@ -414,6 +586,58 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
 
             self.cudagraph_manager = CudaGraphManager(config)
 
+    def _get_rotary_pos_emb(
+        self,
+        inference_context: Optional[BaseInferenceContext],
+        decoder_input: Optional[Tensor],
+        packed_seq_params: Optional[PackedSeqParams],
+    ) -> Tensor | dict[int, Tensor] | None:
+        """Build compatible RoPE inputs for the local attention configurations."""
+
+        resolved_architecture = getattr(self, "resolved_hybrid_architecture", None)
+        if resolved_architecture is None or resolved_architecture.source != "direct":
+            packed_seq = packed_seq_params is not None and packed_seq_params.qkv_format == 'thd'
+            if self.position_embedding_type == 'rope' and not self.config.multi_latent_attention:
+                rotary_seq_len = self.rotary_pos_emb.get_rotary_seq_len(
+                    inference_context, self.decoder, decoder_input, self.config, packed_seq_params
+                )
+                return self.rotary_pos_emb(rotary_seq_len, packed_seq=packed_seq)
+            if self.position_embedding_type == 'yarn':
+                rotary_seq_len = self.rotary_pos_emb.get_rotary_seq_len(
+                    inference_context, self.decoder, decoder_input, self.config, packed_seq_params
+                )
+                rotary_pos_emb, _ = self.rotary_pos_emb(rotary_seq_len, packed_seq=packed_seq)
+                return rotary_pos_emb
+            return None
+
+        if (
+            self.position_embedding_type not in {'rope', 'yarn'}
+            or self.config.multi_latent_attention
+        ):
+            return None
+
+        packed_seq = packed_seq_params is not None and packed_seq_params.qkv_format == 'thd'
+
+        def rotary_input(rotary_module, rotary_config):
+            rotary_seq_len = rotary_module.get_rotary_seq_len(
+                inference_context, self.decoder, decoder_input, rotary_config, packed_seq_params
+            )
+            value = rotary_module(rotary_seq_len, packed_seq=packed_seq)
+            if self.position_embedding_type == 'yarn':
+                value, _ = value
+            return value
+
+        if hasattr(self, 'rotary_pos_emb_by_kv'):
+            return {
+                int(kv_channels): rotary_input(
+                    rotary_module, self._rotary_configs_by_kv[int(kv_channels)]
+                )
+                for kv_channels, rotary_module in self.rotary_pos_emb_by_kv.items()
+            }
+
+        rotary_config = next(iter(self._rotary_configs_by_kv.values()))
+        return rotary_input(self.rotary_pos_emb, rotary_config)
+
     def forward(
         self,
         input_ids: Tensor,
@@ -447,6 +671,21 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
         inference_context = deprecate_inference_params(inference_context, inference_params)
 
         in_inference_mode = InferenceMode.is_active()
+        resolved_architecture = getattr(self, "resolved_hybrid_architecture", None)
+
+        if (
+            in_inference_mode
+            and inference_context is not None
+            and inference_context.is_dynamic_batching()
+            and resolved_architecture is not None
+            and resolved_architecture.source == "direct"
+            and resolved_architecture.has_incompatible_dynamic_inference_shapes(self.config)
+        ):
+            raise NotImplementedError(
+                "Direct HybridModel occurrence configurations are incompatible with dynamic "
+                "inference's model-global cache or runtime buffers (Mamba state/cache "
+                "dimensions, attention KV dimensions, or MoE router top-k values)."
+            )
 
         if in_inference_mode:
             assert runtime_gather_output, "Inference must always gather TP logits"
@@ -478,24 +717,9 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
             # decoder will get hidden_states from encoder.input_tensor
             decoder_input = None
 
-        rotary_pos_emb = None
-        if self.position_embedding_type == 'rope' and not self.config.multi_latent_attention:
-            rotary_seq_len = self.rotary_pos_emb.get_rotary_seq_len(
-                inference_context, self.decoder, decoder_input, self.config, packed_seq_params
-            )
-            rotary_pos_emb = self.rotary_pos_emb(
-                rotary_seq_len,
-                packed_seq=packed_seq_params is not None and packed_seq_params.qkv_format == 'thd',
-            )
-        elif self.position_embedding_type == 'yarn':
-            rotary_seq_len = self.rotary_pos_emb.get_rotary_seq_len(
-                inference_context, self.decoder, decoder_input, self.config, packed_seq_params
-            )
-            # YarnRotaryEmbedding.forward returns (emb, mscale); discard mscale here
-            rotary_pos_emb, _ = self.rotary_pos_emb(
-                rotary_seq_len,
-                packed_seq=packed_seq_params is not None and packed_seq_params.qkv_format == 'thd',
-            )
+        rotary_pos_emb = self._get_rotary_pos_emb(
+            inference_context, decoder_input, packed_seq_params
+        )
 
         # Wrap decoder_input to allow the decoder (HybridStack) to delete the
         # reference held by this caller function, enabling early garbage collection

--- a/megatron/core/recompute.py
+++ b/megatron/core/recompute.py
@@ -50,31 +50,40 @@ def checkpointed_forward(
         extract_layer_indices = set()
     intermediate_hidden_states: List[Tensor] = []
 
-    # Wrap non-dual RoPE to tuple to unify custom_forward interface.
+    # Flatten per-KV-width RoPE mappings because autograd checkpoint inputs must
+    # be tensors (or None), not dictionaries.
+    is_rotary_mapping = isinstance(rotary_pos_emb, dict)
+    rotary_mapping_keys = tuple(sorted(rotary_pos_emb)) if is_rotary_mapping else ()
     is_dual_rope = isinstance(rotary_pos_emb, (tuple, list))
     assert not is_dual_rope or len(rotary_pos_emb) == 2, "Dual RoPE input length is not equal to 2"
-    rotary_pos_emb = rotary_pos_emb if is_dual_rope else (None, rotary_pos_emb)
+    if is_rotary_mapping:
+        rotary_inputs = tuple(rotary_pos_emb[key] for key in rotary_mapping_keys)
+    else:
+        rotary_inputs = rotary_pos_emb if is_dual_rope else (None, rotary_pos_emb)
 
     def custom(start: int, end: int):
-        def custom_forward(
-            hidden_states,
-            attention_mask,
-            context,
-            context_mask,
-            rotary_pos_emb_local,
-            rotary_pos_emb_global,
-            padding_mask=None,
-        ):
-            rotary_pos_emb = (
-                (rotary_pos_emb_local, rotary_pos_emb_global)
-                if is_dual_rope
-                else rotary_pos_emb_global
-            )
+        def custom_forward(hidden_states, attention_mask, context, context_mask, *rope_and_mask):
+            padding_mask = rope_and_mask[-1]
+            rope_values = rope_and_mask[:-1]
+            if is_rotary_mapping:
+                rotary_mapping = dict(zip(rotary_mapping_keys, rope_values))
+                rotary_pos_emb = None
+            else:
+                rotary_mapping = None
+                rotary_pos_emb = tuple(rope_values) if is_dual_rope else rope_values[1]
 
             for index in range(start, end):
                 # Use self.layers[index] (not self._get_layer) so this
                 # function works for both TransformerBlock and HybridStack.
                 layer = self.layers[index]
+                layer_rotary_pos_emb = rotary_pos_emb
+                if rotary_mapping is not None:
+                    layer_spec = self.layer_specs[index]
+                    layer_rotary_pos_emb = (
+                        rotary_mapping.get(layer_spec.config.kv_channels)
+                        if layer_spec.layer_type == "attention"
+                        else None
+                    )
 
                 # Get appropriate inner quantization context
                 if use_inner_quantization_context:
@@ -100,7 +109,7 @@ def checkpointed_forward(
                     attention_mask=attention_mask,
                     context=context,
                     context_mask=context_mask,
-                    rotary_pos_emb=rotary_pos_emb,
+                    rotary_pos_emb=layer_rotary_pos_emb,
                     attention_bias=attention_bias,
                     inference_context=None,
                     packed_seq_params=packed_seq_params,
@@ -126,7 +135,7 @@ def checkpointed_forward(
         nonlocal hidden_states, context
         cf = custom(start, end)
         # Unpack the RoPE tuple as torch cannot save tuples for backward pass.
-        args = (hidden_states, attention_mask, context, context_mask, *rotary_pos_emb, padding_mask)
+        args = (hidden_states, attention_mask, context, context_mask, *rotary_inputs, padding_mask)
         if use_checkpoint:
             # Precision-aware activation checkpoint: TE under FP8/FP4,
             # tensor_parallel under BF16/FP16/FP32.

--- a/megatron/core/transformer/moe/moe_layer.py
+++ b/megatron/core/transformer/moe/moe_layer.py
@@ -139,6 +139,11 @@ class RouterInterface(Protocol):
         """
         ...
 
+    def set_metric_layer_number(self, layer_number: int, num_layers: int | None = None) -> None:
+        """Set a metric-only layer slot independent of checkpoint numbering."""
+
+        ...
+
 
 class RouterBuilder(Protocol):
     """Protocol for building a Router."""
@@ -208,6 +213,11 @@ class BaseMoELayer(MegatronModule, ABC):
         """Set the layer number for the MoE layer."""
         self.layer_number = layer_number
         self.router.set_layer_number(layer_number)
+
+    def set_metric_layer_number(self, layer_number: int, num_layers: int | None = None) -> None:
+        """Set the layer slot used by the MoE metrics tracker."""
+
+        self.router.set_metric_layer_number(layer_number, num_layers)
 
 
 class MoELayer(BaseMoELayer):
@@ -647,8 +657,15 @@ class MoELayer(BaseMoELayer):
         if padding_mask is not None:
             padding_mask = padding_mask.transpose(0, 1).bool()
 
+        metric_layer_number = getattr(self.router, "metric_layer_number", None)
+        metric_num_layers = getattr(self.router, "metric_num_layers", None)
+
         # MoE forward: route -> dispatch -> compute -> combine
         def custom_forward(hidden_states, intermediate_tensors=None, padding_mask=None):
+            if metric_layer_number is not None:
+                # Selective MoE recomputation runs after a repeated direct-MTP module may have
+                # been retargeted to another prediction depth. Restore this invocation's slot.
+                self.router.set_metric_layer_number(metric_layer_number, metric_num_layers)
             try:
                 if "route" in self.fwd_execution_map:
                     shared_expert_output = self.shared_experts_compute(hidden_states)

--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -140,6 +140,12 @@ class Router(ABC, MegatronModule):
         if getattr(self, "router_replay", None) is not None:
             self.router_replay.layer_number = layer_number
 
+    def set_metric_layer_number(self, layer_number: int, num_layers: Optional[int] = None) -> None:
+        """Set an architecture-aware slot used only for MoE metric reporting."""
+
+        self.metric_layer_number = layer_number
+        self.metric_num_layers = num_layers
+
 
 class TopKRouter(Router):
     """Route each token to the top-k experts.
@@ -587,11 +593,18 @@ class TopKRouter(Router):
         # add the aux loss logging value to other layer's since it is difficult to get the
         # correct layer_number for MTP. It does not affect the correctness of the calculation
         # results and the reduced load_balancing_loss logging value.
-        num_layers = self.config.num_layers
-        if self.config.mtp_num_layers is not None:
-            num_layers += self.config.mtp_num_layers
+        metric_num_layers = getattr(self, "metric_num_layers", None)
+        metric_layer_number = getattr(self, "metric_layer_number", None)
+        if metric_num_layers is not None:
+            num_layers = metric_num_layers
+        else:
+            num_layers = self.config.num_layers
+            if self.config.mtp_num_layers is not None:
+                num_layers += self.config.mtp_num_layers
 
-        if self.is_mtp_layer:
+        if metric_layer_number is not None:
+            layer_number = metric_layer_number
+        elif self.is_mtp_layer:
             layer_number = self.layer_number + self.config.num_layers
         else:
             layer_number = self.layer_number
@@ -688,11 +701,18 @@ class TopKRouter(Router):
             ):
                 z_loss = z_loss / self.config.mtp_num_layers
 
-            num_layers = self.config.num_layers
-            if self.config.mtp_num_layers is not None:
-                num_layers += self.config.mtp_num_layers
+            metric_num_layers = getattr(self, "metric_num_layers", None)
+            metric_layer_number = getattr(self, "metric_layer_number", None)
+            if metric_num_layers is not None:
+                num_layers = metric_num_layers
+            else:
+                num_layers = self.config.num_layers
+                if self.config.mtp_num_layers is not None:
+                    num_layers += self.config.mtp_num_layers
 
-            if self.is_mtp_layer:
+            if metric_layer_number is not None:
+                layer_number = metric_layer_number
+            elif self.is_mtp_layer:
                 layer_number = self.layer_number + self.config.num_layers
             else:
                 layer_number = self.layer_number

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import warnings
 from contextlib import nullcontext
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Callable, List, Optional, Union
+from typing import TYPE_CHECKING, Callable, List, Optional, Sequence, Union
 
 import torch
 from torch import Tensor
@@ -42,6 +42,7 @@ from megatron.core.utils import (
 )
 
 if TYPE_CHECKING:
+    from megatron.core.models.hybrid.hybrid_architecture import HybridLayerSpec
     from megatron.core.models.hybrid.hybrid_block import HybridStackSubmodules
 
 if is_torch_min_version("1.13.0"):
@@ -926,6 +927,8 @@ class MultiTokenPredictionLayer(MegatronModule):
         hybrid_submodules: Optional[HybridStackSubmodules] = None,
         mamba_submodules: Optional[HybridStackSubmodules] = None,
         name: str | None = None,
+        mtp_layer_specs: Optional[Sequence[HybridLayerSpec]] = None,
+        moe_metric_num_layers: int | None = None,
     ):
         """
         Args:
@@ -951,6 +954,8 @@ class MultiTokenPredictionLayer(MegatronModule):
         self.cp_group = pg_collection.cp
         self.tp_group = pg_collection.tp if pg_collection is not None else None
         self.mtp_layer_pattern = mtp_layer_pattern
+        if mtp_layer_specs is not None:
+            self.mtp_layer_specs = mtp_layer_specs
 
         # Validate attention mask type if using transformer-based inner layers
         if self.submodules.mtp_model_layer is not None and hasattr(
@@ -1015,14 +1020,34 @@ class MultiTokenPredictionLayer(MegatronModule):
         # Build inner layers: two possible paths
         # 1. Hybrid path: use HybridStack for hybrid pattern support
         # 2. GPT path: single TransformerLayer
-        if mtp_layer_pattern is not None and hybrid_submodules is not None:
+        if (
+            mtp_layer_pattern is not None or mtp_layer_specs is not None
+        ) and hybrid_submodules is not None:
             from megatron.core.models.hybrid.hybrid_block import HybridStack
             from megatron.core.models.hybrid.hybrid_layer_allocation import validate_segment_layers
 
+            layer_type_list = (
+                validate_segment_layers(mtp_layer_pattern)
+                if mtp_layer_pattern is not None
+                else None
+            )
+            metric_layer_count = len(mtp_layer_specs or [])
+            if mtp_layer_specs is not None:
+                self.mtp_metric_layer_count = metric_layer_count
+            stack_architecture_kwargs = (
+                {"layer_type_list": layer_type_list}
+                if mtp_layer_specs is None
+                else {
+                    "layer_specs": mtp_layer_specs,
+                    "moe_metric_layer_offset": (
+                        self.config.num_layers + (layer_number - 1) * metric_layer_count
+                    ),
+                    "moe_metric_num_layers": moe_metric_num_layers,
+                }
+            )
             self.mtp_model_layer = HybridStack(
                 config=self.config,
                 submodules=hybrid_submodules,
-                layer_type_list=validate_segment_layers(mtp_layer_pattern),
                 pp_layer_offset=0,
                 pre_process=True,  # Always receives input from eh_proj
                 post_layer_norm=False,  # MTP has its own final_layernorm
@@ -1030,6 +1055,7 @@ class MultiTokenPredictionLayer(MegatronModule):
                 pg_collection=pg_collection,
                 is_mtp_layer=True,
                 name=(name + ".mtp_model_layer") if name is not None else None,
+                **stack_architecture_kwargs,
             )
         elif self.config.mtp_num_layers is not None:
             # GPT path: Uses the transformer block spec for MTP layer
@@ -1052,6 +1078,23 @@ class MultiTokenPredictionLayer(MegatronModule):
             eps=self.config.layernorm_epsilon,
         )
         self.offload_context = nullcontext()
+
+    def set_moe_metric_depth(self, depth_index: int, num_layers: int | None = None) -> None:
+        """Retarget a repeated hybrid MTP layer to the current prediction-depth slots."""
+
+        # Keep the depth on this invocation so an activation-checkpoint closure
+        # can restore it during backward recomputation.  The same module is
+        # shared by every prediction depth and its router slot is mutable.
+        self._moe_metric_depth_index = depth_index
+        self._moe_metric_num_layers = num_layers
+        metric_layer_count = getattr(self, "mtp_metric_layer_count", 0)
+        if metric_layer_count == 0 or not hasattr(
+            self.mtp_model_layer, "set_moe_metric_layer_offset"
+        ):
+            return
+        self.mtp_model_layer.set_moe_metric_layer_offset(
+            self.config.num_layers + depth_index * metric_layer_count, num_layers
+        )
 
     def _get_embeddings(
         self,
@@ -1186,7 +1229,10 @@ class MultiTokenPredictionLayer(MegatronModule):
             # transformer layer is cudagraphed, the FP8GlobalStateManager.is_first_fp8_module() is
             # True so that the fp8 weight caching can be triggered correctly.
             with transformer_layer_fp8_context:
-                if self.mtp_layer_pattern is not None:
+                if (
+                    self.mtp_layer_pattern is not None
+                    or getattr(self, "mtp_layer_specs", None) is not None
+                ):
                     hidden_states = self.mtp_model_layer(
                         hidden_states=hidden_states,
                         attention_mask=attention_mask,
@@ -1312,6 +1358,16 @@ class MultiTokenPredictionLayer(MegatronModule):
           ``outer_quantization_context`` block below.
         """
 
+        is_rotary_mapping = isinstance(rotary_pos_emb, dict)
+        rotary_mapping_keys = tuple(sorted(rotary_pos_emb)) if is_rotary_mapping else ()
+        rotary_inputs = (
+            tuple(rotary_pos_emb[key] for key in rotary_mapping_keys)
+            if is_rotary_mapping
+            else (rotary_pos_emb,)
+        )
+        moe_metric_depth_index = getattr(self, "_moe_metric_depth_index", None)
+        moe_metric_num_layers = getattr(self, "_moe_metric_num_layers", None)
+
         def custom_forward(
             hidden_states,
             decoder_input,
@@ -1319,11 +1375,17 @@ class MultiTokenPredictionLayer(MegatronModule):
             padding_mask,
             context,
             context_mask,
-            rotary_pos_emb,
-            rotary_pos_cos,
-            rotary_pos_sin,
-            sequence_len_offset,
+            *rope_and_tail,
         ):
+            rope_values = rope_and_tail[:-3]
+            rotary_pos_cos, rotary_pos_sin, sequence_len_offset = rope_and_tail[-3:]
+            checkpoint_rotary_pos_emb = (
+                dict(zip(rotary_mapping_keys, rope_values)) if is_rotary_mapping else rope_values[0]
+            )
+            if moe_metric_depth_index is not None:
+                # Reentrant checkpoint backward runs after the outer depth loop
+                # has left this shared module targeted at its final depth.
+                self.set_moe_metric_depth(moe_metric_depth_index, moe_metric_num_layers)
             return self._proj_and_transformer_layer(
                 hidden_states=hidden_states,
                 decoder_input=decoder_input,
@@ -1331,7 +1393,7 @@ class MultiTokenPredictionLayer(MegatronModule):
                 padding_mask=padding_mask,
                 context=context,
                 context_mask=context_mask,
-                rotary_pos_emb=rotary_pos_emb,
+                rotary_pos_emb=checkpoint_rotary_pos_emb,
                 rotary_pos_cos=rotary_pos_cos,
                 rotary_pos_sin=rotary_pos_sin,
                 attention_bias=attention_bias,
@@ -1378,7 +1440,7 @@ class MultiTokenPredictionLayer(MegatronModule):
                     padding_mask,
                     context,
                     context_mask,
-                    rotary_pos_emb,
+                    *rotary_inputs,
                     rotary_pos_cos,
                     rotary_pos_sin,
                     sequence_len_offset,
@@ -1398,7 +1460,7 @@ class MultiTokenPredictionLayer(MegatronModule):
                     padding_mask,
                     context,
                     context_mask,
-                    rotary_pos_emb,
+                    *rotary_inputs,
                     rotary_pos_cos,
                     rotary_pos_sin,
                     sequence_len_offset,
@@ -1544,7 +1606,7 @@ class MultiTokenPredictionLayer(MegatronModule):
         # named 'transformer_layer'. Remap checkpoint keys so old checkpoints load
         # correctly. Mamba MTP models keep 'mtp_model_layer' as their native format
         # since no older checkpoints exist for them.
-        if self.mtp_layer_pattern is None:
+        if self.mtp_layer_pattern is None and getattr(self, "mtp_layer_specs", None) is None:
             apply_prefix_mapping(
                 sharded_state_dict, {f'{prefix}mtp_model_layer.': f'{prefix}transformer_layer.'}
             )
@@ -1633,6 +1695,8 @@ class MultiTokenPredictionBlock(MegatronModule):
         hybrid_submodules: Optional["HybridStackSubmodules"] = None,
         mamba_submodules: Optional["HybridStackSubmodules"] = None,
         name: str | None = None,
+        mtp_layer_specs: Optional[Sequence[HybridLayerSpec]] = None,
+        moe_metric_num_layers: int | None = None,
     ):
         """
         Args:
@@ -1655,6 +1719,9 @@ class MultiTokenPredictionBlock(MegatronModule):
         self.mtp_loss_scaling_factor = config.mtp_loss_scaling_factor
         self.vp_stage = vp_stage
         self.mtp_layer_pattern = mtp_layer_pattern
+        if mtp_layer_specs is not None:
+            self.mtp_layer_specs = mtp_layer_specs
+            self.moe_metric_num_layers = moe_metric_num_layers
         self.mtp_num_depths = mtp_num_depths
         self.hybrid_submodules = hybrid_submodules
         self.mtp_use_repeated_layer = self.config.mtp_use_repeated_layer
@@ -1689,6 +1756,9 @@ class MultiTokenPredictionBlock(MegatronModule):
                 param.grad_norm_group = 'mtp'
 
     def _build_layers(self, pg_collection):
+        mtp_layer_specs = getattr(self, "mtp_layer_specs", None)
+        moe_metric_num_layers = getattr(self, "moe_metric_num_layers", None)
+
         # Determine number of depths to build
         if self.mtp_num_depths > 0:
             num_depths = self.mtp_num_depths
@@ -1711,10 +1781,18 @@ class MultiTokenPredictionBlock(MegatronModule):
             return module
 
         def build_layer_with_pattern(
-            layer_spec, layer_number, mtp_layer_pattern, hybrid_submodules
+            layer_spec, layer_number, mtp_layer_pattern, mtp_layer_specs, hybrid_submodules
         ):
             """Build layer using pattern-based approach (new Mamba path)."""
             fp8_init_context = get_fp8_context(self.config, is_init=True)
+            architecture_kwargs = (
+                {"mtp_layer_pattern": mtp_layer_pattern}
+                if mtp_layer_specs is None
+                else {
+                    "mtp_layer_specs": mtp_layer_specs,
+                    "moe_metric_num_layers": moe_metric_num_layers,
+                }
+            )
             with fp8_init_context:
                 module = build_module(
                     layer_spec,
@@ -1722,14 +1800,16 @@ class MultiTokenPredictionBlock(MegatronModule):
                     layer_number=layer_number,
                     vp_stage=self.vp_stage,
                     pg_collection=pg_collection,
-                    mtp_layer_pattern=mtp_layer_pattern,
                     hybrid_submodules=hybrid_submodules,
                     name=(self.name + f".layers.{layer_number}") if self.name is not None else None,
+                    **architecture_kwargs,
                 )
             return module
 
         # New Mamba path: use mtp_layer_pattern and hybrid_submodules
-        if self.mtp_layer_pattern is not None and self.hybrid_submodules is not None:
+        if (self.mtp_layer_pattern is not None or mtp_layer_specs is not None) and (
+            self.hybrid_submodules is not None
+        ):
             if self.mtp_use_repeated_layer:
                 # Shared/repeated layer: build one layer, use it for all depths
                 layer_spec = self.submodules.layer_specs[0]
@@ -1737,6 +1817,7 @@ class MultiTokenPredictionBlock(MegatronModule):
                     layer_spec,
                     layer_number=1,
                     mtp_layer_pattern=self.mtp_layer_pattern,
+                    mtp_layer_specs=mtp_layer_specs,
                     hybrid_submodules=self.hybrid_submodules,
                 )
                 self.layers = torch.nn.ModuleList([shared_layer])
@@ -1750,6 +1831,7 @@ class MultiTokenPredictionBlock(MegatronModule):
                             ],
                             layer_number=i + 1,
                             mtp_layer_pattern=self.mtp_layer_pattern,
+                            mtp_layer_specs=mtp_layer_specs,
                             hybrid_submodules=self.hybrid_submodules,
                         )
                         for i in range(num_depths)
@@ -1816,7 +1898,16 @@ class MultiTokenPredictionBlock(MegatronModule):
 
         for iteration in range(self.config.mtp_num_layers):
             layer_idx = 0 if self.mtp_use_repeated_layer else iteration
-            (hidden_states, input_ids, position_ids, padding_mask) = self.layers[layer_idx](
+            mtp_layer_specs = getattr(self, "mtp_layer_specs", None)
+            if (
+                mtp_layer_specs is not None
+                and self.mtp_use_repeated_layer
+                and hasattr(self.layers[layer_idx], "set_moe_metric_depth")
+            ):
+                self.layers[layer_idx].set_moe_metric_depth(
+                    iteration, getattr(self, "moe_metric_num_layers", None)
+                )
+            hidden_states, input_ids, position_ids, padding_mask = self.layers[layer_idx](
                 input_ids=input_ids,
                 position_ids=position_ids,
                 hidden_states=hidden_states,

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -6,15 +6,15 @@ import argparse
 import dataclasses
 import json
 import os
-from pathlib import Path
 import re
 import types
+from pathlib import Path
 
 import torch
 
+from megatron.core.msc_utils import MultiStorageClientFeature
 from megatron.core.rerun_state_machine import RerunStateMachine
 from megatron.core.transformer import TransformerConfig
-from megatron.core.transformer.pipeline_parallel_layer_layout import PipelineParallelLayerLayout
 from megatron.core.transformer.cuda_graph_config import (
     ALLOWED_INFERENCE_SCOPES,
     get_deprecated_cuda_graph_modules_migration,
@@ -23,23 +23,24 @@ from megatron.core.transformer.cuda_graph_config import (
     validate_deprecated_cuda_graph_modules_migration_inputs,
 )
 from megatron.core.transformer.enums import AttnBackend, CudaGraphModule, InferenceCudaGraphScope
+from megatron.core.transformer.pipeline_parallel_layer_layout import PipelineParallelLayerLayout
 from megatron.core.utils import (
     get_torch_version,
     is_flashinfer_min_version,
     is_te_min_version,
     is_torch_min_version,
 )
+from megatron.training.argument_utils import (  # noqa: F401 # pylint: disable=unused-import
+    ArgumentGroupFactory,
+    core_transformer_config_from_args,
+)
 from megatron.training.global_vars import set_global_variables
 from megatron.training.utils import (
     get_device_arch_version,
-    update_use_dist_ckpt,
     print_rank_0,
+    update_use_dist_ckpt,
     warn_rank_0,
 )
-from megatron.core.msc_utils import MultiStorageClientFeature
-
-from megatron.training.argument_utils import ArgumentGroupFactory, core_transformer_config_from_args  # noqa: F401 # pylint: disable=unused-import
-
 
 
 def add_megatron_arguments(parser: argparse.ArgumentParser):
@@ -398,8 +399,9 @@ def validate_args(args, defaults={}):
         'Currently only global and local checkpoints are supported'
     if args.non_persistent_ckpt_type == 'local':
         try:
-            from nvidia_resiliency_ext.checkpointing.local.ckpt_managers.local_manager import \
-                LocalCheckpointManager
+            from nvidia_resiliency_ext.checkpointing.local.ckpt_managers.local_manager import (
+                LocalCheckpointManager,
+            )
         except ModuleNotFoundError as e:
             raise RuntimeError('nvidia_resiliency_ext is required for local checkpointing') from e
 
@@ -740,8 +742,10 @@ def validate_args(args, defaults={}):
         )
 
     from megatron.core.models.hybrid.hybrid_layer_allocation import (
-        Symbols, parse_hybrid_pattern, get_hybrid_total_layer_count,
+        Symbols,
+        get_hybrid_total_layer_count,
         get_hybrid_total_pipeline_segment_count,
+        parse_hybrid_pattern,
     )
     sep = Symbols.MTP_SEPARATOR
 
@@ -948,20 +952,10 @@ def validate_args(args, defaults={}):
         if args.hybrid_layer_pattern is None:
             args.virtual_pipeline_model_parallel_size = None
 
-        if args.decoder_first_pipeline_num_layers is None and args.decoder_last_pipeline_num_layers is None:
-            # Divisibility check not applicable for T5 models which specify encoder_num_layers
-            # and decoder_num_layers, or for hybrid models using --hybrid-layer-pattern.
-            if args.num_layers is not None and args.hybrid_layer_pattern is None:
-                num_layers = args.num_layers
-
-                if args.account_for_embedding_in_pipeline_split:
-                    num_layers += 1
-
-                if args.account_for_loss_in_pipeline_split:
-                    num_layers += 1
-
-                assert num_layers % args.transformer_pipeline_model_parallel_size == 0, \
-                    'Number of layers should be divisible by the pipeline-model-parallel size'
+        # Defer layer-count divisibility to the selected model builder. Direct
+        # HybridModel architecture specs are Python objects constructed after
+        # CLI validation and may legally define uneven or empty explicit chunks.
+        # Conventional transformer builders retain their own divisibility checks.
 
     if args.virtual_pipeline_model_parallel_size is not None:
         if args.overlap_p2p_comm:
@@ -975,6 +969,11 @@ def validate_args(args, defaults={}):
                 'p2p sends and recvs between same 2 ranks per communication batch'
     else:
         # Overlap P2P communication is disabled if not using the interleaved schedule.
+        # Preserve the requested values because a Python HybridModel architecture
+        # can infer VPP only after this CLI-only validation pass.
+        if args.hybrid_layer_pattern is None:
+            args._overlap_p2p_comm_before_direct_vpp = args.overlap_p2p_comm
+            args._align_param_gather_before_direct_vpp = args.align_param_gather
         args.overlap_p2p_comm = False
         args.align_param_gather = False
         # Only print warning if PP size > 1.
@@ -1034,8 +1033,13 @@ def validate_args(args, defaults={}):
             '--overlap-param-gather-with-optimizer-step only supported with distributed optimizer'
         assert args.overlap_param_gather, \
             'Must use --overlap-param-gather-with-optimizer-step with --overlap-param-gather'
-        assert args.virtual_pipeline_model_parallel_size is not None, \
-            '--overlap-param-gather-with-optimizer-step only supported with interleaved pipeline parallelism'
+        if args.hybrid_layer_pattern is not None:
+            assert args.virtual_pipeline_model_parallel_size is not None, (
+                '--overlap-param-gather-with-optimizer-step only supported with '
+                'interleaved pipeline parallelism'
+            )
+        # Otherwise, the interleaved-pipeline requirement is checked in pretrain after
+        # Python model builders have had a chance to infer direct VPP splits.
         assert not args.use_dist_ckpt, \
             '--overlap-param-gather-with-optimizer-step not supported with distributed checkpointing yet'
 
@@ -2714,8 +2718,7 @@ def _add_rl_args(parser):
     return parser
 
 def _add_training_args(parser):
-    from megatron.training.config import TrainingConfig
-    from megatron.training.config import ProfilingConfig
+    from megatron.training.config import ProfilingConfig, TrainingConfig
 
     prof_factory = ArgumentGroupFactory(ProfilingConfig)
     prof_group = prof_factory.build_group(parser, "profiling")
@@ -3582,7 +3585,7 @@ def _add_kitchen_quantization_arguments(parser: argparse.ArgumentParser):
     If kitchen isn't available, nothing to do here, return unchanged parser
     """
     try:
-        from megatron.core.extensions.kitchen import KitchenSpecProvider, HAVE_KITCHEN
+        from megatron.core.extensions.kitchen import HAVE_KITCHEN, KitchenSpecProvider
 
     except (ImportError, ModuleNotFoundError):
         HAVE_KITCHEN = False

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -3,6 +3,7 @@
 """Input/output checkpointing."""
 
 import contextlib
+import copy
 import inspect
 import multiprocessing
 import os
@@ -39,7 +40,10 @@ from megatron.core.dist_checkpointing.strategies.torch import (
 from megatron.core.msc_utils import maybe_msc
 from megatron.core.num_microbatches_calculator import update_num_microbatches
 from megatron.core.optimizer import DistributedOptimizer
-from megatron.core.post_training.modelopt.checkpointing import save_modelopt_state, save_sharded_modelopt_state
+from megatron.core.post_training.modelopt.checkpointing import (
+    save_modelopt_state,
+    save_sharded_modelopt_state,
+)
 from megatron.core.rerun_state_machine import get_rerun_state_machine
 from megatron.core.utils import get_pg_rank, get_pg_size, unwrap_model
 from megatron.post_training.utils import print_distributed_quant_summary
@@ -1348,7 +1352,16 @@ def generate_state_dict(
 
     # Arguments, iteration, and model.
     state_dict = {}
-    state_dict['args'] = args
+    resolved_architecture = getattr(args, 'resolved_hybrid_architecture', None)
+    if getattr(resolved_architecture, "source", None) == "direct":
+        checkpoint_args = copy.copy(args)
+        # This runtime-only summary contains live ModuleSpec/config objects. Direct
+        # architecture recipes must be supplied by Python again on resume.
+        del checkpoint_args.resolved_hybrid_architecture
+        state_dict['args'] = checkpoint_args
+    else:
+        # Preserve the historical args object identity for legacy and non-hybrid checkpoints.
+        state_dict['args'] = args
     state_dict['checkpoint_version'] = 3.0
     if iteration is not None:
         state_dict['iteration'] = iteration

--- a/megatron/training/hybrid_metrics.py
+++ b/megatron/training/hybrid_metrics.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Helpers for reporting metrics from a resolved hybrid architecture."""
+
+from dataclasses import dataclass
+from typing import Any, Iterator
+
+_LAYER_TYPE_ALIASES = {
+    "M": "mamba",
+    "G": "gdn",
+    "*": "attention",
+    "D": "dsa",
+    "+": "mla",
+    "-": "mlp",
+    "E": "moe",
+}
+
+
+def get_resolved_hybrid_architecture(args: Any) -> Any | None:
+    """Return a model-provided direct architecture, if one was installed."""
+
+    architecture = getattr(args, "resolved_hybrid_architecture", None)
+    if architecture is None or getattr(architecture, "source", None) != "direct":
+        return None
+    return architecture
+
+
+def get_hybrid_layer_type(layer: Any) -> str:
+    """Return the stable semantic type name for a resolved hybrid layer."""
+
+    layer_type = layer.layer_type
+    if not isinstance(layer_type, str):
+        layer_type = getattr(layer_type, "value", layer_type)
+    layer_type = str(layer_type)
+    return _LAYER_TYPE_ALIASES.get(layer_type, layer_type.lower())
+
+
+def iter_resolved_hybrid_layers(architecture: Any) -> Iterator[Any]:
+    """Iterate main layers followed by each repeated MTP-depth template."""
+
+    yield from architecture.main_layers
+    for _ in range(architecture.mtp_num_layers):
+        yield from architecture.mtp_layers
+
+
+@dataclass(frozen=True)
+class HybridMoEMetricMetadata:
+    """Arguments needed to size and normalize global MoE metric tensors."""
+
+    num_layers: int
+    moe_layer_freq: list[int]
+    mtp_num_layers: int
+    num_moe_layers: int
+
+
+def get_hybrid_moe_metric_metadata(architecture: Any) -> HybridMoEMetricMetadata:
+    """Derive MoE logging metadata from per-occurrence semantic layer types.
+
+    Direct hybrid models assign metric slots over the fully expanded global
+    architecture, including every layer in every MTP depth. Consequently MTP
+    has already been incorporated into ``num_layers`` and ``moe_layer_freq``;
+    ``mtp_num_layers`` is zero to disable the tracker's legacy implicit MTP
+    expansion.
+    """
+
+    layer_types = [
+        get_hybrid_layer_type(layer) for layer in iter_resolved_hybrid_layers(architecture)
+    ]
+    moe_layer_freq = [int(layer_type == "moe") for layer_type in layer_types]
+    return HybridMoEMetricMetadata(
+        num_layers=len(layer_types),
+        moe_layer_freq=moe_layer_freq,
+        mtp_num_layers=0,
+        num_moe_layers=sum(moe_layer_freq),
+    )

--- a/megatron/training/models/hybrid.py
+++ b/megatron/training/models/hybrid.py
@@ -1,27 +1,32 @@
 # Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Callable, ClassVar, Literal, override
 
 from megatron.core.distributed.distributed_data_parallel_config import DistributedDataParallelConfig
 from megatron.core.enums import ModelType
+from megatron.core.models.hybrid.hybrid_architecture import (
+    HybridLayerPattern,
+    resolve_hybrid_architecture,
+)
+from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_inference_stack_spec
 from megatron.core.models.hybrid.hybrid_layer_specs import (
     hybrid_stack_spec as default_hybrid_stack_spec,
-    hybrid_inference_stack_spec,
 )
 from megatron.core.models.hybrid.hybrid_model import HybridModel
-from megatron.core.pipeline_parallel.utils import is_pp_first_stage, is_pp_last_stage
+from megatron.core.pipeline_parallel.utils import (
+    is_pp_first_stage,
+    is_pp_last_stage,
+    is_vp_first_stage,
+    is_vp_last_stage,
+)
 from megatron.core.post_training.modelopt.hybrid.model_specs import get_hybrid_stack_modelopt_spec
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.transformer.module import Float16Module, MegatronModule
 from megatron.core.transformer.spec_utils import ModuleSpec
 from megatron.core.transformer.transformer_config import TransformerConfig
-from megatron.training.models.base import (
-    ModelBuilder,
-    ModelConfig,
-    compose_hooks,
-)
+from megatron.training.models.base import ModelBuilder, ModelConfig, compose_hooks
 from megatron.training.models.dist_utils import unimodal_build_distributed_models
 from megatron.training.vocab_utils import calculate_padded_vocab_size
 
@@ -39,7 +44,8 @@ class HybridModelConfig(ModelConfig):
     on the embedded ``transformer`` config are accessible directly on this object
     via ``__getattr__``/``__setattr__`` proxying.
 
-    Supports hybrid architectures via ``hybrid_layer_pattern``
+    Direct ``layer_specs`` are the preferred architecture API. The legacy
+    ``hybrid_layer_pattern`` string remains supported for compatibility.
 
     Note:
         ``vocab_size`` must be set before passing this config to ``HybridModelBuilder``.
@@ -56,6 +62,8 @@ class HybridModelConfig(ModelConfig):
     hybrid_mlp_ratio: float = 0.0
     hybrid_override_pattern: str | None = None
     hybrid_layer_pattern: str | None = None
+    layer_specs: HybridLayerPattern | None = field(default=None, repr=False)
+    mtp_layer_specs: HybridLayerPattern | None = field(default=None, repr=False)
     seq_length: int = 8192
     # HybridModel with no attention has no need for position embeddings, so none is default
     position_embedding_type: Literal["learned_absolute", "rope", "none"] = "none"
@@ -109,6 +117,18 @@ class HybridModelConfig(ModelConfig):
         if hasattr(self.transformer, "finalize") and callable(self.transformer.finalize):
             self.transformer.finalize()
 
+    @override
+    def as_dict(self) -> dict[str, Any]:
+        """Serialize scalar configuration without live Python architecture objects.
+
+        The Python recipe must supply direct ``ModuleSpec`` trees again when resuming.
+        """
+
+        result = super().as_dict()
+        result.pop("layer_specs", None)
+        result.pop("mtp_layer_specs", None)
+        return result
+
 
 class HybridModelBuilder(ModelBuilder[HybridModel, HybridModelConfig]):
     """Builder to construct Megatron Core Hybrid models.
@@ -126,6 +146,101 @@ class HybridModelBuilder(ModelBuilder[HybridModel, HybridModelConfig]):
 
     def __init__(self, model_config: HybridModelConfig):
         super().__init__(model_config)
+        has_direct_specs = (
+            model_config.layer_specs is not None or model_config.mtp_layer_specs is not None
+        )
+        # Only direct descriptors need topology resolution before distributed construction.
+        # Legacy patterns retain the historical builder and runtime selector path.
+        if has_direct_specs:
+            self._hybrid_stack_spec = self._get_hybrid_stack_spec()
+            self._resolved_architecture = resolve_hybrid_architecture(
+                config=model_config.transformer,
+                hybrid_stack_spec=self._hybrid_stack_spec,
+                layer_specs=model_config.layer_specs,
+                mtp_layer_specs=model_config.mtp_layer_specs,
+                hybrid_layer_pattern=model_config.hybrid_layer_pattern,
+            )
+
+    @classmethod
+    def prepare_config_for_distributed_init(
+        cls, model_config: HybridModelConfig, args: Any
+    ) -> bool:
+        """Resolve split topology before Megatron initializes pipeline runtime state.
+
+        Direct Python specs are not present while command-line arguments are
+        validated, so their inferred VPP size must be copied to the runtime
+        namespace before ``initialize_model_parallel`` runs. Returns whether
+        direct architecture state was prepared.
+        """
+
+        if model_config.layer_specs is None and model_config.mtp_layer_specs is None:
+            return False
+
+        builder = cls(model_config)
+        resolved_architecture = getattr(builder, "_resolved_architecture", None)
+        if resolved_architecture is None:
+            return False
+
+        transformer = model_config.transformer
+        pp_size = transformer.pipeline_model_parallel_size
+        runtime_pp_size = getattr(args, "pipeline_model_parallel_size", pp_size)
+        if runtime_pp_size != pp_size:
+            raise ValueError(
+                "HybridModelConfig.transformer.pipeline_model_parallel_size must match the "
+                f"runtime pipeline topology; got {pp_size} != {runtime_pp_size}."
+            )
+
+        inferred_vp_size = transformer.virtual_pipeline_model_parallel_size
+        runtime_vp_size = getattr(args, "virtual_pipeline_model_parallel_size", None)
+        if runtime_vp_size is not None and runtime_vp_size != inferred_vp_size:
+            raise ValueError(
+                "Hybrid architecture splits disagree with the runtime virtual pipeline "
+                f"topology; got {inferred_vp_size} != {runtime_vp_size}."
+            )
+        args.virtual_pipeline_model_parallel_size = inferred_vp_size
+
+        # Argument validation temporarily disables interleaved-only options when
+        # direct Python split nodes are not available yet. Restore the user's
+        # requested settings now that those nodes have inferred VPP.
+        if inferred_vp_size is not None and runtime_vp_size is None:
+            requested_overlap = getattr(
+                args,
+                "_overlap_p2p_comm_before_direct_vpp",
+                getattr(args, "overlap_p2p_comm", False),
+            )
+            requested_align = getattr(
+                args,
+                "_align_param_gather_before_direct_vpp",
+                getattr(args, "align_param_gather", False),
+            )
+            if pp_size == 2 and not requested_overlap:
+                raise ValueError(
+                    "Direct PP2/VPP interleaving requires P2P communication overlap; "
+                    "remove --no-overlap-p2p-communication."
+                )
+            args.overlap_p2p_comm = requested_overlap
+            args.align_param_gather = requested_align
+            if hasattr(args, "batch_p2p_comm"):
+                args.batch_p2p_comm = not requested_overlap
+            transformer.overlap_p2p_comm = requested_overlap
+            transformer.batch_p2p_comm = not requested_overlap
+
+        return True
+
+    def _get_hybrid_stack_spec(self) -> ModuleSpec:
+        """Select the stack implementation used by every local model chunk."""
+
+        hybrid_stack_spec = self._model_config.hybrid_stack_spec
+        if hybrid_stack_spec is not None:
+            return hybrid_stack_spec
+        if self._model_config.transformer.transformer_impl == "inference_optimized":
+            return hybrid_inference_stack_spec
+        if self._model_config.restore_modelopt_state:
+            return get_hybrid_stack_modelopt_spec(
+                local_core_attention=False,
+                remap_te_layernorm=False,
+            )
+        return default_hybrid_stack_spec
 
     def build_model(
         self,
@@ -145,20 +260,25 @@ class HybridModelBuilder(ModelBuilder[HybridModel, HybridModelConfig]):
         Returns:
             The constructed model
 
-        Note:
-            Virtual pipeline model parallelism is not supported for Hybrid models.
         """
-        hybrid_stack_spec = self._model_config.hybrid_stack_spec
-        if hybrid_stack_spec is None:
-            if self._model_config.transformer.transformer_impl == "inference_optimized":
-                hybrid_stack_spec = hybrid_inference_stack_spec
-            elif self._model_config.restore_modelopt_state:
-                hybrid_stack_spec = get_hybrid_stack_modelopt_spec(
-                    local_core_attention=False,
-                    remap_te_layernorm=False,
-                )
-            else:
-                hybrid_stack_spec = default_hybrid_stack_spec
+        # Re-resolve if a caller selected a different implementation spec after
+        # builder construction (for example, modelopt or optimized inference).
+        hybrid_stack_spec = self._get_hybrid_stack_spec()
+        has_direct_specs = (
+            self._model_config.layer_specs is not None
+            or self._model_config.mtp_layer_specs is not None
+        )
+        if has_direct_specs and hybrid_stack_spec is not getattr(
+            self, "_hybrid_stack_spec", None
+        ):
+            self._hybrid_stack_spec = hybrid_stack_spec
+            self._resolved_architecture = resolve_hybrid_architecture(
+                config=self._model_config.transformer,
+                hybrid_stack_spec=hybrid_stack_spec,
+                layer_specs=self._model_config.layer_specs,
+                mtp_layer_specs=self._model_config.mtp_layer_specs,
+                hybrid_layer_pattern=self._model_config.hybrid_layer_pattern,
+            )
 
         assert self._model_config.vocab_size is not None, "vocab_size must be configured before calling build_model()"
         if self._model_config.should_pad_vocab:
@@ -170,8 +290,35 @@ class HybridModelBuilder(ModelBuilder[HybridModel, HybridModelConfig]):
         else:
             padded_vocab_size = self._model_config.vocab_size
 
-        pre_process = pre_process if pre_process is not None else is_pp_first_stage(pg_collection.pp)
-        post_process = post_process if post_process is not None else is_pp_last_stage(pg_collection.pp)
+        resolved_architecture = getattr(self, "_resolved_architecture", None)
+        is_direct = resolved_architecture is not None
+        if is_direct:
+            vp_size = self._model_config.transformer.virtual_pipeline_model_parallel_size
+            if vp_size is not None and vp_stage is None:
+                # A single-chunk build defaults to the first virtual stage, matching
+                # ResolvedHybridArchitecture.select_segment's public semantics.
+                vp_stage = 0
+            pre_process = (
+                pre_process
+                if pre_process is not None
+                else is_pp_first_stage(pg_collection.pp) and is_vp_first_stage(vp_stage, vp_size)
+            )
+            post_process = (
+                post_process
+                if post_process is not None
+                else is_pp_last_stage(pg_collection.pp) and is_vp_last_stage(vp_stage, vp_size)
+            )
+        else:
+            pre_process = (
+                pre_process if pre_process is not None else is_pp_first_stage(pg_collection.pp)
+            )
+            post_process = (
+                post_process if post_process is not None else is_pp_last_stage(pg_collection.pp)
+            )
+
+        direct_architecture_kwargs = (
+            {"resolved_hybrid_architecture": resolved_architecture} if is_direct else {}
+        )
         return HybridModel(
             config=self._model_config.transformer,
             hybrid_stack_spec=hybrid_stack_spec,
@@ -189,6 +336,7 @@ class HybridModelBuilder(ModelBuilder[HybridModel, HybridModelConfig]):
             post_process=post_process,
             pg_collection=pg_collection,
             vp_stage=vp_stage,
+            **direct_architecture_kwargs,
         )
 
     def build_distributed_models(

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -146,6 +146,12 @@ from megatron.training.checkpointing import (
 from megatron.training.config import FaultInjectorConfig
 from megatron.training.config.container import PretrainConfigContainer
 from megatron.training.datasets.data_samplers import build_pretraining_data_loader
+from megatron.training.hybrid_metrics import (
+    get_hybrid_layer_type,
+    get_hybrid_moe_metric_metadata,
+    get_resolved_hybrid_architecture,
+    iter_resolved_hybrid_layers,
+)
 from megatron.training.initialize import (
     initialize_megatron,
     set_jit_fusion_options,
@@ -471,16 +477,21 @@ def num_floating_point_operations(
             + 2 * seqlen_squared_sum * hidden_size * p
         )
 
-    def mamba_layer_flops(total_tokens, hidden_size, state_dim=16,
-                          head_dim=64, num_groups=1, num_heads=128):
+    def mamba_layer_flops(
+        total_tokens,
+        hidden_size,
+        state_dim=16,
+        head_dim=64,
+        num_groups=1,
+        num_heads=128,
+        d_in=None,
+    ):
         """Calculate FLOPs for a Mamba layer."""
         # Note (rwaleffe): flops estimate for scan should be updated based on new SSD kernels,
         # but small percent of overall layer flops
-        d_in = 2 * hidden_size
-        if num_heads:
-            nheads = num_heads
-        else:
-            nheads = d_in // head_dim
+        if d_in is None:
+            d_in = 2 * hidden_size
+        nheads = num_heads if num_heads else d_in // head_dim
         return (
             (
                 2
@@ -544,6 +555,127 @@ def num_floating_point_operations(
                                                   gdn_num_qk_heads, gdn_num_v_heads,
                                                   gdn_conv_kernel_dim) +
                 (2 * total_tokens * hidden_size * vocab_size * (1 + mtp_num_layers))  # logits computation
+        )
+        return flops_fwd * 3
+
+    def resolved_hybrid_flops(architecture):
+        """Calculate hybrid FLOPs from every resolved layer occurrence."""
+
+        flops_fwd = 0
+        mtp_num_layers = architecture.mtp_num_layers
+        for layer in iter_resolved_hybrid_layers(architecture):
+            config = layer.config
+            layer_type = get_hybrid_layer_type(layer)
+            hidden_size = config.hidden_size
+
+            if layer_type == "attention":
+                num_heads = config.num_attention_heads
+                num_query_groups = config.num_query_groups or num_heads
+                flops_fwd += attn_layer_flops(
+                    total_real_tokens_in_batch,
+                    seqlen_squared_sum_in_batch,
+                    hidden_size,
+                    num_heads,
+                    gqa=num_query_groups != num_heads,
+                    gqa_groups=num_query_groups,
+                    kv_channels=config.kv_channels,
+                )
+            elif layer_type in {"mla", "dsa"}:
+                if config.q_lora_rank is None:
+                    q_term = (
+                        config.hidden_size
+                        * config.num_attention_heads
+                        * (config.qk_head_dim + config.qk_pos_emb_head_dim)
+                    )
+                else:
+                    q_term = config.q_lora_rank * (
+                        config.hidden_size
+                        + config.num_attention_heads
+                        * (config.qk_head_dim + config.qk_pos_emb_head_dim)
+                        + 1
+                    )
+                projection_term = (
+                    q_term
+                    + config.kv_lora_rank
+                    * (
+                        config.hidden_size
+                        + config.num_attention_heads
+                        * (config.qk_head_dim + config.v_head_dim)
+                        + 1
+                    )
+                    + config.hidden_size * config.qk_pos_emb_head_dim
+                    + config.num_attention_heads * config.v_head_dim * config.hidden_size
+                )
+                core_term = config.num_attention_heads * (
+                    config.qk_head_dim + config.qk_pos_emb_head_dim + config.v_head_dim
+                )
+                flops_fwd += (
+                    2 * total_real_tokens_in_batch * projection_term
+                    + seqlen_squared_sum_in_batch * core_term
+                )
+            elif layer_type == "mamba":
+                flops_fwd += mamba_layer_flops(
+                    total_real_tokens_in_batch,
+                    hidden_size,
+                    state_dim=config.mamba_state_dim,
+                    head_dim=config.mamba_head_dim,
+                    num_groups=config.mamba_num_groups,
+                    num_heads=config.mamba_num_heads,
+                    d_in=(
+                        config.mamba_num_heads * config.mamba_head_dim
+                        if config.mamba_num_heads
+                        else 2 * hidden_size
+                    ),
+                )
+            elif layer_type == "mlp":
+                flops_fwd += mlp_layer_flops(
+                    total_real_tokens_in_batch,
+                    hidden_size,
+                    expansion=config.ffn_hidden_size / hidden_size,
+                    swiglu=config.gated_linear_unit,
+                )
+            elif layer_type == "moe":
+                flops_fwd += moe_layer_flops(
+                    total_real_tokens_in_batch,
+                    hidden_size,
+                    moe_ffn_hidden_size=config.moe_ffn_hidden_size or config.ffn_hidden_size,
+                    shared_expert_ffn_hidden_size=(config.moe_shared_expert_intermediate_size or 0),
+                    num_experts_routed_to=config.moe_router_topk,
+                    moe_latent_size=config.moe_latent_size,
+                    swiglu=config.gated_linear_unit,
+                )
+            elif layer_type == "gdn":
+                flops_fwd += gdn_layer_flops(
+                    total_real_tokens_in_batch,
+                    hidden_size,
+                    qk_head_dim=config.linear_key_head_dim or 128,
+                    v_head_dim=config.linear_value_head_dim or 128,
+                    num_qk_heads=config.linear_num_key_heads or 16,
+                    num_v_heads=config.linear_num_value_heads or 32,
+                    conv_kernel_dim=config.linear_conv_kernel_dim or 4,
+                )
+            else:
+                raise ValueError(
+                    f"FLOPs calculation is not implemented for resolved hybrid "
+                    f"layer type {layer_type!r}."
+                )
+
+        # Each MTP depth adds two norms, a final norm, and the eh projection.
+        # Layer work above already includes every repeated MTP template layer.
+        flops_fwd += (
+            2
+            * total_real_tokens_in_batch
+            * mtp_num_layers
+            * (3 * args.hidden_size + 2 * args.hidden_size * args.hidden_size)
+        )
+
+        # The main decoder and every MTP depth use an output head.
+        flops_fwd += (
+            2
+            * total_real_tokens_in_batch
+            * args.hidden_size
+            * args.padded_vocab_size
+            * (1 + mtp_num_layers)
         )
         return flops_fwd * 3
 
@@ -848,6 +980,10 @@ def num_floating_point_operations(
 
     # Main entrypoint for FLOPs calculation.
     if is_hybrid_model(args):
+        resolved_architecture = get_resolved_hybrid_architecture(args)
+        if resolved_architecture is not None:
+            return resolved_hybrid_flops(resolved_architecture)
+
         # Calculate the number of each type of layer.
         from operator import itemgetter
 
@@ -1084,6 +1220,45 @@ def pretrain(
     # to enable monitoring of the initialization process
     ft_integration.setup()
     timestamp_after_in_job_setup = time.time()
+
+    # Model-defined split nodes may infer VPP after command-line validation.
+    # Give builders a chance to synchronize that topology before MPU state is
+    # initialized and before schedules/data iterators consult the runtime args.
+    runtime_args = get_args()
+    model_config = getattr(cfg_container, "model", None)
+    prepared_direct_architecture = False
+    if model_config is not None:
+        builder_cls = model_config.get_builder_cls()
+        prepare_for_distributed_init = getattr(
+            builder_cls, "prepare_config_for_distributed_init", None
+        )
+        if prepare_for_distributed_init is not None:
+            prepared_direct_architecture = bool(
+                prepare_for_distributed_init(model_config, runtime_args)
+            )
+
+    # Synchronize config objects that were materialized after CLI validation but
+    # before a direct architecture could infer VPP.
+    if (
+        prepared_direct_architecture
+        and getattr(runtime_args, "virtual_pipeline_model_parallel_size", None) is not None
+        and getattr(cfg_container, "ddp", None) is not None
+    ):
+        cfg_container.ddp.align_param_gather = runtime_args.align_param_gather
+    if (
+        getattr(runtime_args, "overlap_param_gather_with_optimizer_step", False)
+        and getattr(runtime_args, "virtual_pipeline_model_parallel_size", None) is None
+    ):
+        raise AssertionError(
+            "--overlap-param-gather-with-optimizer-step only supported with "
+            "interleaved pipeline parallelism"
+        )
+    for deferred_attr in (
+        "_overlap_p2p_comm_before_direct_vpp",
+        "_align_param_gather_before_direct_vpp",
+    ):
+        if hasattr(runtime_args, deferred_attr):
+            delattr(runtime_args, deferred_attr)
 
     # Multimodal MiMo seeds each module's RNG in its builder; a plain collection seeds stock here.
     skip_random_seed = isinstance(pg_collection, MultiModuleProcessGroupCollection)
@@ -2110,6 +2285,23 @@ def setup_model_and_optimizer(
     model = _build_model_wrapper(wrap_with_ddp)
     unwrapped_model = unwrap_model(model)
 
+    # Resolved hybrid architectures are model-construction artifacts rather
+    # than command-line arguments. Make the shared global summary available to
+    # training metrics after all physical/virtual chunks have been built.
+    if hasattr(args, "resolved_hybrid_architecture"):
+        delattr(args, "resolved_hybrid_architecture")
+    model_chunks = unwrapped_model if isinstance(unwrapped_model, list) else [unwrapped_model]
+    for model_chunk in model_chunks:
+        resolved_hybrid_architecture = getattr(
+            model_chunk, "resolved_hybrid_architecture", None
+        )
+        if (
+            resolved_hybrid_architecture is not None
+            and resolved_hybrid_architecture.source == "direct"
+        ):
+            args.resolved_hybrid_architecture = resolved_hybrid_architecture
+            break
+
     # Classify each GTP param's prefetch chain after model build + DDP wrap, before the
     # first forward. Placed here (not in get_model) so it also covers the config-container
     # builder path.
@@ -2792,7 +2984,18 @@ def training_log(
                 wandb_writer.log({'max_attention_logit': max_attention_logit}, iteration)
     # Log MoE metrics.
     moe_log_string = ""
-    if args.num_experts is not None:
+    resolved_architecture = get_resolved_hybrid_architecture(args)
+    resolved_moe_metadata = (
+        get_hybrid_moe_metric_metadata(resolved_architecture)
+        if resolved_architecture is not None
+        else None
+    )
+    has_moe_layers = (
+        resolved_moe_metadata.num_moe_layers > 0
+        if resolved_moe_metadata is not None
+        else args.num_experts is not None
+    )
+    if has_moe_layers:
         moe_loss_scale = 1 / get_num_microbatches()
         track_names = []
         if "aux_loss" in args.moe_router_load_balancing_type:
@@ -2804,7 +3007,13 @@ def training_log(
         if args.moe_z_loss_coeff is not None:
             track_names.append("z_loss")
 
-        if is_hybrid_model(args):
+        if resolved_architecture is not None:
+            assert resolved_moe_metadata is not None
+            moe_metadata = resolved_moe_metadata
+            layers = moe_metadata.num_layers
+            moe_layer_freq = moe_metadata.moe_layer_freq
+            mtp_num_layers = moe_metadata.mtp_num_layers
+        elif is_hybrid_model(args):
             from operator import itemgetter
 
             from megatron.core.ssm.mamba_hybrid_layer_allocation import (
@@ -2812,8 +3021,12 @@ def training_log(
                 get_hybrid_layer_counts,
             )
             layers = itemgetter(Symbols.MOE)(get_hybrid_layer_counts(args.hybrid_layer_pattern))
+            moe_layer_freq = args.moe_layer_freq
+            mtp_num_layers = args.mtp_num_layers
         else:
             layers = args.num_layers
+            moe_layer_freq = args.moe_layer_freq
+            mtp_num_layers = args.mtp_num_layers
 
         moe_log_string = get_moe_metrics_tracker().report(
             loss_scale=moe_loss_scale,
@@ -2824,14 +3037,19 @@ def training_log(
             force_initialize=True,
             track_names=track_names,
             num_layers=layers,
-            moe_layer_freq=args.moe_layer_freq,
-            mtp_num_layers=args.mtp_num_layers,
+            moe_layer_freq=moe_layer_freq,
+            mtp_num_layers=mtp_num_layers,
             pg_collection=pg_collection,
             total_loss_dict=total_loss_dict,
         )
 
     # Log MTP metrics.
-    if args.mtp_num_layers is not None:
+    has_mtp_metrics = (
+        resolved_architecture.mtp_num_layers > 0
+        if resolved_architecture is not None
+        else args.mtp_num_layers is not None
+    )
+    if has_mtp_metrics:
         mtp_loss_scale = 1 / get_num_microbatches()
         MTPLossLoggingHelper.track_mtp_metrics(
             mtp_loss_scale, iteration, writer, wandb_writer, total_loss_dict

--- a/megatron/training/utils/common_utils.py
+++ b/megatron/training/utils/common_utils.py
@@ -12,10 +12,10 @@ from typing import Optional
 
 import torch
 
-from megatron.core.msc_utils import maybe_msc
 from megatron.core._rank_utils import safe_get_rank as _safe_get_rank
 from megatron.core._slurm_utils import resolve_slurm_local_rank
 from megatron.core.dist_checkpointing.strategies.nvrx import has_nvrx_async_support
+from megatron.core.msc_utils import maybe_msc
 
 try:
     from transformer_engine.pytorch.optimizers import multi_tensor_applier, multi_tensor_l2norm
@@ -46,7 +46,6 @@ from megatron.core.utils import (
     unwrap_model,
 )
 from megatron.training import get_adlr_autoresume, get_args, get_timers
-
 
 
 def _compute_norm_2(params_list):
@@ -476,7 +475,11 @@ def print_rank_last(message):
 
 def is_hybrid_model(args):
     """Returns True if the model is a hybrid Mamba-Transformer model."""
-    return args.hybrid_layer_pattern is not None
+    resolved_architecture = getattr(args, 'resolved_hybrid_architecture', None)
+    return (
+        getattr(args, 'hybrid_layer_pattern', None) is not None
+        or getattr(resolved_architecture, 'source', None) == 'direct'
+    )
 
 
 def is_gtp_remat_active(args):

--- a/tests/unit_tests/models/hybrid/test_hybrid_architecture.py
+++ b/tests/unit_tests/models/hybrid/test_hybrid_architecture.py
@@ -1,0 +1,856 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Unit tests for first-class HybridModel architecture descriptions."""
+
+from copy import deepcopy
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from megatron.core.inference.config import MambaInferenceStateConfig
+from megatron.core.inference.utils import InferenceMode
+from megatron.core.models.hybrid.hybrid_architecture import (
+    HYBRID_LAYER_TYPE,
+    HybridLayerSpec,
+    PipelineSplit,
+    flatten_hybrid_layer_pattern,
+    resolve_hybrid_architecture,
+)
+from megatron.core.models.hybrid.hybrid_layer_specs import (
+    hybrid_inference_stack_spec,
+    hybrid_stack_spec,
+)
+from megatron.core.models.hybrid.hybrid_model import HybridModel
+from megatron.core.transformer import TransformerConfig
+from megatron.core.transformer.spec_utils import ModuleSpec
+
+
+class _Layer:
+    """Stand-in module class; resolver tests only inspect ModuleSpec metadata."""
+
+
+class _Stack:
+    """Stand-in HybridStack class for the resolver's legacy symbol mapping."""
+
+
+def _tagged_spec(layer_type: str) -> ModuleSpec:
+    return ModuleSpec(module=_Layer, metainfo={HYBRID_LAYER_TYPE: layer_type})
+
+
+STACK_SPEC = ModuleSpec(
+    module=_Stack,
+    submodules=SimpleNamespace(
+        mamba_layer=_tagged_spec("mamba"),
+        gdn_layer=_tagged_spec("gdn"),
+        attention_layer=_tagged_spec("attention"),
+        dsa_layer=_tagged_spec("dsa"),
+        mla_layer=_tagged_spec("mla"),
+        mlp_layer=_tagged_spec("mlp"),
+        moe_layer=_tagged_spec("moe"),
+    ),
+)
+
+SPEC_BY_TYPE = {
+    "mamba": STACK_SPEC.submodules.mamba_layer,
+    "gdn": STACK_SPEC.submodules.gdn_layer,
+    "attention": STACK_SPEC.submodules.attention_layer,
+    "dsa": STACK_SPEC.submodules.dsa_layer,
+    "mla": STACK_SPEC.submodules.mla_layer,
+    "mlp": STACK_SPEC.submodules.mlp_layer,
+    "moe": STACK_SPEC.submodules.moe_layer,
+}
+
+STOCK_LAYER_TYPES = {
+    "mamba_layer": "mamba",
+    "gdn_layer": "gdn",
+    "attention_layer": "attention",
+    "dsa_layer": "dsa",
+    "mla_layer": "mla",
+    "mlp_layer": "mlp",
+    "moe_layer": "moe",
+}
+
+
+def _config(num_layers: int, *, pp_size: int = 1, mtp_num_layers: int | None = None):
+    return TransformerConfig(
+        num_layers=num_layers,
+        hidden_size=64,
+        num_attention_heads=8,
+        num_query_groups=4,
+        kv_channels=8,
+        ffn_hidden_size=128,
+        num_moe_experts=8,
+        moe_ffn_hidden_size=96,
+        moe_router_topk=2,
+        mamba_state_dim=16,
+        mamba_head_dim=8,
+        mamba_num_heads=8,
+        mamba_num_groups=2,
+        add_bias_linear=False,
+        pipeline_model_parallel_size=pp_size,
+        pipeline_dtype=torch.float32,
+        mtp_num_layers=mtp_num_layers,
+    )
+
+
+def _layer(layer_type: str, config: TransformerConfig) -> HybridLayerSpec:
+    return HybridLayerSpec(module_spec=SPEC_BY_TYPE[layer_type], config=config)
+
+
+def _types(layers) -> list[str]:
+    return [layer.layer_type for layer in layers]
+
+
+def _model_shell(architecture, config):
+    """Create enough of a HybridModel to exercise its early inference guards."""
+
+    model = HybridModel.__new__(HybridModel)
+    torch.nn.Module.__init__(model)
+    model.config = config
+    if architecture is not None:
+        model.resolved_hybrid_architecture = architecture
+    return model
+
+
+@pytest.mark.parametrize(
+    ("stack_spec", "expected_types"),
+    [
+        pytest.param(hybrid_stack_spec, STOCK_LAYER_TYPES, id="training"),
+        pytest.param(
+            hybrid_inference_stack_spec,
+            {name: value for name, value in STOCK_LAYER_TYPES.items() if name != "gdn_layer"},
+            id="inference",
+        ),
+    ],
+)
+def test_every_stock_hybrid_layer_module_spec_has_stable_semantic_tag(stack_spec, expected_types):
+    tagged_types = {
+        field_name: module_spec.metainfo.get(HYBRID_LAYER_TYPE)
+        for field_name in STOCK_LAYER_TYPES
+        if isinstance((module_spec := getattr(stack_spec.submodules, field_name)), ModuleSpec)
+    }
+
+    assert tagged_types == expected_types
+
+
+def test_flatten_preserves_nested_alias_multiplication_and_empty_segments():
+    config = _config(6)
+    mamba = _layer("mamba", config)
+    attention = _layer("attention", config)
+    moe = _layer("moe", config)
+
+    segments = flatten_hybrid_layer_pattern(
+        [[mamba, attention] * 2, PipelineSplit(), [], PipelineSplit(), (moe, [mamba])]
+    )
+
+    assert [_types(segment) for segment in segments] == [
+        ["mamba", "attention", "mamba", "attention"],
+        [],
+        ["moe", "mamba"],
+    ]
+    assert segments[0][0] is mamba
+    assert segments[0][2] is mamba
+
+
+def test_pp2_vpp2_selection_is_vpp_major_and_offsets_include_empty_chunks():
+    config = _config(6, pp_size=2)
+    mamba = _layer("mamba", config)
+    attention = _layer("attention", config)
+    moe = _layer("moe", config)
+    mlp = _layer("mlp", config)
+
+    architecture = resolve_hybrid_architecture(
+        config=config,
+        hybrid_stack_spec=STACK_SPEC,
+        layer_specs=[
+            [mamba],
+            PipelineSplit(),
+            [attention, moe],
+            PipelineSplit(),
+            [],
+            PipelineSplit(),
+            [mlp, mamba, attention],
+        ],
+    )
+
+    assert config.virtual_pipeline_model_parallel_size == 2
+    expected = {
+        (0, 0): (["mamba"], 0),
+        (1, 0): (["attention", "moe"], 1),
+        (0, 1): ([], 3),
+        (1, 1): (["mlp", "mamba", "attention"], 3),
+    }
+    for (pp_rank, vp_stage), (expected_types, expected_offset) in expected.items():
+        layers, offset = architecture.select_segment(pp_rank=pp_rank, pp_size=2, vp_stage=vp_stage)
+        assert _types(layers) == expected_types
+        assert offset == expected_offset
+
+
+def test_resolver_materializes_an_isolated_config_for_every_occurrence():
+    config = _config(3)
+    alias_config = deepcopy(config)
+    alias_config.mamba_state_dim = 24
+    alias = _layer("mamba", alias_config)
+
+    architecture = resolve_hybrid_architecture(
+        config=config, hybrid_stack_spec=STACK_SPEC, layer_specs=[[alias] * 3]
+    )
+
+    resolved_configs = [layer.config for layer in architecture.main_layers]
+    assert len({id(layer_config) for layer_config in resolved_configs}) == 3
+    assert all(layer_config is not alias_config for layer_config in resolved_configs)
+    assert [layer_config.mamba_state_dim for layer_config in resolved_configs] == [24, 24, 24]
+
+    resolved_configs[0].mamba_state_dim = 32
+    assert resolved_configs[1].mamba_state_dim == 24
+    assert alias_config.mamba_state_dim == 24
+
+
+def test_resolver_materializes_pipeline_and_mtp_topology_from_base_config():
+    config = _config(2, pp_size=2, mtp_num_layers=2)
+    config.mtp_use_repeated_layer = True
+    occurrence_config = deepcopy(config)
+    occurrence_config.pipeline_model_parallel_layout = object()
+    occurrence_config.mtp_num_layers = 7
+    occurrence_config.mtp_use_repeated_layer = False
+    occurrence_config.mtp_standalone = True
+
+    architecture = resolve_hybrid_architecture(
+        config=config,
+        hybrid_stack_spec=STACK_SPEC,
+        layer_specs=[
+            _layer("mamba", occurrence_config),
+            PipelineSplit(),
+            _layer("mamba", occurrence_config),
+        ],
+        mtp_layer_specs=[_layer("attention", occurrence_config)],
+    )
+
+    for layer in architecture.main_layers + architecture.mtp_layers:
+        assert layer.config.pipeline_model_parallel_layout is None
+        assert layer.config.mtp_num_layers == 2
+        assert layer.config.mtp_use_repeated_layer is True
+        assert layer.config.mtp_standalone is False
+
+
+def test_resolver_preserves_permitted_per_layer_shape_differences():
+    config = _config(8)
+    configs = [deepcopy(config) for _ in range(8)]
+
+    configs[0].mamba_state_dim = 24
+    configs[0].mamba_head_dim = 4
+    configs[0].mamba_num_heads = 16
+    configs[0].mamba_num_groups = 4
+    configs[1].mamba_state_dim = 32
+
+    configs[2].num_attention_heads = 16
+    configs[2].num_query_groups = 8
+    configs[2].kv_channels = 4
+    configs[3].num_attention_heads = 4
+    configs[3].num_query_groups = 2
+    configs[3].kv_channels = 16
+
+    configs[4].ffn_hidden_size = 160
+    configs[5].ffn_hidden_size = 192
+
+    configs[6].moe_ffn_hidden_size = 112
+    configs[6].moe_router_topk = 3
+    configs[7].moe_ffn_hidden_size = 144
+    configs[7].moe_router_topk = 4
+
+    architecture = resolve_hybrid_architecture(
+        config=config,
+        hybrid_stack_spec=STACK_SPEC,
+        layer_specs=[
+            _layer("mamba", configs[0]),
+            _layer("mamba", configs[1]),
+            _layer("attention", configs[2]),
+            _layer("attention", configs[3]),
+            _layer("mlp", configs[4]),
+            _layer("mlp", configs[5]),
+            _layer("moe", configs[6]),
+            _layer("moe", configs[7]),
+        ],
+    )
+
+    layers = architecture.main_layers
+    assert (
+        layers[0].config.mamba_state_dim,
+        layers[0].config.mamba_head_dim,
+        layers[0].config.mamba_num_heads,
+        layers[0].config.mamba_num_groups,
+    ) == (24, 4, 16, 4)
+    assert layers[1].config.mamba_state_dim == 32
+    assert (
+        layers[2].config.num_attention_heads,
+        layers[2].config.num_query_groups,
+        layers[2].config.kv_channels,
+    ) == (16, 8, 4)
+    assert (
+        layers[3].config.num_attention_heads,
+        layers[3].config.num_query_groups,
+        layers[3].config.kv_channels,
+    ) == (4, 2, 16)
+    assert [layers[index].config.ffn_hidden_size for index in (4, 5)] == [160, 192]
+    assert [
+        (layers[index].config.moe_ffn_hidden_size, layers[index].config.moe_router_topk)
+        for index in (6, 7)
+    ] == [(112, 3), (144, 4)]
+
+
+@pytest.mark.parametrize(
+    ("layer_type", "field_name", "heterogeneous_value"),
+    [
+        pytest.param("mamba", "mamba_state_dim", 24, id="mamba-cache"),
+        pytest.param("attention", "kv_channels", 16, id="attention-kv-cache"),
+        pytest.param("moe", "moe_router_topk", 3, id="moe-router-buffer"),
+    ],
+)
+def test_dynamic_inference_rejects_heterogeneous_runtime_shapes(
+    layer_type, field_name, heterogeneous_value
+):
+    config = _config(2)
+    first_config = deepcopy(config)
+    second_config = deepcopy(config)
+    setattr(second_config, field_name, heterogeneous_value)
+    architecture = resolve_hybrid_architecture(
+        config=config,
+        hybrid_stack_spec=STACK_SPEC,
+        layer_specs=[_layer(layer_type, first_config), _layer(layer_type, second_config)],
+    )
+    model = _model_shell(architecture, config)
+    inference_context = SimpleNamespace(is_dynamic_batching=lambda: True)
+
+    with (
+        InferenceMode.active(),
+        pytest.raises(
+            NotImplementedError, match="incompatible with dynamic inference's model-global"
+        ),
+    ):
+        model.forward(
+            input_ids=None,
+            position_ids=None,
+            attention_mask=None,
+            inference_context=inference_context,
+            runtime_gather_output=False,
+        )
+
+
+@pytest.mark.parametrize(
+    ("layer_type", "field_name", "override_value"),
+    [
+        pytest.param("attention", "kv_channels", 16, id="attention-kv-cache"),
+        pytest.param("moe", "moe_router_topk", 3, id="moe-router-buffer"),
+    ],
+)
+def test_dynamic_inference_rejects_uniform_overrides_incompatible_with_global_buffers(
+    layer_type, field_name, override_value
+):
+    config = _config(2)
+    layer_config = deepcopy(config)
+    setattr(layer_config, field_name, override_value)
+    architecture = resolve_hybrid_architecture(
+        config=config,
+        hybrid_stack_spec=STACK_SPEC,
+        layer_specs=[_layer(layer_type, layer_config), _layer(layer_type, layer_config)],
+    )
+    model = _model_shell(architecture, config)
+    inference_context = SimpleNamespace(is_dynamic_batching=lambda: True)
+
+    with (
+        InferenceMode.active(),
+        pytest.raises(
+            NotImplementedError, match="incompatible with dynamic inference's model-global"
+        ),
+    ):
+        model.forward(
+            input_ids=None,
+            position_ids=None,
+            attention_mask=None,
+            inference_context=inference_context,
+            runtime_gather_output=False,
+        )
+
+
+def test_dynamic_inference_allows_uniform_runtime_shapes_past_heterogeneity_guard():
+    config = _config(2)
+    architecture = resolve_hybrid_architecture(
+        config=config,
+        hybrid_stack_spec=STACK_SPEC,
+        layer_specs=[_layer("mamba", config), _layer("mamba", config)],
+    )
+    model = _model_shell(architecture, config)
+    inference_context = SimpleNamespace(is_dynamic_batching=lambda: True)
+
+    # The next inference invariant proves the heterogeneity guard allowed this
+    # uniform architecture through without needing to construct model layers.
+    with (
+        InferenceMode.active(),
+        pytest.raises(AssertionError, match="Inference must always gather TP logits"),
+    ):
+        model.forward(
+            input_ids=None,
+            position_ids=None,
+            attention_mask=None,
+            inference_context=inference_context,
+            runtime_gather_output=False,
+        )
+
+
+def test_dynamic_inference_rejects_before_reading_layer_state_shapes():
+    config = _config(2)
+    second_config = deepcopy(config)
+    second_config.mamba_state_dim = 24
+    architecture = resolve_hybrid_architecture(
+        config=config,
+        hybrid_stack_spec=STACK_SPEC,
+        layer_specs=[_layer("mamba", config), _layer("mamba", second_config)],
+    )
+
+    class ModelWithUnallocatedState:
+        resolved_hybrid_architecture = architecture
+
+        def __init__(self):
+            self.config = config
+
+        @property
+        def decoder(self):
+            raise AssertionError("Mamba state shapes must not be read before rejection")
+
+    with pytest.raises(
+        NotImplementedError, match="incompatible with dynamic inference's model-global"
+    ):
+        MambaInferenceStateConfig.from_model(ModelWithUnallocatedState())
+
+
+def test_explicit_static_engine_path_skips_dynamic_shape_validation():
+    config = _config(2)
+    second_config = deepcopy(config)
+    second_config.mamba_state_dim = 24
+    architecture = resolve_hybrid_architecture(
+        config=config,
+        hybrid_stack_spec=STACK_SPEC,
+        layer_specs=[_layer("mamba", config), _layer("mamba", second_config)],
+    )
+    decoder = SimpleNamespace(
+        layer_type_list=["mamba", "mamba"],
+        layers=[SimpleNamespace(mixer=SimpleNamespace(chunk_size=64)), SimpleNamespace()],
+        mamba_state_shapes_per_request=lambda: ((8, 4), (8, 16)),
+    )
+    model = SimpleNamespace(
+        resolved_hybrid_architecture=architecture,
+        decoder=decoder,
+        config=SimpleNamespace(params_dtype=torch.bfloat16, batch_invariant_mode=False),
+    )
+
+    inference_config = MambaInferenceStateConfig.from_model(model, validate_dynamic_inference=False)
+
+    assert inference_config is not None
+    assert inference_config.layer_type_list == ["M", "M"]
+
+
+def test_inference_state_normalizes_semantic_layer_types_to_legacy_maps():
+    decoder = SimpleNamespace(
+        layer_type_list=["mamba", "attention"],
+        layers=[SimpleNamespace(mixer=SimpleNamespace(chunk_size=64)), SimpleNamespace()],
+        mamba_state_shapes_per_request=lambda: ((8, 4), (8, 16)),
+    )
+    model = SimpleNamespace(
+        decoder=decoder,
+        config=SimpleNamespace(params_dtype=torch.bfloat16, batch_invariant_mode=False),
+    )
+
+    inference_config = MambaInferenceStateConfig.from_model(model)
+
+    assert inference_config is not None
+    assert inference_config.layer_type_list == ["M", "*"]
+    assert inference_config.mamba_chunk_size == 64
+
+
+def test_legacy_inference_keeps_symbol_list_identity_and_skips_direct_shape_rejection():
+    layer_type_list = ["M", "M"]
+    decoder = SimpleNamespace(
+        layer_type_list=layer_type_list,
+        layers=[SimpleNamespace(mixer=SimpleNamespace(chunk_size=64)), SimpleNamespace()],
+        mamba_state_shapes_per_request=lambda: ((8, 4), (8, 16)),
+    )
+    model = SimpleNamespace(
+        decoder=decoder,
+        config=SimpleNamespace(params_dtype=torch.bfloat16, batch_invariant_mode=False),
+    )
+
+    assert not hasattr(model, "resolved_hybrid_architecture")
+
+    inference_config = MambaInferenceStateConfig.from_model(model)
+
+    assert inference_config is not None
+    assert inference_config.layer_type_list is layer_type_list
+
+
+def test_legacy_forward_does_not_run_direct_heterogeneity_guard():
+    config = _config(2)
+    model = _model_shell(None, config)
+    inference_context = SimpleNamespace(is_dynamic_batching=lambda: True)
+
+    assert not hasattr(model, "resolved_hybrid_architecture")
+
+    with (
+        InferenceMode.active(),
+        pytest.raises(AssertionError, match="Inference must always gather TP logits"),
+    ):
+        model.forward(
+            input_ids=None,
+            position_ids=None,
+            attention_mask=None,
+            inference_context=inference_context,
+            runtime_gather_output=False,
+        )
+
+
+@pytest.mark.parametrize(
+    ("layer_specs", "mtp_layer_specs", "legacy_pattern", "message"),
+    [
+        pytest.param(["direct"], None, "M", "mutually exclusive", id="direct-and-legacy"),
+        pytest.param(None, ["mtp"], "M", "requires direct layer_specs", id="mtp-with-legacy"),
+        pytest.param(None, None, None, "Exactly one", id="missing-architecture"),
+    ],
+)
+def test_resolver_rejects_invalid_architecture_source_combinations(
+    layer_specs, mtp_layer_specs, legacy_pattern, message
+):
+    config = _config(1)
+    direct_layer = _layer("mamba", config)
+    if layer_specs is not None:
+        layer_specs = [direct_layer]
+    if mtp_layer_specs is not None:
+        mtp_layer_specs = [direct_layer]
+
+    with pytest.raises(ValueError, match=message):
+        resolve_hybrid_architecture(
+            config=config,
+            hybrid_stack_spec=STACK_SPEC,
+            layer_specs=layer_specs,
+            mtp_layer_specs=mtp_layer_specs,
+            hybrid_layer_pattern=legacy_pattern,
+        )
+
+
+def test_direct_pp_requires_splits_and_segment_count_divisible_by_pp_size():
+    config = _config(2, pp_size=2)
+    mamba = _layer("mamba", config)
+
+    with pytest.raises(ValueError, match="must contain explicit PipelineSplit"):
+        resolve_hybrid_architecture(
+            config=config, hybrid_stack_spec=STACK_SPEC, layer_specs=[mamba, mamba]
+        )
+
+    config = _config(2, pp_size=2)
+    mamba = _layer("mamba", config)
+    with pytest.raises(ValueError, match="not divisible"):
+        resolve_hybrid_architecture(
+            config=config,
+            hybrid_stack_spec=STACK_SPEC,
+            layer_specs=[mamba, PipelineSplit(), mamba, PipelineSplit()],
+        )
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [
+        ("pipeline_model_parallel_layout", object()),
+        ("num_layers_in_first_pipeline_stage", 1),
+        ("num_layers_in_last_pipeline_stage", 1),
+        ("account_for_embedding_in_pipeline_split", True),
+        ("account_for_loss_in_pipeline_split", True),
+    ],
+)
+def test_direct_splits_reject_other_pipeline_ownership_controls(field_name, value):
+    config = _config(2, pp_size=2)
+    setattr(config, field_name, value)
+    mamba = _layer("mamba", config)
+
+    with pytest.raises(ValueError, match=field_name):
+        resolve_hybrid_architecture(
+            config=config, hybrid_stack_spec=STACK_SPEC, layer_specs=[mamba, PipelineSplit(), mamba]
+        )
+
+
+def test_direct_splits_reject_configured_vpp_mismatch():
+    config = _config(4, pp_size=2)
+    config.virtual_pipeline_model_parallel_size = 3
+    mamba = _layer("mamba", config)
+
+    with pytest.raises(ValueError, match="imply virtual_pipeline_model_parallel_size=2"):
+        resolve_hybrid_architecture(
+            config=config,
+            hybrid_stack_spec=STACK_SPEC,
+            layer_specs=[
+                mamba,
+                PipelineSplit(),
+                mamba,
+                PipelineSplit(),
+                mamba,
+                PipelineSplit(),
+                mamba,
+            ],
+        )
+
+
+def test_mtp_rejects_pipeline_splits():
+    config = _config(1, mtp_num_layers=1)
+    mamba = _layer("mamba", config)
+
+    with pytest.raises(ValueError, match="not allowed in an MTP pattern"):
+        resolve_hybrid_architecture(
+            config=config,
+            hybrid_stack_spec=STACK_SPEC,
+            layer_specs=[mamba],
+            mtp_layer_specs=[mamba, PipelineSplit(), mamba],
+        )
+
+
+def test_direct_mtp_rejects_an_empty_final_decoder_chunk():
+    config = _config(1, pp_size=2, mtp_num_layers=1)
+    mamba = _layer("mamba", config)
+
+    with pytest.raises(ValueError, match="standalone MTP placement"):
+        resolve_hybrid_architecture(
+            config=config,
+            hybrid_stack_spec=STACK_SPEC,
+            layer_specs=[mamba, PipelineSplit()],
+            mtp_layer_specs=[mamba],
+        )
+
+
+def test_direct_architecture_rejects_standalone_mtp_placement():
+    config = _config(1, mtp_num_layers=1)
+    config.mtp_standalone = True
+    mamba = _layer("mamba", config)
+
+    with pytest.raises(ValueError, match="do not support standalone MTP"):
+        resolve_hybrid_architecture(
+            config=config,
+            hybrid_stack_spec=STACK_SPEC,
+            layer_specs=[mamba],
+            mtp_layer_specs=[mamba],
+        )
+
+
+@pytest.mark.parametrize(
+    ("num_layers", "layer_count"),
+    [pytest.param(2, 1, id="too-few"), pytest.param(1, 2, id="too-many")],
+)
+def test_direct_layer_count_must_match_transformer_config(num_layers, layer_count):
+    config = _config(num_layers)
+    mamba = _layer("mamba", config)
+
+    with pytest.raises(ValueError, match=f"contains {layer_count} decoder layers"):
+        resolve_hybrid_architecture(
+            config=config, hybrid_stack_spec=STACK_SPEC, layer_specs=[mamba] * layer_count
+        )
+
+
+def test_direct_mtp_presence_must_match_configured_depth():
+    config = _config(1, mtp_num_layers=1)
+    mamba = _layer("mamba", config)
+    with pytest.raises(ValueError, match="requires mtp_layer_specs"):
+        resolve_hybrid_architecture(
+            config=config, hybrid_stack_spec=STACK_SPEC, layer_specs=[mamba]
+        )
+
+
+def test_legacy_summary_does_not_validate_or_mutate_mtp_depth():
+    config = _config(1, mtp_num_layers=1)
+
+    architecture = resolve_hybrid_architecture(
+        config=config, hybrid_stack_spec=STACK_SPEC, hybrid_layer_pattern="M/M/M"
+    )
+
+    assert architecture.mtp_num_layers == 2
+    assert config.mtp_num_layers == 1
+
+    config = _config(1)
+    mamba = _layer("mamba", config)
+    with pytest.raises(ValueError, match="requires config.mtp_num_layers > 0"):
+        resolve_hybrid_architecture(
+            config=config,
+            hybrid_stack_spec=STACK_SPEC,
+            layer_specs=[mamba],
+            mtp_layer_specs=[mamba],
+        )
+
+
+def test_legacy_summary_preserves_shared_config_identity():
+    config = _config(4, mtp_num_layers=2)
+
+    architecture = resolve_hybrid_architecture(
+        config=config, hybrid_stack_spec=STACK_SPEC, hybrid_layer_pattern="M*E-/M*/M*"
+    )
+
+    assert all(layer.config is config for layer in architecture.main_layers)
+    assert all(layer.config is config for layer in architecture.mtp_layers)
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [
+        ("pipeline_model_parallel_layout", object()),
+        ("account_for_embedding_in_pipeline_split", True),
+        ("account_for_loss_in_pipeline_split", True),
+    ],
+)
+def test_legacy_summary_does_not_reject_new_direct_split_conflicts(field_name, value):
+    config = _config(2, pp_size=2)
+    setattr(config, field_name, value)
+
+    architecture = resolve_hybrid_architecture(
+        config=config, hybrid_stack_spec=STACK_SPEC, hybrid_layer_pattern="M|M"
+    )
+
+    assert [_types(segment) for segment in architecture.segments] == [["mamba"], ["mamba"]]
+    assert getattr(config, field_name) is value
+
+
+def test_legacy_summary_does_not_infer_or_mutate_vpp():
+    config = _config(4, pp_size=2)
+
+    architecture = resolve_hybrid_architecture(
+        config=config, hybrid_stack_spec=STACK_SPEC, hybrid_layer_pattern="M|M|M|M"
+    )
+
+    assert len(architecture.segments) == 4
+    assert config.virtual_pipeline_model_parallel_size is None
+
+
+def test_legacy_summary_does_not_add_a_layer_count_validation():
+    config = _config(3)
+
+    architecture = resolve_hybrid_architecture(
+        config=config, hybrid_stack_spec=STACK_SPEC, hybrid_layer_pattern="M"
+    )
+
+    assert _types(architecture.main_layers) == ["mamba"]
+    assert config.num_layers == 3
+
+
+def test_legacy_summary_accepts_layer_classes_supported_by_hybrid_stack():
+    stack_spec = deepcopy(STACK_SPEC)
+    stack_spec.submodules.mamba_layer = _Layer
+    config = _config(1)
+
+    architecture = resolve_hybrid_architecture(
+        config=config, hybrid_stack_spec=stack_spec, hybrid_layer_pattern="M"
+    )
+
+    assert architecture.main_layers[0].module_spec.module is _Layer
+    assert architecture.main_layers[0].config is config
+
+
+def test_legacy_summary_only_reads_submodule_fields_used_by_the_pattern():
+    stack_spec = ModuleSpec(
+        module=_Stack, submodules=SimpleNamespace(mamba_layer=_tagged_spec("mamba"))
+    )
+    config = _config(1)
+
+    architecture = resolve_hybrid_architecture(
+        config=config, hybrid_stack_spec=stack_spec, hybrid_layer_pattern="M"
+    )
+
+    assert _types(architecture.main_layers) == ["mamba"]
+
+
+def test_legacy_summary_preserves_empty_final_chunk_with_mtp():
+    config = _config(1, pp_size=2, mtp_num_layers=1)
+
+    architecture = resolve_hybrid_architecture(
+        config=config, hybrid_stack_spec=STACK_SPEC, hybrid_layer_pattern="M|/M"
+    )
+
+    assert [len(segment) for segment in architecture.segments] == [1, 0]
+    assert _types(architecture.mtp_layers) == ["mamba"]
+
+
+def test_direct_architecture_rejects_nonuniform_total_expert_count():
+    config = _config(1, mtp_num_layers=1)
+    first_config = deepcopy(config)
+    second_config = deepcopy(config)
+    second_config.num_moe_experts = 16
+
+    with pytest.raises(ValueError, match="uniform num_moe_experts"):
+        resolve_hybrid_architecture(
+            config=config,
+            hybrid_stack_spec=STACK_SPEC,
+            layer_specs=[_layer("moe", first_config)],
+            mtp_layer_specs=[_layer("moe", second_config)],
+        )
+
+
+def test_direct_architecture_expert_count_must_match_base_config():
+    config = _config(1)
+    occurrence_config = deepcopy(config)
+    occurrence_config.num_moe_experts = 16
+
+    with pytest.raises(ValueError, match="must match the model-wide config"):
+        resolve_hybrid_architecture(
+            config=config,
+            hybrid_stack_spec=STACK_SPEC,
+            layer_specs=[_layer("moe", occurrence_config)],
+        )
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [
+        ("fp32_residual_connection", True),
+        ("attention_softmax_in_fp32", False),
+        ("enable_autocast", True),
+        ("fp8_margin", 1),
+        ("layernorm_zero_centered_gamma", True),
+        ("moe_router_dtype", "fp32"),
+        ("mamba_training_ssm_states_dtype", torch.float32),
+        ("dsa_indexer_k_norm_fp32", True),
+        ("tensor_parallel_num_weight_shards", 2),
+        ("expert_tensor_parallel_num_weight_shards", 2),
+        ("hierarchical_context_parallel_sizes", [1]),
+        ("hybrid_context_parallel", True),
+    ],
+)
+def test_direct_architecture_rejects_per_layer_model_wide_changes(field_name, value):
+    config = _config(1)
+    occurrence_config = deepcopy(config)
+    setattr(occurrence_config, field_name, value)
+
+    with pytest.raises(ValueError, match=field_name):
+        resolve_hybrid_architecture(
+            config=config,
+            hybrid_stack_spec=STACK_SPEC,
+            layer_specs=[_layer("mamba", occurrence_config)],
+        )
+
+
+def test_equivalent_legacy_and_direct_architectures_have_same_types_and_order():
+    direct_config = _config(4, pp_size=2)
+    direct_architecture = resolve_hybrid_architecture(
+        config=direct_config,
+        hybrid_stack_spec=STACK_SPEC,
+        layer_specs=[
+            _layer("mamba", direct_config),
+            _layer("attention", direct_config),
+            PipelineSplit(),
+            _layer("moe", direct_config),
+            _layer("mlp", direct_config),
+        ],
+    )
+    legacy_architecture = resolve_hybrid_architecture(
+        config=_config(4, pp_size=2), hybrid_stack_spec=STACK_SPEC, hybrid_layer_pattern="M*|E-"
+    )
+
+    assert [_types(segment) for segment in direct_architecture.segments] == [
+        _types(segment) for segment in legacy_architecture.segments
+    ]
+    assert [layer.module_spec.module for layer in direct_architecture.main_layers] == [
+        layer.module_spec.module for layer in legacy_architecture.main_layers
+    ]
+    assert direct_architecture.source == "direct"
+    assert legacy_architecture.source == "legacy"

--- a/tests/unit_tests/models/hybrid/test_hybrid_stack_checkpoint_keys.py
+++ b/tests/unit_tests/models/hybrid/test_hybrid_stack_checkpoint_keys.py
@@ -1,0 +1,328 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""CPU-only tests for HybridStack distributed-checkpoint layer keys."""
+
+from inspect import signature
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+from torch import nn
+
+from megatron.core.dist_checkpointing.mapping import ShardedTensor
+from megatron.core.models.hybrid import hybrid_block
+from megatron.core.models.hybrid.hybrid_architecture import (
+    HYBRID_LAYER_TYPE,
+    HybridLayerSpec,
+    PipelineSplit,
+    resolve_hybrid_architecture,
+)
+from megatron.core.models.hybrid.hybrid_block import HybridStack, HybridStackSubmodules
+from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols
+from megatron.core.models.hybrid.hybrid_model import HybridModel
+from megatron.core.transformer import TransformerConfig
+from megatron.core.transformer.spec_utils import ModuleSpec
+
+
+class _CheckpointLayer(nn.Module):
+    """Minimal layer exposing a real parameter and a sharded checkpoint entry."""
+
+    def __init__(self, layer_number: int):
+        super().__init__()
+        self.layer_number = layer_number
+        self.weight = nn.Parameter(torch.tensor([float(layer_number)]))
+
+    def sharded_state_dict(self, prefix='', sharded_offsets=(), metadata=None):
+        del sharded_offsets, metadata
+        key = f'{prefix}weight'
+        return {key: ShardedTensor.from_rank_offsets(key, self.weight)}
+
+
+MAMBA_SPEC = ModuleSpec(module=_CheckpointLayer, metainfo={HYBRID_LAYER_TYPE: "mamba"})
+STACK_SPEC = ModuleSpec(
+    module=HybridStack, submodules=HybridStackSubmodules(mamba_layer=MAMBA_SPEC)
+)
+
+
+def _config() -> TransformerConfig:
+    return TransformerConfig(
+        num_layers=8,
+        hidden_size=16,
+        num_attention_heads=4,
+        num_query_groups=2,
+        kv_channels=4,
+        ffn_hidden_size=32,
+        mamba_state_dim=8,
+        mamba_head_dim=4,
+        mamba_num_heads=4,
+        mamba_num_groups=2,
+        pipeline_model_parallel_size=2,
+        pipeline_dtype=torch.float32,
+        use_cpu_initialization=True,
+    )
+
+
+def _stack(config, *, layer_specs=None, layer_type_list=None, offset=0) -> HybridStack:
+    return HybridStack(
+        config=config,
+        submodules=STACK_SPEC.submodules,
+        layer_specs=layer_specs,
+        layer_type_list=layer_type_list,
+        pp_layer_offset=offset,
+        pre_process=False,
+        post_process=False,
+        post_layer_norm=False,
+        pg_collection=SimpleNamespace(pp=object(), tp=object()),
+    )
+
+
+def _checkpoint_keys(stack: HybridStack) -> set[str]:
+    return {entry.key for entry in stack.sharded_state_dict(prefix="decoder.").values()}
+
+
+def test_pp2_vpp2_checkpoint_keys_use_global_offsets_and_match_legacy(monkeypatch):
+    config = _config()
+    layer = HybridLayerSpec(MAMBA_SPEC, config)
+    architecture = resolve_hybrid_architecture(
+        config=config,
+        hybrid_stack_spec=STACK_SPEC,
+        layer_specs=[
+            [layer] * 2,
+            PipelineSplit(),
+            [layer],
+            PipelineSplit(),
+            [layer] * 3,
+            PipelineSplit(),
+            [layer] * 2,
+        ],
+    )
+
+    monkeypatch.setattr(
+        hybrid_block,
+        "build_module",
+        lambda _spec, **kwargs: _CheckpointLayer(kwargs["layer_number"]),
+    )
+
+    expected_chunks = {(0, 0): (2, 0), (1, 0): (1, 2), (0, 1): (3, 3), (1, 1): (2, 6)}
+    all_direct_checkpoint_keys = set()
+
+    for (pp_rank, vp_stage), (expected_length, expected_offset) in expected_chunks.items():
+        layer_specs, offset = architecture.select_segment(
+            pp_rank=pp_rank, pp_size=2, vp_stage=vp_stage
+        )
+        assert len(layer_specs) == expected_length
+        assert offset == expected_offset
+
+        direct_stack = _stack(config, layer_specs=layer_specs, offset=offset)
+        legacy_stack = _stack(
+            config, layer_type_list=[Symbols.MAMBA] * len(layer_specs), offset=offset
+        )
+
+        local_keys = {f'layers.{index}.weight' for index in range(expected_length)}
+        local_prefixed_keys = {f'decoder.layers.{index}.weight' for index in range(expected_length)}
+        global_checkpoint_keys = {
+            f'decoder.layers.{offset + index}.weight' for index in range(expected_length)
+        }
+
+        assert set(direct_stack.state_dict()) == local_keys
+        assert set(legacy_stack.state_dict()) == local_keys
+
+        direct_sharded_state = direct_stack.sharded_state_dict(prefix="decoder.")
+        legacy_sharded_state = legacy_stack.sharded_state_dict(prefix="decoder.")
+        assert set(direct_sharded_state) == local_prefixed_keys
+        assert set(legacy_sharded_state) == local_prefixed_keys
+        assert _checkpoint_keys(direct_stack) == global_checkpoint_keys
+        assert _checkpoint_keys(legacy_stack) == global_checkpoint_keys
+
+        assert [layer.layer_number for layer in direct_stack.layers] == list(
+            range(offset + 1, offset + expected_length + 1)
+        )
+        all_direct_checkpoint_keys.update(global_checkpoint_keys)
+
+    assert all_direct_checkpoint_keys == {
+        f'decoder.layers.{index}.weight' for index in range(config.num_layers)
+    }
+
+
+def test_raw_hybrid_model_derives_ownership_after_inferring_vpp():
+    config = _config()
+    config.num_layers = 4
+    layer = HybridLayerSpec(MAMBA_SPEC, config)
+    layer_specs = [layer, PipelineSplit(), layer, PipelineSplit(), layer, PipelineSplit(), layer]
+    pg_collection = SimpleNamespace(tp=object(), cp=object(), pp=object(), embd=None)
+
+    with (
+        patch(
+            "megatron.core.models.common.language_module.language_module."
+            "LanguageModule._set_attention_backend"
+        ),
+        patch("megatron.core.models.hybrid.hybrid_model.get_pg_rank", return_value=1),
+        patch(
+            "megatron.core.models.hybrid.hybrid_model.build_module",
+            return_value=torch.nn.Identity(),
+        ),
+    ):
+        model = HybridModel(
+            config=config,
+            hybrid_stack_spec=STACK_SPEC,
+            vocab_size=128,
+            max_sequence_length=16,
+            layer_specs=layer_specs,
+            pg_collection=pg_collection,
+            vp_stage=0,
+        )
+
+    assert config.virtual_pipeline_model_parallel_size == 2
+    assert model.vp_size == 2
+    assert model.pre_process is False
+    assert model.post_process is False
+
+
+def test_raw_legacy_hybrid_model_preserves_default_ownership_and_symbol_adapter():
+    config = _config()
+    config.num_layers = 1
+    calls = []
+    pg_collection = SimpleNamespace(tp=None, cp=None, pp=None, embd=None)
+
+    def fake_build_module(_spec, *args, **kwargs):
+        calls.append((args, kwargs))
+        return torch.nn.Identity()
+
+    with (
+        patch(
+            "megatron.core.models.common.language_module.language_module."
+            "LanguageModule._set_attention_backend"
+        ),
+        patch(
+            "megatron.core.models.hybrid.hybrid_model.LanguageModelEmbedding",
+            return_value=torch.nn.Identity(),
+        ),
+        patch(
+            "megatron.core.models.hybrid.hybrid_model.tensor_parallel.ColumnParallelLinear",
+            return_value=torch.nn.Identity(),
+        ),
+        patch(
+            "megatron.core.models.hybrid.hybrid_model.HybridModel."
+            "setup_embeddings_and_output_layer"
+        ),
+        patch(
+            "megatron.core.models.hybrid.hybrid_model.resolve_hybrid_architecture",
+            side_effect=AssertionError("legacy construction must not invoke the direct resolver"),
+        ),
+        patch("megatron.core.models.hybrid.hybrid_model.build_module", fake_build_module),
+    ):
+        model = HybridModel(
+            config=config,
+            hybrid_stack_spec=STACK_SPEC,
+            vocab_size=128,
+            max_sequence_length=16,
+            hybrid_layer_pattern="M",
+            pg_collection=pg_collection,
+        )
+
+    assert model.pre_process is True
+    assert model.post_process is True
+    assert not hasattr(model, "resolved_hybrid_architecture")
+    assert calls[0][1]["layer_type_list"] == [Symbols.MAMBA]
+    assert "layer_specs" not in calls[0][1]
+
+
+def test_raw_legacy_hybrid_model_preserves_explicit_none_ownership():
+    config = _config()
+    config.num_layers = 1
+    pg_collection = SimpleNamespace(tp=None, cp=None, pp=None, embd=None)
+
+    with (
+        patch(
+            "megatron.core.models.common.language_module.language_module."
+            "LanguageModule._set_attention_backend"
+        ),
+        patch(
+            "megatron.core.models.hybrid.hybrid_model.build_module",
+            return_value=torch.nn.Identity(),
+        ),
+    ):
+        model = HybridModel(
+            config=config,
+            hybrid_stack_spec=STACK_SPEC,
+            vocab_size=128,
+            max_sequence_length=16,
+            hybrid_layer_pattern="M",
+            pre_process=None,
+            post_process=None,
+            pg_collection=pg_collection,
+        )
+
+    assert model.pre_process is None
+    assert model.post_process is None
+    assert not hasattr(model, "embedding")
+    assert not hasattr(model, "output_layer")
+
+
+def test_direct_hybrid_model_parameters_are_appended_after_legacy_signature():
+    parameters = signature(HybridModel.__init__).parameters
+
+    parameter_names = list(parameters)
+    assert parameter_names.index("layer_specs") > parameter_names.index("vp_stage")
+    assert parameter_names.index("mtp_layer_specs") > parameter_names.index("vp_stage")
+    assert parameter_names.index("resolved_hybrid_architecture") > parameter_names.index("vp_stage")
+    assert parameters["pre_process"].default is True
+    assert parameters["post_process"].default is True
+    assert parameters["pre_process"].annotation is bool
+    assert parameters["post_process"].annotation is bool
+
+
+def test_legacy_hybrid_model_keeps_string_mtp_construction_path():
+    config = _config()
+    config.num_layers = 1
+    config.mtp_num_layers = 2
+    stack_spec = ModuleSpec(
+        module=HybridStack,
+        submodules=HybridStackSubmodules(
+            mamba_layer=MAMBA_SPEC, mtp_block_spec=ModuleSpec(module=torch.nn.Identity)
+        ),
+    )
+    pg_collection = SimpleNamespace(tp=None, cp=None, pp=None, embd=None)
+
+    with (
+        patch(
+            "megatron.core.models.common.language_module.language_module."
+            "LanguageModule._set_attention_backend"
+        ),
+        patch(
+            "megatron.core.models.hybrid.hybrid_model.LanguageModelEmbedding",
+            return_value=torch.nn.Identity(),
+        ),
+        patch(
+            "megatron.core.models.hybrid.hybrid_model.tensor_parallel.ColumnParallelLinear",
+            return_value=torch.nn.Identity(),
+        ),
+        patch(
+            "megatron.core.models.hybrid.hybrid_model.HybridModel."
+            "setup_embeddings_and_output_layer"
+        ),
+        patch("megatron.core.models.hybrid.hybrid_model.HybridModel._setup_mtp_cuda_graphs"),
+        patch(
+            "megatron.core.models.hybrid.hybrid_model.build_module",
+            return_value=torch.nn.Identity(),
+        ),
+        patch("megatron.core.models.hybrid.hybrid_model.mtp_on_this_rank", return_value=True),
+        patch(
+            "megatron.core.models.hybrid.hybrid_model.MultiTokenPredictionBlock",
+            return_value=torch.nn.Identity(),
+        ) as mtp_block,
+    ):
+        model = HybridModel(
+            config=config,
+            hybrid_stack_spec=stack_spec,
+            vocab_size=128,
+            max_sequence_length=16,
+            hybrid_layer_pattern="M/M/M",
+            pg_collection=pg_collection,
+        )
+
+    assert model.mtp_pattern == "M"
+    assert model.mtp_num_depths == 2
+    assert mtp_block.call_args.kwargs["mtp_layer_pattern"] == "M"
+    assert "mtp_layer_specs" not in mtp_block.call_args.kwargs
+    assert "moe_metric_num_layers" not in mtp_block.call_args.kwargs

--- a/tests/unit_tests/models/hybrid/test_hybrid_stack_direct_specs.py
+++ b/tests/unit_tests/models/hybrid/test_hybrid_stack_direct_specs.py
@@ -1,0 +1,208 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Allocation-free tests for direct layer descriptors at the HybridStack boundary."""
+
+from copy import deepcopy
+from types import SimpleNamespace
+
+from torch import nn
+
+import megatron.core.models.hybrid.hybrid_block as hybrid_block_module
+from megatron.core.models.hybrid.hybrid_architecture import HybridLayerSpec
+from megatron.core.models.hybrid.hybrid_block import HybridStack
+from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_stack_spec
+from megatron.core.transformer import TransformerConfig
+
+
+class _BuiltLayer(nn.Module):
+    """Parameter-free layer returned by the patched module builder."""
+
+    def __init__(self, layer_number: int):
+        super().__init__()
+        self.layer_number = layer_number
+
+    def mamba_state_shapes_per_request(self):
+        return ("conv", self.layer_number), ("ssm", self.layer_number)
+
+
+def _config(num_layers: int) -> TransformerConfig:
+    return TransformerConfig(
+        num_layers=num_layers,
+        hidden_size=64,
+        num_attention_heads=8,
+        num_query_groups=4,
+        kv_channels=8,
+        ffn_hidden_size=128,
+        num_moe_experts=8,
+        moe_ffn_hidden_size=96,
+        moe_router_topk=2,
+        mamba_state_dim=16,
+        mamba_head_dim=8,
+        mamba_num_heads=8,
+        mamba_num_groups=2,
+        add_bias_linear=False,
+    )
+
+
+def _patch_builder(monkeypatch):
+    calls = []
+
+    def fake_build_module(module_spec, **kwargs):
+        calls.append((module_spec, kwargs))
+        return _BuiltLayer(kwargs["layer_number"])
+
+    monkeypatch.setattr(hybrid_block_module, "build_module", fake_build_module)
+    return calls
+
+
+def _build_stack(config, *, layer_specs=None, layer_type_list=None, pp_layer_offset=0):
+    return HybridStack(
+        config=config,
+        submodules=hybrid_stack_spec.submodules,
+        pre_process=False,
+        layer_specs=layer_specs,
+        layer_type_list=layer_type_list,
+        pp_layer_offset=pp_layer_offset,
+        post_layer_norm=False,
+        post_process=False,
+        pg_collection=SimpleNamespace(pp=None, tp=None),
+        name="decoder",
+    )
+
+
+def test_direct_stack_builds_existing_specs_with_occurrence_configs_and_global_numbers(monkeypatch):
+    calls = _patch_builder(monkeypatch)
+    base_config = _config(3)
+    mamba_config = deepcopy(base_config)
+    attention_config = deepcopy(base_config)
+    moe_config = deepcopy(base_config)
+    mamba_config.mamba_state_dim = 24
+    attention_config.kv_channels = 16
+    moe_config.moe_ffn_hidden_size = 112
+    moe_config.moe_router_topk = 4
+
+    stock_specs = [
+        hybrid_stack_spec.submodules.mamba_layer,
+        hybrid_stack_spec.submodules.attention_layer,
+        hybrid_stack_spec.submodules.moe_layer,
+    ]
+    occurrence_configs = [mamba_config, attention_config, moe_config]
+    layer_specs = [
+        HybridLayerSpec(module_spec=module_spec, config=layer_config)
+        for module_spec, layer_config in zip(stock_specs, occurrence_configs)
+    ]
+
+    stack = _build_stack(base_config, layer_specs=layer_specs, pp_layer_offset=11)
+
+    assert len(calls) == 3
+    assert all(call[0] is expected for call, expected in zip(calls, stock_specs))
+    assert all(call[1]["config"] is expected for call, expected in zip(calls, occurrence_configs))
+    assert [call[1]["layer_number"] for call in calls] == [12, 13, 14]
+    assert [layer.layer_number for layer in stack.layers] == [12, 13, 14]
+    assert [call[1]["name"] for call in calls] == [
+        "decoder.layers.0",
+        "decoder.layers.1",
+        "decoder.layers.2",
+    ]
+
+    assert calls[0][1]["pp_layer_offset"] == 11
+    assert calls[1][1]["pp_layer_offset"] == 11
+    assert "pp_layer_offset" not in calls[2][1]
+    assert calls[1][1]["add_layer_offset"] is False
+    assert calls[2][1]["add_layer_offset"] is False
+
+
+def test_legacy_and_equivalent_direct_stack_build_same_semantic_and_module_order(monkeypatch):
+    calls = _patch_builder(monkeypatch)
+    config = _config(4)
+    submodules = hybrid_stack_spec.submodules
+    direct_specs = [
+        HybridLayerSpec(submodules.mamba_layer, config),
+        HybridLayerSpec(submodules.attention_layer, config),
+        HybridLayerSpec(submodules.moe_layer, config),
+        HybridLayerSpec(submodules.mlp_layer, config),
+    ]
+
+    direct_stack = _build_stack(config, layer_specs=direct_specs, pp_layer_offset=3)
+    direct_calls = list(calls)
+    calls.clear()
+    legacy_stack = _build_stack(config, layer_type_list=["M", "*", "E", "-"], pp_layer_offset=3)
+
+    expected_types = ["mamba", "attention", "moe", "mlp"]
+    assert direct_stack.layer_type_list == expected_types
+    assert legacy_stack.layer_type_list == ["M", "*", "E", "-"]
+    assert not hasattr(legacy_stack, "layer_specs")
+    assert [call[0].module for call in direct_calls] == [call[0].module for call in calls]
+    assert [call[1]["layer_number"] for call in direct_calls] == [4, 5, 6, 7]
+    assert [call[1]["layer_number"] for call in calls] == [4, 5, 6, 7]
+    assert all(call[1]["config"] is config for call in calls)
+    assert legacy_stack.mamba_state_shapes_per_request() == (("conv", 4), ("ssm", 4))
+
+
+def test_legacy_stack_preserves_exact_family_specific_builder_kwargs(monkeypatch):
+    calls = _patch_builder(monkeypatch)
+    config = _config(7)
+    symbols = ["M", "*", "D", "+", "-", "E", "G"]
+
+    stack = _build_stack(config, layer_type_list=symbols, pp_layer_offset=4)
+
+    common = {"config", "layer_number", "pg_collection"}
+    expected_keys = [
+        common | {"pp_layer_offset", "name"},
+        common | {"is_mtp_layer", "add_layer_offset", "pp_layer_offset", "name"},
+        common | {"is_mtp_layer", "add_layer_offset", "pp_layer_offset", "name"},
+        common | {"is_mtp_layer", "add_layer_offset", "pp_layer_offset"},
+        common | {"add_layer_offset", "name"},
+        common | {"add_layer_offset", "name"},
+        common | {"add_layer_offset", "name"},
+    ]
+
+    assert stack.layer_type_list is symbols
+    assert [set(kwargs) for _, kwargs in calls] == expected_keys
+    assert all(kwargs["config"] is config for _, kwargs in calls)
+    assert "name" not in calls[3][1]
+
+
+def test_legacy_stack_still_accepts_a_layer_class(monkeypatch):
+    calls = _patch_builder(monkeypatch)
+    config = _config(1)
+    submodules = deepcopy(hybrid_stack_spec.submodules)
+    submodules.mamba_layer = _BuiltLayer
+
+    stack = HybridStack(
+        config=config,
+        submodules=submodules,
+        layer_type_list=["M"],
+        post_layer_norm=False,
+        post_process=False,
+        pg_collection=SimpleNamespace(pp=None, tp=None),
+    )
+
+    assert stack.layer_type_list == ["M"]
+    assert calls[0][0] is _BuiltLayer
+    assert not hasattr(stack, "layer_specs")
+
+
+def test_new_layer_specs_parameter_does_not_shift_legacy_positional_arguments(monkeypatch):
+    calls = _patch_builder(monkeypatch)
+    config = _config(1)
+    pg_collection = SimpleNamespace(pp=None, tp=None)
+
+    stack = HybridStack(
+        config,
+        hybrid_stack_spec.submodules,
+        False,
+        ["M"],
+        9,
+        False,
+        False,
+        None,
+        None,
+        pg_collection,
+        False,
+        "decoder",
+    )
+
+    assert stack.layer_type_list == ["M"]
+    assert calls[0][1]["layer_number"] == 10
+    assert calls[0][1]["name"] == "decoder.layers.0"

--- a/tests/unit_tests/models/hybrid/test_nemotron3_recipes.py
+++ b/tests/unit_tests/models/hybrid/test_nemotron3_recipes.py
@@ -1,0 +1,223 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Structural tests for the architecture-only Nemotron 3 examples."""
+
+from itertools import chain
+
+from examples.nemotron3.nemotron_3_5_nano_30b_a3b import make_model_config as make_nano_model_config
+from examples.nemotron3.nemotron_labs_3_puzzle_75b_a9b import (
+    make_model_config as make_puzzle_model_config,
+)
+from megatron.core.models.hybrid.hybrid_architecture import (
+    flatten_hybrid_layer_pattern,
+    resolve_hybrid_architecture,
+)
+from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_stack_spec
+
+NANO_PATTERN = "MEMEM*EMEMEM*EMEMEM*EMEMEM*EMEMEM*EMEMEMEM*EMEMEMEME"
+PUZZLE_PATTERN = (
+    "MEMEMEM*EMEMEMEM*EMEMEMEM*EMEMEMEMEM*EMEMEMEMEM*" "EMEMEMEMEM*EMEMEMEMEM*EMEMEMEM*EMEMEMEME"
+)
+PUZZLE_MOE_CONFIGS = [
+    (1280, 4),
+    (1280, 8),
+    (1280, 10),
+    (1280, 8),
+    (1280, 8),
+    (1280, 8),
+    (1280, 12),
+    (1280, 8),
+    (1280, 10),
+    (1280, 8),
+    (2688, 12),
+    (1536, 14),
+    (2688, 12),
+    (1536, 12),
+    (1536, 12),
+    (2688, 12),
+    (2688, 12),
+    (2688, 12),
+    (1536, 10),
+    (2688, 12),
+    (2688, 12),
+    (1792, 12),
+    (1792, 14),
+    (1280, 10),
+    (1280, 10),
+    (1280, 12),
+    (1280, 8),
+    (1280, 12),
+    (1280, 10),
+    (1280, 8),
+    (1280, 8),
+    (1280, 10),
+    (1280, 10),
+    (1280, 10),
+    (1280, 12),
+    (1280, 12),
+    (1280, 14),
+    (1280, 16),
+    (1792, 18),
+    (2048, 18),
+]
+
+
+def _segments_and_layers(pattern):
+    segments = flatten_hybrid_layer_pattern(pattern)
+    return segments, tuple(chain.from_iterable(segments))
+
+
+def _layer_symbols(layers) -> str:
+    symbols = {"mamba": "M", "attention": "*", "moe": "E"}
+    return "".join(symbols[layer.module_spec.metainfo["hybrid_layer_type"]] for layer in layers)
+
+
+def _layers_of_type(layers, layer_type: str):
+    return [
+        layer for layer in layers if layer.module_spec.metainfo["hybrid_layer_type"] == layer_type
+    ]
+
+
+def _assert_transformer_values(config, expected):
+    assert {name: getattr(config.transformer, name) for name in expected} == expected
+
+
+def _resolve(config):
+    return resolve_hybrid_architecture(
+        config=config.transformer,
+        hybrid_stack_spec=hybrid_stack_spec,
+        layer_specs=config.layer_specs,
+        mtp_layer_specs=config.mtp_layer_specs,
+    )
+
+
+def test_nano_direct_architecture_matches_published_order_and_pp_vpp_split():
+    config = make_nano_model_config()
+    segments, layers = _segments_and_layers(config.layer_specs)
+
+    assert [len(segment) for segment in segments] == [13, 13, 13, 13]
+    assert [sum(map(len, segments[:index])) for index in range(4)] == [0, 13, 26, 39]
+    assert _layer_symbols(layers) == NANO_PATTERN
+    assert len(_layers_of_type(layers, "mamba")) == 23
+    assert len(_layers_of_type(layers, "moe")) == 23
+    assert [index for index, symbol in enumerate(_layer_symbols(layers)) if symbol == "*"] == [
+        5,
+        12,
+        19,
+        26,
+        33,
+        42,
+    ]
+
+    assert config.hybrid_layer_pattern is None
+    assert config.vocab_size == 131072
+    assert config.seq_length == 262144
+    assert config.transformer.virtual_pipeline_model_parallel_size is None
+    _assert_transformer_values(
+        config,
+        {
+            "pipeline_model_parallel_size": 2,
+            "num_layers": 52,
+            "hidden_size": 2688,
+            "num_attention_heads": 32,
+            "num_query_groups": 2,
+            "kv_channels": 128,
+            "ffn_hidden_size": 1856,
+            "mamba_state_dim": 128,
+            "mamba_head_dim": 64,
+            "mamba_num_heads": 64,
+            "mamba_num_groups": 8,
+            "num_moe_experts": 128,
+            "moe_ffn_hidden_size": 1856,
+            "moe_router_topk": 6,
+            "moe_router_num_groups": 1,
+            "moe_router_group_topk": 1,
+            "moe_shared_expert_intermediate_size": 3712,
+        },
+    )
+
+    architecture = _resolve(config)
+    assert [len(segment) for segment in architecture.segments] == [13, 13, 13, 13]
+    assert config.transformer.virtual_pipeline_model_parallel_size == 2
+
+
+def test_nano_reuses_uniform_family_configs_and_defines_repeated_mtp():
+    config = make_nano_model_config()
+    _, layers = _segments_and_layers(config.layer_specs)
+
+    for layer_type in ("mamba", "attention", "moe"):
+        family = _layers_of_type(layers, layer_type)
+        assert len({id(layer.config) for layer in family}) == 1
+
+    moe_configs = _layers_of_type(layers, "moe")
+    assert {
+        (layer.config.moe_ffn_hidden_size, layer.config.moe_router_topk) for layer in moe_configs
+    } == {(1856, 6)}
+
+    mtp_segments, mtp_layers = _segments_and_layers(config.mtp_layer_specs)
+    assert [len(segment) for segment in mtp_segments] == [2]
+    assert _layer_symbols(mtp_layers) == "*E"
+    assert config.transformer.mtp_num_layers == 2
+    assert config.transformer.mtp_use_repeated_layer is True
+
+
+def test_puzzle_direct_architecture_matches_published_order_and_pp_vpp_split():
+    config = make_puzzle_model_config()
+    segments, layers = _segments_and_layers(config.layer_specs)
+
+    assert [len(segment) for segment in segments] == [22, 22, 22, 22]
+    assert [sum(map(len, segments[:index])) for index in range(4)] == [0, 22, 44, 66]
+    assert _layer_symbols(layers) == PUZZLE_PATTERN
+    assert len(_layers_of_type(layers, "mamba")) == 40
+    assert len(_layers_of_type(layers, "moe")) == 40
+    assert len(_layers_of_type(layers, "attention")) == 8
+
+    assert config.hybrid_layer_pattern is None
+    assert config.vocab_size == 131072
+    assert config.seq_length == 262144
+    assert config.transformer.virtual_pipeline_model_parallel_size is None
+    _assert_transformer_values(
+        config,
+        {
+            "pipeline_model_parallel_size": 2,
+            "num_layers": 88,
+            "hidden_size": 4096,
+            "num_attention_heads": 32,
+            "num_query_groups": 2,
+            "kv_channels": 128,
+            "ffn_hidden_size": 21504,
+            "mamba_state_dim": 96,
+            "mamba_head_dim": 64,
+            "mamba_num_heads": 128,
+            "mamba_num_groups": 8,
+            "num_moe_experts": 512,
+            "moe_router_num_groups": 1,
+            "moe_router_group_topk": 1,
+            "moe_shared_expert_intermediate_size": 5376,
+            "moe_latent_size": 1024,
+        },
+    )
+
+    architecture = _resolve(config)
+    assert [len(segment) for segment in architecture.segments] == [22, 22, 22, 22]
+    assert config.transformer.virtual_pipeline_model_parallel_size == 2
+
+
+def test_puzzle_preserves_every_occurrence_specific_moe_config_and_mtp():
+    config = make_puzzle_model_config()
+    _, layers = _segments_and_layers(config.layer_specs)
+    moe_layers = _layers_of_type(layers, "moe")
+
+    assert [
+        (layer.config.moe_ffn_hidden_size, layer.config.moe_router_topk) for layer in moe_layers
+    ] == PUZZLE_MOE_CONFIGS
+    assert len({id(layer.config) for layer in moe_layers}) == 40
+    assert {layer.config.num_moe_experts for layer in moe_layers} == {512}
+
+    mtp_segments, mtp_layers = _segments_and_layers(config.mtp_layer_specs)
+    assert [len(segment) for segment in mtp_segments] == [2]
+    assert _layer_symbols(mtp_layers) == "*E"
+    assert mtp_layers[1].config.moe_ffn_hidden_size == 2688
+    assert mtp_layers[1].config.moe_router_topk == 22
+    assert config.transformer.mtp_num_layers == 1
+    assert config.transformer.mtp_use_repeated_layer is False

--- a/tests/unit_tests/test_num_floating_point_operations.py
+++ b/tests/unit_tests/test_num_floating_point_operations.py
@@ -18,6 +18,7 @@ import pytest
 import torch
 
 import megatron.training.training as training_module
+from megatron.training.hybrid_metrics import get_hybrid_moe_metric_metadata
 from megatron.training.training import (
     consume_seqlen_stats_in_iteration,
     num_floating_point_operations,
@@ -96,6 +97,58 @@ def _make_hybrid_args(*, num_layers=4, hidden_size=512, num_attention_heads=8, s
     args.mamba_head_dim = 64
     args.mamba_num_groups = 8
     args.mamba_num_heads = 128
+    return args
+
+
+def _make_resolved_layer(layer_type, **overrides):
+    config_values = {
+        "hidden_size": 64,
+        "num_attention_heads": 4,
+        "num_query_groups": 2,
+        "kv_channels": 8,
+        "mamba_state_dim": 16,
+        "mamba_head_dim": 8,
+        "mamba_num_groups": 2,
+        "mamba_num_heads": 8,
+        "ffn_hidden_size": 160,
+        "gated_linear_unit": True,
+        "moe_ffn_hidden_size": 96,
+        "moe_shared_expert_intermediate_size": 32,
+        "moe_router_topk": 2,
+        "moe_latent_size": None,
+        "linear_key_head_dim": 16,
+        "linear_value_head_dim": 16,
+        "linear_num_key_heads": 4,
+        "linear_num_value_heads": 4,
+        "linear_conv_kernel_dim": 4,
+    }
+    config_values.update(overrides)
+    return SimpleNamespace(layer_type=layer_type, config=SimpleNamespace(**config_values))
+
+
+def _make_resolved_hybrid_args():
+    args = _make_gpt_args(
+        num_layers=4, hidden_size=64, num_attention_heads=4, seq_length=16, padded_vocab_size=100
+    )
+    # Direct metrics take MTP depth from the resolved architecture, not from
+    # legacy command-line state.
+    args.mtp_num_layers = None
+    args.resolved_hybrid_architecture = SimpleNamespace(
+        source="direct",
+        mtp_num_layers=2,
+        main_layers=(
+            _make_resolved_layer("attention"),
+            _make_resolved_layer("mamba"),
+            _make_resolved_layer("mlp"),
+            _make_resolved_layer("moe"),
+        ),
+        mtp_layers=(
+            _make_resolved_layer(
+                "attention", num_attention_heads=8, num_query_groups=1, kv_channels=4
+            ),
+            _make_resolved_layer("moe", moe_ffn_hidden_size=224, moe_router_topk=3),
+        ),
+    )
     return args
 
 
@@ -253,6 +306,131 @@ class TestHybridTHDScaling:
         expected_delta_per_layer_per_unit_sum = 2 * kv * n * 3  # *3 for fwd+bwd
         expected_delta = num_attn_layers * expected_delta_per_layer_per_unit_sum * bshd_sum
         assert flops_doubled - flops_bshd == expected_delta
+
+
+class TestResolvedHybridMetrics:
+    """Direct hybrid metrics use every occurrence's resolved configuration."""
+
+    def test_heterogeneous_layer_flops(self):
+        args = _make_resolved_hybrid_args()
+        batch_size = 2
+        total_tokens = batch_size * args.seq_length
+        seqlen_squared_sum = batch_size * args.seq_length**2
+
+        def attention_flops(config):
+            p = config.kv_channels * config.num_attention_heads / config.hidden_size
+            return (
+                4
+                * total_tokens
+                * config.hidden_size
+                * p
+                * (
+                    config.hidden_size
+                    + config.hidden_size * (config.num_query_groups / config.num_attention_heads)
+                )
+                + 2 * seqlen_squared_sum * config.hidden_size * p
+            )
+
+        def mamba_flops(config):
+            # MambaMixer derives d_inner from explicit per-occurrence head geometry.
+            d_in = config.mamba_num_heads * config.mamba_head_dim
+            return (
+                2
+                * total_tokens
+                * config.hidden_size
+                * (
+                    2 * d_in
+                    + 2 * config.mamba_num_groups * config.mamba_state_dim
+                    + config.mamba_num_heads
+                )
+                + 7 * total_tokens * d_in * config.mamba_state_dim
+                + 2 * total_tokens * d_in * config.hidden_size
+            )
+
+        def mlp_flops(config):
+            return 4 * 1.5 * total_tokens * config.hidden_size * config.ffn_hidden_size
+
+        def moe_flops(config):
+            return (
+                4
+                * total_tokens
+                * config.hidden_size
+                * config.moe_ffn_hidden_size
+                * config.moe_router_topk
+                * 1.5
+                + 4
+                * total_tokens
+                * config.hidden_size
+                * config.moe_shared_expert_intermediate_size
+                * 1.5
+            )
+
+        architecture = args.resolved_hybrid_architecture
+        main = architecture.main_layers
+        mtp = architecture.mtp_layers
+        expected_forward = (
+            attention_flops(main[0].config)
+            + mamba_flops(main[1].config)
+            + mlp_flops(main[2].config)
+            + moe_flops(main[3].config)
+            + architecture.mtp_num_layers
+            * (attention_flops(mtp[0].config) + moe_flops(mtp[1].config))
+            + 2
+            * total_tokens
+            * architecture.mtp_num_layers
+            * (3 * args.hidden_size + 2 * args.hidden_size**2)
+            + 2
+            * total_tokens
+            * args.hidden_size
+            * args.padded_vocab_size
+            * (1 + architecture.mtp_num_layers)
+        )
+
+        actual = num_floating_point_operations(args, batch_size)
+
+        assert actual == pytest.approx(expected_forward * 3)
+
+    def test_moe_metadata_uses_expanded_metric_slots(self):
+        args = _make_resolved_hybrid_args()
+
+        metadata = get_hybrid_moe_metric_metadata(args.resolved_hybrid_architecture)
+
+        assert metadata.num_layers == 8
+        assert metadata.moe_layer_freq == [0, 0, 0, 1, 0, 1, 0, 1]
+        assert metadata.mtp_num_layers == 0
+        assert metadata.num_moe_layers == 3
+
+
+class TestLegacyHybridMetricsCompatibility:
+    """Legacy string patterns retain their historical args-based metric formulas."""
+
+    def test_legacy_mamba_flops_keep_model_global_d_in(self):
+        args = _make_hybrid_args(num_layers=1)
+        args.hybrid_layer_pattern = "M"
+        batch_size = 2
+        total_tokens = batch_size * args.seq_length
+        d_in = 2 * args.hidden_size
+        expected_forward = (
+            2
+            * total_tokens
+            * args.hidden_size
+            * (2 * d_in + 2 * args.mamba_num_groups * args.mamba_state_dim + args.mamba_num_heads)
+            + 7 * total_tokens * d_in * args.mamba_state_dim
+            + 2 * total_tokens * d_in * args.hidden_size
+            + 2 * total_tokens * args.hidden_size * args.padded_vocab_size
+        )
+
+        assert num_floating_point_operations(args, batch_size) == expected_forward * 3
+
+    def test_legacy_resolved_summary_does_not_select_direct_metric_path(self):
+        args = _make_hybrid_args()
+        batch_size = 2
+        expected = num_floating_point_operations(args, batch_size)
+        args.resolved_hybrid_architecture = SimpleNamespace(
+            source="legacy", main_layers=(), mtp_layers=(), mtp_num_layers=0
+        )
+
+        assert num_floating_point_operations(args, batch_size) == expected
 
 
 class TestPaddingRemoval:

--- a/tests/unit_tests/training/models/test_hybrid_builder.py
+++ b/tests/unit_tests/training/models/test_hybrid_builder.py
@@ -1,11 +1,13 @@
 # Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 
+from types import SimpleNamespace
 from unittest.mock import Mock, call, patch
 
 import pytest
 
 from megatron.core.transformer import ModuleSpec
 from megatron.core.transformer.transformer_config import TransformerConfig
+from megatron.training.models.base import ModelConfig
 from megatron.training.models.hybrid import HybridModelBuilder, HybridModelConfig
 
 # ---------------------------------------------------------------------------
@@ -73,6 +75,14 @@ class TestHybridModelConfigInitialization:
     def test_hybrid_stack_spec_default_is_none(self):
         config = _make_hybrid_config()
         assert config.hybrid_stack_spec is None
+
+    def test_legacy_as_dict_matches_the_historical_field_set(self):
+        config = _make_hybrid_config(hybrid_layer_pattern="M*")
+        historical = ModelConfig.as_dict(config)
+        historical.pop("layer_specs")
+        historical.pop("mtp_layer_specs")
+
+        assert config.as_dict() == historical
 
 
 class TestHybridModelConfigGetAttr:
@@ -175,6 +185,39 @@ class TestHybridModelBuilderInit:
 
     def test_stores_model_config(self):
         assert self.builder._model_config is self.config
+
+    def test_legacy_pattern_is_not_pre_resolved_or_allowed_to_mutate_topology(self):
+        transformer = _make_transformer(pipeline_model_parallel_size=2)
+        config = _make_hybrid_config(transformer=transformer, hybrid_layer_pattern="M|M|M|M")
+
+        builder = HybridModelBuilder(config)
+
+        assert not hasattr(builder, "_resolved_architecture")
+        assert not hasattr(builder, "_hybrid_stack_spec")
+        assert transformer.virtual_pipeline_model_parallel_size is None
+
+    def test_legacy_builder_init_does_not_select_or_resolve_a_stack(self):
+        config = _make_hybrid_config(hybrid_layer_pattern="M*")
+
+        with (
+            patch.object(HybridModelBuilder, "_get_hybrid_stack_spec") as get_stack_spec,
+            patch("megatron.training.models.hybrid.resolve_hybrid_architecture") as resolve,
+        ):
+            builder = HybridModelBuilder(config)
+
+        assert not hasattr(builder, "_hybrid_stack_spec")
+        assert not hasattr(builder, "_resolved_architecture")
+        get_stack_spec.assert_not_called()
+        resolve.assert_not_called()
+
+    def test_legacy_config_is_ignored_by_direct_distributed_preparation(self):
+        config = _make_hybrid_config(hybrid_layer_pattern="M*")
+        args = SimpleNamespace(virtual_pipeline_model_parallel_size=None)
+
+        prepared = HybridModelBuilder.prepare_config_for_distributed_init(config, args)
+
+        assert prepared is False
+        assert args.virtual_pipeline_model_parallel_size is None
 
 
 class TestHybridModelBuilderBuildModel:
@@ -319,6 +362,24 @@ class TestHybridModelBuilderBuildModel:
         mock_last.assert_called_once_with(self.pg.pp)
         assert mock_model.call_args.kwargs["post_process"] is True
 
+    @patch("megatron.training.models.hybrid.is_vp_last_stage")
+    @patch("megatron.training.models.hybrid.is_vp_first_stage")
+    @patch("megatron.training.models.hybrid.is_pp_last_stage", return_value=True)
+    @patch("megatron.training.models.hybrid.is_pp_first_stage", return_value=False)
+    @patch("megatron.training.models.hybrid.HybridModel")
+    def test_legacy_builder_keeps_pp_only_defaults_when_vp_stage_is_supplied(
+        self, mock_model, _mock_first, _mock_last, mock_vp_first, mock_vp_last
+    ):
+        self.builder.build_model(self.pg, vp_stage=1)
+
+        kwargs = mock_model.call_args.kwargs
+        assert kwargs["vp_stage"] == 1
+        assert kwargs["pre_process"] is False
+        assert kwargs["post_process"] is True
+        assert "resolved_hybrid_architecture" not in kwargs
+        mock_vp_first.assert_not_called()
+        mock_vp_last.assert_not_called()
+
     @patch("megatron.training.models.hybrid.calculate_padded_vocab_size")
     @patch("megatron.training.models.hybrid.is_pp_last_stage", return_value=True)
     @patch("megatron.training.models.hybrid.is_pp_first_stage", return_value=True)
@@ -327,7 +388,7 @@ class TestHybridModelBuilderBuildModel:
         config = _make_hybrid_config(
             vocab_size=32000,
             seq_length=4096,
-            hybrid_layer_pattern="M-A-",
+            hybrid_layer_pattern="M*",
             fp16_lm_cross_entropy=True,
             parallel_output=False,
             share_embeddings_and_output_weights=True,
@@ -343,7 +404,7 @@ class TestHybridModelBuilderBuildModel:
         assert kw["config"] is config.transformer
         assert kw["vocab_size"] == 32000
         assert kw["max_sequence_length"] == 4096
-        assert kw["hybrid_layer_pattern"] == "M-A-"
+        assert kw["hybrid_layer_pattern"] == "M*"
         assert kw["fp16_lm_cross_entropy"] is True
         assert kw["parallel_output"] is False
         assert kw["share_embeddings_and_output_weights"] is True
@@ -353,6 +414,7 @@ class TestHybridModelBuilderBuildModel:
         assert kw["seq_len_interpolation_factor"] is None
         assert kw["pg_collection"] is pg
         assert kw["vp_stage"] is None
+        assert "resolved_hybrid_architecture" not in kw
 
 
 class TestHybridModelBuilderBuildDistributedModels:

--- a/tests/unit_tests/training/models/test_hybrid_direct_builder.py
+++ b/tests/unit_tests/training/models/test_hybrid_direct_builder.py
@@ -1,0 +1,305 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Focused tests for direct HybridModelConfig and PP/VPP builder behavior."""
+
+import sys
+from copy import deepcopy
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+import torch
+
+from megatron.core.models.hybrid.hybrid_architecture import HybridLayerSpec, PipelineSplit
+from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_stack_spec
+from megatron.core.transformer import TransformerConfig
+from megatron.training.argument_utils import core_transformer_config_from_args
+from megatron.training.arguments import parse_args, validate_args
+from megatron.training.checkpointing import generate_state_dict
+from megatron.training.models.hybrid import HybridModelBuilder, HybridModelConfig
+
+
+def _make_transformer() -> TransformerConfig:
+    return TransformerConfig(
+        num_layers=4,
+        hidden_size=128,
+        num_attention_heads=1,
+        pipeline_model_parallel_size=2,
+        pipeline_dtype=torch.float32,
+    )
+
+
+def _make_layer(config: TransformerConfig) -> HybridLayerSpec:
+    return HybridLayerSpec(
+        module_spec=hybrid_stack_spec.submodules.mamba_layer, config=deepcopy(config)
+    )
+
+
+def _make_direct_config() -> HybridModelConfig:
+    transformer = _make_transformer()
+    layer_specs = [
+        [_make_layer(transformer)],
+        PipelineSplit(),
+        [_make_layer(transformer)],
+        PipelineSplit(),
+        [_make_layer(transformer)],
+        PipelineSplit(),
+        [_make_layer(transformer)],
+    ]
+    return HybridModelConfig(transformer=transformer, vocab_size=32000, layer_specs=layer_specs)
+
+
+class TestDirectHybridModelConfig:
+    def test_direct_fields_default_to_none(self):
+        config = HybridModelConfig(transformer=_make_transformer())
+
+        assert config.layer_specs is None
+        assert config.mtp_layer_specs is None
+
+    def test_direct_fields_preserve_python_architecture_objects(self):
+        transformer = _make_transformer()
+        layer_specs = [_make_layer(transformer)]
+        mtp_layer_specs = [_make_layer(transformer)]
+
+        config = HybridModelConfig(
+            transformer=transformer, layer_specs=layer_specs, mtp_layer_specs=mtp_layer_specs
+        )
+
+        assert config.layer_specs is layer_specs
+        assert config.mtp_layer_specs is mtp_layer_specs
+
+    def test_as_dict_excludes_raw_direct_specs(self):
+        transformer = _make_transformer()
+        config = HybridModelConfig(
+            transformer=transformer,
+            vocab_size=32000,
+            layer_specs=[_make_layer(transformer)],
+            mtp_layer_specs=[_make_layer(transformer)],
+        )
+
+        serialized = config.as_dict()
+
+        assert "layer_specs" not in serialized
+        assert "mtp_layer_specs" not in serialized
+        assert serialized["vocab_size"] == 32000
+        assert serialized["transformer"]["num_layers"] == 4
+
+    def test_checkpoint_args_exclude_runtime_resolved_architecture(self):
+        args = SimpleNamespace(
+            resolved_hybrid_architecture=SimpleNamespace(source="direct"),
+            no_save_optim=True,
+            no_save_rng=True,
+        )
+
+        state_dict = generate_state_dict(
+            args, model=[], optimizer=None, opt_param_scheduler=None, rng_state=None
+        )
+
+        assert hasattr(args, "resolved_hybrid_architecture")
+        assert not hasattr(state_dict["args"], "resolved_hybrid_architecture")
+
+    def test_legacy_checkpoint_keeps_the_original_args_object(self):
+        args = SimpleNamespace(
+            hybrid_layer_pattern="M*",
+            resolved_hybrid_architecture=SimpleNamespace(source="legacy"),
+            no_save_optim=True,
+            no_save_rng=True,
+        )
+
+        state_dict = generate_state_dict(
+            args, model=[], optimizer=None, opt_param_scheduler=None, rng_state=None
+        )
+
+        assert state_dict["args"] is args
+        assert state_dict["args"].resolved_hybrid_architecture.source == "legacy"
+
+
+class TestDirectHybridModelBuilder:
+    def test_prepares_inferred_vpp_before_distributed_initialization(self):
+        config = _make_direct_config()
+        args = SimpleNamespace(
+            pipeline_model_parallel_size=2,
+            virtual_pipeline_model_parallel_size=None,
+            overlap_p2p_comm=False,
+            batch_p2p_comm=True,
+            align_param_gather=False,
+            _overlap_p2p_comm_before_direct_vpp=True,
+            _align_param_gather_before_direct_vpp=True,
+        )
+
+        prepared = HybridModelBuilder.prepare_config_for_distributed_init(config, args)
+
+        assert prepared is True
+        assert args.virtual_pipeline_model_parallel_size == 2
+        assert args.overlap_p2p_comm is True
+        assert args.batch_p2p_comm is False
+        assert args.align_param_gather is True
+        assert config.transformer.virtual_pipeline_model_parallel_size == 2
+        assert config.transformer.overlap_p2p_comm is True
+        assert config.transformer.batch_p2p_comm is False
+
+    def test_cli_validation_defers_uneven_direct_pp_vpp_topology(self, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["test_hybrid_direct_builder.py"])
+        monkeypatch.setattr("megatron.training.arguments._print_args", lambda *args: None)
+        args = parse_args()
+        args.world_size = 2
+        args.rank = 0
+        args.pipeline_model_parallel_size = 2
+        args.num_layers = 5
+        args.hidden_size = 128
+        args.num_attention_heads = 4
+        args.max_position_embeddings = 128
+        args.seq_length = 128
+        args.micro_batch_size = 1
+        args.train_iters = 1
+        args.lr = 1.0e-4
+        args.tokenizer_type = "NullTokenizer"
+        args.vocab_size = 1024
+
+        validate_args(args)
+        assert args.virtual_pipeline_model_parallel_size is None
+        assert args.overlap_p2p_comm is False
+        assert args.align_param_gather is False
+
+        transformer = core_transformer_config_from_args(args)
+        layer = _make_layer(transformer)
+        model_config = HybridModelConfig(
+            transformer=transformer,
+            vocab_size=1024,
+            layer_specs=[
+                layer,
+                PipelineSplit(),
+                [],
+                PipelineSplit(),
+                [],
+                PipelineSplit(),
+                [layer] * 4,
+            ],
+        )
+
+        prepared = HybridModelBuilder.prepare_config_for_distributed_init(model_config, args)
+
+        assert prepared is True
+        assert args.virtual_pipeline_model_parallel_size == 2
+        assert args.overlap_p2p_comm is True
+        assert args.align_param_gather is True
+        assert transformer.overlap_p2p_comm is True
+        assert transformer.batch_p2p_comm is False
+
+    def test_cli_validation_does_not_add_direct_vpp_state_to_legacy_patterns(self, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["test_hybrid_direct_builder.py"])
+        monkeypatch.setattr("megatron.training.arguments._print_args", lambda *args: None)
+        args = parse_args()
+        args.world_size = 2
+        args.rank = 0
+        args.pipeline_model_parallel_size = 2
+        args.num_layers = 2
+        args.hidden_size = 128
+        args.num_attention_heads = 4
+        args.max_position_embeddings = 128
+        args.seq_length = 128
+        args.micro_batch_size = 1
+        args.train_iters = 1
+        args.lr = 1.0e-4
+        args.tokenizer_type = "NullTokenizer"
+        args.vocab_size = 1024
+        args.hybrid_layer_pattern = "M*"
+
+        validate_args(args)
+
+        assert not hasattr(args, "_overlap_p2p_comm_before_direct_vpp")
+        assert not hasattr(args, "_align_param_gather_before_direct_vpp")
+
+    @pytest.mark.parametrize(
+        ("runtime_pp_size", "runtime_vp_size", "message"),
+        [
+            pytest.param(1, None, "pipeline_model_parallel_size must match", id="pp"),
+            pytest.param(2, 3, "splits disagree", id="vpp"),
+        ],
+    )
+    def test_pre_init_topology_must_match_runtime(self, runtime_pp_size, runtime_vp_size, message):
+        config = _make_direct_config()
+        args = SimpleNamespace(
+            pipeline_model_parallel_size=runtime_pp_size,
+            virtual_pipeline_model_parallel_size=runtime_vp_size,
+            overlap_p2p_comm=True,
+        )
+
+        with pytest.raises(ValueError, match=message):
+            HybridModelBuilder.prepare_config_for_distributed_init(config, args)
+
+    @patch("megatron.training.models.hybrid.compose_hooks")
+    @patch("megatron.training.models.hybrid.unimodal_build_distributed_models")
+    def test_resolves_before_distributed_construction_and_infers_vpp(
+        self, mock_unimodal, mock_compose
+    ):
+        config = _make_direct_config()
+        assert config.transformer.virtual_pipeline_model_parallel_size is None
+
+        builder = HybridModelBuilder(config)
+        assert config.transformer.virtual_pipeline_model_parallel_size == 2
+        assert [len(segment) for segment in builder._resolved_architecture.segments] == [1, 1, 1, 1]
+
+        observed_vp_sizes = []
+
+        def fake_distributed_builder(*args):
+            observed_vp_sizes.append(args[1].virtual_pipeline_model_parallel_size)
+            return []
+
+        mock_unimodal.side_effect = fake_distributed_builder
+        mock_compose.return_value = Mock(return_value=None)
+
+        builder.build_distributed_models(Mock(), wrap_with_ddp=False)
+
+        assert observed_vp_sizes == [2]
+
+    @pytest.mark.parametrize(
+        ("pp_rank", "vp_stage", "expected_pre", "expected_post"),
+        [(0, 0, True, False), (1, 0, False, False), (0, 1, False, False), (1, 1, False, True)],
+        ids=["first-pp-first-vp", "last-pp-first-vp", "first-pp-last-vp", "last-pp-last-vp"],
+    )
+    @patch("megatron.training.models.hybrid.HybridModel")
+    def test_default_pre_post_process_ownership(
+        self, mock_model, pp_rank, vp_stage, expected_pre, expected_post
+    ):
+        builder = HybridModelBuilder(_make_direct_config())
+        pg_collection = Mock()
+        pg_collection.pp = Mock()
+
+        with (
+            patch("megatron.training.models.hybrid.is_pp_first_stage", return_value=pp_rank == 0),
+            patch("megatron.training.models.hybrid.is_pp_last_stage", return_value=pp_rank == 1),
+        ):
+            builder.build_model(pg_collection, vp_stage=vp_stage)
+
+        kwargs = mock_model.call_args.kwargs
+        assert kwargs["pre_process"] is expected_pre
+        assert kwargs["post_process"] is expected_post
+
+    @patch("megatron.training.models.hybrid.HybridModel")
+    def test_passes_resolved_architecture_to_hybrid_model(self, mock_model):
+        builder = HybridModelBuilder(_make_direct_config())
+        pg_collection = Mock()
+
+        builder.build_model(pg_collection, pre_process=False, post_process=False, vp_stage=1)
+
+        kwargs = mock_model.call_args.kwargs
+        assert builder._resolved_architecture is not None
+        assert kwargs["resolved_hybrid_architecture"] is builder._resolved_architecture
+        assert kwargs["hybrid_layer_pattern"] is None
+        assert kwargs["vp_stage"] == 1
+
+    @patch("megatron.training.models.hybrid.is_pp_first_stage", return_value=True)
+    @patch("megatron.training.models.hybrid.is_pp_last_stage", return_value=False)
+    @patch("megatron.training.models.hybrid.HybridModel")
+    def test_single_chunk_build_defaults_to_first_virtual_stage(
+        self, mock_model, _mock_last_stage, _mock_first_stage
+    ):
+        builder = HybridModelBuilder(_make_direct_config())
+
+        builder.build_model(Mock())
+
+        kwargs = mock_model.call_args.kwargs
+        assert kwargs["vp_stage"] == 0
+        assert kwargs["pre_process"] is True
+        assert kwargs["post_process"] is False

--- a/tests/unit_tests/transformer/test_direct_hybrid_mtp.py
+++ b/tests/unit_tests/transformer/test_direct_hybrid_mtp.py
@@ -1,0 +1,298 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Focused tests for direct hybrid MTP dispatch."""
+
+from contextlib import nullcontext
+from inspect import signature
+from types import SimpleNamespace
+from unittest.mock import Mock, call, patch
+
+import torch
+from torch import nn
+
+from megatron.core.dist_checkpointing.mapping import ShardedTensor
+from megatron.core.transformer.module import MegatronModule
+from megatron.core.transformer.moe.moe_layer import MoELayer
+from megatron.core.transformer.multi_token_prediction import (
+    MultiTokenPredictionBlock,
+    MultiTokenPredictionLayer,
+)
+
+
+def test_direct_mtp_specs_use_the_existing_hybrid_stack_forward_path():
+    """Direct MTP descriptors must not fall through to the GPT tuple-return path."""
+
+    layer = MultiTokenPredictionLayer.__new__(MultiTokenPredictionLayer)
+    torch.nn.Module.__init__(layer)
+    layer.config = SimpleNamespace(sequence_parallel=False, fp8=None, fp4=None)
+    layer.mtp_layer_pattern = None
+    layer.mtp_layer_specs = (object(), object())
+    layer._concat_embeddings = Mock(side_effect=lambda hidden_states, _: hidden_states)
+    layer._postprocess = Mock(side_effect=lambda hidden_states: hidden_states)
+    layer.mtp_model_layer = Mock(
+        side_effect=lambda **kwargs: kwargs["hidden_states"]
+        + torch.ones_like(kwargs["hidden_states"])
+    )
+
+    hidden_states = torch.zeros(2, 1, 4)
+    rotary_pos_emb = {4: torch.ones(2, 1, 1, 4)}
+    output = layer._proj_and_transformer_layer(
+        hidden_states=hidden_states,
+        decoder_input=torch.zeros_like(hidden_states),
+        attention_mask=None,
+        rotary_pos_emb=rotary_pos_emb,
+    )
+
+    assert torch.equal(output, torch.ones_like(hidden_states))
+    assert layer.mtp_model_layer.call_args.kwargs["rotary_pos_emb"] is rotary_pos_emb
+    assert "context" not in layer.mtp_model_layer.call_args.kwargs
+
+
+def test_direct_hybrid_mtp_keeps_native_checkpoint_prefix():
+    layer = MultiTokenPredictionLayer.__new__(MultiTokenPredictionLayer)
+    torch.nn.Module.__init__(layer)
+    layer.mtp_layer_pattern = None
+    layer.mtp_layer_specs = (object(),)
+    sharded_weight = ShardedTensor.from_rank_offsets("mtp.mtp_model_layer.weight", torch.ones(1))
+
+    with patch.object(
+        MegatronModule,
+        "sharded_state_dict",
+        return_value={"mtp.mtp_model_layer.weight": sharded_weight},
+    ):
+        layer.sharded_state_dict(prefix="mtp.")
+
+    assert sharded_weight.key == "mtp.mtp_model_layer.weight"
+
+
+def test_mtp_layer_maps_prediction_depth_to_global_metric_offset():
+    layer = MultiTokenPredictionLayer.__new__(MultiTokenPredictionLayer)
+    torch.nn.Module.__init__(layer)
+    layer.config = SimpleNamespace(num_layers=4)
+    layer.mtp_metric_layer_count = 2
+    layer.mtp_model_layer = Mock()
+
+    layer.set_moe_metric_depth(depth_index=1, num_layers=8)
+
+    layer.mtp_model_layer.set_moe_metric_layer_offset.assert_called_once_with(6, 8)
+
+
+def test_repeated_direct_mtp_builds_one_existing_layer():
+    block = MultiTokenPredictionBlock.__new__(MultiTokenPredictionBlock)
+    torch.nn.Module.__init__(block)
+    block.config = SimpleNamespace(mtp_num_layers=2)
+    block.submodules = SimpleNamespace(layer_specs=[object()])
+    block.mtp_layer_pattern = None
+    block.mtp_layer_specs = (object(), object())
+    block.mtp_num_depths = 2
+    block.hybrid_submodules = object()
+    block.moe_metric_num_layers = 8
+    block.mtp_use_repeated_layer = True
+    block.vp_stage = None
+    block.name = None
+
+    built_layer = nn.Identity()
+    with (
+        patch(
+            "megatron.core.transformer.multi_token_prediction.get_fp8_context",
+            return_value=nullcontext(),
+        ),
+        patch(
+            "megatron.core.transformer.multi_token_prediction.build_module",
+            return_value=built_layer,
+        ) as build_module,
+    ):
+        block._build_layers(pg_collection=object())
+
+    assert list(block.layers) == [built_layer]
+    assert build_module.call_args.kwargs["mtp_layer_specs"] is block.mtp_layer_specs
+
+
+class _RepeatedMtpLayer(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.metric_depths = []
+
+    def set_moe_metric_depth(self, depth_index, num_layers):
+        self.metric_depths.append((depth_index, num_layers))
+
+    def forward(self, **kwargs):
+        return (
+            kwargs["hidden_states"] + 1,
+            kwargs["input_ids"],
+            kwargs["position_ids"],
+            kwargs["padding_mask"],
+        )
+
+
+def test_repeated_mtp_retargets_moe_metric_slots_for_every_depth():
+    block = MultiTokenPredictionBlock.__new__(MultiTokenPredictionBlock)
+    torch.nn.Module.__init__(block)
+    block.config = SimpleNamespace(mtp_num_layers=2, mtp_detach_heads=False)
+    block.vp_stage = None
+    block.mtp_use_repeated_layer = True
+    block.mtp_layer_specs = (object(),)
+    block.moe_metric_num_layers = 8
+    repeated_layer = _RepeatedMtpLayer()
+    block.layers = nn.ModuleList([repeated_layer])
+
+    with patch(
+        "megatron.core.transformer.multi_token_prediction.get_mtp_layer_offset", return_value=0
+    ):
+        output = block(
+            input_ids=torch.zeros(1, 2, dtype=torch.long),
+            position_ids=torch.zeros(1, 2, dtype=torch.long),
+            hidden_states=torch.zeros(2, 1, 4),
+            attention_mask=None,
+        )
+
+    assert repeated_layer.metric_depths == [(0, 8), (1, 8)]
+    assert output.shape == (6, 1, 4)
+
+
+def test_repeated_legacy_mtp_does_not_retarget_moe_metric_slots():
+    block = MultiTokenPredictionBlock.__new__(MultiTokenPredictionBlock)
+    torch.nn.Module.__init__(block)
+    block.config = SimpleNamespace(mtp_num_layers=2, mtp_detach_heads=False)
+    block.vp_stage = None
+    block.mtp_use_repeated_layer = True
+    repeated_layer = _RepeatedMtpLayer()
+    block.layers = nn.ModuleList([repeated_layer])
+
+    with patch(
+        "megatron.core.transformer.multi_token_prediction.get_mtp_layer_offset", return_value=0
+    ):
+        block(
+            input_ids=torch.zeros(1, 2, dtype=torch.long),
+            position_ids=torch.zeros(1, 2, dtype=torch.long),
+            hidden_states=torch.zeros(2, 1, 4),
+            attention_mask=None,
+        )
+
+    assert repeated_layer.metric_depths == []
+    assert not hasattr(block, "mtp_layer_specs")
+    assert not hasattr(block, "moe_metric_num_layers")
+
+
+def test_legacy_hybrid_mtp_builder_does_not_receive_direct_only_kwargs():
+    block = MultiTokenPredictionBlock.__new__(MultiTokenPredictionBlock)
+    torch.nn.Module.__init__(block)
+    block.config = SimpleNamespace(mtp_num_layers=2)
+    block.submodules = SimpleNamespace(layer_specs=[object()])
+    block.mtp_layer_pattern = "ME"
+    block.mtp_num_depths = 2
+    block.hybrid_submodules = object()
+    block.mtp_use_repeated_layer = True
+    block.vp_stage = None
+    block.name = "mtp"
+
+    with (
+        patch(
+            "megatron.core.transformer.multi_token_prediction.get_fp8_context",
+            return_value=nullcontext(),
+        ),
+        patch(
+            "megatron.core.transformer.multi_token_prediction.build_module",
+            return_value=nn.Identity(),
+        ) as build_module,
+    ):
+        block._build_layers(pg_collection=object())
+
+    kwargs = build_module.call_args.kwargs
+    assert kwargs["mtp_layer_pattern"] == "ME"
+    assert "mtp_layer_specs" not in kwargs
+    assert "moe_metric_num_layers" not in kwargs
+    assert not hasattr(block, "mtp_layer_specs")
+    assert not hasattr(block, "moe_metric_num_layers")
+
+
+def test_direct_mtp_parameters_do_not_shift_legacy_positional_signatures():
+    layer_parameters = signature(MultiTokenPredictionLayer.__init__).parameters
+    block_parameters = signature(MultiTokenPredictionBlock.__init__).parameters
+
+    assert list(layer_parameters).index("mtp_layer_specs") > list(layer_parameters).index("name")
+    assert list(layer_parameters).index("moe_metric_num_layers") > list(layer_parameters).index(
+        "name"
+    )
+    assert list(block_parameters).index("mtp_layer_specs") > list(block_parameters).index("name")
+    assert list(block_parameters).index("moe_metric_num_layers") > list(block_parameters).index(
+        "name"
+    )
+
+
+def test_repeated_mtp_restores_metric_depth_inside_recompute_closure():
+    layer = MultiTokenPredictionLayer.__new__(MultiTokenPredictionLayer)
+    torch.nn.Module.__init__(layer)
+    layer.config = SimpleNamespace(
+        num_layers=4,
+        fp8=False,
+        fp4=False,
+        distribute_saved_activations=False,
+        recompute_method="uniform",
+        recompute_num_layers=1,
+    )
+    layer.mtp_metric_layer_count = 2
+    layer.mtp_model_layer = Mock()
+    layer._proj_and_transformer_layer = Mock(side_effect=lambda **kwargs: kwargs["hidden_states"])
+    closures = []
+
+    def checkpoint(function, distribute_saved_activations, *args):
+        closures.append((function, args))
+        return function(*args)
+
+    hidden_states = torch.zeros(2, 1, 4, requires_grad=True)
+    decoder_input = torch.zeros_like(hidden_states)
+    with patch(
+        "megatron.core.transformer.multi_token_prediction.tensor_parallel.checkpoint",
+        side_effect=checkpoint,
+    ):
+        for depth_index in range(2):
+            layer.set_moe_metric_depth(depth_index, num_layers=8)
+            layer._checkpointed_forward(hidden_states, decoder_input)
+
+    # Both checkpoint closures recompute after the outer loop has left the
+    # shared router targeted at depth 1. Each closure must restore its own slot.
+    layer.mtp_model_layer.reset_mock()
+    for function, args in closures:
+        function(*args)
+
+    assert layer.mtp_model_layer.set_moe_metric_layer_offset.call_args_list == [
+        call(4, 8),
+        call(6, 8),
+    ]
+
+
+def test_selective_moe_recompute_restores_direct_mtp_metric_slot():
+    layer = MoELayer.__new__(MoELayer)
+    torch.nn.Module.__init__(layer)
+    layer.training = True
+    layer.config = SimpleNamespace(sequence_parallel=True, fp8=False, fp4=False)
+    layer.attn_tp_group = SimpleNamespace(size=lambda: 1)
+    layer.moe_layer_recompute = True
+    layer.fwd_execution_map = {"route", "expert_compute", "postprocess"}
+    layer.router = Mock(metric_layer_number=5, metric_num_layers=8)
+    layer.shared_experts_compute = Mock(return_value=None)
+    layer.route = Mock(return_value=(torch.ones(1), torch.ones(1)))
+    layer.preprocess = Mock(side_effect=lambda hidden, probs, _routing: (hidden, probs))
+    layer.dispatch = Mock(side_effect=lambda hidden, probs: (hidden, probs))
+    layer.routed_experts_compute = Mock(side_effect=lambda hidden, _probs: (hidden, None))
+    layer.combine = Mock(side_effect=lambda output: output)
+    layer.postprocess = Mock(side_effect=lambda output, _shared: output)
+    closures = []
+
+    def checkpoint(function, _distribute_saved_activations, *args):
+        closures.append((function, args))
+        return function(*args)
+
+    hidden_states = torch.zeros(2, 1, 4, requires_grad=True)
+    with patch(
+        "megatron.core.transformer.moe.moe_layer.tensor_parallel.checkpoint", side_effect=checkpoint
+    ):
+        layer(hidden_states)
+
+    layer.router.metric_layer_number = 9
+    layer.router.set_metric_layer_number.reset_mock()
+    function, args = closures[0]
+    function(*args)
+
+    layer.router.set_metric_layer_number.assert_called_once_with(5, 8)


### PR DESCRIPTION
> [!WARNING]
> **DO NOT MERGE.** This draft is an end-to-end reference implementation and validation vehicle. It intentionally contains the complete implementation and test vertical slice in one PR so the architecture can be exercised with production model definitions. Mergeable changes have been extracted into smaller, reviewable draft PRs; this branch remains the combined validation system.

## Purpose

This PR implements a first-class Python architecture definition for hybrid models without introducing replacement layer-family classes. Each layer occurrence uses an existing `MambaLayer`, `TransformerLayer`, `MLPLayer`, or `MoETransformerLayer` `ModuleSpec`, paired with its own `TransformerConfig`.

The main objective is to support genuinely heterogeneous layer occurrences—including PP/VPP and MTP—while retaining compatibility with the legacy `hybrid_layer_pattern` path. Legacy patterns remain on their original parser, selector, and builder execution path; direct layer specs are the intended long-term API.

Related context:

- [Hybrid-layer design document](https://docs.google.com/document/d/1MS706YygrZiu-7HBaoOgV7muM20as-34VUWqfS16Iu0/edit?tab=t.0)
- Earlier exploration: #4537 and its follow-up PRs

## End-to-end implementation

### Architecture API and resolver

- Adds `HybridLayerSpec(module_spec, config)` for an existing layer spec plus an occurrence-specific configuration.
- Adds a stateless `PipelineSplit()` sentinel and recursive patterns supporting nesting, aliases, and list multiplication.
- Adds `HybridModelConfig.layer_specs` and `mtp_layer_specs`.
- Resolves direct definitions into one global `ResolvedHybridArchitecture`; legacy runtime construction does not invoke it.
- Provides a read-only legacy summary adapter for comparison without changing runtime construction or topology.
- Tags stock hybrid `ModuleSpec`s with stable semantic layer types: `mamba`, `attention`, `mlp`, and `moe`.
- Validates model-wide invariants while allowing supported per-layer Mamba, attention, dense-MLP, and MoE shape differences.

### PP/VPP execution

- Explicit split nodes define logical model chunks in VPP-major, then PP-rank order.
- Infers VPP from the number of chunks and the configured PP size, and validates an explicitly configured VPP size.
- Supports uneven and empty chunks while preserving global one-based layer numbers.
- Selects the local chunk through the supplied `ProcessGroupCollection` and `vp_stage`, without adding new global process-group reads.
- Places embeddings only on `(pp=0, vp=0)` and logits/loss only on the final logical chunk.
- Preserves global distributed-checkpoint keys through prefix-sum layer offsets so equivalent PP/VPP layouts retain the same global layer identity.
- Caches/selects RoPE inputs by attention configuration so differing KV dimensions do not share an incompatible global tensor.

### MTP

- Threads direct `mtp_layer_specs` through the existing MTP block.
- Treats the MTP pattern as one prediction-depth template and repeats it according to `mtp_num_layers`.
- Places MTP on the final logical PP/VPP chunk.
- Preserves repeated-layer behavior, native checkpoint prefixes, and per-depth MoE metric slots.
- Rejects split or standalone MTP placement in this prototype.

### Training, metrics, and inference

- Makes the training builder resolve direct architectures before distributed initialization so PP/VPP topology is available in time.
- Excludes raw Python `ModuleSpec` trees and runtime resolver objects from checkpoint argument serialization.
- Computes FLOPs and MoE/MTP metadata from the resolved per-occurrence architecture rather than `args.hybrid_layer_pattern`.
- Keeps legacy construction, configuration identity, metrics, inference behavior, checkpoint serialization, and module/checkpoint keys on their existing paths.
- Keeps direct checkpoint and module-key compatibility with equivalent legacy definitions when global layer order is unchanged.
- Explicitly rejects dynamic inference when direct occurrence configs require unsupported cache or buffer dimensions instead of silently using a model-global or first-layer value.

## Reference architectures

| Model | Decoder architecture | PP/VPP example | MTP |
|---|---|---|---|
| Nemotron 3.5 Nano 30B-A3B | 52 layers: 23 Mamba, 23 MoE, and 6 attention layers at zero-based indices `[5, 12, 19, 26, 33, 42]`. Family configs are uniform; Nano is not itself per-layer heterogeneous. | PP2/VPP2 with four 13-layer chunks | Attention + MoE template, two prediction depths with repeated-layer behavior |
| Nemotron Labs 3 Puzzle 75B-A9B | 88 layers: 40 Mamba, 40 MoE, and 8 attention layers. Preserves all 40 occurrence-specific `(moe_ffn_hidden_size, moe_router_topk)` pairs with 512 routed experts. | PP2/VPP2 with four 22-layer chunks | Attention + MoE template using FFN size 2688 and top-k 22, one prediction depth |

The examples are architecture-only: they do not invent optimizer, dataset, tokenizer, or golden-value settings, and unit tests do not allocate the complete 30B/75B models.

Numerical sources of truth:

- [NVIDIA Nemotron 3 Nano checkpoint config](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16/raw/main/config.json)
- [NVIDIA Nemotron Labs 3 Puzzle checkpoint config](https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Puzzle-75B-A9B-BF16/raw/main/config.json)

## Validation coverage

The PR includes focused coverage for:

- Recursive resolution, aliases, split preservation, invalid combinations, semantic tags, and occurrence-config isolation.
- PP2/VPP2 ordering, offsets, empty chunks, global numbering, and pre/post ownership.
- Existing-layer construction and equivalent legacy/direct module ordering.
- Global checkpoint keys across PP/VPP splits.
- Direct and repeated MTP behavior, including recompute-time MoE metric depth.
- Exact Nano/Puzzle layer orders, split locations, MTP definitions, and all Puzzle MoE overrides.
- Architecture-aware FLOPs and MoE accounting.
- Strict legacy characterization covering resolver bypass, config and symbol identity, builder kwargs and signatures, pre/post ownership, MTP, metrics, inference, and module/checkpoint keys.
- Dynamic-inference rejection for incompatible direct runtime shapes, with legacy inference bypassing direct-only validation.

The earlier end-to-end prototype completed a focused local run with **161 passed and 12 skipped**; skipped cases require CUDA or multiple ranks. The refreshed monolithic head matches the extracted implementation and test union while intentionally excluding Markdown documentation changes; those remain in #6300. It has passed its available static and formatting checks. A fresh GPU-backed focused run is still pending.

The earlier prototype head also completed GB200 end-to-end training smoke tests with random initialization and mock data:

- [x] Nemotron 3.5 Nano 30B-A3B on 2 GB200 nodes (8 GPUs), TP1/PP2/EP4/DP4, for 2 training iterations.
- [x] Nemotron Labs 3 Puzzle 75B-A9B on 4 GB200 nodes (16 GPUs), TP1/PP2/EP8/DP8, for 2 training iterations.

These model jobs should be rerun against the refreshed legacy-isolated head before treating them as current validation.

Still pending before the extracted stack is merge-ready:

- [ ] Real distributed PP2/VPP2 forward/backward validation
- [ ] Distributed-checkpoint save/load and reshard validation across PP1, PP2, and PP2/VPP2
- [ ] Production-scale memory and throughput characterization

## Known limitations and non-goals

- This PR is not intended to merge in its current all-in-one form.
- Markdown documentation changes are intentionally excluded from this PR and remain in #6300.
- The Python architecture definition remains required on resume; raw `ModuleSpec` trees are not serialized and there is no architecture manifest.
- Dynamic inference for heterogeneous cache/buffer dimensions is rejected; training is the supported heterogeneous path in this prototype.
- The companion Megatron-Bridge dotted `architecture_factory` integration is not included in this repository.
- This does not add a CLI architecture loader or an immediate warning for `--hybrid-layer-pattern`.

## Intended next step

Use this draft as the stable end-to-end system for model validation and as the reference diff for the CODEOWNERS-aligned draft stack below. The extracted implementation preserves the demonstrated behavior while separating the resolver API, core PP/VPP runtime, MTP support, training/metrics integration, inference guard, and reference examples.

## Extracted draft stack

| PR | Scope | Base |
|---|---|---|
| [#6295](https://github.com/NVIDIA/Megatron-LM/pull/6295) | Architecture descriptors and resolver | `main` |
| [#6297](https://github.com/NVIDIA/Megatron-LM/pull/6297) | PP/VPP runtime | #6295 |
| [#6298](https://github.com/NVIDIA/Megatron-LM/pull/6298) | Direct MTP | #6297 |
| [#6299](https://github.com/NVIDIA/Megatron-LM/pull/6299) | Training and metrics | #6298 |
| [#6301](https://github.com/NVIDIA/Megatron-LM/pull/6301) | Dynamic-inference guard | #6297 |
| [#6300](https://github.com/NVIDIA/Megatron-LM/pull/6300) | Nemotron examples and migration docs | #6299 |

All extracted PRs are drafts. This PR remains the end-to-end validation vehicle and is not intended to merge.

### Legacy compatibility in this PR and the extracted stack

The refreshed monolithic PR and extracted PRs keep legacy HybridModels on their original execution path. Legacy construction does not invoke the direct resolver and retains the existing string parser, PP/VPP selector, shared config identity, symbol-valued layer lists, family-specific builder kwargs, pre/post defaults, MTP behavior, RoPE, metrics, inference behavior, and module/checkpoint keys. Direct-only architecture and topology state is created only when direct specs are supplied. Focused characterization tests cover this boundary.

