### PR TITLE
Pseudo-free view outputs in the interleaved pipeline schedule

### DIFF
--- a/megatron/core/pipeline_parallel/schedules.py
+++ b/megatron/core/pipeline_parallel/schedules.py
@@ -192,7 +192,14 @@ def deallocate_output_tensor(out, deallocate_pipeline_outputs=False):
 
     # Base case: deallocate tensor
     assert isinstance(out, torch.Tensor), "expected Tensor, found %s." % type(out).__name__
-    assert out._base is None, "counter-productive to free a view of another tensor."
+    if out._base is not None:
+        # View of another tensor: the base tensor keeps the storage alive, so
+        # this does not reclaim memory. It is still required to swap the data
+        # field: custom_backward() asserts numel()==1 on every pipeline output
+        # before running the C++ autograd engine (interleaved pipeline stages
+        # can emit outputs that alias a p2p/receive buffer).
+        out.data = torch.empty((1,), device=out.device, dtype=out.dtype)
+        return
     out.data = torch.empty((1,), device=out.device, dtype=out.dtype)
 
 


### PR DESCRIPTION
## Summary

`deallocate_output_tensor()` asserted `out._base is None` before swapping the output's data field. With VPP (interleaved) + Megatron-FSDP v2 and the combined-1F1B overlap disabled, stage outputs can alias a p2p/receive buffer (a view), so the assert fired and aborted training. The combined-1F1B overlap schedule never calls `deallocate_output_tensor()`, which is why only the no-overlap interleaved path is affected.

Freeing a view does not reclaim memory (the base tensor keeps the storage alive), but the data-field swap must still happen: `custom_backward()` asserts `numel()==1` on every pipeline output before running the C++ autograd engine.

## Changes

- Skip the `out._base is None` assert and pseudo-free views as well.

## Notes

Split out of PR #6197; standalone (no dependency on the overlap PR).

## Test plan

- py_compile of `schedules.py`
- VPP + Megatron-FSDP v2 no-overlap interleaved training path