### PR TITLE
Add multimodal argument and config plumbing

### DIFF
--- a/examples/multimodal/config.py
+++ b/examples/multimodal/config.py
@@ -6,162 +6,152 @@ import torch
 from megatron.core.activations import fast_gelu, quick_gelu, squared_relu
 
 
-def get_language_model_config(config):
+def get_language_model_config(config, enable_fusions=False, apply_rope_fusion=None):
+    config.bias_activation_fusion = enable_fusions
+    config.bias_dropout_fusion = enable_fusions
+    config.apply_rope_fusion = enable_fusions
+    if apply_rope_fusion is not None:
+        config.apply_rope_fusion = apply_rope_fusion
+
     if config.language_model_type == "llama3_8b":
         config.activation_func = torch.nn.functional.silu
         config.add_bias_linear = False
-        config.bias_activation_fusion = False
         config.gated_linear_unit = True
         config.apply_query_key_layer_scaling = False
         config.layernorm_zero_centered_gamma = (
             False  # Zero centered gamma not supported for RMSNorm
         )
-        config.bias_dropout_fusion = False
-        config.apply_rope_fusion = False
         config.attention_softmax_in_fp32 = True
         config.ffn_hidden_size = 14336
     elif config.language_model_type == "llama3.1_8b":
         config.activation_func = torch.nn.functional.silu
         config.add_bias_linear = False
-        config.bias_activation_fusion = False
         config.gated_linear_unit = True
         config.apply_query_key_layer_scaling = False
         config.layernorm_zero_centered_gamma = (
             False  # Zero centered gamma not supported for RMSNorm
         )
-        config.bias_dropout_fusion = False
-        config.apply_rope_fusion = False
         config.attention_softmax_in_fp32 = True
         config.ffn_hidden_size = 14336
     elif config.language_model_type == "llama3.1_70B":
         config.activation_func = torch.nn.functional.silu
         config.add_bias_linear = False
-        config.bias_activation_fusion = False
         config.gated_linear_unit = True
         config.apply_query_key_layer_scaling = False
         config.layernorm_zero_centered_gamma = (
             False  # Zero centered gamma not supported for RMSNorm
         )
-        config.bias_dropout_fusion = False
-        config.apply_rope_fusion = False
         config.attention_softmax_in_fp32 = True
         config.ffn_hidden_size = 28672
     elif config.language_model_type == "mistral_7b":
         config.activation_func = torch.nn.functional.silu
         config.add_bias_linear = False
-        config.bias_activation_fusion = False
         config.gated_linear_unit = True
         config.apply_query_key_layer_scaling = False
         config.layernorm_zero_centered_gamma = (
             False  # Zero centered gamma not supported for RMSNorm
         )
-        config.bias_dropout_fusion = False
-        config.apply_rope_fusion = False
         config.attention_softmax_in_fp32 = True
         config.ffn_hidden_size = 14336
     elif config.language_model_type == "nemotron5-8b":
         config.add_bias_linear = False
-        config.bias_activation_fusion = False
         config.gated_linear_unit = False
-        config.bias_dropout_fusion = False
-        config.apply_rope_fusion = False
         config.activation_func = squared_relu
+        config.bias_activation_fusion = False
         config.ffn_hidden_size = 21504
         config.masked_softmax_fusion = True
         config.attention_softmax_in_fp32 = True
     elif config.language_model_type == "yi-34b":
         config.activation_func = torch.nn.functional.silu
         config.add_bias_linear = False
-        config.bias_activation_fusion = False
         config.gated_linear_unit = True
         config.apply_query_key_layer_scaling = False
         config.layernorm_zero_centered_gamma = (
             False  # Zero centered gamma not supported for RMSNorm
         )
-        config.bias_dropout_fusion = False
-        config.apply_rope_fusion = False
         config.attention_softmax_in_fp32 = True
         config.ffn_hidden_size = 20480
     elif config.language_model_type == "qwen2.0_72B":
         config.activation_func = torch.nn.functional.silu
         config.add_bias_linear = False
         config.add_qkv_bias = True
-        config.bias_activation_fusion = False
         config.gated_linear_unit = True
         config.apply_query_key_layer_scaling = False
         config.layernorm_zero_centered_gamma = (
             False  # Zero centered gamma not supported for RMSNorm
         )
-        config.bias_dropout_fusion = False
-        config.apply_rope_fusion = False
         config.attention_softmax_in_fp32 = True
         config.ffn_hidden_size = 29568
     elif config.language_model_type == "qwen2.5_7B":
         config.activation_func = torch.nn.functional.silu
         config.add_bias_linear = False
         config.add_qkv_bias = True
-        config.bias_activation_fusion = False
         config.gated_linear_unit = True
         config.apply_query_key_layer_scaling = False
         config.layernorm_zero_centered_gamma = (
             False  # Zero centered gamma not supported for RMSNorm
         )
-        config.bias_dropout_fusion = False
-        config.apply_rope_fusion = False
         config.attention_softmax_in_fp32 = True
         config.ffn_hidden_size = 18944
     elif config.language_model_type == "qwen2.5_72B":
         config.activation_func = torch.nn.functional.silu
         config.add_bias_linear = False
         config.add_qkv_bias = True
-        config.bias_activation_fusion = False
         config.gated_linear_unit = True
         config.apply_query_key_layer_scaling = False
         config.layernorm_zero_centered_gamma = (
             False  # Zero centered gamma not supported for RMSNorm
         )
-        config.bias_dropout_fusion = False
-        config.apply_rope_fusion = False
         config.attention_softmax_in_fp32 = True
         config.ffn_hidden_size = 29568
     elif config.language_model_type == "nemotron5-hybrid-8b":
         config.activation_func = squared_relu
+        config.bias_activation_fusion = False
         config.squared_relu = True
         config.add_bias_linear = False
-        config.bias_activation_fusion = False
         config.apply_query_key_layer_scaling = False
         config.gated_linear_unit = False
         config.layernorm_zero_centered_gamma = (
             False  # Zero centered gamma not supported for RMSNorm
         )
-        config.bias_dropout_fusion = False
         config.attention_softmax_in_fp32 = True
         config.ffn_hidden_size = 21504
-    elif config.language_model_type == "nemotron5-hybrid-56b":
+    elif config.language_model_type == "nemotron5-hybrid-12b":
         config.activation_func = squared_relu
+        config.bias_activation_fusion = False
         config.squared_relu = True
         config.add_bias_linear = False
-        config.bias_activation_fusion = False
         config.apply_query_key_layer_scaling = False
         config.gated_linear_unit = False
         config.layernorm_zero_centered_gamma = (
             False  # Zero centered gamma not supported for RMSNorm
         )
-        config.bias_dropout_fusion = False
+        config.attention_softmax_in_fp32 = True
+        config.ffn_hidden_size = 20480
+        config.mamba_state_dim = 128
+        config.mamba_num_heads = 128
+        config.mamba_head_dim = 80
+    elif config.language_model_type == "nemotron5-hybrid-56b":
+        config.activation_func = squared_relu
+        config.bias_activation_fusion = False
+        config.squared_relu = True
+        config.add_bias_linear = False
+        config.apply_query_key_layer_scaling = False
+        config.gated_linear_unit = False
+        config.layernorm_zero_centered_gamma = (
+            False  # Zero centered gamma not supported for RMSNorm
+        )
         config.attention_softmax_in_fp32 = True
         config.ffn_hidden_size = 32768
         config.mamba_state_dim = 256
     elif config.language_model_type == "llama3.2_1b":
         config.activation_func = torch.nn.functional.silu
         config.add_bias_linear = False
-        config.bias_activation_fusion = False
         config.gated_linear_unit = True
         config.apply_query_key_layer_scaling = False
         config.layernorm_zero_centered_gamma = (
             False  # Zero centered gamma not supported for RMSNorm
         )
-        config.bias_dropout_fusion = False
-        config.apply_rope_fusion = False
         config.attention_softmax_in_fp32 = True
         config.ffn_hidden_size = 8192
     elif config.language_model_type.startswith("hf://"):
@@ -170,13 +160,36 @@ def get_language_model_config(config):
         hf_config = transformers.AutoConfig.from_pretrained(config.language_model_type.split("hf://")[1])
         config.hf_config = hf_config
         config.hidden_size = hf_config.hidden_size
+    elif config.language_model_type == "llama_nemotron_8b":
+        config.activation_func = torch.nn.functional.silu
+        config.add_bias_linear = False
+        config.bias_activation_fusion = False
+        config.gated_linear_unit = True
+        config.apply_query_key_layer_scaling = False
+        config.layernorm_zero_centered_gamma = (
+            False  # Zero centered gamma not supported for RMSNorm
+        )
+        config.bias_dropout_fusion = False
+        config.apply_rope_fusion = False
+        config.attention_softmax_in_fp32 = True
+        config.ffn_hidden_size = 14336
+    elif config.language_model_type == "nemotron6-moe":
+        config.bias_activation_fusion = False
+        config.bias_dropout_fusion = False
     else:
         raise ValueError(f"unknown language model type {config.language_model_type}")
 
     return config
 
 
-def get_vision_model_config(config, apply_query_key_layer_scaling):
+def get_vision_model_config(config, enable_fusions=False):
+    config.bias_activation_fusion = False   # Radio uses an incompatible activation func.
+    config.bias_dropout_fusion = enable_fusions
+    config.apply_rope_fusion = enable_fusions
+
+    if config.language_model_type == "nemotron6-moe":
+        config.bias_dropout_fusion = False
+
     if config.vision_model_type == "clip":
         config.num_layers = 24
         config.num_attention_heads = 16
@@ -191,12 +204,10 @@ def get_vision_model_config(config, apply_query_key_layer_scaling):
         config.kv_channels = 64
         config.num_query_groups = 16
         config.layernorm_zero_centered_gamma = False
-        config.apply_query_key_layer_scaling = apply_query_key_layer_scaling
-        config.bias_activation_fusion = False
-        config.bias_dropout_fusion = False
+        config.apply_query_key_layer_scaling = False
         config.attention_softmax_in_fp32 = True
         config.normalization = 'LayerNorm'
-        config.apply_rope_fusion = False
+        config.class_token_len = 1
     elif config.vision_model_type == "siglip":
         config.num_layers = 27
         config.num_attention_heads = 16
@@ -211,14 +222,12 @@ def get_vision_model_config(config, apply_query_key_layer_scaling):
         config.kv_channels = 72
         config.num_query_groups = 16
         config.layernorm_zero_centered_gamma = False
-        config.apply_query_key_layer_scaling = apply_query_key_layer_scaling
-        config.bias_activation_fusion = False
-        config.bias_dropout_fusion = False
+        config.apply_query_key_layer_scaling = False
         config.attention_softmax_in_fp32 = True
         config.normalization = 'LayerNorm'
-        config.apply_rope_fusion = False
         config.qk_layernorm = False
         config.layernorm_epsilon = 1e-6
+        config.class_token_len = 0
     elif config.vision_model_type == "internvit":
         config.num_layers = 45
         config.num_attention_heads = ((24 // config.tensor_model_parallel_size) + 1) * config.tensor_model_parallel_size
@@ -232,13 +241,11 @@ def get_vision_model_config(config, apply_query_key_layer_scaling):
         config.gated_linear_unit = False
         config.activation_func = torch.nn.functional.gelu
         config.layernorm_zero_centered_gamma = False
-        config.apply_query_key_layer_scaling = apply_query_key_layer_scaling
-        config.bias_activation_fusion = False
-        config.bias_dropout_fusion = False
+        config.apply_query_key_layer_scaling = False
         config.attention_softmax_in_fp32 = True
         config.normalization = 'RMSNorm'
         config.layernorm_epsilon = 1e-6
-        config.apply_rope_fusion = False
+        config.class_token_len = 1
     elif config.vision_model_type == "internvit300M":
         config.num_layers = 24
         config.num_attention_heads = 16
@@ -252,14 +259,12 @@ def get_vision_model_config(config, apply_query_key_layer_scaling):
         config.gated_linear_unit = False
         config.activation_func = torch.nn.functional.gelu
         config.layernorm_zero_centered_gamma = False
-        config.apply_query_key_layer_scaling = apply_query_key_layer_scaling
-        config.bias_activation_fusion = False
-        config.bias_dropout_fusion = False
+        config.apply_query_key_layer_scaling = False
         config.attention_softmax_in_fp32 = True
         config.normalization = 'LayerNorm'
         config.layernorm_epsilon = 1e-6
-        config.apply_rope_fusion = False
         config.qk_layernorm = False
+        config.class_token_len = 1
     elif config.vision_model_type == "radio":
         config.num_layers = 32
         config.num_attention_heads = 16
@@ -272,14 +277,12 @@ def get_vision_model_config(config, apply_query_key_layer_scaling):
         config.kv_channels = 80
         config.num_query_groups = 16
         config.layernorm_zero_centered_gamma = False
-        config.apply_query_key_layer_scaling = apply_query_key_layer_scaling
-        config.bias_activation_fusion = False
-        config.bias_dropout_fusion = False
+        config.apply_query_key_layer_scaling = False
         config.attention_softmax_in_fp32 = True
         config.normalization = 'LayerNorm'
-        config.apply_rope_fusion = False
         config.qk_layernorm = False
         config.layernorm_epsilon = 1e-6
+        config.class_token_len = 8
     elif config.vision_model_type == "radio-g":
         config.num_layers = 40
         config.num_attention_heads = 24
@@ -292,14 +295,12 @@ def get_vision_model_config(config, apply_query_key_layer_scaling):
         config.kv_channels = 64
         config.num_query_groups = 24
         config.layernorm_zero_centered_gamma = False
-        config.apply_query_key_layer_scaling = apply_query_key_layer_scaling
-        config.bias_activation_fusion = False
-        config.bias_dropout_fusion = False
+        config.apply_query_key_layer_scaling = False
         config.attention_softmax_in_fp32 = True
         config.normalization = 'LayerNorm'
-        config.apply_rope_fusion = False
         config.qk_layernorm = False
         config.layernorm_epsilon = 1e-6
+        config.class_token_len = 5
     elif config.vision_model_type == "cradio-g":
         config.num_layers = 40
         config.num_attention_heads = 24
@@ -312,14 +313,12 @@ def get_vision_model_config(config, apply_query_key_layer_scaling):
         config.kv_channels = 64
         config.num_query_groups = 24
         config.layernorm_zero_centered_gamma = False
-        config.apply_query_key_layer_scaling = apply_query_key_layer_scaling
-        config.bias_activation_fusion = False
-        config.bias_dropout_fusion = False
+        config.apply_query_key_layer_scaling = False
         config.attention_softmax_in_fp32 = True
         config.normalization = 'LayerNorm'
-        config.apply_rope_fusion = False
         config.qk_layernorm = False
         config.layernorm_epsilon = 1e-6
+        config.class_token_len = 8
     elif config.vision_model_type.startswith("hf://"):
         import transformers
         hf_config = transformers.AutoConfig.from_pretrained(config.vision_model_type.split("hf://")[1])
@@ -331,16 +330,20 @@ def get_vision_model_config(config, apply_query_key_layer_scaling):
     return config
 
 
-def get_vision_projection_config(config, hidden_size):
+def get_vision_projection_config(config, hidden_size, enable_fusions=False):
     # If using FP8, then keep the whole vision projection in FP8.
     config.first_last_layers_bf16 = False
     config.num_layers_at_start_in_bf16 = 0
     config.num_layers_at_end_in_bf16 = 0
 
     config.gated_linear_unit = False
-    config.bias_activation_fusion = False
     config.add_bias_linear = False
     config.hidden_size = hidden_size  # Used as the vision projection output size, i.e., the input to the language model.
+
+    config.bias_activation_fusion = enable_fusions
+    config.bias_dropout_fusion = enable_fusions
+    config.apply_rope_fusion = enable_fusions
+
     if config.language_model_type == "llama3_8b":
         config.ffn_hidden_size = 14336
         config.activation_func = torch.nn.functional.gelu
@@ -372,9 +375,19 @@ def get_vision_projection_config(config, hidden_size):
     elif config.language_model_type == "nemotron5-hybrid-56b":
         config.ffn_hidden_size = 32768
         config.activation_func = squared_relu
+        config.bias_activation_fusion = False
     elif config.language_model_type in ("nemotron5-8b", "nemotron5-hybrid-8b"):
         config.ffn_hidden_size = 21504
         config.activation_func = squared_relu
+        config.bias_activation_fusion = False
+    elif config.language_model_type == "nemotron5-hybrid-12b":
+        config.ffn_hidden_size = 20480
+        config.activation_func = squared_relu
+        config.bias_activation_fusion = False
+    elif config.language_model_type == "nemotron6-moe":
+        config.ffn_hidden_size = 20480
+        config.bias_activation_fusion = False
+        config.bias_dropout_fusion = False
     elif config.language_model_type == "llama3.2_1b":
         config.ffn_hidden_size = 2048
         config.activation_func = torch.nn.functional.gelu
@@ -382,6 +395,53 @@ def get_vision_projection_config(config, hidden_size):
     elif config.language_model_type.startswith("hf://"):
         config.activation_func = torch.nn.functional.gelu
         config.ffn_hidden_size = 4096
+        config.normalization = "LayerNorm"
+    elif config.language_model_type == "llama_nemotron_8b":
+        config.ffn_hidden_size = 14336
+        config.activation_func = torch.nn.functional.gelu
+        config.layernorm_epsilon = 1e-5
+        config.add_bias_linear = True
+        config.normalization = "LayerNorm"
+    else:
+        raise ValueError(f"unknown language model type {config.language_model_type}")
+
+    return config
+
+
+def get_sound_model_config(config):
+    if config.sound_model_type.startswith("nemo://"):
+        from megatron.core.models.huggingface.fastconformer_model import get_nemo_sound_model
+
+        _, encoder = get_nemo_sound_model(config.sound_model_type)
+        config.hidden_size = encoder.d_model
+    else:
+        raise ValueError(f"unknown sound model type {config.sound_model_type}")
+
+    return config
+
+def get_sound_projection_config(config, hidden_size, enable_fusions=False):
+    config.gated_linear_unit = False
+    config.add_bias_linear = False
+    config.hidden_size = hidden_size  # Used as the vision projection output size, i.e., the input to the language model.
+
+    config.bias_activation_fusion = enable_fusions
+    config.bias_dropout_fusion = enable_fusions
+    config.apply_rope_fusion = enable_fusions
+
+    if config.language_model_type == "llama3.1_8b":
+        config.ffn_hidden_size = 4096
+        config.activation_func = torch.nn.functional.gelu
+        config.layernorm_epsilon = 1e-5
+        config.add_bias_linear = True
+        config.normalization = "LayerNorm"
+    elif config.language_model_type == "nemotron6-moe":
+        config.ffn_hidden_size = 4096
+        config.bias_activation_fusion = False
+    elif config.language_model_type == "llama_nemotron_8b":
+        config.ffn_hidden_size = 14336
+        config.activation_func = torch.nn.functional.gelu
+        config.layernorm_epsilon = 1e-5
+        config.add_bias_linear = True
         config.normalization = "LayerNorm"
     else:
         raise ValueError(f"unknown language model type {config.language_model_type}")
@@ -410,3 +470,6 @@ class EvaluationConfig:
     num_partitions: int = 0
     partition_id: int = 0
     num_samples_per_partition: int = 0
+
+    # Tokenizer kwargs
+    enable_thinking: bool = False

--- a/examples/multimodal/multimodal_args.py
+++ b/examples/multimodal/multimodal_args.py
@@ -9,11 +9,19 @@ def add_multimodal_extra_args(parser):
     group.add_argument("--prompt-path", type=str, default=None)
     group.add_argument('--freeze-LM', action='store_true', default=False)
     group.add_argument('--freeze-ViT', action='store_true', default=False)
+    group.add_argument('--freeze-sound-model', action='store_true', default=False)
     group.add_argument('--language-model-type', type=str, required=True)
     group.add_argument('--vision-model-type', type=str, default="clip")
+    group.add_argument('--sound-model-type', type=str, default=None)
     group.add_argument("--disable-vision-class-token", action="store_true", default=False)
     group.add_argument(
         "--allow-missing-vision-projection-checkpoint", action="store_true", default=False
+    )
+    group.add_argument(
+        "--allow-missing-sound-projection-checkpoint", action="store_true", default=False
+    )
+    group.add_argument(
+        "--allow-missing-sound-model-checkpoint", action="store_true", default=False
     )
     group.add_argument("--use-te", action="store_true", default=False)
     group.add_argument(
@@ -27,9 +35,31 @@ def add_multimodal_extra_args(parser):
         "--use-thumbnail", action="store_true", default=False, help="Add image thumbnail as a tile"
     )
     group.add_argument(
+        "--thumbnail-area-threshold", type=float, default=0.8,
+        help="Maximum area percentage (0.0-1.0) of resized image relative to thumbnail area for which to add thumbnail. Default 0.8 (80%)"
+    )
+    group.add_argument(
         "--dataloader-seq-length",
         type=int,
         help="Make dataloader to produce sequences of specific length.",
+    )
+    group.add_argument(
+        "--dataloader-seed",
+        type=int,
+        default=0,
+        help="The seed for the dataloader to use for training.",
+    )
+    group.add_argument(
+        "--lr-data-range-start",
+        type=float,
+        default=0,
+        help="Start of the learning rate range as percentage (0-100) of the full training schedule. 0% means start from the beginning of the training schedule. E.g. setting to 10, means start at 10% of the training schedule (the dataloader still starts from the beginning of the dataset, but assume that corresponds to 10% of the training schedule)."
+    )
+    group.add_argument(
+        "--lr-data-range-end",
+        type=float,
+        default=100,
+        help="End of the learning rate range as percentage (0-100) of the full training schedule. 100% means the end of the training schedule. E.g. setting to 90, means end at 90% of the training schedule (the dataloader still ends at the end of the dataset, but assume that corresponds to 90% of the training schedule)."
     )
     group.add_argument(
         "--num-frames",
@@ -50,7 +80,8 @@ def add_multimodal_extra_args(parser):
         "--tokenizer-prompt-format",
         type=str,
         choices=["mistral", "llama3", "chatml", "nvlm-yi-34b", "qwen2p0", "qwen2p5", "llama3p1", "nemotron5",
-                 "nemotron5-aligned"],
+                 "nemotron5-aligned", "llama_nemotron_8b", "nemotron-h-5p5-reasoning",
+                 "nemotron-h-5p5-reasoning-inference", "nemotron6-moe"],
         required=True,
         help="Prompt format to use with the tokenizer.",
     )
@@ -63,6 +94,7 @@ def add_multimodal_extra_args(parser):
         help="Surround image tokens with tags.",
     )
     group.add_argument("--use-tile-tags", action="store_true", default=False, help="Use tile tags")
+    group.add_argument("--class-token-len", type=int, default=None, help="Length of class token. If not set, uses model-specific defaults (radio: 8, radio-g: 5, cradio-g: 8). FP8 overrides to 16.")
     group.add_argument(
         "--packing-buffer-size",
         type=int,
@@ -73,7 +105,13 @@ def add_multimodal_extra_args(parser):
         "--packing-seq-length", type=int, default=0, help="Packing sequence length. Must be > 0 if using packing."
     )
     group.add_argument(
+        "--packing-knapsack-algorithm", type=str, default="greedy_knapsack", help="Knapsack algorithm to use for packing."
+    )
+    group.add_argument(
         "--recompute-vision", action="store_true", default=False, help="Enable activation checkpointing in the vision model"
+    )
+    group.add_argument(
+        "--recompute-sound", action="store_true", default=False, help="Enable activation checkpointing in the sound model"
     )
     group.add_argument(
         "--use-loss-scaling", action="store_true", default=False, help="Scale loss based on conversation turn length (in tokens)."
@@ -89,5 +127,248 @@ def add_multimodal_extra_args(parser):
             "image aspect ratio and the area covered by the tiles.")
     )
     group.add_argument("--use-mcore-inference", action="store_true", default=False, help="Use the MCore inference API")
+    group.add_argument("--use-vision-backbone-fp8-arch", action="store_true", default=False, help="Use the FP8 arch in the vision backbone. This is used to load the FP8 checkpoint when running inference.")
+    group.add_argument(
+        "--dynamic-resolution", action="store_true", default=False, help="Use input image dynamic resolution"
+    )
+    group.add_argument(
+        "--dynamic-resolution-min-patches", type=int, default=0, help="Minimum number of patches per image for dynamic resolution"
+    )
+    group.add_argument(
+        "--dynamic-resolution-max-patches", type=int, default=0, help="Maximum number of patches per image for dynamic resolution"
+    )
+    group.add_argument(
+        "--dynamic-resolution-min-side", type=int, default=None, help="Minimum side length for dynamic resolution"
+    )
+    group.add_argument(
+        "--match-tiling-dynamic-resolution", action="store_true", default=False,
+        help="Use match-tiling dynamic resolution strategy that combines tiling logic with dynamic resolution processing"
+    )
+    group.add_argument(
+        "--masked-tiling-dynamic-resolution", action="store_true", default=False,
+        help="Use masked-tiling dynamic resolution strategy that isolates tiles as separate packed samples"
+    )
+    group.add_argument(
+        "--image-break-token", type=str, default=None, help="Token to use for image break tokens, must be added to --special-tokens as well"
+    )
+    group.add_argument("--conv-merging", action="store_true", default=False, help="Use convolution merging which uses a convolution to merge tokens after the vision encoder")
+    group.add_argument(
+        "--allow-missing-conv-merge-checkpoint", action="store_true", default=False
+    )
+    group.add_argument(
+        "--video-min-num-frames", type=int, default=8, help="Minimum number of frames to sample from the video as input to the model.",
+    )
+    group.add_argument(
+        "--video-max-num-frames", type=int, default=32, help="Maximum number of frames to sample from the video as input to the model.",
+    )
+    group.add_argument(
+        "--video-default-fps", type=int, default=2, help="Default frames per second to sample from the video as input to the model.",
+    )
+    group.add_argument(
+        "--video-frame-temporal-jitter", action="store_true", default=False, help="Enable temporal jittering of the frames to sample from the video as input to the model.",
+    )
+    group.add_argument(
+        "--video-target-img-size", type=int, default=None,
+        help="Target image size (pixels) for video frames with dynamic resolution. "
+             "Default None, must specify this or video_target_num_patches."
+    )
+    group.add_argument(
+        "--video-target-num-patches", type=int, default=None,
+        help=(
+            "Target number of patches for video frames. Default None, must specify this or video_target_img_size."
+        )
+    )
+    group.add_argument(
+        "--video-maintain-aspect-ratio", action="store_true", default=False,
+        help="Match video native aspect ratio while respecting target patch budget."
+    )
+    # Temporal compression arguments
+    group.add_argument(
+        "--video-temporal-patch-size", type=int, default=1,
+        help="Temporal patch size for video frames. Default 1 (no temporal compression). "
+             "Set to 2 to group pairs of frames into 3D tubelets for temporal compression."
+    )
+    group.add_argument(
+        "--allow-checkpoint-without-temporal-compression", action="store_true", default=False,
+        help="Allow loading a checkpoint without temporal compression into a model with temporal compression. "
+             "When set, the embedder weights will be duplicated along the temporal dimension if needed."
+    )
+    group.add_argument(
+        "--separate-video-embedder", action="store_true", default=False,
+        help="Use separate embedders for images and videos. When set, the image embedder (self.embedder) "
+             "expects C*P*P input, and a separate video embedder (self.video_embedder) expects C*T*P*P input. "
+             "This avoids duplicating image patches along the temporal dimension. "
+             "Only relevant when --video-temporal-patch-size > 1."
+    )
+    group.add_argument(
+        "--video-prompt-version", type=int, default=2,
+        help="Video prompt format version."
+             "1 = each frame on its own line, <image> at tubelet boundaries. "
+             "2 = group T frames with 'and', one <image> per group (generalization of 1 to support temporal compression)"
+    )
+    group.add_argument(
+        "--enable-fusions", action="store_true", default=True, help="Enable fusions in the model."
+    )
+    group.add_argument(
+        "--optimize-broadcast", action="store_true", default=True, help="Optimize the broadcast of data.",
+    )
+    group.add_argument(
+        "--recompute-vision-num-layers", type=int, default=0, help="Number of layers to recompute in the vision model."
+    )
+    group.add_argument(
+        "--recompute-granularity-vision", type=str, default=None, help="Granularity to recompute in the vision model.",
+        choices=["full", "selective"],
+    )
+    group.add_argument(
+        "--recompute-method-vision", type=str, default=None,
+        choices=['uniform', 'block'], help="Method to recompute in the vision model.",
+    )
+    group.add_argument(
+        "--recompute-vision-projection", action="store_true", default=False, help="Enable activation checkpointing in the vision projection layer."
+    )
+    group.add_argument(
+        "--recompute-sound-projection", action="store_true", default=False, help="Enable activation checkpointing in the sound projection layer."
+    )
+    group.add_argument(
+        "--allow-large-videos", action="store_true", default=False, help="Allow large videos to be loaded into the model."
+    )
+    group.add_argument(
+        "--efficient-video-sampling-variant", type=str, default=None, help="The EVS variant. Read docstring on EVSHelper"
+    )
+    group.add_argument(
+        "--sound-target-rate",
+        type=int,
+        default=16000,
+        help="Target rate of sound clips to regularly sample from the audio as input to the model.",
+    )
+    group.add_argument(
+        "--sound-embedding-size",
+        type=int,
+        default=750,
+        help="Size of the sound embedding.",
+    )
+    group.add_argument(
+        "--sound-clip-duration",
+        type=int,
+        default=30,
+        help="Sound model clip duration in seconds."
+    )
+    group.add_argument(
+        "--sound-min-duration",
+        type=float,
+        default=0.1,
+        help="We will pad the audio clip to at least this duration (in seconds), even when sound-pad-to-clip-duration is False."
+    )
+    group.add_argument(
+        "--sound-pad-to-clip-duration",
+        action="store_true",
+        default=False,
+        help="Pad every audio clip to the clip duration (introduces potentially many padding tokens in the LLM input)."
+    )
+    group.add_argument(
+        "--sound-batch-split",
+        type=int,
+        default=1,
+        help="Splits the sound batch into this many chunks to avoid OOMs. Not necessary when using bucketing; use this only when --sound-pad-to-clip-duration is not specified and bucketing is not enabled."
+    )
+    group.add_argument(
+        "--use-new-dataloader-path", action="store_true", default=False, help="Use the new dataloader path."
+    )
+    group.add_argument(
+        "--decoder-tp-comm-overlap", action="store_true", default=False, help="Enable tensor parallel communication overlap in the decoder."
+    )
+    group.add_argument(
+        "--freeze-vision-projection", action="store_true", default=False, help="Freeze the vision projection module."
+    )
+    group.add_argument(
+        "--freeze-sound-projection", action="store_true", default=False, help="Freeze the sound projection module."
+    )
+    group.add_argument(
+        "--relax-sender-check", action="store_true", default=False, help="Relax the sender check in the dataloader to allow other role than user and assistant."
+    )
+    group.add_argument(
+        "--relax-thinking-trace-check", action="store_true", default=False, help="Relax the checks in the dataloader which ensure the thinking trace is well formatted."
+    )
+    group.add_argument(
+        "--allow-cross-sample-attention", action="store_true", default=False, help="Allow cross sample attention when using sample packing."
+    )
+    group.add_argument(
+        "--only-keep-samples-with-img", action="store_true", default=False, help="Discard samples that do not have an image."
+    )
+    group.add_argument(
+        "--unfreeze-router", action="store_true", default=False, help="Unfreeze MoE router weights."
+    )
+    group.add_argument(
+        "--apply-data-augment", action="store_true", default=False,
+        help="Apply data augmentation to the image. DEPRECATED, will throw NotImplementedError if set to True."
+    )
+    group.add_argument(
+        "--radio-force-eval-mode",
+        action="store_true",
+        default=False,
+        help="Force RADIO to stay in eval mode (eval-mode CPE, no dropout). Recommended for pre-training."
+    )
+    group.add_argument(
+        "--radio-force-cpe-eval-mode",
+        action="store_true",
+        default=False,
+        help="Force RADIO to use CPE (cropped position embeddings) in eval mode. Recommended for SFT."
+    )
+    group.add_argument(
+        "--radio-interpolate-only-cpe",
+        action="store_true",
+        default=False,
+        help="Interpolate the position embeddings to input size, without any cropping."
+    )
+    group.add_argument(
+        "--radio-cpe-aspect-ratio-select",
+        action="store_true",
+        default=False,
+        help="Select position embeddings based on aspect ratio so long edge always mapped to 1."
+    )
+    group.add_argument(
+        "--radio-disable-cpe",
+        action="store_true",
+        default=False,
+        help="Disable cropped position embeddings in the radio model."
+    )
+    group.add_argument(
+        "--no-calculate-per-token-loss", action="store_true", default=False,
+        help="Disable calculating per-token loss."
+    )
+    group.add_argument(
+        "--tokenizer-keep-history-thinking", action="store_true", default=False,
+        help="Keep the history thinking in the tokenizer."
+    )
+    group.add_argument(
+        "--log-model-grad-norms", action="store_true", default=False, help="Log the gradient norms of the model components."
+    )
+    group.add_argument(
+        "--log-model-act-norms", action="store_true", default=False, help="Log the activation norms of the model components."
+    )
+    group.add_argument(
+        "--dynamic-resolution-no-truncate", action="store_true", default=False,
+        help="Disable trunctation during dynamic resolution, and instead throw away the entire sample"
+    )
+    group.add_argument(
+        "--video-aug-scale-frames-up", type=int, default=None,
+        help="Video data augmentation (scale UP): randomly sample s from 1..N and scale both "
+             "FPS and max_frames by s (iso-token mode), while dividing video_target_num_patches "
+             "by s. E.g. --video-aug-scale-frames-up 8 samples uniformly from {1,2,...,8}."
+    )
+    group.add_argument(
+        "--video-aug-scale-resolution-only", action="store_true", default=False,
+        help="When used with --video-aug-scale-frames-up or --video-aug-scale-resolution-up, "
+             "only change the image patch count without changing the frame count. "
+             "With --video-aug-scale-frames-up this reduces spatial resolution; "
+             "with --video-aug-scale-frames-down this increases spatial resolution."
+    )
+    group.add_argument(
+        "--video-aug-scale-resolution-up", type=int, default=None,
+        help="Video data augmentation (resolution UP): randomly sample s from 1..N and divide "
+             "both FPS and max_frames by s, while multiplying video_target_num_patches by s "
+             "(higher resolution per frame, fewer frames). "
+             "E.g. --video-aug-scale-resolution-up 4 samples uniformly from {1,2,3,4}."
+    )
 
     return parser


### PR DESCRIPTION
## Summary

- Port the multimodal argument and configuration plumbing from #5277 onto the current `main` branch.
- Add language, vision, sound, projection, fusion, recomputation, packing, and dynamic-resolution configuration options.
- Extend the multimodal CLI with the corresponding training, inference, video, audio, and dataloader arguments.

## Why

This replaces #5277 with a clean commit that has both the required DCO sign-off and a verified SSH signature. The original author is preserved in the commit metadata.

## Impact

This adds argument and configuration plumbing used by the follow-up Nemotron Nano Omni v3 changes. It does not add the downstream model implementation in this PR.

## Validation

- `python3 -m py_compile examples/multimodal/config.py examples/multimodal/multimodal_args.py`
- `BASE_REF=main CHECK_ONLY=true SKIP_DOCS=false bash tools/autoformat.sh` (the repository formatter reported no targeted files because it scopes formatting to `megatron/core` and `tests`)
- `git diff --check upstream/main..HEAD`
- GitHub commit verification: valid SSH signature

## Attribution

Supersedes #5277. Original work by @trintamaki; the commit retains Tuomas Rintamaki as its author.
