### PR TITLE
Guard optional FlashAttention 4 import

### DIFF
--- a/megatron/core/transformer/attention.py
+++ b/megatron/core/transformer/attention.py
@@ -87,19 +87,30 @@ if not HAVE_FA3:
 # `flash_attn.cute.__version__` (which is 0.0.0), so we cannot use
 # `is_fa_min_version` here.
 _MIN_FA4_VERSION = "4.0.0b20"
-try:
+
+
+def _try_import_flash_attention_4():
+    """Import FA4 only when its distribution is installed and compatible."""
     from importlib.metadata import PackageNotFoundError
     from importlib.metadata import version as _get_dist_version
 
-    from flash_attn.cute import flash_attn_varlen_func as flash_attn4_varlen_func
     from packaging.version import Version as _Version
 
     try:
-        HAVE_FA4 = _Version(_get_dist_version("flash-attn-4")) >= _Version(_MIN_FA4_VERSION)
+        if _Version(_get_dist_version("flash-attn-4")) < _Version(_MIN_FA4_VERSION):
+            return None
     except PackageNotFoundError:
-        HAVE_FA4 = False
-except ImportError:
-    HAVE_FA4 = False
+        return None
+
+    try:
+        from flash_attn.cute import flash_attn_varlen_func
+    except (AttributeError, ImportError):
+        return None
+    return flash_attn_varlen_func
+
+
+flash_attn4_varlen_func = _try_import_flash_attention_4()
+HAVE_FA4 = flash_attn4_varlen_func is not None
 
 try:
     from flash_mla import flash_mla_with_kvcache, get_mla_metadata

--- a/tests/unit_tests/transformer/test_attention.py
+++ b/tests/unit_tests/transformer/test_attention.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
 
 import copy
+from importlib.metadata import PackageNotFoundError
 from unittest import mock
 
 import pytest
@@ -20,7 +21,7 @@ from megatron.core.models.gpt.gpt_model import GPTModel
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer import TransformerConfig
-from megatron.core.transformer.attention import SelfAttention
+from megatron.core.transformer.attention import SelfAttention, _try_import_flash_attention_4
 from megatron.core.transformer.enums import AttnMaskType
 from megatron.core.utils import is_te_min_version, unwrap_model
 from megatron.training.arguments import parse_args
@@ -41,6 +42,32 @@ try:
     HAVE_FUSED_QKV_ROPE = True
 except ImportError:
     HAVE_FUSED_QKV_ROPE = False
+
+
+def test_flash_attention_4_distribution_is_checked_before_import():
+    real_import = __import__
+
+    def reject_cute_import(name, *args, **kwargs):
+        if name == "flash_attn.cute":
+            raise AssertionError("flash_attn.cute must not be imported without flash-attn-4")
+        return real_import(name, *args, **kwargs)
+
+    with mock.patch("importlib.metadata.version", side_effect=PackageNotFoundError):
+        with mock.patch("builtins.__import__", side_effect=reject_cute_import):
+            assert _try_import_flash_attention_4() is None
+
+
+def test_flash_attention_4_incompatible_cute_namespace_is_optional():
+    real_import = __import__
+
+    def reject_cute_import(name, *args, **kwargs):
+        if name == "flash_attn.cute":
+            raise AttributeError("incompatible CUTLASS DSL")
+        return real_import(name, *args, **kwargs)
+
+    with mock.patch("importlib.metadata.version", return_value="4.0.0b20"):
+        with mock.patch("builtins.__import__", side_effect=reject_cute_import):
+            assert _try_import_flash_attention_4() is None
 
 
 @pytest.mark.parametrize("output_gate", [False, True])


### PR DESCRIPTION
## What does this PR do?

- check the flash-attn-4 distribution and minimum version before importing the shared flash_attn.cute namespace
- treat an incompatible optional CuTe/CUTLASS namespace as unavailable instead of failing every Megatron import
- add unit coverage for both an absent flash-attn-4 distribution and an incompatible CUTLASS DSL API

## Reproduction

A current SkyRL Megatron image has flash_attn 2.8.3 and CUTLASS DSL 4.6.0 but does not install the flash-attn-4 distribution. Importing megatron.core.transformer.attention still eagerly imported flash_attn.cute and failed while evaluating its ThrMma annotation:

    AttributeError: module cutlass.cute.core has no attribute ThrMma

The guarded import now disables optional FA4 in that environment while leaving FA2/FA3 selection unchanged.

## Testing

- focused helper tests added to tests/unit_tests/transformer/test_attention.py
- container reproduction with flash_attn 2.8.3 and CUTLASS DSL 4.6.0 now imports Megatron successfully with HAVE_FA4=False
- uv run isort on both changed Python files
- git diff --check