### PR TITLE
perf(inference): fuse the residual add with the pre-MLP RMSNorm on the decode path

### DIFF
--- a/megatron/core/inference/fused_add_rmsnorm.py
+++ b/megatron/core/inference/fused_add_rmsnorm.py
@@ -1,0 +1,176 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Single-launch fused residual-add + RMSNorm for the decode path.
+
+Every transformer block boundary in the ``inference_optimized`` path runs a
+bias-dropout-add (``get_bias_dropout_add``; for Qwen this is a plain
+``residual + hidden`` since there is no bias and dropout is disabled at decode)
+immediately followed by an RMSNorm (``input_layernorm`` / ``pre_mlp_layernorm``).
+In the profile these are two separate kernels per boundary — a
+``triton_poi_fused_add_copy`` (~1.5 µs) then a TE ``rmsnorm_fwd_tuned``
+(~2.9 µs) — i.e. two launches and two CUDA-graph nodes per boundary, ×2 per
+layer ×48 layers. vLLM instead runs one ``triton_..._add_..._rms_norm`` kernel.
+
+This module provides that single kernel: ``new_residual = hidden + residual``
+followed by ``rmsnorm(new_residual) * gamma``, returning both the normalized
+activation (for the next GEMM) and the updated residual (for the next
+bias-dropout-add). The add is done in fp32 and rounded to bf16, matching
+PyTorch's bf16 add; the RMSNorm is fp32 mean-of-squares → ``rsqrt(var+eps)`` →
+(optionally 1-centered) gamma, matching TE's RMSNorm to bf16 rounding.
+
+Env-gated (``MCORE_FUSED_ADD_NORM``); default off so the untouched two-kernel
+path is used unless explicitly enabled.
+"""
+
+import os
+from typing import Tuple
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+
+    HAVE_TRITON = True
+except ImportError:
+    HAVE_TRITON = False
+
+USE_FUSED_ADD_NORM: bool = os.environ.get("MCORE_FUSED_ADD_NORM", "0") == "1"
+
+# The one-row-per-CTA kernel is launch/latency bound; it wins in the decode
+# regime and should not be used for large prefill token counts.
+FUSED_ADD_NORM_MAX_TOKENS: int = int(os.environ.get("MCORE_FUSED_ADD_NORM_MAX_TOKENS", "256"))
+
+
+if HAVE_TRITON:
+
+    @triton.jit
+    def _fused_add_rmsnorm_kernel(
+        x_ptr,
+        res_ptr,
+        w_ptr,
+        o_ptr,
+        nr_ptr,
+        x_rs,
+        res_rs,
+        o_rs,
+        nr_rs,
+        eps,
+        H: tl.constexpr,
+        ZERO_CENTERED: tl.constexpr,
+        BLOCK: tl.constexpr,
+    ):
+        """One CTA per token row: add the residual, store it, then RMSNorm."""
+        row = tl.program_id(0)
+        cols = tl.arange(0, BLOCK)
+        mask = cols < H
+
+        x = tl.load(x_ptr + row * x_rs + cols, mask=mask, other=0.0).to(tl.float32)
+        r = tl.load(res_ptr + row * res_rs + cols, mask=mask, other=0.0).to(tl.float32)
+        s = x + r
+        tl.store(nr_ptr + row * nr_rs + cols, s.to(nr_ptr.dtype.element_ty), mask=mask)
+
+        var = tl.sum(s * s, axis=0) / H
+        inv = 1.0 / tl.sqrt(var + eps)
+        w = tl.load(w_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        if ZERO_CENTERED:
+            w = w + 1.0
+        y = s * inv * w
+        tl.store(o_ptr + row * o_rs + cols, y.to(o_ptr.dtype.element_ty), mask=mask)
+
+
+def _next_pow2(n: int) -> int:
+    p = 1
+    while p < n:
+        p <<= 1
+    return p
+
+
+def fused_add_rmsnorm(
+    hidden: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    zero_centered_gamma: bool,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Fuse ``residual + hidden`` and RMSNorm into one launch.
+
+    Args:
+        hidden: activation to add to the residual; ``[.., H]`` (last dim
+            normalized, must be contiguous).
+        residual: residual stream tensor, same shape as ``hidden``.
+        weight: ``[H]`` RMSNorm gamma.
+        eps: RMSNorm epsilon.
+        zero_centered_gamma: if True, apply ``(1 + gamma)`` (matches TE).
+
+    Returns:
+        ``(normed, new_residual)`` — ``normed`` feeds the next GEMM, and
+        ``new_residual = hidden + residual`` is carried to the next add.
+    """
+    hn = hidden.shape[-1]
+    x2 = hidden.reshape(-1, hn)
+    r2 = residual.reshape(-1, hn)
+
+    o = torch.empty(hidden.shape, dtype=hidden.dtype, device=hidden.device)
+    nr = torch.empty(hidden.shape, dtype=hidden.dtype, device=hidden.device)
+    o2 = o.view(-1, hn)
+    nr2 = nr.view(-1, hn)
+
+    n_rows = x2.shape[0]
+    block = _next_pow2(hn)
+    _fused_add_rmsnorm_kernel[(n_rows,)](
+        x2,
+        r2,
+        weight,
+        o2,
+        nr2,
+        x2.stride(0),
+        r2.stride(0),
+        o2.stride(0),
+        nr2.stride(0),
+        float(eps),
+        H=hn,
+        ZERO_CENTERED=zero_centered_gamma,
+        BLOCK=block,
+        num_warps=8,
+    )
+    return o, nr
+
+
+def _tensors_compatible(w: torch.Tensor, hidden: torch.Tensor, residual: torch.Tensor) -> bool:
+    """Shared shape/layout/token-count check for the fused add+RMSNorm kernel.
+
+    This runs once per layer per decode step, so it short-circuits on the
+    cheapest checks first and allocates nothing.
+    """
+    hn = hidden.shape[-1]
+    if hidden.shape != residual.shape or hn != w.numel():
+        return False
+    if not (hidden.is_cuda and residual.is_cuda):
+        return False
+    if hidden.stride(-1) != 1 or residual.stride(-1) != 1:
+        return False
+    n_tokens = 1
+    for d in hidden.shape[:-1]:
+        n_tokens *= d
+    if n_tokens > FUSED_ADD_NORM_MAX_TOKENS:
+        return False
+    return True
+
+
+def can_use_fused_add_rmsnorm(norm_module, hidden: torch.Tensor, residual: torch.Tensor) -> bool:
+    """Whether the fused kernel reproduces this exact add+RMSNorm contract.
+
+    Requires a weight-only RMSNorm module (no bias), matching contiguous
+    ``[.., H]`` shapes on CUDA, and a decode-sized token count.
+    """
+    if not (HAVE_TRITON and USE_FUSED_ADD_NORM):
+        return False
+    if norm_module is None:
+        return False
+    w = getattr(norm_module, "weight", None)
+    if w is None:
+        return False
+    if getattr(norm_module, "bias", None) is not None:
+        return False
+    return _tensors_compatible(w, hidden, residual)

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -17,6 +17,16 @@ from megatron.core.dist_checkpointing.mapping import ShardedStateDict
 from megatron.core.dist_checkpointing.utils import apply_prefix_mapping
 from megatron.core.inference.utils import InferenceMode
 from megatron.core.packed_seq_params import PackedSeqParams
+
+try:
+    from megatron.core.inference.fused_add_rmsnorm import (
+        can_use_fused_add_rmsnorm as _can_use_fused_add_rmsnorm,
+    )
+    from megatron.core.inference.fused_add_rmsnorm import fused_add_rmsnorm as _fused_add_rmsnorm
+except Exception:  # keep the layer importable if the inference helper is unavailable
+    _can_use_fused_add_rmsnorm = None
+    _fused_add_rmsnorm = None
+
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.transformer.cuda_graphs import is_graph_capturing
 from megatron.core.transformer.enums import CudaGraphModule, InferenceCudaGraphScope, LayerType
@@ -613,6 +623,10 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         """
         inference_context = deprecate_inference_params(inference_context, inference_params)
 
+        # Cleared each forward; set only when the self_attn_bda + pre_mlp_layernorm
+        # fused-add-norm path runs, so _forward_pre_mlp_layernorm can consume it.
+        self._fused_pre_mlp_normed = None
+
         # Optional Input Layer norm
         attn_norm_manager = self.off_interface(self.offload_attn_norm, hidden_states, "attn_norm")
         if self.recompute_input_layernorm:
@@ -680,10 +694,36 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
             # self attention module.
             hidden_states = attention_output_with_bias[0]
         else:
-            with self.bias_dropout_add_exec_handler():
-                hidden_states = self.self_attn_bda(self.training, self.config.bias_dropout_fusion)(
-                    attention_output_with_bias, residual, self.hidden_dropout
+            attn_out = attention_output_with_bias[0]
+            if (
+                _fused_add_rmsnorm is not None
+                and not self.training
+                and self.config.normalization == "RMSNorm"
+                and attention_output_with_bias[1] is None
+                and isinstance(self.cross_attention, IdentityOp)
+                and isinstance(self.pre_cross_attn_layernorm, IdentityOp)
+                and not self.recompute_pre_mlp_layernorm
+                and not getattr(self, "offload_attn_norm", False)
+                and not getattr(self, "offload_mlp_norm", False)
+                and _can_use_fused_add_rmsnorm(self.pre_mlp_layernorm, attn_out, residual)
+            ):
+                # Fuse the residual-add (self_attn_bda) with the standalone
+                # pre-MLP RMSNorm: one kernel yields both the updated residual
+                # and the normalized MLP input, removing a launch + graph node
+                # per layer. Decode-gated; falls back below otherwise.
+                pre_mlp_normed, hidden_states = _fused_add_rmsnorm(
+                    attn_out,
+                    residual,
+                    self.pre_mlp_layernorm.weight,
+                    self.config.layernorm_epsilon,
+                    self.config.layernorm_zero_centered_gamma,
                 )
+                self._fused_pre_mlp_normed = pre_mlp_normed
+            else:
+                with self.bias_dropout_add_exec_handler():
+                    hidden_states = self.self_attn_bda(
+                        self.training, self.config.bias_dropout_fusion
+                    )(attention_output_with_bias, residual, self.hidden_dropout)
         nvtx_range_pop(suffix="self_attn_bda")
 
         # Delay the offload of the attention norm until after the self_attn_bda has been computed
@@ -747,6 +787,12 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         return output, context
 
     def _forward_pre_mlp_layernorm(self, hidden_states: Tensor):
+        # If the fused self_attn_bda + pre_mlp_layernorm path ran, the normed
+        # activation is already computed; consume it and skip the norm call.
+        stashed = getattr(self, "_fused_pre_mlp_normed", None)
+        if stashed is not None:
+            self._fused_pre_mlp_normed = None
+            return stashed
         self.mlp_norm_manager = self.off_interface(self.offload_mlp_norm, hidden_states, "mlp_norm")
         if self.recompute_pre_mlp_layernorm:
             self.pre_mlp_norm_checkpoint = tensor_parallel.CheckpointWithoutOutput()


### PR DESCRIPTION
> Root of a two-PR chain. the parent PR stacks on this one and depends on it **at runtime**, not only
> in the stack ordering — turning this PR's gate off also disables that one. See "Gating and
> blast radius".

## Summary

Every transformer block boundary on the decode path runs a bias-dropout-add — for this model
a plain `residual + hidden`, since there is no bias and dropout is disabled — immediately
followed by an RMSNorm, and they run as two separate kernels: a ~1.5 µs
`triton_poi_fused_add_copy` then a ~2.9 µs TransformerEngine `rmsnorm_fwd_tuned`. One Triton
kernel that adds the residual, stores it, and normalizes the sum does both at the pre-MLP
boundary in 4.11 µs instead of 6.16, deleting ~2 µs of GPU work per layer per step:
**+3.54%** end-to-end decode throughput.

Unlike the Q/K norm fusion elsewhere in this campaign, this kernel does not fall behind
TransformerEngine outside the decode regime — it is flat at ~4.1 µs and 2.0× the two-kernel
pair at 384 and 512 tokens. Its token cap is therefore caution about untested shapes, not a
crossover point.

## Why here

A steady-state decode profile ranked small kernels by count, and the two dominant ones were
adjacent on the serial path: `triton_poi_fused_add_copy` at 103 per step and
`rmsnorm_fwd_tuned` at 104 per step. Each layer contributes two of each — one boundary after
attention, one after the MLP.

Only one of those two boundaries is reachable without touching TransformerEngine. The
pre-MLP norm is a standalone module (48 per step) and can be intercepted; the input norm
lives inside the QKV GEMM's `LayerNormLinear` and cannot, which is what the follow-up in
this chain addresses.

**Size this by the GPU work it deletes, not by the launches it removes.** That framing is
retired for this fusion, and deliberately: launch submission on this path costs on the order
of 10 µs per step in total, not the ~180 µs a launch-bound reading would need to explain
anything, and a separate change in this campaign deleted 76 launches carrying 0.185 ms of
device time for no measurable gain. Across the four kernel families the two fusions in this
chain touch, device time goes **0.787 → 0.401 ms/step**, i.e. 0.386 ms of kernel time
removed, of which roughly two thirds converted into wall-clock saving — which is what partial
overlap predicts. That figure covers **both** fusions in the chain, not this PR alone; this
PR's own number is in Measurement.

## What changed

**Before.** At the `self_attn_bda` site, `get_bias_dropout_add` produces the updated residual
in one kernel; `_forward_pre_mlp_layernorm` then calls `pre_mlp_layernorm` on it in a second.
The sum is written to memory by the first kernel and read back by the second.

**After.** One Triton kernel, one CTA per token row with `BLOCK` the next power of two above
the hidden size and eight warps. It loads the activation and the residual, adds them in fp32,
stores the rounded sum as the new residual, and then — with the sum still in registers —
computes the fp32 mean-of-squares, `rsqrt(var + eps)` and the optionally 1-centered gamma,
storing the normalized result separately. It returns `(normed, new_residual)`: the residual
goes back into the layer's dataflow unchanged, and the normed activation is stashed on the
layer so that `_forward_pre_mlp_layernorm` returns it directly and never calls the norm.

The saving is the round trip. The sum no longer leaves registers between the add and the
reduction, so one full read and one full write of a `[tokens, hidden]` tensor disappear per
boundary, along with the second kernel's own fixed cost.

## Measurement

Fixed protocol: Qwen3-30B-A3B, BF16, TP 1 / PP 1 / EP 4 / ETP 1, 256 gsm8k requests, 1024 output tokens, 2 warmup + 5 timed iterations, a single OCI 4xGB200 node (nvl72160-T04), async dynamic-batching scheduler pinned on. All 20 arms ran back to back in one allocation on that one node; node-to-node variance on this workload is around 2.7%, so cross-node numbers would not be comparable.

- With this change (every other gate in the stack enabled): **31,527 tok/s**
- Without it (same node, same session, only this gate turned off): **30,449 tok/s**
- Leave-one-out delta: **+3.54%**
- Noise floor: sigma = **0.42%** over 3 repeats of the all-gates-on reference
- Verdict: **resolved** by margin (8.4 sigma). The per-iteration distributions do not separate strictly, but only because each reference arm contains one low outlier iteration; excluding those the arms do not overlap.

This is the **marginal contribution measured with every other gate in this stack enabled** — the question a reviewer is actually asking, which is whether this should land, not what it was worth when it was first written.

The reference is drift-corrected. The all-gates-on configuration was re-measured three times across the session (31,745, 31,530, 31,503 tok/s), a +0.77% drift from first to last, so each arm is compared against the reference interpolated to its own position in the run order rather than against a session mean.

For context, the whole stack is worth **+35.80%** on this node (23,265 tok/s with every gate off, 31,593 with every gate on). Per-slice deltas do not sum to that; they compose sub-additively.

## Evidence

Microbench under CUDA-graph replay, at 256 tokens: add + TransformerEngine norm 6.16 µs →
fused 4.11 µs, **1.50×**. At 384 and 512 tokens the fused kernel is flat at ~4.1 µs while the
two-kernel pair grows, so it measures **2.0×** there.

**Liveness has to come from a trace, because no diagnostic ships with this PR, and this
fusion is exactly the one that has silently failed before.** It was written, put in a standing
gate list, and a profile labelled as having every gate enabled contained *zero* fused
add-norm kernels along with precisely the two-kernel pattern the module's own docstring
describes as the thing it replaces — 96 `triton_poi_fused_add_copy` launches (two per layer)
and 193 standalone TransformerEngine RMSNorms. The cause was a second, undocumented gate on
the other boundary, but the reason it went unnoticed for two sessions is that a declining
guard and an ineffective change look identical from the throughput number alone.

So before trusting an arm: confirm `_fused_add_rmsnorm_kernel` appears about once per layer
per step (48 per step here), and that the `triton_poi_fused_add_copy` and TE RMSNorm counts
each drop by the same amount. When this was instrumented during development, the guard
engaged on every layer at 256 tokens; the only refusals were at `(512, 1, 2048)` — prefill,
correctly excluded by the token cap.

## Correctness

Two different classes here, and they should not be collapsed into one.

- **The residual stream is bit-exact.** The add is performed in fp32 and rounded once to
  bf16, which is what PyTorch's bf16 add does, so `new_residual` is bit-identical to the
  tensor the `self_attn_bda` path produced. This matters more than the norm's numerics,
  because the residual is what propagates through the rest of the network.
- **The norm is within one bf16 ulp**, `max_rel ≤ 7.9e-3`, and not bit-exact: TE's internal
  rsqrt and reduction order differ from Triton's and this kernel does not attempt to reproduce
  them. The reduction is fp32 and the gamma handling, including `zero_centered_gamma`, matches
  TE's contract.
- **Tests:** microbench equivalence against the add-then-norm path at the decode shapes, and
  at 384 and 512 tokens where the kernel is also correct even though the guard declines there.
- **Coherence:** **all three** temperature-0 prompts are byte-identical to the reference arm,
  including the one that the Q/K norm fusion in this campaign flipped. Both continuations sets
  are fluent and factually correct. That the bit-exact half is the residual is the likely
  reason this fusion is quieter than the others.

## Gating and blast radius

- Gate: `MCORE_FUSED_ADD_NORM`, **default OFF** (`os.environ.get(..., "0") == "1"`). Unset,
  `can_use_fused_add_rmsnorm` returns `False` on its first condition and the original
  `self_attn_bda` call plus the standalone norm run byte-identically to before this PR.
- Token cap: `MCORE_FUSED_ADD_NORM_MAX_TOKENS`, **default 256**, counted over every dimension
  but the last.
- Preconditions checked at the call site: the inference helper imported successfully;
  `not self.training`; `config.normalization == "RMSNorm"`; no attention output bias; cross
  attention and the pre-cross-attention norm are both `IdentityOp`; `pre_mlp_layernorm` is not
  being recomputed; neither the attention norm nor the MLP norm is being offloaded. Then, in
  the helper: Triton available, a weight-bearing norm module with **no** bias, matching shapes,
  both tensors on CUDA, last dimension contiguous, and the token count under the cap.
- The whole fused branch sits in the `else` of the existing `using_fused_tp_inference_kernel`
  check (`inference_fuse_tp_communication` under inference mode), which already moves the
  residual add inside the MLP. That mode is untouched and takes precedence.
- When any precondition fails: the original `self_attn_bda` path, unchanged. Training is
  excluded twice over — by `not self.training` and by the token cap.
- **The follow-up PR in this chain depends on this gate at runtime.** When this fusion fires,
  `_forward_pre_mlp_layernorm` returns the stashed activation *before* it assigns
  `self.mlp_norm_manager`:

  In `TransformerLayer._forward_pre_mlp_layernorm` (`transformer_layer.py`):

```python
        stashed = getattr(self, "_fused_pre_mlp_normed", None)
        if stashed is not None:
            self._fused_pre_mlp_normed = None
            return stashed
        self.mlp_norm_manager = self.off_interface(self.offload_mlp_norm, hidden_states, "mlp_norm")
```

  `self.off_interface` is a class, so that assignment always produces a non-`None` instance
  whether or not offloading is enabled. The follow-up's guard requires
  `self.mlp_norm_manager is None`, so it can only pass on layers where *this* fusion already
  fired. Setting `MCORE_FUSED_ADD_NORM=0` therefore disables both fusions regardless of the
  other gate, and a leave-one-out arm on this gate is measuring both changes at once. Neither
  gate's name says so.

## Reproduce

```bash
MCORE_FUSED_ADD_NORM=1 \
QWEN30B_TP=1 QWEN30B_EP=4 QWEN30B_ETP=1 \
BENCH_SIZES_OVERRIDE=256 BENCH_OUTPUT_TOKENS=1024 \
NUM_WARMUP_ITERS=2 NUM_TIMED_ITERS=5 \
bash skills/run-qwen-model/run_qwen_inference.sh qwen3-30b-a3b --checkpoint "$QWEN30B_CKPT"
```

Triton is required; without it `HAVE_TRITON` is `False` and the guard declines silently.

## What this does not claim

- **Nothing above 256 tokens** — but not because the kernel regresses there. It measures 2.0×
  at 384 and 512 tokens. The cap is there because prefill shapes were not validated end to
  end, and lifting it is a separate change with its own measurement.
- **Only half the boundaries.** Of the two add-then-norm pairs per layer this reaches one; the
  other's norm is inside `linear_qkv` and needs the follow-up PR.
- **Not a launch-count win, and the description deliberately avoids that framing.** Launch
  submission is too cheap on this path to explain a gain of this size, and this campaign has a
  counterexample where deleting 76 launches worth 0.185 ms of device time bought nothing.
- **The 0.386 ms/step of removed device time is for both fusions in this chain together**, not
  for this PR. So is the roughly two-thirds conversion ratio.
- **The norm is not bit-exact.** See Correctness; acceptance rests on the residual being
  bit-exact and on coherence, not on byte-identity of the norm output.
- **No liveness signal ships.** Verify from kernel counts.
- Deltas in this stack do not add. This change, the follow-up, and the attention-side norm
  fusions all remove small kernels from the same serial chain and the same host dispatch gaps,
  so they compose sub-additively.

## Follow-ups

- the parent PR, which covers the other boundary at TP=1 and depends on this one at runtime.
- The token cap is inherited caution rather than a measured crossover; the kernel is faster
  than the pair it replaces at every shape tested, so raising it is a candidate.
- The stash is an instance attribute cleared at the start of each forward and on read. A
  cleaner form would thread the normed activation through the return value, but that changes a
  widely-used signature and was left alone.

---

## This stack

This is one slice of [#6064](https://github.com/NVIDIA/Megatron-LM/pull/6064), a Qwen3-30B-A3B decode optimization campaign, split into 16 independently reviewable changes. Together they are **+35.80%** end-to-end throughput over the same base commit (23,265 -> 31,593 tok/s, mean of three full runs).

- **MoE grouped-GEMM and dispatch:** #6452 -> #6453 -> #6454 -> #6455
- **MoE router and combine:** #6456 -> #6457 -> #6458
- **Attention: QK norm and decode kernel:** #6459 -> #6460 -> #6461 -> #6462
- **Residual + RMSNorm fusion:** #6463 -> #6464
- **Host path: context bookkeeping:** #6465 -> #6466
- **Host path: independent:** #6467

Each chain is independent of the others and bases on `main`. Within a chain, later PRs depend on earlier ones.

### Per-slice measured delta

Every number is a leave-one-out delta from one same-node, same-session campaign: the full stack with exactly this change's gate off, against the interpolated full-stack reference at that point in the run. It is the change's *marginal* contribution with everything else already in, not its standalone value. Run-to-run sigma was **0.42%** across three full-stack repeats.

| PR | Change | Delta | |
|---|---|---|---|
| #6452 | FC1 SwiGLU epilogue | +14.81% | resolved |
| #6453 | indirection table fusion | +7.21% | resolved |
| #6454 | decode GEMM tile configs | +6.77% | resolved |
| #6455 | predicated top-k gather | +1.99% | by margin |
| #6456 | fused router softmax+top-k | +4.75% | resolved |
| #6457 | fused route padding mask | +1.47% | by margin |
| #6458 | bf16 MoE combine | +2.42% | by margin |
| #6459 | fused QK RMSNorm | +5.17% | resolved |
| #6460 | grouped QK norm input | +1.18% | by margin |
| #6461 | pin FlashAttention 2 | -0.35% | noise floor |
| #6462 | FlashInfer TRT-LLM decode | +1.46% | by margin |
| #6463 | fused add+norm pre-MLP | +3.54% | by margin |
| #6464 | fused add+norm pre-QKV | +0.98% | by margin |
| #6465 | incremental attention state | -0.42% | noise floor |
| #6466 | vectorized decode bookkeeping | -0.07% | noise floor |
| #6467 | post_process_requests fast path | +0.09% | noise floor |

`noise floor` means the delta is inside 2 sigma (0.84%) and this campaign cannot distinguish it from zero. `resolved` means the leave-one-out and full-stack iteration distributions did not overlap. Deltas do not sum to the stack total: these changes shorten the same decode step and compose sub-additively.

**Fixed protocol for every number above.** Qwen3-30B-A3B, BF16, TP1/PP1/EP4/ETP1, 256 gsm8k requests at batch size 256, output length 1024, CUDA graphs on, one OCI GB200 NVL72 node, 4 GPUs. All 20 arms ran back-to-back in a single Slurm allocation on one node, so node assignment and thermal state are held constant.
