### PR TITLE
Fix fused_mla_rope_kv_split for v_dim == 0

### DIFF
--- a/megatron/core/fusions/fused_mla_yarn_rope_apply.py
+++ b/megatron/core/fusions/fused_mla_yarn_rope_apply.py
@@ -571,17 +571,20 @@ def _mla_rope_fwd_kv_split_kernel(
     kv_off = tl.arange(0, BLOCK_H)[:, None] * stride_kv_nheads
     mask = kv_off < head_num * stride_kv_nheads
     k_in_off = kv_off + tl.arange(0, k_dim)[None, :]
-    v_in_off = kv_off + k_dim + tl.arange(0, v_dim)[None, :]
     k = tl.load(KV_ptr + k_in_off, mask=mask)
-    v = tl.load(KV_ptr + v_in_off, mask=mask)
 
     K_ptr = O_KEY + pid_m * stride_k_seq + pid_head * BLOCK_H * stride_k_nheads
     V_ptr = O_VALUE + pid_m * stride_v_seq + pid_head * BLOCK_H * stride_v_nheads
 
     k_out_off = tl.arange(0, BLOCK_H)[:, None] * stride_k_nheads + tl.arange(0, k_dim)[None, :]
-    v_out_off = tl.arange(0, BLOCK_H)[:, None] * stride_v_nheads + tl.arange(0, v_dim)[None, :]
     tl.store(K_ptr + k_out_off, k, mask=mask)
-    tl.store(V_ptr + v_out_off, v, mask=mask)
+    # tl.arange requires end > start, so the value path must be pruned at
+    # compile time when v_dim == 0 (v_dim is a constexpr).
+    if v_dim > 0:
+        v_in_off = kv_off + k_dim + tl.arange(0, v_dim)[None, :]
+        v = tl.load(KV_ptr + v_in_off, mask=mask)
+        v_out_off = tl.arange(0, BLOCK_H)[:, None] * stride_v_nheads + tl.arange(0, v_dim)[None, :]
+        tl.store(V_ptr + v_out_off, v, mask=mask)
 
     EMB = K_POS_EMB + pid_m * stride_emb_seq
     # x1 = t[..., 0::2], x2 = t[..., 1::2]
@@ -681,16 +684,19 @@ def _mla_rope_bwd_kv_split_kernel(
     dkv_off = tl.arange(0, BLOCK_H)[:, None] * stride_dkv_nheads
     mask = dkv_off < head_num * stride_dkv_nheads
     dk_out_off = dkv_off + tl.arange(0, k_dim)[None, :]
-    dv_out_off = dkv_off + k_dim + tl.arange(0, v_dim)[None, :]
 
     dK_ptr = dK + pid_m * stride_dk_seq + pid_head * BLOCK_H * stride_dk_nheads
     dV_ptr = dV + pid_m * stride_dv_seq + pid_head * BLOCK_H * stride_dv_nheads
     dk_in_off = tl.arange(0, BLOCK_H)[:, None] * stride_dk_nheads + tl.arange(0, k_dim)[None, :]
-    dv_in_off = tl.arange(0, BLOCK_H)[:, None] * stride_dv_nheads + tl.arange(0, v_dim)[None, :]
     dk = tl.load(dK_ptr + dk_in_off, mask=mask)
-    dv = tl.load(dV_ptr + dv_in_off, mask=mask)
     tl.store(dKV_ptr + dk_out_off, dk, mask=mask)
-    tl.store(dKV_ptr + dv_out_off, dv, mask=mask)
+    # tl.arange requires end > start, so the value path must be pruned at
+    # compile time when v_dim == 0 (v_dim is a constexpr).
+    if v_dim > 0:
+        dv_out_off = dkv_off + k_dim + tl.arange(0, v_dim)[None, :]
+        dv_in_off = tl.arange(0, BLOCK_H)[:, None] * stride_dv_nheads + tl.arange(0, v_dim)[None, :]
+        dv = tl.load(dV_ptr + dv_in_off, mask=mask)
+        tl.store(dKV_ptr + dv_out_off, dv, mask=mask)
 
     if pid_head == 0:
         x_left_accum = tl.zeros((BLOCK_H, emb_dim // 2), dtype=tl.float32)
@@ -821,8 +827,10 @@ class _FusedMLARoPEKVSplit(torch.autograd.Function):
         ctx.cp_rank = cp_rank
         ctx.cp_size = cp_size
         if cu_seqlens_kv is None:
-            o_key = o_key.view(max_seqlen, -1, nheads, emb_dim + k_dim)
-            o_value = o_value.view(max_seqlen, -1, nheads, v_dim)
+            # Use the explicit batch_size: with v_dim == 0 o_value has zero
+            # elements and view(..., -1, ...) cannot infer the batch dim.
+            o_key = o_key.view(max_seqlen, batch_size, nheads, emb_dim + k_dim)
+            o_value = o_value.view(max_seqlen, batch_size, nheads, v_dim)
         return o_key, o_value
 
     @staticmethod
@@ -843,7 +851,9 @@ class _FusedMLARoPEKVSplit(torch.autograd.Function):
             # sbhd
             max_seqlen, batch_size, nheads, _ = dk.shape
             dk = dk.contiguous().view(-1, nheads, ctx.emb_dim + ctx.k_dim)
-            dv = dv.contiguous().view(-1, nheads, ctx.v_dim)
+            # dk's flattened length is authoritative: with v_dim == 0 dv has
+            # zero elements and view(-1, ...) cannot infer the leading dim.
+            dv = dv.contiguous().view(dk.shape[0], nheads, ctx.v_dim)
             total_seqlen = dk.shape[0]
         else:
             # thd

--- a/tests/unit_tests/fusions/test_mla_yarn_rope_apply.py
+++ b/tests/unit_tests/fusions/test_mla_yarn_rope_apply.py
@@ -156,11 +156,10 @@ def _test_fused_mla_rope_inplace(input_format, inverse=False, remove_interleavin
     )
 
 
-def _test_fused_mla_rope_kv_split(input_format, remove_interleaving=False):
+def _test_fused_mla_rope_kv_split(input_format, remove_interleaving=False, v_dim=128):
     assert fused_mla_rope_kv_split is not None
     num_heads = 32
     k_dim = 128
-    v_dim = 128
     emb_dim = 64
     dtype = torch.bfloat16
     transformer_config = TransformerConfig(
@@ -300,6 +299,11 @@ class TestFusedApplyMLARope:
     @pytest.mark.parametrize("remove_interleaving", [False, True])
     def test_kv_split_forward_backward(self, input_format, remove_interleaving):
         _test_fused_mla_rope_kv_split(input_format, remove_interleaving=remove_interleaving)
+
+    def test_kv_split_forward_backward_zero_v_dim(self, input_format):
+        # v_dim == 0 produces zero-element value tensors, so the wrapper's
+        # output/grad reshapes must not rely on view(-1) shape inference.
+        _test_fused_mla_rope_kv_split(input_format, v_dim=0)
 
 
 @pytest.mark.experimental


### PR DESCRIPTION
# What does this PR do?

`fused_mla_rope_kv_split` fails when `v_dim == 0`. This is a legitimate
configuration for callers that only need the rotary-embedded key stream
from the fused kernel (e.g. compressed-attention paths that carry V
separately).

There are two independent failures:

1. **Wrapper (sbhd)**: the value output (forward) and the value
   gradient (backward) tensors have zero elements, so
   `view(..., -1, ...)` cannot infer the remaining dimension and raises
   `RuntimeError: cannot reshape tensor of 0 elements ...`. Fixed by
   using the explicit `batch_size` in the forward reshape and `dk`'s
   flattened length in the backward reshape. The thd path derives
   shapes from `cu_seqlens` and is unaffected.

2. **Triton kernels**: the value load/store offsets are built with
   `tl.arange(0, v_dim)` unconditionally, and `tl.arange` requires
   `end > start`, so kernel specialization fails at compile time with
   `ValueError: arange's end argument must be greater than the start
   argument`. Fixed by guarding the value path behind the `v_dim`
   constexpr — the branch is resolved at compile time, so for
   `v_dim > 0` the generated kernel is unchanged.

## Tests

Adds a `v_dim == 0` case to the existing kv_split forward/backward
parity tests in `tests/unit_tests/fusions/test_mla_yarn_rope_apply.py`
(covers both sbhd and thd input formats). The new case fails on current
dev (wrapper raises first; with the wrapper fixed, kernel
specialization still fails) and passes with this fix. The pre-existing
kv_split cases pass unchanged (verified on H200 / sm_90a).
