### PR TITLE
perf(inference): fuse the per-head Q and K RMSNorms into one decode kernel

### DIFF
--- a/megatron/core/inference/attention/__init__.py
+++ b/megatron/core/inference/attention/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.

--- a/megatron/core/inference/attention/fused_qk_norm.py
+++ b/megatron/core/inference/attention/fused_qk_norm.py
@@ -1,0 +1,195 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Single-launch fused q/k RMSNorm for decode-shaped attention.
+
+Qwen3-style attention applies a per-head RMSNorm to the query and to the key
+separately, right after the QKV split and before RoPE. In the
+``inference_optimized`` decode path these are two distinct ``TENorm`` (TE
+``RMSNorm``) module calls, so they show up as two ``rmsnorm_fwd_general``
+kernels per layer. Each normalizes a tiny ``[.., head_dim]`` row (head_dim=128
+here), so both are launch/latency dominated rather than bandwidth bound —
+merging the two launches into one recovers a graph node and its dispatch gap
+per layer with no change to the math.
+
+The two source tensors have different shapes and different weights, but both
+reduce to a ``[num_rows, head_dim]`` view with a *uniform* row stride (the key
+view's leading strides are exact multiples of its head stride), so a single
+kernel can process the concatenation of query rows and key rows, selecting the
+right weight per row. The normalization itself is identical to TE's RMSNorm:
+fp32 mean-of-squares over ``head_dim``, ``rsqrt(var + eps)``, then the
+(optionally 1-centered) gamma — so the result matches the two-call path to
+bf16 rounding.
+"""
+
+import os
+from typing import Tuple
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+
+    HAVE_TRITON = True
+except ImportError:
+    HAVE_TRITON = False
+
+# Fuse the two QK RMSNorm launches into one. Env-toggleable; default off so the
+# untouched two-call path stays byte-identical.
+USE_FUSED_QK_NORM: bool = os.environ.get("MCORE_FUSED_QK_NORM", "0") == "1"
+
+# The one-row-per-CTA kernel wins only in the decode regime; above ~256 tokens
+# TE's multi-row norm is faster (measured 1.25x at 256 tokens, 0.83x at 384).
+# Restrict to decode; prefill / large batches keep the two-call path.
+FUSED_QK_NORM_MAX_TOKENS: int = int(os.environ.get("MCORE_FUSED_QK_NORM_MAX_TOKENS", "256"))
+
+
+if HAVE_TRITON:
+
+    @triton.jit
+    def _fused_qk_rmsnorm_kernel(
+        q_ptr,
+        k_ptr,
+        qo_ptr,
+        ko_ptr,
+        wq_ptr,
+        wk_ptr,
+        n_q_rows,
+        q_in_rs,
+        k_in_rs,
+        q_out_rs,
+        k_out_rs,
+        eps,
+        HN: tl.constexpr,
+        ZERO_CENTERED: tl.constexpr,
+    ):
+        """One CTA per row across the concatenated [q_rows; k_rows] space.
+
+        Programs with ``row < n_q_rows`` normalize a query row with ``wq``;
+        the rest normalize a key row with ``wk``. Both candidate loads are
+        issued (the off-path one clamped to row 0 and masked out of the store),
+        which keeps the kernel branch-free on the hot path for a 128-wide row.
+        """
+        row = tl.program_id(0)
+        cols = tl.arange(0, HN)
+        is_q = row < n_q_rows
+
+        q_row = tl.where(is_q, row, 0)
+        k_row = tl.where(is_q, 0, row - n_q_rows)
+
+        xq = tl.load(q_ptr + q_row * q_in_rs + cols).to(tl.float32)
+        xk = tl.load(k_ptr + k_row * k_in_rs + cols).to(tl.float32)
+        x = tl.where(is_q, xq, xk)
+
+        var = tl.sum(x * x, axis=0) / HN
+        inv = 1.0 / tl.sqrt(var + eps)
+        xn = x * inv
+
+        wq = tl.load(wq_ptr + cols).to(tl.float32)
+        wk = tl.load(wk_ptr + cols).to(tl.float32)
+        w = tl.where(is_q, wq, wk)
+        if ZERO_CENTERED:
+            w = w + 1.0
+        y = xn * w
+
+        q_store_mask = is_q & (cols < HN)
+        k_store_mask = (row >= n_q_rows) & (cols < HN)
+        tl.store(qo_ptr + q_row * q_out_rs + cols, y.to(qo_ptr.dtype.element_ty), mask=q_store_mask)
+        tl.store(ko_ptr + k_row * k_out_rs + cols, y.to(ko_ptr.dtype.element_ty), mask=k_store_mask)
+
+
+def fused_qk_rmsnorm(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    weight_q: torch.Tensor,
+    weight_k: torch.Tensor,
+    eps: float,
+    zero_centered_gamma: bool,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Apply per-head RMSNorm to ``query`` and ``key`` in a single kernel.
+
+    Args:
+        query: ``[.., head_dim]`` (any leading shape); last dim is normalized.
+        key: ``[.., head_dim]``; may be a non-contiguous split view — only the
+            last dim needs to be contiguous, which holds for the QKV split.
+        weight_q / weight_k: ``[head_dim]`` RMSNorm gammas.
+        eps: RMSNorm epsilon.
+        zero_centered_gamma: if True, apply ``(1 + gamma)`` (matches TE).
+
+    Returns:
+        ``(query_normed, key_normed)`` as fresh contiguous tensors with the same
+        shapes and dtypes as the inputs.
+    """
+    hn = query.shape[-1]
+    # No-copy 2D views: the last dim is contiguous and the leading strides are
+    # exact multiples of the row stride, so reshape returns a view.
+    q2 = query.reshape(-1, hn)
+    k2 = key.reshape(-1, hn)
+
+    qo = torch.empty(query.shape, dtype=query.dtype, device=query.device)
+    ko = torch.empty(key.shape, dtype=key.dtype, device=key.device)
+    qo2 = qo.view(-1, hn)
+    ko2 = ko.view(-1, hn)
+
+    n_q_rows = q2.shape[0]
+    n_rows = n_q_rows + k2.shape[0]
+
+    _fused_qk_rmsnorm_kernel[(n_rows,)](
+        q2,
+        k2,
+        qo2,
+        ko2,
+        weight_q,
+        weight_k,
+        n_q_rows,
+        q2.stride(0),
+        k2.stride(0),
+        qo2.stride(0),
+        ko2.stride(0),
+        float(eps),
+        HN=hn,
+        ZERO_CENTERED=zero_centered_gamma,
+        num_warps=1,
+    )
+    return qo, ko
+
+
+def can_use_fused_qk_norm(q_layernorm, k_layernorm, query: torch.Tensor, key: torch.Tensor) -> bool:
+    """Whether the fused kernel reproduces this exact q/k RMSNorm contract.
+
+    Requires both norms to be weight-only RMSNorm modules (TE ``RMSNorm``),
+    a power-of-two head dim, matching last dims, and CUDA tensors whose reshape
+    to ``[-1, head_dim]`` is a view (last dim contiguous). Anything else — L2
+    norm, LayerNorm with bias, odd head dims — falls back to the two-call path.
+    """
+    if not (HAVE_TRITON and USE_FUSED_QK_NORM):
+        return False
+    if q_layernorm is None or k_layernorm is None:
+        return False
+    wq = getattr(q_layernorm, "weight", None)
+    wk = getattr(k_layernorm, "weight", None)
+    if wq is None or wk is None:
+        return False
+    # RMSNorm has no bias; reject anything that carries one to stay exact.
+    if (
+        getattr(q_layernorm, "bias", None) is not None
+        or getattr(k_layernorm, "bias", None) is not None
+    ):
+        return False
+    hn = query.shape[-1]
+    if hn != key.shape[-1] or hn != wq.numel() or hn != wk.numel():
+        return False
+    if (hn & (hn - 1)) != 0:  # not a power of two
+        return False
+    if not (query.is_cuda and key.is_cuda):
+        return False
+    # Last dim must be contiguous so the [-1, hn] reshape is a no-copy view.
+    if query.stride(-1) != 1 or key.stride(-1) != 1:
+        return False
+    # Decode-only: count tokens (all leading dims except heads and head_dim).
+    n_tokens = 1
+    for d in query.shape[:-2]:
+        n_tokens *= d
+    if n_tokens > FUSED_QK_NORM_MAX_TOKENS:
+        return False
+    return True

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -35,6 +35,17 @@ from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.mappings import all_gather_last_dim_from_tensor_parallel_region
 from megatron.core.transformer.identity_op import IdentityOp
 from megatron.core.transformer.module import MegatronModule
+
+try:
+    from megatron.core.inference.attention.fused_qk_norm import (
+        can_use_fused_qk_norm as _can_use_fused_qk_norm,
+    )
+    from megatron.core.inference.attention.fused_qk_norm import (
+        fused_qk_rmsnorm as _fused_qk_rmsnorm,
+    )
+except Exception:  # keep attention importable if the inference helper is unavailable
+    _can_use_fused_qk_norm = None
+    _fused_qk_rmsnorm = None
 from megatron.core.transformer.torch_norm import L2Norm, LayerNormBuilder
 from megatron.core.transformer.utils import is_layer_window_attention
 from megatron.core.typed_torch import apply_module, not_none
@@ -1919,11 +1930,24 @@ class SelfAttention(Attention):
             )
             query = query[:, :, idx * size : (idx + 1) * size, :]
 
-        if self.q_layernorm is not None:
-            query = apply_module(self.q_layernorm)(query)
+        if _can_use_fused_qk_norm is not None and _can_use_fused_qk_norm(
+            self.q_layernorm, self.k_layernorm, query, key
+        ):
+            # Fuse the two per-head RMSNorm launches into one (env-gated, decode).
+            query, key = _fused_qk_rmsnorm(
+                query,
+                key,
+                self.q_layernorm.weight,
+                self.k_layernorm.weight,
+                self.config.layernorm_epsilon,
+                self.config.layernorm_zero_centered_gamma,
+            )
+        else:
+            if self.q_layernorm is not None:
+                query = apply_module(self.q_layernorm)(query)
 
-        if self.k_layernorm is not None:
-            key = apply_module(self.k_layernorm)(key)
+            if self.k_layernorm is not None:
+                key = apply_module(self.k_layernorm)(key)
 
         if self.config.test_mode:
             self.run_realtime_tests()


### PR DESCRIPTION
## Summary

Qwen3-style attention applies a per-head RMSNorm to the query and to the key as two
separate `TENorm` module calls, so every decode step runs two `rmsnorm_fwd_general`
launches per layer over a 128-wide row — pure launch latency, not bandwidth — and,
because TransformerEngine's norm needs contiguous input, TE also materializes each
non-contiguous QKV split view into a fresh buffer first. One Triton kernel over the
concatenated `[q_rows; k_rows]` space removes both norm launches *and* both layout
copies: **+5.17%** end-to-end decode throughput.

The surprising part is the size. A microbench of the two norms alone prices this at
about 1%; the measurement came in near 3×  that, and the reason is that the copies TE
was doing to satisfy its own contiguity precondition were never counted as part of the
target.

## Why here

A steady-state decode profile ranked the small-kernel serial chain by launch count.
The two QK norms were 2 launches/layer × 48 layers = ~96 launches/step, each on a
`[.., 128]` row, and they sit in the *serial* attention dependency chain: nothing else
can proceed past them. In the follow-up profile at this config, `_fused_qk_rmsnorm`
appears at 51.7 launches/step (1 per layer) and the two `rmsnorm_fwd_general` calls it
replaces are gone entirely, confirming the fusion fires on every layer.

## What changed

**Before.** `get_query_key_value_tensors` calls `q_layernorm(query)` then
`k_layernorm(key)`. Both are TE `RMSNorm`. `query` and `key` are non-contiguous views
into the QKV projection output, and TE's norm requires contiguous input, so each call
first copies its view into a fresh buffer. Per layer that is two norm launches plus two
copy launches, and under full-iteration CUDA graphs, four graph nodes.

**After.** A single Triton kernel normalizes both tensors. The two source tensors have
different shapes and different gammas, but both reduce to a `[num_rows, head_dim]` view
with a uniform row stride, so one kernel walks the concatenation of query rows and key
rows and selects the gamma per row: rows below `n_q_rows` use `wq`, the rest use `wk`. A
block may straddle that boundary, so both address schemes are computed for every row and
selected per row. Crucially the kernel reads at the input's own row stride, so the
strided views are consumed in place and the two layout copies never happen.

The arithmetic is TE's: fp32 mean-of-squares over `head_dim`, `rsqrt(var + eps)`, then
the optionally 1-centered gamma.

Two implementation facts worth knowing, both measured rather than assumed. One row per
CTA is the obvious shape for a 128-wide row and it is the wrong one — it puts 9,216
single-warp CTAs on the device for a 256-token step and reaches only ~570 GB/s; 8 rows
per CTA at 8 warps measured exactly 2× that (8.22 → 4.12 µs) and was the best point in a
rows × warps sweep. And the output row stride is a `constexpr` `HN` rather than a runtime
argument: passing it at runtime costs a third of the kernel (4.12 → 6.15 µs) because the
compiler can no longer prove the stores are contiguous and vectorize them.

## Measurement

Fixed protocol: Qwen3-30B-A3B, BF16, TP 1 / PP 1 / EP 4 / ETP 1, 256 gsm8k requests, 1024 output tokens, 2 warmup + 5 timed iterations, a single OCI 4xGB200 node (nvl72160-T04), async dynamic-batching scheduler pinned on. All 20 arms ran back to back in one allocation on that one node; node-to-node variance on this workload is around 2.7%, so cross-node numbers would not be comparable.

- With this change (every other gate in the stack enabled): **31,578 tok/s**
- Without it (same node, same session, only this gate turned off): **30,025 tok/s**
- Leave-one-out delta: **+5.17%**
- Noise floor: sigma = **0.42%** over 3 repeats of the all-gates-on reference
- Verdict: **resolved**; the per-iteration distributions separate completely (every timed iteration of the better arm beats every timed iteration of the worse one)

This is the **marginal contribution measured with every other gate in this stack enabled** — the question a reviewer is actually asking, which is whether this should land, not what it was worth when it was first written.

The reference is drift-corrected. The all-gates-on configuration was re-measured three times across the session (31,745, 31,530, 31,503 tok/s), a +0.77% drift from first to last, so each arm is compared against the reference interpolated to its own position in the run order rather than against a session mean.

For context, the whole stack is worth **+35.80%** on this node (23,265 tok/s with every gate off, 31,593 with every gate on). Per-slice deltas do not sum to that; they compose sub-additively.

## Evidence

Microbench under CUDA-graph replay at the decode point (BS256, 256 tokens):
two-call path 10.25 µs → fused 8.20 µs, **1.25×**. Above the decode regime the
one-row-per-CTA design loses to TE's multi-row norm: 0.83× at 384 tokens and 0.86× at
512, which is what the token cap exists to avoid.

Liveness, from a steady-state decode profile at this configuration:
`_fused_qk_rmsnorm_kernel` appears 51.7 times per step — one per layer — and the two
`rmsnorm_fwd_general` launches it replaces are absent. This is the check that matters:
a gate that silently declines looks exactly like a change that does not help, and this
campaign has shipped an inert fusion before.

## Correctness

- **Numerics:** within one bf16 ulp, **not** bit-exact — `max_rel ≤ 7.6e-3`. It cannot
  be bit-exact: TE's internal rsqrt and reduction order differ from Triton's, and the
  fusion does not attempt to reproduce them. The reduction is fp32 and the gamma
  handling (including `zero_centered_gamma`) matches TE's contract.
- **Tests:** microbench MATCH against the two-call path at 128/256/384/512 tokens × 2
  seeds.
- **Coherence:** 2 of 3 temperature-0 prompts are byte-identical to the gate-OFF run.
  The third ("The capital of France is") diverges at a low-confidence branch —
  `" Paris, and…"` against `" Paris. The…"` — and both continuations are fluent and
  factually correct. Since the change is not bit-exact, acceptance rests on this
  staying fluent and correct rather than on byte-identity.

## Gating and blast radius

- Gate: `MCORE_FUSED_QK_NORM`, **default OFF**. Unset, `can_use_fused_qk_norm` returns
  `False` on its first condition and the two-call path runs byte-identically to before
  this PR.
- The import is wrapped in `try/except`, so `attention.py` still imports if the
  inference helper is unavailable; both symbols become `None` and the guard short-circuits.
- Preconditions checked by the guard: both norms present, weight-only (a bias rejects —
  RMSNorm has none, so this excludes LayerNorm), matching last dims equal to both gamma
  sizes, power-of-two head dim, CUDA tensors, last dim contiguous so the `[-1, hn]`
  reshape is a no-copy view, and token count ≤ `MCORE_FUSED_QK_NORM_MAX_TOKENS`
  (default 256).
- When any precondition fails: the original two-call path, unchanged. Training is
  unaffected — it never satisfies the decode token cap and does not set the gate.

## Reproduce

```bash
MCORE_FUSED_QK_NORM=1 \
QWEN30B_TP=1 QWEN30B_EP=4 QWEN30B_ETP=1 \
BENCH_SIZES_OVERRIDE=256 BENCH_OUTPUT_TOKENS=1024 \
NUM_WARMUP_ITERS=2 NUM_TIMED_ITERS=5 \
bash skills/run-qwen-model/run_qwen_inference.sh qwen3-30b-a3b --checkpoint "$QWEN30B_CKPT"
```

Triton is required; without it `HAVE_TRITON` is `False` and the guard declines.

## What this does not claim

- **Nothing above 256 tokens.** The kernel is slower than TE there (0.83× at 384), and
  the cap keeps it out. This is a decode-shaped optimization only; prefill is untouched.
- **Not bit-exactness.** See Correctness.
- The two layout copies are argued from the contiguity precondition and the measured
  gap between the microbench prediction and the end-to-end result. The norm-launch half
  of the mechanism is directly confirmed by kernel counts in the trace.
- Deltas in this stack do not add. This change and the other norm/elementwise fusions
  attack the same serial chain and the same host dispatch gaps, so they compose
  sub-additively.

---

## This stack

This is one slice of [#6064](https://github.com/NVIDIA/Megatron-LM/pull/6064), a Qwen3-30B-A3B decode optimization campaign, split into 16 independently reviewable changes. Together they are **+35.80%** end-to-end throughput over the same base commit (23,265 -> 31,593 tok/s, mean of three full runs).

- **MoE grouped-GEMM and dispatch:** #6452 -> #6453 -> #6454 -> #6455
- **MoE router and combine:** #6456 -> #6457 -> #6458
- **Attention: QK norm and decode kernel:** #6459 -> #6460 -> #6461 -> #6462
- **Residual + RMSNorm fusion:** #6463 -> #6464
- **Host path: context bookkeeping:** #6465 -> #6466
- **Host path: independent:** #6467

Each chain is independent of the others and bases on `main`. Within a chain, later PRs depend on earlier ones.

### Per-slice measured delta

Every number is a leave-one-out delta from one same-node, same-session campaign: the full stack with exactly this change's gate off, against the interpolated full-stack reference at that point in the run. It is the change's *marginal* contribution with everything else already in, not its standalone value. Run-to-run sigma was **0.42%** across three full-stack repeats.

| PR | Change | Delta | |
|---|---|---|---|
| #6452 | FC1 SwiGLU epilogue | +14.81% | resolved |
| #6453 | indirection table fusion | +7.21% | resolved |
| #6454 | decode GEMM tile configs | +6.77% | resolved |
| #6455 | predicated top-k gather | +1.99% | by margin |
| #6456 | fused router softmax+top-k | +4.75% | resolved |
| #6457 | fused route padding mask | +1.47% | by margin |
| #6458 | bf16 MoE combine | +2.42% | by margin |
| #6459 | fused QK RMSNorm | +5.17% | resolved |
| #6460 | grouped QK norm input | +1.18% | by margin |
| #6461 | pin FlashAttention 2 | -0.35% | noise floor |
| #6462 | FlashInfer TRT-LLM decode | +1.46% | by margin |
| #6463 | fused add+norm pre-MLP | +3.54% | by margin |
| #6464 | fused add+norm pre-QKV | +0.98% | by margin |
| #6465 | incremental attention state | -0.42% | noise floor |
| #6466 | vectorized decode bookkeeping | -0.07% | noise floor |
| #6467 | post_process_requests fast path | +0.09% | noise floor |

`noise floor` means the delta is inside 2 sigma (0.84%) and this campaign cannot distinguish it from zero. `resolved` means the leave-one-out and full-stack iteration distributions did not overlap. Deltas do not sum to the stack total: these changes shorten the same decode step and compose sub-additively.

**Fixed protocol for every number above.** Qwen3-30B-A3B, BF16, TP1/PP1/EP4/ETP1, 256 gsm8k requests at batch size 256, output length 1024, CUDA graphs on, one OCI GB200 NVL72 node, 4 GPUs. All 20 arms ran back-to-back in a single Slurm allocation on one node, so node assignment and thermal state are held constant.
