### PR TITLE
Support mixed-precision optimizers in MFSDP v2

### DIFF
--- a/megatron/core/optimizer/__init__.py
+++ b/megatron/core/optimizer/__init__.py
@@ -573,7 +573,9 @@ def _get_megatron_optimizer_based_on_param_groups(
                 # Otherwise, master weight will be managed by TransformerEngine.
                 # Delayed scaling is an exception because casting as well as the computation
                 # of the scaling factor can be conducted in the adam kernel.
-                if config.use_precision_aware_optimizer_no_fp8_or_ds_fp8:
+                if config.use_precision_aware_optimizer_no_fp8_or_ds_fp8 and not isinstance(
+                    model_chunks[0], FullyShardedDataParallelV2
+                ):
                     kwargs.update(
                         {
                             "master_weights": True,
@@ -1052,6 +1054,10 @@ def get_megatron_optimizer(
     if is_mfsdp_v2:
         if config.use_distributed_optimizer:
             raise ValueError("MFSDP v2 currently requires use_distributed_optimizer=False.")
+    elif config.use_precision_aware_optimizer and not config.use_distributed_optimizer:
+        raise ValueError(
+            "--use-precision-aware-optimizer only supported with distributed optimizer"
+        )
 
     # Separate out first model chunk if overlapping param AG with optimizer step.
     if config.overlap_param_gather_with_optimizer_step:
@@ -1142,6 +1148,7 @@ def get_megatron_optimizer(
             if (
                 not USING_PYTORCH_OPTIMIZER
                 and config.use_precision_aware_optimizer
+                and not is_mfsdp_v2
                 and getattr(optimizer_part.optimizer, "master_weights", None) is not None
             ):
                 # NOTE(@cspades): FusedAdam is provided Megatron-FSDP's main weights as

--- a/megatron/core/optimizer/fully_sharded_optimizer.py
+++ b/megatron/core/optimizer/fully_sharded_optimizer.py
@@ -58,6 +58,7 @@ class FullyShardedOptimizer(MixedPrecisionOptimizer):
             if self.ddp_config != model_chunk.ddp_config:
                 raise ValueError("All MFSDP v2 model chunks must share the same ddp_config.")
         self.is_stub_optimizer = optimizer is None
+        self._casted_grads = []
 
     @staticmethod
     def _validate_config(config: OptimizerConfig, model_chunks: List[MegatronModule]) -> None:
@@ -116,7 +117,33 @@ class FullyShardedOptimizer(MixedPrecisionOptimizer):
             model_chunk.zero_grad(set_to_none=set_to_none)
 
     def _copy_model_grads_to_main_grads(self) -> None:
-        """No-op: MFSDP v2 reduces directly into optimizer-visible sharded grads."""
+        """Install optimizer-compatible gradients for non-precision-aware optimizers."""
+        if self.config.use_precision_aware_optimizer:
+            return
+
+        assert not self._casted_grads
+        for parameter in self.get_parameters():
+            if parameter.grad is None:
+                continue
+            if parameter.grad.dtype == parameter.data.dtype:
+                continue
+
+            original_grad = parameter.grad
+            parameter.grad = None
+            parameter.grad_dtype = parameter.data.dtype
+            parameter.grad = original_grad.to(dtype=parameter.data.dtype)
+            self._casted_grads.append((parameter, original_grad))
+
+    @torch.no_grad()
+    def step_with_ready_grads(self) -> bool:
+        """Step the optimizer and restore MFSDP gradient dtypes."""
+        success = super().step_with_ready_grads()
+        for parameter, original_grad in self._casted_grads:
+            parameter.grad = None
+            parameter.grad_dtype = original_grad.dtype
+            parameter.grad = original_grad
+        self._casted_grads.clear()
+        return success
 
     def _copy_main_params_to_model_params(self) -> None:
         """Refresh MFSDP V2 compute weights after updating optimizer weights."""

--- a/megatron/core/optimizer/fully_sharded_optimizer.py
+++ b/megatron/core/optimizer/fully_sharded_optimizer.py
@@ -77,8 +77,6 @@ class FullyShardedOptimizer(MixedPrecisionOptimizer):
             raise ValueError("MFSDP v2 does not support optimizer-step parameter-gather overlap.")
         if config.optimizer_cpu_offload:
             raise ValueError("MFSDP v2 does not currently support optimizer CPU offload.")
-        if config.use_precision_aware_optimizer:
-            raise ValueError("MFSDP v2 does not currently support precision-aware optimizer.")
         if config.use_layer_wise_distributed_optimizer:
             raise ValueError(
                 "MFSDP v2 does not currently support layer-wise distributed optimizer."

--- a/megatron/core/optimizer/optimizer_config.py
+++ b/megatron/core/optimizer/optimizer_config.py
@@ -434,10 +434,6 @@ class OptimizerConfig:
             assert (
                 self.optimizer == 'adam'
             ), '--use-precision-aware-optimizer only supported with adam'
-            assert (
-                self.use_distributed_optimizer
-            ), '--use-precision-aware-optimizer only supported with distributed optimizer'
-
             if not is_te_min_version("2.1.0"):
                 self.store_param_remainders = False
 

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -2096,11 +2096,8 @@ def get_megatron_ddp_config(args: argparse.Namespace) -> DistributedDataParallel
         kwargs["megatron_fsdp_main_params_dtype"] = args.megatron_fsdp_main_params_dtype
         kwargs["megatron_fsdp_main_grads_dtype"] = args.megatron_fsdp_main_grads_dtype
         kwargs["megatron_fsdp_grad_comm_dtype"] = args.megatron_fsdp_grad_comm_dtype
-        kwargs["megatron_fsdp_use_decoupled_grad"] = args.use_precision_aware_optimizer
-        if args.use_megatron_fsdp and args.megatron_fsdp_version == 2:
-            # MFSDP v2 gathers parameters from module hooks rather than the V1
-            # start_param_sync path, so disable the V1-only startup all-gather knob.
-            kwargs["fsdp_all_gather_in_start_param_sync"] = False
+        if args.use_megatron_fsdp and args.megatron_fsdp_version == 1:
+            kwargs["megatron_fsdp_use_decoupled_grad"] = args.use_precision_aware_optimizer
         if args.use_megatron_fsdp and args.cuda_graph_impl != "none":
             # Run Megatron-FSDP in CUDA graph-safe mode. Avoids some graph-unsafe host-side
             # operations (such as pointer dereferencing) that can break CUDA graph replay.

--- a/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
@@ -258,6 +258,62 @@ class TestMcoreAdapterDense:
         torch.testing.assert_close(losses, reference_losses, rtol=1e-3, atol=0)
 
 
+    def test_fused_sgd_rejects_mismatched_grads(self):
+        """FusedSGD cannot consume V2's BF16 gradients for FP32 weights."""
+        config = TransformerConfig(
+            num_layers=1,
+            hidden_size=16,
+            num_attention_heads=4,
+            ffn_hidden_size=32,
+            bf16=True,
+            params_dtype=torch.bfloat16,
+            attention_dropout=0.0,
+            hidden_dropout=0.0,
+        )
+        model = FullyShardedDataParallel(
+            config=config,
+            ddp_config=DistributedDataParallelConfig(
+                use_megatron_fsdp=True,
+                megatron_fsdp_version=2,
+                use_distributed_optimizer=False,
+                data_parallel_sharding_strategy="optim_grads_params",
+                megatron_fsdp_main_params_dtype=torch.float32,
+                megatron_fsdp_main_grads_dtype=torch.bfloat16,
+            ),
+            module=_build_block(config),
+            pg_collection=self.pg_collection,
+        )
+        optimizer_config = OptimizerConfig(
+            optimizer="sgd",
+            lr=1.0e-3,
+            weight_decay=0.0,
+            bf16=True,
+            params_dtype=torch.bfloat16,
+            use_distributed_optimizer=False,
+            clip_grad=0.0,
+        )
+        optimizer = get_megatron_optimizer(
+            optimizer_config,
+            [model],
+            use_gloo_process_groups=False,
+            pg_collection=self.pg_collection,
+        )
+
+        optimizer.zero_grad(set_to_none=True)
+        output = model(
+            hidden_states=torch.randn(
+                8, 2, config.hidden_size, device="cuda", dtype=torch.bfloat16
+            ),
+            attention_mask=None,
+        )
+        output.float().square().mean().backward()
+
+        with pytest.raises(
+            RuntimeError, match="Unsupported combination of weight and gradient types"
+        ):
+            optimizer.step()
+
+
 class TestMcoreAdapterExpertParallel:
     """Exercise the MFSDP v2 adapter over an MoE model with EP=2."""
 

--- a/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
@@ -257,7 +257,6 @@ class TestMcoreAdapterDense:
         assert torch.isfinite(reference_losses).all()
         torch.testing.assert_close(losses, reference_losses, rtol=1e-3, atol=0)
 
-
     def test_fused_sgd_casts_mismatched_grads(self):
         """FusedSGD steps after MCore casts V2's BF16 gradients to FP32."""
         config = TransformerConfig(

--- a/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
@@ -186,7 +186,11 @@ class TestMcoreAdapterDense:
             reference_optimizer_config, [reference_model], use_gloo_process_groups=False
         )
         optimizer_config = replace(
-            reference_optimizer_config, optimizer_cuda_graph=optimizer_cuda_graph
+            reference_optimizer_config,
+            optimizer_cuda_graph=optimizer_cuda_graph,
+            use_precision_aware_optimizer=True,
+            exp_avg_dtype=torch.bfloat16,
+            exp_avg_sq_dtype=torch.bfloat16,
         )
         with pytest.raises(
             ValueError, match="MFSDP v2 currently requires use_distributed_optimizer=False"
@@ -242,6 +246,10 @@ class TestMcoreAdapterDense:
             # The first step is eager; capture replays once and every subsequent step replays.
             graph_launches = sum(event.name == "cudaGraphLaunch" for event in prof.events())
             assert graph_launches == len(steps) - 1
+
+        for state in optimizer.optimizer.state.values():
+            assert state["exp_avg"].dtype == torch.bfloat16
+            assert state["exp_avg_sq"].dtype == torch.bfloat16
 
         losses = torch.stack(losses)
         reference_losses = torch.stack(reference_losses)

--- a/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py
@@ -258,8 +258,8 @@ class TestMcoreAdapterDense:
         torch.testing.assert_close(losses, reference_losses, rtol=1e-3, atol=0)
 
 
-    def test_fused_sgd_rejects_mismatched_grads(self):
-        """FusedSGD cannot consume V2's BF16 gradients for FP32 weights."""
+    def test_fused_sgd_casts_mismatched_grads(self):
+        """FusedSGD steps after MCore casts V2's BF16 gradients to FP32."""
         config = TransformerConfig(
             num_layers=1,
             hidden_size=16,
@@ -308,10 +308,8 @@ class TestMcoreAdapterDense:
         )
         output.float().square().mean().backward()
 
-        with pytest.raises(
-            RuntimeError, match="Unsupported combination of weight and gradient types"
-        ):
-            optimizer.step()
+        success, _, _ = optimizer.step()
+        assert success
 
 
 class TestMcoreAdapterExpertParallel:


### PR DESCRIPTION
## Summary

- Enable `--use-precision-aware-optimizer` with Megatron-FSDP v2 so Transformer Engine FusedAdam receives `exp_avg_dtype` and `exp_avg_sq_dtype`.
- Keep MFSDP v2 on its FP32 main weights and direct reduced gradients; it does not use the V1-only `decoupled_grad` or FusedAdam master-weight path.
- Cast MFSDP v2 gradients to the parameter-data dtype for non-precision-aware optimizers before MCore clipping and stepping, then restore the original gradient dtype. This allows FusedSGD and other regular optimizers to use BF16 reduced gradients with FP32 main weights.

## Why

MFSDP v2 already has FP32 optimizer parameters and may reduce gradients in BF16. FusedAdam can consume that mixed-dtype pair directly, while regular optimizers such as FusedSGD require matching parameter and gradient dtypes. The MCore wrapper now selects the appropriate behavior from `use_precision_aware_optimizer`.

## Validation

- `python -m torch.distributed.run --nproc-per-node 2 -m pytest -q tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py::TestMcoreAdapter::test_build_train_and_step --capture=fd`
- `python -m torch.distributed.run --nproc-per-node 2 -m pytest -q tests/unit_tests/distributed/mfsdp_v2/test_mcore_adapter.py::TestMcoreAdapter::test_fused_sgd_casts_mismatched_grads --capture=fd`
- `git diff --check`