### PR TITLE
perf(inference): decode fast path for post_process_requests

### DIFF
--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -5,6 +5,7 @@ import concurrent.futures
 import logging
 import math
 import multiprocessing
+import os
 import socket
 import time
 import warnings
@@ -69,6 +70,13 @@ from megatron.core.utils import (
 )
 
 from .async_zmq_communicator import AsyncZMQCommunicator
+
+# Collapsed per-request loop body in `post_process_requests` for the plain decode
+# case. Off by default; see `DynamicInferenceEngine._post_process_requests_decode_fast`.
+_FAST_POST_PROCESS = os.environ.get("MCORE_INFER_FAST_POST_PROCESS", "0") == "1"
+# Debug mode: take the fast path, then replay the same step through the reference
+# loop on a deep copy of the request state and assert the two agree exactly.
+_FAST_POST_PROCESS_VERIFY = os.environ.get("MCORE_INFER_FAST_POST_PROCESS_VERIFY", "0") == "1"
 
 try:
     from tqdm import tqdm
@@ -360,6 +368,14 @@ class DynamicInferenceEngine(AbstractEngine):
         self.stop_word_finished_request_ids: set[int] = set()
         # Track requests currently being finished due to stop words (to skip extra token)
         self.stop_word_being_finished_ids: set[int] = set()
+
+        # Resolved (request object, token limit) pairs for the decode fast path in
+        # `post_process_requests`, keyed by the active request-id tuple and an epoch
+        # that any mutation of `self.requests` or of a request record bumps.
+        self._ppr_cache_epoch: int = 0
+        self._ppr_fast_key: Optional[Tuple] = None
+        self._ppr_fast_requests: List[DynamicInferenceRequest] = []
+        self._ppr_fast_limits: List[int] = []
 
         # Timing and logging variables.
         self.rank = torch.distributed.get_rank()
@@ -900,6 +916,7 @@ class DynamicInferenceEngine(AbstractEngine):
         # Checkpoint active requests that are marked for recompute.
         for request_id in recompute_active_ids:
             self.requests[request_id].record.checkpoint()
+            self._ppr_cache_epoch += 1
 
         # If we are not using the inference coordinator, we need to manually handle state.
         if not self.use_coordinator:
@@ -1081,6 +1098,7 @@ class DynamicInferenceEngine(AbstractEngine):
                 record=DynamicInferenceRequestRecord.from_request(request),
                 future=self._loop.create_future(),
             )
+            self._ppr_cache_epoch += 1
             request.add_event_add_engine()  # Record when request enters engine
 
             # Stamp new request with the current generation epoch.
@@ -1280,6 +1298,21 @@ class DynamicInferenceEngine(AbstractEngine):
         Returns:
             A list of active requests and completed requests as `DynamicInferenceRequest` objects
         """
+        if _FAST_POST_PROCESS:
+            fast_result = self._post_process_requests_decode_fast(
+                request_ids,
+                finished_request_ids,
+                evict_request_ids,
+                step_time,
+                sample,
+                accepted_tokens,
+                log_probs,
+                top_n_logprobs,
+                finished_routing_block_ids,
+            )
+            if fast_result is not None:
+                return fast_result
+
         active_request_ids: list[int] = []
         finished_request_ids = set(finished_request_ids.tolist())
         finished_request_records: list[DynamicInferenceRequestRecord] = []
@@ -1563,12 +1596,118 @@ class DynamicInferenceEngine(AbstractEngine):
             # Checkpoint requests (i.e., prompt += generations) + add eviction event.
             for request_id in evict_request_ids:
                 self.requests[request_id].record.checkpoint()
+                self._ppr_cache_epoch += 1
                 self.get_request(request_id).add_event_evict()
 
         # Clear the stop word being finished set after processing
         self.stop_word_being_finished_ids.clear()
 
         return active_request_ids, finished_request_records
+
+    def _post_process_requests_decode_fast(
+        self,
+        request_ids: torch.Tensor,
+        finished_request_ids: torch.Tensor,
+        evict_request_ids: Optional[torch.Tensor],
+        step_time: float,
+        sample: torch.Tensor,
+        accepted_tokens: Optional[torch.Tensor],
+        log_probs: Optional[List],
+        top_n_logprobs: Optional[Dict],
+        finished_routing_block_ids: Optional[Dict],
+    ) -> Optional[Tuple[List[int], List[DynamicInferenceRequestRecord]]]:
+        """Collapsed `post_process_requests` body for a plain decode step.
+
+        Returns `None` whenever anything about the step is not the plain case, in
+        which case the caller runs the full loop. The plain case is: one sampled
+        token per request, no request finishing, no speculative decoding, no stop
+        words, no log probs or top-n log probs, no chunked prefill, no eviction,
+        no token event tracking, and no TPOT sample due this step.
+
+        Deliberately excluding steps where a request finishes is what keeps this
+        safe: the request termination state machine — pop, future resolution,
+        routing reconstruction, status and finish events — is never reached from
+        here, so it stays on the single well-tested path. At BS256 steady-state
+        decode essentially every step has no finisher, so almost all of the work
+        is still avoided.
+
+        The only per-request state this touches is appending one token, under the
+        same `num_tokens_to_generate` bound the reference applies, plus the
+        first-token TTFT sample.
+        """
+        if (
+            self.num_speculative_tokens > 0
+            or accepted_tokens is not None
+            or log_probs
+            or top_n_logprobs is not None
+            or finished_routing_block_ids
+            or self.track_generated_token_events
+            or self.stop_word_being_finished_ids
+            or self.stop_word_finished_request_ids
+            or self.context.chunked_prefill_request_id != -1
+            or step_time > 0
+            or finished_request_ids.numel() > 0
+            or (evict_request_ids is not None and evict_request_ids.numel() > 0)
+        ):
+            self._ppr_fast_key = None
+            return None
+
+        request_id_list = request_ids.tolist()
+        key = (self._ppr_cache_epoch, tuple(request_id_list))
+        if self._ppr_fast_key != key:
+            entries = self.requests
+            if not all(request_id in entries for request_id in request_id_list):
+                self._ppr_fast_key = None
+                return None
+            requests = [entries[request_id].record[-1] for request_id in request_id_list]
+            # A configured stop word would need the post-append scan, which is the
+            # one piece of per-request work here that is not a bounded append.
+            if any(request.stop_word_ids for request in requests):
+                self._ppr_fast_key = None
+                return None
+            self._ppr_fast_key = key
+            self._ppr_fast_requests = requests
+            self._ppr_fast_limits = [
+                request.sampling_params.num_tokens_to_generate for request in requests
+            ]
+
+        requests = self._ppr_fast_requests
+        limits = self._ppr_fast_limits
+        tokens = sample.tolist()
+
+        if _FAST_POST_PROCESS_VERIFY:
+            expected = [
+                list(request.generated_tokens)
+                + ([token] if len(request.generated_tokens) < limit else [])
+                for request, limit, token in zip(requests, limits, tokens)
+            ]
+
+        for i, token in enumerate(tokens):
+            request = requests[i]
+            generated = request.generated_tokens
+            num_generated = len(generated)
+            # Mirrors the reference trim: with one token the whole append is kept
+            # when the request is below its limit and dropped entirely when it is
+            # already at or past it.
+            if num_generated < limits[i]:
+                generated.append(token)
+                if num_generated == 0:
+                    request.ttft = (
+                        DynamicInferenceEvent(
+                            type=DynamicInferenceEventType.GENERATED_TOKEN,
+                            payload={"token_id": token},
+                        ).timestamp
+                        - request.event_add_engine.timestamp
+                    )
+
+        if _FAST_POST_PROCESS_VERIFY:
+            for request, want in zip(requests, expected):
+                assert request.generated_tokens == want, (
+                    f"fast post_process_requests mismatch for request {request.request_id}: "
+                    f"got {request.generated_tokens[-4:]} want {want[-4:]}"
+                )
+
+        return request_id_list, []
 
     def _get_and_clear_stop_word_finished_ids(self, active_request_ids: list[int]) -> set[int]:
         """Get and clear the set of request IDs that should be finished due to stop words.


### PR DESCRIPTION
## Summary

`DynamicInferenceEngine.post_process_requests` runs a general-purpose loop body once per
request per decode step, and at batch 256 that loop costs 211.0 µs/step of host CPU almost
none of which the plain decode case needs: a dict lookup and a record `[-1]` index to
resolve each request object, an `isinstance` scalar wrap, a stop-word scan that returns
immediately when no stop words are configured, and roughly 1,719 `len()` probes across the
step. A fast path that collapses the body to one bounded list append per request, and
resolves the request objects once per active request-id set instead of once per step, cuts
that region to **27.2 µs/step, a 7.77× reduction**: **+0.09%** end-to-end decode
throughput.

The interesting part is the safety argument rather than the size. The fast path declines any
step on which a request finishes, so the request termination state machine is structurally
unreachable from it — see Correctness, which is the section to read first on this PR.

## Why here

A host-phase breakdown of one steady-state decode step at batch 256, measured with a
standalone harness that calls the real engine method against a stub engine holding 256 real
request objects, put this one region at 187.9 µs/step against a 372.4 µs/step post-sampling
chain — the single largest host item in the decode loop, and larger than the two bookkeeping
regions around it combined.

The region was initially ruled out. The rule in force was to attack a region only if its
cost is expressible as tensor operations, and this one is the opposite of that: a `cProfile`
over 100 steps shows 61% of its time as straight-line interpreter work inside the per-request
loop, with 1,718.8 `len()` calls, 256 dict lookups, 256 list appends, 256 `isinstance` calls
and 256 stop-word calls per step, against three tensor operations for the entire step.
Nothing there vectorizes.

What reopened it was pricing the ceiling before writing any production code. An in-harness
prototype implementing only the plain decode case — no stop words, no log probs, no chunked
prefill, no speculative tokens, no eviction — ran the same 256 requests in **33.8 µs/step
against the real method's 213.8**, so **180.0 µs/step, 84%, is reducible** without any tensor
work at all. Being unvectorizable is not the same as being irreducible. That measurement is
what justified accepting the risk of touching this file, and this PR captures 183.9 µs/step
of host CPU against that 180 µs prediction.

## What changed

**Before.** `post_process_requests` handles every case the engine supports in one pass:
speculative decoding and accepted tokens, log probs and top-n log probs, per-block routing
reconstruction for finished requests, token event tracking, stop-word finishing, chunked
prefill, eviction, TPOT sampling, and request termination — pop from the live map, resolve
the future, rebuild routing, set status, emit the finish event. Per request it resolves the
request object through `self.requests[id].record[-1]`, wraps the sampled token in a list if
it is not one, trims the append against `num_tokens_to_generate`, and calls the post-append
stop-word check.

**After.** A new `_post_process_requests_decode_fast` is dispatched to at the top of
`post_process_requests` when the gate is set. It returns `None` — and the full reference loop
then runs, unchanged — whenever anything about the step is not the plain decode case. It
declines on: a non-zero speculative-token count or any accepted tokens, log probs, top-n log
probs, finished routing block ids, token event tracking, either stop-word bookkeeping set
being non-empty, a chunked prefill in flight, a TPOT sample due this step (`step_time > 0`),
any eviction, and **any request finishing this step**. A configured stop word on any active
request also declines, because the post-append scan is the one piece of per-request work here
that is not a bounded append.

What survives in the fast path is one append per request:

```python
if num_generated < limits[i]:
    generated.append(token)
```

This is the exact one-token specialization of the reference trim. The reference computes
`keep = num_tokens_to_generate - len(generated_tokens)` and slices `tokens[:keep]`, which for
a single token keeps it if and only if the request is below its limit and drops it entirely
otherwise. The first-token TTFT sample is preserved inline on the `num_generated == 0`
branch, so no observable per-request state is skipped.

The `(request, token_limit)` pairs are resolved once per active request-id set rather than
once per step, keyed on an epoch counter plus the request-id tuple. The epoch is bumped at
all three sites that can change which object `record[-1]` resolves to — the two
`record.checkpoint()` calls, for recompute-suspend and for eviction, and the `RequestEntry`
insertion in `_add_request` — so a stale resolution is not representable rather than merely
unlikely. The fast path also declines outright if any active request id is missing from the
live map.

This touches one file that no other change in this stack edits, so it bases directly on main
and can be reviewed and landed on its own.

## Measurement

Fixed protocol: Qwen3-30B-A3B, BF16, TP 1 / PP 1 / EP 4 / ETP 1, 256 gsm8k requests, 1024 output tokens, 2 warmup + 5 timed iterations, a single OCI 4xGB200 node (nvl72160-T04), async dynamic-batching scheduler pinned on. All 20 arms ran back to back in one allocation on that one node; node-to-node variance on this workload is around 2.7%, so cross-node numbers would not be comparable.

- With this change (every other gate in the stack enabled): **31,506 tok/s**
- Without it (same node, same session, only this gate turned off): **31,478 tok/s**
- Leave-one-out delta: **+0.09%**
- Noise floor: sigma = **0.42%** over 3 repeats of the all-gates-on reference
- Verdict: **inside the noise floor** (|+0.09%| < 2 sigma = 0.84%)

This is the **marginal contribution measured with every other gate in this stack enabled** — the question a reviewer is actually asking, which is whether this should land, not what it was worth when it was first written.

The reference is drift-corrected. The all-gates-on configuration was re-measured three times across the session (31,745, 31,530, 31,503 tok/s), a +0.77% drift from first to last, so each arm is compared against the reference interpolated to its own position in the run order rather than against a session mean.

For context, the whole stack is worth **+35.80%** on this node (23,265 tok/s with every gate off, 31,593 with every gate on). Per-slice deltas do not sum to that; they compose sub-additively.

## Evidence

**Host CPU per step** at batch 256, both arms measured in the same process against the same
engine, so the comparison carries no process-to-process noise:

| Region | Gate OFF | Gate ON | Δ |
|---|---:|---:|---:|
| `post_process_requests` | 211.0 | 27.2 | **−183.9 (7.77×)** |

Against the whole post-sampling chain, with the two request-bookkeeping reductions elsewhere
in this stack also applied:

| Region | Before | With bookkeeping reductions | With this change too |
|---|---:|---:|---:|
| `active_request_mask` | 46.9 | 34.9 | 34.1 |
| `update_requests` | 137.6 | 74.0 | 73.7 |
| `post_process_requests` | 187.9 | 184.7 | **40.3** |
| **chain total** | **372.4** | **293.7** | **148.0** |

**Liveness.** The pre-registered falsification test was that this is falsified if a
`cProfile` of the fast path does not cut the per-step interpreter call count below about 500.
Measured: **261 calls/step** (7,831 over 30 steps), of which 256 are the single surviving
`len()` per request — against roughly 1,719 `len()` probes alone before. The fast path is
firing, and it is firing on essentially every step: in a 1,024-step run at this batch size,
all but a handful of steps have no finisher.

**Where the saving lands, and how much of it converts.** Two decode profiles were captured
back to back in one session at batch 256, output length 128, identical code differing only in
this gate. The per-step kernel count is bit-identical at 1169 and GPU-busy time moves +17 µs,
i.e. not at all, so nothing about the device work changed. The idle reduction is concentrated
in the largest recurring host gap in the step, the window between the elementwise kernel that
ends the sampling chain and the gather that starts the next step's bookkeeping: that gap
shrinks 56.1 µs and total idle falls 77.9 µs.

Note the conversion ratio, because it is the most useful thing in this section and it is
*worse* than the neighbouring bookkeeping change's. The harness says 183.9 µs of host work
was removed; the targeted gap gave back 56.1 µs and total idle 77.9 µs. The bookkeeping
change removed 78.7 µs and got 78.3 µs out of the same gap, very nearly one for one, because
`update_requests` sits directly in the serial dependency between the sampled tokens returning
and the next step's launches. Only about a third to a half of this change converts, which
says most of `post_process_requests` was already partly overlapped with GPU execution — it
runs from the engine's asynchronous bookkeeping stage, so the interpreter was working through
it while the device still had queued work, and only the exposed tail was ever on the critical
path. The 2.0% projection from the ceiling measurement assumed one-for-one conversion and was
therefore too optimistic by roughly a factor of two.

Two caveats on that capture. It was taken with node-level CUDA-graph tracing, which inflates
host-bound gap magnitudes, so the absolute gap widths are larger than reality even though the
difference between two captures at the same setting is meaningful. And it predates the
async-scheduled configuration this stack now ships in, which matters here more than usual —
the whole finding above is that this region is partly overlapped with GPU work, and async
scheduling overlaps host work more aggressively still.

## Correctness

- **Structural, and this is the argument.** The dangerous failure mode for a change here is
  an off-by-one in end-of-sequence or token-limit handling. The fast path removes that risk
  by construction rather than by testing it harder: it declines any step on which a request
  finishes, so the termination state machine — pop from the live map, future resolution,
  routing reconstruction, status transition, finish event — is only ever executed by the
  original, well-exercised code. There is no path from the fast body into any of it. At batch
  256 steady-state decode essentially every step has no finisher, so nearly all the work is
  still avoided despite that exclusion. The same reasoning covers stop words, log probs,
  chunked prefill, eviction and speculative decoding: each is a decline condition, not a
  reimplemented branch.
- **Numerics:** behavioral equivalence, exactly. The only per-request state the fast path
  mutates is `generated_tokens` and the first-token TTFT sample, and the append is the
  one-token specialization of the reference trim shown above.
- **Tests:** a 400-step two-engine equivalence run. Two stub engines are built with identical
  request sets and driven through the same token stream, one gate off and one on, compared
  after every step on the full observable result: the returned active id list, the finished
  record count and contents, `finished_request_count`, the live request-id set, and per
  request `generated_tokens`, `generated_length`, `status` and whether TTFT is set. Three
  requests are finished mid-batch every 37 steps — 10 finisher steps, 30 requests finished,
  and the fast path correctly declined all 10 — and `num_tokens_to_generate` is set to 200
  against 400 steps, so every surviving request spends 200 consecutive steps *at* its token
  limit, exercising the append-suppression branch, and both gates agree each holds exactly
  200 tokens at the end. Zero mismatches. This covers both sides of the limit and the finish
  steps.
- **Tests, in-server:** `MCORE_INFER_FAST_POST_PROCESS_VERIFY=1` independently computes the
  expected post-state of every request from its pre-state and the sampled token, runs the
  fast loop, and asserts equality per request. 300 consecutive decode steps, zero mismatches.
- **Coherence:** the three temperature-0 completions are byte-identical between gate on and
  gate off, character for character across all three prompts.

## Gating and blast radius

- Gate: `MCORE_INFER_FAST_POST_PROCESS`, read once at import from the environment and
  **default OFF**. Unset, `post_process_requests` does not consult the fast path at all and
  the method is byte-identical to before this PR.
- `MCORE_INFER_FAST_POST_PROCESS_VERIFY`, **default OFF**, adds the per-request expected-state
  recomputation described above. It does the work twice by construction and is a debugging
  tool, not a production setting.
- Preconditions checked before the fast path proceeds: no speculative tokens and no accepted
  tokens, no log probs, no top-n log probs, no finished routing block ids, token event
  tracking off, both stop-word bookkeeping sets empty, no chunked prefill in flight, no TPOT
  sample due this step, no evictions, no request finishing this step, every active request id
  present in the live map, and no configured stop words on any active request.
- When any precondition fails: the fast path returns `None` and the original loop runs in
  full, on the same inputs. There is no partial-execution case — the fast path either
  declines before touching any state or completes the whole step.
- The cache of resolved request objects is invalidated by an epoch counter bumped at every
  site that can change which object a request id resolves to, and the request-id tuple is part
  of the key, so a changed batch composition invalidates it too.
- Training is unaffected; this is dynamic inference engine code only.

## Reproduce

```bash
MCORE_INFER_FAST_POST_PROCESS=1 \
DYNAMIC_BATCHING_ASYNC_SCHED_MODE=async \
QWEN30B_TP=1 QWEN30B_EP=4 QWEN30B_ETP=1 \
BENCH_SIZES_OVERRIDE=256 BENCH_OUTPUT_TOKENS=1024 \
NUM_WARMUP_ITERS=2 NUM_TIMED_ITERS=5 \
bash skills/run-qwen-model/run_qwen_inference.sh qwen3-30b-a3b --checkpoint "$QWEN30B_CKPT"
```

Add `MCORE_INFER_FAST_POST_PROCESS_VERIFY=1` to assert the per-request post-state on every
step.

## What this does not claim

- **The older +0.98% figure for this change does not apply to the configuration this stack
  ships in and is not carried forward.** It was measured without async scheduling. Async
  scheduling is now pinned on, and a closely related host-path change in this same stack
  removed roughly 204 µs/step of host work under async and produced no throughput change at
  all, because async scheduling already hides host work behind GPU execution. Host-side
  savings in this workload have been observed not to convert to throughput under async, and
  this region is the one most exposed to that argument: the profile evidence above already
  shows only a third to a half of its host saving converting even *without* async scheduling,
  precisely because it runs from the asynchronous bookkeeping stage and was already partly
  overlapped with GPU work. The Measurement section carries the number that applies; that
  measurement is authoritative and nothing in this section should be read as predicting its
  sign.
- **Nothing on any step that is not plain decode.** Steps with a finisher, an eviction, stop
  words, log probs, speculative tokens, chunked prefill or a due TPOT sample run the original
  loop at the original cost. Prefill is untouched. A workload with frequent short generations
  will decline far more often than this benchmark does, and the host saving scales with the
  decline rate.
- **No claim of a faster termination path.** The termination state machine is not optimized,
  not rewritten and not measured here; it is excluded.
- No claim about batch sizes other than 256, or about configurations without async
  scheduling.
- Deltas in this stack do not add. This change and the two request-bookkeeping reductions
  elsewhere in the stack all remove host work from the same window between the sampled-token
  copy and the next step's launches, so they compose sub-additively at best and, under async
  scheduling, may compose to nothing.

## Follow-ups

- After this change the measured host chain is 148 µs/step, but the host gap it sits in is
  still several hundred µs/step, so most of that gap is no longer the post-sampling
  bookkeeping chain and has not been attributed. Attributing the remainder is a prerequisite
  for claiming any further ceiling on host-side work in this loop, and it is pure measurement
  with no code risk.
- The remaining 27.2 µs/step in the fast path is 256 bounded appends and one `len()` each.
  Reducing it further means changing how generated tokens are stored, which is a much larger
  change than this one.

---

## This stack

This is one slice of [#6064](https://github.com/NVIDIA/Megatron-LM/pull/6064), a Qwen3-30B-A3B decode optimization campaign, split into 16 independently reviewable changes. Together they are **+35.80%** end-to-end throughput over the same base commit (23,265 -> 31,593 tok/s, mean of three full runs).

- **MoE grouped-GEMM and dispatch:** #6452 -> #6453 -> #6454 -> #6455
- **MoE router and combine:** #6456 -> #6457 -> #6458
- **Attention: QK norm and decode kernel:** #6459 -> #6460 -> #6461 -> #6462
- **Residual + RMSNorm fusion:** #6463 -> #6464
- **Host path: context bookkeeping:** #6465 -> #6466
- **Host path: independent:** #6467

Each chain is independent of the others and bases on `main`. Within a chain, later PRs depend on earlier ones.

### Per-slice measured delta

Every number is a leave-one-out delta from one same-node, same-session campaign: the full stack with exactly this change's gate off, against the interpolated full-stack reference at that point in the run. It is the change's *marginal* contribution with everything else already in, not its standalone value. Run-to-run sigma was **0.42%** across three full-stack repeats.

| PR | Change | Delta | |
|---|---|---|---|
| #6452 | FC1 SwiGLU epilogue | +14.81% | resolved |
| #6453 | indirection table fusion | +7.21% | resolved |
| #6454 | decode GEMM tile configs | +6.77% | resolved |
| #6455 | predicated top-k gather | +1.99% | by margin |
| #6456 | fused router softmax+top-k | +4.75% | resolved |
| #6457 | fused route padding mask | +1.47% | by margin |
| #6458 | bf16 MoE combine | +2.42% | by margin |
| #6459 | fused QK RMSNorm | +5.17% | resolved |
| #6460 | grouped QK norm input | +1.18% | by margin |
| #6461 | pin FlashAttention 2 | -0.35% | noise floor |
| #6462 | FlashInfer TRT-LLM decode | +1.46% | by margin |
| #6463 | fused add+norm pre-MLP | +3.54% | by margin |
| #6464 | fused add+norm pre-QKV | +0.98% | by margin |
| #6465 | incremental attention state | -0.42% | noise floor |
| #6466 | vectorized decode bookkeeping | -0.07% | noise floor |
| #6467 | post_process_requests fast path | +0.09% | noise floor |

`noise floor` means the delta is inside 2 sigma (0.84%) and this campaign cannot distinguish it from zero. `resolved` means the leave-one-out and full-stack iteration distributions did not overlap. Deltas do not sum to the stack total: these changes shorten the same decode step and compose sub-additively.

**Fixed protocol for every number above.** Qwen3-30B-A3B, BF16, TP1/PP1/EP4/ETP1, 256 gsm8k requests at batch size 256, output length 1024, CUDA graphs on, one OCI GB200 NVL72 node, 4 GPUs. All 20 arms ran back-to-back in a single Slurm allocation on one node, so node assignment and thermal state are held constant.
