### PR TITLE
Add CPU offloading path for MoE routed experts

### DIFF
--- a/megatron/core/distributed/distributed_data_parallel.py
+++ b/megatron/core/distributed/distributed_data_parallel.py
@@ -373,6 +373,18 @@ class DistributedDataParallel(_BaseDataParallel):
                                         self._make_backward_post_hook(param)
                                     )
                                     break
+                elif getattr(param, 'is_cpu_offloaded_expert', False) and getattr(
+                    param, 'skip_backward_post_hook', False
+                ):
+                    # for offloaded expert params, gradient is handled manually in backward()
+                    for module in self.module.modules():
+                        if hasattr(module, "register_wgrad_accumulation_and_reduce_hooks"):
+                            for param_value in module.parameters():
+                                if param is param_value:
+                                    module.register_wgrad_accumulation_and_reduce_hooks(
+                                        self._make_backward_post_hook(param)
+                                    )
+                                    break
                 else:
                     # Expand so we get access to grad_fn.
                     param_tmp = param.expand_as(param)

--- a/megatron/core/distributed/param_and_grad_buffer.py
+++ b/megatron/core/distributed/param_and_grad_buffer.py
@@ -66,6 +66,11 @@ class BufferType(Enum):
     GRAD = 2
 
 
+# Peak GPU memory allowed for staging one host-resident param bucket through its all-gather
+# (see _ParamAndGradBucketGroup._all_gather_cpu_param_bucket).
+_CPU_PARAM_GATHER_STAGING_BYTES = 512 * 1024 * 1024
+
+
 def shard_buffer(buffer: torch.Tensor, data_parallel_world_size: int):
     """
     Shard buffer into data_parallel_world_size chunks of equal size.
@@ -200,6 +205,16 @@ class _ParamAndGradBucketGroup:
     ):
         self.buckets = buckets
         self.ddp_config = ddp_config
+
+        # MoE expert offloading keeps some param buffers in pinned host memory. NCCL cannot
+        # gather into host memory, so those buckets are excluded from the coalescing manager
+        # in start_param_sync and gathered separately. The set is fixed for the lifetime of
+        # the group, so resolve it once here rather than re-testing on every param sync.
+        self.cpu_bucket_indices = [
+            i
+            for i, bucket in enumerate(self.buckets)
+            if bucket.param_data is not None and bucket.param_data.device.type == "cpu"
+        ]
 
         # overlap_param_gather covers the layer-wise optimizer case, which sets
         # overlap_param_gather=True without use_distributed_optimizer.
@@ -518,12 +533,27 @@ class _ParamAndGradBucketGroup:
                     local_data_view = self.cached_param_buffer_shard_list[idx][
                         self.intra_distributed_optimizer_instance_rank
                     ]
+
+                    if bucket.param_data.device.type == "cpu":
+                        continue
+
                     dist_all_gather_func(
                         bucket.param_data,
                         local_data_view,
                         group=self.intra_distributed_optimizer_instance_group,
                         async_op=async_op,
                     )
+
+            # Gather the CPU-offloaded buckets (MoE expert offloading) separately. This runs
+            # synchronously and is deliberately not covered by _coalescing_manager.
+            for idx in self.cpu_bucket_indices:
+                self._all_gather_cpu_param_bucket(
+                    self.buckets[idx],
+                    self.cached_param_buffer_shard_list[idx][
+                        self.intra_distributed_optimizer_instance_rank
+                    ],
+                )
+
             if async_op:
                 self.param_gather_handle = cm
             else:
@@ -534,6 +564,61 @@ class _ParamAndGradBucketGroup:
         if force_sync and self.ddp_config.overlap_param_gather:
             self._post_param_sync()
         self.param_gather_dispatched = True
+
+    def _all_gather_cpu_param_bucket(
+        self, bucket: _ParamAndGradBucket, local_data_view: torch.Tensor
+    ):
+        """All-gather one CPU-offloaded param bucket through a bounded GPU staging buffer.
+
+        MoE expert offloading keeps expert weights in pinned host memory, but the collective
+        has to run on GPU. The local shard is moved to GPU, gathered, and copied back
+        to CPU. ``_CPU_PARAM_GATHER_STAGING_BYTES`` is used so peak GPU memory
+        stays bounded no matter how large the bucket is: a bucket that fits is gathered in a
+        single pass, a larger one is split.
+
+        The number of passes is derived only from values replicated across the group (shard
+        size, group size, dtype), never from per-rank state, so every rank issues the same
+        sequence of collectives with the same shapes.
+
+        Args:
+            bucket: the bucket to gather; ``bucket.param_data`` must be host-resident.
+            local_data_view: this rank's shard of ``bucket.param_data``.
+        """
+        world_size = self.intra_distributed_optimizer_instance_size
+        shard_numel = local_data_view.numel()
+        dtype = bucket.param_data.dtype
+        device = torch.cuda.current_device()
+
+        # Each pass stages one shard chunk plus the gathered result for all ranks.
+        max_chunk_numel = max(
+            1,
+            _CPU_PARAM_GATHER_STAGING_BYTES
+            // (bucket.param_data.element_size() * (world_size + 1)),
+        )
+        chunk_numel = min(shard_numel, max_chunk_numel)
+
+        send_buffer = torch.empty(chunk_numel, dtype=dtype, device=device)
+        recv_buffer = torch.empty(chunk_numel * world_size, dtype=dtype, device=device)
+
+        flat_param_data = bucket.param_data.view(-1)
+        flat_local_shard = local_data_view.view(-1)
+
+        for offset in range(0, shard_numel, chunk_numel):
+            numel = min(chunk_numel, shard_numel - offset)
+            send_view = send_buffer[:numel]
+            recv_view = recv_buffer[: numel * world_size]
+
+            send_view.copy_(flat_local_shard[offset : offset + numel])
+            torch.distributed.all_gather_into_tensor(
+                recv_view, send_view, group=self.intra_distributed_optimizer_instance_group
+            )
+
+            # Rank r's shard occupies [r * shard_numel, (r + 1) * shard_numel) in the bucket.
+            # copy the gathered shards back into the CPU param
+            recv_per_rank = recv_view.view(world_size, numel)
+            for rank in range(world_size):
+                dst = rank * shard_numel + offset
+                flat_param_data[dst : dst + numel].copy_(recv_per_rank[rank])
 
     def finish_param_sync(self, skip_next_bucket_dispatch: bool = False):
         """
@@ -1054,6 +1139,13 @@ class _ParamAndGradBuffer:
         self.params = [param for (param, _) in params_with_names]
         self.param_indices = param_indices
 
+        # CPU expert params
+        self.use_cpu_param_data = False
+        if all(p.device == torch.device("cpu") for p in self.params) and all(
+            getattr(p, "is_cpu_offloaded_expert", False) for p in self.params
+        ):
+            self.use_cpu_param_data = True
+
         # Check that params are unique.
         unique_params = set()
         for param, _ in params_with_names:
@@ -1184,7 +1276,10 @@ class _ParamAndGradBuffer:
                     self.param_data = torch.zeros(
                         numel,
                         dtype=self.param_dtype,
-                        device=torch.cuda.current_device(),
+                        device=(
+                            torch.cuda.current_device() if not self.use_cpu_param_data else "cpu"
+                        ),
+                        pin_memory=self.use_cpu_param_data,
                         requires_grad=False,
                     )
                 self.grad_data = torch.zeros(

--- a/megatron/core/optimizer/distrib_optimizer.py
+++ b/megatron/core/optimizer/distrib_optimizer.py
@@ -398,7 +398,11 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                 param_range = gbuf_range["param_map"][model_param]["param"]
 
                 # fp16, bf16 params.
-                if model_param.type() in ['torch.cuda.HalfTensor', 'torch.cuda.BFloat16Tensor']:
+                if model_param.type() in [
+                    'torch.cuda.HalfTensor',
+                    'torch.cuda.BFloat16Tensor',
+                    'torch.BFloat16Tensor',
+                ]:
 
                     # Generate sharded model param.
                     if (
@@ -442,7 +446,15 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
                                     param_range.start : param_range.end
                                 ]
                         else:
-                            shard_main_param = shard_model_param.clone().float()
+                            if model_param.type() == 'torch.BFloat16Tensor':
+                                # NOTE: For bfloat16 params on CPU, we keep main_param on GPU
+                                shard_main_param = (
+                                    shard_model_param.clone()
+                                    .to(torch.cuda.current_device())
+                                    .float()
+                                )
+                            else:
+                                shard_main_param = shard_model_param.clone().float()
 
                         tensor_parallel.copy_tensor_model_parallel_attributes(
                             shard_main_param, model_param

--- a/megatron/core/optimizer/optimizer.py
+++ b/megatron/core/optimizer/optimizer.py
@@ -1006,10 +1006,20 @@ class Float16OptimizerWithFloat16Params(MixedPrecisionOptimizer):
                     if param.requires_grad:
 
                         # float16 params:
-                        if param.type() in ['torch.cuda.HalfTensor', 'torch.cuda.BFloat16Tensor']:
+                        if param.type() in [
+                            'torch.cuda.HalfTensor',
+                            'torch.cuda.BFloat16Tensor',
+                            'torch.BFloat16Tensor',
+                        ]:
                             float16_params_this_group.append(param)
                             # Create a copy
-                            main_param = param.detach().clone().float()
+                            if param.type() == 'torch.BFloat16Tensor':
+                                # for param on CPU, we keep main_param on GPU
+                                main_param = (
+                                    param.detach().clone().to(torch.cuda.current_device()).float()
+                                )
+                            else:
+                                main_param = param.detach().clone().float()
                             # Copy tensor model parallel attributes.
                             tensor_parallel.copy_tensor_model_parallel_attributes(main_param, param)
                             tensor_parallel.copy_gtp_attributes(main_param, param)
@@ -1035,6 +1045,7 @@ class Float16OptimizerWithFloat16Params(MixedPrecisionOptimizer):
                                 'torch.cuda.FloatTensor,  '
                                 'torch.cuda.HalfTensor, or '
                                 'torch.cuda.BFloat16Tensor. '
+                                'torch.BFloat16Tensor. '
                                 'Received {}'.format(param.type())
                             )
 

--- a/megatron/core/transformer/moe/experts.py
+++ b/megatron/core/transformer/moe/experts.py
@@ -9,7 +9,7 @@ from copy import deepcopy
 from dataclasses import dataclass
 from itertools import chain
 from math import ceil
-from typing import Optional, Protocol, Tuple
+from typing import Callable, List, Optional, Protocol, Tuple
 
 import torch
 import torch.nn.functional as F
@@ -84,6 +84,12 @@ except ImportError:
 
 from megatron.core.inference.moe import ActivationType as McoreActivationType
 from megatron.core.inference.moe import InferenceGroupedGemmBackend, mcore_fused_moe, vllm_fused_moe
+from megatron.core.transformer.moe.experts_offloading import offloading_grouped_mlp
+from megatron.core.transformer.moe.experts_offloading_util import (
+    ExpertsWgradScheduler,
+    StreamManager,
+    build_offloading_expert_sharded_tensor,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -1418,4 +1424,418 @@ class SequentialMLP(MegatronModule):
                 sh_ten.replica_id = (*replica_id[:2], self.dp_group.rank())
 
             sharded_state_dict.update(expert_state_dict)
+        return sharded_state_dict
+
+
+class OffloadingExpertsMLP(MegatronModule):
+    """An implementation of the Experts layer with fine-grained experts offloading.
+
+    This class executes each expert sequentially and offloads expert to CPU
+    to save GPU memory.
+    """
+
+    def __init__(
+        self,
+        num_local_experts: int,
+        config: TransformerConfig,
+        pg_collection: Optional[ProcessGroupCollection] = None,
+    ):
+        from torch.nn import Parameter
+
+        from megatron.core.tensor_parallel.layers import _initialize_affine_weight_cpu
+
+        super().__init__(config)
+        self.num_local_experts = num_local_experts
+
+        assert config.gradient_accumulation_fusion
+
+        self.ep_group = pg_collection.ep
+        # use pg_collection.expt_tp_group as tensor parallel group in this module.
+        self.tp_group = pg_collection.expt_tp
+        # use pg_collection.expt_dp_group as data parallel group in this module.
+        self.dp_group = pg_collection.expt_dp
+        # How many feature each rank holds for fc1 and fc2, respectively.
+        etp_size = self.tp_group.size()
+        etp_rank = self.tp_group.rank()
+
+        assert etp_size == 1, "Expert-Tensor parallelism is not supported in OffloadingExpertsMLP"
+        self.expert_parallel = config.expert_model_parallel_size > 1
+
+        self.input_size = (
+            self.config.hidden_size
+            if self.config.moe_latent_size is None
+            else self.config.moe_latent_size
+        )
+
+        fc1_output_size = self.config.moe_ffn_hidden_size * (
+            2 if self.config.gated_linear_unit else 1
+        )
+        fc1_output_size_per_partition = fc1_output_size
+        fc2_input_size = self.config.moe_ffn_hidden_size
+        fc2_input_size_per_partition = fc2_input_size
+
+        # determine expert shape (d_in, d_out) for fc1 and fc2
+        fc1_expert_weight_shape = (self.input_size, fc1_output_size)
+
+        fc2_expert_weight_shape = (fc2_input_size, self.input_size)
+
+        # for now all expert weights are offloaded in CPU.
+        self.weight1 = []
+        self.weight2 = []
+        for i in range(self.num_local_experts):
+            self.register_parameter(
+                f'weight1_expert_{i}',
+                Parameter(
+                    torch.empty(
+                        *fc1_expert_weight_shape,
+                        dtype=config.params_dtype,
+                        device=(
+                            "cpu"
+                            if not self.config.moe_offloading_experts_debug_mode
+                            else torch.cuda.current_device()
+                        ),
+                        pin_memory=not self.config.moe_offloading_experts_debug_mode,
+                    )
+                ),
+            )
+            self.weight1.append(getattr(self, f'weight1_expert_{i}'))
+            self.weight1[i].skip_backward_post_hook = (
+                config.moe_offloading_experts_skip_post_backward_hook
+                and not config.moe_offloading_experts_debug_mode
+            )
+            self.weight1[i].is_cpu_offloaded_expert = (
+                not self.config.moe_offloading_experts_debug_mode
+            )
+
+            self.register_parameter(
+                f'weight2_expert_{i}',
+                Parameter(
+                    torch.empty(
+                        *fc2_expert_weight_shape,
+                        dtype=config.params_dtype,
+                        device=(
+                            "cpu"
+                            if not self.config.moe_offloading_experts_debug_mode
+                            else torch.cuda.current_device()
+                        ),
+                        pin_memory=not self.config.moe_offloading_experts_debug_mode,
+                    )
+                ),
+            )
+            self.weight2.append(getattr(self, f'weight2_expert_{i}'))
+            self.weight2[i].skip_backward_post_hook = (
+                config.moe_offloading_experts_skip_post_backward_hook
+                and not config.moe_offloading_experts_debug_mode
+            )
+            self.weight2[i].is_cpu_offloaded_expert = (
+                not self.config.moe_offloading_experts_debug_mode
+            )
+
+            # Set for the expert weights
+            setattr(self.weight1[i], 'allreduce', not self.expert_parallel)
+            setattr(self.weight2[i], 'allreduce', not self.expert_parallel)
+
+            # TE-style init runs as a group after all params are registered
+            # (see below); the original CPU init runs per-expert here.
+            if config.perform_initialization and not config.moe_offloading_experts_te_style_init:
+                _initialize_affine_weight_cpu(
+                    self.weight1[i],
+                    self.input_size,
+                    fc1_output_size,
+                    fc1_output_size_per_partition,
+                    partition_dim=1,
+                    init_method=config.init_method,
+                    params_dtype=config.params_dtype,
+                    rank=etp_rank,
+                    world_size=etp_size,
+                )
+                _initialize_affine_weight_cpu(
+                    self.weight2[i],
+                    fc2_input_size,
+                    self.input_size,
+                    fc2_input_size_per_partition,
+                    partition_dim=0,
+                    init_method=config.output_layer_init_method,
+                    params_dtype=config.params_dtype,
+                    rank=etp_rank,
+                    world_size=etp_size,
+                )
+
+        # perform TE-style initialization
+        if config.perform_initialization and config.moe_offloading_experts_te_style_init:
+            self._init_expert_weights_like_te(
+                self.weight1,
+                self.weight2,
+                fc1_out_size=fc1_output_size,
+                fc1_in_size=self.input_size,
+                fc2_out_size=self.input_size,
+                fc2_in_size=fc2_input_size,
+                weights_in_te_layout=False,
+            )
+
+        # gpu buffer to prefetch CPU weights
+        self.num_stages = self.config.moe_offloading_num_stages
+        self.num_chunks = self.config.moe_offloading_num_chunks
+        assert (
+            num_local_experts % self.num_chunks == 0
+        ), "num_local_experts should be divisible by num_steps."
+        self.chunk_size = (
+            num_local_experts // self.num_chunks
+        )  # one chunk contains num_local_experts // self.num_chunks experts
+        self.config.moe_offloading_chunk_size = self.chunk_size
+
+        # allocate tensors for gpu buffers
+        buffer_dtype = config.params_dtype
+        experts1_gpu_buffers_storage = torch.empty(
+            self.num_stages
+            * self.chunk_size
+            * fc1_expert_weight_shape[0]
+            * fc1_expert_weight_shape[1],
+            device=torch.cuda.current_device(),
+            dtype=buffer_dtype,
+        ).view(
+            self.num_stages, self.chunk_size, fc1_expert_weight_shape[0], fc1_expert_weight_shape[1]
+        )
+        experts2_gpu_buffers_storage = torch.empty(
+            self.num_stages
+            * self.chunk_size
+            * fc2_expert_weight_shape[0]
+            * fc2_expert_weight_shape[1],
+            device=torch.cuda.current_device(),
+            dtype=buffer_dtype,
+        ).view(
+            self.num_stages, self.chunk_size, fc2_expert_weight_shape[0], fc2_expert_weight_shape[1]
+        )
+
+        # organize as [num_stages, chunk_size, (in, out)]
+        self.experts1_gpu_buffers = [
+            [experts1_gpu_buffers_storage[s, c] for c in range(self.chunk_size)]
+            for s in range(self.num_stages)
+        ]
+        self.experts2_gpu_buffers = [
+            [experts2_gpu_buffers_storage[s, c] for c in range(self.chunk_size)]
+            for s in range(self.num_stages)
+        ]
+
+        # organize as [num_stages, (chunk_size, in, out)]
+        self.experts1_gpu_chunks = [experts1_gpu_buffers_storage[s] for s in range(self.num_stages)]
+        self.experts2_gpu_chunks = [experts2_gpu_buffers_storage[s] for s in range(self.num_stages)]
+
+        # cuda stream manager for h2d transfer and computation
+        self.stream_manager = StreamManager.get_instance(num_compute_streams=1)
+
+        # scheduler to determine when to trigger wgrad compute
+        self.expert_wgrad_scheduler = ExpertsWgradScheduler(config.delay_wgrad_compute)
+
+        # store hooks after wgrad reduce
+        self.wgrad_accumulation_and_reduce_hooks = []
+
+    def _init_expert_weights_like_te(
+        self,
+        weights1: List[torch.nn.Parameter],
+        weights2: List[torch.nn.Parameter],
+        fc1_out_size: int,
+        fc1_in_size: int,
+        fc2_out_size: int,
+        fc2_in_size: int,
+        weights_in_te_layout: bool,
+    ) -> None:
+        """Initialize expert weights to match the TEGroupedMLP path.
+
+        TEGroupedMLP delegates to TE's ``GroupedLinear``, which builds each expert weight on
+        GPU in ``[out_features, in_features]`` layout and applies ``init_method`` under the
+        expert-parallel CUDA RNG tracker, looping over experts within a single fork so that
+        consecutive experts draw distinct values (and different EP ranks differ). The default
+        CPU path (``_initialize_affine_weight_cpu``) instead builds an fp32 master weight with
+        the un-forked global CPU RNG, so it produces different values. This method reproduces
+        the TE behaviour:
+
+        - ``linear_fc1`` is initialized before ``linear_fc2`` so the tracker's RNG stream
+          advances in the same order as TE (which constructs fc1 before fc2).
+        - each expert weight is created on GPU in ``params_dtype`` and ``[out, in]`` layout,
+          matching TE's weight tensors element-for-element.
+        - the result is copied into our (CPU-resident, possibly transposed) parameter, and the
+          tensor-model-parallel attributes that ``_initialize_affine_weight_cpu`` would have
+          stamped are preserved.
+
+        ``weights_in_te_layout`` is True when the parameters are already stored as
+        ``[out, in]`` (the inplace-FP8 case) and False when stored transposed as ``[in, out]``.
+        """
+        from megatron.core.tensor_parallel import (
+            get_cuda_rng_tracker,
+            get_expert_parallel_rng_tracker_name,
+            set_tensor_model_parallel_attributes,
+        )
+
+        device = torch.cuda.current_device()
+        # TE only forks the tracker once it has been seeded (e.g. via
+        # model_parallel_cuda_manual_seed); otherwise it falls back to the default RNG.
+        use_tracker = get_cuda_rng_tracker().is_initialized()
+
+        def _init_group(
+            weights: List[torch.nn.Parameter],
+            out_size: int,
+            in_size: int,
+            init_method: Callable[[torch.Tensor], None],
+            partition_dim: int,
+        ) -> None:
+            def _do_init():
+                for i in range(self.num_local_experts):
+                    # TE orientation: [out_features, in_features], params_dtype, on GPU.
+                    weight = torch.empty(
+                        out_size, in_size, dtype=self.config.params_dtype, device=device
+                    )
+                    init_method(weight)
+                    if not weights_in_te_layout:
+                        # Our parameter stores [in_features, out_features]; transpose to match.
+                        weight = weight.t()
+                    with torch.no_grad():
+                        weights[i].data.copy_(weight)
+                    # Preserve the TP attributes set by _initialize_affine_weight_cpu, which are
+                    # read by sharded_state_dict and gradient bookkeeping.
+                    set_tensor_model_parallel_attributes(
+                        tensor=weights[i], is_parallel=True, dim=partition_dim, stride=1
+                    )
+
+            if use_tracker:
+                with get_cuda_rng_tracker().fork(get_expert_parallel_rng_tracker_name()):
+                    _do_init()
+            else:
+                _do_init()
+
+        # TE constructs linear_fc1 before linear_fc2.
+        _init_group(weights1, fc1_out_size, fc1_in_size, self.config.init_method, partition_dim=1)
+        _init_group(
+            weights2,
+            fc2_out_size,
+            fc2_in_size,
+            self.config.output_layer_init_method,
+            partition_dim=0,
+        )
+
+    def _apply(
+        self, fn: Callable[[torch.Tensor], torch.Tensor], recurse: bool = True
+    ) -> "OffloadingExpertsMLP":
+        saved = {}
+        for name, p in list(self._parameters.items()):
+            if p is not None and getattr(p, 'is_cpu_offloaded_expert', False):
+                saved[name] = self._parameters.pop(name)
+        out = super()._apply(fn, recurse=recurse)
+        for name, p in saved.items():
+            self._parameters[name] = p
+        return out
+
+    def forward(
+        self,
+        permuted_local_hidden_states: torch.Tensor,
+        tokens_per_expert: torch.Tensor,
+        permuted_probs: torch.Tensor,
+    ) -> Tuple[torch.Tensor, None]:
+        """Run the offloaded experts over the permuted tokens.
+
+        Returns:
+            tuple: the expert output, and ``None`` for the unused bias slot.
+        """
+        if permuted_local_hidden_states.nelement() != 0:
+            output = offloading_grouped_mlp(
+                self.weight1,
+                self.weight2,
+                self.experts1_gpu_buffers,
+                self.experts2_gpu_buffers,
+                permuted_local_hidden_states,
+                tokens_per_expert,
+                self.num_local_experts,
+                permuted_probs,
+                self.expert_wgrad_scheduler,
+                self.stream_manager,
+                self.config,
+                self.wgrad_accumulation_and_reduce_hooks,
+            )
+
+            return output, None
+        else:
+            # NOTE: it should be safe to pass empty tensor to the custom function,
+            # but it will introduce meanless h2d transfer.
+            # TODO: add cost free path for empty input
+            output = offloading_grouped_mlp(
+                self.weight1,
+                self.weight2,
+                self.experts1_gpu_buffers,
+                self.experts2_gpu_buffers,
+                permuted_local_hidden_states,
+                tokens_per_expert,
+                self.num_local_experts,
+                permuted_probs,
+                self.expert_wgrad_scheduler,
+                self.stream_manager,
+                self.config,
+                self.wgrad_accumulation_and_reduce_hooks,
+            )
+            return output, None
+
+    def backward_dw(self) -> None:
+        """Run the deferred expert wgrad computations and fire the grad-reduce hooks."""
+        if self.config.delay_wgrad_compute:
+            self.expert_wgrad_scheduler.pop_callback()
+            self.expert_wgrad_scheduler.pop_callback()
+
+            # trigger grad reduce hook
+            for hook_fn in self.wgrad_accumulation_and_reduce_hooks:
+                hook_fn()
+
+    def register_wgrad_accumulation_and_reduce_hooks(self, hook_fn: Callable[[], None]) -> None:
+        """Register a DDP grad accumulation/reduce hook to be fired from backward_dw()."""
+        self.wgrad_accumulation_and_reduce_hooks.append(hook_fn)
+
+    def sharded_state_dict(
+        self, prefix: str = '', sharded_offsets: tuple = (), metadata: Optional[dict] = None
+    ) -> ShardedStateDict:
+        """Maps local experts to global experts (interchangeable across variants).
+
+        Both OffloadingExpertsMLP variants emit the same per-expert, expert-parallel
+        sharded layout under keys ``{prefix}experts.weight{1,2}`` in ``(in, out)``
+        orientation, so a checkpoint saved by one is loadable by the other:
+
+        - bf16 variant: per-expert params already ``(in, out)`` -> saved directly.
+        """
+        metadata = ensure_metadata_has_dp_cp_group(metadata)
+        singleton_local_shards = (metadata or {}).get('singleton_local_shards', False)
+        assert self.tp_group.size() == 1, "OffloadingExpertsMLP assumes ETP size == 1"
+
+        num_global_experts = self.ep_group.size() * self.num_local_experts
+        local_expert_indices_offset = self.ep_group.rank() * self.num_local_experts
+        replica_id = (0, 0, self.dp_group.rank())
+
+        sharded_state_dict = {}
+        for i in range(self.num_local_experts):
+            g_idx = local_expert_indices_offset + i
+            w1 = getattr(self, f'weight1_expert_{i}')
+            w2 = getattr(self, f'weight2_expert_{i}')
+
+            sharded_state_dict[f'{prefix}weight1_expert_{i}'] = (
+                build_offloading_expert_sharded_tensor(
+                    w1,
+                    prefix,
+                    'weight1',
+                    g_idx,
+                    sharded_offsets=sharded_offsets,
+                    num_global_experts=num_global_experts,
+                    replica_id=replica_id,
+                    singleton_local_shards=singleton_local_shards,
+                    transpose=False,
+                )
+            )
+            sharded_state_dict[f'{prefix}weight2_expert_{i}'] = (
+                build_offloading_expert_sharded_tensor(
+                    w2,
+                    prefix,
+                    'weight2',
+                    g_idx,
+                    sharded_offsets=sharded_offsets,
+                    num_global_experts=num_global_experts,
+                    replica_id=replica_id,
+                    singleton_local_shards=singleton_local_shards,
+                    transpose=False,
+                )
+            )
         return sharded_state_dict

--- a/megatron/core/transformer/moe/experts_offloading.py
+++ b/megatron/core/transformer/moe/experts_offloading.py
@@ -1,0 +1,833 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Autograd machinery for the MoE experts offloading path.
+
+Contents:
+
+1) ``OffloadingExpertsGroupedMLP``: an autograd function for the forward and backward pass
+   of the grouped SwiGLU MLP in offloading experts. Both passes interleave GPU computation
+   with CPU-GPU communication at chunk granularity to hide the transfer latency of the
+   expert weights.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from megatron.core.transformer.transformer_config import TransformerConfig
+
+try:
+    from transformer_engine.pytorch.cpp_extensions import general_grouped_gemm
+    from transformer_engine.pytorch.module.base import get_multi_stream_cublas_workspace
+
+    HAVE_TE = True
+except ImportError:
+    HAVE_TE = False
+
+try:
+    from grouped_gemm.backend import batched_h2d_async
+
+    HAVE_BATCHED_H2D = True
+except ImportError:
+    HAVE_BATCHED_H2D = False
+
+from megatron.core.fusions.fused_bias_swiglu import weighted_swiglu, weighted_swiglu_back
+from megatron.core.transformer.moe.experts_offloading_util import (
+    ExpertsWgradScheduler,
+    StreamManager,
+    get_dummy_wgrad,
+    release,
+)
+
+
+def split_per_expert(
+    t: torch.Tensor, total_token_num_per_chunk: list[int], tokens_per_expert_chunks: list[list[int]]
+) -> list[list[torch.Tensor]]:
+    """Split a ``[sum(tokens), K]`` tensor into per-expert views.
+
+    Returns ``[num_chunks][chunk_size]`` views: ``out[i]`` is the operand list for
+    offloading chunk ``i``, and ``flatten_per_expert(out)`` is the operand list for
+    a whole-layer wgrad gemm.
+    """
+    return [
+        list(torch.split(chunk, tokens))
+        for chunk, tokens in zip(
+            torch.split(t, total_token_num_per_chunk), tokens_per_expert_chunks
+        )
+    ]
+
+
+def flatten_per_expert(per_expert: list[list[torch.Tensor]]) -> list[torch.Tensor]:
+    """Flatten ``split_per_expert`` output into one view per local expert."""
+    return [t for chunk in per_expert for t in chunk]
+
+
+class OffloadingExpertsGroupedMLP(torch.autograd.Function):
+    '''
+    Autograd function for Offloading Experts Grouped SwiGLU MLP.
+
+    The forward and backward pass are implemented with chunk-level interleaving of GPU
+    computation and CPU-GPU communication to hide the data transfer latency of expert
+    weights.
+    '''
+
+    @staticmethod
+    def _grouped_gemm(
+        a_chunks: list[torch.Tensor],
+        b_chunks: list[torch.Tensor],
+        m_splits: list[int],
+        trans_a: bool,
+        trans_b: bool,
+        compute_streams: list[torch.cuda.Stream],
+        c: torch.Tensor | list[torch.Tensor],
+        alpha: float = 1.0,
+        beta: float = 0.0,
+    ) -> torch.Tensor | list[torch.Tensor]:
+        """
+        A grouped gemm wrapper over TE's ``general_grouped_gemm``.
+
+        Computes ``c[i] = beta * c[i] + alpha * (op(a_chunks[i]) @ op(b_chunks[i]))``.
+
+        Both operands arrive already split into one view per expert: ``a_chunks``
+        always comes from ``split_per_expert``, ``b_chunks`` either from the GPU
+        weight buffers (fprop/dgrad) or from ``split_per_expert`` too (wgrad).
+
+        ``trans_a=False`` is the dgrad/fprop layout: ``c`` is a single token-major
+        ``[sum(m_splits), N]`` tensor that TE splits internally via ``m_splits``.
+
+        ``trans_a=True`` is the wgrad layout: ``c`` holds one ``[K, N]`` weight
+        gradient per expert.
+
+        TE runs the per-expert gemms on its own pool of cuBLAS streams, forking from
+        and joining back into whichever stream is current at call time. We enter from
+        ``compute_streams[0]`` so that the ordering ``StreamManager`` has already
+        established for the compute streams (the H2D copy-done event before the call,
+        the h2d/launch stream waits after it) also applies to TE's internal streams.
+        """
+        assert HAVE_TE, "Offloading experts grouped gemm requires TransformerEngine."
+        assert alpha == 1.0 and beta in (0.0, 1.0)
+        if trans_a:
+            out = c
+            single_output = False
+        else:
+            out = [c]
+            single_output = True
+
+        # TE evaluates ``D = op(B) @ op(A)`` in row-major terms, so ``A`` takes ``b``
+        # and ``B`` takes ``a``; layout[0] transposes ``b`` and layout[1] transposes ``a``.
+        layout = ('T' if trans_b else 'N') + ('T' if trans_a else 'N')
+
+        with torch.cuda.stream(compute_streams[0]):
+            general_grouped_gemm(
+                A=b_chunks,
+                B=a_chunks,
+                out=out,
+                out_dtype=out[0].dtype,
+                workspaces=get_multi_stream_cublas_workspace(),
+                layout=layout,
+                m_splits=m_splits,
+                single_output=single_output,
+                accumulate=(beta == 1.0),
+            )
+
+        return c
+
+    @classmethod
+    def _prefetch_expert_weights(
+        cls,
+        chunk_idx: int,
+        cpu_weights: list[torch.nn.Parameter],
+        gpu_buffers: list[list[torch.Tensor]],
+        stream_manager: StreamManager,
+        config: TransformerConfig,
+    ) -> tuple[int, int, int, int, torch.cuda.Event]:
+        h2d_stream_idx = chunk_idx % config.moe_offloading_num_stages
+        gpu_buffer_idx = h2d_stream_idx
+        h2d_stream = stream_manager.get_h2d_stream(h2d_stream_idx)
+
+        with torch.cuda.stream(h2d_stream):
+            experts_idx_start = chunk_idx * config.moe_offloading_chunk_size
+            experts_idx_end = (chunk_idx + 1) * config.moe_offloading_chunk_size
+            cpu_weights_slice = cpu_weights[experts_idx_start:experts_idx_end]
+            buf = gpu_buffers[gpu_buffer_idx]
+
+            assert len(cpu_weights_slice) == len(buf), (
+                f"Number of weights in CPU slice {len(cpu_weights_slice)} does not match "
+                f"number of GPU buffers {len(buf)}"
+            )
+            # NOTE: batched H2D copy is used to reduce cpu overhead
+            if HAVE_BATCHED_H2D:
+                batched_h2d_async(cpu_weights_slice, buf, h2d_stream.cuda_stream)
+            else:  # NOTE: fallback to non-batched copy if not pinned
+                for idx in range(experts_idx_start, experts_idx_end):
+                    buf[idx - experts_idx_start].copy_(cpu_weights[idx].data, non_blocking=True)
+
+        copy_done_event = torch.cuda.Event()
+        copy_done_event.record(h2d_stream)
+
+        # NOTE: this is a temp solution to resolve a correctness issue encoutered
+        # when VPP is enabled
+        # h2d_stream.synchronize()
+
+        return (gpu_buffer_idx, h2d_stream_idx, experts_idx_start, experts_idx_end, copy_done_event)
+
+    @classmethod
+    def call_forward_a(
+        cls,
+        cpu_w1: list[torch.nn.Parameter],
+        gpu_w1_buffers: list[list[torch.Tensor]],
+        permuted_local_hidden_states: torch.Tensor,
+        x_per_expert: list[list[torch.Tensor]],
+        total_token_num_per_chunk: list[int],
+        tokens_per_expert_chunks: list[list[int]],
+        stream_manager: StreamManager,
+        config: TransformerConfig,
+    ) -> torch.Tensor:
+        """Run the fc1 gemm for every local expert, one offloading chunk at a time.
+
+        Returns:
+            torch.Tensor: the fc1 output for all local tokens, token-major.
+        """
+        # allocate output buffer for the first linear layer
+        fc1_output = torch.empty(
+            permuted_local_hidden_states.shape[0],
+            config.moe_ffn_hidden_size * (2 if config.gated_linear_unit else 1),
+            device=permuted_local_hidden_states.device,
+            dtype=permuted_local_hidden_states.dtype,
+        )
+        fc1_output_per_chunk = list(torch.split(fc1_output, total_token_num_per_chunk))
+
+        # prefetch the first chunk of expert weights to GPU
+        curr_buffer_metadata = cls._prefetch_expert_weights(
+            0, cpu_w1, gpu_w1_buffers, stream_manager, config
+        )
+
+        # fc1 chunk-level interleaving computation
+        stream_manager.compute_streams_wait_launch_streams()
+        next_buffer_metadata = None
+        for chunk_idx in range(config.moe_offloading_num_chunks):
+            # prefetch the next chunk of expert weights to GPU buffer
+            if chunk_idx + 1 < config.moe_offloading_num_chunks:
+                next_buffer_metadata = cls._prefetch_expert_weights(
+                    chunk_idx + 1, cpu_w1, gpu_w1_buffers, stream_manager, config
+                )
+
+            # computation on the current GPU buffer
+            experts_chunk = gpu_w1_buffers[curr_buffer_metadata[0]]
+            hidden_states_chunk = x_per_expert[chunk_idx]
+            fc1_output_chunk = fc1_output_per_chunk[chunk_idx]
+            tokens_per_expert_chunk = tokens_per_expert_chunks[chunk_idx]
+
+            stream_manager.consumer_streams_wait_event(curr_buffer_metadata[-1])
+            OffloadingExpertsGroupedMLP._grouped_gemm(
+                a_chunks=hidden_states_chunk,
+                b_chunks=experts_chunk,
+                m_splits=tokens_per_expert_chunk,
+                trans_a=False,
+                trans_b=False,
+                compute_streams=stream_manager.get_compute_stream_objects(),
+                c=fc1_output_chunk,
+            )
+            stream_manager.h2d_stream_wait_consumer_streams(curr_buffer_metadata[1])
+
+            # update current buffer metadata
+            curr_buffer_metadata = (
+                next_buffer_metadata if chunk_idx + 1 < config.moe_offloading_num_chunks else None
+            )
+        stream_manager.launch_streams_wait_compute_streams()
+
+        return fc1_output
+
+    @classmethod
+    def call_forward_y(
+        cls,
+        cpu_w2: list[torch.nn.Parameter],
+        gpu_w2_buffers: list[list[torch.Tensor]],
+        permuted_local_hidden_states: torch.Tensor,
+        fc1_output: torch.Tensor,
+        total_token_num_per_chunk: list[int],
+        tokens_per_expert_chunks: list[list[int]],
+        permuted_probs: torch.Tensor,
+        stream_manager: StreamManager,
+        config: TransformerConfig,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Apply the weighted SwiGLU activation and run the fc2 gemm, chunk by chunk.
+
+        Returns:
+            tuple: the layer output for all local tokens, and the activation output.
+        """
+        # prefetch the first chunk of expert weights to GPU
+        curr_buffer_metadata = cls._prefetch_expert_weights(
+            0, cpu_w2, gpu_w2_buffers, stream_manager, config
+        )
+
+        s = weighted_swiglu(fc1_output, permuted_probs.unsqueeze(-1))
+        s_per_expert = split_per_expert(s, total_token_num_per_chunk, tokens_per_expert_chunks)
+
+        # fc2 chunk-level interleaving computation
+        fc2_output = torch.empty_like(permuted_local_hidden_states)
+        fc2_output_per_chunk = list(torch.split(fc2_output, total_token_num_per_chunk))
+
+        stream_manager.compute_streams_wait_launch_streams()
+        next_buffer_metadata = None
+        for chunk_idx in range(config.moe_offloading_num_chunks):
+            # prefetch the next chunk of expert weights to GPU buffer
+            if chunk_idx + 1 < config.moe_offloading_num_chunks:
+                next_buffer_metadata = cls._prefetch_expert_weights(
+                    chunk_idx + 1, cpu_w2, gpu_w2_buffers, stream_manager, config
+                )
+
+            # computation on the current GPU buffer
+            experts_chunk = gpu_w2_buffers[curr_buffer_metadata[0]]
+            s_chunk = s_per_expert[chunk_idx]
+            fc2_output_chunk = fc2_output_per_chunk[chunk_idx]
+            tokens_per_expert_chunk = tokens_per_expert_chunks[chunk_idx]
+
+            stream_manager.consumer_streams_wait_event(curr_buffer_metadata[-1])
+            cls._grouped_gemm(
+                a_chunks=s_chunk,
+                b_chunks=experts_chunk,
+                m_splits=tokens_per_expert_chunk,
+                trans_a=False,
+                trans_b=False,
+                compute_streams=stream_manager.get_compute_stream_objects(),
+                c=fc2_output_chunk,
+            )
+            stream_manager.h2d_stream_wait_consumer_streams(curr_buffer_metadata[1])
+
+            # update current buffer metadata
+            curr_buffer_metadata = (
+                next_buffer_metadata if chunk_idx + 1 < config.moe_offloading_num_chunks else None
+            )
+        stream_manager.launch_streams_wait_compute_streams()
+
+        return fc2_output, s
+
+    @classmethod
+    def call_backward_grad_a(
+        cls,
+        grad_y: torch.Tensor,
+        grad_y_per_expert: list[list[torch.Tensor]],
+        a: torch.Tensor,
+        cpu_w2: list[torch.nn.Parameter],
+        gpu_w2_buffers: list[torch.Tensor],
+        total_token_num_per_chunk: list[int],
+        tokens_per_expert_chunks: list[list[int]],
+        permuted_probs: torch.Tensor,
+        stream_manager: StreamManager,
+        config: TransformerConfig,
+    ) -> torch.Tensor:
+        """Compute the dgrad through fc2 and the SwiGLU, chunk by chunk.
+
+        Returns:
+            torch.Tensor: gradient of the fc1 output (the activation input).
+        """
+        grad_s = torch.empty(
+            grad_y.shape[0], config.moe_ffn_hidden_size, device=grad_y.device, dtype=grad_y.dtype
+        )
+        grad_s_per_chunk = list(torch.split(grad_s, total_token_num_per_chunk))
+
+        # prefetch the first chunk of expert weights to GPU
+        curr_buffer_metadata = cls._prefetch_expert_weights(
+            0, cpu_w2, gpu_w2_buffers, stream_manager, config
+        )
+
+        stream_manager.compute_streams_wait_launch_streams()
+        next_buffer_metadata = None
+        for chunk_idx in range(config.moe_offloading_num_chunks):
+            # prefetch the next chunk of expert weights to GPU buffer
+            if chunk_idx + 1 < config.moe_offloading_num_chunks:
+                next_buffer_metadata = cls._prefetch_expert_weights(
+                    chunk_idx + 1, cpu_w2, gpu_w2_buffers, stream_manager, config
+                )
+
+            # computation on the current GPU buffer
+            experts_chunk = gpu_w2_buffers[curr_buffer_metadata[0]]
+            grad_y_chunk = grad_y_per_expert[chunk_idx]
+            grad_s_chunk = grad_s_per_chunk[chunk_idx]
+            tokens_per_expert_chunk = tokens_per_expert_chunks[chunk_idx]
+
+            stream_manager.consumer_streams_wait_event(curr_buffer_metadata[-1])
+            cls._grouped_gemm(
+                a_chunks=grad_y_chunk,
+                b_chunks=experts_chunk,
+                m_splits=tokens_per_expert_chunk,
+                trans_a=False,
+                trans_b=True,
+                compute_streams=stream_manager.get_compute_stream_objects(),
+                c=grad_s_chunk,
+            )
+            stream_manager.h2d_stream_wait_consumer_streams(curr_buffer_metadata[1])
+
+            # update current buffer metadata
+            curr_buffer_metadata = (
+                next_buffer_metadata if chunk_idx + 1 < config.moe_offloading_num_chunks else None
+            )
+        stream_manager.launch_streams_wait_compute_streams()
+
+        grad_a, grad_probs = weighted_swiglu_back(grad_s, a, permuted_probs.unsqueeze(-1))
+        return grad_a, grad_probs.squeeze(-1)
+
+    @classmethod
+    def call_backward_grad_x(
+        cls,
+        grad_a: torch.Tensor,
+        grad_a_per_expert: list[list[torch.Tensor]],
+        cpu_w1: list[torch.nn.Parameter],
+        gpu_w1_buffers: list[torch.Tensor],
+        total_token_num_per_chunk: list[int],
+        tokens_per_expert_chunks: list[list[int]],
+        stream_manager: StreamManager,
+        config: TransformerConfig,
+    ) -> torch.Tensor:
+        """Compute the dgrad through fc1, chunk by chunk.
+
+        Returns:
+            torch.Tensor: gradient of the permuted expert input.
+        """
+        grad_x = torch.empty(
+            grad_a.shape[0], config.hidden_size, device=grad_a.device, dtype=grad_a.dtype
+        )
+        grad_x_per_chunk = list(torch.split(grad_x, total_token_num_per_chunk))
+
+        # prefetch the first chunk of expert weights to GPU
+        curr_buffer_metadata = cls._prefetch_expert_weights(
+            0, cpu_w1, gpu_w1_buffers, stream_manager, config
+        )
+
+        stream_manager.compute_streams_wait_launch_streams()
+        next_buffer_metadata = None
+        for chunk_idx in range(config.moe_offloading_num_chunks):
+            # prefetch the next chunk of expert weights to GPU buffer
+            if chunk_idx + 1 < config.moe_offloading_num_chunks:
+                next_buffer_metadata = cls._prefetch_expert_weights(
+                    chunk_idx + 1, cpu_w1, gpu_w1_buffers, stream_manager, config
+                )
+
+            # computation on the current GPU buffer
+            experts_chunk = gpu_w1_buffers[curr_buffer_metadata[0]]
+            grad_a_chunk = grad_a_per_expert[chunk_idx]
+            grad_x_chunk = grad_x_per_chunk[chunk_idx]
+            tokens_per_expert_chunk = tokens_per_expert_chunks[chunk_idx]
+
+            stream_manager.consumer_streams_wait_event(curr_buffer_metadata[-1])
+            cls._grouped_gemm(
+                a_chunks=grad_a_chunk,
+                b_chunks=experts_chunk,
+                m_splits=tokens_per_expert_chunk,
+                trans_a=False,
+                trans_b=True,
+                compute_streams=stream_manager.get_compute_stream_objects(),
+                c=grad_x_chunk,
+            )
+            stream_manager.h2d_stream_wait_consumer_streams(curr_buffer_metadata[1])
+
+            # update current buffer metadata
+            curr_buffer_metadata = (
+                next_buffer_metadata if chunk_idx + 1 < config.moe_offloading_num_chunks else None
+            )
+        stream_manager.launch_streams_wait_compute_streams()
+
+        return grad_x
+
+    @staticmethod
+    def _wgrad_post_process(
+        w: list[torch.nn.Parameter],
+        wgrad_output: list[torch.Tensor],
+        fuse_gradient_accumulation: bool,
+    ) -> None:
+        # handle ddp
+        assert (
+            fuse_gradient_accumulation
+        ), "Only support fuse_gradient_accumulation for offloading experts."
+        for i in range(len(w)):
+            if fuse_gradient_accumulation:
+                w[i].grad_added_to_main_grad = True
+                w[i].grad = get_dummy_wgrad(w[i].shape, w[i].dtype, w[i].device)
+
+    @classmethod
+    def call_backward_grad_w2(
+        cls,
+        grad_y: torch.Tensor,
+        grad_y_per_expert: list[torch.Tensor],
+        a: torch.Tensor,
+        cpu_w2: list[torch.nn.Parameter],
+        gpu_w2_buffers: list[torch.Tensor],
+        tokens_per_expert: list[int],
+        permuted_probs: torch.Tensor,
+        stream_manager: StreamManager,
+        config: TransformerConfig,
+        delay_wgrad_compute: bool = False,
+        fuse_gradient_accumulation: bool = False,
+    ) -> list[torch.Tensor]:
+        """Calculate the weight gradient of the second linear layer in the backward pass.
+
+        Returns:
+            list[torch.Tensor]: one weight gradient per local expert.
+        """
+        s = weighted_swiglu(a, permuted_probs.unsqueeze(-1))
+        s_per_expert = list(torch.split(s, tokens_per_expert))
+
+        wgrad_output = None
+        alpha = 1.0
+        beta = 0.0
+        if fuse_gradient_accumulation:
+            wgrad_output = [w.main_grad for w in cpu_w2]
+            beta = 1.0
+        else:
+            wgrad_output = [
+                torch.empty(w.shape, device=grad_y.device, dtype=w.dtype) for w in cpu_w2
+            ]
+            beta = 0.0
+
+        # compute wgrad immediately if not delay_wgrad_compute or wgrad_scheduler is None
+        stream_manager.compute_streams_wait_launch_streams()
+        grad_w2 = cls._grouped_gemm(
+            a_chunks=s_per_expert,
+            b_chunks=grad_y_per_expert,
+            m_splits=tokens_per_expert,
+            trans_a=True,
+            trans_b=False,
+            compute_streams=stream_manager.get_compute_stream_objects(),
+            c=wgrad_output,
+            alpha=alpha,
+            beta=beta,
+        )
+        stream_manager.launch_streams_wait_compute_streams()
+
+        OffloadingExpertsGroupedMLP._wgrad_post_process(
+            cpu_w2, wgrad_output, fuse_gradient_accumulation
+        )
+        return grad_w2
+
+    @classmethod
+    def call_backward_grad_w1(
+        cls,
+        grad_a: torch.Tensor,
+        grad_a_per_expert: list[torch.Tensor],
+        x_per_expert: list[torch.Tensor],
+        cpu_w1: list[torch.nn.Parameter],
+        tokens_per_expert: list[int],
+        stream_manager: StreamManager,
+        wgrad_scheduler: ExpertsWgradScheduler | None = None,
+        delay_wgrad_compute: bool = False,
+        fuse_gradient_accumulation: bool = False,
+    ) -> list[torch.Tensor]:
+        """Calculate the weight gradient of the first linear layer in the backward pass.
+
+        Note: For now fuse_gradient_accumulation is not supported.
+
+        Args:
+            grad_a (torch.Tensor): gradient of the input to the activation function
+            grad_a_per_expert (list[torch.Tensor]): ``grad_a`` as one view per local expert
+            x_per_expert (list[torch.Tensor]): input to the first linear layer, one view
+                per local expert
+            w1 (torch.nn.Parameter): weight parameter for the first linear layer
+            tokens_per_expert (list[int]): number of tokens assigned to each expert
+            fuse_gradient_accumulation (bool, optional): Fuse gradient accumulation in
+                gemm. Defaults to False.
+
+        Returns:
+            torch.Tensor: gradient of the weight parameter for the first linear layer
+        """
+        wgrad_output = None
+        alpha = 1.0
+        beta = 0.0
+        if fuse_gradient_accumulation:
+            wgrad_output = [w.main_grad for w in cpu_w1]
+            beta = 1.0
+        else:
+            wgrad_output = [
+                torch.empty(w.shape, device=grad_a.device, dtype=w.dtype) for w in cpu_w1
+            ]
+            beta = 0.0
+
+        # compute wgrad immediately if not delay_wgrad_compute or wgrad_scheduler is None
+        stream_manager.compute_streams_wait_launch_streams()
+        grad_w1 = cls._grouped_gemm(
+            a_chunks=x_per_expert,
+            b_chunks=grad_a_per_expert,
+            m_splits=tokens_per_expert,
+            trans_a=True,
+            trans_b=False,
+            compute_streams=stream_manager.get_compute_stream_objects(),
+            c=wgrad_output,
+            alpha=alpha,
+            beta=beta,
+        )
+        stream_manager.launch_streams_wait_compute_streams()
+
+        # post process wgrad for ddp
+        OffloadingExpertsGroupedMLP._wgrad_post_process(cpu_w1, grad_w1, fuse_gradient_accumulation)
+        return grad_w1
+
+    @staticmethod
+    def forward(ctx, *args, **kwargs) -> tuple[torch.Tensor, None]:
+        """Run the offloaded grouped SwiGLU MLP forward pass.
+
+        Returns:
+            tuple: the layer output, and ``None`` for the unused bias slot.
+        """
+        if len(args) < 9:
+            raise ValueError(
+                "Insufficient arguments for forward pass of GroupedSwiMLP. "
+                f"Expected at least 9, got {len(args)}"
+            )
+
+        cpu_weights: list[torch.nn.Parameter] = list(args[:-10])
+        cpu_w1: list[torch.nn.Parameter] = cpu_weights[: len(cpu_weights) // 2]
+        cpu_w2: list[torch.nn.Parameter] = cpu_weights[len(cpu_weights) // 2 :]
+        gpu_w1_buffers: list[torch.Tensor] = args[-10]
+        gpu_w2_buffers: list[torch.Tensor] = args[-9]
+        permuted_local_hidden_states: torch.Tensor = args[-8]
+        tokens_per_expert: torch.Tensor = args[-7]
+        num_local_experts: int = args[-6]
+        permuted_probs: torch.Tensor = args[-5]
+        expert_wgrad_scheduler: ExpertsWgradScheduler = args[-4]
+        stream_manager: StreamManager = args[-3]
+        config: TransformerConfig = args[-2]
+        wgrad_accumulation_and_reduce_hooks: list = args[-1]
+
+        # split hidden states, outputs and token_per_experts into chunks for each expert chunks
+        chunk_size = config.moe_offloading_chunk_size
+        tokens_per_expert = tokens_per_expert.tolist()
+        tokens_per_expert_chunks = [
+            tokens_per_expert[i : i + chunk_size]
+            for i in range(0, len(tokens_per_expert), chunk_size)
+        ]
+        total_token_num_per_chunk = [sum(chunk) for chunk in tokens_per_expert_chunks]
+        x_per_expert = split_per_expert(
+            permuted_local_hidden_states, total_token_num_per_chunk, tokens_per_expert_chunks
+        )
+
+        # forward for the first linear layer
+        fc1_output = OffloadingExpertsGroupedMLP.call_forward_a(
+            cpu_w1,
+            gpu_w1_buffers,
+            permuted_local_hidden_states,
+            x_per_expert,
+            total_token_num_per_chunk,
+            tokens_per_expert_chunks,
+            stream_manager,
+            config,
+        )
+
+        # activation and forward for the second linear layer
+        y, _ = OffloadingExpertsGroupedMLP.call_forward_y(
+            cpu_w2,
+            gpu_w2_buffers,
+            permuted_local_hidden_states,
+            fc1_output,
+            total_token_num_per_chunk,
+            tokens_per_expert_chunks,
+            permuted_probs,
+            stream_manager,
+            config,
+        )
+
+        # context saving for backward
+        ctx.wgrad_accumulation_and_reduce_hooks = wgrad_accumulation_and_reduce_hooks
+        ctx.tokens_per_expert = tokens_per_expert
+        ctx.tokens_per_expert_chunks = tokens_per_expert_chunks
+        ctx.total_token_num_per_chunk = total_token_num_per_chunk
+        ctx.expert_wgrad_scheduler = expert_wgrad_scheduler
+        ctx.cpu_w1 = cpu_w1
+        ctx.cpu_w2 = cpu_w2
+        ctx.gpu_w1_buffers = gpu_w1_buffers
+        ctx.gpu_w2_buffers = gpu_w2_buffers
+        ctx.stream_manager = stream_manager
+        ctx.config = config
+
+        activation_recompute = (
+            config.recompute_granularity == 'selective' and "moe_act" in config.recompute_modules
+        )
+        ctx.activation_recompute = activation_recompute
+        if activation_recompute:
+            ctx.save_for_backward(permuted_local_hidden_states, None, permuted_probs)
+            release(fc1_output)
+        else:
+            ctx.save_for_backward(permuted_local_hidden_states, fc1_output, permuted_probs)
+        return y, None
+
+    @staticmethod
+    def backward(ctx, *grad_outputs) -> tuple:
+        """Run the offloaded grouped SwiGLU MLP backward pass.
+
+        Returns:
+            tuple: the input gradient, followed by ``None`` for every non-tensor input.
+        """
+        config: TransformerConfig = ctx.config
+        cpu_w1: list[torch.nn.Parameter] = ctx.cpu_w1
+        cpu_w2: list[torch.nn.Parameter] = ctx.cpu_w2
+        gpu_w1_buffers: list[torch.Tensor] = ctx.gpu_w1_buffers
+        gpu_w2_buffers: list[torch.Tensor] = ctx.gpu_w2_buffers
+        stream_manager: StreamManager = ctx.stream_manager
+        expert_wgrad_scheduler: ExpertsWgradScheduler = ctx.expert_wgrad_scheduler
+        total_token_num_per_chunk: list[int] = ctx.total_token_num_per_chunk
+        tokens_per_expert_chunks: list[list[int]] = ctx.tokens_per_expert_chunks
+        tokens_per_expert: list[int] = ctx.tokens_per_expert
+        permuted_local_hidden_states, fc1_output, permuted_probs = ctx.saved_tensors
+
+        # rematerialize activation if needed
+        x_per_expert = split_per_expert(
+            permuted_local_hidden_states, total_token_num_per_chunk, tokens_per_expert_chunks
+        )
+        if ctx.activation_recompute:
+            fc1_output = OffloadingExpertsGroupedMLP.call_forward_a(
+                cpu_w1,
+                gpu_w1_buffers,
+                permuted_local_hidden_states,
+                x_per_expert,
+                total_token_num_per_chunk,
+                tokens_per_expert_chunks,
+                stream_manager,
+                config,
+            )
+
+        grad_y = grad_outputs[0].contiguous()
+        # ``grad_y`` feeds both the dgrad and the wgrad gemm, ``grad_a`` likewise, so
+        # each is split once here and the views are reused by both consumers.
+        grad_y_per_expert = split_per_expert(
+            grad_y, total_token_num_per_chunk, tokens_per_expert_chunks
+        )
+
+        # backward computation
+        grad_a, grad_probs = OffloadingExpertsGroupedMLP.call_backward_grad_a(
+            grad_y,
+            grad_y_per_expert,
+            fc1_output,
+            cpu_w2,
+            gpu_w2_buffers,
+            total_token_num_per_chunk,
+            tokens_per_expert_chunks,
+            permuted_probs,
+            stream_manager,
+            config,
+        )
+
+        grad_a_per_expert = (
+            None
+            if grad_a is None
+            else split_per_expert(grad_a, total_token_num_per_chunk, tokens_per_expert_chunks)
+        )
+
+        grad_x = (
+            None
+            if grad_a is None
+            else OffloadingExpertsGroupedMLP.call_backward_grad_x(
+                grad_a,
+                grad_a_per_expert,
+                cpu_w1,
+                gpu_w1_buffers,
+                total_token_num_per_chunk,
+                tokens_per_expert_chunks,
+                stream_manager,
+                config,
+            )
+        )
+
+        grad_w2 = OffloadingExpertsGroupedMLP.call_backward_grad_w2(
+            grad_y,
+            flatten_per_expert(grad_y_per_expert),
+            fc1_output,
+            cpu_w2,
+            gpu_w2_buffers,
+            tokens_per_expert,
+            permuted_probs,
+            stream_manager,
+            config,
+            config.delay_wgrad_compute,
+            config.gradient_accumulation_fusion,
+        )
+
+        grad_w1 = (
+            None
+            if grad_a is None
+            else OffloadingExpertsGroupedMLP.call_backward_grad_w1(
+                grad_a,
+                flatten_per_expert(grad_a_per_expert),
+                flatten_per_expert(x_per_expert),
+                cpu_w1,
+                tokens_per_expert,
+                stream_manager,
+                expert_wgrad_scheduler,
+                config.delay_wgrad_compute,
+                config.gradient_accumulation_fusion,
+            )
+        )
+
+        # NOTE: gradients have been attached in _wgrad_post_process,
+        # so we can return None for grad_w1 and grad_w2
+        grad_w1_ret = [None for _ in cpu_w1]
+        grad_w2_ret = [None for _ in cpu_w2]
+
+        # NOTE: manually trigger wgrad accumulation hook
+        # this is needed as the hook may fail to be triggered if
+        # the parameter is on CPU, and hence cause hanging when
+        # overlap_grad_reduce is enabled
+        for hook_fn in ctx.wgrad_accumulation_and_reduce_hooks:
+            hook_fn()
+
+        return (
+            *grad_w1_ret,
+            *grad_w2_ret,
+            None,
+            None,
+            grad_x,
+            None,
+            None,
+            grad_probs,
+            None,
+            None,
+            None,
+            None,
+        )
+
+
+def offloading_grouped_mlp(
+    cpu_w1: list[torch.nn.Parameter],
+    cpu_w2: list[torch.nn.Parameter],
+    gpu_w1_buffers: list[torch.Tensor],
+    gpu_w2_buffers: list[torch.Tensor],
+    permuted_local_hidden_states: torch.Tensor,
+    tokens_per_expert: torch.Tensor,
+    num_local_experts: int,
+    permuted_probs: torch.Tensor,
+    expert_wgrad_scheduler: ExpertsWgradScheduler,
+    stream_manager: StreamManager,
+    config: TransformerConfig,
+    wgrad_accumulation_and_reduce_hooks: list,
+) -> torch.Tensor:
+    """Autograd function for Offloading Experts Grouped SwiGLU MLP.
+
+    Args:
+        cpu_w1 (list[torch.nn.Parameter]): CPU weight parameters for the first linear layer
+        cpu_w2 (list[torch.nn.Parameter]): CPU weight parameters for the second linear layer
+        gpu_w1_buffers (list[torch.Tensor]): GPU buffers for w1 weights
+        gpu_w2_buffers (list[torch.Tensor]): GPU buffers for w2 weights
+        permuted_local_hidden_states (torch.Tensor): input hidden states
+        tokens_per_expert (torch.Tensor): number of tokens assigned to each expert
+        num_local_experts (int): number of local experts
+        permuted_probs (torch.Tensor): probability derived from router
+        expert_wgrad_scheduler (ExpertsWgradScheduler): scheduler for expert weight gradients
+        stream_manager (StreamManager): manager for CUDA streams
+        config (TransformerConfig): transformer configuration
+
+    Returns:
+        torch.Tensor: output of the MLP
+    """
+    output, _ = OffloadingExpertsGroupedMLP.apply(
+        *cpu_w1,
+        *cpu_w2,
+        gpu_w1_buffers,
+        gpu_w2_buffers,
+        permuted_local_hidden_states,
+        tokens_per_expert,
+        num_local_experts,
+        permuted_probs,
+        expert_wgrad_scheduler,
+        stream_manager,
+        config,
+        wgrad_accumulation_and_reduce_hooks,
+    )
+
+    return output

--- a/megatron/core/transformer/moe/experts_offloading_util.py
+++ b/megatron/core/transformer/moe/experts_offloading_util.py
@@ -1,0 +1,231 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Utility classes and functions shared by the MoE experts offloading path.
+
+Contents:
+
+1) ``ExpertsWgradScheduler``: manages the scheduling of weight gradient computations for
+   MoE experts, allowing wgrad computation to be delayed so that GPU computation and
+   CPU-GPU communication interleave better.
+2) ``StreamManager``: owns the CUDA streams and the stream-ordering helpers used to
+   overlap expert-weight H2D transfers with compute.
+3) ``build_offloading_expert_sharded_tensor``: builds the ``ShardedTensor`` for a single
+   offloaded expert weight so checkpoints match the non-offloaded layouts.
+"""
+
+from __future__ import annotations
+
+import queue
+from typing import Any, Callable
+
+import torch
+
+from megatron.core.dist_checkpointing.mapping import ShardedTensor
+
+
+class ExpertsWgradScheduler:
+    """FIFO queue of deferred expert wgrad computations.
+
+    When ``delay_wgrad_compute`` is set, the offloading autograd function registers each
+    wgrad closure here instead of running it inline, and ``backward_dw()`` drains the queue
+    after the dgrad pass has completed.
+    """
+
+    def __init__(self, delay_wgrad_compute: bool = False) -> None:
+        self.delay_wgrad_compute = delay_wgrad_compute
+        self.queue: queue.Queue = queue.Queue()
+
+    def register(self, grad_func: Callable[..., Any], *grad_parms: Any) -> None:
+        """Queue ``grad_func(*grad_parms)`` for later execution, if wgrad is delayed."""
+        if self.delay_wgrad_compute:
+            self.queue.put((grad_func, grad_parms))
+
+    def pop_callback(self) -> Any:
+        """Run the oldest queued wgrad closure, or do nothing if the queue is empty."""
+        if self.queue.qsize() > 0 and self.delay_wgrad_compute:
+            grad_func, grad_parms = self.queue.get()
+            return grad_func(*grad_parms)
+        else:
+            # If there is no token assigned to the expert in this MoE layer,
+            # then there will be case that the wgrad compute is not registered
+            return
+
+
+def release(t: torch.Tensor) -> None:
+    """Helper function to release tensors that are no longer needed to save memory."""
+    t.untyped_storage().resize_(0)
+
+
+class StreamManager:
+    """Manage CUDA streams and events shared by MoE offloading paths."""
+
+    _instance = None
+
+    def __init__(self, num_h2d_streams: int, num_compute_streams: int = 4) -> None:
+        self.num_compute_streams = num_compute_streams
+        self.num_h2d_streams = num_h2d_streams
+        self.h2d_streams = [torch.cuda.Stream() for _ in range(num_h2d_streams)]
+        self.compute_streams = [torch.cuda.Stream() for _ in range(self.num_compute_streams)]
+        self.compute_cuda_streams = [stream.cuda_stream for stream in self.compute_streams]
+
+        # Dedicated copy streams for activation offload D2H/H2D.
+        self.act_d2h_stream = torch.cuda.Stream()
+        self.act_h2d_stream = torch.cuda.Stream()
+
+    @classmethod
+    def get_instance(cls, num_h2d_streams: int = 2, num_compute_streams: int = 4) -> StreamManager:
+        """Return the process-wide singleton, creating it on first use."""
+        if cls._instance is None:
+            cls._instance = StreamManager(num_h2d_streams, num_compute_streams)
+        return cls._instance
+
+    def get_h2d_stream(self, idx: int) -> torch.cuda.Stream:
+        """Return the ``idx``-th host-to-device copy stream."""
+        return self.h2d_streams[idx]
+
+    def get_compute_streams(self) -> list[int]:
+        """Return the raw ``cudaStream_t`` handles of the compute streams."""
+        return self.compute_cuda_streams
+
+    def get_compute_stream_objects(self) -> list[torch.cuda.Stream]:
+        """Return the compute streams as ``torch.cuda.Stream`` objects."""
+        return self.compute_streams
+
+    def get_launch_streams(self) -> list[torch.cuda.Stream]:
+        """Return the streams the caller may have launched this module from.
+
+        This is the current stream, plus the default stream when they differ: with virtual
+        pipeline parallelism a model chunk can execute on a non-default current stream, and
+        both need to participate in the ordering below.
+        """
+        # VPP can execute a model chunk on a non-default current stream.
+        current_stream = torch.cuda.current_stream()
+        default_stream = torch.cuda.default_stream()
+        if current_stream.cuda_stream == default_stream.cuda_stream:
+            return [current_stream]
+        return [current_stream, default_stream]
+
+    def launch_streams_wait_compute_streams(self) -> None:
+        """Join the compute streams back into the launch streams."""
+        launch_streams = self.get_launch_streams()
+        for i in range(self.num_compute_streams):
+            for launch_stream in launch_streams:
+                launch_stream.wait_stream(self.compute_streams[i])
+
+    def default_stream_wait_h2d_stream(self, idx: int) -> None:
+        """Make the default stream wait for the ``idx``-th H2D copy stream."""
+        torch.cuda.default_stream().wait_stream(self.get_h2d_stream(idx))
+
+    def compute_streams_wait_launch_streams(self) -> None:
+        """Fork the compute streams off the launch streams."""
+        launch_streams = self.get_launch_streams()
+        for i in range(self.num_compute_streams):
+            for launch_stream in launch_streams:
+                self.compute_streams[i].wait_stream(launch_stream)
+
+    def h2d_stream_wait_consumer_streams(self, idx: int) -> None:
+        """Make the ``idx``-th H2D stream wait for every consumer of its staging buffer.
+
+        This is what makes the staging buffer safe to overwrite with the next chunk.
+        """
+        h2d_stream = self.get_h2d_stream(idx)
+        for launch_stream in self.get_launch_streams():
+            h2d_stream.wait_stream(launch_stream)
+        for i in range(self.num_compute_streams):
+            h2d_stream.wait_stream(self.compute_streams[i])
+
+    def compute_streams_wait_h2d_stream(self, idx: int) -> None:
+        """Make the compute streams wait for the ``idx``-th H2D copy stream."""
+        h2d_stream = self.get_h2d_stream(idx)
+        for i in range(self.num_compute_streams):
+            self.compute_streams[i].wait_stream(h2d_stream)
+
+    def consumer_streams_wait_event(self, event: torch.cuda.Event) -> None:
+        """Make the launch and compute streams wait on ``event``."""
+        for launch_stream in self.get_launch_streams():
+            launch_stream.wait_event(event)
+        for i in range(self.num_compute_streams):
+            self.compute_streams[i].wait_event(event)
+
+    def h2d_stream_wait_default_stream(self, idx: int) -> None:
+        """Make the ``idx``-th H2D copy stream wait for the default stream."""
+        self.get_h2d_stream(idx).wait_stream(torch.cuda.default_stream())
+
+    def act_d2h_stream_wait_producers(self) -> None:
+        """Make the activation-offload D2H stream wait for activation producers."""
+        for launch_stream in self.get_launch_streams():
+            self.act_d2h_stream.wait_stream(launch_stream)
+        for i in range(self.num_compute_streams):
+            self.act_d2h_stream.wait_stream(self.compute_streams[i])
+
+    def consumer_streams_wait_act_reload(self, h2d_done_event: torch.cuda.Event) -> None:
+        """Make backward consumer streams wait until activation reload H2D completes."""
+        self.consumer_streams_wait_event(h2d_done_event)
+
+
+_dummy_wgrads = {}
+
+
+def get_dummy_wgrad(
+    shape: list[int], dtype: torch.dtype, device: torch.device | int, zero: bool = False
+) -> torch.Tensor:
+    """Returns a dummy tensor of given shape."""
+    global _dummy_wgrads
+    wgard_key = (*shape, dtype)
+    if wgard_key not in _dummy_wgrads:
+        _dummy_wgrads[wgard_key] = torch.empty(
+            shape, dtype=dtype, device=device, requires_grad=False
+        )
+    if zero:
+        _dummy_wgrads[wgard_key].fill_(0)
+    return _dummy_wgrads[wgard_key].detach()
+
+
+def build_offloading_expert_sharded_tensor(
+    weight_slice: torch.Tensor,
+    prefix: str,
+    weight_name: str,
+    global_expert_idx: int,
+    *,
+    sharded_offsets: tuple,
+    num_global_experts: int,
+    replica_id: tuple[int, int, int],
+    singleton_local_shards: bool,
+    transpose: bool,
+) -> ShardedTensor:
+    """Build the ShardedTensor for a single offloaded expert weight.
+
+    Produces the *same* on-disk representation for both OffloadingExpertsMLP
+    variants so their checkpoints are interchangeable:
+
+    - bf16 variant: per-expert params stored as ``(in, out)`` -> ``transpose=False``
+    - inplace-fp8 variant: fused master stored as ``(out, in)`` (NT layout)
+      -> ``transpose=True`` to land on the same ``(in, out)`` checkpoint layout.
+
+    The expert is expressed as a *prepended* axis fragment exactly like
+    ``SequentialMLP``/``TEGroupedMLP`` (see ``apply_swiglu_sharded_factory``),
+    i.e. ``prepend_axis_num == len(offsets)``, which is what makes the expert
+    dimension compose cleanly with any pipeline/tensor ``sharded_offsets``.
+
+    Args:
+        weight_slice (torch.Tensor): one expert's 2D weight. ``(in, out)`` when
+            ``transpose=False`` else ``(out, in)``.
+        prefix (str): module prefix for the on-disk key.
+        weight_name (str): ``'weight1'`` or ``'weight2'``.
+        global_expert_idx (int): this expert's index in the global expert range.
+        sharded_offsets (tuple): offsets inherited from parent modules (PP, ...).
+        num_global_experts (int): total experts across the expert-parallel group.
+        replica_id: ShardedTensor replica id (PP, TP, DP).
+        singleton_local_shards (bool): when True each expert is saved under its own
+            global key with no expert sharding axis.
+        transpose (bool): transpose ``(out, in) -> (in, out)`` before saving.
+    """
+    data = weight_slice.transpose(0, 1).contiguous() if transpose else weight_slice
+    if singleton_local_shards:
+        key = f'{prefix}experts.{global_expert_idx}.{weight_name}'
+        offsets = sharded_offsets
+    else:
+        key = f'{prefix}experts.{weight_name}'
+        offsets = (*sharded_offsets, (len(sharded_offsets), global_expert_idx, num_global_experts))
+    return ShardedTensor.from_rank_offsets(
+        key, data, *offsets, replica_id=replica_id, prepend_axis_num=len(offsets)
+    )

--- a/megatron/core/transformer/moe/moe_layer.py
+++ b/megatron/core/transformer/moe/moe_layer.py
@@ -13,6 +13,7 @@ from megatron.core.extensions.transformer_engine import HAVE_TE
 from megatron.core.inference.utils import InferenceMode
 from megatron.core.process_groups_config import ProcessGroupCollection, resolve_gtp_remat_group
 from megatron.core.transformer.module import MegatronModule
+from megatron.core.transformer.moe.experts import OffloadingExpertsMLP
 from megatron.core.transformer.moe.moe_utils import (
     MoECudaGraphPartialCaptureSignal,
     MoECudaGraphTensorStore,
@@ -330,12 +331,17 @@ class MoELayer(BaseMoELayer):
             )
 
         # Initialize experts
-        self.experts = self.submodules.experts(
-            self.num_local_experts,
-            self.config,
-            pg_collection=pg_collection,
-            name=(name + ".experts") if name is not None else None,
-        )
+        if self.config.moe_use_offloading_experts:
+            self.experts = OffloadingExpertsMLP(
+                self.num_local_experts, self.config, pg_collection=pg_collection
+            )
+        else:
+            self.experts = self.submodules.experts(
+                self.num_local_experts,
+                self.config,
+                pg_collection=pg_collection,
+                name=(name + ".experts") if name is not None else None,
+            )
 
         # Initialize shared experts
         if self.use_shared_expert:

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -989,6 +989,44 @@ class TransformerConfig(ModelParallelConfig):
     count)."""
 
     ##################
+    # MoE Experts Offloading
+    ##################
+    moe_use_offloading_experts: bool = False
+    """Use OffloadingExpertsMLP for the routed experts. Expert weights are kept in pinned CPU
+    memory and prefetched chunk-by-chunk into a small GPU staging buffer during forward and
+    backward, trading host-to-device bandwidth for GPU memory. Requires expert tensor parallel
+    size 1 and gradient_accumulation_fusion."""
+
+    moe_offloading_num_chunks: int = 1
+    """Number of chunks the local experts are split into for offloading. Each chunk is prefetched
+    from CPU as a unit, so more chunks means a smaller GPU staging buffer but more (and smaller)
+    H2D copies. num_local_experts must be divisible by this value."""
+
+    moe_offloading_num_stages: int = 2
+    """Number of GPU staging buffers used to prefetch expert chunks. 2 gives double buffering, so
+    the H2D copy of chunk i+1 overlaps the compute of chunk i. GPU buffer memory is
+    moe_offloading_num_stages * moe_offloading_chunk_size expert weights per FC layer."""
+
+    moe_offloading_chunk_size: int = -1
+    """Number of experts per chunk. Derived by OffloadingExpertsMLP at build time as
+    num_local_experts // moe_offloading_num_chunks; not intended to be set by the user."""
+
+    moe_offloading_experts_te_style_init: bool = True
+    """Initialize offloaded expert weights the way TEGroupedMLP does (per-expert init on GPU under
+    the expert-parallel RNG tracker) instead of _initialize_affine_weight_cpu, so that runs with
+    and without offloading start from the same weights."""
+
+    moe_offloading_experts_skip_post_backward_hook: bool = True
+    """Mark offloaded expert weights with skip_backward_post_hook so DDP registers the grad
+    accumulation/reduce hook on the module rather than the parameter, letting the wgrad reduce run
+    from backward_dw(). Only takes effect with delay_wgrad_compute; ignored in debug mode."""
+
+    moe_offloading_experts_debug_mode: bool = False
+    """Debug mode: keep the 'offloaded' expert weights resident on GPU (unpinned, no H2D staging,
+    no backward post-hook rerouting) so the offloading path can be compared against a plain GPU
+    run."""
+
+    ##################
     # Context Parallel
     ##################
     cp_comm_type: Optional[Union[str, List[str]]] = None
@@ -1888,6 +1926,29 @@ class TransformerConfig(ModelParallelConfig):
                             "transformer-engine>=2.6.0dev0, "
                             f"but your version is {get_te_version()}."
                         )
+
+        if self.moe_use_offloading_experts:
+            if self.moe_offloading_num_chunks < 1:
+                raise ValueError("moe_offloading_num_chunks must be at least 1.")
+            if self.moe_offloading_num_stages < 1:
+                raise ValueError("moe_offloading_num_stages must be at least 1.")
+            if self.moe_offloading_num_chunks > 1 and self.moe_offloading_num_stages < 2:
+                raise ValueError(
+                    "moe_offloading_num_stages must be at least 2 when "
+                    "moe_offloading_num_chunks > 1, otherwise the prefetch of chunk i+1 "
+                    "overwrites the staging buffer chunk i is computing on."
+                )
+            if (
+                self.expert_tensor_parallel_size is not None
+                and self.expert_tensor_parallel_size > 1
+            ):
+                raise ValueError(
+                    "Expert tensor parallelism is not supported with moe_use_offloading_experts."
+                )
+            if not self.gradient_accumulation_fusion:
+                raise ValueError(
+                    "moe_use_offloading_experts requires gradient_accumulation_fusion."
+                )
 
         if self.moe_layer_recompute:
             warnings.warn(

--- a/tests/unit_tests/transformer/moe/test_moe_layer.py
+++ b/tests/unit_tests/transformer/moe/test_moe_layer.py
@@ -9,6 +9,7 @@ from megatron.core.models.gpt.gpt_layer_specs import (
     get_gpt_layer_with_transformer_engine_submodules,
 )
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.transformer.moe.experts import OffloadingExpertsMLP
 from megatron.core.transformer.moe.moe_layer import MoELayer, MoESubmodules
 from megatron.core.transformer.spec_utils import get_submodules
 from megatron.core.transformer.transformer_block import TransformerBlock
@@ -395,6 +396,128 @@ class TestMoELayerRecompute:
 
         for name, param in moe_layer.named_parameters():
             if param.requires_grad:
+                assert param.grad is not None, f"Gradient for {name} should exist"
+
+        Utils.destroy_model_parallel()
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+
+class TestMoELayerOffloading:
+    """Test MoE layer with offloading enabled (weights on CPU)."""
+
+    def setup_method(self, method):
+        pass
+
+    @pytest.mark.parametrize("moe_token_dispatcher_type", ["allgather", "alltoall"])
+    @pytest.mark.parametrize("num_moe_experts", [2, 4])
+    @pytest.mark.parametrize("tp_size,ep_size", [(1, 1), (4, 2)])
+    def test_moe_layer_offloading_forward_backward(
+        self, num_moe_experts, moe_token_dispatcher_type, tp_size, ep_size
+    ):
+        """Test MoE layer forward and backward pass with offloading enabled."""
+        # The offloading experts shard over EP only, so the expert groups must be built with
+        # expert-tensor parallelism disabled, independently of the attention TP size.
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=tp_size,
+            expert_model_parallel_size=ep_size,
+            expert_tensor_parallel_size=1,
+        )
+        _set_random_seed(seed_=123, data_parallel_random_init=False)
+
+        hidden_size = 64
+        sequence_length = 32
+        micro_batch_size = 2
+
+        # One chunk per local expert, so the chunk-by-chunk prefetch pipeline is exercised
+        # whenever this rank owns more than one expert.
+        num_local_experts = num_moe_experts // ep_size
+
+        transformer_config = TransformerConfig(
+            num_layers=1,
+            hidden_size=hidden_size,
+            num_attention_heads=4,
+            num_moe_experts=num_moe_experts,
+            use_cpu_initialization=True,
+            moe_token_dispatcher_type=moe_token_dispatcher_type,
+            moe_router_load_balancing_type="aux_loss",
+            moe_router_topk=2,
+            moe_aux_loss_coeff=0.01,
+            moe_grouped_gemm=False,
+            moe_ffn_hidden_size=256,
+            add_bias_linear=False,
+            tensor_model_parallel_size=tp_size,
+            expert_model_parallel_size=ep_size,
+            sequence_parallel=tp_size > 1,
+            bf16=True,
+            params_dtype=torch.bfloat16,
+            moe_use_offloading_experts=True,
+            moe_offloading_num_chunks=num_local_experts,
+            # Requirements of OffloadingExpertsMLP: it shards experts over EP only, computes
+            # a weighted SwiGLU, and accumulates wgrads into main_grad.
+            expert_tensor_parallel_size=1,
+            gated_linear_unit=True,
+            gradient_accumulation_fusion=True,
+        )
+
+        submodules = get_submodules(
+            get_gpt_layer_local_submodules(num_experts=num_moe_experts, moe_grouped_gemm=False).mlp
+        )
+        assert isinstance(submodules, MoESubmodules)
+
+        moe_layer = MoELayer(transformer_config, submodules).cuda()
+
+        # The config flag must select the offloading experts, whose weights stay in pinned
+        # host memory even though the layer was moved to GPU.
+        assert isinstance(moe_layer.experts, OffloadingExpertsMLP)
+        expert_weights = list(moe_layer.experts.weight1) + list(moe_layer.experts.weight2)
+        assert len(expert_weights) == 2 * num_local_experts
+        for weight in expert_weights:
+            assert weight.device.type == "cpu", f"Expert weight on {weight.device}, expected CPU"
+            assert weight.is_pinned(), "Expert weight should be in pinned memory"
+
+        # gradient_accumulation_fusion accumulates expert wgrads straight into main_grad,
+        # which DDP allocates in real training; this test builds the layer without DDP.
+        for weight in expert_weights:
+            weight.main_grad = torch.zeros(
+                weight.shape, dtype=torch.float32, device=torch.cuda.current_device()
+            )
+
+        hidden_states = torch.randn(
+            sequence_length,
+            micro_batch_size,
+            hidden_size,
+            device=torch.cuda.current_device(),
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+
+        # Forward pass
+        output, _ = moe_layer(hidden_states)
+
+        assert output.dtype == torch.bfloat16, f"Expected bf16 output, got {output.dtype}"
+        assert output.shape == hidden_states.shape, "Output shape mismatch"
+
+        # Backward pass - this is where the expert weights are prefetched back from CPU
+        loss = output.sum()
+        loss.backward()
+
+        assert hidden_states.grad is not None, "Input gradients should exist"
+        assert (
+            hidden_states.grad.dtype == torch.bfloat16
+        ), f"Expected bf16 gradients, got {hidden_states.grad.dtype}"
+
+        # Expert wgrads land in main_grad (param.grad is only a placeholder marked as already
+        # added to main_grad), everything else follows the usual autograd path.
+        for weight in expert_weights:
+            assert weight.grad_added_to_main_grad, "Expert wgrad should be fused into main_grad"
+            assert torch.isfinite(weight.main_grad).all(), "Expert main_grad has non-finite values"
+            assert weight.main_grad.abs().sum() > 0, "Expert main_grad was not accumulated"
+
+        offloaded_params = {id(weight) for weight in expert_weights}
+        for name, param in moe_layer.named_parameters():
+            if param.requires_grad and id(param) not in offloaded_params:
                 assert param.grad is not None, f"Gradient for {name} should exist"
 
         Utils.destroy_model_parallel()

--- a/tests/unit_tests/transformer/moe/test_offloading_experts_numerics.py
+++ b/tests/unit_tests/transformer/moe/test_offloading_experts_numerics.py
@@ -1,0 +1,288 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Numerical equivalence tests for the MoE expert offloading path.
+
+``OffloadingExpertsMLP`` replaces the ordinary expert MLP with a custom autograd function
+that keeps expert weights in pinned host memory, stages them to GPU chunk by chunk, runs
+grouped GEMMs against a fused weighted-SwiGLU, and writes weight gradients straight into
+``main_grad``. None of that is exercised by a shape/finiteness check, so these tests pin
+the whole forward and backward against ``grouped_swiglu_mlp_torch_ref`` -- a plain
+``torch.matmul`` implementation whose backward is ordinary autograd.
+"""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.transformer.moe.experts import OffloadingExpertsMLP
+from megatron.core.transformer.transformer_config import TransformerConfig
+from tests.unit_tests.test_utilities import Utils
+
+HIDDEN_SIZE = 64
+FFN_HIDDEN_SIZE = 128
+
+
+def grouped_swiglu_mlp_torch_ref(
+    w1,
+    w2,
+    permuted_local_hidden_states: torch.Tensor,
+    tokens_per_expert: torch.Tensor,
+    num_local_experts: int,
+    permuted_probs: torch.Tensor,
+) -> torch.Tensor:
+    """Pure-PyTorch reference path for the grouped SwiGLU MoE experts.
+
+    Per expert ``i`` (``x_i: [t_i, in]``, ``w1[i]: [in, 2H]``, ``w2[i]: [H, in]``):
+
+        fc1 = x_i @ w1[i]                 # [t_i, 2H]
+        gate, lin = fc1.chunk(2, dim=-1)
+        s = (silu(gate) * lin) * probs_i  # [t_i, H]
+        y_i = s @ w2[i]                   # [t_i, in]
+    """
+    # Normalize weights to a list of per-expert 2D tensors (supports both the
+    # per-expert parameter list and a stacked [E, in, 2H] / [E, H, in] tensor).
+    w1_list = list(torch.unbind(w1, dim=0)) if isinstance(w1, torch.Tensor) else list(w1)
+    w2_list = list(torch.unbind(w2, dim=0)) if isinstance(w2, torch.Tensor) else list(w2)
+
+    # torch.split needs python ints; .tolist() syncs if tokens_per_expert is on GPU.
+    tokens = (
+        tokens_per_expert.tolist()
+        if isinstance(tokens_per_expert, torch.Tensor)
+        else list(tokens_per_expert)
+    )
+
+    x_chunks = torch.split(permuted_local_hidden_states, tokens, dim=0)
+    probs_chunks = torch.split(permuted_probs.reshape(-1), tokens, dim=0)
+
+    outputs = []
+    for i in range(num_local_experts):
+        x_i = x_chunks[i]
+        fc1 = torch.matmul(x_i, w1_list[i])  # [t_i, 2H]
+        gate, lin = fc1.chunk(2, dim=-1)
+        s = F.silu(gate) * lin  # [t_i, H]
+        s = (s * probs_chunks[i].unsqueeze(-1)).to(x_i.dtype)
+        outputs.append(torch.matmul(s, w2_list[i]))  # [t_i, in]
+
+    return torch.cat(outputs, dim=0)
+
+
+def _make_config(num_experts, num_chunks, num_stages=2):
+    return TransformerConfig(
+        num_layers=1,
+        hidden_size=HIDDEN_SIZE,
+        num_attention_heads=4,
+        num_moe_experts=num_experts,
+        moe_ffn_hidden_size=FFN_HIDDEN_SIZE,
+        moe_router_topk=2,
+        add_bias_linear=False,
+        gated_linear_unit=True,
+        bf16=True,
+        params_dtype=torch.bfloat16,
+        gradient_accumulation_fusion=True,
+        expert_tensor_parallel_size=1,
+        moe_use_offloading_experts=True,
+        moe_offloading_num_chunks=num_chunks,
+        moe_offloading_num_stages=num_stages,
+    )
+
+
+def _build_experts(config, num_local_experts):
+    """Build OffloadingExpertsMLP and give every expert weight an fp32 main_grad.
+
+    The default ``init_method`` uses std 0.02, which after two chained matmuls leaves
+    outputs around 1e-3 -- small enough that any sane absolute tolerance would exceed the
+    whole signal and the comparison would pass no matter what the kernels computed. Weights
+    are re-drawn at 1/sqrt(fan_in) so activations, gradients and wgrads are all O(1) and the
+    tolerances below actually bite.
+    """
+    pg_collection = ProcessGroupCollection.use_mpu_process_groups()
+    experts = OffloadingExpertsMLP(num_local_experts, config, pg_collection=pg_collection)
+    for weight in list(experts.weight1) + list(experts.weight2):
+        with torch.no_grad():
+            weight.normal_(0.0, weight.shape[0] ** -0.5)
+        # gradient_accumulation_fusion accumulates wgrads directly into main_grad, which
+        # DDP would allocate in real training.
+        weight.main_grad = torch.zeros(
+            weight.shape, dtype=torch.float32, device=torch.cuda.current_device()
+        )
+    return experts
+
+
+def _assert_close_scaled(actual, expected, name, rtol=2e-2, atol_frac=5e-3):
+    """Compare two tensors with an absolute tolerance scaled to ``expected``'s magnitude.
+
+    A fixed ``atol`` is the wrong tool for a bf16 GEMM comparison. Too large and it exceeds
+    the whole signal, so the assertion passes no matter what the kernels computed; too small
+    and it trips on the handful of near-zero output elements where the accumulated sum
+    cancels and the relative error is meaningless. Scaling to ``max|expected|`` keeps the
+    bound at a few bf16 ULPs of the tensor's own range, independent of how the weights
+    happen to be initialized.
+    """
+    scale = expected.abs().max().item()
+    assert scale > 0.0, f"{name} is all zeros, so the comparison would be vacuous"
+    torch.testing.assert_close(actual, expected, rtol=rtol, atol=atol_frac * scale)
+
+
+def _reference_weights(experts):
+    """Detached GPU copies of the offloaded weights, as ordinary autograd leaves."""
+    w1 = [
+        w.detach().to(torch.cuda.current_device()).clone().requires_grad_(True)
+        for w in experts.weight1
+    ]
+    w2 = [
+        w.detach().to(torch.cuda.current_device()).clone().requires_grad_(True)
+        for w in experts.weight2
+    ]
+    return w1, w2
+
+
+def _make_inputs(tokens_per_expert, dtype=torch.bfloat16):
+    total_tokens = int(sum(tokens_per_expert))
+    device = torch.cuda.current_device()
+    hidden_states = torch.randn(total_tokens, HIDDEN_SIZE, device=device, dtype=dtype)
+    probs = torch.rand(total_tokens, device=device, dtype=dtype) + 0.5
+    return hidden_states, probs
+
+
+class TestOffloadingExpertsNumerics:
+    """OffloadingExpertsMLP must match a plain-PyTorch grouped SwiGLU MLP."""
+
+    def setup_method(self, method):
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=1,
+            expert_model_parallel_size=1,
+            expert_tensor_parallel_size=1,
+        )
+        model_parallel_cuda_manual_seed(123)
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    @pytest.mark.parametrize(
+        "num_local_experts,num_chunks",
+        [
+            (2, 1),  # single chunk: no prefetch pipelining
+            (4, 2),  # two chunks per pass: double-buffered staging
+            (4, 4),  # one expert per chunk: maximum staging turnover
+        ],
+    )
+    def test_forward_backward_matches_torch_reference(self, num_local_experts, num_chunks):
+        """Forward output, input grad, and expert wgrads must all match the reference."""
+        torch.manual_seed(1234)
+        config = _make_config(num_local_experts, num_chunks)
+        experts = _build_experts(config, num_local_experts)
+
+        tokens_per_expert = torch.tensor(
+            [7, 3, 11, 5][:num_local_experts], dtype=torch.long, device="cpu"
+        )
+        hidden_states, probs = _make_inputs(tokens_per_expert)
+
+        # Offloading path.
+        x_offload = hidden_states.clone().requires_grad_(True)
+        out_offload, bias = experts(x_offload, tokens_per_expert, probs)
+        assert bias is None
+        out_offload.backward(torch.ones_like(out_offload))
+
+        # Reference path, same weights and same input.
+        ref_w1, ref_w2 = _reference_weights(experts)
+        x_ref = hidden_states.clone().requires_grad_(True)
+        out_ref = grouped_swiglu_mlp_torch_ref(
+            ref_w1, ref_w2, x_ref, tokens_per_expert, num_local_experts, probs
+        )
+        out_ref.backward(torch.ones_like(out_ref))
+
+        # bf16 grouped GEMM vs torch.matmul: both accumulate in fp32, so the gap is
+        # dominated by the final bf16 rounding and the fused SwiGLU.
+        _assert_close_scaled(out_offload, out_ref, "forward output")
+        _assert_close_scaled(x_offload.grad, x_ref.grad, "input gradient")
+
+        # Expert wgrads land in main_grad (fp32), not param.grad. They accumulate over all
+        # tokens routed to the expert, so they tolerate a little more drift.
+        for i in range(num_local_experts):
+            assert experts.weight1[i].grad_added_to_main_grad
+            assert experts.weight2[i].grad_added_to_main_grad
+            _assert_close_scaled(
+                experts.weight1[i].main_grad,
+                ref_w1[i].grad.float(),
+                f"expert {i} w1 grad",
+                rtol=3e-2,
+                atol_frac=1e-2,
+            )
+            _assert_close_scaled(
+                experts.weight2[i].main_grad,
+                ref_w2[i].grad.float(),
+                f"expert {i} w2 grad",
+                rtol=3e-2,
+                atol_frac=1e-2,
+            )
+
+    def test_chunking_does_not_change_results(self):
+        """Chunk count is a scheduling knob: it must not change the numbers."""
+        torch.manual_seed(4321)
+        num_local_experts = 4
+        tokens_per_expert = torch.tensor([6, 2, 9, 4], dtype=torch.long, device="cpu")
+        hidden_states, probs = _make_inputs(tokens_per_expert)
+
+        results = []
+        reference_state = None
+        for num_chunks in (1, 2, 4):
+            config = _make_config(num_local_experts, num_chunks)
+            experts = _build_experts(config, num_local_experts)
+
+            # Every variant must start from identical weights.
+            if reference_state is None:
+                reference_state = [w.detach().clone() for w in experts.weight1] + [
+                    w.detach().clone() for w in experts.weight2
+                ]
+            else:
+                weights = list(experts.weight1) + list(experts.weight2)
+                for weight, saved in zip(weights, reference_state):
+                    with torch.no_grad():
+                        weight.copy_(saved)
+
+            x = hidden_states.clone().requires_grad_(True)
+            out, _ = experts(x, tokens_per_expert, probs)
+            out.backward(torch.ones_like(out))
+            results.append(
+                (out.detach().clone(), x.grad.clone(), experts.weight1[0].main_grad.clone())
+            )
+
+        base_out, base_dgrad, base_wgrad = results[0]
+        for out, dgrad, wgrad in results[1:]:
+            _assert_close_scaled(out, base_out, "forward output")
+            _assert_close_scaled(dgrad, base_dgrad, "input gradient")
+            _assert_close_scaled(wgrad, base_wgrad, "expert 0 w1 grad", atol_frac=1e-2)
+
+    def test_weights_stay_on_pinned_host_memory(self):
+        """The whole point of the path: weights never migrate to GPU."""
+        config = _make_config(num_experts=2, num_chunks=2)
+        experts = _build_experts(config, num_local_experts=2).cuda()
+
+        for weight in list(experts.weight1) + list(experts.weight2):
+            assert weight.device.type == "cpu", f"expert weight moved to {weight.device}"
+            assert weight.is_pinned(), "expert weight must live in pinned host memory"
+
+    def test_empty_expert_is_handled(self):
+        """An expert with zero routed tokens must not corrupt the other experts."""
+        torch.manual_seed(99)
+        num_local_experts = 2
+        config = _make_config(num_local_experts, num_chunks=1)
+        experts = _build_experts(config, num_local_experts)
+
+        tokens_per_expert = torch.tensor([0, 8], dtype=torch.long, device="cpu")
+        hidden_states, probs = _make_inputs(tokens_per_expert)
+
+        x_offload = hidden_states.clone().requires_grad_(True)
+        out_offload, _ = experts(x_offload, tokens_per_expert, probs)
+        out_offload.backward(torch.ones_like(out_offload))
+
+        ref_w1, ref_w2 = _reference_weights(experts)
+        x_ref = hidden_states.clone().requires_grad_(True)
+        out_ref = grouped_swiglu_mlp_torch_ref(
+            ref_w1, ref_w2, x_ref, tokens_per_expert, num_local_experts, probs
+        )
+        out_ref.backward(torch.ones_like(out_ref))
+
+        _assert_close_scaled(out_offload, out_ref, "forward output")
+        _assert_close_scaled(x_offload.grad, x_ref.grad, "input gradient")


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Adds MoE routed-expert offloading: expert weights are kept in pinned host memory and streamed to GPU chunk-by-chunk during forward and backward, so each chunk's H2D copy overlaps the previous chunk's grouped GEMM. This trades host-to-device bandwidth for GPU memory, letting an MoE model train at a smaller EP size on clusters where inter-node all-to-all is the bottleneck.

Motivation, the bandwidth-vs-FLOPs analysis, and measurements are in the linked issue #6491. The short version: overlap efficiency is `T_gemm / T_load = M · 450 / 989e3`, which depends only on tokens per expert `M` — so whether a given model and parallel layout benefits is predictable in advance.

## Issue tracking

Linked issue: #6491 

## What changed

New MoE expert module plus the plumbing needed for host-resident parameters:

| File | Change |
|---|---|
| `moe/experts.py` | `OffloadingExpertsMLP` — expert module whose weights live in pinned host memory |
| `moe/experts_offloading.py` | `OffloadingExpertsGroupedMLP` autograd function; per-chunk H2D staging pipelined against grouped GEMMs on separate CUDA streams |
| `moe/experts_offloading_util.py` | `StreamManager` (stream/event ordering), `ExpertsWgradScheduler` (deferred wgrad), sharded-tensor helper |
| `moe/moe_layer.py` | select the offloading experts when `moe_use_offloading_experts` is set |
| `transformer_config.py` | config knobs + validation |
| `distributed/param_and_grad_buffer.py` | allocate `param_data` in pinned host memory for all-offloaded-expert buffers; gather host-resident buckets through a bounded GPU staging buffer |
| `distributed/distributed_data_parallel.py` | route the grad accumulation/reduce hook through the module for offloaded expert params |
| `optimizer/optimizer.py`, `optimizer/distrib_optimizer.py` | allocate the fp32 master weight on GPU for a host-resident parameter |

Two deliberate choices worth calling out for review:

- **Main gradients stay on GPU.** They are written every microbatch; moving them would put H2D/D2H traffic on the critical path. Only the weights are offloaded.
- **Host-resident buckets are gathered through a bounded GPU staging buffer.** NCCL cannot gather into host memory, so the local shard is staged up, all-gathered, and copied back. Staging is capped by a byte budget, and the number of passes is derived only from replicated quantities (shard size, group size, dtype) so every rank issues the same collectives.

## Constraints

Enforced by config validation:

- Adam with `DistributedOptimizer`
- expert tensor parallelism must be 1
- requires `gradient_accumulation_fusion`
- requires TransformerEngine for the grouped GEMM
- async checkpoint save might not be compatible

Known limitation: the parameter all-gather for host-resident buckets is synchronous and does not yet overlap with forward.

Not included: master weight and optimizer state offloading. 

## Testing

`tests/unit_tests/transformer/moe/test_offloading_experts_numerics.py` pins the whole forward and backward against a plain-`torch.matmul` reference whose backward is ordinary autograd:

- forward output, input gradient, and per-expert weight gradients, across chunk counts (1 chunk, 2 chunks, 1 expert/chunk)
- chunk count is a scheduling knob only — it must not change results
- weights stay in pinned host memory after `.cuda()`
- an expert with zero routed tokens does not corrupt its neighbours

Weight gradients are checked through `main_grad`, since `gradient_accumulation_fusion` bypasses `param.grad`. Tolerances scale with each tensor's own magnitude rather than being fixed, so the comparison stays meaningful in bf16; at these settings a 1% weight perturbation is detected.

`tests/unit_tests/transformer/moe/test_moe_layer.py` adds layer-level coverage across dispatchers and EP/TP sizes.

Beyond unit tests, the feature has been validated end-to-end during Apertus training — LM loss tracks the TE baseline, and under `deterministic_mode` it reproduces the legacy grouped-GEMM baseline exactly.

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code
- [ ] I have added relevant documentation
- [x] I have run the autoformatter on my PR

## Open questions for reviewers

1. **Module selection.** `MoELayer` currently branches on the config flag to select `OffloadingExpertsMLP` instead of the standard dispatch.
2. **Placement.** `OffloadingExpertsGroupedMLP` is a self-contained autograd function — is Megatron Core the right home, or would you rather see it in TransformerEngine?
3. **PR split.** This touches several CODEOWNERS groups. Happy to split into (a) the MoE expert module and (b) the DDP/optimizer host-parameter support if that makes review easier.


### Code review

Feel free to message or comment @NVIDIA/mcore-oncall to help accelerate your merge into main. The less complex your PR is, the faster it will be approved and merged!

All PRs start as **draft**. If you open a non-draft PR, it will be automatically converted to draft.

#### Step 1: Mark PR as "Ready for Review"

1. When your PR is ready, click **Ready for Review**.
2. An oncall reviewer is auto-assigned and expert reviewers are notified based on your changes.
   - Some PRs may jump straight to step 2. This is determined by `.github/CODEOWNERS`.

:warning: Only mark as ready once merge-conflicts are resolved and the CI is passing.
Final Review might get declined if these requirements are not fulfilled.

#### Step 2: Final Review

For PRs that change `megatron/core`, once all expert reviewers have approved, the `Final Review` label is applied **automatically** and final reviewers are assigned.

For PRs outside `megatron/core`, this step is skipped.

#### Step 3: Approved

Once all required reviewers have approved, the `Approved` label is applied **automatically**.

### Merge

Any member of [mcore-engineers](https://github.com/orgs/NVIDIA/teams/mcore-engineers) will be able to merge your PR.
