### PR TITLE
test(fsdp): mark default overlap check flaky

### DIFF
--- a/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py
@@ -594,7 +594,20 @@ def test_root_backward_returns_to_resting_memory(distributed_setup):
     )
 
 
-@pytest.mark.parametrize("use_symmetric_memory", [False, True], ids=["default", "symmetric_memory"])
+@pytest.mark.parametrize(
+    "use_symmetric_memory",
+    [
+        # Both variants' all-gathers are launch-timing sensitive, but default-CTA
+        # kernels occupy more compute CTAs, making the profiler overlap count less
+        # stable across ranks (see
+        # https://github.com/NVIDIA/Megatron-LM/actions/runs/31615942188).
+        # The symmetric-memory variant uses zero-CTA all-gather kernels, so its overlap
+        # measurement is more stable and remains enabled.
+        pytest.param(False, marks=(pytest.mark.flaky, pytest.mark.flaky_in_dev)),
+        pytest.param(True),
+    ],
+    ids=["default", "symmetric_memory"],
+)
 def test_overlaps_communication_and_compute(distributed_setup, use_symmetric_memory):
     """Forward and backward communication should overlap GEMM compute."""
     world_size = distributed_setup.world_size


### PR DESCRIPTION
## Summary

Mark the default-CTA all-gather overlap parameter of the MFSDP v2 profiler test as `flaky` and `flaky_in_dev`.

The default all-gather overlap count is launch-timing sensitive across ranks: a merge-queue run observed 5/8 overlaps on seven of eight ranks despite a threshold of six. The symmetric-memory parameter remains enabled because its zero-CTA symmetric-memory all-gather kernels provide a more stable overlap measurement.

## Validation

- `python -m pytest --collect-only -q -m "not flaky and not flaky_in_dev" tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py -k overlaps_communication_and_compute`
  - Collected only the `symmetric_memory` parameter.