### PR TITLE
Fix latent-MoE expert fc2 initialization

### DIFF
--- a/megatron/core/transformer/mlp.py
+++ b/megatron/core/transformer/mlp.py
@@ -241,7 +241,14 @@ class MLP(MegatronModule):
                 self.config.hidden_size if not use_latent_size else self.config.moe_latent_size
             ),
             config=self.config,
-            init_method=not_none(self.config.output_layer_init_method),
+            # For latent MoE, linear_fc2 projects to the latent dim, not the hidden dim,
+            # so it is an intermediate layer. The residual-scaled output_layer_init_method
+            # belongs to fc2_latent_proj (latent -> hidden), the true output projection.
+            init_method=(
+                not_none(self.config.init_method)
+                if use_latent_size
+                else not_none(self.config.output_layer_init_method)
+            ),
             bias=self.config.add_bias_linear,
             input_is_parallel=True,
             skip_bias_add=True,

--- a/megatron/core/transformer/moe/experts.py
+++ b/megatron/core/transformer/moe/experts.py
@@ -241,7 +241,14 @@ class TEGroupedMLP(MegatronModule):
                 else self.config.moe_latent_size
             ),
             config=self.config,
-            init_method=not_none(self.config.output_layer_init_method),
+            # For latent MoE, linear_fc2 projects to the latent dim, not the hidden dim,
+            # so it is an intermediate layer. The residual-scaled output_layer_init_method
+            # belongs to fc2_latent_proj (latent -> hidden), the true output projection.
+            init_method=(
+                not_none(self.config.init_method)
+                if self.config.moe_latent_size is not None
+                else not_none(self.config.output_layer_init_method)
+            ),
             bias=self.config.add_bias_linear,
             skip_bias_add=True,
             is_expert=True,


### PR DESCRIPTION
For latent MoE, the expert linear_fc2 projects to the latent dimension and is an intermediate layer, not the output projection. It was incorrectly initialized with output_layer_init_method (residual-scaled). Use init_method for the expert fc2 when moe_latent_size is set, and reserve output_layer_init_method for fc2_latent_proj, which projects latent back to the hidden dimension and is the true output projection.

- [ ] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
<!-- Add a one line overview of what this PR aims to accomplish. -->

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
