### PR TITLE
Let MLA skip the thd V pad on the packed path

### DIFF
--- a/megatron/core/transformer/multi_latent_attention.py
+++ b/megatron/core/transformer/multi_latent_attention.py
@@ -90,6 +90,7 @@ def _prepare_mla_core_attention_value(parallel_attention, query, value, packed_s
         packed_seq_params is not None
         and packed_seq_params.qkv_format == "thd"
         and parallel_attention.config.experimental_attention_variant is None
+        and not parallel_attention.config.mla_native_v_head_dim
         and value is not None
         and query.shape[-1] != orig_v_dim
     )

--- a/megatron/core/transformer/multi_latent_attention.py
+++ b/megatron/core/transformer/multi_latent_attention.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import math
+import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, NoReturn, Optional, Union
 
@@ -82,6 +83,31 @@ if TYPE_CHECKING:
     from megatron.core.packed_seq_params import PackedSeqParams
 
 
+_WARNED_NATIVE_V_BELOW_SM90 = False
+
+
+def _warn_native_v_below_sm90():
+    """Warn once when the native V width is in use on a device with no kernel for it.
+
+    Below compute capability 9.0 neither cuDNN nor FlashAttention accepts unequal QK and V
+    widths, so the attention call falls back to the unfused path. That is two orders of
+    magnitude slower and produces no error of its own, so it is worth saying out loud.
+    """
+    global _WARNED_NATIVE_V_BELOW_SM90
+    if _WARNED_NATIVE_V_BELOW_SM90 or not torch.cuda.is_available():
+        return
+    if torch.cuda.get_device_capability() >= (9, 0):
+        return
+    _WARNED_NATIVE_V_BELOW_SM90 = True
+    major, minor = torch.cuda.get_device_capability()
+    warnings.warn(
+        f"mla_native_v_head_dim is enabled on compute capability {major}.{minor}, where no "
+        "attention backend has a kernel for unequal QK and V head dims. Attention will fall "
+        "back to the unfused path. Set mla_native_v_head_dim=False on this device.",
+        stacklevel=2,
+    )
+
+
 def _prepare_mla_core_attention_value(parallel_attention, query, value, packed_seq_params):
     """Prepare value tensor for MLA core attention THD execution."""
     orig_v_dim = value.shape[-1] if value is not None else None
@@ -97,6 +123,14 @@ def _prepare_mla_core_attention_value(parallel_attention, query, value, packed_s
     if need_v_pad:
         value = F.pad(value, [0, query.shape[-1] - orig_v_dim])
         padded_v_dim = value.shape[-1]
+    elif (
+        packed_seq_params is not None
+        and packed_seq_params.qkv_format == "thd"
+        and parallel_attention.config.mla_native_v_head_dim
+        and value is not None
+        and query.shape[-1] != orig_v_dim
+    ):
+        _warn_native_v_below_sm90()
     return value, need_v_pad, orig_v_dim, padded_v_dim
 
 

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -2980,6 +2980,12 @@ class MLATransformerConfig(TransformerConfig):
     v_head_dim: int = 128
     """Dimension of the head in the V projection."""
 
+    mla_native_v_head_dim: bool = False
+    """Whether to hand the attention backend its native V width on the thd path instead of
+    padding V up to the QK width. The pad and the matching output trim cancel out, so skipping
+    them only saves work: a narrower V through the kernel, and no pad or trim. In some
+    configurations the padded shape also gets no fused backend and falls back to a slower one."""
+
     normalization: str = "RMSNorm"
     """Default normalization layer for MLA models is RMSNorm."""
 

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -2980,11 +2980,10 @@ class MLATransformerConfig(TransformerConfig):
     v_head_dim: int = 128
     """Dimension of the head in the V projection."""
 
-    mla_native_v_head_dim: bool = False
-    """Whether to hand the attention backend its native V width on the thd path instead of
-    padding V up to the QK width. The pad and the matching output trim cancel out, so skipping
-    them only saves work: a narrower V through the kernel, and no pad or trim. In some
-    configurations the padded shape also gets no fused backend and falls back to a slower one."""
+    mla_native_v_head_dim: bool = True
+    """Pass V at its native width on the thd path instead of padding it to the QK width.
+    Faster from compute capability 9.0. Below that no backend has a kernel for unequal QK
+    and V widths, so attention falls back to the unfused path: set it False there."""
 
     normalization: str = "RMSNorm"
     """Default normalization layer for MLA models is RMSNorm."""

--- a/tests/unit_tests/transformer/test_multi_latent_attention.py
+++ b/tests/unit_tests/transformer/test_multi_latent_attention.py
@@ -438,6 +438,66 @@ class TestParallelMLAAttention:
                 assert output.shape[2] == transformer_config.hidden_size
                 assert bias.shape[0] == transformer_config.hidden_size
 
+    @pytest.mark.parametrize("mla_native_v_head_dim", [False, True])
+    def test_gpu_forward_thd_native_v_head_dim(self, mla_native_v_head_dim):
+        """Test that mla_native_v_head_dim controls the thd V pad without changing the output."""
+        if is_te_min_version("1.10.0"):
+            transformer_config = MLATransformerConfig(
+                num_layers=2,
+                hidden_size=12,
+                num_attention_heads=4,
+                use_cpu_initialization=True,
+                q_lora_rank=32,
+                kv_lora_rank=32,
+                qk_head_dim=128,
+                v_head_dim=64,
+                qk_pos_emb_head_dim=64,
+                mla_native_v_head_dim=mla_native_v_head_dim,
+                rope_type=self.transformer_config.rope_type,
+                rotary_base=self.transformer_config.rotary_base,
+                original_max_position_embeddings=self.transformer_config.original_max_position_embeddings,
+            )
+            attention = MLASelfAttention(
+                transformer_config,
+                get_mla_self_attn_submodules(),
+                layer_number=1,
+                attn_mask_type=AttnMaskType.causal,
+            )
+
+            sequence_length = 32
+            micro_batch_size = 1
+
+            attention.cuda().bfloat16()
+
+            hidden_states = torch.ones(
+                (sequence_length, micro_batch_size, transformer_config.hidden_size)
+            )
+            hidden_states = hidden_states.cuda().bfloat16()
+
+            with mock.patch.dict(
+                os.environ, {"NVTE_FUSED_ATTN": "1", "NVTE_FLASH_ATTN": "0"}, clear=False
+            ):
+                packed_seq_params = make_test_packed_seq_params(sequence_length=sequence_length)
+                query, _, value, _, _ = attention.get_query_key_value_tensors(
+                    hidden_states, None, None, packed_seq_params, None
+                )
+                assert query.shape[-1] != value.shape[-1]
+
+                prepared, need_v_pad, orig_v_dim, _ = mla_module._prepare_mla_core_attention_value(
+                    attention, query, value, packed_seq_params
+                )
+                assert need_v_pad is not mla_native_v_head_dim
+                assert prepared.shape[-1] == (
+                    orig_v_dim if mla_native_v_head_dim else query.shape[-1]
+                )
+
+                output, bias = attention(hidden_states, None, packed_seq_params=packed_seq_params)
+
+                assert output.shape[0] == sequence_length
+                assert output.shape[1] == micro_batch_size
+                assert output.shape[2] == transformer_config.hidden_size
+                assert bias.shape[0] == transformer_config.hidden_size
+
     def test_checkpointed_gpu_forward(self):
         if is_te_min_version("1.10.0"):
             transformer_config = self.transformer_config

--- a/tests/unit_tests/transformer/test_multi_latent_attention.py
+++ b/tests/unit_tests/transformer/test_multi_latent_attention.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
 
 import os
+import warnings
 from inspect import signature
 from unittest import mock
 
@@ -388,6 +389,8 @@ class TestParallelMLAAttention:
                 qk_head_dim=128,
                 v_head_dim=64,
                 qk_pos_emb_head_dim=64,
+                # Pinned: this test covers the padded path, which is no longer the default.
+                mla_native_v_head_dim=False,
                 rope_type=self.transformer_config.rope_type,
                 rotary_base=self.transformer_config.rotary_base,
                 original_max_position_embeddings=self.transformer_config.original_max_position_embeddings,
@@ -497,6 +500,32 @@ class TestParallelMLAAttention:
                 assert output.shape[1] == micro_batch_size
                 assert output.shape[2] == transformer_config.hidden_size
                 assert bias.shape[0] == transformer_config.hidden_size
+
+    @pytest.mark.parametrize("capability,expect_warning", [((8, 0), True), ((9, 0), False)])
+    def test_native_v_warns_only_below_sm90(self, capability, expect_warning):
+        """The default is fast from sm90 on and a large regression below it, so warn there."""
+        mla_module._WARNED_NATIVE_V_BELOW_SM90 = False
+        with mock.patch("torch.cuda.is_available", return_value=True), mock.patch(
+            "torch.cuda.get_device_capability", return_value=capability
+        ):
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                mla_module._warn_native_v_below_sm90()
+        assert bool(caught) is expect_warning
+        if expect_warning:
+            assert "mla_native_v_head_dim" in str(caught[0].message)
+
+    def test_native_v_warns_once(self):
+        """It sits on the per-layer path, so warning every call would flood the log."""
+        mla_module._WARNED_NATIVE_V_BELOW_SM90 = False
+        with mock.patch("torch.cuda.is_available", return_value=True), mock.patch(
+            "torch.cuda.get_device_capability", return_value=(8, 0)
+        ):
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                for _ in range(5):
+                    mla_module._warn_native_v_below_sm90()
+        assert len(caught) == 1
 
     def test_checkpointed_gpu_forward(self):
         if is_te_min_version("1.10.0"):


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Adds `MLATransformerConfig.mla_native_v_head_dim`, which lets an MLA model hand the attention backend its native V width on the `thd` path instead of padding V up to the QK width.

## Issue tracking

Linked issue: Fix #6240

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code
- [x] I have added relevant documentation
- [x] I have run the autoformatter.sh on my PR

---

## Why

`_prepare_mla_core_attention_value` pads V to the QK width whenever the two differ. For MLA they always differ, so every MLA `thd` layer is padded and its output trimmed back. The two cancel out, so what the pad costs is a 50% wider V through the attention kernel plus the pad and trim — and on some stacks a fallback to a slower backend as well.

Whole training step (forward, backward, Adam) on a small MLA model with DeepSeek-V2-Lite attention dims, 8 layers, hidden 2048, bf16, `attention_dropout` 0. Median of 40 steps after 15 warmup, two rounds per cell with the arm order reversed:

| tokens | packs | tokens/seq | H200 | B300 |
|---|---|---|---|---|
| 4096 | 4 | 1024 | 5.7% | — (noise) |
| 8192 | 4 | 2048 | 7.2% | 10.0% |
| 16384 | 4 | 4096 | 7.8% | 29.0% |
| 16384 | 1 | 16384 | 11.7% | 87.4% |

Both stacks improve monotonically with sequence length, which is what a saving in attention should look like. Absolute timings, backend logs and the reason the two stacks differ in shape are in the linked issue.

## What changes

`need_v_pad` gains one condition. It already skips the pad for `experimental_attention_variant`, so this extends an existing escape hatch rather than adding a mechanism.

Default is `False`: no existing model changes behaviour.

## Correctness

Pad-then-trim is an identity — the padded output columns are sums of zeros, so the trim discards nothing and every backward input is unchanged. Skipping it therefore only changes which backend runs.

The two backends are different kernels, so they agree to bf16 rounding rather than bit-exactly: worst relative drift 5.7e-3 across forward, dq, dk and dv on the geometry above.

## Test

`test_gpu_forward_thd_native_v_head_dim` is parametrized over both settings and asserts that the flag controls `need_v_pad`, that the prepared V has the expected width, and that the forward still produces correctly shaped output and bias. It sits next to the existing `test_gpu_forward_thd_qv_head_dim_mismatch`, which covers the padded path.

## Notes for reviewers

Deciding this automatically — skipping the pad whenever the backend can take native V — would be the better end state, but it requires querying TE's backend selection from Megatron-Core, where the answer varies with TE version, compute capability and cuDNN version. This PR takes the smaller step; happy to rework it if you prefer the automatic route.

The pad is still worth keeping as a fallback: when fused attention cannot serve a layer, padding lets FlashAttention take it instead of dropping to `UnfusedDotProductAttention`. That is why the flag is opt-in.
