### PR TITLE
[Main] Recompute EP A2A overlap activations per layer segment (supersedes #5920)

### DIFF
--- a/megatron/core/models/common/model_chunk_schedule_plan.py
+++ b/megatron/core/models/common/model_chunk_schedule_plan.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 from typing import Any, Callable, List, Optional
 
@@ -27,7 +27,21 @@ class ModelChunkState:
 
 # ModelChunkState fields the layer forwards mutate in place; each segment snapshots them
 # so its backward-time replay sees the pre-segment values instead of end-of-chunk ones.
-_MUTABLE_CHUNK_STATE_FIELDS = ("input_ids", "position_ids", "padding_mask", "mtp_hidden_states")
+#
+# ``mtp_input_mask`` belongs here for the same reason as ``input_ids``: MTP's
+# ``_get_embeddings`` rolls the two together (one concatenated roll, so CP does a single
+# boundary exchange) and writes both back to the chunk state. Leaving it out would let a
+# replay roll an already-rolled mask, shifting it one position against ``input_ids``, and
+# the mask drives ``torch.where(valid, decoder_input, decoder_input.detach())`` — so the
+# embedding rows detached would be the wrong ones and the MTP/embedding gradients would be
+# silently wrong rather than failing loudly.
+_MUTABLE_CHUNK_STATE_FIELDS = (
+    "input_ids",
+    "position_ids",
+    "padding_mask",
+    "mtp_input_mask",
+    "mtp_hidden_states",
+)
 
 
 def _copy_chunk_state_value(value: Any) -> Any:

--- a/megatron/core/models/common/model_chunk_schedule_plan.py
+++ b/megatron/core/models/common/model_chunk_schedule_plan.py
@@ -39,10 +39,13 @@ class RecomputeSegment:
     """A contiguous group of layers recomputed as one unit.
 
     The initial forward runs under ``no_grad`` and is replayed with grad enabled at the
-    start of the segment's own backward. What survives the forward->backward gap is the
-    segment's input tensor plus the ``_MUTABLE_CHUNK_STATE_FIELDS`` snapshot. Layers left
-    eager under ``block`` keep their activations throughout. The A2A issued by a replay is
-    exposed by design; normal fwd/bwd A2A overlap is preserved.
+    start of the segment's own backward. A segment drops its layers' activations as soon
+    as its own forward is done (``release_activations``) and the replayed ones as each
+    node backwards (``ScheduleNode._release_state``), so only one segment's activations
+    are live at a time and what crosses the forward->backward gap is the segment's input
+    tensor plus the ``_MUTABLE_CHUNK_STATE_FIELDS`` snapshot. Layers left eager under
+    ``block`` keep their activations throughout. The A2A issued by a replay is exposed by
+    design; normal fwd/bwd A2A overlap is preserved.
 
     ``start_index`` is the segment's first layer index within the chunk, for NVTX labels.
     """
@@ -79,6 +82,25 @@ class RecomputeSegment:
             name: _copy_chunk_state_value(getattr(cs, name)) for name in _MUTABLE_CHUNK_STATE_FIELDS
         }
         self.rng_states = _get_all_rng_states()
+
+    def release_activations(self, layer: "TransformerLayerSchedulePlan") -> None:
+        """Drop this segment's forward activations once its tail layer has forwarded.
+
+        Runs while the chunk forward is still going, not at the end of it: the nodes hold
+        their boundary tensors in ``inputs`` / ``output`` / ``detached`` until something
+        unsets them, so deferring this to the end of the chunk would keep one such set
+        alive per recomputed layer for the rest of the forward. The tail layer's output is
+        the caller's ``f_input`` and is what the next segment captures, so it survives.
+
+        Only the Python references are dropped. Resizing the storages (what
+        ``ScheduleNode``'s ``free_input`` path and ``tensor_parallel.random.checkpoint``
+        do) is not usable here: the replay rebuilds the graph on top of these very
+        tensors, and freeing their storage corrupts it.
+        """
+        if layer is not self.layers[-1]:
+            return
+        for seg_layer in self.layers:
+            seg_layer.reset_for_recompute()
 
     def release_input(self, layer: "TransformerLayerSchedulePlan") -> None:
         """Drop the retained input once the head layer has finished its backward."""
@@ -461,6 +483,9 @@ class TransformerLayerSchedulePlan:
                 # reach back into this segment, which needs a grad-tracking leaf.
                 if not f_input.requires_grad:
                     f_input.requires_grad_(True)
+                # The segment is done forwarding and holds no graph; free its nodes now
+                # rather than at the end of the chunk forward.
+                segment.release_activations(f_layer)
 
         # Delay the last pre_dispatch_computation wgrad in backward pass (wgrad
         # of the first layer) for overlapping with the p2p comm.
@@ -736,12 +761,6 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
             self.post_process.model_chunk_state = None
             self.post_process = None
 
-    def release_layer_activations(self):
-        """Free the segments' forward activations, keeping only their input tensors."""
-        for segment in self._recompute_segments:
-            for layer in segment.layers:
-                layer.reset_for_recompute()
-
     @staticmethod
     def run(
         f_schedule_plan,
@@ -872,11 +891,6 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
         # pre process backward
         if b_schedule_plan is not None:
             b_schedule_plan.pre_process.backward(b_grad)
-
-        # The forward output has been consumed (PP send / post_process), so the
-        # recomputed layers' activations can go; only segment inputs are kept.
-        if f_schedule_plan is not None:
-            f_schedule_plan.release_layer_activations()
 
         if f_schedule_plan:
             f_schedule_plan.wait_current_stream()

--- a/megatron/core/models/common/model_chunk_schedule_plan.py
+++ b/megatron/core/models/common/model_chunk_schedule_plan.py
@@ -1,6 +1,6 @@
-# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
-from typing import Any, Callable, Optional
+from typing import Any, Callable, List, Optional
 
 import torch
 from torch import Tensor
@@ -8,6 +8,7 @@ from torch import Tensor
 from megatron.core.pipeline_parallel.utils import (
     AbstractSchedulePlan,
     NoopScheduleNode,
+    ScheduleNode,
     get_comm_stream,
     get_comp_stream,
 )
@@ -22,6 +23,110 @@ class ModelChunkState:
     """
 
     pass
+
+
+# ModelChunkState fields the layer forwards mutate in place; each segment snapshots them
+# so its backward-time replay sees the pre-segment values instead of end-of-chunk ones.
+_MUTABLE_CHUNK_STATE_FIELDS = ("input_ids", "position_ids", "padding_mask", "mtp_hidden_states")
+
+
+def _copy_chunk_state_value(value: Any) -> Any:
+    """Copy list-valued chunk state so a later in-place append cannot corrupt a snapshot."""
+    return list(value) if isinstance(value, list) else value
+
+
+class RecomputeSegment:
+    """A contiguous group of layers recomputed as one unit.
+
+    The initial forward runs under ``no_grad`` and is replayed with grad enabled at the
+    start of the segment's own backward. What survives the forward->backward gap is the
+    segment's input tensor plus the ``_MUTABLE_CHUNK_STATE_FIELDS`` snapshot. Layers left
+    eager under ``block`` keep their activations throughout. The A2A issued by a replay is
+    exposed by design; normal fwd/bwd A2A overlap is preserved.
+
+    ``start_index`` is the segment's first layer index within the chunk, for NVTX labels.
+    """
+
+    def __init__(
+        self,
+        layers: List["TransformerLayerSchedulePlan"],
+        chunk_state: ModelChunkState,
+        start_index: int,
+    ):
+        assert len(layers) > 0, "a recompute segment must contain at least one layer"
+        self.layers = layers
+        self.chunk_state = chunk_state
+        self.start_index = start_index
+        # Captured at the start of the segment's initial forward.
+        self.input_tensor = None
+        self.state_snapshot = None
+        self.rng_states = None
+        for layer in layers:
+            layer.recompute_segment = self
+            # The initial forward retains no autograd graph for these layers.
+            layer.set_forward_no_grad(True)
+
+    def capture(self, layer: "TransformerLayerSchedulePlan", f_input: Tensor) -> None:
+        """When the head layer starts its forward, snapshot what the replay needs:
+        input tensor, mutable chunk state, RNG."""
+        if layer is not self.layers[0]:
+            return
+        from megatron.core.tensor_parallel.random import _get_all_rng_states
+
+        self.input_tensor = f_input
+        cs = self.chunk_state
+        self.state_snapshot = {
+            name: _copy_chunk_state_value(getattr(cs, name)) for name in _MUTABLE_CHUNK_STATE_FIELDS
+        }
+        self.rng_states = _get_all_rng_states()
+
+    def release_input(self, layer: "TransformerLayerSchedulePlan") -> None:
+        """Drop the retained input once the head layer has finished its backward."""
+        if layer is not self.layers[0]:
+            return
+        self.input_tensor = None
+        self.state_snapshot = None
+
+    def recompute(self, layer: "TransformerLayerSchedulePlan") -> None:
+        """Replay the segment with grad enabled when its tail layer enters the backward.
+
+        Must run before any of that layer's nodes backwards: ``mtp_post_process`` is in the
+        recompute scope, so its graph does not exist until the replay has run. Re-running
+        the same nodes in the same order repopulates each node's ``inputs`` / ``output`` /
+        ``detached`` / ``layer_state`` as in the initial forward.
+        """
+        if layer is not self.layers[-1]:
+            return
+        from megatron.core.tensor_parallel.random import _fork_rng, _set_all_rng_states
+
+        assert self.input_tensor is not None, (
+            "layer-level full recompute requires the retained segment input tensor, "
+            "but it is missing."
+        )
+        cs = self.chunk_state
+
+        for name, value in self.state_snapshot.items():
+            setattr(cs, name, _copy_chunk_state_value(value))
+
+        # The replayed nodes read inputs[i].grad to reach the previous segment, so the
+        # retained input has to be a grad-tracking leaf.
+        segment_input = self.input_tensor
+        if not segment_input.requires_grad:
+            segment_input.requires_grad_(True)
+
+        for seg_layer in self.layers:
+            seg_layer.set_forward_no_grad(False)
+
+        # Replay the forward RNG stream so rng-forked ops reproduce the initial forward.
+        with _fork_rng():
+            _set_all_rng_states(*self.rng_states)
+            f_input = segment_input
+            for i, seg_layer in enumerate(self.layers):
+                nvtx_msg = f"recompute_layer_{self.start_index + i}"
+                nvtx_range_push(nvtx_msg)
+                f_input = seg_layer.recompute_forward(f_input)
+                nvtx_range_pop(nvtx_msg)
+        self.rng_states = None
 
 
 class TransformerLayerSchedulePlan:
@@ -80,11 +185,15 @@ class TransformerLayerSchedulePlan:
         self.comp_stream = comp_stream
         self.comm_stream = comm_stream
 
+        # Set by _build_recompute_segments(); None means this layer keeps its graph.
+        self.recompute_segment = None
+
         # get callable nodes for transformer/mtp layer
         self._build_callable_nodes(event, comp_stream, comm_stream, extra_args)
 
     def release_state(self):
         """Release reference, this helps avoid memory leak."""
+        self.recompute_segment = None
         if hasattr(self, 'pre_dispatch_computation') and self.pre_dispatch_computation is not None:
             del self.pre_dispatch_computation
             self.pre_dispatch_computation = None
@@ -216,6 +325,62 @@ class TransformerLayerSchedulePlan:
         # After the last forward op, release forward-pass params.
         last_fwd_node.set_post_forward_hook(lambda: post_forward_hook(hook_module))
 
+    def _iter_layer_nodes(self):
+        """Yield this layer's nodes in forward order, NoopScheduleNodes included.
+
+        Single definition of the sequence for recompute_forward/set_forward_no_grad/
+        reset_for_recompute; run() issues the same order inline (it interleaves each node
+        with the backward layer's), so a new node must be added in both places.
+
+        This is also the full-recompute scope. mtp_post_process must stay in it: it builds
+        a torch.cat over the MTP pre_dispatch node's detached input, so leaving it outside
+        would anchor that cat on a no_grad leaf and drop the decoder's gradient via MTP.
+        """
+        yield self.pre_dispatch_computation
+        yield self.moe_dispatch
+        yield self.mlp
+        yield self.moe_combine
+        yield self.mtp_post_process
+
+    def _iter_recomputed_nodes(self):
+        """Yield the real ScheduleNodes (skips NoopScheduleNode, which holds no state).
+
+        Only for state toggling; the forward helpers walk _iter_layer_nodes, since a Noop
+        still passes the tensor through and still consumes a low-precision context in run().
+        """
+        for node in self._iter_layer_nodes():
+            if isinstance(node, ScheduleNode):
+                yield node
+
+    def set_forward_no_grad(self, no_grad: bool):
+        """Toggle no-grad forward for this layer's recomputed nodes.
+
+        The initial forward runs with ``no_grad=True`` (no autograd graph retained);
+        the backward-time recompute runs with ``no_grad=False`` to rebuild the graph.
+        """
+        for node in self._iter_recomputed_nodes():
+            node.forward_no_grad = no_grad
+
+    def recompute_forward(self, f_input: Tensor) -> Tensor:
+        """Re-run this layer with grad enabled and return its output.
+
+        One low-precision context per node, matching run()'s forward half node for node.
+        """
+        for node in self._iter_layer_nodes():
+            with self.get_low_precision_context():
+                f_input = node.forward(f_input)
+        return f_input
+
+    def reset_for_recompute(self):
+        """Free the retained forward activations of this layer, keeping the nodes
+        reusable for a recompute forward. Also clears the per-layer shared state."""
+        for node in self._iter_recomputed_nodes():
+            node.reset_for_recompute()
+        if getattr(self, 'layer_state', None) is not None:
+            # Nodes hold a reference to this same layer_state object, so clear it
+            # in place rather than replacing it.
+            self.layer_state.__dict__.clear()
+
     def get_low_precision_context(self):
         """Get the low-precision context for the transformer layer."""
         return self.layer.get_inner_quantization_context()
@@ -247,10 +412,16 @@ class TransformerLayerSchedulePlan:
         """
 
         if b_layer is not None:
+            # Full recompute: rebuild this layer's segment graph before its backward.
+            if b_layer.recompute_segment is not None:
+                b_layer.recompute_segment.recompute(b_layer)
             b_grad = b_layer.mtp_post_process.backward(b_grad)
             b_grad = b_layer.moe_combine.backward(b_grad)
 
         if f_layer is not None:
+            # Full recompute: retain this segment's input for the backward-time replay.
+            if f_layer.recompute_segment is not None:
+                f_layer.recompute_segment.capture(f_layer, f_input)
             with f_layer.get_low_precision_context():
                 f_input = f_layer.pre_dispatch_computation.forward(f_input)
 
@@ -282,11 +453,23 @@ class TransformerLayerSchedulePlan:
         if f_layer is not None:
             with f_layer.get_low_precision_context():
                 f_input = f_layer.mtp_post_process.forward(f_input)
+            segment = f_layer.recompute_segment
+            if segment is not None and f_layer is segment.layers[-1]:
+                # The segment ran under no_grad, so its output can be a plain leaf.
+                # Whatever consumes it - the next segment, an eager layer under
+                # recompute_method='block', or post_process - reads a gradient off it to
+                # reach back into this segment, which needs a grad-tracking leaf.
+                if not f_input.requires_grad:
+                    f_input.requires_grad_(True)
 
         # Delay the last pre_dispatch_computation wgrad in backward pass (wgrad
         # of the first layer) for overlapping with the p2p comm.
         if b_layer is not None and not is_last_layer_in_bwd:
             b_layer.pre_dispatch_computation.backward_dw()
+
+        if b_layer is not None and b_layer.recompute_segment is not None:
+            # The replay has run and its gradient is past this layer; drop the input.
+            b_layer.recompute_segment.release_input(b_layer)
 
         return f_input, b_grad
 
@@ -384,6 +567,13 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
         self.post_process = None
         self.vp_stage = model.vp_stage
 
+        # Full activation recompute; see RecomputeSegment. This plan is only built for
+        # the EP A2A overlap scheduler, so recompute_granularity alone decides (not
+        # re-checking overlap_moe_expert_parallel_comm keeps the schedule unit-testable).
+        self.recompute_full = model.config.recompute_granularity == 'full'
+        self._recompute_segments = []
+        self._num_decoder_layers = 0
+
         # save the inputs of model.forward() to ModelChunkState
         self._model_chunk_state.input_ids = input_ids
         self._model_chunk_state.position_ids = position_ids
@@ -413,6 +603,8 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
         # The methods to obtain layers are different for MTP so we need the other build plan for
         # MTP. Also, this can help annotate MTP layer so that it can know where MTP is.
         self._build_layer_schedule_plan(model.decoder, get_comp_stream, get_comm_stream)
+        # Segmentation applies different rules to the decoder and MTP; mark the split.
+        self._num_decoder_layers = len(self._transformer_layers)
         self._build_layer_schedule_plan(
             getattr(model, "mtp", None), get_comp_stream, get_comm_stream
         )
@@ -422,6 +614,58 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
             self.post_process = post_process_cls(
                 model, self._model_chunk_state, self._event, get_comp_stream
             )
+
+        # Split into segments; pre_process and post_process keep their graphs.
+        self._build_recompute_segments(model.config)
+
+    def _build_recompute_segments(self, config):
+        """Split this chunk's layers into full-recompute segments.
+
+        Decoder segmentation mirrors megatron.core.recompute.checkpointed_forward, so
+        recompute_method / recompute_num_layers mean the same thing with and without
+        --overlap-moe-expert-parallel-comm: 'uniform' groups every decoder layer by
+        recompute_num_layers, 'block' recomputes the first recompute_num_layers decoder
+        layers one per segment. MTP gets one segment per depth under both methods.
+
+        Unlike the non-overlap 'block' branch there is no recompute_skip_num_layers
+        window under fp8/fp4: no checkpoint primitive is involved, since the replay marks
+        the retained segment input grad-tracking itself.
+        """
+        if not self.recompute_full:
+            return
+
+        method = config.recompute_method
+        num_layers = config.recompute_num_layers
+        # TransformerConfig owns the user-facing validation; re-check here because
+        # build_schedule_plan() is reachable directly and 'block' with num_layers=None
+        # would slice [:None] and silently recompute every decoder layer.
+        if method not in ("uniform", "block"):
+            raise ValueError(f"Invalid activation recompute method: {method}.")
+        if not isinstance(num_layers, int) or isinstance(num_layers, bool) or num_layers < 1:
+            raise ValueError(f"recompute_num_layers must be a positive integer, got {num_layers}.")
+
+        def add_segment(layers, start_index):
+            self._recompute_segments.append(
+                RecomputeSegment(layers, self._model_chunk_state, start_index)
+            )
+
+        decoder_layers = self._transformer_layers[: self._num_decoder_layers]
+        mtp_layers = self._transformer_layers[self._num_decoder_layers :]
+
+        if method == "uniform":
+            for start in range(0, len(decoder_layers), num_layers):
+                add_segment(decoder_layers[start : start + num_layers], start)
+        else:
+            for start, layer in enumerate(decoder_layers[:num_layers]):
+                add_segment([layer], start)
+        # MTP is one segment per depth under both methods. overlap_moe_expert_parallel_comm
+        # only supports mtp_num_layers == 1, so the MTP side of the config is identical
+        # either way. MultiTokenPredictionLayer._checkpointed_forward leaves MTP eager
+        # under 'block' (its own TODO), which is safe there because the decoder block goes
+        # through tensor_parallel.checkpoint and keeps an autograd edge into MTP. This
+        # path's replay has no such edge, so an eager MTP would strand the hand-off.
+        for i, layer in enumerate(mtp_layers):
+            add_segment([layer], self._num_decoder_layers + i)
 
     def _build_layer_schedule_plan(self, module, comp_stream, comm_stream):
         if module is None:
@@ -483,6 +727,7 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
 
     def release_state(self):
         """Release reference, this helps avoid memory leak."""
+        self._recompute_segments = []
         self._model_chunk_state.model = None
         self.pre_process.model_chunk_state = None
         self.pre_process = None
@@ -490,6 +735,12 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
         if self.post_process is not None:
             self.post_process.model_chunk_state = None
             self.post_process = None
+
+    def release_layer_activations(self):
+        """Free the segments' forward activations, keeping only their input tensors."""
+        for segment in self._recompute_segments:
+            for layer in segment.layers:
+                layer.reset_for_recompute()
 
     @staticmethod
     def run(
@@ -543,6 +794,9 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
                 pre_backward(b_schedule_plan.vp_stage)
                 b_schedule_plan.record_current_stream()
 
+            # Before any layer backward: post_process keeps its own graph and detaches
+            # its input, and releasing it first avoids co-materializing a large vocab
+            # graph with a recomputed segment on the last PP stage.
             if b_schedule_plan.post_process is not None:
                 b_grad = b_schedule_plan.post_process.backward(b_grad)
 
@@ -610,10 +864,19 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
 
         # post process forward
         if f_schedule_plan is not None and f_schedule_plan.post_process is not None:
+            if f_schedule_plan.recompute_full and f_input is not None and not f_input.requires_grad:
+                # The last layer ran under no_grad, so post_process needs a grad-tracking
+                # leaf to seed the replayed last segment's backward.
+                f_input.requires_grad_(True)
             f_input = f_schedule_plan.post_process.forward(f_input)
         # pre process backward
         if b_schedule_plan is not None:
             b_schedule_plan.pre_process.backward(b_grad)
+
+        # The forward output has been consumed (PP send / post_process), so the
+        # recomputed layers' activations can go; only segment inputs are kept.
+        if f_schedule_plan is not None:
+            f_schedule_plan.release_layer_activations()
 
         if f_schedule_plan:
             f_schedule_plan.wait_current_stream()

--- a/megatron/core/models/common/utils.py
+++ b/megatron/core/models/common/utils.py
@@ -283,6 +283,17 @@ class TransformerLayerNode(ScheduleNode):
         """Free-input policy hook. Subclasses override to specialize."""
         return should_free_input(name, is_moe, config, num_local_experts)
 
+    def reset_for_recompute(self):
+        """Release this node's forward activations, keeping it reusable for a replay.
+
+        Under full recompute only each segment's input survives the forward->backward
+        gap; the same node is later re-run with grad enabled to rebuild its state.
+        """
+        self.inputs = None
+        self.output = None
+        self.detached = tuple()
+        self.before_detached = tuple()
+
     def detach(self, t):
         """Detach a tensor and remember it for backward through the schedule node."""
         detached = make_viewless(t).detach()

--- a/megatron/core/models/common/utils.py
+++ b/megatron/core/models/common/utils.py
@@ -286,8 +286,13 @@ class TransformerLayerNode(ScheduleNode):
     def reset_for_recompute(self):
         """Release this node's forward activations, keeping it reusable for a replay.
 
-        Under full recompute only each segment's input survives the forward->backward
-        gap; the same node is later re-run with grad enabled to rebuild its state.
+        Called as soon as the node's recompute segment has finished forwarding, so a
+        recomputed layer's boundary tensors do not stay pinned for the rest of the chunk
+        forward; the same node is later re-run with grad enabled to rebuild its state.
+
+        Only the references are dropped. The storages are deliberately left intact: the
+        replay rebuilds the autograd graph on top of these tensors, so resizing them the
+        way ``ScheduleNode``'s ``free_input`` path does corrupts that graph.
         """
         self.inputs = None
         self.output = None

--- a/megatron/core/models/common/utils.py
+++ b/megatron/core/models/common/utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 """Schedule-plan helpers shared by GPTModel and HybridModel.
 

--- a/megatron/core/pipeline_parallel/combined_1f1b.py
+++ b/megatron/core/pipeline_parallel/combined_1f1b.py
@@ -398,6 +398,15 @@ def combined_forward_backward_step(
         # may apply to expert parameters only. The release callbacks skip any parameter
         # whose weights are not sharded.
         forward_fsdp_wrapper = find_megatron_fsdp(f_model)
+        # Full recompute re-runs each layer segment's forward at backward time, which
+        # needs the (sharded) parameters to be all-gathered again. That interaction
+        # with the FSDP reshard hooks is not yet supported.
+        assert not (
+            forward_fsdp_wrapper is not None and getattr(f_schedule_plan, "recompute_full", False)
+        ), (
+            "overlap_moe_expert_parallel_comm full recompute (recompute_granularity=full) "
+            "is not yet supported together with Megatron FSDP."
+        )
         if forward_fsdp_wrapper is not None and any_sharding_strategy_in(
             forward_fsdp_wrapper.ddp_config, ["optim_grads_params"]
         ):

--- a/megatron/core/pipeline_parallel/utils.py
+++ b/megatron/core/pipeline_parallel/utils.py
@@ -1,8 +1,8 @@
-# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import logging
 from abc import ABC, abstractmethod
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from typing import Callable, Optional
 
 import torch
@@ -221,6 +221,9 @@ class ScheduleNode:
         self.ncclep_zero_copy = ncclep_zero_copy
         self.inputs = None
         self.outputs = None
+        # When True, the forward runs under torch.no_grad() so no autograd graph is
+        # retained; the layer-level full recompute path replays it with grad at backward.
+        self.forward_no_grad = False
 
     def default_backward_func(self, outputs, output_grad):
         """Default backward function"""
@@ -252,7 +255,10 @@ class ScheduleNode:
                     input.requires_grad = inputs[i].requires_grad
 
             data = tuple(self.inputs)
-            data = self.forward_func(*data)
+            # Full recompute: skip the graph now, rebuild it by re-running at backward.
+            grad_ctx = torch.no_grad() if self.forward_no_grad else nullcontext()
+            with grad_ctx:
+                data = self.forward_func(*data)
 
             if not isinstance(data, tuple):
                 data = make_viewless(data)

--- a/megatron/core/pipeline_parallel/utils.py
+++ b/megatron/core/pipeline_parallel/utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import logging
 from abc import ABC, abstractmethod

--- a/megatron/core/transformer/moe/README.md
+++ b/megatron/core/transformer/moe/README.md
@@ -436,6 +436,8 @@ EP All-to-All can consume 30-40% of training time without optimization. These fe
 
 > **Requirements for EP A2A Overlap**: `expert_model_parallel_size > 1`, CUDA_DEVICE_MAX_CONNECTIONS > 1.
 
+> **Full activation recompute with EP A2A Overlap**: `--recompute-granularity full` is supported and is applied per layer segment, so `--recompute-method` and `--recompute-num-layers` carry exactly the same meaning as without `--overlap-moe-expert-parallel-comm`. Both flags are required.
+
 ### Compute Optimization
 
 Fine-grained MoE produces many small operations that can underutilize GPU resources. These optimizations reduce kernel launch overhead and improve GPU utilization.

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -3291,18 +3291,6 @@ class TransformerConfig(ModelParallelConfig):
                     'attention_dropout==0 and hidden_dropout==0 (RNG replay across the '
                     'interleaved 1F1B schedule is not yet supported for nonzero dropout)'
                 )
-                # CUDA graphs capture a fixed node sequence with static buffers, which
-                # the inserted no_grad forward + backward-time replay does not fit.
-                assert self.cuda_graph_impl == "none", (
-                    'overlap_moe_expert_parallel_comm full recompute is not yet supported '
-                    'together with CUDA graphs (cuda_graph_impl != "none").'
-                )
-                # Paged stash and full recompute are redundant activation-memory
-                # strategies, and stash/restore conflicts with the recompute release.
-                assert not self.moe_paged_stash, (
-                    'overlap_moe_expert_parallel_comm full recompute is not yet supported '
-                    'together with moe_paged_stash.'
-                )
                 # The offload manager pairs a forward-pushed group with the backward that
                 # pops it. Under full recompute the initial forward saves nothing and the
                 # replay pushes its groups immediately before its own backward, which does

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -3263,15 +3263,62 @@ class TransformerConfig(ModelParallelConfig):
                 'flex',
             ], 'overlap_moe_expert_parallel_comm is supported with alltoall/flex token dispatcher'
 
-            assert (
-                self.recompute_granularity != 'full'
-            ), 'disable full recomputation when enabling overlap_moe_expert_parallel_comm'
-            assert (
-                self.recompute_method is None
-            ), 'disable recomputation method when enabling overlap_moe_expert_parallel_comm'
-            assert (
-                self.recompute_num_layers is None
-            ), 'recompute_num_layers must be None when enabling overlap_moe_expert_parallel_comm'
+            if self.recompute_granularity == 'full':
+                # Full recompute runs per layer segment; recompute_method /
+                # recompute_num_layers keep their non-overlap meaning and are validated
+                # by the shared checks in __post_init__. See
+                # megatron/core/models/common/model_chunk_schedule_plan.py.
+                # The replay is hand-rolled rather than a checkpoint primitive, so it
+                # cannot shard the retained segment input across TP ranks.
+                assert not self.distribute_saved_activations, (
+                    'overlap_moe_expert_parallel_comm full recompute does not support '
+                    'distribute_saved_activations: the segment replay does not go through '
+                    'a checkpoint primitive, so the retained input is not sharded.'
+                )
+                # MTP is segmented under both methods here, so unlike
+                # MultiTokenPredictionLayer._checkpointed_forward there is no 'block'
+                # exemption. The 'uniform' restriction below is config parity with that
+                # function's own assert, not a constraint of this schedule - multi-layer
+                # decoder segments hand the MTP bridge over correctly.
+                if self.mtp_num_layers and self.recompute_method == 'uniform':
+                    assert (
+                        self.recompute_num_layers == 1
+                    ), 'recompute_num_layers must be 1 for MTP recompute'
+                # With dropout the forward RNG stream is interleaved across microbatches
+                # in the 1F1B schedule and cannot yet be faithfully replayed.
+                assert self.attention_dropout == 0.0 and self.hidden_dropout == 0.0, (
+                    'overlap_moe_expert_parallel_comm full recompute currently requires '
+                    'attention_dropout==0 and hidden_dropout==0 (RNG replay across the '
+                    'interleaved 1F1B schedule is not yet supported for nonzero dropout)'
+                )
+                # CUDA graphs capture a fixed node sequence with static buffers, which
+                # the inserted no_grad forward + backward-time replay does not fit.
+                assert self.cuda_graph_impl == "none", (
+                    'overlap_moe_expert_parallel_comm full recompute is not yet supported '
+                    'together with CUDA graphs (cuda_graph_impl != "none").'
+                )
+                # Paged stash and full recompute are redundant activation-memory
+                # strategies, and stash/restore conflicts with the recompute release.
+                assert not self.moe_paged_stash, (
+                    'overlap_moe_expert_parallel_comm full recompute is not yet supported '
+                    'together with moe_paged_stash.'
+                )
+                # The offload manager pairs a forward-pushed group with the backward that
+                # pops it. Under full recompute the initial forward saves nothing and the
+                # replay pushes its groups immediately before its own backward, which does
+                # not fit that pairing.
+                assert not self.fine_grained_activation_offloading, (
+                    'overlap_moe_expert_parallel_comm full recompute is not yet supported '
+                    'together with fine_grained_activation_offloading.'
+                )
+            else:
+                assert self.recompute_method is None, (
+                    'disable recomputation method when enabling ' 'overlap_moe_expert_parallel_comm'
+                )
+                assert self.recompute_num_layers is None, (
+                    'recompute_num_layers must be None when enabling '
+                    'overlap_moe_expert_parallel_comm'
+                )
             assert (
                 "moe" not in self.recompute_modules
             ), 'disable moe in recompute_modules when enabling overlap_moe_expert_parallel_comm'

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -3291,6 +3291,23 @@ class TransformerConfig(ModelParallelConfig):
                     'attention_dropout==0 and hidden_dropout==0 (RNG replay across the '
                     'interleaved 1F1B schedule is not yet supported for nonzero dropout)'
                 )
+                # Delayed-scaling FP8 accumulates amax into a persistent amax_history
+                # across microbatches. Both the initial no_grad forward and the
+                # backward-time recompute run under the delayed FP8 autocast, and this
+                # path does not enter TE's activation-recompute (recompute_phase)
+                # machinery that te_checkpoint uses to snapshot and restore FP8 metadata,
+                # so the recompute would update amax_history a second time and silently
+                # diverge. Current-scaling recipes (tensorwise / mxfp8 / blockwise) derive
+                # scales from the current tensor each pass, so the replayed forward
+                # re-derives identical scales; only delayed scaling is rejected here.
+                # self.fp8 is checked because fp8_recipe defaults to 'delayed' in BF16
+                # configs, where no FP8 autocast runs at all.
+                assert not (self.fp8 and self.fp8_recipe == Fp8Recipe.delayed), (
+                    'overlap_moe_expert_parallel_comm full recompute is not yet supported '
+                    'with delayed-scaling FP8 (fp8_recipe="delayed"): the backward-time '
+                    'recompute would double-update the persistent amax_history. Use a '
+                    'current-scaling recipe (tensorwise / mxfp8 / blockwise) instead.'
+                )
                 # The offload manager pairs a forward-pushed group with the backward that
                 # pops it. Under full recompute the initial forward saves nothing and the
                 # replay pushes its groups immediately before its own backward, which does

--- a/tests/unit_tests/a2a_overlap/test_schedule_chunk_1f1b.py
+++ b/tests/unit_tests/a2a_overlap/test_schedule_chunk_1f1b.py
@@ -78,8 +78,9 @@ def run_two_chunk_parity(
     GPTModel.forward/backward, then replays the same inputs through the 1F1B pattern
     (chunk0 fwd -> chunk1 fwd + chunk0 bwd -> chunk1 bwd). ``on_plans_built`` is an
     optional hook for asserting schedule-plan invariants before the overlap run;
-    ``on_forward_done`` runs on chunk 0's plan right after its forward-only pass, i.e.
-    after release_layer_activations().
+    ``on_forward_done`` runs on chunk 0's plan right after its forward-only pass, once per
+    microbatch. With ``microbatches > 1`` both paths accumulate grads over that many
+    identical microbatches and the plans are rebuilt each round, as in a real 1F1B step.
     """
     assert len(layers) == 2, "the 1F1B pattern below is written for exactly two chunks"
 
@@ -232,22 +233,7 @@ class TestA2AOverlap:
         apply_flex_backend_kwargs(extra_kwargs, dispatcher_type, flex_backend)
         run_two_chunk_parity(layers, extra_kwargs, use_padding_mask=True)
 
-    @pytest.mark.skipif(not is_te_min_version("1.9.0.dev0"), reason="Requires TE >= 1.9.0.dev0")
-    @pytest.mark.parametrize("mtp_layers", [0, 1])
-    @pytest.mark.parametrize("dispatcher_type,flex_backend", get_valid_dispatcher_configs())
-    @pytest.mark.parametrize("fp8_flag", get_valid_fp8_flags())
-    @pytest.mark.parametrize(
-        "recompute_method,recompute_num_layers",
-        [
-            ("uniform", 1),
-            ("uniform", 2),
-            # 'block' leaves trailing layers eager, pinning the recomputed -> eager
-            # hand-off: n=1 keeps layers 1.. eager, n=3 recomputes the whole decoder.
-            ("block", 1),
-            ("block", 3),
-        ],
-    )
-    def test_1f1b_schedule_model_chunk_full_recompute(
+    def _run_full_recompute_parity(
         self,
         mtp_layers,
         dispatcher_type,
@@ -255,6 +241,7 @@ class TestA2AOverlap:
         fp8_flag,
         recompute_method,
         recompute_num_layers,
+        microbatches=1,
     ):
         """Layer-level full recompute matches the non-overlap reference, which checkpoints
         through checkpointed_forward / MTP _checkpointed_forward with the same config.
@@ -286,7 +273,9 @@ class TestA2AOverlap:
             # The point of the feature: after the chunk forward a recomputed layer holds
             # no activation and only its segment's input survives. Gradient parity alone
             # cannot catch a regression here - recompute is numerically transparent, so a
-            # segment that quietly kept its graph would still compare equal.
+            # segment that quietly kept its graph would still compare equal. Re-checked
+            # every microbatch, since the plans are rebuilt each round.
+            assert len(plan._recompute_segments) > 0, "no recompute segments were built"
             for segment in plan._recompute_segments:
                 assert segment.input_tensor is not None, "segment input was not retained"
                 for layer in segment.layers:
@@ -297,6 +286,78 @@ class TestA2AOverlap:
         run_two_chunk_parity(
             [3, 2],
             extra_kwargs,
+            microbatches=microbatches,
             on_plans_built=assert_segments_were_built,
             on_forward_done=assert_activations_were_released,
+        )
+
+    @pytest.mark.skipif(not is_te_min_version("1.9.0.dev0"), reason="Requires TE >= 1.9.0.dev0")
+    @pytest.mark.parametrize("mtp_layers", [0, 1])
+    @pytest.mark.parametrize("dispatcher_type,flex_backend", get_valid_dispatcher_configs())
+    @pytest.mark.parametrize("fp8_flag", get_valid_fp8_flags())
+    @pytest.mark.parametrize(
+        "recompute_method,recompute_num_layers",
+        [
+            ("uniform", 1),
+            ("uniform", 2),
+            # 'block' leaves trailing layers eager, pinning the recomputed -> eager
+            # hand-off: n=1 keeps layers 1.. eager, n=3 recomputes the whole decoder.
+            ("block", 1),
+            ("block", 3),
+        ],
+    )
+    def test_1f1b_schedule_model_chunk_full_recompute(
+        self,
+        mtp_layers,
+        dispatcher_type,
+        flex_backend,
+        fp8_flag,
+        recompute_method,
+        recompute_num_layers,
+    ):
+        """Full segmentation matrix, one microbatch."""
+        self._run_full_recompute_parity(
+            mtp_layers,
+            dispatcher_type,
+            flex_backend,
+            fp8_flag,
+            recompute_method,
+            recompute_num_layers,
+        )
+
+    @pytest.mark.skipif(not is_te_min_version("1.9.0.dev0"), reason="Requires TE >= 1.9.0.dev0")
+    @pytest.mark.parametrize("mtp_layers", [0, 1])
+    @pytest.mark.parametrize("dispatcher_type,flex_backend", get_valid_dispatcher_configs())
+    @pytest.mark.parametrize("fp8_flag", get_valid_fp8_flags())
+    @pytest.mark.parametrize(
+        "recompute_method,recompute_num_layers", [("uniform", 1), ("block", 1)]
+    )
+    def test_1f1b_schedule_model_chunk_full_recompute_multi_microbatch(
+        self,
+        mtp_layers,
+        dispatcher_type,
+        flex_backend,
+        fp8_flag,
+        recompute_method,
+        recompute_num_layers,
+    ):
+        """Same parity, but over four microbatches, as in a real 1F1B steady state.
+
+        One microbatch never runs the same modules through forward -> recompute ->
+        backward twice, so it cannot catch state that the replay leaves behind and the
+        next microbatch then reads: FP8 scaling metadata, the segments' RNG snapshots, or
+        a node whose ``forward_no_grad`` was not restored. Grads are accumulated across
+        the four microbatches on both paths and compared bitwise, so any per-round drift
+        shows up. The segmentation axis is trimmed to one segment-per-layer case and one
+        recomputed -> eager hand-off case; the matrix above covers the rest at
+        ``microbatches=1``.
+        """
+        self._run_full_recompute_parity(
+            mtp_layers,
+            dispatcher_type,
+            flex_backend,
+            fp8_flag,
+            recompute_method,
+            recompute_num_layers,
+            microbatches=4,
         )

--- a/tests/unit_tests/a2a_overlap/test_schedule_chunk_1f1b.py
+++ b/tests/unit_tests/a2a_overlap/test_schedule_chunk_1f1b.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 import gc
 
 import pytest
@@ -24,7 +24,7 @@ from tests.unit_tests.a2a_overlap.utils import (
 from tests.unit_tests.test_utilities import Utils
 
 
-def build_model(config, use_padding_mask=False):
+def build_model(config, use_padding_mask=False, use_mtp_input_mask=False):
     seq_len = 32
     max_seq_len = 300
     # ids = random.sample([i for i in range(max_seq_len)], seq_len)
@@ -45,6 +45,18 @@ def build_model(config, use_padding_mask=False):
         padding_mask = torch.zeros((1, seq_len), dtype=torch.bool).cuda()
         padding_mask[0, -8:] = True
         data["padding_mask"] = padding_mask
+
+    # Optionally add mtp_input_mask, with False holes away from both ends. MTP rolls this
+    # mask together with input_ids and then uses it to pick which embedding rows keep a
+    # gradient, so the holes must not be symmetric under a one-position shift — otherwise a
+    # mask that is rolled one time too many still selects the same rows and the test passes
+    # for the wrong reason.
+    if use_mtp_input_mask:
+        mtp_input_mask = torch.ones((1, seq_len), dtype=torch.bool).cuda()
+        mtp_input_mask[0, 5] = False
+        mtp_input_mask[0, 11:14] = False
+        mtp_input_mask[0, 20] = False
+        data["mtp_input_mask"] = mtp_input_mask
 
     # build layer spec
     transformer_layer_spec = get_gpt_decoder_block_spec(config=config, use_transformer_engine=True)
@@ -69,6 +81,7 @@ def run_two_chunk_parity(
     extra_kwargs,
     microbatches=1,
     use_padding_mask=False,
+    use_mtp_input_mask=False,
     on_plans_built=None,
     on_forward_done=None,
 ):
@@ -95,7 +108,9 @@ def run_two_chunk_parity(
             # build config
             config = get_test_config(num_layers=layer_num, extra_kwargs=extra_kwargs)
             # build model
-            gpt_model, schedule_plan, data = build_model(config, use_padding_mask=use_padding_mask)
+            gpt_model, schedule_plan, data = build_model(
+                config, use_padding_mask=use_padding_mask, use_mtp_input_mask=use_mtp_input_mask
+            )
             gpt_model.cuda()
             gpt_models.append(gpt_model)
             datas.append(data)
@@ -163,6 +178,57 @@ def run_two_chunk_parity(
             gpt_models[i] = None
         gc.collect()
         torch.cuda.empty_cache()
+
+
+def capture_overlap_grads(layers, extra_kwargs, use_mtp_input_mask=False):
+    """Run the two-chunk 1F1B overlap pattern once; return one grad dict per chunk.
+
+    Unlike ``run_two_chunk_parity`` this does not involve ``GPTModel.forward`` at all, so
+    both sides of a comparison built on it travel the identical schedule. That matters for
+    the embedding parameters: overlap-vs-reference does not agree on their gradients even
+    with the feature under test disabled (which is why ``run_two_chunk_parity`` passes
+    ``skip_embedding=True``), so a reference-based test cannot say anything about them.
+    Overlap-vs-overlap can.
+    """
+    with deterministic_mode():
+        gpt_models, schedule_plans, datas = [], [], []
+        for layer_num in layers:
+            config = get_test_config(num_layers=layer_num, extra_kwargs=extra_kwargs)
+            gpt_model, schedule_plan, data = build_model(
+                config, use_mtp_input_mask=use_mtp_input_mask
+            )
+            gpt_model.cuda()
+            gpt_models.append(gpt_model)
+            schedule_plans.append(schedule_plan)
+            datas.append(data)
+
+        f_input_0 = TransformerModelChunkSchedulePlan.run(schedule_plans[0], None)
+        f_input_1 = TransformerModelChunkSchedulePlan.run(
+            schedule_plans[1], schedule_plans[0], b_grad=torch.ones_like(f_input_0)
+        )
+        TransformerModelChunkSchedulePlan.run(
+            None, schedule_plans[1], b_grad=torch.ones_like(f_input_1)
+        )
+
+        captures = []
+        for gpt_model in gpt_models:
+            captures.append(
+                {
+                    name: (param.grad.clone() if param.grad is not None else None)
+                    for name, param in gpt_model.named_parameters()
+                }
+            )
+
+        for i in range(len(gpt_models)):
+            schedule_plans[i] = None
+            for k in datas[i]:
+                datas[i][k] = None
+            datas[i] = None
+            gpt_models[i].zero_grad()
+            gpt_models[i] = None
+        gc.collect()
+        torch.cuda.empty_cache()
+    return captures
 
 
 class TestA2AOverlap:
@@ -361,3 +427,43 @@ class TestA2AOverlap:
             recompute_num_layers,
             microbatches=4,
         )
+
+    @pytest.mark.skipif(not is_te_min_version("1.9.0.dev0"), reason="Requires TE >= 1.9.0.dev0")
+    @pytest.mark.parametrize("dispatcher_type,flex_backend", get_valid_dispatcher_configs())
+    def test_full_recompute_preserves_mtp_input_mask(self, dispatcher_type, flex_backend):
+        """Full recompute is transparent to MTP's input mask.
+
+        ``mtp_input_mask`` is a mutable chunk-state field: MTP's ``_get_embeddings`` rolls
+        it together with ``input_ids`` (one concatenated roll, so CP does a single boundary
+        exchange) and writes both back. A segment snapshot that omits it lets the replay
+        roll an already-rolled mask, shifting it one position against ``input_ids``, and the
+        mask then drives
+        ``torch.where(valid, decoder_input, decoder_input.detach())`` -- so the detached
+        embedding rows are the wrong ones.
+
+        That damage is confined to the embedding gradients: masking never changes a forward
+        value, so outputs and every non-embedding parameter still agree. The comparison is
+        therefore overlap-with-recompute against overlap-without-recompute, both through
+        ``capture_overlap_grads``, rather than against ``GPTModel.forward`` -- the reference
+        path does not agree with the overlap path on embedding gradients even without
+        recompute, so it cannot arbitrate this.
+
+        The mask's False holes are deliberately not symmetric under a one-position shift;
+        otherwise an over-rolled mask would still select the same rows and pass.
+        """
+        base_kwargs = {"mtp_num_layers": 1, "mtp_loss_scaling_factor": 1.1}
+        apply_flex_backend_kwargs(base_kwargs, dispatcher_type, flex_backend)
+        recompute_kwargs = dict(
+            base_kwargs,
+            recompute_granularity="full",
+            recompute_method="uniform",
+            recompute_num_layers=1,
+        )
+
+        eager = capture_overlap_grads([2, 1], base_kwargs, use_mtp_input_mask=True)
+        recomputed = capture_overlap_grads([2, 1], recompute_kwargs, use_mtp_input_mask=True)
+
+        for i in range(len(eager)):
+            assert "embedding.word_embeddings.weight" in eager[i], "embedding grad not captured"
+            comp_res = compare_captures(eager[i], recomputed[i], True, False)
+            assert comp_res[0], f"[rank {torch.distributed.get_rank()}] chunk {i}: {comp_res[1]}"

--- a/tests/unit_tests/a2a_overlap/test_schedule_chunk_1f1b.py
+++ b/tests/unit_tests/a2a_overlap/test_schedule_chunk_1f1b.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 import gc
 
 import pytest
@@ -64,6 +64,106 @@ def build_model(config, use_padding_mask=False):
     return gpt_model, f_schedule_plan, data
 
 
+def run_two_chunk_parity(
+    layers,
+    extra_kwargs,
+    microbatches=1,
+    use_padding_mask=False,
+    on_plans_built=None,
+    on_forward_done=None,
+):
+    """Assert the a2a overlap schedule and the reference forward give the same grads.
+
+    Builds one model per entry in ``layers``, captures reference grads from
+    GPTModel.forward/backward, then replays the same inputs through the 1F1B pattern
+    (chunk0 fwd -> chunk1 fwd + chunk0 bwd -> chunk1 bwd). ``on_plans_built`` is an
+    optional hook for asserting schedule-plan invariants before the overlap run;
+    ``on_forward_done`` runs on chunk 0's plan right after its forward-only pass, i.e.
+    after release_layer_activations().
+    """
+    assert len(layers) == 2, "the 1F1B pattern below is written for exactly two chunks"
+
+    gpt_models = []
+    schedule_plans = []
+    ref_captures = []
+    datas = []
+
+    with deterministic_mode():
+        for layer_num in layers:
+            output_tensors = []
+            # build config
+            config = get_test_config(num_layers=layer_num, extra_kwargs=extra_kwargs)
+            # build model
+            gpt_model, schedule_plan, data = build_model(config, use_padding_mask=use_padding_mask)
+            gpt_model.cuda()
+            gpt_models.append(gpt_model)
+            datas.append(data)
+            schedule_plans.append(schedule_plan)
+
+            # run reference
+            for _ in range(microbatches):
+                loss = gpt_model.forward(**data)
+                loss = float16_to_fp32(loss)
+                loss.backward(torch.ones_like(loss))
+                output_tensors.append(loss)
+
+            capture = {"outputs": output_tensors}
+            for name, param in gpt_model.named_parameters():
+                capture[name] = param.grad
+            ref_captures.append(capture)
+            gpt_model.zero_grad()
+        assert gpt_models[0].embedding is not None
+        assert gpt_models[1].embedding is not None
+        if on_plans_built is not None:
+            on_plans_built(schedule_plans)
+        # run a2a overlap
+        capture_0 = {"outputs": []}
+        capture_1 = {"outputs": []}
+        a2a_captures = [capture_0, capture_1]
+        for i in range(microbatches):
+            # 1st forward
+            if i > 0:
+                assert (
+                    schedule_plans[0].pre_process is None
+                ), "pre_process should be released after backward"
+                schedule_plans[0] = gpt_models[0].build_schedule_plan(**datas[0])
+                schedule_plans[1] = gpt_models[1].build_schedule_plan(**datas[1])
+            f_input_0 = TransformerModelChunkSchedulePlan.run(schedule_plans[0], None)
+            if on_forward_done is not None:
+                on_forward_done(schedule_plans[0])
+            capture_0["outputs"].append(f_input_0)
+            # overlap
+            f_input_1 = TransformerModelChunkSchedulePlan.run(
+                schedule_plans[1], schedule_plans[0], b_grad=torch.ones_like(f_input_0)
+            )
+            capture_1["outputs"].append(f_input_1)
+            # last backward
+            TransformerModelChunkSchedulePlan.run(
+                None, schedule_plans[1], b_grad=torch.ones_like(f_input_1)
+            )
+        for i in range(len(gpt_models)):
+            for name, param in gpt_models[i].named_parameters():
+                a2a_captures[i][name] = param.grad
+
+        # compare results
+        for i in range(len(ref_captures)):
+            comp_res = compare_captures(ref_captures[i], a2a_captures[i], True, True)
+            assert comp_res[0], f"[rank {torch.distributed.get_rank()}] {comp_res[1]}"
+
+        # release resources is necessary, otherwise later testcases will oom
+        for i in range(len(schedule_plans)):
+            schedule_plans[i] = None
+            ref_captures[i] = None
+            a2a_captures[i] = None
+            for k in datas[i]:
+                datas[i][k] = None
+            datas[i] = None
+            gpt_models[i].zero_grad()
+            gpt_models[i] = None
+        gc.collect()
+        torch.cuda.empty_cache()
+
+
 class TestA2AOverlap:
     """
     Test class for all-to-all overlap optimization in transformer models.
@@ -95,13 +195,6 @@ class TestA2AOverlap:
         Verifies all-to-all overlap optimization in transformer layer produces
         the same results as the reference implementation.
         """
-        microbatches = 1
-
-        gpt_models = []
-        schedule_plans = []
-        ref_captures = []
-        datas = []
-
         # create TransformerConfig
         extra_kwargs = {}
         apply_flex_backend_kwargs(extra_kwargs, dispatcher_type, flex_backend)
@@ -111,76 +204,7 @@ class TestA2AOverlap:
         if mtp_layers > 0:
             extra_kwargs["mtp_num_layers"] = mtp_layers
             extra_kwargs["mtp_loss_scaling_factor"] = 1.1
-        with deterministic_mode():
-            for layer_num in layers:
-                output_tensors = []
-                # build config
-                config = get_test_config(num_layers=layer_num, extra_kwargs=extra_kwargs)
-                # build model
-                gpt_model, schedule_plan, data = build_model(config)
-                gpt_model.cuda()
-                gpt_models.append(gpt_model)
-                datas.append(data)
-                schedule_plans.append(schedule_plan)
-
-                # run reference
-                for _ in range(microbatches):
-                    loss = gpt_model.forward(**data)
-                    loss = float16_to_fp32(loss)
-                    loss.backward(torch.ones_like(loss))
-                    output_tensors.append(loss)
-
-                capture = {"outputs": output_tensors}
-                for name, param in gpt_model.named_parameters():
-                    capture[name] = param.grad
-                ref_captures.append(capture)
-                gpt_model.zero_grad()
-            assert gpt_models[0].embedding is not None
-            assert gpt_models[1].embedding is not None
-            # run a2a overlap
-            capture_0 = {"outputs": []}
-            capture_1 = {"outputs": []}
-            a2a_captures = [capture_0, capture_1]
-            for i in range(microbatches):
-                # 1st forward
-                if i > 0:
-                    assert (
-                        schedule_plans[0].pre_process is None
-                    ), "pre_process should be released after backward"
-                    schedule_plans[0] = gpt_models[0].build_schedule_plan(**datas[0])
-                    schedule_plans[1] = gpt_models[1].build_schedule_plan(**datas[1])
-                f_input_0 = TransformerModelChunkSchedulePlan.run(schedule_plans[0], None)
-                capture_0["outputs"].append(f_input_0)
-                # overlap
-                f_input_1 = TransformerModelChunkSchedulePlan.run(
-                    schedule_plans[1], schedule_plans[0], b_grad=torch.ones_like(f_input_0)
-                )
-                capture_1["outputs"].append(f_input_1)
-                # last backward
-                TransformerModelChunkSchedulePlan.run(
-                    None, schedule_plans[1], b_grad=torch.ones_like(f_input_1)
-                )
-            for i in range(len(gpt_models)):
-                for name, param in gpt_models[i].named_parameters():
-                    a2a_captures[i][name] = param.grad
-
-            # compare results
-            for i in range(len(ref_captures)):
-                comp_res = compare_captures(ref_captures[i], a2a_captures[i], True, True)
-                assert comp_res[0], f"[rank {torch.distributed.get_rank()}] {comp_res[1]}"
-
-            # release resources is necessary, otherwise later testcases will oom
-            for i in range(len(schedule_plans)):
-                schedule_plans[i] = None
-                ref_captures[i] = None
-                a2a_captures[i] = None
-                for k in datas[i]:
-                    datas[i][k] = None
-                datas[i] = None
-                gpt_models[i].zero_grad()
-                gpt_models[i] = None
-            gc.collect()
-            torch.cuda.empty_cache()
+        run_two_chunk_parity(layers, extra_kwargs)
 
     @pytest.mark.skipif(not is_te_min_version("1.9.0.dev0"), reason="Requires TE >= 1.9.0.dev0")
     @pytest.mark.parametrize("dispatcher_type,flex_backend", get_valid_dispatcher_configs())
@@ -203,83 +227,76 @@ class TestA2AOverlap:
         )
         set_streams()
 
-        microbatches = 1
-
-        gpt_models = []
-        schedule_plans = []
-        ref_captures = []
-        datas = []
-
         # create TransformerConfig
         extra_kwargs = {"tensor_model_parallel_size": tp_size, "sequence_parallel": tp_size > 1}
         apply_flex_backend_kwargs(extra_kwargs, dispatcher_type, flex_backend)
-        with deterministic_mode():
-            for layer_num in layers:
-                output_tensors = []
-                # build config
-                config = get_test_config(num_layers=layer_num, extra_kwargs=extra_kwargs)
-                # build model with padding_mask
-                gpt_model, schedule_plan, data = build_model(config, use_padding_mask=True)
-                gpt_model.cuda()
-                gpt_models.append(gpt_model)
-                datas.append(data)
-                schedule_plans.append(schedule_plan)
+        run_two_chunk_parity(layers, extra_kwargs, use_padding_mask=True)
 
-                # run reference
-                for _ in range(microbatches):
-                    loss = gpt_model.forward(**data)
-                    loss = float16_to_fp32(loss)
-                    loss.backward(torch.ones_like(loss))
-                    output_tensors.append(loss)
+    @pytest.mark.skipif(not is_te_min_version("1.9.0.dev0"), reason="Requires TE >= 1.9.0.dev0")
+    @pytest.mark.parametrize("mtp_layers", [0, 1])
+    @pytest.mark.parametrize("dispatcher_type,flex_backend", get_valid_dispatcher_configs())
+    @pytest.mark.parametrize("fp8_flag", get_valid_fp8_flags())
+    @pytest.mark.parametrize(
+        "recompute_method,recompute_num_layers",
+        [
+            ("uniform", 1),
+            ("uniform", 2),
+            # 'block' leaves trailing layers eager, pinning the recomputed -> eager
+            # hand-off: n=1 keeps layers 1.. eager, n=3 recomputes the whole decoder.
+            ("block", 1),
+            ("block", 3),
+        ],
+    )
+    def test_1f1b_schedule_model_chunk_full_recompute(
+        self,
+        mtp_layers,
+        dispatcher_type,
+        flex_backend,
+        fp8_flag,
+        recompute_method,
+        recompute_num_layers,
+    ):
+        """Layer-level full recompute matches the non-overlap reference, which checkpoints
+        through checkpointed_forward / MTP _checkpointed_forward with the same config.
+        """
+        if mtp_layers > 0 and not (recompute_method == "uniform" and recompute_num_layers == 1):
+            # Otherwise the non-overlap reference warns and skips MTP recompute, so the
+            # two paths are not comparable.
+            pytest.skip("MTP recompute requires recompute_method='uniform' with num_layers=1")
 
-                capture = {"outputs": output_tensors}
-                for name, param in gpt_model.named_parameters():
-                    capture[name] = param.grad
-                ref_captures.append(capture)
-                gpt_model.zero_grad()
-            assert gpt_models[0].embedding is not None
-            assert gpt_models[1].embedding is not None
-            # run a2a overlap
-            capture_0 = {"outputs": []}
-            capture_1 = {"outputs": []}
-            a2a_captures = [capture_0, capture_1]
-            for i in range(microbatches):
-                # 1st forward
-                if i > 0:
-                    assert (
-                        schedule_plans[0].pre_process is None
-                    ), "pre_process should be released after backward"
-                    schedule_plans[0] = gpt_models[0].build_schedule_plan(**datas[0])
-                    schedule_plans[1] = gpt_models[1].build_schedule_plan(**datas[1])
-                f_input_0 = TransformerModelChunkSchedulePlan.run(schedule_plans[0], None)
-                capture_0["outputs"].append(f_input_0)
-                # overlap
-                f_input_1 = TransformerModelChunkSchedulePlan.run(
-                    schedule_plans[1], schedule_plans[0], b_grad=torch.ones_like(f_input_0)
-                )
-                capture_1["outputs"].append(f_input_1)
-                # last backward
-                TransformerModelChunkSchedulePlan.run(
-                    None, schedule_plans[1], b_grad=torch.ones_like(f_input_1)
-                )
-            for i in range(len(gpt_models)):
-                for name, param in gpt_models[i].named_parameters():
-                    a2a_captures[i][name] = param.grad
+        extra_kwargs = {
+            "recompute_granularity": "full",
+            "recompute_method": recompute_method,
+            "recompute_num_layers": recompute_num_layers,
+        }
+        apply_flex_backend_kwargs(extra_kwargs, dispatcher_type, flex_backend)
+        if fp8_flag is not None:
+            extra_kwargs["fp8"] = fp8_flag[0]
+            extra_kwargs["fp8_recipe"] = fp8_flag[1]
+        if mtp_layers > 0:
+            extra_kwargs["mtp_num_layers"] = mtp_layers
+            extra_kwargs["mtp_loss_scaling_factor"] = 1.1
 
-            # compare results
-            for i in range(len(ref_captures)):
-                comp_res = compare_captures(ref_captures[i], a2a_captures[i], True, True)
-                assert comp_res[0], f"[rank {torch.distributed.get_rank()}] {comp_res[1]}"
+        def assert_segments_were_built(schedule_plans):
+            # Guard against degrading into the plain overlap test.
+            for plan in schedule_plans:
+                assert len(plan._recompute_segments) > 0, "no recompute segments were built"
 
-            # release resources is necessary, otherwise later testcases will oom
-            for i in range(len(schedule_plans)):
-                schedule_plans[i] = None
-                ref_captures[i] = None
-                a2a_captures[i] = None
-                for k in datas[i]:
-                    datas[i][k] = None
-                datas[i] = None
-                gpt_models[i].zero_grad()
-                gpt_models[i] = None
-            gc.collect()
-            torch.cuda.empty_cache()
+        def assert_activations_were_released(plan):
+            # The point of the feature: after the chunk forward a recomputed layer holds
+            # no activation and only its segment's input survives. Gradient parity alone
+            # cannot catch a regression here - recompute is numerically transparent, so a
+            # segment that quietly kept its graph would still compare equal.
+            for segment in plan._recompute_segments:
+                assert segment.input_tensor is not None, "segment input was not retained"
+                for layer in segment.layers:
+                    for node in layer._iter_recomputed_nodes():
+                        assert node.output is None, f"{node.name} kept its forward output"
+                        assert node.inputs is None, f"{node.name} kept its forward inputs"
+
+        run_two_chunk_parity(
+            [3, 2],
+            extra_kwargs,
+            on_plans_built=assert_segments_were_built,
+            on_forward_done=assert_activations_were_released,
+        )


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

> Main-branch counterpart of dev PR NVIDIA/Megatron-LM#6311.
>
> **This supersedes and fully covers NVIDIA/Megatron-LM#5920** (the main-branch
> port of the older, model-chunk-granularity design). #5920 can be closed in
> favour of this PR — everything it added to `main` is contained here, with the
> recompute unit changed from *VPP stage* to *layer segment*.

# What does this PR do ?

Adds full activation recompute support for the EP A2A overlap path
(`--overlap-moe-expert-parallel-comm`), which currently hard-asserts
`recompute_granularity=full` off.

Recompute is applied at **layer-segment** granularity: a segment's layers drop
their activations as soon as that segment has finished forwarding, and the
segment is replayed with grad enabled immediately before its own backward (whose
nodes release again as they backward). So only one segment's activations are
materialized at a time, and only each segment's input tensor survives the
forward→backward gap.

## Issue tracking

Linked issue: <!-- internal NVIDIA contribution; add issue link if required -->

## Semantics

`recompute_method` / `recompute_num_layers` mean exactly the same thing with and
without `--overlap-moe-expert-parallel-comm`, mirroring
`megatron.core.recompute.checkpointed_forward` (decoder) and
`MultiTokenPredictionLayer._checkpointed_forward` (MTP):

* `uniform`: decoder layers in groups of `recompute_num_layers`; one segment per
  MTP layer (`recompute_num_layers` must be 1 when MTP is present, as upstream).
* `block`: the first `recompute_num_layers` decoder layers, one segment each;
  trailing decoder layers stay eager.

Both flags are therefore **required** on this path, exactly as on the non-overlap
path — no validation exemption is introduced. (#5920 did add such an exemption,
because it recomputed the whole model chunk as a single unit; that is gone here.)

## Design

* The initial forward of a recomputed layer's nodes runs under `no_grad`
  (`ScheduleNode.forward_no_grad`), so no autograd graph / saved activation is
  retained. `pre_process` / `post_process` keep their graphs.
* `RecomputeSegment` captures, at the head layer's forward: the segment input
  tensor, an RNG snapshot, and a snapshot of the mutable `ModelChunkState`
  fields (`input_ids` / `position_ids` / `padding_mask` / `mtp_hidden_states`) —
  these are mutated in place during the forward (MTP rolls the tokens), so by
  backward time they hold end-of-chunk values rather than what the segment saw.
* At the tail layer's backward, `RecomputeSegment.recompute()` replays the
  segment by re-invoking the **same** `ScheduleNode` objects in forward order, so
  each node repopulates its own `inputs` / `output` / `detached` / `layer_state`.
  The activation→node mapping is therefore implicit and needs no bookkeeping.
* `RecomputeSegment.release_activations()` unsets the segment's nodes'
  `inputs` / `output` / `detached` as soon as its tail layer has forwarded,
  rather than at the end of the chunk forward — otherwise each recomputed layer
  would keep one set of boundary tensors pinned for the remainder of the forward.
  Only the references are dropped; the storages are deliberately left intact,
  since the replay rebuilds the autograd graph on top of those very tensors and
  resizing them (the trick `ScheduleNode`'s `free_input` path and
  `tensor_parallel.random.checkpoint` use) corrupts it. On the way back,
  `ScheduleNode._release_state()` already frees each replayed node as it
  backwards.
* The A2A issued by a replay is **exposed** (not overlapped) by design; the
  normal forward and normal backward A2A overlap is fully preserved.

### Why a segment object rather than a `checkpoint()` wrapper

The non-overlap path can wrap a layer in `tensor_parallel.random.checkpoint`
because a layer is an opaque callable there. Under EP A2A overlap a layer is
decomposed into `ScheduleNode`s (`pre_dispatch_computation` / `moe_dispatch` /
`mlp` / `moe_combine` / `mtp_post_process`) that the 1F1B scheduler interleaves
with *other microbatches'* nodes — which is the whole point of the overlap path.
`checkpoint()` needs its region to run as one contiguous autograd call and to
backward as one contiguous unit, so the replay has to be driven by the scheduler
at segment-backward time instead.

`mtp_post_process` is inside the recompute scope: it builds a
`torch.cat(mtp_hidden_states)` over the MTP `pre_dispatch_computation` node's
detached input, so excluding it would anchor that `cat` on a `no_grad` leaf and
silently drop the decoder's gradient through MTP.

## Constraints (asserted)

Under `overlap_moe_expert_parallel_comm` + `recompute_granularity=full`:

* `distribute_saved_activations` must be off — the replay is hand-rolled rather
  than a checkpoint primitive, so the retained segment input is not TP-sharded.
* `attention_dropout == 0` and `hidden_dropout == 0` — the forward RNG stream is
  interleaved across microbatches in the 1F1B schedule and cannot yet be
  faithfully replayed for nonzero dropout.
* Delayed-scaling FP8 (`fp8` set and `fp8_recipe='delayed'`) is rejected — the
  amax history is persistent across microbatches, and this path does not enter
  TE's `recompute_phase` machinery that `te_checkpoint` uses to snapshot and
  restore FP8 metadata, so the replayed forward would update `amax_history` a
  second time and silently diverge. The current-scaling recipes (`tensorwise` /
  `mxfp8` / `blockwise`) re-derive their scales from the current tensor each
  pass, so the replay reproduces them exactly; those are the recipes the parity
  tests sweep. The assert is gated on `fp8` being set, because `fp8_recipe`
  defaults to `'delayed'` in BF16 configs where no FP8 autocast runs at all.
* Not yet supported (asserted off, left as follow-up): Megatron FSDP, CUDA graphs
  (`cuda_graph_impl != "none"`), `moe_paged_stash`, and
  `fine_grained_activation_offloading` (the offload manager pairs a
  forward-pushed group with the backward that pops it; the replay pushes its
  groups immediately before its own backward, which does not fit that pairing).

The last one is main-only — `dev` has no fine-grained activation offloading, so
it has no counterpart in #6311.

## Differences from the dev PR (#6311)

* Node naming: the attention node is `pre_dispatch_computation` on `main`
  (`attn` on `dev`), and `TransformerLayerNode` lives in
  `megatron/core/models/common/utils.py`.
* `main` has no multi-hyper-connection (mHC) support, so the `mhc_multistream`
  detach-bridge gradient carry-over from #6311 has no counterpart here and is
  omitted.
* `main`'s token dispatchers have no `reset_transient_forward_state()` (that
  arrived on `dev` via #5869), so the per-layer dispatcher routing metadata is
  not additionally freed across the gap. This is a memory refinement only —
  the replay repopulates it unconditionally — and is left as a follow-up.
* Adds the `fine_grained_activation_offloading` assert described above.
* Releases each segment's activations at its own tail-layer forward rather than
  at the end of the chunk forward, and adds the four-microbatch parity case.
  #6311 still does both at chunk granularity / one microbatch; it will be
  brought in line separately.

## Test results

Unit tests, 8×H100 (EOS), CI container (`docker/Dockerfile.ci.dev`, `--target
main`) via the same `tests/unit_tests/run_ci_test.sh` entry point CI uses:

`tests/unit_tests/a2a_overlap/test_schedule_chunk_1f1b.py` — **156 passed,
40 skipped, 0 failed** (9m35s).

Whole-directory regression (the change touches shared code: `ScheduleNode`, the
layer schedule plan), bucket `tests/unit_tests/a2a_overlap/**/*.py` —
**251 passed, 41 skipped, 2 deselected, 0 failed** (19m00s), covering
`test_schedule_chunk_1f1b.py`, `test_schedule_layer_1f1b.py`,
`test_delay_wgrad_compute.py` and `test_fsdp_1f1b_overlap.py`.

The new cases are
`TestA2AOverlap::test_1f1b_schedule_model_chunk_full_recompute` and
`..._full_recompute_multi_microbatch`, which compare gradients from
`TransformerModelChunkSchedulePlan.run` against the non-overlap
`gpt_model.forward` reference under the *same* recompute config, parametrized
over `mtp_layers` 0/1, `get_valid_dispatcher_configs()` and
`get_valid_fp8_flags()`. The first sweeps the full segmentation matrix
(`(uniform,1) (uniform,2) (block,1) (block,3)`) at one microbatch; the second
runs four microbatches over `(uniform,1)` and `(block,1)`, so the same modules
go through forward → recompute → backward repeatedly as in a real 1F1B steady
state and grads accumulate across the four rounds on both paths before the
bitwise compare. One microbatch cannot catch state the replay leaves behind for
the next round to read (FP8 scaling metadata, a segment's RNG snapshot, a node
whose `forward_no_grad` was not restored). The 40 skips are the
MTP × non-`(uniform,1)` combinations, where the non-overlap reference warns and
skips MTP recompute and the two paths are not comparable.

Beyond gradient parity the tests also assert the feature actually happened:
after each chunk forward, every recomputed node has `inputs is None` and
`output is None` while its segment's input tensor is retained. Recompute is
numerically transparent, so a segment that quietly kept its graph would still
compare equal.

The whole file carries `pytestmark = pytest.mark.flaky_in_dev`, so these runs
used `--environment lts` (marker `not flaky`) to actually execute them; under
`--environment dev` the file is deselected wholesale.

The two pre-existing tests in the file were refactored onto a shared
`run_two_chunk_parity()` helper (no behavioural change) so the new test reuses
the same 1F1B pattern.

For the algorithm's bitwise E2E evidence (DeepSeek-V3-Lite deterministic recipe:
BF16 / blockwise-FP8 / MXFP8, with and without MTP, overlap vs non-overlap
100/100 bitwise-identical) see the dev PR NVIDIA/Megatron-LM#6311, which
implements the same segmentation and replay.

## Benchmark: this recompute path against the non-overlap one

The question this section answers is narrow on purpose: **with full recompute
enabled, is the EP A2A overlap schedule still faster than the non-overlap path
it has to compete with?** The exposed replay A2A is a real cost, so it is worth
showing that it does not eat the overlap gain.

Three arms, all on this branch, 64×H100 (8 nodes). DeepSeek-V3 shape at 14
layers with the real 256-expert MoE and MTP 1, TP1 / PP4 / EP16, pipeline layout
`Ett|(tt|)*6mL`, alltoall dispatcher, seq 2048, MBS 1, GBS 256 (16 microbatches),
BF16, 30 iterations with the first 5 dropped as warmup. `recompute` means
`recompute_granularity=full`, `recompute_method=uniform`,
`recompute_num_layers=1`.

| | TFLOP/s/GPU (median) | iter (ms, mean) | peak allocated | peak reserved | device memory used |
|---|---|---|---|---|---|
| B. **this path** — overlap on, recompute on | **199.5** | 2839 | 60,378 MB | 68,392 MB | 74,803 MB |
| C. non-overlap baseline — overlap off, recompute on | 185.2 | 3044 | 60,154 MB | 62,570 MB | 68,973 MB |
| A. overlap on, recompute off (context) | 32.8 | 16985 | 70,279 MB | 75,594 MB | 79,677 MB |

### B vs C — the result this PR rests on

**+7.7 % throughput** (199.5 vs 185.2 TFLOP/s/GPU) at the same recompute
setting. The segment replay's exposed A2A does not cancel the overlap gain, so
enabling full recompute on the overlap path leaves it ahead of the non-overlap
path rather than behind it.

The two arms reach the same *allocated* peak (60,378 vs 60,154 MB, +0.4 %):
recompute drops the same activations either way, and the segment inputs the
replay retains are small next to what is dropped. That equality is also a useful
check on the feature — the segmentation is not quietly retaining more than the
non-overlap checkpoint path does. The overlap arm's cost shows up in *reserved*
memory (+5.8 GB), which is the schedule's own multi-stream working set rather
than anything recompute adds.

One methodological caveat: `CUDA_DEVICE_MAX_CONNECTIONS` is 32 on the overlap
arms and 1 on the non-overlap arm. `moe/README.md` lists `> 1` as a requirement
of EP A2A overlap, so running the overlap arm at 1 would measure a configuration
the feature does not support; 1 is the baseline recipe's value for everything
else. B vs C is therefore a best-configuration comparison rather than a
single-variable one.

### Arm A is context, not a result

Arm A is included only to show why recompute is on at all here. Without it this
configuration reaches 79.7 GB of device memory on the heaviest PP stage — 98 %
of the 80 GB card — and throughput collapses to a memory-bound 32 TFLOP/s/GPU,
flat across all 30 iterations. That reproduced exactly on a second run on a
disjoint node set (peak allocated identical to the MB), so it is the allocator
working against a full card rather than a fluke.

**The 6× gap between A and B is a memory-pressure effect and should not be read
as "recompute makes training 6× faster."** What it does establish is that at
this scale the configuration does not practically run without recompute.
Isolating the replay A2A's own cost would need a configuration where the
recompute-off arm fits comfortably; that measurement is not included here.

## Contribution process

### Pre-checks
- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code
- [x] I have added relevant documentation (inline comments / docstrings)
- [x] I have run the autoformatter.sh on my PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

