### PR TITLE
Fix MFSDP v2 checkpoint test setup

### DIFF
--- a/tests/unit_tests/distributed/mfsdp_v2/test_checkpoint.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_checkpoint.py
@@ -15,6 +15,7 @@ from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
     Flat,
     Placements,
     fully_shard,
+    fully_shard_context,
     fully_shard_optimizer,
     load_checkpoint,
     save_checkpoint,
@@ -47,8 +48,9 @@ def _build_sharded(
         # source; a correct load must overwrite them.
         for parameter in model.parameters():
             nn.init.zeros_(parameter)
-    fully_shard(model.fc1, mesh=mesh, placements=_flat_placements())
-    fully_shard(model.fc2, mesh=mesh, placements=_flat_placements())
+    with fully_shard_context(device=device):
+        fully_shard(model.fc1, mesh=mesh, placements=_flat_placements())
+        fully_shard(model.fc2, mesh=mesh, placements=_flat_placements())
     optimizer = torch.optim.Adam(model.parameters(), lr=0.02)
     # main_weight is fp32 by default, so a bf16 model feeds the fp32 optimizer bf16 grads; the
     # adapter casts them around each step.


### PR DESCRIPTION
## What changed

Wrap the MFSDP v2 checkpoint test setup in `fully_shard_context`.

## Why

The new test called `fully_shard()` without its required context, causing both fp32 and bf16 cases to fail before exercising the DCP checkpoint path.

## Validation

`python -m torch.distributed.run --nproc-per-node 2 -m pytest -q tests/unit_tests/distributed/mfsdp_v2/test_checkpoint.py`

Both parametrizations passed.