### PR TITLE
Add selective recompute for GDP projections

### DIFF
--- a/megatron/core/ssm/gated_delta_product.py
+++ b/megatron/core/ssm/gated_delta_product.py
@@ -14,6 +14,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from megatron.core import tensor_parallel
 from megatron.core.dist_checkpointing import ShardedTensor
 from megatron.core.dist_checkpointing.mapping import ReplicaId, ShardedTensorFactory
 from megatron.core.inference.contexts import BaseInferenceContext, DynamicInferenceContext
@@ -73,6 +74,7 @@ except ImportError:
     HAVE_EINOPS = False
 
 try:
+    from fla.modules.l2norm import l2_norm
     from fla.ops.gated_delta_product import chunk_gated_delta_product
     from fla.ops.gated_delta_rule import fused_recurrent_gated_delta_rule
 
@@ -256,6 +258,15 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
         self.layer_number = layer_number
         self.pp_layer_offset = pp_layer_offset
         self.cached_batch_size = None
+
+        self.recompute_in_proj = (
+            self.config.recompute_granularity == "selective"
+            and "gdp_in_proj" in self.config.recompute_modules
+        )
+        self.recompute_qkv = (
+            self.config.recompute_granularity == "selective"
+            and "gdp_qkv" in self.config.recompute_modules
+        )
 
         tp_size = self.pg_collection.tp.size()
 
@@ -475,74 +486,47 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
             assert batch_size == 1, "Packed sequences require batch=1 (THD/varlen format)."
             cu_seqlens_packed = get_cu_seqlens(packed_seq_params)
 
-        zVKQba, _ = self.in_proj(hidden_states)
+        is_training = inference_context is None
+        in_proj_checkpoint = None
+        if is_training and self.recompute_in_proj:
+            # Capture packed_seq_params rather than passing the non-tensor dataclass
+            # through CheckpointWithoutOutput. Its index tensors are metadata; only
+            # hidden_states must be retained as a differentiable checkpoint input.
+            def in_proj_preprocess(x):
+                return self._in_proj_preprocess(x, packed_seq_params)
 
-        zVKQba = self.cp.pre_conv_ssm(zVKQba, packed_seq_params=packed_seq_params)
+            quantization = self.config.fp8 or self.config.fp4
+            in_proj_checkpoint = tensor_parallel.CheckpointWithoutOutput(fp8=quantization)
+            z, VKQ, ba = in_proj_checkpoint.checkpoint(in_proj_preprocess, hidden_states)
+        else:
+            z, VKQ, ba = self._in_proj_preprocess(hidden_states, packed_seq_params)
 
         # Build seq_idx *after* in_proj's SP all-gather and pre_conv_ssm's CP
-        # all-to-all. ``zVKQba.shape[0]`` is now the true pack_length, so the
-        # helper produces a seq_idx matching the conv1d's input length
-        # regardless of SP/CP/TP upstream-slicing. Mirrors mamba_mixer.py
-        # which calls _create_packed_seq_idx after the same gather points.
+        # all-to-all. ``VKQ.shape[1]`` is now the true pack length, so the
+        # helper produces an index matching the conv1d input regardless of
+        # SP/CP/TP upstream slicing.
         seq_idx_packed = None
         if packed_seq_params is not None:
-            seq_idx_packed = build_packed_seq_idx(packed_seq_params, zVKQba.shape[0])
-
-        zVKQba = rearrange(zVKQba, "l b d -> b l d").contiguous()
-
-        z, VKQ, ba = torch.split(
-            zVKQba,
-            [
-                self.cp.d_inner_local_tpcp,
-                self.cp.d_inner_local_tpcp * self.num_householder
-                + (self.num_householder + 1) * self.cp.ngroups_local_tpcp * self.d_state,
-                self.cp.nheads_local_tpcp * (self.num_householder + 1),
-            ],
-            dim=-1,
-        )
-
-        # ``causal_conv1d_fn`` expects a ``[B, D, L]`` tensor. Its unpacked kernel
-        # supports both channels-first and channels-last memory layouts.
-        if seq_idx_packed is None:
-            if self.config.gdp_cutedsl_kernel:
-                # Keep the channel-last backing storage, stride(1) == 1. The conv
-                # output then becomes dense [B, L, D] after the transpose below,
-                # avoiding a full VKQ copy and downstream layout materializations.
-                VKQ = rearrange(VKQ, "b l d -> b d l")
-            else:
-                # Preserve the existing FLA path: channels-first, stride(2) == 1.
-                VKQ = rearrange(VKQ, "b l d -> b d l").contiguous()
-        else:
-            # ``causal_conv1d_fn(seq_idx=...)`` requires channels-last memory but [B, D, L]
-            # logical shape. This keeps the channels contiguous in memory.
-            VKQ = VKQ.contiguous()
-            VKQ = rearrange(VKQ, "b l d -> b d l")
+            seq_idx_packed = build_packed_seq_idx(packed_seq_params, VKQ.shape[1])
 
         if conv_state is not None:
             # Static-batching prefill: seed the conv state from the prompt's tail.
-            # If we just take x[:, :, -self.d_conv :], it will error if seqlen < self.d_conv
-            # Instead F.pad will pad with zeros if seqlen < self.d_conv, and truncate otherwise.
-            conv_state.copy_(F.pad(VKQ, (self.d_conv - VKQ.shape[-1], 0)))  # Update state (B D W)
-        # causal_conv1d uses seq_idx_packed to reset the convolution boundaries
-        VKQ = causal_conv1d_fn(
-            x=VKQ,
-            weight=rearrange(self.cp.get_conv1d_weight(), "d 1 w -> d w"),
-            bias=self.cp.get_conv1d_bias(),
-            activation=self.activation,
-            seq_idx=seq_idx_packed,
-        )
+            VKQ_conv = rearrange(VKQ, "b l d -> b d l")
+            conv_state.copy_(
+                F.pad(VKQ_conv, (self.d_conv - VKQ_conv.shape[-1], 0))
+            )  # Update state (B D W)
 
-        VKQ = rearrange(VKQ, "b d l ->  b l d").contiguous()
+        qkv_checkpoint = None
+        if is_training and self.recompute_qkv:
+            # seq_idx_packed is immutable, small metadata. Capture it so the only
+            # differentiable checkpoint input is the full-width VKQ activation.
+            def prepare_qkv(x):
+                return self._prepare_qkv(x, seq_idx_packed)
 
-        value, key, query = torch.split(
-            VKQ,
-            [
-                self.cp.d_inner_local_tpcp * self.num_householder,
-                self.cp.ngroups_local_tpcp * self.d_state * self.num_householder,
-                self.cp.ngroups_local_tpcp * self.d_state,
-            ],
-            dim=-1,
-        )
+            qkv_checkpoint = tensor_parallel.CheckpointWithoutOutput()
+            query, key, value = qkv_checkpoint.checkpoint(prepare_qkv, VKQ)
+        else:
+            query, key, value = self._prepare_qkv(VKQ, seq_idx_packed)
 
         b, a = torch.split(
             ba,
@@ -551,31 +535,7 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
         )
 
         z = rearrange(z, "b l (h p) -> b l h p", p=self.headdim).contiguous()
-        if self.config.gdp_cutedsl_kernel:
-            # CuTeDSL consumes one row per token and keeps the Householder copies in
-            # the feature dimension. Avoid materializing the FLA-only b x (l*m)
-            # layouts and their contiguous copies.
-            value = rearrange(
-                value, "b l (m h p) -> (b l) (m h p)", m=self.num_householder, p=self.headdim
-            )
-            key = rearrange(
-                key,
-                "b l (m g n) -> b l m g n",
-                m=self.num_householder,
-                n=self.d_state,
-            )
-            query = rearrange(query, "b l (g n) -> b l g n", n=self.d_state)
-        else:
-            value = rearrange(
-                value, "b l (m h p) -> b (l m) h p", m=self.num_householder, p=self.headdim
-            ).contiguous()
-            key = rearrange(
-                key, "b l (m g n) -> b (l m) g n", m=self.num_householder, n=self.d_state
-            ).contiguous()
-            query = rearrange(query, "b l (g n) -> b l g n", n=self.d_state).contiguous()
-
-            # Preserve the existing FLA layout and stride contract exactly.
-            b, a = b.contiguous(), a.contiguous()
+        b, a = b.contiguous(), a.contiguous()
 
         beta = b.sigmoid()
 
@@ -592,30 +552,16 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
                 beta, "b l (m h) -> b (l m) h", m=self.num_householder
             ).contiguous()
 
-        if self.cp.nheads_local_tpcp // self.cp.ngroups_local_tpcp > 1:
-            query = query.repeat_interleave(
-                self.cp.nheads_local_tpcp // self.cp.ngroups_local_tpcp, dim=-2
-            )
-            key = key.repeat_interleave(
-                self.cp.nheads_local_tpcp // self.cp.ngroups_local_tpcp, dim=-2
-            )
-
-        if self.config.gdp_cutedsl_kernel:
-            # GQA expansion is complete; collapse directly to the flat feature layout
-            # expected by gdp_attn without any explicit contiguous call.
-            key = rearrange(key, "b l m h n -> (b l) (m h n)")
-            query = rearrange(query, "b l h n -> (b l) (h n)")
-
         kernel_cu_seqlens = cu_seqlens_packed
         if self.config.gdp_cutedsl_kernel:
             # Packed input is rejected above. These offsets describe each row of
             # the rectangular batch as an independent fixed-length sequence.
-            kernel_batch_size, kernel_seq_len = zVKQba.shape[:2]
+            kernel_batch_size, kernel_seq_len = VKQ.shape[:2]
             kernel_cu_seqlens = torch.arange(
                 0,
                 (kernel_batch_size + 1) * kernel_seq_len,
                 kernel_seq_len,
-                device=zVKQba.device,
+                device=VKQ.device,
                 dtype=torch.int32,
             )
 
@@ -628,10 +574,13 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
             num_householder=self.num_householder,
             initial_state=None,
             output_final_state=(ssm_state is not None),
-            use_qk_l2norm_in_kernel=True,
+            use_qk_l2norm_in_kernel=self.config.gdp_cutedsl_kernel,
             cu_seqlens=kernel_cu_seqlens,
             **self.gdp_kernel_extra_kwargs,
         )
+
+        if qkv_checkpoint is not None:
+            qkv_checkpoint.discard_output_and_register_recompute(core_attn_out)
 
         if self.config.gdp_cutedsl_kernel:
             # Restore gdp_attn's [(b*l), (h*p)] output to the common layout
@@ -639,8 +588,8 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
             core_attn_out = rearrange(
                 core_attn_out,
                 "(b l) (h p) -> b l h p",
-                b=zVKQba.shape[0],
-                l=zVKQba.shape[1],
+                b=VKQ.shape[0],
+                l=VKQ.shape[1],
                 p=self.headdim,
             )
 
@@ -654,9 +603,93 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
             z = self.cp.post_conv_ssm(z, packed_seq_params=packed_seq_params)
             y = self.norm(y, z)
 
+        if in_proj_checkpoint is not None:
+            # out_proj's backward produces y's gradient before the normalization
+            # and GDP-kernel backwards consume z/VKQ, so this is the earliest safe
+            # point to restore all three discarded projection outputs.
+            in_proj_checkpoint.discard_output_and_register_recompute(y)
+
         out, out_bias = self.out_proj(y)
 
         return out, out_bias
+
+    def _in_proj_preprocess(self, hidden_states, packed_seq_params=None):
+        """Project, redistribute over CP, switch to batch-first layout, and split outputs."""
+        zVKQba, _ = self.in_proj(hidden_states)
+        zVKQba = self.cp.pre_conv_ssm(zVKQba, packed_seq_params=packed_seq_params)
+        zVKQba = rearrange(zVKQba, "l b d -> b l d").contiguous()
+        return torch.split(
+            zVKQba,
+            [
+                self.cp.d_inner_local_tpcp,
+                self.cp.d_inner_local_tpcp * self.num_householder
+                + (self.num_householder + 1) * self.cp.ngroups_local_tpcp * self.d_state,
+                self.cp.nheads_local_tpcp * (self.num_householder + 1),
+            ],
+            dim=-1,
+        )
+
+    def _prepare_qkv(self, x, seq_idx_packed=None):
+        """Run the causal convolution and build the selected GDP kernel's Q/K/V layouts."""
+        # The unpacked CuTeDSL kernel accepts the channel-last backing layout;
+        # FLA prefers channels-first. Packed causal-conv requires channel-last.
+        if seq_idx_packed is None and not self.config.gdp_cutedsl_kernel:
+            x = rearrange(x, "b l d -> b d l").contiguous()
+        else:
+            x = x.contiguous() if seq_idx_packed is not None else x
+            x = rearrange(x, "b l d -> b d l")
+
+        x = causal_conv1d_fn(
+            x=x,
+            weight=rearrange(self.cp.get_conv1d_weight(), "d 1 w -> d w"),
+            bias=self.cp.get_conv1d_bias(),
+            activation=self.activation,
+            seq_idx=seq_idx_packed,
+        )
+        x = rearrange(x, "b d l -> b l d").contiguous()
+
+        value, key, query = torch.split(
+            x,
+            [
+                self.cp.d_inner_local_tpcp * self.num_householder,
+                self.cp.ngroups_local_tpcp * self.d_state * self.num_householder,
+                self.cp.ngroups_local_tpcp * self.d_state,
+            ],
+            dim=-1,
+        )
+
+        if self.config.gdp_cutedsl_kernel:
+            value = rearrange(
+                value, "b l (m h p) -> (b l) (m h p)", m=self.num_householder, p=self.headdim
+            )
+            key = rearrange(
+                key, "b l (m g n) -> b l m g n", m=self.num_householder, n=self.d_state
+            )
+            query = rearrange(query, "b l (g n) -> b l g n", n=self.d_state)
+        else:
+            value = rearrange(
+                value, "b l (m h p) -> b (l m) h p", m=self.num_householder, p=self.headdim
+            ).contiguous()
+            key = rearrange(
+                key, "b l (m g n) -> b (l m) g n", m=self.num_householder, n=self.d_state
+            ).contiguous()
+            query = rearrange(query, "b l (g n) -> b l g n", n=self.d_state).contiguous()
+            query = l2_norm(query)
+            key = l2_norm(key)
+
+        if self.cp.nheads_local_tpcp // self.cp.ngroups_local_tpcp > 1:
+            query = query.repeat_interleave(
+                self.cp.nheads_local_tpcp // self.cp.ngroups_local_tpcp, dim=-2
+            )
+            key = key.repeat_interleave(
+                self.cp.nheads_local_tpcp // self.cp.ngroups_local_tpcp, dim=-2
+            )
+
+        if self.config.gdp_cutedsl_kernel:
+            key = rearrange(key, "b l m h n -> (b l) (m h n)")
+            query = rearrange(query, "b l h n -> (b l) (h n)")
+
+        return query, key, value
 
     # ==================================================================
     # Static / eager inference

--- a/megatron/core/ssm/gated_delta_product.py
+++ b/megatron/core/ssm/gated_delta_product.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the Apache license found in the
 # LICENSE file in the root directory of this source tree.
 
+import inspect
 import logging
 import math
 from dataclasses import dataclass, replace
@@ -77,10 +78,34 @@ try:
 
     HAVE_FLA = True
 except ImportError:
+    chunk_gated_delta_product = None
+    fused_recurrent_gated_delta_rule = None
     HAVE_FLA = False
+
+try:
+    from gdp_attn import chunk_gated_delta_product as cutedsl_chunk_gated_delta_product
+
+    HAVE_CUTEDSL_GDP = True
+except ImportError:
+    cutedsl_chunk_gated_delta_product = None
+    HAVE_CUTEDSL_GDP = False
 
 
 logger = logging.getLogger(__name__)
+
+
+def _kernel_accepts_kwarg(kernel, name: str) -> bool:
+    """Return True if `kernel` explicitly declares a keyword argument called `name`."""
+    try:
+        parameters = inspect.signature(kernel).parameters
+    except (TypeError, ValueError):
+        # Builtins / C extensions without introspectable signatures.
+        return False
+    parameter = parameters.get(name)
+    return parameter is not None and parameter.kind in (
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        inspect.Parameter.KEYWORD_ONLY,
+    )
 
 
 class ExtendedRMSNorm(RMSNormGated):
@@ -176,7 +201,10 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
                 "MambaSSM is not installed. Please install it with `pip install mamba-ssm`."
             )
 
-        if not HAVE_FLA:
+        if config.gdp_cutedsl_kernel:
+            if not HAVE_CUTEDSL_GDP:
+                raise ImportError("gdp_attn (CuTeDSL GatedDeltaProduct) is not installed")
+        elif not HAVE_FLA:
             raise ImportError("FLA is not installed")
 
         super().__init__(config)
@@ -191,6 +219,22 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
         assert ok, reason
 
         self.num_householder = config.gdp_num_householder
+
+        # Select the chunked kernel once. The recurrent FLA kernel remains the decode
+        # implementation, which is why the CuTeDSL path is rejected for decode below.
+        self.gdp_kernel = (
+            cutedsl_chunk_gated_delta_product
+            if config.gdp_cutedsl_kernel
+            else chunk_gated_delta_product
+        )
+
+        # Newer CuTeDSL kernel builds accept num_chunk_states_to_recompute; probe the
+        # signature once so older builds that predate the argument still work.
+        self.gdp_kernel_extra_kwargs = {}
+        if _kernel_accepts_kwarg(self.gdp_kernel, "num_chunk_states_to_recompute"):
+            self.gdp_kernel_extra_kwargs["num_chunk_states_to_recompute"] = (
+                config.gdp_num_chunk_states_to_recompute
+            )
 
         self.config = config
         self.d_model = d_model
@@ -384,11 +428,22 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
         packed_seq_params=None,
     ):
         """Run the gated delta product mixer on hidden states."""
+        inference_context = deprecate_inference_params(inference_context, inference_params)
+
         seq_len, batch_size, dim = hidden_states.shape
+
+        if self.config.gdp_cutedsl_kernel and packed_seq_params is not None:
+            raise NotImplementedError(
+                "--gdp-cutedsl-kernel currently supports unpacked sequences only."
+            )
 
         conv_state, ssm_state = None, None
         if inference_context is not None:
             if inference_context.is_dynamic_batching():
+                if self.config.gdp_cutedsl_kernel:
+                    raise NotImplementedError(
+                        "--gdp-cutedsl-kernel does not support dynamic inference."
+                    )
                 ok, reason = check_fla_sequence_packing_support()
                 assert ok, reason
                 assert (
@@ -403,6 +458,10 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
                 "GDP does not currently support packed sequences during inference. "
                 "Packing is only wired through the training/prefill (chunk) path."
             )
+            if self.config.gdp_cutedsl_kernel and inference_context.seqlen_offset > 0:
+                raise NotImplementedError(
+                    "--gdp-cutedsl-kernel supports static prefill but not decode."
+                )
             conv_state, ssm_state = self._get_states_from_cache(inference_context, batch_size)
             if inference_context.seqlen_offset > 0:
                 # The states are updated in place.
@@ -442,11 +501,17 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
             dim=-1,
         )
 
-        # ``causal_conv1d_fn`` expects a ``[B, D, L]`` tensor.
-        # But the expected memory layout varies depending on whether seq_idx is set.
+        # ``causal_conv1d_fn`` expects a ``[B, D, L]`` tensor. Its unpacked kernel
+        # supports both channels-first and channels-last memory layouts.
         if seq_idx_packed is None:
-            # Default path: channels-first contiguous, stride(2) == 1.
-            VKQ = rearrange(VKQ, "b l d -> b d l").contiguous()
+            if self.config.gdp_cutedsl_kernel:
+                # Keep the channel-last backing storage, stride(1) == 1. The conv
+                # output then becomes dense [B, L, D] after the transpose below,
+                # avoiding a full VKQ copy and downstream layout materializations.
+                VKQ = rearrange(VKQ, "b l d -> b d l")
+            else:
+                # Preserve the existing FLA path: channels-first, stride(2) == 1.
+                VKQ = rearrange(VKQ, "b l d -> b d l").contiguous()
         else:
             # ``causal_conv1d_fn(seq_idx=...)`` requires channels-last memory but [B, D, L]
             # logical shape. This keeps the channels contiguous in memory.
@@ -486,41 +551,98 @@ class GatedDeltaProductMixer(SSMDynamicInferenceMixin, MegatronModule):
         )
 
         z = rearrange(z, "b l (h p) -> b l h p", p=self.headdim).contiguous()
-        value = rearrange(
-            value, "b l (m h p) -> b (l m) h p", m=self.num_householder, p=self.headdim
-        ).contiguous()
-        key = rearrange(
-            key, "b l (m g n) -> b (l m) g n", m=self.num_householder, n=self.d_state
-        ).contiguous()
-        query = rearrange(query, "b l (g n) -> b l g n", n=self.d_state).contiguous()
+        if self.config.gdp_cutedsl_kernel:
+            # CuTeDSL consumes one row per token and keeps the Householder copies in
+            # the feature dimension. Avoid materializing the FLA-only b x (l*m)
+            # layouts and their contiguous copies.
+            value = rearrange(
+                value, "b l (m h p) -> (b l) (m h p)", m=self.num_householder, p=self.headdim
+            )
+            key = rearrange(
+                key,
+                "b l (m g n) -> b l m g n",
+                m=self.num_householder,
+                n=self.d_state,
+            )
+            query = rearrange(query, "b l (g n) -> b l g n", n=self.d_state)
+        else:
+            value = rearrange(
+                value, "b l (m h p) -> b (l m) h p", m=self.num_householder, p=self.headdim
+            ).contiguous()
+            key = rearrange(
+                key, "b l (m g n) -> b (l m) g n", m=self.num_householder, n=self.d_state
+            ).contiguous()
+            query = rearrange(query, "b l (g n) -> b l g n", n=self.d_state).contiguous()
 
-        b, a = b.contiguous(), a.contiguous()
+            # Preserve the existing FLA layout and stride contract exactly.
+            b, a = b.contiguous(), a.contiguous()
+
         beta = b.sigmoid()
-        beta = rearrange(beta, "b l (m h) -> b (l m) h", m=self.num_householder).contiguous()
 
         # If the model is loaded in fp16, without the .float() here, A might be -inf
         g = -self.cp.get_A_log().float().exp() * F.softplus(a.float() + self.cp.get_dt_bias())
 
+        if self.config.gdp_cutedsl_kernel:
+            # Flatten the pointwise outputs directly without requesting separate
+            # contiguous materializations.
+            beta = rearrange(beta, "b l d -> (b l) d")
+            g = rearrange(g, "b l h -> (b l) h")
+        else:
+            beta = rearrange(
+                beta, "b l (m h) -> b (l m) h", m=self.num_householder
+            ).contiguous()
+
         if self.cp.nheads_local_tpcp // self.cp.ngroups_local_tpcp > 1:
             query = query.repeat_interleave(
-                self.cp.nheads_local_tpcp // self.cp.ngroups_local_tpcp, dim=2
+                self.cp.nheads_local_tpcp // self.cp.ngroups_local_tpcp, dim=-2
             )
             key = key.repeat_interleave(
-                self.cp.nheads_local_tpcp // self.cp.ngroups_local_tpcp, dim=2
+                self.cp.nheads_local_tpcp // self.cp.ngroups_local_tpcp, dim=-2
             )
 
-        core_attn_out, last_recurrent_state = chunk_gated_delta_product(
-            query,
-            key,
-            value,
+        if self.config.gdp_cutedsl_kernel:
+            # GQA expansion is complete; collapse directly to the flat feature layout
+            # expected by gdp_attn without any explicit contiguous call.
+            key = rearrange(key, "b l m h n -> (b l) (m h n)")
+            query = rearrange(query, "b l h n -> (b l) (h n)")
+
+        kernel_cu_seqlens = cu_seqlens_packed
+        if self.config.gdp_cutedsl_kernel:
+            # Packed input is rejected above. These offsets describe each row of
+            # the rectangular batch as an independent fixed-length sequence.
+            kernel_batch_size, kernel_seq_len = zVKQba.shape[:2]
+            kernel_cu_seqlens = torch.arange(
+                0,
+                (kernel_batch_size + 1) * kernel_seq_len,
+                kernel_seq_len,
+                device=zVKQba.device,
+                dtype=torch.int32,
+            )
+
+        core_attn_out, last_recurrent_state = self.gdp_kernel(
+            q=query,
+            k=key,
+            v=value,
             g=g,
             beta=beta,
+            num_householder=self.num_householder,
             initial_state=None,
             output_final_state=(ssm_state is not None),
-            num_householder=self.num_householder,
             use_qk_l2norm_in_kernel=True,
-            cu_seqlens=cu_seqlens_packed,
+            cu_seqlens=kernel_cu_seqlens,
+            **self.gdp_kernel_extra_kwargs,
         )
+
+        if self.config.gdp_cutedsl_kernel:
+            # Restore gdp_attn's [(b*l), (h*p)] output to the common layout
+            # without requesting another contiguous materialization here.
+            core_attn_out = rearrange(
+                core_attn_out,
+                "(b l) (h p) -> b l h p",
+                b=zVKQba.shape[0],
+                l=zVKQba.shape[1],
+                p=self.headdim,
+            )
 
         if ssm_state is not None:
             ssm_state.copy_(last_recurrent_state)

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -553,7 +553,7 @@ class TransformerConfig(ModelParallelConfig):
     recompute_modules: Optional[List[str]] = None
     """The submodules to recompute.
     choices: "core_attn", "moe_act", "layernorm", "mla_up_proj", "mlp", "moe",
-    "shared_experts", "gdn_norm_out".
+    "shared_experts", "gdn_norm_out", "gdp_in_proj", "gdp_qkv".
     default: ["core_attn"].
     "core_attn": recompute the core attention part of the transformer layer.
     "moe_act": recompute the MoE MLP activation function.
@@ -563,8 +563,11 @@ class TransformerConfig(ModelParallelConfig):
     "moe": recompute the MoE layer.
     "shared_experts": recompute the shared experts in the MoE layer.
     "gdn_norm_out": recompute the GatedDeltaNet output norm and HP-to-CP all-to-all.
-    "moe_act", "layernorm", "mla_up_proj", and "gdn_norm_out" use output-discarding checkpointing,
-    "core_attn", "mlp", "moe", and "shared_experts" use normal checkpointing.
+    "gdp_in_proj": recompute the GatedDeltaProduct input projection and CP preprocessing.
+    "gdp_qkv": recompute the GatedDeltaProduct causal conv and QKV preparation.
+    "moe_act", "layernorm", "mla_up_proj", "gdn_norm_out", "gdp_in_proj", and "gdp_qkv"
+    use output-discarding checkpointing; "core_attn", "mlp", "moe", and "shared_experts" use
+    normal checkpointing.
     """
 
     ####################
@@ -1866,6 +1869,8 @@ class TransformerConfig(ModelParallelConfig):
                     "moe",
                     "shared_experts",
                     "gdn_norm_out",
+                    "gdp_in_proj",
+                    "gdp_qkv",
                 }
                 invalid_modules = set(self.recompute_modules) - allowed_modules
                 assert not invalid_modules, (

--- a/megatron/core/transformer/transformer_config.py
+++ b/megatron/core/transformer/transformer_config.py
@@ -1216,6 +1216,17 @@ class TransformerConfig(ModelParallelConfig):
     )
     """Controls usage of the memory efficient path for Mamba layers."""
 
+    gdp_cutedsl_kernel: bool = False
+    """Use the CuTeDSL GatedDeltaProduct kernel for unpacked training and static prefill."""
+
+    gdp_num_chunk_states_to_recompute: int = 2
+    """Checkpoint-coarsening ratio N in [0, 64] for the CuTeDSL GatedDeltaProduct kernel.
+    N=0 checkpoints every chunk state for the backward pass (dense, no recompute). N>=1
+    stores one checkpoint per group of N+1 chunks (1/(N+1) the checkpoint memory) and the
+    backward recomputes each group's N missing chunk states, trading recompute time for
+    activation memory monotonically in N (sweet spot N=2..3). Only honored by kernel
+    builds that expose the num_chunk_states_to_recompute argument."""
+
     mlp_chunks_for_prefill: int = 1
     """The number of chunks along the sequence dimension to use for MLP computation
     during prefill."""
@@ -1356,6 +1367,11 @@ class TransformerConfig(ModelParallelConfig):
         if self.gdp_num_householder < 1:
             raise ValueError(
                 f"gdp_num_householder must be positive, got {self.gdp_num_householder}."
+            )
+        if not 0 <= self.gdp_num_chunk_states_to_recompute <= 64:
+            raise ValueError(
+                "gdp_num_chunk_states_to_recompute must be in [0, 64], got "
+                f"{self.gdp_num_chunk_states_to_recompute}."
             )
 
         # Apply BF16 matmul precision setting if needed

--- a/tests/unit_tests/ssm/test_gdp_cutedsl.py
+++ b/tests/unit_tests/ssm/test_gdp_cutedsl.py
@@ -1,0 +1,397 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Tests for the optional CuTeDSL GatedDeltaProduct chunk kernel."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from megatron.core import parallel_state
+from megatron.core.inference.contexts.static_context import StaticInferenceContext
+from megatron.core.inference.utils import InferenceMode
+from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.ssm import gated_delta_product as gdp_module
+from megatron.core.ssm.gated_delta_product import (
+    GatedDeltaProductMixer,
+    GatedDeltaProductMixerSubmodules,
+)
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.transformer import TransformerConfig
+from tests.unit_tests.test_utilities import Utils
+
+try:
+    import causal_conv1d  # noqa: F401
+    import einops  # noqa: F401
+    import fla  # noqa: F401
+    import gdp_attn  # noqa: F401
+    import mamba_ssm  # noqa: F401
+
+    HAVE_GDP_KERNELS = True
+except ImportError:
+    HAVE_GDP_KERNELS = False
+
+
+class _IdentityProjection(torch.nn.Module):
+    """Return a fixed projected tensor while preserving the mixer call contract."""
+
+    def __init__(self, projected: torch.Tensor):
+        super().__init__()
+        self.projected = projected
+
+    def forward(self, _hidden_states):
+        return self.projected, None
+
+
+class _IdentityOutputProjection(torch.nn.Module):
+    def forward(self, hidden_states):
+        return hidden_states, None
+
+
+class _FakeContextParallel:
+    def __init__(self, *, d_inner: int, nheads: int, ngroups: int):
+        self.d_inner_local_tpcp = d_inner
+        self.nheads_local_tpcp = nheads
+        self.ngroups_local_tpcp = ngroups
+        self.cp_size = 1
+
+    def pre_conv_ssm(self, tensor, packed_seq_params=None):
+        del packed_seq_params
+        return tensor
+
+    def post_conv_ssm(self, tensor, packed_seq_params=None):
+        del packed_seq_params
+        return tensor
+
+    def get_conv1d_weight(self):
+        return self.conv_weight
+
+    def get_conv1d_bias(self):
+        return None
+
+    def get_A_log(self):
+        return self.a_log
+
+    def get_dt_bias(self):
+        return self.dt_bias
+
+
+def _make_dispatch_mixer(*, cutedsl: bool, projected: torch.Tensor):
+    """Build only the mixer state needed to exercise the chunk-kernel dispatch."""
+    nheads, ngroups, d_state, headdim, num_householder = 4, 2, 3, 2, 3
+    d_inner = nheads * headdim
+    conv_dim = d_inner * num_householder + ngroups * d_state * (num_householder + 1)
+
+    mixer = GatedDeltaProductMixer.__new__(GatedDeltaProductMixer)
+    torch.nn.Module.__init__(mixer)
+    mixer.config = SimpleNamespace(gdp_cutedsl_kernel=cutedsl, sequence_parallel=False)
+    mixer.gdp_kernel_extra_kwargs = (
+        {"num_chunk_states_to_recompute": 2} if cutedsl else {}
+    )
+    mixer.num_householder = num_householder
+    mixer.d_state = d_state
+    mixer.headdim = headdim
+    mixer.rmsnorm = False
+    mixer.activation = "silu"
+    mixer.in_proj = _IdentityProjection(projected.transpose(0, 1))
+    mixer.out_proj = _IdentityOutputProjection()
+    mixer.conv1d = SimpleNamespace(weight=torch.empty(conv_dim, 1, 1), bias=None)
+
+    mixer.cp = _FakeContextParallel(d_inner=d_inner, nheads=nheads, ngroups=ngroups)
+    mixer.cp.conv_weight = mixer.conv1d.weight
+    mixer.cp.a_log = torch.zeros(nheads)
+    mixer.cp.dt_bias = torch.zeros(nheads)
+    return mixer
+
+
+@pytest.mark.parametrize("cutedsl", [False, True])
+def test_chunk_kernel_dispatch_layouts(monkeypatch, cutedsl):
+    """The CuTeDSL path uses flat token rows while FLA retains its batched layout."""
+    batch_size, seq_len = 2, 5
+    nheads, ngroups, d_state, headdim, num_householder = 4, 2, 3, 2, 3
+    d_inner = nheads * headdim
+    projected_dim = (
+        d_inner * (1 + num_householder)
+        + ngroups * d_state * (num_householder + 1)
+        + nheads * (num_householder + 1)
+    )
+    projected = torch.randn(batch_size, seq_len, projected_dim)
+    mixer = _make_dispatch_mixer(cutedsl=cutedsl, projected=projected)
+
+    # Isolate GDP layout/dispatch from causal-convolution numerics while retaining
+    # the input strides so the CuTeDSL channel-last contract is covered.
+    captured_conv = {}
+
+    def fake_causal_conv1d(**kwargs):
+        captured_conv.update(kwargs)
+        return kwargs["x"]
+
+    monkeypatch.setattr(gdp_module, "causal_conv1d_fn", fake_causal_conv1d)
+
+    captured = {}
+
+    def fake_kernel(**kwargs):
+        captured.update(kwargs)
+        if cutedsl:
+            output = torch.arange(batch_size * seq_len * d_inner, dtype=torch.float32).reshape(
+                batch_size * seq_len, d_inner
+            )
+        else:
+            output = torch.arange(batch_size * seq_len * d_inner, dtype=torch.float32).reshape(
+                batch_size, seq_len, nheads, headdim
+            )
+        return output, None
+
+    mixer.gdp_kernel = fake_kernel
+    hidden_states = torch.empty(seq_len, batch_size, 1)
+    output, output_bias = mixer(hidden_states)
+
+    assert output.shape == (seq_len, batch_size, d_inner)
+    assert output_bias is None
+    assert captured["use_qk_l2norm_in_kernel"] is True
+    assert captured["num_householder"] == num_householder
+
+    if cutedsl:
+        assert captured["num_chunk_states_to_recompute"] == 2
+        assert captured_conv["x"].stride(1) == 1
+        assert not captured_conv["x"].is_contiguous()
+        assert (
+            captured_conv["x"].untyped_storage().data_ptr()
+            == projected.untyped_storage().data_ptr()
+        )
+        assert captured["q"].shape == (batch_size * seq_len, nheads * d_state)
+        assert captured["k"].shape == (
+            batch_size * seq_len,
+            num_householder * nheads * d_state,
+        )
+        assert captured["v"].shape == (
+            batch_size * seq_len,
+            num_householder * nheads * headdim,
+        )
+        assert captured["beta"].shape == (
+            batch_size * seq_len,
+            num_householder * nheads,
+        )
+        assert captured["g"].shape == (batch_size * seq_len, nheads)
+        torch.testing.assert_close(
+            captured["cu_seqlens"], torch.tensor([0, seq_len, 2 * seq_len], dtype=torch.int32)
+        )
+    else:
+        assert "num_chunk_states_to_recompute" not in captured
+        assert captured_conv["x"].stride(2) == 1
+        assert captured_conv["x"].is_contiguous()
+        assert (
+            captured_conv["x"].untyped_storage().data_ptr()
+            != projected.untyped_storage().data_ptr()
+        )
+        assert captured["q"].shape == (batch_size, seq_len, nheads, d_state)
+        assert captured["k"].shape == (
+            batch_size,
+            seq_len * num_householder,
+            nheads,
+            d_state,
+        )
+        assert captured["v"].shape == (
+            batch_size,
+            seq_len * num_householder,
+            nheads,
+            headdim,
+        )
+        assert captured["beta"].shape == (
+            batch_size,
+            seq_len * num_householder,
+            nheads,
+        )
+        assert captured["g"].shape == (batch_size, seq_len, nheads)
+        assert captured["cu_seqlens"] is None
+
+
+def _make_guard_mixer():
+    mixer = GatedDeltaProductMixer.__new__(GatedDeltaProductMixer)
+    torch.nn.Module.__init__(mixer)
+    mixer.config = SimpleNamespace(gdp_cutedsl_kernel=True, sequence_parallel=False)
+    return mixer
+
+
+def test_cutedsl_rejects_packed_sequences():
+    mixer = _make_guard_mixer()
+    with pytest.raises(NotImplementedError, match="unpacked sequences only"):
+        mixer(torch.empty(1, 1, 1), packed_seq_params=object())
+
+
+def test_cutedsl_rejects_dynamic_inference():
+    mixer = _make_guard_mixer()
+    context = SimpleNamespace(is_dynamic_batching=lambda: True)
+    with pytest.raises(NotImplementedError, match="dynamic inference"):
+        mixer(torch.empty(1, 1, 1), inference_context=context)
+
+
+def test_cutedsl_rejects_static_decode():
+    mixer = _make_guard_mixer()
+    context = SimpleNamespace(
+        is_dynamic_batching=lambda: False,
+        is_static_batching=lambda: True,
+        seqlen_offset=1,
+    )
+    with pytest.raises(NotImplementedError, match="static prefill but not decode"):
+        mixer(torch.empty(1, 1, 1), inference_context=context)
+
+
+def _make_real_config(*, cutedsl: bool, chunk_states_to_recompute: int = 2) -> TransformerConfig:
+    # Match the production GDP head/state specialization while keeping the unit-test model small.
+    return TransformerConfig(
+        num_layers=1,
+        hidden_size=512,
+        num_attention_heads=8,
+        num_query_groups=8,
+        ffn_hidden_size=1024,
+        normalization="RMSNorm",
+        bf16=True,
+        mamba_num_heads=8,
+        mamba_head_dim=64,
+        mamba_num_groups=8,
+        mamba_state_dim=128,
+        tensor_model_parallel_size=1,
+        sequence_parallel=False,
+        context_parallel_size=1,
+        gdp_cutedsl_kernel=cutedsl,
+        gdp_num_chunk_states_to_recompute=chunk_states_to_recompute,
+    )
+
+
+def _build_real_mixer(*, cutedsl: bool, chunk_states_to_recompute: int = 2):
+    from megatron.core.extensions.transformer_engine import (
+        TELayerNormColumnParallelLinear,
+        TERowParallelLinear,
+    )
+
+    config = _make_real_config(
+        cutedsl=cutedsl, chunk_states_to_recompute=chunk_states_to_recompute
+    )
+    submodules = GatedDeltaProductMixerSubmodules(
+        in_proj=TELayerNormColumnParallelLinear, out_proj=TERowParallelLinear
+    )
+    pg_collection = ProcessGroupCollection(
+        tp=parallel_state.get_tensor_model_parallel_group(),
+        cp=parallel_state.get_context_parallel_group(),
+    )
+    mixer = GatedDeltaProductMixer(
+        config=config,
+        submodules=submodules,
+        d_model=config.hidden_size,
+        layer_number=1,
+        pg_collection=pg_collection,
+    )
+    return mixer.cuda().bfloat16()
+
+
+@pytest.mark.internal
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+@pytest.mark.skipif(not HAVE_GDP_KERNELS, reason="requires FLA, gdp_attn, and Mamba dependencies")
+class TestGDPCuTeDSLParity:
+    @pytest.fixture(autouse=True)
+    def setup_model_parallel(self):
+        Utils.initialize_model_parallel(
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+            context_parallel_size=1,
+        )
+        model_parallel_cuda_manual_seed(123)
+        yield
+        Utils.destroy_model_parallel()
+
+    def _build_pair(self):
+        fla_mixer = _build_real_mixer(cutedsl=False)
+        cutedsl_mixer = _build_real_mixer(cutedsl=True)
+        cutedsl_mixer.load_state_dict(fla_mixer.state_dict())
+        return fla_mixer, cutedsl_mixer
+
+    def _build_recompute_pair(self):
+        no_recompute = _build_real_mixer(cutedsl=True, chunk_states_to_recompute=0)
+        recompute_two = _build_real_mixer(cutedsl=True, chunk_states_to_recompute=2)
+        recompute_two.load_state_dict(no_recompute.state_dict())
+        return no_recompute, recompute_two
+
+    def test_unpacked_training_forward_backward_parity(self):
+        fla_mixer, cutedsl_mixer = self._build_pair()
+        fla_mixer.train()
+        cutedsl_mixer.train()
+
+        hidden = torch.randn(32, 2, 512, device="cuda", dtype=torch.bfloat16)
+        hidden_fla = hidden.detach().clone().requires_grad_()
+        hidden_cutedsl = hidden.detach().clone().requires_grad_()
+
+        output_fla, _ = fla_mixer(hidden_fla)
+        output_cutedsl, _ = cutedsl_mixer(hidden_cutedsl)
+        torch.testing.assert_close(output_cutedsl, output_fla, rtol=5e-2, atol=5e-2)
+
+        output_grad = torch.randn_like(output_fla)
+        output_fla.backward(output_grad)
+        output_cutedsl.backward(output_grad)
+        torch.testing.assert_close(hidden_cutedsl.grad, hidden_fla.grad, rtol=5e-2, atol=5e-2)
+
+        fla_parameters = dict(fla_mixer.named_parameters())
+        cutedsl_parameters = dict(cutedsl_mixer.named_parameters())
+        for name in ("in_proj.weight", "conv1d.weight", "dt_bias", "A_log", "out_proj.weight"):
+            torch.testing.assert_close(
+                cutedsl_parameters[name].grad,
+                fla_parameters[name].grad,
+                rtol=5e-2,
+                atol=7e-2,
+                msg=name,
+            )
+
+    def test_chunk_state_recompute_forward_backward_parity(self):
+        no_recompute, recompute_two = self._build_recompute_pair()
+        no_recompute.train()
+        recompute_two.train()
+
+        # Exercise multiple GDP chunks so the recomputed boundary states affect backward.
+        hidden = torch.randn(256, 2, 512, device="cuda", dtype=torch.bfloat16)
+        hidden_no_recompute = hidden.detach().clone().requires_grad_()
+        hidden_recompute_two = hidden.detach().clone().requires_grad_()
+
+        output_no_recompute, _ = no_recompute(hidden_no_recompute)
+        output_recompute_two, _ = recompute_two(hidden_recompute_two)
+        torch.testing.assert_close(
+            output_recompute_two, output_no_recompute, rtol=1e-2, atol=1e-2
+        )
+
+        output_grad = torch.randn_like(output_no_recompute)
+        output_no_recompute.backward(output_grad)
+        output_recompute_two.backward(output_grad)
+        torch.testing.assert_close(
+            hidden_recompute_two.grad, hidden_no_recompute.grad, rtol=1e-2, atol=1e-2
+        )
+
+        no_recompute_parameters = dict(no_recompute.named_parameters())
+        recompute_two_parameters = dict(recompute_two.named_parameters())
+        for name in ("in_proj.weight", "conv1d.weight", "dt_bias", "A_log", "out_proj.weight"):
+            torch.testing.assert_close(
+                recompute_two_parameters[name].grad,
+                no_recompute_parameters[name].grad,
+                rtol=1e-2,
+                atol=1e-2,
+            )
+
+    def test_static_prefill_output_and_state_parity(self):
+        fla_mixer, cutedsl_mixer = self._build_pair()
+        fla_mixer.eval()
+        cutedsl_mixer.eval()
+        hidden = torch.randn(32, 2, 512, device="cuda", dtype=torch.bfloat16)
+
+        fla_context = StaticInferenceContext(max_batch_size=2, max_sequence_length=33)
+        cutedsl_context = StaticInferenceContext(max_batch_size=2, max_sequence_length=33)
+        # HybridBlock normally maintains this compatibility alias.
+        fla_context.seqlen_offset = 0
+        cutedsl_context.seqlen_offset = 0
+
+        with torch.no_grad(), InferenceMode.active():
+            output_fla, _ = fla_mixer(hidden, inference_context=fla_context)
+            output_cutedsl, _ = cutedsl_mixer(hidden, inference_context=cutedsl_context)
+
+        torch.testing.assert_close(output_cutedsl, output_fla, rtol=5e-2, atol=5e-2)
+        fla_conv_state, fla_ssm_state = fla_context.key_value_memory_dict[1]
+        cutedsl_conv_state, cutedsl_ssm_state = cutedsl_context.key_value_memory_dict[1]
+        torch.testing.assert_close(cutedsl_conv_state, fla_conv_state)
+        torch.testing.assert_close(cutedsl_ssm_state, fla_ssm_state, rtol=5e-2, atol=5e-2)

--- a/tests/unit_tests/ssm/test_gdp_cutedsl.py
+++ b/tests/unit_tests/ssm/test_gdp_cutedsl.py
@@ -93,6 +93,8 @@ def _make_dispatch_mixer(*, cutedsl: bool, projected: torch.Tensor):
     mixer.headdim = headdim
     mixer.rmsnorm = False
     mixer.activation = "silu"
+    mixer.recompute_in_proj = False
+    mixer.recompute_qkv = False
     mixer.in_proj = _IdentityProjection(projected.transpose(0, 1))
     mixer.out_proj = _IdentityOutputProjection()
     mixer.conv1d = SimpleNamespace(weight=torch.empty(conv_dim, 1, 1), bias=None)
@@ -127,6 +129,7 @@ def test_chunk_kernel_dispatch_layouts(monkeypatch, cutedsl):
         return kwargs["x"]
 
     monkeypatch.setattr(gdp_module, "causal_conv1d_fn", fake_causal_conv1d)
+    monkeypatch.setattr(gdp_module, "l2_norm", lambda tensor: tensor)
 
     captured = {}
 
@@ -148,7 +151,7 @@ def test_chunk_kernel_dispatch_layouts(monkeypatch, cutedsl):
 
     assert output.shape == (seq_len, batch_size, d_inner)
     assert output_bias is None
-    assert captured["use_qk_l2norm_in_kernel"] is True
+    assert captured["use_qk_l2norm_in_kernel"] is cutedsl
     assert captured["num_householder"] == num_householder
 
     if cutedsl:
@@ -237,7 +240,12 @@ def test_cutedsl_rejects_static_decode():
         mixer(torch.empty(1, 1, 1), inference_context=context)
 
 
-def _make_real_config(*, cutedsl: bool, chunk_states_to_recompute: int = 2) -> TransformerConfig:
+def _make_real_config(
+    *,
+    cutedsl: bool,
+    chunk_states_to_recompute: int = 2,
+    recompute_modules: list[str] | None = None,
+) -> TransformerConfig:
     # Match the production GDP head/state specialization while keeping the unit-test model small.
     return TransformerConfig(
         num_layers=1,
@@ -256,17 +264,26 @@ def _make_real_config(*, cutedsl: bool, chunk_states_to_recompute: int = 2) -> T
         context_parallel_size=1,
         gdp_cutedsl_kernel=cutedsl,
         gdp_num_chunk_states_to_recompute=chunk_states_to_recompute,
+        recompute_granularity="selective" if recompute_modules else None,
+        recompute_modules=recompute_modules,
     )
 
 
-def _build_real_mixer(*, cutedsl: bool, chunk_states_to_recompute: int = 2):
+def _build_real_mixer(
+    *,
+    cutedsl: bool,
+    chunk_states_to_recompute: int = 2,
+    recompute_modules: list[str] | None = None,
+):
     from megatron.core.extensions.transformer_engine import (
         TELayerNormColumnParallelLinear,
         TERowParallelLinear,
     )
 
     config = _make_real_config(
-        cutedsl=cutedsl, chunk_states_to_recompute=chunk_states_to_recompute
+        cutedsl=cutedsl,
+        chunk_states_to_recompute=chunk_states_to_recompute,
+        recompute_modules=recompute_modules,
     )
     submodules = GatedDeltaProductMixerSubmodules(
         in_proj=TELayerNormColumnParallelLinear, out_proj=TERowParallelLinear
@@ -311,6 +328,12 @@ class TestGDPCuTeDSLParity:
         recompute_two = _build_real_mixer(cutedsl=True, chunk_states_to_recompute=2)
         recompute_two.load_state_dict(no_recompute.state_dict())
         return no_recompute, recompute_two
+
+    def _build_selective_recompute_pair(self, module: str):
+        no_recompute = _build_real_mixer(cutedsl=False)
+        recompute = _build_real_mixer(cutedsl=False, recompute_modules=[module])
+        recompute.load_state_dict(no_recompute.state_dict())
+        return no_recompute, recompute
 
     def test_unpacked_training_forward_backward_parity(self):
         fla_mixer, cutedsl_mixer = self._build_pair()
@@ -369,6 +392,37 @@ class TestGDPCuTeDSLParity:
         for name in ("in_proj.weight", "conv1d.weight", "dt_bias", "A_log", "out_proj.weight"):
             torch.testing.assert_close(
                 recompute_two_parameters[name].grad,
+                no_recompute_parameters[name].grad,
+                rtol=1e-2,
+                atol=1e-2,
+            )
+
+    @pytest.mark.parametrize("module", ["gdp_in_proj", "gdp_qkv"])
+    def test_selective_recompute_forward_backward_parity(self, module):
+        no_recompute, recompute = self._build_selective_recompute_pair(module)
+        no_recompute.train()
+        recompute.train()
+
+        hidden = torch.randn(32, 2, 512, device="cuda", dtype=torch.bfloat16)
+        hidden_no_recompute = hidden.detach().clone().requires_grad_()
+        hidden_recompute = hidden.detach().clone().requires_grad_()
+
+        output_no_recompute, _ = no_recompute(hidden_no_recompute)
+        output_recompute, _ = recompute(hidden_recompute)
+        torch.testing.assert_close(output_recompute, output_no_recompute, rtol=1e-2, atol=1e-2)
+
+        output_grad = torch.randn_like(output_no_recompute)
+        output_no_recompute.backward(output_grad)
+        output_recompute.backward(output_grad)
+        torch.testing.assert_close(
+            hidden_recompute.grad, hidden_no_recompute.grad, rtol=1e-2, atol=1e-2
+        )
+
+        no_recompute_parameters = dict(no_recompute.named_parameters())
+        recompute_parameters = dict(recompute.named_parameters())
+        for name in ("in_proj.weight", "conv1d.weight", "dt_bias", "A_log", "out_proj.weight"):
+            torch.testing.assert_close(
+                recompute_parameters[name].grad,
                 no_recompute_parameters[name].grad,
                 rtol=1e-2,
                 atol=1e-2,

--- a/tests/unit_tests/transformer/test_transformer_config.py
+++ b/tests/unit_tests/transformer/test_transformer_config.py
@@ -55,3 +55,26 @@ def test_gdp_num_householder_rejects_non_positive_values(num_householder: int):
             num_attention_heads=4,
             gdp_num_householder=num_householder,
         )
+
+
+@pytest.mark.parametrize("num_chunk_states", [0, 2, 64])
+def test_gdp_chunk_state_recompute_accepts_supported_values(num_chunk_states: int):
+    config = TransformerConfig(
+        num_layers=1,
+        hidden_size=128,
+        num_attention_heads=4,
+        gdp_num_chunk_states_to_recompute=num_chunk_states,
+    )
+
+    assert config.gdp_num_chunk_states_to_recompute == num_chunk_states
+
+
+@pytest.mark.parametrize("num_chunk_states", [-1, 65])
+def test_gdp_chunk_state_recompute_rejects_unsupported_values(num_chunk_states: int):
+    with pytest.raises(ValueError, match="must be in \\[0, 64\\]"):
+        TransformerConfig(
+            num_layers=1,
+            hidden_size=128,
+            num_attention_heads=4,
+            gdp_num_chunk_states_to_recompute=num_chunk_states,
+        )


### PR DESCRIPTION
## What changed

- add output-discarding selective recompute for the GDP input projection / context-parallel preprocessing
- add output-discarding selective recompute for causal-convolution and QKV preparation
- preserve packed-sequence, inference, FLA, and CuTeDSL behavior
- keep recomputation opt-in through separate configuration fields

## Why

GDP activation memory is large enough to constrain the production configuration. The selected QKV recompute point releases the projected QKV intermediates while adding only the causal-convolution/QKV preparation work during backward.

In the controlled 5-node / 20-GPU proxy, QKV recompute saved approximately 1.55–1.70 GB of peak allocated memory per LLM rank. Combined with the selected CuTeDSL configuration, it added about 3.1 ms at p75 while retaining the much larger CuTeDSL tail reduction.

## Dependency

This draft is stacked on #6574. The second commit is the selective-recompute change; the first commit is the CuTeDSL prerequisite. It will be rebased onto `main` after #6574 lands.

## Validation

- CMH1, exact upstream-based signed stacked commit: `24 passed`
  - `tests/unit_tests/ssm/test_gdp_cutedsl.py`
  - `tests/unit_tests/transformer/test_transformer_config.py`
- direct forward/backward parity for both `gdp_in_proj` and `gdp_qkv`
- CuTeDSL and FLA dispatch normalization contract
- downstream 5-node / 20-GPU combined training run completed with all ranks and strict trace validation