### PR TITLE
perf(inference): per-GEMM tile configs for the decode expert GEMMs

### DIFF
--- a/megatron/core/inference/moe/vllm_fused_moe.py
+++ b/megatron/core/inference/moe/vllm_fused_moe.py
@@ -124,6 +124,7 @@ def _fused_moe_kernel(
     # Flags / constexprs
     MUL_ROUTED_WEIGHT: tl.constexpr,
     FUSE_SQUARED_RELU: tl.constexpr,
+    FUSE_SWIGLU: tl.constexpr,
     top_k: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
@@ -186,6 +187,13 @@ def _fused_moe_kernel(
                 + off_experts * stride_be
                 + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
             )
+            # SwiGLU epilogue fusion: the same [BLOCK_M, BLOCK_N] output tile of
+            # the activated intermediate needs both the gate columns (offs_bn) and
+            # the paired up columns (offs_bn + N), where N is the activated width.
+            # A second accumulator reads the up half from the same B tensor.
+            if FUSE_SWIGLU:
+                b_up_ptrs = b_ptrs + N * stride_bn
+                up_accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
 
             accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
             for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
@@ -196,6 +204,12 @@ def _fused_moe_kernel(
                 )
                 b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
                 accumulator += tl.dot(a, b)
+                if FUSE_SWIGLU:
+                    b_up = tl.load(
+                        b_up_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0
+                    )
+                    up_accumulator += tl.dot(a, b_up)
+                    b_up_ptrs += BLOCK_SIZE_K * stride_bk
                 a_ptrs += BLOCK_SIZE_K * stride_ak
                 b_ptrs += BLOCK_SIZE_K * stride_bk
 
@@ -204,6 +218,15 @@ def _fused_moe_kernel(
             if FUSE_SQUARED_RELU:
                 accumulator = tl.maximum(accumulator, 0.0)
                 accumulator *= accumulator
+
+            # SwiGLU fused on the fp32 accumulators: SiLU(gate) * up. The
+            # arithmetic matches the standalone `bounded_silu_mul` kernel, but the
+            # results are not bit-identical (measured max_abs 3.9e-5): that kernel
+            # reads gate and up after they have been rounded to bf16, while these
+            # accumulators have not been. The fused result is the less rounded of
+            # the two. Removes that kernel and the 2N intermediate round-trip.
+            if FUSE_SWIGLU:
+                accumulator = accumulator * tl.sigmoid(accumulator) * up_accumulator
 
             if MUL_ROUTED_WEIGHT:
                 moe_weight = tl.load(topk_weights_ptr + offs_token, mask=token_mask, other=0)
@@ -387,12 +410,18 @@ def _invoke_fused_moe_kernel(
     config: dict,
     grid_size: int,
     fuse_squared_relu: bool = False,
+    fuse_swiglu: bool = False,
 ):
     """Launch the Triton fused-MoE kernel for one GEMM pass.
 
     Body matches upstream vLLM `fused_moe_kernel` (1 CTA per (pid_m, pid_n)
     tile, raw pointer arithmetic with `% N` on the N axis), apart from the
     optional fused squared-relu activation in fp32.
+
+    When ``fuse_swiglu`` is set, B is the [E, 2*Nf, K] gate|up FC1 weight and the
+    kernel emits the activated [num_valid, Nf] intermediate directly (SiLU(gate) *
+    up), so ``N`` is the activated width ``Nf = B.size(1) // 2`` and each program
+    also reads the paired up columns at ``+N`` in B.
 
     `grid_size` is sized host-side from `num_tokens_hint` so launch overhead
     at decode is small.  When the actual padded length exceeds the hinted
@@ -402,6 +431,8 @@ def _invoke_fused_moe_kernel(
     """
     M = A.size(0)
     num_tokens = M * top_k
+    # For fused SwiGLU, N is the activated width (half the 2*Nf FC1 output).
+    n_dim = B.size(1) // 2 if fuse_swiglu else B.size(1)
 
     _fused_moe_kernel[(grid_size,)](
         A,
@@ -411,7 +442,7 @@ def _invoke_fused_moe_kernel(
         sorted_token_ids,
         expert_ids,
         num_tokens_post_padded,
-        B.size(1),
+        n_dim,
         B.size(2),
         num_tokens,
         A.stride(0),
@@ -423,6 +454,7 @@ def _invoke_fused_moe_kernel(
         C.stride(1),
         MUL_ROUTED_WEIGHT=mul_routed_weight,
         FUSE_SQUARED_RELU=fuse_squared_relu,
+        FUSE_SWIGLU=fuse_swiglu,
         top_k=top_k,
         BLOCK_SIZE_M=config['BLOCK_SIZE_M'],
         BLOCK_SIZE_N=config['BLOCK_SIZE_N'],
@@ -557,6 +589,7 @@ def vllm_fused_moe(
     routing_map: torch.Tensor,
     out: Optional[torch.Tensor] = None,
     num_tokens_hint: Optional[int] = None,
+    fuse_fc1_activation: bool = False,
 ) -> torch.Tensor:
     """Fused MoE using the vLLM Triton grouped-GEMM kernel (BF16).
 
@@ -580,6 +613,9 @@ def vllm_fused_moe(
         num_tokens_hint: optional host-side int with the expected number of
             valid tokens (e.g. batch_size * ep_size). Used to select a better
             BLOCK_SIZE_M instead of using the worst-case buffer size.
+        fuse_fc1_activation: for SwiGLU, fuse SiLU(gate)*up into the FC1 GEMM
+            epilogue instead of running the standalone ``bounded_silu_mul`` kernel
+            over the 2N-wide intermediate. Ignored for other activations.
 
     Returns:
         [max_tokens, hidden_size] output (fp32 when out=None, else out's dtype).
@@ -606,6 +642,14 @@ def vllm_fused_moe(
     N = fc1_weight.size(1)
     K = fc1_weight.size(2)
 
+    assert activation_type in (ActivationType.SQUARED_RELU, ActivationType.SWIGLU)
+    is_swiglu = activation_type == ActivationType.SWIGLU
+    # When enabled for SwiGLU, FC1 fuses SiLU(gate)*up into its epilogue and
+    # writes the activated [num_valid, N//2] intermediate directly, removing the
+    # standalone bounded_silu_mul kernel and the 2N intermediate round-trip.
+    use_fused_swiglu = is_swiglu and fuse_fc1_activation
+    fc1_out_width = N // 2 if use_fused_swiglu else N
+
     # Grid sized for the typical-case token count (num_tokens_hint).  When the
     # actual num_tokens_post_padded exceeds this, the kernel's outer tl.range
     # makes each CTA stride over additional tiles — correct but with reduced
@@ -614,21 +658,20 @@ def vllm_fused_moe(
     block_m = config['BLOCK_SIZE_M']
     em_hint = effective_tokens * topk + block_m * num_local_experts
     num_pid_m_hint = _ceil_div(em_hint, block_m)
-    num_pid_n_fc1 = _ceil_div(N, config['BLOCK_SIZE_N'])
+    num_pid_n_fc1 = _ceil_div(fc1_out_width, config['BLOCK_SIZE_N'])
     num_pid_n_fc2 = _ceil_div(K, config['BLOCK_SIZE_N'])
     grid_size_fc1 = num_pid_m_hint * num_pid_n_fc1
     grid_size_fc2 = num_pid_m_hint * num_pid_n_fc2
 
     topk_weights_flat = probs.reshape(-1).contiguous()
 
-    # FC1 + activation: [max_tokens, K] → [max_tokens*topk, N]
-    # SQUARED_RELU fuses into the GEMM epilogue (elementwise). SwiGLU pairs column c
-    # with c+N/2 across tiles and cannot, so FC1 runs unfused to the 2N-wide
-    # intermediate and gate/up is applied separately below.
-    assert activation_type in (ActivationType.SQUARED_RELU, ActivationType.SWIGLU)
-    is_swiglu = activation_type == ActivationType.SWIGLU
+    # FC1 + activation: [max_tokens, K] → [max_tokens*topk, fc1_out_width]
+    # SQUARED_RELU fuses into the GEMM epilogue (elementwise). SwiGLU pairs column
+    # c with c+N/2 across N-tiles; the unfused path writes the 2N intermediate and
+    # applies gate/up separately below, while the fused path (use_fused_swiglu)
+    # reads both halves per program and writes the N//2 activated output directly.
     intermediate1 = torch.empty(
-        num_valid, N, dtype=hidden_states.dtype, device=hidden_states.device
+        num_valid, fc1_out_width, dtype=hidden_states.dtype, device=hidden_states.device
     )
     _invoke_fused_moe_kernel(
         hidden_states,
@@ -643,8 +686,9 @@ def vllm_fused_moe(
         config=config,
         grid_size=grid_size_fc1,
         fuse_squared_relu=not is_swiglu,
+        fuse_swiglu=use_fused_swiglu,
     )
-    if is_swiglu:
+    if is_swiglu and not use_fused_swiglu:
         # intermediate1 is [num_valid, 2N] (gate | up); reduce to [num_valid, N] via
         # SiLU(gate) * up over the valid_tokens*topk live rows only.
         n_rows = (valid_tokens * topk).to(torch.int32)

--- a/megatron/core/inference/moe/vllm_fused_moe.py
+++ b/megatron/core/inference/moe/vllm_fused_moe.py
@@ -100,6 +100,60 @@ def _get_default_config(M: int, E: int, top_k: int) -> dict:
     }
 
 
+# Retune the two grouped GEMMs independently for the MoE *decode* regime.
+# Env-toggleable for A/B; the tuned path is the same kernel with different M and N
+# tiles. It inherits BLOCK_SIZE_K, which is what fixes the fp32 reduction order, so
+# the results are bit-exact against the default config.
+_TUNE_DECODE_GEMM: bool = os.environ.get("MCORE_MOE_GEMM_TUNE", "0") == "1"
+
+
+def _get_decode_tuned_configs(M: int, E: int, top_k: int) -> tuple[dict, dict]:
+    """Per-GEMM launch configs for the decode regime; returns (fc1, fc2).
+
+    Measured on GB200 at the Qwen3-30B-A3B EP4 decode shape (hidden 2048,
+    moe_ffn 768, 32 local experts, top-8, 256 tokens): expert-weight traffic is
+    302 MB per layer against a 6.08 TB/s streaming-read ceiling, i.e. a 49.7 us
+    floor, while `_get_default_config` lands at 72.1 us. The gap is *not* FLOPs
+    (63-83 TFLOP/s achieved, ~3% of BF16 peak) and not the indirection-table
+    padding (shrinking it 3.9x -> 1.5x buys only ~1.2x); it is tile-quantized
+    SM occupancy. `_get_default_config` picks BLOCK_SIZE_N=128 for both GEMMs,
+    which leaves FC1 at ceil(768/128)=6 N-tiles x 32 M-tiles = 192 CTAs on 148
+    SMs — 1.3 waves, so ~30% of the machine idles in the tail.
+
+    So the two GEMMs want opposite N-tiles at decode: FC1 (narrow N=768) needs a
+    *small* BLOCK_SIZE_N to manufacture enough CTAs to fill the GPU, while FC2
+    (wide N=2048) already has plenty and prefers a *large* one for weight-load
+    efficiency. `_get_default_config` cannot express that because vLLM shares one
+    config across both passes. BLOCK_SIZE_M stays shared — one indirection table
+    is built for both GEMMs — and is dropped to 16 to cut padded rows as well.
+
+    Measured FC1+FC2, median of 3 x 300 iters: 72.13 us default -> 57.24 us here
+    (1.26x), i.e. 1.15x off the streaming-read floor.
+
+    Falls back to the shared default outside the decode regime (large M is
+    compute-bound and vLLM's heuristic is tuned for it).
+    """
+    default = _get_default_config(M, E, top_k)
+    # Measured CUDA-graph device time vs the default config: 1.289x at 128
+    # tokens, 1.197x at 256 (the decode point, = local_tokens * ep_size),
+    # 1.120x at 384, but 0.952x at 512 — past ~384 tokens there are already
+    # enough M-tiles to fill the GPU and the narrow FC1 tile starts costing
+    # weight-load efficiency. Hand back to upstream's heuristic there.
+    if M > 384:
+        return default, default
+    shared = dict(default)
+    shared['BLOCK_SIZE_M'] = 16
+    shared['GROUP_SIZE_M'] = 1
+    # BLOCK_SIZE_K is deliberately inherited rather than set. The fp32 K-reduction
+    # order is a function of BLOCK_SIZE_K alone, so inheriting it keeps this path
+    # bit-exact against the default config at every M. The default is already 64
+    # throughout the measured range (it only rises to 128 at M <= 64), so this is
+    # a no-op where the configs below were tuned.
+    fc1 = dict(shared, BLOCK_SIZE_N=64, num_warps=4, num_stages=3)
+    fc2 = dict(shared, BLOCK_SIZE_N=256, num_warps=8, num_stages=4)
+    return fc1, fc2
+
+
 @triton.jit
 def _fused_moe_kernel(
     # Pointers
@@ -1050,8 +1104,19 @@ def vllm_fused_moe(
 
     # Mirror upstream vLLM: pick the full launch config (tile sizes, warps,
     # stages) host-side from the token-count hint, not from the worst-case
-    # buffer size. Same config is used for both FC1 and FC2 (matches vLLM).
-    config = _get_default_config(M=effective_tokens, E=num_local_experts, top_k=topk)
+    # buffer size. Same config is used for both FC1 and FC2 (matches vLLM),
+    # unless the decode retune is enabled, which tiles the two passes
+    # separately (they have very different N) around a shared BLOCK_SIZE_M.
+    if _TUNE_DECODE_GEMM:
+        config_fc1, config_fc2 = _get_decode_tuned_configs(
+            M=effective_tokens, E=num_local_experts, top_k=topk
+        )
+    else:
+        config_fc1 = config_fc2 = _get_default_config(
+            M=effective_tokens, E=num_local_experts, top_k=topk
+        )
+    # BLOCK_SIZE_M is shared: one indirection table feeds both GEMMs.
+    config = config_fc1
 
     if _USE_FUSED_ALIGN and _USE_FUSED_COUNT and effective_tokens <= _FUSED_COUNT_MAX_TOKENS:
         if _USE_FUSED_SCATTER:
@@ -1086,8 +1151,8 @@ def vllm_fused_moe(
     block_m = config['BLOCK_SIZE_M']
     em_hint = effective_tokens * topk + block_m * num_local_experts
     num_pid_m_hint = _ceil_div(em_hint, block_m)
-    num_pid_n_fc1 = _ceil_div(fc1_out_width, config['BLOCK_SIZE_N'])
-    num_pid_n_fc2 = _ceil_div(K, config['BLOCK_SIZE_N'])
+    num_pid_n_fc1 = _ceil_div(fc1_out_width, config_fc1['BLOCK_SIZE_N'])
+    num_pid_n_fc2 = _ceil_div(K, config_fc2['BLOCK_SIZE_N'])
     grid_size_fc1 = num_pid_m_hint * num_pid_n_fc1
     grid_size_fc2 = num_pid_m_hint * num_pid_n_fc2
 
@@ -1111,7 +1176,7 @@ def vllm_fused_moe(
         num_post_padded,
         mul_routed_weight=False,
         top_k=topk,
-        config=config,
+        config=config_fc1,
         grid_size=grid_size_fc1,
         fuse_squared_relu=not is_swiglu,
         fuse_swiglu=use_fused_swiglu,
@@ -1140,7 +1205,7 @@ def vllm_fused_moe(
         num_post_padded,
         mul_routed_weight=False,
         top_k=1,
-        config=config,
+        config=config_fc2,
         grid_size=grid_size_fc2,
     )
 

--- a/megatron/core/inference/moe/vllm_fused_moe.py
+++ b/megatron/core/inference/moe/vllm_fused_moe.py
@@ -9,6 +9,7 @@ CUDA-graph compatible: all indirection table construction happens on-device
 via Triton kernels with fixed-size buffers and valid_tokens gating.
 """
 
+import os
 from typing import Optional
 from unittest.mock import MagicMock
 
@@ -319,6 +320,424 @@ def _fill_expert_block_ids_kernel(
     for off in tl.range(0, num_blocks, BLOCK):
         idxs = start_block + off + tl.arange(0, BLOCK)
         tl.store(expert_ids_ptr + idxs, e, mask=idxs < end_block)
+
+
+@triton.jit
+def _prefix_fill_init_kernel(
+    tokens_per_expert_ptr,  # [num_local_experts] raw token counts
+    exclusive_offsets_ptr,  # [num_local_experts] out: exclusive prefix sum (scatter counters)
+    inclusive_offsets_ptr,  # [num_local_experts] out: inclusive prefix sum
+    expert_ids_ptr,  # [max_blocks] out: expert index per BLOCK_SIZE_M block
+    sorted_token_ids_ptr,  # [max_sorted] out: SENTINEL-initialized indirection table
+    num_local_experts,
+    SENTINEL: tl.constexpr,
+    ALIGNMENT: tl.constexpr,  # = BLOCK_SIZE_M
+    NLE_POW2: tl.constexpr,  # next_power_of_2(num_local_experts) for tl.cumsum
+    FILL_BLOCK: tl.constexpr,  # vectorized store width
+):
+    """Fused prefix-sum + expert_ids fill + sorted_token_ids SENTINEL init.
+
+    Merges three kernels of the original indirection-table build
+    (``_init_sorted_ids_kernel`` + ``_prefix_sum_kernel`` +
+    ``_fill_expert_block_ids_kernel``) into one launch. Grid: one CTA per local
+    expert. Every CTA recomputes the (tiny, num_local_experts-wide) aligned
+    cumsum in registers, then CTA ``e`` writes only its own disjoint slices:
+
+      - exclusive_offsets[e], inclusive_offsets[e]   (offset arrays)
+      - expert_ids[excl_e//BM : incl_e//BM] = e      (block→expert map)
+      - sorted_token_ids[excl_e : incl_e] = SENTINEL (padding for its block)
+
+    The union of the per-expert [excl_e, incl_e) ranges is exactly
+    [0, num_tokens_post_padded), which is the only region the grouped-GEMM
+    reads (it strides tiles up to cdiv(num_tokens_post_padded, BM)); the buffer
+    tail beyond that is never read, so it needs no initialization. The
+    subsequent scatter overwrites the real token slots at the front of each
+    expert's block, leaving the alignment padding at SENTINEL. Correctness is
+    identical to the 3-kernel path; the only difference is fewer launches.
+    """
+    e = tl.program_id(0)
+    r = tl.arange(0, NLE_POW2)
+    mask = r < num_local_experts
+    h = tl.load(tokens_per_expert_ptr + r, mask=mask, other=0)
+    if ALIGNMENT > 1:
+        h = tl.where(h > 0, ((h + ALIGNMENT - 1) // ALIGNMENT) * ALIGNMENT, h)
+    inc = tl.cumsum(h, axis=0)
+    exc = inc - h
+    # Select this CTA's own offsets by masked reduction over the lane axis.
+    excl_e = tl.sum(tl.where(r == e, exc, 0))
+    incl_e = tl.sum(tl.where(r == e, inc, 0))
+    tl.store(exclusive_offsets_ptr + e, excl_e)
+    tl.store(inclusive_offsets_ptr + e, incl_e)
+
+    start_block = excl_e // ALIGNMENT
+    end_block = incl_e // ALIGNMENT
+    for off in tl.range(start_block, end_block, FILL_BLOCK):
+        idxs = off + tl.arange(0, FILL_BLOCK)
+        tl.store(expert_ids_ptr + idxs, e, mask=idxs < end_block)
+
+    for off in tl.range(excl_e, incl_e, FILL_BLOCK):
+        idxs = off + tl.arange(0, FILL_BLOCK)
+        tl.store(sorted_token_ids_ptr + idxs, SENTINEL, mask=idxs < incl_e)
+
+
+@triton.jit
+def _count_prefix_fill_init_kernel(
+    routing_map_ptr,  # [max_tokens, topk] expert assignments (global IDs)
+    valid_tokens_ptr,  # scalar int32 CUDA tensor: valid tokens this iteration
+    exclusive_offsets_ptr,  # [num_local_experts] out: exclusive prefix sum (scatter counters)
+    inclusive_offsets_ptr,  # [num_local_experts] out: inclusive prefix sum
+    expert_ids_ptr,  # [max_blocks] out: expert index per BLOCK_SIZE_M block
+    sorted_token_ids_ptr,  # [max_sorted] out: SENTINEL-initialized indirection table
+    num_local_experts,
+    local_expert_start,
+    topk: tl.constexpr,
+    SENTINEL: tl.constexpr,
+    ALIGNMENT: tl.constexpr,  # = BLOCK_SIZE_M
+    NUM_BINS: tl.constexpr,  # next_power_of_2(num_local_experts + 1)
+    COUNT_BLOCK: tl.constexpr,  # pairs histogrammed per iteration
+    FILL_BLOCK: tl.constexpr,  # vectorized store width
+):
+    """``_prefix_fill_init_kernel`` with the per-expert token count folded in.
+
+    ``_prefix_fill_init_kernel`` already has every CTA redundantly recompute the
+    tiny ``num_local_experts``-wide cumsum in registers, and its only input is
+    the count vector. That vector costs two extra launches to produce: a
+    ``torch.zeros`` fill for the counters plus
+    ``_count_local_tokens_kernel_persistent``. Recomputing the histogram
+    redundantly in every CTA removes both launches.
+
+    The count kernel is far more expensive than its work implies (measured 7.52
+    us of device time in the BS256 decode graph, against a 0.72 us empty-kernel
+    floor, to bucket 2048 int32s): with ``BLOCK_SIZE=1024`` and 2048 valid pairs
+    only 2 of its 152 CTAs receive any work, and each issues 1024 global atomics
+    contending on 32 counters. Here each CTA instead accumulates a private
+    register histogram over the same pairs, so there are no global atomics and
+    no cross-CTA ordering at all.
+
+    Counts are integer-identical to the atomic path, so the whole indirection
+    table -- and therefore the GEMM output -- is unchanged.
+
+    Redundant work is the trade: every CTA reads all ``valid_pairs`` entries, so
+    the read volume is ``num_local_experts x`` the atomic path's. At decode that
+    is 32 x 8 KB from L2 and free; the caller restricts this variant to the
+    decode regime for that reason.
+    """
+    e = tl.program_id(0)
+    valid_pairs = tl.load(valid_tokens_ptr) * topk
+
+    # Private per-CTA histogram of local expert IDs. Non-local and out-of-range
+    # pairs are folded into the dropped bin `num_local_experts`, which NUM_BINS
+    # is sized to hold and the mask below discards.
+    acc = tl.zeros([NUM_BINS], dtype=tl.int32)
+    for base in tl.range(0, valid_pairs, COUNT_BLOCK):
+        offs = base + tl.arange(0, COUNT_BLOCK)
+        m = offs < valid_pairs
+        eids = tl.load(routing_map_ptr + offs, mask=m, other=-1)
+        lids = eids - local_expert_start
+        is_local = (lids >= 0) & (lids < num_local_experts) & m
+        # routing_map is int64; tl.histogram wants int32 bin indices.
+        bins = tl.where(is_local, lids, num_local_experts).to(tl.int32)
+        acc += tl.histogram(bins, NUM_BINS)
+
+    r = tl.arange(0, NUM_BINS)
+    mask = r < num_local_experts
+    h = tl.where(mask, acc, 0)
+    if ALIGNMENT > 1:
+        h = tl.where(h > 0, ((h + ALIGNMENT - 1) // ALIGNMENT) * ALIGNMENT, h)
+    inc = tl.cumsum(h, axis=0)
+    exc = inc - h
+    excl_e = tl.sum(tl.where(r == e, exc, 0))
+    incl_e = tl.sum(tl.where(r == e, inc, 0))
+    tl.store(exclusive_offsets_ptr + e, excl_e)
+    tl.store(inclusive_offsets_ptr + e, incl_e)
+
+    start_block = excl_e // ALIGNMENT
+    end_block = incl_e // ALIGNMENT
+    for off in tl.range(start_block, end_block, FILL_BLOCK):
+        idxs = off + tl.arange(0, FILL_BLOCK)
+        tl.store(expert_ids_ptr + idxs, e, mask=idxs < end_block)
+
+    for off in tl.range(excl_e, incl_e, FILL_BLOCK):
+        idxs = off + tl.arange(0, FILL_BLOCK)
+        tl.store(sorted_token_ids_ptr + idxs, SENTINEL, mask=idxs < incl_e)
+
+
+@triton.jit
+def _align_single_kernel(
+    routing_map_ptr,  # [max_tokens, topk] expert assignments (global IDs)
+    valid_tokens_ptr,  # scalar int32 CUDA tensor: valid tokens this iteration
+    exclusive_offsets_ptr,  # [num_local_experts] out: exclusive prefix sum
+    inclusive_offsets_ptr,  # [num_local_experts] out: inclusive prefix sum
+    expert_ids_ptr,  # [max_blocks] out: expert index per BLOCK_SIZE_M block
+    sorted_token_ids_ptr,  # [max_sorted] out: indirection table
+    num_local_experts,
+    local_expert_start,
+    topk: tl.constexpr,
+    SENTINEL: tl.constexpr,
+    ALIGNMENT: tl.constexpr,  # = BLOCK_SIZE_M
+    NUM_BINS: tl.constexpr,  # next_power_of_2(num_local_experts + 1)
+    COUNT_BLOCK: tl.constexpr,  # pairs processed per iteration
+    FILL_BLOCK: tl.constexpr,  # vectorized store width
+):
+    """``_count_prefix_fill_init_kernel`` with the scatter folded in: the whole
+    indirection-table build in one launch.
+
+    CTA ``e`` owns local expert ``e`` and the disjoint output slice
+    ``[excl_e, incl_e)``. It already streams every valid pair once to build its
+    private histogram; a second streaming pass over the same (L2-resident, 16 KB
+    at decode) pairs lets it place its own pairs itself. Within a pass the
+    destination is ``excl_e + written_so_far + exclusive_cumsum(is_mine)``, so
+    no global atomics and no cross-CTA ordering are involved, and the resulting
+    table is deterministic (ascending pair index within each expert block)
+    rather than atomically permuted.
+
+    The second pass is why this is not free: it doubles the redundant read of
+    the routing map. The pairs are tiny and cached, so the trade is one removed
+    launch (``_scatter_token_indices_kernel``, measured 2.66 us + 0.55 us of
+    dispatch gap per layer in the BS256 decode graph) against that extra pass.
+
+    Row order within an expert block does not affect the result: each row of
+    ``sorted_token_ids`` is a ``token * topk + slot`` pair index, and the FC2
+    output is indexed by that same pair index, so any permutation within a
+    block produces identical values downstream.
+    """
+    e = tl.program_id(0)
+    valid_pairs = tl.load(valid_tokens_ptr) * topk
+
+    acc = tl.zeros([NUM_BINS], dtype=tl.int32)
+    for base in tl.range(0, valid_pairs, COUNT_BLOCK):
+        offs = base + tl.arange(0, COUNT_BLOCK)
+        m = offs < valid_pairs
+        eids = tl.load(routing_map_ptr + offs, mask=m, other=-1)
+        lids = eids - local_expert_start
+        is_local = (lids >= 0) & (lids < num_local_experts) & m
+        bins = tl.where(is_local, lids, num_local_experts).to(tl.int32)
+        acc += tl.histogram(bins, NUM_BINS)
+
+    r = tl.arange(0, NUM_BINS)
+    mask = r < num_local_experts
+    h = tl.where(mask, acc, 0)
+    if ALIGNMENT > 1:
+        h = tl.where(h > 0, ((h + ALIGNMENT - 1) // ALIGNMENT) * ALIGNMENT, h)
+    inc = tl.cumsum(h, axis=0)
+    exc = inc - h
+    excl_e = tl.sum(tl.where(r == e, exc, 0))
+    incl_e = tl.sum(tl.where(r == e, inc, 0))
+    tl.store(exclusive_offsets_ptr + e, excl_e)
+    tl.store(inclusive_offsets_ptr + e, incl_e)
+
+    start_block = excl_e // ALIGNMENT
+    end_block = incl_e // ALIGNMENT
+    for off in tl.range(start_block, end_block, FILL_BLOCK):
+        idxs = off + tl.arange(0, FILL_BLOCK)
+        tl.store(expert_ids_ptr + idxs, e, mask=idxs < end_block)
+
+    # SENTINEL-fill this expert's slice first; the scatter below overwrites the
+    # real pairs at the front of it and leaves the alignment padding sentinel.
+    for off in tl.range(excl_e, incl_e, FILL_BLOCK):
+        idxs = off + tl.arange(0, FILL_BLOCK)
+        tl.store(sorted_token_ids_ptr + idxs, SENTINEL, mask=idxs < incl_e)
+
+    pos = excl_e
+    for base in tl.range(0, valid_pairs, COUNT_BLOCK):
+        offs = base + tl.arange(0, COUNT_BLOCK)
+        m = offs < valid_pairs
+        eids = tl.load(routing_map_ptr + offs, mask=m, other=-1)
+        is_mine = (eids - local_expert_start == e) & m
+        sel = is_mine.to(tl.int32)
+        rank = tl.cumsum(sel, axis=0) - sel
+        tl.store(sorted_token_ids_ptr + pos + rank, offs, mask=is_mine)
+        pos += tl.sum(sel)
+
+
+# Fuse init + prefix-sum + expert-block fill (3 tiny serial kernels) into one
+# launch in the decode indirection-table build. Env-toggleable for A/B; the
+# fused path is numerically identical to the default (only launch count differs).
+_USE_FUSED_ALIGN: bool = os.environ.get("MCORE_MOE_FUSED_ALIGN", "0") == "1"
+
+# Additionally fold the per-expert token count (and the `torch.zeros` fill of its
+# counter buffer) into that same launch, taking the decode indirection-table
+# build from 4 kernels to 2. Requires MCORE_MOE_FUSED_ALIGN. Integer-exact.
+_USE_FUSED_COUNT: bool = os.environ.get("MCORE_MOE_FUSED_COUNT", "0") == "1"
+
+# Above this token hint the redundant per-CTA histogram stops being free, so hand
+# back to the atomic count kernel, whose read volume does not scale with the
+# expert count. 512 matches the decode regime `_get_decode_tuned_configs` targets.
+_FUSED_COUNT_MAX_TOKENS = 512
+
+# Additionally fold the scatter into that same launch, taking the decode
+# indirection-table build from 2 kernels to 1. Requires MCORE_MOE_FUSED_COUNT.
+# Produces the same table up to row order within an expert block, which the
+# downstream pair-indexed GEMM is invariant to.
+_USE_FUSED_SCATTER: bool = os.environ.get("MCORE_MOE_FUSED_SCATTER", "0") == "1"
+
+
+def _moe_align_block_size_fused(
+    routing_map: torch.Tensor,
+    block_size: int,
+    num_local_experts: int,
+    local_expert_start: int,
+    valid_tokens: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """3-kernel indirection-table build (count -> prefix_fill_init -> scatter).
+
+    Drop-in replacement for ``_moe_align_block_size_cuda_graphable`` that folds
+    the separate init + prefix-sum + fill kernels into ``_prefix_fill_init_kernel``.
+    Returns the same (sorted_token_ids, expert_ids, num_tokens_post_padded).
+    """
+    max_tokens, topk = routing_map.shape
+    device = routing_map.device
+
+    max_sorted = max_tokens * topk + block_size * (num_local_experts + 1)
+    max_blocks = _ceil_div(max_sorted, block_size)
+    sentinel = max_tokens * topk
+
+    sorted_token_ids = torch.empty(max_sorted, dtype=torch.int32, device=device)
+    expert_ids = torch.empty(max_blocks, dtype=torch.int32, device=device)
+
+    tokens_per_expert = compute_local_tokens_per_expert(
+        routing_map, local_expert_start, num_local_experts, valid_tokens, persistent=True
+    )
+    exclusive_offsets = torch.empty(num_local_experts, dtype=torch.int32, device=device)
+    inclusive_offsets = torch.empty(num_local_experts, dtype=torch.int32, device=device)
+
+    _prefix_fill_init_kernel[(num_local_experts,)](
+        tokens_per_expert,
+        exclusive_offsets,
+        inclusive_offsets,
+        expert_ids,
+        sorted_token_ids,
+        num_local_experts,
+        SENTINEL=sentinel,
+        ALIGNMENT=block_size,
+        NLE_POW2=triton.next_power_of_2(num_local_experts),
+        FILL_BLOCK=128,
+    )
+
+    max_pairs = max_tokens * topk
+    SCATTER_BLOCK = 256
+    scatter_grid = _ceil_div(max_pairs, SCATTER_BLOCK)
+    _scatter_token_indices_kernel[(scatter_grid,)](
+        routing_map,
+        sorted_token_ids,
+        exclusive_offsets,
+        valid_tokens,
+        topk,
+        local_expert_start,
+        num_local_experts,
+        max_pairs,
+        BLOCK_SIZE=SCATTER_BLOCK,
+    )
+
+    num_tokens_post_padded = inclusive_offsets[-1:]
+    return sorted_token_ids, expert_ids, num_tokens_post_padded
+
+
+def _moe_align_block_size_count_fused(
+    routing_map: torch.Tensor,
+    block_size: int,
+    num_local_experts: int,
+    local_expert_start: int,
+    valid_tokens: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """2-kernel indirection-table build (count_prefix_fill_init -> scatter).
+
+    Same contract and same outputs as ``_moe_align_block_size_fused``; it just
+    folds the token count and its counter-buffer zero-fill into the first launch.
+    """
+    max_tokens, topk = routing_map.shape
+    device = routing_map.device
+
+    max_sorted = max_tokens * topk + block_size * (num_local_experts + 1)
+    max_blocks = _ceil_div(max_sorted, block_size)
+    sentinel = max_tokens * topk
+
+    sorted_token_ids = torch.empty(max_sorted, dtype=torch.int32, device=device)
+    expert_ids = torch.empty(max_blocks, dtype=torch.int32, device=device)
+    exclusive_offsets = torch.empty(num_local_experts, dtype=torch.int32, device=device)
+    inclusive_offsets = torch.empty(num_local_experts, dtype=torch.int32, device=device)
+
+    _count_prefix_fill_init_kernel[(num_local_experts,)](
+        routing_map,
+        valid_tokens,
+        exclusive_offsets,
+        inclusive_offsets,
+        expert_ids,
+        sorted_token_ids,
+        num_local_experts,
+        local_expert_start,
+        topk=topk,
+        SENTINEL=sentinel,
+        ALIGNMENT=block_size,
+        NUM_BINS=triton.next_power_of_2(num_local_experts + 1),
+        COUNT_BLOCK=1024,
+        FILL_BLOCK=128,
+    )
+
+    max_pairs = max_tokens * topk
+    SCATTER_BLOCK = 256
+    scatter_grid = _ceil_div(max_pairs, SCATTER_BLOCK)
+    _scatter_token_indices_kernel[(scatter_grid,)](
+        routing_map,
+        sorted_token_ids,
+        exclusive_offsets,
+        valid_tokens,
+        topk,
+        local_expert_start,
+        num_local_experts,
+        max_pairs,
+        BLOCK_SIZE=SCATTER_BLOCK,
+    )
+
+    num_tokens_post_padded = inclusive_offsets[-1:]
+    return sorted_token_ids, expert_ids, num_tokens_post_padded
+
+
+def _moe_align_block_size_single(
+    routing_map: torch.Tensor,
+    block_size: int,
+    num_local_experts: int,
+    local_expert_start: int,
+    valid_tokens: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """1-kernel indirection-table build.
+
+    Same contract and same outputs as ``_moe_align_block_size_count_fused``,
+    with the scatter folded into the single launch as well. Row order within an
+    expert block is ascending pair index instead of atomically permuted; the
+    downstream GEMM indexes rows by pair id, so the result is unchanged.
+    """
+    max_tokens, topk = routing_map.shape
+    device = routing_map.device
+
+    max_sorted = max_tokens * topk + block_size * (num_local_experts + 1)
+    max_blocks = _ceil_div(max_sorted, block_size)
+    sentinel = max_tokens * topk
+
+    sorted_token_ids = torch.empty(max_sorted, dtype=torch.int32, device=device)
+    expert_ids = torch.empty(max_blocks, dtype=torch.int32, device=device)
+    exclusive_offsets = torch.empty(num_local_experts, dtype=torch.int32, device=device)
+    inclusive_offsets = torch.empty(num_local_experts, dtype=torch.int32, device=device)
+
+    _align_single_kernel[(num_local_experts,)](
+        routing_map,
+        valid_tokens,
+        exclusive_offsets,
+        inclusive_offsets,
+        expert_ids,
+        sorted_token_ids,
+        num_local_experts,
+        local_expert_start,
+        topk=topk,
+        SENTINEL=sentinel,
+        ALIGNMENT=block_size,
+        NUM_BINS=triton.next_power_of_2(num_local_experts + 1),
+        COUNT_BLOCK=1024,
+        FILL_BLOCK=128,
+    )
+
+    num_tokens_post_padded = inclusive_offsets[-1:]
+    return sorted_token_ids, expert_ids, num_tokens_post_padded
 
 
 def _moe_align_block_size_cuda_graphable(
@@ -634,7 +1053,16 @@ def vllm_fused_moe(
     # buffer size. Same config is used for both FC1 and FC2 (matches vLLM).
     config = _get_default_config(M=effective_tokens, E=num_local_experts, top_k=topk)
 
-    sorted_token_ids, expert_ids, num_post_padded = _moe_align_block_size_cuda_graphable(
+    if _USE_FUSED_ALIGN and _USE_FUSED_COUNT and effective_tokens <= _FUSED_COUNT_MAX_TOKENS:
+        if _USE_FUSED_SCATTER:
+            align_fn = _moe_align_block_size_single
+        else:
+            align_fn = _moe_align_block_size_count_fused
+    elif _USE_FUSED_ALIGN:
+        align_fn = _moe_align_block_size_fused
+    else:
+        align_fn = _moe_align_block_size_cuda_graphable
+    sorted_token_ids, expert_ids, num_post_padded = align_fn(
         routing_map, config['BLOCK_SIZE_M'], num_local_experts, local_expert_start, valid_tokens
     )
     num_valid = max_tokens * topk

--- a/megatron/core/transformer/moe/experts.py
+++ b/megatron/core/transformer/moe/experts.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import inspect
 import logging
+import os
 from collections.abc import Callable
 from contextlib import nullcontext
 from copy import deepcopy
@@ -86,6 +87,12 @@ from megatron.core.inference.moe import ActivationType as McoreActivationType
 from megatron.core.inference.moe import InferenceGroupedGemmBackend, mcore_fused_moe, vllm_fused_moe
 
 logger = logging.getLogger(__name__)
+
+# Fuse SiLU(gate)*up into the decode FC1 GEMM epilogue, removing the standalone
+# bounded_silu_mul kernel and the 2N intermediate HBM round-trip. No-op for
+# non-SwiGLU activations. Not bit-exact (max_abs 3.9e-5), so it is opt-in. Read
+# once here rather than per forward: the consumer is on the per-layer decode path.
+_FUSE_FC1_ACT: bool = os.environ.get("MCORE_FUSE_FC1_ACT", "0") == "1"
 
 
 class GroupedLinearFc1Interface(Protocol):
@@ -1200,6 +1207,7 @@ class InferenceGroupedMLP(TEGroupedMLP):
             routing_map=routing_map,
             out=NVLSAllGatherVDispatcher._get_rsv_tensor() if self._nvls_dispatcher else None,
             num_tokens_hint=InferenceAllGatherDispatcherBase._get_host_valid_tokens_estimate(),
+            fuse_fc1_activation=_FUSE_FC1_ACT,
         )
         return output, None
 


### PR DESCRIPTION
> Stacked on #6453. Review that one first; this diff is only a per-GEMM tile-config table for the decode expert GEMMs, plus a token-count guard.
>
> GitHub cannot base a pull request from a fork on another unmerged fork branch, so the diff below also contains the parent's commits. This PR's own change is the final commit, `f79a1bc22`; review that one. The rest lands with the parent.

## Summary

`_get_default_config` picks one launch config and both expert GEMMs use it, as upstream
vLLM does — so at decode FC1 (N=768) and FC2 (N=2048) both get `BLOCK_SIZE_N=128`, which
leaves FC1 with `ceil(768/128) = 6` N-tiles × 32 M-tiles = 192 CTAs on 148 SMs. Tiling the
two passes separately around a shared `BLOCK_SIZE_M` takes the two GEMM launches from
**77.65 to 61.89 µs** of device time per layer (**1.255×**) and the whole
`vllm_fused_moe` call from **100.64 to 84.31 µs** (**1.194×**), bit-exactly:
**+6.77%** end-to-end. It is a config table and one threshold.

The reason it is worth doing at all is that the ceiling was priced before any code was
written, and the pricing said *do not write a kernel*: this GEMM is memory-bound, 1.45×
off a measured 6.081 TB/s streaming-read floor, and 1.26× of that 1.45× is reachable by
tile sizes alone, leaving ≤1.15× for the hand-written CUTLASS/CuTe grouped GEMM that was
consequently never built.

## Why here

`_fused_moe_kernel` is about 40% of decode GPU time, so a decision gate measured whether
that is recoverable inefficiency or irreducible expert-weight traffic before anything was
implemented. Four findings.

Bandwidth was measured, not assumed: 6.851 TB/s for a device-to-device copy and
**6.081 TB/s** for a Triton vectorized streaming read on this GB200. (A torch `.sum()`
gives 4.05 TB/s and is a poor proxy — it should not be used as the ceiling.)

Every decode step must read all 32 local experts' weights, 302.0 MB per layer per rank,
which is a **49.66 µs floor** against **72.13 µs** measured for FC1+FC2 — **1.45× off
roofline**. Achieved throughput was 63.4 (FC1) and 83.2 (FC2) TFLOP/s on valid FLOPs,
about 3% of GB200 BF16 dense peak and 246/323 TFLOP/s even counting padded rows, so this
is not a FLOP problem.

Padding is large but nearly free. `num_tokens_post_padded` is 784 / 1024 / 2048 / 4096 at
`BLOCK_SIZE_M` 16 / 32 / 64 / 128 against 527 real local token-expert pairs — 32.8% to
87.1% dead rows — yet cutting it 3.89× → 1.49× buys only ~1.2×, because each expert's
weights are read exactly once per M-tile row-block regardless.

Finally, a 63-config tile sweep found 58.93 µs (**1.225×**) with one shared config and
57.24 µs (**1.26×**) with per-GEMM configs. Most of the 1.45× ceiling is therefore
reachable in Triton, which is what ruled out a hand-written grouped GEMM: its entire
remaining headroom would have been 1.15×.

## What changed

**Before.** One `_get_default_config(M, E, top_k)` result is passed to both
`_invoke_fused_moe_kernel` calls and used for both grid computations. At the decode point
(`M` = the 256-token hint) that means `BLOCK_SIZE_M=64`, `BLOCK_SIZE_N=128`,
`BLOCK_SIZE_K=64`, 8 warps, 3 stages for both passes.

**After.** `_get_decode_tuned_configs(M, E, top_k)` returns an `(fc1, fc2)` pair. Above a
384-token hint it returns the default twice, so upstream's heuristic is untouched. At or
below 384 it starts from the default, overrides `BLOCK_SIZE_M=16`, `GROUP_SIZE_M=1` and
`BLOCK_SIZE_K=64` for both, then splits the N axis: FC1 gets `BLOCK_SIZE_N=64` with 4
warps and 3 stages, FC2 gets `BLOCK_SIZE_N=256` with 8 warps and 4 stages. The call site
threads `config_fc1` and `config_fc2` into their respective kernel launches and into
separate grid sizing, so `num_pid_n_fc1` is computed from FC1's N tile and `num_pid_n_fc2`
from FC2's.

`BLOCK_SIZE_M` stays shared, because one indirection table feeds both GEMMs and its
alignment *is* `BLOCK_SIZE_M`. Dropping it from 64 to 16 also cuts the table's dead rows
from 74.3% to 32.8% at this shape.

**Why the split is the right axis for the part it explains.** FC1's N is narrow, so it
needs a *small* `BLOCK_SIZE_N` to manufacture enough CTAs to fill the GPU; FC2's N is wide,
already has plenty of CTAs, and prefers a *large* one for weight-load efficiency. A single
shared config cannot express both, which is the specific thing upstream's structure
forecloses.

**The threshold is 384, not 512, and that is a measured detail rather than a round
number.** Device time under CUDA-graph replay against the default tiles is **1.289×** at
128 tokens, **1.197×** at 256 (the decode point, `local_tokens × ep_size`), **1.120×** at
384 and **0.952×** at 512. Past roughly 384 tokens there are already enough M-tiles to
fill the machine and FC1's narrow tile starts costing weight-load efficiency, so a
`M > 512` guard would have left a 5% device-time regression sitting inside the tuned
range. Moving the guard to 384 did not change end-to-end throughput, because decode runs
at 256 where both thresholds select the tuned tiles; its whole value is removing a latent
regression at other batch shapes.

## Measurement

Fixed protocol: Qwen3-30B-A3B, BF16, TP 1 / PP 1 / EP 4 / ETP 1, 256 gsm8k requests, 1024 output tokens, 2 warmup + 5 timed iterations, a single OCI 4xGB200 node (nvl72160-T04), async dynamic-batching scheduler pinned on. All 20 arms ran back to back in one allocation on that one node; node-to-node variance on this workload is around 2.7%, so cross-node numbers would not be comparable.

- With this change (every other gate in the stack enabled): **31,673 tok/s**
- Without it (same node, same session, only this gate turned off): **29,665 tok/s**
- Leave-one-out delta: **+6.77%**
- Noise floor: sigma = **0.42%** over 3 repeats of the all-gates-on reference
- Verdict: **resolved**; the per-iteration distributions separate completely (every timed iteration of the better arm beats every timed iteration of the worse one)

This is the **marginal contribution measured with every other gate in this stack enabled** — the question a reviewer is actually asking, which is whether this should land, not what it was worth when it was first written.

The reference is drift-corrected. The all-gates-on configuration was re-measured three times across the session (31,745, 31,530, 31,503 tok/s), a +0.77% drift from first to last, so each arm is compared against the reference interpolated to its own position in the run order rather than against a session mean.

For context, the whole stack is worth **+35.80%** on this node (23,265 tok/s with every gate off, 31,593 with every gate on). Per-slice deltas do not sum to that; they compose sub-additively.

## Evidence

Per-kernel torch-profiler attribution at the decode point: `_fused_moe_kernel` across both
GEMM passes **77.65 → 61.89 µs (1.255×)**, whole `vllm_fused_moe` call
**100.64 → 84.31 µs (1.194×)**.

Microbench of FC1+FC2 alone at the same shape, median of 3 × 300 iterations:
**72.13 → 57.24 µs (1.26×)**, which lands 1.15× off the 49.66 µs streaming-read floor.

Shape sensitivity, CUDA-graph replay device time against the default tiles:
1.289× / 1.197× / 1.120× / 0.952× at 128 / 256 / 384 / 512 tokens.

Liveness: this change alters no launch counts — the same two kernels run with different
tile constants — so the per-kernel device-time delta above *is* the liveness evidence. The
0.952× datapoint at 512 additionally shows both branches of the threshold being exercised.

## Correctness

- **Numerics:** **bit-exact at every `M`**, `max_abs = 0.0` and `max_rel = 0.0` at
  128 / 256 / 384 / 512 valid tokens. It is structural, not luck. The fp32 reduction order
  along K is a function of `BLOCK_SIZE_K` alone, and the tuned config *inherits*
  `BLOCK_SIZE_K` from `_get_default_config` rather than setting it, so that order is
  identical by construction. `BLOCK_SIZE_N`, `BLOCK_SIZE_M`, `GROUP_SIZE_M`, warp count
  and stage count change only which program computes which output tile and in what order,
  never how a single output element is accumulated. A smaller `BLOCK_SIZE_M` produces a
  differently-padded table, but padded rows are masked out of the store, so the values are
  unchanged.
- **Inheriting `BLOCK_SIZE_K` is deliberate, and it is the whole reason the claim is
  unconditional.** An earlier revision of this change forced `BLOCK_SIZE_K = 64`. That is
  identical to the default throughout the tuned range — the default only rises to 128 at
  `M ≤ 64` — so it was a no-op at every measured shape, but it silently broke bit-exactness
  below 64 tokens, which the `M > 384` guard does not exclude. Inheriting instead costs
  nothing where this was tuned and removes the exception.
- **Tests:** whole-MoE output equality at the four token counts above.
- **Coherence:** end-to-end prompts coherent and correct (`2+2=4`, Paris, `3+2` cows = 5
  cows).

## Gating and blast radius

- Gate: `MCORE_MOE_GEMM_TUNE`, **default OFF** —
  `os.environ.get("MCORE_MOE_GEMM_TUNE", "0") == "1"`, read once at import. With it unset,
  both passes receive `_get_default_config` exactly as before and the diff at the call site
  is a rename.
- Precondition checked by the guard: the token hint must be ≤ 384. On failure it returns
  `_get_default_config` for both passes — upstream's heuristic, unchanged.
- **The honest blast radius:** that token-count check is the *only* precondition.
  `_get_decode_tuned_configs` does not inspect N, K, the expert count or the device, so any
  MoE geometry that sets this gate at a small token hint will receive constants hand-tuned
  at exactly one shape — hidden 2048, moe_ffn 768, 32 local experts, top-8, on GB200. For
  the Qwen3-30B-A3B EP4 decode configuration this PR targets, that is the measured
  optimum; for anything else it is an untested guess that happens to be bit-exact.
- Training and every non-matching inference config are unaffected: `vllm_fused_moe` is
  reached only by the `--transformer-impl inference_optimized` inference path with
  `--inference-grouped-gemm-backend vllm`.

## Reproduce

```bash
MCORE_MOE_GEMM_TUNE=1 \
QWEN30B_TP=1 QWEN30B_EP=4 QWEN30B_ETP=1 \
BENCH_SIZES_OVERRIDE=256 BENCH_OUTPUT_TOKENS=1024 \
NUM_WARMUP_ITERS=2 NUM_TIMED_ITERS=5 \
bash skills/run-qwen-model/run_qwen_inference.sh qwen3-30b-a3b --checkpoint "$QWEN30B_CKPT"
```

The gate is read at import, so it must be exported before the interpreter starts.

## What this does not claim

- **Nothing above a 384-token hint.** The guard hands back to upstream's heuristic, and at
  512 tokens the tuned tiles measured **0.952×** — a 5% device-time regression — which is
  precisely why the threshold is 384. Prefill is untouched.
- **The threshold change itself is end-to-end neutral at the decode point**, since decode
  runs at 256 where the old and new thresholds pick the same tiles. Its value is a latent
  regression removed at other batch shapes, and it is supported by device time only.
- **Most of the 1.26× is not the per-GEMM split.** In the same sweep a single *shared*
  retuned config already measured 1.225×, and dropping `BLOCK_SIZE_M` from 64 to 16 on its
  own measured ~1.2×. So the bulk of the win is the retune — above all the smaller M tile —
  and the FC1/FC2 N split is worth roughly the last 3%. The "opposite `BLOCK_SIZE_N`"
  story explains that last part, not the whole number.
- **The occupancy account is a hypothesis.** "192 CTAs on 148 SMs is 1.3 waves, so ~30% of
  the machine idles in the tail" is consistent with the roofline and sweep data, but no
  occupancy or tail-effect measurement isolates it. What is measured is that the tiles are
  1.255× faster and that the workload is memory-bound rather than FLOP-bound.
- **Bit-exactness is structural at every `M`, but only *verified* at 128/256/384/512.**
  The argument below 64 tokens rests on inheriting `BLOCK_SIZE_K`, not on a measurement.
- Deltas in this stack do not add, and this one interacts with its parent specifically:
  `BLOCK_SIZE_M=16` changes the indirection table the previous PR builds — fewer padded
  rows, less fill volume — so the two are not independent.

## Follow-ups

- The GEMM is done. Remaining headroom is 1.15× (57–62 µs against a 49.66 µs bandwidth
  floor), so the next levers are elsewhere: exposed expert-parallel communication (~16% of
  the step) and the routing chain.
- `_get_decode_tuned_configs` is hand-tuned at one shape. If another MoE geometry adopts
  this gate, the constants should be replaced by a small autotune keyed on `(N, E, M)`.

---

## This stack

This is one slice of [#6064](https://github.com/NVIDIA/Megatron-LM/pull/6064), a Qwen3-30B-A3B decode optimization campaign, split into 16 independently reviewable changes. Together they are **+35.80%** end-to-end throughput over the same base commit (23,265 -> 31,593 tok/s, mean of three full runs).

- **MoE grouped-GEMM and dispatch:** #6452 -> #6453 -> #6454 -> #6455
- **MoE router and combine:** #6456 -> #6457 -> #6458
- **Attention: QK norm and decode kernel:** #6459 -> #6460 -> #6461 -> #6462
- **Residual + RMSNorm fusion:** #6463 -> #6464
- **Host path: context bookkeeping:** #6465 -> #6466
- **Host path: independent:** #6467

Each chain is independent of the others and bases on `main`. Within a chain, later PRs depend on earlier ones.

### Per-slice measured delta

Every number is a leave-one-out delta from one same-node, same-session campaign: the full stack with exactly this change's gate off, against the interpolated full-stack reference at that point in the run. It is the change's *marginal* contribution with everything else already in, not its standalone value. Run-to-run sigma was **0.42%** across three full-stack repeats.

| PR | Change | Delta | |
|---|---|---|---|
| #6452 | FC1 SwiGLU epilogue | +14.81% | resolved |
| #6453 | indirection table fusion | +7.21% | resolved |
| #6454 | decode GEMM tile configs | +6.77% | resolved |
| #6455 | predicated top-k gather | +1.99% | by margin |
| #6456 | fused router softmax+top-k | +4.75% | resolved |
| #6457 | fused route padding mask | +1.47% | by margin |
| #6458 | bf16 MoE combine | +2.42% | by margin |
| #6459 | fused QK RMSNorm | +5.17% | resolved |
| #6460 | grouped QK norm input | +1.18% | by margin |
| #6461 | pin FlashAttention 2 | -0.35% | noise floor |
| #6462 | FlashInfer TRT-LLM decode | +1.46% | by margin |
| #6463 | fused add+norm pre-MLP | +3.54% | by margin |
| #6464 | fused add+norm pre-QKV | +0.98% | by margin |
| #6465 | incremental attention state | -0.42% | noise floor |
| #6466 | vectorized decode bookkeeping | -0.07% | noise floor |
| #6467 | post_process_requests fast path | +0.09% | noise floor |

`noise floor` means the delta is inside 2 sigma (0.84%) and this campaign cannot distinguish it from zero. `resolved` means the leave-one-out and full-stack iteration distributions did not overlap. Deltas do not sum to the stack total: these changes shorten the same decode step and compose sub-additively.

**Fixed protocol for every number above.** Qwen3-30B-A3B, BF16, TP1/PP1/EP4/ETP1, 256 gsm8k requests at batch size 256, output length 1024, CUDA graphs on, one OCI GB200 NVL72 node, 4 GPUs. All 20 arms ran back-to-back in a single Slurm allocation on one node, so node assignment and thermal state are held constant.
