### PR TITLE
[Dev] Introduce forward sharing state and enable repeated MTP sharing

### DIFF
--- a/docs/user-guide/features/multi_token_prediction.md
+++ b/docs/user-guide/features/multi_token_prediction.md
@@ -28,7 +28,7 @@ The following table summarizes MTP configuration fields:
 | `mtp_num_layers` | Number of MTP layers. MTP extends prediction to multiple future tokens at each position. This stack uses `mtp_num_layers` sequential modules to predict that many additional tokens per position. Default: `None`. |
 | `mtp_loss_scaling_factor` | Weight for the MTP loss term. The implementation averages MTP losses across depths, multiplies by this factor, and adds the result to the training objective. Default: `0.1`. |
 | `mtp_use_repeated_layer` | Reuse one physical MTP layer for every prediction depth. Parameters are shared, while the hidden state, shifted token input, and query are recomputed at each depth. Default: `False`. |
-| `mtp_repeated_layer_shared_components` | Components to reuse from the first invocation of a repeated MTP layer at later prediction depths in the same forward. The supported value is `sparse_attention_index`. Omit the option or use an empty list to disable repeated-layer sharing. Default: `None`. |
+| `mtp_repeated_layer_shared_components` | Components to reuse from the first invocation of a repeated MTP layer at later prediction depths in the same forward. Supported values are `latent_kv` and `sparse_attention_index`; values must be unique and their order has no effect. Omit the option or use an empty list to disable repeated-layer sharing. Default: `None`. |
 
 ## Repeated-Layer Sharing
 
@@ -37,9 +37,16 @@ Set `mtp_use_repeated_layer: true`, `mtp_num_layers > 1`, and
 at later prediction depths within the same forward and microbatch. Currently,
 this requires `experimental_attention_variant: dsa` and the repeated-layer GPT MTP path.
 
-Set `mtp_repeated_layer_shared_components: ["sparse_attention_index"]` to reuse
-depth-0 top-k indices. Omit the option or use `[]` to disable sharing.
-KV, queries, and sparse attention are computed at every depth.
+| Shared components | Later prediction depths |
+| --- | --- |
+| omitted or `[]` | Recompute KV and follow the ordinary top-k schedule. |
+| `["latent_kv"]` | Reuse depth-0 KV; follow the ordinary top-k schedule. |
+| `["sparse_attention_index"]` | Recompute KV; reuse depth-0 top-k indices. |
+| `["latent_kv", "sparse_attention_index"]` | Reuse both depth-0 KV and top-k indices. |
+
+Queries and sparse attention are computed at every depth. Shared KV remains
+attached to autograd: consumer gradients accumulate into the depth-0 KV projection.
+This is training-time activation reuse, not inference KV caching.
 
 Ordinary IndexShare (`dsa_indexer_topk_freq` and `dsa_indexer_skip_topk_offset`)
 still determines how depth 0 obtains its indices, including reuse from an earlier
@@ -50,13 +57,13 @@ execution segment; cross-PP index sharing remains unsupported.
 Index sharing avoids additional indexer evaluations and auxiliary-loss contributions
 at later depths; review `dsa_indexer_loss_coeff` when changing this setting.
 It disables the combined DSA kernel, but separate fused top-k and sparse-attention
-kernels remain eligible.
+kernels remain eligible. KV-only sharing does not itself disable the combined kernel.
 
 Compatibility:
 
 - Selective recompute supports `mlp`, `moe`, `moe_act`, `shared_experts`,
   `layernorm`, and `mhc`, subject to their existing requirements.
-  `mla_up_proj` recompute is also supported.
+  `mla_up_proj` supports index-only sharing, but not KV sharing.
 - Full recompute and selective `core_attn` recompute are unsupported.
   Set `recompute_modules` explicitly: selective recompute defaults to `core_attn`.
 - Attention CUDA graph capture is unsupported; MoE-only scopes remain compatible.
@@ -88,4 +95,4 @@ Use `m` for MTP layers in the pipeline layout string. For example:
 
 ## Unsupported Combinations
 
-Arbitrary `AttnMaskType` and learned absolute position embeddings are not supported with MTP. Context Parallel support is specific to the attention implementation. Repeated DSA index sharing supports DSA with `cp_comm_type=allgather` and reuses the depth-0 global sparse-attention index within the same microbatch CP group. Speculative decoding is not yet supported when `mtp_repeated_layer_shared_components` is non-empty because its serial calls do not establish one ordered repeated forward; disable repeated-layer sharing or set `num_speculative_tokens=0`.
+Arbitrary `AttnMaskType` and learned absolute position embeddings are not supported with MTP. Context Parallel support is specific to the attention implementation. For repeated DSA sharing, the supported CP path is DSA with `cp_comm_type=allgather`; it reuses the selected depth-0 global latent KV and/or global sparse-attention index within the same microbatch CP group. Speculative decoding is not yet supported when `mtp_repeated_layer_shared_components` is non-empty because its serial calls do not establish one ordered repeated forward; disable repeated-layer sharing or set `num_speculative_tokens=0`.

--- a/docs/user-guide/features/multi_token_prediction.md
+++ b/docs/user-guide/features/multi_token_prediction.md
@@ -27,6 +27,39 @@ The following table summarizes MTP configuration fields:
 | --- | --- |
 | `mtp_num_layers` | Number of MTP layers. MTP extends prediction to multiple future tokens at each position. This stack uses `mtp_num_layers` sequential modules to predict that many additional tokens per position. Default: `None`. |
 | `mtp_loss_scaling_factor` | Weight for the MTP loss term. The implementation averages MTP losses across depths, multiplies by this factor, and adds the result to the training objective. Default: `0.1`. |
+| `mtp_use_repeated_layer` | Reuse one physical MTP layer for every prediction depth. Parameters are shared, while the hidden state, shifted token input, and query are recomputed at each depth. Default: `False`. |
+| `mtp_repeated_layer_shared_components` | Components to reuse from the first invocation of a repeated MTP layer at later prediction depths in the same forward. The supported value is `sparse_attention_index`. Omit the option or use an empty list to disable repeated-layer sharing. Default: `None`. |
+
+## Repeated-Layer Sharing
+
+Set `mtp_use_repeated_layer: true`, `mtp_num_layers > 1`, and
+`mtp_repeated_layer_shared_components` to reuse selected results from depth 0
+at later prediction depths within the same forward and microbatch. Currently,
+this requires `experimental_attention_variant: dsa` and the repeated-layer GPT MTP path.
+
+Set `mtp_repeated_layer_shared_components: ["sparse_attention_index"]` to reuse
+depth-0 top-k indices. Omit the option or use `[]` to disable sharing.
+KV, queries, and sparse attention are computed at every depth.
+
+Ordinary IndexShare (`dsa_indexer_topk_freq` and `dsa_indexer_skip_topk_offset`)
+still determines how depth 0 obtains its indices, including reuse from an earlier
+decoder layer. Repeated-layer index sharing then reuses those indices at later
+depths. An ordinary IndexShare source must run earlier in the same PP/VPP
+execution segment; cross-PP index sharing remains unsupported.
+
+Index sharing avoids additional indexer evaluations and auxiliary-loss contributions
+at later depths; review `dsa_indexer_loss_coeff` when changing this setting.
+It disables the combined DSA kernel, but separate fused top-k and sparse-attention
+kernels remain eligible.
+
+Compatibility:
+
+- Selective recompute supports `mlp`, `moe`, `moe_act`, `shared_experts`,
+  `layernorm`, and `mhc`, subject to their existing requirements.
+  `mla_up_proj` recompute is also supported.
+- Full recompute and selective `core_attn` recompute are unsupported.
+  Set `recompute_modules` explicitly: selective recompute defaults to `core_attn`.
+- Attention CUDA graph capture is unsupported; MoE-only scopes remain compatible.
 
 ## Pipeline Parallel Layout for MTP
 
@@ -55,4 +88,4 @@ Use `m` for MTP layers in the pipeline layout string. For example:
 
 ## Unsupported Combinations
 
-Context Parallel (CP), arbitrary `AttnMaskType`, and learned absolute position embeddings are not supported with MTP.
+Arbitrary `AttnMaskType` and learned absolute position embeddings are not supported with MTP. Context Parallel support is specific to the attention implementation. Repeated DSA index sharing supports DSA with `cp_comm_type=allgather` and reuses the depth-0 global sparse-attention index within the same microbatch CP group. Speculative decoding is not yet supported when `mtp_repeated_layer_shared_components` is non-empty because its serial calls do not establish one ordered repeated forward; disable repeated-layer sharing or set `num_speculative_tokens=0`.

--- a/megatron/core/inference/text_generation_controllers/text_generation_controller.py
+++ b/megatron/core/inference/text_generation_controllers/text_generation_controller.py
@@ -137,6 +137,13 @@ class TextGenerationController:
         inference_config = self.inference_wrapped_model.inference_context.config
         self.tokenizer = tokenizer
         self.num_speculative_tokens = inference_config.num_speculative_tokens
+        if self.num_speculative_tokens and self.model_config.mtp_repeated_layer_shared_components:
+            raise ValueError(
+                "mtp_repeated_layer_shared_components is not supported with speculative "
+                "decoding because serial compute_mtp_single_step calls do not provide one "
+                "ordered forward repeat chain. Clear "
+                "mtp_repeated_layer_shared_components or set num_speculative_tokens=0."
+            )
 
         pg_collection = inference_config.pg_collection
         if pg_collection is not None:

--- a/megatron/core/models/common/model_chunk_schedule_plan.py
+++ b/megatron/core/models/common/model_chunk_schedule_plan.py
@@ -16,6 +16,10 @@ from megatron.core.pipeline_parallel.utils import (
     get_comm_stream,
     get_comp_stream,
 )
+from megatron.core.transformer.forward_sharing import (
+    ForwardSharingState,
+    is_forward_sharing_enabled,
+)
 from megatron.core.utils import nvtx_range_pop, nvtx_range_push
 
 
@@ -692,6 +696,12 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
         self._model_chunk_state.output_processor = output_processor
         self._model_chunk_state.output_processor_context = output_processor_context
         self._model_chunk_state.model = model
+        # The overlap schedule outlives GPTModel.forward and owns its IndexShare
+        # payloads until backward/recompute completes, not until a carrier is collected.
+        self._model_chunk_state.forward_sharing_state = None
+        if is_forward_sharing_enabled(model.config):
+            self._model_chunk_state.forward_sharing_state = ForwardSharingState()
+            self._model_chunk_state.forward_sharing_state.active = True
         self._model_chunk_state.context = None
         self._model_chunk_state.context_mask = None
         self._model_chunk_state.attention_bias = None
@@ -854,6 +864,10 @@ class TransformerModelChunkSchedulePlan(AbstractSchedulePlan):
 
     def release_state(self):
         """Release reference, this helps avoid memory leak."""
+        sharing_state = self._model_chunk_state.forward_sharing_state
+        if sharing_state is not None:
+            sharing_state.clear()
+            self._model_chunk_state.forward_sharing_state = None
         self._recompute_segments = []
         self._model_chunk_state.model = None
         self.pre_process.model_chunk_state = None

--- a/megatron/core/models/gpt/fine_grained_callables.py
+++ b/megatron/core/models/gpt/fine_grained_callables.py
@@ -15,6 +15,7 @@ from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
 )
 from megatron.core.pipeline_parallel.utils import ScheduleNode, make_viewless
 from megatron.core.transformer.enums import CudaGraphModule
+from megatron.core.transformer.forward_sharing import use_forward_sharing_state
 from megatron.core.transformer.module import GraphableMegatronModule, float16_to_fp32
 from megatron.core.transformer.moe.moe_layer import MoELayer
 from megatron.core.transformer.multi_token_prediction import (
@@ -410,7 +411,20 @@ class TransformerLayerNode(ScheduleNode):
 
     def forward_impl(self, *args):
         """Calls the submodule as the forward pass."""
-        return self.submodule(self, *args)
+        sharing_state = getattr(self.chunk_state, 'forward_sharing_state', None)
+        if sharing_state is None:
+            return self.submodule(self, *args)
+        try:
+            with use_forward_sharing_state(
+                sharing_state,
+                self.chunk_state.packed_seq_params,
+                self.chunk_state.attention_mask,
+                self.chunk_state.model.config,
+            ):
+                return self.submodule(self, *args)
+        except Exception:
+            sharing_state.clear()
+            raise
 
     def backward_impl(self, outputs, output_grad):
         """Implements the backward pass for the transformer layer node."""

--- a/megatron/core/models/gpt/gpt_layer_specs.py
+++ b/megatron/core/models/gpt/gpt_layer_specs.py
@@ -793,6 +793,25 @@ def get_gpt_mtp_block_spec_for_backend(
     if num_layers_to_build == 0:
         return None
 
+    if config.mtp_repeated_layer_shared_components:
+        if config.pipeline_model_parallel_layout is not None:
+            layout = config.pipeline_model_parallel_layout
+            assert isinstance(
+                layout, PipelineParallelLayerLayout
+            ), f"Invalid pipeline model parallel layout: {layout}"
+            local_decoder_layer_ids = layout.get_layer_id_list(
+                layer_type=LayerType.decoder, vp_stage=vp_stage, pp_rank=pp_rank
+            )
+        else:
+            decoder_offset = get_transformer_layer_offset(
+                config, vp_stage=vp_stage, pp_rank=pp_rank
+            )
+            decoder_count = get_num_layers_to_build(config, vp_stage=vp_stage, pp_rank=pp_rank)
+            local_decoder_layer_ids = range(decoder_offset, decoder_offset + decoder_count)
+        _validate_dsa_mtp_index_share_pipeline_split(
+            config, local_decoder_layer_ids, mtp_layer_number=config.num_layers + 1
+        )
+
     if isinstance(spec, TransformerBlockSubmodules):
         # get the spec for the last layer of decoder block
         transformer_layer_spec = copy.copy(spec.layer_specs[-1])
@@ -830,3 +849,40 @@ def get_gpt_mtp_block_spec_for_backend(
         mtp_block_spec = None
 
     return mtp_block_spec
+
+
+def _validate_dsa_mtp_index_share_pipeline_split(
+    config: TransformerConfig, local_decoder_layer_ids, mtp_layer_number: int
+) -> None:
+    """Ensure repeated-MTP sharing can obtain ordinary DSA top-k on this PP/VPP segment."""
+    if (
+        config.experimental_attention_variant != "dsa"
+        or not config.mtp_repeated_layer_shared_components
+        or config.dsa_indexer_topk_freq <= 1
+    ):
+        return
+
+    from megatron.core.transformer.experimental_attention_variant.dsa import (
+        is_dsa_skip_topk_layer,
+        source_dsa_compute_layer,
+    )
+
+    if not is_dsa_skip_topk_layer(
+        mtp_layer_number, config.dsa_indexer_skip_topk_offset, config.dsa_indexer_topk_freq
+    ):
+        return
+
+    source_layer_number = source_dsa_compute_layer(
+        mtp_layer_number, config.dsa_indexer_skip_topk_offset, config.dsa_indexer_topk_freq
+    )
+    local_decoder_layer_numbers = {layer_id + 1 for layer_id in local_decoder_layer_ids}
+    if source_layer_number not in local_decoder_layer_numbers:
+        raise RuntimeError(
+            "DSA repeated-MTP IndexShare pipeline split is invalid: MTP layer "
+            f"{mtp_layer_number} reuses top-k indices from computing layer "
+            f"{source_layer_number}, but that decoder layer is not in the same PP/VPP "
+            "execution segment. Cross-layer top-k sharing does not cross PP/VPP boundaries. "
+            "Place the source decoder layer with MTP or adjust "
+            f"dsa_indexer_topk_freq={config.dsa_indexer_topk_freq} and "
+            f"dsa_indexer_skip_topk_offset={config.dsa_indexer_skip_topk_offset}."
+        )

--- a/megatron/core/models/gpt/gpt_model.py
+++ b/megatron/core/models/gpt/gpt_model.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 from collections import OrderedDict
+from contextlib import nullcontext
 from typing import Any, Callable, Dict, Literal, Optional
 
 import torch
@@ -28,6 +29,10 @@ from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.quantization.utils import get_quant_config_or_none
 from megatron.core.tensor_parallel import gather_from_sequence_parallel_region
 from megatron.core.transformer.enums import ModelType
+from megatron.core.transformer.forward_sharing import (
+    forward_sharing_lifetime,
+    is_forward_sharing_enabled,
+)
 from megatron.core.transformer.linear_cross_entropy import LinearCrossEntropyModule
 from megatron.core.transformer.moe.paged_stash import paged_stash_init_chunk_handler
 from megatron.core.transformer.multi_token_prediction import (
@@ -575,84 +580,91 @@ class GPTModel(LanguageModule):
             output_processor_context (Any, optional): User-defined context object forwarded to
                 `output_processor`.
         """
-        if self.config.fine_grained_activation_offloading:
-            self.preprocess_for_fine_grained_offloading()
 
-        if self.config.moe_paged_stash:
-            self.preprocess_for_paged_stash()
+        sharing_lifetime = nullcontext()
+        if is_forward_sharing_enabled(self.config):
+            sharing_lifetime = forward_sharing_lifetime(
+                packed_seq_params, attention_mask, self.config
+            )
+        with sharing_lifetime:
+            if self.config.fine_grained_activation_offloading:
+                self.preprocess_for_fine_grained_offloading()
 
-        inference_context = deprecate_inference_params(inference_context, inference_params)
+            if self.config.moe_paged_stash:
+                self.preprocess_for_paged_stash()
 
-        preproc_output = self._preprocess(
-            input_ids=input_ids,
-            position_ids=position_ids,
-            decoder_input=decoder_input,
-            inference_context=inference_context,
-            packed_seq_params=packed_seq_params,
-            padding_mask=padding_mask,
-        )
+            inference_context = deprecate_inference_params(inference_context, inference_params)
 
-        (
-            decoder_input,
-            rotary_pos_emb,
-            rotary_pos_cos,
-            rotary_pos_sin,
-            sequence_len_offset,
-            padding_mask,
-        ) = preproc_output[:6]
+            preproc_output = self._preprocess(
+                input_ids=input_ids,
+                position_ids=position_ids,
+                decoder_input=decoder_input,
+                inference_context=inference_context,
+                packed_seq_params=packed_seq_params,
+                padding_mask=padding_mask,
+            )
 
-        rotary_pos_cos_sin = preproc_output[6] if len(preproc_output) == 7 else None
+            (
+                decoder_input,
+                rotary_pos_emb,
+                rotary_pos_cos,
+                rotary_pos_sin,
+                sequence_len_offset,
+                padding_mask,
+            ) = preproc_output[:6]
 
-        # Pass input_ids to decoder for hash-based MoE routing
-        decoder_extra_block_kwargs = extra_block_kwargs or {}
-        if self.config.moe_n_hash_layers > 0 and input_ids is not None:
-            decoder_extra_block_kwargs['input_ids'] = input_ids
+            rotary_pos_cos_sin = preproc_output[6] if len(preproc_output) == 7 else None
 
-        # Run decoder.
-        decoder_output = self.decoder(
-            hidden_states=decoder_input,
-            attention_mask=attention_mask,
-            inference_context=inference_context,
-            rotary_pos_emb=rotary_pos_emb,
-            rotary_pos_cos=rotary_pos_cos,
-            rotary_pos_sin=rotary_pos_sin,
-            rotary_pos_cos_sin=rotary_pos_cos_sin,
-            packed_seq_params=packed_seq_params,
-            sequence_len_offset=sequence_len_offset,
-            padding_mask=padding_mask,
-            **decoder_extra_block_kwargs,
-        )
-        # When mHC + MTP, the decoder returns (contracted, multi-stream).
-        # MTP needs multi-stream; lm_head needs contracted.
-        if isinstance(decoder_output, tuple):
-            hidden_states, mhc_multistream = decoder_output
-        else:
-            hidden_states = decoder_output
-            mhc_multistream = None
+            # Pass input_ids to decoder for hash-based MoE routing
+            decoder_extra_block_kwargs = extra_block_kwargs or {}
+            if self.config.moe_n_hash_layers > 0 and input_ids is not None:
+                decoder_extra_block_kwargs['input_ids'] = input_ids
 
-        return self._postprocess(
-            hidden_states=hidden_states,
-            input_ids=input_ids,
-            position_ids=position_ids,
-            labels=labels,
-            rotary_pos_emb=rotary_pos_emb,
-            rotary_pos_cos=rotary_pos_cos,
-            rotary_pos_sin=rotary_pos_sin,
-            mtp_in_postprocess=self.mtp_process,
-            loss_mask=loss_mask,
-            decoder_input=decoder_input,
-            attention_mask=attention_mask,
-            padding_mask=padding_mask,
-            inference_params=inference_params,
-            packed_seq_params=packed_seq_params,
-            sequence_len_offset=sequence_len_offset,
-            runtime_gather_output=runtime_gather_output,
-            extra_block_kwargs=extra_block_kwargs,
-            inference_context=inference_context,
-            mhc_multistream=mhc_multistream,
-            output_processor=output_processor,
-            output_processor_context=output_processor_context,
-        )
+            # Run decoder.
+            decoder_output = self.decoder(
+                hidden_states=decoder_input,
+                attention_mask=attention_mask,
+                inference_context=inference_context,
+                rotary_pos_emb=rotary_pos_emb,
+                rotary_pos_cos=rotary_pos_cos,
+                rotary_pos_sin=rotary_pos_sin,
+                rotary_pos_cos_sin=rotary_pos_cos_sin,
+                packed_seq_params=packed_seq_params,
+                sequence_len_offset=sequence_len_offset,
+                padding_mask=padding_mask,
+                **decoder_extra_block_kwargs,
+            )
+            # When mHC + MTP, the decoder returns (contracted, multi-stream).
+            # MTP needs multi-stream; lm_head needs contracted.
+            if isinstance(decoder_output, tuple):
+                hidden_states, mhc_multistream = decoder_output
+            else:
+                hidden_states = decoder_output
+                mhc_multistream = None
+
+            return self._postprocess(
+                hidden_states=hidden_states,
+                input_ids=input_ids,
+                position_ids=position_ids,
+                labels=labels,
+                rotary_pos_emb=rotary_pos_emb,
+                rotary_pos_cos=rotary_pos_cos,
+                rotary_pos_sin=rotary_pos_sin,
+                mtp_in_postprocess=self.mtp_process,
+                loss_mask=loss_mask,
+                decoder_input=decoder_input,
+                attention_mask=attention_mask,
+                padding_mask=padding_mask,
+                inference_params=inference_params,
+                packed_seq_params=packed_seq_params,
+                sequence_len_offset=sequence_len_offset,
+                runtime_gather_output=runtime_gather_output,
+                extra_block_kwargs=extra_block_kwargs,
+                inference_context=inference_context,
+                mhc_multistream=mhc_multistream,
+                output_processor=output_processor,
+                output_processor_context=output_processor_context,
+            )
 
     def _postprocess(
         self,

--- a/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
+++ b/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
@@ -909,6 +909,14 @@ class AbsorbedMLASelfAttention(Attention):
         assert (
             inference_context is None and inference_params is None
         ), "Inference is not supported for AbsorbedMLA"
+        if (
+            getattr(self.core_attention, "mtp_cross_depth_share", False)
+            and self.checkpoint_core_attention
+            and self.training
+        ):
+            raise RuntimeError(
+                "Repeated-MTP cross-depth sharing does not support core_attn recompute."
+            )
 
         # Set the right cp group for dynamic-cp. Downstream RoPE and CSA core
         # attention use self.pg_collection.cp, which must point at this

--- a/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
+++ b/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
@@ -442,6 +442,7 @@ class AbsorbedMLASelfAttention(Attention):
         key_value_states=None,
         packed_seq_params=None,
         inference_context=None,
+        reuse_mtp_latent_kv: bool = False,
         *,
         inference_params=None,
     ):
@@ -525,36 +526,41 @@ class AbsorbedMLASelfAttention(Attention):
         #     kv_combined: [s, b, (kv_lora_rank + qk_pos_emb_head_dim) / TP]
         # elif linear_kv_down_proj is Linear:
         #     kv_combined: [s / TP, b, (kv_lora_rank + qk_pos_emb_head_dim)]
-        kv_combined, _ = self.linear_kv_down_proj(hidden_states)
-        if kv_combined.size(-1) != self.config.kv_lora_rank + self.config.qk_pos_emb_head_dim:
-            # kv_combined: [s, b, (kv_lora_rank + qk_pos_emb_head_dim)]
-            kv_combined = gather_from_tensor_model_parallel_region(kv_combined)
-            # kv_compressed:[s, b, kv_lora_rank], k_pos_emb: [s, b, qk_pos_emb_head_dim]
-            kv_compressed, k_pos_emb = torch.split(
-                kv_combined, [self.config.kv_lora_rank, self.config.qk_pos_emb_head_dim], dim=-1
-            )
-            if self.config.sequence_parallel:
+        if not reuse_mtp_latent_kv:
+            kv_combined, _ = self.linear_kv_down_proj(hidden_states)
+            if kv_combined.size(-1) != self.config.kv_lora_rank + self.config.qk_pos_emb_head_dim:
+                # kv_combined: [s, b, (kv_lora_rank + qk_pos_emb_head_dim)]
+                kv_combined = gather_from_tensor_model_parallel_region(kv_combined)
+                # kv_compressed:[s, b, kv_lora_rank], k_pos_emb: [s, b, qk_pos_emb_head_dim]
+                kv_compressed, k_pos_emb = torch.split(
+                    kv_combined, [self.config.kv_lora_rank, self.config.qk_pos_emb_head_dim], dim=-1
+                )
+                if self.config.sequence_parallel:
+                    # kv_compressed:[s / TP, b, kv_lora_rank]
+                    kv_compressed = scatter_to_sequence_parallel_region(kv_compressed)
+            else:
                 # kv_compressed:[s / TP, b, kv_lora_rank]
-                kv_compressed = scatter_to_sequence_parallel_region(kv_compressed)
+                # k_pos_emb: [s / TP, b, qk_pos_emb_head_dim]
+                kv_compressed, k_pos_emb = torch.split(
+                    kv_combined, [self.config.kv_lora_rank, self.config.qk_pos_emb_head_dim], dim=-1
+                )
+                if get_pg_size(self.tp_group) > 1 and self.config.sequence_parallel:
+                    # k_pos_emb: [s, b, qk_pos_emb_head_dim]
+                    k_pos_emb = gather_from_sequence_parallel_region(k_pos_emb, group=self.tp_group)
         else:
-            # kv_compressed:[s / TP, b, kv_lora_rank], k_pos_emb: [s / TP, b, qk_pos_emb_head_dim]
-            kv_compressed, k_pos_emb = torch.split(
-                kv_combined, [self.config.kv_lora_rank, self.config.qk_pos_emb_head_dim], dim=-1
-            )
-            if get_pg_size(self.tp_group) > 1 and self.config.sequence_parallel:
-                # k_pos_emb: [s, b, qk_pos_emb_head_dim]
-                k_pos_emb = gather_from_sequence_parallel_region(k_pos_emb, group=self.tp_group)
+            kv_compressed = k_pos_emb = None
 
         if thd_packed_seq:
             assert q_compressed.ndim == 3 and q_compressed.size(1) == 1
-            assert kv_compressed.ndim == 3 and kv_compressed.size(1) == 1
-            assert k_pos_emb.ndim == 3 and k_pos_emb.size(1) == 1
             # If sequence packing, TE expect [t, h, d] shaped qkv input.
             # In Megatron-Core, the qkv shape is [t, 1, h, d].
             # So we need to reshape qkv from [t, 1, h, d] to [t, h, d].
             q_compressed = q_compressed.squeeze(1)
-            kv_compressed = kv_compressed.squeeze(1)
-            k_pos_emb = k_pos_emb.squeeze(1)
+            if not reuse_mtp_latent_kv:
+                assert kv_compressed.ndim == 3 and kv_compressed.size(1) == 1
+                assert k_pos_emb.ndim == 3 and k_pos_emb.size(1) == 1
+                kv_compressed = kv_compressed.squeeze(1)
+                k_pos_emb = k_pos_emb.squeeze(1)
 
         # =========================================
         # Apply norm
@@ -563,11 +569,14 @@ class AbsorbedMLASelfAttention(Attention):
             # q_compressed: [num_tokens, q_lora_rank]
             q_compressed = self.q_layernorm(q_compressed)
 
-        kv_compressed = self.kv_layernorm(kv_compressed)
-        # Because we won't apply V up projection to the compressed KV, so we need to gather it
-        # manually.
-        if get_pg_size(self.tp_group) > 1 and self.config.sequence_parallel:
-            kv_compressed = gather_from_sequence_parallel_region(kv_compressed, group=self.tp_group)
+        if not reuse_mtp_latent_kv:
+            kv_compressed = self.kv_layernorm(kv_compressed)
+            # Because we won't apply V up projection to the compressed KV, so we need to gather it
+            # manually.
+            if get_pg_size(self.tp_group) > 1 and self.config.sequence_parallel:
+                kv_compressed = gather_from_sequence_parallel_region(
+                    kv_compressed, group=self.tp_group
+                )
 
         # =========================================
         # QKV up projection and RoPE apply
@@ -592,10 +601,11 @@ class AbsorbedMLASelfAttention(Attention):
             # q: [num_tokens, n, q_head_dim]
             q = q.view(*q.size()[:-1], self.num_attention_heads_per_partition, self.q_head_dim)
 
-            # [num_tokens, kv_lora_rank] -> [num_tokens, 1, kv_lora_rank]
-            kv_compressed = torch.unsqueeze(kv_compressed, -2)
-            # [num_tokens, qk_pos_emb_head_dim] -> [num_tokens, 1, qk_pos_emb_head_dim]
-            k_pos_emb = torch.unsqueeze(k_pos_emb, -2)
+            if not reuse_mtp_latent_kv:
+                # [num_tokens, kv_lora_rank] -> [num_tokens, 1, kv_lora_rank]
+                kv_compressed = torch.unsqueeze(kv_compressed, -2)
+                # [num_tokens, qk_pos_emb_head_dim] -> [num_tokens, 1, qk_pos_emb_head_dim]
+                k_pos_emb = torch.unsqueeze(k_pos_emb, -2)
 
             k_up_weight, _ = self._get_kv_up_weights()
 
@@ -624,15 +634,19 @@ class AbsorbedMLASelfAttention(Attention):
                     cp_rank,
                     cp_size,
                 )
-                kv_compressed = fused_mla_rope_concat(
-                    kv_compressed,
-                    k_pos_emb,
-                    rotary_pos_cos,
-                    rotary_pos_sin,
-                    cu_seqlens_kv,
-                    cp_rank,
-                    cp_size,
-                )
+                if not reuse_mtp_latent_kv:
+                    kv_compressed = fused_mla_rope_concat(
+                        kv_compressed,
+                        k_pos_emb,
+                        rotary_pos_cos,
+                        rotary_pos_sin,
+                        cu_seqlens_kv,
+                        cp_rank,
+                        cp_size,
+                    )
+                else:
+                    # DSAttention resolves the canonical depth-0 key from its sharing state.
+                    kv_compressed = None
             else:
                 q_len = q.size()[0]
                 if inference_context is not None:
@@ -676,25 +690,29 @@ class AbsorbedMLASelfAttention(Attention):
                     mla_rotary_interleaved=True,
                     max_seqlen=rope_max_seqlen_q,
                 )
-                # k_pos_emb:[num_tokens, 1, qk_pos_emb_head_dim]
-                k_pos_emb = apply_rotary_pos_emb(
-                    k_pos_emb,
-                    rotary_pos_emb,
-                    config=self.config,
-                    cu_seqlens=cu_seqlens_kv,
-                    mscale=mscale,
-                    cp_group=self.pg_collection.cp,
-                    mla_rotary_interleaved=True,
-                    max_seqlen=rope_max_seqlen_kv,
-                )
-
                 # query: [num_tokens, n, (kv_lora_rank + qk_pos_emb_head_dim)]
                 q_absorbed = torch.cat([q_absorbed, q_pos_emb], dim=-1)
-                # key: [num_tokens, 1, (kv_lora_rank + qk_pos_emb_head_dim)]
-                kv_compressed = torch.cat([kv_compressed, k_pos_emb], dim=-1)
+
+                if not reuse_mtp_latent_kv:
+                    # k_pos_emb:[num_tokens, 1, qk_pos_emb_head_dim]
+                    k_pos_emb = apply_rotary_pos_emb(
+                        k_pos_emb,
+                        rotary_pos_emb,
+                        config=self.config,
+                        cu_seqlens=cu_seqlens_kv,
+                        mscale=mscale,
+                        cp_group=self.pg_collection.cp,
+                        mla_rotary_interleaved=True,
+                        max_seqlen=rope_max_seqlen_kv,
+                    )
+                    # key: [num_tokens, 1, (kv_lora_rank + qk_pos_emb_head_dim)]
+                    kv_compressed = torch.cat([kv_compressed, k_pos_emb], dim=-1)
+                else:
+                    # DSAttention resolves the canonical depth-0 key from its sharing state.
+                    kv_compressed = None
 
             assert q_absorbed.is_contiguous()
-            assert kv_compressed.is_contiguous()
+            assert kv_compressed is None or kv_compressed.is_contiguous()
 
             return q_absorbed, kv_compressed
 
@@ -918,6 +936,16 @@ class AbsorbedMLASelfAttention(Attention):
                 "Repeated-MTP cross-depth sharing does not support core_attn recompute."
             )
 
+        if (
+            getattr(self.core_attention, "mtp_latent_kv_share", False)
+            and self.recompute_up_proj
+            and self.training
+        ):
+            raise RuntimeError(
+                "Repeated-MTP latent_kv sharing does not support mla_up_proj recompute: "
+                "the source KV storage would be discarded before later depths consume it."
+            )
+
         # Set the right cp group for dynamic-cp. Downstream RoPE and CSA core
         # attention use self.pg_collection.cp, which must point at this
         # microbatch's dynamic CP group. Restored before returning.
@@ -940,13 +968,28 @@ class AbsorbedMLASelfAttention(Attention):
         # =====================
         # Query, Key, and Value
         # =====================
+        should_reuse_mtp_latent_kv = getattr(
+            self.core_attention, "should_reuse_mtp_latent_kv", None
+        )
+        reuse_mtp_latent_kv = (
+            should_reuse_mtp_latent_kv(packed_seq_params, attention_mask)
+            if should_reuse_mtp_latent_kv is not None
+            else False
+        )
+        mtp_latent_kv_kwargs = {}
+        if reuse_mtp_latent_kv:
+            mtp_latent_kv_kwargs["reuse_mtp_latent_kv"] = True
         q_absorbed, kv_compressed, q_compressed = self.get_query_key_value_tensors(
-            hidden_states, key_value_states, packed_seq_params, inference_context=inference_context
+            hidden_states,
+            key_value_states,
+            packed_seq_params,
+            inference_context=inference_context,
+            **mtp_latent_kv_kwargs,
         )
 
         assert q_absorbed.is_contiguous()
         assert q_compressed.is_contiguous()
-        assert kv_compressed.is_contiguous()
+        assert kv_compressed is None or kv_compressed.is_contiguous()
         v_up_weight = self._get_v_up_weight()
 
         # ==================================

--- a/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
+++ b/megatron/core/transformer/experimental_attention_variant/absorbed_mla.py
@@ -37,6 +37,10 @@ from megatron.core.tensor_parallel.mappings import (
 )
 from megatron.core.transformer.attention import Attention
 from megatron.core.transformer.enums import AttnMaskType
+from megatron.core.transformer.forward_sharing import (
+    is_forward_sharing_enabled,
+    preserve_forward_sharing_for_checkpoint,
+)
 from megatron.core.transformer.mla_qk_norm_config import QKNormConfigResolver
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
 from megatron.core.transformer.transformer_config import MLATransformerConfig
@@ -857,6 +861,10 @@ class AbsorbedMLASelfAttention(Attention):
         if attn_mask_type is None:
             attn_mask_type = self.attn_mask_type
         attn_mask_type = torch.tensor([attn_mask_type.value], dtype=torch.int)
+        if is_forward_sharing_enabled(self.config):
+            custom_forward = preserve_forward_sharing_for_checkpoint(
+                custom_forward, packed_seq_params, self.config, attention_mask_arg=4
+            )
         hidden_states = tensor_parallel.checkpoint(
             custom_forward,
             False,

--- a/megatron/core/transformer/experimental_attention_variant/dsa.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa.py
@@ -30,7 +30,10 @@ from megatron.core.transformer.experimental_attention_variant import (
     dsa_layout,
     dsa_masking,
 )
-from megatron.core.transformer.forward_sharing import get_forward_sharing_state
+from megatron.core.transformer.forward_sharing import (
+    get_forward_sharing_state,
+    is_mtp_repeated_sharing_source,
+)
 from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
 from megatron.core.transformer.transformer_config import TransformerConfig
@@ -38,6 +41,7 @@ from megatron.core.utils import ensure_params_ready, get_pg_size
 
 logger = logging.getLogger(__name__)
 _DSA_WEIGHTS_PROJ_TE_GEMM_FALLBACK_WARNED = False
+_warned_mtp_index_sharing_fused_bypass = False
 
 try:
     from transformer_engine.pytorch.module.base import get_dummy_wgrad
@@ -1941,6 +1945,22 @@ class _DSAIndexSharingPayload:
         return type(self)(dict(self.topk_by_layer), dict(self.topk_length_by_layer))
 
 
+@dataclass
+class _DSAMTPRepeatedSharingPayload:
+    """DSA's repeated-MTP tensors indexed by physical, global layer number.
+
+    Separate from ordinary IndexShare. Source calls replace only their layer's
+    entries; consumers use MTP's explicit source/consumer flag. The enclosing
+    forward owns tensor cleanup, while snapshots retain independent dictionaries.
+    """
+
+    topk_by_layer: dict[int, torch.Tensor] = field(default_factory=dict)
+    topk_length_by_layer: dict[int, torch.Tensor] = field(default_factory=dict)
+
+    def __copy__(self):
+        return type(self)(dict(self.topk_by_layer), dict(self.topk_length_by_layer))
+
+
 class DSAttention(MegatronModule):
     """
     This module implements sparse attention mechanism using an DSA Indexer to compute top-k
@@ -1978,6 +1998,27 @@ class DSAttention(MegatronModule):
         self.skip_topk = self.index_share and is_dsa_skip_topk_layer(
             self.layer_number, self.index_skip_topk_offset, self.index_topk_freq
         )
+        mtp_shared_components = frozenset(self.config.mtp_repeated_layer_shared_components or ())
+        self.mtp_sparse_attention_index_share = (
+            "sparse_attention_index" in mtp_shared_components and is_mtp_layer
+        )
+        self.mtp_cross_depth_share = self.mtp_sparse_attention_index_share
+        global _warned_mtp_index_sharing_fused_bypass
+        if (
+            self.mtp_sparse_attention_index_share
+            and dsa_kernels.use_fused_dsa_kernels(self.config)
+            and not _warned_mtp_index_sharing_fused_bypass
+        ):
+            _warned_mtp_index_sharing_fused_bypass = True
+            log_single_rank(
+                logger,
+                logging.WARNING,
+                "MTP sparse_attention_index sharing requires reusable top-k indices, which the "
+                "combined fused DSA kernel does not expose. The repeated MTP layer therefore "
+                "uses the separable top-k and sparse-attention path; configured fused kernels "
+                "for those operations remain eligible. Benchmark this tradeoff for the target "
+                "MTP depth.",
+            )
         self.source_layer = (
             source_dsa_compute_layer(
                 self.layer_number, self.index_skip_topk_offset, self.index_topk_freq
@@ -2019,6 +2060,35 @@ class DSAttention(MegatronModule):
             _DSAIndexSharingPayload
         )
 
+    def _prepare_mtp_sharing_payload(
+        self, packed_seq_params: Optional[PackedSeqParams], attention_mask: Optional[torch.Tensor]
+    ) -> Tuple[Optional[bool], Optional[_DSAMTPRepeatedSharingPayload]]:
+        """Clear this source layer's old tensors or require its published tensors."""
+        if not self.mtp_cross_depth_share:
+            return None, None
+        state = self._get_forward_sharing_state(packed_seq_params, attention_mask)
+        is_source = is_mtp_repeated_sharing_source(state, self.layer_number)
+        if is_source:
+            payload = state.get_or_create(_DSAMTPRepeatedSharingPayload)
+            payload.topk_by_layer.pop(self.layer_number, None)
+            payload.topk_length_by_layer.pop(self.layer_number, None)
+        else:
+            payload = self._require_mtp_sharing_payload(packed_seq_params, attention_mask)
+        return is_source, payload
+
+    def _require_mtp_sharing_payload(
+        self, packed_seq_params: Optional[PackedSeqParams], attention_mask: Optional[torch.Tensor]
+    ) -> _DSAMTPRepeatedSharingPayload:
+        """Require the tensors published by this physical layer's source call."""
+        state = self._get_forward_sharing_state(packed_seq_params, attention_mask)
+        is_mtp_repeated_sharing_source(state, self.layer_number)
+        payload = state.get(_DSAMTPRepeatedSharingPayload)
+        if payload is None:
+            raise RuntimeError("MTP sharing consumer requires published source tensors.")
+        if self.mtp_sparse_attention_index_share and self.layer_number not in payload.topk_by_layer:
+            raise RuntimeError("MTP sharing consumer requires published source indices.")
+        return payload
+
     def backward_dw(self):
         """Compute the deferred weight gradients (delay_wgrad_compute) of the indexer."""
         if self.indexer is not None:
@@ -2056,6 +2126,12 @@ class DSAttention(MegatronModule):
         Returns:
             output: Output tensor [sq, b, hidden_size]
         """
+        is_mtp_source, mtp_payload = self._prepare_mtp_sharing_payload(
+            packed_seq_params, attention_mask
+        )
+        reuse_sparse_attention_index = bool(
+            self.mtp_sparse_attention_index_share and mtp_payload is not None and not is_mtp_source
+        )
         query, _ = dsa_layout.ensure_sbhd(query, "query")
         key, _ = dsa_layout.ensure_sbhd(key, "key")
         if value is not None:
@@ -2288,7 +2364,7 @@ class DSAttention(MegatronModule):
         qr = qr.detach()
 
         indexer_loss_coeff = self.config.dsa_indexer_loss_coeff or 0.0
-        computes_topk = not self.skip_topk
+        computes_topk = not self.skip_topk and not reuse_sparse_attention_index
         use_indexer_loss = (
             self.training and torch.is_grad_enabled() and indexer_loss_coeff > 0 and computes_topk
         )
@@ -2353,7 +2429,11 @@ class DSAttention(MegatronModule):
             local_packed_cp_query_start = sequence_parallel_tp_row_start
             local_packed_cp_query_len = sequence_parallel_tp_full_rows
 
-        if self.skip_topk:
+        if reuse_sparse_attention_index:
+            assert mtp_payload is not None
+            topk_indices = mtp_payload.topk_by_layer[self.layer_number]
+            topk_length = mtp_payload.topk_length_by_layer.get(self.layer_number)
+        elif self.skip_topk:
             assert index_payload is not None
             if self.source_layer not in index_payload.topk_by_layer:
                 raise RuntimeError(
@@ -2428,7 +2508,7 @@ class DSAttention(MegatronModule):
             )
 
         fused_output = None
-        if use_fused_kernels and not self.index_share:
+        if use_fused_kernels and not self.index_share and not self.mtp_sparse_attention_index_share:
             assert q is not None and k is not None and weights is not None
             fused_output = dsa_kernels.run_fused_dsa_attention(
                 config=self.config,
@@ -2611,11 +2691,22 @@ class DSAttention(MegatronModule):
                     del index_scores
             slice_topk_to_local_sequence_parallel_rows()
 
-        if self.index_share and computes_topk:
+        publish_ordinary_topk = self.index_share and computes_topk
+        publish_mtp_topk = bool(
+            self.mtp_sparse_attention_index_share and mtp_payload is not None and is_mtp_source
+        )
+        if publish_ordinary_topk:
             assert index_payload is not None and topk_indices is not None
             index_payload.topk_by_layer[self.layer_number] = topk_indices
-            if topk_length is not None:
+            if topk_length is None:
+                index_payload.topk_length_by_layer.pop(self.layer_number, None)
+            else:
                 index_payload.topk_length_by_layer[self.layer_number] = topk_length
+        if publish_mtp_topk:
+            assert mtp_payload is not None and topk_indices is not None
+            mtp_payload.topk_by_layer[self.layer_number] = topk_indices
+            if topk_length is not None:
+                mtp_payload.topk_length_by_layer[self.layer_number] = topk_length
 
         # ===================================
         # Run sparse attention kernel

--- a/megatron/core/transformer/experimental_attention_variant/dsa.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa.py
@@ -1956,9 +1956,12 @@ class _DSAMTPRepeatedSharingPayload:
 
     topk_by_layer: dict[int, torch.Tensor] = field(default_factory=dict)
     topk_length_by_layer: dict[int, torch.Tensor] = field(default_factory=dict)
+    latent_kv_by_layer: dict[int, torch.Tensor] = field(default_factory=dict)
 
     def __copy__(self):
-        return type(self)(dict(self.topk_by_layer), dict(self.topk_length_by_layer))
+        return type(self)(
+            dict(self.topk_by_layer), dict(self.topk_length_by_layer), dict(self.latent_kv_by_layer)
+        )
 
 
 class DSAttention(MegatronModule):
@@ -1999,10 +2002,13 @@ class DSAttention(MegatronModule):
             self.layer_number, self.index_skip_topk_offset, self.index_topk_freq
         )
         mtp_shared_components = frozenset(self.config.mtp_repeated_layer_shared_components or ())
+        self.mtp_latent_kv_share = "latent_kv" in mtp_shared_components and is_mtp_layer
         self.mtp_sparse_attention_index_share = (
             "sparse_attention_index" in mtp_shared_components and is_mtp_layer
         )
-        self.mtp_cross_depth_share = self.mtp_sparse_attention_index_share
+        self.mtp_cross_depth_share = (
+            self.mtp_latent_kv_share or self.mtp_sparse_attention_index_share
+        )
         global _warned_mtp_index_sharing_fused_bypass
         if (
             self.mtp_sparse_attention_index_share
@@ -2072,6 +2078,7 @@ class DSAttention(MegatronModule):
             payload = state.get_or_create(_DSAMTPRepeatedSharingPayload)
             payload.topk_by_layer.pop(self.layer_number, None)
             payload.topk_length_by_layer.pop(self.layer_number, None)
+            payload.latent_kv_by_layer.pop(self.layer_number, None)
         else:
             payload = self._require_mtp_sharing_payload(packed_seq_params, attention_mask)
         return is_source, payload
@@ -2085,9 +2092,22 @@ class DSAttention(MegatronModule):
         payload = state.get(_DSAMTPRepeatedSharingPayload)
         if payload is None:
             raise RuntimeError("MTP sharing consumer requires published source tensors.")
+        if self.mtp_latent_kv_share and self.layer_number not in payload.latent_kv_by_layer:
+            raise RuntimeError("MTP sharing consumer requires published source latent KV.")
         if self.mtp_sparse_attention_index_share and self.layer_number not in payload.topk_by_layer:
             raise RuntimeError("MTP sharing consumer requires published source indices.")
         return payload
+
+    def should_reuse_mtp_latent_kv(
+        self,
+        packed_seq_params: Optional[PackedSeqParams],
+        attention_mask: Optional[torch.Tensor] = None,
+    ) -> bool:
+        """Consult the MTP-published role before computing absorbed MLA projections."""
+        if not self.mtp_latent_kv_share:
+            return False
+        state = self._get_forward_sharing_state(packed_seq_params, attention_mask)
+        return not is_mtp_repeated_sharing_source(state, self.layer_number)
 
     def backward_dw(self):
         """Compute the deferred weight gradients (delay_wgrad_compute) of the indexer."""
@@ -2097,7 +2117,7 @@ class DSAttention(MegatronModule):
     def forward(
         self,
         query: torch.Tensor,
-        key: torch.Tensor,
+        key: Optional[torch.Tensor],
         value: Optional[torch.Tensor],
         attention_mask: torch.Tensor,
         x: torch.Tensor,
@@ -2113,7 +2133,8 @@ class DSAttention(MegatronModule):
 
         Args:
             query: Query tensor [sq, b, np, hn] or packed [t, np, hn].
-            key: Key tensor [skv, b, np, hn] or packed [t, np, hn].
+            key: Key tensor [skv, b, np, hn] or packed [t, np, hn]. May be None only for a
+                later repeated-MTP depth that reuses latent KV from the DSA sharing state.
             value: Value tensor [skv, b, np, hnv] or packed [t, np, hnv].
             x: Original hidden states [sq, b, hidden_size].
             qr: Low-rank query representation [sq, b, q_lora_rank].
@@ -2132,6 +2153,19 @@ class DSAttention(MegatronModule):
         reuse_sparse_attention_index = bool(
             self.mtp_sparse_attention_index_share and mtp_payload is not None and not is_mtp_source
         )
+        reuse_latent_kv = bool(
+            self.mtp_latent_kv_share and mtp_payload is not None and not is_mtp_source
+        )
+        if reuse_latent_kv:
+            if key is not None:
+                raise RuntimeError(
+                    "A repeated-MTP latent-KV consumer must obtain key from the DSA sharing "
+                    "state instead of receiving a newly computed key."
+                )
+            assert mtp_payload is not None
+            key = mtp_payload.latent_kv_by_layer[self.layer_number]
+        elif key is None:
+            raise RuntimeError("DSAttention requires a key tensor outside latent-KV reuse.")
         query, _ = dsa_layout.ensure_sbhd(query, "query")
         key, _ = dsa_layout.ensure_sbhd(key, "key")
         if value is not None:
@@ -2189,6 +2223,8 @@ class DSAttention(MegatronModule):
                     "DSA sequence-parallel query row count mismatch: "
                     f"query_rows={sq}, local_rows={local_sequence_rows}, tp_size={tp_size}"
                 )
+        cp_local_sequence_rows = sequence_parallel_tp_full_rows
+        cp_global_sequence_rows = cp_local_sequence_rows * cp_size
         packed_thd = packed_seq_params is not None and packed_seq_params.qkv_format == "thd"
         packed_query_positions = None
         nonpacked_query_positions = None
@@ -2250,19 +2286,18 @@ class DSAttention(MegatronModule):
                 )
             if packed_query_positions is not None:
                 packed_query_positions = packed_query_positions.contiguous()
-        elif cp_size > 1:
-            _validate_nonpacked_cp_uniform_length(
-                sq=sq, skv=key.size(0), cp_size=cp_size, cp_group=cp_group, device=query.device
-            )
-
         if sequence_parallel_tp:
             if key.size(0) == local_sequence_rows:
                 key = gather_from_sequence_parallel_region(key, group=tp_group)
-            elif key.size(0) != sequence_parallel_tp_full_rows:
+            elif key.size(0) != sequence_parallel_tp_full_rows and not (
+                reuse_latent_kv and cp_size > 1 and key.size(0) == cp_global_sequence_rows
+            ):
                 raise RuntimeError(
                     "DSA sequence-parallel key row count mismatch before CP gather: "
                     f"key_rows={key.size(0)}, local_rows={local_sequence_rows}, "
-                    f"full_rows={sequence_parallel_tp_full_rows}, tp_size={tp_size}"
+                    f"full_rows={sequence_parallel_tp_full_rows}, "
+                    f"cp_global_rows={cp_global_sequence_rows}, tp_size={tp_size}, "
+                    f"cp_size={cp_size}"
                 )
             if value is not None:
                 if value.size(0) == local_sequence_rows:
@@ -2274,9 +2309,16 @@ class DSAttention(MegatronModule):
                         f"full_rows={sequence_parallel_tp_full_rows}, tp_size={tp_size}"
                     )
 
-        local_cp_kv_lens = {sq}
-        if sequence_parallel_tp:
-            local_cp_kv_lens.add(sequence_parallel_tp_full_rows)
+        if not packed_thd and cp_size > 1:
+            _validate_nonpacked_cp_uniform_length(
+                sq=cp_local_sequence_rows,
+                skv=key.size(0),
+                cp_size=cp_size,
+                cp_group=cp_group,
+                device=query.device,
+            )
+
+        local_cp_kv_lens = {cp_local_sequence_rows}
         local_cp_kv_len = None
         if cp_size > 1:
             assert (
@@ -2339,6 +2381,13 @@ class DSAttention(MegatronModule):
                     value = value.index_select(0, kv_reorder_idx)
 
         skv = key.size(0)
+
+        if self.mtp_latent_kv_share and mtp_payload is not None and is_mtp_source:
+            # Capture the exact canonical tensor consumed by sparse attention: TP/SP and
+            # CP gathers plus CP reorder have already run. This must precede the combined
+            # fused DSA early return, which remains eligible for latent-KV-only sharing.
+            assert mtp_payload is not None
+            mtp_payload.latent_kv_by_layer[self.layer_number] = key
 
         if not packed_thd and sequence_parallel_query_is_local:
             nonpacked_query_positions = dsa_layout.extract_query_positions_from_position_ids(

--- a/megatron/core/transformer/experimental_attention_variant/dsa.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa.py
@@ -5,7 +5,7 @@ import functools
 import logging
 import math
 from contextlib import nullcontext
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional, Tuple, Union
 
 import torch
@@ -30,6 +30,7 @@ from megatron.core.transformer.experimental_attention_variant import (
     dsa_layout,
     dsa_masking,
 )
+from megatron.core.transformer.forward_sharing import get_forward_sharing_state
 from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
 from megatron.core.transformer.transformer_config import TransformerConfig
@@ -1925,6 +1926,21 @@ def unfused_dsa_fn(
     return output
 
 
+@dataclass
+class _DSAIndexSharingPayload:
+    """Ordinary DSA index-sharing tensors carried across physical layers.
+
+    Source/skip layers follow the configured layer-number schedule. Tensors remain
+    available to decoder and MTP consumers until the enclosing forward is cleared.
+    """
+
+    topk_by_layer: dict[int, torch.Tensor] = field(default_factory=dict)
+    topk_length_by_layer: dict[int, torch.Tensor] = field(default_factory=dict)
+
+    def __copy__(self):
+        return type(self)(dict(self.topk_by_layer), dict(self.topk_length_by_layer))
+
+
 class DSAttention(MegatronModule):
     """
     This module implements sparse attention mechanism using an DSA Indexer to compute top-k
@@ -1936,8 +1952,6 @@ class DSAttention(MegatronModule):
 
     consumes_absorbed_v_up_projection = True
     requires_dsa_inputs = True
-    _HOLDER_ATTR = "_dsa_index_share_topk_holder"
-    _LENGTH_HOLDER_ATTR = "_dsa_index_share_topk_length_holder"
 
     def __init__(
         self,
@@ -1989,39 +2003,21 @@ class DSAttention(MegatronModule):
         self.softmax_scale = softmax_scale
         self.cp_comm_type = dsa_layout.normalize_cp_comm_type(cp_comm_type)
 
-    def _get_index_share_carrier(
+    def _get_forward_sharing_state(
         self, packed_seq_params: Optional[PackedSeqParams], attention_mask: Optional[torch.Tensor]
-    ) -> object:
-        """Return the object that carries DSA top-k sharing state for this forward."""
-        if packed_seq_params is not None:
-            return packed_seq_params
-        return attention_mask if attention_mask is not None else self.config
+    ):
+        """Return the generic state attached to this forward's canonical carrier."""
+        return get_forward_sharing_state(
+            packed_seq_params=packed_seq_params, attention_mask=attention_mask, config=self.config
+        )
 
-    def _get_index_share_topk_holder(
-        self,
-        packed_seq_params: Optional[PackedSeqParams],
-        attention_mask: Optional[torch.Tensor] = None,
-    ) -> dict[int, torch.Tensor]:
-        """Return the per-forward top-k holder for DSA index sharing."""
-        carrier = self._get_index_share_carrier(packed_seq_params, attention_mask)
-        holder = getattr(carrier, self._HOLDER_ATTR, None)
-        if holder is None:
-            holder = {}
-            setattr(carrier, self._HOLDER_ATTR, holder)
-        return holder
-
-    def _get_index_share_topk_length_holder(
-        self,
-        packed_seq_params: Optional[PackedSeqParams],
-        attention_mask: Optional[torch.Tensor] = None,
-    ) -> dict[int, torch.Tensor]:
-        """Return the optional per-forward top-k length holder."""
-        carrier = self._get_index_share_carrier(packed_seq_params, attention_mask)
-        holder = getattr(carrier, self._LENGTH_HOLDER_ATTR, None)
-        if holder is None:
-            holder = {}
-            setattr(carrier, self._LENGTH_HOLDER_ATTR, holder)
-        return holder
+    def _get_dsa_index_sharing_payload(
+        self, packed_seq_params: Optional[PackedSeqParams], attention_mask: Optional[torch.Tensor]
+    ) -> _DSAIndexSharingPayload:
+        """Return DSA's global payload for ordinary cross-layer index sharing."""
+        return self._get_forward_sharing_state(packed_seq_params, attention_mask).get_or_create(
+            _DSAIndexSharingPayload
+        )
 
     def backward_dw(self):
         """Compute the deferred weight gradients (delay_wgrad_compute) of the indexer."""
@@ -2343,13 +2339,8 @@ class DSAttention(MegatronModule):
             cp_group if cp_size > 1 and not self.config.calculate_per_token_loss else None
         )
 
-        topk_holder = (
-            self._get_index_share_topk_holder(packed_seq_params, attention_mask)
-            if self.index_share
-            else None
-        )
-        topk_length_holder = (
-            self._get_index_share_topk_length_holder(packed_seq_params, attention_mask)
+        index_payload = (
+            self._get_dsa_index_sharing_payload(packed_seq_params, attention_mask)
             if self.index_share
             else None
         )
@@ -2363,8 +2354,8 @@ class DSAttention(MegatronModule):
             local_packed_cp_query_len = sequence_parallel_tp_full_rows
 
         if self.skip_topk:
-            assert topk_holder is not None
-            if self.source_layer not in topk_holder:
+            assert index_payload is not None
+            if self.source_layer not in index_payload.topk_by_layer:
                 raise RuntimeError(
                     "DSA index-share skip layer "
                     f"(layer_number={self.layer_number}) needs top-k indices from source "
@@ -2373,11 +2364,10 @@ class DSAttention(MegatronModule):
                     "pipeline stage starts on a computing layer "
                     f"(dsa_indexer_topk_freq={self.index_topk_freq}, "
                     f"dsa_indexer_skip_topk_offset={self.index_skip_topk_offset}). "
-                    f"Holder has layers {sorted(topk_holder)}."
+                    f"Index sharing payload has layers {sorted(index_payload.topk_by_layer)}."
                 )
-            topk_indices = topk_holder[self.source_layer]
-            if topk_length_holder is not None:
-                topk_length = topk_length_holder.get(self.source_layer)
+            topk_indices = index_payload.topk_by_layer[self.source_layer]
+            topk_length = index_payload.topk_length_by_layer.get(self.source_layer)
         else:
             assert self.indexer is not None
             with torch.enable_grad() if use_indexer_loss else torch.no_grad():
@@ -2622,10 +2612,10 @@ class DSAttention(MegatronModule):
             slice_topk_to_local_sequence_parallel_rows()
 
         if self.index_share and computes_topk:
-            assert topk_holder is not None and topk_indices is not None
-            topk_holder[self.layer_number] = topk_indices
-            if topk_length_holder is not None and topk_length is not None:
-                topk_length_holder[self.layer_number] = topk_length
+            assert index_payload is not None and topk_indices is not None
+            index_payload.topk_by_layer[self.layer_number] = topk_indices
+            if topk_length is not None:
+                index_payload.topk_length_by_layer[self.layer_number] = topk_length
 
         # ===================================
         # Run sparse attention kernel

--- a/megatron/core/transformer/forward_sharing.py
+++ b/megatron/core/transformer/forward_sharing.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from copy import copy
+from dataclasses import dataclass, field
 from functools import wraps
 from typing import Any, Callable, Iterator, TypeVar
 
@@ -197,3 +198,49 @@ def preserve_forward_sharing_for_checkpoint(
             replay_state.clear()
 
     return wrapped
+
+
+@dataclass
+class _MTPRepeatedSharingPayload:
+    """Source/consumer flags indexed by physical, global MTP layer number."""
+
+    is_source_by_layer: dict[int, bool | None] = field(default_factory=dict)
+
+    def __copy__(self):
+        return type(self)(dict(self.is_source_by_layer))
+
+
+@contextmanager
+def mtp_repeated_sharing_lifetime(
+    state: ForwardSharingState, layer_number: int
+) -> Iterator[dict[int, bool | None]]:
+    """Publish one physical MTP layer's source/consumer flags for its repeated loop.
+
+    Set the yielded dictionary's ``layer_number`` entry before each call; consumers
+    query it through ``is_mtp_repeated_sharing_source``, not the private payload.
+    Exit removes only this layer's flag, including on exceptions. Backend tensor
+    payloads follow the enclosing forward lifetime, not this flag scope.
+    """
+    payload = state.get_or_create(_MTPRepeatedSharingPayload)
+    if layer_number in payload.is_source_by_layer:
+        raise RuntimeError("Repeated-MTP sharing layer is already active")
+    payload.is_source_by_layer[layer_number] = None
+    try:
+        yield payload.is_source_by_layer
+    finally:
+        del payload.is_source_by_layer[layer_number]
+        if not payload.is_source_by_layer:
+            state.clear(_MTPRepeatedSharingPayload)
+
+
+def is_mtp_repeated_sharing_source(state: ForwardSharingState, layer_number: int) -> bool:
+    """Require an active loop flag and return whether this call produces shared tensors."""
+    payload = state.get(_MTPRepeatedSharingPayload)
+    is_source = payload.is_source_by_layer.get(layer_number) if payload is not None else None
+    if not isinstance(is_source, bool):
+        raise RuntimeError(
+            "Repeated-MTP sharing requires an active layer with an explicit is_source flag. "
+            "Serial compute_mtp_single_step does not establish one; disable repeated-layer "
+            "sharing for speculative decoding."
+        )
+    return is_source

--- a/megatron/core/transformer/forward_sharing.py
+++ b/megatron/core/transformer/forward_sharing.py
@@ -1,0 +1,199 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""State shared by cooperating components during one forward pass.
+
+Payloads are keyed by type and define their own tensor layout and per-layer indexing.
+Cooperating calls must resolve the same carrier: packed-sequence parameters, then
+attention mask, then config. Carrier lifetime does not determine payload lifetime.
+
+The outer forward owns cleanup through ``forward_sharing_lifetime``; nested scopes
+join it. Direct module callers must establish that scope or explicitly clear state.
+Checkpoint and schedule callers may own a separate state and temporarily bind it
+with ``use_forward_sharing_state``.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from copy import copy
+from functools import wraps
+from typing import Any, Callable, Iterator, TypeVar
+
+_FORWARD_SHARING_STATE_ATTR = "_forward_sharing_state"
+
+T = TypeVar("T")
+
+
+def is_forward_sharing_enabled(config: object) -> bool:
+    """Return whether any configured feature needs forward sharing state.
+
+    Add new sharing features here so lifecycle and checkpoint callers do not need
+    component-specific predicates. This is an enablement query, not a recompute
+    compatibility check; those constraints remain with the feature configuration.
+    """
+    return (getattr(config, "dsa_indexer_topk_freq", 1) or 1) > 1 or bool(
+        getattr(config, "mtp_repeated_layer_shared_components", None)
+    )
+
+
+class ForwardSharingState:
+    """One payload per type, independent of carrier lifetime.
+
+    Payloads manage their own per-layer data. Checkpoint snapshots copy the payload
+    objects, not tensor storage; payloads with mutable containers implement ``__copy__``.
+    """
+
+    def __init__(self) -> None:
+        self._entries: dict[type[Any], Any] = {}
+        self.active = False
+
+    def get(self, payload_type: type[T]) -> T | None:
+        """Return the payload registered for an exact type."""
+        self._validate_payload_type(payload_type)
+        return self._entries.get(payload_type)
+
+    def get_or_create(self, payload_type: type[T]) -> T:
+        """Return a payload, constructing it without arguments if absent."""
+        self._validate_payload_type(payload_type)
+        payload = self._entries.get(payload_type)
+        if payload is None:
+            payload = payload_type()
+            self._entries[payload_type] = payload
+        return payload
+
+    def clear(self, payload_type: type[Any] | None = None) -> None:
+        """Clear one payload type, or all payloads when no type is specified."""
+        if payload_type is None:
+            self._entries.clear()
+        else:
+            self._validate_payload_type(payload_type)
+            self._entries.pop(payload_type, None)
+
+    def snapshot(self) -> ForwardSharingState:
+        """Retain independent payload records for a particular checkpoint invocation."""
+        state = ForwardSharingState()
+        state._entries = {key: copy(payload) for key, payload in self._entries.items()}
+        return state
+
+    @staticmethod
+    def _validate_payload_type(payload_type: type[Any]) -> None:
+        if not isinstance(payload_type, type):
+            raise TypeError("payload_type must be a type")
+
+
+def _get_carrier(packed_seq_params, attention_mask, config):
+    carrier = next(
+        (
+            candidate
+            for candidate in (packed_seq_params, attention_mask, config)
+            if candidate is not None
+        ),
+        None,
+    )
+    if carrier is None:
+        raise ValueError("forward sharing requires packed_seq_params, attention_mask, or config")
+    return carrier
+
+
+def get_forward_sharing_state(
+    packed_seq_params: object | None = None,
+    attention_mask: object | None = None,
+    config: object | None = None,
+) -> ForwardSharingState:
+    """Return the sharing state attached to the highest-priority carrier.
+
+    Carrier priority is ``packed_seq_params``, then ``attention_mask``, then
+    ``config``. At least one carrier must be available.
+    """
+    carrier = _get_carrier(packed_seq_params, attention_mask, config)
+
+    state = getattr(carrier, _FORWARD_SHARING_STATE_ATTR, None)
+    if state is None:
+        state = ForwardSharingState()
+        setattr(carrier, _FORWARD_SHARING_STATE_ATTR, state)
+    elif not isinstance(state, ForwardSharingState):
+        raise TypeError(f"{_FORWARD_SHARING_STATE_ATTR} must contain a ForwardSharingState")
+    return state
+
+
+@contextmanager
+def use_forward_sharing_state(
+    state: ForwardSharingState,
+    packed_seq_params: object | None = None,
+    attention_mask: object | None = None,
+    config: object | None = None,
+) -> Iterator[None]:
+    """Temporarily bind a checkpoint/schedule-owned state to its current input carrier.
+
+    Restore the previous binding on exit without clearing payloads or changing
+    ``active``. The checkpoint or schedule remains responsible for state cleanup.
+    """
+    carrier = _get_carrier(packed_seq_params, attention_mask, config)
+    previous = getattr(carrier, _FORWARD_SHARING_STATE_ATTR, None)
+    setattr(carrier, _FORWARD_SHARING_STATE_ATTR, state)
+    try:
+        yield
+    finally:
+        if previous is None:
+            delattr(carrier, _FORWARD_SHARING_STATE_ATTR)
+        else:
+            setattr(carrier, _FORWARD_SHARING_STATE_ATTR, previous)
+
+
+@contextmanager
+def forward_sharing_lifetime(
+    packed_seq_params: object | None = None,
+    attention_mask: object | None = None,
+    config: object | None = None,
+) -> Iterator[ForwardSharingState]:
+    """Clear a forward's payloads on entry and exit, including exceptional exits.
+
+    Nested scopes using the same active state leave cleanup to the outer owner.
+    The state stays attached to its carrier after exit, but its payloads are cleared.
+    """
+    state = get_forward_sharing_state(packed_seq_params, attention_mask, config)
+    if state.active:
+        yield state
+        return
+    state.clear()
+    state.active = True
+    try:
+        yield state
+    finally:
+        state.clear()
+        state.active = False
+
+
+def preserve_forward_sharing_for_checkpoint(
+    function: Callable, packed_seq_params: object | None, config: object, attention_mask_arg: int
+) -> Callable:
+    """Pin caller-selected payloads per checkpoint, independent of later forwards.
+
+    Replays temporarily bind a private snapshot to the actual replay carrier (a detached
+    mask need not be the original Python tensor). The caller decides whether this mechanism
+    is appropriate for its payloads and checkpoint boundary. Snapshots copy payload
+    records, not tensor storage or autograd graphs; retained tensors follow the
+    checkpoint closure's lifetime. This does not make arbitrary recompute boundaries safe.
+    """
+    saved_state = None
+
+    @wraps(function)
+    def wrapped(*args):
+        nonlocal saved_state
+        attention_mask = args[attention_mask_arg]
+        if saved_state is None:
+            result = function(*args)
+            saved_state = get_forward_sharing_state(
+                packed_seq_params, attention_mask, config
+            ).snapshot()
+            return result
+
+        replay_state = saved_state.snapshot()
+        replay_state.active = True
+        try:
+            with use_forward_sharing_state(replay_state, packed_seq_params, attention_mask, config):
+                return function(*args)
+        finally:
+            replay_state.clear()
+
+    return wrapped

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -29,7 +29,10 @@ from megatron.core.tensor_parallel.inference_layers import (
 )
 from megatron.core.transformer.enums import AttnMaskType, LayerType
 from megatron.core.transformer.forward_sharing import (
+    forward_sharing_lifetime,
+    get_forward_sharing_state,
     is_forward_sharing_enabled,
+    mtp_repeated_sharing_lifetime,
     preserve_forward_sharing_for_checkpoint,
 )
 from megatron.core.transformer.hyper_connection import learned_output_contract
@@ -1925,6 +1928,11 @@ class MultiTokenPredictionLayer(MegatronModule):
         self.cp_group = pg_collection.cp
         self.tp_group = pg_collection.tp if pg_collection is not None else None
         self.mtp_layer_pattern = mtp_layer_pattern
+        if self.config.mtp_repeated_layer_shared_components and mtp_layer_pattern is not None:
+            raise ValueError(
+                "mtp_repeated_layer_shared_components currently supports the GPT MTP path only, "
+                "not a hybrid MTP layer pattern."
+            )
 
         # Validate attention mask type if using transformer-based inner layers
         if self.submodules.mtp_model_layer is not None and hasattr(
@@ -2608,6 +2616,11 @@ class MultiTokenPredictionLayer(MegatronModule):
             and self.mtp_layer_pattern is None
         )
         if use_outer_recompute:
+            if self.config.mtp_repeated_layer_shared_components:
+                raise RuntimeError(
+                    "Repeated-MTP cross-depth sharing does not support "
+                    "full activation recomputation."
+                )
             hidden_states = self._checkpointed_forward(
                 hidden_states=hidden_states,
                 decoder_input=decoder_input,
@@ -2956,34 +2969,53 @@ class MultiTokenPredictionBlock(MegatronModule):
         if self.config.mtp_detach_heads:
             hidden_states = hidden_states.detach()
 
-        for iteration in range(self.config.mtp_num_layers):
-            layer_idx = 0 if self.mtp_use_repeated_layer else iteration
-            hidden_states, input_ids, position_ids, padding_mask = self.layers[layer_idx](
-                input_ids=input_ids,
-                position_ids=position_ids,
-                hidden_states=hidden_states,
-                attention_mask=attention_mask,
-                padding_mask=padding_mask,
-                inference_params=inference_params,
-                rotary_pos_emb=rotary_pos_emb,
-                rotary_pos_cos=rotary_pos_cos,
-                rotary_pos_sin=rotary_pos_sin,
-                packed_seq_params=packed_seq_params,
-                sequence_roll_context=sequence_roll_context,
-                roll_depth=iteration,
-                sequence_len_offset=sequence_len_offset,
-                embedding=embedding,
-                **(extra_block_kwargs or {}),
+        sharing_lifetime = nullcontext()
+        if is_forward_sharing_enabled(self.config):
+            sharing_lifetime = forward_sharing_lifetime(
+                packed_seq_params, attention_mask, self.config
+            )
+        repeated_lifetime = nullcontext()
+        forward_sharing_state = None
+        if self.config.mtp_repeated_layer_shared_components:
+            forward_sharing_state = get_forward_sharing_state(
+                packed_seq_params, attention_mask, self.config
+            )
+            repeated_layer_number = self.config.num_layers + offset + 1
+            repeated_lifetime = mtp_repeated_sharing_lifetime(
+                forward_sharing_state, repeated_layer_number
             )
 
-            if mhc_multistream is not None:
-                mhc_chunks.append(hidden_states)
-                hidden_states_list.append(self.layers[layer_idx]._postprocess(hidden_states))
-            else:
-                # append the output hidden states of the current mtp layer
-                # to the hidden_states_list
-                hidden_states_list.append(hidden_states)
+        with sharing_lifetime, repeated_lifetime as is_source_by_layer:
+            for depth in range(self.config.mtp_num_layers):
+                if is_source_by_layer is not None:
+                    is_source_by_layer[repeated_layer_number] = depth == 0
+                layer_idx = 0 if self.mtp_use_repeated_layer else depth
+                layer_outputs = self.layers[layer_idx](
+                    input_ids=input_ids,
+                    position_ids=position_ids,
+                    hidden_states=hidden_states,
+                    attention_mask=attention_mask,
+                    padding_mask=padding_mask,
+                    inference_params=inference_params,
+                    rotary_pos_emb=rotary_pos_emb,
+                    rotary_pos_cos=rotary_pos_cos,
+                    rotary_pos_sin=rotary_pos_sin,
+                    packed_seq_params=packed_seq_params,
+                    sequence_roll_context=sequence_roll_context,
+                    roll_depth=depth,
+                    sequence_len_offset=sequence_len_offset,
+                    embedding=embedding,
+                    **(extra_block_kwargs or {}),
+                )
+                hidden_states, input_ids, position_ids, padding_mask = layer_outputs
 
+                if mhc_multistream is not None:
+                    mhc_chunks.append(hidden_states)
+                    hidden_states_list.append(self.layers[layer_idx]._postprocess(hidden_states))
+                else:
+                    # append the output hidden states of the current mtp layer
+                    # to the hidden_states_list
+                    hidden_states_list.append(hidden_states)
         # concat the hidden states of all mtp layers
         hidden_states = torch.cat(hidden_states_list, dim=0)
         return hidden_states

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -28,6 +28,10 @@ from megatron.core.tensor_parallel.inference_layers import (
     inference_all_gather_from_tensor_model_parallel_region,
 )
 from megatron.core.transformer.enums import AttnMaskType, LayerType
+from megatron.core.transformer.forward_sharing import (
+    is_forward_sharing_enabled,
+    preserve_forward_sharing_for_checkpoint,
+)
 from megatron.core.transformer.hyper_connection import learned_output_contract
 from megatron.core.transformer.module import MegatronModule, mark_keep_in_fp32
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
@@ -2429,6 +2433,11 @@ class MultiTokenPredictionLayer(MegatronModule):
                 inference_params=inference_params,
                 packed_seq_params=packed_seq_params,
                 sequence_len_offset=sequence_len_offset,
+            )
+
+        if is_forward_sharing_enabled(self.config):
+            custom_forward = preserve_forward_sharing_for_checkpoint(
+                custom_forward, packed_seq_params, self.config, attention_mask_arg=3
             )
 
         # Decide the outer quantization context, matching

--- a/megatron/core/transformer/transformer_block.py
+++ b/megatron/core/transformer/transformer_block.py
@@ -25,6 +25,11 @@ from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import MHCCheckpointManager
 from megatron.core.transformer.cuda_graphs import annotate_first_last_layer
 from megatron.core.transformer.enums import InferenceCudaGraphScope, LayerType
+from megatron.core.transformer.forward_sharing import (
+    forward_sharing_lifetime,
+    is_forward_sharing_enabled,
+    preserve_forward_sharing_for_checkpoint,
+)
 from megatron.core.transformer.hyper_connection import (
     HyperConnectionModule,
     learned_output_contract,
@@ -669,6 +674,10 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
                         )
                 return hidden_states, context
 
+            if is_forward_sharing_enabled(self.config):
+                custom_forward = preserve_forward_sharing_for_checkpoint(
+                    custom_forward, packed_seq_params, self.config, attention_mask_arg=1
+                )
             return custom_forward
 
         def checkpoint_handler(forward_func):
@@ -964,7 +973,13 @@ class TransformerBlock(GraphableMegatronModule, MegatronModule):
             use_mhc_recompute
         )
 
-        with rng_context, outer_quantization_context:
+        sharing_lifetime = nullcontext()
+        if is_forward_sharing_enabled(self.config):
+            sharing_lifetime = forward_sharing_lifetime(
+                packed_seq_params, attention_mask, self.config
+            )
+
+        with sharing_lifetime, rng_context, outer_quantization_context:
             # Forward pass.
             if self.config.recompute_granularity == 'full' and self.training:
                 checkpointed_result = self._checkpointed_forward(

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -91,9 +91,8 @@ class TransformerConfig(ModelParallelConfig):
 
     mtp_repeated_layer_shared_components: Optional[List[str]] = None
     """Components obtained by the first repeated MTP layer invocation and reused by later ones.
-    Currently, only "sparse_attention_index" is supported. None or an empty list disables
-    repeated-layer sharing.
-    """
+    Currently supported components are "latent_kv" and "sparse_attention_index". None or an
+    empty list disables repeated-layer sharing."""
 
     mtp_detach_heads: bool = False
     """If True, detach MTP head inputs from the main model graph.
@@ -1815,11 +1814,11 @@ class TransformerConfig(ModelParallelConfig):
         if shared_components is not None and not isinstance(shared_components, list):
             raise ValueError("mtp_repeated_layer_shared_components must be a list or None.")
         if shared_components is not None:
-            allowed_components = {"sparse_attention_index"}
+            allowed_components = {"latent_kv", "sparse_attention_index"}
             if any(not isinstance(component, str) for component in shared_components):
                 raise ValueError(
                     "mtp_repeated_layer_shared_components entries must be strings; supported "
-                    "component is 'sparse_attention_index'."
+                    "components are 'latent_kv' and 'sparse_attention_index'."
                 )
             if len(shared_components) != len(set(shared_components)):
                 raise ValueError(
@@ -2652,6 +2651,17 @@ class TransformerConfig(ModelParallelConfig):
             if "moe_act" in self.recompute_modules and not self.moe_grouped_gemm:
                 raise ValueError(
                     "moe_act in recompute_modules is only supported with moe_grouped_gemm."
+                )
+
+            if (
+                "latent_kv" in (self.mtp_repeated_layer_shared_components or [])
+                and "mla_up_proj" in self.recompute_modules
+            ):
+                raise ValueError(
+                    "mtp_repeated_layer_shared_components containing latent_kv does not support "
+                    "mla_up_proj recompute: it discards the source KV storage before later "
+                    "MTP depths consume it. Remove mla_up_proj from recompute_modules "
+                    "or disable latent_kv sharing."
                 )
 
             if "mla_up_proj" in self.recompute_modules and not self.multi_latent_attention:

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -89,6 +89,12 @@ class TransformerConfig(ModelParallelConfig):
     mtp_use_repeated_layer: bool = False
     """Use a single MTP layer repeatedly instead of multiple separate layers."""
 
+    mtp_repeated_layer_shared_components: Optional[List[str]] = None
+    """Components obtained by the first repeated MTP layer invocation and reused by later ones.
+    Currently, only "sparse_attention_index" is supported. None or an empty list disables
+    repeated-layer sharing.
+    """
+
     mtp_detach_heads: bool = False
     """If True, detach MTP head inputs from the main model graph.
     This prevents MTP loss gradients from flowing back to the main model,
@@ -348,11 +354,12 @@ class TransformerConfig(ModelParallelConfig):
     """Number of top-k tokens to select in DSA indexer."""
 
     dsa_indexer_topk_freq: int = 1
-    """Frequency of DSA indexer top-k computation across layers.
-    A value greater than 1 enables cross-layer top-k sharing."""
+    """Frequency of DSA indexer top-k computation across globally numbered Transformer and MTP
+    layers. A value greater than 1 enables cross-layer top-k sharing. This does not control
+    sharing across repeated MTP layer invocations; use mtp_repeated_layer_shared_components."""
 
     dsa_indexer_skip_topk_offset: int = 0
-    """Layer offset for DSA cross-layer top-k sharing."""
+    """Global layer-number offset for DSA cross-layer top-k sharing."""
 
     dsa_indexer_loss_coeff: Optional[float] = None
     """Coefficient for the DSA indexer KL divergence loss. Set to 0 to disable indexer loss."""
@@ -1804,6 +1811,49 @@ class TransformerConfig(ModelParallelConfig):
                 "Use dsa_kernel_backend='tilelang' or 'none'."
             )
 
+        shared_components = self.mtp_repeated_layer_shared_components
+        if shared_components is not None and not isinstance(shared_components, list):
+            raise ValueError("mtp_repeated_layer_shared_components must be a list or None.")
+        if shared_components is not None:
+            allowed_components = {"sparse_attention_index"}
+            if any(not isinstance(component, str) for component in shared_components):
+                raise ValueError(
+                    "mtp_repeated_layer_shared_components entries must be strings; supported "
+                    "component is 'sparse_attention_index'."
+                )
+            if len(shared_components) != len(set(shared_components)):
+                raise ValueError(
+                    "mtp_repeated_layer_shared_components must not contain duplicate components."
+                )
+            unknown_components = set(shared_components) - allowed_components
+            if unknown_components:
+                raise ValueError(
+                    "Unsupported mtp_repeated_layer_shared_components "
+                    f"{sorted(unknown_components)}; supported components are "
+                    f"{sorted(allowed_components)}."
+                )
+
+        if shared_components:
+            if self.experimental_attention_variant != "dsa":
+                raise ValueError(
+                    "mtp_repeated_layer_shared_components currently requires "
+                    "experimental_attention_variant='dsa'."
+                )
+            if not self.mtp_use_repeated_layer:
+                raise ValueError(
+                    "mtp_repeated_layer_shared_components requires mtp_use_repeated_layer=True."
+                )
+            if self.mtp_num_layers is None or self.mtp_num_layers <= 1:
+                raise ValueError(
+                    "mtp_repeated_layer_shared_components requires mtp_num_layers > 1."
+                )
+            if self.recompute_granularity == "full":
+                raise ValueError(
+                    "mtp_repeated_layer_shared_components does not support full activation "
+                    "recomputation, which replays DSA after the shared state has been cleared. "
+                    "Use selective recompute without core_attn or disable repeated-layer sharing."
+                )
+
         if is_gated_delta_net_variant(self.experimental_attention_variant):
             if not self.is_hybrid_model:
                 assert (
@@ -2574,6 +2624,12 @@ class TransformerConfig(ModelParallelConfig):
             self.recompute_modules = ["core_attn"]
 
         if self.recompute_granularity == "selective":
+            if self.mtp_repeated_layer_shared_components and "core_attn" in self.recompute_modules:
+                raise ValueError(
+                    "mtp_repeated_layer_shared_components does not support core_attn recompute, "
+                    "which replays DSA after the shared state has been cleared. "
+                    "Remove core_attn from recompute_modules or disable repeated-layer sharing."
+                )
             if len(self.recompute_modules) > 0:
                 allowed_modules = {
                     "core_attn",
@@ -3643,6 +3699,11 @@ class TransformerConfig(ModelParallelConfig):
                 f"(experimental_attention_variant={self.experimental_attention_variant!r}, "
                 f"cuda_graph_impl={self.cuda_graph_impl!r}, "
                 f"cuda_graph_modules={self.cuda_graph_modules!r})."
+            )
+        if self.mtp_repeated_layer_shared_components and cuda_graph_captures_attention:
+            raise ValueError(
+                "mtp_repeated_layer_shared_components does not support CUDA graph capture that "
+                "includes attention. Use a MoE-only scope or disable CUDA graphs."
             )
 
         if self.cuda_graph_impl != "none":

--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -1941,6 +1941,7 @@ def load_args_from_checkpoint(args, load_arg='load', checkpointing_context=None)
     _set_arg('mtp_hybrid_override_pattern', force=True)
     _set_arg('mtp_num_layers', force=True)
     _set_arg('mtp_use_repeated_layer', force=True)
+    _set_arg('mtp_repeated_layer_shared_components', force=True)
 
     _set_arg('spec', force=True)
 

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -482,20 +482,44 @@ def _dsa_indexer_flops(
     )
 
 
-def _num_dsa_indexer_layers(num_layers, skip_topk_offset, topk_freq):
-    """Count layers that compute their own DSA index (the rest reuse one).
+def _num_dsa_indexer_layers(
+    num_decoder_layers,
+    skip_topk_offset,
+    topk_freq,
+    *,
+    mtp_num_layers=0,
+    mtp_use_repeated_layer=False,
+    mtp_shares_sparse_attention_index=False,
+):
+    """Count DSA layer executions that compute their own top-k index.
 
-    On the standard-model path every layer is a DSA attention layer (MTP
-    layers included -- ``DSAttention.__init__`` numbers them
-    ``layer_number + config.num_layers``, which is exactly how the caller
-    extends ``num_layers``), so the predicate runs over the whole
-    ``1..num_layers`` range.
+    Decoder layers have distinct global layer numbers. Non-repeated MTP layers
+    do too, while every prediction depth of a repeated MTP layer uses the same
+    global layer number (``num_decoder_layers + 1``). If that repeated layer
+    shares its sparse-attention index, only depth 0 executes its indexer.
     """
-    return sum(
+    decoder_indexer_layers = sum(
         1
-        for layer_number in range(1, num_layers + 1)
+        for layer_number in range(1, num_decoder_layers + 1)
         if not is_dsa_skip_topk_layer(layer_number, skip_topk_offset or 0, topk_freq or 1)
     )
+    if mtp_num_layers <= 0:
+        return decoder_indexer_layers
+
+    if not mtp_use_repeated_layer:
+        return decoder_indexer_layers + sum(
+            1
+            for layer_number in range(
+                num_decoder_layers + 1, num_decoder_layers + mtp_num_layers + 1
+            )
+            if not is_dsa_skip_topk_layer(layer_number, skip_topk_offset or 0, topk_freq or 1)
+        )
+
+    repeated_mtp_layer_number = num_decoder_layers + 1
+    if is_dsa_skip_topk_layer(repeated_mtp_layer_number, skip_topk_offset or 0, topk_freq or 1):
+        return decoder_indexer_layers
+    repeated_mtp_indexer_executions = 1 if mtp_shares_sparse_attention_index else mtp_num_layers
+    return decoder_indexer_layers + repeated_mtp_indexer_executions
 
 
 def _dsv4_hybrid_self_attention_flops(
@@ -1062,6 +1086,11 @@ def num_floating_point_operations(
             mtp_num_layers = 0
             num_layers = args.num_layers
 
+        mtp_use_repeated_layer = getattr(args, "mtp_use_repeated_layer", False)
+        mtp_shared_components = frozenset(
+            getattr(args, "mtp_repeated_layer_shared_components", None) or ()
+        )
+
         moe_ffn_hidden_size = (
             args.moe_ffn_hidden_size
             if args.moe_ffn_hidden_size is not None
@@ -1356,7 +1385,14 @@ def num_floating_point_operations(
                 n_heads=args.dsa_indexer_n_heads,
                 head_dim=args.dsa_indexer_head_dim,
                 num_indexer_layers=_num_dsa_indexer_layers(
-                    num_layers, args.dsa_indexer_skip_topk_offset, args.dsa_indexer_topk_freq
+                    args.num_layers,
+                    args.dsa_indexer_skip_topk_offset,
+                    args.dsa_indexer_topk_freq,
+                    mtp_num_layers=mtp_num_layers,
+                    mtp_use_repeated_layer=mtp_use_repeated_layer,
+                    mtp_shares_sparse_attention_index=(
+                        "sparse_attention_index" in mtp_shared_components
+                    ),
                 ),
                 indexer_loss_coeff=args.dsa_indexer_loss_coeff,
             )
@@ -1488,8 +1524,7 @@ def num_floating_point_operations(
         # ``kw_args``, never back onto ``args``), so the attribute alone misses
         # exactly the runs this guard exists for.
         assert (
-            args.experimental_attention_variant != "dsa"
-            and layer_counts[Symbols.DS_ATTENTION] == 0
+            args.experimental_attention_variant != "dsa" and layer_counts[Symbols.DS_ATTENTION] == 0
         ), (
             "num_floating_point_operations does not support DSA "
             "('D' layers / experimental_attention_variant='dsa') on the "
@@ -1663,6 +1698,7 @@ def preprocess_common_state_dict(common_state_dict):
             if "param_groups" not in inner_optimizer:
                 return
             param_groups = inner_optimizer["param_groups"]
+
             # Treat missing and explicit None identifier values as equivalent.
             # Wrap each component so None never compares directly with floats or strings.
             def key_fn(pg):
@@ -1670,6 +1706,7 @@ def preprocess_common_state_dict(common_state_dict):
                     (value is not None, value)
                     for value in (pg.get(key) for key in param_group_identifier_keys)
                 ]
+
             param_groups.sort(key=key_fn)
             inner_optimizer["param_groups"] = param_groups
 
@@ -5116,7 +5153,7 @@ def evaluate(
             ft_integration.on_eval_step_start()
             if getattr(config, 'sequence_packing_scheduler', None) is not None:
                 try:
-                    (packed_data_iterator, scheduled_eval_num_microbatches, _, _) = (
+                    packed_data_iterator, scheduled_eval_num_microbatches, _, _ = (
                         wrap_data_iterator(data_iterator, config, eval_num_microbatches)
                     )
                 except StopIteration:
@@ -5414,7 +5451,7 @@ def build_train_valid_test_data_loaders(build_train_valid_test_datasets_provider
 
     args = get_args()
 
-    (train_dataloader, valid_dataloaders, test_dataloader) = (None, None, None)
+    train_dataloader, valid_dataloaders, test_dataloader = (None, None, None)
 
     print_rank_0('> building train, validation, and test datasets ...')
 

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1238,6 +1238,7 @@ def num_floating_point_operations(
         dsv4_hybrid_extra_core_term = 0
         dsa_extra_term = 0
         dsa_extra_core_term = 0
+        dsa_repeated_mtp_saved_term = 0
         if is_linear_attention_variant(args.experimental_attention_variant):
             # Calculate number of dense and MoE Transformer MLPs.
             if isinstance(args.linear_attention_freq, int):
@@ -1396,6 +1397,21 @@ def num_floating_point_operations(
                 ),
                 indexer_loss_coeff=args.dsa_indexer_loss_coeff,
             )
+            if mtp_use_repeated_layer and "latent_kv" in mtp_shared_components:
+                # Later depths reuse the normalized, post-RoPE latent KV from depth 0.
+                # They still execute the absorbed K/V up-projection work on their query
+                # and attention output. Runtime also skips key RoPE and communication,
+                # which this FLOPs model does not count; only the KV down projection and
+                # norm disappear from the modeled standard MLA token-linear term.
+                dsa_repeated_mtp_saved_term = (
+                    forward_backward_expansion_factor
+                    * fma_expansion_factor
+                    * max(mtp_num_layers - 1, 0)
+                    * (
+                        args.hidden_size * (args.kv_lora_rank + args.qk_pos_emb_head_dim)
+                        + args.kv_lora_rank
+                    )
+                )
         else:
             num_linear_attention_layers = 0
             linear_self_attn_term = 0
@@ -1408,6 +1424,7 @@ def num_floating_point_operations(
             + standard_self_attn_term * num_standard_attention_layers
             + dsv4_hybrid_extra_term
             + dsa_extra_term
+            - dsa_repeated_mtp_saved_term
         )
         # Core attention (L^2) FLOPs. Standard attention has a uniform per-layer
         # coefficient; DSv4 sparse attention varies by layer type and is pre-summed.

--- a/tests/unit_tests/inference/text_generation_controllers/test_text_generation_controller.py
+++ b/tests/unit_tests/inference/text_generation_controllers/test_text_generation_controller.py
@@ -878,6 +878,19 @@ def test_async_generate_output_tokens_dynamic_batch_assertions(mode, expected_me
         asyncio.run(controller.async_generate_output_tokens_dynamic_batch(skip_bookkeeping=True))
 
 
+@pytest.mark.launch_on_gb200
+def test_mtp_cross_depth_sharing_rejects_speculative_decoding_before_distributed_setup():
+    model_config = SimpleNamespace(mtp_repeated_layer_shared_components=["sparse_attention_index"])
+    inference_config = SimpleNamespace(num_speculative_tokens=1)
+    inference_wrapped_model = SimpleNamespace(
+        model=SimpleNamespace(config=model_config),
+        inference_context=SimpleNamespace(config=inference_config),
+    )
+
+    with pytest.raises(ValueError, match="do not provide"):
+        TextGenerationController(inference_wrapped_model, tokenizer=None)
+
+
 class TestTextGenerationController(TextGenerationControllerTestBase):
 
     @classmethod

--- a/tests/unit_tests/models/test_hybrid_moe_model.py
+++ b/tests/unit_tests/models/test_hybrid_moe_model.py
@@ -109,6 +109,7 @@ GOLDEN_CONFIG: Dict[str, Any] = {
     "dsa_indexer_topk_freq": 1,
     "dsa_indexer_weights_proj_use_quantization": True,
     "dsa_kernel_backend": "none",
+    "mtp_repeated_layer_shared_components": None,
     "embedding_init_method": {},
     "embedding_init_method_std": 0.014,
     "enable_autocast": False,

--- a/tests/unit_tests/test_checkpointing.py
+++ b/tests/unit_tests/test_checkpointing.py
@@ -192,6 +192,44 @@ def test_load_args_preserves_runtime_hybridep_routing_map_mode(
     assert restored_args.moe_hybridep_routing_map_mode == expected_mode
 
 
+@pytest.mark.parametrize(
+    ("checkpoint_args", "expected"),
+    [
+        pytest.param(
+            SimpleNamespace(mtp_repeated_layer_shared_components=["sparse_attention_index"]),
+            ["sparse_attention_index"],
+            id="nonempty",
+        ),
+        pytest.param(
+            SimpleNamespace(mtp_repeated_layer_shared_components=[]), [], id="explicit-empty"
+        ),
+        pytest.param(
+            SimpleNamespace(), ["sparse_attention_index"], id="old-checkpoint-without-field"
+        ),
+    ],
+)
+def test_load_args_restores_mtp_repeated_layer_shared_components_from_checkpoint(
+    checkpoint_args, expected
+):
+    """Repeated-layer sharing behavior must survive a training resume."""
+    args = SimpleNamespace(
+        load="checkpoint",
+        iteration=0,
+        mtp_repeated_layer_shared_components=["sparse_attention_index"],
+        use_tokenizer_model_from_checkpoint_args=False,
+        use_mp_args_from_checkpoint_args=False,
+    )
+    state_dict = {"args": checkpoint_args, "iteration": 12}
+
+    with mock.patch(
+        "megatron.training.checkpointing._load_base_checkpoint",
+        return_value=(state_dict, "checkpoint", False, CheckpointType.LEGACY),
+    ):
+        restored_args, _ = load_args_from_checkpoint(args)
+
+    assert restored_args.mtp_repeated_layer_shared_components == expected
+
+
 def create_checkpoint(load_path, ckpt_format):
     """Setup a dummy checkpoint directory."""
     iteration = 123

--- a/tests/unit_tests/test_num_floating_point_operations.py
+++ b/tests/unit_tests/test_num_floating_point_operations.py
@@ -1373,8 +1373,8 @@ class TestDSA:
             no_sharing, batch_size
         )
 
-    def test_repeated_mtp_sparse_index_sharing_charges_the_indexer_once(self):
-        """Later repeated depths reuse depth 0's index instead of rerunning the indexer."""
+    def test_repeated_mtp_component_sharing(self):
+        """Each selected component removes only its own later-depth work."""
         args = _make_dsa_args()
         args.mtp_num_layers = 3
         args.mtp_use_repeated_layer = True
@@ -1385,9 +1385,26 @@ class TestDSA:
         args.mtp_repeated_layer_shared_components = []
         unshared = num_floating_point_operations(args, batch_size)
 
+        args.mtp_repeated_layer_shared_components = ["latent_kv"]
+        latent_shared = num_floating_point_operations(args, batch_size)
+
         args.mtp_repeated_layer_shared_components = ["sparse_attention_index"]
         index_shared = num_floating_point_operations(args, batch_size)
 
+        args.mtp_repeated_layer_shared_components = ["latent_kv", "sparse_attention_index"]
+        both_shared = num_floating_point_operations(args, batch_size)
+
+        num_consumer_depths = args.mtp_num_layers - 1
+        expected_latent_savings = (
+            total_tokens
+            * 3
+            * 2
+            * num_consumer_depths
+            * (
+                args.hidden_size * (args.kv_lora_rank + args.qk_pos_emb_head_dim)
+                + args.kv_lora_rank
+            )
+        )
         index_dim = args.dsa_indexer_n_heads * args.dsa_indexer_head_dim
         index_token_term = (
             2
@@ -1399,11 +1416,13 @@ class TestDSA:
             )
         )
         index_core_term = 3 * 2 * index_dim / 2
-        expected_savings = (args.mtp_num_layers - 1) * (
+        expected_index_savings = num_consumer_depths * (
             total_tokens * index_token_term + sum_sq * index_core_term
         )
 
-        assert unshared - index_shared == expected_savings
+        assert unshared - latent_shared == expected_latent_savings
+        assert unshared - index_shared == expected_index_savings
+        assert unshared - both_shared == expected_latent_savings + expected_index_savings
 
     def test_repeated_mtp_uses_one_global_layer_number_for_index_schedule(self):
         """A repeated skip layer must not be counted as fictitious later MTP layers."""

--- a/tests/unit_tests/test_num_floating_point_operations.py
+++ b/tests/unit_tests/test_num_floating_point_operations.py
@@ -64,6 +64,8 @@ def _make_gpt_args(
     args.moe_latent_size = None
     args.moe_shared_expert_intermediate_size = None
     args.mtp_num_layers = None
+    args.mtp_use_repeated_layer = False
+    args.mtp_repeated_layer_shared_components = None
     # Linear attention disabled.
     args.experimental_attention_variant = None
     args.linear_attention_freq = None
@@ -1369,6 +1371,56 @@ class TestDSA:
         no_sharing.num_layers = 8
         assert num_floating_point_operations(args, batch_size) < num_floating_point_operations(
             no_sharing, batch_size
+        )
+
+    def test_repeated_mtp_sparse_index_sharing_charges_the_indexer_once(self):
+        """Later repeated depths reuse depth 0's index instead of rerunning the indexer."""
+        args = _make_dsa_args()
+        args.mtp_num_layers = 3
+        args.mtp_use_repeated_layer = True
+        batch_size = 2
+        total_tokens = batch_size * args.seq_length
+        sum_sq = batch_size * args.seq_length**2
+
+        args.mtp_repeated_layer_shared_components = []
+        unshared = num_floating_point_operations(args, batch_size)
+
+        args.mtp_repeated_layer_shared_components = ["sparse_attention_index"]
+        index_shared = num_floating_point_operations(args, batch_size)
+
+        index_dim = args.dsa_indexer_n_heads * args.dsa_indexer_head_dim
+        index_token_term = (
+            2
+            * 2
+            * (
+                args.q_lora_rank * index_dim
+                + args.hidden_size * args.dsa_indexer_head_dim
+                + args.hidden_size * args.dsa_indexer_n_heads
+            )
+        )
+        index_core_term = 3 * 2 * index_dim / 2
+        expected_savings = (args.mtp_num_layers - 1) * (
+            total_tokens * index_token_term + sum_sq * index_core_term
+        )
+
+        assert unshared - index_shared == expected_savings
+
+    def test_repeated_mtp_uses_one_global_layer_number_for_index_schedule(self):
+        """A repeated skip layer must not be counted as fictitious later MTP layers."""
+        from megatron.training.training import _num_dsa_indexer_layers
+
+        # Decoder layers 1..3 compute. Repeated MTP layer 4 is a skip layer at
+        # every depth; fictitious global layers 5..8 must not enter the count.
+        assert (
+            _num_dsa_indexer_layers(
+                3,
+                skip_topk_offset=3,
+                topk_freq=4,
+                mtp_num_layers=5,
+                mtp_use_repeated_layer=True,
+                mtp_shares_sparse_attention_index=False,
+            )
+            == 3
         )
 
     def test_topk_caps_long_context_growth(self):

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
@@ -30,6 +30,7 @@ from megatron.core.transformer.experimental_attention_variant.dsa import (
     DSAttention,
     DSAttentionSubmodules,
     FusedDSAIndexerLoss,
+    _DSAIndexSharingPayload,
     _run_sparse_attention,
     _validate_nonpacked_cp_uniform_length,
     compute_dsa_indexer_loss,
@@ -54,6 +55,7 @@ from megatron.core.transformer.experimental_attention_variant.dsa_masking import
     masked_log_softmax,
     scatter_topk_into_index_mask,
 )
+from megatron.core.transformer.forward_sharing import get_forward_sharing_state
 from megatron.core.transformer.transformer_config import MLATransformerConfig
 from tests.unit_tests.test_utilities import Utils
 
@@ -141,7 +143,7 @@ class TestDSAIndexShareHelpers:
         assert attention.indexer is None
         assert attention.source_layer == 1
 
-    def test_index_share_holder_uses_attention_mask_without_packed_seq_params(self):
+    def test_index_share_state_uses_attention_mask_without_packed_seq_params(self):
         config = SimpleNamespace(
             dsa_indexer_topk=8,
             dsa_indexer_topk_freq=4,
@@ -159,15 +161,15 @@ class TestDSAIndexShareHelpers:
         )
         attention_mask = torch.empty(1)
 
-        topk_holder = attention._get_index_share_topk_holder(None, attention_mask)
-        length_holder = attention._get_index_share_topk_length_holder(None, attention_mask)
+        index_payload = attention._get_dsa_index_sharing_payload(None, attention_mask)
 
-        assert topk_holder is getattr(attention_mask, DSAttention._HOLDER_ATTR)
-        assert length_holder is getattr(attention_mask, DSAttention._LENGTH_HOLDER_ATTR)
-        assert not hasattr(config, DSAttention._HOLDER_ATTR)
-        assert not hasattr(config, DSAttention._LENGTH_HOLDER_ATTR)
+        forward_state = get_forward_sharing_state(None, attention_mask, config)
+        dsa_payload = forward_state.get(_DSAIndexSharingPayload)
+        assert dsa_payload is not None
+        assert index_payload is dsa_payload
+        assert not hasattr(config, "_forward_sharing_state")
 
-    def test_index_share_holder_uses_packed_seq_params_when_available(self):
+    def test_index_share_state_uses_packed_seq_params_when_available(self):
         config = SimpleNamespace(
             dsa_indexer_topk=8,
             dsa_indexer_topk_freq=4,
@@ -186,15 +188,13 @@ class TestDSAIndexShareHelpers:
         packed_seq_params = PackedSeqParams(qkv_format="thd")
         attention_mask = torch.empty(1)
 
-        topk_holder = attention._get_index_share_topk_holder(packed_seq_params, attention_mask)
-        length_holder = attention._get_index_share_topk_length_holder(
-            packed_seq_params, attention_mask
-        )
+        index_payload = attention._get_dsa_index_sharing_payload(packed_seq_params, attention_mask)
 
-        assert topk_holder is getattr(packed_seq_params, DSAttention._HOLDER_ATTR)
-        assert length_holder is getattr(packed_seq_params, DSAttention._LENGTH_HOLDER_ATTR)
-        assert not hasattr(attention_mask, DSAttention._HOLDER_ATTR)
-        assert not hasattr(attention_mask, DSAttention._LENGTH_HOLDER_ATTR)
+        forward_state = get_forward_sharing_state(packed_seq_params, attention_mask, config)
+        dsa_payload = forward_state.get(_DSAIndexSharingPayload)
+        assert dsa_payload is not None
+        assert index_payload is dsa_payload
+        assert not hasattr(attention_mask, "_forward_sharing_state")
 
 
 def _build_packed_causal_mask_for_test(

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
@@ -115,10 +115,11 @@ class TestDSAIndexShareHelpers:
         with pytest.raises(RuntimeError, match="pipeline split is invalid"):
             _validate_dsa_index_share_pipeline_split(config, [1, 2, 3, 4])
 
-    def test_repeated_mtp_index_share_rejects_cross_segment_source(self):
+    @pytest.mark.parametrize("shared_components", [["latent_kv"], ["sparse_attention_index"]])
+    def test_repeated_mtp_index_share_rejects_cross_segment_source(self, shared_components):
         config = SimpleNamespace(
             experimental_attention_variant="dsa",
-            mtp_repeated_layer_shared_components=["sparse_attention_index"],
+            mtp_repeated_layer_shared_components=shared_components,
             dsa_indexer_topk_freq=4,
             dsa_indexer_skip_topk_offset=3,
         )

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_dsa.py
@@ -15,6 +15,7 @@ from megatron.core.models.gpt.experimental_attention_variant_module_specs import
     get_dsa_module_spec_for_backend,
     get_experimental_attention_variant_module_spec,
 )
+from megatron.core.models.gpt.gpt_layer_specs import _validate_dsa_mtp_index_share_pipeline_split
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
@@ -114,6 +115,22 @@ class TestDSAIndexShareHelpers:
         with pytest.raises(RuntimeError, match="pipeline split is invalid"):
             _validate_dsa_index_share_pipeline_split(config, [1, 2, 3, 4])
 
+    def test_repeated_mtp_index_share_rejects_cross_segment_source(self):
+        config = SimpleNamespace(
+            experimental_attention_variant="dsa",
+            mtp_repeated_layer_shared_components=["sparse_attention_index"],
+            dsa_indexer_topk_freq=4,
+            dsa_indexer_skip_topk_offset=3,
+        )
+
+        _validate_dsa_mtp_index_share_pipeline_split(
+            config, local_decoder_layer_ids=[2], mtp_layer_number=4
+        )
+        with pytest.raises(RuntimeError, match="repeated-MTP IndexShare pipeline split"):
+            _validate_dsa_mtp_index_share_pipeline_split(
+                config, local_decoder_layer_ids=[], mtp_layer_number=4
+            )
+
     def test_skip_layer_does_not_build_indexer(self, monkeypatch):
         def fail_build_module(*_args, **_kwargs):
             raise AssertionError("skip layers must not build indexer modules")
@@ -126,6 +143,7 @@ class TestDSAIndexShareHelpers:
             dsa_indexer_topk=8,
             dsa_indexer_topk_freq=4,
             dsa_indexer_skip_topk_offset=1,
+            mtp_repeated_layer_shared_components=None,
             kv_channels=16,
         )
 
@@ -148,6 +166,7 @@ class TestDSAIndexShareHelpers:
             dsa_indexer_topk=8,
             dsa_indexer_topk_freq=4,
             dsa_indexer_skip_topk_offset=1,
+            mtp_repeated_layer_shared_components=None,
             kv_channels=16,
         )
         attention = DSAttention(
@@ -174,6 +193,7 @@ class TestDSAIndexShareHelpers:
             dsa_indexer_topk=8,
             dsa_indexer_topk_freq=4,
             dsa_indexer_skip_topk_offset=1,
+            mtp_repeated_layer_shared_components=None,
             kv_channels=16,
         )
         attention = DSAttention(

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_integration.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_integration.py
@@ -24,9 +24,11 @@ from megatron.core.transformer.experimental_attention_variant.absorbed_mla impor
 from megatron.core.transformer.experimental_attention_variant.dsa import (
     DSAttention,
     DSAttentionSubmodules,
+    _DSAIndexSharingPayload,
     is_dsa_skip_topk_layer,
     source_dsa_compute_layer,
 )
+from megatron.core.transformer.forward_sharing import get_forward_sharing_state
 from megatron.training.argument_utils import _resolve_dsa_kernel_backend_cli_default
 from megatron.training.arguments import _add_experimental_attention_variant_args
 
@@ -89,7 +91,7 @@ def test_mtp_layer_number_offsets_index_share_schedule():
     assert attention.indexer is None
 
 
-def test_index_share_skip_layer_uses_request_scoped_holders(monkeypatch):
+def test_index_share_skip_layer_uses_request_scoped_state(monkeypatch):
     def fail_build_module(*_args, **_kwargs):
         raise AssertionError("skip layers must not build indexer modules")
 
@@ -114,13 +116,14 @@ def test_index_share_skip_layer_uses_request_scoped_holders(monkeypatch):
 
     packed_seq_params = PackedSeqParams(qkv_format="thd")
     attention_mask = torch.empty(1)
-    topk_holder = attention._get_index_share_topk_holder(packed_seq_params, attention_mask)
-    length_holder = attention._get_index_share_topk_length_holder(packed_seq_params, attention_mask)
+    index_payload = attention._get_dsa_index_sharing_payload(packed_seq_params, attention_mask)
 
-    assert topk_holder is getattr(packed_seq_params, DSAttention._HOLDER_ATTR)
-    assert length_holder is getattr(packed_seq_params, DSAttention._LENGTH_HOLDER_ATTR)
-    assert not hasattr(attention_mask, DSAttention._HOLDER_ATTR)
-    assert not hasattr(config, DSAttention._HOLDER_ATTR)
+    forward_state = get_forward_sharing_state(packed_seq_params, attention_mask, config)
+    dsa_payload = forward_state.get(_DSAIndexSharingPayload)
+    assert dsa_payload is not None
+    assert index_payload is dsa_payload
+    assert not hasattr(attention_mask, "_forward_sharing_state")
+    assert not hasattr(config, "_forward_sharing_state")
 
 
 def test_backward_dw_flushes_only_an_owned_indexer():
@@ -287,7 +290,9 @@ def test_checkpointed_absorbed_attention_keeps_metadata_out_of_tensor_args(monke
             return kwargs["x"]
 
     dummy_attention = SimpleNamespace(
-        attn_mask_type=AttnMaskType.causal, core_attention=CoreAttention()
+        attn_mask_type=AttnMaskType.causal,
+        core_attention=CoreAttention(),
+        config=SimpleNamespace(dsa_indexer_topk_freq=1),
     )
     monkeypatch.setattr(absorbed_mla_module.tensor_parallel, "checkpoint", fake_checkpoint)
 

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_integration.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_integration.py
@@ -35,7 +35,11 @@ from megatron.training.arguments import _add_experimental_attention_variant_args
 
 def _index_share_config():
     return SimpleNamespace(
-        dsa_indexer_topk=8, dsa_indexer_topk_freq=4, dsa_indexer_skip_topk_offset=1, kv_channels=16
+        dsa_indexer_topk=8,
+        dsa_indexer_topk_freq=4,
+        dsa_indexer_skip_topk_offset=1,
+        mtp_repeated_layer_shared_components=None,
+        kv_channels=16,
     )
 
 
@@ -70,6 +74,7 @@ def test_mtp_layer_number_offsets_index_share_schedule():
         dsa_indexer_topk=4,
         dsa_indexer_topk_freq=4,
         dsa_indexer_skip_topk_offset=1,
+        mtp_repeated_layer_shared_components=None,
         kv_channels=16,
     )
     pg_collection = SimpleNamespace(tp=object(), cp=object())

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_mtp_dsa_cross_depth_sharing.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_mtp_dsa_cross_depth_sharing.py
@@ -1,0 +1,840 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Coverage for sparse-attention index sharing across repeated MTP invocations."""
+
+import inspect
+from contextlib import nullcontext
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+
+from megatron.core import tensor_parallel
+from megatron.core.transformer.enums import AttnBackend, AttnMaskType, CudaGraphModule
+from megatron.core.transformer.experimental_attention_variant import dsa as dsa_module
+from megatron.core.transformer.experimental_attention_variant.absorbed_mla import (
+    AbsorbedMLASelfAttention,
+)
+from megatron.core.transformer.forward_sharing import (
+    _MTPRepeatedSharingPayload,
+    forward_sharing_lifetime,
+    get_forward_sharing_state,
+    is_mtp_repeated_sharing_source,
+    mtp_repeated_sharing_lifetime,
+)
+from megatron.core.transformer.multi_token_prediction import (
+    MultiTokenPredictionBlock,
+    MultiTokenPredictionLayer,
+)
+from megatron.core.transformer.transformer_config import MLATransformerConfig
+from megatron.core.transformer.transformer_layer import (
+    HyperConnectionTransformerLayer,
+    TransformerLayer,
+)
+from megatron.core.utils import init_method_normal, scaled_init_method_normal
+
+SPARSE_ATTENTION_INDEX = "sparse_attention_index"
+
+
+def _make_config(**overrides) -> MLATransformerConfig:
+    kwargs = dict(
+        num_layers=2,
+        mtp_num_layers=3,
+        mtp_use_repeated_layer=True,
+        mtp_repeated_layer_shared_components=[SPARSE_ATTENTION_INDEX],
+        hidden_size=64,
+        num_attention_heads=4,
+        num_query_groups=4,
+        kv_channels=8,
+        multi_latent_attention=True,
+        experimental_attention_variant="dsa",
+        q_lora_rank=16,
+        kv_lora_rank=16,
+        qk_head_dim=8,
+        qk_pos_emb_head_dim=4,
+        v_head_dim=8,
+        dsa_indexer_n_heads=4,
+        dsa_indexer_head_dim=8,
+        dsa_indexer_topk=4,
+        dsa_indexer_topk_freq=4,
+        dsa_indexer_skip_topk_offset=3,
+        dsa_indexer_loss_coeff=0.0,
+        dsa_indexer_rotate_activation=False,
+        dsa_indexer_scoring_relu=False,
+        dsa_kernel_backend="none",
+        attention_backend=AttnBackend.unfused,
+        add_bias_linear=False,
+        qk_layernorm=True,
+        normalization="RMSNorm",
+        layernorm_epsilon=1e-6,
+        attention_dropout=0.0,
+        hidden_dropout=0.0,
+        bf16=True,
+        params_dtype=torch.bfloat16,
+        tensor_model_parallel_size=1,
+        context_parallel_size=1,
+        sequence_parallel=False,
+        apply_rope_fusion=False,
+        rope_type="rope",
+        rotary_base=10000,
+        gradient_accumulation_fusion=False,
+        init_method=init_method_normal(0.02),
+        output_layer_init_method=scaled_init_method_normal(0.02, 2, multiplier=2.0),
+        use_cpu_initialization=False,
+        perform_initialization=True,
+    )
+    kwargs.update(overrides)
+    return MLATransformerConfig(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "shared_components",
+    [
+        pytest.param(None, id="none"),
+        pytest.param([], id="empty"),
+        pytest.param([SPARSE_ATTENTION_INDEX], id="sparse-attention-index-only"),
+    ],
+)
+def test_cross_depth_shared_components_accept_supported_values(shared_components):
+    config = _make_config(mtp_repeated_layer_shared_components=shared_components)
+
+    assert config.mtp_repeated_layer_shared_components == shared_components
+
+
+@pytest.mark.parametrize(
+    ("shared_components", "message"),
+    [
+        (SPARSE_ATTENTION_INDEX, "must be a list or None"),
+        ([1], "entries must be strings"),
+        (["unknown"], "Unsupported mtp_repeated_layer_shared_components"),
+        ([SPARSE_ATTENTION_INDEX, SPARSE_ATTENTION_INDEX], "must not contain duplicate components"),
+    ],
+)
+def test_cross_depth_shared_components_reject_invalid_lists(shared_components, message):
+    with pytest.raises(ValueError, match=message):
+        _make_config(mtp_repeated_layer_shared_components=shared_components)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"experimental_attention_variant": None}, "requires experimental_attention_variant"),
+        ({"mtp_use_repeated_layer": False}, "requires mtp_use_repeated_layer"),
+        ({"mtp_num_layers": 1}, "requires mtp_num_layers > 1"),
+        (
+            {"recompute_granularity": "full", "recompute_method": "uniform"},
+            "does not support full activation recomputation",
+        ),
+        ({"recompute_granularity": "selective"}, "does not support core_attn recompute"),
+        (
+            {"cuda_graph_impl": "transformer_engine", "cuda_graph_modules": ["attn"]},
+            "does not support CUDA graph capture that includes attention",
+        ),
+        (
+            {"cuda_graph_impl": "local", "cuda_graph_modules": []},
+            "does not support CUDA graph capture that includes attention",
+        ),
+        (
+            {"cuda_graph_impl": "full_iteration", "cuda_graph_modules": []},
+            "does not support CUDA graph capture that includes attention",
+        ),
+    ],
+)
+def test_cross_depth_sharing_rejects_incompatible_config(overrides, message):
+    with pytest.raises(ValueError, match=message):
+        _make_config(**overrides)
+
+
+@pytest.mark.parametrize(
+    "modules",
+    [
+        [],
+        ["mlp"],
+        ["moe"],
+        ["moe_act"],
+        ["shared_experts"],
+        ["layernorm"],
+        ["mhc"],
+        ["mla_up_proj"],
+        ["layernorm", "mlp", "mla_up_proj"],
+        ["layernorm", "moe", "shared_experts"],
+    ],
+)
+def test_index_sharing_accepts_selective_recompute_outside_dsa(modules):
+    config = _make_config(
+        recompute_granularity="selective",
+        recompute_modules=modules,
+        num_moe_experts=4,
+        moe_grouped_gemm=True,
+        moe_shared_expert_intermediate_size=64,
+        enable_hyper_connections="mhc" in modules,
+    )
+    assert config.recompute_modules == modules
+
+
+@pytest.mark.parametrize("modules", [None, ["core_attn"], ["mlp", "core_attn"]])
+def test_index_sharing_rejects_selective_recompute_that_reenters_dsa(modules):
+    with pytest.raises(ValueError, match="does not support core_attn recompute"):
+        _make_config(recompute_granularity="selective", recompute_modules=modules)
+
+
+@pytest.mark.parametrize("method", ["uniform", "block"])
+def test_index_sharing_rejects_full_recompute(method):
+    with pytest.raises(ValueError, match="does not support full activation recomputation"):
+        _make_config(recompute_granularity="full", recompute_method=method, recompute_num_layers=1)
+
+
+def test_mlp_recompute_after_repeat_cleanup_preserves_gradients(monkeypatch):
+    """Exercise MCore's real checkpoint backward with CPU RNG and a DSA-owned payload."""
+    monkeypatch.setattr(dsa_module, "build_module", lambda *_args, **_kwargs: nn.Identity())
+    # The test has no CUDA operations. Keep the checkpoint/autograd implementation intact
+    # while replacing only its device-specific RNG snapshot with the CPU equivalent.
+    monkeypatch.setattr(
+        tensor_parallel.random, "_get_all_rng_states", lambda: (torch.get_rng_state(),)
+    )
+    monkeypatch.setattr(tensor_parallel.random, "_set_all_rng_states", torch.set_rng_state)
+    initial = torch.randn(4, 1, 8)
+    weight = torch.randn(8, 8)
+
+    def run(recompute):
+        config = _make_config(
+            recompute_granularity="selective" if recompute else None, recompute_modules=["mlp"]
+        )
+        attention = dsa_module.DSAttention(
+            config=config,
+            submodules=dsa_module.DSAttentionSubmodules(indexer=None),
+            layer_number=1,
+            attn_mask_type=AttnMaskType.causal,
+            attention_type="self",
+            pg_collection=SimpleNamespace(),
+            is_mtp_layer=True,
+        )
+        state = get_forward_sharing_state(config=config)
+        inputs = initial.clone().requires_grad_(True)
+        mlp_weight = weight.clone().requires_grad_(True)
+        calls = []
+
+        def mlp(value):
+            active_call = state.get(_MTPRepeatedSharingPayload)
+            calls.append(
+                active_call.is_source_by_layer[config.num_layers + 1]
+                if active_call is not None
+                else None
+            )
+            return torch.nn.functional.gelu(value @ mlp_weight)
+
+        outputs = []
+        hidden = inputs
+        with (
+            forward_sharing_lifetime(config=config),
+            mtp_repeated_sharing_lifetime(state, config.num_layers + 1) as sharing_call,
+        ):
+            for depth in range(config.mtp_num_layers):
+                sharing_call[config.num_layers + 1] = depth == 0
+                _, payload = attention._prepare_mtp_sharing_payload(None, None)
+                if depth == 0:
+                    payload.topk_by_layer[config.num_layers + 1] = torch.zeros(1, dtype=torch.int64)
+                hidden = (
+                    tensor_parallel.checkpoint(mlp, False, hidden) if recompute else mlp(hidden)
+                )
+                outputs.append(hidden)
+        assert state.get(_MTPRepeatedSharingPayload) is None
+        sum(output.square().mean() for output in outputs).backward()
+        assert calls[: config.mtp_num_layers] == [True] + [False] * (config.mtp_num_layers - 1)
+        if recompute:
+            assert calls[config.mtp_num_layers :] == [None] * config.mtp_num_layers
+        else:
+            assert len(calls) == config.mtp_num_layers
+        return torch.stack(outputs).detach(), inputs.grad, mlp_weight.grad
+
+    for actual, expected in zip(run(True), run(False)):
+        torch.testing.assert_close(actual, expected)
+
+
+def test_cross_depth_sharing_accepts_supported_cuda_graph_scopes():
+    moe_config = _make_config(
+        cuda_graph_impl="transformer_engine",
+        cuda_graph_modules=["moe_router", "moe_preprocess"],
+        num_moe_experts=4,
+    )
+    assert moe_config.cuda_graph_modules == [
+        CudaGraphModule.moe_router,
+        CudaGraphModule.moe_preprocess,
+    ]
+
+
+@pytest.mark.parametrize("fail_second_layer", [False, True])
+def test_mtp_payload_requires_a_source_and_isolates_layers(monkeypatch, fail_second_layer):
+    monkeypatch.setattr(dsa_module, "build_module", lambda *_args, **_kwargs: nn.Identity())
+    config = _make_config()
+    layers = [
+        dsa_module.DSAttention(
+            config=config,
+            submodules=dsa_module.DSAttentionSubmodules(indexer=None),
+            layer_number=number,
+            attn_mask_type=AttnMaskType.causal,
+            attention_type="self",
+            pg_collection=SimpleNamespace(),
+            is_mtp_layer=True,
+        )
+        for number in (1, 2)
+    ]
+    state = get_forward_sharing_state(config=config)
+    with pytest.raises(RuntimeError, match="active layer"):
+        layers[0]._prepare_mtp_sharing_payload(None, None)
+    first_number, second_number = (layer.layer_number for layer in layers)
+    with forward_sharing_lifetime(config=config):
+        ordinary = state.get_or_create(dsa_module._DSAIndexSharingPayload)
+        ordinary.topk_by_layer[1] = torch.zeros(1)
+        with mtp_repeated_sharing_lifetime(state, first_number) as flags:
+            assert flags == {first_number: None}
+            with pytest.raises(RuntimeError, match="is_source flag"):
+                layers[0]._prepare_mtp_sharing_payload(None, None)
+            flags[first_number] = False
+            with pytest.raises(RuntimeError, match="requires published source"):
+                layers[0]._prepare_mtp_sharing_payload(None, None)
+            flags[first_number] = True
+            is_source, first = layers[0]._prepare_mtp_sharing_payload(None, None)
+            assert is_source
+            first.topk_by_layer[first_number] = torch.ones(1)
+            first.topk_length_by_layer[first_number] = torch.ones(1, dtype=torch.int64)
+            with pytest.raises(RuntimeError, match="already active"):
+                with mtp_repeated_sharing_lifetime(state, first_number):
+                    pass
+            try:
+                with mtp_repeated_sharing_lifetime(state, second_number) as second_flags:
+                    assert second_flags is flags
+                    assert set(flags) == {first_number, second_number}
+                    flags[second_number] = True
+                    _, second = layers[1]._prepare_mtp_sharing_payload(None, None)
+                    assert second is first
+                    with pytest.raises(RuntimeError, match="requires published source"):
+                        layers[1]._require_mtp_sharing_payload(None, None)
+                    second_topk = torch.zeros(1)
+                    second.topk_by_layer[second_number] = second_topk
+                    second.topk_length_by_layer[second_number] = torch.zeros(1, dtype=torch.int64)
+                    flags[first_number] = False
+                    assert layers[0]._prepare_mtp_sharing_payload(None, None) == (False, first)
+                    assert flags[second_number]
+                    if fail_second_layer:
+                        raise RuntimeError("second layer failed")
+            except RuntimeError as error:
+                assert fail_second_layer and str(error) == "second layer failed"
+            assert second_number not in flags
+            assert second.topk_by_layer[second_number] is second_topk
+            assert layers[0]._prepare_mtp_sharing_payload(None, None) == (False, first)
+            with pytest.raises(RuntimeError, match="active layer"):
+                layers[1]._prepare_mtp_sharing_payload(None, None)
+        assert state.get(dsa_module._DSAIndexSharingPayload) is ordinary
+        assert state.get(_MTPRepeatedSharingPayload) is None
+        tensors = state.get(dsa_module._DSAMTPRepeatedSharingPayload)
+        assert tensors is first
+        assert set(tensors.topk_by_layer) == {first_number, second_number}
+        with mtp_repeated_sharing_lifetime(state, first_number) as flags:
+            flags[first_number] = True
+            _, fresh = layers[0]._prepare_mtp_sharing_payload(None, None)
+            assert fresh is first
+            assert first_number not in fresh.topk_by_layer
+            assert first_number not in fresh.topk_length_by_layer
+            assert tensors.topk_by_layer[second_number] is second_topk
+            assert second_number in tensors.topk_length_by_layer
+            flags[first_number] = False
+            with pytest.raises(RuntimeError, match="requires published source"):
+                layers[0]._prepare_mtp_sharing_payload(None, None)
+    assert state._entries == {}
+
+
+def test_mtp_snapshot_copies_dictionaries_and_cleanup_releases_live_tensors():
+    config = SimpleNamespace()
+    state = get_forward_sharing_state(config=config)
+    indices = torch.zeros(2, dtype=torch.int64)
+    lengths = torch.ones(2, dtype=torch.int64)
+    with forward_sharing_lifetime(config=config):
+        with mtp_repeated_sharing_lifetime(state, 7) as flags:
+            flags[7] = True
+            payload = state.get_or_create(dsa_module._DSAMTPRepeatedSharingPayload)
+            payload.topk_by_layer[7] = indices
+            payload.topk_length_by_layer[7] = lengths
+            snapshot = state.snapshot()
+            saved = snapshot.get(dsa_module._DSAMTPRepeatedSharingPayload)
+            assert saved is not payload
+            assert saved.topk_by_layer is not payload.topk_by_layer
+            assert saved.topk_length_by_layer is not payload.topk_length_by_layer
+            payload.topk_by_layer.clear()
+            payload.topk_length_by_layer.clear()
+            flags[7] = False
+            assert snapshot.get(_MTPRepeatedSharingPayload).is_source_by_layer[7]
+        assert state.get(_MTPRepeatedSharingPayload) is None
+        assert state.get(dsa_module._DSAMTPRepeatedSharingPayload) is payload
+        with mtp_repeated_sharing_lifetime(state, 7) as fresh_flags:
+            assert fresh_flags == {7: None}
+    assert state._entries == {}
+    assert saved.topk_by_layer[7] is indices
+    assert saved.topk_length_by_layer[7] is lengths
+
+
+def test_dsa_state_computes_index_once_then_reuses_and_cleans_it(monkeypatch):
+    monkeypatch.setattr(dsa_module, "build_module", lambda *_args, **_kwargs: nn.Identity())
+    config = _make_config(dsa_indexer_topk_freq=1, dsa_indexer_skip_topk_offset=0)
+    attention = dsa_module.DSAttention(
+        config=config,
+        submodules=dsa_module.DSAttentionSubmodules(indexer=None),
+        layer_number=1,
+        attn_mask_type=AttnMaskType.causal,
+        attention_type="self",
+        pg_collection=SimpleNamespace(tp=None, cp=None),
+        is_mtp_layer=True,
+    )
+    sequence_length = 4
+    indexer_calls = []
+    topk_calls = []
+    sparse_topk_pointers = []
+    source_topk = torch.tensor(
+        [[[0, -1, -1, -1], [0, 1, -1, -1], [0, 1, 2, -1], [0, 1, 2, 3]]], dtype=torch.int64
+    )
+
+    def fake_forward_before_topk(_x, _qr, _packed_seq_params):
+        indexer_calls.append(True)
+        return (
+            torch.randn(sequence_length, 1, 2, 4),
+            torch.randn(sequence_length, 1, 4),
+            torch.ones(sequence_length, 1, 2),
+        )
+
+    def fake_topk(*_args, **_kwargs):
+        topk_calls.append(True)
+        return torch.empty(0), source_topk
+
+    def fake_sparse_attention(**kwargs):
+        sparse_topk_pointers.append(kwargs["topk_indices"].data_ptr())
+        return torch.randn(sequence_length, 1, config.hidden_size)
+
+    attention.indexer.forward_before_topk = fake_forward_before_topk
+    monkeypatch.setattr(dsa_module, "fused_qk_topk_naive", fake_topk)
+    monkeypatch.setattr(dsa_module, "_run_sparse_attention", fake_sparse_attention)
+
+    def run_depth():
+        return attention(
+            query=torch.randn(
+                sequence_length,
+                1,
+                config.num_attention_heads,
+                config.kv_lora_rank + config.qk_pos_emb_head_dim,
+            ),
+            key=torch.randn(
+                sequence_length, 1, 1, config.kv_lora_rank + config.qk_pos_emb_head_dim
+            ),
+            value=None,
+            attention_mask=None,
+            x=torch.randn(sequence_length, 1, config.hidden_size),
+            qr=torch.randn(sequence_length, 1, config.q_lora_rank),
+            up_v_weight=torch.randn(
+                config.num_attention_heads, config.v_head_dim, config.kv_lora_rank
+            ),
+            attn_mask_type=AttnMaskType.causal,
+        )
+
+    forward_state = get_forward_sharing_state(config=config)
+    with (
+        forward_sharing_lifetime(config=config),
+        mtp_repeated_sharing_lifetime(forward_state, config.num_layers + 1) as sharing_call,
+    ):
+        outputs = []
+        for depth in range(config.mtp_num_layers):
+            sharing_call[config.num_layers + 1] = depth == 0
+            outputs.append(run_depth())
+
+        shared_payload = forward_state.get(dsa_module._DSAMTPRepeatedSharingPayload)
+        assert shared_payload is not None
+    assert forward_state._entries == {}
+
+    assert all(output.shape == outputs[0].shape for output in outputs)
+    assert len(indexer_calls) == 1
+    assert len(topk_calls) == 1
+    assert sparse_topk_pointers == [source_topk.data_ptr()] * config.mtp_num_layers
+    index_payload = attention._get_dsa_index_sharing_payload(None, None)
+    assert attention.layer_number not in index_payload.topk_by_layer
+
+
+@pytest.mark.parametrize(
+    ("shared_components", "is_mtp_layer", "fused_enabled", "expected_log_count"),
+    [
+        pytest.param([SPARSE_ATTENTION_INDEX], True, True, 1, id="index-only-fused"),
+        pytest.param(None, True, True, 0, id="sharing-off-fused"),
+        pytest.param([SPARSE_ATTENTION_INDEX], True, False, 0, id="index-only-unfused"),
+        pytest.param([SPARSE_ATTENTION_INDEX], False, True, 0, id="non-mtp-fused"),
+    ],
+)
+def test_cross_depth_sharing_logs_when_combined_fused_dsa_is_disabled(
+    monkeypatch, shared_components, is_mtp_layer, fused_enabled, expected_log_count
+):
+    logged_messages = []
+    monkeypatch.setattr(dsa_module, "_warned_mtp_index_sharing_fused_bypass", False)
+    monkeypatch.setattr(
+        dsa_module.dsa_kernels, "use_fused_dsa_kernels", lambda _config: fused_enabled
+    )
+    monkeypatch.setattr(
+        dsa_module,
+        "log_single_rank",
+        lambda _logger, _level, message: logged_messages.append(message),
+    )
+    monkeypatch.setattr(dsa_module, "build_module", lambda *_args, **_kwargs: nn.Identity())
+    config = _make_config(
+        mtp_repeated_layer_shared_components=shared_components,
+        dsa_indexer_topk_freq=1,
+        dsa_indexer_skip_topk_offset=0,
+    )
+
+    for _ in range(2):
+        dsa_module.DSAttention(
+            config=config,
+            submodules=dsa_module.DSAttentionSubmodules(indexer=None),
+            layer_number=1,
+            attn_mask_type=AttnMaskType.causal,
+            attention_type="self",
+            pg_collection=SimpleNamespace(),
+            is_mtp_layer=is_mtp_layer,
+        )
+
+    fallback_messages = [
+        message
+        for message in logged_messages
+        if "combined fused DSA kernel does not expose" in message
+    ]
+    assert len(fallback_messages) == expected_log_count
+
+
+def test_repeated_mtp_sharing_accepts_ordinary_index_share_skip_layer(monkeypatch):
+    monkeypatch.setattr(dsa_module, "build_module", lambda *_args, **_kwargs: nn.Identity())
+    config = _make_config(
+        num_layers=3, mtp_repeated_layer_shared_components=[SPARSE_ATTENTION_INDEX]
+    )
+
+    attention = dsa_module.DSAttention(
+        config=config,
+        submodules=dsa_module.DSAttentionSubmodules(indexer=None),
+        # The repeated physical MTP layer is global layer N+1=4, a skip layer.
+        layer_number=1,
+        attn_mask_type=AttnMaskType.causal,
+        attention_type="self",
+        pg_collection=SimpleNamespace(),
+        is_mtp_layer=True,
+    )
+
+    assert attention.skip_topk
+    assert attention.source_layer == 3
+    assert attention.indexer is None
+
+
+@pytest.mark.parametrize("source_has_length", [False, True])
+def test_dsa_state_reuses_ordinary_skip_index_across_mtp_depths(monkeypatch, source_has_length):
+    """Repeated state may consume, but must not alias or remove, an ordinary source slot."""
+    tracked_losses = []
+    sparse_topk_pointers = []
+    sparse_length_pointers = []
+    monkeypatch.setattr(
+        dsa_module.DSAIndexerLossLoggingHelper,
+        "save_loss_to_tracker",
+        staticmethod(lambda **kwargs: tracked_losses.append(kwargs["loss"])),
+    )
+    original_sparse_attention = dsa_module._run_sparse_attention
+
+    def observed_sparse_attention(*args, **kwargs):
+        sparse_topk_pointers.append(kwargs["topk_indices"].data_ptr())
+        sparse_length_pointers.append(
+            None if kwargs["topk_length"] is None else kwargs["topk_length"].data_ptr()
+        )
+        return original_sparse_attention(*args, **kwargs)
+
+    monkeypatch.setattr(dsa_module, "_run_sparse_attention", observed_sparse_attention)
+    config = _make_config(num_layers=3)
+    attention = dsa_module.DSAttention(
+        config=config,
+        submodules=dsa_module.DSAttentionSubmodules(indexer=None),
+        # The repeated physical MTP layer is global layer N+1=4; its source is layer 3.
+        layer_number=1,
+        attn_mask_type=AttnMaskType.causal,
+        attention_type="self",
+        pg_collection=SimpleNamespace(tp=None, cp=None),
+        is_mtp_layer=True,
+    )
+    sequence_length = 4
+    source_topk = torch.tensor(
+        [[[0, -1, -1, -1], [0, 1, -1, -1], [0, 1, 2, -1], [0, 1, 2, 3]]], dtype=torch.int64
+    )
+    index_payload = attention._get_dsa_index_sharing_payload(None, None)
+    index_payload.topk_by_layer[attention.source_layer] = source_topk
+    source_length = torch.arange(1, sequence_length + 1, dtype=torch.int32).view(1, -1)
+    if source_has_length:
+        index_payload.topk_length_by_layer[attention.source_layer] = source_length
+
+    def run_depth():
+        query = torch.randn(
+            sequence_length,
+            1,
+            config.num_attention_heads,
+            config.kv_lora_rank + config.qk_pos_emb_head_dim,
+        )
+        key = torch.randn(sequence_length, 1, 1, config.kv_lora_rank + config.qk_pos_emb_head_dim)
+        return attention(
+            query=query,
+            key=key,
+            value=None,
+            attention_mask=None,
+            x=torch.randn(sequence_length, 1, config.hidden_size),
+            qr=torch.randn(sequence_length, 1, config.q_lora_rank),
+            up_v_weight=torch.randn(
+                config.num_attention_heads, config.v_head_dim, config.kv_lora_rank
+            ),
+            attn_mask_type=AttnMaskType.causal,
+        )
+
+    forward_state = get_forward_sharing_state(config=config)
+    with mtp_repeated_sharing_lifetime(forward_state, config.num_layers + 1) as sharing_call:
+        outputs = []
+        for depth in range(config.mtp_num_layers):
+            sharing_call[config.num_layers + 1] = depth == 0
+            outputs.append(run_depth())
+
+        shared_payload = forward_state.get(dsa_module._DSAMTPRepeatedSharingPayload)
+        assert shared_payload is not None
+    assert forward_state.get(_MTPRepeatedSharingPayload) is None
+
+    assert all(output.shape == outputs[0].shape for output in outputs)
+    assert attention.indexer is None
+    assert tracked_losses == []
+    assert sparse_topk_pointers == [source_topk.data_ptr()] * config.mtp_num_layers
+    expected_length_pointer = source_length.data_ptr() if source_has_length else None
+    assert sparse_length_pointers == [expected_length_pointer] * config.mtp_num_layers
+    assert index_payload.topk_by_layer[attention.source_layer].data_ptr() == source_topk.data_ptr()
+    assert attention.layer_number not in index_payload.topk_by_layer
+    if source_has_length:
+        assert (
+            index_payload.topk_length_by_layer[attention.source_layer].data_ptr()
+            == source_length.data_ptr()
+        )
+    else:
+        assert attention.source_layer not in index_payload.topk_length_by_layer
+    assert attention.layer_number not in index_payload.topk_length_by_layer
+
+
+def test_mtp_block_and_layer_publish_one_repeat():
+    config = _make_config(mtp_repeated_layer_shared_components=[SPARSE_ATTENTION_INDEX])
+    observed_repeats = []
+
+    class FakeRepeatedLayer:
+        def __init__(self):
+            self.config = config
+
+        def __call__(
+            self,
+            input_ids,
+            position_ids,
+            hidden_states,
+            attention_mask,
+            padding_mask=None,
+            **kwargs,
+        ):
+            forward_state = get_forward_sharing_state(
+                kwargs.get("packed_seq_params"), attention_mask, self.config
+            )
+            observed_repeats.append(
+                is_mtp_repeated_sharing_source(forward_state, config.num_layers + 1)
+            )
+            return hidden_states + 1, input_ids, position_ids, padding_mask
+
+    block = SimpleNamespace(
+        config=config, vp_stage=None, mtp_use_repeated_layer=True, layers=[FakeRepeatedLayer()]
+    )
+    hidden_states = torch.randn(4, 1, 3)
+
+    output = MultiTokenPredictionBlock.forward(
+        block,
+        input_ids=torch.arange(4).view(1, 4),
+        position_ids=torch.arange(4).view(1, 4),
+        hidden_states=hidden_states,
+        attention_mask=None,
+    )
+
+    assert output.shape == (16, 1, 3)
+    assert observed_repeats == [True, False, False]
+    assert get_forward_sharing_state(config=config)._entries == {}
+
+
+@pytest.mark.parametrize("nested", [False, True])
+def test_mtp_block_cleans_dsa_payload_when_a_later_depth_fails(monkeypatch, nested):
+    """The config fallback must not retain a source graph after stack unwind."""
+    monkeypatch.setattr(dsa_module, "build_module", lambda *_args, **_kwargs: nn.Identity())
+    attention = dsa_module.DSAttention(
+        config=_make_config(
+            num_layers=3, mtp_repeated_layer_shared_components=[SPARSE_ATTENTION_INDEX]
+        ),
+        submodules=dsa_module.DSAttentionSubmodules(indexer=None),
+        # The repeated physical MTP layer is global layer N+1=4; its source is layer 3.
+        layer_number=1,
+        attn_mask_type=AttnMaskType.causal,
+        attention_type="self",
+        pg_collection=SimpleNamespace(),
+        is_mtp_layer=True,
+    )
+    forward_state = get_forward_sharing_state(config=attention.config)
+    ordinary_source_topk = torch.zeros((1, 4, 4), dtype=torch.int64)
+
+    class FailingRepeatedLayer:
+        def __init__(self):
+            self.config = attention.config
+
+        def __call__(self, input_ids, position_ids, hidden_states, padding_mask=None, **_kwargs):
+            if not is_mtp_repeated_sharing_source(forward_state, attention.layer_number):
+                raise RuntimeError("injected depth failure")
+            _, shared_payload = attention._prepare_mtp_sharing_payload(None, None)
+            shared_payload.topk_by_layer[attention.layer_number] = ordinary_source_topk
+            return hidden_states + 1, input_ids, position_ids, padding_mask
+
+    block = SimpleNamespace(
+        config=attention.config,
+        vp_stage=None,
+        mtp_use_repeated_layer=True,
+        layers=[FailingRepeatedLayer()],
+    )
+
+    outer_lifetime = forward_sharing_lifetime(config=attention.config) if nested else nullcontext()
+    with outer_lifetime:
+        if nested:
+            index_payload = attention._get_dsa_index_sharing_payload(None, None)
+            index_payload.topk_by_layer[attention.source_layer] = ordinary_source_topk
+        with pytest.raises(RuntimeError, match="injected depth failure"):
+            MultiTokenPredictionBlock.forward(
+                block,
+                input_ids=torch.arange(4).view(1, 4),
+                position_ids=torch.arange(4).view(1, 4),
+                hidden_states=torch.randn(4, 1, 3),
+                attention_mask=None,
+            )
+        assert forward_state.get(_MTPRepeatedSharingPayload) is None
+        if nested:
+            assert forward_state.get(dsa_module._DSAIndexSharingPayload) is index_payload
+            assert index_payload.topk_by_layer[attention.source_layer] is ordinary_source_topk
+            assert forward_state.get(dsa_module._DSAMTPRepeatedSharingPayload) is not None
+    assert forward_state._entries == {}
+
+
+@pytest.mark.parametrize(
+    "callable_object",
+    [
+        MultiTokenPredictionLayer._proj_and_transformer_layer,
+        TransformerLayer._forward_attention,
+        HyperConnectionTransformerLayer._forward_attention,
+        AbsorbedMLASelfAttention.forward,
+        dsa_module.DSAttention.forward,
+    ],
+)
+def test_attention_call_signatures_do_not_expose_mtp_prediction_depth(callable_object):
+    assert "mtp_prediction_depth" not in inspect.signature(callable_object).parameters
+
+
+def test_mtp_layer_preserves_inner_signature_without_prediction_depth():
+    calls = []
+
+    class StrictLegacyTransformerLayer:
+        def __call__(
+            self,
+            hidden_states,
+            attention_mask=None,
+            context=None,
+            context_mask=None,
+            rotary_pos_emb=None,
+            rotary_pos_cos=None,
+            rotary_pos_sin=None,
+            attention_bias=None,
+            packed_seq_params=None,
+            sequence_len_offset=None,
+            padding_mask=None,
+            input_ids=None,
+            *,
+            inference_params=None,
+        ):
+            calls.append(True)
+            return hidden_states, None
+
+    layer = SimpleNamespace(
+        config=SimpleNamespace(fp8=None, sequence_parallel=False),
+        sequence_parallel=False,
+        mtp_layer_pattern=None,
+        mtp_model_layer=StrictLegacyTransformerLayer(),
+        mhc_enabled=True,
+        _concat_embeddings=lambda hidden_states, _decoder_input: hidden_states,
+    )
+    hidden_states = torch.randn(4, 1, 3)
+
+    output = MultiTokenPredictionLayer._proj_and_transformer_layer(
+        layer, hidden_states=hidden_states, decoder_input=torch.randn_like(hidden_states)
+    )
+
+    assert output is hidden_states
+    assert calls == [True]
+
+
+@pytest.mark.parametrize(
+    "shared_components", [pytest.param(None, id="none"), pytest.param([], id="empty")]
+)
+def test_mtp_block_preserves_legacy_layer_signature_when_sharing_is_disabled(shared_components):
+    observed_depths = []
+
+    class LegacyRepeatedLayer:
+        def __call__(
+            self,
+            *,
+            input_ids,
+            position_ids,
+            hidden_states,
+            attention_mask,
+            padding_mask,
+            inference_params,
+            rotary_pos_emb,
+            rotary_pos_cos,
+            rotary_pos_sin,
+            packed_seq_params,
+            sequence_roll_context,
+            roll_depth,
+            sequence_len_offset,
+            embedding,
+        ):
+            observed_depths.append(roll_depth)
+            return hidden_states + 1, input_ids, position_ids, padding_mask
+
+    block = SimpleNamespace(
+        config=SimpleNamespace(
+            pipeline_model_parallel_size=1,
+            mtp_num_layers=2,
+            mtp_detach_heads=False,
+            mtp_repeated_layer_shared_components=shared_components,
+        ),
+        vp_stage=None,
+        mtp_use_repeated_layer=True,
+        layers=[LegacyRepeatedLayer()],
+    )
+
+    output = MultiTokenPredictionBlock.forward(
+        block,
+        input_ids=torch.arange(4).view(1, 4),
+        position_ids=torch.arange(4).view(1, 4),
+        hidden_states=torch.randn(4, 1, 3),
+        attention_mask=None,
+    )
+
+    assert output.shape == (12, 1, 3)
+    assert observed_depths == [0, 1]
+
+
+def test_cross_depth_sharing_rejects_hybrid_mtp_pattern():
+    config = _make_config()
+
+    with pytest.raises(ValueError, match="GPT MTP path only"):
+        MultiTokenPredictionLayer(
+            config=config,
+            submodules=SimpleNamespace(mtp_model_layer=None),
+            pg_collection=SimpleNamespace(cp=None, tp=None),
+            mtp_layer_pattern="M",
+        )

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_mtp_dsa_cross_depth_sharing.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_mtp_dsa_cross_depth_sharing.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
-"""Coverage for sparse-attention index sharing across repeated MTP invocations."""
+"""Coverage for component sharing across repeated MTP prediction depths."""
 
 import inspect
 from contextlib import nullcontext
@@ -9,8 +9,16 @@ from types import SimpleNamespace
 import pytest
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 
+import megatron.core.parallel_state as parallel_state
 from megatron.core import tensor_parallel
+from megatron.core.extensions.transformer_engine_spec_provider import TESpecProvider
+from megatron.core.models.gpt.experimental_attention_variant_module_specs import (
+    get_dsa_module_spec_for_backend,
+)
+from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.enums import AttnBackend, AttnMaskType, CudaGraphModule
 from megatron.core.transformer.experimental_attention_variant import dsa as dsa_module
 from megatron.core.transformer.experimental_attention_variant.absorbed_mla import (
@@ -27,14 +35,18 @@ from megatron.core.transformer.multi_token_prediction import (
     MultiTokenPredictionBlock,
     MultiTokenPredictionLayer,
 )
+from megatron.core.transformer.spec_utils import build_module
 from megatron.core.transformer.transformer_config import MLATransformerConfig
 from megatron.core.transformer.transformer_layer import (
     HyperConnectionTransformerLayer,
     TransformerLayer,
 )
 from megatron.core.utils import init_method_normal, scaled_init_method_normal
+from tests.unit_tests.test_utilities import Utils
 
+LATENT_KV = "latent_kv"
 SPARSE_ATTENTION_INDEX = "sparse_attention_index"
+BOTH_SHARED_COMPONENTS = [LATENT_KV, SPARSE_ATTENTION_INDEX]
 
 
 def _make_config(**overrides) -> MLATransformerConfig:
@@ -93,7 +105,10 @@ def _make_config(**overrides) -> MLATransformerConfig:
     [
         pytest.param(None, id="none"),
         pytest.param([], id="empty"),
+        pytest.param([LATENT_KV], id="latent-kv-only"),
         pytest.param([SPARSE_ATTENTION_INDEX], id="sparse-attention-index-only"),
+        pytest.param(BOTH_SHARED_COMPONENTS, id="both"),
+        pytest.param(list(reversed(BOTH_SHARED_COMPONENTS)), id="both-reversed"),
     ],
 )
 def test_cross_depth_shared_components_accept_supported_values(shared_components):
@@ -185,7 +200,10 @@ def test_index_sharing_rejects_full_recompute(method):
         _make_config(recompute_granularity="full", recompute_method=method, recompute_num_layers=1)
 
 
-def test_mlp_recompute_after_repeat_cleanup_preserves_gradients(monkeypatch):
+@pytest.mark.parametrize(
+    "shared_components", [[SPARSE_ATTENTION_INDEX], [LATENT_KV], BOTH_SHARED_COMPONENTS]
+)
+def test_mlp_recompute_after_repeat_cleanup_preserves_gradients(monkeypatch, shared_components):
     """Exercise MCore's real checkpoint backward with CPU RNG and a DSA-owned payload."""
     monkeypatch.setattr(dsa_module, "build_module", lambda *_args, **_kwargs: nn.Identity())
     # The test has no CUDA operations. Keep the checkpoint/autograd implementation intact
@@ -199,7 +217,9 @@ def test_mlp_recompute_after_repeat_cleanup_preserves_gradients(monkeypatch):
 
     def run(recompute):
         config = _make_config(
-            recompute_granularity="selective" if recompute else None, recompute_modules=["mlp"]
+            mtp_repeated_layer_shared_components=shared_components,
+            recompute_granularity="selective" if recompute else None,
+            recompute_modules=["mlp"],
         )
         attention = dsa_module.DSAttention(
             config=config,
@@ -235,6 +255,10 @@ def test_mlp_recompute_after_repeat_cleanup_preserves_gradients(monkeypatch):
                 _, payload = attention._prepare_mtp_sharing_payload(None, None)
                 if depth == 0:
                     payload.topk_by_layer[config.num_layers + 1] = torch.zeros(1, dtype=torch.int64)
+                    if LATENT_KV in shared_components:
+                        payload.latent_kv_by_layer[config.num_layers + 1] = inputs.square()
+                if LATENT_KV in shared_components:
+                    hidden = hidden + payload.latent_kv_by_layer[config.num_layers + 1]
                 hidden = (
                     tensor_parallel.checkpoint(mlp, False, hidden) if recompute else mlp(hidden)
                 )
@@ -252,6 +276,84 @@ def test_mlp_recompute_after_repeat_cleanup_preserves_gradients(monkeypatch):
         torch.testing.assert_close(actual, expected)
 
 
+@pytest.mark.parametrize("shared_components", [[LATENT_KV], BOTH_SHARED_COMPONENTS])
+@pytest.mark.parametrize(
+    "modules",
+    [
+        [],
+        ["mlp"],
+        ["moe"],
+        ["moe_act"],
+        ["shared_experts"],
+        ["layernorm"],
+        ["mhc"],
+        ["layernorm", "moe", "shared_experts"],
+    ],
+)
+def test_latent_kv_sharing_accepts_selective_recompute_outside_shared_producer(
+    shared_components, modules
+):
+    config = _make_config(
+        mtp_repeated_layer_shared_components=shared_components,
+        recompute_granularity="selective",
+        recompute_modules=modules,
+        num_moe_experts=4,
+        moe_grouped_gemm=True,
+        moe_shared_expert_intermediate_size=64,
+        enable_hyper_connections="mhc" in modules,
+    )
+    assert config.recompute_modules == modules
+
+
+@pytest.mark.parametrize("shared_components", [[LATENT_KV], BOTH_SHARED_COMPONENTS])
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        (
+            {"recompute_granularity": "full", "recompute_method": "uniform"},
+            "does not support full activation recomputation",
+        ),
+        (
+            {"recompute_granularity": "full", "recompute_method": "block"},
+            "does not support full activation recomputation",
+        ),
+        ({"recompute_granularity": "selective"}, "does not support core_attn recompute"),
+        (
+            {"recompute_granularity": "selective", "recompute_modules": ["mlp", "core_attn"]},
+            "does not support core_attn recompute",
+        ),
+        (
+            {"recompute_granularity": "selective", "recompute_modules": ["mla_up_proj"]},
+            "does not support mla_up_proj recompute",
+        ),
+        (
+            {
+                "recompute_granularity": "selective",
+                "recompute_modules": ["layernorm", "mla_up_proj"],
+            },
+            "does not support mla_up_proj recompute",
+        ),
+    ],
+)
+def test_latent_kv_sharing_rejects_conflicting_recompute(shared_components, overrides, message):
+    with pytest.raises(ValueError, match=message):
+        _make_config(mtp_repeated_layer_shared_components=shared_components, **overrides)
+
+
+def test_latent_kv_runtime_rejects_discarding_shared_source_storage():
+    attention = SimpleNamespace(
+        training=True,
+        cache_mla_latents=False,
+        core_attention=SimpleNamespace(mtp_cross_depth_share=True, mtp_latent_kv_share=True),
+        checkpoint_core_attention=False,
+        recompute_up_proj=True,
+    )
+    with pytest.raises(RuntimeError, match="source KV storage would be discarded"):
+        AbsorbedMLASelfAttention.forward(
+            attention, hidden_states=torch.zeros(1, 1, 4), attention_mask=None
+        )
+
+
 def test_cross_depth_sharing_accepts_supported_cuda_graph_scopes():
     moe_config = _make_config(
         cuda_graph_impl="transformer_engine",
@@ -262,6 +364,25 @@ def test_cross_depth_sharing_accepts_supported_cuda_graph_scopes():
         CudaGraphModule.moe_router,
         CudaGraphModule.moe_preprocess,
     ]
+
+
+def test_dsa_state_rejects_latent_kv_consumer_without_source(monkeypatch):
+    monkeypatch.setattr(dsa_module, "build_module", lambda *_args, **_kwargs: nn.Identity())
+    attention = dsa_module.DSAttention(
+        config=_make_config(mtp_repeated_layer_shared_components=[LATENT_KV]),
+        submodules=dsa_module.DSAttentionSubmodules(indexer=None),
+        layer_number=1,
+        attn_mask_type=AttnMaskType.causal,
+        attention_type="self",
+        pg_collection=SimpleNamespace(),
+        is_mtp_layer=True,
+    )
+
+    forward_state = get_forward_sharing_state(config=attention.config)
+    with mtp_repeated_sharing_lifetime(forward_state, attention.layer_number) as sharing_call:
+        sharing_call[attention.layer_number] = False
+        with pytest.raises(RuntimeError, match="requires published source"):
+            attention._prepare_mtp_sharing_payload(None, None)
 
 
 @pytest.mark.parametrize("fail_second_layer", [False, True])
@@ -299,6 +420,7 @@ def test_mtp_payload_requires_a_source_and_isolates_layers(monkeypatch, fail_sec
             assert is_source
             first.topk_by_layer[first_number] = torch.ones(1)
             first.topk_length_by_layer[first_number] = torch.ones(1, dtype=torch.int64)
+            first.latent_kv_by_layer[first_number] = torch.ones(1)
             with pytest.raises(RuntimeError, match="already active"):
                 with mtp_repeated_sharing_lifetime(state, first_number):
                     pass
@@ -314,6 +436,7 @@ def test_mtp_payload_requires_a_source_and_isolates_layers(monkeypatch, fail_sec
                     second_topk = torch.zeros(1)
                     second.topk_by_layer[second_number] = second_topk
                     second.topk_length_by_layer[second_number] = torch.zeros(1, dtype=torch.int64)
+                    second.latent_kv_by_layer[second_number] = torch.zeros(1)
                     flags[first_number] = False
                     assert layers[0]._prepare_mtp_sharing_payload(None, None) == (False, first)
                     assert flags[second_number]
@@ -337,8 +460,10 @@ def test_mtp_payload_requires_a_source_and_isolates_layers(monkeypatch, fail_sec
             assert fresh is first
             assert first_number not in fresh.topk_by_layer
             assert first_number not in fresh.topk_length_by_layer
+            assert first_number not in fresh.latent_kv_by_layer
             assert tensors.topk_by_layer[second_number] is second_topk
             assert second_number in tensors.topk_length_by_layer
+            assert second_number in tensors.latent_kv_by_layer
             flags[first_number] = False
             with pytest.raises(RuntimeError, match="requires published source"):
                 layers[0]._prepare_mtp_sharing_payload(None, None)
@@ -350,19 +475,24 @@ def test_mtp_snapshot_copies_dictionaries_and_cleanup_releases_live_tensors():
     state = get_forward_sharing_state(config=config)
     indices = torch.zeros(2, dtype=torch.int64)
     lengths = torch.ones(2, dtype=torch.int64)
+    source = torch.ones(2, requires_grad=True)
+    latent_kv = source.square()
     with forward_sharing_lifetime(config=config):
         with mtp_repeated_sharing_lifetime(state, 7) as flags:
             flags[7] = True
             payload = state.get_or_create(dsa_module._DSAMTPRepeatedSharingPayload)
             payload.topk_by_layer[7] = indices
             payload.topk_length_by_layer[7] = lengths
+            payload.latent_kv_by_layer[7] = latent_kv
             snapshot = state.snapshot()
             saved = snapshot.get(dsa_module._DSAMTPRepeatedSharingPayload)
             assert saved is not payload
             assert saved.topk_by_layer is not payload.topk_by_layer
             assert saved.topk_length_by_layer is not payload.topk_length_by_layer
+            assert saved.latent_kv_by_layer is not payload.latent_kv_by_layer
             payload.topk_by_layer.clear()
             payload.topk_length_by_layer.clear()
+            payload.latent_kv_by_layer.clear()
             flags[7] = False
             assert snapshot.get(_MTPRepeatedSharingPayload).is_source_by_layer[7]
         assert state.get(_MTPRepeatedSharingPayload) is None
@@ -372,6 +502,9 @@ def test_mtp_snapshot_copies_dictionaries_and_cleanup_releases_live_tensors():
     assert state._entries == {}
     assert saved.topk_by_layer[7] is indices
     assert saved.topk_length_by_layer[7] is lengths
+    assert saved.latent_kv_by_layer[7] is latent_kv
+    saved.latent_kv_by_layer[7].sum().backward()
+    torch.testing.assert_close(source.grad, 2 * source.detach())
 
 
 def test_dsa_state_computes_index_once_then_reuses_and_cleans_it(monkeypatch):
@@ -457,13 +590,128 @@ def test_dsa_state_computes_index_once_then_reuses_and_cleans_it(monkeypatch):
     assert attention.layer_number not in index_payload.topk_by_layer
 
 
+def test_dsa_state_keeps_latent_kv_attached_to_the_source_graph(monkeypatch):
+    monkeypatch.setattr(dsa_module, "build_module", lambda *_args, **_kwargs: nn.Identity())
+    attention = dsa_module.DSAttention(
+        config=_make_config(mtp_num_layers=2, mtp_repeated_layer_shared_components=[LATENT_KV]),
+        submodules=dsa_module.DSAttentionSubmodules(indexer=None),
+        layer_number=1,
+        attn_mask_type=AttnMaskType.causal,
+        attention_type="self",
+        pg_collection=SimpleNamespace(),
+        is_mtp_layer=True,
+    )
+    source_input = torch.randn(4, 1, 8, requires_grad=True)
+    latent_kv = source_input.square()
+    forward_state = get_forward_sharing_state(config=attention.config)
+
+    with forward_sharing_lifetime(config=attention.config):
+        # An interrupted source repeat must not leak its graph into the next repeat.
+        with mtp_repeated_sharing_lifetime(forward_state, attention.layer_number) as sharing_call:
+            sharing_call[attention.layer_number] = True
+            attention._prepare_mtp_sharing_payload(None, None)
+            shared_payload = forward_state.get(dsa_module._DSAMTPRepeatedSharingPayload)
+            shared_payload.latent_kv_by_layer[attention.layer_number] = torch.randn_like(latent_kv)
+
+        with mtp_repeated_sharing_lifetime(forward_state, attention.layer_number) as sharing_call:
+            sharing_call[attention.layer_number] = True
+            attention._prepare_mtp_sharing_payload(None, None)
+            shared_payload = forward_state.get(dsa_module._DSAMTPRepeatedSharingPayload)
+            assert attention.layer_number not in shared_payload.latent_kv_by_layer
+            shared_payload.latent_kv_by_layer[attention.layer_number] = latent_kv
+
+            sharing_call[attention.layer_number] = False
+            _, payload = attention._prepare_mtp_sharing_payload(None, None)
+            reused_latent_kv = payload.latent_kv_by_layer[attention.layer_number]
+
+        assert forward_state.get(_MTPRepeatedSharingPayload) is None
+    assert forward_state._entries == {}
+
+    reused_latent_kv.sum().backward()
+
+    assert reused_latent_kv.data_ptr() == latent_kv.data_ptr()
+    assert reused_latent_kv.grad_fn is not None
+    assert source_input.grad is not None
+
+
+def test_latent_kv_sharing_publishes_before_combined_fused_early_return(monkeypatch):
+    class FakeIndexer(nn.Module):
+        def forward_before_topk(self, x, qr, packed_seq_params):
+            del qr, packed_seq_params
+            return (
+                torch.randn(x.size(0), x.size(1), 2, 4),
+                torch.randn(x.size(0), x.size(1), 4),
+                torch.ones(x.size(0), x.size(1), 2),
+            )
+
+    monkeypatch.setattr(dsa_module, "build_module", lambda *_args, **_kwargs: FakeIndexer())
+    monkeypatch.setattr(dsa_module.dsa_kernels, "use_fused_dsa_kernels", lambda _config: True)
+    fused_key_pointers = []
+
+    def fake_fused_attention(**kwargs):
+        fused_key_pointers.append(kwargs["key"].data_ptr())
+        query = kwargs["query"]
+        return query.new_zeros((query.size(0), query.size(1), config.hidden_size)), None
+
+    monkeypatch.setattr(dsa_module.dsa_kernels, "run_fused_dsa_attention", fake_fused_attention)
+    config = _make_config(
+        mtp_num_layers=2,
+        mtp_repeated_layer_shared_components=[LATENT_KV],
+        dsa_indexer_topk_freq=1,
+        dsa_indexer_skip_topk_offset=0,
+    )
+    attention = dsa_module.DSAttention(
+        config=config,
+        submodules=dsa_module.DSAttentionSubmodules(indexer=None),
+        layer_number=1,
+        attn_mask_type=AttnMaskType.causal,
+        attention_type="self",
+        pg_collection=SimpleNamespace(tp=None, cp=None),
+        is_mtp_layer=True,
+    )
+    sequence_length = 4
+    source_key = torch.randn(
+        sequence_length, 1, 1, config.kv_lora_rank + config.qk_pos_emb_head_dim
+    )
+
+    def run_depth(key):
+        return attention(
+            query=torch.randn(
+                sequence_length,
+                1,
+                config.num_attention_heads,
+                config.kv_lora_rank + config.qk_pos_emb_head_dim,
+            ),
+            key=key,
+            value=None,
+            attention_mask=None,
+            x=torch.randn(sequence_length, 1, config.hidden_size),
+            qr=torch.randn(sequence_length, 1, config.q_lora_rank),
+            up_v_weight=torch.randn(
+                config.num_attention_heads, config.v_head_dim, config.kv_lora_rank
+            ),
+            attn_mask_type=AttnMaskType.causal,
+        )
+
+    forward_state = get_forward_sharing_state(config=config)
+    with mtp_repeated_sharing_lifetime(forward_state, config.num_layers + 1) as sharing_call:
+        sharing_call[config.num_layers + 1] = True
+        run_depth(source_key)
+        sharing_call[config.num_layers + 1] = False
+        run_depth(None)
+
+    assert fused_key_pointers == [source_key.data_ptr(), source_key.data_ptr()]
+
+
 @pytest.mark.parametrize(
     ("shared_components", "is_mtp_layer", "fused_enabled", "expected_log_count"),
     [
+        pytest.param(BOTH_SHARED_COMPONENTS, True, True, 1, id="both-fused"),
         pytest.param([SPARSE_ATTENTION_INDEX], True, True, 1, id="index-only-fused"),
+        pytest.param([LATENT_KV], True, True, 0, id="latent-kv-only-fused"),
         pytest.param(None, True, True, 0, id="sharing-off-fused"),
-        pytest.param([SPARSE_ATTENTION_INDEX], True, False, 0, id="index-only-unfused"),
-        pytest.param([SPARSE_ATTENTION_INDEX], False, True, 0, id="non-mtp-fused"),
+        pytest.param(BOTH_SHARED_COMPONENTS, True, False, 0, id="both-unfused"),
+        pytest.param(BOTH_SHARED_COMPONENTS, False, True, 0, id="non-mtp-fused"),
     ],
 )
 def test_cross_depth_sharing_logs_when_combined_fused_dsa_is_disabled(
@@ -505,11 +753,19 @@ def test_cross_depth_sharing_logs_when_combined_fused_dsa_is_disabled(
     assert len(fallback_messages) == expected_log_count
 
 
-def test_repeated_mtp_sharing_accepts_ordinary_index_share_skip_layer(monkeypatch):
+@pytest.mark.parametrize(
+    "shared_components",
+    [
+        pytest.param([LATENT_KV], id="latent-kv-only"),
+        pytest.param([SPARSE_ATTENTION_INDEX], id="sparse-attention-index-only"),
+        pytest.param(BOTH_SHARED_COMPONENTS, id="both"),
+    ],
+)
+def test_repeated_mtp_sharing_accepts_ordinary_index_share_skip_layer(
+    monkeypatch, shared_components
+):
     monkeypatch.setattr(dsa_module, "build_module", lambda *_args, **_kwargs: nn.Identity())
-    config = _make_config(
-        num_layers=3, mtp_repeated_layer_shared_components=[SPARSE_ATTENTION_INDEX]
-    )
+    config = _make_config(num_layers=3, mtp_repeated_layer_shared_components=shared_components)
 
     attention = dsa_module.DSAttention(
         config=config,
@@ -619,8 +875,16 @@ def test_dsa_state_reuses_ordinary_skip_index_across_mtp_depths(monkeypatch, sou
     assert attention.layer_number not in index_payload.topk_length_by_layer
 
 
-def test_mtp_block_and_layer_publish_one_repeat():
-    config = _make_config(mtp_repeated_layer_shared_components=[SPARSE_ATTENTION_INDEX])
+@pytest.mark.parametrize(
+    "shared_components",
+    [
+        pytest.param([LATENT_KV], id="latent-kv-only"),
+        pytest.param([SPARSE_ATTENTION_INDEX], id="sparse-attention-index-only"),
+        pytest.param(BOTH_SHARED_COMPONENTS, id="both"),
+    ],
+)
+def test_mtp_block_and_layer_publish_one_repeat(shared_components):
+    config = _make_config(mtp_repeated_layer_shared_components=shared_components)
     observed_repeats = []
 
     class FakeRepeatedLayer:
@@ -668,7 +932,7 @@ def test_mtp_block_cleans_dsa_payload_when_a_later_depth_fails(monkeypatch, nest
     monkeypatch.setattr(dsa_module, "build_module", lambda *_args, **_kwargs: nn.Identity())
     attention = dsa_module.DSAttention(
         config=_make_config(
-            num_layers=3, mtp_repeated_layer_shared_components=[SPARSE_ATTENTION_INDEX]
+            num_layers=3, mtp_repeated_layer_shared_components=BOTH_SHARED_COMPONENTS
         ),
         submodules=dsa_module.DSAttentionSubmodules(indexer=None),
         # The repeated physical MTP layer is global layer N+1=4; its source is layer 3.
@@ -680,6 +944,7 @@ def test_mtp_block_cleans_dsa_payload_when_a_later_depth_fails(monkeypatch, nest
     )
     forward_state = get_forward_sharing_state(config=attention.config)
     ordinary_source_topk = torch.zeros((1, 4, 4), dtype=torch.int64)
+    source_input = torch.randn(4, 1, 8, requires_grad=True)
 
     class FailingRepeatedLayer:
         def __init__(self):
@@ -689,6 +954,7 @@ def test_mtp_block_cleans_dsa_payload_when_a_later_depth_fails(monkeypatch, nest
             if not is_mtp_repeated_sharing_source(forward_state, attention.layer_number):
                 raise RuntimeError("injected depth failure")
             _, shared_payload = attention._prepare_mtp_sharing_payload(None, None)
+            shared_payload.latent_kv_by_layer[attention.layer_number] = source_input.square()
             shared_payload.topk_by_layer[attention.layer_number] = ordinary_source_topk
             return hidden_states + 1, input_ids, position_ids, padding_mask
 
@@ -838,3 +1104,510 @@ def test_cross_depth_sharing_rejects_hybrid_mtp_pattern():
             pg_collection=SimpleNamespace(cp=None, tp=None),
             mtp_layer_pattern="M",
         )
+
+
+def _rope_positions(total_tokens: int, segment_lengths: list[int] | None, device) -> torch.Tensor:
+    if segment_lengths is None:
+        return torch.arange(total_tokens, device=device)
+    return torch.cat([torch.arange(length, device=device) for length in segment_lengths])
+
+
+def _apply_rope(
+    x: torch.Tensor, positions: torch.Tensor, base: float, interleaved: bool
+) -> torch.Tensor:
+    dtype = x.dtype
+    dim = x.size(-1)
+    freqs = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32, device=x.device) / dim))
+    freqs = torch.outer(positions.float(), freqs)
+    freqs = torch.polar(torch.ones_like(freqs), freqs).view(x.size(0), 1, 1, -1)
+    if interleaved:
+        x_pairs = x.float().reshape(*x.shape[:-1], -1, 2)
+    else:
+        x_pairs = x.float().reshape(*x.shape[:-1], 2, -1).transpose(-1, -2).contiguous()
+    x_complex = torch.view_as_complex(x_pairs)
+    output = torch.view_as_real(x_complex * freqs).flatten(-2)
+    if not interleaved:
+        output = torch.cat([output[..., 0::2], output[..., 1::2]], dim=-1)
+    return output.to(dtype=dtype)
+
+
+def _causal_segment_mask(
+    total_tokens: int, segment_lengths: list[int] | None, device
+) -> torch.Tensor:
+    valid = torch.zeros((total_tokens, total_tokens), dtype=torch.bool, device=device)
+    start = 0
+    for length in segment_lengths or [total_tokens]:
+        valid[start : start + length, start : start + length] = torch.tril(
+            torch.ones((length, length), dtype=torch.bool, device=device)
+        )
+        start += length
+    return valid
+
+
+class _NativeSharedAbsorbedDSA(nn.Module):
+    """PyTorch-native DSA reference with explicit cross-depth tensor reuse."""
+
+    _PARAMETER_MAP = {
+        "q_down_weight": "linear_q_down_proj.weight",
+        "q_norm_weight": "q_layernorm.weight",
+        "q_up_weight": "linear_q_up_proj.weight",
+        "kv_down_weight": "linear_kv_down_proj.weight",
+        "kv_norm_weight": "kv_layernorm.weight",
+        "kv_up_weight": "linear_kv_up_proj.weight",
+        "output_weight": "linear_proj.weight",
+        "index_q_weight": "core_attention.indexer.linear_wq_b.weight",
+        "index_k_weight": "core_attention.indexer.linear_wk.weight",
+        "index_k_norm_weight": "core_attention.indexer.k_norm.weight",
+        "index_k_norm_bias": "core_attention.indexer.k_norm.bias",
+        "index_weight_proj": "core_attention.indexer.linear_weights_proj.weight",
+    }
+
+    def __init__(self, real_attention, config: MLATransformerConfig):
+        super().__init__()
+        self.config = config
+        real_parameters = dict(real_attention.named_parameters())
+        for native_name, real_name in self._PARAMETER_MAP.items():
+            setattr(self, native_name, nn.Parameter(real_parameters[real_name].detach().clone()))
+
+    def _project_query(self, hidden_states: torch.Tensor, positions: torch.Tensor):
+        qr = F.linear(hidden_states, self.q_down_weight)
+        qr = F.rms_norm(
+            qr, (self.config.q_lora_rank,), self.q_norm_weight, self.config.layernorm_epsilon
+        )
+        query = F.linear(qr, self.q_up_weight).view(
+            hidden_states.size(0),
+            hidden_states.size(1),
+            self.config.num_attention_heads,
+            self.config.qk_head_dim + self.config.qk_pos_emb_head_dim,
+        )
+        query_nope, query_rope = torch.split(
+            query, [self.config.qk_head_dim, self.config.qk_pos_emb_head_dim], dim=-1
+        )
+        query_rope = _apply_rope(query_rope, positions, self.config.rotary_base, interleaved=True)
+
+        kv_up = self.kv_up_weight.view(
+            self.config.num_attention_heads,
+            self.config.qk_head_dim + self.config.v_head_dim,
+            self.config.kv_lora_rank,
+        )
+        k_up = kv_up[:, : self.config.qk_head_dim]
+        query_absorbed = torch.einsum("sbhd,hdc->sbhc", query_nope, k_up)
+        return torch.cat([query_absorbed, query_rope], dim=-1), qr, kv_up
+
+    def _project_key(self, hidden_states: torch.Tensor, positions: torch.Tensor):
+        kv_combined = F.linear(hidden_states, self.kv_down_weight)
+        kv_latent, key_rope = torch.split(
+            kv_combined, [self.config.kv_lora_rank, self.config.qk_pos_emb_head_dim], dim=-1
+        )
+        kv_latent = F.rms_norm(
+            kv_latent,
+            (self.config.kv_lora_rank,),
+            self.kv_norm_weight,
+            self.config.layernorm_epsilon,
+        )
+        key_rope = _apply_rope(
+            key_rope.unsqueeze(2), positions, self.config.rotary_base, interleaved=True
+        )
+        return torch.cat([kv_latent.unsqueeze(2), key_rope], dim=-1)
+
+    def _compute_topk(
+        self,
+        hidden_states: torch.Tensor,
+        qr: torch.Tensor,
+        positions: torch.Tensor,
+        valid: torch.Tensor,
+    ) -> torch.Tensor:
+        detached_hidden = hidden_states.detach()
+        qr = qr.detach()
+        query = F.linear(qr, self.index_q_weight).view(
+            hidden_states.size(0),
+            hidden_states.size(1),
+            self.config.dsa_indexer_n_heads,
+            self.config.dsa_indexer_head_dim,
+        )
+        query_rope, query_nope = torch.split(
+            query,
+            [
+                self.config.qk_pos_emb_head_dim,
+                self.config.dsa_indexer_head_dim - self.config.qk_pos_emb_head_dim,
+            ],
+            dim=-1,
+        )
+        query_rope = _apply_rope(query_rope, positions, self.config.rotary_base, interleaved=False)
+        query = torch.cat([query_rope, query_nope], dim=-1)
+
+        key = F.linear(detached_hidden, self.index_k_weight)
+        key = F.layer_norm(
+            key,
+            (self.config.dsa_indexer_head_dim,),
+            self.index_k_norm_weight,
+            self.index_k_norm_bias,
+            self.config.dsa_indexer_k_norm_epsilon or self.config.layernorm_epsilon,
+        )
+        key = key.unsqueeze(2)
+        key_rope, key_nope = torch.split(
+            key,
+            [
+                self.config.qk_pos_emb_head_dim,
+                self.config.dsa_indexer_head_dim - self.config.qk_pos_emb_head_dim,
+            ],
+            dim=-1,
+        )
+        key_rope = _apply_rope(key_rope, positions, self.config.rotary_base, interleaved=False)
+        key = torch.cat([key_rope, key_nope], dim=-1).squeeze(2)
+
+        weights = F.linear(detached_hidden, self.index_weight_proj)
+        weights = weights * (self.config.dsa_indexer_n_heads**-0.5)
+        weights = weights * (self.config.dsa_indexer_head_dim**-0.5)
+        scores = torch.einsum("sbhd,tbd->bsht", query.float(), key.float())
+        scores = (scores * weights.transpose(0, 1).unsqueeze(-1)).sum(dim=2)
+        scores = scores.masked_fill(~valid.unsqueeze(0), float("-inf"))
+        topk_scores, topk = scores.topk(min(self.config.dsa_indexer_topk, key.size(0)), dim=-1)
+        return topk.masked_fill(topk_scores == float("-inf"), -1)
+
+    def forward_depth(
+        self,
+        hidden_states: torch.Tensor,
+        positions: torch.Tensor,
+        valid: torch.Tensor,
+        shared_key: torch.Tensor | None,
+        shared_topk: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        query, qr, kv_up = self._project_query(hidden_states, positions)
+        key = self._project_key(hidden_states, positions) if shared_key is None else shared_key
+        topk = (
+            self._compute_topk(hidden_states, qr, positions, valid)
+            if shared_topk is None
+            else shared_topk
+        )
+
+        scores = torch.einsum("sbhd,tbnd->bhst", query.float(), key.float())
+        scores = scores * (self.config.qk_head_dim + self.config.qk_pos_emb_head_dim) ** -0.5
+        selected = torch.zeros_like(valid, dtype=torch.int32).unsqueeze(0)
+        selected.scatter_add_(-1, topk.clamp_min(0), (topk >= 0).to(dtype=selected.dtype))
+        sparse_valid = valid.unsqueeze(0) & (selected > 0)
+        scores = scores.masked_fill(~sparse_valid.unsqueeze(1), float("-inf"))
+        probabilities = torch.softmax(scores, dim=-1).to(dtype=key.dtype)
+        latent_value = key[..., : self.config.kv_lora_rank]
+        latent_output = torch.einsum("bhst,tbnd->sbhd", probabilities, latent_value)
+        v_up = kv_up[:, self.config.qk_head_dim :]
+        output = torch.einsum("sbhc,hdc->sbhd", latent_output, v_up)
+        output = F.linear(output.reshape(*hidden_states.shape[:-1], -1), self.output_weight)
+        return output, key, topk
+
+
+def _assert_similarity(left: torch.Tensor, right: torch.Tensor, tolerance: float = 2e-2):
+    assert torch.isfinite(left).all()
+    assert torch.isfinite(right).all()
+    cosine = F.cosine_similarity(
+        left.flatten().double().unsqueeze(0), right.flatten().double().unsqueeze(0)
+    ).item()
+    left = left.double()
+    right = right.double()
+    denominator = (left.square() + right.square()).sum()
+    similarity = 1.0 if denominator == 0 else (2.0 * (left * right).sum() / denominator).item()
+    assert cosine > 1 - tolerance
+    assert similarity > 1 - tolerance
+
+
+@pytest.mark.parametrize(
+    (
+        "shared_components",
+        "shares_latent_kv",
+        "shares_sparse_attention_index",
+        "segment_lengths",
+        "apply_rope_fusion",
+        "topk_frequency",
+    ),
+    [
+        pytest.param([LATENT_KV], True, False, None, False, 4, id="latent-kv-only"),
+        pytest.param(
+            [SPARSE_ATTENTION_INDEX],
+            False,
+            True,
+            None,
+            False,
+            1,
+            id="sparse-index-only-frequency-one",
+        ),
+        pytest.param(BOTH_SHARED_COMPONENTS, True, True, None, False, 4, id="both-unpacked"),
+        pytest.param(BOTH_SHARED_COMPONENTS, True, True, [5, 4], False, 4, id="both-packed"),
+        pytest.param(BOTH_SHARED_COMPONENTS, True, True, None, True, 4, id="both-fused-rope"),
+    ],
+)
+@pytest.mark.launch_on_gb200
+def test_repeated_mtp_dsa_eager_components_match_native_reference(
+    monkeypatch,
+    shared_components,
+    shares_latent_kv,
+    shares_sparse_attention_index,
+    segment_lengths,
+    apply_rope_fusion,
+    topk_frequency,
+):
+    Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=1)
+    try:
+        model_parallel_cuda_manual_seed(1234)
+        torch.manual_seed(1234)
+        torch.cuda.manual_seed(1234)
+        config = _make_config(
+            mtp_repeated_layer_shared_components=shared_components,
+            apply_rope_fusion=apply_rope_fusion,
+            dsa_indexer_topk_freq=topk_frequency,
+        )
+        attention_spec = get_dsa_module_spec_for_backend(config, backend=TESpecProvider())
+        real_attention = (
+            build_module(attention_spec, config=config, layer_number=1, is_mtp_layer=True)
+            .bfloat16()
+            .cuda()
+        )
+        native_attention = _NativeSharedAbsorbedDSA(real_attention, config).bfloat16().cuda()
+
+        total_tokens = sum(segment_lengths) if segment_lengths is not None else 9
+        positions = _rope_positions(total_tokens, segment_lengths, device="cuda")
+        valid = _causal_segment_mask(total_tokens, segment_lengths, device="cuda")
+        if segment_lengths is None:
+            attention_mask = torch.zeros(
+                (1, 1, total_tokens, total_tokens), dtype=torch.float32, device="cuda"
+            ).masked_fill(~valid.view(1, 1, total_tokens, total_tokens), float("-inf"))
+            packed_seq_params = None
+        else:
+            cu_seqlens = torch.tensor(
+                [0, segment_lengths[0], total_tokens], dtype=torch.int32, device="cuda"
+            )
+            attention_mask = None
+            packed_seq_params = PackedSeqParams(
+                qkv_format="thd",
+                cu_seqlens_q=cu_seqlens,
+                cu_seqlens_kv=cu_seqlens,
+                max_seqlen_q=max(segment_lengths),
+                max_seqlen_kv=max(segment_lengths),
+            )
+
+        call_counts = {"q": 0, "kv": 0, "indexer": 0, "sparse": 0}
+        hooks = [
+            real_attention.linear_q_down_proj.register_forward_hook(
+                lambda *_args: call_counts.__setitem__("q", call_counts["q"] + 1)
+            ),
+            real_attention.linear_kv_down_proj.register_forward_hook(
+                lambda *_args: call_counts.__setitem__("kv", call_counts["kv"] + 1)
+            ),
+            real_attention.core_attention.indexer.linear_wq_b.register_forward_hook(
+                lambda *_args: call_counts.__setitem__("indexer", call_counts["indexer"] + 1)
+            ),
+        ]
+        original_sparse_attention = dsa_module._run_sparse_attention
+
+        def counted_sparse_attention(*args, **kwargs):
+            call_counts["sparse"] += 1
+            return original_sparse_attention(*args, **kwargs)
+
+        monkeypatch.setattr(dsa_module, "_run_sparse_attention", counted_sparse_attention)
+
+        real_inputs = [
+            torch.randn(
+                total_tokens,
+                1,
+                config.hidden_size,
+                dtype=torch.bfloat16,
+                device="cuda",
+                requires_grad=True,
+            )
+            for _ in range(config.mtp_num_layers)
+        ]
+        native_inputs = [value.detach().clone().requires_grad_(True) for value in real_inputs]
+        output_grads = [torch.randn_like(value) for value in real_inputs]
+
+        real_outputs = []
+        native_outputs = []
+        shared_latent_kv = None
+        shared_sparse_index = None
+        native_key = native_topk = None
+        forward_state = get_forward_sharing_state(
+            packed_seq_params=packed_seq_params, attention_mask=attention_mask, config=config
+        )
+        with mtp_repeated_sharing_lifetime(forward_state, config.num_layers + 1) as sharing_call:
+            for depth in range(config.mtp_num_layers):
+                sharing_call[config.num_layers + 1] = depth == 0
+                real_output, _ = real_attention(
+                    real_inputs[depth],
+                    attention_mask=attention_mask,
+                    packed_seq_params=packed_seq_params,
+                )
+                if depth == 0:
+                    shared_payload = forward_state.get(dsa_module._DSAMTPRepeatedSharingPayload)
+                    if shares_latent_kv:
+                        shared_latent_kv = shared_payload.latent_kv_by_layer[config.num_layers + 1]
+                    if shares_sparse_attention_index:
+                        shared_sparse_index = shared_payload.topk_by_layer[config.num_layers + 1]
+                real_outputs.append(real_output)
+
+                native_output, current_key, current_topk = native_attention.forward_depth(
+                    native_inputs[depth], positions, valid, native_key, native_topk
+                )
+                if depth == 0:
+                    if shares_latent_kv:
+                        native_key = current_key
+                    if shares_sparse_attention_index:
+                        native_topk = current_topk
+                native_outputs.append(native_output)
+
+        assert forward_state.get(_MTPRepeatedSharingPayload) is None
+
+        assert (shared_latent_kv is not None) is shares_latent_kv
+        assert (shared_sparse_index is not None) is shares_sparse_attention_index
+        if shared_latent_kv is not None:
+            assert shared_latent_kv.grad_fn is not None
+        for output, reference in zip(real_outputs, native_outputs):
+            _assert_similarity(output, reference)
+
+        torch.autograd.backward(real_outputs, output_grads)
+        torch.autograd.backward(native_outputs, output_grads)
+        for real_input, native_input in zip(real_inputs, native_inputs):
+            _assert_similarity(real_input.grad, native_input.grad)
+
+        real_parameters = dict(real_attention.named_parameters())
+        for native_name, real_name in native_attention._PARAMETER_MAP.items():
+            native_parameter = getattr(native_attention, native_name)
+            real_parameter = real_parameters[real_name]
+            if native_parameter.grad is None or real_parameter.grad is None:
+                assert native_parameter.grad is None and real_parameter.grad is None
+                continue
+            _assert_similarity(real_parameter.grad, native_parameter.grad)
+
+        expected_depths = config.mtp_num_layers
+        assert call_counts == {
+            "q": expected_depths,
+            "kv": 1 if shares_latent_kv else expected_depths,
+            "indexer": 1 if shares_sparse_attention_index else expected_depths,
+            "sparse": expected_depths,
+        }
+        for hook in hooks:
+            hook.remove()
+    finally:
+        Utils.destroy_model_parallel()
+
+
+@pytest.mark.launch_on_gb200
+def test_tp2_cp2_reuses_canonical_cp_global_latent_kv(monkeypatch):
+    """A consumer must not gather or reorder the already-canonical source key again."""
+    if Utils.world_size < 4:
+        pytest.skip("TP2+CP2 MTP latent-KV sharing requires at least four distributed ranks")
+    Utils.initialize_model_parallel(tensor_model_parallel_size=2, context_parallel_size=2)
+    try:
+        model_parallel_cuda_manual_seed(3917)
+        model_parallel_rank = (
+            parallel_state.get_context_parallel_rank()
+            * parallel_state.get_tensor_model_parallel_world_size()
+            + parallel_state.get_tensor_model_parallel_rank()
+        )
+        torch.manual_seed(3917 + model_parallel_rank)
+        torch.cuda.manual_seed(3917 + model_parallel_rank)
+
+        config = _make_config(
+            mtp_num_layers=2,
+            tensor_model_parallel_size=2,
+            context_parallel_size=2,
+            sequence_parallel=True,
+            cp_comm_type="all_gather",
+            mtp_repeated_layer_shared_components=[LATENT_KV],
+        )
+        attention_spec = get_dsa_module_spec_for_backend(config, backend=TESpecProvider())
+        attention = (
+            build_module(
+                attention_spec,
+                config=config,
+                layer_number=1,
+                cp_comm_type=config.cp_comm_type,
+                is_mtp_layer=True,
+            )
+            .bfloat16()
+            .cuda()
+        )
+        core_attention = attention.core_attention
+        gather_counts = {"tp": 0, "cp": 0}
+        sparse_key_pointers = []
+        original_sparse_attention = dsa_module._run_sparse_attention
+
+        def observed_sparse_attention(*args, **kwargs):
+            sparse_key_pointers.append(kwargs["key"].data_ptr())
+            return original_sparse_attention(*args, **kwargs)
+
+        monkeypatch.setattr(dsa_module, "_run_sparse_attention", observed_sparse_attention)
+        original_gather = dsa_module.gather_from_sequence_parallel_region
+
+        def observed_gather(tensor, group=None, **kwargs):
+            if tensor.size(-1) == config.kv_lora_rank + config.qk_pos_emb_head_dim:
+                if group is parallel_state.get_tensor_model_parallel_group():
+                    gather_counts["tp"] += 1
+                elif group is parallel_state.get_context_parallel_group():
+                    gather_counts["cp"] += 1
+            return original_gather(tensor, group=group, **kwargs)
+
+        monkeypatch.setattr(dsa_module, "gather_from_sequence_parallel_region", observed_gather)
+
+        local_tokens = 8
+        cp_local_tokens = local_tokens * config.tensor_model_parallel_size
+        global_tokens = cp_local_tokens * config.context_parallel_size
+        local_heads = config.num_attention_heads // config.tensor_model_parallel_size
+        absorbed_dim = config.kv_lora_rank + config.qk_pos_emb_head_dim
+        producer_query = torch.randn(
+            local_tokens, 1, local_heads, absorbed_dim, dtype=torch.bfloat16, device="cuda"
+        )
+        producer_key = torch.randn(
+            local_tokens,
+            1,
+            1,
+            absorbed_dim,
+            dtype=torch.bfloat16,
+            device="cuda",
+            requires_grad=True,
+        )
+        producer_x = torch.randn(
+            local_tokens, 1, config.hidden_size, dtype=torch.bfloat16, device="cuda"
+        )
+        producer_qr = torch.randn(
+            local_tokens, 1, config.q_lora_rank, dtype=torch.bfloat16, device="cuda"
+        )
+        consumer_query = torch.randn_like(producer_query, requires_grad=True)
+        consumer_x = torch.randn_like(producer_x)
+        consumer_qr = torch.randn_like(producer_qr)
+        up_v_weight = attention._get_v_up_weight()
+
+        forward_state = get_forward_sharing_state(config=config)
+        with mtp_repeated_sharing_lifetime(forward_state, config.num_layers + 1) as sharing_call:
+            sharing_call[config.num_layers + 1] = True
+            core_attention(
+                query=producer_query,
+                key=producer_key,
+                value=None,
+                attention_mask=None,
+                x=producer_x,
+                qr=producer_qr,
+                attn_mask_type=AttnMaskType.causal,
+                up_v_weight=up_v_weight,
+            )
+            shared_latent_kv = forward_state.get(
+                dsa_module._DSAMTPRepeatedSharingPayload
+            ).latent_kv_by_layer[config.num_layers + 1]
+            sharing_call[config.num_layers + 1] = False
+            consumer_output = core_attention(
+                query=consumer_query,
+                key=None,
+                value=None,
+                attention_mask=None,
+                x=consumer_x,
+                qr=consumer_qr,
+                attn_mask_type=AttnMaskType.causal,
+                up_v_weight=up_v_weight,
+            )
+        assert forward_state.get(_MTPRepeatedSharingPayload) is None
+        consumer_output.float().square().mean().backward()
+
+        assert shared_latent_kv.size(0) == global_tokens
+        assert producer_key.grad is not None and producer_key.grad.float().norm() > 0
+        assert consumer_query.grad is not None and consumer_query.grad.float().norm() > 0
+        assert gather_counts == {"tp": 1, "cp": 1}
+        assert sparse_key_pointers == [shared_latent_kv.data_ptr()] * 2
+    finally:
+        Utils.destroy_model_parallel()

--- a/tests/unit_tests/transformer/test_forward_sharing.py
+++ b/tests/unit_tests/transformer/test_forward_sharing.py
@@ -1,0 +1,437 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import pytest
+
+from megatron.core.transformer.forward_sharing import (
+    ForwardSharingState,
+    forward_sharing_lifetime,
+    get_forward_sharing_state,
+    is_forward_sharing_enabled,
+    preserve_forward_sharing_for_checkpoint,
+)
+
+
+@dataclass
+class _FirstPayload:
+    value: int = 1
+
+
+@dataclass
+class _SecondPayload:
+    value: int = 2
+
+
+@pytest.mark.parametrize(
+    ("fields", "expected"),
+    [
+        ({}, False),
+        ({"dsa_indexer_topk_freq": None}, False),
+        ({"dsa_indexer_topk_freq": 0}, False),
+        ({"dsa_indexer_topk_freq": 1}, False),
+        ({"dsa_indexer_topk_freq": 2}, True),
+        ({"dsa_indexer_topk_freq": 4}, True),
+        ({"mtp_repeated_layer_shared_components": None}, False),
+        ({"mtp_repeated_layer_shared_components": []}, False),
+        ({"mtp_repeated_layer_shared_components": ["sparse_attention_index"]}, True),
+        ({"mtp_repeated_layer_shared_components": ["latent_kv"]}, True),
+        ({"mtp_repeated_layer_shared_components": ["latent_kv", "sparse_attention_index"]}, True),
+        ({"dsa_indexer_topk_freq": 1, "mtp_repeated_layer_shared_components": ["latent_kv"]}, True),
+    ],
+)
+def test_forward_sharing_enablement(fields, expected):
+    assert is_forward_sharing_enabled(SimpleNamespace(**fields)) is expected
+
+
+def test_carrier_priority_and_reuse():
+    packed_seq_params = SimpleNamespace()
+    attention_mask = SimpleNamespace()
+    config = SimpleNamespace()
+
+    packed_state = get_forward_sharing_state(packed_seq_params, attention_mask, config)
+    assert packed_state is get_forward_sharing_state(packed_seq_params, attention_mask, config)
+    assert packed_state is packed_seq_params._forward_sharing_state
+    assert not hasattr(attention_mask, "_forward_sharing_state")
+    assert not hasattr(config, "_forward_sharing_state")
+
+    mask_state = get_forward_sharing_state(None, attention_mask, config)
+    assert mask_state is attention_mask._forward_sharing_state
+    assert mask_state is not packed_state
+    assert not hasattr(config, "_forward_sharing_state")
+
+    config_state = get_forward_sharing_state(config=config)
+    assert config_state is config._forward_sharing_state
+    assert config_state is not mask_state
+
+
+def test_carrier_validation():
+    with pytest.raises(ValueError, match="forward sharing requires"):
+        get_forward_sharing_state()
+
+    carrier = SimpleNamespace(_forward_sharing_state=object())
+    with pytest.raises(TypeError, match="must contain a ForwardSharingState"):
+        get_forward_sharing_state(config=carrier)
+
+
+def test_global_typed_registry():
+    state = ForwardSharingState()
+
+    assert state.get(_FirstPayload) is None
+    first = state.get_or_create(_FirstPayload)
+    second = state.get_or_create(_SecondPayload)
+    assert first is state.get_or_create(_FirstPayload)
+    assert second is state.get(_SecondPayload)
+
+    state.clear(_FirstPayload)
+    assert state.get(_FirstPayload) is None
+    assert state.get(_SecondPayload) is second
+
+    state.clear()
+    assert state.get(_SecondPayload) is None
+    with pytest.raises(TypeError, match="payload_type must be a type"):
+        state.get("not-a-type")
+
+
+def test_snapshot_copies_payloads_without_changing_type_keys():
+    state = ForwardSharingState()
+    first = state.get_or_create(_FirstPayload)
+    second = state.get_or_create(_SecondPayload)
+    snapshot = state.snapshot()
+    assert set(state._entries) == {_FirstPayload, _SecondPayload}
+    assert snapshot.get(_FirstPayload) is not first
+    assert snapshot.get(_SecondPayload) is not second
+    first.value = 9
+    state.clear(_FirstPayload)
+    assert snapshot.get(_FirstPayload).value == 1
+    assert state.get(_SecondPayload) is second
+
+
+def test_generic_helpers_treat_config_as_an_opaque_carrier():
+    class Carrier:
+        def __getattr__(self, name):
+            if name == "_forward_sharing_state":
+                raise AttributeError(name)
+            raise AssertionError(f"Generic sharing code inspected config field {name}")
+
+    carrier = Carrier()
+
+    def consumer(attention_mask):
+        state = get_forward_sharing_state(attention_mask=attention_mask, config=carrier)
+        return state.get(_FirstPayload).value
+
+    wrapped = preserve_forward_sharing_for_checkpoint(consumer, None, carrier, attention_mask_arg=0)
+    with forward_sharing_lifetime(config=carrier) as state:
+        state.get_or_create(_FirstPayload).value = 7
+        assert wrapped(None) == 7
+    assert state._entries == {}
+    assert wrapped(None) == 7
+    assert state._entries == {}
+
+
+@pytest.mark.parametrize("carrier_kind", ["mask", "packed", "config"])
+@pytest.mark.parametrize("fail", [False, True])
+def test_forward_lifetime_clears_reused_carriers_and_exceptions(carrier_kind, fail):
+    config = SimpleNamespace()
+    packed = SimpleNamespace() if carrier_kind == "packed" else None
+    mask = SimpleNamespace() if carrier_kind == "mask" else None
+    state = get_forward_sharing_state(packed, mask, config)
+    state.get_or_create(_FirstPayload).value = -1
+    for _ in range(2):
+        try:
+            with forward_sharing_lifetime(packed, mask, config) as current:
+                assert current is state
+                assert state.get(_FirstPayload) is None
+                payload = state.get_or_create(_FirstPayload)
+                with forward_sharing_lifetime(packed, mask, config):
+                    assert state.get(_FirstPayload) is payload
+                assert state.get(_FirstPayload) is payload
+                if fail:
+                    raise RuntimeError("forward failed")
+        except RuntimeError as error:
+            assert fail and str(error) == "forward failed"
+        assert not state.active
+        assert state._entries == {}
+
+
+def test_model_boundary_preserves_decoder_payload_until_mtp():
+    class Model:
+        config = SimpleNamespace(dsa_indexer_topk_freq=4)
+
+        def decoder(self, attention_mask, packed_seq_params=None):
+            with forward_sharing_lifetime(packed_seq_params, attention_mask, self.config):
+                state = get_forward_sharing_state(packed_seq_params, attention_mask, self.config)
+                state.get_or_create(_FirstPayload).value = 42
+
+        def forward(self, attention_mask, packed_seq_params=None):
+            with forward_sharing_lifetime(packed_seq_params, attention_mask, self.config):
+                self.decoder(attention_mask, packed_seq_params)
+                state = get_forward_sharing_state(packed_seq_params, attention_mask, self.config)
+                assert state.get(_FirstPayload).value == 42
+
+    model = Model()
+    mask = SimpleNamespace()
+    model.forward(mask)
+    assert get_forward_sharing_state(attention_mask=mask)._entries == {}
+
+
+@pytest.mark.parametrize("nested", [False, True])
+@pytest.mark.parametrize("fail", [False, True])
+@pytest.mark.parametrize("recompute", [None, "full"])
+def test_block_lifetime_wraps_layer_execution(monkeypatch, nested, fail, recompute):
+    from contextlib import nullcontext
+
+    from megatron.core.transformer import transformer_block
+
+    monkeypatch.setattr(transformer_block, "get_transformer_layer_offset", lambda *_: 0)
+    monkeypatch.setattr(transformer_block, "get_pg_rank", lambda *_: 0)
+    config = SimpleNamespace(
+        dsa_indexer_topk_freq=4,
+        sequence_parallel=False,
+        fp8=None,
+        fp4=None,
+        enable_hyper_connections=False,
+        recompute_granularity=recompute,
+        cpu_offloading=False,
+    )
+    state = get_forward_sharing_state(config=config)
+    events = []
+
+    def preprocess(hidden):
+        assert state.active is nested
+        events.append("preprocess")
+        return hidden
+
+    def layer(hidden_states, **_kwargs):
+        assert state.active
+        events.append("layer")
+        state.get_or_create(_FirstPayload).value = 42
+        if fail:
+            raise RuntimeError("layer failed")
+        return hidden_states, None
+
+    def postprocess(hidden, **_kwargs):
+        assert state.active is nested
+        assert (state.get(_FirstPayload) is not None) is nested
+        events.append("postprocess")
+        return hidden, None
+
+    block = SimpleNamespace(
+        config=config,
+        pg_collection=SimpleNamespace(pp=None),
+        vp_stage=None,
+        training=True,
+        layers=[layer],
+        offload_context=nullcontext(),
+        preprocess_for_layer_schedule=preprocess,
+        postprocess_for_layer_schedule=postprocess,
+        _build_mhc_recompute_layer_plan=lambda _: ([None], [False]),
+        _finalize_mhc_recompute_layer=lambda **_: None,
+        _checkpointed_forward=lambda **kwargs: layer(**kwargs)[0],
+    )
+    outer_lifetime = forward_sharing_lifetime(config=config) if nested else nullcontext()
+    with outer_lifetime:
+        if fail:
+            with pytest.raises(RuntimeError, match="layer failed"):
+                transformer_block.TransformerBlock.forward(block, 7, None)
+        else:
+            assert transformer_block.TransformerBlock.forward(block, 7, None) == 7
+        assert state.active is nested
+        if nested:
+            assert state.get(_FirstPayload).value == 42
+        else:
+            assert state._entries == {}
+    assert not state.active
+    assert state._entries == {}
+    assert events == (["preprocess", "layer"] if fail else ["preprocess", "layer", "postprocess"])
+
+
+@pytest.mark.parametrize("carrier_kind", ["mask", "packed", "config"])
+@pytest.mark.parametrize("boundary", ["helper", "core_attn"])
+def test_checkpoint_pins_indices_across_cleanup_and_interleaved_forwards(
+    monkeypatch, carrier_kind, boundary
+):
+    import torch
+
+    from megatron.core import tensor_parallel
+    from megatron.core.transformer.enums import AttnMaskType
+    from megatron.core.transformer.experimental_attention_variant.absorbed_mla import (
+        AbsorbedMLASelfAttention,
+    )
+    from megatron.core.transformer.experimental_attention_variant.dsa import _DSAIndexSharingPayload
+
+    monkeypatch.setattr(
+        tensor_parallel.random, "_get_all_rng_states", lambda: (torch.get_rng_state(),)
+    )
+    monkeypatch.setattr(tensor_parallel.random, "_set_all_rng_states", torch.set_rng_state)
+    config = SimpleNamespace(dsa_indexer_topk_freq=4)
+    packed = SimpleNamespace() if carrier_kind == "packed" else None
+    mask = torch.zeros(1) if carrier_kind == "mask" else None
+    state = get_forward_sharing_state(packed, mask, config)
+    calls = []
+
+    def consumer(hidden, attention_mask):
+        current = get_forward_sharing_state(packed, attention_mask, config)
+        indices = current.get(_DSAIndexSharingPayload).topk_by_layer[1]
+        calls.append(int(indices.item()))
+        return hidden.index_select(0, indices).square()
+
+    def core_attention(_query, _key, *, x, attention_mask, **_kwargs):
+        return consumer(x, attention_mask)
+
+    outputs, inputs = [], []
+    for source_index in [0, 1]:
+        with forward_sharing_lifetime(packed, mask, config):
+            payload = state.get_or_create(_DSAIndexSharingPayload)
+            payload.topk_by_layer[1] = torch.tensor([source_index])
+            hidden = torch.tensor([2.0, 3.0], requires_grad=True)
+            if boundary == "helper":
+                wrapped = preserve_forward_sharing_for_checkpoint(
+                    consumer, packed, config, attention_mask_arg=1
+                )
+                output = tensor_parallel.checkpoint(wrapped, False, hidden, mask)
+            else:
+                attention = SimpleNamespace(
+                    config=config, core_attention=core_attention, attn_mask_type=AttnMaskType.causal
+                )
+                output = AbsorbedMLASelfAttention._checkpointed_attention_forward(
+                    attention,
+                    hidden.detach(),
+                    hidden.detach(),
+                    hidden,
+                    hidden.detach(),
+                    mask,
+                    hidden.detach(),
+                    packed_seq_params=packed,
+                )
+            outputs.append(output)
+            inputs.append(hidden)
+            # Updating the live dictionary must not change this checkpoint's inputs.
+            payload.topk_by_layer[1] = torch.tensor([1 - source_index])
+        assert state._entries == {}
+    outputs[1].sum().backward()
+    outputs[0].sum().backward()
+    assert calls == [0, 1, 1, 0]
+    torch.testing.assert_close(inputs[0].grad, torch.tensor([4.0, 0.0]))
+    torch.testing.assert_close(inputs[1].grad, torch.tensor([0.0, 6.0]))
+    assert state._entries == {}
+
+
+@pytest.mark.parametrize("carrier_kind", ["mask", "packed", "config"])
+@pytest.mark.parametrize(
+    ("method", "chunk_size"), [("uniform", 1), ("uniform", 2), ("block", 1), ("block", 2)]
+)
+def test_block_checkpoint_preserves_cross_chunk_indices(
+    monkeypatch, carrier_kind, method, chunk_size
+):
+    import torch
+
+    from megatron.core import tensor_parallel
+    from megatron.core.transformer.experimental_attention_variant.dsa import _DSAIndexSharingPayload
+    from megatron.core.transformer.transformer_block import TransformerBlock
+
+    monkeypatch.setattr(
+        tensor_parallel.random, "_get_all_rng_states", lambda: (torch.get_rng_state(),)
+    )
+    monkeypatch.setattr(tensor_parallel.random, "_set_all_rng_states", torch.set_rng_state)
+    config = SimpleNamespace(
+        dsa_indexer_topk_freq=4,
+        recompute_method=method,
+        recompute_num_layers=chunk_size,
+        distribute_saved_activations=False,
+        fp8=None,
+        fp4=None,
+    )
+    packed = SimpleNamespace() if carrier_kind == "packed" else None
+    mask = torch.zeros(1) if carrier_kind == "mask" else None
+    state = get_forward_sharing_state(packed, mask, config)
+
+    def producer(hidden_states, attention_mask, context, **kwargs):
+        current = get_forward_sharing_state(kwargs["packed_seq_params"], attention_mask, config)
+        payload = current.get_or_create(_DSAIndexSharingPayload)
+        payload.topk_by_layer[1] = torch.tensor([int(hidden_states[0].item()) % 2])
+        return hidden_states * 2, context
+
+    def consumer(hidden_states, attention_mask, context, **kwargs):
+        current = get_forward_sharing_state(kwargs["packed_seq_params"], attention_mask, config)
+        indices = current.get(_DSAIndexSharingPayload).topk_by_layer[1]
+        return hidden_states.index_select(0, indices).square(), context
+
+    block = SimpleNamespace(
+        config=config,
+        num_layers_per_pipeline_rank=2,
+        _get_layer=lambda index: [producer, consumer][index],
+    )
+    inputs, outputs = [], []
+    for values in ([2.0, 3.0], [3.0, 4.0]):
+        hidden = torch.tensor(values, requires_grad=True)
+        with forward_sharing_lifetime(packed, mask, config):
+            output = TransformerBlock._checkpointed_forward(
+                block,
+                hidden,
+                attention_mask=mask,
+                context=None,
+                context_mask=None,
+                rotary_pos_emb=None,
+                attention_bias=None,
+                packed_seq_params=packed,
+                use_inner_quantization_context=False,
+            )
+        assert state._entries == {}
+        inputs.append(hidden)
+        outputs.append(output)
+    outputs[1].sum().backward()
+    outputs[0].sum().backward()
+    torch.testing.assert_close(inputs[0].grad, torch.tensor([16.0, 0.0]))
+    torch.testing.assert_close(inputs[1].grad, torch.tensor([0.0, 32.0]))
+    assert state._entries == {}
+
+
+def test_overlap_nodes_bind_plan_owned_payloads_and_release_them():
+    from megatron.core.models.common.model_chunk_schedule_plan import (
+        TransformerModelChunkSchedulePlan,
+    )
+    from megatron.core.models.gpt.fine_grained_callables import TransformerLayerNode
+
+    config = SimpleNamespace(dsa_indexer_topk_freq=4)
+    chunks = [
+        SimpleNamespace(
+            forward_sharing_state=ForwardSharingState(),
+            packed_seq_params=None,
+            attention_mask=None,
+            model=SimpleNamespace(config=config),
+        )
+        for _ in range(2)
+    ]
+
+    def component(node, value=None):
+        state = get_forward_sharing_state(config=node.chunk_state.model.config)
+        if value is not None:
+            state.get_or_create(_FirstPayload).value = value
+        return state.get(_FirstPayload).value
+
+    nodes = [SimpleNamespace(chunk_state=chunk, submodule=component) for chunk in chunks]
+    assert TransformerLayerNode.forward_impl(nodes[0], 11) == 11
+    assert TransformerLayerNode.forward_impl(nodes[1], 22) == 22
+    assert TransformerLayerNode.forward_impl(nodes[0]) == 11
+    assert not hasattr(config, "_forward_sharing_state")
+    plan = SimpleNamespace(
+        _model_chunk_state=chunks[0],
+        _recompute_segments=[],
+        pre_process=SimpleNamespace(),
+        post_process=None,
+    )
+    first_state = chunks[0].forward_sharing_state
+    TransformerModelChunkSchedulePlan.release_state(plan)
+    assert first_state._entries == {}
+    assert TransformerLayerNode.forward_impl(nodes[1]) == 22
+
+    def fail(_node):
+        raise RuntimeError("failed schedule node")
+
+    nodes[1].submodule = fail
+    with pytest.raises(RuntimeError, match="failed schedule node"):
+        TransformerLayerNode.forward_impl(nodes[1])
+    assert chunks[1].forward_sharing_state._entries == {}
+    assert not hasattr(config, "_forward_sharing_state")


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Introduce a shared infrastructure for cooperating components to exchange per-forward payloads, migrate existing DSA cross-layer IndexShare onto it, and use it to implement independently selectable index and latent-KV sharing across repeated MTP prediction depths.

## Implementation and review order

The PR is organized into three commits:

1. **Generic forward sharing state.** Introduce `ForwardSharingState`, a type-keyed payload registry with explicit lifetime management. Payloads define their own tensor layout and per-layer indexing. State is carried through existing packed-sequence parameters, attention masks, or config, without adding a new Transformer-layer forward argument. Outer scopes clear payloads on exit; nested scopes join the active lifetime. Temporary state binding and per-checkpoint snapshots preserve the sharing records needed by existing checkpoint/schedule paths. Ordinary DSA cross-layer IndexShare is migrated to this infrastructure.
2. **Repeated MTP index sharing.** Reuse depth-0 sparse-attention indices at later depths of the same repeated physical MTP layer. Ordinary IndexShare still determines how depth 0 obtains its indices; repeated-MTP sharing controls their reuse at subsequent depths. DSA owns the tensor payload, while MTP controls source/consumer sequencing.
3. **Repeated MTP latent-KV sharing.** Independently reuse depth-0 post-RoPE, post-TP/CP-layout latent KV, avoiding repeated KV computation and CP gathering. Shared KV stays connected to autograd so consumer gradients accumulate into the source projection.

The common infrastructure manages payload lookup, binding, and cleanup; it does not prescribe DSA tensor layouts or make arbitrary sharing/recompute combinations safe.

## Feature scope and compatibility

Set `mtp_use_repeated_layer: true`, `mtp_num_layers > 1`, and select `"sparse_attention_index"`, `"latent_kv"`, or both through `mtp_repeated_layer_shared_components`. Repeated-MTP sharing currently supports the DSA GPT MTP path only. Queries and sparse attention remain query-dependent and are computed at every depth. This is training-time activation reuse, not inference KV caching.

- Existing selective recompute of `mlp`, `moe`, `moe_act`, `shared_experts`, `layernorm`, and `mhc` remains supported, subject to those modules' existing requirements.
- `mla_up_proj` recompute supports index-only sharing, but not latent-KV sharing in this PR.
- Full recompute and selective `core_attn` recompute remain unsupported with repeated-MTP sharing. Set `recompute_modules` explicitly, since selective recompute defaults to `core_attn`.
- Attention CUDA graph capture remains unsupported with repeated-MTP sharing; MoE-only scopes remain compatible. Unsupported inference and hybrid-layer combinations are rejected explicitly.

The dependent draft #7107 extends repeated-MTP recompute compatibility; it is not required for the ordinary IndexShare checkpoint handling or the selective combinations supported here.

## Issue tracking

Related to #6392.

## Testing

- Focused local CPU regression suite at `90a3a3fdb`: **172 passed**, with 6 GPU-marked cases deselected.
- Coverage includes state binding and cleanup, nested lifetimes, checkpoint snapshots, ordinary IndexShare, independently selected repeated-MTP components, and compatibility validation.
- Additional tests cover CP layouts, forward/gradient parity, TP/SP layout handling, one-time KV/CP gathering, and PP/VPP placement. GPU execution is not implied by the local CPU result above.
- `git diff --check`, Black, isort, pylint, and ruff pass. The formatter's advisory mypy step still reports missing dependencies and type errors; this is not a clean type-check result.
- Results from the separate recompute follow-up are not included in this PR's test counts.

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code
- [x] I have added relevant documentation
- [x] I have run the autoformatter on this PR

## Main PR

Target-main counterpart: [NVIDIA/Megatron-LM#6874](https://github.com/NVIDIA/Megatron-LM/pull/6874).
