### PR TITLE
Add option to skip Muon for MoE routers

### DIFF
--- a/megatron/core/transformer/moe/router.py
+++ b/megatron/core/transformer/moe/router.py
@@ -70,6 +70,10 @@ class Router(ABC, MegatronModule):
             )
         else:
             self.bias = None
+        if self.config.moe_router_skip_muon:
+            setattr(self.weight, 'use_muon', False)
+            if self.bias is not None:
+                setattr(self.bias, 'use_muon', False)
         # If calculate per token loss, we need to scale up moe aux loss by the number of tokens.
         # So we need to know if the model is configured to calculate per token loss.
         self.calculate_per_token_loss = self.config.calculate_per_token_loss

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -799,6 +799,9 @@ class TransformerConfig(ModelParallelConfig):
     improve stability especially when the number of experts is large (e.g. finegrained-moe).
     None means no changes for dtype."""
 
+    moe_router_skip_muon: bool = False
+    """Use the scalar optimizer instead of Muon for MoE router parameters."""
+
     moe_router_enable_expert_bias: bool = False
     """TopK routing with dynamic per-expert bias in the aux-loss-free load balancing strategy.
     The routing decision is based on the sum of the routing scores and the expert bias.

--- a/tests/unit_tests/models/test_hybrid_moe_model.py
+++ b/tests/unit_tests/models/test_hybrid_moe_model.py
@@ -218,7 +218,7 @@ GOLDEN_CONFIG: Dict[str, Any] = {
     "moe_router_pre_softmax": False,
     "moe_router_quantile_balancing_ema": 0.0,
     "moe_router_score_function": "sigmoid",
-    "moe_router_skip_muon": False,
+    "moe_router_skip_muon": True,
     "moe_router_topk": 6,
     "moe_router_topk_limited_devices": None,
     "moe_router_topk_scaling_factor": 2.5,
@@ -491,6 +491,7 @@ class TestHybridMoEModel:
         args.moe_grouped_gemm = True
         args.moe_shared_expert_intermediate_size = 3712
         args.moe_router_score_function = "sigmoid"
+        args.moe_router_skip_muon = True
         args.moe_router_enable_expert_bias = True
         args.moe_router_topk_scaling_factor = 2.5
         args.mamba_state_dim = 128

--- a/tests/unit_tests/models/test_hybrid_moe_model.py
+++ b/tests/unit_tests/models/test_hybrid_moe_model.py
@@ -218,6 +218,7 @@ GOLDEN_CONFIG: Dict[str, Any] = {
     "moe_router_pre_softmax": False,
     "moe_router_quantile_balancing_ema": 0.0,
     "moe_router_score_function": "sigmoid",
+    "moe_router_skip_muon": False,
     "moe_router_topk": 6,
     "moe_router_topk_limited_devices": None,
     "moe_router_topk_scaling_factor": 2.5,

--- a/tests/unit_tests/transformer/moe/test_routers.py
+++ b/tests/unit_tests/transformer/moe/test_routers.py
@@ -67,6 +67,21 @@ class TestTop2Router:
         assert num_weights == 12 * 4, num_weights
 
     @pytest.mark.internal
+    def test_skip_muon(self):
+        assert getattr(self.router.weight, 'use_muon', True)
+
+        self.transformer_config.moe_router_skip_muon = True
+        self.transformer_config.add_bias_linear = True
+        submodules = get_submodules(
+            get_gpt_layer_local_submodules(num_experts=4, moe_grouped_gemm=False).mlp
+        )
+        router = cast(Router, MoELayer(self.transformer_config, submodules).router)
+
+        assert getattr(router.weight, 'use_muon', True) is False
+        assert router.bias is not None
+        assert getattr(router.bias, 'use_muon', True) is False
+
+    @pytest.mark.internal
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
     @pytest.mark.parametrize("moe_router_pre_softmax", [(True), (False)])
     @pytest.mark.parametrize("score_function", ["sigmoid", "softmax"])


### PR DESCRIPTION
## Summary

- add an opt-in `--moe-router-skip-muon` flag (default: disabled)
- mark MoE router weights and biases with `use_muon=False` when enabled so the existing `_is_muon_excluded` selector routes them to the scalar optimizer
- cover the default and opt-in router parameter tagging behavior

## Validation

- `python3 -m py_compile megatron/core/transformer/transformer_config.py megatron/core/transformer/moe/router.py tests/unit_tests/transformer/moe/test_routers.py`
- `git diff --check HEAD^ HEAD`

The focused distributed pytest and repository autoformatter were not run locally because this checkout does not have `uv` or PyTorch installed.