### PR TITLE
Exit non-zero when --exit-on-missing-checkpoint triggers

### DIFF
--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -1740,10 +1740,16 @@ def _load_base_checkpoint(
             print_rank_0('    will not load any checkpoints and will start from random')
         # Conditionally exit if checkpoint not found.
         if args.exit_on_missing_checkpoint:
-            print_rank_0(">> '--exit-on-missing-checkpoint' set ... exiting. <<")
+            print_rank_0(
+                ">> '--exit-on-missing-checkpoint' is set but no checkpoint was found under "
+                f"load directory '{load_dir}' (missing metadata/tracker file "
+                f"'{tracker_filename}'). Exiting with a non-zero status. <<"
+            )
             if torch.distributed.is_initialized():
                 torch.distributed.barrier()
-            sys.exit()
+            # Exit non-zero so that callers (e.g. CI harnesses) detect the missing
+            # checkpoint as a failure instead of silently treating exit code 0 as success.
+            sys.exit(1)
 
         return None, '', False, None
 


### PR DESCRIPTION
## What does this PR do?

When `--exit-on-missing-checkpoint` is set and no checkpoint is found,
`_load_base_checkpoint` (in `megatron/training/checkpointing.py`) called
`sys.exit()` with **no argument**, i.e. exit code **0**. Callers — notably CI
functional-test harnesses — therefore treat a *missing required checkpoint* as
a **successful** run and continue, which produces confusing downstream
failures far from the real cause.

Concrete example: a dynamic-inference functional test whose checkpoint is not
staged in the CI artifacts tree exits cleanly (code 0) before generating
anything, never writes its `INFERENCE_OUTPUT_PATH`, and then fails only at the
golden-value comparison step with an opaque
`FileNotFoundError: .../golden_values_dev_dgx_h100.json` — giving no hint that
the checkpoint was the problem.

This PR makes the missing-checkpoint path fail loudly at its source:

- Exit with a **non-zero** status (`sys.exit(1)`) so callers/CI detect the
  failure instead of silently treating exit code 0 as success.
- Print a **descriptive message** naming the `--load` directory and the missing
  metadata/tracker file.

## Behavior change

`--exit-on-missing-checkpoint` with a missing checkpoint now returns a non-zero
exit code (previously 0). This flag is only meant to guard "this checkpoint is
required; stop if it's absent," so surfacing it as a failure is the intended
semantics and is consistent across its callers (inference examples, text
generation server, checkpoint converter).

## Test plan

- [ ] Run any inference functional test with a `--load` path that does not
  exist and confirm the job exits non-zero with the new message, instead of
  exiting 0 and later failing on a missing golden/output file.
- [ ] Confirm normal runs (checkpoint present) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)