### PR TITLE
Add a CI ratchet for global process-group reads in megatron/core

### DIFF
--- a/.github/workflows/process-group-usage-check.yml
+++ b/.github/workflows/process-group-usage-check.yml
@@ -1,0 +1,49 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Process group usage check
+
+on:
+  push:
+    branches:
+      - "pull-request/[0-9]+"
+      - "deploy-release/*"
+  merge_group:
+    types: [checks_requested]
+
+jobs:
+  pre-flight:
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_cicd_preflight.yml@v1.0.0
+    if: github.repository == 'NVIDIA/Megatron-LM'
+
+  process-group-usage-check:
+    needs: [pre-flight]
+    if: |
+      !(needs.pre-flight.outputs.docs_only == 'true'
+      || needs.pre-flight.outputs.is_merge_group == 'true'
+      || needs.pre-flight.outputs.is_deployment_workflow == 'true')
+      && github.repository == 'NVIDIA/Megatron-LM'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # No third-party dependencies: the checker is stdlib-only (ast + json).
+      - name: Check for new global process-group reads in megatron/core
+        run: python tools/check_process_group_usage.py

--- a/tests/unit_tests/test_check_process_group_usage.py
+++ b/tests/unit_tests/test_check_process_group_usage.py
@@ -1,0 +1,129 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Tests for the global process-group usage ratchet (``tools/check_process_group_usage.py``).
+
+These exercise the checker's own logic only -- no torch, no distributed init. (The enclosing
+``tests.unit_tests`` package imports torch, so they run as part of the normal unit-test suite;
+the checker itself is stdlib-only and the CI workflow invokes it directly, without pytest.)
+"""
+
+import importlib.util
+import pathlib
+import sys
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+CHECKER = REPO_ROOT / "tools" / "check_process_group_usage.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("check_process_group_usage", CHECKER)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def checker():
+    return _load()
+
+
+def _hits(checker, tmp_path, source):
+    f = tmp_path / "sample.py"
+    f.write_text(source, encoding="utf-8")
+    return [d for _, _, d in checker._violations_in(f)]
+
+
+def test_flags_qualified_accessor(checker, tmp_path):
+    hits = _hits(
+        checker,
+        tmp_path,
+        "from megatron.core import parallel_state\n"
+        "g = parallel_state.get_tensor_model_parallel_group()\n",
+    )
+    assert "parallel_state.get_tensor_model_parallel_group" in hits
+
+
+def test_flags_directly_imported_accessor(checker, tmp_path):
+    hits = _hits(
+        checker,
+        tmp_path,
+        "from megatron.core.parallel_state import "
+        "get_data_parallel_group\n"
+        "g = get_data_parallel_group()\n",
+    )
+    assert "get_data_parallel_group" in hits
+
+
+def test_flags_the_use_mpu_shim(checker, tmp_path):
+    """The PR #5916 'lateral move' must not pass as a migration."""
+    hits = _hits(checker, tmp_path, "pgs = ProcessGroupCollection.use_mpu_process_groups()\n")
+    assert "use_mpu_process_groups" in hits
+
+
+def test_flags_rank_and_world_size_accessors(checker, tmp_path):
+    hits = _hits(
+        checker,
+        tmp_path,
+        "from megatron.core import parallel_state\n"
+        "r = parallel_state.get_tensor_model_parallel_rank()\n"
+        "n = parallel_state.get_data_parallel_world_size()\n",
+    )
+    assert len(hits) == 2
+
+
+def test_ignores_the_long_term_surface(checker, tmp_path):
+    """initialize / destroy / is_initialized are not deprecated."""
+    hits = _hits(
+        checker,
+        tmp_path,
+        "from megatron.core import parallel_state\n"
+        "parallel_state.initialize_model_parallel()\n"
+        "parallel_state.destroy_model_parallel()\n"
+        "parallel_state.is_initialized()\n",
+    )
+    assert hits == []
+
+
+def test_ignores_tier4_globals_with_no_replacement(checker, tmp_path):
+    """Virtual-pipeline and memory-buffer globals have no ProcessGroupCollection equivalent."""
+    hits = _hits(
+        checker,
+        tmp_path,
+        "from megatron.core import parallel_state\n"
+        "parallel_state.get_virtual_pipeline_model_parallel_rank()\n"
+        "parallel_state.get_global_memory_buffer()\n"
+        "parallel_state.get_nccl_options()\n",
+    )
+    assert hits == []
+
+
+def test_does_not_flag_unrelated_getters(checker, tmp_path):
+    hits = _hits(checker, tmp_path, "x = config.get_thing_group()\n" "y = some_object.get_rank()\n")
+    assert hits == []
+
+
+def test_allowlist_matches_the_tree(checker):
+    """The committed allowlist must describe reality, or the ratchet is meaningless."""
+    found = checker.scan()
+    allowed = checker._load_allowlist()
+    new = {f: sorted(set(h) - set(allowed.get(f, []))) for f, h in found.items()}
+    new = {f: h for f, h in new.items() if h}
+    assert not new, (
+        f"new global process-group reads not in the allowlist: {new}. "
+        "megatron/core must not read process groups from parallel_state."
+    )
+
+
+def test_allowlist_has_no_stale_entries(checker):
+    """The allowlist must only shrink; stale entries mean it was not refreshed after a removal."""
+    found = checker.scan()
+    allowed = checker._load_allowlist()
+    stale = {f: sorted(set(h) - set(found.get(f, []))) for f, h in allowed.items()}
+    stale = {f: h for f, h in stale.items() if h}
+    assert not stale, (
+        f"allowlist references sites that no longer exist: {stale}. "
+        "Refresh with `python tools/check_process_group_usage.py --update`."
+    )

--- a/tools/check_process_group_usage.py
+++ b/tools/check_process_group_usage.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+"""Fail on *new* reads of global process-group state in ``megatron/core``.
+
+``megatron.core.parallel_state`` holds the process groups for a single, global parallel grid.
+Reading it inside library code is being removed: for a model built on independent parallel grids
+it returns the wrong grid, silently. See ``docs/developer/parallel-state-deprecation.md``.
+
+This check is a ratchet, not a cleanup. Every existing violation is recorded in an allowlist so
+the build stays green; the check fails only when a *new* one appears, or when the allowlist
+claims a violation that no longer exists (so the allowlist shrinks as the migration lands).
+
+Usage::
+
+    python tools/check_process_group_usage.py            # check
+    python tools/check_process_group_usage.py --update   # regenerate the allowlist
+    python tools/check_process_group_usage.py --stats    # summarize without failing
+"""
+
+import argparse
+import ast
+import json
+import pathlib
+import sys
+from collections import Counter
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+SCAN_ROOT = REPO_ROOT / "megatron" / "core"
+ALLOWLIST = REPO_ROOT / "tools" / "process_group_usage_allowlist.json"
+
+# Files permitted to read global state: the module itself, the collection that bridges to it,
+# and the compatibility helper. Everything else in megatron/core is subject to the ratchet.
+EXEMPT = {"megatron/core/parallel_state.py", "megatron/core/process_groups_config.py"}
+
+# Accessors that read the global grid. Deliberately excludes initialize/destroy/is_initialized
+# (the intended long-term surface) and the virtual-pipeline and memory-buffer globals, which have
+# no replacement yet and are tracked separately.
+DEPRECATED_PREFIXES = ("get_",)
+DEPRECATED_SUFFIXES = ("_group", "_groups", "_rank", "_world_size", "_src_rank")
+NOT_DEPRECATED = {
+    "get_nccl_options",
+    "get_all_ranks",
+    "get_global_memory_buffer",
+    "get_virtual_pipeline_model_parallel_rank",
+    "get_virtual_pipeline_model_parallel_world_size",
+}
+
+
+def _is_deprecated_accessor(name: str) -> bool:
+    if name in NOT_DEPRECATED:
+        return False
+    return name.startswith(DEPRECATED_PREFIXES) and name.endswith(DEPRECATED_SUFFIXES)
+
+
+def _violations_in(path: pathlib.Path):
+    """Yield (lineno, kind, detail) for global process-group reads in one file."""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except SyntaxError:
+        return
+
+    # Names imported directly from parallel_state, e.g. `from ..parallel_state import get_x_group`
+    imported = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module and "parallel_state" in node.module:
+            for alias in node.names:
+                if _is_deprecated_accessor(alias.name):
+                    imported.add(alias.asname or alias.name)
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        # parallel_state.get_x_group(...) / mpu.get_x_group(...)
+        if isinstance(func, ast.Attribute) and _is_deprecated_accessor(func.attr):
+            base = func.value
+            if isinstance(base, ast.Name) and base.id in ("parallel_state", "mpu", "ps"):
+                yield node.lineno, "accessor", f"{base.id}.{func.attr}"
+        # bare get_x_group(...) imported from parallel_state
+        elif isinstance(func, ast.Name) and func.id in imported:
+            yield node.lineno, "accessor", func.id
+        # ProcessGroupCollection.use_mpu_process_groups(...)
+        elif isinstance(func, ast.Attribute) and func.attr == "use_mpu_process_groups":
+            yield node.lineno, "shim", "use_mpu_process_groups"
+
+
+def scan():
+    """Return {relative path: sorted list of "lineno:kind:detail"}."""
+    found = {}
+    for path in sorted(SCAN_ROOT.rglob("*.py")):
+        rel = path.relative_to(REPO_ROOT).as_posix()
+        if rel in EXEMPT:
+            continue
+        hits = [f"{ln}:{kind}:{detail}" for ln, kind, detail in _violations_in(path)]
+        if hits:
+            found[rel] = sorted(set(hits))
+    return found
+
+
+def _load_allowlist():
+    if not ALLOWLIST.exists():
+        return {}
+    return json.loads(ALLOWLIST.read_text(encoding="utf-8")).get("allowed", {})
+
+
+def _counts(found):
+    c = Counter()
+    for hits in found.values():
+        for h in hits:
+            c[h.split(":", 2)[1]] += 1
+    return c
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--update", action="store_true", help="regenerate the allowlist")
+    ap.add_argument("--stats", action="store_true", help="summarize without failing")
+    args = ap.parse_args()
+
+    found = scan()
+    counts = _counts(found)
+    total = sum(counts.values())
+
+    if args.update:
+        ALLOWLIST.write_text(
+            json.dumps(
+                {
+                    "_comment": (
+                        "Grandfathered reads of global process-group state in megatron/core. "
+                        "This list must only shrink. Regenerate with "
+                        "`python tools/check_process_group_usage.py --update` after REMOVING "
+                        "usage -- never to silence a new violation."
+                    ),
+                    "total": total,
+                    "allowed": found,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        print(
+            f"Wrote {ALLOWLIST.relative_to(REPO_ROOT)}: {total} grandfathered site(s) "
+            f"across {len(found)} file(s)."
+        )
+        return 0
+
+    if args.stats:
+        print(f"{total} global process-group read(s) across {len(found)} file(s) in megatron/core")
+        for kind, n in counts.most_common():
+            print(f"  {kind:10} {n}")
+        return 0
+
+    allowed = _load_allowlist()
+
+    added, removed = {}, {}
+    for rel, hits in found.items():
+        new = sorted(set(hits) - set(allowed.get(rel, [])))
+        if new:
+            added[rel] = new
+    for rel, hits in allowed.items():
+        gone = sorted(set(hits) - set(found.get(rel, [])))
+        if gone:
+            removed[rel] = gone
+
+    if added:
+        n = sum(len(v) for v in added.values())
+        print(f"ERROR: {n} new read(s) of global process-group state in megatron/core:\n")
+        for rel, hits in sorted(added.items()):
+            for h in hits:
+                ln, kind, detail = h.split(":", 2)
+                print(f"  {rel}:{ln}  {detail}")
+        print(
+            "\nmegatron/core must not read process groups from parallel_state. Accept a "
+            "ProcessGroupCollection or an explicit torch.distributed.ProcessGroup from the "
+            "caller and pass it through.\n"
+            "Note that ProcessGroupCollection.use_mpu_process_groups() is NOT a valid "
+            "replacement -- it reads the same global state.\n"
+            "See docs/developer/parallel-state-deprecation.md\n"
+        )
+        return 1
+
+    if removed:
+        n = sum(len(v) for v in removed.values())
+        print(
+            f"{n} allowlisted site(s) no longer exist -- nice. Refresh the allowlist:\n"
+            f"  python tools/check_process_group_usage.py --update\n"
+        )
+        for rel, hits in sorted(removed.items()):
+            for h in hits:
+                print(f"  {rel}:{h.split(':', 2)[0]}")
+        return 1
+
+    print(f"OK: no new global process-group reads ({total} grandfathered).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/process_group_usage_allowlist.json
+++ b/tools/process_group_usage_allowlist.json
@@ -1,0 +1,308 @@
+{
+  "_comment": "Grandfathered reads of global process-group state in megatron/core. This list must only shrink. Regenerate with `python tools/check_process_group_usage.py --update` after REMOVING usage -- never to silence a new violation.",
+  "allowed": {
+    "megatron/core/datasets/data_schedule.py": [
+      "34:accessor:parallel_state.get_data_parallel_group",
+      "35:accessor:parallel_state.get_data_parallel_group",
+      "36:accessor:parallel_state.get_tensor_model_parallel_group"
+    ],
+    "megatron/core/distributed/finalize_model_grads.py": [
+      "102:accessor:parallel_state.get_pipeline_model_parallel_group",
+      "190:accessor:parallel_state.get_embedding_group",
+      "193:accessor:parallel_state.get_pipeline_model_parallel_group",
+      "285:accessor:parallel_state.get_pipeline_model_parallel_world_size",
+      "305:accessor:parallel_state.get_pipeline_model_parallel_group",
+      "492:accessor:parallel_state.get_tensor_model_parallel_group",
+      "493:accessor:parallel_state.get_pipeline_model_parallel_group",
+      "494:accessor:parallel_state.get_embedding_group",
+      "495:accessor:parallel_state.get_position_embedding_group",
+      "496:accessor:parallel_state.get_data_parallel_group",
+      "540:accessor:parallel_state.get_tensor_and_data_parallel_group"
+    ],
+    "megatron/core/distributed/fsdp/mcore_fsdp_adapter.py": [
+      "329:accessor:parallel_state.get_tensor_model_parallel_group",
+      "330:accessor:parallel_state.get_expert_tensor_parallel_group",
+      "332:accessor:parallel_state.get_data_parallel_group",
+      "335:accessor:parallel_state.get_inter_distributed_optimizer_instance_group",
+      "336:accessor:parallel_state.get_data_parallel_group",
+      "339:accessor:parallel_state.get_expert_data_parallel_group",
+      "342:accessor:parallel_state.get_expert_data_parallel_group",
+      "345:accessor:parallel_state.get_expert_model_parallel_group",
+      "347:accessor:parallel_state.get_data_parallel_group",
+      "352:accessor:parallel_state.get_expert_data_parallel_group",
+      "353:accessor:parallel_state.get_expert_model_parallel_group"
+    ],
+    "megatron/core/distributed/param_and_grad_buffer.py": [
+      "977:accessor:parallel_state.get_data_and_context_parallel_group",
+      "980:accessor:parallel_state.get_tensor_model_parallel_group"
+    ],
+    "megatron/core/distributed/torch_fully_sharded_data_parallel.py": [
+      "77:accessor:parallel_state.get_data_parallel_group"
+    ],
+    "megatron/core/export/trtllm/trtllm_weights_converter/distributed_trtllm_model_weights_converter.py": [
+      "71:accessor:parallel_state.get_pipeline_model_parallel_world_size",
+      "72:accessor:parallel_state.get_tensor_model_parallel_world_size",
+      "73:accessor:parallel_state.get_tensor_model_parallel_rank",
+      "74:accessor:parallel_state.get_pipeline_model_parallel_rank",
+      "75:accessor:parallel_state.get_tensor_model_parallel_group"
+    ],
+    "megatron/core/extensions/transformer_engine.py": [
+      "1645:accessor:get_tensor_model_parallel_group",
+      "1646:accessor:get_context_parallel_group",
+      "1647:accessor:get_hierarchical_context_parallel_groups",
+      "1691:accessor:get_hierarchical_context_parallel_groups",
+      "1977:shim:use_mpu_process_groups",
+      "2529:accessor:get_tensor_model_parallel_world_size",
+      "2532:accessor:get_tensor_model_parallel_group",
+      "2860:accessor:get_tensor_model_parallel_world_size",
+      "289:accessor:get_amax_reduction_group",
+      "2959:accessor:get_tensor_model_parallel_world_size"
+    ],
+    "megatron/core/fp4_utils.py": [
+      "221:accessor:parallel_state.get_amax_reduction_group"
+    ],
+    "megatron/core/fp8_utils.py": [
+      "641:accessor:parallel_state.get_amax_reduction_group"
+    ],
+    "megatron/core/inference/apis/_llm_base.py": [
+      "270:accessor:parallel_state.get_expert_model_parallel_world_size"
+    ],
+    "megatron/core/inference/communication_utils.py": [
+      "125:accessor:parallel_state.get_pipeline_model_parallel_next_rank",
+      "153:accessor:parallel_state.get_model_parallel_src_rank",
+      "162:accessor:parallel_state.get_model_parallel_group",
+      "179:accessor:parallel_state.get_model_parallel_src_rank",
+      "182:accessor:parallel_state.get_model_parallel_src_rank",
+      "56:accessor:parallel_state.get_pipeline_model_parallel_group",
+      "57:accessor:parallel_state.get_pipeline_model_parallel_last_rank",
+      "94:accessor:parallel_state.get_pipeline_model_parallel_prev_rank"
+    ],
+    "megatron/core/inference/contexts/dynamic_context.py": [
+      "1413:accessor:parallel_state.get_tensor_model_parallel_world_size",
+      "1427:accessor:parallel_state.get_tensor_model_parallel_world_size",
+      "322:accessor:parallel_state.get_pipeline_model_parallel_group",
+      "328:accessor:parallel_state.get_expert_model_parallel_world_size",
+      "329:accessor:parallel_state.get_expert_model_parallel_group"
+    ],
+    "megatron/core/inference/engines/dynamic_engine.py": [
+      "232:shim:use_mpu_process_groups"
+    ],
+    "megatron/core/inference/model_inference_wrappers/abstract_model_inference_wrapper.py": [
+      "59:shim:use_mpu_process_groups"
+    ],
+    "megatron/core/inference/shards.py": [
+      "59:accessor:mpu.get_tensor_model_parallel_world_size",
+      "61:accessor:mpu.get_context_parallel_world_size",
+      "63:accessor:mpu.get_pipeline_model_parallel_world_size",
+      "65:accessor:mpu.get_expert_model_parallel_world_size",
+      "67:accessor:mpu.get_expert_tensor_parallel_world_size"
+    ],
+    "megatron/core/inference/text_generation_controllers/text_generation_controller.py": [
+      "95:accessor:parallel_state.get_pipeline_model_parallel_group"
+    ],
+    "megatron/core/inference/text_generation_server/dynamic_text_gen_server/tokenization.py": [
+      "29:accessor:parallel_state.get_data_parallel_src_rank"
+    ],
+    "megatron/core/inference/text_generation_server/tokenization.py": [
+      "29:accessor:parallel_state.get_data_parallel_src_rank"
+    ],
+    "megatron/core/models/T5/t5_model.py": [
+      "179:shim:use_mpu_process_groups"
+    ],
+    "megatron/core/models/common/embeddings/rope_utils.py": [
+      "288:accessor:parallel_state.get_context_parallel_group"
+    ],
+    "megatron/core/models/common/embeddings/rotary_pos_embedding.py": [
+      "312:accessor:parallel_state.get_context_parallel_group",
+      "89:accessor:parallel_state.get_context_parallel_group"
+    ],
+    "megatron/core/models/common/language_module/language_module.py": [
+      "495:accessor:parallel_state.get_data_parallel_rank",
+      "51:shim:use_mpu_process_groups"
+    ],
+    "megatron/core/models/mimo/partition/utils.py": [
+      "70:accessor:get_context_parallel_group",
+      "73:accessor:get_tensor_model_parallel_group"
+    ],
+    "megatron/core/models/multimodal/context_parallel.py": [
+      "132:accessor:get_context_parallel_world_size",
+      "133:accessor:get_context_parallel_rank",
+      "150:accessor:get_context_parallel_group",
+      "151:accessor:get_context_parallel_world_size",
+      "164:accessor:get_context_parallel_world_size",
+      "184:accessor:get_context_parallel_group",
+      "217:accessor:get_context_parallel_world_size",
+      "221:accessor:get_context_parallel_group",
+      "225:accessor:get_context_parallel_group",
+      "349:accessor:get_context_parallel_world_size",
+      "350:accessor:get_context_parallel_rank"
+    ],
+    "megatron/core/models/multimodal/llava_model.py": [
+      "182:shim:use_mpu_process_groups",
+      "862:accessor:get_context_parallel_group"
+    ],
+    "megatron/core/optimizer/__init__.py": [
+      "689:accessor:parallel_state.get_tensor_model_parallel_group",
+      "773:shim:use_mpu_process_groups",
+      "888:accessor:parallel_state.get_tensor_model_parallel_group"
+    ],
+    "megatron/core/optimizer/optimizer.py": [
+      "278:accessor:parallel_state.get_model_parallel_group"
+    ],
+    "megatron/core/optimizer/qk_clip.py": [
+      "33:accessor:parallel_state.get_data_parallel_group"
+    ],
+    "megatron/core/pipeline_parallel/hybrid_cp_schedule.py": [
+      "516:accessor:parallel_state.get_tensor_model_parallel_src_rank",
+      "517:accessor:parallel_state.get_tensor_model_parallel_group",
+      "554:accessor:parallel_state.get_data_parallel_rank",
+      "555:accessor:parallel_state.get_tensor_model_parallel_rank",
+      "610:accessor:parallel_state.get_data_parallel_group"
+    ],
+    "megatron/core/pipeline_parallel/schedules.py": [
+      "1007:accessor:parallel_state.get_data_parallel_group",
+      "1010:accessor:parallel_state.get_tensor_and_data_parallel_group",
+      "153:accessor:parallel_state.get_pipeline_model_parallel_world_size",
+      "2151:accessor:parallel_state.get_pipeline_model_parallel_group",
+      "2153:accessor:parallel_state.get_tensor_model_parallel_group",
+      "2154:accessor:parallel_state.get_context_parallel_group",
+      "2156:accessor:parallel_state.get_embedding_group",
+      "2157:accessor:parallel_state.get_position_embedding_group",
+      "2158:accessor:parallel_state.get_pipeline_model_parallel_group",
+      "2166:accessor:parallel_state.get_data_parallel_group",
+      "2169:accessor:parallel_state.get_tensor_and_data_parallel_group",
+      "287:accessor:parallel_state.get_context_parallel_world_size",
+      "666:accessor:parallel_state.get_tensor_model_parallel_group",
+      "667:accessor:parallel_state.get_context_parallel_group",
+      "668:accessor:parallel_state.get_embedding_group",
+      "669:accessor:parallel_state.get_pipeline_model_parallel_group",
+      "670:accessor:parallel_state.get_position_embedding_group",
+      "677:accessor:parallel_state.get_data_parallel_group",
+      "680:accessor:parallel_state.get_tensor_and_data_parallel_group",
+      "882:accessor:parallel_state.get_pipeline_model_parallel_world_size",
+      "883:accessor:parallel_state.get_pipeline_model_parallel_rank",
+      "992:accessor:parallel_state.get_pipeline_model_parallel_group",
+      "994:accessor:parallel_state.get_tensor_model_parallel_group",
+      "995:accessor:parallel_state.get_context_parallel_group",
+      "997:accessor:parallel_state.get_embedding_group",
+      "998:accessor:parallel_state.get_pipeline_model_parallel_group",
+      "999:accessor:parallel_state.get_position_embedding_group"
+    ],
+    "megatron/core/resharding/refit.py": [
+      "186:accessor:parallel_state.get_data_parallel_group"
+    ],
+    "megatron/core/ssm/mamba_mixer.py": [
+      "110:accessor:parallel_state.get_tensor_model_parallel_group"
+    ],
+    "megatron/core/tensor_parallel/cross_entropy.py": [
+      "125:accessor:get_tensor_model_parallel_group"
+    ],
+    "megatron/core/tensor_parallel/layers.py": [
+      "101:accessor:get_tensor_model_parallel_rank",
+      "185:accessor:get_tensor_model_parallel_rank",
+      "186:accessor:get_tensor_model_parallel_world_size"
+    ],
+    "megatron/core/tensor_parallel/random.py": [
+      "461:accessor:get_tensor_model_parallel_rank",
+      "463:accessor:get_expert_model_parallel_rank",
+      "465:accessor:get_expert_tensor_parallel_rank"
+    ],
+    "megatron/core/transformer/attention.py": [
+      "1486:accessor:get_data_parallel_rank",
+      "1495:accessor:get_data_parallel_world_size",
+      "1497:accessor:get_data_parallel_group",
+      "1521:accessor:get_tensor_model_parallel_rank",
+      "1522:accessor:get_tensor_model_parallel_world_size",
+      "1524:accessor:get_tensor_model_parallel_group",
+      "1661:accessor:get_tensor_model_parallel_rank",
+      "318:shim:use_mpu_process_groups"
+    ],
+    "megatron/core/transformer/cuda_graphs.py": [
+      "1467:shim:use_mpu_process_groups",
+      "1790:shim:use_mpu_process_groups"
+    ],
+    "megatron/core/transformer/dot_product_attention.py": [
+      "69:shim:use_mpu_process_groups"
+    ],
+    "megatron/core/transformer/experimental_attention_variant/absorbed_mla.py": [
+      "151:shim:use_mpu_process_groups"
+    ],
+    "megatron/core/transformer/experimental_attention_variant/dsa.py": [
+      "100:accessor:parallel_state.get_pipeline_model_parallel_group",
+      "111:accessor:parallel_state.get_data_parallel_group",
+      "705:shim:use_mpu_process_groups"
+    ],
+    "megatron/core/transformer/fsdp_dtensor_checkpoint.py": [
+      "62:accessor:parallel_state.get_expert_model_parallel_world_size",
+      "63:accessor:parallel_state.get_expert_model_parallel_rank"
+    ],
+    "megatron/core/transformer/heterogeneous/linear_replacements.py": [
+      "26:accessor:get_tensor_model_parallel_world_size",
+      "32:accessor:get_tensor_model_parallel_world_size",
+      "34:accessor:get_tensor_model_parallel_rank"
+    ],
+    "megatron/core/transformer/module.py": [
+      "484:accessor:parallel_state.get_pipeline_model_parallel_group",
+      "84:accessor:parallel_state.get_tensor_model_parallel_group"
+    ],
+    "megatron/core/transformer/moe/moe_logging.py": [
+      "257:accessor:parallel_state.get_pipeline_model_parallel_group",
+      "258:accessor:parallel_state.get_data_parallel_group"
+    ],
+    "megatron/core/transformer/moe/moe_utils.py": [
+      "1100:accessor:parallel_state.get_tensor_and_data_parallel_group",
+      "1385:accessor:parallel_state.get_expert_model_parallel_group",
+      "1386:accessor:parallel_state.get_tensor_model_parallel_group",
+      "1387:accessor:parallel_state.get_context_parallel_group",
+      "1388:accessor:parallel_state.get_expert_tensor_parallel_group",
+      "1389:accessor:parallel_state.get_expert_data_parallel_group",
+      "1390:accessor:parallel_state.get_expert_tensor_and_model_parallel_group",
+      "1391:accessor:parallel_state.get_tensor_and_context_parallel_group",
+      "1392:accessor:parallel_state.get_tensor_and_data_parallel_group"
+    ],
+    "megatron/core/transformer/multi_latent_attention.py": [
+      "1236:shim:use_mpu_process_groups",
+      "490:shim:use_mpu_process_groups"
+    ],
+    "megatron/core/transformer/multi_token_prediction.py": [
+      "1374:accessor:parallel_state.get_tensor_model_parallel_group",
+      "1675:shim:use_mpu_process_groups",
+      "531:accessor:parallel_state.get_tensor_model_parallel_world_size",
+      "635:accessor:parallel_state.get_pipeline_model_parallel_rank",
+      "873:accessor:parallel_state.get_data_parallel_group"
+    ],
+    "megatron/core/transformer/pipeline_parallel_layer_layout.py": [
+      "160:accessor:parallel_state.get_pipeline_model_parallel_rank",
+      "178:accessor:parallel_state.get_pipeline_model_parallel_rank"
+    ],
+    "megatron/core/transformer/transformer_block.py": [
+      "276:shim:use_mpu_process_groups",
+      "91:accessor:parallel_state.get_pipeline_model_parallel_rank"
+    ],
+    "megatron/core/transformer/transformer_layer.py": [
+      "1585:accessor:parallel_state.get_tensor_model_parallel_group",
+      "319:shim:use_mpu_process_groups",
+      "51:accessor:parallel_state.get_pipeline_model_parallel_rank"
+    ],
+    "megatron/core/transformer/utils.py": [
+      "133:accessor:parallel_state.get_data_parallel_group",
+      "191:accessor:parallel_state.get_tensor_model_parallel_rank",
+      "192:accessor:parallel_state.get_data_parallel_rank",
+      "222:accessor:parallel_state.get_data_parallel_group",
+      "225:accessor:parallel_state.get_data_parallel_group"
+    ],
+    "megatron/core/utils.py": [
+      "1004:accessor:parallel_state.get_tensor_model_parallel_group",
+      "1005:accessor:parallel_state.get_data_parallel_group",
+      "532:accessor:parallel_state.get_expert_tensor_parallel_group",
+      "536:accessor:parallel_state.get_tensor_model_parallel_group",
+      "819:accessor:parallel_state.get_tensor_model_parallel_rank",
+      "820:accessor:parallel_state.get_data_parallel_rank",
+      "877:accessor:parallel_state.get_data_parallel_group",
+      "877:accessor:parallel_state.get_expert_data_parallel_group",
+      "939:accessor:parallel_state.get_tensor_model_parallel_group",
+      "940:accessor:parallel_state.get_data_parallel_group"
+    ]
+  },
+  "total": 198
+}

--- a/tools/process_group_usage_allowlist.json
+++ b/tools/process_group_usage_allowlist.json
@@ -1,0 +1,326 @@
+{
+  "_comment": "Grandfathered reads of global process-group state in megatron/core. This list must only shrink. Regenerate with `python tools/check_process_group_usage.py --update` after REMOVING usage -- never to silence a new violation.",
+  "allowed": {
+    "megatron/core/datasets/data_schedule.py": [
+      "100:accessor:parallel_state.get_tensor_model_parallel_group",
+      "689:accessor:parallel_state.get_data_parallel_group",
+      "690:accessor:parallel_state.get_data_parallel_group",
+      "691:accessor:parallel_state.get_tensor_model_parallel_group",
+      "692:accessor:parallel_state.get_pipeline_model_parallel_group",
+      "761:accessor:parallel_state.get_tensor_model_parallel_group",
+      "762:accessor:parallel_state.get_pipeline_model_parallel_group",
+      "763:accessor:parallel_state.get_context_parallel_group",
+      "98:accessor:parallel_state.get_data_parallel_group",
+      "99:accessor:parallel_state.get_data_parallel_group"
+    ],
+    "megatron/core/distributed/finalize_model_grads.py": [
+      "102:accessor:parallel_state.get_pipeline_model_parallel_group",
+      "190:accessor:parallel_state.get_embedding_group",
+      "193:accessor:parallel_state.get_pipeline_model_parallel_group",
+      "285:accessor:parallel_state.get_pipeline_model_parallel_world_size",
+      "305:accessor:parallel_state.get_pipeline_model_parallel_group",
+      "607:accessor:parallel_state.get_tensor_model_parallel_group",
+      "608:accessor:parallel_state.get_pipeline_model_parallel_group",
+      "609:accessor:parallel_state.get_embedding_group",
+      "610:accessor:parallel_state.get_position_embedding_group",
+      "611:accessor:parallel_state.get_data_parallel_group",
+      "612:accessor:parallel_state.get_gtp_weight_remat_group",
+      "613:accessor:parallel_state.get_expert_gtp_weight_remat_group",
+      "684:accessor:parallel_state.get_tensor_and_data_parallel_group"
+    ],
+    "megatron/core/distributed/fsdp/mcore_fsdp_adapter.py": [
+      "391:accessor:parallel_state.get_tensor_model_parallel_group",
+      "392:accessor:parallel_state.get_expert_tensor_parallel_group",
+      "394:accessor:parallel_state.get_data_parallel_group",
+      "397:accessor:parallel_state.get_inter_distributed_optimizer_instance_group",
+      "398:accessor:parallel_state.get_data_parallel_group",
+      "401:accessor:parallel_state.get_expert_data_parallel_group",
+      "404:accessor:parallel_state.get_expert_data_parallel_group",
+      "407:accessor:parallel_state.get_expert_model_parallel_group",
+      "409:accessor:parallel_state.get_data_parallel_group",
+      "414:accessor:parallel_state.get_expert_data_parallel_group",
+      "415:accessor:parallel_state.get_expert_model_parallel_group"
+    ],
+    "megatron/core/distributed/param_and_grad_buffer.py": [
+      "1090:accessor:parallel_state.get_data_and_context_parallel_group",
+      "1093:accessor:parallel_state.get_tensor_model_parallel_group"
+    ],
+    "megatron/core/distributed/torch_fully_sharded_data_parallel.py": [
+      "77:accessor:parallel_state.get_data_parallel_group"
+    ],
+    "megatron/core/export/trtllm/trtllm_weights_converter/distributed_trtllm_model_weights_converter.py": [
+      "71:accessor:parallel_state.get_pipeline_model_parallel_world_size",
+      "72:accessor:parallel_state.get_tensor_model_parallel_world_size",
+      "73:accessor:parallel_state.get_tensor_model_parallel_rank",
+      "74:accessor:parallel_state.get_pipeline_model_parallel_rank",
+      "75:accessor:parallel_state.get_tensor_model_parallel_group"
+    ],
+    "megatron/core/extensions/transformer_engine.py": [
+      "2142:accessor:get_tensor_model_parallel_group",
+      "2143:accessor:get_context_parallel_group",
+      "2144:accessor:get_hierarchical_context_parallel_groups",
+      "2188:accessor:get_hierarchical_context_parallel_groups",
+      "2500:shim:use_mpu_process_groups",
+      "3236:accessor:get_tensor_model_parallel_world_size",
+      "326:accessor:get_amax_reduction_group",
+      "3339:accessor:get_tensor_model_parallel_world_size",
+      "3368:accessor:get_tensor_model_parallel_world_size",
+      "873:accessor:get_tensor_model_parallel_world_size",
+      "876:accessor:get_tensor_model_parallel_group"
+    ],
+    "megatron/core/fp4_utils.py": [
+      "268:accessor:parallel_state.get_amax_reduction_group"
+    ],
+    "megatron/core/fp8_utils.py": [
+      "859:accessor:parallel_state.get_amax_reduction_group"
+    ],
+    "megatron/core/inference/apis/_llm_base.py": [
+      "275:accessor:parallel_state.get_expert_model_parallel_world_size"
+    ],
+    "megatron/core/inference/communication_utils.py": [
+      "125:accessor:parallel_state.get_pipeline_model_parallel_next_rank",
+      "153:accessor:parallel_state.get_model_parallel_src_rank",
+      "162:accessor:parallel_state.get_model_parallel_group",
+      "179:accessor:parallel_state.get_model_parallel_src_rank",
+      "182:accessor:parallel_state.get_model_parallel_src_rank",
+      "56:accessor:parallel_state.get_pipeline_model_parallel_group",
+      "57:accessor:parallel_state.get_pipeline_model_parallel_last_rank",
+      "94:accessor:parallel_state.get_pipeline_model_parallel_prev_rank"
+    ],
+    "megatron/core/inference/contexts/dynamic_context.py": [
+      "1667:accessor:parallel_state.get_tensor_model_parallel_world_size",
+      "1681:accessor:parallel_state.get_tensor_model_parallel_world_size",
+      "417:accessor:parallel_state.get_pipeline_model_parallel_group",
+      "423:accessor:parallel_state.get_expert_model_parallel_world_size",
+      "424:accessor:parallel_state.get_expert_model_parallel_group"
+    ],
+    "megatron/core/inference/engines/dynamic_engine.py": [
+      "344:shim:use_mpu_process_groups"
+    ],
+    "megatron/core/inference/model_inference_wrappers/abstract_model_inference_wrapper.py": [
+      "67:shim:use_mpu_process_groups"
+    ],
+    "megatron/core/inference/shards.py": [
+      "59:accessor:mpu.get_tensor_model_parallel_world_size",
+      "61:accessor:mpu.get_context_parallel_world_size",
+      "63:accessor:mpu.get_pipeline_model_parallel_world_size",
+      "65:accessor:mpu.get_expert_model_parallel_world_size",
+      "67:accessor:mpu.get_expert_tensor_parallel_world_size"
+    ],
+    "megatron/core/inference/text_generation_controllers/text_generation_controller.py": [
+      "235:accessor:parallel_state.get_pipeline_model_parallel_group",
+      "236:accessor:parallel_state.get_data_parallel_group"
+    ],
+    "megatron/core/inference/text_generation_server/dynamic_text_gen_server/tokenization.py": [
+      "29:accessor:parallel_state.get_data_parallel_src_rank"
+    ],
+    "megatron/core/inference/text_generation_server/tokenization.py": [
+      "29:accessor:parallel_state.get_data_parallel_src_rank"
+    ],
+    "megatron/core/models/T5/t5_model.py": [
+      "179:shim:use_mpu_process_groups"
+    ],
+    "megatron/core/models/common/embeddings/rope_utils.py": [
+      "336:accessor:parallel_state.get_context_parallel_group"
+    ],
+    "megatron/core/models/common/embeddings/rotary_pos_embedding.py": [
+      "357:accessor:parallel_state.get_context_parallel_group",
+      "89:accessor:parallel_state.get_context_parallel_group"
+    ],
+    "megatron/core/models/common/language_module/language_module.py": [
+      "512:accessor:parallel_state.get_data_parallel_rank",
+      "51:shim:use_mpu_process_groups"
+    ],
+    "megatron/core/models/mimo/partition/utils.py": [
+      "70:accessor:get_context_parallel_group",
+      "73:accessor:get_tensor_model_parallel_group"
+    ],
+    "megatron/core/models/multimodal/context_parallel.py": [
+      "132:accessor:get_context_parallel_world_size",
+      "133:accessor:get_context_parallel_rank",
+      "150:accessor:get_context_parallel_group",
+      "151:accessor:get_context_parallel_world_size",
+      "164:accessor:get_context_parallel_world_size",
+      "184:accessor:get_context_parallel_group",
+      "217:accessor:get_context_parallel_world_size",
+      "221:accessor:get_context_parallel_group",
+      "225:accessor:get_context_parallel_group",
+      "349:accessor:get_context_parallel_world_size",
+      "350:accessor:get_context_parallel_rank"
+    ],
+    "megatron/core/models/multimodal/llava_model.py": [
+      "159:shim:use_mpu_process_groups"
+    ],
+    "megatron/core/optimizer/__init__.py": [
+      "698:shim:use_mpu_process_groups",
+      "787:shim:use_mpu_process_groups"
+    ],
+    "megatron/core/optimizer/optimizer.py": [
+      "340:accessor:parallel_state.get_model_parallel_group",
+      "940:accessor:parallel_state.get_tensor_model_parallel_group",
+      "942:accessor:parallel_state.get_data_parallel_group"
+    ],
+    "megatron/core/optimizer/qk_clip.py": [
+      "33:accessor:parallel_state.get_data_parallel_group"
+    ],
+    "megatron/core/pipeline_parallel/hybrid_cp_schedule.py": [
+      "516:accessor:parallel_state.get_tensor_model_parallel_src_rank",
+      "517:accessor:parallel_state.get_tensor_model_parallel_group",
+      "580:accessor:parallel_state.get_data_parallel_rank",
+      "581:accessor:parallel_state.get_tensor_model_parallel_rank",
+      "635:accessor:parallel_state.get_data_parallel_group"
+    ],
+    "megatron/core/pipeline_parallel/schedules.py": [
+      "1053:accessor:parallel_state.get_pipeline_model_parallel_group",
+      "158:accessor:parallel_state.get_pipeline_model_parallel_world_size",
+      "2197:accessor:parallel_state.get_pipeline_model_parallel_group",
+      "319:accessor:parallel_state.get_context_parallel_world_size",
+      "686:accessor:parallel_state.get_tensor_model_parallel_group",
+      "687:accessor:parallel_state.get_context_parallel_group",
+      "688:accessor:parallel_state.get_embedding_group",
+      "689:accessor:parallel_state.get_position_embedding_group",
+      "690:accessor:parallel_state.get_pipeline_model_parallel_group",
+      "691:accessor:parallel_state.get_data_parallel_group",
+      "694:accessor:parallel_state.get_tensor_and_data_parallel_group",
+      "697:accessor:parallel_state.get_data_parallel_group",
+      "702:accessor:parallel_state.get_gtp_weight_remat_group",
+      "703:accessor:parallel_state.get_expert_gtp_weight_remat_group",
+      "706:accessor:parallel_state.get_data_parallel_group",
+      "943:accessor:parallel_state.get_pipeline_model_parallel_world_size",
+      "944:accessor:parallel_state.get_pipeline_model_parallel_rank"
+    ],
+    "megatron/core/resharding/refit.py": [
+      "230:accessor:parallel_state.get_data_parallel_group"
+    ],
+    "megatron/core/ssm/mamba_mixer.py": [
+      "121:accessor:parallel_state.get_tensor_model_parallel_group"
+    ],
+    "megatron/core/tensor_parallel/cross_entropy.py": [
+      "125:accessor:get_tensor_model_parallel_group"
+    ],
+    "megatron/core/tensor_parallel/generalized_tensor_parallelism.py": [
+      "2735:accessor:parallel_state.get_expert_data_parallel_rank",
+      "2736:accessor:parallel_state.get_data_parallel_rank"
+    ],
+    "megatron/core/tensor_parallel/layers.py": [
+      "110:accessor:get_tensor_model_parallel_rank",
+      "134:accessor:get_expert_gtp_weight_remat_rank",
+      "135:accessor:get_gtp_weight_remat_rank",
+      "274:accessor:get_tensor_model_parallel_rank",
+      "275:accessor:get_tensor_model_parallel_world_size"
+    ],
+    "megatron/core/tensor_parallel/random.py": [
+      "478:accessor:get_tensor_model_parallel_rank",
+      "480:accessor:get_expert_model_parallel_rank",
+      "482:accessor:get_expert_tensor_parallel_rank",
+      "484:accessor:get_gtp_weight_remat_rank",
+      "486:accessor:get_expert_gtp_weight_remat_rank",
+      "488:accessor:get_gtp_weight_remat_world_size",
+      "490:accessor:get_expert_gtp_weight_remat_world_size"
+    ],
+    "megatron/core/transformer/attention.py": [
+      "1817:accessor:get_data_parallel_rank",
+      "1826:accessor:get_data_parallel_world_size",
+      "1828:accessor:get_data_parallel_group",
+      "1852:accessor:get_tensor_model_parallel_rank",
+      "1853:accessor:get_tensor_model_parallel_world_size",
+      "1855:accessor:get_tensor_model_parallel_group",
+      "1992:accessor:get_tensor_model_parallel_rank",
+      "338:shim:use_mpu_process_groups"
+    ],
+    "megatron/core/transformer/cuda_graphs.py": [
+      "1100:shim:use_mpu_process_groups",
+      "1913:shim:use_mpu_process_groups",
+      "2236:shim:use_mpu_process_groups"
+    ],
+    "megatron/core/transformer/dot_product_attention.py": [
+      "69:shim:use_mpu_process_groups"
+    ],
+    "megatron/core/transformer/experimental_attention_variant/absorbed_mla.py": [
+      "153:shim:use_mpu_process_groups"
+    ],
+    "megatron/core/transformer/experimental_attention_variant/dsa.py": [
+      "1277:shim:use_mpu_process_groups",
+      "1724:shim:use_mpu_process_groups"
+    ],
+    "megatron/core/transformer/fsdp_dtensor_checkpoint.py": [
+      "84:accessor:parallel_state.get_expert_model_parallel_world_size",
+      "85:accessor:parallel_state.get_expert_model_parallel_rank"
+    ],
+    "megatron/core/transformer/heterogeneous/linear_replacements.py": [
+      "26:accessor:get_tensor_model_parallel_world_size",
+      "32:accessor:get_tensor_model_parallel_world_size",
+      "34:accessor:get_tensor_model_parallel_rank"
+    ],
+    "megatron/core/transformer/module.py": [
+      "555:accessor:parallel_state.get_pipeline_model_parallel_group",
+      "93:accessor:parallel_state.get_tensor_model_parallel_group"
+    ],
+    "megatron/core/transformer/moe/batch_invariant.py": [
+      "81:accessor:parallel_state.get_expert_model_parallel_world_size"
+    ],
+    "megatron/core/transformer/moe/moe_logging.py": [
+      "263:accessor:parallel_state.get_pipeline_model_parallel_group",
+      "272:accessor:parallel_state.get_data_parallel_group"
+    ],
+    "megatron/core/transformer/moe/moe_utils.py": [
+      "1220:accessor:parallel_state.get_tensor_and_data_parallel_group",
+      "1521:accessor:parallel_state.get_expert_model_parallel_group",
+      "1522:accessor:parallel_state.get_tensor_model_parallel_group",
+      "1523:accessor:parallel_state.get_context_parallel_group",
+      "1524:accessor:parallel_state.get_expert_tensor_parallel_group",
+      "1525:accessor:parallel_state.get_expert_data_parallel_group",
+      "1526:accessor:parallel_state.get_expert_data_parallel_group",
+      "1529:accessor:parallel_state.get_expert_tensor_and_model_parallel_group",
+      "1530:accessor:parallel_state.get_tensor_and_context_parallel_group",
+      "1531:accessor:parallel_state.get_tensor_and_data_parallel_group"
+    ],
+    "megatron/core/transformer/multi_latent_attention.py": [
+      "1384:shim:use_mpu_process_groups",
+      "570:shim:use_mpu_process_groups"
+    ],
+    "megatron/core/transformer/multi_token_prediction.py": [
+      "1164:accessor:parallel_state.get_data_parallel_group",
+      "1828:accessor:parallel_state.get_tensor_model_parallel_group",
+      "2164:shim:use_mpu_process_groups",
+      "713:accessor:parallel_state.get_tensor_model_parallel_world_size",
+      "826:accessor:parallel_state.get_pipeline_model_parallel_rank",
+      "850:accessor:parallel_state.get_pipeline_model_parallel_world_size",
+      "886:accessor:parallel_state.get_pipeline_model_parallel_rank",
+      "914:accessor:parallel_state.get_pipeline_model_parallel_rank"
+    ],
+    "megatron/core/transformer/pipeline_parallel_layer_layout.py": [
+      "161:accessor:parallel_state.get_pipeline_model_parallel_rank",
+      "179:accessor:parallel_state.get_pipeline_model_parallel_rank"
+    ],
+    "megatron/core/transformer/transformer_block.py": [
+      "283:shim:use_mpu_process_groups",
+      "98:accessor:parallel_state.get_pipeline_model_parallel_rank"
+    ],
+    "megatron/core/transformer/transformer_layer.py": [
+      "2310:accessor:parallel_state.get_tensor_model_parallel_group",
+      "350:shim:use_mpu_process_groups",
+      "70:accessor:parallel_state.get_pipeline_model_parallel_rank"
+    ],
+    "megatron/core/transformer/utils.py": [
+      "134:accessor:parallel_state.get_data_parallel_group",
+      "214:accessor:parallel_state.get_tensor_model_parallel_rank",
+      "215:accessor:parallel_state.get_data_parallel_rank",
+      "245:accessor:parallel_state.get_data_parallel_group",
+      "248:accessor:parallel_state.get_data_parallel_group"
+    ],
+    "megatron/core/utils.py": [
+      "1047:accessor:parallel_state.get_tensor_model_parallel_group",
+      "1048:accessor:parallel_state.get_data_parallel_group",
+      "1179:accessor:parallel_state.get_tensor_model_parallel_group",
+      "1180:accessor:parallel_state.get_data_parallel_group",
+      "626:accessor:parallel_state.get_expert_tensor_parallel_group",
+      "630:accessor:parallel_state.get_tensor_model_parallel_group",
+      "925:accessor:parallel_state.get_tensor_model_parallel_rank",
+      "926:accessor:parallel_state.get_data_parallel_rank",
+      "983:accessor:parallel_state.get_data_parallel_group",
+      "984:accessor:parallel_state.get_expert_data_parallel_group"
+    ]
+  },
+  "total": 212
+}


### PR DESCRIPTION
Core library code still contains calls that read the single global parallel grid. Add a stdlib-only CI ratchet to catch new direct accessors and `ProcessGroupCollection.use_mpu_process_groups()` calls while retaining the current migration baseline.

The baseline records 211 calls across 54 files (190 accessors and 21 compatibility shims). Entries use enclosing function/class and accessor counts, so line shifts do not require a refresh and additional identical calls still fail. `--update` removes stale entries and refuses additions; syntax errors also fail the scan. Imports and import aliases are resolved in their enclosing scopes, with parameters and simple assignments shadowing outer bindings. Global rank-list accessors are included. Dynamic lookups and aliases created through assignment are outside the checker's scope.

Run the checker and its standalone stdlib regression tests on synthetic PR branches and merge groups. Existing lifecycle functions, virtual-pipeline/memory-buffer accessors, `parallel_state.py`, and `process_groups_config.py` remain outside this gate.

Baseline audit against the old PR head: no newly grandfathered sites; PR #6888 removed the `parallel_state.get_data_parallel_rank()` read in `LanguageModule.tie_embeddings_and_output_weights_state_dict`, reducing the old 212-site baseline to 211. The comparison was repeated using the new scoped identities to ensure totals do not hide additions or moves. The three previously missed global-rank-list accessors have no current production callers, so detecting them does not grow the baseline.

Validation: 26 stdlib tests passed on Python 3.12.13; current-tree checker passed; isort, Black 26.3.0, Ruff, Pylint with CLI print allowed, workflow YAML parsing, and `git diff --check` passed. The pinned reusable preflight was read to verify outputs and read permissions. CI itself has not run for this refreshed commit.

Related: #6307.

The allowlist remains review-controlled: direct manual JSON additions can allow new calls. The checker rejects CLI-generated additions but does not compare the committed allowlist against the PR base.
