### PR TITLE
Make core-nemo fallback owner for top-level files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,6 @@
+# All files directly in the repository root (later matches must retain this owner).
+/* @NVIDIA/core-nemo
+
 megatron/core/ @NVIDIA/core-adlr @NVIDIA/core-nemo
 megatron/core/tensor_parallel/generalized_tensor_parallelism.py @NVIDIA/core-adlr @NVIDIA/core-nemo @NVIDIA/gtp
 
@@ -65,7 +68,7 @@ megatron/training/arguments.py
 .gitlab/ @NVIDIA/ci
 .github/ @NVIDIA/ci
 .github/oncall_schedule.json @NVIDIA/mcore-oncall-rotation
-.gitlab-ci.yml @NVIDIA/ci
+.gitlab-ci.yml @NVIDIA/core-nemo @NVIDIA/ci
 docker/  @NVIDIA/ci
 tests/functional_tests/python_test_utils/ @NVIDIA/ci
 tests/functional_tests/shell_test_utils/ @NVIDIA/ci
@@ -82,4 +85,4 @@ tests/unit_tests/test_api_backwards_compat_setup.py @NVIDIA/ci
 megatron/rl/ @NVIDIA/reinforcement-learning
 examples/rl/ @NVIDIA/reinforcement-learning
 test/unit_tests/test_rl_utils.py @NVIDIA/reinforcement-learning
-train_rl.py @NVIDIA/reinforcement-learning
+train_rl.py @NVIDIA/core-nemo @NVIDIA/reinforcement-learning

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,6 @@
+# Files directly in the repository root without a more specific owner.
+/* @NVIDIA/core-nemo
+
 megatron/core/ @NVIDIA/core-adlr @NVIDIA/core-nemo
 megatron/core/tensor_parallel/generalized_tensor_parallelism.py @NVIDIA/core-adlr @NVIDIA/core-nemo @NVIDIA/gtp
 


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Makes `@NVIDIA/core-nemo` the fallback code owner for files directly in the repository root that do not already have a more specific owner.

Existing root-level ownership rules remain unchanged. For example, `.gitlab-ci.yml` remains owned by `@NVIDIA/ci`, and `train_rl.py` remains owned by `@NVIDIA/reinforcement-learning`.

## Issue tracking

Linked issue: N/A

## Impact

Pull requests that modify otherwise-unowned root-level files now require Core NeMo approval. Root-level files with existing owners, and files inside nested directories, keep their current ownership behavior.

## Validation

- Ran `git diff --check`.
- Confirmed the final PR diff only adds the fallback rule and its explanatory comment.
- Rebased the SSH-signed and DCO-signed commit onto current `main`.

Runtime tests and autoformatting are not applicable to this CODEOWNERS-only change.
