### PR TITLE
[dev] Share CUDA graph slots across dynamic CP variants

### DIFF
--- a/megatron/core/datasets/data_schedule.py
+++ b/megatron/core/datasets/data_schedule.py
@@ -13,6 +13,7 @@ from megatron.core.datasets.data_schedule_utils import (
     create_data_iterator,
     get_batch_and_global_seqlens,
     get_cp_slice_for_thd,
+    get_data_parallel_gather_group,
     next_hdp_group_packing_aware,
     reroute_samples_to_dcp_ranks,
 )
@@ -263,6 +264,7 @@ class DpBalancedScheduler(BasePackingScheduler):
         """
 
         total_dcp_gpus = dp_cp_group.size()
+        scheduler_dp_group = get_data_parallel_gather_group(dp_group, dp_cp_group)
         is_first_pp = pp_group.rank() == 0
         is_last_pp = pp_group.rank() == pp_group.size() - 1
 
@@ -308,7 +310,7 @@ class DpBalancedScheduler(BasePackingScheduler):
 
             # Step 1: Fetch batches and gather global sequence lengths
             batch, global_id_seqlens, global_ids_this_rank, offsets, seqlens_gathered = (
-                get_batch_and_global_seqlens(data_iterator, num_microbatches, dp_group)
+                get_batch_and_global_seqlens(data_iterator, num_microbatches, scheduler_dp_group)
             )
 
             # Step 2: Check required sample keys
@@ -352,7 +354,7 @@ class DpBalancedScheduler(BasePackingScheduler):
                 global_id_seqlens,
                 sample_id_groups,
                 offsets,
-                dp_group,
+                scheduler_dp_group,
                 dp_cp_group,
             )
 
@@ -390,6 +392,9 @@ class DpBalancedScheduler(BasePackingScheduler):
             )
         )
         num_micro_batches = int(num_micro_batches)
+        graph_slots = getattr(config, '_cuda_graph_num_microbatches', None)
+        if graph_slots is not None and num_micro_batches > graph_slots:
+            raise ValueError(f"{num_micro_batches=} exceeds captured CUDA graph {graph_slots=}.")
 
         # Step 8: Broadcast to TP group and create data_iterator
         new_data_iterator = create_data_iterator(
@@ -433,6 +438,7 @@ class DefaultDynamicCPScheduler(DpBalancedScheduler):
                 self.total_hdp_gpus,
                 max_seq_len_per_rank=mslpr,
                 min_cp_size=min_cp,
+                max_num_seqs=self.max_num_seqs,
             )
             sample_id_groups.append(sample_ids)
 
@@ -457,8 +463,8 @@ def _get_scheduler_max_real_num_seqs(config) -> Optional[int]:
     """Return the scheduler cap for real THD sequences.
 
     ``thd_max_packed_sequences`` is the final static THD capacity, including the
-    optional dummy sequence appended for a padding tail. The dp_balanced
-    scheduler only packs real sequences, so reserve one slot when dummy-tail
+    optional dummy sequence appended for a padding tail. Packing schedulers
+    only place real sequences, so reserve one slot when dummy-tail
     padding is enabled.
     """
     max_num_seqs = getattr(config, 'thd_max_packed_sequences', None)
@@ -525,11 +531,7 @@ def wrap_data_iterator(
     if scheduler_type == 'default_dynamic_cp':
         scheduler_kwargs['min_cp_size'] = config.min_dynamic_context_parallel_size
 
-    scheduler_max_num_seqs = (
-        _get_scheduler_max_real_num_seqs(config)
-        if scheduler_type == 'dp_balanced'
-        else getattr(config, 'thd_max_packed_sequences', None)
-    )
+    scheduler_max_num_seqs = _get_scheduler_max_real_num_seqs(config)
 
     scheduler = scheduler_map[scheduler_type](
         config.max_seqlen_per_dp_cp_rank,

--- a/megatron/core/datasets/data_schedule_utils.py
+++ b/megatron/core/datasets/data_schedule_utils.py
@@ -355,6 +355,22 @@ def create_data_iterator(
     return new_data_iterator
 
 
+def get_data_parallel_gather_group(dp_group, dp_cp_group):
+    """Reuse DPxCP only when it has exactly the same ordered ranks as DP."""
+    if dp_group.size() != dp_cp_group.size():
+        return dp_group
+
+    if dp_group is not dp_cp_group and torch.distributed.is_initialized():
+        dp_ranks = torch.distributed.get_process_group_ranks(dp_group)
+        dp_cp_ranks = torch.distributed.get_process_group_ranks(dp_cp_group)
+        groups_match = dp_ranks == dp_cp_ranks
+    else:
+        groups_match = dp_group.rank() == dp_cp_group.rank()
+    if not groups_match:
+        raise RuntimeError("Equivalent DP and DPxCP groups must use the same rank order.")
+    return dp_cp_group
+
+
 def reroute_samples_to_dcp_ranks(
     batch, global_ids_this_rank, global_id_seqlens, sample_id_groups, offsets, dp_group, dp_cp_group
 ):
@@ -364,7 +380,8 @@ def reroute_samples_to_dcp_ranks(
     Each CP lane gathers the samples from its DP group, then keeps only the
     samples assigned to its DPxCP rank. Gathering within ``dp_group`` avoids
     collecting the identical input held by every CP sibling and avoids the
-    fully connected P2P transport created by NCCL all-to-all.
+    fully connected P2P transport created by NCCL all-to-all. When DP and
+    DPxCP are equivalent, the already-warmed DPxCP communicator is reused.
 
     All ranks in ``dp_group`` must provide the same set of data keys. CP siblings
     that share a non-CP DP rank must additionally provide byte-identical sample
@@ -380,6 +397,7 @@ def reroute_samples_to_dcp_ranks(
     dcp_rank = dp_cp_group.rank()
     dp_rank = dp_group.rank()
     dp_size = dp_group.size()
+    gather_group = get_data_parallel_gather_group(dp_group, dp_cp_group)
 
     # Keep collective ordering independent of dictionary insertion order. Unknown
     # keys require an explicit layout classification rather than being silently dropped.
@@ -462,7 +480,9 @@ def reroute_samples_to_dcp_ranks(
             gathered_tensor = gather_input
         else:
             gathered_tensor = local_tensor.new_empty(dp_size * max_rank_numel)
-            torch.distributed.all_gather_into_tensor(gathered_tensor, gather_input, group=dp_group)
+            torch.distributed.all_gather_into_tensor(
+                gathered_tensor, gather_input, group=gather_group
+            )
 
         for gid in recv_ids:
             start, sample_numel = sample_slices[gid]
@@ -594,6 +614,7 @@ def next_hdp_group_packing_aware(
     total_gpus: int,
     max_seq_len_per_rank: int,
     min_cp_size: int = 1,
+    max_num_seqs: Optional[int] = None,
 ) -> Tuple[List[List[int]], List[Tuple[int, int]], List[float], List[List[int]]]:
     """Form one DCP microbatch with packing-aware CP group selection.
 
@@ -607,7 +628,7 @@ def next_hdp_group_packing_aware(
     The scheduler keeps the legacy invariant that each returned microbatch has
     no empty DPxCP rank after the fill step. For non-power-of-two DPxCP layouts,
     it falls back to the full DPxCP group if power-of-two expansion cannot fill
-    every rank.
+    every rank. ``max_num_seqs`` optionally caps the real sequences per subgroup.
     """
     if not sample_seqlens:
         return (
@@ -667,6 +688,11 @@ def next_hdp_group_packing_aware(
 
             for group_id, size in list(group_size.items()):
                 if size != cp_size:
+                    continue
+                if (
+                    max_num_seqs is not None
+                    and len(micro_batches[group_members[group_id][0]]) >= max_num_seqs
+                ):
                     continue
                 if packing_sequence_len.get(group_id, 0) + seq_len / cp_size > max_seq_len_per_rank:
                     continue
@@ -803,7 +829,9 @@ def next_hdp_group_packing_aware(
 
         for sample_id, seq_len in sample_seqlens:
             per_rank_len = seq_len / total_gpus
-            if packed_sequence_len + per_rank_len <= max_seq_len_per_rank:
+            if (
+                max_num_seqs is None or len(selected) < max_num_seqs
+            ) and packed_sequence_len + per_rank_len <= max_seq_len_per_rank:
                 selected.append((sample_id, seq_len))
                 packed_sequence_len += per_rank_len
             else:

--- a/megatron/core/datasets/data_schedule_utils.py
+++ b/megatron/core/datasets/data_schedule_utils.py
@@ -868,7 +868,7 @@ def align_sample_id_groups(sample_id_groups: List, microbatch_group_size_per_vp_
     remainder = (-len(sample_id_groups)) % multiple
     i = len(sample_id_groups) - 1
 
-    def split_group(sample_id_group):
+    def split_group(sample_id_group, allow_packed_full_group=False):
         total_hdp_ranks = len(sample_id_group)
         cu_ranks = [0]
         prev_cp_size = 0
@@ -888,7 +888,20 @@ def align_sample_id_groups(sample_id_groups: List, microbatch_group_size_per_vp_
             cu_ranks.append(start_rank + cp_size)
             prev_cp_size = cp_size
         if len(cu_ranks) == 2:
-            return None, None
+            if not allow_packed_full_group:
+                return None, None
+            packed_ids = sample_id_group[0]
+            if len(packed_ids) < 2:
+                return None, None
+            assert all(rank_ids == packed_ids for rank_ids in sample_id_group), (
+                "A full DPxCP group must carry the same packed sample IDs on every rank."
+            )
+            kept_ids = packed_ids[:-1]
+            moved_ids = packed_ids[-1:]
+            return (
+                [list(kept_ids) for _ in range(total_hdp_ranks)],
+                [list(moved_ids) for _ in range(total_hdp_ranks)],
+            )
 
         k = 0
         while cu_ranks[k] < total_hdp_ranks // 2:
@@ -934,17 +947,24 @@ def align_sample_id_groups(sample_id_groups: List, microbatch_group_size_per_vp_
         return sample_id_group
 
     attempts_since_split = 0
+    allow_packed_full_group = False
     while remainder > 0:
         if i < 0:
             if attempts_since_split >= len(sample_id_groups):
-                assert False, 'align_sample_id_groups: no tail microbatch has enough ids to split'
+                if allow_packed_full_group:
+                    assert False, 'align_sample_id_groups: no tail microbatch has enough ids to split'
+                allow_packed_full_group = True
+                attempts_since_split = 0
             i = len(sample_id_groups) - 1
-        group1, group2 = split_group(sample_id_groups[i])
+        group1, group2 = split_group(
+            sample_id_groups[i], allow_packed_full_group=allow_packed_full_group
+        )
         if group1 is not None and group2 is not None:
             sample_id_groups[i] = group1
             sample_id_groups.append(group2)
             remainder -= 1
             attempts_since_split = 0
+            allow_packed_full_group = False
         else:
             attempts_since_split += 1
         i -= 1

--- a/megatron/core/datasets/data_schedule_utils.py
+++ b/megatron/core/datasets/data_schedule_utils.py
@@ -893,9 +893,9 @@ def align_sample_id_groups(sample_id_groups: List, microbatch_group_size_per_vp_
             packed_ids = sample_id_group[0]
             if len(packed_ids) < 2:
                 return None, None
-            assert all(rank_ids == packed_ids for rank_ids in sample_id_group), (
-                "A full DPxCP group must carry the same packed sample IDs on every rank."
-            )
+            assert all(
+                rank_ids == packed_ids for rank_ids in sample_id_group
+            ), "A full DPxCP group must carry the same packed sample IDs on every rank."
             kept_ids = packed_ids[:-1]
             moved_ids = packed_ids[-1:]
             return (
@@ -952,7 +952,9 @@ def align_sample_id_groups(sample_id_groups: List, microbatch_group_size_per_vp_
         if i < 0:
             if attempts_since_split >= len(sample_id_groups):
                 if allow_packed_full_group:
-                    assert False, 'align_sample_id_groups: no tail microbatch has enough ids to split'
+                    assert (
+                        False
+                    ), 'align_sample_id_groups: no tail microbatch has enough ids to split'
                 allow_packed_full_group = True
                 attempts_since_split = 0
             i = len(sample_id_groups) - 1

--- a/megatron/core/fusions/fused_mla_yarn_rope_apply.py
+++ b/megatron/core/fusions/fused_mla_yarn_rope_apply.py
@@ -387,11 +387,9 @@ class _FusedMLARoPEInplace(torch.autograd.Function):
             ROPE_FIRST=rope_first,
             HAS_THD_GLOBAL_START=has_thd_global_start,
         )
-        ctx.save_for_backward(cos, sin, *(() if position_ids is None else (position_ids,)))
-        ctx.has_position_ids = position_ids is not None
+        ctx.save_for_backward(cos, sin, position_ids, cu_seqlens_q)
         ctx.nope_dim = nope_dim
         ctx.emb_dim = emb_dim
-        ctx.cu_seqlens_q = cu_seqlens_q
         ctx.rotary_interleaved = rotary_interleaved
         ctx.inverse = inverse
         ctx.remove_interleaving = remove_interleaving
@@ -413,21 +411,17 @@ class _FusedMLARoPEInplace(torch.autograd.Function):
             grad: [seq_len, batch_size, head_num, nope_dim + emb_dim]
                 or [total_seq_len, head_num, nope_dim + emb_dim]
         """
-        if ctx.has_position_ids:
-            cos, sin, position_ids = ctx.saved_tensors
-        else:
-            cos, sin = ctx.saved_tensors
-            position_ids = None
+        cos, sin, position_ids, cu_seqlens_q = ctx.saved_tensors
         max_seqlen = None
         batch_size = None
         seq_num = None
-        if ctx.cu_seqlens_q is None:
+        if cu_seqlens_q is None:
             max_seqlen, batch_size, nheads, headdim = grad.shape
             grad = grad.contiguous().view(-1, nheads, headdim)
             total_seqlen = grad.shape[0]
         else:
-            seq_num = len(ctx.cu_seqlens_q) - 1
-            if ctx.has_position_ids or ctx.has_thd_global_start:
+            seq_num = len(cu_seqlens_q) - 1
+            if position_ids is not None or ctx.has_thd_global_start:
                 grad = grad.contiguous()
             total_seqlen, nheads, headdim = grad.shape
         assert grad.stride(-1) == 1
@@ -442,7 +436,7 @@ class _FusedMLARoPEInplace(torch.autograd.Function):
             nheads,
             batch_size,
             seq_num,
-            ctx.cu_seqlens_q,
+            cu_seqlens_q,
             position_ids,
             ctx.thd_global_start,
             grad.stride(0),
@@ -456,7 +450,7 @@ class _FusedMLARoPEInplace(torch.autograd.Function):
             ROPE_FIRST=ctx.rope_first,
             HAS_THD_GLOBAL_START=ctx.has_thd_global_start,
         )
-        if ctx.cu_seqlens_q is None:
+        if cu_seqlens_q is None:
             grad = grad.view(max_seqlen, batch_size, nheads, headdim)
         return grad, None, None, None, None, None, None, None, None, None, None, None, None, None
 

--- a/megatron/core/models/common/embeddings/rope_utils.py
+++ b/megatron/core/models/common/embeddings/rope_utils.py
@@ -780,6 +780,13 @@ def apply_rotary_pos_emb(
                         "Using unfused implementation.",
                     ),
                     (
+                        max_seqlen is not None and freqs.size(0) < max_seqlen,
+                        "te-rope-thd-short-freqs",
+                        "Transformer Engine fused RoPE for THD layout requires the frequency "
+                        f"table length ({freqs.size(0)}) to cover max_seqlen ({max_seqlen}). "
+                        "Using unfused implementation.",
+                    ),
+                    (
                         fused_apply_rotary_pos_emb_thd is None,
                         "te-rope-thd-unavailable",
                         "Transformer Engine fused RoPE for THD layout is unavailable. "

--- a/megatron/core/models/gpt/gpt_model.py
+++ b/megatron/core/models/gpt/gpt_model.py
@@ -318,6 +318,16 @@ class GPTModel(LanguageModule):
         assert len(input_tensor) == 1, 'input_tensor should only be length 1 for gpt/bert'
         self.decoder.set_input_tensor(input_tensor[0])
 
+    def _bound_thd_rotary_seq_len(self, rotary_seq_len, packed_seq_params):
+        """Keep THD RoPE inputs consistent with the graph capture layout."""
+        if packed_seq_params is None or packed_seq_params.qkv_format != 'thd':
+            return rotary_seq_len
+        cp_size = packed_seq_params.local_cp_size
+        if cp_size is None:
+            cp_size = self.config.context_parallel_size
+        upper_bound = getattr(self.config, '_cuda_graph_thd_rotary_seq_lens', {}).get(int(cp_size))
+        return rotary_seq_len if upper_bound is None else min(rotary_seq_len, upper_bound)
+
     def _preprocess(
         self,
         input_ids: Tensor,
@@ -411,6 +421,7 @@ class GPTModel(LanguageModule):
                 rotary_seq_len = self.rotary_pos_emb.get_rotary_seq_len(
                     inference_context, self.decoder, decoder_input, self.config, packed_seq_params
                 )
+                rotary_seq_len = self._bound_thd_rotary_seq_len(rotary_seq_len, packed_seq_params)
                 rotary_pos_emb = self.rotary_pos_emb(
                     rotary_seq_len,
                     packed_seq=packed_seq_params is not None
@@ -422,6 +433,7 @@ class GPTModel(LanguageModule):
                 rotary_seq_len = self.rotary_pos_emb.get_rotary_seq_len(
                     inference_context, self.decoder, decoder_input, self.config, packed_seq_params
                 )
+                rotary_seq_len = self._bound_thd_rotary_seq_len(rotary_seq_len, packed_seq_params)
                 rotary_pos_emb, _ = self.rotary_pos_emb(
                     rotary_seq_len,
                     packed_seq=packed_seq_params is not None

--- a/megatron/core/packed_seq_params.py
+++ b/megatron/core/packed_seq_params.py
@@ -366,14 +366,8 @@ def _resolve_thd_padding_lengths(
         global_target_len = local_target_len * cp_size
         return local_actual_T, global_actual_T, local_target_len, global_target_len, mask_device
 
-    # Metadata-only path: resolve the global padded endpoint first.
-    global_target_len = (
-        int(target_len) * cp_size
-        if target_len is not None
-        else _round_up_to_alignment(global_actual_T, alignment)
-    )
-
-    # Under CP, ask TE which packed rows this rank would receive.
+    # Metadata-only path: first recover the already-sliced local length. Padding
+    # targets and alignment are CP-local, just as they are in the tensor path.
     if cp_size > 1:
         from megatron.core.extensions.transformer_engine import get_thd_partitioned_indices
 
@@ -388,16 +382,16 @@ def _resolve_thd_padding_lengths(
                 partition_cu_seqlens, global_actual_T, cp_size, cp_rank
             ).numel()
         )
-        # Do the same for the padded endpoint; THD CP is not simple equal split.
-        local_target_len = int(
-            get_thd_partitioned_indices(
-                partition_cu_seqlens, global_target_len, cp_size, cp_rank
-            ).numel()
-        )
     else:
         # Without CP, local and global metadata lengths are identical.
         local_actual_T = global_actual_T
-        local_target_len = global_target_len
+
+    local_target_len = (
+        int(target_len)
+        if target_len is not None
+        else _round_up_to_alignment(local_actual_T, alignment)
+    )
+    global_target_len = local_target_len * cp_size
 
     return local_actual_T, global_actual_T, local_target_len, global_target_len, mask_device
 

--- a/megatron/core/parallel_state.py
+++ b/megatron/core/parallel_state.py
@@ -447,9 +447,7 @@ class RankGenerator(object):
     def __init__(
         self, tp: int, ep: int, dp: int, pp: int, cp: int, order: str, rank_offset: int = 0
     ) -> None:
-        assert (
-            ep == 1 or cp == 1
-        ), "Both EP and CP > 1 in not allow in one rank generator. \
+        assert ep == 1 or cp == 1, "Both EP and CP > 1 in not allow in one rank generator. \
             CP is only included in default RankGenerator, and EP only in expert RankGenerator."
 
         self.tp = tp

--- a/megatron/core/parallel_state.py
+++ b/megatron/core/parallel_state.py
@@ -447,7 +447,9 @@ class RankGenerator(object):
     def __init__(
         self, tp: int, ep: int, dp: int, pp: int, cp: int, order: str, rank_offset: int = 0
     ) -> None:
-        assert ep == 1 or cp == 1, "Both EP and CP > 1 in not allow in one rank generator. \
+        assert (
+            ep == 1 or cp == 1
+        ), "Both EP and CP > 1 in not allow in one rank generator. \
             CP is only included in default RankGenerator, and EP only in expert RankGenerator."
 
         self.tp = tp

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -8,7 +8,7 @@ import math
 import os
 import time
 from collections import defaultdict
-from contextlib import nullcontext
+from contextlib import nullcontext, suppress
 from copy import deepcopy
 from dataclasses import dataclass, is_dataclass
 from enum import Enum
@@ -1640,6 +1640,11 @@ def _layer_is_graphable(layer, config):
     if not isinstance(layer, GraphableMegatronModule):
         return False
 
+    if getattr(config, 'dynamic_context_parallel', False) and not hasattr(
+        layer, '_activate_dynamic_cp_cuda_graph'
+    ):
+        return False
+
     # If cuda_graph_modules is not set, every layer is graphed.
     if not config.cuda_graph_modules:
         return True
@@ -1754,6 +1759,26 @@ def _is_mtp_te_callable(layer, chunk_with_decoder):
     return False
 
 
+class _DynamicCPCaptureCallable(torch.nn.Module):
+    """Set one dynamic-CP context immediately before capturing a wrapped layer."""
+
+    def __init__(self, module, context_setter, context):
+        super().__init__()
+        self.module = module
+        self._context_setter = context_setter
+        self._capture_context = context
+        self.training = module.training
+
+    def forward(self, *args, **kwargs):
+        """Select the dynamic-CP capture context and invoke the wrapped layer."""
+        self._context_setter(self._capture_context)
+        outputs = self.module(*args, **kwargs)
+        mlp_norm_manager = getattr(self.module, 'mlp_norm_manager', None)
+        if mlp_norm_manager is not None and not mlp_norm_manager.offload:
+            self.module.mlp_norm_manager = None
+        return outputs
+
+
 class TECudaGraphHelper:
     """
     Helper class to capture CUDA Graphs using TE make_graphed_callables().
@@ -1797,15 +1822,30 @@ class TECudaGraphHelper:
         self.dp_group = self.pg_collection.dp
         self.dp_cp_group = self.pg_collection.dp_cp
         self.pp_group = self.pg_collection.pp
+        thd_rotary_seq_lens = {}
+        if self.config.max_seqlen_per_dp_cp_rank is not None:
+            capture_cp_sizes = (
+                self._get_dynamic_cp_capture_sizes()
+                if self.config.dynamic_context_parallel
+                else (int(self.config.context_parallel_size),)
+            )
+            thd_rotary_seq_lens = {
+                cp_size: self._get_thd_capture_rotary_layout(cp_size)[0]
+                for cp_size in capture_cp_sizes
+            }
         from megatron.core.pipeline_parallel.p2p_communication import P2PCommunicator
 
         self.p2p_communicator = P2PCommunicator(pp_group=self.pp_group, config=self.config)
         self.num_model_chunks = len(model)
 
-        # Number of microbatches to capture. The value will be set in _get_cuda_graph_input_data().
+        # Number of microbatch graph slots to capture. The value is set in
+        # _get_cuda_graph_input_data().
         self.num_microbatches = None
+        self._dynamic_slot_liveness_limit = None
 
         self._discover_layers()
+        self._thd_rotary_seq_lens = thd_rotary_seq_lens
+        self._publish_thd_rotary_seq_lens(self._thd_rotary_seq_lens)
 
         # Flags to track CUDA Graph state:
         # - _capture_finished: Whether create_cudagraphs() has been called (used by training loop)
@@ -1960,6 +2000,72 @@ class TECudaGraphHelper:
         """
         return self._graphs_created
 
+    def _publish_thd_rotary_seq_lens(self, rotary_seq_lens):
+        """Publish capture RoPE limits to every independently built VPP chunk."""
+        self.config._cuda_graph_thd_rotary_seq_lens = rotary_seq_lens
+        for model_chunk in self.chunks_with_decoder:
+            if model_chunk is not None:
+                model_chunk.config._cuda_graph_thd_rotary_seq_lens = rotary_seq_lens
+
+    def _clear_thd_rotary_seq_lens(self):
+        """Remove capture-only RoPE limits from every VPP config copy."""
+        configs = {id(self.config): self.config}
+        for model_chunk in self.chunks_with_decoder:
+            if model_chunk is not None:
+                configs[id(model_chunk.config)] = model_chunk.config
+        for config in configs.values():
+            vars(config).pop('_cuda_graph_thd_rotary_seq_lens', None)
+
+    def _get_thd_capture_rotary_layout(self, capture_cp_size):
+        """Return the RoPE length and packed boundaries used for THD capture."""
+        token_capacity = int(self.config.max_seqlen_per_dp_cp_rank) * int(capture_cp_size)
+        sample_length_upper_bound = (
+            self.thd_sequence_length_upper_bound
+            if self.thd_sequence_length_upper_bound is not None
+            else self.seq_length
+        )
+        rotary_seq_len = min(token_capacity, int(sample_length_upper_bound))
+        max_num_seqs = int(self.config.thd_max_packed_sequences or 1)
+
+        alignment = self.config.pad_packed_seq_alignment
+        if not isinstance(alignment, int) or alignment < 1:
+            alignment = 2 * int(capture_cp_size)
+        capture_seq_len = (rotary_seq_len // alignment) * alignment
+        num_capture_seqs = (
+            math.ceil(token_capacity / capture_seq_len) if capture_seq_len > 0 else max_num_seqs + 1
+        )
+
+        # The fused THD RoPE kernel indexes by cu_seqlens during warmup/capture.
+        # Fall back to one full-capacity sequence if the fixed cu_seqlens surface
+        # cannot describe enough bounded sequences safely.
+        if num_capture_seqs > max_num_seqs:
+            rotary_seq_len = token_capacity
+            capture_seq_len = token_capacity
+
+        boundaries = tuple(
+            min(index * capture_seq_len, token_capacity) for index in range(max_num_seqs + 1)
+        )
+        return rotary_seq_len, boundaries
+
+    @staticmethod
+    def _seed_thd_capture_cu_seqlens(static_inputs, boundaries):
+        """Seed capture-only THD boundaries without changing their static shapes."""
+        for name in (
+            "cu_seqlens_q",
+            "cu_seqlens_kv",
+            "cu_seqlens_q_padded",
+            "cu_seqlens_kv_padded",
+        ):
+            if name not in static_inputs:
+                continue
+            target = static_inputs[name]
+            if target.numel() != len(boundaries):
+                raise RuntimeError(
+                    f"THD capture input {name} has {target.numel()} entries, "
+                    f"but {len(boundaries)} boundaries were prepared."
+                )
+            target.copy_(torch.tensor(boundaries, dtype=target.dtype, device=target.device))
+
     def _get_sample_arguments(self, order, chunk_id_list=None):
         """
         Generate sample arguments and keyword arguments for CUDA Graph capturing with
@@ -2038,12 +2144,18 @@ class TECudaGraphHelper:
                     transformer_module.position_embedding_type == 'rope'
                     and not self.config.multi_latent_attention
                 ):
-                    rotary_seq_len = transformer_module.rotary_pos_emb.get_rotary_seq_len(
-                        None, transformer_module.decoder, transformer_input, self.config, None
-                    )
+                    packed_seq = hasattr(layer, "_is_thd_cuda_graph") and layer._is_thd_cuda_graph()
+                    capture_cp_group = None
+                    if packed_seq:
+                        capture_cp_size, capture_cp_group = layer._get_thd_cuda_graph_capture_cp()
+                        rotary_seq_len, _ = self._get_thd_capture_rotary_layout(capture_cp_size)
+                    else:
+                        rotary_seq_len = transformer_module.rotary_pos_emb.get_rotary_seq_len(
+                            None, transformer_module.decoder, transformer_input, self.config, None
+                        )
                     if rotary_seq_len not in rotary_pos_emb_cache:
                         rotary_pos_emb_cache[rotary_seq_len] = transformer_module.rotary_pos_emb(
-                            rotary_seq_len
+                            rotary_seq_len, packed_seq=packed_seq, cp_group=capture_cp_group
                         )
                     return rotary_pos_emb_cache[rotary_seq_len]
                 else:
@@ -2068,6 +2180,15 @@ class TECudaGraphHelper:
                     or CudaGraphModule.attn in self.config.cuda_graph_modules
                 )
             )
+
+            if (
+                contains_self_attn
+                and hasattr(layer, "_is_thd_cuda_graph")
+                and layer._is_thd_cuda_graph()
+            ):
+                capture_cp_size, _ = layer._get_thd_cuda_graph_capture_cp()
+                _, boundaries = self._get_thd_capture_rotary_layout(capture_cp_size)
+                self._seed_thd_capture_cu_seqlens(static_inputs, boundaries)
 
             _sample_kwargs = {}
             if is_te_min_version("1.10.0"):
@@ -2247,22 +2368,33 @@ class TECudaGraphHelper:
                 return self.pg_collection.tp
 
     def _should_use_dynamic_microbatch_slots(self) -> bool:
-        """Whether to capture a bounded number of graph slots and reuse them by modulo."""
+        """Whether to capture a schedule that supports a varying microbatch count."""
         return bool(getattr(self.config, "cuda_graph_dynamic_microbatches", False))
+
+    def _should_share_dynamic_cp_pool(self) -> bool:
+        """Whether DCP branches should share one TE graph pool and slot arenas."""
+        return (
+            self.config.dynamic_context_parallel
+            and self._should_use_dynamic_microbatch_slots()
+            and not self.config.overlap_moe_expert_parallel_comm
+            and not self.config.delay_wgrad_compute
+        )
+
+    def _publish_dynamic_cp_graph_microbatch_limit(self) -> None:
+        """Publish the logical PP range proved safe for the physical graph-slot ring."""
+        if self.config.dynamic_context_parallel and self.pp_group.size() > 1:
+            self.config._cuda_graph_num_microbatches = (
+                self._dynamic_slot_liveness_limit or self.num_microbatches
+            )
 
     def _needs_full_local_padding_mask(self, layer, chunk, static_inputs) -> bool:
         """Whether this layer's static padding_mask needs full max_seqlen_per_dp_cp_rank.
 
-        For the post_process chunk (last PP/VPP chunk that holds labels),
-        padding_mask arrives at the full CP-local length because:
-          1. labels are present -> actual_T_is_local=True -> no CP re-partition;
-          2. pre_process=False  -> _preprocess does not scatter under SP.
-        Other non-pre_process chunks (intermediate VPP) have no data, so their
-        captured padding_mask stays at the default scattered size from
-        `get_layer_static_inputs` (~max_seqlen/CP/TP).
+        Sequence packing broadcasts the CP-local padding mask to every PP stage. The
+        pre-process stage scatters it across TP ranks under sequence parallelism, while
+        every later stage passes the full mask directly to its transformer layers.
 
-        Returns True only for that post_process-with-data case under THD CUDA
-        Graph + SP + PP>1.
+        Returns True for every non-pre-process PP/VPP chunk under THD CUDA Graph + SP + PP>1.
         """
         return (
             hasattr(layer, "_is_thd_cuda_graph")
@@ -2270,7 +2402,6 @@ class TECudaGraphHelper:
             and self.config.sequence_parallel
             and self.config.pipeline_model_parallel_size > 1
             and not getattr(chunk, "pre_process", True)
-            and getattr(chunk, "post_process", False)
             and "padding_mask" in static_inputs
         )
 
@@ -2324,6 +2455,25 @@ class TECudaGraphHelper:
         )
 
     @staticmethod
+    def _get_dynamic_slot_liveness_microbatch_counts(
+        max_num_microbatches, microbatch_group_size_per_vp_stage=None
+    ):
+        """Return scheduler-reachable microbatch counts for the liveness union."""
+        assert max_num_microbatches >= 1
+        if microbatch_group_size_per_vp_stage is None:
+            return tuple(range(1, max_num_microbatches + 1))
+
+        multiple = int(microbatch_group_size_per_vp_stage)
+        if multiple <= 1:
+            return tuple(range(1, max_num_microbatches + 1))
+        if max_num_microbatches % multiple:
+            raise ValueError(
+                f"Dynamic CUDA graph microbatch limit {max_num_microbatches} is not "
+                f"aligned to the VPP microbatch group size {multiple}."
+            )
+        return tuple(range(multiple, max_num_microbatches + 1, multiple))
+
+    @staticmethod
     def _get_dp_balanced_thd_max_num_microbatches(
         global_batch_size,
         dp_size,
@@ -2332,6 +2482,7 @@ class TECudaGraphHelper:
         max_sequence_length,
         microbatch_group_size_per_vp_stage=None,
         max_num_seqs=None,
+        max_subsamples_per_item=1,
     ):
         """Return the packed-microbatch upper bound for dp_balanced THD packing."""
         assert global_batch_size >= 1
@@ -2339,13 +2490,15 @@ class TECudaGraphHelper:
         assert cp_size >= 1
         assert max_seqlen_per_dp_cp_rank >= 1
         assert max_sequence_length >= 1
+        assert max_subsamples_per_item >= 1
 
         max_seq_len_all_ranks = max_seqlen_per_dp_cp_rank * cp_size
         seqs_per_pack = max(1, max_seq_len_all_ranks // max_sequence_length)
         if max_num_seqs is not None:
             seqs_per_pack = min(seqs_per_pack, max(1, int(max_num_seqs)))
 
-        num_packed_sequences = math.ceil(global_batch_size / seqs_per_pack)
+        max_subsamples = global_batch_size * max_subsamples_per_item
+        num_packed_sequences = math.ceil(max_subsamples / seqs_per_pack)
         multiple = dp_size * (
             microbatch_group_size_per_vp_stage
             if microbatch_group_size_per_vp_stage is not None
@@ -2354,10 +2507,70 @@ class TECudaGraphHelper:
         num_packed_sequences = math.ceil(num_packed_sequences / multiple) * multiple
         return max(1, num_packed_sequences // dp_size)
 
+    @staticmethod
+    def _get_default_dynamic_cp_thd_max_num_microbatches(
+        global_batch_size,
+        total_dcp_gpus,
+        max_seqlen_per_dp_cp_rank,
+        max_sequence_length,
+        min_cp_size=1,
+        max_subsamples_per_item=1,
+        microbatch_group_size_per_vp_stage=None,
+    ):
+        """Return the scheduler-derived microbatch upper bound for dynamic CP.
+
+        The dynamic scheduler fills every DPxCP rank in each returned microbatch. Since
+        samples are processed longest-first, each non-final microbatch consumes at least
+        ``total_dcp_gpus / max_required_cp_size`` subsamples. The final partial placement is
+        expanded across otherwise-empty ranks. Account for pre-packed dataset items and VPP
+        group alignment before publishing the CUDA graph schedule limit.
+        """
+        assert global_batch_size >= 1
+        assert total_dcp_gpus >= 1
+        assert max_seqlen_per_dp_cp_rank >= 1
+        assert max_sequence_length >= 1
+        assert min_cp_size >= 1
+        assert max_subsamples_per_item >= 1
+
+        raw_required_cp_size = math.ceil(max_sequence_length / max_seqlen_per_dp_cp_rank)
+        rounded_required_cp_size = 1 << (raw_required_cp_size - 1).bit_length()
+        max_required_cp_size = min(total_dcp_gpus, max(min_cp_size, rounded_required_cp_size))
+        subsamples_per_microbatch = max(1, total_dcp_gpus // max_required_cp_size)
+        max_subsamples = global_batch_size * max_subsamples_per_item
+        max_num_microbatches = math.ceil(max_subsamples / subsamples_per_microbatch)
+
+        if microbatch_group_size_per_vp_stage is not None:
+            multiple = int(microbatch_group_size_per_vp_stage)
+            max_num_microbatches = math.ceil(max_num_microbatches / multiple) * multiple
+        return max(1, max_num_microbatches)
+
     def _get_thd_varlen_max_num_microbatches(
         self, runtime_num_microbatches, microbatch_group_size_per_vp_stage
     ):
         """Return the THD packing upper bound used for dynamic CUDA graph capture."""
+        if self.config.sequence_packing_scheduler == 'default_dynamic_cp':
+            global_batch_size = (
+                runtime_num_microbatches * self.micro_batch_size * self.dp_group.size()
+            )
+            max_sequence_length = (
+                self.thd_sequence_length_upper_bound
+                if self.thd_sequence_length_upper_bound is not None
+                else self.seq_length
+            )
+            max_num_microbatches = self._get_default_dynamic_cp_thd_max_num_microbatches(
+                global_batch_size,
+                self.dp_cp_group.size(),
+                int(self.config.max_seqlen_per_dp_cp_rank),
+                int(max_sequence_length),
+                min_cp_size=int(self.config.min_dynamic_context_parallel_size),
+                max_subsamples_per_item=int(getattr(self.config, 'thd_max_subsamples_per_item', 1)),
+                microbatch_group_size_per_vp_stage=(
+                    None
+                    if self.config.virtual_pipeline_model_parallel_size is None
+                    else microbatch_group_size_per_vp_stage
+                ),
+            )
+            return (max_num_microbatches, "dynamic_cp_scheduler_upper_bound")
         if self.config.sequence_packing_scheduler != 'dp_balanced':
             return runtime_num_microbatches, "runtime"
         if self.config.max_seqlen_per_dp_cp_rank is None:
@@ -2397,8 +2610,40 @@ class TECudaGraphHelper:
                     else microbatch_group_size_per_vp_stage
                 ),
                 max_num_seqs=max_num_seqs,
+                max_subsamples_per_item=int(getattr(self.config, 'thd_max_subsamples_per_item', 1)),
             ),
             "thd_varlen_upper_bound",
+        )
+
+    def _build_pipeline_order(
+        self,
+        num_microbatches,
+        microbatch_group_size_per_vp_stage,
+        overlap_moe_expert_parallel_comm=None,
+        p2p_communicator=None,
+    ):
+        """Build the PP/VPP order for one candidate microbatch count."""
+        from megatron.core.pipeline_parallel.schedules import (
+            get_pp_rank_microbatches,
+            get_schedule_table,
+        )
+
+        schedule_kwargs = {'forward_only': False}
+        if overlap_moe_expert_parallel_comm is not None:
+            schedule_kwargs['overlap_moe_expert_parallel_comm'] = overlap_moe_expert_parallel_comm
+        if p2p_communicator is not None:
+            schedule_kwargs['p2p_communicator'] = p2p_communicator
+        _, _, num_warmup_microbatches, _ = get_pp_rank_microbatches(
+            num_microbatches,
+            self.num_model_chunks,
+            microbatch_group_size_per_vp_stage,
+            **schedule_kwargs,
+        )
+        schedule_table = get_schedule_table(
+            num_microbatches, self.num_model_chunks, microbatch_group_size_per_vp_stage
+        )
+        return convert_schedule_table_to_order(
+            num_warmup_microbatches, self.num_model_chunks, schedule_table
         )
 
     def _get_cuda_graph_input_data(self):
@@ -2406,12 +2651,6 @@ class TECudaGraphHelper:
         Create the CUDA Graph capturing input data.
         The data is organized per-chunk per-microbatch per-layer.
         """
-
-        # Get the PP and VPP scheduling order.
-        from megatron.core.pipeline_parallel.schedules import (
-            get_pp_rank_microbatches,
-            get_schedule_table,
-        )
 
         microbatch_group_size_per_vp_stage = self.config.microbatch_group_size_per_vp_stage
         if microbatch_group_size_per_vp_stage is None:
@@ -2426,39 +2665,18 @@ class TECudaGraphHelper:
             ), "If PP is not enabled, there should be only one model chunk."
             self.num_microbatches = 1
         elif self._should_use_dynamic_microbatch_slots():
-            probe_num_microbatches = self._get_probe_num_microbatches_for_dynamic_slots()
-            from megatron.core.pipeline_parallel.schedules import (
-                get_pp_rank_microbatches as _probe_get_pp,
-            )
-            from megatron.core.pipeline_parallel.schedules import (
-                get_schedule_table as _probe_get_st,
-            )
-
-            _, _, _probe_warmup, _ = _probe_get_pp(
-                probe_num_microbatches,
-                self.num_model_chunks,
-                microbatch_group_size_per_vp_stage,
-                False,
-                overlap_moe_expert_parallel_comm=self.config.overlap_moe_expert_parallel_comm,
-            )
-            _probe_st = _probe_get_st(
-                probe_num_microbatches, self.num_model_chunks, microbatch_group_size_per_vp_stage
-            )
-            _probe_order = convert_schedule_table_to_order(
-                _probe_warmup, self.num_model_chunks, _probe_st
-            )
-            auto_num_slots = self._get_required_num_microbatch_slots_from_order(
-                _probe_order, self.num_model_chunks
-            )
-            pp_group = parallel_state.get_pipeline_model_parallel_group()
-            if pp_group is not None and pp_group.size() > 1:
-                auto_num_slots_tensor = torch.tensor(
-                    [auto_num_slots], dtype=torch.int32, device=torch.cuda.current_device()
+            share_dynamic_cp_pool = self._should_share_dynamic_cp_pool()
+            auto_num_slots = None
+            if not share_dynamic_cp_pool:
+                probe_num_microbatches = self._get_probe_num_microbatches_for_dynamic_slots()
+                probe_order = self._build_pipeline_order(
+                    probe_num_microbatches,
+                    microbatch_group_size_per_vp_stage,
+                    overlap_moe_expert_parallel_comm=self.config.overlap_moe_expert_parallel_comm,
                 )
-                torch.distributed.all_reduce(
-                    auto_num_slots_tensor, op=torch.distributed.ReduceOp.MAX, group=pp_group
+                auto_num_slots = self._get_required_num_microbatch_slots_from_order(
+                    probe_order, self.num_model_chunks
                 )
-                auto_num_slots = int(auto_num_slots_tensor.item())
             runtime_num_microbatches = get_num_microbatches()
             max_num_microbatches, capture_mode = self._get_thd_varlen_max_num_microbatches(
                 runtime_num_microbatches, microbatch_group_size_per_vp_stage
@@ -2467,6 +2685,51 @@ class TECudaGraphHelper:
                 self.num_microbatches = runtime_num_microbatches
                 capture_mode = "runtime"
                 fallback_reason = "overlap_moe_expert_parallel_comm/delay_wgrad_compute"
+            elif share_dynamic_cp_pool:
+                # A callable can be replayed after its matching backward has completed. Capture
+                # the exact largest ring required by every scheduler-reachable microbatch count,
+                # then prove its saved-tensor aliases against the same schedule union.
+                liveness_num_microbatches = max(runtime_num_microbatches, max_num_microbatches)
+                self._dynamic_slot_liveness_limit = liveness_num_microbatches
+                candidate_num_microbatches_values = (
+                    self._get_dynamic_slot_liveness_microbatch_counts(
+                        liveness_num_microbatches,
+                        (
+                            None
+                            if self.config.virtual_pipeline_model_parallel_size is None
+                            else microbatch_group_size_per_vp_stage
+                        ),
+                    )
+                )
+                possible_orders = tuple(
+                    tuple(
+                        self._build_pipeline_order(
+                            candidate_num_microbatches,
+                            microbatch_group_size_per_vp_stage,
+                            overlap_moe_expert_parallel_comm=False,
+                        )
+                    )
+                    for candidate_num_microbatches in candidate_num_microbatches_values
+                )
+                self._dynamic_slot_liveness_orders = possible_orders
+                auto_num_slots = max(
+                    self._get_required_num_microbatch_slots_from_order(
+                        possible_order, self.num_model_chunks
+                    )
+                    for possible_order in possible_orders
+                )
+                pp_group = self.pp_group
+                if pp_group is not None and pp_group.size() > 1:
+                    auto_num_slots_tensor = torch.tensor(
+                        [auto_num_slots], dtype=torch.int32, device=torch.cuda.current_device()
+                    )
+                    torch.distributed.all_reduce(
+                        auto_num_slots_tensor, op=torch.distributed.ReduceOp.MAX, group=pp_group
+                    )
+                    auto_num_slots = int(auto_num_slots_tensor.item())
+                self.num_microbatches = auto_num_slots
+                capture_mode = f"{capture_mode}_physical_slots"
+                fallback_reason = None
             else:
                 # auto_num_slots is a topology-only theoretical lower bound for PP/VPP graph
                 # slot liveness. THD varlen packing can produce different real microbatch
@@ -2491,18 +2754,10 @@ class TECudaGraphHelper:
         else:
             self.num_microbatches = get_num_microbatches()
 
-        _, _, num_warmup_microbatches, _ = get_pp_rank_microbatches(
+        order = self._build_pipeline_order(
             self.num_microbatches,
-            self.num_model_chunks,
             microbatch_group_size_per_vp_stage,
-            forward_only=False,
             p2p_communicator=self.p2p_communicator,
-        )
-        schedule_table = get_schedule_table(
-            self.num_microbatches, self.num_model_chunks, microbatch_group_size_per_vp_stage
-        )
-        order = convert_schedule_table_to_order(
-            num_warmup_microbatches, self.num_model_chunks, schedule_table
         )
         log_on_each_pipeline_stage(
             logger=logger,
@@ -2627,22 +2882,420 @@ class TECudaGraphHelper:
                 FineGrainedActivationOffloadingInterface as off_interface,
             )
 
+            post_warmup_hooks = []
             # TE CUDA graph warmup should establish graph state without launching
             # activation D2H copies; the post-warmup hook restores offloading for
             # the measured/replay iterations.
             if self.config.fine_grained_activation_offloading:
                 kwargs['pre_warmup_hook'] = off_interface.disable_offload
-                kwargs['post_warmup_hook'] = off_interface.enable_offload
+                post_warmup_hooks.append(off_interface.enable_offload)
+            if self._should_share_dynamic_cp_pool():
+                post_warmup_hooks.append(self._clear_moe_cudagraph_tensor_attrs)
+            if post_warmup_hooks:
+
+                def post_warmup_hook():
+                    for hook in post_warmup_hooks:
+                        hook()
+
+                kwargs['post_warmup_hook'] = post_warmup_hook
             return kwargs
 
         kwargs = get_make_graphed_callables_kwargs()
         return sample_args, kwargs
 
+    def _clear_moe_cudagraph_tensor_attrs(self) -> None:
+        """Drop eager dispatcher outputs after each TE warmup forward/backward."""
+        seen_dispatchers = set()
+        for layer in self.flattened_callables:
+            for module in layer.modules():
+                dispatcher = getattr(module, 'token_dispatcher', None)
+                if dispatcher is None or id(dispatcher) in seen_dispatchers:
+                    continue
+                seen_dispatchers.add(id(dispatcher))
+                for attr_name in dispatcher.cudagraph_attrs:
+                    dispatcher.set_cudagraph_attr(attr_name, None)
+
+    def _get_dynamic_cp_capture_sizes(self):
+        """Return dynamic CP sizes in capture order."""
+        max_size = self.dp_cp_group.size()
+        min_size = self.config.min_dynamic_context_parallel_size
+        if min_size > max_size or any(
+            size < 1 or size & (size - 1) for size in (min_size, max_size)
+        ):
+            raise ValueError("Dynamic CP graph sizes must be powers of two with min <= max.")
+        largest, smallest = (int(math.log2(size)) for size in (max_size, min_size))
+        return tuple(2**exponent for exponent in range(largest, smallest - 1, -1))
+
+    def _get_dynamic_cp_capture_contexts(self):
+        """Return ``(local_cp_size, process_group)`` contexts to capture eagerly."""
+        if not self.config.dynamic_context_parallel:
+            return [(None, None)]
+
+        return [
+            (size, parallel_state.get_dynamic_data_context_parallel_groups(group_size=size))
+            for size in self._get_dynamic_cp_capture_sizes()
+        ]
+
+    def _set_dynamic_cp_capture_context(self, context):
+        """Propagate the temporary capture context to every layer config copy."""
+        self._set_cuda_graph_config_attr('_cuda_graph_capture_dynamic_cp', context)
+
+    def _get_cuda_graph_configs(self):
+        """Return unique root and graph-layer configs owned by this helper."""
+        configs = {}
+        root_config = getattr(self, 'config', None)
+        if root_config is not None:
+            configs[id(root_config)] = root_config
+        for layers in getattr(self, 'callables_per_chunk', ()):
+            for layer in layers:
+                layer_config = getattr(layer, 'config', None)
+                if layer_config is not None:
+                    configs[id(layer_config)] = layer_config
+        return tuple(configs.values())
+
+    def _set_cuda_graph_config_attr(self, name, value):
+        """Set or clear one capture-only attribute on every helper-owned config."""
+        for config in self._get_cuda_graph_configs():
+            if value is None:
+                vars(config).pop(name, None)
+            else:
+                setattr(config, name, value)
+
+    @staticmethod
+    def _build_slot_aliased_variant_order(
+        order, num_variants, num_model_chunks, canonical_variant=None
+    ):
+        """Capture each CP alternative as one complete PP/VPP schedule."""
+        if num_variants < 1:
+            raise ValueError("Dynamic-CP CUDA graph capture requires at least one CP variant.")
+
+        if canonical_variant is None:
+            canonical_variant = num_variants - 1
+        if canonical_variant < 0 or canonical_variant >= num_variants:
+            raise ValueError(
+                f"Canonical dynamic-CP variant {canonical_variant} is outside "
+                f"[0, {num_variants})."
+            )
+
+        variant_order = [
+            canonical_variant,
+            *(variant for variant in range(num_variants) if variant != canonical_variant),
+        ]
+
+        def remap(c_id, variant):
+            chunk = abs(int(c_id)) + variant * num_model_chunks
+            return chunk if c_id > 0 else -chunk
+
+        for c_id in order:
+            if ceil(c_id) != c_id:
+                raise ValueError(
+                    "Slot-aliased dynamic-CP capture does not support delayed wgrad order "
+                    f"entries, got {c_id}."
+                )
+        return [remap(c_id, variant) for variant in variant_order for c_id in order]
+
+    @staticmethod
+    def _color_liveness_conflicts(conflicts):
+        """Color a frame conflict graph deterministically with DSATUR."""
+        colors = {}
+        uncolored = set(conflicts)
+        while uncolored:
+            frame = max(
+                uncolored,
+                key=lambda candidate: (
+                    len({colors[n] for n in conflicts[candidate] if n in colors}),
+                    len(conflicts[candidate]),
+                    tuple(-value for value in candidate),
+                ),
+            )
+            unavailable = {colors[n] for n in conflicts[frame] if n in colors}
+            color = 0
+            while color in unavailable:
+                color += 1
+            colors[frame] = color
+            uncolored.remove(frame)
+        return colors
+
+    @staticmethod
+    def _build_saved_tensor_liveness_colors(
+        orders, num_slots, num_layers_per_chunk, return_conflicts=False
+    ):
+        """Color saved tensors over possible PP/VPP schedules.
+
+        Dynamic sequence packing changes the microbatch count between iterations, which also
+        changes PP/VPP warmup and cooldown interleaving. A valid reuse color must therefore be
+        non-overlapping in every possible schedule, not just in one long topology probe.
+        """
+        if num_slots < 1:
+            raise ValueError("Saved-tensor liveness coloring requires at least one slot.")
+        if not orders:
+            raise ValueError("Saved-tensor liveness coloring requires at least one PP/VPP order.")
+        if isinstance(orders[0], (int, float)):
+            orders = (orders,)
+
+        num_model_chunks = len(num_layers_per_chunk)
+        frames = [
+            (model_chunk, slot, layer)
+            for model_chunk, num_layers in enumerate(num_layers_per_chunk)
+            for slot in range(num_slots)
+            for layer in range(num_layers)
+        ]
+        conflicts = {frame: set() for frame in frames}
+        for order in orders:
+            live_frames = set()
+            forward_idx = [0] * num_model_chunks
+            backward_idx = [0] * num_model_chunks
+
+            for c_id in order:
+                if ceil(c_id) != c_id:
+                    continue
+                model_chunk = abs(int(c_id)) - 1
+                if model_chunk < 0 or model_chunk >= num_model_chunks:
+                    raise ValueError(f"Invalid model chunk {c_id} in CUDA graph liveness order.")
+
+                logical_microbatch = (
+                    forward_idx[model_chunk] if c_id > 0 else backward_idx[model_chunk]
+                )
+                slot = logical_microbatch % num_slots
+                event_frames = [
+                    (model_chunk, slot, layer) for layer in range(num_layers_per_chunk[model_chunk])
+                ]
+
+                if c_id > 0:
+                    collisions = live_frames.intersection(event_frames)
+                    if collisions:
+                        raise RuntimeError(
+                            "CUDA graph slot period is shorter than the PP/VPP saved-tensor "
+                            f"liveness for frames {sorted(collisions)}."
+                        )
+                    # Frames already live are pairwise-connected from earlier events, so only
+                    # the newly-live frames need edges to everything currently live.
+                    for index, frame in enumerate(event_frames):
+                        for other in chain(live_frames, event_frames[index + 1 :]):
+                            conflicts[frame].add(other)
+                            conflicts[other].add(frame)
+                    live_frames.update(event_frames)
+                    forward_idx[model_chunk] += 1
+                else:
+                    missing = set(event_frames).difference(live_frames)
+                    if missing:
+                        raise RuntimeError(
+                            "CUDA graph PP/VPP order ended saved-tensor liveness before its "
+                            f"forward for frames {sorted(missing)}."
+                        )
+                    live_frames.difference_update(event_frames)
+                    backward_idx[model_chunk] += 1
+
+            if live_frames or forward_idx != backward_idx:
+                raise RuntimeError(
+                    "CUDA graph PP/VPP order did not drain saved-tensor liveness: "
+                    f"live={sorted(live_frames)}, forward={forward_idx}, "
+                    f"backward={backward_idx}."
+                )
+
+        # DSATUR keeps the number of physical ranges low for the circular/modulo conflict graph.
+        colors = TECudaGraphHelper._color_liveness_conflicts(conflicts)
+
+        if return_conflicts:
+            return colors, conflicts
+        return colors
+
+    @staticmethod
+    def _build_user_grad_liveness_colors(orders, num_slots, num_model_chunks):
+        """Color graph-returned input gradients across overlapping PP sends.
+
+        With VPP P2P overlap, the input gradient produced by one backward event remains the
+        source of an asynchronous send until the following backward event completes.  Consecutive
+        backward events therefore need distinct storage even when different model chunks map to
+        the same physical graph slot.
+        """
+        if num_slots < 1:
+            raise ValueError("User-gradient liveness coloring requires at least one slot.")
+        if not orders:
+            raise ValueError("User-gradient liveness coloring requires at least one PP/VPP order.")
+        if isinstance(orders[0], (int, float)):
+            orders = (orders,)
+
+        frames = [
+            (model_chunk, slot)
+            for model_chunk in range(num_model_chunks)
+            for slot in range(num_slots)
+        ]
+        conflicts = {frame: set() for frame in frames}
+        for order in orders:
+            backward_idx = [0] * num_model_chunks
+            previous_frame = None
+            for c_id in order:
+                if ceil(c_id) != c_id or c_id > 0:
+                    continue
+                model_chunk = abs(int(c_id)) - 1
+                if model_chunk < 0 or model_chunk >= num_model_chunks:
+                    raise ValueError(
+                        f"Invalid model chunk {c_id} in CUDA graph user-gradient order."
+                    )
+                frame = (model_chunk, backward_idx[model_chunk] % num_slots)
+                backward_idx[model_chunk] += 1
+                if frame == previous_frame:
+                    raise RuntimeError(
+                        "CUDA graph slot period aliases consecutive backward user gradients for "
+                        f"frame {frame}."
+                    )
+                if previous_frame is not None:
+                    conflicts[frame].add(previous_frame)
+                    conflicts[previous_frame].add(frame)
+                previous_frame = frame
+
+        return TECudaGraphHelper._color_liveness_conflicts(conflicts)
+
+    def _get_dynamic_cp_variant_capture_data(self, capture_banks):
+        """Combine CP alternatives into one slot-aliased TE capture call and pool."""
+        callables = []
+        sample_args = []
+        sample_kwargs = []
+        fp8_enabled = []
+        has_sample_kwargs = False
+        base_order = None
+
+        for variant, (cp_size, cp_group, bank_sample_args, bank_kwargs) in enumerate(capture_banks):
+            context = (cp_size, cp_group)
+            callables.extend(
+                _DynamicCPCaptureCallable(layer, self._set_dynamic_cp_capture_context, context)
+                for layer in self.flattened_callables
+            )
+            sample_args.extend(bank_sample_args)
+            if 'sample_kwargs' in bank_kwargs:
+                has_sample_kwargs = True
+                sample_kwargs.extend(bank_kwargs['sample_kwargs'])
+            if base_order is None:
+                base_order = bank_kwargs['_order']
+            elif bank_kwargs['_order'] != base_order:
+                raise RuntimeError("Dynamic-CP variants produced different PP/VPP graph orders.")
+
+            enabled = bank_kwargs.get('fp8_enabled', False)
+            if isinstance(enabled, tuple):
+                fp8_enabled.extend(enabled)
+            elif enabled:
+                fp8_enabled.extend([True] * len(self.flattened_callables))
+
+        # The PP/VPP liveness proof guarantees that frames separated by this physical period are
+        # never simultaneously live, while CP alternatives for one frame are mutually exclusive.
+        graph_memory_slots = []
+        base_order = tuple(base_order)
+        liveness_orders = tuple(getattr(self, '_dynamic_slot_liveness_orders', (base_order,)))
+        if base_order not in liveness_orders:
+            # The physical slot count need not be scheduler-aligned (for example, a VPP
+            # group size of 4 can produce 7 slots). Capture itself runs that synthetic
+            # microbatch count, so its order must be part of the aliasing proof too.
+            liveness_orders += (base_order,)
+        saved_tensor_liveness_colors = self._build_saved_tensor_liveness_colors(
+            liveness_orders, self.num_microbatches, self.num_layers_per_chunk
+        )
+        user_grad_liveness_colors = self._build_user_grad_liveness_colors(
+            liveness_orders, self.num_microbatches, self.num_model_chunks
+        )
+        for variant in range(len(capture_banks)):
+            layer_offset = 0
+            for model_chunk, num_layers in enumerate(self.num_layers_per_chunk):
+                for physical_slot in range(self.num_microbatches):
+                    io_branch_id = variant * self.num_microbatches + physical_slot
+                    for layer in range(num_layers):
+                        saved_arena_id = saved_tensor_liveness_colors[
+                            (model_chunk, physical_slot, layer)
+                        ]
+                        graph_memory_slots.append(
+                            (
+                                saved_arena_id,
+                                physical_slot,
+                                io_branch_id,
+                                model_chunk,
+                                layer,
+                                variant * len(self.flattened_callables) + layer_offset + layer,
+                                user_grad_liveness_colors[(model_chunk, physical_slot)],
+                            )
+                        )
+                layer_offset += num_layers
+
+        canonical_variant = min(
+            range(len(capture_banks)), key=lambda index: capture_banks[index][0]
+        )
+        combined_kwargs = capture_banks[0][3].copy()
+        if not combined_kwargs.get('_reuse_graph_input_output_buffers', False):
+            raise RuntimeError(
+                "Slot-aliased dynamic-CP capture requires TE graph input/output buffer reuse."
+            )
+        # Each variant runs a complete schedule during capture. Explicit slot arenas use the
+        # union-liveness plan above, so their addresses also remain valid in replay schedules.
+        combined_kwargs['_graph_memory_slots'] = tuple(graph_memory_slots)
+        combined_kwargs['_order'] = self._build_slot_aliased_variant_order(
+            base_order,
+            len(capture_banks),
+            self.num_model_chunks,
+            canonical_variant=canonical_variant,
+        )
+        combined_kwargs['_num_layers_per_chunk'] = self.num_layers_per_chunk * len(capture_banks)
+        if has_sample_kwargs:
+            if len(sample_kwargs) != len(sample_args):
+                raise RuntimeError(
+                    f"Dynamic-CP capture has {len(sample_kwargs)} kwargs for "
+                    f"{len(sample_args)} argument tuples."
+                )
+            combined_kwargs['sample_kwargs'] = tuple(sample_kwargs)
+        else:
+            combined_kwargs.pop('sample_kwargs', None)
+        if fp8_enabled:
+            combined_kwargs['fp8_enabled'] = tuple(fp8_enabled)
+
+        if len(sample_args) != len(graph_memory_slots):
+            raise RuntimeError(
+                f"Dynamic-CP capture built {len(sample_args)} inputs for "
+                f"{len(graph_memory_slots)} memory slots."
+            )
+        return tuple(callables), tuple(sample_args), combined_kwargs
+
+    def _capture_dynamic_cp_variants(self, capture_banks, captured_graphs):
+        """Capture same-slot CP alternatives as branches in one TE memory pool."""
+        log_on_each_pipeline_stage(
+            logger=logger,
+            tp_group=None,
+            dp_cp_group=None,
+            level=logging.INFO,
+            msg=f'Rank {torch.distributed.get_rank()}: capturing {len(capture_banks)} '
+            f'dynamic-CP variants over {self.num_microbatches} slot-aliased physical TE pool '
+            'slots; each CP variant follows one complete PP/VPP schedule.',
+        )
+        callables, sample_args, kwargs = self._get_dynamic_cp_variant_capture_data(capture_banks)
+        sample_args = list(sample_args)
+        variant_graphs = tuple(self._capture_graph_bank(callables, sample_args, kwargs))
+        start = 0
+        for cp_size, _, bank_sample_args, _ in capture_banks:
+            stop = start + len(bank_sample_args)
+            captured_graphs[cp_size] = variant_graphs[start:stop]
+            # TE may rebind the leading input to a liveness-safe staging surface.
+            # Propagate that address back to mHC's eager direct-write path.
+            bank_sample_args[:] = sample_args[start:stop]
+            start = stop
+        if start != len(variant_graphs):
+            raise RuntimeError(
+                f"Dynamic-CP capture returned {len(variant_graphs)} graphs, expected {start}."
+            )
+
+    @staticmethod
+    def _clear_cuda_graph_state(layer):
+        layer.cuda_graphs = []
+        layer.cuda_graphs_by_dynamic_cp_size = {}
+        layer.cuda_graph_manual_hooks = []
+        clear_static_inputs = getattr(layer, 'clear_te_cuda_graph_static_hidden_inputs', None)
+        if clear_static_inputs is not None:
+            clear_static_inputs()
+        for module in layer.modules():
+            vars(module).pop('_cuda_graph_static_tensor_refs', None)
+
     def _start_capturing(self):
         """
         Start capturing CUDA Graphs.
         """
-        assert not self._capture_finished, "CUDA Graph capture has already been finished."
+        if self._capture_finished:
+            raise RuntimeError("CUDA Graph capture has already been finished.")
 
         torch.cuda.synchronize()
         gc.collect()
@@ -2694,7 +3347,90 @@ class TECudaGraphHelper:
         gc.collect()
         torch.cuda.empty_cache()
 
-        self._capture_finished = True
+    def _abort_capturing(self, captured_graphs):
+        """Best-effort, non-collective cleanup that preserves the capture error."""
+        _set_capture_end()
+        self._graphs_created = False
+        if FREEZE_GC:
+            with suppress(BaseException):
+                gc.unfreeze()
+
+        for graph in chain.from_iterable(captured_graphs.values()):
+            with suppress(BaseException):
+                graph.reset()
+
+        for layers in self.callables_per_chunk:
+            for layer in layers:
+                with suppress(BaseException):
+                    self._clear_cuda_graph_state(layer)
+
+        if self.config.fine_grained_activation_offloading:
+            with suppress(BaseException):
+                from megatron.core.pipeline_parallel.fine_grained_activation_offload import (
+                    FineGrainedActivationOffloadingInterface as off_interface,
+                )
+
+                off_interface.reset()
+
+        for cleanup in (self._reset_after_capture, gc.collect, torch.cuda.empty_cache):
+            with suppress(BaseException):
+                cleanup()
+        with suppress(BaseException):
+            self._clear_thd_rotary_seq_lens()
+
+    def _install_captured_graphs(
+        self, capture_contexts, captured_graphs, captured_sample_args=None
+    ):
+        """Install completed graph-bank variants on their corresponding layers."""
+        num_layers_accumulated = 0
+        for layers in self.callables_per_chunk:
+            for layer_number, layer in enumerate(layers):
+                base = (
+                    (num_layers_accumulated + layer_number) * self.num_microbatches
+                    if self.config.overlap_moe_expert_parallel_comm
+                    else num_layers_accumulated * self.num_microbatches + layer_number
+                )
+                stride = 1 if self.config.overlap_moe_expert_parallel_comm else len(layers)
+                for cp_size, _ in capture_contexts:
+                    graphs = captured_graphs[cp_size]
+                    layer_graphs = [
+                        graphs[base + batch_number * stride]
+                        for batch_number in range(self.num_microbatches)
+                    ]
+
+                    layer.cuda_graphs = layer_graphs
+                    if cp_size is not None:
+                        layer.cuda_graphs_by_dynamic_cp_size[cp_size] = layer_graphs
+                    if captured_sample_args is not None:
+                        sample_args = captured_sample_args[cp_size]
+                        static_hidden_inputs = [
+                            sample_args[base + batch_number * stride][0]
+                            for batch_number in range(self.num_microbatches)
+                        ]
+                        layer.set_te_cuda_graph_static_hidden_inputs(
+                            static_hidden_inputs, dynamic_cp_size=cp_size
+                        )
+            num_layers_accumulated += len(layers)
+
+        self._graphs_created = True
+
+    def _capture_graph_bank(self, callables, sample_args, kwargs):
+        """Capture one CP bank with the standard TE graph schedule."""
+        from megatron.core.transformer.moe.paged_stash import paged_stash_te_graph_capture
+
+        rng_context = (
+            get_cuda_rng_tracker().fork() if self.config.sequence_parallel else nullcontext()
+        )
+
+        with (
+            rng_context,
+            paged_stash_te_graph_capture(
+                self._should_enable_paged_stash_capture(),
+                order=kwargs['_order'],
+                config=self.config,
+            ),
+        ):
+            return make_graphed_callables(tuple(callables), sample_args, **kwargs)
 
     def _should_enable_paged_stash_capture(self) -> bool:
         """Whether this rank captures a complete local MoE with paged stash."""
@@ -2715,74 +3451,86 @@ class TECudaGraphHelper:
         Capture CUDA Graphs per TransformerLayer per microbatch.
         """
         validate_moe_cuda_graph_support(self.config)
-        start_time = self._start_capturing()
+        if self._capture_finished:
+            raise RuntimeError("CUDA Graph capture has already been finished.")
 
-        if not self.flattened_callables:
-            # Check if there are any graphable layers. If not, log a warning and skip capture,
-            # but still call _finish_capturing to ensure all ranks complete the capture phase.
-            logger.warning(
-                'TECudaGraphHelper: No graphable layers found. Skipping CUDA graph capture.'
-            )
-        else:
-            # Prepare CUDA Graph capturing input data and call `make_graphed_callables`.
-            sample_args, kwargs = self._get_cuda_graph_input_data()
-            if self.config.sequence_parallel:
-                rng_context = get_cuda_rng_tracker().fork()
-            else:
-                rng_context = nullcontext()
-            from megatron.core.transformer.moe.paged_stash import paged_stash_te_graph_capture
-
-            with (
-                rng_context,
-                paged_stash_te_graph_capture(
-                    self._should_enable_paged_stash_capture(),
-                    order=kwargs['_order'],
-                    config=self.config,
-                ),
-            ):
-                graphs = make_graphed_callables(
-                    tuple(self.flattened_callables), sample_args, **kwargs
+        # A failed attempt clears capture-only RoPE limits so eager execution remains unchanged.
+        # Restore the constructor-computed limits before every retry.
+        self._publish_thd_rotary_seq_lens(self._thd_rotary_seq_lens)
+        captured_graphs = {}
+        captured_sample_args = {} if self._uses_mhc_direct_write_arena() else None
+        try:
+            capture_contexts = self._get_dynamic_cp_capture_contexts()
+            start_time = self._start_capturing()
+            has_graphable_layers = bool(self.flattened_callables)
+            if not has_graphable_layers:
+                # Still participate in every schedule collective and barrier so
+                # PP stages with graphable layers cannot deadlock.
+                logger.warning(
+                    'TECudaGraphHelper: No graphable layers found. Skipping CUDA graph capture.'
                 )
-            self._validate_mhc_static_hidden_inputs(sample_args)
+            # Keep variants helper-local so later captures cannot replay earlier ones.
+            try:
+                if self._should_share_dynamic_cp_pool():
+                    capture_banks = []
+                    expected_num_microbatches = None
+                    for cp_size, cp_group in capture_contexts:
+                        self._set_dynamic_cp_capture_context((cp_size, cp_group))
 
-            # Push the captured graphs to the corresponding TransformerBlock.
-            # Only the direct-write arena consumes these handles. Every other
-            # configuration would retain num_microbatches static input tensors
-            # per layer for nothing. Config-level, so hoisted out of both loops.
-            retain_static_inputs = self._uses_mhc_direct_write_arena()
-            num_layers_accumulated = 0
-            for layers in self.callables_per_chunk:
-                for layer_number, layer in enumerate(layers):
-                    layer.cuda_graphs = []
-                    static_hidden_inputs = []
-                    for batch_number in range(self.num_microbatches):
-                        if self.config.overlap_moe_expert_parallel_comm:
-                            graph_idx = (
-                                num_layers_accumulated + layer_number
-                            ) * self.num_microbatches + batch_number
-                        else:
-                            graph_idx = (
-                                num_layers_accumulated * self.num_microbatches
-                                + batch_number * len(layers)
-                                + layer_number
+                        # This call contains PP-group collectives, so every PP stage must
+                        # prepare banks in the same order even if it has no graphable layers.
+                        sample_args, kwargs = self._get_cuda_graph_input_data()
+                        if expected_num_microbatches is None:
+                            expected_num_microbatches = self.num_microbatches
+                        elif self.num_microbatches != expected_num_microbatches:
+                            raise RuntimeError(
+                                "Dynamic-CP capture changed slot count across variants: "
+                                f"{expected_num_microbatches} -> {self.num_microbatches}."
                             )
-                        layer.cuda_graphs.append(graphs[graph_idx])
-                        # TE may rebind sample inputs while optimizing
-                        # graph-buffer reuse, so retain the final fixed-address
-                        # surface only after make_graphed_callables() has
-                        # returned; the exact graph index keeps graph and input
-                        # slot in lockstep. _validate_mhc_static_hidden_inputs()
-                        # has asserted that aliased entries have disjoint
-                        # [fwd, bwd] liveness windows.
-                        if retain_static_inputs:
-                            static_hidden_inputs.append(sample_args[graph_idx][0])
-                    if retain_static_inputs:
-                        layer.set_te_cuda_graph_static_hidden_inputs(static_hidden_inputs)
-                num_layers_accumulated += len(layers)
+                        capture_banks.append((cp_size, cp_group, sample_args, kwargs))
 
-            self._graphs_created = True
+                    if has_graphable_layers:
+                        self._capture_dynamic_cp_variants(capture_banks, captured_graphs)
+                        for cp_size, _, bank_sample_args, _ in capture_banks:
+                            self._validate_mhc_static_hidden_inputs(bank_sample_args)
+                            if captured_sample_args is not None:
+                                captured_sample_args[cp_size] = bank_sample_args
+                    # Drop construction-time bank lists before final GC so graph inputs replaced
+                    # by either cross-CP aliases or TE-owned surfaces do not stay pinned.
+                    del capture_banks, sample_args, kwargs
+                else:
+                    for capture_idx, (cp_size, cp_group) in enumerate(capture_contexts):
+                        if cp_size is not None:
+                            self._set_dynamic_cp_capture_context((cp_size, cp_group))
 
-        self._finish_capturing(start_time)
+                        # This call contains PP-group collectives when dynamic graph
+                        # slots are enabled, so all PP stages must participate.
+                        sample_args, kwargs = self._get_cuda_graph_input_data()
+                        if has_graphable_layers:
+                            captured_graphs[cp_size] = self._capture_graph_bank(
+                                self.flattened_callables, sample_args, kwargs
+                            )
+                        self._validate_mhc_static_hidden_inputs(sample_args)
+                        if captured_sample_args is not None:
+                            captured_sample_args[cp_size] = sample_args
+
+                        if capture_idx + 1 < len(capture_contexts):
+                            torch.cuda.synchronize()
+                            torch.distributed.barrier()
+                            self._reset_after_capture()
+            finally:
+                self._set_dynamic_cp_capture_context(None)
+
+            if has_graphable_layers:
+                self._install_captured_graphs(
+                    capture_contexts, captured_graphs, captured_sample_args
+                )
+            self._finish_capturing(start_time)
+            self._publish_dynamic_cp_graph_microbatch_limit()
+            self._capture_finished = True
+        except BaseException:
+            self._abort_capturing(captured_graphs)
+            raise
 
     def cuda_graph_set_manual_hooks(self):
         """
@@ -2796,23 +3544,48 @@ class TECudaGraphHelper:
 
     def delete_cuda_graphs(self):
         """
-        Delete all CUDA graphs.
+        Delete all CUDA graphs and release capture-only state.
         """
-        assert self._graphs_created, "No CUDA Graphs were created to delete."
-
         graph_resettable = is_te_min_version("2.10.0")
         graphs_reset, graphs_not_reset = 0, 0
-        for layers in self.callables_per_chunk:
-            for layer in layers:
-                for graph in layer.cuda_graphs:
-                    if graph_resettable:
-                        graph.reset()
-                        graphs_reset += 1
-                    else:
-                        graphs_not_reset += 1
-                layer.cuda_graphs = []
-                layer.cuda_graph_manual_hooks = []
-                layer.clear_te_cuda_graph_static_hidden_inputs()
+        reset_error = None
+        try:
+            for layers in self.callables_per_chunk:
+                for layer in layers:
+                    try:
+                        graph_bank = layer.cuda_graphs_by_dynamic_cp_size
+                        graph_lists = graph_bank.values() if graph_bank else (layer.cuda_graphs,)
+                        for graph in chain.from_iterable(graph_lists):
+                            try:
+                                if graph_resettable:
+                                    graph.reset()
+                                    graphs_reset += 1
+                                else:
+                                    graphs_not_reset += 1
+                            except BaseException as error:
+                                if reset_error is None:
+                                    reset_error = error
+                    except BaseException as error:
+                        if reset_error is None:
+                            reset_error = error
+                    finally:
+                        try:
+                            self._clear_cuda_graph_state(layer)
+                        except BaseException as error:
+                            if reset_error is None:
+                                reset_error = error
+        finally:
+            self._graphs_created = False
+            cleanup_callbacks = (
+                lambda: vars(self.config).pop('_cuda_graph_num_microbatches', None),
+                self._clear_thd_rotary_seq_lens,
+            )
+            for cleanup in cleanup_callbacks:
+                try:
+                    cleanup()
+                except BaseException as error:
+                    if reset_error is None:
+                        reset_error = error
 
         log_on_each_pipeline_stage(
             logger=logger,
@@ -2823,7 +3596,8 @@ class TECudaGraphHelper:
             f'{graphs_reset} graphs deleted with explicit reset, '
             f'{graphs_not_reset} graphs deleted without explicit reset.',
         )
-        self._graphs_created = False
+        if reset_error is not None:
+            raise reset_error
 
 
 def convert_schedule_table_to_order(num_warmup_microbatches, num_model_chunks, schedule_table):

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -3322,6 +3322,15 @@ class TECudaGraphHelper:
         from megatron.core.distributed.finalize_model_grads import reset_model_temporary_tensors
         from megatron.core.transformer.moe.moe_logging import get_moe_metrics_tracker
 
+        if (self.config.dsa_indexer_loss_coeff or 0.0) > 0:
+            from megatron.core.transformer.experimental_attention_variant.dsa import (
+                DSAIndexerLossLoggingHelper,
+            )
+
+            # Capture and warmup replay the tracked in-place accumulation. Keep its storage and
+            # process groups, but remove those synthetic values before the next training step.
+            DSAIndexerLossLoggingHelper.clean_loss_in_tracker(preserve_groups=True)
+
         for model_chunk in self.model:
             model_chunk.zero_grad_buffer()
         for optimizer in self.optimizers:

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -1797,6 +1797,7 @@ class TECudaGraphHelper:
         optimizers=[],
         pg_collection=None,
         thd_sequence_length_upper_bound=None,
+        dynamic_cp_group_getter=None,
     ):
         assert HAVE_TE_GRAPHS, "CUDA Graphs are not supported without TE."
         assert (
@@ -1815,6 +1816,7 @@ class TECudaGraphHelper:
         self.thd_sequence_length_upper_bound = thd_sequence_length_upper_bound
         self.micro_batch_size = micro_batch_size
         self.optimizers = optimizers
+        self.dynamic_cp_group_getter = dynamic_cp_group_getter
         self.pg_collection = pg_collection
         if self.pg_collection is None:
             self.pg_collection = ProcessGroupCollection.use_mpu_process_groups()
@@ -2931,8 +2933,13 @@ class TECudaGraphHelper:
         if not self.config.dynamic_context_parallel:
             return [(None, None)]
 
+        if self.dynamic_cp_group_getter is None:
+            raise RuntimeError(
+                "Dynamic-CP CUDA graph capture requires an explicit process-group getter."
+            )
+
         return [
-            (size, parallel_state.get_dynamic_data_context_parallel_groups(group_size=size))
+            (size, self.dynamic_cp_group_getter(group_size=size))
             for size in self._get_dynamic_cp_capture_sizes()
         ]
 
@@ -3283,6 +3290,7 @@ class TECudaGraphHelper:
     def _clear_cuda_graph_state(layer):
         layer.cuda_graphs = []
         layer.cuda_graphs_by_dynamic_cp_size = {}
+        layer.cuda_graph_cp_groups_by_dynamic_cp_size = {}
         layer.cuda_graph_manual_hooks = []
         clear_static_inputs = getattr(layer, 'clear_te_cuda_graph_static_hidden_inputs', None)
         if clear_static_inputs is not None:
@@ -3391,7 +3399,7 @@ class TECudaGraphHelper:
                     else num_layers_accumulated * self.num_microbatches + layer_number
                 )
                 stride = 1 if self.config.overlap_moe_expert_parallel_comm else len(layers)
-                for cp_size, _ in capture_contexts:
+                for cp_size, cp_group in capture_contexts:
                     graphs = captured_graphs[cp_size]
                     layer_graphs = [
                         graphs[base + batch_number * stride]
@@ -3401,6 +3409,7 @@ class TECudaGraphHelper:
                     layer.cuda_graphs = layer_graphs
                     if cp_size is not None:
                         layer.cuda_graphs_by_dynamic_cp_size[cp_size] = layer_graphs
+                        layer.cuda_graph_cp_groups_by_dynamic_cp_size[cp_size] = cp_group
                     if captured_sample_args is not None:
                         sample_args = captured_sample_args[cp_size]
                         static_hidden_inputs = [

--- a/megatron/core/transformer/cuda_graphs.py
+++ b/megatron/core/transformer/cuda_graphs.py
@@ -3468,9 +3468,9 @@ class TECudaGraphHelper:
         """
         Capture CUDA Graphs per TransformerLayer per microbatch.
         """
-        validate_moe_cuda_graph_support(self.config)
         if self._capture_finished:
             raise RuntimeError("CUDA Graph capture has already been finished.")
+        validate_moe_cuda_graph_support(self.config)
 
         # A failed attempt clears capture-only RoPE limits so eager execution remains unchanged.
         # Restore the constructor-computed limits before every retry.

--- a/megatron/core/transformer/experimental_attention_variant/csa.py
+++ b/megatron/core/transformer/experimental_attention_variant/csa.py
@@ -1862,6 +1862,19 @@ class CompressedSparseAttention(MegatronModule):
         if self.indexer is not None:
             self.indexer.backward_dw()
 
+    def _save_indexer_loss(self, loss, reduce_group=None):
+        """Save an indexer metric using one stable group for mixed CP."""
+        dynamic_cp_metric_group = (
+            self.pg_collection.dp_cp if self.config.dynamic_context_parallel else None
+        )
+        DSAIndexerLossLoggingHelper.save_loss_to_tracker(
+            loss=loss,
+            layer_number=self.layer_number,
+            num_layers=self.config.num_layers + (self.config.mtp_num_layers or 0),
+            reduce_group=reduce_group,
+            dynamic_cp_metric_group=dynamic_cp_metric_group,
+        )
+
     # ------------------------------------------------------------------
     # Private helpers – each owns one logical slice of the forward pass.
     # ------------------------------------------------------------------
@@ -2105,11 +2118,7 @@ class CompressedSparseAttention(MegatronModule):
                         non_compressed_lse,
                     )
                     if indexer_loss_coeff > 0:
-                        DSAIndexerLossLoggingHelper.save_loss_to_tracker(
-                            loss=indexer_loss,
-                            layer_number=self.layer_number,
-                            num_layers=self.config.num_layers + (self.config.mtp_num_layers or 0),
-                        )
+                        self._save_indexer_loss(indexer_loss)
                 else:
                     _, topk_indices_compressed = self.indexer(
                         x_det, qr_det, mask=causal_mask, packed_seq_params=packed_seq_params
@@ -2276,11 +2285,7 @@ class CompressedSparseAttention(MegatronModule):
         nvtx_range_pop("sparse_attn_kernel")
 
         if indexer_loss_coeff > 0:
-            DSAIndexerLossLoggingHelper.save_loss_to_tracker(
-                loss=indexer_loss,
-                layer_number=self.layer_number,
-                num_layers=self.config.num_layers + (self.config.mtp_num_layers or 0),
-            )
+            self._save_indexer_loss(indexer_loss)
         return output, indexer_loss
 
     # ------------------------------------------------------------------
@@ -2486,11 +2491,7 @@ class CompressedSparseAttention(MegatronModule):
                     )
 
                     if indexer_loss_coeff > 0:
-                        DSAIndexerLossLoggingHelper.save_loss_to_tracker(
-                            loss=indexer_loss,
-                            layer_number=self.layer_number,
-                            num_layers=self.config.num_layers + (self.config.mtp_num_layers or 0),
-                        )
+                        self._save_indexer_loss(indexer_loss)
                 else:
                     _, topk_indices_cmp = self.indexer(
                         x_det, qr_det, mask=None, packed_seq_params=packed_seq_params
@@ -2788,11 +2789,7 @@ class CompressedSparseAttention(MegatronModule):
         )
 
         if indexer_loss_coeff > 0:
-            DSAIndexerLossLoggingHelper.save_loss_to_tracker(
-                loss=indexer_loss,
-                layer_number=self.layer_number,
-                num_layers=self.config.num_layers + (self.config.mtp_num_layers or 0),
-            )
+            self._save_indexer_loss(indexer_loss)
         output = output.unsqueeze(1)
         return output, indexer_loss
 
@@ -3180,12 +3177,7 @@ class CompressedSparseAttention(MegatronModule):
                     *indexer_loss_args, tp_group=indexer.pg_collection.tp
                 )
             if indexer_loss_coeff > 0:
-                DSAIndexerLossLoggingHelper.save_loss_to_tracker(
-                    loss=indexer_loss,
-                    layer_number=self.layer_number,
-                    num_layers=self.config.num_layers + (self.config.mtp_num_layers or 0),
-                    reduce_group=cp_group,
-                )
+                self._save_indexer_loss(indexer_loss, reduce_group=cp_group)
             output = DSAIndexerLossAutoScaler.apply(output, indexer_loss)
             return output.unsqueeze(1)
 

--- a/megatron/core/transformer/experimental_attention_variant/csa.py
+++ b/megatron/core/transformer/experimental_attention_variant/csa.py
@@ -1914,19 +1914,22 @@ class CompressedSparseAttention(MegatronModule):
             precision=precision,
         )
         capturing = torch.cuda.is_current_stream_capturing()
-        workspace = self._active_bshd_compact_indexer_workspace
-        if capturing:
-            if workspace is not None and workspace.matches_shape(**match_kwargs):
+        active_workspace = self._active_bshd_compact_indexer_workspace
+        if active_workspace is not None and active_workspace.matches_shape(**match_kwargs):
+            return active_workspace
+
+        for workspace in self._bshd_compact_indexer_workspaces:
+            if workspace is active_workspace:
+                continue
+            if workspace.matches_shape(**match_kwargs):
+                self._active_bshd_compact_indexer_workspace = workspace
                 return workspace
+
+        if capturing:
             raise ValueError(
                 "BSHD compact CUDA graph capture requires an eagerly prepared compact "
                 "workspace for the active static geometry. Run eager warmup before capture."
             )
-
-        for workspace in self._bshd_compact_indexer_workspaces:
-            if workspace.matches_shape(**match_kwargs):
-                self._active_bshd_compact_indexer_workspace = workspace
-                return workspace
 
         q_bshd = q.permute(1, 0, 2, 3).contiguous()
         k_bsd = k.permute(1, 0, 2).contiguous()
@@ -1971,28 +1974,25 @@ class CompressedSparseAttention(MegatronModule):
             return None
 
         capturing = torch.cuda.is_current_stream_capturing()
-        workspace = self._active_thd_compact_indexer_workspace
-        if capturing:
-            if workspace is not None and workspace.matches(
-                q=q,
-                k=k,
-                topk=topk,
-                ratio=ratio,
-                cu_seqlens_q=cu_seqlens_q,
-                cu_seqlens_k=cu_seqlens_k,
-                max_seqlen_q=max_seqlen_q,
-                max_seqlen_k=max_seqlen_k,
-                q_causal_offsets=q_causal_offsets,
-                return_softmax=return_softmax,
-                precision=precision,
-            ):
-                return workspace
-            raise ValueError(
-                "THD compact CUDA graph capture requires an eagerly prepared compact "
-                "workspace for the active packed geometry. Run eager warmup before capture."
-            )
+        active_workspace = self._active_thd_compact_indexer_workspace
+        if active_workspace is not None and active_workspace.matches(
+            q=q,
+            k=k,
+            topk=topk,
+            ratio=ratio,
+            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_k=cu_seqlens_k,
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_k=max_seqlen_k,
+            q_causal_offsets=q_causal_offsets,
+            return_softmax=return_softmax,
+            precision=precision,
+        ):
+            return active_workspace
 
         for workspace in self._thd_compact_indexer_workspaces:
+            if workspace is active_workspace:
+                continue
             if workspace.matches(
                 q=q,
                 k=k,
@@ -2008,6 +2008,12 @@ class CompressedSparseAttention(MegatronModule):
             ):
                 self._active_thd_compact_indexer_workspace = workspace
                 return workspace
+
+        if capturing:
+            raise ValueError(
+                "THD compact CUDA graph capture requires an eagerly prepared compact "
+                "workspace for the active packed geometry. Run eager warmup before capture."
+            )
 
         workspace = prepare_thd_compact_indexer_workspace(
             q,

--- a/megatron/core/transformer/experimental_attention_variant/csa_utils/fused_sparse_attention.py
+++ b/megatron/core/transformer/experimental_attention_variant/csa_utils/fused_sparse_attention.py
@@ -1395,11 +1395,12 @@ class CSASparseAttnFunc(torch.autograd.Function):
         ctx.reconstruct_kv_for_backward = kv_reconstruction_parts is not None
         if ctx.reconstruct_kv_for_backward:
             _validate_kv_reconstruction_parts(kv, kv_reconstruction_parts)
-            ctx.save_for_backward(q, *kv_reconstruction_parts, attn_sink, topk_idxs, out, lse)
+            ctx.save_for_backward(
+                q, *kv_reconstruction_parts, attn_sink, topk_idxs, out, lse, topk_length
+            )
         else:
-            ctx.save_for_backward(q, kv, attn_sink, topk_idxs, out, lse)
+            ctx.save_for_backward(q, kv, attn_sink, topk_idxs, out, lse, topk_length)
         ctx.softmax_scale = softmax_scale
-        ctx.topk_length = topk_length
         return out, lse, lse_indexer
 
     @staticmethod
@@ -1408,12 +1409,20 @@ class CSASparseAttnFunc(torch.autograd.Function):
         _ensure_dsa_namespace()
 
         if ctx.reconstruct_kv_for_backward:
-            q, boundary_kv, local_kv, compressed_kv, attn_sink, topk_idxs, out, lse = (
-                ctx.saved_tensors
-            )
+            (
+                q,
+                boundary_kv,
+                local_kv,
+                compressed_kv,
+                attn_sink,
+                topk_idxs,
+                out,
+                lse,
+                topk_length,
+            ) = ctx.saved_tensors
             kv = torch.cat((boundary_kv, local_kv, compressed_kv), dim=0)
         else:
-            q, kv, attn_sink, topk_idxs, out, lse = ctx.saved_tensors
+            q, kv, attn_sink, topk_idxs, out, lse, topk_length = ctx.saved_tensors
 
         result = _DSA.sparse_attention_backward_wrapper(
             q,
@@ -1424,7 +1433,7 @@ class CSASparseAttnFunc(torch.autograd.Function):
             attn_sink,
             topk_idxs,
             softmax_scale=ctx.softmax_scale,
-            topk_length=ctx.topk_length,
+            topk_length=topk_length,
         )
         dq, dkv, d_sink = result["dq"], result["dkv"], result["d_sink"]
         return dq, dkv, d_sink, None, None, None, None, None
@@ -2822,10 +2831,10 @@ class FusedCSAIndexerSparseAttnFunc(torch.autograd.Function):
             precomputed_grad_q_indexer,
             precomputed_grad_k_indexer,
             precomputed_grad_weights,
+            padding_row_mask,
         )
         ctx.softmax_scale = softmax_scale
         ctx.is_thd = is_thd
-        ctx.padding_row_mask = padding_row_mask
         ctx.np_ = np_
         ctx.d = d
         if is_thd:
@@ -2857,6 +2866,7 @@ class FusedCSAIndexerSparseAttnFunc(torch.autograd.Function):
             precomputed_grad_q_indexer,
             precomputed_grad_k_indexer,
             precomputed_grad_weights,
+            padding_row_mask,
         ) = ctx.saved_tensors
 
         is_thd = ctx.is_thd
@@ -2870,9 +2880,9 @@ class FusedCSAIndexerSparseAttnFunc(torch.autograd.Function):
             sq, b, skv = ctx.sq, ctx.b, ctx.skv
             dO_flat = grad_output.reshape(sq * b, np_, d_v)
 
-        if ctx.padding_row_mask is not None:
-            dO_flat = dO_flat.masked_fill(ctx.padding_row_mask[:, None, None], 0)
-            lse = lse.masked_fill(ctx.padding_row_mask[:, None], 0)
+        if padding_row_mask is not None:
+            dO_flat = dO_flat.masked_fill(padding_row_mask[:, None, None], 0)
+            lse = lse.masked_fill(padding_row_mask[:, None], 0)
 
         attn_bwd = _DSA.sparse_attention_backward_wrapper(
             q_flat,
@@ -3197,6 +3207,7 @@ class FusedCSAIndexerSparseAttnFromTopkFunc(torch.autograd.Function):
                 saved_grad_k_indexer,
                 saved_grad_weights,
                 indexer_rank_map,
+                q_padding_mask,
             )
         else:
             ctx.save_for_backward(
@@ -3211,9 +3222,9 @@ class FusedCSAIndexerSparseAttnFromTopkFunc(torch.autograd.Function):
                 saved_grad_k_indexer,
                 saved_grad_weights,
                 indexer_rank_map,
+                q_padding_mask,
             )
         ctx.softmax_scale = softmax_scale
-        ctx.q_padding_mask = q_padding_mask
 
         return out_flat.reshape(total_q, np_ * out_flat.shape[-1]), indexer_loss
 
@@ -3236,6 +3247,7 @@ class FusedCSAIndexerSparseAttnFromTopkFunc(torch.autograd.Function):
                 saved_grad_k_indexer,
                 saved_grad_weights,
                 indexer_rank_map,
+                q_padding_mask,
             ) = ctx.saved_tensors
             kv_full = torch.cat((boundary_kv, local_kv, compressed_kv), dim=0)
         else:
@@ -3251,6 +3263,7 @@ class FusedCSAIndexerSparseAttnFromTopkFunc(torch.autograd.Function):
                 saved_grad_k_indexer,
                 saved_grad_weights,
                 indexer_rank_map,
+                q_padding_mask,
             ) = ctx.saved_tensors
 
         cp_group = ctx.cp_group
@@ -3272,9 +3285,9 @@ class FusedCSAIndexerSparseAttnFromTopkFunc(torch.autograd.Function):
                 grad_k_indexer_rank_major = grad_k_indexer
 
         dO_flat = grad_output.reshape(query.shape[0], query.shape[1], out_flat.shape[-1])
-        if ctx.q_padding_mask is not None:
-            dO_flat = dO_flat.masked_fill(ctx.q_padding_mask[:, None, None], 0)
-            lse = lse.masked_fill(ctx.q_padding_mask[:, None], 0)
+        if q_padding_mask is not None:
+            dO_flat = dO_flat.masked_fill(q_padding_mask[:, None, None], 0)
+            lse = lse.masked_fill(q_padding_mask[:, None], 0)
         nvtx_range_push("dsv4_cp_sparse_attention_backward")
         attn_bwd = _DSA.sparse_attention_backward_wrapper(
             query,

--- a/megatron/core/transformer/experimental_attention_variant/dsa.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa.py
@@ -301,6 +301,7 @@ class DSAIndexerLossLoggingHelper:
         num_layers: int,
         reduce_group: torch.distributed.ProcessGroup = None,
         avg_group: torch.distributed.ProcessGroup = None,
+        dynamic_cp_metric_group: torch.distributed.ProcessGroup = None,
     ):
         """Save the indexer loss for logging.
 
@@ -310,6 +311,7 @@ class DSAIndexerLossLoggingHelper:
             num_layers: The number of total layers.
             reduce_group: The group for reducing the loss.
             avg_group: The group for averaging the loss.
+            dynamic_cp_metric_group: Stable DP-CP group for mixed-CP metric reduction.
         """
         # Skip indexer loss logging if layer_number is None.
         if layer_number is None:
@@ -329,6 +331,14 @@ class DSAIndexerLossLoggingHelper:
             )
             grown[: tracker["values"].shape[0]] = tracker["values"]
             tracker["values"] = grown
+        if dynamic_cp_metric_group is not None:
+            existing_group = tracker.get("dynamic_cp_metric_group")
+            if existing_group is not None and existing_group is not dynamic_cp_metric_group:
+                raise RuntimeError(
+                    "DSA indexer tracker observed multiple dynamic-CP metric groups."
+                )
+            tracker["dynamic_cp_metric_group"] = dynamic_cp_metric_group
+
         tracker["values"][layer_number - 1] += loss.detach()
         tracker["reduce_group"] = reduce_group
         tracker["avg_group"] = avg_group
@@ -339,10 +349,14 @@ class DSAIndexerLossLoggingHelper:
         tracker = DSAIndexerLossLoggingHelper.tracker
         reduce_group = tracker.get("reduce_group") if preserve_groups else None
         avg_group = tracker.get("avg_group") if preserve_groups else None
+        dynamic_cp_metric_group = (
+            tracker.get("dynamic_cp_metric_group") if preserve_groups else None
+        )
         if "values" in tracker:
             tracker["values"].zero_()
         tracker["reduce_group"] = reduce_group
         tracker["avg_group"] = avg_group
+        tracker["dynamic_cp_metric_group"] = dynamic_cp_metric_group
 
     @staticmethod
     def reduce_loss_in_tracker(num_layers: Optional[int] = None):
@@ -394,13 +408,18 @@ class DSAIndexerLossLoggingHelper:
         values = tracker["values"]
 
         torch.distributed.all_reduce(values, group=pp_group)
-        # Reduce indexer losses across ranks.
-        if tracker.get('reduce_group') is not None:
-            torch.distributed.all_reduce(values, group=tracker.get('reduce_group'))
-        if tracker.get('avg_group') is not None:
+        if tracker.get("dynamic_cp_metric_group") is not None:
             torch.distributed.all_reduce(
-                values, group=tracker['avg_group'], op=torch.distributed.ReduceOp.AVG
+                values, group=tracker["dynamic_cp_metric_group"], op=torch.distributed.ReduceOp.AVG
             )
+        else:
+            # Fixed CP retains its existing SUM/AVG behavior.
+            if tracker.get('reduce_group') is not None:
+                torch.distributed.all_reduce(values, group=tracker.get('reduce_group'))
+            if tracker.get('avg_group') is not None:
+                torch.distributed.all_reduce(
+                    values, group=tracker['avg_group'], op=torch.distributed.ReduceOp.AVG
+                )
         torch.distributed.all_reduce(
             values,
             group=parallel_state.get_data_parallel_group(with_context_parallel=False),
@@ -2342,6 +2361,9 @@ class DSAttention(MegatronModule):
         indexer_avg_group = (
             cp_group if cp_size > 1 and not self.config.calculate_per_token_loss else None
         )
+        dynamic_cp_metric_group = (
+            self.pg_collection.dp_cp if self.config.dynamic_context_parallel else None
+        )
 
         topk_holder = (
             self._get_index_share_topk_holder(packed_seq_params, attention_mask)
@@ -2485,6 +2507,7 @@ class DSAttention(MegatronModule):
                     ),
                     reduce_group=indexer_reduce_group,
                     avg_group=indexer_avg_group,
+                    dynamic_cp_metric_group=dynamic_cp_metric_group,
                 )
                 output = DSAIndexerLossAutoScaler.apply(output, indexer_loss)
             return _normalize_dsattention_output_rank(output, x.ndim)
@@ -2575,6 +2598,7 @@ class DSAttention(MegatronModule):
                     ),
                     reduce_group=indexer_reduce_group,
                     avg_group=indexer_avg_group,
+                    dynamic_cp_metric_group=dynamic_cp_metric_group,
                 )
         elif topk_indices is None:
             assert q is not None and k is not None and weights is not None

--- a/megatron/core/transformer/experimental_attention_variant/dsa_cudnn_kernels.py
+++ b/megatron/core/transformer/experimental_attention_variant/dsa_cudnn_kernels.py
@@ -2270,13 +2270,13 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
             global_idxs,
             out_flat,
             lse,
+            topk_length_flat,
             precomputed_grad_q_indexer,
             precomputed_grad_k_indexer,
             precomputed_grad_weights,
         )
         ctx.has_precomputed_indexer_grads = need_indexer_loss
         ctx.softmax_scale = softmax_scale
-        ctx.topk_length = topk_length_flat
         ctx.sq = sq
         ctx.b = b
         ctx.num_heads = num_heads
@@ -2303,6 +2303,7 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
             global_idxs,
             out_flat,
             lse,
+            topk_length,
             precomputed_grad_q_indexer,
             precomputed_grad_k_indexer,
             precomputed_grad_weights,
@@ -2318,7 +2319,7 @@ class FusedIndexerSparseAttnFunc(torch.autograd.Function):
             global_idxs=global_idxs,
             out_flat=out_flat,
             lse=lse,
-            topk_length=ctx.topk_length,
+            topk_length=topk_length,
             softmax_scale=ctx.softmax_scale,
             sq=sq,
             b=b,
@@ -2546,9 +2547,10 @@ class FusedSparseAttentionFunc(torch.autograd.Function):
             )
         )
 
-        ctx.save_for_backward(q_flat, kv_flat, attn_sink, global_idxs, out_flat, lse)
+        ctx.save_for_backward(
+            q_flat, kv_flat, attn_sink, global_idxs, out_flat, lse, topk_length_flat
+        )
         ctx.softmax_scale = softmax_scale
-        ctx.topk_length = topk_length_flat
         ctx.sq = sq
         ctx.b = b
         ctx.num_heads = num_heads
@@ -2560,7 +2562,7 @@ class FusedSparseAttentionFunc(torch.autograd.Function):
     @staticmethod
     def backward(ctx, grad_output):
         """Run sparse attention backward for saved cuDNN graph inputs."""
-        q_flat, kv_flat, attn_sink, global_idxs, out_flat, lse = ctx.saved_tensors
+        q_flat, kv_flat, attn_sink, global_idxs, out_flat, lse, topk_length = ctx.saved_tensors
 
         sq, b, num_heads, d = ctx.sq, ctx.b, ctx.num_heads, ctx.d
         skv = ctx.skv
@@ -2571,7 +2573,7 @@ class FusedSparseAttentionFunc(torch.autograd.Function):
             global_idxs=global_idxs,
             out_flat=out_flat,
             lse=lse,
-            topk_length=ctx.topk_length,
+            topk_length=topk_length,
             softmax_scale=ctx.softmax_scale,
             sq=sq,
             b=b,

--- a/megatron/core/transformer/module.py
+++ b/megatron/core/transformer/module.py
@@ -186,6 +186,8 @@ class GraphableMegatronModule(MegatronModule):
             # script with the graphs returned by make_graphed_callables API before the first
             # training step.
             self.cuda_graphs = []
+            # DCP communicators are capture-time constants, so keep one graph list per CP size.
+            self.cuda_graphs_by_dynamic_cp_size = {}
             # Positional hidden-state inputs used as TE's fixed CUDA Graph input
             # surfaces, indexed exactly like ``cuda_graphs``.  Most layers do not
             # need to retain these handles.  They are exposed for eager producers
@@ -193,6 +195,8 @@ class GraphableMegatronModule(MegatronModule):
             # downstream graph (for example, mHC aggregation feeding attention).
             self._te_cuda_graph_static_hidden_inputs = ()
             self._te_cuda_graph_static_hidden_input_ptrs = ()
+            self._te_cuda_graph_static_hidden_inputs_by_dynamic_cp_size = {}
+            self._te_cuda_graph_static_hidden_input_ptrs_by_dynamic_cp_size = {}
             # List to store forward pre-hooks. Forward pre-hooks are not captured into CUDA
             # graphs. Those hooks and args are collected in this list and should be manually
             # triggered before CUDA Graph running. This is required to ensure the correct param
@@ -204,7 +208,7 @@ class GraphableMegatronModule(MegatronModule):
             # according to CUDA graph scope.
             self.cuda_graph_backward_dw_wrapper = None
 
-    def set_te_cuda_graph_static_hidden_inputs(self, inputs):
+    def set_te_cuda_graph_static_hidden_inputs(self, inputs, dynamic_cp_size=None):
         """Retain TE's fixed hidden-state input surface for each graph slot.
 
         ``TECudaGraphHelper`` calls this only after ``make_graphed_callables``
@@ -213,16 +217,50 @@ class GraphableMegatronModule(MegatronModule):
         lifetimes do not overlap.
         """
         inputs = tuple(inputs)
-        if len(inputs) != len(self.cuda_graphs):
+        graphs = self.cuda_graphs
+        if dynamic_cp_size is not None:
+            dynamic_cp_size = int(dynamic_cp_size)
+            if dynamic_cp_size not in self.cuda_graphs_by_dynamic_cp_size:
+                raise ValueError(
+                    "Cannot attach TE static inputs for an unknown dynamic CP size: "
+                    f"{dynamic_cp_size}; available sizes are "
+                    f"{sorted(self.cuda_graphs_by_dynamic_cp_size)}"
+                )
+            graphs = self.cuda_graphs_by_dynamic_cp_size[dynamic_cp_size]
+        if len(inputs) != len(graphs):
             raise ValueError(
                 "TE CUDA Graph static-input count must match graph count: "
-                f"got {len(inputs)} inputs and {len(self.cuda_graphs)} graphs"
+                f"got {len(inputs)} inputs and {len(graphs)} graphs"
             )
         if not all(isinstance(tensor, torch.Tensor) and tensor.is_cuda for tensor in inputs):
             raise TypeError("TE CUDA Graph static hidden inputs must be CUDA tensors")
 
+        input_ptrs = tuple(tensor.data_ptr() for tensor in inputs)
+        if dynamic_cp_size is not None:
+            self._te_cuda_graph_static_hidden_inputs_by_dynamic_cp_size[dynamic_cp_size] = inputs
+            self._te_cuda_graph_static_hidden_input_ptrs_by_dynamic_cp_size[dynamic_cp_size] = (
+                input_ptrs
+            )
         self._te_cuda_graph_static_hidden_inputs = inputs
-        self._te_cuda_graph_static_hidden_input_ptrs = tuple(tensor.data_ptr() for tensor in inputs)
+        self._te_cuda_graph_static_hidden_input_ptrs = input_ptrs
+
+    def activate_te_cuda_graph_static_hidden_inputs(self, dynamic_cp_size):
+        """Select the retained static-input surfaces for one dynamic CP graph bank."""
+        if not self._te_cuda_graph_static_hidden_inputs_by_dynamic_cp_size:
+            return
+        dynamic_cp_size = int(dynamic_cp_size)
+        if dynamic_cp_size not in self._te_cuda_graph_static_hidden_inputs_by_dynamic_cp_size:
+            raise RuntimeError(
+                "No TE CUDA Graph static inputs for dynamic CP size "
+                f"{dynamic_cp_size}; available sizes are "
+                f"{sorted(self._te_cuda_graph_static_hidden_inputs_by_dynamic_cp_size)}"
+            )
+        self._te_cuda_graph_static_hidden_inputs = (
+            self._te_cuda_graph_static_hidden_inputs_by_dynamic_cp_size[dynamic_cp_size]
+        )
+        self._te_cuda_graph_static_hidden_input_ptrs = (
+            self._te_cuda_graph_static_hidden_input_ptrs_by_dynamic_cp_size[dynamic_cp_size]
+        )
 
     def get_te_cuda_graph_static_hidden_input(self, microbatch_idx=None):
         """Return the fixed hidden-state input for a TE CUDA Graph slot."""
@@ -245,6 +283,8 @@ class GraphableMegatronModule(MegatronModule):
         """Release retained TE static-input handles when graphs are deleted."""
         self._te_cuda_graph_static_hidden_inputs = ()
         self._te_cuda_graph_static_hidden_input_ptrs = ()
+        self._te_cuda_graph_static_hidden_inputs_by_dynamic_cp_size = {}
+        self._te_cuda_graph_static_hidden_input_ptrs_by_dynamic_cp_size = {}
 
     def init_backward_dw_wrapper(self):
         """Initialize ``self.backward_dw_wrapper`` for delayed-wgrad scheduling.

--- a/megatron/core/transformer/module.py
+++ b/megatron/core/transformer/module.py
@@ -188,6 +188,7 @@ class GraphableMegatronModule(MegatronModule):
             self.cuda_graphs = []
             # DCP communicators are capture-time constants, so keep one graph list per CP size.
             self.cuda_graphs_by_dynamic_cp_size = {}
+            self.cuda_graph_cp_groups_by_dynamic_cp_size = {}
             # Positional hidden-state inputs used as TE's fixed CUDA Graph input
             # surfaces, indexed exactly like ``cuda_graphs``.  Most layers do not
             # need to retain these handles.  They are exposed for eager producers

--- a/megatron/core/transformer/multi_latent_attention.py
+++ b/megatron/core/transformer/multi_latent_attention.py
@@ -138,6 +138,18 @@ class MultiLatentAttention(Attention):
     "cross attn" specializations.
     """
 
+    def _retain_cuda_graph_rope_tensors(self, *rope_tensors: Optional[torch.Tensor]) -> None:
+        """Retain MLA-internal RoPE allocations used by TE CUDA graphs."""
+        if getattr(self.config, 'cuda_graph_impl', 'none') != 'transformer_engine':
+            return
+
+        from megatron.core.transformer.cuda_graphs import is_graph_capturing
+
+        if not is_graph_capturing():
+            return
+        refs = self.__dict__.setdefault('_cuda_graph_static_tensor_refs', {})
+        refs.update((id(tensor), tensor) for tensor in rope_tensors if tensor is not None)
+
     def __init__(
         self,
         config: MLATransformerConfig,
@@ -832,6 +844,8 @@ class MLASelfAttention(MultiLatentAttention):
             rotary_pos_emb = self.rotary_pos_emb(rotary_seq_len, packed_seq=thd_packed_seq)
         else:
             rotary_pos_emb, mscale = self.rotary_pos_emb(rotary_seq_len, packed_seq=thd_packed_seq)
+
+        self._retain_cuda_graph_rope_tensors(rotary_pos_emb, rotary_pos_cos, rotary_pos_sin)
 
         if packed_seq_params is not None and packed_seq_params.qkv_format == 'thd':
             if packed_seq_params.cu_seqlens_q_padded is not None:

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -4140,6 +4140,37 @@ class TransformerConfig(ModelParallelConfig):
                 "sequence_packing_scheduler, or use thd_tail_padding_policy='append_dummy_seq'."
             )
 
+        if self.dynamic_context_parallel and self.cuda_graph_impl != "none":
+            if self.cuda_graph_impl != "transformer_engine":
+                raise ValueError("Dynamic CP supports only layer-wise TE CUDA graphs.")
+            if not self.cuda_graph_dynamic_microbatches:
+                raise ValueError("Dynamic CP CUDA graphs require dynamic microbatch slots.")
+            if self.delay_wgrad_compute or self.overlap_moe_expert_parallel_comm:
+                raise ValueError("Dynamic CP graphs do not support delayed wgrad or EP overlap.")
+            captures_attention = (
+                not self.cuda_graph_modules or CudaGraphModule.attn in self.cuda_graph_modules
+            )
+            if captures_attention and (
+                (
+                    self.fp8 is not None
+                    and (
+                        self.fp8_dot_product_attention
+                        or self.fp8_multi_head_attention
+                        or self.fp8_recipe == Fp8Recipe.custom
+                    )
+                )
+                or (
+                    self.fp4 is not None
+                    and (self.fp8_dot_product_attention or self.fp4_recipe == Fp4Recipe.custom)
+                )
+            ):
+                raise ValueError(
+                    "Dynamic CP CUDA graph attention does not support FP8 DPA/MHA or custom "
+                    "FP8/FP4 recipes: TE's P2P context-parallel backward can use a "
+                    "logical-subgroup all-to-all that cannot use the shared parent graph "
+                    "communicator."
+                )
+
         if self.sequence_packing_scheduler is not None:
             # Check TE version.
             if not HAVE_PACKAGING:

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -4147,29 +4147,6 @@ class TransformerConfig(ModelParallelConfig):
                 raise ValueError("Dynamic CP CUDA graphs require dynamic microbatch slots.")
             if self.delay_wgrad_compute or self.overlap_moe_expert_parallel_comm:
                 raise ValueError("Dynamic CP graphs do not support delayed wgrad or EP overlap.")
-            captures_attention = (
-                not self.cuda_graph_modules or CudaGraphModule.attn in self.cuda_graph_modules
-            )
-            if captures_attention and (
-                (
-                    self.fp8 is not None
-                    and (
-                        self.fp8_dot_product_attention
-                        or self.fp8_multi_head_attention
-                        or self.fp8_recipe == Fp8Recipe.custom
-                    )
-                )
-                or (
-                    self.fp4 is not None
-                    and (self.fp8_dot_product_attention or self.fp4_recipe == Fp4Recipe.custom)
-                )
-            ):
-                raise ValueError(
-                    "Dynamic CP CUDA graph attention does not support FP8 DPA/MHA or custom "
-                    "FP8/FP4 recipes: TE's P2P context-parallel backward can use a "
-                    "logical-subgroup all-to-all that cannot use the shared parent graph "
-                    "communicator."
-                )
 
         if self.sequence_packing_scheduler is not None:
             # Check TE version.

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -2546,7 +2546,9 @@ class HyperConnectionTransformerLayer(TransformerLayer):
             mlp_output_with_bias, mlp_h_res, residual, mlp_hc_h_post, mhc_mlp_bda_recompute_manager
         )
 
-        hidden_states = self.mlp_norm_manager.group_offload(hidden_states)
+        if self.mlp_norm_manager is not None:
+            hidden_states = self.mlp_norm_manager.group_offload(hidden_states)
+            self.mlp_norm_manager = None
 
         output = make_viewless_tensor(
             inp=hidden_states, requires_grad=hidden_states.requires_grad, keep_graph=True

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -1261,6 +1261,12 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         """
         return self.self_attention.linear_qkv.layer_norm_weight.data
 
+    def _get_thd_cuda_graph_capture_cp(self):
+        """Return the CP size/group whose constants are being captured."""
+        if self.config.dynamic_context_parallel:
+            return self.config._cuda_graph_capture_dynamic_cp
+        return self.config.context_parallel_size, None
+
     def get_layer_static_inputs(self, seq_length, micro_batch_size):
         """
         Get the static inputs for the transformer layer. Besides the hidden_states that is
@@ -1289,7 +1295,8 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
                 #   cu_seqlens = [0, max_T, max_T, ..., max_T]
                 # which represents a single packed sequence followed by zero-length
                 # entries. cu_seqlens_q / kv / *_padded all share this layout.
-                max_T = self.config.max_seqlen_per_dp_cp_rank * self.config.context_parallel_size
+                capture_cp_size, _ = self._get_thd_cuda_graph_capture_cp()
+                max_T = self.config.max_seqlen_per_dp_cp_rank * capture_cp_size
                 max_num_seqs = self.config.thd_max_packed_sequences
                 cu_seqlens = torch.zeros(max_num_seqs + 1, dtype=torch.int32, device=device)
                 cu_seqlens[1:] = max_T
@@ -1405,7 +1412,8 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         """
         if 'cu_seqlens_q' not in kwargs:
             return
-        max_seqlen = self.config.max_seqlen_per_dp_cp_rank * self.config.context_parallel_size
+        capture_cp_size, capture_cp_group = self._get_thd_cuda_graph_capture_cp()
+        max_seqlen = self.config.max_seqlen_per_dp_cp_rank * capture_cp_size
         packed_seq_params = PackedSeqParams(
             qkv_format='thd',
             cp_partition_mode=self.config.cp_partition_mode,
@@ -1415,6 +1423,8 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
             cu_seqlens_kv_padded=kwargs.pop('cu_seqlens_kv_padded'),
             max_seqlen_q=max_seqlen,
             max_seqlen_kv=max_seqlen,
+            local_cp_size=(capture_cp_size if self.config.dynamic_context_parallel else None),
+            cp_group=(capture_cp_group if self.config.dynamic_context_parallel else None),
             # CUDA graph inputs do not carry this Python bool. Sequence-packing
             # metadata may contain valid/physical gaps, so use the conservative
             # graph-static value instead of asking TE to infer it with a CUDA
@@ -1423,6 +1433,34 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
             pad_between_seqs=True,
         )
         kwargs['packed_seq_params'] = packed_seq_params
+
+    def _activate_dynamic_cp_cuda_graph(self, packed_seq_params):
+        """Select the graph-bank entry for a runtime DCP microbatch."""
+        graph_bank = self.cuda_graphs_by_dynamic_cp_size
+        if not graph_bank:
+            return
+
+        if packed_seq_params is None or packed_seq_params.local_cp_size is None:
+            raise RuntimeError(
+                "Dynamic-CP CUDA graph replay requires packed sequence metadata with "
+                "local_cp_size."
+            )
+        dynamic_cp_size = int(packed_seq_params.local_cp_size)
+        if dynamic_cp_size not in graph_bank:
+            raise RuntimeError(
+                f"No layer CUDA graph bank entry for local_cp_size={dynamic_cp_size}; "
+                f"available sizes are {sorted(graph_bank)}."
+            )
+        expected_group = parallel_state.get_dynamic_data_context_parallel_groups(
+            group_size=dynamic_cp_size
+        )
+        if packed_seq_params.cp_group is not expected_group:
+            raise RuntimeError(
+                "Dynamic-CP CUDA graph replay received a process group that does not match "
+                f"local_cp_size={dynamic_cp_size}."
+            )
+        self.cuda_graphs = graph_bank[dynamic_cp_size]
+        self.activate_te_cuda_graph_static_hidden_inputs(dynamic_cp_size)
 
     def _te_cuda_graph_capture(self, *args, **kwargs):
         """
@@ -1434,6 +1472,14 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         For THD format, PackedSeqParams is reconstructed from tensor kwargs.
         """
         self._reconstruct_packed_seq_params_from_kwargs(kwargs)
+        if self.config.dynamic_context_parallel and kwargs.get('packed_seq_params') is None:
+            # Scopes such as moe_router may leave attention eager and therefore
+            # have no cu_seqlens tensor inputs. The router still needs the DCP
+            # group for its captured auxiliary-loss reduction.
+            capture_cp_size, capture_cp_group = self._get_thd_cuda_graph_capture_cp()
+            kwargs['packed_seq_params'] = PackedSeqParams(
+                qkv_format='thd', local_cp_size=capture_cp_size, cp_group=capture_cp_group
+            )
 
         # Record the backward event on cuda graph stream in backward pass.
         # This is to ensure the main stream waits for computing on cuda graph stream to complete,
@@ -1497,6 +1543,8 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         Hence, `inference_context` and `packed_seq_params` are excluded from input list.
         For THD format, PackedSeqParams is decomposed into individual tensor kwargs.
         """
+        self._activate_dynamic_cp_cuda_graph(kwargs.get('packed_seq_params'))
+        eager_packed_seq_params = kwargs.get('packed_seq_params')
         context = None
         padding_mask = kwargs.get("padding_mask", None)
         if (
@@ -1526,7 +1574,9 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
             self.off_interface.enter_replay()
 
         try:
-            return self._te_cuda_graph_replay_impl(args, kwargs, context)
+            return self._te_cuda_graph_replay_impl(
+                args, kwargs, context, eager_packed_seq_params=eager_packed_seq_params
+            )
         finally:
             if self.config.delay_offload_until_cuda_graph:
                 self.off_interface.exit_replay()
@@ -1583,7 +1633,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
         nvtx_range_pop(suffix="mlp")
         return mlp_output_with_bias
 
-    def _te_cuda_graph_replay_impl(self, args, kwargs, context):
+    def _te_cuda_graph_replay_impl(self, args, kwargs, context, eager_packed_seq_params=None):
         """Implementation of _te_cuda_graph_replay, separated for replay mode cleanup."""
         cuda_graph_output = list(super()._te_cuda_graph_replay(*args, **kwargs))
 
@@ -1697,7 +1747,7 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
                 hidden_states,
                 padding_mask=kwargs.get("padding_mask", None),
                 input_ids=kwargs.get("input_ids", None),
-                packed_seq_params=kwargs.get("packed_seq_params", None),
+                packed_seq_params=eager_packed_seq_params,
             )
         return output, context
 
@@ -2683,7 +2733,7 @@ class HyperConnectionTransformerLayer(TransformerLayer):
         local_tokens, probs = self.mlp.preprocess(pre_mlp_layernorm_output, probs, routing_map)
         return (residual, local_tokens, probs, shared_expert_output, mlp_h_res, mlp_hc_h_post)
 
-    def _te_cuda_graph_replay_impl(self, args, kwargs, context):
+    def _te_cuda_graph_replay_impl(self, args, kwargs, context, eager_packed_seq_params=None):
         """Implementation of _te_cuda_graph_replay with hyper connection support.
 
         Overrides the parent's _te_cuda_graph_replay_impl so that the
@@ -2859,7 +2909,7 @@ class HyperConnectionTransformerLayer(TransformerLayer):
                 *cuda_graph_output,
                 padding_mask=padding_mask,
                 input_ids=kwargs.get("input_ids", None),
-                packed_seq_params=kwargs.get("packed_seq_params", None),
+                packed_seq_params=eager_packed_seq_params,
                 mhc_recompute_manager=getattr(self, '_mhc_recompute_manager', None),
             )
         return output, context

--- a/megatron/core/transformer/transformer_layer.py
+++ b/megatron/core/transformer/transformer_layer.py
@@ -1451,9 +1451,13 @@ class TransformerLayer(GraphableMegatronModule, BaseTransformerLayer):
                 f"No layer CUDA graph bank entry for local_cp_size={dynamic_cp_size}; "
                 f"available sizes are {sorted(graph_bank)}."
             )
-        expected_group = parallel_state.get_dynamic_data_context_parallel_groups(
-            group_size=dynamic_cp_size
-        )
+        group_bank = self.cuda_graph_cp_groups_by_dynamic_cp_size
+        if dynamic_cp_size not in group_bank:
+            raise RuntimeError(
+                f"No captured process group for local_cp_size={dynamic_cp_size}; "
+                f"available sizes are {sorted(group_bank)}."
+            )
+        expected_group = group_bank[dynamic_cp_size]
         if packed_seq_params.cp_group is not expected_group:
             raise RuntimeError(
                 "Dynamic-CP CUDA graph replay received a process group that does not match "

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1583,6 +1583,11 @@ def validate_args(args, defaults={}):
             f'min_dynamic_context_parallel_size ({args.min_dynamic_context_parallel_size}) '
             f'must be <= dp_size * cp_size ({dp_cp_size})'
         )
+        if (
+            args.cuda_graph_impl == 'transformer_engine'
+            and args.step_batch_size_schedule is not None
+        ):
+            raise ValueError('Dynamic CP CUDA graphs do not support step_batch_size_schedule.')
 
         import warnings
 

--- a/megatron/training/initialize.py
+++ b/megatron/training/initialize.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 
 """Megatron initialization."""
-
 import logging
 import os
 import random
@@ -264,9 +263,8 @@ def _initialize_tp_communicators():
         )
 
 
-def _initialize_distributed(
-    get_embedding_ranks, get_position_embedding_ranks, store, skip_model_parallel_init=False
-):
+def _initialize_distributed(get_embedding_ranks, get_position_embedding_ranks, store,
+                            skip_model_parallel_init=False):
     """Initialize torch.distributed and core model parallel."""
     args = get_args()
 
@@ -423,17 +421,11 @@ def _set_random_seed(
     """
     if seed_ is not None and seed_ > 0:
         # Ensure that different pipeline MP stages get different seeds.
-        pp_rank = (
-            get_pg_rank(pp_group)
-            if pp_group is not None
-            else mpu.get_pipeline_model_parallel_rank()
-        )
+        pp_rank = get_pg_rank(pp_group) if pp_group is not None else mpu.get_pipeline_model_parallel_rank()
         seed = seed_ + (100 * pp_rank)
         # Ensure different data parallel ranks get different seeds
         if data_parallel_random_init:
-            dp_rank = (
-                get_pg_rank(dp_group) if dp_group is not None else mpu.get_data_parallel_rank()
-            )
+            dp_rank = get_pg_rank(dp_group) if dp_group is not None else mpu.get_data_parallel_rank()
             seed = seed + (10 * dp_rank)
         random.seed(seed)
         np.random.seed(seed)

--- a/megatron/training/initialize.py
+++ b/megatron/training/initialize.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 
 """Megatron initialization."""
+
 import logging
 import os
 import random
@@ -263,8 +264,9 @@ def _initialize_tp_communicators():
         )
 
 
-def _initialize_distributed(get_embedding_ranks, get_position_embedding_ranks, store,
-                            skip_model_parallel_init=False):
+def _initialize_distributed(
+    get_embedding_ranks, get_position_embedding_ranks, store, skip_model_parallel_init=False
+):
     """Initialize torch.distributed and core model parallel."""
     args = get_args()
 
@@ -421,11 +423,17 @@ def _set_random_seed(
     """
     if seed_ is not None and seed_ > 0:
         # Ensure that different pipeline MP stages get different seeds.
-        pp_rank = get_pg_rank(pp_group) if pp_group is not None else mpu.get_pipeline_model_parallel_rank()
+        pp_rank = (
+            get_pg_rank(pp_group)
+            if pp_group is not None
+            else mpu.get_pipeline_model_parallel_rank()
+        )
         seed = seed_ + (100 * pp_rank)
         # Ensure different data parallel ranks get different seeds
         if data_parallel_random_init:
-            dp_rank = get_pg_rank(dp_group) if dp_group is not None else mpu.get_data_parallel_rank()
+            dp_rank = (
+                get_pg_rank(dp_group) if dp_group is not None else mpu.get_data_parallel_rank()
+            )
             seed = seed + (10 * dp_rank)
         random.seed(seed)
         np.random.seed(seed)

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -4558,6 +4558,9 @@ def train(
 
     # Initialize CUDA Graphs helper.
     if args.cuda_graph_impl == "transformer_engine":
+        config.thd_max_subsamples_per_item = (
+            1 if args.use_varlen_dataset else args.thd_max_packed_sequences
+        )
         cuda_graph_helper = TECudaGraphHelper(
             model=model,
             config=config,
@@ -4977,7 +4980,7 @@ def train(
             break
 
     # Destroy CUDA Graphs.
-    if args.cuda_graph_impl == "transformer_engine" and cuda_graph_helper.graphs_created():
+    if args.cuda_graph_impl == "transformer_engine":
         cuda_graph_helper.delete_cuda_graphs()
 
     # Call OptimizerCudaGraph destructor to destroy optimizer CUDA graph
@@ -5116,7 +5119,7 @@ def evaluate(
             ft_integration.on_eval_step_start()
             if getattr(config, 'sequence_packing_scheduler', None) is not None:
                 try:
-                    (packed_data_iterator, scheduled_eval_num_microbatches, _, _) = (
+                    packed_data_iterator, scheduled_eval_num_microbatches, _, _ = (
                         wrap_data_iterator(data_iterator, config, eval_num_microbatches)
                     )
                 except StopIteration:
@@ -5414,7 +5417,7 @@ def build_train_valid_test_data_loaders(build_train_valid_test_datasets_provider
 
     args = get_args()
 
-    (train_dataloader, valid_dataloaders, test_dataloader) = (None, None, None)
+    train_dataloader, valid_dataloaders, test_dataloader = (None, None, None)
 
     print_rank_0('> building train, validation, and test datasets ...')
 

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -4568,6 +4568,11 @@ def train(
             micro_batch_size=args.micro_batch_size,
             optimizers=[optimizer],
             thd_sequence_length_upper_bound=_get_thd_sequence_length_upper_bound(args),
+            dynamic_cp_group_getter=(
+                get_dynamic_data_context_parallel_groups
+                if args.dynamic_context_parallel
+                else None
+            ),
         )
 
     # Run training iterations till done.
@@ -5119,7 +5124,7 @@ def evaluate(
             ft_integration.on_eval_step_start()
             if getattr(config, 'sequence_packing_scheduler', None) is not None:
                 try:
-                    packed_data_iterator, scheduled_eval_num_microbatches, _, _ = (
+                    (packed_data_iterator, scheduled_eval_num_microbatches, _, _) = (
                         wrap_data_iterator(data_iterator, config, eval_num_microbatches)
                     )
                 except StopIteration:
@@ -5417,7 +5422,7 @@ def build_train_valid_test_data_loaders(build_train_valid_test_datasets_provider
 
     args = get_args()
 
-    train_dataloader, valid_dataloaders, test_dataloader = (None, None, None)
+    (train_dataloader, valid_dataloaders, test_dataloader) = (None, None, None)
 
     print_rank_0('> building train, validation, and test datasets ...')
 

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -4569,9 +4569,7 @@ def train(
             optimizers=[optimizer],
             thd_sequence_length_upper_bound=_get_thd_sequence_length_upper_bound(args),
             dynamic_cp_group_getter=(
-                get_dynamic_data_context_parallel_groups
-                if args.dynamic_context_parallel
-                else None
+                get_dynamic_data_context_parallel_groups if args.dynamic_context_parallel else None
             ),
         )
 

--- a/tests/unit_tests/fusions/test_fused_mrope.py
+++ b/tests/unit_tests/fusions/test_fused_mrope.py
@@ -731,6 +731,99 @@ def test_materialized_thd_mrope_option_fallbacks_do_not_call_te(
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.parametrize("cp_size, cp_rank", [(1, 0), (2, 0), (2, 1)])
+def test_materialized_thd_short_freqs_fall_back_without_calling_te(monkeypatch, cp_size, cp_rank):
+    global_token_capacity = 8
+    local_token_capacity = global_token_capacity // cp_size
+    generator = torch.Generator(device="cuda").manual_seed(9012)
+    t = torch.randn(
+        local_token_capacity, 3, 20, dtype=torch.bfloat16, device="cuda", generator=generator
+    )
+    freqs = torch.randn(4, 1, 1, 16, dtype=torch.float32, device="cuda", generator=generator)
+    cu_seqlens = torch.tensor([0, 2, global_token_capacity], dtype=torch.int32, device="cuda")
+    cp_group = FakeCPGroup(size=cp_size, rank=cp_rank)
+    config = TransformerConfig(
+        num_attention_heads=t.shape[1],
+        num_layers=1,
+        context_parallel_size=cp_size,
+        apply_rope_fusion=True,
+    )
+
+    def unexpected_te_thd_call(*args, **kwargs):
+        raise AssertionError("TE THD fused RoPE should not be called with a short frequency table")
+
+    monkeypatch.setattr(rope_utils, "fused_apply_rotary_pos_emb_thd", unexpected_te_thd_call)
+    with warnings.catch_warnings(record=True) as recorded_warnings:
+        warnings.simplefilter("always")
+        out = apply_rotary_pos_emb(
+            t, freqs, config, cu_seqlens, cp_group=cp_group, max_seqlen=global_token_capacity
+        )
+
+    fallback_warnings = _fallback_warnings(recorded_warnings)
+    assert len(fallback_warnings) == 1
+    assert "frequency table length (4) to cover max_seqlen (8)" in str(fallback_warnings[0].message)
+    assert _ROPE_FUSION_FALLBACK_WARNINGS == {"te-rope-thd-short-freqs"}
+
+    ref = _apply_rotary_pos_emb_thd(
+        t, cu_seqlens, freqs, cp_group=cp_group, max_seqlen=global_token_capacity
+    )
+    torch.testing.assert_close(ref.float(), out.float(), **_dtype_tols(t.dtype))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_materialized_thd_short_freqs_fallback_captures_and_replays(monkeypatch):
+    global_token_capacity = 8
+    cp_group = FakeCPGroup(size=2, rank=1)
+    generator = torch.Generator(device="cuda").manual_seed(3456)
+    t = torch.randn(
+        global_token_capacity // cp_group.size(),
+        3,
+        20,
+        dtype=torch.bfloat16,
+        device="cuda",
+        generator=generator,
+    )
+    freqs = torch.randn(4, 1, 1, 16, dtype=torch.float32, device="cuda", generator=generator)
+    cu_seqlens = torch.tensor([0, 2, global_token_capacity], dtype=torch.int32, device="cuda")
+    config = TransformerConfig(
+        num_attention_heads=t.shape[1],
+        num_layers=1,
+        context_parallel_size=cp_group.size(),
+        apply_rope_fusion=True,
+    )
+
+    def apply_short_freq_rope():
+        return apply_rotary_pos_emb(
+            t, freqs, config, cu_seqlens, cp_group=cp_group, max_seqlen=global_token_capacity
+        )
+
+    def unexpected_te_thd_call(*args, **kwargs):
+        raise AssertionError("TE THD fused RoPE should not be called with a short frequency table")
+
+    monkeypatch.setattr(rope_utils, "fused_apply_rotary_pos_emb_thd", unexpected_te_thd_call)
+    warmup_stream = torch.cuda.Stream()
+    warmup_stream.wait_stream(torch.cuda.current_stream())
+    with (
+        torch.cuda.stream(warmup_stream),
+        pytest.warns(UserWarning, match="frequency table length"),
+    ):
+        apply_short_freq_rope()
+    torch.cuda.current_stream().wait_stream(warmup_stream)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        graph_out = apply_short_freq_rope()
+
+    t.copy_(torch.randn(t.shape, dtype=t.dtype, device=t.device, generator=generator))
+    cu_seqlens.copy_(torch.tensor([0, 4, 8], dtype=torch.int32, device="cuda"))
+    graph.replay()
+    ref = _apply_rotary_pos_emb_thd(
+        t, cu_seqlens, freqs, cp_group=cp_group, max_seqlen=global_token_capacity
+    )
+    torch.testing.assert_close(ref.float(), graph_out.float(), **_dtype_tols(t.dtype))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.skipif(not is_fused_mrope_available(), reason="Triton fused mRoPE not available")
 @pytest.mark.parametrize("interleaved_mrope", [False, True])
 @pytest.mark.parametrize("cp_size, cp_rank", [(1, 0), (2, 0), (2, 1)])

--- a/tests/unit_tests/fusions/test_mla_yarn_rope_apply.py
+++ b/tests/unit_tests/fusions/test_mla_yarn_rope_apply.py
@@ -538,6 +538,41 @@ class TestFusedApplyMLARope:
 @pytest.mark.internal
 @pytest.mark.skipif(not is_torch_min_version("2.5.0"), reason="Requires PyTorch >= 2.5.0")
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_fused_mla_rope_inplace_saves_thd_cu_seqlens():
+    """Keep generated packed-sequence metadata in the saved-tensor lifecycle."""
+    total_seqlen = 16
+    num_heads = 2
+    nope_dim = 16
+    emb_dim = 64
+    dtype = torch.bfloat16
+    cu_seqlens = torch.tensor([0, 8, total_seqlen], dtype=torch.int32, device="cuda")
+    yarn_rope = YarnRotaryEmbedding(emb_dim, original_max_position_embeddings=total_seqlen)
+    freqs, mscale = yarn_rope(total_seqlen, 0)
+    cos = (torch.cos(freqs) * mscale).to(dtype)
+    sin = (torch.sin(freqs) * mscale).to(dtype)
+    input_ = torch.randn(
+        total_seqlen, num_heads, nope_dim + emb_dim, dtype=dtype, device="cuda", requires_grad=True
+    )
+    packed = []
+
+    def pack(tensor):
+        packed.append(tensor)
+        return tensor
+
+    with torch.autograd.graph.saved_tensors_hooks(pack, lambda tensor: tensor):
+        output = fused_mla_rope_inplace(
+            input_, cos, sin, nope_dim, emb_dim, cu_seqlens_q=cu_seqlens, remove_interleaving=True
+        )
+
+    assert any(tensor.data_ptr() == cu_seqlens.data_ptr() for tensor in packed)
+    output.backward(torch.randn_like(output).contiguous())
+    assert input_.grad is not None
+
+
+@pytest.mark.experimental
+@pytest.mark.internal
+@pytest.mark.skipif(not is_torch_min_version("2.5.0"), reason="Requires PyTorch >= 2.5.0")
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.parametrize("input_format", ["sbhd", "thd"])
 def test_out_of_place_inverse_rope_preserves_upstream_saved_output(input_format):
     """Post-attention inverse RoPE must not overwrite an output saved for backward."""

--- a/tests/unit_tests/test_sequence_packing.py
+++ b/tests/unit_tests/test_sequence_packing.py
@@ -82,7 +82,7 @@ def test_scheduler_sanitizes_thd_padding_values():
     assert torch.equal(batch['position_ids'], torch.tensor([0, 1, 0, 0, 0]))
 
 
-def test_scheduler_reroute_uses_dp_all_gather(monkeypatch):
+def test_scheduler_reroute_reuses_equivalent_dp_cp_group(monkeypatch):
     class _Group:
         def __init__(self, size, rank):
             self._size = size
@@ -137,6 +137,7 @@ def test_scheduler_reroute_uses_dp_all_gather(monkeypatch):
         output.copy_(torch.cat([input_, remote]))
 
     monkeypatch.setattr(torch.cuda, 'current_device', lambda: torch.device('cpu'))
+    monkeypatch.setattr(torch.distributed, 'is_initialized', lambda: False)
     monkeypatch.setattr(torch.distributed, 'all_gather_into_tensor', _all_gather_into_tensor)
     monkeypatch.setattr(
         torch.distributed,
@@ -161,7 +162,35 @@ def test_scheduler_reroute_uses_dp_all_gather(monkeypatch):
     assert torch.equal(received[2]['position_ids'], torch.tensor([0, 1, 2, 3]))
     assert torch.equal(received[2]['original_seq_len'], torch.tensor([4], dtype=torch.int32))
     assert torch.equal(received[2]['padded_seq_len'], torch.tensor([4], dtype=torch.int32))
-    assert gather_groups == [dp_group] * 6
+    assert gather_groups == [dp_cp_group] * 6
+
+    with pytest.raises(RuntimeError, match="must use the same rank order"):
+        reroute_samples_to_dcp_ranks(
+            batch=batch,
+            global_ids_this_rank=torch.tensor([0, 1]),
+            global_id_seqlens=[(0, 2), (1, 1), (2, 4)],
+            sample_id_groups=[[[2], [0, 1]]],
+            offsets=torch.tensor([0, 2, 3]),
+            dp_group=_Group(size=2, rank=1),
+            dp_cp_group=dp_cp_group,
+        )
+
+    monkeypatch.setattr(torch.distributed, 'is_initialized', lambda: True)
+    monkeypatch.setattr(
+        torch.distributed,
+        'get_process_group_ranks',
+        lambda group: [0, 1] if group is dp_group else [0, 2],
+    )
+    with pytest.raises(RuntimeError, match="must use the same rank order"):
+        reroute_samples_to_dcp_ranks(
+            batch=batch,
+            global_ids_this_rank=torch.tensor([0, 1]),
+            global_id_seqlens=[(0, 2), (1, 1), (2, 4)],
+            sample_id_groups=[[[2], [0, 1]]],
+            offsets=torch.tensor([0, 2, 3]),
+            dp_group=dp_group,
+            dp_cp_group=dp_cp_group,
+        )
 
 
 def test_scheduler_reroute_rejects_unsupported_sample_keys():

--- a/tests/unit_tests/test_sequence_packing.py
+++ b/tests/unit_tests/test_sequence_packing.py
@@ -18,6 +18,7 @@ from megatron.core.datasets.data_schedule import (
     wrap_data_iterator,
 )
 from megatron.core.datasets.data_schedule_utils import (
+    align_sample_id_groups,
     next_hdp_group_packing_aware,
     reroute_samples_to_dcp_ranks,
 )
@@ -728,6 +729,44 @@ def test_next_hdp_group_packing_aware_can_use_larger_cp_group_for_short_sequence
     assert micro_batches == [[6144, 2048], [6144, 2048]]
     assert sample_ids == [[0, 1], [0, 1]]
     assert exec_times[0] == exec_times[1]
+
+
+def test_align_sample_id_groups_splits_packed_full_cp_group():
+    sample_id_groups = [
+        [[0] for _ in range(8)],
+        [[1] for _ in range(8)],
+        [[2, 3] for _ in range(8)],
+    ]
+
+    aligned = align_sample_id_groups(sample_id_groups, 4)
+
+    assert len(aligned) == 4
+    assert aligned[2] == [[2] for _ in range(8)]
+    assert aligned[3] == [[3] for _ in range(8)]
+
+
+def test_align_sample_id_groups_repeatedly_splits_packed_full_cp_group():
+    sample_id_groups = [[list(range(16)) for _ in range(8)]]
+
+    aligned = align_sample_id_groups(sample_id_groups, 16)
+
+    assert len(aligned) == 16
+    assert all(rank_ids == group[0] for group in aligned for rank_ids in group)
+    assert sorted(sample_id for group in aligned for sample_id in group[0]) == list(range(16))
+
+
+def test_align_sample_id_groups_prefers_existing_cp_block_split():
+    untouched_full_group = [[10, 11] for _ in range(8)]
+    sample_id_groups = [
+        [[20] for _ in range(8)],
+        [[0], [0], [0], [0], [1], [1], [2], [2]],
+        untouched_full_group,
+    ]
+
+    aligned = align_sample_id_groups(sample_id_groups, 4)
+
+    assert len(aligned) == 4
+    assert aligned[2] == untouched_full_group
 
 
 def test_next_hdp_group_packing_aware_fills_non_power_of_two_dpxcp_group():

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_csa.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_attention_variant_csa.py
@@ -949,6 +949,53 @@ class TestCompressedSparseAttentionCompressed:
             csa.config.cuda_graph_impl = previous_cuda_graph_impl
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_bshd_compact_workspace_capture_selects_warmed_geometry(self, compress_ratio):
+        """Capture can select a non-active BSHD workspace prepared by warmup."""
+        if compress_ratio != 4:
+            pytest.skip("compact indexer workspace applies only to ratio-4 layers")
+
+        csa = CompressedSparseAttention(
+            config=self.config,
+            submodules=_make_csa_submodules(),
+            layer_number=self._get_layer_number(compress_ratio),
+            attn_mask_type=AttnMaskType.causal,
+            attention_type='self',
+            pg_collection=self.pg_collection,
+            rotary_pos_emb=self.rotary_pos_emb,
+            compress_ratio=compress_ratio,
+        ).cuda()
+        previous_cuda_graph_impl = csa.config.cuda_graph_impl
+        csa.config.cuda_graph_impl = "local"
+        q = torch.empty(8, 1, 64, 128, dtype=torch.bfloat16, device="cuda")
+        k = torch.empty(2, 1, 128, dtype=torch.bfloat16, device="cuda")
+        active_workspace, requested_workspace = MagicMock(), MagicMock()
+        active_workspace.matches_shape.return_value = False
+        requested_workspace.matches_shape.return_value = True
+        csa._bshd_compact_indexer_workspaces = [active_workspace, requested_workspace]
+        csa._active_bshd_compact_indexer_workspace = active_workspace
+
+        try:
+            with (
+                patch(
+                    "megatron.core.transformer.experimental_attention_variant.csa."
+                    "bshd_compact_indexer_available",
+                    return_value=True,
+                ),
+                patch(
+                    "megatron.core.transformer.experimental_attention_variant.csa."
+                    "prepare_bshd_compact_indexer_workspace"
+                ) as prepare_workspace,
+                patch.object(torch.cuda, "is_current_stream_capturing", return_value=True),
+            ):
+                workspace = csa._get_bshd_compact_indexer_workspace(q, k, topk=8, ratio=4)
+
+            assert workspace is requested_workspace
+            assert csa._active_bshd_compact_indexer_workspace is requested_workspace
+            prepare_workspace.assert_not_called()
+        finally:
+            csa.config.cuda_graph_impl = previous_cuda_graph_impl
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
     def test_forward(self, compress_ratio):
         """Test forward pass with compressed attention."""
         seq_len = 256
@@ -2090,6 +2137,52 @@ class TestCompressedSparseAttentionThd:
                         max_seqlen_q=8,
                         max_seqlen_k=2,
                     )
+        finally:
+            csa.config.cuda_graph_impl = previous_cuda_graph_impl
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_thd_compact_workspace_capture_selects_warmed_geometry(self):
+        """Capture can select a non-active THD workspace prepared by warmup."""
+        csa = self._build_csa(compress_ratio=4)
+        previous_cuda_graph_impl = csa.config.cuda_graph_impl
+        csa.config.cuda_graph_impl = "local"
+        q = torch.empty(8, 64, 128, dtype=torch.bfloat16, device="cuda")
+        k = torch.empty(2, 128, dtype=torch.bfloat16, device="cuda")
+        cu_q = torch.tensor([0, 8], dtype=torch.int32, device="cuda")
+        cu_k = torch.tensor([0, 2], dtype=torch.int32, device="cuda")
+        active_workspace, requested_workspace = MagicMock(), MagicMock()
+        active_workspace.matches.return_value = False
+        requested_workspace.matches.return_value = True
+        csa._thd_compact_indexer_workspaces = [active_workspace, requested_workspace]
+        csa._active_thd_compact_indexer_workspace = active_workspace
+
+        try:
+            with (
+                patch(
+                    "megatron.core.transformer.experimental_attention_variant.csa."
+                    "thd_compact_indexer_available",
+                    return_value=True,
+                ),
+                patch(
+                    "megatron.core.transformer.experimental_attention_variant.csa."
+                    "prepare_thd_compact_indexer_workspace"
+                ) as prepare_workspace,
+                patch.object(torch.cuda, "is_current_stream_capturing", return_value=True),
+            ):
+                workspace = csa._get_thd_compact_indexer_workspace(
+                    q,
+                    k,
+                    topk=8,
+                    ratio=4,
+                    cu_seqlens_q=cu_q,
+                    cu_seqlens_k=cu_k,
+                    max_seqlen_q=8,
+                    max_seqlen_k=2,
+                )
+
+            assert workspace is requested_workspace
+            assert csa._active_thd_compact_indexer_workspace is requested_workspace
+            prepare_workspace.assert_not_called()
         finally:
             csa.config.cuda_graph_impl = previous_cuda_graph_impl
 

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_csa_fused_sparse_attention.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_csa_fused_sparse_attention.py
@@ -1250,6 +1250,7 @@ class TestCPCommunicationOverlap:
                 saved_grad_k_indexer,
                 saved_grad_weights,
                 indexer_rank_map,
+                None,
             )
             cp_group = FakeGroup()
             compressed_kv_start = 2
@@ -1259,7 +1260,6 @@ class TestCPCommunicationOverlap:
             local_k_indexer_rows = 2
             local_compressed_kv_rows = 2
             softmax_scale = 0.5
-            q_padding_mask = None
             num_forward_inputs = 26
 
         gradients = FusedCSAIndexerSparseAttnFromTopkFunc.backward(
@@ -1611,6 +1611,50 @@ class TestDsaSparseAttn:
         expected_parts = expected_dkv.split((1, 4, 2), dim=0)
         for part, expected_grad in zip((boundary_kv, local_kv, compressed_kv), expected_parts):
             torch.testing.assert_close(part.grad, expected_grad)
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_topk_length_uses_saved_tensor_hooks(self, reset_lazy_kernel_state):
+        """Protect compact lengths with the same saved-tensor lifecycle as indices."""
+        total_q, np_, d, n_kv = 4, 2, 512, 6
+        topk = _get_topk_alignment()
+        query = torch.randn(
+            total_q, np_, d, dtype=torch.bfloat16, device="cuda", requires_grad=True
+        )
+        kv = torch.randn(n_kv, d, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+        attn_sink = torch.zeros(np_, dtype=torch.float32, device="cuda", requires_grad=True)
+        topk_idxs = torch.zeros(total_q, topk, dtype=torch.int32, device="cuda")
+        topk_length = torch.full((total_q,), topk, dtype=torch.int32, device="cuda")
+
+        dk._flash_mla_sparse_fwd = _make_flash_mla_stub(d_v=d)
+        fake_dsa = MagicMock()
+        fake_dsa.sparse_attention_backward_wrapper.return_value = {
+            "dq": torch.zeros_like(query),
+            "dkv": torch.zeros_like(kv),
+            "d_sink": torch.zeros_like(attn_sink),
+        }
+        dk._DSA = fake_dsa
+
+        packed = []
+
+        def pack(tensor):
+            packed.append(tensor)
+            return tensor
+
+        with torch.autograd.graph.saved_tensors_hooks(pack, lambda tensor: tensor):
+            out = csa_sparse_attn(
+                query,
+                kv,
+                attn_sink,
+                topk_idxs,
+                softmax_scale=0.5,
+                topk_length=topk_length,
+                is_thd=True,
+            )
+
+        assert any(tensor.data_ptr() == topk_length.data_ptr() for tensor in packed)
+        out.sum().backward()
+        passed_length = fake_dsa.sparse_attention_backward_wrapper.call_args.kwargs["topk_length"]
+        assert passed_length.data_ptr() == topk_length.data_ptr()
 
 
 # ---------------------------------------------------------------------------
@@ -2685,22 +2729,31 @@ class TestFusedIndexerSparseAttnFromTopk:
         monkeypatch.setattr(dk, '_csa_fwd_flash_mla', fake_flash)
         monkeypatch.setattr(dk, '_DSA', FakeDSA)
 
-        output, loss = FusedCSAIndexerSparseAttnFromTopkFunc.apply(
-            *inputs.values(),
-            1.0,
-            1.0,
-            0.0,
-            float(total_q),
-            True,
-            2,
-            total_q,
-            (
-                torch.tensor([0, total_q], dtype=torch.int32),
-                torch.tensor([0, inputs['k_indexer'].shape[0]], dtype=torch.int32),
-                torch.tensor([0], dtype=torch.int32),
-            ),
-            q_padding_mask,
-        )
+        packed = []
+
+        def pack(tensor):
+            packed.append(tensor)
+            return tensor
+
+        with torch.autograd.graph.saved_tensors_hooks(pack, lambda tensor: tensor):
+            output, loss = FusedCSAIndexerSparseAttnFromTopkFunc.apply(
+                *inputs.values(),
+                1.0,
+                1.0,
+                0.0,
+                float(total_q),
+                True,
+                2,
+                total_q,
+                (
+                    torch.tensor([0, total_q], dtype=torch.int32),
+                    torch.tensor([0, inputs['k_indexer'].shape[0]], dtype=torch.int32),
+                    torch.tensor([0], dtype=torch.int32),
+                ),
+                q_padding_mask,
+            )
+
+        assert any(tensor.data_ptr() == q_padding_mask.data_ptr() for tensor in packed)
         (output.sum() + loss).backward()
 
         torch.testing.assert_close(
@@ -5067,8 +5120,20 @@ class TestThdPaddingRowMasking:
         padded, cu_q_unpadded = self._build_per_seg_padded(
             real, self.SEG_LENS_PADDED, self.SHAPES, dev, fill_pad_random=False
         )
-        _, loss_with_pad = self._run_fused(
-            padded, self.SHAPES, sparse_loss=sparse_loss, cu_seqlens_q_unpadded=cu_q_unpadded
+        padded['q_indexer'] = padded['q_indexer'].detach().requires_grad_(True)
+        packed = []
+
+        def pack(tensor):
+            packed.append(tensor)
+            return tensor
+
+        with torch.autograd.graph.saved_tensors_hooks(pack, lambda tensor: tensor):
+            _, loss_with_pad = self._run_fused(
+                padded, self.SHAPES, sparse_loss=sparse_loss, cu_seqlens_q_unpadded=cu_q_unpadded
+            )
+
+        assert any(
+            tensor.dtype == torch.bool and tensor.shape == (padded['total_q'],) for tensor in packed
         )
 
         assert torch.allclose(loss_with_pad, loss_no_pad, atol=5e-2, rtol=1e-1), (

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_integration.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_integration.py
@@ -570,3 +570,41 @@ def test_dsv4_metric_logging_preserves_graph_groups_and_uses_indexer_layer_count
         assert helper.tracker["dynamic_cp_metric_group"] is dynamic_cp_metric_group
     finally:
         helper.tracker.clear()
+
+
+def test_dsv4_metric_logging_capture_reset_preserves_tracker_storage(monkeypatch):
+    """Capture cleanup removes synthetic indexer values without rebinding graph storage."""
+    from megatron.core.transformer.cuda_graphs import TECudaGraphHelper
+    from megatron.core.transformer.moe import moe_logging
+
+    helper = dsa_module.DSAIndexerLossLoggingHelper
+    reduce_group = object()
+    avg_group = object()
+    metric_group = object()
+    values = torch.tensor([2.0, 3.0], device="cuda")
+    helper.tracker.clear()
+    helper.tracker.update(
+        {
+            "values": values,
+            "reduce_group": reduce_group,
+            "avg_group": avg_group,
+            "dynamic_cp_metric_group": metric_group,
+        }
+    )
+
+    graph_helper = object.__new__(TECudaGraphHelper)
+    graph_helper.config = SimpleNamespace(dsa_indexer_loss_coeff=1e-2)
+    graph_helper.model = []
+    graph_helper.optimizers = []
+    monkeypatch.setattr(moe_logging, "get_moe_metrics_tracker", lambda: {})
+
+    try:
+        graph_helper._reset_after_capture()
+
+        assert helper.tracker["values"] is values
+        torch.testing.assert_close(values, torch.zeros_like(values))
+        assert helper.tracker["reduce_group"] is reduce_group
+        assert helper.tracker["avg_group"] is avg_group
+        assert helper.tracker["dynamic_cp_metric_group"] is metric_group
+    finally:
+        helper.tracker.clear()

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_integration.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_integration.py
@@ -454,6 +454,82 @@ def test_indexer_loss_tracker_grows_for_mtp_layer_numbers():
         helper.tracker.clear()
 
 
+def test_indexer_loss_tracker_uses_one_stable_group_for_mixed_cp(monkeypatch):
+    """Mixed-CP values use one stable metric group, not the last runtime CP group."""
+    helper = dsa_module.DSAIndexerLossLoggingHelper
+    first_runtime_group = object()
+    last_runtime_group = object()
+    metric_group = object()
+    dp_group = object()
+    pp_group = object()
+    helper.tracker.clear()
+    helper.save_loss_to_tracker(
+        loss=torch.tensor(3.0),
+        layer_number=1,
+        num_layers=1,
+        reduce_group=first_runtime_group,
+        dynamic_cp_metric_group=metric_group,
+    )
+    helper.save_loss_to_tracker(
+        loss=torch.tensor(1.0),
+        layer_number=1,
+        num_layers=1,
+        reduce_group=last_runtime_group,
+        dynamic_cp_metric_group=metric_group,
+    )
+    helper.tracker["agreed_size"] = 1
+    reductions = []
+
+    monkeypatch.setattr(
+        dsa_module.parallel_state, "get_pipeline_model_parallel_group", lambda: pp_group
+    )
+    monkeypatch.setattr(
+        dsa_module.parallel_state,
+        "get_data_parallel_group",
+        lambda with_context_parallel=False: dp_group,
+    )
+    monkeypatch.setattr(
+        torch.distributed,
+        "all_reduce",
+        lambda tensor, group=None, op=None: reductions.append((group, op)),
+    )
+
+    try:
+        torch.testing.assert_close(
+            helper.tracker["values"], helper.tracker["values"].new_tensor([4.0])
+        )
+        helper.reduce_loss_in_tracker()
+
+        assert reductions == [
+            (pp_group, None),
+            (metric_group, torch.distributed.ReduceOp.AVG),
+            (dp_group, torch.distributed.ReduceOp.AVG),
+        ]
+        assert all(group is not last_runtime_group for group, _ in reductions)
+    finally:
+        helper.tracker.clear()
+
+
+def test_indexer_loss_tracker_rejects_multiple_dynamic_cp_metric_groups():
+    """A tracker cannot silently mix values from unrelated DP-CP replicas."""
+    helper = dsa_module.DSAIndexerLossLoggingHelper
+    helper.tracker.clear()
+
+    try:
+        helper.save_loss_to_tracker(
+            loss=torch.tensor(1.0), layer_number=1, num_layers=1, dynamic_cp_metric_group=object()
+        )
+        with pytest.raises(RuntimeError, match="multiple dynamic-CP metric groups"):
+            helper.save_loss_to_tracker(
+                loss=torch.tensor(1.0),
+                layer_number=1,
+                num_layers=1,
+                dynamic_cp_metric_group=object(),
+            )
+    finally:
+        helper.tracker.clear()
+
+
 def test_dsv4_metric_logging_preserves_graph_groups_and_uses_indexer_layer_count(monkeypatch):
     """CUDA Graph reuse keeps groups, and only ratio-4 DSv4 layers enter the average."""
     helper = dsa_module.DSAIndexerLossLoggingHelper
@@ -465,8 +541,10 @@ def test_dsv4_metric_logging_preserves_graph_groups_and_uses_indexer_layer_count
             "values": torch.tensor([2.0, 0.0, 6.0, 0.0]),
             "reduce_group": reduce_group,
             "avg_group": avg_group,
+            "dynamic_cp_metric_group": object(),
         }
     )
+    dynamic_cp_metric_group = helper.tracker["dynamic_cp_metric_group"]
     recorded = []
 
     class Writer:
@@ -489,5 +567,6 @@ def test_dsv4_metric_logging_preserves_graph_groups_and_uses_indexer_layer_count
         torch.testing.assert_close(helper.tracker["values"], torch.zeros(4))
         assert helper.tracker["reduce_group"] is reduce_group
         assert helper.tracker["avg_group"] is avg_group
+        assert helper.tracker["dynamic_cp_metric_group"] is dynamic_cp_metric_group
     finally:
         helper.tracker.clear()

--- a/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_native_parity.py
+++ b/tests/unit_tests/transformer/experimental_attention_variant/test_dsa_native_parity.py
@@ -1920,42 +1920,52 @@ def test_cudnn_attention_backward_sanitizes_ignored_topk_slots(monkeypatch, sour
     def fake_flash_mla(q, kv, topk_idxs, softmax_scale, d_v, attn_sink, topk_length):
         seen["fwd_topk"] = topk_idxs.detach().clone()
         seen["fwd_topk_length"] = topk_length.detach().clone()
+        seen["fwd_topk_length_tensor"] = topk_length
         return torch.zeros((2, 1, d_v), dtype=q.dtype), torch.zeros((2, 1), dtype=torch.float32)
 
     monkeypatch.setattr(dsa_cudnn_kernels, "_dsa_fwd_flash_mla", fake_flash_mla)
 
-    if source == "full_fusion":
-        query = torch.zeros((2, 1, 1, 1), dtype=torch.bfloat16, requires_grad=True)
-        monkeypatch.setattr(dsa_cudnn_kernels, "_indexer_topk_bshd", fake_indexer_topk)
-        output, _indexer_loss = dsa_cudnn_kernels.fused_indexer_sparse_attn(
-            query,
-            torch.zeros((4, 1, 1), dtype=torch.bfloat16, requires_grad=True),
-            torch.zeros((2, 1, 1, 1), dtype=torch.bfloat16),
-            torch.zeros((4, 1, 1), dtype=torch.bfloat16),
-            torch.zeros((2, 1, 1), dtype=torch.bfloat16),
-            indexer_topk=4,
-            softmax_scale=1.0,
-            loss_coeff=0.0,
-            sparse_loss=True,
-            calculate_per_token_loss=False,
-            d_v=1,
-        )
-        expected_fwd_topk = torch.tensor([[-1, -1, -1, -1], [1, 2, -1, -1]], dtype=torch.int32)
-        expected_bwd_topk = torch.tensor([[1, 2, 0, 0], [0, 0, 0, 0]], dtype=torch.int32)
-    else:
-        value_dim = 512
-        query = torch.zeros((2, 1, 1, value_dim), dtype=torch.bfloat16, requires_grad=True)
-        key = torch.zeros((4, 1, 1, value_dim), dtype=torch.bfloat16, requires_grad=True)
-        output = dsa_cudnn_kernels.run_fused_absorbed_sparse_attention(
-            query=query,
-            key=key,
-            topk_indices=torch.tensor([[[-1, -1, -1], [2, -1, 1]]], dtype=torch.int32),
-            softmax_scale=1.0,
-            v_channels=value_dim,
-        )
-        assert output is not None
-        expected_fwd_topk = torch.tensor([[-1, -1, -1], [1, 2, -1]], dtype=torch.int32)
-        expected_bwd_topk = torch.tensor([[1, 2, 0], [0, 0, 0]], dtype=torch.int32)
+    packed = []
+
+    def pack(tensor):
+        packed.append(tensor)
+        return tensor
+
+    with torch.autograd.graph.saved_tensors_hooks(pack, lambda tensor: tensor):
+        if source == "full_fusion":
+            query = torch.zeros((2, 1, 1, 1), dtype=torch.bfloat16, requires_grad=True)
+            monkeypatch.setattr(dsa_cudnn_kernels, "_indexer_topk_bshd", fake_indexer_topk)
+            output, _indexer_loss = dsa_cudnn_kernels.fused_indexer_sparse_attn(
+                query,
+                torch.zeros((4, 1, 1), dtype=torch.bfloat16, requires_grad=True),
+                torch.zeros((2, 1, 1, 1), dtype=torch.bfloat16),
+                torch.zeros((4, 1, 1), dtype=torch.bfloat16),
+                torch.zeros((2, 1, 1), dtype=torch.bfloat16),
+                indexer_topk=4,
+                softmax_scale=1.0,
+                loss_coeff=0.0,
+                sparse_loss=True,
+                calculate_per_token_loss=False,
+                d_v=1,
+            )
+            expected_fwd_topk = torch.tensor([[-1, -1, -1, -1], [1, 2, -1, -1]], dtype=torch.int32)
+            expected_bwd_topk = torch.tensor([[1, 2, 0, 0], [0, 0, 0, 0]], dtype=torch.int32)
+        else:
+            value_dim = 512
+            query = torch.zeros((2, 1, 1, value_dim), dtype=torch.bfloat16, requires_grad=True)
+            key = torch.zeros((4, 1, 1, value_dim), dtype=torch.bfloat16, requires_grad=True)
+            output = dsa_cudnn_kernels.run_fused_absorbed_sparse_attention(
+                query=query,
+                key=key,
+                topk_indices=torch.tensor([[[-1, -1, -1], [2, -1, 1]]], dtype=torch.int32),
+                softmax_scale=1.0,
+                v_channels=value_dim,
+            )
+            assert output is not None
+            expected_fwd_topk = torch.tensor([[-1, -1, -1], [1, 2, -1]], dtype=torch.int32)
+            expected_bwd_topk = torch.tensor([[1, 2, 0], [0, 0, 0]], dtype=torch.int32)
+
+    assert any(tensor.data_ptr() == seen["fwd_topk_length_tensor"].data_ptr() for tensor in packed)
 
     output.float().sum().backward()
 

--- a/tests/unit_tests/transformer/test_cuda_graphs.py
+++ b/tests/unit_tests/transformer/test_cuda_graphs.py
@@ -1517,6 +1517,38 @@ class TestTECudaGraphHelper:
         ), f"Order length mismatch: expected {expected_order_length}, got {len(order)}"
 
 
+class TestSlotAliasedVariantOrder:
+    @staticmethod
+    def _dynamic_cp_capture_order():
+        helper = object.__new__(TECudaGraphHelper)
+        helper.flattened_callables = [torch.nn.Identity()]
+        helper.num_microbatches = 1
+        helper.num_layers_per_chunk = [1]
+        helper.num_model_chunks = 1
+        capture_banks = []
+        for cp_size in (4, 2, 1):
+            capture_banks.append(
+                (
+                    cp_size,
+                    None,
+                    ((),),
+                    {'_order': (1, -1), '_reuse_graph_input_output_buffers': True},
+                )
+            )
+        _, _, kwargs = helper._get_dynamic_cp_variant_capture_data(capture_banks)
+        return kwargs['_order']
+
+    def test_capture_uses_minimum_cp_as_canonical(self):
+        assert self._dynamic_cp_capture_order() == [3, -3, 1, -1, 2, -2]
+
+    def test_variant_major_starts_with_canonical_variant(self):
+        order = TECudaGraphHelper._build_slot_aliased_variant_order(
+            [1, 2, -2, -1], num_variants=4, num_model_chunks=2, canonical_variant=3
+        )
+
+        assert order == [7, 8, -8, -7, 1, 2, -2, -1, 3, 4, -4, -3, 5, 6, -6, -5]
+
+
 class TestRequiredNumMicrobatchSlots:
     """Pure-Python tests for ``_get_required_num_microbatch_slots_from_order``.
 

--- a/tests/unit_tests/transformer/test_cuda_graphs.py
+++ b/tests/unit_tests/transformer/test_cuda_graphs.py
@@ -1200,7 +1200,10 @@ class TestTECudaGraphHelper:
         helper.config = _te_whole_moe_paged_stash_config(cuda_graph_modules=cuda_graph_modules)
         helper.flattened_callables = [layer]
         helper.callables_per_chunk = []
+        helper.chunks_with_decoder = []
         helper.num_microbatches = 1
+        helper._thd_rotary_seq_lens = {}
+        helper._capture_finished = False
         helper._start_capturing = lambda: 0.0
         helper._finish_capturing = lambda _start_time: None
         helper._get_cuda_graph_input_data = lambda: ([()], {'_order': [1, -1]})

--- a/tests/unit_tests/transformer/test_thd_cuda_graph.py
+++ b/tests/unit_tests/transformer/test_thd_cuda_graph.py
@@ -1058,7 +1058,7 @@ class TestDynamicMicrobatchSlots:
         "fp8_attention_flag",
         ("fp8_dot_product_attention", "fp8_multi_head_attention", "custom_recipe"),
     )
-    def test_dynamic_cp_graph_attention_rejects_fp8_attention(self, fp8_attention_flag):
+    def test_dynamic_cp_graph_attention_accepts_fp8_with_native_groups(self, fp8_attention_flag):
         from megatron.core.enums import Fp8Recipe
         from megatron.core.transformer.enums import CudaGraphModule
 
@@ -1067,26 +1067,26 @@ class TestDynamicMicrobatchSlots:
             if fp8_attention_flag == "custom_recipe"
             else {fp8_attention_flag: True}
         )
-        with pytest.raises(ValueError, match="does not support FP8 DPA/MHA or custom"):
-            TransformerConfig(
-                num_layers=1,
-                hidden_size=128,
-                num_attention_heads=4,
-                dynamic_context_parallel=True,
-                cuda_graph_impl="transformer_engine",
-                cuda_graph_modules=[CudaGraphModule.attn],
-                cuda_graph_dynamic_microbatches=True,
-                cp_comm_type="p2p",
-                fp8="hybrid",
-                max_seqlen_per_dp_cp_rank=128,
-                pad_packed_seq_alignment=128,
-                thd_max_packed_sequences=2,
-                **kwargs,
-            )
+        config = TransformerConfig(
+            num_layers=1,
+            hidden_size=128,
+            num_attention_heads=4,
+            dynamic_context_parallel=True,
+            cuda_graph_impl="transformer_engine",
+            cuda_graph_modules=[CudaGraphModule.attn],
+            cuda_graph_dynamic_microbatches=True,
+            cp_comm_type="p2p",
+            fp8="hybrid",
+            max_seqlen_per_dp_cp_rank=128,
+            pad_packed_seq_alignment=128,
+            thd_max_packed_sequences=2,
+            **kwargs,
+        )
+        assert config.dynamic_context_parallel
 
     @pytest.mark.internal
     @pytest.mark.parametrize("fp4_attention_flag", ("fp8_dot_product_attention", "custom_recipe"))
-    def test_dynamic_cp_graph_attention_rejects_fp4_attention(self, fp4_attention_flag):
+    def test_dynamic_cp_graph_attention_accepts_fp4_with_native_groups(self, fp4_attention_flag):
         from megatron.core.enums import Fp4Recipe
         from megatron.core.transformer.enums import CudaGraphModule
 
@@ -1095,39 +1095,34 @@ class TestDynamicMicrobatchSlots:
             if fp4_attention_flag == "custom_recipe"
             else {fp4_attention_flag: True}
         )
-        with pytest.raises(ValueError, match="does not support FP8 DPA/MHA or custom"):
-            TransformerConfig(
-                num_layers=1,
-                hidden_size=128,
-                num_attention_heads=4,
-                dynamic_context_parallel=True,
-                cuda_graph_impl="transformer_engine",
-                cuda_graph_modules=[CudaGraphModule.attn],
-                cuda_graph_dynamic_microbatches=True,
-                cp_comm_type="p2p",
-                fp4="e2m1",
-                max_seqlen_per_dp_cp_rank=128,
-                pad_packed_seq_alignment=128,
-                thd_max_packed_sequences=2,
-                **kwargs,
-            )
+        config = TransformerConfig(
+            num_layers=1,
+            hidden_size=128,
+            num_attention_heads=4,
+            dynamic_context_parallel=True,
+            cuda_graph_impl="transformer_engine",
+            cuda_graph_modules=[CudaGraphModule.attn],
+            cuda_graph_dynamic_microbatches=True,
+            cp_comm_type="p2p",
+            fp4="e2m1",
+            max_seqlen_per_dp_cp_rank=128,
+            pad_packed_seq_alignment=128,
+            thd_max_packed_sequences=2,
+            **kwargs,
+        )
+        assert config.dynamic_context_parallel
 
     @pytest.mark.internal
-    def test_dynamic_cp_graph_bank_and_capture_contexts(self, monkeypatch):
-        from megatron.core import parallel_state
+    def test_dynamic_cp_graph_bank_and_capture_contexts(self):
         from megatron.core.transformer.cuda_graphs import TECudaGraphHelper
 
         groups = {size: object() for size in (1, 2, 4, 8)}
-        monkeypatch.setattr(
-            parallel_state,
-            'get_dynamic_data_context_parallel_groups',
-            lambda group_size: groups[group_size],
-        )
         helper = TECudaGraphHelper.__new__(TECudaGraphHelper)
         helper.config = SimpleNamespace(
             dynamic_context_parallel=True, min_dynamic_context_parallel_size=1
         )
         helper.dp_cp_group = SimpleNamespace(size=lambda: 8)
+        helper.dynamic_cp_group_getter = lambda group_size: groups[group_size]
         assert helper._get_dynamic_cp_capture_contexts() == [
             (size, groups[size]) for size in (8, 4, 2, 1)
         ]
@@ -1137,6 +1132,7 @@ class TestDynamicMicrobatchSlots:
         layer = SimpleNamespace(
             cuda_graphs=[],
             cuda_graphs_by_dynamic_cp_size=bank,
+            cuda_graph_cp_groups_by_dynamic_cp_size=groups,
             activate_te_cuda_graph_static_hidden_inputs=activated_static_input_banks.append,
         )
         params = SimpleNamespace(local_cp_size=4, cp_group=groups[4])

--- a/tests/unit_tests/transformer/test_thd_cuda_graph.py
+++ b/tests/unit_tests/transformer/test_thd_cuda_graph.py
@@ -1160,7 +1160,7 @@ class TestDynamicMicrobatchSlots:
         helper._abort_capturing = lambda captured_graphs: helper._clear_thd_rotary_seq_lens()
         helper.flattened_callables = []
         helper.dp_cp_group = object()
-        helper.config = SimpleNamespace()
+        helper.config = SimpleNamespace(num_moe_experts=None)
         helper.chunks_with_decoder = []
         helper.callables_per_chunk = []
 

--- a/tests/unit_tests/transformer/test_thd_cuda_graph.py
+++ b/tests/unit_tests/transformer/test_thd_cuda_graph.py
@@ -25,7 +25,9 @@ import os
 import re
 import socket
 import subprocess
+import weakref
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -273,9 +275,9 @@ class TestResolveThdPaddingLengths:
         expected_local_actual = get_thd_partitioned_indices(
             psp.cu_seqlens_q, 140, cp_size, cp_rank
         ).numel()
-        expected_local_target = get_thd_partitioned_indices(
-            psp.cu_seqlens_q, expected_global_target, cp_size, cp_rank
-        ).numel()
+        expected_local_target = target_len or (
+            (expected_local_actual + alignment - 1) // alignment * alignment
+        )
 
         local_actual, global_actual, local_target, global_target, mask_device = (
             _resolve_thd_padding_lengths(
@@ -290,6 +292,40 @@ class TestResolveThdPaddingLengths:
             expected_global_target,
         )
         assert mask_device == psp.cu_seqlens_q.device
+
+    @pytest.mark.internal
+    @_REQUIRES_TWO_RANKS
+    def test_cp_no_tensor_alignment_matches_local_tensor_path(self):
+        """Intermediate PP stages apply alignment to the CP-local length."""
+        Utils.destroy_model_parallel()
+        Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=2)
+
+        from megatron.core import parallel_state
+        from megatron.core.extensions.transformer_engine import get_thd_partitioned_indices
+
+        global_actual = 2048
+        alignment = 2048
+        psp = _make_psp([global_actual])
+        cp_size = parallel_state.get_context_parallel_world_size()
+        cp_rank = parallel_state.get_context_parallel_rank()
+        local_actual = get_thd_partitioned_indices(
+            psp.cu_seqlens_q, global_actual, cp_size, cp_rank
+        ).numel()
+        metadata_lengths = _resolve_thd_padding_lengths(
+            None, None, None, None, psp, target_len=None, alignment=alignment
+        )[:4]
+        tensor_lengths = _resolve_thd_padding_lengths(
+            torch.ones(1, local_actual, device="cuda"),
+            None,
+            None,
+            None,
+            psp,
+            target_len=None,
+            alignment=alignment,
+        )[:4]
+
+        assert metadata_lengths == tensor_lengths
+        assert metadata_lengths == (local_actual, global_actual, alignment, alignment * cp_size)
 
 
 class TestPadSequenceForThd:
@@ -1005,6 +1041,409 @@ class TestStaticInputs:
 class TestDynamicMicrobatchSlots:
 
     @pytest.mark.internal
+    def test_completed_helper_rejects_recapture_before_communicator_work(self):
+        from megatron.core.transformer.cuda_graphs import TECudaGraphHelper
+
+        helper = TECudaGraphHelper.__new__(TECudaGraphHelper)
+        helper._capture_finished = True
+        helper._get_dynamic_cp_capture_contexts = lambda: pytest.fail(
+            "recapture reached communicator setup"
+        )
+
+        with pytest.raises(RuntimeError, match="capture has already been finished"):
+            helper.create_cudagraphs()
+
+    @pytest.mark.internal
+    @pytest.mark.parametrize(
+        "fp8_attention_flag",
+        ("fp8_dot_product_attention", "fp8_multi_head_attention", "custom_recipe"),
+    )
+    def test_dynamic_cp_graph_attention_rejects_fp8_attention(self, fp8_attention_flag):
+        from megatron.core.enums import Fp8Recipe
+        from megatron.core.transformer.enums import CudaGraphModule
+
+        kwargs = (
+            {"fp8_recipe": Fp8Recipe.custom, "fp8_quantizer_factory": "unused.factory"}
+            if fp8_attention_flag == "custom_recipe"
+            else {fp8_attention_flag: True}
+        )
+        with pytest.raises(ValueError, match="does not support FP8 DPA/MHA or custom"):
+            TransformerConfig(
+                num_layers=1,
+                hidden_size=128,
+                num_attention_heads=4,
+                dynamic_context_parallel=True,
+                cuda_graph_impl="transformer_engine",
+                cuda_graph_modules=[CudaGraphModule.attn],
+                cuda_graph_dynamic_microbatches=True,
+                cp_comm_type="p2p",
+                fp8="hybrid",
+                max_seqlen_per_dp_cp_rank=128,
+                pad_packed_seq_alignment=128,
+                thd_max_packed_sequences=2,
+                **kwargs,
+            )
+
+    @pytest.mark.internal
+    @pytest.mark.parametrize("fp4_attention_flag", ("fp8_dot_product_attention", "custom_recipe"))
+    def test_dynamic_cp_graph_attention_rejects_fp4_attention(self, fp4_attention_flag):
+        from megatron.core.enums import Fp4Recipe
+        from megatron.core.transformer.enums import CudaGraphModule
+
+        kwargs = (
+            {"fp4_recipe": Fp4Recipe.custom, "fp4_quantizer_factory": "unused.factory"}
+            if fp4_attention_flag == "custom_recipe"
+            else {fp4_attention_flag: True}
+        )
+        with pytest.raises(ValueError, match="does not support FP8 DPA/MHA or custom"):
+            TransformerConfig(
+                num_layers=1,
+                hidden_size=128,
+                num_attention_heads=4,
+                dynamic_context_parallel=True,
+                cuda_graph_impl="transformer_engine",
+                cuda_graph_modules=[CudaGraphModule.attn],
+                cuda_graph_dynamic_microbatches=True,
+                cp_comm_type="p2p",
+                fp4="e2m1",
+                max_seqlen_per_dp_cp_rank=128,
+                pad_packed_seq_alignment=128,
+                thd_max_packed_sequences=2,
+                **kwargs,
+            )
+
+    @pytest.mark.internal
+    def test_dynamic_cp_graph_bank_and_capture_contexts(self, monkeypatch):
+        from megatron.core import parallel_state
+        from megatron.core.transformer.cuda_graphs import TECudaGraphHelper
+
+        groups = {size: object() for size in (1, 2, 4, 8)}
+        monkeypatch.setattr(
+            parallel_state,
+            'get_dynamic_data_context_parallel_groups',
+            lambda group_size: groups[group_size],
+        )
+        helper = TECudaGraphHelper.__new__(TECudaGraphHelper)
+        helper.config = SimpleNamespace(
+            dynamic_context_parallel=True, min_dynamic_context_parallel_size=1
+        )
+        helper.dp_cp_group = SimpleNamespace(size=lambda: 8)
+        assert helper._get_dynamic_cp_capture_contexts() == [
+            (size, groups[size]) for size in (8, 4, 2, 1)
+        ]
+
+        bank = {size: [f'cp{size}'] for size in groups}
+        activated_static_input_banks = []
+        layer = SimpleNamespace(
+            cuda_graphs=[],
+            cuda_graphs_by_dynamic_cp_size=bank,
+            activate_te_cuda_graph_static_hidden_inputs=activated_static_input_banks.append,
+        )
+        params = SimpleNamespace(local_cp_size=4, cp_group=groups[4])
+        TransformerLayer._activate_dynamic_cp_cuda_graph(layer, params)
+        assert layer.cuda_graphs is bank[4]
+        assert activated_static_input_banks == [4]
+
+    @pytest.mark.internal
+    def test_failed_capture_retry_restores_capture_only_state(self):
+        from megatron.core.transformer.cuda_graphs import TECudaGraphHelper
+
+        helper = TECudaGraphHelper.__new__(TECudaGraphHelper)
+        helper._capture_finished = False
+        helper._thd_rotary_seq_lens = {2: 4096}
+        helper._uses_mhc_direct_write_arena = lambda: False
+        logical_group = object()
+        capture_contexts = [(2, logical_group)]
+        helper._get_dynamic_cp_capture_contexts = lambda: capture_contexts
+        helper._should_share_dynamic_cp_pool = lambda: False
+        helper._get_cuda_graph_input_data = lambda: ([], {})
+        helper._validate_mhc_static_hidden_inputs = lambda sample_args: None
+        helper._set_dynamic_cp_capture_context = lambda context: None
+        helper._finish_capturing = lambda start_time: None
+        helper._publish_dynamic_cp_graph_microbatch_limit = lambda: None
+        helper._abort_capturing = lambda captured_graphs: helper._clear_thd_rotary_seq_lens()
+        helper.flattened_callables = []
+        helper.dp_cp_group = object()
+        helper.config = SimpleNamespace()
+        helper.chunks_with_decoder = []
+        helper.callables_per_chunk = []
+
+        attempts = iter((RuntimeError("capture failed"), 0.0))
+
+        def start_capturing():
+            assert helper.config._cuda_graph_thd_rotary_seq_lens == {2: 4096}
+            result = next(attempts)
+            if isinstance(result, BaseException):
+                raise result
+            return result
+
+        helper._start_capturing = start_capturing
+
+        with pytest.raises(RuntimeError, match="capture failed"):
+            helper.create_cudagraphs()
+        assert helper._capture_finished is False
+        assert not hasattr(helper.config, '_cuda_graph_thd_rotary_seq_lens')
+
+        helper.create_cudagraphs()
+
+        assert helper._capture_finished is True
+        assert helper.config._cuda_graph_thd_rotary_seq_lens == {2: 4096}
+
+    @pytest.mark.internal
+    def test_thd_capture_rope_and_dummy_boundaries_share_sample_limit(self):
+        from megatron.core.transformer.cuda_graphs import TECudaGraphHelper
+
+        helper = TECudaGraphHelper.__new__(TECudaGraphHelper)
+        helper.config = SimpleNamespace(
+            max_seqlen_per_dp_cp_rank=4096,
+            pad_packed_seq_alignment=4096,
+            thd_max_packed_sequences=32,
+        )
+        helper.seq_length = 16384
+        helper.thd_sequence_length_upper_bound = None
+
+        rope_len, boundaries = helper._get_thd_capture_rotary_layout(4)
+        assert rope_len == 16384
+        assert boundaries[:3] == (0, 16384, 16384)
+
+        rope_len, boundaries = helper._get_thd_capture_rotary_layout(8)
+        assert rope_len == 16384
+        assert boundaries[:4] == (0, 16384, 32768, 32768)
+
+        helper.thd_sequence_length_upper_bound = 12288
+        rope_len, boundaries = helper._get_thd_capture_rotary_layout(8)
+        assert rope_len == 12288
+        assert boundaries[:5] == (0, 12288, 24576, 32768, 32768)
+
+        # Do not exceed the token capacity when the configured sample upper bound
+        # is larger than this capture variant can hold.
+        helper.seq_length = 65536
+        helper.thd_sequence_length_upper_bound = None
+        rope_len, boundaries = helper._get_thd_capture_rotary_layout(8)
+        assert rope_len == 32768
+        assert boundaries[:3] == (0, 32768, 32768)
+
+        # Correctness fallback: one boundary slot cannot represent two bounded
+        # sequences, so retain the original full-capacity RoPE table.
+        helper.seq_length = 16384
+        helper.config.thd_max_packed_sequences = 1
+        rope_len, boundaries = helper._get_thd_capture_rotary_layout(8)
+        assert rope_len == 32768
+        assert boundaries == (0, 32768)
+
+    @pytest.mark.internal
+    def test_thd_capture_rope_limits_reach_every_vpp_chunk(self):
+        from megatron.core.transformer.cuda_graphs import TECudaGraphHelper
+
+        helper = TECudaGraphHelper.__new__(TECudaGraphHelper)
+        helper.config = SimpleNamespace()
+        chunk_configs = [SimpleNamespace(), SimpleNamespace()]
+        helper.model = [
+            SimpleNamespace(config=helper.config, module=SimpleNamespace(config=config))
+            for config in chunk_configs
+        ]
+        helper.chunks_with_decoder = [model.module for model in helper.model]
+        rotary_seq_lens = {4: 16384, 8: 16384}
+
+        helper._publish_thd_rotary_seq_lens(rotary_seq_lens)
+
+        for config in (helper.config, *chunk_configs):
+            assert config._cuda_graph_thd_rotary_seq_lens is rotary_seq_lens
+
+        helper._clear_thd_rotary_seq_lens()
+        for config in (helper.config, *chunk_configs):
+            assert not hasattr(config, '_cuda_graph_thd_rotary_seq_lens')
+
+    @pytest.mark.internal
+    @pytest.mark.parametrize("reset_fails", (False, True))
+    def test_delete_graphs_releases_capture_only_state(self, monkeypatch, reset_fails):
+        from megatron.core.transformer import cuda_graphs
+        from megatron.core.transformer.cuda_graphs import TECudaGraphHelper
+
+        class Graph:
+            reset_count = 0
+
+            def reset(self):
+                self.reset_count += 1
+                if reset_fails:
+                    raise RuntimeError("reset failed")
+
+        helper = TECudaGraphHelper.__new__(TECudaGraphHelper)
+        helper._graphs_created = True
+        helper.config = SimpleNamespace(
+            _cuda_graph_num_microbatches=8, _cuda_graph_thd_rotary_seq_lens={2: 4096}
+        )
+        chunk_config = SimpleNamespace(_cuda_graph_thd_rotary_seq_lens={2: 4096})
+        helper.chunks_with_decoder = [SimpleNamespace(config=chunk_config)]
+        layer = torch.nn.Identity()
+        graph = Graph()
+        later_graph = Graph()
+        layer.cuda_graphs = [graph, later_graph]
+        layer.cuda_graphs_by_dynamic_cp_size = {}
+        layer.cuda_graph_manual_hooks = []
+        helper.callables_per_chunk = [[layer]]
+        helper.tp_group = object()
+        helper.dp_cp_group = object()
+        monkeypatch.setattr(cuda_graphs, 'is_te_min_version', lambda version: True)
+        monkeypatch.setattr(cuda_graphs, 'log_on_each_pipeline_stage', lambda **kwargs: None)
+        monkeypatch.setattr(torch.distributed, 'get_rank', lambda: 0)
+
+        if reset_fails:
+            with pytest.raises(RuntimeError, match="reset failed"):
+                helper.delete_cuda_graphs()
+        else:
+            helper.delete_cuda_graphs()
+
+        assert graph.reset_count == 1
+        assert later_graph.reset_count == 1
+        assert helper._graphs_created is False
+        assert layer.cuda_graphs == []
+        assert layer.cuda_graphs_by_dynamic_cp_size == {}
+        assert not hasattr(helper.config, '_cuda_graph_num_microbatches')
+        assert not hasattr(helper.config, '_cuda_graph_thd_rotary_seq_lens')
+        assert not hasattr(chunk_config, '_cuda_graph_thd_rotary_seq_lens')
+
+    @pytest.mark.internal
+    def test_delete_graphs_without_graphable_layers_releases_state(self, monkeypatch):
+        from megatron.core.transformer import cuda_graphs
+        from megatron.core.transformer.cuda_graphs import TECudaGraphHelper
+
+        helper = TECudaGraphHelper.__new__(TECudaGraphHelper)
+        helper._graphs_created = False
+        helper.config = SimpleNamespace(
+            _cuda_graph_num_microbatches=8, _cuda_graph_thd_rotary_seq_lens={2: 4096}
+        )
+        helper.chunks_with_decoder = []
+        helper.callables_per_chunk = []
+        helper.tp_group = object()
+        helper.dp_cp_group = object()
+        monkeypatch.setattr(cuda_graphs, 'is_te_min_version', lambda version: True)
+        monkeypatch.setattr(cuda_graphs, 'log_on_each_pipeline_stage', lambda **kwargs: None)
+        monkeypatch.setattr(torch.distributed, 'get_rank', lambda: 0)
+
+        helper.delete_cuda_graphs()
+
+        assert not hasattr(helper.config, '_cuda_graph_num_microbatches')
+        assert not hasattr(helper.config, '_cuda_graph_thd_rotary_seq_lens')
+
+    @pytest.mark.internal
+    def test_delete_graphs_preserves_first_error_and_runs_remaining_cleanup(self, monkeypatch):
+        from megatron.core.transformer import cuda_graphs
+        from megatron.core.transformer.cuda_graphs import TECudaGraphHelper
+
+        class Graph:
+            def reset(self):
+                raise RuntimeError("reset failed")
+
+        helper = TECudaGraphHelper.__new__(TECudaGraphHelper)
+        helper._graphs_created = True
+        helper.config = SimpleNamespace(_cuda_graph_num_microbatches=8)
+        helper.chunks_with_decoder = []
+        layer = torch.nn.Identity()
+        layer.cuda_graphs = [Graph()]
+        layer.cuda_graphs_by_dynamic_cp_size = {}
+        layer.cuda_graph_manual_hooks = []
+        helper.callables_per_chunk = [[layer]]
+        helper.tp_group = object()
+        helper.dp_cp_group = object()
+        cleanup_calls = []
+
+        def fail_rope_cleanup():
+            cleanup_calls.append("rope")
+            raise RuntimeError("rope cleanup failed")
+
+        helper._clear_thd_rotary_seq_lens = fail_rope_cleanup
+        monkeypatch.setattr(cuda_graphs, 'is_te_min_version', lambda version: True)
+        monkeypatch.setattr(cuda_graphs, 'log_on_each_pipeline_stage', lambda **kwargs: None)
+        monkeypatch.setattr(torch.distributed, 'get_rank', lambda: 0)
+
+        with pytest.raises(RuntimeError, match="reset failed"):
+            helper.delete_cuda_graphs()
+
+        assert cleanup_calls == ["rope"]
+        assert not hasattr(helper.config, '_cuda_graph_num_microbatches')
+        assert layer.cuda_graphs == []
+
+    @pytest.mark.internal
+    def test_thd_graph_runtime_rope_uses_capture_sample_limit(self):
+        from megatron.core.models.gpt.gpt_model import GPTModel
+
+        model = GPTModel.__new__(GPTModel)
+        object.__setattr__(
+            model,
+            'config',
+            SimpleNamespace(
+                context_parallel_size=4, _cuda_graph_thd_rotary_seq_lens={4: 16384, 8: 16384}
+            ),
+        )
+
+        assert (
+            model._bound_thd_rotary_seq_len(
+                32768, SimpleNamespace(qkv_format='thd', local_cp_size=8)
+            )
+            == 16384
+        )
+        assert (
+            model._bound_thd_rotary_seq_len(
+                32768, SimpleNamespace(qkv_format='thd', local_cp_size=None)
+            )
+            == 16384
+        )
+        assert (
+            model._bound_thd_rotary_seq_len(
+                32768, SimpleNamespace(qkv_format='sbhd', local_cp_size=8)
+            )
+            == 32768
+        )
+        assert model._bound_thd_rotary_seq_len(32768, None) == 32768
+
+    @pytest.mark.internal
+    def test_thd_capture_dummy_boundaries_are_seeded_in_place(self):
+        from megatron.core.transformer.cuda_graphs import TECudaGraphHelper
+
+        original = torch.zeros(5, dtype=torch.int32)
+        static_inputs = {
+            name: original.clone()
+            for name in (
+                "cu_seqlens_q",
+                "cu_seqlens_kv",
+                "cu_seqlens_q_padded",
+                "cu_seqlens_kv_padded",
+            )
+        }
+        boundaries = (0, 16384, 32768, 32768, 32768)
+
+        TECudaGraphHelper._seed_thd_capture_cu_seqlens(static_inputs, boundaries)
+
+        for value in static_inputs.values():
+            assert value.tolist() == list(boundaries)
+
+        with pytest.raises(RuntimeError, match="has 4 entries, but 5 boundaries"):
+            TECudaGraphHelper._seed_thd_capture_cu_seqlens(
+                {"cu_seqlens_q": torch.zeros(4, dtype=torch.int32)}, boundaries
+            )
+
+    @pytest.mark.internal
+    def test_mla_rope_tensor_follows_te_graph_lifetime(self, monkeypatch):
+        from megatron.core.transformer import cuda_graphs
+        from megatron.core.transformer.cuda_graphs import TECudaGraphHelper
+        from megatron.core.transformer.multi_latent_attention import MLASelfAttention
+
+        mla = MLASelfAttention.__new__(MLASelfAttention)
+        torch.nn.Module.__init__(mla)
+        mla.config = SimpleNamespace(cuda_graph_impl='transformer_engine')
+        monkeypatch.setattr(cuda_graphs, 'is_graph_capturing', lambda: True)
+
+        tensor = torch.ones(1)
+        tensor_ref = weakref.ref(tensor)
+        mla._retain_cuda_graph_rope_tensors(tensor)
+        del tensor
+        assert tensor_ref() is not None
+
+        TECudaGraphHelper._clear_cuda_graph_state(mla)
+        assert tensor_ref() is None
+
+    @pytest.mark.internal
     def test_pp2_slots_track_max_outstanding_microbatches(self):
         from megatron.core.transformer.cuda_graphs import TECudaGraphHelper
 
@@ -1046,6 +1485,18 @@ class TestDynamicMicrobatchSlots:
             )
             == 32
         )
+        assert (
+            TECudaGraphHelper._get_dp_balanced_thd_max_num_microbatches(
+                global_batch_size=2,
+                dp_size=1,
+                cp_size=1,
+                max_seqlen_per_dp_cp_rank=4096,
+                max_sequence_length=4096,
+                max_num_seqs=8,
+                max_subsamples_per_item=4,
+            )
+            == 8
+        )
 
     @pytest.mark.internal
     def test_dp_balanced_thd_capture_upper_bound_aligns_vpp_groups(self):
@@ -1063,6 +1514,389 @@ class TestDynamicMicrobatchSlots:
             )
             == 16
         )
+
+    @pytest.mark.internal
+    def test_dynamic_cp_capture_upper_bound_uses_scheduler_rank_fill(self):
+        from megatron.core.transformer.cuda_graphs import TECudaGraphHelper
+
+        get_bound = TECudaGraphHelper._get_default_dynamic_cp_thd_max_num_microbatches
+
+        assert get_bound(64, 8, 8192, 8192, microbatch_group_size_per_vp_stage=4) == 8
+        assert get_bound(64, 8, 8192, 16384, microbatch_group_size_per_vp_stage=4) == 16
+        assert get_bound(64, 8, 8192, 65536, microbatch_group_size_per_vp_stage=4) == 64
+        assert (
+            get_bound(
+                64, 8, 8192, 8192, max_subsamples_per_item=2, microbatch_group_size_per_vp_stage=4
+            )
+            == 16
+        )
+        assert get_bound(9, 8, 8192, 8192, microbatch_group_size_per_vp_stage=8) == 8
+
+    @pytest.mark.internal
+    def test_dynamic_cp_capture_upper_bound_covers_scheduler_outputs(self):
+        from megatron.core.datasets.data_schedule_utils import (
+            align_sample_id_groups,
+            next_hdp_group_packing_aware,
+        )
+        from megatron.core.transformer.cuda_graphs import TECudaGraphHelper
+
+        length_sets = (
+            [8192] * 64,
+            [128] * 64,
+            [8192 if index % 2 else 128 for index in range(64)],
+            [128 + (index * 7919) % 8065 for index in range(64)],
+            list(range(128, 8193, 128)),
+        )
+        bound = TECudaGraphHelper._get_default_dynamic_cp_thd_max_num_microbatches(
+            64, 8, 8192, 8192, microbatch_group_size_per_vp_stage=4
+        )
+
+        for lengths in length_sets:
+            remaining = list(enumerate(lengths))
+            groups = []
+            while remaining:
+                _, remaining, _, sample_ids = next_hdp_group_packing_aware(
+                    remaining,
+                    total_gpus=8,
+                    max_seq_len_per_rank=8192,
+                    min_cp_size=1,
+                    max_num_seqs=31,
+                )
+                groups.append(sample_ids)
+            aligned_groups = align_sample_id_groups(groups, 4)
+            assert len(aligned_groups) <= bound
+
+    @pytest.mark.internal
+    def test_dynamic_slot_liveness_only_includes_vpp_aligned_counts(self):
+        from megatron.core.transformer.cuda_graphs import TECudaGraphHelper
+
+        get_counts = TECudaGraphHelper._get_dynamic_slot_liveness_microbatch_counts
+
+        assert get_counts(4) == (1, 2, 3, 4)
+        assert get_counts(8, 4) == (4, 8)
+        assert get_counts(16, 8) == (8, 16)
+        with pytest.raises(ValueError, match="not aligned"):
+            get_counts(10, 4)
+
+    @pytest.mark.internal
+    def test_pp4_vpp4_liveness_union_matches_fixed_cp4_schedule(self, monkeypatch):
+        from megatron.core import parallel_state
+        from megatron.core.pipeline_parallel.schedules import (
+            get_pp_rank_microbatches,
+            get_schedule_table,
+        )
+        from megatron.core.transformer.cuda_graphs import (
+            TECudaGraphHelper,
+            convert_schedule_table_to_order,
+        )
+
+        monkeypatch.setattr(parallel_state, "get_pipeline_model_parallel_world_size", lambda: 4)
+        monkeypatch.setattr(
+            parallel_state, "get_virtual_pipeline_model_parallel_world_size", lambda: 4
+        )
+
+        expected_color_counts = (60, 60, 48, 48)
+        for pp_rank, expected_colors in enumerate(expected_color_counts):
+            monkeypatch.setattr(
+                parallel_state, "get_pipeline_model_parallel_rank", lambda rank=pp_rank: rank
+            )
+            conflicts_by_count = {}
+            colors_by_count = {}
+            for num_microbatches in range(4, 65, 4):
+                _, _, warmup, _ = get_pp_rank_microbatches(
+                    num_microbatches, 4, 4, forward_only=False
+                )
+                order = convert_schedule_table_to_order(
+                    warmup, 4, get_schedule_table(num_microbatches, 4, 4)
+                )
+                colors, conflicts = TECudaGraphHelper._build_saved_tensor_liveness_colors(
+                    order, 8, [3, 3, 3, 3], return_conflicts=True
+                )
+                colors_by_count[num_microbatches] = colors
+                conflicts_by_count[num_microbatches] = conflicts
+
+            union_conflicts = {
+                frame: set().union(*(conflicts[frame] for conflicts in conflicts_by_count.values()))
+                for frame in conflicts_by_count[4]
+            }
+            for num_microbatches in range(12, 65, 4):
+                assert conflicts_by_count[num_microbatches] == union_conflicts
+            assert conflicts_by_count[32] == union_conflicts
+            assert len(set(colors_by_count[32].values())) == expected_colors
+
+    @pytest.mark.internal
+    def test_dynamic_cp_variant_order_runs_one_schedule_per_variant(self):
+        from megatron.core.transformer.cuda_graphs import TECudaGraphHelper
+
+        order = [1, 2, 1, 2, -1, -2, -1, -2]
+        combined = TECudaGraphHelper._build_slot_aliased_variant_order(
+            order, 2, 2, canonical_variant=0
+        )
+
+        assert combined == [1, 2, 1, 2, -1, -2, -1, -2, 3, 4, 3, 4, -3, -4, -3, -4]
+
+    @pytest.mark.internal
+    def test_slot_memory_colors_follow_pp_vpp_liveness(self):
+        from megatron.core.transformer.cuda_graphs import TECudaGraphHelper
+
+        sequential = TECudaGraphHelper._build_saved_tensor_liveness_colors(
+            [1, 1, -1, -1, 2, 2, -2, -2], 2, [1, 1]
+        )
+        overlapping = TECudaGraphHelper._build_saved_tensor_liveness_colors(
+            [1, 1, 2, 2, -2, -2, -1, -1], 2, [1, 1]
+        )
+
+        assert sequential[(0, 0, 0)] != sequential[(0, 1, 0)]
+        assert overlapping[(0, 0, 0)] != overlapping[(0, 1, 0)]
+        assert len(set(overlapping.values())) > len(set(sequential.values()))
+        with pytest.raises(RuntimeError, match="slot period is shorter"):
+            TECudaGraphHelper._build_saved_tensor_liveness_colors([1, 1, -1, -1], 1, [1])
+
+    @pytest.mark.internal
+    def test_user_grad_colors_separate_adjacent_vpp_chunks(self):
+        """An overlapped PP send must survive the next chunk's backward graph."""
+        from megatron.core.transformer.cuda_graphs import TECudaGraphHelper
+
+        colors = TECudaGraphHelper._build_user_grad_liveness_colors(
+            [1, 2, -2, -1], num_slots=1, num_model_chunks=2
+        )
+
+        assert colors[(0, 0)] != colors[(1, 0)]
+        assert len(set(colors.values())) == 2
+
+    @pytest.mark.internal
+    def test_dynamic_cp_variants_emit_one_compact_slot_plan(self):
+        from megatron.core.transformer.cuda_graphs import TECudaGraphHelper
+
+        helper = TECudaGraphHelper.__new__(TECudaGraphHelper)
+        helper.num_microbatches = 2
+        helper.num_model_chunks = 1
+        helper.num_layers_per_chunk = [1]
+        helper.flattened_callables = [torch.nn.Identity()]
+        helper._set_dynamic_cp_capture_context = lambda context: None
+        order = [1, 1, -1, 1, -1, 1, -1, -1]
+
+        def make_bank(cp_size, offset):
+            return (
+                cp_size,
+                object(),
+                [(offset + index,) for index in range(2)],
+                {
+                    '_order': order,
+                    '_num_layers_per_chunk': [1],
+                    '_reuse_graph_input_output_buffers': True,
+                },
+            )
+
+        banks = [make_bank(2, 0), make_bank(1, 10)]
+        callables, sample_args, kwargs = helper._get_dynamic_cp_variant_capture_data(banks)
+        colors = TECudaGraphHelper._build_saved_tensor_liveness_colors(order, 2, [1])
+        grad_colors = TECudaGraphHelper._build_user_grad_liveness_colors(order, 2, 1)
+        expected_slots = tuple(
+            (
+                colors[(0, logical_slot % 2, 0)],
+                logical_slot,
+                variant * 2 + logical_slot,
+                0,
+                0,
+                variant,
+                grad_colors[(0, logical_slot % 2)],
+            )
+            for variant in range(2)
+            for logical_slot in range(2)
+        )
+
+        assert len(callables) == 2
+        assert sample_args == tuple((index,) for index in range(2)) + tuple(
+            (10 + index,) for index in range(2)
+        )
+        assert kwargs['_graph_memory_slots'] == expected_slots
+        assert kwargs['_num_layers_per_chunk'] == [1, 1]
+        assert not any(
+            key in kwargs
+            for key in (
+                '_saved_tensor_memory_alias_groups',
+                '_slot_io_memory_alias_groups',
+                '_slot_io_liveness_groups',
+                '_warmup_plan_alias_groups',
+            )
+        )
+
+    @pytest.mark.internal
+    def test_dynamic_cp_slot_plan_covers_unaligned_capture_order(self):
+        """A synthetic W-slot capture order must participate in liveness coloring."""
+        from megatron.core.pipeline_parallel.schedules import get_schedule_table
+        from megatron.core.transformer.cuda_graphs import (
+            TECudaGraphHelper,
+            convert_schedule_table_to_order,
+        )
+
+        def get_order(num_microbatches):
+            # PP2 rank 0, VPP2, group size 4 has six warmup virtual microbatches.
+            return tuple(
+                convert_schedule_table_to_order(6, 2, get_schedule_table(num_microbatches, 2, 4))
+            )
+
+        helper = TECudaGraphHelper.__new__(TECudaGraphHelper)
+        helper.num_microbatches = 7
+        helper.num_model_chunks = 2
+        helper.num_layers_per_chunk = [1, 1]
+        helper.flattened_callables = [torch.nn.Identity(), torch.nn.Identity()]
+        helper._set_dynamic_cp_capture_context = lambda context: None
+        helper._dynamic_slot_liveness_orders = (get_order(4), get_order(8))
+        base_order = get_order(7)
+        bank = (
+            1,
+            object(),
+            [(index,) for index in range(14)],
+            {
+                '_order': base_order,
+                '_num_layers_per_chunk': [1, 1],
+                '_reuse_graph_input_output_buffers': True,
+            },
+        )
+
+        _, _, kwargs = helper._get_dynamic_cp_variant_capture_data([bank])
+        saved_arenas = {
+            (model_chunk, physical_slot): saved_arena
+            for (saved_arena, physical_slot, _, model_chunk, _, _, _) in kwargs[
+                '_graph_memory_slots'
+            ]
+        }
+
+        # These frames overlap only in the synthetic M=W=7 capture schedule, not in
+        # either scheduler-reachable M=4/8 schedule.
+        assert saved_arenas[(0, 2)] != saved_arenas[(1, 5)]
+        assert saved_arenas[(0, 3)] != saved_arenas[(1, 6)]
+
+    @pytest.mark.internal
+    def test_dynamic_cp_capture_propagates_te_rebound_static_inputs(self, monkeypatch):
+        from megatron.core.transformer import cuda_graphs
+        from megatron.core.transformer.cuda_graphs import TECudaGraphHelper
+
+        helper = TECudaGraphHelper.__new__(TECudaGraphHelper)
+        helper.num_microbatches = 2
+        helper.num_model_chunks = 1
+        helper.num_layers_per_chunk = [1]
+        helper.flattened_callables = [torch.nn.Identity()]
+        helper._set_dynamic_cp_capture_context = lambda context: None
+        order = [1, 1, -1, 1, -1, 1, -1, -1]
+        banks = [
+            (
+                cp_size,
+                object(),
+                [(cp_size, slot) for slot in range(2)],
+                {
+                    '_order': order,
+                    '_num_layers_per_chunk': [1],
+                    '_reuse_graph_input_output_buffers': True,
+                },
+            )
+            for cp_size in (2, 1)
+        ]
+        rebound_inputs = ((object(),), (object(),))
+
+        def capture_graph_bank(_callables, sample_args, _kwargs):
+            assert isinstance(sample_args, list)
+            sample_args[1] = rebound_inputs[0]
+            sample_args[3] = rebound_inputs[1]
+            return [object() for _ in sample_args]
+
+        helper._capture_graph_bank = capture_graph_bank
+        monkeypatch.setattr(cuda_graphs, 'log_on_each_pipeline_stage', lambda **kwargs: None)
+        monkeypatch.setattr(torch.distributed, 'get_rank', lambda: 0)
+
+        captured_graphs = {}
+        helper._capture_dynamic_cp_variants(banks, captured_graphs)
+
+        assert banks[0][2][1] is rebound_inputs[0]
+        assert banks[1][2][1] is rebound_inputs[1]
+        assert len(captured_graphs[2]) == 2
+        assert len(captured_graphs[1]) == 2
+
+    @pytest.mark.internal
+    def test_shared_slots_publish_logical_not_physical_microbatch_limit(self):
+        from megatron.core.transformer.cuda_graphs import TECudaGraphHelper
+
+        helper = TECudaGraphHelper.__new__(TECudaGraphHelper)
+        helper.config = SimpleNamespace(
+            dynamic_context_parallel=True,
+            cuda_graph_dynamic_microbatches=True,
+            _cuda_graph_num_microbatches=32,
+        )
+        helper.pp_group = SimpleNamespace(size=lambda: 8)
+        helper.num_microbatches = 16
+        helper._dynamic_slot_liveness_limit = 64
+
+        helper._publish_dynamic_cp_graph_microbatch_limit()
+        assert helper.config._cuda_graph_num_microbatches == 64
+
+        helper._dynamic_slot_liveness_limit = None
+        helper.num_microbatches = 32
+        helper._publish_dynamic_cp_graph_microbatch_limit()
+        assert helper.config._cuda_graph_num_microbatches == 32
+
+    @pytest.mark.internal
+    @pytest.mark.parametrize(
+        "fallback", ("overlap_moe_expert_parallel_comm", "delay_wgrad_compute")
+    )
+    def test_shared_slots_fall_back_for_unsupported_graph_orders(self, fallback):
+        from megatron.core.transformer.cuda_graphs import TECudaGraphHelper
+
+        helper = TECudaGraphHelper.__new__(TECudaGraphHelper)
+        helper.config = SimpleNamespace(
+            dynamic_context_parallel=True,
+            cuda_graph_dynamic_microbatches=True,
+            overlap_moe_expert_parallel_comm=False,
+            delay_wgrad_compute=False,
+        )
+        setattr(helper.config, fallback, True)
+
+        assert not helper._should_share_dynamic_cp_pool()
+
+    @pytest.mark.internal
+    def test_pp8_vpp4_uses_sixteen_noncolliding_slots(self):
+        from megatron.core.pipeline_parallel.schedules import get_schedule_table
+        from megatron.core.transformer.cuda_graphs import (
+            TECudaGraphHelper,
+            convert_schedule_table_to_order,
+        )
+
+        pp_size = 8
+        num_model_chunks = 4
+        microbatch_group_size = 8
+        num_microbatches = pp_size * num_model_chunks * 4
+        schedule_table = get_schedule_table(
+            num_microbatches, num_model_chunks, microbatch_group_size
+        )
+        forward_ops = list(schedule_table)
+        backward_ops = [
+            (microbatch, num_model_chunks - chunk - 1) for microbatch, chunk in schedule_table
+        ]
+
+        for pp_rank in range(pp_size):
+            num_warmup = (pp_size - pp_rank - 1) * 2
+            num_warmup += (num_model_chunks - 1) * microbatch_group_size
+            order = convert_schedule_table_to_order(num_warmup, num_model_chunks, schedule_table)
+            num_slots = TECudaGraphHelper._get_required_num_microbatch_slots_from_order(
+                order, num_model_chunks
+            )
+            assert num_slots == 16
+
+            events = [('forward', *op) for op in forward_ops[:num_warmup]]
+            for index in range(num_warmup, len(forward_ops)):
+                events.append(('forward', *forward_ops[index]))
+                events.append(('backward', *backward_ops[index - num_warmup]))
+            events.extend(('backward', *op) for op in backward_ops[-num_warmup:])
+            live_slots = [dict() for _ in range(num_model_chunks)]
+            for phase, microbatch, chunk in events:
+                slot = microbatch % num_slots
+                if phase == 'forward':
+                    assert slot not in live_slots[chunk]
+                    live_slots[chunk][slot] = microbatch
+                else:
+                    assert live_slots[chunk].pop(slot) == microbatch
+            assert all(not slots for slots in live_slots)
 
 
 # =============================================================================

--- a/tests/unit_tests/transformer/test_transformer_layer.py
+++ b/tests/unit_tests/transformer/test_transformer_layer.py
@@ -883,6 +883,21 @@ class TestMHCWithCudaGraph:
             f"HyperConnectionTransformerLayer must override get_layer_static_inputs."
         )
 
+    def test_mhc_post_mlp_tolerates_cleared_norm_manager(self, monkeypatch):
+        """Partial graph replay does not retain a no-op capture manager."""
+        layer, _ = self._create_mhc_layer()
+        hidden_states = torch.randn((4, 1, 64), device="cuda", requires_grad=True)
+        monkeypatch.setattr(
+            layer, "_forward_mhc_mlp_post_core", lambda *_args, **_kwargs: hidden_states
+        )
+
+        layer.mlp_norm_manager = None
+        output = layer._forward_post_mlp_with_fused_hyper_connection(
+            (hidden_states, None), hidden_states, hidden_states, hidden_states
+        )
+
+        assert torch.equal(output, hidden_states)
+
     def test_mhc_recompute_attention_graph_starts_from_one_stream_aggregate(self):
         """The split attention graph input is the eager mHC aggregate [s, b, C]."""
         layer, config = self._create_mhc_layer(

--- a/tests/unit_tests/transformer/test_transformer_layer.py
+++ b/tests/unit_tests/transformer/test_transformer_layer.py
@@ -1060,7 +1060,7 @@ class TestMHCWithCudaGraph:
                 (torch.empty(2, device="cuda"),), dynamic_cp_size=2
             )
 
-    def test_te_graph_static_hidden_inputs_follow_dynamic_cp_graph_bank(self, monkeypatch):
+    def test_te_graph_static_hidden_inputs_follow_dynamic_cp_graph_bank(self):
         """DCP replay must switch the graph and mHC direct-write input as one bank."""
         layer, _ = self._create_mhc_layer(cuda_graph_impl="transformer_engine")
         graph_banks = {1: [object(), object()], 2: [object(), object()]}
@@ -1070,17 +1070,13 @@ class TestMHCWithCudaGraph:
         }
         cp_groups = {1: object(), 2: object()}
         layer.cuda_graphs_by_dynamic_cp_size = graph_banks
+        layer.cuda_graph_cp_groups_by_dynamic_cp_size = cp_groups
         for cp_size in (1, 2):
             layer.cuda_graphs = graph_banks[cp_size]
             layer.set_te_cuda_graph_static_hidden_inputs(
                 input_banks[cp_size], dynamic_cp_size=cp_size
             )
 
-        monkeypatch.setattr(
-            parallel_state,
-            "get_dynamic_data_context_parallel_groups",
-            lambda group_size: cp_groups[group_size],
-        )
         layer.current_microbatch = 1
         for cp_size in (1, 2, 1):
             layer._activate_dynamic_cp_cuda_graph(
@@ -1093,17 +1089,13 @@ class TestMHCWithCudaGraph:
         assert not layer._te_cuda_graph_static_hidden_inputs_by_dynamic_cp_size
         assert not layer._te_cuda_graph_static_hidden_input_ptrs_by_dynamic_cp_size
 
-    def test_dynamic_cp_graph_bank_rejects_invalid_runtime_metadata(self, monkeypatch):
+    def test_dynamic_cp_graph_bank_rejects_invalid_runtime_metadata(self):
         """Runtime graph selection must keep its guards under optimized Python."""
         expected_group = object()
         layer = SimpleNamespace(
             cuda_graphs_by_dynamic_cp_size={2: [object()]},
+            cuda_graph_cp_groups_by_dynamic_cp_size={2: expected_group},
             activate_te_cuda_graph_static_hidden_inputs=lambda _cp_size: None,
-        )
-        monkeypatch.setattr(
-            parallel_state,
-            "get_dynamic_data_context_parallel_groups",
-            lambda group_size: expected_group,
         )
 
         for params in (None, SimpleNamespace(local_cp_size=None, cp_group=expected_group)):

--- a/tests/unit_tests/transformer/test_transformer_layer.py
+++ b/tests/unit_tests/transformer/test_transformer_layer.py
@@ -2,6 +2,7 @@
 
 
 import gc
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -1008,7 +1009,7 @@ class TestMHCWithCudaGraph:
 
     def test_te_graph_static_hidden_input_tracks_runtime_microbatch_slot(self):
         """Static-input handles use the same modulo slot selection as TE graphs."""
-        layer, _ = self._create_mhc_layer()
+        layer, _ = self._create_mhc_layer(cuda_graph_impl="transformer_engine")
         layer.cuda_graphs = [object(), object()]
         slot_inputs = (
             torch.empty((4, 1, 64), device="cuda"),
@@ -1024,7 +1025,7 @@ class TestMHCWithCudaGraph:
 
     def test_te_graph_static_hidden_input_rejects_address_drift(self):
         """A retained static-input handle whose storage moved must refuse to serve."""
-        layer, _ = self._create_mhc_layer()
+        layer, _ = self._create_mhc_layer(cuda_graph_impl="transformer_engine")
         layer.cuda_graphs = [object()]
         slot = torch.empty((4, 1, 64), device="cuda")
         layer.set_te_cuda_graph_static_hidden_inputs((slot,))
@@ -1033,12 +1034,76 @@ class TestMHCWithCudaGraph:
             layer.get_te_cuda_graph_static_hidden_input()
 
     def test_set_te_cuda_graph_static_hidden_inputs_validates_inputs(self):
-        layer, _ = self._create_mhc_layer()
+        layer, _ = self._create_mhc_layer(cuda_graph_impl="transformer_engine")
         layer.cuda_graphs = [object(), object()]
         with pytest.raises(ValueError, match="match graph count"):
             layer.set_te_cuda_graph_static_hidden_inputs((torch.empty(2, device="cuda"),))
         with pytest.raises(TypeError, match="CUDA tensors"):
             layer.set_te_cuda_graph_static_hidden_inputs((torch.empty(2), torch.empty(2)))
+        with pytest.raises(ValueError, match="unknown dynamic CP size"):
+            layer.set_te_cuda_graph_static_hidden_inputs(
+                (torch.empty(2, device="cuda"),), dynamic_cp_size=2
+            )
+
+    def test_te_graph_static_hidden_inputs_follow_dynamic_cp_graph_bank(self, monkeypatch):
+        """DCP replay must switch the graph and mHC direct-write input as one bank."""
+        layer, _ = self._create_mhc_layer(cuda_graph_impl="transformer_engine")
+        graph_banks = {1: [object(), object()], 2: [object(), object()]}
+        input_banks = {
+            1: (torch.empty((8, 1, 64), device="cuda"), torch.empty((8, 1, 64), device="cuda")),
+            2: (torch.empty((4, 1, 64), device="cuda"), torch.empty((4, 1, 64), device="cuda")),
+        }
+        cp_groups = {1: object(), 2: object()}
+        layer.cuda_graphs_by_dynamic_cp_size = graph_banks
+        for cp_size in (1, 2):
+            layer.cuda_graphs = graph_banks[cp_size]
+            layer.set_te_cuda_graph_static_hidden_inputs(
+                input_banks[cp_size], dynamic_cp_size=cp_size
+            )
+
+        monkeypatch.setattr(
+            parallel_state,
+            "get_dynamic_data_context_parallel_groups",
+            lambda group_size: cp_groups[group_size],
+        )
+        layer.current_microbatch = 1
+        for cp_size in (1, 2, 1):
+            layer._activate_dynamic_cp_cuda_graph(
+                SimpleNamespace(local_cp_size=cp_size, cp_group=cp_groups[cp_size])
+            )
+            assert layer.cuda_graphs is graph_banks[cp_size]
+            assert layer.get_te_cuda_graph_static_hidden_input() is input_banks[cp_size][1]
+
+        layer.clear_te_cuda_graph_static_hidden_inputs()
+        assert not layer._te_cuda_graph_static_hidden_inputs_by_dynamic_cp_size
+        assert not layer._te_cuda_graph_static_hidden_input_ptrs_by_dynamic_cp_size
+
+    def test_dynamic_cp_graph_bank_rejects_invalid_runtime_metadata(self, monkeypatch):
+        """Runtime graph selection must keep its guards under optimized Python."""
+        expected_group = object()
+        layer = SimpleNamespace(
+            cuda_graphs_by_dynamic_cp_size={2: [object()]},
+            activate_te_cuda_graph_static_hidden_inputs=lambda _cp_size: None,
+        )
+        monkeypatch.setattr(
+            parallel_state,
+            "get_dynamic_data_context_parallel_groups",
+            lambda group_size: expected_group,
+        )
+
+        for params in (None, SimpleNamespace(local_cp_size=None, cp_group=expected_group)):
+            with pytest.raises(RuntimeError, match="requires packed sequence metadata"):
+                TransformerLayer._activate_dynamic_cp_cuda_graph(layer, params)
+
+        with pytest.raises(RuntimeError, match="No layer CUDA graph bank entry"):
+            TransformerLayer._activate_dynamic_cp_cuda_graph(
+                layer, SimpleNamespace(local_cp_size=4, cp_group=expected_group)
+            )
+
+        with pytest.raises(RuntimeError, match="process group that does not match"):
+            TransformerLayer._activate_dynamic_cp_cuda_graph(
+                layer, SimpleNamespace(local_cp_size=2, cp_group=object())
+            )
 
     def _create_split_layer(self):
         layer, config = self._create_mhc_layer(


### PR DESCRIPTION
## Summary

- capture one CUDA Graph executable bank for every supported runtime CP size
- use the real `torch.distributed.ProcessGroup` for that CP size during capture and replay
- derive a bounded physical-slot ring from the reachable PP/VPP schedules
- union saved-tensor and returned-gradient lifetimes across every supported schedule and CP branch
- pass a seven-field slot/liveness plan to Transformer Engine so mutually exclusive CP branches use the same physical arena range in one memory pool

Runtime selects the graph bank with `packed_seq_params.local_cp_size` and requires the runtime CP group to be the identical object used for capture. Different CP sizes still have different graph executables; their liveness-owned tensor storage is shared by maximum required size rather than summed.

## Communication boundary

Model communication uses native CP process groups. This PR does not intercept NCCL calls and does not route CP collectives through a larger parent communicator. Dataset scheduling uses the public eager `all_gather_into_tensor` path in both graph and eager DCP runs.

## Memory comparison

The required benchmark has three arms:

1. native fixed-CP + CUDA Graph
2. real multi-CP DCP + CUDA Graph
3. the same real multi-CP DCP schedule in eager mode

On source-pinned heads, an 8xH100 Qwen3-30B proxy with TP1/PP4/VPP4/EP2, CP1/2, 50 training steps, and same-iteration physical-slot wrap measured:

| Arm | Whole-device peak |
| --- | ---: |
| fixed CP2 + CG | 75037.062 MiB |
| multi-CP DCP + CG | 76105.062 MiB |
| same-schedule eager DCP | 74251.062 MiB |

- DCP+CG minus fixed-CP2+CG: `+1068 MiB / +1.423297%`
- DCP+CG minus eager DCP: `+1854 MiB / +2.496934%`
- graph/eager DCP loss matched exactly on all 50 steps; maximum grad-norm difference was `0.017929%`
- sample fingerprints and complete scheduler probe streams matched exactly

On a source-pinned full 94-layer Qwen3-235B run with 128 H100 GPUs,
TP4/PP8/VPP6/EP4/ETP4, and real CP1/2/4 groups, the three whole-device peaks were
67497.062 MiB (fixed CP4+CG), 69667.062 MiB (multi-CP DCP+CG), and 66023.062 MiB
(same-schedule eager DCP). The requested deltas are `+2170 MiB / +3.214955%` and
`+3644 MiB / +5.519284%`, respectively. Graph/eager DCP loss and grad norm matched exactly on
all four steps, and their complete scheduler streams matched exactly.

**New numerical blocker:** current-head 50-update job `18201122` (same full 235B recipe,
lr=3.9e-6/min=3.9e-7) completed native fixed CP4+CG and CP1/2/4 DCP+CG, with matching
initial parameter/buffer aggregate hashes on all 128 ranks. Maximum LM loss difference
is `0.695065 / 10.518505%` at step 37, so 50-step fixed/DCP numerical acceptance fails.
Eager DCP also completed 50 steps and matches DCP+CG logged loss and grad norm exactly.
All three arms have 106832 matching initial parameter/buffer records and 384 passing
rank/case RNG checks. Native fixed-CP4 graph/eager 50+50-step control `18202602`
also completed with identical logged loss and grad norm; its native-CG repeat matches
the main run on all50 steps. Thus the observed discrepancy is across fixed/multi-CP paths,
not CG enablement within either tested path. Pure-eager optimizer-gradient diagnostic
`18206344` completed: first-backward sampled reduced gradients differ at equal initial
weights (sampled relative L2 1.459418%). Pre-PR control `18210545` also completed50 updates
per eager arm, with MCore917e8e940 and TE366798ef Python sources and the same compiled
TE binary. Both50-step logged trajectories, all214176 initial audit records and all
gradient/master-parameter samples on steps1/2/3 exactly match the corresponding current-head
arm. Thus this fixed/DCP split reproduces with both runtime patches absent. This is not
full-gradient equality or a resolved operator/kernel cause. Runtime code is unchanged. The four-step result
above must not be extrapolated to optimizer-update parity.

The new 50-step sampled peaks are 69283.0625MiB native fixed+CG, 71533.0625MiB DCP+CG,
and 67825.0625MiB eager DCP: +2250MiB/3.247547% and +3708MiB/5.467006%, respectively.
Fixed/DCP trajectories diverged, so their difference is not a same-weight pure-CP attribution.
Steps3..50 graph/eager times average2206.3375/2593.6479ms (+17.554% sample throughput).
Raw SHA256: `e75d95a1c8d6d45050017a72d7d424eb79f729a43662c2ebc6c848e3b02b591c`.

The native fixed-CP4 control measured graph69301.0625MiB versus eager66649.0625MiB,
+2652MiB/3.979051% in its own allocation; do not use cross-job subtraction as a matched-device
delta. RawSHA256: `ac0c3e3d2d96daaa45e9bef36e11c6ec3169c036d24a75d9a04be92670dd4ad4`.

The current-head full 43-layer DeepSeek-V4-Flash 284B recipe used 128 GB200 GPUs,
TP1/PP16/VPP2/EP8/ETP1, real CP1/2/4/8 groups, 48 runtime microbatches, and 32 physical
slots. Current same-allocation, same-node, sequential pair evidence is:

**Initialization caveat:** an additional full-model initialization-only audit found 848
different parameter hashes out of 33,064 records per fixed/DCP arm before optimizer or
training (DSv4 output group projections and compressor APEs). The fixed/DCP measurements
below are retained as observations, not an initialization-controlled pure CP overhead.
Full-model control `7023789` confirmed the initialization cause: isolating JIT warmup RNG
side effects reduced the differing parameters to zero, with 33,064 matching records per
arm and 256 passing rank/case RNG checks. Controlled job `7024429` completed all three
50-step arms in 03:25:21, exit 0:0, zero skipped/NaN iterations. All 33064 initial
parameter records per arm and 384 rank/case RNG checks match. It uses RNG isolation,
the existing `extend_last` policy, native precision and lr=0.
Sampled device peaks are native fixedCP8+CG 107464.5625, DCP+CG 110780.5625, eager DCP
105950.5625 MiB: **+3316 MiB/3.085668% versus fixed+CG**, **+4830 MiB/4.558730% versus eager**.
All50 iterations are genuinely multi-CP, M48/W32; actual layouts contain CP1/2/4/8 in
2 iterations and CP2/4/8 in 48. The observed-CP field is cumulative.
Graph/eager maximum relative LM/MTP/indexer differences are 0.067458/0.046969/0.192803%;
grad norm 1.180694%. Step1 already differs before first capture, but its cause is not
established. Sample-multiset and recorded CP-layout/length hashes match; actual per-rank
packed tensors were not hashed. Numerical acceptance is not automatic and lr=0 is not
convergence acceptance. Steps3..50 graph/eager average 6953.290/12893.542 ms, samples/s
+85.431%, a mock regression workload rather than tuned throughput. Full raw log, all
three TensorBoard files and frozen scripts are retained with verified hashes.
Allocator-external bytes are not fully object-attributed. No runtime
PR changes have been made for these diagnostics.

| Same-node pair | Baseline peak | DCP+CG peak | Difference | Coverage |
| --- | ---: | ---: | ---: | --- |
| native fixed CP8+CG -> DCP+CG, job `7016910` | 107128.562 MiB | 110762.562 MiB | `+3634 MiB / +3.392186%` | 40+40 steps |
| same-schedule eager DCP -> DCP+CG, job `7015341` | 106564.562 MiB | 112092.562 MiB | `+5528 MiB / +5.187466%` | 50+50 steps, append_dummy_seq |

Peaks are maximum sampled whole-device usage across all 128 ranks and capture/training probes,
not continuous device high-water marks.

Both pairs had exactly zero process-baseline difference. In job `7015341`, both whole-device
peaks occurred on rank 1 (graph step 30, eager step 39), and the capacity difference closes as
`5528 MiB = reserved 3630 MiB + allocator-external 1898 MiB`. Paired-rank peak differences
average `5363.719 MiB = reserved 3787.156 MiB + external 1576.562 MiB`.

This accounting is not a complete object-level attribution: at matched step 39 on rank 1,
the allocated delta is `23775.464 MiB`, graph roots account for `21825.637 MiB`, and the
remaining `1949.827 MiB` is not classified by tensor object. The inactive-reserved delta is
`-20145.464 MiB`, so the roots must not be added again to the net device delta. External
growth is located at capture, but concrete driver/library objects are not identified.

The fixed/DCP pair completed 40/40 steps per arm with matching sample fingerprints and no skipped
or NaN iterations. Its peaks occurred at steps 26 (fixed) and 24 (DCP+CG). Job `7015341`
completed graph/eager 50+50 steps in 02:12:56, exit 0:0, with no skipped or NaN iterations,
matching inputs and complete schedules, and 128-rank memory coverage at every step. This
supersedes the earlier two-step interim observation (`+3990 MiB / +3.769394%`). Its lr=0,
append_dummy_seq recipe predates the initialization audit and must not substitute for completed
controlled job `7024429`. Only redundant pending replicas were canceled; no running training
job was canceled.

For the completed same-allocation 50-step pair, maximum differences were
`0.01232 / 0.097972%` for LM loss (step 27), `0.00654 / 0.052007%` for MTP loss (step 43),
`0.001541 / 0.130579%` for indexer loss (step 50), and `0.508 / 0.931392%` for grad norm
(step 32). Steps 3..50 averaged 7100.025 ms graph and 13431.127 ms eager: step time -47.138%,
sample throughput +89.170%. Raw rounded MCore estimates average 16.202 and 8.556 TFLOP/s/GPU;
these are not hardware-counter measurements or tuned model-performance claims.
Raw log SHA256: `831cc521c415fb341f345e162fc00c66704e8fd836ea318c7968370c031a220a`.

Independent current-head 50-step runs completed all three arms with zero skipped or NaN
iterations. DCP+CG and eager DCP had identical sample fingerprints and complete scheduler streams.
Their maximum differences were `0.00605 / 0.048079%` for LM loss, `0.00794 / 0.063167%`
for MTP loss, `0.001818 / 0.152744%` for DSA indexer loss, and `0.594 / 1.090769%`
for grad norm. Steps 3..50 averaged 7188.981 ms for DCP+CG and 13423.573 ms for eager DCP.
Fixed-CP/DCP numerical equivalence is not established: the independent fixed/DCP indexer-loss
difference reached 15.495150%. Different topologies alone do not prove its cause.

**Full-model NCCL diagnostic `18214315`:** the same three-arm 50-update Qwen recipe
reproduces all corresponding logged trajectories and all321264 initial audit records.
All1152 live-pointer sidecars and native log prefixes were verified. Steady NCCL
initialization ranges are1732MiB/rank for native fixed+CG and1980MiB for both DCP arms,
a net248MiB, not the isolated388MiB singleton result. Atstep50, paired mean DCP+CG minus
fixed is2205.09375MiB = reserved865.96875 + verified init248 + unclassified external1091.125;
minus eager DCP is3319.03125MiB = reserved1972.46875 + init0 + unclassified external1346.5625.
Graph reset/callable/root cleanup returns zero external bytes on every rank; this does
not identify a leak or cache. Follow-up `18217059` did not reach teardown: native fixed+CG
failed with an illegal instruction after3 logged steps; DCP+CG failed with a misaligned
address before completing step1, both on rank119 of the same node. Eager completed no
step before external job cancellation. All321264 initial records and512 completed pointer
audits match/pass, but the failure's cause is unresolved. Identical-input retry `18221968`
completed all3 arms50 updates after excluding that node; exclusion does not establish
hardware fault. All321264 initial records and same-arm50 loss/grad trajectories match
reference18214315; all1152 pointer audits and1536 teardown prefixes passed.
After standard process-group destruction plus5s, retaining model/optimizer, all128 ranks
release3524MiB external in fixed and4572MiB in either DCP arm, with zero Torch allocator
change. The DCP/fixed external mean gap1339.125MiB splits into248MiB verified init,
800MiB additional NCCL shareable owner buffers (now directly identified), and
291.125MiB remaining unclassified. DCP graph/eager's1346.5625MiB external gap survives.
Graph async allocator attributes are all0; trim releases0 additional bytes. Training
peak gaps remain2230MiB/3.217751% versus fixed and3708MiB/5.467006% versus eager.
This is attribution, not runtime saving. Retry rawSHA256:
`c6d753edc178631a029549c75c7df4555cc25919451a5147d9b2a3fe0d616328`.
Training collectives and runtime heads are unchanged. Neither diagnostic is
a performance benchmark. RawSHA256: `607d1d42c2a420fff8c32ddfe43429835dc69a1d3a4133d342f3aacf1c2ed996`.

Full-model rank0 Nsight follow-up `18228561` completed all three50-step arms with
unchanged runtime heads and same-arm logged loss/grad parity. All321264 initial records,
1152 pointer queries and1536 teardown prefixes pass. Every selected native owner
address matches its actual allocation size, step50 lifetime and successful CUDA free
in all three traces:1792MiB fixed,2592MiB in each DCP arm. Requests of9633792 bytes
actually allocate10MiB. All128 ranks have the same native size/count inventory.
This identifies the800MiB increment, but does not classify the remaining291.125MiB
fixed/DCP or1346.5625MiB graph/eager mean external gap. The native allocation helper
serves both P2P and NET, so these are not all labelled as one transport's buffers.
Raw Nsight/SQLite, logs and TensorBoard are retained; profiler totals are not substituted
for unprofiled capacity/performance results. LogSHA256:
`7c16ee174b8274f6a410cbef0abf20d8436b68c1906bc8924c132687f5a848f3`.

Latest full-model boundary control `18233361` completed all3x50 updates. All384 boundary
ledgers have matching local/remote hashes;1152 pointer audits and1536 teardown prefixes pass.
Each arm exactly reproduces its previous logged trajectory. The fixed/DCP loss blocker
remains; runtime source is unchanged. DCP/eager external growth equals capture-window
growth on every rank: mean1346.5625MiB, observed as481.75MiB inside capture and864.8125MiB
inside capture_end. Fixed/DCP external mean is1339.125 =1048 communicator-related release
+289.125 capture-window difference +2MiB still unclassified. This is lifecycle/API-boundary
attribution, not private driver-object inventory. Standalone controls without TE/NCCL/model
show272MiB external for704 instantiated graphs,0 for raw uninstantiated graphs; recreation
rounds end272/272/274MiB rather than adding272MiB each time. Do not transfer these toy
byte totals to the model. Full raw logs, traces and TensorBoard remain retained.

Slot annotation correction: Qwen runtimeM8 uses physicalW16, notW8; the pinned planner
unions M8/16/24/32. All128 ranks' callable counts corroborate this (rank0:528=3x16x11).
DSV4M48/W32 and Qwen30BM12/W8 remain the distinct same-iteration wrap tests.

## Dependency

- NVIDIA/TransformerEngine#3353

The TE change should merge before this PR. The non-DCP CUDA Graph path remains unchanged when no slot plan is supplied.

## Validation

Current source: MCore `dcfad1baabaf`, TE `a0a7dad969d9`.

- TE slot-memory suite: `43 passed, 2 skipped`
- current-head targeted MCore tests: `24 passed, 1 skipped`
- targeted indexer tests: `5 passed`
- eight-rank PP/VPP/slot suite: `116 passed, 2 skipped` on every rank, repeated in two jobs
- two four-rank distributed process-group tests passed
- 128-GPU Qwen3-235B current-head 50-update three-arm run completed with zero skipped/NaN;
  DCP graph/eager logged loss and grad norm match, but fixed/DCP numerical acceptance fails
- 128-GPU full DeepSeek-V4-Flash current-head 50-step runs completed all arms with zero skipped
  and zero NaN iterations; sample fingerprints and graph/eager DCP schedule streams matched
  exactly
- two 128-GPU same-node pair jobs measured DCP+CG against fixed CP8+CG and eager DCP without
  cross-allocation subtraction; all paired memory equations closed with zero residual
- same-allocation 128-GPU fixed/DCP job `7016910` completed 40+40 steps; graph/eager job
  `7015341` completed 50+50 steps; initialization-controlled `7024429` completed all three50-step arms
- repository formatter/lint rules and `git diff --check` passed

The retained design and evidence index is at `dcp-cg-multi-group-design.md` in the experiment handoff directory.

## Current limitations

- dynamic CP sizes are powers of two between configured minimum and maximum
- delayed wgrad and expert-communication overlap are currently unsupported with dynamic-CP graphs
- runtime microbatch counts beyond the proved scheduler bound fail explicitly
- graph executables remain per CP variant; allocator-external ownership is not assumed one-to-one with variants and is not yet fully classified
