### PR TITLE
Document the parallel_state deprecation and its replacement

### DIFF
--- a/docs/developer/contribute.md
+++ b/docs/developer/contribute.md
@@ -47,6 +47,24 @@ File any bugs you find, keeping the following in mind:
 - Include commented-out code.
 - Attempt large architectural changes without first opening an issue to discuss.
 
+### Process groups in `megatron/core`
+
+`megatron.core.parallel_state` is being deprecated. It holds the process groups for a single,
+global parallel grid; Megatron-Core is moving to explicit passing via `ProcessGroupCollection`.
+
+- **New features must not call** `parallel_state.get_*_group()`, `get_*_rank()`, or
+  `get_*_world_size()` in `megatron/core`. Accept a `ProcessGroupCollection` or an explicit
+  `torch.distributed.ProcessGroup` from the caller and pass it through.
+- **Do not add a `None` default that falls back to `parallel_state`.** For a model built on
+  independent parallel grids, that fallback silently selects the wrong grid.
+- **`ProcessGroupCollection.use_mpu_process_groups()` is not a migration target.** It reads the
+  same global state, so swapping a direct accessor for it is a lateral move.
+- **Bug fixes may leave existing calls alone.** Process-group plumbing changes belong in their own
+  PR.
+
+Full guidance, including the tier breakdown and the runtime fallback report:
+[parallel-state-deprecation.md](parallel-state-deprecation.md).
+
 ## Signing Your Work
 
 - We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.

--- a/docs/developer/contribute.md
+++ b/docs/developer/contribute.md
@@ -48,6 +48,24 @@ File any bugs you find, keeping the following in mind:
 - Include commented-out code.
 - Attempt large architectural changes without first opening an issue to discuss.
 
+### Process groups in `megatron/core`
+
+`megatron.core.parallel_state` is being deprecated. It holds the process groups for a single,
+global parallel grid; Megatron-Core is moving to explicit passing via `ProcessGroupCollection`.
+
+- **New features must not call** `parallel_state.get_*_group()`, `get_*_rank()`, or
+  `get_*_world_size()` in `megatron/core`. Accept a `ProcessGroupCollection` or an explicit
+  `torch.distributed.ProcessGroup` from the caller and pass it through.
+- **Do not add a `None` default that falls back to `parallel_state`.** For a model built on
+  independent parallel grids, that fallback silently selects the wrong grid.
+- **`ProcessGroupCollection.use_mpu_process_groups()` is not a migration target.** It reads the
+  same global state, so swapping a direct accessor for it is a lateral move.
+- **Bug fixes may leave existing calls alone.** Process-group plumbing changes belong in their own
+  PR.
+
+Full guidance, including the tier breakdown and reviewer notes:
+[parallel-state-deprecation.md](parallel-state-deprecation.md).
+
 ## Signing Your Work
 
 - We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.

--- a/docs/developer/parallel-state-deprecation.md
+++ b/docs/developer/parallel-state-deprecation.md
@@ -1,0 +1,74 @@
+# Deprecating `parallel_state`
+
+`megatron.core.parallel_state` holds the process groups for a **single, global** parallel grid.
+Megatron-Core is migrating to explicit process-group passing via `ProcessGroupCollection`.
+
+This page answers the question that keeps coming up in review: *is this deprecated, and what do I
+use instead?*
+
+## Why it matters
+
+For a job with one parallel grid, reading a group from `parallel_state` is merely deprecated —
+it returns the right answer.
+
+For a job that builds **independent** grids — a vision encoder and an LLM with different
+parallelism, generalized tensor parallelism, MIMO — it returns a group belonging to the *wrong*
+grid. Nothing raises. The collective runs on the wrong ranks, or a rank is seeded with the wrong
+RNG offset, and the job produces wrong numbers.
+
+That is the reason this migration exists. It is a correctness problem before it is a tidiness
+problem.
+
+## What is deprecated
+
+| Tier | What | Replacement | Status |
+|---|---|---|---|
+| **1** | Group accessors — `get_*_group()` | `pg_collection.<field>` | Deprecated. Banned in new `megatron/core` code. |
+| **2** | Rank / size accessors — `get_*_rank()`, `get_*_world_size()` | `pg.rank()` / `pg.size()` on the group you were passed | Deprecated. Banned in new `megatron/core` code. |
+| **3** | Pipeline-stage predicates — `is_pipeline_first_stage()`, `is_pipeline_last_stage()` | A process-group-based equivalent exists at `megatron/core/inference/communication_utils.py` | Being designed. These encode virtual-pipeline semantics, not just a group. |
+| **4** | Non-group global state — virtual-pipeline rank/size, `GlobalMemoryBuffer`, gloo groups, NCCL options | **None yet.** `ProcessGroupCollection` does not cover these. | Needs design. Do not migrate ad hoc. |
+
+**Not deprecated:** `initialize_model_parallel`, `destroy_model_parallel`, `is_initialized`.
+These are the intended long-term surface — bootstrap, and nothing else.
+
+## `use_mpu_process_groups()` is not a migration target
+
+`ProcessGroupCollection.use_mpu_process_groups()` builds a collection *by reading the same global
+state*. It exists to keep already-migrated call sites working during the transition.
+
+```python
+# Not progress -- both read the global grid.
+- tp_group = parallel_state.get_tensor_model_parallel_group()
++ pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+```
+
+New code must accept a `ProcessGroupCollection` from its caller. Existing call sites are being
+removed; do not add more.
+
+## What this means for your change
+
+**Writing a new feature?** Accept a `ProcessGroupCollection` or an explicit
+`torch.distributed.ProcessGroup` and pass it through. Do not add a `None` default that falls back
+to `parallel_state` — that fallback is the bug, not the convenience.
+
+```python
+# Don't: silently correct for one grid, silently wrong for two.
+def my_op(x, tp_group=None):
+    if tp_group is None:
+        tp_group = parallel_state.get_tensor_model_parallel_group()
+
+# Do: the caller knows which grid it is on.
+def my_op(x, tp_group: torch.distributed.ProcessGroup):
+    ...
+```
+
+**Fixing a bug?** Leave existing `parallel_state` calls as they are. Changing process-group
+plumbing has its own blast radius and belongs in its own PR — bundling it into a fix makes the fix
+harder to review and harder to revert.
+
+**Reviewing?** Flag new tier-1/tier-2 accessor use in `megatron/core`. Allowed exceptions:
+`parallel_state.py` itself, `process_groups_config.py`, bootstrap code that materializes a
+collection from the globals, tests, and explicitly-commented migration fallbacks.
+
+This guidance applies to `megatron/core`. It does not apply to `megatron/training` or other
+training-loop code unless a change explicitly opts in.

--- a/docs/developer/parallel-state-deprecation.md
+++ b/docs/developer/parallel-state-deprecation.md
@@ -1,0 +1,84 @@
+# Deprecating `parallel_state`
+
+`megatron.core.parallel_state` holds the process groups for a **single, global** parallel grid.
+Megatron-Core is migrating to explicit process-group passing via `ProcessGroupCollection`.
+
+This page answers the question that keeps coming up in review: *is this deprecated, and what do I
+use instead?*
+
+## Why it matters
+
+For a job with one parallel grid, reading a group from `parallel_state` is merely deprecated —
+it returns the right answer.
+
+For a job that builds **independent** grids — a vision encoder and an LLM with different
+parallelism, generalized tensor parallelism, MIMO — it returns a group belonging to the *wrong*
+grid. Nothing raises. The collective runs on the wrong ranks, or a rank is seeded with the wrong
+RNG offset, and the job produces wrong numbers.
+
+That is the reason this migration exists. It is a correctness problem before it is a tidiness
+problem.
+
+## What is deprecated
+
+| Tier | What | Replacement | Status |
+|---|---|---|---|
+| **1** | Group accessors — `get_*_group()` | `pg_collection.<field>` | Deprecated. Banned in new `megatron/core` code. |
+| **2** | Rank / size accessors — `get_*_rank()`, `get_*_world_size()` | `pg.rank()` / `pg.size()` on the group you were passed | Deprecated. Banned in new `megatron/core` code. |
+| **3** | Pipeline-stage predicates — `is_pipeline_first_stage()`, `is_pipeline_last_stage()` | A process-group-based equivalent exists at `megatron/core/inference/communication_utils.py` | Being designed. These encode virtual-pipeline semantics, not just a group. |
+| **4** | Non-group global state — virtual-pipeline rank/size, `GlobalMemoryBuffer`, gloo groups, NCCL options | **None yet.** `ProcessGroupCollection` does not cover these. | Needs design. Do not migrate ad hoc. |
+
+**Not deprecated:** `initialize_model_parallel`, `destroy_model_parallel`, `is_initialized`.
+These are the intended long-term surface — bootstrap, and nothing else.
+
+## `use_mpu_process_groups()` is not a migration target
+
+`ProcessGroupCollection.use_mpu_process_groups()` builds a collection *by reading the same global
+state*. It exists to keep already-migrated call sites working during the transition.
+
+```python
+# Not progress -- both read the global grid.
+- tp_group = parallel_state.get_tensor_model_parallel_group()
++ pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+```
+
+New code must accept a `ProcessGroupCollection` from its caller. Existing call sites are being
+removed; do not add more.
+
+## What this means for your change
+
+**Writing a new feature?** Accept a `ProcessGroupCollection` or an explicit
+`torch.distributed.ProcessGroup` and pass it through. Do not add a `None` default that falls back
+to `parallel_state` — that fallback is the bug, not the convenience.
+
+```python
+# Don't: silently correct for one grid, silently wrong for two.
+def my_op(x, tp_group=None):
+    if tp_group is None:
+        tp_group = parallel_state.get_tensor_model_parallel_group()
+
+# Do: the caller knows which grid it is on.
+def my_op(x, tp_group: torch.distributed.ProcessGroup):
+    ...
+```
+
+**Fixing a bug?** Leave existing `parallel_state` calls as they are. Changing process-group
+plumbing has its own blast radius and belongs in its own PR — bundling it into a fix makes the fix
+harder to review and harder to revert.
+
+**Reviewing?** Flag new tier-1/tier-2 accessor use in `megatron/core`. Allowed exceptions:
+`parallel_state.py` itself, `process_groups_config.py`, bootstrap code that materializes a
+collection from the globals, tests, and explicitly-commented migration fallbacks.
+
+This guidance applies to `megatron/core`. It does not apply to `megatron/training` or other
+training-loop code unless a change explicitly opts in.
+
+## Finding fallbacks at runtime
+
+Where a fallback still exists, it reports itself. `megatron.core.utils` provides:
+
+- `get_process_group_fallback_report()` — `{call site: hit count}` for every implicit global
+  process-group fallback taken in this process. A non-empty report means the run depends on global
+  state and would break under independent grids.
+- `MCORE_PG_FALLBACK_WARN_ALL_RANKS=1` — by default only global rank 0 warns, which is not enough
+  when debugging independent grids, since rank 0 may never execute the affected path.

--- a/megatron/core/parallel_state.py
+++ b/megatron/core/parallel_state.py
@@ -1,6 +1,33 @@
 # Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
 
-"""Model and data parallel groups."""
+"""Model and data parallel groups.
+
+.. warning::
+    **This module is being deprecated.** It holds the process groups for a single, global
+    parallel grid. Megatron-Core is migrating to explicit process-group passing via
+    :class:`~megatron.core.process_groups_config.ProcessGroupCollection`.
+
+    The group / rank / world-size accessors here read that global grid. For a job with one grid
+    they are merely deprecated. For a job that builds **independent** grids -- a vision encoder
+    and an LLM with different parallelism, GTP, MIMO -- they return the wrong grid, and the
+    result is silently incorrect rather than an error.
+
+    What this means for a change you are writing:
+
+    * **New features must not call the accessors in this module.** Accept a
+      ``ProcessGroupCollection`` or an explicit ``torch.distributed.ProcessGroup`` and pass it
+      through.
+    * **Bug fixes may leave existing calls alone.** Changing the process-group plumbing belongs
+      in its own change, not bundled into a fix.
+    * ``ProcessGroupCollection.use_mpu_process_groups()`` is **not** a migration target. It is a
+      backward-compatibility shim that reads this same global state, so swapping a direct
+      accessor for it makes no progress.
+
+    ``initialize_model_parallel`` / ``destroy_model_parallel`` / ``is_initialized`` are the
+    intended long-term surface and are not deprecated.
+
+    See ``docs/developer/parallel-state-deprecation.md``.
+"""
 
 import logging
 import os
@@ -1440,14 +1467,24 @@ def model_parallel_is_initialized():
 
 
 def get_model_parallel_group(check_initialized=True):
-    """Get the model-parallel group the caller rank belongs to."""
+    """Get the model-parallel group the caller rank belongs to.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if check_initialized:
         assert _MODEL_PARALLEL_GROUP is not None, "model parallel group is not initialized"
     return _MODEL_PARALLEL_GROUP
 
 
 def get_tensor_model_parallel_group(check_initialized=True):
-    """Get the tensor-model-parallel group the caller rank belongs to."""
+    """Get the tensor-model-parallel group the caller rank belongs to.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if check_initialized:
         assert (
             _TENSOR_MODEL_PARALLEL_GROUP is not None
@@ -1456,7 +1493,12 @@ def get_tensor_model_parallel_group(check_initialized=True):
 
 
 def get_pipeline_model_parallel_group(check_initialized=True):
-    """Get the pipeline-model-parallel group the caller rank belongs to."""
+    """Get the pipeline-model-parallel group the caller rank belongs to.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if check_initialized:
         assert (
             _PIPELINE_MODEL_PARALLEL_GROUP is not None
@@ -1465,7 +1507,12 @@ def get_pipeline_model_parallel_group(check_initialized=True):
 
 
 def get_data_parallel_group(with_context_parallel=False, partial_data_parallel=False):
-    """Get the data-parallel group the caller rank belongs to."""
+    """Get the data-parallel group the caller rank belongs to.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if with_context_parallel:
         if partial_data_parallel:
             assert (
@@ -1483,7 +1530,12 @@ def get_data_parallel_group(with_context_parallel=False, partial_data_parallel=F
 
 
 def get_data_parallel_group_gloo(with_context_parallel=False, partial_data_parallel=False):
-    """Get the Gloo data-parallel group the caller rank belongs to."""
+    """Get the Gloo data-parallel group the caller rank belongs to.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if with_context_parallel:
         if partial_data_parallel:
             assert (
@@ -1501,7 +1553,12 @@ def get_data_parallel_group_gloo(with_context_parallel=False, partial_data_paral
 
 
 def get_context_parallel_group(check_initialized=True):
-    """Get the context-parallel group the caller rank belongs to."""
+    """Get the context-parallel group the caller rank belongs to.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if check_initialized:
         assert _CONTEXT_PARALLEL_GROUP is not None, "context parallel group is not initialized"
     return _CONTEXT_PARALLEL_GROUP
@@ -1517,14 +1574,24 @@ def get_context_parallel_global_ranks(check_initialized=True):
 
 
 def get_hierarchical_context_parallel_groups(check_initialized=True):
-    """Get the inner ring of context parallel group the caller rank belongs to."""
+    """Get the inner ring of context parallel group the caller rank belongs to.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if check_initialized:
         assert _HIERARCHICAL_CONTEXT_PARALLEL_GROUPS is not None
     return _HIERARCHICAL_CONTEXT_PARALLEL_GROUPS
 
 
 def get_hybrid_data_context_parallel_groups(check_initialized=True, group_size=None):
-    """Get the hybrid context parallel groups the caller rank belongs to."""
+    """Get the hybrid context parallel groups the caller rank belongs to.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     # If the group size is the same as the entire DPxCP group, return the original group
     if get_data_parallel_world_size(with_context_parallel=True) == group_size:
         if check_initialized:
@@ -1536,21 +1603,36 @@ def get_hybrid_data_context_parallel_groups(check_initialized=True, group_size=N
 
 
 def get_embedding_group(check_initialized=True):
-    """Get the embedding group the caller rank belongs to."""
+    """Get the embedding group the caller rank belongs to.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if check_initialized:
         assert _EMBEDDING_GROUP is not None, "embedding group is not initialized"
     return _EMBEDDING_GROUP
 
 
 def get_position_embedding_group(check_initialized=True):
-    """Get the position embedding group the caller rank belongs to."""
+    """Get the position embedding group the caller rank belongs to.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if check_initialized:
         assert _POSITION_EMBEDDING_GROUP is not None, "position embedding group is not initialized"
     return _POSITION_EMBEDDING_GROUP
 
 
 def get_amax_reduction_group(with_context_parallel=False, tp_only_amax_red=False):
-    """Get the FP8 amax reduction group the caller rank belongs to."""
+    """Get the FP8 amax reduction group the caller rank belongs to.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if with_context_parallel:
         if not tp_only_amax_red:
             assert (
@@ -1576,7 +1658,12 @@ def get_amax_reduction_group(with_context_parallel=False, tp_only_amax_red=False
 
 
 def get_tensor_and_data_parallel_group(check_initialized=True, with_context_parallel=False):
-    """Get the tensor- and data-parallel group the caller rank belongs to."""
+    """Get the tensor- and data-parallel group the caller rank belongs to.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if with_context_parallel:
         if check_initialized:
             assert (
@@ -1592,7 +1679,12 @@ def get_tensor_and_data_parallel_group(check_initialized=True, with_context_para
 
 
 def get_tensor_and_context_parallel_group(check_initialized=True):
-    """Get the tensor- and context-parallel group the caller rank belongs to."""
+    """Get the tensor- and context-parallel group the caller rank belongs to.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if check_initialized:
         assert (
             _TENSOR_AND_CONTEXT_PARALLEL_GROUP is not None
@@ -1619,7 +1711,12 @@ def set_virtual_pipeline_model_parallel_world_size(world_size):
 
 
 def get_tensor_model_parallel_world_size():
-    """Return world size for the tensor-model-parallel group."""
+    """Return world size for the tensor-model-parallel group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     global _MPU_TENSOR_MODEL_PARALLEL_WORLD_SIZE
     if _MPU_TENSOR_MODEL_PARALLEL_WORLD_SIZE is not None:
         return _MPU_TENSOR_MODEL_PARALLEL_WORLD_SIZE
@@ -1627,7 +1724,12 @@ def get_tensor_model_parallel_world_size():
 
 
 def get_pipeline_model_parallel_world_size():
-    """Return world size for the pipeline-model-parallel group."""
+    """Return world size for the pipeline-model-parallel group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     global _MPU_PIPELINE_MODEL_PARALLEL_WORLD_SIZE
     if _MPU_PIPELINE_MODEL_PARALLEL_WORLD_SIZE is not None:
         return _MPU_PIPELINE_MODEL_PARALLEL_WORLD_SIZE
@@ -1647,7 +1749,12 @@ def set_pipeline_model_parallel_rank(rank):
 
 
 def get_tensor_model_parallel_rank():
-    """Return caller's rank for the tensor-model-parallel group."""
+    """Return caller's rank for the tensor-model-parallel group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     global _MPU_TENSOR_MODEL_PARALLEL_RANK
     if _MPU_TENSOR_MODEL_PARALLEL_RANK is not None:
         return _MPU_TENSOR_MODEL_PARALLEL_RANK
@@ -1655,7 +1762,12 @@ def get_tensor_model_parallel_rank():
 
 
 def get_pipeline_model_parallel_rank():
-    """Return caller's rank for the pipeline-model-parallel group."""
+    """Return caller's rank for the pipeline-model-parallel group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     global _MPU_PIPELINE_MODEL_PARALLEL_RANK
     if _MPU_PIPELINE_MODEL_PARALLEL_RANK is not None:
         return _MPU_PIPELINE_MODEL_PARALLEL_RANK
@@ -1732,6 +1844,10 @@ def get_virtual_pipeline_model_parallel_world_size():
 
 def get_tensor_model_parallel_src_rank():
     """Calculate the global rank corresponding to the first local rank
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
     in the tensor model parallel group."""
     assert (
         _TENSOR_MODEL_PARALLEL_GLOBAL_RANKS is not None
@@ -1741,6 +1857,10 @@ def get_tensor_model_parallel_src_rank():
 
 def get_model_parallel_src_rank():
     """Calculate the global rank corresponding to the first local rank
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
     in the model parallel group."""
     assert _MODEL_PARALLEL_GLOBAL_RANKS is not None, "Model parallel group is not initialized"
     return _MODEL_PARALLEL_GLOBAL_RANKS[0]
@@ -1748,6 +1868,10 @@ def get_model_parallel_src_rank():
 
 def get_data_parallel_src_rank(with_context_parallel=False):
     """Calculate the global rank corresponding to the first local rank
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
     in the data parallel group."""
     if with_context_parallel:
         assert (
@@ -1760,20 +1884,35 @@ def get_data_parallel_src_rank(with_context_parallel=False):
 
 
 def get_pipeline_model_parallel_first_rank():
-    """Return the global rank of the first stage in the current rank's pipeline."""
+    """Return the global rank of the first stage in the current rank's pipeline.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     assert _PIPELINE_GLOBAL_RANKS is not None, "Pipeline parallel group is not initialized"
     return _PIPELINE_GLOBAL_RANKS[0]
 
 
 def get_pipeline_model_parallel_last_rank():
-    """Return the global rank of the last stage in the current rank's pipeline."""
+    """Return the global rank of the last stage in the current rank's pipeline.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     assert _PIPELINE_GLOBAL_RANKS is not None, "Pipeline parallel group is not initialized"
     last_rank_local = get_pipeline_model_parallel_world_size() - 1
     return _PIPELINE_GLOBAL_RANKS[last_rank_local]
 
 
 def get_pipeline_model_parallel_next_rank():
-    """Return the global rank that follows the caller in the pipeline."""
+    """Return the global rank that follows the caller in the pipeline.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     assert _PIPELINE_GLOBAL_RANKS is not None, "Pipeline parallel group is not initialized"
     rank_in_pipeline = get_pipeline_model_parallel_rank()
     world_size = get_pipeline_model_parallel_world_size()
@@ -1781,7 +1920,12 @@ def get_pipeline_model_parallel_next_rank():
 
 
 def get_pipeline_model_parallel_prev_rank():
-    """Return the global rank that precedes the caller in the pipeline."""
+    """Return the global rank that precedes the caller in the pipeline.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     assert _PIPELINE_GLOBAL_RANKS is not None, "Pipeline parallel group is not initialized"
     rank_in_pipeline = get_pipeline_model_parallel_rank()
     world_size = get_pipeline_model_parallel_world_size()
@@ -1789,7 +1933,12 @@ def get_pipeline_model_parallel_prev_rank():
 
 
 def get_data_parallel_world_size(with_context_parallel=False, partial_data_parallel=False):
-    """Return world size for the data parallel group."""
+    """Return world size for the data parallel group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     global _MPU_DATA_PARALLEL_WORLD_SIZE
     if _MPU_DATA_PARALLEL_WORLD_SIZE is not None:
         return _MPU_DATA_PARALLEL_WORLD_SIZE
@@ -1808,7 +1957,12 @@ def set_data_parallel_rank(rank):
 
 
 def get_data_parallel_rank(with_context_parallel=False, partial_data_parallel=False):
-    """Return caller's rank in the data-parallel group."""
+    """Return caller's rank in the data-parallel group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     global _MPU_DATA_PARALLEL_RANK
     if _MPU_DATA_PARALLEL_RANK is not None:
         return _MPU_DATA_PARALLEL_RANK
@@ -1821,7 +1975,12 @@ def get_data_parallel_rank(with_context_parallel=False, partial_data_parallel=Fa
 
 
 def get_context_parallel_world_size():
-    """Return world size for the context parallel group."""
+    """Return world size for the context parallel group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if torch.distributed.is_available() and torch.distributed.is_initialized():
         return get_context_parallel_group().size()
     else:
@@ -1829,7 +1988,12 @@ def get_context_parallel_world_size():
 
 
 def get_context_parallel_rank():
-    """Return caller's rank in the context-parallel group."""
+    """Return caller's rank in the context-parallel group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if torch.distributed.is_available() and torch.distributed.is_initialized():
         return get_context_parallel_group().rank()
     else:
@@ -1837,7 +2001,12 @@ def get_context_parallel_rank():
 
 
 def get_tensor_and_context_parallel_world_size():
-    """Return world size for the tensor and context-parallel group."""
+    """Return world size for the tensor and context-parallel group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if torch.distributed.is_available() and torch.distributed.is_initialized():
         return get_tensor_and_context_parallel_group().size()
     else:
@@ -1845,7 +2014,12 @@ def get_tensor_and_context_parallel_world_size():
 
 
 def get_tensor_and_context_parallel_rank():
-    """Return caller's rank in the joint tensor-model-parallel and context-parallel group."""
+    """Return caller's rank in the joint tensor-model-parallel and context-parallel group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if torch.distributed.is_available() and torch.distributed.is_initialized():
         return get_tensor_and_context_parallel_group().rank()
     else:
@@ -1854,7 +2028,12 @@ def get_tensor_and_context_parallel_rank():
 
 ### Expert-related parallel states functions
 def get_expert_model_parallel_group(check_initialized=True):
-    """Get the expert-model-parallel group the caller rank belongs to."""
+    """Get the expert-model-parallel group the caller rank belongs to.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if check_initialized:
         assert (
             _EXPERT_MODEL_PARALLEL_GROUP is not None
@@ -1864,6 +2043,10 @@ def get_expert_model_parallel_group(check_initialized=True):
 
 def get_expert_model_parallel_src_rank():
     """Calculate the global rank corresponding to the first local rank
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
     in the expert model parallel group."""
     assert (
         _EXPERT_MODEL_PARALLEL_RANKS is not None
@@ -1872,7 +2055,12 @@ def get_expert_model_parallel_src_rank():
 
 
 def get_expert_model_parallel_world_size():
-    """Return world size for the expert-model-parallel group."""
+    """Return world size for the expert-model-parallel group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if _MPU_EXPERT_MODEL_PARALLEL_WORLD_SIZE is not None:
         return _MPU_EXPERT_MODEL_PARALLEL_WORLD_SIZE
     if torch.distributed.is_available() and torch.distributed.is_initialized():
@@ -1888,7 +2076,12 @@ def set_expert_model_parallel_world_size(world_size):
 
 
 def get_expert_model_parallel_rank():
-    """Return caller's rank in the expert-model-parallel group."""
+    """Return caller's rank in the expert-model-parallel group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if _MPU_EXPERT_MODEL_PARALLEL_RANK is not None:
         return _MPU_EXPERT_MODEL_PARALLEL_RANK
     if torch.distributed.is_available() and torch.distributed.is_initialized():
@@ -1904,7 +2097,12 @@ def set_expert_model_parallel_rank(rank):
 
 
 def get_expert_tensor_parallel_group(check_initialized=True):
-    """Get the expert-tensor-parallel group the caller rank belongs to."""
+    """Get the expert-tensor-parallel group the caller rank belongs to.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if check_initialized:
         assert (
             _EXPERT_TENSOR_PARALLEL_GROUP is not None
@@ -1913,7 +2111,12 @@ def get_expert_tensor_parallel_group(check_initialized=True):
 
 
 def get_expert_tensor_parallel_world_size():
-    """Return world size for the expert tensor parallel group."""
+    """Return world size for the expert tensor parallel group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     global _MPU_EXPERT_TENSOR_PARALLEL_WORLD_SIZE
     if _MPU_EXPERT_TENSOR_PARALLEL_WORLD_SIZE is not None:
         return _MPU_EXPERT_TENSOR_PARALLEL_WORLD_SIZE
@@ -1931,7 +2134,12 @@ def set_expert_tensor_parallel_world_size(world_size):
 
 
 def get_expert_tensor_parallel_rank():
-    """Return my rank for the expert tensor parallel group."""
+    """Return my rank for the expert tensor parallel group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     global _MPU_EXPERT_TENSOR_PARALLEL_RANK
     if _MPU_EXPERT_TENSOR_PARALLEL_RANK is not None:
         return _MPU_EXPERT_TENSOR_PARALLEL_RANK
@@ -1949,7 +2157,12 @@ def set_expert_tensor_parallel_rank(rank):
 
 
 def get_expert_tensor_and_model_parallel_group(check_initialized=True):
-    """Get the expert-tensor and expert-model group the caller rank belongs to."""
+    """Get the expert-tensor and expert-model group the caller rank belongs to.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if check_initialized:
         assert (
             _EXPERT_TENSOR_AND_MODEL_PARALLEL_GROUP is not None
@@ -1958,7 +2171,12 @@ def get_expert_tensor_and_model_parallel_group(check_initialized=True):
 
 
 def get_expert_tensor_and_model_parallel_world_size():
-    """Return world size for the expert model parallel group times expert tensor parallel group."""
+    """Return world size for the expert model parallel group times expert tensor parallel group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if torch.distributed.is_available() and torch.distributed.is_initialized():
         world_size = get_expert_tensor_and_model_parallel_group().size()
         return world_size
@@ -1967,7 +2185,12 @@ def get_expert_tensor_and_model_parallel_world_size():
 
 
 def get_expert_tensor_and_model_parallel_rank():
-    """Return caller's rank in the joint tensor- and expert-model-parallel group."""
+    """Return caller's rank in the joint tensor- and expert-model-parallel group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if torch.distributed.is_available() and torch.distributed.is_initialized():
         return get_expert_tensor_and_model_parallel_group().rank()
     else:
@@ -1975,7 +2198,12 @@ def get_expert_tensor_and_model_parallel_rank():
 
 
 def get_expert_tensor_model_pipeline_parallel_group(check_initialized=True):
-    """Get expert tensor-model-pipeline parallel group."""
+    """Get expert tensor-model-pipeline parallel group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if check_initialized:
         assert (
             _EXPERT_TENSOR_MODEL_PIPELINE_PARALLEL_GROUP is not None
@@ -1984,7 +2212,12 @@ def get_expert_tensor_model_pipeline_parallel_group(check_initialized=True):
 
 
 def get_expert_data_parallel_group(check_initialized=True, partial_expert_data_parallel=False):
-    """Get expert data parallel group."""
+    """Get expert data parallel group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if partial_expert_data_parallel:
         if check_initialized:
             assert (
@@ -2000,7 +2233,12 @@ def get_expert_data_parallel_group(check_initialized=True, partial_expert_data_p
 
 
 def get_expert_data_parallel_group_gloo(partial_expert_data_parallel=False):
-    """Get expert data parallel group-gloo."""
+    """Get expert data parallel group-gloo.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if partial_expert_data_parallel:
         assert (
             _INTRA_PARTIAL_EXPERT_DATA_PARALLEL_GROUP_GLOO is not None
@@ -2014,7 +2252,12 @@ def get_expert_data_parallel_group_gloo(partial_expert_data_parallel=False):
 
 
 def get_expert_data_parallel_rank(partial_expert_data_parallel=False):
-    """Return caller's rank in the expert data parallel group."""
+    """Return caller's rank in the expert data parallel group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if torch.distributed.is_available() and torch.distributed.is_initialized():
         return get_expert_data_parallel_group(
             partial_expert_data_parallel=partial_expert_data_parallel
@@ -2024,7 +2267,12 @@ def get_expert_data_parallel_rank(partial_expert_data_parallel=False):
 
 
 def get_expert_data_parallel_world_size(partial_expert_data_parallel=False):
-    """Return world size for the expert data parallel group."""
+    """Return world size for the expert data parallel group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if torch.distributed.is_available() and torch.distributed.is_initialized():
         return get_expert_data_parallel_group(
             partial_expert_data_parallel=partial_expert_data_parallel
@@ -2034,7 +2282,12 @@ def get_expert_data_parallel_world_size(partial_expert_data_parallel=False):
 
 
 def get_intra_distributed_optimizer_instance_group(check_initialized=True):
-    """Get the group of all GPUs in a distributed optimizer instance."""
+    """Get the group of all GPUs in a distributed optimizer instance.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if check_initialized:
         assert (
             _INTRA_DISTRIBUTED_OPTIMIZER_INSTANCE_GROUP is not None
@@ -2046,6 +2299,10 @@ def get_inter_distributed_optimizer_instance_group(check_initialized=True):
     """Get the group spanning the different distributed optimizer instances.
     Attention and MLP/Expert share same inter-instance group, so only built
     inter_partial_expert_data_parallel_group, and return it at here.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
     """
     if check_initialized:
         assert _INTER_PARTIAL_EXPERT_DATA_PARALLEL_GROUP is not None, (

--- a/megatron/core/parallel_state.py
+++ b/megatron/core/parallel_state.py
@@ -1,6 +1,33 @@
 # Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
 
-"""Model and data parallel groups."""
+"""Model and data parallel groups.
+
+.. warning::
+    **This module is being deprecated.** It holds the process groups for a single, global
+    parallel grid. Megatron-Core is migrating to explicit process-group passing via
+    :class:`~megatron.core.process_groups_config.ProcessGroupCollection`.
+
+    The group / rank / world-size accessors here read that global grid. For a job with one grid
+    they are merely deprecated. For a job that builds **independent** grids -- a vision encoder
+    and an LLM with different parallelism, GTP, MIMO -- they return the wrong grid, and the
+    result is silently incorrect rather than an error.
+
+    What this means for a change you are writing:
+
+    * **New features must not call the accessors in this module.** Accept a
+      ``ProcessGroupCollection`` or an explicit ``torch.distributed.ProcessGroup`` and pass it
+      through.
+    * **Bug fixes may leave existing calls alone.** Changing the process-group plumbing belongs
+      in its own change, not bundled into a fix.
+    * ``ProcessGroupCollection.use_mpu_process_groups()`` is **not** a migration target. It is a
+      backward-compatibility shim that reads this same global state, so swapping a direct
+      accessor for it makes no progress.
+
+    ``initialize_model_parallel`` / ``destroy_model_parallel`` / ``is_initialized`` are the
+    intended long-term surface and are not deprecated.
+
+    See ``docs/developer/parallel-state-deprecation.md``.
+"""
 
 import logging
 import os
@@ -1694,14 +1721,24 @@ def model_parallel_is_initialized():
 
 
 def get_model_parallel_group(check_initialized=True):
-    """Get the model-parallel group the caller rank belongs to."""
+    """Get the model-parallel group the caller rank belongs to.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if check_initialized:
         assert _MODEL_PARALLEL_GROUP is not None, "model parallel group is not initialized"
     return _MODEL_PARALLEL_GROUP
 
 
 def get_tensor_model_parallel_group(check_initialized=True):
-    """Get the tensor-model-parallel group the caller rank belongs to."""
+    """Get the tensor-model-parallel group the caller rank belongs to.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if check_initialized:
         assert (
             _TENSOR_MODEL_PARALLEL_GROUP is not None
@@ -1710,7 +1747,12 @@ def get_tensor_model_parallel_group(check_initialized=True):
 
 
 def get_gtp_weight_remat_group(check_initialized=True):
-    """Get the parameter-sharding group the caller rank belongs to."""
+    """Get the parameter-sharding group the caller rank belongs to.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if check_initialized:
         assert (
             _GTP_WEIGHT_REMAT_GROUP is not None
@@ -1719,7 +1761,12 @@ def get_gtp_weight_remat_group(check_initialized=True):
 
 
 def get_gtp_weight_remat_world_size():
-    """Return world size for the parameter-sharding group."""
+    """Return world size for the parameter-sharding group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if torch.distributed.is_available() and torch.distributed.is_initialized():
         group = get_gtp_weight_remat_group(check_initialized=False)
         return group.size() if group is not None else 0
@@ -1728,7 +1775,12 @@ def get_gtp_weight_remat_world_size():
 
 
 def get_gtp_weight_remat_rank():
-    """Return caller's rank in the parameter-sharding group."""
+    """Return caller's rank in the parameter-sharding group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if torch.distributed.is_available() and torch.distributed.is_initialized():
         group = get_gtp_weight_remat_group(check_initialized=False)
         return group.rank() if group is not None else 0
@@ -1746,7 +1798,12 @@ def get_gtp_weight_remat_global_ranks(check_initialized=True):
 
 
 def get_pipeline_model_parallel_group(check_initialized=True):
-    """Get the pipeline-model-parallel group the caller rank belongs to."""
+    """Get the pipeline-model-parallel group the caller rank belongs to.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if check_initialized:
         assert (
             _PIPELINE_MODEL_PARALLEL_GROUP is not None
@@ -1758,6 +1815,10 @@ def get_data_parallel_group(
     with_context_parallel=False, with_gtp_remat=True, partial_data_parallel=False
 ):
     """Get the data-parallel group the caller rank belongs to.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
 
     GTP_remat is an independent axis layered on DP.
     DEFAULT (``with_gtp_remat=True``): full data-distribution group (replicate_DP x
@@ -1807,7 +1868,12 @@ def get_data_parallel_group(
 
 
 def get_data_parallel_group_gloo(with_context_parallel=False, partial_data_parallel=False):
-    """Get the Gloo data-parallel group the caller rank belongs to."""
+    """Get the Gloo data-parallel group the caller rank belongs to.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if with_context_parallel:
         if partial_data_parallel:
             assert (
@@ -1825,7 +1891,12 @@ def get_data_parallel_group_gloo(with_context_parallel=False, partial_data_paral
 
 
 def get_context_parallel_group(check_initialized=True):
-    """Get the context-parallel group the caller rank belongs to."""
+    """Get the context-parallel group the caller rank belongs to.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if check_initialized:
         assert _CONTEXT_PARALLEL_GROUP is not None, "context parallel group is not initialized"
     return _CONTEXT_PARALLEL_GROUP
@@ -1841,14 +1912,24 @@ def get_context_parallel_global_ranks(check_initialized=True):
 
 
 def get_hierarchical_context_parallel_groups(check_initialized=True):
-    """Get the inner ring of context parallel group the caller rank belongs to."""
+    """Get the inner ring of context parallel group the caller rank belongs to.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if check_initialized:
         assert _HIERARCHICAL_CONTEXT_PARALLEL_GROUPS is not None
     return _HIERARCHICAL_CONTEXT_PARALLEL_GROUPS
 
 
 def get_hybrid_data_context_parallel_groups(check_initialized=True, group_size=None):
-    """Get the hybrid context parallel groups the caller rank belongs to."""
+    """Get the hybrid context parallel groups the caller rank belongs to.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     # If the group size is the same as the entire DPxCP group, return the original group
     if get_data_parallel_world_size(with_context_parallel=True) == group_size:
         if check_initialized:
@@ -1860,21 +1941,36 @@ def get_hybrid_data_context_parallel_groups(check_initialized=True, group_size=N
 
 
 def get_embedding_group(check_initialized=True):
-    """Get the embedding group the caller rank belongs to."""
+    """Get the embedding group the caller rank belongs to.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if check_initialized:
         assert _EMBEDDING_GROUP is not None, "embedding group is not initialized"
     return _EMBEDDING_GROUP
 
 
 def get_position_embedding_group(check_initialized=True):
-    """Get the position embedding group the caller rank belongs to."""
+    """Get the position embedding group the caller rank belongs to.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if check_initialized:
         assert _POSITION_EMBEDDING_GROUP is not None, "position embedding group is not initialized"
     return _POSITION_EMBEDDING_GROUP
 
 
 def get_amax_reduction_group(with_context_parallel=False, tp_only_amax_red=False):
-    """Get the FP8 amax reduction group the caller rank belongs to."""
+    """Get the FP8 amax reduction group the caller rank belongs to.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if with_context_parallel:
         if not tp_only_amax_red:
             assert (
@@ -1902,6 +1998,10 @@ def get_amax_reduction_group(with_context_parallel=False, tp_only_amax_red=False
 def get_tensor_and_data_parallel_group(check_initialized=True, with_context_parallel=False):
     """Get the tensor- and data-parallel group the caller rank belongs to.
 
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+
     The group spans gtp_remat (like dp), so it serves both FP8 amax reduction and the MoE router's
     expert-bias / load-balancing token reduction across every distinct-data rank.
     """
@@ -1920,7 +2020,12 @@ def get_tensor_and_data_parallel_group(check_initialized=True, with_context_para
 
 
 def get_tensor_and_context_parallel_group(check_initialized=True):
-    """Get the tensor- and context-parallel group the caller rank belongs to."""
+    """Get the tensor- and context-parallel group the caller rank belongs to.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if check_initialized:
         assert (
             _TENSOR_AND_CONTEXT_PARALLEL_GROUP is not None
@@ -1947,7 +2052,12 @@ def set_virtual_pipeline_model_parallel_world_size(world_size):
 
 
 def get_tensor_model_parallel_world_size():
-    """Return world size for the tensor-model-parallel group."""
+    """Return world size for the tensor-model-parallel group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     global _MPU_TENSOR_MODEL_PARALLEL_WORLD_SIZE
     if _MPU_TENSOR_MODEL_PARALLEL_WORLD_SIZE is not None:
         return _MPU_TENSOR_MODEL_PARALLEL_WORLD_SIZE
@@ -1955,7 +2065,12 @@ def get_tensor_model_parallel_world_size():
 
 
 def get_pipeline_model_parallel_world_size():
-    """Return world size for the pipeline-model-parallel group."""
+    """Return world size for the pipeline-model-parallel group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     global _MPU_PIPELINE_MODEL_PARALLEL_WORLD_SIZE
     if _MPU_PIPELINE_MODEL_PARALLEL_WORLD_SIZE is not None:
         return _MPU_PIPELINE_MODEL_PARALLEL_WORLD_SIZE
@@ -1975,7 +2090,12 @@ def set_pipeline_model_parallel_rank(rank):
 
 
 def get_tensor_model_parallel_rank():
-    """Return caller's rank for the tensor-model-parallel group."""
+    """Return caller's rank for the tensor-model-parallel group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     global _MPU_TENSOR_MODEL_PARALLEL_RANK
     if _MPU_TENSOR_MODEL_PARALLEL_RANK is not None:
         return _MPU_TENSOR_MODEL_PARALLEL_RANK
@@ -1983,7 +2103,12 @@ def get_tensor_model_parallel_rank():
 
 
 def get_pipeline_model_parallel_rank():
-    """Return caller's rank for the pipeline-model-parallel group."""
+    """Return caller's rank for the pipeline-model-parallel group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     global _MPU_PIPELINE_MODEL_PARALLEL_RANK
     if _MPU_PIPELINE_MODEL_PARALLEL_RANK is not None:
         return _MPU_PIPELINE_MODEL_PARALLEL_RANK
@@ -2060,7 +2185,12 @@ def get_virtual_pipeline_model_parallel_world_size():
 
 def get_tensor_model_parallel_src_rank():
     """Calculate the global rank corresponding to the first local rank
-    in the tensor model parallel group."""
+    in the tensor model parallel group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     assert (
         _TENSOR_MODEL_PARALLEL_GLOBAL_RANKS is not None
     ), "Tensor model parallel group is not initialized"
@@ -2069,14 +2199,24 @@ def get_tensor_model_parallel_src_rank():
 
 def get_model_parallel_src_rank():
     """Calculate the global rank corresponding to the first local rank
-    in the model parallel group."""
+    in the model parallel group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     assert _MODEL_PARALLEL_GLOBAL_RANKS is not None, "Model parallel group is not initialized"
     return _MODEL_PARALLEL_GLOBAL_RANKS[0]
 
 
 def get_data_parallel_src_rank(with_context_parallel=False):
     """Calculate the global rank corresponding to the first local rank
-    in the data parallel group."""
+    in the data parallel group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if with_context_parallel:
         assert (
             _DATA_PARALLEL_GLOBAL_RANKS_WITH_CP is not None
@@ -2088,20 +2228,35 @@ def get_data_parallel_src_rank(with_context_parallel=False):
 
 
 def get_pipeline_model_parallel_first_rank():
-    """Return the global rank of the first stage in the current rank's pipeline."""
+    """Return the global rank of the first stage in the current rank's pipeline.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     assert _PIPELINE_GLOBAL_RANKS is not None, "Pipeline parallel group is not initialized"
     return _PIPELINE_GLOBAL_RANKS[0]
 
 
 def get_pipeline_model_parallel_last_rank():
-    """Return the global rank of the last stage in the current rank's pipeline."""
+    """Return the global rank of the last stage in the current rank's pipeline.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     assert _PIPELINE_GLOBAL_RANKS is not None, "Pipeline parallel group is not initialized"
     last_rank_local = get_pipeline_model_parallel_world_size() - 1
     return _PIPELINE_GLOBAL_RANKS[last_rank_local]
 
 
 def get_pipeline_model_parallel_next_rank():
-    """Return the global rank that follows the caller in the pipeline."""
+    """Return the global rank that follows the caller in the pipeline.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     assert _PIPELINE_GLOBAL_RANKS is not None, "Pipeline parallel group is not initialized"
     rank_in_pipeline = get_pipeline_model_parallel_rank()
     world_size = get_pipeline_model_parallel_world_size()
@@ -2109,7 +2264,12 @@ def get_pipeline_model_parallel_next_rank():
 
 
 def get_pipeline_model_parallel_prev_rank():
-    """Return the global rank that precedes the caller in the pipeline."""
+    """Return the global rank that precedes the caller in the pipeline.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     assert _PIPELINE_GLOBAL_RANKS is not None, "Pipeline parallel group is not initialized"
     rank_in_pipeline = get_pipeline_model_parallel_rank()
     world_size = get_pipeline_model_parallel_world_size()
@@ -2120,6 +2280,10 @@ def get_data_parallel_world_size(
     with_context_parallel=False, with_gtp_remat=True, partial_data_parallel=False
 ):
     """Return the data-parallel world size.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
 
     DEFAULT (with_gtp_remat=True): full degree (replicate_DP x gtp_remat).
     with_gtp_remat=False: replicate degree.
@@ -2148,6 +2312,10 @@ def get_data_parallel_rank(
 ):
     """Return the caller's data-parallel rank.
 
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+
     DEFAULT (with_gtp_remat=True): rank in the full group (replicate_DP x gtp_remat).
     with_gtp_remat=False: rank in the replicate group.
     """
@@ -2165,7 +2333,12 @@ def get_data_parallel_rank(
 
 
 def get_context_parallel_world_size():
-    """Return world size for the context parallel group."""
+    """Return world size for the context parallel group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if torch.distributed.is_available() and torch.distributed.is_initialized():
         return get_context_parallel_group().size()
     else:
@@ -2173,7 +2346,12 @@ def get_context_parallel_world_size():
 
 
 def get_context_parallel_rank():
-    """Return caller's rank in the context-parallel group."""
+    """Return caller's rank in the context-parallel group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if torch.distributed.is_available() and torch.distributed.is_initialized():
         return get_context_parallel_group().rank()
     else:
@@ -2181,7 +2359,12 @@ def get_context_parallel_rank():
 
 
 def get_tensor_and_context_parallel_world_size():
-    """Return world size for the tensor and context-parallel group."""
+    """Return world size for the tensor and context-parallel group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if torch.distributed.is_available() and torch.distributed.is_initialized():
         return get_tensor_and_context_parallel_group().size()
     else:
@@ -2189,7 +2372,12 @@ def get_tensor_and_context_parallel_world_size():
 
 
 def get_tensor_and_context_parallel_rank():
-    """Return caller's rank in the joint tensor-model-parallel and context-parallel group."""
+    """Return caller's rank in the joint tensor-model-parallel and context-parallel group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if torch.distributed.is_available() and torch.distributed.is_initialized():
         return get_tensor_and_context_parallel_group().rank()
     else:
@@ -2198,7 +2386,12 @@ def get_tensor_and_context_parallel_rank():
 
 ### Expert-related parallel states functions
 def get_expert_gtp_weight_remat_group(check_initialized=True):
-    """Get the expert-parameter-sharding group the caller rank belongs to."""
+    """Get the expert-parameter-sharding group the caller rank belongs to.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if check_initialized:
         assert (
             _EXPERT_GTP_WEIGHT_REMAT_GROUP is not None
@@ -2207,7 +2400,12 @@ def get_expert_gtp_weight_remat_group(check_initialized=True):
 
 
 def get_expert_gtp_weight_remat_world_size():
-    """Return world size for the expert-parameter-sharding group."""
+    """Return world size for the expert-parameter-sharding group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if torch.distributed.is_available() and torch.distributed.is_initialized():
         group = get_expert_gtp_weight_remat_group(check_initialized=False)
         return group.size() if group is not None else 0
@@ -2216,7 +2414,12 @@ def get_expert_gtp_weight_remat_world_size():
 
 
 def get_expert_gtp_weight_remat_rank():
-    """Return caller's rank in the expert-parameter-sharding group."""
+    """Return caller's rank in the expert-parameter-sharding group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if torch.distributed.is_available() and torch.distributed.is_initialized():
         group = get_expert_gtp_weight_remat_group(check_initialized=False)
         return group.rank() if group is not None else 0
@@ -2234,7 +2437,12 @@ def get_expert_gtp_weight_remat_global_ranks(check_initialized=True):
 
 
 def get_expert_model_parallel_group(check_initialized=True):
-    """Get the expert-model-parallel group the caller rank belongs to."""
+    """Get the expert-model-parallel group the caller rank belongs to.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if check_initialized:
         assert (
             _EXPERT_MODEL_PARALLEL_GROUP is not None
@@ -2244,7 +2452,12 @@ def get_expert_model_parallel_group(check_initialized=True):
 
 def get_expert_model_parallel_src_rank():
     """Calculate the global rank corresponding to the first local rank
-    in the expert model parallel group."""
+    in the expert model parallel group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     assert (
         _EXPERT_MODEL_PARALLEL_RANKS is not None
     ), "Expert model parallel group is not initialized"
@@ -2252,7 +2465,12 @@ def get_expert_model_parallel_src_rank():
 
 
 def get_expert_model_parallel_world_size():
-    """Return world size for the expert-model-parallel group."""
+    """Return world size for the expert-model-parallel group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if _MPU_EXPERT_MODEL_PARALLEL_WORLD_SIZE is not None:
         return _MPU_EXPERT_MODEL_PARALLEL_WORLD_SIZE
     if torch.distributed.is_available() and torch.distributed.is_initialized():
@@ -2268,7 +2486,12 @@ def set_expert_model_parallel_world_size(world_size):
 
 
 def get_expert_model_parallel_rank():
-    """Return caller's rank in the expert-model-parallel group."""
+    """Return caller's rank in the expert-model-parallel group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if _MPU_EXPERT_MODEL_PARALLEL_RANK is not None:
         return _MPU_EXPERT_MODEL_PARALLEL_RANK
     if torch.distributed.is_available() and torch.distributed.is_initialized():
@@ -2284,7 +2507,12 @@ def set_expert_model_parallel_rank(rank):
 
 
 def get_expert_tensor_parallel_group(check_initialized=True):
-    """Get the expert-tensor-parallel group the caller rank belongs to."""
+    """Get the expert-tensor-parallel group the caller rank belongs to.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if check_initialized:
         assert (
             _EXPERT_TENSOR_PARALLEL_GROUP is not None
@@ -2293,7 +2521,12 @@ def get_expert_tensor_parallel_group(check_initialized=True):
 
 
 def get_expert_tensor_parallel_world_size():
-    """Return world size for the expert tensor parallel group."""
+    """Return world size for the expert tensor parallel group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     global _MPU_EXPERT_TENSOR_PARALLEL_WORLD_SIZE
     if _MPU_EXPERT_TENSOR_PARALLEL_WORLD_SIZE is not None:
         return _MPU_EXPERT_TENSOR_PARALLEL_WORLD_SIZE
@@ -2311,7 +2544,12 @@ def set_expert_tensor_parallel_world_size(world_size):
 
 
 def get_expert_tensor_parallel_rank():
-    """Return my rank for the expert tensor parallel group."""
+    """Return my rank for the expert tensor parallel group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     global _MPU_EXPERT_TENSOR_PARALLEL_RANK
     if _MPU_EXPERT_TENSOR_PARALLEL_RANK is not None:
         return _MPU_EXPERT_TENSOR_PARALLEL_RANK
@@ -2329,7 +2567,12 @@ def set_expert_tensor_parallel_rank(rank):
 
 
 def get_expert_tensor_and_model_parallel_group(check_initialized=True):
-    """Get the expert-tensor and expert-model group the caller rank belongs to."""
+    """Get the expert-tensor and expert-model group the caller rank belongs to.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if check_initialized:
         assert (
             _EXPERT_TENSOR_AND_MODEL_PARALLEL_GROUP is not None
@@ -2338,7 +2581,12 @@ def get_expert_tensor_and_model_parallel_group(check_initialized=True):
 
 
 def get_expert_tensor_and_model_parallel_world_size():
-    """Return world size for the expert model parallel group times expert tensor parallel group."""
+    """Return world size for the expert model parallel group times expert tensor parallel group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if torch.distributed.is_available() and torch.distributed.is_initialized():
         world_size = get_expert_tensor_and_model_parallel_group().size()
         return world_size
@@ -2347,7 +2595,12 @@ def get_expert_tensor_and_model_parallel_world_size():
 
 
 def get_expert_tensor_and_model_parallel_rank():
-    """Return caller's rank in the joint tensor- and expert-model-parallel group."""
+    """Return caller's rank in the joint tensor- and expert-model-parallel group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if torch.distributed.is_available() and torch.distributed.is_initialized():
         return get_expert_tensor_and_model_parallel_group().rank()
     else:
@@ -2356,6 +2609,10 @@ def get_expert_tensor_and_model_parallel_rank():
 
 def get_expert_tensor_model_pipeline_parallel_group(check_initialized=True, with_egtp_remat=False):
     """Get expert tensor-model-pipeline parallel group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
 
     Args:
         check_initialized: If True (default), asserts the group has been created.
@@ -2382,6 +2639,10 @@ def get_expert_data_parallel_group(
     check_initialized=True, with_gtp_remat=True, partial_expert_data_parallel=False
 ):
     """Get the expert data parallel group.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
 
     DEFAULT (with_gtp_remat=True): full group for data distribution (EGTP_remat peers
     hold distinct micro-batches).
@@ -2411,7 +2672,12 @@ def get_expert_data_parallel_group(
 
 
 def get_expert_data_parallel_group_gloo(partial_expert_data_parallel=False):
-    """Get expert data parallel group-gloo."""
+    """Get expert data parallel group-gloo.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if partial_expert_data_parallel:
         assert (
             _INTRA_PARTIAL_EXPERT_DATA_PARALLEL_GROUP_GLOO is not None
@@ -2425,7 +2691,12 @@ def get_expert_data_parallel_group_gloo(partial_expert_data_parallel=False):
 
 
 def get_expert_data_parallel_rank(with_gtp_remat=True, partial_expert_data_parallel=False):
-    """Return the caller's expert-data-parallel rank (default: EGTP_remat-inclusive)."""
+    """Return the caller's expert-data-parallel rank (default: EGTP_remat-inclusive).
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if torch.distributed.is_available() and torch.distributed.is_initialized():
         return get_expert_data_parallel_group(
             with_gtp_remat=with_gtp_remat, partial_expert_data_parallel=partial_expert_data_parallel
@@ -2435,7 +2706,12 @@ def get_expert_data_parallel_rank(with_gtp_remat=True, partial_expert_data_paral
 
 
 def get_expert_data_parallel_world_size(with_gtp_remat=True, partial_expert_data_parallel=False):
-    """Return the expert-data-parallel world size (default: EGTP_remat-inclusive)."""
+    """Return the expert-data-parallel world size (default: EGTP_remat-inclusive).
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if torch.distributed.is_available() and torch.distributed.is_initialized():
         return get_expert_data_parallel_group(
             with_gtp_remat=with_gtp_remat, partial_expert_data_parallel=partial_expert_data_parallel
@@ -2445,7 +2721,12 @@ def get_expert_data_parallel_world_size(with_gtp_remat=True, partial_expert_data
 
 
 def get_intra_distributed_optimizer_instance_group(check_initialized=True):
-    """Get the group of all GPUs in a distributed optimizer instance."""
+    """Get the group of all GPUs in a distributed optimizer instance.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
+    """
     if check_initialized:
         assert (
             _INTRA_DISTRIBUTED_OPTIMIZER_INSTANCE_GROUP is not None
@@ -2457,6 +2738,10 @@ def get_inter_distributed_optimizer_instance_group(check_initialized=True):
     """Get the group spanning the different distributed optimizer instances.
     Attention and MLP/Expert share same inter-instance group, so only built
     inter_partial_expert_data_parallel_group, and return it at here.
+
+    Deprecated: reads the global parallel state. Pass an explicit process group from the
+    caller instead -- this returns the wrong group for models built on independent
+    parallel grids. See docs/developer/parallel-state-deprecation.md.
     """
     if check_initialized:
         assert _INTER_PARTIAL_EXPERT_DATA_PARALLEL_GROUP is not None, (

--- a/megatron/core/process_groups_config.py
+++ b/megatron/core/process_groups_config.py
@@ -167,8 +167,18 @@ class ProcessGroupCollection:
 
     @classmethod
     def use_mpu_process_groups(cls, required_pgs: Optional[List[str]] = None):
-        """
-        Use the default process groups from parallel_state.
+        """Build a collection from the global process groups in ``parallel_state``.
+
+        .. warning::
+            **This is a backward-compatibility shim, not a migration target.** It reads the
+            single global parallel grid from :mod:`megatron.core.parallel_state`, so it carries
+            exactly the same problem as calling ``parallel_state.get_*_group()`` directly:
+            for a model built on **independent** parallel grids it returns the wrong grid, and
+            the result is silently incorrect.
+
+            Replacing a direct ``parallel_state`` accessor with this method is a lateral move,
+            not progress. New code must accept a ``ProcessGroupCollection`` from its caller.
+            Existing call sites are being removed; do not add more.
 
         Args:
             required_pgs (List[str], optional): List of process group names to initialize.

--- a/megatron/core/process_groups_config.py
+++ b/megatron/core/process_groups_config.py
@@ -208,8 +208,18 @@ class ProcessGroupCollection:
 
     @classmethod
     def use_mpu_process_groups(cls, required_pgs: Optional[List[str]] = None):
-        """
-        Use the default process groups from parallel_state.
+        """Build a collection from the global process groups in ``parallel_state``.
+
+        .. warning::
+            **This is a backward-compatibility shim, not a migration target.** It reads the
+            single global parallel grid from :mod:`megatron.core.parallel_state`, so it carries
+            exactly the same problem as calling ``parallel_state.get_*_group()`` directly:
+            for a model built on **independent** parallel grids it returns the wrong grid, and
+            the result is silently incorrect.
+
+            Replacing a direct ``parallel_state`` accessor with this method is a lateral move,
+            not progress. New code must accept a ``ProcessGroupCollection`` from its caller.
+            Existing call sites are being removed; do not add more.
 
         Args:
             required_pgs (List[str], optional): List of process group names to initialize.


### PR DESCRIPTION
Global `parallel_state` accessors cannot select an independent model's parallel grid. Document caller-provided `ProcessGroupCollection` / `ProcessGroup` arguments as the migration path, mark 56 accessors with replacement guidance, and clarify where the compatibility shim remains appropriate.

Include current dense/expert and GTP-remat group mappings, global versus group-local rank conversion, optional-group and initialization semantics, and the limits of physical pipeline-stage helpers. This is documentation-only: executable ASTs for both Python files are unchanged from main (`d564dd01de45`).

Validation: Black 26.3.0, isort, Ruff, pylint, syntax, and `git diff --check` pass. The local mypy run reports the same 13 dependency/type diagnostics as main. No GPU execution is needed for this documentation-only change.

Related to #6307.
