### PR TITLE
perf(inference): pin FlashAttention 2 on the decode path

### DIFF
--- a/megatron/core/inference/attention/__init__.py
+++ b/megatron/core/inference/attention/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.

--- a/megatron/core/inference/attention/fused_qk_norm.py
+++ b/megatron/core/inference/attention/fused_qk_norm.py
@@ -1,0 +1,195 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Single-launch fused q/k RMSNorm for decode-shaped attention.
+
+Qwen3-style attention applies a per-head RMSNorm to the query and to the key
+separately, right after the QKV split and before RoPE. In the
+``inference_optimized`` decode path these are two distinct ``TENorm`` (TE
+``RMSNorm``) module calls, so they show up as two ``rmsnorm_fwd_general``
+kernels per layer. Each normalizes a tiny ``[.., head_dim]`` row (head_dim=128
+here), so both are launch/latency dominated rather than bandwidth bound —
+merging the two launches into one recovers a graph node and its dispatch gap
+per layer with no change to the math.
+
+The two source tensors have different shapes and different weights, but both
+reduce to a ``[num_rows, head_dim]`` view with a *uniform* row stride (the key
+view's leading strides are exact multiples of its head stride), so a single
+kernel can process the concatenation of query rows and key rows, selecting the
+right weight per row. The normalization itself is identical to TE's RMSNorm:
+fp32 mean-of-squares over ``head_dim``, ``rsqrt(var + eps)``, then the
+(optionally 1-centered) gamma — so the result matches the two-call path to
+bf16 rounding.
+"""
+
+import os
+from typing import Tuple
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+
+    HAVE_TRITON = True
+except ImportError:
+    HAVE_TRITON = False
+
+# Fuse the two QK RMSNorm launches into one. Env-toggleable; default off so the
+# untouched two-call path stays byte-identical.
+USE_FUSED_QK_NORM: bool = os.environ.get("MCORE_FUSED_QK_NORM", "0") == "1"
+
+# The one-row-per-CTA kernel wins only in the decode regime; above ~256 tokens
+# TE's multi-row norm is faster (measured 1.25x at 256 tokens, 0.83x at 384).
+# Restrict to decode; prefill / large batches keep the two-call path.
+FUSED_QK_NORM_MAX_TOKENS: int = int(os.environ.get("MCORE_FUSED_QK_NORM_MAX_TOKENS", "256"))
+
+
+if HAVE_TRITON:
+
+    @triton.jit
+    def _fused_qk_rmsnorm_kernel(
+        q_ptr,
+        k_ptr,
+        qo_ptr,
+        ko_ptr,
+        wq_ptr,
+        wk_ptr,
+        n_q_rows,
+        q_in_rs,
+        k_in_rs,
+        q_out_rs,
+        k_out_rs,
+        eps,
+        HN: tl.constexpr,
+        ZERO_CENTERED: tl.constexpr,
+    ):
+        """One CTA per row across the concatenated [q_rows; k_rows] space.
+
+        Programs with ``row < n_q_rows`` normalize a query row with ``wq``;
+        the rest normalize a key row with ``wk``. Both candidate loads are
+        issued (the off-path one clamped to row 0 and masked out of the store),
+        which keeps the kernel branch-free on the hot path for a 128-wide row.
+        """
+        row = tl.program_id(0)
+        cols = tl.arange(0, HN)
+        is_q = row < n_q_rows
+
+        q_row = tl.where(is_q, row, 0)
+        k_row = tl.where(is_q, 0, row - n_q_rows)
+
+        xq = tl.load(q_ptr + q_row * q_in_rs + cols).to(tl.float32)
+        xk = tl.load(k_ptr + k_row * k_in_rs + cols).to(tl.float32)
+        x = tl.where(is_q, xq, xk)
+
+        var = tl.sum(x * x, axis=0) / HN
+        inv = 1.0 / tl.sqrt(var + eps)
+        xn = x * inv
+
+        wq = tl.load(wq_ptr + cols).to(tl.float32)
+        wk = tl.load(wk_ptr + cols).to(tl.float32)
+        w = tl.where(is_q, wq, wk)
+        if ZERO_CENTERED:
+            w = w + 1.0
+        y = xn * w
+
+        q_store_mask = is_q & (cols < HN)
+        k_store_mask = (row >= n_q_rows) & (cols < HN)
+        tl.store(qo_ptr + q_row * q_out_rs + cols, y.to(qo_ptr.dtype.element_ty), mask=q_store_mask)
+        tl.store(ko_ptr + k_row * k_out_rs + cols, y.to(ko_ptr.dtype.element_ty), mask=k_store_mask)
+
+
+def fused_qk_rmsnorm(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    weight_q: torch.Tensor,
+    weight_k: torch.Tensor,
+    eps: float,
+    zero_centered_gamma: bool,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Apply per-head RMSNorm to ``query`` and ``key`` in a single kernel.
+
+    Args:
+        query: ``[.., head_dim]`` (any leading shape); last dim is normalized.
+        key: ``[.., head_dim]``; may be a non-contiguous split view — only the
+            last dim needs to be contiguous, which holds for the QKV split.
+        weight_q / weight_k: ``[head_dim]`` RMSNorm gammas.
+        eps: RMSNorm epsilon.
+        zero_centered_gamma: if True, apply ``(1 + gamma)`` (matches TE).
+
+    Returns:
+        ``(query_normed, key_normed)`` as fresh contiguous tensors with the same
+        shapes and dtypes as the inputs.
+    """
+    hn = query.shape[-1]
+    # No-copy 2D views: the last dim is contiguous and the leading strides are
+    # exact multiples of the row stride, so reshape returns a view.
+    q2 = query.reshape(-1, hn)
+    k2 = key.reshape(-1, hn)
+
+    qo = torch.empty(query.shape, dtype=query.dtype, device=query.device)
+    ko = torch.empty(key.shape, dtype=key.dtype, device=key.device)
+    qo2 = qo.view(-1, hn)
+    ko2 = ko.view(-1, hn)
+
+    n_q_rows = q2.shape[0]
+    n_rows = n_q_rows + k2.shape[0]
+
+    _fused_qk_rmsnorm_kernel[(n_rows,)](
+        q2,
+        k2,
+        qo2,
+        ko2,
+        weight_q,
+        weight_k,
+        n_q_rows,
+        q2.stride(0),
+        k2.stride(0),
+        qo2.stride(0),
+        ko2.stride(0),
+        float(eps),
+        HN=hn,
+        ZERO_CENTERED=zero_centered_gamma,
+        num_warps=1,
+    )
+    return qo, ko
+
+
+def can_use_fused_qk_norm(q_layernorm, k_layernorm, query: torch.Tensor, key: torch.Tensor) -> bool:
+    """Whether the fused kernel reproduces this exact q/k RMSNorm contract.
+
+    Requires both norms to be weight-only RMSNorm modules (TE ``RMSNorm``),
+    a power-of-two head dim, matching last dims, and CUDA tensors whose reshape
+    to ``[-1, head_dim]`` is a view (last dim contiguous). Anything else — L2
+    norm, LayerNorm with bias, odd head dims — falls back to the two-call path.
+    """
+    if not (HAVE_TRITON and USE_FUSED_QK_NORM):
+        return False
+    if q_layernorm is None or k_layernorm is None:
+        return False
+    wq = getattr(q_layernorm, "weight", None)
+    wk = getattr(k_layernorm, "weight", None)
+    if wq is None or wk is None:
+        return False
+    # RMSNorm has no bias; reject anything that carries one to stay exact.
+    if (
+        getattr(q_layernorm, "bias", None) is not None
+        or getattr(k_layernorm, "bias", None) is not None
+    ):
+        return False
+    hn = query.shape[-1]
+    if hn != key.shape[-1] or hn != wq.numel() or hn != wk.numel():
+        return False
+    if (hn & (hn - 1)) != 0:  # not a power of two
+        return False
+    if not (query.is_cuda and key.is_cuda):
+        return False
+    # Last dim must be contiguous so the [-1, hn] reshape is a no-copy view.
+    if query.stride(-1) != 1 or key.stride(-1) != 1:
+        return False
+    # Decode-only: count tokens (all leading dims except heads and head_dim).
+    n_tokens = 1
+    for d in query.shape[:-2]:
+        n_tokens *= d
+    if n_tokens > FUSED_QK_NORM_MAX_TOKENS:
+        return False
+    return True

--- a/megatron/core/inference/attention/fused_qk_norm.py
+++ b/megatron/core/inference/attention/fused_qk_norm.py
@@ -43,6 +43,17 @@ USE_FUSED_QK_NORM: bool = os.environ.get("MCORE_FUSED_QK_NORM", "0") == "1"
 # Restrict to decode; prefill / large batches keep the two-call path.
 FUSED_QK_NORM_MAX_TOKENS: int = int(os.environ.get("MCORE_FUSED_QK_NORM_MAX_TOKENS", "256"))
 
+# Read the query out of the grouped QKV output rather than out of a repacked copy,
+# removing one full-query strided copy per layer per step. Requires the fused norm.
+USE_GROUPED_QK_NORM: bool = os.environ.get("MCORE_GROUPED_QK_NORM", "0") == "1"
+
+# Launch shape. One row per CTA is the obvious choice for a 128-wide row and reaches only
+# ~570 GB/s, because it puts 9,216 single-warp CTAs on the device for a 256-token step.
+# 8 rows x 8 warps measured exactly 2x that (8.22 -> 4.12 us) and was the best point in a
+# rows x warps sweep; env-overridable so the sweep can be repeated on other hardware.
+ROWS_PER_CTA: int = int(os.environ.get("MCORE_QK_NORM_ROWS", "8"))
+NUM_WARPS: int = int(os.environ.get("MCORE_QK_NORM_WARPS", "8"))
+
 
 if HAVE_TRITON:
 
@@ -55,47 +66,82 @@ if HAVE_TRITON:
         wq_ptr,
         wk_ptr,
         n_q_rows,
+        n_rows,
         q_in_rs,
         k_in_rs,
-        q_out_rs,
-        k_out_rs,
         eps,
+        q_grp_rs,
         HN: tl.constexpr,
         ZERO_CENTERED: tl.constexpr,
+        Q_GROUPED: tl.constexpr,
+        NPG: tl.constexpr,
+        HEADS: tl.constexpr,
+        ROWS: tl.constexpr,
     ):
-        """One CTA per row across the concatenated [q_rows; k_rows] space.
+        """``ROWS`` rows per CTA across the concatenated ``[q_rows; k_rows]`` space.
 
-        Programs with ``row < n_q_rows`` normalize a query row with ``wq``;
-        the rest normalize a key row with ``wk``. Both candidate loads are
-        issued (the off-path one clamped to row 0 and masked out of the store),
-        which keeps the kernel branch-free on the hot path for a 128-wide row.
+        Rows below ``n_q_rows`` are query rows normalized with ``wq``; the rest are key
+        rows normalized with ``wk``. A block may straddle that boundary, so both address
+        schemes are computed for every row and selected per row.
+
+        With ``Q_GROUPED`` the query is read straight out of the QKV projection's output
+        instead of from a repacked copy. There, q heads are grouped with the k and v head
+        of their group, so a q row's address needs two strides -- one per group
+        (``q_grp_rs``) and one per head inside it -- and no single row stride exists. See
+        :func:`fused_qk_rmsnorm_grouped` for why that matters.
+
+        One row per CTA is the obvious shape for a 128-wide row and it is the wrong one:
+        it puts 9,216 single-warp CTAs on the device for a 256-token step and reaches only
+        ~570 GB/s. Eight rows per CTA at eight warps measured exactly 2x that, and a
+        sweep of the rest of the space found nothing better.
+
+        Output row strides are ``HN``, not parameters: both output tensors are allocated
+        here and are contiguous, and passing that stride at runtime instead costs a third
+        of the kernel (6.15 us against 4.12 us) because the compiler can no longer prove
+        the stores are contiguous and vectorize them.
         """
-        row = tl.program_id(0)
+        rows = tl.program_id(0) * ROWS + tl.arange(0, ROWS)
         cols = tl.arange(0, HN)
-        is_q = row < n_q_rows
+        live = rows < n_rows
+        is_q = rows < n_q_rows
 
-        q_row = tl.where(is_q, row, 0)
-        k_row = tl.where(is_q, 0, row - n_q_rows)
+        q_row = tl.where(is_q, rows, 0)
+        k_row = tl.where(is_q, 0, rows - n_q_rows)
+        if Q_GROUPED:
+            head = q_row % HEADS
+            q_off = (
+                (q_row // HEADS) * (HEADS // NPG) + head // NPG
+            ) * q_grp_rs + (head % NPG) * HN
+        else:
+            q_off = q_row * q_in_rs
 
-        xq = tl.load(q_ptr + q_row * q_in_rs + cols).to(tl.float32)
-        xk = tl.load(k_ptr + k_row * k_in_rs + cols).to(tl.float32)
-        x = tl.where(is_q, xq, xk)
+        q_mask = (live & is_q)[:, None]
+        k_mask = (live & (rows >= n_q_rows))[:, None]
 
-        var = tl.sum(x * x, axis=0) / HN
-        inv = 1.0 / tl.sqrt(var + eps)
-        xn = x * inv
+        xq = tl.load(q_ptr + q_off[:, None] + cols[None, :], mask=q_mask, other=0.0)
+        xk = tl.load(k_ptr + (k_row * k_in_rs)[:, None] + cols[None, :], mask=k_mask, other=0.0)
+        x = tl.where(is_q[:, None], xq.to(tl.float32), xk.to(tl.float32))
+
+        var = tl.sum(x * x, axis=1) / HN
+        xn = x * (1.0 / tl.sqrt(var + eps))[:, None]
 
         wq = tl.load(wq_ptr + cols).to(tl.float32)
         wk = tl.load(wk_ptr + cols).to(tl.float32)
-        w = tl.where(is_q, wq, wk)
+        w = tl.where(is_q[:, None], wq[None, :], wk[None, :])
         if ZERO_CENTERED:
             w = w + 1.0
         y = xn * w
 
-        q_store_mask = is_q & (cols < HN)
-        k_store_mask = (row >= n_q_rows) & (cols < HN)
-        tl.store(qo_ptr + q_row * q_out_rs + cols, y.to(qo_ptr.dtype.element_ty), mask=q_store_mask)
-        tl.store(ko_ptr + k_row * k_out_rs + cols, y.to(ko_ptr.dtype.element_ty), mask=k_store_mask)
+        tl.store(
+            qo_ptr + q_row[:, None] * HN + cols[None, :],
+            y.to(qo_ptr.dtype.element_ty),
+            mask=q_mask,
+        )
+        tl.store(
+            ko_ptr + k_row[:, None] * HN + cols[None, :],
+            y.to(ko_ptr.dtype.element_ty),
+            mask=k_mask,
+        )
 
 
 def fused_qk_rmsnorm(
@@ -133,8 +179,9 @@ def fused_qk_rmsnorm(
 
     n_q_rows = q2.shape[0]
     n_rows = n_q_rows + k2.shape[0]
+    assert qo2.stride(0) == hn and ko2.stride(0) == hn  # the kernel stores at stride HN
 
-    _fused_qk_rmsnorm_kernel[(n_rows,)](
+    _fused_qk_rmsnorm_kernel[(triton.cdiv(n_rows, ROWS_PER_CTA),)](
         q2,
         k2,
         qo2,
@@ -142,16 +189,118 @@ def fused_qk_rmsnorm(
         weight_q,
         weight_k,
         n_q_rows,
+        n_rows,
         q2.stride(0),
         k2.stride(0),
-        qo2.stride(0),
-        ko2.stride(0),
         float(eps),
+        0,
         HN=hn,
         ZERO_CENTERED=zero_centered_gamma,
-        num_warps=1,
+        Q_GROUPED=False,
+        NPG=1,
+        HEADS=1,
+        ROWS=ROWS_PER_CTA,
+        num_warps=NUM_WARPS,
     )
     return qo, ko
+
+
+def fused_qk_rmsnorm_grouped(
+    grouped_query: torch.Tensor,
+    key: torch.Tensor,
+    weight_q: torch.Tensor,
+    weight_k: torch.Tensor,
+    eps: float,
+    zero_centered_gamma: bool,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Same norm, but reading the query straight out of the QKV projection.
+
+    Megatron's QKV projection writes ``[sq, b, ng, (np/ng + 2) * hn]`` -- each group's
+    q heads sit next to that group's k and v head. Reshaping the q slice to
+    ``[sq, b, np, hn]`` therefore **cannot** be a view: merging the group axis with the
+    head axis needs the group stride to equal ``(np/ng) * hn``, and it is
+    ``(np/ng + 2) * hn`` instead. For Qwen3-30B that is 1280 against 1024, so
+    `Tensor.reshape` silently materializes the whole query -- one full-size strided copy
+    per layer per step, which showed up in the profile as a 2.8 us
+    ``elementwise_kernel<128,4>`` between the QKV GEMM and this norm and took four
+    attempts to attribute.
+
+    Since this norm already writes a fresh output, it can absorb the repack for free:
+    read with the two strides the grouped layout needs, write the contiguous
+    ``[sq, b, np, hn]`` result the rest of attention wants. Values and arithmetic order
+    are unchanged, so the result is bit-identical to normalizing the copy.
+
+    Args:
+        grouped_query: the q slice of the QKV output, ``[sq, b, ng, (np/ng) * hn]``.
+        key: ``[sq, b, ng, hn]``, as for :func:`fused_qk_rmsnorm`.
+
+    Returns:
+        ``(query_normed, key_normed)``; the query is ``[sq, b, np, hn]`` contiguous.
+    """
+    hn = key.shape[-1]
+    sq, b, ng = grouped_query.shape[0], grouped_query.shape[1], grouped_query.shape[2]
+    npg = grouped_query.shape[3] // hn
+    heads = ng * npg
+
+    k2 = key.reshape(-1, hn)
+    qo = torch.empty(sq, b, heads, hn, dtype=grouped_query.dtype, device=grouped_query.device)
+    ko = torch.empty(key.shape, dtype=key.dtype, device=key.device)
+    qo2 = qo.view(-1, hn)
+    ko2 = ko.view(-1, hn)
+
+    n_q_rows = sq * b * heads
+    n_rows = n_q_rows + k2.shape[0]
+    assert qo2.stride(0) == hn and ko2.stride(0) == hn  # the kernel stores at stride HN
+
+    _fused_qk_rmsnorm_kernel[(triton.cdiv(n_rows, ROWS_PER_CTA),)](
+        grouped_query,
+        k2,
+        qo2,
+        ko2,
+        weight_q,
+        weight_k,
+        n_q_rows,
+        n_rows,
+        0,  # unused: grouped q rows have no single stride
+        k2.stride(0),
+        float(eps),
+        grouped_query.stride(2),
+        HN=hn,
+        ZERO_CENTERED=zero_centered_gamma,
+        Q_GROUPED=True,
+        NPG=npg,
+        HEADS=heads,
+        ROWS=ROWS_PER_CTA,
+        num_warps=NUM_WARPS,
+    )
+    return qo, ko
+
+
+def can_use_grouped_qk_norm(
+    q_layernorm, k_layernorm, grouped_query: torch.Tensor, key: torch.Tensor
+) -> bool:
+    """Whether the grouped-read path is safe, i.e. the copy can be skipped entirely.
+
+    Everything :func:`can_use_fused_qk_norm` requires, plus the two assumptions the
+    grouped addressing makes about the QKV output: that a token's groups are evenly
+    spaced (so a token stride is ``ng * group_stride``), and that the heads inside a
+    group are contiguous.
+    """
+    if not USE_GROUPED_QK_NORM:
+        return False
+    if grouped_query.ndim != 4 or key.ndim != 4:
+        return False
+    hn = key.shape[-1]
+    if grouped_query.shape[3] % hn != 0:
+        return False
+    ng = grouped_query.shape[2]
+    if grouped_query.stride(3) != 1 or grouped_query.stride(1) != ng * grouped_query.stride(2):
+        return False
+    # `key` stands in for the query in the shared check: the grouped query's last dim is
+    # `(np/ng) * hn` rather than `hn`, and every property that check reads off the query
+    # -- head_dim, cuda-ness, last-dim contiguity, token count from `shape[:-2]` -- is
+    # identical between the two here, with the query's own layout verified just above.
+    return can_use_fused_qk_norm(q_layernorm, k_layernorm, key, key)
 
 
 def can_use_fused_qk_norm(q_layernorm, k_layernorm, query: torch.Tensor, key: torch.Tensor) -> bool:

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -35,6 +35,17 @@ from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.mappings import all_gather_last_dim_from_tensor_parallel_region
 from megatron.core.transformer.identity_op import IdentityOp
 from megatron.core.transformer.module import MegatronModule
+
+try:
+    from megatron.core.inference.attention.fused_qk_norm import (
+        can_use_fused_qk_norm as _can_use_fused_qk_norm,
+    )
+    from megatron.core.inference.attention.fused_qk_norm import (
+        fused_qk_rmsnorm as _fused_qk_rmsnorm,
+    )
+except Exception:  # keep attention importable if the inference helper is unavailable
+    _can_use_fused_qk_norm = None
+    _fused_qk_rmsnorm = None
 from megatron.core.transformer.torch_norm import L2Norm, LayerNormBuilder
 from megatron.core.transformer.utils import is_layer_window_attention
 from megatron.core.typed_torch import apply_module, not_none
@@ -1919,11 +1930,24 @@ class SelfAttention(Attention):
             )
             query = query[:, :, idx * size : (idx + 1) * size, :]
 
-        if self.q_layernorm is not None:
-            query = apply_module(self.q_layernorm)(query)
+        if _can_use_fused_qk_norm is not None and _can_use_fused_qk_norm(
+            self.q_layernorm, self.k_layernorm, query, key
+        ):
+            # Fuse the two per-head RMSNorm launches into one (env-gated, decode).
+            query, key = _fused_qk_rmsnorm(
+                query,
+                key,
+                self.q_layernorm.weight,
+                self.k_layernorm.weight,
+                self.config.layernorm_epsilon,
+                self.config.layernorm_zero_centered_gamma,
+            )
+        else:
+            if self.q_layernorm is not None:
+                query = apply_module(self.q_layernorm)(query)
 
-        if self.k_layernorm is not None:
-            key = apply_module(self.k_layernorm)(key)
+            if self.k_layernorm is not None:
+                key = apply_module(self.k_layernorm)(key)
 
         if self.config.test_mode:
             self.run_realtime_tests()

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import copy
 import inspect
+import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Callable, Optional, Protocol, Tuple, Union
@@ -41,11 +42,19 @@ try:
         can_use_fused_qk_norm as _can_use_fused_qk_norm,
     )
     from megatron.core.inference.attention.fused_qk_norm import (
+        can_use_grouped_qk_norm as _can_use_grouped_qk_norm,
+    )
+    from megatron.core.inference.attention.fused_qk_norm import (
         fused_qk_rmsnorm as _fused_qk_rmsnorm,
+    )
+    from megatron.core.inference.attention.fused_qk_norm import (
+        fused_qk_rmsnorm_grouped as _fused_qk_rmsnorm_grouped,
     )
 except Exception:  # keep attention importable if the inference helper is unavailable
     _can_use_fused_qk_norm = None
     _fused_qk_rmsnorm = None
+    _can_use_grouped_qk_norm = None
+    _fused_qk_rmsnorm_grouped = None
 from megatron.core.transformer.torch_norm import L2Norm, LayerNormBuilder
 from megatron.core.transformer.utils import is_layer_window_attention
 from megatron.core.typed_torch import apply_module, not_none
@@ -66,6 +75,10 @@ from ..models.common.embeddings.yarn_rotary_pos_embedding import (
 )
 from .enums import AttnMaskType
 from .transformer_config import TransformerConfig
+
+# Split QKV with torch.split (views) instead of TE's SplitAlongDim. Under test as the
+# suspected source of one full-QKV-sized copy per decode layer; see COPY-ID-S18.
+_QKV_SPLIT_VIEWS: bool = os.environ.get("MCORE_QKV_SPLIT_VIEWS", "0") == "1"
 
 try:
     from einops import rearrange
@@ -1893,7 +1906,7 @@ class SelfAttention(Attention):
                 self.hidden_size_per_attention_head,
             ]
 
-            if SplitAlongDim is not None:
+            if SplitAlongDim is not None and not _QKV_SPLIT_VIEWS:
                 query, gate, key, value = SplitAlongDim(mixed_qkv, 3, split_arg_list)
             else:
                 query, gate, key, value = torch.split(mixed_qkv, split_arg_list, dim=3)
@@ -1910,31 +1923,23 @@ class SelfAttention(Attention):
             if not split_qkv:
                 return mixed_qkv, split_arg_list
 
-            if SplitAlongDim is not None:
+            if SplitAlongDim is not None and not _QKV_SPLIT_VIEWS:
                 query, key, value = SplitAlongDim(mixed_qkv, 3, split_arg_list)
             else:
                 query, key, value = torch.split(mixed_qkv, split_arg_list, dim=3)
 
-        # Query [sq, b, ng, np/ng * hn] -> [sq, b, np, hn]
-        query = query.reshape(query.size(0), query.size(1), -1, self.hidden_size_per_attention_head)
-
-        if self.config.num_query_groups < self.world_size:
-            # query above corresponds to (num_q_heads / num_kv_heads) q_heads.
-            # Index appropriately into query to get (num_q_heads / tp_size) q_heads.
-            # This is step 4 in the list of steps above.
-            idx = get_pg_rank(self.pg_collection.tp) % (
-                self.world_size // self.config.num_query_groups
-            )
-            size = self.num_attention_heads_per_partition // (
-                self.world_size // self.config.num_query_groups
-            )
-            query = query[:, :, idx * size : (idx + 1) * size, :]
-
-        if _can_use_fused_qk_norm is not None and _can_use_fused_qk_norm(
-            self.q_layernorm, self.k_layernorm, query, key
+        # The [sq, b, ng, np/ng * hn] -> [sq, b, np, hn] reshape below is a *copy*, not a
+        # view: merging the group and head axes needs the group stride to equal
+        # (np/ng) * hn, and it is (np/ng + 2) * hn because each group's k and v head sit
+        # between consecutive groups' q heads. When the fused q/k norm can read the
+        # grouped layout directly it writes that shape itself for free, and the copy --
+        # one full-size strided copy per layer per decode step -- never happens.
+        if (
+            _can_use_grouped_qk_norm is not None
+            and self.config.num_query_groups >= self.world_size
+            and _can_use_grouped_qk_norm(self.q_layernorm, self.k_layernorm, query, key)
         ):
-            # Fuse the two per-head RMSNorm launches into one (env-gated, decode).
-            query, key = _fused_qk_rmsnorm(
+            query, key = _fused_qk_rmsnorm_grouped(
                 query,
                 key,
                 self.q_layernorm.weight,
@@ -1943,11 +1948,41 @@ class SelfAttention(Attention):
                 self.config.layernorm_zero_centered_gamma,
             )
         else:
-            if self.q_layernorm is not None:
-                query = apply_module(self.q_layernorm)(query)
+            # Query [sq, b, ng, np/ng * hn] -> [sq, b, np, hn]
+            query = query.reshape(
+                query.size(0), query.size(1), -1, self.hidden_size_per_attention_head
+            )
 
-            if self.k_layernorm is not None:
-                key = apply_module(self.k_layernorm)(key)
+            if self.config.num_query_groups < self.world_size:
+                # query above corresponds to (num_q_heads / num_kv_heads) q_heads.
+                # Index appropriately into query to get (num_q_heads / tp_size) q_heads.
+                # This is step 4 in the list of steps above.
+                idx = get_pg_rank(self.pg_collection.tp) % (
+                    self.world_size // self.config.num_query_groups
+                )
+                size = self.num_attention_heads_per_partition // (
+                    self.world_size // self.config.num_query_groups
+                )
+                query = query[:, :, idx * size : (idx + 1) * size, :]
+
+            if _can_use_fused_qk_norm is not None and _can_use_fused_qk_norm(
+                self.q_layernorm, self.k_layernorm, query, key
+            ):
+                # Fuse the two per-head RMSNorm launches into one (env-gated, decode).
+                query, key = _fused_qk_rmsnorm(
+                    query,
+                    key,
+                    self.q_layernorm.weight,
+                    self.k_layernorm.weight,
+                    self.config.layernorm_epsilon,
+                    self.config.layernorm_zero_centered_gamma,
+                )
+            else:
+                if self.q_layernorm is not None:
+                    query = apply_module(self.q_layernorm)(query)
+
+                if self.k_layernorm is not None:
+                    key = apply_module(self.k_layernorm)(key)
 
         if self.config.test_mode:
             self.run_realtime_tests()

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -136,6 +136,11 @@ except ImportError:
 
 from megatron.core.transformer.transformer_config import MLATransformerConfig
 
+# See _resolve_flash_version: benchmarking-only override for a config field that
+# has no CLI flag. Empty means "leave the config's choice alone".
+_FA_VERSION_ENV = os.environ.get("MCORE_FLASH_ATTN_VERSION", "")
+
+
 try:
     from flash_attn import flash_attn_varlen_func, flash_attn_with_kvcache
 except:
@@ -1029,6 +1034,10 @@ class Attention(MegatronModule, ABC):
         when both are False the FA2 kernel is used.
         """
         pinned = self.flash_attention_version
+        # Benchmarking override: `flash_attention_version` has no CLI flag, so this
+        # is the only way to A/B generations from a launch script. Config wins.
+        if pinned is None and _FA_VERSION_ENV:
+            pinned = int(_FA_VERSION_ENV)
         if pinned == 4:
             assert (
                 HAVE_FA4


### PR DESCRIPTION
> Stacked on #6460. Review that one first; this diff is only an environment override that
>
> GitHub cannot base a pull request from a fork on another unmerged fork branch, so the diff below also contains the parent's commits. This PR's own change is the final commit, `10eb95f93`; review that one. The rest lands with the parent.
> lets a launch script pin which FlashAttention generation attention resolves to.

## Summary

Megatron's automatic FlashAttention selection prefers the newest installed generation
(FA4 → FA3 → FA2), and on this decode path FA4 has no dedicated decode kernel: decode is
routed into `flash_attn4_varlen_func`, the varlen *prefill* interface, called with
`max_seqlen_q = 1`, while FA2 goes to `flash_attn_with_kvcache`, the purpose-built
flash-decoding kernel with split-KV and combine. Pinning generation 2 selects the second
one, and the block's GPU time drops from 7.70 ms to 7.41 ms: **-0.35%** end-to-end
decode throughput.

This PR writes no kernel. It selects between two implementations that already ship, and the
honest reading is that it works around an upstream default that is wrong for decode rather
than tuning a knob.

## Why here

A per-arm comparison of block-graph GPU time, alternating backends on one node: 7.695 and
7.707 ms with FA4 against 7.412 and 7.400 ms with FA2. Repeat-to-repeat spread is 0.3% on
block time, so the 4.1% separation is roughly ten times the noise.

An ablation localizes all of it to attention. With attention stubbed out, the block floor is
the same under both backends — 5.858 ms for FA4 against 5.884 ms for FA2, inside noise — so
attention itself goes 1.843 → 1.510 ms/step, −18%. Nothing outside attention moves.

## What changed

`Attention._resolve_flash_version` returns `(use_fa4, use_fa3)` from
`config.flash_attention_version`, falling back to the newest available generation when the
field is unset. This diff adds four lines: if the config field is `None` and
`MCORE_FLASH_ATTN_VERSION` is non-empty, that value becomes the pin. `flash_attention_version`
has no CLI flag, so this is the only way to A/B generations from a launch script. Config wins
over the environment.

No dispatch logic, kernel argument or numeric path is touched. Both branches this selects
between already existed and are already reachable through the config field.

**The FA4 rejection has been re-tested.** The original reason FA4 lost was believed to be
that it hardcoded `num_splits=1` and so could not split KV across streaming multiprocessors
at decode. Upstream later changed that to `num_splits=0` (auto), and the comparison was rerun
on that code: FA4 was still behind. So `num_splits` was not the dominant term, and the
varlen-interface routing is.

## Measurement

Fixed protocol: Qwen3-30B-A3B, BF16, TP 1 / PP 1 / EP 4 / ETP 1, 256 gsm8k requests, 1024 output tokens, 2 warmup + 5 timed iterations, a single OCI 4xGB200 node (nvl72160-T04), async dynamic-batching scheduler pinned on. All 20 arms ran back to back in one allocation on that one node; node-to-node variance on this workload is around 2.7%, so cross-node numbers would not be comparable.

- With this change (every other gate in the stack enabled): **31,521 tok/s**
- Without it (same node, same session, only this gate turned off): **31,631 tok/s**
- Leave-one-out delta: **-0.35%**
- Noise floor: sigma = **0.42%** over 3 repeats of the all-gates-on reference
- Verdict: **inside the noise floor** (|-0.35%| < 2 sigma = 0.84%)

This is the **marginal contribution measured with every other gate in this stack enabled** — the question a reviewer is actually asking, which is whether this should land, not what it was worth when it was first written.

The reference is drift-corrected. The all-gates-on configuration was re-measured three times across the session (31,745, 31,530, 31,503 tok/s), a +0.77% drift from first to last, so each arm is compared against the reference interpolated to its own position in the run order rather than against a session mean.

For context, the whole stack is worth **+35.80%** on this node (23,265 tok/s with every gate off, 31,593 with every gate on). Per-slice deltas do not sum to that; they compose sub-additively.

## Evidence

Device time, from the block graph rather than the wall clock, alternating arms on one node:

| arm | backend | block-graph GPU |
|---|---|---|
| reference | FA4 (automatic choice) | 7.695 / 7.707 ms |
| pinned | FA2 | 7.412 / 7.400 ms |

Attention in isolation, by difference against the attention-stubbed floor: 1.843 ms/step under
FA4, 1.510 ms/step under FA2.

**This PR has no built-in liveness signal, and a reviewer should know that before trusting an
arm.** A one-shot latch that logged the resolved generation to stderr was carried while this
was being developed and was removed during the split: it fired on the first call even with the
variable unset, so every process paid a stderr line for a diagnostic, and a bare `print` in
`megatron/core` fails the lint configuration (`bad-functions=print`). `attention.py` has no
logger, and standing up logging infrastructure for one startup line was more invasive than
dropping it. The consequence is that an unset `MCORE_FLASH_ATTN_VERSION` now leaves no trace
in the run output at all, and nothing in the code tells a reader which backend ran.

Verify from a profile instead: with the pin engaged, decode calls
`flash_attn_with_kvcache` and `flash_attn4_varlen_func` is absent from the decode region. If
both arms of an A/B show the same decode kernels, the pin did not take.

## Correctness

- **Numerics:** behavioral only — this is backend selection. No arithmetic is authored here.
  The two backends accumulate in a different order, so their outputs are not bit-identical to
  each other, and that is a property of the dependency rather than of this diff.
- **Tests:** the existing FlashAttention paths are unchanged and remain covered by their own
  assertions; pinning 3 or 4 asserts immediately if that package is not installed.
- **Coherence:** identical on two of three temperature-0 probes and equally correct on the
  third, which is what a different accumulation order predicts.

## Gating and blast radius

- Gate: `MCORE_FLASH_ATTN_VERSION`, and it is **not a boolean and not "default off"**. It
  defaults to the empty string, and empty means *do not override* — behaviour is upstream's
  automatic preference, byte-identical to before this PR. Setting `2`, `3` or `4` pins that
  generation; `3` and `4` assert if the corresponding package is missing. Any other value,
  including `0`, matches no branch and falls through to the same automatic resolution as
  unset. So the three reachable states are: unset or unrecognized (automatic), `2` (FA2),
  and `3`/`4` (pin or fail loudly).
- `config.flash_attention_version` takes precedence: the environment is consulted only when
  that field is `None`, so an explicit configuration is never silently overridden.
- **The resolution function also serves prefill.** `_resolve_flash_version` is called once per
  attention forward and its result governs the mixed/prefill varlen branch as well as decode,
  so pinning changes the prefill backend too. Only decode was measured.
- **The pin is a no-op unless FA4 is installed.** `HAVE_FA4` requires the `flash-attn-4`
  package at or above a minimum version; where it is absent, automatic resolution already
  selects FA2 and both arms of an A/B are the same run. The benchmark runner installs it
  explicitly for this reason.
- Training is unaffected in the sense that it uses the same resolution it always did unless
  someone sets this variable in a training job.

## Reproduce

```bash
MCORE_FLASH_ATTN_VERSION=2 \
QWEN30B_TP=1 QWEN30B_EP=4 QWEN30B_ETP=1 \
BENCH_SIZES_OVERRIDE=256 BENCH_OUTPUT_TOKENS=1024 \
NUM_WARMUP_ITERS=2 NUM_TIMED_ITERS=5 \
bash skills/run-qwen-model/run_qwen_inference.sh qwen3-30b-a3b --checkpoint "$QWEN30B_CKPT"
```

The unset arm is only a different run if `flash-attn-4` is importable in the interpreter the
runner launches; check that first, since there is no log line to tell you which backend ran.

## What this does not claim

- **No kernel is improved.** The gain is a choice between two existing implementations, and it
  is a claim about the dependency's kernel coverage at `seqlen_q = 1`, not about FA2 being a
  better library than FA4 in general.
- **Nothing about FA3.** It is not installed in this container (`HAVE_FA3` is `False`), so
  pinning 3 asserts out and that leg of the comparison is untested.
- **Nothing about prefill**, even though the pin changes prefill's backend as well. The
  ablation shows the measured win is entirely inside attention at decode; prefill was not
  measured under either backend.
- **Nothing outside attention.** The attention-stubbed floor is the same under both backends,
  so this does not reduce the non-attention part of the step at all.
- **This overlaps heavily with the flashinfer decode kernel later in this chain.** Once that
  path engages, decode no longer runs a FlashAttention kernel at all and the pin governs only
  prefill and the calls where flashinfer declines. The two deltas therefore do not add, and
  measuring them together is the only meaningful combination.
- No liveness evidence ships with this change; see Evidence.

## Follow-ups

- The upstream default is the real fix: automatic resolution should not prefer a generation
  that has no decode kernel on the path it is being selected for. Worth raising against
  `_resolve_flash_version` rather than carrying an environment override indefinitely.
- If the override survives, it wants a single logged line at initialization, emitted only when
  the override is actually applied and through a real logger rather than `print`.

---

## This stack

This is one slice of [#6064](https://github.com/NVIDIA/Megatron-LM/pull/6064), a Qwen3-30B-A3B decode optimization campaign, split into 16 independently reviewable changes. Together they are **+35.80%** end-to-end throughput over the same base commit (23,265 -> 31,593 tok/s, mean of three full runs).

- **MoE grouped-GEMM and dispatch:** #6452 -> #6453 -> #6454 -> #6455
- **MoE router and combine:** #6456 -> #6457 -> #6458
- **Attention: QK norm and decode kernel:** #6459 -> #6460 -> #6461 -> #6462
- **Residual + RMSNorm fusion:** #6463 -> #6464
- **Host path: context bookkeeping:** #6465 -> #6466
- **Host path: independent:** #6467

Each chain is independent of the others and bases on `main`. Within a chain, later PRs depend on earlier ones.

### Per-slice measured delta

Every number is a leave-one-out delta from one same-node, same-session campaign: the full stack with exactly this change's gate off, against the interpolated full-stack reference at that point in the run. It is the change's *marginal* contribution with everything else already in, not its standalone value. Run-to-run sigma was **0.42%** across three full-stack repeats.

| PR | Change | Delta | |
|---|---|---|---|
| #6452 | FC1 SwiGLU epilogue | +14.81% | resolved |
| #6453 | indirection table fusion | +7.21% | resolved |
| #6454 | decode GEMM tile configs | +6.77% | resolved |
| #6455 | predicated top-k gather | +1.99% | by margin |
| #6456 | fused router softmax+top-k | +4.75% | resolved |
| #6457 | fused route padding mask | +1.47% | by margin |
| #6458 | bf16 MoE combine | +2.42% | by margin |
| #6459 | fused QK RMSNorm | +5.17% | resolved |
| #6460 | grouped QK norm input | +1.18% | by margin |
| #6461 | pin FlashAttention 2 | -0.35% | noise floor |
| #6462 | FlashInfer TRT-LLM decode | +1.46% | by margin |
| #6463 | fused add+norm pre-MLP | +3.54% | by margin |
| #6464 | fused add+norm pre-QKV | +0.98% | by margin |
| #6465 | incremental attention state | -0.42% | noise floor |
| #6466 | vectorized decode bookkeeping | -0.07% | noise floor |
| #6467 | post_process_requests fast path | +0.09% | noise floor |

`noise floor` means the delta is inside 2 sigma (0.84%) and this campaign cannot distinguish it from zero. `resolved` means the leave-one-out and full-stack iteration distributions did not overlap. Deltas do not sum to the stack total: these changes shorten the same decode step and compose sub-additively.

**Fixed protocol for every number above.** Qwen3-30B-A3B, BF16, TP1/PP1/EP4/ETP1, 256 gsm8k requests at batch size 256, output length 1024, CUDA graphs on, one OCI GB200 NVL72 node, 4 GPUs. All 20 arms ran back-to-back in a single Slurm allocation on one node, so node assignment and thermal state are held constant.
