### PR TITLE
docs: identify this branch's docs as 0.17.1 and fix the version picker

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ import sys
 project = "Megatron Core"
 copyright = "2026, NVIDIA Corporation"
 author = "NVIDIA Corporation"
-release = "0.17.0"
+release = "0.17.1"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/project.json
+++ b/docs/project.json
@@ -1,2 +1,2 @@
-{"name": "megatron-lm", "version": "0.17.0"}
+{"name": "megatron-lm", "version": "0.17.1"}
 

--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -5,9 +5,30 @@
         "url": "https://docs.nvidia.com/megatron-core/developer-guide/nightly/"
     },
     {
-        "name": "0.17.0 (latest)",
+        "name": "0.18.2 (latest)",
+        "version": "0.18.2",
+        "url": "https://docs.nvidia.com/megatron-core/developer-guide/0.18.2/",
+        "preferred": true
+    },
+    {
+        "name": "0.18.0",
+        "version": "0.18.0",
+        "url": "https://docs.nvidia.com/megatron-core/developer-guide/0.18.0/"
+    },
+    {
+        "name": "0.17.1",
+        "version": "0.17.1",
+        "url": "https://docs.nvidia.com/megatron-core/developer-guide/0.17.1/"
+    },
+    {
+        "name": "0.17.0",
         "version": "0.17.0",
-        "url": "https://docs.nvidia.com/megatron-core/developer-guide/latest/"
+        "url": "https://docs.nvidia.com/megatron-core/developer-guide/0.17.0/"
+    },
+    {
+        "name": "0.16.1",
+        "version": "0.16.1",
+        "url": "https://docs.nvidia.com/megatron-core/developer-guide/0.16.1/"
     },
     {
         "name": "0.16.0",


### PR DESCRIPTION
## Background / motivation

- `core_v0.17.1` was tagged and its docs published to `…/developer-guide/0.17.1/`, but `docs/conf.py` and `docs/project.json` on this branch still say `0.17.0` — `https://docs.nvidia.com/megatron-core/developer-guide/0.17.1/project.json` returns `{"name": "megatron-lm", "version": "0.17.0"}`. Since `release` feeds `switcher.version_match`, the 0.17.1 docs highlight the wrong entry.
- This branch's `docs/versions1.json` has no `preferred` entry and predates every release since 0.17.0. Because `json_url` is `../versions1.json` (#4367), the picker is a single shared file at the docs-site root, and any re-publish of this branch with `update-version-picker: true` would overwrite it with that 0.17-era view — hiding 0.18.x from every version of the docs.

## What changed

- `docs/conf.py`: `release` `0.17.0` → `0.17.1`.
- `docs/project.json`: `version` `0.17.0` → `0.17.1`.
- `docs/versions1.json`: list the published releases through `0.18.2`, mark `0.18.2 (latest)` as `preferred`, add `0.17.1` and `0.16.1`, and link every entry to its versioned path instead of the `/latest/` alias.

## Details

- Listing versions newer than this branch is deliberate. The picker is site-wide, so it must describe the whole release line regardless of which branch last uploaded it; `preferred` names the newest tag (`0.18.2`), which is also what tells a reader sitting on 0.17.x docs that they are not on the current release.
- `version_match` still resolves: `release = "0.17.1"` matches the `0.17.1` entry.
- Nothing changes on the live site until the 0.17.x docs are re-published; the value here is that a future re-publish can no longer regress the shared picker.

```python
# docs/conf.py (excerpt)
release = "0.17.1"
```

## Tested

- `json.load` parses; exactly one `preferred` (`0.18.2`); order `nightly, 0.18.2, 0.18.0, 0.17.1, 0.17.0, 0.16.1, 0.16.0, 0.15.0`.
- Every entry URL probed live → **200**. `0.15.1/0.15.2/0.15.3` omitted: tagged but never published (404).
