### PR TITLE
Support reentrant activation recomputation in MFSDP

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -28,6 +28,11 @@ from .parameter_group import FsdpParameterGroup, get_containing_parameter_group
 from .placement import MeshAxis, Placements
 
 
+def _is_in_backward() -> bool:
+    """Return whether the current thread is executing an autograd GraphTask."""
+    return torch._C._current_graph_task_id() != -1
+
+
 class FsdpContextPhase(enum.Enum):
     """The lifecycle phase of an FSDP context.
 
@@ -254,6 +259,10 @@ class FsdpModule:
         torch.cuda.nvtx.range_push(self._nvtx_label("forward"))
         self._ready_grad_parameters.clear()
         context = self.context
+        # A reentrant checkpoint recomputes before the child module's backward-pre
+        # hook can set the context phase. Its forward still runs inside the active
+        # autograd GraphTask, which is the signal PyTorch FSDP2 uses as well.
+        is_recomputing = context.phase is FsdpContextPhase.BACKWARD or _is_in_backward()
         allgather_stream = context.allgather_stream
         current_stream = context.current_stream()
 
@@ -269,7 +278,7 @@ class FsdpModule:
         # Activation recomputation runs forward hooks inside backward. Do not
         # prefetch the next module in forward order: its backward may already
         # be complete, so no later backward hook would reshard it.
-        if context.phase is not FsdpContextPhase.BACKWARD:
+        if not is_recomputing:
             next_module = context.forward_order.next_item(self)
             if next_module is not None:
                 next_module._unshard_parameter_groups()
@@ -296,7 +305,8 @@ class FsdpModule:
         # Recomputed parameters are consumed immediately by this module's
         # backward. Keep them materialized to avoid an unnecessary all-gather;
         # post_backward() will reshard them after gradient reduction.
-        if self.context.phase is not FsdpContextPhase.BACKWARD:
+        is_recomputing = self.context.phase is FsdpContextPhase.BACKWARD or _is_in_backward()
+        if not is_recomputing:
             self._reshard_parameter_groups()
         torch.cuda.nvtx.range_pop()
 

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -47,16 +47,12 @@ class TinyModel(nn.Module):
 
 
 class CheckpointedTinyModel(TinyModel):
-    """Tiny model that activation-checkpoints each shardable module."""
-
-    def __init__(self, use_reentrant: bool) -> None:
-        super().__init__()
-        self.use_reentrant = use_reentrant
+    """Tiny model that reentrantly checkpoints each shardable module."""
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Run each linear layer through activation checkpointing."""
-        x = checkpoint(self.fc1, x, use_reentrant=self.use_reentrant)
-        return checkpoint(self.fc2, self.relu(x), use_reentrant=self.use_reentrant)
+        """Run each linear layer through reentrant activation checkpointing."""
+        x = checkpoint(self.fc1, x, use_reentrant=True)
+        return checkpoint(self.fc2, self.relu(x), use_reentrant=True)
 
 
 class NestedModel(nn.Module):
@@ -204,14 +200,13 @@ def test_fully_shard_sgd_losses_match_baseline(distributed_setup, num_microbatch
     )
 
 
-@pytest.mark.parametrize("use_reentrant", [True, False], ids=["reentrant", "non_reentrant"])
-def test_fully_shard_activation_recompute_reshards_parameters(distributed_setup, use_reentrant):
-    """Activation recomputation should leave every FSDP module resharded."""
+def test_fully_shard_reentrant_activation_recompute_reshards_parameters(distributed_setup):
+    """Reentrant activation recomputation should leave every FSDP module resharded."""
     world_size = distributed_setup.world_size
     device = distributed_setup.device
 
     mesh = init_device_mesh(device.type, (world_size,))
-    model = CheckpointedTinyModel(use_reentrant=use_reentrant).to(device)
+    model = CheckpointedTinyModel().to(device)
     fully_shard(model.fc1, mesh=mesh, placements=_flat_placements())
     fully_shard(model.fc2, mesh=mesh, placements=_flat_placements())
     fully_shard(model, mesh=mesh, placements=_flat_placements())


### PR DESCRIPTION
## What changed

- Detect execution inside an autograd GraphTask using the same signal as PyTorch FSDP2.
- Treat a forward running inside backward as activation recomputation before the child backward-pre hook updates the shared MFSDP phase.
- Avoid forward prefetch and post-forward resharding during reentrant recomputation.
- Narrow the existing activation-recomputation coverage to the reentrant checkpoint path addressed here.

## Why

With reentrant activation checkpointing, a child module can begin its recomputed forward before that child module’s backward-pre hook runs. The shared phase alone therefore cannot reliably identify the recomputation. PyTorch FSDP2 handles this ordering by checking whether execution is inside an active autograd GraphTask; this change applies that signal to MFSDP while retaining the existing phase check for non-reentrant behavior.

This PR is stacked on #6153 and contains only the reentrant-mode follow-up.

## Validation

- `python3 -m torch.distributed.run --nproc-per-node 2 -m pytest -q tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py::test_fully_shard_reentrant_activation_recompute_reshards_parameters`
- Ruff
- Black
- `git diff --check`