### PR TITLE
Expose MFSDP v2 custom-schedule lifecycle

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
@@ -110,6 +110,7 @@ def fully_shard(
     mixed_precision_policy: MixedPrecisionPolicy | None = None,
     grad_divisor: int = 1,
     schedule_policy: SchedulePolicy = SchedulePolicy(),
+    register_hooks: bool = True,
 ) -> None:
     """Apply FSDP to a module in place.
 
@@ -134,6 +135,10 @@ def fully_shard(
             ``grad_divisor=ep_size`` makes up the difference. Dense parameters see only
             their own rank's tokens and need no divisor.
         schedule_policy: Communication scheduling policy for this FSDP module.
+        register_hooks: Whether to register the automatic forward and backward execution
+            hooks on ``module``. Disable this when an external scheduler invokes the
+            corresponding FSDP lifecycle methods explicitly. The state-dict safety hook
+            is registered independently.
     """
     if isinstance(module, FsdpModule):
         raise ValueError("This module is already managed by FSDP.")
@@ -164,6 +169,7 @@ def fully_shard(
             grad_divisor=grad_divisor,
             schedule_policy=schedule_policy,
             use_symmetric_memory=context.use_symmetric_memory,
+            register_hooks=register_hooks,
         )
     except Exception:
         module.__class__ = original_cls

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -15,6 +15,7 @@
 """Module mixin for the minimal Megatron-FSDP path."""
 
 import enum
+from collections.abc import Callable
 from typing import Literal, cast
 from weakref import ref
 
@@ -159,6 +160,7 @@ class FsdpModule:
     _parameter_groups: tuple[FsdpParameterGroup, ...]
     _context: FsdpContext
     _trainable_parameter_countdown: Countdown
+    _post_backward_hook_registered: bool
     _is_root: bool
     _num_trainable_parameters: int
     _schedule_policy: SchedulePolicy
@@ -183,6 +185,7 @@ class FsdpModule:
         grad_divisor: int = 1,
         schedule_policy: SchedulePolicy = SchedulePolicy(),
         use_symmetric_memory: bool = False,
+        register_hooks: bool = True,
     ) -> None:
         """Initialize FSDP runtime state on an already-constructed module."""
         self._context = context
@@ -191,6 +194,7 @@ class FsdpModule:
         self._unshard_event = None
         self._phase = FsdpModule.Phase.RESTING
         self._schedule_policy = schedule_policy
+        self._post_backward_hook_registered = False
         owned_parameters = _collect_owned_parameters(self)
         if grad_divisor <= 0:
             raise ValueError(f"grad_divisor must be positive, got {grad_divisor}.")
@@ -222,7 +226,9 @@ class FsdpModule:
                 if group.requires_grad
             )
         )
-        self._register_hooks()
+        self.register_load_state_dict_pre_hook(FsdpModule._pre_load_state_dict)
+        if register_hooks:
+            self._register_hooks()
         context.register_module(self)
 
     @property
@@ -262,7 +268,6 @@ class FsdpModule:
 
     def _register_hooks(self) -> None:
         module = cast(nn.Module, self)
-        module.register_load_state_dict_pre_hook(FsdpModule._pre_load_state_dict)
         # Use PyTorch's callback module argument instead of capturing self so
         # these hooks do not retain a deleted FSDP module.
         module.register_forward_pre_hook(
@@ -274,12 +279,28 @@ class FsdpModule:
         module.register_full_backward_pre_hook(
             lambda hooked_module, _grad_output: cast(FsdpModule, hooked_module).pre_backward()
         )
+        self.register_post_backward_hook(FsdpModule.post_backward)
+
+    def register_post_backward_hook(
+        self, post_backward_hook: Callable[["FsdpModule"], None]
+    ) -> None:
+        """Register a callback to run when this module's backward is complete.
+
+        Args:
+            post_backward_hook: Callback receiving this FSDP module after all of its
+                trainable parameters have accumulated gradients.
+        """
+        if self._post_backward_hook_registered:
+            raise RuntimeError("This FSDP module already has a post-backward hook registered.")
+
+        module = cast(nn.Module, self)
         if self._trainable_parameter_countdown.initial_value == 0:
             module.register_full_backward_hook(
-                lambda hooked_module, _grad_input, _grad_output: cast(
-                    FsdpModule, hooked_module
-                ).post_backward()
+                lambda hooked_module, _grad_input, _grad_output: post_backward_hook(
+                    cast(FsdpModule, hooked_module)
+                )
             )
+            self._post_backward_hook_registered = True
             return
 
         # Gradient reduction for trainable parameters is parameter-completion
@@ -293,7 +314,7 @@ class FsdpModule:
             if module is None:
                 return
             if module._trainable_parameter_countdown.decrement():
-                module.post_backward()
+                post_backward_hook(module)
 
         for group in self._parameter_groups:
             if not group.requires_grad:
@@ -315,6 +336,7 @@ class FsdpModule:
                 parameter_module.register_wgrad_accumulation_and_reduce_hooks(
                     lambda parameter=parameter: grad_hook(parameter)
                 )
+        self._post_backward_hook_registered = True
 
     @staticmethod
     def _pre_load_state_dict(
@@ -352,25 +374,31 @@ class FsdpModule:
         if self.phase is not FsdpModule.Phase.BACKWARD:
             self.phase = FsdpModule.Phase.FORWARD
         torch.cuda.nvtx.range_push(self._nvtx_label("forward"))
-        allgather_stream = context.allgather_stream
-        current_stream = context.current_stream()
 
         if self.is_root():
-            allgather_stream.wait_stream(current_stream)
+            context.allgather_stream.wait_stream(context.current_stream())
 
+        self.unshard(prefetch="forward" if not is_recomputing else "none")
+
+    def unshard(self, prefetch: Literal["forward", "backward", "none"] = "none") -> None:
+        """Unshard this FsdpModule's parameter groups immediately."""
+        torch.cuda.nvtx.range_push(self._nvtx_label("unshard"))
         self._unshard_parameter_groups()
         assert self._unshard_event is not None
         # Compute waits only for this FsdpModule's all-gather (the prefetch below is
         # issued afterwards, so it is free to run concurrently with this FsdpModule).
-        current_stream.wait_event(self._unshard_event)
+        self.context.current_stream().wait_event(self._unshard_event)
 
-        # Activation recomputation runs forward hooks inside backward. Do not
-        # prefetch the next module in forward order: its backward may already
-        # be complete, so no later backward hook would reshard it.
-        if not is_recomputing:
+        context = self.context
+        if prefetch == "forward":
             self._prefetch_parameter_groups(
                 context.forward_order, self._schedule_policy.forward_prefetch_size
             )
+        elif prefetch == "backward":
+            self._prefetch_parameter_groups(
+                context.backward_order, self._schedule_policy.backward_prefetch_size
+            )
+        torch.cuda.nvtx.range_pop()
 
     def _prefetch_parameter_groups(
         self, order: IndexedOrder["FsdpModule"], prefetch_size: int | None
@@ -412,9 +440,15 @@ class FsdpModule:
         # post_backward() will reshard them after gradient reduction.
         is_recomputing = self.phase is FsdpModule.Phase.BACKWARD or _is_in_backward()
         if not is_recomputing:
-            self._reshard_parameter_groups()
+            self.reshard()
         if self.phase is FsdpModule.Phase.FORWARD:
             self.phase = FsdpModule.Phase.RESTING
+        torch.cuda.nvtx.range_pop()
+
+    def reshard(self) -> None:
+        """Reshard this FsdpModule's parameter groups."""
+        torch.cuda.nvtx.range_push(self._nvtx_label("reshard"))
+        self._reshard_parameter_groups()
         torch.cuda.nvtx.range_pop()
 
     def _reshard_parameter_groups(self) -> None:
@@ -435,14 +469,22 @@ class FsdpModule:
                 group.release_unsharded_storage()
             self._unshard_event = None
 
-    def pre_backward(self) -> None:
-        """Prepare full parameters and prefetch the next FsdpModule in backward order."""
+    def pre_backward(self, register_final_callback: bool = True) -> None:
+        """Prepare full parameters and prefetch the next FsdpModule in backward order.
+
+        Args:
+            register_final_callback: Whether to finalize through the autograd engine.
+                Manual backward schedules (e.g. 1F1B EP overlap schedule) finalize
+                explicitly in ``post_backward()``, so they pass False to avoid
+                installing an autograd callback outside the backward pass.
+        """
         self.phase = FsdpModule.Phase.BACKWARD
-        torch.cuda.nvtx.range_push(self._nvtx_label("backward"))
         context = self.context
+        torch.cuda.nvtx.range_push(self._nvtx_label("backward"))
         current_stream = context.current_stream()
         if self.is_root():
-            context.register_post_backward_final_callback()
+            if register_final_callback:
+                context.register_post_backward_final_callback()
             # Fork the reduce-scatter stream from the current stream once, at the
             # start of backward, so every module's post-backward reduce-scatter is
             # part of any active CUDA-graph capture. A stream only joins the
@@ -452,23 +494,18 @@ class FsdpModule:
             # fork each preceding module issues before its collective.
             context.reduce_scatter_stream.wait_stream(current_stream)
 
-        self._unshard_parameter_groups()
-        assert self._unshard_event is not None
-        current_stream.wait_event(self._unshard_event)
-
-        self._prefetch_parameter_groups(
-            context.backward_order, self._schedule_policy.backward_prefetch_size
-        )
+        self.unshard(prefetch="backward")
 
     def post_backward(self) -> None:
         """Reduce gradients and return parameters to their sharded resting state."""
-        self._reshard_parameter_groups()
+        self.reshard()
         self._reduce_gradient_groups()
         self.phase = FsdpModule.Phase.RESTING
         torch.cuda.nvtx.range_pop()
 
     def _reduce_gradient_groups(self) -> None:
         """Pack gradients and immediately launch their reduce-scatters."""
+        torch.cuda.nvtx.range_push(self._nvtx_label("gradient_reduce"))
         context = self.context
         reduce_scatter_stream = context.reduce_scatter_stream
         current_stream = context.current_stream()
@@ -486,6 +523,7 @@ class FsdpModule:
             reduce_scatter_stream.wait_stream(current_stream)
             with torch.cuda.stream(reduce_scatter_stream):
                 group.reduce_partial_gradients(partial_grad, self.context.is_last_microbatch)
+        torch.cuda.nvtx.range_pop()
 
     @property
     def parameter_groups(self) -> tuple[FsdpParameterGroup, ...]:
@@ -501,9 +539,9 @@ class FsdpModule:
             for parameter in group.fsdp_parameters
         )
 
-    def _nvtx_label(self, phase: Literal["forward", "backward"]) -> str:
-        name = self.name if self.name else "<root>"
-        return f"MFSDP {name} {phase}"
+    def _nvtx_label(self, operation: str) -> str:
+        module_name = self.name or "<root>"
+        return f"MFSDP {module_name} {operation}"
 
 
 def _collect_backward_order(module: nn.Module, order: IndexedOrder["FsdpModule"]) -> None:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -160,7 +160,7 @@ class FsdpModule:
     _parameter_groups: tuple[FsdpParameterGroup, ...]
     _context: FsdpContext
     _trainable_parameter_countdown: Countdown
-    _post_backward_hook_registered: bool
+    _grad_reduction_callback_registered: bool
     _is_root: bool
     _num_trainable_parameters: int
     _schedule_policy: SchedulePolicy
@@ -194,7 +194,7 @@ class FsdpModule:
         self._unshard_event = None
         self._phase = FsdpModule.Phase.RESTING
         self._schedule_policy = schedule_policy
-        self._post_backward_hook_registered = False
+        self._grad_reduction_callback_registered = False
         owned_parameters = _collect_owned_parameters(self)
         if grad_divisor <= 0:
             raise ValueError(f"grad_divisor must be positive, got {grad_divisor}.")
@@ -290,7 +290,7 @@ class FsdpModule:
             post_backward_hook: Callback receiving this FSDP module after all of its
                 trainable parameters have accumulated gradients.
         """
-        if self._post_backward_hook_registered:
+        if self._grad_reduction_callback_registered:
             raise RuntimeError("This FSDP module already has a grad-reduction callback registered.")
 
         module = cast(nn.Module, self)
@@ -300,7 +300,7 @@ class FsdpModule:
                     cast(FsdpModule, hooked_module)
                 )
             )
-            self._post_backward_hook_registered = True
+            self._grad_reduction_callback_registered = True
             return
 
         # Gradient reduction for trainable parameters is parameter-completion
@@ -336,7 +336,7 @@ class FsdpModule:
                 parameter_module.register_wgrad_accumulation_and_reduce_hooks(
                     lambda parameter=parameter: grad_hook(parameter)
                 )
-        self._post_backward_hook_registered = True
+        self._grad_reduction_callback_registered = True
 
     @staticmethod
     def _pre_load_state_dict(
@@ -381,7 +381,15 @@ class FsdpModule:
         self.unshard(prefetch="forward" if not is_recomputing else "none")
 
     def unshard(self, prefetch: Literal["forward", "backward", "none"] = "none") -> None:
-        """Unshard this FsdpModule's parameter groups immediately."""
+        """Unshard this FsdpModule's parameter groups immediately.
+
+        External schedulers invoking this directly (rather than through the
+        automatic ``pre_forward`` hook) must first synchronize the all-gather
+        stream on the root by calling
+        ``context.allgather_stream.wait_stream(context.current_stream())``
+        before this when ``self.is_root()``; the automatic forward path
+        performs that root sync in ``pre_forward()`` immediately before this.
+        """
         torch.cuda.nvtx.range_push(self._nvtx_label("unshard"))
         self._unshard_parameter_groups()
         assert self._unshard_event is not None

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -15,7 +15,8 @@
 """Module mixin for the minimal Megatron-FSDP path."""
 
 import enum
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from typing import Literal, cast
 from weakref import ref
 
@@ -375,6 +376,9 @@ class FsdpModule:
         is_recomputing = self.phase is FsdpModule.Phase.BACKWARD or _is_in_backward()
         if self.phase is not FsdpModule.Phase.BACKWARD:
             self.phase = FsdpModule.Phase.FORWARD
+        # forward/backward each span multiple lifecycle methods (pre_forward ->
+        # post_forward and pre_backward -> post_backward), so they keep explicit
+        # push/pop instead of a single context scope.
         torch.cuda.nvtx.range_push(self._nvtx_label("forward"))
 
         if self.is_root():
@@ -392,23 +396,22 @@ class FsdpModule:
         before this when ``self.is_root()``; the automatic forward path
         performs that root sync in ``pre_forward()`` immediately before this.
         """
-        torch.cuda.nvtx.range_push(self._nvtx_label("unshard"))
-        self._unshard_parameter_groups()
-        assert self._unshard_event is not None
-        # Compute waits only for this FsdpModule's all-gather (the prefetch below is
-        # issued afterwards, so it is free to run concurrently with this FsdpModule).
-        self.context.current_stream().wait_event(self._unshard_event)
+        with self._nvtx_range("unshard"):
+            self._unshard_parameter_groups()
+            assert self._unshard_event is not None
+            # Compute waits only for this FsdpModule's all-gather (the prefetch below is
+            # issued afterwards, so it is free to run concurrently with this FsdpModule).
+            self.context.current_stream().wait_event(self._unshard_event)
 
-        context = self.context
-        if prefetch == "forward":
-            self._prefetch_parameter_groups(
-                context.forward_order, self._schedule_policy.forward_prefetch_size
-            )
-        elif prefetch == "backward":
-            self._prefetch_parameter_groups(
-                context.backward_order, self._schedule_policy.backward_prefetch_size
-            )
-        torch.cuda.nvtx.range_pop()
+            context = self.context
+            if prefetch == "forward":
+                self._prefetch_parameter_groups(
+                    context.forward_order, self._schedule_policy.forward_prefetch_size
+                )
+            elif prefetch == "backward":
+                self._prefetch_parameter_groups(
+                    context.backward_order, self._schedule_policy.backward_prefetch_size
+                )
 
     def _prefetch_parameter_groups(
         self, order: IndexedOrder["FsdpModule"], prefetch_size: int | None
@@ -457,9 +460,8 @@ class FsdpModule:
 
     def reshard(self) -> None:
         """Reshard this FsdpModule's parameter groups."""
-        torch.cuda.nvtx.range_push(self._nvtx_label("reshard"))
-        self._reshard_parameter_groups()
-        torch.cuda.nvtx.range_pop()
+        with self._nvtx_range("reshard"):
+            self._reshard_parameter_groups()
 
     def _reshard_parameter_groups(self) -> None:
         """Reshard parameter groups and release unsharded storage after compute.
@@ -507,25 +509,26 @@ class FsdpModule:
 
     def _reduce_gradient_groups(self) -> None:
         """Pack gradients and immediately launch their reduce-scatters."""
-        torch.cuda.nvtx.range_push(self._nvtx_label("gradient_reduce"))
-        context = self.context
-        reduce_scatter_stream = context.reduce_scatter_stream
-        current_stream = context.current_stream()
+        with self._nvtx_range("gradient_reduce"):
+            context = self.context
+            reduce_scatter_stream = context.reduce_scatter_stream
+            current_stream = context.current_stream()
 
-        for group in self._parameter_groups:
-            if not group.requires_grad:
-                continue
+            for group in self._parameter_groups:
+                if not group.requires_grad:
+                    continue
 
-            with torch.cuda.stream(reduce_scatter_stream):
-                partial_grad = group.allocate_partial_grad_buffer()
+                with torch.cuda.stream(reduce_scatter_stream):
+                    partial_grad = group.allocate_partial_grad_buffer()
 
-            current_stream.wait_stream(reduce_scatter_stream)
-            group.copy_gradients_to_partial_buffer(partial_grad)
+                current_stream.wait_stream(reduce_scatter_stream)
+                group.copy_gradients_to_partial_buffer(partial_grad)
 
-            reduce_scatter_stream.wait_stream(current_stream)
-            with torch.cuda.stream(reduce_scatter_stream):
-                group.reduce_partial_gradients(partial_grad, self.context.is_last_microbatch)
-        torch.cuda.nvtx.range_pop()
+                reduce_scatter_stream.wait_stream(current_stream)
+                with torch.cuda.stream(reduce_scatter_stream):
+                    group.reduce_partial_gradients(
+                        partial_grad, self.context.is_last_microbatch
+                    )
 
     @property
     def parameter_groups(self) -> tuple[FsdpParameterGroup, ...]:
@@ -544,6 +547,15 @@ class FsdpModule:
     def _nvtx_label(self, operation: str) -> str:
         module_name = self.name or "<root>"
         return f"MFSDP {module_name} {operation}"
+
+    @contextmanager
+    def _nvtx_range(self, operation: str) -> Iterator[None]:
+        """Scope an nvtx range to this context so an early return still pops it."""
+        torch.cuda.nvtx.range_push(self._nvtx_label(operation))
+        try:
+            yield
+        finally:
+            torch.cuda.nvtx.range_pop()
 
 
 def _collect_backward_order(module: nn.Module, order: IndexedOrder["FsdpModule"]) -> None:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -472,8 +472,8 @@ class FsdpModule:
     def pre_backward(self) -> None:
         """Prepare full parameters and prefetch the next FsdpModule in backward order."""
         self.phase = FsdpModule.Phase.BACKWARD
-        context = self.context
         torch.cuda.nvtx.range_push(self._nvtx_label("backward"))
+        context = self.context
         current_stream = context.current_stream()
         if self.is_root():
             context.register_post_backward_final_callback()

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -160,7 +160,6 @@ class FsdpModule:
     _parameter_groups: tuple[FsdpParameterGroup, ...]
     _context: FsdpContext
     _trainable_parameter_countdown: Countdown
-    _grad_reduction_callback_registered: bool
     _is_root: bool
     _num_trainable_parameters: int
     _schedule_policy: SchedulePolicy
@@ -194,7 +193,6 @@ class FsdpModule:
         self._unshard_event = None
         self._phase = FsdpModule.Phase.RESTING
         self._schedule_policy = schedule_policy
-        self._grad_reduction_callback_registered = False
         owned_parameters = _collect_owned_parameters(self)
         if grad_divisor <= 0:
             raise ValueError(f"grad_divisor must be positive, got {grad_divisor}.")
@@ -226,6 +224,10 @@ class FsdpModule:
                 if group.requires_grad
             )
         )
+        # The state-dict safety hook is registered unconditionally. It is still
+        # required to keep loading a state dict safe when ``register_hooks`` is
+        # False (i.e. execution hooks are disabled), so it must not be turned off
+        # together with the auto-execution hooks below.
         self.register_load_state_dict_pre_hook(FsdpModule._pre_load_state_dict)
         if register_hooks:
             self._register_hooks()
@@ -279,20 +281,22 @@ class FsdpModule:
         module.register_full_backward_pre_hook(
             lambda hooked_module, _grad_output: cast(FsdpModule, hooked_module).pre_backward()
         )
-        self.register_grad_reduction_callback(FsdpModule.post_backward)
+        self.register_post_backward_hook(FsdpModule.post_backward)
 
-    def register_grad_reduction_callback(
+    def register_post_backward_hook(
         self, post_backward_hook: Callable[["FsdpModule"], None]
     ) -> None:
-        """Register a callback to run gradient reduction when this module's backward is complete.
+        """Register a post-backward hook to run after this module's backward completes.
+
+        The hook runs when this module's backward is complete, so it can reshard
+        this module's parameters and reduce their gradients. It is invoked once
+        all of this module's trainable parameters have accumulated gradients, or
+        via a full-backward hook when the module owns no trainable parameters.
 
         Args:
             post_backward_hook: Callback receiving this FSDP module after all of its
                 trainable parameters have accumulated gradients.
         """
-        if self._grad_reduction_callback_registered:
-            raise RuntimeError("This FSDP module already has a grad-reduction callback registered.")
-
         module = cast(nn.Module, self)
         if self._trainable_parameter_countdown.initial_value == 0:
             module.register_full_backward_hook(
@@ -300,7 +304,6 @@ class FsdpModule:
                     cast(FsdpModule, hooked_module)
                 )
             )
-            self._grad_reduction_callback_registered = True
             return
 
         # Gradient reduction for trainable parameters is parameter-completion
@@ -336,7 +339,6 @@ class FsdpModule:
                 parameter_module.register_wgrad_accumulation_and_reduce_hooks(
                     lambda parameter=parameter: grad_hook(parameter)
                 )
-        self._grad_reduction_callback_registered = True
 
     @staticmethod
     def _pre_load_state_dict(

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -509,7 +509,7 @@ class FsdpModule:
 
     def _reduce_gradient_groups(self) -> None:
         """Pack gradients and immediately launch their reduce-scatters."""
-        with self._nvtx_range("gradient_reduce"):
+        with self._nvtx_range("reduce_gradients"):
             context = self.context
             reduce_scatter_stream = context.reduce_scatter_stream
             current_stream = context.current_stream()

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -279,19 +279,19 @@ class FsdpModule:
         module.register_full_backward_pre_hook(
             lambda hooked_module, _grad_output: cast(FsdpModule, hooked_module).pre_backward()
         )
-        self.register_post_backward_hook(FsdpModule.post_backward)
+        self.register_grad_reduction_callback(FsdpModule.post_backward)
 
-    def register_post_backward_hook(
+    def register_grad_reduction_callback(
         self, post_backward_hook: Callable[["FsdpModule"], None]
     ) -> None:
-        """Register a callback to run when this module's backward is complete.
+        """Register a callback to run gradient reduction when this module's backward is complete.
 
         Args:
             post_backward_hook: Callback receiving this FSDP module after all of its
                 trainable parameters have accumulated gradients.
         """
         if self._post_backward_hook_registered:
-            raise RuntimeError("This FSDP module already has a post-backward hook registered.")
+            raise RuntimeError("This FSDP module already has a grad-reduction callback registered.")
 
         module = cast(nn.Module, self)
         if self._trainable_parameter_countdown.initial_value == 0:

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -469,22 +469,14 @@ class FsdpModule:
                 group.release_unsharded_storage()
             self._unshard_event = None
 
-    def pre_backward(self, register_final_callback: bool = True) -> None:
-        """Prepare full parameters and prefetch the next FsdpModule in backward order.
-
-        Args:
-            register_final_callback: Whether to finalize through the autograd engine.
-                Manual backward schedules (e.g. 1F1B EP overlap schedule) finalize
-                explicitly in ``post_backward()``, so they pass False to avoid
-                installing an autograd callback outside the backward pass.
-        """
+    def pre_backward(self) -> None:
+        """Prepare full parameters and prefetch the next FsdpModule in backward order."""
         self.phase = FsdpModule.Phase.BACKWARD
         context = self.context
         torch.cuda.nvtx.range_push(self._nvtx_label("backward"))
         current_stream = context.current_stream()
         if self.is_root():
-            if register_final_callback:
-                context.register_post_backward_final_callback()
+            context.register_post_backward_final_callback()
             # Fork the reduce-scatter stream from the current stream once, at the
             # start of backward, so every module's post-backward reduce-scatter is
             # part of any active CUDA-graph capture. A stream only joins the

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -526,9 +526,7 @@ class FsdpModule:
 
                 reduce_scatter_stream.wait_stream(current_stream)
                 with torch.cuda.stream(reduce_scatter_stream):
-                    group.reduce_partial_gradients(
-                        partial_grad, self.context.is_last_microbatch
-                    )
+                    group.reduce_partial_gradients(partial_grad, self.context.is_last_microbatch)
 
     @property
     def parameter_groups(self) -> tuple[FsdpParameterGroup, ...]:

--- a/tests/unit_tests/distributed/mfsdp_v2/test_annotation.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_annotation.py
@@ -17,13 +17,13 @@ from megatron.core.distributed.fsdp.src.megatron_fsdp.experimental import (
     fully_shard_context,
 )
 
-_NVTX_LABEL_PATTERN = re.compile(r"MFSDP (.+) (forward|backward)")
+_NVTX_LABEL_PATTERN = re.compile(r"MFSDP (.+) (\S+)")
 
 
 class NvtxEvent(NamedTuple):
     kind: Literal["push", "pop"]
     name: str
-    phase: str
+    operation: str
 
 
 class NestedLinearModel(nn.Module):
@@ -76,16 +76,50 @@ def _setup_nvtx_recording(monkeypatch: pytest.MonkeyPatch, events: list[NvtxEven
         return match.groups()
 
     def record_push(label: str) -> None:
-        name, phase = parse_nvtx_label(label)
-        label_stack.append((name, phase))
-        events.append(NvtxEvent("push", name, phase))
+        name, operation = parse_nvtx_label(label)
+        label_stack.append((name, operation))
+        events.append(NvtxEvent("push", name, operation))
 
     def record_pop() -> None:
-        name, phase = label_stack.pop()
-        events.append(NvtxEvent("pop", name, phase))
+        name, operation = label_stack.pop()
+        events.append(NvtxEvent("pop", name, operation))
 
     monkeypatch.setattr(torch.cuda.nvtx, "range_push", record_push)
     monkeypatch.setattr(torch.cuda.nvtx, "range_pop", record_pop)
+
+
+def _lifecycle_events(events: list[NvtxEvent]) -> list[NvtxEvent]:
+    """Return the forward/backward ranges asserted by the lifecycle tests."""
+    return [event for event in events if event.operation in ("forward", "backward")]
+
+
+def test_fsdp_training_hooks_emit_operation_nvtx_ranges(distributed_setup, monkeypatch):
+    """A training step should annotate each FSDP lifecycle operation."""
+    events: list[NvtxEvent] = []
+    _setup_nvtx_recording(monkeypatch, events)
+    model = nn.Linear(4, 4, bias=False).to(distributed_setup.device)
+    mesh = init_device_mesh(distributed_setup.device.type, (distributed_setup.world_size,))
+    with fully_shard_context(device=distributed_setup.device):
+        fully_shard(model, mesh=mesh, placements=_flat_placements())
+
+    model(torch.ones(2, 4, device=distributed_setup.device)).sum().backward()
+
+    assert events == [
+        NvtxEvent("push", "<root>", "forward"),
+        NvtxEvent("push", "<root>", "unshard"),
+        NvtxEvent("pop", "<root>", "unshard"),
+        NvtxEvent("push", "<root>", "reshard"),
+        NvtxEvent("pop", "<root>", "reshard"),
+        NvtxEvent("pop", "<root>", "forward"),
+        NvtxEvent("push", "<root>", "backward"),
+        NvtxEvent("push", "<root>", "unshard"),
+        NvtxEvent("pop", "<root>", "unshard"),
+        NvtxEvent("push", "<root>", "reshard"),
+        NvtxEvent("pop", "<root>", "reshard"),
+        NvtxEvent("push", "<root>", "gradient_reduce"),
+        NvtxEvent("pop", "<root>", "gradient_reduce"),
+        NvtxEvent("pop", "<root>", "backward"),
+    ]
 
 
 def test_fsdp_sibling_roots_emit_root_nvtx_ranges_after_training_step(
@@ -102,7 +136,7 @@ def test_fsdp_sibling_roots_emit_root_nvtx_ranges_after_training_step(
 
     model(torch.ones(2, 4, device=distributed_setup.device)).sum().backward()
 
-    assert [(event.kind, event.name, event.phase) for event in events] == [
+    assert _lifecycle_events(events) == [
         ("push", "<root>", "forward"),
         ("pop", "<root>", "forward"),
         ("push", "<root>", "forward"),
@@ -127,7 +161,7 @@ def test_fsdp_training_hooks_emit_stacked_nvtx_ranges(distributed_setup, monkeyp
 
     model(torch.ones(2, 4, device=distributed_setup.device)).sum().backward()
 
-    assert [(event.kind, event.name, event.phase) for event in events] == [
+    assert _lifecycle_events(events) == [
         ("push", "<root>", "forward"),
         ("push", "layers.0", "forward"),
         ("pop", "layers.0", "forward"),
@@ -157,7 +191,7 @@ def test_fsdp_frozen_parameters_emit_balanced_backward_nvtx_range(distributed_se
     x = torch.ones(2, 4, device=distributed_setup.device, requires_grad=True)
     model(x).sum().backward()
 
-    assert [(event.kind, event.name, event.phase) for event in events] == [
+    assert _lifecycle_events(events) == [
         ("push", "<root>", "forward"),
         ("pop", "<root>", "forward"),
         ("push", "<root>", "backward"),
@@ -182,7 +216,7 @@ def test_fsdp_frozen_child_without_grad_inputs_skips_backward_nvtx_range(
 
     model(torch.ones(2, 4, device=distributed_setup.device)).sum().backward()
 
-    assert [(event.kind, event.name, event.phase) for event in events] == [
+    assert _lifecycle_events(events) == [
         ("push", "<root>", "forward"),
         ("push", "layers.0", "forward"),
         ("pop", "layers.0", "forward"),
@@ -210,7 +244,7 @@ def test_tied_child_parameters_complete_backward_once_per_cycle(distributed_setu
         model.zero_grad(set_to_none=True)
         model(token_ids).backward()
 
-    assert [(event.kind, event.name, event.phase) for event in events] == [
+    assert _lifecycle_events(events) == [
         ("push", "<root>", "forward"),
         ("pop", "<root>", "forward"),
         ("push", "<root>", "backward"),

--- a/tests/unit_tests/distributed/mfsdp_v2/test_annotation.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_annotation.py
@@ -116,8 +116,8 @@ def test_fsdp_training_hooks_emit_operation_nvtx_ranges(distributed_setup, monke
         NvtxEvent("pop", "<root>", "unshard"),
         NvtxEvent("push", "<root>", "reshard"),
         NvtxEvent("pop", "<root>", "reshard"),
-        NvtxEvent("push", "<root>", "gradient_reduce"),
-        NvtxEvent("pop", "<root>", "gradient_reduce"),
+        NvtxEvent("push", "<root>", "reduce_gradients"),
+        NvtxEvent("pop", "<root>", "reduce_gradients"),
         NvtxEvent("pop", "<root>", "backward"),
     ]
 

--- a/tests/unit_tests/distributed/mfsdp_v2/test_annotation.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_annotation.py
@@ -88,7 +88,7 @@ def _setup_nvtx_recording(monkeypatch: pytest.MonkeyPatch, events: list[NvtxEven
     monkeypatch.setattr(torch.cuda.nvtx, "range_pop", record_pop)
 
 
-def _lifecycle_events(events: list[NvtxEvent]) -> list[NvtxEvent]:
+def _forward_backward_events(events: list[NvtxEvent]) -> list[NvtxEvent]:
     """Return the forward/backward ranges asserted by the lifecycle tests."""
     return [event for event in events if event.operation in ("forward", "backward")]
 
@@ -136,7 +136,7 @@ def test_fsdp_sibling_roots_emit_root_nvtx_ranges_after_training_step(
 
     model(torch.ones(2, 4, device=distributed_setup.device)).sum().backward()
 
-    assert _lifecycle_events(events) == [
+    assert _forward_backward_events(events) == [
         ("push", "<root>", "forward"),
         ("pop", "<root>", "forward"),
         ("push", "<root>", "forward"),
@@ -161,7 +161,7 @@ def test_fsdp_training_hooks_emit_stacked_nvtx_ranges(distributed_setup, monkeyp
 
     model(torch.ones(2, 4, device=distributed_setup.device)).sum().backward()
 
-    assert _lifecycle_events(events) == [
+    assert _forward_backward_events(events) == [
         ("push", "<root>", "forward"),
         ("push", "layers.0", "forward"),
         ("pop", "layers.0", "forward"),
@@ -191,7 +191,7 @@ def test_fsdp_frozen_parameters_emit_balanced_backward_nvtx_range(distributed_se
     x = torch.ones(2, 4, device=distributed_setup.device, requires_grad=True)
     model(x).sum().backward()
 
-    assert _lifecycle_events(events) == [
+    assert _forward_backward_events(events) == [
         ("push", "<root>", "forward"),
         ("pop", "<root>", "forward"),
         ("push", "<root>", "backward"),
@@ -216,7 +216,7 @@ def test_fsdp_frozen_child_without_grad_inputs_skips_backward_nvtx_range(
 
     model(torch.ones(2, 4, device=distributed_setup.device)).sum().backward()
 
-    assert _lifecycle_events(events) == [
+    assert _forward_backward_events(events) == [
         ("push", "<root>", "forward"),
         ("push", "layers.0", "forward"),
         ("pop", "layers.0", "forward"),
@@ -244,7 +244,7 @@ def test_tied_child_parameters_complete_backward_once_per_cycle(distributed_setu
         model.zero_grad(set_to_none=True)
         model(token_ids).backward()
 
-    assert _lifecycle_events(events) == [
+    assert _forward_backward_events(events) == [
         ("push", "<root>", "forward"),
         ("pop", "<root>", "forward"),
         ("push", "<root>", "backward"),

--- a/tests/unit_tests/distributed/mfsdp_v2/test_context.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_context.py
@@ -158,6 +158,90 @@ def test_nested_prefetch_orders_use_dfs(distributed_setup):
     assert list(context.backward_order) == [model, model.right, model.left, model.left.inner]
 
 
+def test_fully_shard_can_disable_execution_hooks(distributed_setup):
+    """An external scheduler can disable execution hooks without disabling load safety."""
+    device = distributed_setup.device
+    mesh = init_device_mesh(device.type, (distributed_setup.world_size,))
+    model = NestedModel().to(device)
+
+    with fully_shard_context(device=device):
+        fully_shard(model.inner, mesh=mesh, placements=_flat_placements(), register_hooks=False)
+        fully_shard(model, mesh=mesh, placements=_flat_placements(), register_hooks=False)
+
+    for fsdp_module in (model, model.inner):
+        assert not fsdp_module._forward_pre_hooks
+        assert not fsdp_module._forward_hooks
+        assert not fsdp_module._backward_pre_hooks
+        assert not fsdp_module._backward_hooks
+        assert len(fsdp_module._load_state_dict_pre_hooks) == 1
+        for group in fsdp_module.parameter_groups:
+            for fsdp_parameter in group.fsdp_parameters:
+                assert not getattr(fsdp_parameter.unsharded, "_post_accumulate_grad_hooks", None)
+
+
+def test_register_post_backward_hook_waits_for_all_parameter_gradients(distributed_setup):
+    """An external scheduler callback should run once all owned gradients are ready."""
+    device = distributed_setup.device
+    mesh = init_device_mesh(device.type, (distributed_setup.world_size,))
+    model = nn.Linear(4, 4).to(device)
+
+    with fully_shard_context(device=device):
+        fully_shard(model, mesh=mesh, placements=_flat_placements(), register_hooks=False)
+
+    parameters = [
+        fsdp_parameter.unsharded
+        for group in model.parameter_groups
+        if group.requires_grad
+        for fsdp_parameter in group.fsdp_parameters
+    ]
+    assert len(parameters) == 2
+    callback_modules = []
+    model.register_post_backward_hook(callback_modules.append)
+
+    parameter_hooks = []
+    for parameter in parameters:
+        hooks = getattr(parameter, "_post_accumulate_grad_hooks", None)
+        assert hooks is not None and len(hooks) == 1
+        parameter_hooks.append(next(iter(hooks.values())))
+
+    for parameter, hook in zip(parameters[:-1], parameter_hooks[:-1]):
+        hook(parameter)
+    assert callback_modules == []
+
+    parameter_hooks[-1](parameters[-1])
+    assert callback_modules == [model]
+
+
+def test_register_post_backward_hook_rejects_duplicate_registration(distributed_setup):
+    """An FSDP unit should accept only one post-backward callback."""
+    device = distributed_setup.device
+    mesh = init_device_mesh(device.type, (distributed_setup.world_size,))
+    model = nn.Linear(4, 4, bias=False).to(device)
+
+    with fully_shard_context(device=device):
+        fully_shard(model, mesh=mesh, placements=_flat_placements(), register_hooks=False)
+
+    model.register_post_backward_hook(lambda _module: None)
+    with pytest.raises(RuntimeError, match="already has a post-backward hook registered"):
+        model.register_post_backward_hook(lambda _module: None)
+
+
+def test_register_post_backward_hook_handles_parameterless_module(distributed_setup):
+    """A parameterless FSDP unit should invoke the external scheduler callback."""
+    device = distributed_setup.device
+    mesh = init_device_mesh(device.type, (distributed_setup.world_size,))
+    model = nn.Identity().to(device)
+
+    with fully_shard_context(device=device):
+        fully_shard(model, mesh=mesh, placements=_flat_placements(), register_hooks=False)
+
+    callback_modules = []
+    model.register_post_backward_hook(callback_modules.append)
+    model(torch.ones(2, 4, device=device, requires_grad=True)).sum().backward()
+
+    assert callback_modules == [model]
+
+
 def test_nested_and_sibling_roots_use_cross_root_orders(distributed_setup):
     """Context orders should concatenate nested roots at construction boundaries."""
     device = distributed_setup.device
@@ -234,3 +318,33 @@ def test_fully_shard_rejects_child_from_another_context(distributed_setup):
             fully_shard(model, mesh=mesh, placements=_flat_placements())
 
     assert model.inner.context is first_context
+
+
+def test_multiple_forwards_before_backwards_reset_gradient_readiness(
+    distributed_setup, monkeypatch
+):
+    """Consecutive pipeline backwards should each finalize gradient reduction."""
+    device = distributed_setup.device
+    mesh = init_device_mesh(device.type, (distributed_setup.world_size,))
+    model = nn.Linear(4, 4, bias=False).to(device)
+
+    with fully_shard_context(device=device):
+        fully_shard(model, mesh=mesh, placements=_flat_placements())
+
+    reduce_calls = []
+    original_reduce_gradient_groups = model._reduce_gradient_groups
+
+    def record_reduce_gradient_groups() -> None:
+        reduce_calls.append(None)
+        original_reduce_gradient_groups()
+
+    monkeypatch.setattr(model, "_reduce_gradient_groups", record_reduce_gradient_groups)
+
+    # Pipeline warmup may run multiple forwards before cooldown runs consecutive
+    # backwards. Each backward must reset the parameter-completion counter.
+    losses = [model(torch.ones(2, 4, device=device)).sum() for _ in range(2)]
+    for loss in reversed(losses):
+        loss.backward()
+
+    assert len(reduce_calls) == 2
+    assert model.phase is model.Phase.RESTING

--- a/tests/unit_tests/distributed/mfsdp_v2/test_context.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_context.py
@@ -179,7 +179,7 @@ def test_fully_shard_can_disable_execution_hooks(distributed_setup):
                 assert not getattr(fsdp_parameter.unsharded, "_post_accumulate_grad_hooks", None)
 
 
-def test_register_post_backward_hook_waits_for_all_parameter_gradients(distributed_setup):
+def test_register_grad_reduction_callback_waits_for_all_parameter_gradients(distributed_setup):
     """An external scheduler callback should run once all owned gradients are ready."""
     device = distributed_setup.device
     mesh = init_device_mesh(device.type, (distributed_setup.world_size,))
@@ -196,7 +196,7 @@ def test_register_post_backward_hook_waits_for_all_parameter_gradients(distribut
     ]
     assert len(parameters) == 2
     callback_modules = []
-    model.register_post_backward_hook(callback_modules.append)
+    model.register_grad_reduction_callback(callback_modules.append)
 
     parameter_hooks = []
     for parameter in parameters:
@@ -212,7 +212,7 @@ def test_register_post_backward_hook_waits_for_all_parameter_gradients(distribut
     assert callback_modules == [model]
 
 
-def test_register_post_backward_hook_rejects_duplicate_registration(distributed_setup):
+def test_register_grad_reduction_callback_rejects_duplicate_registration(distributed_setup):
     """An FSDP unit should accept only one post-backward callback."""
     device = distributed_setup.device
     mesh = init_device_mesh(device.type, (distributed_setup.world_size,))
@@ -221,12 +221,12 @@ def test_register_post_backward_hook_rejects_duplicate_registration(distributed_
     with fully_shard_context(device=device):
         fully_shard(model, mesh=mesh, placements=_flat_placements(), register_hooks=False)
 
-    model.register_post_backward_hook(lambda _module: None)
-    with pytest.raises(RuntimeError, match="already has a post-backward hook registered"):
-        model.register_post_backward_hook(lambda _module: None)
+    model.register_grad_reduction_callback(lambda _module: None)
+    with pytest.raises(RuntimeError, match="already has a grad-reduction callback registered"):
+        model.register_grad_reduction_callback(lambda _module: None)
 
 
-def test_register_post_backward_hook_handles_parameterless_module(distributed_setup):
+def test_register_grad_reduction_callback_handles_parameterless_module(distributed_setup):
     """A parameterless FSDP unit should invoke the external scheduler callback."""
     device = distributed_setup.device
     mesh = init_device_mesh(device.type, (distributed_setup.world_size,))
@@ -236,7 +236,7 @@ def test_register_post_backward_hook_handles_parameterless_module(distributed_se
         fully_shard(model, mesh=mesh, placements=_flat_placements(), register_hooks=False)
 
     callback_modules = []
-    model.register_post_backward_hook(callback_modules.append)
+    model.register_grad_reduction_callback(callback_modules.append)
     model(torch.ones(2, 4, device=device, requires_grad=True)).sum().backward()
 
     assert callback_modules == [model]

--- a/tests/unit_tests/distributed/mfsdp_v2/test_context.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_context.py
@@ -158,60 +158,6 @@ def test_nested_prefetch_orders_use_dfs(distributed_setup):
     assert list(context.backward_order) == [model, model.right, model.left, model.left.inner]
 
 
-def test_fully_shard_can_disable_execution_hooks(distributed_setup):
-    """An external scheduler can disable execution hooks without disabling load safety."""
-    device = distributed_setup.device
-    mesh = init_device_mesh(device.type, (distributed_setup.world_size,))
-    model = NestedModel().to(device)
-
-    with fully_shard_context(device=device):
-        fully_shard(model.inner, mesh=mesh, placements=_flat_placements(), register_hooks=False)
-        fully_shard(model, mesh=mesh, placements=_flat_placements(), register_hooks=False)
-
-    for fsdp_module in (model, model.inner):
-        assert not fsdp_module._forward_pre_hooks
-        assert not fsdp_module._forward_hooks
-        assert not fsdp_module._backward_pre_hooks
-        assert not fsdp_module._backward_hooks
-        assert len(fsdp_module._load_state_dict_pre_hooks) == 1
-        for group in fsdp_module.parameter_groups:
-            for fsdp_parameter in group.fsdp_parameters:
-                assert not getattr(fsdp_parameter.unsharded, "_post_accumulate_grad_hooks", None)
-
-
-def test_register_post_backward_hook_waits_for_all_parameter_gradients(distributed_setup):
-    """An external scheduler callback should run once all owned gradients are ready."""
-    device = distributed_setup.device
-    mesh = init_device_mesh(device.type, (distributed_setup.world_size,))
-    model = nn.Linear(4, 4).to(device)
-
-    with fully_shard_context(device=device):
-        fully_shard(model, mesh=mesh, placements=_flat_placements(), register_hooks=False)
-
-    parameters = [
-        fsdp_parameter.unsharded
-        for group in model.parameter_groups
-        if group.requires_grad
-        for fsdp_parameter in group.fsdp_parameters
-    ]
-    assert len(parameters) == 2
-    callback_modules = []
-    model.register_post_backward_hook(callback_modules.append)
-
-    parameter_hooks = []
-    for parameter in parameters:
-        hooks = getattr(parameter, "_post_accumulate_grad_hooks", None)
-        assert hooks is not None and len(hooks) == 1
-        parameter_hooks.append(next(iter(hooks.values())))
-
-    for parameter, hook in zip(parameters[:-1], parameter_hooks[:-1]):
-        hook(parameter)
-    assert callback_modules == []
-
-    parameter_hooks[-1](parameters[-1])
-    assert callback_modules == [model]
-
-
 def test_register_post_backward_hook_handles_parameterless_module(distributed_setup):
     """A parameterless FSDP unit should invoke the external scheduler callback."""
     device = distributed_setup.device
@@ -304,33 +250,3 @@ def test_fully_shard_rejects_child_from_another_context(distributed_setup):
             fully_shard(model, mesh=mesh, placements=_flat_placements())
 
     assert model.inner.context is first_context
-
-
-def test_multiple_forwards_before_backwards_reset_gradient_readiness(
-    distributed_setup, monkeypatch
-):
-    """Consecutive pipeline backwards should each finalize gradient reduction."""
-    device = distributed_setup.device
-    mesh = init_device_mesh(device.type, (distributed_setup.world_size,))
-    model = nn.Linear(4, 4, bias=False).to(device)
-
-    with fully_shard_context(device=device):
-        fully_shard(model, mesh=mesh, placements=_flat_placements())
-
-    reduce_calls = []
-    original_reduce_gradient_groups = model._reduce_gradient_groups
-
-    def record_reduce_gradient_groups() -> None:
-        reduce_calls.append(None)
-        original_reduce_gradient_groups()
-
-    monkeypatch.setattr(model, "_reduce_gradient_groups", record_reduce_gradient_groups)
-
-    # Pipeline warmup may run multiple forwards before cooldown runs consecutive
-    # backwards. Each backward must reset the parameter-completion counter.
-    losses = [model(torch.ones(2, 4, device=device)).sum() for _ in range(2)]
-    for loss in reversed(losses):
-        loss.backward()
-
-    assert len(reduce_calls) == 2
-    assert model.phase is model.Phase.RESTING

--- a/tests/unit_tests/distributed/mfsdp_v2/test_context.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_context.py
@@ -179,7 +179,7 @@ def test_fully_shard_can_disable_execution_hooks(distributed_setup):
                 assert not getattr(fsdp_parameter.unsharded, "_post_accumulate_grad_hooks", None)
 
 
-def test_register_grad_reduction_callback_waits_for_all_parameter_gradients(distributed_setup):
+def test_register_post_backward_hook_waits_for_all_parameter_gradients(distributed_setup):
     """An external scheduler callback should run once all owned gradients are ready."""
     device = distributed_setup.device
     mesh = init_device_mesh(device.type, (distributed_setup.world_size,))
@@ -196,7 +196,7 @@ def test_register_grad_reduction_callback_waits_for_all_parameter_gradients(dist
     ]
     assert len(parameters) == 2
     callback_modules = []
-    model.register_grad_reduction_callback(callback_modules.append)
+    model.register_post_backward_hook(callback_modules.append)
 
     parameter_hooks = []
     for parameter in parameters:
@@ -212,21 +212,7 @@ def test_register_grad_reduction_callback_waits_for_all_parameter_gradients(dist
     assert callback_modules == [model]
 
 
-def test_register_grad_reduction_callback_rejects_duplicate_registration(distributed_setup):
-    """An FSDP unit should accept only one post-backward callback."""
-    device = distributed_setup.device
-    mesh = init_device_mesh(device.type, (distributed_setup.world_size,))
-    model = nn.Linear(4, 4, bias=False).to(device)
-
-    with fully_shard_context(device=device):
-        fully_shard(model, mesh=mesh, placements=_flat_placements(), register_hooks=False)
-
-    model.register_grad_reduction_callback(lambda _module: None)
-    with pytest.raises(RuntimeError, match="already has a grad-reduction callback registered"):
-        model.register_grad_reduction_callback(lambda _module: None)
-
-
-def test_register_grad_reduction_callback_handles_parameterless_module(distributed_setup):
+def test_register_post_backward_hook_handles_parameterless_module(distributed_setup):
     """A parameterless FSDP unit should invoke the external scheduler callback."""
     device = distributed_setup.device
     mesh = init_device_mesh(device.type, (distributed_setup.world_size,))
@@ -236,7 +222,7 @@ def test_register_grad_reduction_callback_handles_parameterless_module(distribut
         fully_shard(model, mesh=mesh, placements=_flat_placements(), register_hooks=False)
 
     callback_modules = []
-    model.register_grad_reduction_callback(callback_modules.append)
+    model.register_post_backward_hook(callback_modules.append)
     model(torch.ones(2, 4, device=device, requires_grad=True)).sum().backward()
 
     assert callback_modules == [model]


### PR DESCRIPTION
## Summary

Part 1 of the MFSDP v2 combined-1F1B split. This PR contains only the generic experimental MFSDP lifecycle required by external fine-grained schedules.

- add a `register_hooks` option so an external scheduler can disable automatic forward/backward execution hooks while retaining state-dict load safety
- expose explicit `FsdpModule.unshard()` and `reshard()` operations
- expose parameter-completion-based post-backward callback registration, including Transformer Engine delayed-wgrad hooks
- allow manual backward schedules to opt out of the autograd final callback
- preserve NVIDIA main's `SchedulePolicy` prefetch behavior for the default automatic-hook path
- add operation-level NVTX ranges and focused lifecycle/callback coverage

## Split

The MCore adapter and `models/common` integration live in draft PR #6692 and depend on this PR.

## Validation

- DCO: passed
- Black 26.3.0: passed
- isort 5.13.2: passed
- Ruff 0.9.10: passed
- Python compilation and `git diff --check`: passed
- GitHub linting: passed
- focused GPU/unit-test CI on rebased commit `cff249e1969b`: in progress
