### PR TITLE
Support direct hybrid MTP layer specs

### DIFF
--- a/megatron/core/models/hybrid/hybrid_block.py
+++ b/megatron/core/models/hybrid/hybrid_block.py
@@ -93,6 +93,8 @@ class HybridStack(MegatronModule):
         is_mtp_layer: bool = False,
         name: str | None = None,
         layer_specs: Optional[Sequence[HybridLayerSpec]] = None,
+        moe_metric_layer_offset: int | None = None,
+        moe_metric_num_layers: int | None = None,
     ) -> None:
         """
         Args:
@@ -150,6 +152,8 @@ class HybridStack(MegatronModule):
                 pg_collection=pg_collection,
                 is_mtp_layer=is_mtp_layer,
                 name=name,
+                moe_metric_layer_offset=moe_metric_layer_offset,
+                moe_metric_num_layers=moe_metric_num_layers,
             )
 
         if self.config.cuda_graph_impl == "local":
@@ -269,6 +273,8 @@ class HybridStack(MegatronModule):
         pg_collection: ProcessGroupCollection,
         is_mtp_layer: bool,
         name: str | None,
+        moe_metric_layer_offset: int | None,
+        moe_metric_num_layers: int | None,
     ) -> nn.ModuleList:
         """Build occurrence-specific existing layer specs."""
 
@@ -298,12 +304,30 @@ class HybridStack(MegatronModule):
                     build_kwargs["pp_layer_offset"] = pp_layer_offset
                 else:
                     build_kwargs["add_layer_offset"] = False
-                    if layer_type in {"attention", "dsa", "mla"}:
+                    if layer_type != "mlp":
                         build_kwargs["is_mtp_layer"] = is_mtp_layer
+                    if layer_type in {"attention", "dsa", "mla"}:
                         build_kwargs["pp_layer_offset"] = pp_layer_offset
                 layer = build_module(layer_spec.module_spec, **build_kwargs)
+
+            if layer_type == "moe" and moe_metric_layer_offset is not None:
+                metric_layer_number = moe_metric_layer_offset + i + 1
+                if hasattr(layer, "mlp") and hasattr(layer.mlp, "set_metric_layer_number"):
+                    layer.mlp.set_metric_layer_number(metric_layer_number, moe_metric_num_layers)
             layers.append(layer)
         return layers
+
+    def set_moe_metric_layer_offset(self, layer_offset: int, num_layers: int | None = None) -> None:
+        """Retarget MoE metric slots without changing model/checkpoint layer numbers."""
+
+        layer_specs = getattr(self, "layer_specs", None)
+        if layer_specs is None:
+            return
+        for index, (layer_spec, layer) in enumerate(zip(layer_specs, self.layers)):
+            if layer_spec.layer_type != "moe":
+                continue
+            if hasattr(layer, "mlp") and hasattr(layer.mlp, "set_metric_layer_number"):
+                layer.mlp.set_metric_layer_number(layer_offset + index + 1, num_layers)
 
     def _fuse_mla_down_proj(self, submodules: HybridStackSubmodules) -> HybridStackSubmodules:
         # Avoid modifying the original object so users don't get surprised about their `submodules`

--- a/megatron/core/models/hybrid/hybrid_model.py
+++ b/megatron/core/models/hybrid/hybrid_model.py
@@ -74,6 +74,8 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
         layer_specs (HybridLayerPattern, optional): Preferred direct decoder architecture.
             Existing layer ``ModuleSpec`` objects are paired with per-occurrence configs, and
             ``PipelineSplit`` nodes define PP/VPP chunks.
+        mtp_layer_specs (HybridLayerPattern, optional): Direct template for one MTP prediction
+            depth. ``config.mtp_num_layers`` controls repetition.
         resolved_hybrid_architecture (ResolvedHybridArchitecture, optional): Internal global
             architecture supplied by ``HybridModelBuilder`` after validation.
         hybrid_layer_pattern (str): Unified hybrid layer pattern with optional MTP and
@@ -141,17 +143,23 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
         pg_collection: Optional[ProcessGroupCollection] = None,
         vp_stage: Optional[int] = None,
         layer_specs: HybridLayerPattern | None = None,
+        mtp_layer_specs: HybridLayerPattern | None = None,
         resolved_hybrid_architecture: ResolvedHybridArchitecture | None = None,
     ) -> None:
         super().__init__(config=config, pg_collection=pg_collection)
 
-        has_direct_architecture = layer_specs is not None or (
-            resolved_hybrid_architecture is not None
-            and resolved_hybrid_architecture.source == "direct"
+        has_direct_architecture = (
+            layer_specs is not None
+            or mtp_layer_specs is not None
+            or (
+                resolved_hybrid_architecture is not None
+                and resolved_hybrid_architecture.source == "direct"
+            )
         )
         if has_config_logger_enabled(config):
             config_logger_args = dict(locals())
             config_logger_args.pop("layer_specs", None)
+            config_logger_args.pop("mtp_layer_specs", None)
             config_logger_args.pop("resolved_hybrid_architecture", None)
             config_logger_args.pop("has_direct_architecture", None)
             log_config_to_disk(config, config_logger_args, prefix=type(self).__name__)
@@ -224,14 +232,17 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
                     config.num_layers, attn_ratio, mlp_ratio
                 )
 
-        if resolved_hybrid_architecture is None and layer_specs is not None:
+        if resolved_hybrid_architecture is None and (
+            layer_specs is not None or mtp_layer_specs is not None
+        ):
             resolved_hybrid_architecture = resolve_hybrid_architecture(
                 config=self.config,
                 hybrid_stack_spec=hybrid_stack_spec,
                 layer_specs=layer_specs,
+                mtp_layer_specs=mtp_layer_specs,
                 hybrid_layer_pattern=self.hybrid_layer_pattern,
             )
-        elif layer_specs is not None:
+        elif layer_specs is not None or mtp_layer_specs is not None:
             raise ValueError(
                 "resolved_hybrid_architecture cannot be combined with unresolved direct specs."
             )
@@ -241,16 +252,12 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
             and resolved_hybrid_architecture.source == "direct"
         )
 
-        # Keep the existing string-based MTP path until direct MTP support is
-        # introduced. Direct decoder specs are supported independently here.
         from megatron.core.models.hybrid.hybrid_layer_allocation import (
             parse_hybrid_pattern,
             select_pipeline_segment,
         )
 
         parsed = parse_hybrid_pattern(self.hybrid_layer_pattern)
-        if is_direct_architecture and resolved_hybrid_architecture.mtp_layers:
-            raise ValueError("Direct MTP layer specs are not supported by this runtime yet.")
 
         if not is_direct_architecture:
             # Preserve the legacy selector, shared config, symbol API, and constructor defaults.
@@ -266,6 +273,18 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
                 **logging_pg_kwargs,
             )
             local_layer_specs = None
+            self.mtp_pattern = parsed.mtp_pattern
+            self.mtp_num_depths = parsed.mtp_num_depths
+            self.mtp_process = (
+                self.mtp_pattern is not None
+                and self.mtp_num_depths > 0
+                and mtp_on_this_rank(
+                    layout=self.config.pipeline_model_parallel_layout,
+                    mtp_num_layers=self.config.mtp_num_layers,
+                    ignore_virtual=False,
+                    vp_stage=self.vp_stage,
+                )
+            )
         else:
             # Every physical/virtual chunk intentionally keeps the same global summary.
             self.resolved_hybrid_architecture = resolved_hybrid_architecture
@@ -292,19 +311,15 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
                 pp_rank=pp_rank, pp_size=pp_size, vp_stage=vp_stage
             )
             layer_type_list = None
-
-        self.mtp_pattern = parsed.mtp_pattern
-        self.mtp_num_depths = parsed.mtp_num_depths
-        self.mtp_process = (
-            self.mtp_pattern is not None
-            and self.mtp_num_depths > 0
-            and mtp_on_this_rank(
-                layout=self.config.pipeline_model_parallel_layout,
-                mtp_num_layers=self.config.mtp_num_layers,
-                ignore_virtual=False,
-                vp_stage=self.vp_stage,
+            segment_index = vp_rank * pp_size + pp_rank
+            is_final_segment = segment_index == len(resolved_hybrid_architecture.segments) - 1
+            self.mtp_pattern = None
+            self.mtp_num_depths = resolved_hybrid_architecture.mtp_num_layers
+            self.mtp_process = bool(
+                resolved_hybrid_architecture.mtp_layers
+                and self.mtp_num_depths > 0
+                and is_final_segment
             )
-        )
 
         # megatron core pipelining currently depends on model type
         # TODO: remove this dependency ?
@@ -355,9 +370,12 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
         else:
             # Standard attention occurrences may use different KV widths. Keep one RoPE
             # module/input per width; MLA and DSA continue to own their decoupled RoPE.
+            rotary_layers = list(local_layer_specs)
+            if self.mtp_process:
+                rotary_layers.extend(resolved_hybrid_architecture.mtp_layers)
             rotary_configs = {
                 layer.config.kv_channels: layer.config
-                for layer in local_layer_specs
+                for layer in rotary_layers
                 if layer.layer_type == "attention"
             }
             if not rotary_configs:
@@ -413,7 +431,11 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
         decoder_architecture_kwargs = (
             {"layer_type_list": layer_type_list}
             if not is_direct_architecture
-            else {"layer_specs": local_layer_specs}
+            else {
+                "layer_specs": local_layer_specs,
+                "moe_metric_layer_offset": layer_offset,
+                "moe_metric_num_layers": resolved_hybrid_architecture.metric_num_layers,
+            }
         )
         self.decoder = build_module(
             hybrid_stack_spec,
@@ -436,15 +458,23 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
                 "Ensure hybrid_stack_spec includes mtp_block_spec for MTP support."
             )
 
+            mtp_architecture_kwargs = (
+                {"mtp_layer_pattern": self.mtp_pattern}
+                if not is_direct_architecture
+                else {
+                    "mtp_layer_specs": resolved_hybrid_architecture.mtp_layers,
+                    "moe_metric_num_layers": resolved_hybrid_architecture.metric_num_layers,
+                }
+            )
             self.mtp = MultiTokenPredictionBlock(
                 config=self.config,
                 spec=mtp_block_spec,
                 pg_collection=self.pg_collection,
                 vp_stage=self.vp_stage,
-                mtp_layer_pattern=self.mtp_pattern,
                 mtp_num_depths=self.mtp_num_depths,
                 hybrid_submodules=hybrid_submodules,
                 name="mtp",
+                **mtp_architecture_kwargs,
             )
             self._setup_mtp_cuda_graphs()
 

--- a/megatron/core/transformer/moe/moe_layer.py
+++ b/megatron/core/transformer/moe/moe_layer.py
@@ -139,6 +139,11 @@ class RouterInterface(Protocol):
         """
         ...
 
+    def set_metric_layer_number(self, layer_number: int, num_layers: int | None = None) -> None:
+        """Set a metric-only layer slot independent of checkpoint numbering."""
+
+        ...
+
 
 class RouterBuilder(Protocol):
     """Protocol for building a Router."""
@@ -208,6 +213,11 @@ class BaseMoELayer(MegatronModule, ABC):
         """Set the layer number for the MoE layer."""
         self.layer_number = layer_number
         self.router.set_layer_number(layer_number)
+
+    def set_metric_layer_number(self, layer_number: int, num_layers: int | None = None) -> None:
+        """Set the layer slot used by the MoE metrics tracker."""
+
+        self.router.set_metric_layer_number(layer_number, num_layers)
 
 
 class MoELayer(BaseMoELayer):
@@ -647,8 +657,15 @@ class MoELayer(BaseMoELayer):
         if padding_mask is not None:
             padding_mask = padding_mask.transpose(0, 1).bool()
 
+        metric_layer_number = getattr(self.router, "metric_layer_number", None)
+        metric_num_layers = getattr(self.router, "metric_num_layers", None)
+
         # MoE forward: route -> dispatch -> compute -> combine
         def custom_forward(hidden_states, intermediate_tensors=None, padding_mask=None):
+            if metric_layer_number is not None:
+                # Selective MoE recomputation runs after a repeated direct-MTP module may have
+                # been retargeted to another prediction depth. Restore this invocation's slot.
+                self.router.set_metric_layer_number(metric_layer_number, metric_num_layers)
             try:
                 if "route" in self.fwd_execution_map:
                     shared_expert_output = self.shared_experts_compute(hidden_states)

--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -140,6 +140,12 @@ class Router(ABC, MegatronModule):
         if getattr(self, "router_replay", None) is not None:
             self.router_replay.layer_number = layer_number
 
+    def set_metric_layer_number(self, layer_number: int, num_layers: Optional[int] = None) -> None:
+        """Set an architecture-aware slot used only for MoE metric reporting."""
+
+        self.metric_layer_number = layer_number
+        self.metric_num_layers = num_layers
+
 
 class TopKRouter(Router):
     """Route each token to the top-k experts.
@@ -587,11 +593,18 @@ class TopKRouter(Router):
         # add the aux loss logging value to other layer's since it is difficult to get the
         # correct layer_number for MTP. It does not affect the correctness of the calculation
         # results and the reduced load_balancing_loss logging value.
-        num_layers = self.config.num_layers
-        if self.config.mtp_num_layers is not None:
-            num_layers += self.config.mtp_num_layers
+        metric_num_layers = getattr(self, "metric_num_layers", None)
+        metric_layer_number = getattr(self, "metric_layer_number", None)
+        if metric_num_layers is not None:
+            num_layers = metric_num_layers
+        else:
+            num_layers = self.config.num_layers
+            if self.config.mtp_num_layers is not None:
+                num_layers += self.config.mtp_num_layers
 
-        if self.is_mtp_layer:
+        if metric_layer_number is not None:
+            layer_number = metric_layer_number
+        elif self.is_mtp_layer:
             layer_number = self.layer_number + self.config.num_layers
         else:
             layer_number = self.layer_number
@@ -688,11 +701,18 @@ class TopKRouter(Router):
             ):
                 z_loss = z_loss / self.config.mtp_num_layers
 
-            num_layers = self.config.num_layers
-            if self.config.mtp_num_layers is not None:
-                num_layers += self.config.mtp_num_layers
+            metric_num_layers = getattr(self, "metric_num_layers", None)
+            metric_layer_number = getattr(self, "metric_layer_number", None)
+            if metric_num_layers is not None:
+                num_layers = metric_num_layers
+            else:
+                num_layers = self.config.num_layers
+                if self.config.mtp_num_layers is not None:
+                    num_layers += self.config.mtp_num_layers
 
-            if self.is_mtp_layer:
+            if metric_layer_number is not None:
+                layer_number = metric_layer_number
+            elif self.is_mtp_layer:
                 layer_number = self.layer_number + self.config.num_layers
             else:
                 layer_number = self.layer_number

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import warnings
 from contextlib import nullcontext
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Callable, List, Optional, Union
+from typing import TYPE_CHECKING, Callable, List, Optional, Sequence, Union
 
 import torch
 from torch import Tensor
@@ -42,6 +42,7 @@ from megatron.core.utils import (
 )
 
 if TYPE_CHECKING:
+    from megatron.core.models.hybrid.hybrid_architecture import HybridLayerSpec
     from megatron.core.models.hybrid.hybrid_block import HybridStackSubmodules
 
 if is_torch_min_version("1.13.0"):
@@ -926,6 +927,8 @@ class MultiTokenPredictionLayer(MegatronModule):
         hybrid_submodules: Optional[HybridStackSubmodules] = None,
         mamba_submodules: Optional[HybridStackSubmodules] = None,
         name: str | None = None,
+        mtp_layer_specs: Optional[Sequence[HybridLayerSpec]] = None,
+        moe_metric_num_layers: int | None = None,
     ):
         """
         Args:
@@ -951,6 +954,8 @@ class MultiTokenPredictionLayer(MegatronModule):
         self.cp_group = pg_collection.cp
         self.tp_group = pg_collection.tp if pg_collection is not None else None
         self.mtp_layer_pattern = mtp_layer_pattern
+        if mtp_layer_specs is not None:
+            self.mtp_layer_specs = mtp_layer_specs
 
         # Validate attention mask type if using transformer-based inner layers
         if self.submodules.mtp_model_layer is not None and hasattr(
@@ -1015,14 +1020,34 @@ class MultiTokenPredictionLayer(MegatronModule):
         # Build inner layers: two possible paths
         # 1. Hybrid path: use HybridStack for hybrid pattern support
         # 2. GPT path: single TransformerLayer
-        if mtp_layer_pattern is not None and hybrid_submodules is not None:
+        if (
+            mtp_layer_pattern is not None or mtp_layer_specs is not None
+        ) and hybrid_submodules is not None:
             from megatron.core.models.hybrid.hybrid_block import HybridStack
             from megatron.core.models.hybrid.hybrid_layer_allocation import validate_segment_layers
 
+            layer_type_list = (
+                validate_segment_layers(mtp_layer_pattern)
+                if mtp_layer_pattern is not None
+                else None
+            )
+            metric_layer_count = len(mtp_layer_specs or [])
+            if mtp_layer_specs is not None:
+                self.mtp_metric_layer_count = metric_layer_count
+            stack_architecture_kwargs = (
+                {"layer_type_list": layer_type_list}
+                if mtp_layer_specs is None
+                else {
+                    "layer_specs": mtp_layer_specs,
+                    "moe_metric_layer_offset": (
+                        self.config.num_layers + (layer_number - 1) * metric_layer_count
+                    ),
+                    "moe_metric_num_layers": moe_metric_num_layers,
+                }
+            )
             self.mtp_model_layer = HybridStack(
                 config=self.config,
                 submodules=hybrid_submodules,
-                layer_type_list=validate_segment_layers(mtp_layer_pattern),
                 pp_layer_offset=0,
                 pre_process=True,  # Always receives input from eh_proj
                 post_layer_norm=False,  # MTP has its own final_layernorm
@@ -1030,6 +1055,7 @@ class MultiTokenPredictionLayer(MegatronModule):
                 pg_collection=pg_collection,
                 is_mtp_layer=True,
                 name=(name + ".mtp_model_layer") if name is not None else None,
+                **stack_architecture_kwargs,
             )
         elif self.config.mtp_num_layers is not None:
             # GPT path: Uses the transformer block spec for MTP layer
@@ -1052,6 +1078,23 @@ class MultiTokenPredictionLayer(MegatronModule):
             eps=self.config.layernorm_epsilon,
         )
         self.offload_context = nullcontext()
+
+    def set_moe_metric_depth(self, depth_index: int, num_layers: int | None = None) -> None:
+        """Retarget a repeated hybrid MTP layer to the current prediction-depth slots."""
+
+        # Keep the depth on this invocation so an activation-checkpoint closure
+        # can restore it during backward recomputation.  The same module is
+        # shared by every prediction depth and its router slot is mutable.
+        self._moe_metric_depth_index = depth_index
+        self._moe_metric_num_layers = num_layers
+        metric_layer_count = getattr(self, "mtp_metric_layer_count", 0)
+        if metric_layer_count == 0 or not hasattr(
+            self.mtp_model_layer, "set_moe_metric_layer_offset"
+        ):
+            return
+        self.mtp_model_layer.set_moe_metric_layer_offset(
+            self.config.num_layers + depth_index * metric_layer_count, num_layers
+        )
 
     def _get_embeddings(
         self,
@@ -1186,7 +1229,10 @@ class MultiTokenPredictionLayer(MegatronModule):
             # transformer layer is cudagraphed, the FP8GlobalStateManager.is_first_fp8_module() is
             # True so that the fp8 weight caching can be triggered correctly.
             with transformer_layer_fp8_context:
-                if self.mtp_layer_pattern is not None:
+                if (
+                    self.mtp_layer_pattern is not None
+                    or getattr(self, "mtp_layer_specs", None) is not None
+                ):
                     hidden_states = self.mtp_model_layer(
                         hidden_states=hidden_states,
                         attention_mask=attention_mask,
@@ -1312,6 +1358,16 @@ class MultiTokenPredictionLayer(MegatronModule):
           ``outer_quantization_context`` block below.
         """
 
+        is_rotary_mapping = isinstance(rotary_pos_emb, dict)
+        rotary_mapping_keys = tuple(sorted(rotary_pos_emb)) if is_rotary_mapping else ()
+        rotary_inputs = (
+            tuple(rotary_pos_emb[key] for key in rotary_mapping_keys)
+            if is_rotary_mapping
+            else (rotary_pos_emb,)
+        )
+        moe_metric_depth_index = getattr(self, "_moe_metric_depth_index", None)
+        moe_metric_num_layers = getattr(self, "_moe_metric_num_layers", None)
+
         def custom_forward(
             hidden_states,
             decoder_input,
@@ -1319,11 +1375,17 @@ class MultiTokenPredictionLayer(MegatronModule):
             padding_mask,
             context,
             context_mask,
-            rotary_pos_emb,
-            rotary_pos_cos,
-            rotary_pos_sin,
-            sequence_len_offset,
+            *rope_and_tail,
         ):
+            rope_values = rope_and_tail[:-3]
+            rotary_pos_cos, rotary_pos_sin, sequence_len_offset = rope_and_tail[-3:]
+            checkpoint_rotary_pos_emb = (
+                dict(zip(rotary_mapping_keys, rope_values)) if is_rotary_mapping else rope_values[0]
+            )
+            if moe_metric_depth_index is not None:
+                # Reentrant checkpoint backward runs after the outer depth loop
+                # has left this shared module targeted at its final depth.
+                self.set_moe_metric_depth(moe_metric_depth_index, moe_metric_num_layers)
             return self._proj_and_transformer_layer(
                 hidden_states=hidden_states,
                 decoder_input=decoder_input,
@@ -1331,7 +1393,7 @@ class MultiTokenPredictionLayer(MegatronModule):
                 padding_mask=padding_mask,
                 context=context,
                 context_mask=context_mask,
-                rotary_pos_emb=rotary_pos_emb,
+                rotary_pos_emb=checkpoint_rotary_pos_emb,
                 rotary_pos_cos=rotary_pos_cos,
                 rotary_pos_sin=rotary_pos_sin,
                 attention_bias=attention_bias,
@@ -1378,7 +1440,7 @@ class MultiTokenPredictionLayer(MegatronModule):
                     padding_mask,
                     context,
                     context_mask,
-                    rotary_pos_emb,
+                    *rotary_inputs,
                     rotary_pos_cos,
                     rotary_pos_sin,
                     sequence_len_offset,
@@ -1398,7 +1460,7 @@ class MultiTokenPredictionLayer(MegatronModule):
                     padding_mask,
                     context,
                     context_mask,
-                    rotary_pos_emb,
+                    *rotary_inputs,
                     rotary_pos_cos,
                     rotary_pos_sin,
                     sequence_len_offset,
@@ -1544,7 +1606,7 @@ class MultiTokenPredictionLayer(MegatronModule):
         # named 'transformer_layer'. Remap checkpoint keys so old checkpoints load
         # correctly. Mamba MTP models keep 'mtp_model_layer' as their native format
         # since no older checkpoints exist for them.
-        if self.mtp_layer_pattern is None:
+        if self.mtp_layer_pattern is None and getattr(self, "mtp_layer_specs", None) is None:
             apply_prefix_mapping(
                 sharded_state_dict, {f'{prefix}mtp_model_layer.': f'{prefix}transformer_layer.'}
             )
@@ -1633,6 +1695,8 @@ class MultiTokenPredictionBlock(MegatronModule):
         hybrid_submodules: Optional["HybridStackSubmodules"] = None,
         mamba_submodules: Optional["HybridStackSubmodules"] = None,
         name: str | None = None,
+        mtp_layer_specs: Optional[Sequence[HybridLayerSpec]] = None,
+        moe_metric_num_layers: int | None = None,
     ):
         """
         Args:
@@ -1655,6 +1719,9 @@ class MultiTokenPredictionBlock(MegatronModule):
         self.mtp_loss_scaling_factor = config.mtp_loss_scaling_factor
         self.vp_stage = vp_stage
         self.mtp_layer_pattern = mtp_layer_pattern
+        if mtp_layer_specs is not None:
+            self.mtp_layer_specs = mtp_layer_specs
+            self.moe_metric_num_layers = moe_metric_num_layers
         self.mtp_num_depths = mtp_num_depths
         self.hybrid_submodules = hybrid_submodules
         self.mtp_use_repeated_layer = self.config.mtp_use_repeated_layer
@@ -1689,6 +1756,9 @@ class MultiTokenPredictionBlock(MegatronModule):
                 param.grad_norm_group = 'mtp'
 
     def _build_layers(self, pg_collection):
+        mtp_layer_specs = getattr(self, "mtp_layer_specs", None)
+        moe_metric_num_layers = getattr(self, "moe_metric_num_layers", None)
+
         # Determine number of depths to build
         if self.mtp_num_depths > 0:
             num_depths = self.mtp_num_depths
@@ -1711,10 +1781,18 @@ class MultiTokenPredictionBlock(MegatronModule):
             return module
 
         def build_layer_with_pattern(
-            layer_spec, layer_number, mtp_layer_pattern, hybrid_submodules
+            layer_spec, layer_number, mtp_layer_pattern, mtp_layer_specs, hybrid_submodules
         ):
             """Build layer using pattern-based approach (new Mamba path)."""
             fp8_init_context = get_fp8_context(self.config, is_init=True)
+            architecture_kwargs = (
+                {"mtp_layer_pattern": mtp_layer_pattern}
+                if mtp_layer_specs is None
+                else {
+                    "mtp_layer_specs": mtp_layer_specs,
+                    "moe_metric_num_layers": moe_metric_num_layers,
+                }
+            )
             with fp8_init_context:
                 module = build_module(
                     layer_spec,
@@ -1722,14 +1800,16 @@ class MultiTokenPredictionBlock(MegatronModule):
                     layer_number=layer_number,
                     vp_stage=self.vp_stage,
                     pg_collection=pg_collection,
-                    mtp_layer_pattern=mtp_layer_pattern,
                     hybrid_submodules=hybrid_submodules,
                     name=(self.name + f".layers.{layer_number}") if self.name is not None else None,
+                    **architecture_kwargs,
                 )
             return module
 
         # New Mamba path: use mtp_layer_pattern and hybrid_submodules
-        if self.mtp_layer_pattern is not None and self.hybrid_submodules is not None:
+        if (self.mtp_layer_pattern is not None or mtp_layer_specs is not None) and (
+            self.hybrid_submodules is not None
+        ):
             if self.mtp_use_repeated_layer:
                 # Shared/repeated layer: build one layer, use it for all depths
                 layer_spec = self.submodules.layer_specs[0]
@@ -1737,6 +1817,7 @@ class MultiTokenPredictionBlock(MegatronModule):
                     layer_spec,
                     layer_number=1,
                     mtp_layer_pattern=self.mtp_layer_pattern,
+                    mtp_layer_specs=mtp_layer_specs,
                     hybrid_submodules=self.hybrid_submodules,
                 )
                 self.layers = torch.nn.ModuleList([shared_layer])
@@ -1750,6 +1831,7 @@ class MultiTokenPredictionBlock(MegatronModule):
                             ],
                             layer_number=i + 1,
                             mtp_layer_pattern=self.mtp_layer_pattern,
+                            mtp_layer_specs=mtp_layer_specs,
                             hybrid_submodules=self.hybrid_submodules,
                         )
                         for i in range(num_depths)
@@ -1816,7 +1898,16 @@ class MultiTokenPredictionBlock(MegatronModule):
 
         for iteration in range(self.config.mtp_num_layers):
             layer_idx = 0 if self.mtp_use_repeated_layer else iteration
-            (hidden_states, input_ids, position_ids, padding_mask) = self.layers[layer_idx](
+            mtp_layer_specs = getattr(self, "mtp_layer_specs", None)
+            if (
+                mtp_layer_specs is not None
+                and self.mtp_use_repeated_layer
+                and hasattr(self.layers[layer_idx], "set_moe_metric_depth")
+            ):
+                self.layers[layer_idx].set_moe_metric_depth(
+                    iteration, getattr(self, "moe_metric_num_layers", None)
+                )
+            hidden_states, input_ids, position_ids, padding_mask = self.layers[layer_idx](
                 input_ids=input_ids,
                 position_ids=position_ids,
                 hidden_states=hidden_states,

--- a/tests/unit_tests/models/hybrid/test_hybrid_stack_checkpoint_keys.py
+++ b/tests/unit_tests/models/hybrid/test_hybrid_stack_checkpoint_keys.py
@@ -264,8 +264,65 @@ def test_direct_hybrid_model_parameters_are_appended_after_legacy_signature():
 
     parameter_names = list(parameters)
     assert parameter_names.index("layer_specs") > parameter_names.index("vp_stage")
+    assert parameter_names.index("mtp_layer_specs") > parameter_names.index("vp_stage")
     assert parameter_names.index("resolved_hybrid_architecture") > parameter_names.index("vp_stage")
     assert parameters["pre_process"].default is True
     assert parameters["post_process"].default is True
     assert parameters["pre_process"].annotation is bool
     assert parameters["post_process"].annotation is bool
+
+
+def test_legacy_hybrid_model_keeps_string_mtp_construction_path():
+    config = _config()
+    config.num_layers = 1
+    config.mtp_num_layers = 2
+    stack_spec = ModuleSpec(
+        module=HybridStack,
+        submodules=HybridStackSubmodules(
+            mamba_layer=MAMBA_SPEC, mtp_block_spec=ModuleSpec(module=torch.nn.Identity)
+        ),
+    )
+    pg_collection = SimpleNamespace(tp=None, cp=None, pp=None, embd=None)
+
+    with (
+        patch(
+            "megatron.core.models.common.language_module.language_module."
+            "LanguageModule._set_attention_backend"
+        ),
+        patch(
+            "megatron.core.models.hybrid.hybrid_model.LanguageModelEmbedding",
+            return_value=torch.nn.Identity(),
+        ),
+        patch(
+            "megatron.core.models.hybrid.hybrid_model.tensor_parallel.ColumnParallelLinear",
+            return_value=torch.nn.Identity(),
+        ),
+        patch(
+            "megatron.core.models.hybrid.hybrid_model.HybridModel."
+            "setup_embeddings_and_output_layer"
+        ),
+        patch("megatron.core.models.hybrid.hybrid_model.HybridModel._setup_mtp_cuda_graphs"),
+        patch(
+            "megatron.core.models.hybrid.hybrid_model.build_module",
+            return_value=torch.nn.Identity(),
+        ),
+        patch("megatron.core.models.hybrid.hybrid_model.mtp_on_this_rank", return_value=True),
+        patch(
+            "megatron.core.models.hybrid.hybrid_model.MultiTokenPredictionBlock",
+            return_value=torch.nn.Identity(),
+        ) as mtp_block,
+    ):
+        model = HybridModel(
+            config=config,
+            hybrid_stack_spec=stack_spec,
+            vocab_size=128,
+            max_sequence_length=16,
+            hybrid_layer_pattern="M/M/M",
+            pg_collection=pg_collection,
+        )
+
+    assert model.mtp_pattern == "M"
+    assert model.mtp_num_depths == 2
+    assert mtp_block.call_args.kwargs["mtp_layer_pattern"] == "M"
+    assert "mtp_layer_specs" not in mtp_block.call_args.kwargs
+    assert "moe_metric_num_layers" not in mtp_block.call_args.kwargs

--- a/tests/unit_tests/transformer/test_direct_hybrid_mtp.py
+++ b/tests/unit_tests/transformer/test_direct_hybrid_mtp.py
@@ -1,0 +1,298 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Focused tests for direct hybrid MTP dispatch."""
+
+from contextlib import nullcontext
+from inspect import signature
+from types import SimpleNamespace
+from unittest.mock import Mock, call, patch
+
+import torch
+from torch import nn
+
+from megatron.core.dist_checkpointing.mapping import ShardedTensor
+from megatron.core.transformer.module import MegatronModule
+from megatron.core.transformer.moe.moe_layer import MoELayer
+from megatron.core.transformer.multi_token_prediction import (
+    MultiTokenPredictionBlock,
+    MultiTokenPredictionLayer,
+)
+
+
+def test_direct_mtp_specs_use_the_existing_hybrid_stack_forward_path():
+    """Direct MTP descriptors must not fall through to the GPT tuple-return path."""
+
+    layer = MultiTokenPredictionLayer.__new__(MultiTokenPredictionLayer)
+    torch.nn.Module.__init__(layer)
+    layer.config = SimpleNamespace(sequence_parallel=False, fp8=None, fp4=None)
+    layer.mtp_layer_pattern = None
+    layer.mtp_layer_specs = (object(), object())
+    layer._concat_embeddings = Mock(side_effect=lambda hidden_states, _: hidden_states)
+    layer._postprocess = Mock(side_effect=lambda hidden_states: hidden_states)
+    layer.mtp_model_layer = Mock(
+        side_effect=lambda **kwargs: kwargs["hidden_states"]
+        + torch.ones_like(kwargs["hidden_states"])
+    )
+
+    hidden_states = torch.zeros(2, 1, 4)
+    rotary_pos_emb = {4: torch.ones(2, 1, 1, 4)}
+    output = layer._proj_and_transformer_layer(
+        hidden_states=hidden_states,
+        decoder_input=torch.zeros_like(hidden_states),
+        attention_mask=None,
+        rotary_pos_emb=rotary_pos_emb,
+    )
+
+    assert torch.equal(output, torch.ones_like(hidden_states))
+    assert layer.mtp_model_layer.call_args.kwargs["rotary_pos_emb"] is rotary_pos_emb
+    assert "context" not in layer.mtp_model_layer.call_args.kwargs
+
+
+def test_direct_hybrid_mtp_keeps_native_checkpoint_prefix():
+    layer = MultiTokenPredictionLayer.__new__(MultiTokenPredictionLayer)
+    torch.nn.Module.__init__(layer)
+    layer.mtp_layer_pattern = None
+    layer.mtp_layer_specs = (object(),)
+    sharded_weight = ShardedTensor.from_rank_offsets("mtp.mtp_model_layer.weight", torch.ones(1))
+
+    with patch.object(
+        MegatronModule,
+        "sharded_state_dict",
+        return_value={"mtp.mtp_model_layer.weight": sharded_weight},
+    ):
+        layer.sharded_state_dict(prefix="mtp.")
+
+    assert sharded_weight.key == "mtp.mtp_model_layer.weight"
+
+
+def test_mtp_layer_maps_prediction_depth_to_global_metric_offset():
+    layer = MultiTokenPredictionLayer.__new__(MultiTokenPredictionLayer)
+    torch.nn.Module.__init__(layer)
+    layer.config = SimpleNamespace(num_layers=4)
+    layer.mtp_metric_layer_count = 2
+    layer.mtp_model_layer = Mock()
+
+    layer.set_moe_metric_depth(depth_index=1, num_layers=8)
+
+    layer.mtp_model_layer.set_moe_metric_layer_offset.assert_called_once_with(6, 8)
+
+
+def test_repeated_direct_mtp_builds_one_existing_layer():
+    block = MultiTokenPredictionBlock.__new__(MultiTokenPredictionBlock)
+    torch.nn.Module.__init__(block)
+    block.config = SimpleNamespace(mtp_num_layers=2)
+    block.submodules = SimpleNamespace(layer_specs=[object()])
+    block.mtp_layer_pattern = None
+    block.mtp_layer_specs = (object(), object())
+    block.mtp_num_depths = 2
+    block.hybrid_submodules = object()
+    block.moe_metric_num_layers = 8
+    block.mtp_use_repeated_layer = True
+    block.vp_stage = None
+    block.name = None
+
+    built_layer = nn.Identity()
+    with (
+        patch(
+            "megatron.core.transformer.multi_token_prediction.get_fp8_context",
+            return_value=nullcontext(),
+        ),
+        patch(
+            "megatron.core.transformer.multi_token_prediction.build_module",
+            return_value=built_layer,
+        ) as build_module,
+    ):
+        block._build_layers(pg_collection=object())
+
+    assert list(block.layers) == [built_layer]
+    assert build_module.call_args.kwargs["mtp_layer_specs"] is block.mtp_layer_specs
+
+
+class _RepeatedMtpLayer(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.metric_depths = []
+
+    def set_moe_metric_depth(self, depth_index, num_layers):
+        self.metric_depths.append((depth_index, num_layers))
+
+    def forward(self, **kwargs):
+        return (
+            kwargs["hidden_states"] + 1,
+            kwargs["input_ids"],
+            kwargs["position_ids"],
+            kwargs["padding_mask"],
+        )
+
+
+def test_repeated_mtp_retargets_moe_metric_slots_for_every_depth():
+    block = MultiTokenPredictionBlock.__new__(MultiTokenPredictionBlock)
+    torch.nn.Module.__init__(block)
+    block.config = SimpleNamespace(mtp_num_layers=2, mtp_detach_heads=False)
+    block.vp_stage = None
+    block.mtp_use_repeated_layer = True
+    block.mtp_layer_specs = (object(),)
+    block.moe_metric_num_layers = 8
+    repeated_layer = _RepeatedMtpLayer()
+    block.layers = nn.ModuleList([repeated_layer])
+
+    with patch(
+        "megatron.core.transformer.multi_token_prediction.get_mtp_layer_offset", return_value=0
+    ):
+        output = block(
+            input_ids=torch.zeros(1, 2, dtype=torch.long),
+            position_ids=torch.zeros(1, 2, dtype=torch.long),
+            hidden_states=torch.zeros(2, 1, 4),
+            attention_mask=None,
+        )
+
+    assert repeated_layer.metric_depths == [(0, 8), (1, 8)]
+    assert output.shape == (6, 1, 4)
+
+
+def test_repeated_legacy_mtp_does_not_retarget_moe_metric_slots():
+    block = MultiTokenPredictionBlock.__new__(MultiTokenPredictionBlock)
+    torch.nn.Module.__init__(block)
+    block.config = SimpleNamespace(mtp_num_layers=2, mtp_detach_heads=False)
+    block.vp_stage = None
+    block.mtp_use_repeated_layer = True
+    repeated_layer = _RepeatedMtpLayer()
+    block.layers = nn.ModuleList([repeated_layer])
+
+    with patch(
+        "megatron.core.transformer.multi_token_prediction.get_mtp_layer_offset", return_value=0
+    ):
+        block(
+            input_ids=torch.zeros(1, 2, dtype=torch.long),
+            position_ids=torch.zeros(1, 2, dtype=torch.long),
+            hidden_states=torch.zeros(2, 1, 4),
+            attention_mask=None,
+        )
+
+    assert repeated_layer.metric_depths == []
+    assert not hasattr(block, "mtp_layer_specs")
+    assert not hasattr(block, "moe_metric_num_layers")
+
+
+def test_legacy_hybrid_mtp_builder_does_not_receive_direct_only_kwargs():
+    block = MultiTokenPredictionBlock.__new__(MultiTokenPredictionBlock)
+    torch.nn.Module.__init__(block)
+    block.config = SimpleNamespace(mtp_num_layers=2)
+    block.submodules = SimpleNamespace(layer_specs=[object()])
+    block.mtp_layer_pattern = "ME"
+    block.mtp_num_depths = 2
+    block.hybrid_submodules = object()
+    block.mtp_use_repeated_layer = True
+    block.vp_stage = None
+    block.name = "mtp"
+
+    with (
+        patch(
+            "megatron.core.transformer.multi_token_prediction.get_fp8_context",
+            return_value=nullcontext(),
+        ),
+        patch(
+            "megatron.core.transformer.multi_token_prediction.build_module",
+            return_value=nn.Identity(),
+        ) as build_module,
+    ):
+        block._build_layers(pg_collection=object())
+
+    kwargs = build_module.call_args.kwargs
+    assert kwargs["mtp_layer_pattern"] == "ME"
+    assert "mtp_layer_specs" not in kwargs
+    assert "moe_metric_num_layers" not in kwargs
+    assert not hasattr(block, "mtp_layer_specs")
+    assert not hasattr(block, "moe_metric_num_layers")
+
+
+def test_direct_mtp_parameters_do_not_shift_legacy_positional_signatures():
+    layer_parameters = signature(MultiTokenPredictionLayer.__init__).parameters
+    block_parameters = signature(MultiTokenPredictionBlock.__init__).parameters
+
+    assert list(layer_parameters).index("mtp_layer_specs") > list(layer_parameters).index("name")
+    assert list(layer_parameters).index("moe_metric_num_layers") > list(layer_parameters).index(
+        "name"
+    )
+    assert list(block_parameters).index("mtp_layer_specs") > list(block_parameters).index("name")
+    assert list(block_parameters).index("moe_metric_num_layers") > list(block_parameters).index(
+        "name"
+    )
+
+
+def test_repeated_mtp_restores_metric_depth_inside_recompute_closure():
+    layer = MultiTokenPredictionLayer.__new__(MultiTokenPredictionLayer)
+    torch.nn.Module.__init__(layer)
+    layer.config = SimpleNamespace(
+        num_layers=4,
+        fp8=False,
+        fp4=False,
+        distribute_saved_activations=False,
+        recompute_method="uniform",
+        recompute_num_layers=1,
+    )
+    layer.mtp_metric_layer_count = 2
+    layer.mtp_model_layer = Mock()
+    layer._proj_and_transformer_layer = Mock(side_effect=lambda **kwargs: kwargs["hidden_states"])
+    closures = []
+
+    def checkpoint(function, distribute_saved_activations, *args):
+        closures.append((function, args))
+        return function(*args)
+
+    hidden_states = torch.zeros(2, 1, 4, requires_grad=True)
+    decoder_input = torch.zeros_like(hidden_states)
+    with patch(
+        "megatron.core.transformer.multi_token_prediction.tensor_parallel.checkpoint",
+        side_effect=checkpoint,
+    ):
+        for depth_index in range(2):
+            layer.set_moe_metric_depth(depth_index, num_layers=8)
+            layer._checkpointed_forward(hidden_states, decoder_input)
+
+    # Both checkpoint closures recompute after the outer loop has left the
+    # shared router targeted at depth 1. Each closure must restore its own slot.
+    layer.mtp_model_layer.reset_mock()
+    for function, args in closures:
+        function(*args)
+
+    assert layer.mtp_model_layer.set_moe_metric_layer_offset.call_args_list == [
+        call(4, 8),
+        call(6, 8),
+    ]
+
+
+def test_selective_moe_recompute_restores_direct_mtp_metric_slot():
+    layer = MoELayer.__new__(MoELayer)
+    torch.nn.Module.__init__(layer)
+    layer.training = True
+    layer.config = SimpleNamespace(sequence_parallel=True, fp8=False, fp4=False)
+    layer.attn_tp_group = SimpleNamespace(size=lambda: 1)
+    layer.moe_layer_recompute = True
+    layer.fwd_execution_map = {"route", "expert_compute", "postprocess"}
+    layer.router = Mock(metric_layer_number=5, metric_num_layers=8)
+    layer.shared_experts_compute = Mock(return_value=None)
+    layer.route = Mock(return_value=(torch.ones(1), torch.ones(1)))
+    layer.preprocess = Mock(side_effect=lambda hidden, probs, _routing: (hidden, probs))
+    layer.dispatch = Mock(side_effect=lambda hidden, probs: (hidden, probs))
+    layer.routed_experts_compute = Mock(side_effect=lambda hidden, _probs: (hidden, None))
+    layer.combine = Mock(side_effect=lambda output: output)
+    layer.postprocess = Mock(side_effect=lambda output, _shared: output)
+    closures = []
+
+    def checkpoint(function, _distribute_saved_activations, *args):
+        closures.append((function, args))
+        return function(*args)
+
+    hidden_states = torch.zeros(2, 1, 4, requires_grad=True)
+    with patch(
+        "megatron.core.transformer.moe.moe_layer.tensor_parallel.checkpoint", side_effect=checkpoint
+    ):
+        layer(hidden_states)
+
+    layer.router.metric_layer_number = 9
+    layer.router.set_metric_layer_number.reset_mock()
+    function, args = closures[0]
+    function(*args)
+
+    layer.router.set_metric_layer_number.assert_called_once_with(5, 8)


### PR DESCRIPTION
## Summary

- Build and repeat direct MTP templates on the final logical PP/VPP chunk.
- Preserve checkpoint keys and assign direct MoE metrics per prediction depth.
- Leave legacy MTP construction, repeated-layer behavior, and metrics unchanged.

Stacked on #6297.