### PR TITLE
perf(inference): incremental attention-state update for steady-state decode

### DIFF
--- a/megatron/core/inference/contexts/attention_context/mha_metadata.py
+++ b/megatron/core/inference/contexts/attention_context/mha_metadata.py
@@ -65,6 +65,18 @@ class MHAMetadata(MetadataBase):
             "max_seqlen_k": max_seqlen_k,
         }
 
+    def restore_state_data(self, state_data: dict, max_seqlen_q: int, max_seqlen_k: int) -> None:
+        """Re-bind a previously built ``state_data`` after ``reset()``.
+
+        Equivalent to ``set_state_data`` called with the arguments that produced
+        ``state_data``, minus the re-slicing. Used by the incremental decode
+        path in ``DynamicInferenceContext``, where the padded request count and
+        therefore every slice is provably unchanged from the previous step.
+        """
+        self._max_seqlen_q = max_seqlen_q
+        self._max_seqlen_k = max_seqlen_k
+        self.state_data = state_data
+
     def reset(self):
         """Reset the metadata for the next batch.
 

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -3,6 +3,7 @@
 import logging
 import math
 import operator
+import os
 import warnings
 from contextlib import nullcontext
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
@@ -76,6 +77,31 @@ try:
     HAVE_TORCH_MEMORY_SAVER = True
 except ImportError:
     HAVE_TORCH_MEMORY_SAVER = False
+
+# Incremental steady-state decode path for `initialize_attention_state`. Off by
+# default; see `DynamicInferenceContext._incremental_attention_state_update`.
+_INCR_ATTN_STATE = os.environ.get("MCORE_INFER_INCR_ATTN_STATE", "0") == "1"
+# Debug mode: take the fast path, then recompute from scratch and assert that
+# every buffer the fast path served is identical. Very slow; correctness only.
+_INCR_ATTN_STATE_VERIFY = os.environ.get("MCORE_INFER_INCR_ATTN_STATE_VERIFY", "0") == "1"
+
+# Diagnostic: tally why the incremental fast path declines, so a single run answers
+# "which guard is rejecting every step" instead of requiring a guess per experiment.
+_INCR_DIAG = os.environ.get("MCORE_INFER_INCR_DIAG", "0") == "1"
+_incr_diag_counts: Dict[str, int] = {}
+
+
+def _incr_diag(reason: str) -> None:
+    """Count one fast-path outcome and periodically log the tally."""
+    _incr_diag_counts[reason] = _incr_diag_counts.get(reason, 0) + 1
+    total = sum(_incr_diag_counts.values())
+    if total % 500 == 0:
+        parts = ", ".join(
+            f"{k}={v} ({100*v/total:.1f}%)"
+            for k, v in sorted(_incr_diag_counts.items(), key=lambda x: -x[1])
+        )
+        logging.info("[INCR_DIAG] %d calls: %s", total, parts)
+
 
 DEPRECATED_ARGS = [
     "params_dtype",
@@ -317,6 +343,17 @@ class DynamicInferenceContext(BaseInferenceContext):
     TOKEN_ROUNDER = 64
     REQUEST_ROUNDER = 4
     TMS_TAG = "inference_context"
+
+    # Incremental attention-state cache (MCORE_INFER_INCR_ATTN_STATE). Declared
+    # at class scope so every construction path starts from a cold, invalid
+    # cache without depending on __init__ ordering.
+    _request_layout_version = 0
+    _incr_attn_state_key = None
+    _incr_attn_state_real_bs = 0
+    _incr_attn_state_padded_bs = 0
+    _incr_attn_state_max_seqlen_q = 0
+    _incr_attn_state_max_seqlen_k = 0
+    _incr_attn_state_state_data = None
 
     @deprecate_args(
         *DEPRECATED_ARGS,
@@ -1055,6 +1092,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         if self.is_tensor_state_allocated:
             return
         self.is_tensor_state_allocated = True
+        self._bump_request_layout_version()
 
         # Validate no tensors allocated prior to this method.
         for key in vars(self).keys():
@@ -2017,6 +2055,8 @@ class DynamicInferenceContext(BaseInferenceContext):
         if not requests:
             return
 
+        self._bump_request_layout_version()
+
         num_new_requests = len(requests)
         if self.total_request_count + num_new_requests > self.max_requests:
             raise RequestOverflowError(requests[-1].request_id)
@@ -2154,6 +2194,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         Adds dummy requests to reflect the number of prefill and decode requests in the graph config.
         These are using during cuda graph captures.
         """
+        self._bump_request_layout_version()
         prefill_tokens = graph_dimensions.token_count - (
             graph_dimensions.decode_req_count * (self.num_speculative_tokens + 1)
         )
@@ -2225,6 +2266,7 @@ class DynamicInferenceContext(BaseInferenceContext):
 
         Called AFTER the EP sync so graph_dimensions reflects the agreed-upon graph.
         """
+        self._bump_request_layout_version()
         N_decode = graph_dimensions.decode_req_count
         N_prefill = graph_dimensions.prefill_req_count
         N = N_decode + N_prefill
@@ -2307,6 +2349,20 @@ class DynamicInferenceContext(BaseInferenceContext):
                 completion, or `None` when no event was requested or no
                 transfer was performed.
         """
+        _verify_snapshot = None
+        if _INCR_ATTN_STATE and not is_expert_parallel_dummy_cuda_graph_step:
+            advanced, fast_bookkeeping_done_event = self._incremental_attention_state_update(
+                construct_graph_dimensions,
+                transfer_bookkeeping_to_gpu=transfer_bookkeeping_to_gpu,
+                record_bookkeeping_done_event=record_bookkeeping_done_event,
+            )
+            if advanced:
+                if not _INCR_ATTN_STATE_VERIFY:
+                    return fast_bookkeeping_done_event
+                # Verify mode: keep what the fast path produced, redo everything
+                # from scratch below, then assert the two agree exactly.
+                _verify_snapshot = self._incr_attn_state_snapshot()
+
         # Launch deferred Mamba GPU ops first (state zeroing/restore) so they
         # overlap with the CPU work below.  These are non-blocking GPU kernels.
         self._execute_pending_mamba_ops()
@@ -2551,9 +2607,260 @@ class DynamicInferenceContext(BaseInferenceContext):
         )
 
         # Preserve the existing behavior for callers that do not publish explicitly.
+        bookkeeping_done_event = None
         if transfer_bookkeeping_to_gpu:
-            return self.transfer_bookkeeping_to_gpu(record_done_event=record_bookkeeping_done_event)
-        return None
+            bookkeeping_done_event = self.transfer_bookkeeping_to_gpu(
+                record_done_event=record_bookkeeping_done_event
+            )
+
+        if _INCR_ATTN_STATE:
+            self._incr_attn_state_store(real_bs, padded_bs, max_seqlen_q, max_seqlen_k)
+            if _verify_snapshot is not None:
+                self._incr_attn_state_verify(_verify_snapshot)
+
+        return bookkeeping_done_event
+
+    def _bump_request_layout_version(self) -> None:
+        """Invalidate the incremental attention-state cache.
+
+        Called from every path that changes *which* request occupies a slot, a
+        request's sampling metadata, or a request's KV block table — i.e. the
+        inputs that `initialize_attention_state` would otherwise recompute
+        identically on every decode step. Advancing a request's KV length is
+        deliberately *not* such a path: that is the one thing the incremental
+        update recomputes.
+        """
+        self._request_layout_version += 1
+
+    def _incr_attn_state_cache_key(self):
+        """Cheap scalar signature of the batch layout, or None if uncacheable.
+
+        `_request_layout_version` is the primary guard. The remaining entries
+        are independent structural sentinels so that a missed version bump
+        still has to coincide with an unchanged request count, token count and
+        KV block-allocator occupancy to go unnoticed.
+        """
+        if self.is_hybrid_model or self.num_prefill_requests != 0:
+            return None
+        return (
+            self._request_layout_version,
+            self.total_request_count,
+            self.paused_request_count,
+            self.active_token_count,
+            self.kv_block_allocator.pool_avail,
+            self.chunked_prefill_request_id,
+            self.num_speculative_tokens,
+        )
+
+    def _incr_attn_state_store(
+        self, real_bs: int, padded_bs: int, max_seqlen_q: int, max_seqlen_k: int
+    ) -> None:
+        """Record that the state just built by the full path is incrementable."""
+        if (
+            self.is_creating_cuda_graphs
+            or not self._using_cuda_graph_this_step
+            or self.is_hybrid_model
+            or self.num_prefill_requests != 0
+        ):
+            self._incr_attn_state_key = None
+            return
+        self._incr_attn_state_real_bs = real_bs
+        self._incr_attn_state_padded_bs = padded_bs
+        self._incr_attn_state_max_seqlen_q = max_seqlen_q
+        self._incr_attn_state_max_seqlen_k = max_seqlen_k
+        self._incr_attn_state_state_data = self.active_attn_metadata["mha_metadata"].state_data
+        self._incr_attn_state_key = self._incr_attn_state_cache_key()
+
+    def _incremental_attention_state_update(
+        self,
+        construct_graph_dimensions: Optional[InferenceBatchDimensions],
+        *,
+        transfer_bookkeeping_to_gpu: bool = True,
+        record_bookkeeping_done_event: bool = False,
+    ) -> Tuple[bool, Optional[torch.cuda.Event]]:
+        """Advance the cached attention state by one decode step.
+
+        In steady-state decode the request set, sampling metadata, KV block
+        table, CUDA-graph selection, padded dimensions and every
+        query-length-derived buffer are identical to the previous step; only
+        the KV sequence lengths advance by `num_speculative_tokens + 1` per
+        request. Recompute exactly those and reuse the rest.
+
+        The publish arguments mirror :meth:`initialize_attention_state`, so this path
+        serves deferred-publish callers (async scheduling) too. Without them the fast
+        path had to decline those callers, which meant it never ran at all under async
+        scheduling -- and async is the default in the tuned config, so the whole
+        optimization was silently inactive there.
+
+        Returns:
+            Tuple[bool, Optional[torch.cuda.Event]]: whether the state was advanced
+                (False means the caller must run the full path), and the bookkeeping
+                H2D completion event when one was both requested and recorded.
+        """
+        if construct_graph_dimensions is not None:
+            self._incr_attn_state_key = None
+            if _INCR_DIAG:
+                _incr_diag("decline:graph_capture")
+            return False, None
+        key = self._incr_attn_state_cache_key()
+        if key is None or key != self._incr_attn_state_key:
+            if _INCR_DIAG:
+                if key is None:
+                    # Uncacheable batch: hybrid model or a prefill request present.
+                    _incr_diag("decline:key_none")
+                elif self._incr_attn_state_key is None:
+                    # Previous step declined to store, so there is nothing to advance.
+                    _incr_diag("decline:no_stored_key")
+                else:
+                    # Both keys exist but differ: name the first differing field, which
+                    # is what distinguishes "layout really changed" from "one sentinel
+                    # (e.g. KV block availability) churns every step".
+                    fields = (
+                        "layout_version",
+                        "total_reqs",
+                        "paused_reqs",
+                        "active_tokens",
+                        "kv_blocks_avail",
+                        "chunked_prefill_id",
+                        "spec_tokens",
+                    )
+                    diff = next(
+                        (
+                            f
+                            for f, a, b in zip(fields, key, self._incr_attn_state_key)
+                            if a != b
+                        ),
+                        "unknown",
+                    )
+                    _incr_diag(f"decline:key_differs:{diff}")
+            return False, None
+
+        real_bs = self._incr_attn_state_real_bs
+        padded_bs = self._incr_attn_state_padded_bs
+
+        self._execute_pending_mamba_ops()
+        self.is_creating_cuda_graphs = False
+        self._using_cuda_graph_this_step = True
+        self.active_attn_metadata = self.graph_attn_metadata  # type: ignore[assignment]
+
+        active_slice = slice(self.paused_request_count, self.total_request_count)
+        query_lengths_view = self.request_query_lengths[active_slice]
+        request_kv_length_offsets_view = self.request_kv_length_offsets[active_slice]
+
+        # Character-identical to the corresponding statements in the full path,
+        # so the buffers stay bit-identical to a fresh computation.
+        self._cpu_mha_kv_seq_lengths[:real_bs] = (
+            request_kv_length_offsets_view[:real_bs] + query_lengths_view[:real_bs]
+        )
+        self._cpu_mha_cu_kv_seq_lengths[0] = 0
+        if real_bs > 0:
+            self._cpu_mha_cu_kv_seq_lengths[1 : real_bs + 1] = torch.cumsum(
+                self._cpu_mha_kv_seq_lengths[:real_bs], dim=0
+            )
+        if real_bs < padded_bs:
+            self._cpu_mha_cu_kv_seq_lengths[real_bs + 1 : padded_bs + 1] = (
+                self._cpu_mha_cu_kv_seq_lengths[real_bs]
+            )
+
+        # Token padding slots hold step-invariant sentinels, but re-stamp them
+        # whenever padding exists at all, since the token buffers are shared.
+        if self.active_token_count != self.padded_active_token_count:
+            self.token_to_block_idx[self.active_token_count : self.padded_active_token_count] = (
+                self.kv_block_allocator.dummy_block_idx
+            )
+            self.token_to_local_position_within_kv_block[
+                self.active_token_count : self.padded_active_token_count
+            ] = 0
+            self.token_to_position_in_request[
+                self.active_token_count : self.padded_active_token_count
+            ] = 0
+
+        # `reset_attention_state()` clears the max-seqlen scalars every step, so
+        # rebind state_data even though the slices behind it are unchanged.
+        self.active_attn_metadata["mha_metadata"].restore_state_data(
+            self._incr_attn_state_state_data,
+            self._incr_attn_state_max_seqlen_q,
+            self._incr_attn_state_max_seqlen_k,
+        )
+
+        if self.moe_enable_routing_replay:
+            self.moe_routing_metadata.enable_static_buffer_recording()
+
+        if self._nccl_ep_dispatcher:
+            NCCLAllGatherDispatcher._use_allgather_v = False
+
+        self._execute_pending_mamba_ops()
+        # Graph-capture and EP dummy steps are declined above, so this step always
+        # produces real output; clear the flag the publish step reads, which may
+        # still be set from an earlier capture step.
+        self._bookkeeping_no_real_work = False
+        if _INCR_DIAG:
+            _incr_diag("advanced")
+        # Same conditional publish as the tail of the full path: deferred-publish
+        # callers bind the GPU views here and push the values later.
+        bookkeeping_done_event = None
+        if transfer_bookkeeping_to_gpu:
+            bookkeeping_done_event = self.transfer_bookkeeping_to_gpu(
+                record_done_event=record_bookkeeping_done_event
+            )
+        return True, bookkeeping_done_event
+
+    def _incr_attn_state_snapshot(self) -> Dict:
+        """Clone everything the incremental path produced (debug verify only)."""
+        torch.cuda.synchronize()
+        n = self.padded_active_request_count
+        mha = self.active_attn_metadata["mha_metadata"]
+        snapshot = {
+            "mha_query_lengths": self._cpu_mha_query_lengths[:n].clone(),
+            "mha_cu_query_seq_lengths": self._cpu_mha_cu_query_seq_lengths[: n + 1].clone(),
+            "mha_kv_seq_lengths": self._cpu_mha_kv_seq_lengths[:n].clone(),
+            "mha_cu_kv_seq_lengths": self._cpu_mha_cu_kv_seq_lengths[: n + 1].clone(),
+            "mha_block_table": self._cpu_mha_block_table[:n].clone(),
+            "active_request_last_token_idxs": self.active_request_last_token_idxs[:n].clone(),
+            "active_logit_idxs": self.active_logit_idxs.clone(),
+            "gpu_bookkeeping_buf": self.gpu_view._buf.clone(),
+            "padded_active_token_count": self.padded_active_token_count,
+            "padded_active_request_count": self.padded_active_request_count,
+            "padded_batch_dimensions": self.padded_batch_dimensions,
+            "using_cuda_graph_this_step": self._using_cuda_graph_this_step,
+            "max_seqlen_q": mha._max_seqlen_q,
+            "max_seqlen_k": mha._max_seqlen_k,
+        }
+        for label, tensor in self.active_request_metadata.items():
+            snapshot[f"active_request_metadata/{label}"] = tensor[:n].clone()
+        # state_data holds views into the GPU bookkeeping buffer; compare the
+        # bindings (address, shape, dtype) rather than the contents, which the
+        # `gpu_bookkeeping_buf` entry above already covers.
+        for label, value in mha.state_data.items():
+            if isinstance(value, torch.Tensor):
+                value = (value.data_ptr(), tuple(value.shape), str(value.dtype))
+            snapshot[f"state_data/{label}"] = value
+        return snapshot
+
+    def _incr_attn_state_verify(self, snapshot: Dict) -> None:
+        """Assert the freshly recomputed state matches the incremental one."""
+        fresh = self._incr_attn_state_snapshot()
+        mismatches = []
+        for key, want in snapshot.items():
+            got = fresh[key]
+            if isinstance(want, torch.Tensor):
+                if not torch.equal(want, got):
+                    bad = (want != got).nonzero().flatten()[:8].tolist()
+                    mismatches.append(f"{key}: {bad} incr={want.flatten()[:8].tolist()}")
+            elif want != got:
+                mismatches.append(f"{key}: incr={want} full={got}")
+        self._incr_attn_state_verify_steps = getattr(self, "_incr_attn_state_verify_steps", 0) + 1
+        if mismatches:
+            raise AssertionError(
+                "MCORE_INFER_INCR_ATTN_STATE verification failed at step "
+                f"{self._incr_attn_state_verify_steps}: " + "; ".join(mismatches)
+            )
+        if self._incr_attn_state_verify_steps % 10 == 0:
+            logging.info(
+                "[INCR_ATTN_STATE verify] %d incremental steps bit-identical to full "
+                "recomputation",
+                self._incr_attn_state_verify_steps,
+            )
 
     def _execute_pending_mamba_ops(self) -> None:
         """Execute Mamba GPU operations deferred from add_request() / update_requests().
@@ -2726,6 +3033,8 @@ class DynamicInferenceContext(BaseInferenceContext):
     def reset_tensors(self) -> None:
         """Fill all bookkeeping tensors with sentinel values."""
 
+        self._bump_request_layout_version()
+
         # Reset request indexes.
         self.request_ids.fill_(-1)
         self.request_query_lengths.fill_(0)
@@ -2769,6 +3078,8 @@ class DynamicInferenceContext(BaseInferenceContext):
         """
         # There is no prefix-cache state to preserve when caching is disabled.
         preserve_prefix_cache = preserve_prefix_cache and self.enable_prefix_caching
+
+        self._bump_request_layout_version()
 
         # Reset request/token counts.
         self.total_request_count = 0
@@ -3156,6 +3467,8 @@ class DynamicInferenceContext(BaseInferenceContext):
         if not self.is_tensor_state_allocated:
             raise TensorStateDeallocatedError(req.request_id)
 
+        self._bump_request_layout_version()
+
         # Prefill chunk length.
         if prefill_chunk_length is None:
             prefill_chunk_length = req.remaining_prompt_length
@@ -3394,6 +3707,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         """
         Move all the relevent booking tensors with src idxs to dst idxs
         """
+        self._bump_request_layout_version()
         self.request_kv_length_offsets[dst_idxs] = self.request_kv_length_offsets[src_idxs]
         self.request_in_prefill_status_tensor[dst_idxs] = self.request_in_prefill_status_tensor[
             src_idxs
@@ -3423,6 +3737,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         """
         Swaps all the relevent booking tensors with src idxs to dst idxs
         """
+        self._bump_request_layout_version()
         tensor_swap(self.request_kv_length_offsets, src_idxs, dst_idxs)
         tensor_swap(self.request_query_lengths, src_idxs, dst_idxs)
         tensor_swap(self.request_in_prefill_status_tensor, src_idxs, dst_idxs)
@@ -3480,6 +3795,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             request_indexes (torch.Tensor): Request indexes. (*Note*, NOT request
                 ids.)
         """
+        self._bump_request_layout_version()
         kv_blocks_assigned = self.request_to_kv_block_ids[request_indexes]
         non_zero_values_in_kv_memory = kv_blocks_assigned[kv_blocks_assigned != -1]
         self.kv_block_allocator.release_memory_blocks(non_zero_values_in_kv_memory)
@@ -3620,6 +3936,7 @@ class DynamicInferenceContext(BaseInferenceContext):
 
         # Resume requests by assigning blocks and updating bookkeeping tensors.
         if resume_request_count > 0:
+            self._bump_request_layout_version()
             resume_start = self.paused_request_count
             resume_end = self.paused_request_count + resume_request_count
 
@@ -3849,6 +4166,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         if block_ids is not None:
             row_idx = torch.nonzero(rows_requiring_new_block, as_tuple=True)[0]
             col_idx = self.request_kv_block_counts[row_idx]
+            self._bump_request_layout_version()
             self.request_to_kv_block_ids[row_idx, col_idx] = block_ids
             self.request_kv_block_counts[row_idx] += 1
             self.request_last_kv_block_id[row_idx] = block_ids
@@ -3953,6 +4271,14 @@ class DynamicInferenceContext(BaseInferenceContext):
             Tuple[Tensor, Tensor]: Request IDs that finished and source row indices
                 for surviving requests in their resolved destination order.
         """
+        # The layout-version bump is deferred until a request is known to have
+        # finished (below). When the mask is all ones -- the steady-state decode
+        # case -- nothing here touches the layout: no rows move (``survivor_idxs``
+        # equals ``dst_idxs``), no KV blocks are released, the stale slice is empty
+        # and ``total_request_count`` is unchanged. Bumping unconditionally
+        # invalidated the incremental attention-state cache on *every* step, which
+        # made that whole optimization inert under async scheduling (measured: the
+        # fast path advanced on 0.1% of calls, 97.5% declining on this version).
         if active_requests_mask.is_cuda:
             active_requests_mask = active_requests_mask.cpu()
 
@@ -3987,6 +4313,10 @@ class DynamicInferenceContext(BaseInferenceContext):
         self.reset_attention_state()
 
         if finished_idxs.numel() > 0:
+            # Every layout change in this method is downstream of a finished request:
+            # the row compaction below, the KV block release, and the request-count
+            # change all require at least one zero in the mask.
+            self._bump_request_layout_version()
             self.release_memory_blocks_from_request_indexes(finished_idxs)
 
         if active_request_count == 0:


### PR DESCRIPTION
## Summary

At a fixed batch size, `initialize_attention_state` rebuilds per-step attention
bookkeeping that is provably identical to the previous decode step — the request set,
the sampling metadata, the KV block table and the CUDA-graph selection do not change
for a hundred-plus consecutive steps, and only the KV sequence lengths advance. Caching
everything except the lengths behind a request-layout version counter cuts host CPU in
that call from **174.1 µs to 51.7 µs, a 3.37× reduction**.

The honest headline is the second finding, not the first: **under async scheduling this
buys no throughput at all**, because that host work was already fully hidden behind GPU
execution. This PR ships to make a shipped gate actually functional instead of silently
inert, with bit-exactness proven, and a reviewer should not expect a speedup from it.

## Why here

A host-phase breakdown, taken with monotonic-ns marks around each phase and
corroborated by a standalone harness that drives a real `DynamicInferenceContext` at
batch 256 through 400 steady-state decode steps with no model loaded (the two agree to
within 12%), put this one call at 171.5 µs. It was the largest single actionable host
phase.

It was also **concentrated rather than thin**, which is what made it worth attacking:

| Phase | µs/call | What it is |
|---|---:|---|
| `slices` | 73.9 | build and pad the active-request slices, sampling-metadata copies, logit indices |
| `mhameta` | 32.2 | KV/query lengths, both cumsums, block table, `set_state_data` |
| `xfer_inner` | 26.9 | H2D copy of the bookkeeping buffer |
| `graphmatch` | 12.8 | batch dimensions and graph-config match |
| `tokenpad` | 12.0 | stamp the token padding slots |
| `maxlen` | 12.0 | max-seqlen scalars |
| other | 1.8 | pending Mamba ops, padded dimensions, epilogue |

`slices` alone is 43%, and two statements inside it — `build_active_slices` at 29.3 µs
and `pad_active_slices` at 26.7 µs — are a third of the entire call. Had the profile
come back flat across fifty 3 µs statements, this design would not have been worth
building.

## What changed

A single monotonic `_request_layout_version` counter is bumped by every path that
changes *which* request occupies a slot, a request's sampling metadata, or its KV block
table. `initialize_attention_state` takes the fast path only when the current cache key
matches the stored one, where the key is the layout version plus six independent
structural sentinels: total request count, paused request count, active token count,
the block allocator's available-pool count, the chunked-prefill request id, and the
speculative-token count. The version is the real guard; the other six mean that a
missed bump would additionally have to coincide with an unchanged request count, token
count and allocator occupancy to escape detection.

On the fast path it recomputes only the KV sequence lengths and their cumsum — those
statements are copied character-for-character from the full path so the buffers stay
bit-identical — re-stamps the token padding sentinels, rebinds `state_data` through a
new `MHAMetadata.restore_state_data` (needed because `reset_attention_state` clears the
max-seqlen scalars every step), and issues the H2D transfer. Everything else is reused.

Advancing a request's KV length is deliberately *not* a version bump; that is precisely
the one thing the fast path recomputes.

Two later corrections are folded in here, because without them the fast path does not
fire at all and the PR would ship inert:

1. The fast path used to decline any caller that defers the bookkeeping publish, which
   is exactly what async scheduling does. It now takes the publish flags and mirrors the
   full path's conditional publish at its tail, forwarding the event.
2. `resolve_requests` bumped the layout version **unconditionally**, invalidating the
   cache every single step. In steady-state decode that bump is provably spurious: with
   an all-ones active mask no rows move, no KV blocks are released, the stale slice is
   empty and the total request count is unchanged. Every real layout change in that
   method requires at least one finished request, so the bump moved inside the
   `finished_idxs.numel() > 0` branch.

Together these took fast-path engagement from **0.1% of calls to 81%**.

## Measurement

Fixed protocol: Qwen3-30B-A3B, BF16, TP 1 / PP 1 / EP 4 / ETP 1, 256 gsm8k requests, 1024 output tokens, 2 warmup + 5 timed iterations, a single OCI 4xGB200 node (nvl72160-T04), async dynamic-batching scheduler pinned on. All 20 arms ran back to back in one allocation on that one node; node-to-node variance on this workload is around 2.7%, so cross-node numbers would not be comparable.

- With this change (every other gate in the stack enabled): **31,512 tok/s**
- Without it (same node, same session, only this gate turned off): **31,646 tok/s**
- Leave-one-out delta: **-0.42%**
- Noise floor: sigma = **0.42%** over 3 repeats of the all-gates-on reference
- Verdict: **inside the noise floor** (|-0.42%| < 2 sigma = 0.84%)

This is the **marginal contribution measured with every other gate in this stack enabled** — the question a reviewer is actually asking, which is whether this should land, not what it was worth when it was first written.

The reference is drift-corrected. The all-gates-on configuration was re-measured three times across the session (31,745, 31,530, 31,503 tok/s), a +0.77% drift from first to last, so each arm is compared against the reference interpolated to its own position in the run order rather than against a session mean.

For context, the whole stack is worth **+35.80%** on this node (23,265 tok/s with every gate off, 31,593 with every gate on). Per-slice deltas do not sum to that; they compose sub-additively.

## Evidence

**Host CPU.** 174.1 → 51.7 µs per call, 3.37×. The coarse breakdown collapses to
`graphmatch 0.2`, `slices 1.1`, `tokenpad 0.1`, `mhameta 0.4`, `maxlen 0.1`. The 48.2 µs
residual is the KV-length recompute plus the H2D bookkeeping copy, neither of which can
be cached — the GPU buffer genuinely must be rewritten every step.

**Why that host saving does not become throughput.** When the engagement fix landed and
the fast path went from firing on 3 calls in 3,000 to firing on 81% of them, roughly
204 µs/step of host work really was removed and end-to-end throughput did not move
(measured +0.18%, inside a noise band of ~1.5% spread across four samples of the same
configuration). The conclusion is that async scheduling was already hiding this host
work behind GPU execution. That is a negative result and it is the most useful thing
this PR reports: it retires host-side idle as a lever for this workload.

**Liveness.** This is the case that motivated the counter. An earlier version of this
change measured +1.04% and was believed; a decline-reason tally then showed the fast
path advancing on 0.1% of calls, with 97.5% of declines caused by the layout-version
mismatch described above. The mechanism essentially never fired, so the +1.04% had no
cause behind it and was a warm-up-ramp artifact. `MCORE_INFER_INCR_DIAG=1` ships with
this PR so the same question can be answered directly rather than inferred: it tallies
why the fast path declined, per reason.

The lesson is worth stating for the reviewer, because it generalizes: a plausible
mechanism plus a delta above the noise floor is still not evidence. Here the two agreed
with each other and both were wrong.

## Correctness

- **Numerics:** bit-exact. The fast path produces byte-identical buffers, not
  approximately equal ones, because the statements it does run are copied verbatim from
  the full path.
- **Tests:** `MCORE_INFER_INCR_ATTN_STATE_VERIFY=1` runs the fast path, snapshots
  everything it produced, recomputes the whole thing from scratch, and asserts equality
  of both MHA query-length buffers and cumsums, both KV-length buffers and cumsums, the
  block table, `active_request_last_token_idxs`, `active_logit_idxs`, all seven
  `active_request_metadata` tensors, the entire GPU bookkeeping buffer, the padded
  token and request counts, the padded batch dimensions, the graph-selection flag, both
  max-seqlen scalars, and the `(address, shape, dtype)` binding of every `state_data`
  view. **130 consecutive decode steps passed with zero mismatches.** Re-verified after
  the async fix: 132 confirmation lines across ranks, up to 90 verified incremental
  steps each, zero mismatches. The specific risk there — async reordering prepare before
  resolve, letting the cache key match while the true state differs — did not
  materialize.
- **Coherence:** the three temperature-0 completions are byte-identical between gate ON
  and gate OFF.

## Gating and blast radius

- Gate: `MCORE_INFER_INCR_ATTN_STATE`, **default OFF**. Unset, the full recomputation
  path runs exactly as before.
- `MCORE_INFER_INCR_ATTN_STATE_VERIFY`, default OFF, enables the equality check above.
  It is expensive by construction — it does all the work twice — and is a debugging
  tool, not a production setting.
- `MCORE_INFER_INCR_DIAG`, default OFF, tallies fast-path decline reasons.
- Four conditions bail out to the full path outright rather than trusting the key: any
  graph-dimension change (`construct_graph_dimensions is not None`), an expert-parallel
  dummy graph step, a hybrid (Mamba-state) model, and any step containing prefill
  requests. The cache is additionally never *stored* while CUDA graphs are being
  captured, or when the step did not use a graph.
- Thirteen mutation paths bump the version: request add including a chunked-prefill
  chunk, resume, the pause/resume slot swap, slot compaction, end-of-step finish and
  retire, evict and block release, a new KV block allocated mid-decode, dummy padding
  requests, graph-capture padding, the expert-parallel dummy step, tensor state
  reallocation, and both context resets. Every cache attribute is declared at class
  scope, so any construction path starts cold and invalid.

## Reproduce

```bash
MCORE_INFER_INCR_ATTN_STATE=1 \
QWEN30B_TP=1 QWEN30B_EP=4 QWEN30B_ETP=1 \
BENCH_SIZES_OVERRIDE=256 BENCH_OUTPUT_TOKENS=1024 \
NUM_WARMUP_ITERS=2 NUM_TIMED_ITERS=5 \
bash skills/run-qwen-model/run_qwen_inference.sh qwen3-30b-a3b --checkpoint "$QWEN30B_CKPT"
```

Add `MCORE_INFER_INCR_ATTN_STATE_VERIFY=1` to run the equality check, and
`MCORE_INFER_INCR_DIAG=1` to see fast-path engagement.

## What this does not claim

- **No throughput gain under async scheduling.** This is measured, not assumed, and it
  is the main finding. The ~204 µs/step of host work removed is already hidden behind
  GPU execution in this configuration.
- The earlier +0.94% and +1.04% figures associated with this mechanism are **withdrawn**.
  The first predates the async configuration this code now ships in; the second was
  measured while the mechanism fired on 0.1% of calls and had no cause behind it.
- The H2D bookkeeping copy, about 27 µs of every call, is irreducible here — the GPU
  buffer must be rewritten every step — so the 3.37× host reduction is a ceiling that
  cannot be pushed much further at this call site.
- No claim about configurations that are not async-scheduled or not at this batch size.
  A more host-bound configuration could plausibly convert this host saving into
  throughput; that was not measured and should not be assumed.

---

## This stack

This is one slice of [#6064](https://github.com/NVIDIA/Megatron-LM/pull/6064), a Qwen3-30B-A3B decode optimization campaign, split into 16 independently reviewable changes. Together they are **+35.80%** end-to-end throughput over the same base commit (23,265 -> 31,593 tok/s, mean of three full runs).

- **MoE grouped-GEMM and dispatch:** #6452 -> #6453 -> #6454 -> #6455
- **MoE router and combine:** #6456 -> #6457 -> #6458
- **Attention: QK norm and decode kernel:** #6459 -> #6460 -> #6461 -> #6462
- **Residual + RMSNorm fusion:** #6463 -> #6464
- **Host path: context bookkeeping:** #6465 -> #6466
- **Host path: independent:** #6467

Each chain is independent of the others and bases on `main`. Within a chain, later PRs depend on earlier ones.

### Per-slice measured delta

Every number is a leave-one-out delta from one same-node, same-session campaign: the full stack with exactly this change's gate off, against the interpolated full-stack reference at that point in the run. It is the change's *marginal* contribution with everything else already in, not its standalone value. Run-to-run sigma was **0.42%** across three full-stack repeats.

| PR | Change | Delta | |
|---|---|---|---|
| #6452 | FC1 SwiGLU epilogue | +14.81% | resolved |
| #6453 | indirection table fusion | +7.21% | resolved |
| #6454 | decode GEMM tile configs | +6.77% | resolved |
| #6455 | predicated top-k gather | +1.99% | by margin |
| #6456 | fused router softmax+top-k | +4.75% | resolved |
| #6457 | fused route padding mask | +1.47% | by margin |
| #6458 | bf16 MoE combine | +2.42% | by margin |
| #6459 | fused QK RMSNorm | +5.17% | resolved |
| #6460 | grouped QK norm input | +1.18% | by margin |
| #6461 | pin FlashAttention 2 | -0.35% | noise floor |
| #6462 | FlashInfer TRT-LLM decode | +1.46% | by margin |
| #6463 | fused add+norm pre-MLP | +3.54% | by margin |
| #6464 | fused add+norm pre-QKV | +0.98% | by margin |
| #6465 | incremental attention state | -0.42% | noise floor |
| #6466 | vectorized decode bookkeeping | -0.07% | noise floor |
| #6467 | post_process_requests fast path | +0.09% | noise floor |

`noise floor` means the delta is inside 2 sigma (0.84%) and this campaign cannot distinguish it from zero. `resolved` means the leave-one-out and full-stack iteration distributions did not overlap. Deltas do not sum to the stack total: these changes shorten the same decode step and compose sub-additively.

**Fixed protocol for every number above.** Qwen3-30B-A3B, BF16, TP1/PP1/EP4/ETP1, 256 gsm8k requests at batch size 256, output length 1024, CUDA graphs on, one OCI GB200 NVL72 node, 4 GPUs. All 20 arms ran back-to-back in a single Slurm allocation on one node, so node assignment and thermal state are held constant.
