### PR TITLE
perf(inference): build the decode MoE indirection table in one kernel

### DIFF
--- a/megatron/core/inference/moe/vllm_fused_moe.py
+++ b/megatron/core/inference/moe/vllm_fused_moe.py
@@ -124,6 +124,7 @@ def _fused_moe_kernel(
     # Flags / constexprs
     MUL_ROUTED_WEIGHT: tl.constexpr,
     FUSE_SQUARED_RELU: tl.constexpr,
+    FUSE_SWIGLU: tl.constexpr,
     top_k: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
@@ -186,6 +187,13 @@ def _fused_moe_kernel(
                 + off_experts * stride_be
                 + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
             )
+            # SwiGLU epilogue fusion: the same [BLOCK_M, BLOCK_N] output tile of
+            # the activated intermediate needs both the gate columns (offs_bn) and
+            # the paired up columns (offs_bn + N), where N is the activated width.
+            # A second accumulator reads the up half from the same B tensor.
+            if FUSE_SWIGLU:
+                b_up_ptrs = b_ptrs + N * stride_bn
+                up_accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
 
             accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
             for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
@@ -196,6 +204,12 @@ def _fused_moe_kernel(
                 )
                 b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
                 accumulator += tl.dot(a, b)
+                if FUSE_SWIGLU:
+                    b_up = tl.load(
+                        b_up_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0
+                    )
+                    up_accumulator += tl.dot(a, b_up)
+                    b_up_ptrs += BLOCK_SIZE_K * stride_bk
                 a_ptrs += BLOCK_SIZE_K * stride_ak
                 b_ptrs += BLOCK_SIZE_K * stride_bk
 
@@ -204,6 +218,15 @@ def _fused_moe_kernel(
             if FUSE_SQUARED_RELU:
                 accumulator = tl.maximum(accumulator, 0.0)
                 accumulator *= accumulator
+
+            # SwiGLU fused on the fp32 accumulators: SiLU(gate) * up. The
+            # arithmetic matches the standalone `bounded_silu_mul` kernel, but the
+            # results are not bit-identical (measured max_abs 3.9e-5): that kernel
+            # reads gate and up after they have been rounded to bf16, while these
+            # accumulators have not been. The fused result is the less rounded of
+            # the two. Removes that kernel and the 2N intermediate round-trip.
+            if FUSE_SWIGLU:
+                accumulator = accumulator * tl.sigmoid(accumulator) * up_accumulator
 
             if MUL_ROUTED_WEIGHT:
                 moe_weight = tl.load(topk_weights_ptr + offs_token, mask=token_mask, other=0)
@@ -387,12 +410,18 @@ def _invoke_fused_moe_kernel(
     config: dict,
     grid_size: int,
     fuse_squared_relu: bool = False,
+    fuse_swiglu: bool = False,
 ):
     """Launch the Triton fused-MoE kernel for one GEMM pass.
 
     Body matches upstream vLLM `fused_moe_kernel` (1 CTA per (pid_m, pid_n)
     tile, raw pointer arithmetic with `% N` on the N axis), apart from the
     optional fused squared-relu activation in fp32.
+
+    When ``fuse_swiglu`` is set, B is the [E, 2*Nf, K] gate|up FC1 weight and the
+    kernel emits the activated [num_valid, Nf] intermediate directly (SiLU(gate) *
+    up), so ``N`` is the activated width ``Nf = B.size(1) // 2`` and each program
+    also reads the paired up columns at ``+N`` in B.
 
     `grid_size` is sized host-side from `num_tokens_hint` so launch overhead
     at decode is small.  When the actual padded length exceeds the hinted
@@ -402,6 +431,8 @@ def _invoke_fused_moe_kernel(
     """
     M = A.size(0)
     num_tokens = M * top_k
+    # For fused SwiGLU, N is the activated width (half the 2*Nf FC1 output).
+    n_dim = B.size(1) // 2 if fuse_swiglu else B.size(1)
 
     _fused_moe_kernel[(grid_size,)](
         A,
@@ -411,7 +442,7 @@ def _invoke_fused_moe_kernel(
         sorted_token_ids,
         expert_ids,
         num_tokens_post_padded,
-        B.size(1),
+        n_dim,
         B.size(2),
         num_tokens,
         A.stride(0),
@@ -423,6 +454,7 @@ def _invoke_fused_moe_kernel(
         C.stride(1),
         MUL_ROUTED_WEIGHT=mul_routed_weight,
         FUSE_SQUARED_RELU=fuse_squared_relu,
+        FUSE_SWIGLU=fuse_swiglu,
         top_k=top_k,
         BLOCK_SIZE_M=config['BLOCK_SIZE_M'],
         BLOCK_SIZE_N=config['BLOCK_SIZE_N'],
@@ -557,6 +589,7 @@ def vllm_fused_moe(
     routing_map: torch.Tensor,
     out: Optional[torch.Tensor] = None,
     num_tokens_hint: Optional[int] = None,
+    fuse_fc1_activation: bool = False,
 ) -> torch.Tensor:
     """Fused MoE using the vLLM Triton grouped-GEMM kernel (BF16).
 
@@ -580,6 +613,9 @@ def vllm_fused_moe(
         num_tokens_hint: optional host-side int with the expected number of
             valid tokens (e.g. batch_size * ep_size). Used to select a better
             BLOCK_SIZE_M instead of using the worst-case buffer size.
+        fuse_fc1_activation: for SwiGLU, fuse SiLU(gate)*up into the FC1 GEMM
+            epilogue instead of running the standalone ``bounded_silu_mul`` kernel
+            over the 2N-wide intermediate. Ignored for other activations.
 
     Returns:
         [max_tokens, hidden_size] output (fp32 when out=None, else out's dtype).
@@ -606,6 +642,14 @@ def vllm_fused_moe(
     N = fc1_weight.size(1)
     K = fc1_weight.size(2)
 
+    assert activation_type in (ActivationType.SQUARED_RELU, ActivationType.SWIGLU)
+    is_swiglu = activation_type == ActivationType.SWIGLU
+    # When enabled for SwiGLU, FC1 fuses SiLU(gate)*up into its epilogue and
+    # writes the activated [num_valid, N//2] intermediate directly, removing the
+    # standalone bounded_silu_mul kernel and the 2N intermediate round-trip.
+    use_fused_swiglu = is_swiglu and fuse_fc1_activation
+    fc1_out_width = N // 2 if use_fused_swiglu else N
+
     # Grid sized for the typical-case token count (num_tokens_hint).  When the
     # actual num_tokens_post_padded exceeds this, the kernel's outer tl.range
     # makes each CTA stride over additional tiles — correct but with reduced
@@ -614,21 +658,20 @@ def vllm_fused_moe(
     block_m = config['BLOCK_SIZE_M']
     em_hint = effective_tokens * topk + block_m * num_local_experts
     num_pid_m_hint = _ceil_div(em_hint, block_m)
-    num_pid_n_fc1 = _ceil_div(N, config['BLOCK_SIZE_N'])
+    num_pid_n_fc1 = _ceil_div(fc1_out_width, config['BLOCK_SIZE_N'])
     num_pid_n_fc2 = _ceil_div(K, config['BLOCK_SIZE_N'])
     grid_size_fc1 = num_pid_m_hint * num_pid_n_fc1
     grid_size_fc2 = num_pid_m_hint * num_pid_n_fc2
 
     topk_weights_flat = probs.reshape(-1).contiguous()
 
-    # FC1 + activation: [max_tokens, K] → [max_tokens*topk, N]
-    # SQUARED_RELU fuses into the GEMM epilogue (elementwise). SwiGLU pairs column c
-    # with c+N/2 across tiles and cannot, so FC1 runs unfused to the 2N-wide
-    # intermediate and gate/up is applied separately below.
-    assert activation_type in (ActivationType.SQUARED_RELU, ActivationType.SWIGLU)
-    is_swiglu = activation_type == ActivationType.SWIGLU
+    # FC1 + activation: [max_tokens, K] → [max_tokens*topk, fc1_out_width]
+    # SQUARED_RELU fuses into the GEMM epilogue (elementwise). SwiGLU pairs column
+    # c with c+N/2 across N-tiles; the unfused path writes the 2N intermediate and
+    # applies gate/up separately below, while the fused path (use_fused_swiglu)
+    # reads both halves per program and writes the N//2 activated output directly.
     intermediate1 = torch.empty(
-        num_valid, N, dtype=hidden_states.dtype, device=hidden_states.device
+        num_valid, fc1_out_width, dtype=hidden_states.dtype, device=hidden_states.device
     )
     _invoke_fused_moe_kernel(
         hidden_states,
@@ -643,8 +686,9 @@ def vllm_fused_moe(
         config=config,
         grid_size=grid_size_fc1,
         fuse_squared_relu=not is_swiglu,
+        fuse_swiglu=use_fused_swiglu,
     )
-    if is_swiglu:
+    if is_swiglu and not use_fused_swiglu:
         # intermediate1 is [num_valid, 2N] (gate | up); reduce to [num_valid, N] via
         # SiLU(gate) * up over the valid_tokens*topk live rows only.
         n_rows = (valid_tokens * topk).to(torch.int32)

--- a/megatron/core/inference/moe/vllm_fused_moe.py
+++ b/megatron/core/inference/moe/vllm_fused_moe.py
@@ -9,6 +9,7 @@ CUDA-graph compatible: all indirection table construction happens on-device
 via Triton kernels with fixed-size buffers and valid_tokens gating.
 """
 
+import os
 from typing import Optional
 from unittest.mock import MagicMock
 
@@ -319,6 +320,424 @@ def _fill_expert_block_ids_kernel(
     for off in tl.range(0, num_blocks, BLOCK):
         idxs = start_block + off + tl.arange(0, BLOCK)
         tl.store(expert_ids_ptr + idxs, e, mask=idxs < end_block)
+
+
+@triton.jit
+def _prefix_fill_init_kernel(
+    tokens_per_expert_ptr,  # [num_local_experts] raw token counts
+    exclusive_offsets_ptr,  # [num_local_experts] out: exclusive prefix sum (scatter counters)
+    inclusive_offsets_ptr,  # [num_local_experts] out: inclusive prefix sum
+    expert_ids_ptr,  # [max_blocks] out: expert index per BLOCK_SIZE_M block
+    sorted_token_ids_ptr,  # [max_sorted] out: SENTINEL-initialized indirection table
+    num_local_experts,
+    SENTINEL: tl.constexpr,
+    ALIGNMENT: tl.constexpr,  # = BLOCK_SIZE_M
+    NLE_POW2: tl.constexpr,  # next_power_of_2(num_local_experts) for tl.cumsum
+    FILL_BLOCK: tl.constexpr,  # vectorized store width
+):
+    """Fused prefix-sum + expert_ids fill + sorted_token_ids SENTINEL init.
+
+    Merges three kernels of the original indirection-table build
+    (``_init_sorted_ids_kernel`` + ``_prefix_sum_kernel`` +
+    ``_fill_expert_block_ids_kernel``) into one launch. Grid: one CTA per local
+    expert. Every CTA recomputes the (tiny, num_local_experts-wide) aligned
+    cumsum in registers, then CTA ``e`` writes only its own disjoint slices:
+
+      - exclusive_offsets[e], inclusive_offsets[e]   (offset arrays)
+      - expert_ids[excl_e//BM : incl_e//BM] = e      (block→expert map)
+      - sorted_token_ids[excl_e : incl_e] = SENTINEL (padding for its block)
+
+    The union of the per-expert [excl_e, incl_e) ranges is exactly
+    [0, num_tokens_post_padded), which is the only region the grouped-GEMM
+    reads (it strides tiles up to cdiv(num_tokens_post_padded, BM)); the buffer
+    tail beyond that is never read, so it needs no initialization. The
+    subsequent scatter overwrites the real token slots at the front of each
+    expert's block, leaving the alignment padding at SENTINEL. Correctness is
+    identical to the 3-kernel path; the only difference is fewer launches.
+    """
+    e = tl.program_id(0)
+    r = tl.arange(0, NLE_POW2)
+    mask = r < num_local_experts
+    h = tl.load(tokens_per_expert_ptr + r, mask=mask, other=0)
+    if ALIGNMENT > 1:
+        h = tl.where(h > 0, ((h + ALIGNMENT - 1) // ALIGNMENT) * ALIGNMENT, h)
+    inc = tl.cumsum(h, axis=0)
+    exc = inc - h
+    # Select this CTA's own offsets by masked reduction over the lane axis.
+    excl_e = tl.sum(tl.where(r == e, exc, 0))
+    incl_e = tl.sum(tl.where(r == e, inc, 0))
+    tl.store(exclusive_offsets_ptr + e, excl_e)
+    tl.store(inclusive_offsets_ptr + e, incl_e)
+
+    start_block = excl_e // ALIGNMENT
+    end_block = incl_e // ALIGNMENT
+    for off in tl.range(start_block, end_block, FILL_BLOCK):
+        idxs = off + tl.arange(0, FILL_BLOCK)
+        tl.store(expert_ids_ptr + idxs, e, mask=idxs < end_block)
+
+    for off in tl.range(excl_e, incl_e, FILL_BLOCK):
+        idxs = off + tl.arange(0, FILL_BLOCK)
+        tl.store(sorted_token_ids_ptr + idxs, SENTINEL, mask=idxs < incl_e)
+
+
+@triton.jit
+def _count_prefix_fill_init_kernel(
+    routing_map_ptr,  # [max_tokens, topk] expert assignments (global IDs)
+    valid_tokens_ptr,  # scalar int32 CUDA tensor: valid tokens this iteration
+    exclusive_offsets_ptr,  # [num_local_experts] out: exclusive prefix sum (scatter counters)
+    inclusive_offsets_ptr,  # [num_local_experts] out: inclusive prefix sum
+    expert_ids_ptr,  # [max_blocks] out: expert index per BLOCK_SIZE_M block
+    sorted_token_ids_ptr,  # [max_sorted] out: SENTINEL-initialized indirection table
+    num_local_experts,
+    local_expert_start,
+    topk: tl.constexpr,
+    SENTINEL: tl.constexpr,
+    ALIGNMENT: tl.constexpr,  # = BLOCK_SIZE_M
+    NUM_BINS: tl.constexpr,  # next_power_of_2(num_local_experts + 1)
+    COUNT_BLOCK: tl.constexpr,  # pairs histogrammed per iteration
+    FILL_BLOCK: tl.constexpr,  # vectorized store width
+):
+    """``_prefix_fill_init_kernel`` with the per-expert token count folded in.
+
+    ``_prefix_fill_init_kernel`` already has every CTA redundantly recompute the
+    tiny ``num_local_experts``-wide cumsum in registers, and its only input is
+    the count vector. That vector costs two extra launches to produce: a
+    ``torch.zeros`` fill for the counters plus
+    ``_count_local_tokens_kernel_persistent``. Recomputing the histogram
+    redundantly in every CTA removes both launches.
+
+    The count kernel is far more expensive than its work implies (measured 7.52
+    us of device time in the BS256 decode graph, against a 0.72 us empty-kernel
+    floor, to bucket 2048 int32s): with ``BLOCK_SIZE=1024`` and 2048 valid pairs
+    only 2 of its 152 CTAs receive any work, and each issues 1024 global atomics
+    contending on 32 counters. Here each CTA instead accumulates a private
+    register histogram over the same pairs, so there are no global atomics and
+    no cross-CTA ordering at all.
+
+    Counts are integer-identical to the atomic path, so the whole indirection
+    table -- and therefore the GEMM output -- is unchanged.
+
+    Redundant work is the trade: every CTA reads all ``valid_pairs`` entries, so
+    the read volume is ``num_local_experts x`` the atomic path's. At decode that
+    is 32 x 8 KB from L2 and free; the caller restricts this variant to the
+    decode regime for that reason.
+    """
+    e = tl.program_id(0)
+    valid_pairs = tl.load(valid_tokens_ptr) * topk
+
+    # Private per-CTA histogram of local expert IDs. Non-local and out-of-range
+    # pairs are folded into the dropped bin `num_local_experts`, which NUM_BINS
+    # is sized to hold and the mask below discards.
+    acc = tl.zeros([NUM_BINS], dtype=tl.int32)
+    for base in tl.range(0, valid_pairs, COUNT_BLOCK):
+        offs = base + tl.arange(0, COUNT_BLOCK)
+        m = offs < valid_pairs
+        eids = tl.load(routing_map_ptr + offs, mask=m, other=-1)
+        lids = eids - local_expert_start
+        is_local = (lids >= 0) & (lids < num_local_experts) & m
+        # routing_map is int64; tl.histogram wants int32 bin indices.
+        bins = tl.where(is_local, lids, num_local_experts).to(tl.int32)
+        acc += tl.histogram(bins, NUM_BINS)
+
+    r = tl.arange(0, NUM_BINS)
+    mask = r < num_local_experts
+    h = tl.where(mask, acc, 0)
+    if ALIGNMENT > 1:
+        h = tl.where(h > 0, ((h + ALIGNMENT - 1) // ALIGNMENT) * ALIGNMENT, h)
+    inc = tl.cumsum(h, axis=0)
+    exc = inc - h
+    excl_e = tl.sum(tl.where(r == e, exc, 0))
+    incl_e = tl.sum(tl.where(r == e, inc, 0))
+    tl.store(exclusive_offsets_ptr + e, excl_e)
+    tl.store(inclusive_offsets_ptr + e, incl_e)
+
+    start_block = excl_e // ALIGNMENT
+    end_block = incl_e // ALIGNMENT
+    for off in tl.range(start_block, end_block, FILL_BLOCK):
+        idxs = off + tl.arange(0, FILL_BLOCK)
+        tl.store(expert_ids_ptr + idxs, e, mask=idxs < end_block)
+
+    for off in tl.range(excl_e, incl_e, FILL_BLOCK):
+        idxs = off + tl.arange(0, FILL_BLOCK)
+        tl.store(sorted_token_ids_ptr + idxs, SENTINEL, mask=idxs < incl_e)
+
+
+@triton.jit
+def _align_single_kernel(
+    routing_map_ptr,  # [max_tokens, topk] expert assignments (global IDs)
+    valid_tokens_ptr,  # scalar int32 CUDA tensor: valid tokens this iteration
+    exclusive_offsets_ptr,  # [num_local_experts] out: exclusive prefix sum
+    inclusive_offsets_ptr,  # [num_local_experts] out: inclusive prefix sum
+    expert_ids_ptr,  # [max_blocks] out: expert index per BLOCK_SIZE_M block
+    sorted_token_ids_ptr,  # [max_sorted] out: indirection table
+    num_local_experts,
+    local_expert_start,
+    topk: tl.constexpr,
+    SENTINEL: tl.constexpr,
+    ALIGNMENT: tl.constexpr,  # = BLOCK_SIZE_M
+    NUM_BINS: tl.constexpr,  # next_power_of_2(num_local_experts + 1)
+    COUNT_BLOCK: tl.constexpr,  # pairs processed per iteration
+    FILL_BLOCK: tl.constexpr,  # vectorized store width
+):
+    """``_count_prefix_fill_init_kernel`` with the scatter folded in: the whole
+    indirection-table build in one launch.
+
+    CTA ``e`` owns local expert ``e`` and the disjoint output slice
+    ``[excl_e, incl_e)``. It already streams every valid pair once to build its
+    private histogram; a second streaming pass over the same (L2-resident, 16 KB
+    at decode) pairs lets it place its own pairs itself. Within a pass the
+    destination is ``excl_e + written_so_far + exclusive_cumsum(is_mine)``, so
+    no global atomics and no cross-CTA ordering are involved, and the resulting
+    table is deterministic (ascending pair index within each expert block)
+    rather than atomically permuted.
+
+    The second pass is why this is not free: it doubles the redundant read of
+    the routing map. The pairs are tiny and cached, so the trade is one removed
+    launch (``_scatter_token_indices_kernel``, measured 2.66 us + 0.55 us of
+    dispatch gap per layer in the BS256 decode graph) against that extra pass.
+
+    Row order within an expert block does not affect the result: each row of
+    ``sorted_token_ids`` is a ``token * topk + slot`` pair index, and the FC2
+    output is indexed by that same pair index, so any permutation within a
+    block produces identical values downstream.
+    """
+    e = tl.program_id(0)
+    valid_pairs = tl.load(valid_tokens_ptr) * topk
+
+    acc = tl.zeros([NUM_BINS], dtype=tl.int32)
+    for base in tl.range(0, valid_pairs, COUNT_BLOCK):
+        offs = base + tl.arange(0, COUNT_BLOCK)
+        m = offs < valid_pairs
+        eids = tl.load(routing_map_ptr + offs, mask=m, other=-1)
+        lids = eids - local_expert_start
+        is_local = (lids >= 0) & (lids < num_local_experts) & m
+        bins = tl.where(is_local, lids, num_local_experts).to(tl.int32)
+        acc += tl.histogram(bins, NUM_BINS)
+
+    r = tl.arange(0, NUM_BINS)
+    mask = r < num_local_experts
+    h = tl.where(mask, acc, 0)
+    if ALIGNMENT > 1:
+        h = tl.where(h > 0, ((h + ALIGNMENT - 1) // ALIGNMENT) * ALIGNMENT, h)
+    inc = tl.cumsum(h, axis=0)
+    exc = inc - h
+    excl_e = tl.sum(tl.where(r == e, exc, 0))
+    incl_e = tl.sum(tl.where(r == e, inc, 0))
+    tl.store(exclusive_offsets_ptr + e, excl_e)
+    tl.store(inclusive_offsets_ptr + e, incl_e)
+
+    start_block = excl_e // ALIGNMENT
+    end_block = incl_e // ALIGNMENT
+    for off in tl.range(start_block, end_block, FILL_BLOCK):
+        idxs = off + tl.arange(0, FILL_BLOCK)
+        tl.store(expert_ids_ptr + idxs, e, mask=idxs < end_block)
+
+    # SENTINEL-fill this expert's slice first; the scatter below overwrites the
+    # real pairs at the front of it and leaves the alignment padding sentinel.
+    for off in tl.range(excl_e, incl_e, FILL_BLOCK):
+        idxs = off + tl.arange(0, FILL_BLOCK)
+        tl.store(sorted_token_ids_ptr + idxs, SENTINEL, mask=idxs < incl_e)
+
+    pos = excl_e
+    for base in tl.range(0, valid_pairs, COUNT_BLOCK):
+        offs = base + tl.arange(0, COUNT_BLOCK)
+        m = offs < valid_pairs
+        eids = tl.load(routing_map_ptr + offs, mask=m, other=-1)
+        is_mine = (eids - local_expert_start == e) & m
+        sel = is_mine.to(tl.int32)
+        rank = tl.cumsum(sel, axis=0) - sel
+        tl.store(sorted_token_ids_ptr + pos + rank, offs, mask=is_mine)
+        pos += tl.sum(sel)
+
+
+# Fuse init + prefix-sum + expert-block fill (3 tiny serial kernels) into one
+# launch in the decode indirection-table build. Env-toggleable for A/B; the
+# fused path is numerically identical to the default (only launch count differs).
+_USE_FUSED_ALIGN: bool = os.environ.get("MCORE_MOE_FUSED_ALIGN", "0") == "1"
+
+# Additionally fold the per-expert token count (and the `torch.zeros` fill of its
+# counter buffer) into that same launch, taking the decode indirection-table
+# build from 4 kernels to 2. Requires MCORE_MOE_FUSED_ALIGN. Integer-exact.
+_USE_FUSED_COUNT: bool = os.environ.get("MCORE_MOE_FUSED_COUNT", "0") == "1"
+
+# Above this token hint the redundant per-CTA histogram stops being free, so hand
+# back to the atomic count kernel, whose read volume does not scale with the
+# expert count. 512 matches the decode regime `_get_decode_tuned_configs` targets.
+_FUSED_COUNT_MAX_TOKENS = 512
+
+# Additionally fold the scatter into that same launch, taking the decode
+# indirection-table build from 2 kernels to 1. Requires MCORE_MOE_FUSED_COUNT.
+# Produces the same table up to row order within an expert block, which the
+# downstream pair-indexed GEMM is invariant to.
+_USE_FUSED_SCATTER: bool = os.environ.get("MCORE_MOE_FUSED_SCATTER", "0") == "1"
+
+
+def _moe_align_block_size_fused(
+    routing_map: torch.Tensor,
+    block_size: int,
+    num_local_experts: int,
+    local_expert_start: int,
+    valid_tokens: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """3-kernel indirection-table build (count -> prefix_fill_init -> scatter).
+
+    Drop-in replacement for ``_moe_align_block_size_cuda_graphable`` that folds
+    the separate init + prefix-sum + fill kernels into ``_prefix_fill_init_kernel``.
+    Returns the same (sorted_token_ids, expert_ids, num_tokens_post_padded).
+    """
+    max_tokens, topk = routing_map.shape
+    device = routing_map.device
+
+    max_sorted = max_tokens * topk + block_size * (num_local_experts + 1)
+    max_blocks = _ceil_div(max_sorted, block_size)
+    sentinel = max_tokens * topk
+
+    sorted_token_ids = torch.empty(max_sorted, dtype=torch.int32, device=device)
+    expert_ids = torch.empty(max_blocks, dtype=torch.int32, device=device)
+
+    tokens_per_expert = compute_local_tokens_per_expert(
+        routing_map, local_expert_start, num_local_experts, valid_tokens, persistent=True
+    )
+    exclusive_offsets = torch.empty(num_local_experts, dtype=torch.int32, device=device)
+    inclusive_offsets = torch.empty(num_local_experts, dtype=torch.int32, device=device)
+
+    _prefix_fill_init_kernel[(num_local_experts,)](
+        tokens_per_expert,
+        exclusive_offsets,
+        inclusive_offsets,
+        expert_ids,
+        sorted_token_ids,
+        num_local_experts,
+        SENTINEL=sentinel,
+        ALIGNMENT=block_size,
+        NLE_POW2=triton.next_power_of_2(num_local_experts),
+        FILL_BLOCK=128,
+    )
+
+    max_pairs = max_tokens * topk
+    SCATTER_BLOCK = 256
+    scatter_grid = _ceil_div(max_pairs, SCATTER_BLOCK)
+    _scatter_token_indices_kernel[(scatter_grid,)](
+        routing_map,
+        sorted_token_ids,
+        exclusive_offsets,
+        valid_tokens,
+        topk,
+        local_expert_start,
+        num_local_experts,
+        max_pairs,
+        BLOCK_SIZE=SCATTER_BLOCK,
+    )
+
+    num_tokens_post_padded = inclusive_offsets[-1:]
+    return sorted_token_ids, expert_ids, num_tokens_post_padded
+
+
+def _moe_align_block_size_count_fused(
+    routing_map: torch.Tensor,
+    block_size: int,
+    num_local_experts: int,
+    local_expert_start: int,
+    valid_tokens: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """2-kernel indirection-table build (count_prefix_fill_init -> scatter).
+
+    Same contract and same outputs as ``_moe_align_block_size_fused``; it just
+    folds the token count and its counter-buffer zero-fill into the first launch.
+    """
+    max_tokens, topk = routing_map.shape
+    device = routing_map.device
+
+    max_sorted = max_tokens * topk + block_size * (num_local_experts + 1)
+    max_blocks = _ceil_div(max_sorted, block_size)
+    sentinel = max_tokens * topk
+
+    sorted_token_ids = torch.empty(max_sorted, dtype=torch.int32, device=device)
+    expert_ids = torch.empty(max_blocks, dtype=torch.int32, device=device)
+    exclusive_offsets = torch.empty(num_local_experts, dtype=torch.int32, device=device)
+    inclusive_offsets = torch.empty(num_local_experts, dtype=torch.int32, device=device)
+
+    _count_prefix_fill_init_kernel[(num_local_experts,)](
+        routing_map,
+        valid_tokens,
+        exclusive_offsets,
+        inclusive_offsets,
+        expert_ids,
+        sorted_token_ids,
+        num_local_experts,
+        local_expert_start,
+        topk=topk,
+        SENTINEL=sentinel,
+        ALIGNMENT=block_size,
+        NUM_BINS=triton.next_power_of_2(num_local_experts + 1),
+        COUNT_BLOCK=1024,
+        FILL_BLOCK=128,
+    )
+
+    max_pairs = max_tokens * topk
+    SCATTER_BLOCK = 256
+    scatter_grid = _ceil_div(max_pairs, SCATTER_BLOCK)
+    _scatter_token_indices_kernel[(scatter_grid,)](
+        routing_map,
+        sorted_token_ids,
+        exclusive_offsets,
+        valid_tokens,
+        topk,
+        local_expert_start,
+        num_local_experts,
+        max_pairs,
+        BLOCK_SIZE=SCATTER_BLOCK,
+    )
+
+    num_tokens_post_padded = inclusive_offsets[-1:]
+    return sorted_token_ids, expert_ids, num_tokens_post_padded
+
+
+def _moe_align_block_size_single(
+    routing_map: torch.Tensor,
+    block_size: int,
+    num_local_experts: int,
+    local_expert_start: int,
+    valid_tokens: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """1-kernel indirection-table build.
+
+    Same contract and same outputs as ``_moe_align_block_size_count_fused``,
+    with the scatter folded into the single launch as well. Row order within an
+    expert block is ascending pair index instead of atomically permuted; the
+    downstream GEMM indexes rows by pair id, so the result is unchanged.
+    """
+    max_tokens, topk = routing_map.shape
+    device = routing_map.device
+
+    max_sorted = max_tokens * topk + block_size * (num_local_experts + 1)
+    max_blocks = _ceil_div(max_sorted, block_size)
+    sentinel = max_tokens * topk
+
+    sorted_token_ids = torch.empty(max_sorted, dtype=torch.int32, device=device)
+    expert_ids = torch.empty(max_blocks, dtype=torch.int32, device=device)
+    exclusive_offsets = torch.empty(num_local_experts, dtype=torch.int32, device=device)
+    inclusive_offsets = torch.empty(num_local_experts, dtype=torch.int32, device=device)
+
+    _align_single_kernel[(num_local_experts,)](
+        routing_map,
+        valid_tokens,
+        exclusive_offsets,
+        inclusive_offsets,
+        expert_ids,
+        sorted_token_ids,
+        num_local_experts,
+        local_expert_start,
+        topk=topk,
+        SENTINEL=sentinel,
+        ALIGNMENT=block_size,
+        NUM_BINS=triton.next_power_of_2(num_local_experts + 1),
+        COUNT_BLOCK=1024,
+        FILL_BLOCK=128,
+    )
+
+    num_tokens_post_padded = inclusive_offsets[-1:]
+    return sorted_token_ids, expert_ids, num_tokens_post_padded
 
 
 def _moe_align_block_size_cuda_graphable(
@@ -634,7 +1053,16 @@ def vllm_fused_moe(
     # buffer size. Same config is used for both FC1 and FC2 (matches vLLM).
     config = _get_default_config(M=effective_tokens, E=num_local_experts, top_k=topk)
 
-    sorted_token_ids, expert_ids, num_post_padded = _moe_align_block_size_cuda_graphable(
+    if _USE_FUSED_ALIGN and _USE_FUSED_COUNT and effective_tokens <= _FUSED_COUNT_MAX_TOKENS:
+        if _USE_FUSED_SCATTER:
+            align_fn = _moe_align_block_size_single
+        else:
+            align_fn = _moe_align_block_size_count_fused
+    elif _USE_FUSED_ALIGN:
+        align_fn = _moe_align_block_size_fused
+    else:
+        align_fn = _moe_align_block_size_cuda_graphable
+    sorted_token_ids, expert_ids, num_post_padded = align_fn(
         routing_map, config['BLOCK_SIZE_M'], num_local_experts, local_expert_start, valid_tokens
     )
     num_valid = max_tokens * topk

--- a/megatron/core/transformer/moe/experts.py
+++ b/megatron/core/transformer/moe/experts.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import inspect
 import logging
+import os
 from collections.abc import Callable
 from contextlib import nullcontext
 from copy import deepcopy
@@ -86,6 +87,12 @@ from megatron.core.inference.moe import ActivationType as McoreActivationType
 from megatron.core.inference.moe import InferenceGroupedGemmBackend, mcore_fused_moe, vllm_fused_moe
 
 logger = logging.getLogger(__name__)
+
+# Fuse SiLU(gate)*up into the decode FC1 GEMM epilogue, removing the standalone
+# bounded_silu_mul kernel and the 2N intermediate HBM round-trip. No-op for
+# non-SwiGLU activations. Not bit-exact (max_abs 3.9e-5), so it is opt-in. Read
+# once here rather than per forward: the consumer is on the per-layer decode path.
+_FUSE_FC1_ACT: bool = os.environ.get("MCORE_FUSE_FC1_ACT", "0") == "1"
 
 
 class GroupedLinearFc1Interface(Protocol):
@@ -1200,6 +1207,7 @@ class InferenceGroupedMLP(TEGroupedMLP):
             routing_map=routing_map,
             out=NVLSAllGatherVDispatcher._get_rsv_tensor() if self._nvls_dispatcher else None,
             num_tokens_hint=InferenceAllGatherDispatcherBase._get_host_valid_tokens_estimate(),
+            fuse_fc1_activation=_FUSE_FC1_ACT,
         )
         return output, None
 


### PR DESCRIPTION
> Stacked on #6452. Review that one first; this diff is only the decode MoE indirection-table build, collapsed from six launches per layer into one.
>
> GitHub cannot base a pull request from a fork on another unmerged fork branch, so the diff below also contains the parent's commits. This PR's own change is the final commit, `45ddfd787`; review that one. The rest lands with the parent.

## Summary

Every MoE layer rebuilds an indirection table over ~2048 routing pairs and 32 local
experts, and it took six launches to do it: a sentinel init over the whole table buffer,
a `torch.zeros` fill of a 32-entry counter, an atomic per-expert token count, an aligned
prefix sum, a block→expert fill, and the scatter. This PR collapses all six into one
kernel with one CTA per local expert — 240 launches removed per decode step at 48 layers
— and the build's device time under CUDA-graph replay drops from **16.38 µs to 8.23 µs**
per layer at the decode point, bit-exactly: **+7.21%** end-to-end.

The interesting part is that this is not a launch-count win, even though it looks like
one. A per-kernel breakdown showed the intra-graph dispatch gap is only 0.55 µs and an
empty kernel is 0.72 µs, so of the routing category's ~1531 µs per step only 366 µs is
fixed launch cost. What made the build expensive was one kernel that ran on 2 of the
GPU's 152 CTAs.

## Why here

A per-kernel breakdown of one steady-state decode step (9927 µs wall, 7900 µs GPU-busy,
1362 kernels) attributed the routing/permute category — 1251 µs, 15.8% of the step, 242
kernels averaging 5.2 µs — to individual kernel names, with device time and the dispatch
gap that follows each launch. Three measurements set the ceilings. The dispatch gap is
0.55 µs and uniform across kernels in the graph, so a removed launch is worth `duration +
0.55 µs` — more than its device time, far less than the 5.2 µs average would suggest.
The fixed floor per launch is 1.27 µs (0.72 µs empty kernel + the gap). And of the
category's ~1531 µs/step of wall, 366 µs is fixed cost and 1165 µs is real in-kernel
work, so pure launch-count reduction can win at most 3.7% and only by removing every
routing launch.

Against that, `_count_local_tokens_kernel_persistent` cost **7.52 µs per layer to bucket
2048 int32s** — 387 µs/step. It is neither launch-bound (0.72 µs floor) nor
bandwidth-bound (8 KB): with `BLOCK_SIZE=1024` and 2048 valid pairs `total_blocks = 2`,
so exactly **2 of its 152 CTAs receive any work**, and each of those issues 1024 global
atomics contending on 32 counters. Folding it and its `torch.zeros` fill into the kernel
that consumes its output was priced at 48 × (7.52 + 0.55 + 0.74 + 0.55) = **449 µs/step**,
needing no grid synchronisation and integer-exact. This PR captured **291 µs** of that
449; the shortfall is the merged kernel's own cost, which rises from 1.33 to 3.73 µs
because each of the 32 CTAs now histograms all 2048 pairs instead of reading a 32-element
vector.

That breakdown also corrected an earlier wrong conclusion in this campaign, which is
worth stating because it is the reason the fix looks the way it does. An earlier attempt
replaced the count kernel's per-pair atomics with `tl.histogram` but left `BLOCK_SIZE=1024`
alone, so both variants still ran on 2 CTAs; it measured a wash and inferred that the
cost was per-launch overhead and that an in-kernel rewrite could not help. The device-time
split says the opposite — 6.8 of the 7.52 µs is in-kernel — and the fix was to stop
running the count on 2 of 152 CTAs, not to change how it reduces.

## What changed

**Before, six launches per MoE layer.** `_init_sorted_ids_kernel` sentinel-fills the
entire `sorted_token_ids` buffer and −1-fills `expert_ids`; `torch.zeros` allocates and
zeroes the 32-entry counter; `_count_local_tokens_kernel_persistent` atomically
histograms the routing pairs into it; `_prefix_sum_kernel` (grid of 1) computes the
aligned exclusive and inclusive offsets; `_fill_expert_block_ids_kernel` writes the
block→expert map; `_scatter_token_indices_kernel` atomically places each local pair index
into its expert's block.

**After, one launch.** The feature arrives as three nested steps, each a superset of the
previous:

*Step one (`MCORE_MOE_FUSED_ALIGN`), six launches to four.* `_prefix_fill_init_kernel`
runs one CTA per local expert. Every CTA redundantly recomputes the whole 32-wide aligned
cumsum in registers — it is 32 int32s — and then CTA `e` writes only its own disjoint
slices: its two offsets, `expert_ids[excl_e/BM : incl_e/BM] = e`, and
`sorted_token_ids[excl_e : incl_e] = SENTINEL`. Because the cumsum is redundant and the
slices are disjoint, no grid synchronisation is needed. It also shrinks the init itself:
the union of the per-expert ranges is exactly `[0, num_tokens_post_padded)`, which is the
only region the grouped GEMM ever reads, so the buffer tail that the old init kernel
wrote across its whole `max_tokens*topk + BM*(E+1)` length needs no initialisation at all.

*Step two (`MCORE_MOE_FUSED_COUNT`), four launches to two.* Since every CTA already
recomputes the cumsum and the count vector is that kernel's only input,
`_count_prefix_fill_init_kernel` has each CTA build its own `tl.histogram` over the
routing pairs in registers. The `torch.zeros` and the atomic count kernel both go away,
again with no grid synchronisation and now no global atomics anywhere in the build. The
trade is redundant reads: every CTA reads all valid pairs, so read volume is
`num_local_experts ×` the atomic path's — 32 × 8 KB out of L2 at decode, which is why the
caller caps this variant at a 512-token hint.

*Step three (`MCORE_MOE_FUSED_SCATTER`), two launches to one.* CTA `e` already streams
every pair once to build its histogram, so `_align_single_kernel` gives it a second
streaming pass over the same 16 KB and lets it place its own rows itself, at
`excl_e + written_so_far + exclusive_cumsum(is_mine)`. No atomics, no grid sync, and the
resulting table is deterministic — ascending pair index within each expert block — instead
of atomically permuted. The trade is that the second pass scales with the pair count while
the removed launch does not, which is why it stops paying above the decode point.

**Why the three ship as one PR.** The nesting is real and enforced by the dispatch: the
count fold is only reachable with the align fold on, and the scatter fold only with the
count fold on. Each intermediate state exists solely as the stepping stone to the next,
so splitting them would open two PRs nobody would ever ship on their own.

## Measurement

Fixed protocol: Qwen3-30B-A3B, BF16, TP 1 / PP 1 / EP 4 / ETP 1, 256 gsm8k requests, 1024 output tokens, 2 warmup + 5 timed iterations, a single OCI 4xGB200 node (nvl72160-T04), async dynamic-batching scheduler pinned on. All 20 arms ran back to back in one allocation on that one node; node-to-node variance on this workload is around 2.7%, so cross-node numbers would not be comparable.

- With this change (every other gate in the stack enabled): **31,697 tok/s**
- Without it (same node, same session, only this gate turned off): **29,565 tok/s**
- Leave-one-out delta: **+7.21%**
- Noise floor: sigma = **0.42%** over 3 repeats of the all-gates-on reference
- Verdict: **resolved**; the per-iteration distributions separate completely (every timed iteration of the better arm beats every timed iteration of the worse one)

This is the **marginal contribution measured with every other gate in this stack enabled** — the question a reviewer is actually asking, which is whether this should land, not what it was worth when it was first written.

The reference is drift-corrected. The all-gates-on configuration was re-measured three times across the session (31,745, 31,530, 31,503 tok/s), a +0.77% drift from first to last, so each arm is compared against the reference interpolated to its own position in the run order rather than against a session mean.

For context, the whole stack is worth **+35.80%** on this node (23,265 tok/s with every gate off, 31,593 with every gate on). Per-slice deltas do not sum to that; they compose sub-additively.

## Evidence

Device time under CUDA-graph replay at the decode point (256 valid tokens, 300 replays ×
3 repeats). The count fold: table build **16.38 → 10.24 µs (1.600×)**, whole
`vllm_fused_moe` call **86.02 → 79.96 µs (1.076×)**, i.e. 6.06 µs × 48 layers = 291 µs of
a 9.93 ms step. The scatter fold on top: table build **10.08 → 8.23 µs (1.224×)**, whole
call **82.17 → 79.56 µs (1.033×)**. The two pairs come from different sessions with
different sets of other gates enabled, which is why their baselines differ slightly
(86.02 against 82.17); read each as its own A/B rather than chaining them arithmetically.

Eager per-kernel attribution over 100 iterations shows the merges directly. Count fold:
`_count_local_tokens` 4.76 + the `torch.zeros` fill 1.20 + `_prefix_fill_init` 1.76 =
7.72 µs in three kernels, replaced by one kernel at 3.73 µs; the build's total device
time goes 10.17 → 6.11 µs. Scatter fold: `_count_prefix_fill_init` 3.74 +
`_scatter_token_indices` 2.38 = 6.12 µs in two kernels, replaced by `_align_single_kernel`
at 4.91 µs.

Liveness, from a steady-state decode profile with the align fold on: `_init_sorted_ids_kernel`,
`_prefix_sum_kernel` and `_fill_expert_block_ids_kernel` all appear **zero** times, and
`_prefix_fill_init_kernel` appears exactly as often as the count and scatter kernels
(76,032 launches each over the window) — one per MoE layer per step where there were
three. That profile predates the other two folds; those are evidenced by the eager
per-kernel tables above, where the replaced kernel names disappear and the merged kernel
appears in their place.

## Correctness

- **Numerics:** **bit-exact.** Whole-MoE output at 128 / 256 / 384 / 512 valid tokens:
  `max_abs = 0.0` **and** `max_rel = 0.0`. The relative error is checked explicitly rather
  than through a loose `allclose`. It is bit-exact by construction and not by luck: the
  counts are integer-identical (the same bins, with non-local and out-of-range pairs
  folded into a dropped bin), so the table is the same table and the GEMMs see the same
  inputs.
- **Tests:** table equality over 16 cases — valid tokens ∈ {128, 256, 384, 512} ×
  `BLOCK_SIZE_M` ∈ {16, 64} × `local_expert_start` ∈ {0, 32}. Identical
  `num_tokens_post_padded`, identical `expert_ids`, identical multiset of
  `sorted_token_ids[0:npp]`, and the stronger check that every non-sentinel row sits in a
  block whose expert id actually owns that pair.
- **Row order:** the comparison is a multiset because the baseline scatter's atomics
  permute rows within an expert block, and the single-kernel scatter emits ascending pair
  order. Order within a block cannot change the result: each row is a `token * topk + slot`
  pair index and FC2's output is indexed by that same pair index, so any permutation
  within a block produces identical values downstream. The bit-exact whole-MoE output at
  four shapes is the direct confirmation of that argument.
- **A reported mismatch that was not one.** The first harness run flagged a table mismatch
  at `BLOCK_SIZE_M = 16`. That was a bug in the check, not the kernel: an expert's rows
  span several 16-row blocks and the two paths order them differently across that range,
  so comparing block by block reports a difference that does not exist. The whole-MoE
  output was bit-exact in the same run, which is what exposed the faulty check.
- **Coherence:** end-to-end prompts coherent and correct (`2+2=4`, Paris, `3+2` cows = 5
  cows), on both of the two repeated benchmark runs.

## Gating and blast radius

- Gates: `MCORE_MOE_FUSED_ALIGN`, `MCORE_MOE_FUSED_COUNT`, `MCORE_MOE_FUSED_SCATTER`, all
  three **default OFF** (`os.environ.get("MCORE_MOE_FUSED_...", "0") == "1"`), all read
  once at import. With all three unset, `_moe_align_block_size_cuda_graphable` runs
  exactly as before this PR.
- The nesting is enforced in the dispatch, not merely documented: the count path requires
  the align gate, and the scatter path requires the count gate. Setting the scatter or
  count gate alone does nothing.
- Precondition on the count and scatter paths: `num_tokens_hint ≤ 512`
  (`_FUSED_COUNT_MAX_TOKENS`). Above that the redundant per-CTA read of the routing pairs
  stops being free, and the code falls back to the three-kernel align path, which has no
  cap. The align path itself is shape-independent.
- Everything here is inside `vllm_fused_moe`, which only the inference
  `--transformer-impl inference_optimized` path with `--inference-grouped-gemm-backend
  vllm` reaches. Training is unaffected.

## Reproduce

```bash
MCORE_MOE_FUSED_ALIGN=1 MCORE_MOE_FUSED_COUNT=1 MCORE_MOE_FUSED_SCATTER=1 \
QWEN30B_TP=1 QWEN30B_EP=4 QWEN30B_ETP=1 \
BENCH_SIZES_OVERRIDE=256 BENCH_OUTPUT_TOKENS=1024 \
NUM_WARMUP_ITERS=2 NUM_TIMED_ITERS=5 \
bash skills/run-qwen-model/run_qwen_inference.sh qwen3-30b-a3b --checkpoint "$QWEN30B_CKPT"
```

All three gates must be exported before the interpreter imports the module; they are read
at import time.

## What this does not claim

- **The scatter fold is neutral-to-negative above the decode point.** Whole-call device
  time is 1.045× at 128 tokens, 1.033× at 256, **1.007× at 384** and **0.997× at 512** —
  a slight loss — because the extra streaming pass scales with the pair count while the
  removed launch does not. The 512-token cap keeps the count and scatter paths out of the
  shapes where they stop paying, but 384 is inside the cap and is already a wash.
- **The align fold's contribution under CUDA graphs is not in the record.** Its first
  microbench was invalidated by a harness bug — importing the module by name actually
  bound a function of the same name, so patching module flags silently no-opped and the
  A/B compared one path against itself. The corrected re-measurement is an eager wall
  number (148.67 → 124.13 µs on the whole MoE call), which overstates what a removed
  launch is worth inside a captured graph. The align fold's device-time delta under
  replay was never separately measured.
- Only **291 of the 449 µs** priced ceiling for the count fold was captured; the shortfall
  is the merged kernel's own cost rising 1.33 → 3.73 µs.
- **A rejected alternative, so nobody re-runs it:** merging count → prefix-fill → scatter
  with a cooperative grid was priced at 2 × 48 × 1.27 = 122 µs/step, which is the fixed
  cost only, before paying two `grid.sync()`s per layer against a kernel boundary that
  costs 0.55 µs. It was gated out on arithmetic and never built.
- The redundant-read trade scales with `num_local_experts`. At 32 local experts and 2048
  pairs it is free out of L2; where it stops being free was not mapped beyond the
  512-token cap.
- Nothing about `_moe_sum`, which the same breakdown ranked first in this category at
  400 µs/step. A later slice in this stack handles it.
- Deltas in this stack do not add. Every slice shortens the same MoE call and draws on the
  same intra-graph dispatch budget, so they compose sub-additively. In particular the tile
  retune later in this stack drops `BLOCK_SIZE_M` from 64 to 16, which changes this
  table's padding and therefore this kernel's fill volume.

## Follow-ups

- The router pair is the largest remaining item this breakdown left standing:
  `gatherTopK` at 6.05 µs plus a `[256, 128]` fp32 softmax at 1.94 µs is 436.8 µs/step in
  two kernels.
- `_moe_sum` at 7.79 µs/layer is ~7× its own bandwidth floor. Fusing it into the FC2
  epilogue was priced at 400 µs gross but needs cross-CTA fp32 atomics and loses
  bit-exactness; restructuring it in place does not, and is the next slice.

---

## This stack

This is one slice of [#6064](https://github.com/NVIDIA/Megatron-LM/pull/6064), a Qwen3-30B-A3B decode optimization campaign, split into 16 independently reviewable changes. Together they are **+35.80%** end-to-end throughput over the same base commit (23,265 -> 31,593 tok/s, mean of three full runs).

- **MoE grouped-GEMM and dispatch:** #6452 -> #6453 -> #6454 -> #6455
- **MoE router and combine:** #6456 -> #6457 -> #6458
- **Attention: QK norm and decode kernel:** #6459 -> #6460 -> #6461 -> #6462
- **Residual + RMSNorm fusion:** #6463 -> #6464
- **Host path: context bookkeeping:** #6465 -> #6466
- **Host path: independent:** #6467

Each chain is independent of the others and bases on `main`. Within a chain, later PRs depend on earlier ones.

### Per-slice measured delta

Every number is a leave-one-out delta from one same-node, same-session campaign: the full stack with exactly this change's gate off, against the interpolated full-stack reference at that point in the run. It is the change's *marginal* contribution with everything else already in, not its standalone value. Run-to-run sigma was **0.42%** across three full-stack repeats.

| PR | Change | Delta | |
|---|---|---|---|
| #6452 | FC1 SwiGLU epilogue | +14.81% | resolved |
| #6453 | indirection table fusion | +7.21% | resolved |
| #6454 | decode GEMM tile configs | +6.77% | resolved |
| #6455 | predicated top-k gather | +1.99% | by margin |
| #6456 | fused router softmax+top-k | +4.75% | resolved |
| #6457 | fused route padding mask | +1.47% | by margin |
| #6458 | bf16 MoE combine | +2.42% | by margin |
| #6459 | fused QK RMSNorm | +5.17% | resolved |
| #6460 | grouped QK norm input | +1.18% | by margin |
| #6461 | pin FlashAttention 2 | -0.35% | noise floor |
| #6462 | FlashInfer TRT-LLM decode | +1.46% | by margin |
| #6463 | fused add+norm pre-MLP | +3.54% | by margin |
| #6464 | fused add+norm pre-QKV | +0.98% | by margin |
| #6465 | incremental attention state | -0.42% | noise floor |
| #6466 | vectorized decode bookkeeping | -0.07% | noise floor |
| #6467 | post_process_requests fast path | +0.09% | noise floor |

`noise floor` means the delta is inside 2 sigma (0.84%) and this campaign cannot distinguish it from zero. `resolved` means the leave-one-out and full-stack iteration distributions did not overlap. Deltas do not sum to the stack total: these changes shorten the same decode step and compose sub-additively.

**Fixed protocol for every number above.** Qwen3-30B-A3B, BF16, TP1/PP1/EP4/ETP1, 256 gsm8k requests at batch size 256, output length 1024, CUDA graphs on, one OCI GB200 NVL72 node, 4 GPUs. All 20 arms ran back-to-back in a single Slurm allocation on one node, so node assignment and thermal state are held constant.
