### PR TITLE
fix: reset loss logging after checkpoint resume

### DIFF
--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1967,13 +1967,18 @@ def training_log(
     one_logger = get_one_logger()
     energy_monitor = get_energy_monitor()
 
-    # On first iteration, log stats but don't reset accumulators so normal interval stats remain accurate.
-    should_reset = not is_first_iteration
+    # Preserve first-iteration timer accumulation for the next normal logging interval.
+    # Loss stats are preserved only for a fresh run; resumed runs start with an empty
+    # total_loss_dict, so keeping the first resumed loss would count it twice.
+    should_reset_timers = not is_first_iteration
+    should_reset_loss_stats = should_reset_timers or args.iteration > 0
 
     # Advanced, skipped, and Nan iterations.
     advanced_iters_key = 'advanced iterations'
     skipped_iters_key = 'skipped iterations'
     nan_iters_key = 'nan iterations'
+    timer_iters_key = 'timer iterations'
+    total_loss_dict[timer_iters_key] = total_loss_dict.get(timer_iters_key, 0) + 1
     # Advanced iterations.
     if not skipped_iter:
         total_loss_dict[advanced_iters_key] = total_loss_dict.get(advanced_iters_key, 0) + 1
@@ -2039,6 +2044,7 @@ def training_log(
     one_logger_utils.track_app_tag(batch_size, args.world_size, args.seq_length)
 
     total_iterations = total_loss_dict[advanced_iters_key] + total_loss_dict[skipped_iters_key]
+    timer_iterations = total_loss_dict[timer_iters_key]
 
     # learning rate will be None on ranks without trainable params, so we must gather across mp ranks
     learning_rate: float | None = reduce_max_stat_across_model_parallel_group(learning_rate)
@@ -2185,8 +2191,8 @@ def training_log(
             with open(args.memory_snapshot_path, 'wb') as f:
                 dump(snapshot, f)
 
-        elapsed_time = timers('interval-time').elapsed(barrier=True, reset=should_reset)
-        elapsed_time_per_iteration = elapsed_time / total_iterations
+        elapsed_time = timers('interval-time').elapsed(barrier=True, reset=should_reset_timers)
+        elapsed_time_per_iteration = elapsed_time / timer_iterations
 
         throughput = num_floating_point_operations(args, batch_size) / (
             elapsed_time_per_iteration * 10**12 * args.world_size
@@ -2235,13 +2241,13 @@ def training_log(
             log_string += f' learning rate: {learning_rate:.6E} |'
         log_string += f' global batch size: {batch_size:5d} |'
         for key in total_loss_dict:
-            if key not in [advanced_iters_key, skipped_iters_key, nan_iters_key]:
+            if key not in [advanced_iters_key, skipped_iters_key, nan_iters_key, timer_iters_key]:
                 avg = total_loss_dict[key].item() / float(
                     max(1, total_loss_dict[advanced_iters_key])
                 )
                 if avg >= 0.0:
                     log_string += ' {}: {:.6E} |'.format(key, avg)
-                if should_reset:
+                if should_reset_loss_stats:
                     total_loss_dict[key] = torch.tensor([0.0], dtype=torch.float, device='cuda')
         log_string += f' loss scale: {loss_scale:.1f} |'
         if grad_norm is not None:
@@ -2254,10 +2260,12 @@ def training_log(
             total_loss_dict[skipped_iters_key]
         )
         log_string += ' number of nan iterations: {:3d} |'.format(total_loss_dict[nan_iters_key])
-        if should_reset:
+        if should_reset_loss_stats:
             total_loss_dict[advanced_iters_key] = 0
             total_loss_dict[skipped_iters_key] = 0
             total_loss_dict[nan_iters_key] = 0
+        if should_reset_timers:
+            total_loss_dict[timer_iters_key] = 0
         print_rank_last(log_string)
         reported_memory_in_this_iteration = False
         if report_memory_flag:
@@ -2276,10 +2284,10 @@ def training_log(
             report_memory(f'(after {iteration} iterations)')
         # Write timers to wandb, don't reset the counts.
         if args.log_timers_to_tensorboard:
-            timers.write(timers_to_log, writer, iteration, normalizer=args.log_interval, reset=False)
-            timers.write(timers_to_log, wandb_writer, iteration, normalizer=args.log_interval, reset=False)
+            timers.write(timers_to_log, writer, iteration, normalizer=timer_iterations, reset=False)
+            timers.write(timers_to_log, wandb_writer, iteration, normalizer=timer_iterations, reset=False)
         # Log timers to stdout
-        timers.log(timers_to_log, normalizer=args.log_interval, reset=should_reset)
+        timers.log(timers_to_log, normalizer=timer_iterations, reset=should_reset_timers)
 
     return report_memory_flag
 

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1967,8 +1967,10 @@ def training_log(
     one_logger = get_one_logger()
     energy_monitor = get_energy_monitor()
 
-    # On first iteration, log stats but don't reset accumulators so normal interval stats remain accurate.
-    should_reset = not is_first_iteration
+    # Preserve the first-iteration accumulation only for a fresh training run. A resumed
+    # process starts with an empty total_loss_dict, so keeping the first resumed loss would
+    # average it with the next iteration.
+    should_reset = not is_first_iteration or args.iteration > 0
 
     # Advanced, skipped, and Nan iterations.
     advanced_iters_key = 'advanced iterations'

--- a/tests/unit_tests/test_training.py
+++ b/tests/unit_tests/test_training.py
@@ -3,10 +3,12 @@
 from collections import defaultdict
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import torch
 
 from megatron.core.tokenizers.utils.build_tokenizer import vocab_size_with_padding
+from megatron.training import training as training_module
 from megatron.training.checkpointing import save_grads
 from megatron.training.global_vars import set_args
 from megatron.training.training import build_train_valid_test_data_iterators
@@ -79,6 +81,115 @@ class TestTraining:
                     vocab,
                     mult,
                 )
+
+    def test_first_iteration_loss_and_timer_reset_after_resume(self, monkeypatch):
+        args = create_test_args()
+        vars(args).update(
+            consumed_train_samples=1,
+            data_parallel_size=1,
+            dsa_indexer_loss_coeff=None,
+            log_energy=False,
+            log_memory_interval=None,
+            log_throughput=False,
+            log_timers_to_tensorboard=False,
+            micro_batch_size=1,
+            mtp_num_layers=None,
+            num_experts=None,
+            record_memory_history=False,
+            rl_use_sequence_packing=False,
+            seq_length=1,
+            skipped_train_samples=0,
+            timing_log_level=0,
+            world_size=1,
+        )
+        set_args(args)
+
+        timers = MagicMock()
+        timers('interval-time').elapsed.return_value = 1.0
+        monkeypatch.setattr(training_module, 'get_timers', lambda: timers)
+        monkeypatch.setattr(training_module, 'get_tensorboard_writer', lambda: None)
+        monkeypatch.setattr(training_module, 'get_wandb_writer', lambda: None)
+        monkeypatch.setattr(training_module, 'get_one_logger', lambda: None)
+        monkeypatch.setattr(training_module, 'get_energy_monitor', lambda: None)
+        monkeypatch.setattr(training_module, 'get_num_microbatches', lambda: 1)
+        monkeypatch.setattr(
+            training_module, 'reduce_max_stat_across_model_parallel_group', lambda value: value
+        )
+        monkeypatch.setattr(training_module, 'num_floating_point_operations', lambda *_: 1)
+        log_strings = []
+        monkeypatch.setattr(training_module, 'print_rank_last', log_strings.append)
+        monkeypatch.setattr(training_module.one_logger_utils, 'track_app_tag', lambda *_: None)
+        monkeypatch.setattr(training_module.one_logger_utils, 'track_e2e_metrics', lambda *_: None)
+
+        original_tensor = torch.tensor
+
+        def cpu_tensor(*tensor_args, **tensor_kwargs):
+            tensor_kwargs.pop('device', None)
+            return original_tensor(*tensor_args, **tensor_kwargs)
+
+        monkeypatch.setattr(training_module.torch, 'tensor', cpu_tensor)
+
+        for loaded_iteration, log_interval, expected_loss in (
+            (0, 10, 1.0),
+            (50, 1, 0.0),
+            (50, 10, 0.0),
+        ):
+            args.iteration = loaded_iteration
+            args.log_interval = log_interval
+            total_loss_dict = {}
+            timers.reset_mock()
+            timers('interval-time').elapsed.return_value = 1.0
+
+            training_module.training_log(
+                loss_dict={'lm loss': original_tensor([1.0])},
+                total_loss_dict=total_loss_dict,
+                learning_rate=1e-4,
+                iteration=loaded_iteration + 1,
+                loss_scale=1.0,
+                report_memory_flag=False,
+                skipped_iter=0,
+                grad_norm=None,
+                params_norm=None,
+                num_zeros_in_grad=None,
+                max_attention_logit=None,
+                is_first_iteration=True,
+            )
+
+            assert total_loss_dict['lm loss'].item() == expected_loss
+            assert total_loss_dict['advanced iterations'] == int(loaded_iteration == 0)
+            timers('interval-time').elapsed.assert_called_once_with(barrier=True, reset=False)
+            timers.log.assert_called_once_with([], normalizer=1, reset=False)
+
+        args.iteration = 50
+        args.log_interval = 10
+        total_loss_dict = {}
+        log_strings.clear()
+        timers.reset_mock()
+        timers('interval-time').elapsed.side_effect = [1.0, 10.0]
+
+        for iteration in range(51, 61):
+            training_module.training_log(
+                loss_dict={'lm loss': original_tensor([1.0])},
+                total_loss_dict=total_loss_dict,
+                learning_rate=1e-4,
+                iteration=iteration,
+                loss_scale=1.0,
+                report_memory_flag=False,
+                skipped_iter=0,
+                grad_norm=None,
+                params_norm=None,
+                num_zeros_in_grad=None,
+                max_attention_logit=None,
+                is_first_iteration=iteration == 51,
+            )
+
+        assert 'elapsed time per iteration (ms): 1000.0' in log_strings[-1]
+        assert 'lm loss: 1.000000E+00' in log_strings[-1]
+        assert 'timer iterations' not in log_strings[-1]
+        assert [
+            call.kwargs['reset'] for call in timers('interval-time').elapsed.call_args_list
+        ] == [False, True]
+        assert [call.kwargs['normalizer'] for call in timers.log.call_args_list] == [1, 10]
 
     def teardown_method(self, method):
         Utils.destroy_model_parallel()


### PR DESCRIPTION
## What does this PR do?

Fixes loss logging after checkpoint resume when `--log-interval 1` is used.

The first iteration of a resumed process is currently treated as the first iteration of a fresh training run. This keeps its loss in `total_loss_dict`, so the next iteration logs the sum of two losses while dividing by two.

## Why is this needed?

For a fresh run, retaining the first logged loss is intentional because the first iteration is logged before the normal logging interval.

For a resumed run, `total_loss_dict` starts empty while `args.iteration > 0`. Retaining the first resumed loss causes it to be double-counted in the next log. In the observed case:

- uninterrupted iteration 52: `lm loss = 11.156137466430664`
- resumed iteration 52: accumulated loss `= 22.273590087890625`, `advanced iterations = 2`, average `= 11.136795043945312`

The forward loss and pre-optimizer gradient diagnostics match; this change only corrects the logging accumulator boundary.

## What changes?

Use independent accumulation boundaries for loss statistics and timers:

- Reset loss statistics after the first resumed iteration.
- Preserve timer accumulation through that iteration.
- Track timer iterations separately so elapsed time and operation timers are normalized by the exact number of accumulated timer samples.

## Validation

- Added unit coverage for a fresh first iteration and resumed first iterations with `log_interval` values 1 and 10.
- Added sequential resume coverage for iterations 51 through 60, verifying that timer values use 10 samples while loss statistics use the 9 iterations after the forced first log.
- `git diff --check`
- `PYTHONPYCACHEPREFIX=/tmp/megatron-pr-resume-loss-pycache python -m py_compile megatron/training/training.py tests/unit_tests/test_training.py`
- `uvx ruff check megatron/training/training.py tests/unit_tests/test_training.py`
- `uvx --from isort isort --check-only tests/unit_tests/test_training.py`
- `uvx --from black==24.10.0 black --check tests/unit_tests/test_training.py`
- The distributed GPU unit test was not run on this local macOS host.
- NPU runtime validation was not rerun locally.

Fixes #6237