### PR TITLE
Add opt-in MFSDP unified communication stream

### DIFF
--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py
@@ -32,7 +32,10 @@ _FSDP_CONTEXT = ContextVar[FsdpContext | None]("mfsdp_context", default=None)
 
 @contextmanager
 def fully_shard_context(
-    device: torch.device | None = None, *, use_symmetric_memory: bool = False
+    device: torch.device | None = None,
+    *,
+    use_symmetric_memory: bool = False,
+    unify_communication_stream: bool = False,
 ) -> Iterator[FsdpContext]:
     """Construct FSDP modules that share runtime streams and prefetch orders.
 
@@ -44,6 +47,9 @@ def fully_shard_context(
             the current CUDA device.
         use_symmetric_memory: Allocate communication staging buffers from PyTorch's
             NCCL symmetric-memory pool.
+        unify_communication_stream: Whether all-gathers and reduce-scatters share one
+            communication stream to reduce peak transient memory. See
+            https://github.com/NVIDIA/Megatron-LM/issues/6471.
     """
     if _FSDP_CONTEXT.get() is not None:
         raise RuntimeError("fully_shard_context does not support nesting.")
@@ -52,7 +58,11 @@ def fully_shard_context(
     if device.type != "cuda":
         raise ValueError(f"fully_shard_context requires a CUDA device, got {device}.")
 
-    context = FsdpContext(device=device, use_symmetric_memory=use_symmetric_memory)
+    context = FsdpContext(
+        device=device,
+        use_symmetric_memory=use_symmetric_memory,
+        unify_communication_stream=unify_communication_stream,
+    )
     token = _FSDP_CONTEXT.set(context)
     try:
         yield context

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -67,7 +67,9 @@ class FsdpContext:
         self._is_finalized = False
         with torch.cuda.device(device):
             self.allgather_stream = torch.cuda.Stream()
-            self.reduce_scatter_stream = torch.cuda.Stream()
+            # A unified stream lets an all-gather reuse the storage released by a
+            # preceding reduce-scatter.
+            self.reduce_scatter_stream = self.allgather_stream
 
     def register_module(self, module: "FsdpModule") -> None:
         """Register a module constructed in this context."""
@@ -386,8 +388,10 @@ class FsdpModule:
 
     def post_backward(self) -> None:
         """Reduce gradients and return parameters to their sharded resting state."""
-        self._reduce_gradient_groups()
+        # Releasing the current full weight before allocating the packed gradient
+        # lets the communication stream reuse its storage for a later all-gather.
         self._reshard_parameter_groups()
+        self._reduce_gradient_groups()
         self.phase = FsdpModule.Phase.RESTING
         torch.cuda.nvtx.range_pop()
 

--- a/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
+++ b/megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py
@@ -44,32 +44,43 @@ class FsdpContext:
     # from ``main_weight``, has placements different from ``Placements.optimizer``.
     is_last_microbatch: bool
     use_symmetric_memory: bool
+    unify_communication_stream: bool
     # Static orders used to drive all-gather prefetch. We may want to switch to
     # capturing runtime order if static module order proves too fragile. Each
     # FsdpModule tracks its own materialized state via ``FsdpModule._unshard_event``.
     forward_order: IndexedOrder["FsdpModule"]
     backward_order: IndexedOrder["FsdpModule"]
 
-    def __init__(self, device: torch.device, use_symmetric_memory: bool = False) -> None:
+    def __init__(
+        self,
+        device: torch.device,
+        use_symmetric_memory: bool = False,
+        unify_communication_stream: bool = False,
+    ) -> None:
         """Create rank-local runtime state for FSDP modules on ``device``.
 
         Args:
             device: Device on which this context schedules communication.
             use_symmetric_memory: Whether modules constructed in this context allocate
                 communication staging buffers from PyTorch's NCCL symmetric-memory pool.
+            unify_communication_stream: Whether all-gathers and reduce-scatters share one
+                communication stream to reduce peak transient memory.
         """
         self.is_last_microbatch = True
         self.use_symmetric_memory = use_symmetric_memory
+        self.unify_communication_stream = unify_communication_stream
         self.forward_order = IndexedOrder()
         self.backward_order = IndexedOrder()
         # Construction-only; empty after finalization.
         self._registered_modules: list[FsdpModule] = []
         self._is_finalized = False
-        with torch.cuda.device(device):
-            self.allgather_stream = torch.cuda.Stream()
+        self.allgather_stream = torch.cuda.Stream(device)
+        if unify_communication_stream:
             # A unified stream lets an all-gather reuse the storage released by a
             # preceding reduce-scatter.
             self.reduce_scatter_stream = self.allgather_stream
+        else:
+            self.reduce_scatter_stream = torch.cuda.Stream(device)
 
     def register_module(self, module: "FsdpModule") -> None:
         """Register a module constructed in this context."""
@@ -388,8 +399,6 @@ class FsdpModule:
 
     def post_backward(self) -> None:
         """Reduce gradients and return parameters to their sharded resting state."""
-        # Releasing the current full weight before allocating the packed gradient
-        # lets the communication stream reuse its storage for a later all-gather.
         self._reshard_parameter_groups()
         self._reduce_gradient_groups()
         self.phase = FsdpModule.Phase.RESTING

--- a/tests/unit_tests/distributed/mfsdp_v2/test_memory.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_memory.py
@@ -107,8 +107,13 @@ def test_persistent_sharded_storage(distributed_setup, main_params_dtype):
     )
 
 
-def test_training_step_peak_memory_bounds_full_size_buffers(distributed_setup):
-    """A training step should stay below five full-size child buffers."""
+@pytest.mark.parametrize(
+    "unify_communication_stream", [False, True], ids=["separate_streams", "unified_stream"]
+)
+def test_training_step_peak_memory_bounds_full_size_buffers(
+    distributed_setup, unify_communication_stream
+):
+    """A training step should stay within its full-size-buffer bound."""
     rank = distributed_setup.rank
     world_size = distributed_setup.world_size
     device = distributed_setup.device
@@ -121,7 +126,7 @@ def test_training_step_peak_memory_bounds_full_size_buffers(distributed_setup):
     model = MultiChildModel(dim=dim, num_children=8).to(dtype=dtype)
     placements = _flat_placements()
     policy = MixedPrecisionPolicy(main_params_dtype=dtype, main_grads_dtype=dtype)
-    with fully_shard_context(device=device):
+    with fully_shard_context(device=device, unify_communication_stream=unify_communication_stream):
         for layer in model.layers:
             fully_shard(layer, mesh=mesh, placements=placements, mixed_precision_policy=policy)
         fully_shard(model, mesh=mesh, placements=placements, mixed_precision_policy=policy)
@@ -142,15 +147,18 @@ def test_training_step_peak_memory_bounds_full_size_buffers(distributed_setup):
     peak_delta = torch.cuda.max_memory_allocated(device) - resting_allocated
 
     # Backward keeps the current child and one prefetched child unsharded. The current
-    # child also has a full wgrad until it is copied into a full reduce-scatter input,
-    # for a four-full-child-buffer peak. Allow one additional buffer for cuBLAS
-    # workspace, allocator granularity, and small temporaries.
-    bound_nbytes = (4 + 1) * child_weight_nbytes
+    # child also has a full wgrad until it is copied into a full reduce-scatter input.
+    # With separate streams, their allocation cannot reuse the released full-weight
+    # storage, for a four-buffer peak. With a unified stream, the release precedes the
+    # allocation on that stream, reducing the peak to three. Allow one additional buffer
+    # for cuBLAS workspace, allocator granularity, and small temporaries.
+    full_buffer_bound = 4 if unify_communication_stream else 5
+    bound_nbytes = full_buffer_bound * child_weight_nbytes
 
     assert peak_delta < bound_nbytes, (
         "FSDP training-step peak memory exceeded the full-size-buffer bound: "
         f"rank={rank}, peak_delta={_mb(peak_delta)}, "
-        f"five_full_child_buffers={_mb(bound_nbytes)}"
+        f"{full_buffer_bound}_full_child_buffers={_mb(bound_nbytes)}"
     )
 
 

--- a/tests/unit_tests/distributed/mfsdp_v2/test_overlap.py
+++ b/tests/unit_tests/distributed/mfsdp_v2/test_overlap.py
@@ -63,7 +63,12 @@ _GEMM_OP_NAME_SUBSTRING = "aten::mm"
     ],
     ids=["default", "symmetric_memory"],
 )
-def test_overlaps_communication_and_compute(distributed_setup, use_symmetric_memory):
+@pytest.mark.parametrize(
+    "unify_communication_stream", [False, True], ids=["separate_streams", "unified_stream"]
+)
+def test_overlaps_communication_and_compute(
+    distributed_setup, use_symmetric_memory, unify_communication_stream
+):
     """Forward and backward communication should overlap GEMM compute."""
     world_size = distributed_setup.world_size
     device = distributed_setup.device
@@ -110,7 +115,11 @@ def test_overlaps_communication_and_compute(distributed_setup, use_symmetric_mem
     model = MultiChildModel(dim=dim, num_children=num_children).to(device=device, dtype=dtype)
     placements = _flat_placements()
     policy = MixedPrecisionPolicy(main_params_dtype=dtype, main_grads_dtype=dtype)
-    with fully_shard_context(device=device, use_symmetric_memory=use_symmetric_memory):
+    with fully_shard_context(
+        device=device,
+        use_symmetric_memory=use_symmetric_memory,
+        unify_communication_stream=unify_communication_stream,
+    ):
         for layer in model.layers:
             fully_shard(layer, mesh=mesh, placements=placements, mixed_precision_policy=policy)
 
@@ -160,8 +169,11 @@ def test_overlaps_communication_and_compute(distributed_setup, use_symmetric_mem
     gemm_streams = {kernel.device_resource_id for kernel in gemm_kernels}
     if allgather_kernels:
         assert len(allgather_streams) == 1
+        if unify_communication_stream:
+            assert allgather_streams == reduce_scatter_streams
+        else:
+            assert allgather_streams.isdisjoint(reduce_scatter_streams)
     assert len(reduce_scatter_streams) == 1
-    assert allgather_streams.isdisjoint(reduce_scatter_streams)
     assert allgather_streams.isdisjoint(gemm_streams)
     assert reduce_scatter_streams.isdisjoint(gemm_streams)
 


### PR DESCRIPTION
## Summary

Add `unify_communication_stream` as an opt-in `fully_shard_context` / `FsdpContext` setting. When enabled, MFSDP v2 uses one communication stream for all-gathers and reduce-scatters, allowing a later all-gather to reuse released full-weight storage.

Credit to @Autumn1998 for first suggesting this single-stream approach.

The default preserves separate communication streams. All configurations reshard each module before allocating its packed reduce-scatter input.

With stream unification enabled, the training-step transient full-buffer bound decreases from four to three while communication/compute overlap is preserved.

Fixes #6471.

## Validation

- `isort megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py`
- `black megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py`
- `ruff check megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/module.py megatron/core/distributed/fsdp/src/megatron_fsdp/experimental/fully_shard.py tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py`
- `python -m torch.distributed.run --nproc-per-node 2 -m pytest -q --capture=fd tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py::test_training_step_peak_memory_bounds_full_size_buffers tests/unit_tests/distributed/mfsdp_v2/test_fully_shard.py::test_overlaps_communication_and_compute`