### PR TITLE
Fix hidden checkpoint parameter handling in local CUDA graphs

### DIFF
--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -864,11 +864,9 @@ class _CudagraphReplayNode(torch.autograd.Function):
         runner.bwd_graph_replay_complete_event.record(torch.cuda.current_stream())
         for param in runner.params_to_backprop:
             param._cudagraph_wgrad_ready_event = runner.bwd_graph_replay_complete_event
-            if id(param) in runner.checkpoint_param_grad_ids:
-                # Only nested checkpoint backward leaves param.grad after replay; ordinary
-                # parameters use the returned wgrad and leave it unset. Mark that gradient as
-                # already added so the standard DDP hook skips a duplicate add, then clears
-                # param.grad and registers readiness. The GTP path below does both explicitly.
+            if id(param) in runner.param_ids_to_skip_ddp_grad_add_on_replay:
+                # The backward graph already added param.grad to main_grad. Restore the
+                # Python-side flag so DDP skips that add, clears param.grad, and marks readiness.
                 param.grad_added_to_main_grad = True
         runner.status = _GraphStatus.FWD_READY
 
@@ -939,6 +937,7 @@ class _CudaGraphRunner(torch.nn.Module):
         self.fp4_runtime_enabled = None
         self.deallocate_pipeline_outputs = False
         self.num_warmup_steps = 0
+        self.needs_recompute_param_discovery = False
         self.use_stream = False
         self.gtp_remat = False
         self.fwd_side_streams = []
@@ -970,6 +969,9 @@ class _CudaGraphRunner(torch.nn.Module):
             self.backward_retain_grad = self.base_module.config.cuda_graph_retain_backward_graph
             self.deallocate_pipeline_outputs = self.base_module.config.deallocate_pipeline_outputs
             self.num_warmup_steps = self.base_module.config.cuda_graph_warmup_steps
+            self.needs_recompute_param_discovery = (
+                self.grad_enabled and self.base_module.config.recompute_granularity is not None
+            )
             self.fp8_enabled = self.base_module.config.fp8 is not None
             self.fp4_enabled = self.base_module.config.fp4 is not None
             self.fp8_runtime_enabled = None
@@ -1081,12 +1083,10 @@ class _CudaGraphRunner(torch.nn.Module):
         else:
             return nullcontext()
 
-    def get_connected_param_ids(self, outputs):
-        """Find base-module parameters reachable from the autograd graphs of ``outputs``.
-
-        The traversal identifies leaf parameters through their AccumulateGrad nodes and returns
-        only IDs of parameters recursively owned by ``base_module``.
-        """
+    def get_connected_params(self, outputs):
+        """Iterate through the autograd graph of 'outputs' and returns all parameters connected.
+        In theory this should return all parameters that return a nonzero wgrad when computing
+        the backward pass of 'outputs'."""
         # Flatten outputs and start traversal from roots that require gradients
         args = (outputs,) if torch.is_tensor(outputs) else outputs
         stack = [
@@ -1104,18 +1104,7 @@ class _CudaGraphRunner(torch.nn.Module):
                     p_ids.add(id(fn.variable))
                 stack.extend(f for f, _ in fn.next_functions if f)
 
-        module_param_ids = {id(param) for param in self.base_module.parameters()}
-        return p_ids & module_param_ids
-
-    def get_connected_params(self, outputs, warmup_param_ids=()):
-        """Build the ordered parameter inputs required by the captured backward graph.
-
-        This combines parameters reachable from the captured outputs with parameters discovered
-        while warmup bypassed CheckpointWithoutOutput. The result follows ``base_module`` parameter
-        order so the capture and replay input layouts are stable.
-        """
-        p_ids = self.get_connected_param_ids(outputs)
-        p_ids.update(warmup_param_ids)
+        # Return module params that were found in the graph, preserving original order
         return tuple(p for p in self.base_module.parameters() if id(p) in p_ids)
 
     def _weakref_forward_buffers(self, preserve_forward_to_backward_lifetimes: bool) -> None:
@@ -1300,15 +1289,11 @@ class _CudaGraphRunner(torch.nn.Module):
             # warmup again as case graph capture mode may execute a different codepath
             _set_warmup_start()
 
-            warmup_param_ids = None
-            # The outer autograd graph of CheckpointWithoutOutput has no edges to parameters used
-            # only by its recompute function. Warmup bypasses the checkpoint and runs that function
-            # with autograd, exposing those parameters through AccumulateGrad. Always run at least
-            # one training warmup so they can be included in the captured backward graph inputs.
-            num_internal_warmups = (
-                max(self.num_warmup_steps, 1) if self.grad_enabled else self.num_warmup_steps
-            )
-            for _ in range(num_internal_warmups):
+            # Recompute parameter discovery needs one warmup output: graph warmup bypasses
+            # CheckpointWithoutOutput, making parameters hidden by its nested backward reachable
+            # from that output's autograd graph. Force this pass even when configured warmup is 0.
+            num_warmup_steps = max(self.num_warmup_steps, int(self.needs_recompute_param_discovery))
+            for _ in range(num_warmup_steps):
                 with self.get_quantization_context():
 
                     def clone_ten(ten):
@@ -1323,8 +1308,6 @@ class _CudaGraphRunner(torch.nn.Module):
                 if self.grad_enabled:
                     warmup_outputs = self.get_tensors(warmup_outputs)
                     warmup_outputs = tuple(o for o in warmup_outputs if o.requires_grad)
-                    if warmup_param_ids is None:
-                        warmup_param_ids = self.get_connected_param_ids(warmup_outputs)
                     input_tensors = self.get_tensors(warmup_args, warmup_kwargs)
                     torch.autograd.grad(
                         outputs=warmup_outputs,
@@ -1419,9 +1402,10 @@ class _CudaGraphRunner(torch.nn.Module):
             # Preserve only forward buffers whose lifetime crosses into backward capture.
             self._weakref_forward_buffers(preserve_forward_to_backward_lifetimes=True)
 
-            self.params_to_backprop = self.get_connected_params(
-                fwd_graph_outputs, warmup_param_ids=warmup_param_ids or ()
-            )
+            if self.needs_recompute_param_discovery:
+                self.params_to_backprop = self.get_connected_params(warmup_outputs)
+            else:
+                self.params_to_backprop = self.get_connected_params(fwd_graph_outputs)
             self.num_dgrads = len(self.fwd_graph_input_surface)
             self.fwd_graph_input_surface = self.fwd_graph_input_surface + self.params_to_backprop
 
@@ -1498,23 +1482,17 @@ class _CudaGraphRunner(torch.nn.Module):
             n_act_grads = sum(
                 1 for i in self.fwd_graph_input_surface[: self.num_dgrads] if i.requires_grad
             )
-            self.checkpoint_param_grad_ids = set()
-            # allow_unused=True preserves one slot per requested parameter. A parameter hidden by
-            # CheckpointWithoutOutput therefore has wgrad=None here even though its nested
-            # recompute backward accumulated the real gradient into param.grad.
+            self.param_ids_to_skip_ddp_grad_add_on_replay = set()
             for param, wgrad in zip(self.params_to_backprop, grad_inputs[n_act_grads:]):
                 grad_already_accumulated = getattr(param, 'grad_added_to_main_grad', False)
                 if wgrad is not None and not grad_already_accumulated:
                     param.main_grad.add_(wgrad)
                 if param.grad is not None and not grad_already_accumulated:
-                    # CheckpointWithoutOutput's nested backward accumulates gradients for
-                    # closed-over parameters into param.grad instead of returning them through the
-                    # outer autograd.grad call. This is a separate contribution from wgrad, which
-                    # covers uses visible to the outer graph; a parameter used in both places needs
-                    # both contributions added to main_grad.
+                    # A nested backward can accumulate directly into param.grad instead of
+                    # returning that contribution through the outer autograd.grad call.
                     param.main_grad.add_(param.grad)
                     param.grad_added_to_main_grad = True
-                    self.checkpoint_param_grad_ids.add(id(param))
+                    self.param_ids_to_skip_ddp_grad_add_on_replay.add(id(param))
 
             # GTP cross-graph RS overlap, two phases:
             #   Phase 1 — drain AG, fence runner_stream past ag_stream's tail,
@@ -1694,12 +1672,6 @@ class _CudaGraphRunner(torch.nn.Module):
 
         inp_tensors = self.get_tensors(args, kwargs, check_types=False)
         if self.grad_enabled:
-            # Passing parameters as synthetic replay-node inputs creates autograd edges to their
-            # existing AccumulateGrad nodes, where ordinary DDP registered its hooks. This is
-            # essential for parameters discovered only during checkpoint warmup: replay backward
-            # returns None for the synthetic inputs, but visiting AccumulateGrad still lets DDP
-            # skip the already-transferred gradient and mark its bucket ready. GTP hooks are
-            # invoked explicitly in _CudagraphReplayNode.backward instead.
             func_args = inp_tensors + self.params_to_backprop
         else:
             func_args = inp_tensors

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -864,9 +864,7 @@ class _CudagraphReplayNode(torch.autograd.Function):
         runner.bwd_graph_replay_complete_event.record(torch.cuda.current_stream())
         for param in runner.params_to_backprop:
             param._cudagraph_wgrad_ready_event = runner.bwd_graph_replay_complete_event
-            if id(param) in runner.param_ids_to_skip_ddp_grad_add_on_replay:
-                # The backward graph already added param.grad to main_grad. Restore the
-                # Python-side flag so DDP skips that add, clears param.grad, and marks readiness.
+            if hasattr(param, 'grad_added_to_main_grad'):
                 param.grad_added_to_main_grad = True
         runner.status = _GraphStatus.FWD_READY
 
@@ -884,8 +882,6 @@ class _CudagraphReplayNode(torch.autograd.Function):
                 with torch.cuda.stream(gtp_rs_stream):
                     for param in params:
                         param.grad = None
-                        if hasattr(param, 'grad_added_to_main_grad'):
-                            param.grad_added_to_main_grad = True
                         hook = getattr(param, '_grad_accum_hook', None)
                         if hook is not None:
                             hook()
@@ -1482,7 +1478,6 @@ class _CudaGraphRunner(torch.nn.Module):
             n_act_grads = sum(
                 1 for i in self.fwd_graph_input_surface[: self.num_dgrads] if i.requires_grad
             )
-            self.param_ids_to_skip_ddp_grad_add_on_replay = set()
             for param, wgrad in zip(self.params_to_backprop, grad_inputs[n_act_grads:]):
                 grad_already_accumulated = getattr(param, 'grad_added_to_main_grad', False)
                 if wgrad is not None and not grad_already_accumulated:
@@ -1491,8 +1486,7 @@ class _CudaGraphRunner(torch.nn.Module):
                     # A nested backward can accumulate directly into param.grad instead of
                     # returning that contribution through the outer autograd.grad call.
                     param.main_grad.add_(param.grad)
-                    param.grad_added_to_main_grad = True
-                    self.param_ids_to_skip_ddp_grad_add_on_replay.add(id(param))
+                param.grad_added_to_main_grad = True
 
             # GTP cross-graph RS overlap, two phases:
             #   Phase 1 — drain AG, fence runner_stream past ag_stream's tail,

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -864,6 +864,12 @@ class _CudagraphReplayNode(torch.autograd.Function):
         runner.bwd_graph_replay_complete_event.record(torch.cuda.current_stream())
         for param in runner.params_to_backprop:
             param._cudagraph_wgrad_ready_event = runner.bwd_graph_replay_complete_event
+            if id(param) in runner.checkpoint_param_grad_ids:
+                # Only nested checkpoint backward leaves param.grad after replay; ordinary
+                # parameters use the returned wgrad and leave it unset. Mark that gradient as
+                # already added so the standard DDP hook skips a duplicate add, then clears
+                # param.grad and registers readiness. The GTP path below does both explicitly.
+                param.grad_added_to_main_grad = True
         runner.status = _GraphStatus.FWD_READY
 
         # Update FP8 scale factors if needed
@@ -1075,10 +1081,12 @@ class _CudaGraphRunner(torch.nn.Module):
         else:
             return nullcontext()
 
-    def get_connected_params(self, outputs):
-        """Iterate through the autograd graph of 'outputs' and returns all parameters connected.
-        In theory this should return all parameters that return a nonzero wgrad when computing
-        the backward pass of 'outputs'."""
+    def get_connected_param_ids(self, outputs):
+        """Find base-module parameters reachable from the autograd graphs of ``outputs``.
+
+        The traversal identifies leaf parameters through their AccumulateGrad nodes and returns
+        only IDs of parameters recursively owned by ``base_module``.
+        """
         # Flatten outputs and start traversal from roots that require gradients
         args = (outputs,) if torch.is_tensor(outputs) else outputs
         stack = [
@@ -1096,7 +1104,18 @@ class _CudaGraphRunner(torch.nn.Module):
                     p_ids.add(id(fn.variable))
                 stack.extend(f for f, _ in fn.next_functions if f)
 
-        # Return module params that were found in the graph, preserving original order
+        module_param_ids = {id(param) for param in self.base_module.parameters()}
+        return p_ids & module_param_ids
+
+    def get_connected_params(self, outputs, warmup_param_ids=()):
+        """Build the ordered parameter inputs required by the captured backward graph.
+
+        This combines parameters reachable from the captured outputs with parameters discovered
+        while warmup bypassed CheckpointWithoutOutput. The result follows ``base_module`` parameter
+        order so the capture and replay input layouts are stable.
+        """
+        p_ids = self.get_connected_param_ids(outputs)
+        p_ids.update(warmup_param_ids)
         return tuple(p for p in self.base_module.parameters() if id(p) in p_ids)
 
     def _weakref_forward_buffers(self, preserve_forward_to_backward_lifetimes: bool) -> None:
@@ -1280,7 +1299,16 @@ class _CudaGraphRunner(torch.nn.Module):
         with ctx:
             # warmup again as case graph capture mode may execute a different codepath
             _set_warmup_start()
-            for _ in range(self.num_warmup_steps):
+
+            warmup_param_ids = None
+            # The outer autograd graph of CheckpointWithoutOutput has no edges to parameters used
+            # only by its recompute function. Warmup bypasses the checkpoint and runs that function
+            # with autograd, exposing those parameters through AccumulateGrad. Always run at least
+            # one training warmup so they can be included in the captured backward graph inputs.
+            num_internal_warmups = (
+                max(self.num_warmup_steps, 1) if self.grad_enabled else self.num_warmup_steps
+            )
+            for _ in range(num_internal_warmups):
                 with self.get_quantization_context():
 
                     def clone_ten(ten):
@@ -1295,6 +1323,8 @@ class _CudaGraphRunner(torch.nn.Module):
                 if self.grad_enabled:
                     warmup_outputs = self.get_tensors(warmup_outputs)
                     warmup_outputs = tuple(o for o in warmup_outputs if o.requires_grad)
+                    if warmup_param_ids is None:
+                        warmup_param_ids = self.get_connected_param_ids(warmup_outputs)
                     input_tensors = self.get_tensors(warmup_args, warmup_kwargs)
                     torch.autograd.grad(
                         outputs=warmup_outputs,
@@ -1389,7 +1419,9 @@ class _CudaGraphRunner(torch.nn.Module):
             # Preserve only forward buffers whose lifetime crosses into backward capture.
             self._weakref_forward_buffers(preserve_forward_to_backward_lifetimes=True)
 
-            self.params_to_backprop = self.get_connected_params(fwd_graph_outputs)
+            self.params_to_backprop = self.get_connected_params(
+                fwd_graph_outputs, warmup_param_ids=warmup_param_ids or ()
+            )
             self.num_dgrads = len(self.fwd_graph_input_surface)
             self.fwd_graph_input_surface = self.fwd_graph_input_surface + self.params_to_backprop
 
@@ -1466,9 +1498,23 @@ class _CudaGraphRunner(torch.nn.Module):
             n_act_grads = sum(
                 1 for i in self.fwd_graph_input_surface[: self.num_dgrads] if i.requires_grad
             )
+            self.checkpoint_param_grad_ids = set()
+            # allow_unused=True preserves one slot per requested parameter. A parameter hidden by
+            # CheckpointWithoutOutput therefore has wgrad=None here even though its nested
+            # recompute backward accumulated the real gradient into param.grad.
             for param, wgrad in zip(self.params_to_backprop, grad_inputs[n_act_grads:]):
-                if wgrad is not None and not getattr(param, 'grad_added_to_main_grad', False):
+                grad_already_accumulated = getattr(param, 'grad_added_to_main_grad', False)
+                if wgrad is not None and not grad_already_accumulated:
                     param.main_grad.add_(wgrad)
+                if param.grad is not None and not grad_already_accumulated:
+                    # CheckpointWithoutOutput's nested backward accumulates gradients for
+                    # closed-over parameters into param.grad instead of returning them through the
+                    # outer autograd.grad call. This is a separate contribution from wgrad, which
+                    # covers uses visible to the outer graph; a parameter used in both places needs
+                    # both contributions added to main_grad.
+                    param.main_grad.add_(param.grad)
+                    param.grad_added_to_main_grad = True
+                    self.checkpoint_param_grad_ids.add(id(param))
 
             # GTP cross-graph RS overlap, two phases:
             #   Phase 1 — drain AG, fence runner_stream past ag_stream's tail,
@@ -1648,6 +1694,12 @@ class _CudaGraphRunner(torch.nn.Module):
 
         inp_tensors = self.get_tensors(args, kwargs, check_types=False)
         if self.grad_enabled:
+            # Passing parameters as synthetic replay-node inputs creates autograd edges to their
+            # existing AccumulateGrad nodes, where ordinary DDP registered its hooks. This is
+            # essential for parameters discovered only during checkpoint warmup: replay backward
+            # returns None for the synthetic inputs, but visiting AccumulateGrad still lets DDP
+            # skip the already-transferred gradient and mark its bucket ready. GTP hooks are
+            # invoked explicitly in _CudagraphReplayNode.backward instead.
             func_args = inp_tensors + self.params_to_backprop
         else:
             func_args = inp_tensors

--- a/tests/unit_tests/transformer/test_cuda_graphs.py
+++ b/tests/unit_tests/transformer/test_cuda_graphs.py
@@ -1716,6 +1716,8 @@ class TestCheckpointParameterDiscovery:
             use_cpu_initialization=True,
             cuda_graph_impl="local",
             cuda_graph_warmup_steps=0,
+            recompute_granularity="selective",
+            recompute_modules=["layernorm"],
         )
         torch.manual_seed(123)
         reference = _CheckpointDependencyModule(config).cuda()

--- a/tests/unit_tests/transformer/test_cuda_graphs.py
+++ b/tests/unit_tests/transformer/test_cuda_graphs.py
@@ -8,6 +8,7 @@ import pytest
 import torch
 from transformer_engine.pytorch.fp8 import check_fp8_support
 
+from megatron.core.distributed import DistributedDataParallel, DistributedDataParallelConfig
 from megatron.core.enums import ModelType
 from megatron.core.models.gpt.gpt_layer_specs import (
     get_gpt_decoder_block_spec,
@@ -28,6 +29,7 @@ from megatron.core.pipeline_parallel.schedules import set_current_microbatch
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import (
     HAVE_TE,
+    CheckpointWithoutOutput,
     initialize_rng_tracker,
     model_parallel_cuda_manual_seed,
 )
@@ -36,6 +38,7 @@ from megatron.core.transformer.cuda_graphs import (
     TECudaGraphHelper,
     _CudagraphGlobalRecord,
     create_cudagraphs,
+    delete_cuda_graphs,
 )
 from megatron.core.transformer.enums import (
     AttnBackend,
@@ -1643,6 +1646,25 @@ class _SimpleModule(MegatronModule):
         return self.linear(x)
 
 
+class _CheckpointDependencyModule(MegatronModule):
+    """A visible projection consuming the output of a checkpointed child module."""
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.checkpointed = torch.nn.Linear(config.hidden_size, config.hidden_size, bias=False)
+        self.projection = torch.nn.Linear(config.hidden_size, config.hidden_size, bias=False)
+
+    def forward(self, x):
+        return self.my_op(x)
+
+    def my_op(self, x):
+        checkpoint = CheckpointWithoutOutput()
+        hidden = checkpoint.checkpoint(self.checkpointed, x)
+        output = self.projection(hidden)
+        checkpoint.discard_output_and_register_recompute(output)
+        return output
+
+
 class _SimpleNonModule:
     """non-nn.Module base_module for testing the function_name= form of `CudaGraphManager`."""
 
@@ -1659,6 +1681,92 @@ def _make_simple_module(config):
 
 def _make_simple_non_module(config):
     return _SimpleNonModule(config)
+
+
+class TestCheckpointParameterDiscovery:
+    """Local-CG discovery and DDP readiness for a checkpointed nested module."""
+
+    def setup_method(self, method):
+        initialize_rng_tracker(use_te_rng_tracker=True, force_reset=True)
+        Utils.initialize_model_parallel()
+        model_parallel_cuda_manual_seed(123)
+
+    def teardown_method(self, method):
+        if _CudagraphGlobalRecord.cudagraph_created:
+            delete_cuda_graphs()
+        else:
+            _CudagraphGlobalRecord.cudagraph_record = []
+            _CudagraphGlobalRecord.cudagraph_inference_record = []
+            CudaGraphManager.global_mempool = None
+        torch.cuda.set_stream(torch.cuda.default_stream())
+        Utils.destroy_model_parallel()
+
+    @pytest.mark.skipif(
+        not (HAVE_TE and is_te_min_version("1.5.0")),
+        reason="use_te_rng_tracker requires TransformerEngine version >= 1.5",
+    )
+    def test_nested_checkpoint_parameter_gradients_and_ddp_readiness(self):
+        if not torch.distributed.is_initialized() or torch.distributed.get_world_size() < 2:
+            pytest.skip("test requires at least two data-parallel ranks")
+
+        config = TransformerConfig(
+            num_layers=1,
+            hidden_size=32,
+            num_attention_heads=1,
+            use_cpu_initialization=True,
+            cuda_graph_impl="local",
+            cuda_graph_warmup_steps=0,
+        )
+        torch.manual_seed(123)
+        reference = _CheckpointDependencyModule(config).cuda()
+        module = _CheckpointDependencyModule(config).cuda()
+        module.load_state_dict(reference.state_dict())
+
+        manager = CudaGraphManager(
+            config, base_module=module, function_name="my_op", need_backward=True
+        )
+        ddp_model = DistributedDataParallel(
+            config,
+            DistributedDataParallelConfig(overlap_grad_reduce=True, bucket_size=1_000_000),
+            module,
+        )
+
+        # Distinct inputs make the expected DDP result the average of different local gradients.
+        torch.manual_seed(1000 + ddp_model.dp_group.rank())
+        test_input = torch.randn(4, config.hidden_size, device="cuda", requires_grad=True)
+        reference_output = reference.my_op(test_input.detach().clone().requires_grad_(True))
+        reference_output_value = reference_output.detach().clone()
+        reference_output.sum().backward()
+        reference_wgrads = {
+            name: param.grad.detach().clone() for name, param in reference.named_parameters()
+        }
+        for grad in reference_wgrads.values():
+            torch.distributed.all_reduce(grad, group=ddp_model.dp_group)
+            grad.div_(ddp_model.dp_group.size())
+        del reference_output
+
+        ddp_model.zero_grad_buffer()
+        record_input = test_input.detach().clone().requires_grad_(True)
+        ddp_model(record_input).sum().backward()
+        ddp_model.finish_grad_sync()
+        ddp_model.zero_grad_buffer()
+        create_cudagraphs()
+
+        runner = manager.cudagraph_runners[0]
+        assert any(param is module.checkpointed.weight for param in runner.params_to_backprop)
+
+        # The first replay uses DDP's recorded ready counts; the second verifies per-step reset.
+        for _ in range(2):
+            ddp_model.zero_grad_buffer()
+            replay_output = ddp_model(test_input.detach().clone().requires_grad_(True))
+            replay_output.sum().backward()
+            ddp_model.finish_grad_sync()
+            torch.cuda.synchronize()
+
+            torch.testing.assert_close(replay_output, reference_output_value)
+            for name, param in module.named_parameters():
+                assert param.grad is None
+                torch.testing.assert_close(param.main_grad, reference_wgrads[name])
 
 
 class TestInlineCaptureManager:


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
<!-- Add a one line overview of what this PR aims to accomplish. -->

Fixes local CUDA-graph training when `CheckpointWithoutOutput` recomputation uses parameters from nested modules that are not visible in the outer autograd graph.

## Problem                                                                                                                                               

  `CheckpointWithoutOutput` runs its recompute function during backward. Parameters
  used only by that function do not have autograd edges from the outer forward
  outputs.

  CUDA-graph capture previously discovered `params_to_backprop` only by traversing
  the autograd graph from the captured forward outputs. Consequently, a parameter
  used exclusively by checkpoint recomputation could be omitted from the captured
  backward inputs.
 
  This caused two related problems:

  1. The nested recompute backward accumulated the parameter gradient into
     `param.grad`, but `torch.autograd.grad` returned `None` for the corresponding
     outer parameter input. The gradient was therefore not transferred to
     `param.main_grad`.

  2. Because the parameter was not passed as a synthetic input to the CUDA-graph
     replay node, replay had no autograd edge to its `AccumulateGrad` node. The
     normal DDP hook registered on that node did not fire, leaving the DDP bucket
     with an incomplete ready count.

  This can result in missing gradients, incorrect gradient accumulation, or DDP
  waiting for a bucket that never becomes ready.

  Example:
  ```
  def forward(self, x):
      checkpoint = CheckpointWithoutOutput()


      hidden = checkpoint.checkpoint(self.checkpointed, x)
      output = self.projection(hidden)

      checkpoint.discard_output_and_register_recompute(output)
      return output
  ```
  `self.projection.weight` is used by the outer forward autograd graph, so it can be 
    discovered by traversing backward from output. In contrast, `self.checkpointed.weight`
    is closed over by the checkpoint recompute function. Its computation is deferred until
    the nested recompute backward and therefore has no AccumulateGrad edge in the 
    outer graph. Traversing only the captured forward outputs consequently discovers
   `projection.weight` but misses `checkpointed.weight`, even though backward eventually
    produces a gradient for it.

  ## Solution

  ### Automatically discover hidden checkpoint dependencies

  During CUDA-graph warmup, `CheckpointWithoutOutput` bypasses checkpointing and
  executes its recompute function with autograd enabled. Parameters used by nested
  recompute modules are therefore visible through their `AccumulateGrad` nodes.

  This change:                                                                                                                                             

  - Traverses the warmup autograd graph to discover these parameters.
  - Filters the result to parameters recursively owned by the captured base module.
  - Merges the warmup-discovered parameters with those reachable from the actual
    captured forward outputs.
  - Preserves `base_module.parameters()` ordering so capture and replay use a stable
    positional input layout.
  - Runs at least one internal warmup for training graphs, even when
    `cuda_graph_warmup_steps=0`, because one discovery pass is required for correct
    checkpoint handling.

  This discovery is automatic and does not require checkpoint call sites or
  individual modules to declare additional dependencies.

  ### Capture gradients produced by nested recomputation

  For a parameter hidden behind `CheckpointWithoutOutput`,
  `torch.autograd.grad(..., allow_unused=True)` preserves its requested output slot
  but returns `None` for that slot. Its nested backward instead writes the real
  gradient to `param.grad`.

  Backward capture now transfers that contribution into `param.main_grad`.

  The returned `wgrad` and `param.grad` are handled independently. This is
  important when the same parameter is used both outside and inside checkpoint
  recomputation:

  - `wgrad` represents uses visible to the outer autograd graph.
  - `param.grad` represents uses performed by the nested recompute backward.

  Both are legitimate contributions and must be accumulated exactly once.

  ### Preserve normal DDP bucket readiness during replay

  All discovered parameters are passed as synthetic inputs to
  `_CudagraphReplayNode.apply`. For ordinary DDP parameters, this creates replay
  autograd edges to the existing `AccumulateGrad` nodes where DDP registered its
  hooks.

  For checkpoint parameters whose gradients were already transferred from
  `param.grad` to `param.main_grad`, replay sets
  `grad_added_to_main_grad=True` before the normal DDP hook runs. The hook then:

  - Skips adding the same gradient to `main_grad` a second time.
  - Clears `param.grad`.
  - Still calls `register_grad_ready()`, allowing the DDP bucket to be dispatched.

  GTP parameters retain their existing explicit hook path in
  `_CudagraphReplayNode.backward`.

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR
