### PR TITLE
fix(gtp+mtp): zero the placeholder wgrad when zero_out_wgrad is set

### DIFF
--- a/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
+++ b/megatron/core/tensor_parallel/generalized_tensor_parallelism.py
@@ -1765,15 +1765,19 @@ class GTPShardedParam(torch.nn.Parameter):
     def _handle_megatron_grad_accum(param):
         """Handle megatron DDP and gradient-accumulation fusion.
 
-        Do NOT set param.grad before calling the hook — the hook checks param.grad and would
-        accumulate it into main_grad if zero_out_wgrad is True, corrupting it with a dummy.
-
         Returns a cached dummy wgrad; sync callers use it as the graph-safe grad, async drains
-        discard it.
+        discard it. It is zeroed when DDP will accumulate it — see below.
         """
         if hasattr(param, "grad_added_to_main_grad"):
             param.grad_added_to_main_grad = True
-        dummy_grad = get_dummy_wgrad(list(param.main_grad.shape), param.dtype)
+        # This dummy becomes param.grad, and DDP accumulates it when zero_out_wgrad is set
+        # (DistributedDataParallel._make_backward_post_hook in distributed_data_parallel.py).
+        # get_dummy_wgrad returns a SHARED reused buffer, so it must be zeroed in that case
+        # or it injects whatever it last held into the gradient. Same pairing as layers.py.
+        if getattr(param, "zero_out_wgrad", False):
+            dummy_grad = get_dummy_wgrad(list(param.main_grad.shape), param.dtype, zero=True)
+        else:
+            dummy_grad = get_dummy_wgrad(list(param.main_grad.shape), param.dtype)
         if getattr(param, "_grad_accum_hook", None) is not None:
             param._grad_accum_hook()
 

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_mtp.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_mtp.py
@@ -511,6 +511,100 @@ def _worker_ddp_grad_ready_counts(rank, world_size, port, repeated_layer=False):
     )
 
 
+# Value written into the shared dummy-wgrad buffer to make the leak observable. Any non-zero
+# value works; a large one keeps it far outside the range of a real gradient.
+DUMMY_POISON = 12345.0
+
+
+def _worker_dummy_wgrad_not_leaked(rank, world_size, port, repeated_layer=False):
+    """A GTP weight's gradient must not depend on the shared dummy-wgrad buffer's contents.
+
+    GTP returns a PLACEHOLDER from backward, not a gradient -- the real wgrad already went into
+    main_grad via reduce-scatter. But it becomes ``param.grad``, and DDP adds ``param.grad`` into
+    main_grad when ``zero_out_wgrad`` is set (``_make_backward_post_hook``), which MTP does to the
+    shared embedding weight. ``get_dummy_wgrad`` hands back ONE reused buffer, and the shared
+    weight gets N = (1 main pass + mtp_num_layers) x gradient-accumulation steps backward passes
+    per iteration, so::
+
+        want:  S1 + S2 + ... + SN            Si = call i's reduce-scattered gradient
+        got:   S1 + S2 + ... + SN  +  N*D    D  = whatever that shared buffer last held
+
+    D is near-zero while the buffer is fresh and real data once traffic has passed through it --
+    hence the original failure needing both MTP and gradient accumulation, and vanishing whenever
+    an extra allocation shifted the buffer. This test POISONS it with a known value instead, and
+    requires the gradients to come out bit-identical. It runs a single step, so N = 1 + 2 = 3 and
+    reverting the fix shifts the gradient by ~3x the poison.
+    """
+    from transformer_engine.pytorch.module.base import get_dummy_wgrad
+
+    from megatron.core import parallel_state as ps
+    from megatron.core.tensor_parallel.generalized_tensor_parallelism import (
+        GTP_CONFIG,
+        reset_gtp_state,
+    )
+    from megatron.core.tensor_parallel.gtp_api import classify_gtp_remat_chains
+    from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+
+    def _train_one_step_with_poison(poison):
+        """Build a fresh MTP model, poison the shared dummy, run fwd+bwd, return {name: grad}."""
+        reset_gtp_state()  # reset_gtp_globals is an autouse FIXTURE; this is what it defers to
+        ps.destroy_model_parallel()
+        ps.initialize_model_parallel(
+            tensor_model_parallel_size=1, pipeline_model_parallel_size=1, gtp_remat_size=world_size
+        )
+        model_parallel_cuda_manual_seed(42)
+        torch.manual_seed(42)
+
+        model = _build_mtp_gpt_model(repeated_layer, moe=False)
+        classify_gtp_remat_chains([model])
+        for p in model.parameters():
+            p.main_grad = torch.zeros(p.shape, dtype=torch.float32, device='cuda')
+
+        tagged = [n for n, p in model.named_parameters() if getattr(p, "zero_out_wgrad", False)]
+        # Fail loudly rather than pass vacuously: with nothing tagged, DDP never reads the
+        # placeholder and this test would be green no matter what GTP returns.
+        assert tagged, (
+            "no parameter has zero_out_wgrad set -- MTP should tag the shared embedding weight. "
+            "Without it this test cannot observe the placeholder at all."
+        )
+        # get_dummy_wgrad keys on main_grad's shape, so this dirties the exact buffer GTP will
+        # hand back from _handle_megatron_grad_accum.
+        for _, p in model.named_parameters():
+            if getattr(p, "zero_out_wgrad", False):
+                get_dummy_wgrad(list(p.main_grad.shape), p.dtype).fill_(poison)
+
+        _forward_backward(model)
+
+        # The model here is unwrapped, so replay DDP's accumulation rule explicitly -- see
+        # DistributedDataParallel._make_backward_post_hook. This is what makes the test able to
+        # observe the placeholder at all: drop it and the test passes even with the bug present.
+        for p in model.parameters():
+            if p.grad is not None and (
+                not getattr(p, "grad_added_to_main_grad", False)
+                or getattr(p, "zero_out_wgrad", False)
+            ):
+                p.main_grad.add_(p.grad.to(p.main_grad.dtype))
+
+        return _gathered_main_grads(model), tagged
+
+    saved_pad = GTP_CONFIG.pad_for_alignment
+    try:
+        # Shards stay exactly 1/gtp of the weight so _gathered_main_grads reconstructs it.
+        GTP_CONFIG.pad_for_alignment = 0
+        clean, tagged = _train_one_step_with_poison(0.0)
+        dirty, _ = _train_one_step_with_poison(DUMMY_POISON)
+    finally:
+        GTP_CONFIG.pad_for_alignment = saved_pad
+
+    for name in clean:
+        delta = (dirty[name] - clean[name]).abs().max().item()
+        assert delta == 0.0, (
+            f"{name}: gradient changed by {delta} when the shared dummy-wgrad buffer was "
+            f"poisoned with {DUMMY_POISON}. GTP's placeholder grad leaked into the gradient; it "
+            f"must be zeroed whenever zero_out_wgrad is set (tagged here: {tagged})."
+        )
+
+
 class TestGTPMTP:
     @pytest.mark.parametrize("moe", [False, True], ids=["dense", "moe"])
     @pytest.mark.parametrize("repeated_layer", [False, True])
@@ -562,3 +656,15 @@ class TestGTPMTP:
         if torch.cuda.device_count() < 4:
             pytest.skip("Requires 4 CUDA devices")
         _run_distributed(_worker_ddp_grad_ready_counts, 4, repeated_layer)
+
+    @pytest.mark.parametrize("repeated_layer", [False, True])
+    def test_mtp_dummy_wgrad_does_not_leak_into_grad(self, repeated_layer):
+        """MTP sets zero_out_wgrad on the shared embedding, which makes DDP ADD param.grad.
+
+        GTP's placeholder grad must therefore be zeroed, or the shared dummy buffer's stale
+        contents land in main_grad -- silently at first, then as a NaN once enough backward
+        passes have dirtied it.
+        """
+        if torch.cuda.device_count() < 4:
+            pytest.skip("Requires 4 CUDA devices")
+        _run_distributed(_worker_dummy_wgrad_not_leaked, 4, repeated_layer)


### PR DESCRIPTION
- [x] I, the PR author, have personally reviewed every line of this PR.

# What does this PR do?
fix(gtp+mtp): zero the placeholder wgrad when zero_out_wgrad is set to avoid potential NaN issue for GTP+MTP

## What's the bug

MTP sets `zero_out_wgrad` on the shared `embedding`, which makes DDP ADD `param.grad`.

GTP's placeholder grad must therefore be **zeroed**, or the shared dummy buffer's stale
contents land in `main_grad` -- silently at first, then as a NaN once enough backward passes have dirtied it

## How to reproduce the bug
Minimal reproducer as a unit test — poison the shared buffer, then require the gradient to be unchanged:
`tests/unit_tests/generalized_tensor_parallel/test_gtp_mtp.py`

```
from transformer_engine.pytorch.module.base import get_dummy_wgrad

model = _build_mtp_gpt_model(repeated_layer, moe=False)   # GTP=4, mtp_num_layers=2
classify_gtp_remat_chains([model])
for p in model.parameters():
    p.main_grad = torch.zeros(p.shape, dtype=torch.float32, device='cuda')

# dirty the exact buffer GTP will hand back
for _, p in model.named_parameters():
    if getattr(p, "zero_out_wgrad", False):          # MTP tags the shared embedding
        get_dummy_wgrad(list(p.main_grad.shape), p.dtype).fill_(12345.0)

_forward_backward(model)

# DDP's rule (DistributedDataParallel._make_backward_post_hook)
for p in model.parameters():
    if p.grad is not None and (
        not getattr(p, "grad_added_to_main_grad", False)
        or getattr(p, "zero_out_wgrad", False)
    ):
        p.main_grad.add_(p.grad.to(p.main_grad.dtype))
```

Run it twice with poison `0.0` and `12345.0`; the gradients must be bit-identical.

`torchrun --nproc-per-node 4 -m pytest -q \
  tests/unit_tests/generalized_tensor_parallel/test_gtp_mtp.py \
  -k test_mtp_dummy_wgrad_does_not_leak_into_grad`

## Convergence Test

1/5 Nemotron-next, mxfp8, dataset=`1T-phase1var-moresft.json`: w/ and w/o MTP:
<img width="1308" height="354" alt="image" src="https://github.com/user-attachments/assets/a778909a-0f41-4193-851d-2495854cb73f" />

## UTs
All GTP related UTs passed.

## Issue tracking

Fixes #6078 

## Contribution process

### Pre-checks

- [x] I have added relevant unit tests
- [ ] I have added relevant functional tests
- [x] I have added proper typing to my code [Typing guidelines](https://docs.python.org/3/library/typing.html)
- [x] I have added relevant documentation
- [x] I have run the [autoformatter.sh](https://github.com/NVIDIA/Megatron-LM/blob/main/tools/autoformat.sh) on my PR
