### PR TITLE
Add fused mHC support for HybridModel

### DIFF
--- a/megatron/core/fusions/fused_mhc_kernels.py
+++ b/megatron/core/fusions/fused_mhc_kernels.py
@@ -12,6 +12,11 @@ Four fused operations:
   - h_aggregate:         weighted n-stream -> 1-stream aggregation
   - h_post_bda:          fused H_res.T @ residual + H_post * (x + bias)
   - proj_rms_compute_h:  fused projection + RMS normalization + compute_h
+
+Determinism:
+  The native, Triton, and cuTile backends are currently tagged ``unknown``.
+  Numerical and gradient parity are covered, but bit-exact repeatability has
+  not been certified. The accelerated backends use timing-based autotuning.
 """
 
 import logging
@@ -29,6 +34,16 @@ from megatron.core._rank_utils import log_single_rank, safe_get_rank
 
 logger = logging.getLogger(__name__)
 LOG2E = math.log2(math.e)
+
+#: Bit-exact determinism status for each concrete mHC backend. This uses the
+#: same three-value vocabulary proposed for operation-backend metadata while
+#: the ops registry is not available on this PR's base. ``auto`` is a
+#: per-operation selection policy, not a backend of its own.
+MHC_BACKEND_DETERMINISM: dict[str, str] = {
+    "native": "unknown",
+    "triton": "unknown",
+    "cutile": "unknown",
+}
 
 
 def _env_flag(name: str) -> bool:

--- a/megatron/core/fusions/fused_mhc_kernels.py
+++ b/megatron/core/fusions/fused_mhc_kernels.py
@@ -2,10 +2,11 @@
 
 """Fused kernels for mHC (Manifold-Constrained Hyper-Connections).
 
-Uses Triton and cuda.tile (cuTile) kernels when available, with PyTorch
-reference implementations as fallback.  Reference (non-fused) implementations
-live in ``megatron.core.transformer.hyper_connection`` and are used when fused
-kernels are unavailable or when the ``use_fused_mhc`` config flag is False.
+Uses Triton and cuda.tile (cuTile) kernels according to an explicit backend
+policy. With the default ``auto`` policy, unavailable accelerated operations
+fall back to PyTorch reference implementations. Reference implementations live
+in ``megatron.core.transformer.hyper_connection`` and are also used when the
+``use_fused_mhc`` config flag is False.
 
 Four fused operations:
   - sinkhorn:            Sinkhorn-Knopp projection to doubly stochastic matrix
@@ -25,7 +26,7 @@ import os
 import shutil
 import subprocess
 import warnings
-from typing import Optional, Tuple
+from typing import Literal, Optional, Tuple
 
 import torch
 from torch import Tensor
@@ -37,7 +38,7 @@ LOG2E = math.log2(math.e)
 
 #: Bit-exact determinism status for each concrete mHC backend. This uses the
 #: same three-value vocabulary proposed for operation-backend metadata while
-#: the ops registry is not available on this PR's base. ``auto`` is a
+#: the ops registry is unavailable. ``auto`` is a
 #: per-operation selection policy, not a backend of its own.
 MHC_BACKEND_DETERMINISM: dict[str, str] = {
     "native": "unknown",
@@ -45,34 +46,8 @@ MHC_BACKEND_DETERMINISM: dict[str, str] = {
     "cutile": "unknown",
 }
 
-
-def _env_flag(name: str) -> bool:
-    return os.getenv(name, "0").lower() in ("1", "true", "yes", "on")
-
-
-def _forced_backend() -> Tuple[str, Optional[Exception]]:
-    value = os.getenv("MHC_FORCE_BACKEND", "auto").strip().lower()
-    value = value.replace("-", "_").replace("+", "_")
-    aliases = {
-        "auto": "auto",
-        "mixed": "auto",
-        "default": "auto",
-        "native": "native",
-        "torch": "native",
-        "pytorch": "native",
-        "none": "native",
-        "triton": "triton",
-        "triton_native": "triton",
-        "cutile": "cutile",
-        "cu_tile": "cutile",
-        "cuda_tile": "cutile",
-    }
-    if value not in aliases:
-        valid = ", ".join(sorted(aliases))
-        return "auto", ValueError(
-            f"Unsupported MHC_FORCE_BACKEND={value!r}; expected one of: {valid}"
-        )
-    return aliases[value], None
+MHCBackend = Literal["auto", "native", "triton", "cutile"]
+_VALID_MHC_BACKENDS = ("auto", "native", "triton", "cutile")
 
 
 # ---------------------------------------------------------------------------
@@ -107,59 +82,6 @@ try:
     _TRITON_AVAILABLE = True
 except ImportError:
     pass
-
-
-_MHC_FORCED_BACKEND, _MHC_BACKEND_VALIDATION_ERROR = _forced_backend()
-
-
-def _record_mhc_backend_validation_error(error: Exception) -> None:
-    global _MHC_BACKEND_VALIDATION_ERROR
-    if _MHC_BACKEND_VALIDATION_ERROR is None:
-        _MHC_BACKEND_VALIDATION_ERROR = error
-
-
-def _raise_mhc_backend_validation_error() -> None:
-    if _MHC_BACKEND_VALIDATION_ERROR is not None:
-        raise _MHC_BACKEND_VALIDATION_ERROR
-    if _MHC_FORCED_BACKEND == "cutile" and not is_cutile_available():
-        raise RuntimeError(
-            "MHC_FORCE_BACKEND=cutile was requested, but cuTile does not support "
-            f"the current device: {_CUTILE_DEVICE_SUPPORT_ERROR}"
-        )
-
-
-if _MHC_FORCED_BACKEND == "native":
-    _TRITON_AVAILABLE = False
-    _CUTILE_AVAILABLE = False
-    _CUTILE_EXPERIMENTAL_AVAILABLE = False
-elif _MHC_FORCED_BACKEND == "triton":
-    if not _TRITON_AVAILABLE:
-        _record_mhc_backend_validation_error(
-            RuntimeError("MHC_FORCE_BACKEND=triton was requested, but Triton is not available")
-        )
-    _CUTILE_AVAILABLE = False
-    _CUTILE_EXPERIMENTAL_AVAILABLE = False
-elif _MHC_FORCED_BACKEND == "cutile":
-    if not _CUTILE_AVAILABLE:
-        _record_mhc_backend_validation_error(
-            RuntimeError("MHC_FORCE_BACKEND=cutile was requested, but cuTile is not available")
-        )
-    _TRITON_AVAILABLE = False
-
-if _env_flag("MHC_DISABLE_TRITON"):
-    if _MHC_FORCED_BACKEND == "triton":
-        _record_mhc_backend_validation_error(
-            ValueError("MHC_FORCE_BACKEND=triton conflicts with MHC_DISABLE_TRITON=1")
-        )
-    _TRITON_AVAILABLE = False
-
-if _env_flag("MHC_DISABLE_CUTILE"):
-    if _MHC_FORCED_BACKEND == "cutile":
-        _record_mhc_backend_validation_error(
-            ValueError("MHC_FORCE_BACKEND=cutile conflicts with MHC_DISABLE_CUTILE=1")
-        )
-    _CUTILE_AVAILABLE = False
-    _CUTILE_EXPERIMENTAL_AVAILABLE = False
 
 
 def is_cutile_available() -> bool:
@@ -224,6 +146,30 @@ def _cutile_supports_current_device() -> bool:
 def is_triton_available() -> bool:
     """Return True if Triton is enabled for supported mHC kernels."""
     return _TRITON_AVAILABLE
+
+
+def _validate_mhc_backend(backend: MHCBackend) -> None:
+    """Validate an explicit mHC backend policy before dispatch."""
+    if backend not in _VALID_MHC_BACKENDS:
+        raise ValueError(
+            f"Unknown mHC fused backend {backend!r}; expected one of {_VALID_MHC_BACKENDS}."
+        )
+    if backend == "triton" and not is_triton_available():
+        raise RuntimeError("mHC fused backend 'triton' was requested, but Triton is unavailable.")
+    if backend == "cutile" and not is_cutile_available():
+        detail = _CUTILE_DEVICE_SUPPORT_ERROR or "cuTile is unavailable"
+        raise RuntimeError(
+            "mHC fused backend 'cutile' was requested, but cuTile does not support "
+            f"the current environment: {detail}."
+        )
+
+
+def _backend_uses_triton(backend: MHCBackend) -> bool:
+    return backend in ("auto", "triton") and is_triton_available()
+
+
+def _backend_uses_cutile(backend: MHCBackend) -> bool:
+    return backend in ("auto", "cutile") and is_cutile_available()
 
 
 # ============================================================================
@@ -2640,25 +2586,26 @@ from megatron.core.transformer.hyper_connection import (
     native_sinkhorn,
 )
 
-_BACKEND_INFO_LOGGED = False
+_BACKEND_INFO_LOGGED: set[str] = set()
 
 
-def _select_triton_cutile_native(triton_impl) -> str:
+def _select_triton_cutile_native(triton_impl, backend: MHCBackend) -> str:
     if triton_impl is not None:
         return "triton"
-    if is_cutile_available():
+    if _backend_uses_cutile(backend):
         return "cutile"
     return "native"
 
 
-def _mhc_backend_status() -> Tuple[str, bool]:
+def _mhc_backend_status(backend: MHCBackend = "auto") -> Tuple[str, bool]:
     """Return backend description and whether every backend is native."""
-    sinkhorn = _select_triton_cutile_native(_get_triton_sinkhorn())
-    h_aggregate_fwd = _select_triton_cutile_native(_get_triton_h_aggregate_fwd())
-    h_aggregate_bwd = "cutile" if is_cutile_available() else "native"
-    h_post_bda_fwd = _select_triton_cutile_native(_get_triton_h_post_bda_fwd())
-    h_post_bda_bwd = _select_triton_cutile_native(_get_triton_h_post_bda_bwd())
-    proj_rms_compute_h = "cutile" if is_cutile_available() else "native"
+    _validate_mhc_backend(backend)
+    sinkhorn = _select_triton_cutile_native(_get_triton_sinkhorn(backend), backend)
+    h_aggregate_fwd = _select_triton_cutile_native(_get_triton_h_aggregate_fwd(backend), backend)
+    h_aggregate_bwd = "cutile" if _backend_uses_cutile(backend) else "native"
+    h_post_bda_fwd = _select_triton_cutile_native(_get_triton_h_post_bda_fwd(backend), backend)
+    h_post_bda_bwd = _select_triton_cutile_native(_get_triton_h_post_bda_bwd(backend), backend)
+    proj_rms_compute_h = "cutile" if _backend_uses_cutile(backend) else "native"
     selected = (
         sinkhorn,
         h_aggregate_fwd,
@@ -2668,7 +2615,7 @@ def _mhc_backend_status() -> Tuple[str, bool]:
         proj_rms_compute_h,
     )
     message = (
-        f"MHC_FORCE_BACKEND={_MHC_FORCED_BACKEND}; "
+        f"policy={backend}; "
         f"sinkhorn={sinkhorn}; "
         f"h_aggregate=fwd:{h_aggregate_fwd},bwd:{h_aggregate_bwd}; "
         f"h_post_bda=fwd:{h_post_bda_fwd},bwd:{h_post_bda_bwd}; "
@@ -2677,26 +2624,24 @@ def _mhc_backend_status() -> Tuple[str, bool]:
     return message, all(backend == "native" for backend in selected)
 
 
-def _mhc_backend_selection() -> str:
+def _mhc_backend_selection(backend: MHCBackend = "auto") -> str:
     """Return a concise description of the selected mHC fused backends."""
-    message, _ = _mhc_backend_status()
+    message, _ = _mhc_backend_status(backend)
     return message
 
 
-def log_fused_mhc_backend_once() -> None:
-    """Log the fused mHC backend selection once per process."""
-    _raise_mhc_backend_validation_error()
-    global _BACKEND_INFO_LOGGED
-    if _BACKEND_INFO_LOGGED:
+def log_fused_mhc_backend_once(backend: MHCBackend = "auto") -> None:
+    """Log each configured fused mHC backend policy once per process."""
+    if backend in _BACKEND_INFO_LOGGED:
         return
-    _BACKEND_INFO_LOGGED = True
-    backend_selection, all_native = _mhc_backend_status()
+    backend_selection, all_native = _mhc_backend_status(backend)
+    _BACKEND_INFO_LOGGED.add(backend)
     log_single_rank(
         logger,
-        logging.WARNING if all_native else logging.INFO,
+        logging.WARNING if all_native and backend == "auto" else logging.INFO,
         f"[mHC] fused backend selection: {backend_selection}",
     )
-    if all_native and safe_get_rank() == 0:
+    if all_native and backend == "auto" and safe_get_rank() == 0:
         warnings.warn(
             "[mHC] No accelerated mHC backend is available; falling back to native torch "
             "implementations. The fallback is functionally equivalent, but may not provide "
@@ -2711,26 +2656,26 @@ def fused_add_3(a: Tensor, b: Tensor, c: Tensor) -> Tensor:
     return native_fused_add_3(a, b, c)
 
 
-def _get_triton_sinkhorn():
-    if not _TRITON_AVAILABLE:
+def _get_triton_sinkhorn(backend: MHCBackend = "auto"):
+    if not _backend_uses_triton(backend):
         return None
     return _TRITON_IMPLS["sinkhorn"]
 
 
-def _get_triton_h_aggregate_fwd():
-    if not _TRITON_AVAILABLE:
+def _get_triton_h_aggregate_fwd(backend: MHCBackend = "auto"):
+    if not _backend_uses_triton(backend):
         return None
     return _TRITON_IMPLS["h_aggregate_fwd"]
 
 
-def _get_triton_h_post_bda_fwd():
-    if not _TRITON_AVAILABLE:
+def _get_triton_h_post_bda_fwd(backend: MHCBackend = "auto"):
+    if not _backend_uses_triton(backend):
         return None
     return _TRITON_IMPLS["h_post_bda_fwd"]
 
 
-def _get_triton_h_post_bda_bwd():
-    if not _TRITON_AVAILABLE:
+def _get_triton_h_post_bda_bwd(backend: MHCBackend = "auto"):
+    if not _backend_uses_triton(backend):
         return None
     return _TRITON_IMPLS["h_post_bda_bwd"]
 
@@ -2923,32 +2868,35 @@ if _CUTILE_AVAILABLE:
 
 
 class FusedHAggregate(torch.autograd.Function):
-    """H_aggregate with Triton/cuTile/torch forward and cuTile/torch backward."""
+    """H_aggregate dispatched according to the configured backend policy."""
 
     @staticmethod
-    def forward(ctx, x: Tensor, h_pre: Tensor):
+    def forward(ctx, x: Tensor, h_pre: Tensor, backend: MHCBackend):
         """Run h_aggregate forward using the best available backend."""
-        triton_fwd = _get_triton_h_aggregate_fwd()
+        triton_fwd = _get_triton_h_aggregate_fwd(backend)
         if triton_fwd is not None:
             output = triton_fwd(x, h_pre)
-        elif is_cutile_available():
+        elif _backend_uses_cutile(backend):
             output = _cutile_h_aggregate_fwd(x, h_pre)
         else:
             output = native_h_aggregate(x, h_pre)
         ctx.save_for_backward(x, h_pre)
+        ctx.backend = backend
         return output
 
     @staticmethod
     def backward(ctx, grad_output):
         """Run h_aggregate backward using the best available backend."""
         x, h_pre = ctx.saved_tensors
-        if is_cutile_available():
-            return _cutile_h_aggregate_bwd(grad_output, x, h_pre)
-        return _torch_h_aggregate_bwd(grad_output, x, h_pre)
+        if _backend_uses_cutile(ctx.backend):
+            grad_x, grad_h_pre = _cutile_h_aggregate_bwd(grad_output, x, h_pre)
+        else:
+            grad_x, grad_h_pre = _torch_h_aggregate_bwd(grad_output, x, h_pre)
+        return grad_x, grad_h_pre, None
 
 
 class FusedHPostBDA(torch.autograd.Function):
-    """H_post_bda with Triton/cuTile/torch forward and backward."""
+    """H_post_bda dispatched according to the configured backend policy."""
 
     @staticmethod
     def forward(
@@ -2958,12 +2906,13 @@ class FusedHPostBDA(torch.autograd.Function):
         h_post: Tensor,
         x: Tensor,
         bias: Optional[Tensor],
+        backend: MHCBackend,
     ):
         """Run h_post_bda forward using the best available backend."""
-        triton_fwd = _get_triton_h_post_bda_fwd()
+        triton_fwd = _get_triton_h_post_bda_fwd(backend)
         if triton_fwd is not None:
             output = triton_fwd(h_res, original_residual, h_post, x, bias)
-        elif is_cutile_available():
+        elif _backend_uses_cutile(backend):
             output = _cutile_h_post_bda_fwd(h_res, original_residual, h_post, x, bias)
         else:
             output = native_h_post_bda(h_res, original_residual, h_post, x, bias)
@@ -2973,6 +2922,7 @@ class FusedHPostBDA(torch.autograd.Function):
         else:
             ctx.save_for_backward(h_res, original_residual, h_post, x)
             ctx.has_bias = False
+        ctx.backend = backend
         return output
 
     @staticmethod
@@ -2984,40 +2934,50 @@ class FusedHPostBDA(torch.autograd.Function):
             h_res, orig_res, h_post, x = ctx.saved_tensors
             bias = None
 
-        triton_bwd = _get_triton_h_post_bda_bwd()
+        triton_bwd = _get_triton_h_post_bda_bwd(ctx.backend)
         if triton_bwd is not None:
-            return triton_bwd(grad_output, h_res, orig_res, h_post, x, bias)
-        if is_cutile_available():
-            return _cutile_h_post_bda_bwd(grad_output, h_res, orig_res, h_post, x, bias)
-        return _torch_h_post_bda_bwd(grad_output, h_res, orig_res, h_post, x, bias)
+            grads = triton_bwd(grad_output, h_res, orig_res, h_post, x, bias)
+        elif _backend_uses_cutile(ctx.backend):
+            grads = _cutile_h_post_bda_bwd(grad_output, h_res, orig_res, h_post, x, bias)
+        else:
+            grads = _torch_h_post_bda_bwd(grad_output, h_res, orig_res, h_post, x, bias)
+        return (*grads, None)
 
 
-def fused_sinkhorn(input_logits: Tensor, num_iterations: int, eps: float = 1e-6) -> Tensor:
-    """Project logits to a doubly stochastic matrix using Triton, cuTile, then torch."""
-    _raise_mhc_backend_validation_error()
-    triton_sinkhorn = _get_triton_sinkhorn()
+def fused_sinkhorn(
+    input_logits: Tensor, num_iterations: int, eps: float = 1e-6, *, backend: MHCBackend = "auto"
+) -> Tensor:
+    """Project logits according to the configured backend policy."""
+    _validate_mhc_backend(backend)
+    triton_sinkhorn = _get_triton_sinkhorn(backend)
     if triton_sinkhorn is not None:
         return triton_sinkhorn(input_logits, num_iterations, eps)
-    if is_cutile_available():
+    if _backend_uses_cutile(backend):
         return CutileSinkhornKnopp.apply(input_logits, num_iterations, eps)
     return native_sinkhorn(input_logits, num_iterations, eps)
 
 
-def fused_h_aggregate(x: Tensor, h_pre: Tensor) -> Tensor:
-    """Weighted n-stream to 1-stream aggregation using Triton/cuTile/torch."""
-    _raise_mhc_backend_validation_error()
-    if _TRITON_AVAILABLE or is_cutile_available():
-        return FusedHAggregate.apply(x, h_pre)
+def fused_h_aggregate(x: Tensor, h_pre: Tensor, *, backend: MHCBackend = "auto") -> Tensor:
+    """Aggregate n streams into one according to the configured backend policy."""
+    _validate_mhc_backend(backend)
+    if _backend_uses_triton(backend) or _backend_uses_cutile(backend):
+        return FusedHAggregate.apply(x, h_pre, backend)
     return native_h_aggregate(x, h_pre)
 
 
 def fused_h_post_bda(
-    h_res: Tensor, original_residual: Tensor, h_post: Tensor, x: Tensor, bias: Optional[Tensor]
+    h_res: Tensor,
+    original_residual: Tensor,
+    h_post: Tensor,
+    x: Tensor,
+    bias: Optional[Tensor],
+    *,
+    backend: MHCBackend = "auto",
 ) -> Tensor:
-    """Fused H_res.T @ residual + H_post * (x + bias)."""
-    _raise_mhc_backend_validation_error()
-    if _TRITON_AVAILABLE or is_cutile_available():
-        return FusedHPostBDA.apply(h_res, original_residual, h_post, x, bias)
+    """Compute H_res.T @ residual + H_post * (x + bias) using the backend policy."""
+    _validate_mhc_backend(backend)
+    if _backend_uses_triton(backend) or _backend_uses_cutile(backend):
+        return FusedHPostBDA.apply(h_res, original_residual, h_post, x, bias, backend)
     return native_h_post_bda(h_res, original_residual, h_post, x, bias)
 
 
@@ -3031,10 +2991,12 @@ def fused_proj_rms_compute_h(
     n: int,
     eps: float = 1e-6,
     compute_h_eps: float = 1e-6,
+    *,
+    backend: MHCBackend = "auto",
 ) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
-    """Projection + RMS norm + compute_h split outputs using cuTile, then torch."""
-    _raise_mhc_backend_validation_error()
-    if is_cutile_available():
+    """Compute projection, RMS norm, and H outputs using the backend policy."""
+    _validate_mhc_backend(backend)
+    if _backend_uses_cutile(backend):
         return CutileProjRmsComputeH.apply(
             x, weight, alpha_pre, alpha_post, alpha_res, bias, n, eps, compute_h_eps
         )

--- a/megatron/core/fusions/fused_mhc_kernels.py
+++ b/megatron/core/fusions/fused_mhc_kernels.py
@@ -1,0 +1,3028 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Fused kernels for mHC (Manifold-Constrained Hyper-Connections).
+
+Uses Triton and cuda.tile (cuTile) kernels when available, with PyTorch
+reference implementations as fallback.  Reference (non-fused) implementations
+live in ``megatron.core.transformer.hyper_connection`` and are used when fused
+kernels are unavailable or when the ``use_fused_mhc`` config flag is False.
+
+Four fused operations:
+  - sinkhorn:            Sinkhorn-Knopp projection to doubly stochastic matrix
+  - h_aggregate:         weighted n-stream -> 1-stream aggregation
+  - h_post_bda:          fused H_res.T @ residual + H_post * (x + bias)
+  - proj_rms_compute_h:  fused projection + RMS normalization + compute_h
+"""
+
+import logging
+import math
+import os
+import shutil
+import subprocess
+import warnings
+from typing import Optional, Tuple
+
+import torch
+from torch import Tensor
+
+from megatron.core._rank_utils import log_single_rank, safe_get_rank
+
+logger = logging.getLogger(__name__)
+LOG2E = math.log2(math.e)
+
+
+def _env_flag(name: str) -> bool:
+    return os.getenv(name, "0").lower() in ("1", "true", "yes", "on")
+
+
+def _forced_backend() -> Tuple[str, Optional[Exception]]:
+    value = os.getenv("MHC_FORCE_BACKEND", "auto").strip().lower()
+    value = value.replace("-", "_").replace("+", "_")
+    aliases = {
+        "auto": "auto",
+        "mixed": "auto",
+        "default": "auto",
+        "native": "native",
+        "torch": "native",
+        "pytorch": "native",
+        "none": "native",
+        "triton": "triton",
+        "triton_native": "triton",
+        "cutile": "cutile",
+        "cu_tile": "cutile",
+        "cuda_tile": "cutile",
+    }
+    if value not in aliases:
+        valid = ", ".join(sorted(aliases))
+        return "auto", ValueError(
+            f"Unsupported MHC_FORCE_BACKEND={value!r}; expected one of: {valid}"
+        )
+    return aliases[value], None
+
+
+# ---------------------------------------------------------------------------
+# Check cuTile availability
+# ---------------------------------------------------------------------------
+_CUTILE_AVAILABLE = False
+_CUTILE_EXPERIMENTAL_AVAILABLE = False
+_CUTILE_DEVICE_SUPPORT_CACHE: Optional[bool] = None
+_CUTILE_DEVICE_SUPPORT_ERROR: Optional[str] = None
+try:
+    import cuda.tile as ct
+
+    _CUTILE_AVAILABLE = True
+    try:
+        import cuda.tile_experimental as ct_experimental
+
+        _CUTILE_EXPERIMENTAL_AVAILABLE = True
+    except ImportError:
+        pass
+except ImportError:
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Check Triton availability
+# ---------------------------------------------------------------------------
+_TRITON_AVAILABLE = False
+try:
+    import triton
+    import triton.language as tl
+
+    _TRITON_AVAILABLE = True
+except ImportError:
+    pass
+
+
+_MHC_FORCED_BACKEND, _MHC_BACKEND_VALIDATION_ERROR = _forced_backend()
+
+
+def _record_mhc_backend_validation_error(error: Exception) -> None:
+    global _MHC_BACKEND_VALIDATION_ERROR
+    if _MHC_BACKEND_VALIDATION_ERROR is None:
+        _MHC_BACKEND_VALIDATION_ERROR = error
+
+
+def _raise_mhc_backend_validation_error() -> None:
+    if _MHC_BACKEND_VALIDATION_ERROR is not None:
+        raise _MHC_BACKEND_VALIDATION_ERROR
+    if _MHC_FORCED_BACKEND == "cutile" and not is_cutile_available():
+        raise RuntimeError(
+            "MHC_FORCE_BACKEND=cutile was requested, but cuTile does not support "
+            f"the current device: {_CUTILE_DEVICE_SUPPORT_ERROR}"
+        )
+
+
+if _MHC_FORCED_BACKEND == "native":
+    _TRITON_AVAILABLE = False
+    _CUTILE_AVAILABLE = False
+    _CUTILE_EXPERIMENTAL_AVAILABLE = False
+elif _MHC_FORCED_BACKEND == "triton":
+    if not _TRITON_AVAILABLE:
+        _record_mhc_backend_validation_error(
+            RuntimeError("MHC_FORCE_BACKEND=triton was requested, but Triton is not available")
+        )
+    _CUTILE_AVAILABLE = False
+    _CUTILE_EXPERIMENTAL_AVAILABLE = False
+elif _MHC_FORCED_BACKEND == "cutile":
+    if not _CUTILE_AVAILABLE:
+        _record_mhc_backend_validation_error(
+            RuntimeError("MHC_FORCE_BACKEND=cutile was requested, but cuTile is not available")
+        )
+    _TRITON_AVAILABLE = False
+
+if _env_flag("MHC_DISABLE_TRITON"):
+    if _MHC_FORCED_BACKEND == "triton":
+        _record_mhc_backend_validation_error(
+            ValueError("MHC_FORCE_BACKEND=triton conflicts with MHC_DISABLE_TRITON=1")
+        )
+    _TRITON_AVAILABLE = False
+
+if _env_flag("MHC_DISABLE_CUTILE"):
+    if _MHC_FORCED_BACKEND == "cutile":
+        _record_mhc_backend_validation_error(
+            ValueError("MHC_FORCE_BACKEND=cutile conflicts with MHC_DISABLE_CUTILE=1")
+        )
+    _CUTILE_AVAILABLE = False
+    _CUTILE_EXPERIMENTAL_AVAILABLE = False
+
+
+def is_cutile_available() -> bool:
+    """Return True if cuTile fused kernels are enabled."""
+    return _CUTILE_AVAILABLE and _cutile_supports_current_device()
+
+
+def _get_tileiras_path() -> Optional[str]:
+    """Return the tileiras compiler path if it can be found."""
+    tileiras = shutil.which("tileiras")
+    if tileiras is not None:
+        return tileiras
+
+    cuda_home = os.getenv("CUDA_HOME") or os.getenv("CUDA_PATH") or "/usr/local/cuda"
+    candidate = os.path.join(cuda_home, "bin", "tileiras")
+    if os.path.exists(candidate):
+        return candidate
+    return None
+
+
+def _cutile_supports_current_device() -> bool:
+    """Return whether cuTile can compile for the current CUDA device."""
+    global _CUTILE_DEVICE_SUPPORT_CACHE, _CUTILE_DEVICE_SUPPORT_ERROR
+
+    if not _CUTILE_AVAILABLE:
+        return False
+    if _CUTILE_DEVICE_SUPPORT_CACHE is not None:
+        return _CUTILE_DEVICE_SUPPORT_CACHE
+
+    if not torch.cuda.is_available():
+        _CUTILE_DEVICE_SUPPORT_ERROR = "CUDA is not available"
+        _CUTILE_DEVICE_SUPPORT_CACHE = False
+        return False
+
+    major, minor = torch.cuda.get_device_capability()
+    arch = f"sm_{major}{minor}"
+    tileiras = _get_tileiras_path()
+    if tileiras is None:
+        _CUTILE_DEVICE_SUPPORT_ERROR = "tileiras compiler was not found"
+        _CUTILE_DEVICE_SUPPORT_CACHE = False
+        return False
+
+    try:
+        result = subprocess.run(
+            [tileiras, "--gpu-name", arch], capture_output=True, check=False, text=True, timeout=10
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        _CUTILE_DEVICE_SUPPORT_ERROR = str(exc)
+        _CUTILE_DEVICE_SUPPORT_CACHE = False
+        return False
+
+    output = f"{result.stdout}\n{result.stderr}"
+    if "Cannot find option named" in output and arch in output:
+        _CUTILE_DEVICE_SUPPORT_ERROR = output.strip().splitlines()[0]
+        _CUTILE_DEVICE_SUPPORT_CACHE = False
+        return False
+
+    _CUTILE_DEVICE_SUPPORT_CACHE = True
+    return True
+
+
+def is_triton_available() -> bool:
+    """Return True if Triton is enabled for supported mHC kernels."""
+    return _TRITON_AVAILABLE
+
+
+# ============================================================================
+# Triton implementations (only defined when triton is available)
+# ============================================================================
+
+if _TRITON_AVAILABLE:
+    TLOG2E = tl.constexpr(LOG2E)
+
+    # ============================================================================
+    # Sinkhorn-Knopp
+    # ============================================================================
+
+    @triton.autotune(
+        configs=[triton.Config({}, num_warps=nw) for nw in (1, 2, 4, 8)], key=["HC", "NUM_ITERS"]
+    )
+    @triton.jit
+    def _triton_sinkhorn_fwd_kernel(
+        inp_ptr, out_ptr, M_init_ptr, N_batch, eps, HC: tl.constexpr, NUM_ITERS: tl.constexpr
+    ):
+        """Grid: (N_batch,). Each program handles one [HC, HC] matrix."""
+        pid = tl.program_id(0)
+        if pid >= N_batch:
+            return
+
+        base = pid * HC * HC
+        offs_r = tl.arange(0, HC)
+        offs_c = tl.arange(0, HC)
+        mat_ptrs = base + offs_r[:, None] * HC + offs_c[None, :]
+
+        logits = tl.load(inp_ptr + mat_ptrs).to(tl.float32)
+        row_max = tl.max(logits, axis=1)
+        # Subtract row_max before exp to keep the exponent numerically stable.
+        M = tl.exp2((logits - row_max[:, None]) * TLOG2E)
+        tl.store(M_init_ptr + mat_ptrs, M.to(M_init_ptr.dtype.element_ty))
+
+        row_sum = tl.sum(M, axis=1)
+        M = M / row_sum[:, None] + eps
+        col_sum = tl.sum(M, axis=0)
+        M = M / (col_sum[None, :] + eps)
+        for _ in range(NUM_ITERS - 1):
+            row_sum = tl.sum(M, axis=1)
+            M = M / (row_sum[:, None] + eps)
+            col_sum = tl.sum(M, axis=0)
+            M = M / (col_sum[None, :] + eps)
+
+        tl.store(out_ptr + mat_ptrs, M.to(out_ptr.dtype.element_ty))
+
+    @triton.autotune(
+        configs=[triton.Config({}, num_warps=nw) for nw in (1, 2, 4, 8)], key=["HC", "NUM_ITERS"]
+    )
+    @triton.jit
+    def _triton_sinkhorn_bwd_kernel(
+        grad_out_ptr,
+        M_init_ptr,
+        grad_inp_ptr,
+        ws_M_ptr,
+        ws_rs_ptr,
+        ws_cs_ptr,
+        N_batch,
+        eps,
+        HC: tl.constexpr,
+        NUM_ITERS: tl.constexpr,
+    ):
+        """Grid: (N_batch,). Each program handles one [HC, HC] backward."""
+        pid = tl.program_id(0)
+        if pid >= N_batch:
+            return
+
+        base = pid * HC * HC
+        M_ws_base = pid * 2 * NUM_ITERS * HC * HC
+        v_ws_base = pid * NUM_ITERS
+        offs_r = tl.arange(0, HC)
+        offs_c = tl.arange(0, HC)
+        mat_ptrs = base + offs_r[:, None] * HC + offs_c[None, :]
+
+        M = tl.load(M_init_ptr + mat_ptrs).to(tl.float32)
+        for t in range(NUM_ITERS):
+            ws_off = M_ws_base + (2 * t) * HC * HC
+            tl.store(ws_M_ptr + ws_off + offs_r[:, None] * HC + offs_c[None, :], M)
+
+            row_sum = tl.sum(M, axis=1)
+            tl.store(ws_rs_ptr + (v_ws_base + t) * HC + offs_r, row_sum)
+            if t == 0:
+                M = M / row_sum[:, None] + eps
+            else:
+                M = M / (row_sum[:, None] + eps)
+
+            ws_off = M_ws_base + (2 * t + 1) * HC * HC
+            tl.store(ws_M_ptr + ws_off + offs_r[:, None] * HC + offs_c[None, :], M)
+
+            col_sum = tl.sum(M, axis=0)
+            tl.store(ws_cs_ptr + (v_ws_base + t) * HC + offs_c, col_sum)
+            M = M / (col_sum[None, :] + eps)
+
+        # M is the final forward output. It is the right value for the first VJP
+        # through the last column-normalization step.
+        grad = tl.load(grad_out_ptr + mat_ptrs).to(tl.float32)
+        for t_rev in range(NUM_ITERS):
+            t = NUM_ITERS - 1 - t_rev
+
+            col_s = tl.load(ws_cs_ptr + (v_ws_base + t) * HC + offs_c).to(tl.float32)
+            grad = grad / (col_s[None, :] + eps)
+            col_corr = tl.sum(grad * M, axis=0)
+            grad = grad - col_corr[None, :]
+            M = tl.load(
+                ws_M_ptr
+                + M_ws_base
+                + (2 * t + 1) * HC * HC
+                + offs_r[:, None] * HC
+                + offs_c[None, :]
+            ).to(tl.float32)
+
+            row_s = tl.load(ws_rs_ptr + (v_ws_base + t) * HC + offs_r).to(tl.float32)
+            if t == 0:
+                grad = grad / row_s[:, None]
+                row_corr = tl.sum(grad * (M - eps), axis=1)
+            else:
+                grad = grad / (row_s[:, None] + eps)
+                row_corr = tl.sum(grad * M, axis=1)
+            grad = grad - row_corr[:, None]
+            M = tl.load(
+                ws_M_ptr + M_ws_base + (2 * t) * HC * HC + offs_r[:, None] * HC + offs_c[None, :]
+            ).to(tl.float32)
+
+        M_init = tl.load(M_init_ptr + mat_ptrs).to(tl.float32)
+        grad = grad * M_init
+        tl.store(grad_inp_ptr + mat_ptrs, grad.to(grad_inp_ptr.dtype.element_ty))
+
+    def _triton_sinkhorn_fwd(
+        input_logits: Tensor, num_iterations: int, eps: float = 1e-6
+    ) -> Tuple[Tensor, Tensor]:
+        original_shape = input_logits.shape
+        hc = original_shape[-1]
+        N_batch = input_logits.numel() // (hc * hc)
+        dev = input_logits.device
+        out = torch.empty(N_batch, hc, hc, dtype=input_logits.dtype, device=dev)
+        M_init = torch.empty(N_batch, hc, hc, dtype=input_logits.dtype, device=dev)
+        inp = input_logits.contiguous().view(N_batch, hc, hc)
+        _triton_sinkhorn_fwd_kernel[(N_batch,)](inp, out, M_init, N_batch, eps, hc, num_iterations)
+        return out.view(original_shape), M_init.view(original_shape)
+
+    def _triton_sinkhorn_bwd(
+        grad_output: Tensor, M_init: Tensor, num_iterations: int, eps: float = 1e-6
+    ) -> Tensor:
+        original_shape = grad_output.shape
+        hc = original_shape[-1]
+        N_batch = grad_output.numel() // (hc * hc)
+        dev = grad_output.device
+        grad_input = torch.empty(N_batch, hc, hc, dtype=grad_output.dtype, device=dev)
+        go = grad_output.contiguous().view(N_batch, hc, hc)
+        mi = M_init.contiguous().view(N_batch, hc, hc)
+        ws_M = torch.empty(N_batch * 2 * num_iterations * hc * hc, dtype=torch.float32, device=dev)
+        ws_rs = torch.empty(N_batch * num_iterations * hc, dtype=torch.float32, device=dev)
+        ws_cs = torch.empty(N_batch * num_iterations * hc, dtype=torch.float32, device=dev)
+        _triton_sinkhorn_bwd_kernel[(N_batch,)](
+            go, mi, grad_input, ws_M, ws_rs, ws_cs, N_batch, eps, hc, num_iterations
+        )
+        return grad_input.view(original_shape)
+
+    class TritonFusedSinkhorn(torch.autograd.Function):
+        """Autograd wrapper for Triton fused Sinkhorn."""
+
+        @staticmethod
+        def forward(ctx, input_logits: Tensor, num_iterations: int, eps: float = 1e-6):
+            """Run Triton Sinkhorn forward and save initial matrix for backward."""
+            out, M_init = _triton_sinkhorn_fwd(input_logits, num_iterations, eps)
+            ctx.save_for_backward(M_init)
+            ctx.num_iterations = num_iterations
+            ctx.eps = eps
+            return out
+
+        @staticmethod
+        def backward(ctx, grad_output: Tensor):
+            """Run Triton Sinkhorn backward."""
+            (M_init,) = ctx.saved_tensors
+            grad_input = _triton_sinkhorn_bwd(grad_output, M_init, ctx.num_iterations, ctx.eps)
+            return grad_input, None, None
+
+    def triton_fused_sinkhorn(
+        input_logits: Tensor, num_iterations: int, eps: float = 1e-6
+    ) -> Tensor:
+        """Apply Triton fused Sinkhorn with autograd support."""
+        return TritonFusedSinkhorn.apply(input_logits, num_iterations, eps)
+
+    # ============================================================================
+    # H_aggregate forward
+    # ============================================================================
+
+    @triton.autotune(
+        configs=[
+            triton.Config({"BLOCK_C": bc, "BLOCK_S": bs}, num_warps=nw)
+            for bc in (64, 128, 256, 512)
+            for bs in (1, 2, 4, 8)
+            for nw in (2, 4, 8)
+        ],
+        key=["C", "N"],
+    )
+    @triton.jit
+    def _triton_h_agg_fwd_kernel(
+        x_ptr,
+        h_ptr,
+        out_ptr,
+        sb,
+        C: tl.constexpr,
+        N: tl.constexpr,
+        stride_x_s,
+        stride_x_n,
+        stride_x_c,
+        BLOCK_C: tl.constexpr,
+        BLOCK_S: tl.constexpr,
+    ):
+        """out[s, c] = sum_i x[s, i, c] * h[s, i]."""
+        pid_s = tl.program_id(0)
+        pid_c = tl.program_id(1)
+        offs_s = pid_s * BLOCK_S + tl.arange(0, BLOCK_S)
+        offs_c = pid_c * BLOCK_C + tl.arange(0, BLOCK_C)
+        mask_s = offs_s < sb
+        mask_c = offs_c < C
+        mask_2d = mask_s[:, None] & mask_c[None, :]
+
+        acc = tl.zeros((BLOCK_S, BLOCK_C), dtype=tl.float32)
+        for i in tl.static_range(N):
+            x_i = tl.load(
+                x_ptr + offs_s[:, None] * stride_x_s + i * stride_x_n + offs_c[None, :],
+                mask=mask_2d,
+                other=0.0,
+            ).to(tl.float32)
+            h_i = tl.load(h_ptr + offs_s * N + i, mask=mask_s, other=0.0).to(tl.float32)
+            acc += h_i[:, None] * x_i
+        tl.store(
+            out_ptr + offs_s[:, None] * C + offs_c[None, :],
+            acc.to(out_ptr.dtype.element_ty),
+            mask=mask_2d,
+        )
+
+    def _triton_h_aggregate_fwd(x: Tensor, h_pre: Tensor) -> Tensor:
+        s, b, n, C = x.shape
+        sb = s * b
+        out = torch.empty(sb, C, dtype=x.dtype, device=x.device)
+        x_flat = x.contiguous().view(sb, n, C)
+        h_flat = h_pre.contiguous().view(sb, n)
+
+        grid = lambda META: (triton.cdiv(sb, META["BLOCK_S"]), triton.cdiv(C, META["BLOCK_C"]))
+        _triton_h_agg_fwd_kernel[grid](
+            x_flat, h_flat, out, sb, C, n, x_flat.stride(0), x_flat.stride(1), x_flat.stride(2)
+        )
+        return out.view(s, b, C)
+
+    # ============================================================================
+    # H_post BDA
+    # ============================================================================
+
+    @triton.autotune(
+        configs=[
+            triton.Config({"BLOCK_C": bc, "BLOCK_S": bs}, num_warps=nw)
+            for bc in (64, 128, 256, 512)
+            for bs in (1, 2, 4, 8)
+            for nw in (2, 4, 8)
+        ],
+        key=["C", "N"],
+    )
+    @triton.jit
+    def _triton_hpb_fwd_kernel(
+        hr_ptr,
+        orig_ptr,
+        hp_ptr,
+        x_ptr,
+        bias_ptr,
+        out_ptr,
+        sb,
+        C: tl.constexpr,
+        N: tl.constexpr,
+        stride_hr_s,
+        stride_hr_i,
+        stride_hr_j,
+        stride_orig_s,
+        stride_orig_n,
+        stride_orig_c,
+        stride_out_s,
+        stride_out_n,
+        stride_out_c,
+        HAS_BIAS: tl.constexpr,
+        BLOCK_C: tl.constexpr,
+        BLOCK_S: tl.constexpr,
+    ):
+        """out = hr.T @ orig + hp * (x + bias)."""
+        pid_s = tl.program_id(0)
+        pid_c = tl.program_id(1)
+        offs_s = pid_s * BLOCK_S + tl.arange(0, BLOCK_S)
+        offs_c = pid_c * BLOCK_C + tl.arange(0, BLOCK_C)
+        mask_s = offs_s < sb
+        mask_c = offs_c < C
+        mask_2d = mask_s[:, None] & mask_c[None, :]
+
+        x_tile = tl.load(x_ptr + offs_s[:, None] * C + offs_c[None, :], mask=mask_2d, other=0.0).to(
+            tl.float32
+        )
+        if HAS_BIAS:
+            bias_tile = tl.load(bias_ptr + offs_c, mask=mask_c, other=0.0).to(tl.float32)
+            x_tile += bias_tile[None, :]
+
+        for i in tl.static_range(N):
+            hp_i = tl.load(hp_ptr + offs_s * N + i, mask=mask_s, other=0.0).to(tl.float32)
+            out_i = hp_i[:, None] * x_tile
+
+            for j in tl.static_range(N):
+                hr_ji = tl.load(
+                    hr_ptr + offs_s * stride_hr_s + j * stride_hr_i + i * stride_hr_j,
+                    mask=mask_s,
+                    other=0.0,
+                ).to(tl.float32)
+                orig_j = tl.load(
+                    orig_ptr
+                    + offs_s[:, None] * stride_orig_s
+                    + j * stride_orig_n
+                    + offs_c[None, :],
+                    mask=mask_2d,
+                    other=0.0,
+                ).to(tl.float32)
+                out_i += hr_ji[:, None] * orig_j
+
+            tl.store(
+                out_ptr + offs_s[:, None] * stride_out_s + i * stride_out_n + offs_c[None, :],
+                out_i.to(out_ptr.dtype.element_ty),
+                mask=mask_2d,
+            )
+
+    def _triton_h_post_bda_fwd(
+        h_res: Tensor, original_residual: Tensor, h_post: Tensor, x: Tensor, bias: Optional[Tensor]
+    ) -> Tensor:
+        s, b, n, C = original_residual.shape
+        sb = s * b
+        dev = h_res.device
+        out = torch.empty(sb, n, C, dtype=h_res.dtype, device=dev)
+        hr_flat = h_res.contiguous().view(sb, n, n)
+        orig_flat = original_residual.contiguous().view(sb, n, C)
+        hp_flat = h_post.contiguous().view(sb, n)
+        x_flat = x.contiguous().view(sb, C)
+
+        grid = lambda META: (triton.cdiv(sb, META["BLOCK_S"]), triton.cdiv(C, META["BLOCK_C"]))
+        _triton_hpb_fwd_kernel[grid](
+            hr_flat,
+            orig_flat,
+            hp_flat,
+            x_flat,
+            bias if bias is not None else x_flat,
+            out,
+            sb,
+            C,
+            n,
+            hr_flat.stride(0),
+            hr_flat.stride(1),
+            hr_flat.stride(2),
+            orig_flat.stride(0),
+            orig_flat.stride(1),
+            orig_flat.stride(2),
+            out.stride(0),
+            out.stride(1),
+            out.stride(2),
+            HAS_BIAS=(bias is not None),
+        )
+        return out.view(s, b, n, C)
+
+    @triton.autotune(
+        configs=[
+            triton.Config({"BLOCK_C": bc, "BLOCK_S": bs}, num_warps=nw)
+            for bc in (64, 128, 256, 512)
+            for bs in (1, 2, 4, 8)
+            for nw in (2, 4, 8)
+        ],
+        key=["C", "N"],
+    )
+    @triton.jit
+    def _triton_hpb_bwd_g_x_orig_kernel(
+        go_ptr,
+        hr_ptr,
+        hp_ptr,
+        g_orig_ptr,
+        g_x_ptr,
+        sb,
+        C: tl.constexpr,
+        N: tl.constexpr,
+        stride_go_s,
+        stride_go_n,
+        stride_go_c,
+        stride_hr_s,
+        stride_hr_i,
+        stride_hr_j,
+        stride_orig_s,
+        stride_orig_n,
+        stride_orig_c,
+        BLOCK_C: tl.constexpr,
+        BLOCK_S: tl.constexpr,
+    ):
+        """g_x = hp @ go, g_orig = hr @ go."""
+        pid_s = tl.program_id(0)
+        pid_c = tl.program_id(1)
+        offs_s = pid_s * BLOCK_S + tl.arange(0, BLOCK_S)
+        offs_c = pid_c * BLOCK_C + tl.arange(0, BLOCK_C)
+        mask_s = offs_s < sb
+        mask_c = offs_c < C
+        mask_2d = mask_s[:, None] & mask_c[None, :]
+
+        g_x_acc = tl.zeros((BLOCK_S, BLOCK_C), dtype=tl.float32)
+        for j in tl.static_range(N):
+            go_j = tl.load(
+                go_ptr + offs_s[:, None] * stride_go_s + j * stride_go_n + offs_c[None, :],
+                mask=mask_2d,
+                other=0.0,
+            ).to(tl.float32)
+            hp_j = tl.load(hp_ptr + offs_s * N + j, mask=mask_s, other=0.0).to(tl.float32)
+            g_x_acc += hp_j[:, None] * go_j
+        tl.store(
+            g_x_ptr + offs_s[:, None] * C + offs_c[None, :],
+            g_x_acc.to(g_x_ptr.dtype.element_ty),
+            mask=mask_2d,
+        )
+
+        for i in tl.static_range(N):
+            g_orig_i = tl.zeros((BLOCK_S, BLOCK_C), dtype=tl.float32)
+            for j in tl.static_range(N):
+                go_j = tl.load(
+                    go_ptr + offs_s[:, None] * stride_go_s + j * stride_go_n + offs_c[None, :],
+                    mask=mask_2d,
+                    other=0.0,
+                ).to(tl.float32)
+                hr_ij = tl.load(
+                    hr_ptr + offs_s * stride_hr_s + i * stride_hr_i + j * stride_hr_j,
+                    mask=mask_s,
+                    other=0.0,
+                ).to(tl.float32)
+                g_orig_i += hr_ij[:, None] * go_j
+            tl.store(
+                g_orig_ptr + offs_s[:, None] * stride_orig_s + i * stride_orig_n + offs_c[None, :],
+                g_orig_i.to(g_orig_ptr.dtype.element_ty),
+                mask=mask_2d,
+            )
+
+    @triton.autotune(
+        configs=[
+            triton.Config({"BLOCK_C": bc, "BLOCK_S": bs}, num_warps=nw)
+            for bc in (64, 128, 256, 512)
+            for bs in (1, 2, 4, 8)
+            for nw in (2, 4, 8)
+        ],
+        key=["C", "N"],
+    )
+    @triton.jit
+    def _triton_hpb_bwd_g_hp_hr_kernel(
+        go_ptr,
+        orig_ptr,
+        x_ptr,
+        bias_ptr,
+        g_hr_ptr,
+        g_hp_ptr,
+        sb,
+        C: tl.constexpr,
+        N: tl.constexpr,
+        stride_go_s,
+        stride_go_n,
+        stride_go_c,
+        stride_orig_s,
+        stride_orig_n,
+        stride_orig_c,
+        stride_hr_s,
+        stride_hr_i,
+        stride_hr_j,
+        HAS_BIAS: tl.constexpr,
+        BLOCK_C: tl.constexpr,
+        BLOCK_S: tl.constexpr,
+    ):
+        """g_hp = sum_c go*(x+bias), g_hr = orig @ go.T."""
+        pid_s = tl.program_id(0)
+        offs_s = pid_s * BLOCK_S + tl.arange(0, BLOCK_S)
+        mask_s = offs_s < sb
+
+        g_hp_acc = tl.zeros((BLOCK_S, N), dtype=tl.float32)
+        g_hr_acc = tl.zeros((BLOCK_S, N * N), dtype=tl.float32)
+
+        for c_start in range(0, C, BLOCK_C):
+            offs_c = c_start + tl.arange(0, BLOCK_C)
+            mask_c = offs_c < C
+            mask_2d = mask_s[:, None] & mask_c[None, :]
+
+            x_tile = tl.load(
+                x_ptr + offs_s[:, None] * C + offs_c[None, :], mask=mask_2d, other=0.0
+            ).to(tl.float32)
+            if HAS_BIAS:
+                bias_tile = tl.load(bias_ptr + offs_c, mask=mask_c, other=0.0).to(tl.float32)
+                x_tile += bias_tile[None, :]
+
+            for i in tl.static_range(N):
+                go_i = tl.load(
+                    go_ptr + offs_s[:, None] * stride_go_s + i * stride_go_n + offs_c[None, :],
+                    mask=mask_2d,
+                    other=0.0,
+                ).to(tl.float32)
+                dot_hp = tl.sum(go_i * x_tile, axis=1)
+                g_hp_acc += tl.where(
+                    tl.arange(0, N)[None, :] == i,
+                    dot_hp[:, None],
+                    tl.zeros((BLOCK_S, N), dtype=tl.float32),
+                )
+                for j in tl.static_range(N):
+                    orig_j = tl.load(
+                        orig_ptr
+                        + offs_s[:, None] * stride_orig_s
+                        + j * stride_orig_n
+                        + offs_c[None, :],
+                        mask=mask_2d,
+                        other=0.0,
+                    ).to(tl.float32)
+                    dot_hr = tl.sum(go_i * orig_j, axis=1)
+                    g_hr_acc += tl.where(
+                        tl.arange(0, N * N)[None, :] == j * N + i,
+                        dot_hr[:, None],
+                        tl.zeros((BLOCK_S, N * N), dtype=tl.float32),
+                    )
+
+        offs_n = tl.arange(0, N)
+        tl.store(
+            g_hp_ptr + offs_s[:, None] * N + offs_n[None, :],
+            g_hp_acc.to(g_hp_ptr.dtype.element_ty),
+            mask=mask_s[:, None],
+        )
+
+        # N is expected to stay small for mHC, so this simple extraction is acceptable.
+        nn_offs = tl.arange(0, N * N)
+        for i in tl.static_range(N):
+            for j in tl.static_range(N):
+                col_mask = (nn_offs == (i * N + j)).to(tl.float32)
+                val = tl.sum(g_hr_acc * col_mask[None, :], axis=1)
+                tl.store(
+                    g_hr_ptr + offs_s * stride_hr_s + i * stride_hr_i + j * stride_hr_j,
+                    val.to(g_hr_ptr.dtype.element_ty),
+                    mask=mask_s,
+                )
+
+    def _triton_h_post_bda_bwd(
+        grad_output: Tensor,
+        h_res: Tensor,
+        original_residual: Tensor,
+        h_post: Tensor,
+        x: Tensor,
+        bias: Optional[Tensor],
+    ) -> Tuple[Tensor, Tensor, Tensor, Tensor, Optional[Tensor]]:
+        s, b, n, C = original_residual.shape
+        sb = s * b
+        dev = h_res.device
+
+        g_hr = torch.empty(sb, n, n, dtype=h_res.dtype, device=dev)
+        g_res = torch.empty(sb, n, C, dtype=original_residual.dtype, device=dev)
+        g_hp = torch.empty(sb, n, dtype=h_post.dtype, device=dev)
+        g_x = torch.empty(sb, C, dtype=x.dtype, device=dev)
+
+        go_flat = grad_output.contiguous().view(sb, n, C)
+        hr_flat = h_res.contiguous().view(sb, n, n)
+        orig_flat = original_residual.contiguous().view(sb, n, C)
+        hp_flat = h_post.contiguous().view(sb, n)
+        x_flat = x.contiguous().view(sb, C)
+
+        grid_a = lambda META: (triton.cdiv(sb, META["BLOCK_S"]), triton.cdiv(C, META["BLOCK_C"]))
+        _triton_hpb_bwd_g_x_orig_kernel[grid_a](
+            go_flat,
+            hr_flat,
+            hp_flat,
+            g_res,
+            g_x,
+            sb,
+            C,
+            n,
+            go_flat.stride(0),
+            go_flat.stride(1),
+            go_flat.stride(2),
+            hr_flat.stride(0),
+            hr_flat.stride(1),
+            hr_flat.stride(2),
+            g_res.stride(0),
+            g_res.stride(1),
+            g_res.stride(2),
+        )
+
+        grid_b = lambda META: (triton.cdiv(sb, META["BLOCK_S"]),)
+        _triton_hpb_bwd_g_hp_hr_kernel[grid_b](
+            go_flat,
+            orig_flat,
+            x_flat,
+            bias if bias is not None else x_flat,
+            g_hr,
+            g_hp,
+            sb,
+            C,
+            n,
+            go_flat.stride(0),
+            go_flat.stride(1),
+            go_flat.stride(2),
+            orig_flat.stride(0),
+            orig_flat.stride(1),
+            orig_flat.stride(2),
+            g_hr.stride(0),
+            g_hr.stride(1),
+            g_hr.stride(2),
+            HAS_BIAS=(bias is not None),
+        )
+
+        g_bias = g_x.sum(dim=0).to(dtype=bias.dtype) if bias is not None else None
+        return (
+            g_hr.view(s, b, n, n),
+            g_res.view(s, b, n, C),
+            g_hp.view(s, b, n),
+            g_x.view(s, b, C),
+            g_bias,
+        )
+
+
+_TRITON_IMPLS = (
+    {
+        "sinkhorn": triton_fused_sinkhorn,
+        "h_aggregate_fwd": _triton_h_aggregate_fwd,
+        "h_post_bda_fwd": _triton_h_post_bda_fwd,
+        "h_post_bda_bwd": _triton_h_post_bda_bwd,
+    }
+    if _TRITON_AVAILABLE
+    else {"sinkhorn": None, "h_aggregate_fwd": None, "h_post_bda_fwd": None, "h_post_bda_bwd": None}
+)
+
+
+# ============================================================================
+# CuTile implementations (only defined when cuda.tile is available)
+# ============================================================================
+
+if _CUTILE_AVAILABLE:
+    ConstInt = ct.Constant[int]
+    PAD_ZERO = ct.PaddingMode.ZERO
+
+    # -- Sinkhorn kernels ----------------------------------------------------
+
+    @ct.kernel
+    def _ct_sinkhorn_fwd_kernel(
+        inp, out, M_init_out, eps, HC: ConstInt, NUM_ITERS: ConstInt, TILE_SIZE: ConstInt
+    ):
+        pid = ct.bid(0)
+        logits = ct.load(inp, index=(pid, 0, 0), shape=(TILE_SIZE, HC, HC)).astype(ct.float32)
+        row_max = ct.max(logits, axis=2, keepdims=True)
+        M = ct.exp2((logits - row_max) * LOG2E)
+        ct.store(
+            M_init_out,
+            index=(pid, 0, 0),
+            tile=ct.reshape(M.astype(M_init_out.dtype), (TILE_SIZE, HC, HC)),
+        )
+        row_sum = ct.sum(M, axis=2, keepdims=True)
+        M = M / row_sum + eps
+        col_sum = ct.sum(M, axis=1, keepdims=True)
+        M = M / (col_sum + eps)
+        for _ in range(NUM_ITERS - 1):
+            row_sum = ct.sum(M, axis=2, keepdims=True)
+            M = M / (row_sum + eps)
+            col_sum = ct.sum(M, axis=1, keepdims=True)
+            M = M / (col_sum + eps)
+        ct.store(out, index=(pid, 0, 0), tile=ct.reshape(M.astype(out.dtype), (TILE_SIZE, HC, HC)))
+
+    @ct.kernel
+    def _ct_sinkhorn_bwd_kernel(
+        grad_out,
+        M_init,
+        grad_inp,
+        ws_M,
+        ws_rs,
+        ws_cs,
+        eps,
+        HC: ConstInt,
+        NUM_ITERS: ConstInt,
+        TILE_SIZE: ConstInt,
+    ):
+        pid = ct.bid(0)
+        M_base = pid * (2 * NUM_ITERS)
+        v_base = pid * NUM_ITERS
+
+        M = ct.load(M_init, index=(pid, 0, 0), shape=(TILE_SIZE, HC, HC)).astype(ct.float32)
+        for t in range(NUM_ITERS):
+            ct.store(ws_M, index=(M_base + 2 * t, 0, 0), tile=M)
+            row_sum = ct.sum(M, axis=2, keepdims=True)
+            ct.store(ws_rs, index=(v_base + t, 0, 0), tile=row_sum)
+            if t == 0:
+                M = M / row_sum + eps
+            else:
+                M = M / (row_sum + eps)
+            ct.store(ws_M, index=(M_base + 2 * t + 1, 0, 0), tile=M)
+            col_sum = ct.sum(M, axis=1, keepdims=True)
+            ct.store(ws_cs, index=(v_base + t, 0, 0), tile=col_sum)
+            M = M / (col_sum + eps)
+
+        grad = ct.load(grad_out, index=(pid, 0, 0), shape=(TILE_SIZE, HC, HC)).astype(ct.float32)
+        for t_rev in range(NUM_ITERS):
+            t = NUM_ITERS - 1 - t_rev
+            col_s = ct.load(ws_cs, index=(v_base + t, 0, 0), shape=(TILE_SIZE, 1, HC))
+            grad = grad / (col_s + eps)
+            col_corr = ct.sum(grad * M, axis=1, keepdims=True)
+            grad = grad - col_corr
+            M = ct.load(ws_M, index=(M_base + 2 * t + 1, 0, 0), shape=(TILE_SIZE, HC, HC))
+            row_s = ct.load(ws_rs, index=(v_base + t, 0, 0), shape=(TILE_SIZE, HC, 1))
+            if t == 0:
+                grad = grad / row_s
+                row_corr = ct.sum(grad * (M - eps), axis=2, keepdims=True)
+            else:
+                grad = grad / (row_s + eps)
+                row_corr = ct.sum(grad * M, axis=2, keepdims=True)
+            grad = grad - row_corr
+            M = ct.load(ws_M, index=(M_base + 2 * t, 0, 0), shape=(TILE_SIZE, HC, HC))
+        grad = grad * M
+        ct.store(grad_inp, index=(pid, 0, 0), tile=grad.astype(grad_inp.dtype))
+
+    def _sinkhorn_autotune_tile_sizes(N_batch):
+        """Generate autotune search space for sinkhorn kernels."""
+        for ts in (1, 2, 4, 8, 16, 32, 64, 128):
+            if ts <= N_batch:
+                yield ts
+
+    _sinkhorn_fwd_best_cfg: dict = {}
+    _sinkhorn_bwd_best_cfg: dict = {}
+
+    def _cutile_sinkhorn_fwd(
+        input_logits: Tensor, num_iterations: int, eps: float = 1e-6
+    ) -> Tuple[Tensor, Tensor]:
+        original_shape = input_logits.shape
+        hc = original_shape[-1]
+        N_batch = input_logits.numel() // (hc * hc)
+        dev = input_logits.device
+        stream = torch.cuda.current_stream()
+        out = torch.empty(N_batch, hc, hc, dtype=input_logits.dtype, device=dev)
+        M_init = torch.empty(N_batch, hc, hc, dtype=input_logits.dtype, device=dev)
+        inp = input_logits.view(N_batch, hc, hc)
+
+        cache_key = (N_batch, hc, num_iterations)
+        cached = _sinkhorn_fwd_best_cfg.get(cache_key)
+
+        if cached is not None or not _CUTILE_EXPERIMENTAL_AVAILABLE:
+            ts = cached if cached is not None else math.gcd(N_batch, 128)
+            ct.launch(
+                stream,
+                (math.ceil(N_batch / ts), 1, 1),
+                _ct_sinkhorn_fwd_kernel,
+                (inp, out, M_init, eps, hc, num_iterations, ts),
+            )
+        else:
+            from types import SimpleNamespace
+
+            configs = [
+                SimpleNamespace(TILE_SIZE=ts) for ts in _sinkhorn_autotune_tile_sizes(N_batch)
+            ]
+            tuned = ct_experimental.autotune_launch(
+                stream,
+                grid_fn=lambda cfg: (math.ceil(N_batch / cfg.TILE_SIZE), 1, 1),
+                kernel=_ct_sinkhorn_fwd_kernel,
+                args_fn=lambda cfg: (inp, out, M_init, eps, hc, num_iterations, cfg.TILE_SIZE),
+                search_space=configs,
+            )
+            best_ts = tuned.tuned_config.TILE_SIZE
+            _sinkhorn_fwd_best_cfg[cache_key] = best_ts
+            ct.launch(
+                stream,
+                (math.ceil(N_batch / best_ts), 1, 1),
+                _ct_sinkhorn_fwd_kernel,
+                (inp, out, M_init, eps, hc, num_iterations, best_ts),
+            )
+
+        return out.view(original_shape), M_init.view(original_shape)
+
+    def _cutile_sinkhorn_bwd(
+        grad_output: Tensor, M_init: Tensor, num_iterations: int, eps: float = 1e-6
+    ) -> Tensor:
+        original_shape = grad_output.shape
+        hc = original_shape[-1]
+        N_batch = grad_output.numel() // (hc * hc)
+        dev = grad_output.device
+        stream = torch.cuda.current_stream()
+        grad_input = torch.empty(N_batch, hc, hc, dtype=grad_output.dtype, device=dev)
+        go = grad_output.view(N_batch, hc, hc)
+        mi = M_init.view(N_batch, hc, hc)
+
+        cache_key = (N_batch, hc, num_iterations)
+        cached = _sinkhorn_bwd_best_cfg.get(cache_key)
+
+        def _alloc_and_launch(ts):
+            ws_M = torch.empty(
+                N_batch * 2 * num_iterations, hc, hc, dtype=torch.float32, device=dev
+            )
+            ws_rs = torch.empty(N_batch * num_iterations, hc, 1, dtype=torch.float32, device=dev)
+            ws_cs = torch.empty(N_batch * num_iterations, 1, hc, dtype=torch.float32, device=dev)
+            ct.launch(
+                stream,
+                (math.ceil(N_batch / ts), 1, 1),
+                _ct_sinkhorn_bwd_kernel,
+                (go, mi, grad_input, ws_M, ws_rs, ws_cs, eps, hc, num_iterations, ts),
+            )
+
+        if cached is not None or not _CUTILE_EXPERIMENTAL_AVAILABLE:
+            ts = cached if cached is not None else math.gcd(N_batch, 128)
+            _alloc_and_launch(ts)
+        else:
+            from types import SimpleNamespace
+
+            configs = [
+                SimpleNamespace(TILE_SIZE=ts) for ts in _sinkhorn_autotune_tile_sizes(N_batch)
+            ]
+            # Allocate workspace for largest tile size (all configs share same workspace shape).
+            ws_M = torch.empty(
+                N_batch * 2 * num_iterations, hc, hc, dtype=torch.float32, device=dev
+            )
+            ws_rs = torch.empty(N_batch * num_iterations, hc, 1, dtype=torch.float32, device=dev)
+            ws_cs = torch.empty(N_batch * num_iterations, 1, hc, dtype=torch.float32, device=dev)
+            tuned = ct_experimental.autotune_launch(
+                stream,
+                grid_fn=lambda cfg: (math.ceil(N_batch / cfg.TILE_SIZE), 1, 1),
+                kernel=_ct_sinkhorn_bwd_kernel,
+                args_fn=lambda cfg: (
+                    go,
+                    mi,
+                    grad_input,
+                    ws_M,
+                    ws_rs,
+                    ws_cs,
+                    eps,
+                    hc,
+                    num_iterations,
+                    cfg.TILE_SIZE,
+                ),
+                search_space=configs,
+            )
+            best_ts = tuned.tuned_config.TILE_SIZE
+            _sinkhorn_bwd_best_cfg[cache_key] = best_ts
+            # Re-launch with best config.
+            _alloc_and_launch(best_ts)
+
+        return grad_input.view(original_shape)
+
+    # -- H_aggregate kernels -------------------------------------------------
+
+    @ct.kernel
+    def _ct_h_agg_fwd_kernel(x, h_pre, out, N: ConstInt, TILE_M: ConstInt, TILE_C: ConstInt):
+        pid = ct.bid(0)
+        num_tiles = ct.num_tiles(x, axis=2, shape=(TILE_M, N, TILE_C))
+        h_tile = ct.load(h_pre, index=(pid, 0), shape=(TILE_M, N), padding_mode=PAD_ZERO)
+        h_tile = ct.expand_dims(h_tile, axis=2)
+        for j in range(num_tiles):
+            x_tile = ct.load(x, index=(pid, 0, j), shape=(TILE_M, N, TILE_C), padding_mode=PAD_ZERO)
+            acc = ct.sum(x_tile * h_tile, axis=1).astype(ct.float32)
+            ct.store(out, index=(pid, j), tile=acc.astype(out.dtype))
+
+    @ct.kernel
+    def _ct_h_agg_bwd_kernel(go, x, h_pre, gx, gh, N: ConstInt, TILE_M: ConstInt, TILE_C: ConstInt):
+        pid = ct.bid(0)
+        num_c_tiles = ct.num_tiles(go, axis=1, shape=(TILE_M, TILE_C))
+        h_tile = ct.load(h_pre, index=(pid, 0), shape=(TILE_M, N), padding_mode=PAD_ZERO)
+        h_expanded = ct.expand_dims(h_tile, axis=2)
+        gh_acc = ct.full((TILE_M, N), 0, dtype=ct.float32)
+        for ct_idx in range(num_c_tiles):
+            go_tile = ct.load(
+                go, index=(pid, ct_idx), shape=(TILE_M, TILE_C), padding_mode=PAD_ZERO
+            )
+            go_expanded = ct.expand_dims(go_tile, axis=1)
+            x_tile = ct.load(
+                x, index=(pid, 0, ct_idx), shape=(TILE_M, N, TILE_C), padding_mode=PAD_ZERO
+            )
+            gx_tile = go_expanded * h_expanded
+            ct.store(gx, index=(pid, 0, ct_idx), tile=gx_tile.astype(gx.dtype))
+            # Reduce in fp32: the torch reference evaluates this product in fp32
+            # under torch.compile, and a bf16 product makes grad_h ~3x noisier.
+            gh_acc += ct.sum(go_expanded.astype(ct.float32) * x_tile.astype(ct.float32), axis=2)
+        ct.store(gh, index=(pid, 0), tile=gh_acc.astype(gh.dtype))
+
+    def _cutile_h_aggregate_fwd(x: Tensor, h_pre: Tensor) -> Tensor:
+        s, b, n, C = x.shape
+        sb = s * b
+        stream = torch.cuda.current_stream()
+        out = torch.empty(sb, C, dtype=x.dtype, device=x.device)
+        x_flat = x.view(sb, n, C)
+        h_flat = h_pre.view(sb, n)
+
+        # Autotune disabled — causes cudaErrorLaunchFailure during training.
+        tm, tc = math.gcd(sb, 4), math.gcd(C, 1024)
+        ct.launch(
+            stream, (math.ceil(sb / tm),), _ct_h_agg_fwd_kernel, (x_flat, h_flat, out, n, tm, tc)
+        )
+
+        return out.view(s, b, C)
+
+    def _cutile_h_aggregate_bwd(
+        grad_output: Tensor, x: Tensor, h_pre: Tensor
+    ) -> Tuple[Tensor, Tensor]:
+        s, b, n, C = x.shape
+        sb = s * b
+        stream = torch.cuda.current_stream()
+        gx = torch.empty(sb, n, C, dtype=x.dtype, device=x.device)
+        gh = torch.empty(sb, n, dtype=h_pre.dtype, device=x.device)
+        go_flat = grad_output.view(sb, C)
+        x_flat = x.view(sb, n, C)
+        h_flat = h_pre.view(sb, n)
+
+        # Autotune disabled — causes cudaErrorLaunchFailure during training.
+        tm, tc = math.gcd(sb, 4), math.gcd(C, 1024)
+        ct.launch(
+            stream,
+            (math.ceil(sb / tm),),
+            _ct_h_agg_bwd_kernel,
+            (go_flat, x_flat, h_flat, gx, gh, n, tm, tc),
+        )
+
+        return gx.view(s, b, n, C), gh.view(s, b, n)
+
+    # -- H_post BDA kernels --------------------------------------------------
+
+    @ct.kernel
+    def _ct_hpb_fwd_kernel(
+        hr, orig, hp, x, out, N: ConstInt, TILE_C: ConstInt, TILE_SIZE: ConstInt
+    ):
+        pid = ct.bid(0)
+        num_c_tiles = ct.num_tiles(x, axis=1, shape=(TILE_SIZE, TILE_C))
+        hp_tile = ct.load(hp, index=(pid, 0), shape=(TILE_SIZE, N), padding_mode=PAD_ZERO)
+        hp_exp = ct.expand_dims(hp_tile, axis=2)  # (TILE_SIZE, N, 1)
+        hr_tile = ct.load(hr, index=(pid, 0, 0), shape=(TILE_SIZE, N, N), padding_mode=PAD_ZERO)
+        for ct_idx in range(num_c_tiles):
+            orig_tile = ct.load(
+                orig, index=(pid, 0, ct_idx), shape=(TILE_SIZE, N, TILE_C), padding_mode=PAD_ZERO
+            )
+            x_tile = ct.load(
+                x, index=(pid, ct_idx), shape=(TILE_SIZE, TILE_C), padding_mode=PAD_ZERO
+            )
+            x_exp = ct.expand_dims(x_tile, axis=1)  # (TILE_SIZE, 1, TILE_C)
+            out_tile = hp_exp * x_exp  # (TILE_SIZE, N, TILE_C)
+            for j in range(N):
+                hr_row = ct.extract(hr_tile, (0, j, 0), shape=(TILE_SIZE, 1, N))
+                hr_col = ct.reshape(hr_row, (TILE_SIZE, N, 1))
+                orig_row = ct.extract(orig_tile, (0, j, 0), shape=(TILE_SIZE, 1, TILE_C))
+                out_tile = out_tile + hr_col * orig_row
+            ct.store(out, index=(pid, 0, ct_idx), tile=out_tile.astype(out.dtype))
+
+    @ct.kernel
+    def _ct_hpb_fwd_bias_kernel(
+        hr, orig, hp, x, bias, out, N: ConstInt, TILE_C: ConstInt, TILE_SIZE: ConstInt
+    ):
+        pid = ct.bid(0)
+        num_c_tiles = ct.num_tiles(x, axis=1, shape=(TILE_SIZE, TILE_C))
+        hp_tile = ct.load(hp, index=(pid, 0), shape=(TILE_SIZE, N), padding_mode=PAD_ZERO)
+        hp_exp = ct.expand_dims(hp_tile, axis=2)  # (TILE_SIZE, N, 1)
+        hr_tile = ct.load(hr, index=(pid, 0, 0), shape=(TILE_SIZE, N, N), padding_mode=PAD_ZERO)
+        for ct_idx in range(num_c_tiles):
+            orig_tile = ct.load(
+                orig, index=(pid, 0, ct_idx), shape=(TILE_SIZE, N, TILE_C), padding_mode=PAD_ZERO
+            )
+            x_tile = ct.load(
+                x, index=(pid, ct_idx), shape=(TILE_SIZE, TILE_C), padding_mode=PAD_ZERO
+            )
+            bias_tile = ct.load(bias, index=(ct_idx,), shape=(TILE_C,), padding_mode=PAD_ZERO)
+            xb_exp = ct.expand_dims(x_tile + bias_tile, axis=1)  # (TILE_SIZE, 1, TILE_C)
+            out_tile = hp_exp * xb_exp  # (TILE_SIZE, N, TILE_C)
+            for j in range(N):
+                hr_row = ct.extract(hr_tile, (0, j, 0), shape=(TILE_SIZE, 1, N))
+                hr_col = ct.reshape(hr_row, (TILE_SIZE, N, 1))
+                orig_row = ct.extract(orig_tile, (0, j, 0), shape=(TILE_SIZE, 1, TILE_C))
+                out_tile = out_tile + hr_col * orig_row
+            ct.store(out, index=(pid, 0, ct_idx), tile=out_tile.astype(out.dtype))
+
+    @ct.kernel
+    def _ct_hpb_bwd_g_x_orig_kernel(
+        go, hr, hp, g_orig, g_x, N: ConstInt, TILE_C: ConstInt, TILE_SIZE: ConstInt
+    ):
+        """Compute g_x = hp @ go and g_orig = hr @ go.
+
+        Grid: (ceil(sb / TILE_SIZE), ceil(C / TILE_C)).
+        2D grid — no loop, no accumulators.
+        """
+        pid = ct.bid(0)
+        ct_idx = ct.bid(1)
+        hp_tile = ct.load(hp, index=(pid, 0), shape=(TILE_SIZE, N), padding_mode=PAD_ZERO)
+        hr_tile = ct.load(hr, index=(pid, 0, 0), shape=(TILE_SIZE, N, N), padding_mode=PAD_ZERO)
+        go_tile = ct.load(
+            go, index=(pid, 0, ct_idx), shape=(TILE_SIZE, N, TILE_C), padding_mode=PAD_ZERO
+        )
+        g_x_tile = ct.full((TILE_SIZE, 1, TILE_C), 0, dtype=ct.float32)
+        g_orig_tile = ct.full((TILE_SIZE, N, TILE_C), 0, dtype=ct.float32)
+        for j in range(N):
+            hp_j = ct.extract(hp_tile, (0, j), shape=(TILE_SIZE, 1))
+            hp_j_exp = ct.expand_dims(hp_j, axis=2)  # [TS, 1, 1]
+            go_j = ct.extract(go_tile, (0, j, 0), shape=(TILE_SIZE, 1, TILE_C))
+            g_x_tile = g_x_tile + hp_j_exp * go_j
+            hr_col_j = ct.extract(hr_tile, (0, 0, j), shape=(TILE_SIZE, N, 1))
+            g_orig_tile = g_orig_tile + hr_col_j * go_j
+        ct.store(
+            g_x,
+            index=(pid, ct_idx),
+            tile=ct.reshape(g_x_tile, (TILE_SIZE, TILE_C)).astype(g_x.dtype),
+        )
+        ct.store(g_orig, index=(pid, 0, ct_idx), tile=g_orig_tile.astype(g_orig.dtype))
+
+    @ct.kernel
+    def _ct_hpb_bwd_g_hp_hr_kernel(
+        go, orig, x, g_hr, g_hp, N: ConstInt, TILE_C: ConstInt, TILE_SIZE: ConstInt
+    ):
+        """Compute g_hp = sum(go * x) and g_hr = orig @ go.T (no bias).
+
+        Grid: (ceil(sb / TILE_SIZE),).  Loops over C-tiles.
+        """
+        pid = ct.bid(0)
+        num_c_tiles = ct.cdiv(go.shape[2], TILE_C)
+        acc_g_hp = ct.full((TILE_SIZE, N, 1), 0, dtype=ct.float32)
+        acc_g_hr = ct.full((TILE_SIZE, N, N), 0, dtype=ct.float32)
+        for ct_idx in range(num_c_tiles):
+            x_tile = ct.load(
+                x, index=(pid, ct_idx), shape=(TILE_SIZE, TILE_C), padding_mode=PAD_ZERO
+            )
+            x_exp = ct.expand_dims(x_tile, axis=1)  # [TS, 1, TC]
+            go_tile = ct.load(
+                go, index=(pid, 0, ct_idx), shape=(TILE_SIZE, N, TILE_C), padding_mode=PAD_ZERO
+            )
+            orig_tile = ct.load(
+                orig, index=(pid, 0, ct_idx), shape=(TILE_SIZE, N, TILE_C), padding_mode=PAD_ZERO
+            )
+            acc_g_hp = acc_g_hp + ct.sum(go_tile * x_exp, axis=2, keepdims=True)
+            acc_g_hr = acc_g_hr + ct.sum(
+                ct.expand_dims(orig_tile, axis=2) * ct.expand_dims(go_tile, axis=1), axis=3
+            )
+        ct.store(g_hp, index=(pid, 0), tile=ct.reshape(acc_g_hp, (TILE_SIZE, N)).astype(g_hp.dtype))
+        ct.store(g_hr, index=(pid, 0, 0), tile=acc_g_hr.astype(g_hr.dtype))
+
+    @ct.kernel
+    def _ct_hpb_bwd_g_hp_hr_bias_kernel(
+        go, orig, x, bias, g_hr, g_hp, N: ConstInt, TILE_C: ConstInt, TILE_SIZE: ConstInt
+    ):
+        """Compute g_hp = sum(go * (x+bias)) and g_hr = orig @ go.T (with bias).
+
+        Grid: (ceil(sb / TILE_SIZE),).  Loops over C-tiles.
+        """
+        pid = ct.bid(0)
+        num_c_tiles = ct.cdiv(go.shape[2], TILE_C)
+        acc_g_hp = ct.full((TILE_SIZE, N, 1), 0, dtype=ct.float32)
+        acc_g_hr = ct.full((TILE_SIZE, N, N), 0, dtype=ct.float32)
+        for ct_idx in range(num_c_tiles):
+            x_tile = ct.load(
+                x, index=(pid, ct_idx), shape=(TILE_SIZE, TILE_C), padding_mode=PAD_ZERO
+            )
+            bias_tile = ct.load(bias, index=(ct_idx,), shape=(TILE_C,), padding_mode=PAD_ZERO)
+            xb_exp = ct.expand_dims(x_tile + bias_tile, axis=1)  # [TS, 1, TC]
+            go_tile = ct.load(
+                go, index=(pid, 0, ct_idx), shape=(TILE_SIZE, N, TILE_C), padding_mode=PAD_ZERO
+            )
+            orig_tile = ct.load(
+                orig, index=(pid, 0, ct_idx), shape=(TILE_SIZE, N, TILE_C), padding_mode=PAD_ZERO
+            )
+            acc_g_hp = acc_g_hp + ct.sum(go_tile * xb_exp, axis=2, keepdims=True)
+            acc_g_hr = acc_g_hr + ct.sum(
+                ct.expand_dims(orig_tile, axis=2) * ct.expand_dims(go_tile, axis=1), axis=3
+            )
+        ct.store(g_hp, index=(pid, 0), tile=ct.reshape(acc_g_hp, (TILE_SIZE, N)).astype(g_hp.dtype))
+        ct.store(g_hr, index=(pid, 0, 0), tile=acc_g_hr.astype(g_hr.dtype))
+
+    # -- H_post BDA autotune configs & caches --------------------------------
+
+    def _hpb_autotune_configs(sb, C):
+        """Generate TILE_SIZE × TILE_C search space for h_post_bda kernels."""
+        for tile_size in (1, 2, 4, 8):
+            for tile_c in (32, 64, 128, 256, 512, 1024):
+                if tile_c <= C and tile_size <= sb:
+                    yield {"TILE_SIZE": tile_size, "TILE_C": tile_c}
+
+    _hpb_fwd_best_cfg: dict = {}
+    _hpb_bwd_g_x_orig_best_cfg: dict = {}
+    _hpb_bwd_g_hp_hr_best_cfg: dict = {}
+
+    def _cutile_h_post_bda_fwd(
+        h_res: Tensor, original_residual: Tensor, h_post: Tensor, x: Tensor, bias: Optional[Tensor]
+    ) -> Tensor:
+        s, b, n, C = original_residual.shape
+        sb = s * b
+        stream = torch.cuda.current_stream()
+        out = torch.empty(sb, n, C, dtype=h_res.dtype, device=h_res.device)
+        hr_flat = h_res.view(sb, n, n)
+        orig_flat = original_residual.view(sb, n, C)
+        hp_flat = h_post.view(sb, n)
+        x_flat = x.view(sb, C)
+
+        cache_key = (sb, n, C, bias is not None)
+        cached = _hpb_fwd_best_cfg.get(cache_key)
+        kernel = _ct_hpb_fwd_bias_kernel if bias is not None else _ct_hpb_fwd_kernel
+
+        # Autotune disabled — causes cudaErrorLaunchFailure during training.
+        if cached is not None:
+            ts, tc = cached
+        else:
+            ts, tc = 1, math.gcd(C, 1024)
+        args = (hr_flat, orig_flat, hp_flat, x_flat)
+        if bias is not None:
+            args = args + (bias,)
+        args = args + (out, n, tc, ts)
+        ct.launch(stream, (math.ceil(sb / ts),), kernel, args)
+
+        return out.view(s, b, n, C)
+
+    def _cutile_h_post_bda_bwd(
+        grad_output: Tensor,
+        h_res: Tensor,
+        original_residual: Tensor,
+        h_post: Tensor,
+        x: Tensor,
+        bias: Optional[Tensor],
+    ) -> Tuple[Tensor, Tensor, Tensor, Tensor, Optional[Tensor]]:
+        s, b, n, C = original_residual.shape
+        sb = s * b
+        stream = torch.cuda.current_stream()
+        g_hr = torch.empty(sb, n, n, dtype=h_res.dtype, device=h_res.device)
+        g_res = torch.empty(sb, n, C, dtype=original_residual.dtype, device=h_res.device)
+        g_hp = torch.empty(sb, n, dtype=h_post.dtype, device=h_res.device)
+        g_x = torch.empty(sb, C, dtype=x.dtype, device=h_res.device)
+        go_flat = grad_output.view(sb, n, C)
+        hr_flat = h_res.view(sb, n, n)
+        orig_flat = original_residual.view(sb, n, C)
+        hp_flat = h_post.view(sb, n)
+        x_flat = x.view(sb, C)
+
+        # --- Kernel A: g_x, g_orig (2D grid, no loop) ---
+        cache_key_a = ('hpb_bwd_g_x_orig', sb, n, C)
+        cached_a = _hpb_bwd_g_x_orig_best_cfg.get(cache_key_a)
+
+        if cached_a is not None or not _CUTILE_EXPERIMENTAL_AVAILABLE:
+            if cached_a is not None:
+                ts, tc = cached_a
+            else:
+                ts, tc = 1, math.gcd(C, 1024)
+            ct.launch(
+                stream,
+                (math.ceil(sb / ts), math.ceil(C / tc)),
+                _ct_hpb_bwd_g_x_orig_kernel,
+                (go_flat, hr_flat, hp_flat, g_res, g_x, n, tc, ts),
+            )
+        else:
+            from types import SimpleNamespace
+
+            configs = [SimpleNamespace(**c) for c in _hpb_autotune_configs(sb, C)]
+            tuned = ct_experimental.autotune_launch(
+                stream,
+                grid_fn=lambda cfg: (math.ceil(sb / cfg.TILE_SIZE), math.ceil(C / cfg.TILE_C)),
+                kernel=_ct_hpb_bwd_g_x_orig_kernel,
+                args_fn=lambda cfg: (
+                    go_flat,
+                    hr_flat,
+                    hp_flat,
+                    g_res,
+                    g_x,
+                    n,
+                    cfg.TILE_C,
+                    cfg.TILE_SIZE,
+                ),
+                search_space=configs,
+            )
+            best = tuned.tuned_config
+            _hpb_bwd_g_x_orig_best_cfg[cache_key_a] = (best.TILE_SIZE, best.TILE_C)
+            ct.launch(
+                stream,
+                (math.ceil(sb / best.TILE_SIZE), math.ceil(C / best.TILE_C)),
+                _ct_hpb_bwd_g_x_orig_kernel,
+                (go_flat, hr_flat, hp_flat, g_res, g_x, n, best.TILE_C, best.TILE_SIZE),
+            )
+
+        # --- Kernel B: g_hp, g_hr (1D grid, loops C-tiles) ---
+        cache_key_b = ('hpb_bwd_g_hp_hr', sb, n, C, bias is not None)
+        cached_b = _hpb_bwd_g_hp_hr_best_cfg.get(cache_key_b)
+        hp_hr_kernel = (
+            _ct_hpb_bwd_g_hp_hr_bias_kernel if bias is not None else _ct_hpb_bwd_g_hp_hr_kernel
+        )
+
+        if cached_b is not None or not _CUTILE_EXPERIMENTAL_AVAILABLE:
+            if cached_b is not None:
+                ts, tc = cached_b
+            else:
+                ts, tc = 1, math.gcd(C, 1024)
+            args = (go_flat, orig_flat, x_flat)
+            if bias is not None:
+                args = args + (bias,)
+            args = args + (g_hr, g_hp, n, tc, ts)
+            ct.launch(stream, (math.ceil(sb / ts),), hp_hr_kernel, args)
+        else:
+            from types import SimpleNamespace
+
+            configs = [SimpleNamespace(**c) for c in _hpb_autotune_configs(sb, C)]
+
+            def _hp_hr_args_fn(cfg):
+                args = (go_flat, orig_flat, x_flat)
+                if bias is not None:
+                    args = args + (bias,)
+                return args + (g_hr, g_hp, n, cfg.TILE_C, cfg.TILE_SIZE)
+
+            tuned = ct_experimental.autotune_launch(
+                stream,
+                grid_fn=lambda cfg: (math.ceil(sb / cfg.TILE_SIZE),),
+                kernel=hp_hr_kernel,
+                args_fn=_hp_hr_args_fn,
+                search_space=configs,
+            )
+            best = tuned.tuned_config
+            _hpb_bwd_g_hp_hr_best_cfg[cache_key_b] = (best.TILE_SIZE, best.TILE_C)
+            args = (go_flat, orig_flat, x_flat)
+            if bias is not None:
+                args = args + (bias,)
+            args = args + (g_hr, g_hp, n, best.TILE_C, best.TILE_SIZE)
+            ct.launch(stream, (math.ceil(sb / best.TILE_SIZE),), hp_hr_kernel, args)
+
+        g_bias = g_x.sum(dim=0).to(dtype=bias.dtype) if bias is not None else None
+        return (
+            g_hr.view(s, b, n, n),
+            g_res.view(s, b, n, C),
+            g_hp.view(s, b, n),
+            g_x.view(s, b, C),
+            g_bias,
+        )
+
+    # -- Proj RMS kernels ----------------------------------------------------
+
+    @ct.kernel
+    def _ct_proj_rms_fwd_kernel(
+        A,
+        B,
+        PROJ,
+        NORM,
+        R,
+        M: int,
+        N: int,
+        K: int,
+        eps: float,
+        TILE_M: ConstInt,
+        TILE_N: ConstInt,
+        TILE_K: ConstInt,
+        SPLIT_K: ConstInt,
+    ):
+        '''
+        Grid: (num_tiles_m, num_tiles_k).
+        Fused matmul + norm + r: proj, norm, r in one pass over K.
+        R is a retained signature placeholder; r is computed after split-K
+        reduction from NORM.
+        '''
+        tile_m_id = ct.bid(0)
+        split_k_id = ct.bid(1)
+        num_m_tiles = ct.cdiv(M, TILE_M)
+        num_k_tiles = ct.cdiv(K, TILE_K)
+        num_k_tiles_per_split = ct.cdiv(num_k_tiles, SPLIT_K)
+        tile_k_id_start = split_k_id * num_k_tiles_per_split
+        tile_k_id_end = ct.minimum(tile_k_id_start + num_k_tiles_per_split, num_k_tiles)
+        acc = ct.full((TILE_M, TILE_N), 0.0, dtype=ct.float32)
+        sum_sq = ct.full((TILE_M, 1), 0.0, dtype=ct.float32)
+        for tile_k_id in range(tile_k_id_start, tile_k_id_end):
+            a_tile = ct.load(
+                A, index=(tile_m_id, tile_k_id), shape=(TILE_M, TILE_K), padding_mode=PAD_ZERO
+            )
+            b_tile = ct.load(B, index=(0, tile_k_id), shape=(TILE_N, TILE_K), padding_mode=PAD_ZERO)
+            acc = ct.mma(
+                a_tile.astype(ct.tfloat32), b_tile.transpose().astype(ct.tfloat32), acc=acc
+            )
+            # Square in fp32: a bf16 square/reduction loses ~2e-3 relative on the
+            # RMS scale, which native (fp32) does not.
+            a_tile_f32 = a_tile.astype(ct.float32)
+            sum_sq += ct.sum(a_tile_f32 * a_tile_f32, axis=1, keepdims=True)
+
+        bid_m_k = tile_m_id + split_k_id * num_m_tiles
+        ct.store(PROJ, index=(bid_m_k, 0), tile=acc.astype(PROJ.dtype))
+        ct.store(NORM, index=(bid_m_k, 0), tile=sum_sq.astype(NORM.dtype))
+
+    # -- Sigmoid helper for cuTile kernels ------------------------------------
+
+    @ct.function
+    def _ct_sigmoid(x):
+        """Sigmoid via exp2: σ(x) = 1 / (1 + 2^(-x * log2(e)))."""
+        return 1.0 / (1.0 + ct.exp2(-x * LOG2E))
+
+    # -- Reduce split-K + compute_h kernel ------------------------------------
+
+    @ct.kernel
+    def _ct_reduce_compute_h_kernel(
+        Y_acc,
+        R_acc,
+        Bias,
+        Alpha_pre,
+        Alpha_post,
+        Alpha_res,
+        H_PRE,
+        H_POST,
+        H_RES,
+        R,
+        PROJ_OUT,
+        M: int,
+        N: int,
+        K: int,
+        n: ConstInt,
+        eps: float,
+        compute_h_eps: float,
+        TILE_SIZE_M: ConstInt,
+        TILE_SIZE_N: ConstInt,
+        SPLIT_K: ConstInt,
+    ):
+        """Reduce split-K partial proj/norm, compute r, and apply compute_h activations.
+
+        Grid: (ceil(M / TILE_SIZE_M),).
+        TILE_SIZE_N = next_power_of_2(N) so one tile covers the full N dimension.
+        Alpha_{pre,post,res} are [1] tensors (scalar parameters).
+        """
+        bid_m = ct.bid(0)
+        num_bid_m = ct.cdiv(M, TILE_SIZE_M)
+
+        alpha_pre = ct.load(Alpha_pre, index=(0,), shape=(1,)).item()
+        alpha_post = ct.load(Alpha_post, index=(0,), shape=(1,)).item()
+        alpha_res = ct.load(Alpha_res, index=(0,), shape=(1,)).item()
+
+        # 1. Reduce split-K partials for each logical output segment.
+        pre_accum = ct.full((TILE_SIZE_M, n), 0.0, dtype=ct.float32)
+        post_accum = ct.full((TILE_SIZE_M, n), 0.0, dtype=ct.float32)
+        r_accum = ct.full((TILE_SIZE_M, 1), 0.0, dtype=ct.float32)
+
+        for split_idx in ct.static_iter(range(SPLIT_K)):
+            bid_m_k = bid_m + split_idx * num_bid_m
+            pre_tile = ct.load(
+                Y_acc, index=(bid_m_k, 0), shape=(TILE_SIZE_M, n), padding_mode=PAD_ZERO
+            )
+            post_tile = ct.load(
+                Y_acc, index=(bid_m_k, 1), shape=(TILE_SIZE_M, n), padding_mode=PAD_ZERO
+            )
+            pre_accum = pre_accum + ct.astype(pre_tile, ct.float32)
+            post_accum = post_accum + ct.astype(post_tile, ct.float32)
+
+            r_tile = ct.load(
+                R_acc, index=(bid_m_k, 0), shape=(TILE_SIZE_M, 1), padding_mode=PAD_ZERO
+            )
+            r_accum = r_accum + ct.astype(r_tile, ct.float32)
+
+        # Store reduced projection segments for backward.
+        ct.store(PROJ_OUT, index=(bid_m, 0), tile=pre_accum.astype(PROJ_OUT.dtype))
+        ct.store(PROJ_OUT, index=(bid_m, 1), tile=post_accum.astype(PROJ_OUT.dtype))
+
+        # 2. Compute r = norm / sqrt(K)
+        denom = ct.full((TILE_SIZE_M, 1), K * 1.0, dtype=ct.float32)
+        r_val = ct.sqrt(ct.truediv(r_accum, denom))
+
+        ct.store(R, index=(bid_m, 0), tile=r_val.astype(R.dtype))
+
+        # 3. Apply compute_h directly into split outputs.
+        inv_r_eps = 1.0 / (r_val + eps)
+        bias_pre = ct.load(Bias, index=(0, 0), shape=(1, n), padding_mode=PAD_ZERO)
+        bias_post = ct.load(Bias, index=(0, 1), shape=(1, n), padding_mode=PAD_ZERO)
+        bias_pre = ct.astype(bias_pre, ct.float32)
+        bias_post = ct.astype(bias_post, ct.float32)
+
+        h_pre_linear = pre_accum * alpha_pre * inv_r_eps + bias_pre
+        h_post_linear = post_accum * alpha_post * inv_r_eps + bias_post
+        h_pre = _ct_sigmoid(h_pre_linear) + compute_h_eps
+        h_post = _ct_sigmoid(h_post_linear) * 2.0
+
+        ct.store(H_PRE, index=(bid_m, 0), tile=h_pre.astype(H_PRE.dtype))
+        ct.store(H_POST, index=(bid_m, 0), tile=h_post.astype(H_POST.dtype))
+
+        for res_chunk in ct.static_iter(range(n)):
+            res_accum = ct.full((TILE_SIZE_M, n), 0.0, dtype=ct.float32)
+            for split_idx in ct.static_iter(range(SPLIT_K)):
+                bid_m_k = bid_m + split_idx * num_bid_m
+                res_tile = ct.load(
+                    Y_acc,
+                    index=(bid_m_k, 2 + res_chunk),
+                    shape=(TILE_SIZE_M, n),
+                    padding_mode=PAD_ZERO,
+                )
+                res_accum = res_accum + ct.astype(res_tile, ct.float32)
+
+            bias_res = ct.load(Bias, index=(0, 2 + res_chunk), shape=(1, n), padding_mode=PAD_ZERO)
+            bias_res = ct.astype(bias_res, ct.float32)
+            h_res = res_accum * alpha_res * inv_r_eps + bias_res
+            ct.store(PROJ_OUT, index=(bid_m, 2 + res_chunk), tile=res_accum.astype(PROJ_OUT.dtype))
+            ct.store(H_RES, index=(bid_m, res_chunk), tile=h_res.astype(H_RES.dtype))
+
+    def _next_power_of_2(n: int) -> int:
+        n -= 1
+        n |= n >> 1
+        n |= n >> 2
+        n |= n >> 4
+        n |= n >> 8
+        n |= n >> 16
+        n |= n >> 32
+        n += 1
+        return n
+
+    def _proj_rms_fwd_autotune_configs(N):
+        """Generate autotune search space for proj_rms forward kernel."""
+        TILE_N = _next_power_of_2(N)
+        tile_ms = (32, 64, 128)
+        tile_ks = (32, 64, 128)
+        split_ks = (1, 2, 4, 8, 16)
+        for tile_m in tile_ms:
+            for tile_k in tile_ks:
+                for split_k in split_ks:
+                    yield {"TILE_M": tile_m, "TILE_N": TILE_N, "TILE_K": tile_k, 'SPLIT_K': split_k}
+
+    def _default_tile_m(M: int) -> int:
+        """Pick a tile size that avoids unmasked stores past the M dimension."""
+        for tile_m in (128, 64, 32, 16, 8, 4, 2, 1):
+            if tile_m <= M and M % tile_m == 0:
+                return tile_m
+        return 1
+
+    def _default_proj_rms_fwd_config(M: int, K: int, TILE_N: int):
+        """Static fallback for skinny MHC projection when autotune cache is absent."""
+        split_k = 16 if K >= 16384 else 8 if K >= 8192 else 1
+        return _default_tile_m(M), TILE_N, min(128, K), split_k
+
+    # Cache the best config across calls (keyed by M, N, K).
+    _proj_rms_fwd_best_cfg: dict = {}
+
+    # -- Reduce + compute_h launcher ------------------------------------------
+
+    def _reduce_compute_h_autotune_configs(M):
+        """Generate autotune search space for reduce_compute_h kernel."""
+        min_tile_m = 16 if M >= 16 else 1
+        for tile_m in (128, 64, 32, 16, 8, 4, 2, 1):
+            if tile_m < min_tile_m:
+                continue
+            if tile_m <= M and M % tile_m == 0:
+                yield tile_m
+
+    def _default_reduce_compute_h_tile_m(M: int) -> int:
+        """Pick a reduce tile size with enough blocks to cover the GPU."""
+        try:
+            num_sms = torch.cuda.get_device_properties("cuda").multi_processor_count
+        except Exception:
+            num_sms = 128
+
+        valid = [tm for tm in _reduce_compute_h_autotune_configs(M)]
+        for tm in valid:
+            if math.ceil(M / tm) >= num_sms:
+                return tm
+        return valid[-1] if valid else 1
+
+    _reduce_compute_h_best_cfg: dict = {}
+
+    def _cutile_reduce_compute_h(
+        proj_acc: Tensor,
+        norm_acc: Tensor,
+        bias: Tensor,
+        alpha_pre: Tensor,
+        alpha_post: Tensor,
+        alpha_res: Tensor,
+        n: int,
+        M: int,
+        N: int,
+        K: int,
+        eps: float,
+        compute_h_eps: float,
+        _proj_tile_m: int,
+        tile_n: int,
+        split_k: int,
+        out_dtype: torch.dtype,
+    ) -> Tuple[Tensor, Tensor, Tensor, Tensor, Tensor]:
+        """Launch reduce split-K + compute_h kernel.
+
+        Returns:
+            h_pre: [M, n] sigmoid-activated pre weights
+            h_post: [M, n] 2*sigmoid-activated post weights
+            h_res: [M, n*n] residual logits
+            r: [M, 1]  r = norm / sqrt(K)
+            proj_reduced: [M, N] reduced projection (for backward)
+        """
+        dev = proj_acc.device
+        stream = torch.cuda.current_stream()
+
+        bias_2d = bias.unsqueeze(0).contiguous()  # [1, N]
+
+        # Mapping outputs follow the promoted input/parameter dtype (fp32 for
+        # mHC's keep_in_fp32 parameters); the reduced projection is kept in the
+        # fp32 accumulator dtype because the backward consumes it.
+        h_pre_out = torch.empty(M, n, dtype=out_dtype, device=dev)
+        h_post_out = torch.empty(M, n, dtype=out_dtype, device=dev)
+        h_res_out = torch.empty(M, N - 2 * n, dtype=out_dtype, device=dev)
+        r_out = torch.empty(M, 1, dtype=out_dtype, device=dev)
+        proj_out = torch.empty(M, N, dtype=proj_acc.dtype, device=dev)
+
+        default_tm = _default_reduce_compute_h_tile_m(M)
+        cache_key = (M, N, K, n, split_k)
+        cached = _reduce_compute_h_best_cfg.get(cache_key)
+
+        def _make_args(tm):
+            return (
+                proj_acc,
+                norm_acc,
+                bias_2d,
+                alpha_pre,
+                alpha_post,
+                alpha_res,
+                h_pre_out,
+                h_post_out,
+                h_res_out,
+                r_out,
+                proj_out,
+                M,
+                N,
+                K,
+                n,
+                eps,
+                compute_h_eps,
+                tm,
+                tile_n,
+                split_k,
+            )
+
+        if cached is not None or not _CUTILE_EXPERIMENTAL_AVAILABLE:
+            tm = cached if cached is not None else default_tm
+            ct.launch(stream, (math.ceil(M / tm),), _ct_reduce_compute_h_kernel, _make_args(tm))
+        else:
+            from types import SimpleNamespace
+
+            configs = [SimpleNamespace(TILE_M=tm) for tm in _reduce_compute_h_autotune_configs(M)]
+            tuned = ct_experimental.autotune_launch(
+                stream,
+                grid_fn=lambda cfg: (math.ceil(M / cfg.TILE_M),),
+                kernel=_ct_reduce_compute_h_kernel,
+                args_fn=lambda cfg: _make_args(cfg.TILE_M),
+                search_space=configs,
+            )
+            best_tm = tuned.tuned_config.TILE_M
+            _reduce_compute_h_best_cfg[cache_key] = best_tm
+            ct.launch(
+                stream, (math.ceil(M / best_tm),), _ct_reduce_compute_h_kernel, _make_args(best_tm)
+            )
+
+        return h_pre_out, h_post_out, h_res_out, r_out, proj_out
+
+    # -- Combined proj_rms + compute_h forward --------------------------------
+
+    def _cutile_proj_rms_compute_h_fwd(
+        x: Tensor,
+        weight: Tensor,
+        bias: Tensor,
+        alpha_pre: Tensor,
+        alpha_post: Tensor,
+        alpha_res: Tensor,
+        n: int,
+        eps: float,
+        compute_h_eps: float,
+    ) -> Tuple[Tensor, Tensor, Tensor, Tensor, Tensor]:
+        """Fused proj_rms + compute_h forward.
+
+        Launches the existing _ct_proj_rms_fwd_kernel (split-K matmul + partial norm),
+        then _ct_reduce_compute_h_kernel (reduce + r + activations).
+
+        Returns:
+            h_pre: [M, n] activated pre weights
+            h_post: [M, n] activated post weights
+            h_res: [M, n*n] residual logits
+            r: [M, 1] r = norm / sqrt(K)
+            proj_reduced: [M, N] reduced projection (for backward)
+        """
+        M, K = x.shape
+        N = weight.shape[0]
+        TILE_N = _next_power_of_2(N)
+        dev = x.device
+        # The mHC mapping is a keep_in_fp32 computation (see
+        # HyperConnectionModule._projection_and_get_norm): keep the split-K
+        # partials and the mapping outputs in fp32 even when the activations
+        # arrive in bf16, otherwise this path is ~170x less accurate than native.
+        acc_dtype = torch.float32
+        stream = torch.cuda.current_stream()
+
+        cache_key = (M, N, K)
+        cached = _proj_rms_fwd_best_cfg.get(cache_key)
+
+        if cached is not None or not _CUTILE_EXPERIMENTAL_AVAILABLE:
+            if cached is not None:
+                tm, tn, tk, split_k = cached
+            else:
+                tm, tn, tk, split_k = _default_proj_rms_fwd_config(M, K, TILE_N)
+
+            proj_acc = torch.empty(split_k * M, N, dtype=acc_dtype, device=dev)
+            norm_acc = torch.empty(split_k * M, 1, dtype=acc_dtype, device=dev)
+            # _ct_proj_rms_fwd_kernel keeps R in its signature; reduce_compute_h
+            # computes r from norm_acc.
+            r_placeholder = torch.empty(split_k * M, 1, dtype=acc_dtype, device=dev)
+
+            ct.launch(
+                stream,
+                (math.ceil(M / tm), split_k),
+                _ct_proj_rms_fwd_kernel,
+                (x, weight, proj_acc, norm_acc, r_placeholder, M, N, K, eps, tm, tn, tk, split_k),
+            )
+        else:
+            from types import SimpleNamespace
+
+            configs = [SimpleNamespace(**c) for c in _proj_rms_fwd_autotune_configs(N)]
+            configs = [cfg for cfg in configs if cfg.TILE_K <= K and M % cfg.TILE_M == 0]
+            if len(configs) == 0:
+                tm, tn, tk, split_k = _default_proj_rms_fwd_config(M, K, TILE_N)
+                proj_acc = torch.empty(split_k * M, N, dtype=acc_dtype, device=dev)
+                norm_acc = torch.empty(split_k * M, 1, dtype=acc_dtype, device=dev)
+                # Signature placeholder for the cuTile kernel; not read.
+                r_placeholder = torch.empty(split_k * M, 1, dtype=acc_dtype, device=dev)
+                ct.launch(
+                    stream,
+                    (math.ceil(M / tm), split_k),
+                    _ct_proj_rms_fwd_kernel,
+                    (
+                        x,
+                        weight,
+                        proj_acc,
+                        norm_acc,
+                        r_placeholder,
+                        M,
+                        N,
+                        K,
+                        eps,
+                        tm,
+                        tn,
+                        tk,
+                        split_k,
+                    ),
+                )
+            else:
+                mx_split_k = max(cfg.SPLIT_K for cfg in configs)
+                proj_acc = torch.empty(mx_split_k * M, N, dtype=acc_dtype, device=dev)
+                norm_acc = torch.empty(mx_split_k * M, 1, dtype=acc_dtype, device=dev)
+                # Signature placeholder for autotune launches; not read.
+                r_placeholder = torch.empty(mx_split_k * M, 1, dtype=acc_dtype, device=dev)
+                tuned = ct_experimental.autotune_launch(
+                    stream,
+                    grid_fn=lambda cfg: (math.ceil(M / cfg.TILE_M), cfg.SPLIT_K),
+                    kernel=_ct_proj_rms_fwd_kernel,
+                    args_fn=lambda cfg: (
+                        x,
+                        weight,
+                        proj_acc,
+                        norm_acc,
+                        r_placeholder,
+                        M,
+                        N,
+                        K,
+                        eps,
+                        cfg.TILE_M,
+                        cfg.TILE_N,
+                        cfg.TILE_K,
+                        cfg.SPLIT_K,
+                    ),
+                    search_space=configs,
+                )
+                best = tuned.tuned_config
+                _proj_rms_fwd_best_cfg[cache_key] = (
+                    best.TILE_M,
+                    best.TILE_N,
+                    best.TILE_K,
+                    best.SPLIT_K,
+                )
+                tm, tn, tk, split_k = best.TILE_M, best.TILE_N, best.TILE_K, best.SPLIT_K
+
+                proj_acc = torch.empty(split_k * M, N, dtype=acc_dtype, device=dev)
+                norm_acc = torch.empty(split_k * M, 1, dtype=acc_dtype, device=dev)
+                # Signature placeholder for the cuTile kernel; not read.
+                r_placeholder = torch.empty(split_k * M, 1, dtype=acc_dtype, device=dev)
+                ct.launch(
+                    stream,
+                    (math.ceil(M / tm), split_k),
+                    _ct_proj_rms_fwd_kernel,
+                    (
+                        x,
+                        weight,
+                        proj_acc,
+                        norm_acc,
+                        r_placeholder,
+                        M,
+                        N,
+                        K,
+                        eps,
+                        tm,
+                        tn,
+                        tk,
+                        split_k,
+                    ),
+                )
+
+        # Launch reduce + compute_h kernel
+        h_pre, h_post, h_res, r, proj_reduced = _cutile_reduce_compute_h(
+            proj_acc,
+            norm_acc,
+            bias,
+            alpha_pre,
+            alpha_post,
+            alpha_res,
+            n,
+            M,
+            N,
+            K,
+            eps,
+            compute_h_eps,
+            tm,
+            TILE_N,
+            split_k,
+            torch.promote_types(x.dtype, weight.dtype),
+        )
+        return h_pre, h_post, h_res, r, proj_reduced
+
+    # -- Fused compute_h + proj_rms backward kernels ----------------------------
+
+    @ct.kernel
+    def _ct_fused_grad_h_proj_kernel(
+        GRAD_H_PRE,  # [M, n]
+        GRAD_H_POST,  # [M, n]
+        GRAD_H_RES,  # [M, n*n]
+        H_PRE,  # [M, n]
+        H_POST,  # [M, n]
+        PROJ,  # [M, N]
+        R,  # [M, 1]
+        GRAD_R_EXT,  # [M, 1]
+        Alpha_pre,  # [1]
+        Alpha_post,  # [1]
+        Alpha_res,  # [1]
+        GRAD_H,  # [M, TILE_SIZE_N] output
+        GRAD_PROJ,  # [M, TILE_SIZE_N] output
+        GRAD_R_TOTAL,  # [M, 1] output
+        M: int,
+        N: int,
+        n: ConstInt,
+        eps: float,
+        compute_h_eps: float,
+        TILE_SIZE_M: ConstInt,
+        TILE_SIZE_N: ConstInt,
+        HAS_GRAD_H_PRE: ConstInt,
+        HAS_GRAD_H_POST: ConstInt,
+        HAS_GRAD_H_RES: ConstInt,
+        HAS_GRAD_R_EXT: ConstInt,
+    ):
+        """Precompute grad_h, grad_proj, and grad_r_total for downstream backward kernels.
+
+        Grid: (ceil(M / TILE_SIZE_M),).
+        """
+        tile_m_id = ct.bid(0)
+
+        alpha_pre = ct.load(Alpha_pre, index=(0,), shape=(1,)).item()
+        alpha_post = ct.load(Alpha_post, index=(0,), shape=(1,)).item()
+        alpha_res = ct.load(Alpha_res, index=(0,), shape=(1,)).item()
+
+        r_tile = ct.load(R, index=(tile_m_id, 0), shape=(TILE_SIZE_M, 1), padding_mode=PAD_ZERO)
+        r_tile = ct.astype(r_tile, ct.float32)
+
+        r_eps = r_tile + eps
+        inv_r_eps = 1.0 / r_eps
+        grad_r_from_h = ct.full((TILE_SIZE_M, 1), 0.0, dtype=ct.float32)
+
+        # Clear the padded columns once inside this kernel.  Valid columns are
+        # overwritten by the segment stores below.
+        zero_full = ct.full((TILE_SIZE_M, TILE_SIZE_N), 0.0, dtype=ct.float32)
+        ct.store(GRAD_H, index=(tile_m_id, 0), tile=zero_full.astype(GRAD_H.dtype))
+        ct.store(GRAD_PROJ, index=(tile_m_id, 0), tile=zero_full.astype(GRAD_PROJ.dtype))
+
+        if HAS_GRAD_H_PRE:
+            gy_pre = ct.load(
+                GRAD_H_PRE, index=(tile_m_id, 0), shape=(TILE_SIZE_M, n), padding_mode=PAD_ZERO
+            )
+            gy_pre = ct.astype(gy_pre, ct.float32)
+        else:
+            gy_pre = ct.full((TILE_SIZE_M, n), 0.0, dtype=ct.float32)
+        h_pre = ct.load(H_PRE, index=(tile_m_id, 0), shape=(TILE_SIZE_M, n), padding_mode=PAD_ZERO)
+        h_pre = ct.astype(h_pre, ct.float32)
+        proj_pre = ct.load(
+            PROJ, index=(tile_m_id, 0), shape=(TILE_SIZE_M, n), padding_mode=PAD_ZERO
+        )
+        proj_pre = ct.astype(proj_pre, ct.float32)
+        sigmoid_pre = h_pre - compute_h_eps
+        grad_h_pre = gy_pre * sigmoid_pre * (1.0 - sigmoid_pre)
+        grad_proj_pre = grad_h_pre * alpha_pre * inv_r_eps
+        grad_r_from_h += ct.sum(
+            grad_h_pre * proj_pre * alpha_pre * (-inv_r_eps * inv_r_eps), axis=1, keepdims=True
+        )
+        ct.store(GRAD_H, index=(tile_m_id, 0), tile=grad_h_pre.astype(GRAD_H.dtype))
+        ct.store(GRAD_PROJ, index=(tile_m_id, 0), tile=grad_proj_pre.astype(GRAD_PROJ.dtype))
+
+        if HAS_GRAD_H_POST:
+            gy_post = ct.load(
+                GRAD_H_POST, index=(tile_m_id, 0), shape=(TILE_SIZE_M, n), padding_mode=PAD_ZERO
+            )
+            gy_post = ct.astype(gy_post, ct.float32)
+        else:
+            gy_post = ct.full((TILE_SIZE_M, n), 0.0, dtype=ct.float32)
+        h_post = ct.load(
+            H_POST, index=(tile_m_id, 0), shape=(TILE_SIZE_M, n), padding_mode=PAD_ZERO
+        )
+        h_post = ct.astype(h_post, ct.float32)
+        proj_post = ct.load(
+            PROJ, index=(tile_m_id, 1), shape=(TILE_SIZE_M, n), padding_mode=PAD_ZERO
+        )
+        proj_post = ct.astype(proj_post, ct.float32)
+        sigmoid_post = h_post * 0.5
+        grad_h_post = gy_post * sigmoid_post * (1.0 - sigmoid_post) * 2.0
+        grad_proj_post = grad_h_post * alpha_post * inv_r_eps
+        grad_r_from_h += ct.sum(
+            grad_h_post * proj_post * alpha_post * (-inv_r_eps * inv_r_eps), axis=1, keepdims=True
+        )
+        ct.store(GRAD_H, index=(tile_m_id, 1), tile=grad_h_post.astype(GRAD_H.dtype))
+        ct.store(GRAD_PROJ, index=(tile_m_id, 1), tile=grad_proj_post.astype(GRAD_PROJ.dtype))
+
+        for res_chunk in ct.static_iter(range(n)):
+            if HAS_GRAD_H_RES:
+                grad_h_res = ct.load(
+                    GRAD_H_RES,
+                    index=(tile_m_id, res_chunk),
+                    shape=(TILE_SIZE_M, n),
+                    padding_mode=PAD_ZERO,
+                )
+                grad_h_res = ct.astype(grad_h_res, ct.float32)
+            else:
+                grad_h_res = ct.full((TILE_SIZE_M, n), 0.0, dtype=ct.float32)
+            proj_res = ct.load(
+                PROJ,
+                index=(tile_m_id, 2 + res_chunk),
+                shape=(TILE_SIZE_M, n),
+                padding_mode=PAD_ZERO,
+            )
+            proj_res = ct.astype(proj_res, ct.float32)
+            grad_proj_res = grad_h_res * alpha_res * inv_r_eps
+            grad_r_from_h += ct.sum(
+                grad_h_res * proj_res * alpha_res * (-inv_r_eps * inv_r_eps), axis=1, keepdims=True
+            )
+            ct.store(GRAD_H, index=(tile_m_id, 2 + res_chunk), tile=grad_h_res.astype(GRAD_H.dtype))
+            ct.store(
+                GRAD_PROJ,
+                index=(tile_m_id, 2 + res_chunk),
+                tile=grad_proj_res.astype(GRAD_PROJ.dtype),
+            )
+
+        if HAS_GRAD_R_EXT:
+            grad_r_ext_tile = ct.load(
+                GRAD_R_EXT, index=(tile_m_id, 0), shape=(TILE_SIZE_M, 1), padding_mode=PAD_ZERO
+            )
+            grad_r_ext_tile = ct.astype(grad_r_ext_tile, ct.float32)
+        else:
+            grad_r_ext_tile = ct.full((TILE_SIZE_M, 1), 0.0, dtype=ct.float32)
+        grad_r_total = grad_r_from_h + grad_r_ext_tile
+
+        ct.store(GRAD_R_TOTAL, index=(tile_m_id, 0), tile=grad_r_total.astype(GRAD_R_TOTAL.dtype))
+
+    @ct.kernel
+    def _ct_fused_grad_x_weight_kernel(
+        X,  # [M, K]
+        WEIGHT,  # [N, K]
+        GRAD_PROJ,  # [M, TILE_SIZE_N] precomputed
+        GRAD_R_TOTAL,  # [M, 1] precomputed
+        R,  # [M, 1]
+        GRAD_X,  # [M, K] output
+        GRAD_WEIGHT,  # [N, K] output
+        M: int,
+        N: int,
+        K: int,
+        TILE_SIZE_M: ConstInt,
+        TILE_SIZE_N: ConstInt,
+        TILE_SIZE_K: ConstInt,
+    ):
+        """Compute grad_x and grad_weight simultaneously.
+
+        Grid: (ceil(K / TILE_SIZE_K),).
+        Each block handles one K-tile and loops over all M-tiles.
+        Per M-tile: computes and stores grad_x, accumulates grad_weight.
+        """
+        tile_k_id = ct.bid(0)
+        NUM_M_TILES = ct.cdiv(M, TILE_SIZE_M)
+
+        # Load weight tile once — only depends on K-tile
+        weight_tile = ct.load(
+            WEIGHT, index=(0, tile_k_id), shape=(TILE_SIZE_N, TILE_SIZE_K), padding_mode=PAD_ZERO
+        )
+
+        acc_grad_weight = ct.full((TILE_SIZE_K, TILE_SIZE_N), 0.0, dtype=ct.float32)
+
+        for tile_m_id in range(NUM_M_TILES):
+            grad_proj_tile = ct.load(
+                GRAD_PROJ,
+                index=(tile_m_id, 0),
+                shape=(TILE_SIZE_M, TILE_SIZE_N),
+                padding_mode=PAD_ZERO,
+            )
+            x_tile = ct.load(
+                X,
+                index=(tile_m_id, tile_k_id),
+                shape=(TILE_SIZE_M, TILE_SIZE_K),
+                padding_mode=PAD_ZERO,
+            )
+            grad_r_total = ct.load(
+                GRAD_R_TOTAL, index=(tile_m_id, 0), shape=(TILE_SIZE_M, 1), padding_mode=PAD_ZERO
+            )
+            r_tile = ct.load(R, index=(tile_m_id, 0), shape=(TILE_SIZE_M, 1), padding_mode=PAD_ZERO)
+            r_tile = ct.astype(r_tile, ct.float32)
+
+            # grad_x = grad_proj @ weight + grad_r_total * x / (r * K)
+            inv_rK = 1.0 / (r_tile * K)
+            acc_grad_x = (grad_r_total * inv_rK) * ct.astype(x_tile, ct.float32)
+            acc_grad_x = ct.mma(
+                grad_proj_tile.astype(ct.tfloat32), weight_tile.astype(ct.tfloat32), acc=acc_grad_x
+            )
+            ct.store(GRAD_X, index=(tile_m_id, tile_k_id), tile=acc_grad_x.astype(GRAD_X.dtype))
+
+            # Accumulate grad_weight += x.T @ grad_proj
+            acc_grad_weight = ct.mma(
+                x_tile.transpose().astype(ct.tfloat32),
+                grad_proj_tile.astype(ct.tfloat32),
+                acc=acc_grad_weight,
+            )
+
+        ct.store(
+            GRAD_WEIGHT,
+            index=(0, tile_k_id),
+            tile=acc_grad_weight.transpose().astype(GRAD_WEIGHT.dtype),
+        )
+
+    @ct.kernel
+    def _ct_scalar_grads_partials_kernel(
+        GRAD_H,  # [M, TILE_SIZE_N] precomputed
+        PROJ,  # [M, N]
+        R,  # [M, 1]
+        GRAD_ALPHA_PRE_PARTIALS,  # [num_m_blocks, 1] output
+        GRAD_ALPHA_POST_PARTIALS,  # [num_m_blocks, 1] output
+        GRAD_ALPHA_RES_PARTIALS,  # [num_m_blocks, 1] output
+        GRAD_BIAS_PARTIALS,  # [num_m_blocks, TILE_SIZE_N] output
+        M: int,
+        N: int,
+        n: int,
+        eps: float,
+        TILE_SIZE_M: ConstInt,
+        TILE_SIZE_N: ConstInt,
+    ):
+        """Compute per-M-tile scalar-gradient partials.
+
+        Grid: (ceil(M / TILE_SIZE_M),).  Each block processes one M-tile.
+        """
+        bid_m = ct.bid(0)
+
+        offsets = ct.arange(TILE_SIZE_N, dtype=ct.int32)
+        one = ct.full((TILE_SIZE_N,), 1.0, dtype=ct.float32)
+        zero = ct.full((TILE_SIZE_N,), 0.0, dtype=ct.float32)
+        mask_pre = ct.where(ct.less(offsets, n), one, zero)
+        mask_post = ct.where(ct.less(offsets, 2 * n), one, zero) - mask_pre
+        mask_res = one - mask_pre - mask_post
+
+        mask_pre_2d = ct.reshape(mask_pre, (1, TILE_SIZE_N))
+        mask_post_2d = ct.reshape(mask_post, (1, TILE_SIZE_N))
+        mask_res_2d = ct.reshape(mask_res, (1, TILE_SIZE_N))
+
+        grad_h = ct.load(
+            GRAD_H, index=(bid_m, 0), shape=(TILE_SIZE_M, TILE_SIZE_N), padding_mode=PAD_ZERO
+        )
+        proj_tile = ct.load(
+            PROJ, index=(bid_m, 0), shape=(TILE_SIZE_M, TILE_SIZE_N), padding_mode=PAD_ZERO
+        )
+        proj_tile = ct.astype(proj_tile, ct.float32)
+        r_tile = ct.load(R, index=(bid_m, 0), shape=(TILE_SIZE_M, 1), padding_mode=PAD_ZERO)
+        r_tile = ct.astype(r_tile, ct.float32)
+
+        r_eps = r_tile + eps
+        inv_r_eps = 1.0 / r_eps
+
+        ga_all = grad_h * proj_tile * inv_r_eps
+        ga_pre = ct.reshape(ct.sum(ga_all * mask_pre_2d), (1, 1))
+        ga_post = ct.reshape(ct.sum(ga_all * mask_post_2d), (1, 1))
+        ga_res = ct.reshape(ct.sum(ga_all * mask_res_2d), (1, 1))
+        partial_gb = ct.sum(grad_h, axis=0, keepdims=False)
+        ct.store(
+            GRAD_ALPHA_PRE_PARTIALS,
+            index=(bid_m, 0),
+            tile=ga_pre.astype(GRAD_ALPHA_PRE_PARTIALS.dtype),
+        )
+        ct.store(
+            GRAD_ALPHA_POST_PARTIALS,
+            index=(bid_m, 0),
+            tile=ga_post.astype(GRAD_ALPHA_POST_PARTIALS.dtype),
+        )
+        ct.store(
+            GRAD_ALPHA_RES_PARTIALS,
+            index=(bid_m, 0),
+            tile=ga_res.astype(GRAD_ALPHA_RES_PARTIALS.dtype),
+        )
+        ct.store(
+            GRAD_BIAS_PARTIALS,
+            index=(bid_m, 0),
+            tile=ct.reshape(partial_gb, (1, TILE_SIZE_N)).astype(GRAD_BIAS_PARTIALS.dtype),
+        )
+
+    @ct.kernel
+    def _ct_scalar_grads_reduce_kernel(
+        GRAD_ALPHA_PRE_PARTIALS,  # [num_m_blocks, 1]
+        GRAD_ALPHA_POST_PARTIALS,  # [num_m_blocks, 1]
+        GRAD_ALPHA_RES_PARTIALS,  # [num_m_blocks, 1]
+        GRAD_BIAS_PARTIALS,  # [num_m_blocks, TILE_SIZE_N]
+        GRAD_ALPHA_PRE,  # [1, 1] output
+        GRAD_ALPHA_POST,  # [1, 1] output
+        GRAD_ALPHA_RES,  # [1, 1] output
+        GRAD_BIAS,  # [1, TILE_SIZE_N] output
+        NUM_M_BLOCKS: int,
+        TILE_SIZE_N: ConstInt,
+    ):
+        """Reduce scalar-gradient partials and write final dtype outputs."""
+        acc_pre = ct.full((1, 1), 0.0, dtype=ct.float32)
+        acc_post = ct.full((1, 1), 0.0, dtype=ct.float32)
+        acc_res = ct.full((1, 1), 0.0, dtype=ct.float32)
+        acc_bias = ct.full((1, TILE_SIZE_N), 0.0, dtype=ct.float32)
+
+        for bid_m in range(NUM_M_BLOCKS):
+            acc_pre += ct.load(
+                GRAD_ALPHA_PRE_PARTIALS, index=(bid_m, 0), shape=(1, 1), padding_mode=PAD_ZERO
+            ).astype(ct.float32)
+            acc_post += ct.load(
+                GRAD_ALPHA_POST_PARTIALS, index=(bid_m, 0), shape=(1, 1), padding_mode=PAD_ZERO
+            ).astype(ct.float32)
+            acc_res += ct.load(
+                GRAD_ALPHA_RES_PARTIALS, index=(bid_m, 0), shape=(1, 1), padding_mode=PAD_ZERO
+            ).astype(ct.float32)
+            acc_bias += ct.load(
+                GRAD_BIAS_PARTIALS, index=(bid_m, 0), shape=(1, TILE_SIZE_N), padding_mode=PAD_ZERO
+            ).astype(ct.float32)
+
+        ct.store(GRAD_ALPHA_PRE, index=(0, 0), tile=acc_pre.astype(GRAD_ALPHA_PRE.dtype))
+        ct.store(GRAD_ALPHA_POST, index=(0, 0), tile=acc_post.astype(GRAD_ALPHA_POST.dtype))
+        ct.store(GRAD_ALPHA_RES, index=(0, 0), tile=acc_res.astype(GRAD_ALPHA_RES.dtype))
+        ct.store(GRAD_BIAS, index=(0, 0), tile=acc_bias.astype(GRAD_BIAS.dtype))
+
+    @ct.kernel
+    def _ct_fused_compute_h_proj_rms_bwd_small_k_kernel(
+        X,  # [M, K]
+        WEIGHT,  # [N, K]
+        GRAD_PROJ,  # [M, TILE_N] precomputed
+        GRAD_R_TOTAL,  # [M, 1] precomputed
+        R,  # [M, 1]
+        GRAD_X,  # [M, K] output
+        GRAD_WEIGHT,  # [N, K] output
+        M: int,
+        N: int,
+        K: int,
+        TILE_N_SIZE: ConstInt,
+    ):
+        """Fused backward (small K path) with work-stealing.
+
+        Grid: (num_sms, 2).
+        bid(1)==0: grad_weight via work-stealing over K-tiles, loops M.
+        bid(1)==1: grad_x via work-stealing over (M×K) tiles.
+        Scalar gradients are computed by the separate partial/reduce kernels.
+        """
+        zero_pad = ct.PaddingMode.ZERO
+
+        TILE_DB_SIZE_M = 128
+        TILE_DB_SIZE_K = 64
+        NUM_M_TILES = ct.cdiv(M, TILE_DB_SIZE_M)
+        NUM_K_TILES = ct.cdiv(K, TILE_DB_SIZE_K)
+
+        if ct.bid(1) == 0:
+            # --- grad_weight path ---
+            for tile_id in range(ct.bid(0), NUM_K_TILES, ct.num_blocks(0)):
+                accumulator_db = ct.full((TILE_DB_SIZE_K, TILE_N_SIZE), 0.0, dtype=ct.float32)
+                for m_tile in range(NUM_M_TILES):
+                    x_tile = ct.load(
+                        X,
+                        index=(m_tile, tile_id),
+                        shape=(TILE_DB_SIZE_M, TILE_DB_SIZE_K),
+                        padding_mode=zero_pad,
+                    )
+                    grad_proj_tile = ct.load(
+                        GRAD_PROJ,
+                        index=(m_tile, 0),
+                        shape=(TILE_DB_SIZE_M, TILE_N_SIZE),
+                        padding_mode=zero_pad,
+                    )
+
+                    accumulator_db = ct.mma(
+                        x_tile.transpose().astype(ct.tfloat32),
+                        grad_proj_tile.astype(ct.tfloat32),
+                        acc=accumulator_db,
+                    )
+
+                ct.store(
+                    GRAD_WEIGHT,
+                    index=(0, tile_id),
+                    tile=accumulator_db.transpose().astype(GRAD_WEIGHT.dtype),
+                    allow_tma=False,
+                )
+
+        TILE_DA_SIZE_M = 128
+        TILE_DA_SIZE_K = 256
+        NUM_DA_TILES = ct.cdiv(M, TILE_DA_SIZE_M) * ct.cdiv(K, TILE_DA_SIZE_K)
+        NUM_DA_K_TILES = ct.cdiv(K, TILE_DA_SIZE_K)
+
+        if ct.bid(1) == 1:
+            # --- grad_x path ---
+            for tile_id in range(ct.bid(0), NUM_DA_TILES, ct.num_blocks(0)):
+                b_tile_idx = tile_id % NUM_DA_K_TILES
+                dd_tile_idx = tile_id // NUM_DA_K_TILES
+
+                grad_proj_tile = ct.load(
+                    GRAD_PROJ,
+                    index=(dd_tile_idx, 0),
+                    shape=(TILE_DA_SIZE_M, TILE_N_SIZE),
+                    padding_mode=zero_pad,
+                )
+                grad_r_total = ct.load(
+                    GRAD_R_TOTAL,
+                    index=(dd_tile_idx, 0),
+                    shape=(TILE_DA_SIZE_M, 1),
+                    padding_mode=zero_pad,
+                )
+                r_tile = ct.load(
+                    R, index=(dd_tile_idx, 0), shape=(TILE_DA_SIZE_M, 1), padding_mode=zero_pad
+                )
+                r_tile = ct.astype(r_tile, ct.float32)
+
+                x_tile = ct.load(
+                    X,
+                    index=(dd_tile_idx, b_tile_idx),
+                    shape=(TILE_DA_SIZE_M, TILE_DA_SIZE_K),
+                    padding_mode=zero_pad,
+                )
+                inv_rK = 1.0 / (r_tile * K)
+                accumulator_da = (grad_r_total * inv_rK) * ct.astype(x_tile, ct.float32)
+
+                weight_tile = ct.load(
+                    WEIGHT,
+                    index=(0, b_tile_idx),
+                    shape=(TILE_N_SIZE, TILE_DA_SIZE_K),
+                    padding_mode=zero_pad,
+                )
+                accumulator_da = ct.mma(
+                    grad_proj_tile.astype(ct.tfloat32),
+                    weight_tile.astype(ct.tfloat32),
+                    acc=accumulator_da,
+                )
+                ct.store(
+                    GRAD_X,
+                    index=(dd_tile_idx, b_tile_idx),
+                    tile=accumulator_da.astype(GRAD_X.dtype),
+                )
+
+    def _fused_grad_x_weight_autotune_configs(N):
+        """Autotune search space for fused grad_x + grad_weight kernel."""
+        TILE_N = _next_power_of_2(N)
+        tile_ms = (32, 64, 128)
+        tile_ks = (32, 64, 128, 256)
+        for tile_m in tile_ms:
+            for tile_k in tile_ks:
+                yield {"TILE_SIZE_M": tile_m, "TILE_SIZE_N": TILE_N, "TILE_SIZE_K": tile_k}
+
+    _fused_grad_x_weight_best_cfg: dict = {}
+
+    def _cutile_fused_compute_h_proj_rms_bwd(
+        x: Tensor,
+        weight: Tensor,
+        grad_h_pre: Tensor,
+        grad_h_post: Tensor,
+        grad_h_res: Tensor,
+        h_pre: Tensor,
+        h_post: Tensor,
+        h_res: Tensor,
+        proj: Tensor,
+        r: Tensor,
+        grad_r_ext: Tensor,
+        alpha_pre: Tensor,
+        alpha_post: Tensor,
+        alpha_res: Tensor,
+        bias: Tensor,
+        n: int,
+        eps: float,
+        compute_h_eps: float,
+    ) -> Tuple[Tensor, Tensor, Tensor, Tensor, Tensor, Tensor]:
+        """Fused compute_h + proj_rms backward.
+
+        Returns:
+            grad_x: [M, K]
+            grad_weight: [N, K]
+            grad_alpha_pre: [1]
+            grad_alpha_post: [1]
+            grad_alpha_res: [1]
+            grad_bias: [N]
+        """
+        M, K = x.shape
+        N = weight.shape[0]
+        TILE_N = _next_power_of_2(N)
+        assert TILE_N <= 256, f"TILE_SIZE_N too large: {TILE_N}"
+        dev = x.device
+        stream = torch.cuda.current_stream()
+
+        grad_x = torch.empty_like(x)
+        grad_weight = torch.empty_like(weight)
+        has_grad_r_ext = grad_r_ext is not None
+        has_grad_r_ext_flag = int(has_grad_r_ext)
+        grad_r_ext_arg = grad_r_ext if has_grad_r_ext else r
+        has_grad_h_pre = grad_h_pre is not None
+        has_grad_h_post = grad_h_post is not None
+        has_grad_h_res = grad_h_res is not None
+        grad_h_pre_arg = grad_h_pre if has_grad_h_pre else h_pre
+        grad_h_post_arg = grad_h_post if has_grad_h_post else h_post
+        grad_h_res_arg = grad_h_res if has_grad_h_res else h_res
+
+        # 0. Precompute grad_h, grad_proj, grad_r_total
+        grad_h_buf = torch.empty(M, TILE_N, dtype=torch.float32, device=dev)
+        grad_proj_buf = torch.empty(M, TILE_N, dtype=torch.float32, device=dev)
+        grad_r_total_buf = torch.empty(M, 1, dtype=torch.float32, device=dev)
+
+        tile_m_precomp = _default_tile_m(M)
+        ct.launch(
+            stream,
+            (math.ceil(M / tile_m_precomp),),
+            _ct_fused_grad_h_proj_kernel,
+            (
+                grad_h_pre_arg,
+                grad_h_post_arg,
+                grad_h_res_arg,
+                h_pre,
+                h_post,
+                proj,
+                r,
+                grad_r_ext_arg,
+                alpha_pre,
+                alpha_post,
+                alpha_res,
+                grad_h_buf,
+                grad_proj_buf,
+                grad_r_total_buf,
+                M,
+                N,
+                n,
+                eps,
+                compute_h_eps,
+                tile_m_precomp,
+                TILE_N,
+                int(has_grad_h_pre),
+                int(has_grad_h_post),
+                int(has_grad_h_res),
+                has_grad_r_ext_flag,
+            ),
+        )
+
+        if K >= 8192:
+            # 1. Fused grad_x + grad_weight kernel — 1D grid (K-tiles), loops M
+            cache_key = ('grad_x_weight', M, N, K)
+            cached = _fused_grad_x_weight_best_cfg.get(cache_key)
+
+            if cached is not None or not _CUTILE_EXPERIMENTAL_AVAILABLE:
+                if cached is not None:
+                    tm, tn, tk = cached
+                else:
+                    tm, tn, tk = 128, TILE_N, 128
+                ct.launch(
+                    stream,
+                    (math.ceil(K / tk),),
+                    _ct_fused_grad_x_weight_kernel,
+                    (
+                        x,
+                        weight,
+                        grad_proj_buf,
+                        grad_r_total_buf,
+                        r,
+                        grad_x,
+                        grad_weight,
+                        M,
+                        N,
+                        K,
+                        tm,
+                        tn,
+                        tk,
+                    ),
+                )
+            else:
+                from types import SimpleNamespace
+
+                configs = [SimpleNamespace(**c) for c in _fused_grad_x_weight_autotune_configs(N)]
+                tuned = ct_experimental.autotune_launch(
+                    stream,
+                    grid_fn=lambda cfg: (math.ceil(K / cfg.TILE_SIZE_K),),
+                    kernel=_ct_fused_grad_x_weight_kernel,
+                    args_fn=lambda cfg: (
+                        x,
+                        weight,
+                        grad_proj_buf,
+                        grad_r_total_buf,
+                        r,
+                        grad_x,
+                        grad_weight,
+                        M,
+                        N,
+                        K,
+                        cfg.TILE_SIZE_M,
+                        cfg.TILE_SIZE_N,
+                        cfg.TILE_SIZE_K,
+                    ),
+                    search_space=configs,
+                )
+                best = tuned.tuned_config
+                _fused_grad_x_weight_best_cfg[cache_key] = (
+                    best.TILE_SIZE_M,
+                    best.TILE_SIZE_N,
+                    best.TILE_SIZE_K,
+                )
+                ct.launch(
+                    stream,
+                    (math.ceil(K / best.TILE_SIZE_K),),
+                    _ct_fused_grad_x_weight_kernel,
+                    (
+                        x,
+                        weight,
+                        grad_proj_buf,
+                        grad_r_total_buf,
+                        r,
+                        grad_x,
+                        grad_weight,
+                        M,
+                        N,
+                        K,
+                        best.TILE_SIZE_M,
+                        best.TILE_SIZE_N,
+                        best.TILE_SIZE_K,
+                    ),
+                )
+        else:
+            num_sms = torch.cuda.get_device_properties("cuda").multi_processor_count
+            ct.launch(
+                stream,
+                (num_sms, 2, 1),
+                _ct_fused_compute_h_proj_rms_bwd_small_k_kernel,
+                (
+                    x,
+                    weight,
+                    grad_proj_buf,
+                    grad_r_total_buf,
+                    r,
+                    grad_x,
+                    grad_weight,
+                    M,
+                    N,
+                    K,
+                    TILE_N,
+                ),
+            )
+
+        # 2. Separate lightweight kernel for scalar gradients (grad_alpha, grad_bias)
+        tile_m_scalar = min(128, M)
+        num_m_blocks = math.ceil(M / tile_m_scalar)
+        grad_alpha_pre_partials = torch.empty(num_m_blocks, 1, dtype=torch.float32, device=dev)
+        grad_alpha_post_partials = torch.empty(num_m_blocks, 1, dtype=torch.float32, device=dev)
+        grad_alpha_res_partials = torch.empty(num_m_blocks, 1, dtype=torch.float32, device=dev)
+        grad_bias_partials = torch.empty(num_m_blocks, TILE_N, dtype=torch.float32, device=dev)
+        grad_alpha_pre = torch.empty(1, 1, dtype=alpha_pre.dtype, device=dev)
+        grad_alpha_post = torch.empty(1, 1, dtype=alpha_post.dtype, device=dev)
+        grad_alpha_res = torch.empty(1, 1, dtype=alpha_res.dtype, device=dev)
+        grad_bias = torch.empty(1, TILE_N, dtype=bias.dtype, device=dev)
+
+        ct.launch(
+            stream,
+            (num_m_blocks,),
+            _ct_scalar_grads_partials_kernel,
+            (
+                grad_h_buf,
+                proj,
+                r,
+                grad_alpha_pre_partials,
+                grad_alpha_post_partials,
+                grad_alpha_res_partials,
+                grad_bias_partials,
+                M,
+                N,
+                n,
+                eps,
+                tile_m_scalar,
+                TILE_N,
+            ),
+        )
+        ct.launch(
+            stream,
+            (1,),
+            _ct_scalar_grads_reduce_kernel,
+            (
+                grad_alpha_pre_partials,
+                grad_alpha_post_partials,
+                grad_alpha_res_partials,
+                grad_bias_partials,
+                grad_alpha_pre,
+                grad_alpha_post,
+                grad_alpha_res,
+                grad_bias,
+                num_m_blocks,
+                TILE_N,
+            ),
+        )
+
+        return (
+            grad_x,
+            grad_weight,
+            grad_alpha_pre.view_as(alpha_pre),
+            grad_alpha_post.view_as(alpha_post),
+            grad_alpha_res.view_as(alpha_res),
+            grad_bias.view(-1)[:N],
+        )
+
+
+# ============================================================================
+# Unified public dispatch
+# ============================================================================
+# The public fused API chooses the fastest validated backend per operation:
+#
+#   sinkhorn fwd/bwd:       Triton -> cuTile -> torch
+#   h_post_bda fwd/bwd:     Triton -> cuTile -> torch
+#   h_aggregate fwd:        Triton -> cuTile -> torch
+#   h_aggregate bwd:        cuTile -> torch
+#   proj_rms/proj_rms_compute_h: cuTile -> torch
+#
+# Runtime CUDA launch failures are intentionally not swallowed; after such an
+# error the CUDA context may not be safely reusable for fallback work.
+# ============================================================================
+
+from megatron.core.transformer.hyper_connection import (
+    native_fused_add_3,
+    native_h_aggregate,
+    native_h_post_bda,
+    native_sinkhorn,
+)
+
+_BACKEND_INFO_LOGGED = False
+
+
+def _select_triton_cutile_native(triton_impl) -> str:
+    if triton_impl is not None:
+        return "triton"
+    if is_cutile_available():
+        return "cutile"
+    return "native"
+
+
+def _mhc_backend_status() -> Tuple[str, bool]:
+    """Return backend description and whether every backend is native."""
+    sinkhorn = _select_triton_cutile_native(_get_triton_sinkhorn())
+    h_aggregate_fwd = _select_triton_cutile_native(_get_triton_h_aggregate_fwd())
+    h_aggregate_bwd = "cutile" if is_cutile_available() else "native"
+    h_post_bda_fwd = _select_triton_cutile_native(_get_triton_h_post_bda_fwd())
+    h_post_bda_bwd = _select_triton_cutile_native(_get_triton_h_post_bda_bwd())
+    proj_rms_compute_h = "cutile" if is_cutile_available() else "native"
+    selected = (
+        sinkhorn,
+        h_aggregate_fwd,
+        h_aggregate_bwd,
+        h_post_bda_fwd,
+        h_post_bda_bwd,
+        proj_rms_compute_h,
+    )
+    message = (
+        f"MHC_FORCE_BACKEND={_MHC_FORCED_BACKEND}; "
+        f"sinkhorn={sinkhorn}; "
+        f"h_aggregate=fwd:{h_aggregate_fwd},bwd:{h_aggregate_bwd}; "
+        f"h_post_bda=fwd:{h_post_bda_fwd},bwd:{h_post_bda_bwd}; "
+        f"proj_rms_compute_h={proj_rms_compute_h}"
+    )
+    return message, all(backend == "native" for backend in selected)
+
+
+def _mhc_backend_selection() -> str:
+    """Return a concise description of the selected mHC fused backends."""
+    message, _ = _mhc_backend_status()
+    return message
+
+
+def log_fused_mhc_backend_once() -> None:
+    """Log the fused mHC backend selection once per process."""
+    _raise_mhc_backend_validation_error()
+    global _BACKEND_INFO_LOGGED
+    if _BACKEND_INFO_LOGGED:
+        return
+    _BACKEND_INFO_LOGGED = True
+    backend_selection, all_native = _mhc_backend_status()
+    log_single_rank(
+        logger,
+        logging.WARNING if all_native else logging.INFO,
+        f"[mHC] fused backend selection: {backend_selection}",
+    )
+    if all_native and safe_get_rank() == 0:
+        warnings.warn(
+            "[mHC] No accelerated mHC backend is available; falling back to native torch "
+            "implementations. The fallback is functionally equivalent, but may not provide "
+            "the performance benefits of fused mHC backends.",
+            UserWarning,
+            stacklevel=2,
+        )
+
+
+def fused_add_3(a: Tensor, b: Tensor, c: Tensor) -> Tensor:
+    """Add three tensors using the native torch.compile-backed implementation."""
+    return native_fused_add_3(a, b, c)
+
+
+def _get_triton_sinkhorn():
+    if not _TRITON_AVAILABLE:
+        return None
+    return _TRITON_IMPLS["sinkhorn"]
+
+
+def _get_triton_h_aggregate_fwd():
+    if not _TRITON_AVAILABLE:
+        return None
+    return _TRITON_IMPLS["h_aggregate_fwd"]
+
+
+def _get_triton_h_post_bda_fwd():
+    if not _TRITON_AVAILABLE:
+        return None
+    return _TRITON_IMPLS["h_post_bda_fwd"]
+
+
+def _get_triton_h_post_bda_bwd():
+    if not _TRITON_AVAILABLE:
+        return None
+    return _TRITON_IMPLS["h_post_bda_bwd"]
+
+
+def _torch_h_aggregate_bwd(grad_output: Tensor, x: Tensor, h_pre: Tensor) -> Tuple[Tensor, Tensor]:
+    grad_output_expanded = grad_output.unsqueeze(2)
+    grad_x = grad_output_expanded * h_pre.unsqueeze(-1)
+    grad_h = torch.sum(grad_output_expanded * x, dim=-1)
+    return grad_x.to(dtype=x.dtype), grad_h.to(dtype=h_pre.dtype)
+
+
+@torch.compile
+def _torch_h_post_bda_bwd(
+    grad_output: Tensor,
+    h_res: Tensor,
+    original_residual: Tensor,
+    h_post: Tensor,
+    x: Tensor,
+    bias: Optional[Tensor],
+) -> Tuple[Tensor, Tensor, Tensor, Tensor, Optional[Tensor]]:
+    s, b, n, C = original_residual.shape
+    sb = s * b
+    go = grad_output.reshape(sb, n, C)
+    hr = h_res.reshape(sb, n, n)
+    orig = original_residual.reshape(sb, n, C)
+    hp = h_post.reshape(sb, n)
+    x_flat = x.reshape(sb, C)
+
+    g_hr = torch.bmm(orig, go.transpose(1, 2)).view(s, b, n, n)
+    g_res = torch.bmm(hr, go).view(s, b, n, C)
+    g_x = torch.sum(go * hp.unsqueeze(-1), dim=1).view(s, b, C)
+    xb = x_flat if bias is None else x_flat + bias.view(1, C)
+    g_hp = torch.sum(go * xb.unsqueeze(1), dim=2).view(s, b, n)
+    g_bias = g_x.reshape(sb, C).sum(dim=0).to(dtype=bias.dtype) if bias is not None else None
+    return (
+        g_hr.to(dtype=h_res.dtype),
+        g_res.to(dtype=original_residual.dtype),
+        g_hp.to(dtype=h_post.dtype),
+        g_x.to(dtype=x.dtype),
+        g_bias,
+    )
+
+
+@torch.compile
+def _torch_proj_rms_compute_h(
+    x: Tensor,
+    weight: Tensor,
+    alpha_pre: Tensor,
+    alpha_post: Tensor,
+    alpha_res: Tensor,
+    bias: Tensor,
+    n: int,
+    eps: float,
+    compute_h_eps: float = 1e-6,
+) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
+    # compute_mappings() hands us activations in the activation dtype while the
+    # mapping parameters are keep_in_fp32, so matmul would reject the pair.
+    # Compute in the wider of the two, matching the unfused path's fp32 upcast
+    # without letting a lower-precision parameter downcast the activations.
+    x = x.to(torch.promote_types(x.dtype, weight.dtype))
+    proj = torch.matmul(x, weight.t())
+    r = x.norm(dim=-1, keepdim=True) / math.sqrt(x.shape[-1])
+    alpha = torch.cat(
+        [alpha_pre.expand(n), alpha_post.expand(n), alpha_res.expand(weight.shape[0] - 2 * n)],
+        dim=-1,
+    )
+    h = proj * alpha.unsqueeze(0) / (r + eps) + bias.unsqueeze(0)
+    h_pre = h[..., :n].sigmoid() + compute_h_eps
+    h_post = h[..., n : 2 * n].sigmoid() * 2
+    h_res = h[..., 2 * n :]
+    return h_pre, h_post, h_res, r
+
+
+if _CUTILE_AVAILABLE:
+
+    class CutileSinkhornKnopp(torch.autograd.Function):
+        """cuTile Sinkhorn-Knopp projection fallback."""
+
+        @staticmethod
+        def forward(ctx, input_logits: Tensor, num_iterations: int, eps: float = 1e-6):
+            """Run cuTile Sinkhorn forward and save initial matrix for backward."""
+            output, M_init = _cutile_sinkhorn_fwd(input_logits, num_iterations, eps)
+            ctx.save_for_backward(M_init)
+            ctx.num_iterations = num_iterations
+            ctx.eps = eps
+            return output
+
+        @staticmethod
+        def backward(ctx, grad_output):
+            """Run cuTile Sinkhorn backward."""
+            (M_init,) = ctx.saved_tensors
+            grad_input = _cutile_sinkhorn_bwd(grad_output, M_init, ctx.num_iterations, ctx.eps)
+            return grad_input, None, None
+
+    class CutileHAggregate(torch.autograd.Function):
+        """cuTile n-stream weighted aggregation."""
+
+        @staticmethod
+        def forward(ctx, x: Tensor, h_pre: Tensor):
+            """Run cuTile h_aggregate forward."""
+            output = _cutile_h_aggregate_fwd(x, h_pre)
+            ctx.save_for_backward(x, h_pre)
+            return output
+
+        @staticmethod
+        def backward(ctx, grad_output):
+            """Run cuTile h_aggregate backward."""
+            x, h_pre = ctx.saved_tensors
+            return _cutile_h_aggregate_bwd(grad_output, x, h_pre)
+
+    class CutileProjRmsComputeH(torch.autograd.Function):
+        """cuTile projection + RMS norm + compute_h activations."""
+
+        @staticmethod
+        def forward(
+            ctx,
+            x: Tensor,
+            weight: Tensor,
+            alpha_pre: Tensor,
+            alpha_post: Tensor,
+            alpha_res: Tensor,
+            bias: Tensor,
+            n: int,
+            eps: float = 1e-6,
+            compute_h_eps: float = 1e-6,
+        ):
+            """Run fused cuTile projection, RMS normalization, and compute_h forward."""
+            h_pre, h_post, h_res, r, proj_reduced = _cutile_proj_rms_compute_h_fwd(
+                x, weight, bias, alpha_pre, alpha_post, alpha_res, n, eps, compute_h_eps
+            )
+            ctx.save_for_backward(
+                x,
+                weight,
+                h_pre,
+                h_post,
+                h_res,
+                proj_reduced,
+                r,
+                alpha_pre,
+                alpha_post,
+                alpha_res,
+                bias,
+            )
+            ctx.n = n
+            ctx.eps = eps
+            ctx.compute_h_eps = compute_h_eps
+            return h_pre, h_post, h_res, r
+
+        @staticmethod
+        def backward(ctx, grad_h_pre, grad_h_post, grad_h_res, grad_r_ext):
+            """Run fused cuTile projection, RMS normalization, and compute_h backward."""
+            (
+                x,
+                weight,
+                h_pre,
+                h_post,
+                h_res,
+                proj,
+                r,
+                alpha_pre,
+                alpha_post,
+                alpha_res,
+                bias_param,
+            ) = ctx.saved_tensors
+
+            grad_x, grad_weight, grad_ap, grad_apo, grad_ar, grad_bias = (
+                _cutile_fused_compute_h_proj_rms_bwd(
+                    x,
+                    weight,
+                    grad_h_pre,
+                    grad_h_post,
+                    grad_h_res,
+                    h_pre,
+                    h_post,
+                    h_res,
+                    proj,
+                    r,
+                    grad_r_ext,
+                    alpha_pre,
+                    alpha_post,
+                    alpha_res,
+                    bias_param,
+                    ctx.n,
+                    ctx.eps,
+                    ctx.compute_h_eps,
+                )
+            )
+
+            return (grad_x, grad_weight, grad_ap, grad_apo, grad_ar, grad_bias, None, None, None)
+
+
+class FusedHAggregate(torch.autograd.Function):
+    """H_aggregate with Triton/cuTile/torch forward and cuTile/torch backward."""
+
+    @staticmethod
+    def forward(ctx, x: Tensor, h_pre: Tensor):
+        """Run h_aggregate forward using the best available backend."""
+        triton_fwd = _get_triton_h_aggregate_fwd()
+        if triton_fwd is not None:
+            output = triton_fwd(x, h_pre)
+        elif is_cutile_available():
+            output = _cutile_h_aggregate_fwd(x, h_pre)
+        else:
+            output = native_h_aggregate(x, h_pre)
+        ctx.save_for_backward(x, h_pre)
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        """Run h_aggregate backward using the best available backend."""
+        x, h_pre = ctx.saved_tensors
+        if is_cutile_available():
+            return _cutile_h_aggregate_bwd(grad_output, x, h_pre)
+        return _torch_h_aggregate_bwd(grad_output, x, h_pre)
+
+
+class FusedHPostBDA(torch.autograd.Function):
+    """H_post_bda with Triton/cuTile/torch forward and backward."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        h_res: Tensor,
+        original_residual: Tensor,
+        h_post: Tensor,
+        x: Tensor,
+        bias: Optional[Tensor],
+    ):
+        """Run h_post_bda forward using the best available backend."""
+        triton_fwd = _get_triton_h_post_bda_fwd()
+        if triton_fwd is not None:
+            output = triton_fwd(h_res, original_residual, h_post, x, bias)
+        elif is_cutile_available():
+            output = _cutile_h_post_bda_fwd(h_res, original_residual, h_post, x, bias)
+        else:
+            output = native_h_post_bda(h_res, original_residual, h_post, x, bias)
+        if bias is not None:
+            ctx.save_for_backward(h_res, original_residual, h_post, x, bias)
+            ctx.has_bias = True
+        else:
+            ctx.save_for_backward(h_res, original_residual, h_post, x)
+            ctx.has_bias = False
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        """Run h_post_bda backward using the best available backend."""
+        if ctx.has_bias:
+            h_res, orig_res, h_post, x, bias = ctx.saved_tensors
+        else:
+            h_res, orig_res, h_post, x = ctx.saved_tensors
+            bias = None
+
+        triton_bwd = _get_triton_h_post_bda_bwd()
+        if triton_bwd is not None:
+            return triton_bwd(grad_output, h_res, orig_res, h_post, x, bias)
+        if is_cutile_available():
+            return _cutile_h_post_bda_bwd(grad_output, h_res, orig_res, h_post, x, bias)
+        return _torch_h_post_bda_bwd(grad_output, h_res, orig_res, h_post, x, bias)
+
+
+def fused_sinkhorn(input_logits: Tensor, num_iterations: int, eps: float = 1e-6) -> Tensor:
+    """Project logits to a doubly stochastic matrix using Triton, cuTile, then torch."""
+    _raise_mhc_backend_validation_error()
+    triton_sinkhorn = _get_triton_sinkhorn()
+    if triton_sinkhorn is not None:
+        return triton_sinkhorn(input_logits, num_iterations, eps)
+    if is_cutile_available():
+        return CutileSinkhornKnopp.apply(input_logits, num_iterations, eps)
+    return native_sinkhorn(input_logits, num_iterations, eps)
+
+
+def fused_h_aggregate(x: Tensor, h_pre: Tensor) -> Tensor:
+    """Weighted n-stream to 1-stream aggregation using Triton/cuTile/torch."""
+    _raise_mhc_backend_validation_error()
+    if _TRITON_AVAILABLE or is_cutile_available():
+        return FusedHAggregate.apply(x, h_pre)
+    return native_h_aggregate(x, h_pre)
+
+
+def fused_h_post_bda(
+    h_res: Tensor, original_residual: Tensor, h_post: Tensor, x: Tensor, bias: Optional[Tensor]
+) -> Tensor:
+    """Fused H_res.T @ residual + H_post * (x + bias)."""
+    _raise_mhc_backend_validation_error()
+    if _TRITON_AVAILABLE or is_cutile_available():
+        return FusedHPostBDA.apply(h_res, original_residual, h_post, x, bias)
+    return native_h_post_bda(h_res, original_residual, h_post, x, bias)
+
+
+def fused_proj_rms_compute_h(
+    x: Tensor,
+    weight: Tensor,
+    alpha_pre: Tensor,
+    alpha_post: Tensor,
+    alpha_res: Tensor,
+    bias: Tensor,
+    n: int,
+    eps: float = 1e-6,
+    compute_h_eps: float = 1e-6,
+) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
+    """Projection + RMS norm + compute_h split outputs using cuTile, then torch."""
+    _raise_mhc_backend_validation_error()
+    if is_cutile_available():
+        return CutileProjRmsComputeH.apply(
+            x, weight, alpha_pre, alpha_post, alpha_res, bias, n, eps, compute_h_eps
+        )
+    return _torch_proj_rms_compute_h(
+        x, weight, alpha_pre, alpha_post, alpha_res, bias, n, eps, compute_h_eps
+    )

--- a/megatron/core/models/hybrid/hybrid_block.py
+++ b/megatron/core/models/hybrid/hybrid_block.py
@@ -23,6 +23,7 @@ from megatron.core.fp8_utils import get_fp8_context
 from megatron.core.inference.contexts import BaseInferenceContext
 from megatron.core.inference.utils import InferenceMode
 from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols as LayerSymbols
+from megatron.core.models.hybrid.layers.hybrid_hyper_connection import HyperConnectionHybridLayer
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.recompute import checkpointed_forward
@@ -34,11 +35,7 @@ from megatron.core.transformer.hyper_connection import (
     learned_output_contract,
 )
 from megatron.core.transformer.identity_op import IdentityOp
-from megatron.core.transformer.module import (
-    MegatronModule,
-    convert_module_to_dtype_except_fp32_marked,
-    mark_keep_in_fp32,
-)
+from megatron.core.transformer.module import MegatronModule, mark_keep_in_fp32
 from megatron.core.transformer.multi_latent_attention import FusedMLASelfAttention
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
 from megatron.core.transformer.transformer_layer import TransformerLayer
@@ -64,201 +61,6 @@ class HybridStackSubmodules:
     mlp_layer: Union[ModuleSpec, type] = IdentityOp
     moe_layer: Union[ModuleSpec, type] = IdentityOp
     mtp_block_spec: Optional[ModuleSpec] = None
-
-
-class HyperConnectionHybridLayer(MegatronModule):
-    """Layer-boundary mHC wrapper for HybridStack layers.
-
-    Hybrid layers already own their local residual paths. Each wrapped layer is
-    treated as one function by aggregating n streams to its input, running the
-    existing layer, and feeding only the layer delta back through mHC expansion.
-
-    This wrapper nests the inner layer under inner_layer. Checkpoints cannot
-    switch between mHC-enabled and ordinary HybridStacks without key migration.
-    """
-
-    def __init__(self, config: TransformerConfig, layer: MegatronModule) -> None:
-        super().__init__(config=config)
-        self.inner_layer = layer
-        self.layer_number = layer.layer_number
-        self.hyper_connection = HyperConnectionModule(config=config, layer_number=self.layer_number)
-        if config.params_dtype is not None:
-            convert_module_to_dtype_except_fp32_marked(self.hyper_connection, config.params_dtype)
-        if hasattr(layer, 'tp_group'):
-            self.tp_group = layer.tp_group
-
-    def mamba_state_shapes_per_request(self) -> Optional[Tuple[Tuple[int], Tuple[int]]]:
-        """Delegate Mamba inference state shape requests to the wrapped layer."""
-        if not hasattr(self.inner_layer, 'mamba_state_shapes_per_request'):
-            return None
-        return self.inner_layer.mamba_state_shapes_per_request()
-
-    def _call_inner_layer(
-        self,
-        hidden_states: Tensor,
-        attention_mask: Tensor,
-        inference_context: Optional[BaseInferenceContext],
-        rotary_pos_emb: Optional[Tensor],
-        sequence_len_offset: Optional[Tensor],
-        packed_seq_params: Optional[PackedSeqParams],
-        padding_mask: Optional[Tensor],
-    ) -> Tuple[Tensor, Optional[Tensor]]:
-        if isinstance(self.inner_layer, TransformerLayer):
-            output = self.inner_layer(
-                hidden_states=hidden_states,
-                attention_mask=attention_mask,
-                inference_context=inference_context,
-                rotary_pos_emb=rotary_pos_emb,
-                sequence_len_offset=sequence_len_offset,
-                packed_seq_params=packed_seq_params,
-                padding_mask=padding_mask,
-            )
-        else:
-            # Mamba-like layers only consume the common HybridStack arguments.
-            output = self.inner_layer(
-                hidden_states=hidden_states,
-                attention_mask=attention_mask,
-                inference_context=inference_context,
-                packed_seq_params=packed_seq_params,
-            )
-
-        if isinstance(output, tuple):
-            context = output[1] if len(output) > 1 else None
-            return output[0], context
-        return output, None
-
-    def _call_inner_transformer_layer_without_local_bda(
-        self,
-        hidden_states: Tensor,
-        attention_mask: Tensor,
-        inference_context: Optional[BaseInferenceContext],
-        rotary_pos_emb: Optional[Tensor],
-        sequence_len_offset: Optional[Tensor],
-        packed_seq_params: Optional[PackedSeqParams],
-        padding_mask: Optional[Tensor],
-    ) -> Optional[Tuple[Tuple[Tensor, Optional[Tensor]], Optional[Tensor], float, bool]]:
-        """Return a raw branch output for split Hybrid TransformerLayer instances.
-
-        Hybrid layers are normally attention-only or MLP/MoE-only. For those
-        layers, bypass the inner layer's local residual/BDA and let the mHC BDA
-        own that operation directly.
-        """
-        if not isinstance(self.inner_layer, TransformerLayer):
-            return None
-
-        layer = self.inner_layer
-        if InferenceMode.is_active() and layer.config.inference_fuse_tp_communication:
-            return None
-
-        has_attention = not isinstance(layer.self_attention, IdentityOp)
-        has_cross_attention = not isinstance(layer.cross_attention, IdentityOp)
-        has_mlp = not isinstance(layer.mlp, IdentityOp)
-
-        if has_cross_attention or has_attention == has_mlp:
-            return None
-
-        if has_attention:
-            output_with_bias, attn_norm_manager, residual = (
-                layer._forward_self_attention_output_with_bias(
-                    hidden_states=hidden_states,
-                    attention_mask=attention_mask,
-                    inference_context=inference_context,
-                    rotary_pos_emb=rotary_pos_emb,
-                    packed_seq_params=packed_seq_params,
-                    sequence_len_offset=sequence_len_offset,
-                )
-            )
-            output_with_bias = layer._group_offload_output_with_bias(
-                output_with_bias, attn_norm_manager, forced_released_tensors=[residual]
-            )
-            return output_with_bias, None, layer.hidden_dropout, layer.config.bias_dropout_fusion
-
-        output_with_bias, residual = layer._forward_mlp_output_with_bias(
-            hidden_states,
-            inference_context=inference_context,
-            padding_mask=padding_mask,
-            packed_seq_params=packed_seq_params,
-        )
-        if layer.mlp_norm_manager is not None:
-            output_with_bias = layer._group_offload_output_with_bias(
-                output_with_bias, layer.mlp_norm_manager, forced_released_tensors=[residual]
-            )
-            layer.mlp_norm_manager = None
-        return output_with_bias, None, layer.hidden_dropout, layer.config.bias_dropout_fusion
-
-    def forward(
-        self,
-        hidden_states: Tensor,
-        attention_mask: Tensor,
-        inference_context: Optional[BaseInferenceContext] = None,
-        rotary_pos_emb: Optional[Tensor] = None,
-        sequence_len_offset: Optional[Tensor] = None,
-        packed_seq_params: Optional[PackedSeqParams] = None,
-        padding_mask: Optional[Tensor] = None,
-        mhc_recompute_manager=None,
-    ) -> Tuple[Tensor, Optional[Tensor]]:
-        """Run the wrapped hybrid layer through one layer-boundary mHC update."""
-        aggregated, h_res, h_post, residual = self.hyper_connection(
-            hidden_states, mhc_recompute_manager=mhc_recompute_manager, return_residual=True
-        )
-        fast_path_result = self._call_inner_transformer_layer_without_local_bda(
-            aggregated,
-            attention_mask,
-            inference_context,
-            rotary_pos_emb,
-            sequence_len_offset,
-            packed_seq_params,
-            padding_mask,
-        )
-
-        if fast_path_result is None:
-            layer_output, context = self._call_inner_layer(
-                aggregated,
-                attention_mask,
-                inference_context,
-                rotary_pos_emb,
-                sequence_len_offset,
-                packed_seq_params,
-                padding_mask,
-            )
-            if self.config.fp32_residual_connection and aggregated.dtype != layer_output.dtype:
-                aggregated = aggregated.to(layer_output.dtype)
-            layer_output_with_bias = (layer_output - aggregated, None)
-            dropout_prob = 0.0
-            bias_dropout_fusion = False
-        else:
-            layer_output_with_bias, context, dropout_prob, bias_dropout_fusion = fast_path_result
-
-        layer_output = layer_output_with_bias[0]
-        if layer_output.shape != aggregated.shape:
-            raise RuntimeError(
-                "HyperConnectionHybridLayer requires wrapped branches to preserve "
-                f"hidden-state shape. Got {tuple(layer_output.shape)} from wrapped branch "
-                f"vs {tuple(aggregated.shape)} input."
-            )
-
-        is_last_in_recompute_block = bool(
-            mhc_recompute_manager is not None
-            and getattr(mhc_recompute_manager, "is_last_layer_in_recompute_block", False)
-        )
-        mhc_bda_manager = None if is_last_in_recompute_block else mhc_recompute_manager
-        hidden_states = self.hyper_connection.fused_h_res_h_post_bda(
-            h_res,
-            residual,
-            h_post,
-            layer_output_with_bias,
-            dropout_prob=dropout_prob,
-            training=self.training,
-            fused=bias_dropout_fusion,
-            manager=mhc_bda_manager,
-        )
-        if (
-            self.config.fp32_residual_connection
-            and self.config.params_dtype is not None
-            and hidden_states.dtype != self.config.params_dtype
-        ):
-            hidden_states = hidden_states.to(self.config.params_dtype)
-        return hidden_states, context
 
 
 class HybridStack(MegatronModule):

--- a/megatron/core/models/hybrid/hybrid_block.py
+++ b/megatron/core/models/hybrid/hybrid_block.py
@@ -323,6 +323,10 @@ class HybridStack(MegatronModule):
             if layer_type == LayerSymbols.MAMBA:
                 return layer.mamba_state_shapes_per_request()
             if layer_type == LayerSymbols.GDN:
+                if hasattr(layer, 'mamba_state_shapes_per_request'):
+                    state_shapes = layer.mamba_state_shapes_per_request()
+                    if state_shapes is not None:
+                        return state_shapes
                 return layer.self_attention.mamba_state_shapes_per_request()
         return None
 

--- a/megatron/core/models/hybrid/hybrid_block.py
+++ b/megatron/core/models/hybrid/hybrid_block.py
@@ -152,16 +152,6 @@ class HybridStack(MegatronModule):
         if getattr(self.config, "mla_down_proj_fusion", False):
             submodules = self._fuse_mla_down_proj(submodules)
 
-        # Final #4531 rejects mHC on a plain TransformerLayer because it cannot
-        # consume n-stream inputs directly. HybridStack's layer-boundary wrapper
-        # aggregates to a single stream before calling the inner layer, so build
-        # that inner layer with the mHC flag disabled and retain the original
-        # config on HyperConnectionHybridLayer itself.
-        inner_layer_config = self.config
-        if self.config.enable_mhc_connections:
-            inner_layer_config = copy.copy(self.config)
-            inner_layer_config.enable_mhc_connections = False
-
         # Build layers from the pre-selected segment
         self.layers = nn.ModuleList()
         for i, layer_type in enumerate(self.layer_type_list):
@@ -176,7 +166,7 @@ class HybridStack(MegatronModule):
                 if layer_type == LayerSymbols.MAMBA:
                     layer = build_module(
                         submodules.mamba_layer,
-                        config=inner_layer_config,
+                        config=self.config,
                         layer_number=layer_number,
                         pp_layer_offset=pp_layer_offset,
                         pg_collection=pg_collection,
@@ -185,7 +175,7 @@ class HybridStack(MegatronModule):
                 elif layer_type == LayerSymbols.ATTENTION:
                     layer = build_module(
                         submodules.attention_layer,
-                        config=inner_layer_config,
+                        config=self.config,
                         layer_number=layer_number,
                         pg_collection=pg_collection,
                         is_mtp_layer=is_mtp_layer,
@@ -196,7 +186,7 @@ class HybridStack(MegatronModule):
                 elif layer_type == LayerSymbols.DS_ATTENTION:
                     layer = build_module(
                         submodules.dsa_layer,
-                        config=inner_layer_config,
+                        config=self.config,
                         layer_number=layer_number,
                         pg_collection=pg_collection,
                         is_mtp_layer=is_mtp_layer,
@@ -207,7 +197,7 @@ class HybridStack(MegatronModule):
                 elif layer_type == LayerSymbols.MLA:
                     layer = build_module(
                         submodules.mla_layer,
-                        config=inner_layer_config,
+                        config=self.config,
                         layer_number=layer_number,
                         pg_collection=pg_collection,
                         is_mtp_layer=is_mtp_layer,
@@ -217,7 +207,7 @@ class HybridStack(MegatronModule):
                 elif layer_type == LayerSymbols.MLP:
                     layer = build_module(
                         submodules.mlp_layer,
-                        config=inner_layer_config,
+                        config=self.config,
                         layer_number=layer_number,
                         pg_collection=pg_collection,
                         add_layer_offset=False,
@@ -226,7 +216,7 @@ class HybridStack(MegatronModule):
                 elif layer_type == LayerSymbols.MOE:
                     layer = build_module(
                         submodules.moe_layer,
-                        config=inner_layer_config,
+                        config=self.config,
                         layer_number=layer_number,
                         pg_collection=pg_collection,
                         is_mtp_layer=is_mtp_layer,
@@ -244,7 +234,7 @@ class HybridStack(MegatronModule):
                         gdn_layer_spec.submodules.self_attention.module = GatedDeltaNet2
                     layer = build_module(
                         gdn_layer_spec,
-                        config=inner_layer_config,
+                        config=self.config,
                         layer_number=layer_number,
                         pg_collection=pg_collection,
                         # Set to False as we do not want to change offset.

--- a/megatron/core/models/hybrid/hybrid_block.py
+++ b/megatron/core/models/hybrid/hybrid_block.py
@@ -8,7 +8,7 @@
 import copy
 from contextlib import nullcontext
 from dataclasses import dataclass
-from typing import Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 import torch
 from torch import Tensor, nn
@@ -26,14 +26,27 @@ from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols as Layer
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.recompute import checkpointed_forward
+from megatron.core.tensor_parallel.random import CheckpointWithoutOutputManager
 from megatron.core.transformer import TransformerConfig
 from megatron.core.transformer.cuda_graphs import annotate_first_last_layer
+from megatron.core.transformer.hyper_connection import (
+    HyperConnectionModule,
+    learned_output_contract,
+)
 from megatron.core.transformer.identity_op import IdentityOp
-from megatron.core.transformer.module import MegatronModule
+from megatron.core.transformer.module import (
+    MegatronModule,
+    convert_module_to_dtype_except_fp32_marked,
+    mark_keep_in_fp32,
+)
 from megatron.core.transformer.multi_latent_attention import FusedMLASelfAttention
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
 from megatron.core.transformer.transformer_layer import TransformerLayer
-from megatron.core.transformer.utils import sharded_state_dict_default
+from megatron.core.transformer.utils import (
+    ensure_metadata_has_dp_cp_group,
+    make_sharded_tensors_for_checkpoint,
+    sharded_state_dict_default,
+)
 from megatron.core.utils import WrappedTensor, deprecate_inference_params, make_viewless_tensor
 
 
@@ -51,6 +64,201 @@ class HybridStackSubmodules:
     mlp_layer: Union[ModuleSpec, type] = IdentityOp
     moe_layer: Union[ModuleSpec, type] = IdentityOp
     mtp_block_spec: Optional[ModuleSpec] = None
+
+
+class HyperConnectionHybridLayer(MegatronModule):
+    """Layer-boundary mHC wrapper for HybridStack layers.
+
+    Hybrid layers already own their local residual paths. Each wrapped layer is
+    treated as one function by aggregating n streams to its input, running the
+    existing layer, and feeding only the layer delta back through mHC expansion.
+
+    This wrapper nests the inner layer under inner_layer. Checkpoints cannot
+    switch between mHC-enabled and ordinary HybridStacks without key migration.
+    """
+
+    def __init__(self, config: TransformerConfig, layer: MegatronModule) -> None:
+        super().__init__(config=config)
+        self.inner_layer = layer
+        self.layer_number = layer.layer_number
+        self.hyper_connection = HyperConnectionModule(config=config, layer_number=self.layer_number)
+        if config.params_dtype is not None:
+            convert_module_to_dtype_except_fp32_marked(self.hyper_connection, config.params_dtype)
+        if hasattr(layer, 'tp_group'):
+            self.tp_group = layer.tp_group
+
+    def mamba_state_shapes_per_request(self) -> Optional[Tuple[Tuple[int], Tuple[int]]]:
+        """Delegate Mamba inference state shape requests to the wrapped layer."""
+        if not hasattr(self.inner_layer, 'mamba_state_shapes_per_request'):
+            return None
+        return self.inner_layer.mamba_state_shapes_per_request()
+
+    def _call_inner_layer(
+        self,
+        hidden_states: Tensor,
+        attention_mask: Tensor,
+        inference_context: Optional[BaseInferenceContext],
+        rotary_pos_emb: Optional[Tensor],
+        sequence_len_offset: Optional[Tensor],
+        packed_seq_params: Optional[PackedSeqParams],
+        padding_mask: Optional[Tensor],
+    ) -> Tuple[Tensor, Optional[Tensor]]:
+        if isinstance(self.inner_layer, TransformerLayer):
+            output = self.inner_layer(
+                hidden_states=hidden_states,
+                attention_mask=attention_mask,
+                inference_context=inference_context,
+                rotary_pos_emb=rotary_pos_emb,
+                sequence_len_offset=sequence_len_offset,
+                packed_seq_params=packed_seq_params,
+                padding_mask=padding_mask,
+            )
+        else:
+            # Mamba-like layers only consume the common HybridStack arguments.
+            output = self.inner_layer(
+                hidden_states=hidden_states,
+                attention_mask=attention_mask,
+                inference_context=inference_context,
+                packed_seq_params=packed_seq_params,
+            )
+
+        if isinstance(output, tuple):
+            context = output[1] if len(output) > 1 else None
+            return output[0], context
+        return output, None
+
+    def _call_inner_transformer_layer_without_local_bda(
+        self,
+        hidden_states: Tensor,
+        attention_mask: Tensor,
+        inference_context: Optional[BaseInferenceContext],
+        rotary_pos_emb: Optional[Tensor],
+        sequence_len_offset: Optional[Tensor],
+        packed_seq_params: Optional[PackedSeqParams],
+        padding_mask: Optional[Tensor],
+    ) -> Optional[Tuple[Tuple[Tensor, Optional[Tensor]], Optional[Tensor], float, bool]]:
+        """Return a raw branch output for split Hybrid TransformerLayer instances.
+
+        Hybrid layers are normally attention-only or MLP/MoE-only. For those
+        layers, bypass the inner layer's local residual/BDA and let the mHC BDA
+        own that operation directly.
+        """
+        if not isinstance(self.inner_layer, TransformerLayer):
+            return None
+
+        layer = self.inner_layer
+        if InferenceMode.is_active() and layer.config.inference_fuse_tp_communication:
+            return None
+
+        has_attention = not isinstance(layer.self_attention, IdentityOp)
+        has_cross_attention = not isinstance(layer.cross_attention, IdentityOp)
+        has_mlp = not isinstance(layer.mlp, IdentityOp)
+
+        if has_cross_attention or has_attention == has_mlp:
+            return None
+
+        if has_attention:
+            output_with_bias, attn_norm_manager, residual = (
+                layer._forward_self_attention_output_with_bias(
+                    hidden_states=hidden_states,
+                    attention_mask=attention_mask,
+                    inference_context=inference_context,
+                    rotary_pos_emb=rotary_pos_emb,
+                    packed_seq_params=packed_seq_params,
+                    sequence_len_offset=sequence_len_offset,
+                )
+            )
+            output_with_bias = layer._group_offload_output_with_bias(
+                output_with_bias, attn_norm_manager, forced_released_tensors=[residual]
+            )
+            return output_with_bias, None, layer.hidden_dropout, layer.config.bias_dropout_fusion
+
+        output_with_bias, residual = layer._forward_mlp_output_with_bias(
+            hidden_states,
+            inference_context=inference_context,
+            padding_mask=padding_mask,
+            packed_seq_params=packed_seq_params,
+        )
+        if layer.mlp_norm_manager is not None:
+            output_with_bias = layer._group_offload_output_with_bias(
+                output_with_bias, layer.mlp_norm_manager, forced_released_tensors=[residual]
+            )
+            layer.mlp_norm_manager = None
+        return output_with_bias, None, layer.hidden_dropout, layer.config.bias_dropout_fusion
+
+    def forward(
+        self,
+        hidden_states: Tensor,
+        attention_mask: Tensor,
+        inference_context: Optional[BaseInferenceContext] = None,
+        rotary_pos_emb: Optional[Tensor] = None,
+        sequence_len_offset: Optional[Tensor] = None,
+        packed_seq_params: Optional[PackedSeqParams] = None,
+        padding_mask: Optional[Tensor] = None,
+        mhc_recompute_manager=None,
+    ) -> Tuple[Tensor, Optional[Tensor]]:
+        """Run the wrapped hybrid layer through one layer-boundary mHC update."""
+        aggregated, h_res, h_post, residual = self.hyper_connection(
+            hidden_states, mhc_recompute_manager=mhc_recompute_manager, return_residual=True
+        )
+        fast_path_result = self._call_inner_transformer_layer_without_local_bda(
+            aggregated,
+            attention_mask,
+            inference_context,
+            rotary_pos_emb,
+            sequence_len_offset,
+            packed_seq_params,
+            padding_mask,
+        )
+
+        if fast_path_result is None:
+            layer_output, context = self._call_inner_layer(
+                aggregated,
+                attention_mask,
+                inference_context,
+                rotary_pos_emb,
+                sequence_len_offset,
+                packed_seq_params,
+                padding_mask,
+            )
+            if self.config.fp32_residual_connection and aggregated.dtype != layer_output.dtype:
+                aggregated = aggregated.to(layer_output.dtype)
+            layer_output_with_bias = (layer_output - aggregated, None)
+            dropout_prob = 0.0
+            bias_dropout_fusion = False
+        else:
+            layer_output_with_bias, context, dropout_prob, bias_dropout_fusion = fast_path_result
+
+        layer_output = layer_output_with_bias[0]
+        if layer_output.shape != aggregated.shape:
+            raise RuntimeError(
+                "HyperConnectionHybridLayer requires wrapped branches to preserve "
+                f"hidden-state shape. Got {tuple(layer_output.shape)} from wrapped branch "
+                f"vs {tuple(aggregated.shape)} input."
+            )
+
+        is_last_in_recompute_block = bool(
+            mhc_recompute_manager is not None
+            and getattr(mhc_recompute_manager, "is_last_layer_in_recompute_block", False)
+        )
+        mhc_bda_manager = None if is_last_in_recompute_block else mhc_recompute_manager
+        hidden_states = self.hyper_connection.fused_h_res_h_post_bda(
+            h_res,
+            residual,
+            h_post,
+            layer_output_with_bias,
+            dropout_prob=dropout_prob,
+            training=self.training,
+            fused=bias_dropout_fusion,
+            manager=mhc_bda_manager,
+        )
+        if (
+            self.config.fp32_residual_connection
+            and self.config.params_dtype is not None
+            and hidden_states.dtype != self.config.params_dtype
+        ):
+            hidden_states = hidden_states.to(self.config.params_dtype)
+        return hidden_states, context
 
 
 class HybridStack(MegatronModule):
@@ -114,6 +322,8 @@ class HybridStack(MegatronModule):
         self.input_tensor = None
         self.pg_collection = pg_collection
 
+        self._mhc_block_end_plan: Optional[List[bool]] = None
+
         assert layer_type_list is not None, (
             "layer_type_list must be provided. It should be pre-computed from "
             "--hybrid-layer-pattern by HybridModel."
@@ -140,6 +350,16 @@ class HybridStack(MegatronModule):
         if getattr(self.config, "mla_down_proj_fusion", False):
             submodules = self._fuse_mla_down_proj(submodules)
 
+        # Final #4531 rejects mHC on a plain TransformerLayer because it cannot
+        # consume n-stream inputs directly. HybridStack's layer-boundary wrapper
+        # aggregates to a single stream before calling the inner layer, so build
+        # that inner layer with the mHC flag disabled and retain the original
+        # config on HyperConnectionHybridLayer itself.
+        inner_layer_config = self.config
+        if self.config.enable_mhc_connections:
+            inner_layer_config = copy.copy(self.config)
+            inner_layer_config.enable_mhc_connections = False
+
         # Build layers from the pre-selected segment
         self.layers = nn.ModuleList()
         for i, layer_type in enumerate(self.layer_type_list):
@@ -154,7 +374,7 @@ class HybridStack(MegatronModule):
                 if layer_type == LayerSymbols.MAMBA:
                     layer = build_module(
                         submodules.mamba_layer,
-                        config=self.config,
+                        config=inner_layer_config,
                         layer_number=layer_number,
                         pp_layer_offset=pp_layer_offset,
                         pg_collection=pg_collection,
@@ -163,7 +383,7 @@ class HybridStack(MegatronModule):
                 elif layer_type == LayerSymbols.ATTENTION:
                     layer = build_module(
                         submodules.attention_layer,
-                        config=self.config,
+                        config=inner_layer_config,
                         layer_number=layer_number,
                         pg_collection=pg_collection,
                         is_mtp_layer=is_mtp_layer,
@@ -174,7 +394,7 @@ class HybridStack(MegatronModule):
                 elif layer_type == LayerSymbols.DS_ATTENTION:
                     layer = build_module(
                         submodules.dsa_layer,
-                        config=self.config,
+                        config=inner_layer_config,
                         layer_number=layer_number,
                         pg_collection=pg_collection,
                         is_mtp_layer=is_mtp_layer,
@@ -185,7 +405,7 @@ class HybridStack(MegatronModule):
                 elif layer_type == LayerSymbols.MLA:
                     layer = build_module(
                         submodules.mla_layer,
-                        config=self.config,
+                        config=inner_layer_config,
                         layer_number=layer_number,
                         pg_collection=pg_collection,
                         is_mtp_layer=is_mtp_layer,
@@ -195,7 +415,7 @@ class HybridStack(MegatronModule):
                 elif layer_type == LayerSymbols.MLP:
                     layer = build_module(
                         submodules.mlp_layer,
-                        config=self.config,
+                        config=inner_layer_config,
                         layer_number=layer_number,
                         pg_collection=pg_collection,
                         add_layer_offset=False,
@@ -204,7 +424,7 @@ class HybridStack(MegatronModule):
                 elif layer_type == LayerSymbols.MOE:
                     layer = build_module(
                         submodules.moe_layer,
-                        config=self.config,
+                        config=inner_layer_config,
                         layer_number=layer_number,
                         pg_collection=pg_collection,
                         is_mtp_layer=is_mtp_layer,
@@ -222,7 +442,7 @@ class HybridStack(MegatronModule):
                         gdn_layer_spec.submodules.self_attention.module = GatedDeltaNet2
                     layer = build_module(
                         gdn_layer_spec,
-                        config=self.config,
+                        config=inner_layer_config,
                         layer_number=layer_number,
                         pg_collection=pg_collection,
                         # Set to False as we do not want to change offset.
@@ -232,6 +452,8 @@ class HybridStack(MegatronModule):
                     )
                 else:
                     raise ValueError("unexpected layer_type")
+            if self.config.enable_mhc_connections:
+                layer = HyperConnectionHybridLayer(config=self.config, layer=layer)
             self.layers.append(layer)
 
         if self.config.cuda_graph_impl == "local":
@@ -247,6 +469,18 @@ class HybridStack(MegatronModule):
                 hidden_size=self.config.hidden_size,
                 eps=self.config.layernorm_epsilon,
             )
+
+        if self.config.enable_mhc_connections and self.post_process and not self.is_mtp_layer:
+            hc_mult = self.config.mhc_num_residual_streams
+            hc_dim = self.config.hidden_size * hc_mult
+            self.hc_head_fn = mark_keep_in_fp32(nn.Parameter(torch.randn(hc_mult, hc_dim)))
+            self.hc_head_base = mark_keep_in_fp32(nn.Parameter(torch.zeros(hc_mult)))
+            self.hc_head_scale = mark_keep_in_fp32(nn.Parameter(torch.ones(1)))
+            nn.init.xavier_uniform_(self.hc_head_fn)
+            if self.config.sequence_parallel:
+                setattr(self.hc_head_fn, 'sequence_parallel', True)
+                setattr(self.hc_head_base, 'sequence_parallel', True)
+                setattr(self.hc_head_scale, 'sequence_parallel', True)
 
     def _fuse_mla_down_proj(self, submodules: HybridStackSubmodules) -> HybridStackSubmodules:
         # Avoid modifying the original object so users don't get surprised about their `submodules`
@@ -290,6 +524,49 @@ class HybridStack(MegatronModule):
                 return layer.self_attention.mamba_state_shapes_per_request()
         return None
 
+    def _compute_mhc_block_end_plan(self) -> List[bool]:
+        """Compute deterministic per-layer mHC recompute block boundaries."""
+        num_layers = len(self.layers)
+        block_ends: List[bool] = [False] * num_layers
+        if num_layers == 0:
+            return block_ends
+
+        layers_per_block = self.config.mhc_recompute_layer_num
+        for layer_idx in range(num_layers):
+            is_last_in_stack = layer_idx == num_layers - 1
+            block_ends[layer_idx] = is_last_in_stack or (
+                layers_per_block is not None and (layer_idx + 1) % layers_per_block == 0
+            )
+        return block_ends
+
+    def _build_mhc_recompute_layer_plan(
+        self, use_mhc_recompute: bool
+    ) -> Tuple[List[Optional[CheckpointWithoutOutputManager]], List[bool]]:
+        """Build single-use recompute managers for this forward pass."""
+        num_layers = len(self.layers)
+        if not use_mhc_recompute or num_layers == 0:
+            return [None] * num_layers, [False] * num_layers
+
+        if self._mhc_block_end_plan is None:
+            self._mhc_block_end_plan = self._compute_mhc_block_end_plan()
+        block_ends = self._mhc_block_end_plan
+
+        layer_managers: List[Optional[CheckpointWithoutOutputManager]] = [None] * num_layers
+        manager = CheckpointWithoutOutputManager()
+        for layer_idx in range(num_layers):
+            layer_managers[layer_idx] = manager
+            if block_ends[layer_idx] and layer_idx != num_layers - 1:
+                manager = CheckpointWithoutOutputManager()
+        return layer_managers, block_ends
+
+    @staticmethod
+    def _finalize_mhc_recompute_layer(
+        manager: Optional[CheckpointWithoutOutputManager], hidden_states: Tensor, is_block_end: bool
+    ) -> None:
+        """Finalize the current mHC recompute block when its last layer finishes."""
+        if manager is not None and is_block_end:
+            manager.discard_all_outputs_and_register_unified_recompute(hidden_states)
+
     def forward(
         self,
         hidden_states: Union[Tensor, WrappedTensor],
@@ -332,6 +609,11 @@ class HybridStack(MegatronModule):
         # Delete the obsolete reference to the initial input tensor if necessary
         if isinstance(hidden_states, WrappedTensor):
             hidden_states = hidden_states.unwrap()
+
+        if self.config.enable_mhc_connections and self.pre_process and not self.is_mtp_layer:
+            hidden_states = HyperConnectionModule.input_expand(
+                hidden_states, self.config.mhc_num_residual_streams
+            )
 
         if inference_context and inference_context.is_static_batching():
             # NOTE(bnorick): match BaseInferenceContext attributes for
@@ -380,6 +662,14 @@ class HybridStack(MegatronModule):
             def get_inner_quant_context(config, layer_number):
                 return nullcontext()
 
+        use_mhc_recompute = (
+            self.training
+            and self.config.enable_mhc_connections
+            and self.config.recompute_granularity == 'selective'
+            and "mhc" in self.config.recompute_modules
+        )
+        mhc_layer_managers, mhc_block_ends = self._build_mhc_recompute_layer_plan(use_mhc_recompute)
+
         with outer_fp8_context:
             if self.config.recompute_granularity == 'full' and self.training:
                 hidden_states = checkpointed_forward(
@@ -396,19 +686,23 @@ class HybridStack(MegatronModule):
                     cp_layout_state=cp_layout_state,
                 )
             else:
-                for layer_index, layer in enumerate(self.layers):
+                for layer_idx, layer in enumerate(self.layers):
                     layer_packed_seq_params = packed_seq_params
                     if cp_layout_state is not None:
                         hidden_states, layer_packed_seq_params = cp_layout_state.prepare_layer(
-                            layer_index, hidden_states
+                            layer_idx, hidden_states
                         )
                     # Layers have 1-indexed layer numbers attribute.
                     inner_quant_context = get_inner_quant_context(
                         self.config, layer.layer_number - 1
                     )
+                    mhc_manager = mhc_layer_managers[layer_idx]
+                    if mhc_manager is not None:
+                        mhc_manager.is_last_layer_in_recompute_block = mhc_block_ends[layer_idx]
+
                     with inner_quant_context:
-                        if isinstance(layer, TransformerLayer):
-                            hidden_states, _ = layer(
+                        if isinstance(layer, (TransformerLayer, HyperConnectionHybridLayer)):
+                            layer_kwargs = dict(
                                 hidden_states=hidden_states,
                                 attention_mask=attention_mask,
                                 inference_context=inference_context,
@@ -417,6 +711,11 @@ class HybridStack(MegatronModule):
                                 packed_seq_params=layer_packed_seq_params,
                                 padding_mask=padding_mask,
                             )
+                            if mhc_manager is not None and isinstance(
+                                layer, HyperConnectionHybridLayer
+                            ):
+                                layer_kwargs["mhc_recompute_manager"] = mhc_manager
+                            hidden_states, _ = layer(**layer_kwargs)
                         else:  # MambaLayer, Expert, or MLP
                             hidden_states = layer(
                                 hidden_states=hidden_states,
@@ -431,7 +730,26 @@ class HybridStack(MegatronModule):
                     if isinstance(hidden_states, tuple):
                         hidden_states = hidden_states[0]
                     if cp_layout_state is not None:
-                        hidden_states = cp_layout_state.finalize_layer(layer_index, hidden_states)
+                        hidden_states = cp_layout_state.finalize_layer(layer_idx, hidden_states)
+
+                    self._finalize_mhc_recompute_layer(
+                        manager=mhc_manager,
+                        hidden_states=hidden_states,
+                        is_block_end=mhc_block_ends[layer_idx],
+                    )
+
+        mhc_multistream = None
+        if self.config.enable_mhc_connections and self.post_process and not self.is_mtp_layer:
+            if (self.config.mtp_num_layers or 0) > 0:
+                mhc_multistream = hidden_states
+            hidden_states = learned_output_contract(
+                hidden_states,
+                self.hc_head_fn,
+                self.hc_head_base,
+                self.hc_head_scale,
+                self.config.mhc_num_residual_streams,
+                self.config.layernorm_epsilon,
+            )
 
         # Final layer norm.
         if self.post_process and self.post_layer_norm:
@@ -443,6 +761,8 @@ class HybridStack(MegatronModule):
             inp=hidden_states, requires_grad=hidden_states.requires_grad, keep_graph=True
         )
 
+        if mhc_multistream is not None:
+            return hidden_states, mhc_multistream
         return hidden_states
 
     def sharded_state_dict(
@@ -467,6 +787,7 @@ class HybridStack(MegatronModule):
             dict: The sharded state dictionary for the current object.
         """
 
+        sharded_offsets = sharded_offsets or ()
         sharded_state_dict = {}
         layer_prefix = f'{prefix}layers.'
 
@@ -500,6 +821,20 @@ class HybridStack(MegatronModule):
                         tp_group=self.tp_group,
                     )
                 )
+
+        local_state_dict: dict = {}
+        self._save_to_state_dict(local_state_dict, '', keep_vars=True)
+        if local_state_dict:
+            metadata = ensure_metadata_has_dp_cp_group(metadata)
+            sharded_state_dict.update(
+                make_sharded_tensors_for_checkpoint(
+                    local_state_dict,
+                    prefix,
+                    sharded_offsets=sharded_offsets,
+                    tp_group=self.tp_group,
+                    dp_cp_group=metadata['dp_cp_group'],
+                )
+            )
 
         return sharded_state_dict
 

--- a/megatron/core/models/hybrid/hybrid_layer_specs.py
+++ b/megatron/core/models/hybrid/hybrid_layer_specs.py
@@ -81,7 +81,11 @@ _hybrid_mtp_block_spec = ModuleSpec(
                 submodules=MultiTokenPredictionLayerSubmodules(
                     enorm=TENorm,
                     hnorm=TENorm,
+                    # Hybrid MTP selects the combined projection normally and
+                    # per-stream projections when mHC is enabled.
                     eh_proj=TEColumnParallelLinear,
+                    e_proj=TEColumnParallelLinear,
+                    h_proj=TEColumnParallelLinear,
                     mtp_model_layer=None,  # Built via pattern + hybrid_submodules
                     layer_norm=TENorm,
                 ),
@@ -387,7 +391,10 @@ hybrid_inference_stack_spec = ModuleSpec(
                         submodules=MultiTokenPredictionLayerSubmodules(
                             enorm=TENorm,
                             hnorm=TENorm,
+                            # Keep both projection forms available for Hybrid MTP.
                             eh_proj=InferenceColumnParallelLinear,
+                            e_proj=InferenceColumnParallelLinear,
+                            h_proj=InferenceColumnParallelLinear,
                             mtp_model_layer=None,  # Built via pattern + hybrid_submodules
                             layer_norm=TENorm,
                         ),

--- a/megatron/core/models/hybrid/hybrid_model.py
+++ b/megatron/core/models/hybrid/hybrid_model.py
@@ -528,7 +528,7 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
         # assert attention_mask is None, "The attention mask is ignored and should be set to None"
 
         # Run decoder.
-        hidden_states = self.decoder(
+        decoder_output = self.decoder(
             hidden_states=decoder_input,
             attention_mask=attention_mask,
             inference_context=inference_context,
@@ -536,6 +536,11 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
             packed_seq_params=packed_seq_params,
             padding_mask=padding_mask,
         )
+        if isinstance(decoder_output, tuple):
+            hidden_states, mhc_multistream = decoder_output
+        else:
+            hidden_states = decoder_output
+            mhc_multistream = None
 
         output_weight = None
         if self.share_embeddings_and_output_weights:
@@ -559,6 +564,7 @@ class HybridModel(LanguageModule, GraphableMegatronModule):
                 input_ids=input_ids,
                 position_ids=position_ids,
                 hidden_states=hidden_states,
+                mhc_multistream=mhc_multistream,
                 attention_mask=attention_mask,
                 inference_params=inference_params,
                 rotary_pos_emb=rotary_pos_emb,

--- a/megatron/core/models/hybrid/layers/__init__.py
+++ b/megatron/core/models/hybrid/layers/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.

--- a/megatron/core/models/hybrid/layers/hybrid_hyper_connection.py
+++ b/megatron/core/models/hybrid/layers/hybrid_hyper_connection.py
@@ -40,9 +40,12 @@ class HyperConnectionHybridLayer(MegatronModule):
 
     def mamba_state_shapes_per_request(self) -> Optional[Tuple[Tuple[int], Tuple[int]]]:
         """Delegate Mamba inference state shape requests to the wrapped layer."""
-        if not hasattr(self.inner_layer, 'mamba_state_shapes_per_request'):
-            return None
-        return self.inner_layer.mamba_state_shapes_per_request()
+        if hasattr(self.inner_layer, 'mamba_state_shapes_per_request'):
+            return self.inner_layer.mamba_state_shapes_per_request()
+        mixer = getattr(self.inner_layer, 'self_attention', None)
+        if mixer is not None and hasattr(mixer, 'mamba_state_shapes_per_request'):
+            return mixer.mamba_state_shapes_per_request()
+        return None
 
     def _call_inner_layer(
         self,

--- a/megatron/core/models/hybrid/layers/hybrid_hyper_connection.py
+++ b/megatron/core/models/hybrid/layers/hybrid_hyper_connection.py
@@ -1,0 +1,212 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+from typing import Optional, Tuple
+
+from torch import Tensor
+
+from megatron.core.inference.contexts import BaseInferenceContext
+from megatron.core.inference.utils import InferenceMode
+from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core.transformer import TransformerConfig
+from megatron.core.transformer.hyper_connection import HyperConnectionModule
+from megatron.core.transformer.identity_op import IdentityOp
+from megatron.core.transformer.module import (
+    MegatronModule,
+    convert_module_to_dtype_except_fp32_marked,
+)
+from megatron.core.transformer.transformer_layer import TransformerLayer
+
+
+class HyperConnectionHybridLayer(MegatronModule):
+    """Layer-boundary mHC wrapper for HybridStack layers.
+
+    Hybrid layers already own their local residual paths. Each wrapped layer is
+    treated as one function by aggregating n streams to its input, running the
+    existing layer, and feeding only the layer delta back through mHC expansion.
+
+    This wrapper nests the inner layer under inner_layer. Checkpoints cannot
+    switch between mHC-enabled and ordinary HybridStacks without key migration.
+    """
+
+    def __init__(self, config: TransformerConfig, layer: MegatronModule) -> None:
+        super().__init__(config=config)
+        self.inner_layer = layer
+        self.layer_number = layer.layer_number
+        self.hyper_connection = HyperConnectionModule(config=config, layer_number=self.layer_number)
+        if config.params_dtype is not None:
+            convert_module_to_dtype_except_fp32_marked(self.hyper_connection, config.params_dtype)
+        if hasattr(layer, 'tp_group'):
+            self.tp_group = layer.tp_group
+
+    def mamba_state_shapes_per_request(self) -> Optional[Tuple[Tuple[int], Tuple[int]]]:
+        """Delegate Mamba inference state shape requests to the wrapped layer."""
+        if not hasattr(self.inner_layer, 'mamba_state_shapes_per_request'):
+            return None
+        return self.inner_layer.mamba_state_shapes_per_request()
+
+    def _call_inner_layer(
+        self,
+        hidden_states: Tensor,
+        attention_mask: Tensor,
+        inference_context: Optional[BaseInferenceContext],
+        rotary_pos_emb: Optional[Tensor],
+        sequence_len_offset: Optional[Tensor],
+        packed_seq_params: Optional[PackedSeqParams],
+        padding_mask: Optional[Tensor],
+    ) -> Tuple[Tensor, Optional[Tensor]]:
+        if isinstance(self.inner_layer, TransformerLayer):
+            output = self.inner_layer(
+                hidden_states=hidden_states,
+                attention_mask=attention_mask,
+                inference_context=inference_context,
+                rotary_pos_emb=rotary_pos_emb,
+                sequence_len_offset=sequence_len_offset,
+                packed_seq_params=packed_seq_params,
+                padding_mask=padding_mask,
+            )
+        else:
+            # Mamba-like layers only consume the common HybridStack arguments.
+            output = self.inner_layer(
+                hidden_states=hidden_states,
+                attention_mask=attention_mask,
+                inference_context=inference_context,
+                packed_seq_params=packed_seq_params,
+            )
+
+        if isinstance(output, tuple):
+            context = output[1] if len(output) > 1 else None
+            return output[0], context
+        return output, None
+
+    def _call_inner_transformer_layer_without_local_bda(
+        self,
+        hidden_states: Tensor,
+        attention_mask: Tensor,
+        inference_context: Optional[BaseInferenceContext],
+        rotary_pos_emb: Optional[Tensor],
+        sequence_len_offset: Optional[Tensor],
+        packed_seq_params: Optional[PackedSeqParams],
+        padding_mask: Optional[Tensor],
+    ) -> Optional[Tuple[Tuple[Tensor, Optional[Tensor]], Optional[Tensor], float, bool]]:
+        """Return a raw branch output for split Hybrid TransformerLayer instances.
+
+        Hybrid layers are normally attention-only or MLP/MoE-only. For those
+        layers, bypass the inner layer's local residual/BDA and let the mHC BDA
+        own that operation directly.
+        """
+        if not isinstance(self.inner_layer, TransformerLayer):
+            return None
+
+        layer = self.inner_layer
+        if InferenceMode.is_active() and layer.config.inference_fuse_tp_communication:
+            return None
+
+        has_attention = not isinstance(layer.self_attention, IdentityOp)
+        has_cross_attention = not isinstance(layer.cross_attention, IdentityOp)
+        has_mlp = not isinstance(layer.mlp, IdentityOp)
+
+        if has_cross_attention or has_attention == has_mlp:
+            return None
+
+        if has_attention:
+            output_with_bias, attn_norm_manager, residual = (
+                layer._forward_self_attention_output_with_bias(
+                    hidden_states=hidden_states,
+                    attention_mask=attention_mask,
+                    inference_context=inference_context,
+                    rotary_pos_emb=rotary_pos_emb,
+                    packed_seq_params=packed_seq_params,
+                    sequence_len_offset=sequence_len_offset,
+                )
+            )
+            output_with_bias = layer._group_offload_output_with_bias(
+                output_with_bias, attn_norm_manager, forced_released_tensors=[residual]
+            )
+            return output_with_bias, None, layer.hidden_dropout, layer.config.bias_dropout_fusion
+
+        output_with_bias, residual = layer._forward_mlp_output_with_bias(
+            hidden_states,
+            inference_context=inference_context,
+            padding_mask=padding_mask,
+            packed_seq_params=packed_seq_params,
+        )
+        if layer.mlp_norm_manager is not None:
+            output_with_bias = layer._group_offload_output_with_bias(
+                output_with_bias, layer.mlp_norm_manager, forced_released_tensors=[residual]
+            )
+            layer.mlp_norm_manager = None
+        return output_with_bias, None, layer.hidden_dropout, layer.config.bias_dropout_fusion
+
+    def forward(
+        self,
+        hidden_states: Tensor,
+        attention_mask: Tensor,
+        inference_context: Optional[BaseInferenceContext] = None,
+        rotary_pos_emb: Optional[Tensor] = None,
+        sequence_len_offset: Optional[Tensor] = None,
+        packed_seq_params: Optional[PackedSeqParams] = None,
+        padding_mask: Optional[Tensor] = None,
+        mhc_recompute_manager=None,
+    ) -> Tuple[Tensor, Optional[Tensor]]:
+        """Run the wrapped hybrid layer through one layer-boundary mHC update."""
+        aggregated, h_res, h_post, residual = self.hyper_connection(
+            hidden_states, mhc_recompute_manager=mhc_recompute_manager, return_residual=True
+        )
+        fast_path_result = self._call_inner_transformer_layer_without_local_bda(
+            aggregated,
+            attention_mask,
+            inference_context,
+            rotary_pos_emb,
+            sequence_len_offset,
+            packed_seq_params,
+            padding_mask,
+        )
+
+        if fast_path_result is None:
+            layer_output, context = self._call_inner_layer(
+                aggregated,
+                attention_mask,
+                inference_context,
+                rotary_pos_emb,
+                sequence_len_offset,
+                packed_seq_params,
+                padding_mask,
+            )
+            if self.config.fp32_residual_connection and aggregated.dtype != layer_output.dtype:
+                aggregated = aggregated.to(layer_output.dtype)
+            layer_output_with_bias = (layer_output - aggregated, None)
+            dropout_prob = 0.0
+            bias_dropout_fusion = False
+        else:
+            layer_output_with_bias, context, dropout_prob, bias_dropout_fusion = fast_path_result
+
+        layer_output = layer_output_with_bias[0]
+        if layer_output.shape != aggregated.shape:
+            raise RuntimeError(
+                "HyperConnectionHybridLayer requires wrapped branches to preserve "
+                f"hidden-state shape. Got {tuple(layer_output.shape)} from wrapped branch "
+                f"vs {tuple(aggregated.shape)} input."
+            )
+
+        is_last_in_recompute_block = bool(
+            mhc_recompute_manager is not None
+            and getattr(mhc_recompute_manager, "is_last_layer_in_recompute_block", False)
+        )
+        mhc_bda_manager = None if is_last_in_recompute_block else mhc_recompute_manager
+        hidden_states = self.hyper_connection.fused_h_res_h_post_bda(
+            h_res,
+            residual,
+            h_post,
+            layer_output_with_bias,
+            dropout_prob=dropout_prob,
+            training=self.training,
+            fused=bias_dropout_fusion,
+            manager=mhc_bda_manager,
+        )
+        if (
+            self.config.fp32_residual_connection
+            and self.config.params_dtype is not None
+            and hidden_states.dtype != self.config.params_dtype
+        ):
+            hidden_states = hidden_states.to(self.config.params_dtype)
+        return hidden_states, context

--- a/megatron/core/post_training/modelopt/hybrid/model_specs.py
+++ b/megatron/core/post_training/modelopt/hybrid/model_specs.py
@@ -247,6 +247,8 @@ def _get_hybrid_stack_local_spec(
                         enorm=Norm,
                         hnorm=Norm,
                         eh_proj=ColumnParallelLinear,
+                        e_proj=ColumnParallelLinear,
+                        h_proj=ColumnParallelLinear,
                         mtp_model_layer=None,
                         layer_norm=Norm,
                     ),

--- a/megatron/core/transformer/hyper_connection.py
+++ b/megatron/core/transformer/hyper_connection.py
@@ -5,12 +5,16 @@ from typing import Optional, Tuple
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 from torch import Tensor
 
 from megatron.core.tensor_parallel.random import CheckpointWithoutOutputManager
-from megatron.core.transformer.module import MegatronModule
+from megatron.core.transformer.module import MegatronModule, mark_keep_in_fp32
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.utils import nvtx_decorator
+
+_MHC_SINKHORN_EPS = 1e-6
+_MHC_COMPUTE_H_EPS = 1e-6
 
 
 def build_mhc_recompute_layer_plan(
@@ -51,99 +55,135 @@ def finalize_mhc_recompute_layer(
         mhc_manager.discard_all_outputs_and_register_unified_recompute(hidden_states)
 
 
+@torch.compile
+def _sinkhorn_iterations(input_logits: Tensor, num_iterations: int, eps: float) -> Tensor:
+    M = input_logits.softmax(dim=-1) + eps
+    M = M / (M.sum(dim=-2, keepdim=True) + eps)
+    for _ in range(num_iterations - 1):
+        M = M / (M.sum(dim=-1, keepdim=True) + eps)
+        M = M / (M.sum(dim=-2, keepdim=True) + eps)
+    return M
+
+
 class SinkhornKnopp(torch.autograd.Function):
-    """
-    Differentiable Sinkhorn-Knopp algorithm for doubly stochastic projection.
+    """Sinkhorn-Knopp projection to doubly stochastic matrix.
 
-    Projects a positive matrix onto the Birkhoff polytope (doubly stochastic matrices)
-    via iterative row and column normalization.
-
-    Reference: Eq. (9) in mHC paper - M^{(t)} = T_c(T_r(M^{(t-1)}))
+    This is an autograd.Function because the iterative forward is re-executed
+    during backward (under torch.enable_grad) so that PyTorch's autograd can
+    differentiate through it without storing all intermediate iteration states.
     """
 
-    eps = 1e-6
-
     @staticmethod
-    def _sinkhorn_normalize(M: Tensor, num_iterations: int) -> Tensor:
-        """
-        Apply Sinkhorn-Knopp normalization iterations.
-
-        Iteratively applies row and column normalization to project M
-        onto the Birkhoff polytope (doubly stochastic matrices).
-
-        Args:
-            M: [s, b, n, n] - positive matrix to normalize
-            num_iterations: Number of Sinkhorn iterations
-
-        Returns:
-            M: [s, b, n, n] - doubly stochastic matrix
-        """
-        for _ in range(num_iterations):
-            # T_r: Row normalization
-            M = M / M.sum(dim=-1, keepdim=True).clamp(min=SinkhornKnopp.eps)
-            # T_c: Column normalization
-            M = M / M.sum(dim=-2, keepdim=True).clamp(min=SinkhornKnopp.eps)
-        return M
-
-    @staticmethod
-    def forward(ctx, H_res_logits: Tensor, num_iterations: int) -> Tensor:
-        """
-        Project to doubly stochastic matrix via iterative row/col normalization.
-
-        Args:
-            H_res_logits: [s, b, n, n] - raw logits for residual mixing matrix
-            num_iterations: Number of Sinkhorn iterations (paper uses 20)
-
-        Returns:
-            H_res: [s, b, n, n] - doubly stochastic matrix
-        """
-        # Gradients are computed explicitly in backward via recomputation.
-        # Numerical-stability shift: subtract the per-row max before exp to prevent
-        # overflow. This row-wise constant is invariant under Sinkhorn-Knopp
-        # normalization: the first iteration's row normalization (T_r) divides each
-        # row by its sum, which cancels any per-row scalar — i.e. exp(H_ij - c_i) and
-        # exp(H_ij) produce identical row-normalized matrices, hence the same Sinkhorn
-        # fixed point and the same gradient. The shift therefore changes only the
-        # numeric stability of the exp, not the algorithm's output.
-        M_init = torch.exp(H_res_logits - H_res_logits.max(dim=-1, keepdim=True).values)
-
-        M = SinkhornKnopp._sinkhorn_normalize(M_init, num_iterations)
-
-        # Save initial M for backward recomputation
-        ctx.save_for_backward(M_init)
+    def forward(ctx, input_logits: Tensor, num_iterations: int, eps: float = 1e-6) -> Tensor:
+        """Run Sinkhorn iterations and save inputs for backward recomputation."""
+        M = _sinkhorn_iterations(input_logits, num_iterations, eps)
+        ctx.save_for_backward(input_logits)
         ctx.num_iterations = num_iterations
+        ctx.eps = eps
         return M
 
     @staticmethod
-    def backward(ctx, grad_output: Tensor) -> Tuple[Tensor, None]:
-        """
-        Backward through Sinkhorn-Knopp iterations using recomputation.
-
-        Recomputes the forward pass with gradient tracking to obtain accurate gradients.
-        """
-        (M_init,) = ctx.saved_tensors
-        num_iterations = ctx.num_iterations
-
-        # Recompute forward with autograd enabled
+    def backward(ctx, grad_output: Tensor):
+        """Recompute forward under enable_grad and back-propagate."""
+        (input_logits,) = ctx.saved_tensors
         with torch.enable_grad():
-            # Leaf for recomputation
-            M_input = M_init.detach().requires_grad_(True)
+            logits = input_logits.detach().requires_grad_(True)
+            M = _sinkhorn_iterations(logits, ctx.num_iterations, ctx.eps)
+            M.backward(grad_output)
+        return logits.grad, None, None
 
-            M_current = SinkhornKnopp._sinkhorn_normalize(M_input, num_iterations)
 
-            # Compute dL/dM_input (i.e., dL/dM_init) via autograd
-            (grad_M_init,) = torch.autograd.grad(
-                outputs=M_current,
-                inputs=M_input,
-                grad_outputs=grad_output,
-                create_graph=False,
-                retain_graph=False,
-            )
-        # Apply chain rule: dL/dH = dL/dM_init * dM_init/dH = dL/dM_init * M_init
-        # Since M_init = exp(H_res_logits), we have d(exp(x))/dx = exp(x) = M_init
-        grad_input = grad_M_init * M_init
+def native_sinkhorn(input_logits: Tensor, num_iterations: int, eps: float = 1e-6) -> Tensor:
+    """Native Sinkhorn-Knopp (autograd.Function wrapper)."""
+    return SinkhornKnopp.apply(input_logits, num_iterations, eps)
 
-        return grad_input, None
+
+@torch.compile
+def native_h_aggregate(x: Tensor, h_pre: Tensor) -> Tensor:
+    """Native n-stream weighted aggregation: out = sum_j(h_pre_j * x_j)."""
+    return (x * h_pre.unsqueeze(-1)).sum(dim=2)
+
+
+@torch.compile
+def native_h_post_bda(
+    h_res: Tensor, original_residual: Tensor, h_post: Tensor, x: Tensor, bias: Optional[Tensor]
+) -> Tensor:
+    """Native H_res.T @ residual + H_post * (x [+ bias])."""
+    s, b, n, C = original_residual.shape
+    h_res_batched = h_res.view(s * b, n, n)
+    residual_batched = original_residual.view(s * b, n, C)
+    mixed = torch.bmm(h_res_batched.transpose(1, 2), residual_batched).view(s, b, n, C)
+    x_expanded = h_post.unsqueeze(-1) * x.unsqueeze(2)
+    if bias is not None:
+        bias_expanded = h_post.unsqueeze(-1) * bias.view(1, 1, 1, C)
+        return x_expanded + bias_expanded + mixed
+    return x_expanded + mixed
+
+
+@torch.compile
+def native_proj_rms(x: Tensor, weight: Tensor, eps: float = 1e-6) -> Tuple[Tensor, Tensor]:
+    """Native fused projection + RMS normalization."""
+    proj = torch.matmul(x, weight.t())
+    norm = x.norm(dim=-1, keepdim=True)
+    K = x.shape[-1]
+    v = norm / math.sqrt(K) + eps
+    r = 1.0 / v
+    return proj, r
+
+
+@torch.compile
+def native_fused_add_3(a: Tensor, b: Tensor, c: Tensor) -> Tensor:
+    """Native 3-way elementwise add (torch.compile fuses into single kernel)."""
+    return a + b + c
+
+
+class BroadcastTensorFused(torch.autograd.Function):
+    """Split one tensor into 3 autograd-graph children sharing the same storage.
+
+    During backward the three incoming gradients are summed with a caller-
+    supplied fused-add function (cuTile or torch.compile fallback) instead of
+    PyTorch's default sequential accumulation.
+    """
+
+    @staticmethod
+    def forward(ctx, x, fused_add_3_fn):
+        """Return three view aliases and save the fused gradient combiner."""
+        ctx.fused_add_3_fn = fused_add_3_fn
+        return x.view_as(x), x.view_as(x), x.view_as(x)
+
+    @staticmethod
+    def backward(ctx, grad1, grad2, grad3):
+        """Combine gradients from the three broadcast aliases."""
+        grads = [g for g in (grad1, grad2, grad3) if g is not None]
+        if len(grads) == 0:
+            return None, None
+        if len(grads) == 1:
+            return grads[0], None
+        if len(grads) == 2:
+            return grads[0] + grads[1], None
+        return ctx.fused_add_3_fn(grad1, grad2, grad3), None
+
+
+@torch.compile
+def learned_output_contract(
+    hidden_states: Tensor, head_fn: Tensor, base: Tensor, scale: Tensor, n: int, eps: float
+) -> Tensor:
+    """Learned output contraction: n-stream → 1-stream via sigmoid-gated weighted sum."""
+    dtype = hidden_states.dtype
+    hidden_states = hidden_states.to(torch.float32)
+    head_fn = head_fn.to(torch.float32)
+    base = base.to(torch.float32)
+    scale = scale.to(torch.float32)
+    rsqrt = torch.rsqrt(hidden_states.square().mean(-1, keepdim=True) + eps)
+    mixes = F.linear(hidden_states, head_fn) * rsqrt
+    pre = torch.sigmoid(mixes * scale + base) + eps
+    y = torch.sum(pre.unsqueeze(-1) * hidden_states.view(*hidden_states.shape[:-1], n, -1), dim=-2)
+    return y.to(dtype)
+
+
+# ============================================================================
+# HyperConnectionModule
+# ============================================================================
 
 
 # TODO: keep hyper connection in fp32 computation
@@ -152,13 +192,13 @@ class HyperConnectionModule(MegatronModule):
     Unified mHC (Manifold-Constrained Hyper-Connections) module.
 
     Implements the complete mHC propagation:
-        x_{l+1} = H_res @ x_l + H_post^T @ F(H_pre @ x_l)
+        x_{l+1} = H_res^T @ x_l + H_post^T @ F(H_pre @ x_l)
 
     This module handles:
     1. Computing learnable mappings: H_pre, H_post, H_res (with Sinkhorn-Knopp projection)
     2. Aggregation: n-stream → 1-stream (H_pre @ x)
     3. Expansion: 1-stream → n-stream (H_post^T @ output)
-    4. Residual merge: H_res @ x + expanded_output
+    4. Residual merge: H_res^T @ x + expanded_output
     5. Block-level expand/contract for TransformerBlock boundaries
 
     Args:
@@ -173,6 +213,8 @@ class HyperConnectionModule(MegatronModule):
         self.n = config.mhc_num_residual_streams
         self.hidden_size = config.hidden_size
         self.sinkhorn_iterations = config.mhc_sinkhorn_iterations
+        self.sinkhorn_eps = _MHC_SINKHORN_EPS
+        self.compute_h_eps = _MHC_COMPUTE_H_EPS
 
         # Projection weights for dynamic mappings
         # Input: [s, b, n*C] -> Output: n^2 + 2n values per token
@@ -191,7 +233,44 @@ class HyperConnectionModule(MegatronModule):
 
         # Static bias terms
         self.bias = nn.Parameter(torch.zeros(self.n * self.n + 2 * self.n))
+        mark_keep_in_fp32(self.mapping_proj.weight)
+        mark_keep_in_fp32(self.alpha_pre)
+        mark_keep_in_fp32(self.alpha_post)
+        mark_keep_in_fp32(self.alpha_res)
+        mark_keep_in_fp32(self.bias)
         self.norm_eps = 1e-6
+
+        # Choose implementation: unified fused kernels vs reference modules.
+        # The fused public API selects the backend per operation internally.
+        # fused_add_3 always uses torch.compile (native_fused_add_3) regardless
+        # of the kernel backend. cuTile's register overhead (56 regs/thread for
+        # a trivial a+b+c) is not worth it for a pure memory-bound elementwise op.
+        self._fused_add_3_op = native_fused_add_3
+
+        # The fused path computes the projection and compute_h in one op, so
+        # _projection_and_get_norm — and therefore _proj_rms_op — is only ever
+        # reached on the unfused path.
+        self._proj_rms_op = native_proj_rms
+
+        if config.use_fused_mhc:
+            from megatron.core.fusions.fused_mhc_kernels import (
+                fused_h_aggregate,
+                fused_h_post_bda,
+                fused_proj_rms_compute_h,
+                fused_sinkhorn,
+                log_fused_mhc_backend_once,
+            )
+
+            log_fused_mhc_backend_once()
+            self._sinkhorn_op = fused_sinkhorn
+            self._h_aggregate_op = fused_h_aggregate
+            self._h_post_bda_op = fused_h_post_bda
+            self._proj_rms_compute_h_op = fused_proj_rms_compute_h
+        else:
+            self._sinkhorn_op = native_sinkhorn
+            self._h_aggregate_op = native_h_aggregate
+            self._h_post_bda_op = native_h_post_bda
+            self._proj_rms_compute_h_op = None
 
         self._init_weights()
 
@@ -213,19 +292,21 @@ class HyperConnectionModule(MegatronModule):
             setattr(self.alpha_res, 'sequence_parallel', True)
             setattr(self.bias, 'sequence_parallel', True)
 
-    @torch.compile
     def _projection_and_get_norm(self, x: Tensor) -> Tuple[Tensor, Tensor]:
         """
-        Project input hidden states to mapping space and apply RMS normalization.
+        Projection + RMS normalization.
 
         Args:
             x: [s, b, n*C] - n-stream hidden states
         """
-        nC = x.shape[-1]
-        r = x.norm(dim=-1, keepdim=True) / math.sqrt(nC)  # shape: [s, b, 1]
-        r = 1.0 / (r + self.norm_eps)  # shape: [s, b, 1]
-        proj = self.mapping_proj(x)  # [s, b, n^2 + 2n]
-        return proj, r
+        s, b, nC = x.shape
+        # The mHC mapping computation runs in FP32: the parameters are kept in
+        # FP32 and the activations are upcast here, then compute_mappings casts
+        # the bounded mixing weights back to the activation dtype.
+        x_2d = x.reshape(s * b, nC).to(torch.float32)
+        weight = self.mapping_proj.weight.to(torch.float32)
+        proj, r = self._proj_rms_op(x_2d, weight, self.norm_eps)
+        return proj.view(s, b, -1), r.view(s, b, 1)
 
     @torch.compile
     def _compute_h(self, proj: Tensor, r: Tensor) -> Tuple[Tensor, Tensor, Tensor]:
@@ -249,12 +330,13 @@ class HyperConnectionModule(MegatronModule):
             ],
             dim=-1,
         )
+
         h = r * proj * alpha_ + self.bias
         # H_pre = σ(α_pre * (θ_pre @ x̃) + b_pre)
-        h_pre = h[..., : self.n].sigmoid()  # [s, b, n]
+        h_pre = h[..., : self.n].sigmoid() + self.compute_h_eps  # [s, b, n]
 
         # H_post = 2σ(α_post * (θ_post @ x̃) + b_post)
-        h_post = h[..., self.n : 2 * self.n].sigmoid() * 2  # [s, b, n]
+        h_post = h[..., self.n : 2 * self.n].sigmoid() * 2
         h_res = h[..., 2 * self.n :]
         return h_pre, h_post, h_res
 
@@ -274,15 +356,42 @@ class HyperConnectionModule(MegatronModule):
             h_res: [s, b, n, n] - residual mixing matrix (doubly stochastic)
         """
         s, b, _ = x.shape
-        with torch.cuda.nvtx.range("HyperConnection::projection_and_get_norm"):
-            proj, r = self._projection_and_get_norm(x)
-        with torch.cuda.nvtx.range("HyperConnection::compute_h"):
-            h_pre, h_post, h_res = self._compute_h(proj, r)
-        h_res = SinkhornKnopp.apply(
-            h_res.view(s, b, self.n, self.n), self.sinkhorn_iterations
+
+        if self._proj_rms_compute_h_op is not None:
+            # Fused path: proj_rms + compute_h in one kernel launch sequence
+            x_2d = x.reshape(s * b, self.n * self.hidden_size)
+            with torch.cuda.nvtx.range("HyperConnection::fused_proj_rms_compute_h"):
+                h_pre, h_post, h_res, _ = self._proj_rms_compute_h_op(
+                    x_2d,
+                    self.mapping_proj.weight,
+                    self.alpha_pre,
+                    self.alpha_post,
+                    self.alpha_res,
+                    self.bias,
+                    self.n,
+                    self.norm_eps,
+                    self.compute_h_eps,
+                )
+            h_pre = h_pre.view(s, b, self.n)
+            h_post = h_post.view(s, b, self.n)
+            h_res = h_res.view(s, b, self.n, self.n)
+        else:
+            # Native path: separate proj_rms + _compute_h
+            with torch.cuda.nvtx.range("HyperConnection::projection_and_get_norm"):
+                proj, r = self._projection_and_get_norm(x)
+            with torch.cuda.nvtx.range("HyperConnection::compute_h"):
+                h_pre, h_post, h_res = self._compute_h(proj, r)
+            h_res = h_res.view(s, b, self.n, self.n)
+
+        h_res = self._sinkhorn_op(
+            h_res, self.sinkhorn_iterations, self.sinkhorn_eps
         )  # [s, b, n, n]
 
-        return h_pre, h_post, h_res
+        # The mixing weights are bounded (sigmoid outputs / doubly stochastic
+        # matrix), so after the FP32 computation they are safe to apply to the
+        # streams in the activation dtype.
+        dtype = x.dtype
+        return h_pre.to(dtype), h_post.to(dtype), h_res.to(dtype)
 
     @torch.compile
     def _apply_h_post(self, x: Tensor, h_post: Tensor) -> Tensor:
@@ -322,7 +431,7 @@ class HyperConnectionModule(MegatronModule):
         self,
         x_with_bias: Tuple[Tensor, Optional[Tensor]],
         h_post: Tensor,
-        manager: Optional['CheckpointWithoutOutputManager'] = None,
+        manager: Optional[CheckpointWithoutOutputManager] = None,
     ) -> Tuple[Tensor, Optional[Tensor]]:
         """
         Apply H_post to x and optionally bias, with optional checkpointing.
@@ -367,12 +476,9 @@ class HyperConnectionModule(MegatronModule):
 
         return x_out, bias_out
 
-    @torch.compile
     def aggregate(self, x: Tensor, h_pre: Tensor) -> Tensor:
         """
-        Aggregate n-stream to 1-stream using H_pre weights.
-
-        Computes: sum_i(h_pre_i * x_stream_i)
+        Aggregate n-stream to 1-stream.
 
         Args:
             x: [s, b, n*C] - n-stream hidden states
@@ -383,21 +489,15 @@ class HyperConnectionModule(MegatronModule):
         """
         s, b, _ = x.shape
         C = self.hidden_size
-
-        # Reshape to [s, b, n, C]
         x_streams = x.view(s, b, self.n, C)
-
-        # Weighted sum: [s, b, n, C] * [s, b, n, 1] -> sum over n -> [s, b, C]
-        aggregated = (x_streams * h_pre.unsqueeze(-1)).sum(dim=2)
-
-        return aggregated
+        return self._h_aggregate_op(x_streams, h_pre)
 
     @torch.compile
     def apply_h_res(self, h_res: Tensor, residual: Tensor) -> Tensor:
         """
         Apply H_res to residual using H_res weights.
 
-        Computes: H_res @ residual
+        Computes: H_res.T @ residual
 
         Args:
             h_res: [s, b, n, n] - residual mixing matrix
@@ -412,35 +512,47 @@ class HyperConnectionModule(MegatronModule):
         # [s, b, n*C] -> [s, b, n, C] -> [s*b, n, C]
         residual_batched = residual.view(s, b, n, C).view(s * b, n, C)
 
-        # Batch matrix multiply: [s*b, n, n] @ [s*b, n, C] -> [s*b, n, C]
-        mixed = torch.bmm(h_res_batched, residual_batched)
+        # Batch matrix multiply: [s*b, n, n].T @ [s*b, n, C] -> [s*b, n, C]
+        mixed = torch.bmm(h_res_batched.transpose(1, 2), residual_batched)
 
         return mixed.view(s, b, n * C)
 
     def forward(
         self,
         hidden_states: Tensor,
-        mhc_recompute_manager: Optional['CheckpointWithoutOutputManager'] = None,
-    ) -> Tuple[Tensor, Tensor, Tensor]:
+        mhc_recompute_manager: Optional[CheckpointWithoutOutputManager] = None,
+        return_residual: bool = False,
+    ) -> Tuple[Tensor, ...]:
         """
         Full mHC forward pass.
 
+        Uses BroadcastTensorFused to split hidden_states into 3 autograd-graph
+        children so that gradient accumulation from the 3 consumers
+        (compute_mappings, aggregate, fused_h_res_h_post_bda) is handled by a
+        single fused add instead of PyTorch's default sequential accumulation.
+
         Args:
             hidden_states: [s, b, n*C] - n-stream hidden states
-            mhc_recompute_manager: Optional CheckpointWithoutOutputManager for checkpoint mgmt.
+            mhc_recompute_manager: Optional CheckpointWithoutOutputManager for checkpoint
+                management.
                 When provided, uses _forward_with_checkpoint for memory-efficient execution.
 
         Returns:
+            The compatible 3-tuple ``(aggregated, h_res, h_post)`` by default.
+            HybridModel callers set ``return_residual=True`` to also receive the
+            residual branch created by ``BroadcastTensorFused``.
             aggregated: [s, b, C] - aggregated input for layer computation
             h_res: [s, b, n, n] - residual mixing matrix (for fused kernel)
             h_post: [s, b, n] - expansion weights
+            residual: [s, b, n*C] - residual view for fused_h_res_h_post_bda
         """
         if mhc_recompute_manager is not None:
-            return self._forward_with_checkpoint(hidden_states, mhc_recompute_manager)
+            result = self._forward_with_checkpoint(hidden_states, mhc_recompute_manager)
         else:
-            return self._forward_normal(hidden_states)
+            result = self._forward_normal(hidden_states)
+        return result if return_residual else result[:3]
 
-    def _forward_normal(self, hidden_states: Tensor) -> Tuple[Tensor, Tensor, Tensor]:
+    def _forward_normal(self, hidden_states: Tensor) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
         """
         Normal forward pass without checkpointing.
 
@@ -451,19 +563,25 @@ class HyperConnectionModule(MegatronModule):
             aggregated: [s, b, C] - aggregated input for layer computation
             h_res: [s, b, n, n] - residual mixing matrix (for fused kernel)
             h_post: [s, b, n] - expansion weights
+            residual: [s, b, n*C] - residual view for fused_h_res_h_post_bda
         """
+        # Split into 3 views to avoid extra grad accumulations in backward
+        hs_for_mappings, hs_for_aggregate, hs_for_residual = BroadcastTensorFused.apply(
+            hidden_states, self._fused_add_3_op
+        )
+
         # Compute mappings
-        h_pre, h_post, h_res = self.compute_mappings(hidden_states)
+        h_pre, h_post, h_res = self.compute_mappings(hs_for_mappings)
 
         # Aggregate for layer input
         with torch.cuda.nvtx.range("HyperConnection::aggregate"):
-            aggregated = self.aggregate(hidden_states, h_pre)
+            aggregated = self.aggregate(hs_for_aggregate, h_pre)
 
-        return aggregated, h_res, h_post
+        return aggregated, h_res, h_post, hs_for_residual
 
     def _forward_with_checkpoint(
-        self, hidden_states: Tensor, manager: 'CheckpointWithoutOutputManager'
-    ) -> Tuple[Tensor, Tensor, Tensor]:
+        self, hidden_states: Tensor, manager: CheckpointWithoutOutputManager
+    ) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
         """
         Forward pass with checkpointing for memory efficiency.
 
@@ -480,17 +598,23 @@ class HyperConnectionModule(MegatronModule):
             aggregated: [s, b, C] - aggregated input for layer computation
             h_res: [s, b, n, n] - residual mixing matrix (for fused kernel)
             h_post: [s, b, n] - expansion weights
+            residual: [s, b, n*C] - residual view for fused_h_res_h_post_bda
         """
         from megatron.core.tensor_parallel.random import CheckpointWithoutOutput
 
-        h_pre, h_post, h_res = self.compute_mappings(hidden_states)
+        # Split into 3 views to avoid extra grad accumulations in backward
+        hs_for_mappings, hs_for_aggregate, hs_for_residual = BroadcastTensorFused.apply(
+            hidden_states, self._fused_add_3_op
+        )
+
+        h_pre, h_post, h_res = self.compute_mappings(hs_for_mappings)
 
         # Checkpoint aggregate - auto-registers to manager
         aggregated = CheckpointWithoutOutput(ckpt_manager=manager).checkpoint(
-            self.aggregate, hidden_states, h_pre
+            self.aggregate, hs_for_aggregate, h_pre
         )
 
-        return aggregated, h_res, h_post
+        return aggregated, h_res, h_post, hs_for_residual
 
     # ==================== Block-level utilities ====================
 
@@ -546,7 +670,7 @@ class HyperConnectionModule(MegatronModule):
         dropout_prob: float,
         training: bool,
         fused: bool,
-        manager: Optional['CheckpointWithoutOutputManager'] = None,
+        manager: Optional[CheckpointWithoutOutputManager] = None,
     ) -> Tensor:
         """
         Fused kernel combining apply_h_res, apply_h_post and bias-dropout-add.
@@ -555,7 +679,7 @@ class HyperConnectionModule(MegatronModule):
         Currently implements the operations sequentially using native PyTorch.
 
         The computation flow is:
-            1. mixed = H_res @ original_residual (apply_h_res)
+            1. mixed = H_res.T @ original_residual (apply_h_res)
             2. expanded = H_post^T @ layer_output (apply_h_post)
             3. output = dropout(expanded + bias) + mixed (bias-dropout-add)
 
@@ -608,7 +732,11 @@ class HyperConnectionModule(MegatronModule):
         fused: bool,
     ) -> Tensor:
         """
-        Native implementation of fused h_res, h_post and bda operations.
+        h_res, h_post and bda.
+
+        When dropout is zero (or inference), uses a single fused/reference kernel
+        for H_res.T @ residual + H_post * (x + bias). Falls back to unfused
+        implementation when dropout is needed.
 
         Args:
             h_res: [s, b, n, n] - residual mixing matrix
@@ -622,23 +750,26 @@ class HyperConnectionModule(MegatronModule):
         Returns:
             output: [s, b, n*C] - final output
         """
+        x, bias = layer_output_with_bias
+
+        if dropout_prob == 0.0 or not training:
+            s, b, _ = original_residual.shape
+            n = self.n
+            C = self.hidden_size
+            orig_reshaped = original_residual.view(s, b, n, C)
+            output = self._h_post_bda_op(h_res, orig_reshaped, h_post, x, bias)
+            return output.view(s, b, n * C)
+
         from megatron.core.fusions.fused_bias_dropout import get_bias_dropout_add
 
-        # Step 1: Apply H_res to original residual
         with torch.cuda.nvtx.range("HyperConnection::apply_h_res"):
             mixed = self.apply_h_res(h_res, original_residual)
-
-        # Step 2: Apply H_post to layer output
-        x, bias = layer_output_with_bias
         with torch.cuda.nvtx.range("HyperConnection::apply_h_post"):
             x_expanded = self._apply_h_post(x, h_post)
             bias_expanded = self._apply_h_post(bias, h_post) if bias is not None else None
-
-        # Step 3: Bias-dropout-add
         bda_func = get_bias_dropout_add(training, fused)
         with torch.cuda.nvtx.range("HyperConnection::bda"):
             output = bda_func((x_expanded, bias_expanded), mixed, dropout_prob)
-
         return output
 
     @nvtx_decorator(message="HyperConnection::fused_h_res_h_post_bda_with_checkpoint")
@@ -651,12 +782,15 @@ class HyperConnectionModule(MegatronModule):
         dropout_prob: float,
         training: bool,
         fused: bool,
-        manager: 'CheckpointWithoutOutputManager',
+        manager: CheckpointWithoutOutputManager,
     ) -> Tensor:
         """
-        Checkpointed implementation of fused h_res, h_post and bda operations.
+        Checkpointed variant of _fused_h_res_h_post_bda_native.
 
-        Uses a single checkpoint wrapper around all operations for memory efficiency.
+        Wraps compute in CheckpointWithoutOutput for activation memory savings.
+        Cannot reuse _native directly because checkpoint requires all args to be
+        positional Tensors; tuple/Optional/scalar args are unpacked or captured
+        via closure instead.
 
         Args:
             h_res: [s, b, n, n] - residual mixing matrix
@@ -671,42 +805,52 @@ class HyperConnectionModule(MegatronModule):
         Returns:
             output: [s, b, n*C] - final output
         """
-        from megatron.core.fusions.fused_bias_dropout import get_bias_dropout_add
         from megatron.core.tensor_parallel.random import CheckpointWithoutOutput
 
-        # Get BDA function (captured via closure)
-        bda_func = get_bias_dropout_add(training, fused)
-
-        # Unpack layer_output_with_bias to avoid tuple tensors in checkpoint args
         x, bias = layer_output_with_bias
-        has_bias = bias is not None
+        n = self.n
+        C = self.hidden_size
 
-        # Native wrapper that combines all operations without internal checkpointing.
-        # Non-tensor args (dropout_prob, has_bias) are captured via closure.
-        def _native_wrapper(h_res, original_residual, h_post, x, *optional_bias):
-            # Step 1: Apply H_res to original residual
-            with torch.cuda.nvtx.range("HyperConnection::apply_h_res"):
-                mixed = self.apply_h_res(h_res, original_residual)
+        # Fast path: no dropout — use fused/reference h_post_bda kernel (same as _native)
+        if dropout_prob == 0.0 or not training:
 
-            # Step 2: Apply H_post to x and bias
-            with torch.cuda.nvtx.range("HyperConnection::apply_h_post"):
-                x_expanded = self._apply_h_post(x, h_post)
-                if has_bias:
-                    bias_expanded = self._apply_h_post(optional_bias[0], h_post)
-                else:
-                    bias_expanded = None
+            def _fused_wrapper(h_res, original_residual, h_post, x, *optional_bias):
+                s, b, _ = original_residual.shape
+                orig_reshaped = original_residual.view(s, b, n, C)
+                b_arg = optional_bias[0] if optional_bias else None
+                return self._h_post_bda_op(h_res, orig_reshaped, h_post, x, b_arg).view(s, b, n * C)
 
-            # Step 3: Bias-dropout-add
-            with torch.cuda.nvtx.range("HyperConnection::bda"):
-                output = bda_func((x_expanded, bias_expanded), mixed, dropout_prob)
+            ckpt = CheckpointWithoutOutput(ckpt_manager=manager)
+            if bias is not None:
+                output = ckpt.checkpoint(_fused_wrapper, h_res, original_residual, h_post, x, bias)
+            else:
+                output = ckpt.checkpoint(_fused_wrapper, h_res, original_residual, h_post, x)
 
-            return output
-
-        # Use a single checkpoint wrapper for all operations
-        ckpt = CheckpointWithoutOutput(ckpt_manager=manager)
-        if has_bias:
-            output = ckpt.checkpoint(_native_wrapper, h_res, original_residual, h_post, x, bias)
+        # Slow path: dropout required — fused kernel does not support dropout,
+        # fall back to sequential apply_h_res + apply_h_post + bda
         else:
-            output = ckpt.checkpoint(_native_wrapper, h_res, original_residual, h_post, x)
+            from megatron.core.fusions.fused_bias_dropout import get_bias_dropout_add
+
+            bda_func = get_bias_dropout_add(training, fused)
+            has_bias = bias is not None
+
+            def _native_wrapper(h_res, original_residual, h_post, x, *optional_bias):
+                with torch.cuda.nvtx.range("HyperConnection::apply_h_res"):
+                    mixed = self.apply_h_res(h_res, original_residual)
+                with torch.cuda.nvtx.range("HyperConnection::apply_h_post"):
+                    x_expanded = self._apply_h_post(x, h_post)
+                    if has_bias:
+                        bias_expanded = self._apply_h_post(optional_bias[0], h_post)
+                    else:
+                        bias_expanded = None
+                with torch.cuda.nvtx.range("HyperConnection::bda"):
+                    output = bda_func((x_expanded, bias_expanded), mixed, dropout_prob)
+                return output
+
+            ckpt = CheckpointWithoutOutput(ckpt_manager=manager)
+            if has_bias:
+                output = ckpt.checkpoint(_native_wrapper, h_res, original_residual, h_post, x, bias)
+            else:
+                output = ckpt.checkpoint(_native_wrapper, h_res, original_residual, h_post, x)
 
         return output

--- a/megatron/core/transformer/hyper_connection.py
+++ b/megatron/core/transformer/hyper_connection.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import math
+from functools import partial
 from typing import Optional, Tuple
 
 import torch
@@ -261,11 +262,12 @@ class HyperConnectionModule(MegatronModule):
                 log_fused_mhc_backend_once,
             )
 
-            log_fused_mhc_backend_once()
-            self._sinkhorn_op = fused_sinkhorn
-            self._h_aggregate_op = fused_h_aggregate
-            self._h_post_bda_op = fused_h_post_bda
-            self._proj_rms_compute_h_op = fused_proj_rms_compute_h
+            backend = config.mhc_fused_backend
+            log_fused_mhc_backend_once(backend)
+            self._sinkhorn_op = partial(fused_sinkhorn, backend=backend)
+            self._h_aggregate_op = partial(fused_h_aggregate, backend=backend)
+            self._h_post_bda_op = partial(fused_h_post_bda, backend=backend)
+            self._proj_rms_compute_h_op = partial(fused_proj_rms_compute_h, backend=backend)
         else:
             self._sinkhorn_op = native_sinkhorn
             self._h_aggregate_op = native_h_aggregate

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Callable, List, Optional, Union
 
 import torch
+import torch.nn as nn
 from torch import Tensor
 
 from megatron.core import InferenceParams, parallel_state, tensor_parallel
@@ -29,7 +30,8 @@ from megatron.core.tensor_parallel.inference_layers import (
     is_inference_column_parallel_linear,
 )
 from megatron.core.transformer.enums import AttnMaskType, LayerType
-from megatron.core.transformer.module import MegatronModule
+from megatron.core.transformer.hyper_connection import learned_output_contract
+from megatron.core.transformer.module import MegatronModule, mark_keep_in_fp32
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
 from megatron.core.transformer.torch_norm import LayerNormBuilder
 from megatron.core.transformer.transformer_block import TransformerBlockSubmodules
@@ -745,6 +747,8 @@ class MultiTokenPredictionLayerSubmodules:
     layer_norm: LayerNormBuilder
 
     eh_proj: Union[ModuleSpec, type] = None
+    e_proj: Union[ModuleSpec, type] = None
+    h_proj: Union[ModuleSpec, type] = None
     mtp_model_layer: Union[ModuleSpec, type] = None
 
 
@@ -1118,6 +1122,13 @@ class MultiTokenPredictionLayer(MegatronModule):
                 stacklevel=2,
             )
             hybrid_submodules = mamba_submodules
+        if self.config.enable_mhc_connections and (
+            mtp_layer_pattern is None or hybrid_submodules is None
+        ):
+            raise ValueError(
+                "Multi-token prediction with hyper connections requires the HybridModel "
+                "MTP contract: both mtp_layer_pattern and hybrid_submodules must be provided."
+            )
         self.sequence_parallel = config.sequence_parallel
         self.submodules = submodules
         self.layer_number = layer_number + get_mtp_layer_offset(self.config, vp_stage)
@@ -1125,6 +1136,7 @@ class MultiTokenPredictionLayer(MegatronModule):
         self.cp_group = pg_collection.cp
         self.tp_group = pg_collection.tp if pg_collection is not None else None
         self.mtp_layer_pattern = mtp_layer_pattern
+        self.mhc_enabled = self.config.enable_mhc_connections
 
         # Validate attention mask type if using transformer-based inner layers
         if self.submodules.mtp_model_layer is not None and hasattr(
@@ -1166,32 +1178,58 @@ class MultiTokenPredictionLayer(MegatronModule):
             eps=self.config.layernorm_epsilon,
         )
 
-        # For the linear projection at the (k - 1)-th MTP layer, the input is the concatenation
-        # of the i-th token's hidden states and the (i + K)-th token's decoder input,
-        # so the input's shape is [s, b, 2*h].
-        # The output will be send to the following transformer layer,
-        # so the output's shape should be [s, b, h].
-        self.eh_proj = build_module(
-            self.submodules.eh_proj,
-            self.config.hidden_size * 2,
-            self.config.hidden_size,
-            config=self.config,
-            init_method=self.config.init_method,
-            gather_output=False,
-            bias=False,
-            skip_bias_add=False,
-            is_expert=False,
-            tp_comm_buffer_name="mtp_eh_proj",
-            tp_group=pg_collection.tp if pg_collection is not None else None,
-            name=(name + ".eh_proj") if name is not None else None,
-        )
-        # eh_proj's input all-gather reuses the shared "tp" symmetric buffer right
-        # after the preceding layer's all-gather (the fused rs-add-norm-ag terminates
-        # with one, as does the previous MTP step's output all-gather), so it must
-        # barrier before overwriting. Only the inference-optimized linear implements
-        # this all-gather; other eh_proj impls have no such buffer to guard.
-        if is_inference_column_parallel_linear(self.eh_proj):
-            self.eh_proj.set_barrier_before_all_gather(True)
+        if self.mhc_enabled:
+            projection_kwargs = {
+                "config": self.config,
+                "init_method": self.config.init_method,
+                "gather_output": False,
+                "bias": False,
+                "skip_bias_add": False,
+                "is_expert": False,
+                "tp_group": pg_collection.tp if pg_collection is not None else None,
+            }
+            self.e_proj = build_module(
+                self.submodules.e_proj,
+                self.config.hidden_size,
+                self.config.hidden_size,
+                tp_comm_buffer_name="mtp_e_proj",
+                name=(name + ".e_proj") if name is not None else None,
+                **projection_kwargs,
+            )
+            self.h_proj = build_module(
+                self.submodules.h_proj,
+                self.config.hidden_size,
+                self.config.hidden_size,
+                tp_comm_buffer_name="mtp_h_proj",
+                name=(name + ".h_proj") if name is not None else None,
+                **projection_kwargs,
+            )
+            self.eh_proj = None
+        else:
+            # Combine each hidden state with the corresponding future-token embedding.
+            self.eh_proj = build_module(
+                self.submodules.eh_proj,
+                self.config.hidden_size * 2,
+                self.config.hidden_size,
+                config=self.config,
+                init_method=self.config.init_method,
+                gather_output=False,
+                bias=False,
+                skip_bias_add=False,
+                is_expert=False,
+                tp_comm_buffer_name="mtp_eh_proj",
+                tp_group=pg_collection.tp if pg_collection is not None else None,
+                name=(name + ".eh_proj") if name is not None else None,
+            )
+            self.e_proj = None
+            self.h_proj = None
+            # eh_proj's input all-gather reuses the shared "tp" symmetric buffer right
+            # after the preceding layer's all-gather (the fused rs-add-norm-ag terminates
+            # with one, as does the previous MTP step's output all-gather), so it must
+            # barrier before overwriting. Only the inference-optimized linear implements
+            # this all-gather; other eh_proj impls have no such buffer to guard.
+            if is_inference_column_parallel_linear(self.eh_proj):
+                self.eh_proj.set_barrier_before_all_gather(True)
 
         # Build inner layers: two possible paths
         # 1. Hybrid path: use HybridStack for hybrid pattern support
@@ -1249,6 +1287,17 @@ class MultiTokenPredictionLayer(MegatronModule):
             hidden_size=self.config.hidden_size,
             eps=self.config.layernorm_epsilon,
         )
+        if self.mhc_enabled:
+            hc_mult = self.config.mhc_num_residual_streams
+            hc_dim = self.config.hidden_size * hc_mult
+            self.hc_head_fn = mark_keep_in_fp32(nn.Parameter(torch.randn(hc_mult, hc_dim)))
+            self.hc_head_base = mark_keep_in_fp32(nn.Parameter(torch.zeros(hc_mult)))
+            self.hc_head_scale = mark_keep_in_fp32(nn.Parameter(torch.ones(1)))
+            nn.init.xavier_uniform_(self.hc_head_fn)
+            if self.config.sequence_parallel:
+                setattr(self.hc_head_fn, "sequence_parallel", True)
+                setattr(self.hc_head_base, "sequence_parallel", True)
+                setattr(self.hc_head_scale, "sequence_parallel", True)
         self.offload_context = nullcontext()
 
     def _get_embeddings(
@@ -1334,28 +1383,47 @@ class MultiTokenPredictionLayer(MegatronModule):
         """
         decoder_input = apply_module(self.enorm)(decoder_input)
         decoder_input = make_viewless_tensor(inp=decoder_input, requires_grad=True, keep_graph=True)
-        hidden_states = apply_module(self.hnorm)(hidden_states)
-        hidden_states = make_viewless_tensor(inp=hidden_states, requires_grad=True, keep_graph=True)
-        # At the (k - 1)-th MTP module, concatenates the i-th token's hidden_states
-        # and the (i + K)-th token's embedding, and combine them with linear projection.
-        hidden_states = torch.cat((decoder_input, hidden_states), -1)
-        hidden_states, _ = self.eh_proj(hidden_states)
-        # For tensor parallel we need to gather the tensor across the model-parallel
-        # ranks after the linear projection.
-        if InferenceMode.is_active():
-            # This all-gather immediately follows eh_proj's input all-gather on the
-            # same symmetric buffer (only eh_proj's local matmul runs in between), so
-            # it must barrier before overwriting the buffer's previous contents.
-            hidden_states = inference_all_gather_from_tensor_model_parallel_region(
-                hidden_states, self.tp_group, self.config, barrier_before=True
+        if self.mhc_enabled:
+            n = self.config.mhc_num_residual_streams
+            h = self.config.hidden_size
+            seq_len, batch_size, _ = hidden_states.shape
+            hidden_streams = hidden_states.view(seq_len, batch_size, n, h)
+            hidden_streams = apply_module(self.hnorm)(hidden_streams)
+            hidden_streams = make_viewless_tensor(
+                inp=hidden_streams, requires_grad=True, keep_graph=True
             )
+            embedded, _ = self.e_proj(decoder_input)
+            embedded = gather_from_tensor_model_parallel_region(embedded, group=self.tp_group)
+            projected_hidden, _ = self.h_proj(hidden_streams)
+            projected_hidden = gather_from_tensor_model_parallel_region(
+                projected_hidden, group=self.tp_group
+            )
+            seq_len, batch_size, n, h = projected_hidden.shape
+            embedded = embedded.unsqueeze(2).expand(seq_len, batch_size, n, h)
+            hidden_states = (embedded + projected_hidden).reshape(seq_len, batch_size, n * h)
+            if self.sequence_parallel:
+                hidden_states = scatter_to_sequence_parallel_region(
+                    hidden_states, group=self.tp_group
+                )
         else:
-            hidden_states = gather_from_tensor_model_parallel_region(
-                hidden_states, group=self.tp_group
+            hidden_states = apply_module(self.hnorm)(hidden_states)
+            hidden_states = make_viewless_tensor(
+                inp=hidden_states, requires_grad=True, keep_graph=True
             )
-        # For sequence parallel, scatter after linear_fc and before transformer layer.
-        if self.sequence_parallel:
-            hidden_states = scatter_to_sequence_parallel_region(hidden_states, group=self.tp_group)
+            hidden_states = torch.cat((decoder_input, hidden_states), -1)
+            hidden_states, _ = self.eh_proj(hidden_states)
+            if InferenceMode.is_active():
+                hidden_states = inference_all_gather_from_tensor_model_parallel_region(
+                    hidden_states, self.tp_group, self.config, barrier_before=True
+                )
+            else:
+                hidden_states = gather_from_tensor_model_parallel_region(
+                    hidden_states, group=self.tp_group
+                )
+            if self.sequence_parallel:
+                hidden_states = scatter_to_sequence_parallel_region(
+                    hidden_states, group=self.tp_group
+                )
         return hidden_states
 
     def _proj_and_transformer_layer(
@@ -1426,7 +1494,8 @@ class MultiTokenPredictionLayer(MegatronModule):
                         padding_mask=padding_mask,
                     )
 
-        hidden_states = self._postprocess(hidden_states)
+        if not self.mhc_enabled:
+            hidden_states = self._postprocess(hidden_states)
 
         return hidden_states
 
@@ -1434,6 +1503,16 @@ class MultiTokenPredictionLayer(MegatronModule):
         """
         Postprocesses the output of the transformer layers.
         """
+
+        if self.mhc_enabled:
+            hidden_states = learned_output_contract(
+                hidden_states,
+                self.hc_head_fn,
+                self.hc_head_base,
+                self.hc_head_scale,
+                self.config.mhc_num_residual_streams,
+                self.config.layernorm_epsilon,
+            )
 
         # Layer norm before shared head layer.
         hidden_states = apply_module(self.final_layernorm)(hidden_states)
@@ -2020,6 +2099,7 @@ class MultiTokenPredictionBlock(MegatronModule):
         sequence_len_offset: Optional[Tensor] = None,
         extra_block_kwargs: Optional[dict] = None,
         embedding=None,
+        mhc_multistream: Optional[Tensor] = None,
     ) -> Tensor:
         """
         Perform the forward pass through all of the MTP modules.
@@ -2027,6 +2107,8 @@ class MultiTokenPredictionBlock(MegatronModule):
         Args:
             hidden_states (Tensor): Hidden states for input token with the shape [s, b, h]
                 where s is the sequence length, b is the batch size, and h is the hidden size.
+            mhc_multistream (Tensor, optional): Pre-contraction decoder output [s, b, n*h]
+                used as the input to MTP depths when hyper connections are enabled.
             attention_mask (Tensor): Boolean tensor of shape [1, 1, s, s] for masking
                 self-attention.
 
@@ -2036,7 +2118,11 @@ class MultiTokenPredictionBlock(MegatronModule):
         # get hidden states from previous mtp stages
         offset = get_mtp_layer_offset(self.config, self.vp_stage)
         hidden_states_list = list(torch.chunk(hidden_states, 1 + offset, dim=0))
-        hidden_states = hidden_states_list[offset]
+        if mhc_multistream is not None:
+            mhc_chunks = list(torch.chunk(mhc_multistream, 1 + offset, dim=0))
+            hidden_states = mhc_chunks[offset]
+        else:
+            hidden_states = hidden_states_list[offset]
 
         if self.config.mtp_detach_heads:
             hidden_states = hidden_states.detach()
@@ -2131,9 +2217,11 @@ class MultiTokenPredictionBlock(MegatronModule):
             if hidden_state_mixing_enabled:
                 hidden_state_history.append(hidden_states)
 
-            # append the output hidden states of the current mtp layer
-            # to the hidden_states_list
-            hidden_states_list.append(hidden_states)
+            if mhc_multistream is not None:
+                mhc_chunks.append(hidden_states)
+                hidden_states_list.append(self.layers[layer_idx]._postprocess(hidden_states))
+            else:
+                hidden_states_list.append(hidden_states)
 
         # concat the hidden states of all mtp layers
         hidden_states = torch.cat(hidden_states_list, dim=0)

--- a/megatron/core/transformer/transformer_block.py
+++ b/megatron/core/transformer/transformer_block.py
@@ -369,6 +369,14 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
                     pg_collection=self.pg_collection,
                     vp_stage=self.vp_stage,
                 )
+            if layer_config.enable_mhc_connections and not getattr(
+                module, "supports_mhc_connections", False
+            ):
+                raise ValueError(
+                    f"{type(module).__name__} does not implement mHC residual streams. Build "
+                    "TransformerBlock with HyperConnectionTransformerLayer when "
+                    "enable_mhc_connections=True."
+                )
             return module
 
         # offset is implicit in TransformerLayer

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -1161,6 +1161,13 @@ class TransformerConfig(ModelParallelConfig):
     mhc_init_gating_factor: float = 0.01
     """Initial value of Gating Factor (alpha in paper)."""
 
+    use_fused_mhc: bool = False
+    """Use fused kernels for mHC operations when supported.
+
+    Backend selection is operation-specific, with native torch fallbacks that
+    preserve the same public behavior when Triton or cuTile is unavailable.
+    """
+
     mhc_recompute_layer_num: Optional[int] = None
     """Number of layers per MHC recompute block.
 
@@ -2120,12 +2127,8 @@ class TransformerConfig(ModelParallelConfig):
                 "recompute_modules with selective recompute to reduce activation memory."
             )
 
-        # Validation for hyper_connections with MTP
-        if self.enable_mhc_connections and self.mtp_num_layers is not None:
-            raise ValueError(
-                "enable_mhc_connections is not compatible with Multi-Token Prediction (MTP). "
-                "Please disable MTP (set mtp_num_layers=None) when using hyper connections."
-            )
+        if self.use_fused_mhc and not self.enable_mhc_connections:
+            raise ValueError("use_fused_mhc requires enable_mhc_connections=True.")
 
         if self.enable_mhc_connections and self.recompute_granularity == "full":
             raise NotImplementedError(

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -1164,8 +1164,18 @@ class TransformerConfig(ModelParallelConfig):
     use_fused_mhc: bool = False
     """Use fused kernels for mHC operations when supported.
 
-    Backend selection is operation-specific, with native torch fallbacks that
-    preserve the same public behavior when Triton or cuTile is unavailable.
+    With the default ``auto`` backend policy, selection is operation-specific
+    and unavailable accelerated implementations fall back to native torch.
+    Set ``mhc_fused_backend`` to request an explicit backend policy.
+    """
+
+    mhc_fused_backend: Literal["auto", "native", "triton", "cutile"] = "auto"
+    """Backend policy for fused mHC operations.
+
+    ``auto`` selects the fastest available implementation for each operation.
+    Explicit policies require the requested dependency and device support, and
+    never select a different accelerated backend. Operations without an
+    implementation in the selected backend retain their native implementation.
     """
 
     mhc_recompute_layer_num: Optional[int] = None
@@ -2130,6 +2140,15 @@ class TransformerConfig(ModelParallelConfig):
         if self.use_fused_mhc and not self.enable_mhc_connections:
             raise ValueError("use_fused_mhc requires enable_mhc_connections=True.")
 
+        valid_mhc_fused_backends = ("auto", "native", "triton", "cutile")
+        if self.mhc_fused_backend not in valid_mhc_fused_backends:
+            raise ValueError(
+                f"Unknown mhc_fused_backend {self.mhc_fused_backend!r}; expected one of "
+                f"{valid_mhc_fused_backends}."
+            )
+        if self.mhc_fused_backend != "auto" and not self.use_fused_mhc:
+            raise ValueError("mhc_fused_backend requires use_fused_mhc=True when set explicitly.")
+
         if self.enable_mhc_connections and self.recompute_granularity == "full":
             raise NotImplementedError(
                 "enable_mhc_connections is not yet compatible with full activation recompute. "
@@ -2152,7 +2171,7 @@ class TransformerConfig(ModelParallelConfig):
             # TransformerBlock expands to n-stream at `pre_process` and contracts back at
             # the stage holding the final layernorm, so every intermediate pipeline stage
             # exchanges [s, b, n*C] while the p2p buffers are still sized from hidden_size.
-            # Pipeline support lands in the follow-up mHC split, which lifts this guard.
+            # Pipeline support must resize the p2p buffers before this guard can be lifted.
             if self.pipeline_model_parallel_size > 1:
                 raise NotImplementedError(
                     "enable_mhc_connections does not support pipeline_model_parallel_size > 1 "

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -612,6 +612,73 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         )
         return get_transformer_layer_offset(config)
 
+    @staticmethod
+    def _group_offload_output_with_bias(
+        output_with_bias, offload_manager, forced_released_tensors: Optional[list[Tensor]] = None
+    ):
+        """Commit a fine-grained offload group for a raw branch output tuple."""
+        if isinstance(output_with_bias, tuple):
+            output = offload_manager.group_offload(
+                output_with_bias[0], forced_released_tensors=forced_released_tensors
+            )
+            return (output, *output_with_bias[1:])
+        return offload_manager.group_offload(
+            output_with_bias, forced_released_tensors=forced_released_tensors
+        )
+
+    def _forward_self_attention_output_with_bias(
+        self,
+        hidden_states: Tensor,
+        attention_mask: Optional[Tensor] = None,
+        rotary_pos_emb: Optional[Tensor] = None,
+        rotary_pos_cos: Optional[Tensor] = None,
+        rotary_pos_sin: Optional[Tensor] = None,
+        rotary_pos_cos_sin: Optional[Tensor] = None,
+        attention_bias: Optional[Tensor] = None,
+        inference_context: Optional[BaseInferenceContext] = None,
+        packed_seq_params: Optional[PackedSeqParams] = None,
+        sequence_len_offset: Optional[Tensor] = None,
+        *,
+        inference_params: Optional[Any] = None,
+    ):
+        """Run input norm and self-attention, returning the raw output before BDA."""
+        inference_context = deprecate_inference_params(inference_context, inference_params)
+
+        input_layernorm_output, residual, attn_state = self._run_input_layernorm(hidden_states)
+        if attn_state:
+            raise RuntimeError(
+                "Raw HybridStack attention execution requires an ordinary TransformerLayer "
+                "without subclass-specific attention state."
+            )
+
+        using_fused_tp_inference_kernel = (
+            InferenceMode.is_active() and self.config.inference_fuse_tp_communication
+        )
+        if using_fused_tp_inference_kernel:
+            self._set_proj_residual(residual)
+
+        nvtx_range_push(suffix="self_attention")
+        attention_output_with_bias = self.self_attention(
+            input_layernorm_output,
+            attention_mask=attention_mask,
+            inference_context=inference_context,
+            rotary_pos_emb=rotary_pos_emb,
+            rotary_pos_cos=rotary_pos_cos,
+            rotary_pos_sin=rotary_pos_sin,
+            rotary_pos_cos_sin=rotary_pos_cos_sin,
+            attention_bias=attention_bias,
+            packed_seq_params=packed_seq_params,
+            sequence_len_offset=sequence_len_offset,
+        )
+        nvtx_range_pop(suffix="self_attention")
+
+        if self._input_layernorm_checkpoint_active:
+            self.input_layernorm_checkpoint.discard_output_and_register_recompute(
+                attention_output_with_bias[0]
+            )
+
+        return attention_output_with_bias, self.attn_norm_manager, residual
+
     def _forward_attention(
         self,
         hidden_states: Tensor,
@@ -895,6 +962,40 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
             residual = residual.float()
 
         return pre_mlp_layernorm_output, residual, ()
+
+    def _forward_mlp_output_with_bias(
+        self,
+        hidden_states: Tensor,
+        inference_context: BaseInferenceContext | None = None,
+        padding_mask: Tensor | None = None,
+        packed_seq_params=None,
+    ) -> tuple[tuple[Tensor, Tensor | None], Tensor]:
+        """Run pre-MLP norm and MLP/MoE, returning the raw output before BDA."""
+        pre_mlp_layernorm_output, residual, mlp_state = self._pre_mlp_layernorm_and_residual(
+            hidden_states
+        )
+        if mlp_state:
+            raise RuntimeError(
+                "Raw HybridStack MLP execution requires an ordinary TransformerLayer "
+                "without subclass-specific MLP state."
+            )
+
+        pre_mlp_layernorm_output, padding_mask, moe_unflatten_mbs = self._maybe_unflatten_for_moe(
+            pre_mlp_layernorm_output, padding_mask, packed_seq_params
+        )
+
+        mlp_output_with_bias = self._run_mlp(
+            pre_mlp_layernorm_output, residual, padding_mask, inference_context
+        )
+
+        if moe_unflatten_mbs is not None:
+            mlp_output, mlp_bias = mlp_output_with_bias
+            mlp_output = self._maybe_reflatten_from_moe(
+                mlp_output, packed_seq_params, moe_unflatten_mbs
+            )
+            mlp_output_with_bias = (mlp_output, mlp_bias)
+
+        return mlp_output_with_bias, residual
 
     def _forward_mlp(
         self,

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -306,6 +306,11 @@ class BaseTransformerLayer(ABC):
     implementation in `transformer_block.py` file for more details.
     """
 
+    #: Whether the layer accepts mHC n-stream hidden states ([s, b, n*C])
+    #: when owned directly by a TransformerBlock. Custom layer implementations
+    #: that implement this contract should override the marker with ``True``.
+    supports_mhc_connections: bool = False
+
     def __init__(self):
         pass
 
@@ -316,11 +321,6 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
     Transformer layer takes input with size [s, b, h] and returns an
     output of the same size.
     """
-
-    #: Whether this layer class understands mHC n-stream hidden states
-    #: ([s, b, n*C]). Only HyperConnectionTransformerLayer sets this True;
-    #: __init__ rejects `enable_mhc_connections` on any layer that does not.
-    supports_mhc_connections: bool = False
 
     def __init__(
         self,
@@ -552,13 +552,6 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         # use_nvfuser = TORCH_MAJOR > 1 or (TORCH_MAJOR == 1 and TORCH_MINOR >= 10)
         # self.bias_dropout_add_exec_handler = nullcontext if use_nvfuser else torch.enable_grad
         self.bias_dropout_add_exec_handler = torch.enable_grad
-
-        if config.enable_mhc_connections and not self.supports_mhc_connections:
-            raise ValueError(
-                f"{type(self).__name__} does not implement mHC residual streams. Build the "
-                "decoder with HyperConnectionTransformerLayer when "
-                "enable_mhc_connections=True."
-            )
 
         # Resolve the legacy `_forward_post_mlp` override once instead of walking the MRO on
         # every MLP bias-dropout-add. See _apply_mlp_bda_step for the deprecation contract.
@@ -1852,28 +1845,6 @@ class HyperConnectionTransformerLayer(TransformerLayer):
         if CudaGraphModule.mlp in self.config.cuda_graph_modules:
             submodules.append(self.mlp_hyper_connection)
         return submodules
-
-    def forward(self, *args, **kwargs):
-        """Forward pass with MHC recompute manager support.
-
-        Inherits ``_forward_attention`` and ``_forward_mlp`` from base; the
-        mHC-specific behavior is contained in the ``_run_input_layernorm``,
-        ``_apply_self_attn_bda_step``, ``_pre_mlp_layernorm_and_residual``, and
-        ``_apply_mlp_bda_step`` overrides, which read the manager off
-        ``self`` and thread per-call intermediates through the
-        ``attn_state`` / ``mlp_state`` slots.
-
-        Override exists only to skip the ``enable_mhc_connections`` assert
-        on base ``TransformerLayer.forward``.
-        """
-        hidden_states, context = self._forward_attention(*args, **kwargs)
-        output = self._forward_mlp(
-            hidden_states,
-            kwargs.get("inference_context", None),
-            padding_mask=kwargs.get("padding_mask", None),
-            packed_seq_params=kwargs.get("packed_seq_params", None),
-        )
-        return output, context
 
     def _run_input_layernorm(self, hidden_states):
         """HC input layernorm: hyper-connection pre-wrap + mHC-aware checkpoint.

--- a/tests/unit_tests/fusions/test_fused_mhc_kernels.py
+++ b/tests/unit_tests/fusions/test_fused_mhc_kernels.py
@@ -43,6 +43,15 @@ RAND_LO, RAND_HI = -0.1, 0.1
 COSINE_SIM_THRESH = 0.999
 
 
+def test_all_mhc_backends_declare_determinism():
+    """Every concrete backend declares a valid bit-exact determinism status."""
+    from megatron.core.fusions.fused_mhc_kernels import MHC_BACKEND_DETERMINISM
+
+    valid_statuses = {"deterministic", "nondeterministic", "unknown"}
+    assert set(MHC_BACKEND_DETERMINISM) == {"native", "triton", "cutile"}
+    assert set(MHC_BACKEND_DETERMINISM.values()) <= valid_statuses
+
+
 def _assert_cosine_similar(a: Tensor, b: Tensor, threshold: float, msg: str = ""):
     """Assert that flattened tensors have cosine similarity >= threshold."""
     a_flat = a.flatten().float()

--- a/tests/unit_tests/fusions/test_fused_mhc_kernels.py
+++ b/tests/unit_tests/fusions/test_fused_mhc_kernels.py
@@ -1503,12 +1503,7 @@ class TestFusedProjRmsComputeHKeepFp32:
         )
 
     def test_public_entry_point_native_branch(self, monkeypatch):
-        """The public op must also run natively — this is the forced-native path.
-
-        MHC_FORCE_BACKEND=native and an auto run on a cuTile-less container both
-        land here, and the module always calls the public op when
-        use_fused_mhc=True, so this branch is what a real training job hits.
-        """
+        """The public op must honor the explicit native backend policy."""
         from megatron.core.fusions import fused_mhc_kernels as fused_mod
 
         _info()
@@ -1521,9 +1516,139 @@ class TestFusedProjRmsComputeHKeepFp32:
         one = torch.full((1,), 0.1, device=DEVICE, dtype=torch.float32)
         bias = torch.zeros(N, device=DEVICE, dtype=torch.float32)
 
-        outs = fused_mod.fused_proj_rms_compute_h(x, w, one, one, one, bias, n, 1e-6)
+        outs = fused_mod.fused_proj_rms_compute_h(
+            x, w, one, one, one, bias, n, 1e-6, backend="native"
+        )
         for t in outs:
             assert torch.isfinite(t).all()
+
+
+class TestExplicitBackendDispatch:
+    """Configuration-driven dispatch must be strict and stable through backward."""
+
+    def test_backend_logging_is_once_per_policy(self, monkeypatch):
+        from megatron.core.fusions import fused_mhc_kernels as fused_mod
+
+        log_calls = []
+        warning_calls = []
+        monkeypatch.setattr(fused_mod, "_BACKEND_INFO_LOGGED", set())
+        monkeypatch.setattr(
+            fused_mod,
+            "_mhc_backend_status",
+            lambda backend: (f"policy={backend}; all native", True),
+        )
+        monkeypatch.setattr(fused_mod, "safe_get_rank", lambda: 0)
+        monkeypatch.setattr(fused_mod, "log_single_rank", lambda *args: log_calls.append(args))
+        monkeypatch.setattr(
+            fused_mod.warnings,
+            "warn",
+            lambda message, *args, **kwargs: warning_calls.append(message),
+        )
+
+        for backend in ("native", "native", "auto", "auto"):
+            fused_mod.log_fused_mhc_backend_once(backend)
+
+        assert len(log_calls) == 2
+        assert [call[1] for call in log_calls] == [
+            fused_mod.logging.INFO,
+            fused_mod.logging.WARNING,
+        ]
+        assert len(warning_calls) == 1
+        assert "falling back to native torch" in str(warning_calls[0])
+
+    @pytest.mark.parametrize("backend", ["triton", "cutile"])
+    def test_unavailable_explicit_backend_fails(self, monkeypatch, backend):
+        from megatron.core.fusions import fused_mhc_kernels as fused_mod
+
+        if backend == "triton":
+            monkeypatch.setattr(fused_mod, "is_triton_available", lambda: False)
+        else:
+            monkeypatch.setattr(fused_mod, "is_cutile_available", lambda: False)
+
+        logits = _rand(1, 1, 2, 2)
+        with pytest.raises(RuntimeError, match=backend):
+            fused_mod.fused_sinkhorn(logits, 2, backend=backend)
+
+    def test_h_aggregate_forward_backward_share_backend_policy(self, monkeypatch):
+        from megatron.core.fusions import fused_mhc_kernels as fused_mod
+
+        seen = []
+
+        def get_triton_forward(backend):
+            seen.append(("forward", backend))
+            return fused_mod.native_h_aggregate
+
+        def use_cutile(backend):
+            seen.append(("backward", backend))
+            return False
+
+        monkeypatch.setattr(fused_mod, "is_triton_available", lambda: True)
+        monkeypatch.setattr(fused_mod, "_get_triton_h_aggregate_fwd", get_triton_forward)
+        monkeypatch.setattr(fused_mod, "_backend_uses_cutile", use_cutile)
+
+        x = _rand(2, 2, 2, 8).requires_grad_(True)
+        h_pre = _rand(2, 2, 2).requires_grad_(True)
+        fused_mod.fused_h_aggregate(x, h_pre, backend="triton").sum().backward()
+
+        assert ("forward", "triton") in seen
+        assert ("backward", "triton") in seen
+        assert x.grad is not None
+        assert h_pre.grad is not None
+
+    def test_h_aggregate_auto_mixes_triton_forward_and_cutile_backward(self, monkeypatch):
+        from megatron.core.fusions import fused_mhc_kernels as fused_mod
+
+        seen = []
+
+        def get_triton_forward(backend):
+            seen.append(("forward", backend, "triton"))
+            return fused_mod.native_h_aggregate
+
+        def cutile_backward(grad_output, x, h_pre):
+            seen.append(("backward", "auto", "cutile"))
+            return fused_mod._torch_h_aggregate_bwd(grad_output, x, h_pre)
+
+        monkeypatch.setattr(fused_mod, "is_triton_available", lambda: True)
+        monkeypatch.setattr(fused_mod, "is_cutile_available", lambda: True)
+        monkeypatch.setattr(fused_mod, "_get_triton_h_aggregate_fwd", get_triton_forward)
+        monkeypatch.setattr(fused_mod, "_cutile_h_aggregate_bwd", cutile_backward, raising=False)
+
+        x = _rand(2, 2, 2, 8).requires_grad_(True)
+        h_pre = _rand(2, 2, 2).requires_grad_(True)
+        fused_mod.fused_h_aggregate(x, h_pre, backend="auto").sum().backward()
+
+        assert seen == [("forward", "auto", "triton"), ("backward", "auto", "cutile")]
+        assert x.grad is not None
+        assert h_pre.grad is not None
+
+    def test_h_post_bda_forward_backward_share_backend_policy(self, monkeypatch):
+        from megatron.core.fusions import fused_mhc_kernels as fused_mod
+
+        seen = []
+
+        def get_triton_forward(backend):
+            seen.append(("forward", backend))
+            return fused_mod.native_h_post_bda
+
+        def get_triton_backward(backend):
+            seen.append(("backward", backend))
+            return fused_mod._torch_h_post_bda_bwd
+
+        monkeypatch.setattr(fused_mod, "is_triton_available", lambda: True)
+        monkeypatch.setattr(fused_mod, "_get_triton_h_post_bda_fwd", get_triton_forward)
+        monkeypatch.setattr(fused_mod, "_get_triton_h_post_bda_bwd", get_triton_backward)
+
+        h_res = _rand(2, 2, 2, 2).requires_grad_(True)
+        residual = _rand(2, 2, 2, 8).requires_grad_(True)
+        h_post = _rand(2, 2, 2).requires_grad_(True)
+        x = _rand(2, 2, 8).requires_grad_(True)
+        bias = _rand(8).requires_grad_(True)
+        fused_mod.fused_h_post_bda(
+            h_res, residual, h_post, x, bias, backend="triton"
+        ).sum().backward()
+
+        assert seen == [("forward", "triton"), ("backward", "triton")]
+        assert all(tensor.grad is not None for tensor in (h_res, residual, h_post, x, bias))
 
 
 class TestCutileHAggregateBackwardReduction:

--- a/tests/unit_tests/fusions/test_fused_mhc_kernels.py
+++ b/tests/unit_tests/fusions/test_fused_mhc_kernels.py
@@ -1,0 +1,1557 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Unit tests for unified fused mHC kernels and native implementations.
+
+Each test compares the fused kernel's forward output AND backward gradients
+against a pure-PyTorch differentiable reference to catch numerical drift
+introduced by kernel fusion. The public fused API tests also exercise backend
+dispatch and fallback selection through the same entry points used by mHC.
+"""
+
+import math
+from typing import Optional
+
+import pytest
+import torch
+from torch import Tensor
+
+from megatron.core.fusions.fused_mhc_kernels import is_cutile_available, is_triton_available
+from megatron.core.transformer.hyper_connection import (
+    native_h_aggregate,
+    native_h_post_bda,
+    native_proj_rms,
+    native_sinkhorn,
+)
+
+_require_cutile = pytest.mark.skipif(
+    not is_cutile_available(), reason="cuTile unavailable for current device"
+)
+_require_triton = pytest.mark.skipif(not is_triton_available(), reason="Triton not installed")
+
+
+@pytest.fixture(autouse=True)
+def _skip_without_cuda():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+
+DTYPE = torch.bfloat16
+DEVICE = "cuda"
+FWD_ATOL, FWD_RTOL = 2e-2, 2e-2
+BWD_ATOL, BWD_RTOL = 5e-2, 5e-2
+RAND_LO, RAND_HI = -0.1, 0.1
+COSINE_SIM_THRESH = 0.999
+
+
+def _assert_cosine_similar(a: Tensor, b: Tensor, threshold: float, msg: str = ""):
+    """Assert that flattened tensors have cosine similarity >= threshold."""
+    a_flat = a.flatten().float()
+    b_flat = b.flatten().float()
+    sim = torch.nn.functional.cosine_similarity(a_flat.unsqueeze(0), b_flat.unsqueeze(0)).item()
+    assert sim >= threshold, (
+        f"{msg}: cosine similarity {sim:.6f} < {threshold} "
+        f"(max_abs_diff={torch.max(torch.abs(a_flat - b_flat)):.6e})"
+    )
+
+
+def _rand(*shape, **kwargs):
+    """Uniform in [RAND_LO, RAND_HI] to keep magnitudes small for bf16 stability."""
+    return torch.empty(*shape, dtype=DTYPE, device=DEVICE, **kwargs).uniform_(RAND_LO, RAND_HI)
+
+
+def _info():
+    if is_triton_available() and is_cutile_available():
+        backend = "triton+cuTile"
+    elif is_triton_available():
+        backend = "triton+native"
+    elif is_cutile_available():
+        backend = "cuTile"
+    else:
+        backend = "native"
+    print(f"\n  [backend: {backend}]")
+
+
+# ============================================================================
+# Pure-PyTorch differentiable references (used by both fwd AND bwd tests)
+# ============================================================================
+
+
+def _ref_sinkhorn(logits: Tensor, num_iters: int, eps: float = 1e-6) -> Tensor:
+    M = logits.softmax(dim=-1) + eps
+    M = M / (M.sum(dim=-2, keepdim=True) + eps)
+    for _ in range(num_iters - 1):
+        M = M / (M.sum(dim=-1, keepdim=True) + eps)
+        M = M / (M.sum(dim=-2, keepdim=True) + eps)
+    return M
+
+
+def _ref_h_aggregate(x: Tensor, h_pre: Tensor) -> Tensor:
+    return (x * h_pre.unsqueeze(-1)).sum(dim=2)
+
+
+def _ref_h_post_bda(
+    h_res: Tensor, orig_res: Tensor, h_post: Tensor, x: Tensor, bias: Optional[Tensor]
+) -> Tensor:
+    s, b, n, C = orig_res.shape
+    h_res_batched = h_res.view(s * b, n, n)
+    orig_batched = orig_res.view(s * b, n, C)
+    mixed = torch.bmm(h_res_batched.transpose(1, 2), orig_batched).view(s, b, n, C)
+    x_exp = h_post.unsqueeze(-1) * x.unsqueeze(2)
+    out = x_exp + mixed
+    if bias is not None:
+        out = out + h_post.unsqueeze(-1) * bias.view(1, 1, 1, C)
+    return out
+
+
+def _h_post_bda_transpose_case():
+    h_res = torch.tensor([[[[1.0, 2.0], [3.0, 4.0]]]], dtype=DTYPE, device=DEVICE)
+    orig = torch.tensor([[[[10.0, 100.0], [1.0, 2.0]]]], dtype=DTYPE, device=DEVICE)
+    h_post = torch.zeros(1, 1, 2, dtype=DTYPE, device=DEVICE)
+    x = torch.zeros(1, 1, 2, dtype=DTYPE, device=DEVICE)
+    expected = torch.tensor([[[[13.0, 106.0], [24.0, 208.0]]]], dtype=DTYPE, device=DEVICE)
+    return h_res, orig, h_post, x, expected
+
+
+def _ref_proj_rms(x: Tensor, weight: Tensor, eps: float = 1e-6):
+    proj = torch.matmul(x, weight.t())
+    norm = x.norm(dim=-1, keepdim=True)
+    K = x.shape[-1]
+    r = 1.0 / (norm / math.sqrt(K) + eps)
+    return proj, r
+
+
+def _ref_proj_rms_compute_h(
+    x: Tensor,
+    weight: Tensor,
+    alpha_pre: Tensor,
+    alpha_post: Tensor,
+    alpha_res: Tensor,
+    bias: Tensor,
+    n: int,
+    eps: float = 1e-6,
+    compute_h_eps: float = 1e-6,
+):
+    """Reference: fused proj_rms + compute_h."""
+    proj = torch.matmul(x, weight.t())
+    norm = x.norm(dim=-1, keepdim=True)
+    K = x.shape[-1]
+    r = norm / math.sqrt(K)  # [M, 1]
+    N = proj.shape[-1]
+    alpha = torch.cat([alpha_pre.expand(n), alpha_post.expand(n), alpha_res.expand(N - 2 * n)])
+    h = proj * alpha.unsqueeze(0) / (r + eps) + bias.unsqueeze(0)
+    h_pre = h[..., :n].sigmoid() + compute_h_eps
+    h_post = h[..., n : 2 * n].sigmoid() * 2
+    h_res = h[..., 2 * n :]
+    return h_pre, h_post, h_res, r
+
+
+# ============================================================================
+# Sinkhorn
+# ============================================================================
+
+
+class TestNativeSinkhorn:
+    """Tests for the native SinkhornKnopp implementation."""
+
+    @pytest.mark.parametrize("s,b,n,iters", [(2, 4, 4, 5), (1, 1, 2, 10)])
+    def test_fwd_bwd_vs_torch_reference(self, s, b, n, iters):
+        """native_sinkhorn fwd output and bwd grad must match the inline PyTorch reference."""
+        _info()
+        eps = 1e-6
+        data = _rand(s, b, n, n)
+        grad_out = _rand(s, b, n, n)
+
+        # -- native_sinkhorn path (autograd.Function) --
+        inp_f = data.clone().requires_grad_(True)
+        out_f = native_sinkhorn(inp_f, iters, eps)
+        out_f.backward(grad_out)
+        grad_f = inp_f.grad.clone()
+
+        # -- inline torch reference (fully differentiable) --
+        inp_r = data.clone().requires_grad_(True)
+        out_r = _ref_sinkhorn(inp_r, iters, eps)
+        out_r.backward(grad_out)
+        grad_r = inp_r.grad.clone()
+
+        torch.testing.assert_close(out_f, out_r, atol=FWD_ATOL, rtol=FWD_RTOL)
+        torch.testing.assert_close(grad_f, grad_r, atol=BWD_ATOL, rtol=BWD_RTOL)
+
+
+class TestFusedSinkhorn:
+    """Public fused sinkhorn dispatch/fallback plus numerical correctness."""
+
+    @pytest.mark.flaky_in_dev
+    @_require_cutile
+    @pytest.mark.parametrize("s,b,n,iters", [(2, 4, 4, 5), (1, 1, 2, 10)])
+    def test_fwd_bwd_vs_reference(self, s, b, n, iters):
+        """E2E: public fused fwd output and bwd grad must match the PyTorch reference."""
+        from megatron.core.fusions.fused_mhc_kernels import fused_sinkhorn
+
+        _info()
+        eps = 1e-6
+        data = _rand(s, b, n, n)
+        grad_out = _rand(s, b, n, n)
+
+        # -- fused path --
+        inp_f = data.clone().requires_grad_(True)
+        out_f = fused_sinkhorn(inp_f, iters, eps)
+        out_f.backward(grad_out)
+        grad_f = inp_f.grad.clone()
+
+        # -- reference path (fully differentiable) --
+        inp_r = data.clone().requires_grad_(True)
+        out_r = _ref_sinkhorn(inp_r, iters, eps)
+        out_r.backward(grad_out)
+        grad_r = inp_r.grad.clone()
+
+        torch.testing.assert_close(out_f, out_r, atol=FWD_ATOL, rtol=FWD_RTOL)
+        torch.testing.assert_close(grad_f, grad_r, atol=BWD_ATOL, rtol=BWD_RTOL)
+
+
+# ============================================================================
+# H_aggregate
+# ============================================================================
+
+
+class TestNativeHAggregate:
+    """Tests for native_h_aggregate."""
+
+    @pytest.mark.parametrize("s,b,n,C", [(2, 4, 4, 1024), (1, 1, 2, 256)])
+    def test_fwd_bwd_vs_torch_reference(self, s, b, n, C):
+        _info()
+        x_data = _rand(s, b, n, C)
+        h_data = _rand(s, b, n)
+        grad_out = _rand(s, b, C)
+
+        xf = x_data.clone().requires_grad_(True)
+        hf = h_data.clone().requires_grad_(True)
+        of = native_h_aggregate(xf, hf)
+        of.backward(grad_out)
+
+        xr = x_data.clone().requires_grad_(True)
+        hr = h_data.clone().requires_grad_(True)
+        oref = _ref_h_aggregate(xr, hr)
+        oref.backward(grad_out)
+
+        torch.testing.assert_close(of, oref, atol=FWD_ATOL, rtol=FWD_RTOL)
+        torch.testing.assert_close(xf.grad, xr.grad, atol=BWD_ATOL, rtol=BWD_RTOL)
+        torch.testing.assert_close(hf.grad, hr.grad, atol=BWD_ATOL, rtol=BWD_RTOL)
+
+
+class TestFusedHAggregate:
+    """Public fused h_aggregate dispatch/fallback plus numerical correctness."""
+
+    @pytest.mark.flaky_in_dev
+    @_require_cutile
+    @pytest.mark.parametrize("s,b,n,C", [(2, 4, 4, 1024), (1, 1, 2, 256)])
+    def test_fwd_bwd_vs_reference(self, s, b, n, C):
+        """E2E: public fused fwd output and bwd grads must match the PyTorch reference."""
+        from megatron.core.fusions.fused_mhc_kernels import fused_h_aggregate
+
+        _info()
+        x_data = _rand(s, b, n, C)
+        h_data = _rand(s, b, n)
+        grad_out = _rand(s, b, C)
+
+        # -- fused path --
+        xf = x_data.clone().requires_grad_(True)
+        hf = h_data.clone().requires_grad_(True)
+        of = fused_h_aggregate(xf, hf)
+        of.backward(grad_out)
+
+        # -- reference path --
+        xr = x_data.clone().requires_grad_(True)
+        hr = h_data.clone().requires_grad_(True)
+        oref = _ref_h_aggregate(xr, hr)
+        oref.backward(grad_out)
+
+        torch.testing.assert_close(of, oref, atol=FWD_ATOL, rtol=FWD_RTOL)
+        torch.testing.assert_close(xf.grad, xr.grad, atol=BWD_ATOL, rtol=BWD_RTOL)
+        torch.testing.assert_close(hf.grad, hr.grad, atol=BWD_ATOL, rtol=BWD_RTOL)
+
+
+class TestTritonHAggregate:
+    """Tests for Triton h_aggregate forward against PyTorch reference."""
+
+    @_require_triton
+    @pytest.mark.parametrize("s,b,n,C", [(2, 4, 4, 1024), (1, 1, 2, 256), (64, 8, 4, 4096)])
+    def test_fwd_vs_reference(self, s, b, n, C):
+        from megatron.core.fusions.fused_mhc_kernels import _triton_h_aggregate_fwd
+
+        _info()
+        x_data = _rand(s, b, n, C)
+        h_data = _rand(s, b, n)
+
+        out_t = _triton_h_aggregate_fwd(x_data, h_data)
+        out_r = _ref_h_aggregate(x_data, h_data)
+
+        torch.testing.assert_close(out_t, out_r, atol=FWD_ATOL, rtol=FWD_RTOL)
+
+
+# ============================================================================
+# H_post BDA
+# ============================================================================
+
+
+class TestNativeHPostBDA:
+    """Tests for native_h_post_bda."""
+
+    def test_forward_uses_h_res_transpose(self):
+        h_res, orig, h_post, x, expected = _h_post_bda_transpose_case()
+        out = native_h_post_bda(h_res, orig, h_post, x, bias=None)
+
+        torch.testing.assert_close(out, expected, atol=0.0, rtol=0.0)
+
+    @pytest.mark.parametrize("with_bias", [True, False])
+    @pytest.mark.parametrize("s,b,n,C", [(2, 4, 4, 1024), (1, 2, 2, 256)])
+    def test_fwd_bwd_vs_torch_reference(self, s, b, n, C, with_bias):
+        _info()
+        hr_data = _rand(s, b, n, n)
+        orig_data = _rand(s, b, n, C)
+        hp_data = _rand(s, b, n)
+        x_data = _rand(s, b, C)
+        bias_data = _rand(C) if with_bias else None
+        grad_out = _rand(s, b, n, C)
+
+        def _make_inputs():
+            hr = hr_data.clone().requires_grad_(True)
+            orig = orig_data.clone().requires_grad_(True)
+            hp = hp_data.clone().requires_grad_(True)
+            x = x_data.clone().requires_grad_(True)
+            bi = bias_data.clone().requires_grad_(True) if with_bias else None
+            return hr, orig, hp, x, bi
+
+        hr_f, orig_f, hp_f, x_f, bi_f = _make_inputs()
+        out_f = native_h_post_bda(hr_f, orig_f, hp_f, x_f, bi_f)
+        out_f.backward(grad_out)
+
+        hr_r, orig_r, hp_r, x_r, bi_r = _make_inputs()
+        out_r = _ref_h_post_bda(hr_r, orig_r, hp_r, x_r, bi_r)
+        out_r.backward(grad_out)
+
+        torch.testing.assert_close(out_f, out_r, atol=FWD_ATOL, rtol=FWD_RTOL)
+        for name, gf, gr in [
+            ("h_res", hr_f.grad, hr_r.grad),
+            ("orig_res", orig_f.grad, orig_r.grad),
+            ("h_post", hp_f.grad, hp_r.grad),
+            ("x", x_f.grad, x_r.grad),
+        ]:
+            torch.testing.assert_close(
+                gf, gr, atol=BWD_ATOL, rtol=BWD_RTOL, msg=f"backward mismatch on {name}"
+            )
+        if with_bias:
+            torch.testing.assert_close(
+                bi_f.grad, bi_r.grad, atol=BWD_ATOL, rtol=BWD_RTOL, msg="backward mismatch on bias"
+            )
+
+
+class TestFusedHPostBDA:
+    """Public fused h_post_bda dispatch/fallback plus numerical correctness."""
+
+    def test_forward_uses_h_res_transpose(self):
+        from megatron.core.fusions.fused_mhc_kernels import fused_h_post_bda
+
+        h_res, orig, h_post, x, expected = _h_post_bda_transpose_case()
+        out = fused_h_post_bda(h_res, orig, h_post, x, bias=None)
+
+        torch.testing.assert_close(out, expected, atol=0.0, rtol=0.0)
+
+    @pytest.mark.flaky_in_dev
+    @_require_cutile
+    @pytest.mark.parametrize("with_bias", [True, False])
+    @pytest.mark.parametrize("s,b,n,C", [(2, 4, 4, 1024), (1, 2, 2, 256)])
+    def test_fwd_bwd_vs_reference(self, s, b, n, C, with_bias):
+        """E2E: public fused fwd output and bwd grads must match the PyTorch reference."""
+        from megatron.core.fusions.fused_mhc_kernels import fused_h_post_bda
+
+        _info()
+        hr_data = _rand(s, b, n, n)
+        orig_data = _rand(s, b, n, C)
+        hp_data = _rand(s, b, n)
+        x_data = _rand(s, b, C)
+        bias_data = _rand(C) if with_bias else None
+        grad_out = _rand(s, b, n, C)
+
+        def _make_inputs():
+            hr = hr_data.clone().requires_grad_(True)
+            orig = orig_data.clone().requires_grad_(True)
+            hp = hp_data.clone().requires_grad_(True)
+            x = x_data.clone().requires_grad_(True)
+            bi = bias_data.clone().requires_grad_(True) if with_bias else None
+            return hr, orig, hp, x, bi
+
+        # -- fused path --
+        hr_f, orig_f, hp_f, x_f, bi_f = _make_inputs()
+        out_f = fused_h_post_bda(hr_f, orig_f, hp_f, x_f, bi_f)
+        out_f.backward(grad_out)
+
+        # -- reference path --
+        hr_r, orig_r, hp_r, x_r, bi_r = _make_inputs()
+        out_r = _ref_h_post_bda(hr_r, orig_r, hp_r, x_r, bi_r)
+        out_r.backward(grad_out)
+
+        torch.testing.assert_close(out_f, out_r, atol=FWD_ATOL, rtol=FWD_RTOL)
+        for name, gf, gr in [
+            ("h_res", hr_f.grad, hr_r.grad),
+            ("orig_res", orig_f.grad, orig_r.grad),
+            ("h_post", hp_f.grad, hp_r.grad),
+            ("x", x_f.grad, x_r.grad),
+        ]:
+            torch.testing.assert_close(
+                gf, gr, atol=BWD_ATOL, rtol=BWD_RTOL, msg=f"backward mismatch on {name}"
+            )
+        if with_bias:
+            torch.testing.assert_close(
+                bi_f.grad, bi_r.grad, atol=BWD_ATOL, rtol=BWD_RTOL, msg="backward mismatch on bias"
+            )
+
+
+class TestTritonHPostBDA:
+    """Tests for Triton h_post_bda kernels against PyTorch reference."""
+
+    @_require_triton
+    @pytest.mark.parametrize("with_bias", [True, False])
+    @pytest.mark.parametrize("s,b,n,C", [(2, 4, 4, 1024), (1, 2, 2, 256), (64, 8, 4, 4096)])
+    def test_fwd_vs_reference(self, s, b, n, C, with_bias):
+        """Triton hpb forward output must match the PyTorch reference."""
+        from megatron.core.fusions.fused_mhc_kernels import _triton_h_post_bda_fwd
+
+        _info()
+        hr_data = _rand(s, b, n, n)
+        orig_data = _rand(s, b, n, C)
+        hp_data = _rand(s, b, n)
+        x_data = _rand(s, b, C)
+        bias_data = _rand(C) if with_bias else None
+
+        out_t = _triton_h_post_bda_fwd(hr_data, orig_data, hp_data, x_data, bias_data)
+        out_r = _ref_h_post_bda(hr_data, orig_data, hp_data, x_data, bias_data)
+
+        torch.testing.assert_close(out_t, out_r, atol=FWD_ATOL, rtol=FWD_RTOL)
+
+    @_require_triton
+    @pytest.mark.parametrize("with_bias", [True, False])
+    @pytest.mark.parametrize(
+        "s,b,n,C", [(2, 4, 4, 1024), (1, 2, 2, 256), (64, 8, 4, 4096), (128, 1, 8, 7168)]
+    )
+    def test_bwd_vs_reference(self, s, b, n, C, with_bias):
+        """Triton hpb backward grads must match the PyTorch reference."""
+        from megatron.core.fusions.fused_mhc_kernels import _triton_h_post_bda_bwd
+
+        _info()
+        hr_data = _rand(s, b, n, n)
+        orig_data = _rand(s, b, n, C)
+        hp_data = _rand(s, b, n)
+        x_data = _rand(s, b, C)
+        bias_data = _rand(C) if with_bias else None
+        grad_out = _rand(s, b, n, C)
+
+        # -- Triton backward --
+        g_hr_t, g_res_t, g_hp_t, g_x_t, g_bias_t = _triton_h_post_bda_bwd(
+            grad_out, hr_data, orig_data, hp_data, x_data, bias_data
+        )
+
+        # -- Reference backward via autograd --
+        hr_r = hr_data.clone().requires_grad_(True)
+        orig_r = orig_data.clone().requires_grad_(True)
+        hp_r = hp_data.clone().requires_grad_(True)
+        x_r = x_data.clone().requires_grad_(True)
+        bi_r = bias_data.clone().requires_grad_(True) if with_bias else None
+        out_r = _ref_h_post_bda(hr_r, orig_r, hp_r, x_r, bi_r)
+        out_r.backward(grad_out)
+
+        for name, gt, gr in [
+            ("h_res", g_hr_t, hr_r.grad),
+            ("orig_res", g_res_t, orig_r.grad),
+            ("h_post", g_hp_t, hp_r.grad),
+            ("x", g_x_t, x_r.grad),
+        ]:
+            torch.testing.assert_close(
+                gt, gr, atol=BWD_ATOL, rtol=BWD_RTOL, msg=f"Triton backward mismatch on {name}"
+            )
+        if with_bias:
+            torch.testing.assert_close(
+                g_bias_t,
+                bi_r.grad,
+                atol=BWD_ATOL,
+                rtol=BWD_RTOL,
+                msg="Triton backward mismatch on bias",
+            )
+
+    @_require_triton
+    @_require_cutile
+    @pytest.mark.parametrize("with_bias", [True, False])
+    @pytest.mark.parametrize("s,b,n,C", [(2, 4, 4, 1024), (1, 2, 2, 256), (64, 8, 4, 4096)])
+    def test_triton_vs_cutile(self, s, b, n, C, with_bias):
+        """Triton and cuTile backward must produce identical results."""
+        from megatron.core.fusions.fused_mhc_kernels import (
+            _cutile_h_post_bda_bwd,
+            _triton_h_post_bda_bwd,
+        )
+
+        _info()
+        hr_data = _rand(s, b, n, n)
+        orig_data = _rand(s, b, n, C)
+        hp_data = _rand(s, b, n)
+        x_data = _rand(s, b, C)
+        bias_data = _rand(C) if with_bias else None
+        grad_out = _rand(s, b, n, C)
+
+        triton_out = _triton_h_post_bda_bwd(
+            grad_out, hr_data, orig_data, hp_data, x_data, bias_data
+        )
+        cutile_out = _cutile_h_post_bda_bwd(
+            grad_out, hr_data, orig_data, hp_data, x_data, bias_data
+        )
+
+        for i, name in enumerate(["h_res", "orig_res", "h_post", "x", "bias"]):
+            if triton_out[i] is None:
+                continue
+            torch.testing.assert_close(
+                triton_out[i],
+                cutile_out[i],
+                atol=BWD_ATOL,
+                rtol=BWD_RTOL,
+                msg=f"Triton vs cuTile mismatch on {name}",
+            )
+
+
+class TestTritonHPostBDABwdE2EDebug:
+    """Debug: run E2E forward, then compare cuTile vs Triton backward per-output."""
+
+    @_require_triton
+    @_require_cutile
+    def test_e2e_inputs_no_nan(self):
+        """Feed actual E2E backward inputs to Triton kernel and check for NaN."""
+        from megatron.core.fusions.fused_mhc_kernels import (
+            _cutile_h_post_bda_bwd,
+            _triton_h_post_bda_bwd,
+            fused_h_aggregate,
+            fused_h_post_bda,
+            fused_sinkhorn,
+        )
+
+        s, b, n, C = 8, 4, 4, 1024
+        eps = 1e-6
+        sinkhorn_iters = 5
+
+        hs_data = _rand(s, b, n * C)
+        w_data = _rand(n * n + 2 * n, n * C)
+        layer_out_data = _rand(s, b, C)
+        layer_bias_data = _rand(C)
+
+        # Run E2E forward to produce realistic backward inputs
+        hs = hs_data.clone().requires_grad_(True)
+        w = w_data.clone().requires_grad_(True)
+        x_2d = hs.reshape(s * b, n * C)
+        proj, r = native_proj_rms(x_2d, w, eps)
+        proj = proj.view(s, b, -1)
+        r = r.view(s, b, 1)
+        h = r * proj
+        h_pre = h[..., :n].sigmoid()
+        h_post_val = h[..., n : 2 * n].sigmoid() * 2
+        h_res = fused_sinkhorn(h[..., 2 * n :].view(s, b, n, n), sinkhorn_iters, eps)
+        _ = fused_h_aggregate(hs.view(s, b, n, C), h_pre)
+        output = fused_h_post_bda(
+            h_res, hs.view(s, b, n, C), h_post_val, layer_out_data, layer_bias_data
+        )
+        go = torch.ones_like(output)
+
+        # Capture inputs (detach from graph)
+        hr = h_res.detach()
+        orig = hs.view(s, b, n, C).detach()
+        hp = h_post_val.detach()
+        x = layer_out_data.detach()
+        bias = layer_bias_data.detach()
+
+        # Compare cuTile vs Triton per-output
+        ct_out = _cutile_h_post_bda_bwd(go, hr, orig, hp, x, bias)
+        tr_out = _triton_h_post_bda_bwd(go, hr, orig, hp, x, bias)
+
+        names = ["g_hr", "g_res", "g_hp", "g_x", "g_bias"]
+        for name, ct_t, tr_t in zip(names, ct_out, tr_out):
+            if tr_t is None:
+                continue
+            assert not tr_t.isnan().any(), f"Triton {name} has NaN"
+            assert not tr_t.isinf().any(), f"Triton {name} has Inf"
+            torch.testing.assert_close(
+                tr_t,
+                ct_t,
+                atol=BWD_ATOL,
+                rtol=BWD_RTOL,
+                msg=f"Triton vs cuTile mismatch on {name} (E2E inputs)",
+            )
+
+
+# ============================================================================
+# Triton: Sinkhorn
+# ============================================================================
+
+
+class TestTritonSinkhorn:
+    @_require_triton
+    @pytest.mark.parametrize("s,b,n,iters", [(2, 4, 4, 5), (1, 1, 2, 10), (8, 4, 4, 20)])
+    def test_fwd_bwd_vs_reference(self, s, b, n, iters):
+        from megatron.core.fusions.fused_mhc_kernels import triton_fused_sinkhorn
+
+        eps = 1e-6
+        data = _rand(s, b, n, n)
+        grad_out = _rand(s, b, n, n)
+
+        inp_f = data.clone().requires_grad_(True)
+        out_f = triton_fused_sinkhorn(inp_f, iters, eps)
+        out_f.backward(grad_out)
+
+        inp_r = data.clone().requires_grad_(True)
+        out_r = _ref_sinkhorn(inp_r, iters, eps)
+        out_r.backward(grad_out)
+
+        torch.testing.assert_close(out_f, out_r, atol=FWD_ATOL, rtol=FWD_RTOL)
+        torch.testing.assert_close(inp_f.grad, inp_r.grad, atol=BWD_ATOL, rtol=BWD_RTOL)
+
+    @_require_triton
+    @_require_cutile
+    @pytest.mark.parametrize("s,b,n,iters", [(2, 4, 4, 5)])
+    def test_triton_vs_cutile(self, s, b, n, iters):
+        from megatron.core.fusions.fused_mhc_kernels import (
+            _cutile_sinkhorn_bwd,
+            _cutile_sinkhorn_fwd,
+            triton_fused_sinkhorn,
+        )
+
+        eps = 1e-6
+        data = _rand(s, b, n, n)
+        grad_out = _rand(s, b, n, n)
+
+        inp_t = data.clone().requires_grad_(True)
+        out_t = triton_fused_sinkhorn(inp_t, iters, eps)
+        out_t.backward(grad_out)
+
+        out_c, M_init = _cutile_sinkhorn_fwd(data.clone(), iters, eps)
+        grad_c = _cutile_sinkhorn_bwd(grad_out, M_init, iters, eps)
+
+        torch.testing.assert_close(out_t, out_c, atol=FWD_ATOL, rtol=FWD_RTOL)
+        torch.testing.assert_close(inp_t.grad, grad_c, atol=BWD_ATOL, rtol=BWD_RTOL)
+
+
+# ============================================================================
+# Proj RMS
+# ============================================================================
+
+
+class TestNativeProjRms:
+    """Tests for native_proj_rms."""
+
+    @pytest.mark.parametrize("M,N,K", [(256, 20, 4096), (64, 8, 512)])
+    def test_fwd_bwd_vs_torch_reference(self, M, N, K):
+        _info()
+        eps = 1e-6
+        x_data = _rand(M, K)
+        w_data = _rand(N, K)
+        grad_proj = _rand(M, N)
+        grad_r = _rand(M, 1)
+
+        xf = x_data.clone().requires_grad_(True)
+        wf = w_data.clone().requires_grad_(True)
+        proj_f, r_f = native_proj_rms(xf, wf, eps)
+        (proj_f * grad_proj + r_f * grad_r).sum().backward()
+
+        xr = x_data.clone().requires_grad_(True)
+        wr = w_data.clone().requires_grad_(True)
+        proj_r, r_r = _ref_proj_rms(xr, wr, eps)
+        (proj_r * grad_proj + r_r * grad_r).sum().backward()
+
+        torch.testing.assert_close(proj_f, proj_r, atol=FWD_ATOL, rtol=FWD_RTOL)
+        torch.testing.assert_close(r_f, r_r, atol=FWD_ATOL, rtol=FWD_RTOL)
+        torch.testing.assert_close(
+            xf.grad, xr.grad, atol=BWD_ATOL, rtol=BWD_RTOL, msg="backward mismatch on x"
+        )
+        torch.testing.assert_close(
+            wf.grad, wr.grad, atol=BWD_ATOL, rtol=BWD_RTOL, msg="backward mismatch on weight"
+        )
+
+
+# ============================================================================
+# Proj RMS + Compute H (fused)
+# ============================================================================
+
+
+class TestFusedProjRmsComputeH:
+    """Public fused proj_rms_compute_h dispatch/fallback plus numerical correctness."""
+
+    @pytest.mark.parametrize("M,n,K", [(256, 4, 4096), (64, 2, 512), (128, 4, 2048)])
+    def test_fwd_bwd_vs_reference(self, M, n, K):
+        """E2E: public fused fwd output and bwd grads must match the PyTorch reference."""
+        from megatron.core.fusions.fused_mhc_kernels import fused_proj_rms_compute_h
+
+        _info()
+        N = n * n + 2 * n
+        eps = 1e-6
+        x_data = _rand(M, K)
+        w_data = _rand(N, K)
+        ap_data = _rand(1)
+        apo_data = _rand(1)
+        ar_data = _rand(1)
+        bias_data = _rand(N)
+        grad_y = _rand(M, N)
+        grad_h_pre = grad_y[:, :n]
+        grad_h_post = grad_y[:, n : 2 * n]
+        grad_h_res = grad_y[:, 2 * n :]
+        grad_r = _rand(M, 1)
+
+        def _make_inputs():
+            return (
+                x_data.clone().requires_grad_(True),
+                w_data.clone().requires_grad_(True),
+                ap_data.clone().requires_grad_(True),
+                apo_data.clone().requires_grad_(True),
+                ar_data.clone().requires_grad_(True),
+                bias_data.clone().requires_grad_(True),
+            )
+
+        # -- fused path --
+        xf, wf, apf, apof, arf, bf = _make_inputs()
+        h_pre_f, h_post_f, h_res_f, r_f = fused_proj_rms_compute_h(
+            xf, wf, apf, apof, arf, bf, n, eps
+        )
+        loss_f = (
+            (h_pre_f * grad_h_pre).sum()
+            + (h_post_f * grad_h_post).sum()
+            + (h_res_f * grad_h_res).sum()
+            + (r_f * grad_r).sum()
+        )
+        loss_f.backward()
+
+        # -- reference path --
+        xr, wr, apr, apor, arr, br = _make_inputs()
+        h_pre_r, h_post_r, h_res_r, r_r = _ref_proj_rms_compute_h(
+            xr, wr, apr, apor, arr, br, n, eps
+        )
+        loss_r = (
+            (h_pre_r * grad_h_pre).sum()
+            + (h_post_r * grad_h_post).sum()
+            + (h_res_r * grad_h_res).sum()
+            + (r_r * grad_r).sum()
+        )
+        loss_r.backward()
+
+        torch.testing.assert_close(
+            h_pre_f, h_pre_r, atol=FWD_ATOL, rtol=FWD_RTOL, msg="h_pre mismatch"
+        )
+        torch.testing.assert_close(
+            h_post_f, h_post_r, atol=FWD_ATOL, rtol=FWD_RTOL, msg="h_post mismatch"
+        )
+        torch.testing.assert_close(
+            h_res_f, h_res_r, atol=FWD_ATOL, rtol=FWD_RTOL, msg="h_res mismatch"
+        )
+        torch.testing.assert_close(r_f, r_r, atol=FWD_ATOL, rtol=FWD_RTOL, msg="r mismatch")
+        torch.testing.assert_close(
+            xf.grad, xr.grad, atol=BWD_ATOL, rtol=BWD_RTOL, msg="backward mismatch on x"
+        )
+        torch.testing.assert_close(
+            wf.grad, wr.grad, atol=BWD_ATOL, rtol=BWD_RTOL, msg="backward mismatch on weight"
+        )
+        _assert_cosine_similar(
+            apf.grad, apr.grad, COSINE_SIM_THRESH, msg="backward mismatch on alpha_pre"
+        )
+        _assert_cosine_similar(
+            apof.grad, apor.grad, COSINE_SIM_THRESH, msg="backward mismatch on alpha_post"
+        )
+        _assert_cosine_similar(
+            arf.grad, arr.grad, COSINE_SIM_THRESH, msg="backward mismatch on alpha_res"
+        )
+        _assert_cosine_similar(bf.grad, br.grad, COSINE_SIM_THRESH, msg="backward mismatch on bias")
+
+
+# ============================================================================
+# End-to-end pipeline (all four kernels chained)
+# ============================================================================
+
+
+class TestEndToEndNative:
+    """Full mHC pipeline using native modules.
+
+    proj_rms -> compute_h -> sinkhorn -> aggregate -> h_post_bda.
+    Compares the native modules against inline PyTorch reference.
+    """
+
+    def test_full_pipeline_fwd_bwd(self):
+        _info()
+        s, b, n, C = 2, 4, 4, 1024
+        eps = 1e-6
+        sinkhorn_iters = 5
+
+        hs_data = _rand(s, b, n * C)
+        w_data = _rand(n * n + 2 * n, n * C)
+        layer_out_data = _rand(s, b, C)
+        layer_bias_data = _rand(C)
+
+        def _run_native_modules():
+            hs = hs_data.clone().requires_grad_(True)
+            w = w_data.clone().requires_grad_(True)
+
+            x_2d = hs.reshape(s * b, n * C)
+            proj, r = native_proj_rms(x_2d, w, eps)
+            proj = proj.view(s, b, -1)
+            r = r.view(s, b, 1)
+
+            h = r * proj
+            h_pre = h[..., :n].sigmoid()
+            h_post = h[..., n : 2 * n].sigmoid() * 2
+            h_res_logits = h[..., 2 * n :]
+            h_res = native_sinkhorn(h_res_logits.view(s, b, n, n), sinkhorn_iters, eps)
+
+            aggregated = native_h_aggregate(hs.view(s, b, n, C), h_pre)
+
+            output = native_h_post_bda(
+                h_res, hs.view(s, b, n, C), h_post, layer_out_data, layer_bias_data
+            )
+
+            loss = output.sum() + aggregated.sum()
+            loss.backward()
+            return output.detach(), aggregated.detach(), hs.grad.clone()
+
+        def _run_inline_ref():
+            hs = hs_data.clone().requires_grad_(True)
+            w = w_data.clone().requires_grad_(True)
+
+            x_2d = hs.reshape(s * b, n * C)
+            proj, r = _ref_proj_rms(x_2d, w, eps)
+            proj = proj.view(s, b, -1)
+            r = r.view(s, b, 1)
+
+            h = r * proj
+            h_pre = h[..., :n].sigmoid()
+            h_post = h[..., n : 2 * n].sigmoid() * 2
+            h_res_logits = h[..., 2 * n :]
+            h_res = _ref_sinkhorn(h_res_logits.view(s, b, n, n), sinkhorn_iters, eps)
+
+            aggregated = _ref_h_aggregate(hs.view(s, b, n, C), h_pre)
+
+            output = _ref_h_post_bda(
+                h_res, hs.view(s, b, n, C), h_post, layer_out_data, layer_bias_data
+            )
+
+            loss = output.sum() + aggregated.sum()
+            loss.backward()
+            return output.detach(), aggregated.detach(), hs.grad.clone()
+
+        out_m, agg_m, grad_m = _run_native_modules()
+        out_r, agg_r, grad_r = _run_inline_ref()
+
+        torch.testing.assert_close(
+            agg_m, agg_r, atol=FWD_ATOL, rtol=FWD_RTOL, msg="aggregated output mismatch"
+        )
+        torch.testing.assert_close(
+            out_m, out_r, atol=FWD_ATOL, rtol=FWD_RTOL, msg="h_post_bda output mismatch"
+        )
+        _assert_cosine_similar(
+            grad_m, grad_r, COSINE_SIM_THRESH, msg="hidden_states grad (E2E backward)"
+        )
+
+
+class TestEndToEndFused:
+    """Full mHC pipeline using the public fused API."""
+
+    @_require_cutile
+    def test_full_pipeline_fwd_bwd(self):
+        from megatron.core.fusions.fused_mhc_kernels import (
+            fused_h_aggregate,
+            fused_h_post_bda,
+            fused_sinkhorn,
+        )
+
+        _info()
+        s, b, n, C = 8, 4, 4, 1024
+        eps = 1e-6
+        sinkhorn_iters = 5
+
+        hs_data = _rand(s, b, n * C)
+        w_data = _rand(n * n + 2 * n, n * C)
+        layer_out_data = _rand(s, b, C)
+        layer_bias_data = _rand(C)
+
+        def _run_fused():
+            hs = hs_data.clone().requires_grad_(True)
+            w = w_data.clone().requires_grad_(True)
+
+            x_2d = hs.reshape(s * b, n * C)
+            proj, r = native_proj_rms(x_2d, w, eps)
+            proj = proj.view(s, b, -1)
+            r = r.view(s, b, 1)
+
+            h = r * proj
+            h_pre = h[..., :n].sigmoid()
+            h_post = h[..., n : 2 * n].sigmoid() * 2
+            h_res_logits = h[..., 2 * n :]
+            h_res = fused_sinkhorn(h_res_logits.view(s, b, n, n), sinkhorn_iters, eps)
+
+            aggregated = fused_h_aggregate(hs.view(s, b, n, C), h_pre)
+
+            output = fused_h_post_bda(
+                h_res, hs.view(s, b, n, C), h_post, layer_out_data, layer_bias_data
+            )
+
+            loss = output.sum() + aggregated.sum()
+            loss.backward()
+            return proj.detach(), r.detach(), output.detach(), aggregated.detach(), hs.grad.clone()
+
+        def _run_ref():
+            hs = hs_data.clone().requires_grad_(True)
+            w = w_data.clone().requires_grad_(True)
+
+            x_2d = hs.reshape(s * b, n * C)
+            proj, r = _ref_proj_rms(x_2d, w, eps)
+            proj = proj.view(s, b, -1)
+            r = r.view(s, b, 1)
+
+            h = r * proj
+            h_pre = h[..., :n].sigmoid()
+            h_post = h[..., n : 2 * n].sigmoid() * 2
+            h_res_logits = h[..., 2 * n :]
+            h_res = _ref_sinkhorn(h_res_logits.view(s, b, n, n), sinkhorn_iters, eps)
+
+            aggregated = _ref_h_aggregate(hs.view(s, b, n, C), h_pre)
+
+            output = _ref_h_post_bda(
+                h_res, hs.view(s, b, n, C), h_post, layer_out_data, layer_bias_data
+            )
+
+            loss = output.sum() + aggregated.sum()
+            loss.backward()
+            return proj.detach(), r.detach(), output.detach(), aggregated.detach(), hs.grad.clone()
+
+        proj_f, r_f, out_f, agg_f, grad_f = _run_fused()
+        proj_r, r_r, out_r, agg_r, grad_r = _run_ref()
+
+        torch.testing.assert_close(proj_f, proj_r, atol=FWD_ATOL, rtol=FWD_RTOL)
+        torch.testing.assert_close(r_f, r_r, atol=FWD_ATOL, rtol=FWD_RTOL)
+        torch.testing.assert_close(agg_f, agg_r, atol=FWD_ATOL, rtol=FWD_RTOL)
+        torch.testing.assert_close(
+            out_f, out_r, atol=FWD_ATOL, rtol=FWD_RTOL, msg="h_post_bda output mismatch"
+        )
+        _assert_cosine_similar(
+            grad_f, grad_r, COSINE_SIM_THRESH, msg="hidden_states grad (E2E backward)"
+        )
+
+    def test_full_pipeline_fused_compute_h(self):
+        """E2E: fused proj_rms_compute_h replaces separate proj_rms + compute_h."""
+        from megatron.core.fusions.fused_mhc_kernels import (
+            fused_h_aggregate,
+            fused_h_post_bda,
+            fused_proj_rms_compute_h,
+            fused_sinkhorn,
+        )
+
+        _info()
+        s, b, n, C = 8, 4, 4, 1024
+        N = n * n + 2 * n
+        eps = 1e-6
+        sinkhorn_iters = 5
+
+        hs_data = _rand(s, b, n * C)
+        w_data = _rand(N, n * C)
+        ap_data = _rand(1)
+        apo_data = _rand(1)
+        ar_data = _rand(1)
+        bias_data = _rand(N)
+        layer_out_data = _rand(s, b, C)
+        layer_bias_data = _rand(C)
+
+        def _run_fused_compute_h():
+            hs = hs_data.clone().requires_grad_(True)
+            w = w_data.clone().requires_grad_(True)
+            ap = ap_data.clone().requires_grad_(True)
+            apo = apo_data.clone().requires_grad_(True)
+            ar = ar_data.clone().requires_grad_(True)
+            bias_p = bias_data.clone().requires_grad_(True)
+
+            x_2d = hs.reshape(s * b, n * C)
+            h_pre, h_post, h_res_logits, _ = fused_proj_rms_compute_h(
+                x_2d, w, ap, apo, ar, bias_p, n, eps
+            )
+
+            h_pre = h_pre.view(s, b, n)
+            h_post = h_post.view(s, b, n)
+            h_res_logits = h_res_logits.view(s, b, n, n)
+            h_res = fused_sinkhorn(h_res_logits, sinkhorn_iters, eps)
+
+            aggregated = fused_h_aggregate(hs.view(s, b, n, C), h_pre)
+
+            output = fused_h_post_bda(
+                h_res, hs.view(s, b, n, C), h_post, layer_out_data, layer_bias_data
+            )
+
+            loss = output.sum() + aggregated.sum()
+            loss.backward()
+            return output.detach(), aggregated.detach(), hs.grad.clone()
+
+        def _run_ref():
+            hs = hs_data.clone().requires_grad_(True)
+            w = w_data.clone().requires_grad_(True)
+            ap = ap_data.clone().requires_grad_(True)
+            apo = apo_data.clone().requires_grad_(True)
+            ar = ar_data.clone().requires_grad_(True)
+            bias_p = bias_data.clone().requires_grad_(True)
+
+            x_2d = hs.reshape(s * b, n * C)
+            h_pre, h_post, h_res_logits, _ = _ref_proj_rms_compute_h(
+                x_2d, w, ap, apo, ar, bias_p, n, eps
+            )
+
+            h_pre = h_pre.view(s, b, n)
+            h_post = h_post.view(s, b, n)
+            h_res_logits = h_res_logits.view(s, b, n, n)
+            h_res = _ref_sinkhorn(h_res_logits, sinkhorn_iters, eps)
+
+            aggregated = _ref_h_aggregate(hs.view(s, b, n, C), h_pre)
+
+            output = _ref_h_post_bda(
+                h_res, hs.view(s, b, n, C), h_post, layer_out_data, layer_bias_data
+            )
+
+            loss = output.sum() + aggregated.sum()
+            loss.backward()
+            return output.detach(), aggregated.detach(), hs.grad.clone()
+
+        out_f, agg_f, grad_f = _run_fused_compute_h()
+        out_r, agg_r, grad_r = _run_ref()
+
+        torch.testing.assert_close(
+            agg_f, agg_r, atol=FWD_ATOL, rtol=FWD_RTOL, msg="aggregated mismatch"
+        )
+        torch.testing.assert_close(
+            out_f, out_r, atol=FWD_ATOL, rtol=FWD_RTOL, msg="h_post_bda output mismatch"
+        )
+        _assert_cosine_similar(
+            grad_f,
+            grad_r,
+            COSINE_SIM_THRESH,
+            msg="hidden_states grad (E2E backward, fused compute_h)",
+        )
+
+
+# ============================================================================
+# fused_add_3 kernel tests
+# ============================================================================
+
+
+class TestFusedAdd3:
+    """Tests for fused_add_3 (torch.compile backend, no cuTile dependency)."""
+
+    def test_fused_add_3_forward_bf16(self):
+        """fused_add_3 matches a + b + c for bf16 tensors."""
+        from megatron.core.fusions.fused_mhc_kernels import fused_add_3
+
+        a = torch.randn(128, 256, dtype=DTYPE, device=DEVICE)
+        b = torch.randn(128, 256, dtype=DTYPE, device=DEVICE)
+        c = torch.randn(128, 256, dtype=DTYPE, device=DEVICE)
+        result = fused_add_3(a, b, c)
+        expected = (a.float() + b.float() + c.float()).to(DTYPE)
+        torch.testing.assert_close(result, expected, atol=FWD_ATOL, rtol=FWD_RTOL)
+
+    def test_fused_add_3_forward_fp32(self):
+        """fused_add_3 matches a + b + c for fp32 tensors."""
+        from megatron.core.fusions.fused_mhc_kernels import fused_add_3
+
+        a = torch.randn(128, 256, dtype=torch.float32, device=DEVICE)
+        b = torch.randn(128, 256, dtype=torch.float32, device=DEVICE)
+        c = torch.randn(128, 256, dtype=torch.float32, device=DEVICE)
+        result = fused_add_3(a, b, c)
+        expected = a + b + c
+        torch.testing.assert_close(result, expected, atol=1e-5, rtol=1e-5)
+
+    def test_fused_add_3_large_tensor(self):
+        """fused_add_3 handles large tensors."""
+        from megatron.core.fusions.fused_mhc_kernels import fused_add_3
+
+        a = torch.randn(8192, 4096, dtype=DTYPE, device=DEVICE)
+        b = torch.randn(8192, 4096, dtype=DTYPE, device=DEVICE)
+        c = torch.randn(8192, 4096, dtype=DTYPE, device=DEVICE)
+        result = fused_add_3(a, b, c)
+        expected = (a.float() + b.float() + c.float()).to(DTYPE)
+        torch.testing.assert_close(result, expected, atol=FWD_ATOL, rtol=FWD_RTOL)
+
+    def test_fused_add_3_gradient(self):
+        """fused_add_3 produces correct gradients."""
+        from megatron.core.fusions.fused_mhc_kernels import fused_add_3
+
+        a = torch.randn(64, 128, dtype=torch.float32, device=DEVICE, requires_grad=True)
+        b = torch.randn(64, 128, dtype=torch.float32, device=DEVICE, requires_grad=True)
+        c = torch.randn(64, 128, dtype=torch.float32, device=DEVICE, requires_grad=True)
+        result = fused_add_3(a, b, c)
+        result.sum().backward()
+        torch.testing.assert_close(a.grad, torch.ones_like(a))
+        torch.testing.assert_close(b.grad, torch.ones_like(b))
+        torch.testing.assert_close(c.grad, torch.ones_like(c))
+
+
+# ============================================================================
+# End-to-end pipeline with BroadcastTensorFused
+# ============================================================================
+
+
+class TestEndToEndNativeBroadcast:
+    """Full mHC pipeline using native modules + BroadcastTensorFused.
+
+    Same pipeline as TestEndToEndNative but hidden_states is split via
+    BroadcastTensorFused so each consumer (proj_rms/compute_h, aggregate,
+    h_post_bda) gets a distinct autograd graph node. Verifies gradient
+    correctness versus the inline reference that uses the tensor directly.
+    """
+
+    def test_full_pipeline_fwd_bwd(self):
+        from megatron.core.transformer.hyper_connection import (
+            BroadcastTensorFused,
+            native_fused_add_3,
+        )
+
+        _info()
+        s, b, n, C = 2, 4, 4, 1024
+        eps = 1e-6
+        sinkhorn_iters = 5
+
+        hs_data = _rand(s, b, n * C)
+        w_data = _rand(n * n + 2 * n, n * C)
+        layer_out_data = _rand(s, b, C)
+        layer_bias_data = _rand(C)
+
+        def _run_broadcast():
+            hs = hs_data.clone().requires_grad_(True)
+            w = w_data.clone().requires_grad_(True)
+
+            # Split via BroadcastTensorFused
+            hs_map, hs_agg, hs_res = BroadcastTensorFused.apply(hs, native_fused_add_3)
+
+            x_2d = hs_map.reshape(s * b, n * C)
+            proj, r = native_proj_rms(x_2d, w, eps)
+            proj = proj.view(s, b, -1)
+            r = r.view(s, b, 1)
+
+            h = r * proj
+            h_pre = h[..., :n].sigmoid()
+            h_post = h[..., n : 2 * n].sigmoid() * 2
+            h_res_logits = h[..., 2 * n :]
+            h_res = native_sinkhorn(h_res_logits.view(s, b, n, n), sinkhorn_iters, eps)
+
+            aggregated = native_h_aggregate(hs_agg.view(s, b, n, C), h_pre)
+
+            output = native_h_post_bda(
+                h_res, hs_res.view(s, b, n, C), h_post, layer_out_data, layer_bias_data
+            )
+
+            loss = output.sum() + aggregated.sum()
+            loss.backward()
+            return output.detach(), aggregated.detach(), hs.grad.clone()
+
+        def _run_inline_ref():
+            hs = hs_data.clone().requires_grad_(True)
+            w = w_data.clone().requires_grad_(True)
+
+            x_2d = hs.reshape(s * b, n * C)
+            proj, r = _ref_proj_rms(x_2d, w, eps)
+            proj = proj.view(s, b, -1)
+            r = r.view(s, b, 1)
+
+            h = r * proj
+            h_pre = h[..., :n].sigmoid()
+            h_post = h[..., n : 2 * n].sigmoid() * 2
+            h_res_logits = h[..., 2 * n :]
+            h_res = _ref_sinkhorn(h_res_logits.view(s, b, n, n), sinkhorn_iters, eps)
+
+            aggregated = _ref_h_aggregate(hs.view(s, b, n, C), h_pre)
+
+            output = _ref_h_post_bda(
+                h_res, hs.view(s, b, n, C), h_post, layer_out_data, layer_bias_data
+            )
+
+            loss = output.sum() + aggregated.sum()
+            loss.backward()
+            return output.detach(), aggregated.detach(), hs.grad.clone()
+
+        out_b, agg_b, grad_b = _run_broadcast()
+        out_r, agg_r, grad_r = _run_inline_ref()
+
+        torch.testing.assert_close(
+            agg_b, agg_r, atol=FWD_ATOL, rtol=FWD_RTOL, msg="aggregated mismatch (broadcast)"
+        )
+        torch.testing.assert_close(
+            out_b, out_r, atol=FWD_ATOL, rtol=FWD_RTOL, msg="h_post_bda output mismatch (broadcast)"
+        )
+        _assert_cosine_similar(
+            grad_b, grad_r, COSINE_SIM_THRESH, msg="hidden_states grad (E2E backward, broadcast)"
+        )
+
+
+class TestEndToEndFusedBroadcast:
+    """Full mHC pipeline through public fused dispatch + BroadcastTensorFused."""
+
+    def test_full_pipeline_fwd_bwd(self):
+        from megatron.core.fusions.fused_mhc_kernels import (
+            fused_add_3,
+            fused_h_aggregate,
+            fused_h_post_bda,
+            fused_sinkhorn,
+        )
+        from megatron.core.transformer.hyper_connection import BroadcastTensorFused
+
+        _info()
+        s, b, n, C = 8, 4, 4, 1024
+        eps = 1e-6
+        sinkhorn_iters = 5
+
+        hs_data = _rand(s, b, n * C)
+        w_data = _rand(n * n + 2 * n, n * C)
+        layer_out_data = _rand(s, b, C)
+        layer_bias_data = _rand(C)
+
+        def _run_fused_broadcast():
+            hs = hs_data.clone().requires_grad_(True)
+            w = w_data.clone().requires_grad_(True)
+
+            hs_map, hs_agg, hs_res = BroadcastTensorFused.apply(hs, fused_add_3)
+
+            x_2d = hs_map.reshape(s * b, n * C)
+            proj, r = native_proj_rms(x_2d, w, eps)
+            proj = proj.view(s, b, -1)
+            r = r.view(s, b, 1)
+
+            h = r * proj
+            h_pre = h[..., :n].sigmoid()
+            h_post = h[..., n : 2 * n].sigmoid() * 2
+            h_res_logits = h[..., 2 * n :]
+            h_res = fused_sinkhorn(h_res_logits.view(s, b, n, n), sinkhorn_iters, eps)
+
+            aggregated = fused_h_aggregate(hs_agg.view(s, b, n, C), h_pre)
+
+            output = fused_h_post_bda(
+                h_res, hs_res.view(s, b, n, C), h_post, layer_out_data, layer_bias_data
+            )
+
+            loss = output.sum() + aggregated.sum()
+            loss.backward()
+            return output.detach(), aggregated.detach(), hs.grad.clone()
+
+        def _run_ref():
+            hs = hs_data.clone().requires_grad_(True)
+            w = w_data.clone().requires_grad_(True)
+
+            x_2d = hs.reshape(s * b, n * C)
+            proj, r = _ref_proj_rms(x_2d, w, eps)
+            proj = proj.view(s, b, -1)
+            r = r.view(s, b, 1)
+
+            h = r * proj
+            h_pre = h[..., :n].sigmoid()
+            h_post = h[..., n : 2 * n].sigmoid() * 2
+            h_res_logits = h[..., 2 * n :]
+            h_res = _ref_sinkhorn(h_res_logits.view(s, b, n, n), sinkhorn_iters, eps)
+
+            aggregated = _ref_h_aggregate(hs.view(s, b, n, C), h_pre)
+
+            output = _ref_h_post_bda(
+                h_res, hs.view(s, b, n, C), h_post, layer_out_data, layer_bias_data
+            )
+
+            loss = output.sum() + aggregated.sum()
+            loss.backward()
+            return output.detach(), aggregated.detach(), hs.grad.clone()
+
+        out_f, agg_f, grad_f = _run_fused_broadcast()
+        out_r, agg_r, grad_r = _run_ref()
+
+        torch.testing.assert_close(
+            agg_f, agg_r, atol=FWD_ATOL, rtol=FWD_RTOL, msg="aggregated mismatch (fused broadcast)"
+        )
+        torch.testing.assert_close(
+            out_f,
+            out_r,
+            atol=FWD_ATOL,
+            rtol=FWD_RTOL,
+            msg="h_post_bda output mismatch (fused broadcast)",
+        )
+        _assert_cosine_similar(
+            grad_f,
+            grad_r,
+            COSINE_SIM_THRESH,
+            msg="hidden_states grad (E2E backward, fused broadcast)",
+        )
+
+    def test_full_pipeline_fused_compute_h_broadcast(self):
+        """E2E: fused proj_rms_compute_h + BroadcastTensorFused."""
+        from megatron.core.fusions.fused_mhc_kernels import (
+            fused_add_3,
+            fused_h_aggregate,
+            fused_h_post_bda,
+            fused_proj_rms_compute_h,
+            fused_sinkhorn,
+        )
+        from megatron.core.transformer.hyper_connection import BroadcastTensorFused
+
+        _info()
+        s, b, n, C = 8, 4, 4, 1024
+        N = n * n + 2 * n
+        eps = 1e-6
+        sinkhorn_iters = 5
+
+        hs_data = _rand(s, b, n * C)
+        w_data = _rand(N, n * C)
+        ap_data = _rand(1)
+        apo_data = _rand(1)
+        ar_data = _rand(1)
+        bias_data = _rand(N)
+        layer_out_data = _rand(s, b, C)
+        layer_bias_data = _rand(C)
+
+        def _run_fused_compute_h_broadcast():
+            hs = hs_data.clone().requires_grad_(True)
+            w = w_data.clone().requires_grad_(True)
+            ap = ap_data.clone().requires_grad_(True)
+            apo = apo_data.clone().requires_grad_(True)
+            ar = ar_data.clone().requires_grad_(True)
+            bias_p = bias_data.clone().requires_grad_(True)
+
+            hs_map, hs_agg, hs_res = BroadcastTensorFused.apply(hs, fused_add_3)
+
+            x_2d = hs_map.reshape(s * b, n * C)
+            h_pre, h_post, h_res_logits, _ = fused_proj_rms_compute_h(
+                x_2d, w, ap, apo, ar, bias_p, n, eps
+            )
+
+            h_pre = h_pre.view(s, b, n)
+            h_post = h_post.view(s, b, n)
+            h_res_logits = h_res_logits.view(s, b, n, n)
+            h_res = fused_sinkhorn(h_res_logits, sinkhorn_iters, eps)
+
+            aggregated = fused_h_aggregate(hs_agg.view(s, b, n, C), h_pre)
+
+            output = fused_h_post_bda(
+                h_res, hs_res.view(s, b, n, C), h_post, layer_out_data, layer_bias_data
+            )
+
+            loss = output.sum() + aggregated.sum()
+            loss.backward()
+            return output.detach(), aggregated.detach(), hs.grad.clone()
+
+        def _run_ref():
+            hs = hs_data.clone().requires_grad_(True)
+            w = w_data.clone().requires_grad_(True)
+            ap = ap_data.clone().requires_grad_(True)
+            apo = apo_data.clone().requires_grad_(True)
+            ar = ar_data.clone().requires_grad_(True)
+            bias_p = bias_data.clone().requires_grad_(True)
+
+            x_2d = hs.reshape(s * b, n * C)
+            h_pre, h_post, h_res_logits, _ = _ref_proj_rms_compute_h(
+                x_2d, w, ap, apo, ar, bias_p, n, eps
+            )
+
+            h_pre = h_pre.view(s, b, n)
+            h_post = h_post.view(s, b, n)
+            h_res_logits = h_res_logits.view(s, b, n, n)
+            h_res = _ref_sinkhorn(h_res_logits, sinkhorn_iters, eps)
+
+            aggregated = _ref_h_aggregate(hs.view(s, b, n, C), h_pre)
+
+            output = _ref_h_post_bda(
+                h_res, hs.view(s, b, n, C), h_post, layer_out_data, layer_bias_data
+            )
+
+            loss = output.sum() + aggregated.sum()
+            loss.backward()
+            return output.detach(), aggregated.detach(), hs.grad.clone()
+
+        out_f, agg_f, grad_f = _run_fused_compute_h_broadcast()
+        out_r, agg_r, grad_r = _run_ref()
+
+        torch.testing.assert_close(
+            agg_f,
+            agg_r,
+            atol=FWD_ATOL,
+            rtol=FWD_RTOL,
+            msg="aggregated mismatch (fused compute_h broadcast)",
+        )
+        torch.testing.assert_close(
+            out_f,
+            out_r,
+            atol=FWD_ATOL,
+            rtol=FWD_RTOL,
+            msg="h_post_bda output mismatch (fused compute_h broadcast)",
+        )
+        _assert_cosine_similar(
+            grad_f,
+            grad_r,
+            COSINE_SIM_THRESH,
+            msg="hidden_states grad (E2E backward, fused compute_h broadcast)",
+        )
+
+
+class TestFusedProjRmsComputeHKeepFp32:
+    """Regression: the mHC mapping must stay fp32-accurate with bf16 activations.
+
+    HyperConnectionModule marks mapping_proj.weight / alpha_* / bias as
+    keep_in_fp32 and the unfused path upcasts the activations to fp32, so the
+    fused path must not silently degrade the mapping to the activation dtype.
+    Tolerances here are ~15x tighter than the module-level FWD_ATOL/RTOL: the
+    bug this guards against (bf16 split-K partials and bf16 mapping outputs)
+    cost 170x accuracy while staying well inside the loose tolerances.
+    """
+
+    # Native fp32 reference achieves ~8e-6 rms; the bf16-output bug gave ~1.5e-3.
+    MAPPING_RMS_TOL = 1e-4
+    # r is a pure reduction: native reaches ~5e-8, the bug gave ~2.7e-3.
+    R_RMS_TOL = 1e-5
+
+    @staticmethod
+    def _rms_rel(actual: Tensor, ref64: Tensor) -> float:
+        a = actual.detach().to(torch.float64)
+        r = ref64.detach().to(torch.float64)
+        return ((a - r).pow(2).mean().sqrt() / r.abs().max().clamp_min(1e-30)).item()
+
+    @pytest.mark.parametrize("M,n,hidden", [(256, 4, 4096), (128, 4, 1024)])
+    def test_bf16_activations_fp32_params(self, M, n, hidden):
+        """Fused mapping with production dtypes must match an fp64 reference."""
+        from megatron.core.fusions.fused_mhc_kernels import fused_proj_rms_compute_h
+
+        _info()
+        K = n * hidden
+        N = n * n + 2 * n
+        eps = compute_h_eps = 1e-6
+
+        # Activations arrive in bf16; the mapping parameters are keep_in_fp32.
+        x = torch.randn(M, K, device=DEVICE, dtype=torch.float32).to(torch.bfloat16)
+        w = torch.randn(N, K, device=DEVICE, dtype=torch.float32) / math.sqrt(K)
+        alpha_pre = torch.full((1,), 0.1, device=DEVICE, dtype=torch.float32)
+        alpha_post = torch.full((1,), 0.1, device=DEVICE, dtype=torch.float32)
+        alpha_res = torch.full((1,), 0.1, device=DEVICE, dtype=torch.float32)
+        bias = torch.randn(N, device=DEVICE, dtype=torch.float32) * 0.1
+
+        h_pre, h_post, h_res, r = fused_proj_rms_compute_h(
+            x, w, alpha_pre, alpha_post, alpha_res, bias, n, eps, compute_h_eps
+        )
+
+        # fp64 reference from the same input values.
+        x64, w64 = x.to(torch.float64), w.to(torch.float64)
+        proj64 = x64 @ w64.t()
+        r64 = x64.norm(dim=-1, keepdim=True) / math.sqrt(K)
+        alpha64 = torch.cat(
+            [
+                alpha_pre.to(torch.float64).expand(n),
+                alpha_post.to(torch.float64).expand(n),
+                alpha_res.to(torch.float64).expand(N - 2 * n),
+            ],
+            dim=-1,
+        )
+        h64 = proj64 * alpha64.unsqueeze(0) / (r64 + eps) + bias.to(torch.float64).unsqueeze(0)
+
+        assert self._rms_rel(h_pre, h64[..., :n].sigmoid() + compute_h_eps) < self.MAPPING_RMS_TOL
+        assert self._rms_rel(h_post, h64[..., n : 2 * n].sigmoid() * 2) < self.MAPPING_RMS_TOL
+        assert self._rms_rel(h_res, h64[..., 2 * n :]) < self.MAPPING_RMS_TOL
+        assert self._rms_rel(r, r64) < self.R_RMS_TOL
+
+    def test_native_fallback_accepts_mixed_dtypes(self):
+        """The native fallback must run with bf16 activations x fp32 parameters."""
+        from megatron.core.fusions.fused_mhc_kernels import _torch_proj_rms_compute_h
+
+        M, n, K = 64, 4, 512
+        N = n * n + 2 * n
+        x = torch.randn(M, K, device=DEVICE, dtype=torch.bfloat16)
+        w = torch.randn(N, K, device=DEVICE, dtype=torch.float32) / math.sqrt(K)
+        one = torch.full((1,), 0.1, device=DEVICE, dtype=torch.float32)
+        bias = torch.zeros(N, device=DEVICE, dtype=torch.float32)
+
+        h_pre, h_post, h_res, r = _torch_proj_rms_compute_h(x, w, one, one, one, bias, n, 1e-6)
+        for t in (h_pre, h_post, h_res, r):
+            assert torch.isfinite(t).all()
+
+    @_require_cutile
+    def test_no_fp32_activation_copy(self):
+        """cuTile must consume the bf16 activations, not an fp32 copy of them.
+
+        The kernels load and cast each tile independently, so normalizing the
+        activation dtype ahead of the launch would only cost memory.
+        """
+        from megatron.core.fusions.fused_mhc_kernels import fused_proj_rms_compute_h
+
+        _info()
+        M, n, hidden = 4096, 4, 4096
+        K, N = n * hidden, n * n + 2 * n
+        x = torch.randn(M, K, device=DEVICE, dtype=torch.bfloat16)
+        w = torch.randn(N, K, device=DEVICE, dtype=torch.float32) / math.sqrt(K)
+        one = torch.full((1,), 0.1, device=DEVICE, dtype=torch.float32)
+        bias = torch.zeros(N, device=DEVICE, dtype=torch.float32)
+
+        torch.cuda.synchronize()
+        torch.cuda.reset_peak_memory_stats()
+        before = torch.cuda.memory_allocated()
+        fused_proj_rms_compute_h(x, w, one, one, one, bias, n, 1e-6)
+        torch.cuda.synchronize()
+        peak = torch.cuda.max_memory_allocated() - before
+
+        fp32_activation_copy = M * K * 4
+        assert peak < fp32_activation_copy // 2, (
+            f"peak allocation {peak} suggests the activations were upcast "
+            f"(an fp32 copy of x is {fp32_activation_copy} bytes)"
+        )
+
+    def test_public_entry_point_native_branch(self, monkeypatch):
+        """The public op must also run natively — this is the forced-native path.
+
+        MHC_FORCE_BACKEND=native and an auto run on a cuTile-less container both
+        land here, and the module always calls the public op when
+        use_fused_mhc=True, so this branch is what a real training job hits.
+        """
+        from megatron.core.fusions import fused_mhc_kernels as fused_mod
+
+        _info()
+        monkeypatch.setattr(fused_mod, "is_cutile_available", lambda: False)
+
+        M, n, K = 64, 4, 512
+        N = n * n + 2 * n
+        x = torch.randn(M, K, device=DEVICE, dtype=torch.bfloat16)
+        w = torch.randn(N, K, device=DEVICE, dtype=torch.float32) / math.sqrt(K)
+        one = torch.full((1,), 0.1, device=DEVICE, dtype=torch.float32)
+        bias = torch.zeros(N, device=DEVICE, dtype=torch.float32)
+
+        outs = fused_mod.fused_proj_rms_compute_h(x, w, one, one, one, bias, n, 1e-6)
+        for t in outs:
+            assert torch.isfinite(t).all()
+
+
+class TestCutileHAggregateBackwardReduction:
+    """Regression: h_aggregate backward is the only other cuTile-only op.
+
+    `grad_h` is a reduction over the hidden dimension; evaluating the product
+    in bf16 before the fp32 accumulate made it ~2.5x noisier than the torch
+    reference at production widths.
+    """
+
+    @_require_cutile
+    @pytest.mark.parametrize("tokens,n,C", [(8192, 4, 1536), (2048, 4, 4096)])
+    def test_grad_h_reduction_not_worse_than_torch(self, tokens, n, C):
+        """cuTile grad_h must be at least as accurate as the torch reference."""
+        from megatron.core.fusions.fused_mhc_kernels import (
+            _cutile_h_aggregate_bwd,
+            _torch_h_aggregate_bwd,
+        )
+
+        _info()
+        s, b = 1, tokens
+        x = torch.randn(s, b, n, C, device=DEVICE, dtype=torch.float32).to(DTYPE)
+        h_pre = (torch.rand(s, b, n, device=DEVICE, dtype=torch.float32) + 0.5).to(DTYPE)
+        go = torch.randn(s, b, C, device=DEVICE, dtype=torch.float32).to(DTYPE)
+
+        goe = go.double().unsqueeze(2)
+        ref_gx = goe * h_pre.double().unsqueeze(-1)
+        ref_gh = (goe * x.double()).sum(-1)
+
+        def rel(a: Tensor, r: Tensor) -> float:
+            a, r = a.double().flatten(), r.double().flatten()
+            return ((a - r).pow(2).mean().sqrt() / r.pow(2).mean().sqrt()).item()
+
+        t_gx, t_gh = _torch_h_aggregate_bwd(go, x, h_pre)
+        c_gx, c_gh = _cutile_h_aggregate_bwd(go, x, h_pre)
+
+        # grad_x is a pure elementwise product — it must stay bit-identical.
+        assert torch.equal(c_gx, t_gx)
+        # A bf16 product before the fp32 accumulate showed up here as ~2.5x.
+        assert rel(c_gh, ref_gh) <= rel(t_gh, ref_gh) * 1.1

--- a/tests/unit_tests/models/test_hybrid_mhc.py
+++ b/tests/unit_tests/models/test_hybrid_mhc.py
@@ -3,14 +3,11 @@
 import pytest
 import torch
 
-from megatron.core.models.hybrid.hybrid_block import (
-    HybridStack,
-    HybridStackSubmodules,
-    HyperConnectionHybridLayer,
-)
+from megatron.core.models.hybrid.hybrid_block import HybridStack, HybridStackSubmodules
 from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols
 from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_stack_spec
 from megatron.core.models.hybrid.hybrid_model import HybridModel
+from megatron.core.models.hybrid.layers.hybrid_hyper_connection import HyperConnectionHybridLayer
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer import TransformerConfig

--- a/tests/unit_tests/models/test_hybrid_mhc.py
+++ b/tests/unit_tests/models/test_hybrid_mhc.py
@@ -1,0 +1,343 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import pytest
+import torch
+
+from megatron.core.models.hybrid.hybrid_block import (
+    HybridStack,
+    HybridStackSubmodules,
+    HyperConnectionHybridLayer,
+)
+from megatron.core.models.hybrid.hybrid_layer_allocation import Symbols
+from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_stack_spec
+from megatron.core.models.hybrid.hybrid_model import HybridModel
+from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.transformer import TransformerConfig
+from megatron.core.transformer.module import MegatronModule
+from megatron.core.transformer.moe.moe_layer import MoELayer
+from megatron.core.transformer.multi_token_prediction import MultiTokenPredictionLayer
+from megatron.core.transformer.spec_utils import ModuleSpec
+from megatron.core.transformer.transformer_layer import TransformerLayer
+from tests.unit_tests.test_utilities import Utils
+
+
+class _DummyHybridLayer(MegatronModule):
+    """Same-shape residual layer used to isolate HybridStack mHC plumbing."""
+
+    def __init__(self, config: TransformerConfig, layer_number: int, **_kwargs):
+        super().__init__(config=config)
+        self.layer_number = layer_number
+        self.proj = torch.nn.Linear(config.hidden_size, config.hidden_size, bias=False)
+        self.seen_hidden_shapes = []
+
+    def forward(
+        self,
+        hidden_states,
+        attention_mask=None,
+        inference_context=None,
+        packed_seq_params=None,
+        **_kwargs,
+    ):
+        self.seen_hidden_shapes.append(tuple(hidden_states.shape))
+        return hidden_states + 0.125 * self.proj(hidden_states)
+
+
+def _get_pg_collection() -> ProcessGroupCollection:
+    return ProcessGroupCollection.use_mpu_process_groups(required_pgs=['tp', 'pp', 'cp'])
+
+
+def _get_dummy_submodules() -> HybridStackSubmodules:
+    layer_spec = ModuleSpec(module=_DummyHybridLayer)
+    return HybridStackSubmodules(
+        mamba_layer=layer_spec,
+        gdn_layer=layer_spec,
+        attention_layer=layer_spec,
+        dsa_layer=layer_spec,
+        mlp_layer=layer_spec,
+        moe_layer=layer_spec,
+    )
+
+
+def _get_dummy_stack_spec() -> ModuleSpec:
+    return ModuleSpec(
+        module=HybridStack, params={"post_layer_norm": False}, submodules=_get_dummy_submodules()
+    )
+
+
+def _get_config(num_layers: int, **kwargs) -> TransformerConfig:
+    return TransformerConfig(
+        num_layers=num_layers,
+        hidden_size=32,
+        num_attention_heads=4,
+        use_cpu_initialization=True,
+        enable_mhc_connections=True,
+        mhc_num_residual_streams=2,
+        hidden_dropout=0.0,
+        mhc_sinkhorn_iterations=3,
+        **kwargs,
+    )
+
+
+def _get_stack(
+    config: TransformerConfig,
+    num_local_layers: int,
+    *,
+    pre_process: bool = True,
+    post_process: bool = True,
+    pp_layer_offset: int = 0,
+) -> HybridStack:
+    return HybridStack(
+        config=config,
+        submodules=_get_dummy_submodules(),
+        pre_process=pre_process,
+        post_process=post_process,
+        post_layer_norm=False,
+        layer_type_list=[Symbols.MAMBA] * num_local_layers,
+        pp_layer_offset=pp_layer_offset,
+        pg_collection=_get_pg_collection(),
+    )
+
+
+def test_mhc_mtp_requires_hybrid_contract():
+    config = _get_config(num_layers=1, mtp_num_layers=1)
+
+    with pytest.raises(ValueError, match="requires the HybridModel MTP contract"):
+        MultiTokenPredictionLayer(
+            config=config, submodules=object(), layer_number=1, pg_collection=None
+        )
+
+
+@pytest.mark.internal
+class TestHybridStackMHC:
+    def setup_method(self, method):
+        Utils.initialize_model_parallel(1, 1)
+        model_parallel_cuda_manual_seed(123)
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    def test_constructor_and_sharded_state(self):
+        config = _get_config(num_layers=3)
+        stack = _get_stack(config, num_local_layers=3)
+
+        assert all(isinstance(layer, HyperConnectionHybridLayer) for layer in stack.layers)
+        assert stack.hc_head_fn.shape == (
+            config.mhc_num_residual_streams,
+            config.hidden_size * config.mhc_num_residual_streams,
+        )
+        state = stack.sharded_state_dict(prefix="decoder.", metadata={})
+        for name in ("hc_head_fn", "hc_head_base", "hc_head_scale"):
+            assert f"decoder.{name}" in state
+
+    @pytest.mark.parametrize(
+        "recompute_kwargs",
+        [
+            {},
+            {
+                "recompute_granularity": "selective",
+                "recompute_modules": ["core_attn", "mhc"],
+                "mhc_recompute_layer_num": 2,
+            },
+        ],
+        ids=["none", "selective_mhc"],
+    )
+    def test_forward_backward(self, recompute_kwargs):
+        config = _get_config(num_layers=3, **recompute_kwargs)
+        stack = _get_stack(config, num_local_layers=3).cuda()
+        hidden_states = torch.randn(8, 2, config.hidden_size, device="cuda", requires_grad=True)
+
+        output = stack(hidden_states, attention_mask=None)
+
+        assert output.shape == hidden_states.shape
+        assert torch.isfinite(output).all()
+        output.float().sum().backward()
+        assert hidden_states.grad is not None
+        for layer in stack.layers:
+            assert layer.inner_layer.proj.weight.grad is not None
+            assert layer.hyper_connection.mapping_proj.weight.grad is not None
+            assert all(
+                shape == (8, 2, config.hidden_size)
+                for shape in layer.inner_layer.seen_hidden_shapes
+            )
+        for name in ("hc_head_fn", "hc_head_base", "hc_head_scale"):
+            assert getattr(stack, name).grad is not None
+
+    def test_fused_bf16_forward_backward(self):
+        config = _get_config(
+            num_layers=2, bf16=True, params_dtype=torch.bfloat16, use_fused_mhc=True
+        )
+        stack = _get_stack(config, num_local_layers=2).cuda().bfloat16()
+        hidden_states = torch.randn(
+            8, 2, config.hidden_size, device="cuda", dtype=torch.bfloat16, requires_grad=True
+        )
+
+        output = stack(hidden_states, attention_mask=None)
+
+        assert output.shape == hidden_states.shape
+        assert output.dtype == torch.bfloat16
+        assert torch.isfinite(output).all()
+        output.float().sum().backward()
+        assert hidden_states.grad is not None
+        assert all(
+            layer.hyper_connection.mapping_proj.weight.grad is not None for layer in stack.layers
+        )
+
+    def test_real_attention_mlp_forward_backward(self):
+        config = _get_config(num_layers=2)
+        stack = HybridStack(
+            config=config,
+            submodules=hybrid_stack_spec.submodules,
+            post_layer_norm=False,
+            layer_type_list=[Symbols.ATTENTION, Symbols.MLP],
+            pp_layer_offset=0,
+            pg_collection=_get_pg_collection(),
+        ).cuda()
+        hidden_states = torch.randn(8, 2, config.hidden_size, device="cuda", requires_grad=True)
+
+        output = stack(hidden_states, attention_mask=None)
+
+        assert output.shape == hidden_states.shape
+        assert all(isinstance(layer, HyperConnectionHybridLayer) for layer in stack.layers)
+        assert all(isinstance(layer.inner_layer, TransformerLayer) for layer in stack.layers)
+        output.float().sum().backward()
+        assert hidden_states.grad is not None
+        assert all(
+            layer.hyper_connection.mapping_proj.weight.grad is not None for layer in stack.layers
+        )
+
+    def test_real_moe_raw_branch_forward_backward(self):
+        config = _get_config(
+            num_layers=1,
+            num_moe_experts=2,
+            moe_ffn_hidden_size=64,
+            moe_grouped_gemm=True,
+            add_bias_linear=False,
+        )
+        pg_collection = ProcessGroupCollection.use_mpu_process_groups(
+            required_pgs=['tp', 'pp', 'cp', 'ep', 'expt_tp', 'tp_ep', 'expt_dp']
+        )
+        stack = HybridStack(
+            config=config,
+            submodules=hybrid_stack_spec.submodules,
+            post_layer_norm=False,
+            layer_type_list=[Symbols.MOE],
+            pp_layer_offset=0,
+            pg_collection=pg_collection,
+        ).cuda()
+        hidden_states = torch.randn(8, 2, config.hidden_size, device="cuda", requires_grad=True)
+
+        output = stack(hidden_states, attention_mask=None)
+
+        wrapped_layer = stack.layers[0]
+        assert isinstance(wrapped_layer, HyperConnectionHybridLayer)
+        assert isinstance(wrapped_layer.inner_layer.mlp, MoELayer)
+        assert output.shape == hidden_states.shape
+        output.float().sum().backward()
+        assert hidden_states.grad is not None
+        assert wrapped_layer.hyper_connection.mapping_proj.weight.grad is not None
+        assert any(param.grad is not None for param in wrapped_layer.inner_layer.mlp.parameters())
+
+    def test_hybrid_model_forward_backward(self):
+        config = _get_config(num_layers=3)
+        model = HybridModel(
+            config=config,
+            hybrid_stack_spec=_get_dummy_stack_spec(),
+            vocab_size=64,
+            max_sequence_length=8,
+            hybrid_layer_pattern="M*-",
+            parallel_output=False,
+        ).cuda()
+        input_ids = torch.arange(8, dtype=torch.int64, device="cuda").repeat((2, 1))
+        position_ids = torch.arange(8, dtype=torch.int64, device="cuda").repeat((2, 1))
+
+        logits = model(input_ids=input_ids, position_ids=position_ids, attention_mask=None)
+
+        assert logits.shape == (2, 8, model.vocab_size)
+        assert torch.isfinite(logits).all()
+        logits.float().mean().backward()
+        assert all(layer.inner_layer.proj.weight.grad is not None for layer in model.decoder.layers)
+        assert all(
+            layer.hyper_connection.mapping_proj.weight.grad is not None
+            for layer in model.decoder.layers
+        )
+
+    def test_hybrid_model_mtp_forward_backward(self):
+        config = _get_config(num_layers=1, mtp_num_layers=1, mtp_loss_scaling_factor=0.1)
+        model = HybridModel(
+            config=config,
+            hybrid_stack_spec=hybrid_stack_spec,
+            vocab_size=64,
+            max_sequence_length=8,
+            hybrid_layer_pattern="-/-",
+            parallel_output=True,
+        ).cuda()
+        input_ids = torch.arange(8, dtype=torch.int64, device="cuda").repeat((2, 1))
+        position_ids = torch.arange(8, dtype=torch.int64, device="cuda").repeat((2, 1))
+
+        logits = model(input_ids=input_ids, position_ids=position_ids, attention_mask=None)
+
+        assert logits.shape == (2, 8, model.vocab_size)
+        assert torch.isfinite(logits).all()
+        assert not any("mtp_model_layer.hc_head_" in name for name, _ in model.named_parameters())
+        logits.float().mean().backward()
+        mtp_params = [param for name, param in model.named_parameters() if name.startswith("mtp.")]
+        assert mtp_params
+        assert all(param.grad is not None for param in mtp_params)
+
+    def test_recompute_plan(self):
+        config = _get_config(
+            num_layers=3,
+            recompute_granularity="selective",
+            recompute_modules=["core_attn", "mhc"],
+            mhc_recompute_layer_num=2,
+        )
+        stack = _get_stack(config, num_local_layers=3)
+
+        managers, block_ends = stack._build_mhc_recompute_layer_plan(True)
+
+        assert block_ends == [False, True, True]
+        assert managers[0] is managers[1]
+        assert managers[1] is not managers[2]
+
+    def test_boundary_bda_skips_recompute_manager(self, monkeypatch):
+        config = _get_config(num_layers=1)
+        layer = HyperConnectionHybridLayer(
+            config=config, layer=_DummyHybridLayer(config, layer_number=1)
+        )
+        hidden_states = torch.randn(
+            4, 2, config.hidden_size * config.mhc_num_residual_streams, requires_grad=True
+        )
+        manager = type("_FakeManager", (), {})()
+        manager.is_last_layer_in_recompute_block = True
+        seen_managers = []
+
+        def fake_hyper_connection_forward(
+            hidden_states, mhc_recompute_manager=None, return_residual=False
+        ):
+            assert mhc_recompute_manager is manager
+            assert return_residual
+            sequence_length, batch_size, _ = hidden_states.shape
+            n = config.mhc_num_residual_streams
+            hidden_size = config.hidden_size
+            aggregated = hidden_states.view(sequence_length, batch_size, n, hidden_size).mean(dim=2)
+            h_res = torch.empty(sequence_length, batch_size, n, n)
+            h_post = torch.empty(sequence_length, batch_size, n)
+            return aggregated, h_res, h_post, hidden_states
+
+        def fake_bda(
+            h_res, residual, h_post, output_with_bias, dropout_prob, training, fused, manager=None
+        ):
+            seen_managers.append(manager)
+            return residual
+
+        monkeypatch.setattr(layer.hyper_connection, "forward", fake_hyper_connection_forward)
+        monkeypatch.setattr(layer.hyper_connection, "fused_h_res_h_post_bda", fake_bda)
+
+        output, _ = layer(hidden_states, attention_mask=None, mhc_recompute_manager=manager)
+        assert output is hidden_states
+        assert seen_managers == [None]
+
+        manager.is_last_layer_in_recompute_block = False
+        layer(hidden_states, attention_mask=None, mhc_recompute_manager=manager)
+        assert seen_managers[-1] is manager

--- a/tests/unit_tests/models/test_hybrid_mhc.py
+++ b/tests/unit_tests/models/test_hybrid_mhc.py
@@ -134,6 +134,8 @@ class TestHybridStackMHC:
         stack = _get_stack(config, num_local_layers=3)
 
         assert all(isinstance(layer, HyperConnectionHybridLayer) for layer in stack.layers)
+        assert all(layer.inner_layer.config is config for layer in stack.layers)
+        assert all(layer.inner_layer.config.enable_mhc_connections for layer in stack.layers)
         assert stack.hc_head_fn.shape == (
             config.mhc_num_residual_streams,
             config.hidden_size * config.mhc_num_residual_streams,
@@ -141,6 +143,19 @@ class TestHybridStackMHC:
         state = stack.sharded_state_dict(prefix="decoder.", metadata={})
         for name in ("hc_head_fn", "hc_head_base", "hc_head_scale"):
             assert f"decoder.{name}" in state
+
+    def test_fused_backend_policy_is_bound_per_wrapper(self):
+        config = _get_config(num_layers=1, use_fused_mhc=True, mhc_fused_backend="native")
+        stack = _get_stack(config, num_local_layers=1)
+        hyper_connection = stack.layers[0].hyper_connection
+
+        for op_name in (
+            "_sinkhorn_op",
+            "_h_aggregate_op",
+            "_h_post_bda_op",
+            "_proj_rms_compute_h_op",
+        ):
+            assert getattr(hyper_connection, op_name).keywords["backend"] == "native"
 
     def test_wrapped_gdn_preserves_dynamic_inference_state_shapes(self):
         config = _get_config(num_layers=1)

--- a/tests/unit_tests/models/test_hybrid_mhc.py
+++ b/tests/unit_tests/models/test_hybrid_mhc.py
@@ -40,6 +40,21 @@ class _DummyHybridLayer(MegatronModule):
         return hidden_states + 0.125 * self.proj(hidden_states)
 
 
+class _DummyRecurrentMixer(torch.nn.Module):
+    """Minimal GDN-like mixer exposing the dynamic-inference state contract."""
+
+    def mamba_state_shapes_per_request(self):
+        return (4, 8), (2, 16, 32)
+
+
+class _DummyGDNLayer(_DummyHybridLayer):
+    """TransformerLayer-shaped GDN stub used to verify mHC delegation."""
+
+    def __init__(self, config: TransformerConfig, layer_number: int, **kwargs):
+        super().__init__(config=config, layer_number=layer_number, **kwargs)
+        self.self_attention = _DummyRecurrentMixer()
+
+
 def _get_pg_collection() -> ProcessGroupCollection:
     return ProcessGroupCollection.use_mpu_process_groups(required_pgs=['tp', 'pp', 'cp'])
 
@@ -126,6 +141,21 @@ class TestHybridStackMHC:
         state = stack.sharded_state_dict(prefix="decoder.", metadata={})
         for name in ("hc_head_fn", "hc_head_base", "hc_head_scale"):
             assert f"decoder.{name}" in state
+
+    def test_wrapped_gdn_preserves_dynamic_inference_state_shapes(self):
+        config = _get_config(num_layers=1)
+        submodules = _get_dummy_submodules()
+        submodules.gdn_layer = ModuleSpec(module=_DummyGDNLayer)
+        stack = HybridStack(
+            config=config,
+            submodules=submodules,
+            post_layer_norm=False,
+            layer_type_list=[Symbols.GDN],
+            pg_collection=_get_pg_collection(),
+        )
+
+        assert isinstance(stack.layers[0], HyperConnectionHybridLayer)
+        assert stack.mamba_state_shapes_per_request() == ((4, 8), (2, 16, 32))
 
     @pytest.mark.parametrize(
         "recompute_kwargs",

--- a/tests/unit_tests/models/test_hybrid_moe_model.py
+++ b/tests/unit_tests/models/test_hybrid_moe_model.py
@@ -180,6 +180,7 @@ GOLDEN_CONFIG: Dict[str, Any] = {
     "mamba_training_ssm_states_dtype": None,
     "masked_softmax_fusion": True,
     "memory_efficient_layer_norm": False,
+    "mhc_fused_backend": "auto",
     "mhc_init_gating_factor": 0.01,
     "mhc_recompute_layer_num": None,
     "mhc_sinkhorn_iterations": 20,

--- a/tests/unit_tests/models/test_hybrid_moe_model.py
+++ b/tests/unit_tests/models/test_hybrid_moe_model.py
@@ -321,6 +321,7 @@ GOLDEN_CONFIG: Dict[str, Any] = {
     "tp_only_amax_red": False,
     "transformer_impl": "transformer_engine",
     "use_cpu_initialization": None,
+    "use_fused_mhc": False,
     "use_fused_weighted_squared_relu": False,
     "use_inference_optimized_layers": False,
     "use_kitchen": False,

--- a/tests/unit_tests/post_training/test_modelopt_module_spec.py
+++ b/tests/unit_tests/post_training/test_modelopt_module_spec.py
@@ -241,6 +241,35 @@ class TestModelOptHybridModel(TestModelOptGPTModel):
             hybrid_layer_pattern="M*-",
         )
 
+    def test_mhc_mtp_construction(self):
+        """The local ModelOpt Hybrid spec provides the split mHC MTP projections."""
+        config = TransformerConfig(
+            num_layers=1,
+            hidden_size=32,
+            num_attention_heads=4,
+            use_cpu_initialization=True,
+            enable_mhc_connections=True,
+            mhc_num_residual_streams=2,
+            mhc_sinkhorn_iterations=3,
+            hidden_dropout=0.0,
+            mtp_num_layers=1,
+        )
+        model = HybridModel(
+            config=config,
+            hybrid_stack_spec=get_hybrid_stack_modelopt_spec(),
+            vocab_size=64,
+            max_sequence_length=8,
+            hybrid_layer_pattern="-/-",
+        )
+
+        mtp_layer = model.mtp.layers[0]
+        assert mtp_layer.e_proj is not None
+        assert mtp_layer.h_proj is not None
+        assert mtp_layer.eh_proj is None
+        parameter_names = {name for name, _ in model.named_parameters()}
+        assert any(name.startswith("mtp.layers.0.e_proj.") for name in parameter_names)
+        assert any(name.startswith("mtp.layers.0.h_proj.") for name in parameter_names)
+
 
 def test_get_gpt_modelopt_spec_interface():
     # Get the function signature
@@ -357,6 +386,8 @@ def test_get_hybrid_stack_modelopt_spec_local_feature_specs():
     assert mtp_layer_spec.submodules.enorm is Norm
     assert mtp_layer_spec.submodules.hnorm is Norm
     assert mtp_layer_spec.submodules.eh_proj is ColumnParallelLinear
+    assert mtp_layer_spec.submodules.e_proj is ColumnParallelLinear
+    assert mtp_layer_spec.submodules.h_proj is ColumnParallelLinear
     assert mtp_layer_spec.submodules.layer_norm is Norm
 
 

--- a/tests/unit_tests/test_argument_utils.py
+++ b/tests/unit_tests/test_argument_utils.py
@@ -654,6 +654,12 @@ class TestArgumentGroupFactoryArgparseMeta:
 class TestMegatronNetworkArgumentGeneration:
     """Test Megatron's TransformerConfig-derived argument group."""
 
+    @staticmethod
+    def _parser() -> ArgumentParser:
+        from megatron.training.arguments import _add_network_size_args
+
+        return _add_network_size_args(ArgumentParser(exit_on_error=False))
+
     def test_transformer_callback_fields_are_not_registered_as_cli_args(self):
         """Callback fields are runtime hooks, not CLI-provided values."""
         from megatron.training.arguments import _add_network_size_args
@@ -676,6 +682,17 @@ class TestMegatronNetworkArgumentGeneration:
         args = parser.parse_args([])
         for field_name in callback_fields:
             assert not hasattr(args, field_name)
+
+    def test_mhc_fused_backend_is_exposed_as_config_choice(self):
+        assert self._parser().parse_args([]).mhc_fused_backend == "auto"
+
+        args = self._parser().parse_args(["--mhc-fused-backend", "native"])
+
+        assert args.mhc_fused_backend == "native"
+
+    def test_mhc_fused_backend_rejects_unknown_choice(self):
+        with pytest.raises(ArgumentError, match="invalid choice"):
+            self._parser().parse_args(["--mhc-fused-backend", "cuda"])
 
 
 class TestMegatronMixedPrecisionArguments:

--- a/tests/unit_tests/transformer/test_hyper_connection_recompute.py
+++ b/tests/unit_tests/transformer/test_hyper_connection_recompute.py
@@ -49,6 +49,32 @@ class TestHyperConnectionModuleCheckpoint:
         module.cuda()
         return module
 
+    def test_apply_h_res_uses_h_res_transpose(self):
+        """apply_h_res should compute H_res.T @ residual."""
+        module = self._create_hyper_connection_module(hidden_size=4, mhc_num_residual_streams=2)
+        h_res = torch.tensor([[[[1.0, 2.0], [3.0, 4.0]]]], device='cuda')
+        residual = torch.tensor([[[10.0, 100.0, 3.0, 4.0, 1.0, 2.0, 5.0, 6.0]]], device='cuda')
+        expected = torch.tensor(
+            [[[13.0, 106.0, 18.0, 22.0, 24.0, 208.0, 26.0, 32.0]]], device='cuda'
+        )
+
+        mixed = module.apply_h_res(h_res, residual)
+
+        torch.testing.assert_close(mixed, expected, atol=0.0, rtol=0.0)
+
+    def test_forward_preserves_three_tuple_api_and_hybrid_can_request_residual(self):
+        module = self._create_hyper_connection_module(hidden_size=8, mhc_num_residual_streams=2)
+        hidden_states = torch.randn(4, 1, 16, device='cuda', requires_grad=True)
+
+        compatible_output = module(hidden_states)
+        hybrid_output = module(hidden_states, return_residual=True)
+
+        assert len(compatible_output) == 3
+        assert len(hybrid_output) == 4
+        for compatible, hybrid in zip(compatible_output, hybrid_output[:3]):
+            torch.testing.assert_close(compatible, hybrid)
+        assert hybrid_output[3].shape == hidden_states.shape
+
     def test_forward_normal_vs_checkpoint_correctness(self):
         """
         Test that _forward_with_checkpoint produces the same outputs as _forward_normal.
@@ -75,7 +101,7 @@ class TestHyperConnectionModuleCheckpoint:
         # Forward without checkpoint (reference)
         torch.manual_seed(42)
         torch.cuda.manual_seed(42)
-        aggregated_ref, h_res_ref, h_post_ref = module._forward_normal(hidden_states)
+        aggregated_ref, h_res_ref, h_post_ref, residual_ref = module._forward_normal(hidden_states)
         mixed_ref = module.apply_h_res(h_res_ref, residual)
         loss_ref = aggregated_ref.sum() + mixed_ref.sum() + h_post_ref.sum()
         loss_ref.backward()
@@ -86,8 +112,8 @@ class TestHyperConnectionModuleCheckpoint:
         torch.manual_seed(42)
         torch.cuda.manual_seed(42)
         manager = CheckpointWithoutOutputManager()
-        aggregated_ckpt, h_res_ckpt, h_post_ckpt = module._forward_with_checkpoint(
-            hidden_states_ckpt, manager
+        aggregated_ckpt, h_res_ckpt, h_post_ckpt, residual_ckpt_out = (
+            module._forward_with_checkpoint(hidden_states_ckpt, manager)
         )
         mixed_ckpt = module.apply_h_res(h_res_ckpt, residual_ckpt)
         # Calculate loss before discarding outputs

--- a/tests/unit_tests/transformer/test_mhc_block_manager.py
+++ b/tests/unit_tests/transformer/test_mhc_block_manager.py
@@ -505,6 +505,25 @@ class TestTransformerBlockMHCRecompute:
         block, _ = self._make_mhc_block(num_layers=2)
         assert block.mhc_recompute_enabled
 
+    def test_plain_transformer_layer_still_fails_fast_in_transformer_block(self):
+        """The Hybrid ownership exception must not weaken ordinary TransformerBlock wiring."""
+        from megatron.core.models.gpt.gpt_layer_specs import (
+            get_gpt_layer_with_transformer_engine_spec,
+        )
+        from megatron.core.transformer.transformer_block import TransformerBlock
+        from megatron.core.transformer.transformer_config import TransformerConfig
+
+        config = TransformerConfig(
+            num_layers=1,
+            hidden_size=64,
+            num_attention_heads=4,
+            use_cpu_initialization=True,
+            enable_mhc_connections=True,
+        )
+
+        with pytest.raises(ValueError, match="HyperConnectionTransformerLayer"):
+            TransformerBlock(config, get_gpt_layer_with_transformer_engine_spec())
+
     def test_block_forward_input_expand_output_contract(self):
         """Forward exercises ``input_expand`` (pre) and ``output_contract`` (post)."""
         block, config = self._make_mhc_block(num_layers=2, mhc_recompute_layer_num=2)

--- a/tests/unit_tests/transformer/test_multi_token_prediction.py
+++ b/tests/unit_tests/transformer/test_multi_token_prediction.py
@@ -31,6 +31,7 @@ from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import checkpoint as tensor_parallel_checkpoint
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer import multi_token_prediction as mtp_module
+from megatron.core.transformer.hyper_connection import learned_output_contract
 from megatron.core.transformer.multi_token_prediction import (
     MTPLossLoggingHelper,
     MultiTokenPredictionBlock,
@@ -3078,3 +3079,52 @@ class TestMultiTokenPredictionHybrid:
                 pytest.fail(f"Attention mask validation failed for Mamba hybrid model: {e}")
             else:
                 raise
+
+
+class TestLearnedOutputContract:
+    """Tests for the learned n-stream to one-stream mHC contraction."""
+
+    def setup_method(self, method):
+        Utils.initialize_model_parallel(1, 1)
+        model_parallel_cuda_manual_seed(_SEED)
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+    def test_shape_and_dtype(self, dtype):
+        hidden_size, n_streams = 32, 4
+        hidden_states = torch.randn(8, 2, n_streams * hidden_size, device="cuda", dtype=dtype)
+        head_fn = torch.randn(n_streams, n_streams * hidden_size, device="cuda")
+        base = torch.zeros(n_streams, device="cuda")
+        scale = torch.ones(1, device="cuda")
+
+        output = learned_output_contract(hidden_states, head_fn, base, scale, n_streams, eps=1e-6)
+
+        assert output.shape == (8, 2, hidden_size)
+        assert output.dtype == dtype
+
+    def test_gradient_and_reference(self):
+        hidden_size, n_streams, eps = 8, 2, 1e-6
+        hidden_states = torch.randn(
+            2, 1, n_streams * hidden_size, device="cuda", dtype=torch.float32, requires_grad=True
+        )
+        head_fn = torch.randn(n_streams, n_streams * hidden_size, device="cuda", requires_grad=True)
+        base = torch.zeros(n_streams, device="cuda", requires_grad=True)
+        scale = torch.ones(1, device="cuda", requires_grad=True)
+
+        output = learned_output_contract(hidden_states, head_fn, base, scale, n_streams, eps)
+        rsqrt = torch.rsqrt(hidden_states.square().mean(-1, keepdim=True) + eps)
+        mixes = torch.nn.functional.linear(hidden_states, head_fn) * rsqrt
+        weights = torch.sigmoid(mixes * scale + base) + eps
+        expected = torch.sum(
+            weights.unsqueeze(-1)
+            * hidden_states.view(*hidden_states.shape[:-1], n_streams, hidden_size),
+            dim=-2,
+        )
+        torch.testing.assert_close(output, expected)
+
+        output.sum().backward()
+        for tensor in (hidden_states, head_fn, base, scale):
+            assert tensor.grad is not None
+            assert torch.count_nonzero(tensor.grad) > 0

--- a/tests/unit_tests/transformer/test_transformer_config.py
+++ b/tests/unit_tests/transformer/test_transformer_config.py
@@ -45,6 +45,44 @@ def test_batch_invariant_backend_rejects_unknown_value_at_construction():
         )
 
 
+def test_mhc_fused_backend_defaults_to_auto():
+    config = TransformerConfig(num_layers=1, hidden_size=128, num_attention_heads=4)
+
+    assert config.mhc_fused_backend == "auto"
+
+
+@pytest.mark.parametrize("backend", ["native", "triton", "cutile"])
+def test_mhc_fused_backend_accepts_explicit_policy(backend: str):
+    config = TransformerConfig(
+        num_layers=1,
+        hidden_size=128,
+        num_attention_heads=4,
+        enable_mhc_connections=True,
+        use_fused_mhc=True,
+        mhc_fused_backend=backend,
+    )
+
+    assert config.mhc_fused_backend == backend
+
+
+def test_mhc_fused_backend_rejects_unknown_value_at_construction():
+    with pytest.raises(ValueError, match="Unknown mhc_fused_backend"):
+        TransformerConfig(
+            num_layers=1, hidden_size=128, num_attention_heads=4, mhc_fused_backend="cuda"
+        )
+
+
+def test_explicit_mhc_fused_backend_requires_fused_mhc():
+    with pytest.raises(ValueError, match="requires use_fused_mhc"):
+        TransformerConfig(
+            num_layers=1,
+            hidden_size=128,
+            num_attention_heads=4,
+            enable_mhc_connections=True,
+            mhc_fused_backend="native",
+        )
+
+
 def test_gdp_num_householder_defaults_to_three():
     config = TransformerConfig(num_layers=1, hidden_size=128, num_attention_heads=4)
 

--- a/tests/unit_tests/transformer/test_transformer_layer.py
+++ b/tests/unit_tests/transformer/test_transformer_layer.py
@@ -44,9 +44,8 @@ from tests.unit_tests.test_utilities import Utils
 def _make_mhc_layer_spec(**kwargs):
     """Build a layer spec with HyperConnectionModule submodules.
 
-    The ``enable_hyper_connection`` kwarg on ``gpt_layer_specs`` is added by
-    the GPT-wiring follow-up split, so this helper patches the mHC submodules
-    directly to keep the unit tests self-contained for this split.
+    This helper patches the mHC submodules directly so these layer tests do not
+    depend on GPT-spec wiring.
     """
     from megatron.core.transformer.hyper_connection import HyperConnectionModule
 
@@ -959,14 +958,14 @@ class TestMHCWithCudaGraph:
         )
 
     def test_cuda_graph_fwd_bwd_with_hyper_connection(self):
-        """End-to-end CUDA graph capture and replay for forward+backward with mHC.
+        """End-to-end CUDA graph capture and replay for fused mHC.
 
         Captures both the forward and backward pass of HyperConnectionTransformerLayer
         into a torch.cuda.CUDAGraph and replays it with fresh input data, verifying
-        that the computation graph is fully static (capturable) and produces correct
-        output shapes and non-trivial gradients.
+        that the configuration-bound backend policy is capturable and produces
+        correct output shapes and non-trivial gradients.
         """
-        layer, config = self._create_mhc_layer()
+        layer, config = self._create_mhc_layer(use_fused_mhc=True)
         layer.train()
 
         seq_len = 8


### PR DESCRIPTION
# Add fused mHC support for HybridModel

## Summary

Add optional fused manifold hyper-connection (mHC) execution and complete HybridModel/MTP integration. This includes fused kernels with native fallback, Hybrid layer execution, selective-recompute handling, MTP multistream propagation, selective-FP32 mapping, and focused unit coverage.

Related to #5795.

## Scope

- Add optional Triton/cuTile fused mHC operations with numerical and gradient tests.
- Integrate fused mHC execution with HybridModel layers and MTP.
- Preserve mHC multistream and raw-branch behavior through MTP, Hidden State Mixing, and selective recompute.
- Keep the wrapper in `megatron/core/models/hybrid/layers/hybrid_hyper_connection.py` while preserving state-dict key paths.
- Preserve wrapped-GDN dynamic-inference state discovery and ModelOpt Hybrid mHC+MTP construction on current `main`.
- Use the final `enable_mhc_connections` / `mhc_num_residual_streams` APIs and preserve #4531 fail-fast guards.
- Preserve the selective-FP32 mapping correctness from dev #6172 (`d8b71082ea7033974703a101ded49a359b773458`).

## Non-goals

- Pipeline/virtual-pipeline mHC transport, full recompute, FP32 residual mode, or fused TP inference.
- Hash MoE routing; that remains a separate follow-up.
- GPTModel support, DSv4 attention, recipes, or unrelated CUDA-graph expansion.

## Review boundary and dependencies

#5929 and #4531 are merged in `main`. The branch is rebased onto `main@dba084bf7a7d2b43c7317cfefb4be35e1a298941` and contains four signed residual commits:

- `151248d25628b59b65f3844c0640f2c660f5121d` — fused mHC and HybridModel/MTP integration;
- `9a880f441e04c445ed6f38f110ad31292625427e` — determinism metadata;
- `80720c869911bb46bcbe3e134b8b6f4e4670949a` — Hybrid wrapper module move;
- `4f2e0e3b69f9366b7faa5b703cd5ecb58769a09b` — current-main GDN and ModelOpt adaptations.

Please review the complete PR diff: **17 files, +6,045/-250**.

## Provenance

Reconstructed from the mHC behavior tracked by #5795, the final native implementation in #4531, and the earlier focused recut #5936. Original implementation credit remains with the #2943/#3430/#4531 contributors and the #5795 DSv4 adaptation authors.

## Validation

Passed locally on the final changeset:

- clean worktree;
- valid GPG signatures and required `Signed-off-by` trailers on all four commits;
- `git diff --check`;
- Python parsing and Ruff on all 17 changed Python files;
- isort 5.13.2 on all changed Python files;
- Black 26.3.1 on all changed Python files;
- focused line-length lint.

The macOS host has no usable Torch/CUDA runtime, so no local GPU/runtime result is claimed. Full functional CI is required on exact head `4f2e0e3b69f9366b7faa5b703cd5ecb58769a09b`. No dependency or lock-file change is part of this branch.
