### PR TITLE
fix(ci): redact sensitive environment values from test output

### DIFF
--- a/tests/functional_tests/shell_test_utils/_run_training.sh
+++ b/tests/functional_tests/shell_test_utils/_run_training.sh
@@ -8,6 +8,23 @@
 
 set -euxo pipefail
 
+is_sensitive_env_name() {
+    local name="${1^^}"
+    [[ "$name" == *KEY* || "$name" == *TOKEN* || "$name" == *API* ]]
+}
+
+export_env_assignment() {
+    local key="$1"
+    local value="$2"
+
+    export "$key"="$value"
+    if is_sensitive_env_name "$key"; then
+        printf '%s=<redacted>\n' "$key"
+    else
+        printf '%s=%s\n' "$key" "$value"
+    fi
+}
+
 set +x
 for ARGUMENT in "$@"; do
     KEY=$(echo $ARGUMENT | cut -f1 -d=)
@@ -15,8 +32,7 @@ for ARGUMENT in "$@"; do
     KEY_LENGTH=${#KEY}
     VALUE="${ARGUMENT:$KEY_LENGTH+1}"
 
-    export "$KEY"="$VALUE"
-    echo "$KEY=$VALUE"
+    export_env_assignment "$KEY" "$VALUE"
 done
 set -x
 
@@ -56,6 +72,7 @@ TRAINING_PARAMS_PATH="$TRAINING_PARAMS_PATH.tmp"
 set -x
 
 # Pull env vars to export
+set +x
 ENV_VARS=$(/usr/local/bin/yq '... comments="" | .ENV_VARS | to_entries | .[] | [.key + "=" + .value] | join(" ")' "$TRAINING_PARAMS_PATH")
 while IFS= read -r ARGUMENT; do
     KEY=$(echo $ARGUMENT | cut -f1 -d=)
@@ -63,9 +80,9 @@ while IFS= read -r ARGUMENT; do
     KEY_LENGTH=${#KEY}
     VALUE="${ARGUMENT:$KEY_LENGTH+1}"
 
-    export "$KEY"="$VALUE"
-    echo "$KEY=$VALUE"
+    export_env_assignment "$KEY" "$VALUE"
 done <<<"$ENV_VARS"
+set -x
 
 # Run before script
 BEFORE_SCRIPT=$(cat "$TRAINING_PARAMS_PATH" | /usr/local/bin/yq '.BEFORE_SCRIPT')

--- a/tests/functional_tests/shell_test_utils/run_ci_test.sh
+++ b/tests/functional_tests/shell_test_utils/run_ci_test.sh
@@ -2,6 +2,11 @@
 
 set -exo pipefail
 
+is_sensitive_env_name() {
+    local name="${1^^}"
+    [[ "$name" == *KEY* || "$name" == *TOKEN* || "$name" == *API* ]]
+}
+
 # Increase soft limit for number of open files to match hard limit
 ulimit -Sn $(ulimit -Hn)
 
@@ -25,7 +30,11 @@ for ARGUMENT in "$@"; do
 
     # Properly quote the value to preserve spaces and special characters
     export "$KEY"="$(eval echo $VALUE)"
-    echo "$KEY=$VALUE"
+    if is_sensitive_env_name "$KEY"; then
+        printf '%s=<redacted>\n' "$KEY"
+    else
+        printf '%s=%s\n' "$KEY" "$VALUE"
+    fi
 done
 set -x
 

--- a/tests/test_utils/test_training_script_secret_redaction.py
+++ b/tests/test_utils/test_training_script_secret_redaction.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import os
+import subprocess
+from pathlib import Path
+
+RUN_CI_TEST = Path("tests/functional_tests/shell_test_utils/run_ci_test.sh")
+RUN_TRAINING = Path("tests/functional_tests/shell_test_utils/_run_training.sh")
+SENSITIVE_ASSIGNMENTS = {
+    "WANDB_API_KEY": "wandb-value-must-not-appear",
+    "CI_JOB_TOKEN": "token-value-must-not-appear",
+    "INTERNAL_API_URL": "api-value-must-not-appear",
+}
+
+
+def assert_sensitive_values_redacted(result):
+    for name, value in SENSITIVE_ASSIGNMENTS.items():
+        assert value not in result.stdout
+        assert value not in result.stderr
+        assert f"{name}=<redacted>" in result.stdout
+
+
+def test_training_wrappers_redact_sensitive_arguments_from_output():
+    sensitive_args = [f"{name}={value}" for name, value in SENSITIVE_ASSIGNMENTS.items()]
+
+    for script in (RUN_CI_TEST, RUN_TRAINING):
+        result = subprocess.run(
+            ["bash", str(script), *sensitive_args, "VISIBLE_ENV=visible-value"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode != 0  # Intentionally omit required training arguments.
+        assert_sensitive_values_redacted(result)
+        assert "VISIBLE_ENV=visible-value" in result.stdout
+
+
+def test_run_training_redacts_sensitive_values_from_model_config(tmp_path):
+    fake_yq = tmp_path / "yq"
+    fake_yq.write_text("""#!/bin/bash
+if [[ "$1" == *".ENV_VARS"* ]]; then
+    printf 'WANDB_API_KEY=%s\\nCI_JOB_TOKEN=%s\\nINTERNAL_API_URL=%s\\nVISIBLE_ENV=visible-value\\n' \
+        "$TEST_KEY_VALUE" "$TEST_TOKEN_VALUE" "$TEST_API_VALUE"
+elif [[ "$1" == ".BEFORE_SCRIPT" ]]; then
+    printf 'exit 0\\n'
+else
+    printf 'null\\n'
+fi
+""")
+    fake_yq.chmod(0o755)
+
+    script = tmp_path / "run_training.sh"
+    script.write_text(RUN_TRAINING.read_text().replace("/usr/local/bin/yq", str(fake_yq)))
+    config = tmp_path / "model_config.yaml"
+    config.write_text("ENV_VARS: {}\n")
+
+    required_args = {
+        "TRAINING_SCRIPT_PATH": "unused.py",
+        "TRAINING_PARAMS_PATH": str(config),
+        "OUTPUT_PATH": str(tmp_path / "output"),
+        "TENSORBOARD_PATH": str(tmp_path / "tensorboard"),
+        "CHECKPOINT_SAVE_PATH": str(tmp_path / "save"),
+        "CHECKPOINT_LOAD_PATH": str(tmp_path / "load"),
+        "DATA_PATH": str(tmp_path / "data"),
+        "RUN_NUMBER": "1",
+        "REPEAT": "1",
+    }
+    result = subprocess.run(
+        ["bash", str(script), *(f"{key}={value}" for key, value in required_args.items())],
+        check=False,
+        capture_output=True,
+        env={
+            **os.environ,
+            "TEST_KEY_VALUE": SENSITIVE_ASSIGNMENTS["WANDB_API_KEY"],
+            "TEST_TOKEN_VALUE": SENSITIVE_ASSIGNMENTS["CI_JOB_TOKEN"],
+            "TEST_API_VALUE": SENSITIVE_ASSIGNMENTS["INTERNAL_API_URL"],
+        },
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert_sensitive_values_redacted(result)
+    assert "VISIBLE_ENV=visible-value" in result.stdout


### PR DESCRIPTION
## Background

The functional-test wrappers echo imported `KEY=VALUE` assignments. Environment variables with credential-bearing names could therefore reach combined job output when supplied as wrapper arguments or through model-config `ENV_VARS`. The later `WANDB_API_KEY` export was already protected from shell xtrace, but these earlier import paths were not.

## What changed

- Redact values for environment-variable names containing `KEY`, `TOKEN`, or `API`, matched case-insensitively.
- Preserve the existing visibility of ordinary environment assignments.
- Disable shell xtrace before extracting and exporting model-config environment variables.
- Add regression coverage for wrapper arguments and model-config values, checking stdout and stderr.

## Details

Both functional-test wrappers now emit `<name>=<redacted>` for matching names instead of the value. `_run_training.sh` also performs model-config extraction with xtrace disabled, preventing the assignment itself from appearing in the trace before redaction.

The regression matrix independently covers `WANDB_API_KEY`, `CI_JOB_TOKEN`, and `INTERNAL_API_URL`, plus a non-sensitive control variable that remains visible.

## Tested

- `/home/okoenig/Documents/Repositories/github.com/NVIDIA/Megatron-LM/.venv/bin/python -m pytest -q tests/test_utils/test_training_script_secret_redaction.py`
  - Observed: `2 passed`; all `KEY`, `TOKEN`, and `API` sentinel values were absent from stdout and stderr.
- `bash -n tests/functional_tests/shell_test_utils/run_ci_test.sh tests/functional_tests/shell_test_utils/_run_training.sh`
  - Observed: exit code 0.
- `PATH="$PWD/.venv/bin:$PATH" BASE_REF=main CHECK_ONLY=true SKIP_DOCS=false bash tools/autoformat.sh`
  - Observed: Black, isort, Pylint, and Ruff passed with the locked toolchain; the wrapper tolerates unavailable mypy.
- `gitleaks dir --no-banner --redact --exit-code 1` on each changed file.
  - Observed: no leaks found.