### PR TITLE
Save run config with distributed checkpoints

### DIFF
--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -1031,6 +1031,18 @@ def save_checkpoint(
         or torch.distributed.get_rank() == 0
     ):
         tracker_filename = get_checkpoint_tracker_filename(save_dir)
+        config_container = (
+            checkpointing_context.get('config_container')
+            if checkpointing_context is not None
+            else None
+        )
+        run_config_filename = (
+            os.path.join(checkpoint_name, 'run_config.yaml')
+            if ckpt_type == CheckpointType.GLOBAL
+            and config_container is not None
+            and getattr(config_container, 'model', None) is not None
+            else None
+        )
 
         if ckpt_type == CheckpointType.LOCAL:
 
@@ -1081,6 +1093,8 @@ def save_checkpoint(
                     if maybe_msc.os.path.exists(tracker_filename):
                         with maybe_msc.open(tracker_filename, 'r') as f:
                             prev_iteration = int(f.read().strip())
+                if run_config_filename is not None:
+                    config_container.to_yaml(run_config_filename)
                 with maybe_msc.open(tracker_filename, 'w') as f:
                     f.write('release' if release else str(iteration))
                 print_rank_0(

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1813,6 +1813,7 @@ def pretrain(
         }
     else:
         checkpointing_context = {}
+    checkpointing_context['config_container'] = cfg_container
 
     # Model, optimizer, and learning rate.
     timers('model-and-optimizer-setup', log_level=0).start(barrier=True)
@@ -2831,7 +2832,12 @@ def setup_model_and_optimizer(
         )
         args.iteration = 1
         save_checkpoint(
-            args.iteration, model, None, None, args.num_floating_point_operations_so_far
+            args.iteration,
+            model,
+            None,
+            None,
+            args.num_floating_point_operations_so_far,
+            checkpointing_context=checkpointing_context,
         )
         torch.distributed.barrier()
         del dense_model_for_upcycling
@@ -2927,6 +2933,12 @@ def setup_model_and_optimizer(
         args.ckpt_format = args.ckpt_convert_format
         args.save = os.path.join(args.ckpt_convert_save, args.ckpt_convert_format)
         update_use_dist_ckpt(args)
+        conversion_checkpointing_context = {}
+        if cfg_container is not None:
+            conversion_config_container = copy.deepcopy(cfg_container)
+            conversion_config_container.checkpoint.ckpt_format = args.ckpt_format
+            conversion_config_container.checkpoint.save = args.save
+            conversion_checkpointing_context['config_container'] = conversion_config_container
 
         save_checkpoint(
             args.iteration,
@@ -2934,6 +2946,7 @@ def setup_model_and_optimizer(
             optimizer,
             opt_param_scheduler,
             args.num_floating_point_operations_so_far,
+            checkpointing_context=conversion_checkpointing_context,
             preprocess_common_state_dict_fn=preprocess_common_state_dict,
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ training = [
     "transformers",
     "accelerate",
     "omegaconf",
+    "pyyaml",
     "gigatoken",
 ]
 
@@ -88,6 +89,7 @@ mlm = [
     "transformers",
     "accelerate",
     "omegaconf",
+    "pyyaml",
     "gigatoken",
 ]
 

--- a/tests/unit_tests/test_checkpointing.py
+++ b/tests/unit_tests/test_checkpointing.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 # Note: --ckpt-format torch_dist has tests in tests/unit_tests/dist_checkpointing.
 import os
+from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Optional
 from unittest import mock
@@ -8,6 +9,7 @@ from unittest import mock
 import pytest
 import torch
 import torch.distributed.checkpoint
+import yaml
 
 from megatron.core.distributed import DistributedDataParallelConfig
 from megatron.core.distributed.fsdp.mcore_fsdp_adapter import FullyShardedDataParallel
@@ -19,6 +21,7 @@ from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer import MegatronModule
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.utils import is_torch_min_version
+from megatron.training.async_utils import maybe_finalize_async_save
 from megatron.training.checkpointing import (
     CheckpointType,
     _build_sharded_state_dict_metadata,
@@ -30,7 +33,9 @@ from megatron.training.checkpointing import (
     read_metadata,
     save_checkpoint,
 )
+from megatron.training.config.container import ConfigContainerBase
 from megatron.training.global_vars import set_args
+from megatron.training.models.gpt import GPTModelConfig
 from tests.unit_tests.dist_checkpointing import TempNamedDir
 from tests.unit_tests.test_utilities import Utils
 
@@ -74,6 +79,40 @@ class MockState:
     def sharded_state_dict(self, *args, metadata: Optional[dict] = None, **kwargs):
         self._called_metadata.append(metadata)
         return self.state_dict()
+
+
+@dataclass
+class CheckpointSettingsFixture:
+    save_rng: bool
+
+
+@dataclass
+class CheckpointConfigFixture(ConfigContainerBase):
+    model: Optional[GPTModelConfig]
+    checkpoint: CheckpointSettingsFixture
+
+
+def make_checkpoint_config_fixture(include_model: bool = True) -> CheckpointConfigFixture:
+    return CheckpointConfigFixture(
+        model=(
+            GPTModelConfig(
+                transformer=TransformerConfig(num_layers=1, hidden_size=128, num_attention_heads=1),
+                vocab_size=256,
+            )
+            if include_model
+            else None
+        ),
+        checkpoint=CheckpointSettingsFixture(save_rng=True),
+    )
+
+
+def assert_run_config(run_config: dict) -> None:
+    assert run_config["_target_"] == "tests.unit_tests.test_checkpointing.CheckpointConfigFixture"
+    assert run_config["checkpoint"]["save_rng"] is True
+    assert run_config["model"]["_target_"] == "megatron.training.models.gpt.GPTModelConfig"
+    assert run_config["model"]["_builder_"] == GPTModelConfig.builder
+    assert run_config["model"]["vocab_size"] == 256
+    assert run_config["model"]["transformer"]["hidden_size"] == 128
 
 
 def test_maybe_save_dataloader_state_uses_explicit_process_groups(tmp_path):
@@ -357,6 +396,7 @@ def test_save_checkpoint(init_model_parallel, create_args, tmp_path_dist_ckpt, c
         optimizer = MockState({"state": {}})
     opt_param_scheduler = MockState({"opt_param_scheduler": "scheduler_state"})
     num_floating_point_operations_so_far = 456
+    config_container = make_checkpoint_config_fixture()
 
     with TempNamedDir(tmp_path_dist_ckpt / "test_save_checkpoint", sync=True) as save_dir:
         args.save = save_dir
@@ -364,7 +404,12 @@ def test_save_checkpoint(init_model_parallel, create_args, tmp_path_dist_ckpt, c
         set_args(args)
 
         save_checkpoint(
-            iteration, [model], optimizer, opt_param_scheduler, num_floating_point_operations_so_far
+            iteration,
+            [model],
+            optimizer,
+            opt_param_scheduler,
+            num_floating_point_operations_so_far,
+            checkpointing_context={"config_container": config_container},
         )
 
         with open(args.save / "latest_checkpointed_iteration.txt", "r") as f:
@@ -379,6 +424,81 @@ def test_save_checkpoint(init_model_parallel, create_args, tmp_path_dist_ckpt, c
             expected_ckpt_path = ckpt_dir / ".metadata"
 
         assert os.path.exists(expected_ckpt_path)
+
+        run_config_path = ckpt_dir / "run_config.yaml"
+        if args.use_dist_ckpt:
+            with open(run_config_path, "r") as f:
+                run_config = yaml.safe_load(f)
+            assert_run_config(run_config)
+        else:
+            assert not run_config_path.exists()
+
+
+def test_save_run_config_after_async_checkpoint(
+    init_model_parallel, create_ckpt_load_args, tmp_path_dist_ckpt
+):
+    args = create_ckpt_load_args
+    args.async_save = True
+    args.ckpt_format = "torch_dist"
+    args.use_distributed_optimizer = True
+    args.use_dist_ckpt = True
+    args.save_tokenizer_assets = False
+
+    config_container = make_checkpoint_config_fixture()
+    config = TransformerConfig(num_layers=1, kv_channels=1)
+    model = MockModel(config)
+    optimizer = MockState({"optimizer": "optimizer_state"})
+    opt_param_scheduler = MockState({"opt_param_scheduler": "scheduler_state"})
+
+    with mock.patch("megatron.training.async_utils._async_calls_queue", None):
+        with TempNamedDir(tmp_path_dist_ckpt / "test_async_run_config", sync=True) as save_dir:
+            args.save = save_dir
+            set_args(args)
+            run_config_path = save_dir / "iter_0000123" / "run_config.yaml"
+
+            save_checkpoint(
+                123,
+                [model],
+                optimizer,
+                opt_param_scheduler,
+                456,
+                checkpointing_context={"config_container": config_container},
+            )
+
+            assert not run_config_path.exists()
+            maybe_finalize_async_save(blocking=True)
+
+            with open(run_config_path, "r") as f:
+                assert_run_config(yaml.safe_load(f))
+
+
+def test_save_run_config_requires_model_config(
+    init_model_parallel, create_ckpt_load_args, tmp_path_dist_ckpt
+):
+    args = create_ckpt_load_args
+    args.async_save = False
+    args.ckpt_format = "torch_dist"
+    args.use_distributed_optimizer = True
+    args.use_dist_ckpt = True
+    args.save_tokenizer_assets = False
+    config = TransformerConfig(num_layers=1, kv_channels=1)
+
+    with TempNamedDir(tmp_path_dist_ckpt / "test_run_config_without_model", sync=True) as save_dir:
+        args.save = save_dir
+        set_args(args)
+
+        save_checkpoint(
+            123,
+            [MockModel(config)],
+            MockState({"optimizer": "optimizer_state"}),
+            MockState({"opt_param_scheduler": "scheduler_state"}),
+            456,
+            checkpointing_context={
+                "config_container": make_checkpoint_config_fixture(include_model=False)
+            },
+        )
+
+        assert not (save_dir / "iter_0000123" / "run_config.yaml").exists()
 
 
 @pytest.mark.parametrize("ckpt_format", ["torch"])

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -2332,6 +2332,7 @@ mlm = [
     { name = "flask-restful" },
     { name = "gigatoken" },
     { name = "omegaconf" },
+    { name = "pyyaml" },
     { name = "sentencepiece" },
     { name = "tiktoken" },
     { name = "transformers" },
@@ -2353,6 +2354,7 @@ training = [
     { name = "flask-restful" },
     { name = "gigatoken" },
     { name = "omegaconf" },
+    { name = "pyyaml" },
     { name = "sentencepiece" },
     { name = "tiktoken" },
     { name = "transformers" },
@@ -2450,6 +2452,8 @@ requires-dist = [
     { name = "orjson", marker = "extra == 'dev'" },
     { name = "packaging", specifier = ">=24.2" },
     { name = "pillow", marker = "extra == 'dev'" },
+    { name = "pyyaml", marker = "extra == 'mlm'" },
+    { name = "pyyaml", marker = "extra == 'training'" },
     { name = "quart", marker = "extra == 'dev'" },
     { name = "sentencepiece", marker = "extra == 'mlm'" },
     { name = "sentencepiece", marker = "extra == 'training'" },


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?

Writes active `PretrainConfigContainer` to `run_config.yaml` in each global distributed checkpoint iteration directory. Async saves write sidecar after checkpoint payload completes and before latest-iteration tracker advances.

Legacy checkpoint state stays unchanged. Provider-based entrypoints without serializable model config keep Megatron Bridge's existing `common.pt` argument fallback.

Adds direct PyYAML runtime dependency for training extras.

## Issue tracking

Fixes #6002

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code
- [ ] I have added relevant documentation
- [x] I have run the autoformatter on my PR

## Testing

- `CUDA_DEVICE_MAX_CONNECTIONS=1 python -m torch.distributed.run --nproc-per-node=1 -m pytest tests/unit_tests/test_checkpointing.py -q`
  - 22 passed
- `uv run ruff check --no-fix megatron/training/checkpointing.py megatron/training/training.py tests/unit_tests/test_checkpointing.py`
- `uv lock --check`
- `git diff --check`