### PR TITLE
Respect `profile_ranks` on log interval memory snapshots

### DIFF
--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -2855,7 +2855,7 @@ def training_log(
         if args.record_memory_history and (should_prof_rank or torch.distributed.get_backend() == 'fake'):
             rank = safe_get_rank()
             base, ext = os.path.splitext(args.memory_snapshot_path)
-            snapshot_filename = f"{base}-{rank}{ext}"
+            snapshot_filename = f"{base}_{rank}{ext}"
             torch.cuda.memory._dump_snapshot(snapshot_filename)
 
         elapsed_time = timers('interval-time').elapsed(barrier=True, reset=should_reset)

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -41,6 +41,7 @@ logging.basicConfig(handlers=[CustomHandler()], level=logging.INFO)
 _LEGACY_TRAIN_START_TIME = time.time()  # NOTE(asolergi-nv): Legacy timestamp
 
 # First-party.
+from megatron.core._rank_utils import safe_get_rank
 from megatron.core import mpu, nccl_allocator, tensor_parallel
 from megatron.core.datasets.data_schedule import HybridCPDataLoaderWrapper
 from megatron.core.distributed import DistributedDataParallel as DDP
@@ -2850,7 +2851,8 @@ def training_log(
 
     # Dump memory snapshot and print metrics to stdout.
     if iteration % args.log_interval == 0 or is_first_iteration:
-        if args.record_memory_history and (is_last_rank() or torch.distributed.get_backend() == 'fake'):
+        should_prof_rank = (args.profile_ranks == [] or safe_get_rank() in args.profile_ranks)  # [] is all ranks
+        if args.record_memory_history and (should_prof_rank or torch.distributed.get_backend() == 'fake'):
             snapshot = torch.cuda.memory._snapshot()
             from pickle import dump
 

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -2853,11 +2853,7 @@ def training_log(
     if iteration % args.log_interval == 0 or is_first_iteration:
         should_prof_rank = (args.profile_ranks == [] or safe_get_rank() in args.profile_ranks)  # [] is all ranks
         if args.record_memory_history and (should_prof_rank or torch.distributed.get_backend() == 'fake'):
-            snapshot = torch.cuda.memory._snapshot()
-            from pickle import dump
-
-            with open(args.memory_snapshot_path, 'wb') as f:
-                dump(snapshot, f)
+            torch.cuda.memory._dump_snapshot(args.memory_snapshot_path)
 
         elapsed_time = timers('interval-time').elapsed(barrier=True, reset=should_reset)
         elapsed_time_per_iteration = elapsed_time / total_iterations

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -2853,7 +2853,10 @@ def training_log(
     if iteration % args.log_interval == 0 or is_first_iteration:
         should_prof_rank = (args.profile_ranks == [] or safe_get_rank() in args.profile_ranks)  # [] is all ranks
         if args.record_memory_history and (should_prof_rank or torch.distributed.get_backend() == 'fake'):
-            torch.cuda.memory._dump_snapshot(args.memory_snapshot_path)
+            rank = safe_get_rank()
+            base, ext = os.path.splitext(args.memory_snapshot_path)
+            snapshot_filename = f"{base}-{rank}{ext}"
+            torch.cuda.memory._dump_snapshot(snapshot_filename)
 
         elapsed_time = timers('interval-time').elapsed(barrier=True, reset=should_reset)
         elapsed_time_per_iteration = elapsed_time / total_iterations

--- a/megatron/training/utils/utils.py
+++ b/megatron/training/utils/utils.py
@@ -44,7 +44,7 @@ def start_memory_history_recording(profiling: ProfilingConfig | None) -> None:
         """Dump a snapshot on OOM so we can inspect what was live at the failure."""
         rank = safe_get_rank()
         base, ext = os.path.splitext(profiling.memory_snapshot_path)
-        filename = f"{base}_oom_rank-{rank}{ext}"
+        filename = f"{base}_oom_rank_{rank}{ext}"
         torch.cuda.memory._dump_snapshot(filename)
         # logger.info so the message reaches stderr on any profiled rank, not just rank 0.
         logger.info(f"[OOM] rank {rank} saved memory snapshot to {filename}")


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
Quick fix to match logic [here](https://github.com/NVIDIA/Megatron-LM/blob/07a0de65ad95fb4fb999809f260d8b3868e60a97/megatron/training/utils/utils.py#L30C45-L30C58). 

Note: I think this does change the default behavior. When memory profiling is enabled, default is now to dump on all ranks (old behavior was last rank only). However, this respects what is documented in the config/arguments.

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
