### PR TITLE
perf(inference): fuse the mlp_bda residual add with the next layer's QKV input norm

### DIFF
--- a/megatron/core/inference/fused_add_rmsnorm.py
+++ b/megatron/core/inference/fused_add_rmsnorm.py
@@ -1,0 +1,176 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Single-launch fused residual-add + RMSNorm for the decode path.
+
+Every transformer block boundary in the ``inference_optimized`` path runs a
+bias-dropout-add (``get_bias_dropout_add``; for Qwen this is a plain
+``residual + hidden`` since there is no bias and dropout is disabled at decode)
+immediately followed by an RMSNorm (``input_layernorm`` / ``pre_mlp_layernorm``).
+In the profile these are two separate kernels per boundary — a
+``triton_poi_fused_add_copy`` (~1.5 µs) then a TE ``rmsnorm_fwd_tuned``
+(~2.9 µs) — i.e. two launches and two CUDA-graph nodes per boundary, ×2 per
+layer ×48 layers. vLLM instead runs one ``triton_..._add_..._rms_norm`` kernel.
+
+This module provides that single kernel: ``new_residual = hidden + residual``
+followed by ``rmsnorm(new_residual) * gamma``, returning both the normalized
+activation (for the next GEMM) and the updated residual (for the next
+bias-dropout-add). The add is done in fp32 and rounded to bf16, matching
+PyTorch's bf16 add; the RMSNorm is fp32 mean-of-squares → ``rsqrt(var+eps)`` →
+(optionally 1-centered) gamma, matching TE's RMSNorm to bf16 rounding.
+
+Env-gated (``MCORE_FUSED_ADD_NORM``); default off so the untouched two-kernel
+path is used unless explicitly enabled.
+"""
+
+import os
+from typing import Tuple
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+
+    HAVE_TRITON = True
+except ImportError:
+    HAVE_TRITON = False
+
+USE_FUSED_ADD_NORM: bool = os.environ.get("MCORE_FUSED_ADD_NORM", "0") == "1"
+
+# The one-row-per-CTA kernel is launch/latency bound; it wins in the decode
+# regime and should not be used for large prefill token counts.
+FUSED_ADD_NORM_MAX_TOKENS: int = int(os.environ.get("MCORE_FUSED_ADD_NORM_MAX_TOKENS", "256"))
+
+
+if HAVE_TRITON:
+
+    @triton.jit
+    def _fused_add_rmsnorm_kernel(
+        x_ptr,
+        res_ptr,
+        w_ptr,
+        o_ptr,
+        nr_ptr,
+        x_rs,
+        res_rs,
+        o_rs,
+        nr_rs,
+        eps,
+        H: tl.constexpr,
+        ZERO_CENTERED: tl.constexpr,
+        BLOCK: tl.constexpr,
+    ):
+        """One CTA per token row: add the residual, store it, then RMSNorm."""
+        row = tl.program_id(0)
+        cols = tl.arange(0, BLOCK)
+        mask = cols < H
+
+        x = tl.load(x_ptr + row * x_rs + cols, mask=mask, other=0.0).to(tl.float32)
+        r = tl.load(res_ptr + row * res_rs + cols, mask=mask, other=0.0).to(tl.float32)
+        s = x + r
+        tl.store(nr_ptr + row * nr_rs + cols, s.to(nr_ptr.dtype.element_ty), mask=mask)
+
+        var = tl.sum(s * s, axis=0) / H
+        inv = 1.0 / tl.sqrt(var + eps)
+        w = tl.load(w_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        if ZERO_CENTERED:
+            w = w + 1.0
+        y = s * inv * w
+        tl.store(o_ptr + row * o_rs + cols, y.to(o_ptr.dtype.element_ty), mask=mask)
+
+
+def _next_pow2(n: int) -> int:
+    p = 1
+    while p < n:
+        p <<= 1
+    return p
+
+
+def fused_add_rmsnorm(
+    hidden: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    zero_centered_gamma: bool,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Fuse ``residual + hidden`` and RMSNorm into one launch.
+
+    Args:
+        hidden: activation to add to the residual; ``[.., H]`` (last dim
+            normalized, must be contiguous).
+        residual: residual stream tensor, same shape as ``hidden``.
+        weight: ``[H]`` RMSNorm gamma.
+        eps: RMSNorm epsilon.
+        zero_centered_gamma: if True, apply ``(1 + gamma)`` (matches TE).
+
+    Returns:
+        ``(normed, new_residual)`` — ``normed`` feeds the next GEMM, and
+        ``new_residual = hidden + residual`` is carried to the next add.
+    """
+    hn = hidden.shape[-1]
+    x2 = hidden.reshape(-1, hn)
+    r2 = residual.reshape(-1, hn)
+
+    o = torch.empty(hidden.shape, dtype=hidden.dtype, device=hidden.device)
+    nr = torch.empty(hidden.shape, dtype=hidden.dtype, device=hidden.device)
+    o2 = o.view(-1, hn)
+    nr2 = nr.view(-1, hn)
+
+    n_rows = x2.shape[0]
+    block = _next_pow2(hn)
+    _fused_add_rmsnorm_kernel[(n_rows,)](
+        x2,
+        r2,
+        weight,
+        o2,
+        nr2,
+        x2.stride(0),
+        r2.stride(0),
+        o2.stride(0),
+        nr2.stride(0),
+        float(eps),
+        H=hn,
+        ZERO_CENTERED=zero_centered_gamma,
+        BLOCK=block,
+        num_warps=8,
+    )
+    return o, nr
+
+
+def _tensors_compatible(w: torch.Tensor, hidden: torch.Tensor, residual: torch.Tensor) -> bool:
+    """Shared shape/layout/token-count check for the fused add+RMSNorm kernel.
+
+    This runs once per layer per decode step, so it short-circuits on the
+    cheapest checks first and allocates nothing.
+    """
+    hn = hidden.shape[-1]
+    if hidden.shape != residual.shape or hn != w.numel():
+        return False
+    if not (hidden.is_cuda and residual.is_cuda):
+        return False
+    if hidden.stride(-1) != 1 or residual.stride(-1) != 1:
+        return False
+    n_tokens = 1
+    for d in hidden.shape[:-1]:
+        n_tokens *= d
+    if n_tokens > FUSED_ADD_NORM_MAX_TOKENS:
+        return False
+    return True
+
+
+def can_use_fused_add_rmsnorm(norm_module, hidden: torch.Tensor, residual: torch.Tensor) -> bool:
+    """Whether the fused kernel reproduces this exact add+RMSNorm contract.
+
+    Requires a weight-only RMSNorm module (no bias), matching contiguous
+    ``[.., H]`` shapes on CUDA, and a decode-sized token count.
+    """
+    if not (HAVE_TRITON and USE_FUSED_ADD_NORM):
+        return False
+    if norm_module is None:
+        return False
+    w = getattr(norm_module, "weight", None)
+    if w is None:
+        return False
+    if getattr(norm_module, "bias", None) is not None:
+        return False
+    return _tensors_compatible(w, hidden, residual)

--- a/megatron/core/inference/fused_add_rmsnorm.py
+++ b/megatron/core/inference/fused_add_rmsnorm.py
@@ -23,7 +23,7 @@ path is used unless explicitly enabled.
 """
 
 import os
-from typing import Tuple
+from typing import Optional, Tuple
 
 import torch
 
@@ -36,6 +36,12 @@ except ImportError:
     HAVE_TRITON = False
 
 USE_FUSED_ADD_NORM: bool = os.environ.get("MCORE_FUSED_ADD_NORM", "0") == "1"
+
+# Same kernel applied one boundary later: the ``mlp_bda`` residual add at the end of
+# a layer, fused with the *next* layer's QKV input RMSNorm. Gated separately so the
+# two fusions can be A/B'd independently -- this one reaches across the layer
+# boundary and into ``linear_qkv``, so it carries more structural risk.
+USE_FUSED_ADD_NORM_QKV: bool = os.environ.get("MCORE_FUSED_ADD_NORM_QKV", "0") == "1"
 
 # The one-row-per-CTA kernel is launch/latency bound; it wins in the decode
 # regime and should not be used for large prefill token counts.
@@ -174,3 +180,20 @@ def can_use_fused_add_rmsnorm(norm_module, hidden: torch.Tensor, residual: torch
     if getattr(norm_module, "bias", None) is not None:
         return False
     return _tensors_compatible(w, hidden, residual)
+
+
+def can_use_fused_add_rmsnorm_qkv(
+    weight: Optional[torch.Tensor], hidden: torch.Tensor, residual: torch.Tensor
+) -> bool:
+    """Whether the fused kernel can absorb the *next* layer's QKV input RMSNorm.
+
+    Separate gate from :data:`USE_FUSED_ADD_NORM` because this fuses across the
+    layer boundary: the norm being absorbed belongs to the following layer's
+    ``linear_qkv``, and its weight arrives as a raw tensor
+    (``layer_norm_weight``) rather than as a norm module.
+    """
+    if not (HAVE_TRITON and USE_FUSED_ADD_NORM_QKV):
+        return False
+    if weight is None:
+        return False
+    return _tensors_compatible(weight, hidden, residual)

--- a/megatron/core/tensor_parallel/inference_layers.py
+++ b/megatron/core/tensor_parallel/inference_layers.py
@@ -190,6 +190,13 @@ class InferenceLayerNormColumnParallelLinear(TELayerNormColumnParallelLinear):
         # has already applied the rms-norm and all-gather.
         self.skip_norm_and_all_gather = False
 
+        # Set externally (one decode step at a time) by the preceding transformer
+        # layer's fused mlp_bda add + input-RMSNorm kernel, which produces this
+        # layer's normalized QKV input as a by-product of the residual add. When
+        # present it replaces the norm launch below and is consumed immediately.
+        # Only the tp_size == 1 path honors it; see MCORE_FUSED_ADD_NORM_QKV.
+        self.prenormed_input = None
+
     def set_barrier_before_all_gather(self, value: bool = True) -> None:
         """Request a barrier before this layer's input all-gather reuses the buffer.
 
@@ -253,7 +260,14 @@ class InferenceLayerNormColumnParallelLinear(TELayerNormColumnParallelLinear):
             return super().forward(x)
 
         if self.tp_size == 1:
-            x = _te_rms_norm_kernel(x=x, weight=self.layer_norm_weight, eps=self.eps)
+            prenormed = self.prenormed_input
+            if prenormed is not None:
+                # The preceding layer's fused add+norm already produced this; consume
+                # it so a stale tensor can never leak into a later step.
+                self.prenormed_input = None
+                x = prenormed
+            else:
+                x = _te_rms_norm_kernel(x=x, weight=self.layer_norm_weight, eps=self.eps)
             x = _apply_linear(x, self.weight, self.config)
             return x, None
 

--- a/megatron/core/transformer/transformer_block.py
+++ b/megatron/core/transformer/transformer_block.py
@@ -321,6 +321,31 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
         self._build_layers()
         self.num_layers_per_pipeline_rank = len(self.layers)
 
+    def _wire_fused_add_norm_qkv_chain(self):
+        """Let each layer's mlp_bda add absorb the next layer's QKV input RMSNorm.
+
+        The residual add at the end of layer i is immediately followed by the input
+        RMSNorm at the start of layer i+1, which for the non-MLA inference path lives
+        inside ``linear_qkv`` rather than as a standalone module. Handing each layer a
+        reference to the next layer's ``linear_qkv`` lets the two collapse into one
+        kernel. Only the last local layer is left out, since its output feeds
+        ``final_layernorm`` instead.
+
+        Storing references costs nothing when the fusion is disabled -- the runtime
+        guard in the layer decides per step -- so this is wired unconditionally.
+        """
+        layers = getattr(self, "layers", None)
+        if layers is None or len(layers) < 2:
+            return
+        for cur, nxt in zip(layers[:-1], layers[1:]):
+            if not hasattr(cur, "_next_layer_qkv"):
+                continue
+            qkv = getattr(getattr(nxt, "self_attention", None), "linear_qkv", None)
+            # Only the inference QKV layer exposes the prenormed_input hand-off and a
+            # raw layer_norm_weight; anything else keeps the reference path.
+            if qkv is not None and hasattr(qkv, "prenormed_input"):
+                cur._next_layer_qkv = [qkv]
+
     def _build_layers(self):
         # Transformer layers.
         # @jcasper can we improve how we deal with layer_number?
@@ -368,6 +393,8 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
         )
         if self.config.cuda_graph_impl == "local":
             annotate_first_last_layer(self.layers)
+
+        self._wire_fused_add_norm_qkv_chain()
 
         # @TODO: add back account_for_embedding_in_pipeline_split (see issue #293)
         # In pipeline parallelism, we want to add this LN only to the last stage of the pipeline

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -17,6 +17,16 @@ from megatron.core.dist_checkpointing.mapping import ShardedStateDict
 from megatron.core.dist_checkpointing.utils import apply_prefix_mapping
 from megatron.core.inference.utils import InferenceMode
 from megatron.core.packed_seq_params import PackedSeqParams
+
+try:
+    from megatron.core.inference.fused_add_rmsnorm import (
+        can_use_fused_add_rmsnorm as _can_use_fused_add_rmsnorm,
+    )
+    from megatron.core.inference.fused_add_rmsnorm import fused_add_rmsnorm as _fused_add_rmsnorm
+except Exception:  # keep the layer importable if the inference helper is unavailable
+    _can_use_fused_add_rmsnorm = None
+    _fused_add_rmsnorm = None
+
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.transformer.cuda_graphs import is_graph_capturing
 from megatron.core.transformer.enums import CudaGraphModule, InferenceCudaGraphScope, LayerType
@@ -613,6 +623,10 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         """
         inference_context = deprecate_inference_params(inference_context, inference_params)
 
+        # Cleared each forward; set only when the self_attn_bda + pre_mlp_layernorm
+        # fused-add-norm path runs, so _forward_pre_mlp_layernorm can consume it.
+        self._fused_pre_mlp_normed = None
+
         # Optional Input Layer norm
         attn_norm_manager = self.off_interface(self.offload_attn_norm, hidden_states, "attn_norm")
         if self.recompute_input_layernorm:
@@ -680,10 +694,36 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
             # self attention module.
             hidden_states = attention_output_with_bias[0]
         else:
-            with self.bias_dropout_add_exec_handler():
-                hidden_states = self.self_attn_bda(self.training, self.config.bias_dropout_fusion)(
-                    attention_output_with_bias, residual, self.hidden_dropout
+            attn_out = attention_output_with_bias[0]
+            if (
+                _fused_add_rmsnorm is not None
+                and not self.training
+                and self.config.normalization == "RMSNorm"
+                and attention_output_with_bias[1] is None
+                and isinstance(self.cross_attention, IdentityOp)
+                and isinstance(self.pre_cross_attn_layernorm, IdentityOp)
+                and not self.recompute_pre_mlp_layernorm
+                and not getattr(self, "offload_attn_norm", False)
+                and not getattr(self, "offload_mlp_norm", False)
+                and _can_use_fused_add_rmsnorm(self.pre_mlp_layernorm, attn_out, residual)
+            ):
+                # Fuse the residual-add (self_attn_bda) with the standalone
+                # pre-MLP RMSNorm: one kernel yields both the updated residual
+                # and the normalized MLP input, removing a launch + graph node
+                # per layer. Decode-gated; falls back below otherwise.
+                pre_mlp_normed, hidden_states = _fused_add_rmsnorm(
+                    attn_out,
+                    residual,
+                    self.pre_mlp_layernorm.weight,
+                    self.config.layernorm_epsilon,
+                    self.config.layernorm_zero_centered_gamma,
                 )
+                self._fused_pre_mlp_normed = pre_mlp_normed
+            else:
+                with self.bias_dropout_add_exec_handler():
+                    hidden_states = self.self_attn_bda(
+                        self.training, self.config.bias_dropout_fusion
+                    )(attention_output_with_bias, residual, self.hidden_dropout)
         nvtx_range_pop(suffix="self_attn_bda")
 
         # Delay the offload of the attention norm until after the self_attn_bda has been computed
@@ -747,6 +787,12 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         return output, context
 
     def _forward_pre_mlp_layernorm(self, hidden_states: Tensor):
+        # If the fused self_attn_bda + pre_mlp_layernorm path ran, the normed
+        # activation is already computed; consume it and skip the norm call.
+        stashed = getattr(self, "_fused_pre_mlp_normed", None)
+        if stashed is not None:
+            self._fused_pre_mlp_normed = None
+            return stashed
         self.mlp_norm_manager = self.off_interface(self.offload_mlp_norm, hidden_states, "mlp_norm")
         if self.recompute_pre_mlp_layernorm:
             self.pre_mlp_norm_checkpoint = tensor_parallel.CheckpointWithoutOutput()

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -22,9 +22,13 @@ try:
     from megatron.core.inference.fused_add_rmsnorm import (
         can_use_fused_add_rmsnorm as _can_use_fused_add_rmsnorm,
     )
+    from megatron.core.inference.fused_add_rmsnorm import (
+        can_use_fused_add_rmsnorm_qkv as _can_use_fused_add_rmsnorm_qkv,
+    )
     from megatron.core.inference.fused_add_rmsnorm import fused_add_rmsnorm as _fused_add_rmsnorm
 except Exception:  # keep the layer importable if the inference helper is unavailable
     _can_use_fused_add_rmsnorm = None
+    _can_use_fused_add_rmsnorm_qkv = None
     _fused_add_rmsnorm = None
 
 from megatron.core.process_groups_config import ProcessGroupCollection
@@ -449,6 +453,12 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
 
         # [Module 9: BiasDropoutFusion]
         self.mlp_bda = build_module(submodules.mlp_bda)
+
+        # Holds the *next* layer's linear_qkv so this layer's mlp_bda add can absorb
+        # that layer's input RMSNorm. Wired by TransformerBlock. Deliberately a list:
+        # assigning a Module straight to an attribute would register it as a child
+        # here too, duplicating those parameters in state_dict and named_parameters.
+        self._next_layer_qkv: list = []
 
         self.is_moe_layer = isinstance(self.mlp, MoELayer)
 
@@ -1022,10 +1032,41 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
             # MLP module.
             hidden_states = mlp_output_with_bias[0]
         else:
-            with self.bias_dropout_add_exec_handler():
-                hidden_states = self.mlp_bda(self.training, self.config.bias_dropout_fusion)(
-                    mlp_output_with_bias, residual, self.hidden_dropout
+            next_qkv = self._next_layer_qkv[0] if self._next_layer_qkv else None
+            mlp_out = mlp_output_with_bias[0]
+            if (
+                next_qkv is not None
+                and _fused_add_rmsnorm is not None
+                and not self.training
+                and self.config.normalization == "RMSNorm"
+                and mlp_output_with_bias[1] is None
+                and self.mlp_norm_manager is None
+                # _te_rms_norm_kernel hardcodes zero_centered_gamma=False, so this
+                # fusion may only stand in for it when the config agrees.
+                and not self.config.layernorm_zero_centered_gamma
+                and _can_use_fused_add_rmsnorm_qkv(
+                    getattr(next_qkv, "layer_norm_weight", None), mlp_out, residual
                 )
+            ):
+                # Fuse this layer's residual add with the *next* layer's QKV input
+                # RMSNorm: one kernel yields both the residual stream and that
+                # layer's normalized QKV input, removing a launch and a graph node
+                # per boundary. This is the half of the block boundaries the
+                # pre-MLP fusion could not reach, because the input norm lives
+                # inside linear_qkv rather than as a standalone module.
+                prenormed, hidden_states = _fused_add_rmsnorm(
+                    mlp_out,
+                    residual,
+                    next_qkv.layer_norm_weight,
+                    next_qkv.eps,
+                    False,
+                )
+                next_qkv.prenormed_input = prenormed
+            else:
+                with self.bias_dropout_add_exec_handler():
+                    hidden_states = self.mlp_bda(self.training, self.config.bias_dropout_fusion)(
+                        mlp_output_with_bias, residual, self.hidden_dropout
+                    )
         nvtx_range_pop(suffix="mlp_bda")
         # Delay the offload of the mlp norm until after the mlp_bda has been computed
         # because the residual is needed in the mlp_bda.


### PR DESCRIPTION
> Stacked on #6463. Review that one first; this diff is only applying its kernel one boundary
>
> GitHub cannot base a pull request from a fork on another unmerged fork branch, so the diff below also contains the parent's commits. This PR's own change is the final commit, `95004d116`; review that one. The rest lands with the parent.
> later, so a layer's residual add absorbs the *next* layer's QKV input RMSNorm.

## Summary

The parent fuses the residual add with the standalone pre-MLP RMSNorm, which reaches one of
the two block boundaries per layer; the other boundary's norm was ruled unreachable because it
lives inside the QKV GEMM's `LayerNormLinear` rather than as a standalone module. At TP=1 that
ruling is wrong: `InferenceLayerNormColumnParallelLinear.forward` runs the norm as its own
`_te_rms_norm_kernel` launch immediately before the GEMM, so the *preceding* layer can compute
it. Handing each layer a reference to the next layer's `linear_qkv` lets the same fused kernel
produce that layer's normalized QKV input as a by-product of the `mlp_bda` residual add, at 47
of 48 boundaries: **+0.98%** end-to-end decode throughput.

The reusable part is the earlier ruling, not the kernel. "The norm is fused inside
`LayerNormLinear`" was true of the class name and false of the TP=1 code path, and one look at
the actual `forward` would have found it two sessions earlier.

## Why here

The same profile ranking that selected the parent: `triton_poi_fused_add_copy` at 103 launches
per step and `rmsnorm_fwd_tuned` at 104, two of each per layer, adjacent on the serial path.
The parent takes one per layer; this takes the other.

It was priced before it was written, and it beat its price. 47 boundaries × (add 1.5 µs + norm
2.9 µs − fused 4.1 µs) is about 14 µs/step of device time, plus roughly 0.78 µs of per-boundary
graph-node cost, so on the order of 50 µs of a ~9.6 ms step. The measured gain was several
times that. The campaign attributes the excess to the removed graph node and host dispatch gap
per boundary, on the grounds that kernels on the *serial dependency chain* convert at roughly
3× their device-time arithmetic — **but that attribution was not isolated, and there is
countervailing evidence**: a separate change in this campaign deleted 76 launches carrying
0.185 ms of device time and bought nothing measurable. Treat the mechanism as "removes GPU work
on the serial chain" and the excess as unexplained.

Across the four kernel families this chain touches, device time goes 0.787 → 0.401 ms/step for
the two fusions **together**; roughly two thirds of that converted to wall-clock. That number
belongs to the pair, not to this PR.

## What changed

**Before.** Layer *i* ends with `mlp_bda` writing the updated residual in one kernel. Layer
*i+1* begins by calling `linear_qkv`, whose `tp_size == 1` path runs `_te_rms_norm_kernel` on
that residual in a second kernel before the GEMM.

**After.** `TransformerBlock._wire_fused_add_norm_qkv_chain` walks
`zip(layers[:-1], layers[1:])` and gives each layer a handle on the next one's `linear_qkv`.
At the `mlp_bda` site the guarded path calls the parent's kernel with the *next* layer's
`layer_norm_weight` and `eps`, gets back `(normed, new_residual)`, keeps the residual for its
own dataflow, and assigns the normed tensor to `next_qkv.prenormed_input`. In
`InferenceLayerNormColumnParallelLinear.forward`, the `tp_size == 1` branch consumes that
tensor in place of its norm launch and clears the attribute on read, so a stale tensor cannot
leak into a later step.

Three implementation decisions a reviewer should check rather than take on trust:

**The reference is held in a plain list**, `self._next_layer_qkv: list = []`. Assigning a
`Module` straight to an attribute would register it as a second child of this layer and
duplicate the next layer's QKV parameters in `state_dict` and `named_parameters`. A list is not
traversed by `nn.Module`, so the module tree and every checkpoint are unchanged.

**The wiring is unconditional.** Storing a reference costs nothing when the fusion is off — the
runtime guard decides per step — so there is no gate check in `_build_layers`, and the wiring
still skips anything that does not expose `prenormed_input`, i.e. anything other than the
inference QKV layer.

**47 of 48, not 48.** With 48 local layers there are 47 consecutive pairs; the last local
layer's output feeds `final_layernorm` rather than another `linear_qkv`, and is left alone.
Because `layers` is the *local* list, the boundary between pipeline stages is not fused either.

## Measurement

Fixed protocol: Qwen3-30B-A3B, BF16, TP 1 / PP 1 / EP 4 / ETP 1, 256 gsm8k requests, 1024 output tokens, 2 warmup + 5 timed iterations, a single OCI 4xGB200 node (nvl72160-T04), async dynamic-batching scheduler pinned on. All 20 arms ran back to back in one allocation on that one node; node-to-node variance on this workload is around 2.7%, so cross-node numbers would not be comparable.

- With this change (every other gate in the stack enabled): **31,524 tok/s**
- Without it (same node, same session, only this gate turned off): **31,219 tok/s**
- Leave-one-out delta: **+0.98%**
- Noise floor: sigma = **0.42%** over 3 repeats of the all-gates-on reference
- Verdict: **resolved** by margin (2.3 sigma). The per-iteration distributions do not separate strictly, but only because each reference arm contains one low outlier iteration; excluding those the arms do not overlap.

This is the **marginal contribution measured with every other gate in this stack enabled** — the question a reviewer is actually asking, which is whether this should land, not what it was worth when it was first written.

The reference is drift-corrected. The all-gates-on configuration was re-measured three times across the session (31,745, 31,530, 31,503 tok/s), a +0.77% drift from first to last, so each arm is compared against the reference interpolated to its own position in the run order rather than against a session mean.

For context, the whole stack is worth **+35.80%** on this node (23,265 tok/s with every gate off, 31,593 with every gate on). Per-slice deltas do not sum to that; they compose sub-additively.

## Evidence

Same kernel as the parent, so the same microbench: add + TransformerEngine norm 6.16 µs →
fused 4.11 µs at 256 tokens (**1.50×**), and flat at ~4.1 µs against a growing pair at 384 and
512 tokens (**2.0×**). Per boundary this replaces a ~1.5 µs add and a ~2.9 µs norm with one
~4.1 µs kernel and removes one round trip of the residual through memory.

**Liveness matters more here than anywhere else in this stack, because this exact fusion has
already shipped without ever firing.** It was written, its module docstring described the
two-kernel pattern it replaces, and a profile labelled as having every gate enabled contained
zero fused add-norm kernels and exactly that two-kernel pattern: 96 `triton_poi_fused_add_copy`
launches (two per layer) and 193 standalone TransformerEngine RMSNorms. Two causes, both
invisible from the throughput number: this boundary's gate was never in any gate list, and the
two sites are coupled in a way neither gate's name nor docstring mentioned (see below).

No diagnostic ships with this PR. Confirm from a trace that `_fused_add_rmsnorm_kernel` appears
about 95 times per step with both fusions enabled (48 + 47) rather than 48, and that the
standalone TE RMSNorm count falls by ~47. When this was instrumented during development both
sites engaged on every eligible layer at 256 tokens, and the only refusals were at
`(512, 1, 2048)` — prefill, correctly excluded by the shared token cap.

## Correctness

- **Numerics:** the parent's kernel, unchanged, so the same split classes — the **residual is
  bit-exact** (the add is fp32-accumulated and rounded once, reproducing PyTorch's bf16 add)
  and the **norm is within one bf16 ulp**, `max_rel ≤ 7.9e-3`. Nothing about the numerics is
  new in this diff; what is new is that 47 more norms per step take the Triton path.
- **Structural:** `state_dict` and `named_parameters` are unchanged, by the plain-list holder
  above. The hand-off tensor is cleared on read in the consumer and is only ever written
  immediately before the consumer runs, within the same step.
- **Tests:** the parent's microbench equivalence, plus the guard's own precondition that
  `_te_rms_norm_kernel` hardcodes `zero_centered_gamma=False` — so this fusion may only stand
  in for it when `config.layernorm_zero_centered_gamma` is false, which the guard checks and
  the fused call passes explicitly.
- **Coherence:** **2 of 3** temperature-0 prompts byte-identical to the legacy arm. The third
  diverges at a low-confidence branch — `" So, what is the capital of Italy?"` against
  `" So, the capital of Italy is Rome."` — and both continuations are fluent and factually
  correct. This is one prompt worse than the parent alone, which is what 47 additional
  non-bit-exact norms per step would predict; acceptance rests on fluency and correctness
  rather than on byte-identity.

## Gating and blast radius

- Gate: `MCORE_FUSED_ADD_NORM_QKV`, **default OFF** (`os.environ.get(..., "0") == "1"`).
  Unset, `can_use_fused_add_rmsnorm_qkv` returns `False` on its first condition and the original
  `mlp_bda` call plus the QKV norm launch run byte-identically to before this PR. It is a
  separate gate from the parent's precisely because this one reaches across a layer boundary
  and into `linear_qkv`, which is more structural risk.
- Token cap: the parent's `MCORE_FUSED_ADD_NORM_MAX_TOKENS`, default 256, shared.
- **This PR depends on the parent at runtime, not merely in the stack ordering.** Its guard
  includes `self.mlp_norm_manager is None`, and that attribute is assigned a non-`None` value
  inside `_forward_pre_mlp_layernorm` on every layer where the parent's fusion did *not* fire:

  In `TransformerLayer._forward_pre_mlp_layernorm` (`transformer_layer.py`):

```python
        stashed = getattr(self, "_fused_pre_mlp_normed", None)
        if stashed is not None:
            self._fused_pre_mlp_normed = None
            return stashed
        self.mlp_norm_manager = self.off_interface(self.offload_mlp_norm, hidden_states, "mlp_norm")
```

  In `TransformerLayer._forward_post_mlp`, the guard for this fusion:

```python
            if (
                next_qkv is not None
                and _fused_add_rmsnorm is not None
                and not self.training
                and self.config.normalization == "RMSNorm"
                and mlp_output_with_bias[1] is None
                and self.mlp_norm_manager is None
```

  `self.off_interface` is a class, so that assignment yields a non-`None` instance whether or
  not offloading is enabled, and `_forward_pre_mlp_layernorm` runs earlier in the same
  `_forward_mlp` invocation than the guard does. **Consequence: `MCORE_FUSED_ADD_NORM=0`
  disables this fusion too, whatever `MCORE_FUSED_ADD_NORM_QKV` is set to.** A leave-one-out
  arm on the parent's gate measures both changes at once, and this PR cannot be based on `main`.
- Other preconditions: `not self.training`; `config.normalization == "RMSNorm"`; no MLP output
  bias; `not config.layernorm_zero_centered_gamma`; the next layer's `layer_norm_weight`
  present with matching shapes, both tensors on CUDA, last dimension contiguous, token count
  under the cap. The whole branch sits in the `else` of the existing
  `using_fused_tp_inference_kernel` check (`inference_fuse_tp_communication` under inference
  mode), which already handles the residual add inside the MLP and takes precedence.
- **The guard does not check TP size, and it should be read as TP=1-only anyway.** Only the
  consumer's `tp_size == 1` branch honours `prenormed_input`. At TP>1 with the gate on, the
  producing layer still fires the fused kernel and still sets the attribute, and the consumer
  ignores it and normalizes the residual itself. That is numerically fine — it re-normalizes
  the same bit-exact residual — but it is strictly wasted work and leaves a tensor referenced
  until the next step overwrites it. Do not enable this gate at TP>1.
- **Batch-invariant mode is not excluded either.** `_te_rms_norm_kernel` routes to
  `rmsnorm_batch_invariant` when that mode is enabled, and this fusion would replace it with the
  Triton kernel. The guard does not test for it, so the two should not be combined.
- Training is excluded twice over: by `not self.training` at the producer and by
  `if self.training: return super().forward(x)` at the consumer.

## Reproduce

```bash
MCORE_FUSED_ADD_NORM=1 MCORE_FUSED_ADD_NORM_QKV=1 \
QWEN30B_TP=1 QWEN30B_EP=4 QWEN30B_ETP=1 \
BENCH_SIZES_OVERRIDE=256 BENCH_OUTPUT_TOKENS=1024 \
NUM_WARMUP_ITERS=2 NUM_TIMED_ITERS=5 \
bash skills/run-qwen-model/run_qwen_inference.sh qwen3-30b-a3b --checkpoint "$QWEN30B_CKPT"
```

Both variables are required — with only the second one set this fusion never fires. Triton is
required; without it `HAVE_TRITON` is `False` and the guard declines silently.

## What this does not claim

- **Nothing at TP>1.** Only the `tp_size == 1` consumer path honours the hand-off; above that
  the fusion is a pure pessimization, as described above. TP>1 was not measured and the gate
  should stay off there.
- **Nothing above 256 tokens.** Not because the kernel regresses — it is 2.0× the pair at 384
  and 512 — but because prefill shapes were not validated end to end.
- **Not all 48 boundaries.** 47, and none across a pipeline-stage boundary.
- **The excess over the priced ceiling is unexplained.** ~50 µs/step of device time and graph
  node cost was predicted and materially more was measured. The attribution to removed dispatch
  gaps is plausible and unproven, and a counterexample in this campaign argues against reading
  it as a launch-count win.
- **The 0.386 ms/step of removed device time and the roughly two-thirds conversion ratio belong
  to this PR and the parent together**, not to this PR alone.
- **The norm is not bit-exact**, and coherence is 2 of 3 rather than 3 of 3. See Correctness.
- **No liveness signal ships**; verify from kernel counts, and be aware that this fusion's
  precedent is having shipped inert.
- Deltas in this stack do not add. This PR and the parent are coupled at runtime and attack the
  same serial chain, and the attention-side norm fusions attack the same host dispatch gaps, so
  everything here composes sub-additively.

## Follow-ups

- The runtime coupling with the parent is incidental — it falls out of `mlp_norm_manager` being
  used as a proxy for "the parent's fusion did not fire". An explicit flag would make each gate
  independently toggleable and each arm independently measurable; that is worth doing before
  anyone tries to attribute the two fusions separately.
- A TP-size check in the guard, so enabling this at TP>1 declines instead of doing unused work.
- A batch-invariant-mode check, for the same reason.
- The remaining unfused norms are the first local layer's input norm and the last local layer's
  feed into `final_layernorm`; both are single boundaries per step and not worth their own
  kernel.

---

## This stack

This is one slice of [#6064](https://github.com/NVIDIA/Megatron-LM/pull/6064), a Qwen3-30B-A3B decode optimization campaign, split into 16 independently reviewable changes. Together they are **+35.80%** end-to-end throughput over the same base commit (23,265 -> 31,593 tok/s, mean of three full runs).

- **MoE grouped-GEMM and dispatch:** #6452 -> #6453 -> #6454 -> #6455
- **MoE router and combine:** #6456 -> #6457 -> #6458
- **Attention: QK norm and decode kernel:** #6459 -> #6460 -> #6461 -> #6462
- **Residual + RMSNorm fusion:** #6463 -> #6464
- **Host path: context bookkeeping:** #6465 -> #6466
- **Host path: independent:** #6467

Each chain is independent of the others and bases on `main`. Within a chain, later PRs depend on earlier ones.

### Per-slice measured delta

Every number is a leave-one-out delta from one same-node, same-session campaign: the full stack with exactly this change's gate off, against the interpolated full-stack reference at that point in the run. It is the change's *marginal* contribution with everything else already in, not its standalone value. Run-to-run sigma was **0.42%** across three full-stack repeats.

| PR | Change | Delta | |
|---|---|---|---|
| #6452 | FC1 SwiGLU epilogue | +14.81% | resolved |
| #6453 | indirection table fusion | +7.21% | resolved |
| #6454 | decode GEMM tile configs | +6.77% | resolved |
| #6455 | predicated top-k gather | +1.99% | by margin |
| #6456 | fused router softmax+top-k | +4.75% | resolved |
| #6457 | fused route padding mask | +1.47% | by margin |
| #6458 | bf16 MoE combine | +2.42% | by margin |
| #6459 | fused QK RMSNorm | +5.17% | resolved |
| #6460 | grouped QK norm input | +1.18% | by margin |
| #6461 | pin FlashAttention 2 | -0.35% | noise floor |
| #6462 | FlashInfer TRT-LLM decode | +1.46% | by margin |
| #6463 | fused add+norm pre-MLP | +3.54% | by margin |
| #6464 | fused add+norm pre-QKV | +0.98% | by margin |
| #6465 | incremental attention state | -0.42% | noise floor |
| #6466 | vectorized decode bookkeeping | -0.07% | noise floor |
| #6467 | post_process_requests fast path | +0.09% | noise floor |

`noise floor` means the delta is inside 2 sigma (0.84%) and this campaign cannot distinguish it from zero. `resolved` means the leave-one-out and full-stack iteration distributions did not overlap. Deltas do not sum to the stack total: these changes shorten the same decode step and compose sub-additively.

**Fixed protocol for every number above.** Qwen3-30B-A3B, BF16, TP1/PP1/EP4/ETP1, 256 gsm8k requests at batch size 256, output length 1024, CUDA graphs on, one OCI GB200 NVL72 node, 4 GPUs. All 20 arms ran back-to-back in a single Slurm allocation on one node, so node assignment and thermal state are held constant.
