### PR TITLE
[Dev] Skip broadcast for empty cu_seqlens tensors

### DIFF
--- a/megatron/training/utils/common_utils.py
+++ b/megatron/training/utils/common_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 """General utilities."""
 import json
@@ -588,12 +588,13 @@ def get_batch_on_this_tp_rank(
             _broadcast(n_tensor)
 
             if n == 0:
-                buf = torch.empty(0, dtype=torch.int32, device=dev)
-            else:
-                assert isinstance(cu_seqlens, torch.Tensor)
-                assert cu_seqlens.dtype == torch.int32
-                assert cu_seqlens.shape[0] == 1, "micro-batch-size must be 1 for packing"
-                buf = cu_seqlens.to(device=dev, non_blocking=True).contiguous()
+                # Avoid a zero-count NCCL collective backed by a null data pointer.
+                return
+
+            assert isinstance(cu_seqlens, torch.Tensor)
+            assert cu_seqlens.dtype == torch.int32
+            assert cu_seqlens.shape[0] == 1, "micro-batch-size must be 1 for packing"
+            buf = cu_seqlens.to(device=dev, non_blocking=True).contiguous()
             _broadcast(buf)
 
         if args.dynamic_context_parallel:
@@ -693,12 +694,13 @@ def get_batch_on_this_tp_rank(
             n = int(n.item())
 
             if n == 0:
-                cu_seqlens = torch.empty(0, dtype=torch.int32, device=dev)
-            else:
-                cu_seqlens = torch.empty((args.micro_batch_size, n), dtype=torch.int32, device=dev)
+                # The source rank skips the matching zero-count collective.
+                return None
+
+            cu_seqlens = torch.empty((args.micro_batch_size, n), dtype=torch.int32, device=dev)
             _broadcast(cu_seqlens)
 
-            return cu_seqlens if n > 0 else None
+            return cu_seqlens
 
         if args.pipeline_model_parallel_size == 1 or mtp_on_this_rank:
             _broadcast(tokens)

--- a/tests/unit_tests/training/test_common_utils.py
+++ b/tests/unit_tests/training/test_common_utils.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from math import prod
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from megatron.training.utils import common_utils
+
+
+class _FakeTensor:
+    """Minimal CUDA-tensor stand-in for batch-broadcast control-flow tests."""
+
+    def __init__(self, shape, dtype=None, value=None):
+        if isinstance(shape, int):
+            shape = (shape,)
+        self.shape = tuple(shape)
+        self.dtype = dtype
+        self.value = value
+
+    def cuda(self, non_blocking=False):
+        return self
+
+    def fill_(self, value):
+        self.value = value
+        return self
+
+    def item(self):
+        return self.value
+
+    def numel(self):
+        return prod(self.shape) if self.shape else 1
+
+
+@pytest.fixture
+def batch_broadcast_env(monkeypatch):
+    args = SimpleNamespace(
+        create_attention_mask_in_dataloader=False,
+        cuda_graph_impl=None,
+        dynamic_context_parallel=False,
+        micro_batch_size=1,
+        pipeline_model_parallel_size=1,
+        seq_length=4,
+        sft=False,
+    )
+    monkeypatch.setattr(common_utils, "get_args", lambda: args)
+    monkeypatch.setattr(common_utils.mpu, "get_tensor_model_parallel_src_rank", lambda: 0)
+    monkeypatch.setattr(common_utils.mpu, "get_tensor_model_parallel_group", lambda: object())
+    monkeypatch.setattr(common_utils.torch.cuda, "current_device", lambda: 0)
+    monkeypatch.setattr(
+        common_utils.torch,
+        "empty",
+        lambda shape, dtype=None, device=None: _FakeTensor(shape, dtype=dtype),
+    )
+
+    broadcasts = []
+
+    def broadcast(tensor, src, group):
+        broadcasts.append(tensor)
+        if tensor.shape == () and tensor.dtype == torch.int64:
+            tensor.value = 0
+
+    monkeypatch.setattr(common_utils.torch.distributed, "broadcast", broadcast)
+    return broadcasts
+
+
+def test_source_skips_empty_cu_seqlens_broadcast(monkeypatch, batch_broadcast_env):
+    monkeypatch.setattr(common_utils.mpu, "get_tensor_model_parallel_rank", lambda: 0)
+    data = {
+        "tokens": _FakeTensor((1, 4)),
+        "labels": _FakeTensor((1, 4)),
+        "loss_mask": _FakeTensor((1, 4)),
+        "position_ids": _FakeTensor((1, 4)),
+    }
+
+    batch = common_utils.get_batch_on_this_tp_rank(iter([data]))
+
+    assert batch["cu_seqlens"] is None
+    assert all(tensor.numel() > 0 for tensor in batch_broadcast_env)
+
+
+def test_receiver_skips_empty_cu_seqlens_broadcast(monkeypatch, batch_broadcast_env):
+    monkeypatch.setattr(common_utils.mpu, "get_tensor_model_parallel_rank", lambda: 1)
+
+    batch = common_utils.get_batch_on_this_tp_rank(None)
+
+    assert batch["cu_seqlens"] is None
+    assert all(tensor.numel() > 0 for tensor in batch_broadcast_env)


### PR DESCRIPTION
## Summary

- skip the `cu_seqlens` payload broadcast when its announced size is zero
- keep source and receiver control flow symmetric
- avoid issuing a zero-count NCCL collective backed by a null data pointer
- add source-rank and receiver-rank unit coverage

This is an independent correctness fix. It is not required by the full-CUDA-graph path, which returns before this broadcast, but it fixes no-CG/mock-data execution where the empty tensor can reach NCCL.

## Validation

- failing job before the fix: `2548853`
- passing job with the fix: `2549134`
- `CHECK_ONLY=true BASE_REF=dev uv run --no-sync --project /home/scratch.hongbinl_sw/work/fsdp/agentic-mcore-dev --extra mcore-lint -- bash tools/autoformat.sh`
- `PYTHONIOENCODING=utf-8 python3 tools/check_copyright.py megatron/training/utils/common_utils.py tests/unit_tests/training/test_common_utils.py`
- `python3 -m py_compile megatron/training/utils/common_utils.py tests/unit_tests/training/test_common_utils.py`

The local toolkit environment does not contain PyTorch, so import-dependent pytest/mypy execution is deferred to the Megatron CI container.

🤖 Generated with Codex
