### PR TITLE
[Prototype] Reduce M-FSDP v2 CPU overhead: foreach grad copy, cached DBuffer views, nvtx tags

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/dbuffer.py
@@ -100,6 +100,7 @@ class DBuffer:
 
         self.offset, local_numel = self.layout.get_local_range(self.mesh, self.placements)
         self.local_buffer = torch.empty(local_numel, dtype=dtype, device=device)
+        self._local_tensor_cache: dict[int, torch.Tensor] = {}
 
     @property
     def dtype(self) -> torch.dtype:
@@ -129,6 +130,9 @@ class DBuffer:
 
     def _resize_storage(self, numel: int) -> None:
         self.local_buffer.untyped_storage().resize_(numel * self.local_buffer.element_size())
+        # Cached local-tensor views alias this storage, so they are invalid
+        # after a resize (release_storage() and reallocate_storage()).
+        self._local_tensor_cache.clear()
 
     def _get_owned_range(self, tensor_index: int) -> _OwnedRange | None:
         """Return this buffer's owned range for logical tensor ``tensor_index``."""
@@ -195,6 +199,7 @@ class DBuffer:
         buffer.layout = layout
         buffer.offset = offset
         buffer.local_buffer = local_buffer
+        buffer._local_tensor_cache = {}
         return buffer
 
     @classmethod
@@ -461,11 +466,17 @@ class DBuffer:
         Flat placements shard dim 0, so the returned view preserves all
         non-leading dimensions and only changes the leading dimension.
         """
+        cached = self._local_tensor_cache.get(index)
+        if cached is not None:
+            return cached
+
         shape = self.layout.tensor_shapes[index]
         owned_range = self._get_owned_range(index)
 
         row_size = non_leading_numel(shape)
         if owned_range is None:
+            # Empty shards are free to recreate and are not cached, so indices
+            # never share the same (empty) tensor object.
             empty_shape = torch.Size((0, *shape[1:]))
             return torch.empty(empty_shape, dtype=self.dtype, device=self.device)
 
@@ -474,9 +485,11 @@ class DBuffer:
                 f"Local tensor shard for tensor {index} does not preserve dim-0 boundaries."
             )
         local_shape = torch.Size((owned_range.numel // row_size, *shape[1:]))
-        return self.local_buffer.narrow(
+        local = self.local_buffer.narrow(
             0, owned_range.buffer_relative_offset, owned_range.numel
         ).view(local_shape)
+        self._local_tensor_cache[index] = local
+        return local
 
     def get_dtensor(self, index: int) -> DTensor:
         """Return logical tensor ``index`` as a DTensor."""

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -16,7 +16,7 @@
 
 import enum
 from collections.abc import Callable
-from typing import Literal, cast
+from typing import cast
 from weakref import ref
 
 import torch
@@ -324,10 +324,12 @@ class FsdpModule:
             return
 
         allgather_stream = self.context.allgather_stream
+        torch.cuda.nvtx.range_push(self._nvtx_label("allgather"))
         with torch.cuda.stream(allgather_stream):
             for group in self._parameter_groups:
                 group.unshard_parameters()
             self._unshard_event = allgather_stream.record_event()
+        torch.cuda.nvtx.range_pop()
 
     def post_forward(self) -> None:
         """Return parameters to their sharded resting state after forward compute."""
@@ -397,6 +399,7 @@ class FsdpModule:
         reduce_scatter_stream = context.reduce_scatter_stream
         current_stream = context.current_stream()
 
+        torch.cuda.nvtx.range_push(self._nvtx_label("reduce_grad"))
         for group in self._parameter_groups:
             if not group.requires_grad:
                 continue
@@ -410,13 +413,14 @@ class FsdpModule:
             reduce_scatter_stream.wait_stream(current_stream)
             with torch.cuda.stream(reduce_scatter_stream):
                 group.reduce_partial_gradients(partial_grad, self.context.is_last_microbatch)
+        torch.cuda.nvtx.range_pop()
 
     @property
     def parameter_groups(self) -> tuple[FsdpParameterGroup, ...]:
         """Parameter groups owned by this FsdpModule."""
         return self._parameter_groups
 
-    def _nvtx_label(self, phase: Literal["forward", "backward"]) -> str:
+    def _nvtx_label(self, phase: str) -> str:
         name = self.name if self.name else "<root>"
         return f"MFSDP {name} {phase}"
 

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -335,8 +335,15 @@ class FsdpParameterGroup:
     def copy_gradients_to_partial_buffer(self, partial_grad: DBuffer) -> None:
         """Pack full local gradients into an existing reduce-scatter input buffer."""
         # A future fused-wgrad path can write directly into these buffer views.
-        for index, fsdp_parameter in enumerate(self.fsdp_parameters):
-            partial_grad.get_local_tensor(index).copy_(fsdp_parameter.unsharded.grad)
+        destinations = [
+            partial_grad.get_local_tensor(index) for index in range(len(self.fsdp_parameters))
+        ]
+        sources = [
+            self.fsdp_parameters[index].unsharded.grad for index in range(len(self.fsdp_parameters))
+        ]
+        if destinations:
+            torch._foreach_copy_(destinations, sources)
+        for fsdp_parameter in self.fsdp_parameters:
             fsdp_parameter.unsharded.grad = None
 
     def _has_sharded_grads(self) -> bool:


### PR DESCRIPTION
## Summary

Reduce M-FSDP v2 CPU overhead in the backward gradient path and make M-FSDP v2 communication visible in nsys traces.

## Changes

- **`copy_gradients_to_partial_buffer`**: replace the per-parameter `.copy_()` loop with `torch._foreach_copy_()` over batched destination/source lists — one kernel launch instead of O(params) launches.
- **`DBuffer.get_local_tensor`**: cache narrow/view results keyed by tensor index; invalidate on storage resize (release/reallocate). Views are stable within a buffer lifetime since storage is preserved on resize.
- **`FsdpModule`**: add nvtx ranges for the all-gather (unshard) and reduce-grad phases so M-FSDP v2 comm is visible in nsys traces.

## Notes

Split out of PR #6197; standalone (based on main, no dependency on the overlap PR).

## Test plan

- py_compile + isort pass
- M-FSDP v2 unit tests on the GB200 CI container (lyris)