### PR TITLE
Add THD support to CP causal convolution

### DIFF
--- a/megatron/core/ssm/causal_conv1d.py
+++ b/megatron/core/ssm/causal_conv1d.py
@@ -61,22 +61,19 @@ def assert_causal_conv1d_deterministic(deterministic_mode):
 
 
 def _exchange_initial_states(
-    x: torch.Tensor, state_len: int, cp_group: torch.distributed.ProcessGroup
+    x: torch.Tensor,
+    state_len: int,
+    cp_group: torch.distributed.ProcessGroup,
+    initial_state_mask: torch.Tensor | None = None,
 ) -> torch.Tensor | None:
     """Exchange the preceding rank's tail as the local convolution state.
 
     All ranks participate in a differentiable ring exchange. Rank 0 zeros the
-    wrapped tail to preserve the global causal boundary.
+    wrapped tail to preserve the global causal boundary. The optional mask
+    removes tail tokens outside the first local packed sequence.
     """
-    if state_len < 0:
-        raise ValueError(f"state_len must be non-negative, got {state_len}")
     if state_len == 0 or cp_group.size() == 1:
         return None
-    if x.shape[1] < state_len:
-        raise ValueError(
-            "Each local sequence shard must contain at least "
-            f"{state_len} tokens for causal convolution, got {x.shape[1]}"
-        )
 
     cp_size = cp_group.size()
     cp_rank = cp_group.rank()
@@ -93,6 +90,9 @@ def _exchange_initial_states(
         cp_group, tail, output_split_sizes_=output_splits, input_split_sizes=input_splits
     ).view(batch_size, state_len, channels)
 
+    if initial_state_mask is not None:
+        previous_tail = previous_tail.masked_fill(~initial_state_mask.unsqueeze(-1), 0)
+
     if cp_rank == 0:
         # Preserve the autograd path while enforcing the global left boundary.
         previous_tail = previous_tail.clone()
@@ -106,32 +106,71 @@ def causal_conv1d_cp(
     bias: torch.Tensor | None,
     activation: str | None,
     cp_group: torch.distributed.ProcessGroup,
+    global_seq_idx: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Apply causal Conv1d to a contiguous context-parallel shard.
 
     Args:
-        x: Input tensor of shape ``[B, T, D]``.
+        x: Input tensor of shape ``[B, T, D]``. THD callers flatten packed tokens
+            along ``T`` and use ``B=1``.
         weight: Depthwise weights of shape ``[D, W]``.
         bias: Optional channel-wise bias.
         activation: Optional activation passed to ``causal_conv1d_fn``.
         cp_group: Context-parallel process group ordered by sequence shard.
+        global_seq_idx: Global per-token sequence IDs for packed THD input, replicated
+            across CP ranks. IDs must be non-negative. Pass ``None`` for non-packed
+            input. The convolution state resets at each sequence boundary.
 
     Returns:
         Output tensor of shape ``[B, T, D]``.
 
     Raises:
         ImportError: If the optional ``causal-conv1d`` dependency is unavailable.
+        ValueError: If ``global_seq_idx`` has an invalid shape, dtype, or device.
     """
     if causal_conv1d_fn is None:
         raise ImportError("causal_conv1d_cp requires the optional causal-conv1d dependency")
+    state_len = weight.shape[-1] - 1
+    if state_len < 0:
+        raise ValueError(f"state_len must be non-negative, got {state_len}")
+    if state_len > 0 and cp_group.size() > 1 and x.shape[1] < state_len:
+        raise ValueError(
+            "Each local sequence shard must contain at least "
+            f"{state_len} tokens for causal convolution, got {x.shape[1]}"
+        )
+
+    local_seq_idx = None
+    initial_state_mask = None
+    if global_seq_idx is not None:
+        if x.shape[0] != 1:
+            raise ValueError(f"THD input must have batch size 1, got {x.shape[0]}")
+        expected_shape = (x.shape[0], cp_group.size() * x.shape[1])
+        if global_seq_idx.shape != expected_shape:
+            actual_shape = global_seq_idx.shape
+            raise ValueError(f"global_seq_idx shape must be {expected_shape}, got {actual_shape}")
+        if global_seq_idx.dtype != torch.int32:
+            raise ValueError(
+                f"global_seq_idx must have dtype torch.int32, got {global_seq_idx.dtype}"
+            )
+        if global_seq_idx.device != x.device:
+            raise ValueError(
+                f"global_seq_idx must be on device {x.device}, got {global_seq_idx.device}"
+            )
+        cp_rank = cp_group.rank()
+        shard_start = cp_rank * x.shape[1]
+        local_seq_idx = global_seq_idx[:, shard_start : shard_start + x.shape[1]]
+        if cp_rank > 0 and state_len > 0:
+            previous_seq_idx = global_seq_idx[:, shard_start - state_len : shard_start]
+            initial_state_mask = previous_seq_idx == local_seq_idx[:, :1]
 
     initial_states = _exchange_initial_states(
-        x=x, state_len=weight.shape[-1] - 1, cp_group=cp_group
+        x=x, state_len=state_len, cp_group=cp_group, initial_state_mask=initial_state_mask
     )
     output = causal_conv1d_fn(
         x=x.transpose(1, 2),
         weight=weight,
         bias=bias,
+        seq_idx=local_seq_idx,
         initial_states=initial_states,
         activation=activation,
     )

--- a/tests/unit_tests/ssm/test_causal_conv1d.py
+++ b/tests/unit_tests/ssm/test_causal_conv1d.py
@@ -6,6 +6,7 @@ import torch.distributed as dist
 
 from megatron.core import parallel_state
 from megatron.core.ssm import causal_conv1d as causal_conv1d_module
+from megatron.core.utils import is_causal_conv1d_min_version
 from tests.unit_tests.test_utilities import Utils
 
 try:
@@ -25,7 +26,14 @@ def _contiguous_slice(tensor, cp_rank, local_seq_len):
     not HAVE_CAUSAL_CONV1D or not torch.cuda.is_available() or Utils.world_size < 2,
     reason="CP causal convolution parity requires causal-conv1d and at least two GPUs",
 )
-def test_causal_conv1d_cp_matches_full_sequence():
+@pytest.mark.parametrize(
+    ("batch_size", "packed_sequence_len"),
+    [(1, None), (2, None), (1, 64), (1, 63)],
+    ids=["bshd-b1", "bshd-b2", "thd-cp-boundary", "thd-cp-partial"],
+)
+def test_causal_conv1d_cp_matches_full_sequence(batch_size, packed_sequence_len):
+    if packed_sequence_len is not None and not is_causal_conv1d_min_version("1.7.0"):
+        pytest.skip("THD CP causal convolution requires causal-conv1d >= 1.7.0")
     Utils.initialize_model_parallel(context_parallel_size=Utils.world_size)
     try:
         cp_group = parallel_state.get_context_parallel_group()
@@ -40,16 +48,25 @@ def test_causal_conv1d_cp_matches_full_sequence():
         torch.manual_seed(1234)
 
         channels, width = 16, 4
-        x_global = torch.randn(1, global_seq_len, channels, device=device, dtype=dtype)
+        x_global = torch.randn(batch_size, global_seq_len, channels, device=device, dtype=dtype)
         weight_global = torch.randn(channels, width, device=device, dtype=dtype)
         bias_global = torch.randn(channels, device=device, dtype=dtype)
         dy_global = torch.randn_like(x_global)
-
+        global_seq_idx = (
+            torch.arange(global_seq_len, device=device, dtype=torch.int32).unsqueeze(0)
+            // packed_sequence_len
+            if packed_sequence_len is not None
+            else None
+        )
         x_ref = x_global.detach().clone().requires_grad_(True)
         weight_ref = weight_global.detach().clone().requires_grad_(True)
         bias_ref = bias_global.detach().clone().requires_grad_(True)
         output_ref = causal_conv1d_fn(
-            x=x_ref.transpose(1, 2), weight=weight_ref, bias=bias_ref, activation="silu"
+            x=x_ref.transpose(1, 2),
+            weight=weight_ref,
+            bias=bias_ref,
+            seq_idx=global_seq_idx,
+            activation="silu",
         ).transpose(1, 2)
         output_ref.backward(dy_global)
 
@@ -57,7 +74,12 @@ def test_causal_conv1d_cp_matches_full_sequence():
         weight_local = weight_global.detach().clone().requires_grad_(True)
         bias_local = bias_global.detach().clone().requires_grad_(True)
         output_local = causal_conv1d_module.causal_conv1d_cp(
-            x=x_local, weight=weight_local, bias=bias_local, activation="silu", cp_group=cp_group
+            x=x_local,
+            weight=weight_local,
+            bias=bias_local,
+            activation="silu",
+            cp_group=cp_group,
+            global_seq_idx=global_seq_idx,
         )
         output_local.backward(_contiguous_slice(dy_global, cp_rank, local_seq_len))
         dist.all_reduce(weight_local.grad, group=cp_group)


### PR DESCRIPTION
## Summary
- Add THD support to CP-aware causal convolution.

## Testing
```
uv run python -m torch.distributed.run --nproc-per-node 8 -m pytest -q \
    tests/unit_tests/ssm/test_causal_conv1d.py
```