### PR TITLE
Add configurable checkpoint retention limit

### DIFF
--- a/docs/user-guide/training-examples.md
+++ b/docs/user-guide/training-examples.md
@@ -151,6 +151,10 @@ The following tables group common training arguments by category.
 | `--save` | Checkpoint save directory |
 | `--load` | Checkpoint load directory |
 | `--save-interval` | Save checkpoint every N iterations |
+| `--most-recent-k` | Keep only the K most recent checkpoints (`-1` disables the limit) |
+
+When `--most-recent-k` and `--save-retain-interval` are both set, periodic checkpoints selected
+by `--save-retain-interval` are retained in addition to the K most recent checkpoints.
 
 ## Next Steps
 

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1314,6 +1314,10 @@ def validate_args(args, defaults={}):
             assert args.save_retain_interval % args.save_interval == 0
         if args.save_params_interval is not None:
             assert not args.overlap_param_gather
+    if args.most_recent_k is not None:
+        assert args.most_recent_k == -1 or args.most_recent_k > 0, (
+            '--most-recent-k must be -1 or a positive integer'
+        )
     if args.log_memory_interval is not None:
         assert args.log_memory_interval % args.log_interval == 0
     # Mixed precision checks.
@@ -2865,7 +2869,10 @@ def _add_learning_rate_args(parser):
 def _add_checkpointing_args(parser):
     from megatron.training.config import CheckpointConfig
 
-    ckpt_factory = ArgumentGroupFactory(CheckpointConfig, exclude=["most_recent_k", "save_tokenizer_assets", "save_optim", "save_rng", "load_optim", "load_rng"])
+    ckpt_factory = ArgumentGroupFactory(
+        CheckpointConfig,
+        exclude=["save_tokenizer_assets", "save_optim", "save_rng", "load_optim", "load_rng"],
+    )
     group = ckpt_factory.build_group(parser, "checkpointing")
 
     group.add_argument('--no-save-optim', action='store_true', default=None,

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -1029,7 +1029,9 @@ def save_checkpoint(
                 save_retain_interval = getattr(
                     args, 'save_retain_interval', None
                 )  # For backwards compatibility of tests.
-                if save_retain_interval is not None:
+                most_recent_k = getattr(args, 'most_recent_k', -1)
+                keep_most_recent = most_recent_k is not None and most_recent_k > 0
+                if save_retain_interval is not None and not keep_most_recent:
                     if maybe_msc.os.path.exists(tracker_filename):
                         with maybe_msc.open(tracker_filename, 'r') as f:
                             prev_iteration = int(f.read().strip())
@@ -1047,51 +1049,18 @@ def save_checkpoint(
                         args.save, f'Saved async checkpoint\tIteration: {iteration}', barrier=False
                     )
 
-                if save_retain_interval is not None:
+                if keep_most_recent:
+                    for iteration_to_delete in _get_checkpoint_iterations_to_delete(
+                        save_dir, most_recent_k, save_retain_interval
+                    ):
+                        _schedule_checkpoint_deletion(args, save_dir, iteration_to_delete)
+                elif save_retain_interval is not None:
                     if (
                         prev_iteration > 0
                         and prev_iteration != iteration
                         and prev_iteration % save_retain_interval != 0
                     ):
-                        checkpoint_name = get_checkpoint_name(
-                            args.save, iteration=prev_iteration, return_base_dir=True
-                        )
-                        # Don't delete if `checkpoint_name` is a symbolic link.
-                        if os.path.islink(
-                            checkpoint_name
-                        ):  # TODO: Make this work with MSC remote paths?
-                            print_rank_0(
-                                f'  skipping deleting checkpoint from iteration {prev_iteration:7d} '
-                                f'at {args.save} since it is a symbolic link'
-                            )
-                        else:
-                            # Asynchronous version of delete_checkpoint(args, iteration_to_delete=prev_iteration).
-                            # Use multiprocessing to delete checkpoint in background
-                            if args.async_save:
-                                # Clean up any finished deletion processes before starting a new one
-                                finalize_deletion_processes(blocking=False)
-                                ctx = multiprocessing.get_context('fork')
-                                delete_process = ctx.Process(
-                                    target=_async_delete_checkpoint_impl,
-                                    args=(
-                                        args.save,
-                                        prev_iteration,
-                                        args.log_progress,
-                                        True,
-                                        args.async_ckpt_cpu_priority,
-                                        args.async_ckpt_io_priority,
-                                    ),
-                                    daemon=True,
-                                )
-                                delete_process.start()
-                                # Track the process so we can join it later to prevent zombies
-                                _deletion_processes.append(delete_process)
-                            else:
-                                th = threading.Thread(
-                                    target=_async_delete_checkpoint_impl,
-                                    args=(args.save, prev_iteration, args.log_progress),
-                                )
-                                th.start()
+                        _schedule_checkpoint_deletion(args, save_dir, prev_iteration)
 
         if args.async_save:
             assert async_save_request is not None
@@ -1239,6 +1208,67 @@ def _async_delete_checkpoint_impl(
         )
         # Any exception encountered in checkpoint deletion can be ignored and is not fatal.
         pass
+
+
+def _get_checkpoint_iterations_to_delete(
+    save_path, most_recent_k, save_retain_interval=None
+):
+    """Return checkpoint iterations older than the retention window."""
+    checkpoint_iterations = []
+    for checkpoint_path in Path(save_path).glob('iter_*'):
+        match = re.fullmatch(r'iter_(\d+)', checkpoint_path.name)
+        if match is not None and checkpoint_path.is_dir():
+            checkpoint_iterations.append(int(match.group(1)))
+
+    checkpoint_iterations.sort()
+    iterations_to_delete = checkpoint_iterations[:-most_recent_k]
+    if save_retain_interval is not None:
+        iterations_to_delete = [
+            iteration
+            for iteration in iterations_to_delete
+            if iteration % save_retain_interval != 0
+        ]
+    return iterations_to_delete
+
+
+def _schedule_checkpoint_deletion(args, save_path, iteration_to_delete):
+    """Delete a checkpoint in the background after its replacement is durable."""
+    checkpoint_name = get_checkpoint_name(
+        save_path, iteration=iteration_to_delete, return_base_dir=True
+    )
+    # Don't delete if `checkpoint_name` is a symbolic link.
+    if os.path.islink(checkpoint_name):  # TODO: Make this work with MSC remote paths?
+        print_rank_0(
+            f'  skipping deleting checkpoint from iteration {iteration_to_delete:7d} '
+            f'at {save_path} since it is a symbolic link'
+        )
+        return
+
+    # Use multiprocessing for async saves so checkpoint finalization is not blocked by deletion.
+    if args.async_save:
+        # Clean up any finished deletion processes before starting a new one.
+        finalize_deletion_processes(blocking=False)
+        ctx = multiprocessing.get_context('fork')
+        delete_process = ctx.Process(
+            target=_async_delete_checkpoint_impl,
+            args=(
+                save_path,
+                iteration_to_delete,
+                args.log_progress,
+                True,
+                args.async_ckpt_cpu_priority,
+                args.async_ckpt_io_priority,
+            ),
+            daemon=True,
+        )
+        delete_process.start()
+        # Track the process so we can join it later to prevent zombies.
+        _deletion_processes.append(delete_process)
+    else:
+        threading.Thread(
+            target=_async_delete_checkpoint_impl,
+            args=(save_path, iteration_to_delete, args.log_progress),
+        ).start()
 
 
 def cleanup_old_non_persistent_checkpoint(save_dir, leave_ckpt_num=1, do_async=False):

--- a/megatron/training/config/training_config.py
+++ b/megatron/training/config/training_config.py
@@ -419,7 +419,9 @@ class CheckpointConfig:
     """
 
     most_recent_k: int | None = -1
-    """Number of latest checkpoint to be saved."""
+    """Maximum number of recent checkpoints to keep. Set to -1 or None to disable.
+    Checkpoints selected by ``save_retain_interval`` are retained in addition to this limit.
+    """
 
     save_optim: bool = True
     """Do not save current optimizer."""

--- a/tests/unit_tests/test_checkpointing.py
+++ b/tests/unit_tests/test_checkpointing.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 # Note: --ckpt-format torch_dist has tests in tests/unit_tests/dist_checkpointing.
 import os
+import time
 from types import SimpleNamespace
 from typing import Optional
 from unittest import mock
@@ -22,6 +23,7 @@ from megatron.core.utils import is_torch_min_version
 from megatron.training.checkpointing import (
     CheckpointType,
     _build_sharded_state_dict_metadata,
+    _get_checkpoint_iterations_to_delete,
     _load_base_checkpoint,
     get_checkpoint_tracker_filename,
     load_checkpoint,
@@ -326,6 +328,88 @@ def test_save_checkpoint(init_model_parallel, create_args, tmp_path_dist_ckpt, c
             expected_ckpt_path = ckpt_dir / ".metadata"
 
         assert os.path.exists(expected_ckpt_path)
+
+
+def test_save_checkpoint_keeps_most_recent_k(init_model_parallel, create_args, tmp_path_dist_ckpt):
+    """Checkpoint retention keeps only the requested number of recent saves."""
+    args = create_args
+    args.ckpt_format = "torch"
+    args.use_distributed_optimizer = True
+    args.use_dist_ckpt = False
+    args.save_retain_interval = None
+    args.most_recent_k = 2
+
+    config = TransformerConfig(num_layers=1, kv_channels=1)
+    model = MockModel(config)
+    optimizer = MockState({"optimizer": "optimizer_state"})
+    opt_param_scheduler = MockState({"opt_param_scheduler": "scheduler_state"})
+
+    with TempNamedDir(
+        tmp_path_dist_ckpt / "test_save_checkpoint_keeps_most_recent_k", sync=True
+    ) as save_dir:
+        args.save = save_dir
+        set_args(args)
+
+        for iteration in range(1, 4):
+            save_checkpoint(iteration, [model], optimizer, opt_param_scheduler, 0)
+
+        def saved_iterations():
+            return sorted(int(path.name.removeprefix("iter_")) for path in save_dir.glob("iter_*"))
+
+        deadline = time.monotonic() + 5
+        while saved_iterations() != [2, 3] and time.monotonic() < deadline:
+            time.sleep(0.05)
+
+        assert saved_iterations() == [2, 3]
+
+
+def test_most_recent_k_uses_effective_save_directory(
+    init_model_parallel, create_args, tmp_path_dist_ckpt
+):
+    """Retention never schedules deletion outside the directory used for the current save."""
+    args = create_args
+    args.ckpt_format = "torch_dcp"
+    args.use_distributed_optimizer = False
+    args.use_dist_ckpt = True
+    args.save_retain_interval = None
+    args.most_recent_k = 2
+    args.non_persistent_ckpt_type = "global"
+
+    config = TransformerConfig(num_layers=1, kv_channels=1)
+    model = MockModel(config)
+    optimizer = MockState({"optimizer": "optimizer_state"})
+    opt_param_scheduler = MockState({"opt_param_scheduler": "scheduler_state"})
+
+    with TempNamedDir(
+        tmp_path_dist_ckpt / "test_most_recent_k_uses_effective_save_directory", sync=True
+    ) as root_dir:
+        args.save = root_dir / "persistent"
+        args.save.mkdir(exist_ok=True)
+        for iteration in range(1, 4):
+            (args.save / f"iter_{iteration:07d}").mkdir(exist_ok=True)
+        args.non_persistent_global_ckpt_dir = root_dir / "non_persistent"
+        set_args(args)
+
+        with mock.patch("megatron.training.checkpointing._schedule_checkpoint_deletion") as delete:
+            save_checkpoint(4, [model], optimizer, opt_param_scheduler, 0, non_persistent_ckpt=True)
+
+        delete.assert_not_called()
+        assert sorted(path.name for path in args.save.glob("iter_*")) == [
+            "iter_0000001",
+            "iter_0000002",
+            "iter_0000003",
+        ]
+
+
+def test_most_recent_k_preserves_periodic_checkpoints(tmp_path):
+    """Periodic retention checkpoints do not count toward the recent-checkpoint limit."""
+    for iteration in range(1, 6):
+        (tmp_path / f"iter_{iteration:07d}").mkdir()
+    (tmp_path / "iter_invalid").mkdir()
+
+    assert _get_checkpoint_iterations_to_delete(
+        tmp_path, most_recent_k=2, save_retain_interval=2
+    ) == [1, 3]
 
 
 @pytest.mark.parametrize("ckpt_format", ["torch"])


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Adds a configurable checkpoint retention limit that keeps the K most recent checkpoints while preserving checkpoints selected by `--save-retain-interval`.

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

The existing `CheckpointConfig.most_recent_k` setting is now exposed through the training CLI and applied after a checkpoint and its tracker are durable. Retention scans the effective save directory, so non-persistent checkpoint saves cannot schedule deletion from the persistent checkpoint directory.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: Fixes #1354

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [x] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Validation

- `CHECK_ONLY=true BASE_REF=main bash tools/autoformat.sh`
- `pytest -q tests/unit_tests/test_checkpointing.py`: 20 passed
- Two-rank targeted checkpoint retention tests under `torchrun`: 3 passed per rank
- One- and two-GPU `pretrain_gpt.py` checkpoint/resume runs on RTX 3090 GPUs, saving every iteration with `--most-recent-k 2`; both finished with only iterations 5 and 6 retained
- Final single-GPU model, optimizer, scheduler, RNG, iteration, and FLOP checkpoint state matched the unlimited-retention baseline exactly
- Final two-GPU model, optimizer, scheduler, iteration, and FLOP checkpoint state matched the unlimited-retention baseline exactly; validation and test losses also matched

### AI assistance disclosure

OpenAI Codex assisted with implementation and test drafting. I personally reviewed every line of the final diff and validated it with the commands and GPU runs listed above.

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
