### PR TITLE
Track DBuffer allocation stream

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -67,6 +67,10 @@ class DBuffer:
     layout: GlobalLayout
     offset: int
     local_buffer: torch.Tensor
+    # Record the allocation stream so DBuffer users can check that uses are joined back to it
+    # before deleting the buffer. See https://github.com/NVIDIA/Megatron-LM/pull/6187 and
+    # https://docs.pytorch.org/docs/2.13/generated/torch.Tensor.record_stream.html.
+    allocation_stream: torch.cuda.Stream | None
 
     def __init__(
         self,
@@ -100,6 +104,11 @@ class DBuffer:
 
         self.offset, local_numel = self.layout.get_local_range(self.mesh, self.placements)
         self.local_buffer = torch.empty(local_numel, dtype=dtype, device=device)
+        self.allocation_stream = (
+            torch.cuda.current_stream(self.local_buffer.device)
+            if self.local_buffer.is_cuda
+            else None
+        )
 
     @property
     def dtype(self) -> torch.dtype:
@@ -155,6 +164,8 @@ class DBuffer:
         mesh: DeviceMesh,
         placements: Iterable[Placement],
         tensor_shapes: Iterable[Shape],
+        *,
+        allocation_stream: torch.cuda.Stream | None,
     ) -> "DBuffer":
         """Create a DBuffer from an existing local buffer.
 
@@ -165,6 +176,7 @@ class DBuffer:
             mesh: Device mesh whose dimensions correspond to ``placements``.
             placements: Per-mesh-axis DBuffer placements.
             tensor_shapes: Global shapes for each logical tensor in this buffer.
+            allocation_stream: CUDA stream that allocated ``local_buffer``, or ``None`` for CPU.
 
         Returns:
             A DBuffer that reuses ``local_buffer`` without allocating storage.
@@ -195,6 +207,7 @@ class DBuffer:
         buffer.layout = layout
         buffer.offset = offset
         buffer.local_buffer = local_buffer
+        buffer.allocation_stream = allocation_stream
         return buffer
 
     @classmethod
@@ -340,7 +353,11 @@ class DBuffer:
                     "Replicate -> Partial redistribute does not support an out buffer."
                 )
             return DBuffer.from_local(
-                self.local_buffer, self.mesh, new_placements, self.layout.tensor_shapes
+                self.local_buffer,
+                self.mesh,
+                new_placements,
+                self.layout.tensor_shapes,
+                allocation_stream=self.allocation_stream,
             )
         raise NotImplementedError(
             "Unsupported DBuffer placement transition on axis "
@@ -450,7 +467,13 @@ class DBuffer:
             raise RuntimeError("scatter() destination is not contained in the source local buffer.")
         local_slice = self.local_buffer.narrow(0, local_buffer_offset, destination_numel)
         if out is None:
-            return DBuffer.from_local(local_slice, self.mesh, placements, self.layout.tensor_shapes)
+            return DBuffer.from_local(
+                local_slice,
+                self.mesh,
+                placements,
+                self.layout.tensor_shapes,
+                allocation_stream=self.allocation_stream,
+            )
 
         out.local_buffer.copy_(local_slice)
         return out

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -358,6 +358,9 @@ class FsdpParameterGroup:
         # DP-outer-Partial accumulation placement -- a metadata relabel for HSDP,
         # and a fresh reduce-scattered buffer for HFSDP in the future.
         if self.main_grad.placements != self._accumulation_placements:
+            assert self.main_grad.allocation_stream == (
+                torch.cuda.current_stream(self.main_grad.device)
+            )
             self.main_grad = self.main_grad.redistribute(self._accumulation_placements)
 
         can_reduce_into_main_grad = (
@@ -389,6 +392,9 @@ class FsdpParameterGroup:
         if is_last_microbatch:
             # Finalize the deferred DP-outer reduction (all-reduce for HSDP,
             # reduce-scatter for HFSDP) before binding the sharded parameter grads.
+            assert self.main_grad.allocation_stream == (
+                torch.cuda.current_stream(self.main_grad.device)
+            )
             self.main_grad = self.main_grad.redistribute(self.main_weight.placements)
 
         # Make each sharded parameter's .grad consistent with the final main_grad.

--- a/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py
@@ -240,7 +240,11 @@ def test_from_local_reuses_required_local_buffer(distributed_setup):
     local_buffer = replicated_buffer.local_buffer.narrow(0, offset, local_numel)
 
     sharded_buffer = DBuffer.from_local(
-        local_buffer, mesh, iter([Flat()]), replicated_buffer.layout.tensor_shapes
+        local_buffer,
+        mesh,
+        iter([Flat()]),
+        replicated_buffer.layout.tensor_shapes,
+        allocation_stream=replicated_buffer.allocation_stream,
     )
 
     assert sharded_buffer.placements == (Flat(),)


### PR DESCRIPTION
## Summary

Track each `DBuffer` allocation stream, preserve it when `from_local()` aliases existing storage, and check it before `main_grad` is redistributed and replaced.

## Why

An asynchronous use can outlive work on a buffer's allocation stream. Before deleting or replacing the buffer, its owner must join those uses back to the allocation stream. This follows the stream-lifetime guidance in [PyTorch `Tensor.record_stream`](https://docs.pytorch.org/docs/2.13/generated/torch.Tensor.record_stream.html).

`DBuffer.from_local()` cannot infer allocation provenance from a tensor, so it now requires callers to provide it explicitly. Both production aliasing paths forward the source buffer's allocation stream. This catches the stream-lifetime race addressed by [PR #6187](https://github.com/NVIDIA/Megatron-LM/pull/6187) at the relevant `main_grad` replacement boundaries, rather than using a Python destructor check.

## Validation

- `python -m torch.distributed.run --nproc-per-node 2 -m pytest -q tests/unit_tests/distributed/mfsdp_v2/test_dbuffer.py --capture=fd`
  - 22 passed; 6 topology-dependent cases skipped.
- `python -m torch.distributed.run --nproc-per-node 2 -m pytest -q tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py -k "fully_shard_sgd_losses_match_baseline or fully_shard_adam_mixed_precision_losses_match_baseline or hsdp" --capture=fd`
  - 3 passed; 5 HSDP/HFSDP cases skipped because this host has two GPUs.
- `black` and `ruff check` on changed files.
- `git diff --check`