### PR TITLE
fix(mlite): avoid loss hook reference cycle

### DIFF
--- a/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
+++ b/experimental/lite/examples/verl/verl_mlite/engine/mlite_engine.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import math
 import os
+import weakref
 from enum import Enum
 from typing import Any
 
@@ -891,6 +892,8 @@ class MegatronLiteEngine(BaseEngine):
         return output
 
     def _make_runtime_loss_fn(self, loss_function, num_microbatches: int, output_lst=None):
+        loss_fn_ref = None
+
         def _loss_fn(
             raw_output: dict[str, torch.Tensor],
             runtime_batch: PackedBatch,
@@ -919,7 +922,10 @@ class MegatronLiteEngine(BaseEngine):
                 )
 
             raw_output["_verl_metrics"] = metrics
-            if output_lst is not None:
+            assert loss_fn_ref is not None
+            if output_lst is not None and not getattr(
+                loss_fn_ref(), "runtime_collects_outputs", False
+            ):
                 output_lst.append(
                     {
                         "model_output": model_output,
@@ -929,6 +935,14 @@ class MegatronLiteEngine(BaseEngine):
                 )
             return (loss * num_microbatches if loss_function is not None else loss), metrics
 
+        # Avoid a strong self-reference while preserving the runtime hook attributes.
+        loss_fn_ref = weakref.ref(_loss_fn)
+        _loss_fn.runtime_output_collector = output_lst
+        _loss_fn.runtime_output_extractor = lambda output: output["_verl_model_output"]
+        # The static collector records ``loss`` before this hook applies the
+        # microbatch multiplier used for backward.  Runtime sidecars must report
+        # that same application-level value even when they reschedule batches.
+        _loss_fn.runtime_output_loss_scale = 1 / num_microbatches
         return _loss_fn
 
     def _mtp_enable_train(self) -> bool:

--- a/experimental/lite/tests/unit/examples/test_verl_mlite_engine_config.py
+++ b/experimental/lite/tests/unit/examples/test_verl_mlite_engine_config.py
@@ -86,6 +86,25 @@ def test_verl_loss_hook_preserves_gradient_and_micro_outputs(num_microbatches):
     assert [output["loss"] for output in outputs] == [3.0 / num_microbatches] * num_microbatches
 
 
+def test_verl_loss_hook_has_no_strong_self_reference():
+    engine = _engine(engine_config=_engine_config())
+    hook = engine._make_runtime_loss_fn(None, num_microbatches=1)
+
+    assert all(cell.cell_contents is not hook for cell in (hook.__closure__ or ()))
+
+
+def test_verl_loss_hook_honors_runtime_output_collector():
+    engine = _engine(engine_config=_engine_config())
+    outputs = []
+    engine._build_verl_model_output = lambda **_kwargs: {"log_probs": torch.tensor(1.0)}
+    hook = engine._make_runtime_loss_fn(None, num_microbatches=1, output_lst=outputs)
+
+    hook.runtime_collects_outputs = True
+    hook({}, object(), LossContext(source_batch=object()))
+
+    assert outputs == []
+
+
 def test_optimizer_offload_enables_full_optimizer_state_offload_by_default() -> None:
     engine = _engine(
         engine_config=_engine_config(optimizer_offload=True),


### PR DESCRIPTION
## Summary

- Avoid a strong self-reference in the MLite VERL runtime loss hook by retaining only a weak reference.
- Preserve the runtime output collector/extractor protocol used by runtime sidecars.
- Add regression coverage for closure ownership and runtime-managed output collection.

This ports the fix previously reviewed in verl-project/Megatron-LM#24 onto the current NVIDIA `dev` implementation. The conflict in `mlite_engine.py` was resolved semantically against the newer NVIDIA code; this PR contains only two files under `experimental/lite/**`.

## Validation

- `python -m py_compile` for the implementation and test: passed
- `git diff --check`: passed
- Optional VERL loss-hook tests: collected successfully; 4 skipped because VERL is not installed in the local NVIDIA environment

## Formatting note

The pinned isort/black hook chain is not idempotent for the pre-existing `mlite_engine.py` import and line layout. Formatter-only churn was excluded from this PR.
