### PR TITLE
ci(auth): treat svcnemo-autobot as internal

### DIFF
--- a/.github/actions/check-nvidia-sso-membership/action.yml
+++ b/.github/actions/check-nvidia-sso-membership/action.yml
@@ -1,5 +1,5 @@
 name: 'Check NVIDIA SSO Membership'
-description: 'Check if a GitHub username exists in the NVIDIA SSO users list from github-audits'
+description: 'Check if a GitHub username is in the NVIDIA SSO users list or internal allowlist'
 author: 'NVIDIA'
 
 inputs:
@@ -24,7 +24,7 @@ inputs:
 
 outputs:
   is_member:
-    description: 'Boolean - true if user is in NVIDIA SSO list, false otherwise'
+    description: 'Boolean - true if user is in NVIDIA SSO list or internal allowlist, false otherwise'
     value: ${{ steps.check-membership.outputs.is_member }}
   is_org_member:
     description: 'Boolean - true if user has NVIDIA or NVIDIA-NeMo in org_roles'
@@ -90,6 +90,15 @@ runs:
         SSO_FILE="${{ inputs.sso_users_filename }}"
 
         echo "Checking if $USERNAME is in NVIDIA SSO users list..."
+
+        # Service accounts cannot enroll in SSO but can be explicitly trusted.
+        if [ "$USERNAME" = "svcnemo-autobot" ]; then
+          echo "$USERNAME found in NVIDIA internal user allowlist"
+          echo "is_member=true" >> $GITHUB_OUTPUT
+          echo "is_org_member=false" >> $GITHUB_OUTPUT
+          echo "user_orgs=" >> $GITHUB_OUTPUT
+          exit 0
+        fi
 
         # Check if SSO file is available
         if [ "${{ steps.download-sso.outputs.sso_file_available }}" != "true" ] || [ ! -f "$SSO_FILE" ]; then


### PR DESCRIPTION
## Background / motivation

- svcnemo-autobot is an internal service account but cannot enroll in NVIDIA GitHub SSO.
- The SSO-only check classifies its fork PRs as external.

## What changed

- Add svcnemo-autobot to the internal user allowlist.
- Document that is_member includes allowlisted internal accounts.

## Details

- .github/actions/check-nvidia-sso-membership/action.yml returns is_member=true, is_org_member=false, and an empty user_orgs value for svcnemo-autobot.
- Preserve SSO membership behavior for every other username.

## Tested

- git diff --check — passed.
- yq metadata assertion — composite action YAML parsed and expected check-membership step was present.
- Bash behavioral harness extracted the check-membership script with yq — allowlisted service account, SSO member, and external user assertions passed.
- actionlint — repository-wide check reports existing failures in unchanged workflow files; this PR does not modify .github/workflows.