### PR TITLE
Support heterogeneous DDP overlap in multimodal model training

### DIFF
--- a/examples/mimo/training/builder.py
+++ b/examples/mimo/training/builder.py
@@ -24,7 +24,6 @@ from megatron.core.transformer.module import Float16Module
 from megatron.training.global_vars import get_args
 from megatron.training.models.base import ModelBuilder, ModelConfig, compose_hooks
 
-# Match the standalone language-model RNG; only encoders need role offsets.
 _LANGUAGE_SEED_OFFSET = 0
 # Add per-encoder offsets before wiring more than one encoder grid.
 _ENCODER_SEED_OFFSET = 10_000

--- a/examples/mimo/training/builder.py
+++ b/examples/mimo/training/builder.py
@@ -166,7 +166,13 @@ class MimoModelBuilder(ModelBuilder[MimoModel, MimoBuildConfig]):
             )
         mimo_model = model_list[0]
 
-        wrap_active_modules_with_ddp(args, mimo_model, topology, data_parallel_random_init)
+        wrap_active_modules_with_ddp(
+            args,
+            mimo_model,
+            topology,
+            ddp_config=ddp_config,
+            data_parallel_random_init=data_parallel_random_init,
+        )
         configure_grad_sync(args, mimo_model, topology)
         mimo_model.pg_collection = module_pg
         mimo_model.rng_state_key_prefix = rng_state_key_prefix

--- a/examples/mimo/training/builder.py
+++ b/examples/mimo/training/builder.py
@@ -24,7 +24,8 @@ from megatron.core.transformer.module import Float16Module
 from megatron.training.global_vars import get_args
 from megatron.training.models.base import ModelBuilder, ModelConfig, compose_hooks
 
-_LANGUAGE_SEED_OFFSET = 20_000
+# Match the standalone language-model RNG; only encoders need role offsets.
+_LANGUAGE_SEED_OFFSET = 0
 # Add per-encoder offsets before wiring more than one encoder grid.
 _ENCODER_SEED_OFFSET = 10_000
 
@@ -97,9 +98,7 @@ class MimoModelBuilder(ModelBuilder[MimoModel, MimoBuildConfig]):
 
         mimo_config = MimoModelConfig(
             language_model_spec=provider.language_spec(
-                args,
-                active_pg if is_language else None,
-                topology.grids[MIMO_LANGUAGE_MODULE_KEY],
+                args, active_pg if is_language else None, topology.grids[MIMO_LANGUAGE_MODULE_KEY]
             ),
             modality_submodules_spec=modality_submodules_spec,
             special_token_ids=special_token_ids,
@@ -128,6 +127,8 @@ class MimoModelBuilder(ModelBuilder[MimoModel, MimoBuildConfig]):
         use_layer_wise_param_layout: bool = True,
     ) -> list[MimoModel]:
         """Seed, build, prepare, and configure the active rank-local MIMO model."""
+        if use_megatron_fsdp or use_torch_fsdp2:
+            raise NotImplementedError("MIMO training with FSDP/FSDP2 has not been tested yet.")
         if wrap_with_ddp and ddp_config is None:
             raise ValueError("ddp_config is required when wrap_with_ddp is True")
         # MIMO wraps its submodules via wrap_active_modules_with_ddp() rather than the

--- a/examples/mimo/training/runtime.py
+++ b/examples/mimo/training/runtime.py
@@ -81,16 +81,13 @@ def _module_config(module: torch.nn.Module):
 def _ddp_config_from_args(
     args: argparse.Namespace, enable_overlap: bool
 ) -> DistributedDataParallelConfig:
-    """Build a DDP config from CLI args; when ``enable_overlap`` is False both overlaps are off."""
-    return DistributedDataParallelConfig(
-        overlap_grad_reduce=enable_overlap and getattr(args, "overlap_grad_reduce", False),
-        overlap_param_gather=enable_overlap and getattr(args, "overlap_param_gather", False),
-        num_buckets=getattr(args, "ddp_num_buckets", None),
-        bucket_size=getattr(args, "ddp_bucket_size", None),
-        pad_buckets_for_high_nccl_busbw=getattr(args, "ddp_pad_buckets_for_high_nccl_busbw", False),
-        use_distributed_optimizer=True,
-        grad_reduce_in_fp32=getattr(args, "accumulate_allreduce_grads_in_fp32", True),
-    )
+    """Build a module-role DDP config from the global CLI arguments."""
+    from megatron.training.training import get_megatron_ddp_config
+
+    config = get_megatron_ddp_config(args)
+    config.overlap_grad_reduce &= enable_overlap
+    config.overlap_param_gather &= enable_overlap
+    return config
 
 
 def wrap_active_modules_with_ddp(

--- a/examples/mimo/training/runtime.py
+++ b/examples/mimo/training/runtime.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import argparse
+from dataclasses import replace
 
 import torch
 
@@ -78,22 +79,22 @@ def _module_config(module: torch.nn.Module):
     raise ValueError("Cannot resolve a config for DDP wrapping from module")
 
 
-def _ddp_config_from_args(
-    args: argparse.Namespace, enable_overlap: bool
+def _ddp_config_for_role(
+    ddp_config: DistributedDataParallelConfig, enable_overlap: bool
 ) -> DistributedDataParallelConfig:
-    """Build a module-role DDP config from the global CLI arguments."""
-    from megatron.training.training import get_megatron_ddp_config
-
-    config = get_megatron_ddp_config(args)
-    config.overlap_grad_reduce &= enable_overlap
-    config.overlap_param_gather &= enable_overlap
-    return config
+    """Derive a role-specific DDP config without mutating the caller's config."""
+    return replace(
+        ddp_config,
+        overlap_grad_reduce=ddp_config.overlap_grad_reduce and enable_overlap,
+        overlap_param_gather=ddp_config.overlap_param_gather and enable_overlap,
+    )
 
 
 def wrap_active_modules_with_ddp(
     args: argparse.Namespace,
     mimo_model: MimoModel,
     topology: HeteroTopology,
+    ddp_config: DistributedDataParallelConfig,
     data_parallel_random_init: bool = False,
 ) -> None:
     """Freeze (per --freeze-* flags), Float16Module-wrap, and DDP-wrap each active module."""
@@ -106,7 +107,7 @@ def wrap_active_modules_with_ddp(
             [mimo_model.language_model],
             lm_config,
             topology.module_pgs[MIMO_LANGUAGE_MODULE_KEY],
-            ddp_config=_ddp_config_from_args(args, enable_overlap=True),
+            ddp_config=_ddp_config_for_role(ddp_config, enable_overlap=True),
             data_parallel_random_init=data_parallel_random_init,
             mixed_precision_wrapper=Float16Module,
         )[0]
@@ -122,8 +123,8 @@ def wrap_active_modules_with_ddp(
                 [submodule],
                 enc_config,
                 topology.module_pgs[name],
-                ddp_config=_ddp_config_from_args(
-                    args, enable_overlap=getattr(args, "encoder_ddp_overlap", False)
+                ddp_config=_ddp_config_for_role(
+                    ddp_config, enable_overlap=getattr(args, "encoder_ddp_overlap", False)
                 ),
                 data_parallel_random_init=data_parallel_random_init,
                 mixed_precision_wrapper=_EncoderFloat16Module,

--- a/examples/mimo/training/runtime.py
+++ b/examples/mimo/training/runtime.py
@@ -88,6 +88,10 @@ def _ddp_config_from_args(
         pad_buckets_for_high_nccl_busbw=getattr(args, "ddp_pad_buckets_for_high_nccl_busbw", False),
         use_distributed_optimizer=True,
         grad_reduce_in_fp32=getattr(args, "accumulate_allreduce_grads_in_fp32", True),
+        fp8_param_gather=getattr(args, "fp8_param_gather", False),
+        reuse_grad_buf_for_mxfp8_param_ag=getattr(
+            args, "reuse_grad_buf_for_mxfp8_param_ag", False
+        ),
     )
 
 

--- a/megatron/core/models/mimo/model/base.py
+++ b/megatron/core/models/mimo/model/base.py
@@ -299,6 +299,14 @@ class MimoModel(MegatronModule):
             if isinstance(module, DistributedDataParallel):
                 yield module
 
+    @property
+    def remove_forward_pre_hook_handles(self) -> Dict[torch.nn.Module, Any]:
+        """Expose the active inner DDP parameter-gather hooks to the stock train loop."""
+        handles = {}
+        for module in self._active_ddp_modules():
+            handles.update(module.remove_forward_pre_hook_handles)
+        return handles
+
     @contextmanager
     def no_sync(self):
         """Disable grad-ready registration on overlapped inner DDP modules."""

--- a/megatron/core/models/mimo/optimizer.py
+++ b/megatron/core/models/mimo/optimizer.py
@@ -126,7 +126,7 @@ class MimoOptimizer(MegatronOptimizer):
 
     @property
     def chained_optimizers(self) -> List[MegatronOptimizer]:
-        """Expose direct inner optimizers to stock optimizer lifecycle hooks."""
+        """Expose leaf optimizers to stock training, checkpoint, and rerun lifecycle hooks."""
         optimizers = []
         for opt in self._active_optimizers:
             optimizers.extend(getattr(opt, 'chained_optimizers', [opt]))
@@ -354,7 +354,7 @@ def _optimizer_config_for_module(
     """Match optimizer overlap behavior to the module's DDP lifecycle."""
     ddp_config = getattr(module, 'ddp_config', None)
     if ddp_config is None:
-        return config
+        raise ValueError("Active MIMO modules must be DDP-wrapped before optimizer construction.")
     overlap_param_gather = ddp_config.overlap_param_gather
     module_config = copy(config)
     module_config.overlap_param_gather = overlap_param_gather
@@ -392,18 +392,15 @@ def get_mimo_optimizer(mimo_model: "MimoModel", config: OptimizerConfig) -> Mimo
                 assert (
                     pg_collection is not None
                 ), f"Module '{module_name}' must own a ProcessGroupCollection for optimizer setup"
-                assert (
-                    not hasattr(module, 'ddp_config')
-                    or module.ddp_config is None
-                    or module.ddp_config.num_distributed_optimizer_instances == 1
-                ), (
+                module_config = _optimizer_config_for_module(config, module)
+                assert module.ddp_config.num_distributed_optimizer_instances == 1, (
                     "MIMO optimizer does not yet support "
                     "num_distributed_optimizer_instances > 1. "
                     f"Module '{module_name}' has "
                     f"{module.ddp_config.num_distributed_optimizer_instances} instances."
                 )
                 optimizer = get_megatron_optimizer(
-                    config=_optimizer_config_for_module(config, module),
+                    config=module_config,
                     model_chunks=[module],
                     pg_collection=pg_collection,
                     use_gloo_process_groups=False,

--- a/megatron/core/models/mimo/optimizer.py
+++ b/megatron/core/models/mimo/optimizer.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from copy import deepcopy
+from copy import copy, deepcopy
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
@@ -123,6 +123,14 @@ class MimoOptimizer(MegatronOptimizer):
         """Clear gradients on all active module optimizers."""
         for opt in self._active_optimizers:
             opt.zero_grad(set_to_none)
+
+    @property
+    def chained_optimizers(self) -> List[MegatronOptimizer]:
+        """Expose direct inner optimizers to stock optimizer lifecycle hooks."""
+        optimizers = []
+        for opt in self._active_optimizers:
+            optimizers.extend(getattr(opt, 'chained_optimizers', [opt]))
+        return optimizers
 
     def prepare_model_params_for_param_sync(self) -> None:
         """Stage parameters for explicit synchronization in all active module optimizers."""
@@ -340,6 +348,22 @@ def _get_replica_id(pg_collection: Optional[ProcessGroupCollection]) -> tuple:
     return (pg_collection.tp.rank(), pg_collection.pp.rank(), pg_collection.dp.rank())
 
 
+def _optimizer_config_for_module(
+    config: OptimizerConfig, module: torch.nn.Module
+) -> OptimizerConfig:
+    """Match optimizer overlap behavior to the module's DDP lifecycle."""
+    ddp_config = getattr(module, 'ddp_config', None)
+    if ddp_config is None:
+        return config
+    overlap_param_gather = ddp_config.overlap_param_gather
+    module_config = copy(config)
+    module_config.overlap_param_gather = overlap_param_gather
+    module_config.overlap_param_gather_with_optimizer_step = (
+        config.overlap_param_gather_with_optimizer_step and overlap_param_gather
+    )
+    return module_config
+
+
 def get_mimo_optimizer(mimo_model: "MimoModel", config: OptimizerConfig) -> MimoOptimizer:
     """Create optimizer for MimoModel with heterogeneous parallelism."""
     from megatron.core.optimizer import get_megatron_optimizer
@@ -379,7 +403,7 @@ def get_mimo_optimizer(mimo_model: "MimoModel", config: OptimizerConfig) -> Mimo
                     f"{module.ddp_config.num_distributed_optimizer_instances} instances."
                 )
                 optimizer = get_megatron_optimizer(
-                    config=config,
+                    config=_optimizer_config_for_module(config, module),
                     model_chunks=[module],
                     pg_collection=pg_collection,
                     use_gloo_process_groups=False,

--- a/megatron/core/models/mimo/optimizer.py
+++ b/megatron/core/models/mimo/optimizer.py
@@ -4,8 +4,8 @@
 
 from __future__ import annotations
 
-from copy import copy, deepcopy
-from dataclasses import dataclass
+from copy import deepcopy
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 import torch
@@ -351,17 +351,18 @@ def _get_replica_id(pg_collection: Optional[ProcessGroupCollection]) -> tuple:
 def _optimizer_config_for_module(
     config: OptimizerConfig, module: torch.nn.Module
 ) -> OptimizerConfig:
-    """Match optimizer overlap behavior to the module's DDP lifecycle."""
+    """Derive an optimizer config whose param-gather overlap matches the module's DDP config."""
     ddp_config = getattr(module, 'ddp_config', None)
     if ddp_config is None:
         raise ValueError("Active MIMO modules must be DDP-wrapped before optimizer construction.")
     overlap_param_gather = ddp_config.overlap_param_gather
-    module_config = copy(config)
-    module_config.overlap_param_gather = overlap_param_gather
-    module_config.overlap_param_gather_with_optimizer_step = (
-        config.overlap_param_gather_with_optimizer_step and overlap_param_gather
+    return replace(
+        config,
+        overlap_param_gather=overlap_param_gather,
+        overlap_param_gather_with_optimizer_step=(
+            config.overlap_param_gather_with_optimizer_step and overlap_param_gather
+        ),
     )
-    return module_config
 
 
 def get_mimo_optimizer(mimo_model: "MimoModel", config: OptimizerConfig) -> MimoOptimizer:

--- a/megatron/core/models/mimo/optimizer.py
+++ b/megatron/core/models/mimo/optimizer.py
@@ -123,6 +123,14 @@ class MimoOptimizer(MegatronOptimizer):
         for opt in self._active_optimizers:
             opt.zero_grad(set_to_none)
 
+    @property
+    def chained_optimizers(self) -> List[MegatronOptimizer]:
+        """Expose direct inner optimizers to stock optimizer lifecycle hooks."""
+        optimizers = []
+        for opt in self._active_optimizers:
+            optimizers.extend(getattr(opt, 'chained_optimizers', [opt]))
+        return optimizers
+
     def prepare_model_params_for_param_sync(self) -> None:
         """Stage parameters for explicit synchronization in all active module optimizers."""
         for opt in self._active_optimizers:

--- a/megatron/core/transformer/moe/paged_stash.py
+++ b/megatron/core/transformer/moe/paged_stash.py
@@ -1178,8 +1178,11 @@ class PagedStashRunner:
         if self.copy_main_params:
 
             def _try_copy_main_params(opt):
-                if isinstance(opt, DistributedOptimizer) and hasattr(
-                    opt, 'shard_fp32_from_float16_groups'
+                if (
+                    isinstance(opt, DistributedOptimizer)
+                    and hasattr(opt, 'shard_fp32_from_float16_groups')
+                    and opt.ddp_config.reuse_grad_buf_for_mxfp8_param_ag
+                    and opt.ddp_config.overlap_param_gather
                 ):
                     opt._copy_main_params_to_param_buffer()
 

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -3058,7 +3058,11 @@ def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_sch
             full_cg_captured = FullCudaGraphWrapper.cuda_graph.get("training") is not None
             if forward_pre_hook_enabled or full_cg_captured:
                 for optim_instance in optimizer.chained_optimizers:
-                    if isinstance(optim_instance, DistributedOptimizer):
+                    if (
+                        isinstance(optim_instance, DistributedOptimizer)
+                        and optim_instance.ddp_config.reuse_grad_buf_for_mxfp8_param_ag
+                        and optim_instance.ddp_config.overlap_param_gather
+                    ):
                         optim_instance._copy_main_params_to_param_buffer()
 
         # Forward pass.

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -3052,18 +3052,25 @@ def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_sch
         # and subsequent param_data zero are baked into the graph and replay
         # unconditionally. We must populate param_data so the replayed AG gathers
         # correct weights, even when forward pre-hooks are disabled.
-        if args.reuse_grad_buf_for_mxfp8_param_ag and args.overlap_param_gather:
+        # A model component's DDP config may differ from the global args. Check the
+        # DistributedOptimizer config that owns the buffers and hooks; non-overlapped
+        # optimizers stage during optimizer.step().
+        mxfp8_overlap_optimizers = [
+            optim_instance
+            for optim_instance in optimizer.chained_optimizers
+            if (
+                isinstance(optim_instance, DistributedOptimizer)
+                and optim_instance.ddp_config.reuse_grad_buf_for_mxfp8_param_ag
+                and optim_instance.ddp_config.overlap_param_gather
+            )
+        ]
+        if mxfp8_overlap_optimizers:
             # Check if forward_pre_hook is enabled by checking if hooks are registered.
             forward_pre_hook_enabled = len(model[0].remove_forward_pre_hook_handles) > 0
             full_cg_captured = FullCudaGraphWrapper.cuda_graph.get("training") is not None
             if forward_pre_hook_enabled or full_cg_captured:
-                for optim_instance in optimizer.chained_optimizers:
-                    if (
-                        isinstance(optim_instance, DistributedOptimizer)
-                        and optim_instance.ddp_config.reuse_grad_buf_for_mxfp8_param_ag
-                        and optim_instance.ddp_config.overlap_param_gather
-                    ):
-                        optim_instance._copy_main_params_to_param_buffer()
+                for optim_instance in mxfp8_overlap_optimizers:
+                    optim_instance._copy_main_params_to_param_buffer()
 
         # Forward pass.
         if save_activations_in_this_iteration:

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -3055,9 +3055,10 @@ def train_step(forward_step_func, data_iterator, model, optimizer, opt_param_sch
         # A model component's DDP config may differ from the global args. Check the
         # DistributedOptimizer config that owns the buffers and hooks; non-overlapped
         # optimizers stage during optimizer.step().
+        optimizer_instances = getattr(optimizer, 'chained_optimizers', [optimizer])
         mxfp8_overlap_optimizers = [
             optim_instance
-            for optim_instance in optimizer.chained_optimizers
+            for optim_instance in optimizer_instances
             if (
                 isinstance(optim_instance, DistributedOptimizer)
                 and optim_instance.ddp_config.reuse_grad_buf_for_mxfp8_param_ag

--- a/tests/unit_tests/models/mimo/test_mimo_hetero_runtime.py
+++ b/tests/unit_tests/models/mimo/test_mimo_hetero_runtime.py
@@ -297,7 +297,7 @@ def test_builder_applies_outer_hooks_in_order_and_returns_replacement(mocker):
     mocker.patch.object(builder, "build_model", return_value=original_model)
     mocker.patch(
         "examples.mimo.training.builder.wrap_active_modules_with_ddp",
-        side_effect=lambda *_: events.append("wrap"),
+        side_effect=lambda *_, **__: events.append("wrap"),
     )
     mocker.patch(
         "examples.mimo.training.builder.configure_grad_sync",

--- a/tests/unit_tests/models/mimo/test_mimo_hetero_runtime.py
+++ b/tests/unit_tests/models/mimo/test_mimo_hetero_runtime.py
@@ -3,13 +3,14 @@
 """Tests for MIMO per-rank runtime setup (RNG seeding, DDP wrapping)."""
 
 import argparse
+from dataclasses import fields
 from types import SimpleNamespace
 
 import pytest
 import torch
 
 from examples.mimo.training.runtime import (
-    _ddp_config_from_args,
+    _ddp_config_for_role,
     configure_module_rng,
     wrap_active_modules_with_ddp,
 )
@@ -88,36 +89,40 @@ def _build_unwrapped_mimo_model(topo, bf16=False):
     return mimo_model
 
 
-def test_ddp_overlap_config_is_selected_per_module_role():
-    args = _args(
-        overlap_grad_reduce=True,
-        overlap_param_gather=True,
-        check_for_nan_in_loss_and_grad=True,
-        ddp_average_in_collective=True,
+@pytest.mark.parametrize(
+    ("overlap_grad_reduce", "overlap_param_gather", "enable_overlap", "expected"),
+    [
+        (True, True, True, (True, True)),
+        (True, False, True, (True, False)),
+        (False, True, True, (False, True)),
+        (True, True, False, (False, False)),
+    ],
+)
+def test_ddp_config_for_role_preserves_fields_and_masks_overlap(
+    overlap_grad_reduce, overlap_param_gather, enable_overlap, expected
+):
+    ddp_config = DistributedDataParallelConfig(
+        overlap_grad_reduce=overlap_grad_reduce,
+        overlap_param_gather=overlap_param_gather,
+        check_for_nan_in_grad=True,
+        average_in_collective=True,
         use_distributed_optimizer=True,
         fp8_param_gather=True,
         reuse_grad_buf_for_mxfp8_param_ag=True,
     )
+    original_values = {field.name: getattr(ddp_config, field.name) for field in fields(ddp_config)}
 
-    enabled = _ddp_config_from_args(args, enable_overlap=True)
-    disabled = _ddp_config_from_args(args, enable_overlap=False)
+    role_config = _ddp_config_for_role(ddp_config, enable_overlap)
 
-    assert enabled.overlap_grad_reduce
-    assert enabled.overlap_param_gather
-    assert enabled.check_for_nan_in_grad
-    assert enabled.average_in_collective
-    assert enabled.use_distributed_optimizer
-    assert not disabled.overlap_grad_reduce
-    assert not disabled.overlap_param_gather
-    assert disabled.check_for_nan_in_grad
-    assert disabled.average_in_collective
-    assert disabled.use_distributed_optimizer
-    assert enabled.fp8_param_gather and disabled.fp8_param_gather
-    assert enabled.reuse_grad_buf_for_mxfp8_param_ag
-    assert disabled.reuse_grad_buf_for_mxfp8_param_ag
+    assert role_config is not ddp_config
+    assert (role_config.overlap_grad_reduce, role_config.overlap_param_gather) == expected
+    for field in fields(ddp_config):
+        assert getattr(ddp_config, field.name) == original_values[field.name]
+        if field.name not in {"overlap_grad_reduce", "overlap_param_gather"}:
+            assert getattr(role_config, field.name) == original_values[field.name]
 
 
-def test_encoder_overlap_opt_in_reaches_encoder_ddp_config(mocker):
+def test_supplied_ddp_config_wins_over_global_args(mocker):
     encoder = mocker.MagicMock()
     wrapped_encoder = mocker.MagicMock()
     mimo_model = SimpleNamespace(language_model=None, modality_submodules={ENCODER: encoder})
@@ -130,15 +135,18 @@ def test_encoder_overlap_opt_in_reaches_encoder_ddp_config(mocker):
     mocker.patch("examples.mimo.training.runtime._module_config", return_value=mocker.MagicMock())
     mocker.patch("examples.mimo.training.runtime.print_rank_0")
 
-    wrap_active_modules_with_ddp(
-        _args(encoder_ddp_overlap=True, overlap_grad_reduce=True, overlap_param_gather=True),
-        mimo_model,
-        topology,
+    args = _args(encoder_ddp_overlap=True, overlap_grad_reduce=False, overlap_param_gather=False)
+    supplied_ddp_config = DistributedDataParallelConfig(
+        overlap_grad_reduce=True, overlap_param_gather=True, bucket_size=1234
     )
 
-    ddp_config = prepare.call_args.kwargs["ddp_config"]
-    assert ddp_config.overlap_grad_reduce
-    assert ddp_config.overlap_param_gather
+    wrap_active_modules_with_ddp(args, mimo_model, topology, ddp_config=supplied_ddp_config)
+
+    role_ddp_config = prepare.call_args.kwargs["ddp_config"]
+    assert role_ddp_config is not supplied_ddp_config
+    assert role_ddp_config.overlap_grad_reduce
+    assert role_ddp_config.overlap_param_gather
+    assert role_ddp_config.bucket_size == 1234
     assert mimo_model.modality_submodules[ENCODER] is wrapped_encoder
 
 
@@ -178,13 +186,16 @@ def test_builder_seeds_per_role_meta_builds_and_sets_contract(mocker):
     )
     seed = mocker.patch("examples.mimo.training.builder.configure_module_rng")
 
+    ddp_config = DistributedDataParallelConfig()
     assert builder.build_distributed_models(
-        mocker.Mock(), ddp_config=DistributedDataParallelConfig(), data_parallel_random_init=True
+        mocker.Mock(), ddp_config=ddp_config, data_parallel_random_init=True
     ) == [model]
 
     torch_device.assert_called_once_with("meta")
     seed.assert_called_once_with(args, groups, _LANGUAGE_SEED_OFFSET, True)
-    wrap.assert_called_once_with(args, model, topology, True)
+    wrap.assert_called_once_with(
+        args, model, topology, ddp_config=ddp_config, data_parallel_random_init=True
+    )
     grad_sync.assert_called_once_with(args, model, topology)
     # Load-bearing contract for Increments 2/4: own module PGC and role prefix on the model.
     assert model.pg_collection is groups
@@ -369,7 +380,9 @@ class TestRuntimeDistributed:
         try:
             # bf16 = production precision; a bare fp32 modality container has no config for get_model_config.
             mimo_model = _build_unwrapped_mimo_model(topo, bf16=True)
-            wrap_active_modules_with_ddp(_args(fp32=False), mimo_model, topo)
+            wrap_active_modules_with_ddp(
+                _args(fp32=False), mimo_model, topo, ddp_config=DistributedDataParallelConfig()
+            )
             # Non-colocated: each rank owns exactly one active module (language XOR encoder).
             if torch.distributed.get_rank() < 4:
                 active = mimo_model.modality_submodules[ENCODER]
@@ -386,7 +399,12 @@ class TestRuntimeDistributed:
         try:
             # bf16 -> Float16Module wrap; --freeze-vit freezes the encoder backbone only.
             mimo_model = _build_unwrapped_mimo_model(topo, bf16=True)
-            wrap_active_modules_with_ddp(_args(fp32=False, freeze_vit=True), mimo_model, topo)
+            wrap_active_modules_with_ddp(
+                _args(fp32=False, freeze_vit=True),
+                mimo_model,
+                topo,
+                ddp_config=DistributedDataParallelConfig(),
+            )
 
             if torch.distributed.get_rank() < 4:
                 active = mimo_model.modality_submodules[ENCODER]

--- a/tests/unit_tests/models/mimo/test_mimo_hetero_runtime.py
+++ b/tests/unit_tests/models/mimo/test_mimo_hetero_runtime.py
@@ -32,8 +32,27 @@ ENCODER = "images"
 
 
 def _args(**overrides):
+    ddp_defaults = vars(DistributedDataParallelConfig())
     base = dict(
-        seed=1234, image_token_id=100, fp32=True, ddp_num_buckets=None, ddp_bucket_size=None
+        ddp_defaults,
+        seed=1234,
+        image_token_id=100,
+        fp32=True,
+        accumulate_allreduce_grads_in_fp32=ddp_defaults["grad_reduce_in_fp32"],
+        check_for_nan_in_loss_and_grad=ddp_defaults["check_for_nan_in_grad"],
+        check_for_large_grads=ddp_defaults["check_for_large_grads"],
+        ddp_num_buckets=ddp_defaults["num_buckets"],
+        ddp_bucket_size=ddp_defaults["bucket_size"],
+        ddp_pad_buckets_for_high_nccl_busbw=ddp_defaults["pad_buckets_for_high_nccl_busbw"],
+        ddp_reduce_scatter_with_fp32_accumulation=ddp_defaults[
+            "reduce_scatter_with_fp32_accumulation"
+        ],
+        ddp_param_name_patterns_for_fp32_local_accumulation=list(
+            ddp_defaults["param_name_patterns_for_fp32_local_accumulation"]
+        ),
+        ddp_average_in_collective=ddp_defaults["average_in_collective"],
+        use_precision_aware_optimizer=ddp_defaults["megatron_fsdp_use_decoupled_grad"],
+        cuda_graph_impl="none",
     )
     base.update(overrides)
     return argparse.Namespace(**base)
@@ -70,15 +89,32 @@ def _build_unwrapped_mimo_model(topo, bf16=False):
 
 
 def test_ddp_overlap_config_is_selected_per_module_role():
-    args = _args(overlap_grad_reduce=True, overlap_param_gather=True)
+    args = _args(
+        overlap_grad_reduce=True,
+        overlap_param_gather=True,
+        check_for_nan_in_loss_and_grad=True,
+        ddp_average_in_collective=True,
+        use_distributed_optimizer=True,
+        fp8_param_gather=True,
+        reuse_grad_buf_for_mxfp8_param_ag=True,
+    )
 
     enabled = _ddp_config_from_args(args, enable_overlap=True)
     disabled = _ddp_config_from_args(args, enable_overlap=False)
 
     assert enabled.overlap_grad_reduce
     assert enabled.overlap_param_gather
+    assert enabled.check_for_nan_in_grad
+    assert enabled.average_in_collective
+    assert enabled.use_distributed_optimizer
     assert not disabled.overlap_grad_reduce
     assert not disabled.overlap_param_gather
+    assert disabled.check_for_nan_in_grad
+    assert disabled.average_in_collective
+    assert disabled.use_distributed_optimizer
+    assert enabled.fp8_param_gather and disabled.fp8_param_gather
+    assert enabled.reuse_grad_buf_for_mxfp8_param_ag
+    assert disabled.reuse_grad_buf_for_mxfp8_param_ag
 
 
 def test_encoder_overlap_opt_in_reaches_encoder_ddp_config(mocker):
@@ -181,6 +217,18 @@ def test_builder_encoder_role_sets_encoder_contract(mocker):
     seed.assert_called_once_with(args, encoder_pg, _ENCODER_SEED_OFFSET, False)
     assert model.pg_collection is encoder_pg
     assert model.rng_state_key_prefix == "encoder."
+
+
+@pytest.mark.parametrize("fsdp_kwarg", ["use_megatron_fsdp", "use_torch_fsdp2"])
+def test_builder_rejects_untested_fsdp_modes(mocker, fsdp_kwarg):
+    from examples.mimo.training.builder import MimoBuildConfig, MimoModelBuilder
+
+    builder = MimoModelBuilder(MimoBuildConfig(_topology=mocker.Mock()))
+
+    with pytest.raises(NotImplementedError, match="has not been tested yet"):
+        builder.build_distributed_models(
+            mocker.Mock(), ddp_config=DistributedDataParallelConfig(), **{fsdp_kwarg: True}
+        )
 
 
 def test_resolve_role_rejects_colocated_or_zero_active_roles(mocker):

--- a/tests/unit_tests/models/mimo/test_mimo_hetero_runtime.py
+++ b/tests/unit_tests/models/mimo/test_mimo_hetero_runtime.py
@@ -81,6 +81,15 @@ def test_ddp_overlap_config_is_selected_per_module_role():
     assert not disabled.overlap_param_gather
 
 
+def test_mxfp8_param_gather_config_reaches_ddp():
+    args = _args(fp8_param_gather=True, reuse_grad_buf_for_mxfp8_param_ag=True)
+
+    config = _ddp_config_from_args(args, enable_overlap=True)
+
+    assert config.fp8_param_gather
+    assert config.reuse_grad_buf_for_mxfp8_param_ag
+
+
 def test_encoder_overlap_opt_in_reaches_encoder_ddp_config(mocker):
     encoder = mocker.MagicMock()
     wrapped_encoder = mocker.MagicMock()

--- a/tests/unit_tests/models/mimo/test_mimo_overlap_lifecycle.py
+++ b/tests/unit_tests/models/mimo/test_mimo_overlap_lifecycle.py
@@ -7,7 +7,9 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from megatron.core.models.mimo.model.base import MimoModel
-from megatron.core.models.mimo.optimizer import MimoOptimizer
+from megatron.core.models.mimo.optimizer import MimoOptimizer, _optimizer_config_for_module
+from megatron.core.optimizer.optimizer import MixedPrecisionOptimizer
+from megatron.core.optimizer.optimizer_config import OptimizerConfig
 
 
 def _overlap_stub(modules):
@@ -72,6 +74,55 @@ def test_nested_overlap_lifecycle_routes_only_to_enabled_modules():
     encoder.start_param_sync.assert_not_called()
     encoder.start_grad_sync.assert_called_once_with()
     inactive.start_grad_sync.assert_not_called()
+
+
+def test_nested_forward_pre_hook_handles_are_visible_to_stock_train_loop():
+    language = MagicMock()
+    encoder = MagicMock()
+    language.remove_forward_pre_hook_handles = {object(): object()}
+    encoder.remove_forward_pre_hook_handles = {}
+    model = _overlap_stub([language, encoder])
+
+    handles = MimoModel.remove_forward_pre_hook_handles.fget(model)
+
+    assert handles == language.remove_forward_pre_hook_handles
+
+
+def test_mimo_optimizer_exposes_inner_optimizers_to_stock_train_loop():
+    dense = object()
+    expert = object()
+    module_optimizer = SimpleNamespace(chained_optimizers=[dense, expert])
+    standalone_optimizer = object()
+    optimizer = SimpleNamespace(_active_optimizers=[module_optimizer, standalone_optimizer])
+
+    optimizers = MimoOptimizer.chained_optimizers.fget(optimizer)
+
+    assert optimizers == [dense, expert, standalone_optimizer]
+
+
+def test_encoder_optimizer_uses_nonoverlapped_mxfp8_param_copy():
+    global_config = OptimizerConfig(
+        fp8_recipe='mxfp8', reuse_grad_buf_for_mxfp8_param_ag=True, overlap_param_gather=True
+    )
+    module = SimpleNamespace(ddp_config=SimpleNamespace(overlap_param_gather=False))
+    module_config = _optimizer_config_for_module(global_config, module)
+    assert module_config is not global_config
+    assert global_config.reuse_grad_buf_for_mxfp8_param_ag
+    assert global_config.overlap_param_gather
+    assert module_config.reuse_grad_buf_for_mxfp8_param_ag
+    assert not module_config.overlap_param_gather
+    optimizer = SimpleNamespace(
+        config=module_config,
+        timers=None,
+        is_stub_optimizer=False,
+        optimizer=MagicMock(),
+        _copy_main_params_to_model_params=MagicMock(),
+        _copy_main_params_to_param_buffer=MagicMock(),
+    )
+
+    assert MixedPrecisionOptimizer.step_with_ready_grads(optimizer)
+    optimizer._copy_main_params_to_model_params.assert_not_called()
+    optimizer._copy_main_params_to_param_buffer.assert_called_once_with()
 
 
 def test_mimo_optimizer_stages_each_active_optimizer_before_param_sync():

--- a/tests/unit_tests/models/mimo/test_mimo_overlap_lifecycle.py
+++ b/tests/unit_tests/models/mimo/test_mimo_overlap_lifecycle.py
@@ -6,6 +6,8 @@ from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
+
 from megatron.core.models.mimo.model.base import MimoModel
 from megatron.core.models.mimo.optimizer import MimoOptimizer, _optimizer_config_for_module
 from megatron.core.optimizer.optimizer import MixedPrecisionOptimizer
@@ -123,6 +125,11 @@ def test_encoder_optimizer_uses_nonoverlapped_mxfp8_param_copy():
     assert MixedPrecisionOptimizer.step_with_ready_grads(optimizer)
     optimizer._copy_main_params_to_model_params.assert_not_called()
     optimizer._copy_main_params_to_param_buffer.assert_called_once_with()
+
+
+def test_optimizer_config_rejects_module_without_ddp_config():
+    with pytest.raises(ValueError, match="must be DDP-wrapped"):
+        _optimizer_config_for_module(OptimizerConfig(), SimpleNamespace())
 
 
 def test_mimo_optimizer_stages_each_active_optimizer_before_param_sync():

--- a/tests/unit_tests/models/mimo/test_mimo_overlap_lifecycle.py
+++ b/tests/unit_tests/models/mimo/test_mimo_overlap_lifecycle.py
@@ -74,6 +74,32 @@ def test_nested_overlap_lifecycle_routes_only_to_enabled_modules():
     inactive.start_grad_sync.assert_not_called()
 
 
+def test_nested_forward_pre_hook_handles_are_visible_to_stock_train_loop():
+    language = MagicMock()
+    encoder = MagicMock()
+    language.remove_forward_pre_hook_handles = {object(): object()}
+    encoder.remove_forward_pre_hook_handles = {}
+    model = _overlap_stub([language, encoder])
+
+    handles = MimoModel.remove_forward_pre_hook_handles.fget(model)
+
+    assert handles == language.remove_forward_pre_hook_handles
+
+
+def test_mimo_optimizer_exposes_inner_optimizers_to_stock_train_loop():
+    dense = object()
+    expert = object()
+    module_optimizer = SimpleNamespace(chained_optimizers=[dense, expert])
+    standalone_optimizer = object()
+    optimizer = SimpleNamespace(
+        _active_optimizers=[module_optimizer, standalone_optimizer]
+    )
+
+    optimizers = MimoOptimizer.chained_optimizers.fget(optimizer)
+
+    assert optimizers == [dense, expert, standalone_optimizer]
+
+
 def test_mimo_optimizer_stages_each_active_optimizer_before_param_sync():
     language_optimizer = MagicMock()
     encoder_optimizer = MagicMock()

--- a/tests/unit_tests/training/test_train_step_schedule_plumbing.py
+++ b/tests/unit_tests/training/test_train_step_schedule_plumbing.py
@@ -21,7 +21,7 @@ class _Rerun:
         return False, True, 0  # (checkpoint, exit, code)
 
 
-def _run(**kwargs):
+def _run(*, args_overrides=None, model=None, optimizer=None, **kwargs):
     args = SimpleNamespace(
         save_params_interval=None,
         save_activations_interval=None,
@@ -35,8 +35,11 @@ def _run(**kwargs):
         decoder_seq_length=None,
         empty_unused_memory_level=0,
     )
+    for name, value in (args_overrides or {}).items():
+        setattr(args, name, value)
     captured = {}
-    model = [SimpleNamespace(force_all_reduce=False, zero_grad_buffer=lambda: None)]
+    model = model or [SimpleNamespace(force_all_reduce=False, zero_grad_buffer=lambda: None)]
+    optimizer = optimizer or SimpleNamespace(zero_grad=lambda: None)
     with (
         mock.patch.object(training_mod, "get_args", return_value=args),
         mock.patch.object(training_mod, "get_timers", return_value=mock.MagicMock()),
@@ -48,7 +51,7 @@ def _run(**kwargs):
             forward_step_func=lambda *a, **k: None,
             data_iterator=iter([]),
             model=model,
-            optimizer=SimpleNamespace(zero_grad=lambda: None),
+            optimizer=optimizer,
             opt_param_scheduler=None,
             config=SimpleNamespace(),
             forward_backward_func=lambda **kw: captured.update(kw) or [],
@@ -67,3 +70,38 @@ def test_train_step_forwards_schedule_plumbing():
 def test_train_step_defaults_to_none():
     captured = _run()
     assert captured["p2p_communicator"] is None and captured["pg_collection"] is None
+
+
+def test_train_step_stages_only_overlapped_mxfp8_optimizers():
+    class _DistributedOptimizer:
+        def __init__(self, overlap_param_gather):
+            self.ddp_config = SimpleNamespace(
+                reuse_grad_buf_for_mxfp8_param_ag=True, overlap_param_gather=overlap_param_gather
+            )
+            self._copy_main_params_to_param_buffer = mock.Mock()
+
+    overlapped = _DistributedOptimizer(overlap_param_gather=True)
+    nonoverlapped = _DistributedOptimizer(overlap_param_gather=False)
+    optimizer = SimpleNamespace(
+        zero_grad=lambda: None, chained_optimizers=[overlapped, nonoverlapped]
+    )
+    model = [
+        SimpleNamespace(
+            force_all_reduce=False,
+            zero_grad_buffer=lambda: None,
+            remove_forward_pre_hook_handles={object(): object()},
+        )
+    ]
+
+    with mock.patch.object(training_mod, "DistributedOptimizer", _DistributedOptimizer):
+        _run(
+            args_overrides={
+                "reuse_grad_buf_for_mxfp8_param_ag": True,
+                "overlap_param_gather": True,
+            },
+            model=model,
+            optimizer=optimizer,
+        )
+
+    overlapped._copy_main_params_to_param_buffer.assert_called_once_with()
+    nonoverlapped._copy_main_params_to_param_buffer.assert_not_called()

--- a/tests/unit_tests/training/test_train_step_schedule_plumbing.py
+++ b/tests/unit_tests/training/test_train_step_schedule_plumbing.py
@@ -39,7 +39,7 @@ def _run(*, args_overrides=None, model=None, optimizer=None, **kwargs):
         setattr(args, name, value)
     captured = {}
     model = model or [SimpleNamespace(force_all_reduce=False, zero_grad_buffer=lambda: None)]
-    optimizer = optimizer or SimpleNamespace(zero_grad=lambda: None)
+    optimizer = optimizer or SimpleNamespace(zero_grad=lambda: None, chained_optimizers=[])
     with (
         mock.patch.object(training_mod, "get_args", return_value=args),
         mock.patch.object(training_mod, "get_timers", return_value=mock.MagicMock()),
@@ -72,7 +72,7 @@ def test_train_step_defaults_to_none():
     assert captured["p2p_communicator"] is None and captured["pg_collection"] is None
 
 
-def test_train_step_stages_only_overlapped_mxfp8_optimizers():
+def test_train_step_uses_optimizer_ddp_config_for_mxfp8_staging():
     class _DistributedOptimizer:
         def __init__(self, overlap_param_gather):
             self.ddp_config = SimpleNamespace(
@@ -94,10 +94,11 @@ def test_train_step_stages_only_overlapped_mxfp8_optimizers():
     ]
 
     with mock.patch.object(training_mod, "DistributedOptimizer", _DistributedOptimizer):
+        # Global args intentionally disagree; the optimizer DDP config is authoritative.
         _run(
             args_overrides={
-                "reuse_grad_buf_for_mxfp8_param_ag": True,
-                "overlap_param_gather": True,
+                "reuse_grad_buf_for_mxfp8_param_ag": False,
+                "overlap_param_gather": False,
             },
             model=model,
             optimizer=optimizer,

--- a/tests/unit_tests/training/test_train_step_schedule_plumbing.py
+++ b/tests/unit_tests/training/test_train_step_schedule_plumbing.py
@@ -106,3 +106,29 @@ def test_train_step_uses_optimizer_ddp_config_for_mxfp8_staging():
 
     overlapped._copy_main_params_to_param_buffer.assert_called_once_with()
     nonoverlapped._copy_main_params_to_param_buffer.assert_not_called()
+
+
+def test_train_step_supports_bare_distributed_optimizer_for_mxfp8_staging():
+    class _DistributedOptimizer:
+        def __init__(self):
+            self.ddp_config = SimpleNamespace(
+                reuse_grad_buf_for_mxfp8_param_ag=True, overlap_param_gather=True
+            )
+            self._copy_main_params_to_param_buffer = mock.Mock()
+
+        def zero_grad(self):
+            pass
+
+    optimizer = _DistributedOptimizer()
+    model = [
+        SimpleNamespace(
+            force_all_reduce=False,
+            zero_grad_buffer=lambda: None,
+            remove_forward_pre_hook_handles={object(): object()},
+        )
+    ]
+
+    with mock.patch.object(training_mod, "DistributedOptimizer", _DistributedOptimizer):
+        _run(model=model, optimizer=optimizer)
+
+    optimizer._copy_main_params_to_param_buffer.assert_called_once_with()

--- a/tests/unit_tests/transformer/moe/test_paged_stash_runner.py
+++ b/tests/unit_tests/transformer/moe/test_paged_stash_runner.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import torch
 
@@ -204,3 +205,46 @@ def test_retry_disables_and_restores_per_module_configs(monkeypatch):
         decoder_moe_config.moe_paged_stash,
         mtp_moe_config.moe_paged_stash,
     ) == (True, True, True, False)
+
+
+def test_retry_stages_only_overlapped_reused_mxfp8_buffers(monkeypatch):
+    class _DistributedOptimizer:
+
+        def __init__(self, *, reuse_grad_buffer, overlap_param_gather):
+            self.ddp_config = SimpleNamespace(
+                reuse_grad_buf_for_mxfp8_param_ag=reuse_grad_buffer,
+                overlap_param_gather=overlap_param_gather,
+            )
+            self.shard_fp32_from_float16_groups = []
+            self._copy_main_params_to_param_buffer = Mock()
+
+    overlapped = _DistributedOptimizer(reuse_grad_buffer=True, overlap_param_gather=True)
+    nonoverlapped = _DistributedOptimizer(reuse_grad_buffer=True, overlap_param_gather=False)
+    dedicated_buffer = _DistributedOptimizer(reuse_grad_buffer=False, overlap_param_gather=True)
+    optimizer = SimpleNamespace(
+        zero_grad=Mock(), chained_optimizers=[overlapped, nonoverlapped, dedicated_buffer]
+    )
+    model_chunk = SimpleNamespace(zero_grad_buffer=Mock())
+    stash_manager = SimpleNamespace(overflow=None, host_spill=None, release_stash_buffers=Mock())
+    runner = PagedStashRunner.__new__(PagedStashRunner)
+    runner.moe_layers = []
+    runner._required_recv_capacity = None
+    runner.stash_manager = stash_manager
+    runner.copy_main_params = True
+    runner.model = [model_chunk]
+    runner.optimizer = optimizer
+    runner.forward_backward_func = object()
+    runner._set_moe_paged_stash_all = Mock()
+
+    monkeypatch.setattr(
+        "megatron.core.transformer.moe.paged_stash.DistributedOptimizer", _DistributedOptimizer
+    )
+    monkeypatch.setattr(
+        "megatron.core.transformer.moe.paged_stash.nccl_ep_release_context", lambda: None
+    )
+
+    runner.prepare_for_rerun()
+
+    overlapped._copy_main_params_to_param_buffer.assert_called_once_with()
+    nonoverlapped._copy_main_params_to_param_buffer.assert_not_called()
+    dedicated_buffer._copy_main_params_to_param_buffer.assert_not_called()


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

**Allows multimodal  models to use DDP-wrapped submodules with different
parameter-gather overlap policies while participating in the standard
Megatron training, checkpoint, rerun, and paged-stash lifecycles.**

## Issue tracking

Linked issue: N/A — compatibility gaps found during MIMO training integration.

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code
- [ ] I have added relevant documentation
- [ ] I have run `tools/autoformat.sh` on my PR

## Validation

- CMH job `3188397`: 20 focused tests passed; 3 expected 8-GPU tests skipped (1 node / 4 allocated GPUs / 1 pytest process).
- Black 26.3.0, isort 5.13.2, Ruff 0.9.10, Pylint 3.2.6, Python compilation, and `git diff --check` pass on the changed scope. `training.py` imports are unchanged and retain pre-existing full-file isort debt.
