### PR TITLE
Derive LayerWise parameter-gather overlap from DDP

### DIFF
--- a/megatron/core/optimizer/layer_wise_optimizer.py
+++ b/megatron/core/optimizer/layer_wise_optimizer.py
@@ -519,6 +519,16 @@ class LayerWiseDistributedOptimizer(ChainedOptimizer):
 
         self.pg_collection = pg_collection
 
+        # DDP owns the parameter-gather schedule, so derive the overlap policy from
+        # the wrapped model chunks just like DistributedOptimizer does.  The
+        # OptimizerConfig value can differ across modules that use distinct DDP
+        # configurations (for example, heterogeneous models).
+        self.ddp_config = None
+        if model_chunks:
+            self.ddp_config = model_chunks[0].ddp_config
+            for model_chunk in model_chunks:
+                assert self.ddp_config == model_chunk.ddp_config
+
         # The data-parallel groups this optimizer shards parameters over. Cached here so the
         # sharding, all-gather and broadcast paths read one attribute instead of reaching back
         # into pg_collection at every use.
@@ -557,8 +567,13 @@ class LayerWiseDistributedOptimizer(ChainedOptimizer):
         # path.
         self.use_buffer_param_sync = full_param_layouts is not None
 
-        # Set up overlap param gather using DDP bucket infrastructure.
-        self.overlap_param_gather = config.overlap_param_gather
+        # Set up overlap param gather using DDP bucket infrastructure. Fall back
+        # to OptimizerConfig only for direct legacy construction without model chunks.
+        self.overlap_param_gather = (
+            self.ddp_config.overlap_param_gather
+            if self.ddp_config is not None
+            else config.overlap_param_gather
+        )
         if self.overlap_param_gather and not self.use_buffer_param_sync:
             # Legacy path: set up per-bucket param lists for variable-size all-gather.
             # When use_buffer_param_sync is True, the standard distributed optimizer

--- a/tests/unit_tests/test_layer_wise_optimizer.py
+++ b/tests/unit_tests/test_layer_wise_optimizer.py
@@ -153,6 +153,7 @@ class TestLayerWiseOptimizer:
         model_kwargs=None,
         copy_from=None,
         overlap_param_gather=True,
+        optimizer_overlap_param_gather=None,
         grad_reduce_in_fp32=False,
         bucket_size=None,
         use_param_layout=False,
@@ -169,6 +170,8 @@ class TestLayerWiseOptimizer:
             model_kwargs: Optional kwargs for model initialization
             copy_from: Optional DDP model to copy weights from
             overlap_param_gather: If True, defer param all-gather to bucket infrastructure
+            optimizer_overlap_param_gather: Optional conflicting OptimizerConfig value used to
+                verify that the DDP config remains authoritative. Defaults to the DDP value.
             grad_reduce_in_fp32: If True, reduce grads in fp32 (regression test for dtype fix)
             bucket_size: Maximum number of parameters per bucket (None = single bucket)
             use_param_layout: If True, supply DDP a precomputed shard-aligned
@@ -220,6 +223,9 @@ class TestLayerWiseOptimizer:
         else:
             model.broadcast_params()
 
+        if optimizer_overlap_param_gather is None:
+            optimizer_overlap_param_gather = overlap_param_gather
+
         optimizer_config = OptimizerConfig(
             optimizer='muon',
             lr=0.01,
@@ -227,7 +233,7 @@ class TestLayerWiseOptimizer:
             bf16=True,
             use_distributed_optimizer=False,
             clip_grad=clip_grad,
-            overlap_param_gather=overlap_param_gather,
+            overlap_param_gather=optimizer_overlap_param_gather,
             muon_tp_mode="duplicated",
             use_layer_wise_distributed_optimizer=True,
         )
@@ -581,6 +587,33 @@ class TestLayerWiseOptimizer:
             torch.testing.assert_close(param.data, ref_param.data, rtol=0, atol=0)
 
     # ---- Overlap-param-gather tests ----
+
+    @pytest.mark.parametrize('use_param_layout', [False, True])
+    @pytest.mark.parametrize(
+        ('ddp_overlap_param_gather', 'optimizer_overlap_param_gather'),
+        [(False, True), (True, False)],
+    )
+    def test_overlap_param_gather_follows_ddp_config(
+        self, use_param_layout, ddp_overlap_param_gather, optimizer_overlap_param_gather
+    ):
+        """DDP's per-model overlap policy must override the global optimizer value."""
+        model, optimizer, _ = self.create_model_and_optimizer_with_overlap_param_gather(
+            overlap_param_gather=ddp_overlap_param_gather,
+            optimizer_overlap_param_gather=optimizer_overlap_param_gather,
+            use_param_layout=use_param_layout,
+        )
+
+        layer_wise_optimizer = next(
+            (
+                sub_optimizer
+                for sub_optimizer in getattr(optimizer, 'chained_optimizers', [optimizer])
+                if isinstance(sub_optimizer, LayerWiseDistributedOptimizer)
+            ),
+            optimizer,
+        )
+
+        assert layer_wise_optimizer.ddp_config is model.ddp_config
+        assert layer_wise_optimizer.overlap_param_gather == ddp_overlap_param_gather
 
     @pytest.mark.parametrize('use_param_layout', [False, True])
     def test_overlap_param_gather_basic(self, use_param_layout):


### PR DESCRIPTION
## What changed

- Derive `LayerWiseDistributedOptimizer.overlap_param_gather` from the wrapped model chunks' DDP config, matching `DistributedOptimizer`.
- Validate that all model chunks handled by one LayerWise optimizer share the same DDP config.
- Add regression coverage where DDP and `OptimizerConfig` deliberately disagree in both directions, for legacy and full parameter layouts.

## Why

DDP owns the parameter-gather bucket lifecycle. Reading the global optimizer flag could make LayerWise skip a required eager gather, or gather eagerly while DDP expected forward-prehook overlap, when module-specific DDP settings differed from the optimizer config.

## Validation

- `python3 -m py_compile megatron/core/optimizer/layer_wise_optimizer.py tests/unit_tests/test_layer_wise_optimizer.py`
- `isort --check-only` on both changed files
- `black==26.3.0 --check` on both changed files
- `ruff check` on both changed files
- `git diff --check`

The distributed regression requires the repository's 8-GPU unit-test runner and is left to CI; this macOS host has no CUDA/PyTorch test environment.