### PR TITLE
perf(inference): eliminate dead whole-tensor work in decode request bookkeeping

### DIFF
--- a/megatron/core/inference/contexts/attention_context/mha_metadata.py
+++ b/megatron/core/inference/contexts/attention_context/mha_metadata.py
@@ -65,6 +65,18 @@ class MHAMetadata(MetadataBase):
             "max_seqlen_k": max_seqlen_k,
         }
 
+    def restore_state_data(self, state_data: dict, max_seqlen_q: int, max_seqlen_k: int) -> None:
+        """Re-bind a previously built ``state_data`` after ``reset()``.
+
+        Equivalent to ``set_state_data`` called with the arguments that produced
+        ``state_data``, minus the re-slicing. Used by the incremental decode
+        path in ``DynamicInferenceContext``, where the padded request count and
+        therefore every slice is provably unchanged from the previous step.
+        """
+        self._max_seqlen_q = max_seqlen_q
+        self._max_seqlen_k = max_seqlen_k
+        self.state_data = state_data
+
     def reset(self):
         """Reset the metadata for the next batch.
 

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -3,6 +3,7 @@
 import logging
 import math
 import operator
+import os
 import warnings
 from contextlib import nullcontext
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
@@ -76,6 +77,31 @@ try:
     HAVE_TORCH_MEMORY_SAVER = True
 except ImportError:
     HAVE_TORCH_MEMORY_SAVER = False
+
+# Incremental steady-state decode path for `initialize_attention_state`. Off by
+# default; see `DynamicInferenceContext._incremental_attention_state_update`.
+_INCR_ATTN_STATE = os.environ.get("MCORE_INFER_INCR_ATTN_STATE", "0") == "1"
+# Debug mode: take the fast path, then recompute from scratch and assert that
+# every buffer the fast path served is identical. Very slow; correctness only.
+_INCR_ATTN_STATE_VERIFY = os.environ.get("MCORE_INFER_INCR_ATTN_STATE_VERIFY", "0") == "1"
+
+# Diagnostic: tally why the incremental fast path declines, so a single run answers
+# "which guard is rejecting every step" instead of requiring a guess per experiment.
+_INCR_DIAG = os.environ.get("MCORE_INFER_INCR_DIAG", "0") == "1"
+_incr_diag_counts: Dict[str, int] = {}
+
+
+def _incr_diag(reason: str) -> None:
+    """Count one fast-path outcome and periodically log the tally."""
+    _incr_diag_counts[reason] = _incr_diag_counts.get(reason, 0) + 1
+    total = sum(_incr_diag_counts.values())
+    if total % 500 == 0:
+        parts = ", ".join(
+            f"{k}={v} ({100*v/total:.1f}%)"
+            for k, v in sorted(_incr_diag_counts.items(), key=lambda x: -x[1])
+        )
+        logging.info("[INCR_DIAG] %d calls: %s", total, parts)
+
 
 DEPRECATED_ARGS = [
     "params_dtype",
@@ -317,6 +343,17 @@ class DynamicInferenceContext(BaseInferenceContext):
     TOKEN_ROUNDER = 64
     REQUEST_ROUNDER = 4
     TMS_TAG = "inference_context"
+
+    # Incremental attention-state cache (MCORE_INFER_INCR_ATTN_STATE). Declared
+    # at class scope so every construction path starts from a cold, invalid
+    # cache without depending on __init__ ordering.
+    _request_layout_version = 0
+    _incr_attn_state_key = None
+    _incr_attn_state_real_bs = 0
+    _incr_attn_state_padded_bs = 0
+    _incr_attn_state_max_seqlen_q = 0
+    _incr_attn_state_max_seqlen_k = 0
+    _incr_attn_state_state_data = None
 
     @deprecate_args(
         *DEPRECATED_ARGS,
@@ -1055,6 +1092,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         if self.is_tensor_state_allocated:
             return
         self.is_tensor_state_allocated = True
+        self._bump_request_layout_version()
 
         # Validate no tensors allocated prior to this method.
         for key in vars(self).keys():
@@ -2017,6 +2055,8 @@ class DynamicInferenceContext(BaseInferenceContext):
         if not requests:
             return
 
+        self._bump_request_layout_version()
+
         num_new_requests = len(requests)
         if self.total_request_count + num_new_requests > self.max_requests:
             raise RequestOverflowError(requests[-1].request_id)
@@ -2154,6 +2194,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         Adds dummy requests to reflect the number of prefill and decode requests in the graph config.
         These are using during cuda graph captures.
         """
+        self._bump_request_layout_version()
         prefill_tokens = graph_dimensions.token_count - (
             graph_dimensions.decode_req_count * (self.num_speculative_tokens + 1)
         )
@@ -2225,6 +2266,7 @@ class DynamicInferenceContext(BaseInferenceContext):
 
         Called AFTER the EP sync so graph_dimensions reflects the agreed-upon graph.
         """
+        self._bump_request_layout_version()
         N_decode = graph_dimensions.decode_req_count
         N_prefill = graph_dimensions.prefill_req_count
         N = N_decode + N_prefill
@@ -2307,6 +2349,20 @@ class DynamicInferenceContext(BaseInferenceContext):
                 completion, or `None` when no event was requested or no
                 transfer was performed.
         """
+        _verify_snapshot = None
+        if _INCR_ATTN_STATE and not is_expert_parallel_dummy_cuda_graph_step:
+            advanced, fast_bookkeeping_done_event = self._incremental_attention_state_update(
+                construct_graph_dimensions,
+                transfer_bookkeeping_to_gpu=transfer_bookkeeping_to_gpu,
+                record_bookkeeping_done_event=record_bookkeeping_done_event,
+            )
+            if advanced:
+                if not _INCR_ATTN_STATE_VERIFY:
+                    return fast_bookkeeping_done_event
+                # Verify mode: keep what the fast path produced, redo everything
+                # from scratch below, then assert the two agree exactly.
+                _verify_snapshot = self._incr_attn_state_snapshot()
+
         # Launch deferred Mamba GPU ops first (state zeroing/restore) so they
         # overlap with the CPU work below.  These are non-blocking GPU kernels.
         self._execute_pending_mamba_ops()
@@ -2551,9 +2607,260 @@ class DynamicInferenceContext(BaseInferenceContext):
         )
 
         # Preserve the existing behavior for callers that do not publish explicitly.
+        bookkeeping_done_event = None
         if transfer_bookkeeping_to_gpu:
-            return self.transfer_bookkeeping_to_gpu(record_done_event=record_bookkeeping_done_event)
-        return None
+            bookkeeping_done_event = self.transfer_bookkeeping_to_gpu(
+                record_done_event=record_bookkeeping_done_event
+            )
+
+        if _INCR_ATTN_STATE:
+            self._incr_attn_state_store(real_bs, padded_bs, max_seqlen_q, max_seqlen_k)
+            if _verify_snapshot is not None:
+                self._incr_attn_state_verify(_verify_snapshot)
+
+        return bookkeeping_done_event
+
+    def _bump_request_layout_version(self) -> None:
+        """Invalidate the incremental attention-state cache.
+
+        Called from every path that changes *which* request occupies a slot, a
+        request's sampling metadata, or a request's KV block table — i.e. the
+        inputs that `initialize_attention_state` would otherwise recompute
+        identically on every decode step. Advancing a request's KV length is
+        deliberately *not* such a path: that is the one thing the incremental
+        update recomputes.
+        """
+        self._request_layout_version += 1
+
+    def _incr_attn_state_cache_key(self):
+        """Cheap scalar signature of the batch layout, or None if uncacheable.
+
+        `_request_layout_version` is the primary guard. The remaining entries
+        are independent structural sentinels so that a missed version bump
+        still has to coincide with an unchanged request count, token count and
+        KV block-allocator occupancy to go unnoticed.
+        """
+        if self.is_hybrid_model or self.num_prefill_requests != 0:
+            return None
+        return (
+            self._request_layout_version,
+            self.total_request_count,
+            self.paused_request_count,
+            self.active_token_count,
+            self.kv_block_allocator.pool_avail,
+            self.chunked_prefill_request_id,
+            self.num_speculative_tokens,
+        )
+
+    def _incr_attn_state_store(
+        self, real_bs: int, padded_bs: int, max_seqlen_q: int, max_seqlen_k: int
+    ) -> None:
+        """Record that the state just built by the full path is incrementable."""
+        if (
+            self.is_creating_cuda_graphs
+            or not self._using_cuda_graph_this_step
+            or self.is_hybrid_model
+            or self.num_prefill_requests != 0
+        ):
+            self._incr_attn_state_key = None
+            return
+        self._incr_attn_state_real_bs = real_bs
+        self._incr_attn_state_padded_bs = padded_bs
+        self._incr_attn_state_max_seqlen_q = max_seqlen_q
+        self._incr_attn_state_max_seqlen_k = max_seqlen_k
+        self._incr_attn_state_state_data = self.active_attn_metadata["mha_metadata"].state_data
+        self._incr_attn_state_key = self._incr_attn_state_cache_key()
+
+    def _incremental_attention_state_update(
+        self,
+        construct_graph_dimensions: Optional[InferenceBatchDimensions],
+        *,
+        transfer_bookkeeping_to_gpu: bool = True,
+        record_bookkeeping_done_event: bool = False,
+    ) -> Tuple[bool, Optional[torch.cuda.Event]]:
+        """Advance the cached attention state by one decode step.
+
+        In steady-state decode the request set, sampling metadata, KV block
+        table, CUDA-graph selection, padded dimensions and every
+        query-length-derived buffer are identical to the previous step; only
+        the KV sequence lengths advance by `num_speculative_tokens + 1` per
+        request. Recompute exactly those and reuse the rest.
+
+        The publish arguments mirror :meth:`initialize_attention_state`, so this path
+        serves deferred-publish callers (async scheduling) too. Without them the fast
+        path had to decline those callers, which meant it never ran at all under async
+        scheduling -- and async is the default in the tuned config, so the whole
+        optimization was silently inactive there.
+
+        Returns:
+            Tuple[bool, Optional[torch.cuda.Event]]: whether the state was advanced
+                (False means the caller must run the full path), and the bookkeeping
+                H2D completion event when one was both requested and recorded.
+        """
+        if construct_graph_dimensions is not None:
+            self._incr_attn_state_key = None
+            if _INCR_DIAG:
+                _incr_diag("decline:graph_capture")
+            return False, None
+        key = self._incr_attn_state_cache_key()
+        if key is None or key != self._incr_attn_state_key:
+            if _INCR_DIAG:
+                if key is None:
+                    # Uncacheable batch: hybrid model or a prefill request present.
+                    _incr_diag("decline:key_none")
+                elif self._incr_attn_state_key is None:
+                    # Previous step declined to store, so there is nothing to advance.
+                    _incr_diag("decline:no_stored_key")
+                else:
+                    # Both keys exist but differ: name the first differing field, which
+                    # is what distinguishes "layout really changed" from "one sentinel
+                    # (e.g. KV block availability) churns every step".
+                    fields = (
+                        "layout_version",
+                        "total_reqs",
+                        "paused_reqs",
+                        "active_tokens",
+                        "kv_blocks_avail",
+                        "chunked_prefill_id",
+                        "spec_tokens",
+                    )
+                    diff = next(
+                        (
+                            f
+                            for f, a, b in zip(fields, key, self._incr_attn_state_key)
+                            if a != b
+                        ),
+                        "unknown",
+                    )
+                    _incr_diag(f"decline:key_differs:{diff}")
+            return False, None
+
+        real_bs = self._incr_attn_state_real_bs
+        padded_bs = self._incr_attn_state_padded_bs
+
+        self._execute_pending_mamba_ops()
+        self.is_creating_cuda_graphs = False
+        self._using_cuda_graph_this_step = True
+        self.active_attn_metadata = self.graph_attn_metadata  # type: ignore[assignment]
+
+        active_slice = slice(self.paused_request_count, self.total_request_count)
+        query_lengths_view = self.request_query_lengths[active_slice]
+        request_kv_length_offsets_view = self.request_kv_length_offsets[active_slice]
+
+        # Character-identical to the corresponding statements in the full path,
+        # so the buffers stay bit-identical to a fresh computation.
+        self._cpu_mha_kv_seq_lengths[:real_bs] = (
+            request_kv_length_offsets_view[:real_bs] + query_lengths_view[:real_bs]
+        )
+        self._cpu_mha_cu_kv_seq_lengths[0] = 0
+        if real_bs > 0:
+            self._cpu_mha_cu_kv_seq_lengths[1 : real_bs + 1] = torch.cumsum(
+                self._cpu_mha_kv_seq_lengths[:real_bs], dim=0
+            )
+        if real_bs < padded_bs:
+            self._cpu_mha_cu_kv_seq_lengths[real_bs + 1 : padded_bs + 1] = (
+                self._cpu_mha_cu_kv_seq_lengths[real_bs]
+            )
+
+        # Token padding slots hold step-invariant sentinels, but re-stamp them
+        # whenever padding exists at all, since the token buffers are shared.
+        if self.active_token_count != self.padded_active_token_count:
+            self.token_to_block_idx[self.active_token_count : self.padded_active_token_count] = (
+                self.kv_block_allocator.dummy_block_idx
+            )
+            self.token_to_local_position_within_kv_block[
+                self.active_token_count : self.padded_active_token_count
+            ] = 0
+            self.token_to_position_in_request[
+                self.active_token_count : self.padded_active_token_count
+            ] = 0
+
+        # `reset_attention_state()` clears the max-seqlen scalars every step, so
+        # rebind state_data even though the slices behind it are unchanged.
+        self.active_attn_metadata["mha_metadata"].restore_state_data(
+            self._incr_attn_state_state_data,
+            self._incr_attn_state_max_seqlen_q,
+            self._incr_attn_state_max_seqlen_k,
+        )
+
+        if self.moe_enable_routing_replay:
+            self.moe_routing_metadata.enable_static_buffer_recording()
+
+        if self._nccl_ep_dispatcher:
+            NCCLAllGatherDispatcher._use_allgather_v = False
+
+        self._execute_pending_mamba_ops()
+        # Graph-capture and EP dummy steps are declined above, so this step always
+        # produces real output; clear the flag the publish step reads, which may
+        # still be set from an earlier capture step.
+        self._bookkeeping_no_real_work = False
+        if _INCR_DIAG:
+            _incr_diag("advanced")
+        # Same conditional publish as the tail of the full path: deferred-publish
+        # callers bind the GPU views here and push the values later.
+        bookkeeping_done_event = None
+        if transfer_bookkeeping_to_gpu:
+            bookkeeping_done_event = self.transfer_bookkeeping_to_gpu(
+                record_done_event=record_bookkeeping_done_event
+            )
+        return True, bookkeeping_done_event
+
+    def _incr_attn_state_snapshot(self) -> Dict:
+        """Clone everything the incremental path produced (debug verify only)."""
+        torch.cuda.synchronize()
+        n = self.padded_active_request_count
+        mha = self.active_attn_metadata["mha_metadata"]
+        snapshot = {
+            "mha_query_lengths": self._cpu_mha_query_lengths[:n].clone(),
+            "mha_cu_query_seq_lengths": self._cpu_mha_cu_query_seq_lengths[: n + 1].clone(),
+            "mha_kv_seq_lengths": self._cpu_mha_kv_seq_lengths[:n].clone(),
+            "mha_cu_kv_seq_lengths": self._cpu_mha_cu_kv_seq_lengths[: n + 1].clone(),
+            "mha_block_table": self._cpu_mha_block_table[:n].clone(),
+            "active_request_last_token_idxs": self.active_request_last_token_idxs[:n].clone(),
+            "active_logit_idxs": self.active_logit_idxs.clone(),
+            "gpu_bookkeeping_buf": self.gpu_view._buf.clone(),
+            "padded_active_token_count": self.padded_active_token_count,
+            "padded_active_request_count": self.padded_active_request_count,
+            "padded_batch_dimensions": self.padded_batch_dimensions,
+            "using_cuda_graph_this_step": self._using_cuda_graph_this_step,
+            "max_seqlen_q": mha._max_seqlen_q,
+            "max_seqlen_k": mha._max_seqlen_k,
+        }
+        for label, tensor in self.active_request_metadata.items():
+            snapshot[f"active_request_metadata/{label}"] = tensor[:n].clone()
+        # state_data holds views into the GPU bookkeeping buffer; compare the
+        # bindings (address, shape, dtype) rather than the contents, which the
+        # `gpu_bookkeeping_buf` entry above already covers.
+        for label, value in mha.state_data.items():
+            if isinstance(value, torch.Tensor):
+                value = (value.data_ptr(), tuple(value.shape), str(value.dtype))
+            snapshot[f"state_data/{label}"] = value
+        return snapshot
+
+    def _incr_attn_state_verify(self, snapshot: Dict) -> None:
+        """Assert the freshly recomputed state matches the incremental one."""
+        fresh = self._incr_attn_state_snapshot()
+        mismatches = []
+        for key, want in snapshot.items():
+            got = fresh[key]
+            if isinstance(want, torch.Tensor):
+                if not torch.equal(want, got):
+                    bad = (want != got).nonzero().flatten()[:8].tolist()
+                    mismatches.append(f"{key}: {bad} incr={want.flatten()[:8].tolist()}")
+            elif want != got:
+                mismatches.append(f"{key}: incr={want} full={got}")
+        self._incr_attn_state_verify_steps = getattr(self, "_incr_attn_state_verify_steps", 0) + 1
+        if mismatches:
+            raise AssertionError(
+                "MCORE_INFER_INCR_ATTN_STATE verification failed at step "
+                f"{self._incr_attn_state_verify_steps}: " + "; ".join(mismatches)
+            )
+        if self._incr_attn_state_verify_steps % 10 == 0:
+            logging.info(
+                "[INCR_ATTN_STATE verify] %d incremental steps bit-identical to full "
+                "recomputation",
+                self._incr_attn_state_verify_steps,
+            )
 
     def _execute_pending_mamba_ops(self) -> None:
         """Execute Mamba GPU operations deferred from add_request() / update_requests().
@@ -2726,6 +3033,8 @@ class DynamicInferenceContext(BaseInferenceContext):
     def reset_tensors(self) -> None:
         """Fill all bookkeeping tensors with sentinel values."""
 
+        self._bump_request_layout_version()
+
         # Reset request indexes.
         self.request_ids.fill_(-1)
         self.request_query_lengths.fill_(0)
@@ -2769,6 +3078,8 @@ class DynamicInferenceContext(BaseInferenceContext):
         """
         # There is no prefix-cache state to preserve when caching is disabled.
         preserve_prefix_cache = preserve_prefix_cache and self.enable_prefix_caching
+
+        self._bump_request_layout_version()
 
         # Reset request/token counts.
         self.total_request_count = 0
@@ -3156,6 +3467,8 @@ class DynamicInferenceContext(BaseInferenceContext):
         if not self.is_tensor_state_allocated:
             raise TensorStateDeallocatedError(req.request_id)
 
+        self._bump_request_layout_version()
+
         # Prefill chunk length.
         if prefill_chunk_length is None:
             prefill_chunk_length = req.remaining_prompt_length
@@ -3394,6 +3707,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         """
         Move all the relevent booking tensors with src idxs to dst idxs
         """
+        self._bump_request_layout_version()
         self.request_kv_length_offsets[dst_idxs] = self.request_kv_length_offsets[src_idxs]
         self.request_in_prefill_status_tensor[dst_idxs] = self.request_in_prefill_status_tensor[
             src_idxs
@@ -3423,6 +3737,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         """
         Swaps all the relevent booking tensors with src idxs to dst idxs
         """
+        self._bump_request_layout_version()
         tensor_swap(self.request_kv_length_offsets, src_idxs, dst_idxs)
         tensor_swap(self.request_query_lengths, src_idxs, dst_idxs)
         tensor_swap(self.request_in_prefill_status_tensor, src_idxs, dst_idxs)
@@ -3480,6 +3795,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             request_indexes (torch.Tensor): Request indexes. (*Note*, NOT request
                 ids.)
         """
+        self._bump_request_layout_version()
         kv_blocks_assigned = self.request_to_kv_block_ids[request_indexes]
         non_zero_values_in_kv_memory = kv_blocks_assigned[kv_blocks_assigned != -1]
         self.kv_block_allocator.release_memory_blocks(non_zero_values_in_kv_memory)
@@ -3620,6 +3936,7 @@ class DynamicInferenceContext(BaseInferenceContext):
 
         # Resume requests by assigning blocks and updating bookkeeping tensors.
         if resume_request_count > 0:
+            self._bump_request_layout_version()
             resume_start = self.paused_request_count
             resume_end = self.paused_request_count + resume_request_count
 
@@ -3849,6 +4166,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         if block_ids is not None:
             row_idx = torch.nonzero(rows_requiring_new_block, as_tuple=True)[0]
             col_idx = self.request_kv_block_counts[row_idx]
+            self._bump_request_layout_version()
             self.request_to_kv_block_ids[row_idx, col_idx] = block_ids
             self.request_kv_block_counts[row_idx] += 1
             self.request_last_kv_block_id[row_idx] = block_ids
@@ -3953,6 +4271,14 @@ class DynamicInferenceContext(BaseInferenceContext):
             Tuple[Tensor, Tensor]: Request IDs that finished and source row indices
                 for surviving requests in their resolved destination order.
         """
+        # The layout-version bump is deferred until a request is known to have
+        # finished (below). When the mask is all ones -- the steady-state decode
+        # case -- nothing here touches the layout: no rows move (``survivor_idxs``
+        # equals ``dst_idxs``), no KV blocks are released, the stale slice is empty
+        # and ``total_request_count`` is unchanged. Bumping unconditionally
+        # invalidated the incremental attention-state cache on *every* step, which
+        # made that whole optimization inert under async scheduling (measured: the
+        # fast path advanced on 0.1% of calls, 97.5% declining on this version).
         if active_requests_mask.is_cuda:
             active_requests_mask = active_requests_mask.cpu()
 
@@ -3987,6 +4313,10 @@ class DynamicInferenceContext(BaseInferenceContext):
         self.reset_attention_state()
 
         if finished_idxs.numel() > 0:
+            # Every layout change in this method is downstream of a finished request:
+            # the row compaction below, the KV block release, and the request-count
+            # change all require at least one zero in the mask.
+            self._bump_request_layout_version()
             self.release_memory_blocks_from_request_indexes(finished_idxs)
 
         if active_request_count == 0:

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -85,6 +85,13 @@ _INCR_ATTN_STATE = os.environ.get("MCORE_INFER_INCR_ATTN_STATE", "0") == "1"
 # every buffer the fast path served is identical. Very slow; correctness only.
 _INCR_ATTN_STATE_VERIFY = os.environ.get("MCORE_INFER_INCR_ATTN_STATE_VERIFY", "0") == "1"
 
+# Reduced-op path for the post-sampling bookkeeping in `update_requests`. Off by
+# default; see `DynamicInferenceContext._write_decode_token_bookkeeping_fast`.
+_VEC_UPDATE_REQS = os.environ.get("MCORE_INFER_VEC_UPDATE_REQS", "0") == "1"
+# Debug mode: run the reduced-op path, snapshot every buffer it wrote, restore
+# the inputs, run the reference path, and assert the two agree exactly.
+_VEC_UPDATE_REQS_VERIFY = os.environ.get("MCORE_INFER_VEC_UPDATE_REQS_VERIFY", "0") == "1"
+
 # Diagnostic: tally why the incremental fast path declines, so a single run answers
 # "which guard is rejecting every step" instead of requiring a guess per experiment.
 _INCR_DIAG = os.environ.get("MCORE_INFER_INCR_DIAG", "0") == "1"
@@ -354,6 +361,11 @@ class DynamicInferenceContext(BaseInferenceContext):
     _incr_attn_state_max_seqlen_q = 0
     _incr_attn_state_max_seqlen_k = 0
     _incr_attn_state_state_data = None
+
+    # Cached `torch.arange(paused_request_count, total_request_count)` for the
+    # reduced-op decode bookkeeping path (MCORE_INFER_VEC_UPDATE_REQS).
+    _decode_req_idx_bounds = None
+    _decode_req_idx_arange = None
 
     @deprecate_args(
         *DEPRECATED_ARGS,
@@ -4423,7 +4435,13 @@ class DynamicInferenceContext(BaseInferenceContext):
             active_requests_mask[-1] = 1
 
         active_request_count = (active_requests_mask == 1).sum().item()
-        finished_request_count = (active_requests_mask == 0).sum().item()
+        if _VEC_UPDATE_REQS:
+            # The mask is 0/1 by construction (a `&` of two byte comparisons in
+            # text_generation_controller), so the complement is exact and saves a
+            # second full comparison + reduction over the request dimension.
+            finished_request_count = active_requests_mask.numel() - active_request_count
+        else:
+            finished_request_count = (active_requests_mask == 0).sum().item()
         assert (
             active_request_count + finished_request_count + self.paused_request_count
             == self.total_request_count
@@ -4514,7 +4532,11 @@ class DynamicInferenceContext(BaseInferenceContext):
             ]
             active_requests_requiring_new_block = (
                 num_tokens_in_last_block >= self.block_size_tokens - 1 - self.num_speculative_tokens
-            ).byte()
+            )
+            if not _VEC_UPDATE_REQS:
+                # The bool tensor supports every downstream use (nonzero, `== 0`,
+                # scalar assignment, sum), so the byte cast is a pure copy.
+                active_requests_requiring_new_block = active_requests_requiring_new_block.byte()
 
             # Find the id in request_ids that is the chunked_prefill_request_id. Only one request should be chunked.
             if (
@@ -4531,9 +4553,14 @@ class DynamicInferenceContext(BaseInferenceContext):
                     # Force-pause excess requests in a decode-only batch
                     active_requests_requiring_new_block[max_allowed_active:] = 1
 
-            active_requests_requiring_new_block_count = (
-                (active_requests_requiring_new_block == 1).sum().item()
-            )
+            if _VEC_UPDATE_REQS:
+                active_requests_requiring_new_block_count = int(
+                    active_requests_requiring_new_block.sum()
+                )
+            else:
+                active_requests_requiring_new_block_count = (
+                    (active_requests_requiring_new_block == 1).sum().item()
+                )
 
             if active_requests_requiring_new_block_count > 0:
                 newly_paused_request_ids = self.request_ids[
@@ -4681,6 +4708,123 @@ class DynamicInferenceContext(BaseInferenceContext):
             num_generated_tokens
         )
 
+        if _VEC_UPDATE_REQS and self.num_speculative_tokens == 0:
+            if _VEC_UPDATE_REQS_VERIFY:
+                self._verify_decode_token_bookkeeping(active_request_count, next_tokens)
+            else:
+                self._write_decode_token_bookkeeping_fast(active_request_count, next_tokens)
+        else:
+            self._write_token_bookkeeping_reference(
+                active_request_count,
+                num_generated_tokens,
+                next_tokens,
+                prev_last_block_ids,
+                new_speculative_tokens,
+            )
+
+        return {
+            "newly_paused_request_ids": newly_paused_request_ids,
+            "evict_request_ids": evict_request_ids,
+        }
+
+    def _write_decode_token_bookkeeping_fast(
+        self, active_request_count: int, next_tokens: Tensor
+    ) -> None:
+        """Reduced-op form of `_write_token_bookkeeping_reference` for plain decode.
+
+        Only valid when `num_speculative_tokens == 0`, i.e. exactly one generated
+        token per active request. Under that condition the reference path spends
+        most of its host time on operations that are provably identity:
+        `repeat_interleave(1)`, adding `torch.arange(1).repeat(n)` (a zero
+        vector), and building the `raw_positions` / `crosses_boundary` tensors
+        whose only consumer is a branch that a zero speculative-token count makes
+        unreachable. This writes the same values with those operations removed.
+        """
+        paused = self.paused_request_count
+        total = self.total_request_count
+        active_slice = slice(paused, total)
+        num_tokens = active_request_count
+
+        block_offsets = self.request_last_kv_block_offset
+        block_offsets[active_slice] = (
+            block_offsets[active_slice] + 1
+        ) % self.block_size_tokens
+
+        self.active_token_count = num_tokens
+        self.token_to_input_ids[:num_tokens] = next_tokens[active_slice]
+
+        pos_ids = self.token_to_pos_ids
+        pos_ids[:num_tokens] = self.request_kv_length_offsets[active_slice]
+
+        if self._decode_req_idx_bounds != (paused, total):
+            self._decode_req_idx_bounds = (paused, total)
+            self._decode_req_idx_arange = torch.arange(paused, total, device='cpu')
+        self.token_to_request_idx[:num_tokens] = self._decode_req_idx_arange
+
+        self.token_to_position_in_request[:num_tokens] = pos_ids[:num_tokens]
+        self.token_to_local_position_within_kv_block[:num_tokens] = (
+            pos_ids[:num_tokens] % self.block_size_tokens
+        )
+        self.token_to_block_idx[:num_tokens] = self.request_last_kv_block_id[active_slice]
+
+    def _verify_decode_token_bookkeeping(
+        self, active_request_count: int, next_tokens: Tensor
+    ) -> None:
+        """Run the fast path, then the reference path, and assert they agree."""
+        paused = self.paused_request_count
+        total = self.total_request_count
+        pre_block_offsets = self.request_last_kv_block_offset[paused:total].clone()
+
+        self._write_decode_token_bookkeeping_fast(active_request_count, next_tokens)
+        num_tokens = self.active_token_count
+        fast = {
+            "request_last_kv_block_offset": self.request_last_kv_block_offset[
+                paused:total
+            ].clone(),
+            "active_token_count": self.active_token_count,
+            "token_to_input_ids": self.token_to_input_ids[:num_tokens].clone(),
+            "token_to_pos_ids": self.token_to_pos_ids[:num_tokens].clone(),
+            "token_to_request_idx": self.token_to_request_idx[:num_tokens].clone(),
+            "token_to_position_in_request": self.token_to_position_in_request[
+                :num_tokens
+            ].clone(),
+            "token_to_local_position_within_kv_block": (
+                self.token_to_local_position_within_kv_block[:num_tokens].clone()
+            ),
+            "token_to_block_idx": self.token_to_block_idx[:num_tokens].clone(),
+        }
+
+        self.request_last_kv_block_offset[paused:total] = pre_block_offsets
+        self._write_token_bookkeeping_reference(active_request_count, 1, next_tokens, None)
+
+        mismatches = []
+        for name, fast_value in fast.items():
+            if name == "active_token_count":
+                if fast_value != self.active_token_count:
+                    mismatches.append(f"{name}: {fast_value} != {self.active_token_count}")
+                continue
+            if name == "request_last_kv_block_offset":
+                reference = self.request_last_kv_block_offset[paused:total]
+            else:
+                reference = getattr(self, name)[:num_tokens]
+            if not torch.equal(fast_value, reference):
+                bad = int((fast_value != reference).sum())
+                mismatches.append(f"{name}: {bad} of {reference.numel()} elements differ")
+        if mismatches:
+            raise AssertionError(
+                "MCORE_INFER_VEC_UPDATE_REQS verification failed at step "
+                f"{self.step_count}: " + "; ".join(mismatches)
+            )
+
+    def _write_token_bookkeeping_reference(
+        self,
+        active_request_count: int,
+        num_generated_tokens: int,
+        next_tokens: Tensor,
+        prev_last_block_ids: Optional[Tensor],
+        new_speculative_tokens: Optional[Tensor] = None,
+    ) -> None:
+        """Per-token bookkeeping for the next forward pass (general path)."""
         # Clone needed: old_offsets is reused later to compute raw_positions
         # for block-boundary detection. The write-back on the next line overwrites the
         # underlying tensor, so without clone the boundary-crossing logic would see the
@@ -4806,11 +4950,6 @@ class DynamicInferenceContext(BaseInferenceContext):
 
             # Convert back to 1d tensor
             self.token_to_block_idx[: self.active_token_count] = block_idx.flatten()
-
-        return {
-            "newly_paused_request_ids": newly_paused_request_ids,
-            "evict_request_ids": evict_request_ids,
-        }
 
     def _processed_log_probs(
         self,

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -4,6 +4,7 @@ import asyncio
 import concurrent
 import copy
 import functools
+import os
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, OrderedDict, Tuple, Union
@@ -71,6 +72,10 @@ from megatron.core.inference.text_generation_controllers.mtp_utils_triton import
     prepare_next_forward_pass,
     verify_speculative_tokens,
 )
+
+# Reduced-op path for the post-sampling bookkeeping chain; shares the gate with
+# `DynamicInferenceContext.update_requests`. See the ledger record QWEN-024.
+_VEC_UPDATE_REQS = os.environ.get("MCORE_INFER_VEC_UPDATE_REQS", "0") == "1"
 
 
 @dataclass
@@ -1849,6 +1854,26 @@ class TextGenerationController:
         # Clear temporary dummy state while preserving reusable prefix state and counters.
         context.reset(preserve_prefix_cache=True, preserve_counters=True)
 
+    def _empty_finished_idxs(self, device: torch.device) -> Tensor:
+        """Cached empty index tensor matching what `torch.nonzero` would return."""
+        cached = getattr(self, "_empty_finished_idxs_cache", None)
+        if cached is None or cached.device != device:
+            cached = torch.empty(0, dtype=torch.long, device=device)
+            self._empty_finished_idxs_cache = cached
+        return cached
+
+    def _empty_finished_ids(self, request_ids: Tensor) -> Tensor:
+        """Cached empty tensor matching an empty gather from `request_ids`."""
+        cached = getattr(self, "_empty_finished_ids_cache", None)
+        if (
+            cached is None
+            or cached.dtype != request_ids.dtype
+            or cached.device != request_ids.device
+        ):
+            cached = torch.empty(0, dtype=request_ids.dtype, device=request_ids.device)
+            self._empty_finished_ids_cache = cached
+        return cached
+
     def _transfer_samples_to_cpu(self, active_request_count: int) -> tuple:
         """Batch GPU-to-CPU transfer of sampled tokens.
 
@@ -1937,10 +1962,17 @@ class TextGenerationController:
         # Apply stop words detected during the previous engine bookkeeping step.
         self._apply_stop_word_finished_ids(active_request_ids, active_request_mask)
 
-        finished_idxs = (
-            torch.nonzero(active_request_mask == 0, as_tuple=True)[0] + context.paused_request_count
-        )
-        finished_request_ids = context.request_ids[finished_idxs]
+        if _VEC_UPDATE_REQS and int(active_request_mask.sum()) == active_request_count:
+            # Steady-state decode: nothing finished this step, so skip the
+            # `nonzero` scan and the advanced-index gather it feeds.
+            finished_idxs = self._empty_finished_idxs(active_request_mask.device)
+            finished_request_ids = self._empty_finished_ids(context.request_ids)
+        else:
+            finished_idxs = (
+                torch.nonzero(active_request_mask == 0, as_tuple=True)[0]
+                + context.paused_request_count
+            )
+            finished_request_ids = context.request_ids[finished_idxs]
 
         # Save block IDs for finished requests before update_requests releases them.
         # Needed for per-block routing reconstruction in the engine.


### PR DESCRIPTION
> Stacked on #6465. Review that one first; this diff is only a decode-specialized form of the per-token bookkeeping tail of `update_requests` that drops the operations which are identity when there is exactly one generated token per request.
>
> GitHub cannot base a pull request from a fork on another unmerged fork branch, so the diff below also contains the parent's commits. This PR's own change is the final commit, `d01f94fe9`; review that one. The rest lands with the parent.

## Summary

The post-sampling tail of `DynamicInferenceContext.update_requests` spends most of its
host time on whole-tensor CPU operations that compute nothing once there is one generated
token per request: `repeat_interleave(1)` is the identity, the position write adds a
`torch.arange(1).repeat(256)` that is a 256-element zero vector, and a `[256, 1]`
block-boundary tensor is built whose only consumer is an `else` branch that a zero
speculative-token count makes unreachable. A decode-specialized form of that tail with
those operations removed cuts host CPU in `update_requests` from **137.6 to 74.0 µs/step
(1.86×)**, and together with three cheaper count reductions takes the whole post-sampling
bookkeeping chain from 372.4 to 293.7 µs/step: **-0.07%** end-to-end decode
throughput.

The thing to know before reviewing is what this deliberately does *not* fix. The single
largest item in that chain is 187.9 µs/step inside the engine's `post_process_requests`,
and it is untouched here — it is per-request Python object churn, not tensor work, so no
amount of operation elimination reaches it. A separate change handles it. Do not read this
PR as having solved the post-sampling phase.

## Why here

A host-phase breakdown of one steady-state decode step at batch 256 splits the work that
happens after the sampled tokens come back from the device into three regions. Measured
with a standalone harness that drives a real `DynamicInferenceContext` through a synthetic
decode loop with no model loaded, and calls the real engine `post_process_requests` against
a stub engine holding 256 real request objects:

| Region | µs/step | Nature |
|---|---:|---|
| `active_request_mask` (controller) | 46.9 | ~11 whole-tensor CPU ops over 256 elements |
| `update_requests` (context) | 137.6 | ~22 whole-tensor CPU ops over 256 elements |
| `post_process_requests` (engine) | 187.9 | per-request Python object churn |
| **total** | **372.4** | |

The harness runs 10–20% cheaper than the in-server measurement across all three regions,
which is the expected direction — no server threads, no allocator pressure, no profiler —
and the three ratios agree with each other to within 15%.

The pre-agreed rule for this target was: vectorize the region if its cost is a uniform
per-request Python loop expressible as tensor operations, and stop if it is per-request
object churn. The measurement split the chain cleanly in half across that line, and
neither half is the case the rule anticipated. `update_requests` and the
`active_request_mask` block contain no per-request Python loop at all; they are *already*
vectorized. Their cost is roughly 33 whole-tensor operations on 256-element CPU tensors at
2–16 µs each, and about half of that work is provably dead at one generated token per
request. Three statements in `update_requests` cost 30.0 µs/step between them and produce
nothing:

| Statement | µs/step | Why it is dead at one token per request |
|---|---:|---|
| `token_to_pos_ids` write | 16.0 | `repeat_interleave(1)` is the identity, and it adds `torch.arange(1).repeat(256)`, a zero vector |
| `raw_positions` + `crosses_boundary` + `.any()` | 10.1 | builds a `[256, 1]` tensor whose only consumer is an `else` branch that `num_speculative_tokens == 0` makes unreachable |
| `token_to_request_idx` write | 7.3 | `repeat_interleave(1)` over a `torch.arange` that is a pure function of the request-slot bounds |

So the lever here is operation elimination rather than vectorization, which is the low-risk
one: it changes no per-request semantics, touches no termination logic, and every removed
operation is removed because a cheaper statement produces the identical result.

## What changed

The per-token bookkeeping tail of `update_requests` is factored out verbatim into
`_write_token_bookkeeping_reference`, which is still what runs for speculative decoding and
for the gate-off path. A new `_write_decode_token_bookkeeping_fast` is dispatched to only
when `num_speculative_tokens == 0`. It writes the same six `token_to_*` buffers and the same
`request_last_kv_block_offset` values, differing from the reference only in what it does not
do:

- The three dead statements above are gone. `token_to_pos_ids` is a plain slice assignment
  from `request_kv_length_offsets`; `token_to_block_idx` is a plain slice assignment from
  `request_last_kv_block_id`; the `raw_positions` / `crosses_boundary` pair is not built at
  all, because the branch that reads it cannot be taken.
- `request_last_kv_block_offset` is advanced without the reference's defensive `clone()`.
  That clone exists only because `raw_positions` needs the pre-update offsets later in the
  reference path, and `raw_positions` no longer exists here.
- The request-index vector is a cached `torch.arange(paused_request_count,
  total_request_count)`, invalidated by comparing the bounds pair. It depends only on the
  request-slot bounds, so unlike the caching in the parent PR there is no cross-step state
  here beyond that one tensor — this tail consumes the current step's freshly sampled
  tokens and has nothing else to reuse.

Three smaller reductions, all under the same gate, account for the 12 µs the
`active_request_mask` block loses:

1. `finished_request_count` is derived as `numel() - active_request_count` instead of a
   second full comparison and reduction over the request dimension. The mask is 0/1 by
   construction — it is an `&` of two `.byte()` comparisons built in the controller — so the
   complement is exact rather than approximately right.
2. `active_requests_requiring_new_block` stays a bool tensor instead of being cast with
   `.byte()`, which was a pure copy. Every downstream use (`torch.nonzero`, `== 0`, scalar
   assignment, `sum`) is dtype-agnostic.
3. Its population count uses `int(tensor.sum())` rather than `(tensor == 1).sum().item()`,
   removing a second pass over the tensor.

In the controller, when the active-request mask says nothing finished this step, the
`torch.nonzero` scan and the advanced-index gather it feeds are replaced by cached empty
tensors of the same dtype and device, so the downstream code sees exactly what an empty
`nonzero` result would have produced.

**On the stacking.** This has no functional dependency on the parent PR. Both edit
`dynamic_context.py`, and stacking is only how the two are kept from owning the same file;
the mechanisms are independent and neither gate affects the other's guard. If the parent is
declined, this diff rebases onto main with only context conflicts.

## Measurement

Fixed protocol: Qwen3-30B-A3B, BF16, TP 1 / PP 1 / EP 4 / ETP 1, 256 gsm8k requests, 1024 output tokens, 2 warmup + 5 timed iterations, a single OCI 4xGB200 node (nvl72160-T04), async dynamic-batching scheduler pinned on. All 20 arms ran back to back in one allocation on that one node; node-to-node variance on this workload is around 2.7%, so cross-node numbers would not be comparable.

- With this change (every other gate in the stack enabled): **31,509 tok/s**
- Without it (same node, same session, only this gate turned off): **31,531 tok/s**
- Leave-one-out delta: **-0.07%**
- Noise floor: sigma = **0.42%** over 3 repeats of the all-gates-on reference
- Verdict: **inside the noise floor** (|-0.07%| < 2 sigma = 0.84%)

This is the **marginal contribution measured with every other gate in this stack enabled** — the question a reviewer is actually asking, which is whether this should land, not what it was worth when it was first written.

The reference is drift-corrected. The all-gates-on configuration was re-measured three times across the session (31,745, 31,530, 31,503 tok/s), a +0.77% drift from first to last, so each arm is compared against the reference interpolated to its own position in the run order rather than against a session mean.

For context, the whole stack is worth **+35.80%** on this node (23,265 tok/s with every gate off, 31,593 with every gate on). Per-slice deltas do not sum to that; they compose sub-additively.

## Evidence

**Host CPU per step**, from the harness at batch 256 with 256 active requests, gate off
against gate on in the same process:

| Region | Gate OFF | Gate ON | Δ |
|---|---:|---:|---:|
| `active_request_mask` | 46.9 | 34.9 | −12.0 |
| `update_requests` | 137.6 | 74.0 | **−63.6 (1.86×)** |
| `post_process_requests` | 187.9 | 184.7 | unchanged, as intended |
| **chain total** | **372.4** | **293.7** | **−78.7** |

The `post_process_requests` row is the liveness check working in the other direction: the
change is supposed to leave that region alone, and it does.

**Where the saving lands.** Two decode profiles were captured back to back in one session
at batch 256, output length 128, on identical code differing only in this gate. The
per-step kernel count is bit-identical at 1169 and GPU-busy time moves +3.0 µs, i.e. not at
all, so nothing about the device work changed. The reduction is concentrated in exactly one
place: the largest recurring host gap in the step — the window between the elementwise
kernel that ends the sampling chain and the gather that starts the next step's bookkeeping
— shrinks by 78.3 µs, against a harness-measured 78.7 µs of removed host work. Total idle
falls 77.8 µs. The two other large gaps in the step, the one before the first layer norm
and the shorter gap inside the sampling chain, do not move. So the saving is host-side and
localized precisely where the mechanism predicts, and it is not a device-side effect
misattributed.

Two caveats on that capture, both important. It was taken with node-level CUDA-graph
tracing, which inflates host-bound gap magnitudes, so the absolute gap widths above are
larger than reality even though the *difference* between two captures at the same setting
is meaningful. And it predates the async-scheduled configuration this stack now ships in;
the 89.5 µs step-period reduction visible in it is therefore not evidence about the
shipping configuration, and the Measurement section is the only place a number for that
configuration should be read from.

## Correctness

- **Numerics:** integer-exact. The fast tail writes element-wise identical values into
  every buffer the reference tail writes, and this is verified rather than argued from the
  code. Structurally it holds because each removed operation is the identity at
  `num_generated_tokens == 1`: `repeat_interleave(1)` returns its input, `torch.arange(1)`
  is a zero, and the boundary-crossing branch is guarded by `num_speculative_tokens == 0`.
- **Tests:** a 400-step two-context equivalence run. Two `DynamicInferenceContext` objects
  are built identically and driven through the same scripted mask sequence, one with the
  gate off and one on, compared after every step on `total_request_count`,
  `paused_request_count`, `active_token_count`, nine request bookkeeping tensors
  (`request_ids`, `request_kv_length_offsets`, `request_query_lengths`,
  `request_output_lengths`, `request_last_kv_block_offset`, `request_last_kv_block_id`,
  `request_kv_block_counts`, `request_to_kv_block_ids`,
  `request_in_prefill_status_tensor`), all six `token_to_*` tensors, and the KV block
  allocator's available, active and paused counts. The script terminates three requests
  mid-batch every 37 steps — 30 terminations, leaving 226 of 256 active — and runs past the
  256-token KV block boundary so the pause, new-block and resume branches all execute under
  both gates. Zero mismatches. This is the check that answers the off-by-one-in-termination
  risk directly: the finished-request count, the finished index set and the resulting slot
  compaction are compared element-wise on the steps where requests actually finish.
- **Tests, in-server:** `MCORE_INFER_VEC_UPDATE_REQS_VERIFY=1` runs the fast tail,
  snapshots the six token buffers plus `request_last_kv_block_offset` and
  `active_token_count`, restores the inputs, runs the reference tail, and asserts equality.
  300 consecutive decode steps, zero mismatches.
- **Coherence:** the three temperature-0 completions are byte-identical between gate on and
  gate off.

## Gating and blast radius

- Gate: `MCORE_INFER_VEC_UPDATE_REQS`, read once at import from the environment and
  **default OFF**. Unset, every branch this PR adds evaluates false and the code runs the
  original statements — the same reduction, the same `.byte()` cast, the same
  `torch.nonzero` scan, and the reference bookkeeping tail — so the default path is
  byte-identical to before this PR.
- `MCORE_INFER_VEC_UPDATE_REQS_VERIFY`, **default OFF**, runs both tails and asserts
  equality. It is expensive by construction and is a debugging tool, not a production
  setting.
- The fast tail additionally requires `num_speculative_tokens == 0`. Any speculative-decode
  configuration takes the reference tail even with the gate set, which is why the reference
  was factored out verbatim rather than rewritten.
- The controller short-circuit requires that the active-request mask sums to the full active
  request count, i.e. that nothing finished this step. On any step with a finisher it runs
  the original `nonzero` and gather.
- Training is unaffected: this code is in the dynamic inference context and engine, and none
  of it runs outside the decode bookkeeping path.

## Reproduce

```bash
MCORE_INFER_VEC_UPDATE_REQS=1 \
DYNAMIC_BATCHING_ASYNC_SCHED_MODE=async \
QWEN30B_TP=1 QWEN30B_EP=4 QWEN30B_ETP=1 \
BENCH_SIZES_OVERRIDE=256 BENCH_OUTPUT_TOKENS=1024 \
NUM_WARMUP_ITERS=2 NUM_TIMED_ITERS=5 \
bash skills/run-qwen-model/run_qwen_inference.sh qwen3-30b-a3b --checkpoint "$QWEN30B_CKPT"
```

Add `MCORE_INFER_VEC_UPDATE_REQS_VERIFY=1` to run the reference-versus-fast equality check
on every step.

## What this does not claim

- **The older +0.90% figure for this change does not apply to the configuration this stack
  ships in and is not carried forward.** It was measured without async scheduling. Async
  scheduling is now pinned on, and a closely related host-path change in this same stack —
  the parent PR — removed roughly 204 µs/step of host work under async and produced no
  throughput change at all, because async scheduling already hides host work behind GPU
  execution. Host-side savings in this workload have been observed not to convert to
  throughput under async. The Measurement section carries the number that applies; that
  measurement is authoritative and this section should not be read as predicting its sign.
- **The post-sampling phase is not solved.** 187.9 µs/step of per-request Python object
  churn in `post_process_requests` remains, deliberately untouched: it does essentially no
  tensor work — three `.tolist()` calls for an entire step, against 256 dict lookups, 256
  list appends, 256 method calls and roughly 1,719 `len()` probes — so nothing there
  vectorizes or eliminates. Reducing it needs a fast path through the request state machine,
  which is a different mechanism with a different correctness argument.
- No claim about speculative decoding, prefill, chunked prefill or hybrid models. The fast
  tail declines whenever there is more than one generated token per request, and the other
  reductions are arithmetic simplifications that hold regardless.
- No claim about batch sizes other than 256 or about non-async configurations. The host
  saving is per-step and roughly proportional to the request count, but nothing outside this
  operating point was measured.
- Deltas in this stack do not add. This change, the parent PR and the `post_process_requests`
  fast path all remove host work from the same window between the sampled-token copy and the
  next step's launches, so they compose sub-additively at best and, under async scheduling,
  may compose to nothing.

## Follow-ups

- The `post_process_requests` fast path, in a separate PR in this stack. A prototype of the
  plain decode case measured 33.8 µs/step against the real method's 213.8, so about 84% of
  that region is reducible on host CPU. Whether any of it converts to throughput under async
  scheduling is a separate question.
- The remaining 74.0 µs/step in `update_requests` is genuine work: the token buffers must be
  rewritten every step, so there is no further large reduction available at this call site
  without moving the bookkeeping onto the device.

---

## This stack

This is one slice of [#6064](https://github.com/NVIDIA/Megatron-LM/pull/6064), a Qwen3-30B-A3B decode optimization campaign, split into 16 independently reviewable changes. Together they are **+35.80%** end-to-end throughput over the same base commit (23,265 -> 31,593 tok/s, mean of three full runs).

- **MoE grouped-GEMM and dispatch:** #6452 -> #6453 -> #6454 -> #6455
- **MoE router and combine:** #6456 -> #6457 -> #6458
- **Attention: QK norm and decode kernel:** #6459 -> #6460 -> #6461 -> #6462
- **Residual + RMSNorm fusion:** #6463 -> #6464
- **Host path: context bookkeeping:** #6465 -> #6466
- **Host path: independent:** #6467

Each chain is independent of the others and bases on `main`. Within a chain, later PRs depend on earlier ones.

### Per-slice measured delta

Every number is a leave-one-out delta from one same-node, same-session campaign: the full stack with exactly this change's gate off, against the interpolated full-stack reference at that point in the run. It is the change's *marginal* contribution with everything else already in, not its standalone value. Run-to-run sigma was **0.42%** across three full-stack repeats.

| PR | Change | Delta | |
|---|---|---|---|
| #6452 | FC1 SwiGLU epilogue | +14.81% | resolved |
| #6453 | indirection table fusion | +7.21% | resolved |
| #6454 | decode GEMM tile configs | +6.77% | resolved |
| #6455 | predicated top-k gather | +1.99% | by margin |
| #6456 | fused router softmax+top-k | +4.75% | resolved |
| #6457 | fused route padding mask | +1.47% | by margin |
| #6458 | bf16 MoE combine | +2.42% | by margin |
| #6459 | fused QK RMSNorm | +5.17% | resolved |
| #6460 | grouped QK norm input | +1.18% | by margin |
| #6461 | pin FlashAttention 2 | -0.35% | noise floor |
| #6462 | FlashInfer TRT-LLM decode | +1.46% | by margin |
| #6463 | fused add+norm pre-MLP | +3.54% | by margin |
| #6464 | fused add+norm pre-QKV | +0.98% | by margin |
| #6465 | incremental attention state | -0.42% | noise floor |
| #6466 | vectorized decode bookkeeping | -0.07% | noise floor |
| #6467 | post_process_requests fast path | +0.09% | noise floor |

`noise floor` means the delta is inside 2 sigma (0.84%) and this campaign cannot distinguish it from zero. `resolved` means the leave-one-out and full-stack iteration distributions did not overlap. Deltas do not sum to the stack total: these changes shorten the same decode step and compose sub-additively.

**Fixed protocol for every number above.** Qwen3-30B-A3B, BF16, TP1/PP1/EP4/ETP1, 256 gsm8k requests at batch size 256, output length 1024, CUDA graphs on, one OCI GB200 NVL72 node, 4 GPUs. All 20 arms ran back-to-back in a single Slurm allocation on one node, so node assignment and thermal state are held constant.
