### PR TITLE
Do not message oncall in default PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@
 # What does this PR do?
 <!-- Add a one line overview of what this PR aims to accomplish. -->
 
-:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.
+:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact `@NVIDIA/mcore-oncall`.
 
 ## Issue tracking
 
@@ -26,7 +26,7 @@ Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->
 
 ### Code review
 
-Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!
+Feel free to message or comment `@NVIDIA/mcore-oncall` to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!
 
 All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.
 


### PR DESCRIPTION
This causes a lot of noise, since people often just leave the default template as-is, tagging oncall when it's not actually necessary.

- [X] I, the PR author, have personally reviewed every line of this PR.