### PR TITLE
[lite] Add MagiAttention as an optional core-attention backend for qwen3_moe

### DIFF
--- a/experimental/lite/README.md
+++ b/experimental/lite/README.md
@@ -128,6 +128,7 @@ bash experimental/lite/examples/bench/scripts/run_qwen35_correctness_pair.sh
 
 - [Architecture](docs/architecture.md)
 - [Runtime](docs/runtime.md)
+- [MagiAttention](docs/magi_attention.md)
 - [Models](docs/models.md)
 - [Porting Notes](docs/porting.md)
 - [Skills](skills/README.md)

--- a/experimental/lite/docs/magi_attention.md
+++ b/experimental/lite/docs/magi_attention.md
@@ -1,0 +1,99 @@
+# MagiAttention in Megatron Lite
+
+Megatron Lite can use [MagiAttention](https://github.com/SandAI-org/MagiAttention)
+as the distributed core-attention backend for the native `qwen3_moe` model.
+Lite continues to own embeddings, QKV/output projections, Q/K normalization,
+RoPE, MoE, and the training runtime. MagiAttention owns the load-balanced token
+dispatch and context-parallel attention communication.
+
+MagiAttention is an optional, architecture-specific CUDA dependency and is not
+installed with Megatron Lite. Install it for the target GPU before selecting the
+backend.
+
+In the GA=8 Qwen3-30B-A3B heavy-tail THD benchmark, MagiAttention improved
+end-to-end training throughput by 31.88% over Transformer Engine.
+
+```python
+from megatron.lite.runtime import MegatronLiteConfig, RuntimeConfig, create_runtime
+from megatron.lite.runtime.contracts import ParallelConfig
+
+backend_cfg = MegatronLiteConfig(
+    model_name="qwen3_moe",
+    attention_backend_override="magi",
+    parallel=ParallelConfig(tp=2, cp=4),
+    impl_cfg={"use_thd": True},
+)
+runtime = create_runtime(
+    RuntimeConfig(backend="mlite", hf_path="/models/Qwen3-MoE", backend_cfg=backend_cfg)
+)
+handle = runtime.build_model()
+```
+
+There are deliberately no user-facing tuning knobs for this backend: the
+only user decision is ``attention_backend_override="magi"``. Chunk sizing and
+overlap staging are decided automatically (magi derives the chunk size and
+its dynamic overlap solver picks the staging per microbatch), and any locally
+calibrated policy belongs in ``resolve_magi_attention_config`` — the single
+policy seam in the backend primitive. Future attention backends must follow
+the same rule: backend tuning lives in the backend's primitive, never as
+parameters on model constructors or user config surfaces.
+
+The batch protocol pads each sequence to Lite's TP/CP THD alignment and then
+applies one MagiAttention dispatch plan to token IDs, labels, loss masks, and
+position IDs before embedding and QKV projection. The runtime key stays with
+that microbatch for activation recomputation. Q/K RoPE is indexed with the
+dispatched positions, and MagiAttention output remains in the same local order
+for the output projection and loss.
+
+A chunk size chosen by magi (or by a calibration policy) acts as a cap: if
+it would make MagiAttention add a second tail pad, Lite lowers it to the
+nearest padding-free divisor of the per-CP-rank token count, keeping every CP
+shard equal with no extra loss-bearing tokens.
+
+## Hot-swapping backends
+
+The te and magi core-attention backends are interchangeable on a built model:
+``model.set_attention_backend("magi"|"te")`` swaps them in place. Both
+backends are parameter-free, so the swap leaves every parameter and buffer —
+and therefore the optimizer state — untouched; te-trained checkpoints resume
+under magi and vice versa. The only state_dict difference is TE's internal
+``_extra_state`` metadata entries (empty of trainable content in bf16), which
+exist only while the te backend is selected; cross-backend restore must
+tolerate their presence or absence. The batch protocol re-reads the backend for every
+microbatch, so the swap takes effect on the next step; only switch at step
+boundaries (never between a forward and its recompute/backward). Switching to
+magi revalidates its scope (CP>1, PP=1, no MTP/MRoPE).
+
+The initial supported scope is bf16 Qwen3-MoE training with packed THD batches,
+full causal GQA, static CP, TP, and activation recomputation. It requires
+`CP > 1`, `PP = VPP = 1`, and `use_thd=True`.
+
+Qwen3.5, MTP, MRoPE, pipeline/virtual-pipeline parallelism, custom attention
+masks, and inference are rejected or outside the initial integration. Qwen3.5
+is excluded because its linear-attention layers require an order-preserving CP
+layout that is incompatible with MagiAttention's load-balanced permutation.
+
+## Reproducible test environment (Hopper and Blackwell)
+
+The Lite test helpers build MagiAttention v1.1.1 in an isolated, persistent
+venv and run an upstream kernel reference case, the operator-level attention
+test (`tests/smoke/primitive/test_magi_attention_operator.py`: identical
+global varlen Q/K/V through dispatch → core attention → undispatch versus a
+per-sequence fp32 SDPA causal reference, forward and dQ/dK/dV, with
+tolerances anchored to the bf16 SDPA noise floor), and the Lite Qwen3-MoE
+forward/backward/undispatch E2E. The compute capability is auto-detected
+(override with `MAGI_ATTENTION_BUILD_COMPUTE_CAPABILITY=90|100`): sm100
+(Blackwell) builds the FA4 `flash_attn_cute` kernel backend, while sm90
+(Hopper, e.g. H100) prebuilds MagiAttention's native FFA kernels and the
+runner selects the matching `MAGI_ATTENTION_KERNEL_BACKEND` automatically:
+
+```bash
+export MAGI_ATTENTION_SOURCE=/path/to/MagiAttention-v1.1.1
+export MAGI_ATTENTION_VENV=/path/to/magi_attention_test_env_v1.1.1/venv
+experimental/lite/tests/setup_magi_attention_env.sh
+
+# Run this inside a single-node 4-GPU allocation.
+MLITE_MAGI_NPROC=4 experimental/lite/tests/run_magi_attention_e2e.sh all
+```
+
+The runner also accepts `upstream` or `lite` to execute one half of the suite.

--- a/experimental/lite/megatron/lite/model/protocol_utils.py
+++ b/experimental/lite/megatron/lite/model/protocol_utils.py
@@ -12,11 +12,14 @@ own pair.
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import Any
 
 import torch
+
 from megatron.lite.primitive.parallel import ParallelState
 from megatron.lite.primitive.parallel.thd import (
+    ThdPackMeta,
     pack_nested_thd,
     parallel_state_from_model,
     prepare_packed_thd_kwargs_for_context_parallel,
@@ -31,6 +34,19 @@ from megatron.lite.runtime.contracts.loss import get_loss_context
 
 def _parallel_state(model) -> ParallelState:
     return parallel_state_from_model(model) or ParallelState()
+
+
+def _model_attribute(model, name: str):
+    """Read an attribute through optional distributed model wrappers."""
+
+    current = model
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if hasattr(current, name):
+            return getattr(current, name)
+        current = getattr(current, "module", None)
+    return None
 
 
 def nested_from_packed(tensor: torch.Tensor | None, seq_lens: torch.Tensor):
@@ -87,6 +103,98 @@ def pack_thd_forward_kwargs(model, batch: PackedBatch) -> dict[str, Any]:
     }
     prepare_packed_thd_kwargs_for_context_parallel(model, kwargs)
     return kwargs
+
+
+_MAGI_RUNTIME_KEY = "_mlite_magi_runtime_key"
+
+
+def pack_magi_forward_kwargs(model, batch: PackedBatch) -> dict[str, Any]:
+    """Pad a THD batch, then apply MagiAttention's load-balanced CP dispatch.
+
+    Dispatch happens on token IDs and all aligned targets before embeddings and
+    QKV projection. The exact runtime key is carried by ``PackedSeqParams`` so
+    recomputation reuses the same token permutation.
+    """
+
+    from megatron.lite.primitive.modules.attention.magi import (
+        build_magi_attention_runtime_key,
+        dispatch_magi_attention_tensor,
+    )
+
+    ps = _parallel_state(model)
+    if ps.cp_size <= 1 or ps.cp_group is None:
+        raise ValueError("MagiAttention batch dispatch requires CP>1 and an explicit cp_group.")
+    model_cfg = _model_attribute(model, "config")
+    if model_cfg is None:
+        raise ValueError("The model is missing its architecture config.")
+    if model_cfg.num_attention_heads % ps.tp_size != 0:
+        raise ValueError("MagiAttention query heads must be divisible by tensor parallel size.")
+    if model_cfg.num_key_value_heads % ps.tp_size != 0:
+        raise ValueError("MagiAttention KV heads must be divisible by tensor parallel size.")
+
+    seq_lens = batch.seq_lens
+    packed = pack_nested_thd(
+        nested_from_packed(batch.input_ids, seq_lens),
+        tp_size=ps.tp_size,
+        cp_size=ps.cp_size,
+        cp_rank=ps.cp_rank,
+        cp_group=ps.cp_group,
+        split_cp=False,
+        labels=nested_from_packed(batch.labels, seq_lens),
+        roll_labels=batch.labels is not None,
+        loss_mask=nested_from_packed(batch.loss_mask, seq_lens),
+        roll_loss_mask=batch.loss_mask is not None,
+    )
+    # No per-model tuning is threaded through: the primitive's automatic
+    # behaviour (and its resolve_magi_attention_config calibration seam)
+    # fully owns chunk sizing and overlap staging.
+    runtime_key = build_magi_attention_runtime_key(
+        packed.cu_seqlens_padded,
+        num_heads_q=model_cfg.num_attention_heads // ps.tp_size,
+        num_heads_kv=model_cfg.num_key_value_heads // ps.tp_size,
+        head_dim=model_cfg.head_dim,
+        cp_group=ps.cp_group,
+    )
+
+    def dispatch_row(tensor: torch.Tensor | None) -> torch.Tensor | None:
+        if tensor is None:
+            return None
+        if tensor.dim() != 2 or tensor.size(0) != 1:
+            raise ValueError(
+                f"MagiAttention expects packed token rows shaped [1, tokens], got {tensor.shape}."
+            )
+        return dispatch_magi_attention_tensor(tensor[0], runtime_key).unsqueeze(0)
+
+    input_ids = dispatch_row(packed.input_ids)
+    if input_ids is None:
+        raise ValueError("MagiAttention requires input_ids.")
+    if input_ids.size(1) % ps.tp_size != 0:
+        raise ValueError(
+            f"MagiAttention dispatched {input_ids.size(1)} local tokens, which is not "
+            f"divisible by TP={ps.tp_size}. Align the packed batch to the TP/CP "
+            "grid, or encode a chunk policy in resolve_magi_attention_config."
+        )
+
+    max_seqlen = int(packed.padded_lengths.max().item()) if packed.padded_lengths.numel() else 0
+    packed_seq_params = PackedSeqParams(
+        qkv_format="magi",
+        cu_seqlens_q=packed.cu_seqlens_padded,
+        cu_seqlens_kv=packed.cu_seqlens_padded,
+        max_seqlen_q=max_seqlen,
+        max_seqlen_kv=max_seqlen,
+        local_cp_size=ps.cp_size,
+        cp_group=ps.cp_group,
+        cp_rank=ps.cp_rank,
+        magi_runtime_key=runtime_key,
+    )
+    batch.extras[_MAGI_RUNTIME_KEY] = runtime_key
+    return {
+        "input_ids": input_ids,
+        "labels": dispatch_row(packed.labels),
+        "loss_mask": dispatch_row(packed.loss_mask),
+        "position_ids": dispatch_row(packed.position_ids),
+        "packed_seq_params": packed_seq_params,
+    }
 
 
 def unpack_thd_forward_output(model, batch: PackedBatch, output: torch.Tensor) -> torch.Tensor:
@@ -194,6 +302,32 @@ def pack_r3_replay_mask(
     ].bool()
 
 
+def unpack_magi_forward_output(model, batch: PackedBatch, output: torch.Tensor) -> torch.Tensor:
+    """Undispatch a MagiAttention output, then remove THD sequence padding."""
+
+    from megatron.lite.primitive.modules.attention.magi import undispatch_magi_attention_tensor
+
+    runtime_key = batch.extras.get(_MAGI_RUNTIME_KEY)
+    if runtime_key is None:
+        raise ValueError("MagiAttention output cannot be unpacked without its runtime key.")
+    if output.dim() >= 2 and output.size(0) == 1:
+        local_output = output[0]
+    elif output.dim() >= 2 and output.size(1) == 1:
+        local_output = output[:, 0]
+    else:
+        local_output = output
+    full_output = undispatch_magi_attention_tensor(local_output, runtime_key)
+
+    ps = _parallel_state(model)
+    meta: ThdPackMeta = thd_pack_meta(
+        batch.seq_lens, tp_size=ps.tp_size, cp_size=ps.cp_size, cp_group=ps.cp_group
+    )
+    # MagiAttention undispatch already reconstructed the full CP sequence.
+    return unpack_thd_to_nested(
+        full_output, replace(meta, cp_size=1, cp_group=None), contiguous=False
+    )
+
+
 def add_loss_context_kwargs(kwargs: dict[str, Any], *, include_return_log_probs: bool = False) -> None:
     loss_context = get_loss_context()
     if loss_context is None:
@@ -217,9 +351,11 @@ __all__ = [
     "add_cross_entropy_fusion",
     "add_loss_context_kwargs",
     "nested_from_packed",
+    "pack_magi_forward_kwargs",
     "pack_r3_replay_mask",
     "pack_routed_experts",
     "pack_thd_forward_kwargs",
     "set_cross_entropy_fusion",
+    "unpack_magi_forward_output",
     "unpack_thd_forward_output",
 ]

--- a/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_5/lite/protocol.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import torch
 import torch.nn as nn
+
 from megatron.lite.model.protocol_utils import (
     add_cross_entropy_fusion,
     add_loss_context_kwargs,
@@ -141,9 +142,7 @@ def _make_aux_loss_hook():
 def _build_dist_opt_optimizer(
     chunks, model_cfg: Qwen35Config, impl_cfg: ImplConfig, ps: ParallelState
 ):
-    from megatron.lite.primitive.optimizers.megatron_wrap import (
-        build_dist_opt_training_optimizer,
-    )
+    from megatron.lite.primitive.optimizers.megatron_wrap import build_dist_opt_training_optimizer
 
     return build_dist_opt_training_optimizer(
         chunks,
@@ -163,6 +162,11 @@ def build_model(model_cfg: Qwen35Config, *, impl_cfg: ImplConfig) -> ModelBundle
 
     if impl_cfg.use_deepep and (p.etp is not None and p.etp > 1):
         raise ValueError("use_deepep and etp>1 are mutually exclusive")
+    if impl_cfg.attention_backend_override == "magi":
+        raise ValueError(
+            "Qwen3.5 MagiAttention is not supported because its linear-attention layers "
+            "require an order-preserving CP layout. Use qwen3_moe for the initial backend."
+        )
 
     if impl_cfg.router_aux_loss_coef is not None:
         model_cfg.router_aux_loss_coef = impl_cfg.router_aux_loss_coef

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/model.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/model.py
@@ -126,6 +126,7 @@ class TransformerLayer(nn.Module):
         moe_act_recompute: bool = False,
         use_thd: bool = False,
         lora_config: LoraConfig | dict | None = None,
+        attention_backend: str = "te",
     ):
         super().__init__()
         self.layer_idx = layer_idx
@@ -146,6 +147,7 @@ class TransformerLayer(nn.Module):
             use_thd=use_thd,
             qkv_layout="mcore",
             lora_config=lora_config,
+            attention_backend=attention_backend,
         )
         self.mlp_norm = te.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.moe = MoELayer(
@@ -361,6 +363,7 @@ class Qwen3MoEModel(nn.Module):
         mtp_enable_train: bool = False,
         mtp_detach_encoder: bool = False,
         lora_config: LoraConfig | dict | None = None,
+        attention_backend: str = "te",
     ):
         super().__init__()
         self.config = config
@@ -368,6 +371,10 @@ class Qwen3MoEModel(nn.Module):
         self.fp8 = fp8
         self.mtp_enable_train = bool(mtp_enable and mtp_enable_train)
         self.mtp_loss_scaling_factor = config.mtp_loss_scaling_factor
+        # The backend name is the model's entire attention-backend knowledge.
+        # Backend tuning is deliberately not configurable here: policy lives in
+        # the backend primitive (see resolve_magi_attention_config for magi).
+        self.attention_backend = attention_backend
         self._input_tensor: torch.Tensor | None = None
         layout = build_pipeline_chunk_layout(config.num_hidden_layers, ps, vpp, vpp_chunk_id)
         self.layer_indices = layout.layer_indices
@@ -395,6 +402,7 @@ class Qwen3MoEModel(nn.Module):
                     moe_act_recompute=moe_act_recompute,
                     use_thd=use_thd,
                     lora_config=lora_config,
+                    attention_backend=attention_backend,
                 )
                 for idx in self.layer_indices
             ]
@@ -430,6 +438,27 @@ class Qwen3MoEModel(nn.Module):
         self.sp_params: list[nn.Parameter] = []
         if ps.tp_size > 1:
             self.sp_params = _collect_sp_grad_params(self)
+
+    def set_attention_backend(self, attention_backend: str) -> None:
+        """Hot-swap the attention backend on a built model.
+
+        Both backends are parameter-free, so the swap leaves parameters,
+        buffers, and optimizer state untouched: te-trained checkpoints resume
+        under magi and vice versa (only TE's ``_extra_state`` metadata keys
+        follow the te backend). The batch protocol re-reads
+        ``self.attention_backend`` for every microbatch, so the swap takes
+        effect on the next step. Only switch at step boundaries.
+        """
+        if attention_backend == "magi":
+            if self.ps.cp_size <= 1:
+                raise ValueError("MagiAttention requires context parallel size CP>1.")
+            if self.ps.pp_size != 1:
+                raise ValueError("MagiAttention supports PP=1 only.")
+            if self.config.num_nextn_predict_layers > 0:
+                raise ValueError("MagiAttention does not currently support MTP.")
+        for layer in self.layers:
+            layer.attn.set_attention_backend(attention_backend)
+        self.attention_backend = attention_backend
 
     def set_input_tensor(self, input_tensor):
         if isinstance(input_tensor, list):

--- a/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
+++ b/experimental/lite/megatron/lite/model/qwen3_moe/lite/protocol.py
@@ -26,11 +26,14 @@ from typing import Any
 
 import torch
 import torch.nn as nn
+
 from megatron.lite.model.protocol_utils import (
     add_cross_entropy_fusion,
     add_loss_context_kwargs,
+    pack_magi_forward_kwargs,
     pack_thd_forward_kwargs,
     set_cross_entropy_fusion,
+    unpack_magi_forward_output,
     unpack_thd_forward_output,
 )
 from megatron.lite.model.qwen3_moe.common import is_expert_param
@@ -89,6 +92,7 @@ class ImplConfig:
     mtp_use_repeated_layer: bool | None = None
     deterministic: bool = True
     lora: LoraConfig | dict | None = None
+    attention_backend_override: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -127,8 +131,23 @@ def build_model_config(source: str | Path | dict, **overrides) -> Qwen3MoEConfig
 # ---------------------------------------------------------------------------
 
 
+def _model_attention_backend(model: nn.Module) -> str:
+    current = model
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        backend = getattr(current, "attention_backend", None)
+        if backend is not None:
+            return str(backend)
+        current = getattr(current, "module", None)
+    return "te"
+
+
 def _forward_step(model: nn.Module, batch: PackedBatch) -> dict:
-    kwargs = pack_thd_forward_kwargs(model, batch)
+    if _model_attention_backend(model) == "magi":
+        kwargs = pack_magi_forward_kwargs(model, batch)
+    else:
+        kwargs = pack_thd_forward_kwargs(model, batch)
     add_loss_context_kwargs(kwargs, include_return_log_probs=True)
     add_cross_entropy_fusion(kwargs, model)
     return model(**kwargs)
@@ -140,7 +159,29 @@ def _forward_step_bshd(model: nn.Module, batch: PackedBatch) -> dict:
 
 
 def unpack_forward_output(model: nn.Module, batch: PackedBatch, output) -> Any:
+    if _model_attention_backend(model) == "magi":
+        return unpack_magi_forward_output(model, batch, output)
     return unpack_thd_forward_output(model, batch, output)
+
+
+def _validate_magi_attention_config(impl_cfg: ImplConfig) -> None:
+    """Validate the magi backend selection against its supported scope.
+
+    MagiAttention has no user-facing tuning knobs: chunk sizing and overlap
+    staging are decided automatically, and any locally calibrated policy
+    belongs in ``resolve_magi_attention_config`` in the backend primitive.
+    """
+    if impl_cfg.attention_backend_override != "magi":
+        return
+    p = impl_cfg.parallel
+    if not impl_cfg.use_thd:
+        raise ValueError("Qwen3-MoE MagiAttention requires use_thd=True.")
+    if p.cp <= 1:
+        raise ValueError("Qwen3-MoE MagiAttention requires context parallel size CP>1.")
+    if p.pp != 1 or p.vpp != 1:
+        raise ValueError("Qwen3-MoE MagiAttention initially supports PP=1 and VPP=1 only.")
+    if impl_cfg.mtp_enable:
+        raise ValueError("Qwen3-MoE MagiAttention does not currently support MTP.")
 
 
 def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBundle:
@@ -154,6 +195,7 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
     # ── validation ──
     if impl_cfg.use_deepep and (p.etp is not None and p.etp > 1):
         raise ValueError("use_deepep and etp>1 are mutually exclusive")
+    _validate_magi_attention_config(impl_cfg)
 
     # ── override model config from impl_cfg ──
     if impl_cfg.router_aux_loss_coef is not None:
@@ -185,6 +227,7 @@ def build_model(model_cfg: Qwen3MoEConfig, *, impl_cfg: ImplConfig) -> ModelBund
         mtp_enable_train=mtp_enable_train,
         mtp_detach_encoder=impl_cfg.mtp_detach_encoder,
         lora_config=lora_config,
+        attention_backend=("magi" if impl_cfg.attention_backend_override == "magi" else "te"),
     )
 
     vpp = None if p.vpp == 1 else p.vpp

--- a/experimental/lite/megatron/lite/primitive/modules/attention/__init__.py
+++ b/experimental/lite/megatron/lite/primitive/modules/attention/__init__.py
@@ -5,10 +5,16 @@ from megatron.lite.primitive.modules.attention.dsa import (
     build_rope_cache,
     build_rotary_embeddings,
 )
+from megatron.lite.primitive.modules.attention.magi import (
+    MagiAttentionConfig,
+    MagiDotProductAttention,
+)
 from megatron.lite.primitive.modules.attention.mla import MultiLatentAttention
 
 __all__ = [
     "DynamicSparseAttention",
+    "MagiAttentionConfig",
+    "MagiDotProductAttention",
     "MultiLatentAttention",
     "RMSNorm",
     "build_rope_cache",

--- a/experimental/lite/megatron/lite/primitive/modules/attention/magi.py
+++ b/experimental/lite/megatron/lite/primitive/modules/attention/magi.py
@@ -1,0 +1,237 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Optional MagiAttention primitive for load-balanced context parallelism."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, NamedTuple
+
+import torch
+import torch.nn as nn
+
+
+class _MagiAttentionAPI(NamedTuple):
+    calc_attn: Any
+    dispatch: Any
+    undispatch: Any
+    magi_attn_varlen_key: Any
+    DispatchConfig: Any
+    DistAttnConfig: Any
+    OverlapConfig: Any
+    AttnOverlapMode: Any
+
+
+def _load_magi_attention_api() -> _MagiAttentionAPI:
+    """Import MagiAttention lazily so it remains an optional dependency."""
+
+    try:
+        from magi_attention.api import calc_attn, dispatch, magi_attn_varlen_key, undispatch
+        from magi_attention.common.enum import AttnOverlapMode
+        from magi_attention.config import DispatchConfig, DistAttnConfig, OverlapConfig
+    except (ImportError, OSError) as exc:
+        raise ImportError(
+            "Megatron Lite's MagiAttention backend requires a working MagiAttention "
+            "installation for the current CUDA architecture. Install "
+            "SandAI-org/MagiAttention before selecting attention_backend_override='magi'."
+        ) from exc
+
+    return _MagiAttentionAPI(
+        calc_attn=calc_attn,
+        dispatch=dispatch,
+        undispatch=undispatch,
+        magi_attn_varlen_key=magi_attn_varlen_key,
+        DispatchConfig=DispatchConfig,
+        DistAttnConfig=DistAttnConfig,
+        OverlapConfig=OverlapConfig,
+        AttnOverlapMode=AttnOverlapMode,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class MagiAttentionConfig:
+    """Load-balancing and communication-overlap controls for MagiAttention.
+
+    Both fields default to ``None`` = trust MagiAttention's own judgement:
+    the chunk size is derived from the sequence length, and the overlap
+    degree is solved per microbatch by the dynamic overlap solver. Explicit
+    values are expert overrides for when profiling shows the automatic
+    choice is wrong on a given workload or machine.
+    """
+
+    chunk_size: int | None = None
+    overlap_degree: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.chunk_size is not None and self.chunk_size <= 0:
+            raise ValueError("MagiAttention chunk_size must be positive when provided.")
+        if self.overlap_degree is not None and self.overlap_degree < 0:
+            raise ValueError(
+                "MagiAttention overlap_degree must be non-negative or None (dynamic)."
+            )
+
+
+def resolve_magi_attention_config(
+    config: MagiAttentionConfig, *, total_tokens: int, cp_size: int
+) -> MagiAttentionConfig:
+    """Resolve the effective per-microbatch MagiAttention options.
+
+    This is the single policy seam for overriding MagiAttention's own
+    automatic judgement. The default implementation trusts upstream auto:
+    ``None`` fields pass through, so magi derives the chunk size and the
+    dynamic overlap solver picks the overlap degree. If profiling ever shows
+    that judgement is wrong on a given machine (its cost model constants are
+    calibrated upstream), encode the locally calibrated policy here — e.g. a
+    lookup keyed on ``total_tokens // cp_size`` and the device capability —
+    instead of scattering tuning logic across callers.
+    """
+    del total_tokens, cp_size
+    return config
+
+
+def build_magi_attention_runtime_key(
+    cu_seqlens: torch.Tensor,
+    *,
+    num_heads_q: int,
+    num_heads_kv: int,
+    head_dim: int,
+    cp_group: torch.distributed.ProcessGroup,
+    config: MagiAttentionConfig | None = None,
+) -> Any:
+    """Build the per-microbatch MagiAttention runtime and dispatch plan.
+
+    ``config`` defaults to fully automatic behaviour; explicit values exist
+    for tests and for ``resolve_magi_attention_config`` calibration policies.
+    """
+
+    if cu_seqlens.dim() != 1 or cu_seqlens.numel() < 2:
+        raise ValueError(
+            "MagiAttention cu_seqlens must be one-dimensional with at least two entries."
+        )
+    if cu_seqlens.dtype != torch.int32:
+        raise ValueError(f"MagiAttention cu_seqlens must be int32, got {cu_seqlens.dtype}.")
+    if cp_group is None:
+        raise ValueError("MagiAttention requires an explicit context-parallel process group.")
+    if num_heads_q < 1 or num_heads_kv < 1 or num_heads_q % num_heads_kv != 0:
+        raise ValueError(
+            "MagiAttention requires positive query/KV head counts with query heads "
+            "divisible by KV heads."
+        )
+
+    api = _load_magi_attention_api()
+    config = resolve_magi_attention_config(
+        config if config is not None else MagiAttentionConfig(),
+        total_tokens=int(cu_seqlens[-1].item()),
+        cp_size=int(cp_group.size()),
+    )
+
+    def build_key(chunk_size: int | None):
+        if config.overlap_degree is None:
+            # Dynamic mode: the overlap solver picks the degree per microbatch.
+            overlap_config = api.OverlapConfig(mode=api.AttnOverlapMode.DYNAMIC, degree=None)
+        else:
+            overlap_config = api.OverlapConfig(degree=config.overlap_degree)
+        dist_attn_config = api.DistAttnConfig(
+            dispatch_config=api.DispatchConfig(chunk_size=chunk_size),
+            overlap_config=overlap_config,
+        )
+        return api.magi_attn_varlen_key(
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_k=cu_seqlens,
+            num_heads_q=num_heads_q,
+            num_heads_kv=num_heads_kv,
+            head_dim=head_dim,
+            pad_size=0,
+            cp_group_or_mesh=cp_group,
+            causal=True,
+            dist_attn_config=dist_attn_config,
+        )
+
+    runtime_key = build_key(config.chunk_size)
+    if int(getattr(runtime_key, "pad_size", 0)) == 0:
+        return runtime_key
+
+    # Lite already pads each THD sequence to a CP-compatible length. If Magi's
+    # automatically capped chunk size would add another tail pad, lower it to
+    # the nearest divisor of tokens-per-rank. This keeps every CP shard equal
+    # without introducing extra loss-bearing tokens.
+    total_tokens = int(cu_seqlens[-1].item())
+    cp_size = int(cp_group.size())
+    if total_tokens % cp_size != 0:
+        raise ValueError(
+            f"MagiAttention requires total tokens ({total_tokens}) divisible by CP={cp_size}."
+        )
+    tokens_per_rank = total_tokens // cp_size
+    adjusted_chunk_size = min(int(runtime_key.chunk_size), tokens_per_rank)
+    while adjusted_chunk_size > 1 and tokens_per_rank % adjusted_chunk_size != 0:
+        adjusted_chunk_size -= 1
+    runtime_key = build_key(adjusted_chunk_size)
+    if int(getattr(runtime_key, "pad_size", 0)) != 0:
+        raise RuntimeError("Failed to derive a padding-free MagiAttention chunk size.")
+    return runtime_key
+
+
+def dispatch_magi_attention_tensor(
+    tensor: torch.Tensor, runtime_key: Any, *, pad_value: float = 0.0
+) -> torch.Tensor:
+    """Apply a MagiAttention runtime's token permutation and CP dispatch."""
+
+    return _load_magi_attention_api().dispatch(tensor, runtime_key, pad_value=pad_value)
+
+
+def undispatch_magi_attention_tensor(tensor: torch.Tensor, runtime_key: Any) -> torch.Tensor:
+    """Restore a CP-local MagiAttention tensor to global token order."""
+
+    return _load_magi_attention_api().undispatch(tensor, runtime_key)
+
+
+class MagiDotProductAttention(nn.Module):
+    """Core attention adapter consuming a runtime key prepared before QKV projection."""
+
+    def __init__(self, head_dim: int) -> None:
+        super().__init__()
+        if head_dim < 1:
+            raise ValueError(f"head_dim must be positive, got {head_dim}.")
+        self.softmax_scale = head_dim**-0.5
+
+    def forward(self, query, key, value, *, packed_seq_params):
+        runtime_key = getattr(packed_seq_params, "magi_runtime_key", None)
+        if runtime_key is None:
+            raise ValueError(
+                "MagiAttention runtime metadata is missing. Prepare the microbatch with "
+                "pack_magi_forward_kwargs before model.forward."
+            )
+        if query.dim() != 3 or key.dim() != 3 or value.dim() != 3:
+            raise ValueError("MagiAttention expects Q/K/V in THD layout [tokens, heads, head_dim].")
+        if query.dtype not in (torch.float16, torch.bfloat16):
+            raise ValueError(
+                f"MagiAttention requires fp16 or bf16 Q/K/V tensors, got {query.dtype}."
+            )
+        if key.shape != value.shape:
+            raise ValueError(
+                f"MagiAttention key/value shapes must match, got {key.shape} and {value.shape}."
+            )
+        if hasattr(runtime_key, "num_heads_q") and runtime_key.num_heads_q != query.size(1):
+            raise ValueError(
+                f"MagiAttention runtime expects {runtime_key.num_heads_q} query heads, "
+                f"got {query.size(1)}."
+            )
+        if hasattr(runtime_key, "num_heads_kv") and runtime_key.num_heads_kv != key.size(1):
+            raise ValueError(
+                f"MagiAttention runtime expects {runtime_key.num_heads_kv} KV heads, "
+                f"got {key.size(1)}."
+            )
+
+        output, _meta = _load_magi_attention_api().calc_attn(
+            query, key, value, runtime_key, softmax_scale=self.softmax_scale
+        )
+        return output
+
+
+__all__ = [
+    "MagiAttentionConfig",
+    "MagiDotProductAttention",
+    "build_magi_attention_runtime_key",
+    "dispatch_magi_attention_tensor",
+    "resolve_magi_attention_config",
+    "undispatch_magi_attention_tensor",
+]

--- a/experimental/lite/megatron/lite/primitive/modules/gqa.py
+++ b/experimental/lite/megatron/lite/primitive/modules/gqa.py
@@ -11,6 +11,7 @@ import torch
 import torch.nn as nn
 import transformer_engine.pytorch as te
 
+from megatron.lite.primitive.modules.attention.magi import MagiDotProductAttention
 from megatron.lite.primitive.modules.gqa_utils import split_grouped_qkvg
 from megatron.lite.primitive.modules.lora import LinearLoRA, LoraConfig, normalize_lora_config
 from megatron.lite.primitive.modules.mrope import MultimodalRotaryEmbedding
@@ -59,6 +60,7 @@ class GQAttention(nn.Module):
         qkv_layout: str = "flat",
         lora_config: LoraConfig | dict | None = None,
         mrope_section: list[int] | None = None,
+        attention_backend: str = "te",
     ):
         super().__init__()
         self.num_heads_local = ensure_divisible(num_attention_heads, ps.tp_size)
@@ -73,6 +75,9 @@ class GQAttention(nn.Module):
             raise ValueError(f"Unsupported qkv_layout={qkv_layout!r}")
         self._qkv_layout = qkv_layout
         self._mrope_section = list(mrope_section) if mrope_section is not None else None
+        self._use_thd = use_thd
+        self._check_attention_backend(attention_backend)
+        self.attention_backend = attention_backend
 
         # Declaration order follows MC's `SelfAttention` submodule order
         # (linear_proj → linear_qkv → q_layernorm → k_layernorm). `named_
@@ -150,25 +155,51 @@ class GQAttention(nn.Module):
                 rotary_base=rope_theta,
                 cp_group=ps.cp_group if ps.cp_size > 1 else None,
             )
+        self.core_attn = self._build_core_attn(attention_backend)
+
+    def _check_attention_backend(self, attention_backend: str) -> None:
+        if attention_backend not in {"te", "magi"}:
+            raise ValueError(f"Unsupported GQA attention_backend={attention_backend!r}.")
+        if attention_backend == "magi" and self._mrope_section is not None:
+            raise ValueError("MagiAttention does not currently support MRoPE in Megatron Lite.")
+
+    def _build_core_attn(self, attention_backend: str) -> nn.Module:
+        if attention_backend == "magi":
+            return MagiDotProductAttention(head_dim=self.head_dim)
         cp_kwargs = {}
-        if ps.cp_size > 1:
+        if self.ps.cp_size > 1:
             if GQAttention._cp_stream is None:
                 GQAttention._cp_stream = torch.cuda.Stream()
             cp_kwargs = dict(
-                cp_group=ps.cp_group,
-                cp_global_ranks=ps.cp_global_ranks,
+                cp_group=self.ps.cp_group,
+                cp_global_ranks=self.ps.cp_global_ranks,
                 cp_stream=GQAttention._cp_stream,
             )
-
-        self.core_attn = te.DotProductAttention(
+        return te.DotProductAttention(
             num_attention_heads=self.num_heads_local,
-            kv_channels=head_dim,
+            kv_channels=self.head_dim,
             num_gqa_groups=self.num_kv_heads_local,
             attention_dropout=0.0,
             attn_mask_type="causal",
-            qkv_format="thd" if use_thd else "sbhd",
+            qkv_format="thd" if self._use_thd else "sbhd",
             **cp_kwargs,
         )
+
+    def set_attention_backend(self, attention_backend: str) -> None:
+        """Hot-swap the core-attention backend on a built module.
+
+        Both backends are parameter-free, so the swap never touches
+        parameters, buffers, or optimizer state; only TE's internal
+        ``_extra_state`` metadata keys appear/disappear with the te backend.
+        It takes effect on the next forward. Call it only at microbatch boundaries — swapping
+        between a forward and its recompute/backward would replay the
+        recomputation through a different kernel than the saved outputs.
+        """
+        self._check_attention_backend(attention_backend)
+        if attention_backend == self.attention_backend:
+            return
+        self.core_attn = self._build_core_attn(attention_backend)
+        self.attention_backend = attention_backend
 
     def forward(
         self, x: torch.Tensor, position_ids: torch.Tensor | None = None, packed_seq_params=None
@@ -178,8 +209,14 @@ class GQAttention(nn.Module):
             qkv = qkv + self.qkv_lora(self._qkv_lora_input(x))
         q, gate, k, v = self._split_qkv(qkv)
 
-        is_thd = packed_seq_params is not None
-        if is_thd:
+        is_packed = packed_seq_params is not None
+        is_magi = is_packed and getattr(packed_seq_params, "qkv_format", None) == "magi"
+        if (self.attention_backend == "magi") != is_magi:
+            raise ValueError(
+                "GQAttention backend and packed batch layout disagree: MagiAttention "
+                "requires qkv_format='magi' on every microbatch."
+            )
+        if is_packed:
             q, k, v = q.squeeze(1), k.squeeze(1), v.squeeze(1)
 
         q = self.q_norm(q)
@@ -194,14 +231,34 @@ class GQAttention(nn.Module):
                 raise ValueError("MRoPE attention requires position_ids.")
             # Packed THD position_ids are already CP-local after protocol.forward
             # prepares the VERL batch; avoid slicing MRoPE frequencies twice.
-            freqs = self.rotary(position_ids, self._mrope_section, packed_seq=is_thd)
-            if is_thd:
+            freqs = self.rotary(position_ids, self._mrope_section, packed_seq=is_packed)
+            if is_packed:
                 q = _apply_rotary_pos_emb_bshd(q[:, None], freqs).squeeze(1)
                 k = _apply_rotary_pos_emb_bshd(k[:, None], freqs).squeeze(1)
             else:
                 q = _apply_rotary_pos_emb_bshd(q, freqs)
                 k = _apply_rotary_pos_emb_bshd(k, freqs)
-        elif is_thd:
+        elif is_magi:
+            if position_ids is None:
+                raise ValueError("MagiAttention requires dispatched position_ids.")
+            max_q = getattr(packed_seq_params, "max_seqlen_q", None)
+            max_kv = getattr(packed_seq_params, "max_seqlen_kv", None)
+            seq_len_for_rope = int(max(max_q, max_kv))
+            freqs = self.rotary(seq_len_for_rope, packed_seq=True)
+            local_positions = position_ids.reshape(-1).to(device=freqs.device, dtype=torch.long)
+            if local_positions.numel() and (
+                int(local_positions.min().item()) < 0
+                or int(local_positions.max().item()) >= seq_len_for_rope
+            ):
+                raise ValueError("MagiAttention position_ids exceed the RoPE table.")
+            local_freqs = freqs.index_select(0, local_positions)
+            q = _apply_rotary_pos_emb_bshd(
+                q[:, None], local_freqs, rotary_interleaved=False, mscale=1.0
+            ).squeeze(1)
+            k = _apply_rotary_pos_emb_bshd(
+                k[:, None], local_freqs, rotary_interleaved=False, mscale=1.0
+            ).squeeze(1)
+        elif is_packed:
             max_q = getattr(packed_seq_params, "max_seqlen_q", None)
             max_kv = getattr(packed_seq_params, "max_seqlen_kv", None)
             if max_q is None or max_kv is None:
@@ -238,7 +295,10 @@ class GQAttention(nn.Module):
         if self._use_fp32_rope:
             q, k = q.to(orig_dtype), k.to(orig_dtype)
 
-        if is_thd:
+        if is_magi:
+            attn_out = self.core_attn(q, k, v, packed_seq_params=packed_seq_params)
+            attn_out = attn_out.reshape(attn_out.size(0), 1, -1)
+        elif is_packed:
             psp_kwargs = {
                 k: getattr(packed_seq_params, k)
                 for k in _KEPT_PSP_FIELDS

--- a/experimental/lite/megatron/lite/primitive/utils/packed_seq.py
+++ b/experimental/lite/megatron/lite/primitive/utils/packed_seq.py
@@ -26,6 +26,8 @@ class PackedSeqParams:
     total_tokens: int | None = None
     seq_idx: Tensor | None = None
     cp_rank: int | None = None
+    magi_runtime_key: Any | None = None
+    """Per-microbatch MagiAttention dispatch/runtime metadata."""
 
     def __post_init__(self) -> None:
         cu_seqlens = (

--- a/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
+++ b/experimental/lite/megatron/lite/runtime/backends/mlite/runtime.py
@@ -13,11 +13,16 @@ from typing import Any
 
 import torch
 import torch.distributed as dist
+
 from megatron.lite.runtime.backends import Runtime as RuntimeBase
 from megatron.lite.runtime.backends.mlite.config import MegatronLiteConfig
 from megatron.lite.runtime.contracts.data import ForwardResult, ModelOutputs, PackedBatch
 from megatron.lite.runtime.contracts.handle import ModelHandle
-from megatron.lite.runtime.contracts.loss import get_loss_context, split_loss_context, use_loss_context
+from megatron.lite.runtime.contracts.loss import (
+    get_loss_context,
+    split_loss_context,
+    use_loss_context,
+)
 
 
 def _build_impl_cfg(proto, rt_cfg: MegatronLiteConfig):
@@ -61,12 +66,16 @@ def _apply_attention_backend_env(backend: str | None, *, tag: str) -> None:
         "fused": ("0", "1", "0"),
         "unfused": ("0", "0", "1"),
         "local": ("0", "0", "0"),
+        # Magi owns core attention and ignores these TE selectors. Keep TE's
+        # auto-selection available so a built model can hot-swap back to TE.
+        "magi": ("1", "1", "1"),
     }
     try:
         flash, fused, unfused = env_overrides[backend]
     except KeyError as exc:
         raise ValueError(
-            "attention_backend_override must be one of {'auto', 'flash', 'fused', 'unfused', 'local'}"
+            "attention_backend_override must be one of "
+            "{'auto', 'flash', 'fused', 'unfused', 'local', 'magi'}"
         ) from exc
 
     os.environ["NVTE_FLASH_ATTN"] = flash

--- a/experimental/lite/tests/README.md
+++ b/experimental/lite/tests/README.md
@@ -152,3 +152,14 @@ The final summary contains only the source revision with a dirty suffix when
 applicable, safe software and GPU metadata, suite durations, result counts, and
 overall status. It does not print hostnames, container identifiers, environment
 values, credentials, or infrastructure paths.
+
+## Optional MagiAttention Suite
+
+MagiAttention is an optional CUDA dependency, so its coverage is split by
+dependency weight. `unit/primitive/test_magi_attention_unit.py` uses a fake
+MagiAttention API and runs in the standard workflow with no extra install.
+The operator-level numerical test
+(`smoke/primitive/test_magi_attention_operator.py`) and the Qwen3-MoE E2E
+(`smoke/model/test_magi_attention_e2e.py`) require a real MagiAttention
+build; they are marked `optional` and run through their dedicated venv-based
+runner. See `../docs/magi_attention.md` and `run_magi_attention_e2e.sh`.

--- a/experimental/lite/tests/run_magi_attention_e2e.sh
+++ b/experimental/lite/tests/run_magi_attention_e2e.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+WORK_DATA="$(dirname "${ROOT}")"
+VENV="${MAGI_ATTENTION_VENV:-${WORK_DATA}/magi_attention_test_env_v1.1.1/venv}"
+SOURCE="${MAGI_ATTENTION_SOURCE:-${WORK_DATA}/MagiAttention-v1.1.1}"
+NPROC="${MLITE_MAGI_NPROC:-4}"
+SUITE="${1:-all}"
+
+if [[ ! -x "${VENV}/bin/python" ]]; then
+    echo "MagiAttention test environment not found at ${VENV}." >&2
+    echo "Run experimental/lite/tests/setup_magi_attention_env.sh first." >&2
+    exit 2
+fi
+ARCH="$("${VENV}/bin/python" -c 'import torch; print(torch.cuda.get_device_capability()[0] * 10)')"
+if [[ "${ARCH}" == "100" ]]; then
+    KERNEL_BACKEND="fa4"
+    UPSTREAM_BACKEND_FILTER="*FA4*"
+else
+    KERNEL_BACKEND="ffa"
+    UPSTREAM_BACKEND_FILTER="*FFA*"
+fi
+if [[ ! -f "${VENV}/.magi_attention_v1.1.1_sm${ARCH}_complete" ]]; then
+    echo "MagiAttention test environment is incomplete for sm${ARCH}: ${VENV}" >&2
+    exit 2
+fi
+if [[ "${NPROC}" != "2" && "${NPROC}" != "4" ]]; then
+    echo "MLITE_MAGI_NPROC must be 2 or 4, got ${NPROC}." >&2
+    exit 2
+fi
+if [[ "${SUITE}" != "all" && "${SUITE}" != "upstream" && "${SUITE}" != "lite" ]]; then
+    echo "Usage: $0 [all|upstream|lite]" >&2
+    exit 2
+fi
+
+export PYTHONPATH="${ROOT}:${ROOT}/experimental/lite:${PYTHONPATH:-}"
+unset MAGI_ATTENTION_SDPA_BACKEND MAGI_ATTENTION_FA4_BACKEND
+export MAGI_ATTENTION_KERNEL_BACKEND="${KERNEL_BACKEND}"
+export MAGI_ATTENTION_NATIVE_GRPCOLL=0
+export MAGI_ATTENTION_HIERARCHICAL_COMM=0
+export MAGI_ATTENTION_QO_COMM=0
+export MAGI_ATTENTION_DETERMINISTIC_MODE=0
+export MAGI_ATTENTION_FORWARD_HIGH_PRECISION_REDUCE=0
+export MAGI_ATTENTION_BACKWARD_HIGH_PRECISION_REDUCE=0
+export MAGI_ATTENTION_BWD_HIDE_TAIL_REDUCE=0
+
+if [[ "${SUITE}" == "all" || "${SUITE}" == "upstream" ]]; then
+    if [[ ! -f "${SOURCE}/tests/test_pipeline.py" ]]; then
+        echo "MagiAttention source not found at ${SOURCE}." >&2
+        exit 2
+    fi
+    export MAGI_ATTENTION_TEST_WORLD_SIZE="${NPROC}"
+    export MAGI_ATTENTION_TEST_ATTN_CONFIG="sdpa_varlen_block_causal_960"
+    export MAGI_ATTENTION_TEST_NUM_HEADS="8_2"
+    export MAGI_ATTENTION_TEST_HEAD_DIM="64"
+    export MAGI_ATTENTION_TEST_DTYPE="*bfloat16*"
+    export MAGI_ATTENTION_TEST_BACKEND="${UPSTREAM_BACKEND_FILTER}"
+    (
+        cd "${SOURCE}"
+        "${VENV}/bin/python" -m pytest -q -s \
+            "tests/test_pipeline.py::TestPipelineWithWorldSize${NPROC}::test_pipeline"
+    )
+fi
+
+if [[ "${SUITE}" == "all" || "${SUITE}" == "lite" ]]; then
+    cd "${ROOT}"
+    # The operator-level attention test runs first and gates the model E2E:
+    # it isolates the core attention numerics (dispatch -> calc_attn ->
+    # undispatch vs an SDPA reference) in its own torchrun so the two tests
+    # never share one process-group lifecycle.
+    # MLITE_TEST_HARNESS=1 lifts the conftest GPU skip: this runner is the
+    # sanctioned harness for the optional MagiAttention suite (own venv).
+    MLITE_TEST_HARNESS=1 "${VENV}/bin/python" -m torch.distributed.run \
+        --standalone --nproc_per_node="${NPROC}" -m pytest -q -s \
+        experimental/lite/tests/smoke/primitive/test_magi_attention_operator.py
+    MLITE_TEST_HARNESS=1 "${VENV}/bin/python" -m torch.distributed.run \
+        --standalone --nproc_per_node="${NPROC}" -m pytest -q -s \
+        experimental/lite/tests/smoke/model/test_magi_attention_e2e.py
+fi

--- a/experimental/lite/tests/setup_magi_attention_env.sh
+++ b/experimental/lite/tests/setup_magi_attention_env.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SOURCE="${MAGI_ATTENTION_SOURCE:?Set MAGI_ATTENTION_SOURCE to a MagiAttention v1.1.1 checkout}"
+VENV="${MAGI_ATTENTION_VENV:?Set MAGI_ATTENTION_VENV to the persistent test venv path}"
+ARCH="${MAGI_ATTENTION_BUILD_COMPUTE_CAPABILITY:-}"
+MAX_JOBS_VALUE="${MAX_JOBS:-32}"
+
+if [[ -z "${ARCH}" ]]; then
+    ARCH="$(python -c 'import torch; print(torch.cuda.get_device_capability()[0] * 10)')"
+fi
+if [[ "${ARCH}" != "90" && "${ARCH}" != "100" ]]; then
+    echo "Unsupported compute capability sm${ARCH}: expected 90 (Hopper) or 100 (Blackwell)." >&2
+    exit 2
+fi
+MARKER="${VENV}/.magi_attention_v1.1.1_sm${ARCH}_complete"
+
+# sm100 uses the FA4 (flash_attn_cute) kernel backend; sm90 uses the native
+# FFA kernels, which are prebuilt at install time instead.
+if [[ "${ARCH}" == "100" ]]; then
+    IMPORT_CHECK="import flash_attn_cute, magi_attention"
+else
+    IMPORT_CHECK="import magi_attention, magi_attention.magi_attn_ext"
+fi
+
+mkdir -p "${TMPDIR:-/tmp}"
+
+if [[ ! -f "${SOURCE}/pyproject.toml" ]]; then
+    echo "MagiAttention source not found at ${SOURCE}" >&2
+    exit 2
+fi
+
+if [[ -f "${MARKER}" ]]; then
+    "${VENV}/bin/python" -c \
+        "${IMPORT_CHECK}; assert magi_attention.__version__ == '1.1.1'; print(magi_attention.__version__)"
+    exit 0
+fi
+
+if [[ ! -x "${VENV}/bin/python" ]]; then
+    python -m venv --system-site-packages "${VENV}"
+fi
+
+export PATH="${VENV}/bin:${PATH}"
+export MAGI_ATTENTION_BUILD_COMPUTE_CAPABILITY="${ARCH}"
+export MAX_JOBS="${MAX_JOBS_VALUE}"
+export NVCC_THREADS="${NVCC_THREADS:-4}"
+if [[ "${ARCH}" == "100" ]]; then
+    export MAGI_ATTENTION_PREBUILD_FFA=0
+    export MAGI_ATTENTION_FA4_BACKEND=1
+    export FLASH_ATTN_CUDA_ARCHS="${ARCH}"
+else
+    export MAGI_ATTENTION_PREBUILD_FFA=1
+fi
+
+python -m pip install --upgrade \
+    pip setuptools wheel "packaging==25.0" ninja versioningit "pytest==8.3.5"
+python -m pip install -r "${SOURCE}/requirements.txt"
+
+if [[ "${ARCH}" == "100" ]]; then
+    # Some NGC images carry CUTLASS DSL dist-info and payload files without the
+    # .pth file that exposes the ``cutlass`` package. Install the same pinned
+    # payload into the venv when that split-package image state is detected.
+    if ! python -c "import cutlass" >/dev/null 2>&1; then
+        python -m pip install --force-reinstall --no-deps \
+            "nvidia-cutlass-dsl-libs-base==4.4.2" "nvidia-cutlass-dsl==4.4.2"
+    fi
+
+    if ! python -c "import flash_attn_cute" >/dev/null 2>&1; then
+        (
+            cd "${SOURCE}"
+            bash scripts/install_flash_attn_cute.sh "sm${ARCH}"
+        )
+    fi
+fi
+
+if ! python -c "${IMPORT_CHECK}; assert magi_attention.__version__ == '1.1.1'" \
+    >/dev/null 2>&1; then
+    python -m pip install --no-build-isolation "${SOURCE}"
+fi
+python -c \
+    "${IMPORT_CHECK}; assert magi_attention.__version__ == '1.1.1'; print(magi_attention.__version__)"
+touch "${MARKER}"

--- a/experimental/lite/tests/smoke/model/test_magi_attention_e2e.py
+++ b/experimental/lite/tests/smoke/model/test_magi_attention_e2e.py
@@ -1,0 +1,181 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Real-kernel MagiAttention E2E coverage for Megatron Lite."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+
+# Requires a real MagiAttention install (optional dependency): excluded from
+# the standard workflow and driven by tests/run_magi_attention_e2e.sh.
+pytestmark = [pytest.mark.gpus(4), pytest.mark.optional]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _single_node_cuda_dist():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for the MagiAttention E2E test.")
+
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    if world_size not in {2, 4}:
+        pytest.skip("The MagiAttention E2E test requires torchrun with 2 or 4 ranks.")
+
+    os.environ.setdefault("RANK", "0")
+    os.environ.setdefault("LOCAL_RANK", "0")
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", "29532")
+    os.environ.pop("MAGI_ATTENTION_SDPA_BACKEND", None)
+    os.environ.pop("MAGI_ATTENTION_FA4_BACKEND", None)
+    # FA4 (flash_attn_cute) is the Blackwell kernel backend; FFA is native sm90.
+    default_backend = "fa4" if torch.cuda.get_device_capability()[0] >= 10 else "ffa"
+    os.environ.setdefault("MAGI_ATTENTION_KERNEL_BACKEND", default_backend)
+
+    torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
+    created_pg = False
+    if not dist.is_initialized():
+        dist.init_process_group(backend="nccl", init_method="env://")
+        created_pg = True
+    yield
+    if created_pg and dist.is_initialized():
+        dist.destroy_process_group()
+
+
+def _tiny_magi_qwen3_config():
+    from megatron.lite.model.qwen3_moe.config import Qwen3MoEConfig
+
+    return Qwen3MoEConfig(
+        num_hidden_layers=1,
+        hidden_size=128,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=64,
+        vocab_size=256,
+        num_experts=2,
+        num_experts_per_tok=1,
+        moe_intermediate_size=64,
+        max_position_embeddings=256,
+        layer_types=["full_attention"],
+    )
+
+
+def _parallel_state():
+    from megatron.lite.primitive.parallel import init_parallel
+    from megatron.lite.runtime.contracts.config import ParallelConfig
+
+    world_size = dist.get_world_size()
+    return init_parallel(ParallelConfig(tp=1, etp=1, ep=1, pp=1, cp=world_size))
+
+
+def _packed_batch(vocab_size: int):
+    from megatron.lite.runtime.contracts.data import PackedBatch
+
+    # The same unsharded packed batch is present on every CP rank. MagiAttention
+    # owns the load-balanced permutation and dispatch that follows.
+    seq_lens = torch.tensor([256, 192, 128, 64], dtype=torch.int32, device="cuda")
+    generator = torch.Generator(device="cuda").manual_seed(20260710)
+    total_tokens = int(seq_lens.sum().item())
+    input_ids = torch.randint(0, vocab_size, (total_tokens,), generator=generator, device="cuda")
+    return PackedBatch(
+        input_ids=input_ids,
+        labels=input_ids.clone(),
+        loss_mask=torch.ones(total_tokens, dtype=torch.float32, device="cuda"),
+        seq_lens=seq_lens,
+    )
+
+
+def test_qwen3_moe_magi_attention_forward_backward_and_undispatch():
+    pytest.importorskip("magi_attention")
+    if os.environ.get("MAGI_ATTENTION_KERNEL_BACKEND", "ffa").lower() == "fa4":
+        pytest.importorskip("flash_attn_cute")
+
+    from megatron.lite.model.protocol_utils import (
+        pack_magi_forward_kwargs,
+        unpack_magi_forward_output,
+    )
+    from megatron.lite.model.qwen3_moe.lite.model import Qwen3MoEModel
+    from megatron.lite.runtime.backends.mlite.runtime import _apply_attention_backend_env
+
+    torch.manual_seed(1234)
+    _apply_attention_backend_env("magi", tag="magi-e2e")
+    config = _tiny_magi_qwen3_config()
+    model = Qwen3MoEModel(
+        config,
+        _parallel_state(),
+        use_deepep=False,
+        use_thd=True,
+        attention_backend="magi",
+    ).cuda()
+    model = model.to(torch.bfloat16)
+    batch = _packed_batch(config.vocab_size)
+
+    forward_kwargs = pack_magi_forward_kwargs(model, batch)
+    runtime_key = forward_kwargs["packed_seq_params"].magi_runtime_key
+    assert int(runtime_key.pad_size) == 0
+    assert forward_kwargs["input_ids"].numel() == batch.total_tokens // dist.get_world_size()
+
+    output = model(**forward_kwargs)
+    loss = output["loss"]
+    assert loss.ndim == 0
+    assert torch.isfinite(loss)
+    loss.backward()
+
+    grads = [
+        parameter.grad.detach().float()
+        for parameter in model.parameters()
+        if parameter.requires_grad and parameter.grad is not None
+    ]
+    assert grads
+    assert all(torch.isfinite(grad).all() for grad in grads)
+    local_grad_norm = torch.stack([grad.norm() for grad in grads]).sum()
+    assert local_grad_norm > 0
+
+    # Exercise the reverse layout path used by protocol consumers as well as
+    # the forward/backward kernel path above.
+    restored = unpack_magi_forward_output(model, batch, output["hidden_states"].detach())
+    restored_lengths = torch.tensor(
+        [piece.size(0) for piece in restored.unbind()], dtype=torch.int32, device="cuda"
+    )
+    torch.testing.assert_close(restored_lengths, batch.seq_lens)
+
+    # --- hot swap: magi -> te -> magi on the same built model, same weights ---
+    from megatron.lite.model.protocol_utils import pack_thd_forward_kwargs
+
+    def _split_keys(module):
+        keys = set(module.state_dict().keys())
+        # TE modules register backend-internal ``_extra_state`` metadata
+        # entries (fp8 history; empty of trainable content in bf16). The
+        # hot-swap contract is exact invariance of parameters and buffers,
+        # while _extra_state keys may appear/disappear with the te backend.
+        return keys, {k for k in keys if not k.endswith("_extra_state")}
+
+    keys_before, trainable_before = _split_keys(model)
+    loss_magi = float(loss.detach().item())
+
+    model.set_attention_backend("te")
+    assert model.attention_backend == "te"
+    keys_te, trainable_te = _split_keys(model)
+    assert trainable_te == trainable_before, "swap must not touch parameters/buffers"
+    assert all(
+        k.endswith("_extra_state") for k in keys_te.symmetric_difference(keys_before)
+    ), "swap may only change TE _extra_state metadata keys"
+    with torch.no_grad():
+        te_output = model(**pack_thd_forward_kwargs(model, batch))
+    assert torch.isfinite(te_output["loss"])
+
+    model.set_attention_backend("magi")
+    keys_back, trainable_back = _split_keys(model)
+    assert trainable_back == trainable_before
+    assert keys_back == keys_before, "magi round trip must restore the exact key set"
+    with torch.no_grad():
+        magi_output_again = model(**pack_magi_forward_kwargs(model, batch))
+    loss_magi_again = float(magi_output_again["loss"].item())
+    # Same backend, same weights, same batch: the round trip must reproduce
+    # the original loss up to nondeterministic-accumulation noise.
+    assert abs(loss_magi_again - loss_magi) <= max(2e-2 * abs(loss_magi), 2e-2)
+
+    # Make any rank-local assertion failure visible to the entire torchrun job.
+    dist.all_reduce(local_grad_norm, group=model.ps.cp_group)
+    assert torch.isfinite(local_grad_norm) and local_grad_norm > 0

--- a/experimental/lite/tests/smoke/primitive/test_magi_attention_operator.py
+++ b/experimental/lite/tests/smoke/primitive/test_magi_attention_operator.py
@@ -1,0 +1,212 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Operator-level numerical test for the MagiAttention core-attention adapter.
+
+This is the attention test to look at before any model E2E: identical global
+varlen Q/K/V go through Lite's magi path (runtime key -> dispatch ->
+MagiDotProductAttention -> undispatch) and through a per-sequence fp32 SDPA
+causal reference. Forward outputs and dQ/dK/dV are compared token-by-token in
+global order. Tolerances are anchored to the bf16-SDPA-vs-fp32-SDPA noise
+floor so the test stays tight without tracking kernel-version jitter.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# Requires a real MagiAttention install (optional dependency): excluded from
+# the standard workflow and driven by tests/run_magi_attention_e2e.sh.
+pytestmark = [pytest.mark.gpus(4), pytest.mark.optional]
+
+_SEQ_LENS = [192, 128, 320, 64]
+_NUM_HEADS_Q = 8
+_NUM_HEADS_KV = 2
+_HEAD_DIM = 64
+_NOISE_FLOOR_MULTIPLIER = 4.0
+_ABS_FLOOR = 1e-3
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _single_node_cuda_dist():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for the MagiAttention operator test.")
+
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    if world_size not in {2, 4}:
+        pytest.skip("The MagiAttention operator test requires torchrun with 2 or 4 ranks.")
+
+    os.environ.setdefault("RANK", "0")
+    os.environ.setdefault("LOCAL_RANK", "0")
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", "29533")
+    os.environ.pop("MAGI_ATTENTION_SDPA_BACKEND", None)
+    os.environ.pop("MAGI_ATTENTION_FA4_BACKEND", None)
+    default_backend = "fa4" if torch.cuda.get_device_capability()[0] >= 10 else "ffa"
+    os.environ.setdefault("MAGI_ATTENTION_KERNEL_BACKEND", default_backend)
+
+    torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
+    created_pg = False
+    if not dist.is_initialized():
+        dist.init_process_group(backend="nccl", init_method="env://")
+        created_pg = True
+    yield
+    if created_pg and dist.is_initialized():
+        dist.destroy_process_group()
+
+
+def _seeded_randn(generator, total_tokens: int, heads: int, dtype):
+    """Rank-identical tensors: every rank draws the same sequence from the seed."""
+    return torch.randn(
+        (total_tokens, heads, _HEAD_DIM),
+        generator=generator,
+        device="cuda",
+        dtype=torch.float32,
+    ).to(dtype)
+
+
+def _sdpa_reference(q, k, v, seq_lens, dtype):
+    """Per-sequence causal SDPA in the requested dtype, GQA via head repeat."""
+    group = _NUM_HEADS_Q // _NUM_HEADS_KV
+    outputs = []
+    offset = 0
+    for seq_len in seq_lens:
+        qs = q[offset : offset + seq_len].to(dtype).transpose(0, 1).unsqueeze(0)
+        ks = (
+            k[offset : offset + seq_len]
+            .to(dtype)
+            .repeat_interleave(group, dim=1)
+            .transpose(0, 1)
+            .unsqueeze(0)
+        )
+        vs = (
+            v[offset : offset + seq_len]
+            .to(dtype)
+            .repeat_interleave(group, dim=1)
+            .transpose(0, 1)
+            .unsqueeze(0)
+        )
+        out = F.scaled_dot_product_attention(qs, ks, vs, is_causal=True)
+        outputs.append(out.squeeze(0).transpose(0, 1))
+        offset += seq_len
+    return torch.cat(outputs, dim=0)
+
+
+def _max_err(candidate, reference):
+    return float((candidate.float() - reference.float()).abs().max())
+
+
+def _assert_within_noise_floor(name, candidate, noisy_ref, exact_ref):
+    err = _max_err(candidate, exact_ref)
+    floor = _max_err(noisy_ref, exact_ref)
+    limit = max(_NOISE_FLOOR_MULTIPLIER * floor, _ABS_FLOOR)
+    assert torch.isfinite(candidate.float()).all(), f"{name}: non-finite values"
+    assert err <= limit, (
+        f"{name}: max err vs fp32 SDPA = {err:.3e} exceeds {limit:.3e} "
+        f"(bf16 SDPA noise floor = {floor:.3e})"
+    )
+
+
+@pytest.mark.parametrize(
+    "overlap_degree",
+    [1, None],  # None = dynamic mode: the overlap solver picks the staging
+    ids=["static-degree1", "dynamic"],
+)
+def test_magi_core_attention_matches_sdpa_reference(overlap_degree):
+    pytest.importorskip("magi_attention")
+    if os.environ.get("MAGI_ATTENTION_KERNEL_BACKEND", "ffa").lower() == "fa4":
+        pytest.importorskip("flash_attn_cute")
+
+    from megatron.lite.primitive.modules.attention.magi import (
+        MagiAttentionConfig,
+        MagiDotProductAttention,
+        build_magi_attention_runtime_key,
+        dispatch_magi_attention_tensor,
+        undispatch_magi_attention_tensor,
+    )
+    from megatron.lite.primitive.utils.packed_seq import PackedSeqParams
+
+    total_tokens = sum(_SEQ_LENS)
+    cp_group = dist.group.WORLD
+    assert total_tokens % cp_group.size() == 0
+
+    cu_seqlens = torch.tensor(
+        [0] + list(torch.tensor(_SEQ_LENS).cumsum(0).tolist()), dtype=torch.int32, device="cuda"
+    )
+    runtime_key = build_magi_attention_runtime_key(
+        cu_seqlens,
+        num_heads_q=_NUM_HEADS_Q,
+        num_heads_kv=_NUM_HEADS_KV,
+        head_dim=_HEAD_DIM,
+        cp_group=cp_group,
+        config=MagiAttentionConfig(chunk_size=64, overlap_degree=overlap_degree),
+    )
+    assert int(getattr(runtime_key, "pad_size", 0)) == 0
+
+    # Every "global" tensor must be bit-identical on all CP ranks; one shared
+    # seeded generator drawn in a fixed order guarantees that.
+    generator = torch.Generator(device="cuda").manual_seed(20260717)
+
+    # The dispatch/undispatch pair is pure data movement: bitwise round trip.
+    probe = _seeded_randn(generator, total_tokens, _NUM_HEADS_KV, torch.bfloat16)
+    restored = undispatch_magi_attention_tensor(
+        dispatch_magi_attention_tensor(probe, runtime_key), runtime_key
+    )
+    assert torch.equal(restored, probe), "dispatch->undispatch round trip is not exact"
+
+    # --- magi path: dispatch -> core attention -> undispatch, with autograd ---
+    q = _seeded_randn(generator, total_tokens, _NUM_HEADS_Q, torch.bfloat16).requires_grad_(True)
+    k = _seeded_randn(generator, total_tokens, _NUM_HEADS_KV, torch.bfloat16).requires_grad_(True)
+    v = _seeded_randn(generator, total_tokens, _NUM_HEADS_KV, torch.bfloat16).requires_grad_(True)
+    grad_out = _seeded_randn(generator, total_tokens, _NUM_HEADS_Q, torch.float32)
+
+    core_attn = MagiDotProductAttention(head_dim=_HEAD_DIM)
+    psp = PackedSeqParams(
+        qkv_format="magi",
+        cu_seqlens_q=cu_seqlens,
+        cu_seqlens_kv=cu_seqlens,
+        max_seqlen_q=max(_SEQ_LENS),
+        max_seqlen_kv=max(_SEQ_LENS),
+        magi_runtime_key=runtime_key,
+    )
+    out_local = core_attn(
+        dispatch_magi_attention_tensor(q, runtime_key),
+        dispatch_magi_attention_tensor(k, runtime_key),
+        dispatch_magi_attention_tensor(v, runtime_key),
+        packed_seq_params=psp,
+    )
+    out_magi = undispatch_magi_attention_tensor(out_local, runtime_key)
+    dq_magi, dk_magi, dv_magi = torch.autograd.grad(
+        (out_magi.float() * grad_out).sum(), (q, k, v)
+    )
+
+    # Undispatched activations must be identical on every rank.
+    out_bcast = out_magi.detach().clone()
+    dist.broadcast(out_bcast, src=dist.get_process_group_ranks(cp_group)[0], group=cp_group)
+    assert torch.equal(out_bcast, out_magi.detach()), "undispatched output differs across ranks"
+
+    # --- references: fp32 SDPA (exact) and bf16 SDPA (noise floor), same leaves ---
+    refs = {}
+    for dtype in (torch.float32, torch.bfloat16):
+        q_ref = q.detach().clone().requires_grad_(True)
+        k_ref = k.detach().clone().requires_grad_(True)
+        v_ref = v.detach().clone().requires_grad_(True)
+        out_ref = _sdpa_reference(q_ref, k_ref, v_ref, _SEQ_LENS, dtype)
+        dq, dk, dv = torch.autograd.grad(
+            (out_ref.float() * grad_out).sum(), (q_ref, k_ref, v_ref)
+        )
+        refs[dtype] = {"out": out_ref.detach(), "dq": dq, "dk": dk, "dv": dv}
+
+    exact, noisy = refs[torch.float32], refs[torch.bfloat16]
+    _assert_within_noise_floor("forward output", out_magi.detach(), noisy["out"], exact["out"])
+    _assert_within_noise_floor("dQ", dq_magi, noisy["dq"], exact["dq"])
+    _assert_within_noise_floor("dK", dk_magi, noisy["dk"], exact["dk"])
+    _assert_within_noise_floor("dV", dv_magi, noisy["dv"], exact["dv"])
+
+    # Make any rank-local assertion failure visible to the whole torchrun job.
+    ok = torch.tensor([1.0], device="cuda")
+    dist.all_reduce(ok, op=dist.ReduceOp.MIN, group=cp_group)
+    assert ok.item() == 1.0

--- a/experimental/lite/tests/unit/primitive/test_magi_attention_unit.py
+++ b/experimental/lite/tests/unit/primitive/test_magi_attention_unit.py
@@ -1,0 +1,322 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+@pytest.fixture(autouse=True)
+def _te_import_stub(transformer_engine_import_stub):
+    transformer_engine_import_stub()
+
+
+class _FakeGroup:
+    def __init__(self, size: int = 2, rank: int = 0):
+        self._size = size
+        self._rank = rank
+
+    def size(self):
+        return self._size
+
+    def rank(self):
+        return self._rank
+
+
+class _KeywordConfig:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+def _fake_api(group):
+    from megatron.lite.primitive.modules.attention import magi
+
+    def magi_attn_varlen_key(**kwargs):
+        return SimpleNamespace(
+            num_heads_q=kwargs["num_heads_q"],
+            num_heads_kv=kwargs["num_heads_kv"],
+            total_tokens=int(kwargs["cu_seqlens_q"][-1].item()),
+            cp_group=group,
+        )
+
+    def dispatch(tensor, key, pad_value=0.0):
+        del pad_value
+        local_tokens = key.total_tokens // key.cp_group.size()
+        start = key.cp_group.rank() * local_tokens
+        return tensor.narrow(0, start, local_tokens)
+
+    def undispatch(tensor, key):
+        del key
+        return tensor
+
+    def calc_attn(query, key, value, runtime_key, softmax_scale=None):
+        del key, value, runtime_key, softmax_scale
+        return query, None
+
+    return magi._MagiAttentionAPI(
+        calc_attn=calc_attn,
+        dispatch=dispatch,
+        undispatch=undispatch,
+        magi_attn_varlen_key=magi_attn_varlen_key,
+        DispatchConfig=_KeywordConfig,
+        DistAttnConfig=_KeywordConfig,
+        OverlapConfig=_KeywordConfig,
+        AttnOverlapMode=SimpleNamespace(STATIC="static", DYNAMIC="dynamic"),
+    )
+
+
+def test_pack_magi_forward_kwargs_dispatches_aligned_batch_before_qkv(monkeypatch):
+    from megatron.lite.model.protocol_utils import pack_magi_forward_kwargs
+    from megatron.lite.primitive.modules.attention import magi
+    from megatron.lite.runtime.contracts.data import PackedBatch
+
+    group = _FakeGroup()
+    monkeypatch.setattr(magi, "_load_magi_attention_api", lambda: _fake_api(group))
+    ps = SimpleNamespace(tp_size=1, cp_size=2, cp_rank=0, cp_group=group)
+    model = SimpleNamespace(
+        ps=ps,
+        config=SimpleNamespace(num_attention_heads=4, num_key_value_heads=2, head_dim=8),
+    )
+    batch = PackedBatch(
+        input_ids=torch.arange(8),
+        labels=torch.tensor([10, 11, 12, 20, 21, 22, 23, 24]),
+        seq_lens=torch.tensor([3, 5], dtype=torch.int32),
+        loss_mask=torch.ones(8),
+    )
+
+    kwargs = pack_magi_forward_kwargs(model, batch)
+
+    assert torch.equal(kwargs["input_ids"], torch.tensor([[0, 1, 2, 0, 3, 4]]))
+    assert torch.equal(kwargs["labels"], torch.tensor([[11, 12, 0, 0, 21, 22]]))
+    assert torch.equal(kwargs["position_ids"], torch.tensor([[0, 1, 2, 0, 0, 1]]))
+    assert torch.equal(kwargs["loss_mask"], torch.tensor([[1.0, 1.0, 0.0, 0.0, 1.0, 1.0]]))
+    packed_seq_params = kwargs["packed_seq_params"]
+    assert packed_seq_params.qkv_format == "magi"
+    assert packed_seq_params.magi_runtime_key.num_heads_q == 4
+    assert packed_seq_params.magi_runtime_key.num_heads_kv == 2
+    assert batch.extras["_mlite_magi_runtime_key"] is packed_seq_params.magi_runtime_key
+
+
+def test_magi_dot_product_attention_uses_microbatch_runtime(monkeypatch):
+    from megatron.lite.primitive.modules.attention import magi
+    from megatron.lite.primitive.modules.attention.magi import MagiDotProductAttention
+    from megatron.lite.primitive.utils.packed_seq import PackedSeqParams
+
+    group = _FakeGroup()
+    monkeypatch.setattr(magi, "_load_magi_attention_api", lambda: _fake_api(group))
+    module = MagiDotProductAttention(head_dim=4)
+    packed_seq_params = PackedSeqParams(
+        qkv_format="magi", magi_runtime_key=SimpleNamespace(num_heads_q=4, num_heads_kv=2)
+    )
+    query = torch.arange(96, dtype=torch.bfloat16).view(6, 4, 4)
+    key = torch.ones(6, 2, 4, dtype=torch.bfloat16)
+    value = torch.ones_like(key)
+
+    output = module(query, key, value, packed_seq_params=packed_seq_params)
+
+    assert torch.equal(output, query)
+
+
+def test_magi_runtime_lowers_chunk_size_to_avoid_tail_padding(monkeypatch):
+    from megatron.lite.primitive.modules.attention import magi
+    from megatron.lite.primitive.modules.attention.magi import (
+        MagiAttentionConfig,
+        build_magi_attention_runtime_key,
+    )
+
+    group = _FakeGroup()
+    selected_chunks = []
+
+    def magi_attn_varlen_key(**kwargs):
+        chunk_size = kwargs["dist_attn_config"].dispatch_config.chunk_size
+        selected_chunks.append(chunk_size)
+        effective_chunk = 3 if chunk_size is None else chunk_size
+        return SimpleNamespace(
+            chunk_size=effective_chunk, pad_size=2 if effective_chunk == 3 else 0
+        )
+
+    api = magi._MagiAttentionAPI(
+        calc_attn=lambda *args, **kwargs: None,
+        dispatch=lambda *args, **kwargs: None,
+        undispatch=lambda *args, **kwargs: None,
+        magi_attn_varlen_key=magi_attn_varlen_key,
+        DispatchConfig=_KeywordConfig,
+        DistAttnConfig=_KeywordConfig,
+        OverlapConfig=_KeywordConfig,
+        AttnOverlapMode=SimpleNamespace(STATIC="static", DYNAMIC="dynamic"),
+    )
+    monkeypatch.setattr(magi, "_load_magi_attention_api", lambda: api)
+
+    runtime_key = build_magi_attention_runtime_key(
+        torch.tensor([0, 4, 8], dtype=torch.int32),
+        num_heads_q=4,
+        num_heads_kv=2,
+        head_dim=8,
+        cp_group=group,
+        config=MagiAttentionConfig(),
+    )
+
+    assert selected_chunks == [None, 2]
+    assert runtime_key.chunk_size == 2
+    assert runtime_key.pad_size == 0
+
+
+class _StaticQKV(torch.nn.Module):
+    def __init__(self, qkv: torch.Tensor):
+        super().__init__()
+        self.qkv = qkv
+
+    def forward(self, _x):
+        return self.qkv
+
+
+class _ZeroRotary(torch.nn.Module):
+    def forward(self, seq_len, packed_seq=False):
+        assert packed_seq is True
+        return torch.zeros(seq_len, 1, 1, 2, dtype=torch.bfloat16)
+
+
+def test_gqa_magi_branch_uses_dispatched_positions_and_runtime(monkeypatch):
+    from megatron.lite.primitive.modules.attention import magi
+    from megatron.lite.primitive.modules.attention.magi import MagiDotProductAttention
+    from megatron.lite.primitive.modules.gqa import GQAttention
+    from megatron.lite.primitive.utils.packed_seq import PackedSeqParams
+
+    group = _FakeGroup()
+    monkeypatch.setattr(magi, "_load_magi_attention_api", lambda: _fake_api(group))
+    attention = GQAttention.__new__(GQAttention)
+    torch.nn.Module.__init__(attention)
+    attention.num_heads_local = 4
+    attention.num_kv_heads_local = 2
+    attention.head_dim = 2
+    attention.ps = SimpleNamespace(cp_size=2, cp_group=group)
+    attention._output_gate = False
+    attention._use_fp32_rope = False
+    attention._qkv_layout = "flat"
+    attention._mrope_section = None
+    attention.attention_backend = "magi"
+    qkv = torch.arange(96, dtype=torch.bfloat16).view(6, 1, 16)
+    attention.qkv = _StaticQKV(qkv)
+    attention.qkv_lora = None
+    attention.q_norm = torch.nn.Identity()
+    attention.k_norm = torch.nn.Identity()
+    attention.rotary = _ZeroRotary()
+    attention.core_attn = MagiDotProductAttention(head_dim=2)
+    attention.proj = torch.nn.Identity()
+    attention.proj_lora = None
+    packed_seq_params = PackedSeqParams(
+        qkv_format="magi",
+        max_seqlen_q=4,
+        max_seqlen_kv=4,
+        magi_runtime_key=SimpleNamespace(num_heads_q=4, num_heads_kv=2),
+    )
+    positions = torch.tensor([[0, 1, 2, 3, 0, 1]])
+
+    output = attention(
+        torch.zeros(6, 1, 8, dtype=torch.bfloat16),
+        position_ids=positions,
+        packed_seq_params=packed_seq_params,
+    )
+
+    assert output.shape == (6, 1, 8)
+    assert torch.equal(output, qkv[..., :8])
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"use_thd": False}, "use_thd"),
+        ({"parallel": {"cp": 1}}, "CP>1"),
+        ({"parallel": {"cp": 2, "pp": 2}}, "PP=1"),
+        ({"mtp_enable": True}, "MTP"),
+    ],
+)
+def test_qwen3_magi_config_rejects_unsupported_combinations(overrides, message):
+    from megatron.lite.model.qwen3_moe.lite.protocol import (
+        ImplConfig,
+        _validate_magi_attention_config,
+    )
+    from megatron.lite.runtime.contracts import ParallelConfig
+
+    overrides = dict(overrides)
+    kwargs = {
+        "attention_backend_override": "magi",
+        "use_thd": True,
+        "parallel": ParallelConfig(cp=2),
+    }
+    parallel_overrides = overrides.pop("parallel", None)
+    kwargs.update(overrides)
+    if parallel_overrides is not None:
+        kwargs["parallel"] = ParallelConfig(**parallel_overrides)
+
+    with pytest.raises(ValueError, match=message):
+        _validate_magi_attention_config(ImplConfig(**kwargs))
+
+
+def test_qwen3_magi_config_accepts_supported_static_cp():
+    from megatron.lite.model.qwen3_moe.lite.protocol import (
+        ImplConfig,
+        _validate_magi_attention_config,
+    )
+    from megatron.lite.runtime.contracts import ParallelConfig
+
+    _validate_magi_attention_config(
+        ImplConfig(
+            attention_backend_override="magi",
+            use_thd=True,
+            parallel=ParallelConfig(tp=2, cp=2),
+        )
+    )
+
+
+def test_magi_attention_config_defaults_trust_auto():
+    from megatron.lite.primitive.modules.attention.magi import (
+        MagiAttentionConfig,
+        resolve_magi_attention_config,
+    )
+
+    config = MagiAttentionConfig()
+    # None/None = delegate chunk sizing and overlap staging to magi itself.
+    assert config.chunk_size is None
+    assert config.overlap_degree is None
+    # The calibration seam is a pass-through until profiling says otherwise.
+    resolved = resolve_magi_attention_config(config, total_tokens=1024, cp_size=4)
+    assert resolved is config
+    # Dynamic mode stays selectable alongside explicit expert overrides.
+    assert MagiAttentionConfig(chunk_size=64, overlap_degree=2).overlap_degree == 2
+
+
+def test_gqa_attention_backend_hot_swap_contract():
+    from megatron.lite.primitive.modules.attention.magi import MagiDotProductAttention
+    from megatron.lite.primitive.modules.gqa import GQAttention
+
+    attention = object.__new__(GQAttention)
+    torch.nn.Module.__init__(attention)
+    attention._mrope_section = None
+    attention._use_thd = True
+    attention.head_dim = 8
+    attention.num_heads_local = 4
+    attention.num_kv_heads_local = 2
+    attention.ps = SimpleNamespace(cp_size=1, cp_group=None, cp_global_ranks=None)
+    attention.attention_backend = "te"
+    attention.core_attn = torch.nn.Identity()  # stands in for the te module
+
+    # te -> magi builds the parameter-free adapter and flips the attribute.
+    attention.set_attention_backend("magi")
+    assert isinstance(attention.core_attn, MagiDotProductAttention)
+    assert attention.attention_backend == "magi"
+    # Parameter-free contract: the swap can never touch checkpoints.
+    assert dict(attention.core_attn.state_dict()) == {}
+
+    # Same-backend call is a no-op preserving module identity.
+    module = attention.core_attn
+    attention.set_attention_backend("magi")
+    assert attention.core_attn is module
+
+    with pytest.raises(ValueError, match="Unsupported"):
+        attention.set_attention_backend("flash")
+
+    attention.attention_backend = "te"
+    attention._mrope_section = [16, 24, 24]
+    with pytest.raises(ValueError, match="MRoPE"):
+        attention.set_attention_backend("magi")

--- a/experimental/lite/tests/unit/runtime/backends/mlite/test_runtime_backend_unit.py
+++ b/experimental/lite/tests/unit/runtime/backends/mlite/test_runtime_backend_unit.py
@@ -179,6 +179,7 @@ def test_build_impl_cfg_preserves_explicit_impl_hf_path():
         ("fused", ("0", "1", "0")),
         ("unfused", ("0", "0", "1")),
         ("local", ("0", "0", "0")),
+        ("magi", ("1", "1", "1")),
     ],
 )
 def test_attention_backend_override_sets_expected_env(monkeypatch, backend, expected):


### PR DESCRIPTION
## What

Adds [MagiAttention](https://github.com/SandAI-org/MagiAttention) (v1.1.1) as an optional, hot-swappable core-attention backend for Megatron Lite's native `qwen3_moe`, selected via `attention_backend_override="magi"`. Magi replaces TE's zigzag CP with a per-microbatch solved chunk placement that balances **attention area** across CP ranks under an equal-shard constraint, plus scheduled KV group-cast with compute/comm overlap — the win case is varlen packed SFT.

Lite keeps embeddings, QKV/O projections, Q/K norm, RoPE, MoE, loss, and the training runtime; magi owns the load-balanced token permutation and CP attention communication.

## Design

- **New primitive** `primitive/modules/attention/magi.py` (self-contained, magi is a lazy optional dependency): runtime-key construction with a pad-free chunk policy (no second tail pad, equal CP shards preserved), dispatch/undispatch wrappers, parameter-free `MagiDotProductAttention`.
- **GQAttention backend slot**: te default path is verbatim-unchanged; the magi branch applies RoPE via dispatched position ids. `set_attention_backend()` hot-swaps backends on a built model — parameters/buffers/optimizer state untouched (only TE `_extra_state` metadata keys follow the te backend), so te-trained checkpoints resume under magi and vice versa.
- **Batch protocol** (`protocol_utils.py`): dispatch happens once on token streams before embedding (all layers share one plan; activation recompute replays the same runtime key); outputs are undispatched before the loss.
- **No user-facing tuning knobs**: chunk sizing and overlap staging are fully automatic (magi's dynamic overlap solver); locally calibrated policies belong in `resolve_magi_attention_config` — the single policy seam in the primitive.

Scope: bf16 qwen3_moe THD training, full causal GQA, static CP>1, TP/SP, PP=VPP=1. MTP/MRoPE are rejected with actionable errors; qwen3_5 is rejected because its linear-attention layers require an order-preserving CP layout.

## Testing

Layered, from operator to model (all green on 4xH100, FFA backend):

1. **Unit** (fake API, no GPU): wiring, validation, pad-free chunk policy, hot-swap contract.
2. **Operator-level numerical test** (`smoke/primitive/test_magi_attention_operator.py`): identical global varlen Q/K/V through `dispatch → calc_attn → undispatch` vs per-sequence fp32 SDPA — forward **and dQ/dK/dV**, static and dynamic overlap variants, tolerances anchored to the bf16-SDPA noise floor; bitwise dispatch/undispatch round trip and cross-rank consistency asserts.
3. **Qwen3-MoE e2e** incl. a `magi → te → magi` hot-swap round trip with state_dict-invariance asserts.
4. Reproducible env scripts for Hopper (native FFA) and Blackwell (FA4) with arch auto-detection.

**Qwen3-30B-A3B validation** (real HF weights, 8xH100, identical data across runs): token-level masked global CE vs standard attention (tp4 cp1, no CP tricks) within **6.7e-4 relative** on real UltraChat varlen-packed data — the same order as TE zigzag-CP's own deviation (5.6e-4) — and within 1.3e-3 on synthetic data. In the GA=8 Qwen3-30B-A3B heavy-tail THD benchmark, MagiAttention improved end-to-end training throughput by 31.88% over Transformer Engine.

## Known limitations / follow-ups

- MTP: magi upstream ships a `roll(key)` API for exactly this; wiring planned as a follow-up (pack-time pre-shifted streams).
- PP: per-stage deterministic plan rebuild is designed and feasible; follow-up PR.
- Multi-node hierarchical comm (2D DeviceMesh) and nvshmem path not yet exercised; all validation is single-node NCCL fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
