### PR TITLE
perf(inference): opt-in instrumentation for the decode host and device path

### DIFF
--- a/megatron/core/inference/attention/__init__.py
+++ b/megatron/core/inference/attention/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.

--- a/megatron/core/inference/attention/flashinfer_decode.py
+++ b/megatron/core/inference/attention/flashinfer_decode.py
@@ -1,0 +1,143 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+
+"""Blackwell-native paged decode attention via flashinfer's trtllm-gen kernel.
+
+Megatron's decode path runs FlashAttention-2's `flash_attn_with_kvcache`, whose kernels
+predate Blackwell. A matched per-category comparison against vLLM at BS256/OSL1024
+(GAP-S18) found attention to be the largest remaining device-time gap -- 0.409 ms/step at
+an *identical* launch count, which rules out anything Megatron does around the call and
+points at the kernel generation itself. vLLM reaches `fmhaSm100f` through flashinfer, and
+flashinfer is already installed alongside flash-attn here, so the same kernel is
+available to us: at our shapes it is 24% faster than FA2 with matching numerics.
+
+Two properties make it usable at decode without restructuring anything:
+
+  * It takes the paged layout Megatron already has. With ``kv_layout="NHD"`` the k and v
+    caches are ``[num_pages, page_size, num_kv_heads, head_dim]``, exactly FA2's, and it
+    accepts Megatron's 256-token pages (FA2 in fact *requires* pages be a multiple of
+    256, so this is the stricter of the two).
+  * It needs no host-side `plan()` call, unlike flashinfer's wrapper APIs, so it is
+    capturable in the decode CUDA graph.
+
+The one operational constraint is the scratch buffer, which must be zeroed before first
+use. Zeroing it inside a graph capture would record a 128 MiB memset into the graph and
+replay it every step, so the buffer is allocated eagerly and this path declines to engage
+if it is asked to do so for the first time mid-capture.
+"""
+
+import logging
+import os
+import sys
+from typing import Optional, Tuple
+
+import torch
+
+try:
+    from flashinfer.decode import trtllm_batch_decode_with_kv_cache
+
+    HAVE_FLASHINFER = True
+except ImportError:
+    trtllm_batch_decode_with_kv_cache = None
+    HAVE_FLASHINFER = False
+
+logger = logging.getLogger(__name__)
+
+ENABLED: bool = os.environ.get("MCORE_FLASHINFER_DECODE", "0") == "1"
+
+if ENABLED and not HAVE_FLASHINFER:
+    # Say so loudly once. Asking for this path and silently getting FA2 is the failure
+    # this module is easiest to get wrong: flashinfer is commonly present in the run
+    # venv and absent from the container's system python, so the same command can
+    # engage or not depending only on which interpreter launched it.
+    logger.warning(
+        "MCORE_FLASHINFER_DECODE=1 but flashinfer is not importable under %s; "
+        "decode will use the flash-attention path instead",
+        sys.executable,
+    )
+
+# Programmatic Dependent Launch lets this kernel's prologue start while its predecessor
+# drains. 855 of mcore's 934 per-step GPU gaps are sub-microsecond launch overhead
+# (GAP-S18), so it is worth an arm; left as a knob because PDL interacts with graph
+# capture and its benefit is hardware- and neighbour-dependent. None = flashinfer decides.
+_PDL_ENV = os.environ.get("MCORE_FLASHINFER_PDL", "")
+ENABLE_PDL: Optional[bool] = bool(int(_PDL_ENV)) if _PDL_ENV else None
+
+# vLLM sizes this at 128 MiB for the same kernel family.
+_WORKSPACE_BYTES: int = 128 * 1024 * 1024
+
+_workspace: Optional[torch.Tensor] = None
+_declined: bool = False
+
+
+def _get_workspace(device: torch.device) -> Optional[torch.Tensor]:
+    """The zeroed scratch buffer, or None if it cannot be created safely right now."""
+    global _workspace, _declined
+    if _workspace is not None and _workspace.device == device:
+        return _workspace
+    if torch.cuda.is_current_stream_capturing():
+        # Allocating here would bind the buffer to the graph's pool and, worse, record
+        # the 128 MiB zero-fill as a graph node replayed every step. Decline instead;
+        # the caller falls back to FA2 for this graph.
+        if not _declined:
+            _declined = True
+            logger.warning(
+                "flashinfer decode declined: no workspace yet and stream is capturing; "
+                "falling back to FA2 for this graph"
+            )
+        return None
+    _workspace = torch.zeros(_WORKSPACE_BYTES, dtype=torch.uint8, device=device)
+    return _workspace
+
+
+def can_use(
+    query: torch.Tensor,
+    block_table: Optional[torch.Tensor],
+    need_lse: bool,
+    window_size: Tuple[int, int],
+    tokens_per_request: int,
+) -> bool:
+    """Whether the trtllm-gen decode kernel can serve this call.
+
+    Deliberately narrow: every condition below is one this module has not verified
+    against FA2, and a wrong answer here is a silent accuracy bug rather than a crash.
+    """
+    if not (ENABLED and HAVE_FLASHINFER):
+        return False
+    if block_table is None:  # non-paged KV cache
+        return False
+    if need_lse:  # attention sinks need an LSE correction pass; not wired up
+        return False
+    if window_size != (-1, -1):  # sliding window maps to window_left; untested
+        return False
+    if tokens_per_request != 1:  # speculative decoding needs q_len_per_req plumbing
+        return False
+    if query.dtype not in (torch.bfloat16, torch.float16):
+        return False
+    return _get_workspace(query.device) is not None
+
+
+def decode(
+    query: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    block_table: torch.Tensor,
+    seqlens_k: torch.Tensor,
+    max_seqlen_k: int,
+    softmax_scale: float,
+) -> torch.Tensor:
+    """Paged decode attention. ``query`` is ``(B, 1, H, D)``; returns the same shape."""
+    num_requests, tokens_per_request = query.shape[0], query.shape[1]
+    out = trtllm_batch_decode_with_kv_cache(
+        query=query.reshape(-1, query.shape[-2], query.shape[-1]),
+        kv_cache=(k_cache, v_cache),
+        workspace_buffer=_workspace,
+        block_tables=block_table,
+        seq_lens=seqlens_k,
+        max_seq_len=max_seqlen_k,
+        # bmm2 is the P@V product, which needs no rescaling for a bf16 cache.
+        bmm1_scale=softmax_scale,
+        bmm2_scale=1.0,
+        kv_layout="NHD",
+        enable_pdl=ENABLE_PDL,
+    )
+    return out.reshape(num_requests, tokens_per_request, *out.shape[1:])

--- a/megatron/core/inference/attention/fused_qk_norm.py
+++ b/megatron/core/inference/attention/fused_qk_norm.py
@@ -1,0 +1,195 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Single-launch fused q/k RMSNorm for decode-shaped attention.
+
+Qwen3-style attention applies a per-head RMSNorm to the query and to the key
+separately, right after the QKV split and before RoPE. In the
+``inference_optimized`` decode path these are two distinct ``TENorm`` (TE
+``RMSNorm``) module calls, so they show up as two ``rmsnorm_fwd_general``
+kernels per layer. Each normalizes a tiny ``[.., head_dim]`` row (head_dim=128
+here), so both are launch/latency dominated rather than bandwidth bound —
+merging the two launches into one recovers a graph node and its dispatch gap
+per layer with no change to the math.
+
+The two source tensors have different shapes and different weights, but both
+reduce to a ``[num_rows, head_dim]`` view with a *uniform* row stride (the key
+view's leading strides are exact multiples of its head stride), so a single
+kernel can process the concatenation of query rows and key rows, selecting the
+right weight per row. The normalization itself is identical to TE's RMSNorm:
+fp32 mean-of-squares over ``head_dim``, ``rsqrt(var + eps)``, then the
+(optionally 1-centered) gamma — so the result matches the two-call path to
+bf16 rounding.
+"""
+
+import os
+from typing import Tuple
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+
+    HAVE_TRITON = True
+except ImportError:
+    HAVE_TRITON = False
+
+# Fuse the two QK RMSNorm launches into one. Env-toggleable; default off so the
+# untouched two-call path stays byte-identical.
+USE_FUSED_QK_NORM: bool = os.environ.get("MCORE_FUSED_QK_NORM", "0") == "1"
+
+# The one-row-per-CTA kernel wins only in the decode regime; above ~256 tokens
+# TE's multi-row norm is faster (measured 1.25x at 256 tokens, 0.83x at 384).
+# Restrict to decode; prefill / large batches keep the two-call path.
+FUSED_QK_NORM_MAX_TOKENS: int = int(os.environ.get("MCORE_FUSED_QK_NORM_MAX_TOKENS", "256"))
+
+
+if HAVE_TRITON:
+
+    @triton.jit
+    def _fused_qk_rmsnorm_kernel(
+        q_ptr,
+        k_ptr,
+        qo_ptr,
+        ko_ptr,
+        wq_ptr,
+        wk_ptr,
+        n_q_rows,
+        q_in_rs,
+        k_in_rs,
+        q_out_rs,
+        k_out_rs,
+        eps,
+        HN: tl.constexpr,
+        ZERO_CENTERED: tl.constexpr,
+    ):
+        """One CTA per row across the concatenated [q_rows; k_rows] space.
+
+        Programs with ``row < n_q_rows`` normalize a query row with ``wq``;
+        the rest normalize a key row with ``wk``. Both candidate loads are
+        issued (the off-path one clamped to row 0 and masked out of the store),
+        which keeps the kernel branch-free on the hot path for a 128-wide row.
+        """
+        row = tl.program_id(0)
+        cols = tl.arange(0, HN)
+        is_q = row < n_q_rows
+
+        q_row = tl.where(is_q, row, 0)
+        k_row = tl.where(is_q, 0, row - n_q_rows)
+
+        xq = tl.load(q_ptr + q_row * q_in_rs + cols).to(tl.float32)
+        xk = tl.load(k_ptr + k_row * k_in_rs + cols).to(tl.float32)
+        x = tl.where(is_q, xq, xk)
+
+        var = tl.sum(x * x, axis=0) / HN
+        inv = 1.0 / tl.sqrt(var + eps)
+        xn = x * inv
+
+        wq = tl.load(wq_ptr + cols).to(tl.float32)
+        wk = tl.load(wk_ptr + cols).to(tl.float32)
+        w = tl.where(is_q, wq, wk)
+        if ZERO_CENTERED:
+            w = w + 1.0
+        y = xn * w
+
+        q_store_mask = is_q & (cols < HN)
+        k_store_mask = (row >= n_q_rows) & (cols < HN)
+        tl.store(qo_ptr + q_row * q_out_rs + cols, y.to(qo_ptr.dtype.element_ty), mask=q_store_mask)
+        tl.store(ko_ptr + k_row * k_out_rs + cols, y.to(ko_ptr.dtype.element_ty), mask=k_store_mask)
+
+
+def fused_qk_rmsnorm(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    weight_q: torch.Tensor,
+    weight_k: torch.Tensor,
+    eps: float,
+    zero_centered_gamma: bool,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Apply per-head RMSNorm to ``query`` and ``key`` in a single kernel.
+
+    Args:
+        query: ``[.., head_dim]`` (any leading shape); last dim is normalized.
+        key: ``[.., head_dim]``; may be a non-contiguous split view — only the
+            last dim needs to be contiguous, which holds for the QKV split.
+        weight_q / weight_k: ``[head_dim]`` RMSNorm gammas.
+        eps: RMSNorm epsilon.
+        zero_centered_gamma: if True, apply ``(1 + gamma)`` (matches TE).
+
+    Returns:
+        ``(query_normed, key_normed)`` as fresh contiguous tensors with the same
+        shapes and dtypes as the inputs.
+    """
+    hn = query.shape[-1]
+    # No-copy 2D views: the last dim is contiguous and the leading strides are
+    # exact multiples of the row stride, so reshape returns a view.
+    q2 = query.reshape(-1, hn)
+    k2 = key.reshape(-1, hn)
+
+    qo = torch.empty(query.shape, dtype=query.dtype, device=query.device)
+    ko = torch.empty(key.shape, dtype=key.dtype, device=key.device)
+    qo2 = qo.view(-1, hn)
+    ko2 = ko.view(-1, hn)
+
+    n_q_rows = q2.shape[0]
+    n_rows = n_q_rows + k2.shape[0]
+
+    _fused_qk_rmsnorm_kernel[(n_rows,)](
+        q2,
+        k2,
+        qo2,
+        ko2,
+        weight_q,
+        weight_k,
+        n_q_rows,
+        q2.stride(0),
+        k2.stride(0),
+        qo2.stride(0),
+        ko2.stride(0),
+        float(eps),
+        HN=hn,
+        ZERO_CENTERED=zero_centered_gamma,
+        num_warps=1,
+    )
+    return qo, ko
+
+
+def can_use_fused_qk_norm(q_layernorm, k_layernorm, query: torch.Tensor, key: torch.Tensor) -> bool:
+    """Whether the fused kernel reproduces this exact q/k RMSNorm contract.
+
+    Requires both norms to be weight-only RMSNorm modules (TE ``RMSNorm``),
+    a power-of-two head dim, matching last dims, and CUDA tensors whose reshape
+    to ``[-1, head_dim]`` is a view (last dim contiguous). Anything else — L2
+    norm, LayerNorm with bias, odd head dims — falls back to the two-call path.
+    """
+    if not (HAVE_TRITON and USE_FUSED_QK_NORM):
+        return False
+    if q_layernorm is None or k_layernorm is None:
+        return False
+    wq = getattr(q_layernorm, "weight", None)
+    wk = getattr(k_layernorm, "weight", None)
+    if wq is None or wk is None:
+        return False
+    # RMSNorm has no bias; reject anything that carries one to stay exact.
+    if (
+        getattr(q_layernorm, "bias", None) is not None
+        or getattr(k_layernorm, "bias", None) is not None
+    ):
+        return False
+    hn = query.shape[-1]
+    if hn != key.shape[-1] or hn != wq.numel() or hn != wk.numel():
+        return False
+    if (hn & (hn - 1)) != 0:  # not a power of two
+        return False
+    if not (query.is_cuda and key.is_cuda):
+        return False
+    # Last dim must be contiguous so the [-1, hn] reshape is a no-copy view.
+    if query.stride(-1) != 1 or key.stride(-1) != 1:
+        return False
+    # Decode-only: count tokens (all leading dims except heads and head_dim).
+    n_tokens = 1
+    for d in query.shape[:-2]:
+        n_tokens *= d
+    if n_tokens > FUSED_QK_NORM_MAX_TOKENS:
+        return False
+    return True

--- a/megatron/core/inference/attention/fused_qk_norm.py
+++ b/megatron/core/inference/attention/fused_qk_norm.py
@@ -43,6 +43,17 @@ USE_FUSED_QK_NORM: bool = os.environ.get("MCORE_FUSED_QK_NORM", "0") == "1"
 # Restrict to decode; prefill / large batches keep the two-call path.
 FUSED_QK_NORM_MAX_TOKENS: int = int(os.environ.get("MCORE_FUSED_QK_NORM_MAX_TOKENS", "256"))
 
+# Read the query out of the grouped QKV output rather than out of a repacked copy,
+# removing one full-query strided copy per layer per step. Requires the fused norm.
+USE_GROUPED_QK_NORM: bool = os.environ.get("MCORE_GROUPED_QK_NORM", "0") == "1"
+
+# Launch shape. One row per CTA is the obvious choice for a 128-wide row and reaches only
+# ~570 GB/s, because it puts 9,216 single-warp CTAs on the device for a 256-token step.
+# 8 rows x 8 warps measured exactly 2x that (8.22 -> 4.12 us) and was the best point in a
+# rows x warps sweep; env-overridable so the sweep can be repeated on other hardware.
+ROWS_PER_CTA: int = int(os.environ.get("MCORE_QK_NORM_ROWS", "8"))
+NUM_WARPS: int = int(os.environ.get("MCORE_QK_NORM_WARPS", "8"))
+
 
 if HAVE_TRITON:
 
@@ -55,47 +66,82 @@ if HAVE_TRITON:
         wq_ptr,
         wk_ptr,
         n_q_rows,
+        n_rows,
         q_in_rs,
         k_in_rs,
-        q_out_rs,
-        k_out_rs,
         eps,
+        q_grp_rs,
         HN: tl.constexpr,
         ZERO_CENTERED: tl.constexpr,
+        Q_GROUPED: tl.constexpr,
+        NPG: tl.constexpr,
+        HEADS: tl.constexpr,
+        ROWS: tl.constexpr,
     ):
-        """One CTA per row across the concatenated [q_rows; k_rows] space.
+        """``ROWS`` rows per CTA across the concatenated ``[q_rows; k_rows]`` space.
 
-        Programs with ``row < n_q_rows`` normalize a query row with ``wq``;
-        the rest normalize a key row with ``wk``. Both candidate loads are
-        issued (the off-path one clamped to row 0 and masked out of the store),
-        which keeps the kernel branch-free on the hot path for a 128-wide row.
+        Rows below ``n_q_rows`` are query rows normalized with ``wq``; the rest are key
+        rows normalized with ``wk``. A block may straddle that boundary, so both address
+        schemes are computed for every row and selected per row.
+
+        With ``Q_GROUPED`` the query is read straight out of the QKV projection's output
+        instead of from a repacked copy. There, q heads are grouped with the k and v head
+        of their group, so a q row's address needs two strides -- one per group
+        (``q_grp_rs``) and one per head inside it -- and no single row stride exists. See
+        :func:`fused_qk_rmsnorm_grouped` for why that matters.
+
+        One row per CTA is the obvious shape for a 128-wide row and it is the wrong one:
+        it puts 9,216 single-warp CTAs on the device for a 256-token step and reaches only
+        ~570 GB/s. Eight rows per CTA at eight warps measured exactly 2x that, and a
+        sweep of the rest of the space found nothing better.
+
+        Output row strides are ``HN``, not parameters: both output tensors are allocated
+        here and are contiguous, and passing that stride at runtime instead costs a third
+        of the kernel (6.15 us against 4.12 us) because the compiler can no longer prove
+        the stores are contiguous and vectorize them.
         """
-        row = tl.program_id(0)
+        rows = tl.program_id(0) * ROWS + tl.arange(0, ROWS)
         cols = tl.arange(0, HN)
-        is_q = row < n_q_rows
+        live = rows < n_rows
+        is_q = rows < n_q_rows
 
-        q_row = tl.where(is_q, row, 0)
-        k_row = tl.where(is_q, 0, row - n_q_rows)
+        q_row = tl.where(is_q, rows, 0)
+        k_row = tl.where(is_q, 0, rows - n_q_rows)
+        if Q_GROUPED:
+            head = q_row % HEADS
+            q_off = (
+                (q_row // HEADS) * (HEADS // NPG) + head // NPG
+            ) * q_grp_rs + (head % NPG) * HN
+        else:
+            q_off = q_row * q_in_rs
 
-        xq = tl.load(q_ptr + q_row * q_in_rs + cols).to(tl.float32)
-        xk = tl.load(k_ptr + k_row * k_in_rs + cols).to(tl.float32)
-        x = tl.where(is_q, xq, xk)
+        q_mask = (live & is_q)[:, None]
+        k_mask = (live & (rows >= n_q_rows))[:, None]
 
-        var = tl.sum(x * x, axis=0) / HN
-        inv = 1.0 / tl.sqrt(var + eps)
-        xn = x * inv
+        xq = tl.load(q_ptr + q_off[:, None] + cols[None, :], mask=q_mask, other=0.0)
+        xk = tl.load(k_ptr + (k_row * k_in_rs)[:, None] + cols[None, :], mask=k_mask, other=0.0)
+        x = tl.where(is_q[:, None], xq.to(tl.float32), xk.to(tl.float32))
+
+        var = tl.sum(x * x, axis=1) / HN
+        xn = x * (1.0 / tl.sqrt(var + eps))[:, None]
 
         wq = tl.load(wq_ptr + cols).to(tl.float32)
         wk = tl.load(wk_ptr + cols).to(tl.float32)
-        w = tl.where(is_q, wq, wk)
+        w = tl.where(is_q[:, None], wq[None, :], wk[None, :])
         if ZERO_CENTERED:
             w = w + 1.0
         y = xn * w
 
-        q_store_mask = is_q & (cols < HN)
-        k_store_mask = (row >= n_q_rows) & (cols < HN)
-        tl.store(qo_ptr + q_row * q_out_rs + cols, y.to(qo_ptr.dtype.element_ty), mask=q_store_mask)
-        tl.store(ko_ptr + k_row * k_out_rs + cols, y.to(ko_ptr.dtype.element_ty), mask=k_store_mask)
+        tl.store(
+            qo_ptr + q_row[:, None] * HN + cols[None, :],
+            y.to(qo_ptr.dtype.element_ty),
+            mask=q_mask,
+        )
+        tl.store(
+            ko_ptr + k_row[:, None] * HN + cols[None, :],
+            y.to(ko_ptr.dtype.element_ty),
+            mask=k_mask,
+        )
 
 
 def fused_qk_rmsnorm(
@@ -133,8 +179,9 @@ def fused_qk_rmsnorm(
 
     n_q_rows = q2.shape[0]
     n_rows = n_q_rows + k2.shape[0]
+    assert qo2.stride(0) == hn and ko2.stride(0) == hn  # the kernel stores at stride HN
 
-    _fused_qk_rmsnorm_kernel[(n_rows,)](
+    _fused_qk_rmsnorm_kernel[(triton.cdiv(n_rows, ROWS_PER_CTA),)](
         q2,
         k2,
         qo2,
@@ -142,16 +189,118 @@ def fused_qk_rmsnorm(
         weight_q,
         weight_k,
         n_q_rows,
+        n_rows,
         q2.stride(0),
         k2.stride(0),
-        qo2.stride(0),
-        ko2.stride(0),
         float(eps),
+        0,
         HN=hn,
         ZERO_CENTERED=zero_centered_gamma,
-        num_warps=1,
+        Q_GROUPED=False,
+        NPG=1,
+        HEADS=1,
+        ROWS=ROWS_PER_CTA,
+        num_warps=NUM_WARPS,
     )
     return qo, ko
+
+
+def fused_qk_rmsnorm_grouped(
+    grouped_query: torch.Tensor,
+    key: torch.Tensor,
+    weight_q: torch.Tensor,
+    weight_k: torch.Tensor,
+    eps: float,
+    zero_centered_gamma: bool,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Same norm, but reading the query straight out of the QKV projection.
+
+    Megatron's QKV projection writes ``[sq, b, ng, (np/ng + 2) * hn]`` -- each group's
+    q heads sit next to that group's k and v head. Reshaping the q slice to
+    ``[sq, b, np, hn]`` therefore **cannot** be a view: merging the group axis with the
+    head axis needs the group stride to equal ``(np/ng) * hn``, and it is
+    ``(np/ng + 2) * hn`` instead. For Qwen3-30B that is 1280 against 1024, so
+    `Tensor.reshape` silently materializes the whole query -- one full-size strided copy
+    per layer per step, which showed up in the profile as a 2.8 us
+    ``elementwise_kernel<128,4>`` between the QKV GEMM and this norm and took four
+    attempts to attribute.
+
+    Since this norm already writes a fresh output, it can absorb the repack for free:
+    read with the two strides the grouped layout needs, write the contiguous
+    ``[sq, b, np, hn]`` result the rest of attention wants. Values and arithmetic order
+    are unchanged, so the result is bit-identical to normalizing the copy.
+
+    Args:
+        grouped_query: the q slice of the QKV output, ``[sq, b, ng, (np/ng) * hn]``.
+        key: ``[sq, b, ng, hn]``, as for :func:`fused_qk_rmsnorm`.
+
+    Returns:
+        ``(query_normed, key_normed)``; the query is ``[sq, b, np, hn]`` contiguous.
+    """
+    hn = key.shape[-1]
+    sq, b, ng = grouped_query.shape[0], grouped_query.shape[1], grouped_query.shape[2]
+    npg = grouped_query.shape[3] // hn
+    heads = ng * npg
+
+    k2 = key.reshape(-1, hn)
+    qo = torch.empty(sq, b, heads, hn, dtype=grouped_query.dtype, device=grouped_query.device)
+    ko = torch.empty(key.shape, dtype=key.dtype, device=key.device)
+    qo2 = qo.view(-1, hn)
+    ko2 = ko.view(-1, hn)
+
+    n_q_rows = sq * b * heads
+    n_rows = n_q_rows + k2.shape[0]
+    assert qo2.stride(0) == hn and ko2.stride(0) == hn  # the kernel stores at stride HN
+
+    _fused_qk_rmsnorm_kernel[(triton.cdiv(n_rows, ROWS_PER_CTA),)](
+        grouped_query,
+        k2,
+        qo2,
+        ko2,
+        weight_q,
+        weight_k,
+        n_q_rows,
+        n_rows,
+        0,  # unused: grouped q rows have no single stride
+        k2.stride(0),
+        float(eps),
+        grouped_query.stride(2),
+        HN=hn,
+        ZERO_CENTERED=zero_centered_gamma,
+        Q_GROUPED=True,
+        NPG=npg,
+        HEADS=heads,
+        ROWS=ROWS_PER_CTA,
+        num_warps=NUM_WARPS,
+    )
+    return qo, ko
+
+
+def can_use_grouped_qk_norm(
+    q_layernorm, k_layernorm, grouped_query: torch.Tensor, key: torch.Tensor
+) -> bool:
+    """Whether the grouped-read path is safe, i.e. the copy can be skipped entirely.
+
+    Everything :func:`can_use_fused_qk_norm` requires, plus the two assumptions the
+    grouped addressing makes about the QKV output: that a token's groups are evenly
+    spaced (so a token stride is ``ng * group_stride``), and that the heads inside a
+    group are contiguous.
+    """
+    if not USE_GROUPED_QK_NORM:
+        return False
+    if grouped_query.ndim != 4 or key.ndim != 4:
+        return False
+    hn = key.shape[-1]
+    if grouped_query.shape[3] % hn != 0:
+        return False
+    ng = grouped_query.shape[2]
+    if grouped_query.stride(3) != 1 or grouped_query.stride(1) != ng * grouped_query.stride(2):
+        return False
+    # `key` stands in for the query in the shared check: the grouped query's last dim is
+    # `(np/ng) * hn` rather than `hn`, and every property that check reads off the query
+    # -- head_dim, cuda-ness, last-dim contiguity, token count from `shape[:-2]` -- is
+    # identical between the two here, with the query's own layout verified just above.
+    return can_use_fused_qk_norm(q_layernorm, k_layernorm, key, key)
 
 
 def can_use_fused_qk_norm(q_layernorm, k_layernorm, query: torch.Tensor, key: torch.Tensor) -> bool:

--- a/megatron/core/inference/contexts/attention_context/mha_metadata.py
+++ b/megatron/core/inference/contexts/attention_context/mha_metadata.py
@@ -65,6 +65,18 @@ class MHAMetadata(MetadataBase):
             "max_seqlen_k": max_seqlen_k,
         }
 
+    def restore_state_data(self, state_data: dict, max_seqlen_q: int, max_seqlen_k: int) -> None:
+        """Re-bind a previously built ``state_data`` after ``reset()``.
+
+        Equivalent to ``set_state_data`` called with the arguments that produced
+        ``state_data``, minus the re-slicing. Used by the incremental decode
+        path in ``DynamicInferenceContext``, where the padded request count and
+        therefore every slice is provably unchanged from the previous step.
+        """
+        self._max_seqlen_q = max_seqlen_q
+        self._max_seqlen_k = max_seqlen_k
+        self.state_data = state_data
+
     def reset(self):
         """Reset the metadata for the next batch.
 

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -3,6 +3,7 @@
 import logging
 import math
 import operator
+import os
 import warnings
 from contextlib import nullcontext
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
@@ -76,6 +77,31 @@ try:
     HAVE_TORCH_MEMORY_SAVER = True
 except ImportError:
     HAVE_TORCH_MEMORY_SAVER = False
+
+# Incremental steady-state decode path for `initialize_attention_state`. Off by
+# default; see `DynamicInferenceContext._incremental_attention_state_update`.
+_INCR_ATTN_STATE = os.environ.get("MCORE_INFER_INCR_ATTN_STATE", "0") == "1"
+# Debug mode: take the fast path, then recompute from scratch and assert that
+# every buffer the fast path served is identical. Very slow; correctness only.
+_INCR_ATTN_STATE_VERIFY = os.environ.get("MCORE_INFER_INCR_ATTN_STATE_VERIFY", "0") == "1"
+
+# Diagnostic: tally why the incremental fast path declines, so a single run answers
+# "which guard is rejecting every step" instead of requiring a guess per experiment.
+_INCR_DIAG = os.environ.get("MCORE_INFER_INCR_DIAG", "0") == "1"
+_incr_diag_counts: Dict[str, int] = {}
+
+
+def _incr_diag(reason: str) -> None:
+    """Count one fast-path outcome and periodically log the tally."""
+    _incr_diag_counts[reason] = _incr_diag_counts.get(reason, 0) + 1
+    total = sum(_incr_diag_counts.values())
+    if total % 500 == 0:
+        parts = ", ".join(
+            f"{k}={v} ({100*v/total:.1f}%)"
+            for k, v in sorted(_incr_diag_counts.items(), key=lambda x: -x[1])
+        )
+        logging.info("[INCR_DIAG] %d calls: %s", total, parts)
+
 
 DEPRECATED_ARGS = [
     "params_dtype",
@@ -317,6 +343,17 @@ class DynamicInferenceContext(BaseInferenceContext):
     TOKEN_ROUNDER = 64
     REQUEST_ROUNDER = 4
     TMS_TAG = "inference_context"
+
+    # Incremental attention-state cache (MCORE_INFER_INCR_ATTN_STATE). Declared
+    # at class scope so every construction path starts from a cold, invalid
+    # cache without depending on __init__ ordering.
+    _request_layout_version = 0
+    _incr_attn_state_key = None
+    _incr_attn_state_real_bs = 0
+    _incr_attn_state_padded_bs = 0
+    _incr_attn_state_max_seqlen_q = 0
+    _incr_attn_state_max_seqlen_k = 0
+    _incr_attn_state_state_data = None
 
     @deprecate_args(
         *DEPRECATED_ARGS,
@@ -1055,6 +1092,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         if self.is_tensor_state_allocated:
             return
         self.is_tensor_state_allocated = True
+        self._bump_request_layout_version()
 
         # Validate no tensors allocated prior to this method.
         for key in vars(self).keys():
@@ -2017,6 +2055,8 @@ class DynamicInferenceContext(BaseInferenceContext):
         if not requests:
             return
 
+        self._bump_request_layout_version()
+
         num_new_requests = len(requests)
         if self.total_request_count + num_new_requests > self.max_requests:
             raise RequestOverflowError(requests[-1].request_id)
@@ -2154,6 +2194,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         Adds dummy requests to reflect the number of prefill and decode requests in the graph config.
         These are using during cuda graph captures.
         """
+        self._bump_request_layout_version()
         prefill_tokens = graph_dimensions.token_count - (
             graph_dimensions.decode_req_count * (self.num_speculative_tokens + 1)
         )
@@ -2225,6 +2266,7 @@ class DynamicInferenceContext(BaseInferenceContext):
 
         Called AFTER the EP sync so graph_dimensions reflects the agreed-upon graph.
         """
+        self._bump_request_layout_version()
         N_decode = graph_dimensions.decode_req_count
         N_prefill = graph_dimensions.prefill_req_count
         N = N_decode + N_prefill
@@ -2307,6 +2349,20 @@ class DynamicInferenceContext(BaseInferenceContext):
                 completion, or `None` when no event was requested or no
                 transfer was performed.
         """
+        _verify_snapshot = None
+        if _INCR_ATTN_STATE and not is_expert_parallel_dummy_cuda_graph_step:
+            advanced, fast_bookkeeping_done_event = self._incremental_attention_state_update(
+                construct_graph_dimensions,
+                transfer_bookkeeping_to_gpu=transfer_bookkeeping_to_gpu,
+                record_bookkeeping_done_event=record_bookkeeping_done_event,
+            )
+            if advanced:
+                if not _INCR_ATTN_STATE_VERIFY:
+                    return fast_bookkeeping_done_event
+                # Verify mode: keep what the fast path produced, redo everything
+                # from scratch below, then assert the two agree exactly.
+                _verify_snapshot = self._incr_attn_state_snapshot()
+
         # Launch deferred Mamba GPU ops first (state zeroing/restore) so they
         # overlap with the CPU work below.  These are non-blocking GPU kernels.
         self._execute_pending_mamba_ops()
@@ -2551,9 +2607,260 @@ class DynamicInferenceContext(BaseInferenceContext):
         )
 
         # Preserve the existing behavior for callers that do not publish explicitly.
+        bookkeeping_done_event = None
         if transfer_bookkeeping_to_gpu:
-            return self.transfer_bookkeeping_to_gpu(record_done_event=record_bookkeeping_done_event)
-        return None
+            bookkeeping_done_event = self.transfer_bookkeeping_to_gpu(
+                record_done_event=record_bookkeeping_done_event
+            )
+
+        if _INCR_ATTN_STATE:
+            self._incr_attn_state_store(real_bs, padded_bs, max_seqlen_q, max_seqlen_k)
+            if _verify_snapshot is not None:
+                self._incr_attn_state_verify(_verify_snapshot)
+
+        return bookkeeping_done_event
+
+    def _bump_request_layout_version(self) -> None:
+        """Invalidate the incremental attention-state cache.
+
+        Called from every path that changes *which* request occupies a slot, a
+        request's sampling metadata, or a request's KV block table — i.e. the
+        inputs that `initialize_attention_state` would otherwise recompute
+        identically on every decode step. Advancing a request's KV length is
+        deliberately *not* such a path: that is the one thing the incremental
+        update recomputes.
+        """
+        self._request_layout_version += 1
+
+    def _incr_attn_state_cache_key(self):
+        """Cheap scalar signature of the batch layout, or None if uncacheable.
+
+        `_request_layout_version` is the primary guard. The remaining entries
+        are independent structural sentinels so that a missed version bump
+        still has to coincide with an unchanged request count, token count and
+        KV block-allocator occupancy to go unnoticed.
+        """
+        if self.is_hybrid_model or self.num_prefill_requests != 0:
+            return None
+        return (
+            self._request_layout_version,
+            self.total_request_count,
+            self.paused_request_count,
+            self.active_token_count,
+            self.kv_block_allocator.pool_avail,
+            self.chunked_prefill_request_id,
+            self.num_speculative_tokens,
+        )
+
+    def _incr_attn_state_store(
+        self, real_bs: int, padded_bs: int, max_seqlen_q: int, max_seqlen_k: int
+    ) -> None:
+        """Record that the state just built by the full path is incrementable."""
+        if (
+            self.is_creating_cuda_graphs
+            or not self._using_cuda_graph_this_step
+            or self.is_hybrid_model
+            or self.num_prefill_requests != 0
+        ):
+            self._incr_attn_state_key = None
+            return
+        self._incr_attn_state_real_bs = real_bs
+        self._incr_attn_state_padded_bs = padded_bs
+        self._incr_attn_state_max_seqlen_q = max_seqlen_q
+        self._incr_attn_state_max_seqlen_k = max_seqlen_k
+        self._incr_attn_state_state_data = self.active_attn_metadata["mha_metadata"].state_data
+        self._incr_attn_state_key = self._incr_attn_state_cache_key()
+
+    def _incremental_attention_state_update(
+        self,
+        construct_graph_dimensions: Optional[InferenceBatchDimensions],
+        *,
+        transfer_bookkeeping_to_gpu: bool = True,
+        record_bookkeeping_done_event: bool = False,
+    ) -> Tuple[bool, Optional[torch.cuda.Event]]:
+        """Advance the cached attention state by one decode step.
+
+        In steady-state decode the request set, sampling metadata, KV block
+        table, CUDA-graph selection, padded dimensions and every
+        query-length-derived buffer are identical to the previous step; only
+        the KV sequence lengths advance by `num_speculative_tokens + 1` per
+        request. Recompute exactly those and reuse the rest.
+
+        The publish arguments mirror :meth:`initialize_attention_state`, so this path
+        serves deferred-publish callers (async scheduling) too. Without them the fast
+        path had to decline those callers, which meant it never ran at all under async
+        scheduling -- and async is the default in the tuned config, so the whole
+        optimization was silently inactive there.
+
+        Returns:
+            Tuple[bool, Optional[torch.cuda.Event]]: whether the state was advanced
+                (False means the caller must run the full path), and the bookkeeping
+                H2D completion event when one was both requested and recorded.
+        """
+        if construct_graph_dimensions is not None:
+            self._incr_attn_state_key = None
+            if _INCR_DIAG:
+                _incr_diag("decline:graph_capture")
+            return False, None
+        key = self._incr_attn_state_cache_key()
+        if key is None or key != self._incr_attn_state_key:
+            if _INCR_DIAG:
+                if key is None:
+                    # Uncacheable batch: hybrid model or a prefill request present.
+                    _incr_diag("decline:key_none")
+                elif self._incr_attn_state_key is None:
+                    # Previous step declined to store, so there is nothing to advance.
+                    _incr_diag("decline:no_stored_key")
+                else:
+                    # Both keys exist but differ: name the first differing field, which
+                    # is what distinguishes "layout really changed" from "one sentinel
+                    # (e.g. KV block availability) churns every step".
+                    fields = (
+                        "layout_version",
+                        "total_reqs",
+                        "paused_reqs",
+                        "active_tokens",
+                        "kv_blocks_avail",
+                        "chunked_prefill_id",
+                        "spec_tokens",
+                    )
+                    diff = next(
+                        (
+                            f
+                            for f, a, b in zip(fields, key, self._incr_attn_state_key)
+                            if a != b
+                        ),
+                        "unknown",
+                    )
+                    _incr_diag(f"decline:key_differs:{diff}")
+            return False, None
+
+        real_bs = self._incr_attn_state_real_bs
+        padded_bs = self._incr_attn_state_padded_bs
+
+        self._execute_pending_mamba_ops()
+        self.is_creating_cuda_graphs = False
+        self._using_cuda_graph_this_step = True
+        self.active_attn_metadata = self.graph_attn_metadata  # type: ignore[assignment]
+
+        active_slice = slice(self.paused_request_count, self.total_request_count)
+        query_lengths_view = self.request_query_lengths[active_slice]
+        request_kv_length_offsets_view = self.request_kv_length_offsets[active_slice]
+
+        # Character-identical to the corresponding statements in the full path,
+        # so the buffers stay bit-identical to a fresh computation.
+        self._cpu_mha_kv_seq_lengths[:real_bs] = (
+            request_kv_length_offsets_view[:real_bs] + query_lengths_view[:real_bs]
+        )
+        self._cpu_mha_cu_kv_seq_lengths[0] = 0
+        if real_bs > 0:
+            self._cpu_mha_cu_kv_seq_lengths[1 : real_bs + 1] = torch.cumsum(
+                self._cpu_mha_kv_seq_lengths[:real_bs], dim=0
+            )
+        if real_bs < padded_bs:
+            self._cpu_mha_cu_kv_seq_lengths[real_bs + 1 : padded_bs + 1] = (
+                self._cpu_mha_cu_kv_seq_lengths[real_bs]
+            )
+
+        # Token padding slots hold step-invariant sentinels, but re-stamp them
+        # whenever padding exists at all, since the token buffers are shared.
+        if self.active_token_count != self.padded_active_token_count:
+            self.token_to_block_idx[self.active_token_count : self.padded_active_token_count] = (
+                self.kv_block_allocator.dummy_block_idx
+            )
+            self.token_to_local_position_within_kv_block[
+                self.active_token_count : self.padded_active_token_count
+            ] = 0
+            self.token_to_position_in_request[
+                self.active_token_count : self.padded_active_token_count
+            ] = 0
+
+        # `reset_attention_state()` clears the max-seqlen scalars every step, so
+        # rebind state_data even though the slices behind it are unchanged.
+        self.active_attn_metadata["mha_metadata"].restore_state_data(
+            self._incr_attn_state_state_data,
+            self._incr_attn_state_max_seqlen_q,
+            self._incr_attn_state_max_seqlen_k,
+        )
+
+        if self.moe_enable_routing_replay:
+            self.moe_routing_metadata.enable_static_buffer_recording()
+
+        if self._nccl_ep_dispatcher:
+            NCCLAllGatherDispatcher._use_allgather_v = False
+
+        self._execute_pending_mamba_ops()
+        # Graph-capture and EP dummy steps are declined above, so this step always
+        # produces real output; clear the flag the publish step reads, which may
+        # still be set from an earlier capture step.
+        self._bookkeeping_no_real_work = False
+        if _INCR_DIAG:
+            _incr_diag("advanced")
+        # Same conditional publish as the tail of the full path: deferred-publish
+        # callers bind the GPU views here and push the values later.
+        bookkeeping_done_event = None
+        if transfer_bookkeeping_to_gpu:
+            bookkeeping_done_event = self.transfer_bookkeeping_to_gpu(
+                record_done_event=record_bookkeeping_done_event
+            )
+        return True, bookkeeping_done_event
+
+    def _incr_attn_state_snapshot(self) -> Dict:
+        """Clone everything the incremental path produced (debug verify only)."""
+        torch.cuda.synchronize()
+        n = self.padded_active_request_count
+        mha = self.active_attn_metadata["mha_metadata"]
+        snapshot = {
+            "mha_query_lengths": self._cpu_mha_query_lengths[:n].clone(),
+            "mha_cu_query_seq_lengths": self._cpu_mha_cu_query_seq_lengths[: n + 1].clone(),
+            "mha_kv_seq_lengths": self._cpu_mha_kv_seq_lengths[:n].clone(),
+            "mha_cu_kv_seq_lengths": self._cpu_mha_cu_kv_seq_lengths[: n + 1].clone(),
+            "mha_block_table": self._cpu_mha_block_table[:n].clone(),
+            "active_request_last_token_idxs": self.active_request_last_token_idxs[:n].clone(),
+            "active_logit_idxs": self.active_logit_idxs.clone(),
+            "gpu_bookkeeping_buf": self.gpu_view._buf.clone(),
+            "padded_active_token_count": self.padded_active_token_count,
+            "padded_active_request_count": self.padded_active_request_count,
+            "padded_batch_dimensions": self.padded_batch_dimensions,
+            "using_cuda_graph_this_step": self._using_cuda_graph_this_step,
+            "max_seqlen_q": mha._max_seqlen_q,
+            "max_seqlen_k": mha._max_seqlen_k,
+        }
+        for label, tensor in self.active_request_metadata.items():
+            snapshot[f"active_request_metadata/{label}"] = tensor[:n].clone()
+        # state_data holds views into the GPU bookkeeping buffer; compare the
+        # bindings (address, shape, dtype) rather than the contents, which the
+        # `gpu_bookkeeping_buf` entry above already covers.
+        for label, value in mha.state_data.items():
+            if isinstance(value, torch.Tensor):
+                value = (value.data_ptr(), tuple(value.shape), str(value.dtype))
+            snapshot[f"state_data/{label}"] = value
+        return snapshot
+
+    def _incr_attn_state_verify(self, snapshot: Dict) -> None:
+        """Assert the freshly recomputed state matches the incremental one."""
+        fresh = self._incr_attn_state_snapshot()
+        mismatches = []
+        for key, want in snapshot.items():
+            got = fresh[key]
+            if isinstance(want, torch.Tensor):
+                if not torch.equal(want, got):
+                    bad = (want != got).nonzero().flatten()[:8].tolist()
+                    mismatches.append(f"{key}: {bad} incr={want.flatten()[:8].tolist()}")
+            elif want != got:
+                mismatches.append(f"{key}: incr={want} full={got}")
+        self._incr_attn_state_verify_steps = getattr(self, "_incr_attn_state_verify_steps", 0) + 1
+        if mismatches:
+            raise AssertionError(
+                "MCORE_INFER_INCR_ATTN_STATE verification failed at step "
+                f"{self._incr_attn_state_verify_steps}: " + "; ".join(mismatches)
+            )
+        if self._incr_attn_state_verify_steps % 10 == 0:
+            logging.info(
+                "[INCR_ATTN_STATE verify] %d incremental steps bit-identical to full "
+                "recomputation",
+                self._incr_attn_state_verify_steps,
+            )
 
     def _execute_pending_mamba_ops(self) -> None:
         """Execute Mamba GPU operations deferred from add_request() / update_requests().
@@ -2726,6 +3033,8 @@ class DynamicInferenceContext(BaseInferenceContext):
     def reset_tensors(self) -> None:
         """Fill all bookkeeping tensors with sentinel values."""
 
+        self._bump_request_layout_version()
+
         # Reset request indexes.
         self.request_ids.fill_(-1)
         self.request_query_lengths.fill_(0)
@@ -2769,6 +3078,8 @@ class DynamicInferenceContext(BaseInferenceContext):
         """
         # There is no prefix-cache state to preserve when caching is disabled.
         preserve_prefix_cache = preserve_prefix_cache and self.enable_prefix_caching
+
+        self._bump_request_layout_version()
 
         # Reset request/token counts.
         self.total_request_count = 0
@@ -3156,6 +3467,8 @@ class DynamicInferenceContext(BaseInferenceContext):
         if not self.is_tensor_state_allocated:
             raise TensorStateDeallocatedError(req.request_id)
 
+        self._bump_request_layout_version()
+
         # Prefill chunk length.
         if prefill_chunk_length is None:
             prefill_chunk_length = req.remaining_prompt_length
@@ -3394,6 +3707,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         """
         Move all the relevent booking tensors with src idxs to dst idxs
         """
+        self._bump_request_layout_version()
         self.request_kv_length_offsets[dst_idxs] = self.request_kv_length_offsets[src_idxs]
         self.request_in_prefill_status_tensor[dst_idxs] = self.request_in_prefill_status_tensor[
             src_idxs
@@ -3423,6 +3737,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         """
         Swaps all the relevent booking tensors with src idxs to dst idxs
         """
+        self._bump_request_layout_version()
         tensor_swap(self.request_kv_length_offsets, src_idxs, dst_idxs)
         tensor_swap(self.request_query_lengths, src_idxs, dst_idxs)
         tensor_swap(self.request_in_prefill_status_tensor, src_idxs, dst_idxs)
@@ -3480,6 +3795,7 @@ class DynamicInferenceContext(BaseInferenceContext):
             request_indexes (torch.Tensor): Request indexes. (*Note*, NOT request
                 ids.)
         """
+        self._bump_request_layout_version()
         kv_blocks_assigned = self.request_to_kv_block_ids[request_indexes]
         non_zero_values_in_kv_memory = kv_blocks_assigned[kv_blocks_assigned != -1]
         self.kv_block_allocator.release_memory_blocks(non_zero_values_in_kv_memory)
@@ -3620,6 +3936,7 @@ class DynamicInferenceContext(BaseInferenceContext):
 
         # Resume requests by assigning blocks and updating bookkeeping tensors.
         if resume_request_count > 0:
+            self._bump_request_layout_version()
             resume_start = self.paused_request_count
             resume_end = self.paused_request_count + resume_request_count
 
@@ -3849,6 +4166,7 @@ class DynamicInferenceContext(BaseInferenceContext):
         if block_ids is not None:
             row_idx = torch.nonzero(rows_requiring_new_block, as_tuple=True)[0]
             col_idx = self.request_kv_block_counts[row_idx]
+            self._bump_request_layout_version()
             self.request_to_kv_block_ids[row_idx, col_idx] = block_ids
             self.request_kv_block_counts[row_idx] += 1
             self.request_last_kv_block_id[row_idx] = block_ids
@@ -3953,6 +4271,14 @@ class DynamicInferenceContext(BaseInferenceContext):
             Tuple[Tensor, Tensor]: Request IDs that finished and source row indices
                 for surviving requests in their resolved destination order.
         """
+        # The layout-version bump is deferred until a request is known to have
+        # finished (below). When the mask is all ones -- the steady-state decode
+        # case -- nothing here touches the layout: no rows move (``survivor_idxs``
+        # equals ``dst_idxs``), no KV blocks are released, the stale slice is empty
+        # and ``total_request_count`` is unchanged. Bumping unconditionally
+        # invalidated the incremental attention-state cache on *every* step, which
+        # made that whole optimization inert under async scheduling (measured: the
+        # fast path advanced on 0.1% of calls, 97.5% declining on this version).
         if active_requests_mask.is_cuda:
             active_requests_mask = active_requests_mask.cpu()
 
@@ -3987,6 +4313,10 @@ class DynamicInferenceContext(BaseInferenceContext):
         self.reset_attention_state()
 
         if finished_idxs.numel() > 0:
+            # Every layout change in this method is downstream of a finished request:
+            # the row compaction below, the KV block release, and the request-count
+            # change all require at least one zero in the mask.
+            self._bump_request_layout_version()
             self.release_memory_blocks_from_request_indexes(finished_idxs)
 
         if active_request_count == 0:

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -4,6 +4,7 @@ import logging
 import math
 import operator
 import os
+import time
 import warnings
 from contextlib import nullcontext
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
@@ -108,6 +109,56 @@ def _incr_diag(reason: str) -> None:
             for k, v in sorted(_incr_diag_counts.items(), key=lambda x: -x[1])
         )
         logging.info("[INCR_DIAG] %d calls: %s", total, parts)
+
+
+# ---------------------------------------------------------------------------
+# Host-side phase profiling for `initialize_attention_state`.
+#
+# `initialize_attention_state` is pure CPU work on the per-step critical path
+# (see its call site comment in text_generation_controller.py). Set
+# MCORE_INFER_ATTN_PROF=1 to accumulate per-phase host wall time and log a
+# breakdown every MCORE_INFER_ATTN_PROF_EVERY calls. Inert (one predictable
+# branch per phase boundary) when unset.
+# ---------------------------------------------------------------------------
+_ATTN_PROF_ENABLED = os.environ.get("MCORE_INFER_ATTN_PROF", "0") == "1"
+_ATTN_PROF_EVERY = int(os.environ.get("MCORE_INFER_ATTN_PROF_EVERY", "100"))
+_ATTN_PROF_PHASES = (
+    "pre",  # pending mamba ops + dummy-request branches
+    "graphmatch",  # batch dims + match_graph_config
+    "paddims",  # padded batch dimension derivation
+    "slices",  # build_active_slices + pad_active_slices
+    "tokenpad",  # token_to_* padding writes
+    "mhameta",  # MHA metadata into the pinned CPU bookkeeping buffer
+    "maxlen",  # max_seqlen derivation + mha.set_state_data
+    "tail",  # hybrid / routing-replay / dispatcher flags + mamba flush
+    "xfer_inner",  # the transfer_bookkeeping_to_gpu() call at the end
+    "TOTAL",
+)
+_attn_prof_ns = [0] * len(_ATTN_PROF_PHASES)
+_attn_prof_calls = [0]
+_perf_ns = time.perf_counter_ns
+
+
+def _attn_prof_mark(idx: int, t_prev: int) -> int:
+    """Accumulate elapsed ns into phase `idx` and return the new timestamp."""
+    now = _perf_ns()
+    _attn_prof_ns[idx] += now - t_prev
+    return now
+
+
+def _attn_prof_report() -> None:
+    """Log the mean per-call host cost of each phase, then reset counters."""
+    n = _attn_prof_calls[0]
+    if n == 0:
+        return
+    rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
+    parts = " ".join(
+        f"{name}={_attn_prof_ns[i] / n / 1000.0:.1f}" for i, name in enumerate(_ATTN_PROF_PHASES)
+    )
+    logging.info("[ATTN_PROF rank=%d] calls=%d us/call: %s", rank, n, parts)
+    for i in range(len(_attn_prof_ns)):
+        _attn_prof_ns[i] = 0
+    _attn_prof_calls[0] = 0
 
 
 DEPRECATED_ARGS = [
@@ -2361,6 +2412,10 @@ class DynamicInferenceContext(BaseInferenceContext):
                 completion, or `None` when no event was requested or no
                 transfer was performed.
         """
+        _prof = _ATTN_PROF_ENABLED
+        _t = _perf_ns() if _prof else 0
+        _t_start = _t
+
         _verify_snapshot = None
         if _INCR_ATTN_STATE and not is_expert_parallel_dummy_cuda_graph_step:
             advanced, fast_bookkeeping_done_event = self._incremental_attention_state_update(
@@ -2370,6 +2425,12 @@ class DynamicInferenceContext(BaseInferenceContext):
             )
             if advanced:
                 if not _INCR_ATTN_STATE_VERIFY:
+                    if _prof:
+                        _t = _attn_prof_mark(8, _t)
+                        _attn_prof_ns[9] += _t - _t_start
+                        _attn_prof_calls[0] += 1
+                        if _attn_prof_calls[0] >= _ATTN_PROF_EVERY:
+                            _attn_prof_report()
                     return fast_bookkeeping_done_event
                 # Verify mode: keep what the fast path produced, redo everything
                 # from scratch below, then assert the two agree exactly.
@@ -2397,6 +2458,9 @@ class DynamicInferenceContext(BaseInferenceContext):
                 )
             )
 
+        if _prof:
+            _t = _attn_prof_mark(0, _t)
+
         batch_dimensions = InferenceBatchDimensions(
             token_count=self.active_token_count,
             prefill_req_count=self.num_prefill_requests,
@@ -2417,6 +2481,9 @@ class DynamicInferenceContext(BaseInferenceContext):
 
         if construct_graph_dimensions is not None:
             assert self._using_cuda_graph_this_step
+
+        if _prof:
+            _t = _attn_prof_mark(1, _t)
 
         if self.using_cuda_graph_this_step():
             self.padded_batch_dimensions = best_graph
@@ -2452,10 +2519,16 @@ class DynamicInferenceContext(BaseInferenceContext):
         self.padded_active_request_count = self.padded_batch_dimensions.req_count
         self.padding_slice = slice(self.active_token_count, self.padded_active_token_count)
 
+        if _prof:
+            _t = _attn_prof_mark(2, _t)
+
         self.build_active_slices(
             min(self.padded_active_request_count, self.max_requests - self.paused_request_count)
         )
         self.pad_active_slices()
+
+        if _prof:
+            _t = _attn_prof_mark(3, _t)
 
         # Update token position indexes.
         self.token_to_block_idx[self.active_token_count : self.padded_active_token_count] = (
@@ -2494,6 +2567,9 @@ class DynamicInferenceContext(BaseInferenceContext):
                 )
 
         assert self.active_attn_metadata is not None
+
+        if _prof:
+            _t = _attn_prof_mark(4, _t)
 
         # Compute MHA metadata directly into the pinned CPU section of
         # _cpu_bookkeeping_buf. The single coalesced H2D in
@@ -2543,6 +2619,9 @@ class DynamicInferenceContext(BaseInferenceContext):
         if real_bs < padded_bs:
             self._cpu_mha_block_table[real_bs:padded_bs] = self.kv_block_allocator.dummy_block_idx
 
+        if _prof:
+            _t = _attn_prof_mark(5, _t)
+
         # Max sequence lengths (Python scalars; consumed as kernel launch args).
         if not self.using_cuda_graph_this_step() and real_bs > 0:
             # NonGraphedMHAMetadata: use actual max values.
@@ -2570,6 +2649,9 @@ class DynamicInferenceContext(BaseInferenceContext):
             max_seqlen_q=max_seqlen_q,
             max_seqlen_k=max_seqlen_k,
         )
+
+        if _prof:
+            _t = _attn_prof_mark(6, _t)
 
         if self.is_hybrid_model:
             # Mamba metadata update is deferred to transfer_bookkeeping_to_gpu()
@@ -2618,6 +2700,9 @@ class DynamicInferenceContext(BaseInferenceContext):
             construct_graph_dimensions is not None or is_expert_parallel_dummy_cuda_graph_step
         )
 
+        if _prof:
+            _t = _attn_prof_mark(7, _t)
+
         # Preserve the existing behavior for callers that do not publish explicitly.
         bookkeeping_done_event = None
         if transfer_bookkeeping_to_gpu:
@@ -2629,6 +2714,13 @@ class DynamicInferenceContext(BaseInferenceContext):
             self._incr_attn_state_store(real_bs, padded_bs, max_seqlen_q, max_seqlen_k)
             if _verify_snapshot is not None:
                 self._incr_attn_state_verify(_verify_snapshot)
+
+        if _prof:
+            _t = _attn_prof_mark(8, _t)
+            _attn_prof_ns[9] += _t - _t_start
+            _attn_prof_calls[0] += 1
+            if _attn_prof_calls[0] >= _ATTN_PROF_EVERY:
+                _attn_prof_report()
 
         return bookkeeping_done_event
 

--- a/megatron/core/inference/contexts/dynamic_context.py
+++ b/megatron/core/inference/contexts/dynamic_context.py
@@ -85,6 +85,13 @@ _INCR_ATTN_STATE = os.environ.get("MCORE_INFER_INCR_ATTN_STATE", "0") == "1"
 # every buffer the fast path served is identical. Very slow; correctness only.
 _INCR_ATTN_STATE_VERIFY = os.environ.get("MCORE_INFER_INCR_ATTN_STATE_VERIFY", "0") == "1"
 
+# Reduced-op path for the post-sampling bookkeeping in `update_requests`. Off by
+# default; see `DynamicInferenceContext._write_decode_token_bookkeeping_fast`.
+_VEC_UPDATE_REQS = os.environ.get("MCORE_INFER_VEC_UPDATE_REQS", "0") == "1"
+# Debug mode: run the reduced-op path, snapshot every buffer it wrote, restore
+# the inputs, run the reference path, and assert the two agree exactly.
+_VEC_UPDATE_REQS_VERIFY = os.environ.get("MCORE_INFER_VEC_UPDATE_REQS_VERIFY", "0") == "1"
+
 # Diagnostic: tally why the incremental fast path declines, so a single run answers
 # "which guard is rejecting every step" instead of requiring a guess per experiment.
 _INCR_DIAG = os.environ.get("MCORE_INFER_INCR_DIAG", "0") == "1"
@@ -354,6 +361,11 @@ class DynamicInferenceContext(BaseInferenceContext):
     _incr_attn_state_max_seqlen_q = 0
     _incr_attn_state_max_seqlen_k = 0
     _incr_attn_state_state_data = None
+
+    # Cached `torch.arange(paused_request_count, total_request_count)` for the
+    # reduced-op decode bookkeeping path (MCORE_INFER_VEC_UPDATE_REQS).
+    _decode_req_idx_bounds = None
+    _decode_req_idx_arange = None
 
     @deprecate_args(
         *DEPRECATED_ARGS,
@@ -4423,7 +4435,13 @@ class DynamicInferenceContext(BaseInferenceContext):
             active_requests_mask[-1] = 1
 
         active_request_count = (active_requests_mask == 1).sum().item()
-        finished_request_count = (active_requests_mask == 0).sum().item()
+        if _VEC_UPDATE_REQS:
+            # The mask is 0/1 by construction (a `&` of two byte comparisons in
+            # text_generation_controller), so the complement is exact and saves a
+            # second full comparison + reduction over the request dimension.
+            finished_request_count = active_requests_mask.numel() - active_request_count
+        else:
+            finished_request_count = (active_requests_mask == 0).sum().item()
         assert (
             active_request_count + finished_request_count + self.paused_request_count
             == self.total_request_count
@@ -4514,7 +4532,11 @@ class DynamicInferenceContext(BaseInferenceContext):
             ]
             active_requests_requiring_new_block = (
                 num_tokens_in_last_block >= self.block_size_tokens - 1 - self.num_speculative_tokens
-            ).byte()
+            )
+            if not _VEC_UPDATE_REQS:
+                # The bool tensor supports every downstream use (nonzero, `== 0`,
+                # scalar assignment, sum), so the byte cast is a pure copy.
+                active_requests_requiring_new_block = active_requests_requiring_new_block.byte()
 
             # Find the id in request_ids that is the chunked_prefill_request_id. Only one request should be chunked.
             if (
@@ -4531,9 +4553,14 @@ class DynamicInferenceContext(BaseInferenceContext):
                     # Force-pause excess requests in a decode-only batch
                     active_requests_requiring_new_block[max_allowed_active:] = 1
 
-            active_requests_requiring_new_block_count = (
-                (active_requests_requiring_new_block == 1).sum().item()
-            )
+            if _VEC_UPDATE_REQS:
+                active_requests_requiring_new_block_count = int(
+                    active_requests_requiring_new_block.sum()
+                )
+            else:
+                active_requests_requiring_new_block_count = (
+                    (active_requests_requiring_new_block == 1).sum().item()
+                )
 
             if active_requests_requiring_new_block_count > 0:
                 newly_paused_request_ids = self.request_ids[
@@ -4681,6 +4708,123 @@ class DynamicInferenceContext(BaseInferenceContext):
             num_generated_tokens
         )
 
+        if _VEC_UPDATE_REQS and self.num_speculative_tokens == 0:
+            if _VEC_UPDATE_REQS_VERIFY:
+                self._verify_decode_token_bookkeeping(active_request_count, next_tokens)
+            else:
+                self._write_decode_token_bookkeeping_fast(active_request_count, next_tokens)
+        else:
+            self._write_token_bookkeeping_reference(
+                active_request_count,
+                num_generated_tokens,
+                next_tokens,
+                prev_last_block_ids,
+                new_speculative_tokens,
+            )
+
+        return {
+            "newly_paused_request_ids": newly_paused_request_ids,
+            "evict_request_ids": evict_request_ids,
+        }
+
+    def _write_decode_token_bookkeeping_fast(
+        self, active_request_count: int, next_tokens: Tensor
+    ) -> None:
+        """Reduced-op form of `_write_token_bookkeeping_reference` for plain decode.
+
+        Only valid when `num_speculative_tokens == 0`, i.e. exactly one generated
+        token per active request. Under that condition the reference path spends
+        most of its host time on operations that are provably identity:
+        `repeat_interleave(1)`, adding `torch.arange(1).repeat(n)` (a zero
+        vector), and building the `raw_positions` / `crosses_boundary` tensors
+        whose only consumer is a branch that a zero speculative-token count makes
+        unreachable. This writes the same values with those operations removed.
+        """
+        paused = self.paused_request_count
+        total = self.total_request_count
+        active_slice = slice(paused, total)
+        num_tokens = active_request_count
+
+        block_offsets = self.request_last_kv_block_offset
+        block_offsets[active_slice] = (
+            block_offsets[active_slice] + 1
+        ) % self.block_size_tokens
+
+        self.active_token_count = num_tokens
+        self.token_to_input_ids[:num_tokens] = next_tokens[active_slice]
+
+        pos_ids = self.token_to_pos_ids
+        pos_ids[:num_tokens] = self.request_kv_length_offsets[active_slice]
+
+        if self._decode_req_idx_bounds != (paused, total):
+            self._decode_req_idx_bounds = (paused, total)
+            self._decode_req_idx_arange = torch.arange(paused, total, device='cpu')
+        self.token_to_request_idx[:num_tokens] = self._decode_req_idx_arange
+
+        self.token_to_position_in_request[:num_tokens] = pos_ids[:num_tokens]
+        self.token_to_local_position_within_kv_block[:num_tokens] = (
+            pos_ids[:num_tokens] % self.block_size_tokens
+        )
+        self.token_to_block_idx[:num_tokens] = self.request_last_kv_block_id[active_slice]
+
+    def _verify_decode_token_bookkeeping(
+        self, active_request_count: int, next_tokens: Tensor
+    ) -> None:
+        """Run the fast path, then the reference path, and assert they agree."""
+        paused = self.paused_request_count
+        total = self.total_request_count
+        pre_block_offsets = self.request_last_kv_block_offset[paused:total].clone()
+
+        self._write_decode_token_bookkeeping_fast(active_request_count, next_tokens)
+        num_tokens = self.active_token_count
+        fast = {
+            "request_last_kv_block_offset": self.request_last_kv_block_offset[
+                paused:total
+            ].clone(),
+            "active_token_count": self.active_token_count,
+            "token_to_input_ids": self.token_to_input_ids[:num_tokens].clone(),
+            "token_to_pos_ids": self.token_to_pos_ids[:num_tokens].clone(),
+            "token_to_request_idx": self.token_to_request_idx[:num_tokens].clone(),
+            "token_to_position_in_request": self.token_to_position_in_request[
+                :num_tokens
+            ].clone(),
+            "token_to_local_position_within_kv_block": (
+                self.token_to_local_position_within_kv_block[:num_tokens].clone()
+            ),
+            "token_to_block_idx": self.token_to_block_idx[:num_tokens].clone(),
+        }
+
+        self.request_last_kv_block_offset[paused:total] = pre_block_offsets
+        self._write_token_bookkeeping_reference(active_request_count, 1, next_tokens, None)
+
+        mismatches = []
+        for name, fast_value in fast.items():
+            if name == "active_token_count":
+                if fast_value != self.active_token_count:
+                    mismatches.append(f"{name}: {fast_value} != {self.active_token_count}")
+                continue
+            if name == "request_last_kv_block_offset":
+                reference = self.request_last_kv_block_offset[paused:total]
+            else:
+                reference = getattr(self, name)[:num_tokens]
+            if not torch.equal(fast_value, reference):
+                bad = int((fast_value != reference).sum())
+                mismatches.append(f"{name}: {bad} of {reference.numel()} elements differ")
+        if mismatches:
+            raise AssertionError(
+                "MCORE_INFER_VEC_UPDATE_REQS verification failed at step "
+                f"{self.step_count}: " + "; ".join(mismatches)
+            )
+
+    def _write_token_bookkeeping_reference(
+        self,
+        active_request_count: int,
+        num_generated_tokens: int,
+        next_tokens: Tensor,
+        prev_last_block_ids: Optional[Tensor],
+        new_speculative_tokens: Optional[Tensor] = None,
+    ) -> None:
+        """Per-token bookkeeping for the next forward pass (general path)."""
         # Clone needed: old_offsets is reused later to compute raw_positions
         # for block-boundary detection. The write-back on the next line overwrites the
         # underlying tensor, so without clone the boundary-crossing logic would see the
@@ -4806,11 +4950,6 @@ class DynamicInferenceContext(BaseInferenceContext):
 
             # Convert back to 1d tensor
             self.token_to_block_idx[: self.active_token_count] = block_idx.flatten()
-
-        return {
-            "newly_paused_request_ids": newly_paused_request_ids,
-            "evict_request_ids": evict_request_ids,
-        }
 
     def _processed_log_probs(
         self,

--- a/megatron/core/inference/copy_trace.py
+++ b/megatron/core/inference/copy_trace.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+
+"""One-shot naming of the copies inside a single decode layer.
+
+A per-kernel budget can say "there is one 2.7 us bf16 copy per layer" but not
+which line of Python asks for it, because at decode every kernel is replayed
+from a captured graph and has no launch-site backtrace left in the profile. This
+mode runs one layer under a dispatch interceptor and prints each copy-like op
+once, with its shape and the Megatron frames that requested it — enough to
+decide whether the copy is removable or has to be fused.
+
+Enable with ``MCORE_COPY_TRACE=1``; it disarms itself after the first layer, so
+the cost is one layer's worth of Python dispatch on one step.
+"""
+
+# Reports go to stdout/stderr on purpose: this runs inside a multi-rank inference
+# server whose logger configuration is the caller's, and a diagnostic must not
+# depend on it.
+# pylint: disable=bad-builtin
+
+import os
+import traceback
+from typing import Any, Dict, Optional, Tuple
+
+import torch
+from torch.utils._python_dispatch import TorchDispatchMode
+
+ENABLED: bool = os.environ.get("MCORE_COPY_TRACE", "0") == "1"
+SKIP: int = int(os.environ.get("MCORE_COPY_TRACE_SKIP", "500"))
+
+# Ops that move bytes without changing them: the copies a fusion could remove.
+_WATCHED = {"copy_", "_to_copy", "clone", "contiguous", "cat", "index_select", "gather"}
+
+_armed: bool = ENABLED
+_calls: int = 0
+_seen: Dict[Tuple, int] = {}
+
+
+def _describe(t: Any) -> str:
+    if isinstance(t, torch.Tensor):
+        layout = "" if t.is_contiguous() else " strided"
+        return f"{tuple(t.shape)}{layout} {str(t.dtype).split('.')[-1]}"
+    return type(t).__name__
+
+
+def _callsite() -> str:
+    """The innermost Megatron frames, skipping this module and torch internals."""
+    frames = []
+    for f in reversed(traceback.extract_stack()[:-2]):
+        if "/torch/" in f.filename or f.filename.endswith("copy_trace.py"):
+            continue
+        frames.append(f"{os.path.basename(f.filename)}:{f.lineno} {f.name}")
+        if len(frames) == 3:
+            break
+    return " <- ".join(frames)
+
+
+class _CopyTrace(TorchDispatchMode):
+    def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+        kwargs = kwargs or {}
+        name = getattr(getattr(func, "overloadpacket", None), "__name__", str(func))
+        if name in _WATCHED:
+            key = (name, tuple(_describe(a) for a in args[:2]), _callsite())
+            _seen[key] = _seen.get(key, 0) + 1
+        return func(*args, **kwargs)
+
+
+def ready() -> bool:
+    """True once enough layer forwards have gone by to be past one-time work.
+
+    Arming on the *first* forward catches the lazy expert-weight consolidation and
+    reports 32 weight copies per layer, which is one-time cost misread as per-step.
+    Gating on ``inference_context.is_decode_only()`` instead looked more precise but
+    never fired at all: by the time the layer runs under graph capture the context
+    is not reaching it as a keyword argument. A call counter needs nothing from the
+    caller — ``MCORE_COPY_TRACE_SKIP`` forwards (default 500, i.e. past 48 layers of
+    first-touch several times over) are ignored, then the next one is traced.
+    """
+    global _calls
+    if not _armed:
+        return False
+    _calls += 1
+    return _calls > SKIP
+
+
+def trace_one_layer() -> Optional[_CopyTrace]:
+    """Return a mode to wrap one layer with, or None once already traced."""
+    global _armed
+    if not _armed:
+        return None
+    _armed = False
+    return _CopyTrace()
+
+
+def report() -> None:
+    """Print what the traced layer copied, widest tensor first."""
+    if not _seen:
+        return
+    print("===== MCORE_COPY_TRACE: copy-like ops in one decode layer =====", flush=True)
+    for (name, operands, site), count in sorted(_seen.items(), key=lambda kv: -kv[1]):
+        print(f"  {count:3d}x {name:14s} {' | '.join(operands):48s} {site}", flush=True)
+    print("=" * 62, flush=True)
+    _seen.clear()

--- a/megatron/core/inference/dispatch_ballast.py
+++ b/megatron/core/inference/dispatch_ballast.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+
+"""Calibration ballast: add N no-op kernel nodes per layer to the decode graph.
+
+This is not an optimization and must stay off in any measured configuration. It
+exists to answer one question that four sessions of fusion work have had to
+guess at: what does *one more kernel node* cost inside the captured decode
+graph? Fusing two kernels into one removes both the second kernel's device time
+and its node, and the two cannot be separated after the fact — so measure the
+sum directly by adding nodes that do no useful work.
+
+Set ``MCORE_DISPATCH_BALLAST=<n>`` to launch n extra one-element kernels per
+transformer layer. Step time against n gives the per-node cost, which converts
+any future "this fusion removes K launches" into an expected throughput gain.
+"""
+
+import os
+
+import torch
+
+COUNT: int = int(os.environ.get("MCORE_DISPATCH_BALLAST", "0"))
+
+_scratch = None
+
+
+def tick() -> None:
+    """Launch ``COUNT`` minimal kernels, serialized on one scratch element."""
+    if COUNT <= 0:
+        return
+    global _scratch
+    if _scratch is None:
+        _scratch = torch.zeros(1, device=torch.cuda.current_device())
+    for _ in range(COUNT):
+        _scratch.add_(1.0)

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -5,6 +5,7 @@ import concurrent.futures
 import logging
 import math
 import multiprocessing
+import os
 import socket
 import time
 import warnings
@@ -69,6 +70,13 @@ from megatron.core.utils import (
 )
 
 from .async_zmq_communicator import AsyncZMQCommunicator
+
+# Collapsed per-request loop body in `post_process_requests` for the plain decode
+# case. Off by default; see `DynamicInferenceEngine._post_process_requests_decode_fast`.
+_FAST_POST_PROCESS = os.environ.get("MCORE_INFER_FAST_POST_PROCESS", "0") == "1"
+# Debug mode: take the fast path, then replay the same step through the reference
+# loop on a deep copy of the request state and assert the two agree exactly.
+_FAST_POST_PROCESS_VERIFY = os.environ.get("MCORE_INFER_FAST_POST_PROCESS_VERIFY", "0") == "1"
 
 try:
     from tqdm import tqdm
@@ -360,6 +368,14 @@ class DynamicInferenceEngine(AbstractEngine):
         self.stop_word_finished_request_ids: set[int] = set()
         # Track requests currently being finished due to stop words (to skip extra token)
         self.stop_word_being_finished_ids: set[int] = set()
+
+        # Resolved (request object, token limit) pairs for the decode fast path in
+        # `post_process_requests`, keyed by the active request-id tuple and an epoch
+        # that any mutation of `self.requests` or of a request record bumps.
+        self._ppr_cache_epoch: int = 0
+        self._ppr_fast_key: Optional[Tuple] = None
+        self._ppr_fast_requests: List[DynamicInferenceRequest] = []
+        self._ppr_fast_limits: List[int] = []
 
         # Timing and logging variables.
         self.rank = torch.distributed.get_rank()
@@ -900,6 +916,7 @@ class DynamicInferenceEngine(AbstractEngine):
         # Checkpoint active requests that are marked for recompute.
         for request_id in recompute_active_ids:
             self.requests[request_id].record.checkpoint()
+            self._ppr_cache_epoch += 1
 
         # If we are not using the inference coordinator, we need to manually handle state.
         if not self.use_coordinator:
@@ -1081,6 +1098,7 @@ class DynamicInferenceEngine(AbstractEngine):
                 record=DynamicInferenceRequestRecord.from_request(request),
                 future=self._loop.create_future(),
             )
+            self._ppr_cache_epoch += 1
             request.add_event_add_engine()  # Record when request enters engine
 
             # Stamp new request with the current generation epoch.
@@ -1280,6 +1298,21 @@ class DynamicInferenceEngine(AbstractEngine):
         Returns:
             A list of active requests and completed requests as `DynamicInferenceRequest` objects
         """
+        if _FAST_POST_PROCESS:
+            fast_result = self._post_process_requests_decode_fast(
+                request_ids,
+                finished_request_ids,
+                evict_request_ids,
+                step_time,
+                sample,
+                accepted_tokens,
+                log_probs,
+                top_n_logprobs,
+                finished_routing_block_ids,
+            )
+            if fast_result is not None:
+                return fast_result
+
         active_request_ids: list[int] = []
         finished_request_ids = set(finished_request_ids.tolist())
         finished_request_records: list[DynamicInferenceRequestRecord] = []
@@ -1563,12 +1596,118 @@ class DynamicInferenceEngine(AbstractEngine):
             # Checkpoint requests (i.e., prompt += generations) + add eviction event.
             for request_id in evict_request_ids:
                 self.requests[request_id].record.checkpoint()
+                self._ppr_cache_epoch += 1
                 self.get_request(request_id).add_event_evict()
 
         # Clear the stop word being finished set after processing
         self.stop_word_being_finished_ids.clear()
 
         return active_request_ids, finished_request_records
+
+    def _post_process_requests_decode_fast(
+        self,
+        request_ids: torch.Tensor,
+        finished_request_ids: torch.Tensor,
+        evict_request_ids: Optional[torch.Tensor],
+        step_time: float,
+        sample: torch.Tensor,
+        accepted_tokens: Optional[torch.Tensor],
+        log_probs: Optional[List],
+        top_n_logprobs: Optional[Dict],
+        finished_routing_block_ids: Optional[Dict],
+    ) -> Optional[Tuple[List[int], List[DynamicInferenceRequestRecord]]]:
+        """Collapsed `post_process_requests` body for a plain decode step.
+
+        Returns `None` whenever anything about the step is not the plain case, in
+        which case the caller runs the full loop. The plain case is: one sampled
+        token per request, no request finishing, no speculative decoding, no stop
+        words, no log probs or top-n log probs, no chunked prefill, no eviction,
+        no token event tracking, and no TPOT sample due this step.
+
+        Deliberately excluding steps where a request finishes is what keeps this
+        safe: the request termination state machine — pop, future resolution,
+        routing reconstruction, status and finish events — is never reached from
+        here, so it stays on the single well-tested path. At BS256 steady-state
+        decode essentially every step has no finisher, so almost all of the work
+        is still avoided.
+
+        The only per-request state this touches is appending one token, under the
+        same `num_tokens_to_generate` bound the reference applies, plus the
+        first-token TTFT sample.
+        """
+        if (
+            self.num_speculative_tokens > 0
+            or accepted_tokens is not None
+            or log_probs
+            or top_n_logprobs is not None
+            or finished_routing_block_ids
+            or self.track_generated_token_events
+            or self.stop_word_being_finished_ids
+            or self.stop_word_finished_request_ids
+            or self.context.chunked_prefill_request_id != -1
+            or step_time > 0
+            or finished_request_ids.numel() > 0
+            or (evict_request_ids is not None and evict_request_ids.numel() > 0)
+        ):
+            self._ppr_fast_key = None
+            return None
+
+        request_id_list = request_ids.tolist()
+        key = (self._ppr_cache_epoch, tuple(request_id_list))
+        if self._ppr_fast_key != key:
+            entries = self.requests
+            if not all(request_id in entries for request_id in request_id_list):
+                self._ppr_fast_key = None
+                return None
+            requests = [entries[request_id].record[-1] for request_id in request_id_list]
+            # A configured stop word would need the post-append scan, which is the
+            # one piece of per-request work here that is not a bounded append.
+            if any(request.stop_word_ids for request in requests):
+                self._ppr_fast_key = None
+                return None
+            self._ppr_fast_key = key
+            self._ppr_fast_requests = requests
+            self._ppr_fast_limits = [
+                request.sampling_params.num_tokens_to_generate for request in requests
+            ]
+
+        requests = self._ppr_fast_requests
+        limits = self._ppr_fast_limits
+        tokens = sample.tolist()
+
+        if _FAST_POST_PROCESS_VERIFY:
+            expected = [
+                list(request.generated_tokens)
+                + ([token] if len(request.generated_tokens) < limit else [])
+                for request, limit, token in zip(requests, limits, tokens)
+            ]
+
+        for i, token in enumerate(tokens):
+            request = requests[i]
+            generated = request.generated_tokens
+            num_generated = len(generated)
+            # Mirrors the reference trim: with one token the whole append is kept
+            # when the request is below its limit and dropped entirely when it is
+            # already at or past it.
+            if num_generated < limits[i]:
+                generated.append(token)
+                if num_generated == 0:
+                    request.ttft = (
+                        DynamicInferenceEvent(
+                            type=DynamicInferenceEventType.GENERATED_TOKEN,
+                            payload={"token_id": token},
+                        ).timestamp
+                        - request.event_add_engine.timestamp
+                    )
+
+        if _FAST_POST_PROCESS_VERIFY:
+            for request, want in zip(requests, expected):
+                assert request.generated_tokens == want, (
+                    f"fast post_process_requests mismatch for request {request.request_id}: "
+                    f"got {request.generated_tokens[-4:]} want {want[-4:]}"
+                )
+
+        return request_id_list, []
 
     def _get_and_clear_stop_word_finished_ids(self, active_request_ids: list[int]) -> set[int]:
         """Get and clear the set of request IDs that should be finished due to stop words.

--- a/megatron/core/inference/engines/dynamic_engine.py
+++ b/megatron/core/inference/engines/dynamic_engine.py
@@ -55,6 +55,7 @@ from megatron.core.transformer.cuda_graphs import CudaGraphManager, delete_cuda_
 from megatron.core.transformer.enums import InferenceCudaGraphScope
 from megatron.core.transformer.moe.router_replay import RouterReplay, RouterReplayAction
 from megatron.core.utils import (
+    configure_nvtx_profiling,
     deprecate_args,
     experimental_api,
     get_asyncio_loop,
@@ -279,6 +280,35 @@ class DynamicInferenceEngine(AbstractEngine):
         # Initialization options.
         self.controller = controller
         self.context = context
+
+        # Profiling aid: the engine's per-step NVTX ranges (bookkeeping,
+        # detokenization, console_logging, ...) are inert unless NVTX profiling
+        # is enabled, which only the training loop does. Allow the inference
+        # server to opt in via env so an nsys ``cuda,nvtx`` capture can attribute
+        # the host chain between decode steps. Default off (no-op).
+        if os.environ.get("MCORE_INFER_NVTX", "0") == "1":
+            configure_nvtx_profiling(True)
+
+        # Zero-nsys host-phase timing: patches the decode loop's NVTX range
+        # push/pop names with perf_counter self-timers and prints a per-step
+        # breakdown. Env-gated (``MCORE_INFER_HOST_TIMING``); no-op by default.
+        from megatron.core.inference.host_phase_timing import install as _install_host_timing
+
+        _install_host_timing()
+
+        # GPU-side step accounting: times the transformer-block CUDA graph with
+        # CUDA events and records per-rank step-entry timestamps for EP skew.
+        # Env-gated (``MCORE_INFER_STEP_GPU_TIMING``); no-op by default.
+        from megatron.core.inference.step_gpu_timing import install as _install_step_gpu_timing
+
+        _install_step_gpu_timing()
+
+        # Host cost of CUDA graph replay, measured with no profiler attached, because
+        # the profiled figure is confounded by node-level graph tracing.
+        # Env-gated (``MCORE_GRAPH_LAUNCH_TIMING``); no-op by default.
+        from megatron.core.inference.graph_launch_timing import install as _install_graph_timing
+
+        _install_graph_timing()
 
         self.num_speculative_tokens = inference_config.num_speculative_tokens
         self.materialize_only_last_token_logits = (

--- a/megatron/core/inference/fused_add_rmsnorm.py
+++ b/megatron/core/inference/fused_add_rmsnorm.py
@@ -1,0 +1,176 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Single-launch fused residual-add + RMSNorm for the decode path.
+
+Every transformer block boundary in the ``inference_optimized`` path runs a
+bias-dropout-add (``get_bias_dropout_add``; for Qwen this is a plain
+``residual + hidden`` since there is no bias and dropout is disabled at decode)
+immediately followed by an RMSNorm (``input_layernorm`` / ``pre_mlp_layernorm``).
+In the profile these are two separate kernels per boundary — a
+``triton_poi_fused_add_copy`` (~1.5 µs) then a TE ``rmsnorm_fwd_tuned``
+(~2.9 µs) — i.e. two launches and two CUDA-graph nodes per boundary, ×2 per
+layer ×48 layers. vLLM instead runs one ``triton_..._add_..._rms_norm`` kernel.
+
+This module provides that single kernel: ``new_residual = hidden + residual``
+followed by ``rmsnorm(new_residual) * gamma``, returning both the normalized
+activation (for the next GEMM) and the updated residual (for the next
+bias-dropout-add). The add is done in fp32 and rounded to bf16, matching
+PyTorch's bf16 add; the RMSNorm is fp32 mean-of-squares → ``rsqrt(var+eps)`` →
+(optionally 1-centered) gamma, matching TE's RMSNorm to bf16 rounding.
+
+Env-gated (``MCORE_FUSED_ADD_NORM``); default off so the untouched two-kernel
+path is used unless explicitly enabled.
+"""
+
+import os
+from typing import Tuple
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+
+    HAVE_TRITON = True
+except ImportError:
+    HAVE_TRITON = False
+
+USE_FUSED_ADD_NORM: bool = os.environ.get("MCORE_FUSED_ADD_NORM", "0") == "1"
+
+# The one-row-per-CTA kernel is launch/latency bound; it wins in the decode
+# regime and should not be used for large prefill token counts.
+FUSED_ADD_NORM_MAX_TOKENS: int = int(os.environ.get("MCORE_FUSED_ADD_NORM_MAX_TOKENS", "256"))
+
+
+if HAVE_TRITON:
+
+    @triton.jit
+    def _fused_add_rmsnorm_kernel(
+        x_ptr,
+        res_ptr,
+        w_ptr,
+        o_ptr,
+        nr_ptr,
+        x_rs,
+        res_rs,
+        o_rs,
+        nr_rs,
+        eps,
+        H: tl.constexpr,
+        ZERO_CENTERED: tl.constexpr,
+        BLOCK: tl.constexpr,
+    ):
+        """One CTA per token row: add the residual, store it, then RMSNorm."""
+        row = tl.program_id(0)
+        cols = tl.arange(0, BLOCK)
+        mask = cols < H
+
+        x = tl.load(x_ptr + row * x_rs + cols, mask=mask, other=0.0).to(tl.float32)
+        r = tl.load(res_ptr + row * res_rs + cols, mask=mask, other=0.0).to(tl.float32)
+        s = x + r
+        tl.store(nr_ptr + row * nr_rs + cols, s.to(nr_ptr.dtype.element_ty), mask=mask)
+
+        var = tl.sum(s * s, axis=0) / H
+        inv = 1.0 / tl.sqrt(var + eps)
+        w = tl.load(w_ptr + cols, mask=mask, other=0.0).to(tl.float32)
+        if ZERO_CENTERED:
+            w = w + 1.0
+        y = s * inv * w
+        tl.store(o_ptr + row * o_rs + cols, y.to(o_ptr.dtype.element_ty), mask=mask)
+
+
+def _next_pow2(n: int) -> int:
+    p = 1
+    while p < n:
+        p <<= 1
+    return p
+
+
+def fused_add_rmsnorm(
+    hidden: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    zero_centered_gamma: bool,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Fuse ``residual + hidden`` and RMSNorm into one launch.
+
+    Args:
+        hidden: activation to add to the residual; ``[.., H]`` (last dim
+            normalized, must be contiguous).
+        residual: residual stream tensor, same shape as ``hidden``.
+        weight: ``[H]`` RMSNorm gamma.
+        eps: RMSNorm epsilon.
+        zero_centered_gamma: if True, apply ``(1 + gamma)`` (matches TE).
+
+    Returns:
+        ``(normed, new_residual)`` — ``normed`` feeds the next GEMM, and
+        ``new_residual = hidden + residual`` is carried to the next add.
+    """
+    hn = hidden.shape[-1]
+    x2 = hidden.reshape(-1, hn)
+    r2 = residual.reshape(-1, hn)
+
+    o = torch.empty(hidden.shape, dtype=hidden.dtype, device=hidden.device)
+    nr = torch.empty(hidden.shape, dtype=hidden.dtype, device=hidden.device)
+    o2 = o.view(-1, hn)
+    nr2 = nr.view(-1, hn)
+
+    n_rows = x2.shape[0]
+    block = _next_pow2(hn)
+    _fused_add_rmsnorm_kernel[(n_rows,)](
+        x2,
+        r2,
+        weight,
+        o2,
+        nr2,
+        x2.stride(0),
+        r2.stride(0),
+        o2.stride(0),
+        nr2.stride(0),
+        float(eps),
+        H=hn,
+        ZERO_CENTERED=zero_centered_gamma,
+        BLOCK=block,
+        num_warps=8,
+    )
+    return o, nr
+
+
+def _tensors_compatible(w: torch.Tensor, hidden: torch.Tensor, residual: torch.Tensor) -> bool:
+    """Shared shape/layout/token-count check for the fused add+RMSNorm kernel.
+
+    This runs once per layer per decode step, so it short-circuits on the
+    cheapest checks first and allocates nothing.
+    """
+    hn = hidden.shape[-1]
+    if hidden.shape != residual.shape or hn != w.numel():
+        return False
+    if not (hidden.is_cuda and residual.is_cuda):
+        return False
+    if hidden.stride(-1) != 1 or residual.stride(-1) != 1:
+        return False
+    n_tokens = 1
+    for d in hidden.shape[:-1]:
+        n_tokens *= d
+    if n_tokens > FUSED_ADD_NORM_MAX_TOKENS:
+        return False
+    return True
+
+
+def can_use_fused_add_rmsnorm(norm_module, hidden: torch.Tensor, residual: torch.Tensor) -> bool:
+    """Whether the fused kernel reproduces this exact add+RMSNorm contract.
+
+    Requires a weight-only RMSNorm module (no bias), matching contiguous
+    ``[.., H]`` shapes on CUDA, and a decode-sized token count.
+    """
+    if not (HAVE_TRITON and USE_FUSED_ADD_NORM):
+        return False
+    if norm_module is None:
+        return False
+    w = getattr(norm_module, "weight", None)
+    if w is None:
+        return False
+    if getattr(norm_module, "bias", None) is not None:
+        return False
+    return _tensors_compatible(w, hidden, residual)

--- a/megatron/core/inference/fused_add_rmsnorm.py
+++ b/megatron/core/inference/fused_add_rmsnorm.py
@@ -27,6 +27,8 @@ from typing import Optional, Tuple
 
 import torch
 
+from megatron.core.inference import fusion_diag as _diag
+
 try:
     import triton
     import triton.language as tl
@@ -143,12 +145,18 @@ def fused_add_rmsnorm(
     return o, nr
 
 
-def _tensors_compatible(w: torch.Tensor, hidden: torch.Tensor, residual: torch.Tensor) -> bool:
+def _tensors_compatible(
+    w: torch.Tensor, hidden: torch.Tensor, residual: torch.Tensor, site: str = ""
+) -> bool:
     """Shared shape/layout/token-count check for the fused add+RMSNorm kernel.
 
-    This runs once per layer per decode step, so it short-circuits on the
-    cheapest checks first and allocates nothing.
+    This runs twice per layer per decode step, so it keeps the original
+    short-circuiting form: the diagnostic breakdown is built only when
+    ``MCORE_FUSION_DIAG`` is set, never on the default path.
     """
+    if _diag.ENABLED and site:
+        _report_compatibility(w, hidden, residual, site)
+
     hn = hidden.shape[-1]
     if hidden.shape != residual.shape or hn != w.numel():
         return False
@@ -162,6 +170,33 @@ def _tensors_compatible(w: torch.Tensor, hidden: torch.Tensor, residual: torch.T
     if n_tokens > FUSED_ADD_NORM_MAX_TOKENS:
         return False
     return True
+
+
+def _report_compatibility(
+    w: torch.Tensor, hidden: torch.Tensor, residual: torch.Tensor, site: str
+) -> None:
+    """Name the individual compatibility check that rejects this call site.
+
+    Split out because a gate that silently returns False is unfalsifiable from a
+    profile: `FUSION-INERT-S17` spent a session on a fusion that was enabled and
+    never firing, which this would have answered immediately.
+    """
+    n_tokens = 1
+    for d in hidden.shape[:-1]:
+        n_tokens *= d
+    _diag.report(
+        site,
+        lambda: {
+            "shapes_match": hidden.shape == residual.shape,
+            "gamma_matches_H": hidden.shape[-1] == w.numel(),
+            "on_cuda": hidden.is_cuda and residual.is_cuda,
+            "last_dim_contiguous": hidden.stride(-1) == 1 and residual.stride(-1) == 1,
+            "decode_sized": n_tokens <= FUSED_ADD_NORM_MAX_TOKENS,
+            "info:n_tokens": n_tokens,
+            "info:max_tokens": FUSED_ADD_NORM_MAX_TOKENS,
+            "info:hidden": tuple(hidden.shape),
+        },
+    )
 
 
 def can_use_fused_add_rmsnorm(norm_module, hidden: torch.Tensor, residual: torch.Tensor) -> bool:
@@ -179,7 +214,7 @@ def can_use_fused_add_rmsnorm(norm_module, hidden: torch.Tensor, residual: torch
         return False
     if getattr(norm_module, "bias", None) is not None:
         return False
-    return _tensors_compatible(w, hidden, residual)
+    return _tensors_compatible(w, hidden, residual, site="pre_mlp_layernorm")
 
 
 def can_use_fused_add_rmsnorm_qkv(
@@ -196,4 +231,4 @@ def can_use_fused_add_rmsnorm_qkv(
         return False
     if weight is None:
         return False
-    return _tensors_compatible(weight, hidden, residual)
+    return _tensors_compatible(weight, hidden, residual, site="next_layer_qkv_norm")

--- a/megatron/core/inference/fused_add_rmsnorm.py
+++ b/megatron/core/inference/fused_add_rmsnorm.py
@@ -23,7 +23,7 @@ path is used unless explicitly enabled.
 """
 
 import os
-from typing import Tuple
+from typing import Optional, Tuple
 
 import torch
 
@@ -36,6 +36,12 @@ except ImportError:
     HAVE_TRITON = False
 
 USE_FUSED_ADD_NORM: bool = os.environ.get("MCORE_FUSED_ADD_NORM", "0") == "1"
+
+# Same kernel applied one boundary later: the ``mlp_bda`` residual add at the end of
+# a layer, fused with the *next* layer's QKV input RMSNorm. Gated separately so the
+# two fusions can be A/B'd independently -- this one reaches across the layer
+# boundary and into ``linear_qkv``, so it carries more structural risk.
+USE_FUSED_ADD_NORM_QKV: bool = os.environ.get("MCORE_FUSED_ADD_NORM_QKV", "0") == "1"
 
 # The one-row-per-CTA kernel is launch/latency bound; it wins in the decode
 # regime and should not be used for large prefill token counts.
@@ -174,3 +180,20 @@ def can_use_fused_add_rmsnorm(norm_module, hidden: torch.Tensor, residual: torch
     if getattr(norm_module, "bias", None) is not None:
         return False
     return _tensors_compatible(w, hidden, residual)
+
+
+def can_use_fused_add_rmsnorm_qkv(
+    weight: Optional[torch.Tensor], hidden: torch.Tensor, residual: torch.Tensor
+) -> bool:
+    """Whether the fused kernel can absorb the *next* layer's QKV input RMSNorm.
+
+    Separate gate from :data:`USE_FUSED_ADD_NORM` because this fuses across the
+    layer boundary: the norm being absorbed belongs to the following layer's
+    ``linear_qkv``, and its weight arrives as a raw tensor
+    (``layer_norm_weight``) rather than as a norm module.
+    """
+    if not (HAVE_TRITON and USE_FUSED_ADD_NORM_QKV):
+        return False
+    if weight is None:
+        return False
+    return _tensors_compatible(weight, hidden, residual)

--- a/megatron/core/inference/fusion_diag.py
+++ b/megatron/core/inference/fusion_diag.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""One-shot reporting of why a decode fusion did or did not engage.
+
+Several fusions in the decode path are env-gated *and* guarded by a conjunction of
+runtime conditions. When the gate is on but the fused kernel never appears in a
+profile, the gate is not the problem -- one of the guards is silently false, and
+there is no way to tell which from the outside.
+
+Set ``MCORE_FUSION_DIAG=1`` to have each call site print its guard values, once per
+*distinct verdict* rather than once per site. Reporting only the first call is a trap:
+the first call is prefill, where a decode-only token-count guard blocks the fusion by
+design, so a first-call-only report says "blocked" for a fusion that may well engage
+during decode. Keying on the verdict shows both outcomes.
+
+Off by default and free when off: the caller passes a lambda, so the condition dict is
+not even built unless diagnostics are on.
+"""
+
+# Reports go to stderr on purpose: this runs inside a multi-rank inference server
+# whose logger configuration is the caller's, and a diagnostic must not depend on it.
+# pylint: disable=bad-builtin
+
+import os
+import sys
+from typing import Callable, Dict
+
+ENABLED: bool = os.environ.get("MCORE_FUSION_DIAG", "0") == "1"
+
+# Bound the output: a pathological site whose verdict varies every call must not turn
+# into an unbounded log.
+MAX_REPORTS: int = int(os.environ.get("MCORE_FUSION_DIAG_MAX", "12"))
+
+_seen: set = set()
+_count: int = 0
+
+
+def report(site: str, conditions: Callable[[], Dict[str, object]]) -> None:
+    """Print ``site``'s guard values once per distinct verdict, naming the blockers."""
+    global _count
+    if not ENABLED or _count >= MAX_REPORTS:
+        return
+    try:
+        conds = conditions()
+    except Exception as e:  # a diagnostic must never break the run it is diagnosing
+        print(f"[FUSION_DIAG] {site}: could not evaluate conditions: {e}", file=sys.stderr)
+        return
+
+    # Keys prefixed "info:" carry values rather than pass/fail, so they must not count
+    # as blockers when falsy (a shape tuple or token count is never a verdict).
+    checks = {k: v for k, v in conds.items() if not k.startswith("info:")}
+    blockers = [k for k, v in checks.items() if not v]
+    verdict = "ENGAGED" if not blockers else f"BLOCKED by {blockers}"
+
+    key = (site, verdict)
+    if key in _seen:
+        return
+    _seen.add(key)
+    _count += 1
+
+    # One line per report keeps the four ranks' interleaved stderr readable; the
+    # multi-line form was unparseable when ranks wrote concurrently.
+    detail = " ".join(f"{k[5:] if k.startswith('info:') else k}={v!r}" for k, v in conds.items())
+    print(f"[FUSION_DIAG] {site}: {verdict} | {detail}", file=sys.stderr, flush=True)

--- a/megatron/core/inference/graph_launch_timing.py
+++ b/megatron/core/inference/graph_launch_timing.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Host-side cost of CUDA graph replay, measured without a profiler.
+
+`GAP-DECOMP-S17` found `cudaGraphLaunch` accounting for ~707 us/step of exposed GPU
+idle at ~191 us per call, which would make it the single largest item in the 1.645 ms
+idle budget. That number is not trustworthy on its own: both traces were captured with
+``--cuda-graph-trace=node``, and node-level tracing makes the driver do per-node work
+inside the launch, which can inflate a normally-cheap graph launch by an order of
+magnitude. A profiler cannot settle a question about profiler overhead.
+
+This module measures it with ``time.perf_counter_ns`` around
+``torch.cuda.CUDAGraph.replay`` and no profiler attached. The host cost of a replay is
+pure launch submission -- it does not wait for the GPU -- so wall time around the call
+is exactly the quantity of interest.
+
+Enable with ``MCORE_GRAPH_LAUNCH_TIMING=1``. Reports median rather than mean because
+the first replays after capture are not representative.
+"""
+
+# Reports go to stderr on purpose: this runs inside a multi-rank inference server
+# whose logger configuration is the caller's, and a diagnostic must not depend on it.
+# pylint: disable=bad-builtin
+
+import atexit
+import os
+import sys
+import time
+from typing import Dict, List
+
+ENABLED: bool = os.environ.get("MCORE_GRAPH_LAUNCH_TIMING", "0") == "1"
+
+# Skip the first replays: allocator warmup and first-touch page faults land there.
+SKIP: int = int(os.environ.get("MCORE_GRAPH_LAUNCH_SKIP", "20"))
+# Report periodically, not only at exit: the benchmark harness SIGTERMs the server,
+# which skips atexit handlers, so an exit-only report usually prints nothing.
+REPORT_EVERY: int = int(os.environ.get("MCORE_GRAPH_LAUNCH_REPORT_EVERY", "2000"))
+
+_samples: Dict[int, List[int]] = {}
+_calls = 0
+_installed = False
+
+
+def install() -> None:
+    """Wrap ``CUDAGraph.replay`` to record host wall time per call, keyed by graph."""
+    global _installed
+    if _installed or not ENABLED:
+        return
+    import torch
+
+    orig = torch.cuda.CUDAGraph.replay
+
+    def timed_replay(self, *args, **kwargs):
+        global _calls
+        t0 = time.perf_counter_ns()
+        out = orig(self, *args, **kwargs)
+        dt = time.perf_counter_ns() - t0
+        _samples.setdefault(id(self), []).append(dt)
+        _calls += 1
+        if REPORT_EVERY > 0 and _calls % REPORT_EVERY == 0:
+            report()
+        return out
+
+    torch.cuda.CUDAGraph.replay = timed_replay
+    atexit.register(report)
+    _installed = True
+    print(
+        f"[GRAPH_LAUNCH] host timing installed (skip {SKIP}, report every {REPORT_EVERY})",
+        file=sys.stderr,
+        flush=True,
+    )
+
+
+def report() -> None:
+    """Print per-graph and aggregate host replay cost."""
+    if not ENABLED or not _samples:
+        return
+    lines = ["[GRAPH_LAUNCH] host cost of CUDAGraph.replay (no profiler attached)"]
+    total_median_us = 0.0
+    total_calls = 0
+    for i, (gid, xs) in enumerate(sorted(_samples.items(), key=lambda kv: -len(kv[1]))):
+        ys = sorted(xs[SKIP:]) or sorted(xs)
+        med = ys[len(ys) // 2] / 1000.0
+        p90 = ys[int(len(ys) * 0.9)] / 1000.0
+        total_median_us += med
+        total_calls += 1
+        lines.append(f"[GRAPH_LAUNCH]   graph#{i}: n={len(xs)} median={med:.2f}us p90={p90:.2f}us")
+    lines.append(
+        f"[GRAPH_LAUNCH] distinct graphs={total_calls} "
+        f"sum-of-medians={total_median_us:.1f}us "
+        f"(compare: profiled trace claimed ~191us/launch x4 = 766us/step)"
+    )
+    print("\n".join(lines), file=sys.stderr, flush=True)

--- a/megatron/core/inference/host_phase_timing.py
+++ b/megatron/core/inference/host_phase_timing.py
@@ -1,0 +1,165 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Zero-nsys host-phase timing for the dynamic inference decode loop.
+
+The decode step's host chain between CUDA-graph replays is bracketed by NVTX
+ranges (``initialize_attention_state``, ``forward_pass``, ``sampling``,
+``transfer_samples_to_cpu``, ``active_request_mask``, ``update_requests`` in the
+controller; ``bookkeeping`` / ``detokenization`` in the engine). Those are raw
+``torch.cuda.nvtx`` / gated ``nvtx_range_*`` calls that are inert without a
+profiler attached — and the profiler that would name them (nsys with NVTX under
+CUDA graphs) deadlocks finalization on this workload.
+
+This shim monkeypatches those range push/pop names with ``perf_counter``
+self-timers (a shared nesting stack, so each label reports self-time excluding
+children) and periodically prints a per-step breakdown to stderr. It needs no
+nsys and no CUDA-graph interaction, so it safely names the between-step Python
+phases that the clean-trace idle attribution localized. Env-gated
+(``MCORE_INFER_HOST_TIMING``); default off (``install`` is a no-op).
+"""
+
+# Reports go to stderr on purpose: this runs inside a multi-rank inference server
+# whose logger configuration is the caller's, and a diagnostic must not depend on it.
+# pylint: disable=bad-builtin
+
+import os
+import sys
+import threading
+import time
+
+USE_HOST_TIMING: bool = os.environ.get("MCORE_INFER_HOST_TIMING", "0") == "1"
+# Print the running breakdown every N times the step label is popped.
+_REPORT_EVERY: int = int(os.environ.get("MCORE_INFER_HOST_TIMING_EVERY", "32"))
+# The once-per-step range whose pop delimits a decode step for the per-step avg.
+_STEP_LABEL: str = os.environ.get("MCORE_INFER_HOST_TIMING_STEP_LABEL", "forward_pass")
+
+_lock = threading.Lock()
+_totals: dict = {}  # label -> [self_ns, count]
+_stack: list = []  # [label, start_ns, children_ns]
+_step_count: int = 0
+_installed: bool = False
+
+
+def _push(msg=None, *args, **kwargs):
+    _stack.append([msg if msg is not None else "<anon>", time.perf_counter_ns(), 0])
+
+
+def _pop(*args, **kwargs):
+    global _step_count
+    if not _stack:
+        return
+    label, start, children = _stack.pop()
+    dur = time.perf_counter_ns() - start
+    self_ns = dur - children
+    with _lock:
+        t = _totals.setdefault(label, [0, 0])
+        t[0] += self_ns
+        t[1] += 1
+    if _stack:
+        _stack[-1][2] += dur
+    if label == _STEP_LABEL:
+        _step_count += 1
+        if _REPORT_EVERY > 0 and _step_count % _REPORT_EVERY == 0:
+            report()
+
+
+def report():
+    """Print the accumulated per-phase self-time breakdown to stderr."""
+    with _lock:
+        items = sorted(_totals.items(), key=lambda kv: -kv[1][0])
+        n = _step_count or 1
+        lines = [f"[HOST_TIMING] after {_step_count} steps (self-time):"]
+        for label, (ns, c) in items:
+            lines.append(
+                f"  {ns / 1e3 / n:9.1f} us/step   tot {ns / 1e6:8.2f} ms   n={c:7d}   {label}"
+            )
+    print("\n".join(lines), file=sys.stderr, flush=True)
+
+
+# Methods to time individually, as (module, class, [methods]). The coarse ranges
+# localize the cost to ``forward_pass``, but that range is almost entirely one call
+# into the model, so splitting it needs per-method timers rather than more ranges.
+# Missing attributes are skipped, so this list can name methods that only exist on
+# some paths.
+_METHOD_TARGETS = (
+    (
+        "megatron.core.inference.text_generation_controllers.text_generation_controller",
+        "TextGenerationController",
+        (
+            "_dynamic_step_forward_logits",
+            "_router_record_bookkeeping",
+            "_dynamic_step_log_probs_bookkeeping",
+            "_dynamic_step_context_init",
+        ),
+    ),
+    (
+        "megatron.core.inference.model_inference_wrappers.abstract_model_inference_wrapper",
+        "AbstractModelInferenceWrapper",
+        ("run_one_forward_step", "forward_pass_without_pipeline_parallel", "_forward"),
+    ),
+)
+
+
+def _wrap_methods():
+    """Wrap selected methods so their self-time is reported like a range."""
+    import importlib
+
+    for mod_name, cls_name, methods in _METHOD_TARGETS:
+        try:
+            mod = importlib.import_module(mod_name)
+        except ImportError:
+            continue
+        cls = getattr(mod, cls_name, None)
+        if cls is None:
+            continue
+        for meth in methods:
+            fn = getattr(cls, meth, None)
+            if fn is None or getattr(fn, "_host_timed", False):
+                continue
+
+            def make(fn=fn, label=f"{cls_name}.{meth}"):
+                def timed(*args, **kwargs):
+                    _push(label)
+                    try:
+                        return fn(*args, **kwargs)
+                    finally:
+                        _pop()
+
+                timed._host_timed = True
+                return timed
+
+            setattr(cls, meth, make())
+
+
+def install():
+    """Patch the controller / engine range push+pop names with the self-timers."""
+    global _installed
+    if not USE_HOST_TIMING or _installed:
+        return
+    import importlib
+
+    targets = [
+        (
+            "megatron.core.inference.text_generation_controllers.text_generation_controller",
+            "range_push",
+            "range_pop",
+        ),
+        ("megatron.core.inference.engines.dynamic_engine", "nvtx_range_push", "nvtx_range_pop"),
+    ]
+    for mod_name, push_attr, pop_attr in targets:
+        try:
+            mod = importlib.import_module(mod_name)
+        except ImportError:
+            continue
+        if hasattr(mod, push_attr):
+            setattr(mod, push_attr, _push)
+        if hasattr(mod, pop_attr):
+            setattr(mod, pop_attr, _pop)
+    if os.environ.get("MCORE_INFER_HOST_TIMING_METHODS", "1") == "1":
+        _wrap_methods()
+    _installed = True
+    print(
+        f"[HOST_TIMING] installed (report every {_REPORT_EVERY} '{_STEP_LABEL}' pops)",
+        file=sys.stderr,
+        flush=True,
+    )

--- a/megatron/core/inference/insitu_timing.py
+++ b/megatron/core/inference/insitu_timing.py
@@ -1,0 +1,275 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""In-situ per-component timing inside the decode CUDA graph.
+
+This exists because subtraction failed. Ablating a component and reading the change
+in block time works only if the component's absence leaves everything else
+unchanged, and for the MoE decode path it does not:
+``multimem_all_gatherv_3tensor`` produces the routing map that sizes all downstream
+grouped-GEMM work, so removing it silently changes how much work the experts do
+(four failed attempts at exactly this are recorded in
+``skills/run-qwen-model/EXPERIMENTS.md`` under "Measurement approaches that do not
+work"). Nsys is equally unavailable here -- it costs ~28% end-to-end, and
+that overhead is host-side, which desynchronizes the EP ranks and inflates the
+spin-wait NVLS collectives by ~120x.
+
+What is left is to time each component where it stands. An **external** event record
+inside the capture (``cudaEventRecordWithFlags`` with ``cudaEventRecordExternal``)
+becomes a graph node that re-records on every replay, so ``elapsed_time`` after a
+replay yields that replay's duration for the enclosed region. The work descriptor,
+the kernel sequence, and the cross-rank barrier order are all untouched; the only
+addition is two event-record nodes.
+
+The external flag is not optional and PyTorch does not expose it, hence the ctypes
+call on the runtime. A plain ``torch.cuda.Event.record()`` during capture *appears*
+to work -- it raises nothing and becomes a graph node -- but the event carries no
+host-readable timestamp, and ``elapsed_time`` on it fails with
+``cudaErrorInvalidValue``. That was established by standalone probes rather than
+assumed: plain events fail, externally-flagged events work. The flagged record must
+also target the *capturing* stream, which ``torch.cuda.graph()`` picks itself unless
+told otherwise, so the stream is read back at record time rather than assumed --
+getting that wrong returns ``cudaErrorIllegalState`` rather than anything
+descriptive.
+
+Each event pair carries a fixed cost of roughly 5-10 us, which would be a large
+relative error on a 10-40 us component. It is calibrated rather than ignored: a
+``_calib`` site wraps an empty region in the same graph, so its reading *is* the
+per-pair overhead, and every other site is reported both raw and with that
+subtracted. The probe also confirmed the decomposition is additive -- summed sites
+reconstructed the whole graph within 1.3% -- which is what makes subtracting a
+constant legitimate.
+
+Two design points worth stating, because both were the cheap way out of a problem:
+
+1. **Only a couple of occurrences per site are instrumented, not all 48 layers.**
+   Every event record is a graph node, and ~600 of them would inflate the very
+   block time being attributed. The layers are structurally identical, so sampling
+   two of them and scaling by ``MCORE_INSITU_WRAP`` estimates the total; two rather
+   than one so that a layer which turns out to be atypical is visible instead of
+   silently wrong.
+2. **The occurrence counter wraps at ``MCORE_INSITU_WRAP``** (default 48, the layer
+   count) rather than tracking capture boundaries explicitly. Every full block pass
+   calls each site exactly once per layer, so wrapping realigns occurrence indices
+   across the several graphs the bucketed CUDA-graph pool captures, without needing
+   a capture id that torch does not expose.
+
+Numbers from this module are per-*replay* samples of one layer. Cross-check their
+scaled sum against the whole-block figure from ``step_gpu_timing.py`` before
+quoting any of them; if the parts do not reconstruct the whole, the sampling
+assumption is broken and the components are meaningless.
+
+Env-gated (``MCORE_INSITU_TIMING``); default off, zero cost when off.
+"""
+
+# Reports go to stderr on purpose: this runs inside a multi-rank inference server
+# whose logger configuration is the caller's, and a diagnostic must not depend on it.
+# pylint: disable=bad-builtin
+
+import os
+import statistics
+import sys
+from contextlib import contextmanager
+from typing import Dict, List, Optional, Tuple
+
+ENABLED: bool = os.environ.get("MCORE_INSITU_TIMING", "0") == "1"
+# Which per-layer occurrences to instrument. Two mid-stack layers by default: layer
+# 0 can differ (no fused hand-off from a predecessor) and the last layer feeds
+# final_layernorm rather than another block.
+_OCC: Tuple[int, ...] = tuple(
+    int(x) for x in os.environ.get("MCORE_INSITU_OCC", "8,24").split(",") if x.strip()
+)
+# Occurrences per full block pass; also the factor a single layer is scaled by.
+WRAP: int = int(os.environ.get("MCORE_INSITU_WRAP", "48"))
+
+_events: Dict[Tuple[str, int], Tuple["object", "object"]] = {}
+_counts: Dict[str, int] = {}
+_samples: Dict[Tuple[str, int], List[float]] = {}
+_order: List[str] = []
+_reports = 0
+_first_error: Optional[str] = None
+
+
+CALIB = "_calib"
+_record_ext = None
+_runtime_err: Optional[str] = None
+
+
+def _external_record():
+    """Resolve ``cudaEventRecordWithFlags`` once; None if it cannot be reached."""
+    global _record_ext, _runtime_err
+    if _record_ext is not None or _runtime_err is not None:
+        return _record_ext
+    import ctypes
+
+    for name in ("libcudart.so", "libcudart.so.13", "libcudart.so.12"):
+        try:
+            lib = ctypes.CDLL(name)
+        except OSError:
+            continue
+        fn = lib.cudaEventRecordWithFlags
+        fn.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_uint]
+        fn.restype = ctypes.c_int
+        _record_ext = fn
+        return fn
+    _runtime_err = "could not load libcudart for cudaEventRecordWithFlags"
+    print(f"[INSITU] disabled: {_runtime_err}", file=sys.stderr, flush=True)
+    return None
+
+
+def _rec(event, stream_ptr) -> bool:
+    """External-record ``event`` on ``stream_ptr``. False on any failure, once-logged."""
+    global _runtime_err
+    import ctypes
+
+    fn = _external_record()
+    if fn is None:
+        return False
+    rc = fn(ctypes.c_void_p(event.cuda_event), stream_ptr, 1)  # cudaEventRecordExternal
+    if rc != 0 and _runtime_err is None:
+        _runtime_err = f"cudaEventRecordWithFlags returned {rc}"
+        print(f"[INSITU] disabled: {_runtime_err}", file=sys.stderr, flush=True)
+    return rc == 0
+
+
+def _capturing() -> bool:
+    import torch
+
+    return torch.cuda.is_current_stream_capturing()
+
+
+def _ensure_events(name: str) -> None:
+    """Allocate this site's event pairs, outside any capture.
+
+    Creating a CUDA event while the stream is capturing is not reliably legal, and
+    torch creates the underlying ``cudaEvent_t`` lazily on first record, so each
+    event is also recorded once eagerly here -- otherwise ``cuda_event`` is null and
+    the external record would target nothing.
+    """
+    import torch
+
+    if name not in _order:
+        _order.append(name)
+    for occ in _OCC:
+        if (name, occ) not in _events:
+            pair = (torch.cuda.Event(enable_timing=True), torch.cuda.Event(enable_timing=True))
+            for ev in pair:
+                ev.record()
+            _events[(name, occ)] = pair
+
+
+@contextmanager
+def site(name: str):
+    """Time the enclosed region on every graph replay, for sampled occurrences.
+
+    A no-op unless the gate is on. Outside capture this only allocates events; the
+    occurrence counter is deliberately not advanced there, so eager steps (prefill,
+    warmup) cannot shift the occurrence-to-layer mapping.
+    """
+    if not ENABLED:
+        yield
+        return
+    if not _capturing():
+        _ensure_events(name)
+        yield
+        return
+
+    n = _counts.get(name, 0)
+    _counts[name] = (n + 1) % WRAP
+    pair = _events.get((name, n)) if n in _OCC else None
+    if pair is None or _runtime_err is not None:
+        yield
+        return
+
+    import ctypes
+
+    import torch
+
+    # The capturing stream, read rather than assumed: an external record on any
+    # other stream is cudaErrorIllegalState, and torch.cuda.graph() chooses its own
+    # side stream unless one is passed in.
+    sp = ctypes.c_void_p(torch.cuda.current_stream().cuda_stream)
+    if not _rec(pair[0], sp):
+        yield
+        return
+    try:
+        yield
+    finally:
+        _rec(pair[1], sp)
+
+
+def report(block_ms: Optional[float] = None) -> None:
+    """Read every instrumented pair and print a scaled attribution.
+
+    Caller must be at a point where the last replay has been submitted; this
+    synchronizes once, which is why it belongs on a once-per-N-steps path rather
+     than in the step itself.
+    """
+    global _reports
+    if not ENABLED or not _events:
+        return
+    import torch
+
+    global _first_error
+    torch.cuda.synchronize()
+    for key, (st, en) in _events.items():
+        try:
+            _samples.setdefault(key, []).append(st.elapsed_time(en))
+        except Exception as ex:
+            # A read before the graph's first replay legitimately fails, but so does
+            # a broken premise, and the two are indistinguishable without the text.
+            if _first_error is None:
+                _first_error = f"{key}: {type(ex).__name__}: {ex}"
+                print(
+                    f"[INSITU] first elapsed_time failure -- {_first_error}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+
+    def _med(name: str):
+        """Median-of-medians across the sampled layers, plus the per-layer detail."""
+        per_occ = []
+        for occ in _OCC:
+            vals = _samples.get((name, occ))
+            if vals:
+                per_occ.append((occ, statistics.median(vals[-64:])))
+        if not per_occ:
+            return None, []
+        return statistics.median([v for _, v in per_occ]), per_occ
+
+    # The empty-region site reads the per-pair event overhead directly, so every
+    # other site is quoted net of it. Without this a 10 us component reads ~2x high.
+    bias, _ = _med(CALIB)
+    bias = bias or 0.0
+
+    _reports += 1
+    rank = int(os.environ.get("RANK", "0"))
+    lines = [
+        f"[INSITU r{rank}] report {_reports}: per-layer us (net of "
+        f"{bias * 1000:.1f}us/pair event overhead), scaled x{WRAP}"
+    ]
+    total = 0.0
+    for name in _order:
+        if name == CALIB:
+            continue
+        med, per_occ = _med(name)
+        if med is None:
+            continue
+        net = max(med - bias, 0.0)
+        scaled = net * WRAP
+        total += scaled
+        detail = "  ".join(f"L{o}:{(v - bias) * 1000:6.1f}" for o, v in per_occ)
+        spread = ""
+        if len(per_occ) > 1:
+            lo, hi = min(v - bias for _, v in per_occ), max(v - bias for _, v in per_occ)
+            if lo > 0:
+                spread = f"  spread {(hi - lo) / lo * 100:3.0f}%"
+        lines.append(
+            f"  {name:<18} {net * 1000:7.1f} us/layer -> {scaled:6.3f} ms/step  [{detail}]{spread}"
+        )
+    lines.append(f"  {'SUM of sites':<18} {'':>7}     -> {total:6.3f} ms/step")
+    if block_ms:
+        lines.append(
+            f"  block total {block_ms:.3f} ms -> sites {100 * total / block_ms:4.1f}%, "
+            f"{block_ms - total:6.3f} ms unattributed"
+        )
+    print("\n".join(lines), file=sys.stderr, flush=True)

--- a/megatron/core/inference/moe/expert_histogram.py
+++ b/megatron/core/inference/moe/expert_histogram.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Per-expert token-count histogram, for diagnosing EP rank load imbalance.
+
+In-situ timing showed the barrier absorbing a static load imbalance: per layer, rank 0
+spends 63.0 us in the expert GEMM and 28.2 us in the collectives while rank 1 spends 56.8
+and 34.5 -- both summing to 91.2. The rank with less expert work waits correspondingly
+longer at the barrier, so the critical path is set by the *busiest* rank and balancing the
+experts across ranks is worth the difference between the max and the mean (~4.85 us/layer,
+~233 us/step).
+
+Acting on that needs to know which experts are hot. Experts are assigned to ranks in
+contiguous blocks (rank r owns ``[r*E/W, (r+1)*E/W)``), so if popularity correlates with
+index at all, the blocks are unbalanced. This module counts assignments per expert so a
+balanced permutation can be computed offline.
+
+The accumulate runs *inside* the CUDA graph -- Python executes only at capture, but the
+recorded scatter-add replays every step and keeps accumulating into a fixed buffer, which
+is exactly the desired behaviour. The dump has to happen from the host, so it is driven
+from ``step_gpu_timing``'s periodic report rather than from here.
+
+Counts are cumulative from capture, not per step. Only ratios between experts are
+meaningful; do not read an absolute rate out of them.
+
+Env-gated (``MCORE_EXPERT_HISTOGRAM``); default off, zero cost when off.
+"""
+
+# Reports go to stderr on purpose: this runs inside a multi-rank inference server
+# whose logger configuration is the caller's, and a diagnostic must not depend on it.
+# pylint: disable=bad-builtin
+
+import os
+import sys
+from typing import Optional
+
+ENABLED: bool = os.environ.get("MCORE_EXPERT_HISTOGRAM", "0") == "1"
+
+_counts: Optional["object"] = None
+_num_experts: int = 0
+
+
+def record(indices) -> None:
+    """Accumulate one selection tensor's expert assignments. No-op unless gated on.
+
+    ``indices`` is ``[tokens, topk]`` of expert ids, possibly containing the ``-1``
+    CUDA-graph padding sentinel, which is dropped by clamping into a scratch bin.
+    """
+    if not ENABLED:
+        return
+    import torch
+
+    global _counts, _num_experts
+    if _counts is None:
+        return
+    flat = indices.reshape(-1)
+    # Sentinel rows land in the extra trailing bin, which the dump discards. Clamping is
+    # cheaper than a boolean mask and keeps this to a single kernel.
+    safe = torch.where(flat < 0, _num_experts, flat)
+    _counts.scatter_add_(0, safe.to(torch.int64), torch.ones_like(safe, dtype=_counts.dtype))
+
+
+def configure(num_experts: int, device) -> None:
+    """Allocate the histogram once, before capture."""
+    if not ENABLED:
+        return
+    import torch
+
+    global _counts, _num_experts
+    if _counts is not None:
+        return
+    _num_experts = num_experts
+    # One extra bin absorbs the padding sentinel.
+    _counts = torch.zeros(num_experts + 1, dtype=torch.int64, device=device)
+
+
+def dump() -> None:
+    """Print the histogram and the per-rank totals implied by contiguous assignment."""
+    if not ENABLED or _counts is None:
+        return
+    import torch
+
+    c = _counts[:_num_experts].tolist()
+    total = sum(c)
+    if total == 0:
+        return
+    rank = int(os.environ.get("RANK", "0"))
+    if rank != 0:
+        return
+    world = int(os.environ.get("WORLD_SIZE", "4"))
+    per = _num_experts // world
+    loads = [sum(c[r * per : (r + 1) * per]) for r in range(world)]
+    mean = total / world
+    print(
+        f"[EXPHIST] total {total} assignments over {_num_experts} experts\n"
+        f"[EXPHIST] contiguous per-rank loads: "
+        + "  ".join(f"r{r}:{l} ({100 * l / mean - 100:+.1f}%)" for r, l in enumerate(loads))
+        + f"\n[EXPHIST] counts: {','.join(str(x) for x in c)}",
+        file=sys.stderr,
+        flush=True,
+    )

--- a/megatron/core/inference/moe/router_topk.py
+++ b/megatron/core/inference/moe/router_topk.py
@@ -1,0 +1,130 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Fused softmax + top-k router selection for decode-shaped MoE inference.
+
+The eager path runs ``torch.softmax`` over the expert dimension and then
+``torch.topk``. At decode shapes (``[num_tokens, 128]`` fp32) both kernels are
+launch/latency dominated and ``topk`` in particular runs a multi-pass radix
+select. One CTA per token can do the whole thing out of registers.
+"""
+
+import os
+from typing import Tuple
+
+import torch
+
+try:
+    import triton
+    import triton.language as tl
+
+    HAVE_TRITON = True
+except ImportError:
+    HAVE_TRITON = False
+
+# Fuse the router softmax and top-k into one Triton kernel. Env-toggleable; default off.
+USE_FUSED_ROUTER_TOPK: bool = os.environ.get("MCORE_ROUTER_FUSED_TOPK", "0") == "1"
+
+# Above this token count the two-kernel torch path amortizes its launch cost and the
+# one-CTA-per-token kernel stops being the right shape, so the fused path is decode-only.
+FUSED_ROUTER_TOPK_MAX_TOKENS: int = 1024
+
+
+if HAVE_TRITON:
+
+    @triton.jit
+    def _softmax_topk_kernel(
+        logits_ptr,
+        probs_ptr,
+        indices_ptr,
+        num_experts,
+        TOPK: tl.constexpr,
+        BLOCK_E: tl.constexpr,
+    ):
+        """One CTA per token: softmax over experts, then TOPK selection passes.
+
+        Selection is max-then-mask, which yields the top-k in descending score
+        order with ties broken toward the lower expert id. ``torch.topk`` is
+        called with ``sorted=False`` during inference, so its own order is
+        unspecified and any consistent order is an equally valid answer.
+        """
+        token_id = tl.program_id(0)
+        offs = tl.arange(0, BLOCK_E)
+        mask = offs < num_experts
+
+        x = tl.load(logits_ptr + token_id * num_experts + offs, mask=mask, other=-float("inf"))
+        x = x.to(tl.float32)
+        m = tl.max(x, axis=0)
+        e = tl.exp(x - m)
+        e = tl.where(mask, e, 0.0)
+        p = e / tl.sum(e, axis=0)
+
+        cur = tl.where(mask, p, -float("inf"))
+        for k in tl.static_range(TOPK):
+            best = tl.max(cur, axis=0)
+            is_best = cur == best
+            best_idx = tl.min(tl.where(is_best, offs, num_experts), axis=0)
+            tl.store(probs_ptr + token_id * TOPK + k, best)
+            tl.store(indices_ptr + token_id * TOPK + k, best_idx)
+            cur = tl.where(offs == best_idx, -float("inf"), cur)
+
+
+def fused_softmax_topk(logits: torch.Tensor, topk: int) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Pre-softmax top-k routing in a single kernel.
+
+    Args:
+        logits: ``[num_tokens, num_experts]``, any float dtype.
+        topk: number of experts per token.
+
+    Returns:
+        ``(probs, top_indices)`` with shapes ``[num_tokens, topk]``. ``probs``
+        matches the dtype of ``logits`` (the softmax itself is fp32, as in the
+        eager path); ``top_indices`` is int64 to match ``torch.topk``.
+    """
+    assert logits.dim() == 2, f"Expected 2D logits, got {logits.dim()}D"
+    num_tokens, num_experts = logits.shape
+    probs = torch.empty(num_tokens, topk, dtype=logits.dtype, device=logits.device)
+    indices = torch.empty(num_tokens, topk, dtype=torch.int64, device=logits.device)
+    _softmax_topk_kernel[(num_tokens,)](
+        logits,
+        probs,
+        indices,
+        num_experts,
+        TOPK=topk,
+        BLOCK_E=triton.next_power_of_2(num_experts),
+        num_warps=1,
+    )
+    return probs, indices
+
+
+def can_use_fused_softmax_topk(
+    logits: torch.Tensor,
+    topk: int,
+    use_pre_softmax: bool,
+    num_groups,
+    group_topk,
+    scaling_factor,
+    score_function: str,
+    expert_bias,
+    router_replay,
+) -> bool:
+    """Whether the fused kernel reproduces this exact routing contract."""
+    return (
+        HAVE_TRITON
+        and USE_FUSED_ROUTER_TOPK
+        and logits.dim() == 2
+        and logits.is_cuda
+        and logits.shape[0] <= FUSED_ROUTER_TOPK_MAX_TOKENS
+        and score_function == "softmax"
+        and use_pre_softmax
+        and num_groups is None
+        and group_topk is None
+        and not scaling_factor
+        and expert_bias is None
+        and router_replay is None
+        # topk == 1 is excluded because the reference path ends in
+        # `top_indices.squeeze(1)`, which drops the k dimension only at k == 1.
+        # This kernel always returns [num_tokens, topk], so honoring k == 1 here
+        # would hand the dispatcher a differently-ranked tensor than the path it
+        # replaces.
+        and 1 < topk <= logits.shape[1]
+    )

--- a/megatron/core/inference/moe/router_topk.py
+++ b/megatron/core/inference/moe/router_topk.py
@@ -9,7 +9,7 @@ select. One CTA per token can do the whole thing out of registers.
 """
 
 import os
-from typing import Tuple
+from typing import Optional, Tuple
 
 import torch
 
@@ -27,6 +27,27 @@ USE_FUSED_ROUTER_TOPK: bool = os.environ.get("MCORE_ROUTER_FUSED_TOPK", "0") == 
 # Above this token count the two-kernel torch path amortizes its launch cost and the
 # one-CTA-per-token kernel stops being the right shape, so the fused path is decode-only.
 FUSED_ROUTER_TOPK_MAX_TOKENS: int = 1024
+
+# Also write the -1 CUDA-graph padding sentinel from this kernel, retiring the dispatcher's
+# separate mask launch (one per layer per step). Env-toggleable; default off.
+USE_FUSED_ROUTE_MASK: bool = os.environ.get("MCORE_FUSED_ROUTE_MASK", "0") == "1"
+
+# The int32[1] real-token count the dispatcher masks against, published here so the
+# selection kernel can apply the sentinel itself. It is a fixed-address view owned by the
+# inference context; only the value behind it changes between replays, which is what makes
+# reading it inside a captured kernel safe.
+_graph_pad_count: Optional[torch.Tensor] = None
+
+
+def publish_graph_padding(real_token_count: Optional[torch.Tensor]) -> None:
+    """Bind (or clear) the real-token-count tensor used for the fused padding sentinel."""
+    global _graph_pad_count
+    _graph_pad_count = real_token_count
+
+
+def can_fuse_route_mask() -> bool:
+    """Whether the selection kernel should emit the padding sentinel itself."""
+    return USE_FUSED_ROUTE_MASK and _graph_pad_count is not None
 
 
 if HAVE_TRITON:
@@ -67,13 +88,61 @@ if HAVE_TRITON:
             tl.store(indices_ptr + token_id * TOPK + k, best_idx)
             cur = tl.where(offs == best_idx, -float("inf"), cur)
 
+    @triton.jit
+    def _softmax_topk_mask_kernel(
+        logits_ptr,
+        probs_ptr,
+        indices_ptr,
+        real_cnt_ptr,
+        num_experts,
+        TOPK: tl.constexpr,
+        BLOCK_E: tl.constexpr,
+    ):
+        """``_softmax_topk_kernel`` that also writes the CUDA-graph padding sentinel.
 
-def fused_softmax_topk(logits: torch.Tensor, topk: int) -> Tuple[torch.Tensor, torch.Tensor]:
+        Deliberately a separate kernel rather than a constexpr branch in the original:
+        keeping the unmasked path's generated code byte-identical is worth more than the
+        duplication, because the two share no state and this one is only ever reached
+        through an explicit gate.
+
+        One CTA owns exactly one row, so deciding whether that row is padding is a scalar
+        compare against a value already in memory. Rows at or past the real count emit -1
+        in every topk slot and route to no expert.
+        """
+        token_id = tl.program_id(0)
+        offs = tl.arange(0, BLOCK_E)
+        mask = offs < num_experts
+
+        is_padding = token_id >= tl.load(real_cnt_ptr).to(tl.int32)
+
+        x = tl.load(logits_ptr + token_id * num_experts + offs, mask=mask, other=-float("inf"))
+        x = x.to(tl.float32)
+        m = tl.max(x, axis=0)
+        e = tl.exp(x - m)
+        e = tl.where(mask, e, 0.0)
+        p = e / tl.sum(e, axis=0)
+
+        cur = tl.where(mask, p, -float("inf"))
+        for k in tl.static_range(TOPK):
+            best = tl.max(cur, axis=0)
+            is_best = cur == best
+            best_idx = tl.min(tl.where(is_best, offs, num_experts), axis=0)
+            tl.store(probs_ptr + token_id * TOPK + k, best)
+            tl.store(indices_ptr + token_id * TOPK + k, tl.where(is_padding, -1, best_idx))
+            cur = tl.where(offs == best_idx, -float("inf"), cur)
+
+
+def fused_softmax_topk(
+    logits: torch.Tensor, topk: int, mask_padding: bool = False
+) -> Tuple[torch.Tensor, torch.Tensor]:
     """Pre-softmax top-k routing in a single kernel.
 
     Args:
         logits: ``[num_tokens, num_experts]``, any float dtype.
         topk: number of experts per token.
+        mask_padding: also emit the ``-1`` no-expert sentinel for CUDA-graph padding
+            rows, against the count bound by ``publish_graph_padding``. The caller is
+            then responsible for skipping the standalone mask.
 
     Returns:
         ``(probs, top_indices)`` with shapes ``[num_tokens, topk]``. ``probs``
@@ -84,6 +153,23 @@ def fused_softmax_topk(logits: torch.Tensor, topk: int) -> Tuple[torch.Tensor, t
     num_tokens, num_experts = logits.shape
     probs = torch.empty(num_tokens, topk, dtype=logits.dtype, device=logits.device)
     indices = torch.empty(num_tokens, topk, dtype=torch.int64, device=logits.device)
+    if mask_padding:
+        assert _graph_pad_count is not None, "no real-token-count tensor published"
+        _softmax_topk_mask_kernel[(num_tokens,)](
+            logits,
+            probs,
+            indices,
+            _graph_pad_count,
+            num_experts,
+            TOPK=topk,
+            BLOCK_E=triton.next_power_of_2(num_experts),
+            num_warps=1,
+        )
+        # Tells the dispatcher its own mask launch is redundant for this tensor. Set in
+        # Python, so it is the capture-time decision that gets baked into the graph.
+        indices._mcore_padding_masked = True
+        return probs, indices
+
     _softmax_topk_kernel[(num_tokens,)](
         logits,
         probs,

--- a/megatron/core/inference/moe/vllm_fused_moe.py
+++ b/megatron/core/inference/moe/vllm_fused_moe.py
@@ -124,6 +124,7 @@ def _fused_moe_kernel(
     # Flags / constexprs
     MUL_ROUTED_WEIGHT: tl.constexpr,
     FUSE_SQUARED_RELU: tl.constexpr,
+    FUSE_SWIGLU: tl.constexpr,
     top_k: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
@@ -186,6 +187,13 @@ def _fused_moe_kernel(
                 + off_experts * stride_be
                 + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
             )
+            # SwiGLU epilogue fusion: the same [BLOCK_M, BLOCK_N] output tile of
+            # the activated intermediate needs both the gate columns (offs_bn) and
+            # the paired up columns (offs_bn + N), where N is the activated width.
+            # A second accumulator reads the up half from the same B tensor.
+            if FUSE_SWIGLU:
+                b_up_ptrs = b_ptrs + N * stride_bn
+                up_accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
 
             accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
             for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
@@ -196,6 +204,12 @@ def _fused_moe_kernel(
                 )
                 b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
                 accumulator += tl.dot(a, b)
+                if FUSE_SWIGLU:
+                    b_up = tl.load(
+                        b_up_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0
+                    )
+                    up_accumulator += tl.dot(a, b_up)
+                    b_up_ptrs += BLOCK_SIZE_K * stride_bk
                 a_ptrs += BLOCK_SIZE_K * stride_ak
                 b_ptrs += BLOCK_SIZE_K * stride_bk
 
@@ -204,6 +218,15 @@ def _fused_moe_kernel(
             if FUSE_SQUARED_RELU:
                 accumulator = tl.maximum(accumulator, 0.0)
                 accumulator *= accumulator
+
+            # SwiGLU fused on the fp32 accumulators: SiLU(gate) * up. The
+            # arithmetic matches the standalone `bounded_silu_mul` kernel, but the
+            # results are not bit-identical (measured max_abs 3.9e-5): that kernel
+            # reads gate and up after they have been rounded to bf16, while these
+            # accumulators have not been. The fused result is the less rounded of
+            # the two. Removes that kernel and the 2N intermediate round-trip.
+            if FUSE_SWIGLU:
+                accumulator = accumulator * tl.sigmoid(accumulator) * up_accumulator
 
             if MUL_ROUTED_WEIGHT:
                 moe_weight = tl.load(topk_weights_ptr + offs_token, mask=token_mask, other=0)
@@ -387,12 +410,18 @@ def _invoke_fused_moe_kernel(
     config: dict,
     grid_size: int,
     fuse_squared_relu: bool = False,
+    fuse_swiglu: bool = False,
 ):
     """Launch the Triton fused-MoE kernel for one GEMM pass.
 
     Body matches upstream vLLM `fused_moe_kernel` (1 CTA per (pid_m, pid_n)
     tile, raw pointer arithmetic with `% N` on the N axis), apart from the
     optional fused squared-relu activation in fp32.
+
+    When ``fuse_swiglu`` is set, B is the [E, 2*Nf, K] gate|up FC1 weight and the
+    kernel emits the activated [num_valid, Nf] intermediate directly (SiLU(gate) *
+    up), so ``N`` is the activated width ``Nf = B.size(1) // 2`` and each program
+    also reads the paired up columns at ``+N`` in B.
 
     `grid_size` is sized host-side from `num_tokens_hint` so launch overhead
     at decode is small.  When the actual padded length exceeds the hinted
@@ -402,6 +431,8 @@ def _invoke_fused_moe_kernel(
     """
     M = A.size(0)
     num_tokens = M * top_k
+    # For fused SwiGLU, N is the activated width (half the 2*Nf FC1 output).
+    n_dim = B.size(1) // 2 if fuse_swiglu else B.size(1)
 
     _fused_moe_kernel[(grid_size,)](
         A,
@@ -411,7 +442,7 @@ def _invoke_fused_moe_kernel(
         sorted_token_ids,
         expert_ids,
         num_tokens_post_padded,
-        B.size(1),
+        n_dim,
         B.size(2),
         num_tokens,
         A.stride(0),
@@ -423,6 +454,7 @@ def _invoke_fused_moe_kernel(
         C.stride(1),
         MUL_ROUTED_WEIGHT=mul_routed_weight,
         FUSE_SQUARED_RELU=fuse_squared_relu,
+        FUSE_SWIGLU=fuse_swiglu,
         top_k=top_k,
         BLOCK_SIZE_M=config['BLOCK_SIZE_M'],
         BLOCK_SIZE_N=config['BLOCK_SIZE_N'],
@@ -557,6 +589,7 @@ def vllm_fused_moe(
     routing_map: torch.Tensor,
     out: Optional[torch.Tensor] = None,
     num_tokens_hint: Optional[int] = None,
+    fuse_fc1_activation: bool = False,
 ) -> torch.Tensor:
     """Fused MoE using the vLLM Triton grouped-GEMM kernel (BF16).
 
@@ -580,6 +613,9 @@ def vllm_fused_moe(
         num_tokens_hint: optional host-side int with the expected number of
             valid tokens (e.g. batch_size * ep_size). Used to select a better
             BLOCK_SIZE_M instead of using the worst-case buffer size.
+        fuse_fc1_activation: for SwiGLU, fuse SiLU(gate)*up into the FC1 GEMM
+            epilogue instead of running the standalone ``bounded_silu_mul`` kernel
+            over the 2N-wide intermediate. Ignored for other activations.
 
     Returns:
         [max_tokens, hidden_size] output (fp32 when out=None, else out's dtype).
@@ -606,6 +642,14 @@ def vllm_fused_moe(
     N = fc1_weight.size(1)
     K = fc1_weight.size(2)
 
+    assert activation_type in (ActivationType.SQUARED_RELU, ActivationType.SWIGLU)
+    is_swiglu = activation_type == ActivationType.SWIGLU
+    # When enabled for SwiGLU, FC1 fuses SiLU(gate)*up into its epilogue and
+    # writes the activated [num_valid, N//2] intermediate directly, removing the
+    # standalone bounded_silu_mul kernel and the 2N intermediate round-trip.
+    use_fused_swiglu = is_swiglu and fuse_fc1_activation
+    fc1_out_width = N // 2 if use_fused_swiglu else N
+
     # Grid sized for the typical-case token count (num_tokens_hint).  When the
     # actual num_tokens_post_padded exceeds this, the kernel's outer tl.range
     # makes each CTA stride over additional tiles — correct but with reduced
@@ -614,21 +658,20 @@ def vllm_fused_moe(
     block_m = config['BLOCK_SIZE_M']
     em_hint = effective_tokens * topk + block_m * num_local_experts
     num_pid_m_hint = _ceil_div(em_hint, block_m)
-    num_pid_n_fc1 = _ceil_div(N, config['BLOCK_SIZE_N'])
+    num_pid_n_fc1 = _ceil_div(fc1_out_width, config['BLOCK_SIZE_N'])
     num_pid_n_fc2 = _ceil_div(K, config['BLOCK_SIZE_N'])
     grid_size_fc1 = num_pid_m_hint * num_pid_n_fc1
     grid_size_fc2 = num_pid_m_hint * num_pid_n_fc2
 
     topk_weights_flat = probs.reshape(-1).contiguous()
 
-    # FC1 + activation: [max_tokens, K] → [max_tokens*topk, N]
-    # SQUARED_RELU fuses into the GEMM epilogue (elementwise). SwiGLU pairs column c
-    # with c+N/2 across tiles and cannot, so FC1 runs unfused to the 2N-wide
-    # intermediate and gate/up is applied separately below.
-    assert activation_type in (ActivationType.SQUARED_RELU, ActivationType.SWIGLU)
-    is_swiglu = activation_type == ActivationType.SWIGLU
+    # FC1 + activation: [max_tokens, K] → [max_tokens*topk, fc1_out_width]
+    # SQUARED_RELU fuses into the GEMM epilogue (elementwise). SwiGLU pairs column
+    # c with c+N/2 across N-tiles; the unfused path writes the 2N intermediate and
+    # applies gate/up separately below, while the fused path (use_fused_swiglu)
+    # reads both halves per program and writes the N//2 activated output directly.
     intermediate1 = torch.empty(
-        num_valid, N, dtype=hidden_states.dtype, device=hidden_states.device
+        num_valid, fc1_out_width, dtype=hidden_states.dtype, device=hidden_states.device
     )
     _invoke_fused_moe_kernel(
         hidden_states,
@@ -643,8 +686,9 @@ def vllm_fused_moe(
         config=config,
         grid_size=grid_size_fc1,
         fuse_squared_relu=not is_swiglu,
+        fuse_swiglu=use_fused_swiglu,
     )
-    if is_swiglu:
+    if is_swiglu and not use_fused_swiglu:
         # intermediate1 is [num_valid, 2N] (gate | up); reduce to [num_valid, N] via
         # SiLU(gate) * up over the valid_tokens*topk live rows only.
         n_rows = (valid_tokens * topk).to(torch.int32)

--- a/megatron/core/inference/moe/vllm_fused_moe.py
+++ b/megatron/core/inference/moe/vllm_fused_moe.py
@@ -1000,6 +1000,71 @@ def _moe_sum_kernel(
             tl.store(output_ptr + token_id_i64 * K + offs_k, acc, mask=k_mask)
 
 
+@triton.jit
+def _moe_sum_kernel_fast(
+    input_ptr,
+    output_ptr,
+    topk_weights_ptr,
+    valid_tokens_ptr,
+    routing_map_ptr,
+    local_expert_start,
+    num_local_experts: tl.constexpr,
+    K,
+    topk: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    NUM_K_BLOCKS: tl.constexpr,
+):
+    """``_moe_sum_kernel`` with the locality test predicated instead of branched.
+
+    Same reduction, same order, same fp32 arithmetic — so bit-exact — but the
+    ``if lid >= 0 and lid < num_local_experts`` guard becomes a load mask. In the
+    branched form each of the ``topk`` iterations is a uniform scalar branch
+    gated on a dependent global load of ``routing_map``, so the compiler cannot
+    overlap iteration ``t``'s data load with iteration ``t+1``'s index load and
+    the CTA walks the topk slots serially. Predicating lets all ``topk`` data
+    loads issue back to back; masked-off lanes read nothing and contribute an
+    exact fp32 zero.
+
+    Measured cost of the branched form in the BS256 decode graph: 7.79 us per
+    layer to move ~6.3 MB, i.e. 7x its own ~1.05 us bandwidth floor at the
+    6.08 TB/s measured in QWEN-012.
+    """
+    pid = tl.program_id(0)
+    valid_tokens = tl.load(valid_tokens_ptr)
+
+    for token_id in tl.range(pid, valid_tokens, BLOCK_M):
+        token_id_i64 = token_id.to(tl.int64)
+        base = token_id_i64 * topk * K
+
+        for k_idx in range(NUM_K_BLOCKS):
+            offs_k = k_idx * BLOCK_K + tl.arange(0, BLOCK_K)
+            k_mask = offs_k < K
+
+            acc = tl.zeros([BLOCK_K], dtype=tl.float32)
+            for t in tl.static_range(topk):
+                eid = tl.load(routing_map_ptr + token_id * topk + t)
+                lid = eid - local_expert_start
+                is_local = (lid >= 0) & (lid < num_local_experts)
+                v = tl.load(
+                    input_ptr + base + t * K + offs_k, mask=k_mask & is_local, other=0.0
+                )
+                w = tl.load(topk_weights_ptr + token_id * topk + t)
+                acc += v.to(tl.float32) * tl.where(is_local, w, 0.0)
+
+            tl.store(output_ptr + token_id_i64 * K + offs_k, acc, mask=k_mask)
+
+
+# Use the predicated `_moe_sum_kernel_fast` (bit-exact) with a full-K tile in the
+# decode topk reduction. Env-toggleable for A/B; default off.
+_USE_FAST_MOE_SUM: bool = os.environ.get("MCORE_MOE_SUM_FAST", "0") == "1"
+
+
+# Full hidden-size K tile: one pass over topk per token instead of NUM_K_BLOCKS
+# passes, so the per-token routing_map/prob index loads are issued once.
+_FAST_MOE_SUM_MAX_BLOCK_K = 2048
+
+
 def _moe_sum(
     input: torch.Tensor,
     topk_weights: torch.Tensor,
@@ -1025,9 +1090,28 @@ def _moe_sum(
     """
     if out is None:
         out = torch.empty(max_tokens, K, dtype=torch.float32, device=input.device)
+    BLOCK_M = _get_num_sms(input.device)
+    if _USE_FAST_MOE_SUM:
+        BLOCK_K = min(triton.next_power_of_2(K), _FAST_MOE_SUM_MAX_BLOCK_K)
+        NUM_K_BLOCKS = _ceil_div(K, BLOCK_K)
+        _moe_sum_kernel_fast[(BLOCK_M,)](
+            input,
+            out,
+            topk_weights,
+            valid_tokens,
+            routing_map,
+            local_expert_start,
+            num_local_experts,
+            K,
+            topk=topk,
+            BLOCK_M=BLOCK_M,
+            BLOCK_K=BLOCK_K,
+            NUM_K_BLOCKS=NUM_K_BLOCKS,
+            num_warps=8,
+        )
+        return out
     BLOCK_K = min(triton.next_power_of_2(K), 1024)
     NUM_K_BLOCKS = _ceil_div(K, BLOCK_K)
-    BLOCK_M = _get_num_sms(input.device)
     _moe_sum_kernel[(BLOCK_M,)](
         input,
         out,

--- a/megatron/core/inference/moe/vllm_fused_moe.py
+++ b/megatron/core/inference/moe/vllm_fused_moe.py
@@ -30,6 +30,7 @@ if not HAVE_TRITON:
     triton.jit = null_decorator
     tl = MagicMock()
 
+from megatron.core.inference import insitu_timing as _insitu
 from megatron.core.inference.moe.activations import bounded_silu_mul
 from megatron.core.inference.moe.fused_moe import ActivationType
 from megatron.core.inference.moe.permute import (
@@ -1211,9 +1212,14 @@ def vllm_fused_moe(
         align_fn = _moe_align_block_size_fused
     else:
         align_fn = _moe_align_block_size_cuda_graphable
-    sorted_token_ids, expert_ids, num_post_padded = align_fn(
-        routing_map, config['BLOCK_SIZE_M'], num_local_experts, local_expert_start, valid_tokens
-    )
+    with _insitu.site("moe_align"):
+        sorted_token_ids, expert_ids, num_post_padded = align_fn(
+            routing_map,
+            config['BLOCK_SIZE_M'],
+            num_local_experts,
+            local_expert_start,
+            valid_tokens,
+        )
     num_valid = max_tokens * topk
 
     N = fc1_weight.size(1)
@@ -1250,21 +1256,22 @@ def vllm_fused_moe(
     intermediate1 = torch.empty(
         num_valid, fc1_out_width, dtype=hidden_states.dtype, device=hidden_states.device
     )
-    _invoke_fused_moe_kernel(
-        hidden_states,
-        fc1_weight,
-        intermediate1,
-        topk_weights_flat,
-        sorted_token_ids,
-        expert_ids,
-        num_post_padded,
-        mul_routed_weight=False,
-        top_k=topk,
-        config=config_fc1,
-        grid_size=grid_size_fc1,
-        fuse_squared_relu=not is_swiglu,
-        fuse_swiglu=use_fused_swiglu,
-    )
+    with _insitu.site("expert_gemm_fc1"):
+        _invoke_fused_moe_kernel(
+            hidden_states,
+            fc1_weight,
+            intermediate1,
+            topk_weights_flat,
+            sorted_token_ids,
+            expert_ids,
+            num_post_padded,
+            mul_routed_weight=False,
+            top_k=topk,
+            config=config_fc1,
+            grid_size=grid_size_fc1,
+            fuse_squared_relu=not is_swiglu,
+            fuse_swiglu=use_fused_swiglu,
+        )
     if is_swiglu and not use_fused_swiglu:
         # intermediate1 is [num_valid, 2N] (gate | up); reduce to [num_valid, N] via
         # SiLU(gate) * up over the valid_tokens*topk live rows only.
@@ -1279,33 +1286,35 @@ def vllm_fused_moe(
     intermediate3 = torch.empty(
         num_valid, K, dtype=hidden_states.dtype, device=hidden_states.device
     )
-    _invoke_fused_moe_kernel(
-        intermediate1,
-        fc2_weight,
-        intermediate3,
-        topk_weights_flat,
-        sorted_token_ids,
-        expert_ids,
-        num_post_padded,
-        mul_routed_weight=False,
-        top_k=1,
-        config=config_fc2,
-        grid_size=grid_size_fc2,
-    )
+    with _insitu.site("expert_gemm_fc2"):
+        _invoke_fused_moe_kernel(
+            intermediate1,
+            fc2_weight,
+            intermediate3,
+            topk_weights_flat,
+            sorted_token_ids,
+            expert_ids,
+            num_post_padded,
+            mul_routed_weight=False,
+            top_k=1,
+            config=config_fc2,
+            grid_size=grid_size_fc2,
+        )
 
     # Reduce over topk: [max_tokens*topk, K] → [max_tokens, K]
     # Applies routing weights and accumulates in fp32, writes directly to
     # out (if provided), zeros rows beyond valid_tokens, and skips non-local
     # expert slots.
-    return _moe_sum(
-        intermediate3,
-        probs,
-        max_tokens,
-        topk,
-        K,
-        valid_tokens,
-        routing_map,
-        local_expert_start,
-        num_local_experts,
-        out=out,
-    )
+    with _insitu.site("moe_sum"):
+        return _moe_sum(
+            intermediate3,
+            probs,
+            max_tokens,
+            topk,
+            K,
+            valid_tokens,
+            routing_map,
+            local_expert_start,
+            num_local_experts,
+            out=out,
+        )

--- a/megatron/core/inference/moe/vllm_fused_moe.py
+++ b/megatron/core/inference/moe/vllm_fused_moe.py
@@ -100,6 +100,60 @@ def _get_default_config(M: int, E: int, top_k: int) -> dict:
     }
 
 
+# Retune the two grouped GEMMs independently for the MoE *decode* regime.
+# Env-toggleable for A/B; the tuned path is the same kernel with different M and N
+# tiles. It inherits BLOCK_SIZE_K, which is what fixes the fp32 reduction order, so
+# the results are bit-exact against the default config.
+_TUNE_DECODE_GEMM: bool = os.environ.get("MCORE_MOE_GEMM_TUNE", "0") == "1"
+
+
+def _get_decode_tuned_configs(M: int, E: int, top_k: int) -> tuple[dict, dict]:
+    """Per-GEMM launch configs for the decode regime; returns (fc1, fc2).
+
+    Measured on GB200 at the Qwen3-30B-A3B EP4 decode shape (hidden 2048,
+    moe_ffn 768, 32 local experts, top-8, 256 tokens): expert-weight traffic is
+    302 MB per layer against a 6.08 TB/s streaming-read ceiling, i.e. a 49.7 us
+    floor, while `_get_default_config` lands at 72.1 us. The gap is *not* FLOPs
+    (63-83 TFLOP/s achieved, ~3% of BF16 peak) and not the indirection-table
+    padding (shrinking it 3.9x -> 1.5x buys only ~1.2x); it is tile-quantized
+    SM occupancy. `_get_default_config` picks BLOCK_SIZE_N=128 for both GEMMs,
+    which leaves FC1 at ceil(768/128)=6 N-tiles x 32 M-tiles = 192 CTAs on 148
+    SMs — 1.3 waves, so ~30% of the machine idles in the tail.
+
+    So the two GEMMs want opposite N-tiles at decode: FC1 (narrow N=768) needs a
+    *small* BLOCK_SIZE_N to manufacture enough CTAs to fill the GPU, while FC2
+    (wide N=2048) already has plenty and prefers a *large* one for weight-load
+    efficiency. `_get_default_config` cannot express that because vLLM shares one
+    config across both passes. BLOCK_SIZE_M stays shared — one indirection table
+    is built for both GEMMs — and is dropped to 16 to cut padded rows as well.
+
+    Measured FC1+FC2, median of 3 x 300 iters: 72.13 us default -> 57.24 us here
+    (1.26x), i.e. 1.15x off the streaming-read floor.
+
+    Falls back to the shared default outside the decode regime (large M is
+    compute-bound and vLLM's heuristic is tuned for it).
+    """
+    default = _get_default_config(M, E, top_k)
+    # Measured CUDA-graph device time vs the default config: 1.289x at 128
+    # tokens, 1.197x at 256 (the decode point, = local_tokens * ep_size),
+    # 1.120x at 384, but 0.952x at 512 — past ~384 tokens there are already
+    # enough M-tiles to fill the GPU and the narrow FC1 tile starts costing
+    # weight-load efficiency. Hand back to upstream's heuristic there.
+    if M > 384:
+        return default, default
+    shared = dict(default)
+    shared['BLOCK_SIZE_M'] = 16
+    shared['GROUP_SIZE_M'] = 1
+    # BLOCK_SIZE_K is deliberately inherited rather than set. The fp32 K-reduction
+    # order is a function of BLOCK_SIZE_K alone, so inheriting it keeps this path
+    # bit-exact against the default config at every M. The default is already 64
+    # throughout the measured range (it only rises to 128 at M <= 64), so this is
+    # a no-op where the configs below were tuned.
+    fc1 = dict(shared, BLOCK_SIZE_N=64, num_warps=4, num_stages=3)
+    fc2 = dict(shared, BLOCK_SIZE_N=256, num_warps=8, num_stages=4)
+    return fc1, fc2
+
+
 @triton.jit
 def _fused_moe_kernel(
     # Pointers
@@ -1050,8 +1104,19 @@ def vllm_fused_moe(
 
     # Mirror upstream vLLM: pick the full launch config (tile sizes, warps,
     # stages) host-side from the token-count hint, not from the worst-case
-    # buffer size. Same config is used for both FC1 and FC2 (matches vLLM).
-    config = _get_default_config(M=effective_tokens, E=num_local_experts, top_k=topk)
+    # buffer size. Same config is used for both FC1 and FC2 (matches vLLM),
+    # unless the decode retune is enabled, which tiles the two passes
+    # separately (they have very different N) around a shared BLOCK_SIZE_M.
+    if _TUNE_DECODE_GEMM:
+        config_fc1, config_fc2 = _get_decode_tuned_configs(
+            M=effective_tokens, E=num_local_experts, top_k=topk
+        )
+    else:
+        config_fc1 = config_fc2 = _get_default_config(
+            M=effective_tokens, E=num_local_experts, top_k=topk
+        )
+    # BLOCK_SIZE_M is shared: one indirection table feeds both GEMMs.
+    config = config_fc1
 
     if _USE_FUSED_ALIGN and _USE_FUSED_COUNT and effective_tokens <= _FUSED_COUNT_MAX_TOKENS:
         if _USE_FUSED_SCATTER:
@@ -1086,8 +1151,8 @@ def vllm_fused_moe(
     block_m = config['BLOCK_SIZE_M']
     em_hint = effective_tokens * topk + block_m * num_local_experts
     num_pid_m_hint = _ceil_div(em_hint, block_m)
-    num_pid_n_fc1 = _ceil_div(fc1_out_width, config['BLOCK_SIZE_N'])
-    num_pid_n_fc2 = _ceil_div(K, config['BLOCK_SIZE_N'])
+    num_pid_n_fc1 = _ceil_div(fc1_out_width, config_fc1['BLOCK_SIZE_N'])
+    num_pid_n_fc2 = _ceil_div(K, config_fc2['BLOCK_SIZE_N'])
     grid_size_fc1 = num_pid_m_hint * num_pid_n_fc1
     grid_size_fc2 = num_pid_m_hint * num_pid_n_fc2
 
@@ -1111,7 +1176,7 @@ def vllm_fused_moe(
         num_post_padded,
         mul_routed_weight=False,
         top_k=topk,
-        config=config,
+        config=config_fc1,
         grid_size=grid_size_fc1,
         fuse_squared_relu=not is_swiglu,
         fuse_swiglu=use_fused_swiglu,
@@ -1140,7 +1205,7 @@ def vllm_fused_moe(
         num_post_padded,
         mul_routed_weight=False,
         top_k=1,
-        config=config,
+        config=config_fc2,
         grid_size=grid_size_fc2,
     )
 

--- a/megatron/core/inference/moe/vllm_fused_moe.py
+++ b/megatron/core/inference/moe/vllm_fused_moe.py
@@ -9,6 +9,7 @@ CUDA-graph compatible: all indirection table construction happens on-device
 via Triton kernels with fixed-size buffers and valid_tokens gating.
 """
 
+import os
 from typing import Optional
 from unittest.mock import MagicMock
 
@@ -319,6 +320,424 @@ def _fill_expert_block_ids_kernel(
     for off in tl.range(0, num_blocks, BLOCK):
         idxs = start_block + off + tl.arange(0, BLOCK)
         tl.store(expert_ids_ptr + idxs, e, mask=idxs < end_block)
+
+
+@triton.jit
+def _prefix_fill_init_kernel(
+    tokens_per_expert_ptr,  # [num_local_experts] raw token counts
+    exclusive_offsets_ptr,  # [num_local_experts] out: exclusive prefix sum (scatter counters)
+    inclusive_offsets_ptr,  # [num_local_experts] out: inclusive prefix sum
+    expert_ids_ptr,  # [max_blocks] out: expert index per BLOCK_SIZE_M block
+    sorted_token_ids_ptr,  # [max_sorted] out: SENTINEL-initialized indirection table
+    num_local_experts,
+    SENTINEL: tl.constexpr,
+    ALIGNMENT: tl.constexpr,  # = BLOCK_SIZE_M
+    NLE_POW2: tl.constexpr,  # next_power_of_2(num_local_experts) for tl.cumsum
+    FILL_BLOCK: tl.constexpr,  # vectorized store width
+):
+    """Fused prefix-sum + expert_ids fill + sorted_token_ids SENTINEL init.
+
+    Merges three kernels of the original indirection-table build
+    (``_init_sorted_ids_kernel`` + ``_prefix_sum_kernel`` +
+    ``_fill_expert_block_ids_kernel``) into one launch. Grid: one CTA per local
+    expert. Every CTA recomputes the (tiny, num_local_experts-wide) aligned
+    cumsum in registers, then CTA ``e`` writes only its own disjoint slices:
+
+      - exclusive_offsets[e], inclusive_offsets[e]   (offset arrays)
+      - expert_ids[excl_e//BM : incl_e//BM] = e      (block→expert map)
+      - sorted_token_ids[excl_e : incl_e] = SENTINEL (padding for its block)
+
+    The union of the per-expert [excl_e, incl_e) ranges is exactly
+    [0, num_tokens_post_padded), which is the only region the grouped-GEMM
+    reads (it strides tiles up to cdiv(num_tokens_post_padded, BM)); the buffer
+    tail beyond that is never read, so it needs no initialization. The
+    subsequent scatter overwrites the real token slots at the front of each
+    expert's block, leaving the alignment padding at SENTINEL. Correctness is
+    identical to the 3-kernel path; the only difference is fewer launches.
+    """
+    e = tl.program_id(0)
+    r = tl.arange(0, NLE_POW2)
+    mask = r < num_local_experts
+    h = tl.load(tokens_per_expert_ptr + r, mask=mask, other=0)
+    if ALIGNMENT > 1:
+        h = tl.where(h > 0, ((h + ALIGNMENT - 1) // ALIGNMENT) * ALIGNMENT, h)
+    inc = tl.cumsum(h, axis=0)
+    exc = inc - h
+    # Select this CTA's own offsets by masked reduction over the lane axis.
+    excl_e = tl.sum(tl.where(r == e, exc, 0))
+    incl_e = tl.sum(tl.where(r == e, inc, 0))
+    tl.store(exclusive_offsets_ptr + e, excl_e)
+    tl.store(inclusive_offsets_ptr + e, incl_e)
+
+    start_block = excl_e // ALIGNMENT
+    end_block = incl_e // ALIGNMENT
+    for off in tl.range(start_block, end_block, FILL_BLOCK):
+        idxs = off + tl.arange(0, FILL_BLOCK)
+        tl.store(expert_ids_ptr + idxs, e, mask=idxs < end_block)
+
+    for off in tl.range(excl_e, incl_e, FILL_BLOCK):
+        idxs = off + tl.arange(0, FILL_BLOCK)
+        tl.store(sorted_token_ids_ptr + idxs, SENTINEL, mask=idxs < incl_e)
+
+
+@triton.jit
+def _count_prefix_fill_init_kernel(
+    routing_map_ptr,  # [max_tokens, topk] expert assignments (global IDs)
+    valid_tokens_ptr,  # scalar int32 CUDA tensor: valid tokens this iteration
+    exclusive_offsets_ptr,  # [num_local_experts] out: exclusive prefix sum (scatter counters)
+    inclusive_offsets_ptr,  # [num_local_experts] out: inclusive prefix sum
+    expert_ids_ptr,  # [max_blocks] out: expert index per BLOCK_SIZE_M block
+    sorted_token_ids_ptr,  # [max_sorted] out: SENTINEL-initialized indirection table
+    num_local_experts,
+    local_expert_start,
+    topk: tl.constexpr,
+    SENTINEL: tl.constexpr,
+    ALIGNMENT: tl.constexpr,  # = BLOCK_SIZE_M
+    NUM_BINS: tl.constexpr,  # next_power_of_2(num_local_experts + 1)
+    COUNT_BLOCK: tl.constexpr,  # pairs histogrammed per iteration
+    FILL_BLOCK: tl.constexpr,  # vectorized store width
+):
+    """``_prefix_fill_init_kernel`` with the per-expert token count folded in.
+
+    ``_prefix_fill_init_kernel`` already has every CTA redundantly recompute the
+    tiny ``num_local_experts``-wide cumsum in registers, and its only input is
+    the count vector. That vector costs two extra launches to produce: a
+    ``torch.zeros`` fill for the counters plus
+    ``_count_local_tokens_kernel_persistent``. Recomputing the histogram
+    redundantly in every CTA removes both launches.
+
+    The count kernel is far more expensive than its work implies (measured 7.52
+    us of device time in the BS256 decode graph, against a 0.72 us empty-kernel
+    floor, to bucket 2048 int32s): with ``BLOCK_SIZE=1024`` and 2048 valid pairs
+    only 2 of its 152 CTAs receive any work, and each issues 1024 global atomics
+    contending on 32 counters. Here each CTA instead accumulates a private
+    register histogram over the same pairs, so there are no global atomics and
+    no cross-CTA ordering at all.
+
+    Counts are integer-identical to the atomic path, so the whole indirection
+    table -- and therefore the GEMM output -- is unchanged.
+
+    Redundant work is the trade: every CTA reads all ``valid_pairs`` entries, so
+    the read volume is ``num_local_experts x`` the atomic path's. At decode that
+    is 32 x 8 KB from L2 and free; the caller restricts this variant to the
+    decode regime for that reason.
+    """
+    e = tl.program_id(0)
+    valid_pairs = tl.load(valid_tokens_ptr) * topk
+
+    # Private per-CTA histogram of local expert IDs. Non-local and out-of-range
+    # pairs are folded into the dropped bin `num_local_experts`, which NUM_BINS
+    # is sized to hold and the mask below discards.
+    acc = tl.zeros([NUM_BINS], dtype=tl.int32)
+    for base in tl.range(0, valid_pairs, COUNT_BLOCK):
+        offs = base + tl.arange(0, COUNT_BLOCK)
+        m = offs < valid_pairs
+        eids = tl.load(routing_map_ptr + offs, mask=m, other=-1)
+        lids = eids - local_expert_start
+        is_local = (lids >= 0) & (lids < num_local_experts) & m
+        # routing_map is int64; tl.histogram wants int32 bin indices.
+        bins = tl.where(is_local, lids, num_local_experts).to(tl.int32)
+        acc += tl.histogram(bins, NUM_BINS)
+
+    r = tl.arange(0, NUM_BINS)
+    mask = r < num_local_experts
+    h = tl.where(mask, acc, 0)
+    if ALIGNMENT > 1:
+        h = tl.where(h > 0, ((h + ALIGNMENT - 1) // ALIGNMENT) * ALIGNMENT, h)
+    inc = tl.cumsum(h, axis=0)
+    exc = inc - h
+    excl_e = tl.sum(tl.where(r == e, exc, 0))
+    incl_e = tl.sum(tl.where(r == e, inc, 0))
+    tl.store(exclusive_offsets_ptr + e, excl_e)
+    tl.store(inclusive_offsets_ptr + e, incl_e)
+
+    start_block = excl_e // ALIGNMENT
+    end_block = incl_e // ALIGNMENT
+    for off in tl.range(start_block, end_block, FILL_BLOCK):
+        idxs = off + tl.arange(0, FILL_BLOCK)
+        tl.store(expert_ids_ptr + idxs, e, mask=idxs < end_block)
+
+    for off in tl.range(excl_e, incl_e, FILL_BLOCK):
+        idxs = off + tl.arange(0, FILL_BLOCK)
+        tl.store(sorted_token_ids_ptr + idxs, SENTINEL, mask=idxs < incl_e)
+
+
+@triton.jit
+def _align_single_kernel(
+    routing_map_ptr,  # [max_tokens, topk] expert assignments (global IDs)
+    valid_tokens_ptr,  # scalar int32 CUDA tensor: valid tokens this iteration
+    exclusive_offsets_ptr,  # [num_local_experts] out: exclusive prefix sum
+    inclusive_offsets_ptr,  # [num_local_experts] out: inclusive prefix sum
+    expert_ids_ptr,  # [max_blocks] out: expert index per BLOCK_SIZE_M block
+    sorted_token_ids_ptr,  # [max_sorted] out: indirection table
+    num_local_experts,
+    local_expert_start,
+    topk: tl.constexpr,
+    SENTINEL: tl.constexpr,
+    ALIGNMENT: tl.constexpr,  # = BLOCK_SIZE_M
+    NUM_BINS: tl.constexpr,  # next_power_of_2(num_local_experts + 1)
+    COUNT_BLOCK: tl.constexpr,  # pairs processed per iteration
+    FILL_BLOCK: tl.constexpr,  # vectorized store width
+):
+    """``_count_prefix_fill_init_kernel`` with the scatter folded in: the whole
+    indirection-table build in one launch.
+
+    CTA ``e`` owns local expert ``e`` and the disjoint output slice
+    ``[excl_e, incl_e)``. It already streams every valid pair once to build its
+    private histogram; a second streaming pass over the same (L2-resident, 16 KB
+    at decode) pairs lets it place its own pairs itself. Within a pass the
+    destination is ``excl_e + written_so_far + exclusive_cumsum(is_mine)``, so
+    no global atomics and no cross-CTA ordering are involved, and the resulting
+    table is deterministic (ascending pair index within each expert block)
+    rather than atomically permuted.
+
+    The second pass is why this is not free: it doubles the redundant read of
+    the routing map. The pairs are tiny and cached, so the trade is one removed
+    launch (``_scatter_token_indices_kernel``, measured 2.66 us + 0.55 us of
+    dispatch gap per layer in the BS256 decode graph) against that extra pass.
+
+    Row order within an expert block does not affect the result: each row of
+    ``sorted_token_ids`` is a ``token * topk + slot`` pair index, and the FC2
+    output is indexed by that same pair index, so any permutation within a
+    block produces identical values downstream.
+    """
+    e = tl.program_id(0)
+    valid_pairs = tl.load(valid_tokens_ptr) * topk
+
+    acc = tl.zeros([NUM_BINS], dtype=tl.int32)
+    for base in tl.range(0, valid_pairs, COUNT_BLOCK):
+        offs = base + tl.arange(0, COUNT_BLOCK)
+        m = offs < valid_pairs
+        eids = tl.load(routing_map_ptr + offs, mask=m, other=-1)
+        lids = eids - local_expert_start
+        is_local = (lids >= 0) & (lids < num_local_experts) & m
+        bins = tl.where(is_local, lids, num_local_experts).to(tl.int32)
+        acc += tl.histogram(bins, NUM_BINS)
+
+    r = tl.arange(0, NUM_BINS)
+    mask = r < num_local_experts
+    h = tl.where(mask, acc, 0)
+    if ALIGNMENT > 1:
+        h = tl.where(h > 0, ((h + ALIGNMENT - 1) // ALIGNMENT) * ALIGNMENT, h)
+    inc = tl.cumsum(h, axis=0)
+    exc = inc - h
+    excl_e = tl.sum(tl.where(r == e, exc, 0))
+    incl_e = tl.sum(tl.where(r == e, inc, 0))
+    tl.store(exclusive_offsets_ptr + e, excl_e)
+    tl.store(inclusive_offsets_ptr + e, incl_e)
+
+    start_block = excl_e // ALIGNMENT
+    end_block = incl_e // ALIGNMENT
+    for off in tl.range(start_block, end_block, FILL_BLOCK):
+        idxs = off + tl.arange(0, FILL_BLOCK)
+        tl.store(expert_ids_ptr + idxs, e, mask=idxs < end_block)
+
+    # SENTINEL-fill this expert's slice first; the scatter below overwrites the
+    # real pairs at the front of it and leaves the alignment padding sentinel.
+    for off in tl.range(excl_e, incl_e, FILL_BLOCK):
+        idxs = off + tl.arange(0, FILL_BLOCK)
+        tl.store(sorted_token_ids_ptr + idxs, SENTINEL, mask=idxs < incl_e)
+
+    pos = excl_e
+    for base in tl.range(0, valid_pairs, COUNT_BLOCK):
+        offs = base + tl.arange(0, COUNT_BLOCK)
+        m = offs < valid_pairs
+        eids = tl.load(routing_map_ptr + offs, mask=m, other=-1)
+        is_mine = (eids - local_expert_start == e) & m
+        sel = is_mine.to(tl.int32)
+        rank = tl.cumsum(sel, axis=0) - sel
+        tl.store(sorted_token_ids_ptr + pos + rank, offs, mask=is_mine)
+        pos += tl.sum(sel)
+
+
+# Fuse init + prefix-sum + expert-block fill (3 tiny serial kernels) into one
+# launch in the decode indirection-table build. Env-toggleable for A/B; the
+# fused path is numerically identical to the default (only launch count differs).
+_USE_FUSED_ALIGN: bool = os.environ.get("MCORE_MOE_FUSED_ALIGN", "0") == "1"
+
+# Additionally fold the per-expert token count (and the `torch.zeros` fill of its
+# counter buffer) into that same launch, taking the decode indirection-table
+# build from 4 kernels to 2. Requires MCORE_MOE_FUSED_ALIGN. Integer-exact.
+_USE_FUSED_COUNT: bool = os.environ.get("MCORE_MOE_FUSED_COUNT", "0") == "1"
+
+# Above this token hint the redundant per-CTA histogram stops being free, so hand
+# back to the atomic count kernel, whose read volume does not scale with the
+# expert count. 512 matches the decode regime `_get_decode_tuned_configs` targets.
+_FUSED_COUNT_MAX_TOKENS = 512
+
+# Additionally fold the scatter into that same launch, taking the decode
+# indirection-table build from 2 kernels to 1. Requires MCORE_MOE_FUSED_COUNT.
+# Produces the same table up to row order within an expert block, which the
+# downstream pair-indexed GEMM is invariant to.
+_USE_FUSED_SCATTER: bool = os.environ.get("MCORE_MOE_FUSED_SCATTER", "0") == "1"
+
+
+def _moe_align_block_size_fused(
+    routing_map: torch.Tensor,
+    block_size: int,
+    num_local_experts: int,
+    local_expert_start: int,
+    valid_tokens: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """3-kernel indirection-table build (count -> prefix_fill_init -> scatter).
+
+    Drop-in replacement for ``_moe_align_block_size_cuda_graphable`` that folds
+    the separate init + prefix-sum + fill kernels into ``_prefix_fill_init_kernel``.
+    Returns the same (sorted_token_ids, expert_ids, num_tokens_post_padded).
+    """
+    max_tokens, topk = routing_map.shape
+    device = routing_map.device
+
+    max_sorted = max_tokens * topk + block_size * (num_local_experts + 1)
+    max_blocks = _ceil_div(max_sorted, block_size)
+    sentinel = max_tokens * topk
+
+    sorted_token_ids = torch.empty(max_sorted, dtype=torch.int32, device=device)
+    expert_ids = torch.empty(max_blocks, dtype=torch.int32, device=device)
+
+    tokens_per_expert = compute_local_tokens_per_expert(
+        routing_map, local_expert_start, num_local_experts, valid_tokens, persistent=True
+    )
+    exclusive_offsets = torch.empty(num_local_experts, dtype=torch.int32, device=device)
+    inclusive_offsets = torch.empty(num_local_experts, dtype=torch.int32, device=device)
+
+    _prefix_fill_init_kernel[(num_local_experts,)](
+        tokens_per_expert,
+        exclusive_offsets,
+        inclusive_offsets,
+        expert_ids,
+        sorted_token_ids,
+        num_local_experts,
+        SENTINEL=sentinel,
+        ALIGNMENT=block_size,
+        NLE_POW2=triton.next_power_of_2(num_local_experts),
+        FILL_BLOCK=128,
+    )
+
+    max_pairs = max_tokens * topk
+    SCATTER_BLOCK = 256
+    scatter_grid = _ceil_div(max_pairs, SCATTER_BLOCK)
+    _scatter_token_indices_kernel[(scatter_grid,)](
+        routing_map,
+        sorted_token_ids,
+        exclusive_offsets,
+        valid_tokens,
+        topk,
+        local_expert_start,
+        num_local_experts,
+        max_pairs,
+        BLOCK_SIZE=SCATTER_BLOCK,
+    )
+
+    num_tokens_post_padded = inclusive_offsets[-1:]
+    return sorted_token_ids, expert_ids, num_tokens_post_padded
+
+
+def _moe_align_block_size_count_fused(
+    routing_map: torch.Tensor,
+    block_size: int,
+    num_local_experts: int,
+    local_expert_start: int,
+    valid_tokens: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """2-kernel indirection-table build (count_prefix_fill_init -> scatter).
+
+    Same contract and same outputs as ``_moe_align_block_size_fused``; it just
+    folds the token count and its counter-buffer zero-fill into the first launch.
+    """
+    max_tokens, topk = routing_map.shape
+    device = routing_map.device
+
+    max_sorted = max_tokens * topk + block_size * (num_local_experts + 1)
+    max_blocks = _ceil_div(max_sorted, block_size)
+    sentinel = max_tokens * topk
+
+    sorted_token_ids = torch.empty(max_sorted, dtype=torch.int32, device=device)
+    expert_ids = torch.empty(max_blocks, dtype=torch.int32, device=device)
+    exclusive_offsets = torch.empty(num_local_experts, dtype=torch.int32, device=device)
+    inclusive_offsets = torch.empty(num_local_experts, dtype=torch.int32, device=device)
+
+    _count_prefix_fill_init_kernel[(num_local_experts,)](
+        routing_map,
+        valid_tokens,
+        exclusive_offsets,
+        inclusive_offsets,
+        expert_ids,
+        sorted_token_ids,
+        num_local_experts,
+        local_expert_start,
+        topk=topk,
+        SENTINEL=sentinel,
+        ALIGNMENT=block_size,
+        NUM_BINS=triton.next_power_of_2(num_local_experts + 1),
+        COUNT_BLOCK=1024,
+        FILL_BLOCK=128,
+    )
+
+    max_pairs = max_tokens * topk
+    SCATTER_BLOCK = 256
+    scatter_grid = _ceil_div(max_pairs, SCATTER_BLOCK)
+    _scatter_token_indices_kernel[(scatter_grid,)](
+        routing_map,
+        sorted_token_ids,
+        exclusive_offsets,
+        valid_tokens,
+        topk,
+        local_expert_start,
+        num_local_experts,
+        max_pairs,
+        BLOCK_SIZE=SCATTER_BLOCK,
+    )
+
+    num_tokens_post_padded = inclusive_offsets[-1:]
+    return sorted_token_ids, expert_ids, num_tokens_post_padded
+
+
+def _moe_align_block_size_single(
+    routing_map: torch.Tensor,
+    block_size: int,
+    num_local_experts: int,
+    local_expert_start: int,
+    valid_tokens: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """1-kernel indirection-table build.
+
+    Same contract and same outputs as ``_moe_align_block_size_count_fused``,
+    with the scatter folded into the single launch as well. Row order within an
+    expert block is ascending pair index instead of atomically permuted; the
+    downstream GEMM indexes rows by pair id, so the result is unchanged.
+    """
+    max_tokens, topk = routing_map.shape
+    device = routing_map.device
+
+    max_sorted = max_tokens * topk + block_size * (num_local_experts + 1)
+    max_blocks = _ceil_div(max_sorted, block_size)
+    sentinel = max_tokens * topk
+
+    sorted_token_ids = torch.empty(max_sorted, dtype=torch.int32, device=device)
+    expert_ids = torch.empty(max_blocks, dtype=torch.int32, device=device)
+    exclusive_offsets = torch.empty(num_local_experts, dtype=torch.int32, device=device)
+    inclusive_offsets = torch.empty(num_local_experts, dtype=torch.int32, device=device)
+
+    _align_single_kernel[(num_local_experts,)](
+        routing_map,
+        valid_tokens,
+        exclusive_offsets,
+        inclusive_offsets,
+        expert_ids,
+        sorted_token_ids,
+        num_local_experts,
+        local_expert_start,
+        topk=topk,
+        SENTINEL=sentinel,
+        ALIGNMENT=block_size,
+        NUM_BINS=triton.next_power_of_2(num_local_experts + 1),
+        COUNT_BLOCK=1024,
+        FILL_BLOCK=128,
+    )
+
+    num_tokens_post_padded = inclusive_offsets[-1:]
+    return sorted_token_ids, expert_ids, num_tokens_post_padded
 
 
 def _moe_align_block_size_cuda_graphable(
@@ -634,7 +1053,16 @@ def vllm_fused_moe(
     # buffer size. Same config is used for both FC1 and FC2 (matches vLLM).
     config = _get_default_config(M=effective_tokens, E=num_local_experts, top_k=topk)
 
-    sorted_token_ids, expert_ids, num_post_padded = _moe_align_block_size_cuda_graphable(
+    if _USE_FUSED_ALIGN and _USE_FUSED_COUNT and effective_tokens <= _FUSED_COUNT_MAX_TOKENS:
+        if _USE_FUSED_SCATTER:
+            align_fn = _moe_align_block_size_single
+        else:
+            align_fn = _moe_align_block_size_count_fused
+    elif _USE_FUSED_ALIGN:
+        align_fn = _moe_align_block_size_fused
+    else:
+        align_fn = _moe_align_block_size_cuda_graphable
+    sorted_token_ids, expert_ids, num_post_padded = align_fn(
         routing_map, config['BLOCK_SIZE_M'], num_local_experts, local_expert_start, valid_tokens
     )
     num_valid = max_tokens * topk

--- a/megatron/core/inference/step_gpu_timing.py
+++ b/megatron/core/inference/step_gpu_timing.py
@@ -1,0 +1,209 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""GPU-side step accounting for dynamic inference decode, without a profiler.
+
+Two questions this answers that nsys cannot on this workload:
+
+1. **How much of a decode step is the transformer-block CUDA graph?** Everything
+   else (embedding, final norm, logits GEMM, sampling, bookkeeping) is eager and
+   host-driven, so the block-graph share decides whether the remaining gap to
+   vLLM lives inside the model's GPU work or in exposed host/eager time.
+
+2. **How skewed are the EP ranks?** The NVLS dispatch/combine collectives are
+   spin-waits, so their cost is set by cross-rank arrival skew rather than by
+   bytes moved. All four ranks are processes on one node, so ``perf_counter_ns``
+   (CLOCK_MONOTONIC) is directly comparable between them and the spread of
+   step-entry timestamps measures that skew directly.
+
+Why not nsys: on this workload nsys costs ~28% end-to-end regardless of
+``--cuda-graph-trace`` mode, and that overhead is host-side, which desynchronizes
+the EP ranks and inflates exactly these spin-wait collectives (~120x observed).
+Any absolute idle or barrier number read from such a trace is unusable.
+
+Cost control: CUDA events are recorded into a ring of pairs and only read back
+once the ring wraps, so a step never synchronizes on its own work. Env-gated
+(``MCORE_INFER_STEP_GPU_TIMING``); default off.
+"""
+
+# Reports go to stderr on purpose: this runs inside a multi-rank inference server
+# whose logger configuration is the caller's, and a diagnostic must not depend on it.
+# pylint: disable=bad-builtin
+
+import os
+import statistics
+import sys
+import time
+
+USE_STEP_GPU_TIMING: bool = os.environ.get("MCORE_INFER_STEP_GPU_TIMING", "0") == "1"
+# Number of event pairs held before a readback. One readback per RING steps.
+_RING: int = int(os.environ.get("MCORE_INFER_STEP_GPU_RING", "64"))
+_REPORT_EVERY: int = int(os.environ.get("MCORE_INFER_STEP_GPU_REPORT_EVERY", "256"))
+# Steps to discard before accumulating, so graph warmup and the first ramp steps
+# do not pollute the medians.
+_SKIP: int = int(os.environ.get("MCORE_INFER_STEP_GPU_SKIP", "64"))
+
+_installed = False
+
+
+class _Acc:
+    def __init__(self):
+        self.events = []  # [(start_event, end_event)] ring
+        self.slot = 0
+        self.calls = 0
+        self.gpu_ms = []  # block-graph GPU durations
+        self.period_ms = []  # host wall time between consecutive block entries
+        self.entry_ns = []  # step-entry timestamps, for cross-rank skew
+        self.last_entry = None
+        self.pending = []  # slots with recorded-but-unread events
+
+
+_acc = _Acc()
+
+
+def _rank():
+    try:
+        import torch.distributed as dist
+
+        if dist.is_available() and dist.is_initialized():
+            return dist.get_rank()
+    except Exception:
+        pass
+    return int(os.environ.get("RANK", "0"))
+
+
+def _drain():
+    """Read back every recorded pair in the ring. Called only when the ring wraps,
+    so the work being queried is long finished and this does not stall the step."""
+    if not _acc.pending:
+        return
+    # Only the newest pair could still be in flight; syncing on it is what makes
+    # the readback safe without syncing the whole device.
+    _acc.events[_acc.pending[-1]][1].synchronize()
+    for s in _acc.pending:
+        st, en = _acc.events[s]
+        try:
+            _acc.gpu_ms.append(st.elapsed_time(en))
+        except Exception:
+            pass
+    _acc.pending.clear()
+
+
+def _dump_entry_times():
+    """Write this rank's step-entry timestamps so skew can be computed across ranks.
+
+    Comparable across ranks because all four are processes on the same node.
+    """
+    d = os.environ.get("MCORE_INFER_STEP_GPU_DUMP", "")
+    if not d or not _acc.entry_ns:
+        return
+    try:
+        os.makedirs(d, exist_ok=True)
+        with open(os.path.join(d, f"entry_r{_rank()}.txt"), "w", encoding="utf-8") as f:
+            for t in _acc.entry_ns:
+                f.write(f"{t}\n")
+    except Exception as e:
+        print(f"[STEP_GPU] dump failed: {e}", file=sys.stderr, flush=True)
+
+
+def _report():
+    r = _rank()
+    n = len(_acc.gpu_ms)
+    if n < 8:
+        return
+    g = statistics.median(_acc.gpu_ms)
+    lines = [f"[STEP_GPU r{r}] after {_acc.calls} block calls, {n} timed:"]
+    lines.append(
+        f"  block-graph GPU   median {g:7.3f} ms   "
+        f"p10 {statistics.quantiles(_acc.gpu_ms, n=10)[0]:.3f} "
+        f"p90 {statistics.quantiles(_acc.gpu_ms, n=10)[8]:.3f}"
+    )
+    if len(_acc.period_ms) >= 8:
+        p = statistics.median(_acc.period_ms)
+        lines.append(
+            f"  step period (host) median {p:7.3f} ms   "
+            f"p10 {statistics.quantiles(_acc.period_ms, n=10)[0]:.3f} "
+            f"p90 {statistics.quantiles(_acc.period_ms, n=10)[8]:.3f}"
+        )
+        lines.append(
+            f"  => block graph is {100 * g / p:5.1f}% of the step; "
+            f"{p - g:6.3f} ms/step is outside it"
+        )
+    print("\n".join(lines), file=sys.stderr, flush=True)
+    # Per-component in-situ attribution, printed against the block total it has to
+    # reconcile with -- the parts are only meaningful if they reconstruct the whole.
+    try:
+        from megatron.core.inference import insitu_timing
+
+        insitu_timing.report(block_ms=g)
+
+        from megatron.core.inference.moe import expert_histogram
+
+        expert_histogram.dump()
+    except Exception as e:
+        print(f"[STEP_GPU] insitu report failed: {e}", file=sys.stderr, flush=True)
+    # Dump here rather than only at exit: the harness SIGTERMs the server, which
+    # skips atexit handlers, so an exit-only dump would usually produce nothing.
+    _dump_entry_times()
+
+
+def install():
+    """Wrap TransformerBlock.__call__ so the CUDA-graph path is timed."""
+    global _installed
+    if not USE_STEP_GPU_TIMING or _installed:
+        return
+    import atexit
+
+    import torch
+
+    from megatron.core.transformer.transformer_block import TransformerBlock
+
+    orig_call = TransformerBlock.__call__
+    if getattr(orig_call, "_step_gpu_timed", False):
+        return
+
+    for _ in range(_RING):
+        _acc.events.append(
+            (torch.cuda.Event(enable_timing=True), torch.cuda.Event(enable_timing=True))
+        )
+
+    def timed_call(self, *args, **kwargs):
+        # Only the graph path is interesting; prefill and non-graph steps would
+        # mix different work into the same medians.
+        if not self._should_call_local_cudagraph(*args, **kwargs):
+            return orig_call(self, *args, **kwargs)
+
+        _acc.calls += 1
+        if _acc.calls <= _SKIP:
+            return orig_call(self, *args, **kwargs)
+
+        now = time.perf_counter_ns()
+        if _acc.last_entry is not None:
+            _acc.period_ms.append((now - _acc.last_entry) / 1e6)
+        _acc.last_entry = now
+        _acc.entry_ns.append(now)
+
+        s = _acc.slot
+        if s == 0:
+            _drain()
+        st, en = _acc.events[s]
+        st.record()
+        try:
+            return orig_call(self, *args, **kwargs)
+        finally:
+            en.record()
+            _acc.pending.append(s)
+            _acc.slot = (s + 1) % _RING
+            if _REPORT_EVERY > 0 and _acc.calls % _REPORT_EVERY == 0:
+                _drain()
+                _report()
+
+    timed_call._step_gpu_timed = True
+    TransformerBlock.__call__ = timed_call
+    atexit.register(_dump_entry_times)
+    atexit.register(_report)
+    _installed = True
+    print(
+        f"[STEP_GPU] installed (ring {_RING}, skip {_SKIP}, " f"report every {_REPORT_EVERY})",
+        file=sys.stderr,
+        flush=True,
+    )

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -4,6 +4,7 @@ import asyncio
 import concurrent
 import copy
 import functools
+import os
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, OrderedDict, Tuple, Union
@@ -71,6 +72,10 @@ from megatron.core.inference.text_generation_controllers.mtp_utils_triton import
     prepare_next_forward_pass,
     verify_speculative_tokens,
 )
+
+# Reduced-op path for the post-sampling bookkeeping chain; shares the gate with
+# `DynamicInferenceContext.update_requests`. See the ledger record QWEN-024.
+_VEC_UPDATE_REQS = os.environ.get("MCORE_INFER_VEC_UPDATE_REQS", "0") == "1"
 
 
 @dataclass
@@ -1849,6 +1854,26 @@ class TextGenerationController:
         # Clear temporary dummy state while preserving reusable prefix state and counters.
         context.reset(preserve_prefix_cache=True, preserve_counters=True)
 
+    def _empty_finished_idxs(self, device: torch.device) -> Tensor:
+        """Cached empty index tensor matching what `torch.nonzero` would return."""
+        cached = getattr(self, "_empty_finished_idxs_cache", None)
+        if cached is None or cached.device != device:
+            cached = torch.empty(0, dtype=torch.long, device=device)
+            self._empty_finished_idxs_cache = cached
+        return cached
+
+    def _empty_finished_ids(self, request_ids: Tensor) -> Tensor:
+        """Cached empty tensor matching an empty gather from `request_ids`."""
+        cached = getattr(self, "_empty_finished_ids_cache", None)
+        if (
+            cached is None
+            or cached.dtype != request_ids.dtype
+            or cached.device != request_ids.device
+        ):
+            cached = torch.empty(0, dtype=request_ids.dtype, device=request_ids.device)
+            self._empty_finished_ids_cache = cached
+        return cached
+
     def _transfer_samples_to_cpu(self, active_request_count: int) -> tuple:
         """Batch GPU-to-CPU transfer of sampled tokens.
 
@@ -1937,10 +1962,17 @@ class TextGenerationController:
         # Apply stop words detected during the previous engine bookkeeping step.
         self._apply_stop_word_finished_ids(active_request_ids, active_request_mask)
 
-        finished_idxs = (
-            torch.nonzero(active_request_mask == 0, as_tuple=True)[0] + context.paused_request_count
-        )
-        finished_request_ids = context.request_ids[finished_idxs]
+        if _VEC_UPDATE_REQS and int(active_request_mask.sum()) == active_request_count:
+            # Steady-state decode: nothing finished this step, so skip the
+            # `nonzero` scan and the advanced-index gather it feeds.
+            finished_idxs = self._empty_finished_idxs(active_request_mask.device)
+            finished_request_ids = self._empty_finished_ids(context.request_ids)
+        else:
+            finished_idxs = (
+                torch.nonzero(active_request_mask == 0, as_tuple=True)[0]
+                + context.paused_request_count
+            )
+            finished_request_ids = context.request_ids[finished_idxs]
 
         # Save block IDs for finished requests before update_requests releases them.
         # Needed for per-block routing reconstruction in the engine.

--- a/megatron/core/tensor_parallel/inference_layers.py
+++ b/megatron/core/tensor_parallel/inference_layers.py
@@ -190,6 +190,13 @@ class InferenceLayerNormColumnParallelLinear(TELayerNormColumnParallelLinear):
         # has already applied the rms-norm and all-gather.
         self.skip_norm_and_all_gather = False
 
+        # Set externally (one decode step at a time) by the preceding transformer
+        # layer's fused mlp_bda add + input-RMSNorm kernel, which produces this
+        # layer's normalized QKV input as a by-product of the residual add. When
+        # present it replaces the norm launch below and is consumed immediately.
+        # Only the tp_size == 1 path honors it; see MCORE_FUSED_ADD_NORM_QKV.
+        self.prenormed_input = None
+
     def set_barrier_before_all_gather(self, value: bool = True) -> None:
         """Request a barrier before this layer's input all-gather reuses the buffer.
 
@@ -253,7 +260,14 @@ class InferenceLayerNormColumnParallelLinear(TELayerNormColumnParallelLinear):
             return super().forward(x)
 
         if self.tp_size == 1:
-            x = _te_rms_norm_kernel(x=x, weight=self.layer_norm_weight, eps=self.eps)
+            prenormed = self.prenormed_input
+            if prenormed is not None:
+                # The preceding layer's fused add+norm already produced this; consume
+                # it so a stale tensor can never leak into a later step.
+                self.prenormed_input = None
+                x = prenormed
+            else:
+                x = _te_rms_norm_kernel(x=x, weight=self.layer_norm_weight, eps=self.eps)
             x = _apply_linear(x, self.weight, self.config)
             return x, None
 

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -35,6 +35,17 @@ from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.mappings import all_gather_last_dim_from_tensor_parallel_region
 from megatron.core.transformer.identity_op import IdentityOp
 from megatron.core.transformer.module import MegatronModule
+
+try:
+    from megatron.core.inference.attention.fused_qk_norm import (
+        can_use_fused_qk_norm as _can_use_fused_qk_norm,
+    )
+    from megatron.core.inference.attention.fused_qk_norm import (
+        fused_qk_rmsnorm as _fused_qk_rmsnorm,
+    )
+except Exception:  # keep attention importable if the inference helper is unavailable
+    _can_use_fused_qk_norm = None
+    _fused_qk_rmsnorm = None
 from megatron.core.transformer.torch_norm import L2Norm, LayerNormBuilder
 from megatron.core.transformer.utils import is_layer_window_attention
 from megatron.core.typed_torch import apply_module, not_none
@@ -1919,11 +1930,24 @@ class SelfAttention(Attention):
             )
             query = query[:, :, idx * size : (idx + 1) * size, :]
 
-        if self.q_layernorm is not None:
-            query = apply_module(self.q_layernorm)(query)
+        if _can_use_fused_qk_norm is not None and _can_use_fused_qk_norm(
+            self.q_layernorm, self.k_layernorm, query, key
+        ):
+            # Fuse the two per-head RMSNorm launches into one (env-gated, decode).
+            query, key = _fused_qk_rmsnorm(
+                query,
+                key,
+                self.q_layernorm.weight,
+                self.k_layernorm.weight,
+                self.config.layernorm_epsilon,
+                self.config.layernorm_zero_centered_gamma,
+            )
+        else:
+            if self.q_layernorm is not None:
+                query = apply_module(self.q_layernorm)(query)
 
-        if self.k_layernorm is not None:
-            key = apply_module(self.k_layernorm)(key)
+            if self.k_layernorm is not None:
+                key = apply_module(self.k_layernorm)(key)
 
         if self.config.test_mode:
             self.run_realtime_tests()

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import copy
 import inspect
+import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Callable, Optional, Protocol, Tuple, Union
@@ -41,11 +42,19 @@ try:
         can_use_fused_qk_norm as _can_use_fused_qk_norm,
     )
     from megatron.core.inference.attention.fused_qk_norm import (
+        can_use_grouped_qk_norm as _can_use_grouped_qk_norm,
+    )
+    from megatron.core.inference.attention.fused_qk_norm import (
         fused_qk_rmsnorm as _fused_qk_rmsnorm,
+    )
+    from megatron.core.inference.attention.fused_qk_norm import (
+        fused_qk_rmsnorm_grouped as _fused_qk_rmsnorm_grouped,
     )
 except Exception:  # keep attention importable if the inference helper is unavailable
     _can_use_fused_qk_norm = None
     _fused_qk_rmsnorm = None
+    _can_use_grouped_qk_norm = None
+    _fused_qk_rmsnorm_grouped = None
 from megatron.core.transformer.torch_norm import L2Norm, LayerNormBuilder
 from megatron.core.transformer.utils import is_layer_window_attention
 from megatron.core.typed_torch import apply_module, not_none
@@ -66,6 +75,10 @@ from ..models.common.embeddings.yarn_rotary_pos_embedding import (
 )
 from .enums import AttnMaskType
 from .transformer_config import TransformerConfig
+
+# Split QKV with torch.split (views) instead of TE's SplitAlongDim. Under test as the
+# suspected source of one full-QKV-sized copy per decode layer; see COPY-ID-S18.
+_QKV_SPLIT_VIEWS: bool = os.environ.get("MCORE_QKV_SPLIT_VIEWS", "0") == "1"
 
 try:
     from einops import rearrange
@@ -1893,7 +1906,7 @@ class SelfAttention(Attention):
                 self.hidden_size_per_attention_head,
             ]
 
-            if SplitAlongDim is not None:
+            if SplitAlongDim is not None and not _QKV_SPLIT_VIEWS:
                 query, gate, key, value = SplitAlongDim(mixed_qkv, 3, split_arg_list)
             else:
                 query, gate, key, value = torch.split(mixed_qkv, split_arg_list, dim=3)
@@ -1910,31 +1923,23 @@ class SelfAttention(Attention):
             if not split_qkv:
                 return mixed_qkv, split_arg_list
 
-            if SplitAlongDim is not None:
+            if SplitAlongDim is not None and not _QKV_SPLIT_VIEWS:
                 query, key, value = SplitAlongDim(mixed_qkv, 3, split_arg_list)
             else:
                 query, key, value = torch.split(mixed_qkv, split_arg_list, dim=3)
 
-        # Query [sq, b, ng, np/ng * hn] -> [sq, b, np, hn]
-        query = query.reshape(query.size(0), query.size(1), -1, self.hidden_size_per_attention_head)
-
-        if self.config.num_query_groups < self.world_size:
-            # query above corresponds to (num_q_heads / num_kv_heads) q_heads.
-            # Index appropriately into query to get (num_q_heads / tp_size) q_heads.
-            # This is step 4 in the list of steps above.
-            idx = get_pg_rank(self.pg_collection.tp) % (
-                self.world_size // self.config.num_query_groups
-            )
-            size = self.num_attention_heads_per_partition // (
-                self.world_size // self.config.num_query_groups
-            )
-            query = query[:, :, idx * size : (idx + 1) * size, :]
-
-        if _can_use_fused_qk_norm is not None and _can_use_fused_qk_norm(
-            self.q_layernorm, self.k_layernorm, query, key
+        # The [sq, b, ng, np/ng * hn] -> [sq, b, np, hn] reshape below is a *copy*, not a
+        # view: merging the group and head axes needs the group stride to equal
+        # (np/ng) * hn, and it is (np/ng + 2) * hn because each group's k and v head sit
+        # between consecutive groups' q heads. When the fused q/k norm can read the
+        # grouped layout directly it writes that shape itself for free, and the copy --
+        # one full-size strided copy per layer per decode step -- never happens.
+        if (
+            _can_use_grouped_qk_norm is not None
+            and self.config.num_query_groups >= self.world_size
+            and _can_use_grouped_qk_norm(self.q_layernorm, self.k_layernorm, query, key)
         ):
-            # Fuse the two per-head RMSNorm launches into one (env-gated, decode).
-            query, key = _fused_qk_rmsnorm(
+            query, key = _fused_qk_rmsnorm_grouped(
                 query,
                 key,
                 self.q_layernorm.weight,
@@ -1943,11 +1948,41 @@ class SelfAttention(Attention):
                 self.config.layernorm_zero_centered_gamma,
             )
         else:
-            if self.q_layernorm is not None:
-                query = apply_module(self.q_layernorm)(query)
+            # Query [sq, b, ng, np/ng * hn] -> [sq, b, np, hn]
+            query = query.reshape(
+                query.size(0), query.size(1), -1, self.hidden_size_per_attention_head
+            )
 
-            if self.k_layernorm is not None:
-                key = apply_module(self.k_layernorm)(key)
+            if self.config.num_query_groups < self.world_size:
+                # query above corresponds to (num_q_heads / num_kv_heads) q_heads.
+                # Index appropriately into query to get (num_q_heads / tp_size) q_heads.
+                # This is step 4 in the list of steps above.
+                idx = get_pg_rank(self.pg_collection.tp) % (
+                    self.world_size // self.config.num_query_groups
+                )
+                size = self.num_attention_heads_per_partition // (
+                    self.world_size // self.config.num_query_groups
+                )
+                query = query[:, :, idx * size : (idx + 1) * size, :]
+
+            if _can_use_fused_qk_norm is not None and _can_use_fused_qk_norm(
+                self.q_layernorm, self.k_layernorm, query, key
+            ):
+                # Fuse the two per-head RMSNorm launches into one (env-gated, decode).
+                query, key = _fused_qk_rmsnorm(
+                    query,
+                    key,
+                    self.q_layernorm.weight,
+                    self.k_layernorm.weight,
+                    self.config.layernorm_epsilon,
+                    self.config.layernorm_zero_centered_gamma,
+                )
+            else:
+                if self.q_layernorm is not None:
+                    query = apply_module(self.q_layernorm)(query)
+
+                if self.k_layernorm is not None:
+                    key = apply_module(self.k_layernorm)(key)
 
         if self.config.test_mode:
             self.run_realtime_tests()

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -55,6 +55,11 @@ except Exception:  # keep attention importable if the inference helper is unavai
     _fused_qk_rmsnorm = None
     _can_use_grouped_qk_norm = None
     _fused_qk_rmsnorm_grouped = None
+
+try:
+    from megatron.core.inference.attention import flashinfer_decode as _flashinfer_decode
+except Exception:  # keep attention importable if the inference helper is unavailable
+    _flashinfer_decode = None
 from megatron.core.transformer.torch_norm import L2Norm, LayerNormBuilder
 from megatron.core.transformer.utils import is_layer_window_attention
 from megatron.core.typed_torch import apply_module, not_none
@@ -1235,6 +1240,17 @@ class Attention(MegatronModule, ABC):
                     output_total = self._apply_sink_softmax_correction_bshd(
                         output_total, softmax_lse, softmax_offset
                     )
+            elif _flashinfer_decode is not None and _flashinfer_decode.can_use(
+                q, block_table, need_lse, window_size, tokens_per_request
+            ):
+                # Blackwell-native paged decode; ~24% under FA2 at these shapes.
+                if getattr(self, "softmax_scale", None) is not None:
+                    softmax_scale = self.softmax_scale
+                else:
+                    softmax_scale = q.shape[-1] ** -0.5
+                output_total = _flashinfer_decode.decode(
+                    q, k, v, block_table, seqlens_k, max_seqlen_k, softmax_scale
+                )
             else:
                 if use_fa4:
                     if getattr(self, "softmax_scale", None) is not None:

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -13,6 +13,7 @@ from torch import Tensor
 
 from megatron.core import tensor_parallel
 from megatron.core.extensions.transformer_engine import HAVE_TE
+from megatron.core.inference import insitu_timing as _insitu
 from megatron.core.inference.contexts import BaseInferenceContext
 from megatron.core.inference.utils import InferenceMode
 from megatron.core.jit import jit_fuser
@@ -1621,19 +1622,20 @@ class Attention(MegatronModule, ABC):
                 cu_query_lengths, max_seqlen_q = inference_context.cu_query_lengths()
                 cu_kv_lengths, kv_lengths, max_seqlen_k = inference_context.cu_kv_lengths()
 
-                core_attn_out = self.flash_decode_and_prefill(
-                    q,
-                    k,
-                    v,
-                    max_seqlen_q,
-                    max_seqlen_k,
-                    cu_query_lengths,
-                    cu_kv_lengths,
-                    kv_lengths,
-                    block_table,
-                    inference_context.is_decode_only(),
-                    softmax_offset=self._get_inference_softmax_offset(),
-                )
+                with _insitu.site("attn_core"):
+                    core_attn_out = self.flash_decode_and_prefill(
+                        q,
+                        k,
+                        v,
+                        max_seqlen_q,
+                        max_seqlen_k,
+                        cu_query_lengths,
+                        cu_kv_lengths,
+                        kv_lengths,
+                        block_table,
+                        inference_context.is_decode_only(),
+                        softmax_offset=self._get_inference_softmax_offset(),
+                    )
                 core_attn_out = rearrange(core_attn_out, 's b h d -> s b (h d)')
 
                 # Clear the outputs for padding tokens when using quantization scales
@@ -1664,7 +1666,8 @@ class Attention(MegatronModule, ABC):
         nvtx_range_push(suffix="linear_proj")
         attn_proj_manager = off_interface(self.offload_attn_proj, core_attn_out, "attn_proj")
         with attn_proj_manager as core_attn_out:
-            output, bias = apply_module(self.linear_proj)(core_attn_out)
+            with _insitu.site("out_proj"):
+                output, bias = apply_module(self.linear_proj)(core_attn_out)
         output = attn_proj_manager.group_offload(output, forced_released_tensors=[core_attn_out])
         nvtx_range_pop(suffix="linear_proj")
 
@@ -1878,7 +1881,8 @@ class SelfAttention(Attention):
         """
         # If no output gate: Attention heads [sq, b, h] --> [sq, b, ng * (np/ng + 2) * hn)]
         # If have output gate: Attention heads [sq, b, h] --> [sq, b, ng * (2 * np/ng + 2) * hn)]
-        mixed_qkv, _ = apply_module(self.linear_qkv)(hidden_states)
+        with _insitu.site("qkv_proj"):
+            mixed_qkv, _ = apply_module(self.linear_qkv)(hidden_states)
         num_query_heads_per_group = (
             self.num_attention_heads_per_partition // self.num_query_groups_per_partition
         )

--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -136,6 +136,11 @@ except ImportError:
 
 from megatron.core.transformer.transformer_config import MLATransformerConfig
 
+# See _resolve_flash_version: benchmarking-only override for a config field that
+# has no CLI flag. Empty means "leave the config's choice alone".
+_FA_VERSION_ENV = os.environ.get("MCORE_FLASH_ATTN_VERSION", "")
+
+
 try:
     from flash_attn import flash_attn_varlen_func, flash_attn_with_kvcache
 except:
@@ -1029,6 +1034,10 @@ class Attention(MegatronModule, ABC):
         when both are False the FA2 kernel is used.
         """
         pinned = self.flash_attention_version
+        # Benchmarking override: `flash_attention_version` has no CLI flag, so this
+        # is the only way to A/B generations from a launch script. Config wins.
+        if pinned is None and _FA_VERSION_ENV:
+            pinned = int(_FA_VERSION_ENV)
         if pinned == 4:
             assert (
                 HAVE_FA4

--- a/megatron/core/transformer/moe/experts.py
+++ b/megatron/core/transformer/moe/experts.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import inspect
 import logging
+import os
 from collections.abc import Callable
 from contextlib import nullcontext
 from copy import deepcopy
@@ -86,6 +87,12 @@ from megatron.core.inference.moe import ActivationType as McoreActivationType
 from megatron.core.inference.moe import InferenceGroupedGemmBackend, mcore_fused_moe, vllm_fused_moe
 
 logger = logging.getLogger(__name__)
+
+# Fuse SiLU(gate)*up into the decode FC1 GEMM epilogue, removing the standalone
+# bounded_silu_mul kernel and the 2N intermediate HBM round-trip. No-op for
+# non-SwiGLU activations. Not bit-exact (max_abs 3.9e-5), so it is opt-in. Read
+# once here rather than per forward: the consumer is on the per-layer decode path.
+_FUSE_FC1_ACT: bool = os.environ.get("MCORE_FUSE_FC1_ACT", "0") == "1"
 
 
 class GroupedLinearFc1Interface(Protocol):
@@ -1200,6 +1207,7 @@ class InferenceGroupedMLP(TEGroupedMLP):
             routing_map=routing_map,
             out=NVLSAllGatherVDispatcher._get_rsv_tensor() if self._nvls_dispatcher else None,
             num_tokens_hint=InferenceAllGatherDispatcherBase._get_host_valid_tokens_estimate(),
+            fuse_fc1_activation=_FUSE_FC1_ACT,
         )
         return output, None
 

--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -5,6 +5,7 @@ from typing import Optional, Union
 
 import torch
 
+from megatron.core.inference.moe.router_topk import can_use_fused_softmax_topk, fused_softmax_topk
 from megatron.core.inference.utils import InferenceMode
 from megatron.core.jit import jit_fuser
 from megatron.core.transformer.custom_layers.batch_invariant_kernels import (
@@ -955,6 +956,28 @@ class InferenceTopKRouter(TopKRouter):
         precomputed_indices = None
         if self.qb_beta is not None:
             precomputed_indices = (logits - self.qb_beta).topk(self.topk, dim=1).indices
+
+        # The fused kernel selects on the logits themselves, so it cannot honor a
+        # qb_beta-shifted selection; leave those models on the reference path. Batch-
+        # invariant mode stays on the reference path too: it picks its own routing
+        # implementation below, and this kernel is not one of them. That test sits
+        # after the gate check so the gate-off path does not pay for it.
+        if (
+            self.qb_beta is None
+            and can_use_fused_softmax_topk(
+                logits,
+                self.topk,
+                use_pre_softmax=self.config.moe_router_pre_softmax,
+                num_groups=self.config.moe_router_num_groups,
+                group_topk=self.config.moe_router_group_topk,
+                scaling_factor=self.config.moe_router_topk_scaling_factor,
+                score_function=self.score_function,
+                expert_bias=self.expert_bias,
+                router_replay=self.router_replay,
+            )
+            and not is_batch_invariant_mode_enabled()
+        ):
+            return fused_softmax_topk(logits, self.topk)
 
         routing = (
             topk_routing_with_score_function

--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -5,6 +5,7 @@ from typing import Optional, Union
 
 import torch
 
+from megatron.core.inference import insitu_timing as _insitu
 from megatron.core.inference.moe.router_topk import (
     can_fuse_route_mask,
     can_use_fused_softmax_topk,
@@ -981,7 +982,8 @@ class InferenceTopKRouter(TopKRouter):
             )
             and not is_batch_invariant_mode_enabled()
         ):
-            return fused_softmax_topk(logits, self.topk, mask_padding=can_fuse_route_mask())
+            with _insitu.site("router_topk"):
+                return fused_softmax_topk(logits, self.topk, mask_padding=can_fuse_route_mask())
 
         routing = (
             topk_routing_with_score_function

--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -5,7 +5,11 @@ from typing import Optional, Union
 
 import torch
 
-from megatron.core.inference.moe.router_topk import can_use_fused_softmax_topk, fused_softmax_topk
+from megatron.core.inference.moe.router_topk import (
+    can_fuse_route_mask,
+    can_use_fused_softmax_topk,
+    fused_softmax_topk,
+)
 from megatron.core.inference.utils import InferenceMode
 from megatron.core.jit import jit_fuser
 from megatron.core.transformer.custom_layers.batch_invariant_kernels import (
@@ -977,7 +981,7 @@ class InferenceTopKRouter(TopKRouter):
             )
             and not is_batch_invariant_mode_enabled()
         ):
-            return fused_softmax_topk(logits, self.topk)
+            return fused_softmax_topk(logits, self.topk, mask_padding=can_fuse_route_mask())
 
         routing = (
             topk_routing_with_score_function

--- a/megatron/core/transformer/moe/token_dispatcher_inference.py
+++ b/megatron/core/transformer/moe/token_dispatcher_inference.py
@@ -33,6 +33,7 @@ from megatron.core.inference.communication.torch_symm_triton import (
     multimem_reduce_scatter_v,
 )
 from megatron.core.inference.moe import InferenceGroupedGemmBackend, batch_invariant
+from megatron.core.inference.moe import router_topk as _fused_topk
 from megatron.core.inference.moe.metadata import fused_metadata_update
 from megatron.core.inference.symmetric_memory import SymmetricMemoryManager
 from megatron.core.process_groups_config import ProcessGroupCollection
@@ -503,6 +504,11 @@ class NVLSAllGatherVDispatcher(InferenceAllGatherDispatcherBase):
         # the routing map along. Base class self.tp_rank is the expt_tp rank,
         # which is not what we want for the SP padding offset.
         self.sp_rank = get_pg_rank(pg_collection.tp)
+        # Unsharded rows let the router fold the padding sentinel into its selection
+        # kernel: local and global row indices coincide, so no row offset is needed.
+        # Requiring group size 1 rather than rank 0 keeps every rank on the same
+        # branch, which matters because the NVLS path barriers across ranks.
+        self._rows_unsharded = get_pg_size(pg_collection.tp) == 1
         # Set in dispatch_preprocess; consumed by token_dispatch and token_combine.
         self._local_tokens: int = 0
         # When shared_expert_overlap is enabled, the shared expert forward is launched
@@ -568,7 +574,17 @@ class NVLSAllGatherVDispatcher(InferenceAllGatherDispatcherBase):
         # shift local rows into the global frame for the comparison. When unset
         # (standalone dispatcher use without a context) all rows are real, so
         # skip the mask.
-        if self.__class__._real_token_count_tensor is not None:
+        #
+        # Publishing the count lets the router's selection kernel emit the sentinel
+        # itself and retires this launch. The skip below keys off the tag the router
+        # leaves on the tensor it actually masked, so it is evidence that the fused
+        # path ran rather than a second copy of the gate.
+        if self.__class__._real_token_count_tensor is not None and self._rows_unsharded:
+            _fused_topk.publish_graph_padding(self.__class__._real_token_count_tensor)
+
+        if self.__class__._real_token_count_tensor is not None and not getattr(
+            self.routing_map, "_mcore_padding_masked", False
+        ):
             mask_routing_padding(
                 self.routing_map, self.__class__._real_token_count_tensor, self.sp_rank
             )

--- a/megatron/core/transformer/moe/token_dispatcher_inference.py
+++ b/megatron/core/transformer/moe/token_dispatcher_inference.py
@@ -29,11 +29,13 @@ from typing import List, Optional
 import torch
 import torch.distributed as dist
 
+from megatron.core.inference import insitu_timing as _insitu
 from megatron.core.inference.communication.torch_symm_triton import (
     multimem_all_gatherv_3tensor,
     multimem_reduce_scatter_v,
 )
 from megatron.core.inference.moe import InferenceGroupedGemmBackend, batch_invariant
+from megatron.core.inference.moe import expert_histogram as _exphist
 from megatron.core.inference.moe import router_topk as _fused_topk
 from megatron.core.inference.moe.metadata import fused_metadata_update
 from megatron.core.inference.symmetric_memory import SymmetricMemoryManager
@@ -600,6 +602,13 @@ class NVLSAllGatherVDispatcher(InferenceAllGatherDispatcherBase):
         # itself and retires this launch. The skip below keys off the tag the router
         # leaves on the tensor it actually masked, so it is evidence that the fused
         # path ran rather than a second copy of the gate.
+        if _exphist.ENABLED:
+            # Allocated here rather than in __init__ because this is the first point
+            # with both the device and the global expert count in hand; it is a no-op
+            # after the first call, and capture has not happened yet on that call.
+            _exphist.configure(self.config.num_moe_experts, self.routing_map.device)
+        _exphist.record(self.routing_map)
+
         if self.__class__._real_token_count_tensor is not None and self._rows_unsharded:
             _fused_topk.publish_graph_padding(self.__class__._real_token_count_tensor)
 
@@ -619,20 +628,25 @@ class NVLSAllGatherVDispatcher(InferenceAllGatherDispatcherBase):
         rank_token_offset = self._rank_token_offset()
         ep_max_tokens = self._ep_max_tokens()
 
-        multimem_all_gatherv_3tensor(
-            agv_h["tensor"],
-            agv_r["tensor"],
-            agv_p["tensor"],
-            hidden_states,
-            self.routing_map,
-            probs,
-            agv_h["handle"],
-            agv_r["handle"],
-            agv_p["handle"],
-            rank_token_offset=rank_token_offset,
-            ep_max_tokens=ep_max_tokens,
-            per_rank_max_tokens=per_rank_max,
-        )
+        # Empty region in the same graph: its reading is the per-pair event overhead
+        # that every other site is reported net of.
+        with _insitu.site(_insitu.CALIB):
+            pass
+        with _insitu.site("nvls_dispatch"):
+            multimem_all_gatherv_3tensor(
+                agv_h["tensor"],
+                agv_r["tensor"],
+                agv_p["tensor"],
+                hidden_states,
+                self.routing_map,
+                probs,
+                agv_h["handle"],
+                agv_r["handle"],
+                agv_p["handle"],
+                rank_token_offset=rank_token_offset,
+                ep_max_tokens=ep_max_tokens,
+                per_rank_max_tokens=per_rank_max,
+            )
 
         topk = probs.shape[1]
         hidden_dim = hidden_states.shape[1]
@@ -683,14 +697,15 @@ class NVLSAllGatherVDispatcher(InferenceAllGatherDispatcherBase):
             if batch_invariant.enabled()
             else multimem_reduce_scatter_v
         )
-        reduce_scatter_v(
-            output,
-            rsv["tensor"],
-            rsv["handle"],
-            rank_token_offset=self._rank_token_offset(),
-            ep_max_tokens=self._ep_max_tokens(),
-            per_rank_max_tokens=self._per_rank_worst_case_token_count,
-        )
+        with _insitu.site("nvls_combine"):
+            reduce_scatter_v(
+                output,
+                rsv["tensor"],
+                rsv["handle"],
+                rank_token_offset=self._rank_token_offset(),
+                ep_max_tokens=self._ep_max_tokens(),
+                per_rank_max_tokens=self._per_rank_worst_case_token_count,
+            )
         return output.to(torch.bfloat16)
 
     def combine_postprocess(self, hidden_states):

--- a/megatron/core/transformer/moe/token_dispatcher_inference.py
+++ b/megatron/core/transformer/moe/token_dispatcher_inference.py
@@ -22,6 +22,7 @@ per-step metadata kernel is captured inside the CUDA graph.
 """
 
 import operator
+import os
 from functools import reduce
 from typing import List, Optional
 
@@ -47,6 +48,10 @@ from megatron.core.transformer.moe.token_dispatcher import MoEAllGatherTokenDisp
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.typed_torch import apply_module
 from megatron.core.utils import get_pg_rank, get_pg_size
+
+# Reduce the MoE combine in bf16 instead of fp32. Off by default because it changes
+# numerics; see the buffer allocation for why it is worth measuring.
+_NVLS_RS_BF16: bool = os.environ.get("MCORE_NVLS_RS_BF16", "0") == "1"
 
 
 class InferenceAllGatherDispatcherBase(MoEAllGatherTokenDispatcher):
@@ -322,7 +327,8 @@ class NVLSAllGatherVDispatcher(InferenceAllGatherDispatcherBase):
     _real_token_count_tensor: Optional[torch.Tensor] = None
 
     # ── Class-level symmetric buffer handles (allocated once at model init) ───────
-    # Dtypes: hidden=bf16, routing=int64, probs=fp32, rsv=fp32.
+    # Dtypes: hidden=bf16, routing=int64, probs=fp32, rsv=fp32 (bf16 when
+    # MCORE_NVLS_RS_BF16 is set).
     _symm_agv_hidden: Optional[dict] = None  # {"tensor": ..., "handle": ...}
     _symm_agv_routing: Optional[dict] = None
     _symm_agv_probs: Optional[dict] = None
@@ -431,9 +437,24 @@ class NVLSAllGatherVDispatcher(InferenceAllGatherDispatcherBase):
             "ep_agv_p", process_group=ep_group, size_mb=_size_mb(agv_p_shape, torch.float32)
         ).maybe_get_tensor(agv_p_shape, dtype=torch.float32)
 
+        # The combine reduce-scatter buffer. fp32 makes the cross-rank sum exact but
+        # costs twice the NVLink bytes on the largest collective in the step, and it
+        # forces a per-layer cast on the way out because everything downstream is
+        # bf16. vLLM reduces in bf16 (`ncclDevKernel_ReduceScatter_Sum_bf16`), and the
+        # multimem kernel already accepts either, so bf16 is a supported point on the
+        # same curve: the top-k sum still accumulates in fp32 registers inside
+        # `_moe_sum`, only the store and the 4-way cross-rank add become bf16.
+        rsv_dtype = torch.float32
+        if _NVLS_RS_BF16:
+            assert not batch_invariant.enabled(), (
+                "MCORE_NVLS_RS_BF16 cannot be combined with batch-invariant mode: "
+                "ordered_reduce_scatter_v reduces ranks with an explicit fp32 loop and "
+                "requires an fp32 buffer."
+            )
+            rsv_dtype = torch.bfloat16
         cls._symm_rsv = SymmetricMemoryManager.get_buffer(
-            "ep_rsv", process_group=ep_group, size_mb=_size_mb(rsv_shape, torch.float32)
-        ).maybe_get_tensor(rsv_shape, dtype=torch.float32)
+            "ep_rsv", process_group=ep_group, size_mb=_size_mb(rsv_shape, rsv_dtype)
+        ).maybe_get_tensor(rsv_shape, dtype=rsv_dtype)
 
         # Small scratch buffer for fused metadata allgather (WORLD_SIZE int32s).
         cls._symm_metadata = SymmetricMemoryManager.get_buffer(

--- a/megatron/core/transformer/transformer_block.py
+++ b/megatron/core/transformer/transformer_block.py
@@ -321,6 +321,31 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
         self._build_layers()
         self.num_layers_per_pipeline_rank = len(self.layers)
 
+    def _wire_fused_add_norm_qkv_chain(self):
+        """Let each layer's mlp_bda add absorb the next layer's QKV input RMSNorm.
+
+        The residual add at the end of layer i is immediately followed by the input
+        RMSNorm at the start of layer i+1, which for the non-MLA inference path lives
+        inside ``linear_qkv`` rather than as a standalone module. Handing each layer a
+        reference to the next layer's ``linear_qkv`` lets the two collapse into one
+        kernel. Only the last local layer is left out, since its output feeds
+        ``final_layernorm`` instead.
+
+        Storing references costs nothing when the fusion is disabled -- the runtime
+        guard in the layer decides per step -- so this is wired unconditionally.
+        """
+        layers = getattr(self, "layers", None)
+        if layers is None or len(layers) < 2:
+            return
+        for cur, nxt in zip(layers[:-1], layers[1:]):
+            if not hasattr(cur, "_next_layer_qkv"):
+                continue
+            qkv = getattr(getattr(nxt, "self_attention", None), "linear_qkv", None)
+            # Only the inference QKV layer exposes the prenormed_input hand-off and a
+            # raw layer_norm_weight; anything else keeps the reference path.
+            if qkv is not None and hasattr(qkv, "prenormed_input"):
+                cur._next_layer_qkv = [qkv]
+
     def _build_layers(self):
         # Transformer layers.
         # @jcasper can we improve how we deal with layer_number?
@@ -368,6 +393,8 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
         )
         if self.config.cuda_graph_impl == "local":
             annotate_first_last_layer(self.layers)
+
+        self._wire_fused_add_norm_qkv_chain()
 
         # @TODO: add back account_for_embedding_in_pipeline_split (see issue #293)
         # In pipeline parallelism, we want to add this LN only to the last stage of the pipeline

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -17,6 +17,16 @@ from megatron.core.dist_checkpointing.mapping import ShardedStateDict
 from megatron.core.dist_checkpointing.utils import apply_prefix_mapping
 from megatron.core.inference.utils import InferenceMode
 from megatron.core.packed_seq_params import PackedSeqParams
+
+try:
+    from megatron.core.inference.fused_add_rmsnorm import (
+        can_use_fused_add_rmsnorm as _can_use_fused_add_rmsnorm,
+    )
+    from megatron.core.inference.fused_add_rmsnorm import fused_add_rmsnorm as _fused_add_rmsnorm
+except Exception:  # keep the layer importable if the inference helper is unavailable
+    _can_use_fused_add_rmsnorm = None
+    _fused_add_rmsnorm = None
+
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.transformer.cuda_graphs import is_graph_capturing
 from megatron.core.transformer.enums import CudaGraphModule, InferenceCudaGraphScope, LayerType
@@ -613,6 +623,10 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         """
         inference_context = deprecate_inference_params(inference_context, inference_params)
 
+        # Cleared each forward; set only when the self_attn_bda + pre_mlp_layernorm
+        # fused-add-norm path runs, so _forward_pre_mlp_layernorm can consume it.
+        self._fused_pre_mlp_normed = None
+
         # Optional Input Layer norm
         attn_norm_manager = self.off_interface(self.offload_attn_norm, hidden_states, "attn_norm")
         if self.recompute_input_layernorm:
@@ -680,10 +694,36 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
             # self attention module.
             hidden_states = attention_output_with_bias[0]
         else:
-            with self.bias_dropout_add_exec_handler():
-                hidden_states = self.self_attn_bda(self.training, self.config.bias_dropout_fusion)(
-                    attention_output_with_bias, residual, self.hidden_dropout
+            attn_out = attention_output_with_bias[0]
+            if (
+                _fused_add_rmsnorm is not None
+                and not self.training
+                and self.config.normalization == "RMSNorm"
+                and attention_output_with_bias[1] is None
+                and isinstance(self.cross_attention, IdentityOp)
+                and isinstance(self.pre_cross_attn_layernorm, IdentityOp)
+                and not self.recompute_pre_mlp_layernorm
+                and not getattr(self, "offload_attn_norm", False)
+                and not getattr(self, "offload_mlp_norm", False)
+                and _can_use_fused_add_rmsnorm(self.pre_mlp_layernorm, attn_out, residual)
+            ):
+                # Fuse the residual-add (self_attn_bda) with the standalone
+                # pre-MLP RMSNorm: one kernel yields both the updated residual
+                # and the normalized MLP input, removing a launch + graph node
+                # per layer. Decode-gated; falls back below otherwise.
+                pre_mlp_normed, hidden_states = _fused_add_rmsnorm(
+                    attn_out,
+                    residual,
+                    self.pre_mlp_layernorm.weight,
+                    self.config.layernorm_epsilon,
+                    self.config.layernorm_zero_centered_gamma,
                 )
+                self._fused_pre_mlp_normed = pre_mlp_normed
+            else:
+                with self.bias_dropout_add_exec_handler():
+                    hidden_states = self.self_attn_bda(
+                        self.training, self.config.bias_dropout_fusion
+                    )(attention_output_with_bias, residual, self.hidden_dropout)
         nvtx_range_pop(suffix="self_attn_bda")
 
         # Delay the offload of the attention norm until after the self_attn_bda has been computed
@@ -747,6 +787,12 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         return output, context
 
     def _forward_pre_mlp_layernorm(self, hidden_states: Tensor):
+        # If the fused self_attn_bda + pre_mlp_layernorm path ran, the normed
+        # activation is already computed; consume it and skip the norm call.
+        stashed = getattr(self, "_fused_pre_mlp_normed", None)
+        if stashed is not None:
+            self._fused_pre_mlp_normed = None
+            return stashed
         self.mlp_norm_manager = self.off_interface(self.offload_mlp_norm, hidden_states, "mlp_norm")
         if self.recompute_pre_mlp_layernorm:
             self.pre_mlp_norm_checkpoint = tensor_parallel.CheckpointWithoutOutput()

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -22,9 +22,13 @@ try:
     from megatron.core.inference.fused_add_rmsnorm import (
         can_use_fused_add_rmsnorm as _can_use_fused_add_rmsnorm,
     )
+    from megatron.core.inference.fused_add_rmsnorm import (
+        can_use_fused_add_rmsnorm_qkv as _can_use_fused_add_rmsnorm_qkv,
+    )
     from megatron.core.inference.fused_add_rmsnorm import fused_add_rmsnorm as _fused_add_rmsnorm
 except Exception:  # keep the layer importable if the inference helper is unavailable
     _can_use_fused_add_rmsnorm = None
+    _can_use_fused_add_rmsnorm_qkv = None
     _fused_add_rmsnorm = None
 
 from megatron.core.process_groups_config import ProcessGroupCollection
@@ -449,6 +453,12 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
 
         # [Module 9: BiasDropoutFusion]
         self.mlp_bda = build_module(submodules.mlp_bda)
+
+        # Holds the *next* layer's linear_qkv so this layer's mlp_bda add can absorb
+        # that layer's input RMSNorm. Wired by TransformerBlock. Deliberately a list:
+        # assigning a Module straight to an attribute would register it as a child
+        # here too, duplicating those parameters in state_dict and named_parameters.
+        self._next_layer_qkv: list = []
 
         self.is_moe_layer = isinstance(self.mlp, MoELayer)
 
@@ -1022,10 +1032,41 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
             # MLP module.
             hidden_states = mlp_output_with_bias[0]
         else:
-            with self.bias_dropout_add_exec_handler():
-                hidden_states = self.mlp_bda(self.training, self.config.bias_dropout_fusion)(
-                    mlp_output_with_bias, residual, self.hidden_dropout
+            next_qkv = self._next_layer_qkv[0] if self._next_layer_qkv else None
+            mlp_out = mlp_output_with_bias[0]
+            if (
+                next_qkv is not None
+                and _fused_add_rmsnorm is not None
+                and not self.training
+                and self.config.normalization == "RMSNorm"
+                and mlp_output_with_bias[1] is None
+                and self.mlp_norm_manager is None
+                # _te_rms_norm_kernel hardcodes zero_centered_gamma=False, so this
+                # fusion may only stand in for it when the config agrees.
+                and not self.config.layernorm_zero_centered_gamma
+                and _can_use_fused_add_rmsnorm_qkv(
+                    getattr(next_qkv, "layer_norm_weight", None), mlp_out, residual
                 )
+            ):
+                # Fuse this layer's residual add with the *next* layer's QKV input
+                # RMSNorm: one kernel yields both the residual stream and that
+                # layer's normalized QKV input, removing a launch and a graph node
+                # per boundary. This is the half of the block boundaries the
+                # pre-MLP fusion could not reach, because the input norm lives
+                # inside linear_qkv rather than as a standalone module.
+                prenormed, hidden_states = _fused_add_rmsnorm(
+                    mlp_out,
+                    residual,
+                    next_qkv.layer_norm_weight,
+                    next_qkv.eps,
+                    False,
+                )
+                next_qkv.prenormed_input = prenormed
+            else:
+                with self.bias_dropout_add_exec_handler():
+                    hidden_states = self.mlp_bda(self.training, self.config.bias_dropout_fusion)(
+                        mlp_output_with_bias, residual, self.hidden_dropout
+                    )
         nvtx_range_pop(suffix="mlp_bda")
         # Delay the offload of the mlp norm until after the mlp_bda has been computed
         # because the residual is needed in the mlp_bda.

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -15,6 +15,8 @@ from torch import Tensor
 from megatron.core import parallel_state, tensor_parallel
 from megatron.core.dist_checkpointing.mapping import ShardedStateDict
 from megatron.core.dist_checkpointing.utils import apply_prefix_mapping
+from megatron.core.inference import copy_trace as _copy_trace
+from megatron.core.inference import dispatch_ballast as _dispatch_ballast
 from megatron.core.inference.utils import InferenceMode
 from megatron.core.packed_seq_params import PackedSeqParams
 
@@ -787,6 +789,21 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         This method calls the core computation of a transformer layer, including
         self-attention, cross-attention (if applicable), and feed-forward operations.
         """
+        if _copy_trace.ENABLED and _copy_trace.ready():
+            trace = _copy_trace.trace_one_layer()
+            if trace is not None:
+                with trace:
+                    out = self._forward_layer(*args, **kwargs)
+                _copy_trace.report()
+                return out
+        output, context = self._forward_layer(*args, **kwargs)
+        if _dispatch_ballast.COUNT:
+            _dispatch_ballast.tick()
+        return output, context
+
+    def _forward_layer(self, *args, **kwargs):
+        """Attention then MLP — the layer body, factored out so a diagnostic mode can
+        wrap it without paying for a context manager on the fast path."""
         hidden_states, context = self._forward_attention(*args, **kwargs)
         output = self._forward_mlp(
             hidden_states,


### PR DESCRIPTION
> **This PR sits on top of the entire 16-PR stack**, not on a single parent. It carries no
> optimization of its own: it is the opt-in measurement apparatus that produced the numbers
> in the other PRs. Eight instrumentation modules and their call sites, all inert unless an
> `MCORE_*` environment gate is set.
>
> Because GitHub cannot base a fork PR on an unmerged fork branch, the diff below contains
> all 16 slices as well. This PR's own change is the final commit, `684836856`; review that
> one. Land this last, or not at all — nothing else in the stack depends on it.
>
> - MoE grouped-GEMM and dispatch: #6452 -> #6453 -> #6454 -> #6455
> - MoE router and combine: #6456 -> #6457 -> #6458
> - Attention: #6459 -> #6460 -> #6461 -> #6462
> - Residual + RMSNorm fusion: #6463 -> #6464
> - Host path: #6465 -> #6466 -> #6467


## Summary

This ships the measurement apparatus the rest of this stack was built with: eight small
instrumentation modules under `megatron/core/inference/`, each behind its own default-off
environment gate, plus the call sites that install or invoke them in eight decode-path files.
It **claims no speedup and should not be measured for one**. Its entire correctness argument
is that every hook is inert when its gate is unset — no CUDA work, no graph node, no
synchronization, no allocation on the device, and no change to any value the model computes.

This is optional. It exists because the standard tools do not work on this workload, and it
is the only way to reproduce the per-component numbers quoted in the other PRs in this stack.
If a reviewer would rather not carry instrumentation in hot-path files, decline it: every
throughput claim in the other PRs rests on the end-to-end A/B protocol, which needs none of
this.

## Why this exists rather than a profiler

Three independent dead ends drove each of these modules, and they are worth stating because
"why not just use Nsight Systems" is the first question this PR invites.

**Nsight Systems host-visibility capture deadlocks on this workload.** Every attempt to
capture host-side visibility left Nsight's finalization hung after the target exited and
produced an intermediate stream the importer rejected as structurally incomplete. Two
plausible causes were ruled out by experiment — it is not a copy-while-growing race, since a
stream that had been byte-stable for 30 seconds failed identically, and it is not event
volume, since dropping Python sampling cut the capture from 347 MB to 219 MB and it failed the
same way. The trigger is the host flag set itself: operating-system runtime tracing,
process-tree sampling, or NVTX ranges under CUDA graphs each reproduce it independently of the
CUDA-graph trace level. Only a plain CUDA-plus-NVTX capture with sampling off finalizes. That
is why the host phase timer here is a `perf_counter` shim and not a profile.

**Nsight Systems perturbs the thing being measured.** On this workload it costs roughly 28%
end to end regardless of CUDA-graph trace mode, and that overhead is host-side, which
desynchronizes the expert-parallel ranks. The NVLS dispatch and combine collectives are
spin-waits whose cost is set by cross-rank arrival skew rather than by bytes moved, so they
inflate by around 120× under the profiler. Any absolute idle or barrier figure read out of
such a trace is unusable.

**A profiler cannot size an overhead the profiler itself creates.** A node-traced profile
attributed roughly 707 µs/step of exposed GPU idle to `cudaGraphLaunch` at about 191 µs per
call, which would have made graph launch the single largest item in the idle budget and the
top optimization target. Timed with `perf_counter` and no profiler attached, the hot graph
replays in a median of 9 to 10 µs over 1,404 replays — the profiled figure was inflated about
20× by node-level tracing, which makes the driver do per-node bookkeeping inside the launch.
Graph launch is roughly 40 µs/step, not 761, and is not a lever. That correction is the
reason `graph_launch_timing.py` exists, and it is the strongest single argument for keeping
profiler-independent instrumentation in the tree.

**Component subtraction also failed, which is why timing is in situ.** Ablating a component
and reading the change in block time only works if the component's absence leaves everything
else unchanged, and in the MoE decode path it does not: the NVLS all-gather produces the work
descriptor that sizes all downstream grouped-GEMM work, so removing it silently changes how
much work the experts do. What is left is to time each component where it stands, with an
event pair inside the captured graph.

## What each module measures

**`insitu_timing.py` (`MCORE_INSITU_TIMING`)** — per-component GPU time inside the captured
decode graph. A `site(name)` context manager records an *external* CUDA event
(`cudaEventRecordWithFlags` with `cudaEventRecordExternal`, through `ctypes`, since PyTorch
exposes no flags argument) at each end of a region. An external event-record node re-records
on every replay, so `elapsed_time` after a replay gives that replay's duration for the
enclosed region while leaving the work descriptor, the kernel sequence and the cross-rank
barrier order untouched. Reach for this to answer "what does this component cost on the
device", which is what produced the per-component budget behind the fusion PRs in this stack.
Nine regions are instrumented: the QKV projection, attention core and output projection; the
fused and unfused router top-k paths; the MoE alignment kernel, both expert GEMMs and the
expert sum; and the NVLS dispatch and combine collectives.

Three facts make its output trustworthy, and all three are measured rather than assumed. A
plain `torch.cuda.Event.record()` during capture *looks* like it works — it raises nothing and
does become a graph node — but the event carries no host-readable timestamp and `elapsed_time`
on it fails with `cudaErrorInvalidValue`, which is why the first instrumented run reported
every site as zero; the external flag is not optional. Each event pair carries about 2.2 µs of
its own cost, so a `_calib` site wraps an empty region in the same graph and its reading is
subtracted from every other site — without that, an 8 µs component reads about 30% high. And
the summed sites reconstruct the whole graph to within 1.3%, which is what makes the
decomposition additive and the constant subtraction legitimate. Only two per-layer occurrences
are instrumented rather than all 48, because every event record is a graph node and 600 of them
would inflate the very block time being attributed; two rather than one so that an atypical
layer is visible instead of silently wrong.

**`step_gpu_timing.py` (`MCORE_INFER_STEP_GPU_TIMING`)** — whole-step GPU accounting. It times
the transformer-block CUDA graph with event pairs and records per-rank step-entry timestamps.
It answers two questions: how much of a decode step is the block graph, since everything else
(embedding, final norm, logits GEMM, sampling, bookkeeping) is eager and host-driven, and how
skewed the expert-parallel ranks are — all four ranks are processes on one node, so
`perf_counter_ns` is directly comparable between them and the spread of step-entry timestamps
measures the skew that sets the spin-wait collectives' cost. Reach for this first when
deciding whether a remaining gap lives in the model's GPU work or in exposed host time; it is
also the cross-check that tells you whether the `insitu_timing` parts reconstruct the whole.
Events are recorded into a ring and read back only when the ring wraps, so a step never
synchronizes on its own work.

**`host_phase_timing.py` (`MCORE_INFER_HOST_TIMING`)** — per-phase host CPU time for the
decode loop, with no profiler. `install()` replaces the NVTX range push and pop the decode
loop already emits with `perf_counter` self-timers sharing a nesting stack, so each label
reports self time excluding children, and prints a per-step breakdown periodically. This is
the module that exists specifically because the nsys host capture deadlocks, and it is what
produced the per-phase host numbers quoted in the host-path PRs in this stack. Reach for it to
find out which host phase between two graph replays is expensive.

**`graph_launch_timing.py` (`MCORE_GRAPH_LAUNCH_TIMING`)** — host cost of CUDA graph replay.
It wraps `torch.cuda.CUDAGraph.replay` with `perf_counter_ns`, keyed per graph, skipping the
first replays where allocator warmup and first-touch page faults land, and reports medians
because the first replays after capture are not representative. Reach for it whenever a
profile attributes a large cost to graph launch, which is exactly the reading that turned out
to be a 20× artifact.

**`fusion_diag.py` (`MCORE_FUSION_DIAG`)** — why a gated fusion did or did not engage. The
decode fusions in this stack are environment-gated *and* guarded by a conjunction of runtime
conditions, and when the gate is on but the fused kernel never appears in a profile, the gate
is not the problem: one guard is silently false and there is no way to tell which from
outside. Each call site reports its guard values and names the blockers, once per *distinct
verdict* rather than once per site — reporting only the first call is a trap, because the
first call is prefill where a decode-only token-count guard blocks the fusion by design, so a
first-call-only report says "blocked" for a fusion that engages fine during decode. Reach for
it before spending a session on a fusion that is enabled and inert; that has happened in this
campaign, and this answers it in one run.

**`copy_trace.py` (`MCORE_COPY_TRACE`)** — names the copies inside a single decode layer. A
per-kernel budget can say there is one 2.7 µs copy per layer but not which line of Python asks
for it, because at decode every kernel is replayed from a captured graph and has no launch-site
backtrace left in the profile. This runs one layer under a `TorchDispatchMode` and prints each
copy-like operation once — `copy_`, `_to_copy`, `clone`, `contiguous`, `cat`, `index_select`,
`gather` — with its shape, strided-ness and the innermost Megatron frames that requested it.
It disarms itself after the first traced layer, so its cost is one layer's worth of Python
dispatch on one step. Reach for it to decide whether a copy is removable outright or has to be
fused away.

**`dispatch_ballast.py` (`MCORE_DISPATCH_BALLAST=<n>`)** — calibration, and the only module
here that adds work rather than observing it. It launches `n` extra one-element kernels per
transformer layer, serialized on one scratch element. Fusing two kernels into one removes both
the second kernel's device time and its graph node, and the two cannot be separated after the
fact; plotting step time against `n` gives the per-node cost directly, which converts any
future "this fusion removes K launches" into a predicted throughput gain. It must stay off in
any measured configuration, and it is the only module here whose non-zero setting changes
performance on purpose. It answers a question that recurs every time a fusion is proposed,
which is why it is 35 lines and model-agnostic.

**`moe/expert_histogram.py` (`MCORE_EXPERT_HISTOGRAM`)** — per-expert token counts, for
diagnosing expert-parallel load imbalance. In-situ timing showed the barrier absorbing a
static imbalance: per layer, one rank spent 63.0 µs in the expert GEMM and 28.2 µs in the
collectives while another spent 56.8 and 34.5, both summing to 91.2, so the critical path is
set by the busiest rank and balancing the experts is worth the difference between the maximum
and the mean, about 4.85 µs/layer or 233 µs/step. Acting on that requires knowing which
experts are hot, and since experts are assigned to ranks in contiguous index blocks, any
correlation between popularity and index unbalances the blocks. The accumulating scatter-add
runs *inside* the CUDA graph — Python executes only at capture, but the recorded operation
replays every step and keeps accumulating into a fixed buffer, which is the desired behaviour
— and the host-side dump is driven from `step_gpu_timing`'s periodic report. Counts are
cumulative from capture, so only ratios between experts are meaningful.

Alongside these, `dynamic_context.py` carries an inline per-phase host timer for
`initialize_attention_state` (`MCORE_INFER_ATTN_PROF`, also default off), which accumulates
wall time across nine named phases of that call and prints a per-call breakdown periodically.
It is inline rather than a module because it brackets statements inside one method rather than
wrapping a call, and it is the breakdown that selected the attention-state target in this
stack. `dynamic_engine.py` also gains a default-off `MCORE_INFER_NVTX` toggle that turns on
the engine's own NVTX ranges, which are otherwise inert; note that enabling it is one of the
three conditions that reproduces the Nsight finalization deadlock described above, so it is
useful only with a profiler that is not Nsight.

## Where the call sites are

Eight files gain hooks. Three `install()` calls sit in the engine's constructor
(`dynamic_engine.py`) for the host phase timer, the step GPU timer and the graph launch timer;
each is a function call that returns immediately when its gate is unset. Nine `insitu.site()`
regions sit in `attention.py`, `router.py`, `vllm_fused_moe.py` and
`token_dispatcher_inference.py`. One `expert_histogram.record()` call sits in
`token_dispatcher_inference.py` next to the routing map. One `fusion_diag` report sits in
`fused_add_rmsnorm.py`'s compatibility check. The `copy_trace` and `dispatch_ballast` hooks sit
in `transformer_layer.py`, each behind a module-attribute test. `dynamic_context.py` carries
the inline attention-state phase timer.

**Why this is stacked on the whole stack rather than rooted on main.** Every one of those
eight files is edited by an earlier PR in this stack, so rooting this on main would give
those files two owners and guarantee conflicts. Basing it on the tip also matches how it
should be reviewed: last, optional, and only if the reviewer wants the apparatus. As a
consequence, if this PR is declined nothing else in the stack changes — the other PRs were
audited for leaked references to these modules and are clean, so they build and run without
any of these files present.

## Measurement

This PR ships opt-in instrumentation and makes **no throughput claim**. Every hook is a no-op when its gate is unset, so with the gates off the measured configuration is the stack tip unchanged. No arm was run for it.

> **Gate inventory.** Beyond the eight module gates below, this PR adds two more enable
> gates, both read as `os.environ.get(..., "0") == "1"` and so both default off:
> `MCORE_INFER_ATTN_PROF`, the inline phase timer for `initialize_attention_state`, and
> `MCORE_INFER_NVTX`, which opts the inference server into the engine's existing NVTX
> ranges so an `nsys` capture can attribute the host chain between decode steps. The
> remaining `MCORE_*` names in the diff are tuning knobs on an already-enabled module
> (report intervals, ring sizes, skip counts), not independent switches.

## Correctness

- **The no-op guarantee.** Every gate is read once at import from the environment and every
  one defaults to off: `MCORE_INSITU_TIMING`, `MCORE_INFER_STEP_GPU_TIMING`,
  `MCORE_INFER_HOST_TIMING`, `MCORE_GRAPH_LAUNCH_TIMING`, `MCORE_FUSION_DIAG`,
  `MCORE_COPY_TRACE` and `MCORE_EXPERT_HISTOGRAM` all compare against `"0"`, and
  `MCORE_DISPATCH_BALLAST` is a count that defaults to `0` and returns immediately when not
  positive. With the gates unset, no module records a CUDA event, adds a graph node,
  synchronizes, allocates a device buffer, patches a method, installs a dispatch mode, or
  reads or writes any tensor the model computes. Numerically the model is unchanged, and this
  is structural rather than tested: there is no code path from a false gate to any of those
  effects.
- **What the default path does cost.** Being precise, since "zero cost" is easy to overclaim:
  each call site performs one module-attribute read, the three `install()` calls return on
  their first line, and the nine `insitu.site()` regions additionally enter a context manager
  that yields immediately. Those regions sit inside the captured decode region, so their
  Python runs at graph capture rather than on every replay. The `fusion_diag` site is
  short-circuited by `if _diag.ENABLED and site:`, so the condition dictionary it would report
  is never even built on the default path — the caller passes a lambda for exactly that
  reason.
- **What it costs when it is on, measured rather than assumed.** In-situ timing costs 2.0% of
  block time — 7.543 ms instrumented against 7.396 ms control, same configuration, same node.
  That is the only module whose overhead is on the device critical path; the rest are host-side
  reporting. `copy_trace` disarms after one layer. `dispatch_ballast` changes performance by
  design and must be off in any measured configuration.
- **Tests:** the guarantee this PR needs is that turning everything off restores the
  pre-instrumentation behaviour, which the other PRs in this stack exercise on every run,
  since they all measure with these gates unset. Each module's own numbers were validated
  against an independent check before being trusted: the in-situ decomposition against the
  whole-block figure from the step timer (agreeing to 1.3%), the graph replay timing against
  the profiler figure it contradicts (and the contradiction was resolved in favour of the
  unprofiled measurement), and the host phase breakdown against a standalone harness driving
  the same code with no model loaded (agreeing to within 12%).

## Gating and blast radius

| Gate | Default | Effect when unset |
|---|---|---|
| `MCORE_INSITU_TIMING` | off (`"0"`) | `site()` yields immediately; no events allocated or recorded |
| `MCORE_INFER_STEP_GPU_TIMING` | off (`"0"`) | `install()` returns; no event ring, no patching |
| `MCORE_INFER_HOST_TIMING` | off (`"0"`) | `install()` returns; NVTX push/pop unpatched |
| `MCORE_GRAPH_LAUNCH_TIMING` | off (`"0"`) | `install()` returns; `CUDAGraph.replay` unwrapped |
| `MCORE_FUSION_DIAG` | off (`"0"`) | `report()` returns before evaluating its condition lambda |
| `MCORE_COPY_TRACE` | off (`"0"`) | never armed; no dispatch mode entered |
| `MCORE_DISPATCH_BALLAST` | `0` | `tick()` returns; no extra kernels launched |
| `MCORE_EXPERT_HISTOGRAM` | off (`"0"`) | `record()` returns; no count buffer allocated |

Secondary knobs select behaviour *within* an already-enabled module and each defaults to a
benign value: the instrumented occurrence list and wrap factor for in-situ timing, the ring
size, report interval and skip count for the step timer, the report interval and step label
for the host timer, the skip and report interval for graph launch timing, the report cap for
fusion diagnostics, and the skip count for copy tracing. None of them enables anything on its
own.

Training is unaffected. Seven of the eight modules live under `megatron/core/inference/`, and
the hooks in `attention.py`, `router.py`, `token_dispatcher_inference.py` and
`transformer_layer.py` are gate tests that are false in any configuration that does not set
them.

## Reproduce

Per-component device time inside the decode graph, plus the whole-block cross-check that
validates it:

```bash
MCORE_INSITU_TIMING=1 MCORE_INFER_STEP_GPU_TIMING=1 \
DYNAMIC_BATCHING_ASYNC_SCHED_MODE=async \
QWEN30B_TP=1 QWEN30B_EP=4 QWEN30B_ETP=1 \
BENCH_SIZES_OVERRIDE=256 BENCH_OUTPUT_TOKENS=128 \
NUM_WARMUP_ITERS=2 NUM_TIMED_ITERS=5 \
bash skills/run-qwen-model/run_qwen_inference.sh qwen3-30b-a3b --checkpoint "$QWEN30B_CKPT"
```

Per-phase host CPU for the decode loop:

```bash
MCORE_INFER_HOST_TIMING=1 MCORE_INFER_ATTN_PROF=1 \
DYNAMIC_BATCHING_ASYNC_SCHED_MODE=async \
BENCH_SIZES_OVERRIDE=256 BENCH_OUTPUT_TOKENS=1024 \
bash skills/run-qwen-model/run_qwen_inference.sh qwen3-30b-a3b --checkpoint "$QWEN30B_CKPT"
```

Host cost of graph replay, why a fusion is not engaging, and naming the copies in one layer
are `MCORE_GRAPH_LAUNCH_TIMING=1`, `MCORE_FUSION_DIAG=1` and `MCORE_COPY_TRACE=1`
respectively, each usable on its own run. All reports go to stderr or stdout; the host timer
and the graph launch timer report periodically rather than only at exit, because the benchmark
harness terminates the server with a signal and exit handlers do not run.

Never combine `MCORE_DISPATCH_BALLAST` with a throughput measurement you intend to quote.

## What this does not claim

- **No speedup, and none is expected.** This PR adds no optimization. It should not be given
  a throughput arm, and if it appears to move throughput either way, that is noise or a
  mistake in the arm.
- **In-situ timing perturbs what it measures, by a measured 2.0% of block time.** Component
  numbers taken with it on are samples of two instrumented layers scaled by the layer count,
  not a census. Cross-check their scaled sum against the whole-block figure from the step timer
  before quoting any of them; if the parts do not reconstruct the whole, the sampling
  assumption is broken and the components are meaningless.
- **Expert histogram counts are cumulative from graph capture, not per step.** Only ratios
  between experts are meaningful; no absolute rate should be read out of them.
- **`MCORE_DISPATCH_BALLAST` is not an optimization and is not free.** It exists to add cost
  so the cost of a graph node can be priced, and it must be off in any measured configuration.
- **The host phase timer is not a profiler.** It reports self time per named phase on the
  decode thread. It does not attribute across threads, does not see the device, and cannot
  tell you whether a host phase was overlapped with GPU work — which is exactly the question
  the host-path PRs in this stack found to be decisive. Use it to size host phases, not to
  predict throughput.
- **This does not fix the Nsight Systems finalization deadlock**, it works around it. The
  remaining untested suspects, in order, are process-tree context switching, then process-tree
  sampling itself, then operating-system runtime tracing; bisect the flags against a short
  capture rather than retrying the full set, since each full attempt costs about 14 minutes.

## Follow-ups

- If this PR is declined, the durable part of it is the *reasoning*, which lives in the
  campaign notes: the external-event-record method, the graph-launch retraction, the profiler
  overhead figures and the Nsight flag bisection. The code can be rebuilt from that.
- Two modules that existed in the original combined change were dropped on merit before this
  slice was built, because both announce that their output is numerically invalid and both
  hard-code this configuration's constants. Both answered a question that is now answered,
  and one of them was superseded by in-situ timing, which was built precisely because
  subtraction cannot price a component that decides how much work its successors do. Their
  reasoning was moved to the campaign notes; the code was not carried forward, and they should
  not be resurrected without a fresh justification.


---

## This stack

This is one slice of [#6064](https://github.com/NVIDIA/Megatron-LM/pull/6064), a Qwen3-30B-A3B decode optimization campaign, split into 16 independently reviewable changes. Together they are **+35.80%** end-to-end throughput over the same base commit (23,265 -> 31,593 tok/s, mean of three full runs).

- **MoE grouped-GEMM and dispatch:** #6452 -> #6453 -> #6454 -> #6455
- **MoE router and combine:** #6456 -> #6457 -> #6458
- **Attention: QK norm and decode kernel:** #6459 -> #6460 -> #6461 -> #6462
- **Residual + RMSNorm fusion:** #6463 -> #6464
- **Host path: context bookkeeping:** #6465 -> #6466
- **Host path: independent:** #6467

Each chain is independent of the others and bases on `main`. Within a chain, later PRs depend on earlier ones.

### Per-slice measured delta

Every number is a leave-one-out delta from one same-node, same-session campaign: the full stack with exactly this change's gate off, against the interpolated full-stack reference at that point in the run. It is the change's *marginal* contribution with everything else already in, not its standalone value. Run-to-run sigma was **0.42%** across three full-stack repeats.

| PR | Change | Delta | |
|---|---|---|---|
| #6452 | FC1 SwiGLU epilogue | +14.81% | resolved |
| #6453 | indirection table fusion | +7.21% | resolved |
| #6454 | decode GEMM tile configs | +6.77% | resolved |
| #6455 | predicated top-k gather | +1.99% | by margin |
| #6456 | fused router softmax+top-k | +4.75% | resolved |
| #6457 | fused route padding mask | +1.47% | by margin |
| #6458 | bf16 MoE combine | +2.42% | by margin |
| #6459 | fused QK RMSNorm | +5.17% | resolved |
| #6460 | grouped QK norm input | +1.18% | by margin |
| #6461 | pin FlashAttention 2 | -0.35% | noise floor |
| #6462 | FlashInfer TRT-LLM decode | +1.46% | by margin |
| #6463 | fused add+norm pre-MLP | +3.54% | by margin |
| #6464 | fused add+norm pre-QKV | +0.98% | by margin |
| #6465 | incremental attention state | -0.42% | noise floor |
| #6466 | vectorized decode bookkeeping | -0.07% | noise floor |
| #6467 | post_process_requests fast path | +0.09% | noise floor |

`noise floor` means the delta is inside 2 sigma (0.84%) and this campaign cannot distinguish it from zero. `resolved` means the leave-one-out and full-stack iteration distributions did not overlap. Deltas do not sum to the stack total: these changes shorten the same decode step and compose sub-additively.

**Fixed protocol for every number above.** Qwen3-30B-A3B, BF16, TP1/PP1/EP4/ETP1, 256 gsm8k requests at batch size 256, output length 1024, CUDA graphs on, one OCI GB200 NVL72 node, 4 GPUs. All 20 arms ran back-to-back in a single Slurm allocation on one node, so node assignment and thermal state are held constant.
