### PR TITLE
Use explicit GTP replica groups for checkpoints

### DIFF
--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -1334,6 +1334,8 @@ class TELinear(te.pytorch.Linear):
             sharded_offsets,
             tp_group=self._tp_group,
             dp_cp_group=metadata["dp_cp_group"],
+            intra_dp_cp_group=metadata.get("intra_dp_cp_group"),
+            intra_expt_dp_group=metadata.get("intra_expt_dp_group"),
         )
 
     def backward_dw(self):
@@ -1578,6 +1580,8 @@ class TELayerNormColumnParallelLinear(te.pytorch.LayerNormLinear):
             sharded_offsets,
             tp_group=self._tp_group,
             dp_cp_group=metadata["dp_cp_group"],
+            intra_dp_cp_group=metadata.get("intra_dp_cp_group"),
+            intra_expt_dp_group=metadata.get("intra_expt_dp_group"),
         )
 
     @override
@@ -1712,6 +1716,8 @@ class TEColumnParallelLinear(TELinear):
             sharded_offsets,
             tp_group=self._tp_group,
             dp_cp_group=metadata["dp_cp_group"],
+            intra_dp_cp_group=metadata.get("intra_dp_cp_group"),
+            intra_expt_dp_group=metadata.get("intra_expt_dp_group"),
         )
 
     @override
@@ -1969,6 +1975,8 @@ class TERowParallelLinear(TELinear):
             sharded_offsets,
             tp_group=self._tp_group,
             dp_cp_group=metadata["dp_cp_group"],
+            intra_dp_cp_group=metadata.get("intra_dp_cp_group"),
+            intra_expt_dp_group=metadata.get("intra_expt_dp_group"),
         )
 
     @override
@@ -2323,6 +2331,8 @@ class TEDotProductAttention(te.pytorch.DotProductAttention):
             sharded_offsets,
             tp_group=self._tp_group,
             dp_cp_group=metadata["dp_cp_group"],
+            intra_dp_cp_group=metadata.get("intra_dp_cp_group"),
+            intra_expt_dp_group=metadata.get("intra_expt_dp_group"),
         )
 
 
@@ -2783,6 +2793,8 @@ if HAVE_TE and is_te_min_version("1.9.0.dev0"):
                     new_sharded_offsets,
                     tp_group=self._tp_group,
                     dp_cp_group=metadata["dp_cp_group"],
+                    intra_dp_cp_group=metadata.get("intra_dp_cp_group"),
+                    intra_expt_dp_group=metadata.get("intra_expt_dp_group"),
                 )
                 # Remove expert layers indexing from sharded keys
                 replace_prefix_for_sharding(sub_sd, f"{gemm_idx}.", expert_prefix)

--- a/megatron/core/models/common/language_module/language_module.py
+++ b/megatron/core/models/common/language_module/language_module.py
@@ -519,4 +519,6 @@ class LanguageModule(MegatronModule):
             allow_shape_mismatch=True,
             tp_group=self.tp_group,
             dp_cp_group=metadata['dp_cp_group'],
+            intra_dp_cp_group=metadata.get('intra_dp_cp_group'),
+            intra_expt_dp_group=metadata.get('intra_expt_dp_group'),
         )

--- a/megatron/core/models/mimo/model/base.py
+++ b/megatron/core/models/mimo/model/base.py
@@ -98,6 +98,11 @@ class MimoModel(MegatronModule):
         self._initialize_submodules()
         self._initialize_language_model()
 
+    @property
+    def checkpoint_language_model_type(self) -> type[torch.nn.Module]:
+        """Language-model type used by checkpoint compatibility checks on every MIMO rank."""
+        return self.mimo_config.language_model_spec.module
+
     def sharded_state_dict(self, prefix='', sharded_offsets=(), metadata=None):
         """Build sharded state dict, bypassing parallel_state global fallbacks.
 
@@ -125,11 +130,14 @@ class MimoModel(MegatronModule):
                 pg = getattr(pg_src, 'pg_collection', None)
                 mod_metadata = metadata
                 if pg is not None:
-                    assert (
-                        hasattr(pg, 'dp_cp') and pg.dp_cp is not None
-                    ), f"pg_collection on '{name}' is missing dp_cp group"
+                    dp_cp_group = getattr(pg, 'dp_cp_gtp_remat', None) or pg.dp_cp
+                    assert dp_cp_group is not None, (
+                        f"pg_collection on '{name}' is missing a data-parallel group"
+                    )
                     mod_metadata = dict(metadata) if metadata else {}
-                    mod_metadata['dp_cp_group'] = pg.dp_cp
+                    mod_metadata['dp_cp_group'] = dp_cp_group
+                    mod_metadata['intra_dp_cp_group'] = pg.dp_cp
+                    mod_metadata['intra_expt_dp_group'] = getattr(pg, 'expt_dp', None)
                 # Unwrap wrappers so the sharded keys match the raw load_state_dict keys.
                 inner = module
                 child_prefix = f'{prefix}{name}.'

--- a/megatron/core/models/mimo/optimizer.py
+++ b/megatron/core/models/mimo/optimizer.py
@@ -322,7 +322,7 @@ def _restore_grad_scaler(sub_sd):
 def _get_replica_id(pg_collection: Optional[ProcessGroupCollection]) -> tuple:
     """Build replica_id tuple for ShardedObject deduplication.
 
-    Returns (tp_rank, pp_rank, dp_rank) so only (0, 0, 0) within each
+    Returns (tp_gtp_rank, pp_rank, dp_rank) so only (0, 0, 0) within each
     module's parallelism group is the main replica; all other ranks
     in the same module are non-main replicas of the same object.
     """
@@ -336,7 +336,11 @@ def _get_replica_id(pg_collection: Optional[ProcessGroupCollection]) -> tuple:
     assert (
         hasattr(pg_collection, 'dp') and pg_collection.dp is not None
     ), "pg_collection.dp must be set for checkpoint deduplication"
-    return (pg_collection.tp.rank(), pg_collection.pp.rank(), pg_collection.dp.rank())
+    gtp_group = getattr(pg_collection, 'gtp_remat', None)
+    gtp_rank = gtp_group.rank() if gtp_group is not None else 0
+    gtp_size = gtp_group.size() if gtp_group is not None else 1
+    tp_gtp_rank = pg_collection.tp.rank() * gtp_size + gtp_rank
+    return (tp_gtp_rank, pg_collection.pp.rank(), pg_collection.dp.rank())
 
 
 _EXPERT_VIEW = "expert"

--- a/megatron/core/models/mimo/submodules/base.py
+++ b/megatron/core/models/mimo/submodules/base.py
@@ -82,11 +82,15 @@ class ModalitySubmodules(ABC, nn.Module):
         parallel_state global fallback in ensure_metadata_has_dp_cp_group.
         """
         if self.pg_collection is not None:
-            assert (
-                hasattr(self.pg_collection, 'dp_cp') and self.pg_collection.dp_cp is not None
-            ), "pg_collection is missing dp_cp group"
+            dp_cp_group = (
+                getattr(self.pg_collection, 'dp_cp_gtp_remat', None)
+                or self.pg_collection.dp_cp
+            )
+            assert dp_cp_group is not None, "pg_collection is missing a data-parallel group"
             metadata = dict(metadata) if metadata else {}
-            metadata['dp_cp_group'] = self.pg_collection.dp_cp
+            metadata['dp_cp_group'] = dp_cp_group
+            metadata['intra_dp_cp_group'] = self.pg_collection.dp_cp
+            metadata['intra_expt_dp_group'] = getattr(self.pg_collection, 'expt_dp', None)
 
         sharded_sd = {}
         for name, container in self.named_children():

--- a/megatron/core/ssm/mamba_mixer.py
+++ b/megatron/core/ssm/mamba_mixer.py
@@ -128,6 +128,8 @@ class ExtendedRMSNorm(RMSNormGated):
             sharded_offsets,
             tp_group=self.tp_group,
             dp_cp_group=metadata["dp_cp_group"],
+            intra_dp_cp_group=metadata.get("intra_dp_cp_group"),
+            intra_expt_dp_group=metadata.get("intra_expt_dp_group"),
         )
 
 
@@ -1430,6 +1432,8 @@ class MambaMixer(MegatronModule):
             sharded_offsets=sharded_offsets,
             tp_group=self.tp_group,
             dp_cp_group=metadata["dp_cp_group"],
+            intra_dp_cp_group=metadata.get("intra_dp_cp_group"),
+            intra_expt_dp_group=metadata.get("intra_expt_dp_group"),
         )
         # Submodules
         for name, module in self.named_children():
@@ -1481,6 +1485,8 @@ class MambaMixer(MegatronModule):
                 prepend_offsets=sharded_offsets,
                 tp_group=self.tp_group,
                 dp_cp_group=metadata['dp_cp_group'],
+                intra_dp_cp_group=metadata.get('intra_dp_cp_group'),
+                intra_expt_dp_group=metadata.get('intra_expt_dp_group'),
             )
 
         assert sharded_state_dict[f"{prefix}in_proj.weight"].data.size(0) == in_proj_dim, (

--- a/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
+++ b/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
@@ -2149,6 +2149,7 @@ def make_sharded_tensors_for_checkpoint_with_gtp_remat(
     tp_group,
     dp_cp_group,
     intra_dp_cp_group=None,
+    intra_expt_dp_group=None,
 ):
     """GTP-aware analogue of make_sharded_tensors_for_checkpoint.
 
@@ -2190,15 +2191,21 @@ def make_sharded_tensors_for_checkpoint_with_gtp_remat(
     gtp_rank = get_pg_rank(gtp_remat_group)
     gtp_remat_size = get_pg_size(gtp_remat_group)
 
-    # Replicate-group rank — the true replicas of a given GTP chunk live here.
-    if intra_dp_cp_group is not None:
-        dp_replica_rank = get_pg_rank(intra_dp_cp_group)
-    else:
+    def replica_rank(tensor):
+        """Rank in the GTP-excluded dense or expert replica group."""
+        replica_group = intra_dp_cp_group
+        if not getattr(tensor, 'allreduce', True) and intra_expt_dp_group is not None:
+            replica_group = intra_expt_dp_group
+        if replica_group is not None:
+            return get_pg_rank(replica_group)
         from megatron.core import parallel_state  # noqa: E402
 
-        dp_replica_rank = parallel_state.get_data_parallel_rank(
+        return parallel_state.get_data_parallel_rank(
             with_context_parallel=True, with_gtp_remat=False
         )
+
+    # Extra-state objects carry no tensor attributes; use the module's GTP weight kind.
+    gtp_template = next(t for t in state_dict.values() if is_gtp_param(t))
 
     sharded_state_dict = {}
     for layer_name, tensor in state_dict.items():
@@ -2209,7 +2216,11 @@ def make_sharded_tensors_for_checkpoint_with_gtp_remat(
             # ShardedObject (extra_state metadata): GTP-REPLICATED across the GTP group. Fold
             # gtp_rank into position 1 of the replica_id (PP, TP-replica-coord, DP) tuple so
             # GTP-peer ranks within the same TP slice get unique replica_ids.
-            replica_id = (0, tp_rank * gtp_remat_size + gtp_rank, dp_replica_rank)
+            replica_id = (
+                0,
+                tp_rank * gtp_remat_size + gtp_rank,
+                replica_rank(gtp_template),
+            )
             sharded_state_dict[layer_key] = make_sharded_object_for_checkpoint(
                 tensor, layer_key, sharded_offsets, replica_id=replica_id
             )
@@ -2220,7 +2231,7 @@ def make_sharded_tensors_for_checkpoint_with_gtp_remat(
             # ranks would collide on the same replica_id. Inject gtp_rank into replica_id
             # position 1 (same as the GTP-sharded branch below).
             if layer_name in tensor_parallel_layers_axis_map:
-                replica_id = (0, gtp_rank, dp_replica_rank)
+                replica_id = (0, gtp_rank, replica_rank(tensor))
                 sharded_state_dict[layer_key] = make_tp_sharded_tensor_for_checkpoint(
                     tensor,
                     layer_key,
@@ -2229,9 +2240,15 @@ def make_sharded_tensors_for_checkpoint_with_gtp_remat(
                     prepend_offsets=sharded_offsets,
                     tp_group=tp_group,
                     dp_cp_group=dp_cp_group,
+                    intra_dp_cp_group=intra_dp_cp_group,
+                    intra_expt_dp_group=intra_expt_dp_group,
                 )
             else:
-                replica_id = (0, tp_rank * gtp_remat_size + gtp_rank, dp_replica_rank)
+                replica_id = (
+                    0,
+                    tp_rank * gtp_remat_size + gtp_rank,
+                    replica_rank(tensor),
+                )
                 sharded_state_dict[layer_key] = make_sharded_tensor_for_checkpoint(
                     tensor,
                     layer_key,
@@ -2253,6 +2270,8 @@ def make_sharded_tensors_for_checkpoint_with_gtp_remat(
             prepend_offsets=sharded_offsets,
             tp_group=tp_group,
             dp_cp_group=dp_cp_group,
+            intra_dp_cp_group=intra_dp_cp_group,
+            intra_expt_dp_group=intra_expt_dp_group,
         )
 
     return sharded_state_dict

--- a/megatron/core/tensor_parallel/layers.py
+++ b/megatron/core/tensor_parallel/layers.py
@@ -396,6 +396,8 @@ class VocabParallelEmbedding(torch.nn.Module):
                 prepend_offsets=sharded_offsets,
                 tp_group=self.tp_group,
                 dp_cp_group=metadata["dp_cp_group"],
+                intra_dp_cp_group=metadata.get("intra_dp_cp_group"),
+                intra_expt_dp_group=metadata.get("intra_expt_dp_group"),
             )
         }
 
@@ -1222,6 +1224,8 @@ class ColumnParallelLinear(torch.nn.Module):
             sharded_offsets,
             tp_group=self.tp_group,
             dp_cp_group=metadata['dp_cp_group'],
+            intra_dp_cp_group=metadata.get('intra_dp_cp_group'),
+            intra_expt_dp_group=metadata.get('intra_expt_dp_group'),
         )
 
     def set_extra_state(self, state: Any):
@@ -1500,6 +1504,8 @@ class RowParallelLinear(torch.nn.Module):
             sharded_offsets,
             tp_group=self.tp_group,
             dp_cp_group=metadata['dp_cp_group'],
+            intra_dp_cp_group=metadata.get('intra_dp_cp_group'),
+            intra_expt_dp_group=metadata.get('intra_expt_dp_group'),
         )
 
     def set_extra_state(self, state: Any):

--- a/megatron/core/transformer/dot_product_attention.py
+++ b/megatron/core/transformer/dot_product_attention.py
@@ -268,4 +268,6 @@ class DotProductAttention(MegatronModule):
             sharded_offsets,
             tp_group=self.tp_group,
             dp_cp_group=metadata['dp_cp_group'],
+            intra_dp_cp_group=metadata.get('intra_dp_cp_group'),
+            intra_expt_dp_group=metadata.get('intra_expt_dp_group'),
         )

--- a/megatron/core/transformer/module.py
+++ b/megatron/core/transformer/module.py
@@ -92,6 +92,8 @@ class MegatronModule(torch.nn.Module):
             sharded_offsets=sharded_offsets,
             tp_group=tp_group,
             dp_cp_group=metadata['dp_cp_group'],
+            intra_dp_cp_group=metadata.get('intra_dp_cp_group'),
+            intra_expt_dp_group=metadata.get('intra_expt_dp_group'),
         )
         # Recurse into submodules
         for name, module in self.named_children():

--- a/megatron/core/transformer/utils.py
+++ b/megatron/core/transformer/utils.py
@@ -100,6 +100,8 @@ def make_sharded_tensors_for_checkpoint(
     extra_state_suffix: str = '_extra_state',
     tp_group: Optional[torch.distributed.ProcessGroup] = None,
     dp_cp_group: Optional[torch.distributed.ProcessGroup] = None,
+    intra_dp_cp_group: Optional[torch.distributed.ProcessGroup] = None,
+    intra_expt_dp_group: Optional[torch.distributed.ProcessGroup] = None,
 ):
     """Wraps tensors from transformer layers with ShardedTensor or ShardedObject.
 
@@ -122,6 +124,10 @@ def make_sharded_tensors_for_checkpoint(
         dp_cp_group (Optional[torch.distributed.ProcessGroup], optional): data parallel group
             with context parallel. If None, defaults to
             parallel_state.get_data_parallel_group(with_context_parallel=True)
+        intra_dp_cp_group (Optional[torch.distributed.ProcessGroup], optional): GTP-excluded
+            dense replica group used for checkpoint writer election.
+        intra_expt_dp_group (Optional[torch.distributed.ProcessGroup], optional): GTP-excluded
+            expert replica group used for expert checkpoint writer election.
 
     """
 
@@ -152,6 +158,8 @@ def make_sharded_tensors_for_checkpoint(
                 extra_state_suffix=extra_state_suffix,
                 tp_group=tp_group,
                 dp_cp_group=dp_cp_group,
+                intra_dp_cp_group=intra_dp_cp_group,
+                intra_expt_dp_group=intra_expt_dp_group,
             )
 
     sharded_state_dict = {}
@@ -292,6 +300,8 @@ def sharded_state_dict_default(
             sharded_offsets,
             tp_group=tp_group,
             dp_cp_group=metadata['dp_cp_group'],
+            intra_dp_cp_group=metadata.get('intra_dp_cp_group'),
+            intra_expt_dp_group=metadata.get('intra_expt_dp_group'),
         )
     return module_sharded_sd
 

--- a/megatron/core/utils.py
+++ b/megatron/core/utils.py
@@ -988,10 +988,14 @@ def make_tp_sharded_tensor_for_checkpoint(
             - tp_group: Tensor parallel group (default: None, falls back to parallel_state)
             - dp_cp_group: Data parallel + context parallel group
               (default: None, falls back to parallel_state)
+            - intra_dp_cp_group: GTP-excluded dense replica group
+            - intra_expt_dp_group: GTP-excluded expert replica group
     """
     # Pop group parameters from kwargs
     tp_group = kwargs.pop('tp_group', None)
     dp_cp_group = kwargs.pop('dp_cp_group', None)
+    intra_dp_cp_group = kwargs.pop('intra_dp_cp_group', None)
+    intra_expt_dp_group = kwargs.pop('intra_expt_dp_group', None)
 
     prepend_axis_num = len(prepend_offsets)
 
@@ -1051,10 +1055,17 @@ def make_tp_sharded_tensor_for_checkpoint(
             else:
                 # GTP shards axis 0, TP shards a different axis → add a separate axis-0 offset
                 new_offsets.append((prepend_axis_num, gtp_rank, gtp_remat_size))
-            # Elect the writer over the gtp_remat-EXCLUDED DP group (its true replicas).
-            dp_replica_id = parallel_state.get_data_parallel_rank(
-                with_context_parallel=True, with_gtp_remat=False
-            )
+            # Elect the writer over the GTP-remat-excluded replica group. Explicit-grid
+            # callers cannot use MPU globals, and expert weights replicate over expert DP.
+            replica_group = intra_dp_cp_group
+            if not getattr(tensor, 'allreduce', True) and intra_expt_dp_group is not None:
+                replica_group = intra_expt_dp_group
+            if replica_group is not None:
+                dp_replica_id = get_pg_rank(replica_group)
+            else:
+                dp_replica_id = parallel_state.get_data_parallel_rank(
+                    with_context_parallel=True, with_gtp_remat=False
+                )
             # Saved global is the padded shape when GTP padded out_features for alignment.
             if getattr(tensor, "pad_length", 0):
                 kwargs.setdefault("allow_shape_mismatch", True)

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -2055,6 +2055,11 @@ def _maybe_setup_gpt_to_hybrid_load(args, ckpt_args, model):
         while module is not None:
             if isinstance(module, HybridModel):
                 return True
+            language_model_type = getattr(module, 'checkpoint_language_model_type', None)
+            if isinstance(language_model_type, type) and issubclass(
+                language_model_type, HybridModel
+            ):
+                return True
             module = getattr(module, 'module', None)
         return False
 

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_dcp.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_dcp.py
@@ -55,7 +55,11 @@ from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.spec_utils import ModuleSpec  # noqa: E402
 from megatron.core.transformer.transformer_config import TransformerConfig  # noqa: E402
 from megatron.core.transformer.utils import make_sharded_tensors_for_checkpoint  # noqa: E402
-from megatron.core.utils import get_pg_size, make_tp_sharded_tensor_for_checkpoint  # noqa: E402
+from megatron.core.utils import (  # noqa: E402
+    get_pg_rank,
+    get_pg_size,
+    make_tp_sharded_tensor_for_checkpoint,
+)
 from tests.unit_tests.generalized_tensor_parallel.gtp_test_utils import (  # noqa: E402,F401
     _requires_mxfp8,
     _torchrun_dist_init,
@@ -552,6 +556,10 @@ def _worker_helper_offsets_ep_egtp(rank, world_size, port):
     global_expert_idx = ep_rank * num_gemms  # + gemm_idx (0)
 
     weight = _make_gtp_shard(per_expert_out, in_features, egtp_remat_group)
+    weight.allreduce = False
+    expert_dp_group = (
+        _cached_new_group([0, 2]) if rank in (0, 2) else _cached_new_group([1, 3])
+    )
     assert weight.shape == (
         per_shard_out,
         in_features,
@@ -565,6 +573,8 @@ def _worker_helper_offsets_ep_egtp(rank, world_size, port):
         sharded_offsets=((0, global_expert_idx, num_global_experts),),
         tp_group=_cached_new_group([rank]),  # no TP in this case
         dp_cp_group=_cached_new_group(list(range(world_size))),
+        intra_dp_cp_group=_cached_new_group(list(range(world_size))),
+        intra_expt_dp_group=expert_dp_group,
     )
     st = sharded["weight"]
     assert isinstance(st, ShardedTensor), f"Expected ShardedTensor, got {type(st)}"
@@ -581,6 +591,7 @@ def _worker_helper_offsets_ep_egtp(rank, world_size, port):
     assert (
         st.global_offset[1] == egtp_rank * per_shard_out
     ), f"rank={rank} EGTP_remat axis-1 offset {st.global_offset[1]} != {egtp_rank * per_shard_out}"
+    assert st.replica_id[2] == get_pg_rank(expert_dp_group)
 
 
 def _worker_helper_embedding_offsets(rank, world_size, port):

--- a/tests/unit_tests/test_checkpointing.py
+++ b/tests/unit_tests/test_checkpointing.py
@@ -11,6 +11,7 @@ import torch.distributed.checkpoint
 
 from megatron.core.distributed import DistributedDataParallelConfig
 from megatron.core.distributed.fsdp.mcore_fsdp_adapter import FullyShardedDataParallel
+from megatron.core.models.hybrid.hybrid_model import HybridModel
 from megatron.core.num_microbatches_calculator import (
     init_num_microbatches_calculator,
     unset_num_microbatches_calculator,
@@ -23,6 +24,7 @@ from megatron.training.checkpointing import (
     CheckpointType,
     _build_sharded_state_dict_metadata,
     _load_base_checkpoint,
+    _maybe_setup_gpt_to_hybrid_load,
     get_checkpoint_tracker_filename,
     load_checkpoint,
     maybe_save_dataloader_state,
@@ -73,6 +75,19 @@ class MockState:
     def sharded_state_dict(self, *args, metadata: Optional[dict] = None, **kwargs):
         self._called_metadata.append(metadata)
         return self.state_dict()
+
+
+def test_checkpoint_container_reports_hybrid_language_model_type():
+    """Container ranks without a local language module still report checkpoint compatibility."""
+
+    class HybridLanguageModelContainer(torch.nn.Module):
+        checkpoint_language_model_type = HybridModel
+
+    assert _maybe_setup_gpt_to_hybrid_load(
+        SimpleNamespace(hybrid_layer_pattern='M*'),
+        SimpleNamespace(hybrid_layer_pattern='M*'),
+        [HybridLanguageModelContainer()],
+    ) == (None, False)
 
 
 def test_maybe_save_dataloader_state_uses_explicit_process_groups(tmp_path):


### PR DESCRIPTION
## What

- Thread the GTP-excluded dense and expert replica groups through core and Transformer Engine sharded-state helpers.
- Use the GTP-inclusive data domain for MIMO checkpoint distribution while electing dense and routed-expert writers from their correct GTP-excluded replica groups.
- Include the GTP coordinate in MIMO optimizer-object replica IDs.
- Add a generic `checkpoint_language_model_type` container protocol so encoder-only MIMO ranks can participate in GPT-to-hybrid checkpoint compatibility checks without importing or special-casing `MimoModel` in the training checkpoint loader.

## Why

A GTP checkpoint has two distinct domains: data is distributed over DP/CP/GTP, while a specific dense or expert weight shard is replicated only over the corresponding GTP-excluded DP group. Explicit heterogeneous grids cannot recover those groups from MPU globals, and routed-expert weights require expert DP rather than dense DP for writer election.

## Dependency

Stacked directly on #6234 by @fanshiqing. The new groups are optional and preserve the existing fallback when a caller does not provide them.

## Validation

- targeted EGTP expert-writer replica-ID assertion
- generic container checkpoint-compatibility test
- Python compile checks
- import sorting
- git diff --check
- full 100-iteration save/load validation is tracked by the integration PR