### PR TITLE
TE Layernorm dtype guard with fp32 residuals

### DIFF
--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -1555,6 +1555,13 @@ class TELayerNormColumnParallelLinear(te.pytorch.LayerNormLinear):
         )
         quant_context = _get_fp8_autocast_for_quant_params(self.te_quant_params, self.training)
 
+        # FP32 residual connections pass the FP32 residual stream into this fused module, but
+        # TE LayerNormLinear requires its input dtype to match its BF16/FP16 parameters outside
+        # torch.autocast. Tensor.to() is out-of-place, so this only narrows the local norm/linear
+        # input; the residual tensor retained by TransformerLayer remains FP32.
+        if x.dtype != self.layer_norm_weight.dtype:
+            x = x.to(self.layer_norm_weight.dtype)
+
         with quant_context:
             out = super().forward(x, is_first_microbatch=_is_first_microbatch)
 

--- a/tests/unit_tests/extension/test_te_layernorm_column_parallel_linear.py
+++ b/tests/unit_tests/extension/test_te_layernorm_column_parallel_linear.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Tests for the Transformer Engine fused layernorm and column-parallel linear wrapper."""
+
+import pytest
+import torch
+
+from megatron.core.extensions.transformer_engine import HAVE_TE, TELayerNormColumnParallelLinear
+from megatron.core.transformer.transformer_config import TransformerConfig
+from megatron.core.utils import init_method_normal
+from tests.unit_tests.test_utilities import Utils
+
+
+@pytest.mark.skipif(not HAVE_TE, reason="Transformer Engine not installed")
+def test_fp32_residual_input_is_cast_without_mutating_residual():
+    """Keep the residual FP32 while running the fused layer in BF16."""
+    Utils.initialize_model_parallel(1, 1)
+
+    try:
+        config = TransformerConfig(
+            num_layers=1,
+            hidden_size=16,
+            num_attention_heads=4,
+            use_cpu_initialization=True,
+            params_dtype=torch.bfloat16,
+            bf16=True,
+            fp32_residual_connection=True,
+        )
+        layer = TELayerNormColumnParallelLinear(
+            input_size=config.hidden_size,
+            output_size=32,
+            config=config,
+            init_method=init_method_normal(config.init_method_std),
+            gather_output=False,
+            bias=False,
+            skip_bias_add=False,
+            is_expert=False,
+        ).cuda()
+
+        hidden_states = torch.randn(
+            4, 2, config.hidden_size, device="cuda", dtype=torch.float32, requires_grad=True
+        )
+        residual = hidden_states
+        residual_before = residual.detach().clone()
+
+        output, _ = layer(hidden_states)
+
+        assert layer.layer_norm_weight.dtype == torch.bfloat16
+        assert output.dtype == torch.bfloat16
+        assert residual.dtype == torch.float32
+        assert residual.data_ptr() == hidden_states.data_ptr()
+        assert torch.equal(residual.detach(), residual_before)
+
+        output.float().sum().backward()
+        assert hidden_states.grad.dtype == torch.float32
+    finally:
+        Utils.destroy_model_parallel()


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
FP32 residuals crash with TE's layernorm due to a dtype match. This fixes it with a minimal change. Long term, TE's layernorm class should be able to accept fp32 activations, since the layernorm computation is done in FP32 anyway. 

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
