### PR TITLE
Add Nemotron direct hybrid architecture examples

### DIFF
--- a/docs/user-guide/hybrid-model-migration.md
+++ b/docs/user-guide/hybrid-model-migration.md
@@ -19,8 +19,17 @@ format.
 
 A standard `GPTModel` decoder layer contains both a self-attention sublayer and
 an MLP or MoE sublayer under one layer index. `HybridModel` instead builds an
-ordered stack in which every position represents one layer family. The order is
-described by `--hybrid-layer-pattern`:
+ordered stack in which every position represents one layer family. New
+programmatic model providers should describe that order with direct layer
+specifications, as shown below. The `--hybrid-layer-pattern` syntax remains
+available for CLI workflows and checkpoint migration:
+
+Legacy patterns retain their existing runtime contract: the same string parser
+and PP/VPP selector are used, layer classes receive the shared model config,
+public layer-type lists remain symbol-valued, and legacy MTP, metrics,
+checkpoint keys, and dynamic-inference behavior are unchanged. Direct specs
+use a separate adapter so new per-occurrence behavior does not leak into that
+path.
 
 | Symbol | Layer family |
 |--------|--------------|
@@ -67,6 +76,87 @@ These capabilities do not imply an automatic throughput or quality improvement.
 An architecture-preserving `*-` or `*E` migration should be validated for
 numerical equivalence, and a pattern that adds another layer family should be
 treated as a new architecture and benchmarked independently.
+
+### Prefer direct layer specifications for new providers
+
+`HybridModelConfig.layer_specs` is the preferred API for Python model
+providers. Each `HybridLayerSpec` pairs an existing layer `ModuleSpec` with the
+`TransformerConfig` used for that occurrence. This permits, for example,
+different Mamba state dimensions or different MoE expert widths and top-k
+values at individual positions without introducing another layer class.
+
+The pattern is recursive: nested Python lists and list multiplication are
+expanded in order, and aliases can be reused. `PipelineSplit()` remains a
+structural marker rather than a layer. The following abbreviated example uses
+the layer modules from the standard Hybrid stack:
+
+```python
+from copy import deepcopy
+
+from megatron.core.models.hybrid.hybrid_architecture import HybridLayerSpec, PipelineSplit
+from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_stack_spec
+from megatron.training.models.hybrid import HybridModelConfig
+
+modules = hybrid_stack_spec.submodules
+# base_config has num_layers=10, pipeline_model_parallel_size=2, and
+# virtual_pipeline_model_parallel_size=2.
+
+mamba_config = deepcopy(base_config)
+mamba_config.mamba_state_dim = 128
+
+moe_4_config = deepcopy(base_config)
+moe_4_config.moe_ffn_hidden_size = 1280
+moe_4_config.moe_router_topk = 4
+
+moe_8_config = deepcopy(base_config)
+moe_8_config.moe_ffn_hidden_size = 2688
+moe_8_config.moe_router_topk = 8
+
+M = HybridLayerSpec(module_spec=modules.mamba_layer, config=mamba_config)
+A = HybridLayerSpec(module_spec=modules.attention_layer, config=deepcopy(base_config))
+E4 = HybridLayerSpec(module_spec=modules.moe_layer, config=moe_4_config)
+E8 = HybridLayerSpec(module_spec=modules.moe_layer, config=moe_8_config)
+
+# Four chunks for PP=2 and VPP=2. Nested lists are flattened in order.
+layers = [
+    [M, E4] * 2,
+    PipelineSplit(),
+    [M, A, E4],
+    PipelineSplit(),
+    [],
+    PipelineSplit(),
+    [[M, E8], A],
+]
+
+model_config = HybridModelConfig(
+    transformer=base_config,
+    vocab_size=vocab_size,
+    layer_specs=layers,
+    # One prediction depth; base_config.mtp_num_layers controls repetition.
+    mtp_layer_specs=[A, E8],
+)
+```
+
+The number of non-marker leaves in `layer_specs` must equal `num_layers`.
+Configure exactly one architecture source: `layer_specs` for the direct API or
+`hybrid_layer_pattern` for the legacy string API. Direct MTP layers belong in
+the separate `mtp_layer_specs` field; do not put `PipelineSplit()` in that
+field. `mtp_layer_specs` describes one prediction depth and
+`mtp_num_layers` controls how many depths are built on the final logical
+pipeline stage. That final stage must also contain at least one decoder layer;
+standalone or separately split direct MTP placement is not supported.
+
+The Python architecture definition is required when resuming a direct-spec
+model. Distributed checkpoints preserve global layer keys and can be resharded
+under another compatible PP/VPP split, but they do not serialize the
+`ModuleSpec` tree or an architecture manifest.
+
+For complete architecture-only definitions, see
+[`nemotron_3_5_nano_30b_a3b.py`](../../examples/nemotron3/nemotron_3_5_nano_30b_a3b.py),
+which deliberately reuses one config per layer family because Nano is not
+heterogeneous, and
+[`nemotron_labs_3_puzzle_75b_a9b.py`](../../examples/nemotron3/nemotron_labs_3_puzzle_75b_a9b.py),
+which preserves Puzzle's occurrence-specific MoE widths and top-k values.
 
 ## 2. How to Convert a Checkpoint
 
@@ -352,24 +442,40 @@ the intervening MLP or MoE positions.
 
 ### Configure pipeline parallelism
 
-For pipeline parallelism, add `|` separators without changing the ordered layer
-symbols. For example, the converted pattern `*-*-*-*-` can be trained with two
-pipeline segments as `*-*-|*-*-`. The number of pipe-delimited segments must be
-divisible by `--pipeline-model-parallel-size`.
+For direct `layer_specs`, insert `PipelineSplit()` between logical model
+chunks. Chunks use VPP-major, PP-minor order:
 
-The pattern replaces conventional pipeline layout controls. Remove
-`--num-layers-per-virtual-pipeline-stage`,
-`--num-virtual-stages-per-pipeline-rank`, `--pipeline-model-parallel-layout`,
-`--account-for-embedding-in-pipeline-split`, and
-`--account-for-loss-in-pipeline-split`. When the pattern contains `|`, also
-remove `--decoder-first-pipeline-num-layers` and
-`--decoder-last-pipeline-num-layers`. Express virtual-pipeline segmentation
-with additional pipe-delimited segments instead.
+```text
+chunk index = vp_stage * pipeline_model_parallel_size + pp_rank
+```
 
-The declarative `HybridModelBuilder` currently rejects virtual pipeline
-parallelism. Pipe-defined virtual stages are supported by the
-`pretrain_hybrid.py` CLI builder, but custom builder users must avoid VPP or use
-a path that explicitly supports it.
+For example, four chunks with PP=2 and VPP=2 map to `(vp=0, pp=0)`,
+`(vp=0, pp=1)`, `(vp=1, pp=0)`, and `(vp=1, pp=1)`, in that order. The number
+of chunks must be divisible by the PP size. Their quotient determines VPP; an
+explicit `virtual_pipeline_model_parallel_size` must agree. Empty chunks are
+allowed, and direct PP configurations with more than one rank require explicit
+splits.
+
+Split-defined layouts are mutually exclusive with
+`pipeline_model_parallel_layout`, first- or last-stage layer-count overrides,
+embedding/loss pipeline accounting, and the conventional per-virtual-stage
+controls. The ordinary decoder input embedding is built only for
+`(vp=0, pp=0)`, and the output and loss are built only for the final logical
+chunk. When MTP is enabled, the existing MTP implementation also keeps its
+synchronized embedding replica on that final chunk. `HybridModelBuilder`
+supports both PP and VPP for this direct path.
+
+For the legacy string API, add `|` separators without changing the ordered
+layer symbols. For example, the converted pattern `*-*-*-*-` can be trained
+with two pipeline segments as `*-*-|*-*-`. The number of pipe-delimited
+segments must be divisible by `--pipeline-model-parallel-size`, and the same
+VPP-major ordering applies.
+
+Legacy validation and ownership rules are intentionally unchanged. In
+particular, existing CLI recipes should keep following the combinations that
+their current `--hybrid-layer-pattern` workflow accepts. When a legacy pattern
+contains `|`, first- and last-stage layer-count overrides remain invalid;
+express those segment sizes with additional pipe-delimited symbols instead.
 
 ### Update custom providers and conversion mappings
 
@@ -378,13 +484,15 @@ state-dict differences:
 
 - Build or register `HybridModel` instead of `GPTModel`.
 - Supply a `hybrid_stack_spec` instead of a GPT transformer-layer spec.
-- Set programmatic `num_layers` to the number of layer symbols in the main
-  pattern; unlike the CLI path, a custom provider might not derive it.
+- Prefer `layer_specs` with per-occurrence configs for new programmatic
+  providers; use `hybrid_layer_pattern` only for legacy compatibility.
+- Set programmatic `num_layers` to the number of direct layer leaves or main
+  pattern symbols; unlike the CLI path, a custom provider might not derive it.
 - Map attention and MLP/MoE parameters to their separate Hybrid layer indices.
 - Use `decoder.final_norm` in HybridModel mappings instead of
   `decoder.final_layernorm`.
 - Expand per-layer settings such as attention-window schedules to the full
-  HybridModel pattern.
+  HybridModel layer order.
 
 ### Validate before scaling up
 

--- a/examples/nemotron3/__init__.py
+++ b/examples/nemotron3/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Direct HybridModel architecture examples for Nemotron 3 models."""
+
+from .nemotron_3_5_nano_30b_a3b import make_model_config as make_nano_model_config
+from .nemotron_labs_3_puzzle_75b_a9b import make_model_config as make_puzzle_model_config
+
+__all__ = ["make_nano_model_config", "make_puzzle_model_config"]

--- a/examples/nemotron3/nemotron_3_5_nano_30b_a3b.py
+++ b/examples/nemotron3/nemotron_3_5_nano_30b_a3b.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Architecture-only Nemotron 3.5 Nano 30B-A3B HybridModel example.
+
+The direct layer definition intentionally reuses one configuration per layer
+family. Nemotron 3.5 Nano is therefore a compatibility example for the direct
+API, not an example of occurrence-specific layer heterogeneity.
+
+Model dimensions are based on:
+https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16/blob/main/config.json
+"""
+
+from copy import deepcopy
+
+import torch
+
+from megatron.core.activations import squared_relu
+from megatron.core.models.hybrid.hybrid_architecture import HybridLayerSpec, PipelineSplit
+from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_stack_spec
+from megatron.core.transformer import TransformerConfig
+from megatron.training.models.hybrid import HybridModelConfig
+
+
+def _transformer_config() -> TransformerConfig:
+    """Return the model-wide Nano transformer configuration."""
+
+    return TransformerConfig(
+        num_layers=52,
+        hidden_size=2688,
+        num_attention_heads=32,
+        num_query_groups=2,
+        kv_channels=128,
+        ffn_hidden_size=1856,
+        moe_ffn_hidden_size=1856,
+        num_moe_experts=128,
+        moe_router_topk=6,
+        moe_router_num_groups=1,
+        moe_router_group_topk=1,
+        moe_router_topk_scaling_factor=2.5,
+        moe_router_score_function="sigmoid",
+        moe_router_enable_expert_bias=True,
+        moe_router_load_balancing_type="seq_aux_loss",
+        moe_shared_expert_intermediate_size=3712,
+        moe_token_dispatcher_type="alltoall",
+        moe_grouped_gemm=True,
+        mamba_state_dim=128,
+        mamba_head_dim=64,
+        mamba_num_heads=64,
+        mamba_num_groups=8,
+        mtp_num_layers=2,
+        mtp_use_repeated_layer=True,
+        activation_func=squared_relu,
+        gated_linear_unit=False,
+        add_bias_linear=False,
+        add_qkv_bias=False,
+        normalization="RMSNorm",
+        layernorm_epsilon=1.0e-5,
+        attention_dropout=0.0,
+        hidden_dropout=0.0,
+        init_method_std=0.02,
+        is_hybrid_model=True,
+        bf16=True,
+        params_dtype=torch.bfloat16,
+        pipeline_dtype=torch.bfloat16,
+        pipeline_model_parallel_size=2,
+    )
+
+
+def make_model_config() -> HybridModelConfig:
+    """Define Nano with direct specs split into PP2/VPP2 logical chunks."""
+
+    transformer = _transformer_config()
+    submodules = hybrid_stack_spec.submodules
+
+    # Aliases make the family-uniform nature of Nano explicit. The architecture
+    # resolver isolates the configuration of every resolved occurrence.
+    mamba = HybridLayerSpec(module_spec=submodules.mamba_layer, config=deepcopy(transformer))
+    attention = HybridLayerSpec(
+        module_spec=submodules.attention_layer, config=deepcopy(transformer)
+    )
+    moe = HybridLayerSpec(module_spec=submodules.moe_layer, config=deepcopy(transformer))
+
+    # Chunks are VPP-major then PP-rank: (vp0, pp0), (vp0, pp1),
+    # (vp1, pp0), (vp1, pp1). Each chunk contains exactly 13 layers.
+    chunk_0 = [mamba, moe] * 2 + [mamba, attention, moe] + [mamba, moe] * 2 + [mamba, attention]
+    chunk_1 = [moe, mamba] * 3 + [attention] + [moe, mamba] * 3
+    chunk_2 = [attention] + [moe, mamba] * 3 + [attention] + [moe, mamba] * 2 + [moe]
+    chunk_3 = [mamba, moe, mamba, attention, moe] + [mamba, moe] * 4
+
+    layer_specs = [
+        chunk_0,
+        PipelineSplit(),
+        chunk_1,
+        PipelineSplit(),
+        chunk_2,
+        PipelineSplit(),
+        chunk_3,
+    ]
+
+    mtp_attention = HybridLayerSpec(
+        module_spec=submodules.attention_layer, config=deepcopy(transformer)
+    )
+    mtp_moe = HybridLayerSpec(module_spec=submodules.moe_layer, config=deepcopy(transformer))
+
+    return HybridModelConfig(
+        transformer=transformer,
+        layer_specs=layer_specs,
+        mtp_layer_specs=[mtp_attention, mtp_moe],
+        vocab_size=131072,
+        seq_length=262144,
+        position_embedding_type="none",
+        parallel_output=True,
+        share_embeddings_and_output_weights=False,
+    )
+
+
+__all__ = ["make_model_config"]

--- a/examples/nemotron3/nemotron_labs_3_puzzle_75b_a9b.py
+++ b/examples/nemotron3/nemotron_labs_3_puzzle_75b_a9b.py
@@ -1,0 +1,218 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Architecture-only NVIDIA Nemotron Labs 3 Puzzle 75B-A9B example.
+
+Unlike Nano, Puzzle is heterogeneous within the MoE family: every MoE
+occurrence carries the expert width and router top-k published for that block.
+
+Model dimensions and ordered block configurations are based on:
+https://huggingface.co/nvidia/NVIDIA-Nemotron-Labs-3-Puzzle-75B-A9B-BF16/blob/main/config.json
+"""
+
+from copy import deepcopy
+
+import torch
+
+from megatron.core.activations import squared_relu
+from megatron.core.models.hybrid.hybrid_architecture import HybridLayerSpec, PipelineSplit
+from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_stack_spec
+from megatron.core.transformer import TransformerConfig
+from megatron.training.models.hybrid import HybridModelConfig
+
+
+def _transformer_config() -> TransformerConfig:
+    """Return the model-wide Puzzle transformer configuration."""
+
+    return TransformerConfig(
+        num_layers=88,
+        hidden_size=4096,
+        num_attention_heads=32,
+        num_query_groups=2,
+        kv_channels=128,
+        ffn_hidden_size=21504,
+        moe_ffn_hidden_size=1280,
+        num_moe_experts=512,
+        moe_router_topk=4,
+        moe_router_num_groups=1,
+        moe_router_group_topk=1,
+        moe_router_topk_scaling_factor=5.0,
+        moe_router_score_function="sigmoid",
+        moe_router_enable_expert_bias=True,
+        moe_router_load_balancing_type="seq_aux_loss",
+        moe_shared_expert_intermediate_size=5376,
+        moe_shared_expert_overlap=True,
+        moe_latent_size=1024,
+        moe_token_dispatcher_type="alltoall",
+        moe_grouped_gemm=True,
+        mamba_state_dim=96,
+        mamba_head_dim=64,
+        mamba_num_heads=128,
+        mamba_num_groups=8,
+        mtp_num_layers=1,
+        mtp_use_repeated_layer=False,
+        activation_func=squared_relu,
+        gated_linear_unit=False,
+        add_bias_linear=False,
+        add_qkv_bias=False,
+        normalization="RMSNorm",
+        layernorm_epsilon=1.0e-5,
+        attention_dropout=0.0,
+        hidden_dropout=0.0,
+        init_method_std=0.02,
+        is_hybrid_model=True,
+        bf16=True,
+        params_dtype=torch.bfloat16,
+        pipeline_dtype=torch.bfloat16,
+        pipeline_model_parallel_size=2,
+    )
+
+
+def _moe_layer(base_config: TransformerConfig, width: int, topk: int) -> HybridLayerSpec:
+    """Create one occurrence-specific stock MoE layer."""
+
+    config = deepcopy(base_config)
+    config.moe_ffn_hidden_size = width
+    config.moe_router_topk = topk
+    return HybridLayerSpec(module_spec=hybrid_stack_spec.submodules.moe_layer, config=config)
+
+
+def make_model_config() -> HybridModelConfig:
+    """Define Puzzle with direct specs split into PP2/VPP2 logical chunks."""
+
+    transformer = _transformer_config()
+    submodules = hybrid_stack_spec.submodules
+    mamba = HybridLayerSpec(module_spec=submodules.mamba_layer, config=deepcopy(transformer))
+    attention = HybridLayerSpec(
+        module_spec=submodules.attention_layer, config=deepcopy(transformer)
+    )
+
+    def moe(width: int, topk: int) -> HybridLayerSpec:
+        return _moe_layer(transformer, width, topk)
+
+    # Chunks are VPP-major then PP-rank. The inline MoE arguments are the
+    # published blockwise (expert width, active experts) values.
+    chunk_0 = [
+        mamba,
+        moe(1280, 4),
+        mamba,
+        moe(1280, 8),
+        mamba,
+        moe(1280, 10),
+        mamba,
+        attention,
+        moe(1280, 8),
+        mamba,
+        moe(1280, 8),
+        mamba,
+        moe(1280, 8),
+        mamba,
+        moe(1280, 12),
+        mamba,
+        attention,
+        moe(1280, 8),
+        mamba,
+        moe(1280, 10),
+        mamba,
+        moe(1280, 8),
+    ]
+    chunk_1 = [
+        mamba,
+        moe(2688, 12),
+        mamba,
+        attention,
+        moe(1536, 14),
+        mamba,
+        moe(2688, 12),
+        mamba,
+        moe(1536, 12),
+        mamba,
+        moe(1536, 12),
+        mamba,
+        moe(2688, 12),
+        mamba,
+        attention,
+        moe(2688, 12),
+        mamba,
+        moe(2688, 12),
+        mamba,
+        moe(1536, 10),
+        mamba,
+        moe(2688, 12),
+    ]
+    chunk_2 = [
+        mamba,
+        moe(2688, 12),
+        mamba,
+        attention,
+        moe(1792, 12),
+        mamba,
+        moe(1792, 14),
+        mamba,
+        moe(1280, 10),
+        mamba,
+        moe(1280, 10),
+        mamba,
+        moe(1280, 12),
+        mamba,
+        attention,
+        moe(1280, 8),
+        mamba,
+        moe(1280, 12),
+        mamba,
+        moe(1280, 10),
+        mamba,
+        moe(1280, 8),
+    ]
+    chunk_3 = [
+        mamba,
+        moe(1280, 8),
+        mamba,
+        attention,
+        moe(1280, 10),
+        mamba,
+        moe(1280, 10),
+        mamba,
+        moe(1280, 10),
+        mamba,
+        moe(1280, 12),
+        mamba,
+        attention,
+        moe(1280, 12),
+        mamba,
+        moe(1280, 14),
+        mamba,
+        moe(1280, 16),
+        mamba,
+        moe(1792, 18),
+        mamba,
+        moe(2048, 18),
+    ]
+
+    layer_specs = [
+        chunk_0,
+        PipelineSplit(),
+        chunk_1,
+        PipelineSplit(),
+        chunk_2,
+        PipelineSplit(),
+        chunk_3,
+    ]
+
+    mtp_attention = HybridLayerSpec(
+        module_spec=submodules.attention_layer, config=deepcopy(transformer)
+    )
+    mtp_moe = _moe_layer(transformer, width=2688, topk=22)
+
+    return HybridModelConfig(
+        transformer=transformer,
+        layer_specs=layer_specs,
+        mtp_layer_specs=[mtp_attention, mtp_moe],
+        vocab_size=131072,
+        seq_length=262144,
+        position_embedding_type="none",
+        parallel_output=True,
+        share_embeddings_and_output_weights=False,
+    )
+
+
+__all__ = ["make_model_config"]

--- a/tests/unit_tests/models/hybrid/test_nemotron3_recipes.py
+++ b/tests/unit_tests/models/hybrid/test_nemotron3_recipes.py
@@ -1,0 +1,223 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Structural tests for the architecture-only Nemotron 3 examples."""
+
+from itertools import chain
+
+from examples.nemotron3.nemotron_3_5_nano_30b_a3b import make_model_config as make_nano_model_config
+from examples.nemotron3.nemotron_labs_3_puzzle_75b_a9b import (
+    make_model_config as make_puzzle_model_config,
+)
+from megatron.core.models.hybrid.hybrid_architecture import (
+    flatten_hybrid_layer_pattern,
+    resolve_hybrid_architecture,
+)
+from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_stack_spec
+
+NANO_PATTERN = "MEMEM*EMEMEM*EMEMEM*EMEMEM*EMEMEM*EMEMEMEM*EMEMEMEME"
+PUZZLE_PATTERN = (
+    "MEMEMEM*EMEMEMEM*EMEMEMEM*EMEMEMEMEM*EMEMEMEMEM*" "EMEMEMEMEM*EMEMEMEMEM*EMEMEMEM*EMEMEMEME"
+)
+PUZZLE_MOE_CONFIGS = [
+    (1280, 4),
+    (1280, 8),
+    (1280, 10),
+    (1280, 8),
+    (1280, 8),
+    (1280, 8),
+    (1280, 12),
+    (1280, 8),
+    (1280, 10),
+    (1280, 8),
+    (2688, 12),
+    (1536, 14),
+    (2688, 12),
+    (1536, 12),
+    (1536, 12),
+    (2688, 12),
+    (2688, 12),
+    (2688, 12),
+    (1536, 10),
+    (2688, 12),
+    (2688, 12),
+    (1792, 12),
+    (1792, 14),
+    (1280, 10),
+    (1280, 10),
+    (1280, 12),
+    (1280, 8),
+    (1280, 12),
+    (1280, 10),
+    (1280, 8),
+    (1280, 8),
+    (1280, 10),
+    (1280, 10),
+    (1280, 10),
+    (1280, 12),
+    (1280, 12),
+    (1280, 14),
+    (1280, 16),
+    (1792, 18),
+    (2048, 18),
+]
+
+
+def _segments_and_layers(pattern):
+    segments = flatten_hybrid_layer_pattern(pattern)
+    return segments, tuple(chain.from_iterable(segments))
+
+
+def _layer_symbols(layers) -> str:
+    symbols = {"mamba": "M", "attention": "*", "moe": "E"}
+    return "".join(symbols[layer.module_spec.metainfo["hybrid_layer_type"]] for layer in layers)
+
+
+def _layers_of_type(layers, layer_type: str):
+    return [
+        layer for layer in layers if layer.module_spec.metainfo["hybrid_layer_type"] == layer_type
+    ]
+
+
+def _assert_transformer_values(config, expected):
+    assert {name: getattr(config.transformer, name) for name in expected} == expected
+
+
+def _resolve(config):
+    return resolve_hybrid_architecture(
+        config=config.transformer,
+        hybrid_stack_spec=hybrid_stack_spec,
+        layer_specs=config.layer_specs,
+        mtp_layer_specs=config.mtp_layer_specs,
+    )
+
+
+def test_nano_direct_architecture_matches_published_order_and_pp_vpp_split():
+    config = make_nano_model_config()
+    segments, layers = _segments_and_layers(config.layer_specs)
+
+    assert [len(segment) for segment in segments] == [13, 13, 13, 13]
+    assert [sum(map(len, segments[:index])) for index in range(4)] == [0, 13, 26, 39]
+    assert _layer_symbols(layers) == NANO_PATTERN
+    assert len(_layers_of_type(layers, "mamba")) == 23
+    assert len(_layers_of_type(layers, "moe")) == 23
+    assert [index for index, symbol in enumerate(_layer_symbols(layers)) if symbol == "*"] == [
+        5,
+        12,
+        19,
+        26,
+        33,
+        42,
+    ]
+
+    assert config.hybrid_layer_pattern is None
+    assert config.vocab_size == 131072
+    assert config.seq_length == 262144
+    assert config.transformer.virtual_pipeline_model_parallel_size is None
+    _assert_transformer_values(
+        config,
+        {
+            "pipeline_model_parallel_size": 2,
+            "num_layers": 52,
+            "hidden_size": 2688,
+            "num_attention_heads": 32,
+            "num_query_groups": 2,
+            "kv_channels": 128,
+            "ffn_hidden_size": 1856,
+            "mamba_state_dim": 128,
+            "mamba_head_dim": 64,
+            "mamba_num_heads": 64,
+            "mamba_num_groups": 8,
+            "num_moe_experts": 128,
+            "moe_ffn_hidden_size": 1856,
+            "moe_router_topk": 6,
+            "moe_router_num_groups": 1,
+            "moe_router_group_topk": 1,
+            "moe_shared_expert_intermediate_size": 3712,
+        },
+    )
+
+    architecture = _resolve(config)
+    assert [len(segment) for segment in architecture.segments] == [13, 13, 13, 13]
+    assert config.transformer.virtual_pipeline_model_parallel_size == 2
+
+
+def test_nano_reuses_uniform_family_configs_and_defines_repeated_mtp():
+    config = make_nano_model_config()
+    _, layers = _segments_and_layers(config.layer_specs)
+
+    for layer_type in ("mamba", "attention", "moe"):
+        family = _layers_of_type(layers, layer_type)
+        assert len({id(layer.config) for layer in family}) == 1
+
+    moe_configs = _layers_of_type(layers, "moe")
+    assert {
+        (layer.config.moe_ffn_hidden_size, layer.config.moe_router_topk) for layer in moe_configs
+    } == {(1856, 6)}
+
+    mtp_segments, mtp_layers = _segments_and_layers(config.mtp_layer_specs)
+    assert [len(segment) for segment in mtp_segments] == [2]
+    assert _layer_symbols(mtp_layers) == "*E"
+    assert config.transformer.mtp_num_layers == 2
+    assert config.transformer.mtp_use_repeated_layer is True
+
+
+def test_puzzle_direct_architecture_matches_published_order_and_pp_vpp_split():
+    config = make_puzzle_model_config()
+    segments, layers = _segments_and_layers(config.layer_specs)
+
+    assert [len(segment) for segment in segments] == [22, 22, 22, 22]
+    assert [sum(map(len, segments[:index])) for index in range(4)] == [0, 22, 44, 66]
+    assert _layer_symbols(layers) == PUZZLE_PATTERN
+    assert len(_layers_of_type(layers, "mamba")) == 40
+    assert len(_layers_of_type(layers, "moe")) == 40
+    assert len(_layers_of_type(layers, "attention")) == 8
+
+    assert config.hybrid_layer_pattern is None
+    assert config.vocab_size == 131072
+    assert config.seq_length == 262144
+    assert config.transformer.virtual_pipeline_model_parallel_size is None
+    _assert_transformer_values(
+        config,
+        {
+            "pipeline_model_parallel_size": 2,
+            "num_layers": 88,
+            "hidden_size": 4096,
+            "num_attention_heads": 32,
+            "num_query_groups": 2,
+            "kv_channels": 128,
+            "ffn_hidden_size": 21504,
+            "mamba_state_dim": 96,
+            "mamba_head_dim": 64,
+            "mamba_num_heads": 128,
+            "mamba_num_groups": 8,
+            "num_moe_experts": 512,
+            "moe_router_num_groups": 1,
+            "moe_router_group_topk": 1,
+            "moe_shared_expert_intermediate_size": 5376,
+            "moe_latent_size": 1024,
+        },
+    )
+
+    architecture = _resolve(config)
+    assert [len(segment) for segment in architecture.segments] == [22, 22, 22, 22]
+    assert config.transformer.virtual_pipeline_model_parallel_size == 2
+
+
+def test_puzzle_preserves_every_occurrence_specific_moe_config_and_mtp():
+    config = make_puzzle_model_config()
+    _, layers = _segments_and_layers(config.layer_specs)
+    moe_layers = _layers_of_type(layers, "moe")
+
+    assert [
+        (layer.config.moe_ffn_hidden_size, layer.config.moe_router_topk) for layer in moe_layers
+    ] == PUZZLE_MOE_CONFIGS
+    assert len({id(layer.config) for layer in moe_layers}) == 40
+    assert {layer.config.num_moe_experts for layer in moe_layers} == {512}
+
+    mtp_segments, mtp_layers = _segments_and_layers(config.mtp_layer_specs)
+    assert [len(segment) for segment in mtp_segments] == [2]
+    assert _layer_symbols(mtp_layers) == "*E"
+    assert mtp_layers[1].config.moe_ffn_hidden_size == 2688
+    assert mtp_layers[1].config.moe_router_topk == 22
+    assert config.transformer.mtp_num_layers == 1
+    assert config.transformer.mtp_use_repeated_layer is False


### PR DESCRIPTION
## Summary

- Add architecture-only direct-spec definitions for Nemotron 3.5 Nano and Nemotron Labs 3 Puzzle.
- Add exact structural fidelity tests for layer order, PP2/VPP2 splits, MTP, and Puzzle MoE overrides.
- Document the direct API and the strict legacy compatibility boundary.

Stacked on #6299.