### PR TITLE
perf(inference): Blackwell-native decode attention via flashinfer trtllm-gen

### DIFF
--- a/megatron/core/inference/attention/__init__.py
+++ b/megatron/core/inference/attention/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.

--- a/megatron/core/inference/attention/flashinfer_decode.py
+++ b/megatron/core/inference/attention/flashinfer_decode.py
@@ -1,0 +1,143 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+
+"""Blackwell-native paged decode attention via flashinfer's trtllm-gen kernel.
+
+Megatron's decode path runs FlashAttention-2's `flash_attn_with_kvcache`, whose kernels
+predate Blackwell. A matched per-category comparison against vLLM at BS256/OSL1024
+(GAP-S18) found attention to be the largest remaining device-time gap -- 0.409 ms/step at
+an *identical* launch count, which rules out anything Megatron does around the call and
+points at the kernel generation itself. vLLM reaches `fmhaSm100f` through flashinfer, and
+flashinfer is already installed alongside flash-attn here, so the same kernel is
+available to us: at our shapes it is 24% faster than FA2 with matching numerics.
+
+Two properties make it usable at decode without restructuring anything:
+
+  * It takes the paged layout Megatron already has. With ``kv_layout="NHD"`` the k and v
+    caches are ``[num_pages, page_size, num_kv_heads, head_dim]``, exactly FA2's, and it
+    accepts Megatron's 256-token pages (FA2 in fact *requires* pages be a multiple of
+    256, so this is the stricter of the two).
+  * It needs no host-side `plan()` call, unlike flashinfer's wrapper APIs, so it is
+    capturable in the decode CUDA graph.
+
+The one operational constraint is the scratch buffer, which must be zeroed before first
+use. Zeroing it inside a graph capture would record a 128 MiB memset into the graph and
+replay it every step, so the buffer is allocated eagerly and this path declines to engage
+if it is asked to do so for the first time mid-capture.
+"""
+
+import logging
+import os
+import sys
+from typing import Optional, Tuple
+
+import torch
+
+try:
+    from flashinfer.decode import trtllm_batch_decode_with_kv_cache
+
+    HAVE_FLASHINFER = True
+except ImportError:
+    trtllm_batch_decode_with_kv_cache = None
+    HAVE_FLASHINFER = False
+
+logger = logging.getLogger(__name__)
+
+ENABLED: bool = os.environ.get("MCORE_FLASHINFER_DECODE", "0") == "1"
+
+if ENABLED and not HAVE_FLASHINFER:
+    # Say so loudly once. Asking for this path and silently getting FA2 is the failure
+    # this module is easiest to get wrong: flashinfer is commonly present in the run
+    # venv and absent from the container's system python, so the same command can
+    # engage or not depending only on which interpreter launched it.
+    logger.warning(
+        "MCORE_FLASHINFER_DECODE=1 but flashinfer is not importable under %s; "
+        "decode will use the flash-attention path instead",
+        sys.executable,
+    )
+
+# Programmatic Dependent Launch lets this kernel's prologue start while its predecessor
+# drains. 855 of mcore's 934 per-step GPU gaps are sub-microsecond launch overhead
+# (GAP-S18), so it is worth an arm; left as a knob because PDL interacts with graph
+# capture and its benefit is hardware- and neighbour-dependent. None = flashinfer decides.
+_PDL_ENV = os.environ.get("MCORE_FLASHINFER_PDL", "")
+ENABLE_PDL: Optional[bool] = bool(int(_PDL_ENV)) if _PDL_ENV else None
+
+# vLLM sizes this at 128 MiB for the same kernel family.
+_WORKSPACE_BYTES: int = 128 * 1024 * 1024
+
+_workspace: Optional[torch.Tensor] = None
+_declined: bool = False
+
+
+def _get_workspace(device: torch.device) -> Optional[torch.Tensor]:
+    """The zeroed scratch buffer, or None if it cannot be created safely right now."""
+    global _workspace, _declined
+    if _workspace is not None and _workspace.device == device:
+        return _workspace
+    if torch.cuda.is_current_stream_capturing():
+        # Allocating here would bind the buffer to the graph's pool and, worse, record
+        # the 128 MiB zero-fill as a graph node replayed every step. Decline instead;
+        # the caller falls back to FA2 for this graph.
+        if not _declined:
+            _declined = True
+            logger.warning(
+                "flashinfer decode declined: no workspace yet and stream is capturing; "
+                "falling back to FA2 for this graph"
+            )
+        return None
+    _workspace = torch.zeros(_WORKSPACE_BYTES, dtype=torch.uint8, device=device)
+    return _workspace
+
+
+def can_use(
+    query: torch.Tensor,
+    block_table: Optional[torch.Tensor],
+    need_lse: bool,
+    window_size: Tuple[int, int],
+    tokens_per_request: int,
+) -> bool:
+    """Whether the trtllm-gen decode kernel can serve this call.
+
+    Deliberately narrow: every condition below is one this module has not verified
+    against FA2, and a wrong answer here is a silent accuracy bug rather than a crash.
+    """
+    if not (ENABLED and HAVE_FLASHINFER):
+        return False
+    if block_table is None:  # non-paged KV cache
+        return False
+    if need_lse:  # attention sinks need an LSE correction pass; not wired up
+        return False
+    if window_size != (-1, -1):  # sliding window maps to window_left; untested
+        return False
+    if tokens_per_request != 1:  # speculative decoding needs q_len_per_req plumbing
+        return False
+    if query.dtype not in (torch.bfloat16, torch.float16):
+        return False
+    return _get_workspace(query.device) is not None
+
+
+def decode(
+    query: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    block_table: torch.Tensor,
+    seqlens_k: torch.Tensor,
+    max_seqlen_k: int,
+    softmax_scale: float,
+) -> torch.Tensor:
+    """Paged decode attention. ``query`` is ``(B, 1, H, D)``; returns the same shape."""
+    num_requests, tokens_per_request = query.shape[0], query.shape[1]
+    out = trtllm_batch_decode_with_kv_cache(
+        query=query.reshape(-1, query.shape[-2], query.shape[-1]),
+        kv_cache=(k_cache, v_cache),
+        workspace_buffer=_workspace,
+        block_tables=block_table,
+        seq_lens=seqlens_k,
+        max_seq_len=max_seqlen_k,
+        # bmm2 is the P@V product, which needs no rescaling for a bf16 cache.
+        bmm1_scale=softmax_scale,
+        bmm2_scale=1.0,
+        kv_layout="NHD",
+        enable_pdl=ENABLE_PDL,
+    )
+    return out.reshape(num_requests, tokens_per_request, *out.shape[1:])

--- a/megatron/core/inference/attention/fused_qk_norm.py
+++ b/megatron/core/inference/attention/fused_qk_norm.py
@@ -1,0 +1,195 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Single-launch fused q/k RMSNorm for decode-shaped attention.
+
+Qwen3-style attention applies a per-head RMSNorm to the query and to the key
+separately, right after the QKV split and before RoPE. In the
+``inference_optimized`` decode path these are two distinct ``TENorm`` (TE
+``RMSNorm``) module calls, so they show up as two ``rmsnorm_fwd_general``
+kernels per layer. Each normalizes a tiny ``[.., head_dim]`` row (head_dim=128
+here), so both are launch/latency dominated rather than bandwidth bound —
+merging the two launches into one recovers a graph node and its dispatch gap
+per layer with no change to the math.
+
+The two source tensors have different shapes and different weights, but both
+reduce to a ``[num_rows, head_dim]`` view with a *uniform* row stride (the key
+view's leading strides are exact multiples of its head stride), so a single
+kernel can process the concatenation of query rows and key rows, selecting the
+right weight per row. The normalization itself is identical to TE's RMSNorm:
+fp32 mean-of-squares over ``head_dim``, ``rsqrt(var + eps)``, then the
+(optionally 1-centered) gamma — so the result matches the two-call path to
+bf16 rounding.
+"""
+
+import os
+from typing import Tuple
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+
+    HAVE_TRITON = True
+except ImportError:
+    HAVE_TRITON = False
+
+# Fuse the two QK RMSNorm launches into one. Env-toggleable; default off so the
+# untouched two-call path stays byte-identical.
+USE_FUSED_QK_NORM: bool = os.environ.get("MCORE_FUSED_QK_NORM", "0") == "1"
+
+# The one-row-per-CTA kernel wins only in the decode regime; above ~256 tokens
+# TE's multi-row norm is faster (measured 1.25x at 256 tokens, 0.83x at 384).
+# Restrict to decode; prefill / large batches keep the two-call path.
+FUSED_QK_NORM_MAX_TOKENS: int = int(os.environ.get("MCORE_FUSED_QK_NORM_MAX_TOKENS", "256"))
+
+
+if HAVE_TRITON:
+
+    @triton.jit
+    def _fused_qk_rmsnorm_kernel(
+        q_ptr,
+        k_ptr,
+        qo_ptr,
+        ko_ptr,
+        wq_ptr,
+        wk_ptr,
+        n_q_rows,
+        q_in_rs,
+        k_in_rs,
+        q_out_rs,
+        k_out_rs,
+        eps,
+        HN: tl.constexpr,
+        ZERO_CENTERED: tl.constexpr,
+    ):
+        """One CTA per row across the concatenated [q_rows; k_rows] space.
+
+        Programs with ``row < n_q_rows`` normalize a query row with ``wq``;
+        the rest normalize a key row with ``wk``. Both candidate loads are
+        issued (the off-path one clamped to row 0 and masked out of the store),
+        which keeps the kernel branch-free on the hot path for a 128-wide row.
+        """
+        row = tl.program_id(0)
+        cols = tl.arange(0, HN)
+        is_q = row < n_q_rows
+
+        q_row = tl.where(is_q, row, 0)
+        k_row = tl.where(is_q, 0, row - n_q_rows)
+
+        xq = tl.load(q_ptr + q_row * q_in_rs + cols).to(tl.float32)
+        xk = tl.load(k_ptr + k_row * k_in_rs + cols).to(tl.float32)
+        x = tl.where(is_q, xq, xk)
+
+        var = tl.sum(x * x, axis=0) / HN
+        inv = 1.0 / tl.sqrt(var + eps)
+        xn = x * inv
+
+        wq = tl.load(wq_ptr + cols).to(tl.float32)
+        wk = tl.load(wk_ptr + cols).to(tl.float32)
+        w = tl.where(is_q, wq, wk)
+        if ZERO_CENTERED:
+            w = w + 1.0
+        y = xn * w
+
+        q_store_mask = is_q & (cols < HN)
+        k_store_mask = (row >= n_q_rows) & (cols < HN)
+        tl.store(qo_ptr + q_row * q_out_rs + cols, y.to(qo_ptr.dtype.element_ty), mask=q_store_mask)
+        tl.store(ko_ptr + k_row * k_out_rs + cols, y.to(ko_ptr.dtype.element_ty), mask=k_store_mask)
+
+
+def fused_qk_rmsnorm(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    weight_q: torch.Tensor,
+    weight_k: torch.Tensor,
+    eps: float,
+    zero_centered_gamma: bool,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Apply per-head RMSNorm to ``query`` and ``key`` in a single kernel.
+
+    Args:
+        query: ``[.., head_dim]`` (any leading shape); last dim is normalized.
+        key: ``[.., head_dim]``; may be a non-contiguous split view — only the
+            last dim needs to be contiguous, which holds for the QKV split.
+        weight_q / weight_k: ``[head_dim]`` RMSNorm gammas.
+        eps: RMSNorm epsilon.
+        zero_centered_gamma: if True, apply ``(1 + gamma)`` (matches TE).
+
+    Returns:
+        ``(query_normed, key_normed)`` as fresh contiguous tensors with the same
+        shapes and dtypes as the inputs.
+    """
+    hn = query.shape[-1]
+    # No-copy 2D views: the last dim is contiguous and the leading strides are
+    # exact multiples of the row stride, so reshape returns a view.
+    q2 = query.reshape(-1, hn)
+    k2 = key.reshape(-1, hn)
+
+    qo = torch.empty(query.shape, dtype=query.dtype, device=query.device)
+    ko = torch.empty(key.shape, dtype=key.dtype, device=key.device)
+    qo2 = qo.view(-1, hn)
+    ko2 = ko.view(-1, hn)
+
+    n_q_rows = q2.shape[0]
+    n_rows = n_q_rows + k2.shape[0]
+
+    _fused_qk_rmsnorm_kernel[(n_rows,)](
+        q2,
+        k2,
+        qo2,
+        ko2,
+        weight_q,
+        weight_k,
+        n_q_rows,
+        q2.stride(0),
+        k2.stride(0),
+        qo2.stride(0),
+        ko2.stride(0),
+        float(eps),
+        HN=hn,
+        ZERO_CENTERED=zero_centered_gamma,
+        num_warps=1,
+    )
+    return qo, ko
+
+
+def can_use_fused_qk_norm(q_layernorm, k_layernorm, query: torch.Tensor, key: torch.Tensor) -> bool:
+    """Whether the fused kernel reproduces this exact q/k RMSNorm contract.
+
+    Requires both norms to be weight-only RMSNorm modules (TE ``RMSNorm``),
+    a power-of-two head dim, matching last dims, and CUDA tensors whose reshape
+    to ``[-1, head_dim]`` is a view (last dim contiguous). Anything else — L2
+    norm, LayerNorm with bias, odd head dims — falls back to the two-call path.
+    """
+    if not (HAVE_TRITON and USE_FUSED_QK_NORM):
+        return False
+    if q_layernorm is None or k_layernorm is None:
+        return False
+    wq = getattr(q_layernorm, "weight", None)
+    wk = getattr(k_layernorm, "weight", None)
+    if wq is None or wk is None:
+        return False
+    # RMSNorm has no bias; reject anything that carries one to stay exact.
+    if (
+        getattr(q_layernorm, "bias", None) is not None
+        or getattr(k_layernorm, "bias", None) is not None
+    ):
+        return False
+    hn = query.shape[-1]
+    if hn != key.shape[-1] or hn != wq.numel() or hn != wk.numel():
+        return False
+    if (hn & (hn - 1)) != 0:  # not a power of two
+        return False
+    if not (query.is_cuda and key.is_cuda):
+        return False
+    # Last dim must be contiguous so the [-1, hn] reshape is a no-copy view.
+    if query.stride(-1) != 1 or key.stride(-1) != 1:
+        return False
+    # Decode-only: count tokens (all leading dims except heads and head_dim).
+    n_tokens = 1
+    for d in query.shape[:-2]:
+        n_tokens *= d
+    if n_tokens > FUSED_QK_NORM_MAX_TOKENS:
+        return False
+    return True

--- a/megatron/core/inference/attention/fused_qk_norm.py
+++ b/megatron/core/inference/attention/fused_qk_norm.py
@@ -43,6 +43,17 @@ USE_FUSED_QK_NORM: bool = os.environ.get("MCORE_FUSED_QK_NORM", "0") == "1"
 # Restrict to decode; prefill / large batches keep the two-call path.
 FUSED_QK_NORM_MAX_TOKENS: int = int(os.environ.get("MCORE_FUSED_QK_NORM_MAX_TOKENS", "256"))
 
+# Read the query out of the grouped QKV output rather than out of a repacked copy,
+# removing one full-query strided copy per layer per step. Requires the fused norm.
+USE_GROUPED_QK_NORM: bool = os.environ.get("MCORE_GROUPED_QK_NORM", "0") == "1"
+
+# Launch shape. One row per CTA is the obvious choice for a 128-wide row and reaches only
+# ~570 GB/s, because it puts 9,216 single-warp CTAs on the device for a 256-token step.
+# 8 rows x 8 warps measured exactly 2x that (8.22 -> 4.12 us) and was the best point in a
+# rows x warps sweep; env-overridable so the sweep can be repeated on other hardware.
+ROWS_PER_CTA: int = int(os.environ.get("MCORE_QK_NORM_ROWS", "8"))
+NUM_WARPS: int = int(os.environ.get("MCORE_QK_NORM_WARPS", "8"))
+
 
 if HAVE_TRITON:
 
@@ -55,47 +66,82 @@ if HAVE_TRITON:
         wq_ptr,
         wk_ptr,
         n_q_rows,
+        n_rows,
         q_in_rs,
         k_in_rs,
-        q_out_rs,
-        k_out_rs,
         eps,
+        q_grp_rs,
         HN: tl.constexpr,
         ZERO_CENTERED: tl.constexpr,
+        Q_GROUPED: tl.constexpr,
+        NPG: tl.constexpr,
+        HEADS: tl.constexpr,
+        ROWS: tl.constexpr,
     ):
-        """One CTA per row across the concatenated [q_rows; k_rows] space.
+        """``ROWS`` rows per CTA across the concatenated ``[q_rows; k_rows]`` space.
 
-        Programs with ``row < n_q_rows`` normalize a query row with ``wq``;
-        the rest normalize a key row with ``wk``. Both candidate loads are
-        issued (the off-path one clamped to row 0 and masked out of the store),
-        which keeps the kernel branch-free on the hot path for a 128-wide row.
+        Rows below ``n_q_rows`` are query rows normalized with ``wq``; the rest are key
+        rows normalized with ``wk``. A block may straddle that boundary, so both address
+        schemes are computed for every row and selected per row.
+
+        With ``Q_GROUPED`` the query is read straight out of the QKV projection's output
+        instead of from a repacked copy. There, q heads are grouped with the k and v head
+        of their group, so a q row's address needs two strides -- one per group
+        (``q_grp_rs``) and one per head inside it -- and no single row stride exists. See
+        :func:`fused_qk_rmsnorm_grouped` for why that matters.
+
+        One row per CTA is the obvious shape for a 128-wide row and it is the wrong one:
+        it puts 9,216 single-warp CTAs on the device for a 256-token step and reaches only
+        ~570 GB/s. Eight rows per CTA at eight warps measured exactly 2x that, and a
+        sweep of the rest of the space found nothing better.
+
+        Output row strides are ``HN``, not parameters: both output tensors are allocated
+        here and are contiguous, and passing that stride at runtime instead costs a third
+        of the kernel (6.15 us against 4.12 us) because the compiler can no longer prove
+        the stores are contiguous and vectorize them.
         """
-        row = tl.program_id(0)
+        rows = tl.program_id(0) * ROWS + tl.arange(0, ROWS)
         cols = tl.arange(0, HN)
-        is_q = row < n_q_rows
+        live = rows < n_rows
+        is_q = rows < n_q_rows
 
-        q_row = tl.where(is_q, row, 0)
-        k_row = tl.where(is_q, 0, row - n_q_rows)
+        q_row = tl.where(is_q, rows, 0)
+        k_row = tl.where(is_q, 0, rows - n_q_rows)
+        if Q_GROUPED:
+            head = q_row % HEADS
+            q_off = (
+                (q_row // HEADS) * (HEADS // NPG) + head // NPG
+            ) * q_grp_rs + (head % NPG) * HN
+        else:
+            q_off = q_row * q_in_rs
 
-        xq = tl.load(q_ptr + q_row * q_in_rs + cols).to(tl.float32)
-        xk = tl.load(k_ptr + k_row * k_in_rs + cols).to(tl.float32)
-        x = tl.where(is_q, xq, xk)
+        q_mask = (live & is_q)[:, None]
+        k_mask = (live & (rows >= n_q_rows))[:, None]
 
-        var = tl.sum(x * x, axis=0) / HN
-        inv = 1.0 / tl.sqrt(var + eps)
-        xn = x * inv
+        xq = tl.load(q_ptr + q_off[:, None] + cols[None, :], mask=q_mask, other=0.0)
+        xk = tl.load(k_ptr + (k_row * k_in_rs)[:, None] + cols[None, :], mask=k_mask, other=0.0)
+        x = tl.where(is_q[:, None], xq.to(tl.float32), xk.to(tl.float32))
+
+        var = tl.sum(x * x, axis=1) / HN
+        xn = x * (1.0 / tl.sqrt(var + eps))[:, None]
 
         wq = tl.load(wq_ptr + cols).to(tl.float32)
         wk = tl.load(wk_ptr + cols).to(tl.float32)
-        w = tl.where(is_q, wq, wk)
+        w = tl.where(is_q[:, None], wq[None, :], wk[None, :])
         if ZERO_CENTERED:
             w = w + 1.0
         y = xn * w
 
-        q_store_mask = is_q & (cols < HN)
-        k_store_mask = (row >= n_q_rows) & (cols < HN)
-        tl.store(qo_ptr + q_row * q_out_rs + cols, y.to(qo_ptr.dtype.element_ty), mask=q_store_mask)
-        tl.store(ko_ptr + k_row * k_out_rs + cols, y.to(ko_ptr.dtype.element_ty), mask=k_store_mask)
+        tl.store(
+            qo_ptr + q_row[:, None] * HN + cols[None, :],
+            y.to(qo_ptr.dtype.element_ty),
+            mask=q_mask,
+        )
+        tl.store(
+            ko_ptr + k_row[:, None] * HN + cols[None, :],
+            y.to(ko_ptr.dtype.element_ty),
+            mask=k_mask,
+        )
 
 
 def fused_qk_rmsnorm(
@@ -133,8 +179,9 @@ def fused_qk_rmsnorm(
 
     n_q_rows = q2.shape[0]
     n_rows = n_q_rows + k2.shape[0]
+    assert qo2.stride(0) == hn and ko2.stride(0) == hn  # the kernel stores at stride HN
 
-    _fused_qk_rmsnorm_kernel[(n_rows,)](
+    _fused_qk_rmsnorm_kernel[(triton.cdiv(n_rows, ROWS_PER_CTA),)](
         q2,
         k2,
         qo2,
@@ -142,16 +189,118 @@ def fused_qk_rmsnorm(
         weight_q,
         weight_k,
         n_q_rows,
+        n_rows,
         q2.stride(0),
         k2.stride(0),
-        qo2.stride(0),
-        ko2.stride(0),
         float(eps),
+        0,
         HN=hn,
         ZERO_CENTERED=zero_centered_gamma,
-        num_warps=1,
+        Q_GROUPED=False,
+        NPG=1,
+        HEADS=1,
+        ROWS=ROWS_PER_CTA,
+        num_warps=NUM_WARPS,
     )
     return qo, ko
+
+
+def fused_qk_rmsnorm_grouped(
+    grouped_query: torch.Tensor,
+    key: torch.Tensor,
+    weight_q: torch.Tensor,
+    weight_k: torch.Tensor,
+    eps: float,
+    zero_centered_gamma: bool,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Same norm, but reading the query straight out of the QKV projection.
+
+    Megatron's QKV projection writes ``[sq, b, ng, (np/ng + 2) * hn]`` -- each group's
+    q heads sit next to that group's k and v head. Reshaping the q slice to
+    ``[sq, b, np, hn]`` therefore **cannot** be a view: merging the group axis with the
+    head axis needs the group stride to equal ``(np/ng) * hn``, and it is
+    ``(np/ng + 2) * hn`` instead. For Qwen3-30B that is 1280 against 1024, so
+    `Tensor.reshape` silently materializes the whole query -- one full-size strided copy
+    per layer per step, which showed up in the profile as a 2.8 us
+    ``elementwise_kernel<128,4>`` between the QKV GEMM and this norm and took four
+    attempts to attribute.
+
+    Since this norm already writes a fresh output, it can absorb the repack for free:
+    read with the two strides the grouped layout needs, write the contiguous
+    ``[sq, b, np, hn]`` result the rest of attention wants. Values and arithmetic order
+    are unchanged, so the result is bit-identical to normalizing the copy.
+
+    Args:
+        grouped_query: the q slice of the QKV output, ``[sq, b, ng, (np/ng) * hn]``.
+        key: ``[sq, b, ng, hn]``, as for :func:`fused_qk_rmsnorm`.
+
+    Returns:
+        ``(query_normed, key_normed)``; the query is ``[sq, b, np, hn]`` contiguous.
+    """
+    hn = key.shape[-1]
+    sq, b, ng = grouped_query.shape[0], grouped_query.shape[1], grouped_query.shape[2]
+    npg = grouped_query.shape[3] // hn
+    heads = ng * npg
+
+    k2 = key.reshape(-1, hn)
+    qo = torch.empty(sq, b, heads, hn, dtype=grouped_query.dtype, device=grouped_query.device)
+    ko = torch.empty(key.shape, dtype=key.dtype, device=key.device)
+    qo2 = qo.view(-1, hn)
+    ko2 = ko.view(-1, hn)
+
+    n_q_rows = sq * b * heads
+    n_rows = n_q_rows + k2.shape[0]
+    assert qo2.stride(0) == hn and ko2.stride(0) == hn  # the kernel stores at stride HN
+
+    _fused_qk_rmsnorm_kernel[(triton.cdiv(n_rows, ROWS_PER_CTA),)](
+        grouped_query,
+        k2,
+        qo2,
+        ko2,
+        weight_q,
+        weight_k,
+        n_q_rows,
+        n_rows,
+        0,  # unused: grouped q rows have no single stride
+        k2.stride(0),
+        float(eps),
+        grouped_query.stride(2),
+        HN=hn,
+        ZERO_CENTERED=zero_centered_gamma,
+        Q_GROUPED=True,
+        NPG=npg,
+        HEADS=heads,
+        ROWS=ROWS_PER_CTA,
+        num_warps=NUM_WARPS,
+    )
+    return qo, ko
+
+
+def can_use_grouped_qk_norm(
+    q_layernorm, k_layernorm, grouped_query: torch.Tensor, key: torch.Tensor
+) -> bool:
+    """Whether the grouped-read path is safe, i.e. the copy can be skipped entirely.
+
+    Everything :func:`can_use_fused_qk_norm` requires, plus the two assumptions the
+    grouped addressing makes about the QKV output: that a token's groups are evenly
+    spaced (so a token stride is ``ng * group_stride``), and that the heads inside a
+    group are contiguous.
+    """
+    if not USE_GROUPED_QK_NORM:
+        return False
+    if grouped_query.ndim != 4 or key.ndim != 4:
+        return False
+    hn = key.shape[-1]
+    if grouped_query.shape[3] % hn != 0:
+        return False
+    ng = grouped_query.shape[2]
+    if grouped_query.stride(3) != 1 or grouped_query.stride(1) != ng * grouped_query.stride(2):
+        return False
+    # `key` stands in for the query in the shared check: the grouped query's last dim is
+    # `(np/ng) * hn` rather than `hn`, and every property that check reads off the query
+    # -- head_dim, cuda-ness, last-dim contiguity, token count from `shape[:-2]` -- is
+    # identical between the two here, with the query's own layout verified just above.
+    return can_use_fused_qk_norm(q_layernorm, k_layernorm, key, key)
 
 
 def can_use_fused_qk_norm(q_layernorm, k_layernorm, query: torch.Tensor, key: torch.Tensor) -> bool:

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -35,6 +35,17 @@ from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.mappings import all_gather_last_dim_from_tensor_parallel_region
 from megatron.core.transformer.identity_op import IdentityOp
 from megatron.core.transformer.module import MegatronModule
+
+try:
+    from megatron.core.inference.attention.fused_qk_norm import (
+        can_use_fused_qk_norm as _can_use_fused_qk_norm,
+    )
+    from megatron.core.inference.attention.fused_qk_norm import (
+        fused_qk_rmsnorm as _fused_qk_rmsnorm,
+    )
+except Exception:  # keep attention importable if the inference helper is unavailable
+    _can_use_fused_qk_norm = None
+    _fused_qk_rmsnorm = None
 from megatron.core.transformer.torch_norm import L2Norm, LayerNormBuilder
 from megatron.core.transformer.utils import is_layer_window_attention
 from megatron.core.typed_torch import apply_module, not_none
@@ -1919,11 +1930,24 @@ class SelfAttention(Attention):
             )
             query = query[:, :, idx * size : (idx + 1) * size, :]
 
-        if self.q_layernorm is not None:
-            query = apply_module(self.q_layernorm)(query)
+        if _can_use_fused_qk_norm is not None and _can_use_fused_qk_norm(
+            self.q_layernorm, self.k_layernorm, query, key
+        ):
+            # Fuse the two per-head RMSNorm launches into one (env-gated, decode).
+            query, key = _fused_qk_rmsnorm(
+                query,
+                key,
+                self.q_layernorm.weight,
+                self.k_layernorm.weight,
+                self.config.layernorm_epsilon,
+                self.config.layernorm_zero_centered_gamma,
+            )
+        else:
+            if self.q_layernorm is not None:
+                query = apply_module(self.q_layernorm)(query)
 
-        if self.k_layernorm is not None:
-            key = apply_module(self.k_layernorm)(key)
+            if self.k_layernorm is not None:
+                key = apply_module(self.k_layernorm)(key)
 
         if self.config.test_mode:
             self.run_realtime_tests()

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import copy
 import inspect
+import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Callable, Optional, Protocol, Tuple, Union
@@ -41,11 +42,19 @@ try:
         can_use_fused_qk_norm as _can_use_fused_qk_norm,
     )
     from megatron.core.inference.attention.fused_qk_norm import (
+        can_use_grouped_qk_norm as _can_use_grouped_qk_norm,
+    )
+    from megatron.core.inference.attention.fused_qk_norm import (
         fused_qk_rmsnorm as _fused_qk_rmsnorm,
+    )
+    from megatron.core.inference.attention.fused_qk_norm import (
+        fused_qk_rmsnorm_grouped as _fused_qk_rmsnorm_grouped,
     )
 except Exception:  # keep attention importable if the inference helper is unavailable
     _can_use_fused_qk_norm = None
     _fused_qk_rmsnorm = None
+    _can_use_grouped_qk_norm = None
+    _fused_qk_rmsnorm_grouped = None
 from megatron.core.transformer.torch_norm import L2Norm, LayerNormBuilder
 from megatron.core.transformer.utils import is_layer_window_attention
 from megatron.core.typed_torch import apply_module, not_none
@@ -66,6 +75,10 @@ from ..models.common.embeddings.yarn_rotary_pos_embedding import (
 )
 from .enums import AttnMaskType
 from .transformer_config import TransformerConfig
+
+# Split QKV with torch.split (views) instead of TE's SplitAlongDim. Under test as the
+# suspected source of one full-QKV-sized copy per decode layer; see COPY-ID-S18.
+_QKV_SPLIT_VIEWS: bool = os.environ.get("MCORE_QKV_SPLIT_VIEWS", "0") == "1"
 
 try:
     from einops import rearrange
@@ -1893,7 +1906,7 @@ class SelfAttention(Attention):
                 self.hidden_size_per_attention_head,
             ]
 
-            if SplitAlongDim is not None:
+            if SplitAlongDim is not None and not _QKV_SPLIT_VIEWS:
                 query, gate, key, value = SplitAlongDim(mixed_qkv, 3, split_arg_list)
             else:
                 query, gate, key, value = torch.split(mixed_qkv, split_arg_list, dim=3)
@@ -1910,31 +1923,23 @@ class SelfAttention(Attention):
             if not split_qkv:
                 return mixed_qkv, split_arg_list
 
-            if SplitAlongDim is not None:
+            if SplitAlongDim is not None and not _QKV_SPLIT_VIEWS:
                 query, key, value = SplitAlongDim(mixed_qkv, 3, split_arg_list)
             else:
                 query, key, value = torch.split(mixed_qkv, split_arg_list, dim=3)
 
-        # Query [sq, b, ng, np/ng * hn] -> [sq, b, np, hn]
-        query = query.reshape(query.size(0), query.size(1), -1, self.hidden_size_per_attention_head)
-
-        if self.config.num_query_groups < self.world_size:
-            # query above corresponds to (num_q_heads / num_kv_heads) q_heads.
-            # Index appropriately into query to get (num_q_heads / tp_size) q_heads.
-            # This is step 4 in the list of steps above.
-            idx = get_pg_rank(self.pg_collection.tp) % (
-                self.world_size // self.config.num_query_groups
-            )
-            size = self.num_attention_heads_per_partition // (
-                self.world_size // self.config.num_query_groups
-            )
-            query = query[:, :, idx * size : (idx + 1) * size, :]
-
-        if _can_use_fused_qk_norm is not None and _can_use_fused_qk_norm(
-            self.q_layernorm, self.k_layernorm, query, key
+        # The [sq, b, ng, np/ng * hn] -> [sq, b, np, hn] reshape below is a *copy*, not a
+        # view: merging the group and head axes needs the group stride to equal
+        # (np/ng) * hn, and it is (np/ng + 2) * hn because each group's k and v head sit
+        # between consecutive groups' q heads. When the fused q/k norm can read the
+        # grouped layout directly it writes that shape itself for free, and the copy --
+        # one full-size strided copy per layer per decode step -- never happens.
+        if (
+            _can_use_grouped_qk_norm is not None
+            and self.config.num_query_groups >= self.world_size
+            and _can_use_grouped_qk_norm(self.q_layernorm, self.k_layernorm, query, key)
         ):
-            # Fuse the two per-head RMSNorm launches into one (env-gated, decode).
-            query, key = _fused_qk_rmsnorm(
+            query, key = _fused_qk_rmsnorm_grouped(
                 query,
                 key,
                 self.q_layernorm.weight,
@@ -1943,11 +1948,41 @@ class SelfAttention(Attention):
                 self.config.layernorm_zero_centered_gamma,
             )
         else:
-            if self.q_layernorm is not None:
-                query = apply_module(self.q_layernorm)(query)
+            # Query [sq, b, ng, np/ng * hn] -> [sq, b, np, hn]
+            query = query.reshape(
+                query.size(0), query.size(1), -1, self.hidden_size_per_attention_head
+            )
 
-            if self.k_layernorm is not None:
-                key = apply_module(self.k_layernorm)(key)
+            if self.config.num_query_groups < self.world_size:
+                # query above corresponds to (num_q_heads / num_kv_heads) q_heads.
+                # Index appropriately into query to get (num_q_heads / tp_size) q_heads.
+                # This is step 4 in the list of steps above.
+                idx = get_pg_rank(self.pg_collection.tp) % (
+                    self.world_size // self.config.num_query_groups
+                )
+                size = self.num_attention_heads_per_partition // (
+                    self.world_size // self.config.num_query_groups
+                )
+                query = query[:, :, idx * size : (idx + 1) * size, :]
+
+            if _can_use_fused_qk_norm is not None and _can_use_fused_qk_norm(
+                self.q_layernorm, self.k_layernorm, query, key
+            ):
+                # Fuse the two per-head RMSNorm launches into one (env-gated, decode).
+                query, key = _fused_qk_rmsnorm(
+                    query,
+                    key,
+                    self.q_layernorm.weight,
+                    self.k_layernorm.weight,
+                    self.config.layernorm_epsilon,
+                    self.config.layernorm_zero_centered_gamma,
+                )
+            else:
+                if self.q_layernorm is not None:
+                    query = apply_module(self.q_layernorm)(query)
+
+                if self.k_layernorm is not None:
+                    key = apply_module(self.k_layernorm)(key)
 
         if self.config.test_mode:
             self.run_realtime_tests()

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -55,6 +55,11 @@ except Exception:  # keep attention importable if the inference helper is unavai
     _fused_qk_rmsnorm = None
     _can_use_grouped_qk_norm = None
     _fused_qk_rmsnorm_grouped = None
+
+try:
+    from megatron.core.inference.attention import flashinfer_decode as _flashinfer_decode
+except Exception:  # keep attention importable if the inference helper is unavailable
+    _flashinfer_decode = None
 from megatron.core.transformer.torch_norm import L2Norm, LayerNormBuilder
 from megatron.core.transformer.utils import is_layer_window_attention
 from megatron.core.typed_torch import apply_module, not_none
@@ -1235,6 +1240,17 @@ class Attention(MegatronModule, ABC):
                     output_total = self._apply_sink_softmax_correction_bshd(
                         output_total, softmax_lse, softmax_offset
                     )
+            elif _flashinfer_decode is not None and _flashinfer_decode.can_use(
+                q, block_table, need_lse, window_size, tokens_per_request
+            ):
+                # Blackwell-native paged decode; ~24% under FA2 at these shapes.
+                if getattr(self, "softmax_scale", None) is not None:
+                    softmax_scale = self.softmax_scale
+                else:
+                    softmax_scale = q.shape[-1] ** -0.5
+                output_total = _flashinfer_decode.decode(
+                    q, k, v, block_table, seqlens_k, max_seqlen_k, softmax_scale
+                )
             else:
                 if use_fa4:
                     if getattr(self, "softmax_scale", None) is not None:

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -136,6 +136,11 @@ except ImportError:
 
 from megatron.core.transformer.transformer_config import MLATransformerConfig
 
+# See _resolve_flash_version: benchmarking-only override for a config field that
+# has no CLI flag. Empty means "leave the config's choice alone".
+_FA_VERSION_ENV = os.environ.get("MCORE_FLASH_ATTN_VERSION", "")
+
+
 try:
     from flash_attn import flash_attn_varlen_func, flash_attn_with_kvcache
 except:
@@ -1029,6 +1034,10 @@ class Attention(MegatronModule, ABC):
         when both are False the FA2 kernel is used.
         """
         pinned = self.flash_attention_version
+        # Benchmarking override: `flash_attention_version` has no CLI flag, so this
+        # is the only way to A/B generations from a launch script. Config wins.
+        if pinned is None and _FA_VERSION_ENV:
+            pinned = int(_FA_VERSION_ENV)
         if pinned == 4:
             assert (
                 HAVE_FA4


### PR DESCRIPTION
> Stacked on #6461. Review that one first; this diff is only an optional decode-attention
>
> GitHub cannot base a pull request from a fork on another unmerged fork branch, so the diff below also contains the parent's commits. This PR's own change is the final commit, `369cd1657`; review that one. The rest lands with the parent.
> backend that routes paged decode into flashinfer's trtllm-gen kernel instead of
> FlashAttention.

## Summary

Megatron's decode attention calls FlashAttention-2's `flash_attn_with_kvcache`, whose kernels
predate Blackwell; vLLM reaches `fmhaSm100f` for the same shapes through flashinfer, and
flashinfer is already installed in the same environment as flash-attn here. Routing paged
decode into flashinfer's trtllm-gen entry point measures a flat ~24% below FA2 across KV
lengths in isolation — 105.8 → 80.7 µs at KV length 1024 — with outputs matching to bf16
tolerance: **+1.46%** end-to-end decode throughput.

The integration is 143 lines rather than a port because of two properties of this particular
entry point. With `kv_layout="NHD"` the kernel takes exactly the paged layout Megatron already
has, and unlike flashinfer's wrapper APIs it needs no host-side `plan()` call, so it captures
inside the decode CUDA graph.

## Why here

A matched per-category device-time comparison against vLLM at BS256/OSL1024 put attention
**0.409 ms/step behind at an identical launch count**. An identical launch count rules out
everything Megatron does around the call — dispatch, bookkeeping, graph structure — and points
at the kernel generation itself. The reference implementation's answer was already in the
environment: the venv the benchmark runner launches carries flashinfer 0.6.14, so this needed
no new dependency.

The lesson worth carrying: before treating a kernel-quality gap as a porting project, check
what the reference implementation calls and whether it is already installed. Two sessions of
flag-flipping between FA2 and FA4 never left the flash-attn package, and the answer was not
in it.

## What changed

**Before.** The decode-only branch of `flash_decode_and_prefill` dispatches to FlashMLA for
MLA layers and otherwise to `flash_attn_with_kvcache` (or the FA3/FA4 equivalents).

**After.** A new branch between those two: when `flashinfer_decode.can_use` accepts the call,
decode goes to `trtllm_batch_decode_with_kv_cache` with the existing k and v caches, block
table and sequence lengths passed straight through. `bmm1_scale` carries the softmax scale and
`bmm2_scale` is 1.0, since the P·V product needs no rescaling for a bf16 cache. Page size is
irrelevant to the kernel — 256, 128 and 64 measured within 0.1 µs of each other — so
Megatron's 256-token pages stay; FA2 is in fact the stricter of the two, *requiring* pages be
a multiple of 256.

The one operational constraint is the 128 MiB scratch buffer, which must be zeroed before
first use. Zeroing it during graph capture would record a 128 MiB memset as a graph node
replayed every step, so the buffer is allocated eagerly and this path **declines and logs**
if it is first asked for it while a stream is capturing, falling back to FA2 for that graph.

**Programmatic Dependent Launch** is a second, independent knob on the same kernel. It lets
the kernel's prologue start while its predecessor drains, aimed at the 0.416 ms/step that sits
in sub-microsecond inter-kernel gaps (855 of 934 per-step gaps on this path). It measured
small and reproducible across two arms and is kept on the strength of the repeat rather than of
any single measurement; it is left as a knob because PDL interacts with graph capture and its
benefit depends on the neighbouring kernels.

**On the arithmetic.** The kernel is ~24% faster on an attention bucket of about 1.36 ms/step,
so ~0.33 ms/step of device time disappears. Less than that reaches the wall clock, because
removing device time partly un-hides host work — the same partial-overlap conversion this
campaign has measured for its other decode fusions. That is an attribution, not an isolated
result.

## Measurement

Fixed protocol: Qwen3-30B-A3B, BF16, TP 1 / PP 1 / EP 4 / ETP 1, 256 gsm8k requests, 1024 output tokens, 2 warmup + 5 timed iterations, a single OCI 4xGB200 node (nvl72160-T04), async dynamic-batching scheduler pinned on. All 20 arms ran back to back in one allocation on that one node; node-to-node variance on this workload is around 2.7%, so cross-node numbers would not be comparable.

- With this change (every other gate in the stack enabled): **31,518 tok/s**
- Without it (same node, same session, only this gate turned off): **31,066 tok/s**
- Leave-one-out delta: **+1.46%**
- Noise floor: sigma = **0.42%** over 3 repeats of the all-gates-on reference
- Verdict: **resolved** by margin (3.5 sigma). The per-iteration distributions do not separate strictly, but only because each reference arm contains one low outlier iteration; excluding those the arms do not overlap.

This is the **marginal contribution measured with every other gate in this stack enabled** — the question a reviewer is actually asking, which is whether this should land, not what it was worth when it was first written.

The reference is drift-corrected. The all-gates-on configuration was re-measured three times across the session (31,745, 31,530, 31,503 tok/s), a +0.77% drift from first to last, so each arm is compared against the reference interpolated to its own position in the run order rather than against a session mean.

For context, the whole stack is worth **+35.80%** on this node (23,265 tok/s with every gate off, 31,593 with every gate on). Per-slice deltas do not sum to that; they compose sub-additively.

## Evidence

Isolated kernel comparison at B=256, 32 query heads, 4 KV heads, D=128, under graph replay so
the numbers are device time rather than Python:

| KV len | FA2 | trtllm-gen | delta |
|---|---|---|---|
| 512 | 59.6 µs | 45.1 µs | −24.3% |
| 1024 | 105.8 µs | 80.7 µs | −23.7% |
| 2048 | 199.3 µs | 151.9 µs | −23.8% |

Flat across the range, with outputs matching FA2 to bf16 tolerance (rel ~3e-3).

**Liveness, and the trap that makes it necessary.** This is an optional import, and the module
degrades to `HAVE_FLASHINFER = False`. It therefore warns once at import when
`MCORE_FLASHINFER_DECODE=1` but flashinfer is not importable, and names `sys.executable` in
the message, because *the same command engages or declines depending only on which interpreter
launched it*: the container's system python does not have flashinfer, and the venv the
benchmark runner uses does. A session was spent concluding this gate was inert on the strength
of `pip show` run under the wrong interpreter, with a stale attention-bucket number that
appeared to corroborate it. Read the runner for its `PYBIN`/`VENV` before concluding anything
about what is installed.

Positive confirmation still has to come from a profile: with the path engaged, the decode
region contains the `fmhaSm100f`-family kernel and no `flash_attn_with_kvcache`.

## Correctness

- **Numerics:** behavioral only, and deliberately so. This is a different kernel with a
  different accumulation order; it is not bit-exact against FA2 and does not try to be. The
  isolated harness matches FA2 to bf16 tolerance (rel ~3e-3) at KV lengths 512, 1024 and 2048.
- **Tests:** the isolated harness above; the guard's preconditions are each a case this module
  has *not* validated against FA2, and the guard rejects rather than approximates, because a
  wrong answer there is a silent accuracy bug rather than a crash.
- **Coherence:** checked against the FA2 arm at temperature 0 and equally correct; not
  byte-identical, as a different kernel implies.

## Gating and blast radius

- Gate: `MCORE_FLASHINFER_DECODE`, **default OFF** (`os.environ.get(..., "0") == "1"`). Unset,
  `can_use` returns `False` on its first condition and decode runs the FlashAttention path
  byte-identically to before this PR.
- Second gate: `MCORE_FLASHINFER_PDL`, and it is **tri-state rather than default-off**. It
  defaults to the empty string, which becomes `None` and means *let flashinfer choose its own
  default*; `0` forces PDL off and `1` forces it on. That distinction is deliberate — forcing
  it off is not the same as not expressing an opinion — and the variable is unreachable anyway
  unless `MCORE_FLASHINFER_DECODE=1`.
- Preconditions checked by the guard: flashinfer importable; a paged KV cache (a `block_table`
  exists); no log-sum-exp needed, since attention sinks require an LSE correction pass that is
  not wired up; no sliding window, which would map to `window_left` and is untested; exactly
  one token per request, since speculative decoding needs `q_len_per_req` plumbing; dtype bf16
  or fp16; and a workspace obtainable without allocating mid-capture.
- Structurally decode-only: the branch lives in the `else: # decode only` arm of
  `flash_decode_and_prefill`, so prefill and mixed batches never reach it. MLA layers are
  handled by the branch above and are unaffected.
- When any precondition fails, or the import fails, or the workspace cannot be created safely:
  the FlashAttention path, unchanged. Training never reaches this function.

## Reproduce

```bash
MCORE_FLASHINFER_DECODE=1 \
QWEN30B_TP=1 QWEN30B_EP=4 QWEN30B_ETP=1 \
BENCH_SIZES_OVERRIDE=256 BENCH_OUTPUT_TOKENS=1024 \
NUM_WARMUP_ITERS=2 NUM_TIMED_ITERS=5 \
bash skills/run-qwen-model/run_qwen_inference.sh qwen3-30b-a3b --checkpoint "$QWEN30B_CKPT"
```

Add `MCORE_FLASHINFER_PDL=1` for the PDL arm. **Check the interpreter, not the container:**
flashinfer must be importable from the python the runner actually launches, which is the venv
python and not `/usr/bin/python`. If it is missing there, the import warning above fires and
the run silently uses FA2.

## What this does not claim

- **Attention is not closed.** The per-category comparison that selected this target had
  attention 0.409 ms/step behind vLLM, and a later trace with this kernel active still showed
  attention behind — 1.623 against 1.214 ms/step. That second reading was taken on a trace
  whose freshness the campaign itself questioned, so treat it as "a deficit of the same order
  remains" rather than as a precise post-change number. Either way this PR does not eliminate
  the attention gap.
- **Nothing for prefill or MLA.** Both take other branches.
- **Nothing for speculative decoding, sliding-window attention or attention sinks.** Each is a
  precondition the guard rejects, and each is rejected because it is unvalidated, not because
  it is known to be wrong.
- **PDL's contribution is small and rests on a repeat.** It sits below the per-iteration
  spread on any single arm and is credible only because two arms agreed. Anyone re-measuring it
  should expect to need the repeat too, and it should be treated as separable from the kernel
  swap.
- **The e2e result is smaller than the kernel result, and the shortfall is attributed rather
  than isolated.** ~0.33 ms/step of device time is removed; part of it un-hides host work.
- **This overlaps with the FlashAttention pin it stacks on.** When this path engages, decode
  runs no FlashAttention kernel at all and the pin governs only prefill and declined calls, so
  the two deltas certainly do not add. Nor do they add with the norm fusions elsewhere in this
  stack, which attack the same host dispatch gaps.

## Follow-ups

- The remaining attention deficit against vLLM is now the second-largest known gap after the
  MoE kernel, and it is a genuine deficit rather than a misconfiguration.
- Wiring the LSE return would let attention-sink models use this path.
- `q_len_per_req` plumbing would extend it to speculative decoding.
- An optional-import capability gate that degrades silently makes a run script's gate list a
  statement of intent rather than a record of what ran. This module logs when it is asked for
  and unavailable; the other optional-import gates in `inference/` do not, and should.

---

## This stack

This is one slice of [#6064](https://github.com/NVIDIA/Megatron-LM/pull/6064), a Qwen3-30B-A3B decode optimization campaign, split into 16 independently reviewable changes. Together they are **+35.80%** end-to-end throughput over the same base commit (23,265 -> 31,593 tok/s, mean of three full runs).

- **MoE grouped-GEMM and dispatch:** #6452 -> #6453 -> #6454 -> #6455
- **MoE router and combine:** #6456 -> #6457 -> #6458
- **Attention: QK norm and decode kernel:** #6459 -> #6460 -> #6461 -> #6462
- **Residual + RMSNorm fusion:** #6463 -> #6464
- **Host path: context bookkeeping:** #6465 -> #6466
- **Host path: independent:** #6467

Each chain is independent of the others and bases on `main`. Within a chain, later PRs depend on earlier ones.

### Per-slice measured delta

Every number is a leave-one-out delta from one same-node, same-session campaign: the full stack with exactly this change's gate off, against the interpolated full-stack reference at that point in the run. It is the change's *marginal* contribution with everything else already in, not its standalone value. Run-to-run sigma was **0.42%** across three full-stack repeats.

| PR | Change | Delta | |
|---|---|---|---|
| #6452 | FC1 SwiGLU epilogue | +14.81% | resolved |
| #6453 | indirection table fusion | +7.21% | resolved |
| #6454 | decode GEMM tile configs | +6.77% | resolved |
| #6455 | predicated top-k gather | +1.99% | by margin |
| #6456 | fused router softmax+top-k | +4.75% | resolved |
| #6457 | fused route padding mask | +1.47% | by margin |
| #6458 | bf16 MoE combine | +2.42% | by margin |
| #6459 | fused QK RMSNorm | +5.17% | resolved |
| #6460 | grouped QK norm input | +1.18% | by margin |
| #6461 | pin FlashAttention 2 | -0.35% | noise floor |
| #6462 | FlashInfer TRT-LLM decode | +1.46% | by margin |
| #6463 | fused add+norm pre-MLP | +3.54% | by margin |
| #6464 | fused add+norm pre-QKV | +0.98% | by margin |
| #6465 | incremental attention state | -0.42% | noise floor |
| #6466 | vectorized decode bookkeeping | -0.07% | noise floor |
| #6467 | post_process_requests fast path | +0.09% | noise floor |

`noise floor` means the delta is inside 2 sigma (0.84%) and this campaign cannot distinguish it from zero. `resolved` means the leave-one-out and full-stack iteration distributions did not overlap. Deltas do not sum to the stack total: these changes shorten the same decode step and compose sub-additively.

**Fixed protocol for every number above.** Qwen3-30B-A3B, BF16, TP1/PP1/EP4/ETP1, 256 gsm8k requests at batch size 256, output length 1024, CUDA graphs on, one OCI GB200 NVL72 node, 4 GPUs. All 20 arms ran back-to-back in a single Slurm allocation on one node, so node assignment and thermal state are held constant.
