### PR TITLE
ci: publish Linear project overview

### DIFF
--- a/.gitlab/cerno.yml
+++ b/.gitlab/cerno.yml
@@ -7,6 +7,8 @@ gitlab:
 modules:
   megatron_lm:
     build_module: megatron-lm
+    display_name: Megatron-LM
+    grafana_dashboard_url: https://grafana.nvidia.com/d/ccel3m7ntzqkke/megatron-lm-ci
     channel_id_env: MCORE_SLACK_CHANNEL_ID
     reconcile_proposal: true
     team_key: MCORE

--- a/.gitlab/stages/06.triage.yml
+++ b/.gitlab/stages/06.triage.yml
@@ -69,6 +69,31 @@ triage:linear_write:
       when: always
     - when: never
 
+triage:linear_overview:
+  extends: [.linear_triage_job]
+  needs:
+    - job: functional:x_notify
+      artifacts: true
+    - job: triage:linear_write
+      artifacts: true
+  allow_failure: true
+  script:
+    - >-
+      cerno-linear overview
+      --config "${CERNO_CONFIG}"
+      --pipeline-summaries pipeline_summaries.json
+      --failure-buckets failure_buckets.json
+      --linear-report linear_status_report.json
+      --plan linear_action_plan_post.json
+  rules:
+    - if: >-
+        ($CI_PIPELINE_SOURCE == "schedule" || $CI_COMMIT_BRANCH == "main") &&
+        $FUNCTIONAL_TEST == "yes" &&
+        $RUN_LINEAR_STATUS == "True" &&
+        $RUN_LINEAR_WRITE == "True"
+      when: always
+    - when: never
+
 triage:slack_linear_followup:
   extends: [.linear_triage_job]
   needs:
@@ -76,6 +101,8 @@ triage:slack_linear_followup:
       artifacts: true
     - job: triage:linear_write
       artifacts: true
+    - job: triage:linear_overview
+      artifacts: false
   allow_failure: true
   script:
     - >-

--- a/docker/Dockerfile.linting
+++ b/docker/Dockerfile.linting
@@ -24,7 +24,7 @@ RUN --mount=type=secret,id=JET_INDEX_URLS \
 
 # Keep this in the internal-only stage so public CI has no internal service dependency.
 ARG CI_SERVER_URL
-ARG CERNO_COMMIT=5a5fb5360e67f8f09d189871bbc0d768c09c43fa
+ARG CERNO_COMMIT=681545020f385d895652431542813c9700e09a8d
 RUN --mount=type=secret,id=CERNO_TOKEN \
       GIT_CONFIG_COUNT=1 \
       GIT_CONFIG_KEY_0=http.extraHeader \

--- a/tests/test_utils/test_ci_triage.py
+++ b/tests/test_utils/test_ci_triage.py
@@ -126,10 +126,10 @@ def test_cerno_hard_cutover_contract():
     build_script = Path(".gitlab/scripts/build.sh").read_text()
 
     assert pipeline["variables"]["CERNO_CONFIG"] == ".gitlab/cerno.yml"
-    assert triage.count("cerno-linear") == 3
+    assert triage.count("cerno-linear") == 4
     assert triage.count("cerno-notify") == 2
-    assert triage.count('--config "${CERNO_CONFIG}"') == 3
-    assert "ARG CERNO_COMMIT=5a5fb5360e67f8f09d189871bbc0d768c09c43fa" in dockerfile
+    assert triage.count('--config "${CERNO_CONFIG}"') == 4
+    assert "ARG CERNO_COMMIT=681545020f385d895652431542813c9700e09a8d" in dockerfile
     assert '"cerno @ git+${CI_SERVER_URL}/dl/nemo/cerno.git@${CERNO_COMMIT}"' in dockerfile
     assert "id=CERNO_TOKEN" in dockerfile
     assert "/run/secrets/CERNO_TOKEN" in dockerfile
@@ -156,12 +156,46 @@ def test_notification_rules_use_expected_pipeline_sources():
         '$FUNCTIONAL_TEST == "yes"'
     )
 
-    triage_jobs = (".linear_reconcile_rules", "triage:linear_write", "triage:slack_linear_followup")
+    triage_jobs = (
+        ".linear_reconcile_rules",
+        "triage:linear_write",
+        "triage:linear_overview",
+        "triage:slack_linear_followup",
+    )
     for job_name in triage_jobs:
         condition = triage[job_name]["rules"][0]["if"]
         assert '$FUNCTIONAL_TEST == "yes"' in condition
         assert '$CI_PIPELINE_SOURCE == "schedule"' in condition
         assert '$CI_COMMIT_BRANCH == "main"' in condition
+
+
+def test_linear_overview_uses_explicit_upstream_artifacts():
+    functional = yaml.safe_load(Path(".gitlab/stages/04.functional-tests.yml").read_text())
+    triage = yaml.safe_load(Path(".gitlab/stages/06.triage.yml").read_text())
+    overview = triage["triage:linear_overview"]
+
+    assert overview["needs"] == [
+        {"job": "functional:x_notify", "artifacts": True},
+        {"job": "triage:linear_write", "artifacts": True},
+    ]
+    assert {"pipeline_summaries.json", "failure_buckets.json"} <= set(
+        functional["functional:x_notify"]["artifacts"]["paths"]
+    )
+    assert {"linear_status_report.json", "linear_action_plan_post.json"} <= set(
+        triage["triage:linear_write"]["artifacts"]["paths"]
+    )
+    assert overview["rules"] == triage["triage:linear_write"]["rules"]
+    assert overview["script"] == [
+        'cerno-linear overview --config "${CERNO_CONFIG}" '
+        "--pipeline-summaries pipeline_summaries.json "
+        "--failure-buckets failure_buckets.json "
+        "--linear-report linear_status_report.json "
+        "--plan linear_action_plan_post.json"
+    ]
+    assert "cerno-linear write" not in overview["script"][0]
+    assert {"job": "triage:linear_overview", "artifacts": False} in triage[
+        "triage:slack_linear_followup"
+    ]["needs"]
 
 
 def test_all_generated_test_types_enable_error_extraction():
@@ -392,6 +426,10 @@ def test_triage_config_selects_megatron_and_enables_write_actions():
             linear_ci.LINEAR_MODULE,
             {
                 "build_module": "megatron-lm",
+                "display_name": "Megatron-LM",
+                "grafana_dashboard_url": (
+                    "https://grafana.nvidia.com/d/ccel3m7ntzqkke/megatron-lm-ci"
+                ),
                 "channel_id_env": "MCORE_SLACK_CHANNEL_ID",
                 "reconcile_proposal": True,
                 "team_key": "MCORE",


### PR DESCRIPTION
- [ ] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Adds a final Cerno Linear project-overview phase to the existing internal functional-test triage flow and pins Cerno to the immutable implementation commit. The new job publishes a `Megatron-LM` CI overview with the Grafana dashboard link after issue writes, and the Linear Slack follow-up waits for overview completion.

The overview job has explicit direct artifact dependencies on both the functional collector and Linear writer so it receives summaries, failure buckets, the routed Linear project report, and the post-write issue plan without relying on transitive artifacts.

## Issue tracking

Linked issue: N/A — internal CI integration update.

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests — not applicable; this changes internal CI configuration and has focused contract tests
- [ ] I have added proper typing to my code — not applicable; no Python implementation changed
- [ ] I have added relevant documentation — not applicable; the checked-in Cerno configuration is the consumer contract
- [ ] I have run the autoformatter — not applicable; no format-supported source files changed

## Validation

- `python -m pytest -q tests/test_utils/test_ci_triage.py` — 22 passed
- parsed `.gitlab/cerno.yml` and `.gitlab/stages/06.triage.yml`
- `python -m compileall -q tests/test_utils/test_ci_triage.py`
- `git diff --check`

No internal pipeline or Linear write was triggered from this branch.
