### PR TITLE
Parallelism aware Implementation of Hidden State Mixing for the MTP

### DIFF
--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -65,6 +65,36 @@ else:
 from megatron.core.transformer.pipeline_parallel_layer_layout import PipelineParallelLayerLayout
 
 
+def _hsm_mix(hidden_states_list: List[Tensor]) -> Tensor:
+    """Select one accumulated hidden state independently for every token.
+
+    The data-parallel RNG stream is shared by model-parallel ranks, which keeps
+    selections consistent when those ranks hold different shards of the same
+    activation.
+    """
+    num_states = len(hidden_states_list)
+    assert num_states > 0, "Hidden State Mixing requires at least one state."
+
+    sequence_length, batch_size, hidden_size = hidden_states_list[0].shape
+    rng_tracker = tensor_parallel.get_cuda_rng_tracker()
+    rng_context = (
+        rng_tracker.fork(tensor_parallel.get_data_parallel_rng_tracker_name())
+        if rng_tracker.is_initialized()
+        else nullcontext()
+    )
+    with rng_context:
+        indices = torch.randint(
+            num_states,
+            (1, sequence_length, batch_size, 1),
+            device=hidden_states_list[0].device,
+        )
+
+    stacked = torch.stack(hidden_states_list, dim=0)
+    return torch.gather(
+        stacked, dim=0, index=indices.expand(-1, -1, -1, hidden_size)
+    ).squeeze(0)
+
+
 def tie_word_embeddings_state_dict(
     sharded_state_dict: ShardedStateDict,
     word_emb_weight: Tensor,
@@ -1855,12 +1885,46 @@ class MultiTokenPredictionBlock(MegatronModule):
         if self.config.mtp_detach_heads:
             hidden_states = hidden_states.detach()
 
+        hsm_enabled = (
+            self.config.mtp_hsm and self.training and self.config.mtp_num_layers >= 2
+        )
+        if hsm_enabled:
+            hsm_history = [hidden_states]
+
         for iteration in range(self.config.mtp_num_layers):
             layer_idx = 0 if self.mtp_use_repeated_layer else iteration
+
+            # Older HSM entries predict earlier targets than the newest entry. Roll
+            # them once per depth so all candidates correspond to the same target.
+            if hsm_enabled and len(hsm_history) > 1:
+                entries_to_roll = hsm_history[:-1]
+                newest_entry = hsm_history[-1]
+                num_entries = len(entries_to_roll)
+                sequence_length, batch_size, hidden_size = entries_to_roll[0].shape
+                stacked = torch.stack(entries_to_roll, dim=0)
+                flattened = stacked.permute(0, 2, 3, 1).reshape(
+                    num_entries * batch_size, hidden_size, sequence_length
+                )
+                rolled, _ = roll_tensor(
+                    flattened,
+                    shifts=-1,
+                    dims=-1,
+                    cp_group=self.cp_group,
+                    packed_seq_params=packed_seq_params,
+                )
+                hsm_history = list(
+                    rolled.reshape(num_entries, batch_size, hidden_size, sequence_length)
+                    .permute(0, 3, 1, 2)
+                    .unbind(0)
+                ) + [newest_entry]
+                hidden_states_input = _hsm_mix(hsm_history)
+            else:
+                hidden_states_input = hidden_states
+
             hidden_states, input_ids, position_ids, padding_mask = self.layers[layer_idx](
                 input_ids=input_ids,
                 position_ids=position_ids,
-                hidden_states=hidden_states,
+                hidden_states=hidden_states_input,
                 attention_mask=attention_mask,
                 padding_mask=padding_mask,
                 inference_params=inference_params,
@@ -1872,6 +1936,9 @@ class MultiTokenPredictionBlock(MegatronModule):
                 embedding=embedding,
                 **(extra_block_kwargs or {}),
             )
+
+            if hsm_enabled:
+                hsm_history.append(hidden_states)
 
             # append the output hidden states of the current mtp layer
             # to the hidden_states_list

--- a/megatron/core/transformer/multi_token_prediction.py
+++ b/megatron/core/transformer/multi_token_prediction.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import warnings
 from contextlib import nullcontext
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Callable, List, Optional, Union
+from typing import TYPE_CHECKING, Callable, List, Literal, Optional, Union
 
 import torch
 from torch import Tensor
@@ -21,6 +21,7 @@ from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.pipeline_parallel.utils import is_vp_last_stage
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel import (
+    gather_from_sequence_parallel_region,
     gather_from_tensor_model_parallel_region,
     scatter_to_sequence_parallel_region,
 )
@@ -165,7 +166,15 @@ def tie_output_layer_state_dict(
     )
 
 
-def roll_tensor(tensor, shifts=-1, dims=-1, cp_group=None, packed_seq_params=None):
+def roll_tensor(
+    tensor,
+    shifts=-1,
+    dims=-1,
+    cp_group=None,
+    packed_seq_params=None,
+    return_sum=True,
+    cp_token_layout='zigzag',
+):
     """Roll the tensor input along the sequence dimension with Context Parallelism (CP) support.
 
     This function extends the original roll_tensor to support Context Parallelism, which allows
@@ -188,21 +197,49 @@ def roll_tensor(tensor, shifts=-1, dims=-1, cp_group=None, packed_seq_params=Non
                                falls back to standard rolling behavior.
         packed_seq_params (PackedSeqParams): Parameters for packed sequence processing.
                                             If provided, respects sequence boundaries.
+        return_sum (bool): Whether to compute and return the rolled tensor sum.
+        cp_token_layout (str): CP ownership layout, ``zigzag`` or ``contiguous``.
     Returns:
         tuple: (rolled_tensor, sum_of_rolled_tensor)
     """
     if tensor is None:
         return None, None
+    assert cp_token_layout in ('zigzag', 'contiguous'), (
+        f"Unsupported CP token layout {cp_token_layout!r}."
+    )
 
     # Handle packed sequences cases
     if packed_seq_params is not None:
-        return _roll_tensor_packed_seq(tensor, shifts, dims, packed_seq_params, cp_group)
+        return _roll_tensor_packed_seq(
+            tensor,
+            shifts,
+            dims,
+            packed_seq_params,
+            cp_group,
+            return_sum=return_sum,
+            cp_token_layout=cp_token_layout,
+        )
 
     # Standard rolling behavior when CP is not enabled (cp_group is None or size=1)
     if cp_group is None or cp_group.size() == 1:
         rolled_tensor = torch.roll(tensor, shifts=shifts, dims=dims)
         rolled_tensor.select(dims, shifts).fill_(0)
-        return rolled_tensor, rolled_tensor.sum()
+        return rolled_tensor, rolled_tensor.sum() if return_sum else None
+
+    if cp_token_layout == 'contiguous':
+        assert shifts == -1, "Contiguous CP rolling supports only a one-token left shift."
+        sequence_first = tensor.movedim(dims, 0).contiguous()
+        layout = _build_sequence_parallel_context_roll_layout(
+            sequence_first.size(0),
+            None,
+            None,
+            cp_group,
+            cp_token_layout=cp_token_layout,
+        )
+        assert layout is not None, "Invalid contiguous CP rolling layout."
+        rolled = _SequenceParallelContextBoundaryRoll.apply(sequence_first, layout)
+        rolled = rolled.movedim(0, dims).contiguous()
+        return rolled, rolled.sum() if return_sum else None
 
     # CP-enabled rolling: Split tensor into chunks and handle boundary communication
     # This matches the batch splitting logic in get_batch_on_this_cp_rank() function
@@ -263,10 +300,18 @@ def roll_tensor(tensor, shifts=-1, dims=-1, cp_group=None, packed_seq_params=Non
     # Concatenate the processed chunks back into a single tensor
     rolled_tensor = torch.cat(rolled_tensor_list, dim=dims)
 
-    return rolled_tensor, rolled_tensor.sum()
+    return rolled_tensor, rolled_tensor.sum() if return_sum else None
 
 
-def _roll_tensor_packed_seq(tensor, shifts, dims, packed_seq_params, cp_group=None):
+def _roll_tensor_packed_seq(
+    tensor,
+    shifts,
+    dims,
+    packed_seq_params,
+    cp_group=None,
+    return_sum=True,
+    cp_token_layout='zigzag',
+):
     """Roll tensor with packed sequence support.
     This function handles rolling for packed sequences by respecting sequence boundaries
     """
@@ -293,7 +338,20 @@ def _roll_tensor_packed_seq(tensor, shifts, dims, packed_seq_params, cp_group=No
             # Zero out the last position(s) that would cross sequence boundaries
             rolled_seq[..., shifts:] = 0
             rolled_tensor[..., start_idx:end_idx] = rolled_seq
-        return rolled_tensor, rolled_tensor.sum()
+        return rolled_tensor, rolled_tensor.sum() if return_sum else None
+
+    sequence_first = tensor.movedim(dims, 0).contiguous()
+    layout = _build_sequence_parallel_context_roll_layout(
+        sequence_first.size(0),
+        packed_seq_params,
+        None,
+        cp_group,
+        cp_token_layout=cp_token_layout,
+    )
+    if layout is not None:
+        rolled = _SequenceParallelContextBoundaryRoll.apply(sequence_first, layout)
+        rolled = rolled.movedim(0, dims).contiguous()
+        return rolled, rolled.sum() if return_sum else None
 
     # CP enabled: each rank owns two chunks per sequence (front and mirrored tail).
     local_rank = torch.distributed.get_rank(group=cp_group)
@@ -367,7 +425,463 @@ def _roll_tensor_packed_seq(tensor, shifts, dims, packed_seq_params, cp_group=No
         # update the rolled tensor
         rolled_tensor[..., local_start_idx:local_end_idx] = seq_result
 
-    return rolled_tensor, rolled_tensor.sum()
+    return rolled_tensor, rolled_tensor.sum() if return_sum else None
+
+
+class _SequenceParallelBoundaryRoll(torch.autograd.Function):
+    """Left-shift an SP shard by exchanging one boundary token with its TP neighbor."""
+
+    @staticmethod
+    def forward(ctx, tensor, end_mask, tp_group):
+        ctx.tp_group = tp_group
+        ctx.save_for_backward(end_mask)
+
+        tp_size = tp_group.size()
+        tp_rank = torch.distributed.get_rank(group=tp_group)
+        global_ranks = torch.distributed.get_process_group_ranks(group=tp_group)
+        rolled = torch.roll(tensor, shifts=-1, dims=0)
+        send_boundary = tensor[0].contiguous()
+        recv_boundary = torch.empty_like(tensor[0])
+        operations = []
+        if tp_rank > 0:
+            operations.append(
+                torch.distributed.isend(send_boundary, dst=global_ranks[tp_rank - 1])
+            )
+        if tp_rank < tp_size - 1:
+            operations.append(
+                torch.distributed.irecv(recv_boundary, src=global_ranks[tp_rank + 1])
+            )
+        for operation in operations:
+            operation.wait()
+
+        if tp_rank < tp_size - 1:
+            rolled[-1].copy_(recv_boundary)
+        else:
+            rolled[-1].zero_()
+        mask_shape = (end_mask.numel(),) + (1,) * (tensor.dim() - 1)
+        rolled.masked_fill_(end_mask.view(mask_shape), 0)
+        return rolled
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        (end_mask,) = ctx.saved_tensors
+        tp_group = ctx.tp_group
+        tp_size = tp_group.size()
+        tp_rank = torch.distributed.get_rank(group=tp_group)
+        global_ranks = torch.distributed.get_process_group_ranks(group=tp_group)
+
+        mask_shape = (end_mask.numel(),) + (1,) * (grad_output.dim() - 1)
+        grad_output = grad_output.masked_fill(end_mask.view(mask_shape), 0)
+        grad_input = torch.roll(grad_output, shifts=1, dims=0)
+        send_boundary = grad_output[-1].contiguous()
+        recv_boundary = torch.empty_like(grad_output[-1])
+        operations = []
+        if tp_rank < tp_size - 1:
+            operations.append(
+                torch.distributed.isend(send_boundary, dst=global_ranks[tp_rank + 1])
+            )
+        if tp_rank > 0:
+            operations.append(
+                torch.distributed.irecv(recv_boundary, src=global_ranks[tp_rank - 1])
+            )
+        for operation in operations:
+            operation.wait()
+
+        if tp_rank > 0:
+            grad_input[0].copy_(recv_boundary)
+        else:
+            grad_input[0].zero_()
+        return grad_input, None, None
+
+
+@dataclass(frozen=True)
+class _SequenceParallelContextRollLayout:
+    """Local copies and remote routes for one combined SP+CP left shift."""
+
+    copies: tuple
+    exports: tuple
+    imports: tuple
+    send_split_sizes: tuple
+    recv_split_sizes: tuple
+    tp_cp_group: object
+
+
+_SEQUENCE_PARALLEL_CONTEXT_ROLL_LAYOUT_CACHE = {}
+
+
+class _SequenceParallelContextBoundaryRoll(torch.autograd.Function):
+    """Apply a logical-span roll with sparse TP+CP boundary communication."""
+
+    @staticmethod
+    def forward(ctx, tensor, layout):
+        ctx.layout = layout
+        rolled = torch.zeros_like(tensor)
+        for output_start, output_end, input_start in layout.copies:
+            length = output_end - output_start
+            rolled[output_start:output_end].copy_(tensor[input_start : input_start + length])
+
+        export_buffer = torch.empty(
+            (len(layout.exports), *tensor.shape[1:]), dtype=tensor.dtype, device=tensor.device
+        )
+        for export_idx, (_, input_idx) in enumerate(layout.exports):
+            export_buffer[export_idx].copy_(tensor[input_idx])
+        imported_boundaries = torch.empty(
+            (len(layout.imports), *tensor.shape[1:]), dtype=tensor.dtype, device=tensor.device
+        )
+        torch.distributed.all_to_all_single(
+            imported_boundaries,
+            export_buffer,
+            output_split_sizes=list(layout.recv_split_sizes),
+            input_split_sizes=list(layout.send_split_sizes),
+            group=layout.tp_cp_group,
+        )
+        for import_idx, (_, output_idx) in enumerate(layout.imports):
+            rolled[output_idx].copy_(imported_boundaries[import_idx])
+        return rolled
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        layout = ctx.layout
+        grad_input = torch.zeros_like(grad_output)
+        for output_start, output_end, input_start in layout.copies:
+            length = output_end - output_start
+            grad_input[input_start : input_start + length].copy_(
+                grad_output[output_start:output_end]
+            )
+
+        boundary_grad_exports = torch.empty(
+            (len(layout.imports), *grad_output.shape[1:]),
+            dtype=grad_output.dtype,
+            device=grad_output.device,
+        )
+        for import_idx, (_, output_idx) in enumerate(layout.imports):
+            boundary_grad_exports[import_idx].copy_(grad_output[output_idx])
+        imported_boundary_grads = torch.empty(
+            (len(layout.exports), *grad_output.shape[1:]),
+            dtype=grad_output.dtype,
+            device=grad_output.device,
+        )
+        torch.distributed.all_to_all_single(
+            imported_boundary_grads,
+            boundary_grad_exports,
+            output_split_sizes=list(layout.send_split_sizes),
+            input_split_sizes=list(layout.recv_split_sizes),
+            group=layout.tp_cp_group,
+        )
+        for export_idx, (_, input_idx) in enumerate(layout.exports):
+            grad_input[input_idx].add_(imported_boundary_grads[export_idx])
+        return grad_input, None
+
+
+def _build_sequence_parallel_context_roll_layout(
+    sequence_length,
+    packed_seq_params,
+    tp_group,
+    cp_group,
+    tp_cp_group=None,
+    cp_token_layout='zigzag',
+):
+    """Build sparse boundary routing for zigzag or contiguous CP ownership."""
+    tp_size = tp_group.size() if tp_group is not None else 1
+    cp_size = cp_group.size()
+    tp_rank = torch.distributed.get_rank(group=tp_group) if tp_group is not None else 0
+    cp_rank = torch.distributed.get_rank(group=cp_group)
+    global_rank = torch.distributed.get_rank()
+    total_sequence_length = sequence_length * tp_size * cp_size
+    assert cp_token_layout in ('zigzag', 'contiguous'), (
+        f"Unsupported CP token layout {cp_token_layout!r}."
+    )
+    tp_global_ranks = (
+        tuple(torch.distributed.get_process_group_ranks(group=tp_group))
+        if tp_group is not None
+        else (global_rank,)
+    )
+    cp_global_ranks = tuple(torch.distributed.get_process_group_ranks(group=cp_group))
+    layout_chunk_count = 2 * cp_size if cp_token_layout == 'zigzag' else cp_size
+    if total_sequence_length % layout_chunk_count != 0:
+        return None
+
+    topology_key = (
+        sequence_length,
+        id(tp_group) if tp_group is not None else None,
+        id(cp_group),
+        tp_size,
+        cp_size,
+        tp_rank,
+        cp_rank,
+        tp_global_ranks,
+        cp_global_ranks,
+        cp_token_layout,
+    )
+    if packed_seq_params is not None:
+        cu_seqlens_tensor = packed_seq_params.cu_seqlens_q
+        assert cu_seqlens_tensor is not None, (
+            "Packed sequence parameters must provide cu_seqlens_q."
+        )
+        packed_cache = getattr(packed_seq_params, "_mtp_roll_layout_cache", None)
+        if packed_cache is None:
+            packed_cache = {}
+            packed_seq_params._mtp_roll_layout_cache = packed_cache
+        packed_cache_key = topology_key + (
+            id(cu_seqlens_tensor),
+            getattr(cu_seqlens_tensor, "_version", 0),
+        )
+        if packed_cache_key in packed_cache:
+            return packed_cache[packed_cache_key]
+        cu_seqlens = tuple(int(value) for value in cu_seqlens_tensor.cpu().tolist())
+        if not cu_seqlens or cu_seqlens[0] != 0 or cu_seqlens[-1] != total_sequence_length:
+            return None
+    else:
+        packed_cache = None
+        packed_cache_key = None
+        cu_seqlens = (0, total_sequence_length)
+        if topology_key in _SEQUENCE_PARALLEL_CONTEXT_ROLL_LAYOUT_CACHE:
+            return _SEQUENCE_PARALLEL_CONTEXT_ROLL_LAYOUT_CACHE[topology_key]
+    if any(end <= start for start, end in zip(cu_seqlens[:-1], cu_seqlens[1:])):
+        return None
+
+    if tp_group is None:
+        tp_cp_group = cp_group
+    else:
+        assert tp_cp_group is not None, "Combined SP+CP rolling requires a TP-CP group."
+    tp_cp_global_ranks = tuple(torch.distributed.get_process_group_ranks(group=tp_cp_group))
+    group_rank_by_global_rank = {
+        rank: group_rank for group_rank, rank in enumerate(tp_cp_global_ranks)
+    }
+
+    def coordinate_global_rank(owner_cp_rank, owner_tp_rank):
+        if tp_group is None:
+            return cp_global_ranks[owner_cp_rank]
+        owner = tp_global_ranks[owner_tp_rank] + cp_global_ranks[owner_cp_rank] - global_rank
+        assert owner in group_rank_by_global_rank
+        return owner
+
+    ownership_spans = []
+    if cp_token_layout == 'zigzag':
+        chunk_length = total_sequence_length // (2 * cp_size)
+        for chunk_idx in range(2 * cp_size):
+            if chunk_idx < cp_size:
+                owner_cp_rank = chunk_idx
+                cp_local_chunk_start = 0
+            else:
+                owner_cp_rank = 2 * cp_size - chunk_idx - 1
+                cp_local_chunk_start = chunk_length
+            position_in_chunk = 0
+            while position_in_chunk < chunk_length:
+                cp_local_position = cp_local_chunk_start + position_in_chunk
+                owner_tp_rank, owner_local_idx = divmod(cp_local_position, sequence_length)
+                position_end = min(
+                    chunk_length, (owner_tp_rank + 1) * sequence_length - cp_local_chunk_start
+                )
+                owner_global_rank = coordinate_global_rank(owner_cp_rank, owner_tp_rank)
+                global_start = chunk_idx * chunk_length + position_in_chunk
+                ownership_spans.append(
+                    (
+                        global_start,
+                        chunk_idx * chunk_length + position_end,
+                        group_rank_by_global_rank[owner_global_rank],
+                        owner_local_idx,
+                    )
+                )
+                position_in_chunk = position_end
+    else:
+        cp_local_length = total_sequence_length // cp_size
+        for owner_cp_rank in range(cp_size):
+            for owner_tp_rank in range(tp_size):
+                global_start = owner_cp_rank * cp_local_length + owner_tp_rank * sequence_length
+                owner_global_rank = coordinate_global_rank(owner_cp_rank, owner_tp_rank)
+                ownership_spans.append(
+                    (
+                        global_start,
+                        global_start + sequence_length,
+                        group_rank_by_global_rank[owner_global_rank],
+                        0,
+                    )
+                )
+
+    copy_intervals = []
+    remote_edges = []
+    output_span_idx = input_span_idx = sequence_idx = 0
+    current_group_rank = group_rank_by_global_rank[global_rank]
+    while (
+        output_span_idx < len(ownership_spans)
+        and input_span_idx < len(ownership_spans)
+        and sequence_idx < len(cu_seqlens) - 1
+    ):
+        output_start, output_end, output_owner, output_local_start = ownership_spans[
+            output_span_idx
+        ]
+        input_start, input_end, input_owner, input_local_start = ownership_spans[input_span_idx]
+        sequence_start = cu_seqlens[sequence_idx]
+        sequence_output_end = cu_seqlens[sequence_idx + 1] - 1
+        shifted_input_start = input_start - 1
+        shifted_input_end = input_end - 1
+        interval_start = max(output_start, shifted_input_start, sequence_start)
+        interval_end = min(output_end, shifted_input_end, sequence_output_end)
+        if interval_start < interval_end:
+            output_local_idx = output_local_start + interval_start - output_start
+            input_local_idx = input_local_start + interval_start + 1 - input_start
+            if output_owner == input_owner:
+                if output_owner == current_group_rank:
+                    copy_intervals.append(
+                        (
+                            output_local_idx,
+                            output_local_idx + interval_end - interval_start,
+                            input_local_idx,
+                        )
+                    )
+            else:
+                assert interval_end - interval_start == 1
+                remote_edges.append((output_owner, output_local_idx, input_owner, input_local_idx))
+
+        minimum_end = min(output_end, shifted_input_end, sequence_output_end)
+        if output_end == minimum_end:
+            output_span_idx += 1
+        if shifted_input_end == minimum_end:
+            input_span_idx += 1
+        if sequence_output_end == minimum_end:
+            sequence_idx += 1
+
+    copies = []
+    for output_start, output_end, input_start in sorted(copy_intervals):
+        if (
+            copies
+            and output_start == copies[-1][1]
+            and input_start == copies[-1][2] + copies[-1][1] - copies[-1][0]
+        ):
+            previous_output_start, _, previous_input_start = copies[-1]
+            copies[-1] = (previous_output_start, output_end, previous_input_start)
+        else:
+            copies.append((output_start, output_end, input_start))
+
+    exports = tuple(
+        (output_owner, input_local_idx)
+        for output_owner, _, input_owner, input_local_idx in sorted(
+            remote_edges, key=lambda edge: edge[0]
+        )
+        if input_owner == current_group_rank
+    )
+    imports = tuple(
+        (input_owner, output_local_idx)
+        for output_owner, output_local_idx, input_owner, _ in sorted(
+            remote_edges, key=lambda edge: edge[2]
+        )
+        if output_owner == current_group_rank
+    )
+    send_split_sizes = tuple(
+        sum(destination == rank for destination, _ in exports)
+        for rank in range(len(tp_cp_global_ranks))
+    )
+    recv_split_sizes = tuple(
+        sum(source == rank for source, _ in imports) for rank in range(len(tp_cp_global_ranks))
+    )
+    layout = _SequenceParallelContextRollLayout(
+        copies=tuple(copies),
+        exports=exports,
+        imports=imports,
+        send_split_sizes=send_split_sizes,
+        recv_split_sizes=recv_split_sizes,
+        tp_cp_group=tp_cp_group,
+    )
+    if packed_cache is not None:
+        packed_cache[packed_cache_key] = layout
+    else:
+        _SEQUENCE_PARALLEL_CONTEXT_ROLL_LAYOUT_CACHE[topology_key] = layout
+    return layout
+
+
+def _sequence_parallel_end_mask(sequence_length, packed_seq_params, tp_group, device):
+    """Return local output positions that must be zero after an SP left shift."""
+    tp_rank = torch.distributed.get_rank(group=tp_group)
+    local_offset = tp_rank * sequence_length
+    end_mask = torch.zeros(sequence_length, dtype=torch.bool, device=device)
+    if packed_seq_params is None:
+        if tp_rank == tp_group.size() - 1:
+            end_mask[-1] = True
+        return end_mask
+
+    cu_seqlens = packed_seq_params.cu_seqlens_q
+    assert cu_seqlens is not None, "Packed sequence parameters must provide cu_seqlens_q."
+    local_ends = cu_seqlens[1:].to(device=device, dtype=torch.long) - 1 - local_offset
+    local_ends = local_ends[(local_ends >= 0) & (local_ends < sequence_length)]
+    end_mask[local_ends] = True
+    return end_mask
+
+
+def roll_tensor_sequence_parallel(
+    tensor: Tensor | None,
+    shifts: int = -1,
+    dims: int = -1,
+    sequence_parallel: bool = False,
+    tp_group: torch.distributed.ProcessGroup | None = None,
+    cp_group: torch.distributed.ProcessGroup | None = None,
+    tp_cp_group: torch.distributed.ProcessGroup | None = None,
+    packed_seq_params: PackedSeqParams | None = None,
+    return_sum: bool = True,
+    cp_token_layout: Literal['zigzag', 'contiguous'] = 'zigzag',
+) -> tuple[Tensor | None, Tensor | None]:
+    """Roll a tensor along a sequence dimension that may be sequence parallel.
+
+    CP=1 exchanges only TP boundary tokens. Combined SP+CP reconstructs the
+    CP-local sequence, applies the existing CP roll, and restores the SP shard.
+    """
+    if not sequence_parallel:
+        return roll_tensor(
+            tensor,
+            shifts=shifts,
+            dims=dims,
+            cp_group=cp_group,
+            packed_seq_params=packed_seq_params,
+            return_sum=return_sum,
+            cp_token_layout=cp_token_layout,
+        )
+
+    assert tp_group is not None, "Sequence-parallel rolling requires a TP process group."
+    sequence_first = tensor.movedim(dims, 0).contiguous()
+    cp_size = cp_group.size() if cp_group is not None else 1
+    if cp_size == 1:
+        assert shifts == -1, "SP boundary exchange only supports a single-token left shift."
+        end_mask = _sequence_parallel_end_mask(
+            sequence_first.size(0), packed_seq_params, tp_group, sequence_first.device
+        )
+        rolled = _SequenceParallelBoundaryRoll.apply(sequence_first, end_mask, tp_group)
+        rolled = rolled.movedim(0, dims).contiguous()
+        return rolled, rolled.sum() if return_sum else None
+
+    layout = None
+    if shifts == -1:
+        layout = _build_sequence_parallel_context_roll_layout(
+            sequence_first.size(0),
+            packed_seq_params,
+            tp_group,
+            cp_group,
+            tp_cp_group,
+            cp_token_layout=cp_token_layout,
+        )
+    if layout is not None:
+        rolled = _SequenceParallelContextBoundaryRoll.apply(sequence_first, layout)
+        rolled = rolled.movedim(0, dims).contiguous()
+        return rolled, rolled.sum() if return_sum else None
+
+    gathered_sequence_first = gather_from_sequence_parallel_region(
+        sequence_first, tensor_parallel_output_grad=False, group=tp_group
+    )
+    gathered = gathered_sequence_first.movedim(0, dims).contiguous()
+    rolled, _ = roll_tensor(
+        gathered,
+        shifts=shifts,
+        dims=dims,
+        cp_group=cp_group,
+        packed_seq_params=packed_seq_params,
+        return_sum=False,
+        cp_token_layout=cp_token_layout,
+    )
+    rolled_sequence_first = rolled.movedim(dims, 0).contiguous()
+    rolled_sequence_first = scatter_to_sequence_parallel_region(
+        rolled_sequence_first, group=tp_group
+    )
+    rolled = rolled_sequence_first.movedim(0, dims).contiguous()
+    return rolled, rolled.sum() if return_sum else None
 
 
 class MTPLossLoggingHelper:
@@ -842,7 +1356,12 @@ def process_mtp_loss(
         if input_ids is None:
             return hidden_states
         labels, _ = roll_tensor(
-            input_ids, shifts=-1, dims=-1, cp_group=cp_group, packed_seq_params=packed_seq_params
+            input_ids,
+            shifts=-1,
+            dims=-1,
+            cp_group=cp_group,
+            packed_seq_params=packed_seq_params,
+            cp_token_layout=config.mtp_cp_token_layout,
         )
         derived_labels_from_input_ids = True
 
@@ -860,7 +1379,12 @@ def process_mtp_loss(
         # label is fabricated (zeroed). Roll loss_mask in lockstep with the
         # input_ids -> labels shift so that boundary position is masked.
         loss_mask, _ = roll_tensor(
-            loss_mask, shifts=-1, dims=-1, cp_group=cp_group, packed_seq_params=packed_seq_params
+            loss_mask,
+            shifts=-1,
+            dims=-1,
+            cp_group=cp_group,
+            packed_seq_params=packed_seq_params,
+            cp_token_layout=config.mtp_cp_token_layout,
         )
 
     # Store the original number of tokens before rolling for proper normalization
@@ -877,10 +1401,20 @@ def process_mtp_loss(
         if scale_logits_fn is not None:
             mtp_logits = scale_logits_fn(mtp_logits)
         mtp_labels, _ = roll_tensor(
-            mtp_labels, shifts=-1, dims=-1, cp_group=cp_group, packed_seq_params=packed_seq_params
+            mtp_labels,
+            shifts=-1,
+            dims=-1,
+            cp_group=cp_group,
+            packed_seq_params=packed_seq_params,
+            cp_token_layout=config.mtp_cp_token_layout,
         )
         loss_mask, num_tokens = roll_tensor(
-            loss_mask, shifts=-1, dims=-1, cp_group=cp_group, packed_seq_params=packed_seq_params
+            loss_mask,
+            shifts=-1,
+            dims=-1,
+            cp_group=cp_group,
+            packed_seq_params=packed_seq_params,
+            cp_token_layout=config.mtp_cp_token_layout,
         )
 
         mtp_loss = compute_language_model_loss(mtp_labels, mtp_logits)
@@ -1139,6 +1673,7 @@ class MultiTokenPredictionLayer(MegatronModule):
             dims=-1,
             cp_group=self.cp_group,
             packed_seq_params=packed_seq_params,
+            cp_token_layout=self.config.mtp_cp_token_layout,
         )
         position_ids, _ = roll_tensor(
             position_ids,
@@ -1146,6 +1681,7 @@ class MultiTokenPredictionLayer(MegatronModule):
             dims=-1,
             cp_group=self.cp_group,
             packed_seq_params=packed_seq_params,
+            cp_token_layout=self.config.mtp_cp_token_layout,
         )
         if padding_mask is not None:
             padding_mask, _ = roll_tensor(
@@ -1154,6 +1690,7 @@ class MultiTokenPredictionLayer(MegatronModule):
                 dims=-1,
                 cp_group=self.cp_group,
                 packed_seq_params=packed_seq_params,
+                cp_token_layout=self.config.mtp_cp_token_layout,
             )
         # embedding
         decoder_input = embedding(input_ids=input_ids, position_ids=position_ids)
@@ -1743,16 +2280,30 @@ class MultiTokenPredictionBlock(MegatronModule):
         # to the roll_tensor function for proper boundary communication
         if pg_collection is None:
             # Use default MPU process groups if not provided
-            pg_collection = ProcessGroupCollection.use_mpu_process_groups(required_pgs=['cp', 'tp'])
+            required_pgs = ['cp', 'tp']
+            if config.mtp_hsm and config.sequence_parallel and config.context_parallel_size > 1:
+                required_pgs.append('tp_cp')
+            pg_collection = ProcessGroupCollection.use_mpu_process_groups(required_pgs=required_pgs)
         else:
             # Ensure the provided process groups include CP
             assert hasattr(
                 pg_collection, 'cp'
             ), "MultiTokenPredictionBlock pg_collection must have cp process group"
+            if config.mtp_hsm and config.sequence_parallel:
+                assert hasattr(
+                    pg_collection, 'tp'
+                ), "Sequence-parallel HSM requires a tp process group"
+                if config.context_parallel_size > 1:
+                    assert hasattr(
+                        pg_collection, 'tp_cp'
+                    ), "Combined sequence- and context-parallel HSM requires a tp_cp process group"
 
         self._build_layers(pg_collection)
         assert len(self.layers) > 0, "MultiTokenPredictionBlock must have at least one layer."
+        self.sequence_parallel = config.sequence_parallel
         self.cp_group = pg_collection.cp
+        self.tp_group = getattr(pg_collection, 'tp', None)
+        self.tp_cp_group = getattr(pg_collection, 'tp_cp', None)
 
         if self.config.mtp_detach_heads:
             # Tag MTP params so the optimizer can clip their gradients separately.
@@ -1905,12 +2456,17 @@ class MultiTokenPredictionBlock(MegatronModule):
                 flattened = stacked.permute(0, 2, 3, 1).reshape(
                     num_entries * batch_size, hidden_size, sequence_length
                 )
-                rolled, _ = roll_tensor(
+                rolled, _ = roll_tensor_sequence_parallel(
                     flattened,
                     shifts=-1,
                     dims=-1,
+                    sequence_parallel=self.sequence_parallel,
+                    tp_group=self.tp_group,
                     cp_group=self.cp_group,
+                    tp_cp_group=self.tp_cp_group,
                     packed_seq_params=packed_seq_params,
+                    return_sum=False,
+                    cp_token_layout=self.config.mtp_cp_token_layout,
                 )
                 hsm_history = list(
                     rolled.reshape(num_entries, batch_size, hidden_size, sequence_length)

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -87,6 +87,9 @@ class TransformerConfig(ModelParallelConfig):
     This prevents MTP loss gradients from flowing back to the main model,
     only training the MTP heads themselves."""
 
+    mtp_hsm: bool = False
+    """Enable uniform per-token Hidden State Mixing for MTP layers."""
+
     mtp_hybrid_override_pattern: Optional[str] = None
     """DEPRECATED: Use unified hybrid_layer_pattern instead.
     Legacy argument for loading old checkpoints.

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -90,6 +90,9 @@ class TransformerConfig(ModelParallelConfig):
     mtp_hsm: bool = False
     """Enable uniform per-token Hidden State Mixing for MTP layers."""
 
+    mtp_cp_token_layout: Literal['zigzag', 'contiguous'] = 'zigzag'
+    """Context-parallel token ownership layout used by MTP rolling."""
+
     mtp_hybrid_override_pattern: Optional[str] = None
     """DEPRECATED: Use unified hybrid_layer_pattern instead.
     Legacy argument for loading old checkpoints.
@@ -1310,6 +1313,12 @@ class TransformerConfig(ModelParallelConfig):
         details.
         """
         super().__post_init__()
+
+        if self.mtp_cp_token_layout not in ('zigzag', 'contiguous'):
+            raise ValueError(
+                "mtp_cp_token_layout must be either 'zigzag' or 'contiguous', "
+                f"got {self.mtp_cp_token_layout!r}."
+            )
 
         # Resolve deprecated attention variant spellings up front so that every consumer
         # downstream only has to handle the canonical names. Imported lazily because the

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -859,6 +859,11 @@ def validate_args(args, defaults={}):
             + f"The supported position embedding types are rope and none."
         )
 
+    if getattr(args, 'mtp_hsm', False) and not (
+        args.mtp_num_layers and args.mtp_num_layers >= 2
+    ):
+        args.mtp_hsm = False
+
     # Validate MTP args for hybrid vs non-hybrid models
     if args.hybrid_layer_pattern is not None:
         # Mamba/hybrid model MTP validation

--- a/tests/unit_tests/transformer/test_multi_token_prediction.py
+++ b/tests/unit_tests/transformer/test_multi_token_prediction.py
@@ -25,6 +25,7 @@ from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.multi_token_prediction import (
     MTPLossLoggingHelper,
     MultiTokenPredictionBlock,
+    _hsm_mix,
     _mtp_logits_are_vocab_sharded,
     process_mtp_loss,
     roll_tensor,
@@ -81,6 +82,162 @@ class TestMultiTokenPredictionLayer:
             config=config, spec=transformer_layer_spec, use_transformer_engine=use_te
         )
         return config, mtp_block_spec
+
+    def test_hsm_mix_preserves_dtype_and_gradients(self, monkeypatch):
+        """HSM selects per-element history entries without changing dtype or gradients."""
+        first = torch.full((2, 1, 3), 1.0, dtype=torch.bfloat16, requires_grad=True)
+        second = torch.full((2, 1, 3), 2.0, dtype=torch.bfloat16, requires_grad=True)
+        selection = torch.tensor([[[[0]], [[1]]]], dtype=torch.long)
+
+        monkeypatch.setattr(torch, "randint", lambda *args, **kwargs: selection)
+        mixed = _hsm_mix([first, second])
+
+        assert mixed.dtype == torch.bfloat16
+        torch.testing.assert_close(
+            mixed, torch.tensor([[[1, 1, 1]], [[2, 2, 2]]], dtype=torch.bfloat16)
+        )
+        mixed.sum().backward()
+        torch.testing.assert_close(
+            first.grad, torch.tensor([[[1, 1, 1]], [[0, 0, 0]]], dtype=torch.bfloat16)
+        )
+        torch.testing.assert_close(
+            second.grad, torch.tensor([[[0, 0, 0]], [[1, 1, 1]]], dtype=torch.bfloat16)
+        )
+
+    def test_mtp_hsm_defaults_off(self):
+        """HSM is opt-in and requires multiple MTP depths to affect the forward pass."""
+        config = TransformerConfig(num_layers=2, hidden_size=4, num_attention_heads=1)
+        assert config.mtp_hsm is False
+
+        config.mtp_hsm = True
+        config.mtp_num_layers = 1
+
+        class _IncrementLayer:
+            def __call__(self, hidden_states, input_ids, position_ids, padding_mask, **kwargs):
+                return hidden_states + 1, input_ids, position_ids, padding_mask
+
+        block = types.SimpleNamespace(
+            config=config,
+            training=True,
+            vp_stage=None,
+            mtp_use_repeated_layer=False,
+            layers=[_IncrementLayer()],
+        )
+        hidden_states = torch.zeros(2, 1, config.hidden_size)
+        output = MultiTokenPredictionBlock.forward(
+            block,
+            input_ids=torch.zeros(1, 2, dtype=torch.long),
+            position_ids=torch.zeros(1, 2, dtype=torch.long),
+            hidden_states=hidden_states,
+            attention_mask=torch.ones(1, 1, 2, 2, dtype=torch.bool),
+        )
+        torch.testing.assert_close(output[2:], torch.ones_like(hidden_states))
+
+    @pytest.mark.parametrize(("training", "expected_second_input"), [(True, 0.0), (False, 1.0)])
+    def test_hsm_runs_only_during_training(self, monkeypatch, training, expected_second_input):
+        """The block applies HSM in training and leaves evaluation deterministic."""
+        config = TransformerConfig(
+            num_layers=2,
+            hidden_size=4,
+            num_attention_heads=1,
+            mtp_num_layers=2,
+            mtp_hsm=True,
+        )
+        seen_inputs = []
+
+        class _IncrementLayer:
+            def __call__(self, hidden_states, input_ids, position_ids, padding_mask, **kwargs):
+                seen_inputs.append(hidden_states.clone())
+                return hidden_states + 1, input_ids, position_ids, padding_mask
+
+        block = types.SimpleNamespace(
+            config=config,
+            training=training,
+            vp_stage=None,
+            mtp_use_repeated_layer=False,
+            layers=[_IncrementLayer(), _IncrementLayer()],
+        )
+        monkeypatch.setattr(
+            torch,
+            "randint",
+            lambda high, size, device=None: torch.zeros(size, dtype=torch.long, device=device),
+        )
+
+        hidden_states = torch.zeros(2, 1, config.hidden_size)
+        MultiTokenPredictionBlock.forward(
+            block,
+            input_ids=torch.zeros(1, 2, dtype=torch.long),
+            position_ids=torch.zeros(1, 2, dtype=torch.long),
+            hidden_states=hidden_states,
+            attention_mask=torch.ones(1, 1, 2, 2, dtype=torch.bool),
+        )
+
+        torch.testing.assert_close(seen_inputs[0], hidden_states)
+        torch.testing.assert_close(
+            seen_inputs[1], torch.full_like(hidden_states, expected_second_input)
+        )
+
+    @pytest.mark.parametrize("packed", [False, True])
+    def test_hsm_aligns_history_with_target_tokens(self, monkeypatch, packed):
+        """Each reuse of an older HSM state advances it by one target token."""
+        config = TransformerConfig(
+            num_layers=3,
+            hidden_size=1,
+            num_attention_heads=1,
+            mtp_num_layers=3,
+            mtp_hsm=True,
+        )
+        seen_inputs = []
+
+        class _IncrementLayer:
+            def __call__(self, hidden_states, input_ids, position_ids, padding_mask, **kwargs):
+                seen_inputs.append(hidden_states.clone())
+                return hidden_states + 10, input_ids, position_ids, padding_mask
+
+        block = types.SimpleNamespace(
+            config=config,
+            training=True,
+            vp_stage=None,
+            mtp_use_repeated_layer=False,
+            cp_group=None,
+            layers=[_IncrementLayer(), _IncrementLayer(), _IncrementLayer()],
+        )
+        monkeypatch.setattr(
+            torch,
+            "randint",
+            lambda high, size, device=None: torch.zeros(size, dtype=torch.long, device=device),
+        )
+
+        packed_seq_params = None
+        if packed:
+            cu_seqlens = torch.tensor([0, 3, 5], dtype=torch.int32)
+            packed_seq_params = PackedSeqParams(
+                cu_seqlens_q=cu_seqlens,
+                cu_seqlens_kv=cu_seqlens,
+                max_seqlen_q=3,
+                max_seqlen_kv=3,
+                qkv_format='thd',
+            )
+
+        hidden_states = torch.arange(5, dtype=torch.float32).view(5, 1, 1)
+        MultiTokenPredictionBlock.forward(
+            block,
+            input_ids=torch.zeros(1, 5, dtype=torch.long),
+            position_ids=torch.zeros(1, 5, dtype=torch.long),
+            hidden_states=hidden_states,
+            attention_mask=torch.ones(1, 1, 5, 5, dtype=torch.bool),
+            packed_seq_params=packed_seq_params,
+        )
+
+        expected_once = [1, 2, 0, 4, 0] if packed else [1, 2, 3, 4, 0]
+        expected_twice = [2, 0, 0, 0, 0] if packed else [2, 3, 4, 0, 0]
+        torch.testing.assert_close(seen_inputs[0], hidden_states)
+        torch.testing.assert_close(
+            seen_inputs[1], torch.tensor(expected_once, dtype=torch.float32).view(5, 1, 1)
+        )
+        torch.testing.assert_close(
+            seen_inputs[2], torch.tensor(expected_twice, dtype=torch.float32).view(5, 1, 1)
+        )
 
     def test_mtp_detach_heads_config(self):
         """Test that mtp_detach_heads config defaults to False."""

--- a/tests/unit_tests/transformer/test_multi_token_prediction.py
+++ b/tests/unit_tests/transformer/test_multi_token_prediction.py
@@ -19,16 +19,24 @@ from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_stack_spec
 from megatron.core.models.hybrid.hybrid_model import HybridModel
 from megatron.core.num_microbatches_calculator import destroy_num_microbatches_calculator
 from megatron.core.packed_seq_params import PackedSeqParams
-from megatron.core.parallel_state import get_context_parallel_group
+from megatron.core.parallel_state import (
+    get_context_parallel_group,
+    get_context_parallel_rank,
+    get_tensor_and_context_parallel_group,
+    get_tensor_model_parallel_group,
+    get_tensor_model_parallel_rank,
+)
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.multi_token_prediction import (
     MTPLossLoggingHelper,
     MultiTokenPredictionBlock,
+    _build_sequence_parallel_context_roll_layout,
     _hsm_mix,
     _mtp_logits_are_vocab_sharded,
     process_mtp_loss,
     roll_tensor,
+    roll_tensor_sequence_parallel,
 )
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.utils import get_batch_on_this_cp_rank, is_te_min_version, unwrap_model
@@ -155,6 +163,10 @@ class TestMultiTokenPredictionLayer:
             training=training,
             vp_stage=None,
             mtp_use_repeated_layer=False,
+            sequence_parallel=False,
+            cp_group=None,
+            tp_group=None,
+            tp_cp_group=None,
             layers=[_IncrementLayer(), _IncrementLayer()],
         )
         monkeypatch.setattr(
@@ -199,7 +211,10 @@ class TestMultiTokenPredictionLayer:
             training=True,
             vp_stage=None,
             mtp_use_repeated_layer=False,
+            sequence_parallel=False,
             cp_group=None,
+            tp_group=None,
+            tp_cp_group=None,
             layers=[_IncrementLayer(), _IncrementLayer(), _IncrementLayer()],
         )
         monkeypatch.setattr(
@@ -239,12 +254,277 @@ class TestMultiTokenPredictionLayer:
             seen_inputs[2], torch.tensor(expected_twice, dtype=torch.float32).view(5, 1, 1)
         )
 
+    @pytest.mark.parametrize("packed", [False, True])
+    def test_roll_tensor_with_sequence_parallel(self, packed):
+        """SP boundary exchange respects ordinary and packed sequence ends."""
+        tp = 2
+        Utils.initialize_model_parallel(tensor_model_parallel_size=tp)
+        tp_rank = get_tensor_model_parallel_rank()
+        tp_group = get_tensor_model_parallel_group()
+
+        full = torch.arange(8, dtype=torch.float32, device="cuda")
+        local = full.chunk(tp)[tp_rank].clone().requires_grad_(True)
+        packed_seq_params = None
+        if packed:
+            cu_seqlens = torch.tensor([0, 3, 8], dtype=torch.int32, device="cuda")
+            packed_seq_params = PackedSeqParams(
+                cu_seqlens_q=cu_seqlens,
+                cu_seqlens_kv=cu_seqlens,
+                max_seqlen_q=5,
+                max_seqlen_kv=5,
+                qkv_format='thd',
+            )
+            expected_full = torch.tensor(
+                [1, 2, 0, 4, 5, 6, 7, 0], dtype=torch.float32, device="cuda"
+            )
+        else:
+            expected_full = torch.tensor(
+                [1, 2, 3, 4, 5, 6, 7, 0], dtype=torch.float32, device="cuda"
+            )
+
+        rolled, rolled_sum = roll_tensor_sequence_parallel(
+            local,
+            sequence_parallel=True,
+            tp_group=tp_group,
+            packed_seq_params=packed_seq_params,
+        )
+        torch.testing.assert_close(rolled, expected_full.chunk(tp)[tp_rank])
+        assert rolled_sum.numel() == 1
+
+        rolled.sum().backward()
+        expected_grad = torch.ones_like(full)
+        expected_grad[0] = 0
+        if packed:
+            expected_grad[3] = 0
+        torch.testing.assert_close(local.grad, expected_grad.chunk(tp)[tp_rank])
+
+    @pytest.mark.parametrize("packed", [False, True])
+    @pytest.mark.parametrize("cp", [2, 4])
+    @pytest.mark.parametrize("cp_token_layout", ['zigzag', 'contiguous'])
+    def test_roll_tensor_with_sparse_sequence_and_context_parallel(
+        self, cp_token_layout, cp, packed
+    ):
+        """Sparse TP+CP routing preserves mirrored ownership and gradients."""
+        tp = 2
+        if int(os.environ.get("WORLD_SIZE", "1")) < tp * cp:
+            pytest.skip(f"TP={tp}, CP={cp} requires at least {tp * cp} ranks")
+        Utils.initialize_model_parallel(tensor_model_parallel_size=tp, context_parallel_size=cp)
+        tp_rank = get_tensor_model_parallel_rank()
+        cp_rank = get_context_parallel_rank()
+        tp_group = get_tensor_model_parallel_group()
+        cp_group = get_context_parallel_group()
+        tp_cp_group = get_tensor_and_context_parallel_group()
+
+        sequence_lengths = [5, 11] if packed else [16]
+        cu_seqlens_list = [0]
+        for length in sequence_lengths:
+            cu_seqlens_list.append(cu_seqlens_list[-1] + length)
+        full = torch.arange(16, dtype=torch.float32, device="cuda")
+        expected_full = torch.empty_like(full)
+        expected_grad_full = torch.zeros_like(full)
+        for start, end in zip(cu_seqlens_list[:-1], cu_seqlens_list[1:]):
+            expected_full[start : end - 1] = full[start + 1 : end]
+            expected_full[end - 1] = 0
+            expected_grad_full[start + 1 : end] = 1
+
+        def get_cp_local(tensor):
+            if cp_token_layout == 'contiguous':
+                return tensor.chunk(cp)[cp_rank]
+            chunks = tensor.chunk(2 * cp)
+            return torch.cat((chunks[cp_rank], chunks[2 * cp - cp_rank - 1]))
+
+        packed_seq_params = None
+        if packed:
+            cu_seqlens = torch.tensor(cu_seqlens_list, dtype=torch.int32, device="cuda")
+            packed_seq_params = PackedSeqParams(
+                cu_seqlens_q=cu_seqlens,
+                cu_seqlens_kv=cu_seqlens,
+                max_seqlen_q=max(sequence_lengths),
+                max_seqlen_kv=max(sequence_lengths),
+                qkv_format='thd',
+            )
+
+        local = get_cp_local(full).chunk(tp)[tp_rank].clone().requires_grad_(True)
+        layout = _build_sequence_parallel_context_roll_layout(
+            local.numel(),
+            packed_seq_params,
+            tp_group,
+            cp_group,
+            tp_cp_group,
+            cp_token_layout=cp_token_layout,
+        )
+        assert layout is not None
+        assert sum(layout.send_split_sizes) == len(layout.exports)
+        assert sum(layout.recv_split_sizes) == len(layout.imports)
+        assert len(layout.exports) <= 2
+        assert len(layout.imports) <= 2
+        if packed:
+            assert (
+                _build_sequence_parallel_context_roll_layout(
+                    local.numel(),
+                    packed_seq_params,
+                    tp_group,
+                    cp_group,
+                    tp_cp_group,
+                    cp_token_layout=cp_token_layout,
+                )
+                is layout
+            )
+            assert len(packed_seq_params._mtp_roll_layout_cache) == 1
+        rolled, _ = roll_tensor_sequence_parallel(
+            local,
+            sequence_parallel=True,
+            tp_group=tp_group,
+            cp_group=cp_group,
+            tp_cp_group=tp_cp_group,
+            packed_seq_params=packed_seq_params,
+            cp_token_layout=cp_token_layout,
+        )
+        torch.testing.assert_close(rolled, get_cp_local(expected_full).chunk(tp)[tp_rank])
+        rolled.sum().backward()
+        torch.testing.assert_close(
+            local.grad, get_cp_local(expected_grad_full).chunk(tp)[tp_rank]
+        )
+
+    @pytest.mark.parametrize("packed", [False, True])
+    def test_roll_tensor_with_contiguous_context_parallel(self, packed):
+        """CP-only contiguous rolling respects sequence boundaries and gradients."""
+        cp = 2
+        Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=cp)
+        cp_group = get_context_parallel_group()
+        cp_rank = get_context_parallel_rank()
+        sequence_lengths = [5, 11] if packed else [16]
+        cu_seqlens_list = [0]
+        for length in sequence_lengths:
+            cu_seqlens_list.append(cu_seqlens_list[-1] + length)
+        full = torch.arange(16, dtype=torch.float32, device="cuda")
+        expected_full = torch.empty_like(full)
+        output_grad_full = torch.arange(1, 17, dtype=torch.float32, device="cuda")
+        expected_grad_full = torch.zeros_like(full)
+        for start, end in zip(cu_seqlens_list[:-1], cu_seqlens_list[1:]):
+            expected_full[start : end - 1] = full[start + 1 : end]
+            expected_full[end - 1] = 0
+            expected_grad_full[start + 1 : end] = output_grad_full[start : end - 1]
+        packed_seq_params = None
+        if packed:
+            cu_seqlens = torch.tensor(cu_seqlens_list, dtype=torch.int32, device="cuda")
+            packed_seq_params = PackedSeqParams(
+                cu_seqlens_q=cu_seqlens,
+                cu_seqlens_kv=cu_seqlens,
+                max_seqlen_q=max(sequence_lengths),
+                max_seqlen_kv=max(sequence_lengths),
+                qkv_format='thd',
+            )
+        local = full.chunk(cp)[cp_rank].clone().requires_grad_(True)
+        rolled, _ = roll_tensor(
+            local,
+            cp_group=cp_group,
+            packed_seq_params=packed_seq_params,
+            cp_token_layout='contiguous',
+        )
+        torch.testing.assert_close(rolled, expected_full.chunk(cp)[cp_rank])
+        rolled.backward(output_grad_full.chunk(cp)[cp_rank])
+        torch.testing.assert_close(local.grad, expected_grad_full.chunk(cp)[cp_rank])
+
+    def test_constructor_with_explicit_groups_without_tp_cp(self):
+        """Configurations without combined SP+CP do not require a TP-CP group."""
+        config, mtp_block_spec = self._create_config_and_mtp_block_spec(tp=1, cp=1)
+        pg_collection = ProcessGroupCollection(
+            cp=get_context_parallel_group(), tp=get_tensor_model_parallel_group()
+        )
+        mtp = MultiTokenPredictionBlock(
+            config=config, spec=mtp_block_spec, pg_collection=pg_collection
+        )
+        assert mtp.tp_cp_group is None
+
+    def test_sparse_roll_cache_handles_changing_packed_microbatches(self):
+        """Packed routing is cached per microbatch metadata at realistic sequence length."""
+        tp = 2
+        cp = 2
+        if int(os.environ.get("WORLD_SIZE", "1")) < tp * cp:
+            pytest.skip(f"TP={tp}, CP={cp} requires at least {tp * cp} ranks")
+        Utils.initialize_model_parallel(tensor_model_parallel_size=tp, context_parallel_size=cp)
+        tp_rank = get_tensor_model_parallel_rank()
+        cp_rank = get_context_parallel_rank()
+        tp_group = get_tensor_model_parallel_group()
+        cp_group = get_context_parallel_group()
+        tp_cp_group = get_tensor_and_context_parallel_group()
+
+        def get_cp_local(tensor):
+            chunks = tensor.chunk(2 * cp)
+            return torch.cat((chunks[cp_rank], chunks[2 * cp - cp_rank - 1]))
+
+        packed_sequence_lengths = ((17, 31, 257, 1023, 2047, 4817), (*([127] * 64), 64))
+        for sequence_lengths in packed_sequence_lengths:
+            cu_seqlens_list = [0]
+            for length in sequence_lengths:
+                cu_seqlens_list.append(cu_seqlens_list[-1] + length)
+            assert cu_seqlens_list[-1] == 8192
+            cu_seqlens = torch.tensor(cu_seqlens_list, dtype=torch.int32, device="cuda")
+            packed_seq_params = PackedSeqParams(
+                cu_seqlens_q=cu_seqlens,
+                cu_seqlens_kv=cu_seqlens,
+                max_seqlen_q=max(sequence_lengths),
+                max_seqlen_kv=max(sequence_lengths),
+                qkv_format='thd',
+            )
+            full = torch.arange(8192, dtype=torch.float32, device="cuda")
+            expected_full = torch.empty_like(full)
+            expected_grad_full = torch.ones_like(full)
+            for start, end in zip(cu_seqlens_list[:-1], cu_seqlens_list[1:]):
+                expected_full[start : end - 1] = full[start + 1 : end]
+                expected_full[end - 1] = 0
+                expected_grad_full[start] = 0
+            local = get_cp_local(full).chunk(tp)[tp_rank].clone().requires_grad_(True)
+            layout = _build_sequence_parallel_context_roll_layout(
+                local.numel(), packed_seq_params, tp_group, cp_group, tp_cp_group
+            )
+            assert (
+                _build_sequence_parallel_context_roll_layout(
+                    local.numel(), packed_seq_params, tp_group, cp_group, tp_cp_group
+                )
+                is layout
+            )
+            assert len(packed_seq_params._mtp_roll_layout_cache) == 1
+            rolled, _ = roll_tensor_sequence_parallel(
+                local,
+                sequence_parallel=True,
+                tp_group=tp_group,
+                cp_group=cp_group,
+                tp_cp_group=tp_cp_group,
+                packed_seq_params=packed_seq_params,
+            )
+            torch.testing.assert_close(rolled, get_cp_local(expected_full).chunk(tp)[tp_rank])
+            rolled.sum().backward()
+            torch.testing.assert_close(
+                local.grad, get_cp_local(expected_grad_full).chunk(tp)[tp_rank]
+            )
+
     def test_mtp_detach_heads_config(self):
         """Test that mtp_detach_heads config defaults to False."""
         config = TransformerConfig(
             num_layers=4, hidden_size=64, num_attention_heads=8, use_cpu_initialization=True
         )
         assert config.mtp_detach_heads is False
+
+    def test_cp_token_layout_config(self):
+        """MTP rolling defaults to zigzag and validates explicit layouts."""
+        config = TransformerConfig(num_layers=2, hidden_size=8, num_attention_heads=2)
+        assert config.mtp_cp_token_layout == 'zigzag'
+        config = TransformerConfig(
+            num_layers=2,
+            hidden_size=8,
+            num_attention_heads=2,
+            mtp_cp_token_layout='contiguous',
+        )
+        assert config.mtp_cp_token_layout == 'contiguous'
+        with pytest.raises(ValueError, match="mtp_cp_token_layout"):
+            TransformerConfig(
+                num_layers=2,
+                hidden_size=8,
+                num_attention_heads=2,
+                mtp_cp_token_layout='invalid',
+            )
 
     def test_constructor_with_detach_heads(self):
         """Test construction of MTP module with mtp_detach_heads=True."""
@@ -1251,22 +1531,17 @@ class TestMultiTokenPrediction:
         assert seen['labels'] is not None, "loss should be computed in RL mode"
         assert torch.equal(seen['labels'], torch.tensor([[30, 40, 50, 0, 0]], dtype=torch.long))
 
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.int64])
     @pytest.mark.parametrize("cp", [1, 2])
-    def test_roll_tensor_with_packed_sequences(self, cp):
-        """Test roll_tensor function with packed sequences, with and without CP.
-
-        For CP=1: Tests standard packed sequence rolling with verified expected values
-        For CP=2: Tests CP-enabled rolling executes without errors
-        """
+    def test_roll_tensor_with_packed_sequences(self, cp, dtype):
+        """Packed rolling follows complete-stream CP ownership for values and ids."""
         Utils.initialize_model_parallel(tensor_model_parallel_size=1, context_parallel_size=cp)
         cp_group = get_context_parallel_group() if cp > 1 else None
         cp_rank = torch.distributed.get_rank(group=cp_group) if cp_group is not None else 0
 
         if cp == 1:
-            # Test case: Simple packed sequences (CP disabled)
-            tensor = torch.tensor([1, 2, 3, 4, 5], dtype=torch.float32).cuda()
+            tensor = torch.tensor([1, 2, 3, 4, 5], dtype=dtype).cuda()
             cu_seqlens = torch.tensor([0, 3, 5], dtype=torch.int32).cuda()
-
             packed_seq_params = PackedSeqParams(
                 cu_seqlens_q=cu_seqlens,
                 cu_seqlens_kv=cu_seqlens,
@@ -1274,63 +1549,63 @@ class TestMultiTokenPrediction:
                 max_seqlen_kv=3,
                 qkv_format='thd',
             )
-
-            # Roll by -1 (shift left)
             rolled, sum_val = roll_tensor(
                 tensor, shifts=-1, dims=0, cp_group=cp_group, packed_seq_params=packed_seq_params
             )
-
-            # Expected: [2, 3, 0, 5, 0] - boundaries at indices 2 and 4 are zeroed
-            expected = torch.tensor([2, 3, 0, 5, 0], dtype=torch.float32).cuda()
-            assert torch.equal(rolled, expected), f"Expected {expected}, got {rolled}"
+            rolled_without_sum, no_sum = roll_tensor(
+                tensor,
+                shifts=-1,
+                dims=0,
+                cp_group=cp_group,
+                packed_seq_params=packed_seq_params,
+                return_sum=False,
+            )
+            expected = torch.tensor([2, 3, 0, 5, 0], dtype=dtype).cuda()
+            torch.testing.assert_close(rolled, expected)
+            torch.testing.assert_close(rolled_without_sum, expected)
+            assert sum_val.numel() == 1
+            assert no_sum is None
         else:
-            # Test case: Packed sequences with CP=2
-            # Two sequences:
-            #   seq1 = [1, 2, 3, 4, 5, 6, 7, 8]
-            #   seq2 = [11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22]
-
-            if cp_rank == 0:
-                # CP Rank 0: first half of each sequence
-                tensor = torch.tensor(
-                    [1, 2, 7, 8, 11, 12, 13, 20, 21, 22], dtype=torch.float32
-                ).cuda()
-                expected = torch.tensor(
-                    [2, 3, 8, 0, 12, 13, 14, 21, 22, 0], dtype=torch.float32
-                ).cuda()
-            else:
-                # CP Rank 1: second half of each sequence
-                tensor = torch.tensor(
-                    [3, 4, 5, 6, 14, 15, 16, 17, 18, 19], dtype=torch.float32
-                ).cuda()
-                expected = torch.tensor(
-                    [4, 5, 6, 7, 15, 16, 17, 18, 19, 20], dtype=torch.float32
-                ).cuda()
-
-            cu_seqlens = torch.tensor([0, 8, 20], dtype=torch.int32).cuda()
-
+            full = torch.arange(16, dtype=dtype, device="cuda").unsqueeze(0)
+            expected_full = torch.tensor(
+                [1, 2, 3, 4, 0, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0],
+                dtype=dtype,
+                device="cuda",
+            ).unsqueeze(0)
+            chunks = full.chunk(2 * cp, dim=-1)
+            tensor = torch.cat((chunks[cp_rank], chunks[2 * cp - cp_rank - 1]), dim=-1)
+            if dtype.is_floating_point:
+                tensor = tensor.clone().requires_grad_(True)
+            expected_chunks = expected_full.chunk(2 * cp, dim=-1)
+            expected = torch.cat(
+                (expected_chunks[cp_rank], expected_chunks[2 * cp - cp_rank - 1]), dim=-1
+            )
+            cu_seqlens = torch.tensor([0, 5, 16], dtype=torch.int32).cuda()
             packed_seq_params = PackedSeqParams(
                 cu_seqlens_q=cu_seqlens,
                 cu_seqlens_kv=cu_seqlens,
-                max_seqlen_q=6,  # max(4, 6) - max local seq length per sequence
-                max_seqlen_kv=6,
+                max_seqlen_q=11,
+                max_seqlen_kv=11,
                 qkv_format='thd',
             )
-
-            # Roll by -1 (shift left) with CP communication
             rolled, sum_val = roll_tensor(
-                tensor, shifts=-1, dims=0, cp_group=cp_group, packed_seq_params=packed_seq_params
+                tensor, shifts=-1, dims=-1, cp_group=cp_group, packed_seq_params=packed_seq_params
             )
-
-            # Verify the rolled tensor matches expected values
-            assert (
-                rolled.shape == expected.shape
-            ), f"Shape mismatch: expected {expected.shape}, got {rolled.shape}"
-            assert torch.equal(
-                rolled, expected
-            ), f"CP Rank {cp_rank}: Expected\n{expected}\nbut got\n{rolled}\nDiff:\n{rolled - expected}"
-
-            # Verify sum is correct
+            torch.testing.assert_close(rolled, expected)
             assert sum_val.numel() == 1, "Sum should be a scalar"
+            if dtype.is_floating_point:
+                expected_grad_full = torch.ones_like(full)
+                expected_grad_full[..., [0, 5]] = 0
+                expected_grad_chunks = expected_grad_full.chunk(2 * cp, dim=-1)
+                expected_grad = torch.cat(
+                    (
+                        expected_grad_chunks[cp_rank],
+                        expected_grad_chunks[2 * cp - cp_rank - 1],
+                    ),
+                    dim=-1,
+                )
+                rolled.sum().backward()
+                torch.testing.assert_close(tensor.grad, expected_grad)
 
         Utils.destroy_model_parallel()
 


### PR DESCRIPTION
This PR implements HSM (hidden states mixing) for the MTP.
HSM create a set of aligned hidden states - hidden stated that predict the same token position, and sample within this set for each position in the sequence. 

In order to create aligned hidden states the previous mtp outputs needs to be rolled by -1 every iterations. This require passing information from various ranks depending on the parallelism and how the sequence is scatter across ranks. This implementation takes that into account, construct a sequence layout according to TP/SP/CP/packed sequence and pass only the relevant information to the relevant rank