### PR TITLE
perf(inference): fuse SiLU(gate)*up into the decode FC1 GEMM epilogue

### DIFF
--- a/megatron/core/inference/moe/vllm_fused_moe.py
+++ b/megatron/core/inference/moe/vllm_fused_moe.py
@@ -124,6 +124,7 @@ def _fused_moe_kernel(
     # Flags / constexprs
     MUL_ROUTED_WEIGHT: tl.constexpr,
     FUSE_SQUARED_RELU: tl.constexpr,
+    FUSE_SWIGLU: tl.constexpr,
     top_k: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
@@ -186,6 +187,13 @@ def _fused_moe_kernel(
                 + off_experts * stride_be
                 + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
             )
+            # SwiGLU epilogue fusion: the same [BLOCK_M, BLOCK_N] output tile of
+            # the activated intermediate needs both the gate columns (offs_bn) and
+            # the paired up columns (offs_bn + N), where N is the activated width.
+            # A second accumulator reads the up half from the same B tensor.
+            if FUSE_SWIGLU:
+                b_up_ptrs = b_ptrs + N * stride_bn
+                up_accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
 
             accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
             for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
@@ -196,6 +204,12 @@ def _fused_moe_kernel(
                 )
                 b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
                 accumulator += tl.dot(a, b)
+                if FUSE_SWIGLU:
+                    b_up = tl.load(
+                        b_up_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0
+                    )
+                    up_accumulator += tl.dot(a, b_up)
+                    b_up_ptrs += BLOCK_SIZE_K * stride_bk
                 a_ptrs += BLOCK_SIZE_K * stride_ak
                 b_ptrs += BLOCK_SIZE_K * stride_bk
 
@@ -204,6 +218,15 @@ def _fused_moe_kernel(
             if FUSE_SQUARED_RELU:
                 accumulator = tl.maximum(accumulator, 0.0)
                 accumulator *= accumulator
+
+            # SwiGLU fused on the fp32 accumulators: SiLU(gate) * up. The
+            # arithmetic matches the standalone `bounded_silu_mul` kernel, but the
+            # results are not bit-identical (measured max_abs 3.9e-5): that kernel
+            # reads gate and up after they have been rounded to bf16, while these
+            # accumulators have not been. The fused result is the less rounded of
+            # the two. Removes that kernel and the 2N intermediate round-trip.
+            if FUSE_SWIGLU:
+                accumulator = accumulator * tl.sigmoid(accumulator) * up_accumulator
 
             if MUL_ROUTED_WEIGHT:
                 moe_weight = tl.load(topk_weights_ptr + offs_token, mask=token_mask, other=0)
@@ -387,12 +410,18 @@ def _invoke_fused_moe_kernel(
     config: dict,
     grid_size: int,
     fuse_squared_relu: bool = False,
+    fuse_swiglu: bool = False,
 ):
     """Launch the Triton fused-MoE kernel for one GEMM pass.
 
     Body matches upstream vLLM `fused_moe_kernel` (1 CTA per (pid_m, pid_n)
     tile, raw pointer arithmetic with `% N` on the N axis), apart from the
     optional fused squared-relu activation in fp32.
+
+    When ``fuse_swiglu`` is set, B is the [E, 2*Nf, K] gate|up FC1 weight and the
+    kernel emits the activated [num_valid, Nf] intermediate directly (SiLU(gate) *
+    up), so ``N`` is the activated width ``Nf = B.size(1) // 2`` and each program
+    also reads the paired up columns at ``+N`` in B.
 
     `grid_size` is sized host-side from `num_tokens_hint` so launch overhead
     at decode is small.  When the actual padded length exceeds the hinted
@@ -402,6 +431,8 @@ def _invoke_fused_moe_kernel(
     """
     M = A.size(0)
     num_tokens = M * top_k
+    # For fused SwiGLU, N is the activated width (half the 2*Nf FC1 output).
+    n_dim = B.size(1) // 2 if fuse_swiglu else B.size(1)
 
     _fused_moe_kernel[(grid_size,)](
         A,
@@ -411,7 +442,7 @@ def _invoke_fused_moe_kernel(
         sorted_token_ids,
         expert_ids,
         num_tokens_post_padded,
-        B.size(1),
+        n_dim,
         B.size(2),
         num_tokens,
         A.stride(0),
@@ -423,6 +454,7 @@ def _invoke_fused_moe_kernel(
         C.stride(1),
         MUL_ROUTED_WEIGHT=mul_routed_weight,
         FUSE_SQUARED_RELU=fuse_squared_relu,
+        FUSE_SWIGLU=fuse_swiglu,
         top_k=top_k,
         BLOCK_SIZE_M=config['BLOCK_SIZE_M'],
         BLOCK_SIZE_N=config['BLOCK_SIZE_N'],
@@ -557,6 +589,7 @@ def vllm_fused_moe(
     routing_map: torch.Tensor,
     out: Optional[torch.Tensor] = None,
     num_tokens_hint: Optional[int] = None,
+    fuse_fc1_activation: bool = False,
 ) -> torch.Tensor:
     """Fused MoE using the vLLM Triton grouped-GEMM kernel (BF16).
 
@@ -580,6 +613,9 @@ def vllm_fused_moe(
         num_tokens_hint: optional host-side int with the expected number of
             valid tokens (e.g. batch_size * ep_size). Used to select a better
             BLOCK_SIZE_M instead of using the worst-case buffer size.
+        fuse_fc1_activation: for SwiGLU, fuse SiLU(gate)*up into the FC1 GEMM
+            epilogue instead of running the standalone ``bounded_silu_mul`` kernel
+            over the 2N-wide intermediate. Ignored for other activations.
 
     Returns:
         [max_tokens, hidden_size] output (fp32 when out=None, else out's dtype).
@@ -606,6 +642,14 @@ def vllm_fused_moe(
     N = fc1_weight.size(1)
     K = fc1_weight.size(2)
 
+    assert activation_type in (ActivationType.SQUARED_RELU, ActivationType.SWIGLU)
+    is_swiglu = activation_type == ActivationType.SWIGLU
+    # When enabled for SwiGLU, FC1 fuses SiLU(gate)*up into its epilogue and
+    # writes the activated [num_valid, N//2] intermediate directly, removing the
+    # standalone bounded_silu_mul kernel and the 2N intermediate round-trip.
+    use_fused_swiglu = is_swiglu and fuse_fc1_activation
+    fc1_out_width = N // 2 if use_fused_swiglu else N
+
     # Grid sized for the typical-case token count (num_tokens_hint).  When the
     # actual num_tokens_post_padded exceeds this, the kernel's outer tl.range
     # makes each CTA stride over additional tiles — correct but with reduced
@@ -614,21 +658,20 @@ def vllm_fused_moe(
     block_m = config['BLOCK_SIZE_M']
     em_hint = effective_tokens * topk + block_m * num_local_experts
     num_pid_m_hint = _ceil_div(em_hint, block_m)
-    num_pid_n_fc1 = _ceil_div(N, config['BLOCK_SIZE_N'])
+    num_pid_n_fc1 = _ceil_div(fc1_out_width, config['BLOCK_SIZE_N'])
     num_pid_n_fc2 = _ceil_div(K, config['BLOCK_SIZE_N'])
     grid_size_fc1 = num_pid_m_hint * num_pid_n_fc1
     grid_size_fc2 = num_pid_m_hint * num_pid_n_fc2
 
     topk_weights_flat = probs.reshape(-1).contiguous()
 
-    # FC1 + activation: [max_tokens, K] → [max_tokens*topk, N]
-    # SQUARED_RELU fuses into the GEMM epilogue (elementwise). SwiGLU pairs column c
-    # with c+N/2 across tiles and cannot, so FC1 runs unfused to the 2N-wide
-    # intermediate and gate/up is applied separately below.
-    assert activation_type in (ActivationType.SQUARED_RELU, ActivationType.SWIGLU)
-    is_swiglu = activation_type == ActivationType.SWIGLU
+    # FC1 + activation: [max_tokens, K] → [max_tokens*topk, fc1_out_width]
+    # SQUARED_RELU fuses into the GEMM epilogue (elementwise). SwiGLU pairs column
+    # c with c+N/2 across N-tiles; the unfused path writes the 2N intermediate and
+    # applies gate/up separately below, while the fused path (use_fused_swiglu)
+    # reads both halves per program and writes the N//2 activated output directly.
     intermediate1 = torch.empty(
-        num_valid, N, dtype=hidden_states.dtype, device=hidden_states.device
+        num_valid, fc1_out_width, dtype=hidden_states.dtype, device=hidden_states.device
     )
     _invoke_fused_moe_kernel(
         hidden_states,
@@ -643,8 +686,9 @@ def vllm_fused_moe(
         config=config,
         grid_size=grid_size_fc1,
         fuse_squared_relu=not is_swiglu,
+        fuse_swiglu=use_fused_swiglu,
     )
-    if is_swiglu:
+    if is_swiglu and not use_fused_swiglu:
         # intermediate1 is [num_valid, 2N] (gate | up); reduce to [num_valid, N] via
         # SiLU(gate) * up over the valid_tokens*topk live rows only.
         n_rows = (valid_tokens * topk).to(torch.int32)

--- a/megatron/core/transformer/moe/experts.py
+++ b/megatron/core/transformer/moe/experts.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import inspect
 import logging
+import os
 from collections.abc import Callable
 from contextlib import nullcontext
 from copy import deepcopy
@@ -86,6 +87,12 @@ from megatron.core.inference.moe import ActivationType as McoreActivationType
 from megatron.core.inference.moe import InferenceGroupedGemmBackend, mcore_fused_moe, vllm_fused_moe
 
 logger = logging.getLogger(__name__)
+
+# Fuse SiLU(gate)*up into the decode FC1 GEMM epilogue, removing the standalone
+# bounded_silu_mul kernel and the 2N intermediate HBM round-trip. No-op for
+# non-SwiGLU activations. Not bit-exact (max_abs 3.9e-5), so it is opt-in. Read
+# once here rather than per forward: the consumer is on the per-layer decode path.
+_FUSE_FC1_ACT: bool = os.environ.get("MCORE_FUSE_FC1_ACT", "0") == "1"
 
 
 class GroupedLinearFc1Interface(Protocol):
@@ -1200,6 +1207,7 @@ class InferenceGroupedMLP(TEGroupedMLP):
             routing_map=routing_map,
             out=NVLSAllGatherVDispatcher._get_rsv_tensor() if self._nvls_dispatcher else None,
             num_tokens_hint=InferenceAllGatherDispatcherBase._get_host_valid_tokens_estimate(),
+            fuse_fc1_activation=_FUSE_FC1_ACT,
         )
         return output, None
 


### PR DESCRIPTION
## Summary

The decode MoE path runs FC1 into a `[num_valid, 2N]` gate|up intermediate, then a
standalone `bounded_silu_mul` launch reads that intermediate back and writes an N-wide
activated one, then FC2 consumes it. Computing both halves in the same FC1 program and
applying `SiLU(gate) * up` to the two fp32 accumulators emits the activated intermediate
directly: one launch and one full write-read-write of the widest buffer in the MoE call
disappear, the whole MoE call measures **1.25×** faster in an eager microbench, and
end-to-end **+14.81%**.

The surprising part is that this number is not what this change was worth when it was
written. Measured on its own against an untuned baseline it was a **wash**, inside
run-to-run variance, and that null is what redirected the campaign to the routing chain
and the GEMM tiling. Its value appeared only once the rest of the decode MoE path got
fast, and the reason is mechanical rather than mysterious. Unfused, FC1 writes a
`2N`-wide gate|up intermediate instead of the `N`-wide activated one, so on a GEMM that
is memory-bound — 1.45× off a measured 6.081 TB/s streaming-read floor — the output
write traffic doubles and a second full round-trip through the widest buffer in the call
is added on top. Worse, the decode tile config that another slice in this stack
introduces picks `BLOCK_SIZE_N=64` for FC1 because it was tuned against the fused,
half-width output; at double width that same config emits twice the N-tiles.

So the leave-one-out number is real and it is the right number to publish for a change
that ships into this configuration, but it should not be read as "this fusion is worth
15% on its own". It is worth that much *here*, because everything around it is now fast
enough for the doubled traffic to dominate.

## Why here

The decode MoE call was a four-kernel chain: FC1 → `bounded_silu_mul` → FC2 →
`_moe_sum`. The activation kernel is the only member of that chain with no arithmetic
worth a launch — it is pure data movement over the widest buffer in the call, and its
output is something the kernel immediately before it already holds in registers.

It is also doing four times more work than the result needs. `bounded_silu_mul` is
called with `n_rows = valid_tokens * topk` and activates every one of those rows, but
FC1 only writes the rows belonging to this rank's experts. At the decode shape (256
tokens × top-8 = 2048 pairs, of which 527 are local at EP4 with 32 of 128 experts on
this rank), roughly three quarters of the rows it activates are undefined FC1 output
that `_moe_sum` later discards on the routing map.

## What changed

**Before.** FC1 launches `ceil(2N / BLOCK_SIZE_N)` N-tiles per M-tile row-block and
stores a bf16 `[num_valid, 2N]` intermediate. `bounded_silu_mul` then launches
`min(num_valid, 512)` persistent CTAs which, for each live row, load the gate half and
the up half, upcast both to fp32, compute `gate * sigmoid(gate) * up`, cast to bf16 and
store into a fresh `[num_valid, N]` buffer that becomes FC2's A operand.

**After.** With the `FUSE_SWIGLU` constexpr set, `_fused_moe_kernel` takes `N` to be the
activated width (`B.size(1) // 2`) and each program carries a second fp32 accumulator
for the up half, whose B tile is the same pointer offset by `N * stride_bn`. The K loop
issues two `tl.dot`s per step instead of one. In the epilogue the two accumulators
become `accumulator * sigmoid(accumulator) * up_accumulator` before the single bf16 cast
and store, and the caller allocates the intermediate at `N // 2` width and skips the
`bounded_silu_mul` call.

Total FLOPs and total expert-weight traffic are unchanged: the FC1 grid halves (6 N-tiles
instead of 12 at the decode shape) and each program does twice the dot work, reading the
same B columns it would have read before. What goes away is the activation launch, the
2N intermediate's write-read-write, half the intermediate allocation, and half of FC1's
A-operand re-reads — A is re-read once per N-tile, and there are half as many N-tiles.

**The arithmetic does not fully close, and that matters for the claim.** The eager
microbench saves about 35 µs on a ~176 µs MoE call. The HBM traffic removed is about
10 MB per layer per rank at the decode shape, which is ~1.7 µs at the 6.081 TB/s
streaming-read ceiling measured on this GB200, and a launch removed from inside a
captured graph is worth ~0.55 µs. The A-operand re-reads that disappear are ~13 MB but
largely L2-resident. So the mechanism accounts for a few µs of the 35; the remainder is
the eager measurement itself plus the activation kernel's own execution cost, and it was
not isolated. Under CUDA graphs only the device-time part is available to win, which is
why the isolated end-to-end measurement was a wash. What that early accounting missed is
the doubled FC1 output traffic described in the summary: it is not a launch-count effect
at all, and it only became visible once the surrounding GEMM was tuned to the point where
memory traffic set the pace.

## Measurement

Fixed protocol: Qwen3-30B-A3B, BF16, TP 1 / PP 1 / EP 4 / ETP 1, 256 gsm8k requests, 1024 output tokens, 2 warmup + 5 timed iterations, a single OCI 4xGB200 node (nvl72160-T04), async dynamic-batching scheduler pinned on. All 20 arms ran back to back in one allocation on that one node; node-to-node variance on this workload is around 2.7%, so cross-node numbers would not be comparable.

- With this change (every other gate in the stack enabled): **31,503 tok/s**
- Without it (same node, same session, only this gate turned off): **27,439 tok/s**
- Leave-one-out delta: **+14.81%**
- Noise floor: sigma = **0.42%** over 3 repeats of the all-gates-on reference
- Verdict: **resolved**; the per-iteration distributions separate completely (every timed iteration of the better arm beats every timed iteration of the worse one)

This is the **marginal contribution measured with every other gate in this stack enabled** — the question a reviewer is actually asking, which is whether this should land, not what it was worth when it was first written.

The reference is drift-corrected. The all-gates-on configuration was re-measured three times across the session (31,745, 31,530, 31,503 tok/s), a +0.77% drift from first to last, so each arm is compared against the reference interpolated to its own position in the run order rather than against a session mean.

For context, the whole stack is worth **+35.80%** on this node (23,265 tok/s with every gate off, 31,593 with every gate on). Per-slice deltas do not sum to that; they compose sub-additively.

## Evidence

Eager CUDA-event microbench of the whole `vllm_fused_moe` call at the Qwen3-30B-A3B EP4
decode shape (hidden 2048, moe_ffn 768, 32 local experts, top-8, 256 valid tokens),
10 warmup + 200 timed iterations × 3 repeats: unfused 174–182 µs → fused 141–143 µs,
**1.24–1.27×**. The absolute level is corroborated by a later measurement of the same
call in the same mode, which found 142.65 µs with this fusion on.

Liveness is structural rather than observed: the caller only allocates the narrow
intermediate and only skips `bounded_silu_mul` on the same condition that sets
`FUSE_SWIGLU`, so a silently-declining gate would produce a shape mismatch at FC2 rather
than a quiet no-op. No kernel-count delta from a profile was captured for this gate.

## Correctness

- **Numerics:** **not bit-exact.** `max_abs = 3.9e-5` against the unfused
  `vllm_fused_moe`, `allclose` passing. The difference is structural and one-directional:
  the unfused path rounds the gate and up projections to bf16 before the activation
  (FC1 stores bf16, `bounded_silu_mul` reads it back and upcasts), while the fused
  epilogue applies the activation to the fp32 accumulators and rounds once. The fused
  result is therefore the *less* rounded of the two, but it is not the same result.
- **Tests:** microbench equality against the unfused path at the decode shape.
  `max_rel` was **not** recorded for this change, only `max_abs` — later slices in this
  stack record both, and a reviewer who wants a relative bound will have to ask for it.
- **Coherence:** the end-to-end prompts stayed coherent and correct (`2+2=4`, capital of
  France = Paris). Byte-identity against a gate-OFF run was not checked and should not be
  expected, since the change is not bit-exact.

## Gating and blast radius

- Gate: `MCORE_FUSE_FC1_ACT`, **default OFF** — `os.environ.get("MCORE_FUSE_FC1_ACT",
  "0") == "1"` in `experts.py`. It is read once at import, so it must be set before the
  process starts, not per forward.
- With the gate unset, `FUSE_SWIGLU` is `False`, Triton compiles every new block out of
  the kernel, `fc1_out_width` is `N`, and `bounded_silu_mul` runs as before.
- Preconditions: the flag is only passed by `InferenceGroupedMLP._vllm_forward`, so this
  is the `--transformer-impl inference_optimized` inference path with
  `--inference-grouped-gemm-backend vllm` and nothing else; inside `vllm_fused_moe` it is
  ANDed with `activation_type == SWIGLU`, so squared-relu configurations ignore it (their
  activation already fuses). Training never reaches this function.
- When a precondition fails: the unfused two-kernel path, unchanged.

## Reproduce

```bash
MCORE_FUSE_FC1_ACT=1 \
QWEN30B_TP=1 QWEN30B_EP=4 QWEN30B_ETP=1 \
BENCH_SIZES_OVERRIDE=256 BENCH_OUTPUT_TOKENS=1024 \
NUM_WARMUP_ITERS=2 NUM_TIMED_ITERS=5 \
bash skills/run-qwen-model/run_qwen_inference.sh qwen3-30b-a3b --checkpoint "$QWEN30B_CKPT"
```

The gate must be exported before the interpreter imports `experts.py`; setting it after
import has no effect. Triton is required, as it already is for this backend.

## What this does not claim

- **The delta is configuration-dependent, and strongly so.** Measured in isolation
  against an untuned baseline this change was a wash at the same batch size and output
  length. The large number in the Measurement section is its marginal contribution with
  the rest of this stack — in particular the decode tile config — already in. Do not
  quote it as the standalone value of FC1 activation fusion, and do not expect it on a
  tree that does not carry the rest of the stack.
- **The split between the three contributing effects is not isolated.** Turning the gate
  off simultaneously doubles the FC1 output write, adds the activation kernel's read and
  write, and mismatches the tuned FC1 tile width. All three move together with one
  environment variable and I did not separate them.
- **The 1.25× is an eager number.** No CUDA-graph-replay device-time A/B exists for this
  gate, unlike the other slices in this stack. Inside a graph the removed launch is worth
  ~0.55 µs, not a Python launch.
- The removed HBM traffic accounts for only a few of the 35 µs; the rest is eager launch
  overhead and the activation kernel's own cost, which were not separated.
- **Not bit-exact**, and `max_rel` is unrecorded. See Correctness.
- **This gate has no token-count guard**, unlike the tile retune and the table fusion in
  this stack. It applies at prefill shapes too, where it has not been measured — at large
  M the halved FC1 grid means half as many CTAs each doing twice the work, which is
  plausibly neutral but untested.
- Nothing for non-SwiGLU activations.
- Deltas in this stack do not add. Every slice here shortens the same MoE call and the
  same intra-graph dispatch budget, so they compose sub-additively.

## Follow-ups

- The epilogue's code comment used to claim it matched `bounded_silu_mul` "bit-for-bit",
  which was true of the arithmetic but not of the inputs — exactly why the measured
  difference is 3.9e-5 rather than 0. The comment now states the difference and its
  direction.
- A graph-replay device-time A/B for this gate would settle how much of the 35 µs is
  available under CUDA graphs, and would let the three effects above be priced
  separately. It was skipped when the isolated end-to-end result looked like a null;
  the leave-one-out measurement makes it worth doing.
- The decode tile config is tuned against the fused FC1 output width. If this gate is
  ever turned off deliberately, that config should be re-tuned for the `2N` width rather
  than inherited.
- `max_rel` against the unfused path, at the four token counts the later slices use.

---

## This stack

This is one slice of [#6064](https://github.com/NVIDIA/Megatron-LM/pull/6064), a Qwen3-30B-A3B decode optimization campaign, split into 16 independently reviewable changes. Together they are **+35.80%** end-to-end throughput over the same base commit (23,265 -> 31,593 tok/s, mean of three full runs).

- **MoE grouped-GEMM and dispatch:** #6452 -> #6453 -> #6454 -> #6455
- **MoE router and combine:** #6456 -> #6457 -> #6458
- **Attention: QK norm and decode kernel:** #6459 -> #6460 -> #6461 -> #6462
- **Residual + RMSNorm fusion:** #6463 -> #6464
- **Host path: context bookkeeping:** #6465 -> #6466
- **Host path: independent:** #6467

Each chain is independent of the others and bases on `main`. Within a chain, later PRs depend on earlier ones.

### Per-slice measured delta

Every number is a leave-one-out delta from one same-node, same-session campaign: the full stack with exactly this change's gate off, against the interpolated full-stack reference at that point in the run. It is the change's *marginal* contribution with everything else already in, not its standalone value. Run-to-run sigma was **0.42%** across three full-stack repeats.

| PR | Change | Delta | |
|---|---|---|---|
| #6452 | FC1 SwiGLU epilogue | +14.81% | resolved |
| #6453 | indirection table fusion | +7.21% | resolved |
| #6454 | decode GEMM tile configs | +6.77% | resolved |
| #6455 | predicated top-k gather | +1.99% | by margin |
| #6456 | fused router softmax+top-k | +4.75% | resolved |
| #6457 | fused route padding mask | +1.47% | by margin |
| #6458 | bf16 MoE combine | +2.42% | by margin |
| #6459 | fused QK RMSNorm | +5.17% | resolved |
| #6460 | grouped QK norm input | +1.18% | by margin |
| #6461 | pin FlashAttention 2 | -0.35% | noise floor |
| #6462 | FlashInfer TRT-LLM decode | +1.46% | by margin |
| #6463 | fused add+norm pre-MLP | +3.54% | by margin |
| #6464 | fused add+norm pre-QKV | +0.98% | by margin |
| #6465 | incremental attention state | -0.42% | noise floor |
| #6466 | vectorized decode bookkeeping | -0.07% | noise floor |
| #6467 | post_process_requests fast path | +0.09% | noise floor |

`noise floor` means the delta is inside 2 sigma (0.84%) and this campaign cannot distinguish it from zero. `resolved` means the leave-one-out and full-stack iteration distributions did not overlap. Deltas do not sum to the stack total: these changes shorten the same decode step and compose sub-additively.

**Fixed protocol for every number above.** Qwen3-30B-A3B, BF16, TP1/PP1/EP4/ETP1, 256 gsm8k requests at batch size 256, output length 1024, CUDA graphs on, one OCI GB200 NVL72 node, 4 GPUs. All 20 arms ran back-to-back in a single Slurm allocation on one node, so node assignment and thermal state are held constant.
