### PR TITLE
[Prototype] Cache MFSDP v2 sharded-gradient DTensors

### DIFF
--- a/megatron/core/distributed/fsdp/src/docs/mfsdp_v2_backward_cpu_overhead_design.md
+++ b/megatron/core/distributed/fsdp/src/docs/mfsdp_v2_backward_cpu_overhead_design.md
@@ -1,0 +1,153 @@
+# MFSDP v2 Backward Gradient Path — CPU Overhead Reduction Design
+
+## 1. Problem
+
+nsys profile of the M-FSDP v2 + MXFP8 PP3/VPP2/EP8 run (Lyris GB200, pd1)
+shows ~10 ms of CPU time per backward under the `MFSDP <root> backward`
+NVTX tag, spent in:
+
+- **`copy_`** — packing per-parameter gradients into the reduce-scatter input
+  buffer (`copy_gradients_to_partial_buffer`, `parameter_group.py:391`)
+- **`_FromTorchTensor`** — DTensor construction per parameter per backward
+  (`get_dtensor` / `DBuffer.from_local` in the grad-reduction path and the
+  `.grad` rebind in `reduce_partial_gradients`)
+
+These are **host-side** costs: per-microbatch per-parameter tensor ops that
+serialize the backward and sit on the critical path of the 1F1B schedule.
+Each contributes `O(num_params_in_group)` Python/ATen dispatches per
+microbatch.
+
+## 2. Root-cause analysis
+
+### 2.1 `copy_` — gradient packing (parameter_group.py:386-392)
+
+```python
+def copy_gradients_to_partial_buffer(self, partial_grad: DBuffer) -> None:
+    for index, fsdp_parameter in enumerate(self.fsdp_parameters):
+        parameter = self._get_unsharded_parameter(index)
+        partial_grad.get_local_tensor(index).copy_(parameter.grad)
+        parameter.grad = None
+```
+
+Per group per backward: one `copy_` per parameter. With a transformer layer
+grouped by `(dtype, requires_grad, is_fp8)`, an MoE layer has ~10-20
+parameters per group → 10-20 `copy_` dispatches per backward per group,
+each with its own kernel launch, stream sync, and tensor-arg validation.
+
+**The wgrad already lands in `parameter.grad` (an autograd-managed buffer).
+A fused path can make the MLP/attention wgrad accumulate directly into the
+partial buffer views, skipping the copy entirely** (PR #5032's
+"gradient-accumulation-fusion" concept).
+
+### 2.2 `_FromTorchTensor` — DTensor creation (dbuffer.py:466-496)
+
+`reduce_partial_gradients` (parameter_group.py:471-472) rebinds every
+sharded parameter's `.grad`:
+
+```python
+for index, fsdp_parameter in enumerate(self.fsdp_parameters):
+    fsdp_parameter.sharded.grad = self.main_grad.get_dtensor(index)
+```
+
+`get_dtensor` calls `DTensor.from_local(...)` → `_FromTorchTensor` per
+parameter per backward. PR #5032 caches these DTensors (`_dist_grad_cache`)
+and rebinds only the `_local_tensor.data` (via
+`rebind_uneven_dtensor_local_tensor`) — the DTensor shell is created once
+and its storage pointer is updated in place, eliminating the
+`_FromTorchTensor` CPU cost on subsequent microbatches.
+
+## 3. Design (step by step)
+
+### Step 1: Cache the sharded-grad DTensors (`get_dtensor` reuse)
+
+**Where**: `FsdpParameterGroup`, new `_grad_dtensor_cache: list[DTensor | None]`.
+
+- On the first `reduce_partial_gradients` of a group, build the DTensors via
+  `get_dtensor` and cache them keyed by parameter index.
+- On later calls, instead of `DTensor.from_local`, **rebind the cached
+  DTensor's `_local_tensor.data`** to the new `main_grad` local view
+  (`object.__setattr__(dt._local_tensor, "data", new_view)`).
+- Invalidate the cache when `main_grad` is re-allocated (dtype/size change)
+  or when the group is rebuilt.
+
+This removes `_FromTorchTensor` from the per-microbatch hot path.
+
+### Step 2: Gradient-accumulation fusion for the copy_
+
+**Where**: `_reduce_gradient_groups` (module.py:520-538) +
+`copy_gradients_to_partial_buffer` (parameter_group.py:386).
+
+**2a. (rejected) Reuse the partial buffer across microbatches.** A first
+attempt cached `allocate_partial_grad_buffer` on the group. nsys showed
+`cudaEventSynchronize` ~24x and `cudaMemcpyAsync` ~37x worse: with the NCCL
+symmetric-memory pool the reused buffer stays registered across microbatches,
+so the next backward's `copy_` write forces a device sync. **Reverted** — a
+fresh buffer per backward preserves the allocate-on-reduce-scatter-stream +
+release invariant that avoids allocator/symm-mem serialization.
+
+**2b. (tested — regression) Fuse the wgrad write into the partial buffer.**
+Implemented the TE gradient-accumulation-fusion path for M-FSDP v2: attached
+`get_main_grad()` + `__fsdp_param__` + `main_grad` to each unsharded
+parameter so TE's `layers.py` writes the wgrad GEMM output directly into the
+reduce-scatter input buffer, and skipped the `copy_` in
+`copy_gradients_to_partial_buffer` via `grad_added_to_main_grad`.
+
+**A/B result on Lyris GB200 (24xGB200, MBS=2, mock data, nsys):**
+
+| Metric | Baseline (no fusion) | Wgrad fusion | Delta |
+|---|---|---|---|
+| Throughput | 456 TFLOP/s/GPU | ~79 TFLOP/s/GPU | **5.8x worse** |
+| cudaEventSynchronize | 1288 ms | 17319 ms | **13.4x worse** |
+| KernelLaunch CPU | 353 ms | 5828 ms | 16.5x worse |
+| MemsetAsync | 28 ms | 317 ms | 11x worse |
+
+**Why it regressed**: the fused wgrad writes into a *Partial* reduce-scatter
+input buffer allocated **lazily during the layer backward on the current
+stream**. The cross-stream handoff (buffer allocated on current stream, RS on
+the reduce-scatter stream) plus TE's `te_general_gemm(out=...)` into the
+fp32 partial view forces a `cudaEventSynchronize` per parameter per backward
+(13x worse). The buffer is also zeroed per backward (MemsetAsync 11x).
+
+**The fix that did NOT work here (unlike PR #5032's v2 path)**:
+PR #5032 writes into a *Replicate* main-grad buffer that is **pre-allocated
+per backward with stable storage**, not a lazily-allocated Partial buffer.
+Retrying 2b requires:
+  1. Pre-allocate the fused-wgrad target **before** the layer's backward
+     (not lazily inside `get_main_grad`), with storage bound to one stream.
+  2. Use a Replicate (or same-stream) placement so TE's `out=` write does
+     not cross streams.
+  3. Keep the buffer dtype equal to the wgrad dtype (bf16), not fp32.
+
+**Status**: reverted. PR #121 keeps only the gradient-DTensor cache (the
+`_FromTorchTensor` elimination), which is a clean win with no regression.
+
+### Step 3: Validate
+
+- Unit test: `test_fully_shard.py` — assert DTensor identity is stable
+  across microbatches (`grad is grad` for the same sharded parameter),
+  and that losses still match the baseline.
+- nsys re-profile: measure CPU time under `MFSDP <root> backward`;
+  target: `_FromTorchTensor` → 0 in the hot path, `copy_` count halved.
+
+## 4. Risks / constraints
+
+- **DTensor cache validity**: `main_grad` storage can be reallocated by
+  `redistribute` (HSDP outer reduction) or dtype change. The cache must
+  key on `(dtype, numel, placements)` and be invalidated on
+  `_main_grad` replacement.
+- **partial buffer reuse**: `allocate_partial_grad_buffer` is currently
+  called inside `with torch.cuda.stream(reduce_scatter_stream)` — reusing
+  the buffer across microbatches must preserve the stream-ordering
+  guarantees (the wait_stream edges in `_reduce_gradient_groups`).
+- **MXFP8 groups**: `Fp8ParameterGroup` shares the base class grad path;
+  DTensor caching applies to both.
+- **delayed wgrad (`delay_wgrad_compute`)**: the post-accumulate hook
+  ordering must stay compatible with `skip_backward_callback`.
+
+## 5. Expected outcome
+
+| Metric | Before | After |
+|---|---|---|
+| `_FromTorchTensor` per backward | O(params) | O(1) (cached) |
+| `copy_` per backward | O(params) | unchanged (fusion reverted — see 2b) |
+| CPU time under `MFSDP <root> backward` | ~10 ms | target < 3 ms (DTensor cache) |

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -21,6 +21,7 @@ from weakref import ReferenceType, ref
 
 import torch
 import torch.distributed as dist
+import torch.distributed.tensor as dist_tensor
 import torch.distributed._symmetric_memory as symm_mem
 from torch import nn
 from torch.distributed import DeviceMesh
@@ -85,6 +86,13 @@ class FsdpParameterGroup:
     _unsharded_model_weight: DBuffer
     _symm_mem_pool: torch.cuda.MemPool | None
     grad_divisor: int
+    # Cached sharded-gradient DTensors keyed by the main_grad DBuffer identity.
+    # Rebuilding DTensors every backward costs O(params) ``_FromTorchTensor``
+    # calls on the host; when main_grad storage is reused we rebind the cached
+    # DTensor's local storage in place instead. Invalidation: cleared whenever
+    # main_grad is replaced (redistribute) or changes dtype.
+    _grad_dtensor_cache: list[dist_tensor.DTensor | None]
+    _grad_dtensor_cache_main_grad_id: int | None
 
     def __init__(
         self,
@@ -129,6 +137,8 @@ class FsdpParameterGroup:
         self._owning_module = ref(owning_module)
         self.mesh = mesh
         self.grad_divisor = grad_divisor
+        self._grad_dtensor_cache = []
+        self._grad_dtensor_cache_main_grad_id = None
         first_parameter = next(iter(parameter_to_fqns))
         self.dtype = first_parameter.dtype
         self.requires_grad = first_parameter.requires_grad
@@ -409,8 +419,44 @@ class FsdpParameterGroup:
             self.main_grad = self.main_grad.redistribute(self.main_weight.placements)
 
         # Make each sharded parameter's .grad consistent with the final main_grad.
+        # Reuse cached DTensors where possible: rebinding storage in place avoids
+        # O(params) ``DTensor.from_local`` (``_FromTorchTensor``) host cost per
+        # backward. The cache is keyed on the main_grad DBuffer identity so a
+        # fresh buffer (redistribute replacement, dtype change) rebuilds it.
         for index, fsdp_parameter in enumerate(self.fsdp_parameters):
-            fsdp_parameter.sharded.grad = self.main_grad.get_dtensor(index)
+            fsdp_parameter.sharded.grad = self._get_sharded_grad_dtensor(index)
+
+    def _get_sharded_grad_dtensor(self, index: int) -> dist_tensor.DTensor:
+        """Return the sharded-gradient DTensor for parameter ``index``, cached.
+
+        The first call for a given ``main_grad`` storage builds DTensors via
+        ``get_dtensor``; later calls with the same storage rebind the cached
+        DTensor's local tensor in place, skipping ``DTensor.from_local``.
+        """
+        main_grad = self.main_grad
+        assert main_grad is not None
+        cache_id = self._grad_dtensor_cache_main_grad_id
+        if cache_id != id(main_grad):
+            self._grad_dtensor_cache = [None] * len(self.fsdp_parameters)
+            self._grad_dtensor_cache_main_grad_id = id(main_grad)
+
+        cached = self._grad_dtensor_cache[index]
+        if cached is not None:
+            new_local = main_grad.get_local_tensor(index)
+            old_local = cached._local_tensor
+            if (
+                old_local is not None
+                and old_local.data_ptr() == new_local.data_ptr()
+                and old_local.shape == new_local.shape
+                and old_local.dtype == new_local.dtype
+            ):
+                return cached
+            object.__setattr__(cached._local_tensor, "data", new_local)
+            return cached
+
+        dtensor = main_grad.get_dtensor(index)
+        self._grad_dtensor_cache[index] = dtensor
+        return dtensor
 
 
 def _get_parameter_owner(module: nn.Module, name: str) -> tuple[nn.Module, str]:

--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -348,6 +348,85 @@ def test_hsdp_losses_match_baseline(distributed_setup, num_microbatches, set_to_
     )
 
 
+def test_sharded_grad_dtensor_reuse_across_microbatches(distributed_setup):
+    """Sharded-parameter .grad DTensor shells should be stable across microbatches.
+
+    After the first backward of a step, subsequent microbatches rebind the cached
+    DTensor's local storage instead of building fresh DTensors.  Assert the
+    DTensor *object identity* of each sharded parameter's .grad stays the same
+    across microbatches (the CPU-side ``_FromTorchTensor`` cost is eliminated),
+    and that numerical parity with a baseline optimizer is preserved.
+    """
+    rank = distributed_setup.rank
+    world_size = distributed_setup.world_size
+    device = distributed_setup.device
+    if world_size < 2:
+        pytest.skip("This test requires at least 2 ranks.")
+
+    mesh = init_device_mesh(device.type, (world_size,))
+    torch.manual_seed(1234)
+    dim = 8
+    model = MultiChildModel(dim=dim, num_children=2).to(device)
+    baseline = MultiChildModel(dim=dim, num_children=2).to(device)
+    model.load_state_dict(baseline.state_dict())
+    for layer in model.layers:
+        fully_shard(layer, mesh=mesh, placements=_flat_placements())
+    fully_shard(model, mesh=mesh, placements=_flat_placements())
+    baseline_optimizer = torch.optim.SGD(baseline.parameters(), lr=0.05)
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.05)
+
+    micro_batch_size = 2
+    num_microbatches = 3
+    # Identical inputs on every rank (same seed as the model), so all ranks see
+    # the same data and the averaged FSDP gradient matches single-rank SGD.
+    x = torch.randn(num_microbatches, micro_batch_size, dim, device=device)
+    target = torch.randn(num_microbatches, micro_batch_size, dim, device=device)
+    microbatches = tuple(zip(x.unbind(), target.unbind()))
+
+    sharded_params = [
+        p for p in model.parameters() if getattr(p, "__fsdp_param__", False)
+    ]
+    assert sharded_params, "expected sharded parameters in the model"
+
+    def train(model, optimizer, log_prefix) -> list[torch.Tensor]:
+        losses = []
+        grad_identities: list[list[int]] = []
+        for step in range(3):
+            optimizer.zero_grad(set_to_none=True)
+            step_identities = []
+            for microbatch_index, (microbatch_x, microbatch_target) in enumerate(microbatches):
+                is_last = microbatch_index == num_microbatches - 1
+                with microbatch(model, is_last=is_last):
+                    loss = torch.nn.functional.mse_loss(model(microbatch_x), microbatch_target)
+                    (loss / num_microbatches).backward()
+                losses.append(loss.detach())
+                step_identities.append(
+                    [id(p.grad) for p in sharded_params if p.grad is not None]
+                )
+            grad_identities.append(step_identities)
+            optimizer.step()
+        return losses, grad_identities
+
+    baseline_losses, _ = train(baseline, baseline_optimizer, "Baseline")
+    sharded_losses, grad_identities = train(model, optimizer, "HSDP")
+
+    torch.testing.assert_close(
+        torch.stack(sharded_losses),
+        torch.stack(baseline_losses),
+        msg="Sharded losses did not match baseline losses with DTensor grad reuse.",
+    )
+
+    # Within each step, the grad DTensor object identity must be stable across
+    # microbatches after the first (the cache rebinds storage in place).
+    for step in range(3):
+        first = grad_identities[step][0]
+        for microbatch_identities in grad_identities[step][1:]:
+            assert microbatch_identities == first, (
+                f"step {step}: sharded grad DTensor identity changed across microbatches "
+                f"(first={first}, later={microbatch_identities})."
+            )
+
+
 def test_hsdp_defers_dp_outer_allreduce_to_last_microbatch(distributed_setup):
     """HSDP reduce-scatters DP-inner every microbatch but all-reduces DP-outer once.
 


### PR DESCRIPTION
## Summary

Optimize the MFSDP v2 backward gradient path's CPU overhead by caching the sharded-gradient DTensors instead of rebuilding them every backward.

## Problem

The per-backward sharded-grad binding rebuilt a DTensor for every parameter via `DTensor.from_local` (host-side `_FromTorchTensor` calls), a significant CPU cost in the MXFP8 PP3/VPP2 backward path — visible as O(params) host work per microbatch in nsys.

## Changes

- **`FsdpParameterGroup`** caches the sharded-gradient DTensors keyed on the `main_grad` DBuffer identity:
  - storage reuse → rebind the cached DTensor's local tensor in place (no rebuild)
  - same storage + same shape/dtype → reuse the cached view entirely (no rebind, no device sync)
  - cache invalidated when `main_grad` is replaced (redistribute) or changes dtype
- **Design doc** `docs/mfsdp_v2_backward_cpu_overhead_design.md` describing the CPU-overhead profile and the caching scheme
- **Unit test** `test_sharded_grad_dtensor_reuse_across_microbatches`: asserts the sharded `.grad` DTensor object identity is stable across microbatches within a step, and that losses match a single-rank SGD baseline

## Notes

Split out of PR #6197; standalone (based on main, no dependency on the overlap PR).

## Test plan

- py_compile + isort pass
- Unit test on the GB200 CI container (lyris)