### PR TITLE
Reject unsupported heterogeneous hybrid inference

### DIFF
--- a/docs/user-guide/hybrid-model-migration.md
+++ b/docs/user-guide/hybrid-model-migration.md
@@ -366,11 +366,6 @@ remove `--decoder-first-pipeline-num-layers` and
 `--decoder-last-pipeline-num-layers`. Express virtual-pipeline segmentation
 with additional pipe-delimited segments instead.
 
-The declarative `HybridModelBuilder` currently rejects virtual pipeline
-parallelism. Pipe-defined virtual stages are supported by the
-`pretrain_hybrid.py` CLI builder, but custom builder users must avoid VPP or use
-a path that explicitly supports it.
-
 ### Update custom providers and conversion mappings
 
 Custom providers and conversion mappings also need to account for these API and
@@ -398,3 +393,12 @@ Before starting a long run:
   parameter counts by layer.
 - Save and reload one new checkpoint to confirm that the new optimizer and RNG
   state resume correctly.
+
+Direct layer specs are currently training-first. Dynamic inference rejects a
+direct architecture when occurrence configurations are incompatible with its
+model-global cache or runtime buffers, whether the occurrences differ from one
+another or a family-uniform override differs from the base `TransformerConfig`.
+Examples include differing Mamba state dimensions and attention KV dimensions
+or MoE top-k values that differ from the base config. Legacy
+`hybrid_layer_pattern` models retain their existing inference path and do not
+use this direct-spec validator.

--- a/megatron/core/inference/apis/_llm_base.py
+++ b/megatron/core/inference/apis/_llm_base.py
@@ -17,7 +17,7 @@ from typing import Coroutine, List, Optional, Tuple, Union
 
 import torch.distributed as dist
 
-from megatron.core.inference.config import InferenceConfig
+from megatron.core.inference.config import InferenceConfig, validate_dynamic_inference_model
 from megatron.core.inference.contexts.dynamic_context import DynamicInferenceContext
 from megatron.core.inference.engines.dynamic_engine import DynamicInferenceEngine, EngineState
 from megatron.core.inference.inference_request import DynamicInferenceRequest
@@ -279,6 +279,7 @@ class _MegatronLLMBase:
             inference_config = InferenceConfig()
 
         # Build the engine pipeline. Mirrors examples/inference/gpt/gpt_dynamic_inference.py.
+        validate_dynamic_inference_model(model)
         context = DynamicInferenceContext(model.config, inference_config)
         wrapper = GPTInferenceWrapper(model, context)
         controller = TextGenerationController(inference_wrapped_model=wrapper, tokenizer=tokenizer)

--- a/megatron/core/inference/config.py
+++ b/megatron/core/inference/config.py
@@ -12,6 +12,29 @@ from megatron.core.transformer.module import MegatronModule
 from megatron.core.utils import get_attr_wrapped_model
 
 
+def validate_dynamic_inference_model(model: MegatronModule) -> None:
+    """Reject incompatible direct specs before model-global inference buffers are allocated."""
+
+    from megatron.core.models.hybrid.hybrid_architecture import ResolvedHybridArchitecture
+
+    try:
+        architecture = get_attr_wrapped_model(model, "resolved_hybrid_architecture")
+    except RuntimeError:
+        return
+    if not isinstance(architecture, ResolvedHybridArchitecture):
+        return
+    if architecture.source != "direct":
+        return
+
+    model_config = get_attr_wrapped_model(model, "config", allow_none=False)
+    if architecture.has_incompatible_dynamic_inference_shapes(model_config):
+        raise NotImplementedError(
+            "Direct HybridModel occurrence configurations are incompatible with dynamic "
+            "inference's model-global cache or runtime buffers (Mamba state/cache dimensions, "
+            "attention KV dimensions, or MoE router top-k values)."
+        )
+
+
 @dataclass
 class MambaInferenceStateConfig:
     """
@@ -49,14 +72,41 @@ class MambaInferenceStateConfig:
         model: MegatronModule,
         conv_states_dtype: Optional[torch.dtype] = None,
         ssm_states_dtype: Optional[torch.dtype] = None,
+        *,
+        validate_dynamic_inference: bool = True,
     ) -> Optional["MambaInferenceStateConfig"]:
-        """Returns Mamba inference state config from the model if it is a hybrid model."""
+        """Returns Mamba inference state config from the model if it is a hybrid model.
+
+        Args:
+            validate_dynamic_inference: Validate direct specs against the model-global buffers
+                used by dynamic inference. The explicit legacy static engine disables this
+                because its Mamba, attention, and MoE state is allocated by each layer.
+        """
         from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols
 
+        if validate_dynamic_inference:
+            validate_dynamic_inference_model(model)
         decoder = get_attr_wrapped_model(model, "decoder")
         layer_type_list = getattr(decoder, "layer_type_list", None)
+        # HybridStack's first-class API exposes stable semantic names, while
+        # dynamic inference's layer maps intentionally retain legacy symbols.
+        semantic_to_symbol = {
+            "mamba": Symbols.MAMBA,
+            "gdn": Symbols.GDN,
+            "attention": Symbols.ATTENTION,
+            "dsa": Symbols.DS_ATTENTION,
+            "mla": Symbols.MLA,
+            "mlp": Symbols.MLP,
+            "moe": Symbols.MOE,
+        }
+        if layer_type_list is not None and any(
+            layer_type in semantic_to_symbol for layer_type in layer_type_list
+        ):
+            layer_type_list = [
+                semantic_to_symbol.get(layer_type, layer_type) for layer_type in layer_type_list
+            ]
         if layer_type_list is not None and Symbols.MAMBA in layer_type_list:
-            (mamba_conv_states_shape, mamba_ssm_states_shape) = (
+            mamba_conv_states_shape, mamba_ssm_states_shape = (
                 decoder.mamba_state_shapes_per_request()
             )
             if conv_states_dtype is None:
@@ -73,7 +123,7 @@ class MambaInferenceStateConfig:
             elif ssm_states_dtype is None:
                 ssm_states_dtype = model.config.params_dtype
             mamba_chunk_size = 128
-            for layer_type, layer in zip(decoder.layer_type_list, decoder.layers):
+            for layer_type, layer in zip(layer_type_list, decoder.layers):
                 if layer_type == Symbols.MAMBA and hasattr(layer, 'mixer'):
                     mamba_chunk_size = layer.mixer.chunk_size
                     break

--- a/megatron/core/inference/engines/static_engine.py
+++ b/megatron/core/inference/engines/static_engine.py
@@ -94,7 +94,7 @@ class StaticInferenceEngine(AbstractEngine):
         self.scheduler = Scheduler(max_batch_size=max_batch_size)
 
         mamba_inference_state_config = MambaInferenceStateConfig.from_model(
-            self.inference_wrapped_model.model
+            self.inference_wrapped_model.model, validate_dynamic_inference=not legacy
         )
 
         try:

--- a/megatron/core/models/hybrid/hybrid_model.py
+++ b/megatron/core/models/hybrid/hybrid_model.py
@@ -641,6 +641,21 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
         inference_context = deprecate_inference_params(inference_context, inference_params)
 
         in_inference_mode = InferenceMode.is_active()
+        resolved_architecture = getattr(self, "resolved_hybrid_architecture", None)
+
+        if (
+            in_inference_mode
+            and inference_context is not None
+            and inference_context.is_dynamic_batching()
+            and resolved_architecture is not None
+            and resolved_architecture.source == "direct"
+            and resolved_architecture.has_incompatible_dynamic_inference_shapes(self.config)
+        ):
+            raise NotImplementedError(
+                "Direct HybridModel occurrence configurations are incompatible with dynamic "
+                "inference's model-global cache or runtime buffers (Mamba state/cache "
+                "dimensions, attention KV dimensions, or MoE router top-k values)."
+            )
 
         if in_inference_mode:
             assert runtime_gather_output, "Inference must always gather TP logits"

--- a/tests/unit_tests/models/hybrid/test_hybrid_architecture.py
+++ b/tests/unit_tests/models/hybrid/test_hybrid_architecture.py
@@ -8,6 +8,8 @@ from types import SimpleNamespace
 import pytest
 import torch
 
+from megatron.core.inference.config import MambaInferenceStateConfig
+from megatron.core.inference.utils import InferenceMode
 from megatron.core.models.hybrid.hybrid_architecture import (
     HYBRID_LAYER_TYPE,
     HybridLayerSpec,
@@ -19,6 +21,7 @@ from megatron.core.models.hybrid.hybrid_layer_specs import (
     hybrid_inference_stack_spec,
     hybrid_stack_spec,
 )
+from megatron.core.models.hybrid.hybrid_model import HybridModel
 from megatron.core.transformer import TransformerConfig
 from megatron.core.transformer.spec_utils import ModuleSpec
 
@@ -97,6 +100,17 @@ def _layer(layer_type: str, config: TransformerConfig) -> HybridLayerSpec:
 
 def _types(layers) -> list[str]:
     return [layer.layer_type for layer in layers]
+
+
+def _model_shell(architecture, config):
+    """Create enough of a HybridModel to exercise its early inference guards."""
+
+    model = HybridModel.__new__(HybridModel)
+    torch.nn.Module.__init__(model)
+    model.config = config
+    if architecture is not None:
+        model.resolved_hybrid_architecture = architecture
+    return model
 
 
 @pytest.mark.parametrize(
@@ -283,6 +297,215 @@ def test_resolver_preserves_permitted_per_layer_shape_differences():
         (layers[index].config.moe_ffn_hidden_size, layers[index].config.moe_router_topk)
         for index in (6, 7)
     ] == [(112, 3), (144, 4)]
+
+
+@pytest.mark.parametrize(
+    ("layer_type", "field_name", "heterogeneous_value"),
+    [
+        pytest.param("mamba", "mamba_state_dim", 24, id="mamba-cache"),
+        pytest.param("attention", "kv_channels", 16, id="attention-kv-cache"),
+        pytest.param("moe", "moe_router_topk", 3, id="moe-router-buffer"),
+    ],
+)
+def test_dynamic_inference_rejects_heterogeneous_runtime_shapes(
+    layer_type, field_name, heterogeneous_value
+):
+    config = _config(2)
+    first_config = deepcopy(config)
+    second_config = deepcopy(config)
+    setattr(second_config, field_name, heterogeneous_value)
+    architecture = resolve_hybrid_architecture(
+        config=config,
+        hybrid_stack_spec=STACK_SPEC,
+        layer_specs=[_layer(layer_type, first_config), _layer(layer_type, second_config)],
+    )
+    model = _model_shell(architecture, config)
+    inference_context = SimpleNamespace(is_dynamic_batching=lambda: True)
+
+    with (
+        InferenceMode.active(),
+        pytest.raises(
+            NotImplementedError, match="incompatible with dynamic inference's model-global"
+        ),
+    ):
+        model.forward(
+            input_ids=None,
+            position_ids=None,
+            attention_mask=None,
+            inference_context=inference_context,
+            runtime_gather_output=False,
+        )
+
+
+@pytest.mark.parametrize(
+    ("layer_type", "field_name", "override_value"),
+    [
+        pytest.param("attention", "kv_channels", 16, id="attention-kv-cache"),
+        pytest.param("moe", "moe_router_topk", 3, id="moe-router-buffer"),
+    ],
+)
+def test_dynamic_inference_rejects_uniform_overrides_incompatible_with_global_buffers(
+    layer_type, field_name, override_value
+):
+    config = _config(2)
+    layer_config = deepcopy(config)
+    setattr(layer_config, field_name, override_value)
+    architecture = resolve_hybrid_architecture(
+        config=config,
+        hybrid_stack_spec=STACK_SPEC,
+        layer_specs=[_layer(layer_type, layer_config), _layer(layer_type, layer_config)],
+    )
+    model = _model_shell(architecture, config)
+    inference_context = SimpleNamespace(is_dynamic_batching=lambda: True)
+
+    with (
+        InferenceMode.active(),
+        pytest.raises(
+            NotImplementedError, match="incompatible with dynamic inference's model-global"
+        ),
+    ):
+        model.forward(
+            input_ids=None,
+            position_ids=None,
+            attention_mask=None,
+            inference_context=inference_context,
+            runtime_gather_output=False,
+        )
+
+
+def test_dynamic_inference_allows_uniform_runtime_shapes_past_heterogeneity_guard():
+    config = _config(2)
+    architecture = resolve_hybrid_architecture(
+        config=config,
+        hybrid_stack_spec=STACK_SPEC,
+        layer_specs=[_layer("mamba", config), _layer("mamba", config)],
+    )
+    model = _model_shell(architecture, config)
+    inference_context = SimpleNamespace(is_dynamic_batching=lambda: True)
+
+    # The next inference invariant proves the heterogeneity guard allowed this
+    # uniform architecture through without needing to construct model layers.
+    with (
+        InferenceMode.active(),
+        pytest.raises(AssertionError, match="Inference must always gather TP logits"),
+    ):
+        model.forward(
+            input_ids=None,
+            position_ids=None,
+            attention_mask=None,
+            inference_context=inference_context,
+            runtime_gather_output=False,
+        )
+
+
+def test_dynamic_inference_rejects_before_reading_layer_state_shapes():
+    config = _config(2)
+    second_config = deepcopy(config)
+    second_config.mamba_state_dim = 24
+    architecture = resolve_hybrid_architecture(
+        config=config,
+        hybrid_stack_spec=STACK_SPEC,
+        layer_specs=[_layer("mamba", config), _layer("mamba", second_config)],
+    )
+
+    class ModelWithUnallocatedState:
+        resolved_hybrid_architecture = architecture
+
+        def __init__(self):
+            self.config = config
+
+        @property
+        def decoder(self):
+            raise AssertionError("Mamba state shapes must not be read before rejection")
+
+    with pytest.raises(
+        NotImplementedError, match="incompatible with dynamic inference's model-global"
+    ):
+        MambaInferenceStateConfig.from_model(ModelWithUnallocatedState())
+
+
+def test_explicit_static_engine_path_skips_dynamic_shape_validation():
+    config = _config(2)
+    second_config = deepcopy(config)
+    second_config.mamba_state_dim = 24
+    architecture = resolve_hybrid_architecture(
+        config=config,
+        hybrid_stack_spec=STACK_SPEC,
+        layer_specs=[_layer("mamba", config), _layer("mamba", second_config)],
+    )
+    decoder = SimpleNamespace(
+        layer_type_list=["mamba", "mamba"],
+        layers=[SimpleNamespace(mixer=SimpleNamespace(chunk_size=64)), SimpleNamespace()],
+        mamba_state_shapes_per_request=lambda: ((8, 4), (8, 16)),
+    )
+    model = SimpleNamespace(
+        resolved_hybrid_architecture=architecture,
+        decoder=decoder,
+        config=SimpleNamespace(params_dtype=torch.bfloat16, batch_invariant_mode=False),
+    )
+
+    inference_config = MambaInferenceStateConfig.from_model(model, validate_dynamic_inference=False)
+
+    assert inference_config is not None
+    assert inference_config.layer_type_list == ["M", "M"]
+
+
+def test_inference_state_normalizes_semantic_layer_types_to_legacy_maps():
+    decoder = SimpleNamespace(
+        layer_type_list=["mamba", "attention"],
+        layers=[SimpleNamespace(mixer=SimpleNamespace(chunk_size=64)), SimpleNamespace()],
+        mamba_state_shapes_per_request=lambda: ((8, 4), (8, 16)),
+    )
+    model = SimpleNamespace(
+        decoder=decoder,
+        config=SimpleNamespace(params_dtype=torch.bfloat16, batch_invariant_mode=False),
+    )
+
+    inference_config = MambaInferenceStateConfig.from_model(model)
+
+    assert inference_config is not None
+    assert inference_config.layer_type_list == ["M", "*"]
+    assert inference_config.mamba_chunk_size == 64
+
+
+def test_legacy_inference_keeps_symbol_list_identity_and_skips_direct_shape_rejection():
+    layer_type_list = ["M", "M"]
+    decoder = SimpleNamespace(
+        layer_type_list=layer_type_list,
+        layers=[SimpleNamespace(mixer=SimpleNamespace(chunk_size=64)), SimpleNamespace()],
+        mamba_state_shapes_per_request=lambda: ((8, 4), (8, 16)),
+    )
+    model = SimpleNamespace(
+        decoder=decoder,
+        config=SimpleNamespace(params_dtype=torch.bfloat16, batch_invariant_mode=False),
+    )
+
+    assert not hasattr(model, "resolved_hybrid_architecture")
+
+    inference_config = MambaInferenceStateConfig.from_model(model)
+
+    assert inference_config is not None
+    assert inference_config.layer_type_list is layer_type_list
+
+
+def test_legacy_forward_does_not_run_direct_heterogeneity_guard():
+    config = _config(2)
+    model = _model_shell(None, config)
+    inference_context = SimpleNamespace(is_dynamic_batching=lambda: True)
+
+    assert not hasattr(model, "resolved_hybrid_architecture")
+
+    with (
+        InferenceMode.active(),
+        pytest.raises(AssertionError, match="Inference must always gather TP logits"),
+    ):
+        model.forward(
+            input_ids=None,
+            position_ids=None,
+            attention_mask=None,
+            inference_context=inference_context,
+            runtime_gather_output=False,
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Reject incompatible direct occurrence configs before dynamic-inference buffers are allocated.
- Preserve supported semantic layer maps and the explicit legacy static-engine path.
- Bypass direct validation and state remapping for legacy HybridModels.

Stacked on #6297.