### PR TITLE
fix(checkpoint): replicate stateless grouped extra state

### DIFF
--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -2339,6 +2339,10 @@ if HAVE_TE and is_te_min_version("1.9.0.dev0"):
             if not fp8_checkpoint:
                 return [state] * self.num_gemms
 
+            # Stateless FP8 recipes have no extra state to split.
+            if isinstance(state, torch.Tensor) and state.numel() == 0:
+                return [state] * self.num_gemms
+
             state = self._decode_extra_state(state)
             extra_states = []
             extra_fp8_variables = state["extra_fp8_variables"]

--- a/tests/unit_tests/transformer/test_transformer_engine_grouped_linear.py
+++ b/tests/unit_tests/transformer/test_transformer_engine_grouped_linear.py
@@ -93,6 +93,19 @@ def test_split_grouped_checkpoint_tensor_rejects_zero_dim():
         module._split_grouped_checkpoint_tensor(tensor, "weight")
 
 
+def test_split_extra_state_replicates_stateless_empty_state():
+    module = _grouped_linear_stub(num_gemms=2)
+    module.fp8_meta = {"fp8_checkpoint": False}
+    module.fp8 = True
+    module.fp8_calibration = False
+    empty_state = torch.empty(0, dtype=torch.uint8)
+
+    extra_states = module._split_extra_state(empty_state)
+
+    assert len(extra_states) == 2
+    assert all(extra_state is empty_state for extra_state in extra_states)
+
+
 def test_normalize_grouped_parameter_keys_indexed_to_grouped_weight_only():
     module = _grouped_linear_stub(num_gemms=3, use_bias=False, single_grouped_weight=True)
     indexed = [torch.tensor([float(i), float(i) + 0.5]) for i in range(3)]


### PR DESCRIPTION
# What does this PR do?

Replicate an empty Transformer Engine grouped-linear `_extra_state` entry for each expert when saving a sharded checkpoint.

Stateless FP8 recipes encode the absence of extra state as an empty byte tensor. The grouped-linear checkpoint adapter previously tried to decode that tensor as serialized FP8 metadata whenever FP8 execution was active, which returned no state and then failed while indexing it. Treating the empty tensor as stateless preserves the per-expert checkpoint key layout without inventing FP8 metadata.

## Issue tracking

Linked issue: N/A

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code
- [ ] I have added relevant documentation
- [x] I have run the autoformatter on my PR

### Validation

- `uv run python -m torch.distributed.run --standalone --nproc_per_node=4 -m pytest -q tests/unit_tests/transformer/test_transformer_engine_grouped_linear.py` (`15 passed` on every rank)
- `BASE_REF=base CHECK_ONLY=true SKIP_DOCS=true bash tools/autoformat.sh`
- 128-GPU DeepSeek V4 real-data training completed 100 finite steps, saved model, distributed optimizer, and RNG state, then loaded iteration 100 and resumed through iteration 105

- [x] I, the PR author, have personally reviewed every line of this PR.
