### PR TITLE
revert: revert community-bot bump to v1.8.7 (5adbee2)

### DIFF
--- a/.github/workflows/community-bot.yml
+++ b/.github/workflows/community-bot.yml
@@ -21,10 +21,9 @@ on:
 
 jobs:
   community-bot:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_community_bot.yml@98ea77e930f3e1b0f97a1ce5255e12c407e9d0d4 # v1.8.7
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_community_bot.yml@f0dadfd1b2d5c3f48a24ded127abd50afbf8ce11 # v0.65.10
     with:
       community_project_id: ${{ vars.COMMUNITY_PROJECT_ID }}
-      app-id: ${{ vars.BOT_ID }}
     if: github.repository == 'NVIDIA/Megatron-LM'
     secrets:
-      BOT_KEY: ${{ secrets.BOT_KEY }}
+      GH_TOKEN: ${{ secrets.PAT }}


### PR DESCRIPTION
## Summary

- Reverts 5adbee2 which bumped community-bot from v0.65.10 to v1.8.7
- v1.8.7 introduced a GitHub App token (`secrets.BOT_KEY`) to replace the PAT (`secrets.PAT`); the App token is scoped to `NVIDIA/Megatron-LM` only and lacks `read:org` access to the NVIDIA org, so NVIDIA employees with private org membership fail all three maintainer checks and are incorrectly labeled `community-request`
- Example: #6190 (wujingyue, an NVIDIA employee) received the label on Aug 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)