### PR TITLE
Add hybrid layer config definitions

### DIFF
--- a/megatron/core/ssm/gdn_layer_config.py
+++ b/megatron/core/ssm/gdn_layer_config.py
@@ -1,0 +1,10 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+from megatron.core.transformer.transformer_config import TransformerConfig
+
+
+class GDNLayerConfig(TransformerConfig):
+    """Configuration for a Gated DeltaNet layer in a hybrid stack.
+
+    Due to backwards-compatibility, this config's arguments are defined in TransformerConfig.
+    """

--- a/megatron/core/ssm/mamba_layer_config.py
+++ b/megatron/core/ssm/mamba_layer_config.py
@@ -1,0 +1,10 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+from megatron.core.transformer.transformer_config import TransformerConfig
+
+
+class MambaLayerConfig(TransformerConfig):
+    """Configuration for a Mamba layer in a hybrid stack.
+
+    Due to backwards-compatibility, this config's arguments are defined in TransformerConfig.
+    """

--- a/megatron/core/ssm/mlp_layer_config.py
+++ b/megatron/core/ssm/mlp_layer_config.py
@@ -1,0 +1,10 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+from megatron.core.transformer.transformer_config import TransformerConfig
+
+
+class MLPLayerConfig(TransformerConfig):
+    """Configuration for a dense MLP layer in a hybrid stack.
+
+    Due to backwards-compatibility, this config's arguments are defined in TransformerConfig.
+    """

--- a/megatron/core/transformer/attention_layer_config.py
+++ b/megatron/core/transformer/attention_layer_config.py
@@ -1,0 +1,10 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+from megatron.core.transformer.transformer_config import TransformerConfig
+
+
+class AttentionLayerConfig(TransformerConfig):
+    """Configuration for an attention layer in a hybrid stack.
+
+    Due to backwards-compatibility, this config's arguments are defined in TransformerConfig.
+    """

--- a/megatron/core/transformer/experimental_attention_variant/dsa_layer_config.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa_layer_config.py
@@ -1,0 +1,10 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+from megatron.core.transformer.transformer_config import MLATransformerConfig
+
+
+class DSALayerConfig(MLATransformerConfig):
+    """Configuration for a DeepSeek Sparse Attention layer in a hybrid stack.
+
+    Due to backwards-compatibility, this config's arguments are defined in MLATransformerConfig.
+    """

--- a/megatron/core/transformer/mla_layer_config.py
+++ b/megatron/core/transformer/mla_layer_config.py
@@ -1,0 +1,10 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+from megatron.core.transformer.transformer_config import MLATransformerConfig
+
+
+class MLALayerConfig(MLATransformerConfig):
+    """Configuration for a Multi-Latent Attention layer in a hybrid stack.
+
+    Due to backwards-compatibility, this config's arguments are defined in MLATransformerConfig.
+    """

--- a/megatron/core/transformer/moe/moe_layer_config.py
+++ b/megatron/core/transformer/moe/moe_layer_config.py
@@ -1,0 +1,10 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+from megatron.core.transformer.transformer_config import TransformerConfig
+
+
+class MoELayerConfig(TransformerConfig):
+    """Configuration for a Mixture-of-Experts layer in a hybrid stack.
+
+    Due to backwards-compatibility, this config's arguments are defined in TransformerConfig.
+    """


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

[Design doc](https://docs.google.com/document/d/1Qmr2K6_JzZQbakhYqOwvAcsByAyBGmzRelTXzkkrRHw/edit?usp=sharing) (internal-only).

Adds standalone configuration classes for each layer type supported by hybrid models:

- `MambaLayerConfig`
- `GDNLayerConfig`
- `MLPLayerConfig`
- `AttentionLayerConfig`
- `DSALayerConfig`
- `MLALayerConfig`
- `MoELayerConfig`

This PR only defines the new config classes. No existing code imports or uses them, so it does not change model construction or runtime behavior.

This is a merge-first prerequisite for #6313, which will adopt these definitions in a follow-up change.