### PR TITLE
Support Nemotron 6 multimodal SFT masking

### DIFF
--- a/megatron/core/tokenizers/utils/build_tokenizer.py
+++ b/megatron/core/tokenizers/utils/build_tokenizer.py
@@ -89,6 +89,7 @@ def build_tokenizer(args, **kwargs):
         )
         kwargs['image_tag_type'] = args.image_tag_type
         kwargs['force_system_message'] = args.force_system_message
+        kwargs['keep_history_thinking'] = getattr(args, 'tokenizer_keep_history_thinking', False)
     elif args.tokenizer_type == 'SFTTokenizer':
         tokenizer_library = 'sft'
         tokenizer_path = args.tokenizer_model

--- a/megatron/core/tokenizers/vision/libraries/multimodal_tokenizer.py
+++ b/megatron/core/tokenizers/vision/libraries/multimodal_tokenizer.py
@@ -21,6 +21,42 @@ IMAGE_TAGS = {
     "": None,  # Image tag not used.
 }
 
+_NEMOTRON6_MOE_MESSAGE_START_TOKEN_ID = 10
+_NEMOTRON6_MOE_MESSAGE_END_TOKEN_ID = 11
+_NEMOTRON6_MOE_LINE_BREAK_TOKEN_ID = 1010
+_NEMOTRON6_MOE_ASSISTANT_ROLE_TOKEN_IDS = (1503, 19464)
+
+
+def _build_nemotron6_moe_target(tokens: np.ndarray) -> np.ndarray:
+    """Mask all tokens except Nemotron 6 MoE assistant responses."""
+    target = np.full_like(tokens, IGNORE_INDEX)
+    assistant_starts = np.where(
+        (tokens[:-2] == _NEMOTRON6_MOE_MESSAGE_START_TOKEN_ID)
+        & (tokens[1:-1] == _NEMOTRON6_MOE_ASSISTANT_ROLE_TOKEN_IDS[0])
+        & (tokens[2:] == _NEMOTRON6_MOE_ASSISTANT_ROLE_TOKEN_IDS[1])
+    )[0]
+    message_ends = np.where(tokens == _NEMOTRON6_MOE_MESSAGE_END_TOKEN_ID)[0]
+
+    for message_start in assistant_starts:
+        assistant_role_start = message_start + 1
+        content_start = assistant_role_start + 3
+        if tokens[content_start - 1] != _NEMOTRON6_MOE_LINE_BREAK_TOKEN_ID:
+            raise ValueError("expected a line break after the Nemotron 6 MoE assistant role")
+
+        following_ends = message_ends[message_ends > assistant_role_start]
+        if len(following_ends) == 0:
+            raise ValueError("Nemotron 6 MoE assistant message is missing its end token")
+        message_end = following_ends[0]
+        if (
+            message_end + 1 >= len(tokens)
+            or tokens[message_end + 1] != _NEMOTRON6_MOE_LINE_BREAK_TOKEN_ID
+        ):
+            raise ValueError("expected a line break after the Nemotron 6 MoE message end")
+
+        target[content_start : message_end + 1] = tokens[content_start : message_end + 1]
+
+    return target
+
 
 # The default mistral template raises exceptions so we use a custom one.
 mistral_custom_template = """
@@ -62,6 +98,7 @@ class MegatronMultimodalTokenizer:
         special_tokens: List[str],
         image_tag_type: str,
         force_system_message: bool = False,
+        keep_history_thinking: bool = False,
         **kwargs,
     ):
         """Tokenizer with a support for non-text inputs.
@@ -73,6 +110,7 @@ class MegatronMultimodalTokenizer:
             prompt_format (str): Prompt format for the tokenizer.
             special_tokens (List[str]): Non-text tokens.
             image_tag_type (str): Image tag to apply, if any. For example <img><image></img>.
+            keep_history_thinking (bool): Keep thinking traces from earlier assistant turns.
         """
         if not HAVE_TRANSFORMERS:
             raise ImportError(
@@ -198,6 +236,7 @@ class MegatronMultimodalTokenizer:
 
         self._prompt_format = prompt_format
         self._image_tag = IMAGE_TAGS[image_tag_type]
+        self._keep_history_thinking = keep_history_thinking
 
     def _apply_image_tag(self, text: Union[str, List[Dict]]):
         """Surround <image> with image tags such as <img> and </img>."""
@@ -263,6 +302,10 @@ class MegatronMultimodalTokenizer:
         # Apply possible image tag.
         conversation = self._apply_image_tag(conversation)
 
+        chat_template_kwargs = {}
+        if self._keep_history_thinking:
+            chat_template_kwargs["truncate_history_thinking"] = False
+
         tokens = self.tokenizer.apply_chat_template(
             conversation,
             tokenize=True,
@@ -271,12 +314,16 @@ class MegatronMultimodalTokenizer:
             return_tensors="np",
             return_dict=False,
             chat_template=self._prompt_config.custom_chat_template,
+            **chat_template_kwargs,
         )[0]
 
         if not return_target:
             return tokens
 
         target = tokens.copy()
+
+        if self._prompt_format == "nemotron6-moe":
+            return tokens, _build_nemotron6_moe_target(tokens)
 
         # Mask system and user tokens in the target.
         idx = 0

--- a/tests/unit_tests/tokenizers/test_multimodal_tokenizer.py
+++ b/tests/unit_tests/tokenizers/test_multimodal_tokenizer.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import numpy as np
+
+from megatron.core.models.multimodal.llava_model import IGNORE_INDEX
+from megatron.core.tokenizers.text.libraries.sft_tokenizer import PromptConfig
+from megatron.core.tokenizers.vision.libraries.multimodal_tokenizer import (
+    MegatronMultimodalTokenizer,
+)
+
+
+class _FakeNemotron6Tokenizer:
+    """Return a fixed Nemotron 6 MoE conversation and record template options."""
+
+    tokens = np.asarray(
+        (10, 3263, 1010, 42, 11, 1010)
+        + (10, 1503, 19464, 1010, 98, 11, 1010)
+        + (10, 3263, 1010, 43, 11, 1010)
+        + (10, 1503, 19464, 1010, 99, 100, 11, 1010),
+        dtype=np.int64,
+    )
+
+    def apply_chat_template(self, *_args, **kwargs):
+        """Return one tokenized conversation."""
+        self.template_kwargs = kwargs
+        return self.tokens[np.newaxis, :]
+
+
+def test_nemotron6_moe_masks_non_assistant_tokens_and_keeps_history_thinking():
+    """Only assistant content should contribute to loss and history thinking should be retained."""
+    tokenizer = object.__new__(MegatronMultimodalTokenizer)
+    tokenizer.tokenizer = _FakeNemotron6Tokenizer()
+    tokenizer._prompt_config = PromptConfig(
+        assistant_prefix_len=None,
+        pad_token_id=0,
+        custom_chat_template=None,
+        has_bos=False,
+        has_system_role=True,
+    )
+    tokenizer._prompt_format = "nemotron6-moe"
+    tokenizer._image_tag = None
+    tokenizer._keep_history_thinking = True
+
+    tokens, target = tokenizer.tokenize_conversation(
+        [
+            {"role": "user", "content": "question"},
+            {"role": "assistant", "content": "<think>first</think>answer"},
+            {"role": "user", "content": "follow-up"},
+            {"role": "assistant", "content": "<think>second</think>answer"},
+        ],
+        return_target=True,
+        add_generation_prompt=False,
+    )
+
+    expected_target = np.full_like(tokens, IGNORE_INDEX)
+    expected_target[10:12] = tokens[10:12]
+    expected_target[23:26] = tokens[23:26]
+    np.testing.assert_array_equal(target, expected_target)
+    assert tokenizer.tokenizer.template_kwargs["truncate_history_thinking"] is False


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Adds the training-specific multimodal tokenizer behavior needed for the existing `nemotron6-moe` prompt format.

Current `main` already supports selecting `nemotron6-moe` and loading its pre-registered special tokens. This PR adds only the remaining SFT behavior:

- masks system, user, and assistant-prefix tokens so loss is computed only on assistant responses
- forwards `--tokenizer-keep-history-thinking` and preserves thinking traces from earlier assistant turns
- adds one focused multi-turn masking test

The change does not add chat templates, structured image fragments, a Unicode image sentinel, or task-encoder changes. Existing string-based `<image>` handling remains unchanged.

This is the second review-sized change in the multimodal/Nemotron Nano Omni upstreaming series and follows #6332.

## Issue tracking

Linked issue: N/A (follow-up to #6332)

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [ ] I have added relevant documentation
- [ ] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR

### Validation

- four targeted multimodal tokenizer tests passed on each of four distributed ranks
- Nemotron 6 tokenizer integration smoke test in the project container
- Black
- isort
- Ruff
- Python syntax compilation
- `git diff --check`
- public-diff scope and privacy audit

The full-project autoformatter could not be resolved on the local macOS environment because its locked dependencies include Linux-only NVIDIA wheels. Targeted formatting checks passed locally, and the tokenizer tests passed in the Linux/GPU project container.

## Attribution

Based on the original implementation by Tyler Poon.
