### PR TITLE
Remove global process-group reads from Megatron Core

### DIFF
--- a/examples/multimodal/model.py
+++ b/examples/multimodal/model.py
@@ -1,23 +1,35 @@
 # Copyright (c) 2024-2026, NVIDIA CORPORATION.  All rights reserved.
-import warnings
 import logging
+import warnings
 from copy import deepcopy
 
 import torch
 from config import get_language_model_config, get_vision_model_config, get_vision_projection_config
-from layer_specs import (get_layer_spec, get_layer_spec_te, get_mlp_module_spec, get_norm_mlp_module_spec_te,
-                         get_hybrid_layer_spec_te)
+from layer_specs import (
+    get_hybrid_layer_spec_te,
+    get_layer_spec,
+    get_layer_spec_te,
+    get_mlp_module_spec,
+    get_norm_mlp_module_spec_te,
+)
 
 from megatron.core.models.multimodal.llava_model import IMAGE_TOKEN, LLaVAModel
 from megatron.core.models.vision.clip_vit_model import get_num_image_embeddings
+from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.utils import log_single_rank
 from megatron.training import get_args, get_tokenizer, print_rank_0
 from megatron.training.arguments import core_transformer_config_from_args
-from megatron.core.utils import log_single_rank
 
 
 def model_provider(
-    pre_process=True, post_process=True, add_encoder=True, add_decoder=True, parallel_output=True,
-    vp_stage=None, config=None, pg_collection=None
+    pre_process=True,
+    post_process=True,
+    add_encoder=True,
+    add_decoder=True,
+    parallel_output=True,
+    vp_stage=None,
+    config=None,
+    pg_collection=None,
 ) -> LLaVAModel:
     """Builds the model.
 
@@ -51,7 +63,7 @@ def model_provider(
         args.pixel_shuffle,
         args.use_tile_tags,
         args.max_num_tiles,
-        args.tokenizer_prompt_format
+        args.tokenizer_prompt_format,
     )
     old_seq_length = args.seq_length
     args.seq_length = args.encoder_seq_length = num_image_embeddings
@@ -59,10 +71,12 @@ def model_provider(
         log_single_rank(
             logging.getLogger(__name__),
             logging.WARNING,
-            f"Changed seq_length and encoder_seq_length (vision model sequence length) from {old_seq_length} to num_image_tokens ({num_image_embeddings})"
+            f"Changed seq_length and encoder_seq_length (vision model sequence length) from {old_seq_length} to num_image_tokens ({num_image_embeddings})",
         )
 
-    max_num_image_embeddings = max((args.max_num_tiles + int(args.use_thumbnail)), args.num_frames) * num_image_embeddings
+    max_num_image_embeddings = (
+        max((args.max_num_tiles + int(args.use_thumbnail)), args.num_frames) * num_image_embeddings
+    )
 
     assert (
         args.decoder_seq_length is not None
@@ -88,10 +102,16 @@ def model_provider(
     language_config = get_language_model_config(language_config)
 
     if language_model_type.startswith("hf://"):
-        assert args.tensor_model_parallel_size == 1, "Huggingface models do not support --tensor-model-parallel-size > 1"
-        assert args.pipeline_model_parallel_size < 2, "Huggingface models do not support --pipeline-model-parallel-size > 1"
+        assert (
+            args.tensor_model_parallel_size == 1
+        ), "Huggingface models do not support --tensor-model-parallel-size > 1"
+        assert (
+            args.pipeline_model_parallel_size < 2
+        ), "Huggingface models do not support --pipeline-model-parallel-size > 1"
         assert not args.sequence_parallel, "Huggingface models do not support --sequence-parallel"
-        assert args.context_parallel_size < 2, "Huggingface models do not support --context-parallel-size > 1"
+        assert (
+            args.context_parallel_size < 2
+        ), "Huggingface models do not support --context-parallel-size > 1"
 
     if language_model_type.startswith("hf://"):
         language_transformer_layer_spec = None
@@ -115,7 +135,9 @@ def model_provider(
     )
     if vision_model_type.startswith("hf://"):
         assert not args.sequence_parallel, "Huggingface models do not support --sequence-parallel"
-        assert args.context_parallel_size < 2, "Huggingface models do not support --context-parallel-size > 1"
+        assert (
+            args.context_parallel_size < 2
+        ), "Huggingface models do not support --context-parallel-size > 1"
 
     if vision_model_type in ["clip", "siglip", "radio", "cradio-g"]:
         if use_te:
@@ -129,17 +151,23 @@ def model_provider(
     elif vision_model_type == "radio-g":
         if use_te:
             from radio.radio_g import get_radio_g_layer_spec_te
-            vision_transformer_layer_spec = get_radio_g_layer_spec_te()  # TENorm detects LayerNorm/RMS automatically.
+
+            vision_transformer_layer_spec = (
+                get_radio_g_layer_spec_te()
+            )  # TENorm detects LayerNorm/RMS automatically.
         else:
             from radio.radio_g import get_radio_g_layer_spec
+
             vision_transformer_layer_spec = get_radio_g_layer_spec(
                 normalization=vision_config.normalization
             )
     elif vision_model_type == "internvit":
         from nvlm.internvit import get_internvit_layer_spec
+
         vision_transformer_layer_spec = get_internvit_layer_spec(use_te=use_te)
     elif vision_model_type == "internvit300M":
         from nvlm.internvit import get_internvit300M_layer_spec
+
         vision_transformer_layer_spec = get_internvit300M_layer_spec(use_te=use_te)
     elif vision_model_type.startswith("hf://"):
         vision_transformer_layer_spec = None
@@ -154,7 +182,9 @@ def model_provider(
 
     # Make sure vision model pipeline parallel size is not inherited from the language model pipeline parallel size.
     vision_config.pipeline_model_parallel_size = 1
-    vision_projection_config.pipeline_model_parallel_size = vision_config.pipeline_model_parallel_size
+    vision_projection_config.pipeline_model_parallel_size = (
+        vision_config.pipeline_model_parallel_size
+    )
 
     # Make sure the vision model does not inherit first and last pipeline num layers from the language model.
     vision_config.first_pipeline_num_layers = vision_config.last_pipeline_num_layers = None
@@ -166,7 +196,10 @@ def model_provider(
 
     # Toggle --recompute* for the vision and language model separately.
     if args.recompute_vision:
-        if vision_config.recompute_method is not None and vision_config.recompute_granularity is not None:
+        if (
+            vision_config.recompute_method is not None
+            and vision_config.recompute_granularity is not None
+        ):
             vision_config.recompute_num_layers = vision_config.num_layers
     else:
         vision_config.recompute_granularity = None
@@ -188,7 +221,9 @@ def model_provider(
 
     tokenizer = get_tokenizer()
     image_token_index = tokenizer.convert_tokens_to_ids(IMAGE_TOKEN)
-    assert image_token_index is not None, f"IMAGE_TOKEN={IMAGE_TOKEN} needs to be added using the --special-tokens arg."
+    assert (
+        image_token_index is not None
+    ), f"IMAGE_TOKEN={IMAGE_TOKEN} needs to be added using the --special-tokens arg."
 
     tile_tags = _get_tile_tags(args, tokenizer)
 
@@ -224,6 +259,7 @@ def model_provider(
         tile_tags=tile_tags,
         max_num_tiles=args.max_num_tiles,
         tokenizer_type=args.tokenizer_prompt_format,
+        pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
     )
 
     model.freeze(
@@ -247,16 +283,25 @@ def _get_tile_tags(args, tokenizer):
             thumbnail_tag_text = "<tile_global>"
 
         if args.tokenizer_prompt_format.startswith("nemotron"):
-            tile_tags_text = [f"<tile_{i:02d}>" for i in range(1, args.max_num_tiles + 1)] + [thumbnail_tag_text]
+            tile_tags_text = [f"<tile_{i:02d}>" for i in range(1, args.max_num_tiles + 1)] + [
+                thumbnail_tag_text
+            ]
         else:
-            tile_tags_text = [f"<tile_{i}>" for i in range(1, args.max_num_tiles + 1)] + [thumbnail_tag_text]
+            tile_tags_text = [f"<tile_{i}>" for i in range(1, args.max_num_tiles + 1)] + [
+                thumbnail_tag_text
+            ]
     elif args.max_num_tiles <= 12:
         thumbnail_tag_text = "<tile_global_thumbnail0>"
         if args.tokenizer_prompt_format == "nvlm-yi-34b":
             thumbnail_tag_text = "<tile_global0>"
-        elif args.tokenizer_prompt_format.startswith("nemotron") or args.tokenizer_prompt_format == "llama3p1":
+        elif (
+            args.tokenizer_prompt_format.startswith("nemotron")
+            or args.tokenizer_prompt_format == "llama3p1"
+        ):
             thumbnail_tag_text = "<tile_global_thumbnail>"
-        tile_tags_text = [f"<tile_{i:02d}>" for i in range(1, args.max_num_tiles + 1)] + [thumbnail_tag_text]
+        tile_tags_text = [f"<tile_{i:02d}>" for i in range(1, args.max_num_tiles + 1)] + [
+            thumbnail_tag_text
+        ]
     else:
         raise ValueError("We only support max_num_tiles <= 12 when using nvlm image_tag_type")
 

--- a/examples/multimodal/model.py
+++ b/examples/multimodal/model.py
@@ -1,26 +1,37 @@
 # Copyright (c) 2024-2026, NVIDIA CORPORATION.  All rights reserved.
-import warnings
 import logging
+import warnings
 from copy import deepcopy
 
 import torch
 from config import get_language_model_config, get_vision_model_config, get_vision_projection_config
-from layer_specs import (get_layer_spec, get_layer_spec_te, get_mlp_module_spec, get_norm_mlp_module_spec_te,
-                         get_hybrid_layer_spec_te)
+from layer_specs import (
+    get_hybrid_layer_spec_te,
+    get_layer_spec,
+    get_layer_spec_te,
+    get_mlp_module_spec,
+    get_norm_mlp_module_spec_te,
+)
 
 from megatron.core.models.gpt.gpt_layer_specs import get_gpt_decoder_block_spec
 from megatron.core.models.multimodal.llava_model import IMAGE_TOKEN, LLaVAModel
 from megatron.core.models.vision.clip_vit_model import get_num_image_embeddings
+from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.transformer.spec_utils import import_module
+from megatron.core.utils import log_single_rank
 from megatron.training import get_args, get_tokenizer, print_rank_0
 from megatron.training.arguments import core_transformer_config_from_args
-from megatron.core.utils import log_single_rank
-
 
 
 def model_provider(
-    pre_process=True, post_process=True, add_encoder=True, add_decoder=True, parallel_output=True,
-    vp_stage=None, config=None, pg_collection=None,
+    pre_process=True,
+    post_process=True,
+    add_encoder=True,
+    add_decoder=True,
+    parallel_output=True,
+    vp_stage=None,
+    config=None,
+    pg_collection=None,
 ) -> LLaVAModel:
     """Builds the model.
 
@@ -41,6 +52,11 @@ def model_provider(
     """
     args = get_args()
     use_te = args.use_te
+
+    if pg_collection is None:
+        # LLaVAModel requires an explicit process-group collection; this example runs on the
+        # global parallel grid, so resolve that fallback here rather than inside megatron/core.
+        pg_collection = ProcessGroupCollection.use_mpu_process_groups()
 
     print_rank_0('building a multimodal model ...')
 
@@ -64,7 +80,7 @@ def model_provider(
             args.pixel_shuffle,
             args.use_tile_tags,
             args.max_num_tiles,
-            args.tokenizer_prompt_format
+            args.tokenizer_prompt_format,
         )
         old_seq_length = args.seq_length
         args.seq_length = args.encoder_seq_length = num_image_embeddings
@@ -72,10 +88,13 @@ def model_provider(
             log_single_rank(
                 logging.getLogger(__name__),
                 logging.WARNING,
-                f"Changed seq_length and encoder_seq_length (vision model sequence length) from {old_seq_length} to num_image_tokens ({num_image_embeddings})"
+                f"Changed seq_length and encoder_seq_length (vision model sequence length) from {old_seq_length} to num_image_tokens ({num_image_embeddings})",
             )
 
-        max_num_image_embeddings = max((args.max_num_tiles + int(args.use_thumbnail)), args.num_frames) * num_image_embeddings
+        max_num_image_embeddings = (
+            max((args.max_num_tiles + int(args.use_thumbnail)), args.num_frames)
+            * num_image_embeddings
+        )
 
     assert (
         args.decoder_seq_length is not None
@@ -101,10 +120,16 @@ def model_provider(
     language_config = get_language_model_config(language_config)
 
     if language_model_type.startswith("hf://"):
-        assert args.tensor_model_parallel_size == 1, "Huggingface models do not support --tensor-model-parallel-size > 1"
-        assert args.pipeline_model_parallel_size < 2, "Huggingface models do not support --pipeline-model-parallel-size > 1"
+        assert (
+            args.tensor_model_parallel_size == 1
+        ), "Huggingface models do not support --tensor-model-parallel-size > 1"
+        assert (
+            args.pipeline_model_parallel_size < 2
+        ), "Huggingface models do not support --pipeline-model-parallel-size > 1"
         assert not args.sequence_parallel, "Huggingface models do not support --sequence-parallel"
-        assert args.context_parallel_size < 2, "Huggingface models do not support --context-parallel-size > 1"
+        assert (
+            args.context_parallel_size < 2
+        ), "Huggingface models do not support --context-parallel-size > 1"
 
     if language_model_type.startswith("hf://"):
         language_transformer_layer_spec = None
@@ -140,7 +165,9 @@ def model_provider(
     if vision_model_type not in ("pixtral-vit", "pixtral-vit-large"):
         vision_config.add_bias_linear = True
     if vision_model_type.startswith("hf://"):
-        assert args.context_parallel_size < 2, "Huggingface models do not support --context-parallel-size > 1"
+        assert (
+            args.context_parallel_size < 2
+        ), "Huggingface models do not support --context-parallel-size > 1"
 
     if vision_model_type in ["clip", "siglip", "radio", "cradio-g"]:
         if use_te:
@@ -154,17 +181,23 @@ def model_provider(
     elif vision_model_type == "radio-g":
         if use_te:
             from radio.radio_g import get_radio_g_layer_spec_te
-            vision_transformer_layer_spec = get_radio_g_layer_spec_te()  # TENorm detects LayerNorm/RMS automatically.
+
+            vision_transformer_layer_spec = (
+                get_radio_g_layer_spec_te()
+            )  # TENorm detects LayerNorm/RMS automatically.
         else:
             from radio.radio_g import get_radio_g_layer_spec
+
             vision_transformer_layer_spec = get_radio_g_layer_spec(
                 normalization=vision_config.normalization
             )
     elif vision_model_type == "internvit":
         from nvlm.internvit import get_internvit_layer_spec
+
         vision_transformer_layer_spec = get_internvit_layer_spec(use_te=use_te)
     elif vision_model_type == "internvit300M":
         from nvlm.internvit import get_internvit300M_layer_spec
+
         vision_transformer_layer_spec = get_internvit300M_layer_spec(use_te=use_te)
     elif vision_model_type in ("pixtral-vit", "pixtral-vit-large", "qwen-vl", "kimi-vit"):
         if use_te:
@@ -186,7 +219,9 @@ def model_provider(
 
     # Make sure vision model pipeline parallel size is not inherited from the language model pipeline parallel size.
     vision_config.pipeline_model_parallel_size = 1
-    vision_projection_config.pipeline_model_parallel_size = vision_config.pipeline_model_parallel_size
+    vision_projection_config.pipeline_model_parallel_size = (
+        vision_config.pipeline_model_parallel_size
+    )
 
     # Make sure the vision model does not inherit first and last pipeline num layers from the language model.
     vision_config.first_pipeline_num_layers = vision_config.last_pipeline_num_layers = None
@@ -201,7 +236,10 @@ def model_provider(
 
     # Toggle --recompute* for the vision and language model separately.
     if args.recompute_vision:
-        if vision_config.recompute_method is not None and vision_config.recompute_granularity is not None:
+        if (
+            vision_config.recompute_method is not None
+            and vision_config.recompute_granularity is not None
+        ):
             vision_config.recompute_num_layers = vision_config.num_layers
     else:
         vision_config.recompute_granularity = None
@@ -223,7 +261,9 @@ def model_provider(
 
     tokenizer = get_tokenizer()
     image_token_index = tokenizer.convert_tokens_to_ids(IMAGE_TOKEN)
-    assert image_token_index is not None, f"IMAGE_TOKEN={IMAGE_TOKEN} needs to be added using the --special-tokens arg."
+    assert (
+        image_token_index is not None
+    ), f"IMAGE_TOKEN={IMAGE_TOKEN} needs to be added using the --special-tokens arg."
 
     tile_tags = _get_tile_tags(args, tokenizer)
 
@@ -294,16 +334,25 @@ def _get_tile_tags(args, tokenizer):
             thumbnail_tag_text = "<tile_global>"
 
         if args.tokenizer_prompt_format.startswith("nemotron"):
-            tile_tags_text = [f"<tile_{i:02d}>" for i in range(1, args.max_num_tiles + 1)] + [thumbnail_tag_text]
+            tile_tags_text = [f"<tile_{i:02d}>" for i in range(1, args.max_num_tiles + 1)] + [
+                thumbnail_tag_text
+            ]
         else:
-            tile_tags_text = [f"<tile_{i}>" for i in range(1, args.max_num_tiles + 1)] + [thumbnail_tag_text]
+            tile_tags_text = [f"<tile_{i}>" for i in range(1, args.max_num_tiles + 1)] + [
+                thumbnail_tag_text
+            ]
     elif args.max_num_tiles <= 12:
         thumbnail_tag_text = "<tile_global_thumbnail0>"
         if args.tokenizer_prompt_format == "nvlm-yi-34b":
             thumbnail_tag_text = "<tile_global0>"
-        elif args.tokenizer_prompt_format.startswith("nemotron") or args.tokenizer_prompt_format == "llama3p1":
+        elif (
+            args.tokenizer_prompt_format.startswith("nemotron")
+            or args.tokenizer_prompt_format == "llama3p1"
+        ):
             thumbnail_tag_text = "<tile_global_thumbnail>"
-        tile_tags_text = [f"<tile_{i:02d}>" for i in range(1, args.max_num_tiles + 1)] + [thumbnail_tag_text]
+        tile_tags_text = [f"<tile_{i:02d}>" for i in range(1, args.max_num_tiles + 1)] + [
+            thumbnail_tag_text
+        ]
     else:
         raise ValueError("We only support max_num_tiles <= 12 when using nvlm image_tag_type")
 

--- a/examples/t5/pretrain_t5.py
+++ b/examples/t5/pretrain_t5.py
@@ -10,7 +10,6 @@ import torch
 
 import megatron
 from megatron.core import mpu, tensor_parallel
-from megatron.core.tokenizers.utils.build_tokenizer import build_tokenizer
 from megatron.core.datasets.blended_megatron_dataset_builder import BlendedMegatronDatasetBuilder
 from megatron.core.datasets.t5_dataset import (
     T5MaskedWordPieceDataset,
@@ -25,9 +24,11 @@ from megatron.core.models.T5.t5_spec import (
     get_t5_encoder_with_local_block_spec,
     get_t5_encoder_with_transformer_engine_block_spec,
 )
+from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.tokenizers.utils.build_tokenizer import build_tokenizer
 from megatron.training import get_args, get_timers, pretrain, print_rank_0
-from megatron.training.arguments import core_transformer_config_from_args, parse_and_validate_args
 from megatron.training.argument_utils import pretrain_cfg_container_from_args
+from megatron.training.arguments import core_transformer_config_from_args, parse_and_validate_args
 from pretrain_gpt import loss_func
 
 """
@@ -87,7 +88,7 @@ def model_provider(
     """
 
     args = get_args()
-    
+
     if config is None:
         config = core_transformer_config_from_args(args)
 
@@ -132,6 +133,9 @@ def model_provider(
         relative_attention_max_distance=args.relative_attention_max_distance,
         add_encoder=add_encoder,
         add_decoder=add_decoder,
+        pg_collection=ProcessGroupCollection.use_mpu_process_groups(
+            required_pgs=['tp', 'cp', 'pp']
+        ),
     )
 
     return model

--- a/megatron/core/export/trtllm/trtllm_weights_converter/distributed_trtllm_model_weights_converter.py
+++ b/megatron/core/export/trtllm/trtllm_weights_converter/distributed_trtllm_model_weights_converter.py
@@ -4,13 +4,14 @@ from typing import Optional
 
 import torch
 
-from megatron.core import parallel_state
 from megatron.core.export.data_type import DataType
 from megatron.core.export.trtllm.trtllm_layers import NON_TRANSFORMER_LAYERS_NAMES, TRTLLMLayers
 from megatron.core.export.trtllm.trtllm_layers import get_layer_name_without_prefix as suffix
 from megatron.core.export.trtllm.trtllm_weights_converter.utils import is_gated_activation
+from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.utils import VocabUtility
 from megatron.core.transformer.transformer_config import TransformerConfig
+from megatron.core.utils import get_pg_rank, get_pg_size
 
 try:
     from tqdm import tqdm
@@ -68,11 +69,14 @@ class DistributedTRTLLMModelWeightsConverter:
                 num_kv_heads = self.transformer_config.num_attention_heads
         self.num_kv_heads = num_kv_heads
 
-        self.inference_pp_size = parallel_state.get_pipeline_model_parallel_world_size()
-        self.inference_tp_size = parallel_state.get_tensor_model_parallel_world_size()
-        self.tp_rank = parallel_state.get_tensor_model_parallel_rank()
-        self.pp_rank = parallel_state.get_pipeline_model_parallel_rank()
-        self.tp_group = parallel_state.get_tensor_model_parallel_group()
+        # Single compatibility boundary rather than five separate global reads. Export runs on
+        # whatever grid the model was loaded on; see docs/developer/parallel-state-deprecation.md.
+        pg_collection = ProcessGroupCollection.use_mpu_process_groups(required_pgs=['tp', 'pp'])
+        self.inference_pp_size = get_pg_size(pg_collection.pp)
+        self.inference_tp_size = get_pg_size(pg_collection.tp)
+        self.tp_rank = get_pg_rank(pg_collection.tp)
+        self.pp_rank = get_pg_rank(pg_collection.pp)
+        self.tp_group = pg_collection.tp
         vp_size = self.transformer_config.virtual_pipeline_model_parallel_size
 
         assert (

--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -2396,8 +2396,10 @@ if HAVE_TE and is_te_min_version("1.9.0.dev0"):
 
             # The comms between TP and EP group is explicitly handled by MoE token dispatcher.
             # So we disable comms by making TE agnostic of model parallel.
-            if pg_collection is None:
-                pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+            assert pg_collection is not None, (
+                "TEGroupedLinear requires an explicit pg_collection; "
+                "see docs/developer/parallel-state-deprecation.md"
+            )
             self._pg_collection = pg_collection
             assert is_expert, "TEGroupedLinear only supports expert parallelism"
             tp_group = pg_collection.expt_tp

--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -2100,9 +2100,10 @@ class TEDotProductAttention(te.pytorch.DotProductAttention):
                         "hierarchical cp commucation."
                     )
                     extra_kwargs["cp_comm_type"] = "a2a+p2p"
-                    extra_kwargs["cp_group"] = get_hierarchical_context_parallel_groups(
-                        check_initialized=False
-                    )
+                    # pg_collection.hcp is guaranteed here: the caller-supplied branch above
+                    # asserts hasattr(pg_collection, "hcp") for cp_comm_type == "a2a+p2p", and
+                    # the fallback branch populates it.
+                    extra_kwargs["cp_group"] = pg_collection.hcp
                 else:
                     extra_kwargs["cp_comm_type"] = cp_comm_type
 

--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -2497,8 +2497,10 @@ if HAVE_TE and is_te_min_version("1.9.0.dev0"):
 
             # The comms between TP and EP group is explicitly handled by MoE token dispatcher.
             # So we disable comms by making TE agnostic of model parallel.
-            if pg_collection is None:
-                pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+            assert pg_collection is not None, (
+                "TEGroupedLinear requires an explicit pg_collection; "
+                "see docs/developer/parallel-state-deprecation.md"
+            )
             self._pg_collection = pg_collection
             assert is_expert, "TEGroupedLinear only supports expert parallelism"
             tp_group = pg_collection.expt_tp

--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -2185,9 +2185,10 @@ class TEDotProductAttention(te.pytorch.DotProductAttention):
                         "hierarchical cp commucation."
                     )
                     extra_kwargs["cp_comm_type"] = "a2a+p2p"
-                    extra_kwargs["cp_group"] = get_hierarchical_context_parallel_groups(
-                        check_initialized=False
-                    )
+                    # pg_collection.hcp is guaranteed here: the caller-supplied branch above
+                    # asserts hasattr(pg_collection, "hcp") for cp_comm_type == "a2a+p2p", and
+                    # the fallback branch populates it.
+                    extra_kwargs["cp_group"] = pg_collection.hcp
                 else:
                     extra_kwargs["cp_comm_type"] = cp_comm_type
 

--- a/megatron/core/inference/communication_utils.py
+++ b/megatron/core/inference/communication_utils.py
@@ -149,17 +149,17 @@ def broadcast_tensor(size, dtype, tensor=None, rank=0, data_parallel=False):
     Args:
         data_parallel (bool): Broadcast across a single data parallel model replica.
     """
+    # Single compatibility boundary: the source rank is rank 0 of the model-parallel group, so
+    # both are derived from one lookup. See docs/developer/parallel-state-deprecation.md.
+    group = None
     if data_parallel:
-        rank = parallel_state.get_model_parallel_src_rank()
+        group = parallel_state.get_model_parallel_group()
+        rank = torch.distributed.get_global_rank(group, 0)
 
     if torch.distributed.get_rank() == rank:
         _is_cuda_contiguous(tensor)
     else:
         tensor = torch.empty(size, dtype=dtype, device=torch.cuda.current_device())
-
-    group = None
-    if data_parallel:
-        group = parallel_state.get_model_parallel_group()
 
     torch.distributed.broadcast(tensor, rank, group=group)
 
@@ -176,10 +176,9 @@ def broadcast_list(size, dtype, list_values=None, rank=0, data_parallel=False):
     tensor = None
 
     if data_parallel:
-        if parallel_state.get_model_parallel_src_rank() == torch.distributed.get_rank():
-            tensor = torch.tensor(list_values, dtype=dtype, device=torch.cuda.current_device())
-
         rank = parallel_state.get_model_parallel_src_rank()
+        if rank == torch.distributed.get_rank():
+            tensor = torch.tensor(list_values, dtype=dtype, device=torch.cuda.current_device())
     else:
         if torch.distributed.get_rank() == rank:
             tensor = torch.tensor(list_values, dtype=dtype, device=torch.cuda.current_device())

--- a/megatron/core/inference/config.py
+++ b/megatron/core/inference/config.py
@@ -429,6 +429,19 @@ class InferenceConfig:
     """Whether to log detailed context configuration at initialization.
     This is an InitVar and is not stored as a field on the config."""
 
+    def resolve_pg_collection(self) -> ProcessGroupCollection:
+        """Return the configured process groups, falling back to the MPU globals.
+
+        This is the compatibility boundary for inference: engines and wrappers call it once and
+        can then assume a collection, instead of each re-deriving one from global state. Resolution
+        is lazy so it happens after ``initialize_model_parallel``, not at config construction.
+
+        See ``docs/developer/parallel-state-deprecation.md``.
+        """
+        if self.pg_collection is None:
+            self.pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+        return self.pg_collection
+
     def __post_init__(self, verbose: bool):
         self._verbose = verbose
         self.async_sched_mode = AsyncScheduleMode(self.async_sched_mode)

--- a/megatron/core/inference/config.py
+++ b/megatron/core/inference/config.py
@@ -653,6 +653,19 @@ class InferenceConfig:
     only when model weights are guaranteed not to change across those boundaries.
     """
 
+    def resolve_pg_collection(self) -> ProcessGroupCollection:
+        """Return the configured process groups, falling back to the MPU globals.
+
+        This is the compatibility boundary for inference: engines and wrappers call it once and
+        can then assume a collection, instead of each re-deriving one from global state. Resolution
+        is lazy so it happens after ``initialize_model_parallel``, not at config construction.
+
+        See ``docs/developer/parallel-state-deprecation.md``.
+        """
+        if self.pg_collection is None:
+            self.pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+        return self.pg_collection
+
     def __post_init__(self, verbose: bool):
         self._verbose = verbose
         self.async_sched_mode = AsyncScheduleMode(self.async_sched_mode)

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -263,10 +263,7 @@ class DynamicInferenceEngine(AbstractEngine):
         model_config = controller.inference_wrapped_model.model.config
         inference_config = context.config
 
-        if inference_config.pg_collection is not None:
-            self.pg_collection = inference_config.pg_collection
-        else:
-            self.pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+        self.pg_collection = inference_config.resolve_pg_collection()
 
         # Initialization options.
         self.controller = controller

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -338,10 +338,7 @@ class DynamicInferenceEngine(AbstractEngine):
         model_config = controller.inference_wrapped_model.model.config
         inference_config = context.config
 
-        if inference_config.pg_collection is not None:
-            self.pg_collection = inference_config.pg_collection
-        else:
-            self.pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+        self.pg_collection = inference_config.resolve_pg_collection()
 
         # Initialization options.
         self.controller = controller

--- a/megatron/core/inference/model_inference_wrappers/abstract_model_inference_wrapper.py
+++ b/megatron/core/inference/model_inference_wrappers/abstract_model_inference_wrapper.py
@@ -53,10 +53,9 @@ class AbstractModelInferenceWrapper(abc.ABC):
 
         self.inference_context = inference_context
 
-        # Get the inference pg_collection from the config if it exists; otherwise the training
-        # pg_collection might be used during RL
-        if (pg_collection := self.inference_context.config.pg_collection) is None:
-            pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+        # Resolved once at the inference-config boundary; during RL this may be the training
+        # collection rather than an inference-specific one.
+        pg_collection = self.inference_context.config.resolve_pg_collection()
 
         self.tp_group = pg_collection.tp
         self.pp_group = pg_collection.pp

--- a/megatron/core/inference/model_inference_wrappers/abstract_model_inference_wrapper.py
+++ b/megatron/core/inference/model_inference_wrappers/abstract_model_inference_wrapper.py
@@ -61,10 +61,9 @@ class AbstractModelInferenceWrapper(abc.ABC):
 
         self.inference_context = inference_context
 
-        # Get the inference pg_collection from the config if it exists; otherwise the training
-        # pg_collection might be used during RL
-        if (pg_collection := self.inference_context.config.pg_collection) is None:
-            pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+        # Resolved once at the inference-config boundary; during RL this may be the training
+        # collection rather than an inference-specific one.
+        pg_collection = self.inference_context.config.resolve_pg_collection()
 
         self.tp_group = pg_collection.tp
         self.pp_group = pg_collection.pp

--- a/megatron/core/models/T5/t5_model.py
+++ b/megatron/core/models/T5/t5_model.py
@@ -21,7 +21,7 @@ from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.spec_utils import ModuleSpec
 from megatron.core.transformer.transformer_block import TransformerBlock
 from megatron.core.transformer.transformer_config import TransformerConfig
-from megatron.core.utils import deprecate_inference_params, get_tensor_model_parallel_group_if_none
+from megatron.core.utils import deprecate_inference_params
 
 
 class T5LMHead(MegatronModule):
@@ -175,11 +175,13 @@ class T5Model(LanguageModule):
         self.share_embeddings_and_output_weights = share_embeddings_and_output_weights
         self.position_embedding_type = position_embedding_type
         self.encoder_hidden_state = None
-        if pg_collection is None:
-            pg_collection = ProcessGroupCollection.use_mpu_process_groups(
-                required_pgs=['tp', 'cp', 'pp']
-            )
-        self.tp_group = get_tensor_model_parallel_group_if_none(pg_collection.tp)
+        assert pg_collection is not None, (
+            "T5Model requires an explicit pg_collection with tp/cp/pp; "
+            "see docs/developer/parallel-state-deprecation.md"
+        )
+        for _pg in ('tp', 'cp', 'pp'):
+            assert hasattr(pg_collection, _pg), f"T5Model pg_collection must have {_pg}"
+        self.tp_group = pg_collection.tp
 
         self.model_type = ModelType.encoder_or_decoder
 

--- a/megatron/core/models/bert/bert_model.py
+++ b/megatron/core/models/bert/bert_model.py
@@ -126,6 +126,7 @@ class BertModel(LanguageModule):
                 rotary_interleaved=self.config.rotary_interleaved,
                 seq_len_interpolation_factor=seq_len_interpolation_factor,
                 use_cpu_initialization=self.config.use_cpu_initialization,
+                cp_group=self.cp_group,
             )
 
         # Transformer.

--- a/megatron/core/models/common/embeddings/rotary_pos_embedding.py
+++ b/megatron/core/models/common/embeddings/rotary_pos_embedding.py
@@ -17,7 +17,6 @@ from functools import lru_cache
 import torch
 from torch import Tensor, nn
 
-from megatron.core import parallel_state
 from megatron.core.models.common.embeddings.rope_utils import (  # for backward compatibility; pylint: disable=unused-import
     _apply_rotary_pos_emb_bshd,
     _apply_rotary_pos_emb_thd,
@@ -83,11 +82,7 @@ class RotaryEmbedding(nn.Module):
         if rope_scaling:
             self.inv_freq = self._apply_scaling(self.inv_freq, factor=rope_scaling_factor)
 
-        self.cp_group = (
-            cp_group
-            if cp_group is not None
-            else parallel_state.get_context_parallel_group(check_initialized=False)
-        )
+        self.cp_group = cp_group
 
     def _apply_scaling(
         self,
@@ -306,11 +301,7 @@ class MultimodalRotaryEmbedding(nn.Module):
                 / dim
             )
         )
-        self.cp_group = (
-            cp_group
-            if cp_group is not None
-            else parallel_state.get_context_parallel_group(check_initialized=False)
-        )
+        self.cp_group = cp_group
 
     def forward(
         self,

--- a/megatron/core/models/common/embeddings/rotary_pos_embedding.py
+++ b/megatron/core/models/common/embeddings/rotary_pos_embedding.py
@@ -17,7 +17,6 @@ from functools import lru_cache
 import torch
 from torch import Tensor, nn
 
-from megatron.core import parallel_state
 from megatron.core.models.common.embeddings.rope_utils import (  # for backward compatibility; pylint: disable=unused-import
     _apply_rotary_pos_emb_bshd,
     _apply_rotary_pos_emb_thd,
@@ -83,11 +82,7 @@ class RotaryEmbedding(nn.Module):
         if rope_scaling:
             self.inv_freq = self._apply_scaling(self.inv_freq, factor=rope_scaling_factor)
 
-        self.cp_group = (
-            cp_group
-            if cp_group is not None
-            else parallel_state.get_context_parallel_group(check_initialized=False)
-        )
+        self.cp_group = cp_group
 
     def _apply_scaling(
         self,
@@ -351,11 +346,7 @@ class MultimodalRotaryEmbedding(nn.Module):
                 / dim
             )
         )
-        self.cp_group = (
-            cp_group
-            if cp_group is not None
-            else parallel_state.get_context_parallel_group(check_initialized=False)
-        )
+        self.cp_group = cp_group
 
     def forward(
         self,

--- a/megatron/core/models/common/language_module/language_module.py
+++ b/megatron/core/models/common/language_module/language_module.py
@@ -28,6 +28,7 @@ from megatron.core.transformer.multi_token_prediction import tie_word_embeddings
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.transformer.utils import ensure_metadata_has_dp_cp_group
 from megatron.core.utils import (
+    get_pg_rank,
     get_tensor_model_parallel_group_if_none,
     is_te_min_version,
     make_tp_sharded_tensor_for_checkpoint,
@@ -509,7 +510,9 @@ class LanguageModule(MegatronModule):
         last_stage_word_emb_replica_id = (
             1,  # copy of first stage embedding
             0,
-            parallel_state.get_data_parallel_rank(with_context_parallel=True),
+            # Same group the sharded tensor below is built against, so the replica id and the
+            # sharding always agree -- including when the caller supplies its own grid.
+            get_pg_rank(metadata['dp_cp_group']),
         )
 
         sharded_state_dict[output_layer_weight_key] = make_tp_sharded_tensor_for_checkpoint(

--- a/megatron/core/models/gpt/gpt_model.py
+++ b/megatron/core/models/gpt/gpt_model.py
@@ -207,6 +207,7 @@ class GPTModel(LanguageModule):
                     self.config, "yarn_correction_range_round_to_int"
                 ),
                 use_cpu_initialization=self.config.use_cpu_initialization,
+                cp_group=self.cp_group,
             )
         elif self.position_embedding_type == 'mrope' and not self.config.multi_latent_attention:
             self.rotary_pos_emb = MultimodalRotaryEmbedding(
@@ -215,6 +216,7 @@ class GPTModel(LanguageModule):
                 rotary_interleaved=self.config.rotary_interleaved,
                 seq_len_interpolation_factor=seq_len_interpolation_factor,
                 rotary_base=rotary_base,
+                cp_group=self.cp_group,
             )
             self.mrope_section = self.config.mrope_section
             assert (

--- a/megatron/core/models/gpt/gpt_model.py
+++ b/megatron/core/models/gpt/gpt_model.py
@@ -162,6 +162,7 @@ class GPTModel(LanguageModule):
             mtp_num_layers=self.config.mtp_num_layers,
             ignore_virtual=False,
             vp_stage=vp_stage,
+            pp_group=self.pp_group,
         )
 
         if self.pre_process or self.mtp_process:

--- a/megatron/core/models/gpt/gpt_model.py
+++ b/megatron/core/models/gpt/gpt_model.py
@@ -215,6 +215,7 @@ class GPTModel(LanguageModule, GraphableMegatronModule):
                     self.config, "yarn_correction_range_round_to_int"
                 ),
                 use_cpu_initialization=self.config.use_cpu_initialization,
+                cp_group=self.cp_group,
             )
         elif self.position_embedding_type == 'mrope' and not self.config.multi_latent_attention:
             self.rotary_pos_emb = MultimodalRotaryEmbedding(
@@ -223,6 +224,7 @@ class GPTModel(LanguageModule, GraphableMegatronModule):
                 rotary_interleaved=self.config.rotary_interleaved,
                 seq_len_interpolation_factor=seq_len_interpolation_factor,
                 rotary_base=rotary_base,
+                cp_group=self.cp_group,
             )
             self.mrope_section = self.config.mrope_section
             assert (

--- a/megatron/core/models/hybrid/hybrid_model.py
+++ b/megatron/core/models/hybrid/hybrid_model.py
@@ -224,6 +224,7 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
                 mtp_num_layers=self.config.mtp_num_layers,
                 ignore_virtual=False,
                 vp_stage=self.vp_stage,
+                pp_group=self.pp_group,
             )
         )
 

--- a/megatron/core/models/multimodal/context_parallel.py
+++ b/megatron/core/models/multimodal/context_parallel.py
@@ -6,11 +6,7 @@ import math
 import torch
 
 from megatron.core.packed_seq_params import PackedSeqParams
-from megatron.core.parallel_state import (
-    get_context_parallel_group,
-    get_context_parallel_rank,
-    get_context_parallel_world_size,
-)
+from megatron.core.utils import get_pg_rank, get_pg_size
 
 
 def get_padding(
@@ -118,19 +114,20 @@ def get_packed_seq_params(tokens, img_seq_len, padding_needed, cp_size, use_pack
     return packed_seq_params
 
 
-def split_to_context_parallel_ranks(global_t, pad_value=0):
+def split_to_context_parallel_ranks(global_t, cp_group, pad_value=0):
     """Split the tensor global_t into context parallel world size parts.
 
     Args:
         global_t: [batch, ...]
+        cp_group: The context parallel process group to split across.
         pad_value: Value to pad the last rank with.
 
     Returns:
         local_t: [samples_per_rank, ...]. samples_per_rank is the # of samples per CP rank.
         global_pad: Total padding to have equal samples_per_rank across context parallel ranks.
     """
-    cp_size = get_context_parallel_world_size()
-    cp_rank = get_context_parallel_rank()
+    cp_size = get_pg_size(cp_group)
+    cp_rank = get_pg_rank(cp_group)
 
     samples_per_rank = (global_t.shape[0] + cp_size - 1) // cp_size
     local_t = global_t[cp_rank * samples_per_rank : (cp_rank + 1) * samples_per_rank]
@@ -146,9 +143,8 @@ def split_to_context_parallel_ranks(global_t, pad_value=0):
     return local_t, global_pad
 
 
-def _gather_along_second_dim(local_t):
-    group = get_context_parallel_group()
-    cp_size = get_context_parallel_world_size()
+def _gather_along_second_dim(local_t, cp_group):
+    cp_size = get_pg_size(cp_group)
     if cp_size == 1:
         return local_t
 
@@ -156,12 +152,12 @@ def _gather_along_second_dim(local_t):
         torch.empty(local_t.shape, device=local_t.device, dtype=local_t.dtype)
         for _ in range(cp_size)
     ]
-    torch.distributed.all_gather(tensor_list, local_t, group=group)
+    torch.distributed.all_gather(tensor_list, local_t, group=cp_group)
     return torch.cat(tensor_list, dim=1)
 
 
-def _reduce_scatter_along_second_dim(global_t):
-    cp_size = get_context_parallel_world_size()
+def _reduce_scatter_along_second_dim(global_t, cp_group):
+    cp_size = get_pg_size(cp_group)
     if cp_size == 1:
         return global_t
 
@@ -181,7 +177,7 @@ def _reduce_scatter_along_second_dim(global_t):
         dtype=global_t.dtype,
     )
 
-    torch.distributed.reduce_scatter(local_t, tensor_list, group=get_context_parallel_group())
+    torch.distributed.reduce_scatter(local_t, tensor_list, group=cp_group)
     return local_t
 
 
@@ -189,40 +185,42 @@ class GatherFromContextParallelRanks(torch.autograd.Function):
     """Gather the input from context parallel ranks."""
 
     @staticmethod
-    def symbolic(graph, input_):
+    def symbolic(graph, input_, cp_group):
         """Symbolic forward used during ``torch.jit`` tracing."""
-        return _gather_along_second_dim(input_)
+        return _gather_along_second_dim(input_, cp_group)
 
     @staticmethod
-    def forward(ctx, input_):
+    def forward(ctx, input_, cp_group):
         """All-gather ``input_`` along its second dimension across CP ranks."""
-        return _gather_along_second_dim(input_)
+        ctx.cp_group = cp_group
+        return _gather_along_second_dim(input_, cp_group)
 
     @staticmethod
     def backward(ctx, grad_output):
         """Reduce-scatter the gradient along the second dimension."""
-        return _reduce_scatter_along_second_dim(grad_output)
+        # One gradient per forward input; cp_group is not differentiable.
+        return _reduce_scatter_along_second_dim(grad_output, ctx.cp_group), None
 
 
-def gather_from_context_parallel_ranks(local_t, global_pad):
+def gather_from_context_parallel_ranks(local_t, global_pad, cp_group):
     """Gather ``local_t`` across CP ranks, removing ``global_pad`` trailing pad tokens."""
-    global_t = GatherFromContextParallelRanks.apply(local_t)
+    global_t = GatherFromContextParallelRanks.apply(local_t, cp_group)
     if global_pad > 0:
         global_t = global_t[:, :-global_pad]
     return global_t
 
 
-def gather_from_context_parallel_ranks_dynamic_res(local_t, num_padded_imgs=0):
+def gather_from_context_parallel_ranks_dynamic_res(local_t, cp_group, num_padded_imgs=0):
     """Gather dynamic-resolution tensors (variable seq per rank) from CP ranks."""
-    cp_size = get_context_parallel_world_size()
+    cp_size = get_pg_size(cp_group)
     shape = torch.as_tensor(local_t.shape, device=local_t.device)
     shapes = [torch.empty_like(shape) for _ in range(cp_size)]
 
-    torch.distributed.all_gather(shapes, shape, group=get_context_parallel_group())
+    torch.distributed.all_gather(shapes, shape, group=cp_group)
 
     inputs = [local_t] * cp_size
     outputs = [torch.empty(*s, dtype=local_t.dtype, device=local_t.device) for s in shapes]
-    torch.distributed.nn.functional.all_to_all(outputs, inputs, group=get_context_parallel_group())
+    torch.distributed.nn.functional.all_to_all(outputs, inputs, group=cp_group)
 
     if num_padded_imgs > 0:
         outputs = outputs[:-num_padded_imgs]
@@ -315,6 +313,7 @@ def split_to_context_parallel_ranks_dynamic_res(
     global_imgs_sizes,
     global_packed_seq_params,
     *,
+    cp_group,
     patch_dim,
     fp8_enabled=False,
     fp8_recipe=None,
@@ -346,8 +345,8 @@ def split_to_context_parallel_ranks_dynamic_res(
         (local_t, local_imgs_sizes, local_packed_seq_params, has_padding,
          num_padded_ranks, local_num_frames)
     """
-    cp_size = get_context_parallel_world_size()
-    cp_rank = get_context_parallel_rank()
+    cp_size = get_pg_size(cp_group)
+    cp_rank = get_pg_rank(cp_group)
 
     use_tubelet_aware_split = temporal_patch_size > 1
     if use_tubelet_aware_split:

--- a/megatron/core/models/multimodal/llava_model.py
+++ b/megatron/core/models/multimodal/llava_model.py
@@ -858,9 +858,7 @@ class LLaVAModel(MegatronModule):
                 from megatron.core.parallel_state import get_context_parallel_group
                 from megatron.core.utils import get_batch_on_this_cp_rank
 
-                batch = get_batch_on_this_cp_rank(
-                    batch, is_hybrid_cp=False, cp_group=get_context_parallel_group()
-                )
+                batch = get_batch_on_this_cp_rank(batch, is_hybrid_cp=False, cp_group=self.cp_group)
             else:
                 assert HAVE_TEX and is_te_min_version(
                     "1.10.0"

--- a/megatron/core/models/multimodal/llava_model.py
+++ b/megatron/core/models/multimodal/llava_model.py
@@ -1017,6 +1017,7 @@ class LLaVAModel(MegatronModule):
                         images,
                         imgs_sizes,
                         vision_packed_seq_params,
+                        cp_group=self.cp_group,
                         fp8_enabled=False,
                         fp8_recipe=getattr(self.config, "fp8_recipe", None),
                         patch_dim=self.vision_model.patch_dim,
@@ -1062,7 +1063,7 @@ class LLaVAModel(MegatronModule):
                 # matching number of tiles on every rank.
                 if self.context_parallel_lm > 1 and vision_packed_seq_params is not None:
                     image_embeddings = gather_from_context_parallel_ranks_dynamic_res(
-                        image_embeddings, num_padded_imgs
+                        image_embeddings, self.cp_group, num_padded_imgs
                     )
 
                 # After temporal grouping each tubelet is one "tile" for LLaVAModel's

--- a/megatron/core/models/multimodal/llava_model.py
+++ b/megatron/core/models/multimodal/llava_model.py
@@ -178,8 +178,11 @@ class LLaVAModel(MegatronModule):
         self.separate_video_embedder = separate_video_embedder
         self.temporal_ckpt_compat = temporal_ckpt_compat
 
-        if pg_collection is None:
-            pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+        assert pg_collection is not None, (
+            "LLaVAModel requires an explicit pg_collection. A vision encoder and an LLM may run "
+            "on independent parallel grids, so the global grid is not a safe default; "
+            "see docs/developer/parallel-state-deprecation.md"
+        )
         self.pg_collection = pg_collection
 
         language_model_type = getattr(language_transformer_config, "language_model_type", "")

--- a/megatron/core/models/multimodal/llava_model.py
+++ b/megatron/core/models/multimodal/llava_model.py
@@ -155,8 +155,11 @@ class LLaVAModel(MegatronModule):
             "LLaVA is work in progress. Features are missing and methods can change.",
         )
 
-        if pg_collection is None:
-            pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+        assert pg_collection is not None, (
+            "LLaVAModel requires an explicit pg_collection. A vision encoder and an LLM may run "
+            "on independent parallel grids, so the global grid is not a safe default; "
+            "see docs/developer/parallel-state-deprecation.md"
+        )
         language_model_type = getattr(language_transformer_config, "language_model_type", "")
 
         # Constructor configuration and initial module state.

--- a/megatron/core/pipeline_parallel/hybrid_cp_schedule.py
+++ b/megatron/core/pipeline_parallel/hybrid_cp_schedule.py
@@ -7,7 +7,6 @@ from typing import Callable, List, Optional, Tuple
 
 import torch
 
-from megatron.core import parallel_state
 from megatron.core.rerun_state_machine import RerunDataIterator
 
 
@@ -490,6 +489,7 @@ def hybrid_context_parallel_forward_backward(
     total_num_tokens,
     check_first_val_step,
     model_type,
+    pg_collection,
 ):
     """
     Scheduler for Hybrid Context Parallel.
@@ -509,12 +509,13 @@ def hybrid_context_parallel_forward_backward(
     """
     from .schedules import backward_step, forward_step
 
+    tp_group = pg_collection.tp
+    dp_cp_group = pg_collection.dp_cp
+
     def _broadcast(item):
         if item is not None:
             torch.distributed.broadcast(
-                item,
-                parallel_state.get_tensor_model_parallel_src_rank(),
-                group=parallel_state.get_tensor_model_parallel_group(),
+                item, torch.distributed.get_global_rank(tp_group, 0), group=tp_group
             )
 
     def _broadcast_num_samples_this_group(num_samples_this_group):
@@ -559,8 +560,8 @@ def hybrid_context_parallel_forward_backward(
 
     # We get data once per global batch and schedule the sub-samples.
     # TODO(pmannan): Should we wrap the data_iterator here instead of the training.py file?
-    hdp_rank = parallel_state.get_data_parallel_rank(with_context_parallel=True)
-    is_first_tp_rank = parallel_state.get_tensor_model_parallel_rank() == 0
+    hdp_rank = dp_cp_group.rank()
+    is_first_tp_rank = tp_group.rank() == 0
 
     if is_first_tp_rank:
         data = next(data_iterator)
@@ -613,9 +614,7 @@ def hybrid_context_parallel_forward_backward(
             # Create a barrier at end of each group.
             # This barrier ensures that all ranks are prepared to change assigned CP group sizes and
             # no rank is starting a sub-sample ahead of it's partner ranks.
-            torch.distributed.barrier(
-                parallel_state.get_data_parallel_group(with_context_parallel=True)
-            )
+            torch.distributed.barrier(dp_cp_group)
 
     # For the last group, we need to run the last sub-sample out of the context handler.
     with no_sync_func():

--- a/megatron/core/pipeline_parallel/hybrid_cp_schedule.py
+++ b/megatron/core/pipeline_parallel/hybrid_cp_schedule.py
@@ -7,7 +7,6 @@ from typing import Callable, List, Optional, Tuple
 
 import torch
 
-from megatron.core import parallel_state
 from megatron.core.rerun_state_machine import RerunDataIterator
 
 
@@ -490,6 +489,7 @@ def hybrid_context_parallel_forward_backward(
     total_num_tokens,
     check_first_val_step,
     model_type,
+    pg_collection,
 ):
     """
     Scheduler for Hybrid Context Parallel.
@@ -509,12 +509,13 @@ def hybrid_context_parallel_forward_backward(
     """
     from .schedules import backward_step, forward_step
 
+    tp_group = pg_collection.tp
+    dp_cp_group = pg_collection.dp_cp
+
     def _broadcast(item):
         if item is not None:
             torch.distributed.broadcast(
-                item,
-                parallel_state.get_tensor_model_parallel_src_rank(),
-                group=parallel_state.get_tensor_model_parallel_group(),
+                item, torch.distributed.get_global_rank(tp_group, 0), group=tp_group
             )
 
     def _broadcast_num_samples_this_group(num_samples_this_group):
@@ -577,8 +578,8 @@ def hybrid_context_parallel_forward_backward(
 
     # We get data once per global batch and schedule the sub-samples.
     # TODO(pmannan): Should we wrap the data_iterator here instead of the training.py file?
-    hdp_rank = parallel_state.get_data_parallel_rank(with_context_parallel=True)
-    is_first_tp_rank = parallel_state.get_tensor_model_parallel_rank() == 0
+    hdp_rank = dp_cp_group.rank()
+    is_first_tp_rank = tp_group.rank() == 0
 
     if is_first_tp_rank:
         data = next(data_iterator)
@@ -631,9 +632,7 @@ def hybrid_context_parallel_forward_backward(
             # Create a barrier at end of each group.
             # This barrier ensures that all ranks are prepared to change assigned CP group sizes and
             # no rank is starting a sub-sample ahead of it's partner ranks.
-            torch.distributed.barrier(
-                parallel_state.get_data_parallel_group(with_context_parallel=True)
-            )
+            torch.distributed.barrier(dp_cp_group)
 
     # For the last group, we need to run the last sub-sample out of the context handler.
     with no_sync_func():

--- a/megatron/core/pipeline_parallel/schedules.py
+++ b/megatron/core/pipeline_parallel/schedules.py
@@ -766,6 +766,9 @@ def forward_backward_no_pipelining(
             partial(check_first_val_step, first_val_step, forward_only),
         )
     elif config.hybrid_context_parallel:
+        assert hasattr(
+            pg_collection, 'dp_cp'
+        ), "pg_collection must have dp_cp when hybrid_context_parallel is enabled"
         forward_data_store, total_num_tokens = hybrid_context_parallel_forward_backward(
             forward_step_func,
             data_iterator,
@@ -782,6 +785,7 @@ def forward_backward_no_pipelining(
             total_num_tokens,
             check_first_val_step,
             model_type,
+            pg_collection,
         )
     else:
         with no_sync_func():

--- a/megatron/core/pipeline_parallel/schedules.py
+++ b/megatron/core/pipeline_parallel/schedules.py
@@ -793,6 +793,9 @@ def forward_backward_no_pipelining(
             partial(check_first_val_step, first_val_step, forward_only),
         )
     elif config.hybrid_context_parallel:
+        assert hasattr(
+            pg_collection, 'dp_cp'
+        ), "pg_collection must have dp_cp when hybrid_context_parallel is enabled"
         forward_data_store, total_num_tokens = hybrid_context_parallel_forward_backward(
             forward_step_func,
             data_iterator,
@@ -809,6 +812,7 @@ def forward_backward_no_pipelining(
             total_num_tokens,
             check_first_val_step,
             model_type,
+            pg_collection,
         )
     else:
         with no_sync_func():

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -20,11 +20,6 @@ from megatron.core.models.common.embeddings.rope_utils import (
     apply_rotary_pos_emb_with_cos_sin,
 )
 from megatron.core.packed_seq_params import PackedSeqParams
-from megatron.core.parallel_state import (
-    get_data_parallel_group,
-    get_data_parallel_rank,
-    get_data_parallel_world_size,
-)
 from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
     FineGrainedActivationOffloadingInterface as off_interface,
 )
@@ -331,7 +326,11 @@ class Attention(MegatronModule, ABC):
         self.kv_projection_size = self.config.kv_channels * self.config.num_query_groups
 
         if pg_collection is None:
-            pg_collection = ProcessGroupCollection.use_mpu_process_groups(required_pgs=['tp', 'cp'])
+            # 'dp' is only consumed by run_realtime_tests (config.test_mode), but the legacy
+            # fallback must supply it so that path keeps working without an explicit collection.
+            pg_collection = ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=['tp', 'cp', 'dp']
+            )
         else:
             assert hasattr(
                 pg_collection, 'tp'
@@ -1752,7 +1751,13 @@ class SelfAttention(Attention):
 
         # check that all tensor parallel and data parallel ranks have the same
         # Q & K layernorm parameters.
-        rank = get_data_parallel_rank()
+        # Only this consistency check needs the DP group, so it is required here rather than in
+        # __init__, which asks use_mpu_process_groups for tp/cp only.
+        assert hasattr(
+            self.pg_collection, 'dp'
+        ), "run_realtime_tests requires a dp process group; pass one via pg_collection.dp"
+        dp_group = self.pg_collection.dp
+        rank = dp_group.rank()
         inputs = torch.stack(
             [
                 self.q_layernorm.weight.data,
@@ -1761,9 +1766,9 @@ class SelfAttention(Attention):
                 self.k_layernorm.bias.data,
             ]
         )
-        dp_list = [torch.empty_like(inputs) for _ in range(get_data_parallel_world_size())]
+        dp_list = [torch.empty_like(inputs) for _ in range(dp_group.size())]
         dp_list[rank] = inputs
-        torch.distributed.all_gather(dp_list, inputs, group=get_data_parallel_group())
+        torch.distributed.all_gather(dp_list, inputs, group=dp_group)
 
         def _compare(srcs, tgts, names, parallelism):
             assert len(srcs) == len(tgts) == len(names)

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -325,19 +325,12 @@ class Attention(MegatronModule, ABC):
         self.query_projection_size = self.config.kv_channels * self.config.num_attention_heads
         self.kv_projection_size = self.config.kv_channels * self.config.num_query_groups
 
-        if pg_collection is None:
-            # 'dp' is only consumed by run_realtime_tests (config.test_mode), but the legacy
-            # fallback must supply it so that path keeps working without an explicit collection.
-            pg_collection = ProcessGroupCollection.use_mpu_process_groups(
-                required_pgs=['tp', 'cp', 'dp']
-            )
-        else:
-            assert hasattr(
-                pg_collection, 'tp'
-            ), "Attention pg_collection must have tp process group"
-            assert hasattr(
-                pg_collection, 'cp'
-            ), "Attention pg_collection must have cp process group"
+        assert pg_collection is not None, (
+            "Attention requires an explicit pg_collection with tp/cp; "
+            "see docs/developer/parallel-state-deprecation.md"
+        )
+        assert hasattr(pg_collection, 'tp'), "Attention pg_collection must have tp process group"
+        assert hasattr(pg_collection, 'cp'), "Attention pg_collection must have cp process group"
         self.pg_collection = pg_collection
         self.tp_group = pg_collection.tp
 

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -325,19 +325,12 @@ class Attention(MegatronModule, ABC):
         self.query_projection_size = self.config.kv_channels * self.config.num_attention_heads
         self.kv_projection_size = self.config.kv_channels * self.config.num_query_groups
 
-        if pg_collection is None:
-            # 'dp' is only consumed by run_realtime_tests (config.test_mode), but the legacy
-            # fallback must supply it so that path keeps working without an explicit collection.
-            pg_collection = ProcessGroupCollection.use_mpu_process_groups(
-                required_pgs=['tp', 'cp', 'dp']
-            )
-        else:
-            assert hasattr(
-                pg_collection, 'tp'
-            ), "Attention pg_collection must have tp process group"
-            assert hasattr(
-                pg_collection, 'cp'
-            ), "Attention pg_collection must have cp process group"
+        assert pg_collection is not None, (
+            "Attention requires an explicit pg_collection with tp/cp; "
+            "see docs/developer/parallel-state-deprecation.md"
+        )
+        assert hasattr(pg_collection, 'tp'), "Attention pg_collection must have tp process group"
+        assert hasattr(pg_collection, 'cp'), "Attention pg_collection must have cp process group"
         self.pg_collection = pg_collection
         self.tp_group = pg_collection.tp
 
@@ -1752,7 +1745,7 @@ class SelfAttention(Attention):
         # check that all tensor parallel and data parallel ranks have the same
         # Q & K layernorm parameters.
         # Only this consistency check needs the DP group, so it is required here rather than in
-        # __init__, which asks use_mpu_process_groups for tp/cp only.
+        # __init__, which requires tp/cp only.
         assert hasattr(
             self.pg_collection, 'dp'
         ), "run_realtime_tests requires a dp process group; pass one via pg_collection.dp"

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -325,12 +325,19 @@ class Attention(MegatronModule, ABC):
         self.query_projection_size = self.config.kv_channels * self.config.num_attention_heads
         self.kv_projection_size = self.config.kv_channels * self.config.num_query_groups
 
-        assert pg_collection is not None, (
-            "Attention requires an explicit pg_collection with tp/cp; "
-            "see docs/developer/parallel-state-deprecation.md"
-        )
-        assert hasattr(pg_collection, 'tp'), "Attention pg_collection must have tp process group"
-        assert hasattr(pg_collection, 'cp'), "Attention pg_collection must have cp process group"
+        if pg_collection is None:
+            # 'dp' is only consumed by run_realtime_tests (config.test_mode), but the legacy
+            # fallback must supply it so that path keeps working without an explicit collection.
+            pg_collection = ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=['tp', 'cp', 'dp']
+            )
+        else:
+            assert hasattr(
+                pg_collection, 'tp'
+            ), "Attention pg_collection must have tp process group"
+            assert hasattr(
+                pg_collection, 'cp'
+            ), "Attention pg_collection must have cp process group"
         self.pg_collection = pg_collection
         self.tp_group = pg_collection.tp
 
@@ -1745,7 +1752,7 @@ class SelfAttention(Attention):
         # check that all tensor parallel and data parallel ranks have the same
         # Q & K layernorm parameters.
         # Only this consistency check needs the DP group, so it is required here rather than in
-        # __init__, which requires tp/cp only.
+        # __init__, which asks use_mpu_process_groups for tp/cp only.
         assert hasattr(
             self.pg_collection, 'dp'
         ), "run_realtime_tests requires a dp process group; pass one via pg_collection.dp"

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -1745,7 +1745,7 @@ class SelfAttention(Attention):
         # check that all tensor parallel and data parallel ranks have the same
         # Q & K layernorm parameters.
         # Only this consistency check needs the DP group, so it is required here rather than in
-        # __init__, which asks use_mpu_process_groups for tp/cp only.
+        # __init__, which requires tp/cp only.
         assert hasattr(
             self.pg_collection, 'dp'
         ), "run_realtime_tests requires a dp process group; pass one via pg_collection.dp"

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -24,9 +24,6 @@ from megatron.core.parallel_state import (
     get_data_parallel_group,
     get_data_parallel_rank,
     get_data_parallel_world_size,
-    get_tensor_model_parallel_group,
-    get_tensor_model_parallel_rank,
-    get_tensor_model_parallel_world_size,
 )
 from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
     FineGrainedActivationOffloadingInterface as off_interface,
@@ -1790,10 +1787,10 @@ class SelfAttention(Attention):
                 "DP",
             )
 
-        rank = get_tensor_model_parallel_rank()
-        tp_list = [torch.empty_like(inputs) for _ in range(get_tensor_model_parallel_world_size())]
+        rank = self.tp_group.rank()
+        tp_list = [torch.empty_like(inputs) for _ in range(self.tp_group.size())]
         tp_list[rank] = inputs
-        torch.distributed.all_gather(tp_list, inputs, group=get_tensor_model_parallel_group())
+        torch.distributed.all_gather(tp_list, inputs, group=self.tp_group)
 
         for i, tp in enumerate(tp_list):
             q_w, q_b, k_w, k_b = torch.unbind(tp)
@@ -1930,9 +1927,7 @@ class SelfAttention(Attention):
             # Gate [sq, b, ng, np/ng * hn] -> [sq, b, np, hn]
             gate = gate.reshape(*gate.shape[:2], -1, self.hidden_size_per_attention_head)
             if self.config.num_query_groups < self.world_size:
-                idx = get_tensor_model_parallel_rank() % (
-                    self.world_size // self.config.num_query_groups
-                )
+                idx = self.tp_group.rank() % (self.world_size // self.config.num_query_groups)
                 size = self.num_attention_heads_per_partition // (
                     self.world_size // self.config.num_query_groups
                 )

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -1804,7 +1804,7 @@ class SelfAttention(Attention):
         # check that all tensor parallel and data parallel ranks have the same
         # Q & K layernorm parameters.
         # Only this consistency check needs the DP group, so it is required here rather than in
-        # __init__, which asks use_mpu_process_groups for tp/cp only.
+        # __init__, which requires tp/cp only.
         assert hasattr(
             self.pg_collection, 'dp'
         ), "run_realtime_tests requires a dp process group; pass one via pg_collection.dp"

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -326,19 +326,12 @@ class Attention(MegatronModule, ABC):
         self.query_projection_size = self.config.kv_channels * self.config.num_attention_heads
         self.kv_projection_size = self.config.kv_channels * self.config.num_query_groups
 
-        if pg_collection is None:
-            # 'dp' is only consumed by run_realtime_tests (config.test_mode), but the legacy
-            # fallback must supply it so that path keeps working without an explicit collection.
-            pg_collection = ProcessGroupCollection.use_mpu_process_groups(
-                required_pgs=['tp', 'cp', 'dp']
-            )
-        else:
-            assert hasattr(
-                pg_collection, 'tp'
-            ), "Attention pg_collection must have tp process group"
-            assert hasattr(
-                pg_collection, 'cp'
-            ), "Attention pg_collection must have cp process group"
+        assert pg_collection is not None, (
+            "Attention requires an explicit pg_collection with tp/cp; "
+            "see docs/developer/parallel-state-deprecation.md"
+        )
+        assert hasattr(pg_collection, 'tp'), "Attention pg_collection must have tp process group"
+        assert hasattr(pg_collection, 'cp'), "Attention pg_collection must have cp process group"
         self.pg_collection = pg_collection
         # Build-time CP group, kept so runtime (hybrid/dynamic) CP can restore
         # it on microbatches that carry no per-microbatch CP group.
@@ -1811,7 +1804,7 @@ class SelfAttention(Attention):
         # check that all tensor parallel and data parallel ranks have the same
         # Q & K layernorm parameters.
         # Only this consistency check needs the DP group, so it is required here rather than in
-        # __init__, which asks use_mpu_process_groups for tp/cp only.
+        # __init__, which requires tp/cp only.
         assert hasattr(
             self.pg_collection, 'dp'
         ), "run_realtime_tests requires a dp process group; pass one via pg_collection.dp"

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -24,9 +24,6 @@ from megatron.core.parallel_state import (
     get_data_parallel_group,
     get_data_parallel_rank,
     get_data_parallel_world_size,
-    get_tensor_model_parallel_group,
-    get_tensor_model_parallel_rank,
-    get_tensor_model_parallel_world_size,
 )
 from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
     FineGrainedActivationOffloadingInterface as off_interface,
@@ -1849,10 +1846,10 @@ class SelfAttention(Attention):
                 "DP",
             )
 
-        rank = get_tensor_model_parallel_rank()
-        tp_list = [torch.empty_like(inputs) for _ in range(get_tensor_model_parallel_world_size())]
+        rank = self.tp_group.rank()
+        tp_list = [torch.empty_like(inputs) for _ in range(self.tp_group.size())]
         tp_list[rank] = inputs
-        torch.distributed.all_gather(tp_list, inputs, group=get_tensor_model_parallel_group())
+        torch.distributed.all_gather(tp_list, inputs, group=self.tp_group)
 
         for i, tp in enumerate(tp_list):
             q_w, q_b, k_w, k_b = torch.unbind(tp)
@@ -1989,9 +1986,7 @@ class SelfAttention(Attention):
             # Gate [sq, b, ng, np/ng * hn] -> [sq, b, np, hn]
             gate = gate.reshape(*gate.shape[:2], -1, self.hidden_size_per_attention_head)
             if self.config.num_query_groups < self.world_size:
-                idx = get_tensor_model_parallel_rank() % (
-                    self.world_size // self.config.num_query_groups
-                )
+                idx = self.tp_group.rank() % (self.world_size // self.config.num_query_groups)
                 size = self.num_attention_heads_per_partition // (
                     self.world_size // self.config.num_query_groups
                 )

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -326,19 +326,12 @@ class Attention(MegatronModule, ABC):
         self.query_projection_size = self.config.kv_channels * self.config.num_attention_heads
         self.kv_projection_size = self.config.kv_channels * self.config.num_query_groups
 
-        if pg_collection is None:
-            # 'dp' is only consumed by run_realtime_tests (config.test_mode), but the legacy
-            # fallback must supply it so that path keeps working without an explicit collection.
-            pg_collection = ProcessGroupCollection.use_mpu_process_groups(
-                required_pgs=['tp', 'cp', 'dp']
-            )
-        else:
-            assert hasattr(
-                pg_collection, 'tp'
-            ), "Attention pg_collection must have tp process group"
-            assert hasattr(
-                pg_collection, 'cp'
-            ), "Attention pg_collection must have cp process group"
+        assert pg_collection is not None, (
+            "Attention requires an explicit pg_collection with tp/cp; "
+            "see docs/developer/parallel-state-deprecation.md"
+        )
+        assert hasattr(pg_collection, 'tp'), "Attention pg_collection must have tp process group"
+        assert hasattr(pg_collection, 'cp'), "Attention pg_collection must have cp process group"
         self.pg_collection = pg_collection
         # Build-time CP group, kept so runtime (hybrid/dynamic) CP can restore
         # it on microbatches that carry no per-microbatch CP group.

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -326,12 +326,19 @@ class Attention(MegatronModule, ABC):
         self.query_projection_size = self.config.kv_channels * self.config.num_attention_heads
         self.kv_projection_size = self.config.kv_channels * self.config.num_query_groups
 
-        assert pg_collection is not None, (
-            "Attention requires an explicit pg_collection with tp/cp; "
-            "see docs/developer/parallel-state-deprecation.md"
-        )
-        assert hasattr(pg_collection, 'tp'), "Attention pg_collection must have tp process group"
-        assert hasattr(pg_collection, 'cp'), "Attention pg_collection must have cp process group"
+        if pg_collection is None:
+            # 'dp' is only consumed by run_realtime_tests (config.test_mode), but the legacy
+            # fallback must supply it so that path keeps working without an explicit collection.
+            pg_collection = ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=['tp', 'cp', 'dp']
+            )
+        else:
+            assert hasattr(
+                pg_collection, 'tp'
+            ), "Attention pg_collection must have tp process group"
+            assert hasattr(
+                pg_collection, 'cp'
+            ), "Attention pg_collection must have cp process group"
         self.pg_collection = pg_collection
         # Build-time CP group, kept so runtime (hybrid/dynamic) CP can restore
         # it on microbatches that carry no per-microbatch CP group.
@@ -1804,7 +1811,7 @@ class SelfAttention(Attention):
         # check that all tensor parallel and data parallel ranks have the same
         # Q & K layernorm parameters.
         # Only this consistency check needs the DP group, so it is required here rather than in
-        # __init__, which requires tp/cp only.
+        # __init__, which asks use_mpu_process_groups for tp/cp only.
         assert hasattr(
             self.pg_collection, 'dp'
         ), "run_realtime_tests requires a dp process group; pass one via pg_collection.dp"

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -20,11 +20,6 @@ from megatron.core.models.common.embeddings.rope_utils import (
     apply_rotary_pos_emb_with_cos_sin,
 )
 from megatron.core.packed_seq_params import PackedSeqParams
-from megatron.core.parallel_state import (
-    get_data_parallel_group,
-    get_data_parallel_rank,
-    get_data_parallel_world_size,
-)
 from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
     FineGrainedActivationOffloadingInterface as off_interface,
 )
@@ -332,7 +327,11 @@ class Attention(MegatronModule, ABC):
         self.kv_projection_size = self.config.kv_channels * self.config.num_query_groups
 
         if pg_collection is None:
-            pg_collection = ProcessGroupCollection.use_mpu_process_groups(required_pgs=['tp', 'cp'])
+            # 'dp' is only consumed by run_realtime_tests (config.test_mode), but the legacy
+            # fallback must supply it so that path keeps working without an explicit collection.
+            pg_collection = ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=['tp', 'cp', 'dp']
+            )
         else:
             assert hasattr(
                 pg_collection, 'tp'
@@ -1811,7 +1810,13 @@ class SelfAttention(Attention):
 
         # check that all tensor parallel and data parallel ranks have the same
         # Q & K layernorm parameters.
-        rank = get_data_parallel_rank()
+        # Only this consistency check needs the DP group, so it is required here rather than in
+        # __init__, which asks use_mpu_process_groups for tp/cp only.
+        assert hasattr(
+            self.pg_collection, 'dp'
+        ), "run_realtime_tests requires a dp process group; pass one via pg_collection.dp"
+        dp_group = self.pg_collection.dp
+        rank = dp_group.rank()
         inputs = torch.stack(
             [
                 self.q_layernorm.weight.data,
@@ -1820,9 +1825,9 @@ class SelfAttention(Attention):
                 self.k_layernorm.bias.data,
             ]
         )
-        dp_list = [torch.empty_like(inputs) for _ in range(get_data_parallel_world_size())]
+        dp_list = [torch.empty_like(inputs) for _ in range(dp_group.size())]
         dp_list[rank] = inputs
-        torch.distributed.all_gather(dp_list, inputs, group=get_data_parallel_group())
+        torch.distributed.all_gather(dp_list, inputs, group=dp_group)
 
         def _compare(srcs, tgts, names, parallelism):
             assert len(srcs) == len(tgts) == len(names)

--- a/megatron/core/transformer/dot_product_attention.py
+++ b/megatron/core/transformer/dot_product_attention.py
@@ -65,12 +65,13 @@ class DotProductAttention(MegatronModule):
         projection_size = self.config.kv_channels * self.config.num_attention_heads
 
         # Per attention head and per partition values.
-        if pg_collection is None:
-            pg_collection = ProcessGroupCollection.use_mpu_process_groups(required_pgs=['tp'])
-        else:
-            assert hasattr(
-                pg_collection, 'tp'
-            ), "DotProductAttention pg_collection must have tp process group"
+        assert pg_collection is not None, (
+            "DotProductAttention requires an explicit pg_collection; "
+            "see docs/developer/parallel-state-deprecation.md"
+        )
+        assert hasattr(
+            pg_collection, 'tp'
+        ), "DotProductAttention pg_collection must have tp process group"
         self.pg_collection = pg_collection
         self.tp_group = self.pg_collection.tp
 

--- a/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
+++ b/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
@@ -148,8 +148,10 @@ class AbsorbedMLASelfAttention(Attention):
         pp_layer_offset: Optional[int] = None,
         name: str | None = None,
     ):
-        if pg_collection is None:
-            pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+        assert pg_collection is not None, (
+            "AbsorbedMLASelfAttention requires an explicit pg_collection; "
+            "see docs/developer/parallel-state-deprecation.md"
+        )
 
         super().__init__(
             config=config,

--- a/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
+++ b/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
@@ -148,10 +148,8 @@ class AbsorbedMLASelfAttention(Attention):
         pp_layer_offset: Optional[int] = None,
         name: str | None = None,
     ):
-        assert pg_collection is not None, (
-            "AbsorbedMLASelfAttention requires an explicit pg_collection; "
-            "see docs/developer/parallel-state-deprecation.md"
-        )
+        if pg_collection is None:
+            pg_collection = ProcessGroupCollection.use_mpu_process_groups()
 
         super().__init__(
             config=config,

--- a/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
+++ b/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
@@ -149,8 +149,10 @@ class AbsorbedMLASelfAttention(Attention):
         name: str | None = None,
         is_mtp_layer: bool = False,
     ):
-        if pg_collection is None:
-            pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+        assert pg_collection is not None, (
+            "AbsorbedMLASelfAttention requires an explicit pg_collection; "
+            "see docs/developer/parallel-state-deprecation.md"
+        )
 
         super().__init__(
             config=config,

--- a/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
+++ b/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
@@ -149,10 +149,8 @@ class AbsorbedMLASelfAttention(Attention):
         name: str | None = None,
         is_mtp_layer: bool = False,
     ):
-        assert pg_collection is not None, (
-            "AbsorbedMLASelfAttention requires an explicit pg_collection; "
-            "see docs/developer/parallel-state-deprecation.md"
-        )
+        if pg_collection is None:
+            pg_collection = ProcessGroupCollection.use_mpu_process_groups()
 
         super().__init__(
             config=config,

--- a/megatron/core/transformer/experimental_attention_variant/dsa.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa.py
@@ -1130,8 +1130,10 @@ class DSAIndexer(MegatronModule):
 
         self.softmax_scale: float = self.index_head_dim**-0.5
 
-        if pg_collection is None:
-            pg_collection = ProcessGroupCollection.use_mpu_process_groups(required_pgs=["tp", "cp"])
+        assert pg_collection is not None, (
+            "DSAIndexer requires an explicit pg_collection with tp/cp; "
+            "see docs/developer/parallel-state-deprecation.md"
+        )
         self.pg_collection = pg_collection
 
         # Initialize Position Embedding.

--- a/megatron/core/transformer/experimental_attention_variant/dsa.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa.py
@@ -1130,10 +1130,8 @@ class DSAIndexer(MegatronModule):
 
         self.softmax_scale: float = self.index_head_dim**-0.5
 
-        assert pg_collection is not None, (
-            "DSAIndexer requires an explicit pg_collection with tp/cp; "
-            "see docs/developer/parallel-state-deprecation.md"
-        )
+        if pg_collection is None:
+            pg_collection = ProcessGroupCollection.use_mpu_process_groups(required_pgs=['tp', 'cp'])
         self.pg_collection = pg_collection
 
         # Initialize Position Embedding.

--- a/megatron/core/transformer/experimental_attention_variant/dsa.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa.py
@@ -1130,8 +1130,10 @@ class DSAIndexer(MegatronModule):
 
         self.softmax_scale: float = self.index_head_dim**-0.5
 
-        if pg_collection is None:
-            pg_collection = ProcessGroupCollection.use_mpu_process_groups(required_pgs=['tp', 'cp'])
+        assert pg_collection is not None, (
+            "DSAIndexer requires an explicit pg_collection with tp/cp; "
+            "see docs/developer/parallel-state-deprecation.md"
+        )
         self.pg_collection = pg_collection
 
         # Initialize Position Embedding.

--- a/megatron/core/transformer/experimental_attention_variant/dsa.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa.py
@@ -312,16 +312,19 @@ class DSAIndexerLossLoggingHelper:
         tracker["avg_group"] = None
 
     @staticmethod
-    def reduce_loss_in_tracker():
-        """Collect and reduce the indexer losses across ranks."""
+    def reduce_loss_in_tracker(pp_group, dp_group):
+        """Collect and reduce the indexer losses across ranks.
+
+        Args:
+            pp_group: Pipeline-parallel group to sum indexer losses over.
+            dp_group: Data-parallel group (without context parallel) to average over.
+        """
         tracker = DSAIndexerLossLoggingHelper.tracker
         if "values" not in tracker:
             return
         values = tracker["values"]
 
-        torch.distributed.all_reduce(
-            values, group=parallel_state.get_pipeline_model_parallel_group()
-        )
+        torch.distributed.all_reduce(values, group=pp_group)
         # Reduce indexer losses across ranks.
         if tracker.get('reduce_group') is not None:
             torch.distributed.all_reduce(values, group=tracker.get('reduce_group'))
@@ -329,11 +332,7 @@ class DSAIndexerLossLoggingHelper:
             torch.distributed.all_reduce(
                 values, group=tracker['avg_group'], op=torch.distributed.ReduceOp.AVG
             )
-        torch.distributed.all_reduce(
-            values,
-            group=parallel_state.get_data_parallel_group(with_context_parallel=False),
-            op=torch.distributed.ReduceOp.AVG,
-        )
+        torch.distributed.all_reduce(values, group=dp_group, op=torch.distributed.ReduceOp.AVG)
 
     @staticmethod
     def track_indexer_metrics(
@@ -343,6 +342,9 @@ class DSAIndexerLossLoggingHelper:
         wandb_writer=None,
         total_loss_dict=None,
         per_layer_logging: bool = False,
+        *,
+        pp_group,
+        dp_group,
     ):
         """Track the sparse attention indexer metrics for logging.
 
@@ -353,8 +355,10 @@ class DSAIndexerLossLoggingHelper:
             wandb_writer: Weights & Biases writer.
             total_loss_dict: Dictionary to accumulate total losses.
             per_layer_logging: Whether to log per-layer losses.
+            pp_group: Pipeline-parallel group used to reduce indexer losses.
+            dp_group: Data-parallel group used to average indexer losses.
         """
-        DSAIndexerLossLoggingHelper.reduce_loss_in_tracker()
+        DSAIndexerLossLoggingHelper.reduce_loss_in_tracker(pp_group, dp_group)
         tracker = DSAIndexerLossLoggingHelper.tracker
         if "values" not in tracker:
             return

--- a/megatron/core/transformer/experimental_attention_variant/dsa.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa.py
@@ -1273,8 +1273,10 @@ class DSAIndexer(MegatronModule):
 
         self.softmax_scale: float = self.index_head_dim**-0.5
 
-        if pg_collection is None:
-            pg_collection = ProcessGroupCollection.use_mpu_process_groups(required_pgs=['tp', 'cp'])
+        assert pg_collection is not None, (
+            "DSAIndexer requires an explicit pg_collection with tp/cp; "
+            "see docs/developer/parallel-state-deprecation.md"
+        )
         self.pg_collection = pg_collection
 
         # Initialize Position Embedding.

--- a/megatron/core/transformer/experimental_attention_variant/dsa.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa.py
@@ -1273,8 +1273,10 @@ class DSAIndexer(MegatronModule):
 
         self.softmax_scale: float = self.index_head_dim**-0.5
 
-        if pg_collection is None:
-            pg_collection = ProcessGroupCollection.use_mpu_process_groups(required_pgs=["tp", "cp"])
+        assert pg_collection is not None, (
+            "DSAIndexer requires an explicit pg_collection with tp/cp; "
+            "see docs/developer/parallel-state-deprecation.md"
+        )
         self.pg_collection = pg_collection
 
         # Initialize Position Embedding.

--- a/megatron/core/transformer/experimental_attention_variant/dsa.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa.py
@@ -1273,10 +1273,8 @@ class DSAIndexer(MegatronModule):
 
         self.softmax_scale: float = self.index_head_dim**-0.5
 
-        assert pg_collection is not None, (
-            "DSAIndexer requires an explicit pg_collection with tp/cp; "
-            "see docs/developer/parallel-state-deprecation.md"
-        )
+        if pg_collection is None:
+            pg_collection = ProcessGroupCollection.use_mpu_process_groups(required_pgs=['tp', 'cp'])
         self.pg_collection = pg_collection
 
         # Initialize Position Embedding.

--- a/megatron/core/transformer/heterogeneous/linear_replacements.py
+++ b/megatron/core/transformer/heterogeneous/linear_replacements.py
@@ -1,20 +1,17 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 
+import torch
 import torch.nn.functional as F
 from torch import Tensor
 
 from megatron.core.extensions.transformer_engine import HAVE_TE
-from megatron.core.parallel_state import (
-    get_tensor_model_parallel_rank,
-    get_tensor_model_parallel_world_size,
-)
 from megatron.core.tensor_parallel.layers import ColumnParallelLinear
 from megatron.core.tensor_parallel.mappings import (
     gather_from_tensor_model_parallel_region,
     reduce_scatter_to_sequence_parallel_region,
 )
 from megatron.core.transformer.transformer_config import TransformerConfig
-from megatron.core.utils import divide
+from megatron.core.utils import divide, get_pg_rank, get_pg_size
 
 if HAVE_TE:
     from megatron.core.extensions.transformer_engine import TELayerNormColumnParallelLinear
@@ -22,24 +19,27 @@ else:
     TELayerNormColumnParallelLinear = None
 
 
-def _gather_from_tensor_parallel_region(x: Tensor, config: TransformerConfig) -> Tensor:
-    if get_tensor_model_parallel_world_size() > 1:
+def _gather_from_tensor_parallel_region(
+    x: Tensor, config: TransformerConfig, tp_group: torch.distributed.ProcessGroup
+) -> Tensor:
+    tp_size = get_pg_size(tp_group)
+    if tp_size > 1:
         if config.sequence_parallel:
             # pad hidden dimension (last dimension) with zeros such that the valid data is placed in
             # indices [tp_rank * hidden/tp_size, (tp_rank+1) * hidden/tp_size),
             # and zeros fill the other parts.
             output_size = config.hidden_size
-            output_size_per_partition = divide(output_size, get_tensor_model_parallel_world_size())
+            output_size_per_partition = divide(output_size, tp_size)
 
-            pad_before = get_tensor_model_parallel_rank() * output_size_per_partition
+            pad_before = get_pg_rank(tp_group) * output_size_per_partition
             pad_after = output_size - pad_before - output_size_per_partition
 
             pad_shape = [0] * (x.ndim - 1) * 2 + [pad_before, pad_after]
             x = F.pad(x, pad_shape, "constant", 0)
 
-            x = reduce_scatter_to_sequence_parallel_region(x)
+            x = reduce_scatter_to_sequence_parallel_region(x, group=tp_group)
         else:
-            x = gather_from_tensor_model_parallel_region(x)
+            x = gather_from_tensor_model_parallel_region(x, group=tp_group)
 
     return x
 
@@ -70,7 +70,7 @@ if HAVE_TE:
             out, bias = super().forward(x)
             assert bias is None, "bias should be None since we set skip_bias_add=False"
 
-            out = _gather_from_tensor_parallel_region(out, self.config)
+            out = _gather_from_tensor_parallel_region(out, self.config, self._tp_group)
 
             return out, bias
 
@@ -107,6 +107,6 @@ class ColumnParallelLinearGathered(ColumnParallelLinear):
         if runtime_gather_output or self.gather_output:
             raise ValueError("gathering TP outputs is not supported for linear replacement")
 
-        out = _gather_from_tensor_parallel_region(out, self.config)
+        out = _gather_from_tensor_parallel_region(out, self.config, self.tp_group)
 
         return out, bias

--- a/megatron/core/transformer/multi_latent_attention.py
+++ b/megatron/core/transformer/multi_latent_attention.py
@@ -486,8 +486,10 @@ class MLASelfAttention(MultiLatentAttention):
         pp_layer_offset: Optional[int] = None,
         name: str | None = None,
     ):
-        if pg_collection is None:
-            pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+        assert pg_collection is not None, (
+            "MultiLatentAttention requires an explicit pg_collection; "
+            "see docs/developer/parallel-state-deprecation.md"
+        )
 
         super().__init__(
             config=config,
@@ -1242,8 +1244,10 @@ class FusedMLASelfAttention(MLASelfAttention):
         pp_layer_offset: Optional[int] = None,
         name: str | None = None,
     ):
-        if pg_collection is None:
-            pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+        assert pg_collection is not None, (
+            "MultiLatentAttention requires an explicit pg_collection; "
+            "see docs/developer/parallel-state-deprecation.md"
+        )
 
         MultiLatentAttention.__init__(
             self,

--- a/megatron/core/transformer/multi_latent_attention.py
+++ b/megatron/core/transformer/multi_latent_attention.py
@@ -486,10 +486,8 @@ class MLASelfAttention(MultiLatentAttention):
         pp_layer_offset: Optional[int] = None,
         name: str | None = None,
     ):
-        assert pg_collection is not None, (
-            "MultiLatentAttention requires an explicit pg_collection; "
-            "see docs/developer/parallel-state-deprecation.md"
-        )
+        if pg_collection is None:
+            pg_collection = ProcessGroupCollection.use_mpu_process_groups()
 
         super().__init__(
             config=config,
@@ -1244,10 +1242,8 @@ class FusedMLASelfAttention(MLASelfAttention):
         pp_layer_offset: Optional[int] = None,
         name: str | None = None,
     ):
-        assert pg_collection is not None, (
-            "MultiLatentAttention requires an explicit pg_collection; "
-            "see docs/developer/parallel-state-deprecation.md"
-        )
+        if pg_collection is None:
+            pg_collection = ProcessGroupCollection.use_mpu_process_groups()
 
         MultiLatentAttention.__init__(
             self,

--- a/megatron/core/transformer/multi_latent_attention.py
+++ b/megatron/core/transformer/multi_latent_attention.py
@@ -566,8 +566,10 @@ class MLASelfAttention(MultiLatentAttention):
         is_mtp_layer: bool = False,
         name: str | None = None,
     ):
-        if pg_collection is None:
-            pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+        assert pg_collection is not None, (
+            "MultiLatentAttention requires an explicit pg_collection; "
+            "see docs/developer/parallel-state-deprecation.md"
+        )
 
         super().__init__(
             config=config,
@@ -1380,8 +1382,10 @@ class FusedMLASelfAttention(MLASelfAttention):
         pp_layer_offset: Optional[int] = None,
         name: str | None = None,
     ):
-        if pg_collection is None:
-            pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+        assert pg_collection is not None, (
+            "MultiLatentAttention requires an explicit pg_collection; "
+            "see docs/developer/parallel-state-deprecation.md"
+        )
 
         MultiLatentAttention.__init__(
             self,

--- a/megatron/core/transformer/multi_latent_attention.py
+++ b/megatron/core/transformer/multi_latent_attention.py
@@ -566,10 +566,8 @@ class MLASelfAttention(MultiLatentAttention):
         is_mtp_layer: bool = False,
         name: str | None = None,
     ):
-        assert pg_collection is not None, (
-            "MultiLatentAttention requires an explicit pg_collection; "
-            "see docs/developer/parallel-state-deprecation.md"
-        )
+        if pg_collection is None:
+            pg_collection = ProcessGroupCollection.use_mpu_process_groups()
 
         super().__init__(
             config=config,
@@ -1382,10 +1380,8 @@ class FusedMLASelfAttention(MLASelfAttention):
         pp_layer_offset: Optional[int] = None,
         name: str | None = None,
     ):
-        assert pg_collection is not None, (
-            "MultiLatentAttention requires an explicit pg_collection; "
-            "see docs/developer/parallel-state-deprecation.md"
-        )
+        if pg_collection is None:
+            pg_collection = ProcessGroupCollection.use_mpu_process_groups()
 
         MultiLatentAttention.__init__(
             self,

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -618,6 +618,8 @@ def mtp_on_this_rank(
     mtp_num_layers: Optional[int] = None,
     ignore_virtual: Optional[bool] = True,
     vp_stage: Optional[int] = None,
+    *,
+    pp_group: torch.distributed.ProcessGroup,
 ) -> bool:
     """
     Check if there is MTP on the current rank.
@@ -632,7 +634,7 @@ def mtp_on_this_rank(
           pipeline stage. The function returns True only on the last pipeline stage.
     """
     mtp_on_this_rank = False
-    pp_rank = parallel_state.get_pipeline_model_parallel_rank()
+    pp_rank = get_pg_rank(pp_group)
     if layout is not None:
         # with custom PP layout, we support put MTP layers on any pipeline stage
         if (

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -1672,14 +1672,14 @@ class MultiTokenPredictionBlock(MegatronModule):
         # Initialize Context Parallelism (CP) support for MTP
         # This enables MTP to work with CP > 1 by providing the CP process group
         # to the roll_tensor function for proper boundary communication
-        if pg_collection is None:
-            # Use default MPU process groups if not provided
-            pg_collection = ProcessGroupCollection.use_mpu_process_groups(required_pgs=['cp', 'tp'])
-        else:
-            # Ensure the provided process groups include CP
-            assert hasattr(
-                pg_collection, 'cp'
-            ), "MultiTokenPredictionBlock pg_collection must have cp process group"
+        assert pg_collection is not None, (
+            "MultiTokenPredictionBlock requires an explicit pg_collection with cp/tp; "
+            "see docs/developer/parallel-state-deprecation.md"
+        )
+        # Ensure the provided process groups include CP
+        assert hasattr(
+            pg_collection, 'cp'
+        ), "MultiTokenPredictionBlock pg_collection must have cp process group"
 
         self._build_layers(pg_collection)
         assert len(self.layers) > 0, "MultiTokenPredictionBlock must have at least one layer."

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -1371,7 +1371,7 @@ class MultiTokenPredictionLayer(MegatronModule):
                     custom_forward,
                     self.config.distribute_saved_activations,
                     tensor_parallel.random.get_cuda_rng_tracker,
-                    parallel_state.get_tensor_model_parallel_group(),
+                    self.tp_group,
                     hidden_states,
                     decoder_input,
                     attention_mask,

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -1825,7 +1825,7 @@ class MultiTokenPredictionLayer(MegatronModule):
                     custom_forward,
                     self.config.distribute_saved_activations,
                     tensor_parallel.random.get_cuda_rng_tracker,
-                    parallel_state.get_tensor_model_parallel_group(),
+                    self.tp_group,
                     hidden_states,
                     decoder_input,
                     attention_mask,

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -2151,20 +2151,19 @@ class MultiTokenPredictionBlock(MegatronModule):
         # Initialize Context Parallelism (CP) support for MTP
         # This enables MTP to work with CP > 1 by providing the CP process group
         # to the roll_tensor function for proper boundary communication
-        if pg_collection is None:
-            # Use default MPU process groups if not provided
-            required_pgs = ['cp', 'tp', 'pp'] + (['dp'] if self.config.mtp_hsm else [])
-            pg_collection = ProcessGroupCollection.use_mpu_process_groups(required_pgs=required_pgs)
-        else:
-            # Ensure the provided process groups include TP, CP, and PP.
-            for group_name in ('tp', 'cp', 'pp'):
-                assert (
-                    getattr(pg_collection, group_name, None) is not None
-                ), f"MultiTokenPredictionBlock pg_collection must have {group_name} process group"
-            if self.config.mtp_hsm:
-                assert hasattr(
-                    pg_collection, 'dp'
-                ), "MultiTokenPredictionBlock with HSM requires a dp process group"
+        assert pg_collection is not None, (
+            "MultiTokenPredictionBlock requires an explicit pg_collection with tp/cp/pp; "
+            "see docs/developer/parallel-state-deprecation.md"
+        )
+        # Ensure the provided process groups include TP, CP, and PP.
+        for group_name in ('tp', 'cp', 'pp'):
+            assert (
+                getattr(pg_collection, group_name, None) is not None
+            ), f"MultiTokenPredictionBlock pg_collection must have {group_name} process group"
+        if self.config.mtp_hsm:
+            assert hasattr(
+                pg_collection, 'dp'
+            ), "MultiTokenPredictionBlock with HSM requires a dp process group"
 
         self._build_layers(pg_collection)
         assert len(self.layers) > 0, "MultiTokenPredictionBlock must have at least one layer."

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -802,7 +802,8 @@ def mtp_on_this_rank(
     mtp_num_layers: Optional[int] = None,
     ignore_virtual: Optional[bool] = True,
     vp_stage: Optional[int] = None,
-    pp_group: Optional[torch.distributed.ProcessGroup] = None,
+    *,
+    pp_group: torch.distributed.ProcessGroup,
     vp_size: Optional[int] = None,
 ) -> bool:
     """
@@ -818,13 +819,8 @@ def mtp_on_this_rank(
           pipeline stage. The function returns True only on the last pipeline stage.
     """
     mtp_on_this_rank = False
-    if pp_group is not None:
-        pp_rank = get_pg_rank(pp_group)
-        pp_size = get_pg_size(pp_group)
-    else:
-        # Compatibility fallback for callers that have not migrated to an explicit PP group.
-        pp_rank = parallel_state.get_pipeline_model_parallel_rank()
-        pp_size = None
+    pp_rank = get_pg_rank(pp_group)
+    pp_size = get_pg_size(pp_group)
     if vp_size is None and layout is not None:
         vp_size = layout.virtual_pipeline_model_parallel_size
     elif vp_size is None and not ignore_virtual:
@@ -845,9 +841,6 @@ def mtp_on_this_rank(
     else:
         # without custom PP layout, we only support put all of MTP layers on the last pipeline stage
         if mtp_num_layers is not None:
-            if pp_size is None:
-                # Compatibility fallback for callers without explicit pipeline metadata.
-                pp_size = parallel_state.get_pipeline_model_parallel_world_size()
             mtp_on_this_rank = pp_rank == pp_size - 1
             if mtp_on_this_rank and not ignore_virtual and vp_size not in (None, 1):
                 assert (

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -2847,6 +2847,8 @@ def training_log(
             writer=writer,
             wandb_writer=wandb_writer,
             total_loss_dict=total_loss_dict,
+            pp_group=mpu.get_pipeline_model_parallel_group(),
+            dp_group=mpu.get_data_parallel_group(with_context_parallel=False),
         )
 
     # Dump memory snapshot and print metrics to stdout.

--- a/pretrain_vlm.py
+++ b/pretrain_vlm.py
@@ -27,6 +27,7 @@ from megatron.core.models.vision.vit_layer_specs import (
     get_vit_layer_with_local_spec,
     get_vit_layer_with_transformer_engine_spec,
 )
+from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.transformer.enums import AttnMaskType
 from megatron.core.transformer.spec_utils import get_submodules, import_module
 from megatron.training import (
@@ -69,6 +70,11 @@ def model_provider(
     """
     args = get_args()
     vision_model_type = "clip"
+
+    if pg_collection is None:
+        # LLaVAModel requires an explicit process-group collection; this script trains on the
+        # global parallel grid, so resolve that fallback here rather than inside megatron/core.
+        pg_collection = ProcessGroupCollection.use_mpu_process_groups()
 
     assert (
         args.ckpt_format == 'torch'
@@ -228,6 +234,7 @@ def model_provider(
         img_h=args.img_h,
         img_w=args.img_w,
         patch_dim=args.patch_dim,
+        pg_collection=pg_collection,
     )
 
     model.freeze(

--- a/tests/unit_tests/dist_checkpointing/models/test_t5_model.py
+++ b/tests/unit_tests/dist_checkpointing/models/test_t5_model.py
@@ -15,6 +15,7 @@ from megatron.core.models.T5.t5_spec import encoder_model_with_local_spec as t5_
 from megatron.core.models.T5.t5_spec import (
     encoder_model_with_transformer_engine_default_spec as t5_encoder_te_spec,
 )
+from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.transformer_block import TransformerBlockSubmodules
 from megatron.core.transformer.transformer_config import TransformerConfig
@@ -64,6 +65,9 @@ def initialize_t5_model(seed, encoder_decoder_spec_fn, num_layers=8, **config_kw
         post_process=post_process,
         add_encoder=add_encoder,
         add_decoder=add_decoder,
+        pg_collection=ProcessGroupCollection.use_mpu_process_groups(
+            required_pgs=['tp', 'cp', 'pp']
+        ),
     )
 
     with torch.no_grad():

--- a/tests/unit_tests/fusions/test_mla_yarn_rope_apply.py
+++ b/tests/unit_tests/fusions/test_mla_yarn_rope_apply.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import torch
 
+from megatron.core import parallel_state
 from megatron.core.models.common.embeddings import apply_rotary_pos_emb
 from megatron.core.models.common.embeddings import rope_utils as rope_utils_module
 from megatron.core.models.common.embeddings.yarn_rotary_pos_embedding import YarnRotaryEmbedding
@@ -206,7 +207,11 @@ def _test_fused_mla_rope_inplace(input_format, inverse=False, remove_interleavin
         cu_seqlens = None
         seqlen = 1024
         batch_size = 2
-        yarn_rope = YarnRotaryEmbedding(emb_dim, original_max_position_embeddings=seqlen)
+        yarn_rope = YarnRotaryEmbedding(
+            emb_dim,
+            original_max_position_embeddings=seqlen,
+            cp_group=parallel_state.get_context_parallel_group(check_initialized=False),
+        )
         freqs, mscale = yarn_rope(seqlen, 0)
         cos = (torch.cos(freqs) * mscale).to(dtype)
         sin = (torch.sin(freqs) * mscale).to(dtype)
@@ -224,7 +229,11 @@ def _test_fused_mla_rope_inplace(input_format, inverse=False, remove_interleavin
         for i in range(len(cu_seqlens) - 1):
             max_seqlen = max(max_seqlen, cu_seqlens[i + 1] - cu_seqlens[i])
         cu_seqlens = torch.tensor(cu_seqlens, dtype=torch.int32, device='cuda')
-        yarn_rope = YarnRotaryEmbedding(emb_dim, original_max_position_embeddings=max_seqlen)
+        yarn_rope = YarnRotaryEmbedding(
+            emb_dim,
+            original_max_position_embeddings=max_seqlen,
+            cp_group=parallel_state.get_context_parallel_group(check_initialized=False),
+        )
         freqs, mscale = yarn_rope(max_seqlen, 0)
         cos = (torch.cos(freqs) * mscale).to(dtype)
         sin = (torch.sin(freqs) * mscale).to(dtype)
@@ -303,7 +312,11 @@ def _test_fused_mla_rope_kv_split(input_format, remove_interleaving=False):
         cu_seqlens = None
         seqlen = 1024
         batch_size = 2
-        yarn_rope = YarnRotaryEmbedding(emb_dim, original_max_position_embeddings=seqlen)
+        yarn_rope = YarnRotaryEmbedding(
+            emb_dim,
+            original_max_position_embeddings=seqlen,
+            cp_group=parallel_state.get_context_parallel_group(check_initialized=False),
+        )
         freqs, mscale = yarn_rope(seqlen, 0)
         cos = (torch.cos(freqs) * mscale).to(dtype)
         sin = (torch.sin(freqs) * mscale).to(dtype)
@@ -327,7 +340,11 @@ def _test_fused_mla_rope_kv_split(input_format, remove_interleaving=False):
         for i in range(len(cu_seqlens) - 1):
             max_seqlen = max(max_seqlen, cu_seqlens[i + 1] - cu_seqlens[i])
         cu_seqlens = torch.tensor(cu_seqlens, dtype=torch.int32, device='cuda')
-        yarn_rope = YarnRotaryEmbedding(emb_dim, original_max_position_embeddings=max_seqlen)
+        yarn_rope = YarnRotaryEmbedding(
+            emb_dim,
+            original_max_position_embeddings=max_seqlen,
+            cp_group=parallel_state.get_context_parallel_group(check_initialized=False),
+        )
         freqs, mscale = yarn_rope(max_seqlen, 0)
         cos = (torch.cos(freqs) * mscale).to(dtype)
         sin = (torch.sin(freqs) * mscale).to(dtype)

--- a/tests/unit_tests/fusions/test_mla_yarn_rope_apply.py
+++ b/tests/unit_tests/fusions/test_mla_yarn_rope_apply.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import torch
 
+from megatron.core import parallel_state
 from megatron.core.models.common.embeddings import apply_rotary_pos_emb
 from megatron.core.models.common.embeddings import rope_utils as rope_utils_module
 from megatron.core.models.common.embeddings.yarn_rotary_pos_embedding import YarnRotaryEmbedding
@@ -101,7 +102,11 @@ def _test_fused_apply_mla_rope_for_q(input_format):
         cu_seqlens = None
         seqlen = 1024
         batch_size = 2
-        yarn_rope = YarnRotaryEmbedding(emb_dim, original_max_position_embeddings=seqlen)
+        yarn_rope = YarnRotaryEmbedding(
+            emb_dim,
+            original_max_position_embeddings=seqlen,
+            cp_group=parallel_state.get_context_parallel_group(check_initialized=False),
+        )
         freqs, mscale = yarn_rope(seqlen, 0)
         cos = (torch.cos(freqs) * mscale).to(dtype)
         sin = (torch.sin(freqs) * mscale).to(dtype)
@@ -119,7 +124,11 @@ def _test_fused_apply_mla_rope_for_q(input_format):
         for i in range(len(cu_seqlens) - 1):
             max_seqlen = max(max_seqlen, cu_seqlens[i + 1] - cu_seqlens[i])
         cu_seqlens = torch.tensor(cu_seqlens, dtype=torch.int32, device='cuda')
-        yarn_rope = YarnRotaryEmbedding(emb_dim, original_max_position_embeddings=max_seqlen)
+        yarn_rope = YarnRotaryEmbedding(
+            emb_dim,
+            original_max_position_embeddings=max_seqlen,
+            cp_group=parallel_state.get_context_parallel_group(check_initialized=False),
+        )
         freqs, mscale = yarn_rope(max_seqlen, 0)
         cos = (torch.cos(freqs) * mscale).to(dtype)
         sin = (torch.sin(freqs) * mscale).to(dtype)
@@ -187,7 +196,11 @@ def _test_fused_apply_mla_rope_for_kv(input_format):
         cu_seqlens = None
         seqlen = 1024
         batch_size = 2
-        yarn_rope = YarnRotaryEmbedding(emb_dim, original_max_position_embeddings=seqlen)
+        yarn_rope = YarnRotaryEmbedding(
+            emb_dim,
+            original_max_position_embeddings=seqlen,
+            cp_group=parallel_state.get_context_parallel_group(check_initialized=False),
+        )
         freqs, mscale = yarn_rope(seqlen, 0)
         cos = (torch.cos(freqs) * mscale).to(dtype)
         sin = (torch.sin(freqs) * mscale).to(dtype)
@@ -211,7 +224,11 @@ def _test_fused_apply_mla_rope_for_kv(input_format):
         for i in range(len(cu_seqlens) - 1):
             max_seqlen = max(max_seqlen, cu_seqlens[i + 1] - cu_seqlens[i])
         cu_seqlens = torch.tensor(cu_seqlens, dtype=torch.int32, device='cuda')
-        yarn_rope = YarnRotaryEmbedding(emb_dim, original_max_position_embeddings=max_seqlen)
+        yarn_rope = YarnRotaryEmbedding(
+            emb_dim,
+            original_max_position_embeddings=max_seqlen,
+            cp_group=parallel_state.get_context_parallel_group(check_initialized=False),
+        )
         freqs, mscale = yarn_rope(max_seqlen, 0)
         cos = (torch.cos(freqs) * mscale).to(dtype)
         sin = (torch.sin(freqs) * mscale).to(dtype)

--- a/tests/unit_tests/fusions/test_mla_yarn_rope_apply.py
+++ b/tests/unit_tests/fusions/test_mla_yarn_rope_apply.py
@@ -466,7 +466,11 @@ def test_out_of_place_inverse_rope_preserves_upstream_saved_output(input_format)
     emb_dim = 64
     dtype = torch.bfloat16
 
-    yarn_rope = YarnRotaryEmbedding(emb_dim, original_max_position_embeddings=seqlen)
+    yarn_rope = YarnRotaryEmbedding(
+        emb_dim,
+        original_max_position_embeddings=seqlen,
+        cp_group=parallel_state.get_context_parallel_group(check_initialized=False),
+    )
     freqs, mscale = yarn_rope(seqlen, 0)
     cos = (torch.cos(freqs) * mscale).to(dtype)
     sin = (torch.sin(freqs) * mscale).to(dtype)
@@ -543,7 +547,11 @@ def test_legacy_query_api_remains_in_place(input_format):
     emb_dim = 64
     dtype = torch.bfloat16
 
-    yarn_rope = YarnRotaryEmbedding(emb_dim, original_max_position_embeddings=seqlen)
+    yarn_rope = YarnRotaryEmbedding(
+        emb_dim,
+        original_max_position_embeddings=seqlen,
+        cp_group=parallel_state.get_context_parallel_group(check_initialized=False),
+    )
     freqs, mscale = yarn_rope(seqlen, 0)
     cos = (torch.cos(freqs) * mscale).to(dtype)
     sin = (torch.sin(freqs) * mscale).to(dtype)

--- a/tests/unit_tests/inference/model_inference_wrappers/t5/test_t5_inference_wrapper.py
+++ b/tests/unit_tests/inference/model_inference_wrappers/t5/test_t5_inference_wrapper.py
@@ -18,6 +18,7 @@ from megatron.core.models.T5.t5_spec import (
     get_t5_decoder_with_transformer_engine_block_spec,
     get_t5_encoder_with_transformer_engine_block_spec,
 )
+from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.enums import AttnBackend
 from megatron.core.transformer.transformer_config import TransformerConfig
@@ -75,6 +76,9 @@ class TestT5InferenceWrapper:
             post_process=True,
             add_encoder=True,
             add_decoder=True,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=['tp', 'cp', 'pp']
+            ),
         ).cuda()
 
         inference_context = StaticInferenceContext(max_batch_size=8, max_sequence_length=2560)

--- a/tests/unit_tests/inference/test_flash_decode.py
+++ b/tests/unit_tests/inference/test_flash_decode.py
@@ -1,5 +1,6 @@
 import torch
 
+from megatron.core import parallel_state
 from megatron.core.models.common.embeddings.rope_utils import apply_rotary_pos_emb_with_cos_sin
 from megatron.core.models.common.embeddings.rotary_pos_embedding import RotaryEmbedding
 
@@ -10,7 +11,11 @@ class TestRotaryEmbeddingWithPrecomputedCosSin:
         self.batch_size = 3
         self.seq_len = 4
         self.d_rot = 6
-        self.rotary_embedding = RotaryEmbedding(kv_channels=4, rotary_percent=1.0)
+        self.rotary_embedding = RotaryEmbedding(
+            kv_channels=4,
+            rotary_percent=1.0,
+            cp_group=parallel_state.get_context_parallel_group(check_initialized=False),
+        )
 
     def test_output_shapes_match(self):
 

--- a/tests/unit_tests/inference/test_flash_decode.py
+++ b/tests/unit_tests/inference/test_flash_decode.py
@@ -6,6 +6,7 @@ import pytest
 import torch
 
 import megatron.core.transformer.attention as attention_module
+from megatron.core import parallel_state
 from megatron.core.models.common.embeddings.rope_utils import apply_rotary_pos_emb_with_cos_sin
 from megatron.core.models.common.embeddings.rotary_pos_embedding import RotaryEmbedding
 from megatron.core.transformer.attention import SelfAttention
@@ -17,7 +18,11 @@ class TestRotaryEmbeddingWithPrecomputedCosSin:
         self.batch_size = 3
         self.seq_len = 4
         self.d_rot = 6
-        self.rotary_embedding = RotaryEmbedding(kv_channels=4, rotary_percent=1.0)
+        self.rotary_embedding = RotaryEmbedding(
+            kv_channels=4,
+            rotary_percent=1.0,
+            cp_group=parallel_state.get_context_parallel_group(check_initialized=False),
+        )
 
     def test_output_shapes_match(self):
 

--- a/tests/unit_tests/inference/text_generation_controllers/test_encoder_decoder_text_generation_controller.py
+++ b/tests/unit_tests/inference/text_generation_controllers/test_encoder_decoder_text_generation_controller.py
@@ -27,6 +27,7 @@ from megatron.core.models.T5.t5_spec import (
     get_t5_decoder_with_transformer_engine_block_spec,
     get_t5_encoder_with_transformer_engine_block_spec,
 )
+from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.enums import AttnBackend
 from megatron.core.transformer.transformer_config import TransformerConfig
@@ -83,6 +84,9 @@ class TestEncoderDecoderTextGenerationController:
             post_process=True,
             add_encoder=True,
             add_decoder=True,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=['tp', 'cp', 'pp']
+            ),
         ).cuda()
 
         inference_context = StaticInferenceContext(max_batch_size=8, max_sequence_length=2560)

--- a/tests/unit_tests/inference/text_generation_controllers/test_vlm_text_generation_controller.py
+++ b/tests/unit_tests/inference/text_generation_controllers/test_vlm_text_generation_controller.py
@@ -23,6 +23,7 @@ from megatron.core.inference.text_generation_controllers.vlm_text_generation_con
 from megatron.core.inference.utils import InferenceMode
 from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_local_submodules
 from megatron.core.models.multimodal.llava_model import LLaVAModel
+from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.mlp import MLPSubmodules
 from megatron.core.transformer.module import Float16Module
@@ -93,6 +94,7 @@ class TestVLMTextGenerationController:
             img_h=self.img_h,
             img_w=self.img_w,
             patch_dim=14,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         ).cuda()
         self.image_token_index = self.model.image_token_index
         self.model = Float16Module(self.model.config, self.model)

--- a/tests/unit_tests/inference/text_generation_controllers/test_vlm_text_generation_controller.py
+++ b/tests/unit_tests/inference/text_generation_controllers/test_vlm_text_generation_controller.py
@@ -31,6 +31,7 @@ from megatron.core.inference.text_generation_controllers.vlm_text_generation_con
 from megatron.core.inference.utils import InferenceMode
 from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_local_submodules
 from megatron.core.models.multimodal.llava_model import LLaVAModel
+from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.mlp import MLPSubmodules
 from megatron.core.transformer.module import Float16Module
@@ -305,6 +306,7 @@ class TestVLMTextGenerationController:
             img_h=self.img_h,
             img_w=self.img_w,
             patch_dim=14,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         ).cuda()
         self.image_token_index = self.model.image_token_index
         self.model = Float16Module(self.model.config, self.model)

--- a/tests/unit_tests/models/test_llava_model.py
+++ b/tests/unit_tests/models/test_llava_model.py
@@ -14,6 +14,7 @@ from megatron.core.models.gpt.gpt_layer_specs import (
 from megatron.core.models.multimodal import context_parallel
 from megatron.core.models.multimodal.llava_model import LLaVAModel
 from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.enums import AttnMaskType
 from megatron.core.transformer.mlp import MLPSubmodules
@@ -75,6 +76,7 @@ class TestLLaVAModel:
             img_h=336,
             img_w=336,
             patch_dim=14,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
     @pytest.mark.internal
@@ -517,6 +519,7 @@ def setup_and_teardown_llava_model(request):
         img_h=336,
         img_w=336,
         patch_dim=14,
+        pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
     )
 
     yield model, vision_model_type
@@ -626,6 +629,7 @@ class TestLLaVAModelTokenParallel:
             img_h=336,
             img_w=336,
             patch_dim=14,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
         return model

--- a/tests/unit_tests/models/test_llava_model.py
+++ b/tests/unit_tests/models/test_llava_model.py
@@ -14,6 +14,7 @@ from megatron.core.models.gpt.gpt_layer_specs import (
 from megatron.core.models.multimodal import context_parallel
 from megatron.core.models.multimodal.llava_model import LLaVAModel
 from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.enums import AttnMaskType
 from megatron.core.transformer.mlp import MLPSubmodules
@@ -75,6 +76,7 @@ class TestLLaVAModel:
             img_h=336,
             img_w=336,
             patch_dim=14,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
     @pytest.mark.internal
@@ -663,6 +665,7 @@ def setup_and_teardown_llava_model(request):
         img_h=336,
         img_w=336,
         patch_dim=14,
+        pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
     )
 
     yield model, vision_model_type
@@ -772,6 +775,7 @@ class TestLLaVAModelTokenParallel:
             img_h=336,
             img_w=336,
             patch_dim=14,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
         return model

--- a/tests/unit_tests/models/test_multimodal_context_parallel.py
+++ b/tests/unit_tests/models/test_multimodal_context_parallel.py
@@ -492,7 +492,9 @@ class TestDynamicResCPDistributed:
             (1, 4, 8), float(cp_rank + 1), dtype=torch.float32, device="cuda", requires_grad=True
         )
 
-        gathered = GatherFromContextParallelRanks.apply(local_t)
+        gathered = GatherFromContextParallelRanks.apply(
+            local_t, parallel_state.get_context_parallel_group()
+        )
         loss = gathered.sum()
         loss.backward()
 

--- a/tests/unit_tests/models/test_multimodal_context_parallel.py
+++ b/tests/unit_tests/models/test_multimodal_context_parallel.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 import pytest
 import torch
 
+from megatron.core import parallel_state
 from megatron.core.models.multimodal.context_parallel import (
     GatherFromContextParallelRanks,
     _compute_tubelet_aware_split_points,
@@ -168,7 +169,9 @@ class TestSplitToContextParallelRanks:
         Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=1)
         global_t = torch.arange(12, dtype=torch.float32, device="cuda").reshape(4, 3)
 
-        local_t, global_pad = split_to_context_parallel_ranks(global_t)
+        local_t, global_pad = split_to_context_parallel_ranks(
+            global_t, parallel_state.get_context_parallel_group()
+        )
 
         assert torch.equal(local_t, global_t)
         assert global_pad == 0
@@ -213,7 +216,9 @@ class TestDynamicResCPDistributed:
             device="cuda",
         )
 
-        gathered = gather_from_context_parallel_ranks_dynamic_res(local_t)
+        gathered = gather_from_context_parallel_ranks_dynamic_res(
+            local_t, parallel_state.get_context_parallel_group()
+        )
 
         total_tubelets = sum(r + 1 for r in range(cp_size))
         assert gathered.shape == (total_tubelets, patches, hidden)
@@ -235,7 +240,9 @@ class TestDynamicResCPDistributed:
         cp_rank = get_context_parallel_rank()
         local_t = torch.full((1, 2, 4), float(cp_rank), dtype=torch.float32, device="cuda")
 
-        gathered = gather_from_context_parallel_ranks_dynamic_res(local_t, num_padded_imgs=1)
+        gathered = gather_from_context_parallel_ranks_dynamic_res(
+            local_t, parallel_state.get_context_parallel_group(), num_padded_imgs=1
+        )
 
         # With cp_size=2 and one padded rank, only rank 0's tensor survives.
         assert gathered.shape == (1, 2, 4)
@@ -293,6 +300,7 @@ class TestDynamicResCPDistributed:
             global_t,
             global_imgs_sizes,
             global_packed_seq_params,
+            cp_group=parallel_state.get_context_parallel_group(),
             fp8_enabled=False,
             patch_dim=patch_dim,
             temporal_patch_size=1,
@@ -360,6 +368,7 @@ class TestDynamicResCPDistributed:
                 global_t,
                 global_imgs_sizes,
                 global_packed_seq_params,
+                cp_group=parallel_state.get_context_parallel_group(),
                 patch_dim=patch_dim,
                 num_frames=num_frames,
                 temporal_patch_size=temporal_patch_size,
@@ -402,6 +411,7 @@ class TestDynamicResCPDistributed:
                 global_t,
                 global_imgs_sizes,
                 global_packed_seq_params,
+                cp_group=parallel_state.get_context_parallel_group(),
                 patch_dim=patch_dim,
                 temporal_patch_size=1,
             )
@@ -441,6 +451,7 @@ class TestDynamicResCPDistributed:
                 global_t,
                 global_imgs_sizes,
                 global_packed_seq_params,
+                cp_group=parallel_state.get_context_parallel_group(),
                 patch_dim=patch_dim,
                 temporal_patch_size=1,
             )
@@ -457,7 +468,9 @@ class TestDynamicResCPDistributed:
         local_t = torch.full((1, 3, 4), float(cp_rank), dtype=torch.float32, device="cuda")
 
         # Simulate global_pad=2 ⇒ trailing 2 columns of the gathered tensor get dropped.
-        out = gather_from_context_parallel_ranks(local_t, global_pad=2)
+        out = gather_from_context_parallel_ranks(
+            local_t, global_pad=2, cp_group=parallel_state.get_context_parallel_group()
+        )
 
         # cp_size * seq - global_pad = 2*3 - 2 = 4 effective columns.
         assert out.shape == (1, 4, 4)

--- a/tests/unit_tests/models/test_multimodal_context_parallel.py
+++ b/tests/unit_tests/models/test_multimodal_context_parallel.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 import pytest
 import torch
 
+from megatron.core import parallel_state
 from megatron.core.models.multimodal.context_parallel import (
     GatherFromContextParallelRanks,
     _compute_tubelet_aware_split_points,
@@ -168,7 +169,9 @@ class TestSplitToContextParallelRanks:
         Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=1)
         global_t = torch.arange(12, dtype=torch.float32, device="cuda").reshape(4, 3)
 
-        local_t, global_pad = split_to_context_parallel_ranks(global_t)
+        local_t, global_pad = split_to_context_parallel_ranks(
+            global_t, parallel_state.get_context_parallel_group()
+        )
 
         assert torch.equal(local_t, global_t)
         assert global_pad == 0
@@ -213,7 +216,9 @@ class TestDynamicResCPDistributed:
             device="cuda",
         )
 
-        gathered = gather_from_context_parallel_ranks_dynamic_res(local_t)
+        gathered = gather_from_context_parallel_ranks_dynamic_res(
+            local_t, parallel_state.get_context_parallel_group()
+        )
 
         total_tubelets = sum(r + 1 for r in range(cp_size))
         assert gathered.shape == (total_tubelets, patches, hidden)
@@ -235,7 +240,9 @@ class TestDynamicResCPDistributed:
         cp_rank = get_context_parallel_rank()
         local_t = torch.full((1, 2, 4), float(cp_rank), dtype=torch.float32, device="cuda")
 
-        gathered = gather_from_context_parallel_ranks_dynamic_res(local_t, num_padded_imgs=1)
+        gathered = gather_from_context_parallel_ranks_dynamic_res(
+            local_t, parallel_state.get_context_parallel_group(), num_padded_imgs=1
+        )
 
         # With cp_size=2 and one padded rank, only rank 0's tensor survives.
         assert gathered.shape == (1, 2, 4)
@@ -293,6 +300,7 @@ class TestDynamicResCPDistributed:
             global_t,
             global_imgs_sizes,
             global_packed_seq_params,
+            cp_group=parallel_state.get_context_parallel_group(),
             fp8_enabled=False,
             patch_dim=patch_dim,
             temporal_patch_size=1,
@@ -355,11 +363,12 @@ class TestDynamicResCPDistributed:
         )
         num_frames = torch.tensor([frames_per_video] * num_videos, dtype=torch.int32, device="cuda")
 
-        (local_t, local_imgs_sizes, _packed, has_padding, num_padded_ranks, local_num_frames) = (
+        local_t, local_imgs_sizes, _packed, has_padding, num_padded_ranks, local_num_frames = (
             split_to_context_parallel_ranks_dynamic_res(
                 global_t,
                 global_imgs_sizes,
                 global_packed_seq_params,
+                cp_group=parallel_state.get_context_parallel_group(),
                 patch_dim=patch_dim,
                 num_frames=num_frames,
                 temporal_patch_size=temporal_patch_size,
@@ -402,6 +411,7 @@ class TestDynamicResCPDistributed:
                 global_t,
                 global_imgs_sizes,
                 global_packed_seq_params,
+                cp_group=parallel_state.get_context_parallel_group(),
                 patch_dim=patch_dim,
                 temporal_patch_size=1,
             )
@@ -441,6 +451,7 @@ class TestDynamicResCPDistributed:
                 global_t,
                 global_imgs_sizes,
                 global_packed_seq_params,
+                cp_group=parallel_state.get_context_parallel_group(),
                 patch_dim=patch_dim,
                 temporal_patch_size=1,
             )
@@ -457,7 +468,9 @@ class TestDynamicResCPDistributed:
         local_t = torch.full((1, 3, 4), float(cp_rank), dtype=torch.float32, device="cuda")
 
         # Simulate global_pad=2 ⇒ trailing 2 columns of the gathered tensor get dropped.
-        out = gather_from_context_parallel_ranks(local_t, global_pad=2)
+        out = gather_from_context_parallel_ranks(
+            local_t, global_pad=2, cp_group=parallel_state.get_context_parallel_group()
+        )
 
         # cp_size * seq - global_pad = 2*3 - 2 = 4 effective columns.
         assert out.shape == (1, 4, 4)

--- a/tests/unit_tests/pipeline_parallel/test_pipeline_layout.py
+++ b/tests/unit_tests/pipeline_parallel/test_pipeline_layout.py
@@ -76,6 +76,7 @@ def initialize_gpt_model(
             mtp_num_layers=transformer_config.mtp_num_layers,
             ignore_virtual=False,
             vp_stage=i,
+            pp_group=parallel_state.get_pipeline_model_parallel_group(),
         ):
             if is_moe:
                 transformer_layer_spec_for_mtp = gpt_te_spec(transformer_config)

--- a/tests/unit_tests/pipeline_parallel/test_schedules.py
+++ b/tests/unit_tests/pipeline_parallel/test_schedules.py
@@ -113,27 +113,32 @@ def _no_sync():
     yield
 
 
-def _patch_hybrid_cp_parallel_state(monkeypatch, *, is_first_tp_rank):
+class _FakeProcessGroup:
+    """Stand-in for a torch ProcessGroup exposing only rank() and size()."""
+
+    def __init__(self, rank, size):
+        self._rank = rank
+        self._size = size
+
+    def rank(self):
+        return self._rank
+
+    def size(self):
+        return self._size
+
+
+def _hybrid_cp_pg_collection(monkeypatch, *, is_first_tp_rank):
+    """Process groups for the hybrid CP scheduler: a TP group of size 2 and a single-rank
+    DP-CP group. The scheduler resolves the TP broadcast source through
+    torch.distributed.get_global_rank, which needs a real group, so map it to the group rank."""
     monkeypatch.setattr(
-        hybrid_cp_schedule.parallel_state,
-        "get_data_parallel_rank",
-        lambda with_context_parallel=False: 0,
+        hybrid_cp_schedule.torch.distributed,
+        "get_global_rank",
+        lambda group, group_rank: group_rank,
     )
-    monkeypatch.setattr(
-        hybrid_cp_schedule.parallel_state,
-        "get_tensor_model_parallel_rank",
-        lambda: 0 if is_first_tp_rank else 1,
-    )
-    monkeypatch.setattr(
-        hybrid_cp_schedule.parallel_state, "get_tensor_model_parallel_src_rank", lambda: 0
-    )
-    monkeypatch.setattr(
-        hybrid_cp_schedule.parallel_state, "get_tensor_model_parallel_group", lambda: "tp_group"
-    )
-    monkeypatch.setattr(
-        hybrid_cp_schedule.parallel_state,
-        "get_data_parallel_group",
-        lambda with_context_parallel=False: "dp_cp_group",
+    return SimpleNamespace(
+        tp=_FakeProcessGroup(rank=0 if is_first_tp_rank else 1, size=2),
+        dp_cp=_FakeProcessGroup(rank=0, size=1),
     )
 
 
@@ -153,7 +158,7 @@ def _patch_hybrid_cp_cpu_tensors(monkeypatch):
 
 def test_hybrid_context_parallel_forward_backward_passes_local_cp_size(monkeypatch):
     _patch_hybrid_cp_cpu_tensors(monkeypatch)
-    _patch_hybrid_cp_parallel_state(monkeypatch, is_first_tp_rank=True)
+    pg_collection = _hybrid_cp_pg_collection(monkeypatch, is_first_tp_rank=True)
 
     monkeypatch.setattr(
         hybrid_cp_schedule.torch.distributed, "broadcast", lambda *args, **kwargs: None
@@ -242,6 +247,7 @@ def test_hybrid_context_parallel_forward_backward_passes_local_cp_size(monkeypat
             total_num_tokens=0,
             check_first_val_step=lambda first_val_step, forward_only, is_first: is_first,
             model_type="unused",
+            pg_collection=pg_collection,
         )
     )
 
@@ -279,11 +285,11 @@ def test_hybrid_context_parallel_forward_backward_passes_local_cp_size(monkeypat
         ("input", 2.0, "grad"),
     ]
     assert all(call[3] is config for call in backward_calls)
-    assert "dp_cp_group" in barrier_groups
+    assert pg_collection.dp_cp in barrier_groups
 
 
 def test_hybrid_context_parallel_non_first_tp_rank_uses_broadcast_cp_size(monkeypatch):
-    _patch_hybrid_cp_parallel_state(monkeypatch, is_first_tp_rank=False)
+    pg_collection = _hybrid_cp_pg_collection(monkeypatch, is_first_tp_rank=False)
     monkeypatch.setattr(
         hybrid_cp_schedule.torch.cuda, "current_device", lambda: torch.device("cpu")
     )
@@ -339,6 +345,7 @@ def test_hybrid_context_parallel_non_first_tp_rank_uses_broadcast_cp_size(monkey
         total_num_tokens=0,
         check_first_val_step=lambda first_val_step, forward_only, is_first: is_first,
         model_type="unused",
+        pg_collection=pg_collection,
     )
 
     assert forward_calls == [(None, 7, 0)]

--- a/tests/unit_tests/test_optimizer.py
+++ b/tests/unit_tests/test_optimizer.py
@@ -1113,7 +1113,11 @@ def test_distributed_optimizer_synthesizes_fused_qkv_down_weight_for_state_dict_
         ).self_attention.submodules
         assert isinstance(submodules, MLASelfAttentionSubmodules)
         fused_mla = FusedMLASelfAttention(
-            transformer_config, submodules, layer_number=1, attn_mask_type=AttnMaskType.causal
+            transformer_config,
+            submodules,
+            layer_number=1,
+            attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
         model = nn.Module()

--- a/tests/unit_tests/test_optimizer.py
+++ b/tests/unit_tests/test_optimizer.py
@@ -1159,7 +1159,11 @@ def test_distributed_optimizer_synthesizes_fused_qkv_down_weight_for_state_dict_
         ).self_attention.submodules
         assert isinstance(submodules, MLASelfAttentionSubmodules)
         fused_mla = FusedMLASelfAttention(
-            transformer_config, submodules, layer_number=1, attn_mask_type=AttnMaskType.causal
+            transformer_config,
+            submodules,
+            layer_number=1,
+            attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
         model = nn.Module()

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
@@ -2278,7 +2278,12 @@ class TestDSAIndexer:
         )
 
         cls.pg_collection = ProcessGroupCollection.use_mpu_process_groups(required_pgs=['tp', 'cp'])
-        cls.indexer = DSAIndexer(cls.config, indexer_submodules, cls.pg_collection)
+        cls.indexer = DSAIndexer(
+            cls.config,
+            indexer_submodules,
+            cls.pg_collection,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(required_pgs=['tp', 'cp']),
+        )
 
         yield
         Utils.destroy_model_parallel()
@@ -3179,7 +3184,12 @@ class TestIndexerTensorParallel:
             linear_weights_proj=ModuleSpec(module=TELinear),
         )
 
-        return DSAIndexer(config, indexer_submodules, pg_collection)
+        return DSAIndexer(
+            config,
+            indexer_submodules,
+            pg_collection,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(required_pgs=['tp', 'cp']),
+        )
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
     def test_dsa_indexer_weight_consistency(self):

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
@@ -2278,12 +2278,7 @@ class TestDSAIndexer:
         )
 
         cls.pg_collection = ProcessGroupCollection.use_mpu_process_groups(required_pgs=['tp', 'cp'])
-        cls.indexer = DSAIndexer(
-            cls.config,
-            indexer_submodules,
-            cls.pg_collection,
-            pg_collection=ProcessGroupCollection.use_mpu_process_groups(required_pgs=['tp', 'cp']),
-        )
+        cls.indexer = DSAIndexer(cls.config, indexer_submodules, cls.pg_collection)
 
         yield
         Utils.destroy_model_parallel()
@@ -3184,12 +3179,7 @@ class TestIndexerTensorParallel:
             linear_weights_proj=ModuleSpec(module=TELinear),
         )
 
-        return DSAIndexer(
-            config,
-            indexer_submodules,
-            pg_collection,
-            pg_collection=ProcessGroupCollection.use_mpu_process_groups(required_pgs=['tp', 'cp']),
-        )
+        return DSAIndexer(config, indexer_submodules, pg_collection)
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
     def test_dsa_indexer_weight_consistency(self):

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
@@ -2387,12 +2387,7 @@ class TestDSAIndexer:
         )
 
         cls.pg_collection = ProcessGroupCollection.use_mpu_process_groups(required_pgs=['tp', 'cp'])
-        cls.indexer = DSAIndexer(
-            cls.config,
-            indexer_submodules,
-            cls.pg_collection,
-            pg_collection=ProcessGroupCollection.use_mpu_process_groups(required_pgs=['tp', 'cp']),
-        )
+        cls.indexer = DSAIndexer(cls.config, indexer_submodules, cls.pg_collection)
 
         yield
         Utils.destroy_model_parallel()
@@ -3293,12 +3288,7 @@ class TestIndexerTensorParallel:
             linear_weights_proj=ModuleSpec(module=TELinear),
         )
 
-        return DSAIndexer(
-            config,
-            indexer_submodules,
-            pg_collection,
-            pg_collection=ProcessGroupCollection.use_mpu_process_groups(required_pgs=['tp', 'cp']),
-        )
+        return DSAIndexer(config, indexer_submodules, pg_collection)
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
     def test_dsa_indexer_weight_consistency(self):

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
@@ -2387,7 +2387,12 @@ class TestDSAIndexer:
         )
 
         cls.pg_collection = ProcessGroupCollection.use_mpu_process_groups(required_pgs=['tp', 'cp'])
-        cls.indexer = DSAIndexer(cls.config, indexer_submodules, cls.pg_collection)
+        cls.indexer = DSAIndexer(
+            cls.config,
+            indexer_submodules,
+            cls.pg_collection,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(required_pgs=['tp', 'cp']),
+        )
 
         yield
         Utils.destroy_model_parallel()
@@ -3288,7 +3293,12 @@ class TestIndexerTensorParallel:
             linear_weights_proj=ModuleSpec(module=TELinear),
         )
 
-        return DSAIndexer(config, indexer_submodules, pg_collection)
+        return DSAIndexer(
+            config,
+            indexer_submodules,
+            pg_collection,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(required_pgs=['tp', 'cp']),
+        )
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
     def test_dsa_indexer_weight_consistency(self):

--- a/tests/unit_tests/transformer/test_attention.py
+++ b/tests/unit_tests/transformer/test_attention.py
@@ -63,6 +63,9 @@ class TestParallelAttention:
             self.transformer_config,
             get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules,
             layer_number=1,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=['tp', 'cp', 'dp']
+            ),
         )
 
     def teardown_method(self):
@@ -156,6 +159,9 @@ class TestParallelAttention:
             transformer_config,
             get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules,
             layer_number=1,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=['tp', 'cp', 'dp']
+            ),
         )
         config = checkpointed_parallel_attention.config
 
@@ -206,6 +212,9 @@ class TestClipQK:
             transformer_config,
             get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules,
             layer_number=1,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=['tp', 'cp', 'dp']
+            ),
         )
 
         with pytest.raises(ValueError, match="qk_clip option needs to be enabled"):
@@ -226,6 +235,9 @@ class TestClipQK:
             transformer_config,
             get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules,
             layer_number=1,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=['tp', 'cp', 'dp']
+            ),
         )
 
         with pytest.raises(ValueError, match="current_max_attn_logits is None"):
@@ -246,6 +258,9 @@ class TestClipQK:
             transformer_config,
             get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules,
             layer_number=1,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=['tp', 'cp', 'dp']
+            ),
         )
         attention.cuda()
 
@@ -280,6 +295,9 @@ class TestClipQK:
             transformer_config,
             get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules,
             layer_number=1,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=['tp', 'cp', 'dp']
+            ),
         )
         attention.cuda()
 
@@ -315,6 +333,9 @@ class TestClipQK:
             transformer_config,
             get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules,
             layer_number=1,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=['tp', 'cp', 'dp']
+            ),
         )
         attention.cuda()
 
@@ -349,6 +370,9 @@ class TestClipQK:
             transformer_config,
             get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules,
             layer_number=1,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=['tp', 'cp', 'dp']
+            ),
         )
         attention.cuda()
 
@@ -754,7 +778,14 @@ def test_qk_layernorm_from_config_fallback():
         )
         base = get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules
         submodules = replace(base, q_layernorm=None, k_layernorm=None)
-        attn = SelfAttention(config, submodules, layer_number=1)
+        attn = SelfAttention(
+            config,
+            submodules,
+            layer_number=1,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=['tp', 'cp', 'dp']
+            ),
+        )
         assert isinstance(attn.q_layernorm, te_pytorch.LayerNorm)
         assert isinstance(attn.k_layernorm, te_pytorch.LayerNorm)
     finally:
@@ -780,7 +811,14 @@ def test_qk_l2_norm_from_config_fallback():
         )
         base = get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules
         submodules = replace(base, q_layernorm=None, k_layernorm=None)
-        attn = SelfAttention(config, submodules, layer_number=1)
+        attn = SelfAttention(
+            config,
+            submodules,
+            layer_number=1,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=['tp', 'cp', 'dp']
+            ),
+        )
         assert isinstance(attn.q_layernorm, L2Norm)
         assert isinstance(attn.k_layernorm, L2Norm)
     finally:
@@ -803,6 +841,13 @@ def test_qk_layernorm_spec_config_mismatch_raises():
         base = get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules
         submodules = replace(base, q_layernorm=L2Norm, k_layernorm=L2Norm)
         with pytest.raises(ValueError, match="qk_layernorm"):
-            SelfAttention(config, submodules, layer_number=1)
+            SelfAttention(
+                config,
+                submodules,
+                layer_number=1,
+                pg_collection=ProcessGroupCollection.use_mpu_process_groups(
+                    required_pgs=['tp', 'cp', 'dp']
+                ),
+            )
     finally:
         Utils.destroy_model_parallel()

--- a/tests/unit_tests/transformer/test_attention.py
+++ b/tests/unit_tests/transformer/test_attention.py
@@ -63,6 +63,9 @@ class TestParallelAttention:
             self.transformer_config,
             get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules,
             layer_number=1,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=['tp', 'cp', 'dp']
+            ),
         )
 
     def teardown_method(self):
@@ -156,6 +159,9 @@ class TestParallelAttention:
             transformer_config,
             get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules,
             layer_number=1,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=['tp', 'cp', 'dp']
+            ),
         )
         config = checkpointed_parallel_attention.config
 
@@ -206,6 +212,9 @@ class TestClipQK:
             transformer_config,
             get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules,
             layer_number=1,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=['tp', 'cp', 'dp']
+            ),
         )
 
         with pytest.raises(ValueError, match="qk_clip option needs to be enabled"):
@@ -226,6 +235,9 @@ class TestClipQK:
             transformer_config,
             get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules,
             layer_number=1,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=['tp', 'cp', 'dp']
+            ),
         )
 
         with pytest.raises(ValueError, match="current_max_attn_logits is None"):
@@ -246,6 +258,9 @@ class TestClipQK:
             transformer_config,
             get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules,
             layer_number=1,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=['tp', 'cp', 'dp']
+            ),
         )
         attention.cuda()
 
@@ -280,6 +295,9 @@ class TestClipQK:
             transformer_config,
             get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules,
             layer_number=1,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=['tp', 'cp', 'dp']
+            ),
         )
         attention.cuda()
 
@@ -315,6 +333,9 @@ class TestClipQK:
             transformer_config,
             get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules,
             layer_number=1,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=['tp', 'cp', 'dp']
+            ),
         )
         attention.cuda()
 
@@ -349,6 +370,9 @@ class TestClipQK:
             transformer_config,
             get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules,
             layer_number=1,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=['tp', 'cp', 'dp']
+            ),
         )
         attention.cuda()
 
@@ -753,7 +777,14 @@ def test_qk_layernorm_from_config_fallback():
         )
         base = get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules
         submodules = replace(base, q_layernorm=None, k_layernorm=None)
-        attn = SelfAttention(config, submodules, layer_number=1)
+        attn = SelfAttention(
+            config,
+            submodules,
+            layer_number=1,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=['tp', 'cp', 'dp']
+            ),
+        )
         assert isinstance(attn.q_layernorm, te_pytorch.LayerNorm)
         assert isinstance(attn.k_layernorm, te_pytorch.LayerNorm)
     finally:
@@ -779,7 +810,14 @@ def test_qk_l2_norm_from_config_fallback():
         )
         base = get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules
         submodules = replace(base, q_layernorm=None, k_layernorm=None)
-        attn = SelfAttention(config, submodules, layer_number=1)
+        attn = SelfAttention(
+            config,
+            submodules,
+            layer_number=1,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=['tp', 'cp', 'dp']
+            ),
+        )
         assert isinstance(attn.q_layernorm, L2Norm)
         assert isinstance(attn.k_layernorm, L2Norm)
     finally:
@@ -802,6 +840,13 @@ def test_qk_layernorm_spec_config_mismatch_raises():
         base = get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules
         submodules = replace(base, q_layernorm=L2Norm, k_layernorm=L2Norm)
         with pytest.raises(ValueError, match="qk_layernorm"):
-            SelfAttention(config, submodules, layer_number=1)
+            SelfAttention(
+                config,
+                submodules,
+                layer_number=1,
+                pg_collection=ProcessGroupCollection.use_mpu_process_groups(
+                    required_pgs=['tp', 'cp', 'dp']
+                ),
+            )
     finally:
         Utils.destroy_model_parallel()

--- a/tests/unit_tests/transformer/test_attention_no_rope.py
+++ b/tests/unit_tests/transformer/test_attention_no_rope.py
@@ -6,6 +6,7 @@ import torch
 from megatron.core.models.gpt.gpt_layer_specs import (
     get_gpt_layer_with_transformer_engine_submodules,
 )
+from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.attention import SelfAttention
 from megatron.core.transformer.enums import AttnMaskType
@@ -35,6 +36,9 @@ class TestParallelAttentionWithNoRope:
             get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules,
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=['tp', 'cp', 'dp']
+            ),
         )
 
     def teardown_method(self, method):
@@ -181,6 +185,9 @@ class TestParallelAttentionWithNoRope:
             get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules,
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=['tp', 'cp', 'dp']
+            ),
         )
         config = checkpointed_parallel_attention.config
 

--- a/tests/unit_tests/transformer/test_attention_packed_seq.py
+++ b/tests/unit_tests/transformer/test_attention_packed_seq.py
@@ -7,6 +7,7 @@ from megatron.core.models.gpt.gpt_layer_specs import (
     get_gpt_layer_with_transformer_engine_submodules,
 )
 from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.attention import SelfAttention
 from megatron.core.transformer.enums import AttnMaskType
@@ -67,6 +68,9 @@ class TestParallelAttentionWithPackedSequence:
             get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules,
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=['tp', 'cp', 'dp']
+            ),
         )
 
     def teardown_method(self, method):
@@ -143,6 +147,9 @@ class TestParallelAttentionWithPackedSequence:
             get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules,
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=['tp', 'cp', 'dp']
+            ),
         )
         config = checkpointed_parallel_attention.config
 

--- a/tests/unit_tests/transformer/test_attention_packed_seq.py
+++ b/tests/unit_tests/transformer/test_attention_packed_seq.py
@@ -236,6 +236,9 @@ class TestAttentionDynamicContextParallel:
             get_gpt_layer_with_transformer_engine_submodules().self_attention.submodules,
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=['tp', 'cp', 'dp']
+            ),
         )
 
     def teardown_method(self, method):
@@ -280,9 +283,10 @@ class TestAttentionDynamicContextParallel:
             dtype=torch.bfloat16,
             device="cuda",
         )
-        rotary_pos_emb = RotaryEmbedding(kv_channels=16, rotary_percent=1.0)(sequence_length)
-
         build_time_group = self.parallel_attention.pg_collection.cp
+        rotary_pos_emb = RotaryEmbedding(
+            kv_channels=16, rotary_percent=1.0, cp_group=build_time_group
+        )(sequence_length)
 
         # Microbatch with a runtime CP group: RoPE (and the collection) must
         # use it.

--- a/tests/unit_tests/transformer/test_cuda_graphs.py
+++ b/tests/unit_tests/transformer/test_cuda_graphs.py
@@ -876,6 +876,7 @@ class TestLLaVACudaGraph:
             post_process=True,
             add_encoder=True,
             add_decoder=True,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
     def teardown_method(self, method):

--- a/tests/unit_tests/transformer/test_cuda_graphs.py
+++ b/tests/unit_tests/transformer/test_cuda_graphs.py
@@ -950,6 +950,7 @@ class TestLLaVACudaGraph:
             post_process=True,
             add_encoder=True,
             add_decoder=True,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
     def teardown_method(self, method):

--- a/tests/unit_tests/transformer/test_multi_latent_attention.py
+++ b/tests/unit_tests/transformer/test_multi_latent_attention.py
@@ -19,6 +19,7 @@ from megatron.core.models.gpt.gpt_layer_specs import (
 )
 from megatron.core.models.gpt.gpt_model import GPTModel
 from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.attention import Attention
 from megatron.core.transformer.enums import AttnMaskType
@@ -148,6 +149,7 @@ class TestParallelMLAAttention:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
     def teardown_method(self, method):
@@ -263,6 +265,7 @@ class TestParallelMLAAttention:
                 get_mla_self_attn_submodules(),
                 layer_number=1,
                 attn_mask_type=AttnMaskType.causal,
+                pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
             )
             config = checkpointed_parallel_attention.config
 
@@ -397,6 +400,7 @@ class TestParallelMLAAttention:
                 get_mla_self_attn_submodules(),
                 layer_number=1,
                 attn_mask_type=AttnMaskType.causal,
+                pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
             )
 
             sequence_length = 32
@@ -447,6 +451,7 @@ class TestParallelMLAAttention:
                 get_mla_self_attn_submodules(),
                 layer_number=1,
                 attn_mask_type=AttnMaskType.causal,
+                pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
             )
             config = checkpointed_parallel_attention.config
 
@@ -486,6 +491,7 @@ class TestParallelMLAAttention:
                 get_mla_self_attn_submodules(),
                 layer_number=1,
                 attn_mask_type=AttnMaskType.causal,
+                pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
             )
             config = checkpointed_parallel_attention.config
 
@@ -548,6 +554,7 @@ class TestSequenceParallelMLAAttention:
             get_mla_self_attn_submodules(linear_qkv_down_proj=linear_qkv_down_proj),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
     def teardown_method(self, method):
@@ -605,6 +612,7 @@ class TestTensorParallelMLAAttention:
             get_mla_self_attn_submodules(linear_qkv_down_proj=linear_qkv_down_proj),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
     def teardown_method(self, method):
@@ -676,6 +684,7 @@ class TestContextParallelMLAAttention:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         ).bfloat16()
 
     def teardown_method(self, method):
@@ -772,6 +781,7 @@ class TestParallelMLAAttentionPrecision:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
     def teardown_method(self, method):
@@ -934,6 +944,7 @@ class TestContextParallelMLAAttentionPrecision:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         ).bfloat16()
 
     def teardown_method(self, method):
@@ -1084,6 +1095,7 @@ class TestParallelMLAAttentionPrecisionWithRopeFusion:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
     def teardown_method(self, method):
@@ -1252,6 +1264,7 @@ class TestMLAClipQK:
                 get_mla_self_attn_submodules(),
                 layer_number=1,
                 attn_mask_type=AttnMaskType.causal,
+                pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
             )
 
             with pytest.raises(ValueError, match="qk_clip option needs to be enabled"):
@@ -1265,6 +1278,7 @@ class TestMLAClipQK:
                 get_mla_self_attn_submodules(),
                 layer_number=1,
                 attn_mask_type=AttnMaskType.causal,
+                pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
             )
 
             with pytest.raises(ValueError, match="current_max_attn_logits is None"):
@@ -1280,6 +1294,7 @@ class TestMLAClipQK:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
         attention.cuda()
 
@@ -1317,6 +1332,7 @@ class TestMLAClipQK:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
         attention.cuda()
 
@@ -1354,6 +1370,7 @@ class TestMLAClipQK:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
         attention.cuda()
 
@@ -1408,6 +1425,7 @@ class TestMLAClipQK:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
         attention.cuda()
 
@@ -1690,6 +1708,7 @@ class TestFusedMLASelfAttention:
             get_fused_mla_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
     def teardown_method(self, method):
@@ -1837,7 +1856,11 @@ class TestFusedMLAGradientFlow:
 
         config = self.transformer_config
         fused = FusedMLASelfAttention(
-            config, get_fused_mla_submodules(), layer_number=1, attn_mask_type=AttnMaskType.causal
+            config,
+            get_fused_mla_submodules(),
+            layer_number=1,
+            attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
         fused.cuda()
 
@@ -1891,12 +1914,14 @@ class TestFusedMLALoadFromStateDict:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
         fused = FusedMLASelfAttention(
             self.transformer_config,
             get_fused_mla_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
         unfused_sd = unfused.state_dict()
@@ -1926,6 +1951,7 @@ class TestFusedMLALoadFromStateDict:
             get_fused_mla_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
         sharded_sd = fused.sharded_state_dict(prefix="")
@@ -2043,4 +2069,5 @@ class TestFusedMLARequiresQLora:
                 get_fused_mla_submodules(),
                 layer_number=1,
                 attn_mask_type=AttnMaskType.causal,
+                pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
             )

--- a/tests/unit_tests/transformer/test_multi_latent_attention.py
+++ b/tests/unit_tests/transformer/test_multi_latent_attention.py
@@ -1974,7 +1974,9 @@ class TestFusedMLALoadFromStateDict:
             get_fused_mla_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
-        )
+        
+                    pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
+                )
         seen = []
 
         def mock_set_save_original_input(module):
@@ -1998,7 +2000,9 @@ class TestFusedMLALoadFromStateDict:
             get_fused_mla_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
-        )
+        
+                    pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
+                )
 
         sharded_sd = fused.sharded_state_dict(prefix="")
         layernorm_keys = [k for k in sharded_sd if k.startswith("linear_qkv_down_proj.layer_norm_")]
@@ -2017,7 +2021,9 @@ class TestFusedMLALoadFromStateDict:
             get_fused_mla_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
-        )
+        
+                    pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
+                )
         config = self.transformer_config
         q_weight = torch.randn(config.q_lora_rank, config.hidden_size)
         kv_weight = torch.randn(

--- a/tests/unit_tests/transformer/test_multi_latent_attention.py
+++ b/tests/unit_tests/transformer/test_multi_latent_attention.py
@@ -19,6 +19,7 @@ from megatron.core.models.gpt.gpt_layer_specs import (
 )
 from megatron.core.models.gpt.gpt_model import GPTModel
 from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.attention import Attention
 from megatron.core.transformer.enums import AttnMaskType
@@ -148,6 +149,7 @@ class TestParallelMLAAttention:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
     def teardown_method(self, method):
@@ -263,6 +265,7 @@ class TestParallelMLAAttention:
                 get_mla_self_attn_submodules(),
                 layer_number=1,
                 attn_mask_type=AttnMaskType.causal,
+                pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
             )
             config = checkpointed_parallel_attention.config
 
@@ -397,6 +400,7 @@ class TestParallelMLAAttention:
                 get_mla_self_attn_submodules(),
                 layer_number=1,
                 attn_mask_type=AttnMaskType.causal,
+                pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
             )
 
             sequence_length = 32
@@ -447,6 +451,7 @@ class TestParallelMLAAttention:
                 get_mla_self_attn_submodules(),
                 layer_number=1,
                 attn_mask_type=AttnMaskType.causal,
+                pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
             )
             config = checkpointed_parallel_attention.config
 
@@ -486,6 +491,7 @@ class TestParallelMLAAttention:
                 get_mla_self_attn_submodules(),
                 layer_number=1,
                 attn_mask_type=AttnMaskType.causal,
+                pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
             )
             config = checkpointed_parallel_attention.config
 
@@ -548,6 +554,7 @@ class TestSequenceParallelMLAAttention:
             get_mla_self_attn_submodules(linear_qkv_down_proj=linear_qkv_down_proj),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
     def teardown_method(self, method):
@@ -605,6 +612,7 @@ class TestTensorParallelMLAAttention:
             get_mla_self_attn_submodules(linear_qkv_down_proj=linear_qkv_down_proj),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
     def teardown_method(self, method):
@@ -676,6 +684,7 @@ class TestContextParallelMLAAttention:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         ).bfloat16()
 
     def teardown_method(self, method):
@@ -772,6 +781,7 @@ class TestParallelMLAAttentionPrecision:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
     def teardown_method(self, method):
@@ -934,6 +944,7 @@ class TestContextParallelMLAAttentionPrecision:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         ).bfloat16()
 
     def teardown_method(self, method):
@@ -1084,6 +1095,7 @@ class TestParallelMLAAttentionPrecisionWithRopeFusion:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
     def teardown_method(self, method):
@@ -1252,6 +1264,7 @@ class TestMLAClipQK:
                 get_mla_self_attn_submodules(),
                 layer_number=1,
                 attn_mask_type=AttnMaskType.causal,
+                pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
             )
 
             with pytest.raises(ValueError, match="qk_clip option needs to be enabled"):
@@ -1265,6 +1278,7 @@ class TestMLAClipQK:
                 get_mla_self_attn_submodules(),
                 layer_number=1,
                 attn_mask_type=AttnMaskType.causal,
+                pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
             )
 
             with pytest.raises(ValueError, match="current_max_attn_logits is None"):
@@ -1280,6 +1294,7 @@ class TestMLAClipQK:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
         attention.cuda()
 
@@ -1317,6 +1332,7 @@ class TestMLAClipQK:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
         attention.cuda()
 
@@ -1354,6 +1370,7 @@ class TestMLAClipQK:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
         attention.cuda()
 
@@ -1408,6 +1425,7 @@ class TestMLAClipQK:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
         attention.cuda()
 
@@ -1891,6 +1909,7 @@ class TestFusedMLALoadFromStateDict:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
         fused = FusedMLASelfAttention(
             self.transformer_config,

--- a/tests/unit_tests/transformer/test_multi_latent_attention.py
+++ b/tests/unit_tests/transformer/test_multi_latent_attention.py
@@ -19,7 +19,6 @@ from megatron.core.models.gpt.gpt_layer_specs import (
 )
 from megatron.core.models.gpt.gpt_model import GPTModel
 from megatron.core.packed_seq_params import PackedSeqParams
-from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.attention import Attention
 from megatron.core.transformer.enums import AttnMaskType
@@ -149,7 +148,6 @@ class TestParallelMLAAttention:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
-            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
     def teardown_method(self, method):
@@ -265,7 +263,6 @@ class TestParallelMLAAttention:
                 get_mla_self_attn_submodules(),
                 layer_number=1,
                 attn_mask_type=AttnMaskType.causal,
-                pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
             )
             config = checkpointed_parallel_attention.config
 
@@ -400,7 +397,6 @@ class TestParallelMLAAttention:
                 get_mla_self_attn_submodules(),
                 layer_number=1,
                 attn_mask_type=AttnMaskType.causal,
-                pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
             )
 
             sequence_length = 32
@@ -451,7 +447,6 @@ class TestParallelMLAAttention:
                 get_mla_self_attn_submodules(),
                 layer_number=1,
                 attn_mask_type=AttnMaskType.causal,
-                pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
             )
             config = checkpointed_parallel_attention.config
 
@@ -491,7 +486,6 @@ class TestParallelMLAAttention:
                 get_mla_self_attn_submodules(),
                 layer_number=1,
                 attn_mask_type=AttnMaskType.causal,
-                pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
             )
             config = checkpointed_parallel_attention.config
 
@@ -554,7 +548,6 @@ class TestSequenceParallelMLAAttention:
             get_mla_self_attn_submodules(linear_qkv_down_proj=linear_qkv_down_proj),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
-            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
     def teardown_method(self, method):
@@ -612,7 +605,6 @@ class TestTensorParallelMLAAttention:
             get_mla_self_attn_submodules(linear_qkv_down_proj=linear_qkv_down_proj),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
-            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
     def teardown_method(self, method):
@@ -684,7 +676,6 @@ class TestContextParallelMLAAttention:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
-            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         ).bfloat16()
 
     def teardown_method(self, method):
@@ -781,7 +772,6 @@ class TestParallelMLAAttentionPrecision:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
-            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
     def teardown_method(self, method):
@@ -944,7 +934,6 @@ class TestContextParallelMLAAttentionPrecision:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
-            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         ).bfloat16()
 
     def teardown_method(self, method):
@@ -1095,7 +1084,6 @@ class TestParallelMLAAttentionPrecisionWithRopeFusion:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
-            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
     def teardown_method(self, method):
@@ -1264,7 +1252,6 @@ class TestMLAClipQK:
                 get_mla_self_attn_submodules(),
                 layer_number=1,
                 attn_mask_type=AttnMaskType.causal,
-                pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
             )
 
             with pytest.raises(ValueError, match="qk_clip option needs to be enabled"):
@@ -1278,7 +1265,6 @@ class TestMLAClipQK:
                 get_mla_self_attn_submodules(),
                 layer_number=1,
                 attn_mask_type=AttnMaskType.causal,
-                pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
             )
 
             with pytest.raises(ValueError, match="current_max_attn_logits is None"):
@@ -1294,7 +1280,6 @@ class TestMLAClipQK:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
-            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
         attention.cuda()
 
@@ -1332,7 +1317,6 @@ class TestMLAClipQK:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
-            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
         attention.cuda()
 
@@ -1370,7 +1354,6 @@ class TestMLAClipQK:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
-            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
         attention.cuda()
 
@@ -1425,7 +1408,6 @@ class TestMLAClipQK:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
-            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
         attention.cuda()
 
@@ -1909,7 +1891,6 @@ class TestFusedMLALoadFromStateDict:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
-            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
         fused = FusedMLASelfAttention(
             self.transformer_config,

--- a/tests/unit_tests/transformer/test_multi_latent_attention.py
+++ b/tests/unit_tests/transformer/test_multi_latent_attention.py
@@ -20,7 +20,6 @@ from megatron.core.models.gpt.gpt_layer_specs import (
 )
 from megatron.core.models.gpt.gpt_model import GPTModel
 from megatron.core.packed_seq_params import PackedSeqParams
-from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.attention import Attention
 from megatron.core.transformer.enums import AttnMaskType
@@ -151,7 +150,6 @@ class TestParallelMLAAttention:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
-            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
     def teardown_method(self, method):
@@ -267,7 +265,6 @@ class TestParallelMLAAttention:
                 get_mla_self_attn_submodules(),
                 layer_number=1,
                 attn_mask_type=AttnMaskType.causal,
-                pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
             )
             config = checkpointed_parallel_attention.config
 
@@ -402,7 +399,6 @@ class TestParallelMLAAttention:
                 get_mla_self_attn_submodules(),
                 layer_number=1,
                 attn_mask_type=AttnMaskType.causal,
-                pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
             )
 
             sequence_length = 32
@@ -453,7 +449,6 @@ class TestParallelMLAAttention:
                 get_mla_self_attn_submodules(),
                 layer_number=1,
                 attn_mask_type=AttnMaskType.causal,
-                pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
             )
             config = checkpointed_parallel_attention.config
 
@@ -493,7 +488,6 @@ class TestParallelMLAAttention:
                 get_mla_self_attn_submodules(),
                 layer_number=1,
                 attn_mask_type=AttnMaskType.causal,
-                pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
             )
             config = checkpointed_parallel_attention.config
 
@@ -556,7 +550,6 @@ class TestSequenceParallelMLAAttention:
             get_mla_self_attn_submodules(linear_qkv_down_proj=linear_qkv_down_proj),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
-            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
     def teardown_method(self, method):
@@ -614,7 +607,6 @@ class TestTensorParallelMLAAttention:
             get_mla_self_attn_submodules(linear_qkv_down_proj=linear_qkv_down_proj),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
-            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
     def teardown_method(self, method):
@@ -686,7 +678,6 @@ class TestContextParallelMLAAttention:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
-            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         ).bfloat16()
 
     def teardown_method(self, method):
@@ -783,7 +774,6 @@ class TestParallelMLAAttentionPrecision:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
-            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
     def teardown_method(self, method):
@@ -946,7 +936,6 @@ class TestContextParallelMLAAttentionPrecision:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
-            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         ).bfloat16()
 
     def teardown_method(self, method):
@@ -1097,7 +1086,6 @@ class TestParallelMLAAttentionPrecisionWithRopeFusion:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
-            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
     def teardown_method(self, method):
@@ -1266,7 +1254,6 @@ class TestMLAClipQK:
                 get_mla_self_attn_submodules(),
                 layer_number=1,
                 attn_mask_type=AttnMaskType.causal,
-                pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
             )
 
             with pytest.raises(ValueError, match="qk_clip option needs to be enabled"):
@@ -1280,7 +1267,6 @@ class TestMLAClipQK:
                 get_mla_self_attn_submodules(),
                 layer_number=1,
                 attn_mask_type=AttnMaskType.causal,
-                pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
             )
 
             with pytest.raises(ValueError, match="current_max_attn_logits is None"):
@@ -1296,7 +1282,6 @@ class TestMLAClipQK:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
-            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
         attention.cuda()
 
@@ -1334,7 +1319,6 @@ class TestMLAClipQK:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
-            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
         attention.cuda()
 
@@ -1372,7 +1356,6 @@ class TestMLAClipQK:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
-            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
         attention.cuda()
 
@@ -1427,7 +1410,6 @@ class TestMLAClipQK:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
-            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
         attention.cuda()
 
@@ -1912,7 +1894,6 @@ class TestFusedMLALoadFromStateDict:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
-            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
         fused = FusedMLASelfAttention(
             self.transformer_config,

--- a/tests/unit_tests/transformer/test_multi_latent_attention.py
+++ b/tests/unit_tests/transformer/test_multi_latent_attention.py
@@ -20,6 +20,7 @@ from megatron.core.models.gpt.gpt_layer_specs import (
 )
 from megatron.core.models.gpt.gpt_model import GPTModel
 from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.attention import Attention
 from megatron.core.transformer.enums import AttnMaskType
@@ -150,6 +151,7 @@ class TestParallelMLAAttention:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
     def teardown_method(self, method):
@@ -265,6 +267,7 @@ class TestParallelMLAAttention:
                 get_mla_self_attn_submodules(),
                 layer_number=1,
                 attn_mask_type=AttnMaskType.causal,
+                pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
             )
             config = checkpointed_parallel_attention.config
 
@@ -399,6 +402,7 @@ class TestParallelMLAAttention:
                 get_mla_self_attn_submodules(),
                 layer_number=1,
                 attn_mask_type=AttnMaskType.causal,
+                pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
             )
 
             sequence_length = 32
@@ -449,6 +453,7 @@ class TestParallelMLAAttention:
                 get_mla_self_attn_submodules(),
                 layer_number=1,
                 attn_mask_type=AttnMaskType.causal,
+                pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
             )
             config = checkpointed_parallel_attention.config
 
@@ -488,6 +493,7 @@ class TestParallelMLAAttention:
                 get_mla_self_attn_submodules(),
                 layer_number=1,
                 attn_mask_type=AttnMaskType.causal,
+                pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
             )
             config = checkpointed_parallel_attention.config
 
@@ -550,6 +556,7 @@ class TestSequenceParallelMLAAttention:
             get_mla_self_attn_submodules(linear_qkv_down_proj=linear_qkv_down_proj),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
     def teardown_method(self, method):
@@ -607,6 +614,7 @@ class TestTensorParallelMLAAttention:
             get_mla_self_attn_submodules(linear_qkv_down_proj=linear_qkv_down_proj),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
     def teardown_method(self, method):
@@ -678,6 +686,7 @@ class TestContextParallelMLAAttention:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         ).bfloat16()
 
     def teardown_method(self, method):
@@ -774,6 +783,7 @@ class TestParallelMLAAttentionPrecision:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
     def teardown_method(self, method):
@@ -936,6 +946,7 @@ class TestContextParallelMLAAttentionPrecision:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         ).bfloat16()
 
     def teardown_method(self, method):
@@ -1086,6 +1097,7 @@ class TestParallelMLAAttentionPrecisionWithRopeFusion:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
     def teardown_method(self, method):
@@ -1254,6 +1266,7 @@ class TestMLAClipQK:
                 get_mla_self_attn_submodules(),
                 layer_number=1,
                 attn_mask_type=AttnMaskType.causal,
+                pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
             )
 
             with pytest.raises(ValueError, match="qk_clip option needs to be enabled"):
@@ -1267,6 +1280,7 @@ class TestMLAClipQK:
                 get_mla_self_attn_submodules(),
                 layer_number=1,
                 attn_mask_type=AttnMaskType.causal,
+                pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
             )
 
             with pytest.raises(ValueError, match="current_max_attn_logits is None"):
@@ -1282,6 +1296,7 @@ class TestMLAClipQK:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
         attention.cuda()
 
@@ -1319,6 +1334,7 @@ class TestMLAClipQK:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
         attention.cuda()
 
@@ -1356,6 +1372,7 @@ class TestMLAClipQK:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
         attention.cuda()
 
@@ -1410,6 +1427,7 @@ class TestMLAClipQK:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
         attention.cuda()
 
@@ -1894,6 +1912,7 @@ class TestFusedMLALoadFromStateDict:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
         fused = FusedMLASelfAttention(
             self.transformer_config,

--- a/tests/unit_tests/transformer/test_multi_latent_attention.py
+++ b/tests/unit_tests/transformer/test_multi_latent_attention.py
@@ -20,6 +20,7 @@ from megatron.core.models.gpt.gpt_layer_specs import (
 )
 from megatron.core.models.gpt.gpt_model import GPTModel
 from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.attention import Attention
 from megatron.core.transformer.enums import AttnMaskType
@@ -150,6 +151,7 @@ class TestParallelMLAAttention:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
     def teardown_method(self, method):
@@ -265,6 +267,7 @@ class TestParallelMLAAttention:
                 get_mla_self_attn_submodules(),
                 layer_number=1,
                 attn_mask_type=AttnMaskType.causal,
+                pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
             )
             config = checkpointed_parallel_attention.config
 
@@ -399,6 +402,7 @@ class TestParallelMLAAttention:
                 get_mla_self_attn_submodules(),
                 layer_number=1,
                 attn_mask_type=AttnMaskType.causal,
+                pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
             )
 
             sequence_length = 32
@@ -449,6 +453,7 @@ class TestParallelMLAAttention:
                 get_mla_self_attn_submodules(),
                 layer_number=1,
                 attn_mask_type=AttnMaskType.causal,
+                pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
             )
             config = checkpointed_parallel_attention.config
 
@@ -488,6 +493,7 @@ class TestParallelMLAAttention:
                 get_mla_self_attn_submodules(),
                 layer_number=1,
                 attn_mask_type=AttnMaskType.causal,
+                pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
             )
             config = checkpointed_parallel_attention.config
 
@@ -550,6 +556,7 @@ class TestSequenceParallelMLAAttention:
             get_mla_self_attn_submodules(linear_qkv_down_proj=linear_qkv_down_proj),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
     def teardown_method(self, method):
@@ -607,6 +614,7 @@ class TestTensorParallelMLAAttention:
             get_mla_self_attn_submodules(linear_qkv_down_proj=linear_qkv_down_proj),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
     def teardown_method(self, method):
@@ -678,6 +686,7 @@ class TestContextParallelMLAAttention:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         ).bfloat16()
 
     def teardown_method(self, method):
@@ -774,6 +783,7 @@ class TestParallelMLAAttentionPrecision:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
     def teardown_method(self, method):
@@ -936,6 +946,7 @@ class TestContextParallelMLAAttentionPrecision:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         ).bfloat16()
 
     def teardown_method(self, method):
@@ -1086,6 +1097,7 @@ class TestParallelMLAAttentionPrecisionWithRopeFusion:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
     def teardown_method(self, method):
@@ -1254,6 +1266,7 @@ class TestMLAClipQK:
                 get_mla_self_attn_submodules(),
                 layer_number=1,
                 attn_mask_type=AttnMaskType.causal,
+                pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
             )
 
             with pytest.raises(ValueError, match="qk_clip option needs to be enabled"):
@@ -1267,6 +1280,7 @@ class TestMLAClipQK:
                 get_mla_self_attn_submodules(),
                 layer_number=1,
                 attn_mask_type=AttnMaskType.causal,
+                pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
             )
 
             with pytest.raises(ValueError, match="current_max_attn_logits is None"):
@@ -1282,6 +1296,7 @@ class TestMLAClipQK:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
         attention.cuda()
 
@@ -1319,6 +1334,7 @@ class TestMLAClipQK:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
         attention.cuda()
 
@@ -1356,6 +1372,7 @@ class TestMLAClipQK:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
         attention.cuda()
 
@@ -1410,6 +1427,7 @@ class TestMLAClipQK:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
         attention.cuda()
 
@@ -1693,6 +1711,7 @@ class TestFusedMLASelfAttention:
             get_fused_mla_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
     def teardown_method(self, method):
@@ -1840,7 +1859,11 @@ class TestFusedMLAGradientFlow:
 
         config = self.transformer_config
         fused = FusedMLASelfAttention(
-            config, get_fused_mla_submodules(), layer_number=1, attn_mask_type=AttnMaskType.causal
+            config,
+            get_fused_mla_submodules(),
+            layer_number=1,
+            attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
         fused.cuda()
 
@@ -1894,12 +1917,14 @@ class TestFusedMLALoadFromStateDict:
             get_mla_self_attn_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
         fused = FusedMLASelfAttention(
             self.transformer_config,
             get_fused_mla_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
         unfused_sd = unfused.state_dict()
@@ -1929,6 +1954,7 @@ class TestFusedMLALoadFromStateDict:
             get_fused_mla_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
         sharded_sd = fused.sharded_state_dict(prefix="")
@@ -2046,6 +2072,7 @@ class TestFusedMLARequiresQLora:
                 get_fused_mla_submodules(),
                 layer_number=1,
                 attn_mask_type=AttnMaskType.causal,
+                pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
             )
 
 

--- a/tests/unit_tests/transformer/test_multi_latent_attention.py
+++ b/tests/unit_tests/transformer/test_multi_latent_attention.py
@@ -1977,6 +1977,7 @@ class TestFusedMLALoadFromStateDict:
             get_fused_mla_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
         seen = []
 
@@ -2001,6 +2002,7 @@ class TestFusedMLALoadFromStateDict:
             get_fused_mla_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
 
         sharded_sd = fused.sharded_state_dict(prefix="")
@@ -2020,6 +2022,7 @@ class TestFusedMLALoadFromStateDict:
             get_fused_mla_submodules(),
             layer_number=1,
             attn_mask_type=AttnMaskType.causal,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
         config = self.transformer_config
         q_weight = torch.randn(config.q_lora_rank, config.hidden_size)

--- a/tests/unit_tests/transformer/test_multi_latent_attention.py
+++ b/tests/unit_tests/transformer/test_multi_latent_attention.py
@@ -2275,6 +2275,7 @@ class TestFusedMLAQUpProjIntegration:
                     get_mla_self_attn_submodules(),
                     layer_number=1,
                     attn_mask_type=AttnMaskType.causal,
+                    pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
                 )
                 .cuda()
                 .bfloat16()

--- a/tests/unit_tests/transformer/test_multi_token_prediction.py
+++ b/tests/unit_tests/transformer/test_multi_token_prediction.py
@@ -105,7 +105,11 @@ class TestMultiTokenPredictionLayer:
         mtp_block_spec = get_gpt_mtp_block_spec(
             config=config, spec=transformer_layer_spec, use_transformer_engine=False
         )
-        mtp = MultiTokenPredictionBlock(config=config, spec=mtp_block_spec)
+        mtp = MultiTokenPredictionBlock(
+            config=config,
+            spec=mtp_block_spec,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(required_pgs=['cp', 'tp']),
+        )
 
         assert isinstance(mtp, MultiTokenPredictionBlock)
         assert mtp.config.mtp_detach_heads is True
@@ -122,7 +126,11 @@ class TestMultiTokenPredictionLayer:
 
         torch.manual_seed(_SEED)
         config, mtp_block_spec = self._create_config_and_mtp_block_spec(tp, cp=1)
-        mtp = MultiTokenPredictionBlock(config=config, spec=mtp_block_spec)
+        mtp = MultiTokenPredictionBlock(
+            config=config,
+            spec=mtp_block_spec,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(required_pgs=['cp', 'tp']),
+        )
 
         assert isinstance(mtp, MultiTokenPredictionBlock)
         assert len(mtp.layers) == config.mtp_num_layers
@@ -148,7 +156,11 @@ class TestMultiTokenPredictionLayer:
         torch.manual_seed(_SEED)
         Utils.initialize_model_parallel(tensor_model_parallel_size=tp, context_parallel_size=cp)
         config, mtp_block_spec = self._create_config_and_mtp_block_spec(tp, cp, use_te=True)
-        mtp = MultiTokenPredictionBlock(config=config, spec=mtp_block_spec)
+        mtp = MultiTokenPredictionBlock(
+            config=config,
+            spec=mtp_block_spec,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(required_pgs=['cp', 'tp']),
+        )
 
         assert isinstance(mtp, MultiTokenPredictionBlock)
         assert len(mtp.layers) == config.mtp_num_layers
@@ -171,7 +183,11 @@ class TestMultiTokenPredictionLayer:
         """Test that _get_embeddings rolls padding_mask alongside input ids."""
         torch.manual_seed(_SEED)
         config, mtp_block_spec = self._create_config_and_mtp_block_spec(tp=1, cp=1)
-        mtp = MultiTokenPredictionBlock(config=config, spec=mtp_block_spec)
+        mtp = MultiTokenPredictionBlock(
+            config=config,
+            spec=mtp_block_spec,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(required_pgs=['cp', 'tp']),
+        )
         mtp_layer = mtp.layers[0]
 
         seq_len = 6
@@ -209,7 +225,11 @@ class TestMultiTokenPredictionLayer:
         """Test forward passes rolled padding_mask to transformer path."""
         torch.manual_seed(_SEED)
         config, mtp_block_spec = self._create_config_and_mtp_block_spec(tp=1, cp=1)
-        mtp = MultiTokenPredictionBlock(config=config, spec=mtp_block_spec)
+        mtp = MultiTokenPredictionBlock(
+            config=config,
+            spec=mtp_block_spec,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(required_pgs=['cp', 'tp']),
+        )
         mtp_layer = mtp.layers[0]
 
         seq_len = 4
@@ -269,7 +289,11 @@ class TestMultiTokenPredictionLayer:
         torch.manual_seed(_SEED)
         config, mtp_block_spec = self._create_config_and_mtp_block_spec(tp=1, cp=1)
         config.mtp_detach_heads = True
-        mtp = MultiTokenPredictionBlock(config=config, spec=mtp_block_spec)
+        mtp = MultiTokenPredictionBlock(
+            config=config,
+            spec=mtp_block_spec,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(required_pgs=['cp', 'tp']),
+        )
         mtp_layer = mtp.layers[0]
 
         seq_len = 4
@@ -308,7 +332,11 @@ class TestMultiTokenPredictionLayer:
         config.mtp_detach_heads = detach_heads
         # Runs on GPU because _concat_embeddings exercises the (fused) norm and
         # projection kernels; the rest of the MTP transformer layer is stubbed out.
-        mtp = MultiTokenPredictionBlock(config=config, spec=mtp_block_spec).cuda()
+        mtp = MultiTokenPredictionBlock(
+            config=config,
+            spec=mtp_block_spec,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(required_pgs=['cp', 'tp']),
+        ).cuda()
 
         # Replace each MTP transformer layer with an identity so the test isolates
         # gradient flow to the detach logic (not the attention kernels). Must be an

--- a/tests/unit_tests/transformer/test_multi_token_prediction.py
+++ b/tests/unit_tests/transformer/test_multi_token_prediction.py
@@ -564,7 +564,13 @@ class TestMultiTokenPredictionLayer:
         mtp_block_spec = get_gpt_mtp_block_spec(
             config=config, spec=transformer_layer_spec, use_transformer_engine=False
         )
-        mtp = MultiTokenPredictionBlock(config=config, spec=mtp_block_spec)
+        mtp = MultiTokenPredictionBlock(
+            config=config,
+            spec=mtp_block_spec,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=['cp', 'tp', 'pp']
+            ),
+        )
 
         assert isinstance(mtp, MultiTokenPredictionBlock)
         assert mtp.config.mtp_detach_heads is True
@@ -581,7 +587,13 @@ class TestMultiTokenPredictionLayer:
 
         torch.manual_seed(_SEED)
         config, mtp_block_spec = self._create_config_and_mtp_block_spec(tp, cp=1)
-        mtp = MultiTokenPredictionBlock(config=config, spec=mtp_block_spec)
+        mtp = MultiTokenPredictionBlock(
+            config=config,
+            spec=mtp_block_spec,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=['cp', 'tp', 'pp']
+            ),
+        )
 
         assert isinstance(mtp, MultiTokenPredictionBlock)
         assert len(mtp.layers) == config.mtp_num_layers
@@ -607,7 +619,13 @@ class TestMultiTokenPredictionLayer:
         torch.manual_seed(_SEED)
         Utils.initialize_model_parallel(tensor_model_parallel_size=tp, context_parallel_size=cp)
         config, mtp_block_spec = self._create_config_and_mtp_block_spec(tp, cp, use_te=True)
-        mtp = MultiTokenPredictionBlock(config=config, spec=mtp_block_spec)
+        mtp = MultiTokenPredictionBlock(
+            config=config,
+            spec=mtp_block_spec,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=['cp', 'tp', 'pp']
+            ),
+        )
 
         assert isinstance(mtp, MultiTokenPredictionBlock)
         assert len(mtp.layers) == config.mtp_num_layers
@@ -630,7 +648,13 @@ class TestMultiTokenPredictionLayer:
         """Test that _get_embeddings rolls padding_mask alongside input ids."""
         torch.manual_seed(_SEED)
         config, mtp_block_spec = self._create_config_and_mtp_block_spec(tp=1, cp=1)
-        mtp = MultiTokenPredictionBlock(config=config, spec=mtp_block_spec)
+        mtp = MultiTokenPredictionBlock(
+            config=config,
+            spec=mtp_block_spec,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=['cp', 'tp', 'pp']
+            ),
+        )
         mtp_layer = mtp.layers[0]
 
         seq_len = 6
@@ -765,7 +789,13 @@ class TestMultiTokenPredictionLayer:
         """Test forward passes rolled padding_mask to transformer path."""
         torch.manual_seed(_SEED)
         config, mtp_block_spec = self._create_config_and_mtp_block_spec(tp=1, cp=1)
-        mtp = MultiTokenPredictionBlock(config=config, spec=mtp_block_spec)
+        mtp = MultiTokenPredictionBlock(
+            config=config,
+            spec=mtp_block_spec,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=['cp', 'tp', 'pp']
+            ),
+        )
         mtp_layer = mtp.layers[0]
 
         seq_len = 4
@@ -827,7 +857,13 @@ class TestMultiTokenPredictionLayer:
         torch.manual_seed(_SEED)
         config, mtp_block_spec = self._create_config_and_mtp_block_spec(tp=1, cp=1)
         config.mtp_detach_heads = True
-        mtp = MultiTokenPredictionBlock(config=config, spec=mtp_block_spec)
+        mtp = MultiTokenPredictionBlock(
+            config=config,
+            spec=mtp_block_spec,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=['cp', 'tp', 'pp']
+            ),
+        )
         mtp_layer = mtp.layers[0]
 
         seq_len = 4
@@ -924,7 +960,13 @@ class TestMultiTokenPredictionLayer:
         config.mtp_detach_heads = detach_heads
         # Runs on GPU because _concat_embeddings exercises the (fused) norm and
         # projection kernels; the rest of the MTP transformer layer is stubbed out.
-        mtp = MultiTokenPredictionBlock(config=config, spec=mtp_block_spec).cuda()
+        mtp = MultiTokenPredictionBlock(
+            config=config,
+            spec=mtp_block_spec,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=['cp', 'tp', 'pp']
+            ),
+        ).cuda()
 
         # Replace each MTP transformer layer with an identity so the test isolates
         # gradient flow to the detach logic (not the attention kernels). Must be an

--- a/tests/unit_tests/transformer/test_multi_token_prediction.py
+++ b/tests/unit_tests/transformer/test_multi_token_prediction.py
@@ -693,7 +693,13 @@ class TestMultiTokenPredictionLayer:
         """Conditioning validity shares the token-ID roll instead of adding an exchange."""
         torch.manual_seed(_SEED)
         config, mtp_block_spec = self._create_config_and_mtp_block_spec(tp=1, cp=1)
-        mtp_layer = MultiTokenPredictionBlock(config=config, spec=mtp_block_spec).layers[0]
+        mtp_layer = MultiTokenPredictionBlock(
+            config=config,
+            spec=mtp_block_spec,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=['cp', 'tp', 'pp']
+            ),
+        ).layers[0]
         input_ids = torch.tensor([[1, 2, 3, 4]], dtype=torch.int64)
         position_ids = torch.arange(input_ids.size(1), dtype=torch.int64).unsqueeze(0)
         hidden_states = torch.randn(input_ids.size(1), 1, config.hidden_size)
@@ -727,7 +733,13 @@ class TestMultiTokenPredictionLayer:
         """Packed CP rolling keeps token IDs and their validity exactly aligned."""
         torch.manual_seed(_SEED)
         config, mtp_block_spec = self._create_config_and_mtp_block_spec(tp=1, cp=cp, use_te=cp > 1)
-        mtp = MultiTokenPredictionBlock(config=config, spec=mtp_block_spec)
+        mtp = MultiTokenPredictionBlock(
+            config=config,
+            spec=mtp_block_spec,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=['cp', 'tp', 'pp']
+            ),
+        )
         mtp_layer = mtp.layers[0]
         cp_group = get_context_parallel_group() if cp > 1 else None
         cp_rank = torch.distributed.get_rank(group=cp_group) if cp_group is not None else 0
@@ -912,7 +924,13 @@ class TestMultiTokenPredictionLayer:
         torch.manual_seed(_SEED)
         config, mtp_block_spec = self._create_config_and_mtp_block_spec(tp=1, cp=1)
         config.sequence_parallel = True
-        mtp = MultiTokenPredictionBlock(config=config, spec=mtp_block_spec)
+        mtp = MultiTokenPredictionBlock(
+            config=config,
+            spec=mtp_block_spec,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=['cp', 'tp', 'pp']
+            ),
+        )
         mtp_layer = mtp.layers[0]
 
         seq_len = 4
@@ -1047,7 +1065,13 @@ class TestMultiTokenPredictionLayer:
         mtp_block_spec = get_gpt_mtp_block_spec(
             config=config, spec=layer_spec, use_transformer_engine=False
         )
-        mtp = MultiTokenPredictionBlock(config=config, spec=mtp_block_spec).cuda()
+        mtp = MultiTokenPredictionBlock(
+            config=config,
+            spec=mtp_block_spec,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(
+                required_pgs=['cp', 'tp', 'pp']
+            ),
+        ).cuda()
 
         vocab_size = 16
         invalid_token_ids = (9, 10)

--- a/tests/unit_tests/transformer/test_rope.py
+++ b/tests/unit_tests/transformer/test_rope.py
@@ -3,6 +3,7 @@
 import pytest
 import torch
 
+from megatron.core import parallel_state
 from megatron.core.models.common.embeddings import apply_rotary_pos_emb
 from megatron.core.models.common.embeddings.rotary_pos_embedding import (
     MultimodalRotaryEmbedding,
@@ -27,7 +28,11 @@ class TestMultimodalRotaryEmbedding:
         model_parallel_cuda_manual_seed(123)
         self.kv_channels = 128
         self.rotary_percent = 1.0
-        self.rope_gpu_init = MultimodalRotaryEmbedding(self.kv_channels, self.rotary_percent)
+        self.rope_gpu_init = MultimodalRotaryEmbedding(
+            self.kv_channels,
+            self.rotary_percent,
+            cp_group=parallel_state.get_context_parallel_group(check_initialized=False),
+        )
 
     def teardown_method(self, method):
         del self.rope_gpu_init
@@ -56,10 +61,16 @@ class TestRotaryEmbedding:
         self.kv_channels = 8
         self.rotary_percent = 1.0
         self.rope_cpu_init = RotaryEmbedding(
-            self.kv_channels, self.rotary_percent, use_cpu_initialization=True
+            self.kv_channels,
+            self.rotary_percent,
+            use_cpu_initialization=True,
+            cp_group=parallel_state.get_context_parallel_group(check_initialized=False),
         )
         self.rope_gpu_init = RotaryEmbedding(
-            self.kv_channels, self.rotary_percent, use_cpu_initialization=False
+            self.kv_channels,
+            self.rotary_percent,
+            use_cpu_initialization=False,
+            cp_group=parallel_state.get_context_parallel_group(check_initialized=False),
         )
 
     def teardown_method(self, method):
@@ -104,7 +115,10 @@ class TestQKVRotaryEmbedding:
         self.kv_channels = 128
         self.rotary_percent = 1.0
         self.rope_gpu_init = RotaryEmbedding(
-            self.kv_channels, self.rotary_percent, use_cpu_initialization=False
+            self.kv_channels,
+            self.rotary_percent,
+            use_cpu_initialization=False,
+            cp_group=parallel_state.get_context_parallel_group(check_initialized=False),
         )
         self.transformer_config = TransformerConfig(
             num_attention_heads=self.num_heads, num_layers=1, apply_rope_fusion=True

--- a/tests/unit_tests/transformer/test_rope.py
+++ b/tests/unit_tests/transformer/test_rope.py
@@ -3,6 +3,7 @@
 import pytest
 import torch
 
+from megatron.core import parallel_state
 from megatron.core.models.common.embeddings import apply_rotary_pos_emb
 from megatron.core.models.common.embeddings.rotary_pos_embedding import (
     MultimodalRotaryEmbedding,
@@ -27,7 +28,11 @@ class TestMultimodalRotaryEmbedding:
         model_parallel_cuda_manual_seed(123)
         self.kv_channels = 128
         self.rotary_percent = 1.0
-        self.rope_gpu_init = MultimodalRotaryEmbedding(self.kv_channels, self.rotary_percent)
+        self.rope_gpu_init = MultimodalRotaryEmbedding(
+            self.kv_channels,
+            self.rotary_percent,
+            cp_group=parallel_state.get_context_parallel_group(check_initialized=False),
+        )
 
     def teardown_method(self, method):
         del self.rope_gpu_init
@@ -56,10 +61,16 @@ class TestRotaryEmbedding:
         self.kv_channels = 8
         self.rotary_percent = 1.0
         self.rope_cpu_init = RotaryEmbedding(
-            self.kv_channels, self.rotary_percent, use_cpu_initialization=True
+            self.kv_channels,
+            self.rotary_percent,
+            use_cpu_initialization=True,
+            cp_group=parallel_state.get_context_parallel_group(check_initialized=False),
         )
         self.rope_gpu_init = RotaryEmbedding(
-            self.kv_channels, self.rotary_percent, use_cpu_initialization=False
+            self.kv_channels,
+            self.rotary_percent,
+            use_cpu_initialization=False,
+            cp_group=parallel_state.get_context_parallel_group(check_initialized=False),
         )
 
     def teardown_method(self, method):
@@ -117,7 +128,10 @@ class TestQKVRotaryEmbedding:
         self.kv_channels = 128
         self.rotary_percent = 1.0
         self.rope_gpu_init = RotaryEmbedding(
-            self.kv_channels, self.rotary_percent, use_cpu_initialization=False
+            self.kv_channels,
+            self.rotary_percent,
+            use_cpu_initialization=False,
+            cp_group=parallel_state.get_context_parallel_group(check_initialized=False),
         )
         self.transformer_config = TransformerConfig(
             num_attention_heads=self.num_heads, num_layers=1, apply_rope_fusion=True

--- a/tests/unit_tests/transformer/test_vision_cuda_graphs.py
+++ b/tests/unit_tests/transformer/test_vision_cuda_graphs.py
@@ -18,6 +18,7 @@ from megatron.core.num_microbatches_calculator import (
     destroy_num_microbatches_calculator,
     init_num_microbatches_calculator,
 )
+from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import (
     HAVE_TE,
     initialize_rng_tracker,
@@ -271,6 +272,7 @@ class TestVisionTECudaGraphHelper:
             post_process=True,
             add_encoder=True,
             add_decoder=True,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
         self.llava_model.bfloat16()
 
@@ -538,6 +540,7 @@ class TestVisionTECudaGraphHelperPP2:
             post_process=is_last_stage,
             add_encoder=is_first_stage,
             add_decoder=True,
+            pg_collection=ProcessGroupCollection.use_mpu_process_groups(),
         )
         self.llava_model.bfloat16()
 


### PR DESCRIPTION
Core attention, transformer, model, and inference paths still read the global parallel grid when callers omit process groups. Require explicit collections at the migrated constructors and carry caller-owned groups through those paths. The base `LanguageModule` compatibility fallback remains; #6303 is the separate follow-up that makes that collection mandatory.

Refreshed through main `64d156734918e73238de5cad6d97dcfaa6ec1005`. This preserves current checkpoint, GTP, MTP, and multimodal behavior while updating affected callers. Six new LLaVA vision-CP calls needed explicit groups: three omitted the required argument, and three accidentally bound the padding count to the new group parameter. Pass the owning CP group by keyword, retain the padding argument separately, migrate new helper tests, and cover static, dynamic, and temporal vision paths with global CP access forbidden.

The migration also replaces ineffective `hasattr` checks with actual collection-membership or usable-group validation. T5 forwards its collection through the base, embedding, and output layers and validates tied pipeline endpoints; that prerequisite is isolated in #7487 and should land first.

Validation for this refresh:

- Repository formatting/lint passes. Mypy is advisory and remains non-clean.
- Ten source-isolated test cases pass on each of two real CPU/Gloo ranks, using actual forward/preprocessing/helper methods, real tensors, and real collectives. Six CP cases fail at the expected missing-group error in the preserved pre-fix merged source. Tests check supplied-group identity, static padding removal, dynamic partitioning, and all three temporal gathers with exact output/media-count comparisons. Unrelated import dependencies are substituted; this is not full-runtime or GPU acceptance.
- A paired four-GB200 comparison of this head against exact main `64d156734918e73238de5cad6d97dcfaa6ec1005` passes all 15 shared cases on every rank: dynamic vision preprocessing, profiling-group selection, partition logging, and distributed CP helpers. Both additional candidate static/temporal regressions pass on every rank. This uses actual repository imports/fixtures and CUDA/NCCL collectives; all test phases, selected IDs, rank counts, matching environments, and source manifests before/after execution are verified. It is cached nv26.04 compatibility evidence (PyTorch 2.12 development build/TE 2.14), separate from current CI acceptance.
- Earlier four-GPU comparisons and T5 validation belong to their recorded older revisions. The preceding frozen combined snapshot also passes its nine-case attention/LLaVA selection and T5 comparison on eight ranks; that evidence does not establish the later changes in this head. Broader current-head constructor coverage, current CI, and downstream acceptance remain pending.

Inventory remains 162 direct reads across 43 files, versus 211 across 54 files on current main. These are syntactic counts, not proof of complete independent-grid coverage. When #6258 lands, its strict ratchet needs reviewed allowlist substitutions for the export-converter and inference-config compatibility boundaries, plus removal of stale entries.

Keep this PR in draft until its constructor-contract validation and downstream review are complete. Related to #6307.
