### PR TITLE
Complete explicit GTP RNG seeding

### DIFF
--- a/megatron/core/tensor_parallel/random.py
+++ b/megatron/core/tensor_parallel/random.py
@@ -454,6 +454,8 @@ def model_parallel_cuda_manual_seed(
     gtp_remat_rank: Optional[int] = None,
     egtp_remat_rank: Optional[int] = None,
     force_reset_rng: bool = False,
+    gtp_remat_world_size: Optional[int] = None,
+    egtp_remat_world_size: Optional[int] = None,
 ):
     """Initialize model parallel cuda seed.
 
@@ -482,6 +484,10 @@ def model_parallel_cuda_manual_seed(
         gtp_remat_rank = get_gtp_weight_remat_rank()
     if egtp_remat_rank is None:
         egtp_remat_rank = get_expert_gtp_weight_remat_rank()
+    if gtp_remat_world_size is None:
+        gtp_remat_world_size = get_gtp_weight_remat_world_size()
+    if egtp_remat_world_size is None:
+        egtp_remat_world_size = get_expert_gtp_weight_remat_world_size()
     # 2718 is just for fun and any POSITIVE value will work.
     offset = seed + 2718
     tensor_model_parallel_seed = offset + tp_rank
@@ -506,10 +512,10 @@ def model_parallel_cuda_manual_seed(
     # must draw DIFFERENT values (everything above is identical across peers by design). The 65536
     # stride keeps these disjoint from the tp/ep/etp seeds. Added only when the axis is active, so
     # non-GTP runs keep a byte-identical tracker set (and checkpoint rng payload).
-    if get_gtp_weight_remat_world_size() > 1:
+    if gtp_remat_world_size > 1:
         gtp_remat_seed = tensor_model_parallel_seed + 65536 * (1 + gtp_remat_rank)
         _CUDA_RNG_STATE_TRACKER.add(_GTP_REMAT_RNG_TRACKER_NAME, gtp_remat_seed)
-    if get_expert_gtp_weight_remat_world_size() > 1:
+    if egtp_remat_world_size > 1:
         egtp_remat_seed = expert_parallel_seed + 32768 + 65536 * (1 + egtp_remat_rank)
         _CUDA_RNG_STATE_TRACKER.add(_EXPERT_GTP_REMAT_RNG_TRACKER_NAME, egtp_remat_seed)
 

--- a/megatron/training/initialize.py
+++ b/megatron/training/initialize.py
@@ -26,7 +26,13 @@ from megatron.core.rerun_state_machine import (
 from megatron.core.transformer.custom_layers.batch_invariant_kernels import (
     enable_batch_invariant_mode,
 )
-from megatron.core.utils import get_pg_rank, get_te_version, is_te_min_version, is_torch_min_version
+from megatron.core.utils import (
+    get_pg_rank,
+    get_pg_size,
+    get_te_version,
+    is_te_min_version,
+    is_torch_min_version,
+)
 from megatron.training import (
     get_adlr_autoresume,
     get_args,
@@ -426,10 +432,12 @@ def _set_random_seed(
     tp_group: Optional[torch.distributed.ProcessGroup] = None,
     ep_group: Optional[torch.distributed.ProcessGroup] = None,
     etp_group: Optional[torch.distributed.ProcessGroup] = None,
+    gtp_remat_group: Optional[torch.distributed.ProcessGroup] = None,
+    egtp_remat_group: Optional[torch.distributed.ProcessGroup] = None,
 ):
     """Set random seed for reproducability.
 
-    The optional pp/dp/tp/ep/etp groups let a caller without an initialized mpu
+    The optional parallel groups let a caller without an initialized mpu
     (e.g. a disjoint-grid run) supply the parallel ranks explicitly; each falls
     back to the mpu group when None.
     """
@@ -448,6 +456,16 @@ def _set_random_seed(
             tp_rank = get_pg_rank(tp_group) if tp_group is not None else None
             ep_rank = get_pg_rank(ep_group) if ep_group is not None else None
             etp_rank = get_pg_rank(etp_group) if etp_group is not None else None
+            gtp_remat_rank = get_pg_rank(gtp_remat_group) if gtp_remat_group is not None else None
+            egtp_remat_rank = (
+                get_pg_rank(egtp_remat_group) if egtp_remat_group is not None else None
+            )
+            gtp_remat_world_size = (
+                get_pg_size(gtp_remat_group) if gtp_remat_group is not None else None
+            )
+            egtp_remat_world_size = (
+                get_pg_size(egtp_remat_group) if egtp_remat_group is not None else None
+            )
             tensor_parallel.model_parallel_cuda_manual_seed(
                 seed,
                 te_rng_tracker,
@@ -456,6 +474,10 @@ def _set_random_seed(
                 tp_rank=tp_rank,
                 ep_rank=ep_rank,
                 etp_rank=etp_rank,
+                gtp_remat_rank=gtp_remat_rank,
+                egtp_remat_rank=egtp_remat_rank,
+                gtp_remat_world_size=gtp_remat_world_size,
+                egtp_remat_world_size=egtp_remat_world_size,
             )
     else:
         raise ValueError("Seed ({}) should be a positive integer.".format(seed_))

--- a/tests/unit_tests/generalized_tensor_parallel/test_gtp_custom_pgs.py
+++ b/tests/unit_tests/generalized_tensor_parallel/test_gtp_custom_pgs.py
@@ -279,6 +279,47 @@ def _worker_partial_pgs_fall_back_to_mpu(rank, world_size, port):
     ps.initialize_model_parallel()
 
 
+def _worker_seed_custom_gtp_groups_without_mpu(rank, world_size, port):
+    """Explicit GTP groups must seed their trackers without MPU groups."""
+    from megatron.core import parallel_state as ps
+    from megatron.core.tensor_parallel.random import (
+        get_cuda_rng_tracker,
+        get_gtp_remat_rng_tracker_name,
+    )
+    from megatron.training.initialize import _set_random_seed
+
+    singleton_group = None
+    for group_rank in range(world_size):
+        group = dist.new_group([group_rank])
+        if rank == group_rank:
+            singleton_group = group
+
+    pairing_groups = {}
+    for name, pairs in _PAIRINGS.items():
+        for pair in pairs:
+            group = dist.new_group(pair)
+            if rank in pair:
+                pairing_groups[name] = group
+
+    ps.destroy_model_parallel()
+    try:
+        _set_random_seed(
+            42,
+            pp_group=singleton_group,
+            dp_group=singleton_group,
+            tp_group=singleton_group,
+            ep_group=singleton_group,
+            etp_group=singleton_group,
+            gtp_remat_group=pairing_groups["adjacent"],
+            egtp_remat_group=pairing_groups["strided"],
+        )
+        states = get_cuda_rng_tracker().get_states()
+        assert get_gtp_remat_rng_tracker_name() in states
+        assert get_gtp_remat_rng_tracker_name(is_expert=True) in states
+    finally:
+        ps.initialize_model_parallel()
+
+
 class TestGTPCustomProcessGroups:
     def test_custom_gtp_pg_collection_matches_mpu(self):
         """A permuted-but-equivalent gtp_remat group must give identical fwd/bwd results."""
@@ -289,3 +330,8 @@ class TestGTPCustomProcessGroups:
         """Omitting gtp_remat must fall back to the MPU group, not silently disable sharding."""
         _requires_multi_gpu(WORLD)
         _run_distributed(_worker_partial_pgs_fall_back_to_mpu, WORLD)
+
+    def test_custom_gtp_groups_seed_without_mpu(self):
+        """Explicit GTP groups must not depend on MPU rank or world-size state."""
+        _requires_multi_gpu(WORLD)
+        _run_distributed(_worker_seed_custom_gtp_groups_without_mpu, WORLD)


### PR DESCRIPTION
## What

- Thread explicit GTP and expert-GTP process groups through training RNG initialization.
- Derive both tracker ranks and world sizes from the supplied groups.
- Add a distributed regression that seeds both trackers after MPU teardown.

This PR contains no MIMO behavior changes.

## Testing

- Cog / CMH job `3083041`: 1 node, 4 GPUs allocated, 4 torchrun ranks; focused custom-GTP RNG test passed on Transformer Engine `2.19.0.dev0+4adad4c2`.
- `isort --check-only` and `ruff check` passed for the changed files.