### PR TITLE
Execute direct hybrid layers across PP and VPP

### DIFF
--- a/megatron/core/models/hybrid/hybrid_block.py
+++ b/megatron/core/models/hybrid/hybrid_block.py
@@ -8,7 +8,7 @@
 import copy
 from contextlib import nullcontext
 from dataclasses import dataclass
-from typing import Optional, Tuple, Union
+from typing import Optional, Sequence, Tuple, Union
 
 import torch
 from torch import Tensor, nn
@@ -21,6 +21,7 @@ from megatron.core.fp4_utils import get_fp4_context
 from megatron.core.fp8_utils import get_fp8_context
 from megatron.core.inference.contexts import BaseInferenceContext
 from megatron.core.inference.utils import InferenceMode
+from megatron.core.models.hybrid.hybrid_architecture import HybridLayerSpec
 from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols as LayerSymbols
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.process_groups_config import ProcessGroupCollection
@@ -91,6 +92,7 @@ class HybridStack(MegatronModule):
         pg_collection: ProcessGroupCollection = None,
         is_mtp_layer: bool = False,
         name: str | None = None,
+        layer_specs: Optional[Sequence[HybridLayerSpec]] = None,
     ) -> None:
         """
         Args:
@@ -111,18 +113,73 @@ class HybridStack(MegatronModule):
         self.input_tensor = None
         self.pg_collection = pg_collection
 
-        assert layer_type_list is not None, (
-            "layer_type_list must be provided. It should be pre-computed from "
-            "--hybrid-layer-pattern by HybridModel."
-        )
-        self.layer_type_list = layer_type_list
+        if layer_specs is None:
+            assert layer_type_list is not None, (
+                "layer_type_list must be provided. It should be pre-computed from "
+                "--hybrid-layer-pattern by HybridModel."
+            )
+            self.layer_type_list = layer_type_list
+            if getattr(self.config, "mla_down_proj_fusion", False):
+                submodules = self._fuse_mla_down_proj(submodules)
+            self.layers = self._build_legacy_layers(
+                submodules=submodules,
+                layer_type_list=layer_type_list,
+                pp_layer_offset=pp_layer_offset,
+                pg_collection=pg_collection,
+                is_mtp_layer=is_mtp_layer,
+                name=name,
+            )
+        else:
+            if layer_type_list is not None:
+                raise ValueError("Specify layer_specs or layer_type_list, not both.")
+            layer_specs = list(layer_specs)
+            if getattr(self.config, "mla_down_proj_fusion", False):
+                layer_specs = [
+                    (
+                        HybridLayerSpec(self._fuse_mla_layer_spec(spec.module_spec), spec.config)
+                        if spec.layer_type == "mla"
+                        else spec
+                    )
+                    for spec in layer_specs
+                ]
+            self.layer_specs = layer_specs
+            self.layer_type_list = [layer.layer_type for layer in layer_specs]
+            self.layers = self._build_direct_layers(
+                layer_specs=layer_specs,
+                pp_layer_offset=pp_layer_offset,
+                pg_collection=pg_collection,
+                is_mtp_layer=is_mtp_layer,
+                name=name,
+            )
 
-        if getattr(self.config, "mla_down_proj_fusion", False):
-            submodules = self._fuse_mla_down_proj(submodules)
+        if self.config.cuda_graph_impl == "local":
+            annotate_first_last_layer(self.layers)
 
-        # Build layers from the pre-selected segment
-        self.layers = nn.ModuleList()
-        for i, layer_type in enumerate(self.layer_type_list):
+        # Required for activation recomputation
+        self.num_layers_per_pipeline_rank = len(self.layers)
+
+        if self.post_process and self.post_layer_norm:
+            # Final layer norm before output.
+            self.final_norm = TENorm(
+                config=self.config,
+                hidden_size=self.config.hidden_size,
+                eps=self.config.layernorm_epsilon,
+            )
+
+    def _build_legacy_layers(
+        self,
+        *,
+        submodules: HybridStackSubmodules,
+        layer_type_list: list[str],
+        pp_layer_offset: int,
+        pg_collection: ProcessGroupCollection,
+        is_mtp_layer: bool,
+        name: str | None,
+    ) -> nn.ModuleList:
+        """Build the legacy symbol API with its historical per-family kwargs."""
+
+        layers = nn.ModuleList()
+        for i, layer_type in enumerate(layer_type_list):
             layer_number = i + 1 + pp_layer_offset
             if self.config.fp8:
                 quant_init_context = get_fp8_context(self.config, i + pp_layer_offset, is_init=True)
@@ -196,33 +253,69 @@ class HybridStack(MegatronModule):
                         config=self.config,
                         layer_number=layer_number,
                         pg_collection=pg_collection,
-                        # Set to False as we do not want to change offset.
                         add_layer_offset=False,
                         name=(name + f".layers.{i}") if name is not None else None,
                     )
                 else:
                     raise ValueError("unexpected layer_type")
-            self.layers.append(layer)
+            layers.append(layer)
+        return layers
 
-        if self.config.cuda_graph_impl == "local":
-            annotate_first_last_layer(self.layers)
+    def _build_direct_layers(
+        self,
+        *,
+        layer_specs: Sequence[HybridLayerSpec],
+        pp_layer_offset: int,
+        pg_collection: ProcessGroupCollection,
+        is_mtp_layer: bool,
+        name: str | None,
+    ) -> nn.ModuleList:
+        """Build occurrence-specific existing layer specs."""
 
-        # Required for activation recomputation
-        self.num_layers_per_pipeline_rank = len(self.layers)
-
-        if self.post_process and self.post_layer_norm:
-            # Final layer norm before output.
-            self.final_norm = TENorm(
-                config=self.config,
-                hidden_size=self.config.hidden_size,
-                eps=self.config.layernorm_epsilon,
-            )
+        layers = nn.ModuleList()
+        for i, layer_spec in enumerate(layer_specs):
+            layer_type = layer_spec.layer_type
+            layer_config = layer_spec.config
+            layer_number = i + 1 + pp_layer_offset
+            if layer_config.fp8:
+                quant_init_context = get_fp8_context(
+                    layer_config, i + pp_layer_offset, is_init=True
+                )
+            elif layer_config.fp4:
+                quant_init_context = get_fp4_context(
+                    layer_config, i + pp_layer_offset, is_init=True
+                )
+            else:
+                quant_init_context = nullcontext()
+            with quant_init_context:
+                build_kwargs = {
+                    "config": layer_config,
+                    "layer_number": layer_number,
+                    "pg_collection": pg_collection,
+                    "name": (name + f".layers.{i}") if name is not None else None,
+                }
+                if layer_type == "mamba":
+                    build_kwargs["pp_layer_offset"] = pp_layer_offset
+                else:
+                    build_kwargs["add_layer_offset"] = False
+                    if layer_type in {"attention", "dsa", "mla"}:
+                        build_kwargs["is_mtp_layer"] = is_mtp_layer
+                        build_kwargs["pp_layer_offset"] = pp_layer_offset
+                layer = build_module(layer_spec.module_spec, **build_kwargs)
+            layers.append(layer)
+        return layers
 
     def _fuse_mla_down_proj(self, submodules: HybridStackSubmodules) -> HybridStackSubmodules:
         # Avoid modifying the original object so users don't get surprised about their `submodules`
         # being modified underneath them.
         submodules = copy.deepcopy(submodules)
-        mla_spec = submodules.mla_layer
+        submodules.mla_layer = self._fuse_mla_layer_spec(submodules.mla_layer)
+        return submodules
+
+    def _fuse_mla_layer_spec(self, mla_spec: ModuleSpec) -> ModuleSpec:
+        """Return a private MLA spec with fused down projections enabled."""
+
+        mla_spec = copy.deepcopy(mla_spec)
         # We always fuse the input layernorm because Hybrid always uses TransformerEngine.
         mla_spec.submodules.input_layernorm = IdentityOp
         mla_spec.submodules.self_attention.module = FusedMLASelfAttention
@@ -236,7 +329,7 @@ class HybridStack(MegatronModule):
             "self_attention.linear_kv_down_proj.layer_norm_": "input_layernorm.",
             "self_attention.linear_qkv_down_proj.layer_norm_": "input_layernorm.",
         }
-        return submodules
+        return mla_spec
 
     def set_input_tensor(self, input_tensor: Tensor):
         """Set input tensor to be used instead of forward()'s input.
@@ -254,7 +347,7 @@ class HybridStack(MegatronModule):
         if this block contains Mamba layers (this may not be the case with PP > 1).
         """
         for layer_type, layer in zip(self.layer_type_list, self.layers):
-            if layer_type == LayerSymbols.MAMBA:
+            if layer_type in {LayerSymbols.MAMBA, "mamba"}:
                 return layer.mamba_state_shapes_per_request()
         return None
 
@@ -359,18 +452,29 @@ class HybridStack(MegatronModule):
                     use_inner_quantization_context=(use_inner_fp8_context or use_fp4_context),
                 )
             else:
-                for layer in self.layers:
+                layer_specs = getattr(self, "layer_specs", None)
+                for index, layer in enumerate(self.layers):
+                    layer_spec = layer_specs[index] if layer_specs is not None else None
+                    layer_config = layer_spec.config if layer_spec is not None else self.config
                     # Layers have 1-indexed layer numbers attribute.
                     inner_quant_context = get_inner_quant_context(
-                        self.config, layer.layer_number - 1
+                        layer_config, layer.layer_number - 1
                     )
+                    layer_rotary_pos_emb = rotary_pos_emb
+                    if isinstance(rotary_pos_emb, dict):
+                        assert layer_spec is not None
+                        layer_rotary_pos_emb = (
+                            rotary_pos_emb.get(layer_spec.config.kv_channels)
+                            if layer_spec.layer_type == "attention"
+                            else None
+                        )
                     with inner_quant_context:
                         if isinstance(layer, TransformerLayer):
                             hidden_states, _ = layer(
                                 hidden_states=hidden_states,
                                 attention_mask=attention_mask,
                                 inference_context=inference_context,
-                                rotary_pos_emb=rotary_pos_emb,
+                                rotary_pos_emb=layer_rotary_pos_emb,
                                 sequence_len_offset=sequence_len_offset,
                                 packed_seq_params=packed_seq_params,
                                 padding_mask=padding_mask,

--- a/megatron/core/models/hybrid/hybrid_model.py
+++ b/megatron/core/models/hybrid/hybrid_model.py
@@ -3,6 +3,7 @@
 import logging
 from typing import Literal, Optional
 
+import torch
 from torch import Tensor
 
 from megatron.core import tensor_parallel
@@ -13,6 +14,11 @@ from megatron.core.models.common.embeddings.language_model_embedding import Lang
 from megatron.core.models.common.embeddings.rotary_pos_embedding import RotaryEmbedding
 from megatron.core.models.common.embeddings.yarn_rotary_pos_embedding import YarnRotaryEmbedding
 from megatron.core.models.common.language_module.language_module import LanguageModule
+from megatron.core.models.hybrid.hybrid_architecture import (
+    HybridLayerPattern,
+    ResolvedHybridArchitecture,
+    resolve_hybrid_architecture,
+)
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
     FineGrainedActivationOffloadingInterface as off_interface,
@@ -33,6 +39,8 @@ from megatron.core.transformer.spec_utils import ModuleSpec, build_module
 from megatron.core.utils import (
     WrappedTensor,
     deprecate_inference_params,
+    get_pg_rank,
+    get_pg_size,
     is_using_quantization_scales,
     log_single_rank,
 )
@@ -41,6 +49,8 @@ logger = logging.getLogger(__name__)
 
 
 def _hybrid_logging_pg_kwargs(pg_collection: ProcessGroupCollection) -> dict:
+    """Return paired process groups used by legacy per-stage logging."""
+
     tp_group = getattr(pg_collection, 'tp', None)
     dp_cp_group = getattr(pg_collection, 'dp_cp', None)
     if (tp_group is None) != (dp_cp_group is None):
@@ -61,6 +71,11 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
         vocab_size (int): Vocabulary size
         max_sequence_length (int): maximum size of sequence.
             This is used for positional embedding
+        layer_specs (HybridLayerPattern, optional): Preferred direct decoder architecture.
+            Existing layer ``ModuleSpec`` objects are paired with per-occurrence configs, and
+            ``PipelineSplit`` nodes define PP/VPP chunks.
+        resolved_hybrid_architecture (ResolvedHybridArchitecture, optional): Internal global
+            architecture supplied by ``HybridModelBuilder`` after validation.
         hybrid_layer_pattern (str): Unified hybrid layer pattern with optional MTP and
             pipeline stage boundaries.
             Format: "<main_pattern>/<mtp_pattern>/<mtp_pattern>/..."
@@ -78,10 +93,12 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
         hybrid_override_pattern (str, optional): Deprecated. Use hybrid_layer_pattern instead.
             If set and hybrid_layer_pattern is None, the value is copied to hybrid_layer_pattern
             with a deprecation warning.
-        pre_process (bool, optional): Include embedding layer
-            (used with pipeline parallelism). Defaults to True.
+        pre_process (bool, optional): Include embedding layer (used with pipeline parallelism).
+            Legacy patterns retain the historical True default. Direct architectures constrain
+            ownership to the first logical PP/VPP chunk.
         post_process (bool, optional): Include an output layer (used with pipeline parallelism).
-            Defaults to True.
+            Legacy patterns retain the historical True default. Direct architectures constrain
+            ownership to the final logical PP/VPP chunk.
         fp16_lm_cross_entropy (bool, optional): Defaults to False.
         parallel_output (bool, optional): Do not gather the outputs, keep them split across tensor
             parallel ranks. Defaults to True.
@@ -123,11 +140,21 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
         seq_len_interpolation_factor: Optional[float] = None,
         pg_collection: Optional[ProcessGroupCollection] = None,
         vp_stage: Optional[int] = None,
+        layer_specs: HybridLayerPattern | None = None,
+        resolved_hybrid_architecture: ResolvedHybridArchitecture | None = None,
     ) -> None:
         super().__init__(config=config, pg_collection=pg_collection)
 
+        has_direct_architecture = layer_specs is not None or (
+            resolved_hybrid_architecture is not None
+            and resolved_hybrid_architecture.source == "direct"
+        )
         if has_config_logger_enabled(config):
-            log_config_to_disk(config, locals(), prefix=type(self).__name__)
+            config_logger_args = dict(locals())
+            config_logger_args.pop("layer_specs", None)
+            config_logger_args.pop("resolved_hybrid_architecture", None)
+            config_logger_args.pop("has_direct_architecture", None)
+            log_config_to_disk(config, config_logger_args, prefix=type(self).__name__)
 
         if self.config.use_mup and not getattr(HybridModel, "mup_warning_printed", False):
             log_single_rank(
@@ -141,16 +168,24 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
         self.vocab_size = vocab_size
         self.max_sequence_length = max_sequence_length
         self.hybrid_layer_pattern = hybrid_layer_pattern
-        self.pre_process = pre_process
-        self.post_process = post_process
+        self.vp_stage = vp_stage
         self.fp16_lm_cross_entropy = fp16_lm_cross_entropy
         self.parallel_output = parallel_output
         self.share_embeddings_and_output_weights = share_embeddings_and_output_weights
         self.position_embedding_type = position_embedding_type
-        self.vp_stage = vp_stage
         self.disable_param_offloading = True
 
         # Backward compatibility for deprecated hybrid parameters
+        if has_direct_architecture and hybrid_override_pattern is not None:
+            raise ValueError("hybrid_override_pattern cannot be combined with direct layer_specs.")
+        if has_direct_architecture and (
+            (hybrid_attention_ratio is not None and hybrid_attention_ratio > 0.0)
+            or (hybrid_mlp_ratio is not None and hybrid_mlp_ratio > 0.0)
+        ):
+            raise ValueError(
+                "hybrid_attention_ratio and hybrid_mlp_ratio cannot be combined with "
+                "direct layer_specs."
+            )
         if hybrid_override_pattern is not None:
             if self.hybrid_layer_pattern is None:
                 log_single_rank(
@@ -189,36 +224,80 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
                     config.num_layers, attn_ratio, mlp_ratio
                 )
 
-        # Parse unified pattern to extract main and MTP components, and
-        # determine the pipeline segment for this model instance.
+        if resolved_hybrid_architecture is None and layer_specs is not None:
+            resolved_hybrid_architecture = resolve_hybrid_architecture(
+                config=self.config,
+                hybrid_stack_spec=hybrid_stack_spec,
+                layer_specs=layer_specs,
+                hybrid_layer_pattern=self.hybrid_layer_pattern,
+            )
+        elif layer_specs is not None:
+            raise ValueError(
+                "resolved_hybrid_architecture cannot be combined with unresolved direct specs."
+            )
+
+        is_direct_architecture = (
+            resolved_hybrid_architecture is not None
+            and resolved_hybrid_architecture.source == "direct"
+        )
+
+        # Keep the existing string-based MTP path until direct MTP support is
+        # introduced. Direct decoder specs are supported independently here.
         from megatron.core.models.hybrid.hybrid_layer_allocation import (
             parse_hybrid_pattern,
             select_pipeline_segment,
         )
 
         parsed = parse_hybrid_pattern(self.hybrid_layer_pattern)
+        if is_direct_architecture and resolved_hybrid_architecture.mtp_layers:
+            raise ValueError("Direct MTP layer specs are not supported by this runtime yet.")
+
+        if not is_direct_architecture:
+            # Preserve the legacy selector, shared config, symbol API, and constructor defaults.
+            self.pre_process = pre_process
+            self.post_process = post_process
+            logging_pg_kwargs = _hybrid_logging_pg_kwargs(self.pg_collection)
+            layer_type_list, layer_offset = select_pipeline_segment(
+                parsed.main_pattern or '',
+                self.pg_collection.pp,
+                vp_stage,
+                first_stage_layers=self.config.num_layers_in_first_pipeline_stage,
+                last_stage_layers=self.config.num_layers_in_last_pipeline_stage,
+                **logging_pg_kwargs,
+            )
+            local_layer_specs = None
+        else:
+            # Every physical/virtual chunk intentionally keeps the same global summary.
+            self.resolved_hybrid_architecture = resolved_hybrid_architecture
+            self.vp_size = self.config.virtual_pipeline_model_parallel_size
+            # Raw direct callers resolve split nodes here rather than in the builder, so derive
+            # ownership only after resolution has inferred VPP.
+            pp_size = self.config.pipeline_model_parallel_size
+            pp_rank = get_pg_rank(self.pg_collection.pp)
+            if torch.distributed.is_initialized():
+                actual_pp_size = get_pg_size(self.pg_collection.pp)
+                if actual_pp_size != pp_size:
+                    raise ValueError(
+                        "TransformerConfig.pipeline_model_parallel_size must match the supplied "
+                        f"PP process group; got {pp_size} != {actual_pp_size}."
+                    )
+            vp_rank = 0 if vp_stage is None else vp_stage
+            owns_pre_process = pp_rank == 0 and vp_rank == 0
+            owns_post_process = pp_rank == pp_size - 1 and (
+                self.vp_size is None or vp_rank == self.vp_size - 1
+            )
+            self.pre_process = owns_pre_process if pre_process is not False else False
+            self.post_process = owns_post_process if post_process is not False else False
+            local_layer_specs, layer_offset = resolved_hybrid_architecture.select_segment(
+                pp_rank=pp_rank, pp_size=pp_size, vp_stage=vp_stage
+            )
+            layer_type_list = None
+
         self.mtp_pattern = parsed.mtp_pattern
         self.mtp_num_depths = parsed.mtp_num_depths
-
-        logging_pg_kwargs = _hybrid_logging_pg_kwargs(self.pg_collection)
-
-        layer_type_list, layer_offset = select_pipeline_segment(
-            parsed.main_pattern or '',
-            self.pg_collection.pp,
-            vp_stage,
-            first_stage_layers=self.config.num_layers_in_first_pipeline_stage,
-            last_stage_layers=self.config.num_layers_in_last_pipeline_stage,
-            **logging_pg_kwargs,
-        )
-
-        # Determine if MTP is needed (based on pattern parsing)
         self.mtp_process = (
             self.mtp_pattern is not None
             and self.mtp_num_depths > 0
-            # The following forces MTP to be on the final pipeline stage. It might be more optimal
-            # to split the hybrid layer pattern into pipeline stages before parsing the pattern for
-            # the current pipeline stage. This could also enable MTP standalone (MTP in a pipeline
-            # stage separate from loss) to be supported in the hybrid model.
             and mtp_on_this_rank(
                 layout=self.config.pipeline_model_parallel_layout,
                 mtp_num_layers=self.config.mtp_num_layers,
@@ -242,47 +321,110 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
                 pg_collection=self.pg_collection,
             )
 
-        # MLA (also used by DeepSeek Sparse Attention) uses its own decoupled RoPE, therefore we do
-        # not build standard RoPE here when using MLA.
-        if self.position_embedding_type == 'rope' and not self.config.multi_latent_attention:
-            self.rotary_pos_emb = RotaryEmbedding(
-                kv_channels=self.config.kv_channels,
-                rotary_percent=rotary_percent,
-                seq_len_interpolation_factor=seq_len_interpolation_factor,
-                rotary_base=rotary_base,
-                use_cpu_initialization=self.config.use_cpu_initialization,
-                cp_group=self.pg_collection.cp,
-            )
-        elif self.position_embedding_type == 'yarn':
-            self.rotary_pos_emb = YarnRotaryEmbedding(
-                kv_channels=self.config.kv_channels,
-                rotary_percent=rotary_percent,
-                seq_len_interpolation_factor=seq_len_interpolation_factor,
-                rotary_base=rotary_base,
-                scaling_factor=getattr(self.config, "yarn_rotary_scaling_factor"),
-                original_max_position_embeddings=getattr(
-                    self.config, "yarn_original_max_position_embeddings"
-                ),
-                beta_fast=getattr(self.config, "yarn_beta_fast"),
-                beta_slow=getattr(self.config, "yarn_beta_slow"),
-                mscale=getattr(self.config, "yarn_mscale"),
-                mscale_all_dim=getattr(self.config, "yarn_mscale_all_dim"),
-                correction_range_round_to_int=getattr(
-                    self.config, "yarn_correction_range_round_to_int"
-                ),
-                use_cpu_initialization=self.config.use_cpu_initialization,
-                cp_group=self.pg_collection.cp,
-            )
+        if not is_direct_architecture:
+            # Preserve the legacy model-global RoPE/Yarn construction exactly.
+            if self.position_embedding_type == 'rope' and not self.config.multi_latent_attention:
+                self.rotary_pos_emb = RotaryEmbedding(
+                    kv_channels=self.config.kv_channels,
+                    rotary_percent=rotary_percent,
+                    seq_len_interpolation_factor=seq_len_interpolation_factor,
+                    rotary_base=rotary_base,
+                    use_cpu_initialization=self.config.use_cpu_initialization,
+                    cp_group=self.pg_collection.cp,
+                )
+            elif self.position_embedding_type == 'yarn':
+                self.rotary_pos_emb = YarnRotaryEmbedding(
+                    kv_channels=self.config.kv_channels,
+                    rotary_percent=rotary_percent,
+                    seq_len_interpolation_factor=seq_len_interpolation_factor,
+                    rotary_base=rotary_base,
+                    scaling_factor=getattr(self.config, "yarn_rotary_scaling_factor"),
+                    original_max_position_embeddings=getattr(
+                        self.config, "yarn_original_max_position_embeddings"
+                    ),
+                    beta_fast=getattr(self.config, "yarn_beta_fast"),
+                    beta_slow=getattr(self.config, "yarn_beta_slow"),
+                    mscale=getattr(self.config, "yarn_mscale"),
+                    mscale_all_dim=getattr(self.config, "yarn_mscale_all_dim"),
+                    correction_range_round_to_int=getattr(
+                        self.config, "yarn_correction_range_round_to_int"
+                    ),
+                    use_cpu_initialization=self.config.use_cpu_initialization,
+                    cp_group=self.pg_collection.cp,
+                )
+        else:
+            # Standard attention occurrences may use different KV widths. Keep one RoPE
+            # module/input per width; MLA and DSA continue to own their decoupled RoPE.
+            rotary_configs = {
+                layer.config.kv_channels: layer.config
+                for layer in local_layer_specs
+                if layer.layer_type == "attention"
+            }
+            if not rotary_configs:
+                rotary_configs = {self.config.kv_channels: self.config}
+            self._rotary_configs_by_kv = rotary_configs
+
+            def build_rotary_embedding(rotary_config: TransformerConfig):
+                if self.position_embedding_type == 'rope':
+                    return RotaryEmbedding(
+                        kv_channels=rotary_config.kv_channels,
+                        rotary_percent=rotary_percent,
+                        seq_len_interpolation_factor=seq_len_interpolation_factor,
+                        rotary_base=rotary_base,
+                        use_cpu_initialization=rotary_config.use_cpu_initialization,
+                        cp_group=self.pg_collection.cp,
+                    )
+                return YarnRotaryEmbedding(
+                    kv_channels=rotary_config.kv_channels,
+                    rotary_percent=rotary_percent,
+                    seq_len_interpolation_factor=seq_len_interpolation_factor,
+                    rotary_base=rotary_base,
+                    scaling_factor=getattr(rotary_config, "yarn_rotary_scaling_factor"),
+                    original_max_position_embeddings=getattr(
+                        rotary_config, "yarn_original_max_position_embeddings"
+                    ),
+                    beta_fast=getattr(rotary_config, "yarn_beta_fast"),
+                    beta_slow=getattr(rotary_config, "yarn_beta_slow"),
+                    mscale=getattr(rotary_config, "yarn_mscale"),
+                    mscale_all_dim=getattr(rotary_config, "yarn_mscale_all_dim"),
+                    correction_range_round_to_int=getattr(
+                        rotary_config, "yarn_correction_range_round_to_int"
+                    ),
+                    use_cpu_initialization=rotary_config.use_cpu_initialization,
+                    cp_group=self.pg_collection.cp,
+                )
+
+            if (
+                self.position_embedding_type in {'rope', 'yarn'}
+                and not self.config.multi_latent_attention
+            ):
+                if len(rotary_configs) == 1:
+                    self.rotary_pos_emb = build_rotary_embedding(
+                        next(iter(rotary_configs.values()))
+                    )
+                else:
+                    self.rotary_pos_emb_by_kv = torch.nn.ModuleDict(
+                        {
+                            str(kv_channels): build_rotary_embedding(rotary_config)
+                            for kv_channels, rotary_config in rotary_configs.items()
+                        }
+                    )
+
+        decoder_architecture_kwargs = (
+            {"layer_type_list": layer_type_list}
+            if not is_direct_architecture
+            else {"layer_specs": local_layer_specs}
+        )
         self.decoder = build_module(
             hybrid_stack_spec,
             self.config,
             pre_process=self.pre_process,
-            layer_type_list=layer_type_list,
             pp_layer_offset=layer_offset,
             post_process=self.post_process,
             dtype=config.params_dtype,
             pg_collection=self.pg_collection,
             name="decoder",
+            **decoder_architecture_kwargs,
         )
 
         # MTP block - uses mtp_block_spec from hybrid_stack_spec.submodules
@@ -307,7 +449,7 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
             self._setup_mtp_cuda_graphs()
 
         # Output
-        if post_process or self.mtp_process:
+        if self.post_process or self.mtp_process:
             self.output_layer = tensor_parallel.ColumnParallelLinear(
                 config.hidden_size,
                 self.vocab_size,
@@ -414,6 +556,58 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
 
             self.cudagraph_manager = CudaGraphManager(config)
 
+    def _get_rotary_pos_emb(
+        self,
+        inference_context: Optional[BaseInferenceContext],
+        decoder_input: Optional[Tensor],
+        packed_seq_params: Optional[PackedSeqParams],
+    ) -> Tensor | dict[int, Tensor] | None:
+        """Build compatible RoPE inputs for the local attention configurations."""
+
+        resolved_architecture = getattr(self, "resolved_hybrid_architecture", None)
+        if resolved_architecture is None or resolved_architecture.source != "direct":
+            packed_seq = packed_seq_params is not None and packed_seq_params.qkv_format == 'thd'
+            if self.position_embedding_type == 'rope' and not self.config.multi_latent_attention:
+                rotary_seq_len = self.rotary_pos_emb.get_rotary_seq_len(
+                    inference_context, self.decoder, decoder_input, self.config, packed_seq_params
+                )
+                return self.rotary_pos_emb(rotary_seq_len, packed_seq=packed_seq)
+            if self.position_embedding_type == 'yarn':
+                rotary_seq_len = self.rotary_pos_emb.get_rotary_seq_len(
+                    inference_context, self.decoder, decoder_input, self.config, packed_seq_params
+                )
+                rotary_pos_emb, _ = self.rotary_pos_emb(rotary_seq_len, packed_seq=packed_seq)
+                return rotary_pos_emb
+            return None
+
+        if (
+            self.position_embedding_type not in {'rope', 'yarn'}
+            or self.config.multi_latent_attention
+        ):
+            return None
+
+        packed_seq = packed_seq_params is not None and packed_seq_params.qkv_format == 'thd'
+
+        def rotary_input(rotary_module, rotary_config):
+            rotary_seq_len = rotary_module.get_rotary_seq_len(
+                inference_context, self.decoder, decoder_input, rotary_config, packed_seq_params
+            )
+            value = rotary_module(rotary_seq_len, packed_seq=packed_seq)
+            if self.position_embedding_type == 'yarn':
+                value, _ = value
+            return value
+
+        if hasattr(self, 'rotary_pos_emb_by_kv'):
+            return {
+                int(kv_channels): rotary_input(
+                    rotary_module, self._rotary_configs_by_kv[int(kv_channels)]
+                )
+                for kv_channels, rotary_module in self.rotary_pos_emb_by_kv.items()
+            }
+
+        rotary_config = next(iter(self._rotary_configs_by_kv.values()))
+        return rotary_input(self.rotary_pos_emb, rotary_config)
+
     def forward(
         self,
         input_ids: Tensor,
@@ -478,24 +672,9 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
             # decoder will get hidden_states from encoder.input_tensor
             decoder_input = None
 
-        rotary_pos_emb = None
-        if self.position_embedding_type == 'rope' and not self.config.multi_latent_attention:
-            rotary_seq_len = self.rotary_pos_emb.get_rotary_seq_len(
-                inference_context, self.decoder, decoder_input, self.config, packed_seq_params
-            )
-            rotary_pos_emb = self.rotary_pos_emb(
-                rotary_seq_len,
-                packed_seq=packed_seq_params is not None and packed_seq_params.qkv_format == 'thd',
-            )
-        elif self.position_embedding_type == 'yarn':
-            rotary_seq_len = self.rotary_pos_emb.get_rotary_seq_len(
-                inference_context, self.decoder, decoder_input, self.config, packed_seq_params
-            )
-            # YarnRotaryEmbedding.forward returns (emb, mscale); discard mscale here
-            rotary_pos_emb, _ = self.rotary_pos_emb(
-                rotary_seq_len,
-                packed_seq=packed_seq_params is not None and packed_seq_params.qkv_format == 'thd',
-            )
+        rotary_pos_emb = self._get_rotary_pos_emb(
+            inference_context, decoder_input, packed_seq_params
+        )
 
         # Wrap decoder_input to allow the decoder (HybridStack) to delete the
         # reference held by this caller function, enabling early garbage collection

--- a/megatron/core/recompute.py
+++ b/megatron/core/recompute.py
@@ -50,31 +50,40 @@ def checkpointed_forward(
         extract_layer_indices = set()
     intermediate_hidden_states: List[Tensor] = []
 
-    # Wrap non-dual RoPE to tuple to unify custom_forward interface.
+    # Flatten per-KV-width RoPE mappings because autograd checkpoint inputs must
+    # be tensors (or None), not dictionaries.
+    is_rotary_mapping = isinstance(rotary_pos_emb, dict)
+    rotary_mapping_keys = tuple(sorted(rotary_pos_emb)) if is_rotary_mapping else ()
     is_dual_rope = isinstance(rotary_pos_emb, (tuple, list))
     assert not is_dual_rope or len(rotary_pos_emb) == 2, "Dual RoPE input length is not equal to 2"
-    rotary_pos_emb = rotary_pos_emb if is_dual_rope else (None, rotary_pos_emb)
+    if is_rotary_mapping:
+        rotary_inputs = tuple(rotary_pos_emb[key] for key in rotary_mapping_keys)
+    else:
+        rotary_inputs = rotary_pos_emb if is_dual_rope else (None, rotary_pos_emb)
 
     def custom(start: int, end: int):
-        def custom_forward(
-            hidden_states,
-            attention_mask,
-            context,
-            context_mask,
-            rotary_pos_emb_local,
-            rotary_pos_emb_global,
-            padding_mask=None,
-        ):
-            rotary_pos_emb = (
-                (rotary_pos_emb_local, rotary_pos_emb_global)
-                if is_dual_rope
-                else rotary_pos_emb_global
-            )
+        def custom_forward(hidden_states, attention_mask, context, context_mask, *rope_and_mask):
+            padding_mask = rope_and_mask[-1]
+            rope_values = rope_and_mask[:-1]
+            if is_rotary_mapping:
+                rotary_mapping = dict(zip(rotary_mapping_keys, rope_values))
+                rotary_pos_emb = None
+            else:
+                rotary_mapping = None
+                rotary_pos_emb = tuple(rope_values) if is_dual_rope else rope_values[1]
 
             for index in range(start, end):
                 # Use self.layers[index] (not self._get_layer) so this
                 # function works for both TransformerBlock and HybridStack.
                 layer = self.layers[index]
+                layer_rotary_pos_emb = rotary_pos_emb
+                if rotary_mapping is not None:
+                    layer_spec = self.layer_specs[index]
+                    layer_rotary_pos_emb = (
+                        rotary_mapping.get(layer_spec.config.kv_channels)
+                        if layer_spec.layer_type == "attention"
+                        else None
+                    )
 
                 # Get appropriate inner quantization context
                 if use_inner_quantization_context:
@@ -100,7 +109,7 @@ def checkpointed_forward(
                     attention_mask=attention_mask,
                     context=context,
                     context_mask=context_mask,
-                    rotary_pos_emb=rotary_pos_emb,
+                    rotary_pos_emb=layer_rotary_pos_emb,
                     attention_bias=attention_bias,
                     inference_context=None,
                     packed_seq_params=packed_seq_params,
@@ -126,7 +135,7 @@ def checkpointed_forward(
         nonlocal hidden_states, context
         cf = custom(start, end)
         # Unpack the RoPE tuple as torch cannot save tuples for backward pass.
-        args = (hidden_states, attention_mask, context, context_mask, *rotary_pos_emb, padding_mask)
+        args = (hidden_states, attention_mask, context, context_mask, *rotary_inputs, padding_mask)
         if use_checkpoint:
             # Precision-aware activation checkpoint: TE under FP8/FP4,
             # tensor_parallel under BF16/FP16/FP32.

--- a/tests/unit_tests/models/hybrid/test_hybrid_stack_checkpoint_keys.py
+++ b/tests/unit_tests/models/hybrid/test_hybrid_stack_checkpoint_keys.py
@@ -1,0 +1,271 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""CPU-only tests for HybridStack distributed-checkpoint layer keys."""
+
+from inspect import signature
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+from torch import nn
+
+from megatron.core.dist_checkpointing.mapping import ShardedTensor
+from megatron.core.models.hybrid import hybrid_block
+from megatron.core.models.hybrid.hybrid_architecture import (
+    HYBRID_LAYER_TYPE,
+    HybridLayerSpec,
+    PipelineSplit,
+    resolve_hybrid_architecture,
+)
+from megatron.core.models.hybrid.hybrid_block import HybridStack, HybridStackSubmodules
+from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols
+from megatron.core.models.hybrid.hybrid_model import HybridModel
+from megatron.core.transformer import TransformerConfig
+from megatron.core.transformer.spec_utils import ModuleSpec
+
+
+class _CheckpointLayer(nn.Module):
+    """Minimal layer exposing a real parameter and a sharded checkpoint entry."""
+
+    def __init__(self, layer_number: int):
+        super().__init__()
+        self.layer_number = layer_number
+        self.weight = nn.Parameter(torch.tensor([float(layer_number)]))
+
+    def sharded_state_dict(self, prefix='', sharded_offsets=(), metadata=None):
+        del sharded_offsets, metadata
+        key = f'{prefix}weight'
+        return {key: ShardedTensor.from_rank_offsets(key, self.weight)}
+
+
+MAMBA_SPEC = ModuleSpec(module=_CheckpointLayer, metainfo={HYBRID_LAYER_TYPE: "mamba"})
+STACK_SPEC = ModuleSpec(
+    module=HybridStack, submodules=HybridStackSubmodules(mamba_layer=MAMBA_SPEC)
+)
+
+
+def _config() -> TransformerConfig:
+    return TransformerConfig(
+        num_layers=8,
+        hidden_size=16,
+        num_attention_heads=4,
+        num_query_groups=2,
+        kv_channels=4,
+        ffn_hidden_size=32,
+        mamba_state_dim=8,
+        mamba_head_dim=4,
+        mamba_num_heads=4,
+        mamba_num_groups=2,
+        pipeline_model_parallel_size=2,
+        pipeline_dtype=torch.float32,
+        use_cpu_initialization=True,
+    )
+
+
+def _stack(config, *, layer_specs=None, layer_type_list=None, offset=0) -> HybridStack:
+    return HybridStack(
+        config=config,
+        submodules=STACK_SPEC.submodules,
+        layer_specs=layer_specs,
+        layer_type_list=layer_type_list,
+        pp_layer_offset=offset,
+        pre_process=False,
+        post_process=False,
+        post_layer_norm=False,
+        pg_collection=SimpleNamespace(pp=object(), tp=object()),
+    )
+
+
+def _checkpoint_keys(stack: HybridStack) -> set[str]:
+    return {entry.key for entry in stack.sharded_state_dict(prefix="decoder.").values()}
+
+
+def test_pp2_vpp2_checkpoint_keys_use_global_offsets_and_match_legacy(monkeypatch):
+    config = _config()
+    layer = HybridLayerSpec(MAMBA_SPEC, config)
+    architecture = resolve_hybrid_architecture(
+        config=config,
+        hybrid_stack_spec=STACK_SPEC,
+        layer_specs=[
+            [layer] * 2,
+            PipelineSplit(),
+            [layer],
+            PipelineSplit(),
+            [layer] * 3,
+            PipelineSplit(),
+            [layer] * 2,
+        ],
+    )
+
+    monkeypatch.setattr(
+        hybrid_block,
+        "build_module",
+        lambda _spec, **kwargs: _CheckpointLayer(kwargs["layer_number"]),
+    )
+
+    expected_chunks = {(0, 0): (2, 0), (1, 0): (1, 2), (0, 1): (3, 3), (1, 1): (2, 6)}
+    all_direct_checkpoint_keys = set()
+
+    for (pp_rank, vp_stage), (expected_length, expected_offset) in expected_chunks.items():
+        layer_specs, offset = architecture.select_segment(
+            pp_rank=pp_rank, pp_size=2, vp_stage=vp_stage
+        )
+        assert len(layer_specs) == expected_length
+        assert offset == expected_offset
+
+        direct_stack = _stack(config, layer_specs=layer_specs, offset=offset)
+        legacy_stack = _stack(
+            config, layer_type_list=[Symbols.MAMBA] * len(layer_specs), offset=offset
+        )
+
+        local_keys = {f'layers.{index}.weight' for index in range(expected_length)}
+        local_prefixed_keys = {f'decoder.layers.{index}.weight' for index in range(expected_length)}
+        global_checkpoint_keys = {
+            f'decoder.layers.{offset + index}.weight' for index in range(expected_length)
+        }
+
+        assert set(direct_stack.state_dict()) == local_keys
+        assert set(legacy_stack.state_dict()) == local_keys
+
+        direct_sharded_state = direct_stack.sharded_state_dict(prefix="decoder.")
+        legacy_sharded_state = legacy_stack.sharded_state_dict(prefix="decoder.")
+        assert set(direct_sharded_state) == local_prefixed_keys
+        assert set(legacy_sharded_state) == local_prefixed_keys
+        assert _checkpoint_keys(direct_stack) == global_checkpoint_keys
+        assert _checkpoint_keys(legacy_stack) == global_checkpoint_keys
+
+        assert [layer.layer_number for layer in direct_stack.layers] == list(
+            range(offset + 1, offset + expected_length + 1)
+        )
+        all_direct_checkpoint_keys.update(global_checkpoint_keys)
+
+    assert all_direct_checkpoint_keys == {
+        f'decoder.layers.{index}.weight' for index in range(config.num_layers)
+    }
+
+
+def test_raw_hybrid_model_derives_ownership_after_inferring_vpp():
+    config = _config()
+    config.num_layers = 4
+    layer = HybridLayerSpec(MAMBA_SPEC, config)
+    layer_specs = [layer, PipelineSplit(), layer, PipelineSplit(), layer, PipelineSplit(), layer]
+    pg_collection = SimpleNamespace(tp=object(), cp=object(), pp=object(), embd=None)
+
+    with (
+        patch(
+            "megatron.core.models.common.language_module.language_module."
+            "LanguageModule._set_attention_backend"
+        ),
+        patch("megatron.core.models.hybrid.hybrid_model.get_pg_rank", return_value=1),
+        patch(
+            "megatron.core.models.hybrid.hybrid_model.build_module",
+            return_value=torch.nn.Identity(),
+        ),
+    ):
+        model = HybridModel(
+            config=config,
+            hybrid_stack_spec=STACK_SPEC,
+            vocab_size=128,
+            max_sequence_length=16,
+            layer_specs=layer_specs,
+            pg_collection=pg_collection,
+            vp_stage=0,
+        )
+
+    assert config.virtual_pipeline_model_parallel_size == 2
+    assert model.vp_size == 2
+    assert model.pre_process is False
+    assert model.post_process is False
+
+
+def test_raw_legacy_hybrid_model_preserves_default_ownership_and_symbol_adapter():
+    config = _config()
+    config.num_layers = 1
+    calls = []
+    pg_collection = SimpleNamespace(tp=None, cp=None, pp=None, embd=None)
+
+    def fake_build_module(_spec, *args, **kwargs):
+        calls.append((args, kwargs))
+        return torch.nn.Identity()
+
+    with (
+        patch(
+            "megatron.core.models.common.language_module.language_module."
+            "LanguageModule._set_attention_backend"
+        ),
+        patch(
+            "megatron.core.models.hybrid.hybrid_model.LanguageModelEmbedding",
+            return_value=torch.nn.Identity(),
+        ),
+        patch(
+            "megatron.core.models.hybrid.hybrid_model.tensor_parallel.ColumnParallelLinear",
+            return_value=torch.nn.Identity(),
+        ),
+        patch(
+            "megatron.core.models.hybrid.hybrid_model.HybridModel."
+            "setup_embeddings_and_output_layer"
+        ),
+        patch(
+            "megatron.core.models.hybrid.hybrid_model.resolve_hybrid_architecture",
+            side_effect=AssertionError("legacy construction must not invoke the direct resolver"),
+        ),
+        patch("megatron.core.models.hybrid.hybrid_model.build_module", fake_build_module),
+    ):
+        model = HybridModel(
+            config=config,
+            hybrid_stack_spec=STACK_SPEC,
+            vocab_size=128,
+            max_sequence_length=16,
+            hybrid_layer_pattern="M",
+            pg_collection=pg_collection,
+        )
+
+    assert model.pre_process is True
+    assert model.post_process is True
+    assert not hasattr(model, "resolved_hybrid_architecture")
+    assert calls[0][1]["layer_type_list"] == [Symbols.MAMBA]
+    assert "layer_specs" not in calls[0][1]
+
+
+def test_raw_legacy_hybrid_model_preserves_explicit_none_ownership():
+    config = _config()
+    config.num_layers = 1
+    pg_collection = SimpleNamespace(tp=None, cp=None, pp=None, embd=None)
+
+    with (
+        patch(
+            "megatron.core.models.common.language_module.language_module."
+            "LanguageModule._set_attention_backend"
+        ),
+        patch(
+            "megatron.core.models.hybrid.hybrid_model.build_module",
+            return_value=torch.nn.Identity(),
+        ),
+    ):
+        model = HybridModel(
+            config=config,
+            hybrid_stack_spec=STACK_SPEC,
+            vocab_size=128,
+            max_sequence_length=16,
+            hybrid_layer_pattern="M",
+            pre_process=None,
+            post_process=None,
+            pg_collection=pg_collection,
+        )
+
+    assert model.pre_process is None
+    assert model.post_process is None
+    assert not hasattr(model, "embedding")
+    assert not hasattr(model, "output_layer")
+
+
+def test_direct_hybrid_model_parameters_are_appended_after_legacy_signature():
+    parameters = signature(HybridModel.__init__).parameters
+
+    parameter_names = list(parameters)
+    assert parameter_names.index("layer_specs") > parameter_names.index("vp_stage")
+    assert parameter_names.index("resolved_hybrid_architecture") > parameter_names.index("vp_stage")
+    assert parameters["pre_process"].default is True
+    assert parameters["post_process"].default is True
+    assert parameters["pre_process"].annotation is bool
+    assert parameters["post_process"].annotation is bool

--- a/tests/unit_tests/models/hybrid/test_hybrid_stack_direct_specs.py
+++ b/tests/unit_tests/models/hybrid/test_hybrid_stack_direct_specs.py
@@ -1,0 +1,208 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Allocation-free tests for direct layer descriptors at the HybridStack boundary."""
+
+from copy import deepcopy
+from types import SimpleNamespace
+
+from torch import nn
+
+import megatron.core.models.hybrid.hybrid_block as hybrid_block_module
+from megatron.core.models.hybrid.hybrid_architecture import HybridLayerSpec
+from megatron.core.models.hybrid.hybrid_block import HybridStack
+from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_stack_spec
+from megatron.core.transformer import TransformerConfig
+
+
+class _BuiltLayer(nn.Module):
+    """Parameter-free layer returned by the patched module builder."""
+
+    def __init__(self, layer_number: int):
+        super().__init__()
+        self.layer_number = layer_number
+
+    def mamba_state_shapes_per_request(self):
+        return ("conv", self.layer_number), ("ssm", self.layer_number)
+
+
+def _config(num_layers: int) -> TransformerConfig:
+    return TransformerConfig(
+        num_layers=num_layers,
+        hidden_size=64,
+        num_attention_heads=8,
+        num_query_groups=4,
+        kv_channels=8,
+        ffn_hidden_size=128,
+        num_moe_experts=8,
+        moe_ffn_hidden_size=96,
+        moe_router_topk=2,
+        mamba_state_dim=16,
+        mamba_head_dim=8,
+        mamba_num_heads=8,
+        mamba_num_groups=2,
+        add_bias_linear=False,
+    )
+
+
+def _patch_builder(monkeypatch):
+    calls = []
+
+    def fake_build_module(module_spec, **kwargs):
+        calls.append((module_spec, kwargs))
+        return _BuiltLayer(kwargs["layer_number"])
+
+    monkeypatch.setattr(hybrid_block_module, "build_module", fake_build_module)
+    return calls
+
+
+def _build_stack(config, *, layer_specs=None, layer_type_list=None, pp_layer_offset=0):
+    return HybridStack(
+        config=config,
+        submodules=hybrid_stack_spec.submodules,
+        pre_process=False,
+        layer_specs=layer_specs,
+        layer_type_list=layer_type_list,
+        pp_layer_offset=pp_layer_offset,
+        post_layer_norm=False,
+        post_process=False,
+        pg_collection=SimpleNamespace(pp=None, tp=None),
+        name="decoder",
+    )
+
+
+def test_direct_stack_builds_existing_specs_with_occurrence_configs_and_global_numbers(monkeypatch):
+    calls = _patch_builder(monkeypatch)
+    base_config = _config(3)
+    mamba_config = deepcopy(base_config)
+    attention_config = deepcopy(base_config)
+    moe_config = deepcopy(base_config)
+    mamba_config.mamba_state_dim = 24
+    attention_config.kv_channels = 16
+    moe_config.moe_ffn_hidden_size = 112
+    moe_config.moe_router_topk = 4
+
+    stock_specs = [
+        hybrid_stack_spec.submodules.mamba_layer,
+        hybrid_stack_spec.submodules.attention_layer,
+        hybrid_stack_spec.submodules.moe_layer,
+    ]
+    occurrence_configs = [mamba_config, attention_config, moe_config]
+    layer_specs = [
+        HybridLayerSpec(module_spec=module_spec, config=layer_config)
+        for module_spec, layer_config in zip(stock_specs, occurrence_configs)
+    ]
+
+    stack = _build_stack(base_config, layer_specs=layer_specs, pp_layer_offset=11)
+
+    assert len(calls) == 3
+    assert all(call[0] is expected for call, expected in zip(calls, stock_specs))
+    assert all(call[1]["config"] is expected for call, expected in zip(calls, occurrence_configs))
+    assert [call[1]["layer_number"] for call in calls] == [12, 13, 14]
+    assert [layer.layer_number for layer in stack.layers] == [12, 13, 14]
+    assert [call[1]["name"] for call in calls] == [
+        "decoder.layers.0",
+        "decoder.layers.1",
+        "decoder.layers.2",
+    ]
+
+    assert calls[0][1]["pp_layer_offset"] == 11
+    assert calls[1][1]["pp_layer_offset"] == 11
+    assert "pp_layer_offset" not in calls[2][1]
+    assert calls[1][1]["add_layer_offset"] is False
+    assert calls[2][1]["add_layer_offset"] is False
+
+
+def test_legacy_and_equivalent_direct_stack_build_same_semantic_and_module_order(monkeypatch):
+    calls = _patch_builder(monkeypatch)
+    config = _config(4)
+    submodules = hybrid_stack_spec.submodules
+    direct_specs = [
+        HybridLayerSpec(submodules.mamba_layer, config),
+        HybridLayerSpec(submodules.attention_layer, config),
+        HybridLayerSpec(submodules.moe_layer, config),
+        HybridLayerSpec(submodules.mlp_layer, config),
+    ]
+
+    direct_stack = _build_stack(config, layer_specs=direct_specs, pp_layer_offset=3)
+    direct_calls = list(calls)
+    calls.clear()
+    legacy_stack = _build_stack(config, layer_type_list=["M", "*", "E", "-"], pp_layer_offset=3)
+
+    expected_types = ["mamba", "attention", "moe", "mlp"]
+    assert direct_stack.layer_type_list == expected_types
+    assert legacy_stack.layer_type_list == ["M", "*", "E", "-"]
+    assert not hasattr(legacy_stack, "layer_specs")
+    assert [call[0].module for call in direct_calls] == [call[0].module for call in calls]
+    assert [call[1]["layer_number"] for call in direct_calls] == [4, 5, 6, 7]
+    assert [call[1]["layer_number"] for call in calls] == [4, 5, 6, 7]
+    assert all(call[1]["config"] is config for call in calls)
+    assert legacy_stack.mamba_state_shapes_per_request() == (("conv", 4), ("ssm", 4))
+
+
+def test_legacy_stack_preserves_exact_family_specific_builder_kwargs(monkeypatch):
+    calls = _patch_builder(monkeypatch)
+    config = _config(7)
+    symbols = ["M", "*", "D", "+", "-", "E", "G"]
+
+    stack = _build_stack(config, layer_type_list=symbols, pp_layer_offset=4)
+
+    common = {"config", "layer_number", "pg_collection"}
+    expected_keys = [
+        common | {"pp_layer_offset", "name"},
+        common | {"is_mtp_layer", "add_layer_offset", "pp_layer_offset", "name"},
+        common | {"is_mtp_layer", "add_layer_offset", "pp_layer_offset", "name"},
+        common | {"is_mtp_layer", "add_layer_offset", "pp_layer_offset"},
+        common | {"add_layer_offset", "name"},
+        common | {"add_layer_offset", "name"},
+        common | {"add_layer_offset", "name"},
+    ]
+
+    assert stack.layer_type_list is symbols
+    assert [set(kwargs) for _, kwargs in calls] == expected_keys
+    assert all(kwargs["config"] is config for _, kwargs in calls)
+    assert "name" not in calls[3][1]
+
+
+def test_legacy_stack_still_accepts_a_layer_class(monkeypatch):
+    calls = _patch_builder(monkeypatch)
+    config = _config(1)
+    submodules = deepcopy(hybrid_stack_spec.submodules)
+    submodules.mamba_layer = _BuiltLayer
+
+    stack = HybridStack(
+        config=config,
+        submodules=submodules,
+        layer_type_list=["M"],
+        post_layer_norm=False,
+        post_process=False,
+        pg_collection=SimpleNamespace(pp=None, tp=None),
+    )
+
+    assert stack.layer_type_list == ["M"]
+    assert calls[0][0] is _BuiltLayer
+    assert not hasattr(stack, "layer_specs")
+
+
+def test_new_layer_specs_parameter_does_not_shift_legacy_positional_arguments(monkeypatch):
+    calls = _patch_builder(monkeypatch)
+    config = _config(1)
+    pg_collection = SimpleNamespace(pp=None, tp=None)
+
+    stack = HybridStack(
+        config,
+        hybrid_stack_spec.submodules,
+        False,
+        ["M"],
+        9,
+        False,
+        False,
+        None,
+        None,
+        pg_collection,
+        False,
+        "decoder",
+    )
+
+    assert stack.layer_type_list == ["M"]
+    assert calls[0][1]["layer_number"] == 10
+    assert calls[0][1]["name"] == "decoder.layers.0"


### PR DESCRIPTION
## Summary

- Build direct specs with existing layer classes and per-occurrence configs.
- Execute explicit PP/VPP chunks with global numbering, checkpoint keys, and compatible RoPE inputs.
- Preserve legacy parser, selector, shared config, layer kwargs, and ownership behavior.

Stacked on #6295.