### PR TITLE
Fix MFSDP v2 shared-embedding gradient all-reduce under pipeline parallelism

### DIFF
--- a/megatron/core/distributed/finalize_model_grads.py
+++ b/megatron/core/distributed/finalize_model_grads.py
@@ -6,6 +6,10 @@ from typing import Callable, Dict, List, Optional, Union
 import torch
 from torch._utils import _flatten_dense_tensors, _unflatten_dense_tensors
 
+from megatron.core.distributed.fsdp.src.megatron_fsdp.uneven_dtensor import (
+    uneven_dtensor_to_full_tensor,
+)
+
 try:
     from torch.distributed._tensor import DTensor, distribute_tensor
 
@@ -250,13 +254,28 @@ def _allreduce_embedding_grad(
         grad_attr = _get_main_grad_attr(weight)
         orig_grad = getattr(weight, grad_attr)
         if ddp_config.use_megatron_fsdp:
-            orig_grad = orig_grad._local_tensor if orig_grad is not None else None
-        grad = _unshard_if_dtensor(orig_grad)
+            # MFSDP v2 shards the embedding with uneven (flat-buffer) offsets, and
+            # different PP stages can use different flattened layouts. Two ranks that
+            # own the same logical tensor slice may therefore hold it at different
+            # flat-buffer offsets with different local shard shapes, so reducing the
+            # raw local shards directly would combine mismatched elements. Reconstruct
+            # the full logical gradient before the all-reduce, then copy back the slice
+            # this rank owns into its shard's local tensor.
+            grad = uneven_dtensor_to_full_tensor(orig_grad) if orig_grad is not None else None
+        else:
+            grad = _unshard_if_dtensor(orig_grad)
         # When the embedding is frozen, the grad is None.
         if grad is None and skip_if_none:
             return
         torch.distributed.all_reduce(grad, group=embd_group)
-        setattr(weight, grad_attr, _reshard_if_dtensor(grad, orig_grad))
+        if ddp_config.use_megatron_fsdp:
+            chunk = orig_grad.__create_chunk_list__()[0]
+            local_slice = tuple(
+                slice(offset, offset + size) for offset, size in zip(chunk.offsets, chunk.sizes)
+            )
+            orig_grad._local_tensor.copy_(grad[local_slice])
+        else:
+            setattr(weight, grad_attr, _reshard_if_dtensor(grad, orig_grad))
 
 
 def _allreduce_position_embedding_grads(


### PR DESCRIPTION
## Summary

MFSDP v2 shards embeddings with uneven (flat-buffer) offsets, and different PP stages can use different flattened layouts. Two ranks that own the same logical slice may hold it at different flat-buffer offsets with different local shard shapes, so reducing the raw local shards directly would combine mismatched elements.

Reconstruct the full logical embedding gradient via `uneven_dtensor_to_full_tensor` before the PP all-reduce, then copy back the slice this rank owns into its shard's local tensor.

## Changes

- `finalize_model_grads.py`: in `_allreduce_embedding_grad`, for `use_megatron_fsdp`, reconstruct the full logical embedding gradient before the all-reduce and copy back the local shard slice.

## Notes

Split out of PR #6197; standalone (no dependency on the overlap PR).