### PR TITLE
docs(version-picker): preserve 0.19.0 and add patch releases

### DIFF
--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -11,14 +11,29 @@
         "preferred": true
     },
     {
+        "name": "0.18.2",
+        "version": "0.18.2",
+        "url": "https://docs.nvidia.com/megatron-core/developer-guide/0.18.2/"
+    },
+    {
         "name": "0.18.0",
         "version": "0.18.0",
         "url": "https://docs.nvidia.com/megatron-core/developer-guide/0.18.0/"
     },
     {
+        "name": "0.17.1",
+        "version": "0.17.1",
+        "url": "https://docs.nvidia.com/megatron-core/developer-guide/0.17.1/"
+    },
+    {
         "name": "0.17.0",
         "version": "0.17.0",
         "url": "https://docs.nvidia.com/megatron-core/developer-guide/0.17.0/"
+    },
+    {
+        "name": "0.16.1",
+        "version": "0.16.1",
+        "url": "https://docs.nvidia.com/megatron-core/developer-guide/0.16.1/"
     },
     {
         "name": "0.16.0",


### PR DESCRIPTION
## Background / motivation

- `docs/conf.py` sets `json_url: "../versions1.json"`, so the switcher on every published version loads one shared file at the docs-site root: `https://docs.nvidia.com/megatron-core/developer-guide/versions1.json`.
- The 0.19.0 docs release is scheduled for later today. Its picker entry must remain in the source file used by the release publication even though the versioned URL is not live yet.
- Three published patch releases are absent from the picker: 0.16.1, 0.17.1, and 0.18.2.

## What changed

- Preserve 0.19.0 as the preferred latest release and keep its `/latest/` URL.
- Add the published 0.18.2, 0.17.1, and 0.16.1 releases.
- Point the historical stable releases to their own versioned paths.

## Details

- `docs/conf.py` remains unchanged: `main` publishes nightly docs, so `release = "nightly"` and `project.json` remain correct.
- The preferred 0.19.0 entry intentionally follows the `/latest/` alias, which `overwrite-latest-on-tag` will repoint during today's release publication.
- 0.15.1, 0.15.2, and 0.15.3 remain omitted because their versioned docs were never published.

## Tested

- `python -m json.tool docs/versions1.json`
- Python audit: exactly one preferred entry (`0.19.0`), no duplicate versions, and order `nightly, 0.19.0, 0.18.2, 0.18.0, 0.17.1, 0.17.0, 0.16.1, 0.16.0, 0.15.0`.
- `git diff --check upstream/main...HEAD`
- Live URL probes: `/latest/`, 0.15.0, 0.16.0, 0.16.1, 0.17.0, 0.17.1, 0.18.0, and 0.18.2 returned HTTP 200.
