### PR TITLE
perf(inference): predicate the locality test in the MoE top-k reduction

### DIFF
--- a/megatron/core/inference/moe/vllm_fused_moe.py
+++ b/megatron/core/inference/moe/vllm_fused_moe.py
@@ -124,6 +124,7 @@ def _fused_moe_kernel(
     # Flags / constexprs
     MUL_ROUTED_WEIGHT: tl.constexpr,
     FUSE_SQUARED_RELU: tl.constexpr,
+    FUSE_SWIGLU: tl.constexpr,
     top_k: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
@@ -186,6 +187,13 @@ def _fused_moe_kernel(
                 + off_experts * stride_be
                 + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
             )
+            # SwiGLU epilogue fusion: the same [BLOCK_M, BLOCK_N] output tile of
+            # the activated intermediate needs both the gate columns (offs_bn) and
+            # the paired up columns (offs_bn + N), where N is the activated width.
+            # A second accumulator reads the up half from the same B tensor.
+            if FUSE_SWIGLU:
+                b_up_ptrs = b_ptrs + N * stride_bn
+                up_accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
 
             accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
             for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
@@ -196,6 +204,12 @@ def _fused_moe_kernel(
                 )
                 b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
                 accumulator += tl.dot(a, b)
+                if FUSE_SWIGLU:
+                    b_up = tl.load(
+                        b_up_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0
+                    )
+                    up_accumulator += tl.dot(a, b_up)
+                    b_up_ptrs += BLOCK_SIZE_K * stride_bk
                 a_ptrs += BLOCK_SIZE_K * stride_ak
                 b_ptrs += BLOCK_SIZE_K * stride_bk
 
@@ -204,6 +218,15 @@ def _fused_moe_kernel(
             if FUSE_SQUARED_RELU:
                 accumulator = tl.maximum(accumulator, 0.0)
                 accumulator *= accumulator
+
+            # SwiGLU fused on the fp32 accumulators: SiLU(gate) * up. The
+            # arithmetic matches the standalone `bounded_silu_mul` kernel, but the
+            # results are not bit-identical (measured max_abs 3.9e-5): that kernel
+            # reads gate and up after they have been rounded to bf16, while these
+            # accumulators have not been. The fused result is the less rounded of
+            # the two. Removes that kernel and the 2N intermediate round-trip.
+            if FUSE_SWIGLU:
+                accumulator = accumulator * tl.sigmoid(accumulator) * up_accumulator
 
             if MUL_ROUTED_WEIGHT:
                 moe_weight = tl.load(topk_weights_ptr + offs_token, mask=token_mask, other=0)
@@ -387,12 +410,18 @@ def _invoke_fused_moe_kernel(
     config: dict,
     grid_size: int,
     fuse_squared_relu: bool = False,
+    fuse_swiglu: bool = False,
 ):
     """Launch the Triton fused-MoE kernel for one GEMM pass.
 
     Body matches upstream vLLM `fused_moe_kernel` (1 CTA per (pid_m, pid_n)
     tile, raw pointer arithmetic with `% N` on the N axis), apart from the
     optional fused squared-relu activation in fp32.
+
+    When ``fuse_swiglu`` is set, B is the [E, 2*Nf, K] gate|up FC1 weight and the
+    kernel emits the activated [num_valid, Nf] intermediate directly (SiLU(gate) *
+    up), so ``N`` is the activated width ``Nf = B.size(1) // 2`` and each program
+    also reads the paired up columns at ``+N`` in B.
 
     `grid_size` is sized host-side from `num_tokens_hint` so launch overhead
     at decode is small.  When the actual padded length exceeds the hinted
@@ -402,6 +431,8 @@ def _invoke_fused_moe_kernel(
     """
     M = A.size(0)
     num_tokens = M * top_k
+    # For fused SwiGLU, N is the activated width (half the 2*Nf FC1 output).
+    n_dim = B.size(1) // 2 if fuse_swiglu else B.size(1)
 
     _fused_moe_kernel[(grid_size,)](
         A,
@@ -411,7 +442,7 @@ def _invoke_fused_moe_kernel(
         sorted_token_ids,
         expert_ids,
         num_tokens_post_padded,
-        B.size(1),
+        n_dim,
         B.size(2),
         num_tokens,
         A.stride(0),
@@ -423,6 +454,7 @@ def _invoke_fused_moe_kernel(
         C.stride(1),
         MUL_ROUTED_WEIGHT=mul_routed_weight,
         FUSE_SQUARED_RELU=fuse_squared_relu,
+        FUSE_SWIGLU=fuse_swiglu,
         top_k=top_k,
         BLOCK_SIZE_M=config['BLOCK_SIZE_M'],
         BLOCK_SIZE_N=config['BLOCK_SIZE_N'],
@@ -557,6 +589,7 @@ def vllm_fused_moe(
     routing_map: torch.Tensor,
     out: Optional[torch.Tensor] = None,
     num_tokens_hint: Optional[int] = None,
+    fuse_fc1_activation: bool = False,
 ) -> torch.Tensor:
     """Fused MoE using the vLLM Triton grouped-GEMM kernel (BF16).
 
@@ -580,6 +613,9 @@ def vllm_fused_moe(
         num_tokens_hint: optional host-side int with the expected number of
             valid tokens (e.g. batch_size * ep_size). Used to select a better
             BLOCK_SIZE_M instead of using the worst-case buffer size.
+        fuse_fc1_activation: for SwiGLU, fuse SiLU(gate)*up into the FC1 GEMM
+            epilogue instead of running the standalone ``bounded_silu_mul`` kernel
+            over the 2N-wide intermediate. Ignored for other activations.
 
     Returns:
         [max_tokens, hidden_size] output (fp32 when out=None, else out's dtype).
@@ -606,6 +642,14 @@ def vllm_fused_moe(
     N = fc1_weight.size(1)
     K = fc1_weight.size(2)
 
+    assert activation_type in (ActivationType.SQUARED_RELU, ActivationType.SWIGLU)
+    is_swiglu = activation_type == ActivationType.SWIGLU
+    # When enabled for SwiGLU, FC1 fuses SiLU(gate)*up into its epilogue and
+    # writes the activated [num_valid, N//2] intermediate directly, removing the
+    # standalone bounded_silu_mul kernel and the 2N intermediate round-trip.
+    use_fused_swiglu = is_swiglu and fuse_fc1_activation
+    fc1_out_width = N // 2 if use_fused_swiglu else N
+
     # Grid sized for the typical-case token count (num_tokens_hint).  When the
     # actual num_tokens_post_padded exceeds this, the kernel's outer tl.range
     # makes each CTA stride over additional tiles — correct but with reduced
@@ -614,21 +658,20 @@ def vllm_fused_moe(
     block_m = config['BLOCK_SIZE_M']
     em_hint = effective_tokens * topk + block_m * num_local_experts
     num_pid_m_hint = _ceil_div(em_hint, block_m)
-    num_pid_n_fc1 = _ceil_div(N, config['BLOCK_SIZE_N'])
+    num_pid_n_fc1 = _ceil_div(fc1_out_width, config['BLOCK_SIZE_N'])
     num_pid_n_fc2 = _ceil_div(K, config['BLOCK_SIZE_N'])
     grid_size_fc1 = num_pid_m_hint * num_pid_n_fc1
     grid_size_fc2 = num_pid_m_hint * num_pid_n_fc2
 
     topk_weights_flat = probs.reshape(-1).contiguous()
 
-    # FC1 + activation: [max_tokens, K] → [max_tokens*topk, N]
-    # SQUARED_RELU fuses into the GEMM epilogue (elementwise). SwiGLU pairs column c
-    # with c+N/2 across tiles and cannot, so FC1 runs unfused to the 2N-wide
-    # intermediate and gate/up is applied separately below.
-    assert activation_type in (ActivationType.SQUARED_RELU, ActivationType.SWIGLU)
-    is_swiglu = activation_type == ActivationType.SWIGLU
+    # FC1 + activation: [max_tokens, K] → [max_tokens*topk, fc1_out_width]
+    # SQUARED_RELU fuses into the GEMM epilogue (elementwise). SwiGLU pairs column
+    # c with c+N/2 across N-tiles; the unfused path writes the 2N intermediate and
+    # applies gate/up separately below, while the fused path (use_fused_swiglu)
+    # reads both halves per program and writes the N//2 activated output directly.
     intermediate1 = torch.empty(
-        num_valid, N, dtype=hidden_states.dtype, device=hidden_states.device
+        num_valid, fc1_out_width, dtype=hidden_states.dtype, device=hidden_states.device
     )
     _invoke_fused_moe_kernel(
         hidden_states,
@@ -643,8 +686,9 @@ def vllm_fused_moe(
         config=config,
         grid_size=grid_size_fc1,
         fuse_squared_relu=not is_swiglu,
+        fuse_swiglu=use_fused_swiglu,
     )
-    if is_swiglu:
+    if is_swiglu and not use_fused_swiglu:
         # intermediate1 is [num_valid, 2N] (gate | up); reduce to [num_valid, N] via
         # SiLU(gate) * up over the valid_tokens*topk live rows only.
         n_rows = (valid_tokens * topk).to(torch.int32)

--- a/megatron/core/inference/moe/vllm_fused_moe.py
+++ b/megatron/core/inference/moe/vllm_fused_moe.py
@@ -1000,6 +1000,71 @@ def _moe_sum_kernel(
             tl.store(output_ptr + token_id_i64 * K + offs_k, acc, mask=k_mask)
 
 
+@triton.jit
+def _moe_sum_kernel_fast(
+    input_ptr,
+    output_ptr,
+    topk_weights_ptr,
+    valid_tokens_ptr,
+    routing_map_ptr,
+    local_expert_start,
+    num_local_experts: tl.constexpr,
+    K,
+    topk: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    NUM_K_BLOCKS: tl.constexpr,
+):
+    """``_moe_sum_kernel`` with the locality test predicated instead of branched.
+
+    Same reduction, same order, same fp32 arithmetic — so bit-exact — but the
+    ``if lid >= 0 and lid < num_local_experts`` guard becomes a load mask. In the
+    branched form each of the ``topk`` iterations is a uniform scalar branch
+    gated on a dependent global load of ``routing_map``, so the compiler cannot
+    overlap iteration ``t``'s data load with iteration ``t+1``'s index load and
+    the CTA walks the topk slots serially. Predicating lets all ``topk`` data
+    loads issue back to back; masked-off lanes read nothing and contribute an
+    exact fp32 zero.
+
+    Measured cost of the branched form in the BS256 decode graph: 7.79 us per
+    layer to move ~6.3 MB, i.e. 7x its own ~1.05 us bandwidth floor at the
+    6.08 TB/s measured in QWEN-012.
+    """
+    pid = tl.program_id(0)
+    valid_tokens = tl.load(valid_tokens_ptr)
+
+    for token_id in tl.range(pid, valid_tokens, BLOCK_M):
+        token_id_i64 = token_id.to(tl.int64)
+        base = token_id_i64 * topk * K
+
+        for k_idx in range(NUM_K_BLOCKS):
+            offs_k = k_idx * BLOCK_K + tl.arange(0, BLOCK_K)
+            k_mask = offs_k < K
+
+            acc = tl.zeros([BLOCK_K], dtype=tl.float32)
+            for t in tl.static_range(topk):
+                eid = tl.load(routing_map_ptr + token_id * topk + t)
+                lid = eid - local_expert_start
+                is_local = (lid >= 0) & (lid < num_local_experts)
+                v = tl.load(
+                    input_ptr + base + t * K + offs_k, mask=k_mask & is_local, other=0.0
+                )
+                w = tl.load(topk_weights_ptr + token_id * topk + t)
+                acc += v.to(tl.float32) * tl.where(is_local, w, 0.0)
+
+            tl.store(output_ptr + token_id_i64 * K + offs_k, acc, mask=k_mask)
+
+
+# Use the predicated `_moe_sum_kernel_fast` (bit-exact) with a full-K tile in the
+# decode topk reduction. Env-toggleable for A/B; default off.
+_USE_FAST_MOE_SUM: bool = os.environ.get("MCORE_MOE_SUM_FAST", "0") == "1"
+
+
+# Full hidden-size K tile: one pass over topk per token instead of NUM_K_BLOCKS
+# passes, so the per-token routing_map/prob index loads are issued once.
+_FAST_MOE_SUM_MAX_BLOCK_K = 2048
+
+
 def _moe_sum(
     input: torch.Tensor,
     topk_weights: torch.Tensor,
@@ -1025,9 +1090,28 @@ def _moe_sum(
     """
     if out is None:
         out = torch.empty(max_tokens, K, dtype=torch.float32, device=input.device)
+    BLOCK_M = _get_num_sms(input.device)
+    if _USE_FAST_MOE_SUM:
+        BLOCK_K = min(triton.next_power_of_2(K), _FAST_MOE_SUM_MAX_BLOCK_K)
+        NUM_K_BLOCKS = _ceil_div(K, BLOCK_K)
+        _moe_sum_kernel_fast[(BLOCK_M,)](
+            input,
+            out,
+            topk_weights,
+            valid_tokens,
+            routing_map,
+            local_expert_start,
+            num_local_experts,
+            K,
+            topk=topk,
+            BLOCK_M=BLOCK_M,
+            BLOCK_K=BLOCK_K,
+            NUM_K_BLOCKS=NUM_K_BLOCKS,
+            num_warps=8,
+        )
+        return out
     BLOCK_K = min(triton.next_power_of_2(K), 1024)
     NUM_K_BLOCKS = _ceil_div(K, BLOCK_K)
-    BLOCK_M = _get_num_sms(input.device)
     _moe_sum_kernel[(BLOCK_M,)](
         input,
         out,

--- a/megatron/core/inference/moe/vllm_fused_moe.py
+++ b/megatron/core/inference/moe/vllm_fused_moe.py
@@ -100,6 +100,60 @@ def _get_default_config(M: int, E: int, top_k: int) -> dict:
     }
 
 
+# Retune the two grouped GEMMs independently for the MoE *decode* regime.
+# Env-toggleable for A/B; the tuned path is the same kernel with different M and N
+# tiles. It inherits BLOCK_SIZE_K, which is what fixes the fp32 reduction order, so
+# the results are bit-exact against the default config.
+_TUNE_DECODE_GEMM: bool = os.environ.get("MCORE_MOE_GEMM_TUNE", "0") == "1"
+
+
+def _get_decode_tuned_configs(M: int, E: int, top_k: int) -> tuple[dict, dict]:
+    """Per-GEMM launch configs for the decode regime; returns (fc1, fc2).
+
+    Measured on GB200 at the Qwen3-30B-A3B EP4 decode shape (hidden 2048,
+    moe_ffn 768, 32 local experts, top-8, 256 tokens): expert-weight traffic is
+    302 MB per layer against a 6.08 TB/s streaming-read ceiling, i.e. a 49.7 us
+    floor, while `_get_default_config` lands at 72.1 us. The gap is *not* FLOPs
+    (63-83 TFLOP/s achieved, ~3% of BF16 peak) and not the indirection-table
+    padding (shrinking it 3.9x -> 1.5x buys only ~1.2x); it is tile-quantized
+    SM occupancy. `_get_default_config` picks BLOCK_SIZE_N=128 for both GEMMs,
+    which leaves FC1 at ceil(768/128)=6 N-tiles x 32 M-tiles = 192 CTAs on 148
+    SMs — 1.3 waves, so ~30% of the machine idles in the tail.
+
+    So the two GEMMs want opposite N-tiles at decode: FC1 (narrow N=768) needs a
+    *small* BLOCK_SIZE_N to manufacture enough CTAs to fill the GPU, while FC2
+    (wide N=2048) already has plenty and prefers a *large* one for weight-load
+    efficiency. `_get_default_config` cannot express that because vLLM shares one
+    config across both passes. BLOCK_SIZE_M stays shared — one indirection table
+    is built for both GEMMs — and is dropped to 16 to cut padded rows as well.
+
+    Measured FC1+FC2, median of 3 x 300 iters: 72.13 us default -> 57.24 us here
+    (1.26x), i.e. 1.15x off the streaming-read floor.
+
+    Falls back to the shared default outside the decode regime (large M is
+    compute-bound and vLLM's heuristic is tuned for it).
+    """
+    default = _get_default_config(M, E, top_k)
+    # Measured CUDA-graph device time vs the default config: 1.289x at 128
+    # tokens, 1.197x at 256 (the decode point, = local_tokens * ep_size),
+    # 1.120x at 384, but 0.952x at 512 — past ~384 tokens there are already
+    # enough M-tiles to fill the GPU and the narrow FC1 tile starts costing
+    # weight-load efficiency. Hand back to upstream's heuristic there.
+    if M > 384:
+        return default, default
+    shared = dict(default)
+    shared['BLOCK_SIZE_M'] = 16
+    shared['GROUP_SIZE_M'] = 1
+    # BLOCK_SIZE_K is deliberately inherited rather than set. The fp32 K-reduction
+    # order is a function of BLOCK_SIZE_K alone, so inheriting it keeps this path
+    # bit-exact against the default config at every M. The default is already 64
+    # throughout the measured range (it only rises to 128 at M <= 64), so this is
+    # a no-op where the configs below were tuned.
+    fc1 = dict(shared, BLOCK_SIZE_N=64, num_warps=4, num_stages=3)
+    fc2 = dict(shared, BLOCK_SIZE_N=256, num_warps=8, num_stages=4)
+    return fc1, fc2
+
+
 @triton.jit
 def _fused_moe_kernel(
     # Pointers
@@ -1050,8 +1104,19 @@ def vllm_fused_moe(
 
     # Mirror upstream vLLM: pick the full launch config (tile sizes, warps,
     # stages) host-side from the token-count hint, not from the worst-case
-    # buffer size. Same config is used for both FC1 and FC2 (matches vLLM).
-    config = _get_default_config(M=effective_tokens, E=num_local_experts, top_k=topk)
+    # buffer size. Same config is used for both FC1 and FC2 (matches vLLM),
+    # unless the decode retune is enabled, which tiles the two passes
+    # separately (they have very different N) around a shared BLOCK_SIZE_M.
+    if _TUNE_DECODE_GEMM:
+        config_fc1, config_fc2 = _get_decode_tuned_configs(
+            M=effective_tokens, E=num_local_experts, top_k=topk
+        )
+    else:
+        config_fc1 = config_fc2 = _get_default_config(
+            M=effective_tokens, E=num_local_experts, top_k=topk
+        )
+    # BLOCK_SIZE_M is shared: one indirection table feeds both GEMMs.
+    config = config_fc1
 
     if _USE_FUSED_ALIGN and _USE_FUSED_COUNT and effective_tokens <= _FUSED_COUNT_MAX_TOKENS:
         if _USE_FUSED_SCATTER:
@@ -1086,8 +1151,8 @@ def vllm_fused_moe(
     block_m = config['BLOCK_SIZE_M']
     em_hint = effective_tokens * topk + block_m * num_local_experts
     num_pid_m_hint = _ceil_div(em_hint, block_m)
-    num_pid_n_fc1 = _ceil_div(fc1_out_width, config['BLOCK_SIZE_N'])
-    num_pid_n_fc2 = _ceil_div(K, config['BLOCK_SIZE_N'])
+    num_pid_n_fc1 = _ceil_div(fc1_out_width, config_fc1['BLOCK_SIZE_N'])
+    num_pid_n_fc2 = _ceil_div(K, config_fc2['BLOCK_SIZE_N'])
     grid_size_fc1 = num_pid_m_hint * num_pid_n_fc1
     grid_size_fc2 = num_pid_m_hint * num_pid_n_fc2
 
@@ -1111,7 +1176,7 @@ def vllm_fused_moe(
         num_post_padded,
         mul_routed_weight=False,
         top_k=topk,
-        config=config,
+        config=config_fc1,
         grid_size=grid_size_fc1,
         fuse_squared_relu=not is_swiglu,
         fuse_swiglu=use_fused_swiglu,
@@ -1140,7 +1205,7 @@ def vllm_fused_moe(
         num_post_padded,
         mul_routed_weight=False,
         top_k=1,
-        config=config,
+        config=config_fc2,
         grid_size=grid_size_fc2,
     )
 

--- a/megatron/core/inference/moe/vllm_fused_moe.py
+++ b/megatron/core/inference/moe/vllm_fused_moe.py
@@ -9,6 +9,7 @@ CUDA-graph compatible: all indirection table construction happens on-device
 via Triton kernels with fixed-size buffers and valid_tokens gating.
 """
 
+import os
 from typing import Optional
 from unittest.mock import MagicMock
 
@@ -319,6 +320,424 @@ def _fill_expert_block_ids_kernel(
     for off in tl.range(0, num_blocks, BLOCK):
         idxs = start_block + off + tl.arange(0, BLOCK)
         tl.store(expert_ids_ptr + idxs, e, mask=idxs < end_block)
+
+
+@triton.jit
+def _prefix_fill_init_kernel(
+    tokens_per_expert_ptr,  # [num_local_experts] raw token counts
+    exclusive_offsets_ptr,  # [num_local_experts] out: exclusive prefix sum (scatter counters)
+    inclusive_offsets_ptr,  # [num_local_experts] out: inclusive prefix sum
+    expert_ids_ptr,  # [max_blocks] out: expert index per BLOCK_SIZE_M block
+    sorted_token_ids_ptr,  # [max_sorted] out: SENTINEL-initialized indirection table
+    num_local_experts,
+    SENTINEL: tl.constexpr,
+    ALIGNMENT: tl.constexpr,  # = BLOCK_SIZE_M
+    NLE_POW2: tl.constexpr,  # next_power_of_2(num_local_experts) for tl.cumsum
+    FILL_BLOCK: tl.constexpr,  # vectorized store width
+):
+    """Fused prefix-sum + expert_ids fill + sorted_token_ids SENTINEL init.
+
+    Merges three kernels of the original indirection-table build
+    (``_init_sorted_ids_kernel`` + ``_prefix_sum_kernel`` +
+    ``_fill_expert_block_ids_kernel``) into one launch. Grid: one CTA per local
+    expert. Every CTA recomputes the (tiny, num_local_experts-wide) aligned
+    cumsum in registers, then CTA ``e`` writes only its own disjoint slices:
+
+      - exclusive_offsets[e], inclusive_offsets[e]   (offset arrays)
+      - expert_ids[excl_e//BM : incl_e//BM] = e      (block→expert map)
+      - sorted_token_ids[excl_e : incl_e] = SENTINEL (padding for its block)
+
+    The union of the per-expert [excl_e, incl_e) ranges is exactly
+    [0, num_tokens_post_padded), which is the only region the grouped-GEMM
+    reads (it strides tiles up to cdiv(num_tokens_post_padded, BM)); the buffer
+    tail beyond that is never read, so it needs no initialization. The
+    subsequent scatter overwrites the real token slots at the front of each
+    expert's block, leaving the alignment padding at SENTINEL. Correctness is
+    identical to the 3-kernel path; the only difference is fewer launches.
+    """
+    e = tl.program_id(0)
+    r = tl.arange(0, NLE_POW2)
+    mask = r < num_local_experts
+    h = tl.load(tokens_per_expert_ptr + r, mask=mask, other=0)
+    if ALIGNMENT > 1:
+        h = tl.where(h > 0, ((h + ALIGNMENT - 1) // ALIGNMENT) * ALIGNMENT, h)
+    inc = tl.cumsum(h, axis=0)
+    exc = inc - h
+    # Select this CTA's own offsets by masked reduction over the lane axis.
+    excl_e = tl.sum(tl.where(r == e, exc, 0))
+    incl_e = tl.sum(tl.where(r == e, inc, 0))
+    tl.store(exclusive_offsets_ptr + e, excl_e)
+    tl.store(inclusive_offsets_ptr + e, incl_e)
+
+    start_block = excl_e // ALIGNMENT
+    end_block = incl_e // ALIGNMENT
+    for off in tl.range(start_block, end_block, FILL_BLOCK):
+        idxs = off + tl.arange(0, FILL_BLOCK)
+        tl.store(expert_ids_ptr + idxs, e, mask=idxs < end_block)
+
+    for off in tl.range(excl_e, incl_e, FILL_BLOCK):
+        idxs = off + tl.arange(0, FILL_BLOCK)
+        tl.store(sorted_token_ids_ptr + idxs, SENTINEL, mask=idxs < incl_e)
+
+
+@triton.jit
+def _count_prefix_fill_init_kernel(
+    routing_map_ptr,  # [max_tokens, topk] expert assignments (global IDs)
+    valid_tokens_ptr,  # scalar int32 CUDA tensor: valid tokens this iteration
+    exclusive_offsets_ptr,  # [num_local_experts] out: exclusive prefix sum (scatter counters)
+    inclusive_offsets_ptr,  # [num_local_experts] out: inclusive prefix sum
+    expert_ids_ptr,  # [max_blocks] out: expert index per BLOCK_SIZE_M block
+    sorted_token_ids_ptr,  # [max_sorted] out: SENTINEL-initialized indirection table
+    num_local_experts,
+    local_expert_start,
+    topk: tl.constexpr,
+    SENTINEL: tl.constexpr,
+    ALIGNMENT: tl.constexpr,  # = BLOCK_SIZE_M
+    NUM_BINS: tl.constexpr,  # next_power_of_2(num_local_experts + 1)
+    COUNT_BLOCK: tl.constexpr,  # pairs histogrammed per iteration
+    FILL_BLOCK: tl.constexpr,  # vectorized store width
+):
+    """``_prefix_fill_init_kernel`` with the per-expert token count folded in.
+
+    ``_prefix_fill_init_kernel`` already has every CTA redundantly recompute the
+    tiny ``num_local_experts``-wide cumsum in registers, and its only input is
+    the count vector. That vector costs two extra launches to produce: a
+    ``torch.zeros`` fill for the counters plus
+    ``_count_local_tokens_kernel_persistent``. Recomputing the histogram
+    redundantly in every CTA removes both launches.
+
+    The count kernel is far more expensive than its work implies (measured 7.52
+    us of device time in the BS256 decode graph, against a 0.72 us empty-kernel
+    floor, to bucket 2048 int32s): with ``BLOCK_SIZE=1024`` and 2048 valid pairs
+    only 2 of its 152 CTAs receive any work, and each issues 1024 global atomics
+    contending on 32 counters. Here each CTA instead accumulates a private
+    register histogram over the same pairs, so there are no global atomics and
+    no cross-CTA ordering at all.
+
+    Counts are integer-identical to the atomic path, so the whole indirection
+    table -- and therefore the GEMM output -- is unchanged.
+
+    Redundant work is the trade: every CTA reads all ``valid_pairs`` entries, so
+    the read volume is ``num_local_experts x`` the atomic path's. At decode that
+    is 32 x 8 KB from L2 and free; the caller restricts this variant to the
+    decode regime for that reason.
+    """
+    e = tl.program_id(0)
+    valid_pairs = tl.load(valid_tokens_ptr) * topk
+
+    # Private per-CTA histogram of local expert IDs. Non-local and out-of-range
+    # pairs are folded into the dropped bin `num_local_experts`, which NUM_BINS
+    # is sized to hold and the mask below discards.
+    acc = tl.zeros([NUM_BINS], dtype=tl.int32)
+    for base in tl.range(0, valid_pairs, COUNT_BLOCK):
+        offs = base + tl.arange(0, COUNT_BLOCK)
+        m = offs < valid_pairs
+        eids = tl.load(routing_map_ptr + offs, mask=m, other=-1)
+        lids = eids - local_expert_start
+        is_local = (lids >= 0) & (lids < num_local_experts) & m
+        # routing_map is int64; tl.histogram wants int32 bin indices.
+        bins = tl.where(is_local, lids, num_local_experts).to(tl.int32)
+        acc += tl.histogram(bins, NUM_BINS)
+
+    r = tl.arange(0, NUM_BINS)
+    mask = r < num_local_experts
+    h = tl.where(mask, acc, 0)
+    if ALIGNMENT > 1:
+        h = tl.where(h > 0, ((h + ALIGNMENT - 1) // ALIGNMENT) * ALIGNMENT, h)
+    inc = tl.cumsum(h, axis=0)
+    exc = inc - h
+    excl_e = tl.sum(tl.where(r == e, exc, 0))
+    incl_e = tl.sum(tl.where(r == e, inc, 0))
+    tl.store(exclusive_offsets_ptr + e, excl_e)
+    tl.store(inclusive_offsets_ptr + e, incl_e)
+
+    start_block = excl_e // ALIGNMENT
+    end_block = incl_e // ALIGNMENT
+    for off in tl.range(start_block, end_block, FILL_BLOCK):
+        idxs = off + tl.arange(0, FILL_BLOCK)
+        tl.store(expert_ids_ptr + idxs, e, mask=idxs < end_block)
+
+    for off in tl.range(excl_e, incl_e, FILL_BLOCK):
+        idxs = off + tl.arange(0, FILL_BLOCK)
+        tl.store(sorted_token_ids_ptr + idxs, SENTINEL, mask=idxs < incl_e)
+
+
+@triton.jit
+def _align_single_kernel(
+    routing_map_ptr,  # [max_tokens, topk] expert assignments (global IDs)
+    valid_tokens_ptr,  # scalar int32 CUDA tensor: valid tokens this iteration
+    exclusive_offsets_ptr,  # [num_local_experts] out: exclusive prefix sum
+    inclusive_offsets_ptr,  # [num_local_experts] out: inclusive prefix sum
+    expert_ids_ptr,  # [max_blocks] out: expert index per BLOCK_SIZE_M block
+    sorted_token_ids_ptr,  # [max_sorted] out: indirection table
+    num_local_experts,
+    local_expert_start,
+    topk: tl.constexpr,
+    SENTINEL: tl.constexpr,
+    ALIGNMENT: tl.constexpr,  # = BLOCK_SIZE_M
+    NUM_BINS: tl.constexpr,  # next_power_of_2(num_local_experts + 1)
+    COUNT_BLOCK: tl.constexpr,  # pairs processed per iteration
+    FILL_BLOCK: tl.constexpr,  # vectorized store width
+):
+    """``_count_prefix_fill_init_kernel`` with the scatter folded in: the whole
+    indirection-table build in one launch.
+
+    CTA ``e`` owns local expert ``e`` and the disjoint output slice
+    ``[excl_e, incl_e)``. It already streams every valid pair once to build its
+    private histogram; a second streaming pass over the same (L2-resident, 16 KB
+    at decode) pairs lets it place its own pairs itself. Within a pass the
+    destination is ``excl_e + written_so_far + exclusive_cumsum(is_mine)``, so
+    no global atomics and no cross-CTA ordering are involved, and the resulting
+    table is deterministic (ascending pair index within each expert block)
+    rather than atomically permuted.
+
+    The second pass is why this is not free: it doubles the redundant read of
+    the routing map. The pairs are tiny and cached, so the trade is one removed
+    launch (``_scatter_token_indices_kernel``, measured 2.66 us + 0.55 us of
+    dispatch gap per layer in the BS256 decode graph) against that extra pass.
+
+    Row order within an expert block does not affect the result: each row of
+    ``sorted_token_ids`` is a ``token * topk + slot`` pair index, and the FC2
+    output is indexed by that same pair index, so any permutation within a
+    block produces identical values downstream.
+    """
+    e = tl.program_id(0)
+    valid_pairs = tl.load(valid_tokens_ptr) * topk
+
+    acc = tl.zeros([NUM_BINS], dtype=tl.int32)
+    for base in tl.range(0, valid_pairs, COUNT_BLOCK):
+        offs = base + tl.arange(0, COUNT_BLOCK)
+        m = offs < valid_pairs
+        eids = tl.load(routing_map_ptr + offs, mask=m, other=-1)
+        lids = eids - local_expert_start
+        is_local = (lids >= 0) & (lids < num_local_experts) & m
+        bins = tl.where(is_local, lids, num_local_experts).to(tl.int32)
+        acc += tl.histogram(bins, NUM_BINS)
+
+    r = tl.arange(0, NUM_BINS)
+    mask = r < num_local_experts
+    h = tl.where(mask, acc, 0)
+    if ALIGNMENT > 1:
+        h = tl.where(h > 0, ((h + ALIGNMENT - 1) // ALIGNMENT) * ALIGNMENT, h)
+    inc = tl.cumsum(h, axis=0)
+    exc = inc - h
+    excl_e = tl.sum(tl.where(r == e, exc, 0))
+    incl_e = tl.sum(tl.where(r == e, inc, 0))
+    tl.store(exclusive_offsets_ptr + e, excl_e)
+    tl.store(inclusive_offsets_ptr + e, incl_e)
+
+    start_block = excl_e // ALIGNMENT
+    end_block = incl_e // ALIGNMENT
+    for off in tl.range(start_block, end_block, FILL_BLOCK):
+        idxs = off + tl.arange(0, FILL_BLOCK)
+        tl.store(expert_ids_ptr + idxs, e, mask=idxs < end_block)
+
+    # SENTINEL-fill this expert's slice first; the scatter below overwrites the
+    # real pairs at the front of it and leaves the alignment padding sentinel.
+    for off in tl.range(excl_e, incl_e, FILL_BLOCK):
+        idxs = off + tl.arange(0, FILL_BLOCK)
+        tl.store(sorted_token_ids_ptr + idxs, SENTINEL, mask=idxs < incl_e)
+
+    pos = excl_e
+    for base in tl.range(0, valid_pairs, COUNT_BLOCK):
+        offs = base + tl.arange(0, COUNT_BLOCK)
+        m = offs < valid_pairs
+        eids = tl.load(routing_map_ptr + offs, mask=m, other=-1)
+        is_mine = (eids - local_expert_start == e) & m
+        sel = is_mine.to(tl.int32)
+        rank = tl.cumsum(sel, axis=0) - sel
+        tl.store(sorted_token_ids_ptr + pos + rank, offs, mask=is_mine)
+        pos += tl.sum(sel)
+
+
+# Fuse init + prefix-sum + expert-block fill (3 tiny serial kernels) into one
+# launch in the decode indirection-table build. Env-toggleable for A/B; the
+# fused path is numerically identical to the default (only launch count differs).
+_USE_FUSED_ALIGN: bool = os.environ.get("MCORE_MOE_FUSED_ALIGN", "0") == "1"
+
+# Additionally fold the per-expert token count (and the `torch.zeros` fill of its
+# counter buffer) into that same launch, taking the decode indirection-table
+# build from 4 kernels to 2. Requires MCORE_MOE_FUSED_ALIGN. Integer-exact.
+_USE_FUSED_COUNT: bool = os.environ.get("MCORE_MOE_FUSED_COUNT", "0") == "1"
+
+# Above this token hint the redundant per-CTA histogram stops being free, so hand
+# back to the atomic count kernel, whose read volume does not scale with the
+# expert count. 512 matches the decode regime `_get_decode_tuned_configs` targets.
+_FUSED_COUNT_MAX_TOKENS = 512
+
+# Additionally fold the scatter into that same launch, taking the decode
+# indirection-table build from 2 kernels to 1. Requires MCORE_MOE_FUSED_COUNT.
+# Produces the same table up to row order within an expert block, which the
+# downstream pair-indexed GEMM is invariant to.
+_USE_FUSED_SCATTER: bool = os.environ.get("MCORE_MOE_FUSED_SCATTER", "0") == "1"
+
+
+def _moe_align_block_size_fused(
+    routing_map: torch.Tensor,
+    block_size: int,
+    num_local_experts: int,
+    local_expert_start: int,
+    valid_tokens: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """3-kernel indirection-table build (count -> prefix_fill_init -> scatter).
+
+    Drop-in replacement for ``_moe_align_block_size_cuda_graphable`` that folds
+    the separate init + prefix-sum + fill kernels into ``_prefix_fill_init_kernel``.
+    Returns the same (sorted_token_ids, expert_ids, num_tokens_post_padded).
+    """
+    max_tokens, topk = routing_map.shape
+    device = routing_map.device
+
+    max_sorted = max_tokens * topk + block_size * (num_local_experts + 1)
+    max_blocks = _ceil_div(max_sorted, block_size)
+    sentinel = max_tokens * topk
+
+    sorted_token_ids = torch.empty(max_sorted, dtype=torch.int32, device=device)
+    expert_ids = torch.empty(max_blocks, dtype=torch.int32, device=device)
+
+    tokens_per_expert = compute_local_tokens_per_expert(
+        routing_map, local_expert_start, num_local_experts, valid_tokens, persistent=True
+    )
+    exclusive_offsets = torch.empty(num_local_experts, dtype=torch.int32, device=device)
+    inclusive_offsets = torch.empty(num_local_experts, dtype=torch.int32, device=device)
+
+    _prefix_fill_init_kernel[(num_local_experts,)](
+        tokens_per_expert,
+        exclusive_offsets,
+        inclusive_offsets,
+        expert_ids,
+        sorted_token_ids,
+        num_local_experts,
+        SENTINEL=sentinel,
+        ALIGNMENT=block_size,
+        NLE_POW2=triton.next_power_of_2(num_local_experts),
+        FILL_BLOCK=128,
+    )
+
+    max_pairs = max_tokens * topk
+    SCATTER_BLOCK = 256
+    scatter_grid = _ceil_div(max_pairs, SCATTER_BLOCK)
+    _scatter_token_indices_kernel[(scatter_grid,)](
+        routing_map,
+        sorted_token_ids,
+        exclusive_offsets,
+        valid_tokens,
+        topk,
+        local_expert_start,
+        num_local_experts,
+        max_pairs,
+        BLOCK_SIZE=SCATTER_BLOCK,
+    )
+
+    num_tokens_post_padded = inclusive_offsets[-1:]
+    return sorted_token_ids, expert_ids, num_tokens_post_padded
+
+
+def _moe_align_block_size_count_fused(
+    routing_map: torch.Tensor,
+    block_size: int,
+    num_local_experts: int,
+    local_expert_start: int,
+    valid_tokens: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """2-kernel indirection-table build (count_prefix_fill_init -> scatter).
+
+    Same contract and same outputs as ``_moe_align_block_size_fused``; it just
+    folds the token count and its counter-buffer zero-fill into the first launch.
+    """
+    max_tokens, topk = routing_map.shape
+    device = routing_map.device
+
+    max_sorted = max_tokens * topk + block_size * (num_local_experts + 1)
+    max_blocks = _ceil_div(max_sorted, block_size)
+    sentinel = max_tokens * topk
+
+    sorted_token_ids = torch.empty(max_sorted, dtype=torch.int32, device=device)
+    expert_ids = torch.empty(max_blocks, dtype=torch.int32, device=device)
+    exclusive_offsets = torch.empty(num_local_experts, dtype=torch.int32, device=device)
+    inclusive_offsets = torch.empty(num_local_experts, dtype=torch.int32, device=device)
+
+    _count_prefix_fill_init_kernel[(num_local_experts,)](
+        routing_map,
+        valid_tokens,
+        exclusive_offsets,
+        inclusive_offsets,
+        expert_ids,
+        sorted_token_ids,
+        num_local_experts,
+        local_expert_start,
+        topk=topk,
+        SENTINEL=sentinel,
+        ALIGNMENT=block_size,
+        NUM_BINS=triton.next_power_of_2(num_local_experts + 1),
+        COUNT_BLOCK=1024,
+        FILL_BLOCK=128,
+    )
+
+    max_pairs = max_tokens * topk
+    SCATTER_BLOCK = 256
+    scatter_grid = _ceil_div(max_pairs, SCATTER_BLOCK)
+    _scatter_token_indices_kernel[(scatter_grid,)](
+        routing_map,
+        sorted_token_ids,
+        exclusive_offsets,
+        valid_tokens,
+        topk,
+        local_expert_start,
+        num_local_experts,
+        max_pairs,
+        BLOCK_SIZE=SCATTER_BLOCK,
+    )
+
+    num_tokens_post_padded = inclusive_offsets[-1:]
+    return sorted_token_ids, expert_ids, num_tokens_post_padded
+
+
+def _moe_align_block_size_single(
+    routing_map: torch.Tensor,
+    block_size: int,
+    num_local_experts: int,
+    local_expert_start: int,
+    valid_tokens: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """1-kernel indirection-table build.
+
+    Same contract and same outputs as ``_moe_align_block_size_count_fused``,
+    with the scatter folded into the single launch as well. Row order within an
+    expert block is ascending pair index instead of atomically permuted; the
+    downstream GEMM indexes rows by pair id, so the result is unchanged.
+    """
+    max_tokens, topk = routing_map.shape
+    device = routing_map.device
+
+    max_sorted = max_tokens * topk + block_size * (num_local_experts + 1)
+    max_blocks = _ceil_div(max_sorted, block_size)
+    sentinel = max_tokens * topk
+
+    sorted_token_ids = torch.empty(max_sorted, dtype=torch.int32, device=device)
+    expert_ids = torch.empty(max_blocks, dtype=torch.int32, device=device)
+    exclusive_offsets = torch.empty(num_local_experts, dtype=torch.int32, device=device)
+    inclusive_offsets = torch.empty(num_local_experts, dtype=torch.int32, device=device)
+
+    _align_single_kernel[(num_local_experts,)](
+        routing_map,
+        valid_tokens,
+        exclusive_offsets,
+        inclusive_offsets,
+        expert_ids,
+        sorted_token_ids,
+        num_local_experts,
+        local_expert_start,
+        topk=topk,
+        SENTINEL=sentinel,
+        ALIGNMENT=block_size,
+        NUM_BINS=triton.next_power_of_2(num_local_experts + 1),
+        COUNT_BLOCK=1024,
+        FILL_BLOCK=128,
+    )
+
+    num_tokens_post_padded = inclusive_offsets[-1:]
+    return sorted_token_ids, expert_ids, num_tokens_post_padded
 
 
 def _moe_align_block_size_cuda_graphable(
@@ -634,7 +1053,16 @@ def vllm_fused_moe(
     # buffer size. Same config is used for both FC1 and FC2 (matches vLLM).
     config = _get_default_config(M=effective_tokens, E=num_local_experts, top_k=topk)
 
-    sorted_token_ids, expert_ids, num_post_padded = _moe_align_block_size_cuda_graphable(
+    if _USE_FUSED_ALIGN and _USE_FUSED_COUNT and effective_tokens <= _FUSED_COUNT_MAX_TOKENS:
+        if _USE_FUSED_SCATTER:
+            align_fn = _moe_align_block_size_single
+        else:
+            align_fn = _moe_align_block_size_count_fused
+    elif _USE_FUSED_ALIGN:
+        align_fn = _moe_align_block_size_fused
+    else:
+        align_fn = _moe_align_block_size_cuda_graphable
+    sorted_token_ids, expert_ids, num_post_padded = align_fn(
         routing_map, config['BLOCK_SIZE_M'], num_local_experts, local_expert_start, valid_tokens
     )
     num_valid = max_tokens * topk

--- a/megatron/core/transformer/moe/experts.py
+++ b/megatron/core/transformer/moe/experts.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import inspect
 import logging
+import os
 from collections.abc import Callable
 from contextlib import nullcontext
 from copy import deepcopy
@@ -86,6 +87,12 @@ from megatron.core.inference.moe import ActivationType as McoreActivationType
 from megatron.core.inference.moe import InferenceGroupedGemmBackend, mcore_fused_moe, vllm_fused_moe
 
 logger = logging.getLogger(__name__)
+
+# Fuse SiLU(gate)*up into the decode FC1 GEMM epilogue, removing the standalone
+# bounded_silu_mul kernel and the 2N intermediate HBM round-trip. No-op for
+# non-SwiGLU activations. Not bit-exact (max_abs 3.9e-5), so it is opt-in. Read
+# once here rather than per forward: the consumer is on the per-layer decode path.
+_FUSE_FC1_ACT: bool = os.environ.get("MCORE_FUSE_FC1_ACT", "0") == "1"
 
 
 class GroupedLinearFc1Interface(Protocol):
@@ -1200,6 +1207,7 @@ class InferenceGroupedMLP(TEGroupedMLP):
             routing_map=routing_map,
             out=NVLSAllGatherVDispatcher._get_rsv_tensor() if self._nvls_dispatcher else None,
             num_tokens_hint=InferenceAllGatherDispatcherBase._get_host_valid_tokens_estimate(),
+            fuse_fc1_activation=_FUSE_FC1_ACT,
         )
         return output, None
 


### PR DESCRIPTION
> Stacked on #6454. Review that one first; this diff is only a predicated locality test and a wider K tile in the MoE top-k reduction kernel.
>
> GitHub cannot base a pull request from a fork on another unmerged fork branch, so the diff below also contains the parent's commits. This PR's own change is the final commit, `afeb6601b`; review that one. The rest lands with the parent.

## Summary

`_moe_sum_kernel` spends 7.79 µs per layer moving about 6.3 MB — roughly **7× what its own
traffic implies** at the 6.081 TB/s measured on this GB200 — and the reason is control
flow, not bandwidth: the per-slot locality test is a uniform scalar branch on a dependent
`routing_map` load, so slot `t`'s data load cannot be issued before slot `t`'s predicate
comes back from memory and each CTA walks the eight top-k slots serially. Predicating that
test into the load mask, widening the K tile to the full hidden size and giving the launch
8 warps takes the kernel from **8.14 to 5.97 µs per layer (1.36×)** while staying
bit-exact: **+1.99%** end-to-end.

The claim this PR defends is about **1%**, and it is worth saying so up front: 2.17 µs per
layer × 48 layers is 104 µs of a 9.93 ms decode step, and the whole-MoE-call delta under
graph replay is smaller still. At 5.97 µs the kernel is still ~6× its own bandwidth floor,
and what is left is the strided gather, not the branch.

## Why here

A per-kernel breakdown of one steady-state decode step ranked `_moe_sum_kernel` first in
the routing category: 7.79 µs of device time plus the 0.55 µs intra-graph dispatch gap,
× 48 layers = **400 µs/step, 4.03% of the step**. It is not launch-bound (an empty kernel
in this graph is 0.72 µs) and not bandwidth-bound (~6.3 MB is ~1.05 µs at the measured
6.081 TB/s), which is what pointed at the kernel's internals.

Two ways to attack it were priced before either was written.

*Fuse the reduction into the FC2 epilogue.* This removes the whole 400 µs gross, but a
token's top-k slots land in different experts' blocks and therefore different M-tiles, so
accumulating into the output needs cross-CTA fp32 atomics — about 4 MB per layer of
read-modify-write — plus a zeroing pass over the output that does not exist today because
the kernel writes rather than accumulates. That gives back ~70 µs, leaves ~3.3% net, stops
being bit-exact, and is the exact shape an earlier attempt in this campaign measured at
0.68–0.80×. It was held as a fallback and not built.

*Restructure the kernel in place*: stop serialising the slot walk and hoist the per-token
scalar index loads out of the K loop. Priced at up to 48 × 5.8 = **278 µs (2.8%)**, with no
atomics and no loss of bit-exactness. That is this PR, and it recovered 104 µs of the 278.

## What changed

**Before.** `_moe_sum_kernel` runs a persistent grid of `num_sms` CTAs striding over
`valid_tokens`, with `BLOCK_K = min(next_pow2(K), 1024)`, so hidden 2048 is covered in two
K passes. For each K tile, for each of the 8 slots, it loads `routing_map[token, slot]`,
subtracts `local_expert_start`, and then `if lid >= 0 and lid < num_local_experts:` loads
the `BLOCK_K` bf16 values and the scalar routing probability and accumulates in fp32. Two
consequences follow from that shape. The branch is control flow gated on a value that has
to return from memory, so the compiler cannot begin slot `t+1`'s work while slot `t`'s
predicate is outstanding. And because the K loop is the outer loop, each token's 8 index
loads and 8 probability loads are issued once per K tile — 16 of each instead of 8.

**After.** `_moe_sum_kernel_fast` keeps the same loop nest, the same reduction and the same
fp32 arithmetic, and changes three things. The locality test becomes part of the load mask
(`mask = k_mask & is_local`) and the weight becomes `tl.where(is_local, w, 0.0)`, so there
is no branch and all eight data loads can issue back to back; the slot loop becomes
`tl.static_range` and is fully unrolled. `BLOCK_K` is raised to `min(next_pow2(K), 2048)`,
so at hidden 2048 there is a single K pass and each token's index and probability loads are
issued once. And the launch requests 8 warps rather than Triton's default 4, which the now
2048-wide tile needs.

**The mask is load-bearing for correctness, not only for speed.** FC2 only writes the
local-expert blocks, so the rows of its output belonging to a non-local slot are
uninitialized. Keeping `is_local` inside the *load* mask is what prevents that garbage from
being read at all. Multiplying an unmasked load by zero would not be safe here, because a
NaN would survive it.

## Measurement

Fixed protocol: Qwen3-30B-A3B, BF16, TP 1 / PP 1 / EP 4 / ETP 1, 256 gsm8k requests, 1024 output tokens, 2 warmup + 5 timed iterations, a single OCI 4xGB200 node (nvl72160-T04), async dynamic-batching scheduler pinned on. All 20 arms ran back to back in one allocation on that one node; node-to-node variance on this workload is around 2.7%, so cross-node numbers would not be comparable.

- With this change (every other gate in the stack enabled): **31,650 tok/s**
- Without it (same node, same session, only this gate turned off): **31,033 tok/s**
- Leave-one-out delta: **+1.99%**
- Noise floor: sigma = **0.42%** over 3 repeats of the all-gates-on reference
- Verdict: **resolved** by margin (4.7 sigma). The per-iteration distributions do not separate strictly, but only because each reference arm contains one low outlier iteration; excluding those the arms do not overlap.

This is the **marginal contribution measured with every other gate in this stack enabled** — the question a reviewer is actually asking, which is whether this should land, not what it was worth when it was first written.

The reference is drift-corrected. The all-gates-on configuration was re-measured three times across the session (31,745, 31,530, 31,503 tok/s), a +0.77% drift from first to last, so each arm is compared against the reference interpolated to its own position in the run order rather than against a session mean.

For context, the whole stack is worth **+35.80%** on this node (23,265 tok/s with every gate off, 31,593 with every gate on). Per-slice deltas do not sum to that; they compose sub-additively.

## Evidence

Eager per-kernel attribution at the decode point (256 valid tokens, 100 iterations), which
isolates the change cleanly because it touches exactly one kernel and no launch counts:
`_moe_sum_kernel` **8.14 → 5.97 µs (1.36×)**, with every other kernel in the call
unchanged — the grouped GEMM 62.18 → 61.88 µs, the fused table kernel 4.18 → 4.18 µs, the
scatter 3.07 → 3.03 µs.

Whole `vllm_fused_moe` call under CUDA-graph replay, 300 replays × 3 repeats:
73.10 → 71.59 µs at 128 tokens (**1.021×**), 80.69 → 78.77 at 256 (**1.024×**),
86.81 → 83.94 at 384 (**1.034×**), 102.68 → 98.56 at 512 (**1.042×**). Positive at every
shape measured, and improving with token count, which is what the mechanism predicts: the
serialisation it removes is per token.

What that implies for the step: 2.17 µs/layer × 48 = **104 µs** of a 9.93 ms step, about
1%. The whole-call graph-replay delta at 256 tokens is smaller, 1.92 µs × 48 = 92 µs.

Liveness: launch counts are unchanged — one kernel replaced by one kernel — so there is no
kernel-count delta to point at. The per-kernel table above serves instead: the replaced
kernel's device time moves and nothing else in the call does.

## Correctness

- **Numerics:** **bit-exact.** Whole-MoE output at 128 / 256 / 384 / 512 valid tokens,
  `max_abs = 0.0` **and** `max_rel = 0.0`; the relative error is checked explicitly rather
  than through a loose `allclose`.
- **Why that is structural.** The reduction runs over slots independently for each K lane,
  and the slot order is unchanged, so widening the K tile cannot alter any element's
  accumulation order — K lanes never interact. A masked-off slot contributes `0.0 * 0.0`
  added to an fp32 accumulator initialised to `+0.0`, which is an exact no-op. The warp
  count changes how a tile is distributed across threads, not the per-lane arithmetic.
- **Tests:** whole-MoE output equality at the four token counts above.
- **Coherence:** end-to-end prompts coherent and correct (`2+2=4`, Paris, `3+2` cows = 5
  cows); the benchmark completed all timed iterations.

## Gating and blast radius

- Gate: `MCORE_MOE_SUM_FAST`, **default OFF** —
  `os.environ.get("MCORE_MOE_SUM_FAST", "0") == "1"`, read once at import. Unset, `_moe_sum`
  dispatches the original kernel with `BLOCK_K` capped at 1024 and Triton's default warp
  count, byte-identically to before this PR.
- There is **no token-count cap** on this gate, unlike the table fusion and the tile retune
  earlier in this stack, because the kernel measured faster at every shape from 128 to 512
  tokens rather than degrading with pair count. Above 512 it is untested.
- The `BLOCK_K` ceiling of 2048 means a hidden size above 2048 falls back to multiple K
  passes with the predicated kernel: still correct, still bit-exact, but it recovers only
  the predication half of the win.
- Training and non-matching inference configs are unaffected: `vllm_fused_moe` is reached
  only by the `--transformer-impl inference_optimized` inference path with
  `--inference-grouped-gemm-backend vllm`.

## Reproduce

```bash
MCORE_MOE_SUM_FAST=1 \
QWEN30B_TP=1 QWEN30B_EP=4 QWEN30B_ETP=1 \
BENCH_SIZES_OVERRIDE=256 BENCH_OUTPUT_TOKENS=1024 \
NUM_WARMUP_ITERS=2 NUM_TIMED_ITERS=5 \
bash skills/run-qwen-model/run_qwen_inference.sh qwen3-30b-a3b --checkpoint "$QWEN30B_CKPT"
```

The gate is read at import, so it must be exported before the interpreter starts.

## What this does not claim

- **About 1%, not more.** The device-time evidence supports ~104 µs/step. When this change
  was first measured end-to-end the observed gain was larger than that, but the
  per-iteration throughput ranges of the two arms overlapped, so the excess is run-to-run
  variance rather than kernel time and is not claimed here.
- **Not the full priced ceiling.** Restructuring this kernel in place was priced at 278 µs
  and this captures 104 µs. At 5.97 µs the kernel is still ~6× its own bandwidth floor, and
  the remaining gap is the strided `[token, slot, K]` gather itself, not the branch.
- **The three changes are not separated.** Predication, the wider K tile and the warp-count
  bump ship together and no A/B splits them, so the 1.36× is attributed to the combination.
  The account of *why* the branched form was slow — a dependent scalar load blocking
  issue of the next slot's data load — is inferred from the code shape and supported by the
  fact that removing it recovers 2.17 µs; it was not confirmed with a stall-reason profile.
- **Nothing above 512 tokens**, which is untested, though every shape that was measured
  improved. Prefill is not a target.
- **The fused-into-FC2 alternative is deliberately not built**, and this PR does not claim
  its ~3.3% net. See Follow-ups.
- Deltas in this stack do not add. Every slice here shortens the same MoE call and draws on
  the same intra-graph dispatch budget, so they compose sub-additively.

## Follow-ups

- Fusing the top-k reduction into the FC2 epilogue is the remaining lever on this kernel:
  ~400 µs/step gross, ~3.3% net after the zeroing pass, but it needs cross-CTA fp32 atomics
  (~4 MB/layer of read-modify-write), it stops being bit-exact, and the same shape was
  previously measured at 0.68–0.80×. Left alone on purpose.
- The router pair — `gatherTopK` at 6.05 µs plus a `[256, 128]` fp32 softmax at 1.94 µs —
  is 436.8 µs/step in two kernels and is the largest routing item still standing.

---

## This stack

This is one slice of [#6064](https://github.com/NVIDIA/Megatron-LM/pull/6064), a Qwen3-30B-A3B decode optimization campaign, split into 16 independently reviewable changes. Together they are **+35.80%** end-to-end throughput over the same base commit (23,265 -> 31,593 tok/s, mean of three full runs).

- **MoE grouped-GEMM and dispatch:** #6452 -> #6453 -> #6454 -> #6455
- **MoE router and combine:** #6456 -> #6457 -> #6458
- **Attention: QK norm and decode kernel:** #6459 -> #6460 -> #6461 -> #6462
- **Residual + RMSNorm fusion:** #6463 -> #6464
- **Host path: context bookkeeping:** #6465 -> #6466
- **Host path: independent:** #6467

Each chain is independent of the others and bases on `main`. Within a chain, later PRs depend on earlier ones.

### Per-slice measured delta

Every number is a leave-one-out delta from one same-node, same-session campaign: the full stack with exactly this change's gate off, against the interpolated full-stack reference at that point in the run. It is the change's *marginal* contribution with everything else already in, not its standalone value. Run-to-run sigma was **0.42%** across three full-stack repeats.

| PR | Change | Delta | |
|---|---|---|---|
| #6452 | FC1 SwiGLU epilogue | +14.81% | resolved |
| #6453 | indirection table fusion | +7.21% | resolved |
| #6454 | decode GEMM tile configs | +6.77% | resolved |
| #6455 | predicated top-k gather | +1.99% | by margin |
| #6456 | fused router softmax+top-k | +4.75% | resolved |
| #6457 | fused route padding mask | +1.47% | by margin |
| #6458 | bf16 MoE combine | +2.42% | by margin |
| #6459 | fused QK RMSNorm | +5.17% | resolved |
| #6460 | grouped QK norm input | +1.18% | by margin |
| #6461 | pin FlashAttention 2 | -0.35% | noise floor |
| #6462 | FlashInfer TRT-LLM decode | +1.46% | by margin |
| #6463 | fused add+norm pre-MLP | +3.54% | by margin |
| #6464 | fused add+norm pre-QKV | +0.98% | by margin |
| #6465 | incremental attention state | -0.42% | noise floor |
| #6466 | vectorized decode bookkeeping | -0.07% | noise floor |
| #6467 | post_process_requests fast path | +0.09% | noise floor |

`noise floor` means the delta is inside 2 sigma (0.84%) and this campaign cannot distinguish it from zero. `resolved` means the leave-one-out and full-stack iteration distributions did not overlap. Deltas do not sum to the stack total: these changes shorten the same decode step and compose sub-additively.

**Fixed protocol for every number above.** Qwen3-30B-A3B, BF16, TP1/PP1/EP4/ETP1, 256 gsm8k requests at batch size 256, output length 1024, CUDA graphs on, one OCI GB200 NVL72 node, 4 GPUs. All 20 arms ran back-to-back in a single Slurm allocation on one node, so node assignment and thermal state are held constant.
