### PR TITLE
fix(ci): prevent queue stalls and stale merge-group runs

### DIFF
--- a/.github/scripts/cancel_superseded_merge_group_runs.py
+++ b/.github/scripts/cancel_superseded_merge_group_runs.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Cancel active workflow runs for superseded generations of one queued PR."""
+
+import json
+import os
+import re
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+_ACTIVE_STATUSES = ("requested", "queued", "in_progress", "waiting", "pending")
+_MERGE_GROUP_REF = re.compile(r"^gh-readonly-queue/.+/pr-(\d+)-[0-9a-f]+$", re.IGNORECASE)
+
+
+class GitHubApiError(RuntimeError):
+    """Report a failed GitHub REST API request."""
+
+    def __init__(self, status: int, message: str) -> None:
+        super().__init__(message)
+        self.status = status
+
+
+class GitHubClient:
+    """Minimal GitHub Actions REST API client."""
+
+    def __init__(self, api_url: str, repository: str, token: str) -> None:
+        owner, name = repository.split("/", maxsplit=1)
+        self._repository_path = f"repos/{urllib.parse.quote(owner)}/{urllib.parse.quote(name)}"
+        self._api_url = api_url.rstrip("/")
+        self._headers = {
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+
+    def _request(self, path: str, method: str = "GET") -> dict[str, object] | None:
+        for attempt in range(5):
+            request = urllib.request.Request(
+                f"{self._api_url}/{self._repository_path}/{path}",
+                data=b"" if method == "POST" else None,
+                headers=self._headers,
+                method=method,
+            )
+            try:
+                with urllib.request.urlopen(request, timeout=30) as response:
+                    payload = response.read()
+                return json.loads(payload) if payload else None
+            except urllib.error.HTTPError as error:
+                details = error.read().decode("utf-8", errors="replace")
+                if error.code != 429 and error.code < 500:
+                    raise GitHubApiError(
+                        error.code, f"GitHub API {method} {path} failed: {details}"
+                    ) from error
+                if attempt == 4:
+                    raise GitHubApiError(
+                        error.code, f"GitHub API {method} {path} failed after retries: {details}"
+                    ) from error
+                delay = min(int(error.headers.get("Retry-After", 2**attempt)), 30)
+            except (TimeoutError, urllib.error.URLError) as error:
+                if attempt == 4:
+                    raise RuntimeError(f"GitHub API {method} {path} failed after retries: {error}") from error
+                delay = 2**attempt
+
+            print(f"GitHub API {method} {path} failed transiently; retrying in {delay}s")
+            time.sleep(delay)
+
+        raise AssertionError("unreachable")
+
+    def _list_runs(self, endpoint: str, parameters: dict[str, str]) -> list[dict[str, object]]:
+        runs: list[dict[str, object]] = []
+        page = 1
+        while True:
+            query = urllib.parse.urlencode({**parameters, "per_page": "100", "page": str(page)})
+            response = self._request(f"{endpoint}?{query}")
+            if not isinstance(response, dict) or not isinstance(response.get("workflow_runs"), list):
+                raise RuntimeError(f"GitHub API returned an invalid workflow-runs response for {endpoint}")
+
+            page_runs = response["workflow_runs"]
+            runs.extend(page_runs)
+            if len(page_runs) < 100:
+                return runs
+            page += 1
+
+    def list_trigger_workflow_runs(
+        self, workflow_id: int, head_branches: set[str]
+    ) -> list[dict[str, object]]:
+        """List merge-group runs that establish the ordering of active generations."""
+
+        runs: list[dict[str, object]] = []
+        for head_branch in sorted(head_branches):
+            runs.extend(
+                self._list_runs(
+                    f"actions/workflows/{workflow_id}/runs",
+                    {"branch": head_branch, "event": "merge_group"},
+                )
+            )
+        return runs
+
+    def list_active_merge_group_runs(self) -> list[dict[str, object]]:
+        """List all non-terminal merge-group workflow runs in the repository."""
+
+        runs_by_id: dict[int, dict[str, object]] = {}
+        for status in _ACTIVE_STATUSES:
+            for run in self._list_runs("actions/runs", {"event": "merge_group", "status": status}):
+                runs_by_id[int(run["id"])] = run
+        return list(runs_by_id.values())
+
+    def cancel_run(self, run_id: int) -> None:
+        """Request cancellation of one workflow run."""
+
+        self._request(f"actions/runs/{run_id}/cancel", method="POST")
+
+
+def _pr_number(head_branch: object) -> int | None:
+    match = _MERGE_GROUP_REF.fullmatch(str(head_branch))
+    return int(match.group(1)) if match else None
+
+
+def _run_order(run: dict[str, object]) -> tuple[str, int]:
+    return str(run["created_at"]), int(run["id"])
+
+
+def _select_superseded_runs(
+    active_runs: list[dict[str, object]],
+    trigger_workflow_runs: list[dict[str, object]],
+    current_run: dict[str, object],
+) -> list[dict[str, object]]:
+    current_head = str(current_run["head_branch"])
+    current_pr = _pr_number(current_head)
+    if current_pr is None:
+        raise ValueError(f"Unexpected merge-group head branch: {current_head}")
+
+    generation_order: dict[str, tuple[str, int]] = {}
+    for run in trigger_workflow_runs:
+        head_branch = str(run.get("head_branch", ""))
+        if _pr_number(head_branch) != current_pr:
+            continue
+        run_order = _run_order(run)
+        previous_order = generation_order.get(head_branch)
+        if previous_order is None or run_order < previous_order:
+            generation_order[head_branch] = run_order
+
+    current_order = _run_order(current_run)
+    generation_order[current_head] = min(generation_order.get(current_head, current_order), current_order)
+    if any(head != current_head and order > current_order for head, order in generation_order.items()):
+        print(f"A newer merge-group generation exists for PR #{current_pr}; this cleanup is stale")
+        return []
+
+    superseded = []
+    for run in active_runs:
+        head_branch = str(run.get("head_branch", ""))
+        if head_branch == current_head or _pr_number(head_branch) != current_pr:
+            continue
+
+        old_generation_order = generation_order.get(head_branch)
+        if old_generation_order is None:
+            print(f"Skipping run {run.get('id')} because its merge-group generation was not found")
+            continue
+        if old_generation_order < current_order:
+            superseded.append(run)
+
+    return sorted(superseded, key=_run_order)
+
+
+def main() -> None:
+    """Cancel active runs belonging to older merge-group generations of the triggering PR."""
+
+    current_run = {
+        "id": int(os.environ["TRIGGER_RUN_ID"]),
+        "head_branch": os.environ["TRIGGER_HEAD_BRANCH"],
+        "created_at": os.environ["TRIGGER_CREATED_AT"],
+    }
+    client = GitHubClient(
+        api_url=os.environ.get("GITHUB_API_URL", "https://api.github.com"),
+        repository=os.environ["GITHUB_REPOSITORY"],
+        token=os.environ["GITHUB_TOKEN"],
+    )
+
+    active_runs = client.list_active_merge_group_runs()
+    current_pr = _pr_number(current_run["head_branch"])
+    if current_pr is None:
+        raise ValueError(f"Unexpected merge-group head branch: {current_run['head_branch']}")
+    active_heads = {
+        str(run.get("head_branch", "")) for run in active_runs if _pr_number(run.get("head_branch")) == current_pr
+    }
+    active_heads.add(str(current_run["head_branch"]))
+    trigger_runs = client.list_trigger_workflow_runs(int(os.environ["TRIGGER_WORKFLOW_ID"]), active_heads)
+    superseded_runs = _select_superseded_runs(active_runs, trigger_runs, current_run)
+
+    canceled = 0
+    for run in superseded_runs:
+        run_id = int(run["id"])
+        try:
+            client.cancel_run(run_id)
+        except GitHubApiError as error:
+            if error.status == 409:
+                print(f"Run {run_id} became terminal before cancellation")
+                continue
+            raise
+        print(f"Canceled superseded {run.get('name', 'workflow')} run {run_id} ({run.get('head_branch')})")
+        canceled += 1
+
+    print(f"Canceled {canceled} superseded merge-group run(s)")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_approve_test_queue.sh
+++ b/.github/scripts/test_approve_test_queue.sh
@@ -3,6 +3,11 @@ set -euo pipefail
 
 readonly WORKFLOW=${WORKFLOW:-.github/workflows/cicd-approve-test-queue.yml}
 readonly EXTERNAL_QUEUE='          - branch: all'
+readonly WORKFLOW_RUN_EVENT='  workflow_run:'
+readonly CICD_COMPLETION_TRIGGER='    workflows: ["CICD Megatron-LM"]'
+readonly COMPLETED_ACTIVITY='    types: [completed]'
+readonly CONCURRENCY_GROUP='  group: approve-test-queue'
+readonly SERIALIZED_RUNS='  cancel-in-progress: false'
 
 if [[ $(/usr/bin/grep -c -F "$EXTERNAL_QUEUE" "$WORKFLOW") -ne 1 ]]; then
   echo "Approve Test Queue must define exactly one global external worker" >&2
@@ -19,4 +24,16 @@ if [[ $(/usr/bin/grep -c -F 'if CONTRIBUTOR_TYPE == "external":' "$WORKFLOW") -n
   exit 1
 fi
 
-echo "Approve Test Queue uses one global external worker"
+for expected in \
+  "$WORKFLOW_RUN_EVENT" \
+  "$CICD_COMPLETION_TRIGGER" \
+  "$COMPLETED_ACTIVITY" \
+  "$CONCURRENCY_GROUP" \
+  "$SERIALIZED_RUNS"; do
+  if [[ $(/usr/bin/grep -c -F "$expected" "$WORKFLOW") -ne 1 ]]; then
+    echo "Approve Test Queue must wake on completed CICD runs without racing approvals: $expected" >&2
+    exit 1
+  fi
+done
+
+echo "Approve Test Queue uses one global external worker and wakes on completed CICD runs"

--- a/.github/scripts/test_approve_test_queue.sh
+++ b/.github/scripts/test_approve_test_queue.sh
@@ -8,6 +8,8 @@ readonly CICD_COMPLETION_TRIGGER='    workflows: ["CICD Megatron-LM"]'
 readonly COMPLETED_ACTIVITY='    types: [completed]'
 readonly CONCURRENCY_GROUP='  group: approve-test-queue'
 readonly SERIALIZED_RUNS='  cancel-in-progress: false'
+readonly INTERNAL_SERVICE_ACCOUNT='          INTERNAL_SERVICE_ACCOUNTS = {"svcnemo-autobot"}'
+readonly INTERNAL_SERVICE_ACCOUNT_CHECK='              return login in INTERNAL_SERVICE_ACCOUNTS or any('
 
 if [[ $(/usr/bin/grep -c -F "$EXTERNAL_QUEUE" "$WORKFLOW") -ne 1 ]]; then
   echo "Approve Test Queue must define exactly one global external worker" >&2
@@ -36,4 +38,14 @@ for expected in \
   fi
 done
 
-echo "Approve Test Queue uses one global external worker and wakes on completed CICD runs"
+if [[ $(/usr/bin/grep -c -F "$INTERNAL_SERVICE_ACCOUNT" "$WORKFLOW") -ne 1 ]]; then
+  echo "Approve Test Queue must classify svcnemo-autobot as internal without relying on the SSO export" >&2
+  exit 1
+fi
+
+if [[ $(/usr/bin/grep -c -F "$INTERNAL_SERVICE_ACCOUNT_CHECK" "$WORKFLOW") -ne 1 ]]; then
+  echo "Approve Test Queue must apply its internal service-account allowlist" >&2
+  exit 1
+fi
+
+echo "Approve Test Queue uses one global external worker, recognizes its service account, and wakes on completion"

--- a/.github/scripts/test_cancel_superseded_merge_group_runs.py
+++ b/.github/scripts/test_cancel_superseded_merge_group_runs.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+import unittest
+from pathlib import Path
+
+from cancel_superseded_merge_group_runs import _pr_number, _select_superseded_runs
+
+
+def _run(run_id: int, head_branch: str, created_at: str, name: str = "CICD Megatron-LM") -> dict[str, object]:
+    return {
+        "id": run_id,
+        "event": "merge_group",
+        "head_branch": head_branch,
+        "created_at": created_at,
+        "name": name,
+    }
+
+
+class TestCancelSupersededMergeGroupRuns(unittest.TestCase):
+    def setUp(self) -> None:
+        self.old_head = "gh-readonly-queue/main/pr-123-a1d1234"
+        self.current_head = "gh-readonly-queue/main/pr-123-b2e5678"
+        self.current_run = _run(200, self.current_head, "2026-08-13T22:00:00Z")
+        self.trigger_runs = [
+            self.current_run,
+            _run(100, self.old_head, "2026-08-13T21:00:00Z"),
+        ]
+
+    def test_extracts_pr_number_only_from_merge_group_refs(self) -> None:
+        self.assertEqual(_pr_number(self.current_head), 123)
+        self.assertIsNone(_pr_number("pull-request/123"))
+        self.assertIsNone(_pr_number("feature/pr-123-not-a-merge-group"))
+
+    def test_selects_all_active_runs_from_the_older_generation(self) -> None:
+        old_cicd = _run(100, self.old_head, "2026-08-13T21:00:00Z")
+        old_release = _run(250, self.old_head, "2026-08-13T22:01:00Z", name="Release")
+        current_release = _run(201, self.current_head, "2026-08-13T22:00:01Z", name="Release")
+        other_pr = _run(50, "gh-readonly-queue/main/pr-456-a7e1234", "2026-08-13T20:00:00Z")
+
+        selected = _select_superseded_runs(
+            [old_cicd, old_release, self.current_run, current_release, other_pr],
+            self.trigger_runs,
+            self.current_run,
+        )
+
+        self.assertEqual([run["id"] for run in selected], [100, 250])
+
+    def test_stale_cleanup_does_not_cancel_a_newer_generation(self) -> None:
+        newer_head = "gh-readonly-queue/main/pr-123-c3f9abc"
+        newer_run = _run(300, newer_head, "2026-08-13T23:00:00Z")
+
+        selected = _select_superseded_runs(
+            [self.current_run, newer_run],
+            [newer_run, *self.trigger_runs],
+            self.current_run,
+        )
+
+        self.assertEqual(selected, [])
+
+    def test_rerun_does_not_change_the_generation_order(self) -> None:
+        old_rerun = _run(400, self.old_head, "2026-08-13T23:00:00Z")
+
+        selected = _select_superseded_runs(
+            [old_rerun],
+            [old_rerun, *self.trigger_runs],
+            self.current_run,
+        )
+
+        self.assertEqual([run["id"] for run in selected], [400])
+
+    def test_skips_an_active_generation_without_trusted_ordering_data(self) -> None:
+        unknown_head = "gh-readonly-queue/main/pr-123-d4a1111"
+        unknown_run = _run(50, unknown_head, "2026-08-13T20:00:00Z")
+
+        selected = _select_superseded_runs([unknown_run], self.trigger_runs, self.current_run)
+
+        self.assertEqual(selected, [])
+
+    def test_workflow_runs_from_the_default_branch_with_minimal_write_permission(self) -> None:
+        workflow = Path(".github/workflows/cicd-cancel-superseded-merge-groups.yml").read_text()
+
+        self.assertIn('workflows: ["CICD Megatron-LM"]', workflow)
+        self.assertIn("types: [requested]", workflow)
+        self.assertIn("github.event.workflow_run.event == 'merge_group'", workflow)
+        self.assertIn("actions: write", workflow)
+        self.assertIn("ref: ${{ github.event.repository.default_branch }}", workflow)
+        self.assertIn("persist-credentials: false", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/cicd-approve-test-queue.yml
+++ b/.github/workflows/cicd-approve-test-queue.yml
@@ -87,6 +87,7 @@ jobs:
           GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
           REPO = os.environ["GITHUB_REPOSITORY"]
           CONTRIBUTOR_TYPE = os.environ["CONTRIBUTOR_TYPE"]
+          INTERNAL_SERVICE_ACCOUNTS = {"svcnemo-autobot"}
           if CONTRIBUTOR_TYPE == "external":
               # Global limit across all branches — no division needed since we count globally.
               MAX_CONCURRENCY = int(os.environ["MAX_CONCURRENCY_EXTERNAL"])
@@ -139,10 +140,12 @@ jobs:
               return None
 
           def is_internal_contributor(pr_info):
-              """Return True if the PR author is a member of NVIDIA or NVIDIA-NeMo org (is_org_member)."""
+              """Return True for internal service accounts or NVIDIA organization members."""
               login = pr_info.get("user", {}).get("login", "")
               org_roles = sso_users.get(login, {}).get("org_roles", [])
-              return any(role in ("NVIDIA:Member", "NVIDIA-NeMo:Member") for role in org_roles)
+              return login in INTERNAL_SERVICE_ACCOUNTS or any(
+                  role in ("NVIDIA:Member", "NVIDIA-NeMo:Member") for role in org_roles
+              )
 
           def get_pr_base_branch(workflow_run):
               """

--- a/.github/workflows/cicd-approve-test-queue.yml
+++ b/.github/workflows/cicd-approve-test-queue.yml
@@ -17,7 +17,15 @@ name: Approve Test Queue
 on:
   schedule:
     - cron: "*/5 * * * *" # Runs every 5 minutes
+  # Scheduled events can be delayed, so refill released queue slots immediately.
+  workflow_run:
+    workflows: ["CICD Megatron-LM"]
+    types: [completed]
   workflow_dispatch: # Allows manual triggering
+
+concurrency:
+  group: approve-test-queue
+  cancel-in-progress: false
 
 jobs:
   approve-queue:

--- a/.github/workflows/cicd-cancel-superseded-merge-groups.yml
+++ b/.github/workflows/cicd-cancel-superseded-merge-groups.yml
@@ -1,0 +1,35 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+name: Cancel Superseded Merge-Group Runs
+
+on:
+  workflow_run:
+    workflows: ["CICD Megatron-LM"]
+    types: [requested]
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  cancel-superseded-runs:
+    if: >-
+      github.repository == 'NVIDIA/Megatron-LM' &&
+      github.event.workflow_run.event == 'merge_group'
+    runs-on: ubuntu-latest
+    steps:
+      # workflow_run is privileged, so execute only code from the trusted default branch.
+      - name: Checkout trusted repository code
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Cancel superseded merge-group runs for this PR
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          TRIGGER_CREATED_AT: ${{ github.event.workflow_run.created_at }}
+          TRIGGER_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          TRIGGER_RUN_ID: ${{ github.event.workflow_run.id }}
+          TRIGGER_WORKFLOW_ID: ${{ github.event.workflow_run.workflow_id }}
+        run: python3 .github/scripts/cancel_superseded_merge_group_runs.py

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -360,6 +360,9 @@ jobs:
       - name: Test queue approval topology
         run: .github/scripts/test_approve_test_queue.sh
 
+      - name: Test superseded merge-group cleanup
+        run: python3 .github/scripts/test_cancel_superseded_merge_group_runs.py
+
       - name: Get PR info
         id: get-pr-info
         if: startsWith(github.ref, 'refs/heads/pull-request/') && github.event_name == 'push'


### PR DESCRIPTION
## Background / motivation

The CI queue had two independent sources of avoidable waiting:

- `Approve Test Queue` relied on a five-minute schedule to refill released concurrency slots, and observed scheduled runs were delayed by 17–25 minutes.
- GitHub creates a new `gh-readonly-queue/.../pr-<number>-<sha>` ref whenever it rebuilds a merge group. The existing concurrency keys include that generated ref, so workflows from the replaced generation were not canceled and continued consuming runners.

`svcnemo-autobot` was also classified as external because the service account is intentionally absent from the SSO export.

## What changed

- Wake `Approve Test Queue` whenever `CICD Megatron-LM` completes, retaining the five-minute schedule as a fallback and serializing overlapping wakeups.
- Add a trusted default-branch cleanup workflow that cancels active workflow runs from older merge-group generations of the same PR.
- Treat `svcnemo-autobot` as an internal service account before consulting SSO organization roles.
- Add regression coverage for queue topology, merge-group selection, cross-workflow cancellation, and delayed-cleanup races.

## Details

```mermaid
flowchart LR
  CICD[New CICD merge-group run requested] --> Cleanup[Trusted workflow_run cleanup]
  Cleanup --> Discover[Find active generations for PR A]
  Discover -->|older than current| Cancel[Cancel old CICD and release runs]
  Discover -->|current or newer| Preserve[Preserve runs]
  CICDDone[CICD run completes] --> Approver[Approve Test Queue]
  Schedule[Five-minute fallback] --> Approver
  Approver --> Recount[Re-read queued, running, and waiting state]
  Recount --> Gate[Approve within current budget]
```

The cleanup uses `workflow_run: requested`, which runs from the default branch. It explicitly checks out the default branch without persisting credentials and receives only `actions: write` plus `contents: read`. It does not execute or consume code or artifacts from the merge-group commit.

Generation ordering comes from `CICD Megatron-LM` runs for each active merge-group ref. A delayed cleanup exits without cancellation if it observes a newer generation, and a generation without trusted ordering data is skipped. The cancellation pass covers `requested`, `queued`, `in_progress`, `waiting`, and `pending` merge-group runs across all workflows.

## Tested

- `python3 .github/scripts/test_cancel_superseded_merge_group_runs.py` — 6 tests passed
- `.github/scripts/test_approve_test_queue.sh` — passed
- `uv run isort .github/scripts/cancel_superseded_merge_group_runs.py .github/scripts/test_cancel_superseded_merge_group_runs.py`
- `uv run ruff check .github/scripts/cancel_superseded_merge_group_runs.py .github/scripts/test_cancel_superseded_merge_group_runs.py` — passed
- `shellcheck .github/scripts/test_approve_test_queue.sh` — passed
- `actionlint .github/workflows/cicd-cancel-superseded-merge-groups.yml` — passed
- `BASE_REF=main CHECK_ONLY=true SKIP_DOCS=false bash tools/autoformat.sh` — passed (`.github/`-only changes are outside its Python changeset)
- `git diff --check` — passed
- Live read-only `gh run list --event merge_group` check confirmed refs use `gh-readonly-queue/<base>/pr-<number>-<hex-sha>`.

Unfiltered actionlint on the existing approval and main workflows still reports pre-existing embedded-script findings outside this change.
