### PR TITLE
[Bug]Fix local MLA dot product attention channel handling

### DIFF
--- a/megatron/core/transformer/dot_product_attention.py
+++ b/megatron/core/transformer/dot_product_attention.py
@@ -47,6 +47,8 @@ class DotProductAttention(MegatronModule):
         attention_type: str,
         attention_dropout: Optional[float] = None,
         softmax_scale: Optional[float] = None,
+        k_channels: Optional[int] = None,
+        v_channels: Optional[int] = None,
         cp_comm_type: Optional[str] = None,
         pg_collection: Optional[ProcessGroupCollection] = None,
     ):
@@ -62,7 +64,11 @@ class DotProductAttention(MegatronModule):
         self.attn_mask_type = attn_mask_type
         self.attention_type = attention_type  # unused for now
 
-        projection_size = self.config.kv_channels * self.config.num_attention_heads
+        k_channels = self.config.kv_channels if k_channels is None else k_channels
+        v_channels = k_channels if v_channels is None else v_channels
+
+        query_key_projection_size = k_channels * self.config.num_attention_heads
+        value_projection_size = v_channels * self.config.num_attention_heads
 
         # Per attention head and per partition values.
         if pg_collection is None:
@@ -75,8 +81,10 @@ class DotProductAttention(MegatronModule):
         self.tp_group = self.pg_collection.tp
 
         world_size = pg_collection.tp.size()
-        self.hidden_size_per_partition = divide(projection_size, world_size)
-        self.hidden_size_per_attention_head = divide(projection_size, config.num_attention_heads)
+        self.hidden_size_per_partition = divide(value_projection_size, world_size)
+        self.hidden_size_per_attention_head = divide(
+            query_key_projection_size, config.num_attention_heads
+        )
         self.num_attention_heads_per_partition = divide(self.config.num_attention_heads, world_size)
         self.num_query_groups_per_partition = divide(self.config.num_query_groups, world_size)
 

--- a/tests/unit_tests/transformer/test_dot_product_attention.py
+++ b/tests/unit_tests/transformer/test_dot_product_attention.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+import pytest
+import torch
+
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.transformer.dot_product_attention import DotProductAttention
+from megatron.core.transformer.enums import AttnMaskType
+from megatron.core.transformer.transformer_config import TransformerConfig
+from tests.unit_tests.test_utilities import Utils
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+class TestDotProductAttention:
+    def setup_method(self, method):
+        Utils.initialize_model_parallel(1, 1)
+        model_parallel_cuda_manual_seed(123)
+
+    def teardown_method(self, method):
+        Utils.destroy_model_parallel()
+
+    def test_forward_with_distinct_key_and_value_channels(self):
+        config = TransformerConfig(
+            num_layers=1,
+            hidden_size=64,
+            num_attention_heads=4,
+            attention_dropout=0.0,
+            masked_softmax_fusion=False,
+        )
+        attention = DotProductAttention(
+            config=config,
+            layer_number=1,
+            attn_mask_type=AttnMaskType.causal,
+            attention_type="self",
+            k_channels=24,
+            v_channels=16,
+        ).cuda()
+
+        sequence_length = 8
+        micro_batch_size = 2
+        query = torch.ones(
+            sequence_length,
+            micro_batch_size,
+            config.num_attention_heads,
+            24,
+            device="cuda",
+        )
+        key = torch.ones_like(query)
+        value = torch.ones(
+            sequence_length,
+            micro_batch_size,
+            config.num_attention_heads,
+            16,
+            device="cuda",
+        )
+        attention_mask = torch.zeros(
+            1,
+            1,
+            sequence_length,
+            sequence_length,
+            dtype=torch.bool,
+            device="cuda",
+        )
+
+        output = attention(query, key, value, attention_mask)
+
+        assert output.shape == (sequence_length, micro_batch_size, 64)


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
Fix local `DotProductAttention` so MLA can be used with `--transformer-impl local` when Q/K and V head dimensions differ.

## Details

`MultiLatentAttention` builds its core attention module with MLA-specific channel sizes:

```python
k_channels=self.q_head_dim
v_channels=self.config.v_head_dim
```

This works for core attention implementations that accept those arguments, but the local `DotProductAttention` constructor did not accept them. As a result, trying to run MLA without Transformer Engine failed during model construction with:

```text
TypeError: DotProductAttention.__init__() got an unexpected keyword argument 'k_channels'
```

This PR updates local `DotProductAttention` to accept optional `k_channels` and `v_channels`.

The default behavior is unchanged for standard attention:

- `k_channels` defaults to `config.kv_channels`
- `v_channels` defaults to `k_channels`

For MLA, Q/K and V can have different per-head dimensions. The local attention module now uses:

- `k_channels` for Q/K head dimension and default softmax scaling
- `v_channels * num_attention_heads` for the output hidden width

This aligns local `DotProductAttention` with the arguments already passed by `MultiLatentAttention`, while preserving the existing MHA/GQA behavior.

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [x] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR


### Validation

Unit test:

```bash
torchrun --nproc_per_node=1 \
  --master_addr=127.0.0.1 --master_port=29541 \
  -m pytest -q --confcutdir=tests/unit_tests/transformer \
  tests/unit_tests/transformer/test_dot_product_attention.py::TestDotProductAttention::test_forward_with_distinct_key_and_value_channels
```

Result:

```text
1 passed
```

1 GPU local MLA training smoke test:

```bash
torchrun --nproc_per_node=1 \
  --master_addr=127.0.0.1 --master_port=29542 \
  pretrain_gpt.py \
  --use-mcore-models \
  --transformer-impl local \
  --attention-backend unfused \
  --multi-latent-attention \
  --position-embedding-type none \
  --num-layers 2 \
  --hidden-size 128 \
  --ffn-hidden-size 512 \
  --num-attention-heads 4 \
  --seq-length 64 \
  --max-position-embeddings 64 \
  --micro-batch-size 1 \
  --global-batch-size 1 \
  --train-iters 2 \
  --lr 1e-4 \
  --min-lr 1e-5 \
  --lr-decay-style cosine \
  --log-interval 1 \
  --eval-iters 0 \
  --eval-interval 1000 \
  --tokenizer-type NullTokenizer \
  --vocab-size 8192 \
  --mock-data \
  --bf16 \
  --no-persist-layer-norm \
  --no-gradient-accumulation-fusion \
  --no-masked-softmax-fusion \
  --q-lora-rank 32 \
  --kv-lora-rank 32 \
  --qk-head-dim 16 \
  --qk-pos-emb-head-dim 8 \
  --v-head-dim 16
```

8 GPU local MLA training smoke test:

```bash
torchrun --nproc_per_node=8 \
  --master_addr=127.0.0.1 --master_port=29543 \
  pretrain_gpt.py \
  --use-mcore-models \
  --transformer-impl local \
  --attention-backend unfused \
  --multi-latent-attention \
  --position-embedding-type none \
  --tensor-model-parallel-size 2 \
  --pipeline-model-parallel-size 2 \
  --num-layers 4 \
  --hidden-size 128 \
  --ffn-hidden-size 512 \
  --num-attention-heads 4 \
  --seq-length 64 \
  --max-position-embeddings 64 \
  --micro-batch-size 1 \
  --global-batch-size 8 \
  --train-iters 2 \
  --lr 1e-4 \
  --min-lr 1e-5 \
  --lr-decay-style cosine \
  --log-interval 1 \
  --eval-iters 0 \
  --eval-interval 1000 \
  --tokenizer-type NullTokenizer \
  --vocab-size 8192 \
  --mock-data \
  --bf16 \
  --no-persist-layer-norm \
  --no-gradient-accumulation-fusion \
  --no-masked-softmax-fusion \
  --q-lora-rank 32 \
  --kv-lora-rank 32 \
  --qk-head-dim 16 \
  --qk-pos-emb-head-dim 8 \
  --v-head-dim 16
```

Environment used for smoke tests:

```text
PyTorch version: 2.11.0+cu128
Megatron-Core version: 0.20.0+9e96f45
GPU: 8x NVIDIA GeForce RTX 5090
```
