### PR TITLE
perf(inference): fold the CUDA-graph padding sentinel into the router top-k

### DIFF
--- a/megatron/core/inference/moe/router_topk.py
+++ b/megatron/core/inference/moe/router_topk.py
@@ -1,0 +1,130 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Fused softmax + top-k router selection for decode-shaped MoE inference.
+
+The eager path runs ``torch.softmax`` over the expert dimension and then
+``torch.topk``. At decode shapes (``[num_tokens, 128]`` fp32) both kernels are
+launch/latency dominated and ``topk`` in particular runs a multi-pass radix
+select. One CTA per token can do the whole thing out of registers.
+"""
+
+import os
+from typing import Tuple
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+
+    HAVE_TRITON = True
+except ImportError:
+    HAVE_TRITON = False
+
+# Fuse the router softmax and top-k into one Triton kernel. Env-toggleable; default off.
+USE_FUSED_ROUTER_TOPK: bool = os.environ.get("MCORE_ROUTER_FUSED_TOPK", "0") == "1"
+
+# Above this token count the two-kernel torch path amortizes its launch cost and the
+# one-CTA-per-token kernel stops being the right shape, so the fused path is decode-only.
+FUSED_ROUTER_TOPK_MAX_TOKENS: int = 1024
+
+
+if HAVE_TRITON:
+
+    @triton.jit
+    def _softmax_topk_kernel(
+        logits_ptr,
+        probs_ptr,
+        indices_ptr,
+        num_experts,
+        TOPK: tl.constexpr,
+        BLOCK_E: tl.constexpr,
+    ):
+        """One CTA per token: softmax over experts, then TOPK selection passes.
+
+        Selection is max-then-mask, which yields the top-k in descending score
+        order with ties broken toward the lower expert id. ``torch.topk`` is
+        called with ``sorted=False`` during inference, so its own order is
+        unspecified and any consistent order is an equally valid answer.
+        """
+        token_id = tl.program_id(0)
+        offs = tl.arange(0, BLOCK_E)
+        mask = offs < num_experts
+
+        x = tl.load(logits_ptr + token_id * num_experts + offs, mask=mask, other=-float("inf"))
+        x = x.to(tl.float32)
+        m = tl.max(x, axis=0)
+        e = tl.exp(x - m)
+        e = tl.where(mask, e, 0.0)
+        p = e / tl.sum(e, axis=0)
+
+        cur = tl.where(mask, p, -float("inf"))
+        for k in tl.static_range(TOPK):
+            best = tl.max(cur, axis=0)
+            is_best = cur == best
+            best_idx = tl.min(tl.where(is_best, offs, num_experts), axis=0)
+            tl.store(probs_ptr + token_id * TOPK + k, best)
+            tl.store(indices_ptr + token_id * TOPK + k, best_idx)
+            cur = tl.where(offs == best_idx, -float("inf"), cur)
+
+
+def fused_softmax_topk(logits: torch.Tensor, topk: int) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Pre-softmax top-k routing in a single kernel.
+
+    Args:
+        logits: ``[num_tokens, num_experts]``, any float dtype.
+        topk: number of experts per token.
+
+    Returns:
+        ``(probs, top_indices)`` with shapes ``[num_tokens, topk]``. ``probs``
+        matches the dtype of ``logits`` (the softmax itself is fp32, as in the
+        eager path); ``top_indices`` is int64 to match ``torch.topk``.
+    """
+    assert logits.dim() == 2, f"Expected 2D logits, got {logits.dim()}D"
+    num_tokens, num_experts = logits.shape
+    probs = torch.empty(num_tokens, topk, dtype=logits.dtype, device=logits.device)
+    indices = torch.empty(num_tokens, topk, dtype=torch.int64, device=logits.device)
+    _softmax_topk_kernel[(num_tokens,)](
+        logits,
+        probs,
+        indices,
+        num_experts,
+        TOPK=topk,
+        BLOCK_E=triton.next_power_of_2(num_experts),
+        num_warps=1,
+    )
+    return probs, indices
+
+
+def can_use_fused_softmax_topk(
+    logits: torch.Tensor,
+    topk: int,
+    use_pre_softmax: bool,
+    num_groups,
+    group_topk,
+    scaling_factor,
+    score_function: str,
+    expert_bias,
+    router_replay,
+) -> bool:
+    """Whether the fused kernel reproduces this exact routing contract."""
+    return (
+        HAVE_TRITON
+        and USE_FUSED_ROUTER_TOPK
+        and logits.dim() == 2
+        and logits.is_cuda
+        and logits.shape[0] <= FUSED_ROUTER_TOPK_MAX_TOKENS
+        and score_function == "softmax"
+        and use_pre_softmax
+        and num_groups is None
+        and group_topk is None
+        and not scaling_factor
+        and expert_bias is None
+        and router_replay is None
+        # topk == 1 is excluded because the reference path ends in
+        # `top_indices.squeeze(1)`, which drops the k dimension only at k == 1.
+        # This kernel always returns [num_tokens, topk], so honoring k == 1 here
+        # would hand the dispatcher a differently-ranked tensor than the path it
+        # replaces.
+        and 1 < topk <= logits.shape[1]
+    )

--- a/megatron/core/inference/moe/router_topk.py
+++ b/megatron/core/inference/moe/router_topk.py
@@ -9,7 +9,7 @@ select. One CTA per token can do the whole thing out of registers.
 """
 
 import os
-from typing import Tuple
+from typing import Optional, Tuple
 
 import torch
 
@@ -27,6 +27,27 @@ USE_FUSED_ROUTER_TOPK: bool = os.environ.get("MCORE_ROUTER_FUSED_TOPK", "0") == 
 # Above this token count the two-kernel torch path amortizes its launch cost and the
 # one-CTA-per-token kernel stops being the right shape, so the fused path is decode-only.
 FUSED_ROUTER_TOPK_MAX_TOKENS: int = 1024
+
+# Also write the -1 CUDA-graph padding sentinel from this kernel, retiring the dispatcher's
+# separate mask launch (one per layer per step). Env-toggleable; default off.
+USE_FUSED_ROUTE_MASK: bool = os.environ.get("MCORE_FUSED_ROUTE_MASK", "0") == "1"
+
+# The int32[1] real-token count the dispatcher masks against, published here so the
+# selection kernel can apply the sentinel itself. It is a fixed-address view owned by the
+# inference context; only the value behind it changes between replays, which is what makes
+# reading it inside a captured kernel safe.
+_graph_pad_count: Optional[torch.Tensor] = None
+
+
+def publish_graph_padding(real_token_count: Optional[torch.Tensor]) -> None:
+    """Bind (or clear) the real-token-count tensor used for the fused padding sentinel."""
+    global _graph_pad_count
+    _graph_pad_count = real_token_count
+
+
+def can_fuse_route_mask() -> bool:
+    """Whether the selection kernel should emit the padding sentinel itself."""
+    return USE_FUSED_ROUTE_MASK and _graph_pad_count is not None
 
 
 if HAVE_TRITON:
@@ -67,13 +88,61 @@ if HAVE_TRITON:
             tl.store(indices_ptr + token_id * TOPK + k, best_idx)
             cur = tl.where(offs == best_idx, -float("inf"), cur)
 
+    @triton.jit
+    def _softmax_topk_mask_kernel(
+        logits_ptr,
+        probs_ptr,
+        indices_ptr,
+        real_cnt_ptr,
+        num_experts,
+        TOPK: tl.constexpr,
+        BLOCK_E: tl.constexpr,
+    ):
+        """``_softmax_topk_kernel`` that also writes the CUDA-graph padding sentinel.
 
-def fused_softmax_topk(logits: torch.Tensor, topk: int) -> Tuple[torch.Tensor, torch.Tensor]:
+        Deliberately a separate kernel rather than a constexpr branch in the original:
+        keeping the unmasked path's generated code byte-identical is worth more than the
+        duplication, because the two share no state and this one is only ever reached
+        through an explicit gate.
+
+        One CTA owns exactly one row, so deciding whether that row is padding is a scalar
+        compare against a value already in memory. Rows at or past the real count emit -1
+        in every topk slot and route to no expert.
+        """
+        token_id = tl.program_id(0)
+        offs = tl.arange(0, BLOCK_E)
+        mask = offs < num_experts
+
+        is_padding = token_id >= tl.load(real_cnt_ptr).to(tl.int32)
+
+        x = tl.load(logits_ptr + token_id * num_experts + offs, mask=mask, other=-float("inf"))
+        x = x.to(tl.float32)
+        m = tl.max(x, axis=0)
+        e = tl.exp(x - m)
+        e = tl.where(mask, e, 0.0)
+        p = e / tl.sum(e, axis=0)
+
+        cur = tl.where(mask, p, -float("inf"))
+        for k in tl.static_range(TOPK):
+            best = tl.max(cur, axis=0)
+            is_best = cur == best
+            best_idx = tl.min(tl.where(is_best, offs, num_experts), axis=0)
+            tl.store(probs_ptr + token_id * TOPK + k, best)
+            tl.store(indices_ptr + token_id * TOPK + k, tl.where(is_padding, -1, best_idx))
+            cur = tl.where(offs == best_idx, -float("inf"), cur)
+
+
+def fused_softmax_topk(
+    logits: torch.Tensor, topk: int, mask_padding: bool = False
+) -> Tuple[torch.Tensor, torch.Tensor]:
     """Pre-softmax top-k routing in a single kernel.
 
     Args:
         logits: ``[num_tokens, num_experts]``, any float dtype.
         topk: number of experts per token.
+        mask_padding: also emit the ``-1`` no-expert sentinel for CUDA-graph padding
+            rows, against the count bound by ``publish_graph_padding``. The caller is
+            then responsible for skipping the standalone mask.
 
     Returns:
         ``(probs, top_indices)`` with shapes ``[num_tokens, topk]``. ``probs``
@@ -84,6 +153,23 @@ def fused_softmax_topk(logits: torch.Tensor, topk: int) -> Tuple[torch.Tensor, t
     num_tokens, num_experts = logits.shape
     probs = torch.empty(num_tokens, topk, dtype=logits.dtype, device=logits.device)
     indices = torch.empty(num_tokens, topk, dtype=torch.int64, device=logits.device)
+    if mask_padding:
+        assert _graph_pad_count is not None, "no real-token-count tensor published"
+        _softmax_topk_mask_kernel[(num_tokens,)](
+            logits,
+            probs,
+            indices,
+            _graph_pad_count,
+            num_experts,
+            TOPK=topk,
+            BLOCK_E=triton.next_power_of_2(num_experts),
+            num_warps=1,
+        )
+        # Tells the dispatcher its own mask launch is redundant for this tensor. Set in
+        # Python, so it is the capture-time decision that gets baked into the graph.
+        indices._mcore_padding_masked = True
+        return probs, indices
+
     _softmax_topk_kernel[(num_tokens,)](
         logits,
         probs,

--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -5,6 +5,7 @@ from typing import Optional, Union
 
 import torch
 
+from megatron.core.inference.moe.router_topk import can_use_fused_softmax_topk, fused_softmax_topk
 from megatron.core.inference.utils import InferenceMode
 from megatron.core.jit import jit_fuser
 from megatron.core.transformer.custom_layers.batch_invariant_kernels import (
@@ -955,6 +956,28 @@ class InferenceTopKRouter(TopKRouter):
         precomputed_indices = None
         if self.qb_beta is not None:
             precomputed_indices = (logits - self.qb_beta).topk(self.topk, dim=1).indices
+
+        # The fused kernel selects on the logits themselves, so it cannot honor a
+        # qb_beta-shifted selection; leave those models on the reference path. Batch-
+        # invariant mode stays on the reference path too: it picks its own routing
+        # implementation below, and this kernel is not one of them. That test sits
+        # after the gate check so the gate-off path does not pay for it.
+        if (
+            self.qb_beta is None
+            and can_use_fused_softmax_topk(
+                logits,
+                self.topk,
+                use_pre_softmax=self.config.moe_router_pre_softmax,
+                num_groups=self.config.moe_router_num_groups,
+                group_topk=self.config.moe_router_group_topk,
+                scaling_factor=self.config.moe_router_topk_scaling_factor,
+                score_function=self.score_function,
+                expert_bias=self.expert_bias,
+                router_replay=self.router_replay,
+            )
+            and not is_batch_invariant_mode_enabled()
+        ):
+            return fused_softmax_topk(logits, self.topk)
 
         routing = (
             topk_routing_with_score_function

--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -5,7 +5,11 @@ from typing import Optional, Union
 
 import torch
 
-from megatron.core.inference.moe.router_topk import can_use_fused_softmax_topk, fused_softmax_topk
+from megatron.core.inference.moe.router_topk import (
+    can_fuse_route_mask,
+    can_use_fused_softmax_topk,
+    fused_softmax_topk,
+)
 from megatron.core.inference.utils import InferenceMode
 from megatron.core.jit import jit_fuser
 from megatron.core.transformer.custom_layers.batch_invariant_kernels import (
@@ -977,7 +981,7 @@ class InferenceTopKRouter(TopKRouter):
             )
             and not is_batch_invariant_mode_enabled()
         ):
-            return fused_softmax_topk(logits, self.topk)
+            return fused_softmax_topk(logits, self.topk, mask_padding=can_fuse_route_mask())
 
         routing = (
             topk_routing_with_score_function

--- a/megatron/core/transformer/moe/token_dispatcher_inference.py
+++ b/megatron/core/transformer/moe/token_dispatcher_inference.py
@@ -33,6 +33,7 @@ from megatron.core.inference.communication.torch_symm_triton import (
     multimem_reduce_scatter_v,
 )
 from megatron.core.inference.moe import InferenceGroupedGemmBackend, batch_invariant
+from megatron.core.inference.moe import router_topk as _fused_topk
 from megatron.core.inference.moe.metadata import fused_metadata_update
 from megatron.core.inference.symmetric_memory import SymmetricMemoryManager
 from megatron.core.process_groups_config import ProcessGroupCollection
@@ -503,6 +504,11 @@ class NVLSAllGatherVDispatcher(InferenceAllGatherDispatcherBase):
         # the routing map along. Base class self.tp_rank is the expt_tp rank,
         # which is not what we want for the SP padding offset.
         self.sp_rank = get_pg_rank(pg_collection.tp)
+        # Unsharded rows let the router fold the padding sentinel into its selection
+        # kernel: local and global row indices coincide, so no row offset is needed.
+        # Requiring group size 1 rather than rank 0 keeps every rank on the same
+        # branch, which matters because the NVLS path barriers across ranks.
+        self._rows_unsharded = get_pg_size(pg_collection.tp) == 1
         # Set in dispatch_preprocess; consumed by token_dispatch and token_combine.
         self._local_tokens: int = 0
         # When shared_expert_overlap is enabled, the shared expert forward is launched
@@ -568,7 +574,17 @@ class NVLSAllGatherVDispatcher(InferenceAllGatherDispatcherBase):
         # shift local rows into the global frame for the comparison. When unset
         # (standalone dispatcher use without a context) all rows are real, so
         # skip the mask.
-        if self.__class__._real_token_count_tensor is not None:
+        #
+        # Publishing the count lets the router's selection kernel emit the sentinel
+        # itself and retires this launch. The skip below keys off the tag the router
+        # leaves on the tensor it actually masked, so it is evidence that the fused
+        # path ran rather than a second copy of the gate.
+        if self.__class__._real_token_count_tensor is not None and self._rows_unsharded:
+            _fused_topk.publish_graph_padding(self.__class__._real_token_count_tensor)
+
+        if self.__class__._real_token_count_tensor is not None and not getattr(
+            self.routing_map, "_mcore_padding_masked", False
+        ):
             mask_routing_padding(
                 self.routing_map, self.__class__._real_token_count_tensor, self.sp_rank
             )


### PR DESCRIPTION
> Stacked on #6456. Review that one first; this diff is only the CUDA-graph padding sentinel
>
> GitHub cannot base a pull request from a fork on another unmerged fork branch, so the diff below also contains the parent's commits. This PR's own change is the final commit, `dcffe578d`; review that one. The rest lands with the parent.
> moved into the router's selection kernel so the dispatcher's separate masking launch can be
> dropped.

## Summary

Under CUDA-graph capture the local token count is padded up to the captured graph size, and the
NVLS dispatcher fixes that up with `mask_routing_padding`, a Triton launch that writes `-1` into
every top-k slot of the padding rows so those tokens route to no expert — one launch per MoE layer
per decode step, 48 per step, over a `[256, 8]` int64 tensor of about 16 KiB. The router's
selection kernel already owns exactly one row per CTA and already stores that row's expert ids, so
the sentinel is a scalar compare and a select with no launch of its own: **+1.47%**
end-to-end decode throughput for 48 launches per step removed and no arithmetic added.

The thing worth knowing up front is that this is a launch-count change and nothing else. The
compare and the select still happen; they just stop costing a kernel launch, a graph node, and a
dispatch gap to happen in.

## Why here

The masking pass is the cheapest member of the routing chain and almost pure launch overhead: 48
launches per step to write at most a few hundred int64 values. To find out whether that overhead
was actually on the critical path before writing a fused version, the launch was ablated outright
under a temporary flag that is not part of this diff — correctness-breaking by construction and
valid only as a ceiling, since dropping the mask lets padding rows route to real experts. The
ablation moved throughput on a control-to-control spread of
1.5 tok/s between the two replicate baselines, the tightest replicate pair measured anywhere in
this campaign, so the effect was clearly above the noise. That ablation is also a lower bound on
what a fusion can win, because letting padding rows route to real experts if anything *adds*
expert-GEMM work, so the fused version should land just under it. The ceiling number itself and
this PR's measured delta both belong in the Measurement block rather than here.

## What changed

**Before.** The router produces the routing map, and then the dispatcher's `token_dispatch`
unconditionally calls `mask_routing_padding(self.routing_map, real_token_count_tensor,
self.sp_rank)` before the AllGather-V, so the gathered buffer carries `-1` in the padding slots.
That kernel reads the real token count from a fixed-address `int32[1]` GPU tensor, which is what
makes it safe inside a captured graph: only the value behind the pointer changes between replays.

**After.** A second Triton entry point, `_softmax_topk_mask_kernel`, does the same selection as the
parent PR's kernel plus one extra step: it loads the same `int32[1]` count, computes
`is_padding = token_id >= real_count` once per CTA, and stores `tl.where(is_padding, -1, best_idx)`
instead of `best_idx`. One CTA owns exactly one row, so this is a scalar compare against a value
already resident in memory, and the padding decision costs one predicated select per top-k slot.
The dispatcher then skips its own launch.

Two implementation choices are deliberate and both are about safety rather than speed.

The masked variant is a separate `@triton.jit` function rather than a `constexpr` branch inside the
shared kernel, and the diff does not touch `_softmax_topk_kernel` at all. An earlier version of this
change did put the sentinel behind a compile-time branch in the shared kernel, and that version hung
during warmup *with the gate off* — the fault was in generated code for the always-on path, not in
the masking logic. Duplicating the kernel eliminates that class of failure by construction instead of
testing for it: with the gate off, the code the unmasked path compiles and runs is provably
unchanged. The duplication is the price and it is worth paying.

The dispatcher's skip keys off a tag the router leaves on the tensor it masked
(`indices._mcore_padding_masked = True`), not off a second reading of the gate. That makes the skip
conditional on evidence that the fused kernel actually ran, so the two decisions cannot disagree. The
tag is set in Python, so under CUDA-graph capture it is a capture-time decision baked into the graph;
on replay neither branch is re-evaluated. If anything between the router and the dispatcher were ever
to replace that tensor, the attribute would be lost and the standalone mask would simply run again —
redundant work, never a correctness hole.

## Measurement

Fixed protocol: Qwen3-30B-A3B, BF16, TP 1 / PP 1 / EP 4 / ETP 1, 256 gsm8k requests, 1024 output tokens, 2 warmup + 5 timed iterations, a single OCI 4xGB200 node (nvl72160-T04), async dynamic-batching scheduler pinned on. All 20 arms ran back to back in one allocation on that one node; node-to-node variance on this workload is around 2.7%, so cross-node numbers would not be comparable.

- With this change (every other gate in the stack enabled): **31,602 tok/s**
- Without it (same node, same session, only this gate turned off): **31,145 tok/s**
- Leave-one-out delta: **+1.47%**
- Noise floor: sigma = **0.42%** over 3 repeats of the all-gates-on reference
- Verdict: **resolved** by margin (3.5 sigma). The per-iteration distributions do not separate strictly, but only because each reference arm contains one low outlier iteration; excluding those the arms do not overlap.

This is the **marginal contribution measured with every other gate in this stack enabled** — the question a reviewer is actually asking, which is whether this should land, not what it was worth when it was first written.

The reference is drift-corrected. The all-gates-on configuration was re-measured three times across the session (31,745, 31,530, 31,503 tok/s), a +0.77% drift from first to last, so each arm is compared against the reference interpolated to its own position in the run order rather than against a session mean.

For context, the whole stack is worth **+35.80%** on this node (23,265 tok/s with every gate off, 31,593 with every gate on). Per-slice deltas do not sum to that; they compose sub-additively.

## Evidence

The guard chain a reviewer should walk, because the win is entirely a launch that is or is not
there, and a gate that silently declines looks exactly like a change that does not help. This
campaign has shipped an inert fusion before, which is why this section exists:

1. **Gate.** `MCORE_FUSED_ROUTE_MASK=1` sets `USE_FUSED_ROUTE_MASK` in
   `megatron/core/inference/moe/router_topk.py` at import time.
2. **Publisher.** `NVLSAllGatherVDispatcher.token_dispatch` calls
   `router_topk.publish_graph_padding(self.__class__._real_token_count_tensor)`, which binds the
   module-level `_graph_pad_count`. It fires only when the inference context has wired that tensor
   and when `self._rows_unsharded` is true.
3. **Predicate.** `can_fuse_route_mask()` returns `USE_FUSED_ROUTE_MASK and _graph_pad_count is not
   None`, so both the gate and the binding are required.
4. **Call site.** `InferenceTopKRouter._forward` calls `fused_softmax_topk(logits, self.topk,
   mask_padding=can_fuse_route_mask())`, reached only when the parent PR's predicate
   `can_use_fused_softmax_topk(...)` is already true.
5. **Kernel and skip.** `fused_softmax_topk` launches `_softmax_topk_mask_kernel`, which emits the
   sentinel, and tags the returned indices tensor; the dispatcher's `mask_routing_padding` call is
   then skipped for that tensor only.

The consequence to check when reviewing is that **this gate does nothing on its own.** It requires
`MCORE_ROUTER_FUSED_TOPK=1` as well, because link 4 is inside the parent's fused branch. Break any
link and `can_fuse_route_mask()` is permanently `False`, the standalone launch stays, and the flag
measures as no effect.

Liveness is observable two ways. The `mask_routing_padding` launch disappears from the step only if
the tag was set, and the tag is set only if the masked kernel was launched, so the absence of that
launch is itself the evidence: 48 fewer launches per step, `_softmax_topk_mask_kernel` in place of
`_softmax_topk_kernel`. And the sentinel is directly checked by the equivalence sweep below, which
fails loudly if the `-1` rows are not written.

## Correctness

- **Numerics:** unchanged for real rows. The probabilities and the selected expert ids come out of the
  same arithmetic as the parent PR's kernel; the only difference is the stored index for rows at or
  past the real token count. Against the reference path (parent kernel followed by the standalone
  mask) the indices are bit-exact and the probability delta is `0.000e+00`.
- **Tests:** the equivalence sweep runs at real token counts 256, 200, 137, 1 and 0 against a padded
  buffer, covering the fully-real case, ordinary partial batches, and both degenerate ends; padding
  rows come out all `-1` in every case. A full server run is part of acceptance rather than optional,
  and deliberately so: the failure mode of a mis-evaluated sentinel is that *every* row is marked
  padding, in which case no token routes anywhere and the cross-rank barrier inside the NVLS
  AllGather-V can hang on rank-divergent counts. A shape harness alone would not catch that; the full
  run does, and it completes.
- **Coherence:** the greedy-decode probes stay correct with the gate on. Since real rows are
  bit-exact against the reference masking pass, coherence here is a smoke test rather than the
  argument.
- **MTP is inherited, not special-cased.** The controller overrides the routing-mask boundary for an
  MTP forward by writing into the same `int32[1]` tensor; the fused kernel reads that same tensor, so
  it follows the override with no additional code.

## Gating and blast radius

- Gate: `MCORE_FUSED_ROUTE_MASK`, read once at import as `os.environ.get(..., "0") == "1"`, so
  **default OFF**. Unset, `can_fuse_route_mask()` returns `False`, `fused_softmax_topk` takes its
  original branch, no tag is set, and the dispatcher masks exactly as before. The unmasked kernel's
  source is untouched by this diff, so its generated code is identical too.
- Preconditions: the inference context must have wired the real-token-count tensor (so this is the
  dynamic inference path only, never training and never a standalone dispatcher without a context);
  expert parallelism must be greater than one, since the publisher sits after `token_dispatch`'s
  `ep_size == 1` early return; the routing map must not be sequence-parallel sharded, enforced as
  `get_pg_size(pg_collection.tp) == 1`; and the parent PR's routing-contract guard must already
  accept the shapes.
- The sharding precondition is the load-bearing one. `mask_routing_padding` shifts local rows into
  the global frame with `rows + sp_rank * total_rows` before comparing against the count, while the
  fused kernel compares a bare `token_id` and has no rank offset. Requiring group size 1 rather than
  rank 0 also keeps every rank on the same branch, which matters because this path barriers across
  ranks.
- When any precondition fails, the standalone mask runs and the result is byte-identical to the
  parent PR. Nothing raises on the hot path; the only assertion is a defensive one inside
  `fused_softmax_topk` that the count tensor was published before `mask_padding=True` is passed.

## Reproduce

```bash
MCORE_ROUTER_FUSED_TOPK=1 MCORE_FUSED_ROUTE_MASK=1 \
QWEN30B_TP=1 QWEN30B_EP=4 QWEN30B_ETP=1 \
BENCH_SIZES_OVERRIDE=256 BENCH_OUTPUT_TOKENS=1024 \
NUM_WARMUP_ITERS=2 NUM_TIMED_ITERS=5 \
bash skills/run-qwen-model/run_qwen_inference.sh qwen3-30b-a3b --checkpoint "$QWEN30B_CKPT"
```

Both gates are required; with only `MCORE_FUSED_ROUTE_MASK` set the change cannot fire. Run any
standalone equivalence check with the run venv's interpreter and `PYTHONPATH` pointing at the repo —
the container's system python cannot import megatron, and a failed import reads as an inert gate.

## What this does not claim

- **Nothing at TP > 1.** With the routing map sequence-parallel sharded, the fused kernel cannot form
  the global row index, the precondition rejects, and the standalone launch stays. The same is true
  with expert parallelism of one, where there is no masking launch to remove in the first place.
- **The effect is small enough to be inverted by a single bad run.** During development, two
  back-to-back A/B pairs disagreed in sign, and the effect only resolved over six alternating pairs
  (paired *t* ≈ 5.0). The cause was not a broadly noisy node — the gate-off arm was reproducible to
  about 0.2% across eight runs — but an occasional anomalously slow server start, roughly one in
  sixteen, which is enough to flip the sign of an effect this size. Do not read a single-pair A/B of
  this gate as evidence either way.
- **The very first MoE layer executed in a process still pays the standalone mask.** The count is
  published from the dispatcher, which runs after that layer's router has already selected, so the
  binding is not yet in place the first time through. The binding then persists for the life of the
  process, so every subsequent layer — including all layers of a graph captured after at least one
  uncaptured forward — takes the fused path.
- No claim is made about prefill. The masking pass exists because of CUDA-graph padding on the decode
  path; the parent PR's token cap and the context wiring both keep this out of large prefill chunks.
- Deltas in this stack do not add. This change removes one launch from the same per-layer serial
  chain that the parent PR and the other routing fusions shorten, so it overlaps with them by
  construction and the combination has to be measured rather than summed.

## Follow-ups

- Supporting TP > 1 needs only the sequence-parallel row offset passed into the kernel, matching what
  `mask_routing_padding` already does with `rows + sp_rank * total_rows`. It was left out because the
  configuration being optimized runs TP 1 and every added argument to a captured kernel is a new way
  for the gate-off path to change.
- The duplicated kernel body is a maintenance cost that should be paid down once this gate is
  default-on and the unmasked variant can be retired rather than preserved.

---

## This stack

This is one slice of [#6064](https://github.com/NVIDIA/Megatron-LM/pull/6064), a Qwen3-30B-A3B decode optimization campaign, split into 16 independently reviewable changes. Together they are **+35.80%** end-to-end throughput over the same base commit (23,265 -> 31,593 tok/s, mean of three full runs).

- **MoE grouped-GEMM and dispatch:** #6452 -> #6453 -> #6454 -> #6455
- **MoE router and combine:** #6456 -> #6457 -> #6458
- **Attention: QK norm and decode kernel:** #6459 -> #6460 -> #6461 -> #6462
- **Residual + RMSNorm fusion:** #6463 -> #6464
- **Host path: context bookkeeping:** #6465 -> #6466
- **Host path: independent:** #6467

Each chain is independent of the others and bases on `main`. Within a chain, later PRs depend on earlier ones.

### Per-slice measured delta

Every number is a leave-one-out delta from one same-node, same-session campaign: the full stack with exactly this change's gate off, against the interpolated full-stack reference at that point in the run. It is the change's *marginal* contribution with everything else already in, not its standalone value. Run-to-run sigma was **0.42%** across three full-stack repeats.

| PR | Change | Delta | |
|---|---|---|---|
| #6452 | FC1 SwiGLU epilogue | +14.81% | resolved |
| #6453 | indirection table fusion | +7.21% | resolved |
| #6454 | decode GEMM tile configs | +6.77% | resolved |
| #6455 | predicated top-k gather | +1.99% | by margin |
| #6456 | fused router softmax+top-k | +4.75% | resolved |
| #6457 | fused route padding mask | +1.47% | by margin |
| #6458 | bf16 MoE combine | +2.42% | by margin |
| #6459 | fused QK RMSNorm | +5.17% | resolved |
| #6460 | grouped QK norm input | +1.18% | by margin |
| #6461 | pin FlashAttention 2 | -0.35% | noise floor |
| #6462 | FlashInfer TRT-LLM decode | +1.46% | by margin |
| #6463 | fused add+norm pre-MLP | +3.54% | by margin |
| #6464 | fused add+norm pre-QKV | +0.98% | by margin |
| #6465 | incremental attention state | -0.42% | noise floor |
| #6466 | vectorized decode bookkeeping | -0.07% | noise floor |
| #6467 | post_process_requests fast path | +0.09% | noise floor |

`noise floor` means the delta is inside 2 sigma (0.84%) and this campaign cannot distinguish it from zero. `resolved` means the leave-one-out and full-stack iteration distributions did not overlap. Deltas do not sum to the stack total: these changes shorten the same decode step and compose sub-additively.

**Fixed protocol for every number above.** Qwen3-30B-A3B, BF16, TP1/PP1/EP4/ETP1, 256 gsm8k requests at batch size 256, output length 1024, CUDA graphs on, one OCI GB200 NVL72 node, 4 GPUs. All 20 arms ran back-to-back in a single Slurm allocation on one node, so node assignment and thermal state are held constant.
