### PR TITLE
fix(mfsdp): refresh V2 compute weights after optimizer step

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/checkpoint.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/checkpoint.py
@@ -41,26 +41,9 @@ from torch.distributed.checkpoint.state_dict import (
 )
 
 from ..uneven_dtensor import preprocess_state_dict_for_uneven_dtensor
-from .module import FsdpModule
+from .parameter_group import sync_model_weights_from_main_weights
 
 __all__ = ["save_checkpoint", "load_checkpoint"]
-
-
-def _sync_model_weight_from_main_weight(model: torch.nn.Module) -> None:
-    """Refresh every FSDP group's compute weights from its (loaded) main weights.
-
-    A load writes into the ``main_weight``-backed sharded DTensors. When mixed precision keeps a
-    separate lower-precision compute buffer, that buffer is stale until the next forward pre-hook
-    would resync it; doing it here makes the post-load state deterministic. It is a no-op when the
-    compute buffer aliases the main buffer.
-
-    Args:
-        model: Root module (or any module tree) containing ``FsdpModule`` instances.
-    """
-    for module in model.modules():
-        if isinstance(module, FsdpModule):
-            for parameter_group in module.parameter_groups:
-                parameter_group.sync_model_weight_from_main_weight()
 
 
 def _init_optimizer_state(optimizer: torch.optim.Optimizer) -> None:
@@ -139,4 +122,4 @@ def load_checkpoint(
     set_model_state_dict(model, model_state_dict)
     set_optimizer_state_dict(model, optimizer, optimizer_state_dict)
     if sync_model_weights:
-        _sync_model_weight_from_main_weight(model)
+        sync_model_weights_from_main_weights(model.parameters())

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/optimizer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/optimizer.py
@@ -14,12 +14,13 @@
 
 """Optimizer adapter for the minimal Megatron-FSDP path."""
 
+from itertools import chain
 from typing import Any, NamedTuple
 
 import torch
 from torch import nn
 
-from .parameter_group import FsdpParameterGroup, get_containing_parameter_group
+from .parameter_group import get_containing_parameter_group, sync_model_weights_from_main_weights
 
 
 def fully_shard_optimizer(
@@ -109,16 +110,9 @@ def fully_shard_optimizer(
             set_grad(parameter, original_grad)
         casted_grads.clear()
 
-        fsdp_parameter_groups: set[FsdpParameterGroup] = set()
-        for optimizer_group in hooked_optimizer.param_groups:
-            for parameter in optimizer_group["params"]:
-                parameter_group = get_containing_parameter_group(parameter)
-                if parameter_group is None:
-                    continue
-                fsdp_parameter_groups.add(parameter_group)
-
-        for parameter_group in fsdp_parameter_groups:
-            parameter_group.sync_model_weight_from_main_weight()
+        sync_model_weights_from_main_weights(
+            chain.from_iterable(group["params"] for group in hooked_optimizer.param_groups)
+        )
 
     optimizer.register_step_pre_hook(step_pre_hook)
     optimizer.register_step_post_hook(step_post_hook)

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -14,6 +14,7 @@
 
 """Parameter-group runtime state for the minimal Megatron-FSDP path."""
 
+from collections.abc import Iterable
 from contextlib import nullcontext
 from dataclasses import dataclass
 from weakref import ReferenceType, ref
@@ -39,6 +40,22 @@ def get_containing_parameter_group(parameter: nn.Parameter) -> "FsdpParameterGro
     if parameter_group_ref is None:
         return None
     return parameter_group_ref()
+
+
+def sync_model_weights_from_main_weights(parameters: Iterable[nn.Parameter]) -> None:
+    """Refresh MFSDP compute weights for parameter groups represented by ``parameters``.
+
+    Parameters outside the experimental MFSDP path are ignored. A parameter group
+    may own multiple parameters, but its compute-weight buffer is refreshed once.
+    """
+    seen_parameter_groups = set()
+    for parameter in parameters:
+        if (parameter_group := get_containing_parameter_group(parameter)) is None:
+            continue
+        if parameter_group in seen_parameter_groups:
+            continue
+        seen_parameter_groups.add(parameter_group)
+        parameter_group.sync_model_weight_from_main_weight()
 
 
 @dataclass(frozen=True, eq=False)

--- a/megatron/core/optimizer/fully_sharded_optimizer.py
+++ b/megatron/core/optimizer/fully_sharded_optimizer.py
@@ -8,6 +8,9 @@ import torch
 
 from ..config_logger import has_config_logger_enabled, log_config_to_disk
 from ..dist_checkpointing.mapping import ShardedStateDict
+from ..distributed.fsdp.src.megatron_fsdp.experimental.parameter_group import (
+    get_containing_parameter_group,
+)
 from ..transformer.module import MegatronModule
 from .grad_scaler import MegatronGradScaler
 from .optimizer import MixedPrecisionOptimizer
@@ -120,7 +123,16 @@ class FullyShardedOptimizer(MixedPrecisionOptimizer):
         """No-op: MFSDP v2 reduces directly into optimizer-visible sharded grads."""
 
     def _copy_main_params_to_model_params(self) -> None:
-        """No-op: MFSDP v2 currently syncs compute weights in its forward pre-hook."""
+        """Refresh MFSDP V2 compute weights after updating optimizer weights."""
+        # TODO(wujingyue): Reuse experimental.checkpoint.resync_compute_weights after #6024 merges.
+        seen_parameter_groups = set()
+        for parameter in self.get_parameters():
+            if (parameter_group := get_containing_parameter_group(parameter)) is None:
+                continue
+            if parameter_group in seen_parameter_groups:
+                continue
+            seen_parameter_groups.add(parameter_group)
+            parameter_group.sync_model_weight_from_main_weight()
 
     def _copy_model_params_to_main_params(self, state_dict=None) -> None:
         """No-op: model loads already write into MFSDP v2's main weights."""

--- a/megatron/core/optimizer/fully_sharded_optimizer.py
+++ b/megatron/core/optimizer/fully_sharded_optimizer.py
@@ -9,7 +9,7 @@ import torch
 from ..config_logger import has_config_logger_enabled, log_config_to_disk
 from ..dist_checkpointing.mapping import ShardedStateDict
 from ..distributed.fsdp.src.megatron_fsdp.experimental.parameter_group import (
-    get_containing_parameter_group,
+    sync_model_weights_from_main_weights,
 )
 from ..transformer.module import MegatronModule
 from .grad_scaler import MegatronGradScaler
@@ -124,15 +124,7 @@ class FullyShardedOptimizer(MixedPrecisionOptimizer):
 
     def _copy_main_params_to_model_params(self) -> None:
         """Refresh MFSDP V2 compute weights after updating optimizer weights."""
-        # TODO(wujingyue): Reuse experimental.checkpoint.resync_compute_weights after #6024 merges.
-        seen_parameter_groups = set()
-        for parameter in self.get_parameters():
-            if (parameter_group := get_containing_parameter_group(parameter)) is None:
-                continue
-            if parameter_group in seen_parameter_groups:
-                continue
-            seen_parameter_groups.add(parameter_group)
-            parameter_group.sync_model_weight_from_main_weight()
+        sync_model_weights_from_main_weights(self.get_parameters())
 
     def _copy_model_params_to_main_params(self, state_dict=None) -> None:
         """No-op: model loads already write into MFSDP v2's main weights."""

--- a/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
@@ -164,7 +164,7 @@ class TestMcoreAdapter:
                 torch.randn(8, 2, config.hidden_size, device="cuda", dtype=torch.bfloat16)
                 for _ in range(2)
             ]
-            for _ in range(3)
+            for _ in range(10)
         ]
 
         reference_losses = []
@@ -198,4 +198,4 @@ class TestMcoreAdapter:
         reference_losses = torch.stack(reference_losses)
         assert torch.isfinite(losses).all()
         assert torch.isfinite(reference_losses).all()
-        torch.testing.assert_close(losses, reference_losses, rtol=1e-2, atol=0)
+        torch.testing.assert_close(losses, reference_losses, rtol=1e-3, atol=0)


### PR DESCRIPTION
## Summary

- Refresh MFSDP V2 BF16 compute weights through `FullyShardedOptimizer`'s native post-step copy hook.
- Extract `sync_model_weights_from_main_weights()` so the checkpoint-load path and the `fully_shard_optimizer()` step post-hook refresh compute weights through one implementation instead of two.
- Extend the MFSDP V2 optimizer integration test from three to ten steps so missing compute-weight refreshes are detected.

## Root cause

[#5949](https://github.com/NVIDIA/Megatron-LM/pull/5949) moved main-weight to model-weight synchronization from pre-forward to optimizer post-step. `FullyShardedOptimizer` inherited the post-step extension point but left its implementation as a no-op, so optimizer weights updated while subsequent forwards continued to use stale compute weights.

The existing three-step integration test used a 1% relative tolerance. The resulting loss drift remained below that threshold, so the test passed despite the missing refresh.

## Also fixes a rank-order deadlock in `fully_shard_optimizer()`

The experimental `step_post_hook` collected parameter groups into a `set` and iterated it:

```python
fsdp_parameter_groups: set[FsdpParameterGroup] = set()
...
for parameter_group in fsdp_parameter_groups:
    parameter_group.sync_model_weight_from_main_weight()
```

`FsdpParameterGroup` is `@dataclass(frozen=True, eq=False)`, so it hashes by `id()` and set iteration order varies per process. `sync_model_weight_from_main_weight()` issues a collective whenever `main_weight` and `model_weight` are distinct buffers, so ranks could issue the per-group collectives in different orders and hang.

Routing the hook through the shared helper fixes this as a consequence of the refactor rather than as a special case: the helper iterates the parameters, whose order is identical on every rank, and uses a set only to skip groups already synced.

The bug is latent on `main` today because it needs both conditions at once — two or more parameter groups **and** `main_weight is not model_weight`. No in-tree test combines them: configurations whose optimizer and parameter placements match (e.g. HSDP) alias the two buffers, so the sync early-returns without a collective.

## Validation

- `uv run python -m torch.distributed.run --nproc_per_node=2 -m pytest -q tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py::TestMcoreAdapter::test_build_train_and_step`
- Full `tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py` on 4x H100: 32 passed. The one failure, `test_overlaps_communication_and_compute[default]`, reproduces identically on unmodified `main` — it is a launch-bound profiler assertion, unrelated to this change.
- Deadlock repro: an HFSDP configuration (optimizer `[Flat, Flat]`, parameter `[Replicate, Flat]`) over three parameter groups on 4 GPUs hung indefinitely before this change and completes in ~9s after it.
- `ruff check` and `black --check` on edited files

Related to #5949 and #6325.
