### PR TITLE
chore(ci): bump community workflow to v1.8.8

### DIFF
--- a/.github/workflows/community-bot.yml
+++ b/.github/workflows/community-bot.yml
@@ -21,9 +21,11 @@ on:
 
 jobs:
   community-bot:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_community_bot.yml@f0dadfd1b2d5c3f48a24ded127abd50afbf8ce11 # v0.65.10
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_community_bot.yml@0af357dc15c04c3f28d33478d5055b1ca88a9ea1 # v1.8.8
     with:
       community_project_id: ${{ vars.COMMUNITY_PROJECT_ID }}
+      app-id: ${{ vars.BOT_ID }}
     if: github.repository == 'NVIDIA/Megatron-LM'
     secrets:
+      BOT_KEY: ${{ secrets.BOT_KEY }}
       GH_TOKEN: ${{ secrets.PAT }}


### PR DESCRIPTION
## Background / motivation

- The previous `v1.8.7` bump was reverted because replacing the PAT with only a repository-scoped GitHub App token broke private NVIDIA organization membership checks and cross-organization project writes.
- `v1.8.8` preserves the PAT for membership and project operations while retaining GitHub App authentication where supported.

## What changed

- Pin the reusable community workflow to the commit behind `v1.8.8`.
- Pass `BOT_ID` and `BOT_KEY` for GitHub App authentication.
- Retain `PAT` as `GH_TOKEN` for membership checks and cross-organization project access.

## Details

- Updated `.github/workflows/community-bot.yml`.
- Pinned `NVIDIA-NeMo/FW-CI-templates` to `0af357dc15c04c3f28d33478d5055b1ca88a9ea1` instead of using a mutable tag.
- No flowchart: this is a single reusable-workflow caller update.

## Tested

- `gh api repos/NVIDIA-NeMo/FW-CI-templates/git/ref/tags/v1.8.8` — verified the tag resolves to commit `0af357dc15c04c3f28d33478d5055b1ca88a9ea1`.
- `actionlint .github/workflows/community-bot.yml` — passed with actionlint 1.7.12.
- `git diff --check` — passed.
- `pre-commit run --files .github/workflows/community-bot.yml` — completed; configured Python-only hooks skipped the YAML file.