### PR TITLE
Add HybridModel Python recipe API and launcher support

### DIFF
--- a/examples/nemotron3/__init__.py
+++ b/examples/nemotron3/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.

--- a/examples/nemotron3/__init__.py
+++ b/examples/nemotron3/__init__.py
@@ -1,1 +1,3 @@
-# Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Nemotron-3 example recipes and launchers."""

--- a/examples/nemotron3/nano.py
+++ b/examples/nemotron3/nano.py
@@ -1,0 +1,206 @@
+# Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Nemotron-3 Nano model recipe expressed in the HybridModel Python DSL.
+
+A 52-layer hybrid model interleaving Mamba SSM, attention, and MoE layers.
+Faithful 1:1 with the canonical
+``Megatron-Bridge/recipes/nemotronh/nemotron_3_nano.py::nemotron_3_nano_pretrain_config``.
+
+Recipe entry point: :func:`make_recipe`. ``num_layers`` is intentionally
+**not** set anywhere — it is derived at lowering time from the flattened
+decoder length of ``layer_pattern``.
+
+Use this recipe via the ``--model-recipe`` flag in any of these forms::
+
+    --model-recipe examples.nemotron3.nano
+    --model-recipe examples.nemotron3.nano:make_recipe
+    --model-recipe /path/to/this/file.py
+    --model-recipe /path/to/this/file.py:make_recipe
+
+Run this file directly to print the resulting ``layer_type_list``::
+
+    uv run python -m examples.nemotron3.nano
+"""
+
+import torch
+
+from megatron.core.models.hybrid import (
+    AttentionLayerConfig,
+    CommonLayerConfig,
+    CrossEntropyLayerConfig,
+    EmbeddingLayerConfig,
+    HybridModelConfig,
+    MambaLayerConfig,
+    MoELayerConfig,
+)
+
+VOCAB_SIZE: int = 131072
+MAX_SEQUENCE_LENGTH: int = 8192
+
+
+# --- Common (model-wide) defaults ------------------------------------------
+
+#
+# Each field below either differs from the TransformerConfig default OR is
+# unique to Nemotron-3 Nano. TC-default-matching fields (``apply_rope_fusion``,
+# ``gated_linear_unit``, ``transformer_impl``,
+# ``cuda_graph_impl``, ``cuda_graph_scope``, ``cuda_graph_warmup_steps``,
+# ``moe_layer_freq``, ``moe_router_bias_update_rate``,
+# ``mtp_loss_scaling_factor``, ``overlap_p2p_comm``) are intentionally
+# omitted — they fall through to TC's own defaults at lowering time.
+#
+# ``is_hybrid_model=True`` is also intentionally absent — every HybridModel
+# recipe is a hybrid model by construction; the DSL's internal lowering
+# forces it on every per-layer TC.
+#
+# ``make_vocab_size_divisible_by=128`` from the canonical config is NOT a
+# TransformerConfig field — it's a launcher-side tokenizer pad. The DSL
+# expresses it by setting ``EmbeddingLayerConfig.vocab_size`` to the already-
+# padded value (131072 below = 1024 * 128).
+common_config = CommonLayerConfig(
+    # Architecture
+    hidden_size=2688,
+    ffn_hidden_size=1856,
+    # Precision
+    mixed_precision_dtype=torch.bfloat16,
+    first_last_layers_bf16=True,
+    # Layer-level parallelism (TP/CP/EP sizes live on HybridModelConfig).
+    sequence_parallel=True,
+    # Initialisation
+    init_method_std=0.0173,
+    # Norms
+    normalization="RMSNorm",
+    # Bias / activation
+    add_bias_linear=False,
+    activation_func="squared_relu",
+    # Fusions
+    persist_layer_norm=True,
+    # ``tp_comm_overlap`` is not a curated DSL field today; the Bridge config
+    # sets it via CommOverlapConfig. Use ``extra`` to project it onto every
+    # per-layer TransformerConfig (matches the legacy ``--tp-comm-overlap``
+    # CLI flag).
+    extra={"tp_comm_overlap": True},
+)
+
+
+# --- Per-layer configs -----------------------------------------------------
+
+Embedding = EmbeddingLayerConfig(
+    common_config=common_config,
+    vocab_size=VOCAB_SIZE,
+    max_sequence_length=MAX_SEQUENCE_LENGTH,
+    position_embedding_type="none",
+)
+
+Mamba = MambaLayerConfig(
+    common_config=common_config, head_dim=64, state_size=128, num_groups=8, num_heads=64
+)
+
+Att = AttentionLayerConfig(
+    common_config=common_config,
+    num_attention_heads=32,
+    num_query_groups=2,
+    kv_channels=128,
+    attention_softmax_in_fp32=False,
+    masked_softmax_fusion=True,
+    attention_backend="fused",
+)
+
+MoE = MoELayerConfig(
+    common_config=common_config,
+    num_experts=128,
+    top_k=6,
+    ffn_hidden_size=1856,
+    router_score_function="sigmoid",
+    router_load_balancing_type="seq_aux_loss",
+    router_topk_scaling_factor=2.5,
+    router_enable_expert_bias=True,
+    router_dtype="fp32",
+    aux_loss_coeff=1e-4,
+    shared_expert_intermediate_size=3712,
+    # DeepEP-backed flex dispatcher (final canonical value).
+    token_dispatcher_type="flex",
+    flex_dispatcher_backend="deepep",
+    hybridep_num_sms=16,
+    grouped_gemm=True,
+    permute_fusion=True,
+    router_num_groups=1,
+    router_group_topk=1,
+    router_fusion=False,
+    shared_expert_overlap=False,
+    use_fused_weighted_squared_relu=True,
+)
+
+Loss = CrossEntropyLayerConfig(loss_fusion=True, fusion_impl="native")
+
+
+# --- Layer pattern composition ---------------------------------------------
+#
+# Decoder layout (52 layers total = 6 + 28 + 9 + 9). ``num_layers`` is never
+# set explicitly; ``HybridModelConfig.num_layers`` derives it from the
+# flattened pattern length.
+
+stage0 = [Mamba] + [MoE, Mamba] * 2 + [Att]
+stage1 = [MoE, Mamba] * 3 + [Att]
+stage2 = [MoE, Mamba] * 4 + [Att]
+stage3 = [MoE, Mamba] * 4 + [MoE]
+
+decoder = stage0 + stage1 * 4 + stage2 + stage3
+
+layer_pattern = [Embedding] + decoder + [Loss]
+
+
+# --- Recipe entry point ----------------------------------------------------
+
+
+def make_recipe() -> HybridModelConfig:
+    """Return the Nemotron-3 Nano HybridModel pretrain recipe.
+
+    ``make_recipe`` is the canonical default entry point used when
+    ``--model-recipe`` is passed without a ``:func`` suffix.
+    """
+    return HybridModelConfig(
+        common_config=common_config,
+        layer_pattern=layer_pattern,
+        untie_embeddings_and_output_weights=True,
+        # Model-level parallelism (PP intentionally absent — the recipe DSL
+        # is PP-free; recipes that need PP must use the legacy string DSL).
+        tensor_model_parallel_size=4,
+        expert_model_parallel_size=8,
+        expert_tensor_parallel_size=1,
+    )
+
+
+def nemotron_3_nano_pretrain_config():
+    """Bridge-style alias retained for explicit ``:func`` selection."""
+    return make_recipe()
+
+
+if __name__ == "__main__":
+    # Lower the recipe and print the resulting layer_type_list. This is
+    # the same code path ``--model-recipe`` exercises in production via
+    # ``HybridModel.from_recipe``.
+    #
+    # The full lowering requires Transformer Engine
+    # (``moe_permute_fusion=True``, ``transformer_impl="transformer_engine"``,
+    # etc. trigger TE checks at config-construction time). In dev environments
+    # without TE, fall back to the pure-Python ``flatten_decoder`` +
+    # ``SYMBOL`` derivation so the smoke test can still verify the pattern
+    # composition.
+    recipe = make_recipe()
+    try:
+        _, layer_type_list, _ = recipe._lower()
+    except (ValueError, ImportError, ModuleNotFoundError) as e:
+        msg = str(e)
+        if "fused permutation" not in msg and "TE" not in msg and "transformer_engine" not in msg:
+            raise
+        print(
+            f"NOTE: full lowering needs Transformer Engine "
+            f"({type(e).__name__}: {e}). Falling back to pattern-only "
+            f"verification — production runs go through HybridModel.from_recipe."
+        )
+        layer_type_list = [type(lc).SYMBOL for lc in recipe.flatten_decoder()]
+    composed_string = "".join(layer_type_list)
+
+    print(f"Composed layer pattern: {composed_string}")
+    print(f"Layer count:            {len(layer_type_list)}")

--- a/examples/nemotron3/nano.py
+++ b/examples/nemotron3/nano.py
@@ -1,26 +1,17 @@
-# Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
-
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 """Nemotron-3 Nano model recipe expressed in the HybridModel Python DSL.
 
-A 52-layer hybrid model interleaving Mamba SSM, attention, and MoE layers.
-Faithful 1:1 with the canonical
-``Megatron-Bridge/recipes/nemotronh/nemotron_3_nano.py::nemotron_3_nano_pretrain_config``.
+The recipe defines the same 52-layer hybrid model as the legacy string DSL
+pattern used by :mod:`examples.nemotron3.nano.sh`:
 
-Recipe entry point: :func:`make_recipe`. ``num_layers`` is intentionally
-**not** set anywhere — it is derived at lowering time from the flattened
-decoder length of ``layer_pattern``.
+``MEMEM*EMEMEM*EMEMEM*EMEMEM*EMEMEM*EMEMEMEM*EMEMEMEME``
 
-Use this recipe via the ``--model-recipe`` flag in any of these forms::
-
-    --model-recipe examples.nemotron3.nano
-    --model-recipe examples.nemotron3.nano:make_recipe
-    --model-recipe /path/to/this/file.py
-    --model-recipe /path/to/this/file.py:make_recipe
-
-Run this file directly to print the resulting ``layer_type_list``::
-
-    uv run python -m examples.nemotron3.nano
+Use it with ``pretrain_hybrid.py --model-recipe examples.nemotron3.nano``.
+The SLURM launcher can override topology with ``NANO_TP``, ``NANO_CP``,
+``NANO_EP``, ``NANO_ETP``, and ``NANO_SP``.
 """
+
+import os
 
 import torch
 
@@ -34,173 +25,125 @@ from megatron.core.models.hybrid import (
     MoELayerConfig,
 )
 
-VOCAB_SIZE: int = 131072
-MAX_SEQUENCE_LENGTH: int = 8192
+LEGACY_HYBRID_LAYER_PATTERN = "MEMEM*EMEMEM*EMEMEM*EMEMEM*EMEMEM*EMEMEMEM*EMEMEMEME"
+VOCAB_SIZE = 131072
+MAX_SEQUENCE_LENGTH = 8192
 
 
-# --- Common (model-wide) defaults ------------------------------------------
-
-#
-# Each field below either differs from the TransformerConfig default OR is
-# unique to Nemotron-3 Nano. TC-default-matching fields (``apply_rope_fusion``,
-# ``gated_linear_unit``, ``transformer_impl``,
-# ``cuda_graph_impl``, ``cuda_graph_scope``, ``cuda_graph_warmup_steps``,
-# ``moe_layer_freq``, ``moe_router_bias_update_rate``,
-# ``mtp_loss_scaling_factor``, ``overlap_p2p_comm``) are intentionally
-# omitted — they fall through to TC's own defaults at lowering time.
-#
-# ``is_hybrid_model=True`` is also intentionally absent — every HybridModel
-# recipe is a hybrid model by construction; the DSL's internal lowering
-# forces it on every per-layer TC.
-#
-# ``make_vocab_size_divisible_by=128`` from the canonical config is NOT a
-# TransformerConfig field — it's a launcher-side tokenizer pad. The DSL
-# expresses it by setting ``EmbeddingLayerConfig.vocab_size`` to the already-
-# padded value (131072 below = 1024 * 128).
-common_config = CommonLayerConfig(
-    # Architecture
-    hidden_size=2688,
-    ffn_hidden_size=1856,
-    # Precision
-    mixed_precision_dtype=torch.bfloat16,
-    first_last_layers_bf16=True,
-    # Layer-level parallelism (TP/CP/EP sizes live on HybridModelConfig).
-    sequence_parallel=True,
-    # Initialisation
-    init_method_std=0.0173,
-    # Norms
-    normalization="RMSNorm",
-    # Bias / activation
-    add_bias_linear=False,
-    activation_func="squared_relu",
-    # Fusions
-    persist_layer_norm=True,
-    # ``tp_comm_overlap`` is not a curated DSL field today; the Bridge config
-    # sets it via CommOverlapConfig. Use ``extra`` to project it onto every
-    # per-layer TransformerConfig (matches the legacy ``--tp-comm-overlap``
-    # CLI flag).
-    extra={"tp_comm_overlap": True},
-)
+def _env_int(name: str, default: int) -> int:
+    value = os.getenv(name)
+    return default if value is None else int(value)
 
 
-# --- Per-layer configs -----------------------------------------------------
-
-Embedding = EmbeddingLayerConfig(
-    common_config=common_config,
-    vocab_size=VOCAB_SIZE,
-    max_sequence_length=MAX_SEQUENCE_LENGTH,
-    position_embedding_type="none",
-)
-
-Mamba = MambaLayerConfig(
-    common_config=common_config, head_dim=64, state_size=128, num_groups=8, num_heads=64
-)
-
-Att = AttentionLayerConfig(
-    common_config=common_config,
-    num_attention_heads=32,
-    num_query_groups=2,
-    kv_channels=128,
-    attention_softmax_in_fp32=False,
-    masked_softmax_fusion=True,
-    attention_backend="fused",
-)
-
-MoE = MoELayerConfig(
-    common_config=common_config,
-    num_experts=128,
-    top_k=6,
-    ffn_hidden_size=1856,
-    router_score_function="sigmoid",
-    router_load_balancing_type="seq_aux_loss",
-    router_topk_scaling_factor=2.5,
-    router_enable_expert_bias=True,
-    router_dtype="fp32",
-    aux_loss_coeff=1e-4,
-    shared_expert_intermediate_size=3712,
-    # DeepEP-backed flex dispatcher (final canonical value).
-    token_dispatcher_type="flex",
-    flex_dispatcher_backend="deepep",
-    hybridep_num_sms=16,
-    grouped_gemm=True,
-    permute_fusion=True,
-    router_num_groups=1,
-    router_group_topk=1,
-    router_fusion=False,
-    shared_expert_overlap=False,
-    use_fused_weighted_squared_relu=True,
-)
-
-Loss = CrossEntropyLayerConfig(loss_fusion=True, fusion_impl="native")
-
-
-# --- Layer pattern composition ---------------------------------------------
-#
-# Decoder layout (52 layers total = 6 + 28 + 9 + 9). ``num_layers`` is never
-# set explicitly; ``HybridModelConfig.num_layers`` derives it from the
-# flattened pattern length.
-
-stage0 = [Mamba] + [MoE, Mamba] * 2 + [Att]
-stage1 = [MoE, Mamba] * 3 + [Att]
-stage2 = [MoE, Mamba] * 4 + [Att]
-stage3 = [MoE, Mamba] * 4 + [MoE]
-
-decoder = stage0 + stage1 * 4 + stage2 + stage3
-
-layer_pattern = [Embedding] + decoder + [Loss]
-
-
-# --- Recipe entry point ----------------------------------------------------
+def _env_bool(name: str, default: bool) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.lower() in {"1", "true", "t", "yes", "y", "on"}
 
 
 def make_recipe() -> HybridModelConfig:
-    """Return the Nemotron-3 Nano HybridModel pretrain recipe.
+    """Return the Nemotron-3 Nano HybridModel pretrain recipe."""
 
-    ``make_recipe`` is the canonical default entry point used when
-    ``--model-recipe`` is passed without a ``:func`` suffix.
-    """
+    common_config = CommonLayerConfig(
+        hidden_size=2688,
+        ffn_hidden_size=1856,
+        mixed_precision_dtype=torch.bfloat16,
+        first_last_layers_bf16=True,
+        sequence_parallel=_env_bool("NANO_SP", True),
+        init_method_std=0.0173,
+        normalization="RMSNorm",
+        add_bias_linear=False,
+        activation_func="squared_relu",
+        persist_layer_norm=True,
+        cuda_graph_impl="none",
+    )
+
+    embedding = EmbeddingLayerConfig(
+        common_config=common_config,
+        vocab_size=_env_int("NANO_VOCAB_SIZE", VOCAB_SIZE),
+        max_sequence_length=_env_int("NANO_MAX_SEQUENCE_LENGTH", MAX_SEQUENCE_LENGTH),
+        position_embedding_type="none",
+    )
+    mamba = MambaLayerConfig(
+        common_config=common_config,
+        head_dim=64,
+        state_size=128,
+        num_groups=8,
+        num_heads=64,
+    )
+    attention = AttentionLayerConfig(
+        common_config=common_config,
+        num_attention_heads=32,
+        num_query_groups=2,
+        kv_channels=128,
+        attention_softmax_in_fp32=False,
+        masked_softmax_fusion=True,
+        attention_backend="fused",
+    )
+    moe = MoELayerConfig(
+        common_config=common_config,
+        num_experts=128,
+        top_k=6,
+        ffn_hidden_size=1856,
+        router_score_function="sigmoid",
+        router_load_balancing_type="seq_aux_loss",
+        router_topk_scaling_factor=2.5,
+        router_enable_expert_bias=True,
+        router_dtype="fp32",
+        aux_loss_coeff=0.0001,
+        shared_expert_intermediate_size=3712,
+        token_dispatcher_type="flex",
+        flex_dispatcher_backend="deepep",
+        hybridep_num_sms=16,
+        grouped_gemm=True,
+        permute_fusion=True,
+        router_num_groups=1,
+        router_group_topk=1,
+        router_fusion=False,
+        shared_expert_overlap=False,
+        use_fused_weighted_squared_relu=True,
+    )
+    loss = CrossEntropyLayerConfig(loss_fusion=True, fusion_impl="native")
+
+    stage0 = [mamba] + [moe, mamba] * 2 + [attention]
+    stage1 = [moe, mamba] * 3 + [attention]
+    stage2 = [moe, mamba] * 4 + [attention]
+    stage3 = [moe, mamba] * 4 + [moe]
+    decoder = stage0 + stage1 * 4 + stage2 + stage3
+
     return HybridModelConfig(
         common_config=common_config,
-        layer_pattern=layer_pattern,
+        layer_pattern=[embedding] + decoder + [loss],
         untie_embeddings_and_output_weights=True,
-        # Model-level parallelism (PP intentionally absent — the recipe DSL
-        # is PP-free; recipes that need PP must use the legacy string DSL).
-        tensor_model_parallel_size=4,
-        expert_model_parallel_size=8,
-        expert_tensor_parallel_size=1,
+        tensor_model_parallel_size=_env_int("NANO_TP", 4),
+        context_parallel_size=_env_int("NANO_CP", 1),
+        expert_model_parallel_size=_env_int("NANO_EP", 8),
+        expert_tensor_parallel_size=_env_int("NANO_ETP", 1),
     )
 
 
-def nemotron_3_nano_pretrain_config():
-    """Bridge-style alias retained for explicit ``:func`` selection."""
+def nemotron_3_nano_pretrain_config() -> HybridModelConfig:
+    """Bridge-style alias for explicit ``--model-recipe ...:func`` selection."""
+
     return make_recipe()
 
 
 if __name__ == "__main__":
-    # Lower the recipe and print the resulting layer_type_list. This is
-    # the same code path ``--model-recipe`` exercises in production via
-    # ``HybridModel.from_recipe``.
-    #
-    # The full lowering requires Transformer Engine
-    # (``moe_permute_fusion=True``, ``transformer_impl="transformer_engine"``,
-    # etc. trigger TE checks at config-construction time). In dev environments
-    # without TE, fall back to the pure-Python ``flatten_decoder`` +
-    # ``SYMBOL`` derivation so the smoke test can still verify the pattern
-    # composition.
     recipe = make_recipe()
     try:
         _, layer_type_list, _ = recipe._lower()
-    except (ValueError, ImportError, ModuleNotFoundError) as e:
-        msg = str(e)
-        if "fused permutation" not in msg and "TE" not in msg and "transformer_engine" not in msg:
-            raise
+    except (ValueError, ImportError, ModuleNotFoundError) as exc:
         print(
-            f"NOTE: full lowering needs Transformer Engine "
-            f"({type(e).__name__}: {e}). Falling back to pattern-only "
-            f"verification — production runs go through HybridModel.from_recipe."
+            "NOTE: full lowering failed "
+            f"({type(exc).__name__}: {exc}). Falling back to pattern-only verification."
         )
         layer_type_list = [type(lc).SYMBOL for lc in recipe.flatten_decoder()]
-    composed_string = "".join(layer_type_list)
 
-    print(f"Composed layer pattern: {composed_string}")
+    composed = "".join(layer_type_list)
+    print(f"Composed layer pattern: {composed}")
     print(f"Layer count:            {len(layer_type_list)}")
+    print(f"Legacy reference:       {LEGACY_HYBRID_LAYER_PATTERN}")
+    print(f"Match:                  {composed == LEGACY_HYBRID_LAYER_PATTERN}")
+    if composed != LEGACY_HYBRID_LAYER_PATTERN:
+        raise SystemExit("Composed pattern does not match the legacy string DSL pattern.")

--- a/examples/nemotron3/nano.sh
+++ b/examples/nemotron3/nano.sh
@@ -1,0 +1,118 @@
+# Megatron-LM legacy-CLI launch line for Nemotron-3 Nano (30B-A3B MoE).
+#
+# Faithful 1:1 with the canonical Megatron-Bridge recipe at
+# Megatron-Bridge/src/megatron/bridge/recipes/nemotronh/nemotron_3_nano.py
+# ::nemotron_3_nano_pretrain_config.
+#
+# This file is the legacy ``--hybrid-layer-pattern`` baseline; the recommended
+# path is the Python recipe at examples/nemotron3/nano.py
+# (entry point: ``--model-recipe examples.nemotron3.nano``). Both produce
+# byte-identical models when seeded the same way.
+#
+# Usage (assumes a running torchrun environment):
+#   torchrun ... pretrain_hybrid.py $(cat examples/nemotron3/nano.sh)
+
+  --use-mcore-models \
+  --transformer-impl transformer_engine \
+  --group-query-attention \
+  --squared-relu \
+  --bf16 \
+  --first-last-layers-bf16 \
+  --use-fused-weighted-squared-relu \
+  --split 9999,8,2 \
+  --cuda-graph-scope full \
+  --cuda-graph-impl none \
+  --cuda-graph-warmup-steps 3 \
+  --seq-length 8192 \
+  --max-position-embeddings 8192 \
+  --seed 1234 \
+  --micro-batch-size 2 \
+  --global-batch-size 3072 \
+  --train-iters 39735 \
+  --manual-gc-interval 0 \
+  --tensor-model-parallel-size 4 \
+  --pipeline-model-parallel-size 1 \
+  --sequence-parallel \
+  --context-parallel-size 1 \
+  --expert-model-parallel-size 8 \
+  --expert-tensor-parallel-size 1 \
+  --tp-comm-overlap \
+  --cross-entropy-loss-fusion \
+  --cross-entropy-fusion-impl native \
+  --no-overlap-p2p-communication \
+  --num-layers 52 \
+  --hybrid-layer-pattern "MEMEM*EMEMEM*EMEMEM*EMEMEM*EMEMEM*EMEMEMEM*EMEMEMEME" \
+  --hidden-size 2688 \
+  --num-attention-heads 32 \
+  --attention-backend fused \
+  --num-query-groups 2 \
+  --ffn-hidden-size 1856 \
+  --kv-channels 128 \
+  --hidden-dropout 0.0 \
+  --attention-dropout 0.0 \
+  --norm-epsilon 1e-05 \
+  --disable-bias-linear \
+  --normalization RMSNorm \
+  --init-method-std 0.0173 \
+  --no-rope-fusion \
+  --mamba-num-heads 64 \
+  --mamba-state-dim 128 \
+  --mamba-head-dim 64 \
+  --mamba-num-groups 8 \
+  --num-experts 128 \
+  --moe-shared-expert-intermediate-size 3712 \
+  --moe-layer-freq 1 \
+  --moe-ffn-hidden-size 1856 \
+  --moe-router-load-balancing-type seq_aux_loss \
+  --moe-router-topk 6 \
+  --moe-router-num-groups 1 \
+  --moe-router-group-topk 1 \
+  --moe-router-topk-scaling-factor 2.5 \
+  --moe-router-score-function sigmoid \
+  --moe-router-dtype fp32 \
+  --moe-router-enable-expert-bias \
+  --moe-router-bias-update-rate 0.001 \
+  --moe-grouped-gemm \
+  --moe-aux-loss-coeff 0.0001 \
+  --moe-token-dispatcher-type flex \
+  --moe-flex-dispatcher-backend deepep \
+  --moe-hybridep-num-sms 16 \
+  --moe-permute-fusion \
+  --untie-embeddings-and-output-weights \
+  --position-embedding-type none \
+  --rotary-percent 1.0 \
+  --rotary-base 10000 \
+  --make-vocab-size-divisible-by 128 \
+  --lr 0.0016 \
+  --min-lr 1.6e-05 \
+  --weight-decay 0.1 \
+  --adam-beta1 0.9 \
+  --adam-beta2 0.95 \
+  --adam-eps 1e-08 \
+  --clip-grad 1.0 \
+  --grad-reduce-in-fp32 \
+  --overlap-grad-reduce \
+  --overlap-param-gather \
+  --use-distributed-optimizer \
+  --eval-iters 32 \
+  --eval-interval 500 \
+  --lr-decay-style cosine \
+  --lr-warmup-iters 333 \
+  --lr-warmup-samples 0 \
+  --lr-warmup-init 0.0 \
+  --override-opt-param-scheduler \
+  --start-weight-decay 0.1 \
+  --end-weight-decay 0.1 \
+  --weight-decay-incr-style constant \
+  --dataloader-type single \
+  --num-workers 8 \
+  --num-dataset-builder-threads 1 \
+  --no-mmap-bin-files \
+  --log-interval 10 \
+  --tokenizer-type HuggingFaceTokenizer \
+  --tokenizer-model nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16 \
+  --save-interval 200 \
+  --ckpt-format torch_dist \
+  --use-persistent-ckpt-worker \
+  --dist-ckpt-strictness log_all \
+  --distributed-timeout-minutes 10

--- a/examples/nemotron3/nano.sh
+++ b/examples/nemotron3/nano.sh
@@ -1,118 +1,162 @@
-# Megatron-LM legacy-CLI launch line for Nemotron-3 Nano (30B-A3B MoE).
+#!/bin/bash
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 #
-# Faithful 1:1 with the canonical Megatron-Bridge recipe at
-# Megatron-Bridge/src/megatron/bridge/recipes/nemotronh/nemotron_3_nano.py
-# ::nemotron_3_nano_pretrain_config.
-#
-# This file is the legacy ``--hybrid-layer-pattern`` baseline; the recommended
-# path is the Python recipe at examples/nemotron3/nano.py
-# (entry point: ``--model-recipe examples.nemotron3.nano``). Both produce
-# byte-identical models when seeded the same way.
-#
-# Usage (assumes a running torchrun environment):
-#   torchrun ... pretrain_hybrid.py $(cat examples/nemotron3/nano.sh)
+# Legacy string-DSL launcher for the Nemotron-3 Nano experiment.
 
-  --use-mcore-models \
-  --transformer-impl transformer_engine \
-  --group-query-attention \
-  --squared-relu \
-  --bf16 \
-  --first-last-layers-bf16 \
-  --use-fused-weighted-squared-relu \
-  --split 9999,8,2 \
-  --cuda-graph-scope full \
-  --cuda-graph-impl none \
-  --cuda-graph-warmup-steps 3 \
-  --seq-length 8192 \
-  --max-position-embeddings 8192 \
-  --seed 1234 \
-  --micro-batch-size 2 \
-  --global-batch-size 3072 \
-  --train-iters 39735 \
-  --manual-gc-interval 0 \
-  --tensor-model-parallel-size 4 \
-  --pipeline-model-parallel-size 1 \
-  --sequence-parallel \
-  --context-parallel-size 1 \
-  --expert-model-parallel-size 8 \
-  --expert-tensor-parallel-size 1 \
-  --tp-comm-overlap \
-  --cross-entropy-loss-fusion \
-  --cross-entropy-fusion-impl native \
-  --no-overlap-p2p-communication \
-  --num-layers 52 \
-  --hybrid-layer-pattern "MEMEM*EMEMEM*EMEMEM*EMEMEM*EMEMEM*EMEMEMEM*EMEMEMEME" \
-  --hidden-size 2688 \
-  --num-attention-heads 32 \
-  --attention-backend fused \
-  --num-query-groups 2 \
-  --ffn-hidden-size 1856 \
-  --kv-channels 128 \
-  --hidden-dropout 0.0 \
-  --attention-dropout 0.0 \
-  --norm-epsilon 1e-05 \
-  --disable-bias-linear \
-  --normalization RMSNorm \
-  --init-method-std 0.0173 \
-  --no-rope-fusion \
-  --mamba-num-heads 64 \
-  --mamba-state-dim 128 \
-  --mamba-head-dim 64 \
-  --mamba-num-groups 8 \
-  --num-experts 128 \
-  --moe-shared-expert-intermediate-size 3712 \
-  --moe-layer-freq 1 \
-  --moe-ffn-hidden-size 1856 \
-  --moe-router-load-balancing-type seq_aux_loss \
-  --moe-router-topk 6 \
-  --moe-router-num-groups 1 \
-  --moe-router-group-topk 1 \
-  --moe-router-topk-scaling-factor 2.5 \
-  --moe-router-score-function sigmoid \
-  --moe-router-dtype fp32 \
-  --moe-router-enable-expert-bias \
-  --moe-router-bias-update-rate 0.001 \
-  --moe-grouped-gemm \
-  --moe-aux-loss-coeff 0.0001 \
-  --moe-token-dispatcher-type flex \
-  --moe-flex-dispatcher-backend deepep \
-  --moe-hybridep-num-sms 16 \
-  --moe-permute-fusion \
-  --untie-embeddings-and-output-weights \
-  --position-embedding-type none \
-  --rotary-percent 1.0 \
-  --rotary-base 10000 \
-  --make-vocab-size-divisible-by 128 \
-  --lr 0.0016 \
-  --min-lr 1.6e-05 \
-  --weight-decay 0.1 \
-  --adam-beta1 0.9 \
-  --adam-beta2 0.95 \
-  --adam-eps 1e-08 \
-  --clip-grad 1.0 \
-  --grad-reduce-in-fp32 \
-  --overlap-grad-reduce \
-  --overlap-param-gather \
-  --use-distributed-optimizer \
-  --eval-iters 32 \
-  --eval-interval 500 \
-  --lr-decay-style cosine \
-  --lr-warmup-iters 333 \
-  --lr-warmup-samples 0 \
-  --lr-warmup-init 0.0 \
-  --override-opt-param-scheduler \
-  --start-weight-decay 0.1 \
-  --end-weight-decay 0.1 \
-  --weight-decay-incr-style constant \
-  --dataloader-type single \
-  --num-workers 8 \
-  --num-dataset-builder-threads 1 \
-  --no-mmap-bin-files \
-  --log-interval 10 \
-  --tokenizer-type HuggingFaceTokenizer \
-  --tokenizer-model nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16 \
-  --save-interval 200 \
-  --ckpt-format torch_dist \
-  --use-persistent-ckpt-worker \
-  --dist-ckpt-strictness log_all \
-  --distributed-timeout-minutes 10
+set -euo pipefail
+
+SOURCE=${SOURCE:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}
+cd "${SOURCE}"
+
+LEGACY_HYBRID_LAYER_PATTERN=${LEGACY_HYBRID_LAYER_PATTERN:-"MEMEM*EMEMEM*EMEMEM*EMEMEM*EMEMEM*EMEMEMEM*EMEMEMEME"}
+WORKSPACE=${WORKSPACE:-/workspace}
+RUN_NAME=${RUN_NAME:-nano_sh}
+
+GPUS_PER_NODE=${GPUS_PER_NODE:-${SLURM_GPUS_ON_NODE:-8}}
+NUM_NODES=${NUM_NODES:-${SLURM_JOB_NUM_NODES:-1}}
+NODE_RANK=${NODE_RANK:-${SLURM_NODEID:-0}}
+MASTER_PORT=${MASTER_PORT:-29500}
+if [ -z "${MASTER_ADDR:-}" ]; then
+    if [ -n "${SLURM_JOB_NODELIST:-}" ] && command -v scontrol >/dev/null 2>&1; then
+        MASTER_ADDR=$(scontrol show hostnames "${SLURM_JOB_NODELIST}" | head -n 1)
+    else
+        MASTER_ADDR=localhost
+    fi
+fi
+
+NANO_TP=${NANO_TP:-4}
+NANO_PP=${NANO_PP:-1}
+NANO_EP=${NANO_EP:-8}
+NANO_ETP=${NANO_ETP:-1}
+NANO_CP=${NANO_CP:-1}
+NANO_SP=${NANO_SP:-True}
+
+SEQ_LENGTH=${SEQ_LENGTH:-512}
+MAX_SEQUENCE_LENGTH=${MAX_SEQUENCE_LENGTH:-8192}
+TRAIN_ITERS=${TRAIN_ITERS:-50}
+GLOBAL_BATCH_SIZE=${GLOBAL_BATCH_SIZE:-32}
+MICRO_BATCH_SIZE=${MICRO_BATCH_SIZE:-1}
+EVAL_ITERS=${EVAL_ITERS:-10}
+LR_WARMUP_ITERS=${LR_WARMUP_ITERS:-5}
+LOG_INTERVAL=${LOG_INTERVAL:-1}
+VOCAB_SIZE=${VOCAB_SIZE:-131072}
+
+CHECKPOINT_DIR=${CHECKPOINT_DIR:-${WORKSPACE}/results/${RUN_NAME}_tp${NANO_TP}_pp${NANO_PP}_ep${NANO_EP}_cp${NANO_CP}}
+TENSORBOARD_DIR=${TENSORBOARD_DIR:-${WORKSPACE}/tensorboard/${RUN_NAME}_tp${NANO_TP}_pp${NANO_PP}_ep${NANO_EP}_cp${NANO_CP}}
+DATA_CACHE_DIR=${DATA_CACHE_DIR:-${WORKSPACE}/data-cache/${RUN_NAME}}
+
+mkdir -p "${CHECKPOINT_DIR}" "${TENSORBOARD_DIR}" "${DATA_CACHE_DIR}"
+
+export CUDA_DEVICE_MAX_CONNECTIONS=${CUDA_DEVICE_MAX_CONNECTIONS:-1}
+export TORCH_NCCL_AVOID_RECORD_STREAMS=${TORCH_NCCL_AVOID_RECORD_STREAMS:-1}
+export NCCL_NVLS_ENABLE=${NCCL_NVLS_ENABLE:-0}
+export TRITON_CACHE_DIR=${TRITON_CACHE_DIR:-${WORKSPACE}/triton-cache}
+export TRITON_CACHE_MANAGER=${TRITON_CACHE_MANAGER:-megatron.core.ssm.triton_cache_manager:ParallelFileCacheManager}
+
+DISTRIBUTED_ARGS=(
+    --nproc_per_node "${GPUS_PER_NODE}"
+    --nnodes "${NUM_NODES}"
+    --node_rank "${NODE_RANK}"
+    --master_addr "${MASTER_ADDR}"
+    --master_port "${MASTER_PORT}"
+)
+
+MODEL_ARGS=(
+    --use-mcore-models
+    --spec megatron.core.models.hybrid.hybrid_layer_specs hybrid_stack_spec
+    --hybrid-layer-pattern "${LEGACY_HYBRID_LAYER_PATTERN}"
+    --hidden-size 2688
+    --ffn-hidden-size 1856
+    --num-attention-heads 32
+    --group-query-attention
+    --num-query-groups 2
+    --kv-channels 128
+    --mamba-num-heads 64
+    --mamba-head-dim 64
+    --mamba-state-dim 128
+    --mamba-num-groups 8
+    --position-embedding-type none
+    --normalization RMSNorm
+    --untie-embeddings-and-output-weights
+    --init-method-std 0.0173
+    --disable-bias-linear
+    --squared-relu
+    --first-last-layers-bf16
+    --use-fused-weighted-squared-relu
+    --transformer-impl transformer_engine
+    --attention-backend fused
+    --cross-entropy-loss-fusion
+    --cross-entropy-fusion-impl native
+    --tensor-model-parallel-size "${NANO_TP}"
+    --pipeline-model-parallel-size "${NANO_PP}"
+    --context-parallel-size "${NANO_CP}"
+    --expert-model-parallel-size "${NANO_EP}"
+    --expert-tensor-parallel-size "${NANO_ETP}"
+    --num-experts 128
+    --moe-ffn-hidden-size 1856
+    --moe-shared-expert-intermediate-size 3712
+    --moe-router-topk 6
+    --moe-router-topk-scaling-factor 2.5
+    --moe-router-num-groups 1
+    --moe-router-group-topk 1
+    --moe-router-score-function sigmoid
+    --moe-router-enable-expert-bias
+    --moe-router-load-balancing-type seq_aux_loss
+    --moe-router-dtype fp32
+    --moe-aux-loss-coeff 0.0001
+    --moe-grouped-gemm
+    --moe-token-dispatcher-type flex
+    --moe-flex-dispatcher-backend deepep
+    --moe-hybridep-num-sms 16
+    --moe-permute-fusion
+)
+
+if [[ "${NANO_SP,,}" == "true" || "${NANO_SP}" == "1" ]]; then
+    MODEL_ARGS+=(--sequence-parallel)
+fi
+
+TRAINING_ARGS=(
+    --mock-data
+    --tokenizer-type NullTokenizer
+    --vocab-size "${VOCAB_SIZE}"
+    --make-vocab-size-divisible-by 128
+    --seq-length "${SEQ_LENGTH}"
+    --max-position-embeddings "${MAX_SEQUENCE_LENGTH}"
+    --split 949,50,1
+    --distributed-backend nccl
+    --micro-batch-size "${MICRO_BATCH_SIZE}"
+    --global-batch-size "${GLOBAL_BATCH_SIZE}"
+    --train-iters "${TRAIN_ITERS}"
+    --lr 1.6e-3
+    --min-lr 1.6e-5
+    --lr-decay-style cosine
+    --lr-warmup-iters "${LR_WARMUP_ITERS}"
+    --weight-decay 0.1
+    --clip-grad 1.0
+    --attention-dropout 0.0
+    --hidden-dropout 0.0
+    --adam-beta1 0.9
+    --adam-beta2 0.95
+    --bf16
+    --use-distributed-optimizer
+    --overlap-grad-reduce
+    --overlap-param-gather
+    --no-create-attention-mask-in-dataloader
+    --save "${CHECKPOINT_DIR}"
+    --save-interval 10000
+    --no-save-optim
+    --no-save-rng
+    --ckpt-format torch_dist
+    --eval-interval 1000
+    --eval-iters "${EVAL_ITERS}"
+    --log-interval "${LOG_INTERVAL}"
+    --tensorboard-dir "${TENSORBOARD_DIR}"
+    --data-cache-path "${DATA_CACHE_DIR}"
+)
+
+echo "Running legacy nano.sh experiment"
+echo "Topology: TP=${NANO_TP} PP=${NANO_PP} EP=${NANO_EP} ETP=${NANO_ETP} CP=${NANO_CP} SP=${NANO_SP}"
+echo "torchrun: nnodes=${NUM_NODES} nproc_per_node=${GPUS_PER_NODE} node_rank=${NODE_RANK} master=${MASTER_ADDR}:${MASTER_PORT}"
+
+exec uv run --no-sync python -m torch.distributed.run "${DISTRIBUTED_ARGS[@]}" \
+    pretrain_hybrid.py "${MODEL_ARGS[@]}" "${TRAINING_ARGS[@]}" "$@"

--- a/examples/nemotron3/sbatch_pretrain_nano_py.sh
+++ b/examples/nemotron3/sbatch_pretrain_nano_py.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Submit with: sbatch examples/nemotron3/sbatch_pretrain_nano_py.sh
+
+#SBATCH --job-name=nano-py
+#SBATCH --nodes=4
+#SBATCH --ntasks-per-node=1
+#SBATCH --gpus-per-node=8
+#SBATCH --time=24:00:00
+#SBATCH --partition=gpu
+#SBATCH --account=my_account
+#SBATCH --output=logs/nano_py_%j.out
+#SBATCH --error=logs/nano_py_%j.err
+#SBATCH --exclusive
+
+set -euo pipefail
+
+CONTAINER_IMAGE=${CONTAINER_IMAGE:-gitlab-master.nvidia.com:5005/ppetrakian/containers/mcore/dsl:latest}
+CONTAINER_WORKDIR=${CONTAINER_WORKDIR:-/workspace}
+HOST_REPO=${HOST_REPO:-$(pwd)}
+CONTAINER_MOUNTS=${CONTAINER_MOUNTS:-${HOST_REPO}:${CONTAINER_WORKDIR}}
+WORKSPACE=${WORKSPACE:-/workspace}
+MODEL_RECIPE=${MODEL_RECIPE:-examples.nemotron3.nano}
+
+SEQ_LENGTH=${SEQ_LENGTH:-512}
+TRAIN_ITERS=${TRAIN_ITERS:-50}
+GLOBAL_BATCH_SIZE=${GLOBAL_BATCH_SIZE:-32}
+MICRO_BATCH_SIZE=${MICRO_BATCH_SIZE:-1}
+EVAL_ITERS=${EVAL_ITERS:-10}
+LR_WARMUP_ITERS=${LR_WARMUP_ITERS:-5}
+LOG_INTERVAL=${LOG_INTERVAL:-1}
+VOCAB_SIZE=${VOCAB_SIZE:-131072}
+MAX_SEQUENCE_LENGTH=${MAX_SEQUENCE_LENGTH:-8192}
+
+# "TP,PP,EP,CP,SP" per entry. The Python recipe DSL is PP-free, so PP must stay 1.
+PARALLELISM_CONFIGS=(${PARALLELISM_CONFIGS:-"4,1,8,1,True"})
+
+export TORCH_NCCL_AVOID_RECORD_STREAMS=${TORCH_NCCL_AVOID_RECORD_STREAMS:-1}
+export NCCL_NVLS_ENABLE=${NCCL_NVLS_ENABLE:-0}
+
+mkdir -p logs
+
+if [ -z "${CONTAINER_IMAGE}" ]; then
+    echo "ERROR: CONTAINER_IMAGE must be set."
+    exit 1
+fi
+
+MASTER_ADDR=${MASTER_ADDR:-$(scontrol show hostnames "${SLURM_JOB_NODELIST}" | head -n 1)}
+GPUS_PER_NODE=${GPUS_PER_NODE:-${SLURM_GPUS_ON_NODE:-8}}
+BASE_MASTER_PORT=${MASTER_PORT:-29500}
+
+SRUN_CMD=(
+    srun
+    --mpi=pmix
+    --ntasks="${SLURM_JOB_NUM_NODES}"
+    --ntasks-per-node=1
+    --container-image="${CONTAINER_IMAGE}"
+    --container-workdir="${CONTAINER_WORKDIR}"
+)
+if [ -n "${CONTAINER_MOUNTS}" ]; then
+    SRUN_CMD+=(--container-mounts="${CONTAINER_MOUNTS}")
+fi
+
+echo "======================================"
+echo "Nemotron-3 Nano Python recipe DSL job"
+echo "Job ID: ${SLURM_JOB_ID}"
+echo "Nodes: ${SLURM_JOB_NUM_NODES}"
+echo "GPUs per node: ${GPUS_PER_NODE}"
+echo "Container: ${CONTAINER_IMAGE}"
+echo "Mounts: ${CONTAINER_MOUNTS}"
+echo "Model recipe: ${MODEL_RECIPE}"
+echo "Parallelism configs: ${PARALLELISM_CONFIGS[*]}"
+echo "======================================"
+
+CONFIG_INDEX=0
+for CONFIG in "${PARALLELISM_CONFIGS[@]}"; do
+    IFS=',' read -r TP PP EP CP SP <<< "${CONFIG}"
+    CONFIG_INDEX=$((CONFIG_INDEX + 1))
+    if [ "${PP}" != "1" ]; then
+        echo "ERROR: nano.py recipe DSL runs require PP=1; got PP=${PP}."
+        exit 1
+    fi
+
+    MASTER_PORT_FOR_CONFIG=$((BASE_MASTER_PORT + CONFIG_INDEX - 1))
+    RUN_NAME="nano_py_tp${TP}_pp${PP}_ep${EP}_sp${SP}_cp${CP}"
+    CHECKPOINT_DIR="${WORKSPACE}/results/${RUN_NAME}"
+    TENSORBOARD_DIR="${WORKSPACE}/tensorboard/${RUN_NAME}"
+    DATA_CACHE_DIR="${WORKSPACE}/data-cache/${RUN_NAME}"
+    SEQUENCE_PARALLEL_ARG=""
+    if [[ "${SP,,}" == "true" || "${SP}" == "1" ]]; then
+        SEQUENCE_PARALLEL_ARG="--sequence-parallel"
+    fi
+
+    echo ""
+    echo "======================================"
+    echo "Config ${CONFIG_INDEX}/${#PARALLELISM_CONFIGS[@]}: TP=${TP}, PP=${PP}, EP=${EP}, CP=${CP}, SP=${SP}"
+    echo "======================================"
+
+    CMD="cd ${CONTAINER_WORKDIR} && \
+        mkdir -p ${CHECKPOINT_DIR} ${TENSORBOARD_DIR} ${DATA_CACHE_DIR} && \
+        export CUDA_DEVICE_MAX_CONNECTIONS=\${CUDA_DEVICE_MAX_CONNECTIONS:-1} && \
+        export TRITON_CACHE_DIR=\${TRITON_CACHE_DIR:-${WORKSPACE}/triton-cache} && \
+        export TRITON_CACHE_MANAGER=\${TRITON_CACHE_MANAGER:-megatron.core.ssm.triton_cache_manager:ParallelFileCacheManager} && \
+        NANO_TP=${TP} NANO_EP=${EP} NANO_CP=${CP} NANO_SP=${SP} NANO_ETP=1 \
+        NANO_VOCAB_SIZE=${VOCAB_SIZE} NANO_MAX_SEQUENCE_LENGTH=${MAX_SEQUENCE_LENGTH} \
+        uv run --no-sync python -m torch.distributed.run \
+            --nproc_per_node ${GPUS_PER_NODE} \
+            --nnodes ${SLURM_JOB_NUM_NODES} \
+            --node_rank \${SLURM_NODEID} \
+            --master_addr ${MASTER_ADDR} \
+            --master_port ${MASTER_PORT_FOR_CONFIG} \
+            pretrain_hybrid.py \
+            --model-recipe ${MODEL_RECIPE} \
+            ${SEQUENCE_PARALLEL_ARG} \
+            --mock-data \
+            --tokenizer-type NullTokenizer \
+            --vocab-size ${VOCAB_SIZE} \
+            --make-vocab-size-divisible-by 128 \
+            --seq-length ${SEQ_LENGTH} \
+            --split 949,50,1 \
+            --distributed-backend nccl \
+            --micro-batch-size ${MICRO_BATCH_SIZE} \
+            --global-batch-size ${GLOBAL_BATCH_SIZE} \
+            --train-iters ${TRAIN_ITERS} \
+            --lr 1.6e-3 \
+            --min-lr 1.6e-5 \
+            --lr-decay-style cosine \
+            --lr-warmup-iters ${LR_WARMUP_ITERS} \
+            --weight-decay 0.1 \
+            --clip-grad 1.0 \
+            --attention-dropout 0.0 \
+            --hidden-dropout 0.0 \
+            --adam-beta1 0.9 \
+            --adam-beta2 0.95 \
+            --bf16 \
+            --use-mcore-models \
+            --use-distributed-optimizer \
+            --overlap-grad-reduce \
+            --overlap-param-gather \
+            --no-create-attention-mask-in-dataloader \
+            --save ${CHECKPOINT_DIR} \
+            --save-interval 10000 \
+            --no-save-optim \
+            --no-save-rng \
+            --ckpt-format torch_dist \
+            --eval-interval 1000 \
+            --eval-iters ${EVAL_ITERS} \
+            --log-interval ${LOG_INTERVAL} \
+            --tensorboard-dir ${TENSORBOARD_DIR} \
+            --data-cache-path ${DATA_CACHE_DIR}"
+
+    echo "Executing command:"
+    echo "${CMD}"
+    "${SRUN_CMD[@]}" bash -lc "${CMD}"
+done
+
+echo "======================================"
+echo "Python recipe nano.py job completed"
+echo "======================================"

--- a/examples/nemotron3/sbatch_pretrain_nano_sh.sh
+++ b/examples/nemotron3/sbatch_pretrain_nano_sh.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Submit with: sbatch examples/nemotron3/sbatch_pretrain_nano_sh.sh
+
+#SBATCH --job-name=nano-sh
+#SBATCH --nodes=4
+#SBATCH --ntasks-per-node=1
+#SBATCH --gpus-per-node=8
+#SBATCH --time=24:00:00
+#SBATCH --partition=gpu
+#SBATCH --account=my_account
+#SBATCH --output=logs/nano_sh_%j.out
+#SBATCH --error=logs/nano_sh_%j.err
+#SBATCH --exclusive
+
+set -euo pipefail
+
+CONTAINER_IMAGE=${CONTAINER_IMAGE:-gitlab-master.nvidia.com:5005/ppetrakian/containers/mcore/dsl:latest}
+CONTAINER_WORKDIR=${CONTAINER_WORKDIR:-/workspace}
+HOST_REPO=${HOST_REPO:-$(pwd)}
+CONTAINER_MOUNTS=${CONTAINER_MOUNTS:-${HOST_REPO}:${CONTAINER_WORKDIR}}
+WORKSPACE=${WORKSPACE:-/workspace}
+
+SEQ_LENGTH=${SEQ_LENGTH:-512}
+TRAIN_ITERS=${TRAIN_ITERS:-50}
+GLOBAL_BATCH_SIZE=${GLOBAL_BATCH_SIZE:-32}
+MICRO_BATCH_SIZE=${MICRO_BATCH_SIZE:-1}
+EVAL_ITERS=${EVAL_ITERS:-10}
+LR_WARMUP_ITERS=${LR_WARMUP_ITERS:-5}
+LOG_INTERVAL=${LOG_INTERVAL:-1}
+
+# "TP,PP,EP,CP,SP" per entry. Keep PP=1 for direct comparison with nano.py.
+PARALLELISM_CONFIGS=(${PARALLELISM_CONFIGS:-"4,1,8,1,True"})
+
+export TORCH_NCCL_AVOID_RECORD_STREAMS=${TORCH_NCCL_AVOID_RECORD_STREAMS:-1}
+export NCCL_NVLS_ENABLE=${NCCL_NVLS_ENABLE:-0}
+
+mkdir -p logs
+
+if [ -z "${CONTAINER_IMAGE}" ]; then
+    echo "ERROR: CONTAINER_IMAGE must be set."
+    exit 1
+fi
+
+MASTER_ADDR=${MASTER_ADDR:-$(scontrol show hostnames "${SLURM_JOB_NODELIST}" | head -n 1)}
+GPUS_PER_NODE=${GPUS_PER_NODE:-${SLURM_GPUS_ON_NODE:-8}}
+BASE_MASTER_PORT=${MASTER_PORT:-29500}
+
+SRUN_CMD=(
+    srun
+    --mpi=pmix
+    --ntasks="${SLURM_JOB_NUM_NODES}"
+    --ntasks-per-node=1
+    --container-image="${CONTAINER_IMAGE}"
+    --container-workdir="${CONTAINER_WORKDIR}"
+)
+if [ -n "${CONTAINER_MOUNTS}" ]; then
+    SRUN_CMD+=(--container-mounts="${CONTAINER_MOUNTS}")
+fi
+
+echo "======================================"
+echo "Nemotron-3 Nano legacy string DSL job"
+echo "Job ID: ${SLURM_JOB_ID}"
+echo "Nodes: ${SLURM_JOB_NUM_NODES}"
+echo "GPUs per node: ${GPUS_PER_NODE}"
+echo "Container: ${CONTAINER_IMAGE}"
+echo "Mounts: ${CONTAINER_MOUNTS}"
+echo "Parallelism configs: ${PARALLELISM_CONFIGS[*]}"
+echo "======================================"
+
+CONFIG_INDEX=0
+for CONFIG in "${PARALLELISM_CONFIGS[@]}"; do
+    IFS=',' read -r TP PP EP CP SP <<< "${CONFIG}"
+    CONFIG_INDEX=$((CONFIG_INDEX + 1))
+    MASTER_PORT_FOR_CONFIG=$((BASE_MASTER_PORT + CONFIG_INDEX - 1))
+    RUN_NAME="nano_sh_tp${TP}_pp${PP}_ep${EP}_sp${SP}_cp${CP}"
+
+    echo ""
+    echo "======================================"
+    echo "Config ${CONFIG_INDEX}/${#PARALLELISM_CONFIGS[@]}: TP=${TP}, PP=${PP}, EP=${EP}, CP=${CP}, SP=${SP}"
+    echo "======================================"
+
+    CMD="cd ${CONTAINER_WORKDIR} && \
+        RUN_NAME=${RUN_NAME} \
+        WORKSPACE=${WORKSPACE} \
+        GPUS_PER_NODE=${GPUS_PER_NODE} \
+        NUM_NODES=${SLURM_JOB_NUM_NODES} \
+        MASTER_ADDR=${MASTER_ADDR} \
+        MASTER_PORT=${MASTER_PORT_FOR_CONFIG} \
+        NANO_TP=${TP} NANO_PP=${PP} NANO_EP=${EP} NANO_CP=${CP} NANO_SP=${SP} \
+        SEQ_LENGTH=${SEQ_LENGTH} TRAIN_ITERS=${TRAIN_ITERS} \
+        GLOBAL_BATCH_SIZE=${GLOBAL_BATCH_SIZE} MICRO_BATCH_SIZE=${MICRO_BATCH_SIZE} \
+        EVAL_ITERS=${EVAL_ITERS} LR_WARMUP_ITERS=${LR_WARMUP_ITERS} \
+        LOG_INTERVAL=${LOG_INTERVAL} \
+        bash examples/nemotron3/nano.sh"
+
+    echo "Executing command:"
+    echo "${CMD}"
+    "${SRUN_CMD[@]}" bash -lc "${CMD}"
+done
+
+echo "======================================"
+echo "Legacy nano.sh job completed"
+echo "======================================"

--- a/hybrid_builders.py
+++ b/hybrid_builders.py
@@ -1,46 +1,86 @@
 # Copyright (c) 2025-2026, NVIDIA CORPORATION.  All rights reserved.
 
-from model_provider import count_parameters_in_layer
+from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_inference_stack_spec
 from megatron.core.models.hybrid.hybrid_model import HybridModel
+from megatron.core.models.hybrid.layer_pattern import load_recipe
 from megatron.core.transformer import TransformerConfig
 from megatron.core.transformer.spec_utils import import_module
 from megatron.training import print_rank_0
 from megatron.training.arguments import core_transformer_config_from_args
-from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_inference_stack_spec
+from model_provider import count_parameters_in_layer
 
 
 def hybrid_builder(args, pre_process, post_process, vp_stage=None, config=None, pg_collection=None):
+    """Construct a HybridModel from CLI args, dispatching on ``--model-recipe``."""
     print_rank_0('building Hybrid model ...')
-    if config is None:
-        config = core_transformer_config_from_args(args, TransformerConfig)
+    assert args.use_legacy_models is False, "Hybrid model only supported in Mcore!"
 
-    if config.transformer_impl == "inference_optimized":
-        hybrid_stack_spec = hybrid_inference_stack_spec
-        assert (
-            not config.inference_fuse_tp_communication
-        ), "inference_fuse_tp_communication is not supported for HybridModel"
-    elif args.spec is not None:
-        hybrid_stack_spec = import_module(args.spec)
+    # --model-recipe path: the recipe is the source of truth for the model
+    # architecture (config + layer pattern). Skip args→config conversion entirely.
+    if getattr(args, 'model_recipe', None) is not None:
+        if config is not None:
+            print_rank_0(
+                "Note: --model-recipe was provided; ignoring caller-supplied config "
+                "and using the recipe."
+            )
+        recipe = getattr(args, '_model_recipe', None)
+        if recipe is None:
+            recipe = load_recipe(args.model_recipe)
+
+        # Spec selection: ``--spec`` (CLI) overrides everything; otherwise
+        # auto-pick by ``transformer_impl`` set on the recipe's common
+        # config. ``None`` falls through to HybridModel's default
+        # hybrid_stack_spec. Same precedence as the legacy path below —
+        # recipe-built models get spec selection from the launcher, not
+        # from the recipe itself.
+        if getattr(args, 'spec', None) is not None:
+            recipe_stack_spec = import_module(args.spec)
+        elif recipe.common_config.transformer_impl == "inference_optimized":
+            recipe_stack_spec = hybrid_inference_stack_spec
+        else:
+            recipe_stack_spec = None
+
+        # Phase 2: call the new TC-free constructor directly.
+        # ``HybridModel(config: HybridModelConfig, ...)`` is the public
+        # surface; ``from_recipe`` now exists only as a thin alias.
+        model = HybridModel(
+            config=recipe,
+            hybrid_stack_spec=recipe_stack_spec,
+            pre_process=pre_process,
+            post_process=post_process,
+            pg_collection=pg_collection,
+            vp_stage=vp_stage,
+        )
     else:
-        raise ValueError("You must provide a valid hybrid layer spec via --spec")
+        if config is None:
+            config = core_transformer_config_from_args(args, TransformerConfig)
+        if config.transformer_impl == "inference_optimized":
+            hybrid_stack_spec = hybrid_inference_stack_spec
+            assert (
+                not config.inference_fuse_tp_communication
+            ), "inference_fuse_tp_communication is not supported for HybridModel"
+        elif args.spec is not None:
+            hybrid_stack_spec = import_module(args.spec)
+        else:
+            raise ValueError("You must provide a valid hybrid layer spec via --spec")
 
-    model = HybridModel(
-        config=config,
-        hybrid_stack_spec=hybrid_stack_spec,
-        vocab_size=args.padded_vocab_size,
-        max_sequence_length=args.max_position_embeddings,
-        hybrid_layer_pattern=args.hybrid_layer_pattern,
-        pre_process=pre_process,
-        post_process=post_process,
-        fp16_lm_cross_entropy=args.fp16_lm_cross_entropy,
-        parallel_output=True,
-        share_embeddings_and_output_weights=not args.untie_embeddings_and_output_weights,
-        position_embedding_type=args.position_embedding_type,
-        rotary_percent=args.rotary_percent,
-        rotary_base=args.rotary_base,
-        pg_collection=pg_collection,
-        vp_stage=vp_stage,
-    )
+        model = HybridModel(
+            config=config,
+            hybrid_stack_spec=hybrid_stack_spec,
+            vocab_size=args.padded_vocab_size,
+            max_sequence_length=args.max_position_embeddings,
+            pre_process=pre_process,
+            post_process=post_process,
+            fp16_lm_cross_entropy=args.fp16_lm_cross_entropy,
+            parallel_output=True,
+            share_embeddings_and_output_weights=not args.untie_embeddings_and_output_weights,
+            position_embedding_type=args.position_embedding_type,
+            rotary_percent=args.rotary_percent,
+            rotary_base=args.rotary_base,
+            pg_collection=pg_collection,
+            vp_stage=vp_stage,
+            hybrid_layer_pattern=args.hybrid_layer_pattern,
+        )
 
     for l in range(model.decoder.num_layers_per_pipeline_rank):
         layer_params = count_parameters_in_layer(model, f'decoder.layers.{l}.')

--- a/megatron/core/models/hybrid/__init__.py
+++ b/megatron/core/models/hybrid/__init__.py
@@ -1,1 +1,27 @@
 # Copyright (c) 2024-2026, NVIDIA CORPORATION. All rights reserved.
+
+from megatron.core.models.hybrid.common_layer_config import CommonLayerConfig
+from megatron.core.models.hybrid.layer_configs import (
+    AttentionLayerConfig,
+    CrossEntropyLayerConfig,
+    DSALayerConfig,
+    EmbeddingLayerConfig,
+    GDNLayerConfig,
+    LayerConfig,
+    MambaLayerConfig,
+    MLPLayerConfig,
+    MoELayerConfig,
+)
+
+__all__ = [
+    "AttentionLayerConfig",
+    "CommonLayerConfig",
+    "CrossEntropyLayerConfig",
+    "DSALayerConfig",
+    "EmbeddingLayerConfig",
+    "GDNLayerConfig",
+    "LayerConfig",
+    "MambaLayerConfig",
+    "MLPLayerConfig",
+    "MoELayerConfig",
+]

--- a/megatron/core/models/hybrid/__init__.py
+++ b/megatron/core/models/hybrid/__init__.py
@@ -12,6 +12,20 @@ from megatron.core.models.hybrid.layer_configs import (
     MLPLayerConfig,
     MoELayerConfig,
 )
+from megatron.core.models.hybrid.layer_pattern import (
+    RECIPE_ENTRY_POINT,
+    flatten_decoder_pattern,
+    load_recipe,
+)
+
+
+def __getattr__(name):
+    if name == "HybridModelConfig":
+        from megatron.training.models.hybrid import HybridModelConfig
+
+        return HybridModelConfig
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "AttentionLayerConfig",
@@ -20,8 +34,11 @@ __all__ = [
     "DSALayerConfig",
     "EmbeddingLayerConfig",
     "GDNLayerConfig",
+    "HybridModelConfig",
     "LayerConfig",
     "MambaLayerConfig",
     "MLPLayerConfig",
     "MoELayerConfig",
+    "RECIPE_ENTRY_POINT",
+    "load_recipe",
 ]

--- a/megatron/core/models/hybrid/common_layer_config.py
+++ b/megatron/core/models/hybrid/common_layer_config.py
@@ -1,0 +1,380 @@
+# Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Common (model-wide) configuration for the HybridModel Python DSL.
+
+:class:`CommonLayerConfig` is a focused dataclass exposing the fields that
+typical hybrid-model authors actually customise per-model. It is *not* a
+subclass of :class:`TransformerConfig`; instead, it normalises a small set of
+Python-native fields (e.g. ``mixed_precision_dtype=torch.bfloat16`` rather
+than the ``bf16: bool`` / ``fp16: bool`` pair) and converts to a full
+:class:`TransformerConfig` only at layer-construction time.
+
+All fields here are *defaults* shared by at least two decoder layer families
+in the HybridModel stack. Per-layer :class:`LayerConfig` instances may
+override or augment via either:
+
+- :meth:`update`: a sibling :class:`CommonLayerConfig` produced by
+  :func:`dataclasses.replace`. Use this for layer-class-wide overrides
+  (e.g. an MoE-specific common with a different ``ffn_hidden_size``).
+- per-layer fields on the layer-specific config (e.g.
+  :class:`MambaLayerConfig.head_dim`).
+
+Anything derivable from the model architecture (``num_layers`` from pattern
+length, ``num_query_groups`` from ``num_attention_heads``,
+``kv_channels`` from ``hidden_size // num_attention_heads``,
+``mamba_num_heads`` from ``hidden_size * expand // mamba_head_dim``) does
+**not** appear here — it is computed at compile time.
+"""
+
+import dataclasses
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict
+
+import torch
+
+from megatron.core.activations import squared_relu
+
+_ACTIVATION_BY_NAME: Dict[str, Callable] = {
+    "gelu": torch.nn.functional.gelu,
+    "relu": torch.nn.functional.relu,
+    "silu": torch.nn.functional.silu,
+    "swish": torch.nn.functional.silu,
+    "swiglu": torch.nn.functional.silu,  # SwiGLU = SiLU + GLU; gated_linear_unit=True separately
+    "squared_relu": squared_relu,
+}
+
+
+def _require_torch_dtype(value: Any, field_name: str) -> torch.dtype:
+    if not isinstance(value, torch.dtype):
+        raise TypeError(f"{field_name} must be a torch.dtype, got {value!r}.")
+    return value
+
+
+def _resolve_activation(name_or_callable: Any) -> Callable:
+    if callable(name_or_callable):
+        return name_or_callable
+    try:
+        return _ACTIVATION_BY_NAME[name_or_callable]
+    except KeyError as e:
+        raise ValueError(
+            f"Unknown activation {name_or_callable!r}; expected a callable or "
+            f"one of {sorted(_ACTIVATION_BY_NAME)}."
+        ) from e
+
+
+# --- the config itself ----------------------------------------------------
+
+
+@dataclass
+class CommonLayerConfig:
+    """Model-wide defaults shared across every layer in a HybridModel recipe."""
+
+    # === Architecture ===
+    hidden_size: int = 0
+    """Layer hidden size. Required (must be set by the recipe)."""
+
+    ffn_hidden_size: int | None = None
+    """MLP intermediate size. If None, ``TransformerConfig`` derives ``4 * hidden_size``."""
+
+    # === Precision ===
+    mixed_precision_dtype: torch.dtype = torch.float32
+    """Mixed-precision compute dtype. One of ``torch.float32``, ``torch.float16``,
+    ``torch.bfloat16``."""
+
+    params_dtype: torch.dtype | None = None
+    """Parameter storage dtype. ``None`` follows :attr:`mixed_precision_dtype`."""
+
+    first_last_layers_bf16: bool = False
+    """Retain the first and last N TransformerBlocks in BF16 instead of FP8."""
+
+    # === Parallelism (layer-level only) ===
+    # Model-level parallelism sizes (TP/PP/CP/EP/ETP) live on
+    # :class:`HybridModelConfig`, not here — they're job-/model-level
+    # concerns and can't actually vary per-layer in the current
+    # implementation. ``sequence_parallel`` stays here because it is a
+    # per-layer behaviour toggle for layer norms / dropout.
+    sequence_parallel: bool = False
+    """Enable sequence-parallel layer norms / dropout (paired with TP)."""
+
+    # === Initialisation ===
+    init_method_std: float = 0.02
+    """Standard deviation for the default normal-init method."""
+
+    perform_initialization: bool = True
+    """If False, skip weight init at construction (useful when loading checkpoints)."""
+
+    use_cpu_initialization: bool = False
+    """Initialise on CPU instead of GPU (slower but TP-deterministic)."""
+
+    # === Norms ===
+    normalization: str = "LayerNorm"
+    """``"LayerNorm"`` or ``"RMSNorm"``."""
+
+    layernorm_epsilon: float = 1e-5
+    """Epsilon for normalisation layers."""
+
+    layernorm_zero_centered_gamma: bool = False
+    """Centre LayerNorm gamma around 0 for numerical stability."""
+
+    # === Bias / activation ===
+    add_bias_linear: bool = True
+    """Bias in supported projection / MLP / expert linear layers."""
+
+    gated_linear_unit: bool = False
+    """Use GLU on the first MLP linear layer."""
+
+    activation_func: str = "gelu"
+    """MLP activation function name (looked up in :data:`_ACTIVATION_BY_NAME`)."""
+
+    # === Dropout ===
+    hidden_dropout: float = 0.0
+    """Dropout on the transformer hidden state."""
+
+    # === Residual ===
+    fp32_residual_connection: bool = False
+    """Cast residual connections to fp32."""
+
+    # === Fusions ===
+    apply_rope_fusion: bool = False
+    """Use the fused RoPE kernel for attention-like layers."""
+
+    persist_layer_norm: bool = False
+    """Use the persistent fused LayerNorm kernel (only supports a fixed set of hidden sizes)."""
+
+    # === Layer wiring ===
+    apply_residual_connection_post_layernorm: bool = False
+    """Apply the residual connection after layernorm (post-LN) instead of before it."""
+
+    # === FP8 quantization ===
+    fp8: str | None = None
+    """FP8 format (``"e4m3"`` / ``"hybrid"``); ``None`` disables FP8."""
+
+    fp8_recipe: str | None = None
+    """FP8 scaling recipe (``"tensorwise"`` / ``"delayed"`` / ``"mxfp8"`` /
+    ``"blockwise"`` / ``"custom"``); ``None`` keeps the TC default."""
+
+    fp8_param: bool = False
+    """Keep parameters in FP8 precision (requires :attr:`fp8` to be set)."""
+
+    fp8_margin: int = 0
+    """Margin used by the FP8 amax history."""
+
+    fp8_amax_history_len: int = 1
+    """Length of the FP8 amax history window."""
+
+    fp8_dot_product_attention: bool = False
+    """Apply FP8 to the dot-product attention kernel."""
+
+    # === FP4 quantization ===
+    fp4: str | None = None
+    """FP4 format (``"e2m1"``); ``None`` disables FP4."""
+
+    fp4_recipe: str | None = None
+    """FP4 scaling recipe (``"nvfp4"`` / ``"custom"``); ``None`` keeps the
+    TC default."""
+
+    fp4_param: bool = False
+    """Keep parameters in FP4 precision (requires :attr:`fp4` to be set)."""
+
+    # === Activation recomputation ===
+    recompute_granularity: str | None = None
+    """``"full"`` recomputes the whole transformer block; ``"selective"``
+    recomputes only the attention activations."""
+
+    recompute_method: str | None = None
+    """``"uniform"`` distributes recomputation evenly; ``"block"`` recomputes
+    a contiguous block."""
+
+    recompute_num_layers: int | None = None
+    """How many layers to recompute (interpretation depends on
+    :attr:`recompute_method`)."""
+
+    distribute_saved_activations: bool | None = False
+    """Distribute saved activations across the tensor-parallel group."""
+
+    # === Model family ===
+    # ``is_hybrid_model`` is intentionally NOT exposed here — every HybridModel
+    # recipe is a hybrid model by construction, so :meth:`HybridModelConfig.compile`
+    # forces it to ``True`` on every per-layer / stack-level TC. Putting it on the
+    # user surface would just be a redundant ``=True`` users have to write.
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # TransformerConfig-specific fields below this line.
+    #
+    # These knobs map directly to ``TransformerConfig`` settings that select
+    # implementation backends or kernel-fusion details specific to the
+    # ``TransformerConfig`` / ``TransformerLayer`` machinery. They exist to
+    # let recipes faithfully reproduce existing models that already set them.
+    # When the underlying layer infrastructure is rewritten with dedicated
+    # per-layer configs, these fields will move, change shape, or disappear —
+    # they are not a stable part of the DSL's contract. New recipes should
+    # only set them if they actually need to override the default.
+    # ─────────────────────────────────────────────────────────────────────────
+
+    transformer_impl: str = "transformer_engine"
+    """Transformer implementation: ``"transformer_engine"``, ``"local"``, or
+    ``"inference_optimized"``."""
+
+    cuda_graph_impl: str | None = None
+    """CUDA graph capture implementation: ``"none"``, ``"local"``, or ``"transformer_engine"``."""
+
+    cuda_graph_scope: str = "full"
+    """CUDA graph capture scope (e.g. ``"full"``, ``"attn"``, ``"mlp"``, ``"full_iteration"``)."""
+
+    cuda_graph_warmup_steps: int = 3
+    """Number of warmup steps for CUDA graphs."""
+
+    # === Escape hatch for any TransformerConfig field not curated above ===
+    extra: Dict[str, Any] = field(default_factory=dict)
+    """Passthrough kwargs forwarded to :class:`TransformerConfig`.
+
+    Use this to set any TransformerConfig field that isn't a first-class
+    attribute on :class:`CommonLayerConfig`. New fields added to
+    TransformerConfig upstream propagate to recipes immediately without
+    needing a DSL update::
+
+        common = CommonLayerConfig(
+            hidden_size=2688,
+            extra={"qk_layernorm": True, "moe_expert_capacity_factor": 1.5},
+        )
+
+    Keys are validated against ``dataclasses.fields(TransformerConfig)`` at
+    compile time — typos raise ``ValueError``. Curated fields (e.g.
+    ``hidden_size``) take precedence; ``extra`` only fills in fields the
+    curated set does not cover.
+    """
+
+    # ---------------------------------------------------------------- helpers
+
+    def update(self, **overrides) -> "CommonLayerConfig":
+        """Return a fresh CommonLayerConfig with overrides applied."""
+        return dataclasses.replace(self, **overrides)
+
+    def to_transformer_config_kwargs(self) -> Dict[str, Any]:
+        """Translate to keyword arguments accepted by :class:`TransformerConfig`.
+
+        Validates torch dtype fields and performs string→callable mapping. Does
+        **not** include layer-specific fields (``num_attention_heads``,
+        ``mamba_head_dim``, ``num_moe_experts``, ...) — those come from the
+        per-layer :class:`LayerConfig` and are merged on top.
+
+        .. note::
+
+            This method is the bridge between the DSL's user-facing fields
+            and the underlying :class:`TransformerConfig` machinery the
+            current layer classes consume. When the layer classes are
+            rewritten with dedicated per-layer configs, this method's
+            output type and name change but the DSL's user-facing surface
+            (``CommonLayerConfig`` fields, ``LayerConfig`` subclasses) is
+            preserved. Recipe code does not need to touch this method.
+        """
+        mixed_precision_dtype = _require_torch_dtype(
+            self.mixed_precision_dtype, "mixed_precision_dtype"
+        )
+        if self.params_dtype is None:
+            params_dtype_resolved = mixed_precision_dtype
+        else:
+            params_dtype_resolved = _require_torch_dtype(self.params_dtype, "params_dtype")
+
+        kwargs: Dict[str, Any] = {
+            "hidden_size": self.hidden_size,
+            "params_dtype": params_dtype_resolved,
+            "sequence_parallel": self.sequence_parallel,
+            "init_method_std": self.init_method_std,
+            "perform_initialization": self.perform_initialization,
+            "use_cpu_initialization": self.use_cpu_initialization,
+            "normalization": self.normalization,
+            "layernorm_epsilon": self.layernorm_epsilon,
+            "layernorm_zero_centered_gamma": self.layernorm_zero_centered_gamma,
+            "add_bias_linear": self.add_bias_linear,
+            "gated_linear_unit": self.gated_linear_unit,
+            "activation_func": _resolve_activation(self.activation_func),
+            "hidden_dropout": self.hidden_dropout,
+            "fp32_residual_connection": self.fp32_residual_connection,
+            "first_last_layers_bf16": self.first_last_layers_bf16,
+            "apply_rope_fusion": self.apply_rope_fusion,
+            "persist_layer_norm": self.persist_layer_norm,
+            "apply_residual_connection_post_layernorm": (
+                self.apply_residual_connection_post_layernorm
+            ),
+            "fp8_param": self.fp8_param,
+            "fp8_margin": self.fp8_margin,
+            "fp8_amax_history_len": self.fp8_amax_history_len,
+            "fp8_dot_product_attention": self.fp8_dot_product_attention,
+            "fp4_param": self.fp4_param,
+            "distribute_saved_activations": self.distribute_saved_activations,
+            "transformer_impl": self.transformer_impl,
+            "cuda_graph_scope": self.cuda_graph_scope,
+            "cuda_graph_warmup_steps": self.cuda_graph_warmup_steps,
+        }
+        if self.ffn_hidden_size is not None:
+            kwargs["ffn_hidden_size"] = self.ffn_hidden_size
+        if self.cuda_graph_impl is not None:
+            kwargs["cuda_graph_impl"] = self.cuda_graph_impl
+        for name in (
+            "fp8",
+            "fp8_recipe",
+            "fp4",
+            "fp4_recipe",
+            "recompute_granularity",
+            "recompute_method",
+            "recompute_num_layers",
+        ):
+            v = getattr(self, name)
+            if v is not None:
+                kwargs[name] = v
+        # mixed_precision_dtype → bf16/fp16 booleans expected by TransformerConfig
+        if mixed_precision_dtype == torch.bfloat16:
+            kwargs["bf16"] = True
+        elif mixed_precision_dtype == torch.float16:
+            kwargs["fp16"] = True
+        elif mixed_precision_dtype != torch.float32:
+            raise ValueError(
+                "mixed_precision_dtype must be one of torch.float32, torch.float16, "
+                f"or torch.bfloat16; got {mixed_precision_dtype!r}."
+            )
+        # Escape-hatch passthrough: validate keys then merge over curated kwargs
+        # for any TransformerConfig field not exposed as a first-class attribute.
+        # Reject keys that name a curated CommonLayerConfig attribute — those
+        # would silently shadow the dataclass field.
+        if self.extra:
+            validate_extra_kwargs(self.extra, "CommonLayerConfig.extra")
+            curated = {f.name for f in dataclasses.fields(self) if f.name != "extra"}
+            curated_tc_keys = set(kwargs) | {"bf16", "fp16"}
+            shadowed = sorted(set(self.extra) & (curated | curated_tc_keys))
+            if shadowed:
+                raise ValueError(
+                    f"CommonLayerConfig.extra cannot name curated fields: {shadowed}. "
+                    f"Set them on the dataclass attribute directly."
+                )
+            kwargs.update(self.extra)
+        return kwargs
+
+
+def validate_extra_kwargs(
+    extra: Dict[str, Any], origin: str, config_cls: type | None = None
+) -> None:
+    """Validate that every key in ``extra`` names a real target config field.
+
+    The DSL accepts an ``extra: Dict[str, Any]`` passthrough on every config
+    class to keep the recipe surface complete relative to the TransformerConfig
+    class it lowers to without monotonically growing the curated DSL field set.
+    To catch typos early, this validator rejects keys that don't appear on the
+    target config dataclass.
+
+    Raises:
+        ValueError: if any key in ``extra`` is not a target config field.
+    """
+    from megatron.core.transformer.transformer_config import TransformerConfig
+
+    if config_cls is None:
+        config_cls = TransformerConfig
+
+    valid_fields = {f.name for f in dataclasses.fields(config_cls)}
+    unknown = sorted(set(extra) - valid_fields)
+    if unknown:
+        raise ValueError(
+            f"{origin} contains keys that are not {config_cls.__name__} fields: "
+            f"{unknown}. Either correct the spelling or add the field upstream "
+            f"in megatron/core/transformer/transformer_config.py."
+        )

--- a/megatron/core/models/hybrid/hybrid_block.py
+++ b/megatron/core/models/hybrid/hybrid_block.py
@@ -64,6 +64,12 @@ class HybridStack(MegatronModule):
         layer_type_list (list, optional): pre-computed list of layer type symbols for
             this pipeline segment. When provided (by HybridModel), pipeline stage
             selection has already been done via '|' separators in the pattern.
+        layer_config_list (list[TransformerConfig], optional): per-layer
+            :class:`TransformerConfig` instances, parallel to ``layer_type_list``.
+            When provided (by HybridModel built via the Python layer-pattern DSL),
+            each layer is constructed with its own per-layer config instead of the
+            stack-level ``config``. When ``None``, every layer uses ``config``,
+            preserving the legacy string-pattern path byte-for-byte.
         pp_layer_offset (int, optional): the global layer offset for this pipeline
             segment. Defaults to 0.
         post_layer_norm (bool, optional): whether to include a final layer norm.
@@ -83,6 +89,7 @@ class HybridStack(MegatronModule):
         submodules: HybridStackSubmodules,
         pre_process: bool = True,
         layer_type_list: Optional[list[str]] = None,
+        layer_config_list: Optional[list[TransformerConfig]] = None,
         pp_layer_offset: int = 0,
         post_layer_norm: bool = True,
         post_process: bool = True,
@@ -117,6 +124,13 @@ class HybridStack(MegatronModule):
         )
         self.layer_type_list = layer_type_list
 
+        if layer_config_list is not None and len(layer_config_list) != len(layer_type_list):
+            raise ValueError(
+                f"layer_config_list length ({len(layer_config_list)}) must match "
+                f"layer_type_list length ({len(layer_type_list)})."
+            )
+        self.layer_config_list = layer_config_list
+
         if getattr(self.config, "mla_down_proj_fusion", False):
             submodules = self._fuse_mla_down_proj(submodules)
 
@@ -124,6 +138,11 @@ class HybridStack(MegatronModule):
         self.layers = nn.ModuleList()
         for i, layer_type in enumerate(self.layer_type_list):
             layer_number = i + 1 + pp_layer_offset
+            # Per-layer config from the Python DSL when provided; otherwise
+            # every layer uses the stack-level config (legacy string-pattern path).
+            per_layer_config = (
+                layer_config_list[i] if layer_config_list is not None else self.config
+            )
             if self.config.fp8:
                 quant_init_context = get_fp8_context(self.config, i + pp_layer_offset, is_init=True)
             elif self.config.fp4:
@@ -134,7 +153,7 @@ class HybridStack(MegatronModule):
                 if layer_type == LayerSymbols.MAMBA:
                     layer = build_module(
                         submodules.mamba_layer,
-                        config=self.config,
+                        config=per_layer_config,
                         layer_number=layer_number,
                         pp_layer_offset=pp_layer_offset,
                         pg_collection=pg_collection,
@@ -143,7 +162,7 @@ class HybridStack(MegatronModule):
                 elif layer_type == LayerSymbols.ATTENTION:
                     layer = build_module(
                         submodules.attention_layer,
-                        config=self.config,
+                        config=per_layer_config,
                         layer_number=layer_number,
                         pg_collection=pg_collection,
                         is_mtp_layer=is_mtp_layer,
@@ -154,7 +173,7 @@ class HybridStack(MegatronModule):
                 elif layer_type == LayerSymbols.DS_ATTENTION:
                     layer = build_module(
                         submodules.dsa_layer,
-                        config=self.config,
+                        config=per_layer_config,
                         layer_number=layer_number,
                         pg_collection=pg_collection,
                         is_mtp_layer=is_mtp_layer,
@@ -175,7 +194,7 @@ class HybridStack(MegatronModule):
                 elif layer_type == LayerSymbols.MLP:
                     layer = build_module(
                         submodules.mlp_layer,
-                        config=self.config,
+                        config=per_layer_config,
                         layer_number=layer_number,
                         pg_collection=pg_collection,
                         add_layer_offset=False,
@@ -184,7 +203,7 @@ class HybridStack(MegatronModule):
                 elif layer_type == LayerSymbols.MOE:
                     layer = build_module(
                         submodules.moe_layer,
-                        config=self.config,
+                        config=per_layer_config,
                         layer_number=layer_number,
                         pg_collection=pg_collection,
                         add_layer_offset=False,
@@ -193,7 +212,7 @@ class HybridStack(MegatronModule):
                 elif layer_type == LayerSymbols.GDN:
                     layer = build_module(
                         submodules.gdn_layer,
-                        config=self.config,
+                        config=per_layer_config,
                         layer_number=layer_number,
                         pg_collection=pg_collection,
                         # Set to False as we do not want to change offset.

--- a/megatron/core/models/hybrid/hybrid_model.py
+++ b/megatron/core/models/hybrid/hybrid_model.py
@@ -1,8 +1,11 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
-import logging
-from typing import Literal, Optional
+from __future__ import annotations
 
+import logging
+from typing import TYPE_CHECKING, Literal, Optional, Union
+
+import torch
 from torch import Tensor
 
 from megatron.core import tensor_parallel
@@ -39,6 +42,13 @@ from megatron.core.utils import (
 
 logger = logging.getLogger(__name__)
 
+if TYPE_CHECKING:
+    from megatron.training.models.hybrid import HybridModelConfig
+
+
+def _is_recipe_config(config: object) -> bool:
+    return bool(getattr(config, "is_recipe_config", False))
+
 
 def _hybrid_logging_pg_kwargs(pg_collection: ProcessGroupCollection) -> dict:
     tp_group = getattr(pg_collection, 'tp', None)
@@ -55,14 +65,54 @@ def _hybrid_logging_pg_kwargs(pg_collection: ProcessGroupCollection) -> dict:
 class HybridModel(LanguageModule, GraphableMegatronModule):
     """Hybrid language model.
 
+    A HybridModel is constructed via either of two paths:
+
+    1. **Recipe path (recommended).** Pass a :class:`HybridModelConfig`
+       directly as ``config``: ``HybridModel(config=recipe, ...)``. The
+       recipe is the public contract; lowering to the underlying
+       :class:`TransformerConfig`-based representation happens internally
+       inside ``__init__``. The :meth:`from_recipe` classmethod is retained
+       as a thin alias for backward compatibility.
+    2. **Legacy string-pattern path.** Pass ``config`` (a
+       :class:`TransformerConfig`) together with ``hybrid_layer_pattern``
+       (a single-character pattern string). Retained for backwards
+       compatibility — including pipeline parallelism and MTP, which the
+       recipe DSL does not yet cover.
+
     Args:
-        config (TransformerConfig): Model config
-        hybrid_stack_spec (ModuleSpec): Specifies the modules to use for the various layer types
-        vocab_size (int): Vocabulary size
-        max_sequence_length (int): maximum size of sequence.
-            This is used for positional embedding
-        hybrid_layer_pattern (str): Unified hybrid layer pattern with optional MTP and
-            pipeline stage boundaries.
+        config (Union[TransformerConfig, HybridModelConfig]): Either a
+            :class:`HybridModelConfig` (recipe path — the recipe is the
+            single source of truth for everything except construction-time
+            concerns like ``pg_collection`` and ``vp_stage``) or a stack-
+            level :class:`TransformerConfig` (legacy path). When a
+            :class:`HybridModelConfig` is passed, the architecture / loss
+            / position-embedding kwargs below (``vocab_size``,
+            ``max_sequence_length``, ``position_embedding_type``,
+            ``rotary_percent``, ``rotary_base``,
+            ``scatter_embedding_sequence_parallel``,
+            ``seq_len_interpolation_factor``, ``fp16_lm_cross_entropy``,
+            ``parallel_output``, ``share_embeddings_and_output_weights``)
+            are read from the recipe's
+            :class:`EmbeddingLayerConfig` / :class:`CrossEntropyLayerConfig`
+            markers and the recipe's
+            ``untie_embeddings_and_output_weights`` field; any explicit
+            values passed alongside a recipe are silently overridden.
+        hybrid_stack_spec (ModuleSpec, optional): Module specs for the
+            various layer types. Required on the legacy string-pattern path.
+            On the recipe path, defaults to the production
+            ``hybrid_stack_spec`` in
+            :mod:`megatron.core.models.hybrid.hybrid_layer_specs` when not
+            supplied.
+        vocab_size (int): Vocabulary size. Legacy path only — on the
+            recipe path the value comes from
+            ``recipe.embedding_marker.vocab_size``.
+        max_sequence_length (int): Maximum size of sequence used for
+            positional embedding. Legacy path only — on the recipe path
+            the value comes from
+            ``recipe.embedding_marker.max_sequence_length``.
+        hybrid_layer_pattern (str): Legacy string-pattern path. Unified
+            hybrid layer pattern with optional MTP and pipeline stage
+            boundaries.
             Format: "<main_pattern>/<mtp_pattern>/<mtp_pattern>/..."
             The main pattern may contain "|" to define pipeline stage boundaries.
             Examples:
@@ -82,30 +132,39 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
             (used with pipeline parallelism). Defaults to True.
         post_process (bool, optional): Include an output layer (used with pipeline parallelism).
             Defaults to True.
-        fp16_lm_cross_entropy (bool, optional): Defaults to False.
+        fp16_lm_cross_entropy (bool, optional): Defaults to False. Legacy path only — on
+            the recipe path the value comes from ``recipe.loss_marker.fp16_lm_cross_entropy``.
         parallel_output (bool, optional): Do not gather the outputs, keep them split across tensor
-            parallel ranks. Defaults to True.
+            parallel ranks. Defaults to True. Legacy path only — on the recipe path the
+            value comes from ``recipe.loss_marker.parallel_output``.
         share_embeddings_and_output_weights (bool, optional): When True, input embeddings and
-            output logit weights are shared. Defaults to False.
+            output logit weights are shared. Defaults to False. Legacy path only — on the
+            recipe path the value is derived as
+            ``not recipe.untie_embeddings_and_output_weights``.
         position_embedding_type (Literal[learned_absolute,rope,yarn,none], optional):  Position
-            embedding type. Defaults to 'none'.
+            embedding type. Defaults to 'none'. Legacy path only — on the recipe path the
+            value comes from ``recipe.embedding_marker.position_embedding_type``.
         rotary_percent (float, optional): Percent of rotary dimension to use for rotary position
             embeddings. Ignored unless position_embedding_type is 'rope'. Defaults to 1.0.
+            Legacy path only — on the recipe path the value comes from
+            ``recipe.embedding_marker.rotary_percent``.
         rotary_base (int, optional): Base period for rotary position embeddings. Ignored unless
-            position_embedding_type is 'rope'. Defaults to 10000.
+            position_embedding_type is 'rope'. Defaults to 10000. Legacy path only — on
+            the recipe path the value comes from ``recipe.embedding_marker.rotary_base``.
         seq_len_interpolation_factor (Optional[float], optional): scale of linearly
             interpolating RoPE for longer sequences. The value must be a float larger than 1.0.
-             Defaults to None.
+             Defaults to None. Legacy path only — on the recipe path the value comes from
+             ``recipe.embedding_marker.seq_len_interpolation_factor``.
         pg_collection (ProcessGroupCollection, optional): Model communication process groups.
         vp_stage (Optional[int], optional): Virtual pipeline stage index. Defaults to None.
     """
 
     def __init__(
         self,
-        config: TransformerConfig,
-        hybrid_stack_spec: ModuleSpec,
-        vocab_size: int,
-        max_sequence_length: int,
+        config: Union[TransformerConfig, HybridModelConfig],
+        hybrid_stack_spec: Optional[ModuleSpec] = None,
+        vocab_size: Optional[int] = None,
+        max_sequence_length: Optional[int] = None,
         hybrid_layer_pattern: Optional[str] = None,
         hybrid_attention_ratio: Optional[float] = None,
         hybrid_mlp_ratio: Optional[float] = None,
@@ -124,6 +183,65 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
         pg_collection: Optional[ProcessGroupCollection] = None,
         vp_stage: Optional[int] = None,
     ) -> None:
+        # Recipe path dispatch: when ``config`` is a HybridModelConfig,
+        # lower it inline and read the model-wrapping fields directly from
+        # the recipe's embedding/loss markers (``recipe.embedding_marker``,
+        # ``recipe.loss_marker``) and from the recipe itself
+        # (``untie_embeddings_and_output_weights``). Construction-time
+        # concerns (pg_collection, pre_process, post_process, vp_stage,
+        # optional hybrid_stack_spec) flow through unchanged.
+        layer_type_list: Optional[list] = None
+        layer_config_list: Optional[list] = None
+        recipe_path: bool = False
+
+        if _is_recipe_config(config):
+            if (
+                hybrid_layer_pattern is not None
+                or hybrid_override_pattern is not None
+                or (hybrid_attention_ratio is not None and hybrid_attention_ratio > 0.0)
+                or (hybrid_mlp_ratio is not None and hybrid_mlp_ratio > 0.0)
+            ):
+                raise ValueError(
+                    "HybridModelConfig (Python DSL) and the legacy "
+                    "hybrid_layer_pattern / hybrid_override_pattern / "
+                    "hybrid_attention_ratio / hybrid_mlp_ratio arguments are "
+                    "mutually exclusive; pass exactly one architecture surface."
+                )
+            recipe = config
+            stack_tc, layer_type_list, layer_config_list = recipe._lower()
+            # HybridModel-specific invariant: the inference-optimized stack
+            # does not support fused-TP communication. TC's own
+            # ``__post_init__`` checks the forward direction
+            # (fuse-TP-comm → inference_optimized); the reverse
+            # (inference_optimized + fuse-TP-comm → reject for hybrid) is
+            # a hybrid-stack-spec constraint that lives here so it fires
+            # on both ``HybridModel(config=recipe)`` and the
+            # ``from_recipe`` alias.
+            if (
+                stack_tc.transformer_impl == "inference_optimized"
+                and stack_tc.inference_fuse_tp_communication
+            ):
+                raise ValueError(
+                    "inference_fuse_tp_communication is not supported for HybridModel."
+                )
+            # Read embedding-marker fields directly from the recipe.
+            emb = recipe.embedding_marker
+            vocab_size = emb.vocab_size
+            max_sequence_length = emb.max_sequence_length
+            position_embedding_type = emb.position_embedding_type
+            rotary_percent = emb.rotary_percent
+            rotary_base = emb.rotary_base
+            scatter_embedding_sequence_parallel = emb.scatter_embedding_sequence_parallel
+            seq_len_interpolation_factor = emb.seq_len_interpolation_factor
+            # Read loss-marker fields directly from the recipe.
+            loss = recipe.loss_marker
+            fp16_lm_cross_entropy = loss.fp16_lm_cross_entropy
+            parallel_output = loss.parallel_output
+            # Tied-weights toggle lives on the recipe itself.
+            share_embeddings_and_output_weights = not recipe.untie_embeddings_and_output_weights
+            config = stack_tc
+            recipe_path = True
+
         super().__init__(config=config, pg_collection=pg_collection)
 
         if has_config_logger_enabled(config):
@@ -137,7 +255,6 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
             )
             HybridModel.mup_warning_printed = True
 
-        self.hybrid_stack_spec: ModuleSpec = hybrid_stack_spec
         self.vocab_size = vocab_size
         self.max_sequence_length = max_sequence_length
         self.hybrid_layer_pattern = hybrid_layer_pattern
@@ -149,6 +266,34 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
         self.position_embedding_type = position_embedding_type
         self.vp_stage = vp_stage
         self.disable_param_offloading = True
+
+        # ``recipe_path``, ``layer_type_list``, and ``layer_config_list``
+        # are set above by the recipe dispatch; on the legacy path the
+        # lists stay None and ``HybridStack`` derives them from
+        # ``hybrid_layer_pattern`` further below.
+        if not recipe_path and (vocab_size is None or max_sequence_length is None):
+            raise ValueError(
+                "vocab_size and max_sequence_length are required on the legacy "
+                "(hybrid_layer_pattern) construction path; pass both explicitly. "
+                "On the recipe path, HybridModel reads them from the "
+                "EmbeddingLayerConfig marker."
+            )
+
+        # When using a recipe, fall back to the default hybrid_stack_spec so that
+        # users do not need to construct or pass a ModuleSpec.
+        if recipe_path and hybrid_stack_spec is None:
+            from megatron.core.models.hybrid.hybrid_layer_specs import (
+                hybrid_stack_spec as _default_hybrid_stack_spec,
+            )
+
+            hybrid_stack_spec = _default_hybrid_stack_spec
+        elif hybrid_stack_spec is None:
+            raise ValueError(
+                "hybrid_stack_spec is required when using the legacy string-pattern path "
+                "(hybrid_layer_pattern). Pass a ModuleSpec, or use a Python recipe via "
+                "the --model-recipe path."
+            )
+        self.hybrid_stack_spec: ModuleSpec = hybrid_stack_spec
 
         # Backward compatibility for deprecated hybrid parameters
         if hybrid_override_pattern is not None:
@@ -189,27 +334,51 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
                     config.num_layers, attn_ratio, mlp_ratio
                 )
 
-        # Parse unified pattern to extract main and MTP components, and
-        # determine the pipeline segment for this model instance.
-        from megatron.core.models.hybrid.hybrid_layer_allocation import (
-            parse_hybrid_pattern,
-            select_pipeline_segment,
-        )
+        if recipe_path:
+            # Recipe path: per-layer symbols and configs were lowered from
+            # HybridModelConfig by the recipe-dispatch block above (when
+            # ``config`` was a HybridModelConfig). Pipeline parallelism
+            # and MTP are not part of the recipe DSL — recipes that need
+            # either must use the legacy hybrid_layer_pattern string DSL.
+            # The PP > 1 check below catches launcher/CLI mismatches
+            # where a PP group was constructed despite the recipe being
+            # PP-free.
+            pp_size = (
+                torch.distributed.get_world_size(self.pg_collection.pp)
+                if self.pg_collection.pp is not None
+                else 1
+            )
+            if pp_size > 1:
+                raise NotImplementedError(
+                    "The Python DSL recipe path does not support pipeline "
+                    "parallelism. Use hybrid_layer_pattern (string DSL "
+                    "with '|' separators) for PP."
+                )
+            layer_offset = 0
+            self.mtp_pattern = None
+            self.mtp_num_depths = 0
+        else:
+            # Parse unified pattern to extract main and MTP components, and
+            # determine the pipeline segment for this model instance.
+            from megatron.core.models.hybrid.hybrid_layer_allocation import (
+                parse_hybrid_pattern,
+                select_pipeline_segment,
+            )
 
-        parsed = parse_hybrid_pattern(self.hybrid_layer_pattern)
-        self.mtp_pattern = parsed.mtp_pattern
-        self.mtp_num_depths = parsed.mtp_num_depths
+            parsed = parse_hybrid_pattern(self.hybrid_layer_pattern)
+            self.mtp_pattern = parsed.mtp_pattern
+            self.mtp_num_depths = parsed.mtp_num_depths
 
-        logging_pg_kwargs = _hybrid_logging_pg_kwargs(self.pg_collection)
-
-        layer_type_list, layer_offset = select_pipeline_segment(
-            parsed.main_pattern or '',
-            self.pg_collection.pp,
-            vp_stage,
-            first_stage_layers=self.config.num_layers_in_first_pipeline_stage,
-            last_stage_layers=self.config.num_layers_in_last_pipeline_stage,
-            **logging_pg_kwargs,
-        )
+            logging_pg_kwargs = _hybrid_logging_pg_kwargs(self.pg_collection)
+            layer_type_list, layer_offset = select_pipeline_segment(
+                parsed.main_pattern or '',
+                self.pg_collection.pp,
+                vp_stage,
+                first_stage_layers=self.config.num_layers_in_first_pipeline_stage,
+                last_stage_layers=self.config.num_layers_in_last_pipeline_stage,
+                **logging_pg_kwargs,
+            )
+            layer_config_list = None
 
         # Determine if MTP is needed (based on pattern parsing)
         self.mtp_process = (
@@ -278,6 +447,7 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
             self.config,
             pre_process=self.pre_process,
             layer_type_list=layer_type_list,
+            layer_config_list=layer_config_list,
             pp_layer_offset=layer_offset,
             post_process=self.post_process,
             dtype=config.params_dtype,
@@ -333,6 +503,58 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
             if hasattr(module, 'finish_init'):
                 quant_config = get_quant_config_or_none(name, self.config.quant_recipe)
                 module.finish_init(quant_config)
+
+    @classmethod
+    def from_recipe(
+        cls,
+        recipe: HybridModelConfig,
+        *,
+        hybrid_stack_spec: Optional[ModuleSpec] = None,
+        pre_process: bool = True,
+        post_process: bool = True,
+        pg_collection: Optional[ProcessGroupCollection] = None,
+        vp_stage: Optional[int] = None,
+    ) -> "HybridModel":
+        """Construct a :class:`HybridModel` from a :class:`HybridModelConfig`.
+
+        .. note::
+           This classmethod is now a thin alias for
+           ``HybridModel(config=recipe, ...)``. New code should call the
+           constructor directly; ``from_recipe`` is retained for backward
+           compatibility with callers that pre-date the constructor's
+           native :class:`HybridModelConfig` support.
+
+        ``HybridModelConfig`` is the source of truth for everything about
+        the model (architecture, embeddings, loss behaviour, parallelism
+        pins). Only construction-time concerns — process groups, pipeline
+        staging, optional stack-spec override — come in as kwargs.
+
+        Args:
+            recipe: The recipe to build. Typically returned by a
+                ``make_recipe()`` entry point and resolved via
+                :func:`load_recipe` from the ``--model-recipe`` flag.
+            hybrid_stack_spec: Optional override for the per-layer module
+                spec. Defaults to the production
+                :data:`hybrid_layer_specs.hybrid_stack_spec`.
+            pre_process: Include the embedding layer (used with PP).
+            post_process: Include the output layer (used with PP).
+            pg_collection: Process-group collection for distributed
+                construction.
+            vp_stage: Virtual pipeline stage index.
+
+        Note:
+            Pipeline parallelism is not part of the recipe DSL.
+            :class:`HybridModel` raises if it is constructed under a PP
+            group greater than 1 via this path.
+        """
+        return cls(
+            config=recipe,
+            hybrid_stack_spec=hybrid_stack_spec,
+            pre_process=pre_process,
+            post_process=post_process,
+            pg_collection=pg_collection,
+            vp_stage=vp_stage,
+        )
 
     def set_input_tensor(self, input_tensor: Tensor) -> None:
         """Sets input tensor to the model.

--- a/megatron/core/models/hybrid/layer_configs.py
+++ b/megatron/core/models/hybrid/layer_configs.py
@@ -411,8 +411,8 @@ class MoELayerConfig(LayerConfig):
     router_score_function: str = "softmax"
     """``"softmax"`` or ``"sigmoid"``."""
 
-    router_load_balancing_type: str = "aux_loss"
-    """``"aux_loss"`` / ``"seq_aux_loss"`` / ``"global_aux_loss"`` / ``"sinkhorn"`` / ``"none"``."""
+    router_load_balancing_type: str | list[str] = "aux_loss"
+    """Load balancing type or ordered list of types for multi-loss MoE routing."""
 
     router_topk_scaling_factor: float | None = None
     """Optional scaling factor applied to top-k logits."""
@@ -423,8 +423,8 @@ class MoELayerConfig(LayerConfig):
     router_dtype: str | None = None
     """Router compute dtype name; ``None`` → input dtype."""
 
-    aux_loss_coeff: float = 0.0
-    """Auxiliary load-balancing loss coefficient (``moe_aux_loss_coeff``)."""
+    aux_loss_coeff: float | list[float] = 0.0
+    """Auxiliary load-balancing loss coefficient or per-loss coefficient list."""
 
     shared_expert_intermediate_size: int | None = None
     """If set, enables shared experts at this size."""

--- a/megatron/core/models/hybrid/layer_configs.py
+++ b/megatron/core/models/hybrid/layer_configs.py
@@ -1,0 +1,595 @@
+# Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Per-type :class:`LayerConfig` subclasses for the HybridModel Python DSL.
+
+Each layer-type config exposes only the fields a recipe author actually needs
+to set: layer-specific architecture knobs and per-layer overrides of the
+common config. Anything derivable from other fields (``num_query_groups``,
+``kv_channels``, ``mamba_num_heads``, ``num_layers``) is computed at compile
+time inside :meth:`LayerConfig.to_transformer_config` rather than required
+from the recipe.
+
+Special pattern markers — :class:`EmbeddingLayerConfig` and
+:class:`CrossEntropyLayerConfig` — also live here. They participate in
+the layer pattern but are not "layers" the :class:`HybridStack`
+constructs; they encode model-wrapping metadata (vocab/sequence shape).
+"""
+
+from dataclasses import dataclass, field, fields
+from typing import Any, ClassVar, Dict, Union
+
+from megatron.core.models.hybrid.common_layer_config import (
+    CommonLayerConfig,
+    _resolve_activation,
+    validate_extra_kwargs,
+)
+from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols
+from megatron.core.transformer.enums import AttnBackend
+from megatron.core.transformer.transformer_config import MLATransformerConfig, TransformerConfig
+
+# ------------------------------------------------------------------- LAYERS
+
+
+@dataclass
+class LayerConfig:
+    """Base class for layer-pattern leaves.
+
+    Concrete subclasses set a class-level ``SYMBOL`` matching one of
+    :class:`Symbols.VALID_LAYERS` and override
+    :meth:`_layer_specific_kwargs` to supply layer-class-specific fields
+    (e.g. ``mamba_state_dim``) for the per-layer
+    :class:`TransformerConfig`.
+    """
+
+    common_config: CommonLayerConfig | None = None
+    """Per-layer common config; ``None`` (the default) means
+    "inherit from the recipe's :attr:`HybridModelConfig.common_config`",
+    which :meth:`HybridModelConfig.compile` substitutes in. Pass an
+    explicit :class:`CommonLayerConfig` to override (e.g. via
+    :meth:`CommonLayerConfig.update`). After ``compile()`` runs, this
+    field is always non-None."""
+
+    extra: Dict[str, Any] = field(default_factory=dict)
+    """Per-layer passthrough kwargs forwarded to this layer's
+    :class:`TransformerConfig`. Same semantics as
+    :attr:`CommonLayerConfig.extra` but applied per-layer instead of
+    model-wide. Layer ``extra`` overrides curated layer fields, which
+    override common ``extra``, which overrides common curated fields."""
+
+    SYMBOL: ClassVar[str]
+
+    TC_CLASS: ClassVar[type] = TransformerConfig
+    """The :class:`TransformerConfig` subclass used to materialise this
+    layer's per-layer config. Subclasses override (e.g.
+    :class:`DSALayerConfig` uses :class:`MLATransformerConfig`) when they
+    need fields that only live on a specialised subclass."""
+
+    def _layer_specific_kwargs(self) -> Dict[str, Any]:
+        """Return the layer-class-specific TransformerConfig kwargs."""
+        return {}
+
+    def to_transformer_config(
+        self,
+        num_layers: int,
+        parallelism: Dict[str, Any] | None = None,
+        placeholders: Dict[str, Any] | None = None,
+    ) -> TransformerConfig:
+        """Build a per-layer :class:`TransformerConfig`.
+
+        ``num_layers`` is supplied by the caller (usually
+        :meth:`HybridModelConfig.compile`) after counting the flattened
+        layer pattern, so recipes never need to set it manually.
+
+        ``parallelism`` carries the universal model-level parallelism
+        settings (TP/CP) — these **always win** because they're
+        job-level. EP/ETP are MoE-only and are injected into MoE
+        per-layer TCs by :meth:`HybridModelConfig.compile`, not via this
+        path. ``placeholders`` carries values that satisfy
+        :meth:`TransformerConfig.__post_init__` invariants on layers that
+        don't naturally set them (e.g. ``num_attention_heads`` is required
+        for the ``kv_channels`` derivation even on Mamba layers) — these
+        **only fill in if absent**, so a recipe author's
+        ``common.extra={"num_attention_heads": 32}`` overrides the
+        placeholder.
+
+        Final precedence (lowest → highest): common curated → ``common.extra``
+        → ``parallelism`` → ``placeholders`` (only if absent) →
+        ``layer._layer_specific_kwargs()`` → ``layer.extra``.
+        """
+        kwargs = self.common_config.to_transformer_config_kwargs()
+        if parallelism:
+            kwargs.update(parallelism)
+        if placeholders:
+            for k, v in placeholders.items():
+                kwargs.setdefault(k, v)
+        layer_kwargs = self._layer_specific_kwargs()
+        kwargs.update({k: v for k, v in layer_kwargs.items() if v is not None})
+        if self.extra:
+            origin = f"{type(self).__name__}.extra"
+            validate_extra_kwargs(self.extra, origin, self.TC_CLASS)
+            # Reject ``extra`` keys that shadow this layer's curated fields
+            # (silent dataclass shadowing) or model-wide parallelism (process
+            # groups are global; a per-layer disagreement is invalid sharding).
+            # Layer ``extra`` may still override a value carried over from
+            # common scope — more-specific scope wins.
+            curated = {f.name for f in fields(self) if f.name not in ("common_config", "extra")}
+            curated_tc_keys = set(layer_kwargs)
+            shadowed = sorted(set(self.extra) & (curated | curated_tc_keys))
+            if shadowed:
+                raise ValueError(
+                    f"{origin} cannot name curated fields: {shadowed}. "
+                    f"Set them on the dataclass attribute directly."
+                )
+            if parallelism:
+                shadowed = sorted(set(parallelism) & set(self.extra))
+                if shadowed:
+                    raise ValueError(
+                        f"{origin} cannot override model-wide parallelism fields "
+                        f"{shadowed}; set them on HybridModelConfig instead."
+                    )
+            kwargs.update(self.extra)
+        # Test-friendly fallback: ``compile()`` always supplies a placeholder,
+        # but unit tests calling ``lc.to_transformer_config(num_layers=N)``
+        # directly need a non-zero baseline so TC's ``__post_init__`` doesn't
+        # divide by zero deriving ``kv_channels``.
+        kwargs.setdefault("num_attention_heads", 1)
+        kwargs["num_layers"] = num_layers
+        # Drop None values so TransformerConfig defaults apply.
+        kwargs = {k: v for k, v in kwargs.items() if v is not None}
+        return self.TC_CLASS(**kwargs)
+
+
+@dataclass
+class MambaLayerConfig(LayerConfig):
+    """Mamba SSM layer (symbol ``M``).
+
+    ``num_heads`` may be left ``None`` to auto-derive
+    ``hidden_size * expand // head_dim`` (TransformerConfig handles this
+    derivation when ``mamba_num_heads`` is ``None``).
+    """
+
+    head_dim: int = 64
+    """Mamba head dimension (``mamba_head_dim``)."""
+
+    state_size: int = 128
+    """SSM state dimension (``mamba_state_dim``)."""
+
+    num_groups: int = 8
+    """Mamba groups (``mamba_num_groups``)."""
+
+    num_heads: int | None = None
+    """Optional explicit head count; defaults to derived value."""
+
+    SYMBOL: ClassVar[str] = Symbols.MAMBA
+
+    def _layer_specific_kwargs(self) -> Dict[str, Any]:
+        return {
+            "mamba_head_dim": self.head_dim,
+            "mamba_state_dim": self.state_size,
+            "mamba_num_groups": self.num_groups,
+            "mamba_num_heads": self.num_heads,
+        }
+
+
+@dataclass
+class AttentionLayerConfig(LayerConfig):
+    """Self-attention layer (symbol ``*``).
+
+    ``num_query_groups`` and ``kv_channels`` may be left ``None`` to
+    auto-derive from ``num_attention_heads`` and ``hidden_size`` respectively
+    (handled in :meth:`TransformerConfig.__post_init__`).
+    """
+
+    num_attention_heads: int = 1
+    """Number of attention heads."""
+
+    num_query_groups: int | None = None
+    """GQA group count; ``None`` → ``num_attention_heads`` (i.e. MHA)."""
+
+    kv_channels: int | None = None
+    """KV head dim; ``None`` → ``hidden_size // num_attention_heads``."""
+
+    attention_dropout: float | None = None
+    """Dropout on attention weights; ``None`` → TransformerConfig default."""
+
+    attention_softmax_in_fp32: bool | None = None
+    """Run attention masking and softmax in fp32; ``None`` keeps the default."""
+
+    add_qkv_bias: bool | None = None
+    """Bias only in QKV projections, overriding ``add_bias_linear`` for QKV."""
+
+    masked_softmax_fusion: bool | None = None
+    """Use fused masked-softmax; ``None`` keeps the default."""
+
+    attention_backend: str | None = None
+    """Attention backend name (``"flash"`` / ``"fused"`` / ``"unfused"`` /
+    ``"local"`` / ``"auto"``); ``None`` → TransformerConfig default."""
+
+    SYMBOL: ClassVar[str] = Symbols.ATTENTION
+
+    def _layer_specific_kwargs(self) -> Dict[str, Any]:
+        kwargs: Dict[str, Any] = {
+            "num_attention_heads": self.num_attention_heads,
+            "num_query_groups": self.num_query_groups,
+            "kv_channels": self.kv_channels,
+            "attention_dropout": self.attention_dropout,
+            "attention_softmax_in_fp32": self.attention_softmax_in_fp32,
+            "add_qkv_bias": self.add_qkv_bias,
+            "masked_softmax_fusion": self.masked_softmax_fusion,
+        }
+        if self.attention_backend is not None:
+            kwargs["attention_backend"] = AttnBackend[self.attention_backend]
+        return kwargs
+
+
+@dataclass
+class DSALayerConfig(LayerConfig):
+    """DeepSeek Sparse Attention / MLA layer (symbol ``D``).
+
+    Cannot be combined with :class:`AttentionLayerConfig` in the same pattern.
+    The MLA-defining knobs (``q_lora_rank``, ``kv_lora_rank``,
+    ``qk_head_dim``, ``qk_pos_emb_head_dim``, ``v_head_dim``,
+    ``rope_type`` / YaRN fields, and DSA indexer fields) all default to
+    ``None``, which means "fall through to the underlying
+    :class:`MLATransformerConfig` default"; DeepSeek-style models override
+    them to the values the model card specifies.
+    """
+
+    num_attention_heads: int = 1
+    """Number of attention heads."""
+
+    num_query_groups: int | None = None
+    """GQA group count."""
+
+    kv_channels: int | None = None
+    """KV head dim."""
+
+    add_qkv_bias: bool | None = None
+    """Bias in the QKV projection only, overriding ``add_bias_linear`` for
+    QKV. Mirrors the same field on :class:`AttentionLayerConfig`."""
+
+    q_lora_rank: int | None = None
+    """Rank of the query tensor's low-rank representation."""
+
+    kv_lora_rank: int | None = None
+    """Rank of the key/value tensors' low-rank representation."""
+
+    qk_head_dim: int | None = None
+    """Dimension of the QK projection head. Together with
+    ``qk_pos_emb_head_dim`` this gives the full Q head dim
+    (``q_head_dim = qk_head_dim + qk_pos_emb_head_dim``)."""
+
+    qk_pos_emb_head_dim: int | None = None
+    """Position-embedding portion of the QK projection head dim."""
+
+    v_head_dim: int | None = None
+    """Dimension of the V projection head."""
+
+    rope_type: str | None = None
+    """MLA RoPE type (``"rope"`` or ``"yarn"``); ``None`` keeps the
+    :class:`MLATransformerConfig` default."""
+
+    rotary_base: float | None = None
+    """RoPE base for MLA-internal rotary embeddings."""
+
+    rotary_percent: float | None = None
+    """RoPE percentage for ``rope_type="rope"``."""
+
+    rotary_scaling_factor: float | None = None
+    """Rotary scaling factor for YaRN-style rope inside MLA."""
+
+    original_max_position_embeddings: int | None = None
+    """Original maximum position embeddings for YaRN-style MLA RoPE."""
+
+    beta_fast: float | None = None
+    """YaRN beta-fast value for MLA RoPE."""
+
+    beta_slow: float | None = None
+    """YaRN beta-slow value for MLA RoPE."""
+
+    mscale: float | None = None
+    """YaRN mscale value for MLA RoPE."""
+
+    mscale_all_dim: float | None = None
+    """YaRN mscale-all-dim value for MLA RoPE."""
+
+    cache_mla_latents: bool | None = None
+    """Cache compressed MLA latents for dynamic-backend inference."""
+
+    mla_down_proj_fusion: bool | None = None
+    """Enable fused MLA q/kv down-projection when the backend supports it."""
+
+    dsa_indexer_n_heads: int | None = None
+    """Number of DSA indexer heads."""
+
+    dsa_indexer_head_dim: int | None = None
+    """Dimension per DSA indexer head."""
+
+    dsa_indexer_topk: int | None = None
+    """Number of top-k tokens selected by the DSA indexer."""
+
+    dsa_indexer_loss_coeff: float | None = None
+    """KL-divergence loss coefficient for the DSA indexer."""
+
+    dsa_indexer_use_sparse_loss: bool | None = None
+    """Whether the DSA indexer loss is computed only over selected top-k
+    entries."""
+
+    SYMBOL: ClassVar[str] = Symbols.DS_ATTENTION
+    TC_CLASS: ClassVar[type] = MLATransformerConfig
+
+    def _layer_specific_kwargs(self) -> Dict[str, Any]:
+        kwargs: Dict[str, Any] = {
+            "num_attention_heads": self.num_attention_heads,
+            "num_query_groups": self.num_query_groups,
+            "kv_channels": self.kv_channels,
+            "multi_latent_attention": True,
+            "experimental_attention_variant": "dsa",
+            "q_lora_rank": self.q_lora_rank,
+            "kv_lora_rank": self.kv_lora_rank,
+            "qk_head_dim": self.qk_head_dim,
+            "qk_pos_emb_head_dim": self.qk_pos_emb_head_dim,
+            "v_head_dim": self.v_head_dim,
+            "rope_type": self.rope_type,
+            "rotary_base": self.rotary_base,
+            "rotary_percent": self.rotary_percent,
+            "rotary_scaling_factor": self.rotary_scaling_factor,
+            "original_max_position_embeddings": self.original_max_position_embeddings,
+            "beta_fast": self.beta_fast,
+            "beta_slow": self.beta_slow,
+            "mscale": self.mscale,
+            "mscale_all_dim": self.mscale_all_dim,
+            "cache_mla_latents": self.cache_mla_latents,
+            "mla_down_proj_fusion": self.mla_down_proj_fusion,
+            "dsa_indexer_n_heads": self.dsa_indexer_n_heads,
+            "dsa_indexer_head_dim": self.dsa_indexer_head_dim,
+            "dsa_indexer_topk": self.dsa_indexer_topk,
+            "dsa_indexer_loss_coeff": self.dsa_indexer_loss_coeff,
+            "dsa_indexer_use_sparse_loss": self.dsa_indexer_use_sparse_loss,
+        }
+        if self.add_qkv_bias is not None:
+            kwargs["add_qkv_bias"] = self.add_qkv_bias
+        return kwargs
+
+
+@dataclass
+class GDNLayerConfig(LayerConfig):
+    """Gated DeltaNet layer (symbol ``G``)."""
+
+    num_attention_heads: int = 1
+    """Used for the attention-shaped paths inside GDN."""
+
+    num_query_groups: int | None = None
+
+    kv_channels: int | None = None
+
+    SYMBOL: ClassVar[str] = Symbols.GDN
+
+    def _layer_specific_kwargs(self) -> Dict[str, Any]:
+        return {
+            "num_attention_heads": self.num_attention_heads,
+            "num_query_groups": self.num_query_groups,
+            "kv_channels": self.kv_channels,
+        }
+
+
+@dataclass
+class MLPLayerConfig(LayerConfig):
+    """Dense MLP layer (symbol ``-``)."""
+
+    ffn_hidden_size: int | None = None
+    """MLP intermediate size; ``None`` → ``4 * hidden_size``."""
+
+    SYMBOL: ClassVar[str] = Symbols.MLP
+
+    def _layer_specific_kwargs(self) -> Dict[str, Any]:
+        return {"ffn_hidden_size": self.ffn_hidden_size}
+
+
+@dataclass
+class MoELayerConfig(LayerConfig):
+    """Mixture-of-Experts layer (symbol ``E``).
+
+    Two distinct :class:`MoELayerConfig` instances with different
+    architecture overrides may coexist in the same pattern (e.g. one with
+    128 experts/top-6 and one with 64 experts/top-2). Expert parallelism
+    (EP/ETP) is a model-wide concept and lives on
+    :class:`HybridModelConfig`; :meth:`HybridModelConfig.compile` injects
+    those fields into MoE per-layer TransformerConfigs only.
+    """
+
+    num_experts: int = 1
+    """Total experts (``num_moe_experts``)."""
+
+    top_k: int = 1
+    """Top-k routing (``moe_router_topk``)."""
+
+    ffn_hidden_size: int | None = None
+    """Per-expert FFN size; falls back to ``moe_ffn_hidden_size`` semantics."""
+
+    router_score_function: str = "softmax"
+    """``"softmax"`` or ``"sigmoid"``."""
+
+    router_load_balancing_type: str = "aux_loss"
+    """``"aux_loss"`` / ``"seq_aux_loss"`` / ``"global_aux_loss"`` / ``"sinkhorn"`` / ``"none"``."""
+
+    router_topk_scaling_factor: float | None = None
+    """Optional scaling factor applied to top-k logits."""
+
+    router_enable_expert_bias: bool = False
+    """Enable learnable per-expert bias term in the router."""
+
+    router_dtype: str | None = None
+    """Router compute dtype name; ``None`` → input dtype."""
+
+    aux_loss_coeff: float = 0.0
+    """Auxiliary load-balancing loss coefficient (``moe_aux_loss_coeff``)."""
+
+    shared_expert_intermediate_size: int | None = None
+    """If set, enables shared experts at this size."""
+
+    token_dispatcher_type: str = "allgather"
+    """``"allgather"`` / ``"alltoall"`` / ``"flex"``."""
+
+    grouped_gemm: bool = False
+    """Use grouped GEMM for expert MLPs."""
+
+    permute_fusion: bool = False
+    """Fuse the token permutation kernel."""
+
+    activation: str | None = None
+    """Override the MLP activation for this layer (defaults to common)."""
+
+    # === Architecture / Routing / Fusion ===
+
+    router_num_groups: int | None = None
+    """Number of router groups for grouped top-k routing (``moe_router_num_groups``)."""
+
+    router_group_topk: int | None = None
+    """Per-group top-k for grouped routing (``moe_router_group_topk``)."""
+
+    shared_expert_overlap: bool = False
+    """Overlap shared-expert compute with dispatcher comms (``moe_shared_expert_overlap``)."""
+
+    flex_dispatcher_backend: str | None = None
+    """Flex token-dispatcher backend (``"deepep"`` / ``"hybridep"``);
+    ``None`` → TransformerConfig default."""
+
+    hybridep_num_sms: int | None = None
+    """Number of SMs reserved for the HybridEP dispatcher
+    (``moe_hybridep_num_sms``); ``None`` → TransformerConfig default."""
+
+    router_padding_for_fp8: bool = False
+    """Pad router output for FP8 alignment (``moe_router_padding_for_fp8``)."""
+
+    router_fusion: bool = False
+    """Enable fused router kernels (``moe_router_fusion``)."""
+
+    router_force_load_balancing: bool = False
+    """Force balanced routing assignment (``moe_router_force_load_balancing``)."""
+
+    use_fused_weighted_squared_relu: bool = False
+    """Enable the fused weighted squared-ReLU expert activation kernel."""
+
+    SYMBOL: ClassVar[str] = Symbols.MOE
+
+    def _layer_specific_kwargs(self) -> Dict[str, Any]:
+        kwargs: Dict[str, Any] = {
+            "num_moe_experts": self.num_experts,
+            "moe_router_topk": self.top_k,
+            "moe_ffn_hidden_size": self.ffn_hidden_size,
+            "moe_router_score_function": self.router_score_function,
+            "moe_router_load_balancing_type": self.router_load_balancing_type,
+            "moe_router_topk_scaling_factor": self.router_topk_scaling_factor,
+            "moe_router_enable_expert_bias": self.router_enable_expert_bias,
+            "moe_router_dtype": self.router_dtype,
+            "moe_aux_loss_coeff": self.aux_loss_coeff,
+            "moe_shared_expert_intermediate_size": self.shared_expert_intermediate_size,
+            "moe_token_dispatcher_type": self.token_dispatcher_type,
+            "moe_grouped_gemm": self.grouped_gemm,
+            "moe_permute_fusion": self.permute_fusion,
+            "moe_router_num_groups": self.router_num_groups,
+            "moe_router_group_topk": self.router_group_topk,
+            "moe_shared_expert_overlap": self.shared_expert_overlap,
+            "moe_flex_dispatcher_backend": self.flex_dispatcher_backend,
+            "moe_hybridep_num_sms": self.hybridep_num_sms,
+            "moe_router_padding_for_fp8": self.router_padding_for_fp8,
+            "moe_router_fusion": self.router_fusion,
+            "moe_router_force_load_balancing": self.router_force_load_balancing,
+            "use_fused_weighted_squared_relu": self.use_fused_weighted_squared_relu,
+        }
+        if self.activation is not None:
+            kwargs["activation_func"] = _resolve_activation(self.activation)
+        return kwargs
+
+
+# -------------------------------------------------------- PATTERN MARKERS
+
+
+@dataclass
+class EmbeddingLayerConfig:
+    """Input embedding marker (must appear at the start of a layer pattern).
+
+    Carries the runtime model-shape parameters that aren't part of any single
+    decoder layer: vocab size, max sequence length, position-embedding
+    selection, and rotary settings.
+    """
+
+    common_config: CommonLayerConfig | None = None
+    """Per-marker common config; ``None`` (the default) means "inherit from
+    the recipe's :attr:`HybridModelConfig.common_config`", which
+    :meth:`HybridModelConfig.compile` substitutes in. After ``compile()``
+    runs, this field is always non-None."""
+
+    vocab_size: int = 0
+    """Vocabulary size (post-padding)."""
+
+    max_sequence_length: int = 0
+    """Maximum sequence length the embedding supports."""
+
+    position_embedding_type: str = "none"
+    """``"learned_absolute"`` / ``"rope"`` / ``"yarn"`` / ``"none"``."""
+
+    rotary_percent: float = 1.0
+    """Fraction of the head dim to apply RoPE to (only when ``rope``/``yarn``)."""
+
+    rotary_base: int = 10000
+    """RoPE base period."""
+
+    seq_len_interpolation_factor: float | None = None
+    """Linear-interpolation scaling for longer-than-trained sequences."""
+
+    scatter_embedding_sequence_parallel: bool = True
+    """Scatter the embedding output along the sequence-parallel dim."""
+
+    yarn: Dict[str, Any] | None = None
+    """YARN scaling parameters (consumed only when
+    ``position_embedding_type == "yarn"``). These are not
+    :class:`TransformerConfig` dataclass fields today; they are attached
+    as ad-hoc attributes by :meth:`HybridModelConfig.compile` to match
+    the :func:`getattr` lookups in :class:`HybridModel.__init__`.
+    Recognised keys: ``yarn_rotary_scaling_factor``,
+    ``yarn_original_max_position_embeddings``, ``yarn_beta_fast``,
+    ``yarn_beta_slow``, ``yarn_mscale``, ``yarn_mscale_all_dim``,
+    ``yarn_correction_range_round_to_int``. Unknown keys raise at compile
+    time. When upstream lifts these onto :class:`TransformerConfig`, this
+    field collapses to a plain ``extra`` passthrough and the setattr
+    loop in ``compile()`` goes away."""
+
+    extra: Dict[str, Any] = field(default_factory=dict)
+    """Passthrough kwargs forwarded to the stack-level
+    :class:`TransformerConfig` (used for the embedding init / final norm).
+    Same semantics as :attr:`CommonLayerConfig.extra`."""
+
+
+@dataclass
+class CrossEntropyLayerConfig:
+    """Output / loss marker (must appear at the end of a layer pattern)."""
+
+    fp16_lm_cross_entropy: bool = False
+    """Compute the LM cross-entropy in fp16."""
+
+    parallel_output: bool = True
+    """Keep logits split across tensor-parallel ranks (no all-gather)."""
+
+    loss_fusion: bool = False
+    """Enable fused cross-entropy loss (``cross_entropy_loss_fusion``)."""
+
+    fusion_impl: str = "native"
+    """Fused CE implementation (``"native"`` / ``"te"``); maps to
+    ``cross_entropy_fusion_impl``."""
+
+    calculate_per_token_loss: bool = False
+    """Average loss per token rather than per microbatch
+    (``calculate_per_token_loss``)."""
+
+    extra: Dict[str, Any] = field(default_factory=dict)
+    """Passthrough kwargs forwarded to the stack-level
+    :class:`TransformerConfig`. Same semantics as
+    :attr:`CommonLayerConfig.extra`."""
+
+
+# ----------------------------------------------------------- type aliases
+
+#: Anything that may legally appear at a leaf of a layer pattern.
+PatternLeaf = Union[LayerConfig, EmbeddingLayerConfig, CrossEntropyLayerConfig]

--- a/megatron/core/models/hybrid/layer_configs.py
+++ b/megatron/core/models/hybrid/layer_configs.py
@@ -44,9 +44,9 @@ class LayerConfig:
     common_config: CommonLayerConfig | None = None
     """Per-layer common config; ``None`` (the default) means
     "inherit from the recipe's :attr:`HybridModelConfig.common_config`",
-    which :meth:`HybridModelConfig.compile` substitutes in. Pass an
+    which the recipe's internal lowering substitutes in. Pass an
     explicit :class:`CommonLayerConfig` to override (e.g. via
-    :meth:`CommonLayerConfig.update`). After ``compile()`` runs, this
+    :meth:`CommonLayerConfig.update`). After lowering runs, this
     field is always non-None."""
 
     extra: Dict[str, Any] = field(default_factory=dict)
@@ -128,10 +128,11 @@ class LayerConfig:
                         f"{shadowed}; set them on HybridModelConfig instead."
                     )
             kwargs.update(self.extra)
-        # Test-friendly fallback: ``compile()`` always supplies a placeholder,
-        # but unit tests calling ``lc.to_transformer_config(num_layers=N)``
-        # directly need a non-zero baseline so TC's ``__post_init__`` doesn't
-        # divide by zero deriving ``kv_channels``.
+        # Test-friendly fallback: the recipe's lowering always supplies a
+        # placeholder, but unit tests calling
+        # ``lc.to_transformer_config(num_layers=N)`` directly need a non-zero
+        # baseline so TC's ``__post_init__`` doesn't divide by zero deriving
+        # ``kv_channels``.
         kwargs.setdefault("num_attention_heads", 1)
         kwargs["num_layers"] = num_layers
         # Drop None values so TransformerConfig defaults apply.
@@ -517,9 +518,9 @@ class EmbeddingLayerConfig:
 
     common_config: CommonLayerConfig | None = None
     """Per-marker common config; ``None`` (the default) means "inherit from
-    the recipe's :attr:`HybridModelConfig.common_config`", which
-    :meth:`HybridModelConfig.compile` substitutes in. After ``compile()``
-    runs, this field is always non-None."""
+    the recipe's :attr:`HybridModelConfig.common_config`", which the
+    recipe's internal lowering substitutes in. After lowering runs,
+    this field is always non-None."""
 
     vocab_size: int = 0
     """Vocabulary size (post-padding)."""
@@ -545,16 +546,16 @@ class EmbeddingLayerConfig:
     yarn: Dict[str, Any] | None = None
     """YARN scaling parameters (consumed only when
     ``position_embedding_type == "yarn"``). These are not
-    :class:`TransformerConfig` dataclass fields today; they are attached
-    as ad-hoc attributes by :meth:`HybridModelConfig.compile` to match
-    the :func:`getattr` lookups in :class:`HybridModel.__init__`.
+    :class:`TransformerConfig` dataclass fields today; the recipe's
+    internal lowering attaches them as ad-hoc attributes to match the
+    :func:`getattr` lookups in :class:`HybridModel.__init__`.
     Recognised keys: ``yarn_rotary_scaling_factor``,
     ``yarn_original_max_position_embeddings``, ``yarn_beta_fast``,
     ``yarn_beta_slow``, ``yarn_mscale``, ``yarn_mscale_all_dim``,
-    ``yarn_correction_range_round_to_int``. Unknown keys raise at compile
+    ``yarn_correction_range_round_to_int``. Unknown keys raise at lowering
     time. When upstream lifts these onto :class:`TransformerConfig`, this
-    field collapses to a plain ``extra`` passthrough and the setattr
-    loop in ``compile()`` goes away."""
+    field collapses to a plain ``extra`` passthrough and the setattr loop
+    in the lowering goes away."""
 
     extra: Dict[str, Any] = field(default_factory=dict)
     """Passthrough kwargs forwarded to the stack-level

--- a/megatron/core/models/hybrid/layer_pattern.py
+++ b/megatron/core/models/hybrid/layer_pattern.py
@@ -1,0 +1,216 @@
+# Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Pattern-flattening and recipe-loading helpers for the HybridModel DSL.
+
+The Python DSL composes a model from a (possibly nested) list of
+:class:`LayerConfig` instances. :func:`flatten_decoder_pattern` flattens the
+*decoder body* (i.e. between the :class:`EmbeddingLayerConfig` and
+:class:`CrossEntropyLayerConfig` markers) into a flat list of layer configs.
+:func:`load_recipe` resolves a recipe spec — either a dotted Python module
+path or a filesystem path, with an optional ``:func`` suffix — and returns
+the :class:`HybridModelConfig` ready to feed into :class:`HybridModel` via
+``HybridModel(config=recipe)``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple
+
+from megatron.core.models.hybrid.layer_configs import (
+    CrossEntropyLayerConfig,
+    EmbeddingLayerConfig,
+    LayerConfig,
+)
+
+if TYPE_CHECKING:
+    from megatron.training.models.hybrid import HybridModelConfig
+
+# Canonical recipe entry point. When a recipe module / file omits the
+# ``:func`` suffix, this function name is preferred as the default recipe.
+RECIPE_ENTRY_POINT = "make_recipe"
+
+
+def flatten_decoder_pattern(pattern: Any) -> List[LayerConfig]:
+    """Recursively flatten the decoder portion of a layer pattern.
+
+    The decoder body is everything between the :class:`EmbeddingLayerConfig`
+    and :class:`CrossEntropyLayerConfig` markers. Lists and tuples are
+    descended into; every leaf must be a :class:`LayerConfig` (Mamba,
+    Attention, MoE, MLP, GDN, DSA). Embedding / loss markers at this
+    point are an error — they should have been handled earlier.
+
+    Raises :class:`TypeError` (with the offending index path) on
+    non-conforming leaves.
+    """
+    flat: List[LayerConfig] = []
+    _flatten_into(pattern, flat, path=())
+    return flat
+
+
+def _flatten_into(node: Any, out: List[LayerConfig], path: tuple) -> None:
+    if isinstance(node, LayerConfig):
+        out.append(node)
+        return
+    if isinstance(node, (EmbeddingLayerConfig, CrossEntropyLayerConfig)):
+        raise TypeError(
+            f"Encountered {type(node).__name__} at path {list(path)} inside the "
+            f"decoder body; embedding/loss markers may only appear at the "
+            f"start/end of layer_pattern."
+        )
+    if isinstance(node, (list, tuple)):
+        for i, child in enumerate(node):
+            _flatten_into(child, out, path + (i,))
+        return
+    raise TypeError(
+        f"layer_pattern leaf at path {list(path)} has unsupported type "
+        f"{type(node).__name__!r}; expected a LayerConfig instance or a "
+        f"nested list/tuple of LayerConfigs."
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Recipe loading
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _split_spec(spec: str) -> Tuple[str, Optional[str]]:
+    """Split ``module-or-path[:func]`` into ``(module-or-path, func or None)``.
+
+    Special-cases Windows drive letters in file paths (``C:/foo``) so the
+    drive-letter colon isn't confused with the function-name separator.
+    """
+    if ":" not in spec:
+        return spec, None
+    head, tail = spec.rsplit(":", 1)
+    # Windows drive-letter check: ``C:/foo`` or ``C:\foo`` would have a
+    # one-char head and a tail that starts with ``/`` or ``\``.
+    if len(head) == 1 and tail.startswith(("/", "\\")):
+        return spec, None
+    return head, tail or None
+
+
+def _is_file_path(s: str) -> bool:
+    """Heuristic: treat ``s`` as a filesystem path when it ends in ``.py`` or
+    contains a path separator."""
+    return s.endswith(".py") or os.sep in s or "/" in s
+
+
+def _import_from_spec(spec: str):
+    """Import a module from either a dotted path or a filesystem path."""
+    if _is_file_path(spec):
+        path = Path(spec).expanduser().resolve()
+        if not path.is_file():
+            raise ImportError(f"--model-recipe file path {spec!r} does not exist or is not a file.")
+        # Use a unique synthetic module name so multiple recipes loaded by
+        # path don't collide in ``sys.modules``. SHA-1 of the absolute path is
+        # stable across processes and avoids the per-process randomization of
+        # builtin ``hash()``.
+        digest = hashlib.sha1(str(path).encode("utf-8")).hexdigest()[:16]
+        module_name = f"_megatron_recipe_{digest}"
+        cached = sys.modules.get(module_name)
+        if cached is not None:
+            return cached
+        spec_obj = importlib.util.spec_from_file_location(module_name, path)
+        if spec_obj is None or spec_obj.loader is None:
+            raise ImportError(f"could not build import spec for {path}")
+        module = importlib.util.module_from_spec(spec_obj)
+        sys.modules[module_name] = module
+        spec_obj.loader.exec_module(module)
+        return module
+    try:
+        return importlib.import_module(spec)
+    except ImportError as e:
+        raise ImportError(
+            f"--model-recipe {spec!r} could not be imported. Ensure the module "
+            f"path is correct and on PYTHONPATH (or pass a filesystem path "
+            f"ending in ``.py``). Underlying error: {e}"
+        ) from e
+
+
+def _resolve_recipe_object(module, func_name: Optional[str], origin: str) -> HybridModelConfig:
+    """Find the :class:`HybridModelConfig` to compile.
+
+    Resolution order, given a loaded module:
+
+    1. If ``func_name`` is given (i.e. the user wrote ``--model-recipe foo:bar``),
+       call that function and return its result.
+    2. Otherwise call :data:`RECIPE_ENTRY_POINT`, the canonical recipe
+       convention.
+    """
+    # 1. Explicit :func selection
+    if func_name is not None:
+        if not hasattr(module, func_name):
+            raise AttributeError(
+                f"--model-recipe {origin!r}: module has no attribute " f"{func_name!r}."
+            )
+        return _call_recipe_function(getattr(module, func_name), origin, source=func_name)
+
+    # 2. Canonical default: a function literally named ``make_recipe``.
+    if hasattr(module, RECIPE_ENTRY_POINT):
+        return _call_recipe_function(
+            getattr(module, RECIPE_ENTRY_POINT), origin, source=RECIPE_ENTRY_POINT
+        )
+    raise AttributeError(
+        f"--model-recipe {origin!r}: no {RECIPE_ENTRY_POINT}() function found. "
+        f"Define {RECIPE_ENTRY_POINT}() in the recipe module, or pass an "
+        f"explicit function with ``--model-recipe {origin}:<func_name>``."
+    )
+
+
+def _call_recipe_function(fn, origin: str, source: str) -> HybridModelConfig:
+    if not callable(fn):
+        raise TypeError(f"--model-recipe {origin!r}: {source!r} is not callable.")
+    return _ensure_hybrid_model_config(fn(), origin, source=source)
+
+
+def _ensure_hybrid_model_config(value, origin: str, source: str) -> HybridModelConfig:
+    from megatron.training.models.hybrid import HybridModelConfig
+
+    if not isinstance(value, HybridModelConfig):
+        raise TypeError(
+            f"--model-recipe {origin!r}: {source!r} returned "
+            f"{type(value).__name__}, not HybridModelConfig."
+        )
+    return value
+
+
+def load_recipe(spec: str) -> HybridModelConfig:
+    """Resolve a recipe spec and return its :class:`HybridModelConfig`.
+
+    The recipe is the public contract: pass it directly to
+    :class:`HybridModel` via ``HybridModel(config=recipe)`` or to the
+    ``--model-recipe`` argparse adapter, both of which own the lowering
+    internally.
+
+    ``spec`` accepts three forms:
+
+    1. Dotted Python path::
+
+           --model-recipe examples.nemotron3.nano
+
+    2. Dotted path with explicit function selection::
+
+           --model-recipe examples.nemotron3.nano:make_recipe
+
+    3. Filesystem path (anywhere on disk; no PYTHONPATH manipulation needed),
+       with optional ``:func`` suffix::
+
+           --model-recipe /home/me/recipes/qwen3_next.py
+           --model-recipe /home/me/recipes/qwen3_next.py:my_pretrain_recipe
+
+    When no ``:func`` is given, the loader calls ``make_recipe()``.
+
+    Raises:
+        ImportError: if the module / file cannot be loaded.
+        AttributeError: if the selected recipe function is missing.
+        TypeError: if the resolved value is not a :class:`HybridModelConfig`.
+    """
+    module_or_path, func_name = _split_spec(spec)
+    module = _import_from_spec(module_or_path)
+    return _resolve_recipe_object(module, func_name, origin=spec)

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -6,12 +6,13 @@ import argparse
 import dataclasses
 import json
 import os
-from pathlib import Path
 import re
 import types
+from pathlib import Path
 
 import torch
 
+from megatron.core.msc_utils import MultiStorageClientFeature
 from megatron.core.rerun_state_machine import RerunStateMachine
 from megatron.core.transformer import TransformerConfig
 from megatron.core.transformer.pipeline_parallel_layer_layout import PipelineParallelLayerLayout
@@ -32,15 +33,12 @@ from megatron.core.utils import (
 from megatron.training.global_vars import set_global_variables
 from megatron.training.utils import (
     get_device_arch_version,
-    update_use_dist_ckpt,
     print_rank_0,
+    update_use_dist_ckpt,
     warn_rank_0,
 )
-from megatron.core.msc_utils import MultiStorageClientFeature
 
 from megatron.training.argument_utils import ArgumentGroupFactory, core_transformer_config_from_args  # noqa: F401 # pylint: disable=unused-import
-
-
 
 def add_megatron_arguments(parser: argparse.ArgumentParser):
     """"Add Megatron-LM arguments to the given parser."""
@@ -385,6 +383,104 @@ def tuple_type(x):
     assert isinstance(x, str)
     return tuple(int(i) for i in x.strip('()').split(','))
 
+
+def _apply_model_recipe_to_args(args):
+    """Project a HybridModel recipe onto the legacy argparse namespace.
+
+    ``--model-recipe`` makes the Python recipe the source of truth for model
+    architecture, but launcher setup still reads a few shape/topology fields
+    from ``args``. This adapter is intentionally one-way: recipe values win,
+    and the recipe itself is cached on ``args._model_recipe`` so the builder
+    can consume it without re-loading or depending on the lowering output.
+    """
+    from megatron.core.models.hybrid.layer_configs import (
+        AttentionLayerConfig,
+        DSALayerConfig,
+        MoELayerConfig,
+    )
+    from megatron.core.models.hybrid.layer_pattern import load_recipe
+
+    # Reject user-supplied conflicts up front; the projection below sets
+    # ``args.hybrid_layer_pattern`` so existing hybrid-model checks keep
+    # recognizing recipe-built HybridModels on the legacy launcher path.
+    assert getattr(args, 'hybrid_layer_pattern', None) is None, (
+        '--model-recipe and --hybrid-layer-pattern are mutually exclusive. '
+        'The recipe supplies the layer pattern; remove --hybrid-layer-pattern.'
+    )
+    assert getattr(args, 'hybrid_override_pattern', None) is None, (
+        '--model-recipe and --hybrid-override-pattern are mutually exclusive.'
+    )
+    assert not getattr(args, 'mtp_num_layers', None), (
+        '--model-recipe does not support Multi-Token Prediction yet; remove '
+        '--mtp-num-layers and use the legacy hybrid string DSL for MTP.'
+    )
+    assert getattr(args, 'mtp_hybrid_override_pattern', None) is None, (
+        '--model-recipe does not support Multi-Token Prediction yet; remove '
+        '--mtp-hybrid-override-pattern and use the legacy hybrid string DSL for MTP.'
+    )
+
+    recipe = load_recipe(args.model_recipe)
+    args._model_recipe = recipe
+
+    decoder_layers = recipe.flatten_decoder()
+    embedding = recipe.embedding_marker
+    loss = recipe.loss_marker
+    common = recipe.common_config
+
+    # Uniform attention-head count across attention/DSA layers, when one
+    # exists. If attention is heterogeneous, the launcher has no single right
+    # value and the recipe lowering remains responsible for validation.
+    attention_layers = [
+        lc for lc in decoder_layers if isinstance(lc, (AttentionLayerConfig, DSALayerConfig))
+    ]
+    head_counts = {
+        lc.num_attention_heads
+        for lc in attention_layers
+        if lc.num_attention_heads is not None
+    }
+    num_attention_heads = head_counts.pop() if len(head_counts) == 1 else None
+
+    # Topology values read from the recipe directly. ``None`` means "defer to
+    # the launcher's CLI flag"; do not read substituted values from lowering
+    # or recipes would silently clobber explicit launcher choices.
+    recipe_values = {
+        "num_layers": recipe.num_layers,
+        "hidden_size": common.hidden_size,
+        "num_attention_heads": num_attention_heads,
+        "max_position_embeddings": embedding.max_sequence_length,
+        "padded_vocab_size": embedding.vocab_size,
+        "tensor_model_parallel_size": recipe.tensor_model_parallel_size,
+        "context_parallel_size": recipe.context_parallel_size,
+        "expert_model_parallel_size": recipe.expert_model_parallel_size,
+        "expert_tensor_parallel_size": recipe.expert_tensor_parallel_size,
+        "position_embedding_type": embedding.position_embedding_type,
+        "rotary_percent": embedding.rotary_percent,
+        "rotary_base": embedding.rotary_base,
+        "rotary_seq_len_interpolation_factor": embedding.seq_len_interpolation_factor,
+        "untie_embeddings_and_output_weights": recipe.untie_embeddings_and_output_weights,
+        "fp16_lm_cross_entropy": loss.fp16_lm_cross_entropy,
+    }
+    for attr, value in recipe_values.items():
+        if value is not None and hasattr(args, attr):
+            setattr(args, attr, value)
+
+    # The generic num_layers/encoder_num_layers normalization below asserts
+    # they are not both populated. A recipe describes the decoder stack.
+    if hasattr(args, "encoder_num_layers"):
+        args.encoder_num_layers = None
+
+    moe_experts = [lc.num_experts for lc in decoder_layers if isinstance(lc, MoELayerConfig)]
+    args._model_recipe_num_experts = tuple(moe_experts)
+    unique_moe_experts = set(moe_experts)
+    if len(unique_moe_experts) == 1 and hasattr(args, "num_experts"):
+        args.num_experts = unique_moe_experts.pop()
+
+    if recipe.has_multi_latent_attention and hasattr(args, "multi_latent_attention"):
+        args.multi_latent_attention = True
+
+    args.hybrid_layer_pattern = "".join(type(lc).SYMBOL for lc in decoder_layers)
+
+
 def validate_args(args, defaults={}):
 
     # Prep for checkpoint conversion.
@@ -398,8 +494,9 @@ def validate_args(args, defaults={}):
         'Currently only global and local checkpoints are supported'
     if args.non_persistent_ckpt_type == 'local':
         try:
-            from nvidia_resiliency_ext.checkpointing.local.ckpt_managers.local_manager import \
-                LocalCheckpointManager
+            from nvidia_resiliency_ext.checkpointing.local.ckpt_managers.local_manager import (
+                LocalCheckpointManager,
+            )
         except ModuleNotFoundError as e:
             raise RuntimeError('nvidia_resiliency_ext is required for local checkpointing') from e
 
@@ -407,6 +504,12 @@ def validate_args(args, defaults={}):
     validate_model_config_args_from_heterogeneous_config(args)
 
     update_use_dist_ckpt(args)
+
+    # A HybridModel Python recipe is the source of truth for model
+    # architecture. Project its supported values onto the argparse namespace
+    # before generic validation and process-group setup inspect them.
+    if getattr(args, 'model_recipe', None) is not None:
+        _apply_model_recipe_to_args(args)
 
     # GTP_remat counts toward total_model_size (an independent weight-shard axis), so the
     # args.data_parallel_size below is the replicate degree (matches
@@ -740,8 +843,10 @@ def validate_args(args, defaults={}):
         )
 
     from megatron.core.models.hybrid.hybrid_layer_allocation import (
-        Symbols, parse_hybrid_pattern, get_hybrid_total_layer_count,
+        Symbols,
+        get_hybrid_total_layer_count,
         get_hybrid_total_pipeline_segment_count,
+        parse_hybrid_pattern,
     )
     sep = Symbols.MTP_SEPARATOR
 
@@ -2714,8 +2819,7 @@ def _add_rl_args(parser):
     return parser
 
 def _add_training_args(parser):
-    from megatron.training.config import TrainingConfig
-    from megatron.training.config import ProfilingConfig
+    from megatron.training.config import ProfilingConfig, TrainingConfig
 
     prof_factory = ArgumentGroupFactory(ProfilingConfig)
     prof_group = prof_factory.build_group(parser, "profiling")
@@ -3495,6 +3599,14 @@ def _add_experimental_args(parser):
                        'Example: "M-M-|M-M*-|M-M-|M-M*-" or "M-M-|M-M*-/MM/MM". '
                        'When this flag is used, it is the sole indicator that a hybrid model '
                        'is being run.')
+    group.add_argument('--model-recipe', type=str, default=None,
+                       help='Recipe spec for a HybridModel. Accepts a dotted module path, '
+                       'module:function, filesystem path, or filesystem path:function. '
+                       'When no function is supplied, the loader calls make_recipe(). '
+                       'When set, the recipe is the source of truth for the model '
+                       'architecture; --hidden-size, --num-layers, '
+                       '--hybrid-layer-pattern, etc. are ignored. Mutually exclusive '
+                       'with --hybrid-layer-pattern.')
     group.add_argument('--hybrid-override-pattern', type=str, default=None,
                        help='Deprecated. Use --hybrid-layer-pattern instead. '
                        'If specified, its value will be forwarded to --hybrid-layer-pattern.')
@@ -3582,7 +3694,7 @@ def _add_kitchen_quantization_arguments(parser: argparse.ArgumentParser):
     If kitchen isn't available, nothing to do here, return unchanged parser
     """
     try:
-        from megatron.core.extensions.kitchen import KitchenSpecProvider, HAVE_KITCHEN
+        from megatron.core.extensions.kitchen import HAVE_KITCHEN, KitchenSpecProvider
 
     except (ImportError, ModuleNotFoundError):
         HAVE_KITCHEN = False

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -15,7 +15,6 @@ import torch
 from megatron.core.msc_utils import MultiStorageClientFeature
 from megatron.core.rerun_state_machine import RerunStateMachine
 from megatron.core.transformer import TransformerConfig
-from megatron.core.transformer.pipeline_parallel_layer_layout import PipelineParallelLayerLayout
 from megatron.core.transformer.cuda_graph_config import (
     ALLOWED_INFERENCE_SCOPES,
     get_deprecated_cuda_graph_modules_migration,
@@ -24,11 +23,16 @@ from megatron.core.transformer.cuda_graph_config import (
     validate_deprecated_cuda_graph_modules_migration_inputs,
 )
 from megatron.core.transformer.enums import AttnBackend, CudaGraphModule, InferenceCudaGraphScope
+from megatron.core.transformer.pipeline_parallel_layer_layout import PipelineParallelLayerLayout
 from megatron.core.utils import (
     get_torch_version,
     is_flashinfer_min_version,
     is_te_min_version,
     is_torch_min_version,
+)
+from megatron.training.argument_utils import (  # noqa: F401 # pylint: disable=unused-import
+    ArgumentGroupFactory,
+    core_transformer_config_from_args,
 )
 from megatron.training.global_vars import set_global_variables
 from megatron.training.utils import (
@@ -38,7 +42,6 @@ from megatron.training.utils import (
     warn_rank_0,
 )
 
-from megatron.training.argument_utils import ArgumentGroupFactory, core_transformer_config_from_args  # noqa: F401 # pylint: disable=unused-import
 
 def add_megatron_arguments(parser: argparse.ArgumentParser):
     """"Add Megatron-LM arguments to the given parser."""

--- a/megatron/training/models/hybrid.py
+++ b/megatron/training/models/hybrid.py
@@ -857,14 +857,6 @@ class HybridModelBuilder(ModelBuilder[HybridModel, HybridModelConfig]):
             else:
                 hybrid_stack_spec = default_hybrid_stack_spec
 
-        assert (
-            getattr(transformer_config, "virtual_pipeline_model_parallel_size", None) is None
-            and vp_stage is None
-        ), (
-            "Virtual pipeline model parallelism is temporarily unsupported in Hybrid "
-            "models due to upstream MCore HybridModel API dependency"
-        )
-
         if self._model_config.is_recipe_config:
             pre_process = pre_process if pre_process is not None else is_pp_first_stage(pg_collection.pp)
             post_process = post_process if post_process is not None else is_pp_last_stage(pg_collection.pp)

--- a/megatron/training/models/hybrid.py
+++ b/megatron/training/models/hybrid.py
@@ -842,7 +842,7 @@ class HybridModelBuilder(ModelBuilder[HybridModel, HybridModelConfig]):
             The constructed model
 
         Note:
-            Virtual pipeline model parallelism is not supported for Hybrid models.
+            The Python recipe path does not support virtual pipeline model parallelism.
         """
         transformer_config = self._model_config.get_transformer_config()
         hybrid_stack_spec = self._model_config.hybrid_stack_spec
@@ -858,6 +858,13 @@ class HybridModelBuilder(ModelBuilder[HybridModel, HybridModelConfig]):
                 hybrid_stack_spec = default_hybrid_stack_spec
 
         if self._model_config.is_recipe_config:
+            if (
+                transformer_config.virtual_pipeline_model_parallel_size is not None
+                or vp_stage is not None
+            ):
+                raise NotImplementedError(
+                    "The HybridModel recipe path does not support virtual pipeline parallelism."
+                )
             pre_process = pre_process if pre_process is not None else is_pp_first_stage(pg_collection.pp)
             post_process = post_process if post_process is not None else is_pp_last_stage(pg_collection.pp)
             return HybridModel(

--- a/megatron/training/models/hybrid.py
+++ b/megatron/training/models/hybrid.py
@@ -1,54 +1,108 @@
 # Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 
+import dataclasses
 import logging
 from dataclasses import dataclass
-from typing import Any, Callable, ClassVar, Literal, override
+from typing import Any, Callable, ClassVar, List, Literal, Tuple
+
+from typing_extensions import override
 
 from megatron.core.distributed.distributed_data_parallel_config import DistributedDataParallelConfig
 from megatron.core.enums import ModelType
+from megatron.core.models.hybrid.common_layer_config import CommonLayerConfig
+from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_inference_stack_spec
 from megatron.core.models.hybrid.hybrid_layer_specs import (
     hybrid_stack_spec as default_hybrid_stack_spec,
-    hybrid_inference_stack_spec,
 )
 from megatron.core.models.hybrid.hybrid_model import HybridModel
+from megatron.core.models.hybrid.layer_configs import (
+    AttentionLayerConfig,
+    CrossEntropyLayerConfig,
+    DSALayerConfig,
+    EmbeddingLayerConfig,
+    LayerConfig,
+    MoELayerConfig,
+)
 from megatron.core.pipeline_parallel.utils import is_pp_first_stage, is_pp_last_stage
 from megatron.core.post_training.modelopt.hybrid.model_specs import get_hybrid_stack_modelopt_spec
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.transformer.module import Float16Module, MegatronModule
 from megatron.core.transformer.spec_utils import ModuleSpec
 from megatron.core.transformer.transformer_config import TransformerConfig
-from megatron.training.models.base import (
-    ModelBuilder,
-    ModelConfig,
-    compose_hooks,
-)
+from megatron.training.models.base import ModelBuilder, ModelConfig, compose_hooks
 from megatron.training.models.dist_utils import unimodal_build_distributed_models
 from megatron.training.vocab_utils import calculate_padded_vocab_size
 
 logger = logging.getLogger(__name__)
 
+# YARN scaling parameters that HybridModel reads via getattr when
+# position_embedding_type == "yarn" (see hybrid_model.py around the
+# YarnRotaryEmbedding construction). They are not currently
+# TransformerConfig dataclass fields; _lower() applies them via setattr to
+# match the existing legacy-path pattern.
+_YARN_FIELDS = (
+    "yarn_rotary_scaling_factor",
+    "yarn_original_max_position_embeddings",
+    "yarn_beta_fast",
+    "yarn_beta_slow",
+    "yarn_mscale",
+    "yarn_mscale_all_dim",
+    "yarn_correction_range_round_to_int",
+)
+
 
 @dataclass(kw_only=True)
 class HybridModelConfig(ModelConfig):
-    """Configuration for a Megatron Core Hybrid model.
+    """A complete HybridModel recipe.
 
-    This is purely a configuration object. All model construction
-    logic lives in ``HybridModelBuilder``.
-
-    Contains a ``TransformerConfig`` alongside Hybrid-specific parameters. Attributes
-    on the embedded ``transformer`` config are accessible directly on this object
-    via ``__getattr__``/``__setattr__`` proxying.
-
-    Supports hybrid architectures via ``hybrid_layer_pattern``
-
-    Note:
-        ``vocab_size`` must be set before passing this config to ``HybridModelBuilder``.
-        ``hybrid_attention_ratio``,``hybrid_mlp_ratio``, and
-        ``hybrid_override_pattern`` are deprecated and will be removed in a future release.
+    Returned by a recipe module's ``make_recipe()`` entry point. Pass an
+    instance directly to :class:`HybridModel` via ``HybridModel(config=recipe)``;
+    the ``--model-recipe`` adapter loads the recipe and projects its fields
+    onto the legacy launcher namespace using the public query methods on
+    this class (no lowering object is exposed to callers).
     """
 
+    # TODO(recipe-api): two follow-ups deferred from the Phase 1 review:
+    #   (1) Add a public ``validate(self) -> None`` method that runs the
+    #       structural / parallelism / attention-geometry checks
+    #       independently of ``_lower()`` so users can sanity-check a
+    #       recipe from a non-distributed script (no TC construction, no
+    #       process groups). The checks already fire inside ``_lower()``
+    #       before any process-group setup, so this is ergonomic, not
+    #       blocking.
+    #   (2) Document the polarity flip on
+    #       :attr:`untie_embeddings_and_output_weights`: the recipe
+    #       default is ``False`` (i.e., tied / shared by default), but
+    #       :class:`HybridModel`'s legacy default is
+    #       ``share_embeddings_and_output_weights=False`` (i.e., NOT
+    #       shared). Recipe authors migrating from a legacy bash launcher
+    #       must set ``untie_embeddings_and_output_weights=True`` to
+    #       reproduce the legacy default. A migration-note docstring on
+    #       the field would help people not silently drift from their
+    #       legacy baseline.
+
     builder: ClassVar[str] = "megatron.training.models.hybrid.HybridModelBuilder"
-    transformer: TransformerConfig
+
+    common_config: CommonLayerConfig | None = None
+    """Model-wide defaults shared by every layer."""
+
+    layer_pattern: list | None = None
+    """The layer pattern. Must begin with an :class:`EmbeddingLayerConfig`,
+    contain at least one decoder :class:`LayerConfig`, and end with a
+    :class:`CrossEntropyLayerConfig`. Decoder layers may be nested in any
+    list/tuple structure; :meth:`flatten_decoder` flattens them. Pipeline
+    parallelism is not part of the recipe DSL — recipes that need PP must
+    use the legacy ``hybrid_layer_pattern`` string DSL."""
+
+    untie_embeddings_and_output_weights: bool = False
+    """Untie input embedding and output projection weights."""
+
+    # === Legacy / argparse-derived construction path ===
+    # These fields preserve the existing training-config API while the
+    # recipe API becomes the canonical surface. When ``common_config`` /
+    # ``layer_pattern`` are set, the recipe path owns model definition and
+    # these legacy architecture fields are ignored by ``HybridModelBuilder``.
+    transformer: TransformerConfig | None = None
     fp16_lm_cross_entropy: bool = False
     parallel_output: bool = True
     share_embeddings_and_output_weights: bool = False
@@ -57,8 +111,8 @@ class HybridModelConfig(ModelConfig):
     hybrid_override_pattern: str | None = None
     hybrid_layer_pattern: str | None = None
     seq_length: int = 8192
-    # HybridModel with no attention has no need for position embeddings, so none is default
-    position_embedding_type: Literal["learned_absolute", "rope", "none"] = "none"
+    # HybridModel with no attention has no need for position embeddings.
+    position_embedding_type: Literal["learned_absolute", "rope", "yarn", "none"] = "none"
     rotary_percent: float = 1.0
     rotary_base: int = 10000
     seq_len_interpolation_factor: float | None = None
@@ -66,6 +120,61 @@ class HybridModelConfig(ModelConfig):
     hybrid_stack_spec: ModuleSpec | None = None
     vocab_size: int | None = None
     should_pad_vocab: bool = False
+
+    # === Model-level parallelism ===
+    # These live here (not on :class:`CommonLayerConfig`) because they are
+    # job-/model-level concerns: process groups are constructed once, not
+    # per-layer, and they cannot meaningfully vary per layer. ``_lower()``
+    # injects them into every per-layer TransformerConfig and the
+    # stack-level TC. PP is intentionally absent — the recipe DSL is
+    # PP-free; recipes that need PP must use the legacy string DSL.
+    #
+    # All four default to ``None``, meaning "do not pin from the recipe".
+    # When unset, the launcher's args projection skips writing them onto
+    # ``args``, so launcher CLI flags (``--tensor-model-parallel-size`` etc.)
+    # win. Recipes for topology-bound models (e.g. Nemotron-3 Nano needs
+    # TP=4/EP=8 to fit) should pin these explicitly; ad-hoc / debugging
+    # recipes can leave them unset and let the launcher decide.
+    tensor_model_parallel_size: int | None = None
+    """Tensor-model-parallel world size; ``None`` = use ``--tensor-model-parallel-size``."""
+
+    context_parallel_size: int | None = None
+    """Context-parallel world size; ``None`` = use ``--context-parallel-size``."""
+
+    expert_model_parallel_size: int | None = None
+    """Expert-model-parallel world size (used by MoE layers); ``None`` = use
+    ``--expert-model-parallel-size``."""
+
+    expert_tensor_parallel_size: int | None = None
+    """Expert tensor-parallel size; ``None`` = use ``--expert-tensor-parallel-size``
+    (which itself defaults to ``tensor_model_parallel_size``)."""
+
+    # === Stack-level MoE metadata override (heterogeneous-MoE recipes only) ===
+    # The stack-level TransformerConfig carries one ``num_moe_experts`` /
+    # ``moe_ffn_hidden_size`` pair. With homogeneous MoE the value is
+    # unambiguous; with heterogeneous MoE there is no single right answer.
+    # Two consumers read these fields from the stack TC: MTP's MoE body and
+    # the inference text-generation capacity-factor calculation. Recipes
+    # that mix MoE shapes must pin the values they want those consumers to
+    # see — :meth:`derived_moe_metadata` raises if MoE is heterogeneous and
+    # these are unset.
+    stack_moe_num_experts: int | None = None
+    """Stack-level ``num_moe_experts`` for heterogeneous-MoE recipes.
+    Required when MoE layers disagree on ``num_experts``; ignored otherwise."""
+
+    stack_moe_ffn_hidden_size: int | None = None
+    """Stack-level ``moe_ffn_hidden_size`` for heterogeneous-MoE recipes.
+    Required when MoE layers disagree on ``ffn_hidden_size``; ignored
+    otherwise. ``None`` falls through to ``ffn_hidden_size``."""
+
+    # ──────────────────────────────────────────────────────────────────────
+    # Compatibility / builder helpers
+    # ──────────────────────────────────────────────────────────────────────
+
+    @property
+    def is_recipe_config(self) -> bool:
+        """Whether this config uses the Python recipe surface."""
+        return self.common_config is not None or self.layer_pattern is not None
 
     @property
     def mamba_stack_spec(self):
@@ -84,7 +193,7 @@ class HybridModelConfig(ModelConfig):
             transformer = object.__getattribute__(self, "transformer")
         except AttributeError:
             raise AttributeError(f"HybridModelConfig has no attribute '{name}'")
-        if hasattr(transformer, name):
+        if transformer is not None and hasattr(transformer, name):
             return getattr(transformer, name)
         raise AttributeError(f"Neither HybridModelConfig nor TransformerConfig has any attribute '{name}'.")
 
@@ -98,16 +207,603 @@ class HybridModelConfig(ModelConfig):
             # `transformer` not yet initialised; store the attribute on self.
             super().__setattr__(name, value)
             return
-        if hasattr(transformer, name):
+        if transformer is not None and hasattr(transformer, name):
             setattr(transformer, name, value)
         else:
             super().__setattr__(name, value)
 
     def finalize(self) -> None:
         """One time validation to run once config is ready to be used by builder."""
-
+        if self.is_recipe_config:
+            self._lower()
+            return
+        if self.transformer is None:
+            raise ValueError(
+                "HybridModelConfig requires either common_config/layer_pattern "
+                "for the recipe path or transformer for the legacy path."
+            )
         if hasattr(self.transformer, "finalize") and callable(self.transformer.finalize):
             self.transformer.finalize()
+
+    def get_transformer_config(self) -> TransformerConfig:
+        """Return the stack-level TransformerConfig used to build/wrap the model."""
+        if self.is_recipe_config:
+            stack_config, _, _ = self._lower()
+            return stack_config
+        if self.transformer is None:
+            raise ValueError(
+                "HybridModelConfig requires a transformer config on the legacy path."
+            )
+        return self.transformer
+
+    # Public queries
+    #
+    # These are TC-free observations on the recipe itself. The launcher's
+    # args projection reads them to populate ``args.num_layers``,
+    # ``args.num_experts``, etc., without going through ``_lower()``. They
+    # also let tests assert recipe semantics without depending on the
+    # lowering's output shape.
+    # ──────────────────────────────────────────────────────────────────────
+
+    @property
+    def embedding_marker(self) -> EmbeddingLayerConfig:
+        """The :class:`EmbeddingLayerConfig` at the start of ``layer_pattern``.
+
+        Validates pattern structure on access.
+        """
+        self._require_recipe_fields()
+        embedding, _, _ = _split_pattern(self.layer_pattern)
+        return embedding
+
+    @property
+    def loss_marker(self) -> CrossEntropyLayerConfig:
+        """The :class:`CrossEntropyLayerConfig` at the end of ``layer_pattern``.
+
+        Validates pattern structure on access.
+        """
+        self._require_recipe_fields()
+        _, _, loss = _split_pattern(self.layer_pattern)
+        return loss
+
+    def flatten_decoder(self) -> List[LayerConfig]:
+        """Return the decoder body as a flat list of :class:`LayerConfig`.
+
+        Walks the (possibly nested) ``layer_pattern[1:-1]`` and flattens it
+        into a single ordered list. Useful for the launcher and for tests
+        that need to inspect "what layers does this recipe contain".
+        """
+        from megatron.core.models.hybrid.layer_pattern import flatten_decoder_pattern
+
+        self._require_recipe_fields()
+        _, decoder_body, _ = _split_pattern(self.layer_pattern)
+        return flatten_decoder_pattern(decoder_body)
+
+    @property
+    def num_layers(self) -> int:
+        """Number of decoder layers, derived from ``layer_pattern``."""
+        return len(self.flatten_decoder())
+
+    @property
+    def has_multi_latent_attention(self) -> bool:
+        """Whether the recipe uses MLA (any :class:`DSALayerConfig` in the decoder).
+
+        Surfaced as a query because the launcher needs it to set
+        ``args.multi_latent_attention`` *before* any process-group / config
+        wiring happens, i.e. before lowering can run.
+        """
+        return any(isinstance(lc, DSALayerConfig) for lc in self.flatten_decoder())
+
+    def derived_moe_metadata(self) -> tuple[int | None, int | None]:
+        """Return ``(num_moe_experts, moe_ffn_hidden_size)`` for stack-level
+        MoE consumers (MTP body construction, inference capacity-factor calc).
+
+        Three cases:
+
+        1. No :class:`MoELayerConfig` in the decoder → ``(None, None)``.
+        2. Homogeneous MoE → that value.
+        3. Heterogeneous MoE → the recipe must pin :attr:`stack_moe_num_experts`
+           (and optionally :attr:`stack_moe_ffn_hidden_size`); raises otherwise.
+        """
+        return _derive_stack_moe_metadata(
+            self.flatten_decoder(),
+            override_num_experts=self.stack_moe_num_experts,
+            override_ffn_hidden_size=self.stack_moe_ffn_hidden_size,
+        )
+
+    # ──────────────────────────────────────────────────────────────────────
+    # Internal lowering
+    #
+    # Do not call from outside the hybrid package. ``HybridModel.__init__``
+    # invokes this when constructed with ``config: HybridModelConfig``; it
+    # returns the three pieces HybridModel still needs as TransformerConfig:
+    # the stack-level TC, the per-layer symbol list, and the per-layer TC
+    # list. Embedding-marker fields (vocab_size, position_embedding_type,
+    # …) and loss-marker fields (fp16_lm_cross_entropy, parallel_output)
+    # are NOT included — read them directly from
+    # :attr:`embedding_marker` and :attr:`loss_marker`. This method's
+    # signature and return shape are implementation details that will
+    # change when TC / TransformerLayer are retired.
+    # ──────────────────────────────────────────────────────────────────────
+
+    def _lower(self) -> Tuple[TransformerConfig, List[str], List[TransformerConfig]]:
+        """Lower this recipe into ``(stack_tc, layer_symbols, layer_tcs)``.
+
+        The three returned pieces are exactly what :class:`HybridModel`
+        consumes when constructed with a :class:`HybridModelConfig`.
+        Marker-derived fields (vocab_size, max_sequence_length,
+        position_embedding_type, rotary_*, fp16_lm_cross_entropy,
+        parallel_output, …) are not in the return value — read them
+        directly from :attr:`embedding_marker` and :attr:`loss_marker`.
+        """
+        self._require_recipe_fields()
+        embedding, decoder_leaves, loss = _split_pattern(self.layer_pattern)
+
+        # Auto-inherit the recipe's common_config into any layer/marker that
+        # was constructed without an explicit ``common_config=`` argument.
+        # Without this, a layer like ``MambaLayerConfig(head_dim=64)`` carries
+        # a default-constructed CommonLayerConfig with ``hidden_size=0``,
+        # silently producing an invalid model.
+        embedding = _inherit_common_if_default(embedding, self.common_config)
+        loss = _inherit_common_if_default(loss, self.common_config)
+        decoder_leaves = _inherit_common_in_pattern(decoder_leaves, self.common_config)
+
+        from megatron.core.models.hybrid.layer_pattern import flatten_decoder_pattern
+
+        decoder_flat: List[LayerConfig] = flatten_decoder_pattern(decoder_leaves)
+        if not decoder_flat:
+            raise ValueError(
+                "layer_pattern has no decoder layers between the EmbeddingLayerConfig "
+                "and CrossEntropyLayerConfig markers."
+            )
+
+        num_layers = len(decoder_flat)
+
+        # ─────────────────────────────────────────────────────────────────
+        # Glue between the DSL surface and the underlying TransformerConfig
+        # machinery. ``parallelism`` carries the universal job-level
+        # settings (TP/PP/CP) that flow into every per-layer config.
+        # ``expert_parallelism`` carries EP/ETP, which are MoE-only and
+        # therefore only flow into MoE per-layer TCs (and the stack-level
+        # TC for the model-wide topology snapshot). ``placeholders`` carries
+        # values that exist solely to satisfy
+        # ``TransformerConfig.__post_init__`` invariants on layers that
+        # don't naturally set them (e.g. ``num_attention_heads`` is
+        # required for the kv_channels derivation even on Mamba layers).
+        #
+        # When the layer infrastructure is rewritten with dedicated
+        # per-layer config classes, neither the placeholder logic nor the
+        # split parallelism dicts will be needed — the new layers won't
+        # share a single config type and won't impose cross-layer
+        # invariants. The DSL's user-facing surface stays the same; only
+        # this glue block changes.
+        # ─────────────────────────────────────────────────────────────────
+
+        # Topology fields default to ``None`` on the recipe (= "let the
+        # launcher decide"). For per-layer TC construction we still need
+        # concrete values, so substitute TC defaults (1 / TP) here. The
+        # ``None``-ness is preserved on the recipe itself so the launcher's
+        # args projection only writes to ``args.<field>`` when the recipe
+        # pinned a value.
+        tp = self.tensor_model_parallel_size if self.tensor_model_parallel_size is not None else 1
+        cp = self.context_parallel_size if self.context_parallel_size is not None else 1
+        ep = self.expert_model_parallel_size if self.expert_model_parallel_size is not None else 1
+        etp = (
+            self.expert_tensor_parallel_size if self.expert_tensor_parallel_size is not None else tp
+        )
+
+        # Universal parallelism — flows into every per-layer TC. PP is
+        # intentionally absent: the recipe DSL is PP-free. ``is_hybrid_model``
+        # is implicit for any HybridModelConfig recipe; force it on every TC
+        # so users don't carry a redundant ``=True``.
+        parallelism: dict = {
+            "tensor_model_parallel_size": tp,
+            "context_parallel_size": cp,
+            "is_hybrid_model": True,
+        }
+
+        # MoE-only parallelism — applied to MoE per-layer TCs (after their
+        # base build) and to the stack-level TC. Non-MoE per-layer TCs do
+        # not receive these fields; TransformerConfig's defaults
+        # (``expert_model_parallel_size=1``, ``expert_tensor_parallel_size``
+        # auto-derived from TP) take over, which is correct because those
+        # layers don't participate in expert parallelism.
+        expert_parallelism: dict = {
+            "expert_model_parallel_size": ep,
+            "expert_tensor_parallel_size": etp,
+        }
+
+        # ``placeholders`` only fill if absent, so a recipe author's
+        # ``common.extra={...}`` or per-layer override wins.
+        # ``num_attention_heads % tensor_model_parallel_size == 0`` is
+        # required by TC; setting the placeholder to TP satisfies the
+        # check trivially on non-attention layers. Attention layers override
+        # with their real value via ``_layer_specific_kwargs``.
+        attention_metadata = _infer_uniform_attention_metadata(decoder_flat)
+
+        # Heterogeneous attention geometry under RoPE/YARN is not supported:
+        # HybridModel builds one global rotary embedding from the stack TC
+        # and passes it to every attention layer. If layers disagree on
+        # ``num_attention_heads`` / ``num_query_groups`` / ``kv_channels``,
+        # the rotary tensor is sized for the placeholder value and at
+        # runtime layers with different geometry hit shape mismatches.
+        # Reject at lowering time until per-layer rotary lands.
+        if embedding.position_embedding_type in ("rope", "yarn"):
+            _reject_heterogeneous_attention_geometry(decoder_flat, attention_metadata)
+
+        placeholders: dict = {"num_attention_heads": max(1, tp)}
+        # If the recipe contains a uniform attention geometry, use it as the
+        # semantic placeholder for non-attention layer TransformerConfigs.
+        # This keeps recipe authors out of TransformerConfig compatibility
+        # details like "Mamba still needs num_attention_heads to satisfy
+        # TC.__post_init__".
+        placeholders.update(attention_metadata)
+
+        layer_type_list = [type(lc).SYMBOL for lc in decoder_flat]
+        layer_config_list: List[TransformerConfig] = []
+        for lc in decoder_flat:
+            # Only MoE layers carry expert parallelism; non-MoE TCs default
+            # to EP=1 (TC default), which is what they actually consume at
+            # runtime. Merging into the initial kwargs (rather than via a
+            # follow-up dataclasses.replace) keeps TC.__post_init__'s MoE
+            # cross-checks (e.g. ``add_bias_linear`` requires ``ETP==1``)
+            # validating against the right ETP value the first time around.
+            layer_parallelism = parallelism
+            if isinstance(lc, MoELayerConfig):
+                layer_parallelism = {**parallelism, **expert_parallelism}
+            tc = lc.to_transformer_config(
+                num_layers, parallelism=layer_parallelism, placeholders=placeholders
+            )
+            layer_config_list.append(tc)
+
+        # Reuse the existing pattern validator for the Attention/DSA mix rule.
+        from megatron.core.models.hybrid.hybrid_layer_allocation import _validate_pattern
+
+        _validate_pattern("".join(layer_type_list), "main", allow_pipe=False)
+
+        # Stack-level config: a model-wide topology snapshot used for the
+        # final norm, embedding init, inference capacity sizing, and the
+        # launcher's args projection. Carries EP/ETP because it represents
+        # the global topology, even though non-MoE per-layer TCs do not.
+        stack_kwargs = embedding.common_config.to_transformer_config_kwargs()
+        stack_kwargs.update(parallelism)
+        stack_kwargs.update(expert_parallelism)
+        for k, v in attention_metadata.items():
+            stack_kwargs.setdefault(k, v)
+        for k, v in placeholders.items():
+            stack_kwargs.setdefault(k, v)
+        for k, v in _infer_uniform_moe_metadata(decoder_flat).items():
+            stack_kwargs.setdefault(k, v)
+        # Derive stack-level MoE metadata from the recipe's actual MoE
+        # configs rather than using a placeholder. Two consumers read these
+        # fields semantically: the MTP block construction path (when a body
+        # symbol contains ``E``, the MoE layer inside MTP is built from the
+        # stack TC) and the inference capacity-factor calculation
+        # (``capacity_factor = num_moe_experts / moe_router_topk``).
+        stack_moe_experts, stack_moe_ffn_hidden_size = _derive_stack_moe_metadata(
+            decoder_flat,
+            override_num_experts=self.stack_moe_num_experts,
+            override_ffn_hidden_size=self.stack_moe_ffn_hidden_size,
+        )
+        if stack_moe_experts is not None:
+            stack_kwargs["num_moe_experts"] = stack_moe_experts
+            if stack_moe_ffn_hidden_size is not None:
+                stack_kwargs["moe_ffn_hidden_size"] = stack_moe_ffn_hidden_size
+        elif ep > 1:
+            raise ValueError(
+                "expert_model_parallel_size > 1 requires at least one "
+                "MoELayerConfig in the layer_pattern; the recipe has none. "
+                "Either drop expert parallelism, or add MoE layers."
+            )
+        # DSA / MLA layers carry their own decoupled RoPE; HybridModel uses
+        # ``self.config.multi_latent_attention`` (the stack TC) to decide
+        # whether to construct the global RoPE embedding. Without this flag
+        # promoted to the stack, recipes containing DSALayerConfig get a
+        # global rotary built and passed in alongside the MLA-internal one.
+        if any(isinstance(lc, DSALayerConfig) for lc in decoder_flat):
+            stack_kwargs["multi_latent_attention"] = True
+        stack_kwargs["num_layers"] = num_layers
+        stack_kwargs["cross_entropy_loss_fusion"] = loss.loss_fusion
+        stack_kwargs["cross_entropy_fusion_impl"] = loss.fusion_impl
+        stack_kwargs["calculate_per_token_loss"] = loss.calculate_per_token_loss
+        # Marker-level passthroughs: Embedding and CrossEntropy markers may
+        # set TransformerConfig fields the curated DSL surface doesn't cover.
+        # Same shadowing rule as CommonLayerConfig.extra and LayerConfig.extra:
+        # ``extra`` cannot name a curated field on the same marker.
+        from megatron.core.models.hybrid.common_layer_config import validate_extra_kwargs
+
+        if embedding.extra:
+            validate_extra_kwargs(embedding.extra, "EmbeddingLayerConfig.extra")
+            curated = {
+                f.name
+                for f in dataclasses.fields(embedding)
+                if f.name not in ("common_config", "extra")
+            }
+            shadowed = sorted(set(embedding.extra) & curated)
+            if shadowed:
+                raise ValueError(
+                    f"EmbeddingLayerConfig.extra cannot name curated fields: {shadowed}. "
+                    f"Set them on the dataclass attribute directly."
+                )
+            stack_kwargs.update(embedding.extra)
+        if loss.extra:
+            validate_extra_kwargs(loss.extra, "CrossEntropyLayerConfig.extra")
+            # CrossEntropy's curated fields are renamed when projected onto
+            # TransformerConfig (``loss_fusion`` → ``cross_entropy_loss_fusion``
+            # etc.); reject both the recipe-side dataclass names and the
+            # TC-side names ``_lower`` writes into ``stack_kwargs`` above.
+            curated = {f.name for f in dataclasses.fields(loss) if f.name != "extra"} | {
+                "cross_entropy_loss_fusion",
+                "cross_entropy_fusion_impl",
+                "calculate_per_token_loss",
+            }
+            shadowed = sorted(set(loss.extra) & curated)
+            if shadowed:
+                raise ValueError(
+                    f"CrossEntropyLayerConfig.extra cannot name curated fields: {shadowed}. "
+                    f"Set them on the dataclass attribute directly."
+                )
+            stack_kwargs.update(loss.extra)
+        stack_kwargs = {k: v for k, v in stack_kwargs.items() if v is not None}
+        stack_config = TransformerConfig(**stack_kwargs)
+
+        # YARN parameters are not TransformerConfig dataclass fields today
+        # (see model_builder.py:196-201 and tests/.../test_hybrid_model.py for
+        # the existing setattr pattern). HybridModel.__init__ reads them via
+        # getattr when position_embedding_type == "yarn"; mirror that
+        # convention here so recipe-built models support YARN without forcing
+        # the recipe author to monkey-patch the config.
+        if embedding.yarn:
+            unknown = set(embedding.yarn) - set(_YARN_FIELDS)
+            if unknown:
+                raise ValueError(
+                    f"EmbeddingLayerConfig.yarn has unknown keys {sorted(unknown)}; "
+                    f"valid keys are {sorted(_YARN_FIELDS)}."
+                )
+            if embedding.position_embedding_type == "yarn":
+                for name, value in embedding.yarn.items():
+                    setattr(stack_config, name, value)
+
+        return stack_config, layer_type_list, layer_config_list
+
+    def _require_recipe_fields(self) -> None:
+        if self.common_config is None or self.layer_pattern is None:
+            raise ValueError(
+                "HybridModelConfig recipe path requires both common_config "
+                "and layer_pattern. The legacy path requires transformer "
+                "and hybrid_layer_pattern instead."
+            )
+
+
+# --- pattern-structure helpers --------------------------------------------
+
+
+def _inherit_common_if_default(node: Any, recipe_common: CommonLayerConfig) -> Any:
+    """If ``node`` carries no explicit common_config (left as ``None``),
+    substitute ``recipe_common`` via :func:`dataclasses.replace`. An
+    explicit :class:`CommonLayerConfig` (even a default-constructed one)
+    is preserved — recipe authors who write ``CommonLayerConfig()``
+    intentionally get the default values they asked for. Applies to
+    LayerConfig instances and pattern markers."""
+    if not hasattr(node, "common_config"):
+        return node
+    if node.common_config is None:
+        return dataclasses.replace(node, common_config=recipe_common)
+    return node
+
+
+def _inherit_common_in_pattern(node: Any, recipe_common: CommonLayerConfig) -> Any:
+    """Recursive variant: walks lists/tuples and applies
+    :func:`_inherit_common_if_default` to every leaf."""
+    if isinstance(node, list):
+        return [_inherit_common_in_pattern(child, recipe_common) for child in node]
+    if isinstance(node, tuple):
+        return tuple(_inherit_common_in_pattern(child, recipe_common) for child in node)
+    return _inherit_common_if_default(node, recipe_common)
+
+
+def _split_pattern(pattern: list):
+    """Split ``[Embedding, ...decoder..., Loss]`` into its three pieces.
+
+    The returned tuple is ``(embedding, decoder_body, loss)``.
+
+    Validates that exactly one :class:`EmbeddingLayerConfig` appears at the
+    start and exactly one :class:`CrossEntropyLayerConfig` at the end. MTP
+    and pipeline parallelism are intentionally not part of the recipe DSL;
+    recipes that need either should use the legacy ``hybrid_layer_pattern``
+    string DSL.
+    """
+    if not isinstance(pattern, list) or not pattern:
+        raise TypeError("layer_pattern must be a non-empty list.")
+
+    if not isinstance(pattern[0], EmbeddingLayerConfig):
+        raise TypeError(
+            "layer_pattern must begin with an EmbeddingLayerConfig; got "
+            f"{type(pattern[0]).__name__}."
+        )
+    if not isinstance(pattern[-1], CrossEntropyLayerConfig):
+        raise TypeError(
+            "layer_pattern must end with a CrossEntropyLayerConfig; got "
+            f"{type(pattern[-1]).__name__}."
+        )
+
+    body = pattern[1:-1]
+
+    # Embedding/Loss in the decoder body → wrong slot.
+    def _walk(node):
+        if isinstance(node, (EmbeddingLayerConfig, CrossEntropyLayerConfig)):
+            raise TypeError(
+                "EmbeddingLayerConfig / CrossEntropyLayerConfig may only appear "
+                "at the start / end of layer_pattern, never in the body."
+            )
+        if isinstance(node, (list, tuple)):
+            for child in node:
+                _walk(child)
+
+    for entry in body:
+        _walk(entry)
+
+    return pattern[0], body, pattern[-1]
+
+
+def _infer_uniform_attention_metadata(decoder_flat: List[LayerConfig]) -> dict[str, Any]:
+    """Infer model-wide attention geometry from attention-like layers.
+
+    ``TransformerConfig`` still requires attention-shaped fields even for
+    non-attention layer configs. Those requirements are an implementation
+    artifact of the current lowering target, not DSL concepts recipe authors
+    should have to spell in ``CommonLayerConfig.extra``.
+
+    When all attention/DSA layers in the pattern agree on a field, expose that
+    value to the lowering as a private placeholder. If attention layers are
+    heterogeneous, return only the fields that are actually uniform; the
+    remaining TransformerConfig invariants fall back to minimal placeholders.
+    """
+
+    attention_layers = [
+        lc for lc in decoder_flat if isinstance(lc, (AttentionLayerConfig, DSALayerConfig))
+    ]
+    if not attention_layers:
+        return {}
+
+    candidate_fields = ("num_attention_heads", "num_query_groups", "kv_channels")
+    metadata: dict[str, Any] = {}
+    for field_name in candidate_fields:
+        values = [getattr(lc, field_name) for lc in attention_layers]
+        if any(v is None for v in values):
+            continue
+        first = values[0]
+        if all(v == first for v in values[1:]):
+            metadata[field_name] = first
+    return metadata
+
+
+def _derive_stack_moe_metadata(
+    decoder_flat: List[LayerConfig],
+    override_num_experts: int | None,
+    override_ffn_hidden_size: int | None,
+) -> tuple[int | None, int | None]:
+    """Derive ``(num_moe_experts, moe_ffn_hidden_size)`` for the stack-level TC.
+
+    The stack TC is a model-wide topology snapshot, not a per-layer config,
+    but two consumers read its MoE fields semantically:
+    :class:`MultiTokenPredictionBlock` (when a body symbol contains ``E``,
+    the MoE layer inside MTP is built from the stack TC) and the inference
+    text-generation controller's capacity-factor calculation. Three cases:
+
+    1. No MoELayerConfig in the decoder → ``(None, None)``. The stack TC is
+       dense; the caller is responsible for raising on ``EP > 1``.
+    2. Homogeneous MoE → that value. The stack TC matches what every MoE
+       layer in the recipe actually uses.
+    3. Heterogeneous MoE → recipe must pin
+       :attr:`HybridModelConfig.stack_moe_num_experts` (and optionally
+       :attr:`stack_moe_ffn_hidden_size`). Without the pin we raise rather
+       than silently picking a "max"-shaped value: MTP and the inference
+       capacity-factor calc would otherwise consume a config that matches
+       no actual layer, and per-consumer wrongness is hard to debug after
+       the fact.
+    """
+    moe_layers = [lc for lc in decoder_flat if isinstance(lc, MoELayerConfig)]
+    if not moe_layers:
+        return None, None
+
+    distinct_experts = {lc.num_experts for lc in moe_layers}
+    distinct_ffn = {lc.ffn_hidden_size for lc in moe_layers if lc.ffn_hidden_size is not None}
+
+    if len(distinct_experts) == 1:
+        num_experts = next(iter(distinct_experts))
+    elif override_num_experts is not None:
+        num_experts = override_num_experts
+    else:
+        raise ValueError(
+            f"Heterogeneous MoE recipe (num_experts values: {sorted(distinct_experts)}) "
+            f"requires HybridModelConfig.stack_moe_num_experts to pin the value the "
+            f"stack-level TransformerConfig should expose. The stack TC is read by "
+            f"MTP and by the inference capacity-factor calculation; without an "
+            f"explicit pin those consumers would see a config that matches no "
+            f"actual MoE layer."
+        )
+
+    if len(distinct_ffn) <= 1:
+        # Homogeneous (or all None) — pick the matching layer's value, or fall
+        # through to ``ffn_hidden_size`` when every MoE layer leaves it unset.
+        ffn_hidden_size = next(
+            (
+                lc.ffn_hidden_size
+                for lc in moe_layers
+                if lc.num_experts == num_experts and lc.ffn_hidden_size is not None
+            ),
+            None,
+        )
+    elif override_ffn_hidden_size is not None:
+        ffn_hidden_size = override_ffn_hidden_size
+    else:
+        raise ValueError(
+            f"Heterogeneous MoE recipe (ffn_hidden_size values: {sorted(distinct_ffn)}) "
+            f"requires HybridModelConfig.stack_moe_ffn_hidden_size to pin the value the "
+            f"stack-level TransformerConfig should expose."
+        )
+
+    return num_experts, ffn_hidden_size
+
+
+def _infer_uniform_moe_metadata(decoder_flat: List[LayerConfig]) -> dict[str, Any]:
+    """Infer stack-level MoE metadata from homogeneous MoE layer configs.
+
+    The stack TC is still read by a few model-wide consumers. When every
+    MoE layer agrees on a MoE TransformerConfig field, expose that value on
+    the stack TC so recipe authors do not need to duplicate MoE router /
+    dispatcher settings through marker ``extra`` passthroughs.
+    """
+    moe_layers = [lc for lc in decoder_flat if isinstance(lc, MoELayerConfig)]
+    if not moe_layers:
+        return {}
+
+    layer_kwargs = [lc._layer_specific_kwargs() for lc in moe_layers]
+    candidate_fields = set().union(*(kwargs.keys() for kwargs in layer_kwargs))
+    metadata: dict[str, Any] = {}
+    for field_name in candidate_fields:
+        values = [kwargs.get(field_name) for kwargs in layer_kwargs]
+        if any(v is None for v in values):
+            continue
+        first = values[0]
+        if all(v == first for v in values[1:]):
+            metadata[field_name] = first
+    return metadata
+
+
+def _reject_heterogeneous_attention_geometry(
+    decoder_flat: List[LayerConfig], attention_metadata: dict[str, Any]
+) -> None:
+    """Raise if attention layers under RoPE/YARN disagree on rotary geometry.
+
+    HybridModel builds a single global rotary embedding from the stack TC's
+    ``num_attention_heads`` / ``kv_channels``. When per-layer attention
+    configs diverge on those fields, the rotary tensor is sized for the
+    placeholder and runtime hits shape mismatches. Until per-layer rotary
+    lands, force recipes under RoPE/YARN to use uniform attention geometry.
+    """
+
+    attention_layers = [
+        lc for lc in decoder_flat if isinstance(lc, (AttentionLayerConfig, DSALayerConfig))
+    ]
+    if not attention_layers:
+        return
+    for field_name in ("num_attention_heads", "num_query_groups", "kv_channels"):
+        # If inference produced this field, all layers agree; skip.
+        if field_name in attention_metadata:
+            continue
+        values = [getattr(lc, field_name) for lc in attention_layers]
+        non_none = {v for v in values if v is not None}
+        if len(non_none) > 1:
+            raise NotImplementedError(
+                f"Heterogeneous attention geometry under RoPE/YARN is not "
+                f"supported: attention layers disagree on {field_name!r} "
+                f"(values: {sorted(non_none)}). HybridModel builds one global "
+                f"rotary embedding from the stack TC and passes it to every "
+                f"attention layer; per-layer rotary support is a follow-up. "
+                f"Use uniform attention geometry, or position_embedding_type="
+                f"\"none\" / \"learned_absolute\"."
+            )
 
 
 class HybridModelBuilder(ModelBuilder[HybridModel, HybridModelConfig]):
@@ -148,9 +844,10 @@ class HybridModelBuilder(ModelBuilder[HybridModel, HybridModelConfig]):
         Note:
             Virtual pipeline model parallelism is not supported for Hybrid models.
         """
+        transformer_config = self._model_config.get_transformer_config()
         hybrid_stack_spec = self._model_config.hybrid_stack_spec
         if hybrid_stack_spec is None:
-            if self._model_config.transformer.transformer_impl == "inference_optimized":
+            if transformer_config.transformer_impl == "inference_optimized":
                 hybrid_stack_spec = hybrid_inference_stack_spec
             elif self._model_config.restore_modelopt_state:
                 hybrid_stack_spec = get_hybrid_stack_modelopt_spec(
@@ -160,12 +857,32 @@ class HybridModelBuilder(ModelBuilder[HybridModel, HybridModelConfig]):
             else:
                 hybrid_stack_spec = default_hybrid_stack_spec
 
+        assert (
+            getattr(transformer_config, "virtual_pipeline_model_parallel_size", None) is None
+            and vp_stage is None
+        ), (
+            "Virtual pipeline model parallelism is temporarily unsupported in Hybrid "
+            "models due to upstream MCore HybridModel API dependency"
+        )
+
+        if self._model_config.is_recipe_config:
+            pre_process = pre_process if pre_process is not None else is_pp_first_stage(pg_collection.pp)
+            post_process = post_process if post_process is not None else is_pp_last_stage(pg_collection.pp)
+            return HybridModel(
+                config=self._model_config,
+                hybrid_stack_spec=hybrid_stack_spec,
+                pre_process=pre_process,
+                post_process=post_process,
+                pg_collection=pg_collection,
+                vp_stage=vp_stage,
+            )
+
         assert self._model_config.vocab_size is not None, "vocab_size must be configured before calling build_model()"
         if self._model_config.should_pad_vocab:
             padded_vocab_size = calculate_padded_vocab_size(
                 self._model_config.vocab_size,
                 self._model_config.make_vocab_size_divisible_by,
-                self._model_config.transformer.tensor_model_parallel_size,
+                transformer_config.tensor_model_parallel_size,
             )
         else:
             padded_vocab_size = self._model_config.vocab_size
@@ -173,7 +890,7 @@ class HybridModelBuilder(ModelBuilder[HybridModel, HybridModelConfig]):
         pre_process = pre_process if pre_process is not None else is_pp_first_stage(pg_collection.pp)
         post_process = post_process if post_process is not None else is_pp_last_stage(pg_collection.pp)
         return HybridModel(
-            config=self._model_config.transformer,
+            config=transformer_config,
             hybrid_stack_spec=hybrid_stack_spec,
             vocab_size=padded_vocab_size,
             max_sequence_length=self._model_config.seq_length,
@@ -220,7 +937,7 @@ class HybridModelBuilder(ModelBuilder[HybridModel, HybridModelConfig]):
         Returns:
             List of model stages.
         """
-        transformer_config = self._model_config.transformer
+        transformer_config = self._model_config.get_transformer_config()
         composed_pre_wrap_hook = compose_hooks(self._model_config.pre_wrap_hooks)
         model_list = unimodal_build_distributed_models(
             self.build_model,

--- a/tests/functional_tests/test_cases/hybrid/hybrid_recipe_dsl_mr_mcore_te_tp1_pp1_cp1_dgx_a100_1N8G/model_config.yaml
+++ b/tests/functional_tests/test_cases/hybrid/hybrid_recipe_dsl_mr_mcore_te_tp1_pp1_cp1_dgx_a100_1N8G/model_config.yaml
@@ -1,0 +1,58 @@
+ENV_VARS:
+  CUDA_DEVICE_MAX_CONNECTIONS: 1
+  NVTE_ALLOW_NONDETERMINISTIC_ALGO: 1
+  NCCL_ALGO: Ring
+  CUBLAS_WORKSPACE_CONFIG: :4096:8
+MODEL_ARGS:
+  # Architecture is defined entirely by the recipe — no --hybrid-layer-pattern,
+  # --hidden-size, --num-attention-heads, --num-query-groups, --spec, etc.
+  # The launcher's --model-recipe path projects recipe values onto args; this
+  # config carries only training/runtime concerns.
+  --model-recipe: ./tests/functional_tests/test_cases/hybrid/hybrid_recipe_dsl_mr_mcore_te_tp1_pp1_cp1_dgx_a100_1N8G/recipe.py
+  --log-params-norm: true
+  --log-num-zeros-in-grad: true
+  --log-validation-ppl-to-tensorboard: true
+  --log-timers-to-tensorboard: true
+  --tensorboard-dir: ${TENSORBOARD_PATH}
+  --micro-batch-size: 4
+  --global-batch-size: 32
+  --seq-length: 1024
+  --max-position-embeddings: 1024
+  --train-iters: 50
+  --timing-log-level: 0
+  --lr-decay-iters: 320000
+  --save: ${CHECKPOINT_SAVE_PATH}
+  --load: ${CHECKPOINT_LOAD_PATH}
+  --data-path: ${DATA_PATH}/text/common_pile/v01_filtered_data/my-gpt3_00_text_document
+  --vocab-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/vocab.json
+  --merge-file: ${DATA_PATH}/text/common_pile/v01_filtered_data/bpe/merges.txt
+  --split: 949,50,1
+  --distributed-backend: nccl
+  --lr: 0.00015
+  --lr-decay-style: cosine
+  --min-lr: 1.0e-5
+  --weight-decay: 1e-2
+  --clip-grad: 1.0
+  --lr-warmup-fraction: .01
+  --log-interval: 1
+  --save-interval: 10000
+  --eval-interval: 1000
+  --eval-iters: 10
+  --transformer-impl: transformer_engine
+  --tensor-model-parallel-size: 1
+  --pipeline-model-parallel-size: 1
+  --use-distributed-optimizer: true
+  --overlap-grad-reduce: true
+  --overlap-param-gather: true
+  --check-weight-hash-across-dp-replicas-interval: 10
+  --ckpt-fully-parallel-load: true
+  --no-gradient-accumulation-fusion: true
+  --use-mcore-models: true
+  --ckpt-format: torch_dist
+  --data-cache-path: ${DATA_CACHE_PATH}
+  --bf16: true
+  --attention-backend: unfused
+  --log-memory-to-tensorboard: true
+  --async-save: true
+  --use-persistent-ckpt-worker: true
+TEST_TYPE: regular

--- a/tests/functional_tests/test_cases/hybrid/hybrid_recipe_dsl_mr_mcore_te_tp1_pp1_cp1_dgx_a100_1N8G/recipe.py
+++ b/tests/functional_tests/test_cases/hybrid/hybrid_recipe_dsl_mr_mcore_te_tp1_pp1_cp1_dgx_a100_1N8G/recipe.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Smoke-test recipe for the HybridModel Python DSL construction path.
+
+A small Mamba / Attention / MLP hybrid that exercises
+``HybridModel(config: HybridModelConfig, ...)`` end-to-end through the
+real training launcher (``pretrain_hybrid.py --model-recipe``). The CI
+test that consumes this recipe trains for ~50 iterations and locks loss /
+gradient-norm golden values on the first successful run; subsequent runs
+detect numerical regressions.
+
+The recipe is deliberately small (12 decoder layers, hidden_size=1024) so
+the test runs quickly. Architecture style mirrors the existing
+``hybrid_mr_mcore_te_tp1_pp1_cp1_dgx_a100_1N8G`` legacy-string-DSL
+functional test, but the entry point is the new constructor surface.
+"""
+
+import torch
+
+from megatron.core.models.hybrid import (
+    AttentionLayerConfig,
+    CommonLayerConfig,
+    CrossEntropyLayerConfig,
+    EmbeddingLayerConfig,
+    HybridModelConfig,
+    MambaLayerConfig,
+    MLPLayerConfig,
+)
+
+# Model-wide defaults shared by every layer below.
+common = CommonLayerConfig(
+    hidden_size=1024,
+    mixed_precision_dtype=torch.bfloat16,
+    normalization="RMSNorm",
+    add_bias_linear=False,
+    activation_func="silu",
+    gated_linear_unit=True,
+)
+
+# Pattern markers — embedding at the head, loss at the tail.
+Embedding = EmbeddingLayerConfig(
+    common_config=common,
+    vocab_size=131072,
+    max_sequence_length=1024,
+    position_embedding_type="none",
+)
+Loss = CrossEntropyLayerConfig()
+
+# Layer building blocks. Mamba uses CommonLayerConfig defaults; Attention
+# pins the GQA group count to match the legacy functional test.
+Mamba = MambaLayerConfig(common_config=common)
+Attn = AttentionLayerConfig(
+    common_config=common, num_attention_heads=16, num_query_groups=8, attention_softmax_in_fp32=True
+)
+MLP = MLPLayerConfig(common_config=common)
+
+# 12-layer decoder: two repeats of [Mamba, MLP, Mamba, MLP, Attn, MLP].
+# Plain Python list operations replace the legacy string DSL.
+decoder = [Mamba, MLP, Mamba, MLP, Attn, MLP] * 2
+layer_pattern = [Embedding] + decoder + [Loss]
+
+
+def make_recipe() -> HybridModelConfig:
+    """Recipe entry point consumed by ``--model-recipe``."""
+    return HybridModelConfig(
+        common_config=common,
+        layer_pattern=layer_pattern,
+        # Match HybridModel's legacy default
+        # (``share_embeddings_and_output_weights=False``).
+        untie_embeddings_and_output_weights=True,
+    )

--- a/tests/test_utils/recipes/h100/mamba.yaml
+++ b/tests/test_utils/recipes/h100/mamba.yaml
@@ -103,3 +103,18 @@ products:
       - environment: [dev]
         scope: [mr-broken, mr-github-broken]
         platforms: [dgx_h100]
+
+  # End-to-end smoke test for the HybridModel Python DSL recipe path:
+  # exercises HybridModel(config: HybridModelConfig, ...) through the real
+  # training launcher (pretrain_hybrid.py --model-recipe), trains for 50
+  # iterations, and locks loss / gradient-norm golden values. Architecture
+  # and entry point are defined in:
+  #   tests/functional_tests/test_cases/hybrid/
+  #     hybrid_recipe_dsl_mr_mcore_te_tp1_pp1_cp1_dgx_a100_1N8G/{recipe.py,model_config.yaml}
+  - test_case: [hybrid_recipe_dsl_mr_mcore_te_tp1_pp1_cp1_dgx_a100_1N8G]
+    products:
+      - environment: [dev]
+        scope: [mr, mr-github]
+        platforms: [dgx_h100]
+      # - environment: [lts] # disabled until triton is bumped
+      #   scope: [nightly]

--- a/tests/unit_tests/models/hybrid/__init__.py
+++ b/tests/unit_tests/models/hybrid/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.

--- a/tests/unit_tests/models/hybrid/test_layer_configs.py
+++ b/tests/unit_tests/models/hybrid/test_layer_configs.py
@@ -1,0 +1,340 @@
+# Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Unit tests for HybridModel recipe layer config primitives."""
+
+import dataclasses
+
+import pytest
+import torch
+
+from megatron.core.models.hybrid.common_layer_config import CommonLayerConfig, validate_extra_kwargs
+from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols
+from megatron.core.models.hybrid.layer_configs import (
+    AttentionLayerConfig,
+    DSALayerConfig,
+    GDNLayerConfig,
+    MambaLayerConfig,
+    MLPLayerConfig,
+    MoELayerConfig,
+)
+from megatron.core.transformer import MLATransformerConfig
+
+
+def _make_common(**overrides) -> CommonLayerConfig:
+    base = dict(hidden_size=256, use_cpu_initialization=True)
+    base.update(overrides)
+    return CommonLayerConfig(**base)
+
+
+@pytest.mark.internal
+class TestCommonLayerConfig:
+
+    COMMON_FIELD_LAYER_COVERAGE = {
+        "hidden_size": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "ffn_hidden_size": ("mlp", "moe"),
+        "mixed_precision_dtype": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "params_dtype": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "first_last_layers_bf16": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "sequence_parallel": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "init_method_std": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "perform_initialization": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "use_cpu_initialization": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "normalization": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "layernorm_epsilon": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "layernorm_zero_centered_gamma": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "add_bias_linear": ("attention", "dsa", "mlp", "moe"),
+        "gated_linear_unit": ("mlp", "moe"),
+        "activation_func": ("gdn", "mlp", "moe"),
+        "hidden_dropout": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "fp32_residual_connection": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "apply_rope_fusion": ("attention", "dsa"),
+        "persist_layer_norm": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "transformer_impl": ("attention", "mlp", "moe"),
+        "cuda_graph_impl": ("mamba", "attention", "mlp", "moe"),
+        "cuda_graph_scope": ("mamba", "attention", "mlp", "moe"),
+        "cuda_graph_warmup_steps": ("mamba", "attention", "mlp", "moe"),
+        "apply_residual_connection_post_layernorm": (
+            "mamba",
+            "attention",
+            "dsa",
+            "gdn",
+            "mlp",
+            "moe",
+        ),
+        "fp8": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "fp8_recipe": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "fp8_param": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "fp8_margin": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "fp8_amax_history_len": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "fp8_dot_product_attention": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "fp4": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "fp4_recipe": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "fp4_param": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "recompute_granularity": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "recompute_method": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "recompute_num_layers": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "distribute_saved_activations": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+    }
+
+    NON_SHARED_FIELDS = {
+        "attention_dropout",
+        "attention_softmax_in_fp32",
+        "apply_query_key_layer_scaling",
+        "add_qkv_bias",
+        "masked_softmax_fusion",
+        "use_fused_weighted_squared_relu",
+    }
+
+    def test_common_fields_are_explicitly_audited_as_shared(self):
+        common_fields = {f.name for f in dataclasses.fields(CommonLayerConfig) if f.name != "extra"}
+        assert common_fields == set(self.COMMON_FIELD_LAYER_COVERAGE)
+
+    def test_non_shared_fields_are_not_common_fields(self):
+        common_fields = {f.name for f in dataclasses.fields(CommonLayerConfig)}
+        assert common_fields.isdisjoint(self.NON_SHARED_FIELDS)
+
+    def test_update_returns_new_instance(self):
+        common = _make_common()
+        updated = common.update(hidden_size=512)
+        assert updated is not common
+        assert common.hidden_size == 256
+        assert updated.hidden_size == 512
+
+    def test_mixed_precision_dtype_bf16_maps_to_bf16_true(self):
+        common = _make_common(mixed_precision_dtype=torch.bfloat16)
+        layer = MambaLayerConfig(common_config=common, head_dim=64, state_size=128, num_groups=8)
+        tc = layer.to_transformer_config(num_layers=4)
+        assert tc.bf16 is True
+        assert tc.fp16 is False
+        assert tc.params_dtype == torch.bfloat16
+
+    def test_params_dtype_can_explicitly_differ_from_mixed_precision_dtype(self):
+        common = _make_common(
+            mixed_precision_dtype=torch.bfloat16,
+            params_dtype=torch.float32,
+        )
+        layer = MambaLayerConfig(common_config=common, head_dim=64, state_size=128, num_groups=8)
+        tc = layer.to_transformer_config(num_layers=4)
+        assert tc.bf16 is True
+        assert tc.params_dtype == torch.float32
+
+    def test_invalid_mixed_precision_dtype_raises(self):
+        common = _make_common(mixed_precision_dtype="nope")
+        with pytest.raises(TypeError, match="mixed_precision_dtype"):
+            common.to_transformer_config_kwargs()
+
+    def test_unsupported_mixed_precision_torch_dtype_raises(self):
+        common = _make_common(mixed_precision_dtype=torch.float64)
+        with pytest.raises(ValueError, match="mixed_precision_dtype"):
+            common.to_transformer_config_kwargs()
+
+    def test_invalid_params_dtype_raises(self):
+        common = _make_common(params_dtype="bf16")
+        with pytest.raises(TypeError, match="params_dtype"):
+            common.to_transformer_config_kwargs()
+
+    def test_invalid_activation_func_raises(self):
+        common = _make_common(activation_func="not_a_real_activation")
+        with pytest.raises(ValueError, match="activation"):
+            common.to_transformer_config_kwargs()
+
+    def test_fp8_cluster_propagates(self):
+        common = _make_common(
+            fp8="hybrid",
+            fp8_recipe="delayed",
+            fp8_param=True,
+            fp8_margin=2,
+            fp8_amax_history_len=1024,
+            fp8_dot_product_attention=True,
+        )
+        layer = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        tc = layer.to_transformer_config(num_layers=2)
+        assert tc.fp8 == "hybrid"
+        assert tc.fp8_recipe == "delayed"
+        assert tc.fp8_param is True
+        assert tc.fp8_margin == 2
+        assert tc.fp8_amax_history_len == 1024
+        assert tc.fp8_dot_product_attention is True
+
+    def test_recompute_cluster_propagates(self):
+        common = _make_common(
+            recompute_granularity="full", recompute_method="uniform", recompute_num_layers=4
+        )
+        layer = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        tc = layer.to_transformer_config(num_layers=8)
+        assert tc.recompute_granularity == "full"
+        assert tc.recompute_method == "uniform"
+        assert tc.recompute_num_layers == 4
+
+
+@pytest.mark.internal
+class TestLayerConfigSymbols:
+
+    def test_symbol_assignments(self):
+        assert MambaLayerConfig.SYMBOL == Symbols.MAMBA
+        assert GDNLayerConfig.SYMBOL == Symbols.GDN
+        assert AttentionLayerConfig.SYMBOL == Symbols.ATTENTION
+        assert DSALayerConfig.SYMBOL == Symbols.DS_ATTENTION
+        assert MLPLayerConfig.SYMBOL == Symbols.MLP
+        assert MoELayerConfig.SYMBOL == Symbols.MOE
+
+    def test_symbols_are_valid(self):
+        for cls in (
+            MambaLayerConfig,
+            GDNLayerConfig,
+            AttentionLayerConfig,
+            DSALayerConfig,
+            MLPLayerConfig,
+            MoELayerConfig,
+        ):
+            assert cls.SYMBOL in Symbols.VALID_LAYERS
+
+
+@pytest.mark.internal
+class TestLayerConfigToTransformerConfig:
+
+    def test_mamba_layer_config(self):
+        common = _make_common()
+        layer = MambaLayerConfig(common_config=common, head_dim=64, state_size=128, num_groups=8)
+        tc = layer.to_transformer_config(num_layers=4)
+        assert tc.mamba_head_dim == 64
+        assert tc.mamba_state_dim == 128
+        assert tc.mamba_num_groups == 8
+        assert tc.num_layers == 4
+
+    def test_attention_layer_config(self):
+        common = _make_common()
+        layer = AttentionLayerConfig(common_config=common, num_attention_heads=32)
+        tc = layer.to_transformer_config(num_layers=4)
+        assert tc.num_attention_heads == 32
+        assert tc.num_query_groups == 32
+        assert tc.kv_channels == common.hidden_size // 32
+
+    def test_moe_layer_config(self):
+        common = _make_common()
+        layer = MoELayerConfig(common_config=common, num_experts=8, top_k=2)
+        tc = layer.to_transformer_config(num_layers=4)
+        assert tc.num_moe_experts == 8
+        assert tc.moe_router_topk == 2
+
+    def test_none_layer_field_does_not_clobber_common_ffn_hidden_size(self):
+        common = _make_common(ffn_hidden_size=3072)
+        layer = MLPLayerConfig(common_config=common)
+        tc = layer.to_transformer_config(num_layers=4)
+        assert tc.ffn_hidden_size == 3072
+
+    def test_explicit_layer_field_overrides_common_field(self):
+        common = _make_common(ffn_hidden_size=3072)
+        layer = MLPLayerConfig(common_config=common, ffn_hidden_size=2048)
+        tc = layer.to_transformer_config(num_layers=4)
+        assert tc.ffn_hidden_size == 2048
+
+    def test_none_layer_fields_do_not_clobber_common_extra_attention_fields(self):
+        common = _make_common(
+            extra={
+                "attention_dropout": 0.25,
+                "attention_softmax_in_fp32": True,
+                "add_qkv_bias": True,
+                "masked_softmax_fusion": False,
+            }
+        )
+        layer = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        tc = layer.to_transformer_config(num_layers=4)
+        assert tc.attention_dropout == 0.25
+        assert tc.attention_softmax_in_fp32 is True
+        assert tc.add_qkv_bias is True
+        assert tc.masked_softmax_fusion is False
+
+    def test_dsa_uses_mla_transformer_config(self):
+        common = _make_common()
+        layer = DSALayerConfig(common_config=common, num_attention_heads=4)
+        tc = layer.to_transformer_config(num_layers=2)
+        assert isinstance(tc, MLATransformerConfig)
+        assert tc.multi_latent_attention is True
+        assert tc.experimental_attention_variant == "dsa"
+
+    def test_dsa_mla_knobs_curated(self):
+        common = _make_common()
+        layer = DSALayerConfig(
+            common_config=common,
+            num_attention_heads=128,
+            q_lora_rank=1536,
+            kv_lora_rank=512,
+            qk_head_dim=128,
+            qk_pos_emb_head_dim=64,
+            v_head_dim=128,
+            rotary_scaling_factor=40.0,
+            dsa_indexer_topk=32,
+        )
+        tc = layer.to_transformer_config(num_layers=2)
+        assert tc.q_lora_rank == 1536
+        assert tc.kv_lora_rank == 512
+        assert tc.qk_head_dim == 128
+        assert tc.qk_pos_emb_head_dim == 64
+        assert tc.v_head_dim == 128
+        assert tc.rotary_scaling_factor == 40.0
+        assert tc.dsa_indexer_topk == 32
+
+
+@pytest.mark.internal
+class TestExtraPassthrough:
+
+    def test_common_extra_propagates_to_layer_tc(self):
+        common = _make_common(extra={"qk_layernorm": True})
+        layer = MambaLayerConfig(common_config=common)
+        tc = layer.to_transformer_config(num_layers=2)
+        assert tc.qk_layernorm is True
+
+    def test_layer_extra_overrides_common_extra(self):
+        common = _make_common(extra={"qk_layernorm": False})
+        layer = AttentionLayerConfig(
+            common_config=common, num_attention_heads=4, extra={"qk_layernorm": True}
+        )
+        tc = layer.to_transformer_config(num_layers=2)
+        assert tc.qk_layernorm is True
+
+    def test_common_extra_unknown_field_raises(self):
+        common = _make_common(extra={"definitely_not_a_real_tc_field": 7})
+        with pytest.raises(ValueError, match="not TransformerConfig fields"):
+            common.to_transformer_config_kwargs()
+
+    def test_layer_extra_unknown_field_raises(self):
+        common = _make_common()
+        layer = MambaLayerConfig(common_config=common, extra={"another_typo_field": 1.0})
+        with pytest.raises(ValueError, match="MambaLayerConfig.extra"):
+            layer.to_transformer_config(num_layers=2)
+
+    def test_extra_validation_can_target_mla_transformer_config(self):
+        validate_extra_kwargs(
+            {"mla_down_proj_fusion": True}, "DSALayerConfig.extra", MLATransformerConfig
+        )
+
+    def test_common_extra_cannot_shadow_curated_field(self):
+        common = _make_common(extra={"hidden_size": 999})
+        with pytest.raises(ValueError, match="hidden_size"):
+            common.to_transformer_config_kwargs()
+
+    def test_common_extra_cannot_shadow_curated_transformer_config_key(self):
+        common = _make_common(mixed_precision_dtype=torch.bfloat16, extra={"bf16": False})
+        with pytest.raises(ValueError, match="bf16"):
+            common.to_transformer_config_kwargs()
+
+    def test_layer_extra_cannot_shadow_curated_field(self):
+        common = _make_common()
+        layer = AttentionLayerConfig(
+            common_config=common, num_attention_heads=4, extra={"num_attention_heads": 8}
+        )
+        with pytest.raises(ValueError, match="num_attention_heads"):
+            layer.to_transformer_config(num_layers=2)
+
+    def test_layer_extra_cannot_shadow_curated_none_field(self):
+        common = _make_common()
+        layer = MLPLayerConfig(common_config=common, extra={"ffn_hidden_size": 4096})
+        with pytest.raises(ValueError, match="ffn_hidden_size"):
+            layer.to_transformer_config(num_layers=2)
+
+    def test_layer_extra_cannot_shadow_curated_transformer_config_key(self):
+        common = _make_common()
+        layer = MoELayerConfig(common_config=common, num_experts=8, extra={"num_moe_experts": 4})
+        with pytest.raises(ValueError, match="num_moe_experts"):
+            layer.to_transformer_config(num_layers=2)

--- a/tests/unit_tests/models/hybrid/test_layer_configs.py
+++ b/tests/unit_tests/models/hybrid/test_layer_configs.py
@@ -109,10 +109,7 @@ class TestCommonLayerConfig:
         assert tc.params_dtype == torch.bfloat16
 
     def test_params_dtype_can_explicitly_differ_from_mixed_precision_dtype(self):
-        common = _make_common(
-            mixed_precision_dtype=torch.bfloat16,
-            params_dtype=torch.float32,
-        )
+        common = _make_common(mixed_precision_dtype=torch.bfloat16, params_dtype=torch.float32)
         layer = MambaLayerConfig(common_config=common, head_dim=64, state_size=128, num_groups=8)
         tc = layer.to_transformer_config(num_layers=4)
         assert tc.bf16 is True

--- a/tests/unit_tests/models/hybrid/test_layer_configs.py
+++ b/tests/unit_tests/models/hybrid/test_layer_configs.py
@@ -217,6 +217,19 @@ class TestLayerConfigToTransformerConfig:
         assert tc.num_moe_experts == 8
         assert tc.moe_router_topk == 2
 
+    def test_moe_layer_config_accepts_multi_loss_router_fields(self):
+        common = _make_common()
+        layer = MoELayerConfig(
+            common_config=common,
+            num_experts=8,
+            top_k=2,
+            router_load_balancing_type=["aux_loss", "seq_aux_loss"],
+            aux_loss_coeff=[0.1, 0.2],
+        )
+        tc = layer.to_transformer_config(num_layers=4)
+        assert tc.moe_router_load_balancing_type == ["aux_loss", "seq_aux_loss"]
+        assert tc.moe_aux_loss_coeff == [0.1, 0.2]
+
     def test_none_layer_field_does_not_clobber_common_ffn_hidden_size(self):
         common = _make_common(ffn_hidden_size=3072)
         layer = MLPLayerConfig(common_config=common)

--- a/tests/unit_tests/models/hybrid/test_layer_pattern.py
+++ b/tests/unit_tests/models/hybrid/test_layer_pattern.py
@@ -1,0 +1,1152 @@
+# Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Unit tests for the HybridModel Python layer-pattern DSL primitives.
+
+These tests exercise pure-Python composition logic and do not require a
+distributed initialization or a CUDA device.
+"""
+
+import dataclasses
+from collections import namedtuple
+
+import pytest
+import torch
+
+from megatron.core.models.hybrid.common_layer_config import CommonLayerConfig, validate_extra_kwargs
+from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols
+from megatron.core.models.hybrid.layer_configs import (
+    AttentionLayerConfig,
+    CrossEntropyLayerConfig,
+    DSALayerConfig,
+    EmbeddingLayerConfig,
+    GDNLayerConfig,
+    LayerConfig,
+    MambaLayerConfig,
+    MLPLayerConfig,
+    MoELayerConfig,
+)
+from megatron.core.models.hybrid.layer_pattern import flatten_decoder_pattern
+from megatron.core.transformer import MLATransformerConfig
+from megatron.training.models.hybrid import HybridModelConfig
+
+# ``HybridModelConfig._lower()`` now returns a 3-tuple
+# ``(stack_tc, layer_symbols, layer_tcs)``; the previous ``_RecipeLowering``
+# named-attribute struct went away when the recipe-API refactor inlined the
+# lowering into ``HybridModel.__init__``. Tests in this module use
+# ``compiled.config`` / ``.layer_type_list`` / ``.layer_config_list`` style
+# access purely for readability — wrap the tuple here so existing
+# assertions stay legible without coupling the production code to a
+# named-attribute return type.
+_Lowered = namedtuple("_Lowered", ["config", "layer_type_list", "layer_config_list"])
+
+
+def _lower(recipe: HybridModelConfig) -> _Lowered:
+    return _Lowered(*recipe._lower())
+
+
+def _make_common(**overrides) -> CommonLayerConfig:
+    """Build a minimal valid CommonLayerConfig for unit tests."""
+    base = dict(hidden_size=256, use_cpu_initialization=True)
+    base.update(overrides)
+    return CommonLayerConfig(**base)
+
+
+@pytest.mark.internal
+class TestCommonLayerConfig:
+
+    COMMON_FIELD_LAYER_COVERAGE = {
+        "hidden_size": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "ffn_hidden_size": ("mlp", "moe"),
+        "mixed_precision_dtype": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "params_dtype": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "first_last_layers_bf16": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "sequence_parallel": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "init_method_std": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "perform_initialization": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "use_cpu_initialization": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "normalization": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "layernorm_epsilon": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "layernorm_zero_centered_gamma": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "add_bias_linear": ("attention", "dsa", "mlp", "moe"),
+        "gated_linear_unit": ("mlp", "moe"),
+        "activation_func": ("gdn", "mlp", "moe"),
+        "hidden_dropout": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "fp32_residual_connection": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "apply_rope_fusion": ("attention", "dsa"),
+        "persist_layer_norm": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "transformer_impl": ("attention", "mlp", "moe"),
+        "cuda_graph_impl": ("mamba", "attention", "mlp", "moe"),
+        "cuda_graph_scope": ("mamba", "attention", "mlp", "moe"),
+        "cuda_graph_warmup_steps": ("mamba", "attention", "mlp", "moe"),
+        # TransformerLayer-level wiring — applies wherever the per-layer
+        # type is wrapped in a TransformerLayer (i.e. everywhere).
+        "apply_residual_connection_post_layernorm": (
+            "mamba",
+            "attention",
+            "dsa",
+            "gdn",
+            "mlp",
+            "moe",
+        ),
+        # FP8/FP4/recompute clusters — TC-level concerns that affect every
+        # layer family the recipe builds.
+        "fp8": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "fp8_recipe": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "fp8_param": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "fp8_margin": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "fp8_amax_history_len": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "fp8_dot_product_attention": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "fp4": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "fp4_recipe": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "fp4_param": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "recompute_granularity": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "recompute_method": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "recompute_num_layers": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+        "distribute_saved_activations": ("mamba", "attention", "dsa", "gdn", "mlp", "moe"),
+    }
+
+    NON_SHARED_FIELDS = {
+        "attention_dropout",
+        "attention_softmax_in_fp32",
+        "apply_query_key_layer_scaling",
+        "add_qkv_bias",
+        "masked_softmax_fusion",
+        "use_fused_weighted_squared_relu",
+    }
+
+    def test_common_fields_are_explicitly_audited_as_shared(self):
+        common_fields = {f.name for f in dataclasses.fields(CommonLayerConfig) if f.name != "extra"}
+        assert common_fields == set(self.COMMON_FIELD_LAYER_COVERAGE)
+        for field_name, layer_families in self.COMMON_FIELD_LAYER_COVERAGE.items():
+            assert len(layer_families) >= 2, field_name
+
+    def test_non_shared_fields_are_not_common_fields(self):
+        common_fields = {f.name for f in dataclasses.fields(CommonLayerConfig)}
+        assert common_fields.isdisjoint(self.NON_SHARED_FIELDS)
+
+    def test_update_returns_new_instance(self):
+        common = _make_common()
+        updated = common.update(hidden_size=512)
+        assert updated is not common
+        assert common.hidden_size == 256
+        assert updated.hidden_size == 512
+
+    def test_mixed_precision_dtype_bf16_maps_to_bf16_true(self):
+        common = _make_common(mixed_precision_dtype=torch.bfloat16)
+        layer = MambaLayerConfig(common_config=common, head_dim=64, state_size=128, num_groups=8)
+        tc = layer.to_transformer_config(num_layers=4)
+        assert tc.bf16 is True
+        assert tc.fp16 is False
+
+    def test_params_dtype_auto_derives_from_mixed_precision_when_unset(self):
+        """Setting ``mixed_precision_dtype=torch.bfloat16`` without overriding
+        ``params_dtype`` should produce a TC whose
+        params live in bf16 — matching the legacy --bf16 CLI flag's
+        behaviour."""
+        common = _make_common(mixed_precision_dtype=torch.bfloat16)
+        layer = MambaLayerConfig(common_config=common, head_dim=64, state_size=128, num_groups=8)
+        tc = layer.to_transformer_config(num_layers=4)
+        assert tc.params_dtype == torch.bfloat16
+
+    def test_explicit_params_dtype_override_preserved(self):
+        """An explicit ``params_dtype`` from the recipe author wins over the
+        auto-derive. Useful when a recipe wants bf16 mixed precision but
+        keeps params in fp32 (e.g. for fp32 master-weight workflows)."""
+        common = _make_common(
+            mixed_precision_dtype=torch.bfloat16,
+            params_dtype=torch.float16,
+        )
+        layer = MambaLayerConfig(common_config=common, head_dim=64, state_size=128, num_groups=8)
+        tc = layer.to_transformer_config(num_layers=4)
+        assert tc.params_dtype == torch.float16
+
+    def test_invalid_mixed_precision_dtype_raises(self):
+        common = _make_common(mixed_precision_dtype="nope")
+        with pytest.raises(TypeError, match="mixed_precision_dtype"):
+            common.to_transformer_config_kwargs()
+
+    def test_invalid_activation_func_raises(self):
+        common = _make_common(activation_func="not_a_real_activation")
+        with pytest.raises(ValueError, match="activation"):
+            common.to_transformer_config_kwargs()
+
+    def test_attention_specific_fields_live_on_attention_layer_config(self):
+        common = _make_common()
+        layer = AttentionLayerConfig(
+            common_config=common,
+            num_attention_heads=4,
+            attention_dropout=0.25,
+            attention_softmax_in_fp32=False,
+            add_qkv_bias=True,
+            masked_softmax_fusion=True,
+            # Niche legacy fp16-stability knob; reachable via ``extra`` rather
+            # than as a curated AttentionLayerConfig field.
+            extra={"apply_query_key_layer_scaling": False},
+        )
+
+        tc = layer.to_transformer_config(num_layers=2)
+
+        assert tc.attention_dropout == 0.25
+        assert tc.attention_softmax_in_fp32 is False
+        assert tc.apply_query_key_layer_scaling is False
+        assert tc.add_qkv_bias is True
+        assert tc.masked_softmax_fusion is True
+
+    def test_moe_specific_fields_live_on_moe_layer_config(self):
+        common = _make_common(activation_func="squared_relu")
+        layer = MoELayerConfig(
+            common_config=common, num_experts=8, top_k=2, use_fused_weighted_squared_relu=True
+        )
+
+        tc = layer.to_transformer_config(num_layers=2)
+
+        assert tc.use_fused_weighted_squared_relu is True
+
+    def test_fp8_cluster_propagates(self):
+        """FP8 cluster on CommonLayerConfig flows through to per-layer TC."""
+        common = _make_common(
+            fp8="hybrid",
+            fp8_recipe="delayed",
+            fp8_param=True,
+            fp8_margin=2,
+            fp8_amax_history_len=1024,
+            fp8_dot_product_attention=True,
+        )
+        layer = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        tc = layer.to_transformer_config(num_layers=2)
+        assert tc.fp8 == "hybrid"
+        assert tc.fp8_recipe == "delayed"
+        assert tc.fp8_param is True
+        assert tc.fp8_margin == 2
+        assert tc.fp8_amax_history_len == 1024
+        assert tc.fp8_dot_product_attention is True
+
+    def test_recompute_cluster_propagates(self):
+        common = _make_common(
+            recompute_granularity="full", recompute_method="uniform", recompute_num_layers=4
+        )
+        layer = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        tc = layer.to_transformer_config(num_layers=8)
+        assert tc.recompute_granularity == "full"
+        assert tc.recompute_method == "uniform"
+        assert tc.recompute_num_layers == 4
+
+    def test_apply_residual_connection_post_layernorm_propagates(self):
+        common = _make_common(apply_residual_connection_post_layernorm=True)
+        layer = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        tc = layer.to_transformer_config(num_layers=2)
+        assert tc.apply_residual_connection_post_layernorm is True
+
+    def test_dsa_add_qkv_bias_curated(self):
+        """``add_qkv_bias`` is curated on :class:`DSALayerConfig` (parity with
+        :class:`AttentionLayerConfig`); it should not require ``extra``."""
+        common = _make_common()
+        layer = DSALayerConfig(common_config=common, num_attention_heads=4, add_qkv_bias=True)
+        tc = layer.to_transformer_config(num_layers=2)
+        assert tc.add_qkv_bias is True
+
+    def test_dsa_mla_knobs_curated(self):
+        """The MLA-defining knobs are curated on :class:`DSALayerConfig` so
+        DeepSeek-style models don't need ``extra={...}`` for every field.
+        Each is ``None`` by default and falls through to the underlying
+        :class:`TransformerConfig` MLA defaults; setting them explicitly
+        overrides those defaults."""
+        common = _make_common()
+        # DeepSeek-V3-style values (representative — not the exact card).
+        layer = DSALayerConfig(
+            common_config=common,
+            num_attention_heads=128,
+            q_lora_rank=1536,
+            kv_lora_rank=512,
+            qk_head_dim=128,
+            qk_pos_emb_head_dim=64,
+            v_head_dim=128,
+            rope_type="yarn",
+            rotary_base=1000000.0,
+            rotary_percent=1.0,
+            rotary_scaling_factor=40.0,
+            original_max_position_embeddings=4096,
+            beta_fast=32.0,
+            beta_slow=1.0,
+            mscale=1.0,
+            mscale_all_dim=0.0,
+            cache_mla_latents=True,
+            mla_down_proj_fusion=True,
+            dsa_indexer_n_heads=8,
+            dsa_indexer_head_dim=64,
+            dsa_indexer_topk=32,
+            dsa_indexer_loss_coeff=0.1,
+            dsa_indexer_use_sparse_loss=True,
+        )
+        tc = layer.to_transformer_config(num_layers=2)
+        assert tc.multi_latent_attention is True
+        assert tc.experimental_attention_variant == "dsa"
+        assert tc.q_lora_rank == 1536
+        assert tc.kv_lora_rank == 512
+        assert tc.qk_head_dim == 128
+        assert tc.qk_pos_emb_head_dim == 64
+        assert tc.v_head_dim == 128
+        assert tc.rope_type == "yarn"
+        assert tc.rotary_base == 1000000.0
+        assert tc.rotary_percent == 1.0
+        assert tc.rotary_scaling_factor == 40.0
+        assert tc.original_max_position_embeddings == 4096
+        assert tc.beta_fast == 32.0
+        assert tc.beta_slow == 1.0
+        assert tc.mscale == 1.0
+        assert tc.mscale_all_dim == 0.0
+        assert tc.cache_mla_latents is True
+        assert tc.mla_down_proj_fusion is True
+        assert tc.dsa_indexer_n_heads == 8
+        assert tc.dsa_indexer_head_dim == 64
+        assert tc.dsa_indexer_topk == 32
+        assert tc.dsa_indexer_loss_coeff == 0.1
+        assert tc.dsa_indexer_use_sparse_loss is True
+
+    def test_dsa_mla_knobs_default_to_transformer_config_defaults(self):
+        """Unset MLA knobs on :class:`DSALayerConfig` fall through to the
+        underlying TransformerConfig defaults — recipe authors don't have
+        to repeat the model-card defaults to opt in."""
+        common = _make_common()
+        layer = DSALayerConfig(common_config=common, num_attention_heads=4)
+        tc = layer.to_transformer_config(num_layers=2)
+        # TC's MLA defaults (transformer_config.py around line 2297+).
+        assert tc.q_lora_rank == 512
+        assert tc.kv_lora_rank == 512
+        assert tc.qk_head_dim == 128
+        assert tc.qk_pos_emb_head_dim == 64
+        assert tc.v_head_dim == 128
+        assert tc.rotary_scaling_factor == 40
+        assert tc.experimental_attention_variant == "dsa"
+
+
+@pytest.mark.internal
+class TestLayerConfigSymbols:
+    """Each LayerConfig subclass binds the correct hybrid-allocation symbol."""
+
+    def test_symbol_assignments(self):
+        assert MambaLayerConfig.SYMBOL == Symbols.MAMBA
+        assert GDNLayerConfig.SYMBOL == Symbols.GDN
+        assert AttentionLayerConfig.SYMBOL == Symbols.ATTENTION
+        assert DSALayerConfig.SYMBOL == Symbols.DS_ATTENTION
+        assert MLPLayerConfig.SYMBOL == Symbols.MLP
+        assert MoELayerConfig.SYMBOL == Symbols.MOE
+
+    def test_symbols_are_valid(self):
+        for cls in (
+            MambaLayerConfig,
+            GDNLayerConfig,
+            AttentionLayerConfig,
+            DSALayerConfig,
+            MLPLayerConfig,
+            MoELayerConfig,
+        ):
+            assert cls.SYMBOL in Symbols.VALID_LAYERS
+
+    def test_mlp_layer_compiles_and_emits_dash_symbol(self):
+        """The recipe-DSL ``MLPLayerConfig`` produces the same ``-`` symbol
+        the legacy string DSL writes, and yields a per-layer TC with the
+        author-specified ``ffn_hidden_size``. This proves the MLP path is
+        not dead code in the recipe pipeline."""
+        common = _make_common()
+        emb = EmbeddingLayerConfig(common_config=common, vocab_size=32, max_sequence_length=8)
+        m = MambaLayerConfig(common_config=common)
+        mlp = MLPLayerConfig(common_config=common, ffn_hidden_size=192)
+        loss = CrossEntropyLayerConfig()
+        compiled = HybridModelConfig(
+            common_config=common, layer_pattern=[emb, m, mlp, loss]
+        )._lower()
+        assert compiled.layer_type_list == [Symbols.MAMBA, Symbols.MLP]
+        assert compiled.layer_config_list[1].ffn_hidden_size == 192
+
+    def test_gdn_layer_compiles_and_emits_g_symbol(self):
+        """The recipe-DSL ``GDNLayerConfig`` produces the same ``G`` symbol
+        the legacy string DSL writes, and yields a per-layer TC carrying
+        the author-specified attention-head count. This proves the GDN
+        path is not dead code in the recipe pipeline."""
+        common = _make_common()
+        emb = EmbeddingLayerConfig(common_config=common, vocab_size=32, max_sequence_length=8)
+        g = GDNLayerConfig(common_config=common, num_attention_heads=8)
+        loss = CrossEntropyLayerConfig()
+        compiled = _lower(HybridModelConfig(common_config=common, layer_pattern=[emb, g, loss]))
+        assert compiled.layer_type_list == [Symbols.GDN]
+        assert compiled.layer_config_list[0].num_attention_heads == 8
+
+
+@pytest.mark.internal
+class TestLayerConfigToTransformerConfig:
+
+    def test_mamba_layer_config(self):
+        common = _make_common()
+        layer = MambaLayerConfig(common_config=common, head_dim=64, state_size=128, num_groups=8)
+        tc = layer.to_transformer_config(num_layers=4)
+        assert tc.mamba_head_dim == 64
+        assert tc.mamba_state_dim == 128
+        assert tc.mamba_num_groups == 8
+        assert tc.num_layers == 4
+
+    def test_attention_layer_config(self):
+        common = _make_common()
+        layer = AttentionLayerConfig(common_config=common, num_attention_heads=32)
+        tc = layer.to_transformer_config(num_layers=4)
+        assert tc.num_attention_heads == 32
+        # num_query_groups auto-derived to num_attention_heads when not set.
+        assert tc.num_query_groups == 32
+        # kv_channels auto-derived to hidden_size // num_attention_heads.
+        assert tc.kv_channels == common.hidden_size // 32
+        assert tc.num_layers == 4
+
+    def test_moe_layer_config(self):
+        common = _make_common()
+        layer = MoELayerConfig(common_config=common, num_experts=8, top_k=2)
+        tc = layer.to_transformer_config(num_layers=4)
+        assert tc.num_moe_experts == 8
+        assert tc.moe_router_topk == 2
+        assert tc.num_layers == 4
+
+
+@pytest.mark.internal
+class TestFlatten:
+
+    def test_flat_with_repeat_block(self):
+        common = _make_common()
+        m = MambaLayerConfig(common_config=common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        e = MoELayerConfig(common_config=common, num_experts=4, top_k=2)
+        # [Mamba, [Att, MoE] * 3] → length 1 + 2*3 = 7
+        result = flatten_decoder_pattern([m, [a, e] * 3])
+        assert len(result) == 7
+        assert result == [m, a, e, a, e, a, e]
+
+    def test_tuples_treated_as_lists(self):
+        common = _make_common()
+        m = MambaLayerConfig(common_config=common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        result = flatten_decoder_pattern([m, (a, m)])
+        assert result == [m, a, m]
+
+    def test_non_layerconfig_leaf_rejected(self):
+        common = _make_common()
+        m = MambaLayerConfig(common_config=common)
+        with pytest.raises(TypeError, match="path"):
+            flatten_decoder_pattern([m, "M", m])
+
+    def test_embedding_in_body_rejected(self):
+        common = _make_common()
+        m = MambaLayerConfig(common_config=common)
+        emb = EmbeddingLayerConfig(common_config=common)
+        with pytest.raises(TypeError, match="start/end"):
+            flatten_decoder_pattern([m, emb, m])
+
+    def test_loss_in_body_rejected(self):
+        common = _make_common()
+        m = MambaLayerConfig(common_config=common)
+        loss = CrossEntropyLayerConfig()
+        with pytest.raises(TypeError, match="start/end"):
+            flatten_decoder_pattern([m, loss, m])
+
+
+@pytest.mark.internal
+class TestHybridModelConfigLowering:
+
+    def _embedding(self, common, **overrides):
+        kwargs = dict(
+            common_config=common,
+            vocab_size=32000,
+            max_sequence_length=2048,
+            position_embedding_type="rope",
+        )
+        kwargs.update(overrides)
+        return EmbeddingLayerConfig(**kwargs)
+
+    def test_lower_returns_stack_tc_and_per_layer_tcs(self):
+        common = _make_common()
+        emb = self._embedding(common)
+        m = MambaLayerConfig(common_config=common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        loss = CrossEntropyLayerConfig()
+        recipe = HybridModelConfig(common_config=common, layer_pattern=[emb, m, a, m, a, loss])
+        compiled = _lower(recipe)
+        # The lowering produces the stack TC, per-layer symbol list, and
+        # per-layer TC list — exactly what HybridModel needs in addition to
+        # what it reads directly from the recipe's markers.
+        assert compiled.layer_type_list == ["M", "*", "M", "*"]
+        assert len(compiled.layer_config_list) == 4
+        # Marker-derived fields are NOT in the lowering output any more —
+        # they're read directly from the recipe at the call site.
+        assert recipe.embedding_marker.vocab_size == 32000
+        assert recipe.embedding_marker.max_sequence_length == 2048
+        assert recipe.embedding_marker.position_embedding_type == "rope"
+        # Default untie=False → share=True at the call site.
+        assert recipe.untie_embeddings_and_output_weights is False
+        assert recipe.num_layers == 4
+
+    def test_recipe_topology_defaults_to_none(self):
+        """``HybridModelConfig`` topology fields default to ``None`` — the
+        launcher's args projection reads these directly off the recipe to
+        decide whether to overwrite a CLI flag, so the default is part of
+        the public contract."""
+        common = _make_common()
+        emb = self._embedding(common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        loss = CrossEntropyLayerConfig()
+        recipe = HybridModelConfig(common_config=common, layer_pattern=[emb, a, loss])
+        assert recipe.tensor_model_parallel_size is None
+        assert recipe.context_parallel_size is None
+        assert recipe.expert_model_parallel_size is None
+        assert recipe.expert_tensor_parallel_size is None
+
+    def test_lower_substitutes_concrete_topology_into_stack_tc(self):
+        """When the recipe leaves topology unset, ``_lower`` substitutes
+        TC defaults (1 / TP) into the stack TC and per-layer TCs because
+        ``TransformerConfig`` cannot accept ``None`` for those fields. The
+        ``None``-ness on the recipe itself (verified above) is what the
+        launcher reads — the substituted concrete value is purely an
+        implementation detail of the current TC backend."""
+        common = _make_common()
+        emb = self._embedding(common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        loss = CrossEntropyLayerConfig()
+        compiled = _lower(HybridModelConfig(common_config=common, layer_pattern=[emb, a, loss]))
+        assert compiled.config.tensor_model_parallel_size == 1
+
+    def test_recipe_topology_pin_propagates_through_lowering(self):
+        """When the recipe pins a topology field, the recipe itself carries
+        the pin (for the launcher) and the lowering's stack TC carries it
+        too (for downstream TC consumers)."""
+        common = _make_common()
+        emb = self._embedding(common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        loss = CrossEntropyLayerConfig()
+        recipe = HybridModelConfig(
+            common_config=common,
+            layer_pattern=[emb, a, loss],
+            tensor_model_parallel_size=4,
+            context_parallel_size=2,
+        )
+        assert recipe.tensor_model_parallel_size == 4
+        assert recipe.context_parallel_size == 2
+        assert recipe.expert_model_parallel_size is None
+        assert recipe.expert_tensor_parallel_size is None
+        compiled = _lower(recipe)
+        assert compiled.config.tensor_model_parallel_size == 4
+        assert compiled.config.context_parallel_size == 2
+
+    def test_common_config_auto_inherited_into_layers_without_explicit_common(self):
+        """A recipe author who omits ``common_config=common`` on a layer
+        should still get the recipe's common_config injected — otherwise the
+        layer compiles with ``hidden_size=0`` and silently produces an
+        invalid model."""
+        common = _make_common()
+        emb = EmbeddingLayerConfig(
+            vocab_size=1024, max_sequence_length=512, position_embedding_type="rope"
+        )
+        m = MambaLayerConfig()  # No common_config — should auto-inherit.
+        a = AttentionLayerConfig(num_attention_heads=4)  # Same.
+        loss = CrossEntropyLayerConfig()
+        compiled = _lower(HybridModelConfig(common_config=common, layer_pattern=[emb, m, a, loss]))
+        # All per-layer TCs see the recipe's hidden_size, not 0.
+        for tc in compiled.layer_config_list:
+            assert tc.hidden_size == common.hidden_size
+
+    def test_common_config_explicit_override_preserved(self):
+        """An explicit non-default ``common_config`` on a layer wins over
+        the auto-inherit path — auto-inherit only fills in defaults."""
+        common = _make_common(hidden_size=256)
+        other_common = _make_common(hidden_size=512)
+        emb = self._embedding(common)
+        # Layer carries an explicit, non-default common_config.
+        m = MambaLayerConfig(common_config=other_common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        loss = CrossEntropyLayerConfig()
+        compiled = _lower(HybridModelConfig(common_config=common, layer_pattern=[emb, m, a, loss]))
+        # Mamba layer (idx 0) keeps its explicit hidden_size=512.
+        assert compiled.layer_config_list[0].hidden_size == 512
+        # Attention layer (idx 1) uses the recipe common's 256.
+        assert compiled.layer_config_list[1].hidden_size == 256
+
+    def test_lower_infers_uniform_attention_metadata(self):
+        common = _make_common()
+        emb = self._embedding(common)
+        m = MambaLayerConfig(common_config=common)
+        a = AttentionLayerConfig(
+            common_config=common, num_attention_heads=8, num_query_groups=2, kv_channels=16
+        )
+        loss = CrossEntropyLayerConfig()
+        recipe = HybridModelConfig(
+            common_config=common, layer_pattern=[emb, m, a, m, loss], tensor_model_parallel_size=2
+        )
+
+        compiled = _lower(recipe)
+        assert compiled.config.num_attention_heads == 8
+        assert compiled.config.num_query_groups == 2
+        assert compiled.config.kv_channels == 16
+        # The Mamba layer still lowers to TransformerConfig today, but the
+        # recipe author does not have to pass attention fields through
+        # CommonLayerConfig.extra just to satisfy TransformerConfig invariants.
+        mamba_tc = compiled.layer_config_list[0]
+        assert mamba_tc.num_attention_heads == 8
+        assert mamba_tc.num_query_groups == 2
+        assert mamba_tc.kv_channels == 16
+
+    def test_untie_disables_sharing(self):
+        common = _make_common()
+        emb = self._embedding(common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        loss = CrossEntropyLayerConfig()
+        recipe = HybridModelConfig(
+            common_config=common,
+            layer_pattern=[emb, a, loss],
+            untie_embeddings_and_output_weights=True,
+        )
+        # ``untie_embeddings_and_output_weights`` is a recipe-level field;
+        # callers (HybridModel.__init__, the launcher) read it directly off
+        # the recipe rather than going through ``_lower``.
+        _lower(recipe)  # smoke-test: lowering succeeds with this setting.
+        assert recipe.untie_embeddings_and_output_weights is True
+
+    def test_missing_embedding_raises(self):
+        common = _make_common()
+        m = MambaLayerConfig(common_config=common)
+        loss = CrossEntropyLayerConfig()
+        recipe = HybridModelConfig(common_config=common, layer_pattern=[m, loss])
+        with pytest.raises(TypeError, match="EmbeddingLayerConfig"):
+            recipe._lower()
+
+    def test_missing_loss_raises(self):
+        common = _make_common()
+        emb = self._embedding(common)
+        m = MambaLayerConfig(common_config=common)
+        recipe = HybridModelConfig(common_config=common, layer_pattern=[emb, m])
+        with pytest.raises(TypeError, match="CrossEntropyLayerConfig"):
+            recipe._lower()
+
+    def test_no_decoder_layers_raises(self):
+        common = _make_common()
+        emb = self._embedding(common)
+        loss = CrossEntropyLayerConfig()
+        recipe = HybridModelConfig(common_config=common, layer_pattern=[emb, loss])
+        with pytest.raises(ValueError, match="no decoder layers"):
+            recipe._lower()
+
+    def test_attention_dsa_mix_rejected(self):
+        common = _make_common()
+        emb = self._embedding(common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        d = DSALayerConfig(common_config=common, num_attention_heads=4)
+        loss = CrossEntropyLayerConfig()
+        recipe = HybridModelConfig(common_config=common, layer_pattern=[emb, a, d, loss])
+        with pytest.raises(ValueError, match="Attention.*MLA/DSA|MLA/DSA.*Attention"):
+            recipe._lower()
+
+    def test_dsa_recipe_promotes_multi_latent_attention_to_stack(self):
+        """DSA / MLA layers use their own decoupled RoPE.
+        ``HybridModel.__init__`` skips global RoPE construction when
+        ``self.config.multi_latent_attention`` (stack TC) is True. Compile
+        must promote the flag whenever the decoder contains any DSA layer."""
+        common = _make_common()
+        emb = self._embedding(common)
+        d = DSALayerConfig(common_config=common, num_attention_heads=4)
+        loss = CrossEntropyLayerConfig()
+        compiled = _lower(HybridModelConfig(common_config=common, layer_pattern=[emb, d, loss]))
+        assert compiled.config.multi_latent_attention is True
+
+    def test_no_dsa_layers_keeps_multi_latent_attention_default(self):
+        """A recipe without DSA must not flip the stack-level flag — that
+        would silently disable global RoPE construction for ordinary
+        Attention layers."""
+        common = _make_common()
+        emb = self._embedding(common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        loss = CrossEntropyLayerConfig()
+        compiled = _lower(HybridModelConfig(common_config=common, layer_pattern=[emb, a, loss]))
+        assert compiled.config.multi_latent_attention is False
+
+    def test_heterogeneous_attention_under_rope_rejected(self):
+        """Two attention layers with different ``num_attention_heads`` under
+        RoPE produce a single global rotary sized for a placeholder; the
+        layer with the non-matching head count would hit shape mismatches
+        at runtime. Reject at compile time until per-layer rotary lands."""
+        common = _make_common()
+        emb = self._embedding(common, position_embedding_type="rope")
+        a1 = AttentionLayerConfig(common_config=common, num_attention_heads=8)
+        a2 = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        loss = CrossEntropyLayerConfig()
+        recipe = HybridModelConfig(common_config=common, layer_pattern=[emb, a1, a2, loss])
+        with pytest.raises(NotImplementedError, match="[Hh]eterogeneous attention geometry"):
+            recipe._lower()
+
+    def test_heterogeneous_attention_under_none_position_embedding_allowed(self):
+        """Without RoPE/YARN, no global rotary is built — heterogeneous
+        attention geometry is fine."""
+        common = _make_common()
+        emb = self._embedding(common, position_embedding_type="none")
+        a1 = AttentionLayerConfig(common_config=common, num_attention_heads=8)
+        a2 = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        loss = CrossEntropyLayerConfig()
+        compiled = HybridModelConfig(
+            common_config=common, layer_pattern=[emb, a1, a2, loss]
+        )._lower()
+        assert compiled.layer_config_list[0].num_attention_heads == 8
+        assert compiled.layer_config_list[1].num_attention_heads == 4
+
+
+@pytest.mark.internal
+class TestHeterogeneousMoE:
+    """Two distinct MoELayerConfig instances in one recipe must produce two
+    per-layer TransformerConfigs whose MoE fields actually differ. This is
+    the headline DSL capability the legacy single-character pattern can't
+    express."""
+
+    def _embedding(self, common):
+        return EmbeddingLayerConfig(
+            common_config=common,
+            vocab_size=1024,
+            max_sequence_length=512,
+            position_embedding_type="rope",
+        )
+
+    def test_two_moe_configs_produce_distinct_tcs(self):
+        common = _make_common()
+        emb = self._embedding(common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        dense = MoELayerConfig(common_config=common, num_experts=8, top_k=4, ffn_hidden_size=256)
+        sparse = MoELayerConfig(common_config=common, num_experts=4, top_k=2, ffn_hidden_size=128)
+        loss = CrossEntropyLayerConfig()
+        # Pattern: [emb, a, dense, a, sparse, loss] — 4 decoder layers, 2 MoE.
+        # Heterogeneous MoE requires explicit stack-TC pins.
+        compiled = HybridModelConfig(
+            common_config=common,
+            layer_pattern=[emb, a, dense, a, sparse, loss],
+            tensor_model_parallel_size=2,
+            expert_model_parallel_size=2,
+            expert_tensor_parallel_size=1,
+            stack_moe_num_experts=8,
+            stack_moe_ffn_hidden_size=256,
+        )._lower()
+        tcs = compiled.layer_config_list
+        # Decoder indices: 0=att, 1=dense MoE, 2=att, 3=sparse MoE.
+        dense_tc, sparse_tc = tcs[1], tcs[3]
+        assert dense_tc.num_moe_experts == 8 and sparse_tc.num_moe_experts == 4
+        assert dense_tc.moe_router_topk == 4 and sparse_tc.moe_router_topk == 2
+        assert dense_tc.moe_ffn_hidden_size == 256 and sparse_tc.moe_ffn_hidden_size == 128
+        # And the two are not the same Python object (no aliasing).
+        assert dense_tc is not sparse_tc
+
+    def test_two_moe_configs_share_global_ep(self):
+        """EP is a model-wide topology fact — both MoE TCs must agree on it
+        regardless of any per-layer-config differences."""
+        common = _make_common()
+        emb = self._embedding(common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        dense = MoELayerConfig(common_config=common, num_experts=8, top_k=2)
+        sparse = MoELayerConfig(common_config=common, num_experts=4, top_k=2)
+        loss = CrossEntropyLayerConfig()
+        compiled = HybridModelConfig(
+            common_config=common,
+            layer_pattern=[emb, a, dense, a, sparse, loss],
+            tensor_model_parallel_size=2,
+            expert_model_parallel_size=2,
+            expert_tensor_parallel_size=1,
+            stack_moe_num_experts=8,
+        )._lower()
+        dense_tc, sparse_tc = compiled.layer_config_list[1], compiled.layer_config_list[3]
+        assert dense_tc.expert_model_parallel_size == 2
+        assert sparse_tc.expert_model_parallel_size == 2
+
+    def test_non_moe_tcs_carry_no_expert_parallelism(self):
+        """The other half of the EP-only-on-MoE invariant: non-MoE TCs in a
+        heterogeneous-MoE recipe default to EP=1 and ``num_moe_experts=None``,
+        which is what the runtime layer construction actually consumes."""
+        common = _make_common()
+        emb = self._embedding(common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        dense = MoELayerConfig(common_config=common, num_experts=8, top_k=2)
+        sparse = MoELayerConfig(common_config=common, num_experts=4, top_k=2)
+        loss = CrossEntropyLayerConfig()
+        compiled = HybridModelConfig(
+            common_config=common,
+            layer_pattern=[emb, a, dense, a, sparse, loss],
+            tensor_model_parallel_size=2,
+            expert_model_parallel_size=2,
+            expert_tensor_parallel_size=1,
+            stack_moe_num_experts=8,
+        )._lower()
+        # Indices 0 and 2 are attention layers in the pattern above.
+        att_tc_0, att_tc_2 = compiled.layer_config_list[0], compiled.layer_config_list[2]
+        for tc in (att_tc_0, att_tc_2):
+            assert tc.expert_model_parallel_size == 1
+            assert tc.num_moe_experts is None
+
+    def test_homogeneous_moe_stack_num_experts_matches_recipe(self):
+        """Stack TC's ``num_moe_experts`` reflects the recipe's actual MoE
+        configuration — not a magic placeholder. MTP block construction and
+        inference capacity sizing both read this value semantically."""
+        common = _make_common()
+        emb = self._embedding(common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        moe = MoELayerConfig(
+            common_config=common,
+            num_experts=128,
+            top_k=6,
+            router_score_function="sigmoid",
+            router_topk_scaling_factor=2.5,
+        )
+        loss = CrossEntropyLayerConfig()
+        compiled = HybridModelConfig(
+            common_config=common,
+            layer_pattern=[emb, a, moe, a, moe, loss],
+            tensor_model_parallel_size=2,
+            expert_model_parallel_size=2,
+            expert_tensor_parallel_size=1,
+        )._lower()
+        assert compiled.config.num_moe_experts == 128
+        assert compiled.config.moe_router_topk == 6
+        assert compiled.config.moe_router_score_function == "sigmoid"
+        assert compiled.config.moe_router_topk_scaling_factor == 2.5
+
+    def test_heterogeneous_moe_without_override_raises(self):
+        """Heterogeneous MoE without an explicit ``stack_moe_num_experts``
+        pin is rejected: the stack TC is read by MTP and the inference
+        capacity-factor calc, and silently picking a value that matches
+        no actual layer would mislead both consumers."""
+        common = _make_common()
+        emb = self._embedding(common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        dense = MoELayerConfig(common_config=common, num_experts=128, top_k=2)
+        sparse = MoELayerConfig(common_config=common, num_experts=64, top_k=2)
+        loss = CrossEntropyLayerConfig()
+        recipe = HybridModelConfig(
+            common_config=common,
+            layer_pattern=[emb, a, dense, a, sparse, loss],
+            tensor_model_parallel_size=2,
+            expert_model_parallel_size=2,
+            expert_tensor_parallel_size=1,
+        )
+        with pytest.raises(ValueError, match="stack_moe_num_experts"):
+            recipe._lower()
+
+    def test_heterogeneous_moe_with_override_uses_pinned_num_experts(self):
+        """An explicit ``stack_moe_num_experts`` pins the stack-TC value
+        for MTP / inference consumers in a heterogeneous-MoE recipe."""
+        common = _make_common()
+        emb = self._embedding(common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        dense = MoELayerConfig(common_config=common, num_experts=128, top_k=2)
+        sparse = MoELayerConfig(common_config=common, num_experts=64, top_k=2)
+        loss = CrossEntropyLayerConfig()
+        compiled = HybridModelConfig(
+            common_config=common,
+            layer_pattern=[emb, a, dense, a, sparse, loss],
+            tensor_model_parallel_size=2,
+            expert_model_parallel_size=2,
+            expert_tensor_parallel_size=1,
+            stack_moe_num_experts=128,
+        )._lower()
+        assert compiled.config.num_moe_experts == 128
+
+    def test_heterogeneous_moe_ffn_hidden_size_requires_override(self):
+        """Same rule for ``moe_ffn_hidden_size``: heterogeneous values
+        require an explicit pin."""
+        common = _make_common()
+        emb = self._embedding(common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        wide = MoELayerConfig(common_config=common, num_experts=128, top_k=2, ffn_hidden_size=1024)
+        narrow = MoELayerConfig(common_config=common, num_experts=128, top_k=2, ffn_hidden_size=512)
+        loss = CrossEntropyLayerConfig()
+        recipe = HybridModelConfig(
+            common_config=common,
+            layer_pattern=[emb, a, wide, a, narrow, loss],
+            tensor_model_parallel_size=2,
+            expert_model_parallel_size=2,
+            expert_tensor_parallel_size=1,
+        )
+        with pytest.raises(ValueError, match="stack_moe_ffn_hidden_size"):
+            recipe._lower()
+        # With both overrides set, compile succeeds with the pinned values.
+        recipe.stack_moe_ffn_hidden_size = 1024
+        compiled = _lower(recipe)
+        assert compiled.config.num_moe_experts == 128
+        assert compiled.config.moe_ffn_hidden_size == 1024
+
+    def test_no_moe_no_ep_keeps_num_experts_none(self):
+        """A dense recipe (no MoE, EP=1) must leave ``num_moe_experts``
+        unset on the stack TC — TC defaults take over."""
+        common = _make_common()
+        emb = self._embedding(common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        loss = CrossEntropyLayerConfig()
+        compiled = _lower(HybridModelConfig(common_config=common, layer_pattern=[emb, a, loss]))
+        assert compiled.config.num_moe_experts is None
+
+    def test_ep_gt_1_without_moe_layers_rejected(self):
+        """Setting ``expert_model_parallel_size > 1`` without any MoE layer
+        is a recipe misconfiguration — surface it loudly rather than
+        silently filling in a placeholder."""
+        common = _make_common()
+        emb = self._embedding(common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        loss = CrossEntropyLayerConfig()
+        recipe = HybridModelConfig(
+            common_config=common,
+            layer_pattern=[emb, a, loss],
+            tensor_model_parallel_size=2,
+            expert_model_parallel_size=2,
+            expert_tensor_parallel_size=1,
+        )
+        with pytest.raises(ValueError, match="requires at least one MoELayerConfig"):
+            recipe._lower()
+
+
+@pytest.mark.internal
+class TestExtraPassthrough:
+    """Every config exposes an ``extra: dict`` escape hatch for any
+    TransformerConfig field not in the curated DSL surface."""
+
+    def _embedding(self, common, **kwargs):
+        base = dict(
+            common_config=common,
+            vocab_size=32000,
+            max_sequence_length=2048,
+            position_embedding_type="rope",
+        )
+        base.update(kwargs)
+        return EmbeddingLayerConfig(**base)
+
+    def test_common_extra_propagates_to_layer_tc(self):
+        # qk_layernorm is a real TransformerConfig field but isn't curated
+        # on CommonLayerConfig — the passthrough should set it.
+        common = _make_common(extra={"qk_layernorm": True})
+        layer = MambaLayerConfig(common_config=common)
+        tc = layer.to_transformer_config(num_layers=2)
+        assert tc.qk_layernorm is True
+
+    def test_layer_extra_overrides_common_extra(self):
+        common = _make_common(extra={"qk_layernorm": False})
+        layer = AttentionLayerConfig(
+            common_config=common, num_attention_heads=4, extra={"qk_layernorm": True}
+        )
+        tc = layer.to_transformer_config(num_layers=2)
+        assert tc.qk_layernorm is True
+
+    def test_common_extra_unknown_field_raises(self):
+        common = _make_common(extra={"definitely_not_a_real_tc_field": 7})
+        with pytest.raises(ValueError, match="not TransformerConfig fields"):
+            common.to_transformer_config_kwargs()
+
+    def test_layer_extra_unknown_field_raises(self):
+        common = _make_common()
+        layer = MambaLayerConfig(common_config=common, extra={"another_typo_field": 1.0})
+        with pytest.raises(ValueError, match="MambaLayerConfig.extra"):
+            layer.to_transformer_config(num_layers=2)
+
+    def test_extra_validation_can_target_mla_transformer_config(self):
+        """The low-level escape-hatch validator can target a TC subclass, so
+        MLATransformerConfig-only fields are not rejected as typos."""
+        validate_extra_kwargs(
+            {"mla_down_proj_fusion": True}, "DSALayerConfig.extra", MLATransformerConfig
+        )
+
+    def test_layer_extra_cannot_shadow_parallelism(self):
+        """Per-layer ``extra`` cannot override model-wide topology fields —
+        process groups are global and a per-layer disagreement would be
+        invalid sharding."""
+        common = _make_common()
+        a = AttentionLayerConfig(
+            common_config=common,
+            num_attention_heads=4,
+            extra={"tensor_model_parallel_size": 8},  # Conflicts with TP=2 below.
+        )
+        emb = self._embedding(common)
+        loss = CrossEntropyLayerConfig()
+        recipe = HybridModelConfig(
+            common_config=common, layer_pattern=[emb, a, loss], tensor_model_parallel_size=2
+        )
+        with pytest.raises(ValueError, match="tensor_model_parallel_size"):
+            recipe._lower()
+
+    def test_embedding_extra_propagates_to_stack_tc(self):
+        common = _make_common()
+        emb = self._embedding(common, extra={"qk_layernorm": True})
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        loss = CrossEntropyLayerConfig()
+        compiled = _lower(HybridModelConfig(common_config=common, layer_pattern=[emb, a, loss]))
+        assert compiled.config.qk_layernorm is True
+
+    def test_loss_extra_propagates_to_stack_tc(self):
+        common = _make_common()
+        emb = self._embedding(common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        loss = CrossEntropyLayerConfig(extra={"qk_layernorm": True})
+        compiled = _lower(HybridModelConfig(common_config=common, layer_pattern=[emb, a, loss]))
+        assert compiled.config.qk_layernorm is True
+
+    def test_embedding_extra_unknown_field_raises(self):
+        common = _make_common()
+        emb = self._embedding(common, extra={"made_up_field": 1})
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        loss = CrossEntropyLayerConfig()
+        with pytest.raises(ValueError, match="EmbeddingLayerConfig.extra"):
+            HybridModelConfig(common_config=common, layer_pattern=[emb, a, loss])._lower()
+
+    def test_loss_extra_cannot_shadow_curated_field(self):
+        """``CrossEntropyLayerConfig.extra`` may not name a curated field that
+        the marker already exposes (e.g. ``loss_fusion``). Such an entry would
+        silently override the marker's value otherwise."""
+        common = _make_common()
+        emb = self._embedding(common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        loss = CrossEntropyLayerConfig(loss_fusion=True, extra={"cross_entropy_loss_fusion": False})
+        with pytest.raises(ValueError, match="cross_entropy_loss_fusion"):
+            HybridModelConfig(common_config=common, layer_pattern=[emb, a, loss])._lower()
+
+    def test_common_extra_cannot_shadow_curated_field(self):
+        """Same shadowing rule across all four ``extra`` sites: ``extra`` may
+        not name a curated dataclass field on the same config."""
+        common = _make_common(extra={"hidden_size": 999})
+        with pytest.raises(ValueError, match="hidden_size"):
+            common.to_transformer_config_kwargs()
+
+    def test_common_extra_cannot_shadow_curated_transformer_config_key(self):
+        """Curated fields may lower to differently named TC fields; those
+        lowered names are reserved too. ``mixed_precision_dtype`` owns
+        ``bf16`` / ``fp16``."""
+        common = _make_common(mixed_precision_dtype=torch.bfloat16, extra={"bf16": False})
+        with pytest.raises(ValueError, match="bf16"):
+            common.to_transformer_config_kwargs()
+
+    def test_layer_extra_cannot_shadow_curated_field(self):
+        common = _make_common()
+        layer = AttentionLayerConfig(
+            common_config=common, num_attention_heads=4, extra={"num_attention_heads": 8}
+        )
+        with pytest.raises(ValueError, match="num_attention_heads"):
+            layer.to_transformer_config(num_layers=2)
+
+    def test_layer_extra_cannot_shadow_curated_transformer_config_key(self):
+        common = _make_common()
+        layer = MoELayerConfig(common_config=common, num_experts=8, extra={"num_moe_experts": 4})
+        with pytest.raises(ValueError, match="num_moe_experts"):
+            layer.to_transformer_config(num_layers=2)
+
+    def test_embedding_extra_cannot_shadow_curated_field(self):
+        common = _make_common()
+        emb = self._embedding(common, vocab_size=100, extra={"vocab_size": 999})
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        loss = CrossEntropyLayerConfig()
+        with pytest.raises(ValueError, match="vocab_size"):
+            HybridModelConfig(common_config=common, layer_pattern=[emb, a, loss])._lower()
+
+
+@pytest.mark.internal
+class TestYarnEmbedding:
+    """``EmbeddingLayerConfig`` exposes curated YARN fields that
+    :meth:`HybridModelConfig.compile` attaches to the stack-level
+    :class:`TransformerConfig` when ``position_embedding_type == "yarn"``.
+    This mirrors the existing setattr pattern in ``model_builder.py`` and
+    matches the ``getattr`` lookups in :class:`HybridModel.__init__`."""
+
+    def _attention_loss(self, common):
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        return a, CrossEntropyLayerConfig()
+
+    def test_yarn_fields_attached_when_position_embedding_is_yarn(self):
+        common = _make_common()
+        emb = EmbeddingLayerConfig(
+            common_config=common,
+            vocab_size=1024,
+            max_sequence_length=512,
+            position_embedding_type="yarn",
+            yarn={
+                "yarn_rotary_scaling_factor": 32.0,
+                "yarn_original_max_position_embeddings": 131072,
+                "yarn_beta_fast": 32.0,
+                "yarn_beta_slow": 1.0,
+                "yarn_mscale": 1.0,
+                "yarn_mscale_all_dim": 0.0,
+                "yarn_correction_range_round_to_int": True,
+            },
+        )
+        a, loss = self._attention_loss(common)
+        compiled = _lower(HybridModelConfig(common_config=common, layer_pattern=[emb, a, loss]))
+        assert compiled.config.yarn_rotary_scaling_factor == 32.0
+        assert compiled.config.yarn_original_max_position_embeddings == 131072
+        assert compiled.config.yarn_beta_fast == 32.0
+        assert compiled.config.yarn_beta_slow == 1.0
+        assert compiled.config.yarn_mscale == 1.0
+        assert compiled.config.yarn_mscale_all_dim == 0.0
+        assert compiled.config.yarn_correction_range_round_to_int is True
+
+    def test_yarn_fields_not_attached_when_position_embedding_is_rope(self):
+        """When ``position_embedding_type != "yarn"``, the yarn block is
+        silently unused — a no-op rather than an error so a recipe author
+        can toggle the embedding type without removing the yarn block."""
+        common = _make_common()
+        emb = EmbeddingLayerConfig(
+            common_config=common,
+            vocab_size=1024,
+            max_sequence_length=512,
+            position_embedding_type="rope",
+            yarn={"yarn_rotary_scaling_factor": 32.0},
+        )
+        a, loss = self._attention_loss(common)
+        compiled = _lower(HybridModelConfig(common_config=common, layer_pattern=[emb, a, loss]))
+        assert not hasattr(compiled.config, "yarn_rotary_scaling_factor")
+
+    def test_yarn_partial_dict_only_stamps_provided_keys(self):
+        """A partial yarn dict stamps only the keys the recipe author
+        provided; absent keys are not stamped, so missing-required-attribute
+        bugs in HybridModel.__init__ surface clearly via AttributeError."""
+        common = _make_common()
+        emb = EmbeddingLayerConfig(
+            common_config=common,
+            vocab_size=1024,
+            max_sequence_length=512,
+            position_embedding_type="yarn",
+            yarn={"yarn_rotary_scaling_factor": 32.0},
+        )
+        a, loss = self._attention_loss(common)
+        compiled = _lower(HybridModelConfig(common_config=common, layer_pattern=[emb, a, loss]))
+        assert compiled.config.yarn_rotary_scaling_factor == 32.0
+        assert not hasattr(compiled.config, "yarn_beta_fast")
+
+    def test_yarn_unknown_key_rejected(self):
+        """Typos in the yarn dict raise at compile time."""
+        common = _make_common()
+        emb = EmbeddingLayerConfig(
+            common_config=common,
+            vocab_size=1024,
+            max_sequence_length=512,
+            position_embedding_type="yarn",
+            yarn={"yarn_typo_field": 1.0},
+        )
+        a, loss = self._attention_loss(common)
+        recipe = HybridModelConfig(common_config=common, layer_pattern=[emb, a, loss])
+        with pytest.raises(ValueError, match="unknown keys"):
+            recipe._lower()
+
+
+@pytest.mark.internal
+class TestNumLayersDerived:
+    """The recipe author never sets num_layers; compile derives it."""
+
+    def test_num_layers_from_flattened_count(self):
+        common = _make_common()
+        # The recipe author never sets num_layers anywhere; CommonLayerConfig
+        # does not even have a num_layers field.
+        assert not hasattr(common, "num_layers")
+        emb = EmbeddingLayerConfig(
+            common_config=common,
+            vocab_size=32000,
+            max_sequence_length=2048,
+            position_embedding_type="rope",
+        )
+        m = MambaLayerConfig(common_config=common)
+        a = AttentionLayerConfig(common_config=common, num_attention_heads=4)
+        loss = CrossEntropyLayerConfig()
+        # 5 decoder layers.
+        recipe = HybridModelConfig(common_config=common, layer_pattern=[emb, m, a, m, a, m, loss])
+        compiled = _lower(recipe)
+        assert len(compiled.layer_config_list) == 5
+        for tc in compiled.layer_config_list:
+            assert tc.num_layers == 5

--- a/tests/unit_tests/models/hybrid/test_layer_pattern.py
+++ b/tests/unit_tests/models/hybrid/test_layer_pattern.py
@@ -152,10 +152,7 @@ class TestCommonLayerConfig:
         """An explicit ``params_dtype`` from the recipe author wins over the
         auto-derive. Useful when a recipe wants bf16 mixed precision but
         keeps params in fp32 (e.g. for fp32 master-weight workflows)."""
-        common = _make_common(
-            mixed_precision_dtype=torch.bfloat16,
-            params_dtype=torch.float16,
-        )
+        common = _make_common(mixed_precision_dtype=torch.bfloat16, params_dtype=torch.float16)
         layer = MambaLayerConfig(common_config=common, head_dim=64, state_size=128, num_groups=8)
         tc = layer.to_transformer_config(num_layers=4)
         assert tc.params_dtype == torch.float16

--- a/tests/unit_tests/models/hybrid/test_load_recipe.py
+++ b/tests/unit_tests/models/hybrid/test_load_recipe.py
@@ -1,0 +1,354 @@
+# Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Unit tests for the recipe loader behind the ``--model-recipe`` flag.
+
+The loader accepts three spec forms (see :func:`load_recipe`):
+
+1. Dotted Python path (``foo.bar``)
+2. Dotted path with explicit function selection (``foo.bar:func_name``)
+3. Filesystem path to a ``.py`` file (with optional ``:func`` suffix)
+
+When ``:func`` is omitted, the loader calls the module's ``make_recipe()``
+function. These tests use synthetic in-memory modules for dotted-path loading
+and temporary files for filesystem-path loading.
+"""
+
+import sys
+import textwrap
+import types
+from pathlib import Path
+
+import pytest
+
+from megatron.core.models.hybrid.common_layer_config import CommonLayerConfig
+from megatron.core.models.hybrid.layer_configs import (
+    AttentionLayerConfig,
+    CrossEntropyLayerConfig,
+    EmbeddingLayerConfig,
+    MambaLayerConfig,
+)
+from megatron.core.models.hybrid.layer_pattern import RECIPE_ENTRY_POINT, load_recipe
+from megatron.training.models.hybrid import HybridModelConfig
+
+
+def _make_common(**overrides) -> CommonLayerConfig:
+    base = dict(hidden_size=128, use_cpu_initialization=True)
+    base.update(overrides)
+    return CommonLayerConfig(**base)
+
+
+def _make_valid_pattern(common):
+    return [
+        EmbeddingLayerConfig(
+            common_config=common,
+            vocab_size=1024,
+            max_sequence_length=512,
+            position_embedding_type="rope",
+        ),
+        AttentionLayerConfig(common_config=common, num_attention_heads=4),
+        AttentionLayerConfig(common_config=common, num_attention_heads=4),
+        CrossEntropyLayerConfig(),
+    ]
+
+
+def _register_synthetic_module(monkeypatch, name: str, **attrs) -> types.ModuleType:
+    """Build a fresh :class:`types.ModuleType` with the requested attributes
+    and inject into ``sys.modules`` for the test's lifetime."""
+    module = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(module, k, v)
+    monkeypatch.setitem(sys.modules, name, module)
+    return module
+
+
+def test_recipe_entry_point_constant():
+    """The canonical entry-point name is the documented public constant."""
+    assert RECIPE_ENTRY_POINT == "make_recipe"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Resolution form 1 — module:func explicit selection
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.internal
+class TestExplicitFuncSelection:
+
+    def test_module_colon_func_selects_named_function(self, monkeypatch):
+        common = _make_common()
+        recipe = HybridModelConfig(common_config=common, layer_pattern=_make_valid_pattern(common))
+
+        def my_pretrain_recipe() -> HybridModelConfig:
+            return recipe
+
+        # Other (non-recipe) module attrs should be ignored.
+        def helper(x):
+            return x + 1
+
+        _register_synthetic_module(
+            monkeypatch,
+            "tests._explicit_func_recipe",
+            my_pretrain_recipe=my_pretrain_recipe,
+            helper=helper,
+        )
+        loaded = load_recipe("tests._explicit_func_recipe:my_pretrain_recipe")
+        assert isinstance(loaded, HybridModelConfig)
+        assert loaded is recipe
+
+    def test_module_colon_func_missing_function(self, monkeypatch):
+        _register_synthetic_module(monkeypatch, "tests._explicit_func_missing")
+        with pytest.raises(AttributeError, match="missing_func"):
+            load_recipe("tests._explicit_func_missing:missing_func")
+
+    def test_module_colon_func_returning_wrong_type(self, monkeypatch):
+        def bad() -> HybridModelConfig:
+            return 42  # type: ignore[return-value]
+
+        _register_synthetic_module(monkeypatch, "tests._explicit_func_wrong_type", bad=bad)
+        with pytest.raises(TypeError, match="HybridModelConfig"):
+            load_recipe("tests._explicit_func_wrong_type:bad")
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Resolution form 2 — canonical ``make_recipe``
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.internal
+class TestMakeRecipeDefault:
+
+    def test_make_recipe_used_when_no_other_resolution(self, monkeypatch):
+        common = _make_common()
+        recipe = HybridModelConfig(common_config=common, layer_pattern=_make_valid_pattern(common))
+
+        def make_recipe():
+            return recipe
+
+        _register_synthetic_module(
+            monkeypatch, "tests._make_recipe_convention", make_recipe=make_recipe
+        )
+        loaded = load_recipe("tests._make_recipe_convention")
+        assert isinstance(loaded, HybridModelConfig)
+        assert loaded is recipe
+
+    def test_make_recipe_used_even_when_other_functions_exist(self, monkeypatch):
+        common = _make_common()
+        default_recipe = HybridModelConfig(
+            common_config=common,
+            layer_pattern=_make_valid_pattern(common),
+            tensor_model_parallel_size=2,
+        )
+        variant_recipe = HybridModelConfig(
+            common_config=common,
+            layer_pattern=_make_valid_pattern(common),
+            tensor_model_parallel_size=4,
+        )
+
+        def make_recipe() -> HybridModelConfig:
+            return default_recipe
+
+        def debug_recipe() -> HybridModelConfig:
+            return variant_recipe
+
+        _register_synthetic_module(
+            monkeypatch,
+            "tests._make_recipe_default",
+            make_recipe=make_recipe,
+            debug_recipe=debug_recipe,
+        )
+        loaded = load_recipe("tests._make_recipe_default")
+        assert loaded.tensor_model_parallel_size == 2
+        explicit = load_recipe("tests._make_recipe_default:debug_recipe")
+        assert explicit.tensor_model_parallel_size == 4
+
+    def test_make_recipe_must_be_callable(self, monkeypatch):
+        common = _make_common()
+        recipe = HybridModelConfig(common_config=common, layer_pattern=_make_valid_pattern(common))
+        _register_synthetic_module(monkeypatch, "tests._non_callable_recipe", make_recipe=recipe)
+        with pytest.raises(TypeError, match="not callable"):
+            load_recipe("tests._non_callable_recipe")
+
+    def test_module_with_nothing_resolvable_errors(self, monkeypatch):
+        _register_synthetic_module(monkeypatch, "tests._empty_recipe")
+        with pytest.raises(AttributeError, match="no make_recipe"):
+            load_recipe("tests._empty_recipe")
+
+    def test_unimportable_module_raises(self):
+        with pytest.raises(ImportError, match="could not be imported"):
+            load_recipe("definitely.does.not.exist.module")
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Filesystem-path form
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.internal
+class TestFilesystemPath:
+
+    def _write_recipe_file(self, tmp_path: Path, body: str) -> Path:
+        path = tmp_path / "my_recipe.py"
+        path.write_text(textwrap.dedent(body))
+        return path
+
+    def test_file_path_with_make_recipe(self, tmp_path):
+        path = self._write_recipe_file(
+            tmp_path,
+            """
+            from megatron.core.models.hybrid import (
+                AttentionLayerConfig, CommonLayerConfig, CrossEntropyLayerConfig,
+                EmbeddingLayerConfig,
+            )
+            from megatron.training.models.hybrid import HybridModelConfig
+            def make_recipe() -> HybridModelConfig:
+                common = CommonLayerConfig(hidden_size=128, use_cpu_initialization=True)
+                return HybridModelConfig(
+                    common_config=common,
+                    layer_pattern=[
+                        EmbeddingLayerConfig(common_config=common, vocab_size=1024,
+                                             max_sequence_length=512, position_embedding_type="rope"),
+                        AttentionLayerConfig(common_config=common, num_attention_heads=4),
+                        CrossEntropyLayerConfig(),
+                    ],
+                )
+            """,
+        )
+        loaded = load_recipe(str(path))
+        assert isinstance(loaded, HybridModelConfig)
+
+    def test_file_path_with_explicit_func(self, tmp_path):
+        path = self._write_recipe_file(
+            tmp_path,
+            """
+            from megatron.core.models.hybrid import (
+                AttentionLayerConfig, CommonLayerConfig, CrossEntropyLayerConfig,
+                EmbeddingLayerConfig,
+            )
+            from megatron.training.models.hybrid import HybridModelConfig
+            def my_pretrain_config() -> HybridModelConfig:
+                common = CommonLayerConfig(hidden_size=128, use_cpu_initialization=True)
+                return HybridModelConfig(
+                    common_config=common,
+                    layer_pattern=[
+                        EmbeddingLayerConfig(common_config=common, vocab_size=1024,
+                                             max_sequence_length=512, position_embedding_type="rope"),
+                        AttentionLayerConfig(common_config=common, num_attention_heads=4),
+                        CrossEntropyLayerConfig(),
+                    ],
+                )
+            """,
+        )
+        loaded = load_recipe(f"{path}:my_pretrain_config")
+        assert isinstance(loaded, HybridModelConfig)
+
+    def test_file_path_does_not_exist(self, tmp_path):
+        path = tmp_path / "nope.py"
+        with pytest.raises(ImportError, match="does not exist"):
+            load_recipe(str(path))
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Pattern-validation errors surface on first use
+#
+# ``load_recipe`` is now a pure loader — it returns the unmodified
+# :class:`HybridModelConfig`. Pattern-shape validation runs lazily, the
+# first time a consumer queries the recipe (``embedding_marker``,
+# ``flatten_decoder``, lowering inside ``HybridModel.from_recipe``, etc.).
+# That keeps loading cheap and pushes validation to the call site that
+# actually depends on the malformed field.
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.internal
+class TestPatternValidation:
+
+    def test_bad_pattern_validates_on_first_use(self, monkeypatch):
+        common = _make_common()
+        bad = HybridModelConfig(
+            common_config=common,
+            layer_pattern=[MambaLayerConfig(common_config=common), CrossEntropyLayerConfig()],
+        )
+
+        def make_recipe() -> HybridModelConfig:
+            return bad
+
+        _register_synthetic_module(
+            monkeypatch, "tests._bad_pattern_recipe", make_recipe=make_recipe
+        )
+        loaded = load_recipe("tests._bad_pattern_recipe")
+        assert isinstance(loaded, HybridModelConfig)
+        with pytest.raises(TypeError, match="EmbeddingLayerConfig"):
+            loaded.flatten_decoder()
+
+
+def _has_apply_model_recipe_to_args() -> bool:
+    try:
+        from megatron.training.arguments import _apply_model_recipe_to_args  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+@pytest.mark.internal
+@pytest.mark.skipif(
+    not _has_apply_model_recipe_to_args(),
+    reason="--model-recipe argparse adapter lives in the CLI follow-up PR; auto-enables once it lands.",
+)
+class TestRecipeArgProjection:
+    """The launcher should learn model-shape/topology args from --model-recipe.
+
+    This keeps recipe authors from passing dummy legacy shape flags whose
+    values are ignored later by hybrid_builder.
+    """
+
+    def test_apply_model_recipe_to_args_sets_legacy_namespace_fields(self, monkeypatch):
+        from megatron.training.arguments import _apply_model_recipe_to_args
+
+        common = _make_common()
+        recipe = HybridModelConfig(
+            common_config=common,
+            layer_pattern=_make_valid_pattern(common),
+            tensor_model_parallel_size=2,
+        )
+        _register_synthetic_module(
+            monkeypatch, "tests._args_projection_recipe", make_recipe=lambda: recipe
+        )
+        args = types.SimpleNamespace(
+            model_recipe="tests._args_projection_recipe",
+            num_layers=None,
+            hidden_size=None,
+            num_attention_heads=None,
+            max_position_embeddings=None,
+            padded_vocab_size=None,
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+            context_parallel_size=1,
+            expert_model_parallel_size=1,
+            expert_tensor_parallel_size=None,
+            position_embedding_type=None,
+            rotary_percent=None,
+            rotary_base=None,
+            rotary_seq_len_interpolation_factor=None,
+            untie_embeddings_and_output_weights=False,
+            fp16_lm_cross_entropy=False,
+            mtp_num_layers=None,
+            encoder_num_layers=123,
+            num_experts=None,
+        )
+
+        _apply_model_recipe_to_args(args)
+
+        # ``args._model_recipe`` carries the loaded HybridModelConfig itself —
+        # not a lowered intermediate. The launcher and ``hybrid_builder``
+        # both consume it via the public recipe surface (queries on
+        # HybridModelConfig + ``HybridModel.from_recipe``).
+        assert isinstance(args._model_recipe, HybridModelConfig)
+        assert args._model_recipe.num_layers == 2
+        assert args.num_layers == 2
+        assert args.encoder_num_layers is None
+        assert args.hidden_size == common.hidden_size
+        assert args.num_attention_heads == 4
+        assert args.max_position_embeddings == 512
+        assert args.padded_vocab_size == 1024
+        assert args.tensor_model_parallel_size == 2

--- a/tests/unit_tests/models/hybrid/test_load_recipe.py
+++ b/tests/unit_tests/models/hybrid/test_load_recipe.py
@@ -197,9 +197,8 @@ class TestFilesystemPath:
             """
             from megatron.core.models.hybrid import (
                 AttentionLayerConfig, CommonLayerConfig, CrossEntropyLayerConfig,
-                EmbeddingLayerConfig,
+                EmbeddingLayerConfig, HybridModelConfig,
             )
-            from megatron.training.models.hybrid import HybridModelConfig
             def make_recipe() -> HybridModelConfig:
                 common = CommonLayerConfig(hidden_size=128, use_cpu_initialization=True)
                 return HybridModelConfig(
@@ -222,9 +221,8 @@ class TestFilesystemPath:
             """
             from megatron.core.models.hybrid import (
                 AttentionLayerConfig, CommonLayerConfig, CrossEntropyLayerConfig,
-                EmbeddingLayerConfig,
+                EmbeddingLayerConfig, HybridModelConfig,
             )
-            from megatron.training.models.hybrid import HybridModelConfig
             def my_pretrain_config() -> HybridModelConfig:
                 common = CommonLayerConfig(hidden_size=128, use_cpu_initialization=True)
                 return HybridModelConfig(
@@ -302,6 +300,35 @@ class TestRecipeArgProjection:
     values are ignored later by hybrid_builder.
     """
 
+    def _projection_args(self, model_recipe: str, **overrides):
+        values = dict(
+            model_recipe=model_recipe,
+            num_layers=None,
+            hidden_size=None,
+            num_attention_heads=None,
+            max_position_embeddings=None,
+            padded_vocab_size=None,
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+            context_parallel_size=1,
+            expert_model_parallel_size=1,
+            expert_tensor_parallel_size=None,
+            position_embedding_type=None,
+            rotary_percent=None,
+            rotary_base=None,
+            rotary_seq_len_interpolation_factor=None,
+            untie_embeddings_and_output_weights=False,
+            fp16_lm_cross_entropy=False,
+            mtp_num_layers=None,
+            mtp_hybrid_override_pattern=None,
+            hybrid_layer_pattern=None,
+            hybrid_override_pattern=None,
+            encoder_num_layers=None,
+            num_experts=None,
+        )
+        values.update(overrides)
+        return types.SimpleNamespace(**values)
+
     def test_apply_model_recipe_to_args_sets_legacy_namespace_fields(self, monkeypatch):
         from megatron.training.arguments import _apply_model_recipe_to_args
 
@@ -352,3 +379,78 @@ class TestRecipeArgProjection:
         assert args.max_position_embeddings == 512
         assert args.padded_vocab_size == 1024
         assert args.tensor_model_parallel_size == 2
+
+    def test_unset_recipe_topology_does_not_clobber_cli_flag(self, monkeypatch):
+        """The headline contract for the recipe→args projection: a recipe
+        that leaves ``tensor_model_parallel_size=None`` (= "defer to the
+        launcher") must NOT overwrite a value the user passed via
+        ``--tensor-model-parallel-size`` on the CLI. Same for CP/EP/ETP.
+
+        Regression guard: the launcher reads topology from the recipe's
+        ``int | None`` fields directly; reading from the lowered stack
+        TC instead would see substituted concrete values (TC always carries
+        them) and silently clobber ``args.tensor_model_parallel_size``."""
+        from megatron.training.arguments import _apply_model_recipe_to_args
+
+        common = _make_common()
+        # No topology pinned on the recipe.
+        recipe = HybridModelConfig(common_config=common, layer_pattern=_make_valid_pattern(common))
+        _register_synthetic_module(
+            monkeypatch, "tests._args_projection_recipe_no_topology", make_recipe=lambda: recipe
+        )
+        # CLI-supplied values that the projection must preserve.
+        args = types.SimpleNamespace(
+            model_recipe="tests._args_projection_recipe_no_topology",
+            num_layers=None,
+            hidden_size=None,
+            num_attention_heads=None,
+            max_position_embeddings=None,
+            padded_vocab_size=None,
+            tensor_model_parallel_size=4,  # ← from CLI; must survive
+            pipeline_model_parallel_size=1,
+            context_parallel_size=2,  # ← from CLI; must survive
+            expert_model_parallel_size=8,  # ← from CLI; must survive
+            expert_tensor_parallel_size=1,  # ← from CLI; must survive
+            position_embedding_type=None,
+            rotary_percent=None,
+            rotary_base=None,
+            rotary_seq_len_interpolation_factor=None,
+            untie_embeddings_and_output_weights=False,
+            fp16_lm_cross_entropy=False,
+            mtp_num_layers=None,
+            encoder_num_layers=None,
+            num_experts=None,
+        )
+
+        _apply_model_recipe_to_args(args)
+
+        assert args.tensor_model_parallel_size == 4
+        assert args.context_parallel_size == 2
+        assert args.expert_model_parallel_size == 8
+        assert args.expert_tensor_parallel_size == 1
+
+    def test_model_recipe_rejects_mtp_num_layers(self, monkeypatch):
+        from megatron.training.arguments import _apply_model_recipe_to_args
+
+        common = _make_common()
+        recipe = HybridModelConfig(common_config=common, layer_pattern=_make_valid_pattern(common))
+        module_name = "tests._args_projection_recipe_mtp_num_layers"
+        _register_synthetic_module(monkeypatch, module_name, make_recipe=lambda: recipe)
+
+        args = self._projection_args(module_name, mtp_num_layers=1)
+
+        with pytest.raises(AssertionError, match="Multi-Token Prediction"):
+            _apply_model_recipe_to_args(args)
+
+    def test_model_recipe_rejects_mtp_hybrid_override_pattern(self, monkeypatch):
+        from megatron.training.arguments import _apply_model_recipe_to_args
+
+        common = _make_common()
+        recipe = HybridModelConfig(common_config=common, layer_pattern=_make_valid_pattern(common))
+        module_name = "tests._args_projection_recipe_mtp_override"
+        _register_synthetic_module(monkeypatch, module_name, make_recipe=lambda: recipe)
+
+        args = self._projection_args(module_name, mtp_hybrid_override_pattern="MM")
+
+        with pytest.raises(AssertionError, match="Multi-Token Prediction"):
+            _apply_model_recipe_to_args(args)

--- a/tests/unit_tests/models/hybrid/test_nano_legacy_equivalence.py
+++ b/tests/unit_tests/models/hybrid/test_nano_legacy_equivalence.py
@@ -1,0 +1,475 @@
+# Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Architectural equivalence test: ``examples/nemotron3/nano.sh`` ↔ ``examples/nemotron3/nano.py``.
+
+Both files encode Nemotron-3 Nano. ``nano.sh`` was emitted by the
+Megatron-Bridge `translate_mlm_to_bridge.py --reverse` converter and
+expresses the model through legacy `pretrain_hybrid.py` CLI flags;
+``nano.py`` expresses it through the Python DSL that ``--model-recipe``
+consumes. This test parses ``nano.sh``, runs Megatron's argparse +
+``core_transformer_config_from_args`` to reconstruct the legacy-path
+:class:`TransformerConfig`, then lowers the DSL recipe (via the package's
+internal ``_lower`` helper) and asserts the two paths agree on every
+architectural field they can both express.
+
+Three known classes of difference are explicitly tolerated, with reasons:
+
+1. ``LEGACY_CLI_CANT_EXPRESS`` — fields whose canonical value nano.py
+   carries but the legacy MLM CLI surface in this checkout has no
+   argparse flag for, or the Bridge converter doesn't map. nano.sh
+   defaults these; nano.py overrides; the divergence is irreducible
+   today.
+
+2. ``CONVERTER_BUG_PATCHES`` — flags the converter should emit but
+   doesn't (or emits in a malformed shape). The test patches the
+   namespace from canonical values so the rest of the comparison can
+   proceed; each patch carries a one-line explanation.
+
+3. ``NARGS_PLUS_FIELDS`` — argparse parses some flags as
+   one-element lists (``nargs='+'``); the recipe stores scalars.
+   Same value, different container — unwrapped before comparison.
+
+Training-orchestration flags from ``nano.sh`` (``--lr``, ``--global-batch-size``,
+``--save-interval``, optimizer / scheduler / DDP / dataset / logger) are
+intentionally NOT compared — those are launcher concerns, not part of
+the model recipe.
+"""
+
+import argparse
+import warnings
+from pathlib import Path
+
+import pytest
+
+NANO_SH = Path(__file__).resolve().parents[4] / "examples" / "nemotron3" / "nano.sh"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Known-divergence registries (all real; document why each item is here)
+# ──────────────────────────────────────────────────────────────────────────
+
+#: Fields whose canonical value nano.py carries but nano.sh cannot.
+LEGACY_CLI_CANT_EXPRESS: dict[str, str] = {
+    "first_last_layers_bf16": (
+        "No --first-last-layers-bf16 flag in this MLM checkout; "
+        "nano.py carries the canonical value via CommonLayerConfig."
+    ),
+    "use_fused_weighted_squared_relu": (
+        "Bridge converter does not emit --use-fused-weighted-squared-relu "
+        "even though the flag exists in MLM; nano.py carries the canonical "
+        "value on the MoE layer config."
+    ),
+    "is_hybrid_model": (
+        "Set implicitly by --hybrid-layer-pattern in production validate_args(); "
+        "this test bypasses validate_args, so the legacy side reads as the TC "
+        "default (False) while the recipe forces True during lowering."
+    ),
+}
+
+
+#: Flags the Bridge converter should emit but doesn't, or emits malformed.
+#: We patch the parsed namespace from canonical values so the rest of
+#: the architectural comparison can proceed. Each entry: namespace attr →
+#: (value, reason).
+CONVERTER_BUG_PATCHES: dict[str, tuple[object, str]] = {
+    "hybrid_layer_pattern": (
+        "MEMEM*EMEMEM*EMEMEM*EMEMEM*EMEMEM*EMEMEMEM*EMEMEMEME",
+        "Bridge converter omits --hybrid-layer-pattern for hybrid models",
+    ),
+    "mamba_num_heads": (
+        64,
+        "Bridge converter omits --mamba-num-heads despite the flag existing "
+        "in MLM. Without it, nano.sh as-emitted would silently auto-derive "
+        "mamba_num_heads = hidden_size * expand // mamba_head_dim = 84, "
+        "i.e. it would actually train a different model than the canonical.",
+    ),
+}
+
+
+#: nano.sh has --attention-backend ``AttnBackend.fused`` (verbatim Python
+#: ``repr()`` of the enum); the argparse type lambda expects the bare name.
+ATTENTION_BACKEND_REPR_PATCHES: dict[str, str] = {
+    "AttnBackend.fused": "fused",
+    "AttnBackend.flash": "flash",
+    "AttnBackend.unfused": "unfused",
+    "AttnBackend.local": "local",
+    "AttnBackend.auto": "auto",
+}
+
+
+#: Argparse flags with ``nargs='+'``: parsed as singleton lists; the recipe
+#: stores scalars. Same value semantically.
+NARGS_PLUS_FIELDS: tuple[str, ...] = ("moe_router_load_balancing_type", "moe_aux_loss_coeff")
+
+
+#: Architectural TransformerConfig fields applied uniformly to every per-layer
+#: TC and the stack-level TC. Compared between the legacy global TC and the
+#: recipe's stack-level TC.
+MODEL_WIDE_FIELDS: tuple[str, ...] = (
+    # Topology
+    "num_layers",
+    "hidden_size",
+    "ffn_hidden_size",
+    # Norms / bias / activation
+    "normalization",
+    "layernorm_epsilon",
+    "add_bias_linear",
+    "gated_linear_unit",
+    # Init
+    "init_method_std",
+    # Numerical-stability flags
+    "first_last_layers_bf16",
+    # Fusions
+    "apply_rope_fusion",
+    "persist_layer_norm",
+    # Hybrid / model family
+    "is_hybrid_model",
+    "transformer_impl",
+    # Parallelism
+    "tensor_model_parallel_size",
+    "pipeline_model_parallel_size",
+    "context_parallel_size",
+    "expert_model_parallel_size",
+    "expert_tensor_parallel_size",
+    "sequence_parallel",
+    # Mixed precision
+    "bf16",
+    "fp16",
+    # Cross-entropy fusion (stack-only on the recipe side)
+    "cross_entropy_loss_fusion",
+    "cross_entropy_fusion_impl",
+)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# nano.sh parsing
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _extract_args_from_sh(sh_path: Path) -> list[str]:
+    """Return the flat list of ``--*`` flags + values found in nano.sh.
+
+    Uses :func:`shlex.split` so values that the shell needs quoted (e.g.
+    ``--hybrid-layer-pattern "M*M*..."`` whose ``*`` would otherwise glob)
+    are tokenised correctly without the quote characters being passed
+    through as part of the value.
+    """
+    import shlex
+
+    args: list[str] = []
+    for raw in sh_path.read_text().splitlines():
+        line = raw.strip().rstrip("\\").strip()
+        if not line.startswith("--"):
+            continue
+        args.extend(shlex.split(line))
+    return args
+
+
+def _patch_known_converter_bugs(args: list[str]) -> list[str]:
+    """Convert ``AttnBackend.fused``-style enum reprs to bare names."""
+    return [ATTENTION_BACKEND_REPR_PATCHES.get(a, a) for a in args]
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Legacy-path compilation
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _legacy_path_from_sh(sh_path: Path):
+    """Run nano.sh's args through Megatron's argparse and return:
+
+    - ``ns``: the parsed ``argparse.Namespace``  (with converter-gap patches)
+    - ``legacy_tc``: the :class:`TransformerConfig` core_transformer_config_from_args produces
+    - ``layer_type_list``: the decoded layer_type_list (single-char per layer)
+    """
+    import torch
+
+    from megatron.core.models.hybrid.hybrid_layer_allocation import (
+        parse_hybrid_pattern,
+        validate_segment_layers,
+    )
+    from megatron.core.transformer.transformer_config import TransformerConfig
+    from megatron.training.arguments import (
+        add_megatron_arguments,
+        core_transformer_config_from_args,
+    )
+
+    args_list = _patch_known_converter_bugs(_extract_args_from_sh(sh_path))
+
+    parser = argparse.ArgumentParser(description="nano.sh-equivalence", allow_abbrev=False)
+    add_megatron_arguments(parser)
+    ns, unknown = parser.parse_known_args(args_list)
+    if unknown:
+        warnings.warn(
+            "nano.sh contains flags not registered in this Megatron-LM's argparse "
+            "(Bridge↔MLM version drift): " + " ".join(unknown),
+            stacklevel=2,
+        )
+
+    # Apply the small subset of validate_args() logic the recipe relies on,
+    # without invoking distributed-init checks that need a real world size.
+    if not getattr(ns, "padded_vocab_size", None):
+        ns.padded_vocab_size = 131072  # = 1024 × 128, what nano.py hardcodes
+    if not getattr(ns, "params_dtype", None):
+        if getattr(ns, "bf16", False):
+            ns.params_dtype = torch.bfloat16
+        elif getattr(ns, "fp16", False):
+            ns.params_dtype = torch.float16
+        else:
+            ns.params_dtype = torch.float32
+    if not getattr(ns, "activation_func", None) and getattr(ns, "squared_relu", False):
+        from megatron.core.activations import squared_relu
+
+        ns.activation_func = squared_relu
+
+    # Patch converter-gap fields the Bridge converter forgot to emit.
+    for attr, (value, reason) in CONVERTER_BUG_PATCHES.items():
+        if not getattr(ns, attr, None):
+            setattr(ns, attr, value)
+
+    legacy_tc = core_transformer_config_from_args(ns, TransformerConfig)
+
+    parsed = parse_hybrid_pattern(ns.hybrid_layer_pattern)
+    # Bypass select_pipeline_segment: that helper logs through a distributed
+    # collective which would require ``torch.distributed`` to be initialised.
+    # pp_size=1 (the test's degenerate case) is just "every char becomes a
+    # layer type".
+    layer_type_list = validate_segment_layers(parsed.main_pattern or "")
+    return ns, legacy_tc, layer_type_list
+
+
+class _LoweredRecipe:
+    """Compatibility view over ``HybridModelConfig._lower()`` for assertions."""
+
+    def __init__(self, recipe) -> None:
+        self._recipe = recipe
+        self.config, self.layer_type_list, self.layer_config_list = recipe._lower()
+
+    @property
+    def vocab_size(self) -> int:
+        return self._recipe.embedding_marker.vocab_size
+
+    @property
+    def max_sequence_length(self) -> int:
+        return self._recipe.embedding_marker.max_sequence_length
+
+    @property
+    def position_embedding_type(self) -> str:
+        return self._recipe.embedding_marker.position_embedding_type
+
+    @property
+    def share_embeddings_and_output_weights(self) -> bool:
+        return not self._recipe.untie_embeddings_and_output_weights
+
+    @property
+    def mtp_num_depths(self) -> int:
+        return 0
+
+    @property
+    def mtp_layer_pattern(self) -> None:
+        return None
+
+
+def _recipe_lowered():
+    from examples.nemotron3.nano import make_recipe
+
+    return _LoweredRecipe(make_recipe())
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Field comparison helpers
+# ──────────────────────────────────────────────────────────────────────────
+
+
+_MISSING = object()
+
+
+def _normalise(field_name: str, value):
+    """Unwrap singleton-list values for ``nargs='+'`` fields so they
+    compare equal to the recipe's scalar form."""
+    if field_name in NARGS_PLUS_FIELDS and isinstance(value, list) and len(value) == 1:
+        return value[0]
+    return value
+
+
+def _eq(legacy_val, recipe_val) -> bool:
+    """Equality with one tolerance: ``activation_func`` is a callable; compare
+    by ``__name__`` since the recipe resolves a string to the same function
+    the legacy path imports."""
+    if callable(legacy_val) and callable(recipe_val):
+        return getattr(legacy_val, "__name__", None) == getattr(recipe_val, "__name__", None)
+    return legacy_val == recipe_val
+
+
+def _diff_fields(legacy_tc, candidate_tc, fields, label: str) -> list[str]:
+    diffs = []
+    for f in fields:
+        if f in LEGACY_CLI_CANT_EXPRESS:
+            continue
+        legacy_val = _normalise(f, getattr(legacy_tc, f, _MISSING))
+        recipe_val = getattr(candidate_tc, f, _MISSING)
+        if legacy_val is _MISSING and recipe_val is _MISSING:
+            continue
+        if not _eq(legacy_val, recipe_val):
+            diffs.append(f"  [{label}] {f}: legacy={legacy_val!r}  recipe={recipe_val!r}")
+    return diffs
+
+
+def _first_layer_of_type(layer_type_list, layer_config_list, sym):
+    for i, s in enumerate(layer_type_list):
+        if s == sym:
+            return layer_config_list[i]
+    raise AssertionError(f"no layer of type {sym!r} in pattern")
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Tests
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def _no_tc_post_init():
+    """Disable :meth:`TransformerConfig.__post_init__` for the test module.
+
+    Both the legacy-path and recipe-path TC instantiations bypass the
+    surrounding ``validate_args`` / launcher logic that normally enforces
+    cross-field invariants (e.g. ``bias_activation_fusion`` being
+    incompatible with ``squared_relu``). We only care about whether the two
+    sides write identical values into TC's fields.
+    """
+    from megatron.core.transformer.transformer_config import TransformerConfig
+
+    original = TransformerConfig.__post_init__
+    TransformerConfig.__post_init__ = lambda self: None
+    try:
+        yield
+    finally:
+        TransformerConfig.__post_init__ = original
+
+
+@pytest.fixture(scope="module")
+def legacy(_no_tc_post_init):
+    return _legacy_path_from_sh(NANO_SH)
+
+
+@pytest.fixture(scope="module")
+def recipe(_no_tc_post_init):
+    # Named ``recipe`` for fixture-scope brevity; the value is a test-only
+    # compatibility view over ``HybridModelConfig._lower()``.
+    return _recipe_lowered()
+
+
+@pytest.mark.internal
+class TestNanoArchitecturalEquivalence:
+    """nano.sh and nano.py must encode the same model architecture.
+
+    Differences listed in ``LEGACY_CLI_CANT_EXPRESS`` are tolerated (they
+    are unavoidable today). A new divergence appearing outside that list is
+    a real drift between the two artifacts and fails the test.
+    """
+
+    # === Layer pattern ===
+
+    def test_layer_type_list_matches(self, legacy, recipe):
+        _, _, legacy_layer_types = legacy
+        assert "".join(recipe.layer_type_list) == "".join(legacy_layer_types)
+
+    def test_layer_count_matches(self, legacy, recipe):
+        _, _, legacy_layer_types = legacy
+        assert len(recipe.layer_config_list) == len(legacy_layer_types)
+
+    # === Recipe-level scalars ===
+
+    def test_vocab_size_matches(self, legacy, recipe):
+        ns, _, _ = legacy
+        assert recipe.vocab_size == ns.padded_vocab_size
+
+    def test_max_sequence_length_matches(self, legacy, recipe):
+        ns, _, _ = legacy
+        assert recipe.max_sequence_length == ns.max_position_embeddings
+
+    def test_position_embedding_type_matches(self, legacy, recipe):
+        ns, _, _ = legacy
+        assert recipe.position_embedding_type == ns.position_embedding_type
+
+    def test_share_embeddings_and_output_weights_matches(self, legacy, recipe):
+        ns, _, _ = legacy
+        assert recipe.share_embeddings_and_output_weights == (
+            not ns.untie_embeddings_and_output_weights
+        )
+
+    def test_mtp_matches(self, legacy, recipe):
+        ns, _, _ = legacy
+        legacy_mtp_depths = getattr(ns, "mtp_num_layers", 0) or 0
+        assert recipe.mtp_num_depths == legacy_mtp_depths
+        if legacy_mtp_depths == 0:
+            assert recipe.mtp_layer_pattern is None
+
+    # === Stack-level (model-wide) TransformerConfig ===
+
+    def test_stack_tc_fields_match(self, legacy, recipe):
+        _, legacy_tc, _ = legacy
+        diffs = _diff_fields(legacy_tc, recipe.config, MODEL_WIDE_FIELDS, "stack")
+        assert not diffs, "stack-level TC divergences:\n" + "\n".join(diffs)
+
+    # === Per-layer-type architectural fields (compared on a representative
+    # layer of each type — comparing every per-layer TC against the legacy
+    # global TC would be apples-to-oranges since non-matching layer types
+    # carry placeholders, not real values).
+
+    def test_first_mamba_layer_matches(self, legacy, recipe):
+        _, legacy_tc, _ = legacy
+        mamba_tc = _first_layer_of_type(recipe.layer_type_list, recipe.layer_config_list, "M")
+        diffs = _diff_fields(
+            legacy_tc,
+            mamba_tc,
+            ("mamba_num_heads", "mamba_head_dim", "mamba_state_dim", "mamba_num_groups"),
+            "mamba_layer",
+        )
+        assert not diffs, "Mamba layer TC divergences:\n" + "\n".join(diffs)
+
+    def test_first_attention_layer_matches(self, legacy, recipe):
+        _, legacy_tc, _ = legacy
+        att_tc = _first_layer_of_type(recipe.layer_type_list, recipe.layer_config_list, "*")
+        diffs = _diff_fields(
+            legacy_tc,
+            att_tc,
+            (
+                "num_attention_heads",
+                "num_query_groups",
+                "kv_channels",
+                "attention_softmax_in_fp32",
+                "apply_query_key_layer_scaling",
+                "masked_softmax_fusion",
+            ),
+            "attention_layer",
+        )
+        assert not diffs, "Attention layer TC divergences:\n" + "\n".join(diffs)
+
+    def test_first_moe_layer_matches(self, legacy, recipe):
+        _, legacy_tc, _ = legacy
+        moe_tc = _first_layer_of_type(recipe.layer_type_list, recipe.layer_config_list, "E")
+        diffs = _diff_fields(
+            legacy_tc,
+            moe_tc,
+            (
+                "num_moe_experts",
+                "moe_router_topk",
+                "moe_ffn_hidden_size",
+                "moe_shared_expert_intermediate_size",
+                "moe_router_score_function",
+                "moe_router_load_balancing_type",
+                "moe_router_topk_scaling_factor",
+                "moe_router_enable_expert_bias",
+                "moe_router_dtype",
+                "moe_router_num_groups",
+                "moe_router_group_topk",
+                "moe_aux_loss_coeff",
+                "moe_grouped_gemm",
+                "moe_token_dispatcher_type",
+                "moe_permute_fusion",
+                "use_fused_weighted_squared_relu",
+            ),
+            "moe_layer",
+        )
+        assert not diffs, "MoE layer TC divergences:\n" + "\n".join(diffs)

--- a/tests/unit_tests/models/hybrid/test_python_dsl_equivalence.py
+++ b/tests/unit_tests/models/hybrid/test_python_dsl_equivalence.py
@@ -25,6 +25,7 @@ from megatron.core.models.hybrid import (
     CommonLayerConfig,
     CrossEntropyLayerConfig,
     EmbeddingLayerConfig,
+    HybridModelConfig,
     MambaLayerConfig,
     MLPLayerConfig,
 )
@@ -32,7 +33,6 @@ from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_stack_spec
 from megatron.core.models.hybrid.hybrid_model import HybridModel
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer import TransformerConfig
-from megatron.training.models.hybrid import HybridModelConfig
 from tests.unit_tests.test_utilities import Utils
 
 
@@ -66,7 +66,10 @@ def _loss() -> CrossEntropyLayerConfig:
 
 
 def _build_model_from_recipe(recipe: HybridModelConfig) -> HybridModel:
-    return HybridModel.from_recipe(recipe)
+    # Phase 2: call the new TC-free constructor directly. ``from_recipe``
+    # is now a thin alias; the equivalence between the two paths is
+    # asserted in test_recipe_constructor.py.
+    return HybridModel(config=recipe)
 
 
 @pytest.mark.internal

--- a/tests/unit_tests/models/hybrid/test_python_dsl_equivalence.py
+++ b/tests/unit_tests/models/hybrid/test_python_dsl_equivalence.py
@@ -1,0 +1,192 @@
+# Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
+
+"""End-to-end equivalence tests between the legacy string DSL and the recipe DSL.
+
+Building a HybridModel via ``hybrid_layer_pattern="M*-"`` and via a
+``HybridModelConfig`` recipe must produce equivalent models: identical layer
+types, identical parameter counts, and — when seeded the same way — identical
+forward outputs.
+
+Heterogeneous-within-type smoke tests confirm that the Python DSL's per-layer
+config plumbing actually reaches the constructed layer instances.
+
+These tests require CUDA + Transformer Engine (matching the rest of the
+hybrid test suite) and run inside the Megatron-LM CI container.
+"""
+
+import pytest
+import torch
+from transformer_engine.pytorch.fp8 import check_fp8_support  # noqa: F401  # CI gate
+
+pytest.importorskip("mamba_ssm", reason="HybridModel Mamba equivalence tests require MambaSSM")
+
+from megatron.core.models.hybrid import (
+    AttentionLayerConfig,
+    CommonLayerConfig,
+    CrossEntropyLayerConfig,
+    EmbeddingLayerConfig,
+    MambaLayerConfig,
+    MLPLayerConfig,
+)
+from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_stack_spec
+from megatron.core.models.hybrid.hybrid_model import HybridModel
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.transformer import TransformerConfig
+from megatron.training.models.hybrid import HybridModelConfig
+from tests.unit_tests.test_utilities import Utils
+
+
+def _make_common(**overrides) -> CommonLayerConfig:
+    # ``hidden_dropout=0.1`` matches the TransformerConfig default; the
+    # CommonLayerConfig default (0.0) would silently diverge from the
+    # legacy-CLI side of the equivalence comparison.
+    base = dict(hidden_size=256, use_cpu_initialization=True, hidden_dropout=0.1)
+    base.update(overrides)
+    return CommonLayerConfig(**base)
+
+
+def _make_legacy_config(**overrides) -> TransformerConfig:
+    base = dict(
+        num_layers=3,
+        hidden_size=256,
+        num_attention_heads=4,
+        use_cpu_initialization=True,
+        is_hybrid_model=True,
+    )
+    base.update(overrides)
+    return TransformerConfig(**base)
+
+
+def _embedding(common: CommonLayerConfig) -> EmbeddingLayerConfig:
+    return EmbeddingLayerConfig(common_config=common, vocab_size=100, max_sequence_length=4)
+
+
+def _loss() -> CrossEntropyLayerConfig:
+    return CrossEntropyLayerConfig()
+
+
+def _build_model_from_recipe(recipe: HybridModelConfig) -> HybridModel:
+    return HybridModel.from_recipe(recipe)
+
+
+@pytest.mark.internal
+class TestPythonDSLStringEquivalence:
+    """Two models built from the same architecture — one via the string DSL, one
+    via the recipe DSL — must be functionally identical."""
+
+    def setup_method(self, method):
+        Utils.initialize_model_parallel(1, 1)
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    def _build_string_dsl_model(self) -> HybridModel:
+        model_parallel_cuda_manual_seed(123)
+        return HybridModel(
+            config=_make_legacy_config(),
+            hybrid_stack_spec=hybrid_stack_spec,
+            vocab_size=100,
+            max_sequence_length=4,
+            hybrid_layer_pattern="M*-",
+        )
+
+    def _build_python_dsl_model(self) -> HybridModel:
+        model_parallel_cuda_manual_seed(123)
+        common = _make_common()
+        # ``untie_embeddings_and_output_weights=True`` matches HybridModel's
+        # legacy default (``share_embeddings_and_output_weights=False``);
+        # without it the recipe path produces a single shared embedding+output
+        # table while the legacy path produces two separate tables.
+        recipe = HybridModelConfig(
+            common_config=common,
+            layer_pattern=[
+                _embedding(common),
+                MambaLayerConfig(common_config=common),
+                AttentionLayerConfig(common_config=common, num_attention_heads=4),
+                MLPLayerConfig(common_config=common),
+                _loss(),
+            ],
+            untie_embeddings_and_output_weights=True,
+        )
+        return _build_model_from_recipe(recipe)
+
+    def test_layer_types_match(self):
+        legacy = self._build_string_dsl_model()
+        new = self._build_python_dsl_model()
+        assert legacy.decoder.layer_type_list == new.decoder.layer_type_list
+        assert len(legacy.decoder.layers) == len(new.decoder.layers)
+
+    def test_parameter_count_matches(self):
+        legacy_params = sum(p.numel() for p in self._build_string_dsl_model().parameters())
+        new_params = sum(p.numel() for p in self._build_python_dsl_model().parameters())
+        assert legacy_params == new_params
+
+    def test_forward_outputs_match(self):
+        """The two paths' forward outputs must agree on shape and dtype.
+
+        We deliberately do **not** compare values: even with identical
+        ``model_parallel_cuda_manual_seed`` and identical per-layer field
+        values, the legacy and recipe construction paths consume CUDA RNG in
+        different orders during weight init (one shared TC vs per-layer TC
+        list, traversed by different code paths). The architectural-
+        equivalence guarantee is captured by ``test_layer_types_match`` and
+        ``test_parameter_count_matches``; this test catches divergent
+        forward signatures (extra outputs, wrong dtype, wrong shape) on top.
+        """
+        legacy = self._build_string_dsl_model().cuda()
+        new = self._build_python_dsl_model().cuda()
+
+        seq_len = legacy.max_sequence_length
+        bsz = 2
+        data = list(range(seq_len))
+        input_ids = torch.tensor(data, dtype=torch.int64).repeat((bsz, 1)).cuda()
+        position_ids = torch.tensor(data, dtype=torch.int64).repeat((bsz, 1)).cuda()
+        attention_mask = torch.ones((bsz, 1, seq_len, seq_len), dtype=bool).cuda()
+
+        legacy_out = legacy.forward(
+            input_ids=input_ids, position_ids=position_ids, attention_mask=attention_mask
+        )
+        new_out = new.forward(
+            input_ids=input_ids, position_ids=position_ids, attention_mask=attention_mask
+        )
+
+        assert legacy_out.shape == new_out.shape
+        assert legacy_out.dtype == new_out.dtype
+
+
+@pytest.mark.internal
+class TestHeterogeneousWithinType:
+    """Within-type heterogeneity (e.g. two distinct MambaLayerConfig instances)
+    must produce layers whose constructed config reflects the per-layer
+    overrides — not just the global common config."""
+
+    def setup_method(self, method):
+        Utils.initialize_model_parallel(1, 1)
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    def test_per_layer_mamba_overrides_reach_constructed_layer(self):
+        # MambaMixer requires ``num_heads % num_groups == 0``. Pick num_groups
+        # that divides both heterogeneous head counts so the layers actually
+        # construct (the test target is heterogeneity, not the divisibility
+        # constraint).
+        common = _make_common(hidden_dropout=0.0)
+        big = MambaLayerConfig(common_config=common, num_heads=16, head_dim=32, num_groups=2)
+        small = MambaLayerConfig(common_config=common, num_heads=8, head_dim=64, num_groups=2)
+
+        model_parallel_cuda_manual_seed(123)
+        recipe = HybridModelConfig(
+            common_config=common, layer_pattern=[_embedding(common), big, small, _loss()]
+        )
+        model = _build_model_from_recipe(recipe)
+
+        # The constructed layers' configs must match the per-layer overrides,
+        # not the (default) global common config.
+        layer0_cfg = model.decoder.layer_config_list[0]
+        layer1_cfg = model.decoder.layer_config_list[1]
+        assert layer0_cfg.mamba_num_heads == 16
+        assert layer0_cfg.mamba_head_dim == 32
+        assert layer1_cfg.mamba_num_heads == 8
+        assert layer1_cfg.mamba_head_dim == 64
+        assert layer0_cfg is not layer1_cfg

--- a/tests/unit_tests/models/hybrid/test_recipe_constructor.py
+++ b/tests/unit_tests/models/hybrid/test_recipe_constructor.py
@@ -1,0 +1,159 @@
+# Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Equivalence tests for the two recipe-path entry points.
+
+Phase 1 of the HybridModel recipe-API design adds direct
+:class:`HybridModelConfig` support to :meth:`HybridModel.__init__`::
+
+    HybridModel(config=recipe, ...)
+
+The pre-existing :meth:`HybridModel.from_recipe` classmethod continues to
+work — it is now a thin alias that delegates to the constructor. This
+module verifies the two entry points produce equivalent models (same layer
+types, same parameter counts, same forward signature) and that the
+constructor rejects mutually-exclusive kwargs on the recipe path.
+
+These tests require CUDA + Transformer Engine (matching the rest of the
+hybrid test suite) and run inside the Megatron-LM CI container.
+"""
+
+import pytest
+import torch
+from transformer_engine.pytorch.fp8 import check_fp8_support  # noqa: F401  # CI gate
+
+pytest.importorskip("mamba_ssm", reason="HybridModel Mamba equivalence tests require MambaSSM")
+
+from megatron.core.models.hybrid import (
+    AttentionLayerConfig,
+    CommonLayerConfig,
+    CrossEntropyLayerConfig,
+    EmbeddingLayerConfig,
+    MambaLayerConfig,
+    MLPLayerConfig,
+)
+from megatron.core.models.hybrid.hybrid_model import HybridModel
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.training.models.hybrid import HybridModelConfig
+from tests.unit_tests.test_utilities import Utils
+
+
+def _make_common(**overrides) -> CommonLayerConfig:
+    # ``hidden_dropout=0.1`` matches the TransformerConfig default; the
+    # CommonLayerConfig default (0.0) would silently diverge from any
+    # legacy-CLI counterpart that left ``--hidden-dropout`` at its default.
+    base = dict(hidden_size=256, use_cpu_initialization=True, hidden_dropout=0.1)
+    base.update(overrides)
+    return CommonLayerConfig(**base)
+
+
+def _make_recipe() -> HybridModelConfig:
+    common = _make_common()
+    return HybridModelConfig(
+        common_config=common,
+        layer_pattern=[
+            EmbeddingLayerConfig(common_config=common, vocab_size=100, max_sequence_length=4),
+            MambaLayerConfig(common_config=common),
+            AttentionLayerConfig(common_config=common, num_attention_heads=4),
+            MLPLayerConfig(common_config=common),
+            CrossEntropyLayerConfig(),
+        ],
+        # Match HybridModel's legacy default
+        # (``share_embeddings_and_output_weights=False``).
+        untie_embeddings_and_output_weights=True,
+    )
+
+
+@pytest.mark.internal
+class TestRecipeConstructorEquivalence:
+    """``HybridModel(config=recipe)`` and ``HybridModel.from_recipe(recipe)``
+    must produce equivalent models.
+
+    ``from_recipe`` is now a thin alias for the constructor; this guards
+    against drift if either path is touched independently.
+    """
+
+    def setup_method(self, method):
+        Utils.initialize_model_parallel(1, 1)
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    def _build_via_constructor(self) -> HybridModel:
+        model_parallel_cuda_manual_seed(123)
+        return HybridModel(config=_make_recipe())
+
+    def _build_via_from_recipe(self) -> HybridModel:
+        model_parallel_cuda_manual_seed(123)
+        return HybridModel.from_recipe(_make_recipe())
+
+    def test_layer_types_match(self):
+        ctor = self._build_via_constructor()
+        factory = self._build_via_from_recipe()
+        assert ctor.decoder.layer_type_list == factory.decoder.layer_type_list
+        assert len(ctor.decoder.layers) == len(factory.decoder.layers)
+
+    def test_parameter_count_matches(self):
+        ctor_params = sum(p.numel() for p in self._build_via_constructor().parameters())
+        factory_params = sum(p.numel() for p in self._build_via_from_recipe().parameters())
+        assert ctor_params == factory_params
+
+    def test_forward_signature_matches(self):
+        """Forward outputs must agree on shape and dtype.
+
+        Bit-equality is not asserted: ``from_recipe`` delegates to the
+        constructor, so today the two paths consume the CUDA RNG
+        identically — but if either picks up additional construction work
+        (e.g. a future ``validate()`` call, or an extra log line that
+        touches state), bit-equality could drift. Shape/dtype is the
+        structural guarantee that matters here; deeper equivalence is
+        already covered by ``test_python_dsl_equivalence``.
+        """
+        ctor = self._build_via_constructor().cuda()
+        factory = self._build_via_from_recipe().cuda()
+
+        seq_len = ctor.max_sequence_length
+        bsz = 2
+        data = list(range(seq_len))
+        input_ids = torch.tensor(data, dtype=torch.int64).repeat((bsz, 1)).cuda()
+        position_ids = torch.tensor(data, dtype=torch.int64).repeat((bsz, 1)).cuda()
+        attention_mask = torch.ones((bsz, 1, seq_len, seq_len), dtype=bool).cuda()
+
+        ctor_out = ctor.forward(
+            input_ids=input_ids, position_ids=position_ids, attention_mask=attention_mask
+        )
+        factory_out = factory.forward(
+            input_ids=input_ids, position_ids=position_ids, attention_mask=attention_mask
+        )
+
+        assert ctor_out.shape == factory_out.shape
+        assert ctor_out.dtype == factory_out.dtype
+
+
+@pytest.mark.internal
+class TestRecipeConstructorRejection:
+    """The recipe-path entry point rejects kwargs that conflict with the
+    recipe DSL. These guards keep recipes from being silently shadowed by
+    a stale CLI flag in callers that mix entry points.
+    """
+
+    def setup_method(self, method):
+        Utils.initialize_model_parallel(1, 1)
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    def test_rejects_string_pattern(self):
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            HybridModel(config=_make_recipe(), hybrid_layer_pattern="M*-")
+
+    def test_rejects_legacy_attention_ratio(self):
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            HybridModel(config=_make_recipe(), hybrid_attention_ratio=0.5)
+
+    def test_rejects_legacy_mlp_ratio(self):
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            HybridModel(config=_make_recipe(), hybrid_mlp_ratio=0.5)
+
+    def test_rejects_legacy_override_pattern(self):
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            HybridModel(config=_make_recipe(), hybrid_override_pattern="M*-")


### PR DESCRIPTION
## Summary

- Add a declarative Python recipe API for HybridModel, including model-wide defaults, per-layer configuration, embedding/loss markers, validation, and lowering.
- Support loading recipes from dotted modules or Python files and constructing models directly with `HybridModel(config=recipe)`.
- Add `--model-recipe` launcher and ModelBuilder integration while preserving the legacy hybrid string DSL.
- Add a Nemotron-3 Nano recipe, launcher examples, unit/equivalence coverage, and an end-to-end functional workload.

This consolidates the changes from #4537, #5030, #5031, #4538, and #4539 into one PR.

## Upstream sync

The seven substantive commits were replayed onto `main` at `a54bd8cc1`; eight stack-only merge commits were omitted. Conflict resolutions preserve current-main behavior for:

- explicit `ProcessGroupCollection` and logging process-group plumbing
- legacy HybridModel virtual pipeline parallelism, MLA down-projection fusion, and CUDA graph handling
- GTP-aware total model-size calculation
- strict functional-test shell handling and the existing quarantined Nemotron Pico workload

All commits are DCO-signed-off and GitHub-verified.

## Validation

- [x] `git diff --check upstream/main...HEAD`
- [x] Check-only formatter: Black 26.3.0, isort, pylint (10.00/10), and Ruff
- [x] HybridModel test collection: 144 tests collected
- [ ] 8-GPU HybridModel unit suite (this host has no usable NVIDIA driver)
- [ ] H100 functional workload and golden generation; `golden_values_dev_dgx_h100.json` is not yet present

The cached lint image did not include `mypy`; the repository formatter treats that invocation as optional.
