### PR TITLE
docs: identify this branch's docs as 0.18.2 and fix the version picker

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ import sys
 project = "Megatron Core"
 copyright = "2026, NVIDIA Corporation"
 author = "NVIDIA Corporation"
-release = "0.18.0"
+release = "0.18.2"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/project.json
+++ b/docs/project.json
@@ -1,2 +1,2 @@
-{"name": "megatron-lm", "version": "0.18.0"}
+{"name": "megatron-lm", "version": "0.18.2"}
 

--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -5,14 +5,30 @@
         "url": "https://docs.nvidia.com/megatron-core/developer-guide/nightly/"
     },
     {
-        "name": "0.18.0 (latest)",
+        "name": "0.18.2 (latest)",
+        "version": "0.18.2",
+        "url": "https://docs.nvidia.com/megatron-core/developer-guide/0.18.2/",
+        "preferred": true
+    },
+    {
+        "name": "0.18.0",
         "version": "0.18.0",
-        "url": "https://docs.nvidia.com/megatron-core/developer-guide/latest/"
+        "url": "https://docs.nvidia.com/megatron-core/developer-guide/0.18.0/"
+    },
+    {
+        "name": "0.17.1",
+        "version": "0.17.1",
+        "url": "https://docs.nvidia.com/megatron-core/developer-guide/0.17.1/"
     },
     {
         "name": "0.17.0",
         "version": "0.17.0",
         "url": "https://docs.nvidia.com/megatron-core/developer-guide/0.17.0/"
+    },
+    {
+        "name": "0.16.1",
+        "version": "0.16.1",
+        "url": "https://docs.nvidia.com/megatron-core/developer-guide/0.16.1/"
     },
     {
         "name": "0.16.0",


### PR DESCRIPTION
## Background / motivation

- `core_v0.18.2` was tagged and its docs published to `…/developer-guide/0.18.2/`, but `docs/conf.py` and `docs/project.json` on this branch were never bumped past `0.18.0`. The published tree therefore identifies itself as 0.18.0 — `https://docs.nvidia.com/megatron-core/developer-guide/0.18.2/project.json` returns `{"name": "megatron-lm", "version": "0.18.0"}`.
- `docs/conf.py` feeds `release` into `html_theme_options.switcher.version_match`, so the 0.18.2 docs ask the switcher to highlight `0.18.0`.
- This branch's picker has **no `preferred` entry at all** — and it is the file currently live at the shared root (`…/developer-guide/versions1.json`, uploaded by the last 0.18.x publish), so *no* version of the docs currently has a stable version to anchor on.
- `0.16.1`, `0.17.1` and `0.18.2` are published but absent from the switcher.

## What changed

- `docs/conf.py`: `release` `0.18.0` → `0.18.2`.
- `docs/project.json`: `version` `0.18.0` → `0.18.2`.
- `docs/versions1.json`: add `0.18.2` (marked `(latest)` + `preferred`), `0.17.1`, `0.16.1`; repoint the newest entry off the `/latest/` alias onto its versioned path.

## Details

- Since `json_url` is `../versions1.json` (#4367), the picker is shared site-wide; this branch's copy is what a 0.18.x re-publish uploads to the root. Getting it right here is what fixes the switcher for **all** versions, including the 0.15.x/0.16.x trees, without re-publishing those.
- `preferred` is set to `0.18.2` — the newest tag — rather than to this branch's older releases, so the theme's notion of "latest" is correct no matter which tree the reader is on.
- Entries link to versioned paths, not `/latest/`: that alias is repointed by `overwrite-latest-on-tag` on every release, which is how the `0.18.0 (latest)` entry ended up aimed at content that will change under it.
- The fix reaches the site only when the 0.18.x docs are re-published (`Release docs` with `update-version-picker: true`); merging alone changes nothing live.

```python
# docs/conf.py (excerpt)
release = "0.18.2"
```

## Tested

- `json.load` parses; exactly one `preferred` (`0.18.2`); order `nightly, 0.18.2, 0.18.0, 0.17.1, 0.17.0, 0.16.1, 0.16.0, 0.15.0`.
- `release = "0.18.2"` now matches a picker entry, so `version_match` resolves for the 0.18.2 tree.
- Every entry URL probed live → **200**. `0.15.1/0.15.2/0.15.3` omitted: tagged but never published (404).
