### PR TITLE
Fix non-fused mHC projection for empty sequences

### DIFF
--- a/megatron/core/transformer/hyper_connection.py
+++ b/megatron/core/transformer/hyper_connection.py
@@ -272,7 +272,7 @@ class HyperConnectionModule(MegatronModule):
         x_2d = x.reshape(s * b, nC).to(torch.float32)
         weight = self.mapping_proj.weight.to(torch.float32)
         proj, r = self._proj_rms_op(x_2d, weight, self.norm_eps)
-        return proj.view(s, b, -1), r.view(s, b, 1)
+        return proj.view(s, b, proj.shape[-1]), r.view(s, b, 1)
 
     # dynamic=True handles the hybrid mHC variable-shape path (was blanket-disabled)
     @torch.compile

--- a/tests/unit_tests/transformer/test_hyper_connection_recompute.py
+++ b/tests/unit_tests/transformer/test_hyper_connection_recompute.py
@@ -59,6 +59,22 @@ class TestHyperConnectionCheckpoint:
 
         torch.testing.assert_close(mixed, expected, atol=0.0, rtol=0.0)
 
+    def test_forward_supports_empty_sequence(self):
+        """Forward and backward should support an empty sequence."""
+        module = self._create_hyper_connection_module(hidden_size=4, num_residual_streams=2)
+        hidden_states = torch.empty(0, 1, 8, device='cuda', requires_grad=True)
+
+        aggregated, h_res, h_post, residual = module(hidden_states)
+
+        assert aggregated.shape == (0, 1, 4)
+        assert h_res.shape == (0, 1, 2, 2)
+        assert h_post.shape == (0, 1, 2)
+        assert residual.shape == (0, 1, 8)
+
+        (aggregated.sum() + h_res.sum() + h_post.sum() + residual.sum()).backward()
+        assert hidden_states.grad is not None
+        assert module.mapping_proj.weight.grad is not None
+
     def test_forward_normal_vs_checkpoint_correctness(self):
         """
         Test that _forward_with_checkpoint produces the same outputs as _forward_normal.


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Allow non-fused mHC projection to handle empty sequence tensors without changing non-empty behavior.

## Issue tracking

Linked issue: N/A

## Reproduction

For hidden states shaped `[0, b, n*C]`, projection produces a valid tensor shaped `[0, n²+2n]`, but inferring its final dimension is ambiguous:

```text
RuntimeError: cannot reshape tensor of 0 elements into shape [0, 1, -1] because the unspecified dimension size -1 can be any value and is ambiguous
```

Reshaping with `proj.shape[-1]` preserves existing projection and autograd behavior while making empty dimensions unambiguous.

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests (not applicable; this is a shape-only fix)
- [x] I have added proper typing to my code (no API or signature changes)
- [ ] I have added relevant documentation (not applicable)
- [x] I have run `tools/autoformat.sh` on my PR

## Testing

- Reproduced failure against current `upstream/dev` with `HyperConnectionModule` on CUDA.
- Ran CUDA distributed tests for mHC recompute, checkpoint management, and PP/VPP compatibility: 63 passed, 5 skipped because they require at least 2 GPUs.
- Ran 108 CUDA projection cases covering empty and non-empty sequence/batch dimensions, 1/2/4 residual streams, two hidden widths, FP32/BF16, backward gradients, and exact non-empty parity.
- Passed Black, isort, pylint (10.00/10), Ruff, `git diff --check`, DCO, installation, and wheel checks.
