### PR TITLE
docs: link the 0.19.0 picker entry to its own path and add patch releases

### DIFF
--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -7,8 +7,13 @@
     {
         "name": "0.19.0 (latest)",
         "version": "0.19.0",
-        "url": "https://docs.nvidia.com/megatron-core/developer-guide/latest/",
+        "url": "https://docs.nvidia.com/megatron-core/developer-guide/0.19.0/",
         "preferred": true
+    },
+    {
+        "name": "0.18.2",
+        "version": "0.18.2",
+        "url": "https://docs.nvidia.com/megatron-core/developer-guide/0.18.2/"
     },
     {
         "name": "0.18.0",
@@ -16,9 +21,19 @@
         "url": "https://docs.nvidia.com/megatron-core/developer-guide/0.18.0/"
     },
     {
+        "name": "0.17.1",
+        "version": "0.17.1",
+        "url": "https://docs.nvidia.com/megatron-core/developer-guide/0.17.1/"
+    },
+    {
         "name": "0.17.0",
         "version": "0.17.0",
         "url": "https://docs.nvidia.com/megatron-core/developer-guide/0.17.0/"
+    },
+    {
+        "name": "0.16.1",
+        "version": "0.16.1",
+        "url": "https://docs.nvidia.com/megatron-core/developer-guide/0.16.1/"
     },
     {
         "name": "0.16.0",


### PR DESCRIPTION
## Background / motivation

- `docs/conf.py` sets `json_url: "../versions1.json"` (#4367), so all published versions share **one** picker at the docs-site root. Whichever branch publishes last with `update-version-picker: true` owns that file — so this branch's copy becomes the switcher for every version the moment 0.19.0's docs are published.
- The `0.19.0` entry currently links to the `/latest/` alias. `/latest/` is repointed by `overwrite-latest-on-tag` on each release and today serves **0.18.0**, so the entry labelled 0.19.0 does not resolve to 0.19.0 docs.
- Three published patch releases are missing from the picker: `0.16.1`, `0.17.1`, `0.18.2`.

## What changed

- `docs/versions1.json`: `0.19.0` now links to `/0.19.0/` instead of `/latest/`; it keeps `(latest)` and `preferred`, since this is the 0.19.0 release branch.
- `docs/versions1.json`: add `0.18.2`, `0.17.1`, `0.16.1`.

## Details

- `docs/conf.py` (`release = "0.19.0"`) and `docs/project.json` already carry `0.19.0` and are untouched. `version_match` resolves against the `0.19.0` entry.
- `/0.19.0/` is a 404 today — by construction. This file is uploaded **by** the 0.19.0 publish, so the path exists the moment the picker referencing it goes live.
- Every other entry URL was verified to return 200. `0.15.1` / `0.15.2` / `0.15.3` are omitted: tagged, but their docs were never published (404).

```json
// docs/versions1.json (excerpt)
{
    "name": "0.19.0 (latest)",
    "version": "0.19.0",
    "url": "https://docs.nvidia.com/megatron-core/developer-guide/0.19.0/",
    "preferred": true
},
{
    "name": "0.18.2",
    "version": "0.18.2",
    "url": "https://docs.nvidia.com/megatron-core/developer-guide/0.18.2/"
}
```

## Tested

- `json.load` parses; exactly one `preferred` (`0.19.0`); order `nightly, 0.19.0, 0.18.2, 0.18.0, 0.17.1, 0.17.0, 0.16.1, 0.16.0, 0.15.0`.
- Live probe of every entry: all **200** except `/0.19.0/`, which is this branch's own not-yet-published path.
- `release = "0.19.0"` matches the `0.19.0` entry.
