### PR TITLE
GTP+Muon: support 'blockwise' and 'distributed' tp_mode

### DIFF
--- a/megatron/core/optimizer/emerging_optimizers.py
+++ b/megatron/core/optimizer/emerging_optimizers.py
@@ -312,12 +312,17 @@ class TensorParallelMuon(OrthogonalizedOptimizer):
             return gathered_grad[gtp_rank * shard_size : (gtp_rank + 1) * shard_size].contiguous()
 
         # distributed: NS via the small-Gram all-reduce (no redundant full-matrix NS).
-        is_tp_active = (
+        # A momentum with both TP and GTP as sharding axes takes two communication steps: an
+        # all-gather that eliminates one axis, then the Gram all-reduce that distributes NS over
+        # the other. With GTP as the only sharding axis, the Gram all-reduce is the only
+        # communication needed. partition_dim is what says whether TP is a sharding axis here,
+        # the same signal scaled_orthogonalize_fn and newton_schulz_tp key off.
+        needs_two_step_communication = (
             partition_dim is not None and tp_group is not None and get_pg_size(tp_group) > 1
         )
 
-        if not is_tp_active:
-            # GTP-only: distribute NS over the GTP group on the local dim-0 row shard.
+        if not needs_two_step_communication:
+            # GTP is the only sharding axis: distribute NS over it on the local dim-0 row shard.
             return self.scaled_orthogonalize_fn(grad, gtp_remat_group, partition_dim=0)
 
         # GTP + TP: distributed NS can only operate over one (group, dim) at a

--- a/megatron/core/optimizer/emerging_optimizers.py
+++ b/megatron/core/optimizer/emerging_optimizers.py
@@ -258,13 +258,24 @@ class TensorParallelMuon(OrthogonalizedOptimizer):
             scaled_orthogonalize_fn=scaled_orthogonalize_fn,
         )
 
-    def scaled_orthogonalize_fn_with_gtp_remat(self, p, grad, tp_group, partition_dim):
-        """All-gather grad along GTP_remat/EGTP_remat dim 0, orthogonalize, then slice back.
+    @staticmethod
+    def _all_gather_tensor(t, group, dim):
+        """All-gather equal-size shards of ``t`` over ``group`` and concat along ``dim``."""
+        shards = [torch.empty_like(t) for _ in range(get_pg_size(group))]
+        torch.distributed.all_gather(shards, t.contiguous(), group)
+        return torch.cat(shards, dim=dim)
 
-        GTP_remat shards weights along dim 0 independently of TP's partition_dim. Newton-Schulz
-        needs the full weight matrix, so we reconstruct the GTP_remat dimension before running
-        the TP-aware orthogonalization, then extract the local GTP_remat shard from the result.
-        When GTP_remat is inactive this is a plain passthrough to scaled_orthogonalize_fn.
+    def scaled_orthogonalize_fn_with_gtp_remat(self, p, grad, tp_group, partition_dim):
+        """Orthogonalize a (possibly GTP-sharded) momentum, then reshard.
+
+        When GTP is inactive this is a plain passthrough to ``scaled_orthogonalize_fn``.
+        Otherwise, ``self.tp_mode`` controls how GTP sharding is handled:
+
+        - **blockwise**: orthogonalize the local GTP shard independently, no collective.
+        - **duplicated**: all-gather over GTP, run whole-matrix NS (TP-aware), reshard.
+        - **distributed**: distribute NS over GTP via small-Gram all-reduce. When both
+          GTP and TP are active, NS is distributed over the larger group to minimize
+          redundant compute; the smaller group is all-gathered beforehand.
         """
         # TODO: Clean up code that determines if parameter is a MoE layer and which TP group to use
         is_expert = getattr(p, 'expert_tp', False)
@@ -284,21 +295,56 @@ class TensorParallelMuon(OrthogonalizedOptimizer):
             return self.scaled_orthogonalize_fn(grad, tp_group, partition_dim)
 
         gtp_remat_size = get_pg_size(gtp_remat_group)
-        gtp_rank = get_pg_rank(gtp_remat_group)
-        shards = [torch.empty_like(grad) for _ in range(gtp_remat_size)]
-        torch.distributed.all_gather(shards, grad, gtp_remat_group)
-        gathered_grad = torch.cat(shards, dim=0)
 
-        gathered_grad = self.scaled_orthogonalize_fn(gathered_grad, tp_group, partition_dim)
+        if self.tp_mode == "blockwise":
+            # Local block NS on this rank's GTP row-shard (shape [M/gtp_remat_size, K]):
+            # partition_dim=None makes scaled_orthogonalize_fn run a plain Newton-Schulz on
+            # the shard with no GTP/TP collective.
+            return self.scaled_orthogonalize_fn(grad, tp_group, None)
 
-        shard_size = gathered_grad.shape[0] // gtp_remat_size
-        return gathered_grad[gtp_rank * shard_size : (gtp_rank + 1) * shard_size].contiguous()
+        if self.tp_mode == "duplicated":
+            # All-gather the full matrix over GTP (dim 0), orthogonalize the whole tensor
+            # (scaled_orthogonalize_fn handles any TP sharding per tp_mode), reshard dim 0.
+            gathered_grad = self._all_gather_tensor(grad, gtp_remat_group, 0)
+            gathered_grad = self.scaled_orthogonalize_fn(gathered_grad, tp_group, partition_dim)
+            shard_size = gathered_grad.size(0) // gtp_remat_size
+            gtp_rank = get_pg_rank(gtp_remat_group)
+            return gathered_grad[gtp_rank * shard_size : (gtp_rank + 1) * shard_size].contiguous()
+
+        # distributed: NS via the small-Gram all-reduce (no redundant full-matrix NS).
+        is_tp_active = (
+            partition_dim is not None and tp_group is not None and get_pg_size(tp_group) > 1
+        )
+
+        if not is_tp_active:
+            # GTP-only: distribute NS over the GTP group on the local dim-0 row shard.
+            return self.scaled_orthogonalize_fn(grad, gtp_remat_group, partition_dim=0)
+
+        # GTP + TP: distributed NS can only operate over one (group, dim) at a
+        # time. Distribute over the larger group so that the NS GEMMs are sharded
+        # across more ranks (less redundant compute), and all-gather the smaller
+        # group to eliminate its sharding beforehand.
+        tp_size = get_pg_size(tp_group)
+        if gtp_remat_size >= tp_size:
+            smaller_group, smaller_dim = tp_group, partition_dim
+            larger_group, larger_dim = gtp_remat_group, 0
+        else:
+            smaller_group, smaller_dim = gtp_remat_group, 0
+            larger_group, larger_dim = tp_group, partition_dim
+
+        gathered_grad = self._all_gather_tensor(grad, smaller_group, smaller_dim)
+        orthogonalized_grad = self.scaled_orthogonalize_fn(gathered_grad, larger_group, larger_dim)
+        shard_size = orthogonalized_grad.size(smaller_dim) // get_pg_size(smaller_group)
+        reshard_rank = get_pg_rank(smaller_group)
+        return orthogonalized_grad.narrow(
+            smaller_dim, reshard_rank * shard_size, shard_size
+        ).contiguous()
 
     def orthogonalize(self, p: torch.Tensor, grad: torch.Tensor, **kwargs: Any) -> torch.Tensor:
         """Orthogonalize the momentum.
 
         Args:
-            p: The parameter tensor. i is necessary to pass param tensor in addition to
+            p: The parameter tensor. It is necessary to pass param tensor in addition to
                 momentum because a lot of information is only available in the param tensor,
                 attributes for example.
             grad: The momentum tensor.

--- a/megatron/core/optimizer/optimizer_config.py
+++ b/megatron/core/optimizer/optimizer_config.py
@@ -279,8 +279,11 @@ class OptimizerConfig:
     muon_num_ns_steps: int = 5
     """The number of iteration steps to use in the Newton-Schulz iteration."""
 
-    muon_tp_mode: str = "blockwise"
-    """How to perform NS calculation for tensor parallel weights. Defaults to "blockwise"."""
+    muon_tp_mode: str = "duplicated"
+    """How to perform NS calculation for tensor parallel weights. "blockwise" orthogonalizes
+    each shard independently, which makes the update rule depend on the parallelism config;
+    "duplicated" and "distributed" both orthogonalize the whole matrix, so results do not
+    change as TP changes. Defaults to "duplicated"."""
 
     muon_use_syrk: bool = False
     """Use the Triton SYRK kernel for the Gram matrix in Newton-Schulz iteration."""

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2614,9 +2614,12 @@ def _add_regularization_args(parser):
                        'Validated at optimizer creation time.')
     group.add_argument('--muon-num-ns-steps', type=int, default=5,
                        help='Number of Newton-Schulz steps for Muon optimizer')
-    group.add_argument('--muon-tp-mode', type=str, default='blockwise',
+    group.add_argument('--muon-tp-mode', type=str, default='duplicated',
                        choices=['blockwise', 'duplicated', 'distributed'],
-                       help='How to perform NS calculation for tensor model parallel weights')
+                       help='How to perform NS calculation for tensor model parallel weights. '
+                       'blockwise orthogonalizes each shard on its own, so the update rule '
+                       'depends on the parallelism config; duplicated and distributed both '
+                       'orthogonalize the whole matrix and give TP-invariant results.')
     group.add_argument('--muon-use-syrk', action='store_true',
                        help='Use the Triton SYRK kernel for the Gram matrix '
                        'in Newton-Schulz iteration.')

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_muon.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_muon.py
@@ -7,13 +7,15 @@ momentum in one of three modes (blockwise, duplicated, distributed) instead of a
 the full matrix and running a redundant full NS on every rank. These tests verify that each
 mode produces the correct per-shard result:
 
-  1. test_gtp_distributed_mode - GTP4, TP1: distribute NS over GTP (dim 0).
-  2. test_row_parallel         - TP2, GTP2 (TP dim 1, GTP dim 0): gather smaller, distribute larger.
-  3. test_col_parallel         - TP2, GTP2 (both dim 0): gather smaller, distribute larger.
-  4. test_gtp_duplicated_mode  - GTP4, TP1: all-gather over GTP, full NS, reshard.
-  5. test_gtp_blockwise_mode   - GTP4, TP1: local NS on GTP shard, no collective.
+  1. test_gtp_only_parity   - TP1: distributed and duplicated both match full-matrix NS.
+  2. test_gtp_blockwise_mode - TP1: local NS on the GTP shard, no collective.
+  3. test_row_parallel      - TP on dim 1, GTP on dim 0: gather smaller group, distribute larger.
+  4. test_col_parallel      - TP and GTP both on dim 0: gather smaller group, distribute larger.
 
-All require world_size == 4.
+The TP cases run at ``tp_size * gtp_remat_size`` ranks and cover ``tp_size != gtp_remat_size``
+in both directions, since equal sizes are the one shape where a mix-up of the two dim-0 axes
+would still land on self-consistent offsets. Each case skips unless the launched world size
+matches, so the 4-rank shapes cover a 4-GPU dev box and the 8-rank ones cover CI.
 """
 
 import pytest
@@ -22,7 +24,7 @@ import torch
 from megatron.core.tensor_parallel.gtp_api import HAVE_GTP
 
 if not HAVE_GTP:
-    pytest.skip("GTP requires TransformerEngine >= 2.17", allow_module_level=True)
+    pytest.skip("GTP requires TE with hook registry", allow_module_level=True)
 
 from megatron.core import parallel_state as ps
 from megatron.core.optimizer.emerging_optimizers import HAVE_EMERGING_OPTIMIZERS, TensorParallelMuon
@@ -30,16 +32,18 @@ from megatron.core.optimizer.emerging_optimizers import HAVE_EMERGING_OPTIMIZERS
 if not HAVE_EMERGING_OPTIMIZERS:
     pytest.skip("emerging_optimizers not available", allow_module_level=True)
 
+from emerging_optimizers.orthogonalized_optimizers import get_muon_scale_factor
+from emerging_optimizers.orthogonalized_optimizers.muon_utils import newton_schulz
+
 from megatron.core.process_groups_config import ProcessGroupCollection
-from tests.unit_tests.generalized_tensor_parallel.gtp_test_utils import (
-    _torchrun_dist_init,  # autouse fixture: initializes the torchrun dist group
-)
-from tests.unit_tests.generalized_tensor_parallel.gtp_test_utils import (
-    reset_gtp_globals,  # autouse fixture: resets GTP class state between tests
-)
+
+# _torchrun_dist_init and reset_gtp_globals are autouse fixtures; pytest only applies them
+# if the names are bound in this module.
 from tests.unit_tests.generalized_tensor_parallel.gtp_test_utils import (  # noqa: F401
     _requires_multi_gpu,
     _run_distributed,
+    _torchrun_dist_init,
+    reset_gtp_globals,
 )
 
 # Parity is asserted at num_ns_steps=1: there the distributed Gram all-reduce equals the
@@ -52,6 +56,16 @@ _M, _K = 128, 64
 _NS_STEPS = 1
 _ATOL, _RTOL = 1e-4, 1e-4
 
+# Spelled out rather than left to TensorParallelMuon's defaults so the blockwise test can
+# rebuild the expected value from the same primitives the production path uses.
+_COEFFICIENT_TYPE = "quintic"
+_SCALE_MODE = "spectral"
+
+# GTP-only shapes (TP1); the GTP group spans the whole world.
+_GTP_ONLY_WORLD_SIZES = [4, 8]
+# (tp_size, gtp_remat_size) for the combined TP + GTP shapes; world size is their product.
+_TP_GTP_SHAPES = [(2, 2), (2, 4), (4, 2)]
+
 
 def _make_muon(pg_collection, tp_mode="distributed"):
     """A TensorParallelMuon used only for its orthogonalize helpers (never stepped)."""
@@ -62,6 +76,8 @@ def _make_muon(pg_collection, tp_mode="distributed"):
         momentum=0.95,
         weight_decay=0.0,
         num_ns_steps=_NS_STEPS,
+        coefficient_type=_COEFFICIENT_TYPE,
+        scale_mode=_SCALE_MODE,
         fp32_matmul_prec="highest",
         pg_collection=pg_collection,
         tp_mode=tp_mode,
@@ -89,15 +105,25 @@ def _rank(group):
     return torch.distributed.get_rank(group=group)
 
 
-def _worker_gtp_distributed(rank, world_size, port):
-    """distributed mode (GTP4, TP1): distribute NS over the GTP group on the local dim-0 shard."""
+def _init_model_parallel(tp_size, gtp_remat_size):
     ps.destroy_model_parallel()
     ps.initialize_model_parallel(
-        tensor_model_parallel_size=1, pipeline_model_parallel_size=1, gtp_remat_size=world_size
+        tensor_model_parallel_size=tp_size,
+        pipeline_model_parallel_size=1,
+        gtp_remat_size=gtp_remat_size,
     )
+
+
+def _worker_gtp_only_parity(rank, world_size, port, tp_mode):
+    """distributed and duplicated (TP1): the local GTP shard must match full-matrix NS.
+
+    Both modes are mathematically identical to orthogonalizing the whole matrix, one by
+    distributing the Gram all-reduce over GTP and one by all-gathering first.
+    """
+    _init_model_parallel(1, world_size)
     try:
         pgc = ProcessGroupCollection.use_mpu_process_groups()
-        opt = _make_muon(pgc)
+        opt = _make_muon(pgc, tp_mode=tp_mode)
         w = _full_weight()
         ref = _reference_full_orth(opt, w, pgc.tp)
 
@@ -114,12 +140,9 @@ def _worker_gtp_distributed(rank, world_size, port):
         ps.initialize_model_parallel()
 
 
-def _worker_row_parallel(rank, world_size, port):
+def _worker_row_parallel(rank, world_size, port, tp_size, gtp_remat_size):
     """RowParallel TP, GTP (TP dim 1, GTP dim 0): gather the smaller group, distribute larger."""
-    ps.destroy_model_parallel()
-    ps.initialize_model_parallel(
-        tensor_model_parallel_size=2, pipeline_model_parallel_size=1, gtp_remat_size=2
-    )
+    _init_model_parallel(tp_size, gtp_remat_size)
     try:
         pgc = ProcessGroupCollection.use_mpu_process_groups()
         opt = _make_muon(pgc)
@@ -140,16 +163,13 @@ def _worker_row_parallel(rank, world_size, port):
         ps.initialize_model_parallel()
 
 
-def _worker_col_parallel(rank, world_size, port):
+def _worker_col_parallel(rank, world_size, port, tp_size, gtp_remat_size):
     """ColumnParallel TP, GTP (both dim 0): gather smaller group, distribute larger.
 
     dim-0 carve is TP-outer / GTP-inner (GTP slices the already-TP-sharded weight), so this
     rank owns rows ``tr*(M/ts) + gr*sp : + sp``.
     """
-    ps.destroy_model_parallel()
-    ps.initialize_model_parallel(
-        tensor_model_parallel_size=2, pipeline_model_parallel_size=1, gtp_remat_size=2
-    )
+    _init_model_parallel(tp_size, gtp_remat_size)
     try:
         pgc = ProcessGroupCollection.use_mpu_process_groups()
         opt = _make_muon(pgc)
@@ -172,18 +192,17 @@ def _worker_col_parallel(rank, world_size, port):
         ps.initialize_model_parallel()
 
 
-def _worker_gtp_duplicated(rank, world_size, port):
-    """duplicated mode (GTP4, TP1): all-gather full matrix over GTP, whole NS, reshard.
+def _worker_gtp_blockwise(rank, world_size, port):
+    """blockwise mode (TP1): local NS on the [M/gtp_size, K] shard, no GTP collective.
 
-    Mathematically identical to the full-matrix reference, so the local block must match.
+    The expected value is rebuilt from newton_schulz and get_muon_scale_factor rather than
+    from ``scaled_orthogonalize_fn``, so the check is independent of the production wrapper
+    and pins the scale factor to the shard row count instead of the full M.
     """
-    ps.destroy_model_parallel()
-    ps.initialize_model_parallel(
-        tensor_model_parallel_size=1, pipeline_model_parallel_size=1, gtp_remat_size=world_size
-    )
+    _init_model_parallel(1, world_size)
     try:
         pgc = ProcessGroupCollection.use_mpu_process_groups()
-        opt = _make_muon(pgc, tp_mode="duplicated")
+        opt = _make_muon(pgc, tp_mode="blockwise")
         w = _full_weight()
         ref = _reference_full_orth(opt, w, pgc.tp)
 
@@ -193,36 +212,16 @@ def _worker_gtp_duplicated(rank, world_size, port):
         local.is_gtp_weight_remat = True
 
         out = opt.scaled_orthogonalize_fn_with_gtp_remat(local, local, pgc.tp, None)
-        expected = ref[gr * sp : (gr + 1) * sp, :]
+
+        raw = newton_schulz(local.clone(), steps=_NS_STEPS, coefficient_type=_COEFFICIENT_TYPE)
+        expected = raw * get_muon_scale_factor(sp, _K, mode=_SCALE_MODE)
         torch.testing.assert_close(out, expected, atol=_ATOL, rtol=_RTOL)
-    finally:
-        ps.destroy_model_parallel()
-        ps.initialize_model_parallel()
 
-
-def _worker_gtp_blockwise(rank, world_size, port):
-    """blockwise mode (GTP4, TP1): local NS on the [M/gtp_size, K] shard, no GTP collective.
-
-    Must equal a plain Newton-Schulz of the local shard, not the full-matrix shard.
-    """
-    ps.destroy_model_parallel()
-    ps.initialize_model_parallel(
-        tensor_model_parallel_size=1, pipeline_model_parallel_size=1, gtp_remat_size=world_size
-    )
-    try:
-        pgc = ProcessGroupCollection.use_mpu_process_groups()
-        opt = _make_muon(pgc, tp_mode="blockwise")
-        w = _full_weight()
-
-        gs, gr = _world_size(pgc.gtp_remat), _rank(pgc.gtp_remat)
-        sp = _M // gs
-        local = w[gr * sp : (gr + 1) * sp, :].clone()
-        local.is_gtp_weight_remat = True
-
-        out = opt.scaled_orthogonalize_fn_with_gtp_remat(local, local, pgc.tp, None)
-        # blockwise orthogonalizes the local block independently, no GTP comm.
-        expected = opt.scaled_orthogonalize_fn(local.clone(), pgc.tp, None)
-        torch.testing.assert_close(out, expected, atol=_ATOL, rtol=_RTOL)
+        # NS of a row block is not the row block of NS of the full matrix, so a silent
+        # regression to the all-gather path would show up here.
+        assert not torch.allclose(
+            out, ref[gr * sp : (gr + 1) * sp, :], atol=_ATOL, rtol=_RTOL
+        ), "blockwise matched the full-matrix result; it is not orthogonalizing the shard alone"
     finally:
         ps.destroy_model_parallel()
         ps.initialize_model_parallel()
@@ -231,22 +230,25 @@ def _worker_gtp_blockwise(rank, world_size, port):
 class TestGTPMuonDistributedNS:
     """Distributed-NS orthogonalization matches full-matrix NS, per shard."""
 
-    def test_gtp_distributed_mode(self):
-        _requires_multi_gpu(4)
-        _run_distributed(_worker_gtp_distributed, 4)
+    @pytest.mark.parametrize("tp_mode", ["distributed", "duplicated"])
+    @pytest.mark.parametrize("world_size", _GTP_ONLY_WORLD_SIZES)
+    def test_gtp_only_parity(self, world_size, tp_mode):
+        _requires_multi_gpu(world_size)
+        _run_distributed(_worker_gtp_only_parity, world_size, tp_mode)
 
-    def test_row_parallel(self):
-        _requires_multi_gpu(4)
-        _run_distributed(_worker_row_parallel, 4)
+    @pytest.mark.parametrize("tp_size,gtp_remat_size", _TP_GTP_SHAPES)
+    def test_row_parallel(self, tp_size, gtp_remat_size):
+        world_size = tp_size * gtp_remat_size
+        _requires_multi_gpu(world_size)
+        _run_distributed(_worker_row_parallel, world_size, tp_size, gtp_remat_size)
 
-    def test_col_parallel(self):
-        _requires_multi_gpu(4)
-        _run_distributed(_worker_col_parallel, 4)
+    @pytest.mark.parametrize("tp_size,gtp_remat_size", _TP_GTP_SHAPES)
+    def test_col_parallel(self, tp_size, gtp_remat_size):
+        world_size = tp_size * gtp_remat_size
+        _requires_multi_gpu(world_size)
+        _run_distributed(_worker_col_parallel, world_size, tp_size, gtp_remat_size)
 
-    def test_gtp_duplicated_mode(self):
-        _requires_multi_gpu(4)
-        _run_distributed(_worker_gtp_duplicated, 4)
-
-    def test_gtp_blockwise_mode(self):
-        _requires_multi_gpu(4)
-        _run_distributed(_worker_gtp_blockwise, 4)
+    @pytest.mark.parametrize("world_size", _GTP_ONLY_WORLD_SIZES)
+    def test_gtp_blockwise_mode(self, world_size):
+        _requires_multi_gpu(world_size)
+        _run_distributed(_worker_gtp_blockwise, world_size)

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_muon.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_muon.py
@@ -1,0 +1,252 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Parity tests for GTP + Muon Newton-Schulz orthogonalization.
+
+``TensorParallelMuon.scaled_orthogonalize_fn_with_gtp_remat`` orthogonalizes a GTP-row-sharded
+momentum in one of three modes (blockwise, duplicated, distributed) instead of all-gathering
+the full matrix and running a redundant full NS on every rank. These tests verify that each
+mode produces the correct per-shard result:
+
+  1. test_gtp_distributed_mode - GTP4, TP1: distribute NS over GTP (dim 0).
+  2. test_row_parallel         - TP2, GTP2 (TP dim 1, GTP dim 0): gather smaller, distribute larger.
+  3. test_col_parallel         - TP2, GTP2 (both dim 0): gather smaller, distribute larger.
+  4. test_gtp_duplicated_mode  - GTP4, TP1: all-gather over GTP, full NS, reshard.
+  5. test_gtp_blockwise_mode   - GTP4, TP1: local NS on GTP shard, no collective.
+
+All require world_size == 4.
+"""
+
+import pytest
+import torch
+
+from megatron.core.tensor_parallel.gtp_api import HAVE_GTP
+
+if not HAVE_GTP:
+    pytest.skip("GTP requires TransformerEngine >= 2.17", allow_module_level=True)
+
+from megatron.core import parallel_state as ps
+from megatron.core.optimizer.emerging_optimizers import HAVE_EMERGING_OPTIMIZERS, TensorParallelMuon
+
+if not HAVE_EMERGING_OPTIMIZERS:
+    pytest.skip("emerging_optimizers not available", allow_module_level=True)
+
+from megatron.core.process_groups_config import ProcessGroupCollection
+from tests.unit_tests.generalized_tensor_parallel.gtp_test_utils import (
+    _torchrun_dist_init,  # autouse fixture: initializes the torchrun dist group
+)
+from tests.unit_tests.generalized_tensor_parallel.gtp_test_utils import (
+    reset_gtp_globals,  # autouse fixture: resets GTP class state between tests
+)
+from tests.unit_tests.generalized_tensor_parallel.gtp_test_utils import (  # noqa: F401
+    _requires_multi_gpu,
+    _run_distributed,
+)
+
+# Parity is asserted at num_ns_steps=1: there the distributed Gram all-reduce equals the
+# full-matrix Gram to fp32 reduction-order noise (~1e-5). At more steps the (mathematically
+# identical) distributed result still matches full NS in exact arithmetic, but the aggressive
+# NS coefficients are tuned beyond convergence (see newton_schulz docstring) and amplify the
+# ~1e-6 fp difference (~1e-2 by step 5); that is NS conditioning, not a distribution error, so
+# a one-step parity check is the meaningful correctness test. fp32-highest matmul throughout.
+_M, _K = 128, 64
+_NS_STEPS = 1
+_ATOL, _RTOL = 1e-4, 1e-4
+
+
+def _make_muon(pg_collection, tp_mode="distributed"):
+    """A TensorParallelMuon used only for its orthogonalize helpers (never stepped)."""
+    placeholder = torch.nn.Parameter(torch.zeros(1, device="cuda"))
+    return TensorParallelMuon(
+        params=[placeholder],
+        lr=0.01,
+        momentum=0.95,
+        weight_decay=0.0,
+        num_ns_steps=_NS_STEPS,
+        fp32_matmul_prec="highest",
+        pg_collection=pg_collection,
+        tp_mode=tp_mode,
+    )
+
+
+def _full_weight():
+    """Full [M, K] momentum, identical on every rank (rank-0 broadcast)."""
+    torch.manual_seed(0)
+    w = torch.randn(_M, _K, dtype=torch.float32, device="cuda")
+    torch.distributed.broadcast(w, src=0)
+    return w
+
+
+def _reference_full_orth(opt, w, tp_group):
+    """Orthogonalize the full matrix (partition_dim=None gives plain NS), same scale/coeffs."""
+    return opt.scaled_orthogonalize_fn(w.clone(), tp_group, partition_dim=None)
+
+
+def _world_size(group):
+    return torch.distributed.get_world_size(group=group)
+
+
+def _rank(group):
+    return torch.distributed.get_rank(group=group)
+
+
+def _worker_gtp_distributed(rank, world_size, port):
+    """distributed mode (GTP4, TP1): distribute NS over the GTP group on the local dim-0 shard."""
+    ps.destroy_model_parallel()
+    ps.initialize_model_parallel(
+        tensor_model_parallel_size=1, pipeline_model_parallel_size=1, gtp_remat_size=world_size
+    )
+    try:
+        pgc = ProcessGroupCollection.use_mpu_process_groups()
+        opt = _make_muon(pgc)
+        w = _full_weight()
+        ref = _reference_full_orth(opt, w, pgc.tp)
+
+        gs, gr = _world_size(pgc.gtp_remat), _rank(pgc.gtp_remat)
+        sp = _M // gs
+        local = w[gr * sp : (gr + 1) * sp, :].clone()
+        local.is_gtp_weight_remat = True
+
+        out = opt.scaled_orthogonalize_fn_with_gtp_remat(local, local, pgc.tp, None)
+        expected = ref[gr * sp : (gr + 1) * sp, :]
+        torch.testing.assert_close(out, expected, atol=_ATOL, rtol=_RTOL)
+    finally:
+        ps.destroy_model_parallel()
+        ps.initialize_model_parallel()
+
+
+def _worker_row_parallel(rank, world_size, port):
+    """RowParallel TP, GTP (TP dim 1, GTP dim 0): gather the smaller group, distribute larger."""
+    ps.destroy_model_parallel()
+    ps.initialize_model_parallel(
+        tensor_model_parallel_size=2, pipeline_model_parallel_size=1, gtp_remat_size=2
+    )
+    try:
+        pgc = ProcessGroupCollection.use_mpu_process_groups()
+        opt = _make_muon(pgc)
+        w = _full_weight()
+        ref = _reference_full_orth(opt, w, pgc.tp)
+
+        gs, gr = _world_size(pgc.gtp_remat), _rank(pgc.gtp_remat)
+        ts, tr = _world_size(pgc.tp), _rank(pgc.tp)
+        sp, kt = _M // gs, _K // ts  # GTP row block, TP col block
+        local = w[gr * sp : (gr + 1) * sp, tr * kt : (tr + 1) * kt].clone()
+        local.is_gtp_weight_remat = True
+
+        out = opt.scaled_orthogonalize_fn_with_gtp_remat(local, local, pgc.tp, 1)
+        expected = ref[gr * sp : (gr + 1) * sp, tr * kt : (tr + 1) * kt]
+        torch.testing.assert_close(out, expected, atol=_ATOL, rtol=_RTOL)
+    finally:
+        ps.destroy_model_parallel()
+        ps.initialize_model_parallel()
+
+
+def _worker_col_parallel(rank, world_size, port):
+    """ColumnParallel TP, GTP (both dim 0): gather smaller group, distribute larger.
+
+    dim-0 carve is TP-outer / GTP-inner (GTP slices the already-TP-sharded weight), so this
+    rank owns rows ``tr*(M/ts) + gr*sp : + sp``.
+    """
+    ps.destroy_model_parallel()
+    ps.initialize_model_parallel(
+        tensor_model_parallel_size=2, pipeline_model_parallel_size=1, gtp_remat_size=2
+    )
+    try:
+        pgc = ProcessGroupCollection.use_mpu_process_groups()
+        opt = _make_muon(pgc)
+        w = _full_weight()
+        ref = _reference_full_orth(opt, w, pgc.tp)
+
+        gs, gr = _world_size(pgc.gtp_remat), _rank(pgc.gtp_remat)
+        ts, tr = _world_size(pgc.tp), _rank(pgc.tp)
+        m_tp = _M // ts
+        sp = m_tp // gs
+        off = tr * m_tp + gr * sp
+        local = w[off : off + sp, :].clone()
+        local.is_gtp_weight_remat = True
+
+        out = opt.scaled_orthogonalize_fn_with_gtp_remat(local, local, pgc.tp, 0)
+        expected = ref[off : off + sp, :]
+        torch.testing.assert_close(out, expected, atol=_ATOL, rtol=_RTOL)
+    finally:
+        ps.destroy_model_parallel()
+        ps.initialize_model_parallel()
+
+
+def _worker_gtp_duplicated(rank, world_size, port):
+    """duplicated mode (GTP4, TP1): all-gather full matrix over GTP, whole NS, reshard.
+
+    Mathematically identical to the full-matrix reference, so the local block must match.
+    """
+    ps.destroy_model_parallel()
+    ps.initialize_model_parallel(
+        tensor_model_parallel_size=1, pipeline_model_parallel_size=1, gtp_remat_size=world_size
+    )
+    try:
+        pgc = ProcessGroupCollection.use_mpu_process_groups()
+        opt = _make_muon(pgc, tp_mode="duplicated")
+        w = _full_weight()
+        ref = _reference_full_orth(opt, w, pgc.tp)
+
+        gs, gr = _world_size(pgc.gtp_remat), _rank(pgc.gtp_remat)
+        sp = _M // gs
+        local = w[gr * sp : (gr + 1) * sp, :].clone()
+        local.is_gtp_weight_remat = True
+
+        out = opt.scaled_orthogonalize_fn_with_gtp_remat(local, local, pgc.tp, None)
+        expected = ref[gr * sp : (gr + 1) * sp, :]
+        torch.testing.assert_close(out, expected, atol=_ATOL, rtol=_RTOL)
+    finally:
+        ps.destroy_model_parallel()
+        ps.initialize_model_parallel()
+
+
+def _worker_gtp_blockwise(rank, world_size, port):
+    """blockwise mode (GTP4, TP1): local NS on the [M/gtp_size, K] shard, no GTP collective.
+
+    Must equal a plain Newton-Schulz of the local shard, not the full-matrix shard.
+    """
+    ps.destroy_model_parallel()
+    ps.initialize_model_parallel(
+        tensor_model_parallel_size=1, pipeline_model_parallel_size=1, gtp_remat_size=world_size
+    )
+    try:
+        pgc = ProcessGroupCollection.use_mpu_process_groups()
+        opt = _make_muon(pgc, tp_mode="blockwise")
+        w = _full_weight()
+
+        gs, gr = _world_size(pgc.gtp_remat), _rank(pgc.gtp_remat)
+        sp = _M // gs
+        local = w[gr * sp : (gr + 1) * sp, :].clone()
+        local.is_gtp_weight_remat = True
+
+        out = opt.scaled_orthogonalize_fn_with_gtp_remat(local, local, pgc.tp, None)
+        # blockwise orthogonalizes the local block independently, no GTP comm.
+        expected = opt.scaled_orthogonalize_fn(local.clone(), pgc.tp, None)
+        torch.testing.assert_close(out, expected, atol=_ATOL, rtol=_RTOL)
+    finally:
+        ps.destroy_model_parallel()
+        ps.initialize_model_parallel()
+
+
+class TestGTPMuonDistributedNS:
+    """Distributed-NS orthogonalization matches full-matrix NS, per shard."""
+
+    def test_gtp_distributed_mode(self):
+        _requires_multi_gpu(4)
+        _run_distributed(_worker_gtp_distributed, 4)
+
+    def test_row_parallel(self):
+        _requires_multi_gpu(4)
+        _run_distributed(_worker_row_parallel, 4)
+
+    def test_col_parallel(self):
+        _requires_multi_gpu(4)
+        _run_distributed(_worker_col_parallel, 4)
+
+    def test_gtp_duplicated_mode(self):
+        _requires_multi_gpu(4)
+        _run_distributed(_worker_gtp_duplicated, 4)
+
+    def test_gtp_blockwise_mode(self):
+        _requires_multi_gpu(4)
+        _run_distributed(_worker_gtp_blockwise, 4)

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_muon_dcp.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_muon_dcp.py
@@ -8,6 +8,13 @@ matrix params (e.g. the MoE router) are kept whole and must be disambiguated
 by ``replica_id`` so DCP does not see multiple writers for the same shard.
 """
 
+import pytest
+
+from megatron.core.tensor_parallel.gtp_api import HAVE_GTP
+
+if not HAVE_GTP:
+    pytest.skip("GTP requires TransformerEngine >= 2.17", allow_module_level=True)
+
 import torch
 
 from megatron.core.dist_checkpointing import load, save

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_muon_dcp.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_muon_dcp.py
@@ -13,7 +13,7 @@ import pytest
 from megatron.core.tensor_parallel.gtp_api import HAVE_GTP
 
 if not HAVE_GTP:
-    pytest.skip("GTP requires TransformerEngine >= 2.17", allow_module_level=True)
+    pytest.skip("GTP requires TE with hook registry", allow_module_level=True)
 
 import torch
 


### PR DESCRIPTION
## Summary

`TensorParallelMuon.scaled_orthogonalize_fn_with_gtp_remat` had one hard-coded strategy for GTP-sharded momenta: all-gather along the GTP dim, run whole-matrix Newton-Schulz redundantly on every GTP rank, slice the local shard back out. That ignores `self.tp_mode`, which already selects between `blockwise`, `duplicated` and `distributed` for TP-sharded params. This branches the GTP path on it so both axes behave consistently:

- **blockwise**: NS locally on the `[M/g, K]` GTP shard, no GTP collective.
- **duplicated**: the previous behavior, now explicit rather than implicit.
- **distributed**: NS distributed over GTP via the small-Gram all-reduce, so no rank does redundant full-matrix work.

Under `distributed` with both GTP and TP active, NS can only be distributed over one (group, dim) pair, so the code distributes over the larger group and all-gathers the smaller one first.

## Default `muon_tp_mode` changes from `blockwise` to `duplicated`

`blockwise` orthogonalizes each shard on its own, so the update rule, and with `scale_mode="spectral"` the effective learning rate, move whenever the parallelism config changes. `duplicated` and `distributed` orthogonalize the whole matrix and are TP-invariant.

This is wider than the GTP path: it changes behavior for any Muon run with TP > 1. Golden values are unaffected, since all six Muon functional tests run at TP and expert TP of 1, where the two modes are the same computation, and every Muon unit test sets `muon_tp_mode` explicitly. It also aligns the training-config default with `TensorParallelMuon.__init__`, which already defaulted to `duplicated`.

## Tests

`tests/unit_tests/generalized_tensor_parallel/test_gtp_muon.py` asserts per-shard parity against a full-matrix reference for all three modes:

- `test_gtp_only_parity` — TP1, `distributed` and `duplicated`, at GTP4 and GTP8.
- `test_row_parallel` / `test_col_parallel` — TP on dim 1 / dim 0, at `(tp, gtp)` of (2,2), (2,4), (4,2).
- `test_gtp_blockwise_mode` — TP1, at GTP4 and GTP8.

Every test in this directory required exactly 4 ranks while the unit-test recipe launches 8 GPUs, so a 4-GPU box was the only place they ran. Both shapes are now covered, and TP2xGTP4 / TP4xGTP2 additionally cover `tp_size != gtp_remat_size`, the case equal sizes cannot reach. Note this does not make the directory run in CI: `HAVE_GTP` is false in the CI container, whose TE has no hook registry, so the module-level guard fires before any world-size check. These need a GTP-capable 8-GPU node to exercise.

Parity is asserted at `num_ns_steps=1`: at more steps the distributed result is still mathematically identical, but the past-convergence NS coefficients amplify the ~1e-6 fp difference to ~1e-2 by step 5. The `blockwise` expected value is rebuilt from `newton_schulz` and `get_muon_scale_factor` rather than from `scaled_orthogonalize_fn`, so it does not restate the production branch and it pins the scale factor to the shard row count.

`test_gtp_muon_dcp.py` gains the standard `HAVE_GTP` module-level skip guard used elsewhere in the directory.

## Notes

Original implementation by @fanshiqing; both sign-offs are on the first commit.

