### PR TITLE
[Dev] Preserve explicit NCCL NVLS configuration

### DIFF
--- a/megatron/core/nccl_allocator.py
+++ b/megatron/core/nccl_allocator.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 import logging
 import os
 from contextlib import nullcontext
@@ -150,8 +150,10 @@ def init() -> None:
     trigger NCCL errors. To avoid this, the pool is explicitly deregistered
     on entry and re-registered on exit for each context use.
     """
-    # Enables NCCL NVLS algorithm
-    os.environ["NCCL_NVLS_ENABLE"] = "1"
+    # Enable NCCL NVLS by default without overriding an explicit application or
+    # recipe choice.  Disabling NVLS is useful for isolating registration paths
+    # and for platforms where the NVLS algorithm is not operational.
+    os.environ.setdefault("NCCL_NVLS_ENABLE", "1")
     # Disables the use of the tensor register allocator hook
     os.environ["TORCH_NCCL_USE_TENSOR_REGISTER_ALLOCATOR_HOOK"] = "0"
     _build_nccl_allocator()

--- a/tests/unit_tests/test_nccl_allocator.py
+++ b/tests/unit_tests/test_nccl_allocator.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 import os
 
 import pytest
@@ -22,10 +22,15 @@ class TestNCCLAllocator:
         version.parse(torch.__version__) < version.parse('2.7.0'),
         reason="Requires PyTorch 2.7.0 or later",
     )
-    def test_nccl_allocator_init_sets_env_vars(self):
+    def test_nccl_allocator_init_sets_env_vars(self, monkeypatch):
+        monkeypatch.delenv("NCCL_NVLS_ENABLE", raising=False)
         nccl_allocator.init()
         assert os.environ.get("NCCL_NVLS_ENABLE") == "1"
         assert os.environ.get("TORCH_NCCL_USE_TENSOR_REGISTER_ALLOCATOR_HOOK") == "0"
+
+        monkeypatch.setenv("NCCL_NVLS_ENABLE", "0")
+        nccl_allocator.init()
+        assert os.environ.get("NCCL_NVLS_ENABLE") == "0"
 
     @pytest.mark.skipif(
         version.parse(torch.__version__) < version.parse('2.7.0'),


### PR DESCRIPTION
## Summary

- default `NCCL_NVLS_ENABLE` to `1` only when the caller has not set it
- preserve an explicit `NCCL_NVLS_ENABLE=0` or `1` from the launch environment
- cover both the default and explicit-override behavior with a unit test

This change is not required when a recipe always runs with NVLS enabled, but it is required for valid NVLS A/B experiments and for preserving caller-controlled NCCL semantics.

## Test plan

- `CHECK_ONLY=true BASE_REF=dev uv run --no-sync --project /home/scratch.hongbinl_sw/work/fsdp/agentic-mcore-dev --extra mcore-lint -- bash tools/autoformat.sh`
- `python tools/check_copyright.py megatron/core/distributed/distributed_data_parallel.py tests/unit_tests/distributed/test_distributed_data_parallel.py`

The local toolkit environment does not contain PyTorch, so import-dependent pytest/mypy execution is deferred to the Megatron CI container.

🤖 Generated with Codex
