### PR TITLE
perf(logging): gate expensive work behind log levels

### DIFF
--- a/megatron/core/_rank_utils.py
+++ b/megatron/core/_rank_utils.py
@@ -74,16 +74,28 @@ def safe_get_world_size() -> int:
     return 1
 
 
-def log_single_rank(logger: logging.Logger, *args: Any, rank: int = 0, **kwargs: Any) -> None:
+def log_single_rank(
+    logger: logging.Logger,
+    level: int,
+    msg: object,
+    *args: Any,
+    rank: int = 0,
+    **kwargs: Any,
+) -> None:
     """Log a message only on a single rank.
 
     If torch distributed is initialized, write log on only one rank.
 
     Args:
         logger: The logger to write the logs.
-        *args: All logging.Logger.log positional arguments.
+        level: Logging level for the message.
+        msg: Message format string.
+        *args: Message format arguments.
         rank: The rank to write on. Defaults to 0.
-        **kwargs: All logging.Logger.log keyword arguments.
+        **kwargs: Additional ``logging.Logger.log`` keyword arguments.
     """
+    if not logger.isEnabledFor(level):
+        return
+
     if safe_get_rank() == rank:
-        logger.log(*args, **kwargs)
+        logger.log(level, msg, *args, **kwargs)

--- a/megatron/core/datasets/blended_megatron_dataset_builder.py
+++ b/megatron/core/datasets/blended_megatron_dataset_builder.py
@@ -57,7 +57,10 @@ class BlendedMegatronDatasetBuilder(object):
         log_single_rank(
             logger,
             logging.INFO,
-            f"Building {cls.__name__} splits with sizes={self.sizes} and config={self.config}",
+            "Building %s splits with sizes=%s and config=%s",
+            cls.__name__,
+            self.sizes,
+            self.config,
         )
 
         if not self.config.mock:

--- a/megatron/core/dist_checkpointing/exchange_utils.py
+++ b/megatron/core/dist_checkpointing/exchange_utils.py
@@ -11,6 +11,8 @@ from typing import Any, Dict, List, NamedTuple, Optional, Set, Tuple, TypeVar, c
 import numpy as np
 import torch
 
+from megatron.core._rank_utils import safe_get_rank
+
 from .core import CheckpointingException
 from .dict_utils import nested_values
 from .mapping import ShardedStateDict, ShardedTensor, is_main_replica
@@ -401,8 +403,6 @@ def exchange_loaded_tensors_gather_object(
             previously loaded tensors (from `loaded_tensors` input)
 
     """
-    from ..utils import log_single_rank
-
     all_loaded_tensors_list = [None] * torch.distributed.get_world_size(group=parallelization_group)
     torch.distributed.all_gather_object(
         all_loaded_tensors_list, loaded_tensors, group=parallelization_group
@@ -413,11 +413,9 @@ def exchange_loaded_tensors_gather_object(
     # Error checks
     if len(all_loaded_tensors) != sum(map(len, all_loaded_tensors_list)):
         err_msg = "Duplicate shard ids loaded by different ranks"
-        log_single_rank(
-            logger,
-            logging.ERROR,
-            f"{err_msg}. Shards ids by rank:" f" {[lt.keys() for lt in all_loaded_tensors_list]}",
-        )
+        if logger.isEnabledFor(logging.ERROR) and safe_get_rank() == 0:
+            shard_ids_by_rank = [lt.keys() for lt in all_loaded_tensors_list]
+            logger.error("%s. Shards ids by rank: %s", err_msg, shard_ids_by_rank)
         raise CheckpointingException(err_msg)
 
     return all_loaded_tensors
@@ -436,8 +434,6 @@ def exchange_loaded_objects_gather_object(
         Dict[_ShardId, Any]: dictionary mapping shard ids to objects needed by this rank to
          load a given state dict.
     """
-    from ..utils import log_single_rank
-
     all_loaded_objects_list = [None] * torch.distributed.get_world_size()
     torch.distributed.all_gather_object(all_loaded_objects_list, loaded_objects, group=None)
     all_loaded_objects_list = cast(List[Dict[_ShardId, Any]], all_loaded_objects_list)
@@ -446,11 +442,9 @@ def exchange_loaded_objects_gather_object(
     # Error checks
     if len(all_loaded_objects) != sum(map(len, all_loaded_objects_list)):
         err_msg = "Duplicate shard ids loaded by different ranks"
-        log_single_rank(
-            logger,
-            logging.ERROR,
-            f"{err_msg}. Shards ids by rank:" f" {[lt.keys() for lt in all_loaded_objects_list]}",
-        )
+        if logger.isEnabledFor(logging.ERROR) and safe_get_rank() == 0:
+            shard_ids_by_rank = [lt.keys() for lt in all_loaded_objects_list]
+            logger.error("%s. Shards ids by rank: %s", err_msg, shard_ids_by_rank)
         raise CheckpointingException(err_msg)
 
     return all_loaded_objects

--- a/megatron/core/dist_checkpointing/mapping.py
+++ b/megatron/core/dist_checkpointing/mapping.py
@@ -535,7 +535,7 @@ def apply_factory_merges(
                 f"Cannot merge two lists with different lengths "
                 f"({len(x1)} and {len(x2)}, encountered at key {key})"
             )
-            logger.error(err_msg + f"\nx1: {x1}\nx2: {x2}")
+            logger.error("%s\nx1: %s\nx2: %s", err_msg, x1, x2)
             raise ValueError(err_msg)
         for i, v2 in enumerate(x2):
             x1[i] = apply_factory_merges(x1[i], v2, key=key + (i,))

--- a/megatron/core/dist_checkpointing/optimizer.py
+++ b/megatron/core/dist_checkpointing/optimizer.py
@@ -67,7 +67,7 @@ def get_param_id_to_sharded_param_map(
         if id(ten.data) in param_to_id_map:
             id_to_sharded_param_map[param_to_id_map[id(ten.data)]] = ten
         else:
-            logger.debug(f'{ten} is not tracked by the optimizer')
+            logger.debug('%s is not tracked by the optimizer', ten)
 
     if not id_to_sharded_param_map:
         log_single_rank(

--- a/megatron/core/distributed/param_and_grad_buffer.py
+++ b/megatron/core/distributed/param_and_grad_buffer.py
@@ -1412,28 +1412,31 @@ class _ParamAndGradBuffer:
                 _create_bucket(cur_bucket_id, bucket_params, bucket_params_with_extra_main_grads)
             )
         # Log buckets for all PP stages.
-        log_strs = []
-        log_strs.append(
-            f"Number of buckets for gradient all-reduce / reduce-scatter: {len(self.buckets)}"
-        )
-        for index, bucket in enumerate(self.buckets):
-            numel = 0
-            for param in bucket.params_list:
-                numel += param.data.nelement()
+        if (
+            logger.isEnabledFor(logging.INFO)
+            and self.tp_group.rank() == 0
+            and self.dp_cp_group.rank() == 0
+        ):
+            log_strs = []
             log_strs.append(
-                f"Params for bucket {index + 1} ({numel} elements, "
-                f"{bucket.grad_data.nelement()} padded size, "
-                f"{len(bucket.params_with_extra_main_grads)} param(s) with extra main_grads):"
+                f"Number of buckets for gradient all-reduce / reduce-scatter:"
+                f" {len(self.buckets)}"
             )
-            for param in bucket.params_list:
-                log_strs.append(f"\t{param_to_name[param]} ({param.main_grad.dtype=})")
-        log_on_each_pipeline_stage(
-            logger,
-            logging.INFO,
-            "\n".join(log_strs),
-            tp_group=self.tp_group,
-            dp_cp_group=self.dp_cp_group,
-        )
+            for index, bucket in enumerate(self.buckets):
+                numel = 0
+                for param in bucket.params_list:
+                    numel += param.data.nelement()
+                log_strs.append(
+                    f"Params for bucket {index + 1} ({numel} elements, "
+                    f"{bucket.grad_data.nelement()} padded size, "
+                    f"{len(bucket.params_with_extra_main_grads)} param(s)"
+                    f" with extra main_grads):"
+                )
+                for param in bucket.params_list:
+                    log_strs.append(
+                        f"\t{param_to_name[param]} ({param.main_grad.dtype=})"
+                    )
+            logger.info("\n".join(log_strs))
 
     def _compute_nvfp4_packed_layout(self, params_with_names):
         """Derive packed NVFP4 index map and bucket indices from the primary layout.

--- a/megatron/core/hyper_comm_grid.py
+++ b/megatron/core/hyper_comm_grid.py
@@ -261,12 +261,16 @@ class HyperCommGrid:
         if dist.is_initialized() and dist.get_rank() == 0:
             if self._is_base_pg_key(unique_group_key):
                 logging.info(
-                    f"Generated process group for {unique_group_key} with enumeration {rank_enum}"
+                    "Generated process group for %s with enumeration %s",
+                    unique_group_key,
+                    rank_enum,
                 )
             else:
                 logging.info(
-                    f"Generated process group for view {view_spec.name!r} {ordered_dims} with "
-                    f"enumeration {rank_enum}"
+                    "Generated process group for view %r %s with enumeration %s",
+                    view_spec.name,
+                    ordered_dims,
+                    rank_enum,
                 )
         self._pgs[unique_group_key] = pg
         return pg

--- a/megatron/core/pipeline_parallel/bridge_communicator.py
+++ b/megatron/core/pipeline_parallel/bridge_communicator.py
@@ -2,6 +2,8 @@
 
 import logging
 from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
 from enum import Enum
 from typing import Dict, List, Optional, Tuple
 
@@ -167,14 +169,15 @@ class BridgeCommunicator:
         bridge_ranks = sorted(set(self.src_tp_leaders) | set(self.dest_tp_leaders))
         self.bridge_pg = self._get_or_create_bridge_pg(bridge_ranks)
 
-        log_msg = (
-            f"[Rank {self.current_rank}] "
-            f"srcLeader={self.src_local_leader_rank} "
-            f"destLeader={self.dest_local_leader_rank} "
-            f"srcBroadcastGrpRanks={self.src_grid_broadcast_ranks} "
-            f"destBroadcastGrpRanks={self.dest_grid_broadcast_ranks}"
+        logger.info(
+            "[Rank %s] srcLeader=%s destLeader=%s "
+            "srcBroadcastGrpRanks=%s destBroadcastGrpRanks=%s",
+            self.current_rank,
+            self.src_local_leader_rank,
+            self.dest_local_leader_rank,
+            self.src_grid_broadcast_ranks,
+            self.dest_grid_broadcast_ranks,
         )
-        logging.info(log_msg)
 
         self.build_comm_map(self.src_tp_leaders, self.dest_tp_leaders)
         dist.barrier()
@@ -376,9 +379,10 @@ class BridgeCommunicator:
                 tensor_splits = self._split_tensor_at_batch_dim(tensor_to_send, num_sends)
                 self._communicate_shapes(tensor_to_send_next=tensor_splits)
                 for dest_rank, tensor_split in zip(rank_info.send_to_ranks, tensor_splits):
-                    logging.debug(
-                        f"[Bridge Comunicator] [send_forward] Rank {self.current_rank} "
-                        f"send to rank {dest_rank}"
+                    logger.debug(
+                        "[Bridge Comunicator] [send_forward] Rank %s send to rank %s",
+                        self.current_rank,
+                        dest_rank,
                     )
                     dist.send(tensor_split, dst=dest_rank, group=self.bridge_pg)
 
@@ -400,10 +404,13 @@ class BridgeCommunicator:
 
         rank_info = self.comm_map.get(self.current_rank)
         assert rank_info is not None, f"Rank {self.current_rank} is not in the comm map"
-        logging.debug(
-            f"[Bridge Communicator] [receive_forward] Rank {self.current_rank} "
-            f"[src - {self.src_module_name}] [dest - {self.dest_module_name}] "
-            f"rank_info: {rank_info}"
+        logger.debug(
+            "[Bridge Communicator] [receive_forward] Rank %s "
+            "[src - %s] [dest - %s] rank_info: %s",
+            self.current_rank,
+            self.src_module_name,
+            self.dest_module_name,
+            rank_info,
         )
         if rank_info.role == CommRole.RECEIVER:
             assert (
@@ -411,9 +418,12 @@ class BridgeCommunicator:
             ), f"Rank {self.current_rank} is not the leader rank"
             # p2p call to receive the tensor
             recv_forward_shapes, recv_grad_shapes = self._communicate_shapes(recv_prev=True)
-            logging.debug(
-                f"[Bridge Communicator] [receive_forward] Rank {self.current_rank} "
-                f"received forward shapes {recv_forward_shapes} and grad shapes {recv_grad_shapes}"
+            logger.debug(
+                "[Bridge Communicator] [receive_forward] Rank %s "
+                "received forward shapes %s and grad shapes %s",
+                self.current_rank,
+                recv_forward_shapes,
+                recv_grad_shapes,
             )
             received_tensors_list = []
             for src_rank, shape in zip(rank_info.recv_from_ranks, recv_forward_shapes):
@@ -424,17 +434,25 @@ class BridgeCommunicator:
                     requires_grad=True,
                 )
                 dist.recv(tensor_to_recv, src=src_rank, group=self.bridge_pg)
-                logging.debug(
-                    f"[Bridge Communicator] [receive_forward] Rank {self.current_rank} "
-                    f"received tensor from src rank {src_rank} "
-                    f"shape {tensor_to_recv.shape} sum {tensor_to_recv.sum()}"
-                )
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.debug(
+                        "[Bridge Communicator] [receive_forward] Rank %s "
+                        "received tensor from src rank %s shape %s sum %s",
+                        self.current_rank,
+                        src_rank,
+                        tensor_to_recv.shape,
+                        tensor_to_recv.sum(),
+                    )
                 received_tensors_list.append(tensor_to_recv)
             aggregated_tensor = torch.cat(received_tensors_list, dim=self._batch_dim)
-            logging.debug(
-                f"[Bridge Communicator] [receive_forward] Rank {self.current_rank} "
-                f"broadcasting tensor {aggregated_tensor.shape} sum {aggregated_tensor.sum()}"
-            )
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    "[Bridge Communicator] [receive_forward] Rank %s "
+                    "broadcasting tensor %s sum %s",
+                    self.current_rank,
+                    aggregated_tensor.shape,
+                    aggregated_tensor.sum(),
+                )
 
             # Step 1: broadcast its shape so receivers can allocate
             shape_tensor = torch.tensor(
@@ -474,9 +492,11 @@ class BridgeCommunicator:
                 received_tensor, src=self.dest_local_leader_rank, group=self.dest_grid_broadcast_pg
             )
 
-            logging.debug(
-                f"[Bridge Communicator] [receive_forward] Rank {self.current_rank} "
-                f"received tensor via broadcast, shape {received_tensor.shape}"
+            logger.debug(
+                "[Bridge Communicator] [receive_forward] Rank %s "
+                "received tensor via broadcast, shape %s",
+                self.current_rank,
+                received_tensor.shape,
             )
             return received_tensor
 
@@ -508,11 +528,15 @@ class BridgeCommunicator:
             if num_receives > 0:
                 for src_rank, tensor_split in zip(rank_info.recv_from_ranks, tensor_splits):
                     # Send the gradient split back to the source rank
-                    logging.debug(
-                        f"[Bridge Communicator] [send_backward] Rank {self.current_rank} "
-                        f"sending gradient to src rank {src_rank} "
-                        f"shape {tensor_split.shape} sum {tensor_split.sum()}"
-                    )
+                    if logger.isEnabledFor(logging.DEBUG):
+                        logger.debug(
+                            "[Bridge Communicator] [send_backward] Rank %s "
+                            "sending gradient to src rank %s shape %s sum %s",
+                            self.current_rank,
+                            src_rank,
+                            tensor_split.shape,
+                            tensor_split.sum(),
+                        )
                     dist.send(tensor_split, dst=src_rank, group=self.bridge_pg)
 
     def recv_backward(self) -> torch.Tensor:
@@ -541,9 +565,12 @@ class BridgeCommunicator:
                 self.current_rank == self.src_local_leader_rank
             ), f"Rank {self.current_rank} is not the leader rank"
             recv_forward_shapes, recv_grad_shapes = self._communicate_shapes(recv_next=True)
-            logging.debug(
-                f"[Bridge Communicator] [receive_backward] Rank {self.current_rank} "
-                f"received forward shapes {recv_forward_shapes} and grad shapes {recv_grad_shapes}"
+            logger.debug(
+                "[Bridge Communicator] [receive_backward] Rank %s "
+                "received forward shapes %s and grad shapes %s",
+                self.current_rank,
+                recv_forward_shapes,
+                recv_grad_shapes,
             )
             # Receive gradient tensors from destination ranks
             received_gradients_list = []
@@ -553,19 +580,27 @@ class BridgeCommunicator:
                     grad_shape, device=torch.cuda.current_device(), dtype=self.comm_dtype
                 )
                 dist.recv(grad_tensor, src=dest_rank, group=self.bridge_pg)
-                logging.debug(
-                    f"[Bridge Communicator] [receive_backward] Rank {self.current_rank} "
-                    f"received gradient from dest rank {dest_rank} "
-                    f"shape {grad_tensor.shape} sum {grad_tensor.sum()}"
-                )
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.debug(
+                        "[Bridge Communicator] [receive_backward] Rank %s "
+                        "received gradient from dest rank %s shape %s sum %s",
+                        self.current_rank,
+                        dest_rank,
+                        grad_tensor.shape,
+                        grad_tensor.sum(),
+                    )
                 received_gradients_list.append(grad_tensor)
 
             # Concatenate received gradients
             aggregated_gradient = torch.cat(received_gradients_list, dim=self._batch_dim)
-            logging.debug(
-                f"[Bridge Communicator] [receive_backward] Rank {self.current_rank} "
-                f"agg grad shape {aggregated_gradient.shape} sum {aggregated_gradient.sum()}"
-            )
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    "[Bridge Communicator] [receive_backward] Rank %s "
+                    "agg grad shape %s sum %s",
+                    self.current_rank,
+                    aggregated_gradient.shape,
+                    aggregated_gradient.sum(),
+                )
 
             shape_tensor = torch.tensor(
                 aggregated_gradient.shape, device=torch.cuda.current_device(), dtype=torch.int64
@@ -590,10 +625,6 @@ class BridgeCommunicator:
                 shape_tensor, src=self.src_local_leader_rank, group=self.src_grid_broadcast_pg
             )
 
-            logging.debug(
-                f"[Bridge Communicator] [receive_backward] Rank {self.current_rank} "
-                f"received shape tensor {shape_tensor}"
-            )
             received_shape = tuple(shape_tensor.tolist())
             received_gradient = torch.empty(
                 received_shape, device=torch.cuda.current_device(), dtype=self.comm_dtype
@@ -602,9 +633,16 @@ class BridgeCommunicator:
             dist.broadcast(
                 received_gradient, src=self.src_local_leader_rank, group=self.src_grid_broadcast_pg
             )
-            logging.debug(
-                f"[Bridge Communicator] [receive_backward] Rank {self.current_rank} "
-                f"received gradient from scatter operation, shape {received_gradient.shape}"
+            logger.debug(
+                "[Bridge Communicator] [receive_backward] Rank %s received shape tensor %s",
+                self.current_rank,
+                shape_tensor,
+            )
+            logger.debug(
+                "[Bridge Communicator] [receive_backward] Rank %s "
+                "received gradient from scatter operation, shape %s",
+                self.current_rank,
+                received_gradient.shape,
             )
             return received_gradient
 
@@ -628,10 +666,13 @@ class BridgeCommunicator:
 
         rank_info = self.comm_map.get(self.current_rank)
         assert rank_info is not None, f"Rank {self.current_rank} is not in the comm map"
-        logging.debug(
-            f"[Bridge Communicator] [send_forward_recv_backward] Rank {self.current_rank} "
-            f"[src - {self.src_module_name}] [dest - {self.dest_module_name}] "
-            f"rank_info: {rank_info}"
+        logger.debug(
+            "[Bridge Communicator] [send_forward_recv_backward] Rank %s "
+            "[src - %s] [dest - %s] rank_info: %s",
+            self.current_rank,
+            self.src_module_name,
+            self.dest_module_name,
+            rank_info,
         )
         if rank_info.role == CommRole.SENDER:
             assert (
@@ -644,9 +685,12 @@ class BridgeCommunicator:
             recv_forward_shapes, recv_grad_shapes = self._communicate_shapes(
                 tensor_to_send_next=activation_splits, recv_next=True
             )
-            logging.debug(
-                f"[Bridge Communicator] [send_forward_recv_backward] Rank {self.current_rank} "
-                f"received forward shapes {recv_forward_shapes} and grad shapes {recv_grad_shapes}"
+            logger.debug(
+                "[Bridge Communicator] [send_forward_recv_backward] Rank %s "
+                "received forward shapes %s and grad shapes %s",
+                self.current_rank,
+                recv_forward_shapes,
+                recv_grad_shapes,
             )
 
             # Prepare simultaneous send/receive operations
@@ -677,9 +721,11 @@ class BridgeCommunicator:
                         )
                     )
 
-                logging.debug(
-                    f"[Bridge Communicator] [send_forward_recv_backward] Rank {self.current_rank} "
-                    f"executing {len(ops)} simultaneous P2P operations"
+                logger.debug(
+                    "[Bridge Communicator] [send_forward_recv_backward] Rank %s "
+                    "executing %s simultaneous P2P operations",
+                    self.current_rank,
+                    len(ops),
                 )
                 reqs = torch.distributed.batch_isend_irecv(ops)
                 for req in reqs:
@@ -687,10 +733,14 @@ class BridgeCommunicator:
 
                 # Concatenate received gradients
                 aggregated_gradient = torch.cat(received_gradients_list, dim=self._batch_dim)
-                logging.debug(
-                    f"[Bridge Communicator] [send_forward_recv_backward] Rank {self.current_rank} "
-                    f"agg grad shape {aggregated_gradient.shape} sum {aggregated_gradient.sum()}"
-                )
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.debug(
+                        "[Bridge Communicator] [send_forward_recv_backward] Rank %s "
+                        "agg grad shape %s sum %s",
+                        self.current_rank,
+                        aggregated_gradient.shape,
+                        aggregated_gradient.sum(),
+                    )
                 # Broadcast tensor shape to all ranks in scatter_pg
                 tensor_shape_to_broadcast = aggregated_gradient.shape
                 shape_tensor = torch.tensor(
@@ -727,9 +777,11 @@ class BridgeCommunicator:
             dist.broadcast(
                 received_gradient, src=self.src_local_leader_rank, group=self.src_grid_broadcast_pg
             )
-            logging.debug(
-                f"[Bridge Communicator] [send_forward_recv_backward] Rank {self.current_rank} "
-                f"received gradient from broadcast, shape {received_gradient.shape}"
+            logger.debug(
+                "[Bridge Communicator] [send_forward_recv_backward] Rank %s "
+                "received gradient from broadcast, shape %s",
+                self.current_rank,
+                received_gradient.shape,
             )
             return received_gradient
 
@@ -765,9 +817,12 @@ class BridgeCommunicator:
             recv_forward_shapes, recv_grad_shapes = self._communicate_shapes(
                 tensor_to_send_prev=gradient_splits, recv_prev=True
             )
-            logging.debug(
-                f"[Bridge Communicator] [send_backward_recv_backward] Rank {self.current_rank} "
-                f"received forward shapes {recv_forward_shapes} and grad shapes {recv_grad_shapes}"
+            logger.debug(
+                "[Bridge Communicator] [send_backward_recv_backward] Rank %s "
+                "received forward shapes %s and grad shapes %s",
+                self.current_rank,
+                recv_forward_shapes,
+                recv_grad_shapes,
             )
 
             # Prepare simultaneous send/receive operations
@@ -803,9 +858,11 @@ class BridgeCommunicator:
                     )
 
                 # Execute all operations simultaneously
-                logging.debug(
-                    f"[Bridge Communicator] [send_backward_recv_backward] Rank {self.current_rank} "
-                    f"executing {len(ops)} simultaneous P2P operations"
+                logger.debug(
+                    "[Bridge Communicator] [send_backward_recv_backward] Rank %s "
+                    "executing %s simultaneous P2P operations",
+                    self.current_rank,
+                    len(ops),
                 )
                 reqs = torch.distributed.batch_isend_irecv(ops)
                 for req in reqs:
@@ -813,10 +870,14 @@ class BridgeCommunicator:
 
                 # Concatenate received activations
                 aggregated_activation = torch.cat(received_activations_list, dim=self._batch_dim)
-                logging.debug(
-                    f"[Bridge Communicator] [send_backward_recv_forward] Rank {self.current_rank} "
-                    f"agg act shape {aggregated_activation.shape} sum {aggregated_activation.sum()}"
-                )
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.debug(
+                        "[Bridge Communicator] [send_backward_recv_forward] Rank %s "
+                        "agg act shape %s sum %s",
+                        self.current_rank,
+                        aggregated_activation.shape,
+                        aggregated_activation.sum(),
+                    )
 
                 # Broadcast tensor shape to all ranks in scatter_pg
                 tensor_shape_to_scatter = aggregated_activation.shape
@@ -857,9 +918,11 @@ class BridgeCommunicator:
                 src=self.dest_local_leader_rank,
                 group=self.dest_grid_broadcast_pg,
             )
-            logging.debug(
-                f"[Bridge Communicator] [send_backward_recv_backward] Rank {self.current_rank}  "
-                f"received activation from scatter operation, shape {received_activation.shape}"
+            logger.debug(
+                "[Bridge Communicator] [send_backward_recv_backward] Rank %s  "
+                "received activation from scatter operation, shape %s",
+                self.current_rank,
+                received_activation.shape,
             )
             return received_activation
 
@@ -894,9 +957,11 @@ class BridgeCommunicator:
 
         recv_forward_shapes = []
         recv_grad_shapes = []
-        logging.debug(
-            f"[Bridge Communicator] [communicate_shapes] Rank {self.current_rank} "
-            f"is a {rank_info.role} and is running the shape communication"
+        logger.debug(
+            "[Bridge Communicator] [communicate_shapes] Rank %s "
+            "is a %s and is running the shape communication",
+            self.current_rank,
+            rank_info.role,
         )
         # Collect all P2P operations for batch execution
         ops = []

--- a/megatron/core/transformer/pipeline_parallel_layer_layout.py
+++ b/megatron/core/transformer/pipeline_parallel_layer_layout.py
@@ -7,6 +7,7 @@ from functools import lru_cache
 from typing import Optional
 
 from megatron.core import parallel_state
+from megatron.core._rank_utils import safe_get_rank
 from megatron.core.transformer.enums import LayerType
 
 logger = logging.getLogger(__name__)
@@ -264,13 +265,12 @@ class PipelineParallelLayerLayout:
         """Parse the pipeline model parallel layout from a string."""
         parsed_layout = PipelineParallelLayerLayout(layout, pipeline_model_parallel_size)
         # Pretty print the layout distribution.
-        from megatron.core.utils import log_single_rank
-
-        log_single_rank(
-            logger,
-            logging.INFO,
-            f"Parse pipeline model parallel layout {layout} to:\n" + parsed_layout.pretty_repr(),
-        )
+        if logger.isEnabledFor(logging.INFO) and safe_get_rank() == 0:
+            logger.info(
+                "Parse pipeline model parallel layout %s to:\n%s",
+                layout,
+                parsed_layout.pretty_repr(),
+            )
         return parsed_layout
 
     @staticmethod

--- a/megatron/core/utils.py
+++ b/megatron/core/utils.py
@@ -859,6 +859,8 @@ def mup_scaled_init_method_normal(sigma, num_layers, width_mult, multiplier=2.0)
 
 def log_on_each_pipeline_stage(
     logger: logging.Logger,
+    level: int,
+    msg: object,
     *args: Any,
     tp_group: Optional[torch.distributed.ProcessGroup] = None,
     dp_cp_group: Optional[torch.distributed.ProcessGroup] = None,
@@ -869,23 +871,34 @@ def log_on_each_pipeline_stage(
     Args:
         logger (logging.Logger): The logger to write the logs
 
-        args (Tuple[Any]): All logging.Logger.log positional arguments
+        level (int): Logging level for the message.
+
+        msg (object): Message format string.
+
+        args (Tuple[Any]): Message format arguments.
 
         kwargs (Dict[str, Any]): All logging.Logger.log keyword arguments
     """
     assert torch.distributed.is_initialized()
 
+    if (tp_group is None) != (dp_cp_group is None):
+        raise ValueError(
+            "tp_group and dp_cp_group must be provided or not provided together"
+        )
+
+    if not logger.isEnabledFor(level):
+        return
+
     if tp_group is None and dp_cp_group is None:
         tp_rank = parallel_state.get_tensor_model_parallel_rank()
         dp_cp_rank = parallel_state.get_data_parallel_rank(with_context_parallel=True)
-    elif tp_group is not None and dp_cp_group is not None:
+    else:
+        assert tp_group is not None and dp_cp_group is not None
         tp_rank = tp_group.rank()
         dp_cp_rank = dp_cp_group.rank()
-    else:
-        raise ValueError("tp_group and dp_cp_group must be provided or not provided together")
 
     if tp_rank == 0 and dp_cp_rank == 0:
-        logger.log(*args, **kwargs)
+        logger.log(level, msg, *args, **kwargs)
 
 
 def check_param_hashes_across_dp_replicas(

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -15,7 +15,7 @@ import types
 from argparse import Namespace
 from datetime import datetime
 from enum import Enum, auto
-from logging import getLogger
+from logging import DEBUG, getLogger
 from pathlib import Path
 from time import time
 from typing import Any, Dict, List, Optional, Union
@@ -103,9 +103,13 @@ def finalize_deletion_processes(blocking=False):
     finished = []
     for proc in _deletion_processes:
         if not proc.is_alive() or blocking:
-            logger.debug(
-                f'Joining deletion process {proc.pid} (blocking={blocking}, is_alive={proc.is_alive()})'
-            )
+            if logger.isEnabledFor(DEBUG):
+                logger.debug(
+                    "Joining deletion process %s (blocking=%s, is_alive=%s)",
+                    proc.pid,
+                    blocking,
+                    proc.is_alive(),
+                )
             proc.join()
             finished.append(proc)
     for proc in finished:

--- a/tests/unit_tests/test_rank_utils.py
+++ b/tests/unit_tests/test_rank_utils.py
@@ -1,0 +1,149 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import logging
+from unittest.mock import Mock, patch
+
+import pytest
+
+from megatron.core._rank_utils import log_single_rank
+from megatron.core.utils import log_on_each_pipeline_stage
+
+
+def test_log_single_rank_skips_rank_query_when_level_is_disabled():
+    logger = Mock(spec=logging.Logger)
+    logger.isEnabledFor.return_value = False
+
+    with patch("megatron.core._rank_utils.safe_get_rank") as safe_get_rank:
+        log_single_rank(logger, logging.DEBUG, "message")
+
+    logger.isEnabledFor.assert_called_once_with(logging.DEBUG)
+    safe_get_rank.assert_not_called()
+    logger.log.assert_not_called()
+
+
+def test_log_single_rank_preserves_keyword_call():
+    logger = Mock(spec=logging.Logger)
+    logger.isEnabledFor.return_value = True
+
+    with patch("megatron.core._rank_utils.safe_get_rank", return_value=3):
+        log_single_rank(
+            logger=logger,
+            level=logging.INFO,
+            msg="message",
+            rank=3,
+            extra={"key": "value"},
+        )
+
+    logger.isEnabledFor.assert_called_once_with(logging.INFO)
+    logger.log.assert_called_once_with(logging.INFO, "message", extra={"key": "value"})
+
+
+def test_log_single_rank_suppresses_log_when_rank_does_not_match():
+    logger = Mock(spec=logging.Logger)
+    logger.isEnabledFor.return_value = True
+
+    with patch("megatron.core._rank_utils.safe_get_rank", return_value=2):
+        log_single_rank(logger, logging.INFO, "message", rank=3)
+
+    logger.isEnabledFor.assert_called_once_with(logging.INFO)
+    logger.log.assert_not_called()
+
+
+def test_log_single_rank_forwards_format_args():
+    logger = Mock(spec=logging.Logger)
+    logger.isEnabledFor.return_value = True
+
+    with patch("megatron.core._rank_utils.safe_get_rank", return_value=0):
+        log_single_rank(logger, logging.INFO, "value=%s", 42)
+
+    logger.log.assert_called_once_with(logging.INFO, "value=%s", 42)
+
+
+def test_log_on_each_pipeline_stage_skips_group_queries_when_level_is_disabled():
+    logger = Mock(spec=logging.Logger)
+    logger.isEnabledFor.return_value = False
+    tp_group = Mock()
+    dp_cp_group = Mock()
+
+    with patch("megatron.core.utils.torch.distributed.is_initialized", return_value=True):
+        log_on_each_pipeline_stage(
+            logger,
+            logging.DEBUG,
+            "message",
+            tp_group=tp_group,
+            dp_cp_group=dp_cp_group,
+        )
+
+    logger.isEnabledFor.assert_called_once_with(logging.DEBUG)
+    tp_group.rank.assert_not_called()
+    dp_cp_group.rank.assert_not_called()
+    logger.log.assert_not_called()
+
+
+def test_log_on_each_pipeline_stage_validates_group_pair():
+    logger = Mock(spec=logging.Logger)
+    logger.isEnabledFor.return_value = False
+
+    with patch("megatron.core.utils.torch.distributed.is_initialized", return_value=True):
+        with pytest.raises(
+            ValueError,
+            match="tp_group and dp_cp_group must be provided or not provided together",
+        ):
+            log_on_each_pipeline_stage(logger, logging.DEBUG, "message", tp_group=Mock())
+
+    logger.log.assert_not_called()
+
+
+def test_log_on_each_pipeline_stage_requires_distributed():
+    logger = Mock(spec=logging.Logger)
+
+    with patch("megatron.core.utils.torch.distributed.is_initialized", return_value=False):
+        with pytest.raises(AssertionError):
+            log_on_each_pipeline_stage(logger, logging.DEBUG, "message")
+
+    logger.log.assert_not_called()
+
+
+def test_log_on_each_pipeline_stage_logs_and_forwards_arguments_on_emitter():
+    logger = Mock(spec=logging.Logger)
+    logger.isEnabledFor.return_value = True
+    tp_group = Mock()
+    tp_group.rank.return_value = 0
+    dp_cp_group = Mock()
+    dp_cp_group.rank.return_value = 0
+
+    with patch("megatron.core.utils.torch.distributed.is_initialized", return_value=True):
+        log_on_each_pipeline_stage(
+            logger,
+            logging.INFO,
+            "value=%s",
+            42,
+            tp_group=tp_group,
+            dp_cp_group=dp_cp_group,
+            extra={"key": "value"},
+        )
+
+    logger.log.assert_called_once_with(
+        logging.INFO, "value=%s", 42, extra={"key": "value"}
+    )
+
+
+@pytest.mark.parametrize("tp_rank,dp_cp_rank", [(1, 0), (0, 1), (1, 1)])
+def test_log_on_each_pipeline_stage_suppresses_log_on_non_emitter(tp_rank, dp_cp_rank):
+    logger = Mock(spec=logging.Logger)
+    logger.isEnabledFor.return_value = True
+    tp_group = Mock()
+    tp_group.rank.return_value = tp_rank
+    dp_cp_group = Mock()
+    dp_cp_group.rank.return_value = dp_cp_rank
+
+    with patch("megatron.core.utils.torch.distributed.is_initialized", return_value=True):
+        log_on_each_pipeline_stage(
+            logger,
+            logging.INFO,
+            "message",
+            tp_group=tp_group,
+            dp_cp_group=dp_cp_group,
+        )
+
+    logger.log.assert_not_called()


### PR DESCRIPTION
- [ ] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
<!-- Add a one line overview of what this PR aims to accomplish. -->

Make log_single_rank() and log_on_each_pipeline_stage() level-aware: both now accept explicit level and msg positional args and return early via isEnabledFor() before querying ranks or process group ranks.

Gate the DDP bucket summary loop in param_and_grad_buffer.py behind isEnabledFor(INFO) and rank checks so per-parameter element counts are not computed when INFO logging is off.

Wrap all tensor.sum() calls in bridge_communicator.py behind isEnabledFor(DEBUG) to avoid CUDA synchronizations on the hot path when debug logging is disabled.

Convert f-string log arguments to lazy %s format strings throughout the affected files so string allocation is deferred until the message is actually emitted.

:warning: For major changes (either in lines of code or in its impact), please make sure to first share a design doc with the team. If you're unsure what's the best way to do so, contact @NVIDIA/mcore-oncall.

## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [ ] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [ ] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
