### PR TITLE
fix(ci): remove community workflow PAT

### DIFF
--- a/.github/workflows/community-bot.yml
+++ b/.github/workflows/community-bot.yml
@@ -21,11 +21,10 @@ on:
 
 jobs:
   community-bot:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_community_bot.yml@0af357dc15c04c3f28d33478d5055b1ca88a9ea1 # v1.8.8
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_community_bot.yml@affd689912d7975a1aa29ea60c1b983f12dfb7e7 # v1.8.9
     with:
       community_project_id: ${{ vars.COMMUNITY_PROJECT_ID }}
-      app-id: ${{ vars.BOT_ID }}
+      app-id: ${{ vars.COMMUNITY_BOT_ID }}
     if: github.repository == 'NVIDIA/Megatron-LM'
     secrets:
-      BOT_KEY: ${{ secrets.BOT_KEY }}
-      GH_TOKEN: ${{ secrets.PAT }}
+      BOT_KEY: ${{ secrets.COMMUNITY_BOT_KEY }}


### PR DESCRIPTION
## Background / motivation

- The `nemo-automation-bot` App is installed in both NVIDIA/Megatron-LM and NVIDIA-NeMo.
- GitHub issues separate tokens for each App installation, so repository labels and the NVIDIA-NeMo community project must use installation-specific tokens.
- This removes the community workflow dependency on the long-lived repository PAT.

Depends on NVIDIA-NeMo/FW-CI-templates#541.

## What changed

- Pin the community workflow to the immutable FW-CI-templates `v1.8.9` revision.
- Use dedicated `COMMUNITY_BOT_ID` and `COMMUNITY_BOT_KEY` configuration.
- Let the reusable workflow derive NVIDIA-NeMo as the cross-organization installation from the NVIDIA caller.
- Stop passing `secrets.PAT` to the community workflow.

## Details

- Updated `.github/workflows/community-bot.yml` only.
- `COMMUNITY_BOT_ID=1605575` and `COMMUNITY_BOT_KEY` are configured in NVIDIA/Megatron-LM.
- Existing `BOT_ID` and `BOT_KEY` release credentials are unchanged.
- The workflow is pinned to the immutable commit behind FW-CI-templates `v1.8.9`.

## Tested

- `gh api repos/NVIDIA-NeMo/FW-CI-templates/git/commits/affd689912d7975a1aa29ea60c1b983f12dfb7e7 --jq .sha` — verified the `v1.8.9` commit exists.
- `actionlint .github/workflows/community-bot.yml` — passed with actionlint 1.7.12 and zero findings.
- PyYAML parse of `.github/workflows/community-bot.yml` — passed.
- `git diff --check` — passed.
- Live App `1605575` two-token smoke test:
  - repository access returned `200` and private NVIDIA membership returned `204`;
  - private NVIDIA-NeMo membership returned `204` and project 20 resolved as `NeMo Support` through the cross-organization token;
  - both temporary tokens were revoked with `204`.
- Commit `bc183911eb9ebccb6637fd799ce0aa906ef5a7ab` — GPG signature and NVIDIA DCO sign-off verified locally.