### PR TITLE
fix(cuda-graphs): honor FP32 residual input dtype

### DIFF
--- a/megatron/core/transformer/module.py
+++ b/megatron/core/transformer/module.py
@@ -253,10 +253,14 @@ class GraphableMegatronModule(MegatronModule):
             slen_per_cp // tensor_model_parallel_size if sequence_parallel else slen_per_cp
         )
 
+        hidden_states_dtype = (
+            torch.float32 if self.config.fp32_residual_connection else self.config.params_dtype
+        )
+
         static_inputs = {}
         static_inputs["hidden_states"] = torch.ones(
             (slen_per_cptp, micro_batch_size, self.config.hidden_size),
-            dtype=torch.bfloat16,
+            dtype=hidden_states_dtype,
             requires_grad=True,
             device=torch.cuda.current_device(),
         )

--- a/tests/unit_tests/transformer/test_graphable_module.py
+++ b/tests/unit_tests/transformer/test_graphable_module.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from megatron.core.transformer.module import GraphableMegatronModule
+
+
+@pytest.mark.parametrize(
+    ("fp32_residual_connection", "params_dtype", "expected_dtype"),
+    [
+        (True, torch.bfloat16, torch.float32),
+        (False, torch.bfloat16, torch.bfloat16),
+        (False, torch.float16, torch.float16),
+    ],
+)
+def test_static_hidden_states_match_residual_stream_dtype(
+    monkeypatch: pytest.MonkeyPatch,
+    fp32_residual_connection: bool,
+    params_dtype: torch.dtype,
+    expected_dtype: torch.dtype,
+) -> None:
+    captured = {}
+    sentinel = object()
+
+    def fake_ones(shape, **kwargs):
+        captured["shape"] = shape
+        captured.update(kwargs)
+        return sentinel
+
+    monkeypatch.setattr(torch, "ones", fake_ones)
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: 3)
+
+    module = SimpleNamespace(
+        config=SimpleNamespace(
+            context_parallel_size=2,
+            sequence_parallel=True,
+            tensor_model_parallel_size=4,
+            hidden_size=128,
+            fp32_residual_connection=fp32_residual_connection,
+            params_dtype=params_dtype,
+        )
+    )
+
+    static_inputs = GraphableMegatronModule.get_layer_static_inputs(
+        module, seq_length=64, micro_batch_size=2
+    )
+
+    assert static_inputs == {"hidden_states": sentinel}
+    assert captured == {
+        "shape": (8, 2, 128),
+        "dtype": expected_dtype,
+        "requires_grad": True,
+        "device": 3,
+    }


### PR DESCRIPTION

  # What does this PR do?

  Fixes CUDA graph static input creation to preserve the hidden-state dtype when `fp32_residual_connection` is enabled.

  `GraphableMegatronModule.get_layer_static_inputs()` previously hardcoded the static `hidden_states` tensor to BF16. However, with `fp32_residual_connection=True`, the actual residual stream is FP32.
  This mismatch can cause CUDA graph capture or replay failures.

  The static input now:

  - Uses `torch.float32` when `fp32_residual_connection=True`.
  - Otherwise follows `config.params_dtype`, preserving BF16 and FP16 behavior.

  A regression test covers FP32 residual, BF16, and FP16 configurations.

  ## Issue tracking

  Linked issue: N/A

  ## Contribution process

  ### Pre-checks

  - [x] I have added relevant unit tests
  - [ ] I have added relevant functional tests (not applicable for this focused dtype fix)
  - [x] I have added proper typing to my code
  - [ ] I have added relevant documentation (not applicable; no user-facing API change)
  - [ ] I have run `autoformatter.sh`