### PR TITLE
[MoE] Add optional output normalization for latent MoE

### DIFF
--- a/megatron/core/transformer/moe/moe_layer.py
+++ b/megatron/core/transformer/moe/moe_layer.py
@@ -63,9 +63,9 @@ except ImportError:
     HAVE_TRITON = False
 
 if HAVE_TE:
-    from megatron.core.extensions.transformer_engine import TELinear, te_checkpoint
+    from megatron.core.extensions.transformer_engine import TELinear, TENorm, te_checkpoint
 else:
-    TELinear, te_checkpoint = None, None
+    TELinear, TENorm, te_checkpoint = None, None, None
 
 
 class ExpertsInterface(Protocol):
@@ -315,6 +315,12 @@ class MoELayer(BaseMoELayer):
                 is_expert=False,
                 name=(name + ".fc2_latent_proj") if name is not None else None,
             )
+            if self.config.moe_latent_output_norm:
+                self.routed_expert_norm = TENorm(
+                    config=self.config,
+                    hidden_size=self.config.moe_latent_size,
+                    eps=self.config.layernorm_epsilon,
+                )
 
         # Initialize token dispatcher
         if config.moe_token_dispatcher_type == "allgather":
@@ -656,6 +662,8 @@ class MoELayer(BaseMoELayer):
 
         output = self.token_dispatcher.combine_postprocess(output)
         if self.config.moe_latent_size:
+            if self.config.moe_latent_output_norm:
+                output = self.routed_expert_norm(output)
             output, _ = self.fc2_latent_proj(output)
 
         if shared_expert_output is not None:

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -1044,6 +1044,11 @@ class TransformerConfig(ModelParallelConfig):
     moe_latent_size: Optional[int] = None
     """Latent projection dimension for MoE. If None, MoE latent projections are not used."""
 
+    moe_latent_output_norm: bool = False
+    """Apply normalization to the combined routed-expert output in the latent dimension before
+    projecting it back to the transformer hidden size. The normalization type and epsilon are
+    controlled by ``normalization`` and ``layernorm_epsilon``, respectively."""
+
     moe_flex_dispatcher_num_sms: Optional[int] = None
     """Number of SMs for the flex token dispatcher's dispatch/combine communication, for all
     backends (deepep, hybridep, ncclep). None lets each backend use its own default. Unifies the
@@ -2094,6 +2099,9 @@ class TransformerConfig(ModelParallelConfig):
 
         if self.num_moe_experts is not None and self.num_moe_experts <= 0:
             raise ValueError("num_moe_experts must be non-negative.")
+
+        if self.moe_latent_output_norm and self.moe_latent_size is None:
+            raise ValueError("moe_latent_output_norm requires moe_latent_size to be set.")
 
         if self.num_moe_experts is not None and self.moe_ffn_hidden_size is None:
             self.moe_ffn_hidden_size = self.ffn_hidden_size

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -2312,6 +2312,7 @@ def core_transformer_config_from_args(args, config_class=None):
         kw_args['quant_recipe'] = kitchen_quantization_recipe_config(args.kitchen_recipe_number)
 
     kw_args['moe_latent_size'] = args.moe_latent_size
+    kw_args['moe_latent_output_norm'] = args.moe_latent_output_norm
 
     if args.te_precision_config_file:
         assert not 'quant_recipe' in kw_args, "Quantization recipe already configured."

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -1974,6 +1974,7 @@ def load_args_from_checkpoint(args, load_arg='load', checkpointing_context=None)
 
     # MoE latent projection.
     _set_arg('moe_latent_size', force=True)
+    _set_arg('moe_latent_output_norm', force=True)
 
     # Tokenizer args.
     if args.use_tokenizer_model_from_checkpoint_args:

--- a/tests/unit_tests/models/test_hybrid_moe_model.py
+++ b/tests/unit_tests/models/test_hybrid_moe_model.py
@@ -211,6 +211,7 @@ GOLDEN_CONFIG: Dict[str, Any] = {
     "moe_hybridep_num_blocks_unpermute": None,
     "moe_input_jitter_eps": None,
     "moe_latent_size": None,
+    "moe_latent_output_norm": False,
     "moe_layer_freq": 1,
     "moe_layer_recompute": False,
     "moe_n_hash_layers": 0,

--- a/tests/unit_tests/transformer/moe/test_latent_moe_layer.py
+++ b/tests/unit_tests/transformer/moe/test_latent_moe_layer.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 
@@ -27,8 +29,15 @@ class TestLatentMoELayer:
     @pytest.mark.parametrize("num_moe_experts", [4])
     @pytest.mark.parametrize("use_te,grouped_gemm", [(True, True), (True, False), (False, False)])
     @pytest.mark.parametrize("moe_latent_size", [8, 16])
+    @pytest.mark.parametrize("moe_latent_output_norm", [False, True])
     def test_latent_moe_layer(
-        self, num_moe_experts, moe_token_dispatcher_type, use_te, grouped_gemm, moe_latent_size
+        self,
+        num_moe_experts,
+        moe_token_dispatcher_type,
+        use_te,
+        grouped_gemm,
+        moe_latent_size,
+        moe_latent_output_norm,
     ):
         Utils.initialize_model_parallel(1, 1)
         _set_random_seed(seed_=123, data_parallel_random_init=False)
@@ -48,6 +57,8 @@ class TestLatentMoELayer:
             gated_linear_unit=True,
             add_bias_linear=False,
             moe_latent_size=moe_latent_size,
+            moe_latent_output_norm=moe_latent_output_norm,
+            normalization="RMSNorm",
         )
         if use_te:
             transformer_layer_submodules = get_gpt_layer_with_transformer_engine_submodules(
@@ -62,6 +73,11 @@ class TestLatentMoELayer:
         moe_layer = MoELayer(self.transformer_config, submodules)
         moe_layer.cuda()
         config = moe_layer.config
+
+        if moe_latent_output_norm:
+            assert moe_layer.routed_expert_norm.weight.shape[0] == config.moe_latent_size
+        else:
+            assert not hasattr(moe_layer, "routed_expert_norm")
 
         assert (
             moe_layer.shared_experts.linear_fc1.weight.shape[1] == config.hidden_size
@@ -99,3 +115,36 @@ class TestLatentMoELayer:
         assert output.shape[2] == config.hidden_size
 
         Utils.destroy_model_parallel()
+
+    def test_latent_output_norm_requires_latent_size(self):
+        with pytest.raises(ValueError, match="requires moe_latent_size"):
+            TransformerConfig(
+                num_layers=1, hidden_size=32, num_attention_heads=4, moe_latent_output_norm=True
+            )
+
+    def test_latent_output_norm_is_applied_after_combine_and_before_up_projection(self):
+        class FakeDispatcher:
+            @staticmethod
+            def combine_postprocess(output):
+                return output + 1
+
+        class FakeNorm(torch.nn.Module):
+            def forward(self, output):
+                return output * 2
+
+        class FakeProjection(torch.nn.Module):
+            def forward(self, output):
+                return output + 3, None
+
+        moe_layer = object.__new__(MoELayer)
+        torch.nn.Module.__init__(moe_layer)
+        moe_layer.config = SimpleNamespace(moe_latent_size=2, moe_latent_output_norm=True)
+        moe_layer.token_dispatcher = FakeDispatcher()
+        moe_layer.routed_expert_norm = FakeNorm()
+        moe_layer.fc2_latent_proj = FakeProjection()
+        moe_layer._latent_shared_expert_output = None
+
+        output = moe_layer.postprocess(torch.zeros(1, 2), shared_expert_output=None)
+
+        # combine (+1), normalize (*2), then project (+3)
+        torch.testing.assert_close(output, torch.full((1, 2), 5.0))


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Add an optional normalization layer on the combined routed-expert output in latent MoE, applied after token combination and before the up-projection back to the transformer hidden size.

## Motivation

Megatron Core already supports latent MoE through `moe_latent_size` (down-projection → routed experts → combine → up-projection), but the combined latent output is fed into `fc2_latent_proj` with no way to normalize it. The Kimi K3 technical report (§2.3.1 "Normalized LatentMoE", Eq. 11) shows this step is a necessary part of the latent-MoE pipeline: the aggregated routed representation varies in scale with expert selection and routing weights, and normalizing it before the up-projection stabilizes training and improves validation loss. Since the normalization point sits between dispatcher combine and `fc2_latent_proj` inside `MoELayer`'s execution flow, it belongs in the layer itself rather than in model-specific wrapper code.

This PR exposes it as an optional, architecture-agnostic configuration that is disabled by default. Kimi K3 is the first public consumer; nothing in the implementation is K3-specific, and it works uniformly across token dispatchers (allgather / alltoall) and expert-parallel layouts.

A concurrent Megatron-Bridge integration (NVIDIA-NeMo/Megatron-Bridge#5130) currently duplicates `MoELayer.postprocess` to insert exactly this normalization; landing the option in Core would let that integration drop the override.

## Changes

New config field `moe_latent_output_norm: bool = False`. When enabled, the combined routed-expert output is normalized in the latent dimension after combine and before the up-projection:

```
hidden_states → fc1_latent_proj → router → experts → combine
→ routed_expert_norm (new, optional) → fc2_latent_proj → output
```

- `transformer_config.py`: add `moe_latent_output_norm` field + validation requiring `moe_latent_size`.
- `moe_layer.py`: build `routed_expert_norm = TENorm(...)` when enabled; apply it in `postprocess` between `combine_postprocess` and `fc2_latent_proj`. The norm type and epsilon follow the existing `normalization` / `layernorm_epsilon` configs.
- `arguments.py` / `checkpointing.py`: pass-through and checkpoint restore. The CLI flag `--moe-latent-output-norm` is auto-generated from the config field.
- `test_latent_moe_layer.py`: parametrize the layer test over `moe_latent_output_norm` (`True`/`False`) so both the enabled and the default disabled paths stay covered; add config-validation and execution-order tests.                               
- `test_hybrid_moe_model.py`: add the new field to `GOLDEN_CONFIG` so the config snapshot test stays green. 

## Test plan

- [x] `pytest tests/unit_tests/transformer/moe/test_latent_moe_layer.py` — parametrized over dispatcher (allgather/alltoall) × TE/local × grouped/non-grouped GEMM × norm on/off, plus config-validation and execution-order tests
- [ ] End-to-end training convergence check with `--moe-latent-output-norm`

## Issue tracking

Linked issue: Fix #6448

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code
- [x] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR