### PR TITLE
[Dev] Add MoonEP balanced expert-parallel token dispatcher

### DIFF
--- a/megatron/core/distributed/distributed_data_parallel.py
+++ b/megatron/core/distributed/distributed_data_parallel.py
@@ -477,8 +477,11 @@ class DistributedDataParallel(_BaseDataParallel):
                 return
 
             if getattr(param, '_moonep_is_replica', False):
-                # TE writes replica wgrad straight into MoonEP's reduce buffer via
-                # gradient-accumulation fusion; drop the autograd placeholder grad.
+                # Replica main_grad is a row of MoonEP's reduce buffer. With
+                # gradient-accumulation fusion TE has already written it; otherwise fold
+                # the autograd grad in here. Replicas intentionally have no DDP bucket.
+                if param.grad is not None and not param.grad_added_to_main_grad:
+                    param.main_grad.add_(param.grad.data)
                 param.grad = None
                 return
 

--- a/megatron/core/distributed/distributed_data_parallel.py
+++ b/megatron/core/distributed/distributed_data_parallel.py
@@ -115,11 +115,17 @@ class DistributedDataParallel(_BaseDataParallel):
             if not param.requires_grad:
                 continue
 
+            param.grad_added_to_main_grad = False
+            # MoonEP prefetch-slot parameters live in its cross-layer reduce buffer. They
+            # are trainable so TE produces wgrad, but they must not consume DDP buffer
+            # space or take part in DP collectives.
+            if getattr(param, '_moonep_is_replica', False):
+                continue
+
             # Track params with grad to enable direct setting
             # of param.grad_added_to_main_grad
             self.params_with_grad.append(param)
 
-            param.grad_added_to_main_grad = False
             param_to_name[param] = name
             all_params.append(param)
 
@@ -336,6 +342,8 @@ class DistributedDataParallel(_BaseDataParallel):
                 for bucket in bucket_group.buckets:
                     for param in bucket.params_list:
                         self.param_to_bucket_group[param] = bucket_group
+                        if getattr(param, '_moonep_is_master', False):
+                            param._moonep_ddp_bucket_group = bucket_group
 
         # Delete references to weight_tensor if they exist since we don't want two parameter copies
         # if we re-mapped parameters (which happens when we use the distributed optimizer).
@@ -468,6 +476,12 @@ class DistributedDataParallel(_BaseDataParallel):
             if is_graph_capturing():
                 return
 
+            if getattr(param, '_moonep_is_replica', False):
+                # TE writes replica wgrad straight into MoonEP's reduce buffer via
+                # gradient-accumulation fusion; drop the autograd placeholder grad.
+                param.grad = None
+                return
+
             if param in self.param_to_bucket_group:
                 assert param.requires_grad
                 cudagraph_wgrad_ready_event = getattr(param, '_cudagraph_wgrad_ready_event', None)
@@ -482,9 +496,14 @@ class DistributedDataParallel(_BaseDataParallel):
                 param.grad = None
 
                 if self.ddp_config.overlap_grad_reduce:
-                    self.param_to_bucket_group[param].register_grad_ready(
-                        param, self.force_all_reduce
-                    )
+                    if getattr(param, '_moonep_is_master', False):
+                        # MoonEP adds the duplicated experts' wgrad into this master after
+                        # the expert backward; its dispatch backward releases the bucket.
+                        param._moonep_force_all_reduce = self.force_all_reduce
+                    else:
+                        self.param_to_bucket_group[param].register_grad_ready(
+                            param, self.force_all_reduce
+                        )
 
         return hook
 

--- a/megatron/core/distributed/param_and_grad_buffer.py
+++ b/megatron/core/distributed/param_and_grad_buffer.py
@@ -969,6 +969,10 @@ def group_params_for_buffers(
 
     for param in params:
         assert param.requires_grad
+        # Filter MoonEP prefetch-slot params here as well as in DDP so precomputed
+        # distributed-optimizer layouts match the buffers DDP actually constructs.
+        if getattr(param, '_moonep_is_replica', False):
+            continue
 
         param_dtype = param.dtype
         if _param_uses_quantized_storage(param):

--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -330,6 +330,10 @@ def _get_param_groups(
         for name, param in model_chunk.named_parameters():
             if not param.requires_grad:
                 continue
+            # MoonEP prefetch slots are ephemeral copies of remote master experts. Their
+            # storage is owned by MoonEP and must not receive optimizer state or updates.
+            if getattr(param, '_moonep_is_replica', False):
+                continue
 
             uses_default_config = False
             # Get optimizer config overrides for this parameter.

--- a/megatron/core/transformer/moe/README.md
+++ b/megatron/core/transformer/moe/README.md
@@ -310,6 +310,35 @@ After routing, tokens are **dispatched** to the GPU hosting the assigned expert.
 | **FlexDispatcher with [DeepEP](https://github.com/deepseek-ai/DeepEP) backend** | Removes redundant tokens during cross-node communication, fuses intra/inter-node communication into single kernel | Cross-node EP, fine-grained MoE (DeepSeek-V3) | `--moe-token-dispatcher-type flex --moe-flex-dispatcher-backend deepep` |
 | **FlexDispatcher with [HybridEP](https://github.com/deepseek-ai/DeepEP/tree/hybrid-ep) backend** | NVIDIA's optimized dispatcher using TMA and IBGDA, fewer SMs, native MNNVL support | GB200 NVL72, Multi-Node NVLink | `--moe-token-dispatcher-type flex --moe-flex-dispatcher-backend hybridep` |
 | **allgather** | Gathers all tokens to each GPU, no inter-GPU token movement | TP-only setups, small EP, large Top-K | `--moe-token-dispatcher-type allgather` |
+| **[MoonEP](https://github.com/MoonshotAI/MoonEP)** | Plans redundant experts online so every rank receives exactly `S x K` tokens, prefetches the duplicated experts' weights over NVLink, and writes tokens directly into their expert-grouped slots | Skewed routing, single-node NVLink EP | `--moe-token-dispatcher-type moonep` |
+
+#### MoonEP Balanced Dispatch
+
+[MoonEP](https://github.com/MoonshotAI/MoonEP) removes the load imbalance of expert parallelism
+instead of tolerating it. Each microbatch is planned on the GPU from the current router output: a
+small number of hot experts are duplicated onto the ranks that have spare capacity, their weights
+are prefetched over NVLink, and every rank ends up computing exactly `S x K` tokens with statically
+known shapes. Duplicated experts' weight gradients are reduced back to their home rank in the
+backward pass.
+
+Install MoonEP and a matching `nvidia-cutlass-dsl` in the training container, then enable it with:
+
+```bash
+--moe-token-dispatcher-type moonep
+--moe-grouped-gemm
+--accumulate-allreduce-grads-in-fp32
+```
+
+Each EP rank reserves `num_experts / EP` prefetch slots, so its grouped GEMM runs over twice as
+many physical experts as it owns. The slot parameters alias MoonEP's process-global prefetch pool
+and gradient reduce buffer and are excluded from DDP, optimizer state, and distributed checkpoints.
+
+The current integration supports BF16 training with MCore DDP, TE per-expert GroupedLinear weights,
+ETP1, dropless routing, and DP/PP/VPP. The configuration validator rejects unsupported
+combinations, including FP8/FP4 experts, FSDP, expert TP, single grouped expert weights, latent
+MoE, CUDA graphs, the TE operation fuser, batch-level EP overlap, delayed expert wgrad, and
+inference-optimized layers. MoonEP requires an NVLink domain (expert parallelism must stay inside
+one node) and expert weight dimensions that are multiples of 128.
 
 ### Upcycling
 Use `--moe-use-upcycling` to enable upcycling, which loads the dense model from the `--load` directory, converts it to an MoE model at runtime, and starts training. The converted model is saved to the `--save` path before training begins. Upcycling is built on distributed checkpointing, supporting parallel modes different from existing dense checkpoints, such as arbitrary expert parallelism during upcycling.
@@ -548,7 +577,9 @@ For MoE models, certain configurations may prevent CUDA Graph capture of MoE lay
 ### Token Dispatching
 | Argument | Description | Default |
 |----------|-------------|---------|
-| --moe-token-dispatcher-type | Dispatcher: allgather, alltoall, flex | allgather |
+| --moe-token-dispatcher-type | Dispatcher: allgather, alltoall, flex, moonep | allgather |
+| --moe-moonep-num-sms | SMs for MoonEP's communication kernels | 32 |
+| --moe-moonep-token-padding | Token multiple each MoonEP expert group is padded to | 128 |
 | --moe-enable-deepep | Enable DeepEP (with flex) | False |
 | --moe-expert-capacity-factor | Capacity factor | None |
 | --moe-pad-expert-input-to-capacity | Pad to capacity | False |

--- a/megatron/core/transformer/moe/experts.py
+++ b/megatron/core/transformer/moe/experts.py
@@ -6,7 +6,7 @@ import logging
 from collections.abc import Callable
 from contextlib import nullcontext
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from itertools import chain
 from math import ceil
 from typing import Optional, Protocol, Tuple
@@ -16,7 +16,7 @@ import torch.nn.functional as F
 
 from megatron.core import tensor_parallel
 from megatron.core.activations import squared_relu
-from megatron.core.dist_checkpointing.mapping import ShardedStateDict
+from megatron.core.dist_checkpointing.mapping import ShardedObject, ShardedStateDict, ShardedTensor
 from megatron.core.dist_checkpointing.utils import replace_prefix_for_sharding
 from megatron.core.enums import Fp4Recipe, Fp8Recipe
 from megatron.core.extensions.transformer_engine import HAVE_TE
@@ -168,6 +168,21 @@ class GroupedMLPSubmodules:
     """
     Builder for an activation function module; only used if config.use_te_activation_func is True.
     """
+
+
+def _parse_te_expert_idx(key: str, module_name: str) -> Optional[int]:
+    """Extract a local expert index from a TE GroupedLinear state-dict key."""
+    prefix = f'{module_name}.'
+    if not key.startswith(prefix):
+        return None
+
+    suffix = key[len(prefix) :]
+    for kind in ('weight', 'bias'):
+        index = suffix.removeprefix(kind)
+        if index != suffix and index.isdigit():
+            return int(index)
+    # GroupedLinear owns one module-level extra state, replicated across EP ranks.
+    return None
 
 
 class TEGroupedMLP(MegatronModule):
@@ -918,15 +933,21 @@ class TEGroupedMLP(MegatronModule):
         metadata = ensure_metadata_has_dp_cp_group(metadata)
         singleton_local_shards = (metadata or {}).get('singleton_local_shards', False)
         sharded_state_dict = {}
+        # MoonEP appends prefetch-slot experts to the local expert axis; checkpoints
+        # only describe the master experts.
+        num_local_checkpoint_experts = getattr(
+            self, 'num_local_master_experts', self.num_local_experts
+        )
+        has_replica_experts = num_local_checkpoint_experts < self.num_local_experts
         for name, module in self._modules.items():
             sub_sd = sharded_state_dict_default(
                 module, f'{name}.', sharded_offsets, metadata, tp_group=self.tp_group
             )
             if name == 'linear_fc1' and self.config.gated_linear_unit:
-                num_global_experts = self.ep_group.size() * self.num_local_experts
-                local_expert_indices_offset = self.ep_group.rank() * self.num_local_experts
+                num_global_experts = self.ep_group.size() * num_local_checkpoint_experts
+                local_expert_indices_offset = self.ep_group.rank() * num_local_checkpoint_experts
                 ep_axis = len(sharded_offsets)
-                for i in range(self.num_local_experts):
+                for i in range(num_local_checkpoint_experts):
                     if singleton_local_shards:
                         new_sharded_offsets = sharded_offsets
                     else:
@@ -939,6 +960,14 @@ class TEGroupedMLP(MegatronModule):
                             sub_sd[k] = apply_swiglu_sharded_factory(
                                 sub_sd[k], new_sharded_offsets, singleton_local_shards
                             )
+            if has_replica_experts:
+                sub_sd = self._filter_replica_checkpoint_entries(
+                    sub_sd,
+                    name,
+                    len(sharded_offsets),
+                    num_local_checkpoint_experts,
+                    fix_metadata=not singleton_local_shards,
+                )
             if singleton_local_shards:
                 replace_prefix_for_sharding(sub_sd, '', f'{prefix}experts.')
             else:
@@ -946,6 +975,63 @@ class TEGroupedMLP(MegatronModule):
                 replace_prefix_for_sharding(sub_sd, f'{name}.', f'{prefix}experts.{name}.')
             sharded_state_dict.update({f"{prefix}{k}": v for k, v in sub_sd.items()})
         return sharded_state_dict
+
+    def _filter_replica_checkpoint_entries(
+        self,
+        sub_sd: dict,
+        module_name: str,
+        ep_axis: int,
+        num_local_master_experts: int,
+        *,
+        fix_metadata: bool,
+    ) -> dict:
+        """Drop ephemeral replica experts and restore master-expert checkpoint metadata."""
+        num_global_master_experts = self.ep_group.size() * num_local_master_experts
+        local_master_offset = self.ep_group.rank() * num_local_master_experts
+        filtered = {}
+
+        for key, value in sub_sd.items():
+            local_expert_idx = _parse_te_expert_idx(key, module_name)
+            if local_expert_idx is None:
+                filtered[key] = value
+                continue
+            if local_expert_idx >= num_local_master_experts:
+                continue
+            if not fix_metadata:
+                filtered[key] = value
+                continue
+
+            global_expert_idx = local_master_offset + local_expert_idx
+            if isinstance(value, ShardedTensor):
+                global_shape = list(value.global_shape)
+                global_offset = list(value.global_offset)
+                axis_fragmentations = (
+                    list(value.axis_fragmentations)
+                    if value.axis_fragmentations is not None
+                    else None
+                )
+                global_shape[ep_axis] = num_global_master_experts
+                global_offset[ep_axis] = global_expert_idx
+                if axis_fragmentations is not None:
+                    axis_fragmentations[ep_axis] = num_global_master_experts
+                value = replace(
+                    value,
+                    global_shape=tuple(global_shape),
+                    global_offset=tuple(global_offset),
+                    axis_fragmentations=(
+                        tuple(axis_fragmentations) if axis_fragmentations is not None else None
+                    ),
+                )
+            elif isinstance(value, ShardedObject):
+                global_shape = list(value.global_shape)
+                global_offset = list(value.global_offset)
+                global_shape[ep_axis] = num_global_master_experts
+                global_offset[ep_axis] = global_expert_idx
+                value = replace(
+                    value, global_shape=tuple(global_shape), global_offset=tuple(global_offset)
+                )
+            filtered[key] = value
+        return filtered
 
     def backward_dw(self):
         """Performs backward pass for weight gradients in TEGroupedMLP.

--- a/megatron/core/transformer/moe/moe_layer.py
+++ b/megatron/core/transformer/moe/moe_layer.py
@@ -24,9 +24,9 @@ from megatron.core.transformer.moe.moe_utils import (
     maybe_skip_or_early_return_by_cudagraph,
     record_dispatch_token_counts,
 )
+from megatron.core.transformer.moe.moonep_dispatcher import MoEMoonEPTokenDispatcher
 from megatron.core.transformer.moe.router import TopKRouter
 from megatron.core.transformer.moe.shared_experts import SharedExpertMLP
-from megatron.core.transformer.moe.moonep_dispatcher import MoEMoonEPTokenDispatcher
 from megatron.core.transformer.moe.token_dispatcher import (
     MoEAllGatherTokenDispatcher,
     MoEAlltoAllTokenDispatcher,

--- a/megatron/core/transformer/moe/moe_layer.py
+++ b/megatron/core/transformer/moe/moe_layer.py
@@ -15,6 +15,7 @@ from megatron.core.inference.utils import InferenceMode
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.transformer.module import MegatronModule
+from megatron.core.transformer.moe.experts import TEGroupedMLP
 from megatron.core.transformer.moe.moe_logging import get_moe_overload_factor_tracker
 from megatron.core.transformer.moe.moe_utils import (
     MoECudaGraphPartialCaptureSignal,
@@ -25,6 +26,7 @@ from megatron.core.transformer.moe.moe_utils import (
 )
 from megatron.core.transformer.moe.router import TopKRouter
 from megatron.core.transformer.moe.shared_experts import SharedExpertMLP
+from megatron.core.transformer.moe.moonep_dispatcher import MoEMoonEPTokenDispatcher
 from megatron.core.transformer.moe.token_dispatcher import (
     MoEAllGatherTokenDispatcher,
     MoEAlltoAllTokenDispatcher,
@@ -197,6 +199,14 @@ class BaseMoELayer(MegatronModule, ABC):
             local_expert_indices_offset + i for i in range(self.num_local_experts)
         ]
         assert all(map(lambda x: x < self.config.num_moe_experts, self.local_expert_indices))
+
+        # MoonEP reserves one prefetch slot per local expert; those slots are extra
+        # physical experts in the grouped GEMM but not extra logical experts.
+        self.moonep_enabled = config.moe_token_dispatcher_type == "moonep"
+        self.num_local_physical_experts = (
+            2 * self.num_local_experts if self.moonep_enabled else self.num_local_experts
+        )
+
         self.router: RouterInterface = None
         self.experts = None
         self.shared_experts = None
@@ -325,6 +335,14 @@ class MoELayer(BaseMoELayer):
                 config=self.config,
                 pg_collection=pg_collection,
             )
+        elif config.moe_token_dispatcher_type == "moonep":
+            self.token_dispatcher = MoEMoonEPTokenDispatcher(
+                self.num_local_physical_experts,
+                self.local_expert_indices,
+                config=self.config,
+                pg_collection=pg_collection,
+                layer_number=layer_number,
+            )
         else:
             raise ValueError(
                 f"Unsupported token dispatcher type: {config.moe_token_dispatcher_type}"
@@ -332,11 +350,21 @@ class MoELayer(BaseMoELayer):
 
         # Initialize experts
         self.experts = self.submodules.experts(
-            self.num_local_experts,
+            self.num_local_physical_experts,
             self.config,
             pg_collection=pg_collection,
             name=(name + ".experts") if name is not None else None,
         )
+        if self.moonep_enabled:
+            if not isinstance(self.experts, TEGroupedMLP):
+                raise TypeError(
+                    f"MoonEP requires TEGroupedMLP experts, got {type(self.experts).__name__}."
+                )
+            self.experts.num_local_master_experts = self.num_local_experts
+            self.token_dispatcher.manager.bind_replica_parameters(
+                self.token_dispatcher.layer_buffers,
+                (self.experts.linear_fc1, self.experts.linear_fc2),
+            )
 
         # Initialize shared experts
         if self.use_shared_expert:
@@ -696,6 +724,14 @@ class MoELayer(BaseMoELayer):
                 "During training, performance may degrade if MoE and tensor parallelism"
                 "are enabled without also enabling sequence parallelism."
             )
+        if self.moonep_enabled:
+            if intermediate_tensors is not None:
+                raise RuntimeError("MoonEP requires the unsplit MoE forward path.")
+            self.token_dispatcher.manager.bind_master_parameters(
+                self.token_dispatcher.layer_buffers,
+                (self.experts.linear_fc1, self.experts.linear_fc2),
+            )
+
         # Select the active token dispatcher based on whether the inference engine
         # is currently using the model. Only applies when the inference dispatcher
         # was set up (config.transformer_impl == "inference_optimized").

--- a/megatron/core/transformer/moe/moonep_dispatcher.py
+++ b/megatron/core/transformer/moe/moonep_dispatcher.py
@@ -146,11 +146,16 @@ class MoEMoonEPTokenDispatcher(MoETokenDispatcher):
         hidden_states = hidden_states.view(-1, self.hidden_shape[-1])
         num_tokens = hidden_states.shape[0]
 
-        routing_map = routing_map.reshape(num_tokens, self.num_experts)
         probs = probs.reshape(num_tokens, self.num_experts)
         self.topk_probs, topk_indices = torch.topk(probs, self.config.moe_router_topk, dim=-1)
         self.topk_indices = topk_indices.to(torch.int32).contiguous()
-        self.tokens_per_expert = routing_map.sum(dim=0).to(torch.int32).contiguous()
+        # Count from the indices actually handed to MoonEP so the planner and the
+        # dispatch agree even when the router emits zero-probability slots.
+        self.router_tokens_per_expert = (
+            torch.bincount(topk_indices.flatten(), minlength=self.num_experts)
+            .to(torch.int32)
+            .contiguous()
+        )
 
         self.manager.stage_master_weights(self.layer_buffers)
         return hidden_states, self.topk_probs
@@ -162,7 +167,7 @@ class MoEMoonEPTokenDispatcher(MoETokenDispatcher):
             hidden_states,
             self.topk_probs.float().contiguous(),
             self.topk_indices,
-            self.tokens_per_expert,
+            self.router_tokens_per_expert,
             self.manager,
             self.layer_buffers,
             plan_holder,

--- a/megatron/core/transformer/moe/moonep_dispatcher.py
+++ b/megatron/core/transformer/moe/moonep_dispatcher.py
@@ -195,9 +195,7 @@ class MoEMoonEPTokenDispatcher(MoETokenDispatcher):
 
     def token_combine(self, hidden_states: torch.Tensor):
         """K-sum expert outputs back to token-major order."""
-        return _MoonEPCombine.apply(
-            hidden_states, self.manager, self.layer_buffers, self.plan
-        )
+        return _MoonEPCombine.apply(hidden_states, self.manager, self.layer_buffers, self.plan)
 
     def combine_postprocess(self, hidden_states: torch.Tensor):
         """Restore the original hidden-state shape."""

--- a/megatron/core/transformer/moe/moonep_dispatcher.py
+++ b/megatron/core/transformer/moe/moonep_dispatcher.py
@@ -1,0 +1,197 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Token dispatcher backed by MoonEP's perfectly balanced expert-parallel kernels."""
+
+from __future__ import annotations
+
+from typing import List, Optional, Tuple
+
+import torch
+
+from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.transformer.moe.moonep_manager import (
+    MoonEPLayerBuffers,
+    MoonEPManager,
+    get_or_create_moonep_manager,
+)
+from megatron.core.transformer.moe.token_dispatcher import MoETokenDispatcher
+from megatron.core.transformer.transformer_config import TransformerConfig
+
+
+class _MoonEPDispatch(torch.autograd.Function):
+    """Scatter tokens to expert-grouped slots and prefetch the duplicated experts.
+
+    The backward is MoonEP's combine: it K-sums each token's dispatched gradient
+    copies back to token-major and, on the same pass, gathers the permuted probs
+    gradient. Duplicated experts' wgrad is reduced to its home rank here because
+    this node runs after the expert backward.
+    """
+
+    @staticmethod
+    def forward(
+        ctx, hidden_sh, probs_sk, topk_sk, tokens_per_expert, manager, layer_buffers, plan_holder
+    ):
+        """Run MoonEP planning plus dispatch, then fill the local prefetch slots."""
+        buffer = manager.ensure_buffer(hidden_sh.shape[0])
+        hidden_nvsh, route_weights_nvs, cu_seqlens, plan = buffer.dispatch(
+            hidden_sh.contiguous(), probs_sk, topk_sk, tokens_per_expert
+        )
+        manager.prefetch(layer_buffers, plan)
+        plan_holder.append(plan)
+        ctx.manager = manager
+        ctx.layer_buffers = layer_buffers
+        ctx.plan = plan
+        return hidden_nvsh, route_weights_nvs, cu_seqlens
+
+    @staticmethod
+    def backward(ctx, grad_hidden_nvsh, grad_route_weights_nvs, _grad_cu_seqlens):
+        """Combine token gradients back and reduce duplicated experts' weight gradients."""
+        manager = ctx.manager
+        grad_hidden_sh, grad_probs_sk, _ = manager.buffer.combine(
+            plan=ctx.plan,
+            hidden_nvsh=grad_hidden_nvsh.contiguous(),
+            route_weights_nvs=grad_route_weights_nvs.contiguous().float(),
+        )
+        manager.reduce_grad(ctx.layer_buffers, ctx.plan)
+        return grad_hidden_sh, grad_probs_sk, None, None, None, None, None
+
+
+class _MoonEPCombine(torch.autograd.Function):
+    """K-sum expert outputs back to token-major.
+
+    The backward re-dispatches the output gradient with the saved plan. It first
+    restores this microbatch's prefetched weights, because the prefetch pool is
+    shared across layers and has since been overwritten by other layers' forwards.
+    """
+
+    @staticmethod
+    def forward(ctx, expert_output_nvsh, manager, layer_buffers, plan):
+        """Gather expert outputs from the NVL buffer into token-major order."""
+        output_sh, _, _ = manager.buffer.combine(
+            plan=plan, hidden_nvsh=expert_output_nvsh.contiguous()
+        )
+        ctx.manager = manager
+        ctx.layer_buffers = layer_buffers
+        ctx.plan = plan
+        return output_sh
+
+    @staticmethod
+    def backward(ctx, grad_output_sh):
+        """Restore replica weights, then scatter the output gradient back to VM group order."""
+        manager = ctx.manager
+        manager.prefetch(ctx.layer_buffers, ctx.plan)
+        manager.reset_grad_accumulators(ctx.layer_buffers)
+        grad_expert_output_nvsh, _, _, _ = manager.buffer.dispatch(
+            grad_output_sh.contiguous(), plan=ctx.plan
+        )
+        return grad_expert_output_nvsh, None, None, None
+
+
+class MoEMoonEPTokenDispatcher(MoETokenDispatcher):
+    """Dispatch tokens with MoonEP so every rank computes exactly S*K tokens.
+
+    MoonEP plans a small set of redundant experts from the current router output,
+    prefetches their weights over NVLink, and writes tokens straight into their
+    expert-grouped destination slots. The local expert axis therefore holds this
+    rank's own experts followed by the prefetch slots.
+    """
+
+    def __init__(
+        self,
+        num_local_experts: int,
+        local_expert_indices: List[int],
+        config: TransformerConfig,
+        pg_collection: Optional[ProcessGroupCollection] = None,
+        layer_number: Optional[int] = None,
+    ) -> None:
+        """
+        Initialize the MoonEP token dispatcher.
+
+        Args:
+            num_local_experts (int): Number of physical experts on this device.
+            local_expert_indices (List[int]): Global indices of this device's master experts.
+            config (TransformerConfig): Configuration for the transformer model.
+            pg_collection (ProcessGroupCollection, optional): Process groups for MoE operations.
+            layer_number (int, optional): One-based MoE layer number, used to key MoonEP's
+                per-layer symmetric weight and gradient storage.
+        """
+        super().__init__(config=config, pg_collection=pg_collection)
+        if self.tp_size != 1:
+            raise ValueError("MoonEP currently requires expert_tensor_parallel_size=1.")
+        if layer_number is None:
+            raise ValueError("MoonEP MoE layers require a stable layer_number.")
+
+        self.num_local_experts = num_local_experts
+        self.local_expert_indices = local_expert_indices
+        self.layer_number = layer_number
+        self.manager: MoonEPManager = get_or_create_moonep_manager(config, self.ep_group)
+        self.layer_buffers: MoonEPLayerBuffers = self.manager.register_layer(layer_number)
+        self.num_experts = config.num_moe_experts
+
+        self.hidden_shape: Optional[torch.Size] = None
+        self.plan = None
+        self.cu_seqlens: Optional[torch.Tensor] = None
+        self.num_dispatched_tokens: Optional[int] = None
+        self.num_padded_slots: Optional[int] = None
+
+    def reset_transient_forward_state(self) -> None:
+        """Release the per-forward plan and offsets; the backward reads autograd-saved state."""
+        self.plan = None
+        self.cu_seqlens = None
+
+    def dispatch_preprocess(
+        self, hidden_states: torch.Tensor, routing_map: torch.Tensor, probs: torch.Tensor
+    ):
+        """Flatten tokens and convert the multihot routing map into MoonEP's topk format."""
+        self.hidden_shape = hidden_states.shape
+        hidden_states = hidden_states.view(-1, self.hidden_shape[-1])
+        num_tokens = hidden_states.shape[0]
+
+        routing_map = routing_map.reshape(num_tokens, self.num_experts)
+        probs = probs.reshape(num_tokens, self.num_experts)
+        self.topk_probs, topk_indices = torch.topk(probs, self.config.moe_router_topk, dim=-1)
+        self.topk_indices = topk_indices.to(torch.int32).contiguous()
+        self.tokens_per_expert = routing_map.sum(dim=0).to(torch.int32).contiguous()
+
+        self.manager.stage_master_weights(self.layer_buffers)
+        return hidden_states, self.topk_probs
+
+    def token_dispatch(self, hidden_states: torch.Tensor, probs: Optional[torch.Tensor] = None):
+        """Run MoonEP planning, dispatch and weight prefetch."""
+        plan_holder: List = []
+        dispatched, route_weights_nvs, cu_seqlens = _MoonEPDispatch.apply(
+            hidden_states,
+            self.topk_probs.float().contiguous(),
+            self.topk_indices,
+            self.tokens_per_expert,
+            self.manager,
+            self.layer_buffers,
+            plan_holder,
+        )
+        self.plan = plan_holder[0]
+        self.cu_seqlens = cu_seqlens
+        return dispatched, route_weights_nvs
+
+    def dispatch_postprocess(self, hidden_states: torch.Tensor, probs: torch.Tensor):
+        """Slice the padded NVL buffer down to the rows this rank's group GEMM consumes."""
+        tokens_per_expert = self.manager.local_tokens_per_expert(self.cu_seqlens)
+        counts = tokens_per_expert.tolist()
+        total = sum(counts)
+        self.num_padded_slots = hidden_states.shape[0]
+        self.num_dispatched_tokens = total
+        return hidden_states[:total], tokens_per_expert, probs[:total]
+
+    def combine_preprocess(self, hidden_states: torch.Tensor):
+        """Pad expert outputs back to MoonEP's static [NvS, H] slot count."""
+        padded = hidden_states.new_zeros(self.num_padded_slots, hidden_states.shape[-1])
+        padded[: self.num_dispatched_tokens] = hidden_states
+        return padded
+
+    def token_combine(self, hidden_states: torch.Tensor):
+        """K-sum expert outputs back to token-major order."""
+        return _MoonEPCombine.apply(
+            hidden_states, self.manager, self.layer_buffers, self.plan
+        )
+
+    def combine_postprocess(self, hidden_states: torch.Tensor):
+        """Restore the original hidden-state shape."""
+        return hidden_states.view(self.hidden_shape)

--- a/megatron/core/transformer/moe/moonep_dispatcher.py
+++ b/megatron/core/transformer/moe/moonep_dispatcher.py
@@ -46,6 +46,8 @@ class _MoonEPDispatch(torch.autograd.Function):
     def backward(ctx, grad_hidden_nvsh, grad_route_weights_nvs, _grad_cu_seqlens):
         """Combine token gradients back and reduce duplicated experts' weight gradients."""
         manager = ctx.manager
+        if grad_route_weights_nvs is None:
+            grad_route_weights_nvs = torch.zeros_like(grad_hidden_nvsh[:, 0], dtype=torch.float32)
         grad_hidden_sh, grad_probs_sk, _ = manager.buffer.combine(
             plan=ctx.plan,
             hidden_nvsh=grad_hidden_nvsh.contiguous(),

--- a/megatron/core/transformer/moe/moonep_manager.py
+++ b/megatron/core/transformer/moe/moonep_manager.py
@@ -16,12 +16,7 @@ if TYPE_CHECKING:
 
 try:
     from moonep import Buffer, MoonEPCommPlan
-    from moonep._C import (
-        get_vmm_granularity,
-        nvl_dist_alloc,
-        nvl_dist_map,
-        nvl_release_mem_handle,
-    )
+    from moonep._C import get_vmm_granularity, nvl_dist_alloc, nvl_dist_map, nvl_release_mem_handle
     from moonep.buffer import _exchange_ipc_fds
     from moonep.grad_reduce import launch_grad_reduce
     from moonep.prefetch import launch_prefetch
@@ -381,10 +376,7 @@ class MoonEPManager:
         experts_to_copy = plan.experts_to_copy[self.rank]
         for projection in layer_buffers.projections():
             launch_prefetch(
-                projection.source_weights,
-                projection.prefetch_slots,
-                experts_to_copy,
-                self.num_sms,
+                projection.source_weights, projection.prefetch_slots, experts_to_copy, self.num_sms
             )
 
     def reset_grad_accumulators(self, layer_buffers: MoonEPLayerBuffers) -> None:
@@ -464,9 +456,7 @@ def expert_weight_shapes(config: TransformerConfig) -> Tuple[Tuple[int, int], Tu
     return (fc1_out, hidden), (hidden, ffn)
 
 
-def _config_signature(
-    config: TransformerConfig, ep_group: torch.distributed.ProcessGroup
-) -> tuple:
+def _config_signature(config: TransformerConfig, ep_group: torch.distributed.ProcessGroup) -> tuple:
     """Signature of the MoonEP settings every layer on a process group must agree on."""
     num_ranks = utils.get_pg_size(ep_group)
     fc1_shape, fc2_shape = expert_weight_shapes(config)

--- a/megatron/core/transformer/moe/moonep_manager.py
+++ b/megatron/core/transformer/moe/moonep_manager.py
@@ -58,8 +58,6 @@ class MoonEPProjectionBuffers:
     reduce_buffer: torch.Tensor
     num_global_experts: int
     master_parameters: List[torch.nn.Parameter] = field(default_factory=list)
-    master_weights: List[torch.Tensor] = field(default_factory=list)
-    master_main_grads: List[torch.Tensor] = field(default_factory=list)
 
     @property
     def source_weights(self) -> torch.Tensor:
@@ -348,8 +346,6 @@ class MoonEPManager:
             return
         for projection, linear in zip(layer_buffers.projections(), linear_modules):
             projection.master_parameters.clear()
-            projection.master_weights.clear()
-            projection.master_main_grads.clear()
             for index in range(self.num_local_master_experts):
                 param = getattr(linear, f"weight{index}")
                 main_grad = getattr(param, "main_grad", None)
@@ -363,8 +359,6 @@ class MoonEPManager:
                         "--accumulate-allreduce-grads-in-fp32."
                     )
                 projection.master_parameters.append(param)
-                projection.master_weights.append(param.data)
-                projection.master_main_grads.append(main_grad)
         layer_buffers.parameters_bound = True
 
     # ------------------------------------------------------------------
@@ -377,8 +371,10 @@ class MoonEPManager:
             raise RuntimeError("MoonEP master parameters are staged before they were bound.")
         for projection in layer_buffers.projections():
             local_rows = projection.source_weights[self.local_master_slice]
-            for index, weight in enumerate(projection.master_weights):
-                local_rows[index].copy_(weight)
+            # Read param.data live: the distributed optimizer re-points it on every
+            # overlapped parameter all-gather.
+            for index, param in enumerate(projection.master_parameters):
+                local_rows[index].copy_(param.data)
 
     def prefetch(self, layer_buffers: MoonEPLayerBuffers, plan: MoonEPCommPlan) -> None:
         """Copy the duplicated experts' weights from their home ranks into local slots."""
@@ -412,8 +408,8 @@ class MoonEPManager:
                 grid_sync_bar=ctx['grid_sync_bar'],
             )
             local_rows = projection.source_grads[self.local_master_slice]
-            for index, main_grad in enumerate(projection.master_main_grads):
-                main_grad.add_(local_rows[index])
+            for index, param in enumerate(projection.master_parameters):
+                param.main_grad.add_(local_rows[index])
         self.release_master_grads(layer_buffers)
 
     def release_master_grads(self, layer_buffers: MoonEPLayerBuffers) -> None:

--- a/megatron/core/transformer/moe/moonep_manager.py
+++ b/megatron/core/transformer/moe/moonep_manager.py
@@ -1,0 +1,497 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""MoonEP runtime ownership and per-layer buffer registration for MCore MoE."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+
+import torch
+
+from megatron.core import utils
+
+if TYPE_CHECKING:
+    from megatron.core.transformer.transformer_config import TransformerConfig
+
+try:
+    from moonep import Buffer, MoonEPCommPlan
+    from moonep._C import nvl_dist_alloc, nvl_dist_map, nvl_release_mem_handle
+    from moonep.buffer import _exchange_ipc_fds
+    from moonep.grad_reduce import launch_grad_reduce
+    from moonep.prefetch import launch_prefetch
+
+    HAVE_MOONEP = True
+except ImportError:
+    Buffer = None
+    MoonEPCommPlan = None
+    nvl_dist_alloc = None
+    nvl_dist_map = None
+    nvl_release_mem_handle = None
+    _exchange_ipc_fds = None
+    launch_grad_reduce = None
+    launch_prefetch = None
+    HAVE_MOONEP = False
+
+# MoonEP's prefetch and grad-reduce kernels tile both trailing weight dimensions.
+MOONEP_WEIGHT_TILE = 128
+
+
+@dataclass
+class MoonEPProjectionBuffers:
+    """MoonEP storage for one expert projection of one layer.
+
+    ``weight`` and ``grad`` are the contiguous [E+B, H, H'] VMM ranges MoonEP's
+    kernels expect: rows [0, E) map every rank's expert chunk (only this rank's
+    E/R rows are physically local) and rows [E, E+B) are the process-global
+    prefetch pool and gradient reduce chunk shared by all layers.
+    """
+
+    weight: torch.Tensor
+    grad: torch.Tensor
+    reduce_buffer: torch.Tensor
+    num_global_experts: int
+    master_parameters: List[torch.nn.Parameter] = field(default_factory=list)
+    master_weights: List[torch.Tensor] = field(default_factory=list)
+    master_main_grads: List[torch.Tensor] = field(default_factory=list)
+
+    @property
+    def source_weights(self) -> torch.Tensor:
+        """Rows [0, E): every rank's expert weights for this projection."""
+        return self.weight[: self.num_global_experts]
+
+    @property
+    def prefetch_slots(self) -> torch.Tensor:
+        """Rows [E, E+B): the local prefetch slots the duplicated experts land in."""
+        return self.weight[self.num_global_experts :]
+
+    @property
+    def source_grads(self) -> torch.Tensor:
+        """Rows [0, E): every rank's expert gradients for this projection."""
+        return self.grad[: self.num_global_experts]
+
+    @property
+    def prefetch_slot_grads(self) -> torch.Tensor:
+        """Rows [E, E+B): backed by this rank's chunk of the shared reduce buffer."""
+        return self.grad[self.num_global_experts :]
+
+
+@dataclass
+class MoonEPLayerBuffers:
+    """Per-layer MoonEP storage for the two TEGroupedMLP projections."""
+
+    fc1: MoonEPProjectionBuffers
+    fc2: MoonEPProjectionBuffers
+    parameters_bound: bool = False
+
+    def projections(self) -> Tuple[MoonEPProjectionBuffers, MoonEPProjectionBuffers]:
+        """Iterate projections in TEGroupedMLP order."""
+        return (self.fc1, self.fc2)
+
+
+@dataclass
+class _SharedChunk:
+    """A process-global chunk reused as the [E, E+B) tail of every layer's range."""
+
+    keepalive: torch.Tensor
+    fd: int
+    reduce_view: Optional[torch.Tensor] = None
+
+
+class MoonEPManager:
+    """Own one MoonEP runtime per expert-parallel process group.
+
+    The runtime holds the communication ``Buffer`` plus the process-global prefetch
+    pool and gradient reduce buffer that every MoE layer shares, and maps each
+    layer its own [E+B, H, H'] weight and gradient range.
+
+    Args:
+        config: Transformer configuration for the MoE model.
+        ep_group: Expert-parallel process group owned by this runtime.
+    """
+
+    def __init__(self, config: TransformerConfig, ep_group: torch.distributed.ProcessGroup) -> None:
+        if not HAVE_MOONEP:
+            raise ImportError(
+                "moe_token_dispatcher_type='moonep' requires the MoonEP package. Install "
+                "https://github.com/MoonshotAI/MoonEP in the training container."
+            )
+        if config.num_moe_experts is None or config.moe_ffn_hidden_size is None:
+            raise ValueError("MoonEP requires num_moe_experts and moe_ffn_hidden_size.")
+
+        self.config = config
+        self.group = ep_group
+        self.rank = utils.get_pg_rank(ep_group)
+        self.num_ranks = utils.get_pg_size(ep_group)
+        self.num_global_experts = config.num_moe_experts
+        if self.num_global_experts % self.num_ranks != 0:
+            raise ValueError(
+                f"MoonEP requires num_moe_experts ({self.num_global_experts}) to be divisible "
+                f"by the expert-parallel size ({self.num_ranks})."
+            )
+        self.num_local_master_experts = self.num_global_experts // self.num_ranks
+        # Training must reserve one prefetch slot per local expert: the planner can
+        # duplicate a whole remote home group onto this rank.
+        self.num_prefetch_slots = self.num_local_master_experts
+        self.num_local_physical_experts = self.num_local_master_experts + self.num_prefetch_slots
+        self.router_topk = config.moe_router_topk
+
+        self.fc1_shape, self.fc2_shape = expert_weight_shapes(config)
+        for name, shape in (("linear_fc1", self.fc1_shape), ("linear_fc2", self.fc2_shape)):
+            for dim in shape:
+                if dim % MOONEP_WEIGHT_TILE != 0:
+                    raise ValueError(
+                        f"MoonEP requires both {name} weight dims to be multiples of "
+                        f"{MOONEP_WEIGHT_TILE}, got {shape}."
+                    )
+
+        self.num_sms = config.moe_moonep_num_sms
+        self.token_padding = config.moe_moonep_token_padding
+        self._buffer: Optional[Buffer] = None
+        self._tokens_per_rank: Optional[int] = None
+        self._layers: Dict[int, MoonEPLayerBuffers] = {}
+        self._shared_chunks: Dict[str, _SharedChunk] = {}
+        self._closed = False
+
+    @property
+    def signature(self) -> tuple:
+        """Configuration fields that must match for layers sharing the runtime."""
+        return _config_signature(self.config, self.group)
+
+    @property
+    def local_master_slice(self) -> slice:
+        """Rows of the global [E] expert axis physically owned by this rank."""
+        start = self.rank * self.num_local_master_experts
+        return slice(start, start + self.num_local_master_experts)
+
+    # ------------------------------------------------------------------
+    # Runtime and storage
+    # ------------------------------------------------------------------
+
+    def ensure_buffer(self, tokens_per_rank: int) -> Buffer:
+        """Create the communication buffer on first use and pin its token count."""
+        if self._buffer is None:
+            self._buffer = Buffer(
+                S=tokens_per_rank,
+                H=self.config.hidden_size,
+                K=self.router_topk,
+                E=self.num_global_experts,
+                num_ep_ranks=self.num_ranks,
+                num_sms=self.num_sms,
+                token_padding=self.token_padding,
+                B=self.num_prefetch_slots,
+                group=self.group,
+                explicitly_destroy=True,
+            )
+            self._tokens_per_rank = tokens_per_rank
+        elif self._tokens_per_rank != tokens_per_rank:
+            raise ValueError(
+                f"MoonEP buffers are allocated for {self._tokens_per_rank} tokens per rank but "
+                f"got {tokens_per_rank}; variable sequence or micro-batch size is unsupported."
+            )
+        return self._buffer
+
+    @property
+    def buffer(self) -> Buffer:
+        """Return the communication buffer, which the first dispatch must have allocated."""
+        if self._buffer is None:
+            raise RuntimeError("MoonEP buffer is used before the first dispatch allocated it.")
+        return self._buffer
+
+    def _exchange_chunk_fds(self, local_fd: int) -> List[int]:
+        """Swap one chunk's POSIX handle with every rank in the expert-parallel group."""
+        received = _exchange_ipc_fds(
+            local_fd, list(range(self.num_ranks)), self.rank, self.num_ranks, self.group
+        )
+        return [received[peer] for peer in range(self.num_ranks)]
+
+    def _alloc_shared_chunk(
+        self, name: str, chunk_shape: List[int], dtype: torch.dtype, symmetric: bool
+    ) -> _SharedChunk:
+        """Allocate (once) the chunk every layer reuses as its [E, E+B) tail rows.
+
+        ``symmetric`` additionally maps all ranks' chunks as the [R, B, H, H']
+        reduce-buffer view that ``reduce_grad`` reads over NVLink.
+        """
+        if name in self._shared_chunks:
+            return self._shared_chunks[name]
+
+        keepalive, local_fd, owned_handle = nvl_dist_alloc(shape=chunk_shape, dtype=dtype)
+        tail_fd = os.dup(local_fd)
+        reduce_view = None
+        try:
+            if symmetric:
+                peer_fds = self._exchange_chunk_fds(local_fd)
+                try:
+                    reduce_view = nvl_dist_map(
+                        chunk_shape=chunk_shape,
+                        dtype=dtype,
+                        fds=peer_fds,
+                        local_rank=self.rank,
+                        world_size=self.num_ranks,
+                    ).view(self.num_ranks, *chunk_shape)
+                finally:
+                    for fd in peer_fds:
+                        os.close(fd)
+            os.close(local_fd)
+        finally:
+            nvl_release_mem_handle(owned_handle)
+
+        keepalive.zero_()
+        chunk = _SharedChunk(keepalive=keepalive, fd=tail_fd, reduce_view=reduce_view)
+        self._shared_chunks[name] = chunk
+        return chunk
+
+    def _map_expert_range(
+        self, chunk_shape: List[int], dtype: torch.dtype, tail_fd: int
+    ) -> torch.Tensor:
+        """Map [E+B, H, H'] as one VMM range: the R ranks' chunks then the shared tail."""
+        keepalive, local_fd, owned_handle = nvl_dist_alloc(shape=chunk_shape, dtype=dtype)
+        try:
+            peer_fds = self._exchange_chunk_fds(local_fd)
+            os.close(local_fd)
+            try:
+                full = nvl_dist_map(
+                    chunk_shape=chunk_shape,
+                    dtype=dtype,
+                    fds=peer_fds + [tail_fd],
+                    local_rank=self.rank,
+                    world_size=self.num_ranks + 1,
+                )
+            finally:
+                for fd in peer_fds:
+                    os.close(fd)
+        finally:
+            nvl_release_mem_handle(owned_handle)
+        full._keepalive = keepalive
+        return full
+
+    def _make_projection(self, name: str, shape: Tuple[int, int]) -> MoonEPProjectionBuffers:
+        """Allocate one layer's [E+B] weight and gradient ranges for one projection."""
+        chunk_shape = [self.num_prefetch_slots, shape[0], shape[1]]
+        pool = self._alloc_shared_chunk(f"{name}_pool", chunk_shape, torch.bfloat16, False)
+        reduce = self._alloc_shared_chunk(f"{name}_reduce", chunk_shape, torch.float32, True)
+        weight = self._map_expert_range(chunk_shape, torch.bfloat16, pool.fd)
+        grad = self._map_expert_range(chunk_shape, torch.float32, reduce.fd)
+        grad[self.local_master_slice].zero_()
+        return MoonEPProjectionBuffers(
+            weight=weight,
+            grad=grad,
+            reduce_buffer=reduce.reduce_view,
+            num_global_experts=self.num_global_experts,
+        )
+
+    def register_layer(self, layer_number: int) -> MoonEPLayerBuffers:
+        """Allocate (once) and return the MoonEP storage for one MoE layer."""
+        if layer_number not in self._layers:
+            self._layers[layer_number] = MoonEPLayerBuffers(
+                fc1=self._make_projection("fc1", self.fc1_shape),
+                fc2=self._make_projection("fc2", self.fc2_shape),
+            )
+        return self._layers[layer_number]
+
+    # ------------------------------------------------------------------
+    # Parameter binding
+    # ------------------------------------------------------------------
+
+    def bind_replica_parameters(
+        self, layer_buffers: MoonEPLayerBuffers, linear_modules: Tuple[torch.nn.Module, ...]
+    ) -> None:
+        """Point the prefetch-slot parameters at MoonEP's pool and reduce rows.
+
+        Runs before DDP so the marked replicas are skipped when its buffers are built
+        and the marked masters have their gradient release deferred past reduce_grad.
+        """
+        for projection, linear in zip(layer_buffers.projections(), linear_modules):
+            slots = projection.prefetch_slots
+            slot_grads = projection.prefetch_slot_grads
+            for index in range(self.num_local_master_experts):
+                getattr(linear, f"weight{index}")._moonep_is_master = True
+            for slot in range(self.num_prefetch_slots):
+                name = f"weight{self.num_local_master_experts + slot}"
+                param = getattr(linear, name, None)
+                if param is None:
+                    raise AttributeError(f"MoonEP expects per-expert parameter {name} in {linear}.")
+                if tuple(param.shape) != tuple(slots.shape[1:]):
+                    raise ValueError(
+                        f"MoonEP expert weight shape mismatch for {name}: expected "
+                        f"{tuple(slots.shape[1:])}, got {tuple(param.shape)}."
+                    )
+                param._moonep_is_replica = True
+                param.data = slots[slot]
+                param.main_grad = slot_grads[slot]
+
+    def bind_master_parameters(
+        self, layer_buffers: MoonEPLayerBuffers, linear_modules: Tuple[torch.nn.Module, ...]
+    ) -> None:
+        """Record master weight and DDP main-grad pointers after DDP has built its buffers."""
+        if layer_buffers.parameters_bound:
+            return
+        for projection, linear in zip(layer_buffers.projections(), linear_modules):
+            projection.master_parameters.clear()
+            projection.master_weights.clear()
+            projection.master_main_grads.clear()
+            for index in range(self.num_local_master_experts):
+                param = getattr(linear, f"weight{index}")
+                main_grad = getattr(param, "main_grad", None)
+                if main_grad is None:
+                    raise RuntimeError(
+                        "MoonEP master registration must run after MCore DDP initialization."
+                    )
+                if main_grad.dtype != torch.float32:
+                    raise TypeError(
+                        "MoonEP requires FP32 main gradients; enable "
+                        "--accumulate-allreduce-grads-in-fp32."
+                    )
+                projection.master_parameters.append(param)
+                projection.master_weights.append(param.data)
+                projection.master_main_grads.append(main_grad)
+        layer_buffers.parameters_bound = True
+
+    # ------------------------------------------------------------------
+    # Per-microbatch operations
+    # ------------------------------------------------------------------
+
+    def stage_master_weights(self, layer_buffers: MoonEPLayerBuffers) -> None:
+        """Publish this rank's master expert weights into its symmetric slice."""
+        if not layer_buffers.parameters_bound:
+            raise RuntimeError("MoonEP master parameters are staged before they were bound.")
+        for projection in layer_buffers.projections():
+            local_rows = projection.source_weights[self.local_master_slice]
+            for index, weight in enumerate(projection.master_weights):
+                local_rows[index].copy_(weight)
+
+    def prefetch(self, layer_buffers: MoonEPLayerBuffers, plan: MoonEPCommPlan) -> None:
+        """Copy the duplicated experts' weights from their home ranks into local slots."""
+        experts_to_copy = plan.experts_to_copy[self.rank]
+        for projection in layer_buffers.projections():
+            launch_prefetch(
+                projection.source_weights,
+                projection.prefetch_slots,
+                experts_to_copy,
+                self.num_sms,
+            )
+
+    def reset_grad_accumulators(self, layer_buffers: MoonEPLayerBuffers) -> None:
+        """Clear the rows that ``reduce_grad`` accumulates duplicated-expert wgrad into."""
+        for projection in layer_buffers.projections():
+            projection.source_grads[self.local_master_slice].zero_()
+
+    def reduce_grad(self, layer_buffers: MoonEPLayerBuffers, plan: MoonEPCommPlan) -> None:
+        """Merge duplicated experts' wgrad from every rank into the owning DDP gradients."""
+        ctx = self.buffer._ctx  # noqa: SLF001 - MoonEP exposes no public accessor yet
+        for projection in layer_buffers.projections():
+            launch_grad_reduce(
+                projection.source_grads,
+                projection.reduce_buffer,
+                plan.experts_to_copy,
+                rank=self.rank,
+                num_sms=self.num_sms,
+                meta_buf=ctx['meta_buf'],
+                meta_stride=int(ctx['meta_chunk_padded']),
+                barrier_off=int(ctx['BARRIER_OFF']),
+                grid_sync_bar=ctx['grid_sync_bar'],
+            )
+            local_rows = projection.source_grads[self.local_master_slice]
+            for index, main_grad in enumerate(projection.master_main_grads):
+                main_grad.add_(local_rows[index])
+        self.release_master_grads(layer_buffers)
+
+    def release_master_grads(self, layer_buffers: MoonEPLayerBuffers) -> None:
+        """Hand the completed master gradients to DDP's overlapping reduction.
+
+        DDP defers this for MoonEP masters so the duplicated-expert contribution is
+        already accumulated when the bucket reduce starts.
+        """
+        for projection in layer_buffers.projections():
+            for param in projection.master_parameters:
+                bucket_group = getattr(param, "_moonep_ddp_bucket_group", None)
+                if bucket_group is None or not bucket_group.ddp_config.overlap_grad_reduce:
+                    continue
+                bucket_group.register_grad_ready(
+                    param, getattr(param, "_moonep_force_all_reduce", False)
+                )
+
+    def close(self) -> None:
+        """Release the MoonEP runtime, its NVLink mappings and the retained chunk fds."""
+        if self._closed:
+            return
+        if self._buffer is not None:
+            self._buffer.destroy()
+            self._buffer = None
+        self._layers.clear()
+        for chunk in self._shared_chunks.values():
+            os.close(chunk.fd)
+        self._shared_chunks.clear()
+        self._closed = True
+
+    # ------------------------------------------------------------------
+    # Routing helpers
+    # ------------------------------------------------------------------
+
+    def local_tokens_per_expert(self, cu_seqlens: torch.Tensor) -> torch.Tensor:
+        """Turn MoonEP's [E+B] cumulative offsets into this rank's physical group sizes.
+
+        Rows outside this rank's home group are empty, so its master experts and then
+        its prefetch slots are already contiguous at the front of the dispatched buffer.
+        """
+        counts = cu_seqlens - torch.cat((cu_seqlens.new_zeros(1), cu_seqlens[:-1]))
+        masters = counts[self.local_master_slice]
+        slots = counts[self.num_global_experts :]
+        return torch.cat((masters, slots))
+
+
+def expert_weight_shapes(config: TransformerConfig) -> Tuple[Tuple[int, int], Tuple[int, int]]:
+    """Return the per-expert (fc1, fc2) weight shapes a TEGroupedMLP allocates."""
+    hidden = config.hidden_size
+    ffn = config.moe_ffn_hidden_size
+    fc1_out = 2 * ffn if config.gated_linear_unit else ffn
+    return (fc1_out, hidden), (hidden, ffn)
+
+
+def _config_signature(
+    config: TransformerConfig, ep_group: torch.distributed.ProcessGroup
+) -> tuple:
+    """Signature of the MoonEP settings every layer on a process group must agree on."""
+    num_ranks = utils.get_pg_size(ep_group)
+    fc1_shape, fc2_shape = expert_weight_shapes(config)
+    return (
+        config.num_moe_experts,
+        config.num_moe_experts // num_ranks,
+        config.moe_router_topk,
+        fc1_shape,
+        fc2_shape,
+        config.moe_moonep_num_sms,
+        config.moe_moonep_token_padding,
+    )
+
+
+_MOONEP_MANAGER_REGISTRY: Dict[int, MoonEPManager] = {}
+
+
+def get_or_create_moonep_manager(
+    config: TransformerConfig, ep_group: torch.distributed.ProcessGroup
+) -> MoonEPManager:
+    """Get the shared MoonEP runtime for an expert-parallel process group."""
+    key = id(ep_group)
+    manager = _MOONEP_MANAGER_REGISTRY.get(key)
+    if manager is None:
+        manager = MoonEPManager(config, ep_group)
+        _MOONEP_MANAGER_REGISTRY[key] = manager
+    elif manager.signature != _config_signature(config, ep_group):
+        raise ValueError(
+            "MoE layers sharing an EP process group must use the same MoonEP configuration."
+        )
+    return manager
+
+
+def clear_moonep_manager_registry() -> None:
+    """Drop Python references to cached MoonEP managers (primarily for tests)."""
+    _MOONEP_MANAGER_REGISTRY.clear()
+
+
+def destroy_moonep_managers() -> None:
+    """Destroy all MoonEP runtimes before the process group is torn down."""
+    for manager in _MOONEP_MANAGER_REGISTRY.values():
+        manager.close()
+    _MOONEP_MANAGER_REGISTRY.clear()

--- a/megatron/core/transformer/moe/moonep_manager.py
+++ b/megatron/core/transformer/moe/moonep_manager.py
@@ -16,7 +16,12 @@ if TYPE_CHECKING:
 
 try:
     from moonep import Buffer, MoonEPCommPlan
-    from moonep._C import nvl_dist_alloc, nvl_dist_map, nvl_release_mem_handle
+    from moonep._C import (
+        get_vmm_granularity,
+        nvl_dist_alloc,
+        nvl_dist_map,
+        nvl_release_mem_handle,
+    )
     from moonep.buffer import _exchange_ipc_fds
     from moonep.grad_reduce import launch_grad_reduce
     from moonep.prefetch import launch_prefetch
@@ -25,6 +30,7 @@ try:
 except ImportError:
     Buffer = None
     MoonEPCommPlan = None
+    get_vmm_granularity = None
     nvl_dist_alloc = None
     nvl_dist_map = None
     nvl_release_mem_handle = None
@@ -266,9 +272,22 @@ class MoonEPManager:
         full._keepalive = keepalive
         return full
 
+    def _check_chunk_alignment(self, name: str, chunk_shape: List[int]) -> None:
+        """MoonEP maps chunks with cuMemMap, so each must be an exact VMM granularity multiple."""
+        granularity = get_vmm_granularity()
+        for dtype, size in ((torch.bfloat16, 2), (torch.float32, 4)):
+            nbytes = chunk_shape[0] * chunk_shape[1] * chunk_shape[2] * size
+            if nbytes % granularity != 0:
+                raise ValueError(
+                    f"MoonEP {name} {dtype} chunk of {nbytes} bytes (shape {chunk_shape}) is not a "
+                    f"multiple of the {granularity}-byte VMM granularity; adjust the expert "
+                    f"count per rank or the expert FFN size."
+                )
+
     def _make_projection(self, name: str, shape: Tuple[int, int]) -> MoonEPProjectionBuffers:
         """Allocate one layer's [E+B] weight and gradient ranges for one projection."""
         chunk_shape = [self.num_prefetch_slots, shape[0], shape[1]]
+        self._check_chunk_alignment(name, chunk_shape)
         pool = self._alloc_shared_chunk(f"{name}_pool", chunk_shape, torch.bfloat16, False)
         reduce = self._alloc_shared_chunk(f"{name}_reduce", chunk_shape, torch.float32, True)
         weight = self._map_expert_range(chunk_shape, torch.bfloat16, pool.fd)

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -924,9 +924,15 @@ class TransformerConfig(ModelParallelConfig):
     specified capacity, similar to GShard, Switch-Transformer, and DeepSpeed-MoE. Note that this is
     currently unsupported so should remain False."""
 
-    moe_token_dispatcher_type: Literal['allgather', 'alltoall', 'flex'] = "allgather"
+    moe_token_dispatcher_type: Literal['allgather', 'alltoall', 'flex', 'moonep'] = "allgather"
     """The type of token dispatcher to use. The default is 'allgather'.
-    Options are 'allgather','alltoall' and 'flex'."""
+    Options are 'allgather','alltoall', 'flex' and 'moonep'."""
+
+    moe_moonep_num_sms: int = 32
+    """Number of SMs for MoonEP's dispatch/combine/prefetch/grad-reduce kernels."""
+
+    moe_moonep_token_padding: int = 128
+    """Token multiple each non-empty MoonEP expert group is padded up to."""
 
     moe_enable_deepep: bool = False
     """[Experimental] Enable DeepEP for efficient token dispatching and combine in MoE models."""
@@ -1996,6 +2002,9 @@ class TransformerConfig(ModelParallelConfig):
                     "moe_flex_dispatcher_backend='ncclep' requires "
                     "moe_token_dispatcher_type='flex'."
                 )
+
+        if self.moe_token_dispatcher_type == "moonep":
+            self._validate_moonep()
 
         # moe_deepep_num_sms / moe_hybridep_num_sms are deprecated and unified into
         # moe_flex_dispatcher_num_sms. If either is set, route it (an explicit
@@ -3512,6 +3521,45 @@ class TransformerConfig(ModelParallelConfig):
                     f"Unsupported scheduler: {self.sequence_packing_scheduler}. "
                     f"Available schedulers: {supported_schedulers}"
                 )
+
+    def _validate_moonep(self):
+        """Reject configurations the MoonEP token dispatcher does not implement yet."""
+        if self.num_moe_experts is None or self.moe_ffn_hidden_size is None:
+            raise ValueError("MoonEP requires num_moe_experts and moe_ffn_hidden_size.")
+        if not self.moe_grouped_gemm:
+            raise ValueError("MoonEP requires moe_grouped_gemm=True (TEGroupedMLP).")
+        if self.expert_tensor_parallel_size not in (None, 1):
+            raise ValueError("MoonEP currently requires expert_tensor_parallel_size=1.")
+        if not self.gradient_accumulation_fusion:
+            raise ValueError("MoonEP requires gradient_accumulation_fusion=True.")
+        # MoonEP's dispatch/combine and prefetch kernels assert bf16 activations and
+        # bf16 expert weights; there is no FP8/FP4 path in the library.
+        if self.params_dtype != torch.bfloat16 or self.fp8 or self.fp4:
+            raise ValueError("MoonEP supports BF16 expert weights and activations only.")
+        if not self.gated_linear_unit:
+            raise ValueError("MoonEP currently requires a gated expert MLP (for example SwiGLU).")
+        if self.add_bias_linear:
+            raise ValueError("MoonEP currently requires add_bias_linear=False.")
+        if self.moe_single_grouped_weight or self.moe_single_grouped_bias:
+            raise ValueError("MoonEP does not support single grouped expert parameters.")
+        if self.moe_latent_size is not None:
+            raise ValueError("MoonEP does not currently support latent MoE projections.")
+        if self.use_transformer_engine_op_fuser:
+            raise ValueError("MoonEP does not currently support the TE operation fuser.")
+        if self.cuda_graph_impl != "none":
+            raise ValueError("MoonEP does not currently support CUDA graph capture.")
+        if self.overlap_moe_expert_parallel_comm:
+            raise ValueError("MoonEP does not currently support batch-level EP overlap.")
+        if self.overlap_dispatch_backward_with_experts_wgrad:
+            raise ValueError("MoonEP does not currently support delayed expert wgrad overlap.")
+        if self.delay_wgrad_compute:
+            raise ValueError("MoonEP does not currently support delay_wgrad_compute.")
+        if self.transformer_impl == "inference_optimized":
+            raise ValueError("MoonEP integration currently supports training mode only.")
+        if self.moe_expert_capacity_factor is not None or self.moe_pad_expert_input_to_capacity:
+            raise ValueError("MoonEP supports dropless MoE routing only.")
+        if self.moe_shared_expert_overlap:
+            raise ValueError("MoonEP does not currently support moe_shared_expert_overlap.")
 
 
 @dataclass

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -3530,8 +3530,8 @@ class TransformerConfig(ModelParallelConfig):
             raise ValueError("MoonEP requires moe_grouped_gemm=True (TEGroupedMLP).")
         if self.expert_tensor_parallel_size not in (None, 1):
             raise ValueError("MoonEP currently requires expert_tensor_parallel_size=1.")
-        if not self.gradient_accumulation_fusion:
-            raise ValueError("MoonEP requires gradient_accumulation_fusion=True.")
+        if self.mtp_num_layers not in (None, 0):
+            raise ValueError("MoonEP does not currently support MTP layers.")
         # MoonEP's dispatch/combine and prefetch kernels assert bf16 activations and
         # bf16 expert weights; there is no FP8/FP4 path in the library.
         if self.params_dtype != torch.bfloat16 or self.fp8 or self.fp4:

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1078,6 +1078,17 @@ def validate_args(args, defaults={}):
             args.overlap_grad_reduce
         ), 'Must use --overlap-param-gather with --overlap-grad-reduce'
 
+    if args.moe_token_dispatcher_type == "moonep":
+        if args.use_torch_fsdp2 or args.use_megatron_fsdp:
+            raise ValueError(
+                "MoonEP currently supports MCore DDP only; disable FSDP for this integration."
+            )
+        if not args.accumulate_allreduce_grads_in_fp32:
+            raise ValueError(
+                "MoonEP requires --accumulate-allreduce-grads-in-fp32 so master and replica "
+                "gradients use the same FP32 dtype."
+            )
+
     if args.use_torch_fsdp2:
         assert is_torch_min_version("2.4.0"), 'FSDP2 requires PyTorch >= 2.4.0 with FSDP 2 support.'
         assert (

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1921,6 +1921,13 @@ def pretrain(
     if args.perform_rl_step:
         rl_utils.rl_inference_interface_shutdown()
 
+    if args.moe_token_dispatcher_type == "moonep":
+        # MoonEP holds VMM/NVLink mappings that must be released before the process
+        # group is torn down.
+        from megatron.core.transformer.moe.moonep_manager import destroy_moonep_managers
+
+        destroy_moonep_managers()
+
     ft_integration.shutdown()
     one_logger_utils.finish()
 

--- a/tests/unit_tests/test_optimizer.py
+++ b/tests/unit_tests/test_optimizer.py
@@ -73,6 +73,21 @@ class Net(nn.Module):
 @patch(
     'torch.distributed.all_gather_object', lambda output_list, obj: output_list.__setitem__(0, obj)
 )
+def test_get_param_groups_excludes_moonep_replicas(mock_get_world_size):
+    net = Net()
+    net.fc3.weight._moonep_is_replica = True
+
+    param_groups = _get_param_groups([net], OptimizerConfig(optimizer='adam', lr=0.01), {})
+    optimizer_params = {param for group in param_groups for param in group['params']}
+
+    assert net.fc3.weight not in optimizer_params
+    assert optimizer_params == set(net.parameters()) - {net.fc3.weight}
+
+
+@patch('torch.distributed.get_world_size', return_value=1)
+@patch(
+    'torch.distributed.all_gather_object', lambda output_list, obj: output_list.__setitem__(0, obj)
+)
 def test_get_param_groups_no_overrides(mock_get_world_size):
     net = Net()
     # NOTE: to get no overrides, supply an empty dictionary rather than None.

--- a/tests/unit_tests/transformer/moe/test_moonep.py
+++ b/tests/unit_tests/transformer/moe/test_moonep.py
@@ -1,0 +1,189 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from megatron.core.dist_checkpointing.mapping import ShardedObject, ShardedTensor
+from megatron.core.transformer.moe import moonep_manager
+from megatron.core.transformer.moe.experts import TEGroupedMLP, _parse_te_expert_idx
+from megatron.core.transformer.moe.moonep_manager import MoonEPManager, expert_weight_shapes
+from megatron.core.transformer.transformer_config import TransformerConfig
+
+
+def _moonep_config_kwargs(**overrides):
+    kwargs = dict(
+        num_layers=2,
+        hidden_size=256,
+        num_attention_heads=4,
+        num_moe_experts=8,
+        moe_ffn_hidden_size=128,
+        expert_model_parallel_size=2,
+        expert_tensor_parallel_size=1,
+        moe_grouped_gemm=True,
+        moe_token_dispatcher_type='moonep',
+        gradient_accumulation_fusion=True,
+        params_dtype=torch.bfloat16,
+        gated_linear_unit=True,
+        add_bias_linear=False,
+    )
+    kwargs.update(overrides)
+    return kwargs
+
+
+def test_moonep_transformer_config_accepts_supported_configuration():
+    config = TransformerConfig(**_moonep_config_kwargs())
+
+    assert config.moe_token_dispatcher_type == 'moonep'
+    assert config.moe_moonep_num_sms == 32
+    assert config.moe_moonep_token_padding == 128
+
+
+@pytest.mark.parametrize(
+    ("overrides", "match"),
+    [
+        ({"moe_grouped_gemm": False}, "moe_grouped_gemm"),
+        ({"add_bias_linear": True}, "add_bias_linear"),
+        ({"gated_linear_unit": False}, "gated expert MLP"),
+        ({"expert_tensor_parallel_size": 2}, "expert_tensor_parallel_size"),
+        ({"params_dtype": torch.float16}, "BF16"),
+        ({"moe_expert_capacity_factor": 1.0}, "dropless"),
+    ],
+)
+def test_moonep_transformer_config_rejects_unsupported_configuration(overrides, match):
+    with pytest.raises(ValueError, match=match):
+        TransformerConfig(**_moonep_config_kwargs(**overrides))
+
+
+def test_expert_weight_shapes_uses_fused_gated_fc1():
+    config = TransformerConfig(**_moonep_config_kwargs())
+
+    assert expert_weight_shapes(config) == ((256, 256), (256, 128))
+
+
+@pytest.mark.parametrize(
+    ("key", "expected"),
+    [
+        ("linear_fc1.weight0", 0),
+        ("linear_fc1.bias12", 12),
+        ("linear_fc1._extra_state", None),
+        ("linear_fc2.weight1", None),
+        ("linear_fc1.weight", None),
+    ],
+)
+def test_parse_te_expert_idx(key, expected):
+    assert _parse_te_expert_idx(key, "linear_fc1") == expected
+
+
+def test_moonep_checkpoint_filter_drops_replica_entries_in_singleton_mode():
+    experts = TEGroupedMLP.__new__(TEGroupedMLP)
+    torch.nn.Module.__init__(experts)
+    experts.ep_group = SimpleNamespace(size=lambda: 2, rank=lambda: 1)
+    master_value = object()
+    extra_state = object()
+
+    filtered = experts._filter_replica_checkpoint_entries(
+        {
+            "linear_fc1.weight0": master_value,
+            "linear_fc1.weight1": object(),
+            "linear_fc1._extra_state": extra_state,
+        },
+        "linear_fc1",
+        ep_axis=0,
+        num_local_master_experts=1,
+        fix_metadata=False,
+    )
+
+    assert filtered == {"linear_fc1.weight0": master_value, "linear_fc1._extra_state": extra_state}
+
+
+def test_moonep_checkpoint_filter_restores_logical_expert_metadata():
+    experts = TEGroupedMLP.__new__(TEGroupedMLP)
+    torch.nn.Module.__init__(experts)
+    experts.ep_group = SimpleNamespace(size=lambda: 2, rank=lambda: 1)
+    master = ShardedTensor.from_rank_offsets(
+        "linear_fc2.weight0", torch.zeros(2, 3), (0, 3, 6), prepend_axis_num=1
+    )
+    replica = ShardedTensor.from_rank_offsets(
+        "linear_fc2.weight1", torch.zeros(2, 3), (0, 4, 6), prepend_axis_num=1
+    )
+    extra_state = ShardedObject("linear_fc2._extra_state", object(), (1,), (0,))
+
+    filtered = experts._filter_replica_checkpoint_entries(
+        {
+            "linear_fc2.weight0": master,
+            "linear_fc2.weight1": replica,
+            "linear_fc2._extra_state": extra_state,
+        },
+        "linear_fc2",
+        ep_axis=0,
+        num_local_master_experts=1,
+        fix_metadata=True,
+    )
+
+    assert set(filtered) == {"linear_fc2.weight0", "linear_fc2._extra_state"}
+    assert filtered["linear_fc2.weight0"].global_shape == (2, 2, 3)
+    assert filtered["linear_fc2.weight0"].global_offset == (1, 0, 0)
+    assert filtered["linear_fc2._extra_state"] is extra_state
+
+
+def _manager_stub(rank, num_ranks, num_global_experts):
+    manager = MoonEPManager.__new__(MoonEPManager)
+    manager.rank = rank
+    manager.num_ranks = num_ranks
+    manager.num_global_experts = num_global_experts
+    manager.num_local_master_experts = num_global_experts // num_ranks
+    manager.num_prefetch_slots = manager.num_local_master_experts
+    return manager
+
+
+def test_local_master_slice_selects_this_ranks_home_group():
+    manager = _manager_stub(rank=2, num_ranks=4, num_global_experts=8)
+
+    assert manager.local_master_slice == slice(4, 6)
+
+
+def test_local_tokens_per_expert_takes_home_group_then_prefetch_slots():
+    manager = _manager_stub(rank=1, num_ranks=2, num_global_experts=4)
+    # Rows: experts 0..3 then 2 prefetch slots; rank 1 owns experts 2 and 3.
+    counts = torch.tensor([0, 0, 5, 7, 3, 4], dtype=torch.int32)
+    cu_seqlens = torch.cumsum(counts, dim=0).to(torch.int32)
+
+    assert manager.local_tokens_per_expert(cu_seqlens).tolist() == [5, 7, 3, 4]
+
+
+def test_local_tokens_per_expert_handles_an_empty_home_group():
+    manager = _manager_stub(rank=0, num_ranks=2, num_global_experts=4)
+    counts = torch.tensor([0, 0, 0, 0, 6, 0], dtype=torch.int32)
+    cu_seqlens = torch.cumsum(counts, dim=0).to(torch.int32)
+
+    assert manager.local_tokens_per_expert(cu_seqlens).tolist() == [0, 0, 6, 0]
+
+
+def test_destroy_moonep_managers_closes_and_clears_registry():
+    manager_a = SimpleNamespace(close=Mock())
+    manager_b = SimpleNamespace(close=Mock())
+    moonep_manager._MOONEP_MANAGER_REGISTRY.update({1: manager_a, 2: manager_b})
+
+    moonep_manager.destroy_moonep_managers()
+
+    manager_a.close.assert_called_once_with()
+    manager_b.close.assert_called_once_with()
+    assert moonep_manager._MOONEP_MANAGER_REGISTRY == {}
+
+
+def test_moonep_manager_close_is_idempotent():
+    manager = MoonEPManager.__new__(MoonEPManager)
+    manager._buffer = SimpleNamespace(destroy=Mock())
+    manager._layers = {}
+    manager._shared_chunks = {}
+    manager._closed = False
+
+    buffer = manager._buffer
+    manager.close()
+    manager.close()
+
+    buffer.destroy.assert_called_once_with()
+    assert manager._closed


### PR DESCRIPTION
## Summary

Add [MoonEP](https://github.com/MoonshotAI/MoonEP) as a new MoE token dispatcher
(`--moe-token-dispatcher-type moonep`).

MoonEP removes expert-parallel load imbalance rather than tolerating it. Each
microbatch is planned on the GPU from the current router output: a few hot experts
are duplicated onto ranks with spare capacity, their weights are prefetched over
NVLink, and tokens are written straight into their expert-grouped destination
slots. Every rank then computes exactly `S x K` tokens with statically known
shapes. Duplicated experts' weight gradients are reduced back to their home rank
in the backward pass.

Structure follows the UltraEP integration in Victarry/Megatron-LM#5.

### What's here

- `moe/moonep_manager.py` — one runtime per EP process group: the communication
  `Buffer`, the process-global prefetch pool and gradient reduce buffer shared by
  all layers, and each layer's contiguous `[E+B, H, H']` weight/gradient VMM range
  (R peer chunks plus the shared tail chunk).
- `moe/moonep_dispatcher.py` — dispatch/combine with autograd. The permuted-probs
  backward reuses MoonEP's combine route-weight gather.
- Each EP rank reserves `num_experts / EP` prefetch slots, so its grouped GEMM runs
  over twice as many physical experts as it owns. Those slot parameters alias
  MoonEP storage and are excluded from DDP, optimizer state and distributed
  checkpoints. Master expert gradients are released to DDP only after `reduce_grad`
  has merged the duplicated experts' wgrad.
- Config fields, a validator for unsupported combinations, `moe/README.md`, and
  unit tests.

Supported: BF16 experts, ETP1, grouped GEMM, FP32 main gradients, dropless
routing, MCore DDP, DP/PP/VPP. The validator rejects FP8/FP4 experts, FSDP,
expert TP, single grouped expert weights, latent MoE, MTP, CUDA graphs, the TE
operation fuser, batch-level EP overlap, delayed expert wgrad, and
inference-optimized layers. MoonEP requires an NVLink domain (expert parallelism
must stay inside one node) and expert weight dims that are multiples of 128.

## Test plan

EOS H100, `h100-torch2603` + MoonEP built against `nvidia-cutlass-dsl==4.4.2`.

**Unit tests**
- `tests/unit_tests/transformer/moe/test_moonep.py`: 20 passed
- `tests/unit_tests/test_optimizer.py -k moonep`: 1 passed
- MoonEP's own 8-GPU suite (planning / prefetch / dispatch / combine / grad_reduce / e2e): 67 passed

**End-to-end** — 8-layer MoE proxy (hidden 1024, 32 experts, top-4, seq 2048),
SlimPajama, 500 steps, **forced router load balancing disabled** (verified in the
run logs), `alltoall` vs `moonep`:

| config | final lm loss (alltoall) | final lm loss (moonep) | rel |
|---|---|---|---|
| PP1 / EP8 | 6.102471 | 6.086476 | 2.6e-3 |
| PP2 / VPP2 / EP4 | 6.103039 | 6.101658 | 2.3e-4 |

Both start at ~10.54 and converge to ~6.10; MoonEP ends marginally lower in both.

The redundant-expert path is genuinely exercised, not idle: instrumenting
`plan.experts_to_copy` over the PP1 run shows **87% of the 64,000 prefetch calls
duplicate a hot expert** (1 of 4 slots), 0.7% duplicate two.

**Numerical behaviour.** Two independent `moonep` runs are bitwise identical
across all 500 steps, so the prefetch / grad-reduce / barrier sequencing is
race-free. Against `alltoall` the results are not bitwise: SHA-hashing the MoE
layer boundary shows the layer *input* is bitwise identical on the first two
calls while the *output* already differs, so the divergence originates inside the
dispatch/expert/combine path and is present from the first forward. Iteration-1
relative loss difference is 3.4e-4 (PP1) and 1.6e-3 (PP2/VPP2). I have not
isolated whether this comes from the combine K-sum order, the grouped-GEMM tiling
driven by differing per-expert token counts, or both — a `top-k=1` run did not
collapse the gap, so the K-sum order alone does not explain it.

## Note for reviewers

`MoonEPManager.reduce_grad` reads four fields (`meta_buf`, `meta_chunk_padded`,
`BARRIER_OFF`, `grid_sync_bar`) from `Buffer._ctx` because MoonEP does not yet
expose a public accessor for its cross-rank barrier state. That is the only
private-API coupling and is confined to one function; I intend to upstream a
public accessor to MoonEP and switch to it.
