### PR TITLE
fix(transformer): chunk no-context inference prefill

### DIFF
--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -847,10 +847,12 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
 
         nvtx_range_push(suffix="mlp")
         # Potentially chunk the MLP computation during prefill to minimize the peak activation size
+        is_prefill = (inference_context is None and not self.training) or (
+            inference_context is not None and not inference_context.is_decode_only()
+        )
         should_chunk_mlp_for_prefill = (
             self.config.mlp_chunks_for_prefill > 1
-            and inference_context is not None
-            and not inference_context.is_decode_only()
+            and is_prefill
             and not isinstance(self.mlp, IdentityOp)
             and not self.config.transformer_impl == "inference_optimized"
         )

--- a/tests/unit_tests/transformer/test_transformer_layer.py
+++ b/tests/unit_tests/transformer/test_transformer_layer.py
@@ -125,6 +125,32 @@ class TestParallelTransformerLayer:
 
             assert torch.equal(outputs[1][0], outputs[4][0])
 
+            # Full-prefix eval without a cache context should use the same prefill chunks.
+            outputs = {}
+            mlp_input_sequence_lengths = {}
+            with InferenceMode.active():
+                for mlp_chunks_for_prefill in [1, 4]:
+                    transformer_config.mlp_chunks_for_prefill = mlp_chunks_for_prefill
+                    observed_sequence_lengths = []
+                    handle = parallel_transformer_layer.mlp.register_forward_pre_hook(
+                        lambda _module, args: observed_sequence_lengths.append(args[0].shape[0])
+                    )
+                    hidden_states, context = parallel_transformer_layer(
+                        hidden_states=input_hidden_states,
+                        attention_mask=attention_mask,
+                        inference_context=None,
+                    )
+                    handle.remove()
+                    assert hidden_states.shape[0] == sequence_length
+                    assert hidden_states.shape[1] == micro_batch_size
+                    assert hidden_states.shape[2] == hidden_size
+                    outputs[mlp_chunks_for_prefill] = (hidden_states, context)
+                    mlp_input_sequence_lengths[mlp_chunks_for_prefill] = observed_sequence_lengths
+
+            assert torch.equal(outputs[1][0], outputs[4][0])
+            assert mlp_input_sequence_lengths[1] == [sequence_length]
+            assert mlp_input_sequence_lengths[4] == [sequence_length // 4] * 4
+
             # Test chunked training: chunks=1 vs chunks=4 should be identical
             parallel_transformer_layer.train()
             outputs = {}


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Allows `mlp_chunks_for_prefill` to bound MLP/MoE activations during full-prefix evaluation without requiring an inference context.

The existing predicate coupled prefill chunking to KV-cache ownership. Callers that recompute a complete prefix therefore had to create a `StaticInferenceContext` solely to activate chunking, retaining attention KV buffers that were not reused. For Kimi K2.5 VL inference, that retained memory consumed the headroom recovered by chunking and exposed another expert allocation failure.

This change treats `eval()` with no inference context as a full-prefix prefill. Context-backed prefill, decode, training chunking, and the inference-optimized implementation keep their existing behavior.

## Issue tracking

Linked issue: NVBug 6566459

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests (not applicable; the focused transformer-layer GPU test covers the predicate and chunk shapes)
- [ ] I have added proper typing to my code (not applicable; no public or typed API changed)
- [ ] I have added relevant documentation (not applicable; the existing configuration contract is unchanged)
- [ ] I have run the `autoformatter.sh` on my PR (targeted Black, isort, and pylint checks pass)

## Validation

- Independent MCore reproducer: before the change, no-context eval made one full-length MLP call while the context-backed path retained KV buffers; after the change, no-context eval made four quarter-length calls and allocated no context cache.
- `uv run python -m pytest tests/unit_tests/transformer/test_transformer_layer.py::TestParallelTransformerLayer::test_chunked_mlp -vv`
- Targeted Black, isort, and pylint checks.
