### PR TITLE
perf(inference): read the decode Q/K norm input from the grouped QKV output

### DIFF
--- a/megatron/core/inference/attention/__init__.py
+++ b/megatron/core/inference/attention/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.

--- a/megatron/core/inference/attention/fused_qk_norm.py
+++ b/megatron/core/inference/attention/fused_qk_norm.py
@@ -1,0 +1,195 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Single-launch fused q/k RMSNorm for decode-shaped attention.
+
+Qwen3-style attention applies a per-head RMSNorm to the query and to the key
+separately, right after the QKV split and before RoPE. In the
+``inference_optimized`` decode path these are two distinct ``TENorm`` (TE
+``RMSNorm``) module calls, so they show up as two ``rmsnorm_fwd_general``
+kernels per layer. Each normalizes a tiny ``[.., head_dim]`` row (head_dim=128
+here), so both are launch/latency dominated rather than bandwidth bound —
+merging the two launches into one recovers a graph node and its dispatch gap
+per layer with no change to the math.
+
+The two source tensors have different shapes and different weights, but both
+reduce to a ``[num_rows, head_dim]`` view with a *uniform* row stride (the key
+view's leading strides are exact multiples of its head stride), so a single
+kernel can process the concatenation of query rows and key rows, selecting the
+right weight per row. The normalization itself is identical to TE's RMSNorm:
+fp32 mean-of-squares over ``head_dim``, ``rsqrt(var + eps)``, then the
+(optionally 1-centered) gamma — so the result matches the two-call path to
+bf16 rounding.
+"""
+
+import os
+from typing import Tuple
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+
+    HAVE_TRITON = True
+except ImportError:
+    HAVE_TRITON = False
+
+# Fuse the two QK RMSNorm launches into one. Env-toggleable; default off so the
+# untouched two-call path stays byte-identical.
+USE_FUSED_QK_NORM: bool = os.environ.get("MCORE_FUSED_QK_NORM", "0") == "1"
+
+# The one-row-per-CTA kernel wins only in the decode regime; above ~256 tokens
+# TE's multi-row norm is faster (measured 1.25x at 256 tokens, 0.83x at 384).
+# Restrict to decode; prefill / large batches keep the two-call path.
+FUSED_QK_NORM_MAX_TOKENS: int = int(os.environ.get("MCORE_FUSED_QK_NORM_MAX_TOKENS", "256"))
+
+
+if HAVE_TRITON:
+
+    @triton.jit
+    def _fused_qk_rmsnorm_kernel(
+        q_ptr,
+        k_ptr,
+        qo_ptr,
+        ko_ptr,
+        wq_ptr,
+        wk_ptr,
+        n_q_rows,
+        q_in_rs,
+        k_in_rs,
+        q_out_rs,
+        k_out_rs,
+        eps,
+        HN: tl.constexpr,
+        ZERO_CENTERED: tl.constexpr,
+    ):
+        """One CTA per row across the concatenated [q_rows; k_rows] space.
+
+        Programs with ``row < n_q_rows`` normalize a query row with ``wq``;
+        the rest normalize a key row with ``wk``. Both candidate loads are
+        issued (the off-path one clamped to row 0 and masked out of the store),
+        which keeps the kernel branch-free on the hot path for a 128-wide row.
+        """
+        row = tl.program_id(0)
+        cols = tl.arange(0, HN)
+        is_q = row < n_q_rows
+
+        q_row = tl.where(is_q, row, 0)
+        k_row = tl.where(is_q, 0, row - n_q_rows)
+
+        xq = tl.load(q_ptr + q_row * q_in_rs + cols).to(tl.float32)
+        xk = tl.load(k_ptr + k_row * k_in_rs + cols).to(tl.float32)
+        x = tl.where(is_q, xq, xk)
+
+        var = tl.sum(x * x, axis=0) / HN
+        inv = 1.0 / tl.sqrt(var + eps)
+        xn = x * inv
+
+        wq = tl.load(wq_ptr + cols).to(tl.float32)
+        wk = tl.load(wk_ptr + cols).to(tl.float32)
+        w = tl.where(is_q, wq, wk)
+        if ZERO_CENTERED:
+            w = w + 1.0
+        y = xn * w
+
+        q_store_mask = is_q & (cols < HN)
+        k_store_mask = (row >= n_q_rows) & (cols < HN)
+        tl.store(qo_ptr + q_row * q_out_rs + cols, y.to(qo_ptr.dtype.element_ty), mask=q_store_mask)
+        tl.store(ko_ptr + k_row * k_out_rs + cols, y.to(ko_ptr.dtype.element_ty), mask=k_store_mask)
+
+
+def fused_qk_rmsnorm(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    weight_q: torch.Tensor,
+    weight_k: torch.Tensor,
+    eps: float,
+    zero_centered_gamma: bool,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Apply per-head RMSNorm to ``query`` and ``key`` in a single kernel.
+
+    Args:
+        query: ``[.., head_dim]`` (any leading shape); last dim is normalized.
+        key: ``[.., head_dim]``; may be a non-contiguous split view — only the
+            last dim needs to be contiguous, which holds for the QKV split.
+        weight_q / weight_k: ``[head_dim]`` RMSNorm gammas.
+        eps: RMSNorm epsilon.
+        zero_centered_gamma: if True, apply ``(1 + gamma)`` (matches TE).
+
+    Returns:
+        ``(query_normed, key_normed)`` as fresh contiguous tensors with the same
+        shapes and dtypes as the inputs.
+    """
+    hn = query.shape[-1]
+    # No-copy 2D views: the last dim is contiguous and the leading strides are
+    # exact multiples of the row stride, so reshape returns a view.
+    q2 = query.reshape(-1, hn)
+    k2 = key.reshape(-1, hn)
+
+    qo = torch.empty(query.shape, dtype=query.dtype, device=query.device)
+    ko = torch.empty(key.shape, dtype=key.dtype, device=key.device)
+    qo2 = qo.view(-1, hn)
+    ko2 = ko.view(-1, hn)
+
+    n_q_rows = q2.shape[0]
+    n_rows = n_q_rows + k2.shape[0]
+
+    _fused_qk_rmsnorm_kernel[(n_rows,)](
+        q2,
+        k2,
+        qo2,
+        ko2,
+        weight_q,
+        weight_k,
+        n_q_rows,
+        q2.stride(0),
+        k2.stride(0),
+        qo2.stride(0),
+        ko2.stride(0),
+        float(eps),
+        HN=hn,
+        ZERO_CENTERED=zero_centered_gamma,
+        num_warps=1,
+    )
+    return qo, ko
+
+
+def can_use_fused_qk_norm(q_layernorm, k_layernorm, query: torch.Tensor, key: torch.Tensor) -> bool:
+    """Whether the fused kernel reproduces this exact q/k RMSNorm contract.
+
+    Requires both norms to be weight-only RMSNorm modules (TE ``RMSNorm``),
+    a power-of-two head dim, matching last dims, and CUDA tensors whose reshape
+    to ``[-1, head_dim]`` is a view (last dim contiguous). Anything else — L2
+    norm, LayerNorm with bias, odd head dims — falls back to the two-call path.
+    """
+    if not (HAVE_TRITON and USE_FUSED_QK_NORM):
+        return False
+    if q_layernorm is None or k_layernorm is None:
+        return False
+    wq = getattr(q_layernorm, "weight", None)
+    wk = getattr(k_layernorm, "weight", None)
+    if wq is None or wk is None:
+        return False
+    # RMSNorm has no bias; reject anything that carries one to stay exact.
+    if (
+        getattr(q_layernorm, "bias", None) is not None
+        or getattr(k_layernorm, "bias", None) is not None
+    ):
+        return False
+    hn = query.shape[-1]
+    if hn != key.shape[-1] or hn != wq.numel() or hn != wk.numel():
+        return False
+    if (hn & (hn - 1)) != 0:  # not a power of two
+        return False
+    if not (query.is_cuda and key.is_cuda):
+        return False
+    # Last dim must be contiguous so the [-1, hn] reshape is a no-copy view.
+    if query.stride(-1) != 1 or key.stride(-1) != 1:
+        return False
+    # Decode-only: count tokens (all leading dims except heads and head_dim).
+    n_tokens = 1
+    for d in query.shape[:-2]:
+        n_tokens *= d
+    if n_tokens > FUSED_QK_NORM_MAX_TOKENS:
+        return False
+    return True

--- a/megatron/core/inference/attention/fused_qk_norm.py
+++ b/megatron/core/inference/attention/fused_qk_norm.py
@@ -43,6 +43,17 @@ USE_FUSED_QK_NORM: bool = os.environ.get("MCORE_FUSED_QK_NORM", "0") == "1"
 # Restrict to decode; prefill / large batches keep the two-call path.
 FUSED_QK_NORM_MAX_TOKENS: int = int(os.environ.get("MCORE_FUSED_QK_NORM_MAX_TOKENS", "256"))
 
+# Read the query out of the grouped QKV output rather than out of a repacked copy,
+# removing one full-query strided copy per layer per step. Requires the fused norm.
+USE_GROUPED_QK_NORM: bool = os.environ.get("MCORE_GROUPED_QK_NORM", "0") == "1"
+
+# Launch shape. One row per CTA is the obvious choice for a 128-wide row and reaches only
+# ~570 GB/s, because it puts 9,216 single-warp CTAs on the device for a 256-token step.
+# 8 rows x 8 warps measured exactly 2x that (8.22 -> 4.12 us) and was the best point in a
+# rows x warps sweep; env-overridable so the sweep can be repeated on other hardware.
+ROWS_PER_CTA: int = int(os.environ.get("MCORE_QK_NORM_ROWS", "8"))
+NUM_WARPS: int = int(os.environ.get("MCORE_QK_NORM_WARPS", "8"))
+
 
 if HAVE_TRITON:
 
@@ -55,47 +66,82 @@ if HAVE_TRITON:
         wq_ptr,
         wk_ptr,
         n_q_rows,
+        n_rows,
         q_in_rs,
         k_in_rs,
-        q_out_rs,
-        k_out_rs,
         eps,
+        q_grp_rs,
         HN: tl.constexpr,
         ZERO_CENTERED: tl.constexpr,
+        Q_GROUPED: tl.constexpr,
+        NPG: tl.constexpr,
+        HEADS: tl.constexpr,
+        ROWS: tl.constexpr,
     ):
-        """One CTA per row across the concatenated [q_rows; k_rows] space.
+        """``ROWS`` rows per CTA across the concatenated ``[q_rows; k_rows]`` space.
 
-        Programs with ``row < n_q_rows`` normalize a query row with ``wq``;
-        the rest normalize a key row with ``wk``. Both candidate loads are
-        issued (the off-path one clamped to row 0 and masked out of the store),
-        which keeps the kernel branch-free on the hot path for a 128-wide row.
+        Rows below ``n_q_rows`` are query rows normalized with ``wq``; the rest are key
+        rows normalized with ``wk``. A block may straddle that boundary, so both address
+        schemes are computed for every row and selected per row.
+
+        With ``Q_GROUPED`` the query is read straight out of the QKV projection's output
+        instead of from a repacked copy. There, q heads are grouped with the k and v head
+        of their group, so a q row's address needs two strides -- one per group
+        (``q_grp_rs``) and one per head inside it -- and no single row stride exists. See
+        :func:`fused_qk_rmsnorm_grouped` for why that matters.
+
+        One row per CTA is the obvious shape for a 128-wide row and it is the wrong one:
+        it puts 9,216 single-warp CTAs on the device for a 256-token step and reaches only
+        ~570 GB/s. Eight rows per CTA at eight warps measured exactly 2x that, and a
+        sweep of the rest of the space found nothing better.
+
+        Output row strides are ``HN``, not parameters: both output tensors are allocated
+        here and are contiguous, and passing that stride at runtime instead costs a third
+        of the kernel (6.15 us against 4.12 us) because the compiler can no longer prove
+        the stores are contiguous and vectorize them.
         """
-        row = tl.program_id(0)
+        rows = tl.program_id(0) * ROWS + tl.arange(0, ROWS)
         cols = tl.arange(0, HN)
-        is_q = row < n_q_rows
+        live = rows < n_rows
+        is_q = rows < n_q_rows
 
-        q_row = tl.where(is_q, row, 0)
-        k_row = tl.where(is_q, 0, row - n_q_rows)
+        q_row = tl.where(is_q, rows, 0)
+        k_row = tl.where(is_q, 0, rows - n_q_rows)
+        if Q_GROUPED:
+            head = q_row % HEADS
+            q_off = (
+                (q_row // HEADS) * (HEADS // NPG) + head // NPG
+            ) * q_grp_rs + (head % NPG) * HN
+        else:
+            q_off = q_row * q_in_rs
 
-        xq = tl.load(q_ptr + q_row * q_in_rs + cols).to(tl.float32)
-        xk = tl.load(k_ptr + k_row * k_in_rs + cols).to(tl.float32)
-        x = tl.where(is_q, xq, xk)
+        q_mask = (live & is_q)[:, None]
+        k_mask = (live & (rows >= n_q_rows))[:, None]
 
-        var = tl.sum(x * x, axis=0) / HN
-        inv = 1.0 / tl.sqrt(var + eps)
-        xn = x * inv
+        xq = tl.load(q_ptr + q_off[:, None] + cols[None, :], mask=q_mask, other=0.0)
+        xk = tl.load(k_ptr + (k_row * k_in_rs)[:, None] + cols[None, :], mask=k_mask, other=0.0)
+        x = tl.where(is_q[:, None], xq.to(tl.float32), xk.to(tl.float32))
+
+        var = tl.sum(x * x, axis=1) / HN
+        xn = x * (1.0 / tl.sqrt(var + eps))[:, None]
 
         wq = tl.load(wq_ptr + cols).to(tl.float32)
         wk = tl.load(wk_ptr + cols).to(tl.float32)
-        w = tl.where(is_q, wq, wk)
+        w = tl.where(is_q[:, None], wq[None, :], wk[None, :])
         if ZERO_CENTERED:
             w = w + 1.0
         y = xn * w
 
-        q_store_mask = is_q & (cols < HN)
-        k_store_mask = (row >= n_q_rows) & (cols < HN)
-        tl.store(qo_ptr + q_row * q_out_rs + cols, y.to(qo_ptr.dtype.element_ty), mask=q_store_mask)
-        tl.store(ko_ptr + k_row * k_out_rs + cols, y.to(ko_ptr.dtype.element_ty), mask=k_store_mask)
+        tl.store(
+            qo_ptr + q_row[:, None] * HN + cols[None, :],
+            y.to(qo_ptr.dtype.element_ty),
+            mask=q_mask,
+        )
+        tl.store(
+            ko_ptr + k_row[:, None] * HN + cols[None, :],
+            y.to(ko_ptr.dtype.element_ty),
+            mask=k_mask,
+        )
 
 
 def fused_qk_rmsnorm(
@@ -133,8 +179,9 @@ def fused_qk_rmsnorm(
 
     n_q_rows = q2.shape[0]
     n_rows = n_q_rows + k2.shape[0]
+    assert qo2.stride(0) == hn and ko2.stride(0) == hn  # the kernel stores at stride HN
 
-    _fused_qk_rmsnorm_kernel[(n_rows,)](
+    _fused_qk_rmsnorm_kernel[(triton.cdiv(n_rows, ROWS_PER_CTA),)](
         q2,
         k2,
         qo2,
@@ -142,16 +189,118 @@ def fused_qk_rmsnorm(
         weight_q,
         weight_k,
         n_q_rows,
+        n_rows,
         q2.stride(0),
         k2.stride(0),
-        qo2.stride(0),
-        ko2.stride(0),
         float(eps),
+        0,
         HN=hn,
         ZERO_CENTERED=zero_centered_gamma,
-        num_warps=1,
+        Q_GROUPED=False,
+        NPG=1,
+        HEADS=1,
+        ROWS=ROWS_PER_CTA,
+        num_warps=NUM_WARPS,
     )
     return qo, ko
+
+
+def fused_qk_rmsnorm_grouped(
+    grouped_query: torch.Tensor,
+    key: torch.Tensor,
+    weight_q: torch.Tensor,
+    weight_k: torch.Tensor,
+    eps: float,
+    zero_centered_gamma: bool,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Same norm, but reading the query straight out of the QKV projection.
+
+    Megatron's QKV projection writes ``[sq, b, ng, (np/ng + 2) * hn]`` -- each group's
+    q heads sit next to that group's k and v head. Reshaping the q slice to
+    ``[sq, b, np, hn]`` therefore **cannot** be a view: merging the group axis with the
+    head axis needs the group stride to equal ``(np/ng) * hn``, and it is
+    ``(np/ng + 2) * hn`` instead. For Qwen3-30B that is 1280 against 1024, so
+    `Tensor.reshape` silently materializes the whole query -- one full-size strided copy
+    per layer per step, which showed up in the profile as a 2.8 us
+    ``elementwise_kernel<128,4>`` between the QKV GEMM and this norm and took four
+    attempts to attribute.
+
+    Since this norm already writes a fresh output, it can absorb the repack for free:
+    read with the two strides the grouped layout needs, write the contiguous
+    ``[sq, b, np, hn]`` result the rest of attention wants. Values and arithmetic order
+    are unchanged, so the result is bit-identical to normalizing the copy.
+
+    Args:
+        grouped_query: the q slice of the QKV output, ``[sq, b, ng, (np/ng) * hn]``.
+        key: ``[sq, b, ng, hn]``, as for :func:`fused_qk_rmsnorm`.
+
+    Returns:
+        ``(query_normed, key_normed)``; the query is ``[sq, b, np, hn]`` contiguous.
+    """
+    hn = key.shape[-1]
+    sq, b, ng = grouped_query.shape[0], grouped_query.shape[1], grouped_query.shape[2]
+    npg = grouped_query.shape[3] // hn
+    heads = ng * npg
+
+    k2 = key.reshape(-1, hn)
+    qo = torch.empty(sq, b, heads, hn, dtype=grouped_query.dtype, device=grouped_query.device)
+    ko = torch.empty(key.shape, dtype=key.dtype, device=key.device)
+    qo2 = qo.view(-1, hn)
+    ko2 = ko.view(-1, hn)
+
+    n_q_rows = sq * b * heads
+    n_rows = n_q_rows + k2.shape[0]
+    assert qo2.stride(0) == hn and ko2.stride(0) == hn  # the kernel stores at stride HN
+
+    _fused_qk_rmsnorm_kernel[(triton.cdiv(n_rows, ROWS_PER_CTA),)](
+        grouped_query,
+        k2,
+        qo2,
+        ko2,
+        weight_q,
+        weight_k,
+        n_q_rows,
+        n_rows,
+        0,  # unused: grouped q rows have no single stride
+        k2.stride(0),
+        float(eps),
+        grouped_query.stride(2),
+        HN=hn,
+        ZERO_CENTERED=zero_centered_gamma,
+        Q_GROUPED=True,
+        NPG=npg,
+        HEADS=heads,
+        ROWS=ROWS_PER_CTA,
+        num_warps=NUM_WARPS,
+    )
+    return qo, ko
+
+
+def can_use_grouped_qk_norm(
+    q_layernorm, k_layernorm, grouped_query: torch.Tensor, key: torch.Tensor
+) -> bool:
+    """Whether the grouped-read path is safe, i.e. the copy can be skipped entirely.
+
+    Everything :func:`can_use_fused_qk_norm` requires, plus the two assumptions the
+    grouped addressing makes about the QKV output: that a token's groups are evenly
+    spaced (so a token stride is ``ng * group_stride``), and that the heads inside a
+    group are contiguous.
+    """
+    if not USE_GROUPED_QK_NORM:
+        return False
+    if grouped_query.ndim != 4 or key.ndim != 4:
+        return False
+    hn = key.shape[-1]
+    if grouped_query.shape[3] % hn != 0:
+        return False
+    ng = grouped_query.shape[2]
+    if grouped_query.stride(3) != 1 or grouped_query.stride(1) != ng * grouped_query.stride(2):
+        return False
+    # `key` stands in for the query in the shared check: the grouped query's last dim is
+    # `(np/ng) * hn` rather than `hn`, and every property that check reads off the query
+    # -- head_dim, cuda-ness, last-dim contiguity, token count from `shape[:-2]` -- is
+    # identical between the two here, with the query's own layout verified just above.
+    return can_use_fused_qk_norm(q_layernorm, k_layernorm, key, key)
 
 
 def can_use_fused_qk_norm(q_layernorm, k_layernorm, query: torch.Tensor, key: torch.Tensor) -> bool:

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -35,6 +35,17 @@ from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.mappings import all_gather_last_dim_from_tensor_parallel_region
 from megatron.core.transformer.identity_op import IdentityOp
 from megatron.core.transformer.module import MegatronModule
+
+try:
+    from megatron.core.inference.attention.fused_qk_norm import (
+        can_use_fused_qk_norm as _can_use_fused_qk_norm,
+    )
+    from megatron.core.inference.attention.fused_qk_norm import (
+        fused_qk_rmsnorm as _fused_qk_rmsnorm,
+    )
+except Exception:  # keep attention importable if the inference helper is unavailable
+    _can_use_fused_qk_norm = None
+    _fused_qk_rmsnorm = None
 from megatron.core.transformer.torch_norm import L2Norm, LayerNormBuilder
 from megatron.core.transformer.utils import is_layer_window_attention
 from megatron.core.typed_torch import apply_module, not_none
@@ -1919,11 +1930,24 @@ class SelfAttention(Attention):
             )
             query = query[:, :, idx * size : (idx + 1) * size, :]
 
-        if self.q_layernorm is not None:
-            query = apply_module(self.q_layernorm)(query)
+        if _can_use_fused_qk_norm is not None and _can_use_fused_qk_norm(
+            self.q_layernorm, self.k_layernorm, query, key
+        ):
+            # Fuse the two per-head RMSNorm launches into one (env-gated, decode).
+            query, key = _fused_qk_rmsnorm(
+                query,
+                key,
+                self.q_layernorm.weight,
+                self.k_layernorm.weight,
+                self.config.layernorm_epsilon,
+                self.config.layernorm_zero_centered_gamma,
+            )
+        else:
+            if self.q_layernorm is not None:
+                query = apply_module(self.q_layernorm)(query)
 
-        if self.k_layernorm is not None:
-            key = apply_module(self.k_layernorm)(key)
+            if self.k_layernorm is not None:
+                key = apply_module(self.k_layernorm)(key)
 
         if self.config.test_mode:
             self.run_realtime_tests()

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import copy
 import inspect
+import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Callable, Optional, Protocol, Tuple, Union
@@ -41,11 +42,19 @@ try:
         can_use_fused_qk_norm as _can_use_fused_qk_norm,
     )
     from megatron.core.inference.attention.fused_qk_norm import (
+        can_use_grouped_qk_norm as _can_use_grouped_qk_norm,
+    )
+    from megatron.core.inference.attention.fused_qk_norm import (
         fused_qk_rmsnorm as _fused_qk_rmsnorm,
+    )
+    from megatron.core.inference.attention.fused_qk_norm import (
+        fused_qk_rmsnorm_grouped as _fused_qk_rmsnorm_grouped,
     )
 except Exception:  # keep attention importable if the inference helper is unavailable
     _can_use_fused_qk_norm = None
     _fused_qk_rmsnorm = None
+    _can_use_grouped_qk_norm = None
+    _fused_qk_rmsnorm_grouped = None
 from megatron.core.transformer.torch_norm import L2Norm, LayerNormBuilder
 from megatron.core.transformer.utils import is_layer_window_attention
 from megatron.core.typed_torch import apply_module, not_none
@@ -66,6 +75,10 @@ from ..models.common.embeddings.yarn_rotary_pos_embedding import (
 )
 from .enums import AttnMaskType
 from .transformer_config import TransformerConfig
+
+# Split QKV with torch.split (views) instead of TE's SplitAlongDim. Under test as the
+# suspected source of one full-QKV-sized copy per decode layer; see COPY-ID-S18.
+_QKV_SPLIT_VIEWS: bool = os.environ.get("MCORE_QKV_SPLIT_VIEWS", "0") == "1"
 
 try:
     from einops import rearrange
@@ -1893,7 +1906,7 @@ class SelfAttention(Attention):
                 self.hidden_size_per_attention_head,
             ]
 
-            if SplitAlongDim is not None:
+            if SplitAlongDim is not None and not _QKV_SPLIT_VIEWS:
                 query, gate, key, value = SplitAlongDim(mixed_qkv, 3, split_arg_list)
             else:
                 query, gate, key, value = torch.split(mixed_qkv, split_arg_list, dim=3)
@@ -1910,31 +1923,23 @@ class SelfAttention(Attention):
             if not split_qkv:
                 return mixed_qkv, split_arg_list
 
-            if SplitAlongDim is not None:
+            if SplitAlongDim is not None and not _QKV_SPLIT_VIEWS:
                 query, key, value = SplitAlongDim(mixed_qkv, 3, split_arg_list)
             else:
                 query, key, value = torch.split(mixed_qkv, split_arg_list, dim=3)
 
-        # Query [sq, b, ng, np/ng * hn] -> [sq, b, np, hn]
-        query = query.reshape(query.size(0), query.size(1), -1, self.hidden_size_per_attention_head)
-
-        if self.config.num_query_groups < self.world_size:
-            # query above corresponds to (num_q_heads / num_kv_heads) q_heads.
-            # Index appropriately into query to get (num_q_heads / tp_size) q_heads.
-            # This is step 4 in the list of steps above.
-            idx = get_pg_rank(self.pg_collection.tp) % (
-                self.world_size // self.config.num_query_groups
-            )
-            size = self.num_attention_heads_per_partition // (
-                self.world_size // self.config.num_query_groups
-            )
-            query = query[:, :, idx * size : (idx + 1) * size, :]
-
-        if _can_use_fused_qk_norm is not None and _can_use_fused_qk_norm(
-            self.q_layernorm, self.k_layernorm, query, key
+        # The [sq, b, ng, np/ng * hn] -> [sq, b, np, hn] reshape below is a *copy*, not a
+        # view: merging the group and head axes needs the group stride to equal
+        # (np/ng) * hn, and it is (np/ng + 2) * hn because each group's k and v head sit
+        # between consecutive groups' q heads. When the fused q/k norm can read the
+        # grouped layout directly it writes that shape itself for free, and the copy --
+        # one full-size strided copy per layer per decode step -- never happens.
+        if (
+            _can_use_grouped_qk_norm is not None
+            and self.config.num_query_groups >= self.world_size
+            and _can_use_grouped_qk_norm(self.q_layernorm, self.k_layernorm, query, key)
         ):
-            # Fuse the two per-head RMSNorm launches into one (env-gated, decode).
-            query, key = _fused_qk_rmsnorm(
+            query, key = _fused_qk_rmsnorm_grouped(
                 query,
                 key,
                 self.q_layernorm.weight,
@@ -1943,11 +1948,41 @@ class SelfAttention(Attention):
                 self.config.layernorm_zero_centered_gamma,
             )
         else:
-            if self.q_layernorm is not None:
-                query = apply_module(self.q_layernorm)(query)
+            # Query [sq, b, ng, np/ng * hn] -> [sq, b, np, hn]
+            query = query.reshape(
+                query.size(0), query.size(1), -1, self.hidden_size_per_attention_head
+            )
 
-            if self.k_layernorm is not None:
-                key = apply_module(self.k_layernorm)(key)
+            if self.config.num_query_groups < self.world_size:
+                # query above corresponds to (num_q_heads / num_kv_heads) q_heads.
+                # Index appropriately into query to get (num_q_heads / tp_size) q_heads.
+                # This is step 4 in the list of steps above.
+                idx = get_pg_rank(self.pg_collection.tp) % (
+                    self.world_size // self.config.num_query_groups
+                )
+                size = self.num_attention_heads_per_partition // (
+                    self.world_size // self.config.num_query_groups
+                )
+                query = query[:, :, idx * size : (idx + 1) * size, :]
+
+            if _can_use_fused_qk_norm is not None and _can_use_fused_qk_norm(
+                self.q_layernorm, self.k_layernorm, query, key
+            ):
+                # Fuse the two per-head RMSNorm launches into one (env-gated, decode).
+                query, key = _fused_qk_rmsnorm(
+                    query,
+                    key,
+                    self.q_layernorm.weight,
+                    self.k_layernorm.weight,
+                    self.config.layernorm_epsilon,
+                    self.config.layernorm_zero_centered_gamma,
+                )
+            else:
+                if self.q_layernorm is not None:
+                    query = apply_module(self.q_layernorm)(query)
+
+                if self.k_layernorm is not None:
+                    key = apply_module(self.k_layernorm)(key)
 
         if self.config.test_mode:
             self.run_realtime_tests()


### PR DESCRIPTION
> Stacked on #6459. Review that one first; this diff is only teaching that PR's fused Q/K
>
> GitHub cannot base a pull request from a fork on another unmerged fork branch, so the diff below also contains the parent's commits. This PR's own change is the final commit, `0f4686d82`; review that one. The rest lands with the parent.
> norm to read the query out of the grouped QKV projection output instead of out of a
> repacked copy, and retiling its launch.

## Summary

Megatron's QKV projection writes `[sq, b, ng, (np/ng + 2) * hn]`, so each group's q heads
sit beside that group's k and v head. Reshaping the q slice to `[sq, b, np, hn]` therefore
cannot be a view — merging the group axis with the head axis needs a group stride of
`(np/ng) * hn` and the actual stride is `(np/ng + 2) * hn`, 1024 against 1280 for this
model — so `Tensor.reshape` silently materializes the entire query, one full-size strided
copy per layer per decode step. Making the fused norm address the grouped layout directly
with two strides, and write the contiguous result the rest of attention wants, absorbs that
repack into a store the norm was already paying for: **+1.18%** end-to-end decode
throughput.

The copy was expensive to find rather than expensive to fix. It has no name in the source —
it appears in the profile as a 2.8 µs `elementwise_kernel<128, 4>` sitting between the QKV
GEMM and the norm — and it took four attempts to attribute. The second half of this diff is
an unrelated change to the same kernel's launch shape: eight rows per CTA instead of one,
which doubles its achieved bandwidth.

## Why here

Two measurements on the same kernel.

The copy: a steady-state decode profile shows one `elementwise_kernel<128, 4>` per layer
between the QKV GEMM and the Q/K norm, ~2.8 µs each, ~0.13 ms/step across 48 layers. It is
on the serial attention dependency chain — RoPE cannot start until the query is normalized,
and the norm cannot start until the copy lands.

The launch shape: the parent's kernel moves about 4.5 MB in 8.22 µs, roughly 570 GB/s on a
GB200. One CTA per row is the obvious choice for a 128-wide row and it is the wrong one,
because at 256 tokens it puts 9,216 single-warp CTAs on the device (8,192 query rows plus
1,024 key rows). A rows × warps sweep, keeping only bit-exact candidates, found eight rows
at eight warps to be exactly 2× the one-row point and the best in the space.

## What changed

**Before.** `get_query_key_value_tensors` splits the projection output, reshapes the q slice
to `[sq, b, np, hn]` — a copy, per the stride arithmetic above — optionally takes the
tensor-parallel head slice, and hands the result to the norm.

**After.** When the grouped path is eligible, the reshape and the slice are skipped entirely
and the raw `[sq, b, ng, (np/ng) * hn]` slice goes to the kernel. A query row's address now
needs two strides rather than one, because no single row stride exists: flat head index `h`
becomes group `h // NPG` at the runtime group stride and head `h % NPG` inside it at a
compile-time `HN`. That is exactly the mapping `reshape` produced, so the output ordering is
unchanged. The key half is untouched.

The saving is the whole copy, not a fraction of it. The norm already allocates a fresh
contiguous `[sq, b, np, hn]` output and already writes every element of it; changing where
it *reads* from adds no traffic, so the copy's device time is deleted rather than moved.

**Launch shape.** The kernel now processes `ROWS` rows per program instead of one, masked at
the tail, with the reduction over the head dimension moved from `axis=0` to `axis=1` of an
`[ROWS, HN]` tile. Defaults are eight rows and eight warps, overridable through
`MCORE_QK_NORM_ROWS` and `MCORE_QK_NORM_WARPS` so the sweep can be repeated on other
hardware. The output row stride is now a compile-time `HN` rather than a kernel argument,
since both output tensors are allocated inside this module and are contiguous; an assertion
enforces that in both entry points.

Size the retiling honestly: it removes about 2.06 µs per layer, roughly 0.10 ms/step of
device time across 48 layers, and only a fraction of that converted end-to-end — this
kernel is not the step's critical path, so a device-time sum over it is an upper bound and
not a forecast.

## Measurement

Fixed protocol: Qwen3-30B-A3B, BF16, TP 1 / PP 1 / EP 4 / ETP 1, 256 gsm8k requests, 1024 output tokens, 2 warmup + 5 timed iterations, a single OCI 4xGB200 node (nvl72160-T04), async dynamic-batching scheduler pinned on. All 20 arms ran back to back in one allocation on that one node; node-to-node variance on this workload is around 2.7%, so cross-node numbers would not be comparable.

- With this change (every other gate in the stack enabled): **31,554 tok/s**
- Without it (same node, same session, only this gate turned off): **31,185 tok/s**
- Leave-one-out delta: **+1.18%**
- Noise floor: sigma = **0.42%** over 3 repeats of the all-gates-on reference
- Verdict: **resolved** by margin (2.8 sigma). The per-iteration distributions do not separate strictly, but only because each reference arm contains one low outlier iteration; excluding those the arms do not overlap.

This is the **marginal contribution measured with every other gate in this stack enabled** — the question a reviewer is actually asking, which is whether this should land, not what it was worth when it was first written.

The reference is drift-corrected. The all-gates-on configuration was re-measured three times across the session (31,745, 31,530, 31,503 tok/s), a +0.77% drift from first to last, so each arm is compared against the reference interpolated to its own position in the run order rather than against a session mean.

For context, the whole stack is worth **+35.80%** on this node (23,265 tok/s with every gate off, 31,593 with every gate on). Per-slice deltas do not sum to that; they compose sub-additively.

## Evidence

Launch-shape sweep, microbench under CUDA-graph replay at the decode point (BS256, 256
tokens), bit-exact candidates only:

| rows/CTA | warps | µs | GB/s | vs 1×1 |
|---:|---:|---:|---:|---:|
| 1 | 1 | 8.21 | 574 | 1.00× |
| 2 | 2 | 6.17 | 765 | 1.33× |
| 4 | 4 | 6.15 | 767 | 1.34× |
| **8** | **8** | **4.12** | **1146** | **2.00×** |

A PTX-level comparison confirms the shipped kernel is at the standalone harness's number
rather than behind it: both measure 4.12 µs, 21 registers, no spills, `.v2` vectorized loads
and stores. That check exists because an in-tree reading of 6.15 µs was carried through three
separate hypotheses, each of which measured 6.15 µs again and was rejected for the right
reason — every one of them was profiling a kernel that was already fast. The 6.15 µs
readings were stale.

Liveness, from a steady-state decode profile: the `elementwise_kernel<128, 4>` between the
QKV GEMM and the norm is absent, and `_fused_qk_rmsnorm_kernel` still appears once per layer.
Confirm both before trusting an A/B arm — the gate declines silently, and a declining gate
looks exactly like a change that does not help.

## Correctness

- **Numerics:** **bit-exact against the parent's fused kernel.** This is structural, not
  luck. The reduction is still an fp32 mean-of-squares over the same 128 values of the same
  row in the same order, `rsqrt(var + eps)` is unchanged, the gamma handling is unchanged,
  and the flat-head-to-(group, head) mapping is the one `reshape` used. Only the load
  addresses and the CTA tiling change, and the launch sweep admitted only candidates that
  were bit-exact.
- **Inherited, and not re-litigated here:** the fused kernel is *not* bit-exact against
  TransformerEngine's two-call path — it is within one bf16 ulp, `max_rel ≤ 7.6e-3` — because
  TE's internal rsqrt and reduction order differ. That is the parent's claim and this diff
  neither improves nor worsens it.
- **Tests:** microbench MATCH against the parent's kernel at 128/256/384/512 tokens × 2
  seeds; the rows × warps sweep discarded any candidate that was not bit-exact.
- **Coherence:** generated text is identical character for character to the parent-only arm,
  which is what bit-exactness requires and is therefore the check that would have caught an
  addressing error.

## Gating and blast radius

- Gate: `MCORE_GROUPED_QK_NORM`, **default OFF** (`os.environ.get(..., "0") == "1"`). Unset,
  `can_use_grouped_qk_norm` returns `False` on its first condition and control flows into the
  reshape-then-normalize path, byte-identical to before this PR.
- **It also requires the parent's gate.** `can_use_grouped_qk_norm` delegates to
  `can_use_fused_qk_norm`, which checks `MCORE_FUSED_QK_NORM`, so with the parent's gate
  unset this one cannot engage regardless of its own setting.
- Preconditions checked by the guard: 4-D grouped query and key; the grouped last dim a
  multiple of `head_dim`; last dim contiguous; and the two layout assumptions the addressing
  makes — evenly spaced groups (`stride(1) == ng * stride(2)`) and contiguous heads inside a
  group. The call site adds `num_query_groups >= world_size`, so the path **declines whenever
  tensor parallelism requires the query head slice**, since the grouped read bypasses that
  slice. Everything `can_use_fused_qk_norm` requires still applies, including the token cap.
- When any precondition fails: the reshape, the head slice and the parent's fused kernel (or
  the two TE calls) run exactly as before. Training never satisfies the token cap and does not
  set the gates.
- **Not gated:** the eight-rows-per-CTA launch shape applies to the parent's ungrouped entry
  point too, so merging this PR changes what `MCORE_FUSED_QK_NORM=1` alone produces. The
  shape is bit-exact, so this is a speed change and not a numerics change, and
  `MCORE_QK_NORM_ROWS=1 MCORE_QK_NORM_WARPS=1` restores the parent's launch exactly.
- Second gate: `MCORE_QKV_SPLIT_VIEWS`, **default OFF**, forces `torch.split` instead of
  TransformerEngine's `SplitAlongDim` at both QKV split sites. It was the instrument used to
  test whether the splitter itself was materializing the per-layer copy; it was not, the
  `reshape` was. See "What this does not claim".

## Reproduce

```bash
MCORE_FUSED_QK_NORM=1 MCORE_GROUPED_QK_NORM=1 \
QWEN30B_TP=1 QWEN30B_EP=4 QWEN30B_ETP=1 \
BENCH_SIZES_OVERRIDE=256 BENCH_OUTPUT_TOKENS=1024 \
NUM_WARMUP_ITERS=2 NUM_TIMED_ITERS=5 \
bash skills/run-qwen-model/run_qwen_inference.sh qwen3-30b-a3b --checkpoint "$QWEN30B_CKPT"
```

Triton is required; without it `HAVE_TRITON` is `False` and both guards decline.

## What this does not claim

- **The 256-token cap is inherited, not re-derived.** `MCORE_FUSED_QK_NORM_MAX_TOKENS`
  defaults to 256 because the parent measured 1.25× at 256 tokens and 0.83× at 384 *with one
  row per CTA*. This PR changes that launch shape and there is no above-256 measurement for
  the new one. Keeping the cap is the conservative choice; the guard comment still cites the
  old numbers and should be read as a bound that has not been re-validated rather than as a
  boundary that has been shown to be right.
- **Nothing at tensor-parallel sizes that split query groups.** With
  `num_query_groups < world_size` the query needs a per-rank head slice that the grouped read
  does not perform, and the call site declines. That configuration keeps the parent's
  behaviour.
- **No measured effect for `MCORE_QKV_SPLIT_VIEWS`.** It is a default-off escape hatch left in
  place because the two splitters are interchangeable here; no part of the delta is attributed
  to it and nobody should re-run it expecting one.
- **The retiling's device-time saving is an upper bound.** About 0.10 ms/step of kernel time
  disappears and materially less than that reached the wall clock, because this kernel is not
  the binding constraint on the step.
- The claim that the runtime output stride would block store vectorization is *not* made here.
  The stride is a compile-time constant because it is provably constant, and the one
  experiment on record that isolated it did not reproduce a difference.
- Deltas in this stack do not add. This change, the parent, and the residual/norm fusions all
  attack the same serial attention chain and the same host dispatch gaps, so they compose
  sub-additively.

## Follow-ups

- Re-derive the token cap for the eight-row shape. The kernel that lost to TE above 256 tokens
  is not the kernel that ships here, and the cap may now be too tight.
- The grouped addressing could absorb the tensor-parallel head slice as well, which would
  remove the `num_query_groups >= world_size` precondition and extend the win to sharded
  query groups.

---

## This stack

This is one slice of [#6064](https://github.com/NVIDIA/Megatron-LM/pull/6064), a Qwen3-30B-A3B decode optimization campaign, split into 16 independently reviewable changes. Together they are **+35.80%** end-to-end throughput over the same base commit (23,265 -> 31,593 tok/s, mean of three full runs).

- **MoE grouped-GEMM and dispatch:** #6452 -> #6453 -> #6454 -> #6455
- **MoE router and combine:** #6456 -> #6457 -> #6458
- **Attention: QK norm and decode kernel:** #6459 -> #6460 -> #6461 -> #6462
- **Residual + RMSNorm fusion:** #6463 -> #6464
- **Host path: context bookkeeping:** #6465 -> #6466
- **Host path: independent:** #6467

Each chain is independent of the others and bases on `main`. Within a chain, later PRs depend on earlier ones.

### Per-slice measured delta

Every number is a leave-one-out delta from one same-node, same-session campaign: the full stack with exactly this change's gate off, against the interpolated full-stack reference at that point in the run. It is the change's *marginal* contribution with everything else already in, not its standalone value. Run-to-run sigma was **0.42%** across three full-stack repeats.

| PR | Change | Delta | |
|---|---|---|---|
| #6452 | FC1 SwiGLU epilogue | +14.81% | resolved |
| #6453 | indirection table fusion | +7.21% | resolved |
| #6454 | decode GEMM tile configs | +6.77% | resolved |
| #6455 | predicated top-k gather | +1.99% | by margin |
| #6456 | fused router softmax+top-k | +4.75% | resolved |
| #6457 | fused route padding mask | +1.47% | by margin |
| #6458 | bf16 MoE combine | +2.42% | by margin |
| #6459 | fused QK RMSNorm | +5.17% | resolved |
| #6460 | grouped QK norm input | +1.18% | by margin |
| #6461 | pin FlashAttention 2 | -0.35% | noise floor |
| #6462 | FlashInfer TRT-LLM decode | +1.46% | by margin |
| #6463 | fused add+norm pre-MLP | +3.54% | by margin |
| #6464 | fused add+norm pre-QKV | +0.98% | by margin |
| #6465 | incremental attention state | -0.42% | noise floor |
| #6466 | vectorized decode bookkeeping | -0.07% | noise floor |
| #6467 | post_process_requests fast path | +0.09% | noise floor |

`noise floor` means the delta is inside 2 sigma (0.84%) and this campaign cannot distinguish it from zero. `resolved` means the leave-one-out and full-stack iteration distributions did not overlap. Deltas do not sum to the stack total: these changes shorten the same decode step and compose sub-additively.

**Fixed protocol for every number above.** Qwen3-30B-A3B, BF16, TP1/PP1/EP4/ETP1, 256 gsm8k requests at batch size 256, output length 1024, CUDA graphs on, one OCI GB200 NVL72 node, 4 GPUs. All 20 arms ran back-to-back in a single Slurm allocation on one node, so node assignment and thermal state are held constant.
