### PR TITLE
test(fsdp): verify optimizer CUDA graphs in v2

### DIFF
--- a/megatron/core/optimizer/fully_sharded_optimizer.py
+++ b/megatron/core/optimizer/fully_sharded_optimizer.py
@@ -83,8 +83,6 @@ class FullyShardedOptimizer(MixedPrecisionOptimizer):
             raise ValueError(
                 "MFSDP v2 does not currently support layer-wise distributed optimizer."
             )
-        if config.optimizer_cuda_graph:
-            raise ValueError("MFSDP v2 does not currently support optimizer CUDA graphs.")
 
     def state_dict(self):
         """Return optimizer state.

--- a/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
@@ -18,6 +18,7 @@ from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_stack_spec
 from megatron.core.models.hybrid.hybrid_model import HybridModel
 from megatron.core.optimizer import OptimizerConfig, get_megatron_optimizer
 from megatron.core.optimizer.fully_sharded_optimizer import FullyShardedOptimizer
+from megatron.core.optimizer.optimizer_cuda_graph import OptimizerCudaGraphWrapper
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.enums import AttnBackend
@@ -137,7 +138,8 @@ class TestMcoreAdapterDense:
 
         assert fully_shard_context_calls == [True]
 
-    def test_build_train_and_step(self):
+    @pytest.mark.parametrize("optimizer_cuda_graph", [False, True], ids=["eager", "cuda_graph"])
+    def test_build_train_and_step(self, optimizer_cuda_graph):
         config = TransformerConfig(
             num_layers=2,
             hidden_size=16,
@@ -156,16 +158,19 @@ class TestMcoreAdapterDense:
         # DistributedOptimizer path that expects DDP/FSDP buffer metadata.
         reference_model.ddp_config = DistributedDataParallelConfig(use_distributed_optimizer=False)
 
+        ddp_config = DistributedDataParallelConfig(
+            use_megatron_fsdp=True,
+            megatron_fsdp_version=2,
+            use_distributed_optimizer=False,
+            data_parallel_sharding_strategy="optim_grads_params",
+        )
+        if optimizer_cuda_graph:
+            # Capturable TE FusedAdam requires the main-gradient and main-weight dtypes
+            # to match (https://github.com/NVIDIA/TransformerEngine/issues/3358).
+            ddp_config.megatron_fsdp_main_grads_dtype = ddp_config.megatron_fsdp_main_params_dtype
+
         model = FullyShardedDataParallel(
-            config=config,
-            ddp_config=DistributedDataParallelConfig(
-                use_megatron_fsdp=True,
-                megatron_fsdp_version=2,
-                use_distributed_optimizer=False,
-                data_parallel_sharding_strategy="optim_grads_params",
-            ),
-            module=model,
-            pg_collection=self.pg_collection,
+            config=config, ddp_config=ddp_config, module=model, pg_collection=self.pg_collection
         )
 
         reference_optimizer_config = OptimizerConfig(
@@ -180,7 +185,9 @@ class TestMcoreAdapterDense:
         reference_optimizer = get_megatron_optimizer(
             reference_optimizer_config, [reference_model], use_gloo_process_groups=False
         )
-        optimizer_config = replace(reference_optimizer_config)
+        optimizer_config = replace(
+            reference_optimizer_config, optimizer_cuda_graph=optimizer_cuda_graph
+        )
         with pytest.raises(
             ValueError, match="MFSDP v2 currently requires use_distributed_optimizer=False"
         ):
@@ -192,6 +199,8 @@ class TestMcoreAdapterDense:
         optimizer = get_megatron_optimizer(optimizer_config, [model], use_gloo_process_groups=False)
         assert isinstance(optimizer, FullyShardedOptimizer)
         optimizer.reload_model_params()
+        if optimizer_cuda_graph:
+            optimizer.step = OptimizerCudaGraphWrapper(optimizer.step, cuda_graph_warmup_steps=1)
 
         steps = [
             [

--- a/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
@@ -224,18 +224,24 @@ class TestMcoreAdapterDense:
             reference_losses.append(torch.stack(microbatch_losses).mean())
 
         losses = []
-        for microbatches in steps:
-            model.zero_grad_buffer()
-            optimizer.zero_grad(set_to_none=True)
-            microbatch_losses = []
-            for batch in microbatches:
-                output = model(hidden_states=batch, attention_mask=None)
-                loss = output.float().square().mean()
-                (loss / len(microbatches)).backward()
-                microbatch_losses.append(loss.detach())
-            success, _, _ = optimizer.step()
-            assert success
-            losses.append(torch.stack(microbatch_losses).mean())
+        with torch.profiler.profile(activities=[torch.profiler.ProfilerActivity.CPU]) as prof:
+            for microbatches in steps:
+                model.zero_grad_buffer()
+                optimizer.zero_grad(set_to_none=True)
+                microbatch_losses = []
+                for batch in microbatches:
+                    output = model(hidden_states=batch, attention_mask=None)
+                    loss = output.float().square().mean()
+                    (loss / len(microbatches)).backward()
+                    microbatch_losses.append(loss.detach())
+                success, _, _ = optimizer.step()
+                assert success
+                losses.append(torch.stack(microbatch_losses).mean())
+
+        if optimizer_cuda_graph:
+            # The first step is eager; capture replays once and every subsequent step replays.
+            graph_launches = sum(event.name == "cudaGraphLaunch" for event in prof.events())
+            assert graph_launches == len(steps) - 1
 
         losses = torch.stack(losses)
         reference_losses = torch.stack(reference_losses)


### PR DESCRIPTION
## Summary

Enable `optimizer_cuda_graph` for MFSDP v2 by removing its configuration guard.

Extend the MCore adapter optimizer integration test to exercise eager execution plus optimizer-step CUDA-graph warmup, capture, and replay against the existing unsharded reference.

Capturable Transformer Engine FusedAdam requires main gradients to use the configured main-weight dtype. The CUDA-graph test derives that dtype from the MFSDP configuration; the eager variant retains its default bf16 main gradients. See NVIDIA/TransformerEngine#3358.

## Validation

- `python -m torch.distributed.run --nproc-per-node 2 -m pytest -q tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py::TestMcoreAdapter::test_build_train_and_step`
  - 2 passed: eager and optimizer CUDA-graph variants.
- `python -m black --check tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py`
- `python -m isort --check-only tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py`