### PR TITLE
[GTP] Symmetric Memory Registration for the GTP/EGTP ReduceScatter path

### DIFF
--- a/docs/api-guide/core/generalized_tensor_parallel.md
+++ b/docs/api-guide/core/generalized_tensor_parallel.md
@@ -379,8 +379,8 @@ it** — a different collective over a different process group, so enable either
 ### 2.7 NCCL symmetric-memory wgrad reduce-scatter (optional)
 
 ```bash
---gtp-remat-nccl-ub        # dense gtp_remat group          default: off
---gtp-expert-remat-nccl-ub       # routed-expert egtp_remat group  default: off
+--gtp-remat-nccl-ub         # dense gtp_remat group           default: off
+--gtp-expert-remat-nccl-ub  # routed-expert egtp_remat group  default: off
 ```
 
 **Allocates the wgrad reduce-scatter send buffers from an NCCL-window-registered memory pool on the gtp_remat / egtp_remat group, so NCCL runs the reduce-scatter as a single symmetric device kernel — NVLS multimem within an NVLink domain, rail kernels when the group spans domains — instead of a ring.** Only the send side needs registration; the sharded output lands in the ordinary `main_grad`.
@@ -399,10 +399,10 @@ it** — a different collective over a different process group, so enable either
   (when the wgrad dtype matches `main_grad`). The untied embedding's wgrad is materialized by
   `F.embedding`'s own backward and pays one copy into the buffer.
 - **FP32-accumulation interplay.** A registered pool takes precedence over §2.6 on its group:
-  NCCL symmetric reduce-scatters provide equivalent numerics with better performance, so the
-  group keeps the symmetric reduce-scatter and the fp32-accum all-to-all applies only to axes
-  without a pool. E.g. `--gtp-remat-nccl-ub` + §2.6 gives a symmetric dense-GTP reduce-scatter and
-  the fp32-accum all-to-all on the EGTP axis.
+  NVLS symmetric reduce-scatters accumulate in fp32 in-switch (NCCL's `multimem.ld_reduce` uses
+  `.acc::f32` for bf16), so the group keeps the symmetric reduce-scatter and the fp32-accum
+  all-to-all applies only to axes without a pool. E.g. `--gtp-remat-nccl-ub` + §2.6 gives a
+  symmetric dense-GTP reduce-scatter and the fp32-accum all-to-all on the EGTP axis.
 - **Independent of `--use-nccl-ub`.** That flag registers DP-group (DDP bucket) buffers; these
   flags cover the gtp_remat axes only.
 

--- a/docs/api-guide/core/generalized_tensor_parallel.md
+++ b/docs/api-guide/core/generalized_tensor_parallel.md
@@ -48,6 +48,7 @@ Both `GTP_remat` collectives are prefetched one step ahead, so they overlap the 
     - [2.4 Minimal end-to-end example](#24-minimal-end-to-end-example)
     - [2.5 Tuning knobs](#25-tuning-knobs)
     - [2.6 FP32-accumulation wgrad reduce-scatter (optional)](#26-fp32-accumulation-wgrad-reduce-scatter-optional)
+    - [2.7 NCCL symmetric-memory wgrad reduce-scatter (optional)](#27-nccl-symmetric-memory-wgrad-reduce-scatter-optional)
   - [3. Implementation details](#3-implementation-details)
     - [3.1 GTP\_remat architecture (Mcore ↔ TE integration)](#31-gtp_remat-architecture-mcore--te-integration)
       - [What the flags do under the hood](#what-the-flags-do-under-the-hood)
@@ -362,7 +363,8 @@ it** — a different collective over a different process group, so enable either
   applies either way.
 - **Auto-bypass at axis size ≤ 2.** The gate reads the per-chain group, so each axis decides
   independently: a `GTP_remat=8 × EGTP_remat=2` run gets FP32 accumulation on the dense weights
-  and the plain reduce-scatter on the experts.
+  and the plain reduce-scatter on the experts. A group with a registered symmetric pool (§2.7)
+  also bypasses — the pool takes precedence.
 - **Scratch lifetime.** The buffer comes from GTP's wgrad pool rather than a fresh `empty_like`,
   and is returned only once the handle is waited — it is the *input* to the deferred FP32 sum.
 - **Batched (grouped / routed-expert) path.** The all-to-alls share one `ncclGroupStart/End` via
@@ -371,6 +373,36 @@ it** — a different collective over a different process group, so enable either
   behind it in one composite handle — which is why the all-to-alls are issued with
   `async_op=True`: for this primitive that flag defers the sum, it does not merely return a
   handle. (DDP's own flag sidesteps all this by asserting a single bucket.)
+
+### 2.7 NCCL symmetric-memory wgrad reduce-scatter (optional)
+
+```bash
+--gtp-nccl-ub        # dense gtp_remat group          default: off
+--egtp-nccl-ub       # routed-expert egtp_remat group  default: off
+```
+
+**Allocates the wgrad reduce-scatter send buffers from an NCCL-window-registered memory pool on the gtp_remat / egtp_remat group, so NCCL runs the reduce-scatter as a single symmetric device kernel — NVLS multimem within an NVLink domain, rail kernels when the group spans domains — instead of a ring.** Only the send side needs registration; the sharded output lands in the ordinary `main_grad`.
+
+| | |
+|---|---|
+| **Use when** | NVLS-capable systems (NVSwitch, NCCL with symmetric-kernel support) where the gtp_remat wgrad reduce-scatter is exposed |
+| **Skip when** | `--disable-symmetric-registration` is set (asserted incompatible) |
+| **Gain** | in-switch reduction: fewer SMs and lower latency per reduce-scatter |
+| **Cost** | a persistent registered pool of unsharded-wgrad-sized buffers per group, plus a one-time registration warmup; deregistered at shutdown |
+
+**Behaviour notes**
+
+- **Zero-copy producers.** Wgrads are written straight into the registered buffer — TE modules
+  via the `DistributedWeight.grad_buffer` protocol, Megatron-native linears via an `out=` matmul
+  (when the wgrad dtype matches `main_grad`). The untied embedding's wgrad is materialized by
+  `F.embedding`'s own backward and pays one copy into the buffer.
+- **FP32-accumulation interplay.** A registered pool takes precedence over §2.6 on its group:
+  NCCL symmetric reduce-scatters provide equivalent numerics with better performance, so the
+  group keeps the symmetric reduce-scatter and the fp32-accum all-to-all applies only to axes
+  without a pool. E.g. `--gtp-nccl-ub` + §2.6 gives a symmetric dense-GTP reduce-scatter and
+  the fp32-accum all-to-all on the EGTP axis.
+- **Independent of `--use-nccl-ub`.** That flag registers DP-group (DDP bucket) buffers; these
+  flags cover the gtp_remat axes only. Enable either, both, or neither.
 
 ---
 

--- a/docs/api-guide/core/generalized_tensor_parallel.md
+++ b/docs/api-guide/core/generalized_tensor_parallel.md
@@ -231,7 +231,7 @@ The table below covers every GTP-related CLI flag and Python knob. "Required" me
 | `--expert-tensor-parallel-num-weight-shards` | **Required** | MoE models (to shard routed-expert weights) | — | Total ETP×EGTP_remat shards per expert weight; EGTP_remat degree = value ÷ ETP. Independent of dense axis. [§2.2](#22-required-flags) |
 | `--gtp-remat-reduce-scatter-with-fp32-accumulation` | **Optional** | BF16 wgrads **and** GTP_remat axis ≥ 4 | off | Replaces the ring RS with an all-to-all + local FP32 sum to eliminate per-hop rounding error. Auto-bypassed at axis size ≤ 2. [§2.6](#26-fp32-accumulation-wgrad-reduce-scatter-optional) |
 | `--gtp-remat-nccl-ub` | **Optional** | For enabling symmetric-memory NCCL kernels on supported systems | off | Enables symmetric memory registration for the dense gtp_remat wgrad reduce-scatter path. Takes precedence over fp32-accum on its group; incompatible with `--disable-symmetric-registration`. [§2.7](#27-nccl-symmetric-memory-wgrad-reduce-scatter-optional) |
-| `--egtp-remat-nccl-ub` | **Optional** | For enabling symmetric-memory NCCL kernels on supported systems | off | Enables symmetric memory registration for the routed-expert egtp_remat wgrad reduce-scatter path. [§2.7](#27-nccl-symmetric-memory-wgrad-reduce-scatter-optional) |
+| `--gtp-expert-remat-nccl-ub` | **Optional** | For enabling symmetric-memory NCCL kernels on supported systems | off | Enables symmetric memory registration for the routed-expert egtp_remat wgrad reduce-scatter path. [§2.7](#27-nccl-symmetric-memory-wgrad-reduce-scatter-optional) |
 | `--gtp-remat-opt-in-modules` | **Optional** | MoE models with large `--moe-latent-size` | `[]` | Space-separated list of module tokens to opt in to GTP_remat sharding. Currently supported: `moe_latent_proj` (shards `fc1_latent_proj` / `fc2_latent_proj`; only beneficial when the latent size is large enough to amortize the all-gather). [§1.5](#15-opt-in-minimally-invasive-integration) |
 | `--fp8-param-gather` | **Required** | GTP + `--fp8-recipe mxfp8` | off | Gathers native MXFP8 shard directly; without it the grad-buffer reuse path is unavailable and `arguments.py` asserts. Always paired with `--reuse-grad-buf-for-mxfp8-param-ag`. [§1.3](#13-low-precision-gather-native-fp8--nvfp4-param) |
 | `--reuse-grad-buf-for-mxfp8-param-ag` | **Required** | GTP + `--fp8-recipe mxfp8` | off | Reuses the grad buffer for the MXFP8 all-gather (MXFP8 cannot map into the contiguous param buffer). Must accompany `--fp8-param-gather`. [§1.3](#13-low-precision-gather-native-fp8--nvfp4-param) |
@@ -380,7 +380,7 @@ it** — a different collective over a different process group, so enable either
 
 ```bash
 --gtp-remat-nccl-ub        # dense gtp_remat group          default: off
---egtp-remat-nccl-ub       # routed-expert egtp_remat group  default: off
+--gtp-expert-remat-nccl-ub       # routed-expert egtp_remat group  default: off
 ```
 
 **Allocates the wgrad reduce-scatter send buffers from an NCCL-window-registered memory pool on the gtp_remat / egtp_remat group, so NCCL runs the reduce-scatter as a single symmetric device kernel — NVLS multimem within an NVLink domain, rail kernels when the group spans domains — instead of a ring.** Only the send side needs registration; the sharded output lands in the ordinary `main_grad`.

--- a/docs/api-guide/core/generalized_tensor_parallel.md
+++ b/docs/api-guide/core/generalized_tensor_parallel.md
@@ -230,6 +230,8 @@ The table below covers every GTP-related CLI flag and Python knob. "Required" me
 | `--tensor-parallel-num-weight-shards` | **Required** | Always, to activate dense GTP | — | Total TP×GTP_remat shards per dense weight; GTP_remat degree = value ÷ TP. Must be ≥ TP and divisible by it. [§2.2](#22-required-flags) |
 | `--expert-tensor-parallel-num-weight-shards` | **Required** | MoE models (to shard routed-expert weights) | — | Total ETP×EGTP_remat shards per expert weight; EGTP_remat degree = value ÷ ETP. Independent of dense axis. [§2.2](#22-required-flags) |
 | `--gtp-remat-reduce-scatter-with-fp32-accumulation` | **Optional** | BF16 wgrads **and** GTP_remat axis ≥ 4 | off | Replaces the ring RS with an all-to-all + local FP32 sum to eliminate per-hop rounding error. Auto-bypassed at axis size ≤ 2. [§2.6](#26-fp32-accumulation-wgrad-reduce-scatter-optional) |
+| `--gtp-remat-nccl-ub` | **Optional** | For enabling symmetric-memory NCCL kernels on supported systems | off | Enables symmetric memory registration for the dense gtp_remat wgrad reduce-scatter path. Takes precedence over fp32-accum on its group; incompatible with `--disable-symmetric-registration`. [§2.7](#27-nccl-symmetric-memory-wgrad-reduce-scatter-optional) |
+| `--egtp-remat-nccl-ub` | **Optional** | For enabling symmetric-memory NCCL kernels on supported systems | off | Enables symmetric memory registration for the routed-expert egtp_remat wgrad reduce-scatter path. [§2.7](#27-nccl-symmetric-memory-wgrad-reduce-scatter-optional) |
 | `--gtp-remat-opt-in-modules` | **Optional** | MoE models with large `--moe-latent-size` | `[]` | Space-separated list of module tokens to opt in to GTP_remat sharding. Currently supported: `moe_latent_proj` (shards `fc1_latent_proj` / `fc2_latent_proj`; only beneficial when the latent size is large enough to amortize the all-gather). [§1.5](#15-opt-in-minimally-invasive-integration) |
 | `--fp8-param-gather` | **Required** | GTP + `--fp8-recipe mxfp8` | off | Gathers native MXFP8 shard directly; without it the grad-buffer reuse path is unavailable and `arguments.py` asserts. Always paired with `--reuse-grad-buf-for-mxfp8-param-ag`. [§1.3](#13-low-precision-gather-native-fp8--nvfp4-param) |
 | `--reuse-grad-buf-for-mxfp8-param-ag` | **Required** | GTP + `--fp8-recipe mxfp8` | off | Reuses the grad buffer for the MXFP8 all-gather (MXFP8 cannot map into the contiguous param buffer). Must accompany `--fp8-param-gather`. [§1.3](#13-low-precision-gather-native-fp8--nvfp4-param) |
@@ -377,15 +379,15 @@ it** — a different collective over a different process group, so enable either
 ### 2.7 NCCL symmetric-memory wgrad reduce-scatter (optional)
 
 ```bash
---gtp-nccl-ub        # dense gtp_remat group          default: off
---egtp-nccl-ub       # routed-expert egtp_remat group  default: off
+--gtp-remat-nccl-ub        # dense gtp_remat group          default: off
+--egtp-remat-nccl-ub       # routed-expert egtp_remat group  default: off
 ```
 
 **Allocates the wgrad reduce-scatter send buffers from an NCCL-window-registered memory pool on the gtp_remat / egtp_remat group, so NCCL runs the reduce-scatter as a single symmetric device kernel — NVLS multimem within an NVLink domain, rail kernels when the group spans domains — instead of a ring.** Only the send side needs registration; the sharded output lands in the ordinary `main_grad`.
 
 | | |
 |---|---|
-| **Use when** | NVLS-capable systems (NVSwitch, NCCL with symmetric-kernel support) where the gtp_remat wgrad reduce-scatter is exposed |
+| **Use when** | Systems with NCCL symmetric memory support |
 | **Skip when** | `--disable-symmetric-registration` is set (asserted incompatible) |
 | **Gain** | in-switch reduction: fewer SMs and lower latency per reduce-scatter |
 | **Cost** | a persistent registered pool of unsharded-wgrad-sized buffers per group, plus a one-time registration warmup; deregistered at shutdown |
@@ -399,10 +401,10 @@ it** — a different collective over a different process group, so enable either
 - **FP32-accumulation interplay.** A registered pool takes precedence over §2.6 on its group:
   NCCL symmetric reduce-scatters provide equivalent numerics with better performance, so the
   group keeps the symmetric reduce-scatter and the fp32-accum all-to-all applies only to axes
-  without a pool. E.g. `--gtp-nccl-ub` + §2.6 gives a symmetric dense-GTP reduce-scatter and
+  without a pool. E.g. `--gtp-remat-nccl-ub` + §2.6 gives a symmetric dense-GTP reduce-scatter and
   the fp32-accum all-to-all on the EGTP axis.
 - **Independent of `--use-nccl-ub`.** That flag registers DP-group (DDP bucket) buffers; these
-  flags cover the gtp_remat axes only. Enable either, both, or neither.
+  flags cover the gtp_remat axes only.
 
 ---
 

--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -454,7 +454,7 @@ def _gtp_pre_init(
     return shard_out, gtp_ctx
 
 
-def _gtp_attach_post_init(module, gtp_ctx, is_grouped=False, is_expert=False):
+def _gtp_attach_post_init(module, gtp_ctx, is_grouped=False):
     """Attach the GTP surface to a pre-sharded TE module's weights and restore logical out_features.
 
     ``is_grouped=True`` for GroupedLinear (per-expert weight0..N, coalesced AG via weight_list).
@@ -466,9 +466,7 @@ def _gtp_attach_post_init(module, gtp_ctx, is_grouped=False, is_expert=False):
     # super().__init__): downstream code reads it, e.g. the grouped-MLP fusion gate checks
     # fc1.out_features == 2 * fc2.in_features (a shard-sized fc1 would silently disable fusion).
     module.out_features = logical_out_features
-    attach_gtp_to_presharded_module(
-        module, gtp_remat_group, pad_length, is_grouped=is_grouped, is_expert=is_expert
-    )
+    attach_gtp_to_presharded_module(module, gtp_remat_group, pad_length, is_grouped=is_grouped)
 
 
 @contextmanager
@@ -501,7 +499,7 @@ def _init_gtp_remat_context(
         out_split_size=out_split_size,
     )
     yield out_features
-    _gtp_attach_post_init(module, gtp_ctx, is_grouped=is_grouped, is_expert=is_expert)
+    _gtp_attach_post_init(module, gtp_ctx, is_grouped=is_grouped)
 
 
 def split_te_layernorm_column_parallel_linear(

--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -1502,7 +1502,6 @@ class TELayerNormColumnParallelLinear(te.pytorch.LayerNormLinear):
             output_size,
             gtp_remat_group,
             extra_kwargs,
-            is_expert=is_expert,
             rng_via_kwarg=False,
             out_split_size=self.tp_size,
         )

--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -454,7 +454,7 @@ def _gtp_pre_init(
     return shard_out, gtp_ctx
 
 
-def _gtp_attach_post_init(module, gtp_ctx, is_grouped=False):
+def _gtp_attach_post_init(module, gtp_ctx, is_grouped=False, is_expert=False):
     """Attach the GTP surface to a pre-sharded TE module's weights and restore logical out_features.
 
     ``is_grouped=True`` for GroupedLinear (per-expert weight0..N, coalesced AG via weight_list).
@@ -466,7 +466,9 @@ def _gtp_attach_post_init(module, gtp_ctx, is_grouped=False):
     # super().__init__): downstream code reads it, e.g. the grouped-MLP fusion gate checks
     # fc1.out_features == 2 * fc2.in_features (a shard-sized fc1 would silently disable fusion).
     module.out_features = logical_out_features
-    attach_gtp_to_presharded_module(module, gtp_remat_group, pad_length, is_grouped=is_grouped)
+    attach_gtp_to_presharded_module(
+        module, gtp_remat_group, pad_length, is_grouped=is_grouped, is_expert=is_expert
+    )
 
 
 @contextmanager
@@ -499,7 +501,7 @@ def _init_gtp_remat_context(
         out_split_size=out_split_size,
     )
     yield out_features
-    _gtp_attach_post_init(module, gtp_ctx, is_grouped=is_grouped)
+    _gtp_attach_post_init(module, gtp_ctx, is_grouped=is_grouped, is_expert=is_expert)
 
 
 def split_te_layernorm_column_parallel_linear(
@@ -1502,6 +1504,7 @@ class TELayerNormColumnParallelLinear(te.pytorch.LayerNormLinear):
             output_size,
             gtp_remat_group,
             extra_kwargs,
+            is_expert=is_expert,
             rng_via_kwarg=False,
             out_split_size=self.tp_size,
         )

--- a/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
+++ b/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
@@ -2155,7 +2155,11 @@ class GTPShardedParam(torch.nn.Parameter):
                 for buf in wgrads:
                     _wgrad_pool_put(buf)
             for buf in rs_inputs:
-                symmetric_wgrad_pool.free(buf)  # tag-gated: symm LIFO parents only
+                # Dual release, mirroring _release_comm_scratch: each free is tag-gated
+                # and takes only its own pool's buffers.
+                if poolable:
+                    _wgrad_pool_put(buf)
+                symmetric_wgrad_pool.free(buf)
             ret = result if batched else result[0]
 
         # Wait for last reduce scatter if it was async

--- a/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
+++ b/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
@@ -43,6 +43,11 @@ from megatron.core.tensor_parallel.gtp_cuda_graphs import (
     register_capture_params_to_ensure_ready,
     register_capture_wgrad_ring_slot,
 )
+from megatron.core.tensor_parallel.gtp_symmetric_memory import (
+    is_gtp_symm_pool_registered,
+    register_gtp_symm_pool,
+    symmetric_wgrad_pool,
+)
 from megatron.core.utils import ensure_params_ready, log_single_rank
 
 logger = logging.getLogger(__name__)
@@ -308,6 +313,37 @@ _wgrad_buf_pool: Dict[tuple, list] = {}
 _GTP_GROUPED_BUF_PARITY_COUNTER: Dict[tuple, int] = {}
 
 
+def _use_symmetric_wgrad_buffer(weight) -> bool:
+    """True when this weight's reduce-scatter should send from the window-registered pool.
+
+    A registered pool takes precedence over fp32-accum on its group: the group keeps the
+    plain (symmetric) reduce-scatter, and fp32-accum applies only to unregistered groups.
+    """
+    return getattr(weight, "gtp_smr", False) and is_gtp_symm_pool_registered(weight.group)
+
+
+def _use_fp32_accum_rs(group) -> bool:
+    """True when this group's wgrad reduction runs as the fp32-accum all-to-all.
+
+    Size <= 2 gains nothing (one addition) and still costs the scratch, so it bypasses. A
+    registered symmetric pool takes precedence (see _use_symmetric_wgrad_buffer).
+    """
+    return (
+        GTP_CONFIG.reduce_scatter_with_fp32_accumulation
+        and group.size() > 2
+        and not is_gtp_symm_pool_registered(group)
+    )
+
+
+def _alloc_symmetric_wgrad_buffer(weight, dtype, device) -> torch.Tensor:
+    """Padded send buffer from the registered LIFO, pad tail zeroed (the RS sends the
+    whole buffer, and recycled LIFO storage may hold stale rows)."""
+    buf = symmetric_wgrad_pool.alloc(weight._unsharded_shape_padded, dtype, device, weight.group)
+    if weight.pad_length:
+        buf[weight._unsharded_shape[0] :].zero_()
+    return buf
+
+
 def _wgrad_pool_get(shape: tuple, dtype: torch.dtype, device) -> torch.Tensor:
     """Get a pool buffer or allocate fresh, tagged so _wgrad_pool_put accepts only
     pool-owned buffers (other callers fall through to the caching allocator on release)."""
@@ -439,6 +475,12 @@ class GTPRematConfig:
     # TODO: Infer each domain's ring size automatically.
     graph_wgrad_ring_size: int = 2
 
+    # Symmetric-memory registration: back the wgrad reduce-scatter send buffers with
+    # ncclMemAlloc pools registered on the GTP / EGTP group, so NCCL can use its
+    # symmetric (NVLS) kernels. Independent of --use-nccl-ub, which covers the DP group.
+    gtp_nccl_ub: bool = False
+    egtp_nccl_ub: bool = False
+
 
 GTP_CONFIG = GTPRematConfig()
 
@@ -469,10 +511,14 @@ def configure_gtp_remat_from_recipe(
     fp8=False,
     calculate_per_token_loss=False,
     reduce_scatter_with_fp32_accumulation=False,
+    gtp_nccl_ub=False,
+    egtp_nccl_ub=False,
+    pg_collection=None,
 ):
     """
-    Configure GTP weight-remat (padding + loss reduction) from the quantization recipe.
-    Must be called once BEFORE model construction.
+    Configure GTP weight-remat (padding + loss reduction + symm mem) from the training recipe.
+    Must be called once BEFORE model construction. ``pg_collection`` (optional) supplies the
+    GTP/EGTP groups whose symmetric pools to register; without it the MPU globals are used.
     """
     # gtp_remat grad reduction SUMs (not means) the gtp_remat axis under per-token-loss.
     # check_param_states=False: GTP buffer reuse (notably under CUDA-graph capture) trips the
@@ -481,6 +527,8 @@ def configure_gtp_remat_from_recipe(
         calculate_per_token_loss=calculate_per_token_loss,
         check_param_states=False,
         reduce_scatter_with_fp32_accumulation=reduce_scatter_with_fp32_accumulation,
+        gtp_nccl_ub=gtp_nccl_ub,
+        egtp_nccl_ub=egtp_nccl_ub,
     )
     if fp4:
         update_gtp_config(pad_for_alignment=16)
@@ -488,6 +536,28 @@ def configure_gtp_remat_from_recipe(
         update_gtp_config(pad_for_alignment=32)
     elif fp8:
         update_gtp_config(pad_for_alignment=16)
+
+    if reduce_scatter_with_fp32_accumulation and (gtp_nccl_ub or egtp_nccl_ub):
+        log_single_rank(
+            logger,
+            logging.WARNING,
+            "--gtp-nccl-ub/--egtp-nccl-ub take precedence over "
+            "--gtp-remat-reduce-scatter-with-fp32-accumulation on their groups: NCCL "
+            "symmetric reduce-scatters provide equivalent numerics with better performance.",
+        )
+
+    # Register the dense-GTP and EGTP pools centrally (pre-construction, before any forward),
+    # so all modules -- including TE pre-sharded ones -- share the registered per-group pools.
+    # resolve_gtp_remat_group prefers the caller's pg_collection (custom groups included) and
+    # falls back to the MPU globals; register_gtp_symm_pool no-ops on None/single-rank groups.
+    # Local import: process_groups_config reaches parallel_state, which imports this module.
+    if gtp_nccl_ub or egtp_nccl_ub:
+        from megatron.core.process_groups_config import resolve_gtp_remat_group
+
+        if gtp_nccl_ub:
+            register_gtp_symm_pool(resolve_gtp_remat_group(pg_collection, is_expert=False))
+        if egtp_nccl_ub:
+            register_gtp_symm_pool(resolve_gtp_remat_group(pg_collection, is_expert=True))
 
     if not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0:
         logger.info("> GTP_remat enabled. %s", GTP_CONFIG)
@@ -576,7 +646,9 @@ def _gtp_slice_one_param(param, gtp_remat_group, *, name="<unnamed>"):
     return gtp_shard
 
 
-def _gtp_attach_attrs(gtp_shard, gtp_remat_group, *, is_grouped=False, expert_idx=0):
+def _gtp_attach_attrs(
+    gtp_shard, gtp_remat_group, *, is_grouped=False, expert_idx=0, is_expert=False
+):
     """Attach group / gtp_remat_size / routed-expert tags and register in _GTP_PARAMS.
 
     Separate from _gtp_slice_one_param so attrs land on the post-quantize param (when
@@ -595,6 +667,9 @@ def _gtp_attach_attrs(gtp_shard, gtp_remat_group, *, is_grouped=False, expert_id
         gtp_shard.chain_id = GTPChain.UNGRAPHED.value
     gtp_shard.group = gtp_remat_group
     gtp_shard.gtp_remat_size = gtp_remat_group.size()
+    # gtp_smr: draw this param's reduce-scatter send buffers from the per-group
+    # window-registered pool. Expert vs dense comes from the caller's is_expert.
+    gtp_shard.gtp_smr = GTP_CONFIG.egtp_nccl_ub if is_expert else GTP_CONFIG.gtp_nccl_ub
     global _GTP_PARAMS
     _GTP_PARAMS.append(gtp_shard)
 
@@ -647,7 +722,9 @@ def _gtp_reclass_native_fp8_shard(param):
     return param
 
 
-def attach_gtp_to_presharded_module(module, gtp_remat_group, pad_length, is_grouped=False):
+def attach_gtp_to_presharded_module(
+    module, gtp_remat_group, pad_length, is_grouped=False, is_expert=False
+):
     """Turn each pre-sharded weight into a GTP param (FP8/BF16) and attach GTP wiring."""
     # GTP shards per-expert weight0..weight{num_gemms-1}; a coalesced single weight has no sibling
     # shards to attach, so reject it here (once, at setup) instead of silently attaching nothing.
@@ -672,7 +749,9 @@ def attach_gtp_to_presharded_module(module, gtp_remat_group, pad_length, is_grou
         else:
             gtp_param = _gtp_wrap_bf16_shard(module, name, param)
         gtp_param.pad_length = pad_length
-        _gtp_attach_attrs(gtp_param, gtp_remat_group, is_grouped=is_grouped, expert_idx=idx)
+        _gtp_attach_attrs(
+            gtp_param, gtp_remat_group, is_grouped=is_grouped, expert_idx=idx, is_expert=is_expert
+        )
         new_weights.append(gtp_param)
     if is_grouped and new_weights:
         new_weights[0].weight_list = new_weights
@@ -774,7 +853,7 @@ def gtp_native_fp8_load_context(module):
             param.__class__ = sub_cls
 
 
-def wrap_module_params_gtp(module, weight_names, gtp_remat_group, is_grouped=None):
+def wrap_module_params_gtp(module, weight_names, gtp_remat_group, is_grouped=None, is_expert=False):
     """Shard and re-register module params as GTPShardedParam (post-init slice).
 
     Called post-init for Megatron-style local modules (ColumnParallelLinear, etc.), which build
@@ -798,7 +877,13 @@ def wrap_module_params_gtp(module, weight_names, gtp_remat_group, is_grouped=Non
         delattr(module, name)
         gtp_shard = _gtp_slice_one_param(param, gtp_remat_group, name=name)
         del param
-        _gtp_attach_attrs(gtp_shard, gtp_remat_group, is_grouped=bool(is_grouped), expert_idx=idx)
+        _gtp_attach_attrs(
+            gtp_shard,
+            gtp_remat_group,
+            is_grouped=bool(is_grouped),
+            expert_idx=idx,
+            is_expert=is_expert,
+        )
         # register the newly sharded param back to the module
         module._parameters[name] = gtp_shard
 
@@ -907,6 +992,8 @@ def _init_gtp_runtime_attrs(obj):
     obj.rs_event = torch.cuda.Event(external=True)
     obj._rs_ticket = None
     obj._rs_a2a_bufs = None  # all-to-all scratch held by an in-flight fp32-accum RS
+    # Symmetric wgrad slot
+    obj._wgrad_symm_slot = None
     # Padding
     obj.pad_length = 0
     # Debug
@@ -1736,13 +1823,22 @@ class GTPShardedParam(torch.nn.Parameter):
         return self.all_gather_and_prefetch(**kwargs)
 
     def get_wgrad_tensor(self):
-        """Return a logical-shape view of stable ring storage or ordinary scratch.
-
-        Capture ownership is registered later, when the final RS input is selected.
-        """
+        """Return a logical-shape view of stable ring storage or ordinary scratch."""
         ring_slot = getattr(self, "_gtp_graph_wgrad_ring_slot", None)
         if ring_slot is not None:
             return self._gtp_graph_wgrad_ring_view
+
+        # TODO: Merge the ring wgrad slot and symmetric wgrad slot into a single slot.
+        if _use_symmetric_wgrad_buffer(self):
+            # Lifecycle invariant: get_wgrad_tensor -> GEMM -> _prepare consumes the slot -> RS.
+            if self._wgrad_symm_slot is not None:
+                raise RuntimeError(
+                    "[GTP] get_wgrad_tensor called again before the previous symmetric "
+                    f"wgrad buffer was consumed ({self._debug_name})."
+                )
+            buf = _alloc_symmetric_wgrad_buffer(self, self.main_grad.dtype, self.device)
+            self._wgrad_symm_slot = buf
+            return buf[: self._unsharded_shape[0]]
         return _wgrad_pool_get(self._unsharded_shape, self.main_grad.dtype, self.device)
 
     def register_grad_accum_hook(
@@ -1841,6 +1937,11 @@ class GTPShardedParam(torch.nn.Parameter):
             if not _chain_is_graphed(self.chain_id):
                 for buf in bufs:
                     _wgrad_pool_put(buf)
+            for buf in bufs:
+                # Return symm LIFO parents (tag-gated no-op for plain and ring buffers).
+                # Unconditional on chain kind: the LIFO's captured alloc/free pops replay
+                # at stable addresses.
+                symmetric_wgrad_pool.free(buf)
             setattr(self, attr, None)
 
     def _record_graph_wgrad_ring_slots_ready(self) -> None:
@@ -1945,9 +2046,8 @@ class GTPShardedParam(torch.nn.Parameter):
             rs_ctx = nullcontext()
 
         with rs_ctx:
-            # Size <= 2 gains nothing (one addition) and still costs the scratch, so it bypasses.
             # self.group is per chain, so each axis decides on its own.
-            if GTP_CONFIG.reduce_scatter_with_fp32_accumulation and self.group.size() > 2:
+            if _use_fp32_accum_rs(self.group):
                 nvtx_range_push(f"{nvtx_label}.gtp_rs_fp32accum")
                 outputs, sum_handles = [], []
                 if len(wgrads) > 1:
@@ -2009,9 +2109,29 @@ class GTPShardedParam(torch.nn.Parameter):
         that prefix, copy it there before RS.
         """
         prepared = []
-        for weight, wgrad in zip(self._weights, wgrads):
+        for index, (weight, wgrad) in enumerate(zip(self._weights, wgrads)):
             slot = getattr(weight, "_gtp_graph_wgrad_ring_slot", None)
+
             if slot is None:
+
+                # With SMR, send the padded parent tensor of the logical view
+                # that get_wgrad_tensor handed the GEMM.
+                if _use_symmetric_wgrad_buffer(weight):
+                    symm_slot = weight._wgrad_symm_slot
+                    weight._wgrad_symm_slot = None
+                    if symm_slot is None:
+                        symm_slot = _alloc_symmetric_wgrad_buffer(weight, wgrad.dtype, wgrad.device)
+
+                    # Alias check and copy
+                    if wgrad.data_ptr() != symm_slot.data_ptr():
+                        symm_slot[: weight._unsharded_shape[0]].copy_(wgrad)
+                        _wgrad_pool_put(wgrad)
+
+                    # Required to free the slot after the RS is waited on.
+                    wgrads[index] = symm_slot
+                    prepared.append(symm_slot)
+                    continue
+
                 if weight.pad_length > 0:
                     wgrad = torch.nn.functional.pad(wgrad, (0, 0, 0, weight.pad_length))
                 prepared.append(wgrad)
@@ -2065,7 +2185,11 @@ class GTPShardedParam(torch.nn.Parameter):
             self._wgrad_input_bufs = wgrads
             ret = tuple([None] * len(wgrads)) if batched else None
         else:
-            # Sync reduce-scatter — reached as the natural chain-head case, recycle immediately
+            # Sync reduce-scatter — reached as the natural chain-head case, recycle immediately.
+            # Keep a handle on the RS inputs: the name is rebound to the outputs below, and
+            # symm LIFO scratch among the inputs must go back to the LIFO (not leak to the
+            # allocator, which would starve the free list the CG capture guard relies on).
+            rs_inputs = wgrads
             wgrads, _ = self._reduce_scatter(wgrads, async_op=False, nvtx_label=nvtx_label)
             nvtx_range_push(f"{nvtx_label}.gtp_wgrad_accum")
             if len(weights) == 1:
@@ -2078,6 +2202,8 @@ class GTPShardedParam(torch.nn.Parameter):
             if poolable:
                 for buf in wgrads:
                     _wgrad_pool_put(buf)
+            for buf in rs_inputs:
+                symmetric_wgrad_pool.free(buf)  # tag-gated: symm LIFO parents only
             ret = result if batched else result[0]
 
         # Wait for last reduce scatter if it was async

--- a/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
+++ b/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
@@ -45,7 +45,6 @@ from megatron.core.tensor_parallel.gtp_cuda_graphs import (
 )
 from megatron.core.tensor_parallel.gtp_symmetric_memory import (
     is_gtp_symm_pool_registered,
-    register_gtp_symm_pool,
     symmetric_wgrad_pool,
 )
 from megatron.core.utils import ensure_params_ready, log_single_rank
@@ -313,26 +312,17 @@ _wgrad_buf_pool: Dict[tuple, list] = {}
 _GTP_GROUPED_BUF_PARITY_COUNTER: Dict[tuple, int] = {}
 
 
-def _use_symmetric_wgrad_buffer(weight) -> bool:
-    """True when this weight's reduce-scatter should send from the window-registered pool.
-
-    A registered pool takes precedence over fp32-accum on its group: the group keeps the
-    plain (symmetric) reduce-scatter, and fp32-accum applies only to unregistered groups.
-    """
-    return weight.gtp_smr and is_gtp_symm_pool_registered(weight.group)
-
-
 def _use_fp32_accum_rs(weight) -> bool:
     """True when this weight's wgrad reduction runs as the fp32-accum all-to-all.
 
     Size <= 2 gains nothing (one addition) and still costs the scratch, so it bypasses.
-    The exact complement of _use_symmetric_wgrad_buffer: a symmetric send buffer takes
-    precedence, so a weight never routes to both.
+    A registered pool takes precedence: its group keeps the plain (symmetric)
+    reduce-scatter, so fp32-accum applies only to unregistered groups.
     """
     return (
         GTP_CONFIG.reduce_scatter_with_fp32_accumulation
         and weight.group.size() > 2
-        and not _use_symmetric_wgrad_buffer(weight)
+        and not is_gtp_symm_pool_registered(weight.group)
     )
 
 
@@ -470,6 +460,8 @@ class GTPRematConfig:
     # wire, but accumulation no longer loses precision as the axis grows. Bypassed at axis size
     # <= 2. Independent of the DDP-axis --ddp-reduce-scatter-with-fp32-accumulation.
     reduce_scatter_with_fp32_accumulation: bool = False
+    gtp_remat_nccl_ub: bool = False
+    egtp_remat_nccl_ub: bool = False
     # Persistent wgrad slots per scheduling/shape domain for partial-CG asynchronous reduce-scatter.
     # Two slots cover the usual case of one same-key writer per graph. A graph containing multiple
     # same-key writers may need more slots to keep all in-flight RS inputs distinct.
@@ -479,8 +471,6 @@ class GTPRematConfig:
     # Symmetric-memory registration: back the wgrad reduce-scatter send buffers with
     # ncclMemAlloc pools registered on the GTP / EGTP group, so NCCL can use its
     # symmetric (NVLS) kernels. Independent of --use-nccl-ub, which covers the DP group.
-    gtp_nccl_ub: bool = False
-    egtp_nccl_ub: bool = False
 
 
 GTP_CONFIG = GTPRematConfig()
@@ -512,14 +502,12 @@ def configure_gtp_remat_from_recipe(
     fp8=False,
     calculate_per_token_loss=False,
     reduce_scatter_with_fp32_accumulation=False,
-    gtp_nccl_ub=False,
-    egtp_nccl_ub=False,
-    pg_collection=None,
+    gtp_remat_nccl_ub=False,
+    egtp_remat_nccl_ub=False,
 ):
     """
     Configure GTP weight-remat (padding + loss reduction + symm mem) from the training recipe.
-    Must be called once BEFORE model construction. ``pg_collection`` (optional) supplies the
-    GTP/EGTP groups whose symmetric pools to register; without it the MPU globals are used.
+    Must be called once BEFORE model construction.
     """
     # gtp_remat grad reduction SUMs (not means) the gtp_remat axis under per-token-loss.
     # check_param_states=False: GTP buffer reuse (notably under CUDA-graph capture) trips the
@@ -528,8 +516,8 @@ def configure_gtp_remat_from_recipe(
         calculate_per_token_loss=calculate_per_token_loss,
         check_param_states=False,
         reduce_scatter_with_fp32_accumulation=reduce_scatter_with_fp32_accumulation,
-        gtp_nccl_ub=gtp_nccl_ub,
-        egtp_nccl_ub=egtp_nccl_ub,
+        gtp_remat_nccl_ub=gtp_remat_nccl_ub,
+        egtp_remat_nccl_ub=egtp_remat_nccl_ub,
     )
     if fp4:
         update_gtp_config(pad_for_alignment=16)
@@ -537,28 +525,6 @@ def configure_gtp_remat_from_recipe(
         update_gtp_config(pad_for_alignment=32)
     elif fp8:
         update_gtp_config(pad_for_alignment=16)
-
-    if reduce_scatter_with_fp32_accumulation and (gtp_nccl_ub or egtp_nccl_ub):
-        log_single_rank(
-            logger,
-            logging.WARNING,
-            "--gtp-nccl-ub/--egtp-nccl-ub take precedence over "
-            "--gtp-remat-reduce-scatter-with-fp32-accumulation on their groups: NCCL "
-            "symmetric reduce-scatters provide equivalent numerics with better performance.",
-        )
-
-    # Register the dense-GTP and EGTP pools centrally (pre-construction, before any forward),
-    # so all modules -- including TE pre-sharded ones -- share the registered per-group pools.
-    # resolve_gtp_remat_group prefers the caller's pg_collection (custom groups included) and
-    # falls back to the MPU globals; register_gtp_symm_pool no-ops on None/single-rank groups.
-    # Local import: process_groups_config reaches parallel_state, which imports this module.
-    if gtp_nccl_ub or egtp_nccl_ub:
-        from megatron.core.process_groups_config import resolve_gtp_remat_group
-
-        if gtp_nccl_ub:
-            register_gtp_symm_pool(resolve_gtp_remat_group(pg_collection, is_expert=False))
-        if egtp_nccl_ub:
-            register_gtp_symm_pool(resolve_gtp_remat_group(pg_collection, is_expert=True))
 
     if not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0:
         logger.info("> GTP_remat enabled. %s", GTP_CONFIG)
@@ -647,9 +613,7 @@ def _gtp_slice_one_param(param, gtp_remat_group, *, name="<unnamed>"):
     return gtp_shard
 
 
-def _gtp_attach_attrs(
-    gtp_shard, gtp_remat_group, *, is_grouped=False, expert_idx=0, is_expert=False
-):
+def _gtp_attach_attrs(gtp_shard, gtp_remat_group, *, is_grouped=False, expert_idx=0):
     """Attach group / gtp_remat_size / routed-expert tags and register in _GTP_PARAMS.
 
     Separate from _gtp_slice_one_param so attrs land on the post-quantize param (when
@@ -668,9 +632,6 @@ def _gtp_attach_attrs(
         gtp_shard.chain_id = GTPChain.UNGRAPHED.value
     gtp_shard.group = gtp_remat_group
     gtp_shard.gtp_remat_size = gtp_remat_group.size()
-    # gtp_smr: draw this param's reduce-scatter send buffers from the per-group
-    # window-registered pool. Expert vs dense comes from the caller's is_expert.
-    gtp_shard.gtp_smr = GTP_CONFIG.egtp_nccl_ub if is_expert else GTP_CONFIG.gtp_nccl_ub
     global _GTP_PARAMS
     _GTP_PARAMS.append(gtp_shard)
 
@@ -723,9 +684,7 @@ def _gtp_reclass_native_fp8_shard(param):
     return param
 
 
-def attach_gtp_to_presharded_module(
-    module, gtp_remat_group, pad_length, is_grouped=False, is_expert=False
-):
+def attach_gtp_to_presharded_module(module, gtp_remat_group, pad_length, is_grouped=False):
     """Turn each pre-sharded weight into a GTP param (FP8/BF16) and attach GTP wiring."""
     # GTP shards per-expert weight0..weight{num_gemms-1}; a coalesced single weight has no sibling
     # shards to attach, so reject it here (once, at setup) instead of silently attaching nothing.
@@ -750,9 +709,7 @@ def attach_gtp_to_presharded_module(
         else:
             gtp_param = _gtp_wrap_bf16_shard(module, name, param)
         gtp_param.pad_length = pad_length
-        _gtp_attach_attrs(
-            gtp_param, gtp_remat_group, is_grouped=is_grouped, expert_idx=idx, is_expert=is_expert
-        )
+        _gtp_attach_attrs(gtp_param, gtp_remat_group, is_grouped=is_grouped, expert_idx=idx)
         new_weights.append(gtp_param)
     if is_grouped and new_weights:
         new_weights[0].weight_list = new_weights
@@ -854,7 +811,7 @@ def gtp_native_fp8_load_context(module):
             param.__class__ = sub_cls
 
 
-def wrap_module_params_gtp(module, weight_names, gtp_remat_group, is_grouped=None, is_expert=False):
+def wrap_module_params_gtp(module, weight_names, gtp_remat_group, is_grouped=None):
     """Shard and re-register module params as GTPShardedParam (post-init slice).
 
     Called post-init for Megatron-style local modules (ColumnParallelLinear, etc.), which build
@@ -878,13 +835,7 @@ def wrap_module_params_gtp(module, weight_names, gtp_remat_group, is_grouped=Non
         delattr(module, name)
         gtp_shard = _gtp_slice_one_param(param, gtp_remat_group, name=name)
         del param
-        _gtp_attach_attrs(
-            gtp_shard,
-            gtp_remat_group,
-            is_grouped=bool(is_grouped),
-            expert_idx=idx,
-            is_expert=is_expert,
-        )
+        _gtp_attach_attrs(gtp_shard, gtp_remat_group, is_grouped=bool(is_grouped), expert_idx=idx)
         # register the newly sharded param back to the module
         module._parameters[name] = gtp_shard
 
@@ -1830,7 +1781,7 @@ class GTPShardedParam(torch.nn.Parameter):
             return self._gtp_graph_wgrad_ring_view
 
         # TODO: Merge the ring wgrad slot and symmetric wgrad slot into a single slot.
-        if _use_symmetric_wgrad_buffer(self):
+        if is_gtp_symm_pool_registered(self.group):
             # Lifecycle invariant: get_wgrad_tensor -> GEMM -> _prepare consumes the slot -> RS.
             if self._wgrad_symm_slot is not None:
                 raise RuntimeError(
@@ -2117,7 +2068,7 @@ class GTPShardedParam(torch.nn.Parameter):
 
                 # With SMR, send the padded parent tensor of the logical view
                 # that get_wgrad_tensor handed the GEMM.
-                if _use_symmetric_wgrad_buffer(weight):
+                if is_gtp_symm_pool_registered(weight.group):
                     symm_slot = weight._wgrad_symm_slot
                     weight._wgrad_symm_slot = None
                     if symm_slot is None:

--- a/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
+++ b/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
@@ -312,20 +312,6 @@ _wgrad_buf_pool: Dict[tuple, list] = {}
 _GTP_GROUPED_BUF_PARITY_COUNTER: Dict[tuple, int] = {}
 
 
-def _use_fp32_accum_rs(weight) -> bool:
-    """True when this weight's wgrad reduction runs as the fp32-accum all-to-all.
-
-    Size <= 2 gains nothing (one addition) and still costs the scratch, so it bypasses.
-    A registered pool takes precedence: its group keeps the plain (symmetric)
-    reduce-scatter, so fp32-accum applies only to unregistered groups.
-    """
-    return (
-        GTP_CONFIG.reduce_scatter_with_fp32_accumulation
-        and weight.group.size() > 2
-        and not is_gtp_symm_pool_registered(weight.group)
-    )
-
-
 def _alloc_symmetric_wgrad_buffer(weight, dtype, device) -> torch.Tensor:
     """Padded send buffer from the registered LIFO, pad tail zeroed (the RS sends the
     whole buffer, and recycled LIFO storage may hold stale rows)."""
@@ -461,7 +447,7 @@ class GTPRematConfig:
     # <= 2. Independent of the DDP-axis --ddp-reduce-scatter-with-fp32-accumulation.
     reduce_scatter_with_fp32_accumulation: bool = False
     gtp_remat_nccl_ub: bool = False
-    egtp_remat_nccl_ub: bool = False
+    gtp_expert_remat_nccl_ub: bool = False
     # Persistent wgrad slots per scheduling/shape domain for partial-CG asynchronous reduce-scatter.
     # Two slots cover the usual case of one same-key writer per graph. A graph containing multiple
     # same-key writers may need more slots to keep all in-flight RS inputs distinct.
@@ -503,7 +489,7 @@ def configure_gtp_remat_from_recipe(
     calculate_per_token_loss=False,
     reduce_scatter_with_fp32_accumulation=False,
     gtp_remat_nccl_ub=False,
-    egtp_remat_nccl_ub=False,
+    gtp_expert_remat_nccl_ub=False,
 ):
     """
     Configure GTP weight-remat (padding + loss reduction + symm mem) from the training recipe.
@@ -517,7 +503,7 @@ def configure_gtp_remat_from_recipe(
         check_param_states=False,
         reduce_scatter_with_fp32_accumulation=reduce_scatter_with_fp32_accumulation,
         gtp_remat_nccl_ub=gtp_remat_nccl_ub,
-        egtp_remat_nccl_ub=egtp_remat_nccl_ub,
+        gtp_expert_remat_nccl_ub=gtp_expert_remat_nccl_ub,
     )
     if fp4:
         update_gtp_config(pad_for_alignment=16)
@@ -1998,8 +1984,12 @@ class GTPShardedParam(torch.nn.Parameter):
             rs_ctx = nullcontext()
 
         with rs_ctx:
-            # self.group is per chain, so each axis decides on its own.
-            if _use_fp32_accum_rs(self):
+            # fp32-accum all-to-all: skipped at size <= 2 and on symm-registered groups.
+            if (
+                GTP_CONFIG.reduce_scatter_with_fp32_accumulation
+                and self.group.size() > 2
+                and not is_gtp_symm_pool_registered(self.group)
+            ):
                 nvtx_range_push(f"{nvtx_label}.gtp_rs_fp32accum")
                 outputs, sum_handles = [], []
                 if len(wgrads) > 1:

--- a/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
+++ b/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
@@ -38,6 +38,7 @@ from packaging.version import Version
 
 from megatron.core.tensor_parallel.gtp_cuda_graphs import (
     allocate_graph_wgrad_rings,
+    clear_graph_wgrad_rings,
     cuda_graph_pool_allocation,
     register_capture_comm,
     register_capture_params_to_ensure_ready,
@@ -1750,6 +1751,14 @@ class GTPShardedParam(torch.nn.Parameter):
         assert self.is_routed_expert and self.weight_list is not None
         return self.all_gather_and_prefetch(**kwargs)
 
+    def use_zero_copy_wgrad(self, wgrad_dtype) -> bool:
+        """True when the wgrad GEMM should write straight into this weight's symmetric
+        RS send buffer (dtype permitting): direct writes keep the RS send out of the
+        copy-into-registered-memory path. Deliberately symm-only so behavior off the
+        --gtp*-remat-nccl-ub flags is unchanged; ring slots keep the copy fallback in
+        _prepare_wgrad_reduce_scatter_inputs."""
+        return self.main_grad.dtype == wgrad_dtype and is_gtp_symm_pool_registered(self.group)
+
     def get_wgrad_tensor(self):
         """Return a logical-shape view of stable ring storage or ordinary scratch."""
         ring_slot = getattr(self, "_gtp_graph_wgrad_ring_slot", None)
@@ -1869,8 +1878,8 @@ class GTPShardedParam(torch.nn.Parameter):
                     _wgrad_pool_put(buf)
             for buf in bufs:
                 # Return symm pool buffers (tag-gated no-op for plain and ring buffers).
-                # Unconditional on chain kind: the pool's captured alloc/free pops replay
-                # at stable addresses.
+                # Unconditional on chain kind: free() is captured, so replayed reuse keeps
+                # the eager wait edges, and replays serialize on the launch stream.
                 symmetric_wgrad_pool.free(buf)
             setattr(self, attr, None)
 
@@ -2052,12 +2061,14 @@ class GTPShardedParam(torch.nn.Parameter):
 
             if slot is None:
 
-                # With SMR, send the padded parent tensor of the logical view
-                # that get_wgrad_tensor handed the GEMM.
+                # With symmetric memory registration, send the padded parent tensor of the
+                # logical view that get_wgrad_tensor handed the GEMM.
                 if is_gtp_symm_pool_registered(weight.group):
                     symm_slot = weight._wgrad_symm_slot
                     weight._wgrad_symm_slot = None
                     if symm_slot is None:
+                        # wgrad.dtype on purpose: a foreign wgrad reduce-scatters in its own
+                        # dtype (upstream behavior); main_grad.add_ upcasts on mismatch.
                         symm_slot = _alloc_symmetric_wgrad_buffer(weight, wgrad.dtype, wgrad.device)
 
                     # Alias check and copy
@@ -2152,6 +2163,11 @@ class GTPShardedParam(torch.nn.Parameter):
                 pass  # next_w has not reduce-scattered yet, or something already finalized it
             elif getattr(self.next_w, "_already_finalized", False):
                 self.next_w._already_finalized = False
+                # No compute-stream fence needed: only MTP's double-RS weights
+                # (embedding/output) reach the force-finalize path, no other weight
+                # shares their vocab-sized LIFO bucket, and their next pop is behind
+                # the end-of-backward flush fence -- the buffers freed there cannot
+                # be re-popped within this backward.
             else:
                 self.next_w.rs_event.wait()
                 cache = get_global_GTP_cache()
@@ -2577,6 +2593,7 @@ def reset_gtp_state():
     GTPShardedParam._link_tables_flushed = False
     GTPShardedParam._recompute_link_tables_flushed = False
     _GTP_GROUPED_BUF_PARITY_COUNTER.clear()
+    clear_graph_wgrad_rings()
 
 
 # ------------------------------------------------------------------------

--- a/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
+++ b/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
@@ -1848,10 +1848,10 @@ class GTPShardedParam(torch.nn.Parameter):
                     for w in self._weights:
                         self._handle_megatron_grad_accum(w)
                     self._already_finalized = True
-        self._release_comm_scratch()
+        self._release_wgrad_scratch()
         return waited
 
-    def _release_comm_scratch(self, attrs=("_wgrad_input_bufs", "_rs_a2a_bufs")):
+    def _release_wgrad_scratch(self, attrs=("_wgrad_input_bufs", "_rs_a2a_bufs")):
         """Release the buffers a finished RS was reading.
 
         Its wgrad inputs, and the fp32-accum all-to-all scratch (input to the deferred FP32 sum,
@@ -1925,13 +1925,14 @@ class GTPShardedParam(torch.nn.Parameter):
             all_to_all_output_tensor=a2a_buf,
         )
         # Input to the deferred FP32 sum: held until the handle is waited on, then released by
-        # _release_comm_scratch (from _wait_reduce_scatter, or inline on the sync path).
+        # _release_wgrad_scratch (from _wait_reduce_scatter, or inline on the sync path).
         self._rs_a2a_bufs = (self._rs_a2a_bufs or []) + [a2a_buf]
         return out_buffer, handle
 
     def _reduce_scatter(self, wgrads, async_op, nvtx_label=None):
-        """Reduce-scatter one or more wgrads → (outputs, handle). Single tensor: plain RS;
-        multiple: coalesced RS."""
+        """Reduce-scatter one or more wgrads → (outputs, handle, release_bufs). Single
+        tensor: plain RS; multiple: coalesced RS. ``release_bufs`` are the send buffers
+        to free once the collective has been waited on."""
         if nvtx_label is None:
             nvtx_label = self._debug_name + ".bwd" + (".async" if async_op else ".sync")
 
@@ -1943,7 +1944,7 @@ class GTPShardedParam(torch.nn.Parameter):
             for w in self._weights:
                 w._set_rs_state(new_rs_state)
 
-        wgrads = self._prepare_wgrad_reduce_scatter_inputs(wgrads)
+        wgrads, release_bufs = self._prepare_wgrad_reduce_scatter_inputs(wgrads)
 
         if async_op:
             dtypes = [w.dtype for w in wgrads]
@@ -2005,13 +2006,13 @@ class GTPShardedParam(torch.nn.Parameter):
                     outputs.append(out)
                 nvtx_range_pop(f"{nvtx_label}.gtp_rs_fp32accum")
                 if async_op:
-                    return outputs, handle
+                    return outputs, handle, release_bufs
                 # Sync RS: the FP32 sums were deferred out of the issue loop, so finish here.
                 # Only the a2a scratch is ours to release — the wgrad inputs belong to the
                 # caller on this path (recycled in wgrad_reduce_scatter).
                 handle.wait()
-                self._release_comm_scratch(("_rs_a2a_bufs",))
-                return outputs, None
+                self._release_wgrad_scratch(("_rs_a2a_bufs",))
+                return outputs, None, release_bufs
 
             if len(wgrads) == 1:
                 nvtx_range_push(f"{nvtx_label}.gtp_rs")
@@ -2019,7 +2020,7 @@ class GTPShardedParam(torch.nn.Parameter):
                     wgrads[0], self.group, async_op=async_op, output=out_buffers[0]
                 )
                 nvtx_range_pop(f"{nvtx_label}.gtp_rs")
-                return [out], handle
+                return [out], handle, release_bufs
 
             outputs = []
             nvtx_range_push(f"{nvtx_label}.batched_gtp_rs")
@@ -2031,17 +2032,20 @@ class GTPShardedParam(torch.nn.Parameter):
                     outputs.append(out)
             nvtx_range_pop(f"{nvtx_label}.batched_gtp_rs")
 
-            return outputs, cm if async_op else None
+            return outputs, cm if async_op else None, release_bufs
 
     def _prepare_wgrad_reduce_scatter_inputs(self, wgrads):
-        """Return alignment-padded RS inputs with stable ownership when ring-backed.
+        """Split each wgrad into what the reduce-scatter sends and what to free once it
+        completes -> (send_bufs, release_bufs), both index-aligned with self._weights.
 
-        A ring slot owns the full padded tensor. The wgrad GEMM writes only its logical prefix,
-        while the zero tail remains untouched. If a caller did not produce wgrad directly into
-        that prefix, copy it there before RS.
+        Ring slots are sent but never released (their addresses must stay stable across
+        graph replays); the wgrad that fed them is released instead. A symmetric send
+        buffer is both sent and released (ownership transfer). Plain wgrads are sent
+        as-is (padded by copy if needed) and released themselves.
         """
-        prepared = []
-        for index, (weight, wgrad) in enumerate(zip(self._weights, wgrads)):
+        send_bufs = []
+        release_bufs = []
+        for weight, wgrad in zip(self._weights, wgrads):
             slot = getattr(weight, "_gtp_graph_wgrad_ring_slot", None)
 
             if slot is None:
@@ -2060,14 +2064,14 @@ class GTPShardedParam(torch.nn.Parameter):
                         if not _chain_is_graphed(self.chain_id):
                             _wgrad_pool_put(wgrad)
 
-                    # Required to free the slot after the RS is waited on.
-                    wgrads[index] = symm_slot
-                    prepared.append(symm_slot)
+                    send_bufs.append(symm_slot)
+                    release_bufs.append(symm_slot)
                     continue
 
+                release_bufs.append(wgrad)
                 if weight.pad_length > 0:
                     wgrad = torch.nn.functional.pad(wgrad, (0, 0, 0, weight.pad_length))
-                prepared.append(wgrad)
+                send_bufs.append(wgrad)
                 continue
 
             register_capture_wgrad_ring_slot(slot, weight)
@@ -2079,9 +2083,10 @@ class GTPShardedParam(torch.nn.Parameter):
                 )
             if wgrad.data_ptr() != logical_view.data_ptr():
                 logical_view.copy_(wgrad)
-            prepared.append(slot.tensor)
+            send_bufs.append(slot.tensor)
+            release_bufs.append(wgrad)
 
-        return prepared
+        return send_bufs, release_bufs
 
     def wgrad_reduce_scatter(self, wgrad, nvtx_label=None):
         """Reduce-scatter wgrad(s): sync for the last weight, async+deferred for others.
@@ -2104,26 +2109,22 @@ class GTPShardedParam(torch.nn.Parameter):
             # Accounted for here, so the cascade below must not skip the next one.
             self._already_finalized = False
 
-        # UNGRAPHED wgrads recycle via the standalone pool (_wgrad_pool_put); GRAPHED wgrads
-        # cannot, since CUDA graphs require stable buffer addresses across replay.
-        poolable = not _chain_is_graphed(self.chain_id)
-
         if GTP_CONFIG.async_reduction and self.prev_w is not None:
             # Async RS (not last weight — deferred finish). Pre-RS work on caller; NCCL wrap
             # lives at the collective site inside _reduce_scatter (mirrors the AG prefetch sites).
-            _, rs_handle = self._reduce_scatter(wgrads, async_op=True, nvtx_label=nvtx_label)
+            _, rs_handle, release_bufs = self._reduce_scatter(
+                wgrads, async_op=True, nvtx_label=nvtx_label
+            )
             self._wgrad_rs_handle = GTPShardHandle(rs_handle, weights, reduce_scatter=True)
-            # Stash wgrad input buffers — cannot recycle yet because the async RS
-            # kernel is still reading them on rs_stream.
-            self._wgrad_input_bufs = wgrads
+            # Cannot recycle yet: the async RS is still reading these on rs_stream.
+            self._wgrad_input_bufs = release_bufs
             ret = tuple([None] * len(wgrads)) if batched else None
         else:
-            # Sync reduce-scatter — reached as the natural chain-head case, recycle immediately.
-            # Keep a handle on the RS inputs: the name is rebound to the outputs below, and
-            # symm LIFO scratch among the inputs must go back to the LIFO (not leak to the
-            # allocator, which would starve the free list the CG capture guard relies on).
-            rs_inputs = wgrads
-            wgrads, _ = self._reduce_scatter(wgrads, async_op=False, nvtx_label=nvtx_label)
+            # Sync reduce-scatter — reached as the natural chain-head case; the RS is
+            # complete on return, so the send buffers recycle immediately.
+            wgrads, _, release_bufs = self._reduce_scatter(
+                wgrads, async_op=False, nvtx_label=nvtx_label
+            )
             nvtx_range_push(f"{nvtx_label}.gtp_wgrad_accum")
             if len(weights) == 1:
                 weights[0].main_grad.add_(wgrads[0])
@@ -2131,16 +2132,9 @@ class GTPShardedParam(torch.nn.Parameter):
                 torch._foreach_add_([p.main_grad for p in weights], wgrads)
             nvtx_range_pop(f"{nvtx_label}.gtp_wgrad_accum")
             result = [self._handle_megatron_grad_accum(p) for p in weights]
-
-            if poolable:
-                for buf in wgrads:
-                    _wgrad_pool_put(buf)
-            for buf in rs_inputs:
-                # Dual release, mirroring _release_comm_scratch: each free is tag-gated
-                # and takes only its own pool's buffers.
-                if poolable:
-                    _wgrad_pool_put(buf)
-                symmetric_wgrad_pool.free(buf)
+            # The sync RS is complete: hand the inputs to the shared release path.
+            self._wgrad_input_bufs = release_bufs
+            self._release_wgrad_scratch()
             ret = result if batched else result[0]
 
         # Wait for last reduce scatter if it was async

--- a/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
+++ b/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
@@ -319,19 +319,20 @@ def _use_symmetric_wgrad_buffer(weight) -> bool:
     A registered pool takes precedence over fp32-accum on its group: the group keeps the
     plain (symmetric) reduce-scatter, and fp32-accum applies only to unregistered groups.
     """
-    return getattr(weight, "gtp_smr", False) and is_gtp_symm_pool_registered(weight.group)
+    return weight.gtp_smr and is_gtp_symm_pool_registered(weight.group)
 
 
-def _use_fp32_accum_rs(group) -> bool:
-    """True when this group's wgrad reduction runs as the fp32-accum all-to-all.
+def _use_fp32_accum_rs(weight) -> bool:
+    """True when this weight's wgrad reduction runs as the fp32-accum all-to-all.
 
-    Size <= 2 gains nothing (one addition) and still costs the scratch, so it bypasses. A
-    registered symmetric pool takes precedence (see _use_symmetric_wgrad_buffer).
+    Size <= 2 gains nothing (one addition) and still costs the scratch, so it bypasses.
+    The exact complement of _use_symmetric_wgrad_buffer: a symmetric send buffer takes
+    precedence, so a weight never routes to both.
     """
     return (
         GTP_CONFIG.reduce_scatter_with_fp32_accumulation
-        and group.size() > 2
-        and not is_gtp_symm_pool_registered(group)
+        and weight.group.size() > 2
+        and not _use_symmetric_wgrad_buffer(weight)
     )
 
 
@@ -2047,7 +2048,7 @@ class GTPShardedParam(torch.nn.Parameter):
 
         with rs_ctx:
             # self.group is per chain, so each axis decides on its own.
-            if _use_fp32_accum_rs(self.group):
+            if _use_fp32_accum_rs(self):
                 nvtx_range_push(f"{nvtx_label}.gtp_rs_fp32accum")
                 outputs, sum_handles = [], []
                 if len(wgrads) > 1:

--- a/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
+++ b/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
@@ -446,17 +446,11 @@ class GTPRematConfig:
     # wire, but accumulation no longer loses precision as the axis grows. Bypassed at axis size
     # <= 2. Independent of the DDP-axis --ddp-reduce-scatter-with-fp32-accumulation.
     reduce_scatter_with_fp32_accumulation: bool = False
-    gtp_remat_nccl_ub: bool = False
-    gtp_expert_remat_nccl_ub: bool = False
     # Persistent wgrad slots per scheduling/shape domain for partial-CG asynchronous reduce-scatter.
     # Two slots cover the usual case of one same-key writer per graph. A graph containing multiple
     # same-key writers may need more slots to keep all in-flight RS inputs distinct.
     # TODO: Infer each domain's ring size automatically.
     graph_wgrad_ring_size: int = 2
-
-    # Symmetric-memory registration: back the wgrad reduce-scatter send buffers with
-    # ncclMemAlloc pools registered on the GTP / EGTP group, so NCCL can use its
-    # symmetric (NVLS) kernels. Independent of --use-nccl-ub, which covers the DP group.
 
 
 GTP_CONFIG = GTPRematConfig()
@@ -488,11 +482,9 @@ def configure_gtp_remat_from_recipe(
     fp8=False,
     calculate_per_token_loss=False,
     reduce_scatter_with_fp32_accumulation=False,
-    gtp_remat_nccl_ub=False,
-    gtp_expert_remat_nccl_ub=False,
 ):
     """
-    Configure GTP weight-remat (padding + loss reduction + symm mem) from the training recipe.
+    Configure GTP weight-remat (padding + loss reduction) from the training recipe.
     Must be called once BEFORE model construction.
     """
     # gtp_remat grad reduction SUMs (not means) the gtp_remat axis under per-token-loss.
@@ -502,8 +494,6 @@ def configure_gtp_remat_from_recipe(
         calculate_per_token_loss=calculate_per_token_loss,
         check_param_states=False,
         reduce_scatter_with_fp32_accumulation=reduce_scatter_with_fp32_accumulation,
-        gtp_remat_nccl_ub=gtp_remat_nccl_ub,
-        gtp_expert_remat_nccl_ub=gtp_expert_remat_nccl_ub,
     )
     if fp4:
         update_gtp_config(pad_for_alignment=16)
@@ -2067,7 +2057,8 @@ class GTPShardedParam(torch.nn.Parameter):
                     # Alias check and copy
                     if wgrad.data_ptr() != symm_slot.data_ptr():
                         symm_slot[: weight._unsharded_shape[0]].copy_(wgrad)
-                        _wgrad_pool_put(wgrad)
+                        if not _chain_is_graphed(self.chain_id):
+                            _wgrad_pool_put(wgrad)
 
                     # Required to free the slot after the RS is waited on.
                     wgrads[index] = symm_slot

--- a/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
+++ b/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
@@ -1762,7 +1762,9 @@ class GTPShardedParam(torch.nn.Parameter):
             if self._wgrad_symm_slot is not None:
                 raise RuntimeError(
                     "[GTP] get_wgrad_tensor called again before the previous symmetric "
-                    f"wgrad buffer was consumed ({self._debug_name})."
+                    f"wgrad buffer was consumed ({self._debug_name}). The previous backward "
+                    "either aborted between the wgrad GEMM and its reduce-scatter, or a "
+                    "deferred-wgrad schedule skipped the reduce-scatter for this weight."
                 )
             buf = _alloc_symmetric_wgrad_buffer(self, self.main_grad.dtype, self.device)
             self._wgrad_symm_slot = buf

--- a/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
+++ b/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
@@ -313,8 +313,8 @@ _GTP_GROUPED_BUF_PARITY_COUNTER: Dict[tuple, int] = {}
 
 
 def _alloc_symmetric_wgrad_buffer(weight, dtype, device) -> torch.Tensor:
-    """Padded send buffer from the registered LIFO, pad tail zeroed (the RS sends the
-    whole buffer, and recycled LIFO storage may hold stale rows)."""
+    """Padded send buffer from the registered recycling pool, pad tail zeroed (the RS
+    sends the whole buffer, and a recycled buffer may hold stale rows)."""
     buf = symmetric_wgrad_pool.alloc(weight._unsharded_shape_padded, dtype, device, weight.group)
     if weight.pad_length:
         buf[weight._unsharded_shape[0] :].zero_()
@@ -1868,8 +1868,8 @@ class GTPShardedParam(torch.nn.Parameter):
                 for buf in bufs:
                     _wgrad_pool_put(buf)
             for buf in bufs:
-                # Return symm LIFO parents (tag-gated no-op for plain and ring buffers).
-                # Unconditional on chain kind: the LIFO's captured alloc/free pops replay
+                # Return symm pool buffers (tag-gated no-op for plain and ring buffers).
+                # Unconditional on chain kind: the pool's captured alloc/free pops replay
                 # at stable addresses.
                 symmetric_wgrad_pool.free(buf)
             setattr(self, attr, None)

--- a/megatron/core/tensor_parallel/gtp_api.py
+++ b/megatron/core/tensor_parallel/gtp_api.py
@@ -11,7 +11,7 @@ module uses GTP symbols without TE.
 
 # Outside the HAVE_TE guard on purpose: gtp_symmetric_memory has no TE dependency, and
 # shutdown must be able to deregister pools even where the TE-backed surface is unavailable.
-from megatron.core.tensor_parallel.gtp_symmetric_memory import deregister_gtp_symm_pools
+from megatron.core.tensor_parallel.gtp_symmetric_memory import deregister_and_clear_gtp_symm_pools
 
 try:
     from megatron.core.tensor_parallel.generalized_tensor_parallelism import (
@@ -48,7 +48,7 @@ except ImportError:
 
 __all__ = [
     "HAVE_GTP",
-    "deregister_gtp_symm_pools",
+    "deregister_and_clear_gtp_symm_pools",
     "GTP_CONFIG",
     "GTPChain",
     "GTPEmbeddingWeight",

--- a/megatron/core/tensor_parallel/gtp_api.py
+++ b/megatron/core/tensor_parallel/gtp_api.py
@@ -9,6 +9,10 @@ too old the core module imports cleanly but reports ``HAVE_TE = False``, mirrore
 module uses GTP symbols without TE.
 """
 
+# Outside the HAVE_TE guard on purpose: gtp_symmetric_memory has no TE dependency, and
+# shutdown must be able to deregister pools even where the TE-backed surface is unavailable.
+from megatron.core.tensor_parallel.gtp_symmetric_memory import deregister_gtp_symm_pools
+
 try:
     from megatron.core.tensor_parallel.generalized_tensor_parallelism import (
         GTP_CONFIG,
@@ -44,6 +48,7 @@ except ImportError:
 
 __all__ = [
     "HAVE_GTP",
+    "deregister_gtp_symm_pools",
     "GTP_CONFIG",
     "GTPChain",
     "GTPEmbeddingWeight",

--- a/megatron/core/tensor_parallel/gtp_api.py
+++ b/megatron/core/tensor_parallel/gtp_api.py
@@ -9,10 +9,6 @@ too old the core module imports cleanly but reports ``HAVE_TE = False``, mirrore
 module uses GTP symbols without TE.
 """
 
-# Outside the HAVE_TE guard on purpose: gtp_symmetric_memory has no TE dependency, and
-# shutdown must be able to deregister pools even where the TE-backed surface is unavailable.
-from megatron.core.tensor_parallel.gtp_symmetric_memory import deregister_and_clear_gtp_symm_pools
-
 try:
     from megatron.core.tensor_parallel.generalized_tensor_parallelism import (
         GTP_CONFIG,
@@ -38,6 +34,10 @@ try:
         set_cuda_graph_mempool,
         track_gtp_capture_comms,
     )
+    from megatron.core.tensor_parallel.gtp_symmetric_memory import (
+        deregister_and_clear_gtp_symm_pools,
+        register_gtp_symm_pool,
+    )
 
     HAVE_GTP = HAVE_TE
 except ImportError:
@@ -45,10 +45,15 @@ except ImportError:
     # the other symbols lazily under an ``if HAVE_GTP:`` guard, so no stubs needed.
     HAVE_GTP = False
 
+    def deregister_and_clear_gtp_symm_pools() -> None:
+        """No-op stub: shutdown calls this unconditionally, and without the GTP
+        surface no pool can have been registered."""
+
 
 __all__ = [
     "HAVE_GTP",
     "deregister_and_clear_gtp_symm_pools",
+    "register_gtp_symm_pool",
     "GTP_CONFIG",
     "GTPChain",
     "GTPEmbeddingWeight",

--- a/megatron/core/tensor_parallel/gtp_cuda_graphs.py
+++ b/megatron/core/tensor_parallel/gtp_cuda_graphs.py
@@ -13,12 +13,16 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass, field
 from typing import Callable, Iterable, Optional
 
 import torch
 
+from megatron.core.tensor_parallel.gtp_symmetric_memory import (
+    gtp_symm_pool_ctx,
+    is_gtp_symm_pool_registered,
+)
 from megatron.core.utils import log_single_rank
 
 logger = logging.getLogger(__name__)
@@ -171,6 +175,10 @@ def allocate_graph_wgrad_rings(
             )
             params_by_key[key].append(param)
 
+    # Symm-RS: GRAPHED chains send their persistent ring slot directly, so allocating the
+    # slot from the window-registered pool puts the RS send buffer in the NCCL symmetric
+    # window. This runs pre-capture and the pool routing is collective-free, so it is
+    # capture-safe; slot addresses stay stable either way.
     total_bytes = 0
     buffer_count = 0
     new_slots = []
@@ -178,13 +186,17 @@ def allocate_graph_wgrad_rings(
         slot_count = min(ring_size, len(matching_params))
         slots = []
         exemplar = matching_params[0]
+        symm = getattr(exemplar, "gtp_smr", False) and is_gtp_symm_pool_registered(
+            exemplar.group
+        )
         for slot_index in range(slot_count):
-            tensor = torch.empty(
-                exemplar._unsharded_shape_padded,
-                dtype=exemplar.main_grad.dtype,
-                device=exemplar.device,
-                memory_format=torch.contiguous_format,
-            )
+            with gtp_symm_pool_ctx(exemplar.group) if symm else nullcontext():
+                tensor = torch.empty(
+                    exemplar._unsharded_shape_padded,
+                    dtype=exemplar.main_grad.dtype,
+                    device=exemplar.device,
+                    memory_format=torch.contiguous_format,
+                )
             if exemplar.pad_length > 0:
                 tensor.narrow(0, exemplar._unsharded_shape[0], exemplar.pad_length).zero_()
             slot = GraphWgradRingSlot(

--- a/megatron/core/tensor_parallel/gtp_cuda_graphs.py
+++ b/megatron/core/tensor_parallel/gtp_cuda_graphs.py
@@ -172,7 +172,6 @@ def allocate_graph_wgrad_rings(
                 param._unsharded_shape_padded,
                 param.main_grad.dtype,
                 param.expert_idx,
-                param.gtp_smr,
             )
             params_by_key[key].append(param)
 
@@ -187,7 +186,7 @@ def allocate_graph_wgrad_rings(
         slot_count = min(ring_size, len(matching_params))
         slots = []
         exemplar = matching_params[0]
-        symm = exemplar.gtp_smr and is_gtp_symm_pool_registered(exemplar.group)
+        symm = is_gtp_symm_pool_registered(exemplar.group)
         for slot_index in range(slot_count):
             with gtp_symm_pool_ctx(exemplar.group) if symm else nullcontext():
                 tensor = torch.empty(

--- a/megatron/core/tensor_parallel/gtp_cuda_graphs.py
+++ b/megatron/core/tensor_parallel/gtp_cuda_graphs.py
@@ -186,6 +186,10 @@ def allocate_graph_wgrad_rings(
         slot_count = min(ring_size, len(matching_params))
         slots = []
         exemplar = matching_params[0]
+        assert all(p.group is exemplar.group for p in matching_params), (
+            "GTP wgrad ring slots are allocated from the exemplar's symmetric pool, so "
+            "every param sharing a ring key must share its process group"
+        )
         symm = is_gtp_symm_pool_registered(exemplar.group)
         for slot_index in range(slot_count):
             with gtp_symm_pool_ctx(exemplar.group) if symm else nullcontext():
@@ -232,6 +236,16 @@ def allocate_graph_wgrad_rings(
         f"[GTP Wgrad Ring] allocated {buffer_count} buffers "
         f"({total_bytes / 1024**2:.1f} MB), ring_size={ring_size}",
     )
+
+
+def clear_graph_wgrad_rings() -> None:
+    """Drop every ring slot so a rebuilt model reallocates them.
+
+    Without this, the stale non-empty dict makes allocate_graph_wgrad_rings a silent
+    no-op on the next build, leaving slots keyed by the old model's groups and shapes.
+    GPU work must be idle (callers synchronize).
+    """
+    _GRAPH_WGRAD_RINGS.clear()
 
 
 _CG_MEMPOOL_DEVICE = None

--- a/megatron/core/tensor_parallel/gtp_cuda_graphs.py
+++ b/megatron/core/tensor_parallel/gtp_cuda_graphs.py
@@ -172,6 +172,7 @@ def allocate_graph_wgrad_rings(
                 param._unsharded_shape_padded,
                 param.main_grad.dtype,
                 param.expert_idx,
+                param.gtp_smr,
             )
             params_by_key[key].append(param)
 
@@ -186,9 +187,7 @@ def allocate_graph_wgrad_rings(
         slot_count = min(ring_size, len(matching_params))
         slots = []
         exemplar = matching_params[0]
-        symm = getattr(exemplar, "gtp_smr", False) and is_gtp_symm_pool_registered(
-            exemplar.group
-        )
+        symm = exemplar.gtp_smr and is_gtp_symm_pool_registered(exemplar.group)
         for slot_index in range(slot_count):
             with gtp_symm_pool_ctx(exemplar.group) if symm else nullcontext():
                 tensor = torch.empty(

--- a/megatron/core/tensor_parallel/gtp_symmetric_memory.py
+++ b/megatron/core/tensor_parallel/gtp_symmetric_memory.py
@@ -31,7 +31,7 @@ import torch
 import torch.distributed as dist
 
 import megatron.core.nccl_allocator as nccl_allocator
-from megatron.core.utils import log_single_rank
+from megatron.core.utils import is_torch_min_version, log_single_rank
 
 logger = logging.getLogger(__name__)
 
@@ -71,6 +71,12 @@ def register_gtp_symm_pool(group: dist.ProcessGroup | None) -> torch.cuda.MemPoo
     """
     if group is None or group.size() <= 1:
         return None
+    if not is_torch_min_version("2.9.0a0"):
+        raise RuntimeError(
+            "[GTP] --gtp-remat-nccl-ub/--egtp-remat-nccl-ub require PyTorch >= 2.9: older "
+            "versions cannot create a symmetric memory pool (create_nccl_mem_pool silently "
+            "falls back to a non-symmetric one, so the reduce-scatter would not be symmetric)."
+        )
     pool = get_gtp_symm_pool(group)
     if group.group_name in _registered:
         return pool

--- a/megatron/core/tensor_parallel/gtp_symmetric_memory.py
+++ b/megatron/core/tensor_parallel/gtp_symmetric_memory.py
@@ -101,22 +101,6 @@ def is_gtp_symm_pool_registered(group: dist.ProcessGroup | None) -> bool:
     return group is not None and group.size() > 1 and group.group_name in _registered
 
 
-def deregister_gtp_symm_pools() -> None:
-    """Deregister every GTP-owned pool (a window left registered at process-group
-    destruction makes NCCL abort). Call on all ranks before teardown; no-op if nothing
-    was registered. Also drops the recycled send buffers living in these pools."""
-    # Drop the recycled send buffers first: they alias the pools torn down below.
-    symmetric_wgrad_pool.clear()
-    # Quiesce the device before deregistering windows: an in-flight kernel or
-    # collective still reading pool memory would otherwise fault asynchronously.
-    if torch.cuda.is_available() and torch.cuda.is_initialized():
-        torch.cuda.synchronize()
-    for name in sorted(_registered):
-        nccl_allocator.deregister_mem_pool(_pools[name], _registered[name])
-    _registered.clear()
-    _pools.clear()
-
-
 # ---------------------------------------------------------------------------
 # RS send-buffer LIFO: recycled window-registered scratch for wgrad reduce-scatters
 # ---------------------------------------------------------------------------
@@ -186,7 +170,7 @@ class RegisteredLifoPool:
         group = getattr(buf, "_gtp_symm_group", None)
         if group is None:
             return
-        self._free[(buf.numel(), buf.dtype, group.group_name)].append(buf.reshape(-1))
+        self._free[(buf.numel(), buf.dtype, group.group_name)].append(buf.view(-1))
 
     def clear(self) -> None:
         """Drop every cached buffer. Called at teardown, before the pools they alias go away."""
@@ -194,5 +178,24 @@ class RegisteredLifoPool:
 
 
 # The process-wide send-buffer cache, used by generalized_tensor_parallelism. Lives here
-# so deregister_gtp_symm_pools can drop its buffers at teardown.
+# so deregister_and_clear_gtp_symm_pools can drop its buffers at teardown.
 symmetric_wgrad_pool = RegisteredLifoPool()
+
+
+def deregister_and_clear_gtp_symm_pools() -> None:
+    """Deregister every GTP-owned pool (a window left registered at process-group
+    destruction makes NCCL abort) and drop the recycled send buffers living in them.
+    Call on all ranks before teardown; no-op if nothing was registered."""
+    # Wait for all GPU work to finish first: a kernel or collective still reading
+    # pool memory would fault once the windows go away.
+    if torch.cuda.is_available() and torch.cuda.is_initialized():
+        torch.cuda.synchronize()
+    # Deregister while the recycled send buffers are still alive. Their memory keeps
+    # the pool non-empty, so deregister_mem_pool (which skips empty pools) always runs.
+    for name in sorted(_registered):
+        nccl_allocator.deregister_mem_pool(_pools[name], _registered[name])
+    # Only now drop the buffers and the pools; the windows are gone, so the memory
+    # is safe to release.
+    symmetric_wgrad_pool.clear()
+    _registered.clear()
+    _pools.clear()

--- a/megatron/core/tensor_parallel/gtp_symmetric_memory.py
+++ b/megatron/core/tensor_parallel/gtp_symmetric_memory.py
@@ -1,0 +1,198 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# See LICENSE for license information.
+
+"""GTP symmetric memory: NCCL window registration for GTP communication buffers.
+
+This module keeps one ``ncclMemAlloc``-backed ``torch.cuda.MemPool`` per GTP process
+group. Once ``register_gtp_symm_pool(group)`` registers a pool on its group, PyTorch's
+ProcessGroupNCCL hook window-registers every allocation made inside
+``gtp_symm_pool_ctx(group)``, which lets NCCL run its symmetric / NVLS kernels on
+those buffers.
+
+Two parts:
+  - Pool lifecycle: create, register, query, and tear down the per-group pools,
+    plus the allocation context ``gtp_symm_pool_ctx``.
+  - ``symmetric_wgrad_pool`` (a ``RegisteredLifoPool``): recycled, window-registered
+    send buffers for the wgrad reduce-scatter.
+
+The launcher must set ``NCCL_NVLS_ENABLE=1`` and
+``TORCH_NCCL_USE_TENSOR_REGISTER_ALLOCATOR_HOOK=0`` before ``init_process_group``.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from collections import defaultdict
+from contextlib import AbstractContextManager
+
+import torch
+import torch.distributed as dist
+
+import megatron.core.nccl_allocator as nccl_allocator
+from megatron.core.utils import log_single_rank
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Registries (process-global, keyed by group.group_name)
+# ---------------------------------------------------------------------------
+
+# One MemPool per GTP/EGTP group, created once.
+_pools: "dict[str, torch.cuda.MemPool]" = {}
+
+# Groups whose pool registration is live. Maps name -> group (not a set) because
+# teardown needs the group object to deregister.
+_registered: "dict[str, object]" = {}
+
+# ---------------------------------------------------------------------------
+# Pool lifecycle: create -> warm -> register -> allocate-into -> query -> deregister
+# ---------------------------------------------------------------------------
+
+
+def get_gtp_symm_pool(group: dist.ProcessGroup) -> torch.cuda.MemPool:
+    """Return the per-group ``ncclMemAlloc``-backed MemPool, creating it once."""
+    name = group.group_name
+    pool = _pools.get(name)
+    if pool is None:
+        nccl_allocator.init()
+        pool = nccl_allocator.create_nccl_mem_pool(symmetric=True)
+        _pools[name] = pool
+    return pool
+
+
+def register_gtp_symm_pool(group: dist.ProcessGroup | None) -> torch.cuda.MemPool | None:
+    """Create (if needed) and register the group's pool. Safe to call more than once;
+    does nothing for ``None`` or single-rank groups.
+
+    Issues a collective, so call it during model construction — before the first
+    forward or any CUDA-graph capture. New segments register automatically afterwards.
+    """
+    if group is None or group.size() <= 1:
+        return None
+    pool = get_gtp_symm_pool(group)
+    if group.group_name in _registered:
+        return pool
+    # NCCL creates communicators lazily on the first collective; run one tiny all-reduce
+    # so the registration below sees an initialized communicator.
+    warmup = torch.zeros(1, device=torch.cuda.current_device())
+    dist.all_reduce(warmup, group=group)
+    nccl_allocator.register_mem_pool(pool, group, symmetric=True)
+    _registered[group.group_name] = group
+    log_single_rank(
+        logger,
+        logging.INFO,
+        f"[MCORE][GTP] Registered GTP cache pool on group {group.group_name} "
+        f"(size={group.size()})",
+    )
+    return pool
+
+
+def gtp_symm_pool_ctx(group: dist.ProcessGroup) -> AbstractContextManager[None]:
+    """Context manager: allocations inside it come from ``group``'s pool. Collective-free
+    (capture-safe); register the pool first or allocations are not window-registered."""
+    return torch.cuda.use_mem_pool(get_gtp_symm_pool(group))
+
+
+def is_gtp_symm_pool_registered(group: dist.ProcessGroup | None) -> bool:
+    """True once ``register_gtp_symm_pool`` has registered this group's pool; also False for
+    ``None`` and single-rank groups, which are never registered."""
+    return group is not None and group.size() > 1 and group.group_name in _registered
+
+
+def deregister_gtp_symm_pools() -> None:
+    """Deregister every GTP-owned pool (a window left registered at process-group
+    destruction makes NCCL abort). Call on all ranks before teardown; no-op if nothing
+    was registered. Also drops the recycled send buffers living in these pools."""
+    # Drop the recycled send buffers first: they alias the pools torn down below.
+    symmetric_wgrad_pool.clear()
+    # Quiesce the device before deregistering windows: an in-flight kernel or
+    # collective still reading pool memory would otherwise fault asynchronously.
+    if torch.cuda.is_available() and torch.cuda.is_initialized():
+        torch.cuda.synchronize()
+    for name in sorted(_registered):
+        nccl_allocator.deregister_mem_pool(_pools[name], _registered[name])
+    _registered.clear()
+    _pools.clear()
+
+
+# ---------------------------------------------------------------------------
+# RS send-buffer LIFO: recycled window-registered scratch for wgrad reduce-scatters
+# ---------------------------------------------------------------------------
+
+
+class RegisteredLifoPool:
+    """A recycling cache of window-registered buffers, one free list per group.
+
+    The wgrad reduce-scatter can only use symmetric collectives if its send buffer is
+    window-registered, so the wgrad is written into a buffer from this cache. ``alloc``
+    pops a free buffer (or allocates a new one through ``gtp_symm_pool_ctx``); ``free``
+    returns it once the reduce-scatter has finished reading it. Buffers are shared by
+    all weights of the same size, so memory stays at the peak number of in-flight
+    reduce-scatters instead of one buffer per weight.
+
+    CUDA graphs: the eager warmup iterations run the same reduce-scatter overlap as
+    the captured steps, so by capture time the free lists already hold enough buffers
+    and ``alloc`` only ever pops. Allocating a new buffer during capture would be
+    illegal, so that case raises a clear error instead.
+
+    Buffers are stored 1-D, so one free list serves every shape with the same element
+    count. ``alloc`` returns a view tagged with ``_gtp_symm_group``; ``free`` ignores
+    untagged tensors, which lets callers pass mixed buffer lists to both this pool and
+    the plain scratch pool and have each take only its own.
+    """
+
+    def __init__(self) -> None:
+        # (numel, dtype, group_name) -> list of free 1-D buffers.
+        self._free: dict[tuple, list] = defaultdict(list)
+
+    def alloc(
+        self,
+        shape: torch.Size | tuple[int, ...],
+        dtype: torch.dtype,
+        device: torch.device,
+        group: dist.ProcessGroup,
+    ) -> torch.Tensor:
+        """Return a buffer of ``shape`` from ``group``'s free list, allocating one if empty.
+
+        Raises RuntimeError if a fresh allocation would be needed during CUDA-graph capture.
+        """
+        numel = int(math.prod(shape))
+        bucket = self._free[(numel, dtype, group.group_name)]
+        if bucket:
+            flat = bucket.pop()
+        else:
+            if torch.cuda.is_current_stream_capturing():
+                raise RuntimeError(
+                    "[GTP] RegisteredLifoPool exhausted during CUDA-graph capture "
+                    f"(group={group.group_name}, numel={numel}, dtype={dtype}). The "
+                    "eager warmup did not pre-populate enough RS send buffers for "
+                    "the reduce-scatter overlap depth -- run more warmup iters, or "
+                    "the RS concurrency changed between warmup and capture."
+                )
+            # Allocate from the group's registered pool when it has one; else plain memory.
+            if is_gtp_symm_pool_registered(group):
+                with gtp_symm_pool_ctx(group):
+                    flat = torch.empty(numel, dtype=dtype, device=device)
+            else:
+                flat = torch.empty(numel, dtype=dtype, device=device)
+        out = flat.view(shape)
+        out._gtp_symm_group = group  # marks the buffer as pool-owned; free() keys on this
+        return out
+
+    def free(self, buf: torch.Tensor) -> None:
+        """Return ``buf`` to its group's free list; no-op for untagged (foreign) buffers."""
+        group = getattr(buf, "_gtp_symm_group", None)
+        if group is None:
+            return
+        self._free[(buf.numel(), buf.dtype, group.group_name)].append(buf.reshape(-1))
+
+    def clear(self) -> None:
+        """Drop every cached buffer. Called at teardown, before the pools they alias go away."""
+        self._free.clear()
+
+
+# The process-wide send-buffer cache, used by generalized_tensor_parallelism. Lives here
+# so deregister_gtp_symm_pools can drop its buffers at teardown.
+symmetric_wgrad_pool = RegisteredLifoPool()

--- a/megatron/core/tensor_parallel/gtp_symmetric_memory.py
+++ b/megatron/core/tensor_parallel/gtp_symmetric_memory.py
@@ -15,9 +15,6 @@ Two parts:
     plus the allocation context ``gtp_symm_pool_ctx``.
   - ``symmetric_wgrad_pool`` (a ``RegisteredLIFOPool``): recycled, window-registered
     send buffers for the wgrad reduce-scatter.
-
-The launcher must set ``NCCL_NVLS_ENABLE=1`` and
-``TORCH_NCCL_USE_TENSOR_REGISTER_ALLOCATOR_HOOK=0`` before ``init_process_group``.
 """
 
 from __future__ import annotations
@@ -190,9 +187,9 @@ symmetric_wgrad_pool = RegisteredLIFOPool()
 
 
 def deregister_and_clear_gtp_symm_pools() -> None:
-    """Deregister every GTP-owned pool (a window left registered at process-group
-    destruction makes NCCL abort) and drop the recycled send buffers living in them.
-    Call on all ranks before teardown; no-op if nothing was registered."""
+    """Tear down what this module owns: deregister the pools' windows, then drop the
+    recycled send buffers. Allocations owned by others (e.g. graph wgrad ring slots)
+    are not freed here. Call on all ranks before teardown; no-op if never registered."""
     # Wait for all GPU work to finish first: a kernel or collective still reading
     # pool memory would fault once the windows go away.
     if torch.cuda.is_available() and torch.cuda.is_initialized():

--- a/megatron/core/tensor_parallel/gtp_symmetric_memory.py
+++ b/megatron/core/tensor_parallel/gtp_symmetric_memory.py
@@ -13,7 +13,7 @@ those buffers.
 Two parts:
   - Pool lifecycle: create, register, query, and tear down the per-group pools,
     plus the allocation context ``gtp_symm_pool_ctx``.
-  - ``symmetric_wgrad_pool`` (a ``RegisteredLifoPool``): recycled, window-registered
+  - ``symmetric_wgrad_pool`` (a ``RegisteredLIFOPool``): recycled, window-registered
     send buffers for the wgrad reduce-scatter.
 
 The launcher must set ``NCCL_NVLS_ENABLE=1`` and
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import logging
 import math
+import typing
 from collections import defaultdict
 from contextlib import AbstractContextManager
 
@@ -40,18 +41,18 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 # One MemPool per GTP/EGTP group, created once.
-_pools: "dict[str, torch.cuda.MemPool]" = {}
+_pools: typing.Dict[str, torch.cuda.MemPool] = {}
 
 # Groups whose pool registration is live. Maps name -> group (not a set) because
 # teardown needs the group object to deregister.
-_registered: "dict[str, object]" = {}
+_registered: typing.Dict[str, typing.Any] = {}
 
 # ---------------------------------------------------------------------------
 # Pool lifecycle: create -> warm -> register -> allocate-into -> query -> deregister
 # ---------------------------------------------------------------------------
 
 
-def get_gtp_symm_pool(group: dist.ProcessGroup) -> torch.cuda.MemPool:
+def _get_gtp_symm_pool(group: dist.ProcessGroup) -> torch.cuda.MemPool:
     """Return the per-group ``ncclMemAlloc``-backed MemPool, creating it once."""
     name = group.group_name
     pool = _pools.get(name)
@@ -73,11 +74,11 @@ def register_gtp_symm_pool(group: dist.ProcessGroup | None) -> torch.cuda.MemPoo
         return None
     if not is_torch_min_version("2.9.0a0"):
         raise RuntimeError(
-            "[GTP] --gtp-remat-nccl-ub/--egtp-remat-nccl-ub require PyTorch >= 2.9: older "
+            "[GTP] --gtp-remat-nccl-ub/--gtp-expert-remat-nccl-ub require PyTorch >= 2.9: older "
             "versions cannot create a symmetric memory pool (create_nccl_mem_pool silently "
             "falls back to a non-symmetric one, so the reduce-scatter would not be symmetric)."
         )
-    pool = get_gtp_symm_pool(group)
+    pool = _get_gtp_symm_pool(group)
     if group.group_name in _registered:
         return pool
     # NCCL creates communicators lazily on the first collective; run one tiny all-reduce
@@ -98,7 +99,7 @@ def register_gtp_symm_pool(group: dist.ProcessGroup | None) -> torch.cuda.MemPoo
 def gtp_symm_pool_ctx(group: dist.ProcessGroup) -> AbstractContextManager[None]:
     """Context manager: allocations inside it come from ``group``'s pool. Collective-free
     (capture-safe); register the pool first or allocations are not window-registered."""
-    return torch.cuda.use_mem_pool(get_gtp_symm_pool(group))
+    return torch.cuda.use_mem_pool(_get_gtp_symm_pool(group))
 
 
 def is_gtp_symm_pool_registered(group: dist.ProcessGroup | None) -> bool:
@@ -112,7 +113,7 @@ def is_gtp_symm_pool_registered(group: dist.ProcessGroup | None) -> bool:
 # ---------------------------------------------------------------------------
 
 
-class RegisteredLifoPool:
+class RegisteredLIFOPool:
     """A recycling cache of window-registered buffers, one free list per group.
 
     The wgrad reduce-scatter can only use symmetric collectives if its send buffer is
@@ -155,7 +156,7 @@ class RegisteredLifoPool:
         else:
             if torch.cuda.is_current_stream_capturing():
                 raise RuntimeError(
-                    "[GTP] RegisteredLifoPool exhausted during CUDA-graph capture "
+                    "[GTP] RegisteredLIFOPool exhausted during CUDA-graph capture "
                     f"(group={group.group_name}, numel={numel}, dtype={dtype}). The "
                     "eager warmup did not pre-populate enough RS send buffers for "
                     "the reduce-scatter overlap depth -- run more warmup iters, or "
@@ -185,7 +186,7 @@ class RegisteredLifoPool:
 
 # The process-wide send-buffer cache, used by generalized_tensor_parallelism. Lives here
 # so deregister_and_clear_gtp_symm_pools can drop its buffers at teardown.
-symmetric_wgrad_pool = RegisteredLifoPool()
+symmetric_wgrad_pool = RegisteredLIFOPool()
 
 
 def deregister_and_clear_gtp_symm_pools() -> None:

--- a/megatron/core/tensor_parallel/gtp_symmetric_memory.py
+++ b/megatron/core/tensor_parallel/gtp_symmetric_memory.py
@@ -129,6 +129,12 @@ class RegisteredLIFOPool:
     count. ``alloc`` returns a view tagged with ``_gtp_symm_group``; ``free`` ignores
     untagged tensors, which lets callers pass mixed buffer lists to both this pool and
     the plain scratch pool and have each take only its own.
+
+    Why LIFO: ordering cannot affect correctness (buffers enter the free list only
+    after their reduce-scatter has been waited on), but LIFO keeps the same buffer
+    reused for the same operation at steady state even if a key ever over-allocates,
+    whereas FIFO would rotate the assignment every iteration -- LIFO keeps memory
+    behavior deterministic and repeatable across iterations.
     """
 
     def __init__(self) -> None:
@@ -157,7 +163,9 @@ class RegisteredLIFOPool:
                     f"(group={group.group_name}, numel={numel}, dtype={dtype}). The "
                     "eager warmup did not pre-populate enough RS send buffers for "
                     "the reduce-scatter overlap depth -- run more warmup iters, or "
-                    "the RS concurrency changed between warmup and capture."
+                    "the RS concurrency changed between warmup and capture, or "
+                    "symmetric send buffers were stranded by backwards that never "
+                    "reduce-scattered."
                 )
             # Allocate from the group's registered pool when it has one; else plain memory.
             if is_gtp_symm_pool_registered(group):

--- a/megatron/core/tensor_parallel/gtp_symmetric_memory.py
+++ b/megatron/core/tensor_parallel/gtp_symmetric_memory.py
@@ -121,9 +121,9 @@ class RegisteredLIFOPool:
     reduce-scatters instead of one buffer per weight.
 
     CUDA graphs: the eager warmup iterations run the same reduce-scatter overlap as
-    the captured steps, so by capture time the free lists already hold enough buffers
-    and ``alloc`` only ever pops. Allocating a new buffer during capture would be
-    illegal, so that case raises a clear error instead.
+    the captured steps and are expected to pre-populate the free lists, so that during
+    capture ``alloc`` only ever pops. Allocating a new buffer during capture would be
+    illegal, so ``alloc`` raises if that expectation did not hold.
 
     Buffers are stored 1-D, so one free list serves every shape with the same element
     count. ``alloc`` returns a view tagged with ``_gtp_symm_group``; ``free`` ignores
@@ -140,12 +140,13 @@ class RegisteredLIFOPool:
     def __init__(self) -> None:
         # (numel, dtype, group_name) -> list of free 1-D buffers.
         self._free: dict[tuple, list] = defaultdict(list)
+        self._warned_unregistered: set = set()
 
     def alloc(
         self,
         shape: torch.Size | tuple[int, ...],
         dtype: torch.dtype,
-        device: torch.device,
+        device: torch.device | str,
         group: dist.ProcessGroup,
     ) -> torch.Tensor:
         """Return a buffer of ``shape`` from ``group``'s free list, allocating one if empty.
@@ -158,20 +159,35 @@ class RegisteredLIFOPool:
             flat = bucket.pop()
         else:
             if torch.cuda.is_current_stream_capturing():
+                mine = sum(len(v) for k, v in self._free.items() if k[2] == group.group_name)
+                others = sum(len(v) for k, v in self._free.items() if k[2] != group.group_name)
+                hint = (
+                    "this group's free lists are empty while other groups have "
+                    f"{others} free buffer(s) -- likely stranded send buffers from "
+                    "backwards that never reduce-scattered"
+                    if mine == 0 and others > 0
+                    else "likely the warmup depth or RS concurrency changed between "
+                    "warmup and capture -- run more warmup iters"
+                )
                 raise RuntimeError(
                     "[GTP] RegisteredLIFOPool exhausted during CUDA-graph capture "
-                    f"(group={group.group_name}, numel={numel}, dtype={dtype}). The "
-                    "eager warmup did not pre-populate enough RS send buffers for "
-                    "the reduce-scatter overlap depth -- run more warmup iters, or "
-                    "the RS concurrency changed between warmup and capture, or "
-                    "symmetric send buffers were stranded by backwards that never "
-                    "reduce-scattered."
+                    f"(group={group.group_name}, numel={numel}, dtype={dtype}): {hint}."
                 )
             # Allocate from the group's registered pool when it has one; else plain memory.
             if is_gtp_symm_pool_registered(group):
                 with gtp_symm_pool_ctx(group):
                     flat = torch.empty(numel, dtype=dtype, device=device)
             else:
+                # Unreachable in production (callers gate on registration); the buffer
+                # would be sent with regular kernels, so make a misconfiguration visible.
+                if group.group_name not in self._warned_unregistered:
+                    self._warned_unregistered.add(group.group_name)
+                    log_single_rank(
+                        logger,
+                        logging.WARNING,
+                        f"[GTP] RegisteredLIFOPool.alloc on unregistered group "
+                        f"{group.group_name}: buffer will not be window-registered.",
+                    )
                 flat = torch.empty(numel, dtype=dtype, device=device)
         out = flat.view(shape)
         out._gtp_symm_group = group  # marks the buffer as pool-owned; free() keys on this

--- a/megatron/core/tensor_parallel/layers.py
+++ b/megatron/core/tensor_parallel/layers.py
@@ -767,7 +767,12 @@ class LinearWithGradAccumulationAndAsyncCommunication(torch.autograd.Function):
             # across ranks before the fp32 accum sees the value.
             grad_weight = _wgrad_gemm(sharded_weight.get_wgrad_tensor(), grad_output, total_input)
         else:
-            grad_weight = grad_output.t().matmul(total_input)
+            if ctx.gtp_remat_size > 1 and sharded_weight.main_grad.dtype == grad_output.dtype:
+                # GTP: write the wgrad straight into the reduce-scatter send buffer.
+                grad_weight = sharded_weight.get_wgrad_tensor()
+                torch.matmul(grad_output.t(), total_input, out=grad_weight)
+            else:
+                grad_weight = grad_output.t().matmul(total_input)
         grad_bias = grad_output.sum(dim=0) if use_bias else None
 
         # GTP: reduce-scatter wgrad

--- a/megatron/core/tensor_parallel/layers.py
+++ b/megatron/core/tensor_parallel/layers.py
@@ -1089,7 +1089,7 @@ class ColumnParallelLinear(torch.nn.Module):
         if gtp_remat_group is not None and gtp_remat_group.size() > 1:
             from megatron.core.tensor_parallel.gtp_api import wrap_module_params_gtp
 
-            wrap_module_params_gtp(self, ["weight"], gtp_remat_group, is_expert=self.is_expert)
+            wrap_module_params_gtp(self, ["weight"], gtp_remat_group)
             self.gtp_remat_size = gtp_remat_group.size()
 
         if bias:
@@ -1453,7 +1453,7 @@ class RowParallelLinear(torch.nn.Module):
         if gtp_remat_group is not None and gtp_remat_group.size() > 1:
             from megatron.core.tensor_parallel.gtp_api import wrap_module_params_gtp
 
-            wrap_module_params_gtp(self, ["weight"], gtp_remat_group, is_expert=self.is_expert)
+            wrap_module_params_gtp(self, ["weight"], gtp_remat_group)
             self.gtp_remat_size = gtp_remat_group.size()
 
         if bias:

--- a/megatron/core/tensor_parallel/layers.py
+++ b/megatron/core/tensor_parallel/layers.py
@@ -1084,7 +1084,7 @@ class ColumnParallelLinear(torch.nn.Module):
         if gtp_remat_group is not None and gtp_remat_group.size() > 1:
             from megatron.core.tensor_parallel.gtp_api import wrap_module_params_gtp
 
-            wrap_module_params_gtp(self, ["weight"], gtp_remat_group)
+            wrap_module_params_gtp(self, ["weight"], gtp_remat_group, is_expert=self.is_expert)
             self.gtp_remat_size = gtp_remat_group.size()
 
         if bias:
@@ -1448,7 +1448,7 @@ class RowParallelLinear(torch.nn.Module):
         if gtp_remat_group is not None and gtp_remat_group.size() > 1:
             from megatron.core.tensor_parallel.gtp_api import wrap_module_params_gtp
 
-            wrap_module_params_gtp(self, ["weight"], gtp_remat_group)
+            wrap_module_params_gtp(self, ["weight"], gtp_remat_group, is_expert=self.is_expert)
             self.gtp_remat_size = gtp_remat_group.size()
 
         if bias:

--- a/megatron/core/tensor_parallel/layers.py
+++ b/megatron/core/tensor_parallel/layers.py
@@ -767,7 +767,7 @@ class LinearWithGradAccumulationAndAsyncCommunication(torch.autograd.Function):
             # across ranks before the fp32 accum sees the value.
             grad_weight = _wgrad_gemm(sharded_weight.get_wgrad_tensor(), grad_output, total_input)
         else:
-            if ctx.gtp_remat_size > 1 and sharded_weight.main_grad.dtype == grad_output.dtype:
+            if ctx.gtp_remat_size > 1 and sharded_weight.use_zero_copy_wgrad(grad_output.dtype):
                 # GTP: write the wgrad straight into the reduce-scatter send buffer.
                 grad_weight = sharded_weight.get_wgrad_tensor()
                 torch.matmul(grad_output.t(), total_input, out=grad_weight)

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1580,11 +1580,17 @@ def validate_args(args, defaults={}):
 
         # GTP symmetric memory registers pools with symmetric=True (NVLS needs symmetric
         # windows), which contradicts --disable-symmetric-registration.
-        if getattr(args, 'gtp_nccl_ub', False) or getattr(args, 'egtp_nccl_ub', False):
+        if getattr(args, 'gtp_remat_nccl_ub', False) or getattr(args, 'egtp_remat_nccl_ub', False):
             assert not getattr(args, 'disable_symmetric_registration', False), (
-                "--gtp-nccl-ub/--egtp-nccl-ub require symmetric window registration and "
+                "--gtp-remat-nccl-ub/--egtp-remat-nccl-ub require symmetric window registration and "
                 "cannot be combined with --disable-symmetric-registration."
             )
+            if getattr(args, 'gtp_remat_reduce_scatter_with_fp32_accumulation', False):
+                print_rank_0(
+                    "WARNING: --gtp-remat-nccl-ub/--egtp-remat-nccl-ub take precedence over "
+                    "--gtp-remat-reduce-scatter-with-fp32-accumulation on their groups: NCCL "
+                    "symmetric reduce-scatters provide equivalent numerics with better performance."
+                )
 
     # Disable bias gelu fusion if we are disabling bias altogether
     if not args.add_bias_linear:
@@ -3159,12 +3165,13 @@ def _add_distributed_args(parser):
                        'which is improving the performance of the overlapped computation.')
     group.add_argument('--disable-symmetric-registration', action='store_true', dest='disable_symmetric_registration',
                        default=False, help='Disable symmetric (window) registration for NCCL userbuffer registration.'
-                       'This option will force to use conventional (local) userbuffer registration when use-nccl-ub is set.')
-    group.add_argument('--gtp-nccl-ub', action='store_true', dest='gtp_nccl_ub',
+                       'This option will force to use conventional (local) userbuffer registration when use-nccl-ub is set. '
+                       'Cannot be combined with --gtp-remat-nccl-ub/--egtp-remat-nccl-ub, which require symmetric windows.')
+    group.add_argument('--gtp-remat-nccl-ub', action='store_true', dest='gtp_remat_nccl_ub',
                        default=False, help='Register the wgrad reduce-scatter send buffers with NCCL symmetric '
                        'memory on the GTP group, independent of --use-nccl-ub (which covers the DP group).')
-    group.add_argument('--egtp-nccl-ub', action='store_true', dest='egtp_nccl_ub',
-                       default=False, help='Like --gtp-nccl-ub but for routed-expert (EGTP) groups.')
+    group.add_argument('--egtp-remat-nccl-ub', action='store_true', dest='egtp_remat_nccl_ub',
+                       default=False, help='Like --gtp-remat-nccl-ub but for routed-expert (EGTP) groups.')
     group.add_argument('--fsdp-manual-registration', action='store_true', dest='fsdp_manual_registration',
                        default=False, help='Manually register the FSDP communication buffers to NCCL user buffer.'
                        'This option is only effective when use-megatron-fsdp and use-nccl-ub is set.')

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1588,8 +1588,9 @@ def validate_args(args, defaults={}):
             if getattr(args, 'gtp_remat_reduce_scatter_with_fp32_accumulation', False):
                 print_rank_0(
                     "WARNING: --gtp-remat-nccl-ub/--gtp-expert-remat-nccl-ub take precedence over "
-                    "--gtp-remat-reduce-scatter-with-fp32-accumulation on their groups: NCCL "
-                    "symmetric reduce-scatters provide equivalent numerics with better performance."
+                    "--gtp-remat-reduce-scatter-with-fp32-accumulation on their groups: NVLS "
+                    "symmetric reduce-scatters accumulate in fp32 in-switch "
+                    "(NCCL multimem.ld_reduce .acc::f32)."
                 )
 
     # Disable bias gelu fusion if we are disabling bias altogether

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1580,14 +1580,14 @@ def validate_args(args, defaults={}):
 
         # GTP symmetric memory registers pools with symmetric=True (NVLS needs symmetric
         # windows), which contradicts --disable-symmetric-registration.
-        if getattr(args, 'gtp_remat_nccl_ub', False) or getattr(args, 'egtp_remat_nccl_ub', False):
+        if getattr(args, 'gtp_remat_nccl_ub', False) or getattr(args, 'gtp_expert_remat_nccl_ub', False):
             assert not getattr(args, 'disable_symmetric_registration', False), (
-                "--gtp-remat-nccl-ub/--egtp-remat-nccl-ub require symmetric window registration and "
+                "--gtp-remat-nccl-ub/--gtp-expert-remat-nccl-ub require symmetric window registration and "
                 "cannot be combined with --disable-symmetric-registration."
             )
             if getattr(args, 'gtp_remat_reduce_scatter_with_fp32_accumulation', False):
                 print_rank_0(
-                    "WARNING: --gtp-remat-nccl-ub/--egtp-remat-nccl-ub take precedence over "
+                    "WARNING: --gtp-remat-nccl-ub/--gtp-expert-remat-nccl-ub take precedence over "
                     "--gtp-remat-reduce-scatter-with-fp32-accumulation on their groups: NCCL "
                     "symmetric reduce-scatters provide equivalent numerics with better performance."
                 )
@@ -3166,11 +3166,11 @@ def _add_distributed_args(parser):
     group.add_argument('--disable-symmetric-registration', action='store_true', dest='disable_symmetric_registration',
                        default=False, help='Disable symmetric (window) registration for NCCL userbuffer registration.'
                        'This option will force to use conventional (local) userbuffer registration when use-nccl-ub is set. '
-                       'Cannot be combined with --gtp-remat-nccl-ub/--egtp-remat-nccl-ub, which require symmetric windows.')
+                       'Cannot be combined with --gtp-remat-nccl-ub/--gtp-expert-remat-nccl-ub, which require symmetric windows.')
     group.add_argument('--gtp-remat-nccl-ub', action='store_true', dest='gtp_remat_nccl_ub',
                        default=False, help='Register the wgrad reduce-scatter send buffers with NCCL symmetric '
                        'memory on the GTP group, independent of --use-nccl-ub (which covers the DP group).')
-    group.add_argument('--egtp-remat-nccl-ub', action='store_true', dest='egtp_remat_nccl_ub',
+    group.add_argument('--gtp-expert-remat-nccl-ub', action='store_true', dest='gtp_expert_remat_nccl_ub',
                        default=False, help='Like --gtp-remat-nccl-ub but for routed-expert (EGTP) groups.')
     group.add_argument('--fsdp-manual-registration', action='store_true', dest='fsdp_manual_registration',
                        default=False, help='Manually register the FSDP communication buffers to NCCL user buffer.'

--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1578,6 +1578,14 @@ def validate_args(args, defaults={}):
                 "buffer via replace_raw_data is unsupported)."
             )
 
+        # GTP symmetric memory registers pools with symmetric=True (NVLS needs symmetric
+        # windows), which contradicts --disable-symmetric-registration.
+        if getattr(args, 'gtp_nccl_ub', False) or getattr(args, 'egtp_nccl_ub', False):
+            assert not getattr(args, 'disable_symmetric_registration', False), (
+                "--gtp-nccl-ub/--egtp-nccl-ub require symmetric window registration and "
+                "cannot be combined with --disable-symmetric-registration."
+            )
+
     # Disable bias gelu fusion if we are disabling bias altogether
     if not args.add_bias_linear:
         args.bias_gelu_fusion = False
@@ -3152,6 +3160,11 @@ def _add_distributed_args(parser):
     group.add_argument('--disable-symmetric-registration', action='store_true', dest='disable_symmetric_registration',
                        default=False, help='Disable symmetric (window) registration for NCCL userbuffer registration.'
                        'This option will force to use conventional (local) userbuffer registration when use-nccl-ub is set.')
+    group.add_argument('--gtp-nccl-ub', action='store_true', dest='gtp_nccl_ub',
+                       default=False, help='Register the wgrad reduce-scatter send buffers with NCCL symmetric '
+                       'memory on the GTP group, independent of --use-nccl-ub (which covers the DP group).')
+    group.add_argument('--egtp-nccl-ub', action='store_true', dest='egtp_nccl_ub',
+                       default=False, help='Like --gtp-nccl-ub but for routed-expert (EGTP) groups.')
     group.add_argument('--fsdp-manual-registration', action='store_true', dest='fsdp_manual_registration',
                        default=False, help='Manually register the FSDP communication buffers to NCCL user buffer.'
                        'This option is only effective when use-megatron-fsdp and use-nccl-ub is set.')

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -2137,7 +2137,7 @@ def pretrain(
     if args.perform_rl_step:
         rl_utils.rl_inference_interface_shutdown()
 
-    if getattr(args, 'gtp_nccl_ub', False) or getattr(args, 'egtp_nccl_ub', False):
+    if getattr(args, 'gtp_remat_nccl_ub', False) or getattr(args, 'egtp_remat_nccl_ub', False):
         from megatron.core.tensor_parallel.gtp_api import deregister_and_clear_gtp_symm_pools
 
         # Deregister the GTP symmetric-memory pools: windows left registered when the
@@ -2720,7 +2720,11 @@ def setup_model_and_optimizer(
     # alignment governs how dim-0 shards are built). Placed here (not in get_model) so it
     # also covers the config-container builder path, which does not call get_model.
     if is_gtp_remat_active(args):
-        from megatron.core.tensor_parallel.gtp_api import configure_gtp_remat_from_recipe
+        from megatron.core.process_groups_config import resolve_gtp_remat_group
+        from megatron.core.tensor_parallel.gtp_api import (
+            configure_gtp_remat_from_recipe,
+            register_gtp_symm_pool,
+        )
 
         configure_gtp_remat_from_recipe(
             fp4=getattr(args, 'fp4', None) is not None,
@@ -2730,10 +2734,14 @@ def setup_model_and_optimizer(
             reduce_scatter_with_fp32_accumulation=getattr(
                 args, 'gtp_remat_reduce_scatter_with_fp32_accumulation', False
             ),
-            gtp_nccl_ub=getattr(args, 'gtp_nccl_ub', False),
-            egtp_nccl_ub=getattr(args, 'egtp_nccl_ub', False),
-            pg_collection=pg_collection,
+            gtp_remat_nccl_ub=getattr(args, 'gtp_remat_nccl_ub', False),
+            egtp_remat_nccl_ub=getattr(args, 'egtp_remat_nccl_ub', False),
         )
+
+        if getattr(args, 'gtp_remat_nccl_ub', False):
+            register_gtp_symm_pool(resolve_gtp_remat_group(pg_collection, is_expert=False))
+        if getattr(args, 'egtp_remat_nccl_ub', False):
+            register_gtp_symm_pool(resolve_gtp_remat_group(pg_collection, is_expert=True))
 
     model = _build_model_wrapper(wrap_with_ddp)
     unwrapped_model = unwrap_model(model)
@@ -5045,7 +5053,7 @@ def train(
         # ncclCommDeregister on handles created by ncclCommWindowRegister,
         # causing "NCCL WARN Deregister: Could not find handle" and a crash.
         torch.distributed.barrier()
-        if getattr(args, 'gtp_nccl_ub', False) or getattr(args, 'egtp_nccl_ub', False):
+        if getattr(args, 'gtp_remat_nccl_ub', False) or getattr(args, 'egtp_remat_nccl_ub', False):
             from megatron.core.tensor_parallel.gtp_api import deregister_and_clear_gtp_symm_pools
 
             # Deregister the GTP symmetric-memory pools: windows left registered when the

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -2138,11 +2138,11 @@ def pretrain(
         rl_utils.rl_inference_interface_shutdown()
 
     if getattr(args, 'gtp_nccl_ub', False) or getattr(args, 'egtp_nccl_ub', False):
-        from megatron.core.tensor_parallel.gtp_api import deregister_gtp_symm_pools
+        from megatron.core.tensor_parallel.gtp_api import deregister_and_clear_gtp_symm_pools
 
         # Deregister the GTP symmetric-memory pools: windows left registered when the
         # process groups are destroyed make NCCL abort.
-        deregister_gtp_symm_pools()
+        deregister_and_clear_gtp_symm_pools()
 
     ft_integration.shutdown()
     one_logger_utils.finish()
@@ -5046,11 +5046,11 @@ def train(
         # causing "NCCL WARN Deregister: Could not find handle" and a crash.
         torch.distributed.barrier()
         if getattr(args, 'gtp_nccl_ub', False) or getattr(args, 'egtp_nccl_ub', False):
-            from megatron.core.tensor_parallel.gtp_api import deregister_gtp_symm_pools
+            from megatron.core.tensor_parallel.gtp_api import deregister_and_clear_gtp_symm_pools
 
             # Deregister the GTP symmetric-memory pools: windows left registered when the
             # process groups are destroyed make NCCL abort.
-            deregister_gtp_symm_pools()
+            deregister_and_clear_gtp_symm_pools()
 
         for model_module in model:
             if isinstance(model_module, DDP):

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -2734,8 +2734,6 @@ def setup_model_and_optimizer(
             reduce_scatter_with_fp32_accumulation=getattr(
                 args, 'gtp_remat_reduce_scatter_with_fp32_accumulation', False
             ),
-            gtp_remat_nccl_ub=getattr(args, 'gtp_remat_nccl_ub', False),
-            gtp_expert_remat_nccl_ub=getattr(args, 'gtp_expert_remat_nccl_ub', False),
         )
 
         if getattr(args, 'gtp_remat_nccl_ub', False):

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -2137,7 +2137,7 @@ def pretrain(
     if args.perform_rl_step:
         rl_utils.rl_inference_interface_shutdown()
 
-    if getattr(args, 'gtp_remat_nccl_ub', False) or getattr(args, 'egtp_remat_nccl_ub', False):
+    if getattr(args, 'gtp_remat_nccl_ub', False) or getattr(args, 'gtp_expert_remat_nccl_ub', False):
         from megatron.core.tensor_parallel.gtp_api import deregister_and_clear_gtp_symm_pools
 
         # Deregister the GTP symmetric-memory pools: windows left registered when the
@@ -2735,12 +2735,12 @@ def setup_model_and_optimizer(
                 args, 'gtp_remat_reduce_scatter_with_fp32_accumulation', False
             ),
             gtp_remat_nccl_ub=getattr(args, 'gtp_remat_nccl_ub', False),
-            egtp_remat_nccl_ub=getattr(args, 'egtp_remat_nccl_ub', False),
+            gtp_expert_remat_nccl_ub=getattr(args, 'gtp_expert_remat_nccl_ub', False),
         )
 
         if getattr(args, 'gtp_remat_nccl_ub', False):
             register_gtp_symm_pool(resolve_gtp_remat_group(pg_collection, is_expert=False))
-        if getattr(args, 'egtp_remat_nccl_ub', False):
+        if getattr(args, 'gtp_expert_remat_nccl_ub', False):
             register_gtp_symm_pool(resolve_gtp_remat_group(pg_collection, is_expert=True))
 
     model = _build_model_wrapper(wrap_with_ddp)
@@ -5053,7 +5053,7 @@ def train(
         # ncclCommDeregister on handles created by ncclCommWindowRegister,
         # causing "NCCL WARN Deregister: Could not find handle" and a crash.
         torch.distributed.barrier()
-        if getattr(args, 'gtp_remat_nccl_ub', False) or getattr(args, 'egtp_remat_nccl_ub', False):
+        if getattr(args, 'gtp_remat_nccl_ub', False) or getattr(args, 'gtp_expert_remat_nccl_ub', False):
             from megatron.core.tensor_parallel.gtp_api import deregister_and_clear_gtp_symm_pools
 
             # Deregister the GTP symmetric-memory pools: windows left registered when the

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -2137,6 +2137,13 @@ def pretrain(
     if args.perform_rl_step:
         rl_utils.rl_inference_interface_shutdown()
 
+    if getattr(args, 'gtp_nccl_ub', False) or getattr(args, 'egtp_nccl_ub', False):
+        from megatron.core.tensor_parallel.gtp_api import deregister_gtp_symm_pools
+
+        # Deregister the GTP symmetric-memory pools: windows left registered when the
+        # process groups are destroyed make NCCL abort.
+        deregister_gtp_symm_pools()
+
     ft_integration.shutdown()
     one_logger_utils.finish()
 
@@ -2723,6 +2730,9 @@ def setup_model_and_optimizer(
             reduce_scatter_with_fp32_accumulation=getattr(
                 args, 'gtp_remat_reduce_scatter_with_fp32_accumulation', False
             ),
+            gtp_nccl_ub=getattr(args, 'gtp_nccl_ub', False),
+            egtp_nccl_ub=getattr(args, 'egtp_nccl_ub', False),
+            pg_collection=pg_collection,
         )
 
     model = _build_model_wrapper(wrap_with_ddp)
@@ -5035,6 +5045,13 @@ def train(
         # ncclCommDeregister on handles created by ncclCommWindowRegister,
         # causing "NCCL WARN Deregister: Could not find handle" and a crash.
         torch.distributed.barrier()
+        if getattr(args, 'gtp_nccl_ub', False) or getattr(args, 'egtp_nccl_ub', False):
+            from megatron.core.tensor_parallel.gtp_api import deregister_gtp_symm_pools
+
+            # Deregister the GTP symmetric-memory pools: windows left registered when the
+            # process groups are destroyed make NCCL abort.
+            deregister_gtp_symm_pools()
+
         for model_module in model:
             if isinstance(model_module, DDP):
                 for buf in model_module.buffers + model_module.expert_parallel_buffers:

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
@@ -71,6 +71,7 @@ class _FakeGroup:
     def __init__(self, size=1, rank=0):
         self._size = size
         self._rank = rank
+        self.group_name = f"fake_group_{id(self)}"
 
     def size(self):
         return self._size
@@ -1449,7 +1450,6 @@ class TestGTPGraphWgradRing:
             weight.group = group
             weight.chain_id = GTPChain.GRAPHED.value
             weight.pad_length = 2
-            weight.gtp_smr = False
             weight.main_grad = torch.empty_like(weight)
         for previous, current in zip(weights, weights[1:]):
             previous.next_w = current
@@ -1502,7 +1502,6 @@ class TestGTPGraphWgradRing:
                 self.group = group
                 self.chain_id = GTPChain.GRAPHED.value
                 self.pad_length = 2
-                self.gtp_smr = False
                 self.expert_idx = 0
                 self.device = torch.device("cuda")
                 self.main_grad = torch.empty(3, 4, device=self.device)

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
@@ -1449,6 +1449,7 @@ class TestGTPGraphWgradRing:
             weight.group = group
             weight.chain_id = GTPChain.GRAPHED.value
             weight.pad_length = 2
+            weight.gtp_smr = False
             weight.main_grad = torch.empty_like(weight)
         for previous, current in zip(weights, weights[1:]):
             previous.next_w = current
@@ -1501,6 +1502,7 @@ class TestGTPGraphWgradRing:
                 self.group = group
                 self.chain_id = GTPChain.GRAPHED.value
                 self.pad_length = 2
+                self.gtp_smr = False
                 self.expert_idx = 0
                 self.device = torch.device("cuda")
                 self.main_grad = torch.empty(3, 4, device=self.device)

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
@@ -1484,9 +1484,11 @@ class TestGTPGraphWgradRing:
         assert logical_view.data_ptr() == slot_1.tensor.data_ptr()
 
         logical_view.fill_(7)
-        prepared = weights[1]._prepare_wgrad_reduce_scatter_inputs([logical_view])
+        send_bufs, release_bufs = weights[1]._prepare_wgrad_reduce_scatter_inputs([logical_view])
         assert capture_state.wgrad_ring_slots == [slot_1]
-        assert prepared[0] is slot_1.tensor
+        assert send_bufs[0] is slot_1.tensor
+        # The ring slot is sent but never released; the feeding wgrad is released instead.
+        assert release_bufs[0] is logical_view
         assert torch.count_nonzero(slot_1.tensor[4:]) == 0
 
         with pytest.raises(RuntimeError, match="increase GTP_CONFIG.graph_wgrad_ring_size"):
@@ -1540,9 +1542,11 @@ class TestGTPGraphWgradRing:
         gtp_module.initialize_graph_wgrad_rings()
 
         wgrad = torch.arange(16, dtype=torch.float32, device="cuda").reshape(4, 4)
-        rs_input = weights[1]._prepare_wgrad_reduce_scatter_inputs([wgrad])[0]
+        send_bufs, release_bufs = weights[1]._prepare_wgrad_reduce_scatter_inputs([wgrad])
+        rs_input = send_bufs[0]
 
         assert rs_input is weights[1]._gtp_graph_wgrad_ring_slot.tensor
+        assert release_bufs[0] is wgrad
         torch.testing.assert_close(rs_input[:4], wgrad)
         assert torch.count_nonzero(rs_input[4:]) == 0
 

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_symmetric_memory.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_symmetric_memory.py
@@ -43,7 +43,7 @@ import megatron.core.tensor_parallel.gtp_symmetric_memory as gtp_symm
 from megatron.core.tensor_parallel.generalized_tensor_parallelism import GTP_CONFIG, GTPShardedParam
 from megatron.core.tensor_parallel.gtp_symmetric_memory import (
     RegisteredLifoPool,
-    deregister_gtp_symm_pools,
+    deregister_and_clear_gtp_symm_pools,
     gtp_symm_pool_ctx,
     is_gtp_symm_pool_registered,
     register_gtp_symm_pool,
@@ -310,7 +310,7 @@ def _worker_wgrad_split(rank, world_size, port):
         GTP_CONFIG.reduce_scatter_with_fp32_accumulation = True
         t = wa.get_wgrad_tensor()
         assert wa._wgrad_symm_slot is not None
-        assert not gtp_module._use_fp32_accum_rs(group)
+        assert not gtp_module._use_fp32_accum_rs(wa)
         symmetric_wgrad_pool.free(wa._wgrad_symm_slot)
         wa._wgrad_symm_slot = None
     finally:
@@ -318,7 +318,7 @@ def _worker_wgrad_split(rank, world_size, port):
         gtp_symm.is_gtp_symm_pool_registered = saved_symm_pred
         GTP_CONFIG.reduce_scatter_with_fp32_accumulation = False
         # Drop the LIFO buffers and the (unregistered) pools created via gtp_symm_pool_ctx.
-        deregister_gtp_symm_pools()
+        deregister_and_clear_gtp_symm_pools()
 
 
 class TestWgradSendBufferSplit:
@@ -363,7 +363,7 @@ def _worker_symm_backward_numerics(rank, world_size, port):
     finally:
         gtp_module.is_gtp_symm_pool_registered = saved_pred
         gtp_symm.is_gtp_symm_pool_registered = saved_symm_pred
-        deregister_gtp_symm_pools()
+        deregister_and_clear_gtp_symm_pools()
 
     # Same inputs, same weights, same collective — the send buffer's provenance must
     # not change the reduced gradient.
@@ -407,7 +407,7 @@ def _worker_real_pool_registration(rank, world_size, port):
         torch.cuda.synchronize()
     finally:
         # Mandatory: leftover windows abort the ProcessGroupNCCL destructor at teardown.
-        deregister_gtp_symm_pools()
+        deregister_and_clear_gtp_symm_pools()
     assert not is_gtp_symm_pool_registered(group)
 
 

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_symmetric_memory.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_symmetric_memory.py
@@ -96,6 +96,13 @@ def _restore_gtp_config():
 # ---------------------------------------------------------------------------
 
 
+class TestRegisterVersionGuard:
+    def test_register_rejects_old_torch(self, monkeypatch):
+        monkeypatch.setattr(gtp_symm, "is_torch_min_version", lambda v: False)
+        with pytest.raises(RuntimeError, match="PyTorch >= 2.9"):
+            gtp_symm.register_gtp_symm_pool(_StubGroup(size=2))
+
+
 class TestRegisteredLifoPool:
     def test_alloc_returns_tagged_view(self):
         pool = RegisteredLifoPool()

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_symmetric_memory.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_symmetric_memory.py
@@ -5,8 +5,6 @@
 Test groups
 -----------
 - TestRegisteredLifoPool    - LIFO recycling, keying, tagging, capture guard (single process)
-- TestSymmFlagStamping      - gtp_smr from is_expert x config flags
-- TestConfigureRecipeSymm   - symm kwargs land in GTP_CONFIG, pools registered, fp32-accum warning
 - TestWgradSendBufferSplit  - get_wgrad_tensor / _prepare_wgrad_reduce_scatter_inputs routing:
                               symm scratch is a logical view of a registered padded LIFO
                               parent sent whole (zero-copy, padded or not) with ownership
@@ -75,8 +73,8 @@ class _StubGroup:
 
 
 _CONFIG_FIELDS = (
-    "gtp_nccl_ub",
-    "egtp_nccl_ub",
+    "gtp_remat_nccl_ub",
+    "egtp_remat_nccl_ub",
     "reduce_scatter_with_fp32_accumulation",
     "pad_for_alignment",
     "check_param_states",
@@ -154,58 +152,6 @@ class TestRegisteredLifoPool:
 
 
 # ---------------------------------------------------------------------------
-# gtp_smr stamping (single process)
-# ---------------------------------------------------------------------------
-
-
-class TestSymmFlagStamping:
-    @pytest.mark.parametrize(
-        "gtp_flag,egtp_flag,is_expert,expect",
-        [
-            (True, False, False, True),  # dense param, dense flag on
-            (True, False, True, False),  # expert param must NOT take the dense flag
-            (False, True, True, True),  # expert param, expert flag on
-            (False, True, False, False),  # dense param must NOT take the expert flag
-            (False, False, False, False),
-        ],
-    )
-    def test_stamping_follows_is_expert(self, gtp_flag, egtp_flag, is_expert, expect):
-        GTP_CONFIG.gtp_nccl_ub = gtp_flag
-        GTP_CONFIG.egtp_nccl_ub = egtp_flag
-        p = GTPShardedParam(torch.randn(4, 4, device="cuda", dtype=torch.bfloat16))
-        gtp_module._gtp_attach_attrs(p, _StubGroup(), is_expert=is_expert)
-        assert p.gtp_smr is expect
-
-
-# ---------------------------------------------------------------------------
-# configure_gtp_remat_from_recipe: symm kwargs + fp32-accum warning
-# ---------------------------------------------------------------------------
-
-
-class TestConfigureRecipeSymm:
-    def test_symm_kwargs_land_in_config_and_register(self, monkeypatch, caplog):
-        registered = []
-        monkeypatch.setattr(
-            gtp_module, "register_gtp_symm_pool", lambda group: registered.append(group)
-        )
-        with caplog.at_level(logging.WARNING, logger=gtp_module.logger.name):
-            gtp_module.configure_gtp_remat_from_recipe(
-                gtp_nccl_ub=True, egtp_nccl_ub=False, reduce_scatter_with_fp32_accumulation=True
-            )
-        assert GTP_CONFIG.gtp_nccl_ub is True
-        assert GTP_CONFIG.egtp_nccl_ub is False
-        assert len(registered) == 1  # dense group only
-        if not dist.is_initialized() or dist.get_rank() == 0:
-            assert any("take precedence" in r.message for r in caplog.records)
-
-    def test_no_warning_without_fp32_accum(self, monkeypatch, caplog):
-        monkeypatch.setattr(gtp_module, "register_gtp_symm_pool", lambda group: None)
-        with caplog.at_level(logging.WARNING, logger=gtp_module.logger.name):
-            gtp_module.configure_gtp_remat_from_recipe(gtp_nccl_ub=True, egtp_nccl_ub=True)
-        assert not any("take precedence" in r.message for r in caplog.records)
-
-
-# ---------------------------------------------------------------------------
 # get_wgrad_tensor / _prepare_wgrad_reduce_scatter_inputs routing (world 4)
 # ---------------------------------------------------------------------------
 
@@ -230,12 +176,6 @@ def _worker_wgrad_split(rank, world_size, port):
     gtp_module.is_gtp_symm_pool_registered = lambda g: g is group
     gtp_symm.is_gtp_symm_pool_registered = lambda g: g is group
     try:
-        # Not symm-stamped -> plain scratch even with the pool "registered".
-        t = wa.get_wgrad_tensor()
-        assert getattr(wa, "_wgrad_symm_slot", None) is None
-        wa.gtp_smr = True
-        wp.gtp_smr = True
-
         # Unpadded symm weight: the GEMM scratch is a view of a registered LIFO parent.
         assert group.group_name not in gtp_symm._pools
         t = wa.get_wgrad_tensor()
@@ -355,7 +295,6 @@ def _worker_symm_backward_numerics(rank, world_size, port):
             pred = (lambda g: g is group) if symm else saved_pred
             gtp_module.is_gtp_symm_pool_registered = pred
             gtp_symm.is_gtp_symm_pool_registered = pred if symm else saved_symm_pred
-            w.gtp_smr = symm
             x = inp.clone().requires_grad_(True)
             out = layer(x, is_first_microbatch=True)
             out.backward(gout)

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_symmetric_memory.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_symmetric_memory.py
@@ -73,8 +73,6 @@ class _StubGroup:
 
 
 _CONFIG_FIELDS = (
-    "gtp_remat_nccl_ub",
-    "gtp_expert_remat_nccl_ub",
     "reduce_scatter_with_fp32_accumulation",
     "pad_for_alignment",
     "check_param_states",
@@ -94,6 +92,29 @@ def _restore_gtp_config():
 # ---------------------------------------------------------------------------
 # RegisteredLIFOPool (single process)
 # ---------------------------------------------------------------------------
+
+
+class TestTeardownContract:
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA pool test")
+    def test_teardown_clears_own_state_but_not_foreign_allocations(self):
+        group = _StubGroup(name="teardown_contract_group")
+        # A buffer owned by another subsystem (ring-slot style), allocated in the pool.
+        with gtp_symm.gtp_symm_pool_ctx(group):
+            foreign = torch.full((8,), 7.0, device="cuda")
+        assert group.group_name in gtp_symm._pools
+        # A LIFO-owned buffer sitting in the free list.
+        buf = symmetric_wgrad_pool.alloc((4,), torch.bfloat16, "cuda", group)
+        symmetric_wgrad_pool.free(buf)
+        del buf
+
+        deregister_and_clear_gtp_symm_pools()
+
+        # Own state is gone: registries empty, free lists dropped.
+        assert not gtp_symm._pools and not gtp_symm._registered
+        assert not symmetric_wgrad_pool._free
+        # Foreign allocations survive teardown untouched.
+        torch.cuda.synchronize()
+        assert torch.equal(foreign, torch.full((8,), 7.0, device="cuda"))
 
 
 class TestRegisterVersionGuard:
@@ -161,6 +182,30 @@ class TestRegisteredLIFOPool:
 # ---------------------------------------------------------------------------
 # get_wgrad_tensor / _prepare_wgrad_reduce_scatter_inputs routing (world 4)
 # ---------------------------------------------------------------------------
+
+
+def _worker_sync_plain_recycle(rank, world_size, port):
+    torch.manual_seed(0)
+    dtype = torch.bfloat16
+    group = dist.new_group(list(range(world_size)))
+    layer = _make_gtp_linear(64, 128, group, dtype)
+    w = layer.weight
+    w.main_grad = torch.zeros(w.shape, dtype=dtype, device="cuda")
+
+    # Unregistered group: get_wgrad_tensor hands out plain pool scratch (the native
+    # zero-copy path with the ub flags off).
+    scratch = w.get_wgrad_tensor()
+    assert getattr(scratch, "_from_gtp_wgrad_pool", False)
+    ptr = scratch.data_ptr()
+    scratch.normal_()
+
+    # Chain head -> synchronous reduce-scatter; the release path must return the
+    # scratch to the plain pool (regression test for the sync-path dual release).
+    w.wgrad_reduce_scatter(scratch)
+    torch.cuda.synchronize()
+    again = gtp_module._wgrad_pool_get(tuple(w._unsharded_shape), dtype, "cuda")
+    assert again.data_ptr() == ptr, "sync RS did not recycle the plain wgrad scratch"
+    gtp_module._wgrad_pool_put(again)
 
 
 def _worker_wgrad_split(rank, world_size, port):
@@ -264,6 +309,12 @@ def _worker_wgrad_split(rank, world_size, port):
         GTP_CONFIG.reduce_scatter_with_fp32_accumulation = False
         # Drop the LIFO buffers and the (unregistered) pools created via gtp_symm_pool_ctx.
         deregister_and_clear_gtp_symm_pools()
+
+
+class TestSyncPlainScratchRecycle:
+    def test_sync_rs_returns_plain_scratch_to_pool(self):
+        _requires_multi_gpu(4)
+        _run_distributed(_worker_sync_plain_recycle, 4)
 
 
 class TestWgradSendBufferSplit:

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_symmetric_memory.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_symmetric_memory.py
@@ -1,0 +1,417 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""Unit tests for the GTP symmetric-memory (NVLS) path.
+
+Test groups
+-----------
+- TestRegisteredLifoPool    - LIFO recycling, keying, tagging, capture guard (single process)
+- TestSymmFlagStamping      - gtp_smr from is_expert x config flags
+- TestConfigureRecipeSymm   - symm kwargs land in GTP_CONFIG, pools registered, fp32-accum warning
+- TestWgradSendBufferSplit  - get_wgrad_tensor / _prepare_wgrad_reduce_scatter_inputs routing:
+                              symm scratch is a logical view of a registered padded LIFO
+                              parent sent whole (zero-copy, padded or not) with ownership
+                              transferred into the caller's RS-input list; the copy fallback
+                              covers foreign wgrads
+- TestSymmBackwardNumerics  - symm-flagged backward produces the same main_grad as plain GTP
+- TestRealPoolRegistration  - register_gtp_symm_pool + gtp_symm_pool_ctx + a
+                              collective on pool memory; skips where NCCL window
+                              registration is unsupported
+
+The buffer-routing tests monkeypatch ``is_gtp_symm_pool_registered`` in BOTH consuming
+namespaces
+(the gtp module's binding for routing decisions AND gtp_symmetric_memory's own for the LIFO's
+branch), so LIFO allocations genuinely flow through ``gtp_symm_pool_ctx`` into the group's
+ncclMemAlloc pool — just without the (collective, environment-dependent) window registration,
+which TestRealPoolRegistration covers for real.
+
+Multi-GPU tests skip when ``torch.distributed.get_world_size()`` != 4.
+"""
+
+import logging
+
+import pytest
+import torch
+import torch.distributed as dist
+
+from megatron.core.tensor_parallel.gtp_api import HAVE_GTP
+
+if not HAVE_GTP:
+    pytest.skip("GTP requires TransformerEngine >= 2.19", allow_module_level=True)
+
+import megatron.core.tensor_parallel.generalized_tensor_parallelism as gtp_module
+import megatron.core.tensor_parallel.gtp_symmetric_memory as gtp_symm
+from megatron.core.tensor_parallel.generalized_tensor_parallelism import GTP_CONFIG, GTPShardedParam
+from megatron.core.tensor_parallel.gtp_symmetric_memory import (
+    RegisteredLifoPool,
+    deregister_gtp_symm_pools,
+    gtp_symm_pool_ctx,
+    is_gtp_symm_pool_registered,
+    register_gtp_symm_pool,
+    symmetric_wgrad_pool,
+)
+from tests.unit_tests.generalized_tensor_parallel.gtp_test_utils import (
+    _make_gtp_linear,
+    _requires_multi_gpu,
+    _run_distributed,
+    _torchrun_dist_init,
+    reset_fp8_state,
+    reset_gtp_globals,
+)
+
+
+class _StubGroup:
+    """Minimal stand-in for a dist process group (never used for real comms)."""
+
+    def __init__(self, name="stub_gtp_symm_group", size=2, rank=0):
+        self.group_name = name
+        self._size = size
+        self._rank = rank
+
+    def size(self):
+        return self._size
+
+    def rank(self):
+        return self._rank
+
+
+_CONFIG_FIELDS = (
+    "gtp_nccl_ub",
+    "egtp_nccl_ub",
+    "reduce_scatter_with_fp32_accumulation",
+    "pad_for_alignment",
+    "check_param_states",
+    "calculate_per_token_loss",
+)
+
+
+@pytest.fixture(autouse=True)
+def _restore_gtp_config():
+    """Snapshot/restore the GTP_CONFIG fields these tests mutate."""
+    saved = {f: getattr(GTP_CONFIG, f) for f in _CONFIG_FIELDS}
+    yield
+    for f, v in saved.items():
+        setattr(GTP_CONFIG, f, v)
+
+
+# ---------------------------------------------------------------------------
+# RegisteredLifoPool (single process)
+# ---------------------------------------------------------------------------
+
+
+class TestRegisteredLifoPool:
+    def test_alloc_returns_tagged_view(self):
+        pool = RegisteredLifoPool()
+        group = _StubGroup()
+        buf = pool.alloc((8, 4), torch.bfloat16, "cuda", group)
+        assert tuple(buf.shape) == (8, 4)
+        assert buf.dtype == torch.bfloat16
+        assert getattr(buf, "_gtp_symm_group", None) is group
+
+    def test_free_then_alloc_recycles_lifo(self):
+        pool = RegisteredLifoPool()
+        group = _StubGroup()
+        a = pool.alloc((8, 4), torch.bfloat16, "cuda", group)
+        b = pool.alloc((8, 4), torch.bfloat16, "cuda", group)
+        a_ptr, b_ptr = a.data_ptr(), b.data_ptr()
+        assert a_ptr != b_ptr
+        pool.free(a)
+        pool.free(b)
+        # LIFO: last freed comes back first; storage identity is preserved.
+        assert pool.alloc((8, 4), torch.bfloat16, "cuda", group).data_ptr() == b_ptr
+        assert pool.alloc((8, 4), torch.bfloat16, "cuda", group).data_ptr() == a_ptr
+        # A 1-D key serves any shape with that numel.
+        pool.free(a)
+        c = pool.alloc((4, 8), torch.bfloat16, "cuda", group)
+        assert c.data_ptr() == a_ptr and tuple(c.shape) == (4, 8)
+
+    def test_keying_isolates_dtype_numel_group(self):
+        pool = RegisteredLifoPool()
+        g1, g2 = _StubGroup("g1"), _StubGroup("g2")
+        a = pool.alloc((8,), torch.bfloat16, "cuda", g1)
+        pool.free(a)
+        assert pool.alloc((8,), torch.float32, "cuda", g1).data_ptr() != a.data_ptr()
+        assert pool.alloc((16,), torch.bfloat16, "cuda", g1).data_ptr() != a.data_ptr()
+        assert pool.alloc((8,), torch.bfloat16, "cuda", g2).data_ptr() != a.data_ptr()
+        assert pool.alloc((8,), torch.bfloat16, "cuda", g1).data_ptr() == a.data_ptr()
+
+    def test_free_untagged_is_noop(self):
+        pool = RegisteredLifoPool()
+        pool.free(torch.empty(8, device="cuda"))
+        assert not pool._free  # nothing entered the free lists
+
+    def test_capture_guard_raises_on_empty_bucket(self, monkeypatch):
+        pool = RegisteredLifoPool()
+        group = _StubGroup()
+        warm = pool.alloc((8,), torch.bfloat16, "cuda", group)
+        pool.free(warm)
+        monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: True)
+        # Pop from the warmed bucket is capture-safe...
+        got = pool.alloc((8,), torch.bfloat16, "cuda", group)
+        assert got.data_ptr() == warm.data_ptr()
+        # ...but a fresh allocation during capture must fail loudly.
+        with pytest.raises(RuntimeError, match="during CUDA-graph capture"):
+            pool.alloc((8,), torch.bfloat16, "cuda", group)
+
+
+# ---------------------------------------------------------------------------
+# gtp_smr stamping (single process)
+# ---------------------------------------------------------------------------
+
+
+class TestSymmFlagStamping:
+    @pytest.mark.parametrize(
+        "gtp_flag,egtp_flag,is_expert,expect",
+        [
+            (True, False, False, True),  # dense param, dense flag on
+            (True, False, True, False),  # expert param must NOT take the dense flag
+            (False, True, True, True),  # expert param, expert flag on
+            (False, True, False, False),  # dense param must NOT take the expert flag
+            (False, False, False, False),
+        ],
+    )
+    def test_stamping_follows_is_expert(self, gtp_flag, egtp_flag, is_expert, expect):
+        GTP_CONFIG.gtp_nccl_ub = gtp_flag
+        GTP_CONFIG.egtp_nccl_ub = egtp_flag
+        p = GTPShardedParam(torch.randn(4, 4, device="cuda", dtype=torch.bfloat16))
+        gtp_module._gtp_attach_attrs(p, _StubGroup(), is_expert=is_expert)
+        assert p.gtp_smr is expect
+
+
+# ---------------------------------------------------------------------------
+# configure_gtp_remat_from_recipe: symm kwargs + fp32-accum warning
+# ---------------------------------------------------------------------------
+
+
+class TestConfigureRecipeSymm:
+    def test_symm_kwargs_land_in_config_and_register(self, monkeypatch, caplog):
+        registered = []
+        monkeypatch.setattr(
+            gtp_module, "register_gtp_symm_pool", lambda group: registered.append(group)
+        )
+        with caplog.at_level(logging.WARNING, logger=gtp_module.logger.name):
+            gtp_module.configure_gtp_remat_from_recipe(
+                gtp_nccl_ub=True, egtp_nccl_ub=False, reduce_scatter_with_fp32_accumulation=True
+            )
+        assert GTP_CONFIG.gtp_nccl_ub is True
+        assert GTP_CONFIG.egtp_nccl_ub is False
+        assert len(registered) == 1  # dense group only
+        if not dist.is_initialized() or dist.get_rank() == 0:
+            assert any("take precedence" in r.message for r in caplog.records)
+
+    def test_no_warning_without_fp32_accum(self, monkeypatch, caplog):
+        monkeypatch.setattr(gtp_module, "register_gtp_symm_pool", lambda group: None)
+        with caplog.at_level(logging.WARNING, logger=gtp_module.logger.name):
+            gtp_module.configure_gtp_remat_from_recipe(gtp_nccl_ub=True, egtp_nccl_ub=True)
+        assert not any("take precedence" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# get_wgrad_tensor / _prepare_wgrad_reduce_scatter_inputs routing (world 4)
+# ---------------------------------------------------------------------------
+
+
+def _worker_wgrad_split(rank, world_size, port):
+    torch.manual_seed(0)
+    dtype = torch.bfloat16
+    group = dist.new_group(list(range(world_size)))
+    # pad_for_alignment=16, world 4 -> alignment 64: out=128 -> pad 0; out=100 -> pad 28.
+    aligned = _make_gtp_linear(64, 128, group, dtype)
+    padded = _make_gtp_linear(64, 100, group, dtype)
+    wa, wp = aligned.weight, padded.weight
+    assert wa.pad_length == 0 and wp.pad_length > 0
+    for w in (wa, wp):
+        w.main_grad = torch.zeros(w.shape, dtype=dtype, device="cuda")
+
+    saved_pred = gtp_module.is_gtp_symm_pool_registered
+    saved_symm_pred = gtp_symm.is_gtp_symm_pool_registered
+    # Patch BOTH consuming namespaces: gtp_module's binding drives the routing decisions;
+    # gtp_symm's own drives RegisteredLifoPool.alloc's pool-vs-plain branch, so LIFO
+    # allocations genuinely land in the group's ncclMemAlloc pool.
+    gtp_module.is_gtp_symm_pool_registered = lambda g: g is group
+    gtp_symm.is_gtp_symm_pool_registered = lambda g: g is group
+    try:
+        # Not symm-stamped -> plain scratch even with the pool "registered".
+        t = wa.get_wgrad_tensor()
+        assert getattr(wa, "_wgrad_symm_slot", None) is None
+        wa.gtp_smr = True
+        wp.gtp_smr = True
+
+        # Unpadded symm weight: the GEMM scratch is a view of a registered LIFO parent.
+        assert group.group_name not in gtp_symm._pools
+        t = wa.get_wgrad_tensor()
+        parent = wa._wgrad_symm_slot
+        assert parent is not None
+        assert getattr(parent, "_gtp_symm_group", None) is group
+        assert t.data_ptr() == parent.data_ptr()
+        assert tuple(t.shape) == tuple(wa._unsharded_shape)
+        # Positive proof the allocation routed through gtp_symm_pool_ctx: the group's
+        # pool was created by this alloc.
+        assert group.group_name in gtp_symm._pools
+        # _prepare sends the parent whole, consuming the slot — zero-copy (alias hit) —
+        # and transfers ownership into the caller's wgrads list.
+        bufs = [t]
+        prepared = wa._prepare_wgrad_reduce_scatter_inputs(bufs)
+        assert prepared[0] is parent
+        assert bufs[0] is parent
+        assert wa._wgrad_symm_slot is None
+
+        # Release (the existing RS-input path) recycles it through the registered LIFO.
+        ptr = parent.data_ptr()
+        wa._wgrad_input_bufs = bufs
+        wa._release_comm_scratch()
+        assert wa._wgrad_input_bufs is None
+        t2 = symmetric_wgrad_pool.alloc(
+            tuple(wa._unsharded_shape_padded), dtype, parent.device, group
+        )
+        assert t2.data_ptr() == ptr
+        symmetric_wgrad_pool.free(t2)
+
+        # Padded symm weight: same mechanism — logical view of a padded parent whose
+        # tail was zeroed at alloc; sent whole with no copy.
+        g = wp.get_wgrad_tensor()
+        pparent = wp._wgrad_symm_slot
+        assert pparent is not None
+        assert g.data_ptr() == pparent.data_ptr()
+        assert tuple(g.shape) == tuple(wp._unsharded_shape)
+        assert tuple(pparent.shape) == tuple(wp._unsharded_shape_padded)
+        g.normal_()
+        n = wp._unsharded_shape[0]
+        assert torch.count_nonzero(pparent[n:]) == 0
+        pbufs = [g]
+        prepared = wp._prepare_wgrad_reduce_scatter_inputs(pbufs)
+        assert prepared[0] is pparent
+        assert pbufs[0] is pparent
+        assert torch.equal(pparent[:n], g)
+        assert torch.count_nonzero(pparent[n:]) == 0
+        symmetric_wgrad_pool.free(pparent)
+
+        # Foreign (untagged) wgrad with no recorded parent: the copy fallback covers it
+        # (e.g. fuse_wgrad_accumulation off, where get_wgrad_tensor is never asked).
+        assert wa._wgrad_symm_slot is None
+        f = torch.randn(tuple(wa._unsharded_shape), dtype=dtype, device="cuda")
+        fbufs = [f]
+        prepared = wa._prepare_wgrad_reduce_scatter_inputs(fbufs)
+        assert prepared[0] is not f
+        assert fbufs[0] is prepared[0]  # ownership transferred over the foreign tensor
+        assert getattr(prepared[0], "_gtp_symm_group", None) is group
+        assert torch.equal(prepared[0][: wa._unsharded_shape[0]], f)
+        symmetric_wgrad_pool.free(prepared[0])
+
+        # Calling get_wgrad_tensor again before _prepare consumed the slot is an
+        # invariant violation (recycled storage would alias two live views).
+        t = wa.get_wgrad_tensor()
+        with pytest.raises(RuntimeError, match="before the previous"):
+            wa.get_wgrad_tensor()
+        symmetric_wgrad_pool.free(wa._wgrad_symm_slot)
+        wa._wgrad_symm_slot = None
+
+        # A registered pool takes precedence over fp32-accum: the symm send still wins,
+        # and the fp32-accum all-to-all route is off for this group.
+        GTP_CONFIG.reduce_scatter_with_fp32_accumulation = True
+        t = wa.get_wgrad_tensor()
+        assert wa._wgrad_symm_slot is not None
+        assert not gtp_module._use_fp32_accum_rs(group)
+        symmetric_wgrad_pool.free(wa._wgrad_symm_slot)
+        wa._wgrad_symm_slot = None
+    finally:
+        gtp_module.is_gtp_symm_pool_registered = saved_pred
+        gtp_symm.is_gtp_symm_pool_registered = saved_symm_pred
+        GTP_CONFIG.reduce_scatter_with_fp32_accumulation = False
+        # Drop the LIFO buffers and the (unregistered) pools created via gtp_symm_pool_ctx.
+        deregister_gtp_symm_pools()
+
+
+class TestWgradSendBufferSplit:
+    def test_send_buffer_routing(self):
+        _requires_multi_gpu(4)
+        _run_distributed(_worker_wgrad_split, 4)
+
+
+# ---------------------------------------------------------------------------
+# Backward numerics: symm buffers must not change the reduced gradient (world 4)
+# ---------------------------------------------------------------------------
+
+
+def _worker_symm_backward_numerics(rank, world_size, port):
+    dtype = torch.bfloat16
+    group = dist.new_group(list(range(world_size)))
+    inp = torch.randn(16, 64, dtype=dtype, device="cuda")
+    gout = torch.randn(16, 128, dtype=dtype, device="cuda")
+    dist.broadcast(inp, src=0)
+    dist.broadcast(gout, src=0)
+
+    saved_pred = gtp_module.is_gtp_symm_pool_registered
+    saved_symm_pred = gtp_symm.is_gtp_symm_pool_registered
+    grads = {}
+    try:
+        for symm in (False, True):
+            # Fresh chain state per phase so both layers are standalone chain heads
+            # (sync RS) instead of linking into one chain with a dangling async RS.
+            gtp_module.reset_gtp_state()
+            torch.manual_seed(0)
+            layer = _make_gtp_linear(64, 128, group, dtype)
+            w = layer.weight
+            w.main_grad = torch.zeros(w.shape, dtype=dtype, device="cuda")
+            pred = (lambda g: g is group) if symm else saved_pred
+            gtp_module.is_gtp_symm_pool_registered = pred
+            gtp_symm.is_gtp_symm_pool_registered = pred if symm else saved_symm_pred
+            w.gtp_smr = symm
+            x = inp.clone().requires_grad_(True)
+            out = layer(x, is_first_microbatch=True)
+            out.backward(gout)
+            grads[symm] = w.main_grad.clone()
+    finally:
+        gtp_module.is_gtp_symm_pool_registered = saved_pred
+        gtp_symm.is_gtp_symm_pool_registered = saved_symm_pred
+        deregister_gtp_symm_pools()
+
+    # Same inputs, same weights, same collective — the send buffer's provenance must
+    # not change the reduced gradient.
+    torch.testing.assert_close(grads[True], grads[False], atol=0.0, rtol=0.0)
+
+
+class TestSymmBackwardNumerics:
+    def test_main_grad_matches_plain_gtp(self):
+        _requires_multi_gpu(4)
+        _run_distributed(_worker_symm_backward_numerics, 4)
+
+
+# ---------------------------------------------------------------------------
+# Real pool registration + collective on pool memory (world 4)
+# ---------------------------------------------------------------------------
+
+
+def _worker_real_pool_registration(rank, world_size, port):
+    group = dist.new_group(list(range(world_size)))
+    try:
+        register_gtp_symm_pool(group)
+    except Exception as e:  # NCCL window registration unsupported in this environment
+        pytest.skip(f"NCCL symmetric registration unavailable: {e}")
+    try:
+        assert is_gtp_symm_pool_registered(group)
+        # Idempotent re-register must not raise or re-issue the warmup.
+        register_gtp_symm_pool(group)
+        with gtp_symm_pool_ctx(group):
+            src = torch.full((4,), float(rank), device="cuda")
+            out = torch.empty(4 * world_size, device="cuda")
+        dist.all_gather_into_tensor(out, src, group=group)
+        expected = torch.repeat_interleave(
+            torch.arange(world_size, device="cuda", dtype=torch.float32), 4
+        )
+        assert torch.equal(out, expected)
+        # Pool tensors must be gone before the pools are deregistered and dropped
+        # (mirrors production teardown, which clears the LIFO first): a pool torn
+        # down with live allocations later frees blocks into a dead pool and a
+        # subsequent NCCL op hits deregistered memory (intermittent IMA).
+        del src, out
+        torch.cuda.synchronize()
+    finally:
+        # Mandatory: leftover windows abort the ProcessGroupNCCL destructor at teardown.
+        deregister_gtp_symm_pools()
+    assert not is_gtp_symm_pool_registered(group)
+
+
+class TestRealPoolRegistration:
+    def test_register_alloc_collective_deregister(self):
+        _requires_multi_gpu(4)
+        _run_distributed(_worker_real_pool_registration, 4)

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_symmetric_memory.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_symmetric_memory.py
@@ -4,7 +4,7 @@
 
 Test groups
 -----------
-- TestRegisteredLifoPool    - LIFO recycling, keying, tagging, capture guard (single process)
+- TestRegisteredLIFOPool    - LIFO recycling, keying, tagging, capture guard (single process)
 - TestWgradSendBufferSplit  - get_wgrad_tensor / _prepare_wgrad_reduce_scatter_inputs routing:
                               symm scratch is a logical view of a registered padded LIFO
                               parent sent whole (zero-copy, padded or not) with ownership
@@ -40,7 +40,7 @@ import megatron.core.tensor_parallel.generalized_tensor_parallelism as gtp_modul
 import megatron.core.tensor_parallel.gtp_symmetric_memory as gtp_symm
 from megatron.core.tensor_parallel.generalized_tensor_parallelism import GTP_CONFIG, GTPShardedParam
 from megatron.core.tensor_parallel.gtp_symmetric_memory import (
-    RegisteredLifoPool,
+    RegisteredLIFOPool,
     deregister_and_clear_gtp_symm_pools,
     gtp_symm_pool_ctx,
     is_gtp_symm_pool_registered,
@@ -74,7 +74,7 @@ class _StubGroup:
 
 _CONFIG_FIELDS = (
     "gtp_remat_nccl_ub",
-    "egtp_remat_nccl_ub",
+    "gtp_expert_remat_nccl_ub",
     "reduce_scatter_with_fp32_accumulation",
     "pad_for_alignment",
     "check_param_states",
@@ -92,7 +92,7 @@ def _restore_gtp_config():
 
 
 # ---------------------------------------------------------------------------
-# RegisteredLifoPool (single process)
+# RegisteredLIFOPool (single process)
 # ---------------------------------------------------------------------------
 
 
@@ -103,9 +103,9 @@ class TestRegisterVersionGuard:
             gtp_symm.register_gtp_symm_pool(_StubGroup(size=2))
 
 
-class TestRegisteredLifoPool:
+class TestRegisteredLIFOPool:
     def test_alloc_returns_tagged_view(self):
-        pool = RegisteredLifoPool()
+        pool = RegisteredLIFOPool()
         group = _StubGroup()
         buf = pool.alloc((8, 4), torch.bfloat16, "cuda", group)
         assert tuple(buf.shape) == (8, 4)
@@ -113,7 +113,7 @@ class TestRegisteredLifoPool:
         assert getattr(buf, "_gtp_symm_group", None) is group
 
     def test_free_then_alloc_recycles_lifo(self):
-        pool = RegisteredLifoPool()
+        pool = RegisteredLIFOPool()
         group = _StubGroup()
         a = pool.alloc((8, 4), torch.bfloat16, "cuda", group)
         b = pool.alloc((8, 4), torch.bfloat16, "cuda", group)
@@ -130,7 +130,7 @@ class TestRegisteredLifoPool:
         assert c.data_ptr() == a_ptr and tuple(c.shape) == (4, 8)
 
     def test_keying_isolates_dtype_numel_group(self):
-        pool = RegisteredLifoPool()
+        pool = RegisteredLIFOPool()
         g1, g2 = _StubGroup("g1"), _StubGroup("g2")
         a = pool.alloc((8,), torch.bfloat16, "cuda", g1)
         pool.free(a)
@@ -140,12 +140,12 @@ class TestRegisteredLifoPool:
         assert pool.alloc((8,), torch.bfloat16, "cuda", g1).data_ptr() == a.data_ptr()
 
     def test_free_untagged_is_noop(self):
-        pool = RegisteredLifoPool()
+        pool = RegisteredLIFOPool()
         pool.free(torch.empty(8, device="cuda"))
         assert not pool._free  # nothing entered the free lists
 
     def test_capture_guard_raises_on_empty_bucket(self, monkeypatch):
-        pool = RegisteredLifoPool()
+        pool = RegisteredLIFOPool()
         group = _StubGroup()
         warm = pool.alloc((8,), torch.bfloat16, "cuda", group)
         pool.free(warm)
@@ -178,7 +178,7 @@ def _worker_wgrad_split(rank, world_size, port):
     saved_pred = gtp_module.is_gtp_symm_pool_registered
     saved_symm_pred = gtp_symm.is_gtp_symm_pool_registered
     # Patch BOTH consuming namespaces: gtp_module's binding drives the routing decisions;
-    # gtp_symm's own drives RegisteredLifoPool.alloc's pool-vs-plain branch, so LIFO
+    # gtp_symm's own drives RegisteredLIFOPool.alloc's pool-vs-plain branch, so LIFO
     # allocations genuinely land in the group's ncclMemAlloc pool.
     gtp_module.is_gtp_symm_pool_registered = lambda g: g is group
     gtp_symm.is_gtp_symm_pool_registered = lambda g: g is group
@@ -252,12 +252,10 @@ def _worker_wgrad_split(rank, world_size, port):
         symmetric_wgrad_pool.free(wa._wgrad_symm_slot)
         wa._wgrad_symm_slot = None
 
-        # A registered pool takes precedence over fp32-accum: the symm send still wins,
-        # and the fp32-accum all-to-all route is off for this group.
+        # A registered pool takes precedence over fp32-accum: the symm send still wins.
         GTP_CONFIG.reduce_scatter_with_fp32_accumulation = True
         t = wa.get_wgrad_tensor()
         assert wa._wgrad_symm_slot is not None
-        assert not gtp_module._use_fp32_accum_rs(wa)
         symmetric_wgrad_pool.free(wa._wgrad_symm_slot)
         wa._wgrad_symm_slot = None
     finally:

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_symmetric_memory.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_symmetric_memory.py
@@ -199,6 +199,21 @@ def _worker_sync_plain_recycle(rank, world_size, port):
     ptr = scratch.data_ptr()
     scratch.normal_()
 
+    # Plain unpadded branch: sent as-is, released as itself.
+    send_bufs, release_bufs = w._prepare_wgrad_reduce_scatter_inputs([scratch])
+    assert send_bufs[0] is scratch and release_bufs[0] is scratch
+
+    # Plain padded branch: a padded copy is sent, the original is released.
+    padded_layer = _make_gtp_linear(64, 100, group, dtype)
+    wp = padded_layer.weight
+    wp.main_grad = torch.zeros(wp.shape, dtype=dtype, device="cuda")
+    p_scratch = wp.get_wgrad_tensor()
+    send_bufs, release_bufs = wp._prepare_wgrad_reduce_scatter_inputs([p_scratch])
+    assert send_bufs[0] is not p_scratch
+    assert tuple(send_bufs[0].shape) == tuple(wp._unsharded_shape_padded)
+    assert release_bufs[0] is p_scratch
+    gtp_module._wgrad_pool_put(p_scratch)
+
     # Chain head -> synchronous reduce-scatter; the release path must return the
     # scratch to the plain pool (regression test for the sync-path dual release).
     w.wgrad_reduce_scatter(scratch)
@@ -240,17 +255,18 @@ def _worker_wgrad_split(rank, world_size, port):
         # pool was created by this alloc.
         assert group.group_name in gtp_symm._pools
         # _prepare sends the parent whole, consuming the slot — zero-copy (alias hit) —
-        # and transfers ownership into the caller's wgrads list.
+        # and returns it in both lists (ownership transfer); the input list is untouched.
         bufs = [t]
-        prepared = wa._prepare_wgrad_reduce_scatter_inputs(bufs)
-        assert prepared[0] is parent
-        assert bufs[0] is parent
+        send_bufs, release_bufs = wa._prepare_wgrad_reduce_scatter_inputs(bufs)
+        assert send_bufs[0] is parent
+        assert release_bufs[0] is parent
+        assert bufs[0] is t
         assert wa._wgrad_symm_slot is None
 
-        # Release (the existing RS-input path) recycles it through the registered LIFO.
+        # Release (the RS-input path) recycles it through the registered LIFO.
         ptr = parent.data_ptr()
-        wa._wgrad_input_bufs = bufs
-        wa._release_comm_scratch()
+        wa._wgrad_input_bufs = release_bufs
+        wa._release_wgrad_scratch()
         assert wa._wgrad_input_bufs is None
         t2 = symmetric_wgrad_pool.alloc(
             tuple(wa._unsharded_shape_padded), dtype, parent.device, group
@@ -270,9 +286,10 @@ def _worker_wgrad_split(rank, world_size, port):
         n = wp._unsharded_shape[0]
         assert torch.count_nonzero(pparent[n:]) == 0
         pbufs = [g]
-        prepared = wp._prepare_wgrad_reduce_scatter_inputs(pbufs)
-        assert prepared[0] is pparent
-        assert pbufs[0] is pparent
+        send_bufs, release_bufs = wp._prepare_wgrad_reduce_scatter_inputs(pbufs)
+        assert send_bufs[0] is pparent
+        assert release_bufs[0] is pparent
+        assert pbufs[0] is g
         assert torch.equal(pparent[:n], g)
         assert torch.count_nonzero(pparent[n:]) == 0
         symmetric_wgrad_pool.free(pparent)
@@ -282,12 +299,13 @@ def _worker_wgrad_split(rank, world_size, port):
         assert wa._wgrad_symm_slot is None
         f = torch.randn(tuple(wa._unsharded_shape), dtype=dtype, device="cuda")
         fbufs = [f]
-        prepared = wa._prepare_wgrad_reduce_scatter_inputs(fbufs)
-        assert prepared[0] is not f
-        assert fbufs[0] is prepared[0]  # ownership transferred over the foreign tensor
-        assert getattr(prepared[0], "_gtp_symm_group", None) is group
-        assert torch.equal(prepared[0][: wa._unsharded_shape[0]], f)
-        symmetric_wgrad_pool.free(prepared[0])
+        send_bufs, release_bufs = wa._prepare_wgrad_reduce_scatter_inputs(fbufs)
+        assert send_bufs[0] is not f
+        assert release_bufs[0] is send_bufs[0]  # the allocated parent is what gets freed
+        assert fbufs[0] is f
+        assert getattr(send_bufs[0], "_gtp_symm_group", None) is group
+        assert torch.equal(send_bufs[0][: wa._unsharded_shape[0]], f)
+        symmetric_wgrad_pool.free(send_bufs[0])
 
         # Calling get_wgrad_tensor again before _prepare consumed the slot is an
         # invariant violation (recycled storage would alias two live views).


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
Adds symmetric memory registration support for the wgrad tensors in GTP to enable symmetric memory NCCL kernels. 

## Summary

Symmetric memory registration allows for the use of faster LSA/GIN based and CE based collectives in NCCL to improve communication performance for GTP. Specifically, for reduce scatter, NCCL uses an NVLS kernel within an NVLink domain and a RailA2A kernel across IB/Network. These kernels provide better numerical error compared to the legacy NCCL kernels and we want to enable them for the GTP/EGTP group as an alternative to a2a + local fp32 reduction.

For reduce-scatter, only the input needs to be backed by symmetric memory registration but output does not.

Based on these requirements, this MR enables symmetric memory backed tensors gated by two flags:
Flag | Scope
-- | --
--gtp-remat-nccl-ub | dense GTP remat group
--gtp-expert-remat-nccl-ub | routed-expert (EGTP) group
These are independent of independent of `--use-nccl-ub` and off by default.

Support for AG will be added in a separate MR. This MR is one-half of https://github.com/NVIDIA/Megatron-LM/pull/6155 (split for easier review).

## Design

One `ncclMemAlloc`-backed `torch.cuda.MemPool` per GTP process group, created and registered
once by `register_gtp_symm_pool(group)` (`gtp_symmetric_memory.py`). PyTorch's
ProcessGroupNCCL segment hook then auto-registers (`ncclCommWindowRegister` with
`NCCL_WIN_COLL_SYMMETRIC`) every later allocation made under `gtp_symm_pool_ctx(group)`, so
the context manager itself is collective-free and capture-safe. Only the send side of the
reduce-scatter needs a window; the output is the ordinary sharded `main_grad`.

Every buffer the wgrad reduce-scatter touches, where it comes from, and what puts it in the pool:

| Buffer | Where it comes from | What puts it in the pool |
|---|---|---|
| **RS send (ungraphed chains)** | `symmetric_wgrad_pool` (`RegisteredLIFOPool`), padded full shape; producers write into it directly — TE modules via the `grad_buffer()` protocol, Megatron-native linears via an `out=` matmul on the `get_wgrad_tensor()` view | `alloc()` under the pool context |
| **RS send (graphed chains)** | persistent graph wgrad ring slot, allocated pre-capture in `allocate_graph_wgrad_rings` | slot `torch.empty` under `gtp_symm_pool_ctx` |
| **RS recv** | the param's sharded `main_grad` | nothing — send-side-only registration suffices |
| **fp32-accum a2a scratch** | plain wgrad pool | nothing — a registered group takes precedence over `--gtp-remat-reduce-scatter-with-fp32-accumulation` and skips the all-to-all entirely (no scratch drawn, so enabling both costs no extra memory on registered groups) |

Pools are registered at `configure_gtp_remat_from_recipe` time (groups resolved via
`resolve_gtp_remat_group(pg_collection, ...)`) and torn down by `deregister_gtp_symm_pools()`
at the end of `pretrain()`: LIFO buffers dropped first, a synchronize to quiesce outstanding
work, then window deregistration.


## Testing 
All GTP UTs pass 

#### Convergence
<img width="1002" height="523" alt="Screenshot 2026-08-20 at 10 02 26 PM" src="https://github.com/user-attachments/assets/65789e50-d760-44e7-b51b-3588cfe0a596" />


## Issue tracking

For PRs from open-source community contributors:

- **New features**: a linked issue is **required**. Please open a [feature request](https://github.com/NVIDIA/Megatron-LM/issues/new?template=feature_request.md) and reference it here before submitting the PR.
- **Small updates (bug fixes, minor improvements)**: a linked issue is **recommended** and will accelerate the PR review process.

Linked issue: <!-- e.g. Fixes #1234 / Related to #1234 -->

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [x] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR