### PR TITLE
Fix EP ZMQ init ordering before CUDA graph capture

### DIFF
--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -411,6 +411,42 @@ class DynamicInferenceEngine(AbstractEngine):
             raise ValueError(f"Cannot wait for transient state {state}")
         await event.wait()
 
+    def _init_expert_parallel_zmq_communicator(self, hostname: str | None = None) -> None:
+        """Wire EP ZMQ before CUDA graph capture when expert parallelism is enabled.
+
+        ``DynamicInferenceEngine.__init__`` calls ``create_cuda_graphs()`` before
+        ``start_listening_to_data_parallel_coordinator()`` would otherwise create
+        the EP communicator. During graph capture, ``match_graph_config()`` needs
+        the ZMQ MAX-reduction path; without it EP batch-dimension sync falls back
+        to NCCL AllReduce on the compute stream, which can desync across multinode
+        EP groups during warmup.
+        """
+        ep_size = get_pg_size(self.pg_collection.ep)
+        if ep_size <= 1:
+            return
+
+        if getattr(self, "expert_parallel_zmq_communicator", None) is not None:
+            if hasattr(self.context, "set_ep_zmq_communicator"):
+                self.context.set_ep_zmq_communicator(self.expert_parallel_zmq_communicator)
+            return
+
+        assert HAVE_ZMQ, (
+            "please install the pyzmq library for expert-parallel inference with CUDA graphs\n"
+            "pip install pyzmq"
+        )
+
+        if not getattr(self, "zmq_context", None):
+            self.zmq_context = zmq.Context.instance()
+
+        local_hostname = hostname or socket.gethostname()
+        self.ep_rank = get_pg_rank(self.pg_collection.ep)
+        self.ep_world_size = ep_size
+        self.expert_parallel_zmq_communicator = AsyncZMQCommunicator(
+            self.zmq_context, process_group=self.pg_collection.ep, hostname=local_hostname
+        )
+        if hasattr(self.context, "set_ep_zmq_communicator"):
+            self.context.set_ep_zmq_communicator(self.expert_parallel_zmq_communicator)
+
     def create_cuda_graphs(self, reset_context: bool = True):
         """Create cuda graphs.
 
@@ -426,6 +462,8 @@ class DynamicInferenceEngine(AbstractEngine):
 
         if self.cuda_graph_impl != "local":
             return
+
+        self._init_expert_parallel_zmq_communicator()
 
         context = self.context
         controller = self.controller
@@ -746,19 +784,13 @@ class DynamicInferenceEngine(AbstractEngine):
 
         torch.distributed.barrier(mp_group)
 
-        # initialize zmq-based EP communicator
+        # initialize zmq-based EP communicator (may already exist from create_cuda_graphs)
         self.ep_rank = get_pg_rank(self.pg_collection.ep)
         self.ep_world_size = get_pg_size(self.pg_collection.ep)
-        self._ep_consensus_loop_counter = 0
-        self._last_ep_consensus: tuple[int, bool] = (0, False)
-        if self.ep_world_size > 1:
-            self.expert_parallel_zmq_communicator = AsyncZMQCommunicator(
-                self.zmq_context, process_group=self.pg_collection.ep, hostname=hostname
-            )
-            # Give the context a CPU-side MAX-reduction primitive so
-            # match_graph_config() can avoid a per-step NCCL AllReduce kernel.
-            if hasattr(self.context, "set_ep_zmq_communicator"):
-                self.context.set_ep_zmq_communicator(self.expert_parallel_zmq_communicator)
+        if not hasattr(self, "_ep_consensus_loop_counter"):
+            self._ep_consensus_loop_counter = 0
+            self._last_ep_consensus: tuple[int, bool] = (0, False)
+        self._init_expert_parallel_zmq_communicator(hostname=local_ip)
 
         # initialize zmq-based world communicator for consensus barriers
         total_world_size = torch.distributed.get_world_size()

--- a/tests/unit_tests/inference/engines/test_dynamic_engine.py
+++ b/tests/unit_tests/inference/engines/test_dynamic_engine.py
@@ -940,6 +940,26 @@ class TestDynamicInferenceEngine(DynamicInferenceEngineTestBase):
     @pytest.mark.skipif(
         not is_fa_min_version("2.7.3"), reason="need latest flash attn for dynamic batching"
     )
+    def test_create_cuda_graphs_skips_ep_zmq_when_ep_is_one(self) -> None:
+        """EP ZMQ setup is only required when expert parallelism is enabled."""
+        with mock.patch(
+            "megatron.core.inference.engines.dynamic_engine.AsyncZMQCommunicator"
+        ) as mock_ep_zmq:
+            self._build_test_env(
+                DynamicEngineTestConfig(
+                    model_provider="gpt",
+                    expert_model_parallel_size=1,
+                    num_cuda_graphs=1,
+                    force_build_cuda_graphs=True,
+                    context_max_requests=128,
+                )
+            )
+        mock_ep_zmq.assert_not_called()
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(
+        not is_fa_min_version("2.7.3"), reason="need latest flash attn for dynamic batching"
+    )
     def test_deprecated_full_iteration_inference_scope_matches_new_flag_runtime_behavior(
         self,
     ) -> None:
@@ -5652,6 +5672,29 @@ class TestDynamicInferenceEngineParallel(DynamicInferenceEngineTestBase):
             expert_tensor_parallel_size=1,
         )
         return super()._build_test_env(test_config)
+
+    @pytest.mark.internal
+    @pytest.mark.skipif(
+        not is_fa_min_version("2.7.3"), reason="need latest flash attn for dynamic batching"
+    )
+    def test_create_cuda_graphs_initializes_ep_zmq_before_capture(self) -> None:
+        """EP ZMQ must be wired before CUDA graph capture when EP > 1."""
+        if int(os.environ.get("WORLD_SIZE", "1")) < 2:
+            pytest.skip("Test requires at least 2 GPUs for EP=2")
+        with mock.patch(
+            "megatron.core.inference.engines.dynamic_engine.AsyncZMQCommunicator"
+        ) as mock_ep_zmq:
+            env = self._build_test_env(
+                DynamicEngineTestConfig(
+                    model_provider="gpt",
+                    expert_model_parallel_size=2,
+                    num_cuda_graphs=1,
+                    force_build_cuda_graphs=True,
+                    context_max_requests=128,
+                )
+            )
+        assert mock_ep_zmq.called
+        assert hasattr(env.engine, "expert_parallel_zmq_communicator")
 
     @pytest.mark.internal
     @pytest.mark.skipif(


### PR DESCRIPTION
# Fix EP ZMQ init ordering before CUDA graph capture
- [x] I, the PR author, have personally reviewed every line of this PR.
# What does this PR do?
Fixes a multinode MoE inference hang during CUDA graph warmup by initializing the expert-parallel ZMQ communicator **before** graph capture, instead of only in `start_listening_to_data_parallel_coordinator()`.
## When does this bug trigger?
**Required:**
- MoE inference with **EP > 1** (expert parallelism enabled)
- **CUDA graph capture** enabled (`cuda_graph_impl=local`, inference CUDA graph scope ≠ none)
**Typically observed when:**
- **Multiple nodes / multiple DP replicas** run graph warmup concurrently (e.g. 8×8 lockstep gen: one EP=8 engine per node, ranks 56–63 on the last replica)
**Often NOT observed when:**
- **Single node, single DP replica** (e.g. 1×8 with EP=8): all EP ranks are NVLink-colocated on one node and stay synchronized during the synchronous capture loop, so the NCCL fallback path may complete even though EP ZMQ was not initialized yet.
> **EP > 1 enables the broken code path; multinode parallel warmup exposes it. Single-node EP=8 can pass by timing, not because init order is correct.**
## Root cause
`DynamicInferenceEngine.__init__` calls `create_cuda_graphs()` before `start_listening_to_data_parallel_coordinator()` wires the EP ZMQ communicator.
During MoE graph warmup with **EP > 1**, `match_graph_config()` needs EP batch-dimension sync. Without EP ZMQ, that sync falls back to **NCCL AllReduce on the compute stream**. On multinode runs with several DP replicas warming graphs in parallel, EP ranks within a replica can enter that collective out of lockstep and **hang during capture** (observed on the last DP replica during large batch-dimension buckets).
Note: In common 8×8 layouts (EP=8 per node), EP traffic stays **intra-node**; the failure mode is **cross-replica warmup timing** on multinode jobs, not EP all-to-all across the cluster.
## What this PR changes
1. Adds `_init_expert_parallel_zmq_communicator()` and calls it at the start of `create_cuda_graphs()` when EP > 1.
2. Reuses that communicator in `start_listening_to_data_parallel_coordinator()` (idempotent; avoids creating a second EP ZMQ stack).
3. Adds unit tests for EP=1 (no init) and EP=2 (init during capture).
EP=1 behavior is unchanged (early return). No API or config changes.
## Issue tracking
Linked issue: <!-- TODO: Fixes #XXXX — open a bug report with multinode EP>1 + CUDA graphs repro -->
## Contribution process
### Pre-checks
- [x] I have added relevant unit tests
- [x] I have added relevant functional tests *(manual multinode validation below)*
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [x] I have added relevant documentation *(docstring on `_init_expert_parallel_zmq_communicator`)*
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR
### Test plan
**Unit tests:**
```bash
# EP=1: no EP ZMQ init during graph capture (1 GPU)
pytest tests/unit_tests/inference/engines/test_dynamic_engine.py::TestDynamicInferenceEngine::test_create_cuda_graphs_skips_ep_zmq_when_ep_is_one
# EP=2: EP ZMQ init during graph capture (requires >= 2 GPUs)
pytest tests/unit_tests/inference/engines/test_dynamic_engine.py::TestDynamicInferenceEngineParallel::test_create_cuda_graphs_initializes_ep_zmq_before_capture
```
**Manual validation (recommended):**
- Multinode MoE m-inf with **EP > 1** and **CUDA graphs enabled**
- All DP replicas complete `prepare_for_generation` / graph warmup without hanging on the last node
- Regression: single-node **1×8 EP=8** still completes warmup


### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
