### PR TITLE
Enable MXFP8 2D weight quantization

### DIFF
--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -88,6 +88,36 @@ _TE_CONFIG_TYPE_KEY = "transformer_engine_config_type"
 _EXPERT_PARAMETER_NAME_PATTERN = re.compile(r"(weight|bias)\d*")
 
 
+def get_mxfp8_block_scaling_recipe(*, mxfp8_2d_quantization: bool = False, **kwargs) -> Any:
+    """Create an MXFP8 recipe, optionally enabling 2D weight quantization.
+
+    Args:
+        mxfp8_2d_quantization: Whether to use 2D block scaling for forward-pass linear weights.
+        **kwargs: Additional arguments forwarded to Transformer Engine's MXFP8 recipe.
+
+    Returns:
+        A Transformer Engine MXFP8 block-scaling recipe.
+
+    Raises:
+        RuntimeError: If 2D quantization is requested with an older Transformer Engine build.
+    """
+    if mxfp8_2d_quantization:
+        parameters = inspect.signature(te.common.recipe.MXFP8BlockScaling).parameters.values()
+        supports_2d_quantization = any(
+            parameter.name == "enable_2d_quantization"
+            or parameter.kind == inspect.Parameter.VAR_KEYWORD
+            for parameter in parameters
+        )
+        if not supports_2d_quantization:
+            raise RuntimeError(
+                "MXFP8 2D quantization requires a Transformer Engine build whose "
+                "MXFP8BlockScaling recipe supports enable_2d_quantization."
+            )
+        kwargs["enable_2d_quantization"] = True
+
+    return te.common.recipe.MXFP8BlockScaling(**kwargs)
+
+
 def _set_expert_parameter_attributes(
     module: torch.nn.Module, parallel_mode: Optional[str], use_expert_pgs: bool
 ) -> None:
@@ -149,6 +179,8 @@ class TEQuantizationRecipe:
     """The path to a custom recipe factory if a custom Fp4 or Fp8 recipe is configured"""
     fp8_format: str = "e4m3"
     """A format to select from an FP8Recipe"""
+    mxfp8_2d_quantization: bool = False
+    """Whether to use 2D block scaling for forward-pass linear weights with MXFP8."""
     override_quantized_autocast: bool = True
     """
     If the quantization autocast context for a targeted module is enabled,
@@ -189,6 +221,8 @@ class TEQuantizationRecipe:
         instance = TEQuantizationRecipe(**kwargs)
         if instance.fp8_quantization_recipe == Fp8Recipe.delayed:
             raise ValueError("Delayed scaling not in scope of te per-module quantization config.")
+        if instance.mxfp8_2d_quantization and instance.fp8_quantization_recipe != Fp8Recipe.mxfp8:
+            raise ValueError("mxfp8_2d_quantization requires fp8_quantization_recipe='mxfp8'.")
         if (
             instance.fp8_quantization_recipe is not None
             and instance.fp4_quantization_recipe is not None
@@ -277,7 +311,9 @@ def _get_fp8_model_init_for_quant_recipe(qrecipe: TEQuantizationRecipe):
         elif qrecipe.fp8_quantization_recipe == Fp8Recipe.blockwise:
             quant_recipe = te.common.recipe.Float8BlockScaling(fp8_format=fp8_format)
         elif qrecipe.fp8_quantization_recipe == Fp8Recipe.mxfp8:
-            quant_recipe = te.common.recipe.MXFP8BlockScaling(fp8_format=fp8_format)
+            quant_recipe = get_mxfp8_block_scaling_recipe(
+                mxfp8_2d_quantization=qrecipe.mxfp8_2d_quantization, fp8_format=fp8_format
+            )
         else:
             raise ValueError(f"Unhandled fp8 recipe: {qrecipe.fp8_quantization_recipe}")
     else:
@@ -347,7 +383,9 @@ def _get_fp8_autocast_for_quant_recipe(qrecipe: TEQuantizationRecipe):
             elif qrecipe.fp8_quantization_recipe == Fp8Recipe.blockwise:
                 quant_recipe = te.common.recipe.Float8BlockScaling(fp8_format=fp8_format)
             elif qrecipe.fp8_quantization_recipe == Fp8Recipe.mxfp8:
-                quant_recipe = te.common.recipe.MXFP8BlockScaling(fp8_format=fp8_format)
+                quant_recipe = get_mxfp8_block_scaling_recipe(
+                    mxfp8_2d_quantization=qrecipe.mxfp8_2d_quantization, fp8_format=fp8_format
+                )
             else:
                 raise ValueError(f"Unhandled fp8 recipe: {qrecipe.fp8_quantization_recipe}")
         else:
@@ -3247,7 +3285,9 @@ if HAVE_TE and is_te_min_version("1.13.0"):
                 if os.getenv("FP4_RECIPE", "") == "nvfp4":
                     self._recipe = te.common.recipe.NVFP4BlockScaling()
                 else:
-                    self._recipe = te.common.recipe.MXFP8BlockScaling()
+                    self._recipe = get_mxfp8_block_scaling_recipe(
+                        mxfp8_2d_quantization=self.config.mxfp8_2d_quantization
+                    )
             recipe = self._recipe
 
             if self._fused_impl is None:

--- a/megatron/core/extensions/transformer_engine.py
+++ b/megatron/core/extensions/transformer_engine.py
@@ -102,13 +102,8 @@ def get_mxfp8_block_scaling_recipe(*, mxfp8_2d_quantization: bool = False, **kwa
         RuntimeError: If 2D quantization is requested with an older Transformer Engine build.
     """
     if mxfp8_2d_quantization:
-        parameters = inspect.signature(te.common.recipe.MXFP8BlockScaling).parameters.values()
-        supports_2d_quantization = any(
-            parameter.name == "enable_2d_quantization"
-            or parameter.kind == inspect.Parameter.VAR_KEYWORD
-            for parameter in parameters
-        )
-        if not supports_2d_quantization:
+        parameters = inspect.signature(te.common.recipe.MXFP8BlockScaling).parameters
+        if "enable_2d_quantization" not in parameters:
             raise RuntimeError(
                 "MXFP8 2D quantization requires a Transformer Engine build whose "
                 "MXFP8BlockScaling recipe supports enable_2d_quantization."

--- a/megatron/core/fp8_utils.py
+++ b/megatron/core/fp8_utils.py
@@ -749,7 +749,10 @@ def is_mxfp8_output_proj_active(config) -> bool:
 
 if HAVE_TE:
     from megatron.core import parallel_state
-    from megatron.core.extensions.transformer_engine import TEDelayedScaling
+    from megatron.core.extensions.transformer_engine import (
+        TEDelayedScaling,
+        get_mxfp8_block_scaling_recipe,
+    )
 
     def get_fp8_recipe(config: TransformerConfig):
         """Return fp8 recipe.
@@ -785,8 +788,10 @@ if HAVE_TE:
                     fp8_format=fp8_format
                 )
             elif config.fp8_recipe == Fp8Recipe.mxfp8:
-                fp8_recipe = transformer_engine.common.recipe.MXFP8BlockScaling(
-                    fp8_format=fp8_format, fp8_dpa=config.fp8_dot_product_attention
+                fp8_recipe = get_mxfp8_block_scaling_recipe(
+                    mxfp8_2d_quantization=config.mxfp8_2d_quantization,
+                    fp8_format=fp8_format,
+                    fp8_dpa=config.fp8_dot_product_attention,
                 )
             elif config.fp8_recipe == Fp8Recipe.custom:
                 assert config.fp8_quantizer_factory is not None

--- a/megatron/core/fp8_utils.py
+++ b/megatron/core/fp8_utils.py
@@ -347,11 +347,9 @@ def _get_custom_recipe(quantizer_factory_python_path: str) -> Union[Fp8Recipe, F
     try:
         custom_recipe = transformer_engine.common.recipe.CustomRecipe(qfactory=quantizer_factory)
     except AttributeError:
-        raise ValueError(
-            """CustomRecipe recipe is not available in this version of 
+        raise ValueError("""CustomRecipe recipe is not available in this version of 
             Transformer Engine. Please make sure you are using TE version 
-            >= 2.9.0.dev0."""
-        )
+            >= 2.9.0.dev0.""")
     return custom_recipe
 
 

--- a/megatron/core/transformer/moe/shared_experts.py
+++ b/megatron/core/transformer/moe/shared_experts.py
@@ -10,7 +10,7 @@ import torch
 import torch.nn.functional as F
 
 from megatron.core.dist_checkpointing.mapping import ShardedStateDict
-from megatron.core.extensions.transformer_engine import HAVE_TE
+from megatron.core.extensions.transformer_engine import HAVE_TE, get_mxfp8_block_scaling_recipe
 from megatron.core.fusions.fused_bias_geglu import bias_geglu_impl
 from megatron.core.fusions.fused_bias_gelu import bias_gelu_impl
 from megatron.core.fusions.fused_bias_swiglu import bias_swiglu_impl
@@ -34,11 +34,7 @@ from megatron.core.utils import (
 if HAVE_TE:
     import transformer_engine as te
 
-    from megatron.core.extensions.transformer_engine import (
-        TELinear,
-        get_mxfp8_block_scaling_recipe,
-        set_save_original_input,
-    )
+    from megatron.core.extensions.transformer_engine import TELinear, set_save_original_input
     from megatron.core.tensor_parallel.random import get_cuda_rng_tracker
 else:
     te = None

--- a/megatron/core/transformer/moe/shared_experts.py
+++ b/megatron/core/transformer/moe/shared_experts.py
@@ -34,7 +34,11 @@ from megatron.core.utils import (
 if HAVE_TE:
     import transformer_engine as te
 
-    from megatron.core.extensions.transformer_engine import TELinear, set_save_original_input
+    from megatron.core.extensions.transformer_engine import (
+        TELinear,
+        get_mxfp8_block_scaling_recipe,
+        set_save_original_input,
+    )
     from megatron.core.tensor_parallel.random import get_cuda_rng_tracker
 else:
     te = None
@@ -456,7 +460,9 @@ class FusedSharedExpertMLP(SharedExpertMLP):
             if self.config.fp4 and fp4_recipe == "nvfp4":
                 self._fused_grouped_swiglu_recipe = te.common.recipe.NVFP4BlockScaling()
             elif self.config.fp8 and fp8_recipe == "mxfp8":
-                self._fused_grouped_swiglu_recipe = te.common.recipe.MXFP8BlockScaling()
+                self._fused_grouped_swiglu_recipe = get_mxfp8_block_scaling_recipe(
+                    mxfp8_2d_quantization=self.config.mxfp8_2d_quantization
+                )
             else:
                 raise ValueError(
                     f"{self.__class__.__name__} requires fp4_recipe='nvfp4' or "

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -1483,6 +1483,10 @@ class TransformerConfig(ModelParallelConfig):
                     "mxfp8_2d_quantization requires fp8_recipe='mxfp8', "
                     f"got '{self.fp8_recipe}'."
                 )
+            if self.moe_single_grouped_weight:
+                raise ValueError(
+                    "mxfp8_2d_quantization does not support moe_single_grouped_weight."
+                )
 
         if self.fp8_output_proj:
             if not self.fp8:

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -585,6 +585,10 @@ class TransformerConfig(ModelParallelConfig):
     uses delayed scaling recipe, 3) 'mxfp8' for Blackwell architecture only,
     4) 'blockwise' for blockwise scaling recipe, 5) 'custom' for custom quantization recipe."""
 
+    mxfp8_2d_quantization: bool = False
+    """If True, use 2D block scaling for forward-pass linear and grouped-linear weights.
+    Requires fp8_recipe='mxfp8' and a Transformer Engine build with 2D MXFP8 support."""
+
     fp8_param: bool = False
     """If set, keep the parameters in fp8 precision to save memory. This option must be used
     together with fp8 mode (i.e., TransformerConfig.fp8 is not None). Note that not all parameters
@@ -1470,6 +1474,15 @@ class TransformerConfig(ModelParallelConfig):
 
         if self.fp8_param and not self.fp8:
             raise ValueError("fp8_param must be used together with fp8 mode.")
+
+        if self.mxfp8_2d_quantization:
+            if not self.fp8:
+                raise ValueError("mxfp8_2d_quantization must be used together with fp8 mode.")
+            if self.fp8_recipe != Fp8Recipe.mxfp8:
+                raise ValueError(
+                    "mxfp8_2d_quantization requires fp8_recipe='mxfp8', "
+                    f"got '{self.fp8_recipe}'."
+                )
 
         if self.fp8_output_proj:
             if not self.fp8:

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
@@ -813,9 +813,7 @@ def _worker_mxfp8_linear(rank, world_size, port, mxfp8_2d_quantization):
     batch, in_f, out_f = 32, 64, 128  # out_f % (16*world_size)==0 → no padding
     dtype = torch.bfloat16
     gtp_remat_group = dist.new_group(list(range(world_size)))
-    recipe = get_mxfp8_block_scaling_recipe(
-        mxfp8_2d_quantization=mxfp8_2d_quantization
-    )
+    recipe = get_mxfp8_block_scaling_recipe(mxfp8_2d_quantization=mxfp8_2d_quantization)
     layer = _make_native_fp8_gtp_linear(in_f, out_f, gtp_remat_group, dtype, recipe)
 
     # The weight IS the native FP8 shard: a QuantizedTensor with the GTP surface attached.
@@ -864,9 +862,7 @@ def _worker_mxfp8_linear_unaligned(rank, world_size, port, mxfp8_2d_quantization
     batch = 32
     dtype = torch.bfloat16
     gtp_remat_group = dist.new_group(list(range(world_size)))
-    recipe = get_mxfp8_block_scaling_recipe(
-        mxfp8_2d_quantization=mxfp8_2d_quantization
-    )
+    recipe = get_mxfp8_block_scaling_recipe(mxfp8_2d_quantization=mxfp8_2d_quantization)
     layer = _make_native_fp8_gtp_linear(in_f, out_f, gtp_remat_group, dtype, recipe)
     assert layer.weight.pad_length == 8, f"expected pad 8, got {layer.weight.pad_length}"
 

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_basics.py
@@ -46,6 +46,7 @@ from transformer_engine.pytorch.quantized_tensor import QuantizedTensor
 import megatron.core.tensor_parallel.generalized_tensor_parallelism as gtp_module
 import megatron.core.tensor_parallel.gtp_cuda_graphs as gtp_cuda_graphs
 from megatron.core import parallel_state
+from megatron.core.extensions.transformer_engine import get_mxfp8_block_scaling_recipe
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.generalized_tensor_parallelism import (
     GTPChain,
@@ -792,14 +793,19 @@ def _make_native_fp8_gtp_linear(in_f, out_f, gtp_remat_group, dtype, recipe):
     return layer
 
 
-def _worker_mxfp8_linear(rank, world_size, port):
+def _requires_mxfp8_2d():
+    try:
+        get_mxfp8_block_scaling_recipe(mxfp8_2d_quantization=True)
+    except (AttributeError, RuntimeError, TypeError, ValueError) as exc:
+        pytest.skip(f"MXFP8 2D quantization is not available: {exc}")
+
+
+def _worker_mxfp8_linear(rank, world_size, port, mxfp8_2d_quantization):
     """Verify GTP Linear with a native MXFP8 param: all-gather + GEMM + backward.
 
     mxfp8 always implies --fp8-param-gather: the weight is built as a native FP8 shard at
     construction (no BF16 source, no per-forward cast).
     """
-    from transformer_engine.common.recipe import MXFP8BlockScaling
-
     from megatron.core.tensor_parallel.generalized_tensor_parallelism import update_gtp_config
 
     torch.manual_seed(0)
@@ -807,7 +813,9 @@ def _worker_mxfp8_linear(rank, world_size, port):
     batch, in_f, out_f = 32, 64, 128  # out_f % (16*world_size)==0 → no padding
     dtype = torch.bfloat16
     gtp_remat_group = dist.new_group(list(range(world_size)))
-    recipe = MXFP8BlockScaling()
+    recipe = get_mxfp8_block_scaling_recipe(
+        mxfp8_2d_quantization=mxfp8_2d_quantization
+    )
     layer = _make_native_fp8_gtp_linear(in_f, out_f, gtp_remat_group, dtype, recipe)
 
     # The weight IS the native FP8 shard: a QuantizedTensor with the GTP surface attached.
@@ -838,7 +846,7 @@ def _worker_mxfp8_linear(rank, world_size, port):
     assert torch.isfinite(out2).all(), "MXFP8 GTP second-microbatch output has non-finite"
 
 
-def _worker_mxfp8_linear_unaligned(rank, world_size, port):
+def _worker_mxfp8_linear_unaligned(rank, world_size, port, mxfp8_2d_quantization):
     """Verify native-FP8 MXFP8 GTP when out_features needs padding.
 
     MXFP8 requires tensor dims divisible by 32, so shard_size (= M_padded / world_size)
@@ -847,8 +855,6 @@ def _worker_mxfp8_linear_unaligned(rank, world_size, port):
     holds 24 real rows zero-padded to 32. After all-gather, _strip_padding removes the
     padded rows before the GEMM, so the output has the original out_f columns.
     """
-    from transformer_engine.common.recipe import MXFP8BlockScaling
-
     from megatron.core.tensor_parallel.generalized_tensor_parallelism import update_gtp_config
 
     torch.manual_seed(0)
@@ -858,7 +864,9 @@ def _worker_mxfp8_linear_unaligned(rank, world_size, port):
     batch = 32
     dtype = torch.bfloat16
     gtp_remat_group = dist.new_group(list(range(world_size)))
-    recipe = MXFP8BlockScaling()
+    recipe = get_mxfp8_block_scaling_recipe(
+        mxfp8_2d_quantization=mxfp8_2d_quantization
+    )
     layer = _make_native_fp8_gtp_linear(in_f, out_f, gtp_remat_group, dtype, recipe)
     assert layer.weight.pad_length == 8, f"expected pad 8, got {layer.weight.pad_length}"
 
@@ -874,15 +882,21 @@ def _worker_mxfp8_linear_unaligned(rank, world_size, port):
 
 
 class TestMXFP8LinearGTP:
-    def test_forward_backward(self):
+    @pytest.mark.parametrize("mxfp8_2d_quantization", [False, True], ids=["1d", "2d"])
+    def test_forward_backward(self, mxfp8_2d_quantization):
         _requires_mxfp8()
+        if mxfp8_2d_quantization:
+            _requires_mxfp8_2d()
         _requires_multi_gpu(4)
-        _run_distributed(_worker_mxfp8_linear, 4)
+        _run_distributed(_worker_mxfp8_linear, 4, mxfp8_2d_quantization)
 
-    def test_forward_unaligned_padding(self):
+    @pytest.mark.parametrize("mxfp8_2d_quantization", [False, True], ids=["1d", "2d"])
+    def test_forward_unaligned_padding(self, mxfp8_2d_quantization):
         _requires_mxfp8()
+        if mxfp8_2d_quantization:
+            _requires_mxfp8_2d()
         _requires_multi_gpu(4)
-        _run_distributed(_worker_mxfp8_linear_unaligned, 4)
+        _run_distributed(_worker_mxfp8_linear_unaligned, 4, mxfp8_2d_quantization)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/models/test_hybrid_moe_model.py
+++ b/tests/unit_tests/models/test_hybrid_moe_model.py
@@ -130,6 +130,7 @@ GOLDEN_CONFIG: Dict[str, Any] = {
     "fp8_param": False,
     "fp8_quantizer_factory": None,
     "fp8_recipe": "delayed",
+    "mxfp8_2d_quantization": False,
     "fp8_wgrad": True,
     "fused_residual_rmsnorm": False,
     "fused_single_qkv_rope": False,

--- a/tests/unit_tests/test_argument_utils.py
+++ b/tests/unit_tests/test_argument_utils.py
@@ -654,6 +654,16 @@ class TestArgumentGroupFactoryArgparseMeta:
 class TestMegatronNetworkArgumentGeneration:
     """Test Megatron's TransformerConfig-derived argument group."""
 
+    def test_mxfp8_2d_quantization_flag_is_registered(self):
+        """The TransformerConfig field is exposed through the generated network arguments."""
+        from megatron.training.arguments import _add_network_size_args
+
+        parser = ArgumentParser()
+        _add_network_size_args(parser)
+
+        args = parser.parse_args(["--mxfp8-2d-quantization"])
+        assert args.mxfp8_2d_quantization is True
+
     def test_transformer_callback_fields_are_not_registered_as_cli_args(self):
         """Callback fields are runtime hooks, not CLI-provided values."""
         from megatron.training.arguments import _add_network_size_args

--- a/tests/unit_tests/test_fp8_utils.py
+++ b/tests/unit_tests/test_fp8_utils.py
@@ -58,6 +58,14 @@ class TestMXFP82DRecipe:
     def test_get_fp8_recipe_forwards_2d_quantization_option(self, mxfp8_2d_quantization):
         recipe = object()
         recipe_constructor = Mock(return_value=recipe)
+
+        def mxfp8_recipe(fp8_format, fp8_dpa=False, enable_2d_quantization=False):
+            return recipe_constructor(
+                fp8_format=fp8_format,
+                fp8_dpa=fp8_dpa,
+                enable_2d_quantization=enable_2d_quantization,
+            )
+
         config = Mock(
             fp8="e4m3",
             fp8_recipe=Fp8Recipe.mxfp8,
@@ -69,7 +77,7 @@ class TestMXFP82DRecipe:
             patch.object(fp8_utils, "is_te_min_version", return_value=True),
             patch(
                 "megatron.core.extensions.transformer_engine.te.common.recipe.MXFP8BlockScaling",
-                recipe_constructor,
+                mxfp8_recipe,
             ),
         ):
             assert fp8_utils.get_fp8_recipe(config) is recipe
@@ -77,9 +85,8 @@ class TestMXFP82DRecipe:
         expected_kwargs = {
             "fp8_format": fp8_utils.transformer_engine.common.recipe.Format.E4M3,
             "fp8_dpa": False,
+            "enable_2d_quantization": mxfp8_2d_quantization,
         }
-        if mxfp8_2d_quantization:
-            expected_kwargs["enable_2d_quantization"] = True
         recipe_constructor.assert_called_once_with(**expected_kwargs)
 
     def test_get_fp8_recipe_rejects_te_without_2d_quantization_support(self):
@@ -98,6 +105,27 @@ class TestMXFP82DRecipe:
             patch(
                 "megatron.core.extensions.transformer_engine.te.common.recipe.MXFP8BlockScaling",
                 old_mxfp8_recipe,
+            ),
+            pytest.raises(RuntimeError, match="enable_2d_quantization"),
+        ):
+            fp8_utils.get_fp8_recipe(config)
+
+    def test_get_fp8_recipe_rejects_kwargs_only_2d_quantization_support(self):
+        config = Mock(
+            fp8="e4m3",
+            fp8_recipe=Fp8Recipe.mxfp8,
+            fp8_dot_product_attention=False,
+            mxfp8_2d_quantization=True,
+        )
+
+        def kwargs_only_mxfp8_recipe(**kwargs):
+            return Mock(**kwargs)
+
+        with (
+            patch.object(fp8_utils, "is_te_min_version", return_value=True),
+            patch(
+                "megatron.core.extensions.transformer_engine.te.common.recipe.MXFP8BlockScaling",
+                kwargs_only_mxfp8_recipe,
             ),
             pytest.raises(RuntimeError, match="enable_2d_quantization"),
         ):

--- a/tests/unit_tests/test_fp8_utils.py
+++ b/tests/unit_tests/test_fp8_utils.py
@@ -7,6 +7,8 @@ import torch
 import torch.nn as nn
 
 from megatron.core import fp8_utils
+from megatron.core.enums import Fp8Recipe
+from megatron.core.extensions import transformer_engine as te_ext
 from megatron.training.utils import get_device_arch_version
 from tests.unit_tests.test_utilities import Utils
 
@@ -46,6 +48,86 @@ def test_get_fp8_disabled_context_uses_disabled_te_context(is_init, config_value
 
     assert result is disabled_context
     te_context.assert_called_once_with(enabled=False)
+
+
+@pytest.mark.skipif(not fp8_utils.HAVE_TE, reason="Transformer Engine is not available")
+class TestMXFP82DRecipe:
+    """Test MCore propagation of the MXFP8 2D quantization option."""
+
+    @pytest.mark.parametrize("mxfp8_2d_quantization", [False, True])
+    def test_get_fp8_recipe_forwards_2d_quantization_option(self, mxfp8_2d_quantization):
+        recipe = object()
+        recipe_constructor = Mock(return_value=recipe)
+        config = Mock(
+            fp8="e4m3",
+            fp8_recipe=Fp8Recipe.mxfp8,
+            fp8_dot_product_attention=False,
+            mxfp8_2d_quantization=mxfp8_2d_quantization,
+        )
+
+        with (
+            patch.object(fp8_utils, "is_te_min_version", return_value=True),
+            patch(
+                "megatron.core.extensions.transformer_engine.te.common.recipe.MXFP8BlockScaling",
+                recipe_constructor,
+            ),
+        ):
+            assert fp8_utils.get_fp8_recipe(config) is recipe
+
+        expected_kwargs = {
+            "fp8_format": fp8_utils.transformer_engine.common.recipe.Format.E4M3,
+            "fp8_dpa": False,
+        }
+        if mxfp8_2d_quantization:
+            expected_kwargs["enable_2d_quantization"] = True
+        recipe_constructor.assert_called_once_with(**expected_kwargs)
+
+    def test_get_fp8_recipe_rejects_te_without_2d_quantization_support(self):
+        config = Mock(
+            fp8="e4m3",
+            fp8_recipe=Fp8Recipe.mxfp8,
+            fp8_dot_product_attention=False,
+            mxfp8_2d_quantization=True,
+        )
+
+        def old_mxfp8_recipe(fp8_format, fp8_dpa=False):
+            return Mock(fp8_format=fp8_format, fp8_dpa=fp8_dpa)
+
+        with (
+            patch.object(fp8_utils, "is_te_min_version", return_value=True),
+            patch(
+                "megatron.core.extensions.transformer_engine.te.common.recipe.MXFP8BlockScaling",
+                old_mxfp8_recipe,
+            ),
+            pytest.raises(RuntimeError, match="enable_2d_quantization"),
+        ):
+            fp8_utils.get_fp8_recipe(config)
+
+    def test_per_module_recipe_forwards_2d_quantization_option(self):
+        recipe = object()
+        model_init_context = object()
+        quantization_recipe = te_ext.TEQuantizationRecipe(
+            fp8_quantization_recipe=Fp8Recipe.mxfp8, mxfp8_2d_quantization=True, fp8_param=True
+        )
+
+        with (
+            patch.object(te_ext, "get_mxfp8_block_scaling_recipe", return_value=recipe) as factory,
+            patch.object(te_ext, "fp8_model_init", return_value=model_init_context),
+        ):
+            assert (
+                te_ext._get_fp8_model_init_for_quant_recipe(quantization_recipe)
+                is model_init_context
+            )
+
+        factory.assert_called_once_with(
+            mxfp8_2d_quantization=True, fp8_format=te_ext.te.common.recipe.Format.E4M3
+        )
+
+    def test_per_module_recipe_rejects_2d_quantization_without_mxfp8(self):
+        with pytest.raises(ValueError, match="requires fp8_quantization_recipe='mxfp8'"):
+            te_ext.TEQuantizationRecipe.parse_from_config(
+                {"fp8_quantization_recipe": Fp8Recipe.tensorwise, "mxfp8_2d_quantization": True}
+            )
 
 
 class MockTELinear(nn.Module):

--- a/tests/unit_tests/transformer/moe/test_shared_experts.py
+++ b/tests/unit_tests/transformer/moe/test_shared_experts.py
@@ -123,6 +123,11 @@ def _patch_fake_shared_expert_te(monkeypatch, linear_cls=_FakeTELinear):
         "get_cuda_rng_tracker",
         lambda: SimpleNamespace(is_initialized=lambda: False),
     )
+    monkeypatch.setattr(
+        shared_experts_module,
+        "get_mxfp8_block_scaling_recipe",
+        lambda **_kwargs: fake_te.common.recipe.MXFP8BlockScaling(),
+    )
     return fake_te
 
 
@@ -141,6 +146,7 @@ def _fake_shared_expert(**config_kwargs):
         fp4_recipe="nvfp4",
         fp8=True,
         fp8_recipe="mxfp8",
+        mxfp8_2d_quantization=False,
     )
     for key, value in config_kwargs.items():
         setattr(config, key, value)
@@ -334,6 +340,21 @@ def test_fused_grouped_swiglu_no_comm_flattens_and_caches_fused_ops(monkeypatch)
     torch.testing.assert_close(scales, torch.ones(1))
     assert cached_tokens_per_expert is tokens_per_expert
     assert cached_scales is scales
+
+
+def test_fused_grouped_swiglu_recipe_forwards_2d_quantization(monkeypatch):
+    _patch_fake_shared_expert_te(monkeypatch)
+    shared_expert = _fake_shared_expert(mxfp8_2d_quantization=True)
+    calls = []
+    monkeypatch.setattr(
+        shared_experts_module,
+        "get_mxfp8_block_scaling_recipe",
+        lambda **kwargs: calls.append(kwargs) or _FakeMXFP8Recipe(),
+    )
+
+    shared_expert._get_fused_grouped_swiglu_recipe()
+
+    assert calls == [{"mxfp8_2d_quantization": True}]
 
 
 def test_backward_dw_dispatches_fused_children_and_original_reduce_hooks(monkeypatch):

--- a/tests/unit_tests/transformer/test_te_fused_mlp_with_grouped_linear_spec.py
+++ b/tests/unit_tests/transformer/test_te_fused_mlp_with_grouped_linear_spec.py
@@ -261,6 +261,11 @@ class TestTEFusedMLPWithGroupedLinearControlFlow:
             recipe_calls.append((name, kwargs))
             return recipe
 
+        def make_mxfp8_recipe(*, enable_2d_quantization=False):
+            return make_recipe(
+                "MXFP8BlockScaling", enable_2d_quantization=enable_2d_quantization
+            )
+
         monkeypatch.setattr(te_ext, "get_tensor_model_parallel_world_size", lambda: 1)
         monkeypatch.setattr(
             te_ext.te.common.recipe,
@@ -271,7 +276,7 @@ class TestTEFusedMLPWithGroupedLinearControlFlow:
         monkeypatch.setattr(
             te_ext.te.common.recipe,
             "MXFP8BlockScaling",
-            lambda **kwargs: make_recipe("MXFP8BlockScaling", **kwargs),
+            make_mxfp8_recipe,
             raising=False,
         )
         monkeypatch.setattr(

--- a/tests/unit_tests/transformer/test_te_fused_mlp_with_grouped_linear_spec.py
+++ b/tests/unit_tests/transformer/test_te_fused_mlp_with_grouped_linear_spec.py
@@ -262,9 +262,7 @@ class TestTEFusedMLPWithGroupedLinearControlFlow:
             return recipe
 
         def make_mxfp8_recipe(*, enable_2d_quantization=False):
-            return make_recipe(
-                "MXFP8BlockScaling", enable_2d_quantization=enable_2d_quantization
-            )
+            return make_recipe("MXFP8BlockScaling", enable_2d_quantization=enable_2d_quantization)
 
         monkeypatch.setattr(te_ext, "get_tensor_model_parallel_world_size", lambda: 1)
         monkeypatch.setattr(
@@ -274,10 +272,7 @@ class TestTEFusedMLPWithGroupedLinearControlFlow:
             raising=False,
         )
         monkeypatch.setattr(
-            te_ext.te.common.recipe,
-            "MXFP8BlockScaling",
-            make_mxfp8_recipe,
-            raising=False,
+            te_ext.te.common.recipe, "MXFP8BlockScaling", make_mxfp8_recipe, raising=False
         )
         monkeypatch.setattr(
             te_ext.te.pytorch,

--- a/tests/unit_tests/transformer/test_te_fused_mlp_with_grouped_linear_spec.py
+++ b/tests/unit_tests/transformer/test_te_fused_mlp_with_grouped_linear_spec.py
@@ -253,11 +253,12 @@ class TestTEFusedMLPWithGroupedLinearControlFlow:
         module = TEFusedMLPWithGroupedLinear.__new__(TEFusedMLPWithGroupedLinear)
         module._fused_impl = None
         module._norm_seq = (lambda hidden_states: hidden_states,)
+        module.config = SimpleNamespace(mxfp8_2d_quantization=True)
         module.linear_fc2 = SimpleNamespace(te_return_bias=True, bias=torch.empty(0))
         object.__setattr__(module, "_make_fused_impl", lambda: fused_impl)
 
-        def make_recipe(name):
-            recipe_calls.append(name)
+        def make_recipe(name, **kwargs):
+            recipe_calls.append((name, kwargs))
             return recipe
 
         monkeypatch.setattr(te_ext, "get_tensor_model_parallel_world_size", lambda: 1)
@@ -270,7 +271,7 @@ class TestTEFusedMLPWithGroupedLinearControlFlow:
         monkeypatch.setattr(
             te_ext.te.common.recipe,
             "MXFP8BlockScaling",
-            lambda: make_recipe("MXFP8BlockScaling"),
+            lambda **kwargs: make_recipe("MXFP8BlockScaling", **kwargs),
             raising=False,
         )
         monkeypatch.setattr(
@@ -292,7 +293,10 @@ class TestTEFusedMLPWithGroupedLinearControlFlow:
         assert out.shape == (2, 3, 4)
         assert bias is None
         assert module._recipe is recipe
-        assert recipe_calls == [recipe_name]
+        expected_kwargs = (
+            {"enable_2d_quantization": True} if recipe_name == "MXFP8BlockScaling" else {}
+        )
+        assert recipe_calls == [(recipe_name, expected_kwargs)]
 
     def test_dense_grouped_spec_selected_only_with_te_op_fuser(self):
         grouped_spec = gpt_layer_specs.get_mlp_module_spec_for_backend(

--- a/tests/unit_tests/transformer/test_transformer_config.py
+++ b/tests/unit_tests/transformer/test_transformer_config.py
@@ -73,11 +73,7 @@ def test_mxfp8_2d_quantization_accepts_mxfp8_recipe():
         ({"fp8_recipe": "mxfp8"}, "together with fp8 mode"),
         ({"fp8": "e4m3", "fp8_recipe": "delayed"}, "requires fp8_recipe='mxfp8'"),
         (
-            {
-                "fp8": "e4m3",
-                "fp8_recipe": "mxfp8",
-                "moe_single_grouped_weight": True,
-            },
+            {"fp8": "e4m3", "fp8_recipe": "mxfp8", "moe_single_grouped_weight": True},
             "does not support moe_single_grouped_weight",
         ),
     ],

--- a/tests/unit_tests/transformer/test_transformer_config.py
+++ b/tests/unit_tests/transformer/test_transformer_config.py
@@ -72,6 +72,14 @@ def test_mxfp8_2d_quantization_accepts_mxfp8_recipe():
     [
         ({"fp8_recipe": "mxfp8"}, "together with fp8 mode"),
         ({"fp8": "e4m3", "fp8_recipe": "delayed"}, "requires fp8_recipe='mxfp8'"),
+        (
+            {
+                "fp8": "e4m3",
+                "fp8_recipe": "mxfp8",
+                "moe_single_grouped_weight": True,
+            },
+            "does not support moe_single_grouped_weight",
+        ),
     ],
 )
 def test_mxfp8_2d_quantization_rejects_incompatible_fp8_config(config_kwargs, match):

--- a/tests/unit_tests/transformer/test_transformer_config.py
+++ b/tests/unit_tests/transformer/test_transformer_config.py
@@ -5,6 +5,10 @@ import pytest
 from megatron.core.transformer.transformer_config import TransformerConfig
 
 
+def _make_transformer_config(**kwargs) -> TransformerConfig:
+    return TransformerConfig(num_layers=1, hidden_size=128, num_attention_heads=4, **kwargs)
+
+
 def _make_overlap_config(mtp_num_layers: int | None) -> TransformerConfig:
     return TransformerConfig(
         num_layers=1,
@@ -55,3 +59,21 @@ def test_gdp_num_householder_rejects_non_positive_values(num_householder: int):
             num_attention_heads=4,
             gdp_num_householder=num_householder,
         )
+
+
+def test_mxfp8_2d_quantization_accepts_mxfp8_recipe():
+    config = _make_transformer_config(fp8="e4m3", fp8_recipe="mxfp8", mxfp8_2d_quantization=True)
+
+    assert config.mxfp8_2d_quantization
+
+
+@pytest.mark.parametrize(
+    ("config_kwargs", "match"),
+    [
+        ({"fp8_recipe": "mxfp8"}, "together with fp8 mode"),
+        ({"fp8": "e4m3", "fp8_recipe": "delayed"}, "requires fp8_recipe='mxfp8'"),
+    ],
+)
+def test_mxfp8_2d_quantization_rejects_incompatible_fp8_config(config_kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        _make_transformer_config(mxfp8_2d_quantization=True, **config_kwargs)


### PR DESCRIPTION
## What does this PR do?

Enable Transformer Engine's 2D MXFP8 weight quantization from Megatron Core while keeping 1D MXFP8 as the default.

- Add the `mxfp8_2d_quantization` transformer configuration and generated `--mxfp8-2d-quantization` CLI option.
- Forward the option to TE's `MXFP8BlockScaling(enable_2d_quantization=True)` recipe in global, per-module, fused grouped-MLP, and shared-expert paths.
- Reject incompatible recipes and report a clear error when the installed TE does not explicitly support the 2D option.
- Reject `mxfp8_2d_quantization` together with `moe_single_grouped_weight`, which is not covered by TE's 2D implementation.

## Why is this needed?

Transformer Engine added 2D MXFP8 weight quantization in NVIDIA/TransformerEngine#2634, but Megatron Core currently has no configuration path to select it.

The default is unchanged: without `--mxfp8-2d-quantization`, MXFP8 continues using 1D quantization.

## Validation

- Focused GB300 validation: 14 tests passed on four ranks, covering:
  - recipe and configuration propagation;
  - strict TE capability detection;
  - 1D and 2D native-MXFP8 GTP forward/backward;
  - aligned and unaligned GTP weight shapes.
- Full offline GTP unit-test suite: 126 tests passed on four GB300 GPUs, including existing native-MXFP8 parameter-gather and distributed-checkpoint coverage.
- Transformer Engine feature validation: 135 feature tests, 6 grouped-tensor tests, and 8 GroupedLinear cases passed on GB300.
- Two-node, 11-layer real-data proxy:
  - 1D and 2D native-MXFP8 + GTP + AdamW showed matching initial convergence, memory, and performance.
  - A 2D run saved at step 250 and resumed to step 500 consistently with the uninterrupted run. This checkpoint test used the separate GTP/GDP checkpoint fix from NVIDIA/Megatron-LM#6503.
- A 76-layer TP1 evaluation on 256 GB300 GPUs showed matching performance and memory between 1D and 2D MXFP8.

## Scope notes

- Requires a Transformer Engine build containing NVIDIA/TransformerEngine#2634.
- The separate GTP/GDP checkpoint-layout fix is provided by NVIDIA/Megatron-LM#6503 and is not part of this PR.

## Related issues

Fix #6363