### PR TITLE
fix(multimodal): align video pixel shuffle with inference

### DIFF
--- a/megatron/core/models/multimodal/llava_model.py
+++ b/megatron/core/models/multimodal/llava_model.py
@@ -1057,6 +1057,12 @@ class LLaVAModel(MegatronModule):
                 chunks = torch.split(image_embeddings.squeeze(0), seq_lens, dim=0)
                 if self._drop_vision_class_token and ct_len > 0:
                     chunks = [c[ct_len:] for c in chunks]
+                if self._pixel_shuffle:
+                    chunks = _pixel_shuffle_dynamic_resolution_chunks(
+                        chunks,
+                        sizes_iter,
+                        self.vision_model.patch_dim,
+                    )
                 image_embeddings = torch.stack(chunks)  # [num_tubelets, patches, h_vision]
 
                 # Gather per-rank tubelet embeddings back to the full set so the
@@ -1067,11 +1073,15 @@ class LLaVAModel(MegatronModule):
                         image_embeddings, num_padded_imgs
                     )
 
-                # After temporal grouping each tubelet is one "tile" for LLaVAModel's
-                # _preprocess_data; one entry per post-grouping image (images have 1 frame,
-                # videos contribute ceil(nf/T) tubelets).
-                num_image_tiles = torch.ones(
-                    image_embeddings.shape[0], dtype=torch.int, device=image_embeddings.device
+                # Dynamic-resolution tubelets can have a different token count than
+                # ``self.img_seq_len``. Treat each output token as a packed tile so
+                # _preprocess_data expands every placeholder by the actual count.
+                is_packed_dynamic_res = True
+                num_image_tiles = torch.full(
+                    (image_embeddings.shape[0],),
+                    image_embeddings.shape[1],
+                    dtype=torch.int,
+                    device=image_embeddings.device,
                 )
             else:
                 # Packed dynamic-resolution image path: imgs_sizes carries per-image
@@ -1105,17 +1115,12 @@ class LLaVAModel(MegatronModule):
                         chunks = [c[ct_len:] for c in chunks]
 
                     if self._pixel_shuffle:
-                        shuffled_chunks = []
-                        for chunk, (h, w) in zip(chunks, sizes):
-                            ps_h, ps_w = int(h) // P, int(w) // P
-                            chunk_b = chunk.unsqueeze(0)  # [1, patches_i, h_vision]
-                            shuffled = pixel_shuffle(chunk_b, h=ps_h, w=ps_w)
-                            shuffled_chunks.append(shuffled.squeeze(0))
-                        cat = torch.cat(shuffled_chunks, dim=0)
+                        chunks = _pixel_shuffle_dynamic_resolution_chunks(chunks, sizes, P)
+                        cat = torch.cat(chunks, dim=0)
                     else:
                         cat = torch.cat(list(chunks), dim=0)
                     image_embeddings = cat.unsqueeze(0).contiguous()
-                    _tile_counts = [p // 4 if self._pixel_shuffle else p for p in patch_counts]
+                    _tile_counts = [chunk.shape[0] for chunk in chunks]
                     num_image_tiles = torch.tensor(
                         _tile_counts, dtype=torch.int, device=image_embeddings.device
                     )
@@ -1137,7 +1142,7 @@ class LLaVAModel(MegatronModule):
 
             # Packed dynamic-res path already pixel-shuffled per-image above; skip outer call.
             # For the single-image (non-packed) case pass h/w from imgs_sizes if available.
-            skip_outer_pixel_shuffle = (not use_temporal) and is_packed_dynamic_res
+            skip_outer_pixel_shuffle = is_packed_dynamic_res
             if self._pixel_shuffle and not skip_outer_pixel_shuffle:
                 ps_h = ps_w = None
                 if (
@@ -1327,6 +1332,25 @@ def _load_state_dict_hook_ignore_extra_state(
 # pylint: disable-next=line-too-long
 # Based on https://github.com/OpenGVLab/InternVL/blob/c7c5af1a8930b4862afe8ed14672307082ef61fa/internvl_chat/internvl/model/internvl_chat/modeling_internvl_chat.py#L218
 # Copyright (c) 2023 OpenGVLab.
+def _pixel_shuffle_dynamic_resolution_chunks(chunks, image_sizes, patch_dim):
+    """Pixel-shuffle dynamic-resolution image chunks using their real patch grids."""
+    assert len(chunks) == len(image_sizes), (
+        "each image chunk requires a matching image size"
+    )
+
+    shuffled_chunks = []
+    for chunk, (height, width) in zip(chunks, image_sizes):
+        patch_height = int(height) // int(patch_dim)
+        patch_width = int(width) // int(patch_dim)
+        shuffled = pixel_shuffle(
+            chunk.unsqueeze(0),
+            h=patch_height,
+            w=patch_width,
+        )
+        shuffled_chunks.append(shuffled.squeeze(0))
+    return shuffled_chunks
+
+
 def pixel_shuffle(x, scale_factor=0.5, version=2, h=None, w=None):
     """Pixel shuffle based on InternVL but adapted for our use case.
 
@@ -1343,8 +1367,25 @@ def pixel_shuffle(x, scale_factor=0.5, version=2, h=None, w=None):
         assert h is not None and w is not None, "h and w must both be provided"
         assert h * w == x.shape[1], f"h*w ({h}*{w}={h*w}) must equal patches ({x.shape[1]})"
         r = int(1 / scale_factor)
-        n, patches, c = x.shape
-        return x.reshape(n, patches // (r * r), c * r * r)
+        assert h % r == 0 and w % r == 0, (
+            f"h and w ({h}, {w}) must both be divisible by {r}"
+        )
+        x = x.reshape(x.shape[0], h, w, -1)
+
+        n, h, w, c = x.size()
+        x = x.view(n, h, int(w * scale_factor), int(c / scale_factor))
+        x = x.permute(0, 2, 1, 3).contiguous()
+        x = x.view(
+            n,
+            int(w * scale_factor),
+            int(h * scale_factor),
+            int(c / (scale_factor * scale_factor)),
+        )
+
+        if version == 2:
+            x = x.permute(0, 2, 1, 3).contiguous()
+
+        return x.reshape(x.shape[0], -1, x.shape[-1])
     h = w = int(x.shape[1] ** 0.5)  # sq
     x = x.reshape(x.shape[0], h, w, -1)  # [num_tiles, sq, sq, h_vision]
 

--- a/tests/unit_tests/models/test_radio_model.py
+++ b/tests/unit_tests/models/test_radio_model.py
@@ -290,12 +290,33 @@ class TestPixelShuffleNonSquare:
     def test_non_square_h_w_required_for_dynamic_res(self):
         from megatron.core.models.multimodal.llava_model import pixel_shuffle
 
-        # 12 patches arranged as 3×4 (non-square). With h, w supplied the
-        # function must accept this and produce the shuffled output.
+        # An even 4x6 grid must group each spatial 2x2 neighborhood, not just
+        # reshape every four consecutive flattened patches together.
+        x = torch.arange(24, dtype=torch.float32).reshape(1, 24, 1)
+        out = pixel_shuffle(x, h=4, w=6)
+
+        expected = torch.tensor(
+            [
+                [
+                    [0, 1, 6, 7],
+                    [2, 3, 8, 9],
+                    [4, 5, 10, 11],
+                    [12, 13, 18, 19],
+                    [14, 15, 20, 21],
+                    [16, 17, 22, 23],
+                ]
+            ],
+            dtype=torch.float32,
+        )
+        torch.testing.assert_close(out, expected)
+
+    @pytest.mark.internal
+    def test_non_square_h_w_must_be_even(self):
+        from megatron.core.models.multimodal.llava_model import pixel_shuffle
+
         x = torch.randn(1, 12, 4)
-        out = pixel_shuffle(x, h=3, w=4)
-        # scale=0.5 ⇒ each spatial dim halves ⇒ output area = (3*4)/(2*2) = 3.
-        assert out.shape == (1, 3, 16)
+        with pytest.raises(AssertionError, match="must both be divisible"):
+            pixel_shuffle(x, h=3, w=4)
 
     @pytest.mark.internal
     def test_h_w_mismatch_raises(self):
@@ -305,6 +326,24 @@ class TestPixelShuffleNonSquare:
         # Mismatch: h*w != patches.
         with pytest.raises(AssertionError):
             pixel_shuffle(x, h=2, w=2)
+
+    @pytest.mark.internal
+    def test_dynamic_resolution_video_chunks_use_their_non_square_grids(self):
+        from megatron.core.models.multimodal.llava_model import (
+            _pixel_shuffle_dynamic_resolution_chunks,
+        )
+
+        # The video validation path produces 448x576 frames: 28x36=1008 patches.
+        # Applying square-only pixel shuffle tries to reshape these as 31x31.
+        chunks = [torch.randn(1008, 8) for _ in range(16)]
+        shuffled = _pixel_shuffle_dynamic_resolution_chunks(
+            chunks,
+            [(448, 576)] * 16,
+            patch_dim=16,
+        )
+
+        assert len(shuffled) == 16
+        assert all(chunk.shape == (252, 32) for chunk in shuffled)
 
 
 class TestRADIODynamicResAndTemporal:


### PR DESCRIPTION
## Summary

  Correct dynamic-resolution pixel shuffling for multimodal image and temporal-video inputs.

  - Perform spatial pixel shuffle using each input's real patch grid.
  - Apply pixel shuffle independently to dynamic-resolution video tubelets.
  - Use the actual post-shuffle token count when expanding multimodal placeholders.
  - Avoid applying pixel shuffle twice on packed inputs.
  - Add regression coverage for non-square inputs and 448x576 video frames.

  ## Motivation

  The policy training path must preserve the same spatial feature ordering used during inference. Flattened reshaping of non-square video frames grouped the wrong neighboring
  patches, causing generation and training to consume differently ordered visual features.

  This is required for consistent Nemotron Omni video GRPO training and rollout/training log-probability parity.

  ## Validation

  - Added unit coverage for non-square pixel-shuffle ordering.
  - Added dynamic-resolution temporal-video coverage using 448x576 frames.
  - Exercised through synchronous NeMo RL video GRPO training.

  ## Related work

Megatron-Bridge: https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/5304
Gym: https://github.com/NVIDIA-NeMo/Gym/pull/2324
