### PR TITLE
Update Nemotron 3 Super GB200 release config

### DIFF
--- a/tests/functional_tests/test_cases/nemotron/nemotron3_super_release_gb200/model_config.yaml
+++ b/tests/functional_tests/test_cases/nemotron/nemotron3_super_release_gb200/model_config.yaml
@@ -90,6 +90,7 @@ MODEL_ARGS:
   --moe-router-dtype: fp32
   --moe-router-load-balancing-type: seq_aux_loss
   --moe-aux-loss-coeff: 1e-4
+  --moe-router-padding-for-quantization: true
   --moe-token-dispatcher-type: flex
   --moe-flex-dispatcher-backend: hybridep
   --moe-hybridep-num-sms: 32
@@ -106,12 +107,13 @@ MODEL_ARGS:
   # Mixed precision / quantization args
   --bf16: true
   --grad-reduce-in-bf16: true
-  --te-precision-config-file: /mnt/artifacts/model/nemotron3_super_release_gb200/te_quant.cfg
   --first-last-layers-bf16: true
   --num-layers-at-start-in-bf16: 0
   --num-layers-at-end-in-bf16: 14
-  --fp4-format: e2m1
-  --fp4-recipe: nvfp4
+  --fp8-format: e4m3
+  --fp8-recipe: mxfp8
+  --fp8-param-gather: true
+  --reuse-grad-buf-for-mxfp8-param-ag: true
 
   # Regularization args
   --attention-dropout: 0.0

--- a/tests/functional_tests/test_cases/nemotron/nemotron3_super_release_gb200/model_config.yaml
+++ b/tests/functional_tests/test_cases/nemotron/nemotron3_super_release_gb200/model_config.yaml
@@ -1,11 +1,18 @@
 ENV_VARS:
-  NVTE_FWD_LAYERNORM_SM_MARGIN: 16
-  NVTE_BWD_LAYERNORM_SM_MARGIN: 16
+  CUDA_DEVICE_MAX_CONNECTIONS: 32
+  NCCL_GRAPH_REGISTER: 0
+  NCCL_NVLS_ENABLE: 0
+  PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:True"
+  TORCH_NCCL_AVOID_RECORD_STREAMS: 1
+  TORCH_NCCL_HIGH_PRIORITY: 1
+  NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN: 64
+  NUM_OF_TOKENS_PER_CHUNK_COMBINE_API: 128
+  NVLINK_DOMAIN_SIZE: 72
+  USE_MNNVL: 1
+  NVTE_BWD_LAYERNORM_SM_MARGIN: 20
+  NVTE_FWD_LAYERNORM_SM_MARGIN: 20
   TORCHINDUCTOR_WORKER_START: fork
   QUANTIZATION_TYPE_DEBUG: 1
-  # PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
-  NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN: 64
-  USE_MNNVL: 1
   NON_DETERMINSTIC_RESULTS: 1
 TEST_TYPE: "release"
 MODEL_ARGS:
@@ -30,12 +37,14 @@ MODEL_ARGS:
   --train-samples: 12207031
   --cross-entropy-loss-fusion: true
   --cross-entropy-fusion-impl: native
-  --attention-backend: flash
-  --enable-cuda-graph: true
-  --cuda-graph-modules: "[mamba attn]"
+  --attention-backend: fused
+  --transformer-impl: transformer_engine
+  --cuda-graph-impl: transformer_engine
+  --cuda-graph-modules: "[attn mamba moe_router moe_preprocess]"
+  --cuda-graph-warmup-steps: 3
   --te-rng-tracker: true
   --manual-gc: true
-  --manual-gc-interval: 10
+  --manual-gc-interval: 100
   --no-create-attention-mask-in-dataloader: true
   --num-workers: 1
   --exit-interval: 23840
@@ -53,7 +62,7 @@ MODEL_ARGS:
   --group-query-attention: true
   --num-query-groups: 2
   --kv-channels: 128
-  --hybrid-override-pattern: MEMEMEM*EMEMEMEM*EMEMEMEM*EMEMEMEMEM*EMEMEMEMEM*EMEMEMEMEM*EMEMEMEMEM*EMEMEMEM*EMEMEMEME
+  --hybrid-layer-pattern: "MEMEMEM*EMEMEMEM*EMEMEMEM*EMEMEMEMEM*EMEMEMEMEM*EMEMEMEMEM*EMEMEMEMEM*EMEMEMEM*EMEMEMEME/*E/*E"
   --position-embedding-type: none
   --normalization: RMSNorm
   --untie-embeddings-and-output-weights: true
@@ -91,12 +100,12 @@ MODEL_ARGS:
 
   # MTP args
   --mtp-num-layers: 2
-  --mtp-hybrid-override-pattern: \"*E\"
   --calculate-per-token-loss: true
   --mtp-loss-scaling-factor: 0.3
 
   # Mixed precision / quantization args
   --bf16: true
+  --grad-reduce-in-bf16: true
   --te-precision-config-file: /mnt/artifacts/model/nemotron3_super_release_gb200/te_quant.cfg
   --first-last-layers-bf16: true
   --num-layers-at-start-in-bf16: 0
@@ -128,9 +137,8 @@ MODEL_ARGS:
   --ckpt-fully-parallel-save: true
   --ckpt-fully-parallel-load: true
   --ckpt-assume-constant-structure: true
-  --async-save: true
-  --use-persistent-ckpt-worker: true
-  --save-interval: 100
+  --dist-ckpt-strictness: log_all
+  --save-interval: 200
   --save-retain-interval: 2000
 
   # Validation args

--- a/tests/functional_tests/test_cases/nemotron/nemotron3_super_release_gb200_sm/model_config.yaml
+++ b/tests/functional_tests/test_cases/nemotron/nemotron3_super_release_gb200_sm/model_config.yaml
@@ -90,6 +90,7 @@ MODEL_ARGS:
   --moe-router-dtype: fp32
   --moe-router-load-balancing-type: seq_aux_loss
   --moe-aux-loss-coeff: 1e-4
+  --moe-router-padding-for-quantization: true
   --moe-token-dispatcher-type: flex
   --moe-flex-dispatcher-backend: hybridep
   --moe-hybridep-num-sms: 32
@@ -106,12 +107,13 @@ MODEL_ARGS:
   # Mixed precision / quantization args
   --bf16: true
   --grad-reduce-in-bf16: true
-  --te-precision-config-file: /mnt/artifacts/model/nemotron3_super_release_gb200/te_quant.cfg
   --first-last-layers-bf16: true
   --num-layers-at-start-in-bf16: 0
   --num-layers-at-end-in-bf16: 14
-  --fp4-format: e2m1
-  --fp4-recipe: nvfp4
+  --fp8-format: e4m3
+  --fp8-recipe: mxfp8
+  --fp8-param-gather: true
+  --reuse-grad-buf-for-mxfp8-param-ag: true
 
   # Regularization args
   --attention-dropout: 0.0

--- a/tests/functional_tests/test_cases/nemotron/nemotron3_super_release_gb200_sm/model_config.yaml
+++ b/tests/functional_tests/test_cases/nemotron/nemotron3_super_release_gb200_sm/model_config.yaml
@@ -1,11 +1,18 @@
 ENV_VARS:
-  NVTE_FWD_LAYERNORM_SM_MARGIN: 16
-  NVTE_BWD_LAYERNORM_SM_MARGIN: 16
+  CUDA_DEVICE_MAX_CONNECTIONS: 32
+  NCCL_GRAPH_REGISTER: 0
+  NCCL_NVLS_ENABLE: 0
+  PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:True"
+  TORCH_NCCL_AVOID_RECORD_STREAMS: 1
+  TORCH_NCCL_HIGH_PRIORITY: 1
+  NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN: 64
+  NUM_OF_TOKENS_PER_CHUNK_COMBINE_API: 128
+  NVLINK_DOMAIN_SIZE: 72
+  USE_MNNVL: 1
+  NVTE_BWD_LAYERNORM_SM_MARGIN: 20
+  NVTE_FWD_LAYERNORM_SM_MARGIN: 20
   TORCHINDUCTOR_WORKER_START: fork
   QUANTIZATION_TYPE_DEBUG: 1
-  # PYTORCH_CUDA_ALLOC_CONF: expandable_segments:True
-  NUM_OF_HYBRID_EP_RANKS_PER_NVLINK_DOMAIN: 64
-  USE_MNNVL: 1
   NON_DETERMINSTIC_RESULTS: 1
 TEST_TYPE: "release"
 MODEL_ARGS:
@@ -30,12 +37,14 @@ MODEL_ARGS:
   --train-samples: 12207031
   --cross-entropy-loss-fusion: true
   --cross-entropy-fusion-impl: native
-  --attention-backend: flash
-  --enable-cuda-graph: true
-  --cuda-graph-modules: "[mamba attn]"
+  --attention-backend: fused
+  --transformer-impl: transformer_engine
+  --cuda-graph-impl: transformer_engine
+  --cuda-graph-modules: "[attn mamba moe_router moe_preprocess]"
+  --cuda-graph-warmup-steps: 3
   --te-rng-tracker: true
   --manual-gc: true
-  --manual-gc-interval: 10
+  --manual-gc-interval: 100
   --no-create-attention-mask-in-dataloader: true
   --num-workers: 1
   --exit-interval: 4768
@@ -53,7 +62,7 @@ MODEL_ARGS:
   --group-query-attention: true
   --num-query-groups: 2
   --kv-channels: 128
-  --hybrid-override-pattern: MEMEMEM*EMEMEMEM*EMEMEMEM*EMEMEMEMEM*EMEMEMEMEM*EMEMEMEMEM*EMEMEMEMEM*EMEMEMEM*EMEMEMEME
+  --hybrid-layer-pattern: "MEMEMEM*EMEMEMEM*EMEMEMEM*EMEMEMEMEM*EMEMEMEMEM*EMEMEMEMEM*EMEMEMEMEM*EMEMEMEM*EMEMEMEME/*E/*E"
   --position-embedding-type: none
   --normalization: RMSNorm
   --untie-embeddings-and-output-weights: true
@@ -91,12 +100,12 @@ MODEL_ARGS:
 
   # MTP args
   --mtp-num-layers: 2
-  --mtp-hybrid-override-pattern: \"*E\"
   --calculate-per-token-loss: true
   --mtp-loss-scaling-factor: 0.3
 
   # Mixed precision / quantization args
   --bf16: true
+  --grad-reduce-in-bf16: true
   --te-precision-config-file: /mnt/artifacts/model/nemotron3_super_release_gb200/te_quant.cfg
   --first-last-layers-bf16: true
   --num-layers-at-start-in-bf16: 0
@@ -128,9 +137,8 @@ MODEL_ARGS:
   --ckpt-fully-parallel-save: true
   --ckpt-fully-parallel-load: true
   --ckpt-assume-constant-structure: true
-  --async-save: true
-  --use-persistent-ckpt-worker: true
-  --save-interval: 100
+  --dist-ckpt-strictness: log_all
+  --save-interval: 200
   --save-retain-interval: 2000
 
   # Validation args


### PR DESCRIPTION
## What changed

- Align the Nemotron 3 Super GB200 release and `_sm` recipes with the current Megatron Bridge GB200 runtime configuration.
- Use fused attention and Transformer Engine CUDA graphs for attention, Mamba, MoE routing, and MoE preprocessing.
- Update the HybridEP, NCCL, CUDA, and layer-pattern settings while keeping the existing NVSHMEM dependency unchanged.
- Switch both recipes from the mixed NVFP4 precision configuration to E4M3 MXFP8 with FP8 parameter gather, MXFP8 grad-buffer reuse, and quantization-aware MoE router padding.
- Preserve the release-oriented BF16 boundary layers, optimizer schedule, validation, and checkpoint settings rather than adopting benchmark-only performance overrides.

## Why

The existing MCore release recipes lag the configurations used by the current Megatron Bridge Nemotron 3 GB200 recipes. The prior mixed NVFP4 configuration also repeatedly encountered an illegal memory access during CUDA-graph backward replay after iteration-100 validation.

The MXFP8 diagnostic retains the full CUDA-graph module set and has crossed that same validation boundary without reproducing the failure. This update applies that tested precision recipe consistently to both release variants while preserving their intentional exit-interval difference.

The target branch already includes NVIDIA/Megatron-LM#6220 and its Transformer Engine 2.18 update.

## Validation

- [x] Both model configuration files parse as YAML.
- [x] The release and `_sm` configurations differ only in their intended `--exit-interval` values.
- [x] `git diff --check`
- [x] The MXFP8 GB200 diagnostic in [pipeline 61060072](https://gitlab-master.nvidia.com/ADLR/megatron-lm/-/pipelines/61060072) reached iteration 170 with zero skipped and zero NaN iterations, including successful training after iteration-100 validation.
- [ ] The full release-duration MXFP8 run is still pending.
