### PR TITLE
[dev] Replace DP balance all-to-all rerouting with all-gather

### DIFF
--- a/megatron/core/datasets/data_schedule.py
+++ b/megatron/core/datasets/data_schedule.py
@@ -318,12 +318,10 @@ class DpBalancedScheduler(BasePackingScheduler):
                 ), f"Batch missing required key {key}, provided keys: {batch[0].keys()}"
 
             # Step 3: Strip data fields not needed by this PP stage to avoid
-            # unnecessary all-to-all communication. First PP needs tokens/position_ids,
+            # unnecessary rerouting communication. First PP needs tokens/position_ids,
             # last PP needs labels/loss_mask. MTP stages need all four.
-            # NOTE: this assumes _unpack_batch produces only the six keys below
-            # (tokens, position_ids, labels, loss_mask, original_seq_len,
-            # padded_seq_len). Any custom dataset metadata key outside this set
-            # would be silently dropped here; extend keys_to_keep if needed.
+            # DpBalancedScheduler supports the six fields below. Extend keys_to_keep
+            # and the reroute schema together when adding custom dataset metadata.
             keys_to_keep = {'original_seq_len', 'padded_seq_len'}
             if is_first_pp or mtp_on_this_pp:
                 keys_to_keep.update(['tokens', 'position_ids'])
@@ -355,9 +353,7 @@ class DpBalancedScheduler(BasePackingScheduler):
                 sample_id_groups,
                 offsets,
                 dp_group,
-                tp_group,
                 dp_cp_group,
-                total_dcp_gpus,
             )
 
             dcp_rank = dp_cp_group.rank()
@@ -382,7 +378,7 @@ class DpBalancedScheduler(BasePackingScheduler):
             ) = (None, None, None, None)
 
         # Broadcast to TP group (for non-TP-0 ranks)
-        (num_micro_batches, seqlen_sum_this_global_batch, seqlen_squared_sum_this_global_batch) = (
+        num_micro_batches, seqlen_sum_this_global_batch, seqlen_squared_sum_this_global_batch = (
             broadcast_scalars(
                 [
                     num_micro_batches,

--- a/megatron/core/datasets/data_schedule_utils.py
+++ b/megatron/core/datasets/data_schedule_utils.py
@@ -11,6 +11,17 @@ from megatron.core.rerun_state_machine import RerunDataIterator
 
 _DYNAMIC_CP_WORKLOAD_CAP_DELTA = 0.05
 
+_REROUTE_KEY_ORDER = (
+    "tokens",
+    "labels",
+    "loss_mask",
+    "position_ids",
+    "original_seq_len",
+    "padded_seq_len",
+)
+_REROUTE_KEY_SET = frozenset(_REROUTE_KEY_ORDER)
+_REROUTE_SCALAR_KEYS = frozenset(("original_seq_len", "padded_seq_len"))
+
 
 def get_cp_slice_for_thd(
     batch,
@@ -345,122 +356,120 @@ def create_data_iterator(
 
 
 def reroute_samples_to_dcp_ranks(
-    batch,
-    global_ids_this_rank,
-    global_id_seqlens,
-    sample_id_groups,
-    offsets,
-    dp_group,
-    tp_group,
-    dp_cp_group,
-    total_dcp_gpus,
+    batch, global_ids_this_rank, global_id_seqlens, sample_id_groups, offsets, dp_group, dp_cp_group
 ):
     """
     Reroutes the sub-samples to the correct rank after scheduling.
 
-    For each key in the batch dict, we perform an all-to-all communication
-    to transfer the data to the correct ranks.
+    Each CP lane gathers the samples from its DP group, then keeps only the
+    samples assigned to its DPxCP rank. Gathering within ``dp_group`` avoids
+    collecting the identical input held by every CP sibling and avoids the
+    fully connected P2P transport created by NCCL all-to-all.
+
+    All ranks in ``dp_group`` must provide the same set of data keys. CP siblings
+    that share a non-CP DP rank must additionally provide byte-identical sample
+    contents. This holds for the in-tree samplers, which use the non-CP DP rank
+    to select dataset indices.
+
+    The gather is intentionally issued one data key at a time. This pays the
+    fixed collective latency once per key, but bounds temporary memory to one
+    global field at a time. Selected slices are cloned before advancing to the
+    next key so the full gather buffer can be freed.
     """
 
-    def _gid_to_src_rank(gid: int) -> int:
-        dp_src_rank = torch.bucketize(gid, offsets[1:] - 1)
-        dcp_rank = (
-            torch.distributed.get_process_group_ranks(dp_group)[dp_src_rank] // tp_group.size()
-        ) % dp_cp_group.size()
-        return dcp_rank
-
-    gid2local_id = {int(gid): i for i, gid in enumerate(global_ids_this_rank)}
     dcp_rank = dp_cp_group.rank()
-    dp_ranks = torch.distributed.get_process_group_ranks(dp_group)
-    dp_ranks = [(r // tp_group.size()) % dp_cp_group.size() for r in dp_ranks]
+    dp_rank = dp_group.rank()
+    dp_size = dp_group.size()
 
-    data_keys = batch[0].keys()
-
-    # Create the send plan
-    combined_sample_id_groups: List[List[int]] = [[] for _ in range(total_dcp_gpus)]
-    for d in range(total_dcp_gpus):
-        for sample_id_group in sample_id_groups:
-            combined_sample_id_groups[d].extend(sample_id_group[d])
-    for dest_rank in range(total_dcp_gpus):
-        combined_sample_id_groups[dest_rank].sort()
-
-    send_ids_sorted = [
-        gid for d in dp_ranks for gid in combined_sample_id_groups[d] if gid in global_ids_this_rank
-    ]
-
-    send_num_split = [0] * total_dcp_gpus
-    send_lens_split = [0] * total_dcp_gpus
-    for dest_rank in range(total_dcp_gpus):
-        if dest_rank in dp_ranks:
-            send_seq_lens = [
-                global_id_seqlens[gid][1]
-                for gid in combined_sample_id_groups[dest_rank]
-                if gid in global_ids_this_rank
-            ]
-            send_num_split[dest_rank] = len(send_seq_lens)
-            send_lens_split[dest_rank] = sum(send_seq_lens)
-        else:
-            send_lens_split[dest_rank] = 0
-
-    # Create the recv plan
-    recv_sample_id_groups = [[] for _ in range(total_dcp_gpus)]
-    for gid in combined_sample_id_groups[dcp_rank]:
-        src_rank = _gid_to_src_rank(gid)
-        recv_sample_id_groups[src_rank].append(gid)
-
-    recv_lens_split = [0] * total_dcp_gpus
-    for src_rank in range(total_dcp_gpus):
-        recv_lens_split[src_rank] = sum(
-            [global_id_seqlens[gid][1] for gid in recv_sample_id_groups[src_rank]]
+    # Keep collective ordering independent of dictionary insertion order. Unknown
+    # keys require an explicit layout classification rather than being silently dropped.
+    batch_keys = set(batch[0])
+    unsupported_keys = batch_keys - _REROUTE_KEY_SET
+    assert not unsupported_keys, (
+        f"Cannot reroute unsupported sample keys {sorted(unsupported_keys)}; "
+        "extend _REROUTE_KEY_ORDER and classify their element layout."
+    )
+    for sample_idx, sample in enumerate(batch[1:], start=1):
+        sample_keys = set(sample)
+        assert sample_keys == batch_keys, (
+            f"Sample {sample_idx} keys {sorted(sample_keys)} do not match sample 0 keys "
+            f"{sorted(batch_keys)}."
         )
+    data_keys = [key for key in _REROUTE_KEY_ORDER if key in batch_keys]
 
-    recv_ids_sorted = [gid for d in range(total_dcp_gpus) for gid in recv_sample_id_groups[d]]
-    recv_counts = [len(recv_sample_id_groups[d]) for d in range(total_dcp_gpus)]
+    offset_values = [int(value) for value in offsets.tolist()]
+    assert (
+        len(offset_values) == dp_size + 1
+    ), f"Expected {dp_size + 1} DP offsets, got {len(offset_values)}."
+    local_ids = [int(gid) for gid in global_ids_this_rank.tolist()]
+    expected_local_ids = list(range(offset_values[dp_rank], offset_values[dp_rank + 1]))
+    assert (
+        local_ids == expected_local_ids
+    ), f"Local sample IDs {local_ids} do not match DP-rank range {expected_local_ids}."
+    assert len(batch) == len(
+        local_ids
+    ), f"Local batch size {len(batch)} does not match sample-ID count {len(local_ids)}."
 
-    recv_samples = [{k: None for k in data_keys} for _ in range(sum(recv_counts))]
+    recv_ids = sorted(
+        {gid for sample_id_group in sample_id_groups for gid in sample_id_group[dcp_rank]}
+    )
+    recv_samples = {gid: {key: None for key in data_keys} for gid in recv_ids}
+    seq_len_by_gid = dict(global_id_seqlens)
 
-    def _pack_sample_by_key(key: str) -> torch.Tensor:
-        flattened_tensors = []
-        for gid in send_ids_sorted:
-            t = batch[gid2local_id[gid]][key].to(torch.cuda.current_device(), non_blocking=True)
-            flattened_tensors.append(t.reshape(-1))
-        return (
-            torch.cat(flattened_tensors, dim=0)
-            if flattened_tensors
-            else torch.empty(0, device=torch.cuda.current_device(), dtype=batch[0][key].dtype)
-        )
+    def _build_layout(is_scalar):
+        sample_numels = {
+            gid: 1 if is_scalar else int(seq_len_by_gid[gid]) for gid in range(offset_values[-1])
+        }
+        rank_numels = [
+            sum(sample_numels[gid] for gid in range(offset_values[rank], offset_values[rank + 1]))
+            for rank in range(dp_size)
+        ]
+        max_rank_numel = max(rank_numels)
 
-    def _unpack_sample_by_key(key: str, recv_tensor: torch.Tensor):
-        cursor = 0
-        for i, gid in enumerate(recv_ids_sorted):
-            sample_len = (
-                1 if key in ["original_seq_len", "padded_seq_len"] else global_id_seqlens[gid][1]
-            )
-            recv_samples[i][key] = recv_tensor[cursor : cursor + sample_len]
-            cursor += sample_len
+        sample_slices = {}
+        for source_rank in range(dp_size):
+            cursor = source_rank * max_rank_numel
+            for gid in range(offset_values[source_rank], offset_values[source_rank + 1]):
+                sample_numel = sample_numels[gid]
+                sample_slices[gid] = (cursor, sample_numel)
+                cursor += sample_numel
+
+        return rank_numels, max_rank_numel, sample_slices
+
+    layouts = {False: _build_layout(is_scalar=False), True: _build_layout(is_scalar=True)}
 
     for key in data_keys:
-        output_split_sizes, input_split_sizes = (
-            (recv_counts, send_num_split)
-            if key in ["original_seq_len", "padded_seq_len"]
-            else (recv_lens_split, send_lens_split)
-        )
-        send_tensor = _pack_sample_by_key(key)
-        recv_tensor_size = sum(output_split_sizes)
-        recv_tensor = torch.empty(
-            recv_tensor_size, device=torch.cuda.current_device(), dtype=send_tensor.dtype
-        )
-        torch.distributed.all_to_all_single(
-            output=recv_tensor,
-            input=send_tensor,
-            output_split_sizes=output_split_sizes,
-            input_split_sizes=input_split_sizes,
-            group=dp_cp_group,
-        )
-        _unpack_sample_by_key(key, recv_tensor)
+        rank_numels, max_rank_numel, sample_slices = layouts[key in _REROUTE_SCALAR_KEYS]
 
-    recv_sample_with_id = {recv_id: recv_samples[i] for i, recv_id in enumerate(recv_ids_sorted)}
-    return recv_sample_with_id
+        local_tensor = torch.cat(
+            [
+                sample[key].to(torch.cuda.current_device(), non_blocking=True).reshape(-1)
+                for sample in batch
+            ],
+            dim=0,
+        )
+        assert (
+            local_tensor.numel() == rank_numels[dp_rank]
+        ), f"Packed {key} has {local_tensor.numel()} elements, expected {rank_numels[dp_rank]}."
+
+        if local_tensor.numel() < max_rank_numel:
+            gather_input = local_tensor.new_zeros(max_rank_numel)
+            gather_input[: local_tensor.numel()].copy_(local_tensor)
+        else:
+            gather_input = local_tensor.contiguous()
+
+        if dp_size == 1:
+            gathered_tensor = gather_input
+        else:
+            gathered_tensor = local_tensor.new_empty(dp_size * max_rank_numel)
+            torch.distributed.all_gather_into_tensor(gathered_tensor, gather_input, group=dp_group)
+
+        for gid in recv_ids:
+            start, sample_numel = sample_slices[gid]
+            # Clone so this sample does not retain the full global gather buffer.
+            recv_samples[gid][key] = gathered_tensor[start : start + sample_numel].clone()
+
+    return recv_samples
 
 
 def build_packed_microbatches(

--- a/megatron/core/datasets/readme.md
+++ b/megatron/core/datasets/readme.md
@@ -246,11 +246,18 @@ Utility functions consumed by the schedulers above:
 | Function | Role |
 |---|---|
 | `get_batch_and_global_seqlens()` | Fetch `num_microbatches` batches from the data iterator and all-gather sequence lengths across DP ranks. |
-| `reroute_samples_to_dcp_ranks()` | All-to-all communication to transfer sub-samples to their scheduled DP×CP rank. |
+| `reroute_samples_to_dcp_ranks()` | All-gather communication within each CP lane, followed by local selection of sub-samples for the scheduled DP×CP rank. |
 | `build_packed_microbatches()` | Concatenate sub-samples within each microbatch group and produce `cu_seqlens`. |
 | `broadcast_scalars()` | Broadcast scalar values (e.g. `num_microbatches`, FLOPs stats) across a process group. |
 | `broadcast_tensor()` | Broadcast a single tensor within a process group. |
 | `create_data_iterator()` | Wrap packed sample lists into a data iterator; handles VPP stage splitting. |
+
+`reroute_samples_to_dcp_ranks()` requires all ranks in a DP group to provide the same
+field set. CP siblings that share a non-CP DP rank must additionally load byte-identical
+sample contents. The in-tree samplers satisfy this by selecting dataset indices with the
+non-CP DP rank. Fields are gathered one at a time: this incurs one collective launch per
+field, but limits temporary memory to one global field before the selected slices are
+cloned and the gather buffer is released.
 
 ## Offline cache preparation
 

--- a/tests/unit_tests/test_sequence_packing.py
+++ b/tests/unit_tests/test_sequence_packing.py
@@ -17,7 +17,10 @@ from megatron.core.datasets.data_schedule import (
     get_batch_on_this_rank_for_sequence_packing,
     wrap_data_iterator,
 )
-from megatron.core.datasets.data_schedule_utils import next_hdp_group_packing_aware
+from megatron.core.datasets.data_schedule_utils import (
+    next_hdp_group_packing_aware,
+    reroute_samples_to_dcp_ranks,
+)
 from megatron.core.rerun_state_machine import RerunDataIterator
 from megatron.training.global_vars import unset_global_variables
 from tests.unit_tests.test_utilities import Utils
@@ -77,6 +80,228 @@ def test_scheduler_sanitizes_thd_padding_values():
     assert torch.equal(batch['labels'], torch.tensor([12, 13, 0, 22, 0]))
     assert torch.equal(batch['loss_mask'], torch.tensor([1.0, 1.0, 0.0, 1.0, 0.0]))
     assert torch.equal(batch['position_ids'], torch.tensor([0, 1, 0, 0, 0]))
+
+
+def test_scheduler_reroute_uses_dp_all_gather(monkeypatch):
+    class _Group:
+        def __init__(self, size, rank):
+            self._size = size
+            self._rank = rank
+
+        def size(self):
+            return self._size
+
+        def rank(self):
+            return self._rank
+
+    dp_group = _Group(size=2, rank=0)
+    dp_cp_group = _Group(size=2, rank=0)
+    batch = [
+        {
+            'tokens': torch.tensor([10, 11]),
+            'labels': torch.tensor([110, 111]),
+            'loss_mask': torch.tensor([1.0, 0.0]),
+            'position_ids': torch.tensor([0, 1]),
+            'original_seq_len': torch.tensor([2], dtype=torch.int32),
+            'padded_seq_len': torch.tensor([2], dtype=torch.int32),
+        },
+        {
+            'tokens': torch.tensor([20]),
+            'labels': torch.tensor([120]),
+            'loss_mask': torch.tensor([1.0]),
+            'position_ids': torch.tensor([0]),
+            'original_seq_len': torch.tensor([1], dtype=torch.int32),
+            'padded_seq_len': torch.tensor([1], dtype=torch.int32),
+        },
+    ]
+    remote_inputs = iter(
+        [
+            torch.tensor([30, 31, 32, 33]),
+            torch.tensor([130, 131, 132, 133]),
+            torch.tensor([1.0, 1.0, 0.0, 0.0]),
+            torch.tensor([0, 1, 2, 3]),
+            torch.tensor([4, 0], dtype=torch.int32),
+            torch.tensor([4, 0], dtype=torch.int32),
+        ]
+    )
+    gather_groups = []
+
+    def _all_gather_into_tensor(output, input_, group):
+        gather_groups.append(group)
+        remote = next(remote_inputs)
+        assert input_.numel() == remote.numel(), (
+            f'gather input {input_.numel()} must be padded to the common rank width '
+            f'{remote.numel()}'
+        )
+        assert output.numel() == dp_group.size() * input_.numel()
+        output.copy_(torch.cat([input_, remote]))
+
+    monkeypatch.setattr(torch.cuda, 'current_device', lambda: torch.device('cpu'))
+    monkeypatch.setattr(torch.distributed, 'all_gather_into_tensor', _all_gather_into_tensor)
+    monkeypatch.setattr(
+        torch.distributed,
+        'all_to_all_single',
+        lambda *args, **kwargs: pytest.fail('reroute must not use all_to_all_single'),
+    )
+
+    received = reroute_samples_to_dcp_ranks(
+        batch=batch,
+        global_ids_this_rank=torch.tensor([0, 1]),
+        global_id_seqlens=[(0, 2), (1, 1), (2, 4)],
+        sample_id_groups=[[[2], [0, 1]]],
+        offsets=torch.tensor([0, 2, 3]),
+        dp_group=dp_group,
+        dp_cp_group=dp_cp_group,
+    )
+
+    assert list(received) == [2]
+    assert torch.equal(received[2]['tokens'], torch.tensor([30, 31, 32, 33]))
+    assert torch.equal(received[2]['labels'], torch.tensor([130, 131, 132, 133]))
+    assert torch.equal(received[2]['loss_mask'], torch.tensor([1.0, 1.0, 0.0, 0.0]))
+    assert torch.equal(received[2]['position_ids'], torch.tensor([0, 1, 2, 3]))
+    assert torch.equal(received[2]['original_seq_len'], torch.tensor([4], dtype=torch.int32))
+    assert torch.equal(received[2]['padded_seq_len'], torch.tensor([4], dtype=torch.int32))
+    assert gather_groups == [dp_group] * 6
+
+
+def test_scheduler_reroute_rejects_unsupported_sample_keys():
+    group = SimpleNamespace(size=lambda: 1, rank=lambda: 0)
+    batch = [
+        {
+            'tokens': torch.tensor([10]),
+            'original_seq_len': torch.tensor([1], dtype=torch.int32),
+            'padded_seq_len': torch.tensor([1], dtype=torch.int32),
+            'custom_weights': torch.tensor([1.0]),
+        }
+    ]
+
+    with pytest.raises(AssertionError, match=r"unsupported sample keys \['custom_weights'\]"):
+        reroute_samples_to_dcp_ranks(
+            batch=batch,
+            global_ids_this_rank=torch.tensor([0]),
+            global_id_seqlens=[(0, 1)],
+            sample_id_groups=[[[0]]],
+            offsets=torch.tensor([0, 1]),
+            dp_group=group,
+            dp_cp_group=group,
+        )
+
+
+def test_scheduler_reroute_rejects_inconsistent_local_sample_keys():
+    group = SimpleNamespace(size=lambda: 1, rank=lambda: 0)
+    batch = [
+        {
+            'tokens': torch.tensor([10]),
+            'original_seq_len': torch.tensor([1], dtype=torch.int32),
+            'padded_seq_len': torch.tensor([1], dtype=torch.int32),
+        },
+        {'tokens': torch.tensor([20]), 'original_seq_len': torch.tensor([1], dtype=torch.int32)},
+    ]
+
+    with pytest.raises(AssertionError, match='Sample 1 keys'):
+        reroute_samples_to_dcp_ranks(
+            batch=batch,
+            global_ids_this_rank=torch.tensor([0, 1]),
+            global_id_seqlens=[(0, 1), (1, 1)],
+            sample_id_groups=[[[0, 1]]],
+            offsets=torch.tensor([0, 2]),
+            dp_group=group,
+            dp_cp_group=group,
+        )
+
+
+def test_scheduler_reroute_dp_all_gather_distributed():
+    Utils.initialize_distributed()
+    world_size = torch.distributed.get_world_size()
+    if world_size < 2:
+        pytest.skip('requires at least two distributed ranks')
+
+    rank = torch.distributed.get_rank()
+    device = torch.device('cuda', torch.cuda.current_device())
+    # WORLD for both groups is the degenerate CP=1 case. This test covers the real
+    # NCCL gather path; CP-lane selection is covered by the DP=2/CP=2 test below.
+    sample_len = rank + 1
+    batch = [
+        {
+            'tokens': torch.full((sample_len,), rank, dtype=torch.int64, device=device),
+            'original_seq_len': torch.tensor([sample_len], dtype=torch.int32, device=device),
+            'padded_seq_len': torch.tensor([sample_len], dtype=torch.int32, device=device),
+        }
+    ]
+    target_gid = (rank + 1) % world_size
+    sample_id_groups = [[[(dcp_rank + 1) % world_size] for dcp_rank in range(world_size)]]
+
+    received = reroute_samples_to_dcp_ranks(
+        batch=batch,
+        global_ids_this_rank=torch.tensor([rank], dtype=torch.int32, device=device),
+        global_id_seqlens=[(gid, gid + 1) for gid in range(world_size)],
+        sample_id_groups=sample_id_groups,
+        offsets=torch.arange(world_size + 1, dtype=torch.int32),
+        dp_group=torch.distributed.group.WORLD,
+        dp_cp_group=torch.distributed.group.WORLD,
+    )
+
+    assert list(received) == [target_gid]
+    assert torch.equal(
+        received[target_gid]['tokens'],
+        torch.full((target_gid + 1,), target_gid, dtype=torch.int64, device=device),
+    )
+    assert received[target_gid]['original_seq_len'].item() == target_gid + 1
+    assert received[target_gid]['padded_seq_len'].item() == target_gid + 1
+
+
+def test_scheduler_reroute_dp_all_gather_is_dcp_compatible():
+    if Utils.world_size < 4 or Utils.world_size % 2:
+        pytest.skip('requires an even distributed world size of at least four')
+
+    Utils.initialize_model_parallel(
+        tensor_model_parallel_size=1,
+        pipeline_model_parallel_size=1,
+        context_parallel_size=2,
+        dynamic_context_parallel=True,
+        min_dynamic_context_parallel_size=1,
+    )
+    try:
+        dp_group = parallel_state.get_data_parallel_group()
+        dp_cp_group = parallel_state.get_data_parallel_group(with_context_parallel=True)
+        dp_rank = dp_group.rank()
+        dcp_rank = dp_cp_group.rank()
+        total_dcp_gpus = dp_cp_group.size()
+        device = torch.device('cuda', torch.cuda.current_device())
+
+        # CP siblings intentionally construct the same two samples for their DP rank.
+        # A CP-lane DP all-gather makes every global sample visible, after which
+        # the DCP schedule assigns one distinct sample to each DPxCP rank.
+        local_gids = [2 * dp_rank, 2 * dp_rank + 1]
+        batch = [
+            {
+                'tokens': torch.full((gid + 1,), gid, dtype=torch.int64, device=device),
+                'original_seq_len': torch.tensor([gid + 1], dtype=torch.int32, device=device),
+                'padded_seq_len': torch.tensor([gid + 1], dtype=torch.int32, device=device),
+            }
+            for gid in local_gids
+        ]
+        sample_id_groups = [[[rank] for rank in range(total_dcp_gpus)]]
+
+        received = reroute_samples_to_dcp_ranks(
+            batch=batch,
+            global_ids_this_rank=torch.tensor(local_gids, dtype=torch.int32, device=device),
+            global_id_seqlens=[(gid, gid + 1) for gid in range(total_dcp_gpus)],
+            sample_id_groups=sample_id_groups,
+            offsets=torch.arange(0, total_dcp_gpus + 1, 2, dtype=torch.int32),
+            dp_group=dp_group,
+            dp_cp_group=dp_cp_group,
+        )
+
+        assert list(received) == [dcp_rank]
+        assert torch.equal(
+            received[dcp_rank]['tokens'],
+            torch.full((dcp_rank + 1,), dcp_rank, dtype=torch.int64, device=device),
+        )
+        assert received[dcp_rank]['original_seq_len'].item() == dcp_rank + 1
+        assert received[dcp_rank]['padded_seq_len'].item() == dcp_rank + 1
+    finally:
+        Utils.destroy_model_parallel()
 
 
 class MockVariableLengthSequencePackingDataIterator:


### PR DESCRIPTION
## What changed

- Replace `DpBalancedScheduler` sample rerouting via `all_to_all_single` on the DP×CP group with per-field `all_gather_into_tensor` within each CP lane's DP group.
- Pad variable-size rank payloads to the largest DP-rank payload, gather in a fixed field order, and locally retain only samples assigned to the current DP×CP rank.
- Clone selected slices so returned samples do not retain the global gather buffer.
- Add mock, real NCCL, and DP×CP compatibility coverage, and update the scheduler documentation.

## Why

The first DP-balance all-to-all lazily initializes NCCL's fully connected P2P transport. At 64 ranks and 32 channels, its shareable receive/send allocations account for approximately:

```text
63 peers × 32 channels × (10 MiB + 2 MiB) = 23.625 GiB/GPU
```

Using the existing DP collective communicator for all-gather avoids that peer-per-channel transport allocation. In a 4-rank GB200 A/B smoke, the original path used 9804–10246 MiB/GPU and this path used 8652–9094 MiB/GPU, a 1152–1154 MiB/GPU reduction. This matches `3 peers × 32 channels × 12 MiB = 1.125 GiB/GPU`.

## Impact and tradeoff

This removes the large NCCL P2P transport memory overhead from DP-balance rerouting and remains compatible with CP siblings and dynamic CP rank assignment. The tradeoff is increased communication volume: every rank receives all DP shards before selecting its scheduled samples, so large-DP throughput should be profiled separately.

## Validation

- `python -m py_compile megatron/core/datasets/data_schedule.py megatron/core/datasets/data_schedule_utils.py tests/unit_tests/test_sequence_packing.py`
- `git diff --check`
- Four-rank GB200/NCCL run; all ranks passed:
  - `test_scheduler_reroute_uses_dp_all_gather`
  - `test_scheduler_reroute_dp_all_gather_distributed`
  - `test_scheduler_reroute_dp_all_gather_is_dcp_compatible` (DP=2, CP=2)
- Two-step GB200 THD/dynamic-CP smoke with DP=4 and dynamic CP sizes 1–4 completed training, validation, and test without skipped or NaN iterations.

## Additional observation

An EP=4 HybridEP+DCP A/B run left both the unmodified baseline and this branch in the same first-backward state for over ten minutes, so those jobs were stopped after collecting the memory comparison above. The matching baseline/feature behavior indicates this is separate from the rerouting change; the successful standard-dispatcher DCP smoke is used for the end-to-end compatibility result.
