### PR TITLE
perf(inference): reduce the MoE combine in bf16 instead of fp32

### DIFF
--- a/megatron/core/inference/moe/router_topk.py
+++ b/megatron/core/inference/moe/router_topk.py
@@ -1,0 +1,130 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Fused softmax + top-k router selection for decode-shaped MoE inference.
+
+The eager path runs ``torch.softmax`` over the expert dimension and then
+``torch.topk``. At decode shapes (``[num_tokens, 128]`` fp32) both kernels are
+launch/latency dominated and ``topk`` in particular runs a multi-pass radix
+select. One CTA per token can do the whole thing out of registers.
+"""
+
+import os
+from typing import Tuple
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+
+    HAVE_TRITON = True
+except ImportError:
+    HAVE_TRITON = False
+
+# Fuse the router softmax and top-k into one Triton kernel. Env-toggleable; default off.
+USE_FUSED_ROUTER_TOPK: bool = os.environ.get("MCORE_ROUTER_FUSED_TOPK", "0") == "1"
+
+# Above this token count the two-kernel torch path amortizes its launch cost and the
+# one-CTA-per-token kernel stops being the right shape, so the fused path is decode-only.
+FUSED_ROUTER_TOPK_MAX_TOKENS: int = 1024
+
+
+if HAVE_TRITON:
+
+    @triton.jit
+    def _softmax_topk_kernel(
+        logits_ptr,
+        probs_ptr,
+        indices_ptr,
+        num_experts,
+        TOPK: tl.constexpr,
+        BLOCK_E: tl.constexpr,
+    ):
+        """One CTA per token: softmax over experts, then TOPK selection passes.
+
+        Selection is max-then-mask, which yields the top-k in descending score
+        order with ties broken toward the lower expert id. ``torch.topk`` is
+        called with ``sorted=False`` during inference, so its own order is
+        unspecified and any consistent order is an equally valid answer.
+        """
+        token_id = tl.program_id(0)
+        offs = tl.arange(0, BLOCK_E)
+        mask = offs < num_experts
+
+        x = tl.load(logits_ptr + token_id * num_experts + offs, mask=mask, other=-float("inf"))
+        x = x.to(tl.float32)
+        m = tl.max(x, axis=0)
+        e = tl.exp(x - m)
+        e = tl.where(mask, e, 0.0)
+        p = e / tl.sum(e, axis=0)
+
+        cur = tl.where(mask, p, -float("inf"))
+        for k in tl.static_range(TOPK):
+            best = tl.max(cur, axis=0)
+            is_best = cur == best
+            best_idx = tl.min(tl.where(is_best, offs, num_experts), axis=0)
+            tl.store(probs_ptr + token_id * TOPK + k, best)
+            tl.store(indices_ptr + token_id * TOPK + k, best_idx)
+            cur = tl.where(offs == best_idx, -float("inf"), cur)
+
+
+def fused_softmax_topk(logits: torch.Tensor, topk: int) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Pre-softmax top-k routing in a single kernel.
+
+    Args:
+        logits: ``[num_tokens, num_experts]``, any float dtype.
+        topk: number of experts per token.
+
+    Returns:
+        ``(probs, top_indices)`` with shapes ``[num_tokens, topk]``. ``probs``
+        matches the dtype of ``logits`` (the softmax itself is fp32, as in the
+        eager path); ``top_indices`` is int64 to match ``torch.topk``.
+    """
+    assert logits.dim() == 2, f"Expected 2D logits, got {logits.dim()}D"
+    num_tokens, num_experts = logits.shape
+    probs = torch.empty(num_tokens, topk, dtype=logits.dtype, device=logits.device)
+    indices = torch.empty(num_tokens, topk, dtype=torch.int64, device=logits.device)
+    _softmax_topk_kernel[(num_tokens,)](
+        logits,
+        probs,
+        indices,
+        num_experts,
+        TOPK=topk,
+        BLOCK_E=triton.next_power_of_2(num_experts),
+        num_warps=1,
+    )
+    return probs, indices
+
+
+def can_use_fused_softmax_topk(
+    logits: torch.Tensor,
+    topk: int,
+    use_pre_softmax: bool,
+    num_groups,
+    group_topk,
+    scaling_factor,
+    score_function: str,
+    expert_bias,
+    router_replay,
+) -> bool:
+    """Whether the fused kernel reproduces this exact routing contract."""
+    return (
+        HAVE_TRITON
+        and USE_FUSED_ROUTER_TOPK
+        and logits.dim() == 2
+        and logits.is_cuda
+        and logits.shape[0] <= FUSED_ROUTER_TOPK_MAX_TOKENS
+        and score_function == "softmax"
+        and use_pre_softmax
+        and num_groups is None
+        and group_topk is None
+        and not scaling_factor
+        and expert_bias is None
+        and router_replay is None
+        # topk == 1 is excluded because the reference path ends in
+        # `top_indices.squeeze(1)`, which drops the k dimension only at k == 1.
+        # This kernel always returns [num_tokens, topk], so honoring k == 1 here
+        # would hand the dispatcher a differently-ranked tensor than the path it
+        # replaces.
+        and 1 < topk <= logits.shape[1]
+    )

--- a/megatron/core/inference/moe/router_topk.py
+++ b/megatron/core/inference/moe/router_topk.py
@@ -9,7 +9,7 @@ select. One CTA per token can do the whole thing out of registers.
 """
 
 import os
-from typing import Tuple
+from typing import Optional, Tuple
 
 import torch
 
@@ -27,6 +27,27 @@ USE_FUSED_ROUTER_TOPK: bool = os.environ.get("MCORE_ROUTER_FUSED_TOPK", "0") == 
 # Above this token count the two-kernel torch path amortizes its launch cost and the
 # one-CTA-per-token kernel stops being the right shape, so the fused path is decode-only.
 FUSED_ROUTER_TOPK_MAX_TOKENS: int = 1024
+
+# Also write the -1 CUDA-graph padding sentinel from this kernel, retiring the dispatcher's
+# separate mask launch (one per layer per step). Env-toggleable; default off.
+USE_FUSED_ROUTE_MASK: bool = os.environ.get("MCORE_FUSED_ROUTE_MASK", "0") == "1"
+
+# The int32[1] real-token count the dispatcher masks against, published here so the
+# selection kernel can apply the sentinel itself. It is a fixed-address view owned by the
+# inference context; only the value behind it changes between replays, which is what makes
+# reading it inside a captured kernel safe.
+_graph_pad_count: Optional[torch.Tensor] = None
+
+
+def publish_graph_padding(real_token_count: Optional[torch.Tensor]) -> None:
+    """Bind (or clear) the real-token-count tensor used for the fused padding sentinel."""
+    global _graph_pad_count
+    _graph_pad_count = real_token_count
+
+
+def can_fuse_route_mask() -> bool:
+    """Whether the selection kernel should emit the padding sentinel itself."""
+    return USE_FUSED_ROUTE_MASK and _graph_pad_count is not None
 
 
 if HAVE_TRITON:
@@ -67,13 +88,61 @@ if HAVE_TRITON:
             tl.store(indices_ptr + token_id * TOPK + k, best_idx)
             cur = tl.where(offs == best_idx, -float("inf"), cur)
 
+    @triton.jit
+    def _softmax_topk_mask_kernel(
+        logits_ptr,
+        probs_ptr,
+        indices_ptr,
+        real_cnt_ptr,
+        num_experts,
+        TOPK: tl.constexpr,
+        BLOCK_E: tl.constexpr,
+    ):
+        """``_softmax_topk_kernel`` that also writes the CUDA-graph padding sentinel.
 
-def fused_softmax_topk(logits: torch.Tensor, topk: int) -> Tuple[torch.Tensor, torch.Tensor]:
+        Deliberately a separate kernel rather than a constexpr branch in the original:
+        keeping the unmasked path's generated code byte-identical is worth more than the
+        duplication, because the two share no state and this one is only ever reached
+        through an explicit gate.
+
+        One CTA owns exactly one row, so deciding whether that row is padding is a scalar
+        compare against a value already in memory. Rows at or past the real count emit -1
+        in every topk slot and route to no expert.
+        """
+        token_id = tl.program_id(0)
+        offs = tl.arange(0, BLOCK_E)
+        mask = offs < num_experts
+
+        is_padding = token_id >= tl.load(real_cnt_ptr).to(tl.int32)
+
+        x = tl.load(logits_ptr + token_id * num_experts + offs, mask=mask, other=-float("inf"))
+        x = x.to(tl.float32)
+        m = tl.max(x, axis=0)
+        e = tl.exp(x - m)
+        e = tl.where(mask, e, 0.0)
+        p = e / tl.sum(e, axis=0)
+
+        cur = tl.where(mask, p, -float("inf"))
+        for k in tl.static_range(TOPK):
+            best = tl.max(cur, axis=0)
+            is_best = cur == best
+            best_idx = tl.min(tl.where(is_best, offs, num_experts), axis=0)
+            tl.store(probs_ptr + token_id * TOPK + k, best)
+            tl.store(indices_ptr + token_id * TOPK + k, tl.where(is_padding, -1, best_idx))
+            cur = tl.where(offs == best_idx, -float("inf"), cur)
+
+
+def fused_softmax_topk(
+    logits: torch.Tensor, topk: int, mask_padding: bool = False
+) -> Tuple[torch.Tensor, torch.Tensor]:
     """Pre-softmax top-k routing in a single kernel.
 
     Args:
         logits: ``[num_tokens, num_experts]``, any float dtype.
         topk: number of experts per token.
+        mask_padding: also emit the ``-1`` no-expert sentinel for CUDA-graph padding
+            rows, against the count bound by ``publish_graph_padding``. The caller is
+            then responsible for skipping the standalone mask.
 
     Returns:
         ``(probs, top_indices)`` with shapes ``[num_tokens, topk]``. ``probs``
@@ -84,6 +153,23 @@ def fused_softmax_topk(logits: torch.Tensor, topk: int) -> Tuple[torch.Tensor, t
     num_tokens, num_experts = logits.shape
     probs = torch.empty(num_tokens, topk, dtype=logits.dtype, device=logits.device)
     indices = torch.empty(num_tokens, topk, dtype=torch.int64, device=logits.device)
+    if mask_padding:
+        assert _graph_pad_count is not None, "no real-token-count tensor published"
+        _softmax_topk_mask_kernel[(num_tokens,)](
+            logits,
+            probs,
+            indices,
+            _graph_pad_count,
+            num_experts,
+            TOPK=topk,
+            BLOCK_E=triton.next_power_of_2(num_experts),
+            num_warps=1,
+        )
+        # Tells the dispatcher its own mask launch is redundant for this tensor. Set in
+        # Python, so it is the capture-time decision that gets baked into the graph.
+        indices._mcore_padding_masked = True
+        return probs, indices
+
     _softmax_topk_kernel[(num_tokens,)](
         logits,
         probs,

--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -5,6 +5,7 @@ from typing import Optional, Union
 
 import torch
 
+from megatron.core.inference.moe.router_topk import can_use_fused_softmax_topk, fused_softmax_topk
 from megatron.core.inference.utils import InferenceMode
 from megatron.core.jit import jit_fuser
 from megatron.core.transformer.custom_layers.batch_invariant_kernels import (
@@ -955,6 +956,28 @@ class InferenceTopKRouter(TopKRouter):
         precomputed_indices = None
         if self.qb_beta is not None:
             precomputed_indices = (logits - self.qb_beta).topk(self.topk, dim=1).indices
+
+        # The fused kernel selects on the logits themselves, so it cannot honor a
+        # qb_beta-shifted selection; leave those models on the reference path. Batch-
+        # invariant mode stays on the reference path too: it picks its own routing
+        # implementation below, and this kernel is not one of them. That test sits
+        # after the gate check so the gate-off path does not pay for it.
+        if (
+            self.qb_beta is None
+            and can_use_fused_softmax_topk(
+                logits,
+                self.topk,
+                use_pre_softmax=self.config.moe_router_pre_softmax,
+                num_groups=self.config.moe_router_num_groups,
+                group_topk=self.config.moe_router_group_topk,
+                scaling_factor=self.config.moe_router_topk_scaling_factor,
+                score_function=self.score_function,
+                expert_bias=self.expert_bias,
+                router_replay=self.router_replay,
+            )
+            and not is_batch_invariant_mode_enabled()
+        ):
+            return fused_softmax_topk(logits, self.topk)
 
         routing = (
             topk_routing_with_score_function

--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -5,7 +5,11 @@ from typing import Optional, Union
 
 import torch
 
-from megatron.core.inference.moe.router_topk import can_use_fused_softmax_topk, fused_softmax_topk
+from megatron.core.inference.moe.router_topk import (
+    can_fuse_route_mask,
+    can_use_fused_softmax_topk,
+    fused_softmax_topk,
+)
 from megatron.core.inference.utils import InferenceMode
 from megatron.core.jit import jit_fuser
 from megatron.core.transformer.custom_layers.batch_invariant_kernels import (
@@ -977,7 +981,7 @@ class InferenceTopKRouter(TopKRouter):
             )
             and not is_batch_invariant_mode_enabled()
         ):
-            return fused_softmax_topk(logits, self.topk)
+            return fused_softmax_topk(logits, self.topk, mask_padding=can_fuse_route_mask())
 
         routing = (
             topk_routing_with_score_function

--- a/megatron/core/transformer/moe/token_dispatcher_inference.py
+++ b/megatron/core/transformer/moe/token_dispatcher_inference.py
@@ -33,6 +33,7 @@ from megatron.core.inference.communication.torch_symm_triton import (
     multimem_reduce_scatter_v,
 )
 from megatron.core.inference.moe import InferenceGroupedGemmBackend, batch_invariant
+from megatron.core.inference.moe import router_topk as _fused_topk
 from megatron.core.inference.moe.metadata import fused_metadata_update
 from megatron.core.inference.symmetric_memory import SymmetricMemoryManager
 from megatron.core.process_groups_config import ProcessGroupCollection
@@ -503,6 +504,11 @@ class NVLSAllGatherVDispatcher(InferenceAllGatherDispatcherBase):
         # the routing map along. Base class self.tp_rank is the expt_tp rank,
         # which is not what we want for the SP padding offset.
         self.sp_rank = get_pg_rank(pg_collection.tp)
+        # Unsharded rows let the router fold the padding sentinel into its selection
+        # kernel: local and global row indices coincide, so no row offset is needed.
+        # Requiring group size 1 rather than rank 0 keeps every rank on the same
+        # branch, which matters because the NVLS path barriers across ranks.
+        self._rows_unsharded = get_pg_size(pg_collection.tp) == 1
         # Set in dispatch_preprocess; consumed by token_dispatch and token_combine.
         self._local_tokens: int = 0
         # When shared_expert_overlap is enabled, the shared expert forward is launched
@@ -568,7 +574,17 @@ class NVLSAllGatherVDispatcher(InferenceAllGatherDispatcherBase):
         # shift local rows into the global frame for the comparison. When unset
         # (standalone dispatcher use without a context) all rows are real, so
         # skip the mask.
-        if self.__class__._real_token_count_tensor is not None:
+        #
+        # Publishing the count lets the router's selection kernel emit the sentinel
+        # itself and retires this launch. The skip below keys off the tag the router
+        # leaves on the tensor it actually masked, so it is evidence that the fused
+        # path ran rather than a second copy of the gate.
+        if self.__class__._real_token_count_tensor is not None and self._rows_unsharded:
+            _fused_topk.publish_graph_padding(self.__class__._real_token_count_tensor)
+
+        if self.__class__._real_token_count_tensor is not None and not getattr(
+            self.routing_map, "_mcore_padding_masked", False
+        ):
             mask_routing_padding(
                 self.routing_map, self.__class__._real_token_count_tensor, self.sp_rank
             )

--- a/megatron/core/transformer/moe/token_dispatcher_inference.py
+++ b/megatron/core/transformer/moe/token_dispatcher_inference.py
@@ -22,6 +22,7 @@ per-step metadata kernel is captured inside the CUDA graph.
 """
 
 import operator
+import os
 from functools import reduce
 from typing import List, Optional
 
@@ -47,6 +48,10 @@ from megatron.core.transformer.moe.token_dispatcher import MoEAllGatherTokenDisp
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.typed_torch import apply_module
 from megatron.core.utils import get_pg_rank, get_pg_size
+
+# Reduce the MoE combine in bf16 instead of fp32. Off by default because it changes
+# numerics; see the buffer allocation for why it is worth measuring.
+_NVLS_RS_BF16: bool = os.environ.get("MCORE_NVLS_RS_BF16", "0") == "1"
 
 
 class InferenceAllGatherDispatcherBase(MoEAllGatherTokenDispatcher):
@@ -322,7 +327,8 @@ class NVLSAllGatherVDispatcher(InferenceAllGatherDispatcherBase):
     _real_token_count_tensor: Optional[torch.Tensor] = None
 
     # ── Class-level symmetric buffer handles (allocated once at model init) ───────
-    # Dtypes: hidden=bf16, routing=int64, probs=fp32, rsv=fp32.
+    # Dtypes: hidden=bf16, routing=int64, probs=fp32, rsv=fp32 (bf16 when
+    # MCORE_NVLS_RS_BF16 is set).
     _symm_agv_hidden: Optional[dict] = None  # {"tensor": ..., "handle": ...}
     _symm_agv_routing: Optional[dict] = None
     _symm_agv_probs: Optional[dict] = None
@@ -431,9 +437,24 @@ class NVLSAllGatherVDispatcher(InferenceAllGatherDispatcherBase):
             "ep_agv_p", process_group=ep_group, size_mb=_size_mb(agv_p_shape, torch.float32)
         ).maybe_get_tensor(agv_p_shape, dtype=torch.float32)
 
+        # The combine reduce-scatter buffer. fp32 makes the cross-rank sum exact but
+        # costs twice the NVLink bytes on the largest collective in the step, and it
+        # forces a per-layer cast on the way out because everything downstream is
+        # bf16. vLLM reduces in bf16 (`ncclDevKernel_ReduceScatter_Sum_bf16`), and the
+        # multimem kernel already accepts either, so bf16 is a supported point on the
+        # same curve: the top-k sum still accumulates in fp32 registers inside
+        # `_moe_sum`, only the store and the 4-way cross-rank add become bf16.
+        rsv_dtype = torch.float32
+        if _NVLS_RS_BF16:
+            assert not batch_invariant.enabled(), (
+                "MCORE_NVLS_RS_BF16 cannot be combined with batch-invariant mode: "
+                "ordered_reduce_scatter_v reduces ranks with an explicit fp32 loop and "
+                "requires an fp32 buffer."
+            )
+            rsv_dtype = torch.bfloat16
         cls._symm_rsv = SymmetricMemoryManager.get_buffer(
-            "ep_rsv", process_group=ep_group, size_mb=_size_mb(rsv_shape, torch.float32)
-        ).maybe_get_tensor(rsv_shape, dtype=torch.float32)
+            "ep_rsv", process_group=ep_group, size_mb=_size_mb(rsv_shape, rsv_dtype)
+        ).maybe_get_tensor(rsv_shape, dtype=rsv_dtype)
 
         # Small scratch buffer for fused metadata allgather (WORLD_SIZE int32s).
         cls._symm_metadata = SymmetricMemoryManager.get_buffer(


### PR DESCRIPTION
> Stacked on #6457. Review that one first; this diff is only the dtype of the MoE combine's
>
> GitHub cannot base a pull request from a fork on another unmerged fork branch, so the diff below also contains the parent's commits. This PR's own change is the final commit, `5a012ad4f`; review that one. The rest lands with the parent.
> symmetric reduce-scatter buffer, changed from fp32 to bf16 behind a gate.

The stacking is bookkeeping, not a dependency. This change and #6457 both touch
`token_dispatcher_inference.py`, in disjoint regions — this one is in `allocate_buffers`, that one
is in `__init__` and `token_dispatch` — and nothing here has anything to do with routing. If this
needs to land first it can be cherry-picked onto main and the routing chain rebased; do not read the
base as evidence that one depends on the other.

## Summary

The MoE combine's symmetric reduce-scatter buffer is allocated fp32, which decides three things at
once: `_moe_sum` stores its fp32 accumulator into it, the multimem reduce-scatter moves fp32
operands across NVLink, and because everything downstream of the combine is bf16, every layer pays
an `output.to(torch.bfloat16)` cast on the way back to the residual stream. Allocating that one
buffer bf16 collapses all three — the accumulator's `tl.store` rounds on the way in for free, the
hardware reduce switches to its bf16 operand form, and the trailing cast becomes the identity and
its kernel disappears, removing 48 launches per decode step: **+2.42%** end-to-end decode
throughput.

**This is not a bandwidth win, and the description would be wrong if it implied one.** The collective
does move half as many bytes, and that turns out to be nearly irrelevant: measured in place with an
in-graph event timer, dispatch plus combine costs 1.039 ms/step with bf16 against 1.035 ms/step with
fp32 — a 0.4% move in the *unfavourable* direction, which is to say no move at all, for a 2× reduction
in traffic. These collectives are latency-bound at this size. What this change buys is the
removed per-layer cast and the halved store and load traffic around the buffer, not a faster wire.

## Why here

Two measurements pointed here, and neither was a bandwidth argument.

The first was a post-reduce-scatter copy that kept showing up in traces as a fusion candidate. Three
earlier sessions treated the per-layer copies as targets worth roughly 0.06 ms each and tried to fuse
them away. Following the copy back to its cause instead found `output.to(torch.bfloat16)` at the end
of `NVLSAllGatherVDispatcher.token_combine`, and behind it a buffer dtype decision. That is the general lesson
worth carrying out of this PR: when a copy shows up next to a collective, check what dtype the
collective is moving before trying to fuse the copy.

The second was an in-graph event timer that re-priced every per-layer component. It put `nvls_combine`
at 0.548 ms/step and `nvls_dispatch` at 0.491 ms/step against a per-layer site total of 7.060 ms/step,
and it is also the measurement that says the transport is not the lever: the same 1.039 ms/step for
dispatch plus combine both before and after the bytes were halved. There is also no structural
deficit to close against vLLM here: vLLM runs the same two collectives at the same per-layer cadence,
NCCL ring/LL rather than NVLink multimem, and on the one clean measurement each way this path is
ahead — 30.6 µs/layer from in-graph events against 41.5 µs/layer for vLLM. Treat that gap as
directional only, since vLLM's number is measured under a profiler where ring/LL also spins, so its
true cost lies somewhere between the roughly microsecond wire floor for the ~1 MB each launch moves
and the 41.5 µs observed. What survives is the part that matters here: both sides sit 15–30× above the
wire time for the bytes they move, so both are barrier-latency bound and bytes were never the
constraint.

## What changed

**Before.** `allocate_buffers` allocates the `ep_rsv` symmetric buffer as fp32. `_moe_sum` reduces the
top-k dimension with the routing weights applied, accumulating in fp32 registers, and writes fp32
directly into that buffer. `token_combine` then allocates an fp32 output, runs
`multimem_reduce_scatter_v` — which selects `multimem.ld_reduce.relaxed.sys.global.add.v4.f32` because
the output is fp32 — and returns `output.to(torch.bfloat16)`, a real cast kernel per layer per step.

**After.** With the gate set, the same buffer is allocated bf16. `_moe_sum` is unchanged: it still
accumulates in fp32 registers and its `tl.store` handles the cast to the buffer's dtype, so the store
now writes half as many bytes. `token_combine` allocates its output with the buffer's dtype, so
`multimem_reduce_scatter_v` selects `multimem.ld_reduce.relaxed.sys.global.add.acc::f32.v4.bf16x2` —
still an f32 accumulation in hardware, only the loaded operands change width — and
`output.to(torch.bfloat16)` becomes a no-op that returns its argument. The symmetric allocation for
this buffer also halves, which is worth having on a path where symmetric memory is capped.

What makes this cheaper, stated as narrowly as the data supports: 48 cast launches per step are gone,
and the store into the buffer plus the load out of it move half the bytes. The collective itself is
essentially unchanged in time. This also lands the path where vLLM already is — its combine is
`ncclDevKernel_ReduceScatter_Sum_bf16` — so bf16 is not an exotic operating point for this collective.

## Measurement

Fixed protocol: Qwen3-30B-A3B, BF16, TP 1 / PP 1 / EP 4 / ETP 1, 256 gsm8k requests, 1024 output tokens, 2 warmup + 5 timed iterations, a single OCI 4xGB200 node (nvl72160-T04), async dynamic-batching scheduler pinned on. All 20 arms ran back to back in one allocation on that one node; node-to-node variance on this workload is around 2.7%, so cross-node numbers would not be comparable.

- With this change (every other gate in the stack enabled): **31,515 tok/s**
- Without it (same node, same session, only this gate turned off): **30,770 tok/s**
- Leave-one-out delta: **+2.42%**
- Noise floor: sigma = **0.42%** over 3 repeats of the all-gates-on reference
- Verdict: **resolved** by margin (5.8 sigma). The per-iteration distributions do not separate strictly, but only because each reference arm contains one low outlier iteration; excluding those the arms do not overlap.

This is the **marginal contribution measured with every other gate in this stack enabled** — the question a reviewer is actually asking, which is whether this should land, not what it was worth when it was first written.

The reference is drift-corrected. The all-gates-on configuration was re-measured three times across the session (31,745, 31,530, 31,503 tok/s), a +0.77% drift from first to last, so each arm is compared against the reference interpolated to its own position in the run order rather than against a session mean.

For context, the whole stack is worth **+35.80%** on this node (23,265 tok/s with every gate off, 31,593 with every gate on). Per-slice deltas do not sum to that; they compose sub-additively.

## Evidence

**Mechanism confirmed by launch count, not by time.** A trace captured with the gate on shows
`bfloat16_copy_kernel` instances falling from 258,564 to 4,572 whole-trace, a 98% reduction, and the
copy bucket falling from 107 to 59 launches per step. The difference is exactly 48, one per layer —
the cast that is now the identity.

Counts rather than times, deliberately. The two traces' per-bucket times are not comparable to each
other: the second window's expert GEMM is 27% cheaper (2.436 → 1.777 ms/step) and its attention
launches went from 50 to 63 per step, neither of which a reduce-scatter dtype can cause. The two
60-step windows simply sit at different average sequence lengths, so per-bucket ms/step may only be
compared *within* a trace. The trace's own accounting for what this change removes came to about
0.29 ms/step, which is the right order for 48 cast launches and the associated traffic, but I am
quoting it as a prediction from within one trace and not as a measured delta.

The counter-evidence belongs here too, because it is what keeps the mechanism honest: the in-graph
timer's 1.039 ms/step for dispatch plus combine after this change, against 1.035 ms/step before it.
Together with an earlier CTA-count sweep and a barrier analysis, that is three independent
measurements saying these collectives cannot be made faster by moving fewer bytes, only hidden.

## Correctness

- **Numerics: this is a real numerics change, and it is not bit-exact.** The precision cost is smaller
  than "reduce in bf16" suggests, but it is not zero. The cross-rank sum is still accumulated in f32
  by the hardware — `acc::f32.v4.bf16x2` selects only the width of the operands it loads — and
  `_moe_sum` still accumulates the top-k weighted sum in fp32 registers. What changes is *where the
  single bf16 rounding happens*: previously each rank's partial went on the wire in fp32, the four
  partials were summed in f32, and the total was rounded to bf16 once at the end; now each rank's
  partial is rounded to bf16 before it goes on the wire and the total is already bf16. Analytically
  that is at most a half bf16 ulp, `2^-8` ≈ 0.4% relative, per partial, so the result can differ from
  the previous path by a few bf16 ulps in the worst case. That bound is arithmetic, not measured — no
  tolerance sweep was run against the fp32 path.
- **Tests and coherence:** behavioral only, and deliberately reported as thin. Greedy decode stayed
  correct on all three probes with the gate on and the benchmark completed every iteration; that is the
  whole numerical evidence. Byte-identity against the gate-off run is neither expected nor checked,
  since the change alters results by construction, and three greedy probes do not establish accuracy.
- **Batch-invariant mode is rejected, not silently degraded.** `ordered_reduce_scatter_v` reduces ranks
  with an explicit fp32 loop and requires an fp32 buffer, so combining the two raises an
  `AssertionError` at buffer allocation during model init, with a message naming both flags. This fails
  before any token is produced rather than quietly producing different numbers.

## Gating and blast radius

- Gate: `MCORE_NVLS_RS_BF16`, read once at import as `os.environ.get(..., "0") == "1"`, so **default
  OFF**, and it stays off until someone runs a real accuracy evaluation. Unset, `rsv_dtype` is
  `torch.float32` and every path — the buffer, the store, the reduce instruction selected, the trailing
  cast — is byte-identical to before this PR.
- Scope: the change is confined to one buffer allocation in `NVLSAllGatherVDispatcher.allocate_buffers`,
  which runs once at model init. There is no hot-path branch and no per-step cost to the gate. Only the
  NVLS AllGather-V inference dispatcher is affected; the NCCL dispatcher, every other inference
  dispatcher, and all training paths are untouched.
- Preconditions: batch-invariant mode off, asserted as described above. The collective itself already
  accepts either dtype — `multimem_reduce_scatter_v` asserts the dtype is bf16 or fp32 and that input
  and output agree, both of which hold because the output is allocated from the buffer's dtype.
- When the assertion fires it raises at init. There is no fallback and there should not be: silently
  reverting to fp32 under a flag whose entire purpose is the dtype would be worse than failing.

## Reproduce

```bash
MCORE_NVLS_RS_BF16=1 \
QWEN30B_TP=1 QWEN30B_EP=4 QWEN30B_ETP=1 \
BENCH_SIZES_OVERRIDE=256 BENCH_OUTPUT_TOKENS=1024 \
NUM_WARMUP_ITERS=2 NUM_TIMED_ITERS=5 \
bash skills/run-qwen-model/run_qwen_inference.sh qwen3-30b-a3b --checkpoint "$QWEN30B_CKPT"
```

Measure this without a profiler attached. Under nsys these collectives spin-wait and read roughly 25×
their true cost, so a profiled run cannot size this change; the profile is only good for the launch
counts quoted above.

## What this does not claim

- **No bandwidth win on the collective.** Halving the traffic moved dispatch plus combine by 0.4%, in
  the wrong direction and within noise. If you are looking for a faster wire in this diff it is not
  here, and three separate measurements say it is not available: these collectives are latency-bound at
  this size and can only be hidden, not accelerated.
- **No accuracy claim.** Three greedy-decode probes are a smoke test. Nothing here justifies turning
  this on by default; that needs lm-eval or an equivalent accuracy run against the fp32 path.
- **The delta is not decomposed.** The removed cast is confirmed by launch count and the collective is
  confirmed as nearly unchanged, but I cannot split the remaining benefit between the 48 removed
  launches, the halved store traffic out of `_moe_sum`, and the halved load traffic into the reduce.
  They were changed together by one dtype and I did not isolate them.
- **`CUDA_DEVICE_MAX_CONNECTIONS=8` is not an additional win on top of this.** Stacking it on this
  change adds nothing measurable. Its earlier gain was relieving contention on the same fp32
  reduce-scatter that this change shrinks, so the two are one win and must not be counted twice.
- Nothing is measured outside this configuration. The allocation change itself is independent of tensor
  parallelism, but it was only measured at TP 1 / EP 4 on one node, so no claim is made for other
  layouts or batch sizes. The NCCL dispatcher and every training path never reach this allocation at
  all.
- Deltas in this stack do not add. This change removes per-layer launches and traffic from the same
  decode step that the other changes in the stack also shorten, so it composes sub-additively with
  them and the combination has to be measured rather than summed.

## Follow-ups

- An accuracy evaluation against the fp32 path is the only blocker for making this the default; three
  greedy-decode probes are not enough to flip a numerics change on for everyone.
- The exposed collective time this PR does *not* recover, about 1.04 ms/step, needs a second
  independent stream of work to hide behind. Inside a layer everything is strictly dependent —
  attention feeds the router, the router feeds dispatch, the all-gather sizes the expert GEMM, the GEMM
  feeds the combine — and this model has no shared expert, so the shared-expert stream is empty. The
  standard remedy is two interleaved microbatches, which the inference decode path has no machinery
  for. That is the single largest remaining prize on this path and it is an architecture project, not
  a tuning change.

---

## This stack

This is one slice of [#6064](https://github.com/NVIDIA/Megatron-LM/pull/6064), a Qwen3-30B-A3B decode optimization campaign, split into 16 independently reviewable changes. Together they are **+35.80%** end-to-end throughput over the same base commit (23,265 -> 31,593 tok/s, mean of three full runs).

- **MoE grouped-GEMM and dispatch:** #6452 -> #6453 -> #6454 -> #6455
- **MoE router and combine:** #6456 -> #6457 -> #6458
- **Attention: QK norm and decode kernel:** #6459 -> #6460 -> #6461 -> #6462
- **Residual + RMSNorm fusion:** #6463 -> #6464
- **Host path: context bookkeeping:** #6465 -> #6466
- **Host path: independent:** #6467

Each chain is independent of the others and bases on `main`. Within a chain, later PRs depend on earlier ones.

### Per-slice measured delta

Every number is a leave-one-out delta from one same-node, same-session campaign: the full stack with exactly this change's gate off, against the interpolated full-stack reference at that point in the run. It is the change's *marginal* contribution with everything else already in, not its standalone value. Run-to-run sigma was **0.42%** across three full-stack repeats.

| PR | Change | Delta | |
|---|---|---|---|
| #6452 | FC1 SwiGLU epilogue | +14.81% | resolved |
| #6453 | indirection table fusion | +7.21% | resolved |
| #6454 | decode GEMM tile configs | +6.77% | resolved |
| #6455 | predicated top-k gather | +1.99% | by margin |
| #6456 | fused router softmax+top-k | +4.75% | resolved |
| #6457 | fused route padding mask | +1.47% | by margin |
| #6458 | bf16 MoE combine | +2.42% | by margin |
| #6459 | fused QK RMSNorm | +5.17% | resolved |
| #6460 | grouped QK norm input | +1.18% | by margin |
| #6461 | pin FlashAttention 2 | -0.35% | noise floor |
| #6462 | FlashInfer TRT-LLM decode | +1.46% | by margin |
| #6463 | fused add+norm pre-MLP | +3.54% | by margin |
| #6464 | fused add+norm pre-QKV | +0.98% | by margin |
| #6465 | incremental attention state | -0.42% | noise floor |
| #6466 | vectorized decode bookkeeping | -0.07% | noise floor |
| #6467 | post_process_requests fast path | +0.09% | noise floor |

`noise floor` means the delta is inside 2 sigma (0.84%) and this campaign cannot distinguish it from zero. `resolved` means the leave-one-out and full-stack iteration distributions did not overlap. Deltas do not sum to the stack total: these changes shorten the same decode step and compose sub-additively.

**Fixed protocol for every number above.** Qwen3-30B-A3B, BF16, TP1/PP1/EP4/ETP1, 256 gsm8k requests at batch size 256, output length 1024, CUDA graphs on, one OCI GB200 NVL72 node, 4 GPUs. All 20 arms ran back-to-back in a single Slurm allocation on one node, so node assignment and thermal state are held constant.
