### PR TITLE
fix(optimizer): support MFSDP v2 gradient clipping across dense and expert meshes

### DIFF
--- a/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
+++ b/megatron/core/distributed/fsdp/mcore_fsdp_adapter.py
@@ -636,6 +636,15 @@ class FullyShardedDataParallelV2(_BaseDataParallel):
         if not hasattr(pg_collection, 'dp_cp'):
             raise ValueError("MFSDP v2 requires an explicit dp_cp process group.")
 
+        if config.mtp_detach_heads:
+            # Detached MTP heads are tagged into a separate gradient-norm group, which
+            # the shared helpers reduce with get_grad_norm_fp32. That path derives a
+            # data-parallel group from the gradients' DTensor mesh and reduces over it
+            # in addition to the grad-stats group, double-counting for MFSDP v2 whose
+            # mesh already is the grad-stats group. Reject it rather than report a
+            # silently inflated norm.
+            raise ValueError("MFSDP v2 does not currently support mtp_detach_heads.")
+
         unsupported_parallelisms = [
             "tensor_model_parallel_size",
             "pipeline_model_parallel_size",

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -232,6 +232,8 @@ class FsdpParameterGroup:
             sharded_parameter = nn.Parameter(
                 self.main_weight.get_dtensor(index), requires_grad=parameter.requires_grad
             )
+            # Route optimizer gradient statistics through the FSDP local-shard path.
+            sharded_parameter.__fsdp_param__ = True
             if main_grad_dtype:
                 sharded_parameter.grad_dtype = main_grad_dtype
             setattr(sharded_parameter, _CONTAINING_PARAMETER_GROUP_ATTR, ref(self))

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/parameter_group.py
@@ -232,8 +232,6 @@ class FsdpParameterGroup:
             sharded_parameter = nn.Parameter(
                 self.main_weight.get_dtensor(index), requires_grad=parameter.requires_grad
             )
-            # Route optimizer gradient statistics through the FSDP local-shard path.
-            sharded_parameter.__fsdp_param__ = True
             if main_grad_dtype:
                 sharded_parameter.grad_dtype = main_grad_dtype
             setattr(sharded_parameter, _CONTAINING_PARAMETER_GROUP_ATTR, ref(self))

--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -676,7 +676,9 @@ def _get_megatron_optimizer_based_on_param_groups(
         optimizer = FullyShardedOptimizer(
             optimizer, config, grad_scaler, init_state_fn, model_chunks=model_chunks
         )
-        setattr(optimizer, 'grad_stats_parallel_group', data_parallel_group)
+        # get_grad_norm divides each rank's contribution by that gradient's replication
+        # factor, so summing it over every rank is correct by construction.
+        setattr(optimizer, 'grad_stats_parallel_group', torch.distributed.group.WORLD)
     elif config.fp16 or config.bf16:
         optimizer = Float16OptimizerWithFloat16Params(optimizer, config, grad_scaler, init_state_fn)
         setattr(optimizer, 'grad_stats_parallel_group', model_parallel_group)

--- a/megatron/core/optimizer/clip_grads.py
+++ b/megatron/core/optimizer/clip_grads.py
@@ -171,9 +171,10 @@ def clip_grad_by_total_norm_fp32(
                 grads.append(to_local_if_dtensor(param.decoupled_grad).detach())
         else:
             if param.grad is not None:
-                assert param.grad.type() == 'torch.cuda.FloatTensor'
+                local_grad = to_local_if_dtensor(param.grad)
+                assert local_grad.type() == 'torch.cuda.FloatTensor'
                 params.append(param)
-                grads.append(to_local_if_dtensor(param.grad).detach())
+                grads.append(local_grad.detach())
 
     # Scale.
     clip_coeff = max_norm / (total_norm + 1.0e-6)

--- a/megatron/core/optimizer/clip_grads.py
+++ b/megatron/core/optimizer/clip_grads.py
@@ -172,7 +172,7 @@ def clip_grad_by_total_norm_fp32(
         else:
             if param.grad is not None:
                 local_grad = to_local_if_dtensor(param.grad)
-                assert local_grad.type() == 'torch.cuda.FloatTensor'
+                assert local_grad.dtype in (torch.float32, torch.bfloat16)
                 params.append(param)
                 grads.append(local_grad.detach())
 

--- a/megatron/core/optimizer/clip_grads.py
+++ b/megatron/core/optimizer/clip_grads.py
@@ -171,10 +171,9 @@ def clip_grad_by_total_norm_fp32(
                 grads.append(to_local_if_dtensor(param.decoupled_grad).detach())
         else:
             if param.grad is not None:
-                local_grad = to_local_if_dtensor(param.grad)
-                assert local_grad.dtype in (torch.float32, torch.bfloat16)
+                assert param.grad.dtype in [torch.float32, torch.bfloat16]
                 params.append(param)
-                grads.append(local_grad.detach())
+                grads.append(to_local_if_dtensor(param.grad).detach())
 
     # Scale.
     clip_coeff = max_norm / (total_norm + 1.0e-6)

--- a/megatron/core/optimizer/fully_sharded_optimizer.py
+++ b/megatron/core/optimizer/fully_sharded_optimizer.py
@@ -19,6 +19,28 @@ from .optimizer import MixedPrecisionOptimizer
 from .optimizer_config import OptimizerConfig
 
 
+def count_replication(tensor: DTensor) -> int:
+    """Return how many ranks hold an identical copy of ``tensor``'s local shard.
+
+    A sharded mesh axis holds disjoint pieces that must all be counted; a replicated
+    axis holds identical copies that must be counted once, so a gradient statistic
+    summed over the grad-stats group has to divide by this.
+
+    MFSDP v2 gradients are always DTensors, so this takes one rather than accepting
+    a plain tensor and guessing a layout for it.
+    """
+    replication = 1
+    for axis, placement in enumerate(tensor.placements):
+        if placement.is_replicate():
+            replication *= tensor.device_mesh.size(axis)
+        elif placement.is_partial():
+            raise RuntimeError(
+                "MFSDP v2 gradient is still Partial when gradient statistics are taken; "
+                "the reduction must be finalized first."
+            )
+    return replication
+
+
 class FullyShardedOptimizer(MixedPrecisionOptimizer):
     """MCore optimizer wrapper for MFSDP-owned sharded parameters and gradients.
 
@@ -107,28 +129,6 @@ class FullyShardedOptimizer(MixedPrecisionOptimizer):
         """Build a sharded optimizer state dict."""
         raise NotImplementedError("MFSDP v2 optimizer checkpointing is not yet supported.")
 
-    @staticmethod
-    def count_replication(tensor: DTensor) -> int:
-        """Return how many ranks hold an identical copy of ``tensor``'s local shard.
-
-        A sharded mesh axis holds disjoint pieces that must all be counted; a replicated
-        axis holds identical copies that must be counted once, so a gradient statistic
-        summed over the grad-stats group has to divide by this.
-
-        MFSDP v2 gradients are always DTensors, so this takes one rather than accepting
-        a plain tensor and guessing a layout for it.
-        """
-        replication = 1
-        for axis, placement in enumerate(tensor.placements):
-            if placement.is_replicate():
-                replication *= tensor.device_mesh.size(axis)
-            elif placement.is_partial():
-                raise RuntimeError(
-                    "MFSDP v2 gradient is still Partial when gradient statistics are taken; "
-                    "the reduction must be finalized first."
-                )
-        return replication
-
     def get_grad_norm(self):
         """Compute the global gradient L2 norm from each gradient's own DTensor layout.
 
@@ -163,7 +163,7 @@ class FullyShardedOptimizer(MixedPrecisionOptimizer):
             grad = parameter.grad
             if grad is None:
                 continue
-            replication = self.count_replication(grad)
+            replication = count_replication(grad)
             local_grad = grad.to_local()
             if local_grad.numel():
                 total_norm_squared += local_grad.float().pow(2).sum() / replication
@@ -202,7 +202,7 @@ class FullyShardedOptimizer(MixedPrecisionOptimizer):
             grad = parameter.grad
             if grad is None:
                 continue
-            replication = self.count_replication(grad)
+            replication = count_replication(grad)
             local_grad = grad.to_local()
             if local_grad.numel():
                 zeros = local_grad.numel() - torch.count_nonzero(local_grad)

--- a/megatron/core/optimizer/fully_sharded_optimizer.py
+++ b/megatron/core/optimizer/fully_sharded_optimizer.py
@@ -2,7 +2,7 @@
 
 """MCore optimizer wrapper for experimental Megatron-FSDP v2."""
 
-from typing import Callable, List, Optional
+from typing import Callable, List, Optional, override
 
 import torch
 from torch.distributed.tensor import DTensor
@@ -51,6 +51,7 @@ class FullyShardedOptimizer(MixedPrecisionOptimizer):
     MFSDP-specific storage operations explicit.
     """
 
+    @override
     def __init__(
         self,
         optimizer: torch.optim.Optimizer,
@@ -107,6 +108,7 @@ class FullyShardedOptimizer(MixedPrecisionOptimizer):
                 "MFSDP v2 does not currently support layer-wise distributed optimizer."
             )
 
+    @override
     def state_dict(self):
         """Return optimizer state.
 
@@ -116,10 +118,12 @@ class FullyShardedOptimizer(MixedPrecisionOptimizer):
         """
         raise NotImplementedError("MFSDP v2 optimizer checkpointing is not yet supported.")
 
+    @override
     def load_state_dict(self, state_dict):
         """Load optimizer state."""
         raise NotImplementedError("MFSDP v2 optimizer checkpointing is not yet supported.")
 
+    @override
     def sharded_state_dict(
         self,
         model_sharded_state_dict: ShardedStateDict,
@@ -129,6 +133,7 @@ class FullyShardedOptimizer(MixedPrecisionOptimizer):
         """Build a sharded optimizer state dict."""
         raise NotImplementedError("MFSDP v2 optimizer checkpointing is not yet supported.")
 
+    @override
     def get_grad_norm(self):
         """Compute the global gradient L2 norm from each gradient's own DTensor layout.
 
@@ -175,6 +180,7 @@ class FullyShardedOptimizer(MixedPrecisionOptimizer):
         )
         return total_norm_squared.sqrt()
 
+    @override
     def get_grads_for_grad_norm(self, grad_norm_group: Optional[str] = None):
         """Return local gradient shards for the shared grad-norm helpers.
 
@@ -188,6 +194,7 @@ class FullyShardedOptimizer(MixedPrecisionOptimizer):
             to_local_if_dtensor(grad) for grad in super().get_grads_for_grad_norm(grad_norm_group)
         ]
 
+    @override
     def count_zeros(self) -> float:
         """Count zero gradient entries from each gradient's own DTensor layout.
 
@@ -215,6 +222,7 @@ class FullyShardedOptimizer(MixedPrecisionOptimizer):
         )
         return total_zeros.item()
 
+    @override
     def zero_grad(self, set_to_none: bool = True) -> None:
         """Clear optimizer-visible sharded grads and any grads filtered from local groups."""
         if not self.is_stub_optimizer:
@@ -244,6 +252,7 @@ class FullyShardedOptimizer(MixedPrecisionOptimizer):
             parameter.grad = original_grad.to(dtype=parameter.data.dtype)
             self._casted_grads.append((parameter, original_grad))
 
+    @override
     @torch.no_grad()
     def step_with_ready_grads(self) -> bool:
         """Step the optimizer and restore MFSDP gradient dtypes."""

--- a/megatron/core/optimizer/fully_sharded_optimizer.py
+++ b/megatron/core/optimizer/fully_sharded_optimizer.py
@@ -5,6 +5,7 @@
 from typing import Callable, List, Optional
 
 import torch
+from torch.distributed.tensor import DTensor
 
 from ..config_logger import has_config_logger_enabled, log_config_to_disk
 from ..dist_checkpointing.mapping import ShardedStateDict
@@ -130,9 +131,9 @@ class FullyShardedOptimizer(MixedPrecisionOptimizer):
         ``get_data_parallel_group_if_dtensor`` always sees plain tensors, returns None,
         and the layout is gone by the time the norm is taken.
         """
-        from torch.distributed.tensor import DTensor
-
-        total_sq = torch.zeros((), dtype=torch.float32, device=torch.cuda.current_device())
+        total_norm_squared = torch.zeros(
+            (), dtype=torch.float32, device=torch.cuda.current_device()
+        )
         for parameter in self.get_parameters():
             # MFSDP v2 reduces into parameter.grad; it never populates decoupled_grad,
             # which is a v1 param-and-grad-buffer concept.
@@ -149,18 +150,18 @@ class FullyShardedOptimizer(MixedPrecisionOptimizer):
                             "MFSDP v2 gradient is still Partial when the norm is taken; "
                             "the reduction must be finalized first."
                         )
-                local = grad.to_local()
+                local_grad = grad.to_local()
             else:
-                local = grad
-            if local.numel():
-                total_sq += local.float().pow(2).sum() / replication
+                local_grad = grad
+            if local_grad.numel():
+                total_norm_squared += local_grad.float().pow(2).sum() / replication
 
         torch.distributed.all_reduce(
-            total_sq,
+            total_norm_squared,
             op=torch.distributed.ReduceOp.SUM,
             group=self.get_grad_stats_parallel_group(),
         )
-        return total_sq.sqrt()
+        return total_norm_squared.sqrt()
 
     def zero_grad(self, set_to_none: bool = True) -> None:
         """Clear optimizer-visible sharded grads and any grads filtered from local groups."""

--- a/megatron/core/optimizer/fully_sharded_optimizer.py
+++ b/megatron/core/optimizer/fully_sharded_optimizer.py
@@ -148,11 +148,6 @@ class FullyShardedOptimizer(MixedPrecisionOptimizer):
         over the grad-stats group is then exact, because every shard is held by exactly
         one rank in that group.
 
-        No duplicate filtering is needed here. ``get_grad_norm_fp32``'s shared/TP/GTP
-        filters exist to count replicas once along the model-parallel axes, and MFSDP v2
-        rejects TP, PP and CP sizes above 1 (see ``mcore_fsdp_adapter``), so those axes
-        are trivial and every parameter is unique. Revisit if v2 gains TP composability.
-
         ``get_grad_norm_fp32`` cannot do this: ``get_main_grads_for_grad_norm``
         replaces each DTensor with ``grad._local_tensor`` before it runs, so
         ``get_data_parallel_group_if_dtensor`` always sees plain tensors, returns None,

--- a/megatron/core/optimizer/fully_sharded_optimizer.py
+++ b/megatron/core/optimizer/fully_sharded_optimizer.py
@@ -13,6 +13,7 @@ from ..distributed.fsdp.src.megatron_fsdp.experimental.parameter_group import (
     sync_model_weights_from_main_weights,
 )
 from ..transformer.module import MegatronModule
+from ..utils import to_local_if_dtensor
 from .grad_scaler import MegatronGradScaler
 from .optimizer import MixedPrecisionOptimizer
 from .optimizer_config import OptimizerConfig
@@ -106,6 +107,28 @@ class FullyShardedOptimizer(MixedPrecisionOptimizer):
         """Build a sharded optimizer state dict."""
         raise NotImplementedError("MFSDP v2 optimizer checkpointing is not yet supported.")
 
+    @staticmethod
+    def count_replication(tensor: DTensor) -> int:
+        """Return how many ranks hold an identical copy of ``tensor``'s local shard.
+
+        A sharded mesh axis holds disjoint pieces that must all be counted; a replicated
+        axis holds identical copies that must be counted once, so a gradient statistic
+        summed over the grad-stats group has to divide by this.
+
+        MFSDP v2 gradients are always DTensors, so this takes one rather than accepting
+        a plain tensor and guessing a layout for it.
+        """
+        replication = 1
+        for axis, placement in enumerate(tensor.placements):
+            if placement.is_replicate():
+                replication *= tensor.device_mesh.size(axis)
+            elif placement.is_partial():
+                raise RuntimeError(
+                    "MFSDP v2 gradient is still Partial when gradient statistics are taken; "
+                    "the reduction must be finalized first."
+                )
+        return replication
+
     def get_grad_norm(self):
         """Compute the global gradient L2 norm from each gradient's own DTensor layout.
 
@@ -140,19 +163,8 @@ class FullyShardedOptimizer(MixedPrecisionOptimizer):
             grad = parameter.grad
             if grad is None:
                 continue
-            replication = 1
-            if isinstance(grad, DTensor):
-                for axis, placement in enumerate(grad.placements):
-                    if placement.is_replicate():
-                        replication *= grad.device_mesh.size(axis)
-                    elif placement.is_partial():
-                        raise RuntimeError(
-                            "MFSDP v2 gradient is still Partial when the norm is taken; "
-                            "the reduction must be finalized first."
-                        )
-                local_grad = grad.to_local()
-            else:
-                local_grad = grad
+            replication = self.count_replication(grad)
+            local_grad = grad.to_local()
             if local_grad.numel():
                 total_norm_squared += local_grad.float().pow(2).sum() / replication
 
@@ -162,6 +174,46 @@ class FullyShardedOptimizer(MixedPrecisionOptimizer):
             group=self.get_grad_stats_parallel_group(),
         )
         return total_norm_squared.sqrt()
+
+    def get_grads_for_grad_norm(self, grad_norm_group: Optional[str] = None):
+        """Return local gradient shards for the shared grad-norm helpers.
+
+        The base implementation only unwraps a DTensor gradient when the parameter
+        carries ``__fsdp_param__``; otherwise the DTensor reaches ``get_grad_norm_fp32``,
+        which feeds every gradient to ``get_data_parallel_group_if_dtensor`` and asserts
+        they all share one device mesh. MFSDP v2 breaks that assumption, so unwrap here
+        instead of marking the parameters.
+        """
+        return [
+            to_local_if_dtensor(grad) for grad in super().get_grads_for_grad_norm(grad_norm_group)
+        ]
+
+    def count_zeros(self) -> float:
+        """Count zero gradient entries from each gradient's own DTensor layout.
+
+        ``count_zeros_fp32`` has the same single-mesh assumption as the grad-norm path,
+        and additionally rejects the combination of a Megatron-FSDP parameter with a
+        DTensor-derived data-parallel group. Counting here keeps MFSDP v2 off that path,
+        and matches how ``get_grad_norm`` reduces: each rank contributes its own shard,
+        divided by the size of any replicated mesh axis, summed over the grad-stats group.
+        """
+        total_zeros = torch.zeros((), dtype=torch.float32, device=torch.cuda.current_device())
+        for parameter in self.get_parameters():
+            grad = parameter.grad
+            if grad is None:
+                continue
+            replication = self.count_replication(grad)
+            local_grad = grad.to_local()
+            if local_grad.numel():
+                zeros = local_grad.numel() - torch.count_nonzero(local_grad)
+                total_zeros += zeros.float() / replication
+
+        torch.distributed.all_reduce(
+            total_zeros,
+            op=torch.distributed.ReduceOp.SUM,
+            group=self.get_grad_stats_parallel_group(),
+        )
+        return total_zeros.item()
 
     def zero_grad(self, set_to_none: bool = True) -> None:
         """Clear optimizer-visible sharded grads and any grads filtered from local groups."""

--- a/megatron/core/optimizer/fully_sharded_optimizer.py
+++ b/megatron/core/optimizer/fully_sharded_optimizer.py
@@ -105,6 +105,63 @@ class FullyShardedOptimizer(MixedPrecisionOptimizer):
         """Build a sharded optimizer state dict."""
         raise NotImplementedError("MFSDP v2 optimizer checkpointing is not yet supported.")
 
+    def get_grad_norm(self):
+        """Compute the global gradient L2 norm from each gradient's own DTensor layout.
+
+        MFSDP v2 gradients are DTensors that record how they are distributed, and the
+        dense and expert gradients do not share a device mesh: with EP=2 over eight
+        ranks the dense gradients live on all eight while the expert gradients live on
+        the four-rank expert-DP stripe. Reading the layout off each gradient keeps the
+        norm correct without assuming a single mesh for all of them.
+
+        Each rank contributes ``||local||^2`` divided by the product of its replicated
+        mesh-axis sizes. A sharded axis holds disjoint pieces that must all be added; a
+        replicated axis holds identical copies that must be counted once. Summing that
+        over the grad-stats group is then exact, because every shard is held by exactly
+        one rank in that group.
+
+        No duplicate filtering is needed here. ``get_grad_norm_fp32``'s shared/TP/GTP
+        filters exist to count replicas once along the model-parallel axes, and MFSDP v2
+        rejects TP, PP and CP sizes above 1 (see ``mcore_fsdp_adapter``), so those axes
+        are trivial and every parameter is unique. Revisit if v2 gains TP composability.
+
+        ``get_grad_norm_fp32`` cannot do this: ``get_main_grads_for_grad_norm``
+        replaces each DTensor with ``grad._local_tensor`` before it runs, so
+        ``get_data_parallel_group_if_dtensor`` always sees plain tensors, returns None,
+        and the layout is gone by the time the norm is taken.
+        """
+        from torch.distributed.tensor import DTensor
+
+        total_sq = torch.zeros((), dtype=torch.float32, device=torch.cuda.current_device())
+        for parameter in self.get_parameters():
+            # MFSDP v2 reduces into parameter.grad; it never populates decoupled_grad,
+            # which is a v1 param-and-grad-buffer concept.
+            grad = parameter.grad
+            if grad is None:
+                continue
+            replication = 1
+            if isinstance(grad, DTensor):
+                for axis, placement in enumerate(grad.placements):
+                    if placement.is_replicate():
+                        replication *= grad.device_mesh.size(axis)
+                    elif placement.is_partial():
+                        raise RuntimeError(
+                            "MFSDP v2 gradient is still Partial when the norm is taken; "
+                            "the reduction must be finalized first."
+                        )
+                local = grad.to_local()
+            else:
+                local = grad
+            if local.numel():
+                total_sq += local.float().pow(2).sum() / replication
+
+        torch.distributed.all_reduce(
+            total_sq,
+            op=torch.distributed.ReduceOp.SUM,
+            group=self.get_grad_stats_parallel_group(),
+        )
+        return total_sq.sqrt()
+
     def zero_grad(self, set_to_none: bool = True) -> None:
         """Clear optimizer-visible sharded grads and any grads filtered from local groups."""
         if not self.is_stub_optimizer:

--- a/megatron/core/optimizer/fully_sharded_optimizer.py
+++ b/megatron/core/optimizer/fully_sharded_optimizer.py
@@ -169,7 +169,7 @@ class FullyShardedOptimizer(MixedPrecisionOptimizer):
                 continue
             replication = count_replication(grad)
             local_grad = grad.to_local()
-            if local_grad.numel():
+            if local_grad.numel() > 0:
                 total_norm_squared += local_grad.float().pow(2).sum() / replication
 
         torch.distributed.all_reduce(
@@ -196,7 +196,7 @@ class FullyShardedOptimizer(MixedPrecisionOptimizer):
                 continue
             replication = count_replication(grad)
             local_grad = grad.to_local()
-            if local_grad.numel():
+            if local_grad.numel() > 0:
                 zeros = local_grad.numel() - torch.count_nonzero(local_grad)
                 total_zeros += zeros.float() / replication
 

--- a/megatron/core/optimizer/fully_sharded_optimizer.py
+++ b/megatron/core/optimizer/fully_sharded_optimizer.py
@@ -13,7 +13,6 @@ from ..distributed.fsdp.src.megatron_fsdp.experimental.parameter_group import (
     sync_model_weights_from_main_weights,
 )
 from ..transformer.module import MegatronModule
-from ..utils import to_local_if_dtensor
 from .grad_scaler import MegatronGradScaler
 from .optimizer import MixedPrecisionOptimizer
 from .optimizer_config import OptimizerConfig
@@ -179,20 +178,6 @@ class FullyShardedOptimizer(MixedPrecisionOptimizer):
             group=self.get_grad_stats_parallel_group(),
         )
         return total_norm_squared.sqrt()
-
-    @override
-    def get_grads_for_grad_norm(self, grad_norm_group: Optional[str] = None):
-        """Return local gradient shards for the shared grad-norm helpers.
-
-        The base implementation only unwraps a DTensor gradient when the parameter
-        carries ``__fsdp_param__``; otherwise the DTensor reaches ``get_grad_norm_fp32``,
-        which feeds every gradient to ``get_data_parallel_group_if_dtensor`` and asserts
-        they all share one device mesh. MFSDP v2 breaks that assumption, so unwrap here
-        instead of marking the parameters.
-        """
-        return [
-            to_local_if_dtensor(grad) for grad in super().get_grads_for_grad_norm(grad_norm_group)
-        ]
 
     @override
     def count_zeros(self) -> float:

--- a/megatron/core/optimizer/optimizer.py
+++ b/megatron/core/optimizer/optimizer.py
@@ -379,13 +379,11 @@ class MegatronOptimizer(ABC):
         """
         self.grad_norms_by_group = {}
         params = self.get_parameters()
-        if params:
-            grads_for_norm = self.get_grads_for_grad_norm()
-        else:
-            grads_for_norm = []
-        grad_norm = get_grad_norm_fp32(
-            grads_for_norm, grad_stats_parallel_group=self.get_grad_stats_parallel_group()
-        )
+        # Go through get_grad_norm() so a subclass that computes the norm differently
+        # clips by the value it reports. The base implementation is unchanged. Called
+        # unconditionally: it reduces over the grad-stats group even with no local
+        # parameters, and skipping it on a param-less rank would strand the others.
+        grad_norm = self.get_grad_norm()
 
         if clip_grad > 0.0 and params:
             # Only reduce group grad norms when clipping can use them.

--- a/megatron/core/optimizer/optimizer.py
+++ b/megatron/core/optimizer/optimizer.py
@@ -378,13 +378,9 @@ class MegatronOptimizer(ABC):
         norm and clipped independently using their group norm.
         """
         self.grad_norms_by_group = {}
-        params = self.get_parameters()
-        # Go through get_grad_norm() so a subclass that computes the norm differently
-        # clips by the value it reports. The base implementation is unchanged. Called
-        # unconditionally: it reduces over the grad-stats group even with no local
-        # parameters, and skipping it on a param-less rank would strand the others.
         grad_norm = self.get_grad_norm()
 
+        params = self.get_parameters()
         if clip_grad > 0.0 and params:
             # Only reduce group grad norms when clipping can use them.
             self._compute_grad_norms_by_group()

--- a/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
@@ -523,9 +523,9 @@ class TestMcoreAdapterExpertParallel:
             reference_loss.backward()
             reference_success, reference_pre_clip_norm, _ = reference_optimizer.step()
             assert reference_success
-            assert reference_pre_clip_norm > optimizer_config.clip_grad, (
-                "Reference gradients must exceed the clipping threshold to exercise clipping."
-            )
+            assert (
+                reference_pre_clip_norm > optimizer_config.clip_grad
+            ), "Reference gradients must exceed the clipping threshold to exercise clipping."
             reference_losses.append(reference_loss.detach())
 
         losses = []

--- a/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
@@ -415,8 +415,8 @@ class TestMcoreAdapterExpertParallel:
         torch.distributed.destroy_process_group(self.reference_group)
         Utils.destroy_model_parallel()
 
-    def test_build_train_and_step(self):
-        """Shard experts over expert-DP and dense parameters over full DP."""
+    def test_build_train_step_and_clip(self):
+        """Shard experts over expert-DP and clip their combined gradients."""
         # The in-process EP=1 reference needs rank-invariant initialization. GPU expert
         # initialization instead uses the globally configured EP=2 rank in its RNG seed.
         config = TransformerConfig(
@@ -491,7 +491,7 @@ class TestMcoreAdapterExpertParallel:
         assert isinstance(model.module.decoder.layers[1].mlp.experts, FsdpModule)
 
         optimizer_config = OptimizerConfig(
-            lr=1.0e-3, weight_decay=0.0, use_distributed_optimizer=False, clip_grad=0.0
+            lr=1.0e-3, weight_decay=0.0, use_distributed_optimizer=False, clip_grad=1.0e-4
         )
         reference_optimizer = get_megatron_optimizer(
             optimizer_config, [reference_model], use_gloo_process_groups=False
@@ -521,8 +521,11 @@ class TestMcoreAdapterExpertParallel:
                 targets,
             )
             reference_loss.backward()
-            reference_success, _, _ = reference_optimizer.step()
+            reference_success, reference_pre_clip_norm, _ = reference_optimizer.step()
             assert reference_success
+            assert reference_pre_clip_norm > optimizer_config.clip_grad, (
+                "Reference gradients must exceed the clipping threshold to exercise clipping."
+            )
             reference_losses.append(reference_loss.detach())
 
         losses = []

--- a/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
@@ -312,6 +312,18 @@ class TestMcoreAdapterDense:
         assert success
 
     def test_gradient_clipping_reaches_global_norm(self):
+        """MFSDP v2 reports the true global gradient norm and clips the update to it.
+
+        Clipping is measured through the optimizer update rather than through
+        parameter.grad after the step. _copy_model_grads_to_main_grads installs a
+        dtype-cast copy of each gradient, clip_grad_norm scales that copy, and
+        step_with_ready_grads restores the original afterwards, so the post-step
+        gradient is unclipped by design. Plain SGD at lr=1.0 makes the weight delta
+        exactly the gradient the optimizer stepped with, which keeps this test on the
+        default FP32-main-weight / BF16-gradient configuration.
+        """
+        clip_grad = 1.0
+        learning_rate = 1.0
         config = TransformerConfig(
             num_layers=2,
             hidden_size=16,
@@ -335,23 +347,21 @@ class TestMcoreAdapterDense:
         )
         optimizer = get_megatron_optimizer(
             OptimizerConfig(
-                optimizer="adam",
-                lr=1.0e-3,
+                optimizer="sgd",
+                lr=learning_rate,
                 weight_decay=0.0,
                 bf16=True,
                 params_dtype=torch.bfloat16,
                 use_distributed_optimizer=False,
-                clip_grad=1.0,
+                clip_grad=clip_grad,
             ),
             [model],
         )
 
-        def global_grad_norm() -> float:
+        def global_norm(local_tensors) -> float:
             squared_norm = torch.zeros(1, dtype=torch.float32, device="cuda")
-            for parameter in optimizer.get_parameters():
-                if parameter.grad is not None:
-                    assert isinstance(parameter.grad, DTensor)
-                    squared_norm += parameter.grad.to_local().float().square().sum()
+            for local_tensor in local_tensors:
+                squared_norm += local_tensor.float().square().sum()
             torch.distributed.all_reduce(squared_norm)
             return squared_norm.sqrt().item()
 
@@ -367,17 +377,25 @@ class TestMcoreAdapterDense:
         )
         output.float().square().sum().backward()
 
-        clip_grad = optimizer.config.clip_grad
-        expected_pre_clip_norm = global_grad_norm()
+        parameters = [
+            parameter for parameter in optimizer.get_parameters() if parameter.grad is not None
+        ]
+        assert all(isinstance(parameter.grad, DTensor) for parameter in parameters)
+        expected_pre_clip_norm = global_norm([p.grad.to_local() for p in parameters])
+        weights_before = [p.data.to_local().float().clone() for p in parameters]
+
         success, pre_clip_norm, _ = optimizer.step()
-        post_clip_norm = global_grad_norm()
+        updates = [
+            before - parameter.data.to_local().float()
+            for parameter, before in zip(parameters, weights_before)
+        ]
 
         assert success
         torch.testing.assert_close(pre_clip_norm.item(), expected_pre_clip_norm)
         assert (
             expected_pre_clip_norm > clip_grad
         ), "Test gradients must exceed the clipping threshold to exercise clipping."
-        torch.testing.assert_close(post_clip_norm, clip_grad, rtol=1e-3, atol=0)
+        torch.testing.assert_close(global_norm(updates), clip_grad, rtol=1e-3, atol=0)
 
 
 class TestMcoreAdapterExpertParallel:

--- a/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
@@ -357,11 +357,11 @@ class TestMcoreAdapterDense:
 
         optimizer.zero_grad(set_to_none=True)
         output = model(
-            hidden_states=torch.full(
-                (8, 2, config.hidden_size),
-                fill_value=torch.distributed.get_rank() + 1,
-                device="cuda",
-                dtype=torch.bfloat16,
+            hidden_states=(
+                torch.arange(1, config.hidden_size + 1, device="cuda", dtype=torch.bfloat16)
+                .view(1, 1, -1)
+                .expand(8, 2, -1)
+                * (torch.distributed.get_rank() + 1)
             ),
             attention_mask=None,
         )
@@ -373,11 +373,11 @@ class TestMcoreAdapterDense:
         post_clip_norm = global_grad_norm()
 
         assert success
-        torch.testing.assert_close(pre_clip_norm, expected_pre_clip_norm)
+        torch.testing.assert_close(pre_clip_norm.item(), expected_pre_clip_norm)
         assert (
             expected_pre_clip_norm > clip_grad
         ), "Test gradients must exceed the clipping threshold to exercise clipping."
-        torch.testing.assert_close(post_clip_norm, clip_grad)
+        torch.testing.assert_close(post_clip_norm, clip_grad, rtol=1e-3, atol=0)
 
 
 class TestMcoreAdapterExpertParallel:

--- a/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
@@ -8,6 +8,7 @@ from dataclasses import replace
 
 import pytest
 import torch
+from torch.distributed.tensor import DTensor
 
 import megatron.core.distributed.fsdp.mcore_fsdp_adapter as mcore_fsdp_adapter
 from megatron.core.distributed import DistributedDataParallelConfig
@@ -309,6 +310,74 @@ class TestMcoreAdapterDense:
 
         success, _, _ = optimizer.step()
         assert success
+
+    def test_gradient_clipping_reaches_global_norm(self):
+        config = TransformerConfig(
+            num_layers=2,
+            hidden_size=16,
+            num_attention_heads=4,
+            ffn_hidden_size=32,
+            bf16=True,
+            params_dtype=torch.bfloat16,
+            attention_dropout=0.0,
+            hidden_dropout=0.0,
+        )
+        model = FullyShardedDataParallel(
+            config=config,
+            ddp_config=DistributedDataParallelConfig(
+                use_megatron_fsdp=True,
+                megatron_fsdp_version=2,
+                use_distributed_optimizer=False,
+                data_parallel_sharding_strategy="optim_grads_params",
+            ),
+            module=_build_block(config),
+            pg_collection=self.pg_collection,
+        )
+        optimizer = get_megatron_optimizer(
+            OptimizerConfig(
+                optimizer="adam",
+                lr=1.0e-3,
+                weight_decay=0.0,
+                bf16=True,
+                params_dtype=torch.bfloat16,
+                use_distributed_optimizer=False,
+                clip_grad=1.0,
+            ),
+            [model],
+        )
+
+        def global_grad_norm() -> float:
+            squared_norm = torch.zeros(1, dtype=torch.float32, device="cuda")
+            for parameter in optimizer.get_parameters():
+                if parameter.grad is not None:
+                    assert isinstance(parameter.grad, DTensor)
+                    squared_norm += parameter.grad.to_local().float().square().sum()
+            torch.distributed.all_reduce(squared_norm)
+            return squared_norm.sqrt().item()
+
+        optimizer.zero_grad(set_to_none=True)
+        output = model(
+            hidden_states=torch.full(
+                (8, 2, config.hidden_size),
+                fill_value=torch.distributed.get_rank() + 1,
+                device="cuda",
+                dtype=torch.bfloat16,
+            ),
+            attention_mask=None,
+        )
+        output.float().square().sum().backward()
+
+        clip_grad = optimizer.config.clip_grad
+        expected_pre_clip_norm = global_grad_norm()
+        success, pre_clip_norm, _ = optimizer.step()
+        post_clip_norm = global_grad_norm()
+
+        assert success
+        torch.testing.assert_close(pre_clip_norm, expected_pre_clip_norm)
+        assert (
+            expected_pre_clip_norm > clip_grad
+        ), "Test gradients must exceed the clipping threshold to exercise clipping."
+        torch.testing.assert_close(post_clip_norm, clip_grad)
 
 
 class TestMcoreAdapterExpertParallel:

--- a/tests/unit_tests/test_optimizer.py
+++ b/tests/unit_tests/test_optimizer.py
@@ -646,6 +646,7 @@ def test_mtp_grad_clipping_uses_separate_norms():
     class MockOptimizer:
         _filter_grads_for_norm = MegatronOptimizer._filter_grads_for_norm
         get_grads_for_grad_norm = MegatronOptimizer.get_grads_for_grad_norm
+        get_grad_norm = MegatronOptimizer.get_grad_norm
         get_grad_stats_parallel_group = MegatronOptimizer.get_grad_stats_parallel_group
         has_grad_norm_group = MegatronOptimizer.has_grad_norm_group
         _compute_grad_norms_by_group = MegatronOptimizer._compute_grad_norms_by_group


### PR DESCRIPTION
## Summary

MFSDP v2 gradients are DTensors, and dense and expert gradients do not share a device
mesh: with EP=2 over eight ranks the dense gradients span all eight while the expert
gradients span the four-rank expert-DP stripe. The shared gradient-statistics helpers
assume a single mesh, so `FullyShardedOptimizer` computes its own statistics from each
gradient's placements.

- `clip_grads.py`: accept BF16 DTensor gradients in the FP32 clipping assert.
- `optimizer.py`: route `clip_grad_norm` through `self.get_grad_norm()` so a subclass
  clips by the norm it reports. The base implementation is unchanged.
- `optimizer/__init__.py`: reduce MFSDP v2 gradient statistics over the world group.
  `get_grad_norm` divides each contribution by its replication factor, so summing over
  every rank is correct by construction. Inert today, since the two groups coincide.
- `fully_sharded_optimizer.py`: override `get_grad_norm` and `count_zeros`, and drop the
  `__fsdp_param__` marker.
- `mcore_fsdp_adapter.py`: reject `mtp_detach_heads`. Behavior change — that config
  previously trained, with the silently inflated group norm described below.
- tests: dense and expert-parallel clipping coverage.

## Why override `get_grad_norm` instead of inheriting it

The inherited path ends in `get_grad_norm_fp32`, which needs local tensors. Given
DTensors it asserts they all share one device mesh — dense and expert do not, so EP
fails outright — and when it does find a mesh group it reduces over that group *in
addition to* the grad-stats group. For MFSDP v2 those are the same group, so the squared
norm is summed twice and the reported norm is inflated by `sqrt(world_size)`, silently.

That unwrapping previously depended on the `__fsdp_param__` marker — a side channel,
and one more thing to keep in sync. Reading each gradient's `placements` drops both the
marker and the single-mesh assumption, and divides out replicated axes instead of
double-counting them (inert today; it matters under HSDP).

## Validation

On 8 GPUs:

| Suite | Result |
| --- | --- |
| `distributed/mfsdp_v2/` | 113 passed |
| `test_optimizer.py` | 33 passed, 35 skipped |

`black`, `isort` and `pylint` clean at the versions CI pins.

The world-group commit came after those runs and was checked separately on 4 ranks
(`test_optimizer` 2 passed, `test_mcore_adapter` 7 passed). Note that no test can
distinguish the two groups today: MFSDP v2 rejects tensor, pipeline and context
parallelism, so the data-parallel group already spans the world.