### PR TITLE
perf(inference): fused softmax + top-k router selection for decode

### DIFF
--- a/megatron/core/inference/moe/router_topk.py
+++ b/megatron/core/inference/moe/router_topk.py
@@ -1,0 +1,130 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Fused softmax + top-k router selection for decode-shaped MoE inference.
+
+The eager path runs ``torch.softmax`` over the expert dimension and then
+``torch.topk``. At decode shapes (``[num_tokens, 128]`` fp32) both kernels are
+launch/latency dominated and ``topk`` in particular runs a multi-pass radix
+select. One CTA per token can do the whole thing out of registers.
+"""
+
+import os
+from typing import Tuple
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+
+    HAVE_TRITON = True
+except ImportError:
+    HAVE_TRITON = False
+
+# Fuse the router softmax and top-k into one Triton kernel. Env-toggleable; default off.
+USE_FUSED_ROUTER_TOPK: bool = os.environ.get("MCORE_ROUTER_FUSED_TOPK", "0") == "1"
+
+# Above this token count the two-kernel torch path amortizes its launch cost and the
+# one-CTA-per-token kernel stops being the right shape, so the fused path is decode-only.
+FUSED_ROUTER_TOPK_MAX_TOKENS: int = 1024
+
+
+if HAVE_TRITON:
+
+    @triton.jit
+    def _softmax_topk_kernel(
+        logits_ptr,
+        probs_ptr,
+        indices_ptr,
+        num_experts,
+        TOPK: tl.constexpr,
+        BLOCK_E: tl.constexpr,
+    ):
+        """One CTA per token: softmax over experts, then TOPK selection passes.
+
+        Selection is max-then-mask, which yields the top-k in descending score
+        order with ties broken toward the lower expert id. ``torch.topk`` is
+        called with ``sorted=False`` during inference, so its own order is
+        unspecified and any consistent order is an equally valid answer.
+        """
+        token_id = tl.program_id(0)
+        offs = tl.arange(0, BLOCK_E)
+        mask = offs < num_experts
+
+        x = tl.load(logits_ptr + token_id * num_experts + offs, mask=mask, other=-float("inf"))
+        x = x.to(tl.float32)
+        m = tl.max(x, axis=0)
+        e = tl.exp(x - m)
+        e = tl.where(mask, e, 0.0)
+        p = e / tl.sum(e, axis=0)
+
+        cur = tl.where(mask, p, -float("inf"))
+        for k in tl.static_range(TOPK):
+            best = tl.max(cur, axis=0)
+            is_best = cur == best
+            best_idx = tl.min(tl.where(is_best, offs, num_experts), axis=0)
+            tl.store(probs_ptr + token_id * TOPK + k, best)
+            tl.store(indices_ptr + token_id * TOPK + k, best_idx)
+            cur = tl.where(offs == best_idx, -float("inf"), cur)
+
+
+def fused_softmax_topk(logits: torch.Tensor, topk: int) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Pre-softmax top-k routing in a single kernel.
+
+    Args:
+        logits: ``[num_tokens, num_experts]``, any float dtype.
+        topk: number of experts per token.
+
+    Returns:
+        ``(probs, top_indices)`` with shapes ``[num_tokens, topk]``. ``probs``
+        matches the dtype of ``logits`` (the softmax itself is fp32, as in the
+        eager path); ``top_indices`` is int64 to match ``torch.topk``.
+    """
+    assert logits.dim() == 2, f"Expected 2D logits, got {logits.dim()}D"
+    num_tokens, num_experts = logits.shape
+    probs = torch.empty(num_tokens, topk, dtype=logits.dtype, device=logits.device)
+    indices = torch.empty(num_tokens, topk, dtype=torch.int64, device=logits.device)
+    _softmax_topk_kernel[(num_tokens,)](
+        logits,
+        probs,
+        indices,
+        num_experts,
+        TOPK=topk,
+        BLOCK_E=triton.next_power_of_2(num_experts),
+        num_warps=1,
+    )
+    return probs, indices
+
+
+def can_use_fused_softmax_topk(
+    logits: torch.Tensor,
+    topk: int,
+    use_pre_softmax: bool,
+    num_groups,
+    group_topk,
+    scaling_factor,
+    score_function: str,
+    expert_bias,
+    router_replay,
+) -> bool:
+    """Whether the fused kernel reproduces this exact routing contract."""
+    return (
+        HAVE_TRITON
+        and USE_FUSED_ROUTER_TOPK
+        and logits.dim() == 2
+        and logits.is_cuda
+        and logits.shape[0] <= FUSED_ROUTER_TOPK_MAX_TOKENS
+        and score_function == "softmax"
+        and use_pre_softmax
+        and num_groups is None
+        and group_topk is None
+        and not scaling_factor
+        and expert_bias is None
+        and router_replay is None
+        # topk == 1 is excluded because the reference path ends in
+        # `top_indices.squeeze(1)`, which drops the k dimension only at k == 1.
+        # This kernel always returns [num_tokens, topk], so honoring k == 1 here
+        # would hand the dispatcher a differently-ranked tensor than the path it
+        # replaces.
+        and 1 < topk <= logits.shape[1]
+    )

--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -5,6 +5,7 @@ from typing import Optional, Union
 
 import torch
 
+from megatron.core.inference.moe.router_topk import can_use_fused_softmax_topk, fused_softmax_topk
 from megatron.core.inference.utils import InferenceMode
 from megatron.core.jit import jit_fuser
 from megatron.core.transformer.custom_layers.batch_invariant_kernels import (
@@ -955,6 +956,28 @@ class InferenceTopKRouter(TopKRouter):
         precomputed_indices = None
         if self.qb_beta is not None:
             precomputed_indices = (logits - self.qb_beta).topk(self.topk, dim=1).indices
+
+        # The fused kernel selects on the logits themselves, so it cannot honor a
+        # qb_beta-shifted selection; leave those models on the reference path. Batch-
+        # invariant mode stays on the reference path too: it picks its own routing
+        # implementation below, and this kernel is not one of them. That test sits
+        # after the gate check so the gate-off path does not pay for it.
+        if (
+            self.qb_beta is None
+            and can_use_fused_softmax_topk(
+                logits,
+                self.topk,
+                use_pre_softmax=self.config.moe_router_pre_softmax,
+                num_groups=self.config.moe_router_num_groups,
+                group_topk=self.config.moe_router_group_topk,
+                scaling_factor=self.config.moe_router_topk_scaling_factor,
+                score_function=self.score_function,
+                expert_bias=self.expert_bias,
+                router_replay=self.router_replay,
+            )
+            and not is_batch_invariant_mode_enabled()
+        ):
+            return fused_softmax_topk(logits, self.topk)
 
         routing = (
             topk_routing_with_score_function


### PR DESCRIPTION
> This is the root of a three-PR chain: this one, then the CUDA-graph padding-sentinel fold
> (the parent PR), then the bf16 MoE combine (the parent PR). Nothing has to be reviewed before this PR. The
> two children stack on it in that order and each carries its own description; as they merge,
> their bases collapse onto this one and then onto main.

## Summary

`InferenceTopKRouter` selects experts by running `torch.softmax` over the expert dimension and
then `torch.topk(sorted=False)`, and at decode shapes that pair lowers to four kernels per
layer — 48 layers per decode step — for nothing more than a `[num_tokens, 128]` fp32 row
reduction and an 8-of-128 selection, with `torch.topk` paying for a multi-pass radix select
sized for large `n`. One Triton kernel with one CTA per token holds the whole expert row in
registers, softmaxes it, and picks the top 8 by eight max-then-mask passes, taking the router
selection from 16.41 µs to 4.10 µs per layer under CUDA-graph replay at 256 tokens:
**+4.75%** end-to-end decode throughput.

The one thing to know before reading the diff is that the profile that selected this target
undercounted it. It attributed two kernels to the router; the fused kernel absorbs four,
because a `.type_as` cast and one more elementwise kernel live in the same region, and that is
why the campaign's original measurement came in above the ceiling priced from the two-kernel
accounting.

## Why here

A steady-state decode profile ranked the routing chain by device time and left this pair as its
largest untouched item: `gatherTopK` at 6.05 µs and the compiled softmax at 1.94 µs per layer,
436.8 µs/step across 48 layers, roughly 4% of the step. Pricing the ceiling before writing any
code — replace about 8.0 µs of kernel time plus about 0.55 µs of dispatch gap per layer with a
single ~2 µs kernel — gave ~312 µs/step, which was enough to justify the kernel.

TransformerEngine's built-in fused router was already ruled out for this path in an earlier
session, because it emits a dense 128-expert map while the `inference_optimized` MoE stack needs
the dense top-8 contract. This kernel is written to the top-8 contract directly, so the
rejection of the vendor kernel does not apply to it.

## What changed

**Before.** `_forward` computes the gating logits and hands them to `_compiled_topk_routing`, a
`torch.compile` wrapper around `topk_routing_with_score_function`. At 256 tokens that lowers to
four launches, measured eagerly and individually: `gatherTopK` 9.12 µs, `unrolled_elementwise`
2.76 µs, `softmax_warp_forward` 2.09 µs, `vectorized_elementwise` 1.57 µs — 15.54 µs in four
kernels, all of it inside the serial routing dependency chain, since dispatch cannot start until
the routing map exists.

**After.** `fused_softmax_topk` launches `_softmax_topk_kernel` with a grid of one CTA per token
and `num_warps=1`. Each CTA loads its entire expert row, padded up to the next power of two with
`-inf`, converts to fp32, does the max-subtract/exp/normalize softmax in registers, and then runs
`TOPK` statically unrolled passes of max, tie-broken argmax, store, mask-out. That is 2.04 µs in
one kernel: four launches become one.

The reason this is cheaper has nothing to do with bandwidth. A 128-expert fp32 row is 512 bytes;
the work is trivial and the cost is the launches plus `topk`'s multi-pass structure. With only 128
candidates the whole selection fits in registers, so the passes cost register reductions instead
of round trips through global memory. The consequence shows up as flatness in token count: the
fused kernel measures 4.10 µs at 128, 256 and 384 tokens and 4.11 µs at 512, while the torch pair
climbs from 16.40 to 20.47 µs over the same range, because the fused kernel adds CTAs where the
torch path adds work inside a fixed number of launches.

One contract detail matters for review. Max-then-mask returns the k results in descending score
order with ties broken toward the lower expert id, whereas `torch.topk` is called with
`sorted=False` and therefore leaves its own order unspecified. Both are valid: the downstream
consumer (`_moe_sum`) reads slot `t` of the probability tensor together with slot `t` of the
routing map and treats the slots as an unordered set, so only the pairing has to be consistent,
and it is.

## Measurement

Fixed protocol: Qwen3-30B-A3B, BF16, TP 1 / PP 1 / EP 4 / ETP 1, 256 gsm8k requests, 1024 output tokens, 2 warmup + 5 timed iterations, a single OCI 4xGB200 node (nvl72160-T04), async dynamic-batching scheduler pinned on. All 20 arms ran back to back in one allocation on that one node; node-to-node variance on this workload is around 2.7%, so cross-node numbers would not be comparable.

- With this change (every other gate in the stack enabled): **31,626 tok/s**
- Without it (same node, same session, only this gate turned off): **30,192 tok/s**
- Leave-one-out delta: **+4.75%**
- Noise floor: sigma = **0.42%** over 3 repeats of the all-gates-on reference
- Verdict: **resolved**; the per-iteration distributions separate completely (every timed iteration of the better arm beats every timed iteration of the worse one)

This is the **marginal contribution measured with every other gate in this stack enabled** — the question a reviewer is actually asking, which is whether this should land, not what it was worth when it was first written.

The reference is drift-corrected. The all-gates-on configuration was re-measured three times across the session (31,745, 31,530, 31,503 tok/s), a +0.77% drift from first to last, so each arm is compared against the reference interpolated to its own position in the run order rather than against a session mean.

For context, the whole stack is worth **+35.80%** on this node (23,265 tok/s with every gate off, 31,593 with every gate on). Per-slice deltas do not sum to that; they compose sub-additively.

## Evidence

Microbench of the router selection alone under CUDA-graph replay, 500 replays × 3 repeats at 128
experts: 16.40 → 4.10 µs at 128 tokens, **16.41 → 4.10 µs at 256 tokens (4.00×)**, 18.43 → 4.10 µs
at 384 (4.49×), 20.47 → 4.11 µs at 512 (4.99×). The eager per-kernel accounting at 256 tokens is
the 15.54 µs in four kernels quoted above, against 2.04 µs in one.

Liveness comes from that same per-kernel attribution rather than from a trace. The reference arm
shows `gatherTopK`, `softmax_warp_forward` and the two elementwise kernels; the gated arm shows
`_softmax_topk_kernel` and none of the four. That is a direct 4 → 1 launch observation with names
on both sides, which is why no Nsight capture was taken for this change — a gate that silently
declines looks exactly like a change that does not help, and this campaign has shipped an inert
fusion before, so the check is not optional even when the mechanism is obvious.

## Correctness

- **Numerics:** the probabilities came out bit-exact and the expert sets identical at 128/256/384/512
  tokens × 2 seeds — `max_abs` 0.0 and `max_rel` 0.0 after aligning the k slots by expert id, with
  no duplicate expert ids on either side. Be aware that this is an empirical result, not a
  structural guarantee: the kernel performs the same fp32 max-subtract/exp/normalize sequence as
  the eager path, but Triton's `exp` and torch's are not contractually identical, so I would claim
  bit-exactness at 128 experts and these shapes, and not for an arbitrary expert count.
- **Tests:** the shape × seed sweep above, run against the compiled torch path in the same process.
  There is no new unit test in this diff, and the existing router unit tests exercise only the
  gate-off path.
- **Coherence:** the three greedy-decode probes used throughout this campaign stayed correct
  (`2+2 = 4`, "Paris", `3+2` cows = 5 cows) and the benchmark completed all five timed iterations.

## Gating and blast radius

- Gate: `MCORE_ROUTER_FUSED_TOPK`, read once at import as `os.environ.get(..., "0") == "1"`, so
  **default OFF**. Unset, `can_use_fused_softmax_topk` returns `False` on its second term and the
  compiled torch path runs byte-identically to before this PR.
- The Triton import is wrapped in `try/except ImportError`; without Triton `HAVE_TRITON` is `False`
  and the predicate short-circuits on its first term.
- Preconditions checked by the guard: 2-D CUDA logits, at most 1024 tokens, `score_function ==
  "softmax"`, pre-softmax normalization, no expert groups, no group top-k, no router top-k scaling
  factor, no expert bias, no router replay, and `1 < topk <= num_experts`. Two more are checked at
  the call site: `qb_beta is None`, because the kernel selects on the raw logits and cannot honor a
  `qb_beta`-shifted selection, and batch-invariant mode off, because that mode chooses its own
  routing implementation and this kernel is not one of them.
- **`topk == 1` is deliberately excluded**, and the reason is a shape contract rather than a
  numerical one. The reference path ends in `top_indices.squeeze(1)`, which is the identity at
  every `k > 1` but drops the k dimension entirely at `k == 1`, returning `[num_tokens]`. This
  kernel always returns `[num_tokens, topk]`. Admitting `k == 1` would therefore hand the
  dispatcher a differently-ranked tensor than the path it replaces. Top-1 routed models keep the
  compiled path; every other `k` is unaffected, and the measured configuration is `k = 8`.
- When any precondition fails, the existing compiled path runs unchanged; nothing raises. Training
  is unaffected on two independent counts: `InferenceTopKRouter.forward` delegates to
  `TopKRouter.forward` whenever `InferenceMode` is not active, and training does not set the gate.

## Reproduce

```bash
MCORE_ROUTER_FUSED_TOPK=1 \
QWEN30B_TP=1 QWEN30B_EP=4 QWEN30B_ETP=1 \
BENCH_SIZES_OVERRIDE=256 BENCH_OUTPUT_TOKENS=1024 \
NUM_WARMUP_ITERS=2 NUM_TIMED_ITERS=5 \
bash skills/run-qwen-model/run_qwen_inference.sh qwen3-30b-a3b --checkpoint "$QWEN30B_CKPT"
```

Triton is required. Use the run venv's interpreter rather than the container's system python; the
gate looks inert if `import triton` fails, because the predicate then declines silently.

## What this does not claim

- **The 1024-token cap is conservative, not a measured crossover.** The sweep stops at 512 tokens,
  where the fused kernel is still about 5× faster than the torch pair, so no claim is made about
  where the two actually cross. The cap exists because one CTA per token with a single warp stops
  being a sensible shape at prefill sizes, not because a regression was measured. Prefill chunks
  above the cap take the reference path.
- Nothing is claimed for sigmoid scoring, post-softmax normalization, group-limited routing, a
  top-k scaling factor, expert bias, router replay, `qb_beta` models, or batch-invariant mode. All
  of those are excluded by the guard and keep their current behavior exactly.
- Bit-exactness is an empirical result at the shapes tested, as described above.
- The four-launch figure is measured; the split of the win between the selection and softmax kernels
  and the two elementwise kernels is not, because all four were removed together by one change and I
  did not isolate them.
- Deltas in this stack do not add. This change, the padding-sentinel fold that stacks on it, and
  the other per-layer launch removals in the campaign all attack the same serial routing chain and
  the same host dispatch gaps, so they compose sub-additively and the combination has to be
  measured rather than summed.

## Follow-ups

- A unit test for the fused path against the compiled reference across the guard's accepted shapes
  would let this gate move toward default-on; the current evidence is a development harness that is
  not part of this diff.

---

## This stack

This is one slice of [#6064](https://github.com/NVIDIA/Megatron-LM/pull/6064), a Qwen3-30B-A3B decode optimization campaign, split into 16 independently reviewable changes. Together they are **+35.80%** end-to-end throughput over the same base commit (23,265 -> 31,593 tok/s, mean of three full runs).

- **MoE grouped-GEMM and dispatch:** #6452 -> #6453 -> #6454 -> #6455
- **MoE router and combine:** #6456 -> #6457 -> #6458
- **Attention: QK norm and decode kernel:** #6459 -> #6460 -> #6461 -> #6462
- **Residual + RMSNorm fusion:** #6463 -> #6464
- **Host path: context bookkeeping:** #6465 -> #6466
- **Host path: independent:** #6467

Each chain is independent of the others and bases on `main`. Within a chain, later PRs depend on earlier ones.

### Per-slice measured delta

Every number is a leave-one-out delta from one same-node, same-session campaign: the full stack with exactly this change's gate off, against the interpolated full-stack reference at that point in the run. It is the change's *marginal* contribution with everything else already in, not its standalone value. Run-to-run sigma was **0.42%** across three full-stack repeats.

| PR | Change | Delta | |
|---|---|---|---|
| #6452 | FC1 SwiGLU epilogue | +14.81% | resolved |
| #6453 | indirection table fusion | +7.21% | resolved |
| #6454 | decode GEMM tile configs | +6.77% | resolved |
| #6455 | predicated top-k gather | +1.99% | by margin |
| #6456 | fused router softmax+top-k | +4.75% | resolved |
| #6457 | fused route padding mask | +1.47% | by margin |
| #6458 | bf16 MoE combine | +2.42% | by margin |
| #6459 | fused QK RMSNorm | +5.17% | resolved |
| #6460 | grouped QK norm input | +1.18% | by margin |
| #6461 | pin FlashAttention 2 | -0.35% | noise floor |
| #6462 | FlashInfer TRT-LLM decode | +1.46% | by margin |
| #6463 | fused add+norm pre-MLP | +3.54% | by margin |
| #6464 | fused add+norm pre-QKV | +0.98% | by margin |
| #6465 | incremental attention state | -0.42% | noise floor |
| #6466 | vectorized decode bookkeeping | -0.07% | noise floor |
| #6467 | post_process_requests fast path | +0.09% | noise floor |

`noise floor` means the delta is inside 2 sigma (0.84%) and this campaign cannot distinguish it from zero. `resolved` means the leave-one-out and full-stack iteration distributions did not overlap. Deltas do not sum to the stack total: these changes shorten the same decode step and compose sub-additively.

**Fixed protocol for every number above.** Qwen3-30B-A3B, BF16, TP1/PP1/EP4/ETP1, 256 gsm8k requests at batch size 256, output length 1024, CUDA graphs on, one OCI GB200 NVL72 node, 4 GPUs. All 20 arms ran back-to-back in a single Slurm allocation on one node, so node assignment and thermal state are held constant.
